### PR TITLE
Fix KiCad workflow

### DIFF
--- a/.github/workflows/kicad-export.yml
+++ b/.github/workflows/kicad-export.yml
@@ -11,6 +11,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install KiCad
+        run: |
+          sudo add-apt-repository --yes ppa:kicad/kicad-7.0-releases
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y kicad kicad-cli
+
+      - name: Export KiCad files
+        uses: actions-for-kicad/generate-kicad-files@v1.1
+        with:
+          schematic_pdf: true
+          gerber: true
+          bom: true
+
       - name: Fabricate board with KiBot
         # Use a container image with KiCad 9 to open the project
         uses: INTI-CMNB/kibot@v2_k9


### PR DESCRIPTION
## Summary
- ensure KiCad is installed on the runner before export

## Testing
- `pre-commit run --files .github/workflows/kicad-export.yml`

------
https://chatgpt.com/codex/tasks/task_e_688867b6d624832f9f4b8923311b160a