### PR TITLE
🔧 : widen panel bracket edge radius to 2 mm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * pi_carrier: rounded base corners via new `corner_radius` parameter
 * panel_bracket: parameterise screw size via `screw_nominal`
 
+### Changed
+* panel_bracket: increase default edge radius to 2 mm for smoother corners
+
 ### Fixed
 * pi_carrier: standoff length increased from 20 mm to 22 mm (flush fit with PoE HAT)
 * panel_bracket: add chamfers to printed mounting hole for easier screw insertion

--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -10,7 +10,7 @@
 size          = 40;           // leg length (mm)
 thickness     = 6;            // plate thickness (mm)
 beam_width    = 20;           // width to match 2020 extrusion (mm)
-edge_radius   = 1;            // rounding radius for outer edges (mm)
+edge_radius   = 2;            // rounding radius for outer edges (mm)
 hole_offset   = [0,0];        // XY offset of mounting hole from centre (mm)
 gusset        = true;         // add triangular support in inner corner
 gusset_size   = thickness*1.5; // leg length of gusset triangle (mm)


### PR DESCRIPTION
what: increase default edge radius on panel bracket.
why: smoother corners and easier printing.
how to test:
- bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad
- STANDOFF_MODE=printed bash scripts/openscad_render.sh \
  cad/solar_cube/panel_bracket.scad
- pre-commit run --all-files
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_689eb767c248832f99a169718db31f1b