### PR TITLE
🐛 : respect default standoff mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,13 @@ linkchecker README.md docs/
 STL files are produced automatically by CI for each OpenSCAD model and can be
 downloaded from the workflow run. To render a variant locally you can run:
 
-Set `STANDOFF_MODE` to `heatset` for heat-set inserts or `printed` for 3D-printed threads.
+The script uses the model's default `standoff_mode` (`heatset`) when
+`STANDOFF_MODE` is unset. Set `STANDOFF_MODE=printed` to generate
+3D-printed threads.
 
 ```bash
-STANDOFF_MODE=heatset bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad
+bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad
+STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad
 ```
 
 See [AGENTS.md](AGENTS.md) for included LLM assistants.

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -25,7 +25,7 @@ REQUEST:
 1. Inspect `cad/*.scad` for todo comments or needed adjustments.
 2. Modify geometry or parameters as required.
 3. Render the model via:
-   STANDOFF_MODE=heatset bash scripts/openscad_render.sh <path/to.scad>
+   bash scripts/openscad_render.sh <path/to.scad> # defaults to heatset
    STANDOFF_MODE=printed bash scripts/openscad_render.sh <path/to.scad>
 4. Commit updated SCAD sources and any documentation.
 

--- a/scripts/openscad_render.sh
+++ b/scripts/openscad_render.sh
@@ -14,4 +14,9 @@ if [ -n "$STANDOFF_MODE" ]; then
 fi
 output="stl/${base}${mode_suffix}.stl"
 mkdir -p "$(dirname "$output")"
-openscad -o "$output" --export-format binstl -D standoff_mode=\"${STANDOFF_MODE}\" "$FILE"
+cmd=(openscad -o "$output" --export-format binstl)
+if [ -n "$STANDOFF_MODE" ]; then
+  cmd+=(-D "standoff_mode=\"${STANDOFF_MODE}\"")
+fi
+cmd+=("$FILE")
+"${cmd[@]}"

--- a/tests/openscad_render_test.py
+++ b/tests/openscad_render_test.py
@@ -1,0 +1,32 @@
+import os
+import subprocess
+
+
+def test_script_respects_model_default(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    log_file = tmp_path / "args.log"
+    openscad = fake_bin / "openscad"
+    openscad.write_text(
+        """#!/usr/bin/env bash
+printf '%s ' "$@" > "$LOG_FILE"
+"""
+    )
+    openscad.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["LOG_FILE"] = str(log_file)
+
+    subprocess.run(
+        [
+            "bash",
+            "scripts/openscad_render.sh",
+            "cad/pi_cluster/pi5_triple_carrier_rot45.scad",
+        ],
+        check=True,
+        env=env,
+    )
+
+    args = log_file.read_text()
+    assert "-D" not in args


### PR DESCRIPTION
## Summary
- skip empty `standoff_mode` override in OpenSCAD render script
- document optional `STANDOFF_MODE` flag
- test render script respects default mode

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_6893e2cb65dc832fa9f38a5217adfcca