### PR TITLE
📝 : clarify spellcheck prompt checks

### DIFF
--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -7,7 +7,7 @@ slug: 'prompts-codex-spellcheck'
 
 Use this prompt to catch and correct spelling issues in Markdown docs.
 
-```
+```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
 
@@ -17,7 +17,9 @@ Keep Markdown documentation free of spelling errors.
 CONTEXT:
 - Run `pyspelling -c .spellcheck.yaml` to scan `README.md` and `docs/`.
 - Add legitimate new words to `.wordlist.txt`.
-- Follow AGENTS.md and run `pre-commit run --all-files`; ensure `linkchecker --no-warnings README.md docs/` also passes.
+- Follow [AGENTS.md](../AGENTS.md) and run `pre-commit run --all-files`.
+- Ensure `linkchecker --no-warnings README.md docs/` passes.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 
 REQUEST:
 1. Run the spellcheck and review results.
@@ -37,8 +39,9 @@ Use this prompt to refine sugarkube's own prompt documentation.
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
 Follow `AGENTS.md` and `README.md`.
-Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
-`linkchecker --no-warnings README.md docs/` before committing.
+Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`,
+`linkchecker --no-warnings README.md docs/`, and
+`git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).


### PR DESCRIPTION
## Summary
- document secret scanning and link checks in spellcheck prompt

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`

------
https://chatgpt.com/codex/tasks/task_e_68b6787d8b60832fb610ce3a4477a1fc