### PR TITLE
📝 : clarify build guide wiring

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -94,6 +94,7 @@ PETG
 explainer
 PLA
 STL
+STLs
 retightened
 http
 localhost

--- a/docs/build_guide.md
+++ b/docs/build_guide.md
@@ -6,15 +6,19 @@ junction box.
 
 1. Print the triple Pi carrier from `cad/pi_cluster` if building a Pi cluster.
    Download STL files for either insert variant from the latest
-   [scad-to-stl workflow run][stl-workflow] in GitHub Actions.
-2. Assemble the extrusion cube using M5 hardware.
-3. Mount the solar panels using the printed brackets.
-   Each has a gusset that stiffens the corner.
-4. Attach the battery leads to the MPPT charge controller before any solar wiring. Refer to the
-   controller's manual for the recommended connection order. The KiCad schematic and board specs
-   live under [elex/power_ring](../elex/power_ring/).
-5. Before connecting the array, verify each panel's open-circuit voltage and polarity with a
-   multimeter. Join panels with MC4 connectors and 12 AWG wire, then attach them to the controller.
+   [scad-to-stl workflow run][stl-workflow] in GitHub Actions. To render STLs
+   locally, run `scripts/openscad_render.sh`.
+2. Assemble the extrusion cube using M5 hardware, squaring each corner.
+3. Mount the solar panels using the printed brackets. Each has a gusset that
+   stiffens the corner. Keep panels covered or face-down during wiring to avoid
+   live voltage.
+4. Attach the battery leads to the MPPT charge controller before any solar
+   wiring. Refer to the controller's manual for the recommended connection order
+   and connect the load output last. The KiCad schematic and board specs live
+   under [elex/power_ring](../elex/power_ring/).
+5. Before connecting the array, verify each panel's open-circuit voltage and
+   polarity with a multimeter. Join panels with MC4 connectors and 12 AWG wire,
+   then attach them to the controller.
 6. Install the 12 V air pump and Raspberry Pi on dedicated protection: a 15 A breaker for the pump
    and a 5 A fuse for the Pi. Verify battery voltage with a multimeter before powering devices.
 7. Tidy and secure all wiring. Confirm the charge controller shows a charging indicator before


### PR DESCRIPTION
what: expand build instructions with STL rendering and wiring safety
why: helps builders generate parts locally and avoid live PV wiring
how to test: pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_689eb76ced3c832f911b5b18379638c3