### PR TITLE
⚡: trim pi-gen stages for faster builds

### DIFF
--- a/docs/pi_image_builder_design.md
+++ b/docs/pi_image_builder_design.md
@@ -9,7 +9,7 @@
 ## Inputs / Outputs
 - Inputs:
   - `scripts/cloud-init/user-data.yaml` (cloud-init seed including Cloudflare compose file)
-  - Environment variables: `PI_GEN_BRANCH` (default `bookworm`), `IMG_NAME` (default `sugarkube`), `ARM64` (default `1`), optional `OUTPUT_DIR`
+  - Environment variables: `PI_GEN_BRANCH` (default `bookworm`), `IMG_NAME` (default `sugarkube`), `ARM64` (default `1`), optional `OUTPUT_DIR`, `PI_GEN_STAGES` (default `stage0 stage1 stage2`)
 - Outputs:
   - `IMG_NAME.img.xz` and `IMG_NAME.img.xz.sha256` in `OUTPUT_DIR`
 
@@ -60,6 +60,8 @@
 ## CI Considerations
 - CI can run the official container path with the same env mirrors and qcow2
   - Artifacts: upload `IMG_NAME.img.xz` and checksum; retain `deploy/` in run artifacts if needed
+- Default `PI_GEN_STAGES` only builds `stage0`–`stage2` so CI skips heavyweight desktop
+  packages. Override to build a full image.
 
 ## Operations & Recovery
 - If apt stalls: rerun; caches and retries reduce recurrence

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -68,6 +68,9 @@ IMG_NAME="${IMG_NAME:-sugarkube}"
 OUTPUT_DIR="${OUTPUT_DIR:-${REPO_ROOT}}"
 mkdir -p "${OUTPUT_DIR}"
 
+# Build only the minimal lite image by default to keep CI fast
+PI_GEN_STAGES="${PI_GEN_STAGES:-stage0 stage1 stage2}"
+
 git clone --depth 1 --single-branch --branch "${PI_GEN_BRANCH}" \
   "${PI_GEN_URL:-https://github.com/RPi-Distro/pi-gen.git}" \
   "${WORK_DIR}/pi-gen"
@@ -97,6 +100,7 @@ RASPBIAN_MIRROR=http://raspbian.raspberrypi.org/raspbian
 APT_MIRROR_RASPBERRYPI=http://archive.raspberrypi.org/debian
 DEBIAN_MIRROR=http://deb.debian.org/debian
 APT_OPTS="${APT_OPTS}"
+STAGE_LIST="${PI_GEN_STAGES}"
 CFG
 
 # Ensure binfmt_misc mount exists for pi-gen checks (harmless if already mounted)


### PR DESCRIPTION
## Summary
- default to stage0-2 in build_pi_image.sh
- document PI_GEN_STAGES for lite-only builds

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68b153df0734832fb23606e7346cf5dc