### PR TITLE
🔌 : add high-current trace note

### DIFF
--- a/elex/power_ring/README.md
+++ b/elex/power_ring/README.md
@@ -10,7 +10,8 @@ Included files:
 - `power_ring.kicad_sym` and `power_ring_schlib.kicad_sym` – symbol libraries
 - `power_ring.pretty/` – footprint library
 
-A title block comment reminds you to place decoupling capacitors near power pins for easy review.
+A title block comment reminds you to place decoupling capacitors near power pins, and
+a second note encourages keeping high-current traces short for better performance.
 
 Open the project in **KiCad 9** or newer and modify the schematic to suit your power distribution needs (for example, add screw terminals, fuses and test points).  Use [KiBot](https://github.com/INTI-CMNB/KiBot) with `.kibot/power_ring.yaml` or run the GitHub workflow to produce Gerber files, a PDF schematic and a BOM in `build/power_ring/`.
 

--- a/elex/power_ring/power_ring.kicad_pcb
+++ b/elex/power_ring/power_ring.kicad_pcb
@@ -6,9 +6,12 @@
 		(thickness 1.6)
 		(legacy_teardrops no)
 	)
-	(paper "A4")
-	(layers
-		(0 "F.Cu" signal)
+        (paper "A4")
+        (title_block
+                (comment 1 "Keep high-current traces short")
+        )
+        (layers
+                (0 "F.Cu" signal)
 		(2 "B.Cu" signal)
 		(9 "F.Adhes" user "F.Adhesive")
 		(11 "B.Adhes" user "B.Adhesive")

--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -6,6 +6,7 @@
 	(paper "A4")
         (title_block
                 (comment 1 "Place decoupling capacitors near power pins")
+                (comment 2 "Keep high-current traces short")
         )
 	(lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/outages/2025-08-23-kicad-export-pcbnew-python-missing.json
+++ b/outages/2025-08-23-kicad-export-pcbnew-python-missing.json
@@ -1,0 +1,11 @@
+{
+  "id": "kicad-export-pcbnew-python-missing",
+  "date": "2025-08-23",
+  "component": "kicad-export",
+  "rootCause": "KiBot could not import pcbnew Python module because KiCad is not installed.",
+  "resolution": "Install KiCad 9 with Python bindings or run KiBot in the KiCad 9 container.",
+  "references": [
+    "kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml",
+    "https://github.com/INTI-CMNB/kibot"
+  ]
+}


### PR DESCRIPTION
what: add high-current trace reminder to power_ring design and docs; log KiBot pcbnew issue.
why: guide routing for heavy currents and track missing KiCad environment.
how to test: pre-commit run --all-files; kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a9673c349c832fb1f4b471d5740f8e