### PR TITLE
🧪 : expand Pi image download tests

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -20,8 +20,8 @@ for onboarding steps.
 
 - [ ] Build or download a Raspberry Pi OS image. `scripts/build_pi_image.sh`
       now embeds `scripts/cloud-init/user-data.yaml`, verifies `docker`, `xz`
-      and `git` are installed, and only uses `sudo` when required. 
-      `scripts/download_pi_image.sh` fetches the latest prebuilt image via the GitHub CLI, 
+      and `git` are installed, and only uses `sudo` when required.
+      `scripts/download_pi_image.sh` fetches the latest prebuilt image via the GitHub CLI,
       or you can grab it from the Actions tab with `gh run download -n pi-image`.
 - [ ] Verify the download: `sha256sum -c sugarkube.img.xz.sha256`.
 - [ ] If downloaded, decompress it with `xz -d sugarkube.img.xz`.

--- a/scripts/download_pi_image.sh
+++ b/scripts/download_pi_image.sh
@@ -21,7 +21,9 @@ dirname=$(dirname "$OUTPUT")
 mkdir -p "$dirname"
 
 gh run download "$RUN_ID" --name sugarkube-img --dir "$dirname"
-
-mv "$dirname/sugarkube.img.xz" "$OUTPUT"
+downloaded="$dirname/sugarkube.img.xz"
+if [ "$(basename "$OUTPUT")" != "sugarkube.img.xz" ]; then
+  mv "$downloaded" "$OUTPUT"
+fi
 ls -lh "$OUTPUT"
 echo "Image saved to $OUTPUT"

--- a/tests/download_pi_image_test.py
+++ b/tests/download_pi_image_test.py
@@ -54,3 +54,74 @@ def test_downloads_artifact(tmp_path):
     )
     assert result.returncode == 0
     assert (tmp_path / "out.img.xz").exists()
+
+
+def test_errors_when_no_run_found(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "download_called"
+    gh = fake_bin / "gh"
+    gh.write_text(
+        f"#!/bin/bash\n"
+        'if [ "$1" = run ] && [ "$2" = list ]; then\n'
+        "  exit 0\n"
+        'elif [ "$1" = run ] && [ "$2" = download ]; then\n'
+        f"  echo called > {marker}\n"
+        "  exit 0\n"
+        "else\n"
+        "  exit 1\n"
+        "fi\n"
+    )
+    gh.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = str(fake_bin)
+    base = Path(__file__).resolve().parents[1]
+    script = base / "scripts" / "download_pi_image.sh"
+    result = subprocess.run(
+        ["/bin/bash", str(script)],
+        env=env,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "no pi-image workflow runs found" in result.stderr
+    assert not marker.exists()
+
+
+def test_uses_default_output(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    src = tmp_path / "src.img.xz"
+    src.write_text("data")
+    gh = fake_bin / "gh"
+    gh.write_text(
+        "#!/bin/bash\n"
+        'if [ "$1" = run ] && [ "$2" = list ]; then\n'
+        "  echo 42\n"
+        'elif [ "$1" = run ] && [ "$2" = download ]; then\n'
+        "  shift 2\n"
+        '  while [ "$1" != --dir ]; do shift; done\n'
+        "  dir=$2\n"
+        '  cp "$GH_SRC" "$dir/sugarkube.img.xz"\n'
+        "else\n"
+        "  exit 1\n"
+        "fi\n"
+    )
+    gh.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["GH_SRC"] = str(src)
+    base = Path(__file__).resolve().parents[1]
+    script = base / "scripts" / "download_pi_image.sh"
+    result = subprocess.run(
+        ["/bin/bash", str(script)],
+        env=env,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert (tmp_path / "sugarkube.img.xz").exists()


### PR DESCRIPTION
what: cover missing runs and default output in download_pi_image.sh
why: ensure helpful failures and skip redundant mv
how to test: pytest && pre-commit run --all-files
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68ae8cef2460832f801bef644a914e13