### PR TITLE
Add chamfer to panel bracket mounting hole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## [Unreleased]
 ### Fixed
 * pi_carrier: standoff length increased from 20 mm to 22 mm (flush fit with PoE HAT)
+* panel_bracket: add chamfers to printed mounting hole for easier screw insertion

--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -56,15 +56,27 @@ module l_bracket()
               0])
     {
       if (standoff_mode == "printed") {
-        // through-hole
-        cylinder(h=thickness + 0.2, r=screw_clearance/2, $fn=32);
+        // through-hole with lead-in chamfers on both faces
+        union() {
+          // main clearance hole
+          cylinder(h=thickness + 0.2, r=screw_clearance/2, $fn=32);
+          // bottom chamfer
+          translate([0,0,-0.1])
+            cylinder(h=chamfer, r1=screw_clearance/2 + chamfer,
+                     r2=screw_clearance/2, $fn=32);
+          // top chamfer
+          translate([0,0,thickness - chamfer + 0.1])
+            cylinder(h=chamfer, r1=screw_clearance/2,
+                     r2=screw_clearance/2 + chamfer, $fn=32);
+        }
       } else {
         // blind hole for insert
         translate([0,0,thickness - insert_length - 0.1])
           cylinder(h=insert_length + 0.2, r=insert_hole_diam/2, $fn=40);
         // chamfer
         translate([0,0,thickness - insert_length - chamfer])
-          cylinder(h=chamfer, r1=insert_hole_diam/2 + chamfer, r2=insert_hole_diam/2, $fn=32);
+          cylinder(h=chamfer, r1=insert_hole_diam/2 + chamfer,
+                   r2=insert_hole_diam/2, $fn=32);
       }
     }
   }

--- a/tests/openscad_render_test.py
+++ b/tests/openscad_render_test.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 
 
@@ -70,8 +71,16 @@ def test_errors_when_arg_missing():
 
 
 def test_errors_when_openscad_missing(tmp_path):
+    fake_path = tmp_path / "bin"
+    fake_path.mkdir()
+    # Symlink required utilities but omit openscad to simulate absence
+    for cmd in ["basename", "dirname", "mkdir"]:
+        target = shutil.which(cmd)
+        assert target is not None
+        (fake_path / cmd).symlink_to(target)
+
     env = os.environ.copy()
-    env["PATH"] = "/usr/bin"
+    env["PATH"] = str(fake_path)
 
     result = subprocess.run(
         [


### PR DESCRIPTION
## Summary
- add dual chamfers to printed panel bracket hole
- make OpenSCAD-missing test independent of system PATH

## Testing
- `bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `bash scripts/openscad_render.sh cad/solar_cube/sugarkube.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/sugarkube.scad`
- `bash scripts/openscad_render.sh cad/solar_cube/frame.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/frame.scad`
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_689c25c46d50832fa9fd99a5d1bf5ba4