### PR TITLE
🔧 : tag pi-gen image for caching

### DIFF
--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -177,15 +177,20 @@ echo "Starting pi-gen build..."
 ${SUDO} stdbuf -oL -eL timeout "${BUILD_TIMEOUT}" ./build.sh
 echo "pi-gen build finished"
 
-# Ensure the pi-gen Docker image is tagged for caching
+# Ensure a pi-gen Docker image exists and is tagged for caching
 if ! docker image inspect pi-gen:latest >/dev/null 2>&1; then
   img_id=$(docker images --format '{{.Repository}} {{.ID}}' | awk '$1=="pi-gen"{print $2; exit}')
   if [ -n "${img_id}" ]; then
-    docker image tag "${img_id}" pi-gen:latest
+    ${SUDO} docker image tag "${img_id}" pi-gen:latest
   else
     echo "pi-gen Docker image not found" >&2
     exit 1
   fi
+fi
+
+if ! docker image inspect pi-gen:latest >/dev/null 2>&1; then
+  echo "pi-gen Docker image not found" >&2
+  exit 1
 fi
 
 OUT_IMG="${OUTPUT_DIR}/${IMG_NAME}.img.xz"


### PR DESCRIPTION
what: tag existing pi-gen image if pi-gen:latest missing
why: avoids rebuilding with deploy artifacts and keeps workflow cacheable
how to test: pre-commit run --files scripts/build_pi_image.sh

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b5247f2864832fa3040055fd737b07