### PR TITLE
Fix KiCad version in workflow

### DIFF
--- a/.github/workflows/kicad-export.yml
+++ b/.github/workflows/kicad-export.yml
@@ -8,8 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install KiCad
+      - name: Install latest KiCad
         run: |
+          sudo add-apt-repository --yes ppa:kicad/kicad-7.0-releases
           sudo apt-get update
           sudo apt-get install -y kicad
       - name: Generate outputs


### PR DESCRIPTION
## Summary
- install latest KiCad from the official PPA so the board file opens correctly

## Testing
- `pre-commit run --files .github/workflows/kicad-export.yml`

------
https://chatgpt.com/codex/tasks/task_e_68832f7f9058832f845aa593827b8940