### PR TITLE
🧪: – add pi-gen artifact collector and unit tests

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -1,10 +1,38 @@
 name: pi-image
 
 on:
+  # Keep manual builds for the heavy job
   workflow_dispatch:
+  # Also run the lightweight unit tests automatically when relevant bits change
+  pull_request:
+    paths:
+      - 'scripts/collect_pi_image.sh'
+      - 'tests/**'
+      - '.github/workflows/pi-image.yml'
 
 jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Install collector dependencies
+        run: |
+          sudo apt-get -o Acquire::Retries=5 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            update
+          sudo apt-get -o Acquire::Retries=5 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            install -y --no-install-recommends libarchive-tools xz-utils
+      - name: Run artifact detection unit tests
+        run: bash tests/artifact_detection_test.sh
+
   build:
+    # Only run the expensive image build when manually dispatched
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       ARM64: 1
@@ -14,6 +42,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
       - name: Free up disk space
         run: |
           sudo apt-get clean
@@ -22,58 +51,70 @@ jobs:
             /usr/local/share/boost
           docker system prune -af || true
           df -h
+
       - name: Install pi-gen dependencies
         run: |
           sudo apt-get -o Acquire::Retries=5 \
-                       -o Acquire::http::Timeout=30 \
-                       -o Acquire::https::Timeout=30 \
-                       update
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            update
           sudo apt-get -o Acquire::Retries=5 \
-                       -o Acquire::http::Timeout=30 \
-                       -o Acquire::https::Timeout=30 \
-                       install -y --no-install-recommends \
-                       quilt qemu-user-static debootstrap libarchive-tools arch-test
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            install -y --no-install-recommends \
+            quilt qemu-user-static debootstrap libarchive-tools arch-test xz-utils
+
       - name: Clean up apt cache and temp files
         run: |
           sudo apt-get clean
-          sudo rm -rf /var/lib/apt/lists/*
-          sudo rm -rf /tmp/*
+          sudo rm -rf /var/lib/apt/lists/* /tmp/*
+
       - name: Compute pi-gen cache key
         id: pigen-key
         run: |
           branch=bookworm
-          if [ "$ARM64" = "1" ]; then
+          if [ "${ARM64}" = "1" ]; then
             branch=arm64
           fi
           ref=$(git ls-remote https://github.com/RPi-Distro/pi-gen.git "refs/heads/${branch}" | cut -f1)
           echo "key=pigen-${RUNNER_OS}-${branch}-${ref}-$(date +'%Y-%m')" >> "$GITHUB_OUTPUT"
+
       - name: Restore pi-gen Docker image
         id: cache-pigen
         uses: actions/cache@v4
         with:
           path: ~/cache/pi-gen.tar
           key: ${{ steps.pigen-key.outputs.key }}
+
       - name: Load cached pi-gen image
         if: steps.cache-pigen.outputs.cache-hit == 'true'
         run: docker load -i ~/cache/pi-gen.tar
+
       - name: Build Raspberry Pi OS image
         timeout-minutes: 120
         run: |
-          sudo env BUILD_TIMEOUT=7200 ./scripts/build_pi_image.sh
-          status=$?
-          if [ "$status" -ne 0 ]; then
-            echo "Build failed"
-            exit "$status"
+          sudo env BUILD_TIMEOUT="${BUILD_TIMEOUT}" ./scripts/build_pi_image.sh
+
+      - name: List deploy directory
+        if: always()
+        run: |
+          echo "--- list of deploy ---"
+          if [ -d deploy ]; then
+            find deploy -maxdepth 3 -type f -printf "%p\t%k KB\n" | sort
+          else
+            echo "deploy directory not found"
           fi
-          if ! ls ./sugarkube.img* >/dev/null 2>&1; then
-            echo "No image found after build"
-            exit 1
-          fi
+
+      - name: Collect image artifact
+        run: |
+          bash scripts/collect_pi_image.sh . ./sugarkube.img.xz
+
       - name: Save pi-gen Docker image
         if: steps.cache-pigen.outputs.cache-hit != 'true'
         run: |
           mkdir -p ~/cache
           docker image save pi-gen:latest -o ~/cache/pi-gen.tar
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/collect_pi_image.sh
+++ b/scripts/collect_pi_image.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Normalize pi-gen output (wherever it lands under deploy/) into ./sugarkube.img.xz
+# Usage: bash scripts/collect_pi_image.sh [DEPLOY_ROOT] [OUTPUT_PATH]
+set -euo pipefail
+
+DEPLOY_ROOT="${1:-deploy}"
+OUTPUT_PATH="${2:-sugarkube.img.xz}"
+
+# Log what's in deploy for debuggability
+echo "==> Scanning '${DEPLOY_ROOT}' for image artifacts"
+if [ -d "${DEPLOY_ROOT}" ]; then
+  find "${DEPLOY_ROOT}" -maxdepth 3 -type f -printf '%p\t%k KB\n' | sort || true
+else
+  echo "ERROR: '${DEPLOY_ROOT}' does not exist"
+  exit 1
+fi
+
+# Helper: find first match by pattern preference
+_find_first() {
+  local pat="$1"
+  # Prioritize shallower and lexicographically-stable paths
+  find "${DEPLOY_ROOT}" -maxdepth 3 -type f -name "${pat}" -printf '%d\t%p\n' \
+    | sort -n | cut -f2 | head -n1
+}
+
+found=""
+# Prefer pre-compressed images
+found="$(_find_first '*.img.xz' || true)"
+if [ -z "${found}" ]; then
+  # Accept zip bundles containing a .img
+  zipfile="$(_find_first '*.zip' || true)"
+  if [ -n "${zipfile}" ]; then
+    tmpdir="$(mktemp -d)"
+    # Use bsdtar from libarchive-tools (handles zip); avoid needing 'unzip'
+    bsdtar -xf "${zipfile}" -C "${tmpdir}"
+    img_in_zip="$(find "${tmpdir}" -type f -name '*.img' | head -n1 || true)"
+    if [ -n "${img_in_zip}" ]; then
+      found="${img_in_zip}"
+    else
+      echo "ERROR: Zip contained no .img: ${zipfile}"
+      exit 1
+    fi
+  fi
+fi
+
+if [ -z "${found}" ]; then
+  # Accept gz-compressed .img
+  gzfile="$(_find_first '*.img.gz' || true)"
+  if [ -n "${gzfile}" ]; then
+    tmpdir="$(mktemp -d)"
+    gunzip -c "${gzfile}" > "${tmpdir}/image.img"
+    found="${tmpdir}/image.img"
+  fi
+fi
+
+if [ -z "${found}" ]; then
+  # Finally, accept raw .img
+  rawimg="$(_find_first '*.img' || true)"
+  if [ -n "${rawimg}" ]; then
+    found="${rawimg}"
+  fi
+fi
+
+if [ -z "${found}" ]; then
+  echo "ERROR: No image file found under '${DEPLOY_ROOT}' (looked for *.img.xz, *.zip, *.img.gz, *.img)"
+  exit 1
+fi
+
+echo "==> Found image source: ${found}"
+
+# Normalize to .xz (keep original artifact in place for forensics)
+mkdir -p "$(dirname "${OUTPUT_PATH}")"
+
+if [[ "${found}" == *.img.xz ]]; then
+  # Skip copying if source already matches destination
+  if [ "$(readlink -f "${found}")" != "$(readlink -f "${OUTPUT_PATH}")" ]; then
+    cp -f "${found}" "${OUTPUT_PATH}"
+  fi
+else
+  # Aim for deterministic-ish output:
+  # - fix mtime of input so xz header doesn't vary
+  # - respect SOURCE_DATE_EPOCH if set; else git commit time; else now
+  SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log -1 --format=%ct 2>/dev/null || date +%s)}"
+  touch -d "@${SOURCE_DATE_EPOCH}" "${found}" || true
+
+  # Compress; -e for better ratio, -T0 to use all cores on the runner
+  : "${XZ_OPT:=-T0 -9e}"
+  echo "==> Compressing to ${OUTPUT_PATH} (XZ_OPT='${XZ_OPT}')"
+  xz -c ${XZ_OPT} "${found}" > "${OUTPUT_PATH}"
+fi
+
+# Write checksum next to artifact
+sha256sum "${OUTPUT_PATH}" | awk '{print $1}' > "${OUTPUT_PATH}.sha256"
+
+echo "==> Wrote:"
+ls -lh "${OUTPUT_PATH}" "${OUTPUT_PATH}.sha256"

--- a/tests/artifact_detection_test.sh
+++ b/tests/artifact_detection_test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Minimal, fast tests that validate artifact discovery and normalization logic.
+set -euo pipefail
+
+ROOT="$(pwd)"
+SCRIPT="${ROOT}/scripts/collect_pi_image.sh"
+
+if [ ! -f "${SCRIPT}" ]; then
+  echo "collect_pi_image.sh missing"
+  exit 1
+fi
+
+export XZ_OPT="-T0 -0"  # speed up compression during tests
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+# Case 1: nested pre-compressed .img.xz
+mkdir -p "${tmp}/deploy/nested"
+echo "hello-from-xz" > "${tmp}/deploy/nested/foo.img"
+xz -c ${XZ_OPT} "${tmp}/deploy/nested/foo.img" > "${tmp}/deploy/nested/foo.img.xz"
+rm -f "${tmp}/deploy/nested/foo.img"
+bash "${SCRIPT}" "${tmp}/deploy" "${tmp}/out1.img.xz"
+test -s "${tmp}/out1.img.xz"
+test -s "${tmp}/out1.img.xz.sha256"
+
+# Reset deploy between cases
+rm -rf "${tmp}/deploy"
+
+# Case 2: zip containing a .img (use bsdtar to avoid requiring 'zip')
+mkdir -p "${tmp}/deploy/zipcase"
+echo "hi-from-zip" > "${tmp}/deploy/zipcase/bar.img"
+# bsdtar auto-detects format from extension with -a
+bsdtar -a -cf "${tmp}/deploy/zipcase/bar.zip" -C "${tmp}/deploy/zipcase" bar.img
+rm -f "${tmp}/deploy/zipcase/bar.img"
+bash "${SCRIPT}" "${tmp}/deploy" "${tmp}/out2.img.xz"
+test -s "${tmp}/out2.img.xz"
+test -s "${tmp}/out2.img.xz.sha256"
+
+# Reset deploy between cases
+rm -rf "${tmp}/deploy"
+
+# Case 3: raw .img
+mkdir -p "${tmp}/deploy/rawcase"
+dd if=/dev/zero of="${tmp}/deploy/rawcase/baz.img" bs=1 count=16 status=none
+bash "${SCRIPT}" "${tmp}/deploy" "${tmp}/out3.img.xz"
+test -s "${tmp}/out3.img.xz"
+test -s "${tmp}/out3.img.xz.sha256"
+
+# Clean up prior outputs
+rm -f "${tmp}"/out*.img.xz "${tmp}"/out*.img.xz.sha256 2>/dev/null || true
+
+# Case 4: pre-existing .img.xz in root (no copy)
+echo "hello-same" > "${tmp}/same.img"
+xz -c ${XZ_OPT} "${tmp}/same.img" > "${tmp}/out4.img.xz"
+rm -f "${tmp}/same.img"
+bash "${SCRIPT}" "${tmp}" "${tmp}/out4.img.xz"
+test -s "${tmp}/out4.img.xz"
+test -s "${tmp}/out4.img.xz.sha256"
+
+echo "All artifact detection tests passed."


### PR DESCRIPTION
what: collect pi-gen image artifacts, add shell unit tests, skip self-copy
why: handle nested deploy paths, varied formats, and pre-existing outputs
how to test: bash tests/artifact_detection_test.sh

------
https://chatgpt.com/codex/tasks/task_e_68b3857565d8832f85c9619fb779343d