### PR TITLE
🔧 standardize insert undersize to 0.2 mm

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -143,3 +143,4 @@ WiFi
 lcd
 LCD
 todo
+undersize

--- a/cad/pi_cluster/pi5_triple_carrier_rot45.scad
+++ b/cad/pi_cluster/pi5_triple_carrier_rot45.scad
@@ -46,8 +46,8 @@ standoff_mode   = "heatset";
 /* ---- heat-set insert geometry (M2 short, 3 mm OD, 3 mm long) ---- */
 insert_od         = 3.00;        // outer diameter of the insert (mm)
 insert_length     = 3.00;        // nominal length (mm)
-insert_clearance  = 0.10;        // designed undersize for interference fit (mm)
-insert_hole_diam  = insert_od - insert_clearance; // about 2.9 mm
+insert_clearance  = 0.20;        // designed undersize for interference fit (mm)
+insert_hole_diam  = insert_od - insert_clearance; // about 2.8 mm
 insert_chamfer    = 0.5;         // chamfer to guide the soldering tip
 
 /* ---- screw / printed thread geometry (unchanged) ---- */

--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -20,7 +20,8 @@ standoff_diam = 6.0;
 insert_od         = 3.5;         // outer Ø for common brass inserts
 insert_length     = 4.0;         // full length of the insert
 insert_pocket_depth = insert_length + 0.7; // keeps 0.7 mm extra for chamfer
-hole_diam         = insert_od + 0.1;       // slip-fit pilot
+insert_clearance  = 0.2;         // designed undersize for interference fit
+hole_diam         = insert_od - insert_clearance;
 lead_chamfer = 0.5;
 screw_clearance_diam = 3.0; // through-hole clearance
 

--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -15,7 +15,7 @@ hole_offset   = [0,0];        // XY offset of mounting hole from centre (mm)
 // insert / screw parameters
 insert_od         = 5.0;      // brass insert outer Ø (mm)
 insert_length     = 5.0;
-insert_clearance  = 0.10;     // interference amount (mm)
+insert_clearance  = 0.20;     // interference amount (mm)
 insert_hole_diam  = insert_od - insert_clearance;
 screw_clearance   = 5.2;      // through-hole Ø for M5 (mm)
 chamfer           = 0.6;      // lead-in chamfer (mm)

--- a/docs/insert_basics.md
+++ b/docs/insert_basics.md
@@ -8,6 +8,7 @@ Heat‑set inserts are knurled brass cylinders that melt into a printed hole. On
 
 - Choose inserts with an outer diameter around **3.5 mm** and **4 mm** length for M2.5 screws.
 - Size the hole **0.1–0.2 mm smaller** than the insert’s outer diameter so the plastic grips the knurling.
+- Sugarkube models default to a **0.2 mm** undersize which suits typical brass inserts.
 - Use a soldering iron with a flat or conical tip. Set it around **200–220 °C** and press the insert flush with gentle downward pressure.
 - Let each insert cool for a few seconds before removing the tip to avoid pulling it back out.
 


### PR DESCRIPTION
## Summary
- use 0.2 mm undersize for heat-set insert holes across carrier and bracket models
- document default insert undersize in guide

## Testing
- `bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker README.md docs/`

------
https://chatgpt.com/codex/tasks/task_e_6896ce578820832f94437e3cff1462b6