### PR TITLE
📝 log collect_pi_image sha256 permission outage

### DIFF
--- a/outages/2025-08-31-pi-image-collect-sha256-permission.json
+++ b/outages/2025-08-31-pi-image-collect-sha256-permission.json
@@ -1,0 +1,10 @@
+{
+  "id": "pi-image-collect-sha256-permission",
+  "date": "2025-08-31",
+  "component": "pi-image collect script",
+  "rootCause": "collect_pi_image.sh failed to write checksum when existing file lacked write permission",
+  "resolution": "script now removes any existing .sha256 file before writing",
+  "references": [
+    "scripts/collect_pi_image.sh"
+  ]
+}


### PR DESCRIPTION
what: record failure to overwrite read-only checksum file during collect_pi_image
why: document root cause and fix in outage catalog
how to test: pre-commit run --all-files (fails: run-checks E501 etc.)
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68b3e20fce04832faf1fdf38234b8a72