### PR TITLE
Add corner radius option to Pi carrier base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
 ## [Unreleased]
+### Added
+* pi_carrier: rounded base corners via new `corner_radius` parameter
+
 ### Fixed
 * pi_carrier: standoff length increased from 20 mm to 22 mm (flush fit with PoE HAT)

--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -14,6 +14,7 @@ hole_spacing_x = 58;
 hole_spacing_y = 49;
 
 plate_thickness = 2.0;
+corner_radius   = 5.0;  // round base corners to avoid sharp edges
 standoff_height = 6.0;
 standoff_diam = 6.5;   // increased for added strength
 
@@ -97,7 +98,10 @@ module base_plate()
 {
     difference()
     {
-        cube([plate_len, plate_wid, plate_thickness]);
+        linear_extrude(height=plate_thickness)
+            offset(r=corner_radius)
+                square([plate_len - 2*corner_radius,
+                        plate_wid - 2*corner_radius]);
         if (variation != "blind") {
             for (pos = pi_positions) {
                 pcb_cx = edge_margin + rotX/2 + pos[0]*board_spacing_x;

--- a/docs/lcd_mount.md
+++ b/docs/lcd_mount.md
@@ -4,6 +4,9 @@ The basic Pi carrier can host a 1602 I²C LCD in the free quadrant.
 Its standoffs match the common 80×36 mm module with holes 3 mm from each
 edge (75 mm × 31 mm spacing).
 
+The base plate includes rounded corners set by `corner_radius` (default 5 mm)
+to make handling safer.
+
 LCD support is disabled by default. To add the display set
 `include_lcd = true` near the top of `cad/pi_cluster/pi_carrier.scad`
 and render the model from the repository root:


### PR DESCRIPTION
## Summary
- round pi_carrier base plate via new `corner_radius` parameter
- document corner radius in LCD mount guide

## Testing
- `bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `bash scripts/openscad_render.sh cad/solar_cube/frame.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/frame.scad`
- `bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `bash scripts/openscad_render.sh cad/solar_cube/sugarkube.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/sugarkube.scad`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689c25c46d50832fa9fd99a5d1bf5ba4