### PR TITLE
🛠️ : guard against empty stage list

### DIFF
--- a/docs/pi_image_builder_design.md
+++ b/docs/pi_image_builder_design.md
@@ -10,7 +10,12 @@
 - Inputs:
 - `scripts/cloud-init/user-data.yaml` (cloud-init seed)
 - `scripts/cloud-init/docker-compose.cloudflared.yml` (Cloudflare Tunnel compose file)
-  - Environment variables: `PI_GEN_BRANCH` (default `bookworm`), `IMG_NAME` (default `sugarkube`), `ARM64` (default `1`), optional `OUTPUT_DIR`, `PI_GEN_STAGES` (default `stage0 stage1 stage2`)
+  - Environment variables:
+    `PI_GEN_BRANCH` (default `bookworm`),
+    `IMG_NAME` (default `sugarkube`),
+    `ARM64` (default `1`),
+    optional `OUTPUT_DIR`,
+    `PI_GEN_STAGES` (default `stage0 stage1 stage2`; empty values are rejected)
 - Outputs:
   - `IMG_NAME.img.xz` and `IMG_NAME.img.xz.sha256` in `OUTPUT_DIR`. pi-gen
     exports a `*.img.zip` which this script unzips before recompressing to
@@ -65,7 +70,8 @@
   - Artifacts: upload `IMG_NAME.img.xz` and checksum; retain `deploy/` (with the
     original `*.img.zip`) in run artifacts if needed
 - Default `PI_GEN_STAGES` only builds `stage0`–`stage2` so CI skips heavyweight desktop
-  packages. Override to build a full image.
+  packages. Override to build a full image. An empty value halts the script before
+  running pi-gen.
 
 ## Operations & Recovery
 - If apt stalls: rerun; caches and retries reduce recurrence

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -95,6 +95,11 @@ check_space "${OUTPUT_DIR}"
 
 # Build only the minimal lite image by default to keep CI fast
 PI_GEN_STAGES="${PI_GEN_STAGES:-stage0 stage1 stage2}"
+# Abort early if no stages were requested
+if [[ -z "${PI_GEN_STAGES// }" ]]; then
+  echo "PI_GEN_STAGES must include at least one stage" >&2
+  exit 1
+fi
 
 git clone --depth 1 --single-branch --branch "${PI_GEN_BRANCH}" \
   "${PI_GEN_URL:-https://github.com/RPi-Distro/pi-gen.git}" \

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -402,6 +402,14 @@ def test_requires_cloud_init_file(tmp_path):
     assert "Cloud-init file not found" in result.stderr
 
 
+def test_requires_stage_list(tmp_path):
+    env = _setup_build_env(tmp_path)
+    env["PI_GEN_STAGES"] = "   "
+    result, _ = _run_build_script(tmp_path, env)
+    assert result.returncode != 0
+    assert "PI_GEN_STAGES must include at least one stage" in result.stderr
+
+
 def test_powershell_script_mentions_cloudflared_compose():
     text = Path("scripts/build_pi_image.ps1").read_text()
     assert "docker-compose.cloudflared.yml" in text


### PR DESCRIPTION
what: fail early when PI_GEN_STAGES resolves to blank
why: blank stage list causes pi-gen to skip image export
how to test: pre-commit run --files scripts/build_pi_image.sh tests/build_pi_image_test.py docs/pi_image_builder_design.md
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b2aaff0d28832fb74053140c975910