### PR TITLE
📝: scope linkchecker to core docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,10 @@ pre-commit install
 ```bash
 pre-commit run --all-files
 pyspelling -c .spellcheck.yaml
-linkchecker README.md docs/ CONTRIBUTING.md CODE_OF_CONDUCT.md
+linkchecker --no-warnings README.md docs/
 ```
 
-The pre-commit script also checks links in these files.
+The pre-commit script also checks links in those paths.
 
 - Use the commit format `emoji : summary` with a short body.
 - Open a pull request once CI passes.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ pre-commit install
 pre-commit run --all-files
 ```
 
-If you update documentation, install spell-check tools and verify spelling and links,
-including `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.
+If you update documentation, install spell-check tools and verify spelling and links.
 `pyspelling` relies on `aspell` and an English dictionary (`aspell-en`). Ensure they are
 installed. pre-commit runs these checks and fails if spelling or links are broken:
 
@@ -57,7 +56,7 @@ installed. pre-commit runs these checks and fails if spelling or links are broke
 pip install pyspelling linkchecker
 sudo apt-get install aspell aspell-en
 pyspelling -c .spellcheck.yaml
-linkchecker --no-warnings README.md docs/ CONTRIBUTING.md CODE_OF_CONDUCT.md
+linkchecker --no-warnings README.md docs/
 ```
 
 STL files are produced automatically by CI for each OpenSCAD model and can be

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -23,5 +23,5 @@ if command -v pyspelling >/dev/null 2>&1 && [ -f .spellcheck.yaml ]; then
   pyspelling -c .spellcheck.yaml
 fi
 if command -v linkchecker >/dev/null 2>&1; then
-  linkchecker --no-warnings README.md docs/ CONTRIBUTING.md CODE_OF_CONDUCT.md
+  linkchecker --no-warnings README.md docs/
 fi


### PR DESCRIPTION
what: check only README.md and docs/ for broken links
why: reduce noise and align docs with current linkcheck scope
how to test: pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a0104c9ae4832f805a64eab1a5b231