### PR TITLE
📝 docs: add SSH key step to network setup

### DIFF
--- a/docs/network_setup.md
+++ b/docs/network_setup.md
@@ -15,6 +15,8 @@ It assumes you are using Raspberry Pi 5 boards in a small k3s setup.
    `ping <hostname>.local` and then `ssh <user>@<hostname>.local` to change the
    default password with `passwd`. If mDNS fails, use the IP shown on your
    router's client list.
+7. For SSH logins without a password, copy your public key to each Pi:
+   `ssh-copy-id <user>@<hostname>.local`
 
 ## Switch and PoE
 


### PR DESCRIPTION
## Summary
- mention ssh-copy-id for headless setup so Pis accept key-based logins

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_689c25cb7064832fab091591bf0d50f4