### PR TITLE
docs: clarify Pi image download and k3s cluster onboarding

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -170,6 +170,7 @@ cloudflared
 SSD
 cloudflare
 subdomain
+prebuilt
 preconfigure
 preloaded
 Dockerfile

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -12,13 +12,17 @@ defaulting to `bookworm` for reproducible builds. Ensure `docker`, `xz` and
 `git` are installed before running it. Use the prepared image to deploy
 containerized apps. The companion guide
 [docker_repo_walkthrough.md](docker_repo_walkthrough.md) explains how to run
-projects such as token.place and dspace.
+projects such as token.place and dspace. Use the resulting image to bootstrap a
+three-node k3s cluster; see [raspi_cluster_setup.md](raspi_cluster_setup.md)
+for onboarding steps.
 
 ## Checklist
 
 - [ ] Build or download a Raspberry Pi OS image. `scripts/build_pi_image.sh`
       now embeds `scripts/cloud-init/user-data.yaml`, verifies `docker`, `xz`
       and `git` are installed, and only uses `sudo` when required.
+- [ ] Fetch the latest prebuilt image with `gh run download -n pi-image` or
+      grab it from the Actions tab.
 - [ ] If downloaded, decompress it with `xz -d sugarkube.img.xz`.
 - [ ] (Optional) If building the image manually, place `scripts/cloud-init/user-data.yaml`
       on the SD card's boot partition as `user-data`.

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -17,10 +17,12 @@ This expanded guide walks through building a three-node Raspberry Pi 5 cluster a
 - Internet connection to download images and packages
 
 ## 1. Prepare the OS image
-1. Download `sugarkube.img.xz` from the latest [pi-image workflow run](https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml)
+1. Download `sugarkube.img.xz` from the latest
+   [pi-image workflow run](https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml)
+   or build it locally with `./scripts/build_pi_image.sh`
 2. Optional: verify the checksum with `sha256sum`
 3. Flash the image to a microSD card using Raspberry Pi Imager
-   - Set hostname, enable SSH, and create a user with a strong password
+   - Set a unique hostname, enable SSH, and create a user with a strong password
    - Use <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd> to enter advanced options and configure WiFi SSID, password, and locale
    - The same image can be reused for all nodes
 
@@ -53,6 +55,8 @@ Follow the steps above for each node so every Pi boots from its own SSD.
    ```bash
    sudo kubectl get nodes
    ```
+5. (Optional) Copy `/etc/rancher/k3s/k3s.yaml` to your workstation for remote
+   `kubectl` access.
 
 ## 6. Deploy applications
 1. Clone the repositories:


### PR DESCRIPTION
what: cross-link pi image build to raspi cluster setup, note gh run download
why: streamline onboarding for new three-node k3s clusters
how to test: pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68ae3e092344832fa60e75879694c696