### PR TITLE
📝 : document aspell requirement for spellcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@ pre-commit install
 pre-commit run --all-files
 ```
 
-If you update documentation, install spell-check tools and verify spelling and links:
+If you update documentation, install spell-check tools and verify spelling and links. `pyspelling`
+relies on `aspell`, so make sure it is installed as well:
 
 ```bash
 pip install pyspelling linkchecker
+sudo apt-get install aspell
 pyspelling -c .spellcheck.yaml
 linkchecker README.md docs/
 ```

--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -17,8 +17,8 @@ Keep the documentation clear and accurate.
 CONTEXT:
 - Docs live in `docs/`.
 - Follow AGENTS.md for style and testing requirements.
-- Run `pre-commit run --all-files`; ensure `pyspelling` and `linkchecker`
-  succeed.
+- Run `pre-commit run --all-files`; ensure `pyspelling` (requires `aspell`) and
+  `linkchecker` succeed.
 
 REQUEST:
 1. Choose a markdown file in `docs/` that needs clarification or an update.

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -18,7 +18,7 @@ Keep the project healthy by making small, well-tested improvements.
 CONTEXT:
 - Follow AGENTS.md and README.md.
 - Run `pre-commit run --all-files` to lint, test and validate docs.
-- On documentation changes ensure `pyspelling -c .spellcheck.yaml` and
+- On documentation changes ensure `pyspelling -c .spellcheck.yaml` (requires `aspell`) and
   `linkchecker README.md docs/` succeed.
 
 REQUEST:


### PR DESCRIPTION
## Summary
- mention that pyspelling depends on aspell
- update prompts to note aspell when running doc checks

## Testing
- `pre-commit run --all-files`
- `linkchecker README.md docs/`
- `pyspelling -c .spellcheck.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689919220c1c832fbe05becc7092d1d8