### PR TITLE
Add codecov workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Test Suite
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v1
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          uv pip install --system pytest pytest-cov coverage
+          if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=. --cov-report=xml --cov-report=term --maxfail=1 --disable-warnings -q
+      - name: Upload coverage
+        if: hashFiles('coverage.xml') != ''
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: python
+          fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ kicad-export/
 *.kicad_prl
 *-cache.lib
 fp-info-cache/
+coverage.xml
+.coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,8 @@ repos:
           - isort
           - black
           - pytest
+          - pytest-cov
+          - coverage
           - linkchecker
           - requests
           - Flask

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![spellcheck](https://github.com/futuroptimist/sugarkube/actions/workflows/spellcheck.yml/badge.svg?branch=main)](https://github.com/futuroptimist/sugarkube/actions/workflows/spellcheck.yml)
 [![kicad](https://github.com/futuroptimist/sugarkube/actions/workflows/kicad-export.yml/badge.svg?branch=main)](https://github.com/futuroptimist/sugarkube/actions/workflows/kicad-export.yml)
 [![stl](https://github.com/futuroptimist/sugarkube/actions/workflows/scad-to-stl.yml/badge.svg?branch=main)](https://github.com/futuroptimist/sugarkube/actions/workflows/scad-to-stl.yml)
+[![Coverage](https://codecov.io/gh/futuroptimist/sugarkube/branch/main/graph/badge.svg)](https://codecov.io/gh/futuroptimist/sugarkube)
 [![license](https://img.shields.io/github/license/futuroptimist/sugarkube)](LICENSE)
 
 An accessible k3s platform for Raspberry Pis and other SBCs integrated with an off-grid solar setup.  This repository also documents the solar cube art installation for powering aquarium air pumps and small computers.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 100
+        threshold: 0
+    patch:
+      default:
+        target: 90
+ignore: []
+comment:
+  layout: "header, diff"

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -16,7 +16,7 @@ if [ -f package.json ]; then
 fi
 
 # run tests
-pytest -q
+pytest --cov=. --cov-report=xml --cov-report=term -q
 
 # docs checks
 if command -v pyspelling >/dev/null 2>&1 && [ -f .spellcheck.yaml ]; then


### PR DESCRIPTION
## Summary
- run tests with coverage via GitHub Actions
- upload coverage using codecov
- track coverage configuration
- show coverage badge in README
- measure coverage in pre-commit checks

## Testing
- `pre-commit run --files .pre-commit-config.yaml README.md scripts/checks.sh .github/workflows/tests.yml codecov.yml .gitignore`
- `pytest --cov=. --cov-report=term --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_68882d6d3e38832fa63b47fd1542352e