### PR TITLE
Add nut fastener mode to panel bracket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 * pi_carrier: rounded base corners via new `corner_radius` parameter
 * panel_bracket: parameterise screw size via `screw_nominal`
+* panel_bracket: add `nut` standoff_mode for captive hex recess
 
 ### Fixed
 * pi_carrier: standoff length increased from 20 mm to 22 mm (flush fit with PoE HAT)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ the docs you will see the term used in both contexts.
 
 - `cad/` — OpenSCAD models of structural parts.  See `docs/pi_cluster_carrier.md` for the
   Pi carrier plate and `cad/solar_cube/panel_bracket.scad` for the solar panel bracket
-  with an `edge_radius` parameter to round its outer edges.
+  with an `edge_radius` parameter to round its outer edges and `standoff_mode`
+  options for `printed`, `heatset` or `nut` fasteners.
 - `elex/` — KiCad and Fritzing electronics schematics including the `power_ring` board (see `elex/power_ring/specs.md`)
 - `docs/` — build instructions, safety notes, and learning resources
 - `docs/solar_basics.md` — introduction to how solar panels generate power

--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -1,9 +1,10 @@
 /*
   Parametric L-bracket for mounting solar panels to 2020 extrusion
 
-  Generates two variants:
+  Generates three variants:
     standoff_mode="printed" → through-hole for machine screw
     standoff_mode="heatset" → blind hole sized for brass insert
+    standoff_mode="nut"     → through-hole with hex recess
   A variable of that name is passed in by the CI render script.
 */
 
@@ -23,6 +24,8 @@ insert_hole_diam  = insert_od - insert_clearance;
 screw_nominal     = 5.0;      // nominal screw size for through-hole (mm)
 screw_clearance   = screw_nominal + 0.2; // through-hole Ø with clearance (mm)
 chamfer           = 0.8;      // lead-in chamfer (mm)
+nut_flat          = 8.0;      // across flats for M5 nut (mm)
+nut_thick         = 4.0;      // nut thickness (mm)
 
 assert(insert_length < thickness,
        "insert_length must be < thickness to maintain a blind hole");
@@ -32,8 +35,10 @@ assert(insert_length + chamfer <= thickness,
        "insert_length + chamfer must be ≤ thickness");
 assert(edge_radius*2 <= min([beam_width, size, thickness]),
        "edge_radius too large for given dimensions");
+assert(nut_thick <= thickness,
+       "nut_thick must be ≤ thickness");
 
-// read from CLI (-D standoff_mode="printed"/"heatset")
+// read from CLI (-D standoff_mode="printed"/"heatset"/"nut")
 standoff_mode = "heatset";
 
 /* rounded cube helper */
@@ -83,6 +88,16 @@ module l_bracket()
             cylinder(h=chamfer, r1=screw_clearance/2 + chamfer,
                      r2=screw_clearance/2, $fn=32);
           // top chamfer
+          translate([0,0,thickness - chamfer + 0.1])
+            cylinder(h=chamfer, r1=screw_clearance/2,
+                     r2=screw_clearance/2 + chamfer, $fn=32);
+        }
+      } else if (standoff_mode == "nut") {
+        // through-hole with captive hex recess on underside
+        union() {
+          cylinder(h=thickness + 0.2, r=screw_clearance/2, $fn=32);
+          translate([0,0,-nut_thick + 0.1])
+            cylinder(h=nut_thick, r=nut_flat/(2*cos(30)), $fn=6);
           translate([0,0,thickness - chamfer + 0.1])
             cylinder(h=chamfer, r1=screw_clearance/2,
                      r2=screw_clearance/2 + chamfer, $fn=32);


### PR DESCRIPTION
## Summary
- add `nut` standoff_mode to solar panel bracket
- document bracket fastener options

## Testing
- `pre-commit run --all-files`
- `bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `bash scripts/openscad_render.sh cad/solar_cube/sugarkube.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/sugarkube.scad`
- `bash scripts/openscad_render.sh cad/solar_cube/frame.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/frame.scad`


------
https://chatgpt.com/codex/tasks/task_e_689eb767c248832f99a169718db31f1b