### PR TITLE
🛠️: check disk space before Pi image builds

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -21,7 +21,9 @@ adjust the maximum build duration and `CLOUD_INIT_PATH` to load a custom
 cloud-init configuration instead of the default `scripts/cloud-init/user-data.yaml`.
 Ensure `curl`, `docker` (with its daemon running), `git`, `sha256sum`, `stdbuf`,
 `timeout`, and `xz` are installed before running it; `stdbuf` and `timeout`
-come from GNU coreutils. Use the prepared image to deploy
+come from GNU coreutils. The script checks that both the temporary and output
+directories have at least 10 GB free before starting. Use the prepared image to
+deploy
 containerized apps. The companion guide
 [docker_repo_walkthrough.md](docker_repo_walkthrough.md) explains how to run
 projects such as token.place and dspace. Use the resulting image to bootstrap a

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+REQUIRED_SPACE_GB="${REQUIRED_SPACE_GB:-10}"
+
+check_space() {
+  local dir="$1"
+  local avail_kb required_kb
+  avail_kb=$(df -Pk "$dir" | awk 'NR==2 {print $4}')
+  required_kb=$((REQUIRED_SPACE_GB * 1024 * 1024))
+  if [ "$avail_kb" -lt "$required_kb" ]; then
+    echo "Need at least ${REQUIRED_SPACE_GB}GB free in $dir" >&2
+    exit 1
+  fi
+}
+
 # Build a Raspberry Pi OS image with cloud-init files preloaded.
 # Requires curl, docker, git, sha256sum, stdbuf, timeout, xz, unzip and roughly
 # 10 GB of free disk space. Set PI_GEN_URL to override the default pi-gen
@@ -52,6 +65,9 @@ fi
 WORK_DIR=$(mktemp -d)
 trap 'rm -rf "${WORK_DIR}"' EXIT
 
+# Ensure temporary and output locations have enough space
+check_space "$(dirname "${WORK_DIR}")"
+
 PI_GEN_URL="${PI_GEN_URL:-https://github.com/RPi-Distro/pi-gen.git}"
 DEBIAN_MIRROR="${DEBIAN_MIRROR:-https://deb.debian.org/debian}"
 RPI_MIRROR="${RPI_MIRROR:-https://archive.raspberrypi.com/debian}"
@@ -75,6 +91,7 @@ fi
 IMG_NAME="${IMG_NAME:-sugarkube}"
 OUTPUT_DIR="${OUTPUT_DIR:-${REPO_ROOT}}"
 mkdir -p "${OUTPUT_DIR}"
+check_space "${OUTPUT_DIR}"
 
 # Build only the minimal lite image by default to keep CI fast
 PI_GEN_STAGES="${PI_GEN_STAGES:-stage0 stage1 stage2}"


### PR DESCRIPTION
what: verify ≥10 GB free in temp and output dirs before building images.
why: avoid late failures from running out of space.
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/.


------
https://chatgpt.com/codex/tasks/task_e_68b2a81e6918832fa68e207054fe7dcc