### PR TITLE
docs: clarify CAD rendering prompt

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -203,3 +203,11 @@ prebuilt
 linkchecker
 pyspelling
 sugarkube's
+
+wsl
+wslconfig
+WSL
+PowerShell
+powershell
+localhostForwarding
+vmIdleTimeout

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -7,7 +7,7 @@ slug: 'prompts-codex-cad'
 
 Use this prompt whenever 3D models need updating or verification.
 
-```
+```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository focused on 3D assets.
 
@@ -26,8 +26,9 @@ REQUEST:
 1. Inspect `cad/*.scad` for todo comments or needed adjustments.
 2. Modify geometry or parameters as required.
 3. Render the model via:
-   bash scripts/openscad_render.sh <path/to.scad> # defaults to heatset
-   STANDOFF_MODE=printed bash scripts/openscad_render.sh <path/to.scad> # case-insensitive
+    ./scripts/openscad_render.sh path/to/model.scad # heatset (default)
+    STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad # case-insensitive
+
 4. Commit updated SCAD sources and any documentation.
 
 OUTPUT:

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -20,7 +20,7 @@ This expanded guide walks through building a three-node Raspberry Pi 5 cluster a
 1. Run `scripts/download_pi_image.sh` to fetch `sugarkube.img.xz` from the latest
    [pi-image workflow run](https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml),
    or download it manually from the Actions tab.
-   
+
    Alternatively, build locally:
    - Linux/macOS: `./scripts/build_pi_image.sh`
    - Windows (PowerShell):
@@ -35,7 +35,7 @@ This expanded guide walks through building a three-node Raspberry Pi 5 cluster a
      # vmIdleTimeout=7200
      # Then apply and rerun build:
      wsl --shutdown
-     
+
      # Build the image
      powershell -ExecutionPolicy Bypass -File .\scripts\build_pi_image.ps1
      ```

--- a/scripts/build_pi_image.ps1
+++ b/scripts/build_pi_image.ps1
@@ -323,5 +323,3 @@ finally {
     try { Remove-Item -Recurse -Force -- $workDir } catch { }
   }
 }
-
-


### PR DESCRIPTION
## Summary
- document explicit script usage for CAD renderings
- add spellcheck entries for WSL and PowerShell terms
- normalize whitespace in related docs and scripts

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68b11c940eb8832fb2cbee381647a57e