### PR TITLE
Add BOM validation note to power_ring schematic

### DIFF
--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -8,7 +8,7 @@
                 (comment 1 "Place decoupling capacitors near power pins")
                 (comment 2 "Keep high-current traces short")
                 (comment 3 "Label polarity and voltage on connectors")
-                (comment 4 "Verify KiBot exports before fabrication")
+                (comment 4 "Verify KiBot exports and BOM before fabrication")
         )
         (lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/elex/power_ring/specs.md
+++ b/elex/power_ring/specs.md
@@ -1,6 +1,7 @@
 # Power Ring Board Specifications
 
-This document outlines the intended features for the Sugarkube power distribution board.  The design may evolve as the project grows.
+This document outlines the intended features for the Sugarkube power distribution board.
+The design may evolve as the project grows.
 
 ## Connectors
 
@@ -17,6 +18,8 @@ This document outlines the intended features for the Sugarkube power distributio
 
 - Test points for measuring battery voltage
 - Silkscreen labels for polarity and connector numbers
-- Title block comments record decoupling guidelines, high-current trace layout, connector labeling and export checks
+- Title block comments record decoupling guidelines, high-current trace layout, connector
+  labeling, export checks, and BOM validation
 
-These requirements are a starting point – modify the KiCad project as needed and update this file when the schematic changes.
+These requirements are a starting point – modify the KiCad project as needed and
+update this file when the schematic changes.

--- a/outages/2025-09-03-kicad-export-kibot-missing.json
+++ b/outages/2025-09-03-kicad-export-kibot-missing.json
@@ -1,0 +1,10 @@
+{
+  "id": "kicad-export-kibot-missing-20250903",
+  "date": "2025-09-03",
+  "component": "kibot",
+  "rootCause": "`kibot` command was not found in the environment, preventing schematic export.",
+  "resolution": "Install KiBot or use a container image that includes KiCad 9 with KiBot support.",
+  "references": [
+    "kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml"
+  ]
+}

--- a/outages/2025-09-03-pre-commit-missing.json
+++ b/outages/2025-09-03-pre-commit-missing.json
@@ -1,0 +1,10 @@
+{
+  "id": "pre-commit-missing-20250903",
+  "date": "2025-09-03",
+  "component": "pre-commit",
+  "rootCause": "`pre-commit` was not installed in the environment, so repository checks could not run.",
+  "resolution": "Install pre-commit with `uv pip install pre-commit` before running repository hooks.",
+  "references": [
+    "pre-commit run --all-files"
+  ]
+}


### PR DESCRIPTION
## Summary
- remind to verify KiBot exports include BOM
- document BOM validation in power_ring specs
- record outages for missing KiBot and pre-commit (use uv for install)

## Testing
- `kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml` *(fails: command not found)*
- `pre-commit run --all-files` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d2f324d8832fb050a4567ef3bda5