### PR TITLE
🔧 : – Round Pi5 carrier corners

### DIFF
--- a/cad/pi_cluster/pi5_triple_carrier_rot45.scad
+++ b/cad/pi_cluster/pi5_triple_carrier_rot45.scad
@@ -12,6 +12,7 @@ board_wid          = 56;         // Y-size of Pi-5 PCB  (mm)
 hole_spacing_x     = 58;         // long-direction hole spacing (mm)
 hole_spacing_y     = 49;         // short-direction hole spacing (mm)
 plate_thickness    = 4;          // base-plate thickness (mm)
+corner_radius     = 5;          // round base corners to avoid sharp edges
 
 gap_between_boards = 10;         // service gap between rotated PCBs (mm)
 
@@ -118,7 +119,10 @@ module standoff(pos=[0,0])
 /* ---------- PLATE BASE ---------- */
 difference()
 {
-    cube([plate_len, plate_wid, plate_thickness]);
+    linear_extrude(height=plate_thickness)
+        offset(r=corner_radius)
+            square([plate_len - 2*corner_radius,
+                    plate_wid - 2*corner_radius]);
 
     /* screw-head relief */
     head_r = 2.5;  // counterbore radius (5 mm diameter)

--- a/docs/pi_cluster_carrier.md
+++ b/docs/pi_cluster_carrier.md
@@ -2,6 +2,8 @@
 
 This design mounts three Raspberry Pi 5 boards on a common plate. Each Pi is rotated 45° so the USB and Ethernet ports remain accessible. By default the boards are arranged in a 2×2 grid with one corner empty so the plate fits on printers with a 256 mm build area (e.g. the Bambu Lab A1). Brass heat‑set inserts can be used for durability, or you can print threads directly.
 
+The base corners are rounded with a configurable `corner_radius` parameter (default 5 mm) to soften sharp edges.
+
 The model lives at `cad/pi_cluster/pi5_triple_carrier_rot45.scad`.  STL files for both heat‑set and printed‑thread variants are produced by GitHub Actions and published as artifacts whenever the SCAD file changes.
 You can edit the `pi_positions` array near the top of the file to tweak the arrangement if your printer allows a larger build area.
 For an overview of insert installation and printed threads see [insert_basics.md](insert_basics.md).


### PR DESCRIPTION
what: soften Pi5 triple carrier edges via corner_radius
why: avoid sharp edges on base plate
how to test:
- bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad
- STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad


------
https://chatgpt.com/codex/tasks/task_e_689eb767c248832f99a169718db31f1b