### PR TITLE
Handle STANDOFF_MODE case insensitively

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_
 ```
 
 By default the script uses the model's `standoff_mode` value (`heatset`).
-Set `STANDOFF_MODE=printed` to generate 3D-printed threads. Only `heatset`
+Set `STANDOFF_MODE=printed` to generate 3D-printed threads. Values are case-insensitive; `heatset`
 and `printed` are accepted.
 
 The helper script validates that the provided `.scad` file exists and that

--- a/docs/lcd_mount.md
+++ b/docs/lcd_mount.md
@@ -23,4 +23,4 @@ Rotate the LCD or tweak offsets if your board slightly differs. The
 extra standoffs avoid the Pi mounting holes so you can add the display
 without enlarging the plate.
 
-Valid `STANDOFF_MODE` values are `heatset` (default) and `printed`.
+Valid `STANDOFF_MODE` values are `heatset` (default) and `printed`. Values are case-insensitive.

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -26,7 +26,7 @@ REQUEST:
 2. Modify geometry or parameters as required.
 3. Render the model via:
    bash scripts/openscad_render.sh <path/to.scad> # defaults to heatset
-   STANDOFF_MODE=printed bash scripts/openscad_render.sh <path/to.scad>
+   STANDOFF_MODE=printed bash scripts/openscad_render.sh <path/to.scad> # case-insensitive
 4. Commit updated SCAD sources and any documentation.
 
 OUTPUT:

--- a/scripts/openscad_render.sh
+++ b/scripts/openscad_render.sh
@@ -19,10 +19,12 @@ fi
 
 base=$(basename "$FILE" .scad)
 mode_suffix=""
+standoff_mode=""
 if [ -n "${STANDOFF_MODE:-}" ]; then
-  case "$STANDOFF_MODE" in
+  standoff_mode="${STANDOFF_MODE,,}"
+  case "$standoff_mode" in
     heatset|printed)
-      mode_suffix="_$STANDOFF_MODE"
+      mode_suffix="_$standoff_mode"
       ;;
     *)
       echo "Invalid STANDOFF_MODE: $STANDOFF_MODE (expected 'heatset' or 'printed')" >&2
@@ -38,8 +40,8 @@ fi
 output="stl/${base}${mode_suffix}.stl"
 mkdir -p "$(dirname "$output")"
 cmd=(openscad -o "$output" --export-format binstl)
-if [ -n "${STANDOFF_MODE:-}" ]; then
-  cmd+=(-D "standoff_mode=\"${STANDOFF_MODE}\"")
+if [ -n "$standoff_mode" ]; then
+  cmd+=(-D "standoff_mode=\"${standoff_mode}\"")
 fi
 cmd+=(-- "$FILE")
 "${cmd[@]}"


### PR DESCRIPTION
## Summary
- allow STANDOFF_MODE values in any case
- document STANDOFF_MODE is case-insensitive

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_689d5b1a2c28832f8a382a3ac3dc1ecb