### PR TITLE
Generate STL files via pre-commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ dictionary.dic
 .venv/
 playwright-report/
 test-results/
+stl/*.stl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,11 @@ repos:
       - id: check-yaml
   - repo: local
     hooks:
+      - id: build-stls
+        name: build STL files
+        entry: bash scripts/gen_stls.sh
+        language: system
+        pass_filenames: false
       - id: run-checks
         name: run project checks
         entry: bash scripts/checks.sh

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An accessible k3s platform for Raspberry Pis and other SBCs integrated with an o
 ## Repository layout
 
 - `cad/` — OpenSCAD models of structural parts.  See `docs/pi_cluster_carrier.md` for the Pi carrier plate.
-- `stl/` — generated STL files (via GitHub Actions)
+- `stl/` — auto-generated STL files (ignored by Git)
 - `elex/` — KiCad and Fritzing electronics schematics
 - `docs/` — build instructions and safety notes
 - `scripts/` — helper scripts for rendering and exports

--- a/docs/build_guide.md
+++ b/docs/build_guide.md
@@ -4,7 +4,7 @@ This project uses 20x20 aluminium extrusion to suspend four 100W solar panels ar
 
 1. Print the brackets from `cad/solar_cube`.
 2. Print the triple Pi carrier from `cad/pi_cluster` if building a Pi cluster.
-   STL files for both insert variants are generated automatically under `stl/`.
+   STL files for both insert variants are generated automatically under `stl/` by the pre-commit hook (not stored in Git).
 3. Assemble the extrusion cube using M5 hardware.
 4. Mount the solar panels using the printed brackets.
 5. Wire the panels to the Victron MPPT charge controller as shown in the `elex/power_ring` schematic.

--- a/docs/pi_cluster_carrier.md
+++ b/docs/pi_cluster_carrier.md
@@ -2,7 +2,7 @@
 
 This design mounts three Raspberry Pi 5 boards on a common plate. Each Pi is rotated 45° so the USB and Ethernet ports remain accessible. By default the boards are arranged in a 2×2 grid with one corner empty so the plate fits on printers with a 256 mm build area (e.g. the Bambu Lab A1). Brass heat‑set inserts can be used for durability, or you can print threads directly.
 
-The model lives at `cad/pi_cluster/pi5_triple_carrier_rot45.scad`.  STL files for both heat‑set and printed‑thread variants are generated automatically under `stl/` by GitHub Actions whenever the SCAD file changes.
+The model lives at `cad/pi_cluster/pi5_triple_carrier_rot45.scad`.  STL files for both heat‑set and printed‑thread variants are generated automatically under `stl/` by the pre-commit hook (not stored in Git) whenever the SCAD file changes.
 You can edit the `pi_positions` array near the top of the file to tweak the arrangement if your printer allows a larger build area.
 
 Use OpenSCAD to preview and tweak parameters:

--- a/scripts/gen_stls.sh
+++ b/scripts/gen_stls.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+modes=(heatset printed)
+mkdir -p stl
+for mode in "${modes[@]}"; do
+  export STANDOFF_MODE="$mode"
+  find cad -name '*.scad' -print0 | xargs -0 -I{} bash scripts/openscad_render.sh "{}"
+  unset STANDOFF_MODE
+done

--- a/scripts/openscad_render.sh
+++ b/scripts/openscad_render.sh
@@ -9,4 +9,6 @@ if [ -n "$STANDOFF_MODE" ]; then
 fi
 output="stl/${base}${mode_suffix}.stl"
 mkdir -p "$(dirname "$output")"
-openscad -o "$output" --export-format binstl -D standoff_mode=\"${STANDOFF_MODE}\" "$FILE"
+xvfb-run --auto-servernum \
+  openscad -o "$output" --export-format binstl \
+  -D standoff_mode=\"${STANDOFF_MODE}\" "$FILE"

--- a/stl/README.md
+++ b/stl/README.md
@@ -1,0 +1,5 @@
+# STL Files
+
+This directory is generated automatically by `scripts/gen_stls.sh` (via pre-commit).
+The STL files are ignored in Git to keep the repository light. Run the script to
+populate this folder.


### PR DESCRIPTION
## Summary
- add script to generate STL outputs
- update OpenSCAD rendering to use xvfb-run
- build STL files in pre-commit hook
- ignore generated STLs and add placeholder README
- update docs referencing GitHub Actions

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_687ebaec5918832f9cd659fe8aad26a5