### PR TITLE
🛠️ : fix pi-image apt dependency install

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -9,8 +9,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install pi-gen dependencies
-        run: sudo apt-get update && sudo apt-get install -y \
-          quilt qemu-user-static debootstrap libarchive-tools arch-test
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y quilt qemu-user-static debootstrap libarchive-tools arch-test
       - name: Build Raspberry Pi OS image
         run: sudo ./scripts/build_pi_image.sh
       - name: Compress image


### PR DESCRIPTION
what: use multiline run block to install pi-gen dependencies
why: single-line command left stray backslash, so apt couldn't find quilt
how to test: pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68afed070900832fa390ca42d9e12c9d