### PR TITLE
Handle missing sudo in Pi image build script

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -9,8 +9,10 @@ It bakes Docker, the compose plugin, and a Cloudflare Tunnel into the OS image u
 
 ## Checklist
 
-- [ ] Build or download a Raspberry Pi OS image.
-- [ ] Place `scripts/cloud-init/user-data.yaml` on the SD card's boot partition as `user-data`.
+- [ ] Build or download a Raspberry Pi OS image. `scripts/build_pi_image.sh` now embeds
+      `scripts/cloud-init/user-data.yaml` and only uses `sudo` when required.
+- [ ] (Optional) If building the image manually, place `scripts/cloud-init/user-data.yaml`
+      on the SD card's boot partition as `user-data`.
 - [ ] Flash the image with Raspberry Pi Imager.
 - [ ] Boot the Pi and run `sudo rpi-clone sda -f` to copy the OS to an SSD.
 - [ ] Reboot and verify `/opt/sugarkube/docker-compose.cloudflared.yml` exists.

--- a/outages/2025-08-20-pi-image-build-sudo-missing.json
+++ b/outages/2025-08-20-pi-image-build-sudo-missing.json
@@ -1,0 +1,10 @@
+{
+  "id": "pi-image-build-sudo-missing",
+  "date": "2025-08-20",
+  "component": "pi-image build script",
+  "rootCause": "build_pi_image.sh always invoked sudo, failing in minimal containers that lack sudo",
+  "resolution": "script now detects root execution and only uses sudo when necessary",
+  "references": [
+    "scripts/build_pi_image.sh"
+  ]
+}

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -9,6 +9,17 @@ if ! command -v docker >/dev/null 2>&1; then
   exit 1
 fi
 
+# Use sudo only when not running as root. Some CI containers omit sudo.
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+  if command -v sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+  else
+    echo "Run as root or install sudo" >&2
+    exit 1
+  fi
+fi
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 WORK_DIR=$(mktemp -d)
 trap 'rm -rf "${WORK_DIR}"' EXIT
@@ -21,7 +32,7 @@ cat > config <<'CFG'
 IMG_NAME="sugarkube"
 ENABLE_SSH=1
 CFG
-sudo ./build.sh
+${SUDO} ./build.sh
 mv deploy/*.img "${REPO_ROOT}/sugarkube.img"
 ls -lh "${REPO_ROOT}/sugarkube.img"
 echo "Image written to ${REPO_ROOT}/sugarkube.img"


### PR DESCRIPTION
## Summary
- skip sudo in build_pi_image.sh when running as root
- note sudo behavior in Cloudflare image guide
- log recurring sudo build failures in outages catalog

## Testing
- `detect-secrets scan --string "$(git diff --cached)"`
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a57cd97c84832fa0aba439a0726bad