### PR TITLE
🐛 : – support directory outputs in image downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ pre-commit install
 pre-commit run --all-files
 ```
 
+Fetch the latest pre-built Pi image with the GitHub CLI:
+
+```bash
+scripts/download_pi_image.sh      # saves as ./sugarkube.img.xz
+scripts/download_pi_image.sh out/ # saves to out/sugarkube.img.xz
+```
+
+Authenticate `gh` with access to the repository before running the script.
+
 If you update documentation, install spell-check tools and verify spelling and links.
 `pyspelling` relies on `aspell` and an English dictionary (`aspell-en`). The
 `scripts/checks.sh` helper tries to install them via `apt-get` when missing. pre-commit

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -20,8 +20,8 @@ for onboarding steps.
 
 - [ ] Build or download a Raspberry Pi OS image. `scripts/build_pi_image.sh`
       now embeds `scripts/cloud-init/user-data.yaml`, verifies `docker`, `xz`
-      and `git` are installed, and only uses `sudo` when required. 
-      `scripts/download_pi_image.sh` fetches the latest prebuilt image via the GitHub CLI, 
+      and `git` are installed, and only uses `sudo` when required.
+      `scripts/download_pi_image.sh` fetches the latest prebuilt image via the GitHub CLI,
       or you can grab it from the Actions tab with `gh run download -n pi-image`.
 - [ ] Verify the download: `sha256sum -c sugarkube.img.xz.sha256`.
 - [ ] If downloaded, decompress it with `xz -d sugarkube.img.xz`.

--- a/scripts/download_pi_image.sh
+++ b/scripts/download_pi_image.sh
@@ -10,6 +10,9 @@ if ! command -v gh >/dev/null 2>&1; then
 fi
 
 OUTPUT="${1:-sugarkube.img.xz}"
+if [ -d "$OUTPUT" ] || [[ "$OUTPUT" == */ ]]; then
+  OUTPUT="${OUTPUT%/}/sugarkube.img.xz"
+fi
 
 RUN_ID=$(gh run list --workflow pi-image.yml --branch main --json databaseId -q '.[0].databaseId')
 if [ -z "$RUN_ID" ]; then
@@ -22,6 +25,9 @@ mkdir -p "$dirname"
 
 gh run download "$RUN_ID" --name sugarkube-img --dir "$dirname"
 
-mv "$dirname/sugarkube.img.xz" "$OUTPUT"
+src="$dirname/sugarkube.img.xz"
+if [ "$src" != "$OUTPUT" ]; then
+  mv "$src" "$OUTPUT"
+fi
 ls -lh "$OUTPUT"
 echo "Image saved to $OUTPUT"

--- a/tests/download_pi_image_test.py
+++ b/tests/download_pi_image_test.py
@@ -54,3 +54,42 @@ def test_downloads_artifact(tmp_path):
     )
     assert result.returncode == 0
     assert (tmp_path / "out.img.xz").exists()
+
+
+def test_accepts_directory_output(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    src = tmp_path / "src.img.xz"
+    src.write_text("data")
+    gh = fake_bin / "gh"
+    gh.write_text(
+        "#!/bin/bash\n"
+        'if [ "$1" = run ] && [ "$2" = list ]; then\n'
+        "  echo 42\n"
+        'elif [ "$1" = run ] && [ "$2" = download ]; then\n'
+        "  shift 2\n"
+        '  while [ "$1" != --dir ]; do shift; done\n'
+        "  dir=$2\n"
+        '  cp "$GH_SRC" "$dir/sugarkube.img.xz"\n'
+        "else\n"
+        "  exit 1\n"
+        "fi\n"
+    )
+    gh.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["GH_SRC"] = str(src)
+    base = Path(__file__).resolve().parents[1]
+    script = base / "scripts" / "download_pi_image.sh"
+    outdir = tmp_path / "images"
+    outdir.mkdir()
+    result = subprocess.run(
+        ["/bin/bash", str(script), str(outdir)],
+        env=env,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert (outdir / "sugarkube.img.xz").exists()


### PR DESCRIPTION
what: allow download_pi_image.sh to accept directories; doc and test
why: avoid mv same file error when saving to directory
how to test: pre-commit run --all-files

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68ae8cf5fc10832f90c6fcb8ea20b632