### PR TITLE
📝 : clarify CAD prompt tooling

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -5,7 +5,7 @@ slug: 'prompts-codex-cad'
 
 # Codex CAD Prompt
 
-Use this prompt when 3D models need updating or verification.
+Use this prompt when OpenSCAD models need updating or verification.
 
 ```text
 SYSTEM:
@@ -18,17 +18,18 @@ CONTEXT:
 - CAD files reside in [`cad/`](../cad/).
 - Use [`scripts/openscad_render.sh`](../scripts/openscad_render.sh) to export STL meshes into
   [`stl/`](../stl/).
+- Ensure [OpenSCAD](https://openscad.org) is installed before rendering.
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these models
   as artifacts. Do not commit `.stl` files.
 - Render each model in all supported `standoff_mode` variants (for example, `heatset`
   or `printed`). `STANDOFF_MODE` is case-insensitive and defaults to the model's
   `standoff_mode` value (typically `heatset`).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` after changes.
-  For documentation updates, also run `pyspelling -c .spellcheck.yaml` (requires `aspell` and
-  `aspell-en`) and `linkchecker --no-warnings README.md docs/`.
-- Scan staged changes for secrets with:
-  `git diff --cached | ./scripts/scan-secrets.py` before committing.
+- Run `pre-commit run --all-files`.
+- When documentation is updated, also run `pyspelling -c .spellcheck.yaml`
+  (requires `aspell` and `aspell-en`) and `linkchecker --no-warnings README.md docs/`.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`
+  before committing.
 - Log tool failures in [`outages/`](../outages/) using
   [`outages/schema.json`](../outages/schema.json).
 
@@ -38,8 +39,8 @@ REQUEST:
 3. Render the model via:
 
    ```bash
-   ./scripts/openscad_render.sh path/to/model.scad  # defaults to heatset
-   STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad  # case-insensitive
+   bash scripts/openscad_render.sh path/to/model.scad  # defaults to heatset
+   STANDOFF_MODE=printed bash scripts/openscad_render.sh path/to/model.scad  # case-insensitive
    ```
 
 4. Commit updated SCAD sources and any documentation.


### PR DESCRIPTION
what: refine CAD prompt to mention OpenSCAD and spell out doc checks
why: help contributors render models and run required validations
how to test:
- pre-commit run --files docs/prompts-codex-cad.md
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68b678568780832f91bee3b12a239f31