### PR TITLE
build pi-gen image when cache miss

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -73,9 +73,6 @@ jobs:
         id: pigen-key
         run: |
           branch=bookworm
-          if [ "${ARM64}" = "1" ]; then
-            branch=arm64
-          fi
           ref=$(git ls-remote https://github.com/RPi-Distro/pi-gen.git "refs/heads/${branch}" | cut -f1)
           echo "key=pigen-${RUNNER_OS}-${branch}-${ref}-$(date +'%Y-%m')" >> "$GITHUB_OUTPUT"
 
@@ -90,8 +87,14 @@ jobs:
         if: steps.cache-pigen.outputs.cache-hit == 'true'
         run: docker load -i ~/cache/pi-gen.tar
 
+      - name: Build pi-gen Docker image
+        if: steps.cache-pigen.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth=1 --branch bookworm https://github.com/RPi-Distro/pi-gen.git ~/pi-gen
+          cd ~/pi-gen
+          docker build -t pi-gen:latest .
+
       - name: Verify pi-gen Docker image
-        if: steps.cache-pigen.outputs.cache-hit == 'true'
         run: |
           if ! docker image inspect pi-gen:latest > /dev/null 2>&1; then
             echo "pi-gen:latest Docker image not found!"

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -9,8 +9,8 @@ It uses `cloud-init` to bake Docker, the compose plugin, the Cloudflare apt
 repository, and a
 [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/)
 into the OS image. The `build_pi_image.sh` script clones `pi-gen` using
-`PI_GEN_BRANCH` (default: `bookworm` for 32-bit builds and `arm64` for
-64-bit). Set `PI_GEN_URL` to use a fork or mirror if the default repository is
+`PI_GEN_BRANCH` (default: `bookworm`). Set `PI_GEN_URL` to use a fork or mirror
+if the default repository is
 unavailable. `IMG_NAME` controls the output filename and `OUTPUT_DIR` selects
 where artifacts are written; the script creates the directory if needed. To
 reduce flaky downloads it pins the official Raspberry Pi and Debian mirrors and

--- a/outages/2025-09-01-pi-image-build-pi-gen-cache-miss.json
+++ b/outages/2025-09-01-pi-image-build-pi-gen-cache-miss.json
@@ -1,0 +1,10 @@
+{
+  "id": "pi-image-build-pi-gen-cache-miss",
+  "date": "2025-09-01",
+  "component": "pi-image GitHub workflow",
+  "rootCause": "pi-image build failed when the pi-gen Docker image was missing and not rebuilt",
+  "resolution": "workflow now builds the pi-gen image when the cache is cold before verification",
+  "references": [
+    ".github/workflows/pi-image.yml"
+  ]
+}

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -89,15 +89,8 @@ for url in "$DEBIAN_MIRROR" "$RPI_MIRROR" "$PI_GEN_URL"; do
 done
 
 ARM64="${ARM64:-1}"
-# Clone the arm64 branch when building 64-bit images to avoid generating
-# both architectures and exhausting disk space.
-if [ -z "${PI_GEN_BRANCH:-}" ]; then
-  if [ "$ARM64" -eq 1 ]; then
-    PI_GEN_BRANCH="arm64"
-  else
-    PI_GEN_BRANCH="bookworm"
-  fi
-fi
+# Use the release branch; architecture is controlled via the config.
+PI_GEN_BRANCH="${PI_GEN_BRANCH:-bookworm}"
 IMG_NAME="${IMG_NAME:-sugarkube}"
 OUTPUT_DIR="${OUTPUT_DIR:-${REPO_ROOT}}"
 mkdir -p "${OUTPUT_DIR}"

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -369,11 +369,11 @@ def test_uses_default_pi_gen_branch(tmp_path):
     assert (tmp_path / "sugarkube.img.xz").exists()
 
 
-def test_arm64_build_uses_arm64_branch(tmp_path):
+def test_arm64_build_uses_release_branch(tmp_path):
     env = _setup_build_env(tmp_path)
     result, git_args = _run_build_script(tmp_path, env)
     assert result.returncode == 0
-    assert "--branch arm64" in git_args
+    assert "--branch bookworm" in git_args
     assert (tmp_path / "sugarkube.img.xz").exists()
 
 


### PR DESCRIPTION
## Summary
- build pi-gen Docker image when cache is cold in pi-image workflow
- record outage for missing pi-gen image
- always clone bookworm release branch

## Testing
- `pre-commit run --all-files` *(fails: end-of-file-fixer touched .pigen-build scripts)*
- `./scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b4fc815148832fa1a1fc1554bfeb2e