### PR TITLE
Fix KiCad export workflow

### DIFF
--- a/.github/workflows/kicad-export.yml
+++ b/.github/workflows/kicad-export.yml
@@ -12,7 +12,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Fabricate board with KiBot
-        uses: INTI-CMNB/kibot@v2
+        # Use a container image with KiCad 9 to open the project
+        uses: INTI-CMNB/kibot@v2_k9
         with:
           board: elex/power_ring/power_ring.kicad_pcb
           config: .kibot/power_ring.yaml

--- a/elex/README.md
+++ b/elex/README.md
@@ -5,4 +5,4 @@ The `elex` folder collects KiCad and Fritzing designs used throughout the Sugark
 - `power_ring/` – KiCad project for a small distribution board.  See its README and `power_ring/specs.md` for details.
 - `fritzing_sketch/` – placeholder for simplified wiring diagrams (coming soon).
 
-Contributions welcome: edit the KiCad project with **KiCad 8** or newer and export updated artifacts with KiBot or via the GitHub workflow.
+Contributions welcome: edit the KiCad project with **KiCad 9** or newer and export updated artifacts with KiBot or via the GitHub workflow.

--- a/elex/power_ring/README.md
+++ b/elex/power_ring/README.md
@@ -10,4 +10,4 @@ Included files:
 - `power_ring.kicad_sym` and `power_ring_schlib.kicad_sym` – symbol libraries
 - `power_ring.pretty/` – footprint library
 
-Open the project in **KiCad 8** or newer and modify the schematic to suit your power distribution needs (for example, add screw terminals, fuses and test points).  Use [KiBot](https://github.com/INTI-CMNB/KiBot) with `.kibot/power_ring.yaml` or run the GitHub workflow to produce Gerber files, a PDF schematic and a BOM in `build/power_ring/`.
+Open the project in **KiCad 9** or newer and modify the schematic to suit your power distribution needs (for example, add screw terminals, fuses and test points).  Use [KiBot](https://github.com/INTI-CMNB/KiBot) with `.kibot/power_ring.yaml` or run the GitHub workflow to produce Gerber files, a PDF schematic and a BOM in `build/power_ring/`.


### PR DESCRIPTION
## Summary
- upgrade KiCad workflow to use KiCad 9 container
- update docs to mention KiCad 9

## Testing
- `pre-commit run --files .github/workflows/kicad-export.yml elex/README.md elex/power_ring/README.md`

------
https://chatgpt.com/codex/tasks/task_e_68886291cfbc832fa5d2baef2fe074e9