### PR TITLE
📝 docs: verify key auth step in network setup

### DIFF
--- a/docs/network_setup.md
+++ b/docs/network_setup.md
@@ -24,6 +24,8 @@ It assumes you are using Raspberry Pi 5 boards in a small k3s setup.
 10. If you skipped adding a key earlier, generate one with
     `ssh-keygen -t ed25519`, then copy your public key to each Pi:
     `ssh-copy-id <user>@<hostname>.local`
+11. Test key-based login: `ssh <user>@<hostname>.local` should connect without
+    prompting for credentials.
 
 ## Switch and PoE
 


### PR DESCRIPTION
## Summary
- add step to confirm key-based SSH works in network_setup guide

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6785940e8832f8314a3a7dad14b56