### PR TITLE
clarify connector voltage in power_ring schematic

### DIFF
--- a/elex/power_ring/README.md
+++ b/elex/power_ring/README.md
@@ -12,7 +12,7 @@ Included files:
 
 A title block comment reminds you to place decoupling capacitors near power pins,
 a second note encourages keeping high-current traces short for better performance,
-and a third note urges labeling polarity on connectors to avoid wiring mistakes.
+and a third note urges labeling polarity and voltage on connectors to avoid wiring mistakes.
 
 Open the project in **KiCad 9** or newer and modify the schematic to suit your power distribution needs (for example, add screw terminals, fuses and test points).  Use [KiBot](https://github.com/INTI-CMNB/KiBot) with `.kibot/power_ring.yaml` or run the GitHub workflow to produce Gerber files, a PDF schematic and a BOM in `build/power_ring/`.
 

--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -7,7 +7,7 @@
         (title_block
                 (comment 1 "Place decoupling capacitors near power pins")
                 (comment 2 "Keep high-current traces short")
-                (comment 3 "Label polarity on connectors")
+                (comment 3 "Label polarity and voltage on connectors")
         )
         (lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/elex/power_ring/specs.md
+++ b/elex/power_ring/specs.md
@@ -17,6 +17,6 @@ This document outlines the intended features for the Sugarkube power distributio
 
 - Test points for measuring battery voltage
 - Silkscreen labels for polarity and connector numbers
-- Title block comments record decoupling guidelines and export checks
+- Title block comments record decoupling guidelines, connector labeling and export checks
 
 These requirements are a starting point – modify the KiCad project as needed and update this file when the schematic changes.

--- a/outages/2025-08-29-kicad-export-pcbnew-missing.json
+++ b/outages/2025-08-29-kicad-export-pcbnew-missing.json
@@ -1,0 +1,10 @@
+{
+  "id": "kicad-export-pcbnew-missing-20250829",
+  "date": "2025-08-29",
+  "component": "kicad-export",
+  "rootCause": "kibot failed: cannot import pcbnew Python module; KiCad not installed",
+  "resolution": "Install KiCad 9+ with Python bindings so pcbnew module is available to KiBot",
+  "references": [
+    "kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml"
+  ]
+}

--- a/outages/2025-08-29-pre-commit-spellcheck.json
+++ b/outages/2025-08-29-pre-commit-spellcheck.json
@@ -1,0 +1,10 @@
+{
+  "id": "pre-commit-spellcheck-20250829",
+  "date": "2025-08-29",
+  "component": "pre-commit",
+  "rootCause": "pyspelling flagged missing words in docs/raspi_cluster_setup.md",
+  "resolution": "Add spelling exceptions to .wordlist.txt or fix documentation",
+  "references": [
+    "pre-commit run --all-files"
+  ]
+}


### PR DESCRIPTION
## Summary
- note connector voltage in schematic comment and docs
- log KiCad export and pre-commit spellcheck outages

## Testing
- `kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml` (fails: pcbnew missing)
- `pre-commit run --all-files` (fails: pyspelling)


------
https://chatgpt.com/codex/tasks/task_e_68b11c354910832fa52f24731c81b03e