### PR TITLE
🔒 : – verify Pi image checksums on download

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -203,3 +203,10 @@ prebuilt
 linkchecker
 pyspelling
 sugarkube's
+PowerShell
+WSL
+localhostForwarding
+powershell
+vmIdleTimeout
+wsl
+wslconfig

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -18,9 +18,11 @@ This expanded guide walks through building a three-node Raspberry Pi 5 cluster a
 
 ## 1. Prepare the OS image
 1. Run `scripts/download_pi_image.sh` to fetch `sugarkube.img.xz` from the latest
-   [pi-image workflow run](https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml),
-   or download it manually from the Actions tab.
-   
+   [pi-image workflow run](https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml).
+   The script verifies the SHA256 checksum and writes `sugarkube.img.xz.sha256`
+   alongside the image.  Alternatively, download the artifact manually from the
+   Actions tab.
+
    Alternatively, build locally:
    - Linux/macOS: `./scripts/build_pi_image.sh`
    - Windows (PowerShell):
@@ -35,7 +37,7 @@ This expanded guide walks through building a three-node Raspberry Pi 5 cluster a
      # vmIdleTimeout=7200
      # Then apply and rerun build:
      wsl --shutdown
-     
+
      # Build the image
      powershell -ExecutionPolicy Bypass -File .\scripts\build_pi_image.ps1
      ```
@@ -43,7 +45,8 @@ This expanded guide walks through building a three-node Raspberry Pi 5 cluster a
      - Requires Docker Desktop running and Git for Windows installed
      - The script auto-falls back to a Dockerized build and sets up binfmt/qemu
      - Expect 45–120 minutes on Windows; ensure ≥30 GB free disk
-2. Verify the checksum: `sha256sum -c sugarkube.img.xz.sha256`
+2. If you downloaded the image manually, verify the checksum:
+   `sha256sum -c sugarkube.img.xz.sha256`
 3. Flash the image to a microSD card using Raspberry Pi Imager
    - Set a unique hostname (e.g., `sugar-01`, `sugar-02`, `sugar-03`), enable SSH, and create a user with a strong password
    - Use <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd> to enter advanced options and configure WiFi SSID, password, and locale

--- a/scripts/download_pi_image.sh
+++ b/scripts/download_pi_image.sh
@@ -32,9 +32,12 @@ if [ -f "$sha" ]; then
   if [ ! -e "$dest_sha" ] || [ "$(realpath "$sha")" != "$(realpath "$dest_sha")" ]; then
     mv "$sha" "$dest_sha"
   fi
+  base="$(basename "$OUTPUT")"
+  sed -i "s|$(basename "$img")|$base|" "$dest_sha"
 fi
 
 if [ -f "${OUTPUT}.sha256" ]; then
+  sha256sum -c "${OUTPUT}.sha256"
   ls -lh "$OUTPUT" "${OUTPUT}.sha256"
   echo "Image saved to $OUTPUT with checksum ${OUTPUT}.sha256"
 else


### PR DESCRIPTION
what: verify Pi image downloads with sha256sum; document checksum
why: catch corrupted images before flashing
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b11c8344bc832f9c1c1135ad97fe62