### PR TITLE
🔧: thicken panel bracket and tighten insert fit

### DIFF
--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -8,16 +8,16 @@
 */
 
 size          = 40;           // leg length (mm)
-thickness     = 3;            // plate thickness (mm)
+thickness     = 4;            // plate thickness (mm)
 beam_width    = 20;           // width to match 2020 extrusion (mm)
 hole_offset   = [0,0];        // XY offset of mounting hole from centre (mm)
 
 // insert / screw parameters
 insert_od         = 5.0;      // brass insert outer Ø (mm)
 insert_length     = 5.0;
-insert_clearance  = 0.15;     // interference amount (mm)
+insert_clearance  = 0.10;     // interference amount (mm)
 insert_hole_diam  = insert_od - insert_clearance;
-screw_clearance   = 5.0;      // through-hole Ø for M5 (mm)
+screw_clearance   = 5.2;      // through-hole Ø for M5 (mm)
 chamfer           = 0.6;      // lead-in chamfer (mm)
 
 // read from CLI (-D standoff_mode="printed"/"heatset")


### PR DESCRIPTION
what: increase panel bracket plate to 4 mm and adjust hole tolerances.
why: extra thickness boosts stiffness, tighter insert fit holds better.
how to test:
- bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad
- STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad
- pre-commit run --all-files
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_689462ab3350832fb67667c02f9e85a6