### PR TITLE
🔧 : use HTTPS for outage schema

### DIFF
--- a/outages/schema.json
+++ b/outages/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Outage record",
   "type": "object",
   "required": ["id", "date", "component", "rootCause", "resolution", "references"],


### PR DESCRIPTION
What: switch outage JSON schema reference to HTTPS
Why: avoid redirects and keep link checks stable
How to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68b2a8457ce4832facb388640055f8d1