### PR TITLE
📝 docs: record apt mirror outage

### DIFF
--- a/outages/2025-08-29-pi-image-build-apt-mirror-timeout.json
+++ b/outages/2025-08-29-pi-image-build-apt-mirror-timeout.json
@@ -1,0 +1,11 @@
+{
+  "id": "pi-image-build-apt-mirror-timeout",
+  "date": "2025-08-29",
+  "component": "pi-image build script",
+  "rootCause": "pi-gen failed when mirrors.ocf.berkeley.edu timed out during apt installs",
+  "resolution": "defaulted to raspbian.raspberrypi.com mirror and added retry logic",
+  "references": [
+    "scripts/build_pi_image.ps1",
+    "docs/pi_image_cloudflare.md"
+  ]
+}

--- a/tests/download_pi_image_test.py
+++ b/tests/download_pi_image_test.py
@@ -143,10 +143,10 @@ def test_downloads_without_realpath(tmp_path):
         "  echo 42\n"
         'elif [ "$1" = run ] && [ "$2" = download ]; then\n'
         "  shift 2\n"
-        '  while [ \"$1\" != --dir ]; do shift; done\n'
+        '  while [ "$1" != --dir ]; do shift; done\n'
         "  dir=$2\n"
-        '  cp \"$GH_SRC\" \"$dir/sugarkube.img.xz\"\n'
-        '  cp \"$GH_SHA\" \"$dir/sugarkube.img.xz.sha256\"\n'
+        '  cp "$GH_SRC" "$dir/sugarkube.img.xz"\n'
+        '  cp "$GH_SHA" "$dir/sugarkube.img.xz.sha256"\n'
         "else\n"
         "  exit 1\n"
         "fi\n"


### PR DESCRIPTION
what: document apt mirror timeout during pi-image build
why: capture failure when mirror unreachable
how to test: pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b12f1964b8832fa121d456d17facaf