### PR TITLE
Add polarity reminder to power ring schematic

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -20,8 +20,8 @@ for onboarding steps.
 
 - [ ] Build or download a Raspberry Pi OS image. `scripts/build_pi_image.sh`
       now embeds `scripts/cloud-init/user-data.yaml`, verifies `docker`, `xz`
-      and `git` are installed, and only uses `sudo` when required. 
-      `scripts/download_pi_image.sh` fetches the latest prebuilt image via the GitHub CLI, 
+      and `git` are installed, and only uses `sudo` when required.
+      `scripts/download_pi_image.sh` fetches the latest prebuilt image via the GitHub CLI,
       or you can grab it from the Actions tab with `gh run download -n pi-image`.
 - [ ] Verify the download: `sha256sum -c sugarkube.img.xz.sha256`.
 - [ ] If downloaded, decompress it with `xz -d sugarkube.img.xz`.

--- a/elex/power_ring/README.md
+++ b/elex/power_ring/README.md
@@ -10,8 +10,9 @@ Included files:
 - `power_ring.kicad_sym` and `power_ring_schlib.kicad_sym` – symbol libraries
 - `power_ring.pretty/` – footprint library
 
-A title block comment reminds you to place decoupling capacitors near power pins, and
-a second note encourages keeping high-current traces short for better performance.
+A title block comment reminds you to place decoupling capacitors near power pins,
+a second note encourages keeping high-current traces short for better performance,
+and a third note urges labeling polarity on connectors to avoid wiring mistakes.
 
 Open the project in **KiCad 9** or newer and modify the schematic to suit your power distribution needs (for example, add screw terminals, fuses and test points).  Use [KiBot](https://github.com/INTI-CMNB/KiBot) with `.kibot/power_ring.yaml` or run the GitHub workflow to produce Gerber files, a PDF schematic and a BOM in `build/power_ring/`.
 

--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -7,6 +7,7 @@
         (title_block
                 (comment 1 "Place decoupling capacitors near power pins")
                 (comment 2 "Keep high-current traces short")
+                (comment 3 "Label polarity on connectors")
         )
         (lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/outages/2025-08-27-kicad-export-pcbnew-missing.json
+++ b/outages/2025-08-27-kicad-export-pcbnew-missing.json
@@ -1,0 +1,10 @@
+{
+  "id": "kicad-export-pcbnew-missing-20250827",
+  "date": "2025-08-27",
+  "component": "kicad-export",
+  "rootCause": "kibot failed: cannot import pcbnew Python module; KiCad not installed",
+  "resolution": "Install KiCad 9+ with Python bindings so pcbnew module is available to KiBot",
+  "references": [
+    "kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml"
+  ]
+}

--- a/outages/2025-08-27-scan-secrets-missing.json
+++ b/outages/2025-08-27-scan-secrets-missing.json
@@ -1,0 +1,10 @@
+{
+  "id": "scan-secrets-missing-20250827",
+  "date": "2025-08-27",
+  "component": "security-scan",
+  "rootCause": "scripts/scan-secrets.py not found; credential scan unavailable",
+  "resolution": "Add scan-secrets.py to scripts/ or update instructions to use available tool",
+  "references": [
+    "git diff --cached | ./scripts/scan-secrets.py"
+  ]
+}


### PR DESCRIPTION
## Summary
- note connector polarity in power ring schematic and docs
- record missing KiCad and scan-secrets tooling gaps

## Testing
- `kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml` *(fails: pcbnew module missing)*
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68ae8cc0a764832facb95df27f511885