### PR TITLE
docs: add upgrade prompts to codex prompt docs

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -198,3 +198,7 @@ kicad
 KiBot
 nonint
 prebuilt
+
+linkchecker
+pyspelling
+sugarkube's

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -20,8 +20,8 @@ for onboarding steps.
 
 - [ ] Build or download a Raspberry Pi OS image. `scripts/build_pi_image.sh`
       now embeds `scripts/cloud-init/user-data.yaml`, verifies `docker`, `xz`
-      and `git` are installed, and only uses `sudo` when required. 
-      `scripts/download_pi_image.sh` fetches the latest prebuilt image via the GitHub CLI, 
+      and `git` are installed, and only uses `sudo` when required.
+      `scripts/download_pi_image.sh` fetches the latest prebuilt image via the GitHub CLI,
       or you can grab it from the Actions tab with `gh run download -n pi-image`.
 - [ ] Verify the download: `sha256sum -c sugarkube.img.xz.sha256`.
 - [ ] If downloaded, decompress it with `xz -d sugarkube.img.xz`.

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -33,3 +33,24 @@ REQUEST:
 OUTPUT:
 A pull request summarizing the CAD changes and confirming the render commands succeed.
 ```
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine sugarkube's own prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the sugarkube repository.
+Follow `AGENTS.md` and `README.md`.
+Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
+`linkchecker --no-warnings README.md docs/` before committing.
+
+USER:
+1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
+2. Fix outdated instructions, links, or formatting.
+3. Run the commands above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```

--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -28,3 +28,24 @@ REQUEST:
 OUTPUT:
 A pull request describing the fix and showing passing checks.
 ```
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine sugarkube's own prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the sugarkube repository.
+Follow `AGENTS.md` and `README.md`.
+Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
+`linkchecker --no-warnings README.md docs/` before committing.
+
+USER:
+1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
+2. Fix outdated instructions, links, or formatting.
+3. Run the commands above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```

--- a/docs/prompts-codex-docker-repo.md
+++ b/docs/prompts-codex-docker-repo.md
@@ -29,3 +29,24 @@ REQUEST:
 OUTPUT:
 A pull request with passing checks and a concise summary.
 ```
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine sugarkube's own prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the sugarkube repository.
+Follow `AGENTS.md` and `README.md`.
+Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
+`linkchecker --no-warnings README.md docs/` before committing.
+
+USER:
+1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
+2. Fix outdated instructions, links, or formatting.
+3. Run the commands above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```

--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -29,3 +29,24 @@ REQUEST:
 OUTPUT:
 A pull request with the refined documentation and passing checks.
 ```
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine sugarkube's own prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the sugarkube repository.
+Follow `AGENTS.md` and `README.md`.
+Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
+`linkchecker --no-warnings README.md docs/` before committing.
+
+USER:
+1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
+2. Fix outdated instructions, links, or formatting.
+3. Run the commands above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```

--- a/docs/prompts-codex-elex.md
+++ b/docs/prompts-codex-elex.md
@@ -30,3 +30,24 @@ REQUEST:
 OUTPUT:
 A pull request summarizing electronics updates and confirming KiBot export.
 ```
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine sugarkube's own prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the sugarkube repository.
+Follow `AGENTS.md` and `README.md`.
+Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
+`linkchecker --no-warnings README.md docs/` before committing.
+
+USER:
+1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
+2. Fix outdated instructions, links, or formatting.
+3. Run the commands above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```

--- a/docs/prompts-codex-pi-image.md
+++ b/docs/prompts-codex-pi-image.md
@@ -29,3 +29,24 @@ REQUEST:
 OUTPUT:
 A pull request with passing checks and a concise summary.
 ```
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine sugarkube's own prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the sugarkube repository.
+Follow `AGENTS.md` and `README.md`.
+Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
+`linkchecker --no-warnings README.md docs/` before committing.
+
+USER:
+1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
+2. Fix outdated instructions, links, or formatting.
+3. Run the commands above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```

--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -27,3 +27,24 @@ REQUEST:
 OUTPUT:
 A pull request summarizing the corrections and confirming passing checks.
 ```
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine sugarkube's own prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the sugarkube repository.
+Follow `AGENTS.md` and `README.md`.
+Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
+`linkchecker --no-warnings README.md docs/` before committing.
+
+USER:
+1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
+2. Fix outdated instructions, links, or formatting.
+3. Run the commands above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```

--- a/docs/prompts-codex-tests.md
+++ b/docs/prompts-codex-tests.md
@@ -28,3 +28,24 @@ REQUEST:
 OUTPUT:
 A pull request describing the test improvements and confirming checks pass.
 ```
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine sugarkube's own prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the sugarkube repository.
+Follow `AGENTS.md` and `README.md`.
+Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
+`linkchecker --no-warnings README.md docs/` before committing.
+
+USER:
+1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
+2. Fix outdated instructions, links, or formatting.
+3. Run the commands above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -31,3 +31,24 @@ REQUEST:
 OUTPUT:
 A pull request describing the change and summarizing test results.
 ```
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine sugarkube's own prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the sugarkube repository.
+Follow `AGENTS.md` and `README.md`.
+Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
+`linkchecker --no-warnings README.md docs/` before committing.
+
+USER:
+1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
+2. Fix outdated instructions, links, or formatting.
+3. Run the commands above.
+
+OUTPUT:
+A pull request with the improved prompt doc and passing checks.
+```


### PR DESCRIPTION
## Summary
- add Upgrade Prompt sections to all codex prompt docs

## Testing
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68ae8d1d66dc832fa83b141f0bbc9060