### PR TITLE
📝 : refine tests prompt and fix ps1 test style

### DIFF
--- a/docs/prompts-codex-tests.md
+++ b/docs/prompts-codex-tests.md
@@ -16,14 +16,15 @@ Improve and maintain test coverage.
 
 CONTEXT:
 - Tests live in `tests/` and use `pytest`.
-- Run `pytest` and `pre-commit run --all-files` to lint, test, and check docs.
-- Follow AGENTS.md and README.md.
+- Run `pre-commit run --all-files` to lint, format, test, and check docs.
+- Use `pytest` for faster feedback.
+- Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
 
 REQUEST:
 1. Identify missing or flaky test cases.
 2. Write or update tests in `tests/`.
 3. Adjust implementation if a test exposes a bug.
-4. Re-run `pytest` and `pre-commit run --all-files`.
+4. Re-run `pre-commit run --all-files`; use `pytest` during development.
 
 OUTPUT:
 A pull request describing the test improvements and confirming checks pass.
@@ -38,8 +39,9 @@ Use this prompt to refine sugarkube's own prompt documentation.
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
 Follow `AGENTS.md` and `README.md`.
-Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
-`linkchecker --no-warnings README.md docs/` before committing.
+Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`,
+`linkchecker --no-warnings README.md docs/`,
+and `git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).

--- a/scripts/build_pi_image.ps1
+++ b/scripts/build_pi_image.ps1
@@ -50,6 +50,7 @@ function Test-CommandAvailable {
   }
 }
 
+
 function Invoke-Docker-Info {
   try {
     & docker info | Out-Null
@@ -592,4 +593,4 @@ try {
 } catch {
   Write-Error ("[sugarkube] Fatal error: {0}" -f $_.Exception.Message)
   exit 1
-}
+ }

--- a/tests/build_pi_image_ps1_test.py
+++ b/tests/build_pi_image_ps1_test.py
@@ -2,12 +2,15 @@ import subprocess
 
 
 def test_ps1_has_entrypoint_banner():
-    # Prevent regressions where the PS1 script only defines functions and exits silently
-    result = subprocess.run(
-        ["/usr/bin/env", "bash", "-lc", "grep -q '\[sugarkube\] Starting Raspberry Pi image build' scripts/build_pi_image.ps1"],
-        capture_output=True,
-        text=True,
-    )
+    """Ensure PowerShell entrypoint prints a starting message."""
+    cmd = [
+        "/usr/bin/env",
+        "bash",
+        "-lc",
+        (
+            "grep -q '\\[sugarkube\\] Starting Raspberry Pi image build' "
+            "scripts/build_pi_image.ps1"
+        ),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
     assert result.returncode == 0, result.stderr
-
-


### PR DESCRIPTION
## Summary
- clarify testing prompt with pre-commit guidance and secret scan reminder
- clean up PowerShell entrypoint test and add missing newline to build script

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3e81ab30c832f8e4354ea54377b9d