### PR TITLE
Add Pi image download helper for cluster onboarding

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -196,3 +196,4 @@ yaml
 kicad
 KiBot
 nonint
+prebuilt

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -18,7 +18,8 @@ projects such as token.place and dspace.
 
 - [ ] Build or download a Raspberry Pi OS image. `scripts/build_pi_image.sh`
       now embeds `scripts/cloud-init/user-data.yaml`, verifies `docker`, `xz`
-      and `git` are installed, and only uses `sudo` when required.
+      and `git` are installed, and only uses `sudo` when required. `scripts/download_pi_image.sh`
+      fetches the latest prebuilt image via the GitHub CLI.
 - [ ] If downloaded, decompress it with `xz -d sugarkube.img.xz`.
 - [ ] (Optional) If building the image manually, place `scripts/cloud-init/user-data.yaml`
       on the SD card's boot partition as `user-data`.

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -17,7 +17,9 @@ This expanded guide walks through building a three-node Raspberry Pi 5 cluster a
 - Internet connection to download images and packages
 
 ## 1. Prepare the OS image
-1. Download `sugarkube.img.xz` from the latest [pi-image workflow run](https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml)
+1. Run `scripts/download_pi_image.sh` to fetch `sugarkube.img.xz` from the latest
+   [pi-image workflow run](https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml),
+   or download it manually from the Actions tab
 2. Optional: verify the checksum with `sha256sum`
 3. Flash the image to a microSD card using Raspberry Pi Imager
    - Set hostname, enable SSH, and create a user with a strong password

--- a/scripts/download_pi_image.sh
+++ b/scripts/download_pi_image.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Download the latest sugarkube Pi image artifact via the GitHub CLI.
+# Requires the GitHub CLI to be authenticated with access to this repository.
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh is required" >&2
+  exit 1
+fi
+
+OUTPUT="${1:-sugarkube.img.xz}"
+
+RUN_ID=$(gh run list --workflow pi-image.yml --branch main --json databaseId -q '.[0].databaseId')
+if [ -z "$RUN_ID" ]; then
+  echo "no pi-image workflow runs found" >&2
+  exit 1
+fi
+
+dirname=$(dirname "$OUTPUT")
+mkdir -p "$dirname"
+
+gh run download "$RUN_ID" --name sugarkube-img --dir "$dirname"
+
+mv "$dirname/sugarkube.img.xz" "$OUTPUT"
+ls -lh "$OUTPUT"
+echo "Image saved to $OUTPUT"

--- a/tests/download_pi_image_test.py
+++ b/tests/download_pi_image_test.py
@@ -1,0 +1,56 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_requires_gh(tmp_path):
+    env = os.environ.copy()
+    env["PATH"] = str(tmp_path)
+    base = Path(__file__).resolve().parents[1]
+    script = base / "scripts" / "download_pi_image.sh"
+    result = subprocess.run(
+        ["/bin/bash", str(script)],
+        env=env,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "gh is required" in result.stderr
+
+
+def test_downloads_artifact(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    src = tmp_path / "src.img.xz"
+    src.write_text("data")
+    gh = fake_bin / "gh"
+    gh.write_text(
+        "#!/bin/bash\n"
+        'if [ "$1" = run ] && [ "$2" = list ]; then\n'
+        "  echo 42\n"
+        'elif [ "$1" = run ] && [ "$2" = download ]; then\n'
+        "  shift 2\n"
+        '  while [ "$1" != --dir ]; do shift; done\n'
+        "  dir=$2\n"
+        '  cp "$GH_SRC" "$dir/sugarkube.img.xz"\n'
+        "else\n"
+        "  exit 1\n"
+        "fi\n"
+    )
+    gh.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["GH_SRC"] = str(src)
+    base = Path(__file__).resolve().parents[1]
+    script = base / "scripts" / "download_pi_image.sh"
+    result = subprocess.run(
+        ["/bin/bash", str(script), "out.img.xz"],
+        env=env,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert (tmp_path / "out.img.xz").exists()


### PR DESCRIPTION
## Summary
- add script to fetch latest Pi image via GitHub CLI
- document download step for three-node Pi cluster setup
- cover helper with tests and allow "prebuilt" in wordlist

## Testing
- pre-commit run --all-files
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ae3e092344832fa60e75879694c696