### PR TITLE
📝 tidy whitespace in pi image setup doc

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -20,8 +20,8 @@ for onboarding steps.
 
 - [ ] Build or download a Raspberry Pi OS image. `scripts/build_pi_image.sh`
       now embeds `scripts/cloud-init/user-data.yaml`, verifies `docker`, `xz`
-      and `git` are installed, and only uses `sudo` when required. 
-      `scripts/download_pi_image.sh` fetches the latest prebuilt image via the GitHub CLI, 
+      and `git` are installed, and only uses `sudo` when required.
+      `scripts/download_pi_image.sh` fetches the latest prebuilt image via the GitHub CLI,
       or you can grab it from the Actions tab with `gh run download -n pi-image`.
 - [ ] Verify the download: `sha256sum -c sugarkube.img.xz.sha256`.
 - [ ] If downloaded, decompress it with `xz -d sugarkube.img.xz`.


### PR DESCRIPTION
## Summary
- remove trailing spaces in `pi_image_cloudflare` guide

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68ae8cd55500832fbe9fa4fb289c28f2