### PR TITLE
Widen Pi carrier standoffs

### DIFF
--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -16,7 +16,7 @@ hole_spacing_y = 49;
 plate_thickness = 2.0;
 corner_radius   = 5.0;  // round base corners to avoid sharp edges
 standoff_height = 6.0;
-standoff_diam = 6.5;   // increased for added strength
+standoff_diam = 7.0;   // widened for added insert grip
 
 insert_od         = 3.5;         // outer Ø for common brass inserts
 insert_length     = 4.0;         // full length of the insert


### PR DESCRIPTION
## Summary
- thicken Pi carrier standoffs for sturdier heat-set insert walls

## Testing
- `bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `pre-commit run --all-files` *(fails: run project checks—KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689d5b14b0ec832f98faa924749190d7