### PR TITLE
docs: note BMS and consolidate disconnect switch

### DIFF
--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -3,14 +3,14 @@
 This setup uses a 12 V LiFePO4 battery and outdoor wiring. Follow these precautions:
 
 - Place a 60 A fuse within 7 in (18 cm) of the battery positive terminal.
+- Use a battery management system (BMS) to prevent over‑charge and over‑discharge.
 - Keep the MPPT charge controller in a ventilated enclosure, never sealed inside the battery box.
 - Disconnect the solar panels before wiring the controller to avoid live voltage.
 - Fuse the air pump branch at 15 A and the Raspberry Pi buck converter at 5 A.
 - Size wiring for the expected current; undersized conductors can overheat.
 - Verify polarity with a multimeter before powering devices.
 - Disconnect the battery before working on wiring and remove metal jewelry to avoid shorts.
-- Add a DC-rated disconnect switch on the battery positive lead so you can kill power quickly.
+- Add a DC-rated disconnect switch on the battery positive lead so you can kill power quickly and isolate it during maintenance.
 - Route cables so water cannot drip onto connectors; use cable glands and strain relief.
 - Wear eye protection while crimping and avoid short circuits when working on the battery.
-- Install a battery disconnect switch on the positive lead to isolate power during maintenance.
 - Wear insulated gloves along with eye protection when handling the battery or live circuits.


### PR DESCRIPTION
## Summary
- mention using a battery management system for LiFePO4 safety
- merge duplicate guidance into one disconnect switch bullet

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`
- `npm run lint && npm run test:ci` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b6785940e8832f8314a3a7dad14b56