### PR TITLE
🧪 : test scan-secrets path handling

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -20,9 +20,9 @@ the Debian mirror with `DEBIAN_MIRROR`. Use `BUILD_TIMEOUT` (default: `4h`) to
 adjust the maximum build duration and `CLOUD_INIT_PATH` to load a custom
 cloud-init configuration instead of the default `scripts/cloud-init/user-data.yaml`.
 
-`REQUIRED_SPACE_GB` (default: `10`) controls the free disk space check.  
+`REQUIRED_SPACE_GB` (default: `10`) controls the free disk space check.
 The script rewrites the Cloudflare apt source architecture to `armhf` when
-`ARM64=0` so 32-bit builds install the correct packages.  
+`ARM64=0` so 32-bit builds install the correct packages.
 
 Set `TUNNEL_TOKEN` or `TUNNEL_TOKEN_FILE` to bake a Cloudflare token into
 `/opt/sugarkube/.cloudflared.env`; otherwise edit the file after boot. The image

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -56,7 +56,7 @@ def regex_scan(lines: Iterable[str]) -> bool:
     file_path = None
     for line in lines:
         if line.startswith("+++"):
-            file_path = line[4:]
+            file_path = line[4:].strip()
             continue
         if not line.startswith("+") or file_path == SCAN_SCRIPT_PATH:
             continue

--- a/tests/build_pi_image_ps1_test.py
+++ b/tests/build_pi_image_ps1_test.py
@@ -4,7 +4,8 @@ import subprocess
 def test_ps1_has_entrypoint_banner():
     """Ensure the PS1 script prints its startup banner.
 
-    Prevent regressions where the PS1 script only defines functions and exits silently.
+    Prevent regressions where the PS1 script only defines functions
+    and exits silently.
     """
     result = subprocess.run(
         [

--- a/tests/scan_secrets_test.py
+++ b/tests/scan_secrets_test.py
@@ -1,0 +1,42 @@
+import importlib.util
+import io
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def scan_secrets():
+    spec = importlib.util.spec_from_file_location(
+        "scan_secrets",
+        Path(__file__).resolve().parents[1] / "scripts" / "scan-secrets.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_regex_scan_detects_pattern(scan_secrets):
+    diff = ["+++ b/file.txt", "+api" "_key=123"]
+    assert scan_secrets.regex_scan(diff)
+
+
+def test_regex_scan_ignores_self(scan_secrets):
+    diff = ["+++ b/scripts/scan-secrets.py", "+api" "_key=123"]
+    assert not scan_secrets.regex_scan(diff)
+
+
+def test_main_exit_codes(monkeypatch, scan_secrets):
+    monkeypatch.setattr(scan_secrets, "run_ripsecrets", lambda diff_text: None)
+    monkeypatch.setattr(
+        scan_secrets.sys,
+        "stdin",
+        io.StringIO("+++ b/file\n+safe=1\n"),
+    )
+    assert scan_secrets.main() == 0
+    monkeypatch.setattr(
+        scan_secrets.sys,
+        "stdin",
+        io.StringIO("+++ b/file\n+pass" "word=abc\n"),
+    )
+    assert scan_secrets.main() == 1


### PR DESCRIPTION
## Summary
- add tests covering scan-secrets detection and self-ignore
- strip diff paths in scan-secrets to avoid false positives
- fix pre-commit issues in doc and existing test

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b53aea58832fb7927742e1a02b17