### PR TITLE
chore: improve pi-image workflows and helpers

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -2,47 +2,133 @@ name: pi-image
 
 on:
   workflow_dispatch:
+    inputs:
+      pi_model:
+        description: 'Pi model to build'
+        type: choice
+        options: [all, pi5, pi4]
+        default: all
+      standoff_mode:
+        description: 'Standoff mode'
+        type: choice
+        options: [all, heatset, printed]
+        default: all
+      pi_gen_branch:
+        description: 'pi-gen branch'
+        default: bookworm
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pi_model: >-
+          ${{ fromJSON(inputs.pi_model == 'all' && '["pi5","pi4"]' || format('["{0}"]', inputs.pi_model)) }}
+        standoff_mode: >-
+          ${{ fromJSON(inputs.standoff_mode == 'all' && '["heatset","printed"]' || format('["{0}"]', inputs.standoff_mode)) }}
+    env:
+      PI_GEN_BRANCH: ${{ inputs.pi_gen_branch || 'bookworm' }}
     steps:
       - uses: actions/checkout@v4
-      - name: Prepare APT cache
+      - id: prereqs
+        name: Check prerequisites
+        run: ./scripts/check_prereqs.sh
+      - name: Determine environment keys
+        id: env
         run: |
-          sudo mkdir -p /var/cache/apt/archives
-          sudo chown -R "$USER" /var/cache/apt/archives
-      - name: Restore APT cache
-        uses: actions/cache@v4
+          echo "os_codename=$(lsb_release -sc)" >> $GITHUB_OUTPUT
+      - name: Resolve pi-gen revision
+        id: pigen-ref
+        run: |
+          echo "rev=$(git ls-remote https://github.com/RPi-Distro/pi-gen.git ${{ env.PI_GEN_BRANCH }} | cut -f1)" >> $GITHUB_OUTPUT
+      - name: Restore APT caches
+        id: cache-apt
+        uses: actions/cache/restore@v4
         with:
-          path: /var/cache/apt/archives
-          key: ${{ runner.os }}-apt-${{ hashFiles('.github/workflows/pi-image.yml') }}
+          path: |
+            /var/cache/apt/archives
+            ~/.cache/apt
+          key: apt-${{ steps.env.outputs.os_codename }}-${{ steps.pigen-ref.outputs.rev }}
+          restore-keys: |
+            apt-${{ steps.env.outputs.os_codename }}-
       - name: Install pi-gen dependencies
         run: |
           sudo add-apt-repository -y universe
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             quilt qemu-user-static debootstrap libarchive-tools arch-test
+      - name: Save APT cache
+        if: steps.cache-apt.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            /var/cache/apt/archives
+            ~/.cache/apt
+          key: apt-${{ steps.env.outputs.os_codename }}-${{ steps.pigen-ref.outputs.rev }}
       - name: Restore pi-gen Docker image
         id: cache-pigen
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ~/cache/pi-gen.tar
-          key: pigen-${{ runner.os }}-bookworm
+          key: pigen-${{ runner.os }}-${{ env.PI_GEN_BRANCH }}
       - name: Load cached pi-gen image
         if: steps.cache-pigen.outputs.cache-hit == 'true'
         run: docker load -i ~/cache/pi-gen.tar
+      - name: Restore pi-gen work cache
+        id: cache-work
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/pi-gen/work
+          key: work-${{ steps.env.outputs.os_codename }}-${{ steps.pigen-ref.outputs.rev }}
+          restore-keys: |
+            work-${{ steps.env.outputs.os_codename }}-
       - name: Build Raspberry Pi OS image
+        id: build
         env:
           ARM64: 1
+          PI_GEN_DIR: ~/pi-gen
+          IMG_NAME: pi-image-${{ matrix.pi_model }}-${{ matrix.standoff_mode }}
+          STANDOFF_MODE: ${{ matrix.standoff_mode }}
         run: sudo ./scripts/build_pi_image.sh
       - name: Save pi-gen Docker image
         if: steps.cache-pigen.outputs.cache-hit != 'true'
         run: |
           mkdir -p ~/cache
           docker image save pi-gen:latest -o ~/cache/pi-gen.tar
+      - name: Save pi-gen work cache
+        if: steps.cache-work.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/pi-gen/work
+          key: work-${{ steps.env.outputs.os_codename }}-${{ steps.pigen-ref.outputs.rev }}
+      - name: Generate manifest
+        run: |
+          cat <<MANIFEST > manifest.json
+          {
+            "pi_model": "${{ matrix.pi_model }}",
+            "standoff_mode": "${{ matrix.standoff_mode }}",
+            "pi_gen_branch": "${{ env.PI_GEN_BRANCH }}",
+            "git_sha": "${{ github.sha }}",
+            "build_time_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          MANIFEST
       - name: Upload artifact
+        id: upload
         uses: actions/upload-artifact@v4
         with:
-          name: sugarkube-img
-          path: sugarkube.img.xz
+          name: pi-image-${{ matrix.pi_model }}-${{ matrix.standoff_mode }}-${{ github.sha }}
+          path: |
+            pi-image-${{ matrix.pi_model }}-${{ matrix.standoff_mode }}.img.xz
+            pi-image-${{ matrix.pi_model }}-${{ matrix.standoff_mode }}.img.xz.sha256
+            manifest.json
+      - name: Summary
+        if: always()
+        run: |
+          echo "prereqs: ${{ steps.prereqs.outcome }}"
+          echo "build: ${{ steps.build.outcome }}"
+          echo "upload: ${{ steps.upload.outcome }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,11 +15,13 @@ jobs:
           python-version: '3.x'
       - name: Install dependencies
         run: |
-          uv pip install --system pytest pytest-cov coverage
+          uv pip install --system pytest pytest-cov coverage requests-mock
           if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
       - name: Run tests with coverage
         run: |
-          pytest --cov=. --cov-report=xml --cov-report=term --maxfail=1 --disable-warnings -q
+          PYTHONPATH=$PYTHONPATH:$(pwd) pytest --cov=scripts/download_latest_image.py \
+            --cov-report=xml --cov-report=term --cov-fail-under=85 --maxfail=1 \
+            --disable-warnings -q
       - name: Upload coverage
         if: hashFiles('coverage.xml') != ''
         uses: codecov/codecov-action@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,20 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.2
+    hooks:
+      - id: ruff
+      - id: ruff-format
+  - repo: https://github.com/adamchainz/pyproject-fmt
+    rev: 0.9.1
+    hooks:
+      - id: pyproject-fmt
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        files: '\.(yml|yaml|md)$'
   - repo: local
     hooks:
       - id: run-checks
@@ -21,6 +35,7 @@ repos:
           - pyspelling
           - linkchecker
           - requests
+          - requests-mock
           - Flask
           - responses
         pass_filenames: false

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -203,3 +203,4 @@ prebuilt
 linkchecker
 pyspelling
 sugarkube's
+Quickstart

--- a/README.md
+++ b/README.md
@@ -18,8 +18,23 @@ Hanging baskets can clip onto the frame so the installation is surrounded by gre
 ### What's in a name?
 
 "Sugarkube" refers to both the aluminium cube covered in solar panels **and**
-the helper scripts that provide "syntactic sugar" for Kubernetes.  Throughout
+the helper scripts that provide "syntactic sugar" for Kubernetes. Throughout
 the docs you will see the term used in both contexts.
+
+## Quickstart: build on GitHub Actions
+
+Use the `pi-image` workflow to build Raspberry Pi OS images in CI.
+From the repository page select **Actions → pi-image → Run workflow**, then
+choose the `pi_model` (`pi5` or `pi4`) and `standoff_mode` (`heatset` or
+`printed`).
+
+Each matrix build uploads artifacts named
+`pi-image-<pi_model>-<standoff_mode>-<git_sha>` containing the image, a
+`manifest.json` and a `.sha256` checksum. Verify downloads with:
+
+```bash
+sha256sum -c *.sha256
+```
 
 ## Repository layout
 

--- a/docs/pi_image_build.md
+++ b/docs/pi_image_build.md
@@ -1,0 +1,26 @@
+# Pi image build
+
+## Quickstart: build on GitHub Actions
+
+1. Go to **Actions → pi-image → Run workflow**.
+2. Pick the `pi_model` (`pi5` or `pi4`) and `standoff_mode` (`heatset` or `printed`).
+3. Run the workflow. Each build uploads an artifact named
+   `pi-image-<pi_model>-<standoff_mode>-<git_sha>` containing:
+   - `pi-image-<pi_model>-<standoff_mode>.img.xz`
+   - `pi-image-<pi_model>-<standoff_mode>.img.xz.sha256`
+   - `manifest.json` with build metadata.
+
+Verify the image after download:
+
+```bash
+sha256sum -c *.sha256
+```
+
+### Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| Docker daemon is not running | Start Docker and retry |
+| Missing `universe` repo | `sudo add-apt-repository -y universe` |
+| Cache not restored | Check cache key and rerun with same commit |
+| GitHub API rate limit | Set `GITHUB_TOKEN` or wait before retrying |

--- a/scripts/check_prereqs.sh
+++ b/scripts/check_prereqs.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+err=0
+
+# Check Docker daemon
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker command not found" >&2
+  err=1
+elif ! docker info >/dev/null 2>&1; then
+  echo "Docker daemon is not running or not accessible" >&2
+  err=1
+fi
+
+# Check arch-test
+if ! command -v arch-test >/dev/null 2>&1; then
+  echo "arch-test is required. Install with: sudo apt-get install arch-test" >&2
+  err=1
+fi
+
+# Ensure universe repo enabled
+if ! grep -R "^[^#].*universe" /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null | head -n1 >/dev/null; then
+  echo "APT 'universe' repository not enabled. Run: sudo add-apt-repository -y universe" >&2
+  err=1
+fi
+
+# Check free disk space (>15GB)
+avail_kb=$(df --output=avail -k . | tail -n1)
+if [ "$avail_kb" -lt $((15 * 1024 * 1024)) ]; then
+  echo "Insufficient disk space. Need at least 15GB free" >&2
+  err=1
+fi
+
+if [ "$err" -ne 0 ]; then
+  exit 1
+fi

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -36,7 +36,7 @@ if [ -f package.json ]; then
 fi
 
 # run tests
-pytest --cov=. --cov-report=xml --cov-report=term -q
+PYTHONPATH="${PYTHONPATH:-}:$(pwd)" pytest -q
 
 # docs checks
 if ! command -v aspell >/dev/null 2>&1; then

--- a/scripts/download_latest_image.py
+++ b/scripts/download_latest_image.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Download the latest pi-image artifact from GitHub."""
+
+import argparse
+import fnmatch
+import hashlib
+import io
+import os
+import sys
+import time
+import zipfile
+from datetime import datetime, timezone
+
+import requests
+
+API = "https://api.github.com"
+
+
+def _request(
+    session: requests.Session, method: str, url: str, **kwargs
+) -> requests.Response:
+    for attempt in range(6):
+        resp = session.request(method, url, **kwargs)
+        if resp.status_code < 500 and resp.status_code not in (429, 403):
+            return resp
+        time.sleep(2**attempt)
+    resp.raise_for_status()
+    return resp
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default="futuroptimist/sugarkube")
+    parser.add_argument("--workflow", default="pi-image.yml")
+    parser.add_argument("--artifact-pattern", default="*.img.xz")
+    parser.add_argument("--max-age-hours", type=int, default=24)
+    args = parser.parse_args(argv)
+
+    token = os.getenv("GITHUB_TOKEN")
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    with requests.Session() as session:
+        session.headers.update(headers)
+        base = f"{API}/repos/{args.repo}/actions/workflows/"
+        runs_url = f"{base}{args.workflow}/runs"
+        runs_resp = _request(
+            session,
+            "GET",
+            runs_url,
+            params={"per_page": 1, "status": "success"},
+        )
+        runs = runs_resp.json().get("workflow_runs", [])
+        if not runs:
+            print("no successful workflow runs found", file=sys.stderr)
+            return 1
+        run = runs[0]
+        ts = run["updated_at"].rstrip("Z")
+        updated = datetime.fromisoformat(ts).replace(tzinfo=timezone.utc)
+        delta = datetime.now(timezone.utc) - updated
+        age_hours = delta.total_seconds() / 3600
+        if age_hours > args.max_age_hours:
+            print("latest run too old", file=sys.stderr)
+            return 1
+
+        arts_resp = _request(session, "GET", run["artifacts_url"])
+        artifacts = arts_resp.json().get("artifacts", [])
+        target = None
+        for art in artifacts:
+            if fnmatch.fnmatch(f"{art['name']}.img.xz", args.artifact_pattern):
+                target = art
+                break
+        if not target:
+            print("no artifact matched pattern", file=sys.stderr)
+            return 1
+
+        download_resp = _request(
+            session, "GET", target["archive_download_url"], stream=True
+        )
+        zf = zipfile.ZipFile(io.BytesIO(download_resp.content))
+        img_name = None
+        sha_file = None
+        for name in zf.namelist():
+            if name.endswith(".img.xz") and fnmatch.fnmatch(
+                name, args.artifact_pattern
+            ):
+                img_name = name
+            elif name.endswith(".sha256"):
+                sha_file = name
+        if not img_name or not sha_file:
+            print("artifact missing image or checksum", file=sys.stderr)
+            return 1
+        zf.extract(img_name)
+        zf.extract(sha_file)
+        with open(img_name, "rb") as f:
+            digest = hashlib.sha256(f.read()).hexdigest()
+        with open(sha_file, "r", encoding="utf-8") as f:
+            recorded = f.read().split()[0]
+        if digest != recorded:
+            print("checksum mismatch", file=sys.stderr)
+            return 1
+        print(f"{img_name} {digest}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/test_download_latest_image.py
+++ b/tests/test_download_latest_image.py
@@ -1,0 +1,98 @@
+import hashlib
+import io
+import sys
+import zipfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+import scripts.download_latest_image as download_latest_image  # noqa: E402
+
+API = "https://api.github.com"
+REPO = "futuroptimist/sugarkube"
+WORKFLOW = "pi-image.yml"
+
+
+def _zip_bytes(filename: str, content: bytes, sha_file: str) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr(filename, content)
+        digest = hashlib.sha256(content).hexdigest()
+        z.writestr(sha_file, f"{digest}  {filename}\n")
+    return buf.getvalue()
+
+
+def test_no_runs_exits_nonzero(requests_mock):
+    requests_mock.get(
+        f"{API}/repos/{REPO}/actions/workflows/{WORKFLOW}/runs",
+        json={"workflow_runs": []},
+    )
+    assert download_latest_image.main([]) == 1
+
+
+def test_no_artifact_match(requests_mock):
+    now = datetime.now(timezone.utc).isoformat()
+    run = {
+        "id": 1,
+        "updated_at": now,
+        "artifacts_url": f"{API}/run/1/artifacts",
+    }
+    requests_mock.get(
+        f"{API}/repos/{REPO}/actions/workflows/{WORKFLOW}/runs",
+        json={"workflow_runs": [run]},
+    )
+    requests_mock.get(
+        run["artifacts_url"],
+        json={"artifacts": [{"name": "other", "archive_download_url": "url"}]},
+    )
+    pattern = ["--artifact-pattern", "pi-image-*.img.xz"]
+    assert download_latest_image.main(pattern) == 1
+
+
+def test_too_old_run_respects_max_age(requests_mock):
+    old = (datetime.now(timezone.utc) - timedelta(hours=5)).isoformat()
+    run = {
+        "id": 2,
+        "updated_at": old,
+        "artifacts_url": f"{API}/run/2/artifacts",
+    }
+    requests_mock.get(
+        f"{API}/repos/{REPO}/actions/workflows/{WORKFLOW}/runs",
+        json={"workflow_runs": [run]},
+    )
+    assert download_latest_image.main(["--max-age-hours", "1"]) == 1
+
+
+def test_success_downloads_and_validates_checksum(
+    tmp_path, requests_mock, capsys, monkeypatch
+):
+    content = b"data"
+    zip_bytes = _zip_bytes(
+        "pi-image-pi5-heatset.img.xz",
+        content,
+        "pi-image-pi5-heatset.img.xz.sha256",
+    )
+    now = datetime.now(timezone.utc).isoformat()
+    run = {
+        "id": 3,
+        "updated_at": now,
+        "artifacts_url": f"{API}/run/3/artifacts",
+    }
+    art = {
+        "name": "pi-image-pi5-heatset-123",
+        "archive_download_url": f"{API}/artifact/3.zip",
+    }
+    requests_mock.get(
+        f"{API}/repos/{REPO}/actions/workflows/{WORKFLOW}/runs",
+        json={"workflow_runs": [run]},
+    )
+    requests_mock.get(run["artifacts_url"], json={"artifacts": [art]})
+    requests_mock.get(art["archive_download_url"], content=zip_bytes)
+    monkeypatch.chdir(tmp_path)
+    assert download_latest_image.main([]) == 0
+    out = capsys.readouterr().out.strip()
+    digest = hashlib.sha256(content).hexdigest()
+    assert out == f"pi-image-pi5-heatset.img.xz {digest}"
+    assert (tmp_path / "pi-image-pi5-heatset.img.xz").exists()
+    assert (tmp_path / "pi-image-pi5-heatset.img.xz.sha256").exists()


### PR DESCRIPTION
## Summary
- matrix and cached pi-image workflow with manifest artifacts
- add robust GitHub artifact downloader with tests
- document artifact naming and quickstart

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68b002b39328832f9307b9bf833df3f2