### PR TITLE
🐛: ignore blank STANDOFF_MODE

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_
 
 By default the script uses the model's `standoff_mode` value (`heatset`).
 Set `STANDOFF_MODE=printed` to generate 3D-printed threads. Values are case-insensitive and ignore
-surrounding whitespace; `heatset` and `printed` are accepted.
+surrounding whitespace; `heatset` and `printed` are accepted. Supplying only
+whitespace uses the model's default `standoff_mode`.
 
 The helper script validates that the provided `.scad` file exists and that
 OpenSCAD is available in `PATH`, printing a helpful error if either check fails.

--- a/scripts/openscad_render.sh
+++ b/scripts/openscad_render.sh
@@ -22,15 +22,17 @@ mode_suffix=""
 standoff_mode=""
 if [ -n "${STANDOFF_MODE:-}" ]; then
   standoff_mode="$(printf '%s' "${STANDOFF_MODE,,}" | xargs)"
-  case "$standoff_mode" in
-    heatset|printed)
-      mode_suffix="_$standoff_mode"
-      ;;
-    *)
-      echo "Invalid STANDOFF_MODE: $STANDOFF_MODE (expected 'heatset' or 'printed')" >&2
-      exit 1
-      ;;
-  esac
+  if [ -n "$standoff_mode" ]; then
+    case "$standoff_mode" in
+      heatset|printed)
+        mode_suffix="_$standoff_mode"
+        ;;
+      *)
+        echo "Invalid STANDOFF_MODE: $STANDOFF_MODE (expected 'heatset' or 'printed')" >&2
+        exit 1
+        ;;
+    esac
+  fi
 fi
 
 if ! command -v openscad >/dev/null 2>&1; then

--- a/tests/openscad_render_test.py
+++ b/tests/openscad_render_test.py
@@ -237,6 +237,37 @@ printf '%s ' "$@" > "$LOG_FILE"
     assert 'standoff_mode="printed"' in args
 
 
+def test_blank_standoff_mode_uses_default(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    log_file = tmp_path / "args.log"
+    openscad = fake_bin / "openscad"
+    openscad.write_text(
+        """#!/usr/bin/env bash
+printf '%s ' "$@" > "$LOG_FILE"
+""",
+    )
+    openscad.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["LOG_FILE"] = str(log_file)
+    env["STANDOFF_MODE"] = "   "
+
+    subprocess.run(
+        [
+            "bash",
+            "scripts/openscad_render.sh",
+            "cad/pi_cluster/pi_carrier.scad",
+        ],
+        check=True,
+        env=env,
+    )
+
+    args = log_file.read_text()
+    assert "-D" not in args
+
+
 def test_handles_leading_dash_filename(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()


### PR DESCRIPTION
what: handle whitespace-only STANDOFF_MODE, add test and docs
why: script errored when STANDOFF_MODE was spaces
how: pre-commit run --all-files
Refs: none

------
https://chatgpt.com/codex/tasks/task_e_68a816432198832fa9c6860d3bb8b983