### PR TITLE
🔧 : embed Cloudflare token in Pi image

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -202,6 +202,7 @@ tfrac
 todo
 token.place
 tokenplace
+TUNNEL_TOKEN
 txt
 undersize
 uv

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -19,6 +19,8 @@ passes `APT_OPTS` so apt retries on transient timeouts. Override the mirrors
 with `RPI_MIRROR` and `DEBIAN_MIRROR`. Use `BUILD_TIMEOUT` (default: `4h`) to
 adjust the maximum build duration and `CLOUD_INIT_PATH` to load a custom
 cloud-init configuration instead of the default `scripts/cloud-init/user-data.yaml`.
+Set `TUNNEL_TOKEN` to bake a Cloudflare token into
+`/opt/sugarkube/.cloudflared.env`; otherwise edit the file after boot.
 Ensure `curl`, `docker` (with its daemon running), `git`, `sha256sum`, `stdbuf`,
 `timeout`, and `xz` are installed before running it; `stdbuf` and `timeout`
 come from GNU coreutils. Use the prepared image to deploy
@@ -40,7 +42,8 @@ for onboarding steps.
    `/opt/sugarkube/`. Cloud-init adds the Cloudflare apt repo, pre-creates
    `/opt/sugarkube/.cloudflared.env` with `0600` permissions, and enables the
    Docker service; verify both files and the service.
-5. Add your Cloudflare token to `/opt/sugarkube/.cloudflared.env`.
+5. Add your Cloudflare token to `/opt/sugarkube/.cloudflared.env` if it wasn't
+   provided via `TUNNEL_TOKEN` during the build.
 6. Start the tunnel with `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml up -d`.
 7. Confirm the tunnel is running: `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml ps` should show `cloudflared` as `Up`.
 8. View the tunnel logs to confirm a connection:

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -83,8 +83,12 @@ git clone --depth 1 --single-branch --branch "${PI_GEN_BRANCH}" \
   "${PI_GEN_URL:-https://github.com/RPi-Distro/pi-gen.git}" \
   "${WORK_DIR}/pi-gen"
 
-cp "${CLOUD_INIT_PATH}" \
-  "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/user-data"
+USER_DATA="${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/user-data"
+cp "${CLOUD_INIT_PATH}" "${USER_DATA}"
+if [ -n "${TUNNEL_TOKEN:-}" ]; then
+  echo "Embedding Cloudflare token into cloud-init"
+  sed -i "s|TUNNEL_TOKEN=\"\"|TUNNEL_TOKEN=\"${TUNNEL_TOKEN}\"|" "${USER_DATA}"
+fi
 
 install -Dm644 "${REPO_ROOT}/scripts/cloud-init/docker-compose.cloudflared.yml" \
   "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/docker-compose.cloudflared.yml"

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -16,6 +16,7 @@ write_files:
   - path: /opt/sugarkube/.cloudflared.env
     permissions: '0600'
     content: |
+      # Inject with TUNNEL_TOKEN env var or edit after boot
       TUNNEL_TOKEN=""
 runcmd:
   - [bash, -c, 'usermod -aG docker pi']


### PR DESCRIPTION
- what: allow TUNNEL_TOKEN to prepopulate cloudflared env and update docs
- why: simplify Pi image setup by baking token into image
- how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b2a81e6918832fa68e207054fe7dcc