### PR TITLE
📝 : – update test prompt links and fix pi_token_dspace newline

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -46,4 +46,3 @@ dspace. To expose them through a Cloudflare Tunnel, update
 
 Use `EXTRA_REPOS` to experiment with other projects and extend the image over
 time.
-

--- a/docs/prompts-codex-tests.md
+++ b/docs/prompts-codex-tests.md
@@ -15,7 +15,7 @@ PURPOSE:
 Improve and maintain test coverage.
 
 CONTEXT:
-- Tests live in [`tests/`](../tests/) and use [pytest](https://docs.pytest.org/).
+- Tests live in [`tests/`](../tests/) and use [pytest](https://docs.pytest.org/en/stable/).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
 - Run `pre-commit run --all-files` to invoke `scripts/checks.sh` for linting, formatting, and tests.
 - For documentation updates, also run `pyspelling -c .spellcheck.yaml` (requires
@@ -43,7 +43,7 @@ Use this prompt to refine sugarkube's own prompt documentation.
 ```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
-Follow `AGENTS.md` and `README.md`.
+Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
 Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`,
 `linkchecker --no-warnings README.md docs/`, and
 `git diff --cached | ./scripts/scan-secrets.py` before committing.


### PR DESCRIPTION
## Summary
- link tests prompt to pytest stable docs and cross-reference AGENTS/README
- add missing newline in pi_token_dspace.md to satisfy linters

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7d3d7074c832f80a064e241e0c10d