### PR TITLE
📝 : refresh test prompt instructions

### DIFF
--- a/docs/prompts-codex-tests.md
+++ b/docs/prompts-codex-tests.md
@@ -15,15 +15,20 @@ PURPOSE:
 Improve and maintain test coverage.
 
 CONTEXT:
-- Tests live in `tests/` and use `pytest`.
-- Run `pytest` and `pre-commit run --all-files` to lint, test, and check docs.
-- Follow AGENTS.md and README.md.
+- Tests live in [`tests/`](../tests/) and use `pytest`.
+- Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
+- Run `pre-commit run --all-files` to lint, format, and test.
+- For documentation updates, also run `pyspelling -c .spellcheck.yaml` (requires
+  `aspell` and `aspell-en`) and `linkchecker --no-warnings README.md docs/`.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`
+  before committing.
 
 REQUEST:
 1. Identify missing or flaky test cases.
 2. Write or update tests in `tests/`.
 3. Adjust implementation if a test exposes a bug.
-4. Re-run `pytest` and `pre-commit run --all-files`.
+4. Re-run `pre-commit run --all-files`.
+5. Scan staged changes for secrets before committing.
 
 OUTPUT:
 A pull request describing the test improvements and confirming checks pass.
@@ -38,8 +43,9 @@ Use this prompt to refine sugarkube's own prompt documentation.
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
 Follow `AGENTS.md` and `README.md`.
-Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
-`linkchecker --no-warnings README.md docs/` before committing.
+Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`,
+`linkchecker --no-warnings README.md docs/`, and
+`git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).

--- a/tests/build_pi_image_ps1_test.py
+++ b/tests/build_pi_image_ps1_test.py
@@ -4,7 +4,8 @@ import subprocess
 def test_ps1_has_entrypoint_banner():
     """Ensure the PS1 script prints its startup banner.
 
-    Prevent regressions where the PS1 script only defines functions and exits silently.
+    Prevent regressions where the PS1 script only defines functions and exits
+    silently.
     """
     result = subprocess.run(
         [


### PR DESCRIPTION
Clarify testing prompt steps and add secret scanning guidance.

- align context links and commands with current repo practices
- wrap long test docstring to satisfy flake8

Test: pre-commit run --all-files
      pyspelling -c .spellcheck.yaml
      linkchecker --no-warnings README.md docs/

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b4b53f5d58832fbedd0582bd409fc3