### PR TITLE
🔧: support nut standoffs and strengthen pi carrier

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,12 @@ supplied:
 ```bash
 bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad
 STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad
+STANDOFF_MODE=nut bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad
 ```
 
 By default the script uses the model's `standoff_mode` value (`heatset`).
-Set `STANDOFF_MODE=printed` to generate 3D-printed threads. Values are case-insensitive and ignore
-surrounding whitespace; `heatset` and `printed` are accepted. Supplying only
+Set `STANDOFF_MODE=printed` to generate 3D-printed threads or `STANDOFF_MODE=nut` for a captive hex recess. Values are case-insensitive and ignore
+surrounding whitespace; `heatset`, `printed`, and `nut` are accepted. Supplying only
 whitespace uses the model's default `standoff_mode`.
 
 The helper script validates that the provided `.scad` file exists and that

--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -16,7 +16,7 @@ hole_spacing_y = 49;
 plate_thickness = 2.0;
 corner_radius   = 5.0;  // round base corners to avoid sharp edges
 standoff_height = 6.0;
-standoff_diam = 6.3;   // trim material while maintaining insert grip
+standoff_diam = 6.5;   // increased diameter for added strength
 
 insert_od         = 3.5;         // outer Ø for common brass inserts
 insert_length     = 4.0;         // full length of the insert

--- a/docs/lcd_mount.md
+++ b/docs/lcd_mount.md
@@ -5,7 +5,7 @@ Its standoffs match the common 80×36 mm module with holes 3 mm from each
 edge (75 mm × 31 mm spacing).
 
 The base plate includes rounded corners set by `corner_radius` (default 5 mm)
-to make handling safer. Standoff pillars now use a 6.3 mm diameter to conserve
+to make handling safer. Standoff pillars now use a 6.5 mm diameter to conserve
 material while gripping heat‑set inserts firmly.
 
 LCD support is disabled by default. To add the display set
@@ -18,6 +18,9 @@ bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad
 
 # Render a version with printed threads
 STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad
+
+# Render a captive hex recess variant
+STANDOFF_MODE=nut bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad
 ```
 
 ## Enable I²C and Connect
@@ -33,4 +36,4 @@ After printing the mount, enable the I²C interface and wire the display:
 Rotate the LCD or tweak offsets if your board slightly differs. The extra standoffs avoid the Pi
 mounting holes so you can add the display without enlarging the plate.
 
-Valid `STANDOFF_MODE` values are `heatset` (default) and `printed`. Values are case-insensitive.
+Valid `STANDOFF_MODE` values are `heatset` (default), `printed`, and `nut`. Values are case-insensitive.

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -20,8 +20,7 @@ CONTEXT:
   [`stl/`](../stl/).
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these models
   as artifacts. Do not commit `.stl` files.
-- Render each model in all supported `standoff_mode` variants (for example, `heatset`
-  or `printed`). `STANDOFF_MODE` is case-insensitive and defaults to the model's
+- Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`, or `nut`). `STANDOFF_MODE` is case-insensitive and defaults to the model's
   `standoff_mode` value (typically `heatset`).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
 - Run `pre-commit run --all-files` after changes.
@@ -40,6 +39,7 @@ REQUEST:
    ```bash
    ./scripts/openscad_render.sh path/to/model.scad  # defaults to heatset
    STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad  # case-insensitive
+   STANDOFF_MODE=nut ./scripts/openscad_render.sh path/to/model.scad
    ```
 
 4. Commit updated SCAD sources and any documentation.

--- a/scripts/openscad_render.sh
+++ b/scripts/openscad_render.sh
@@ -24,11 +24,11 @@ if [ -n "${STANDOFF_MODE:-}" ]; then
   standoff_mode="$(printf '%s' "${STANDOFF_MODE,,}" | xargs)"
   if [ -n "$standoff_mode" ]; then
     case "$standoff_mode" in
-      heatset|printed)
+      heatset|printed|nut)
         mode_suffix="_$standoff_mode"
         ;;
       *)
-        echo "Invalid STANDOFF_MODE: $STANDOFF_MODE (expected 'heatset' or 'printed')" >&2
+        echo "Invalid STANDOFF_MODE: $STANDOFF_MODE (expected 'heatset', 'printed', or 'nut')" >&2
         exit 1
         ;;
     esac

--- a/tests/openscad_render_test.py
+++ b/tests/openscad_render_test.py
@@ -237,6 +237,38 @@ printf '%s ' "$@" > "$LOG_FILE"
     assert output == "stl/pi_carrier_heatset.stl"
 
 
+def test_nut_mode_adds_suffix(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    log_file = tmp_path / "args.log"
+    openscad = fake_bin / "openscad"
+    openscad.write_text(
+        """#!/usr/bin/env bash
+printf '%s ' "$@" > "$LOG_FILE"
+""",
+    )
+    openscad.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["LOG_FILE"] = str(log_file)
+    env["STANDOFF_MODE"] = "nut"
+
+    subprocess.run(
+        [
+            "bash",
+            "scripts/openscad_render.sh",
+            "cad/pi_cluster/pi_carrier.scad",
+        ],
+        check=True,
+        env=env,
+    )
+
+    args = log_file.read_text().split()
+    output = args[args.index("-o") + 1]
+    assert output == "stl/pi_carrier_nut.stl"
+
+
 def test_trims_whitespace_in_standoff_mode(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()


### PR DESCRIPTION
## Summary
- allow `nut` as a valid STANDOFF_MODE in OpenSCAD render script
- widen Pi carrier standoffs to 6.5 mm and document new option
- test nut output and refresh docs to mention all modes

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`

------
https://chatgpt.com/codex/tasks/task_e_68b67851516c832f86b8d9bb5943aa73