### PR TITLE
docs: note Pi reboot and stub linkchecker test

### DIFF
--- a/docs/network_setup.md
+++ b/docs/network_setup.md
@@ -18,11 +18,12 @@ It assumes you are using Raspberry Pi 5 boards in a small k3s setup.
    router's client list.
 7. After logging in, update packages so each Pi starts with the latest fixes:
    `sudo apt update && sudo apt full-upgrade -y`
-8. Reserve each Pi's MAC address in your router's DHCP table so its IP stays
+8. Reboot to ensure kernel updates apply before moving on.
+9. Reserve each Pi's MAC address in your router's DHCP table so its IP stays
    consistent even if mDNS stops working.
-9. If you skipped adding a key earlier, generate one with
-   `ssh-keygen -t ed25519`, then copy your public key to each Pi:
-   `ssh-copy-id <user>@<hostname>.local`
+10. If you skipped adding a key earlier, generate one with
+    `ssh-keygen -t ed25519`, then copy your public key to each Pi:
+    `ssh-copy-id <user>@<hostname>.local`
 
 ## Switch and PoE
 

--- a/tests/checks_script_test.py
+++ b/tests/checks_script_test.py
@@ -33,7 +33,7 @@ def test_skips_js_checks_when_package_lock_missing(tmp_path):
         f.chmod(0o755)
 
     env = os.environ.copy()
-    env["PATH"] = f"/bin:{fake_bin}"
+    env["PATH"] = f"{fake_bin}:/bin"
 
     result = subprocess.run(
         ["/bin/bash", str(script)],


### PR DESCRIPTION
what: document reboot after upgrades and stub linkchecker path in tests
why: ensure kernel updates apply and keep link checks passing
how to test:
- pre-commit run --all-files
- pytest -q
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- npm run lint (fails: no package.json)
- npm run test:ci (fails: no package.json)
- git diff --cached | ./scripts/scan-secrets.py (missing)


------
https://chatgpt.com/codex/tasks/task_e_68a96721d344832fa8631cbbe0eb8148