### PR TITLE
power ring: note voltage testpoints

### DIFF
--- a/elex/power_ring/README.md
+++ b/elex/power_ring/README.md
@@ -11,6 +11,7 @@ Included files:
 - `power_ring.pretty/` – footprint library
 
 A title block comment reminds you to place decoupling capacitors near power pins for easy review.
+A second comment notes to include test points for monitoring the supply voltage.
 
 Open the project in **KiCad 9** or newer and modify the schematic to suit your power distribution needs (for example, add screw terminals, fuses and test points).  Use [KiBot](https://github.com/INTI-CMNB/KiBot) with `.kibot/power_ring.yaml` or run the GitHub workflow to produce Gerber files, a PDF schematic and a BOM in `build/power_ring/`.
 

--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -6,6 +6,7 @@
 	(paper "A4")
         (title_block
                 (comment 1 "Place decoupling capacitors near power pins")
+                (comment 2 "Include test points for voltage monitoring")
         )
 	(lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/outages/2025-08-23-kicad-export-no-kicad.json
+++ b/outages/2025-08-23-kicad-export-no-kicad.json
@@ -1,0 +1,8 @@
+{
+  "id": "2025-08-23-kicad-export-no-kicad",
+  "date": "2025-08-23",
+  "component": "kicad-export",
+  "rootCause": "KiCad not installed; pcbnew Python module missing prevents KiBot export",
+  "resolution": "Install KiCad 9 and ensure pcbnew Python module is in PYTHONPATH",
+  "references": []
+}


### PR DESCRIPTION
## Summary
- add reminder for voltage-monitoring test points in schematic
- document new schematic comment
- log Kibot failure due to missing KiCad

## Testing
- `npm run lint` *(fails: Could not read package.json)*
- `npm run test:ci` *(fails: Could not read package.json)*
- `kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml` *(fails: pcbnew module missing)*
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68a9673c349c832fb1f4b471d5740f8e