### PR TITLE
🔧 : honor mirror overrides in Pi image build

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -15,8 +15,9 @@ into the OS image. The `build_pi_image.sh` script clones `pi-gen` using
 unavailable. `IMG_NAME` controls the output filename and `OUTPUT_DIR` selects
 where artifacts are written; the script creates the directory if needed. To
 reduce flaky downloads it pins the official Raspberry Pi and Debian mirrors and
-passes `APT_OPTS` so apt retries on transient timeouts. Override the mirrors
-with `RPI_MIRROR` and `DEBIAN_MIRROR`. Use `BUILD_TIMEOUT` (default: `4h`) to
+passes `APT_OPTS` so apt retries on transient timeouts. Override the Raspberry Pi
+packages mirror with `RPI_MIRROR` (mapped to pi-gen's `APT_MIRROR_RASPBERRYPI`) and
+the Debian mirror with `DEBIAN_MIRROR`. Use `BUILD_TIMEOUT` (default: `4h`) to
 adjust the maximum build duration and `CLOUD_INIT_PATH` to load a custom
 cloud-init configuration instead of the default `scripts/cloud-init/user-data.yaml`.
 Ensure `curl`, `docker` (with its daemon running), `git`, `sha256sum`, `stdbuf`,

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -106,8 +106,8 @@ ARM64=${ARM64}
 # Prefer primary mirrors to avoid flaky community mirrors and set apt timeouts
 APT_MIRROR=http://raspbian.raspberrypi.org/raspbian
 RASPBIAN_MIRROR=http://raspbian.raspberrypi.org/raspbian
-APT_MIRROR_RASPBERRYPI=http://archive.raspberrypi.org/debian
-DEBIAN_MIRROR=http://deb.debian.org/debian
+APT_MIRROR_RASPBERRYPI=${RPI_MIRROR}
+DEBIAN_MIRROR=${DEBIAN_MIRROR}
 APT_OPTS="${APT_OPTS}"
 STAGE_LIST="${PI_GEN_STAGES}"
 CFG


### PR DESCRIPTION
what: pass RPI_MIRROR and DEBIAN_MIRROR to pi-gen config;
      document RPI_MIRROR mapping
why: allow selecting nearby package mirrors for faster, more reliable builds
how to test: pre-commit run --all-files;
             pyspelling -c .spellcheck.yaml;
             linkchecker --no-warnings README.md docs/
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b2a81e6918832fa68e207054fe7dcc