### PR TITLE
♻️ : – rotate pi-gen cache monthly

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -23,12 +23,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             quilt qemu-user-static debootstrap libarchive-tools arch-test
+      - name: Compute pi-gen cache key
+        id: pigen-key
+        run: |
+          ref=$(git ls-remote https://github.com/RPi-Distro/pi-gen.git refs/heads/bookworm | cut -f1)
+          echo "key=pigen-${RUNNER_OS}-bookworm-${ref}-$(date +'%Y-%m')" >> "$GITHUB_OUTPUT"
       - name: Restore pi-gen Docker image
         id: cache-pigen
         uses: actions/cache@v4
         with:
           path: ~/cache/pi-gen.tar
-          key: pigen-${{ runner.os }}-bookworm
+          key: ${{ steps.pigen-key.outputs.key }}
       - name: Load cached pi-gen image
         if: steps.cache-pigen.outputs.cache-hit == 'true'
         run: docker load -i ~/cache/pi-gen.tar

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -47,4 +47,6 @@ for onboarding steps.
 The `pi-image` workflow builds the OS image with `scripts/build_pi_image.sh`,
 compresses it to `sugarkube.img.xz`, and uploads it as an artifact. Download it
 from the [workflow artifacts](https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml)
-or run the script locally if you need customizations.
+or run the script locally if you need customizations. The workflow rotates its
+cached pi-gen Docker image monthly by hashing the upstream branch, ensuring each
+build pulls in the latest security updates.


### PR DESCRIPTION
what: hash upstream pi-gen commit and month in cache key; doc rotation
why: ensure images rebuild with latest security fixes
how to test: pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b0016a294c832f963b086be7b34fe3