### PR TITLE
Harden pi image build pipeline

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -9,6 +9,7 @@ jobs:
     env:
       ARM64: 1
       DEBIAN_FRONTEND: noninteractive
+      BUILD_TIMEOUT: 7200
     steps:
       - uses: actions/checkout@v4
         with:
@@ -23,8 +24,8 @@ jobs:
           df -h
       - name: Install pi-gen dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
             quilt qemu-user-static debootstrap libarchive-tools arch-test
       - name: Clean up apt cache and temp files
         run: |
@@ -50,7 +51,8 @@ jobs:
         if: steps.cache-pigen.outputs.cache-hit == 'true'
         run: docker load -i ~/cache/pi-gen.tar
       - name: Build Raspberry Pi OS image
-        run: sudo ./scripts/build_pi_image.sh
+        timeout-minutes: 120
+        run: sudo env BUILD_TIMEOUT=7200 ./scripts/build_pi_image.sh
       - name: Save pi-gen Docker image
         if: steps.cache-pigen.outputs.cache-hit != 'true'
         run: |

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -20,7 +20,7 @@ This expanded guide walks through building a three-node Raspberry Pi 5 cluster a
 1. Run `scripts/download_pi_image.sh` to fetch `sugarkube.img.xz` from the latest
    [pi-image workflow run](https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml),
    or download it manually from the Actions tab.
-   
+
    Alternatively, build locally:
    - Linux/macOS: `./scripts/build_pi_image.sh`
    - Windows (PowerShell):
@@ -35,7 +35,7 @@ This expanded guide walks through building a three-node Raspberry Pi 5 cluster a
      # vmIdleTimeout=7200
      # Then apply and rerun build:
      wsl --shutdown
-     
+
      # Build the image
      powershell -ExecutionPolicy Bypass -File .\scripts\build_pi_image.ps1
      ```

--- a/scripts/build_pi_image.ps1
+++ b/scripts/build_pi_image.ps1
@@ -18,7 +18,10 @@ param(
   [string]$PiGenBranch = $(if ($env:PI_GEN_BRANCH) { $env:PI_GEN_BRANCH } else { 'bookworm' }),
   [string]$ImageName   = $(if ($env:IMG_NAME) { $env:IMG_NAME } else { 'sugarkube' }),
   [string]$OutputDir   = $(if ($env:OUTPUT_DIR) { $env:OUTPUT_DIR } else { (Resolve-Path "$PSScriptRoot\..").Path }),
-  [int]$Arm64          = $(if ($env:ARM64) { [int]$env:ARM64 } else { 1 })
+  [int]$Arm64          = $(if ($env:ARM64) { [int]$env:ARM64 } else { 1 }),
+  [string]$DebianMirror = $(if ($env:DEBIAN_MIRROR) { $env:DEBIAN_MIRROR } else { 'https://deb.debian.org/debian' }),
+  [string]$RpiMirror    = $(if ($env:RPI_MIRROR) { $env:RPI_MIRROR } else { 'https://archive.raspberrypi.com/debian' }),
+  [int]$TimeoutSec     = $(if ($env:BUILD_TIMEOUT) { [int]$env:BUILD_TIMEOUT } else { 14400 })
 )
 
 $ErrorActionPreference = 'Stop'
@@ -119,7 +122,8 @@ function Invoke-BuildPiGen {
     [Parameter(Mandatory=$true)][string]$OutputDir,
     [Parameter(Mandatory=$true)][string]$PiGenBranch,
     [Parameter(Mandatory=$true)][int]$Arm64,
-    [Parameter(Mandatory=$true)][string]$RepoRoot
+    [Parameter(Mandatory=$true)][string]$RepoRoot,
+    [int]$TimeoutSec = 14400
   )
 
   # Prefer WSL; fall back to Git Bash if available
@@ -127,8 +131,15 @@ function Invoke-BuildPiGen {
   $gitBash = Get-GitBashPath
   if ($gitBash) {
     $msysPath = Convert-ToMsysPath -WindowsPath $PiGenPath
-    & $gitBash -lc "export MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*'; set -exuo pipefail; cd '$msysPath' && chmod +x ./build.sh && ./build.sh"
-    if ($LASTEXITCODE -ne 0) { throw "pi-gen build failed under Git Bash (exit $LASTEXITCODE)" }
+    $cmd = "export MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*'; " +
+      "set -exuo pipefail; cd '$msysPath' && chmod +x ./build.sh && ./build.sh"
+    $args = '-lc', $cmd
+    $proc = Start-Process -FilePath $gitBash -ArgumentList $args -NoNewWindow -PassThru
+    if (-not $proc.WaitForExit($TimeoutSec * 1000)) {
+      $proc.Kill()
+      throw "pi-gen build timed out after $TimeoutSec seconds"
+    }
+    if ($proc.ExitCode -ne 0) { throw "pi-gen build failed under Git Bash (exit $($proc.ExitCode))" }
     return
   }
 
@@ -138,8 +149,14 @@ function Invoke-BuildPiGen {
     $distro = Get-WslDistroWithBash -WslPath $wsl
     if ($distro) {
       $linuxPath = Convert-ToWslLinuxPath -WindowsPath $PiGenPath
-      & $wsl -d $distro -- bash -lc "set -exuo pipefail; cd '$linuxPath' && chmod +x ./build.sh && ./build.sh"
-      if ($LASTEXITCODE -ne 0) { throw "pi-gen build failed under WSL ($distro) (exit $LASTEXITCODE)" }
+      $cmd = "set -exuo pipefail; cd '$linuxPath' && chmod +x ./build.sh && ./build.sh"
+      $args = '-d', $distro, '--', 'bash', '-lc', $cmd
+      $proc = Start-Process -FilePath $wsl -ArgumentList $args -NoNewWindow -PassThru
+      if (-not $proc.WaitForExit($TimeoutSec * 1000)) {
+        $proc.Kill()
+        throw "pi-gen build failed under WSL ($distro): timeout after $TimeoutSec seconds"
+      }
+      if ($proc.ExitCode -ne 0) { throw "pi-gen build failed under WSL ($distro) (exit $($proc.ExitCode))" }
       return
     }
   }
@@ -153,14 +170,18 @@ function Invoke-BuildPiGenDocker {
     [Parameter(Mandatory=$true)][string]$OutputDir,
     [Parameter(Mandatory=$true)][string]$PiGenBranch,
     [Parameter(Mandatory=$true)][string]$ImageName,
-    [Parameter(Mandatory=$true)][int]$Arm64
+    [Parameter(Mandatory=$true)][int]$Arm64,
+    [int]$TimeoutSec = 14400
   )
 
   $hostRoot = (Resolve-Path $RepoRoot).Path
   $hostOut = (Resolve-Path $OutputDir).Path
   # Ensure binfmt handlers are installed on the Docker host for ARM emulation
-  & docker run --privileged --rm tonistiigi/binfmt --install arm64,arm | Out-Null
-  if ($LASTEXITCODE -ne 0) { throw "Failed to install binfmt handlers on host" }
+  $proc = Start-Process -FilePath docker -ArgumentList @(
+    'run','--privileged','--rm','tonistiigi/binfmt','--install','arm64,arm'
+  ) -NoNewWindow -PassThru
+  if (-not $proc.WaitForExit(600000)) { $proc.Kill() }
+  if ($proc.ExitCode -ne 0) { throw "Failed to install binfmt handlers on host" }
   $bash = @'
 set -e
 export DEBIAN_FRONTEND=noninteractive
@@ -211,8 +232,16 @@ cp "$artifact" /out/{1}.img
   $tempScript = Join-Path $hostRoot '.pigen-build.sh'
   try {
     $bashLF | Set-Content -NoNewline -Encoding Ascii -- $tempScript
-    & docker run --rm --privileged -v "${hostRoot}:/host" -v "${hostOut}:/out" debian:bookworm bash -lc "bash /host/.pigen-build.sh"
-    if ($LASTEXITCODE -ne 0) { throw "pi-gen Docker run failed (exit $LASTEXITCODE)" }
+    $args = @(
+      'run','--rm','--privileged','-v',"${hostRoot}:/host",'-v',
+      "${hostOut}:/out",'debian:bookworm','bash','-lc','bash /host/.pigen-build.sh'
+    )
+    $proc = Start-Process -FilePath docker -ArgumentList $args -NoNewWindow -PassThru
+    if (-not $proc.WaitForExit($TimeoutSec * 1000)) {
+      $proc.Kill()
+      throw "pi-gen Docker run timed out after $TimeoutSec seconds"
+    }
+    if ($proc.ExitCode -ne 0) { throw "pi-gen Docker run failed (exit $($proc.ExitCode))" }
   } finally {
     if (Test-Path $tempScript) { Remove-Item -Force -- $tempScript }
   }
@@ -269,6 +298,16 @@ Test-CommandAvailable docker
 Test-CommandAvailable git
 Invoke-Docker-Info
 
+$urls = @($DebianMirror, $RpiMirror, 'https://github.com')
+foreach ($u in $urls) {
+  try {
+    Invoke-WebRequest -Method Head -Uri $u -TimeoutSec 10 | Out-Null
+  } catch {
+    Write-Error "Cannot reach $u"
+    exit 1
+  }
+}
+
 # Paths and working directory
 $repoRoot = (Resolve-Path "$PSScriptRoot\..").Path
 $workDir = New-TemporaryDirectory
@@ -295,14 +334,16 @@ try {
   $config += ('IMG_NAME="' + $ImageName + '"')
   $config += "ENABLE_SSH=1"
   $config += "ARM64=$Arm64"
+  $config += ('DEBIAN_MIRROR="' + $DebianMirror + '"')
+  $config += ('RPI_MIRROR="' + $RpiMirror + '"')
   $config -join "`n" | Set-Content -NoNewline (Join-Path $piGenDir 'config')
 
   # Run the build (prefer local shell; fallback to containerized pi-gen)
   try {
-    Invoke-BuildPiGen -PiGenPath $piGenDir -ImageName $ImageName -OutputDir $OutputDir -PiGenBranch $PiGenBranch -Arm64 $Arm64 -RepoRoot $repoRoot
+    Invoke-BuildPiGen -PiGenPath $piGenDir -ImageName $ImageName -OutputDir $OutputDir -PiGenBranch $PiGenBranch -Arm64 $Arm64 -RepoRoot $repoRoot -TimeoutSec $TimeoutSec
   } catch {
     Write-Warning "Local shell build failed: $($_.Exception.Message). Falling back to Dockerized pi-gen."
-    Invoke-BuildPiGenDocker -RepoRoot $repoRoot -OutputDir $OutputDir -PiGenBranch $PiGenBranch -ImageName $ImageName -Arm64 $Arm64
+    Invoke-BuildPiGenDocker -RepoRoot $repoRoot -OutputDir $OutputDir -PiGenBranch $PiGenBranch -ImageName $ImageName -Arm64 $Arm64 -TimeoutSec $TimeoutSec
   }
 
   # Collect artifact

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -86,6 +86,13 @@ def test_docker_daemon_must_be_running(tmp_path):
         path = fake_bin / name
         path.write_text("#!/bin/sh\nexit 0\n")
         path.chmod(0o755)
+    for name in ["curl", "timeout"]:
+        path = fake_bin / name
+        if name == "timeout":
+            path.write_text('#!/bin/sh\nshift\nexec "$@"\n')
+        else:
+            path.write_text("#!/bin/sh\nexit 0\n")
+        path.chmod(0o755)
     env = os.environ.copy()
     env["PATH"] = str(fake_bin)
     result = subprocess.run(
@@ -107,6 +114,8 @@ def test_requires_sudo_when_non_root(tmp_path):
         "git": "#!/bin/sh\nexit 0\n",
         "sha256sum": "#!/bin/sh\nexit 0\n",
         "id": "#!/bin/sh\necho 1000\n",
+        "curl": "#!/bin/sh\nexit 0\n",
+        "timeout": '#!/bin/sh\nshift\nexec "$@"\n',
     }.items():
         path = fake_bin / name
         path.write_text(content)
@@ -157,6 +166,14 @@ def _setup_build_env(tmp_path, check_compose: bool = False):
     git = fake_bin / "git"
     git.write_text(git_stub)
     git.chmod(0o755)
+
+    for name in ["curl", "timeout"]:
+        path = fake_bin / name
+        if name == "timeout":
+            path.write_text('#!/bin/sh\nshift\nexec "$@"\n')
+        else:
+            path.write_text("#!/bin/sh\nexit 0\n")
+        path.chmod(0o755)
 
     (fake_bin / "id").write_text("#!/bin/sh\necho 0\n")
     (fake_bin / "id").chmod(0o755)


### PR DESCRIPTION
## Summary
- verify Debian and Raspberry Pi mirrors before building and support explicit build timeouts
- retry apt in pi-image workflow and limit build step duration
- stub curl/timeout in image build tests; remove stray doc whitespace

## Testing
- `npm run lint` *(fails: Could not read package.json: ENOENT)*
- `npm run test:ci` *(fails: Could not read package.json: ENOENT)*
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68b1304b4a94832fbf1a852664ac35e4