### PR TITLE
📚 : refresh CAD prompt instructions

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -203,3 +203,11 @@ prebuilt
 linkchecker
 pyspelling
 sugarkube's
+PowerShell
+WSL
+localhostForwarding
+powershell
+vmIdleTimeout
+wsl
+wslconfig
+GPT

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -1,9 +1,9 @@
 ---
-title: 'Sugarkube Codex CAD Prompt'
+title: 'Sugarkube CAD Prompt'
 slug: 'prompts-codex-cad'
 ---
 
-# OpenAI Codex CAD Prompt
+# OpenAI GPT CAD Prompt
 
 Use this prompt whenever 3D models need updating or verification.
 
@@ -26,8 +26,11 @@ REQUEST:
 1. Inspect `cad/*.scad` for todo comments or needed adjustments.
 2. Modify geometry or parameters as required.
 3. Render the model via:
-   bash scripts/openscad_render.sh <path/to.scad> # defaults to heatset
-   STANDOFF_MODE=printed bash scripts/openscad_render.sh <path/to.scad> # case-insensitive
+
+   ```bash
+   bash scripts/openscad_render.sh path/to/model.scad # defaults to heatset
+   STANDOFF_MODE=printed bash scripts/openscad_render.sh path/to/model.scad # case-insensitive
+   ```
 4. Commit updated SCAD sources and any documentation.
 
 OUTPUT:


### PR DESCRIPTION
what: clarify CAD prompt and modernize instructions
why: codex reference was outdated; code block was misformatted
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/

------
https://chatgpt.com/codex/tasks/task_e_68b11c38ebec832f8eb2ecfa31727474