### PR TITLE
docs: clarify CI fix prompt checks

### DIFF
--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -17,8 +17,10 @@ Diagnose and fix continuous integration failures so all checks pass.
 CONTEXT:
 - Follow AGENTS.md for workflow and testing requirements.
 - Run `pre-commit run --all-files` to reproduce failures; it executes `scripts/checks.sh`.
-- Ensure `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` succeed.
+- Ensure `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`) and
+  `linkchecker --no-warnings README.md docs/` succeed.
 - Install missing dependencies with `pip` or `npm` as needed.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 REQUEST:
 1. Re-run the failing check locally.
@@ -38,8 +40,9 @@ Use this prompt to refine sugarkube's own prompt documentation.
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
 Follow `AGENTS.md` and `README.md`.
-Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
-`linkchecker --no-warnings README.md docs/` before committing.
+Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`
+(requires `aspell` and `aspell-en`), `linkchecker --no-warnings README.md docs/`,
+and `git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).


### PR DESCRIPTION
## Summary
- note spelling tool requirements in CI fix prompt
- remind contributors to scan secrets and include secret scan in Upgrade Prompt

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68b678568780832f91bee3b12a239f31