### PR TITLE
⚡ speed up pi-image workflow

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -8,11 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Enable universe repository
+        run: sudo add-apt-repository -y universe
       - name: Install pi-gen dependencies
-        run: |
-          sudo add-apt-repository -y universe
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >-
             quilt qemu-user-static debootstrap libarchive-tools arch-test
       - name: Build Raspberry Pi OS image
         env:

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -49,7 +49,8 @@ ARM64=${ARM64}
 CFG
 ${SUDO} ./build.sh
 mv deploy/*.img "${OUTPUT_DIR}/${IMG_NAME}.img"
-xz -T0 "${OUTPUT_DIR}/${IMG_NAME}.img"
+# Use a faster xz compression level to reduce build time
+xz -T0 -3 "${OUTPUT_DIR}/${IMG_NAME}.img"
 sha256sum "${OUTPUT_DIR}/${IMG_NAME}.img.xz" > \
   "${OUTPUT_DIR}/${IMG_NAME}.img.xz.sha256"
 ls -lh "${OUTPUT_DIR}/${IMG_NAME}.img.xz" \

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -91,7 +91,11 @@ def _setup_build_env(tmp_path):
     (fake_bin / "docker").chmod(0o755)
 
     xz = fake_bin / "xz"
-    xz.write_text('#!/bin/bash\n[ "$1" = "-T0" ] && shift\nmv "$1" "$1.xz"\n')
+    xz.write_text(
+        "#!/bin/bash\n"
+        'while [ "${1#-}" != "$1" ]; do shift; done\n'
+        'mv "$1" "$1.xz"\n'
+    )
     xz.chmod(0o755)
 
     git_stub = (


### PR DESCRIPTION
## Summary
- cache pi-gen dependencies to avoid repeated apt downloads
- compress image with faster xz level

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68affef14278832f84542b1ddd0c0944