### PR TITLE
🐛: fail doc checks on errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ pre-commit install
 pre-commit run --all-files
 ```
 
-If you update documentation, install spell-check tools and verify spelling and links. `pyspelling`
-relies on `aspell`, so make sure it is installed as well:
+If you update documentation, install spell-check tools and verify spelling and links.
+`pyspelling` relies on `aspell`, so make sure it is installed as well. pre-commit runs
+these checks and fails if spelling or links are broken:
 
 ```bash
 pip install pyspelling linkchecker

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -20,8 +20,8 @@ pytest --cov=. --cov-report=xml --cov-report=term -q
 
 # docs checks
 if command -v pyspelling >/dev/null 2>&1 && [ -f .spellcheck.yaml ]; then
-  pyspelling -c .spellcheck.yaml || true
+  pyspelling -c .spellcheck.yaml
 fi
 if command -v linkchecker >/dev/null 2>&1; then
-  linkchecker README.md docs/ || true
+  linkchecker --no-warnings README.md docs/
 fi


### PR DESCRIPTION
what: fail docs checks when spelling or links break
why: ensure broken links or typos cause CI failures
how to test:
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_689abbaa85ac832fac4edf5916b66162