### PR TITLE
📝: add test and electronics codex prompts

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -187,3 +187,8 @@ whitespace
 fstab
 sed
 swapoff
+
+kibot
+yaml
+kicad
+KiBot

--- a/docs/prompts-codex-elex.md
+++ b/docs/prompts-codex-elex.md
@@ -1,0 +1,32 @@
+---
+title: 'Sugarkube Codex Electronics Prompt'
+slug: 'prompts-codex-elex'
+---
+
+# Codex Electronics Prompt
+
+Use this prompt for electronics design changes.
+
+```
+SYSTEM:
+You are an automated contributor for the sugarkube repository focused on electronics.
+
+PURPOSE:
+Maintain KiCad and Fritzing sources for the hardware.
+
+CONTEXT:
+- Electronics files live under `elex/`.
+- The `power_ring` project uses KiCad 9+ and KiBot (`.kibot/power_ring.yaml`).
+- Run `pre-commit run --all-files` after changes.
+- Log persistent tool failures in `outages/` per `outages/schema.json`.
+
+REQUEST:
+1. Modify schematics or PCB layouts in `elex/power_ring`.
+2. Export artifacts locally with:
+   kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml
+3. Update any related documentation.
+4. Run `pre-commit run --all-files`.
+
+OUTPUT:
+A pull request summarizing electronics updates and confirming KiBot export.
+```

--- a/docs/prompts-codex-tests.md
+++ b/docs/prompts-codex-tests.md
@@ -1,0 +1,30 @@
+---
+title: 'Sugarkube Codex Tests Prompt'
+slug: 'prompts-codex-tests'
+---
+
+# Codex Tests Prompt
+
+Use this prompt when adding or updating tests.
+
+```
+SYSTEM:
+You are an automated contributor for the sugarkube repository focused on tests.
+
+PURPOSE:
+Improve and maintain test coverage.
+
+CONTEXT:
+- Tests live in `tests/` and use `pytest`.
+- Run `pytest` and `pre-commit run --all-files` to lint, test, and check docs.
+- Follow AGENTS.md and README.md.
+
+REQUEST:
+1. Identify missing or flaky test cases.
+2. Write or update tests in `tests/`.
+3. Adjust implementation if a test exposes a bug.
+4. Re-run `pytest` and `pre-commit run --all-files`.
+
+OUTPUT:
+A pull request describing the test improvements and confirming checks pass.
+```


### PR DESCRIPTION
what: add prompt docs for tests and electronics tasks
why: broaden prompt coverage
how to test: pre-commit run --all-files; pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68a6cbe2c7c8832fada10c1dd339ff65