### PR TITLE
ci: modernize KiCad export workflow

### DIFF
--- a/.github/workflows/kicad-export.yml
+++ b/.github/workflows/kicad-export.yml
@@ -3,35 +3,18 @@ on:
   push:
     paths:
       - 'elex/**/*.kicad_*'
+  schedule:
+    - cron: '0 0 * * 0'
 
 jobs:
   kibot:
     runs-on: ubuntu-latest
-    # Kibot action pulls its own container image with KiCad 9 + Python
+    # KiBot action pulls its own container image with KiCad 9
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install KiCad
-        run: |
-          sudo add-apt-repository --yes ppa:kicad/kicad-7.0-releases
-          sudo apt-get update
-
-      - name: Install KiCad 9
-        run: |
-          sudo add-apt-repository -y ppa:kicad/kicad-9.0-releases
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends kicad
-
-      - name: Export KiCad files
-        uses: actions-for-kicad/generate-kicad-files@v1.1
-        with:
-          schematic_pdf: true
-          gerber: true
-          bom: true
-
       - name: Fabricate board with KiBot
         # Use the KiBot action pinned to the k9 container tag
-        # This ships a KiCad 9 environment able to load the board
         uses: INTI-CMNB/kibot@v2_k9
         with:
           board: elex/power_ring/power_ring.kicad_pcb
@@ -45,3 +28,10 @@ jobs:
           path: |
             build/power_ring/**/*.zip
             build/power_ring/**/*.pdf
+
+      - name: Upload workflow logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: workflow-logs
+          path: /github/workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,10 @@ The name **sugarkube** has two meanings:
   3. Fail if compilation or regeneration fails.
 
 ## KiCad Agent
-- **When:** KiCad schematic or PCB files change
+- **When:** KiCad schematic or PCB files change and on a weekly schedule
 - **Does:** run the [KiBot action](https://github.com/INTI-CMNB/kibot) with `.kibot/power_ring.yaml` to export Gerbers, PDF schematics and BOM. The project
   requires **KiCad 9** so we use the `v2_k9` container tag.
+- **Logs:** workflow logs are uploaded as artifacts so non-admins can download failure details.
 
 ### STL generation
 STL meshes are not stored in the repository. The `scad-to-stl.yml` workflow renders them after each commit and exposes the files as downloadable artifacts.


### PR DESCRIPTION
## Summary
- simplify KiCad CI by relying solely on KiBot
- run KiCad exports on a weekly schedule and publish logs as artifacts
- document scheduled runs and log retrieval in AGENTS.md

## Testing
- `pre-commit run --files AGENTS.md .github/workflows/kicad-export.yml`


------
https://chatgpt.com/codex/tasks/task_e_688f05a543d4832f94c543efa3c43a75