### PR TITLE
🧪 : expand scan-secrets tests

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -1,3 +1,4 @@
+
 # token.place and dspace Quickstart
 
 Build a Raspberry Pi 5 image that includes the
@@ -46,4 +47,3 @@ dspace. To expose them through a Cloudflare Tunnel, update
 
 Use `EXTRA_REPOS` to experiment with other projects and extend the image over
 time.
-

--- a/tests/scan_secrets_test.py
+++ b/tests/scan_secrets_test.py
@@ -42,6 +42,21 @@ def test_main_exit_codes(monkeypatch, scan_secrets):
     assert scan_secrets.main() == 1
 
 
+def test_main_respects_ripsecrets(monkeypatch, scan_secrets):
+    def _run_true(_):
+        return True
+
+    def _run_false(_):
+        return False
+
+    monkeypatch.setattr(scan_secrets, "run_ripsecrets", _run_true)
+    monkeypatch.setattr(scan_secrets.sys, "stdin", io.StringIO("diff"))
+    assert scan_secrets.main() == 1
+    monkeypatch.setattr(scan_secrets, "run_ripsecrets", _run_false)
+    monkeypatch.setattr(scan_secrets.sys, "stdin", io.StringIO("diff"))
+    assert scan_secrets.main() == 0
+
+
 def test_run_ripsecrets_returns_none_when_missing(monkeypatch, scan_secrets):
     monkeypatch.setattr(scan_secrets.shutil, "which", lambda _: None)
     assert scan_secrets.run_ripsecrets("diff") is None


### PR DESCRIPTION
what: test scan-secrets.main with ripsecrets and fix doc newline
why: ensure ripsecrets results propagate and EOF hook passes
how to test: pre-commit run --all-files
             pyspelling -c .spellcheck.yaml
             linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68b7d32ac5e4832faab8ca90a593a2b8