### PR TITLE
🛠️: raise panel bracket edge radius to 3 mm

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ the docs you will see the term used in both contexts.
 - `cad/` — OpenSCAD models of structural parts. See
   [docs/pi_cluster_carrier.md](docs/pi_cluster_carrier.md) for the Pi carrier plate and
   [cad/solar_cube/panel_bracket.scad](cad/solar_cube/panel_bracket.scad) for the solar
-  panel bracket with an `edge_radius` parameter to round its outer edges.
+  panel bracket with an `edge_radius` parameter (default 3 mm) to round its outer edges.
 - `elex/` — KiCad and Fritzing electronics schematics including the `power_ring`
   board (see [elex/power_ring/specs.md](elex/power_ring/specs.md))
 - `docs/` — build instructions, safety notes, and learning resources

--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -11,7 +11,7 @@
 size          = 40;           // leg length (mm)
 thickness     = 6;            // plate thickness (mm)
 beam_width    = 20;           // width to match 2020 extrusion (mm)
-edge_radius   = 2;            // rounding radius for outer edges (mm)
+edge_radius   = 3;            // default 3 mm outer-edge rounding
 hole_offset   = [0,0];        // XY offset of mounting hole from centre (mm)
 gusset        = true;         // add triangular support in inner corner
 gusset_size   = thickness*1.5; // leg length of gusset triangle (mm)


### PR DESCRIPTION
what: default edge_radius to 3 mm and mention in README
why: smoother bracket corners
how to test:
- bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad
- STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad

------
https://chatgpt.com/codex/tasks/task_e_68a0104edec4832fa44cfd7c1639950f