### PR TITLE
📝 : – generalize charge controller guidance

### DIFF
--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -3,7 +3,7 @@
 This setup uses a 12V LiFePO4 battery and outdoor wiring.  Follow these precautions:
 
 - Place a 60A fuse within 7 inches of the battery positive terminal.
-- Keep the Victron MPPT charge controller in a ventilated enclosure, never sealed inside the battery box.
+- Keep the MPPT charge controller in a ventilated enclosure, never sealed inside the battery box.
 - Fuse the air pump branch at 15A and the Raspberry Pi buck converter at 5A.
 - Route cables so water cannot drip onto connectors; use cable glands and strain relief.
 - Wear eye protection while crimping and avoid short circuits when working on the battery.

--- a/docs/build_guide.md
+++ b/docs/build_guide.md
@@ -8,9 +8,11 @@ junction box.
    insert variants are published as artifacts by GitHub Actions.
 2. Assemble the extrusion cube using M5 hardware.
 3. Mount the solar panels using the printed brackets.
-4. Wire the panels to the Victron MPPT charge controller. The KiCad schematic and board specs
+4. Attach the battery leads to the MPPT charge controller before any solar wiring. Refer to the
+   controller's manual for the recommended connection order. The KiCad schematic and board specs
    live under [elex/power_ring](../elex/power_ring/).
-5. Install the 12 V air pump and Raspberry Pi behind a 15 A breaker and 5 A fuse respectively.
-6. Connect the battery and verify voltage before powering devices.
+5. Wire the solar panels to the controller once the battery is present, observing polarity.
+6. Install the 12 V air pump and Raspberry Pi on dedicated protection: a 15 A breaker for the pump
+   and a 5 A fuse for the Pi. Verify battery voltage with a multimeter before powering devices.
 
 For details on electronics and safety precautions see [SAFETY.md](SAFETY.md).


### PR DESCRIPTION
what: remove brand-specific charge controller references in docs
why: keep build and safety instructions broadly applicable
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker README.md docs/
Refs: N/A

------
https://chatgpt.com/codex/tasks/task_e_689462b16148832f9c7157ba1749ca8f