### PR TITLE
Expand solar docs for beginners

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Treat STL meshes as binary artefacts and avoid interactive merge conflicts
-*.stl -text -diff merge=ours 
+*.stl -text -diff merge=ours

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -121,3 +121,11 @@ Bambu
 HANGLIFE
 YVJYD
 B0CS6YVJYD
+multimeter
+resettable
+crimpers
+Wh
+chemistries
+AGM
+SLA
+PWM

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ An accessible k3s platform for Raspberry Pis and other SBCs integrated with an o
 - `cad/` — OpenSCAD models of structural parts.  See `docs/pi_cluster_carrier.md` for the Pi carrier plate.
 - `stl/` — generated STL files (via GitHub Actions)
 - `elex/` — KiCad and Fritzing electronics schematics *(placeholders; actual designs forthcoming)*
-- `docs/` — build instructions and safety notes
+- `docs/` — build instructions, safety notes, and learning resources
+- `docs/solar_basics.md` — introduction to how solar panels generate power
+- `docs/electronics_basics.md` — essential circuits and tools
+- `docs/power_system_design.md` — sizing batteries and charge controllers
 - `docs/insert_basics.md` — guide for heat-set inserts and printed threads
 - `scripts/` — helper scripts for rendering and exports
 

--- a/docs/electronics_basics.md
+++ b/docs/electronics_basics.md
@@ -1,0 +1,31 @@
+# Electronics Essentials
+
+Beginners can start here to learn the fundamentals needed to assemble the power system and troubleshoot issues.
+
+## Basic Concepts
+- **Voltage** is the potential difference between two points. A standard USB supply provides 5 V.
+- **Current** is the rate of flow measured in amperes (A).
+- **Resistance** follows Ohm's law: `V = I × R`.
+- **Power** equals voltage times current (P = V × I).
+
+### Measuring
+- Use a multimeter to check voltage at the battery terminals.
+- Clamp meters allow measuring current without breaking the circuit.
+
+### Soldering Tips
+- Keep the iron around 350 °C for most lead-free solder.
+- Tin both surfaces before joining wires.
+- Work in a ventilated area and wear eye protection.
+
+### Common Components
+- **Fuses** protect against short circuits.
+- **Breakers** act like resettable fuses.
+- **Buck converters** step down voltage to power your Raspberry Pi.
+
+## Recommended Tools
+- Digital multimeter
+- Adjustable soldering iron with stand
+- Wire strippers and crimpers
+- Assortment of heat shrink and connectors
+
+Understanding these basics helps you diagnose problems and build reliable circuits.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,17 @@
 # Sugarkube
 
-Welcome to **sugarkube**, a solar-powered off-grid platform for Raspberry Pi and aquarium aeration.  This repo tracks CAD models, electronics schematics, and documentation so anyone can replicate the setup.
+Welcome to **sugarkube**, a solar-powered off-grid platform for Raspberry Pi and aquarium aeration. This repo tracks CAD models, electronics schematics, and documentation so anyone can replicate the setup.
 
 ![solar cube](images/solar_cube.jpg)
 
-See [build_guide.md](build_guide.md) for assembly steps.  The Pi cluster carrier is documented in [pi_cluster_carrier.md](pi_cluster_carrier.md). For tips on heat‑set inserts and printed threads see [insert_basics.md](insert_basics.md).
+## Getting Started
+- [build_guide.md](build_guide.md) — step-by-step assembly instructions
+- [pi_cluster_carrier.md](pi_cluster_carrier.md) — details on the Raspberry Pi mounting plate
+- [insert_basics.md](insert_basics.md) — heat-set inserts and printed threads
+
+## Learn the Fundamentals
+- [solar_basics.md](solar_basics.md) — how photovoltaic panels work
+- [electronics_basics.md](electronics_basics.md) — wiring, tools, and safety
+- [power_system_design.md](power_system_design.md) — sizing batteries and choosing a charge controller
+
+Start with the basics and progress toward a fully autonomous solar cube.

--- a/docs/power_system_design.md
+++ b/docs/power_system_design.md
@@ -1,0 +1,26 @@
+# Power System Design
+
+This section dives deeper into sizing batteries and choosing a charge controller for more advanced setups.
+
+## Batteries
+Several chemistries are common in small solar installations:
+- **Lead-acid** (SLA or AGM) – inexpensive but heavy and less tolerant of deep discharge.
+- **LiFePO4** – lightweight and long-lived, ideal for off-grid electronics.
+
+Choose a capacity large enough for a day or two of autonomy. Multiply your daily watt-hour use by the number of backup days.
+
+## Charge Controllers
+A controller regulates the energy from the panels into the battery.
+
+### PWM vs MPPT
+- **PWM** controllers are inexpensive but waste excess panel voltage as heat.
+- **MPPT** units track the optimal voltage to harvest more power, especially in cold or shaded conditions.
+
+For a four-panel array, a 20 A MPPT controller provides room to grow and keeps charging efficient.
+
+## Energy Budget Example
+A Raspberry Pi draws roughly 10 W. Running 24 h uses 240 Wh. Add 20 Wh for a small air pump and 40 Wh for conversion losses for a total of ~300 Wh per day.
+
+To provide two days of reserve you would want a 12 V battery rated at least 600 Wh (about 50 Ah). Combine that with 400 W of solar panels and an MPPT charge controller for reliable operation.
+
+Continually monitor voltage and temperature to prolong battery life.

--- a/docs/solar_basics.md
+++ b/docs/solar_basics.md
@@ -1,0 +1,26 @@
+# Solar Power Basics
+
+This primer explains how photovoltaic panels convert sunlight into electricity and how to size a simple system.
+
+## Key Terms
+- **Voltage (V)** – Electrical "pressure" that drives current. Typical panels produce around 18 V in full sun.
+- **Current (A)** – The flow of electrons. Multiply voltage by current to get **power** in watts.
+- **Watt-hours (Wh)** – One watt of power used for an hour. Batteries are often rated in watt-hours or amp-hours (Ah).
+
+## How Panels Work
+Silicon cells generate a voltage when exposed to light. Cells are wired in series to increase voltage and in parallel to increase current. A 100 W panel might produce about 18 V at 5.5 A in bright sun.
+
+### Orientation
+- Face panels toward the equator for maximum exposure.
+- Tilt roughly equal to your latitude.
+- Keep the surface free of shade and dirt.
+
+### Connecting Panels
+- **Series** connections add voltage but keep current the same.
+- **Parallel** connections add current but keep voltage the same.
+- Use outdoor‑rated connectors and wire gauges sized for the expected current.
+
+## Example Budget
+Four 100 W panels wired in parallel can deliver roughly 20 A at 18 V to the charge controller. Over a six‑hour sunny day you might collect around 600 Wh.
+
+That energy then charges the battery and powers small loads like an aquarium pump or Raspberry Pi.

--- a/tests/cad_regress_test.py
+++ b/tests/cad_regress_test.py
@@ -10,7 +10,10 @@ SKIP = shutil.which("openscad") is None
 @pytest.mark.skipif(SKIP, reason="OpenSCAD not installed")
 @pytest.mark.parametrize("mode", ["heatset", "printed"])
 def test_stl_generation(mode: str, tmp_path):
-    """Compile every SCAD in both standoff modes and ensure we get a non-empty STL."""
+    """Compile each SCAD in both standoff modes.
+
+    Ensure we get a non-empty STL output.
+    """
 
     scad_files = list(Path("cad").rglob("*.scad"))
     assert scad_files, "no scad files found"
@@ -25,7 +28,7 @@ def test_stl_generation(mode: str, tmp_path):
                 "--export-format",
                 "binstl",
                 "-D",
-                f"standoff_mode=\"{mode}\"",
+                f'standoff_mode="{mode}"',
                 str(scad),
             ],
             check=True,


### PR DESCRIPTION
## Summary
- add guides covering solar power, basic electronics, and system design
- link the new docs from the index and README
- fix `cad_regress_test.py` formatting and update spell wordlist

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker README.md docs/`

------
https://chatgpt.com/codex/tasks/task_e_6881cffc0ed0832f87aee255f6af3cdc