### PR TITLE
docs: link k3s project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 [![Coverage](https://codecov.io/gh/futuroptimist/sugarkube/branch/main/graph/badge.svg)](https://codecov.io/gh/futuroptimist/sugarkube)
 [![license](https://img.shields.io/github/license/futuroptimist/sugarkube)](LICENSE)
 
-An accessible k3s platform for Raspberry Pis and SBCs, integrated with an off-grid solar setup.
+An accessible [k3s](https://k3s.io/) platform for Raspberry Pis and SBCs,
+integrated with an off-grid solar setup.
 The repository also covers the solar cube art installation, which powers aquarium air pumps and
 small computers. It doubles as a living trellis—climbing plants weave through the aluminium
 extrusions while shade-loving herbs thrive beneath the panels. Hanging baskets can clip onto the

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -20,9 +20,9 @@ the Debian mirror with `DEBIAN_MIRROR`. Use `BUILD_TIMEOUT` (default: `4h`) to
 adjust the maximum build duration and `CLOUD_INIT_PATH` to load a custom
 cloud-init configuration instead of the default `scripts/cloud-init/user-data.yaml`.
 
-`REQUIRED_SPACE_GB` (default: `10`) controls the free disk space check.  
+`REQUIRED_SPACE_GB` (default: `10`) controls the free disk space check.
 The script rewrites the Cloudflare apt source architecture to `armhf` when
-`ARM64=0` so 32-bit builds install the correct packages.  
+`ARM64=0` so 32-bit builds install the correct packages.
 
 Set `TUNNEL_TOKEN` or `TUNNEL_TOKEN_FILE` to bake a Cloudflare token into
 `/opt/sugarkube/.cloudflared.env`; otherwise edit the file after boot. The image

--- a/tests/build_pi_image_ps1_test.py
+++ b/tests/build_pi_image_ps1_test.py
@@ -4,7 +4,8 @@ import subprocess
 def test_ps1_has_entrypoint_banner():
     """Ensure the PS1 script prints its startup banner.
 
-    Prevent regressions where the PS1 script only defines functions and exits silently.
+    Prevent regressions where the PS1 script only defines functions
+    and exits silently.
     """
     result = subprocess.run(
         [


### PR DESCRIPTION
## Summary
- add link to k3s homepage in README
- wrap long test docstring and trim whitespace

## Testing
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68b4b543c82c832f9f4bd6668465be8f