### PR TITLE
Harden Pi image build checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ the docs you will see the term used in both contexts.
 - `scripts/` — helper scripts for rendering and exports
   - `download_pi_image.sh` — fetch the latest Pi image via the GitHub CLI; uses
     POSIX `-ef` instead of `realpath` for better macOS compatibility
+  - `build_pi_image.sh` — build a Raspberry Pi OS image with cloud-init
+    preloaded; needs a valid `user-data.yaml` and ~10 GB free disk space
 - `tests/` — quick checks for helper scripts and documentation
 
 Run `pre-commit run --all-files` before committing.

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -62,6 +62,14 @@ if [ ! -f "${CLOUD_INIT_PATH}" ]; then
   echo "Cloud-init file not found: ${CLOUD_INIT_PATH}" >&2
   exit 1
 fi
+if [ ! -s "${CLOUD_INIT_PATH}" ]; then
+  echo "Cloud-init file is empty: ${CLOUD_INIT_PATH}" >&2
+  exit 1
+fi
+if ! head -n1 "${CLOUD_INIT_PATH}" | grep -q '^#cloud-config'; then
+  echo "Cloud-init file missing #cloud-config header: ${CLOUD_INIT_PATH}" >&2
+  exit 1
+fi
 WORK_DIR=$(mktemp -d)
 trap 'rm -rf "${WORK_DIR}"' EXIT
 
@@ -159,7 +167,8 @@ elif compgen -G "deploy/*.img.zip" > /dev/null; then
   cp deploy/*.img "${OUT_IMG%.xz}"
   xz -T0 "${OUT_IMG%.xz}"
 else
-  echo "No image file found in deploy/" >&2
+  echo "No image file found in deploy/; directory contents:" >&2
+  ls -al deploy >&2 || echo "(deploy directory missing)" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## What
- validate cloud-init user-data and display deploy contents on failure
- document Pi image build script requirements

## Why
- missing or empty configs led to silent pi-gen failures

## How to test
- `pre-commit run --all-files`
- `./scripts/checks.sh`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b2aaff0d28832fb74053140c975910