### PR TITLE
🔧: thicken panel bracket for insert pocket

### DIFF
--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -8,7 +8,7 @@
 */
 
 size          = 40;           // leg length (mm)
-thickness     = 4;            // plate thickness (mm)
+thickness     = 6;            // plate thickness (mm)
 beam_width    = 20;           // width to match 2020 extrusion (mm)
 hole_offset   = [0,0];        // XY offset of mounting hole from centre (mm)
 gusset        = true;         // add triangular support in inner corner
@@ -20,6 +20,9 @@ insert_clearance  = 0.20;     // interference amount (mm)
 insert_hole_diam  = insert_od - insert_clearance;
 screw_clearance   = 5.2;      // through-hole Ø for M5 (mm)
 chamfer           = 0.6;      // lead-in chamfer (mm)
+
+assert(insert_length < thickness,
+       "insert_length must be < thickness to maintain a blind hole");
 
 // read from CLI (-D standoff_mode="printed"/"heatset")
 standoff_mode = "heatset";


### PR DESCRIPTION
## Summary
- beef up panel bracket thickness so 5 mm insert leaves solid floor
- guard against insert length exceeding bracket thickness

## Testing
- `bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6896ec812a84832faea481c765e29a7b