### PR TITLE
🔧 : fix kicad workflow log upload path

### DIFF
--- a/.github/workflows/kicad-export.yml
+++ b/.github/workflows/kicad-export.yml
@@ -34,4 +34,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: workflow-logs
-          path: /github/workflow
+          path: ${{ runner.temp }}/_github_workflow
+          if-no-files-found: ignore


### PR DESCRIPTION
## What
- update workflow log artifact path

## Why
- fix failing KiCad export workflow

## How to test
- `pre-commit run --files .github/workflows/kicad-export.yml`
- `bash scripts/checks.sh`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689c18cbc7f0832fbd7429b729f06467