### PR TITLE
Align Pi carrier standoff diameter with triple carrier

### DIFF
--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -16,7 +16,7 @@ hole_spacing_y = 49;
 plate_thickness = 2.0;
 corner_radius   = 5.0;  // round base corners to avoid sharp edges
 standoff_height = 6.0;
-standoff_diam = 7.0;   // widened for added insert grip
+standoff_diam = 6.5;   // match triple carrier for consistent insert grip
 
 insert_od         = 3.5;         // outer Ø for common brass inserts
 insert_length     = 4.0;         // full length of the insert


### PR DESCRIPTION
## Summary
- narrow Pi carrier standoff pillars to 6.5 mm for consistent insert fit

## Testing
- `bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a0104edec4832fa44cfd7c1639950f