### PR TITLE
docs: refine CAD prompt instructions

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -46,4 +46,3 @@ dspace. To expose them through a Cloudflare Tunnel, update
 
 Use `EXTRA_REPOS` to experiment with other projects and extend the image over
 time.
-

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -5,11 +5,11 @@ slug: 'prompts-codex-cad'
 
 # Codex CAD Prompt
 
-Use this prompt when OpenSCAD models need updating or verification.
+Use this prompt to update or verify OpenSCAD models.
 
 ```text
 SYSTEM:
-You are an automated contributor for the sugarkube repository focused on 3D assets.
+You are an automated contributor to the sugarkube repository focused on 3D assets.
 
 PURPOSE:
 Keep OpenSCAD sources current and ensure they render cleanly.
@@ -17,7 +17,7 @@ Keep OpenSCAD sources current and ensure they render cleanly.
 CONTEXT:
 - CAD files reside in [`cad/`](../cad/).
 - Use [`scripts/openscad_render.sh`](../scripts/openscad_render.sh) to export STL meshes into
-  [`stl/`](../stl/). Ensure [OpenSCAD](https://openscad.org/) is installed and available in
+  [`stl/`](../stl/). Ensure [OpenSCAD](https://openscad.org) is installed and available in
   `PATH`; the script exits early if it cannot find the binary.
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these models
   as artifacts. Do not commit `.stl` files.
@@ -25,10 +25,10 @@ CONTEXT:
   `STANDOFF_MODE` is case-insensitive and defaults to the model's `standoff_mode` value (typically `heatset`).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
 - Run `pre-commit run --all-files` to lint, format, and test.
-  For documentation updates, also run `pyspelling -c .spellcheck.yaml` (requires `aspell` and
+- For documentation updates, run `pyspelling -c .spellcheck.yaml` (requires `aspell` and
   `aspell-en`) and `linkchecker --no-warnings README.md docs/`.
-- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`
-  before committing.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
+  committing.
 - Log tool failures in [`outages/`](../outages/) using
   [`outages/schema.json`](../outages/schema.json).
 


### PR DESCRIPTION
## Summary
- clarify OpenSCAD CAD prompt and restructure validation steps
- ensure pi_token_dspace doc ends with newline for lint compliance

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7d2e17ebc832fba27a484c5afce8c