### PR TITLE
📝 docs: clarify LCD mount rendering steps

### DIFF
--- a/docs/lcd_mount.md
+++ b/docs/lcd_mount.md
@@ -1,19 +1,21 @@
 # Optional LCD Mount
 
 The basic Pi carrier can host a 1602 I²C LCD in the free quadrant.
-Standoffs match the common 80×36 mm module with holes 3 mm from each
-edge (75 mm × 31 mm hole spacing).
+Its standoffs match the common 80×36 mm module with holes 3 mm from each
+edge (75 mm × 31 mm spacing).
 
-LCD support is disabled by default. Enable the display by setting
+LCD support is disabled by default. To add the display set
 `include_lcd = true` near the top of `cad/pi_cluster/pi_carrier.scad`
-then render the model:
+and render the model from the repository root:
 
 ```bash
+# Render the default heat-set insert variant
 bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad
-STANDOFF_MODE=printed \
-  bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad
+
+# Render a version with printed threads
+STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad
 ```
 
 Rotate the LCD or tweak offsets if your board slightly differs. The
-extra standoffs keep clear of the Pi mounting holes so you can add the
-display without enlarging the plate.
+extra standoffs avoid the Pi mounting holes so you can add the display
+without enlarging the plate.


### PR DESCRIPTION
what: refine LCD mount docs with clearer rendering commands
why: previous example used a confusing env var syntax
how to test: pre-commit run --all-files


------
https://chatgpt.com/codex/tasks/task_e_6896ce5f5860832fbab2edb966df10bd