### PR TITLE
📝 : – clarify CAD prompt checks

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -22,9 +22,9 @@ CONTEXT:
 - Render each model in both `heatset` and `printed` modes. The `STANDOFF_MODE`
   value is case-insensitive and defaults to `heatset`.
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` after changes. For documentation updates, also run
-  `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`) and
-  `linkchecker --no-warnings README.md docs/`.
+- Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires
+  `aspell` and `aspell-en`), and `linkchecker --no-warnings README.md docs/`
+  before committing.
 - Log tool failures in [`outages/`](../outages/) using
   [`outages/schema.json`](../outages/schema.json).
 
@@ -35,7 +35,7 @@ REQUEST:
 
    ```bash
    ./scripts/openscad_render.sh path/to/model.scad  # defaults to heatset
-   STANDOFF_MODE=PRINTED ./scripts/openscad_render.sh path/to/model.scad  # value is case-insensitive
+   STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad  # value is case-insensitive
    ```
 
 4. Commit updated SCAD sources and any documentation.


### PR DESCRIPTION
what: require all checks in CAD prompt and lowercase STANDOFF_MODE example
why: keep 3D workflow instructions current
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b2a847abf8832f9e3570ddb68d0aec