### PR TITLE
docs: tidy CAD prompt formatting

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -23,10 +23,10 @@ CONTEXT:
 - Render each model in both `heatset` and `printed` modes. `STANDOFF_MODE` is case-insensitive and
   defaults to `heatset`.
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` after changes.  
+- Run `pre-commit run --all-files` after changes.
   For documentation updates, also run `pyspelling -c .spellcheck.yaml` (requires `aspell` and
   `aspell-en`) and `linkchecker --no-warnings README.md docs/`.
-- Scan staged changes for secrets with:  
+- Scan staged changes for secrets with:
   `git diff --cached | ./scripts/scan-secrets.py` before committing.
 - Log tool failures in [`outages/`](../outages/) using
   [`outages/schema.json`](../outages/schema.json).


### PR DESCRIPTION
## Summary
- remove stray trailing spaces in `docs/prompts-codex-cad.md`

## Testing
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `pre-commit run --files docs/prompts-codex-cad.md` *(fails: tests/build_pi_image_ps1_test.py: line too long, invalid escape sequence)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e84727b4832fa20be5ab5a456228