### PR TITLE
Add saddle cap tray extension for Mac mini station

### DIFF
--- a/hardware/mac-mini-station/LICENSE
+++ b/hardware/mac-mini-station/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 futuroptimist
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/hardware/mac-mini-station/README.md
+++ b/hardware/mac-mini-station/README.md
@@ -1,0 +1,22 @@
+# Mac mini station
+
+Press-fit saddle cap extension for the Mac mini M4 keyboard station. The cap slides over the
+existing top saddle and widens the keyboard tray so a Magic Keyboard or TKL board will not tip
+off when bumped.
+
+## Usage
+
+1. Pick keyboard width preset in `scad/mac_mini_station.scad`.
+2. Run `scripts/build.sh` to export STL files.
+3. Print the cap upside down without supports.
+4. Start with `press_fit_clearance_mm = 0.35` and adjust after a test fit.
+
+## Attribution
+
+Inspired by [Magic Tray – Holder for Apple's Magic Keyboard and Trackpad](https://archive.org/details/thingiverse-4910431)
+(Thingiverse 4910431) by reddit user **CaptainDarwin**, licensed under CC BY-NC-SA 4.0. This
+repository links to the original design and does not redistribute their files.
+
+## License
+
+Code is licensed under the MIT License, see [LICENSE](LICENSE).

--- a/hardware/mac-mini-station/scad/mac_mini_station.scad
+++ b/hardware/mac-mini-station/scad/mac_mini_station.scad
@@ -1,0 +1,142 @@
+// Mac mini M4 station with Magic Keyboard tray
+
+// keyboard width presets
+// keyboard_width_mm = 418.7; // full
+keyboard_width_mm = 279;      // tenkeyless
+
+keyboard_depth_mm = 114.9;
+keyboard_front_height_mm = 4.1;
+keyboard_back_height_mm = 10.9;
+
+keyboard_incline_degrees = 3.387;
+keyboard_full_stand_degrees = 40;
+keyboard_incline_height_diff = keyboard_back_height_mm - keyboard_front_height_mm;
+
+subtraction_padding_mm = 4;
+subtraction_z_offset = keyboard_incline_height_diff + 1.4;
+subtraction_x_offset = 0.5;
+subtraction_vertical_padding = 2;
+
+corner_radius = 9;
+cylinder_height = keyboard_back_height_mm + 0.1;
+
+mac_mini_m4_corner_radius = 18;
+mac_mini_side_grille_gap = 4;
+mac_mini_height = 43.5;
+mac_mini_platform_wall_width = 5;
+mac_mini_height_full = 50;
+mac_mini_depth = 127;
+mac_mini_saddle_wall_width = 2;
+
+keyboard_middle_offset =
+    keyboard_width_mm / 2 - mac_mini_height / 2 - mac_mini_platform_wall_width * 2;
+
+PRINT_MAIN_STATION = true;
+PRINT_SADDLE_CAP = true;
+include <modules/saddle_cap_extension.scad>;
+
+module keyboard_body_with_rounding() {
+    hull() {
+        translate([corner_radius, corner_radius, 0])
+            cylinder(h = cylinder_height, r = corner_radius);
+        translate([keyboard_width_mm - corner_radius, corner_radius, 0])
+            cylinder(h = cylinder_height, r = corner_radius);
+        translate([corner_radius, keyboard_depth_mm - corner_radius, 0])
+            cylinder(h = cylinder_height, r = corner_radius);
+        translate([keyboard_width_mm - corner_radius, keyboard_depth_mm - corner_radius, 0])
+            cylinder(h = cylinder_height, r = corner_radius);
+    }
+}
+
+module inclined_cutout() {
+    translate([-subtraction_x_offset, 0, subtraction_z_offset * 0.5])
+        rotate([keyboard_incline_degrees, 0, 0])
+        cube([
+            keyboard_width_mm + subtraction_padding_mm,
+            keyboard_depth_mm + subtraction_padding_mm,
+            keyboard_back_height_mm + subtraction_vertical_padding
+        ]);
+}
+
+module mac_mini_m4_platform() {
+    translate([keyboard_middle_offset, 0, 0])
+        cube([
+            mac_mini_height + mac_mini_platform_wall_width * 2,
+            keyboard_depth_mm,
+            keyboard_back_height_mm
+        ]);
+    translate([keyboard_middle_offset, 0, keyboard_back_height_mm])
+        cube([mac_mini_platform_wall_width, keyboard_depth_mm, mac_mini_side_grille_gap]);
+    translate([
+        keyboard_width_mm / 2 + mac_mini_height / 2 - mac_mini_platform_wall_width,
+        0,
+        keyboard_back_height_mm
+    ])
+        cube([mac_mini_platform_wall_width, keyboard_depth_mm, mac_mini_side_grille_gap]);
+    translate([
+        keyboard_width_mm / 2 - mac_mini_height / 2 - mac_mini_platform_wall_width,
+        0,
+        keyboard_back_height_mm
+    ])
+        cube([mac_mini_height, mac_mini_platform_wall_width, mac_mini_side_grille_gap]);
+    translate([
+        keyboard_width_mm / 2 - mac_mini_height / 2 - mac_mini_platform_wall_width,
+        keyboard_depth_mm - mac_mini_platform_wall_width,
+        keyboard_back_height_mm
+    ])
+        cube([mac_mini_height, mac_mini_platform_wall_width, mac_mini_side_grille_gap]);
+}
+
+module mac_mini_m4_top_saddle() {
+    difference() {
+        translate([keyboard_middle_offset - 6, 0, 100])
+            cube([
+                mac_mini_height_full + mac_mini_saddle_wall_width * 2 + 0.4 + 10,
+                mac_mini_depth + 0.4 + 10,
+                60
+            ]);
+        translate([keyboard_middle_offset, 5, 80])
+            cube([
+                mac_mini_height_full + mac_mini_saddle_wall_width * 2 + 0.4,
+                mac_mini_depth + 0.4,
+                75
+            ]);
+        translate([keyboard_middle_offset + 22.2 - 2.5, -40, 75]) cube([20, 50, 100]);
+        translate([
+            keyboard_middle_offset + 36.3 - 12,
+            keyboard_depth_mm + mac_mini_platform_wall_width + 10,
+            95
+        ])
+            cube([12, 12, 60]);
+    }
+}
+
+module keyboard_full_tray() {
+    difference() {
+        translate([keyboard_middle_offset + 1, 118, 159])
+            rotate([90 + keyboard_full_stand_degrees, 0, 0])
+            cube([50, keyboard_depth_mm, 100]);
+        translate([keyboard_middle_offset - 3, -100, 50])
+            cube([55, keyboard_depth_mm, 200]);
+        translate([keyboard_middle_offset - 3, 0, 50])
+            cube([55, keyboard_depth_mm, 110]);
+    }
+    translate([keyboard_middle_offset - 50, 114, 156])
+        rotate([keyboard_full_stand_degrees, 0, 0]) cube([150, 5, 45]);
+    translate([keyboard_middle_offset + 1, 120.15, 156])
+        rotate([keyboard_full_stand_degrees, 0, 0]) cube([50, 5, 5]);
+}
+
+if (PRINT_MAIN_STATION) {
+    difference() {
+        keyboard_body_with_rounding();
+        inclined_cutout();
+    }
+    mac_mini_m4_platform();
+    mac_mini_m4_top_saddle();
+    keyboard_full_tray();
+}
+
+if (PRINT_SADDLE_CAP) {
+    saddle_cap_tray_extension();
+}

--- a/hardware/mac-mini-station/scad/modules/saddle_cap_extension.scad
+++ b/hardware/mac-mini-station/scad/modules/saddle_cap_extension.scad
@@ -1,0 +1,75 @@
+// ------------------------------
+// Saddle-cap tray extension (press-fit add-on)
+// ------------------------------
+
+// --- User-tunable parameters ---
+press_fit_clearance_mm      = 0.35; // per side; adjust for printer tolerance
+cap_wall_mm                 = 2.4;  // side walls thickness
+cap_grip_height_mm          = 16;   // how far cap slides down over saddle
+cap_top_plate_thickness_mm  = 3;    // thickness of plate under keyboard
+wing_depth_mm               = min(keyboard_depth_mm, mac_mini_depth + 10);
+wing_extra_each_side_mm     = max(
+    40,
+    (keyboard_width_mm - (mac_mini_height_full + mac_mini_saddle_wall_width * 2)) / 2 - 6
+);
+curb_height_mm              = 1.0;  // low side curb height
+curb_thickness_mm           = 1.2;  // low side curb thickness
+
+// --- Helper functions for existing saddle bbox ---
+function saddle_outer_pos() = [keyboard_middle_offset - 6, 0, 100];
+function saddle_outer_size() = [
+    mac_mini_height_full + mac_mini_saddle_wall_width * 2 + 0.4 + 10,
+    mac_mini_depth + 0.4 + 10,
+    60
+];
+
+module saddle_cap_tray_extension() {
+    S = saddle_outer_size();
+    O = saddle_outer_pos();
+    cap_top_z = O[2] + S[2];
+
+    // 1) press-fit cap shell
+    difference() {
+        translate([
+            O[0] - cap_wall_mm,
+            O[1] - cap_wall_mm,
+            cap_top_z - cap_grip_height_mm - cap_top_plate_thickness_mm
+        ])
+            cube([
+                S[0] + 2 * cap_wall_mm,
+                S[1] + 2 * cap_wall_mm,
+                cap_grip_height_mm + cap_top_plate_thickness_mm
+            ]);
+
+        translate([
+            O[0] - press_fit_clearance_mm,
+            O[1] - press_fit_clearance_mm,
+            cap_top_z - cap_grip_height_mm - 0.2
+        ])
+            cube([
+                S[0] + 2 * press_fit_clearance_mm,
+                S[1] + 2 * press_fit_clearance_mm,
+                cap_grip_height_mm + 0.4
+            ]);
+    }
+
+    // 2) left and right wings to widen support
+    wing_y_start = O[1] + (S[1] - wing_depth_mm) / 2;
+
+    translate([O[0] - wing_extra_each_side_mm, wing_y_start, cap_top_z])
+        cube([wing_extra_each_side_mm, wing_depth_mm, cap_top_plate_thickness_mm]);
+    translate([O[0] + S[0], wing_y_start, cap_top_z])
+        cube([wing_extra_each_side_mm, wing_depth_mm, cap_top_plate_thickness_mm]);
+
+    // 3) optional curbs at far edges
+    if (curb_height_mm > 0) {
+        translate([O[0] - wing_extra_each_side_mm, wing_y_start, cap_top_z])
+            cube([curb_thickness_mm, wing_depth_mm, curb_height_mm]);
+        translate([
+            O[0] + S[0] + wing_extra_each_side_mm - curb_thickness_mm,
+            wing_y_start,
+            cap_top_z
+        ])
+            cube([curb_thickness_mm, wing_depth_mm, curb_height_mm]);
+    }
+}

--- a/hardware/mac-mini-station/scripts/build.sh
+++ b/hardware/mac-mini-station/scripts/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAD="$ROOT/scad/mac_mini_station.scad"
+mkdir -p "$ROOT/stl"
+# Export full station
+openscad -o "$ROOT/stl/mac_mini_station.stl" \
+  -D PRINT_MAIN_STATION=true -D PRINT_SADDLE_CAP=false "$SCAD"
+# Export saddle cap only
+openscad -o "$ROOT/stl/saddle_cap_extension.stl" \
+  -D PRINT_MAIN_STATION=false -D PRINT_SADDLE_CAP=true "$SCAD"
+echo "STLs exported to ./stl"

--- a/hardware/mac-mini-station/stl/.gitignore
+++ b/hardware/mac-mini-station/stl/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- add Mac mini station scaffold and press-fit saddle cap module
- document usage and third-party Magic Tray attribution
- provide build script to export STLs

## Testing
- `STANDOFF_MODE=heatset scripts/openscad_render.sh hardware/mac-mini-station/scad/mac_mini_station.scad`
- `STANDOFF_MODE=printed scripts/openscad_render.sh hardware/mac-mini-station/scad/mac_mini_station.scad`
- `pre-commit run --files hardware/mac-mini-station/README.md hardware/mac-mini-station/LICENSE hardware/mac-mini-station/scad/mac_mini_station.scad hardware/mac-mini-station/scad/modules/saddle_cap_extension.scad hardware/mac-mini-station/scripts/build.sh hardware/mac-mini-station/stl/.gitignore hardware/mac-mini-station/images/.gitkeep`
- `git diff --cached | scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68b60886ba80832f8895f675fdfa0861