### PR TITLE
docs: clarify build guide wiring order

### DIFF
--- a/docs/build_guide.md
+++ b/docs/build_guide.md
@@ -4,7 +4,7 @@ This project uses 20x20 aluminium extrusion to suspend four 100 W solar panels a
 The battery, charge controller, and electronics mount inside a marine battery box and a small
 junction box.
 
-1. Print the triple Pi carrier from `cad/pi_cluster` if building a Pi cluster.
+1. Print the triple Pi carrier from [`cad/pi_cluster`](../cad/pi_cluster/) if building a Pi cluster.
    Download pre-rendered STLs from the repository's **Actions** tab. Sign in to
    GitHub, open the latest [scad-to-stl workflow run][stl-workflow], and grab the
    `pi_cluster` artifact. Artifacts expire after 90 days; if none are available,
@@ -15,17 +15,18 @@ junction box.
    stiffens the corner. Keep panels covered or face-down during wiring to avoid
    live voltage.
 4. Attach the battery leads to the MPPT charge controller before any solar
-   wiring. Refer to the controller's manual for the recommended connection order
-   and connect the load output last. The KiCad schematic and board specs live
-   under [elex/power_ring](../elex/power_ring/).
+   wiring. Powering the controller first lets it regulate incoming solar; connecting
+   panels with no battery attached can damage it. Refer to the controller's manual
+   for the recommended connection order and connect the load output last. The KiCad
+   schematic and board specs live under [elex/power_ring](../elex/power_ring/).
 5. Before connecting the array, verify each panel's open-circuit voltage and
    polarity with a multimeter. Join panels with MC4 connectors and 12 AWG wire,
    then attach them to the controller.
 6. Install the 12 V air pump and Raspberry Pi with dedicated overcurrent protection.
    Route the pump through a 15 A breaker and the Pi through a 5 A fuse.
    Verify battery voltage and polarity with a multimeter before powering devices.
-7. Tidy and secure all wiring. Confirm the charge controller shows a charging indicator before
-   closing the enclosure.
+7. Tidy and secure all wiring with cable ties or clamps for strain relief. Confirm the
+   charge controller shows a charging indicator before closing the enclosure.
 
 For details on electronics and safety precautions see [SAFETY.md](SAFETY.md).
 


### PR DESCRIPTION
## Summary
- link to cad/pi_cluster for printing the triple Pi carrier
- warn that powering the MPPT controller via battery prevents panel damage
- remind builders to secure wiring for strain relief

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6785940e8832f8314a3a7dad14b56