### PR TITLE
🛠️ : skip JS checks without package-lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ linkchecker --no-warnings README.md docs/
 
 The `--no-warnings` flag avoids non-zero exits from benign Markdown parsing warnings.
 
+If the repository includes a `package.json` but `npm` or `package-lock.json`
+are missing, `scripts/checks.sh` will warn and skip JavaScript-specific
+checks.
+
 STL files are produced automatically by CI for each OpenSCAD model and can be
 downloaded from the workflow run. Provide a single `.scad` file path to render a
 variant locally. The script exits with a usage message if extra arguments are

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -8,11 +8,19 @@ black --check . --exclude ".venv/"
 
 # js checks
 if [ -f package.json ]; then
-  npm ci
-  npx playwright install --with-deps
-  npm run lint
-  npm run format:check
-  npm test -- --coverage
+  if command -v npm >/dev/null 2>&1; then
+    if [ -f package-lock.json ]; then
+      npm ci
+      npx playwright install --with-deps
+      npm run lint
+      npm run format:check
+      npm test -- --coverage
+    else
+      echo "package-lock.json not found, skipping JS checks" >&2
+    fi
+  else
+    echo "npm not found, skipping JS checks" >&2
+  fi
 fi
 
 # run tests

--- a/tests/checks_script_test.py
+++ b/tests/checks_script_test.py
@@ -1,0 +1,47 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_skips_js_checks_when_package_lock_missing(tmp_path):
+    script_src = Path(__file__).resolve().parents[1] / "scripts" / "checks.sh"
+    script = tmp_path / "checks.sh"
+    script.write_text(script_src.read_text())
+    script.chmod(0o755)
+
+    # simulate project with package.json but no package-lock.json
+    (tmp_path / "package.json").write_text("{}")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "npm_called"
+    for cmd in [
+        "flake8",
+        "isort",
+        "black",
+        "pytest",
+        "pyspelling",
+        "linkchecker",
+        "npm",
+        "npx",
+    ]:
+        f = fake_bin / cmd
+        if cmd == "npm":
+            f.write_text(f"#!/bin/bash\necho called > {marker}\nexit 0\n")
+        else:
+            f.write_text("#!/bin/bash\nexit 0\n")
+        f.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"/bin:{fake_bin}"
+
+    result = subprocess.run(
+        ["/bin/bash", str(script)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "package-lock.json not found" in result.stderr
+    assert not marker.exists()


### PR DESCRIPTION
## Summary
- warn and skip JS checks when npm or package-lock.json missing
- clarify README for optional JavaScript tooling
- test that checks.sh skips JS checks if lockfile absent

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a816432198832fa9c6860d3bb8b983