### PR TITLE
📝 : document nut standoff mode and fix lint

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -20,9 +20,9 @@ the Debian mirror with `DEBIAN_MIRROR`. Use `BUILD_TIMEOUT` (default: `4h`) to
 adjust the maximum build duration and `CLOUD_INIT_PATH` to load a custom
 cloud-init configuration instead of the default `scripts/cloud-init/user-data.yaml`.
 
-`REQUIRED_SPACE_GB` (default: `10`) controls the free disk space check.  
+`REQUIRED_SPACE_GB` (default: `10`) controls the free disk space check.
 The script rewrites the Cloudflare apt source architecture to `armhf` when
-`ARM64=0` so 32-bit builds install the correct packages.  
+`ARM64=0` so 32-bit builds install the correct packages.
 
 Set `TUNNEL_TOKEN` or `TUNNEL_TOKEN_FILE` to bake a Cloudflare token into
 `/opt/sugarkube/.cloudflared.env`; otherwise edit the file after boot. The image

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -20,8 +20,9 @@ CONTEXT:
   [`stl/`](../stl/).
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these models
   as artifacts. Do not commit `.stl` files.
-- Render each model in both `heatset` and `printed` modes. `STANDOFF_MODE` is case-insensitive and
-  defaults to `heatset`.
+- Render each model in all supported `standoff_mode` variants (for example, `heatset`,
+  `printed`, or `nut`). `STANDOFF_MODE` is case-insensitive and defaults to the model's
+  `standoff_mode` value (typically `heatset`).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
 - Run `pre-commit run --all-files` after changes.
   For documentation updates, also run `pyspelling -c .spellcheck.yaml` (requires `aspell` and
@@ -37,8 +38,9 @@ REQUEST:
 3. Render the model via:
 
    ```bash
-   ./scripts/openscad_render.sh path/to/model.scad  # defaults to heatset
-   STANDOFF_MODE=PRINTED ./scripts/openscad_render.sh path/to/model.scad  # case-insensitive
+   ./scripts/openscad_render.sh path/to/model.scad  # use model's default standoff_mode
+   STANDOFF_MODE=PRINTED ./scripts/openscad_render.sh path/to/model.scad
+   STANDOFF_MODE=NUT ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad
    ```
 
 4. Commit updated SCAD sources and any documentation.

--- a/tests/build_pi_image_ps1_test.py
+++ b/tests/build_pi_image_ps1_test.py
@@ -4,7 +4,8 @@ import subprocess
 def test_ps1_has_entrypoint_banner():
     """Ensure the PS1 script prints its startup banner.
 
-    Prevent regressions where the PS1 script only defines functions and exits silently.
+    Prevent regressions where the PS1 script only defines functions and exits
+    silently.
     """
     result = subprocess.run(
         [


### PR DESCRIPTION
what: mention nut standoff mode in CAD prompt, wrap long test docstring, trim whitespace
why: keep docs current and satisfy lint checks
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68b4b545499c832f99b1a52adcdbd5e5