### PR TITLE
docs: add macOS sed example to network guide

### DIFF
--- a/docs/network_setup.md
+++ b/docs/network_setup.md
@@ -81,6 +81,8 @@ export KUBECONFIG=~/.kube/config
 kubectl get nodes
 ```
 
+On macOS, run `sed -i '' "s/127.0.0.1/<server-ip>/g" ~/.kube/config` to avoid creating a backup file.
+
 The `sed` command swaps the default localhost address for the control-plane
 IP, and `kubectl get nodes` confirms your workstation can reach the cluster.
 


### PR DESCRIPTION
what: clarify sed usage for macOS in network setup.
why: prevents unwanted backup files on kubeconfig edits.
how to test: pre-commit run --all-files
how to test: pyspelling -c .spellcheck.yaml
how to test: linkchecker README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_689eb7794dd4832f93bbe63f104b11fd