### PR TITLE
docs: expand Docker repo walkthrough

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -11,7 +11,12 @@ but the steps apply to any repository.
 1. Follow [pi_image_cloudflare.md](pi_image_cloudflare.md) to flash the SD card and
    start the Cloudflare Tunnel.
 2. Confirm you can SSH to the Pi: `ssh pi@<hostname>.local`.
-3. Optionally update packages and reboot:
+3. Ensure the Cloudflare Tunnel container is running:
+   ```sh
+   docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml ps
+   ```
+   `cloudflared` should display `Up`.
+4. Optionally update packages and reboot:
    ```sh
    sudo apt update && sudo apt upgrade -y
    sudo reboot
@@ -27,6 +32,11 @@ but the steps apply to any repository.
    git clone https://github.com/democratizedspace/dspace.git
    ```
    Replace the URLs with any other repository that contains a `Dockerfile`.
+   If you prefer the GitHub CLI:
+   ```sh
+   gh repo clone futuroptimist/token.place
+   gh repo clone democratizedspace/dspace
+   ```
 3. Review the project's README for architecture-specific notes and required
    environment variables.
 

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -20,8 +20,8 @@ for onboarding steps.
 
 - [ ] Build or download a Raspberry Pi OS image. `scripts/build_pi_image.sh`
       now embeds `scripts/cloud-init/user-data.yaml`, verifies `docker`, `xz`
-      and `git` are installed, and only uses `sudo` when required. 
-      `scripts/download_pi_image.sh` fetches the latest prebuilt image via the GitHub CLI, 
+      and `git` are installed, and only uses `sudo` when required.
+      `scripts/download_pi_image.sh` fetches the latest prebuilt image via the GitHub CLI,
       or you can grab it from the Actions tab with `gh run download -n pi-image`.
 - [ ] Verify the download: `sha256sum -c sugarkube.img.xz.sha256`.
 - [ ] If downloaded, decompress it with `xz -d sugarkube.img.xz`.


### PR DESCRIPTION
what: add tunnel check and gh clone snippet to Docker repo guide; trim trailing whitespace in pi_image_cloudflare.md
why: ensure Pi users verify Cloudflare and have gh alternative
how to test: pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68ae8cba21e4832f9acf6c3e19cc4813