### PR TITLE
🩹 : handle pi-gen .img.zip artifacts

### DIFF
--- a/docs/pi_image_builder_design.md
+++ b/docs/pi_image_builder_design.md
@@ -11,7 +11,9 @@
   - `scripts/cloud-init/user-data.yaml` (cloud-init seed including Cloudflare compose file)
   - Environment variables: `PI_GEN_BRANCH` (default `bookworm`), `IMG_NAME` (default `sugarkube`), `ARM64` (default `1`), optional `OUTPUT_DIR`, `PI_GEN_STAGES` (default `stage0 stage1 stage2`)
 - Outputs:
-  - `IMG_NAME.img.xz` and `IMG_NAME.img.xz.sha256` in `OUTPUT_DIR`
+  - `IMG_NAME.img.xz` and `IMG_NAME.img.xz.sha256` in `OUTPUT_DIR`. pi-gen
+    exports a `*.img.zip` which this script unzips before recompressing to
+    `xz`.
 
 ## Build Strategies
 
@@ -59,7 +61,8 @@
 
 ## CI Considerations
 - CI can run the official container path with the same env mirrors and qcow2
-- Artifacts: upload `IMG_NAME.img.xz` and checksum; retain `deploy/` in run artifacts if needed
+  - Artifacts: upload `IMG_NAME.img.xz` and checksum; retain `deploy/` (with the
+    original `*.img.zip`) in run artifacts if needed
 - Default `PI_GEN_STAGES` only builds `stage0`–`stage2` so CI skips heavyweight desktop
   packages. Override to build a full image.
 

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -2,10 +2,11 @@
 set -euo pipefail
 
 # Build a Raspberry Pi OS image with cloud-init files preloaded.
-# Requires curl, docker, git, sha256sum, stdbuf, timeout, xz and roughly 10 GB of
-# free disk space. Set PI_GEN_URL to override the default pi-gen repository.
+# Requires curl, docker, git, sha256sum, stdbuf, timeout, xz, unzip and roughly
+# 10 GB of free disk space. Set PI_GEN_URL to override the default pi-gen
+# repository.
 
-for cmd in curl docker git sha256sum stdbuf timeout xz; do
+for cmd in curl docker git sha256sum stdbuf timeout xz unzip; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "$cmd is required" >&2
     exit 1
@@ -116,7 +117,15 @@ echo "Starting pi-gen build..."
 ${SUDO} stdbuf -oL -eL timeout "${BUILD_TIMEOUT}" ./build.sh
 echo "pi-gen build finished"
 
-mv deploy/*.img "${OUTPUT_DIR}/${IMG_NAME}.img"
+if compgen -G "deploy/*.img" > /dev/null; then
+  mv deploy/*.img "${OUTPUT_DIR}/${IMG_NAME}.img"
+elif compgen -G "deploy/*.img.zip" > /dev/null; then
+  unzip -q deploy/*.img.zip -d deploy
+  mv deploy/*.img "${OUTPUT_DIR}/${IMG_NAME}.img"
+else
+  echo "No image file found in deploy/" >&2
+  exit 1
+fi
 xz -T0 "${OUTPUT_DIR}/${IMG_NAME}.img"
 sha256sum "${OUTPUT_DIR}/${IMG_NAME}.img.xz" > \
   "${OUTPUT_DIR}/${IMG_NAME}.img.xz.sha256"

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -46,6 +46,38 @@ def test_requires_xz(tmp_path):
     assert "xz is required" in result.stderr
 
 
+def test_requires_unzip(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    for name in [
+        "curl",
+        "docker",
+        "git",
+        "sha256sum",
+        "stdbuf",
+        "timeout",
+        "xz",
+    ]:
+        path = fake_bin / name
+        if name == "timeout":
+            path.write_text('#!/bin/sh\nshift\nexec "$@"\n')
+        elif name == "stdbuf":
+            path.write_text('#!/bin/sh\nshift\nshift\nexec "$@"\n')
+        else:
+            path.write_text("#!/bin/sh\nexit 0\n")
+        path.chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = str(fake_bin)
+    result = subprocess.run(
+        ["/bin/bash", "scripts/build_pi_image.sh"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "unzip is required" in result.stderr
+
+
 def test_requires_git(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
@@ -94,7 +126,7 @@ def test_docker_daemon_must_be_running(tmp_path):
     docker = fake_bin / "docker"
     docker.write_text('#!/bin/sh\n[ "$1" = info ] && exit 1 || exit 0\n')
     docker.chmod(0o755)
-    for name in ["xz", "git", "sha256sum"]:
+    for name in ["xz", "git", "sha256sum", "unzip"]:
         path = fake_bin / name
         path.write_text("#!/bin/sh\nexit 0\n")
         path.chmod(0o755)
@@ -131,6 +163,7 @@ def test_requires_sudo_when_non_root(tmp_path):
         "curl": "#!/bin/sh\nexit 0\n",
         "timeout": '#!/bin/sh\nshift\nexec "$@"\n',
         "stdbuf": "#!/bin/sh\nexit 0\n",
+        "unzip": "#!/bin/sh\nexit 0\n",
     }.items():
         path = fake_bin / name
         path.write_text(content)
@@ -178,7 +211,11 @@ def _setup_build_env(tmp_path, check_compose: bool = False):
         "#!/bin/bash\n"
         f"{compose_check}"
         "mkdir -p deploy\n"
-        "touch deploy/sugarkube.img\n"
+        "python3 - <<'PY'\n"
+        "import zipfile\n"
+        "with zipfile.ZipFile('deploy/sugarkube.img.zip', 'w') as zf:\n"
+        "    zf.writestr('sugarkube.img', '')\n"
+        "PY\n"
         "EOF\n"
         'chmod +x "$target/build.sh"\n'
     )


### PR DESCRIPTION
## Summary
- handle .img.zip output from pi-gen by unzipping before xz
- document pi-gen zipped artifact
- cover unzip requirement in tests

## Testing
- `pre-commit run --all-files`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b1578e942c832fb3aeb48e30d660fc