### PR TITLE
📝 : clarify mesh rendering step

### DIFF
--- a/docs/build_guide.md
+++ b/docs/build_guide.md
@@ -7,7 +7,8 @@ junction box.
 1. Print the triple Pi carrier from `cad/pi_cluster` if building a Pi cluster.
    Download pre-rendered STLs from the repository's **Actions** tab: open the
    latest [scad-to-stl workflow run][stl-workflow] and grab the `pi_cluster`
-   artifact. To render meshes locally instead, run `./scripts/openscad_render.sh`.
+   artifact. To render meshes locally instead, run
+   `bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`.
 2. Assemble the extrusion cube using M5 hardware, squaring each corner.
 3. Mount the solar panels using the printed brackets. Each has a gusset that
    stiffens the corner. Keep panels covered or face-down during wiring to avoid


### PR DESCRIPTION
## What
- document example scad path for `openscad_render.sh`

## Why
- script requires a `.scad` argument; previous docs omitted it

## How to test
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `pre-commit run --all-files`

Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68a96755f59c832f9f6f53108db11766