### PR TITLE
📝 docs: clarify Pi carrier hardware guidance

### DIFF
--- a/docs/pi_cluster_carrier.md
+++ b/docs/pi_cluster_carrier.md
@@ -4,7 +4,7 @@ This design mounts three Raspberry Pi 5 boards on a common plate. Each Pi is rot
 
 The base corners are rounded with a configurable `corner_radius` parameter (default 5 mm) to soften sharp edges.
 
-The model lives at `cad/pi_cluster/pi5_triple_carrier_rot45.scad`.  STL files for both heat‑set and printed‑thread variants are produced by GitHub Actions and published as artifacts whenever the SCAD file changes.
+The model lives at `cad/pi_cluster/pi5_triple_carrier_rot45.scad`. STL files for both heat‑set and printed‑thread variants are produced by GitHub Actions and published as artifacts whenever the SCAD file changes.
 You can edit the `pi_positions` array near the top of the file to tweak the arrangement if your printer allows a larger build area.
 For an overview of insert installation and printed threads see [insert_basics.md](insert_basics.md).
 
@@ -29,8 +29,8 @@ See the main [build guide](build_guide.md) for assembly details.
 ## Mounting hardware
 
 For the strongest hold install brass heat‑set inserts in each printed
-standoff.  Use a single long screw per corner that threads down through
-an 11 mm brass spacer and the Pi board into the insert.  This keeps the
+standoff. Use a single long screw per corner that threads down through
+an 11 mm brass spacer and the Pi board into the insert. This keeps the
 underside flat and lets you stack an M.2 HAT or other accessory on top.
 
 | Part   | Spec                                 | Example listing                          |
@@ -39,9 +39,9 @@ underside flat and lets you stack an M.2 HAT or other accessory on top.
 | Spacer | M2.5 female‑female, 11 mm long       | "M2.5×11 mm brass hex standoff"          |
 | Insert | M2.5 heat‑set, 3.5 mm OD × 4 mm long | "M2.5 × D3.5 × L4 brass insert" |
 
-- These dimensions match common brass inserts (3.5 mm outer diameter, 4 mm length). Using a 22 mm screw guarantees at least 3 mm of bite in the insert even if your brass spacer is slightly oversize or you add a washer.
+- These dimensions match common brass inserts (3.5 mm outer diameter, 4 mm length). Using a 22 mm screw guarantees at least 3 mm of bite in the insert even if your brass spacer is slightly oversized or you add a washer.
 
 Screw from the top and gently tighten until the screw stops against the
-blind insert.  If you prefer screws from the bottom, print the
+blind insert. If you prefer screws from the bottom, print the
 `through` variant instead and use M2.5 × 10 mm screws up into the same
 spacers.

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -21,10 +21,10 @@ CONTEXT:
   `PATH`; the script exits early if it cannot find the binary.
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these
   models as artifacts. Do not commit `.stl` files.
-- Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`, or `nut`).  
+- Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`, or `nut`).
   `STANDOFF_MODE` is case-insensitive and defaults to the model’s `standoff_mode` value (often `heatset`).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test.  
+- Run `pre-commit run --all-files` to lint, format, and test.
   For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`

--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -18,7 +18,7 @@ CONTEXT:
 - Docs live in [`docs/`](../docs/).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for style, testing, and repository conventions.
 - Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../scripts/checks.sh) for
-  linting, formatting, and tests.  
+  linting, formatting, and tests.
   For documentation changes, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`

--- a/docs/prompts-codex-elex.md
+++ b/docs/prompts-codex-elex.md
@@ -18,7 +18,7 @@ CONTEXT:
 - Electronics files live under [`elex/`](../elex/).
 - The `power_ring` project uses KiCad 9+ and KiBot ([`.kibot/power_ring.yaml`](../.kibot/power_ring.yaml)).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test.  
+- Run `pre-commit run --all-files` to lint, format, and test.
   For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`


### PR DESCRIPTION
## Summary
- clarify brass insert hardware wording for Pi cluster carrier
- normalize trailing whitespace in prompt docs

## Testing
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68bb39733c18832f85bfbe6d687b5ef5