### PR TITLE
🔧 : – ensure checks script installs deps

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ensure required Python tooling is available
+if ! command -v flake8 >/dev/null 2>&1; then
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install --system \
+      flake8 isort black pytest pytest-cov coverage pyspelling linkchecker \
+      >/dev/null 2>&1
+  else
+    pip install flake8 isort black pytest pytest-cov coverage pyspelling linkchecker \
+      >/dev/null 2>&1
+  fi
+fi
+
 # python checks
 flake8 . --exclude=.venv
 isort --check-only . --skip .venv
@@ -42,7 +54,8 @@ fi
 # the `aspell` binary by default which would cause `pyspelling` to error.  In
 # those cases we silently skip the spelling check instead of failing the whole
 # pre-commit run.
-if command -v pyspelling >/dev/null 2>&1 && command -v aspell >/dev/null 2>&1 && [ -f .spellcheck.yaml ]; then
+if command -v pyspelling >/dev/null 2>&1 && command -v aspell >/dev/null 2>&1 \
+  && [ -f .spellcheck.yaml ]; then
   pyspelling -c .spellcheck.yaml
 fi
 if command -v linkchecker >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- ensure run checks script installs required Python tooling when missing

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `npm run lint` *(fails: Could not read package.json)*
- `npm run test:ci` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68a9671b63e8832fbf2ca29f83c109c3