### PR TITLE
✨ auto-start cloudflared when token set

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -38,11 +38,16 @@ for onboarding steps.
 3. Boot the Pi and run `sudo rpi-clone sda -f` to copy the OS to an SSD.
 4. The build script copies `docker-compose.cloudflared.yml` into
    `/opt/sugarkube/`. Cloud-init adds the Cloudflare apt repo, pre-creates
-   `/opt/sugarkube/.cloudflared.env` with `0600` permissions, and enables the
-   Docker service; verify both files and the service.
-5. Add your Cloudflare token to `/opt/sugarkube/.cloudflared.env`.
-6. Start the tunnel with `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml up -d`.
-7. Confirm the tunnel is running: `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml ps` should show `cloudflared` as `Up`.
+   `/opt/sugarkube/.cloudflared.env` with `0600` permissions, installs
+   `/opt/sugarkube/start-cloudflared.sh`, and enables the Docker service; verify
+   both files and the service.
+5. Add your Cloudflare token to `/opt/sugarkube/.cloudflared.env` before the
+   first boot to launch the tunnel automatically, or edit the file later.
+6. If the token was added after boot, start the tunnel manually with
+   `bash /opt/sugarkube/start-cloudflared.sh`.
+7. Confirm the tunnel is running:
+   `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml ps` should
+   show `cloudflared` as `Up`.
 8. View the tunnel logs to confirm a connection:
    `docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml logs -f`.
 9. Clone target projects:

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -17,8 +17,19 @@ write_files:
     permissions: '0600'
     content: |
       TUNNEL_TOKEN=""
+  - path: /opt/sugarkube/start-cloudflared.sh
+    permissions: '0755'
+    content: |
+      #!/usr/bin/env bash
+      set -e
+      if ! grep -q 'TUNNEL_TOKEN=""' /opt/sugarkube/.cloudflared.env; then
+        docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml up -d
+      else
+        echo "TUNNEL_TOKEN not set; skipping tunnel start"
+      fi
 runcmd:
   - [bash, -c, 'usermod -aG docker pi']
   - [bash, -c, 'mkdir -p /opt/sugarkube']
   - [bash, -c, 'chown -R pi:pi /opt/sugarkube']
   - [systemctl, enable, --now, docker]
+  - [/opt/sugarkube/start-cloudflared.sh]


### PR DESCRIPTION
what: start-cloudflared script auto-runs when TUNNEL_TOKEN present
why: reduce manual steps for Cloudflare tunnel setup
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68b2a81e6918832fa68e207054fe7dcc