### PR TITLE
Add git requirement for Pi image builds

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -8,22 +8,25 @@ Raspberry Pi deployment so it can host multiple projects such as
 It bakes Docker, the compose plugin, the Cloudflare apt repository, and a
 Cloudflare Tunnel into the OS image using `cloud-init`. The `build_pi_image.sh`
 script clones `pi-gen` using the `PI_GEN_BRANCH` environment variable,
-defaulting to `bookworm` for reproducible builds. Use the prepared image to
-deploy containerized apps. The companion guide
+defaulting to `bookworm` for reproducible builds. Ensure `docker`, `xz` and
+`git` are installed before running it. Use the prepared image to deploy
+containerized apps. The companion guide
 [docker_repo_walkthrough.md](docker_repo_walkthrough.md) explains how to run
 projects such as token.place and dspace.
 
 ## Checklist
 
-- [ ] Build or download a Raspberry Pi OS image. `scripts/build_pi_image.sh` now embeds
-      `scripts/cloud-init/user-data.yaml` and only uses `sudo` when required.
+- [ ] Build or download a Raspberry Pi OS image. `scripts/build_pi_image.sh`
+      now embeds `scripts/cloud-init/user-data.yaml`, verifies `docker`, `xz`
+      and `git` are installed, and only uses `sudo` when required.
 - [ ] If downloaded, decompress it with `xz -d sugarkube.img.xz`.
 - [ ] (Optional) If building the image manually, place `scripts/cloud-init/user-data.yaml`
       on the SD card's boot partition as `user-data`.
 - [ ] Flash the image with Raspberry Pi Imager.
 - [ ] Boot the Pi and run `sudo rpi-clone sda -f` to copy the OS to an SSD.
-- [ ] Cloud-init adds the Cloudflare apt repo and writes
-      `/opt/sugarkube/docker-compose.cloudflared.yml`; verify both exist.
+- [ ] Cloud-init adds the Cloudflare apt repo, writes
+      `/opt/sugarkube/docker-compose.cloudflared.yml`, and enables the Docker
+      service; verify all three.
 - [ ] Add your Cloudflare token to `/opt/sugarkube/.cloudflared.env`.
 - [ ] Start the tunnel with `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml up -d`.
 - [ ] Confirm the tunnel is running: `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml ps` should show `cloudflared` as `Up`.

--- a/outages/2025-08-23-pi-image-build-git-missing.json
+++ b/outages/2025-08-23-pi-image-build-git-missing.json
@@ -1,0 +1,10 @@
+{
+  "id": "pi-image-build-git-missing",
+  "date": "2025-08-23",
+  "component": "pi-image build script",
+  "rootCause": "build_pi_image.sh failed when git was absent but did not check for it",
+  "resolution": "script now verifies git is installed before running",
+  "references": [
+    "scripts/build_pi_image.sh"
+  ]
+}

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 # Build a Raspberry Pi OS image with cloud-init files preloaded.
-# Requires Docker, xz and roughly 10 GB of free disk space.
+# Requires Docker, xz, git and roughly 10 GB of free disk space.
 
-for cmd in docker xz; do
+for cmd in docker xz git; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "$cmd is required" >&2
     exit 1

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -27,3 +27,4 @@ runcmd:
   - [bash, -c, 'usermod -aG docker pi']
   - [bash, -c, 'touch /opt/sugarkube/.cloudflared.env']
   - [bash, -c, 'chown -R pi:pi /opt/sugarkube']
+  - [systemctl, enable, --now, docker]

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -33,12 +33,35 @@ def test_requires_xz(tmp_path):
     assert "xz is required" in result.stderr
 
 
+def test_requires_git(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    for name, content in {
+        "docker": "#!/bin/sh\nexit 0\n",
+        "xz": "#!/bin/sh\nexit 0\n",
+    }.items():
+        path = fake_bin / name
+        path.write_text(content)
+        path.chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = str(fake_bin)
+    result = subprocess.run(
+        ["/bin/bash", "scripts/build_pi_image.sh"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "git is required" in result.stderr
+
+
 def test_requires_sudo_when_non_root(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     for name, content in {
         "docker": "#!/bin/sh\nexit 0\n",
         "xz": "#!/bin/sh\nexit 0\n",
+        "git": "#!/bin/sh\nexit 0\n",
         "id": "#!/bin/sh\necho 1000\n",
     }.items():
         path = fake_bin / name


### PR DESCRIPTION
## Summary
- check for git in build script and enable Docker at boot via cloud-init
- document prerequisites and start Docker automatically
- record outage for missing git

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-status docs/pi_image_cloudflare.md`


------
https://chatgpt.com/codex/tasks/task_e_68a96748c264832fbcb1be5bed0a103d