### PR TITLE
docs: clarify network setup steps

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -146,3 +146,6 @@ lcd
 LCD
 todo
 undersize
+sfL
+kubectl
+sudo

--- a/docs/network_setup.md
+++ b/docs/network_setup.md
@@ -26,6 +26,9 @@ install `k3s`:
 
 ```sh
 curl -sfL https://get.k3s.io | sh -
+
+# Wait for the service to report Ready
+sudo kubectl get nodes
 ```
 
 Display the worker join token:
@@ -63,10 +66,12 @@ copy the kubeconfig generated on the control-plane node:
 mkdir -p ~/.kube
 scp <user>@<server-ip>:/etc/rancher/k3s/k3s.yaml ~/.kube/config
 chmod 600 ~/.kube/config
+sed -i "s/127.0.0.1/<server-ip>/" ~/.kube/config
+export KUBECONFIG=~/.kube/config
 ```
 
-Edit the file and replace the server IP with the control-plane address.
-Now `kubectl get nodes` works from your workstation.
+The `sed` command swaps the default localhost address for the control-plane
+IP so `kubectl get nodes` works from your workstation.
 
 See the deployment guide at
 [token.place](https://github.com/futuroptimist/token.place) for a detailed


### PR DESCRIPTION
## Summary
- expand network setup guide with readiness check and kubeconfig fix
- allow kubectl and sudo in spellcheck wordlist

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68991918a098832f97193245e23bf05d