### PR TITLE
📝 : fix spellcheck errors in docs

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -213,3 +213,12 @@ localhostForwarding
 vmIdleTimeout
 overcurrent
 GPT
+
+CPUs
+Parametrize
+Raspbian
+env
+failover
+MSYS
+qcow
+qcow2

--- a/docs/pi_image_builder_design.md
+++ b/docs/pi_image_builder_design.md
@@ -58,7 +58,7 @@
 
 ## CI Considerations
 - CI can run the official container path with the same env mirrors and qcow2
-- Artifacts: upload `<IMG_NAME>.img.xz` and checksum; retain `deploy/` in run artifacts if needed
+- Artifacts: upload `IMG_NAME.img.xz` and checksum; retain `deploy/` in run artifacts if needed
 
 ## Operations & Recovery
 - If apt stalls: rerun; caches and retries reduce recurrence


### PR DESCRIPTION
## Summary
- add technical terms to wordlist so docs spellcheck passes
- drop angle brackets around IMG_NAME placeholder to avoid HTML parsing

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `npm run lint` *(fails: Could not read package.json)*
- `npm run test:ci` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68b14187c1f4832fb3a247bbb19709ec