### PR TITLE
Add network setup guide and clarify sugarkube meaning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,21 @@
 
 This repository uses lightweight LLM helpers inspired by the [flywheel](https://github.com/futuroptimist/flywheel) project. It follows the [AGENTS.md spec](https://gist.github.com/dpaluy/cc42d59243b0999c1b3f9cf60dfd3be6) and [agentsmd.net](https://agentsmd.net/AGENTS.md).
 
+The name **sugarkube** has two meanings:
+
+1. The physical aluminium cube with solar panels that houses a Pi-based k3s
+   cluster.
+2. "Syntactic sugar for Kubernetes"—the helper scripts and automation that make
+   deploying the cluster easier.
+
 ## Code Linter Agent
 - **When:** every PR
 - **Does:** run `scripts/checks.sh` via pre-commit to lint, format and test.
 
 ## Docs Agent
 - **When:** documentation or README change
-- **Does:** run `pyspelling` and `linkchecker` to validate docs.
+- **Does:** run `pyspelling` and `linkchecker` to validate docs. This covers
+  guides such as `docs/network_setup.md`.
 
 ## CAD Agent
 - **When:** `.scad` files change

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 
 An accessible k3s platform for Raspberry Pis and other SBCs integrated with an off-grid solar setup.  This repository also documents the solar cube art installation for powering aquarium air pumps and small computers.
 
+### What's in a name?
+
+"Sugarkube" refers to both the aluminium cube covered in solar panels **and**
+the helper scripts that provide "syntactic sugar" for Kubernetes.  Throughout
+the docs you will see the term used in both contexts.
+
 ## Repository layout
 
 - `cad/` — OpenSCAD models of structural parts.  See `docs/pi_cluster_carrier.md` for the Pi carrier plate.
@@ -18,6 +24,7 @@ An accessible k3s platform for Raspberry Pis and other SBCs integrated with an o
 - `docs/electronics_basics.md` — essential circuits and tools
 - `docs/power_system_design.md` — sizing batteries and charge controllers
 - `docs/insert_basics.md` — guide for heat-set inserts and printed threads
+- `docs/network_setup.md` — connect the Pi cluster to your network
 - `scripts/` — helper scripts for rendering and exports
 
 Run `pre-commit run --all-files` before committing.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Welcome to **sugarkube**, a solar-powered off-grid platform for Raspberry Pi and
 - [build_guide.md](build_guide.md) — step-by-step assembly instructions
 - [pi_cluster_carrier.md](pi_cluster_carrier.md) — details on the Raspberry Pi mounting plate
 - [insert_basics.md](insert_basics.md) — heat-set inserts and printed threads
+- [network_setup.md](network_setup.md) — connect the cluster to your network
 
 ## Learn the Fundamentals
 - [solar_basics.md](solar_basics.md) — how photovoltaic panels work

--- a/docs/network_setup.md
+++ b/docs/network_setup.md
@@ -1,0 +1,26 @@
+# Network Setup
+
+This guide explains how to connect your Pi cluster to a home network.
+It assumes you are using Raspberry Pi 5 boards in a small k3s setup.
+
+## Preconfigure Wi‑Fi
+
+1. Launch **Raspberry Pi Imager** and press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>.
+2. Enter your Wi‑Fi **SSID** and **password** under advanced options.
+3. Enable **SSH** and set a unique hostname for each Pi.
+4. Write the image to an SD card or M.2 drive and repeat for the other boards.
+
+## Switch and PoE
+
+A gigabit Ethernet switch keeps the cluster stable. If the switch offers
+PoE+ you can power the Pis with PoE HATs; otherwise use USB‑C supplies.
+
+## Join the cluster
+
+Boot the control-plane Pi first. Confirm it appears on your router then
+install `k3s`. Boot the remaining Pis and join them as workers once they
+can ping the control-plane node.
+
+See the deployment guide at
+[token.place](https://github.com/futuroptimist/token.place) for a detailed
+walkthrough.

--- a/llms.txt
+++ b/llms.txt
@@ -3,6 +3,8 @@
 > Off-grid k3s cluster with solar power. Contains 3D printed parts, KiCad schematics and build docs.
 
 This repository provides hardware designs and instructions for building a solar-powered Raspberry Pi cluster.
+The word *sugarkube* is used both for the solar cube itself and for helper
+scripts that provide "syntactic sugar" for Kubernetes.
 
 ## Docs
 - [Build guide](docs/build_guide.md)
@@ -10,6 +12,7 @@ This repository provides hardware designs and instructions for building a solar-
 - [Electronics basics](docs/electronics_basics.md)
 - [Power system design](docs/power_system_design.md)
 - [Insert basics](docs/insert_basics.md)
+- [Network setup](docs/network_setup.md)
 
 ## CAD
 - [OpenSCAD models](cad/)


### PR DESCRIPTION
## Summary
- clarify dual meaning of "sugarkube" in AGENTS.md, README.md and llms.txt
- add `docs/network_setup.md` describing how to connect the Pi cluster to Wi‑Fi and a switch
- link the new guide from README and docs index
- note the guide in AGENTS.md Docs Agent section

## Testing
- `pre-commit run --files AGENTS.md README.md docs/index.md docs/network_setup.md llms.txt`

------
https://chatgpt.com/codex/tasks/task_e_688941a349dc832f9e3c59d0c3f83ba2