### PR TITLE
Fix missing STL upload

### DIFF
--- a/.github/workflows/scad-to-stl.yml
+++ b/.github/workflows/scad-to-stl.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Render all .scad -> .stl (${{ matrix.mode }})
         run: |
           mkdir -p stl
-          STANDOFF_MODE=${{ matrix.mode }} find cad -name '*.scad' -print0 | xargs -0 -n1 -I{} bash scripts/openscad_render.sh "{}"
+          export STANDOFF_MODE=${{ matrix.mode }}
+          find cad -name '*.scad' -print0 | xargs -0 -n1 -I{} bash scripts/openscad_render.sh "{}"
       - name: Upload STL artefacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- export `STANDOFF_MODE` in the STL build workflow so generated files include the mode suffix

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_687b4e3d0dec832f81b24957e621dccd