### PR TITLE
🛠️: compress Pi image build and docs

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -10,6 +10,7 @@ It bakes Docker, the compose plugin, and a Cloudflare Tunnel into the OS image u
 ## Checklist
 
 - [ ] Build or download a Raspberry Pi OS image.
+- [ ] If downloaded, decompress it with `xz -d sugarkube.img.xz`.
 - [ ] Place `scripts/cloud-init/user-data.yaml` on the SD card's boot partition as `user-data`.
 - [ ] Flash the image with Raspberry Pi Imager.
 - [ ] Boot the Pi and run `sudo rpi-clone sda -f` to copy the OS to an SSD.
@@ -23,5 +24,6 @@ It bakes Docker, the compose plugin, and a Cloudflare Tunnel into the OS image u
 
 ## GitHub Actions
 
-The `pi-image` workflow builds the OS image with `scripts/build_pi_image.sh` and uploads `sugarkube.img.xz` as an artifact.
+The `pi-image` workflow builds the OS image with `scripts/build_pi_image.sh`, compresses it to
+`sugarkube.img.xz` and uploads it as an artifact.
 Download it from the Actions tab or run the script locally if you need customizations.

--- a/outages/2025-08-20-pi-image-artifact-too-large.json
+++ b/outages/2025-08-20-pi-image-artifact-too-large.json
@@ -1,0 +1,10 @@
+{
+  "id": "pi-image-artifact-too-large",
+  "date": "2025-08-20",
+  "component": "pi-image workflow",
+  "rootCause": "Uncompressed Raspberry Pi image exceeded GitHub Actions artifact limit, blocking uploads.",
+  "resolution": "Updated build_pi_image.sh to compress the image with xz before uploading.",
+  "references": [
+    "https://github.com/futuroptimist/sugarkube/blob/main/scripts/build_pi_image.sh"
+  ]
+}

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -2,12 +2,14 @@
 set -euo pipefail
 
 # Build a Raspberry Pi OS image with cloud-init files preloaded.
-# Requires Docker and roughly 10 GB of free disk space.
+# Requires Docker, xz and roughly 10 GB of free disk space.
 
-if ! command -v docker >/dev/null 2>&1; then
-  echo "Docker is required" >&2
-  exit 1
-fi
+for cmd in docker xz; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd is required" >&2
+    exit 1
+  fi
+done
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 WORK_DIR=$(mktemp -d)
@@ -23,5 +25,6 @@ ENABLE_SSH=1
 CFG
 sudo ./build.sh
 mv deploy/*.img "${REPO_ROOT}/sugarkube.img"
-ls -lh "${REPO_ROOT}/sugarkube.img"
-echo "Image written to ${REPO_ROOT}/sugarkube.img"
+xz -T0 "${REPO_ROOT}/sugarkube.img"
+ls -lh "${REPO_ROOT}/sugarkube.img.xz"
+echo "Image written to ${REPO_ROOT}/sugarkube.img.xz"

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -3,6 +3,7 @@ package_update: true
 packages:
   - docker.io
   - docker-compose-plugin
+  - curl
   - git
   - cloudflared
 runcmd:


### PR DESCRIPTION
what: compress Pi image artifact, add curl to cloud-init, note decompression and log outage.
why: shrink GitHub Actions artifact and document reliable setup.
how to test: pre-commit run --all-files.

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a57cd97c84832fa0aba439a0726bad