### PR TITLE
🔧: add Cloudflare apt repo for Pi image

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -5,10 +5,11 @@ Raspberry Pi deployment so it can host multiple projects such as
 [token.place](https://github.com/futuroptimist/token.place) and
 [dspace](https://github.com/democratizedspace/dspace).
 
-It bakes Docker, the compose plugin, and a Cloudflare Tunnel into the OS image
-using `cloud-init`. The `build_pi_image.sh` script clones `pi-gen` using the
-`PI_GEN_BRANCH` environment variable, defaulting to `bookworm` for reproducible
-builds. Use the prepared image to deploy containerized apps. The companion guide
+It bakes Docker, the compose plugin, the Cloudflare apt repository, and a
+Cloudflare Tunnel into the OS image using `cloud-init`. The `build_pi_image.sh`
+script clones `pi-gen` using the `PI_GEN_BRANCH` environment variable,
+defaulting to `bookworm` for reproducible builds. Use the prepared image to
+deploy containerized apps. The companion guide
 [docker_repo_walkthrough.md](docker_repo_walkthrough.md) explains how to run
 projects such as token.place and dspace.
 
@@ -21,7 +22,8 @@ projects such as token.place and dspace.
       on the SD card's boot partition as `user-data`.
 - [ ] Flash the image with Raspberry Pi Imager.
 - [ ] Boot the Pi and run `sudo rpi-clone sda -f` to copy the OS to an SSD.
-- [ ] Cloud-init writes `/opt/sugarkube/docker-compose.cloudflared.yml`; verify it exists.
+- [ ] Cloud-init adds the Cloudflare apt repo and writes
+      `/opt/sugarkube/docker-compose.cloudflared.yml`; verify both exist.
 - [ ] Add your Cloudflare token to `/opt/sugarkube/.cloudflared.env`.
 - [ ] Start the tunnel with `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml up -d`.
 - [ ] Confirm the tunnel is running: `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml ps` should show `cloudflared` as `Up`.

--- a/outages/2025-08-22-pi-image-cloudflared-apt-repo.json
+++ b/outages/2025-08-22-pi-image-cloudflared-apt-repo.json
@@ -1,0 +1,11 @@
+{
+  "id": "2025-08-22-pi-image-cloudflared-apt-repo",
+  "date": "2025-08-22",
+  "component": "pi-image",
+  "rootCause": "cloudflared package install failed because Cloudflare apt repo was missing in cloud-init",
+  "resolution": "Add cloud-init apt source for Cloudflare to install cloudflared from upstream repo",
+  "references": [
+    "scripts/cloud-init/user-data.yaml",
+    "docs/pi_image_cloudflare.md"
+  ]
+}

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -1,5 +1,11 @@
 #cloud-config
 package_update: true
+apt:
+  sources:
+    cloudflare:
+      source: "deb [arch=arm64] https://pkg.cloudflare.com/ bookworm main"
+      keyid: FBA8C0EE63617C5EED695C43254B391D8CACCBF8
+      keyserver: https://keyserver.ubuntu.com
 packages:
   - docker.io
   - docker-compose-plugin


### PR DESCRIPTION
## Summary
- configure Cloudflare apt source in cloud-init for pi images
- document the new repo usage and record outage details

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a8141cfce8832f93362dcbf62f8c3f