### PR TITLE
📝 : clarify kubectl config steps

### DIFF
--- a/docs/network_setup.md
+++ b/docs/network_setup.md
@@ -68,12 +68,12 @@ mkdir -p ~/.kube
 scp <user>@<server-ip>:/etc/rancher/k3s/k3s.yaml ~/.kube/config
 sed -i "s/127.0.0.1/<server-ip>/g" ~/.kube/config
 chmod 600 ~/.kube/config
-sed -i "s/127.0.0.1/<server-ip>/" ~/.kube/config
 export KUBECONFIG=~/.kube/config
+kubectl get nodes
 ```
 
 The `sed` command swaps the default localhost address for the control-plane
-IP so `kubectl get nodes` works from your workstation.
+IP so `kubectl` can reach the cluster from your workstation.
 
 See the deployment guide at
 [token.place](https://github.com/futuroptimist/token.place) for a detailed


### PR DESCRIPTION
## Summary
- remove duplicate sed instruction and add kubectl verification
- clarify how the command updates kubeconfig for remote access

## Testing
- `npm run lint` *(fails: ENOENT package.json)*
- `npm run test:ci` *(fails: ENOENT package.json)*
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker README.md docs/`
- `pytest`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_689abbc855ec832fb091ade9f36fbc73