### PR TITLE
ci: simplify kicad workflow

### DIFF
--- a/.github/workflows/kicad-export.yml
+++ b/.github/workflows/kicad-export.yml
@@ -7,31 +7,11 @@ on:
 jobs:
   kibot:
     runs-on: ubuntu-latest
-    # Kibot action pulls its own container image with KiCad 9 + Python
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install KiCad
-        run: |
-          sudo add-apt-repository --yes ppa:kicad/kicad-7.0-releases
-          sudo apt-get update
-
-      - name: Install KiCad 9
-        run: |
-          sudo add-apt-repository -y ppa:kicad/kicad-9.0-releases
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends kicad
-
-      - name: Export KiCad files
-        uses: actions-for-kicad/generate-kicad-files@v1.1
-        with:
-          schematic_pdf: true
-          gerber: true
-          bom: true
-
       - name: Fabricate board with KiBot
-        # Use the KiBot action pinned to the k9 container tag
-        # This ships a KiCad 9 environment able to load the board
+        # Use the KiBot action pinned to the KiCad 9 container
         uses: INTI-CMNB/kibot@v2_k9
         with:
           board: elex/power_ring/power_ring.kicad_pcb


### PR DESCRIPTION
## Summary
- run KiBot directly to export KiCad outputs
- drop redundant apt installations and generate-kicad-files step

## Testing
- `pre-commit run --files .github/workflows/kicad-export.yml`

------
https://chatgpt.com/codex/tasks/task_e_688f05aed184832fa69625e3848d47a4