### PR TITLE
Add checksum for Pi image and clarify cluster onboarding

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -19,6 +19,7 @@ projects such as token.place and dspace.
 - [ ] Build or download a Raspberry Pi OS image. `scripts/build_pi_image.sh`
       now embeds `scripts/cloud-init/user-data.yaml`, verifies `docker`, `xz`
       and `git` are installed, and only uses `sudo` when required.
+- [ ] Verify the download: `sha256sum -c sugarkube.img.xz.sha256`.
 - [ ] If downloaded, decompress it with `xz -d sugarkube.img.xz`.
 - [ ] (Optional) If building the image manually, place `scripts/cloud-init/user-data.yaml`
       on the SD card's boot partition as `user-data`.

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -18,9 +18,9 @@ This expanded guide walks through building a three-node Raspberry Pi 5 cluster a
 
 ## 1. Prepare the OS image
 1. Download `sugarkube.img.xz` from the latest [pi-image workflow run](https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml)
-2. Optional: verify the checksum with `sha256sum`
+2. Verify the checksum: `sha256sum -c sugarkube.img.xz.sha256`
 3. Flash the image to a microSD card using Raspberry Pi Imager
-   - Set hostname, enable SSH, and create a user with a strong password
+   - Set a unique hostname (e.g., `sugar-01`, `sugar-02`, `sugar-03`), enable SSH, and create a user with a strong password
    - Use <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd> to enter advanced options and configure WiFi SSID, password, and locale
    - The same image can be reused for all nodes
 

--- a/outages/2025-08-23-kicad-export-unknown-file-type.json
+++ b/outages/2025-08-23-kicad-export-unknown-file-type.json
@@ -9,4 +9,3 @@
     "PYTHONPATH=/usr/lib/python3/dist-packages kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml"
   ]
 }
-

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -39,5 +39,8 @@ CFG
 ${SUDO} ./build.sh
 mv deploy/*.img "${REPO_ROOT}/sugarkube.img"
 xz -T0 "${REPO_ROOT}/sugarkube.img"
-ls -lh "${REPO_ROOT}/sugarkube.img.xz"
+sha256sum "${REPO_ROOT}/sugarkube.img.xz" > \
+  "${REPO_ROOT}/sugarkube.img.xz.sha256"
+ls -lh "${REPO_ROOT}/sugarkube.img.xz" \
+  "${REPO_ROOT}/sugarkube.img.xz.sha256"
 echo "Image written to ${REPO_ROOT}/sugarkube.img.xz"


### PR DESCRIPTION
## Summary
- add SHA256 output to Pi image build script
- document checksum verification and unique hostnames for three-node k3s clusters
- normalize outage log newline for pre-commit

## Testing
- `pre-commit run --all-files`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*
- `detect-secrets scan $(git diff --name-only --cached)`

------
https://chatgpt.com/codex/tasks/task_e_68ae3e092344832fa60e75879694c696