### PR TITLE
docs: clarify kubeconfig setup for workstations

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -140,6 +140,7 @@ walkthrough
 Kubernetes
 kube
 kubeconfig
+kubectl
 Wi-Fi
 WiFi
 lcd

--- a/docs/network_setup.md
+++ b/docs/network_setup.md
@@ -56,16 +56,18 @@ sudo cat /var/lib/rancher/k3s/server/node-token
 
 ## Manage from a workstation
 
-To run `kubectl` from your laptop, first create a kube directory and then
-copy the kubeconfig generated on the control-plane node:
+To run `kubectl` from your laptop, ensure the
+[kubectl client is installed](https://kubernetes.io/docs/tasks/tools/#kubectl).
+Copy the kubeconfig generated on the control-plane node and update its
+server address:
 
 ```sh
 mkdir -p ~/.kube
 scp <user>@<server-ip>:/etc/rancher/k3s/k3s.yaml ~/.kube/config
+sed -i "s/127.0.0.1/<server-ip>/g" ~/.kube/config
 chmod 600 ~/.kube/config
 ```
 
-Edit the file and replace the server IP with the control-plane address.
 Now `kubectl get nodes` works from your workstation.
 
 See the deployment guide at


### PR DESCRIPTION
## Summary
- document replacing localhost in kubeconfig copied from k3s server
- add kubectl to spelling wordlist

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_689918f26dc0832f8d5e4ce8c5153d84