### PR TITLE
🔧 : – ensure pi-image workflow uses arm64 cache

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      ARM64: 1
+      DEBIAN_FRONTEND: noninteractive
     steps:
       - uses: actions/checkout@v4
         with:
@@ -31,8 +34,12 @@ jobs:
       - name: Compute pi-gen cache key
         id: pigen-key
         run: |
-          ref=$(git ls-remote https://github.com/RPi-Distro/pi-gen.git refs/heads/bookworm | cut -f1)
-          echo "key=pigen-${RUNNER_OS}-bookworm-${ref}-$(date +'%Y-%m')" >> "$GITHUB_OUTPUT"
+          branch=bookworm
+          if [ "$ARM64" = "1" ]; then
+            branch=arm64
+          fi
+          ref=$(git ls-remote https://github.com/RPi-Distro/pi-gen.git "refs/heads/${branch}" | cut -f1)
+          echo "key=pigen-${RUNNER_OS}-${branch}-${ref}-$(date +'%Y-%m')" >> "$GITHUB_OUTPUT"
       - name: Restore pi-gen Docker image
         id: cache-pigen
         uses: actions/cache@v4
@@ -43,8 +50,6 @@ jobs:
         if: steps.cache-pigen.outputs.cache-hit == 'true'
         run: docker load -i ~/cache/pi-gen.tar
       - name: Build Raspberry Pi OS image
-        env:
-          ARM64: 1
         run: sudo ./scripts/build_pi_image.sh
       - name: Save pi-gen Docker image
         if: steps.cache-pigen.outputs.cache-hit != 'true'

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -50,6 +50,7 @@ git clone --depth 1 --branch "${PI_GEN_BRANCH}" \
 cp "${REPO_ROOT}/scripts/cloud-init/user-data.yaml" \
   "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/user-data"
 cd "${WORK_DIR}/pi-gen"
+export DEBIAN_FRONTEND=noninteractive
 cat > config <<CFG
 IMG_NAME="${IMG_NAME}"
 ENABLE_SSH=1


### PR DESCRIPTION
## What
- cache pi-gen using correct branch
- force noninteractive apt to avoid hangs

## Why
- image builds stalled in CI

## How to Test
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68b10eb0d828832fa12fff1b10c2b393