### PR TITLE
📝 : add contributing guide and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Code of Conduct
+
+## Our Pledge
+We pledge to make participation in sugarkube a harassment-free experience for
+everyone, regardless of age, body size, disability, ethnicity, gender identity
+and expression, level of experience, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+Examples of behaviour that contributes to a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Accepting constructive criticism
+- Showing empathy towards others
+
+Examples of unacceptable behaviour include:
+
+- The use of sexualised language or imagery and unwelcome sexual attention
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without permission
+
+## Enforcement
+Project maintainers are responsible for clarifying standards of acceptable
+behaviour and will take appropriate and fair corrective action in response to
+any behaviour they deem inappropriate.
+
+## Scope
+This Code of Conduct applies within project spaces and in public spaces when
+an individual represents the project or its community.
+
+## Enforcement Guidelines
+Community leaders will follow these guidelines when enforcing the Code of
+Conduct:
+
+1. **Correction** – private, written warning.
+2. **Warning** – public warning and temporary exclusion.
+3. **Temporary Ban** – temporary exclusion from participation.
+4. **Permanent Ban** – permanent exclusion from the community.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant][homepage].
+
+[homepage]: https://www.contributor-covenant.org
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+Thanks for helping improve sugarkube!
+
+## Workflow
+
+- Fork the repository and create a feature branch.
+- Install tooling:
+
+```bash
+pip install pre-commit pyspelling linkchecker
+sudo apt-get install aspell
+pre-commit install
+```
+
+- Run all checks before committing:
+
+```bash
+pre-commit run --all-files
+pyspelling -c .spellcheck.yaml
+linkchecker README.md docs/ CONTRIBUTING.md CODE_OF_CONDUCT.md
+```
+
+- Use the commit format `emoji : summary` with a short body.
+- Open a pull request once CI passes.
+
+## Code of Conduct
+
+All contributors must follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+

--- a/README.md
+++ b/README.md
@@ -69,5 +69,10 @@ and `printed` are accepted.
 The helper script validates that the provided `.scad` file exists and that
 OpenSCAD is available in `PATH`, printing a helpful error if either check fails.
 
+## Community
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for ways to help.
+Participation is governed by the [Code of Conduct](CODE_OF_CONDUCT.md).
+
 See [AGENTS.md](AGENTS.md) for included LLM assistants.
 See [llms.txt](llms.txt) for an overview suitable for language models.


### PR DESCRIPTION
what: add CONTRIBUTING.md and CODE_OF_CONDUCT.md, link from README
why: satisfy policy automation
how to test: pre-commit run --all-files
pyspelling -c .spellcheck.yaml
linkchecker README.md docs/ CONTRIBUTING.md CODE_OF_CONDUCT.md
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689c193a7908832f89f97a8dc72e434c