### PR TITLE
Improve KiCad agent documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@ This repository uses lightweight LLM helpers inspired by the [flywheel](https://
 
 ## KiCad Agent
 - **When:** KiCad schematic or PCB files change
-- **Does:** run the [KiBot action](https://github.com/INTI-CMNB/kibot) with `.kibot/power_ring.yaml` to export Gerbers, PDF schematics and BOM.
+- **Does:** run the [KiBot action](https://github.com/INTI-CMNB/kibot) with `.kibot/power_ring.yaml` to export Gerbers, PDF schematics and BOM. The project
+  requires **KiCad 9** so we use the `v2_k9` container tag.
 
 ### STL merge safety
 STL files are treated as binary artefacts. `.gitattributes` marks them with `merge=ours` so merges remain conflict-free.


### PR DESCRIPTION
## Summary
- clarify KiCad agent uses KiCad 9 container

## Testing
- `pre-commit run --files AGENTS.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688864dfd5b0832f8c86bd9d7648743c