### PR TITLE
🐛 fix: guard linkchecker in checks script

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -22,4 +22,6 @@ pytest --cov=. --cov-report=xml --cov-report=term -q
 if command -v pyspelling >/dev/null 2>&1 && [ -f .spellcheck.yaml ]; then
   pyspelling -c .spellcheck.yaml || true
 fi
-linkchecker README.md docs/ || true
+if command -v linkchecker >/dev/null 2>&1; then
+  linkchecker README.md docs/ || true
+fi


### PR DESCRIPTION
## Summary
- call linkchecker only when installed

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker README.md docs/`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689462b7cb8c832f93f77ce16e4b176c