### PR TITLE
🐛: run pyspelling via pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
           - pytest
           - pytest-cov
           - coverage
+          - pyspelling
           - linkchecker
           - requests
           - Flask

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ pre-commit install
 pre-commit run --all-files
 ```
 
-If you update documentation, install spell-check tools and verify spelling and links.
-`pyspelling` relies on `aspell`, so make sure it is installed as well. pre-commit runs
-these checks and fails if spelling or links are broken:
+If you update documentation, verify spelling and links. pre-commit installs
+`pyspelling` and `linkchecker` automatically but they require the `aspell` package.
+To run the checks manually outside pre-commit:
 
 ```bash
 pip install pyspelling linkchecker


### PR DESCRIPTION
## Summary
- ensure pyspelling runs during pre-commit by adding to hook deps
- clarify README instructions for running doc checks

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_689d5b1a2c28832f8a382a3ac3dc1ecb