### PR TITLE
🐛 : include contributing and CoC in link checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,8 @@ pyspelling -c .spellcheck.yaml
 linkchecker README.md docs/ CONTRIBUTING.md CODE_OF_CONDUCT.md
 ```
 
+The pre-commit script also checks links in these files.
+
 - Use the commit format `emoji : summary` with a short body.
 - Open a pull request once CI passes.
 

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -23,5 +23,5 @@ if command -v pyspelling >/dev/null 2>&1 && [ -f .spellcheck.yaml ]; then
   pyspelling -c .spellcheck.yaml
 fi
 if command -v linkchecker >/dev/null 2>&1; then
-  linkchecker --no-warnings README.md docs/
+  linkchecker --no-warnings README.md docs/ CONTRIBUTING.md CODE_OF_CONDUCT.md
 fi


### PR DESCRIPTION
## Summary
- run linkchecker on CONTRIBUTING.md and CODE_OF_CONDUCT.md
- note that pre-commit covers these docs

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker README.md docs/ CONTRIBUTING.md CODE_OF_CONDUCT.md`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689d5b1a2c28832f8a382a3ac3dc1ecb