### PR TITLE
Embed Cloudflare compose file in Pi image build

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -203,3 +203,10 @@ prebuilt
 linkchecker
 pyspelling
 sugarkube's
+PowerShell
+powershell
+WSL
+wsl
+wslconfig
+vmIdleTimeout
+localhostForwarding

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -28,10 +28,10 @@ for onboarding steps.
 2. Flash the image with Raspberry Pi Imager. Open the tool, choose **Use custom**,
    browse for the downloaded file, and write it to your SD card.
 3. Boot the Pi and run `sudo rpi-clone sda -f` to copy the OS to an SSD.
-4. Cloud-init adds the Cloudflare apt repo, writes
-   `/opt/sugarkube/docker-compose.cloudflared.yml`, pre-creates
+4. The build script copies `docker-compose.cloudflared.yml` into
+   `/opt/sugarkube/`. Cloud-init adds the Cloudflare apt repo, pre-creates
    `/opt/sugarkube/.cloudflared.env` with `0600` permissions, and enables the
-   Docker service; verify all three.
+   Docker service; verify both files and the service.
 5. Add your Cloudflare token to `/opt/sugarkube/.cloudflared.env`.
 6. Start the tunnel with `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml up -d`.
 7. Confirm the tunnel is running: `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml ps` should show `cloudflared` as `Up`.

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -20,7 +20,7 @@ This expanded guide walks through building a three-node Raspberry Pi 5 cluster a
 1. Run `scripts/download_pi_image.sh` to fetch `sugarkube.img.xz` from the latest
    [pi-image workflow run](https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml),
    or download it manually from the Actions tab.
-   
+
    Alternatively, build locally:
    - Linux/macOS: `./scripts/build_pi_image.sh`
    - Windows (PowerShell):
@@ -35,7 +35,7 @@ This expanded guide walks through building a three-node Raspberry Pi 5 cluster a
      # vmIdleTimeout=7200
      # Then apply and rerun build:
      wsl --shutdown
-     
+
      # Build the image
      powershell -ExecutionPolicy Bypass -File .\scripts\build_pi_image.ps1
      ```

--- a/outages/2025-08-29-pi-image-build-xz-missing.json
+++ b/outages/2025-08-29-pi-image-build-xz-missing.json
@@ -1,0 +1,10 @@
+{
+  "id": "pi-image-build-xz-missing-20250829",
+  "date": "2025-08-29",
+  "component": "pi-image build",
+  "rootCause": "xz utility not installed causing compression step to fail",
+  "resolution": "Install xz so build_pi_image.sh can compress the image",
+  "references": [
+    "scripts/build_pi_image.sh"
+  ]
+}

--- a/scripts/build_pi_image.ps1
+++ b/scripts/build_pi_image.ps1
@@ -323,5 +323,3 @@ finally {
     try { Remove-Item -Recurse -Force -- $workDir } catch { }
   }
 }
-
-

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -49,6 +49,8 @@ git clone --depth 1 --branch "${PI_GEN_BRANCH}" \
   https://github.com/RPi-Distro/pi-gen.git "${WORK_DIR}/pi-gen"
 cp "${REPO_ROOT}/scripts/cloud-init/user-data.yaml" \
   "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/user-data"
+install -Dm644 "${REPO_ROOT}/scripts/cloud-init/docker-compose.cloudflared.yml" \
+  "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/docker-compose.cloudflared.yml"
 cd "${WORK_DIR}/pi-gen"
 export DEBIAN_FRONTEND=noninteractive
 cat > config <<CFG

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -13,16 +13,6 @@ packages:
   - git
   - cloudflared
 write_files:
-  - path: /opt/sugarkube/docker-compose.cloudflared.yml
-    permissions: '0644'
-    content: |
-      services:
-        tunnel:
-          image: cloudflare/cloudflared:latest
-          restart: unless-stopped
-          command: tunnel run
-          env_file:
-            - /opt/sugarkube/.cloudflared.env
   - path: /opt/sugarkube/.cloudflared.env
     permissions: '0600'
     content: |
@@ -30,6 +20,5 @@ write_files:
 runcmd:
   - [bash, -c, 'usermod -aG docker pi']
   - [bash, -c, 'mkdir -p /opt/sugarkube']
-  - [bash, -c, 'touch /opt/sugarkube/.cloudflared.env']
   - [bash, -c, 'chown -R pi:pi /opt/sugarkube']
   - [systemctl, enable, --now, docker]


### PR DESCRIPTION
## Summary
- copy Cloudflare tunnel compose file into Pi image during build
- simplify cloud-init user-data and document new workflow
- record outage for missing xz dependency

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b11c4cb638832f8719728448c4efe0