### PR TITLE
🐛 fix: harden OpenSCAD render script

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_
 By default the script uses the model's `standoff_mode` value (`heatset`).
 Set `STANDOFF_MODE=printed` to generate 3D-printed threads.
 
-The helper script validates that the provided `.scad` file exists and prints a helpful
-error if it does not.
+The helper script validates that the provided `.scad` file exists and that
+OpenSCAD is available in `PATH`, printing a helpful error if either check fails.
 
 See [AGENTS.md](AGENTS.md) for included LLM assistants.
 See [llms.txt](llms.txt) for an overview suitable for language models.

--- a/scripts/openscad_render.sh
+++ b/scripts/openscad_render.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 FILE=$1
 if [ -z "$FILE" ]; then
@@ -18,13 +18,13 @@ fi
 
 base=$(basename "$FILE" .scad)
 mode_suffix=""
-if [ -n "$STANDOFF_MODE" ]; then
+if [ -n "${STANDOFF_MODE:-}" ]; then
   mode_suffix="_$STANDOFF_MODE"
 fi
 output="stl/${base}${mode_suffix}.stl"
 mkdir -p "$(dirname "$output")"
 cmd=(openscad -o "$output" --export-format binstl)
-if [ -n "$STANDOFF_MODE" ]; then
+if [ -n "${STANDOFF_MODE:-}" ]; then
   cmd+=(-D "standoff_mode=\"${STANDOFF_MODE}\"")
 fi
 cmd+=("$FILE")


### PR DESCRIPTION
## Summary
- exit on unset vars and pipe failures in render script
- document OpenSCAD availability check

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_6896ed0e352c832f90ab95f7c080d679