### PR TITLE
🧪 tests: cover ripsecrets outcomes in main

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -46,4 +46,3 @@ dspace. To expose them through a Cloudflare Tunnel, update
 
 Use `EXTRA_REPOS` to experiment with other projects and extend the image over
 time.
-

--- a/tests/scan_secrets_test.py
+++ b/tests/scan_secrets_test.py
@@ -42,6 +42,30 @@ def test_main_exit_codes(monkeypatch, scan_secrets):
     assert scan_secrets.main() == 1
 
 
+def test_main_ripsecrets_detects_secret(monkeypatch, scan_secrets):
+    monkeypatch.setattr(scan_secrets, "run_ripsecrets", lambda diff_text: True)
+    monkeypatch.setattr(
+        scan_secrets.sys,
+        "stdin",
+        io.StringIO("+++ b/file\n+safe=1\n"),
+    )
+    assert scan_secrets.main() == 1
+
+
+def test_main_ripsecrets_clean(monkeypatch, scan_secrets):
+    monkeypatch.setattr(
+        scan_secrets,
+        "run_ripsecrets",
+        lambda diff_text: False,
+    )
+    monkeypatch.setattr(
+        scan_secrets.sys,
+        "stdin",
+        io.StringIO("+++ b/file\n+safe=1\n"),
+    )
+    assert scan_secrets.main() == 0
+
+
 def test_run_ripsecrets_returns_none_when_missing(monkeypatch, scan_secrets):
     monkeypatch.setattr(scan_secrets.shutil, "which", lambda _: None)
     assert scan_secrets.run_ripsecrets("diff") is None


### PR DESCRIPTION
## Summary
- test scan-secrets main when ripsecrets finds a secret or is clean
- ensure pi token doc ends with a newline

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/scan_secrets_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7d32ac5e4832faab8ca90a593a2b8