### PR TITLE
Add arch-test dependency for pi image workflow

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -13,7 +13,7 @@ jobs:
           sudo add-apt-repository -y universe
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            quilt qemu-user-static debootstrap libarchive-tools
+            quilt qemu-user-static debootstrap libarchive-tools arch-test
       - name: Build Raspberry Pi OS image
         env:
           ARM64: 1


### PR DESCRIPTION
## Summary
- include arch-test in pi-image GitHub workflow to satisfy pi-gen dependencies

## Testing
- `pre-commit run --all-files`
- `detect-secrets scan /tmp/diff.patch`


------
https://chatgpt.com/codex/tasks/task_e_68affaeb3938832f87c4dc8905506a84