### PR TITLE
docs: document linkchecker external flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ linkchecker --no-warnings README.md docs/
 
 The `--no-warnings` flag avoids non-zero exits from benign Markdown parsing warnings.
 
+Include `--check-extern` to validate external URLs as well.
+
 If the repository includes a `package.json` but `npm` or `package-lock.json`
 are missing, `scripts/checks.sh` will warn and skip JavaScript-specific
 checks.

--- a/outages/2025-08-23-scan-secrets-script-missing.json
+++ b/outages/2025-08-23-scan-secrets-script-missing.json
@@ -1,0 +1,10 @@
+{
+  "id": "scan-secrets-script-missing",
+  "date": "2025-08-23",
+  "component": "security",
+  "rootCause": "scripts/scan-secrets.py not found during secret scanning",
+  "resolution": "Add scripts/scan-secrets.py or adjust instructions to use an available secret scanning tool",
+  "references": [
+    "git diff --cached | ./scripts/scan-secrets.py"
+  ]
+}


### PR DESCRIPTION
what: clarify linkchecker usage and log missing secret scan script
why: help contributors validate external links and track security gap
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a96755f59c832f9f6f53108db11766