### PR TITLE
🧪 : add test for missing cloud-init file

### DIFF
--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -361,6 +361,14 @@ def test_respects_build_timeout_env(tmp_path):
     assert log.read_text().strip() == "2h"
 
 
+def test_requires_cloud_init_file(tmp_path):
+    env = _setup_build_env(tmp_path)
+    env["CLOUD_INIT_PATH"] = str(tmp_path / "missing.yaml")
+    result, _ = _run_build_script(tmp_path, env)
+    assert result.returncode != 0
+    assert "Cloud-init file not found" in result.stderr
+
+
 def test_powershell_script_mentions_cloudflared_compose():
     text = Path("scripts/build_pi_image.ps1").read_text()
     assert "docker-compose.cloudflared.yml" in text


### PR DESCRIPTION
what: add regression test for missing CLOUD_INIT_PATH
why: avoid silent misconfigurations when user-data is absent
how: pytest -q && pre-commit run --all-files
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68b2a830ef38832fb77d90d64788d4f9