### PR TITLE
🔧 widen Pi carrier standoffs

### DIFF
--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -15,7 +15,7 @@ hole_spacing_y = 49;
 
 plate_thickness = 2.0;
 standoff_height = 6.0;
-standoff_diam = 6.0;
+standoff_diam = 6.5;   // increased for added strength
 
 insert_od         = 3.5;         // outer Ø for common brass inserts
 insert_length     = 4.0;         // full length of the insert


### PR DESCRIPTION
## Summary
- strengthen pi carrier by expanding standoff diameter to 6.5 mm

## Testing
- `bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `npm run lint` *(fails: Could not read package.json)*
- `npm run test:ci` *(fails: Could not read package.json)*
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6896ec812a84832faea481c765e29a7b