### PR TITLE
🧱 : map STANDOFF_MODE to pi_carrier variants

### DIFF
--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -1,4 +1,11 @@
-variation = "blind"; // blind, through, nut
+// STANDOFF_MODE is passed via -D by openscad_render.sh
+// "heatset" → blind hole sized for brass insert
+// "printed" → simple through-hole
+// "nut"     → through-hole with hex recess
+standoff_mode = "heatset";
+variation = standoff_mode == "printed" ? "through"
+          : standoff_mode == "heatset" ? "blind"
+          : standoff_mode;
 
 pi_positions = [[0,0], [1,0], [0,1]]; // layout as [x,y] offsets
 board_len = 85;

--- a/docs/lcd_mount.md
+++ b/docs/lcd_mount.md
@@ -9,7 +9,9 @@ LCD support is disabled by default. Enable the display by setting
 then render the model:
 
 ```bash
-openscad cad/pi_cluster/pi_carrier.scad
+bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad
+STANDOFF_MODE=printed \
+  bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad
 ```
 
 Rotate the LCD or tweak offsets if your board slightly differs. The


### PR DESCRIPTION
## Summary
- accept STANDOFF_MODE for pi_carrier and map to existing variations
- document LCD carrier render steps for heatset and printed modes

## Testing
- `bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `bash scripts/openscad_render.sh cad/solar_cube/frame.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/frame.scad`
- `bash scripts/openscad_render.sh cad/solar_cube/sugarkube.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/sugarkube.scad`
- `bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker README.md docs/`
- `pre-commit run --all-files`

Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_689437cc8d74832fb8665686094f3a17