### PR TITLE
📝 : fix pi_token_dspace doc EOF newline

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -46,4 +46,3 @@ dspace. To expose them through a Cloudflare Tunnel, update
 
 Use `EXTRA_REPOS` to experiment with other projects and extend the image over
 time.
-


### PR DESCRIPTION
## Summary
- remove trailing blank line in pi_token_dspace doc to satisfy end-of-file-fixer

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7d2d4d72c832fa90f5452a7a6ad28