### PR TITLE
📝 docs: clarify codex prompt instructions

### DIFF
--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -8,7 +8,7 @@ slug: 'prompts-codex'
 Use this prompt to guide OpenAI Codex or similar agents when contributing to
 this repository.
 
-```
+```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
 
@@ -16,10 +16,12 @@ PURPOSE:
 Keep the project healthy by making small, well-tested improvements.
 
 CONTEXT:
-- Follow AGENTS.md and README.md.
+- Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
 - Run `pre-commit run --all-files` to lint, test and validate docs.
 - On documentation changes ensure `pyspelling -c .spellcheck.yaml` (requires `aspell` and
   `aspell-en`) and `linkchecker --no-warnings README.md docs/` succeed.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
+  committing.
 - Log persistent failures in `outages/` as JSON per `outages/schema.json`.
 
 REQUEST:
@@ -40,9 +42,10 @@ Use this prompt to refine sugarkube's own prompt documentation.
 ```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
-Follow `AGENTS.md` and `README.md`.
-Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
-`linkchecker --no-warnings README.md docs/` before committing.
+Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
+Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires `aspell` and
+`aspell-en`), `linkchecker --no-warnings README.md docs/`, and
+`git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).


### PR DESCRIPTION
## Summary
- link to AGENTS.md and README.md
- note secret-scanning step

## Testing
- `python3 -m pre_commit run --files docs/prompts-codex.md`
- `python3 -m pyspelling -c .spellcheck.yaml`
- `/root/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6094304f8832f8fd4fc50e180c02d