### PR TITLE
🛠️ : – add pi-gen dependencies to pi-image workflow

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install pi-gen dependencies
+        run: sudo apt-get update && sudo apt-get install -y \
+          quilt qemu-user-static debootstrap libarchive-tools arch-test
       - name: Build Raspberry Pi OS image
         run: sudo ./scripts/build_pi_image.sh
       - name: Compress image

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -20,37 +20,31 @@ projects such as token.place and dspace. Use the resulting image to bootstrap a
 three-node k3s cluster; see [raspi_cluster_setup.md](raspi_cluster_setup.md)
 for onboarding steps.
 
-## Checklist
+## Steps
 
-- [ ] Build or download a Raspberry Pi OS image. `scripts/build_pi_image.sh`
-      embeds `scripts/cloud-init/user-data.yaml`, verifies `docker` (and its
-      daemon is running), `xz`, `git`, and `sha256sum` are installed, honors
-      `IMG_NAME` and `OUTPUT_DIR`, and only uses `sudo` when required.
-      `scripts/download_pi_image.sh` fetches the latest prebuilt image via the
-      GitHub CLI, or you can grab it from the Actions tab with
-      `gh run download -n pi-image`.
-- [ ] Verify the download: `sha256sum -c sugarkube.img.xz.sha256`.
-- [ ] If downloaded, decompress it with `xz -d sugarkube.img.xz`.
-- [ ] (Optional) If building the image manually, place `scripts/cloud-init/user-data.yaml`
-      on the SD card's boot partition as `user-data`.
-- [ ] Flash the image with Raspberry Pi Imager.
-- [ ] Boot the Pi and run `sudo rpi-clone sda -f` to copy the OS to an SSD.
-- [ ] Cloud-init adds the Cloudflare apt repo, writes
-      `/opt/sugarkube/docker-compose.cloudflared.yml`, pre-creates
-      `/opt/sugarkube/.cloudflared.env` with `0600` permissions, and enables the
-      Docker service; verify all three.
-- [ ] Add your Cloudflare token to `/opt/sugarkube/.cloudflared.env`.
-- [ ] Start the tunnel with `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml up -d`.
-- [ ] Confirm the tunnel is running: `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml ps` should show `cloudflared` as `Up`.
-- [ ] View the tunnel logs to confirm a connection:
-      `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml logs -f`.
-- [ ] Clone target projects:
-  - [ ] `git clone https://github.com/futuroptimist/token.place.git`
-  - [ ] `git clone https://github.com/democratizedspace/dspace.git`
-- [ ] Add more `docker-compose` files for additional services.
+1. Download the latest prebuilt Sugarkube Raspberry Pi OS image from the
+   [pi-image workflow artifacts](https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml)
+   and verify it: `sha256sum -c sugarkube.img.xz.sha256`.
+2. Flash the image with Raspberry Pi Imager. Open the tool, choose **Use custom**,
+   browse for the downloaded file, and write it to your SD card.
+3. Boot the Pi and run `sudo rpi-clone sda -f` to copy the OS to an SSD.
+4. Cloud-init adds the Cloudflare apt repo, writes
+   `/opt/sugarkube/docker-compose.cloudflared.yml`, pre-creates
+   `/opt/sugarkube/.cloudflared.env` with `0600` permissions, and enables the
+   Docker service; verify all three.
+5. Add your Cloudflare token to `/opt/sugarkube/.cloudflared.env`.
+6. Start the tunnel with `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml up -d`.
+7. Confirm the tunnel is running: `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml ps` should show `cloudflared` as `Up`.
+8. View the tunnel logs to confirm a connection:
+   `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml logs -f`.
+9. Clone target projects:
+   - `git clone https://github.com/futuroptimist/token.place.git`
+   - `git clone https://github.com/democratizedspace/dspace.git`
+10. Add more `docker-compose` files for additional services.
 
 ## GitHub Actions
 
 The `pi-image` workflow builds the OS image with `scripts/build_pi_image.sh`,
 compresses it to `sugarkube.img.xz`, and uploads it as an artifact. Download it
-from the Actions tab or run the script locally if you need customizations.
+from the [workflow artifacts](https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml)
+or run the script locally if you need customizations.


### PR DESCRIPTION
## Summary
- replace Cloudflare pi image checklist with numbered steps
- link directly to pi-image workflow artifacts
- install pi-gen dependencies in pi-image workflow to avoid missing packages

## Testing
- `pre-commit run --all-files`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68afea826650832f99af5646924591e5