### PR TITLE
📝 : clarify STL download in build guide

### DIFF
--- a/docs/build_guide.md
+++ b/docs/build_guide.md
@@ -5,9 +5,9 @@ The battery, charge controller, and electronics mount inside a marine battery bo
 junction box.
 
 1. Print the triple Pi carrier from `cad/pi_cluster` if building a Pi cluster.
-   To grab STLs, open the repository's **Actions** tab, select the latest
-   [scad-to-stl workflow run][stl-workflow], and download the `pi_cluster`
-   artifact. You can also render them locally with `scripts/openscad_render.sh`.
+   Download pre-rendered STLs from the repository's **Actions** tab: open the
+   latest [scad-to-stl workflow run][stl-workflow] and grab the `pi_cluster`
+   artifact. To render meshes locally instead, run `./scripts/openscad_render.sh`.
 2. Assemble the extrusion cube using M5 hardware, squaring each corner.
 3. Mount the solar panels using the printed brackets. Each has a gusset that
    stiffens the corner. Keep panels covered or face-down during wiring to avoid


### PR DESCRIPTION
what: clarify how to fetch or render Pi carrier STLs
why: saves builders hunting for artifacts
how to test: pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a01035dd00832f9f087c0a20c03c73