### PR TITLE
🩹 fix: validate render script args and document STANDOFF_MODE

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ pre-commit run --all-files
 STL files are produced automatically by CI for each OpenSCAD model and can be
 downloaded from the workflow run. To render a variant locally you can run:
 
+Set `STANDOFF_MODE` to `heatset` for heat-set inserts or `printed` for 3D-printed threads.
+
 ```bash
 STANDOFF_MODE=heatset bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad
 ```

--- a/scripts/openscad_render.sh
+++ b/scripts/openscad_render.sh
@@ -2,6 +2,11 @@
 set -e
 
 FILE=$1
+if [ -z "$FILE" ]; then
+  echo "Usage: $0 path/to/model.scad" >&2
+  exit 1
+fi
+
 base=$(basename "$FILE" .scad)
 mode_suffix=""
 if [ -n "$STANDOFF_MODE" ]; then


### PR DESCRIPTION
what: add usage check to render script and explain STANDOFF_MODE values
why: avoid silent errors and guide users on standoff variants
how to test:
- pyspelling -c .spellcheck.yaml
- linkchecker README.md docs/
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_6892df4b3020832f8a63fefdd8b6a652