### PR TITLE
Add chamfer to panel bracket and docs tip

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -153,3 +153,5 @@ kubectl
 sudo
 
 AWG
+chamfer
+Chamfer

--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -20,7 +20,7 @@ insert_length     = 5.0;
 insert_clearance  = 0.20;     // interference amount (mm)
 insert_hole_diam  = insert_od - insert_clearance;
 screw_clearance   = 5.2;      // through-hole Ø for M5 (mm)
-chamfer           = 0.6;      // lead-in chamfer (mm)
+chamfer           = 0.6;      // shared lead-in chamfer (mm)
 
 assert(insert_length < thickness,
        "insert_length must be < thickness to maintain a blind hole");
@@ -56,8 +56,11 @@ module l_bracket()
               0])
     {
       if (standoff_mode == "printed") {
-        // through-hole
+        // through-hole with chamfer
         cylinder(h=thickness + 0.2, r=screw_clearance/2, $fn=32);
+        translate([0,0,thickness - chamfer])
+          cylinder(h=chamfer, r1=screw_clearance/2 + chamfer,
+                   r2=screw_clearance/2, $fn=32);
       } else {
         // blind hole for insert
         translate([0,0,thickness - insert_length - 0.1])

--- a/docs/insert_basics.md
+++ b/docs/insert_basics.md
@@ -32,5 +32,6 @@ Printed threads work best with a fine nozzle (0.4 mm or smaller) and four or mo
 
 - **CAD:** OpenSCAD parameters are plain text values near the top of each file. Adjust them to move boards or change standoff sizes, then preview with `openscad`.
 - **3D printing:** Use PLA or PETG with at least 40 % infill for structural parts. Ensure your printer is calibrated so holes come out accurately.
+- **Chamfer through-holes:** A ~0.5 mm chamfer guides screws and avoids any elephant's foot flare.
 - **Soldering:** Keep your iron clean and tinned. Rest it in a safe stand when not in use.
 - **Assembly:** Test‑fit the hardware before final tightening. If threads feel rough, back out and remove any debris.


### PR DESCRIPTION
## Summary
- chamfer printed screw holes in panel_bracket.scad
- document chamfering through-holes in insert guide

## Testing
- `bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_689c25c46d50832fa9fd99a5d1bf5ba4