### PR TITLE
📝 : add nonint to word list

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -195,3 +195,4 @@ kibot
 yaml
 kicad
 KiBot
+nonint


### PR DESCRIPTION
## Summary
- add nonint to word list for raspi-config docs

## Testing
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `pre-commit run --all-files`
- `pytest --cov=. --cov-report=term --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9674ef9a4832fa5d5c26f9467e458