### PR TITLE
📝 : – remind to keep k3s node token private

### DIFF
--- a/docs/network_setup.md
+++ b/docs/network_setup.md
@@ -49,7 +49,7 @@ sudo cat /var/lib/rancher/k3s/server/node-token
 ```
 
 The token is stored at `/var/lib/rancher/k3s/server/node-token`; copy it for
-later.
+later. Treat this token like a password and keep it private.
 
 Boot the remaining Pis once they can reach the control-plane node. Replace
 `<server-ip>` with the control-plane's IP and `<node-token>` with the value


### PR DESCRIPTION
what: clarify node token handling in network setup guide
why: leaking the token allows unauthorized cluster access
how to test: pyspelling -c .spellcheck.yaml
             linkchecker README.md docs/
             pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a57ce869dc832fbac7f1ffa8569e1d