### PR TITLE
Increase Pi board spacing

### DIFF
--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -23,7 +23,7 @@ hole_diameter    = 2.75;           // M2.5 clearance
 standoff_diam    = 6;              // Printed pillar Ø
 standoff_height  = 6;              // Under‑board clearance (fits PoE headers):contentReference[oaicite:3]{index=3}
 base_thickness   = 3;              // Plate thickness
-row_gap          = 15;             // **NEW** extra spacing between Pi rows (mm)
+row_gap          = 25;             // +10 mm breathing room for HDMI/USB-C plugs
 
 // ----------  Derived geometry  ----------
 bay_w = mount_cc[0] + 2*edge_margin;


### PR DESCRIPTION
## Summary
- widen the gap between the two bottom Pi boards in `pi_carrier.scad`

## Testing
- `pre-commit run --files cad/pi_cluster/pi_carrier.scad`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688733728a14832fa5a9b26cd35f869b