### PR TITLE
Fix KiCad export config

### DIFF
--- a/.github/workflows/kicad-export.yml
+++ b/.github/workflows/kicad-export.yml
@@ -15,8 +15,7 @@ jobs:
         uses: INTI-CMNB/kibot@v2
         with:
           board: elex/power_ring/power_ring.kicad_pcb
-          # optional: point to a *.kibot.yaml config if you have one
-          # config: .kibot/power_ring.yaml
+          config: .kibot/power_ring.yaml
           dir: build/power_ring
 
       - name: Upload fab outputs

--- a/.kibot/power_ring.yaml
+++ b/.kibot/power_ring.yaml
@@ -6,3 +6,9 @@ outputs:
   assembly:
     type: position
     dir: fab
+  schematic:
+    type: schematic_pdf
+    dir: fab
+  bom:
+    type: bom
+    dir: fab


### PR DESCRIPTION
## Summary
- use Kibot config in workflow
- export schematic PDF and BOM too

## Testing
- `pre-commit run --files .kibot/power_ring.yaml .github/workflows/kicad-export.yml`

------
https://chatgpt.com/codex/tasks/task_e_6888607f4e38832f89627f138d169ee0