### PR TITLE
🛠️: reset checksum file before writing

### DIFF
--- a/scripts/collect_pi_image.sh
+++ b/scripts/collect_pi_image.sh
@@ -91,6 +91,8 @@ else
 fi
 
 # Write checksum next to artifact
+# Remove any existing checksum file so read-only artifacts don't block new writes
+rm -f "${OUTPUT_PATH}.sha256"
 sha256sum "${OUTPUT_PATH}" | awk '{print $1}' > "${OUTPUT_PATH}.sha256"
 
 echo "==> Wrote:"


### PR DESCRIPTION
## Summary
- handle existing checksum file in collect_pi_image

## Testing
- `pre-commit run --all-files` *(fails: flake8 errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b3db43a620832fa72ac93f0fcfab3a