### PR TITLE
🧹 : streamline pi-image workflow

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -12,12 +12,12 @@ jobs:
         run: |
           sudo add-apt-repository -y universe
           sudo apt-get update
-          sudo apt-get install -y \
-            quilt qemu-user-static debootstrap libarchive-tools arch-test
+          sudo apt-get install -y --no-install-recommends \
+            quilt qemu-user-static debootstrap libarchive-tools
       - name: Build Raspberry Pi OS image
+        env:
+          ARM64: 1
         run: sudo ./scripts/build_pi_image.sh
-      - name: Compress image
-        run: xz -9 --keep sugarkube.img
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -35,6 +35,7 @@ trap 'rm -rf "${WORK_DIR}"' EXIT
 PI_GEN_BRANCH="${PI_GEN_BRANCH:-bookworm}"
 IMG_NAME="${IMG_NAME:-sugarkube}"
 OUTPUT_DIR="${OUTPUT_DIR:-${REPO_ROOT}}"
+ARM64="${ARM64:-1}"
 
 git clone --depth 1 --branch "${PI_GEN_BRANCH}" \
   https://github.com/RPi-Distro/pi-gen.git "${WORK_DIR}/pi-gen"
@@ -44,6 +45,7 @@ cd "${WORK_DIR}/pi-gen"
 cat > config <<CFG
 IMG_NAME="${IMG_NAME}"
 ENABLE_SSH=1
+ARM64=${ARM64}
 CFG
 ${SUDO} ./build.sh
 mv deploy/*.img "${OUTPUT_DIR}/${IMG_NAME}.img"


### PR DESCRIPTION
## Summary
- drop duplicate compression and arch-test from pi-image workflow
- default build script to ARM64 for Raspberry Pi 5

## Testing
- `scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aff95a83b8832f82e9a1feef3da526