### PR TITLE
Add Pi image Cloudflare docs and tooling

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -164,3 +164,12 @@ Bonjour
 responder
 DHCP
 IPs
+Cloudflare
+cloudflared
+SSD
+cloudflare
+subdomain
+preconfigure
+preloaded
+Dockerfile
+walkthroughs

--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -1,0 +1,52 @@
+# Docker Repo Deployment Walkthrough
+
+This guide shows how to run any GitHub project that ships a `Dockerfile` or
+`docker-compose.yml` on the Raspberry Pi image preloaded with Docker and a
+Cloudflare Tunnel. Token.place and dspace are real-world examples, but the
+steps work for any repository.
+
+## 1. Prepare the Pi
+1. Follow [pi_image_cloudflare.md](pi_image_cloudflare.md) to flash the SD card and
+   start the Cloudflare Tunnel.
+2. Confirm you can SSH to the Pi: `ssh pi@<hostname>.local`.
+
+## 2. Clone a repository
+1. Choose a location for projects, e.g. `/opt/projects`.
+2. Clone the repo:
+   ```sh
+   mkdir -p /opt/projects
+   cd /opt/projects
+   git clone https://github.com/futuroptimist/token.place.git
+   git clone https://github.com/democratizedspace/dspace.git
+   ```
+   Replace the URLs with any other repository that contains a `Dockerfile`.
+
+## 3. Build or start containers
+1. Change into the repo directory: `cd token.place`.
+2. If the repo provides `docker-compose.yml`:
+   ```sh
+   cp .env.example .env   # if the project uses an env file
+   docker compose up -d   # build and start containers in the background
+   ```
+3. If the repo only has a `Dockerfile`:
+   ```sh
+   docker build -t tokenplace .
+   docker run -d --name tokenplace -p 3000:3000 tokenplace
+   ```
+   Adjust port numbers and image names to match the project.
+
+## 4. Expose services through Cloudflare
+1. Edit `/opt/sugarkube/docker-compose.cloudflared.yml` and add a new
+   `ingress` rule mapping a subdomain to the container's port.
+2. Restart the tunnel:
+   ```sh
+   docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml up -d
+   ```
+3. Visit the Cloudflare-managed URL to verify the service is reachable.
+
+## 5. Manage containers
+- List running containers: `docker ps`.
+- Stop a container: `docker stop tokenplace`.
+- View logs: `docker compose logs -f`.
+
+Repeat these steps for each repository you want to deploy.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,8 @@ Review the safety notes before working with power components.
 - [lcd_mount.md](lcd_mount.md) — optional 1602 LCD placement
 - [insert_basics.md](insert_basics.md) — heat-set inserts and printed threads
 - [network_setup.md](network_setup.md) — connect the cluster to your network
+- [pi_image_cloudflare.md](pi_image_cloudflare.md) — preconfigure Docker and Cloudflare tunnels
+- [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
 
 ## Learn the Fundamentals
 - [solar_basics.md](solar_basics.md) — how photovoltaic panels work
@@ -30,3 +32,5 @@ Start with the basics and progress toward a fully autonomous solar cube.
 - [prompts-codex.md](prompts-codex.md) — baseline Codex instructions for maintaining the repo
 - [prompts-codex-cad.md](prompts-codex-cad.md) — keep OpenSCAD models rendering cleanly
 - [prompts-codex-docs.md](prompts-codex-docs.md) — refine build guides and reference docs
+- [prompts-codex-pi-image.md](prompts-codex-pi-image.md) — maintain the Pi image tooling
+- [prompts-codex-docker-repo.md](prompts-codex-docker-repo.md) — improve Docker repo guides

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -1,0 +1,27 @@
+# Raspberry Pi Image with Cloudflare Tunnel
+
+This guide generalizes the [token.place](https://github.com/futuroptimist/token.place)
+Raspberry Pi deployment so it can host multiple projects such as
+[token.place](https://github.com/futuroptimist/token.place) and
+[dspace](https://github.com/democratizedspace/dspace).
+
+It bakes Docker, the compose plugin, and a Cloudflare Tunnel into the OS image using `cloud-init`.
+
+## Checklist
+
+- [ ] Build or download a Raspberry Pi OS image.
+- [ ] Place `scripts/cloud-init/user-data.yaml` on the SD card's boot partition as `user-data`.
+- [ ] Flash the image with Raspberry Pi Imager.
+- [ ] Boot the Pi and run `sudo rpi-clone sda -f` to copy the OS to an SSD.
+- [ ] Reboot and verify `/opt/sugarkube/docker-compose.cloudflared.yml` exists.
+- [ ] Add your Cloudflare token to `/opt/sugarkube/.cloudflared.env`.
+- [ ] Start the tunnel with `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml up -d`.
+- [ ] Clone target projects:
+  - [ ] `git clone https://github.com/futuroptimist/token.place.git`
+  - [ ] `git clone https://github.com/democratizedspace/dspace.git`
+- [ ] Add more `docker-compose` files for additional services.
+
+## GitHub Actions
+
+Building a full OS image in CI is heavy. If GitHub Actions proves too slow,
+run `scripts/build_pi_image.sh` locally on a Linux machine with Docker.

--- a/docs/prompts-codex-docker-repo.md
+++ b/docs/prompts-codex-docker-repo.md
@@ -1,0 +1,30 @@
+---
+title: 'Sugarkube Codex Docker Repo Prompt'
+slug: 'prompts-codex-docker-repo'
+---
+
+# Codex Docker Repo Prompt
+
+Use this prompt to evolve beginner docs for deploying Docker-based projects on the Pi image.
+
+```
+SYSTEM:
+You are an automated contributor for the sugarkube repository.
+
+PURPOSE:
+Write step-by-step instructions for running a GitHub repo that includes a
+Dockerfile or docker-compose file on the prepared Raspberry Pi image.
+
+CONTEXT:
+- The base image and tunnel setup live in `docs/pi_image_cloudflare.md`.
+- New walkthroughs belong in `docs/docker_repo_walkthrough.md`.
+- Run `pre-commit run --all-files`; ensure `pyspelling` and `linkchecker` pass.
+
+REQUEST:
+1. Expand the walkthrough or add examples.
+2. Reference token.place and dspace where helpful.
+3. Verify all commands and links.
+
+OUTPUT:
+A pull request with passing checks and a concise summary.
+```

--- a/docs/prompts-codex-pi-image.md
+++ b/docs/prompts-codex-pi-image.md
@@ -1,0 +1,30 @@
+---
+title: 'Sugarkube Codex Pi Image Prompt'
+slug: 'prompts-codex-pi-image'
+---
+
+# Codex Pi Image Prompt
+
+Use this prompt to evolve the Raspberry Pi OS image and Cloudflare tunnel setup.
+
+```
+SYSTEM:
+You are an automated contributor for the sugarkube repository.
+
+PURPOSE:
+Improve the Pi image build tooling and deployment docs.
+
+CONTEXT:
+- Cloud-init config lives under `scripts/cloud-init/`.
+- `scripts/build_pi_image.sh` builds an image locally or in CI.
+- `docs/pi_image_cloudflare.md` is the user guide.
+- Run `pre-commit run --all-files`; ensure `pyspelling` and `linkchecker` pass.
+
+REQUEST:
+1. Refine the image build script or cloud-init files.
+2. Update relevant documentation.
+3. Run `pre-commit run --all-files` and confirm success.
+
+OUTPUT:
+A pull request with passing checks and a concise summary.
+```

--- a/llms.txt
+++ b/llms.txt
@@ -3,7 +3,8 @@
 > Off-grid k3s cluster with solar power. Contains 3D printed parts, KiCad schematics and build docs.
 
 Plants grow up and around the cube, taking advantage of the shade cast by the solar panels.
-This repository provides hardware designs and instructions for building a solar-powered Raspberry Pi cluster.
+This repository provides hardware designs and instructions for building a
+solar-powered Raspberry Pi cluster.
 The word *sugarkube* is used both for the solar cube itself and for helper
 scripts that provide "syntactic sugar" for Kubernetes.
 
@@ -14,6 +15,8 @@ scripts that provide "syntactic sugar" for Kubernetes.
 - [Power system design](docs/power_system_design.md)
 - [Insert basics](docs/insert_basics.md)
 - [Network setup](docs/network_setup.md)
+- [Pi image with Cloudflare tunnel](docs/pi_image_cloudflare.md)
+- [Docker repo deployment walkthrough](docs/docker_repo_walkthrough.md)
 
 ## CAD
 - [OpenSCAD models](cad/)

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build a Raspberry Pi OS image with cloud-init files preloaded.
+# Requires Docker and roughly 10 GB of free disk space.
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+git clone --depth 1 https://github.com/RPi-Distro/pi-gen.git "${WORK_DIR}/pi-gen"
+cp "${REPO_ROOT}/scripts/cloud-init/user-data.yaml" \
+  "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/user-data"
+cd "${WORK_DIR}/pi-gen"
+cat > config <<'CFG'
+IMG_NAME="sugarkube"
+ENABLE_SSH=1
+CFG
+sudo ./build.sh
+mv deploy/*.img "${REPO_ROOT}/sugarkube.img"
+ls -lh "${REPO_ROOT}/sugarkube.img"
+echo "Image written to ${REPO_ROOT}/sugarkube.img"

--- a/scripts/cloud-init/docker-compose.cloudflared.yml
+++ b/scripts/cloud-init/docker-compose.cloudflared.yml
@@ -1,0 +1,7 @@
+services:
+  tunnel:
+    image: cloudflare/cloudflared:latest
+    restart: unless-stopped
+    command: tunnel run
+    env_file:
+      - /opt/sugarkube/.cloudflared.env

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -1,0 +1,13 @@
+#cloud-config
+package_update: true
+packages:
+  - docker.io
+  - docker-compose-plugin
+  - git
+  - cloudflared
+runcmd:
+  - [bash, -c, 'usermod -aG docker pi']
+  - [bash, -c, 'mkdir -p /opt/sugarkube']
+  - [bash, -c, 'curl -fsSL https://raw.githubusercontent.com/futuroptimist/sugarkube/main/scripts/cloud-init/docker-compose.cloudflared.yml -o /opt/sugarkube/docker-compose.cloudflared.yml']
+  - [bash, -c, 'touch /opt/sugarkube/.cloudflared.env']
+  - [bash, -c, 'chown -R pi:pi /opt/sugarkube']


### PR DESCRIPTION
## Summary
- document Raspberry Pi image with Docker and Cloudflare Tunnel
- add cloud-init config, build script, and Codex prompt
- link new docs from index and llms.txt
- add beginner-friendly Docker repo walkthrough and prompt

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/pi_image_cloudflare.md docs/index.md docs/docker_repo_walkthrough.md`


------
https://chatgpt.com/codex/tasks/task_e_68a1843493c0832fb8a28a1b0ac68070