### PR TITLE
🔒 : add secret scan script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ the docs you will see the term used in both contexts.
 - `tests/` — quick checks for helper scripts and documentation
 
 Run `pre-commit run --all-files` before committing.
+Scan staged changes for credentials:
+
+```bash
+git diff --cached | scripts/scan-secrets.py
+```
 
 ## Getting Started
 

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Scan text from stdin for common secret patterns.
+
+Exits with status 1 if potential secrets are found, otherwise 0.
+"""
+import re
+import sys
+
+PATTERNS = [
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "AWS Access Key ID"),
+    (
+        re.compile(r"(?i)aws_secret_access_key\s*[:=]\s*[0-9a-zA-Z/+]{40}"),
+        "AWS Secret Access Key",
+    ),
+    (re.compile(r"-----BEGIN[ \w]*PRIVATE KEY-----"), "Private key"),
+    (re.compile(r"(?i)password\s*[:=]\s*[^\s]+"), "Password assignment"),
+]
+
+
+def _mask(value: str) -> str:
+    """Mask the middle of a string to avoid leaking secrets."""
+    if len(value) <= 8:
+        return value
+    return f"{value[:4]}{'*' * (len(value) - 8)}{value[-4:]}"
+
+
+def main() -> int:
+    data = sys.stdin.read()
+    findings = []
+    for pattern, label in PATTERNS:
+        for match in pattern.finditer(data):
+            findings.append((label, _mask(match.group(0))))
+
+    if findings:
+        print("Potential secrets detected:")
+        for label, value in findings:
+            print(f" - {label}: {value}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scan_secrets_test.py
+++ b/tests/scan_secrets_test.py
@@ -1,0 +1,25 @@
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "scan-secrets.py"
+
+
+def run_scan(data: str):
+    return subprocess.run(
+        [str(SCRIPT)],
+        input=data,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_detects_aws_key():
+    key = "AKIA" + "1234567890ABCDEF"
+    result = run_scan(key)
+    assert result.returncode == 1
+    assert "AWS Access Key ID" in result.stdout
+
+
+def test_passes_clean_input():
+    result = run_scan("just some text")
+    assert result.returncode == 0


### PR DESCRIPTION
what: add scripts/scan-secrets.py and doc note
why: ensure staged diffs are scanned for credentials
how to test: pre-commit run --files README.md scripts/scan-secrets.py tests/scan_secrets_test.py; pytest
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b2abb2560c832f9eb15ffeb647b927