### PR TITLE
🧹 : clean apt cache in pi-image workflow

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -23,6 +23,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             quilt qemu-user-static debootstrap libarchive-tools arch-test
+      - name: Clean up apt cache and temp files
+        run: |
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/*
+          sudo rm -rf /tmp/*
       - name: Compute pi-gen cache key
         id: pigen-key
         run: |


### PR DESCRIPTION
## Summary
- free pi-image runner disk by clearing apt cache and temp files after dependency install

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68b0da00df20832fb7b55cefa6d97f40