### PR TITLE
Ensure cloudflared tunnel waits for network

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -10,31 +10,17 @@ It uses `cloud-init` to update and upgrade packages, bake Docker, the compose
 plugin, the Cloudflare apt repository, and a
 [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/)
 into the OS image. The `build_pi_image.sh` script clones `pi-gen` using
-<<<<<<< HEAD
 `PI_GEN_BRANCH` (default: `bookworm`). Set `PI_GEN_URL` to use a fork or mirror
 if the default repository is unavailable. `IMG_NAME` controls the output filename
 and `OUTPUT_DIR` selects where artifacts are written; the script creates the
 directory if needed. To reduce flaky downloads it pins the official Raspberry Pi
-and Debian mirrors and passes `APT_OPTS` so apt retries on transient timeouts.
-Override the Raspberry Pi packages mirror with `RPI_MIRROR` (mapped to pi-gen's
-`APT_MIRROR_RASPBERRYPI`) and the Debian mirror with `DEBIAN_MIRROR`. Use
-`BUILD_TIMEOUT` (default: `4h`) to adjust the maximum build duration and
-`CLOUD_INIT_PATH` to load a custom cloud-init configuration instead of the
-default `scripts/cloud-init/user-data.yaml`.
-=======
-`PI_GEN_BRANCH` (default: `bookworm` for 32-bit builds and `arm64` for
-64-bit). Set `PI_GEN_URL` to use a fork or mirror if the default repository is
-unavailable. `IMG_NAME` controls the output filename and `OUTPUT_DIR` selects
-where artifacts are written; the script creates the directory if needed. To
-reduce flaky downloads it pins the official Raspberry Pi and Debian mirrors,
-adds `APT_OPTS` (retries, timeouts, `--fix-missing`), and installs a persistent
-apt/dpkg Pre-Invoke hook that rewrites any raspbian host to a stable HTTPS
-mirror before each apt action. Override the Raspberry Pi
-packages mirror with `RPI_MIRROR` (mapped to pi-gen's `APT_MIRROR_RASPBERRYPI`) and
-the Debian mirror with `DEBIAN_MIRROR`. Use `BUILD_TIMEOUT` (default: `4h`) to
-adjust the maximum build duration and `CLOUD_INIT_PATH` to load a custom
-cloud-init configuration instead of the default `scripts/cloud-init/user-data.yaml`.
->>>>>>> a1a90dc (docs: document mirror rewrite hook, proxy exceptions, zip-only export handling; link builder design)
+and Debian mirrors, passes `APT_OPTS` with retries and timeouts, and installs a
+persistent apt/dpkg Pre-Invoke hook that rewrites any raspbian host to a stable
+HTTPS mirror before each apt action. Override the Raspberry Pi packages mirror
+with `RPI_MIRROR` (mapped to pi-gen's `APT_MIRROR_RASPBERRYPI`) and the Debian
+mirror with `DEBIAN_MIRROR`. Use `BUILD_TIMEOUT` (default: `4h`) to adjust the
+maximum build duration and `CLOUD_INIT_PATH` to load a custom cloud-init
+configuration instead of the default `scripts/cloud-init/user-data.yaml`.
 
 `REQUIRED_SPACE_GB` (default: `10`) controls the free disk space check.
 The script rewrites the Cloudflare apt source architecture to `armhf` when
@@ -48,8 +34,9 @@ repositories under `/opt/projects`.
 Set `TUNNEL_TOKEN` or `TUNNEL_TOKEN_FILE` to bake a Cloudflare token into
 `/opt/sugarkube/.cloudflared.env`; otherwise edit the file after boot. The image
 installs a `cloudflared-compose` systemd unit which starts the tunnel via Docker
-once the token is present. The script curls the Debian, Raspberry Pi, and pi-gen
-repositories with a 10-second timeout before building; override this via the
+once the token is present and waits for `network-online.target` to ensure
+connectivity. The script curls the Debian, Raspberry Pi, and pi-gen repositories
+with a 10-second timeout before building; override this via the
 `URL_CHECK_TIMEOUT` environment variable. Ensure `curl`, `docker` (with its
 daemon running), `git`, `sha256sum`, `stdbuf`, `timeout`, and `xz` are installed
 before running it; `stdbuf` and `timeout` come from GNU coreutils. The script
@@ -71,8 +58,8 @@ image to bootstrap a three-node k3s cluster; see
 4. The build script copies `docker-compose.cloudflared.yml` into
    `/opt/sugarkube/`. Cloud-init adds the Cloudflare apt repo, pre-creates
    `/opt/sugarkube/.cloudflared.env` with `0600` permissions, installs the
-   `cloudflared-compose` systemd unit, and enables Docker; verify the files and
-   service.
+   `cloudflared-compose` systemd unit (wired to `network-online.target`), and
+   enables Docker; verify the files and service.
 5. Add your Cloudflare token to `/opt/sugarkube/.cloudflared.env` if it wasn't
    provided via `TUNNEL_TOKEN` or `TUNNEL_TOKEN_FILE` during the build. The
    tunnel starts automatically when the token exists; otherwise run:

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -26,6 +26,7 @@ write_files:
       Description=Cloudflare Tunnel via docker compose
       Requires=docker.service
       After=docker.service network-online.target
+      Wants=network-online.target
 
       [Service]
       Type=oneshot


### PR DESCRIPTION
## Summary
- make cloudflared-compose systemd unit wait for network-online target
- document network dependency and clean up Cloudflare image guide

## Testing
- `SKIP=end-of-file-fixer pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68b60940edcc832f81aa11c10e112f9e