### PR TITLE
📝: refresh pi image prompt docs

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -21,10 +21,10 @@ CONTEXT:
   `PATH`; the script exits early if it cannot find the binary.
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these
   models as artifacts. Do not commit `.stl` files.
-- Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`, or `nut`).  
+- Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`, or `nut`).
   `STANDOFF_MODE` is case-insensitive and defaults to the model’s `standoff_mode` value (often `heatset`).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test.  
+- Run `pre-commit run --all-files` to lint, format, and test.
   For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`

--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -18,7 +18,7 @@ CONTEXT:
 - Docs live in [`docs/`](../docs/).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for style, testing, and repository conventions.
 - Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../scripts/checks.sh) for
-  linting, formatting, and tests.  
+  linting, formatting, and tests.
   For documentation changes, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`

--- a/docs/prompts-codex-elex.md
+++ b/docs/prompts-codex-elex.md
@@ -18,7 +18,7 @@ CONTEXT:
 - Electronics files live under [`elex/`](../elex/).
 - The `power_ring` project uses KiCad 9+ and KiBot ([`.kibot/power_ring.yaml`](../.kibot/power_ring.yaml)).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test.  
+- Run `pre-commit run --all-files` to lint, format, and test.
   For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`

--- a/docs/prompts-codex-pi-image.md
+++ b/docs/prompts-codex-pi-image.md
@@ -18,9 +18,11 @@ CONTEXT:
 - Cloud-init config lives under [`scripts/cloud-init/`](../scripts/cloud-init/).
 - [`scripts/build_pi_image.sh`](../scripts/build_pi_image.sh) builds an image locally or in CI.
 - [`pi_image_cloudflare.md`](./pi_image_cloudflare.md) is the user guide.
-- Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`
-  (requires `aspell` and `aspell-en`), and
-  `linkchecker --no-warnings README.md docs/`.
+- Run `pre-commit run --all-files` to invoke
+  [`scripts/checks.sh`](../scripts/checks.sh) for linting, formatting, and tests. For
+  documentation changes, also run:
+  - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
+  - `linkchecker --no-warnings README.md docs/`
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py` before committing.
 - Log persistent build issues in [`outages/`](../outages/) per
@@ -46,7 +48,7 @@ Use this prompt to refine sugarkube's own prompt documentation.
 ```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
-Follow `AGENTS.md` and `README.md`.
+Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
 Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`
 (requires `aspell` and `aspell-en`),
 `linkchecker --no-warnings README.md docs/`, and


### PR DESCRIPTION
## What
- link AGENTS/README and clarify required checks in pi image prompt
- remove stray trailing whitespace in related prompt docs

## Why
- keep prompt guidance accurate and maintain formatting

## How to Test
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bb396fa34c832fb853e4b819bcf5c1