### PR TITLE
Update insert dimensions and docs

### DIFF
--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -2,6 +2,10 @@
 ```markdown
 # Raspberry Pi 5 Triple-Stack Carrier
 
+| Screw | Standoff | Insert |
+|-------|----------|--------|
+| M2.5 × 18 mm | 11 mm | 3.5 mm OD × 4 mm |
+
 | Variation | Description |
 |-----------|-------------|
 | `"blind"` (default) | Standoffs sized for blind-hole heat-set inserts. |
@@ -30,10 +34,10 @@ plate_thickness = 2.0;
 standoff_height = 6.0;
 standoff_diam = 6.0;
 
-insert_od = 3.6;      // heat-set insert outer diameter
-insert_length = 3.0;  // insert length
-hole_diam = 3.5;      // hole size for insert or screw
-insert_pocket_depth = 3.7;
+insert_od         = 3.5;         // outer Ø matches HANGLIFE inserts
+insert_length     = 4.0;         // full length of the insert
+insert_pocket_depth = insert_length + 0.7; // keeps 0.7 mm extra for chamfer
+hole_diam         = insert_od + 0.1;       // slip-fit pilot
 lead_chamfer = 0.5;
 screw_clearance_diam = 3.0; // through-hole clearance
 

--- a/docs/pi_cluster_carrier.md
+++ b/docs/pi_cluster_carrier.md
@@ -33,7 +33,9 @@ underside flat and lets you stack an M.2 HAT or other accessory on top.
 | ------ | ------------------------------------ | ---------------------------------------- |
 | Screw  | M2.5 × 18 mm pan head                | "M2.5×18 Phillips pan head"              |
 | Spacer | M2.5 female‑female, 11 mm long       | "M2.5×11 mm brass hex standoff"          |
-| Insert | M2.5 heat‑set, 3.6 mm OD × 3 mm long | "M2.5×3 mm brass heat‑set insert"        |
+| Insert | M2.5 heat‑set, 3.5 mm OD × 4 mm long (HANGLIFE B0CS6YVJYD) | "HANGLIFE M2.5 × D3.5 × L4 brass insert" |
+
+- These dimensions match the Amazon Prime HANGLIFE inserts (3.5 mm outer diameter, 4 mm length). No other changes are needed to the 18 mm screw or 11 mm standoff.
 
 Screw from the top and gently tighten until the screw stops against the
 blind insert.  If you prefer screws from the bottom, print the


### PR DESCRIPTION
## Summary
- tweak heat-set insert parameters for Amazon Prime parts
- capture the hardware spec in the OpenSCAD header
- document the new insert dimensions in the build notes

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_687c416769e0832f94f3a0258622a792