### PR TITLE
🔧 : harden Pi image builds against mirror timeouts

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -16,6 +16,8 @@ unavailable. Set `IMG_NAME` to change the image name or `OUTPUT_DIR` to control
 where artifacts are written; the script creates the directory if needed. Use
 `CLOUD_INIT_PATH` (or override `CLOUD_INIT_DIR`) to load a custom cloud-init
 configuration instead of the default `scripts/cloud-init/user-data.yaml`.
+To avoid random apt timeouts, the script pins primary Raspberry Pi and Debian
+mirrors and adds retry/timeout options.
 Ensure `docker` (with its daemon running), `xz`, `git`, and `sha256sum` are
 installed before running it. Use the prepared image to deploy containerized
 apps. The companion guide


### PR DESCRIPTION
## Summary
- pin official Raspberry Pi and Debian mirrors with apt retries
- install qemu binfmt handlers to prevent random hangs
- document mirror pinning for reproducible builds

## Testing
- `pre-commit run --files docs/pi_image_cloudflare.md scripts/build_pi_image.sh scripts/build_pi_image.ps1`


------
https://chatgpt.com/codex/tasks/task_e_68b1304b4a94832fbf1a852664ac35e4