### PR TITLE
Normalize prompt doc whitespace

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -21,10 +21,10 @@ CONTEXT:
   `PATH`; the script exits early if it cannot find the binary.
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these
   models as artifacts. Do not commit `.stl` files.
-- Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`, or `nut`).  
+- Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`, or `nut`).
   `STANDOFF_MODE` is case-insensitive and defaults to the model’s `standoff_mode` value (often `heatset`).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test.  
+- Run `pre-commit run --all-files` to lint, format, and test.
   For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`

--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -18,7 +18,7 @@ CONTEXT:
 - Docs live in [`docs/`](../docs/).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for style, testing, and repository conventions.
 - Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../scripts/checks.sh) for
-  linting, formatting, and tests.  
+  linting, formatting, and tests.
   For documentation changes, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`

--- a/docs/prompts-codex-elex.md
+++ b/docs/prompts-codex-elex.md
@@ -18,7 +18,7 @@ CONTEXT:
 - Electronics files live under [`elex/`](../elex/).
 - The `power_ring` project uses KiCad 9+ and KiBot ([`.kibot/power_ring.yaml`](../.kibot/power_ring.yaml)).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test.  
+- Run `pre-commit run --all-files` to lint, format, and test.
   For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`


### PR DESCRIPTION
## Summary
- remove trailing whitespace from codex prompt docs

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb38ade6b0832fb79a576b4cf1012f