### PR TITLE
Add grid layout for Pi carrier

### DIFF
--- a/cad/pi_cluster/pi5_triple_carrier_rot45.scad
+++ b/cad/pi_cluster/pi5_triple_carrier_rot45.scad
@@ -4,7 +4,9 @@
  *********************************************************************/
 
 /* ---------- USER-EDITABLE PARAMETERS ---------- */
-num_pis            = 3;          // how many Pi-5s
+/* layout of Pi boards as [x,y] offsets forming a 2x2 grid with one corner empty */
+pi_positions = [[0,0], [1,0], [0,1]];
+num_pis     = len(pi_positions); // how many Pi-5s
 board_len          = 85;         // X-size of Pi-5 PCB  (mm)
 board_wid          = 56;         // Y-size of Pi-5 PCB  (mm)
 hole_spacing_x     = 58;         // long-direction hole spacing (mm)
@@ -44,8 +46,14 @@ thread_facets = 32;     // helix resolution
 rotX = abs(board_len*cos(board_angle)) + abs(board_wid*sin(board_angle));
 rotY = abs(board_len*sin(board_angle)) + abs(board_wid*cos(board_angle));
 
-plate_len = num_pis*rotX + (num_pis-1)*gap_between_boards + 2*edge_margin;
-plate_wid = rotY + 2*edge_margin + 2*port_clearance;
+board_spacing_x = rotX + gap_between_boards;
+board_spacing_y = rotY + gap_between_boards;
+
+max_x = max([for(p=pi_positions) p[0]]);
+max_y = max([for(p=pi_positions) p[1]]);
+
+plate_len = (max_x+1)*rotX + max_x*gap_between_boards + 2*edge_margin;
+plate_wid = (max_y+1)*rotY + max_y*gap_between_boards + 2*edge_margin + 2*port_clearance;
 
 /* ---------- HELPERS ---------- */
 function rot2d(v, ang) = [
@@ -102,9 +110,9 @@ difference()
     head_r = 2.5;  // counterbore radius (5 mm diameter)
     head_h = 1.6;  // depth of screw head recess
 
-    for (i=[0:num_pis-1]) {
-        pcb_cx = edge_margin + rotX/2 + i*(rotX + gap_between_boards);
-        pcb_cy = edge_margin + port_clearance + rotY/2;
+    for (pos = pi_positions) {
+        pcb_cx = edge_margin + rotX/2 + pos[0]*board_spacing_x;
+        pcb_cy = edge_margin + port_clearance + rotY/2 + pos[1]*board_spacing_y;
 
         for (dx = [-hole_spacing_x/2, hole_spacing_x/2])
         for (dy = [-hole_spacing_y/2, hole_spacing_y/2]) {
@@ -116,9 +124,9 @@ difference()
 }
 
 /* ---------- STANDOFF ARRAY ---------- */
-for (i=[0:num_pis-1]) {
-    pcb_cx = edge_margin + rotX/2 + i*(rotX + gap_between_boards);
-    pcb_cy = edge_margin + port_clearance + rotY/2;
+for (pos = pi_positions) {
+    pcb_cx = edge_margin + rotX/2 + pos[0]*board_spacing_x;
+    pcb_cy = edge_margin + port_clearance + rotY/2 + pos[1]*board_spacing_y;
 
     for (dx = [-hole_spacing_x/2, hole_spacing_x/2])
     for (dy = [-hole_spacing_y/2, hole_spacing_y/2]) {

--- a/docs/pi_cluster_carrier.md
+++ b/docs/pi_cluster_carrier.md
@@ -1,8 +1,9 @@
 # Pi Cluster Carrier
 
-This design mounts three Raspberry Pi 5 boards side by side on a common plate.  Each Pi is rotated 45° so the USB and Ethernet ports remain accessible.  Brass heat‑set inserts can be used for durability, or you can print threads directly.
+This design mounts three Raspberry Pi 5 boards on a common plate. Each Pi is rotated 45° so the USB and Ethernet ports remain accessible. By default the boards are arranged in a 2×2 grid with one corner empty so the plate fits on printers with a 256 mm build area (e.g. the Bambu Lab A1). Brass heat‑set inserts can be used for durability, or you can print threads directly.
 
 The model lives at `cad/pi_cluster/pi5_triple_carrier_rot45.scad`.  STL files for both heat‑set and printed‑thread variants are generated automatically under `stl/` by GitHub Actions whenever the SCAD file changes.
+You can edit the `pi_positions` array near the top of the file to tweak the arrangement if your printer allows a larger build area.
 
 Use OpenSCAD to preview and tweak parameters:
 


### PR DESCRIPTION
## Summary
- support a 2x2 grid layout for the Pi cluster carrier
- document the new layout and how to customize `pi_positions`

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879955bf4e8832f825c41f3d3b186cf