### PR TITLE
docs: clarify k3s worker join steps

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -43,4 +43,3 @@ Conduct:
 This Code of Conduct is adapted from the [Contributor Covenant][homepage].
 
 [homepage]: https://www.contributor-covenant.org
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,4 +27,3 @@ linkchecker README.md docs/ CONTRIBUTING.md CODE_OF_CONDUCT.md
 ## Code of Conduct
 
 All contributors must follow the [Code of Conduct](CODE_OF_CONDUCT.md).
-

--- a/docs/network_setup.md
+++ b/docs/network_setup.md
@@ -39,22 +39,24 @@ Display the worker join token:
 sudo cat /var/lib/rancher/k3s/server/node-token
 ```
 
-Keep this token handy; it's stored at
-`/var/lib/rancher/k3s/server/node-token` if you need it later.
+The token is stored at `/var/lib/rancher/k3s/server/node-token`; copy it for
+later.
 
-Boot the remaining Pis and join them as workers once they can ping the
-control-plane node. Use the token printed on the server (also stored at
-`/var/lib/rancher/k3s/server/node-token`) and run the installer as root:
+Boot the remaining Pis once they can reach the control-plane node. Replace
+`<server-ip>` with the control-plane's IP and `<node-token>` with the value
+above, then run the installer as root:
 
 ```sh
 curl -sfL https://get.k3s.io | K3S_URL=https://<server-ip>:6443 K3S_TOKEN=<node-token> sh -
 ```
 
-Verify the cluster:
+Watch the nodes join:
 
 ```sh
-sudo kubectl get nodes
+sudo kubectl get nodes -w
 ```
+
+Press <kbd>Ctrl</kbd>+<kbd>C</kbd> once all nodes show `Ready` to exit the watch.
 
 ## Manage from a workstation
 


### PR DESCRIPTION
## Summary
- explain where the k3s join token is stored
- show how to watch nodes join the cluster
- normalize EOF in contributing docs

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_689c25cb7064832fab091591bf0d50f4