### PR TITLE
📝 docs: refine test prompt and trim whitespace

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -21,10 +21,10 @@ CONTEXT:
   `PATH`; the script exits early if it cannot find the binary.
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these
   models as artifacts. Do not commit `.stl` files.
-- Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`, or `nut`).  
+- Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`, or `nut`).
   `STANDOFF_MODE` is case-insensitive and defaults to the model’s `standoff_mode` value (often `heatset`).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test.  
+- Run `pre-commit run --all-files` to lint, format, and test.
   For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`

--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -18,7 +18,7 @@ CONTEXT:
 - Docs live in [`docs/`](../docs/).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for style, testing, and repository conventions.
 - Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../scripts/checks.sh) for
-  linting, formatting, and tests.  
+  linting, formatting, and tests.
   For documentation changes, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`

--- a/docs/prompts-codex-elex.md
+++ b/docs/prompts-codex-elex.md
@@ -18,7 +18,7 @@ CONTEXT:
 - Electronics files live under [`elex/`](../elex/).
 - The `power_ring` project uses KiCad 9+ and KiBot ([`.kibot/power_ring.yaml`](../.kibot/power_ring.yaml)).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test.  
+- Run `pre-commit run --all-files` to lint, format, and test.
   For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`

--- a/docs/prompts-codex-tests.md
+++ b/docs/prompts-codex-tests.md
@@ -15,9 +15,16 @@ PURPOSE:
 Improve and maintain test coverage.
 
 CONTEXT:
-- Tests live in [`tests/`](../tests/) and use [pytest](https://docs.pytest.org/en/stable/).
-- Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to invoke `scripts/checks.sh` for linting, formatting, and tests.
+- Tests live in [`tests/`](../tests/) and include Python suites run with
+  [pytest](https://docs.pytest.org/en/stable/) and shell tests written in
+  [Bats](https://bats-core.readthedocs.io/).
+- Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository
+  conventions.
+- Run `pre-commit run --all-files`; it invokes
+  [`scripts/checks.sh`](../scripts/checks.sh) for linting, formatting, and executing both
+  test frameworks.
+- The CI workflow [`tests.yml`](../.github/workflows/tests.yml) runs the test suite on
+  each push.
 - For documentation updates, also run `pyspelling -c .spellcheck.yaml` (requires
   `aspell` and `aspell-en`) and `linkchecker --no-warnings README.md docs/`.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`


### PR DESCRIPTION
## Summary
- explain Bats and CI coverage in tests prompt
- remove stray spaces in other prompt docs

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py


------
https://chatgpt.com/codex/tasks/task_e_68bb39902ab4832f8e107ee2809486a8