### PR TITLE
🔌 Add connector orientation note to power ring schematic

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -46,4 +46,3 @@ dspace. To expose them through a Cloudflare Tunnel, update
 
 Use `EXTRA_REPOS` to experiment with other projects and extend the image over
 time.
-

--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -9,6 +9,7 @@
                 (comment 2 "Keep high-current traces short")
                 (comment 3 "Label polarity and voltage on connectors")
                 (comment 4 "Verify KiBot exports before fabrication")
+                (comment 5 "Note output connector orientation")
         )
         (lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/elex/power_ring/specs.md
+++ b/elex/power_ring/specs.md
@@ -17,6 +17,6 @@ This document outlines the intended features for the Sugarkube power distributio
 
 - Test points for measuring battery voltage
 - Silkscreen labels for polarity and connector numbers
-- Title block comments record decoupling guidelines, high-current trace layout, connector labeling and export checks
+- Title block comments record decoupling guidelines, high-current trace layout, connector labeling, output connector orientation, and export checks
 
 These requirements are a starting point – modify the KiCad project as needed and update this file when the schematic changes.

--- a/outages/2025-09-03-kicad-export-pcbnew-missing.json
+++ b/outages/2025-09-03-kicad-export-pcbnew-missing.json
@@ -1,0 +1,11 @@
+{
+  "id": "kicad-export-pcbnew-missing",
+  "date": "2025-09-03",
+  "component": "kicad-export",
+  "rootCause": "kibot failed: cannot import pcbnew Python module, KiCad not installed",
+  "resolution": "Install KiCad with Python bindings and ensure pcbnew module is available or use KiCad 9+ container",
+  "references": [
+    "kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml",
+    "apt-get install kicad"
+  ]
+}


### PR DESCRIPTION
## Summary
- document output connector orientation in power ring schematic
- note connector orientation in specs
- record KiCad export outage for missing pcbnew module

## Testing
- `kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml` *(fails: pcbnew module missing)*
- `pyspelling` *(fails: configuration missing)*
- `linkchecker README.md`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68b7d2f324d8832fb050a4567ef3bda5