### PR TITLE
🔧: verify openscad is installed before rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad
 STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad
 ```
 
-The helper script validates that the provided `.scad` file exists and prints a helpful
-error if it does not.
+The helper script validates that the provided `.scad` file exists and that `openscad`
+is on your `PATH`, printing a helpful error when something is missing.
 
 See [AGENTS.md](AGENTS.md) for included LLM assistants.
 See [llms.txt](llms.txt) for an overview suitable for language models.

--- a/scripts/openscad_render.sh
+++ b/scripts/openscad_render.sh
@@ -11,6 +11,11 @@ if [ ! -f "$FILE" ]; then
   exit 1
 fi
 
+if ! command -v openscad >/dev/null 2>&1; then
+  echo "OpenSCAD not found in PATH" >&2
+  exit 1
+fi
+
 base=$(basename "$FILE" .scad)
 mode_suffix=""
 if [ -n "$STANDOFF_MODE" ]; then

--- a/tests/openscad_render_test.py
+++ b/tests/openscad_render_test.py
@@ -57,3 +57,21 @@ echo called > {marker}
     assert result.returncode != 0
     assert "File not found" in result.stderr
     assert not marker.exists()
+
+
+def test_errors_when_openscad_missing(tmp_path):
+    env = os.environ.copy()
+    env["PATH"] = str(tmp_path)
+
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "scripts/openscad_render.sh",
+            "cad/pi_cluster/pi5_triple_carrier_rot45.scad",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "OpenSCAD not found" in result.stderr


### PR DESCRIPTION
## Summary
- check openscad_render.sh for OpenSCAD on PATH and exit with message
- document and test missing OpenSCAD scenario

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_6896ce6541fc832fa27f3b5cb9c32521