### PR TITLE
🐛 : default to arm64 branch for 64-bit Pi image builds

### DIFF
--- a/outages/2025-08-28-pi-image-build-passwd-io-error.json
+++ b/outages/2025-08-28-pi-image-build-passwd-io-error.json
@@ -1,0 +1,10 @@
+{
+  "id": "pi-image-build-passwd-io-error",
+  "date": "2025-08-28",
+  "component": "pi-image build script",
+  "rootCause": "pi-gen built both 32-bit and 64-bit images by default, exhausting disk space and causing useradd to fail writing /etc/passwd",
+  "resolution": "build script now selects the arm64 branch for 64-bit builds to avoid duplicate architectures",
+  "references": [
+    "scripts/build_pi_image.sh"
+  ]
+}

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -32,10 +32,18 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 WORK_DIR=$(mktemp -d)
 trap 'rm -rf "${WORK_DIR}"' EXIT
 
-PI_GEN_BRANCH="${PI_GEN_BRANCH:-bookworm}"
+ARM64="${ARM64:-1}"
+# Clone the arm64 branch when building 64-bit images to avoid generating
+# both architectures and exhausting disk space.
+if [ -z "${PI_GEN_BRANCH:-}" ]; then
+  if [ "$ARM64" -eq 1 ]; then
+    PI_GEN_BRANCH="arm64"
+  else
+    PI_GEN_BRANCH="bookworm"
+  fi
+fi
 IMG_NAME="${IMG_NAME:-sugarkube}"
 OUTPUT_DIR="${OUTPUT_DIR:-${REPO_ROOT}}"
-ARM64="${ARM64:-1}"
 
 git clone --depth 1 --branch "${PI_GEN_BRANCH}" \
   https://github.com/RPi-Distro/pi-gen.git "${WORK_DIR}/pi-gen"

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -146,9 +146,18 @@ def _run_build_script(tmp_path, env):
 
 def test_uses_default_pi_gen_branch(tmp_path):
     env = _setup_build_env(tmp_path)
+    env["ARM64"] = "0"
     result, git_args = _run_build_script(tmp_path, env)
     assert result.returncode == 0
     assert "--branch bookworm" in git_args
+    assert (tmp_path / "sugarkube.img.xz").exists()
+
+
+def test_arm64_build_uses_arm64_branch(tmp_path):
+    env = _setup_build_env(tmp_path)
+    result, git_args = _run_build_script(tmp_path, env)
+    assert result.returncode == 0
+    assert "--branch arm64" in git_args
     assert (tmp_path / "sugarkube.img.xz").exists()
 
 


### PR DESCRIPTION
what: ensure build_pi_image.sh selects arm64 branch for 64-bit builds and log outage
why: building both arches exhausted disk space and broke useradd during image export
how to test: scripts/checks.sh
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68b0e20aeff8832fa15a344959c7b8a0