### PR TITLE
📝 docs: note gh auth for image script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ the docs you will see the term used in both contexts.
 - [docs/network_setup.md](docs/network_setup.md) — connect the Pi cluster to your network
 - [docs/lcd_mount.md](docs/lcd_mount.md) — optional 1602 LCD standoff locations
 - `scripts/` — helper scripts for rendering and exports
-  - `download_pi_image.sh` — fetch the latest Pi image via the GitHub CLI; uses
-    POSIX `-ef` instead of `realpath` for better macOS compatibility
+  - `download_pi_image.sh` — fetch the latest Pi image via the GitHub CLI;
+    requires `gh` to be installed and authenticated. Uses POSIX `-ef` instead
+    of `realpath` for better macOS compatibility
   - `build_pi_image.sh` — build a Raspberry Pi OS image with cloud-init
     preloaded; needs a valid `user-data.yaml` and ~10 GB free disk space
 - `tests/` — quick checks for helper scripts and documentation
@@ -71,7 +72,8 @@ pyspelling -c .spellcheck.yaml
 linkchecker --no-warnings README.md docs/
 ```
 
-The `--no-warnings` flag avoids non-zero exits from benign Markdown parsing warnings.
+The `--no-warnings` flag prevents linkchecker from returning a non-zero exit
+code on benign Markdown parsing warnings.
 
 If the repository includes a `package.json` but `npm` or `package-lock.json`
 are missing, `scripts/checks.sh` will warn and skip JavaScript-specific

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -20,9 +20,9 @@ the Debian mirror with `DEBIAN_MIRROR`. Use `BUILD_TIMEOUT` (default: `4h`) to
 adjust the maximum build duration and `CLOUD_INIT_PATH` to load a custom
 cloud-init configuration instead of the default `scripts/cloud-init/user-data.yaml`.
 
-`REQUIRED_SPACE_GB` (default: `10`) controls the free disk space check.  
+`REQUIRED_SPACE_GB` (default: `10`) controls the free disk space check.
 The script rewrites the Cloudflare apt source architecture to `armhf` when
-`ARM64=0` so 32-bit builds install the correct packages.  
+`ARM64=0` so 32-bit builds install the correct packages.
 
 Set `TUNNEL_TOKEN` or `TUNNEL_TOKEN_FILE` to bake a Cloudflare token into
 `/opt/sugarkube/.cloudflared.env`; otherwise edit the file after boot. The image

--- a/tests/build_pi_image_ps1_test.py
+++ b/tests/build_pi_image_ps1_test.py
@@ -4,7 +4,8 @@ import subprocess
 def test_ps1_has_entrypoint_banner():
     """Ensure the PS1 script prints its startup banner.
 
-    Prevent regressions where the PS1 script only defines functions and exits silently.
+    Prevent regressions where the PS1 script only defines functions and exits
+    silently.
     """
     result = subprocess.run(
         [


### PR DESCRIPTION
## Summary
- clarify that download_pi_image.sh requires an authenticated gh
- wrap test docstring to satisfy flake8
- tidy trailing whitespace in Cloudflare image doc

## Testing
- `python -m pre_commit run --all-files`
- `python -m pyspelling -c .spellcheck.yaml`
- `/root/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md docs/`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b543c82c832f9f4bd6668465be8f