### PR TITLE
🛠️ : – guard pi-image build prerequisites

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -8,8 +8,8 @@ Raspberry Pi deployment so it can host multiple projects such as
 It bakes Docker, the compose plugin, the Cloudflare apt repository, and a
 Cloudflare Tunnel into the OS image using `cloud-init`. The `build_pi_image.sh`
 script clones `pi-gen` using the `PI_GEN_BRANCH` environment variable,
-defaulting to `bookworm` for reproducible builds. Ensure `docker`, `xz` and
-`git` are installed before running it. Use the prepared image to deploy
+defaulting to `bookworm` for reproducible builds. Ensure `docker`, `xz`, `git`,
+and `sha256sum` are installed before running it. Use the prepared image to deploy
 containerized apps. The companion guide
 [docker_repo_walkthrough.md](docker_repo_walkthrough.md) explains how to run
 projects such as token.place and dspace. Use the resulting image to bootstrap a
@@ -19,9 +19,9 @@ for onboarding steps.
 ## Checklist
 
 - [ ] Build or download a Raspberry Pi OS image. `scripts/build_pi_image.sh`
-      now embeds `scripts/cloud-init/user-data.yaml`, verifies `docker`, `xz`
-      and `git` are installed, and only uses `sudo` when required. 
-      `scripts/download_pi_image.sh` fetches the latest prebuilt image via the GitHub CLI, 
+      now embeds `scripts/cloud-init/user-data.yaml`, verifies `docker`, `xz`,
+      `git`, and `sha256sum` are installed, and only uses `sudo` when required.
+      `scripts/download_pi_image.sh` fetches the latest prebuilt image via the GitHub CLI,
       or you can grab it from the Actions tab with `gh run download -n pi-image`.
 - [ ] Verify the download: `sha256sum -c sugarkube.img.xz.sha256`.
 - [ ] If downloaded, decompress it with `xz -d sugarkube.img.xz`.
@@ -30,8 +30,9 @@ for onboarding steps.
 - [ ] Flash the image with Raspberry Pi Imager.
 - [ ] Boot the Pi and run `sudo rpi-clone sda -f` to copy the OS to an SSD.
 - [ ] Cloud-init adds the Cloudflare apt repo, writes
-      `/opt/sugarkube/docker-compose.cloudflared.yml`, and enables the Docker
-      service; verify all three.
+      `/opt/sugarkube/docker-compose.cloudflared.yml`, pre-creates
+      `/opt/sugarkube/.cloudflared.env` with `0600` permissions, and enables the
+      Docker service; verify all three.
 - [ ] Add your Cloudflare token to `/opt/sugarkube/.cloudflared.env`.
 - [ ] Start the tunnel with `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml up -d`.
 - [ ] Confirm the tunnel is running: `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml ps` should show `cloudflared` as `Up`.

--- a/outages/2025-08-27-pi-image-build-sha256sum-missing.json
+++ b/outages/2025-08-27-pi-image-build-sha256sum-missing.json
@@ -1,0 +1,10 @@
+{
+  "id": "pi-image-build-sha256sum-missing",
+  "date": "2025-08-27",
+  "component": "pi-image build script",
+  "rootCause": "build_pi_image.sh failed when sha256sum was absent because it wasn't checked",
+  "resolution": "script now verifies sha256sum is installed before running",
+  "references": [
+    "scripts/build_pi_image.sh"
+  ]
+}

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 # Build a Raspberry Pi OS image with cloud-init files preloaded.
-# Requires Docker, xz, git and roughly 10 GB of free disk space.
+# Requires Docker, xz, git, sha256sum and roughly 10 GB of free disk space.
 
-for cmd in docker xz git; do
+for cmd in docker xz git sha256sum; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "$cmd is required" >&2
     exit 1

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -23,8 +23,11 @@ write_files:
           command: tunnel run
           env_file:
             - /opt/sugarkube/.cloudflared.env
+  - path: /opt/sugarkube/.cloudflared.env
+    permissions: '0600'
+    content: |
+      TUNNEL_TOKEN=""
 runcmd:
   - [bash, -c, 'usermod -aG docker pi']
-  - [bash, -c, 'touch /opt/sugarkube/.cloudflared.env']
   - [bash, -c, 'chown -R pi:pi /opt/sugarkube']
   - [systemctl, enable, --now, docker]

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -64,6 +64,7 @@ def test_requires_sudo_when_non_root(tmp_path):
         "docker": "#!/bin/sh\nexit 0\n",
         "xz": "#!/bin/sh\nexit 0\n",
         "git": "#!/bin/sh\nexit 0\n",
+        "sha256sum": "#!/bin/sh\nexit 0\n",
         "id": "#!/bin/sh\necho 1000\n",
     }.items():
         path = fake_bin / name


### PR DESCRIPTION
what: require sha256sum and pre-create cloudflared token file
why: prevent build failures and streamline tunnel setup
how to test: pre-commit run --all-files
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68ae8cc198d0832f83ec59669e3f6ef8