### PR TITLE
🛠️ : add gusset option to panel bracket

### DIFF
--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -11,6 +11,7 @@ size          = 40;           // leg length (mm)
 thickness     = 4;            // plate thickness (mm)
 beam_width    = 20;           // width to match 2020 extrusion (mm)
 hole_offset   = [0,0];        // XY offset of mounting hole from centre (mm)
+gusset        = true;         // add triangular support in inner corner
 
 // insert / screw parameters
 insert_od         = 5.0;      // brass insert outer Ø (mm)
@@ -34,6 +35,13 @@ module l_bracket()
       // vertical leg (XZ plane)
       translate([0, size - thickness, 0])
         cube([beam_width, thickness, size]);
+
+      // optional gusset to reinforce the corner
+      if (gusset)
+        translate([0, size - thickness, 0])
+          rotate([0,90,0])
+            linear_extrude(height=beam_width)
+              polygon([[0,0],[thickness,0],[0,thickness]]);
     }
 
     /* drill hole at centre of base leg for mounting */

--- a/docs/build_guide.md
+++ b/docs/build_guide.md
@@ -8,6 +8,7 @@ junction box.
    insert variants are published as artifacts by GitHub Actions.
 2. Assemble the extrusion cube using M5 hardware.
 3. Mount the solar panels using the printed brackets.
+   Each has a gusset that stiffens the corner.
 4. Attach the battery leads to the MPPT charge controller before any solar wiring. Refer to the
    controller's manual for the recommended connection order. The KiCad schematic and board specs
    live under [elex/power_ring](../elex/power_ring/).


### PR DESCRIPTION
## Summary
- add configurable gusset to panel bracket for extra rigidity
- document bracket gusset in build guide

## Testing
- `bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_6896ce578820832f94437e3cff1462b6