### PR TITLE
🐛 : trim STANDOFF_MODE whitespace

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -182,3 +182,4 @@ raspi
 PuTTY
 microSD
 filesystem
+whitespace

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_
 ```
 
 By default the script uses the model's `standoff_mode` value (`heatset`).
-Set `STANDOFF_MODE=printed` to generate 3D-printed threads. Values are case-insensitive; `heatset`
-and `printed` are accepted.
+Set `STANDOFF_MODE=printed` to generate 3D-printed threads. Values are case-insensitive and ignore
+surrounding whitespace; `heatset` and `printed` are accepted.
 
 The helper script validates that the provided `.scad` file exists and that
 OpenSCAD is available in `PATH`, printing a helpful error if either check fails.

--- a/scripts/openscad_render.sh
+++ b/scripts/openscad_render.sh
@@ -21,7 +21,7 @@ base=$(basename -- "$FILE" ".$ext")
 mode_suffix=""
 standoff_mode=""
 if [ -n "${STANDOFF_MODE:-}" ]; then
-  standoff_mode="${STANDOFF_MODE,,}"
+  standoff_mode="$(printf '%s' "${STANDOFF_MODE,,}" | xargs)"
   case "$standoff_mode" in
     heatset|printed)
       mode_suffix="_$standoff_mode"

--- a/tests/openscad_render_test.py
+++ b/tests/openscad_render_test.py
@@ -205,6 +205,38 @@ printf '%s ' "$@" > "$LOG_FILE"
     assert 'standoff_mode="printed"' in args
 
 
+def test_trims_whitespace_in_standoff_mode(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    log_file = tmp_path / "args.log"
+    openscad = fake_bin / "openscad"
+    openscad.write_text(
+        """#!/usr/bin/env bash
+printf '%s ' "$@" > "$LOG_FILE"
+""",
+    )
+    openscad.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["LOG_FILE"] = str(log_file)
+    env["STANDOFF_MODE"] = "  printed  "
+
+    subprocess.run(
+        [
+            "bash",
+            "scripts/openscad_render.sh",
+            "cad/pi_cluster/pi_carrier.scad",
+        ],
+        check=True,
+        env=env,
+    )
+
+    args = log_file.read_text().split()
+    assert "-D" in args
+    assert 'standoff_mode="printed"' in args
+
+
 def test_handles_leading_dash_filename(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()


### PR DESCRIPTION
## What
- trim STANDOFF_MODE whitespace in openscad_render.sh
- document that STANDOFF_MODE ignores surrounding whitespace
- cover behavior with a regression test

## Why
- env values with stray spaces were rejected

## How to Test
- `pre-commit run --all-files`
- `pytest -q`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68a57ce869dc832fbac7f1ffa8569e1d