### PR TITLE
📝 : clarify k3s service check

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -151,5 +151,6 @@ undersize
 sfL
 kubectl
 sudo
+systemctl
 
 AWG

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -43,4 +43,3 @@ Conduct:
 This Code of Conduct is adapted from the [Contributor Covenant][homepage].
 
 [homepage]: https://www.contributor-covenant.org
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,4 +27,3 @@ linkchecker README.md docs/ CONTRIBUTING.md CODE_OF_CONDUCT.md
 ## Code of Conduct
 
 All contributors must follow the [Code of Conduct](CODE_OF_CONDUCT.md).
-

--- a/docs/network_setup.md
+++ b/docs/network_setup.md
@@ -29,6 +29,9 @@ install `k3s` on that node as root:
 ```sh
 curl -sfL https://get.k3s.io | sh -
 
+# Ensure the service is running
+sudo systemctl status k3s --no-pager
+
 # Wait for the service to report Ready
 sudo kubectl get nodes
 ```


### PR DESCRIPTION
## Summary
- document using `systemctl` to confirm k3s service health
- allow "systemctl" in spell checks and normalize EOF in repo docs

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689c25cb7064832fab091591bf0d50f4