### PR TITLE
📝 : – streamline README trellis description and whitelist WSL terms

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -203,3 +203,10 @@ prebuilt
 linkchecker
 pyspelling
 sugarkube's
+PowerShell
+WSL
+localhostForwarding
+powershell
+vmIdleTimeout
+wsl
+wslconfig

--- a/README.md
+++ b/README.md
@@ -8,12 +8,10 @@
 [![license](https://img.shields.io/github/license/futuroptimist/sugarkube)](LICENSE)
 
 An accessible k3s platform for Raspberry Pis and SBCs, integrated with an off-grid solar setup.
-The repository also covers the solar cube art installation,
-which powers aquarium air pumps and small computers.
-The cube also doubles as a living trellis.
-Climbing plants weave through the aluminium extrusions while shade-loving herbs thrive
-beneath the panels.
-Hanging baskets can clip onto the frame so the installation is surrounded by greenery.
+The repository also covers the solar cube art installation, which powers aquarium air pumps and
+small computers. It doubles as a living trellis—climbing plants weave through the aluminium
+extrusions while shade-loving herbs thrive beneath the panels. Hanging baskets can clip onto the
+frame so the installation is surrounded by greenery.
 
 ### What's in a name?
 


### PR DESCRIPTION
## Summary
- clarify README intro by merging duplicate trellis sentences
- whitelist WSL terms so spellcheck passes

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68b11c8344bc832f9c1c1135ad97fe62