### PR TITLE
🐛 fix: validate STANDOFF_MODE values

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_
 ```
 
 By default the script uses the model's `standoff_mode` value (`heatset`).
-Set `STANDOFF_MODE=printed` to generate 3D-printed threads.
+Set `STANDOFF_MODE=printed` to generate 3D-printed threads. Only `heatset`
+and `printed` are accepted.
 
 The helper script validates that the provided `.scad` file exists and that
 OpenSCAD is available in `PATH`, printing a helpful error if either check fails.

--- a/docs/lcd_mount.md
+++ b/docs/lcd_mount.md
@@ -19,3 +19,5 @@ STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.
 Rotate the LCD or tweak offsets if your board slightly differs. The
 extra standoffs avoid the Pi mounting holes so you can add the display
 without enlarging the plate.
+
+Valid `STANDOFF_MODE` values are `heatset` (default) and `printed`.

--- a/scripts/openscad_render.sh
+++ b/scripts/openscad_render.sh
@@ -17,15 +17,23 @@ if [[ "$FILE" != *.scad ]]; then
   exit 1
 fi
 
-if ! command -v openscad >/dev/null 2>&1; then
-  echo "OpenSCAD not found in PATH" >&2
-  exit 1
-fi
-
 base=$(basename "$FILE" .scad)
 mode_suffix=""
 if [ -n "${STANDOFF_MODE:-}" ]; then
-  mode_suffix="_$STANDOFF_MODE"
+  case "$STANDOFF_MODE" in
+    heatset|printed)
+      mode_suffix="_$STANDOFF_MODE"
+      ;;
+    *)
+      echo "Invalid STANDOFF_MODE: $STANDOFF_MODE (expected 'heatset' or 'printed')" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+if ! command -v openscad >/dev/null 2>&1; then
+  echo "OpenSCAD not found in PATH" >&2
+  exit 1
 fi
 output="stl/${base}${mode_suffix}.stl"
 mkdir -p "$(dirname "$output")"

--- a/tests/openscad_render_test.py
+++ b/tests/openscad_render_test.py
@@ -71,7 +71,7 @@ def test_errors_when_arg_missing():
 
 def test_errors_when_openscad_missing(tmp_path):
     env = os.environ.copy()
-    env["PATH"] = str(tmp_path)
+    env["PATH"] = "/usr/bin"
 
     result = subprocess.run(
         [
@@ -114,3 +114,21 @@ echo called > {marker}
     assert result.returncode != 0
     assert "Expected .scad file" in result.stderr
     assert not marker.exists()
+
+
+def test_errors_when_standoff_mode_invalid():
+    env = os.environ.copy()
+    env["STANDOFF_MODE"] = "invalid"
+
+    result = subprocess.run(
+        [
+            "bash",
+            "scripts/openscad_render.sh",
+            "cad/pi_cluster/pi_carrier.scad",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "Invalid STANDOFF_MODE" in result.stderr


### PR DESCRIPTION
what: reject unsupported STANDOFF_MODE in renderer, document valid modes
why: prevent typos from producing unexpected STL outputs
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker README.md docs/
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689abbaa85ac832fac4edf5916b66162