### PR TITLE
Handle relative dash filenames in OpenSCAD script

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ and `printed` are accepted.
 
 The helper script validates that the provided `.scad` file exists and that
 OpenSCAD is available in `PATH`, printing a helpful error if either check fails.
-It also separates options from the file path with `--`, allowing filenames that begin with a dash.
+It separates options from the file path with `--` and handles filenames
+that begin with a dash, whether absolute or relative.
 The `.scad` extension is matched case-insensitively, so `MODEL.SCAD` works too.
 
 ## Community

--- a/scripts/openscad_render.sh
+++ b/scripts/openscad_render.sh
@@ -17,7 +17,7 @@ if [[ "${ext,,}" != scad ]]; then
   exit 1
 fi
 
-base=$(basename "$FILE" ".$ext")
+base=$(basename -- "$FILE" ".$ext")
 mode_suffix=""
 standoff_mode=""
 if [ -n "${STANDOFF_MODE:-}" ]; then

--- a/tests/openscad_render_test.py
+++ b/tests/openscad_render_test.py
@@ -152,7 +152,7 @@ def test_standoff_mode_case_insensitive(tmp_path):
     openscad.write_text(
         """#!/usr/bin/env bash
 printf '%s ' "$@" > "$LOG_FILE"
-""",
+"""
     )
     openscad.chmod(0o755)
 
@@ -206,6 +206,38 @@ printf '%s ' "$@" > "$LOG_FILE"
     args = log_file.read_text().strip().split()
     assert "--" in args
     assert args[args.index("--") + 1] == str(scad)
+
+
+def test_handles_relative_leading_dash_filename(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    log_file = tmp_path / "args.log"
+    openscad = fake_bin / "openscad"
+    openscad.write_text(
+        """#!/usr/bin/env bash
+printf '%s ' "$@" > "$LOG_FILE"
+"""
+    )
+    openscad.chmod(0o755)
+
+    scad = tmp_path / "-rel.scad"
+    scad.write_text("cube();")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["LOG_FILE"] = str(log_file)
+
+    script = Path(__file__).resolve().parents[1] / "scripts/openscad_render.sh"
+    subprocess.run(
+        ["bash", str(script), scad.name],
+        check=True,
+        env=env,
+        cwd=tmp_path,
+    )
+
+    args = log_file.read_text().strip().split()
+    assert "--" in args
+    assert args[args.index("--") + 1] == scad.name
 
 
 def test_accepts_uppercase_extension(tmp_path):


### PR DESCRIPTION
## Summary
- handle relative `.scad` paths that begin with `-`
- document dash-prefixed filename support
- test OpenSCAD script against relative dash paths

## Testing
- `pre-commit run --all-files`
- `pytest tests/openscad_render_test.py -q`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_689f8b2baaec832fb5230d710d7ff046