### PR TITLE
🩹 : enforce single argument for OpenSCAD renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ linkchecker --no-warnings README.md docs/ CONTRIBUTING.md CODE_OF_CONDUCT.md
 ```
 
 STL files are produced automatically by CI for each OpenSCAD model and can be
-downloaded from the workflow run. Provide a `.scad` file path to render a
-variant locally:
+downloaded from the workflow run. Provide a single `.scad` file path to render a
+variant locally. The script exits with a usage message if extra arguments are
+supplied:
 
 ```bash
 bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad

--- a/scripts/openscad_render.sh
+++ b/scripts/openscad_render.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -lt 1 ]; then
-  echo "Usage: $0 path/to/model.scad" >&2
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $(basename "$0") path/to/model.scad" >&2
   exit 1
 fi
 


### PR DESCRIPTION
what: guard against extra arguments in openscad_render.sh
why: prevent unexpected inputs from being ignored
how to test: pre-commit run --all-files

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a0104c9ae4832f805a64eab1a5b231