### PR TITLE
🛠️ : stream pi-gen build logs

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -54,3 +54,5 @@ from the [workflow artifacts](https://github.com/futuroptimist/sugarkube/actions
 or run the script locally if you need customizations. The workflow rotates its
 cached pi-gen Docker image monthly by hashing the upstream branch, ensuring each
 build pulls in the latest security updates.
+The build script streams output line-by-line so GitHub Actions logs show
+progress during the long-running image creation process.

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -20,7 +20,7 @@ This expanded guide walks through building a three-node Raspberry Pi 5 cluster a
 1. Run `scripts/download_pi_image.sh` to fetch `sugarkube.img.xz` from the latest
    [pi-image workflow run](https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml),
    or download it manually from the Actions tab.
-   
+
    Alternatively, build locally:
    - Linux/macOS: `./scripts/build_pi_image.sh`
    - Windows (PowerShell):
@@ -35,7 +35,7 @@ This expanded guide walks through building a three-node Raspberry Pi 5 cluster a
      # vmIdleTimeout=7200
      # Then apply and rerun build:
      wsl --shutdown
-     
+
      # Build the image
      powershell -ExecutionPolicy Bypass -File .\scripts\build_pi_image.ps1
      ```

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -76,7 +76,11 @@ IMG_NAME="${IMG_NAME}"
 ENABLE_SSH=1
 ARM64=${ARM64}
 CFG
-${SUDO} ./build.sh
+echo "Starting pi-gen build..."
+# Stream output line-by-line so GitHub Actions shows progress and doesn't
+# appear to hang during the lengthy build.
+${SUDO} stdbuf -oL -eL ./build.sh
+echo "pi-gen build finished"
 mv deploy/*.img "${OUTPUT_DIR}/${IMG_NAME}.img"
 xz -T0 "${OUTPUT_DIR}/${IMG_NAME}.img"
 sha256sum "${OUTPUT_DIR}/${IMG_NAME}.img.xz" > \


### PR DESCRIPTION
what: stream pi-gen build output in CI
why: builds appeared stuck without log activity
how to test:
- pre-commit run --all-files
- npm run lint (fails: missing package.json)
- npm run test:ci (fails: missing package.json)
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b130fe9610832f8860fa8f1059a3db