### PR TITLE
build pi-gen image when cache miss

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -90,8 +90,18 @@ jobs:
         if: steps.cache-pigen.outputs.cache-hit == 'true'
         run: docker load -i ~/cache/pi-gen.tar
 
+      - name: Build pi-gen Docker image
+        if: steps.cache-pigen.outputs.cache-hit != 'true'
+        run: |
+          branch=bookworm
+          if [ "${ARM64}" = "1" ]; then
+            branch=arm64
+          fi
+          git clone --depth=1 --branch "${branch}" https://github.com/RPi-Distro/pi-gen.git ~/pi-gen
+          cd ~/pi-gen
+          docker build -t pi-gen:latest .
+
       - name: Verify pi-gen Docker image
-        if: steps.cache-pigen.outputs.cache-hit == 'true'
         run: |
           if ! docker image inspect pi-gen:latest > /dev/null 2>&1; then
             echo "pi-gen:latest Docker image not found!"

--- a/outages/2025-09-01-pi-image-build-pi-gen-cache-miss.json
+++ b/outages/2025-09-01-pi-image-build-pi-gen-cache-miss.json
@@ -1,0 +1,10 @@
+{
+  "id": "pi-image-build-pi-gen-cache-miss",
+  "date": "2025-09-01",
+  "component": "pi-image GitHub workflow",
+  "rootCause": "pi-image build failed when the pi-gen Docker image was missing and not rebuilt",
+  "resolution": "workflow now builds the pi-gen image when the cache is cold before verification",
+  "references": [
+    ".github/workflows/pi-image.yml"
+  ]
+}


### PR DESCRIPTION
## Summary
- build pi-gen Docker image when cache is cold in pi-image workflow
- record outage for missing pi-gen image

## Testing
- `./scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b4fc815148832fa1a1fc1554bfeb2e