### PR TITLE
docs: clarify CAD prompt instructions

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -46,4 +46,3 @@ dspace. To expose them through a Cloudflare Tunnel, update
 
 Use `EXTRA_REPOS` to experiment with other projects and extend the image over
 time.
-

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -17,20 +17,21 @@ Keep OpenSCAD sources current and ensure they render cleanly.
 CONTEXT:
 - CAD files reside in [`cad/`](../cad/).
 - Use [`scripts/openscad_render.sh`](../scripts/openscad_render.sh) to export STL meshes into
-  [`stl/`](../stl/). Ensure [OpenSCAD](https://openscad.org/) is installed and available in
-  `PATH`; the script exits early if it cannot find the binary.
-- The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these models
-  as artifacts. Do not commit `.stl` files.
-- Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`, or `nut`).
-  `STANDOFF_MODE` is case-insensitive and defaults to the model's `standoff_mode` value (typically `heatset`).
+  [`stl/`](../stl/).
+- Ensure [OpenSCAD](https://openscad.org/) is installed and available in `PATH`; the script exits early
+  if it cannot find the binary.
+- The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these models as
+  artifacts. Do not commit `.stl` files.
+- Render each model in all supported `standoff_mode` variants (e.g., `heatset`, `printed`, or `nut`).
+- `STANDOFF_MODE` is case-insensitive and defaults to the model's `standoff_mode` value (typically
+  `heatset`).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test.
-  For documentation updates, also run `pyspelling -c .spellcheck.yaml` (requires `aspell` and
+- Run `pre-commit run --all-files` to invoke `scripts/checks.sh` for linting, formatting, and tests.
+- For documentation updates, also run `pyspelling -c .spellcheck.yaml` (requires `aspell` and
   `aspell-en`) and `linkchecker --no-warnings README.md docs/`.
-- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`
-  before committing.
-- Log tool failures in [`outages/`](../outages/) using
-  [`outages/schema.json`](../outages/schema.json).
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
+  committing.
+- Log tool failures in [`outages/`](../outages/) using [`outages/schema.json`](../outages/schema.json).
 
 REQUEST:
 1. Inspect `cad/*.scad` for todo comments or needed adjustments.


### PR DESCRIPTION
## Summary
- clarify CAD prompt context bullets and add explicit reference to scripts/checks.sh
- normalize trailing newline in Pi token doc

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7d2f46ff4832f86b3d7bc362ebac6