### PR TITLE
📝 : clarify CAD prompt instructions

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -46,4 +46,3 @@ dspace. To expose them through a Cloudflare Tunnel, update
 
 Use `EXTRA_REPOS` to experiment with other projects and extend the image over
 time.
-

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -21,12 +21,12 @@ CONTEXT:
   `PATH`; the script exits early if it cannot find the binary.
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these models
   as artifacts. Do not commit `.stl` files.
-- Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`, or `nut`).
-  `STANDOFF_MODE` is case-insensitive and defaults to the model's `standoff_mode` value (typically `heatset`).
+- Render each model in all supported `standoff_mode` variants (for example, `heatset`,
+  `printed`, or `nut`). `STANDOFF_MODE` is case-insensitive and defaults to the model's
+  `standoff_mode` value (typically `heatset`).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test.
-  For documentation updates, also run `pyspelling -c .spellcheck.yaml` (requires `aspell` and
-  `aspell-en`) and `linkchecker --no-warnings README.md docs/`.
+- Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
+  `linkchecker --no-warnings README.md docs/` (requires `aspell` and `aspell-en`).
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`
   before committing.
 - Log tool failures in [`outages/`](../outages/) using
@@ -38,7 +38,7 @@ REQUEST:
 3. Render the model via:
 
    ```bash
-   ./scripts/openscad_render.sh path/to/model.scad  # defaults to heatset
+   ./scripts/openscad_render.sh path/to/model.scad  # uses model's default standoff_mode
    STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad  # case-insensitive
    STANDOFF_MODE=nut ./scripts/openscad_render.sh path/to/model.scad
    ```


### PR DESCRIPTION
what: clarify standoff mode note and consolidate doc check commands.
why: keep CAD prompt accurate and easier to follow.
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68b7d3c87e04832fb2a1653943cab7fc