### PR TITLE
🛠️ : – install aspell automatically for docs checks

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -19,6 +19,16 @@ fi
 pytest --cov=. --cov-report=xml --cov-report=term -q
 
 # docs checks
+if ! command -v aspell >/dev/null 2>&1; then
+  if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update && sudo apt-get install -y aspell aspell-en
+  elif command -v brew >/dev/null 2>&1; then
+    brew install aspell
+  else
+    echo "aspell not found" >&2
+    exit 1
+  fi
+fi
 if command -v pyspelling >/dev/null 2>&1 && [ -f .spellcheck.yaml ]; then
   pyspelling -c .spellcheck.yaml
 fi


### PR DESCRIPTION
## Summary
- ensure checks.sh installs aspell if missing so doc checks run

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker README.md docs/`
- `npm run lint` *(fails: package.json missing)*
- `npm run test:ci` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a81400a648832f9a1bc508457c5e16