### PR TITLE
🐛: log pi-gen build failure details

### DIFF
--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -160,6 +160,14 @@ elif compgen -G "deploy/*.img.zip" > /dev/null; then
   xz -T0 "${OUT_IMG%.xz}"
 else
   echo "No image file found in deploy/" >&2
+  if ls deploy/* >/dev/null 2>&1; then
+    echo "Contents of deploy/:" >&2
+    ls -lh deploy >&2
+  fi
+  if [ -f deploy/build.log ]; then
+    echo "Last 20 lines of deploy/build.log:" >&2
+    tail -n 20 deploy/build.log >&2
+  fi
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- show deploy/ contents and tail build.log when no image is produced

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68b2aaff0d28832fb74053140c975910