### PR TITLE
🐛: validate input path in openscad render

### DIFF
--- a/scripts/openscad_render.sh
+++ b/scripts/openscad_render.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 set -e
 
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <file.scad>" >&2
+  exit 1
+fi
+
 FILE=$1
+if [ ! -f "$FILE" ]; then
+  echo "Error: $FILE not found" >&2
+  exit 1
+fi
+
 base=$(basename "$FILE" .scad)
 mode_suffix=""
 if [ -n "$STANDOFF_MODE" ]; then


### PR DESCRIPTION
## Summary
- ensure `scripts/openscad_render.sh` exits early when no SCAD file is provided

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `detect-secrets scan scripts/openscad_render.sh`


------
https://chatgpt.com/codex/tasks/task_e_6892df4b3020832f8a63fefdd8b6a652