### PR TITLE
📝: clarify CAD prompt instructions

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -17,15 +17,17 @@ Keep OpenSCAD models current and ensure they render cleanly.
 CONTEXT:
 - CAD files reside in [`cad/`](../cad/).
 - Use [`scripts/openscad_render.sh`](../scripts/openscad_render.sh) to export STL meshes into
-  [`stl/`](../stl/). Ensure [OpenSCAD](https://openscad.org) is installed and available in
-  `PATH`; the script exits early if it cannot find the binary.
+  [`stl/`](../stl/). Ensure [OpenSCAD](https://openscad.org) is installed and in `PATH`.
+  The script exits early if it cannot find the binary.
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these
   models as artifacts. Do not commit `.stl` files.
-- Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`, or `nut`).  
-  `STANDOFF_MODE` is case-insensitive and defaults to the model’s `standoff_mode` value (often `heatset`).
+- Render each model in all supported `standoff_mode` variants (for example,
+  `heatset`, `printed`, or `nut`). Set the `STANDOFF_MODE` environment variable
+  to choose a variant; it defaults to the model's `standoff_mode` value (often
+  `heatset`).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test.  
-  For documentation updates, also run:
+- Run `pre-commit run --all-files` to lint, format, and test.
+- For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
@@ -39,8 +41,8 @@ REQUEST:
 3. Render the model via:
 
    ```bash
-   ./scripts/openscad_render.sh path/to/model.scad  # uses model’s default standoff_mode (often heatset)
-   STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad  # case-insensitive
+   ./scripts/openscad_render.sh path/to/model.scad  # default standoff_mode
+   STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad
    STANDOFF_MODE=nut ./scripts/openscad_render.sh path/to/model.scad
    ```
 


### PR DESCRIPTION
## Summary
- clarify OpenSCAD render script guidance and STANDOFF_MODE usage
- tidy CAD prompt formatting and line wrapping

## Testing
- `pre-commit run --files docs/prompts-codex-cad.md`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb38b20a34832fb72579d7c7c7b0ff