### PR TITLE
📝 : clarify OpenSCAD requirement in CAD prompt

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -17,7 +17,8 @@ Keep OpenSCAD sources current and ensure they render cleanly.
 CONTEXT:
 - CAD files reside in [`cad/`](../cad/).
 - Use [`scripts/openscad_render.sh`](../scripts/openscad_render.sh) to export STL meshes into
-  [`stl/`](../stl/).
+  [`stl/`](../stl/). Ensure [OpenSCAD](https://openscad.org/) is installed and available in
+  `PATH`; the script exits early if it cannot find the binary.
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these models
   as artifacts. Do not commit `.stl` files.
 - Render each model in all supported `standoff_mode` variants (for example, `heatset`


### PR DESCRIPTION
## Summary
- note OpenSCAD dependency in CAD prompt doc

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`
- `npm run lint` (fails: ENOENT package.json)
- `npm run test:ci` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b6786f91c8832fa2ea0fc9d8077960