### PR TITLE
📦 : bundle verifier and optional repo clones in Pi image

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -3,6 +3,19 @@ name: pi-image
 on:
   # Keep manual builds for the heavy job
   workflow_dispatch:
+    inputs:
+      clone_sugarkube:
+        description: "Clone sugarkube repo into image"
+        type: boolean
+        default: false
+      clone_token_place:
+        description: "Clone token.place repo into image"
+        type: boolean
+        default: false
+      clone_dspace:
+        description: "Clone democratizedspace/dspace v3 repo into image"
+        type: boolean
+        default: false
   # Also run the lightweight unit tests automatically when relevant bits change
   pull_request:
     paths:
@@ -38,6 +51,9 @@ jobs:
       ARM64: 1
       DEBIAN_FRONTEND: noninteractive
       BUILD_TIMEOUT: 7200
+      CLONE_SUGARKUBE: ${{ github.event.inputs.clone_sugarkube }}
+      CLONE_TOKEN_PLACE: ${{ github.event.inputs.clone_token_place }}
+      CLONE_DSPACE: ${{ github.event.inputs.clone_dspace }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ the docs you will see the term used in both contexts.
   - `collect_pi_image.sh` — normalize pi-gen output into a single `.img.xz`
     and clean up temporary work directories
   - `build_pi_image.sh` — build a Raspberry Pi OS image with cloud-init
-    preloaded; needs a valid `user-data.yaml` and ~10 GB free disk space
+    preloaded; embeds `pi_node_verifier.sh` and can optionally clone
+    `sugarkube`, `token.place`, and `democratizedspace/dspace` (branch `v3`)
+    when selected in the workflow dispatch; needs a valid `user-data.yaml`
+    and ~10 GB free disk space
+  - `pi_node_verifier.sh` — check k3s prerequisites; use `--json` for machine output
 - `tests/` — quick checks for helper scripts and documentation
 
 Run `pre-commit run --all-files` before committing.

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -26,6 +26,10 @@ The script rewrites the Cloudflare apt source architecture to `armhf` when
 `ARM64=0` so 32-bit builds install the correct packages and sets `ARMHF=0` when
 `ARM64=1` to avoid generating both architectures.
 
+The image embeds `pi_node_verifier.sh` in `/usr/local/sbin` and can optionally
+clone the `sugarkube`, `token.place`, and `democratizedspace/dspace` (branch
+`v3`) repositories under `/opt/projects` when selected via workflow inputs.
+
 Set `TUNNEL_TOKEN` or `TUNNEL_TOKEN_FILE` to bake a Cloudflare token into
 `/opt/sugarkube/.cloudflared.env`; otherwise edit the file after boot. The image
 installs a `cloudflared-compose` systemd unit which starts the tunnel via Docker
@@ -61,9 +65,9 @@ image to bootstrap a three-node k3s cluster; see
 6. Confirm the tunnel is running: `systemctl status cloudflared-compose --no-pager` should show `active`.
 7. View the tunnel logs to confirm a connection:
    `journalctl -u cloudflared-compose -f`.
-8. Clone target projects:
-   - `git clone https://github.com/futuroptimist/token.place.git`
-   - `git clone https://github.com/democratizedspace/dspace.git`
+8. If any repositories were selected during the build, explore them under
+   `/opt/projects` (e.g. `sugarkube`, `token.place`, or `dspace` on branch
+   `v3`).
 9. Add more `docker-compose` files for additional services.
 
 ## GitHub Actions

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -140,6 +140,32 @@ fi
 install -Dm644 "${REPO_ROOT}/scripts/cloud-init/docker-compose.cloudflared.yml" \
   "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/docker-compose.cloudflared.yml"
 
+# Bundle pi_node_verifier and optionally clone repos into the image
+install -Dm755 "${REPO_ROOT}/scripts/pi_node_verifier.sh" \
+  "${WORK_DIR}/pi-gen/stage2/02-sugarkube-tools/files/usr/local/sbin/pi_node_verifier.sh"
+
+CLONE_SUGARKUBE="${CLONE_SUGARKUBE:-false}"
+CLONE_TOKEN_PLACE="${CLONE_TOKEN_PLACE:-false}"
+CLONE_DSPACE="${CLONE_DSPACE:-false}"
+
+run_sh="${WORK_DIR}/pi-gen/stage2/02-sugarkube-tools/00-run.sh"
+{
+  echo "#!/usr/bin/env bash"
+  echo "set -euo pipefail"
+  if [[ "$CLONE_SUGARKUBE" == "true" || "$CLONE_TOKEN_PLACE" == "true" || "$CLONE_DSPACE" == "true" ]]; then
+    echo "apt-get update"
+    echo "apt-get install -y git"
+    echo "install -d /opt/projects"
+    echo "cd /opt/projects"
+    [[ "$CLONE_SUGARKUBE" == "true" ]] && echo "git clone --depth 1 https://github.com/futuroptimist/sugarkube.git"
+    [[ "$CLONE_TOKEN_PLACE" == "true" ]] && echo "git clone --depth 1 https://github.com/futuroptimist/token.place.git"
+    [[ "$CLONE_DSPACE" == "true" ]] && echo "git clone --depth 1 --branch v3 https://github.com/democratizedspace/dspace.git"
+  else
+    echo 'echo "no optional repositories selected; skipping clones"'
+  fi
+} > "$run_sh"
+chmod +x "$run_sh"
+
 cd "${WORK_DIR}/pi-gen"
 export DEBIAN_FRONTEND=noninteractive
 

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -38,6 +38,13 @@ fi
 # run tests
 pytest --cov=. --cov-report=xml --cov-report=term -q
 
+# run bats tests when available
+if command -v bats >/dev/null 2>&1 && ls tests/*.bats >/dev/null 2>&1; then
+  bats tests/*.bats
+else
+  echo "bats not found or no Bats tests, skipping" >&2
+fi
+
 # docs checks
 if ! command -v aspell >/dev/null 2>&1; then
   if command -v apt-get >/dev/null 2>&1; then

--- a/scripts/pi_node_verifier.sh
+++ b/scripts/pi_node_verifier.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+JSON=false
+for arg in "$@"; do
+  case "$arg" in
+    --json) JSON=true ;;
+    --help) echo "Usage: $0 [--json]"; exit 0 ;;
+  esac
+done
+
+json_parts=()
+print_result() {
+  local name="$1"
+  local status="$2"
+  if ! $JSON; then
+    printf '%s: %s\n' "$name" "$status"
+  fi
+  json_parts+=('{"name":"'"$name"'","status":"'"$status"'"}')
+}
+
+# cgroup memory
+if [[ -f /sys/fs/cgroup/cgroup.controllers ]] && \
+   grep -qw 'cgroup_memory=1' /proc/cmdline && \
+   grep -qw 'cgroup_enable=memory' /proc/cmdline; then
+  print_result "cgroup_memory" "pass"
+else
+  print_result "cgroup_memory" "fail"
+fi
+
+# cloud-init status
+if command -v cloud-init >/dev/null 2>&1; then
+  if cloud-init status --wait >/dev/null 2>&1; then
+    print_result "cloud_init" "pass"
+  else
+    print_result "cloud_init" "fail"
+  fi
+else
+  print_result "cloud_init" "skip"
+fi
+
+# time synchronization
+if command -v timedatectl >/dev/null 2>&1; then
+  if timedatectl show -p NTPSynchronized --value 2>/dev/null | grep -q yes; then
+    print_result "time_sync" "pass"
+  else
+    print_result "time_sync" "fail"
+  fi
+else
+  print_result "time_sync" "skip"
+fi
+
+# iptables backend
+if command -v iptables >/dev/null 2>&1; then
+  if iptables --version 2>/dev/null | grep -qi nf_tables; then
+    print_result "iptables_backend" "pass"
+  else
+    print_result "iptables_backend" "fail"
+  fi
+else
+  print_result "iptables_backend" "skip"
+fi
+
+# optional k3s check-config
+if command -v k3s >/dev/null 2>&1; then
+  if k3s check-config >/dev/null 2>&1; then
+    print_result "k3s_check_config" "pass"
+  else
+    print_result "k3s_check_config" "fail"
+  fi
+else
+  print_result "k3s_check_config" "skip"
+fi
+
+if $JSON; then
+  printf '{"checks":[%s]}\n' "$(IFS=,; echo "${json_parts[*]}")"
+fi

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -340,6 +340,11 @@ def _run_build_script(tmp_path, env):
     collect.write_text(collect_src.read_text())
     collect.chmod(0o755)
 
+    verifier_src = repo_root / "scripts" / "pi_node_verifier.sh"
+    verifier = script_dir / "pi_node_verifier.sh"
+    verifier.write_text(verifier_src.read_text())
+    verifier.chmod(0o755)
+
     ci_dir = script_dir / "cloud-init"
     ci_dir.mkdir(parents=True)
     user_src = repo_root / "scripts" / "cloud-init" / "user-data.yaml"

--- a/tests/pi_node_verifier_json_test.bats
+++ b/tests/pi_node_verifier_json_test.bats
@@ -1,0 +1,7 @@
+#!/usr/bin/env bats
+
+@test "pi_node_verifier emits valid JSON" {
+  run scripts/pi_node_verifier.sh --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.checks | length > 0' > /dev/null
+}


### PR DESCRIPTION
what: embed pi_node_verifier in built image and allow optional repo clones via workflow checkboxes
why: keep Pi image focused on sugarkube while letting builders include other repos when needed
how to test: pre-commit run --all-files
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68b53d3a4e8c832f8b9fd45882b6efd6