### PR TITLE
🐛 fix: preserve SCAD directory structure in STL output

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,12 @@ linkchecker README.md docs/
 
 STL files are produced automatically by CI for each OpenSCAD model and can be
 downloaded from the workflow run. Provide a `.scad` file path to render a
-variant locally:
+variant locally; the resulting STL is written under `stl/` mirroring the source
+directory:
 
 ```bash
 bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad
+# -> stl/pi_cluster/pi5_triple_carrier_rot45.stl
 STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad
 ```
 

--- a/scripts/openscad_render.sh
+++ b/scripts/openscad_render.sh
@@ -22,12 +22,13 @@ if ! command -v openscad >/dev/null 2>&1; then
   exit 1
 fi
 
-base=$(basename "$FILE" .scad)
+rel=${FILE%.scad}
+rel=${rel#cad/}
 mode_suffix=""
 if [ -n "${STANDOFF_MODE:-}" ]; then
   mode_suffix="_$STANDOFF_MODE"
 fi
-output="stl/${base}${mode_suffix}.stl"
+output="stl/${rel}${mode_suffix}.stl"
 mkdir -p "$(dirname "$output")"
 cmd=(openscad -o "$output" --export-format binstl)
 if [ -n "${STANDOFF_MODE:-}" ]; then

--- a/tests/openscad_render_test.py
+++ b/tests/openscad_render_test.py
@@ -29,6 +29,7 @@ printf '%s ' "$@" > "$LOG_FILE"
     )
 
     args = log_file.read_text()
+    assert "stl/pi_cluster/pi5_triple_carrier_rot45.stl" in args
     assert "-D" not in args
 
 


### PR DESCRIPTION
what: keep OpenSCAD render outputs in matching subdirectories
why: avoid overwriting STL files that share names
how to test: pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689abbaa85ac832fac4edf5916b66162