### PR TITLE
🔧 : extend panel bracket leg length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 ## [Unreleased]
 ### Fixed
 * pi_carrier: standoff length increased from 20 mm to 22 mm (flush fit with PoE HAT)
+### Changed
+* panel_bracket: default leg length increased from 40 mm to 45 mm for extra panel support

--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -7,7 +7,7 @@
   A variable of that name is passed in by the CI render script.
 */
 
-size          = 40;           // leg length (mm)
+size          = 45;           // leg length (mm)
 thickness     = 4;            // plate thickness (mm)
 beam_width    = 20;           // width to match 2020 extrusion (mm)
 hole_offset   = [0,0];        // XY offset of mounting hole from centre (mm)


### PR DESCRIPTION
## Summary
- increase panel_bracket default leg length from 40 mm to 45 mm

## Testing
- `bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6896ec812a84832faea481c765e29a7b