### PR TITLE
Fix KiBot schematic output type and log outage

### DIFF
--- a/.kibot/power_ring.yaml
+++ b/.kibot/power_ring.yaml
@@ -1,14 +1,17 @@
+kibot:
+  version: 1
+
 preflight: []
 outputs:
-  gerbers:
+  - name: gerbers
     type: gerber
     dir: gerbers
-  assembly:
+  - name: assembly
     type: position
     dir: fab
-  schematic:
-    type: schematic_pdf
+  - name: schematic
+    type: pdf_sch_print
     dir: fab
-  bom:
+  - name: bom
     type: bom
     dir: fab

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,11 @@ The name **sugarkube** has two meanings:
   requires **KiCad 9** so we use the `v2_k9` container tag.
 - **Logs:** workflow logs are uploaded as artifacts so non-admins can download failure details.
 
+## Outage Agent
+- **When:** a script or workflow fails repeatedly
+- **Does:** add a JSON record under `outages/` using `schema.json` describing the
+  root cause and resolution.
+
 ### STL generation
 STL meshes are not stored in the repository. The `scad-to-stl.yml` workflow renders them after each commit and exposes the files as downloadable artifacts.
 

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -20,6 +20,7 @@ CONTEXT:
 - Render each model in both `heatset` and `printed` modes.
 - Follow AGENTS.md and README.md for repository conventions.
 - Run `pre-commit run --all-files` after changes.
+- Log tool failures in `outages/` per `outages/schema.json`.
 
 REQUEST:
 1. Inspect `cad/*.scad` for todo comments or needed adjustments.

--- a/docs/prompts-codex-docker-repo.md
+++ b/docs/prompts-codex-docker-repo.md
@@ -19,6 +19,7 @@ CONTEXT:
 - The base image and tunnel setup live in `docs/pi_image_cloudflare.md`.
 - New walkthroughs belong in `docs/docker_repo_walkthrough.md`.
 - Run `pre-commit run --all-files`; ensure `pyspelling` and `linkchecker` pass.
+- File recurring deployment failures in `outages/` per `outages/schema.json`.
 
 REQUEST:
 1. Expand the walkthrough or add examples.

--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -19,6 +19,7 @@ CONTEXT:
 - Follow AGENTS.md for style and testing requirements.
 - Run `pre-commit run --all-files`; ensure `pyspelling` (requires `aspell` and `aspell-en`)
   and `linkchecker` succeed.
+- Record recurring issues in `outages/` using the JSON schema.
 
 REQUEST:
 1. Choose a markdown file in `docs/` that needs clarification or an update.

--- a/docs/prompts-codex-pi-image.md
+++ b/docs/prompts-codex-pi-image.md
@@ -19,6 +19,7 @@ CONTEXT:
 - `scripts/build_pi_image.sh` builds an image locally or in CI.
 - `docs/pi_image_cloudflare.md` is the user guide.
 - Run `pre-commit run --all-files`; ensure `pyspelling` and `linkchecker` pass.
+- Document persistent build issues in `outages/` using the schema.
 
 REQUEST:
 1. Refine the image build script or cloud-init files.

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -20,6 +20,7 @@ CONTEXT:
 - Run `pre-commit run --all-files` to lint, test and validate docs.
 - On documentation changes ensure `pyspelling -c .spellcheck.yaml` (requires `aspell` and
   `aspell-en`) and `linkchecker README.md docs/` succeed.
+- Log persistent failures in `outages/` as JSON per `outages/schema.json`.
 
 REQUEST:
 1. Identify a small bug fix or documentation clarification.

--- a/elex/power_ring/fp-lib-table
+++ b/elex/power_ring/fp-lib-table
@@ -1,4 +1,4 @@
 (fp_lib_table
   (version 7)
-  (lib (name "custom_pads_test")(type "KiCad")(uri "${KIPRJMOD}/custom_pads_test.pretty")(options "")(descr ""))
+  (lib (name "custom_pads_test")(type "KiCad")(uri "${KIPRJMOD}/power_ring.pretty")(options "")(descr ""))
 )

--- a/elex/power_ring/power_ring.kicad_pcb
+++ b/elex/power_ring/power_ring.kicad_pcb
@@ -174,7 +174,7 @@
 			)
 		)
 		(path "/00000000-0000-0000-0000-000056a7cec8")
-		(sheetfile "Fichier: custom_pads_test.kicad_sch")
+            (sheetfile "Fichier: power_ring.kicad_sch")
 		(attr smd)
 		(fp_line
 			(start -4.8 -3.2)
@@ -343,7 +343,7 @@
 			)
 		)
 		(path "/00000000-0000-0000-0000-00005a3a4ef2")
-		(sheetfile "Fichier: custom_pads_test.kicad_sch")
+            (sheetfile "Fichier: power_ring.kicad_sch")
 		(attr smd)
 		(fp_line
 			(start -20 -10)
@@ -609,7 +609,7 @@
 			)
 		)
 		(path "/00000000-0000-0000-0000-00005a3a4e22")
-		(sheetfile "Fichier: custom_pads_test.kicad_sch")
+            (sheetfile "Fichier: power_ring.kicad_sch")
 		(fp_line
 			(start -20 -10)
 			(end 1.499999 -10)
@@ -1094,7 +1094,7 @@
 			)
 		)
 		(path "/00000000-0000-0000-0000-000056a7ce3b")
-		(sheetfile "Fichier: custom_pads_test.kicad_sch")
+           (sheetfile "Fichier: power_ring.kicad_sch")
 		(fp_circle
 			(center 0 0)
 			(end 12.065 -11.938)

--- a/elex/power_ring/power_ring.kicad_pro
+++ b/elex/power_ring/power_ring.kicad_pro
@@ -470,7 +470,7 @@
     "pinned_symbol_libs": []
   },
   "meta": {
-    "filename": "custom_pads_test.kicad_pro",
+    "filename": "power_ring.kicad_pro",
     "version": 3
   },
   "net_settings": {

--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -668,7 +668,7 @@
 			(uuid "10860437-a635-4d74-b402-955f5ed187da")
 		)
 		(instances
-			(project "custom_pads_test"
+			(project "power_ring"
 				(path "/2323577b-cad3-4f70-b734-06368b53e30c"
 					(reference "SW1")
 					(unit 1)
@@ -733,7 +733,7 @@
 			(uuid "b4dd82a4-5077-4d9a-a760-ac6779aaf468")
 		)
 		(instances
-			(project "custom_pads_test"
+			(project "power_ring"
 				(path "/2323577b-cad3-4f70-b734-06368b53e30c"
 					(reference "R2")
 					(unit 1)
@@ -799,7 +799,7 @@
 			(uuid "b59c4dab-c021-4b53-a74a-0bec4ed69fb1")
 		)
 		(instances
-			(project "custom_pads_test"
+			(project "power_ring"
 				(path "/2323577b-cad3-4f70-b734-06368b53e30c"
 					(reference "AE1")
 					(unit 1)
@@ -865,7 +865,7 @@
 			(uuid "60a403dd-a34c-4a29-8f71-799067995cfd")
 		)
 		(instances
-			(project "custom_pads_test"
+			(project "power_ring"
 				(path "/2323577b-cad3-4f70-b734-06368b53e30c"
 					(reference "AE2")
 					(unit 1)
@@ -930,7 +930,7 @@
 			(uuid "4ecf714e-5b71-4668-b538-2197c7a782e7")
 		)
 		(instances
-			(project "custom_pads_test"
+			(project "power_ring"
 				(path "/2323577b-cad3-4f70-b734-06368b53e30c"
 					(reference "#PWR0001")
 					(unit 1)
@@ -995,7 +995,7 @@
 			(uuid "7cd2ec9f-4877-489f-b2ba-b60b140d9b7e")
 		)
 		(instances
-			(project "custom_pads_test"
+			(project "power_ring"
 				(path "/2323577b-cad3-4f70-b734-06368b53e30c"
 					(reference "#PWR0002")
 					(unit 1)
@@ -1060,7 +1060,7 @@
 			(uuid "fafe19cb-82f5-4a4e-89fa-b574df0dbfe9")
 		)
 		(instances
-			(project "custom_pads_test"
+			(project "power_ring"
 				(path "/2323577b-cad3-4f70-b734-06368b53e30c"
 					(reference "#PWR000101")
 					(unit 1)
@@ -1125,7 +1125,7 @@
 			(uuid "d4ba3335-efee-4bc8-a0b5-433823f2c23f")
 		)
 		(instances
-			(project "custom_pads_test"
+			(project "power_ring"
 				(path "/2323577b-cad3-4f70-b734-06368b53e30c"
 					(reference "#FLG000101")
 					(unit 1)

--- a/elex/power_ring/sym-lib-table
+++ b/elex/power_ring/sym-lib-table
@@ -1,4 +1,4 @@
 (sym_lib_table
   (version 7)
-  (lib (name "custom_pads_test")(type "KiCad")(uri "${KIPRJMOD}/custom_pads_test.kicad_sym")(options "")(descr ""))
+  (lib (name "custom_pads_test")(type "KiCad")(uri "${KIPRJMOD}/power_ring.kicad_sym")(options "")(descr ""))
 )

--- a/llms.txt
+++ b/llms.txt
@@ -25,6 +25,9 @@ scripts that provide "syntactic sugar" for Kubernetes.
 ## Schematics
 - [Power ring board](elex/power_ring/README.md)
 
+## Outages
+- Incident reports live in `outages/` as JSON following `outages/schema.json`.
+
 ## Optional
 - [AGENTS spec](https://agentsmd.net/AGENTS.md)
 - [llms.txt proposal](https://llmstxt.org/index.md)

--- a/outages/2025-08-17-kicad-export-missing-kibot-version.json
+++ b/outages/2025-08-17-kicad-export-missing-kibot-version.json
@@ -1,0 +1,10 @@
+{
+  "id": "kicad-export-missing-kibot-version",
+  "date": "2025-08-17",
+  "component": "kicad-export workflow",
+  "rootCause": "KiBot config lacked required kibot.version field, causing export to abort.",
+  "resolution": "Added 'kibot.version: 1' to .kibot/power_ring.yaml so KiBot recognizes the configuration.",
+  "references": [
+    "https://github.com/futuroptimist/sugarkube/actions/runs/17027329052"
+  ]
+}

--- a/outages/2025-08-17-kicad-export-missing-libs.json
+++ b/outages/2025-08-17-kicad-export-missing-libs.json
@@ -1,0 +1,10 @@
+{
+  "id": "kicad-export-missing-libs",
+  "date": "2025-08-17",
+  "component": "kicad-export workflow",
+  "rootCause": "KiBot failed to export because sym-lib-table and fp-lib-table pointed to non-existent custom_pads_test libraries.",
+  "resolution": "Updated library tables to use local power_ring libraries so KiBot can find symbols and footprints.",
+  "references": [
+    "https://github.com/futuroptimist/sugarkube/actions/runs/17014463006"
+  ]
+}

--- a/outages/2025-08-18-kicad-export-outputs-not-list.json
+++ b/outages/2025-08-18-kicad-export-outputs-not-list.json
@@ -1,0 +1,10 @@
+{
+  "id": "kicad-export-outputs-not-list",
+  "date": "2025-08-18",
+  "component": "kicad-export workflow",
+  "rootCause": "KiBot config defined outputs as a map rather than a list, causing parsing error.",
+  "resolution": "Converted outputs to a list of named entries in .kibot/power_ring.yaml.",
+  "references": [
+    "https://github.com/futuroptimist/sugarkube/actions/runs/17030146281"
+  ]
+}

--- a/outages/2025-08-18-kicad-export-unknown-output-type.json
+++ b/outages/2025-08-18-kicad-export-unknown-output-type.json
@@ -1,0 +1,10 @@
+{
+  "id": "kicad-export-unknown-output-type",
+  "date": "2025-08-18",
+  "component": "kicad-export workflow",
+  "rootCause": "KiBot config used unsupported output type 'schematic_pdf', causing workflow failure.",
+  "resolution": "Renamed the schematic output to 'pdf_sch_print' in .kibot/power_ring.yaml.",
+  "references": [
+    "https://github.com/futuroptimist/sugarkube/actions/runs/17030266883"
+  ]
+}

--- a/outages/README.md
+++ b/outages/README.md
@@ -1,0 +1,15 @@
+# Outage Catalog
+
+Structured archive of past outages. Each outage is stored as a JSON file using the schema in `schema.json`.
+
+File naming: `YYYY-MM-DD-<slug>.json`.
+
+Required fields:
+- `id`: unique identifier
+- `date`: ISO date
+- `component`: affected subsystem
+- `rootCause`: brief description of failure cause
+- `resolution`: how it was fixed
+- `references`: array of related links (PRs, issues, docs)
+
+Agents can parse these files to learn from previous incidents.

--- a/outages/schema.json
+++ b/outages/schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Outage record",
+  "type": "object",
+  "required": ["id", "date", "component", "rootCause", "resolution", "references"],
+  "properties": {
+    "id": { "type": "string" },
+    "date": { "type": "string", "format": "date" },
+    "component": { "type": "string" },
+    "rootCause": { "type": "string" },
+    "resolution": { "type": "string" },
+    "references": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- correct schematic export output type for KiBot
- record unknown output type failure in outage catalog

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `pyspelling -c .spellcheck.yaml` *(fails: command not found)*
- `linkchecker README.md docs/` *(fails: command not found)*
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: no such file or directory)*
- `docker run --rm hello-world` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a26531f228832fbafc2ac74ce6527d