### PR TITLE
🐛: handle missing arg in OpenSCAD script

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ linkchecker README.md docs/
 ```
 
 STL files are produced automatically by CI for each OpenSCAD model and can be
-downloaded from the workflow run. To render a variant locally, run:
+downloaded from the workflow run. Provide a `.scad` file path to render a
+variant locally:
 
 ```bash
 bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad

--- a/scripts/openscad_render.sh
+++ b/scripts/openscad_render.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-FILE=$1
-if [ -z "$FILE" ]; then
+if [ "$#" -lt 1 ]; then
   echo "Usage: $0 path/to/model.scad" >&2
   exit 1
 fi
+
+FILE=$1
 if [ ! -f "$FILE" ]; then
   echo "File not found: $FILE" >&2
   exit 1

--- a/tests/openscad_render_test.py
+++ b/tests/openscad_render_test.py
@@ -59,6 +59,16 @@ echo called > {marker}
     assert not marker.exists()
 
 
+def test_errors_when_arg_missing():
+    result = subprocess.run(
+        ["bash", "scripts/openscad_render.sh"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "Usage:" in result.stderr
+
+
 def test_errors_when_openscad_missing(tmp_path):
     env = os.environ.copy()
     env["PATH"] = str(tmp_path)


### PR DESCRIPTION
what: guard against missing argument and add regression test
why: script crashed with unbound variable when no file path provided
how to test: pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689919220c1c832fbe05becc7092d1d8