### PR TITLE
Enable token.place and dspace on Pi image

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ the docs you will see the term used in both contexts.
   - `collect_pi_image.sh` — normalize pi-gen output into a single `.img.xz`
     and clean up temporary work directories
   - `build_pi_image.sh` — build a Raspberry Pi OS image with cloud-init
-    preloaded; embeds `pi_node_verifier.sh` and can optionally clone
-    `sugarkube`, `token.place`, and `democratizedspace/dspace` (branch `v3`)
-    when selected in the workflow dispatch; needs a valid `user-data.yaml`
+    preloaded; embeds `pi_node_verifier.sh` and clones `token.place` and
+    `democratizedspace/dspace` (branch `v3`) by default. Set
+    `CLONE_SUGARKUBE=true` to include this repo and pass space-separated Git
+    URLs via `EXTRA_REPOS` to clone additional projects; needs a valid `user-data.yaml`
     and ~10 GB free disk space
   - `pi_node_verifier.sh` — check k3s prerequisites; use `--json` for machine output
 - `outages/` — structured outage records (see

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ Review the safety notes before working with power components.
 - [pi_image_cloudflare.md](pi_image_cloudflare.md) — preconfigure Docker and Cloudflare tunnels
 - [raspi_cluster_setup.md](raspi_cluster_setup.md) — build a three-node k3s cluster and deploy apps
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
+- [pi_token_dspace.md](pi_token_dspace.md) — run token.place and dspace on the Pi image
 - [pi_image_builder_design.md](pi_image_builder_design.md) — design and reliability features of the image builder
 
 ## Learn the Fundamentals

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -31,9 +31,10 @@ The script rewrites the Cloudflare apt source architecture to `armhf` when
 `ARM64=0` so 32-bit builds install the correct packages and sets `ARMHF=0` when
 `ARM64=1` to avoid generating both architectures.
 
-The image embeds `pi_node_verifier.sh` in `/usr/local/sbin` and can optionally
-clone the `sugarkube`, `token.place`, and `democratizedspace/dspace` (branch
-`v3`) repositories under `/opt/projects` when selected via workflow inputs.
+The image embeds `pi_node_verifier.sh` in `/usr/local/sbin` and clones the
+`token.place` and `democratizedspace/dspace` (branch `v3`) repositories into
+`/opt/projects` by default. Set `CLONE_SUGARKUBE=true` to include this repo and
+pass space-separated Git URLs in `EXTRA_REPOS` to pull additional projects.
 
 Set `TUNNEL_TOKEN` or `TUNNEL_TOKEN_FILE` to bake a Cloudflare token into
 `/opt/sugarkube/.cloudflared.env`; otherwise edit the file after boot. The image

--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -1,0 +1,49 @@
+# token.place and dspace Quickstart
+
+Build a Raspberry Pi 5 image that includes the
+[token.place](https://github.com/futuroptimist/token.place) and
+[dspace](https://github.com/democratizedspace/dspace) repositories so you can run
+both apps out of the box. The image builder clones these projects and leaves
+hooks for additional repositories.
+
+## Build the image
+
+```sh
+# inside the sugarkube repo
+./scripts/build_pi_image.sh
+```
+
+`build_pi_image.sh` clones `token.place` and `dspace` by default. To add more
+projects, pass their Git URLs via `EXTRA_REPOS`:
+
+```sh
+EXTRA_REPOS="https://github.com/example/repo.git" ./scripts/build_pi_image.sh
+```
+
+The script clones each repo into `/opt/projects` and assigns ownership to the
+`pi` user.
+
+## Run the apps
+
+After flashing the image and booting the Pi, start the services:
+
+```sh
+# token.place
+cd /opt/projects/token.place
+docker buildx build --platform linux/arm64 -f docker/Dockerfile.server -t tokenplace . --load
+docker run -d --name tokenplace -p 5000:5000 tokenplace
+
+# dspace frontend
+cd /opt/projects/dspace/frontend
+cp .env.example .env  # if the file exists
+docker compose up -d
+```
+
+Visit `http://<pi-host>:5000` for token.place and `http://<pi-host>:3000` for
+dspace. To expose them through a Cloudflare Tunnel, update
+`/opt/sugarkube/docker-compose.cloudflared.yml` as shown in
+[docker_repo_walkthrough.md](docker_repo_walkthrough.md).
+
+Use `EXTRA_REPOS` to experiment with other projects and extend the image over
+time.
+

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -160,14 +160,15 @@ install -Dm755 "${REPO_ROOT}/scripts/pi_node_verifier.sh" \
   "${WORK_DIR}/pi-gen/stage2/02-sugarkube-tools/files/usr/local/sbin/pi_node_verifier.sh"
 
 CLONE_SUGARKUBE="${CLONE_SUGARKUBE:-false}"
-CLONE_TOKEN_PLACE="${CLONE_TOKEN_PLACE:-false}"
-CLONE_DSPACE="${CLONE_DSPACE:-false}"
+CLONE_TOKEN_PLACE="${CLONE_TOKEN_PLACE:-true}"
+CLONE_DSPACE="${CLONE_DSPACE:-true}"
+EXTRA_REPOS="${EXTRA_REPOS:-}"
 
 run_sh="${WORK_DIR}/pi-gen/stage2/02-sugarkube-tools/00-run-chroot.sh"
 {
   echo "#!/usr/bin/env bash"
   echo "set -euo pipefail"
-  if [[ "$CLONE_SUGARKUBE" == "true" || "$CLONE_TOKEN_PLACE" == "true" || "$CLONE_DSPACE" == "true" ]]; then
+  if [[ "$CLONE_SUGARKUBE" == "true" || "$CLONE_TOKEN_PLACE" == "true" || "$CLONE_DSPACE" == "true" || -n "$EXTRA_REPOS" ]]; then
     echo "apt-get update"
     echo "apt-get install -y git"
     echo "install -d /opt/projects"
@@ -175,6 +176,12 @@ run_sh="${WORK_DIR}/pi-gen/stage2/02-sugarkube-tools/00-run-chroot.sh"
     [[ "$CLONE_SUGARKUBE" == "true" ]] && echo "git clone --depth 1 https://github.com/futuroptimist/sugarkube.git"
     [[ "$CLONE_TOKEN_PLACE" == "true" ]] && echo "git clone --depth 1 https://github.com/futuroptimist/token.place.git"
     [[ "$CLONE_DSPACE" == "true" ]] && echo "git clone --depth 1 --branch v3 https://github.com/democratizedspace/dspace.git"
+    if [[ -n "$EXTRA_REPOS" ]]; then
+      for repo in $EXTRA_REPOS; do
+        echo "git clone --depth 1 $repo"
+      done
+    fi
+    echo "chown -R pi:pi /opt/projects"
   else
     echo 'echo "no optional repositories selected; skipping clones"'
   fi

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -41,6 +41,7 @@ runcmd:
   - [bash, -c, 'usermod -aG docker pi']
   - [bash, -c, 'mkdir -p /opt/sugarkube']
   - [bash, -c, 'chown -R pi:pi /opt/sugarkube']
+  - [bash, -c, 'if [ -d /opt/projects ]; then chown -R pi:pi /opt/projects; fi']
   - [systemctl, enable, --now, docker]
   - [bash, -c, 'apt-get clean']
   - |


### PR DESCRIPTION
## Summary
- clone token.place and dspace by default during Pi image build and allow cloning arbitrary repos via EXTRA_REPOS
- adjust cloud-init to grant the pi user ownership of cloned projects and add quickstart docs

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `pytest`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6786cb288832f82541d1f73099ed7