### PR TITLE
🧪 : expand collect_pi_image tests

### DIFF
--- a/scripts/collect_pi_image.sh
+++ b/scripts/collect_pi_image.sh
@@ -19,7 +19,7 @@ echo "==> Scanning '${DEPLOY_ROOT}' for image artifacts"
 if [ -d "${DEPLOY_ROOT}" ]; then
   find "${DEPLOY_ROOT}" -maxdepth 3 -type f -printf '%p\t%k KB\n' | sort || true
 else
-  echo "ERROR: '${DEPLOY_ROOT}' does not exist"
+  echo "ERROR: '${DEPLOY_ROOT}' does not exist" >&2
   exit 1
 fi
 
@@ -46,7 +46,7 @@ if [ -z "${found}" ]; then
     if [ -n "${img_in_zip}" ]; then
       found="${img_in_zip}"
     else
-      echo "ERROR: Zip contained no .img: ${zipfile}"
+      echo "ERROR: Zip contained no .img: ${zipfile}" >&2
       exit 1
     fi
   fi
@@ -72,7 +72,7 @@ if [ -z "${found}" ]; then
 fi
 
 if [ -z "${found}" ]; then
-  echo "ERROR: No image file found under '${DEPLOY_ROOT}' (looked for *.img.xz, *.zip, *.img.gz, *.img)"
+  echo "ERROR: No image file found under '${DEPLOY_ROOT}' (looked for *.img.xz, *.zip, *.img.gz, *.img)" >&2
   exit 1
 fi
 

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -1,0 +1,66 @@
+import gzip
+import os
+import subprocess
+import zipfile
+from pathlib import Path
+
+
+def _run_script(tmp_path, deploy, out_img, extra_env=None):
+    env = os.environ.copy()
+    env.update(extra_env or {})
+    env["XZ_OPT"] = "-T0 -0"
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "scripts" / "collect_pi_image.sh"
+    return subprocess.run(
+        ["/bin/bash", str(script), str(deploy), str(out_img)],
+        env=env,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_handles_img_gz(tmp_path):
+    deploy = tmp_path / "deploy"
+    deploy.mkdir()
+    img_gz = deploy / "foo.img.gz"
+    with gzip.open(img_gz, "wb") as f:
+        f.write(b"data")
+
+    out_img = tmp_path / "out.img.xz"
+    result = _run_script(tmp_path, deploy, out_img)
+    assert result.returncode == 0, result.stderr
+    assert out_img.exists()
+    assert (out_img.with_suffix(out_img.suffix + ".sha256")).exists()
+
+
+def test_errors_on_zip_without_img(tmp_path):
+    deploy = tmp_path / "deploy"
+    deploy.mkdir()
+    zip_path = deploy / "foo.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("readme.txt", "hello")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    bsdtar = fake_bin / "bsdtar"
+    bsdtar.write_text(
+        "#!/bin/bash\n"
+        'python - <<\'PY\' "$2" "$4"\n'
+        "import sys, zipfile\n"
+        "zip_path, dest = sys.argv[1:3]\n"
+        "with zipfile.ZipFile(zip_path) as zf:\n"
+        "    zf.extractall(dest)\n"
+        "PY\n"
+    )
+    bsdtar.chmod(0o755)
+
+    out_img = tmp_path / "out.img.xz"
+    result = _run_script(
+        tmp_path,
+        deploy,
+        out_img,
+        extra_env={"PATH": f"{fake_bin}:{os.environ['PATH']}"},
+    )
+    assert result.returncode != 0
+    assert "Zip contained no .img" in result.stderr


### PR DESCRIPTION
what: add tests for .img.gz inputs and zip without image errors; route collect_pi_image errors to stderr
why: ensure collect_pi_image.sh handles extra paths and surfaces failures
how to test: python -m pre_commit run --all-files
Refs: #n/a

------
https://chatgpt.com/codex/tasks/task_e_68b6787595f8832fba6b2a73e8ce0510