### PR TITLE
🧪 : test build timeout handling

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -38,6 +38,14 @@ io
 isort
 json
 js
+CPUs
+Env
+MSYS
+Parametrize
+Raspbian
+env
+failover
+qcow
 macOS
 md
 npm


### PR DESCRIPTION
## What
- verify build_pi_image.sh honors BUILD_TIMEOUT
- update wordlist for docs checks

## Why
- ensure custom timeouts and spelling checks stay green

## How to Test
- `pytest -q`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68b1416201b0832f85ad14ccdd98ce5a