### PR TITLE
📝 : clarify Docker repo prompt checks

### DIFF
--- a/docs/prompts-codex-docker-repo.md
+++ b/docs/prompts-codex-docker-repo.md
@@ -7,7 +7,7 @@ slug: 'prompts-codex-docker-repo'
 
 Use this prompt to evolve beginner docs for deploying Docker-based projects on the Pi image.
 
-```
+```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
 
@@ -18,7 +18,9 @@ Dockerfile or docker-compose file on the prepared Raspberry Pi image.
 CONTEXT:
 - The base image and tunnel setup live in `docs/pi_image_cloudflare.md`.
 - New walkthroughs belong in `docs/docker_repo_walkthrough.md`.
-- Run `pre-commit run --all-files`; ensure `pyspelling` and `linkchecker` pass.
+- Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires
+  `aspell` and `aspell-en`), `linkchecker --no-warnings README.md docs/`, and
+  `git diff --cached | ./scripts/scan-secrets.py` before committing.
 - File recurring deployment failures in `outages/` per `outages/schema.json`.
 
 REQUEST:
@@ -39,8 +41,9 @@ Use this prompt to refine sugarkube's own prompt documentation.
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
 Follow `AGENTS.md` and `README.md`.
-Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
-`linkchecker --no-warnings README.md docs/` before committing.
+Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires
+`aspell` and `aspell-en`), `linkchecker --no-warnings README.md docs/`, and
+`git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).


### PR DESCRIPTION
## What
- document full lint, spellcheck, linkcheck, and secret scan steps in Docker repo prompt

## Why
- keep prompt instructions current with repository checks

## How to Test
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68b67866fc00832f9d24cf3cf030531a