### PR TITLE
📝: clarify docs prompt instructions

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -46,4 +46,3 @@ dspace. To expose them through a Cloudflare Tunnel, update
 
 Use `EXTRA_REPOS` to experiment with other projects and extend the image over
 time.
-

--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -7,7 +7,7 @@ slug: 'prompts-codex-docs'
 
 Use this prompt to refine build guides and reference material.
 
-```
+```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
 
@@ -16,7 +16,8 @@ Keep the documentation clear and accurate.
 
 CONTEXT:
 - Docs live in `docs/`.
-- Follow [AGENTS.md](../AGENTS.md) for style and testing requirements.
+- Follow [AGENTS.md](../AGENTS.md) and [README.md](../README.md) for style and
+  testing requirements.
 - Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
   `linkchecker --no-warnings README.md docs/` (requires `aspell` and `aspell-en`).
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.


### PR DESCRIPTION
what: point docs prompt to README and use text code fences
why: keep prompt guidance consistent and formatted
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/; git diff --cached | ./scripts/scan-secrets.py
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b7d2d9e434832f8ad19ada0d06941f