### PR TITLE
Fix CI: Install KiCad 9 from PPA

### DIFF
--- a/.github/workflows/kicad-export.yml
+++ b/.github/workflows/kicad-export.yml
@@ -15,7 +15,12 @@ jobs:
         run: |
           sudo add-apt-repository --yes ppa:kicad/kicad-7.0-releases
           sudo apt-get update
-          sudo apt-get install --no-install-recommends -y kicad kicad-cli
+
+      - name: Install KiCad 9
+        run: |
+          sudo add-apt-repository -y ppa:kicad/kicad-9.0-releases
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends kicad
 
       - name: Export KiCad files
         uses: actions-for-kicad/generate-kicad-files@v1.1


### PR DESCRIPTION
## Summary
- update `kicad-export.yml` to install KiCad 9 from the official PPA

## Testing
- `pre-commit run --files .github/workflows/kicad-export.yml`

------
https://chatgpt.com/codex/tasks/task_e_68886d85b950832fb337fde5d3040f7f