### PR TITLE
Document electronics folder placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An accessible k3s platform for Raspberry Pis and other SBCs integrated with an o
 
 - `cad/` — OpenSCAD models of structural parts.  See `docs/pi_cluster_carrier.md` for the Pi carrier plate.
 - `stl/` — generated STL files (via GitHub Actions)
-- `elex/` — KiCad and Fritzing electronics schematics
+- `elex/` — KiCad and Fritzing electronics schematics *(placeholders; actual designs forthcoming)*
 - `docs/` — build instructions and safety notes
 - `scripts/` — helper scripts for rendering and exports
 

--- a/docs/build_guide.md
+++ b/docs/build_guide.md
@@ -7,7 +7,7 @@ This project uses 20x20 aluminium extrusion to suspend four 100W solar panels ar
    STL files for both insert variants are generated automatically under `stl/`.
 3. Assemble the extrusion cube using M5 hardware.
 4. Mount the solar panels using the printed brackets.
-5. Wire the panels to the Victron MPPT charge controller as shown in the `elex/power_ring` schematic.
+5. Wire the panels to the Victron MPPT charge controller.  The KiCad schematic will live under `elex/power_ring` once available.
 6. Install the 12V air pump and Raspberry Pi behind a 15A breaker and 5A fuse respectively.
 7. Connect the battery and verify voltage before powering devices.
 

--- a/elex/README.md
+++ b/elex/README.md
@@ -1,0 +1,5 @@
+# Electronics Schematics
+
+This directory is reserved for KiCad and Fritzing files documenting the Sugarkube power system.
+
+The designs are still a work in progress, so only placeholder README files are present for now.

--- a/elex/fritzing_sketch/README.md
+++ b/elex/fritzing_sketch/README.md
@@ -1,0 +1,3 @@
+# Fritzing Sketch
+
+Placeholder for wiring diagrams created with Fritzing.

--- a/elex/power_ring/README.md
+++ b/elex/power_ring/README.md
@@ -1,0 +1,3 @@
+# Power Ring
+
+This folder will contain the KiCad project for the power distribution ring.


### PR DESCRIPTION
## Summary
- clarify `elex/` directory in README
- explain missing electronics schematics in docs and READMEs

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_687ec85f8a84832fa9c69896277c1659