### PR TITLE
Harden cloud-init service and docs

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -63,8 +63,11 @@ image to bootstrap a three-node k3s cluster; see
    `CLOUDFLARED_COMPOSE_PATH`) into `/opt/sugarkube/`. Cloud-init adds the
    Cloudflare apt repo, pre-creates
    `/opt/sugarkube/.cloudflared.env` with `0600` permissions, installs the
-   `cloudflared-compose` systemd unit (wired to `network-online.target`), and
-   enables Docker; verify the files and service.
+   `cloudflared-compose` systemd unit (wired to `network-online.target` and set
+   to restart on failure), and enables Docker. If the default `pi` user exists
+   it's added to the `docker` group and given ownership of `/opt/sugarkube`; for
+   custom usernames, adjust `user-data.yaml` accordingly. Verify the files and
+   service.
 5. Add your Cloudflare token to `/opt/sugarkube/.cloudflared.env` if it wasn't
    provided via `TUNNEL_TOKEN` or `TUNNEL_TOKEN_FILE` during the build. The
    tunnel starts automatically when the token exists; otherwise run:

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -34,13 +34,15 @@ write_files:
       ExecStart=/usr/bin/docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml up -d
       ExecStop=/usr/bin/docker compose -f /opt/sugarkube/docker-compose.cloudflared.yml down
       RemainAfterExit=yes
+      Restart=on-failure
+      RestartSec=5s
 
       [Install]
       WantedBy=multi-user.target
 runcmd:
-  - [bash, -c, 'usermod -aG docker pi']
+  - [bash, -c, 'id pi >/dev/null 2>&1 && usermod -aG docker pi']
   - [bash, -c, 'mkdir -p /opt/sugarkube']
-  - [bash, -c, 'chown -R pi:pi /opt/sugarkube']
+  - [bash, -c, 'id pi >/dev/null 2>&1 && chown -R pi:pi /opt/sugarkube']
   - [systemctl, enable, --now, docker]
   - [bash, -c, 'apt-get clean']
   - |


### PR DESCRIPTION
## Summary
- restart cloudflared-compose on failure
- skip docker user changes when pi user absent
- document conditional user handling

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- pytest
- npm run lint (fails: missing package.json)
- npm run test:ci (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b6786356a4832f97afd7e9a5040d71