### PR TITLE
📝 : fix prompts-codex upgrade prompt formatting

### DIFF
--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -41,22 +41,20 @@ Type: evergreen
 
 Use this prompt to refine sugarkube's own prompt documentation.
 
+```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
 Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
-Run `pre-commit run --all-files`, `pyspelling -c` [`.spellcheck.yaml`](../.spellcheck.yaml)
-(requires `aspell` and `aspell-en`), `linkchecker --no-warnings README.md docs/`, and
-`git diff --cached |` [`./scripts/scan-secrets.py`](../scripts/scan-secrets.py) before committing.
+Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires `aspell` and
+`aspell-en`), `linkchecker --no-warnings README.md docs/`, and
+`git diff --cached | ./scripts/scan-secrets.py` before committing.
 Fix any issues reported by these tools.
 
 USER:
-1. Choose a `docs/prompts-*.md` file to update (for example,
-   `prompts-codex-cad.md`).
-2. Clarify context, refresh links, and ensure all referenced instructions or
-   scripts still exist.
+1. Choose a `docs/prompts-*.md` file to update (for example, `prompts-codex-cad.md`).
+2. Clarify context, refresh links, and ensure all referenced instructions or scripts still exist.
 3. Run the commands above and address any failures.
 
 OUTPUT:
-A pull request that updates the selected prompt doc with current references
-and passing checks.
+A pull request that updates the selected prompt doc with current references and passing checks.
 ```


### PR DESCRIPTION
what: correct code fencing and command syntax in prompts-codex upgrade section
why: keep contributor prompt accurate and readable
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68bb396fa34c832fb853e4b819bcf5c1