### PR TITLE
🔧: enable universe repo for pi-image

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -9,8 +9,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install pi-gen dependencies
-        run: sudo apt-get update && sudo apt-get install -y \
-          quilt qemu-user-static debootstrap libarchive-tools arch-test
+        run: |
+          sudo add-apt-repository -y universe
+          sudo apt-get update
+          sudo apt-get install -y \
+            quilt qemu-user-static debootstrap libarchive-tools arch-test
       - name: Build Raspberry Pi OS image
         run: sudo ./scripts/build_pi_image.sh
       - name: Compress image

--- a/outages/2025-08-28-pi-image-quilt-missing.json
+++ b/outages/2025-08-28-pi-image-quilt-missing.json
@@ -1,0 +1,10 @@
+{
+  "id": "pi-image-quilt-missing",
+  "date": "2025-08-28",
+  "component": "pi-image workflow",
+  "rootCause": "pi-image workflow failed to install quilt because the universe repo was not enabled",
+  "resolution": "workflow enables the universe repository before installing dependencies",
+  "references": [
+    ".github/workflows/pi-image.yml"
+  ]
+}


### PR DESCRIPTION
what: add universe repo to pi-image workflow so quilt installs
why: fix CI apt failure
how to test: pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68afed070900832fa390ca42d9e12c9d