### PR TITLE
fix KiCad workflow log path

### DIFF
--- a/.github/workflows/kicad-export.yml
+++ b/.github/workflows/kicad-export.yml
@@ -34,4 +34,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: workflow-logs
-          path: /github/workflow
+          path: ${{ runner.temp }}/_github_workflow
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- fix KiCad export workflow log upload path

## Testing
- `pre-commit run --all-files`
- `detect-secrets scan .github/workflows/kicad-export.yml`


------
https://chatgpt.com/codex/tasks/task_e_689c18cbc7f0832fbd7429b729f06467