### PR TITLE
📝 : clarify SSH key step in network setup

### DIFF
--- a/docs/network_setup.md
+++ b/docs/network_setup.md
@@ -15,7 +15,8 @@ It assumes you are using Raspberry Pi 5 boards in a small k3s setup.
    `ping <hostname>.local` and then `ssh <user>@<hostname>.local` to change the
    default password with `passwd`. If mDNS fails, use the IP shown on your
    router's client list.
-7. For SSH logins without a password, copy your public key to each Pi:
+7. For SSH logins without a password, generate a key if needed with
+   `ssh-keygen -t ed25519`, then copy your public key to each Pi:
    `ssh-copy-id <user>@<hostname>.local`
 
 ## Switch and PoE


### PR DESCRIPTION
what: document generating ssh key before using ssh-copy-id
why: helps new users set up passwordless ssh
how to test: pre-commit run --all-files
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_689d5b17d8ac832f88c54c9292e09fec