### PR TITLE
Add KiBot export reminder to power ring schematic

### DIFF
--- a/elex/power_ring/README.md
+++ b/elex/power_ring/README.md
@@ -12,7 +12,8 @@ Included files:
 
 A title block comment reminds you to place decoupling capacitors near power pins,
 a second note encourages keeping high-current traces short for better performance,
-and a third note urges labeling polarity and voltage on connectors to avoid wiring mistakes.
+a third note urges labeling polarity and voltage on connectors to avoid wiring mistakes,
+and a fourth note reminds you to verify KiBot exports before fabrication.
 
 Open the project in **KiCad 9** or newer and modify the schematic to suit your power distribution needs (for example, add screw terminals, fuses and test points).  Use [KiBot](https://github.com/INTI-CMNB/KiBot) with `.kibot/power_ring.yaml` or run the GitHub workflow to produce Gerber files, a PDF schematic and a BOM in `build/power_ring/`.
 

--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -8,6 +8,7 @@
                 (comment 1 "Place decoupling capacitors near power pins")
                 (comment 2 "Keep high-current traces short")
                 (comment 3 "Label polarity and voltage on connectors")
+                (comment 4 "Verify KiBot exports before fabrication")
         )
         (lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/elex/power_ring/specs.md
+++ b/elex/power_ring/specs.md
@@ -17,6 +17,6 @@ This document outlines the intended features for the Sugarkube power distributio
 
 - Test points for measuring battery voltage
 - Silkscreen labels for polarity and connector numbers
-- Title block comments record decoupling guidelines, connector labeling and export checks
+- Title block comments record decoupling guidelines, high-current trace layout, connector labeling and export checks
 
 These requirements are a starting point – modify the KiCad project as needed and update this file when the schematic changes.

--- a/outages/2025-08-31-kicad-export-kicad9-missing.json
+++ b/outages/2025-08-31-kicad-export-kicad9-missing.json
@@ -1,0 +1,11 @@
+{
+  "id": "2025-08-31-kicad-export-kicad9-missing",
+  "date": "2025-08-31",
+  "component": "kicad",
+  "rootCause": "KiBot export failed; KiCad 9 is unavailable in apt repositories, leaving only KiCad 7 which cannot open project files",
+  "resolution": "Install KiCad 9 or run KiBot with v2_k9 container to generate outputs",
+  "references": [
+    "https://github.com/INTI-CMNB/kibot",
+    "https://kicad.org/download/"
+  ]
+}

--- a/outages/2025-08-31-pre-commit-hooks-build-error.json
+++ b/outages/2025-08-31-pre-commit-hooks-build-error.json
@@ -1,0 +1,11 @@
+{
+  "id": "2025-08-31-pre-commit-hooks-build-error",
+  "date": "2025-08-31",
+  "component": "pre-commit",
+  "rootCause": "pre-commit run failed to install pre-commit-hooks; setuptools missing from isolated build environment",
+  "resolution": "Ensure setuptools is available or pin pre-commit-hooks to a version with wheels",
+  "references": [
+    "https://github.com/pre-commit/pre-commit-hooks",
+    "https://setuptools.pypa.io/en/latest/userguide/quickstart.html"
+  ]
+}


### PR DESCRIPTION
## Summary
- document KiBot export reminder in schematic and docs
- log KiCad 9 and pre-commit hook build failures

## Testing
- `kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml` (fails: KiCad 9 unavailable)
- `pre-commit run --all-files` (fails: setuptools missing for pre-commit-hooks)


------
https://chatgpt.com/codex/tasks/task_e_68b3e834eae0832f932b6474bac4199f