### PR TITLE
🐛 : harden checks script with strict bash flags

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # python checks
 flake8 . --exclude=.venv


### PR DESCRIPTION
## Summary
- enforce -u and pipefail in checks script for stricter bash

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml` *(command not found)*
- `linkchecker README.md docs/` *(command not found)*

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689919220c1c832fbe05becc7092d1d8