### PR TITLE
🔩 : parameterise panel bracket screw size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 ### Added
 * pi_carrier: rounded base corners via new `corner_radius` parameter
+* panel_bracket: parameterise screw size via `screw_nominal`
 
 ### Fixed
 * pi_carrier: standoff length increased from 20 mm to 22 mm (flush fit with PoE HAT)

--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -19,7 +19,8 @@ insert_od         = 5.0;      // brass insert outer Ø (mm)
 insert_length     = 5.0;
 insert_clearance  = 0.20;     // interference amount (mm)
 insert_hole_diam  = insert_od - insert_clearance;
-screw_clearance   = 5.2;      // through-hole Ø for M5 (mm)
+screw_nominal     = 5.0;      // nominal screw size for through-hole (mm)
+screw_clearance   = screw_nominal + 0.2; // through-hole Ø with clearance (mm)
 chamfer           = 0.8;      // lead-in chamfer (mm)
 
 assert(insert_length < thickness,


### PR DESCRIPTION
what: expose screw_nominal to size panel bracket clearance hole
why: ease adapting bracket to different screw diameters
how to test:
- bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad
- STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad
- pre-commit run --all-files


------
https://chatgpt.com/codex/tasks/task_e_689d5b14b0ec832f98faa924749190d7