### PR TITLE
🧹 : update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer


### PR DESCRIPTION
what: bump pre-commit-hooks to v6.0.0 to drop deprecated stage names.
why: avoid future warnings in lint workflow.
how to test: pre-commit run --all-files;
pyspelling -c .spellcheck.yaml;
linkchecker --no-warnings README.md docs/
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a9671b63e8832fbf2ca29f83c109c3