### PR TITLE
🔌 Add SugarKube PCB label and log KiBot failure

### DIFF
--- a/elex/power_ring/README.md
+++ b/elex/power_ring/README.md
@@ -11,3 +11,5 @@ Included files:
 - `power_ring.pretty/` – footprint library
 
 Open the project in **KiCad 9** or newer and modify the schematic to suit your power distribution needs (for example, add screw terminals, fuses and test points).  Use [KiBot](https://github.com/INTI-CMNB/KiBot) with `.kibot/power_ring.yaml` or run the GitHub workflow to produce Gerber files, a PDF schematic and a BOM in `build/power_ring/`.
+
+The layout now includes a "SugarKube" copper label for easy identification.

--- a/elex/power_ring/power_ring.kicad_pcb
+++ b/elex/power_ring/power_ring.kicad_pcb
@@ -1274,7 +1274,7 @@
 		(layer "Edge.Cuts")
 		(uuid "fe9dd4af-9c39-4231-b588-395a35cc7f25")
 	)
-	(gr_text "Test"
+	(gr_text "SugarKube"
 		(at 159.3 91.4 0)
 		(layer "F.Cu")
 		(uuid "e2ecccdd-5374-4255-9fc5-749bd4111d55")

--- a/outages/2025-08-22-kicad-export-missing-pcbnew-module.json
+++ b/outages/2025-08-22-kicad-export-missing-pcbnew-module.json
@@ -1,0 +1,10 @@
+{
+  "id": "kicad-export-missing-pcbnew-module",
+  "date": "2025-08-22",
+  "component": "kicad-export workflow",
+  "rootCause": "KiBot failed to import pcbnew because KiCad 7's Python module is incompatible with Python 3.12; project requires KiCad 9.",
+  "resolution": "Run KiBot in the KiCad 9 container or install a compatible pcbnew Python module.",
+  "references": [
+    "https://github.com/INTI-CMNB/kibot"
+  ]
+}


### PR DESCRIPTION
## Summary
- add 'SugarKube' copper text to power_ring PCB
- document board label in power_ring README
- record outage for KiBot missing pcbnew Python module

## Testing
- `pre-commit run --all-files`
- `kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml` *(fails: pcbnew module)*

------
https://chatgpt.com/codex/tasks/task_e_68a81416da30832fbe52aff9ba648614