### PR TITLE
Add tests for build_pi_image dependency checks

### DIFF
--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -1,0 +1,56 @@
+import os
+import subprocess
+
+
+def test_requires_docker(tmp_path):
+    env = os.environ.copy()
+    env["PATH"] = str(tmp_path)
+    result = subprocess.run(
+        ["/bin/bash", "scripts/build_pi_image.sh"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "docker is required" in result.stderr
+
+
+def test_requires_xz(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    docker = fake_bin / "docker"
+    docker.write_text("#!/bin/sh\nexit 0\n")
+    docker.chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = str(fake_bin)
+    result = subprocess.run(
+        ["/bin/bash", "scripts/build_pi_image.sh"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "xz is required" in result.stderr
+
+
+def test_requires_sudo_when_non_root(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    for name, content in {
+        "docker": "#!/bin/sh\nexit 0\n",
+        "xz": "#!/bin/sh\nexit 0\n",
+        "id": "#!/bin/sh\necho 1000\n",
+    }.items():
+        path = fake_bin / name
+        path.write_text(content)
+        path.chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = str(fake_bin)
+    result = subprocess.run(
+        ["/bin/bash", "scripts/build_pi_image.sh"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "Run as root or install sudo" in result.stderr


### PR DESCRIPTION
## Summary
- add coverage for build_pi_image.sh when docker/xz/sudo missing

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8164041c8832f859a7f906bb79a42