### PR TITLE
🛠️ : strengthen Pi carrier standoffs

### DIFF
--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -16,13 +16,15 @@ hole_spacing_y = 49;
 plate_thickness = 2.0;
 corner_radius   = 5.0;  // round base corners to avoid sharp edges
 standoff_height = 6.0;
-standoff_diam = 6.3;   // trim material while maintaining insert grip
+standoff_diam = 6.5;   // match Pi5 carrier standoffs for extra strength
 
 insert_od         = 3.5;         // outer Ø for common brass inserts
 insert_length     = 4.0;         // full length of the insert
 insert_pocket_depth = insert_length + 0.7; // keeps 0.7 mm extra for chamfer
 insert_clearance  = 0.2;         // designed undersize for interference fit
 hole_diam         = insert_od - insert_clearance;
+assert(standoff_diam >= insert_od + 2,
+       "standoff_diam must be ≥ insert_od + 2");
 lead_chamfer = 0.5;
 screw_clearance_diam = 3.0; // through-hole clearance
 


### PR DESCRIPTION
what: increase standoff_diam to 6.5 mm and assert wall thickness
why: align with Pi5 carrier for better strength
how to test:
  ./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad
  STANDOFF_MODE=printed ./scripts/openscad_render.sh \
    cad/pi_cluster/pi_carrier.scad
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b67851516c832f86b8d9bb5943aa73