### PR TITLE
📝: clarify linkchecker usage in Codex prompts

### DIFF
--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -17,7 +17,7 @@ Diagnose and fix continuous integration failures so all checks pass.
 CONTEXT:
 - Follow AGENTS.md for workflow and testing requirements.
 - Run `pre-commit run --all-files` to reproduce failures; it executes `scripts/checks.sh`.
-- Ensure `pyspelling -c .spellcheck.yaml` and `linkchecker README.md docs/` succeed.
+- Ensure `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` succeed.
 - Install missing dependencies with `pip` or `npm` as needed.
 
 REQUEST:

--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -17,7 +17,7 @@ Keep Markdown documentation free of spelling errors.
 CONTEXT:
 - Run `pyspelling -c .spellcheck.yaml` to scan `README.md` and `docs/`.
 - Add legitimate new words to `.wordlist.txt`.
-- Follow AGENTS.md and run `pre-commit run --all-files`; ensure `linkchecker README.md docs/` also passes.
+- Follow AGENTS.md and run `pre-commit run --all-files`; ensure `linkchecker --no-warnings README.md docs/` also passes.
 
 REQUEST:
 1. Run the spellcheck and review results.

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -19,7 +19,7 @@ CONTEXT:
 - Follow AGENTS.md and README.md.
 - Run `pre-commit run --all-files` to lint, test and validate docs.
 - On documentation changes ensure `pyspelling -c .spellcheck.yaml` (requires `aspell` and
-  `aspell-en`) and `linkchecker README.md docs/` succeed.
+  `aspell-en`) and `linkchecker --no-warnings README.md docs/` succeed.
 - Log persistent failures in `outages/` as JSON per `outages/schema.json`.
 
 REQUEST:


### PR DESCRIPTION
## Summary
- standardize Codex prompt docs on `linkchecker --no-warnings README.md docs/`

## Testing
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a816432198832fa9c6860d3bb8b983