### PR TITLE
🛠️ widen standoffs on rotated Pi carrier

### DIFF
--- a/cad/pi_cluster/pi5_triple_carrier_rot45.scad
+++ b/cad/pi_cluster/pi5_triple_carrier_rot45.scad
@@ -35,7 +35,7 @@ assert(screw_length >= required_len,
 
 /* ---------- STANDOFF & INSERT OPTIONS ---------- */
 standoff_height = 6;             // pillar height under PCB (mm)
-standoff_diam   = 6;             // outer diameter of standoff (mm)
+standoff_diam   = 6.5;           // increased for added strength (mm)
 
 /* Choose one of:
  *  "printed"   → generate printable ISO metric threads (M2.5)


### PR DESCRIPTION
## What
- increase standoff diameter on rotated Pi carrier to 6.5mm

## Why
- adds more material around inserts for strength

## How to Test
- `bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `SKIP=run-checks pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689d5b14b0ec832f98faa924749190d7