### PR TITLE
📝 : clarify aspell dictionary requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ pre-commit run --all-files
 ```
 
 If you update documentation, install spell-check tools and verify spelling and links.
-`pyspelling` relies on `aspell`, so make sure it is installed as well. pre-commit runs
-these checks and fails if spelling or links are broken:
+`pyspelling` relies on `aspell` and an English dictionary (`aspell-en`). Ensure they are
+installed. pre-commit runs these checks and fails if spelling or links are broken:
 
 ```bash
 pip install pyspelling linkchecker
-sudo apt-get install aspell
+sudo apt-get install aspell aspell-en
 pyspelling -c .spellcheck.yaml
 linkchecker README.md docs/
 ```

--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -17,8 +17,8 @@ Keep the documentation clear and accurate.
 CONTEXT:
 - Docs live in `docs/`.
 - Follow AGENTS.md for style and testing requirements.
-- Run `pre-commit run --all-files`; ensure `pyspelling` (requires `aspell`) and
-  `linkchecker` succeed.
+- Run `pre-commit run --all-files`; ensure `pyspelling` (requires `aspell` and `aspell-en`)
+  and `linkchecker` succeed.
 
 REQUEST:
 1. Choose a markdown file in `docs/` that needs clarification or an update.

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -18,8 +18,8 @@ Keep the project healthy by making small, well-tested improvements.
 CONTEXT:
 - Follow AGENTS.md and README.md.
 - Run `pre-commit run --all-files` to lint, test and validate docs.
-- On documentation changes ensure `pyspelling -c .spellcheck.yaml` (requires `aspell`) and
-  `linkchecker README.md docs/` succeed.
+- On documentation changes ensure `pyspelling -c .spellcheck.yaml` (requires `aspell` and
+  `aspell-en`) and `linkchecker README.md docs/` succeed.
 
 REQUEST:
 1. Identify a small bug fix or documentation clarification.


### PR DESCRIPTION
## Summary
- clarify that pyspelling requires aspell and the aspell-en dictionary
- update contributor prompts to mention aspell-en

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*
- `git diff --cached | detect-secrets-hook --disable-plugin HexHighEntropyString --disable-plugin Base64HighEntropyString`

------
https://chatgpt.com/codex/tasks/task_e_689d5b1a2c28832f8a382a3ac3dc1ecb