### PR TITLE
docs: refine spellcheck prompt instructions

### DIFF
--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -7,7 +7,7 @@ slug: 'prompts-codex-spellcheck'
 
 Use this prompt to catch and correct spelling issues in Markdown docs.
 
-```
+```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
 
@@ -15,9 +15,10 @@ PURPOSE:
 Keep Markdown documentation free of spelling errors.
 
 CONTEXT:
-- Run `pyspelling -c .spellcheck.yaml` to scan `README.md` and `docs/`.
+- Run `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`) to scan `README.md` and `docs/`.
 - Add legitimate new words to `.wordlist.txt`.
-- Follow AGENTS.md and run `pre-commit run --all-files`; ensure `linkchecker --no-warnings README.md docs/` also passes.
+- Follow [`AGENTS.md`](../AGENTS.md) and run `pre-commit run --all-files`.
+  Ensure `linkchecker --no-warnings README.md docs/` also passes.
 
 REQUEST:
 1. Run the spellcheck and review results.


### PR DESCRIPTION
## Summary
- clarify spellcheck prompt dependencies and link formatting

## Testing
- `pre-commit run --all-files` *(fails: tests/build_pi_image_ps1_test.py: W605, E501)*
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68b3e80df6b4832faaa04dcfd2fff7e4