### PR TITLE
🧹: – prune runner for pi-image build

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -8,18 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Prepare APT cache
-        run: |
-          sudo mkdir -p /var/cache/apt/archives
-          sudo chown -R "$USER" /var/cache/apt/archives
-      - name: Restore APT cache
-        uses: actions/cache@v4
         with:
-          path: /var/cache/apt/archives
-          key: ${{ runner.os }}-apt-${{ hashFiles('.github/workflows/pi-image.yml') }}
+          fetch-depth: 1
+      - name: Free up disk space
+        run: |
+          sudo apt-get clean
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache /usr/local/lib/node_modules \
+            /usr/local/share/boost
+          docker system prune -af || true
+          df -h
       - name: Install pi-gen dependencies
         run: |
-          sudo add-apt-repository -y universe
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             quilt qemu-user-static debootstrap libarchive-tools arch-test


### PR DESCRIPTION
what: drop apt cache steps and prune hosted tool cache in pi-image workflow
why: reclaim disk space so pi image builds succeed on GitHub Actions
how to test: pre-commit run --all-files

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b0c3be980c832fa59c707ef21a79ce