### PR TITLE
🧪 : cover scan-secrets empty diff path

### DIFF
--- a/tests/scan_secrets_test.py
+++ b/tests/scan_secrets_test.py
@@ -85,3 +85,9 @@ def test_run_ripsecrets_clean(monkeypatch, scan_secrets):
         lambda *a, **k: Result,
     )
     assert scan_secrets.run_ripsecrets("diff") is False
+
+
+def test_main_skips_when_no_diff(monkeypatch, scan_secrets, capsys):
+    monkeypatch.setattr(scan_secrets.sys, "stdin", io.StringIO(""))
+    assert scan_secrets.main() == 0
+    assert "No diff provided" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- add regression test for scan-secrets handling empty diff input

## Testing
- `pytest -q`
- `bats tests/*.bats` *(fails: command not found)*
- `pre-commit run --all-files` *(fails: interrupted run-checks)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d32ac5e4832faab8ca90a593a2b8