### PR TITLE
📝 docs: verify docker service before container builds

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -2,7 +2,7 @@
 
 This guide shows how to run any GitHub project that ships a `Dockerfile` or
 `docker-compose.yml` on the Raspberry Pi image preloaded with Docker and a
-Cloudflare Tunnel. The walkthrough uses
+[Cloudflare Tunnel](https://www.cloudflare.com/products/tunnel/). The walkthrough uses
 [token.place](https://github.com/futuroptimist/token.place) and
 [dspace](https://github.com/democratizedspace/dspace) as real-world examples,
 but the steps apply to any repository.
@@ -15,6 +15,11 @@ but the steps apply to any repository.
    ```sh
    sudo apt update && sudo apt upgrade -y
    sudo reboot
+   ```
+4. Verify Docker is running and the compose plugin is available:
+   ```sh
+   sudo systemctl status docker --no-pager
+   docker compose version
    ```
 
 ## 2. Clone a repository


### PR DESCRIPTION
## Summary
- link Cloudflare Tunnel docs in Docker deployment guide
- add step to confirm Docker service and compose plugin are running

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68ae8cbcd01c832f8c4301c08207d53e