### PR TITLE
📝: document linkchecker flag usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,8 @@ pyspelling -c .spellcheck.yaml
 linkchecker --no-warnings README.md docs/
 ```
 
+The `--no-warnings` flag suppresses parse warnings so the command exits cleanly.
+
 The pre-commit script also checks links in those paths.
 
 - Use the commit format `emoji : summary` with a short body.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ pyspelling -c .spellcheck.yaml
 linkchecker --no-warnings README.md docs/
 ```
 
+The `--no-warnings` flag avoids non-zero exits from benign Markdown parsing warnings.
+
 STL files are produced automatically by CI for each OpenSCAD model and can be
 downloaded from the workflow run. Provide a single `.scad` file path to render a
 variant locally. The script exits with a usage message if extra arguments are


### PR DESCRIPTION
## Summary
- explain `--no-warnings` for linkchecker to avoid spurious exit codes

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68a57ce869dc832fbac7f1ffa8569e1d