### PR TITLE
docs: clarify spellcheck prompt formatting

### DIFF
--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -19,8 +19,8 @@ CONTEXT:
   (requires `aspell` and `aspell-en`).
 - Add legitimate new words to [`.wordlist.txt`](../.wordlist.txt).
 - Follow [AGENTS.md](../AGENTS.md) and [README.md](../README.md).
-- Run `pre-commit run --all-files` and ensure
-  `linkchecker --no-warnings README.md docs/` passes.
+- Run `pre-commit run --all-files`.
+- Verify links with `linkchecker --no-warnings README.md docs/`.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 
 REQUEST:
@@ -40,7 +40,7 @@ Use this prompt to refine sugarkube's own prompt documentation.
 ```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
-Follow `AGENTS.md` and `README.md`.
+Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
 Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`,
 `linkchecker --no-warnings README.md docs/`, and
 `git diff --cached | ./scripts/scan-secrets.py` before committing.


### PR DESCRIPTION
## Summary
- clarify lint and linkcheck steps in spellcheck prompt
- link AGENTS and README in upgrade instructions

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7d2c95a94832f905152ed403b7b2f