### PR TITLE
✅ : broaden secret pattern tests

### DIFF
--- a/tests/scan_secrets_test.py
+++ b/tests/scan_secrets_test.py
@@ -16,8 +16,13 @@ def scan_secrets():
     return module
 
 
-def test_regex_scan_detects_pattern(scan_secrets):
-    diff = ["+++ b/file.txt", "+api" "_key=123"]
+# Ensure regex scan catches common secret patterns.
+@pytest.mark.parametrize(
+    "line",
+    ["+api" "_key=123", "+token" ": abc", "+aws_secret" "_key=xyz"],
+)
+def test_regex_scan_detects_patterns(scan_secrets, line):
+    diff = ["+++ b/file.txt", line]
     assert scan_secrets.regex_scan(diff)
 
 


### PR DESCRIPTION
what: cover token and AWS key patterns in scan-secrets tests
why: prevent regressions in secret detection
how to test: SKIP=trailing-whitespace,end-of-file-fixer pre-commit run --files tests/scan_secrets_test.py
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bb396def6c832fb19c2e7f8c8dacae