### PR TITLE
📝 : clarify Codex prompt upgrade instructions

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -46,4 +46,3 @@ dspace. To expose them through a Cloudflare Tunnel, update
 
 Use `EXTRA_REPOS` to experiment with other projects and extend the image over
 time.
-

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -5,8 +5,8 @@ slug: 'prompts-codex'
 
 # Codex Automation Prompt
 
-Use this prompt to guide OpenAI Codex or similar agents when contributing to
-this repository.
+Use this prompt to guide LLM-based contributors (for example, OpenAI models)
+when making changes to this repository.
 
 ```text
 SYSTEM:
@@ -17,7 +17,7 @@ Keep the project healthy by making small, well-tested improvements.
 
 CONTEXT:
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
-- Run `pre-commit run --all-files` to lint, test and validate docs.
+- Run `pre-commit run --all-files` to lint, format, and test the repository.
 - On documentation changes ensure `pyspelling -c .spellcheck.yaml` (requires `aspell` and
   `aspell-en`) and `linkchecker --no-warnings README.md docs/` succeed.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
@@ -43,15 +43,19 @@ Use this prompt to refine sugarkube's own prompt documentation.
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
 Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
-Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires `aspell` and
-`aspell-en`), `linkchecker --no-warnings README.md docs/`, and
-`git diff --cached | ./scripts/scan-secrets.py` before committing.
+Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires
+`aspell` and `aspell-en`), `linkchecker --no-warnings README.md docs/`, and
+`git diff --cached | ./scripts/scan-secrets.py` before committing. Fix any
+issues reported by these tools.
 
 USER:
-1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
-2. Fix outdated instructions, links, or formatting.
-3. Run the commands above.
+1. Choose a `docs/prompts-*.md` file to update (for example,
+   `prompts-codex-cad.md`).
+2. Clarify context, refresh links, and ensure all referenced instructions or
+   scripts still exist.
+3. Run the commands above and address any failures.
 
 OUTPUT:
-A pull request with the improved prompt doc and passing checks.
+A pull request that updates the selected prompt doc with current references
+and passing checks.
 ```


### PR DESCRIPTION
## Summary
- clarify Codex prompt to reference LLM-based contributors
- expand upgrade prompt with clearer steps and link refresh guidance

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7d30f0fd4832f86ced42194f28f9f