### PR TITLE
📚 : clarify codex prompt doc

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -46,4 +46,3 @@ dspace. To expose them through a Cloudflare Tunnel, update
 
 Use `EXTRA_REPOS` to experiment with other projects and extend the image over
 time.
-

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -17,12 +17,15 @@ Keep the project healthy by making small, well-tested improvements.
 
 CONTEXT:
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
-- Run `pre-commit run --all-files` to lint, test and validate docs.
-- On documentation changes ensure `pyspelling -c .spellcheck.yaml` (requires `aspell` and
-  `aspell-en`) and `linkchecker --no-warnings README.md docs/` succeed.
-- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
-  committing.
-- Log persistent failures in `outages/` as JSON per `outages/schema.json`.
+- Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../scripts/checks.sh) for
+  linting, tests and doc validation.
+- On documentation changes ensure `pyspelling -c [.spellcheck.yaml](../.spellcheck.yaml)`
+  (requires `aspell` and `aspell-en`) and `linkchecker --no-warnings README.md docs/`
+  succeed.
+- Scan staged changes for secrets with `git diff --cached |` [`./scripts/scan-secrets.py`](../scripts/scan-secrets.py)
+  before committing.
+- Log persistent failures in [`outages/`](../outages/) as JSON per
+  [`outages/schema.json`](../outages/schema.json).
 
 REQUEST:
 1. Identify a small bug fix or documentation clarification.
@@ -43,9 +46,9 @@ Use this prompt to refine sugarkube's own prompt documentation.
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
 Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
-Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires `aspell` and
-`aspell-en`), `linkchecker --no-warnings README.md docs/`, and
-`git diff --cached | ./scripts/scan-secrets.py` before committing.
+Run `pre-commit run --all-files`, `pyspelling -c` [`.spellcheck.yaml`](../.spellcheck.yaml)
+(requires `aspell` and `aspell-en`), `linkchecker --no-warnings README.md docs/`, and
+`git diff --cached |` [`./scripts/scan-secrets.py`](../scripts/scan-secrets.py) before committing.
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).


### PR DESCRIPTION
what: link internal instructions and note secret scan script
why: keep codex prompt references current
how to test:
  pre-commit run --all-files
  pyspelling -c .spellcheck.yaml
  linkchecker --no-warnings README.md docs/
  git diff --cached | ./scripts/scan-secrets.py
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b7d30f0fd4832f86ced42194f28f9f