### PR TITLE
📝 : clarify outage schema reference

### DIFF
--- a/docs/outage_catalog.md
+++ b/docs/outage_catalog.md
@@ -1,6 +1,6 @@
 # Outage Catalog
 
-Structured archive of past outages. Each outage is stored as a JSON file using the schema in `schema.json`.
+Structured archive of past outages. Each outage is stored as a JSON file using the schema in [`outages/schema.json`](../outages/schema.json).
 
 File naming: `YYYY-MM-DD-<slug>.json`.
 

--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -46,4 +46,3 @@ dspace. To expose them through a Cloudflare Tunnel, update
 
 Use `EXTRA_REPOS` to experiment with other projects and extend the image over
 time.
-


### PR DESCRIPTION
## Summary
- link outage catalog guide to outages/schema.json
- drop trailing blank line in pi_token_dspace doc to satisfy linters

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68b7d3cbe1d4832f89fdb8c754a2dff2