### PR TITLE
docs: clarify remote kubectl setup

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -138,6 +138,7 @@ PoE
 HATs
 walkthrough
 Kubernetes
+kubeconfig
 Wi-Fi
 WiFi
 lcd

--- a/docs/network_setup.md
+++ b/docs/network_setup.md
@@ -51,6 +51,19 @@ If you need the token again, view it on the control-plane node:
 sudo cat /var/lib/rancher/k3s/server/node-token
 ```
 
+## Manage from a workstation
+
+To run `kubectl` from your laptop, copy the kubeconfig generated on the
+control-plane node and secure it locally:
+
+```sh
+scp pi@<server-ip>:/etc/rancher/k3s/k3s.yaml ~/.kube/config
+chmod 600 ~/.kube/config
+```
+
+Edit the file and replace the server IP with the control-plane address.
+Now `kubectl get nodes` works from your workstation.
+
 See the deployment guide at
 [token.place](https://github.com/futuroptimist/token.place) for a detailed
 walkthrough. For more options consult the


### PR DESCRIPTION
## Summary
- describe copying kubeconfig to a workstation
- whitelist `kubeconfig` in wordlist

## Testing
- `python -m pre_commit run --all-files`
- `python -m pyspelling -c .spellcheck.yaml`
- `/root/.pyenv/versions/3.12.10/bin/linkchecker README.md docs/`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896ce5f5860832fbab2edb966df10bd