### PR TITLE
📝 : document secret scan in CAD prompt

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -213,3 +213,11 @@ localhostForwarding
 vmIdleTimeout
 overcurrent
 GPT
+Raspbian
+env
+CPUs
+Parametrize
+failover
+MSYS
+qcow
+htmlcontent

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -21,6 +21,8 @@ CONTEXT:
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
 - Run `pre-commit run --all-files` after changes. If docs are updated, also run
   `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/`.
+- Scan staged changes for secrets with
+  `git diff --cached | ./scripts/scan-secrets.py` before committing.
 - Log tool failures in [`outages/`](../outages/) per
   [`outages/schema.json`](../outages/schema.json).
 


### PR DESCRIPTION
what: mention secret scanning in CAD prompt and extend wordlist
why: align instructions with current workflow and fix spellcheck failures
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b1418bccc8832fa0b10ef904ae023a