### PR TITLE
🧪 : ensure collect_pi_image errors when deploy dir missing

### DIFF
--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -34,6 +34,14 @@ def test_handles_img_gz(tmp_path):
     assert (out_img.with_suffix(out_img.suffix + ".sha256")).exists()
 
 
+def test_errors_when_deploy_missing(tmp_path):
+    deploy = tmp_path / "missing"
+    out_img = tmp_path / "out.img.xz"
+    result = _run_script(tmp_path, deploy, out_img)
+    assert result.returncode != 0
+    assert f"'{deploy}' does not exist" in result.stderr
+
+
 def test_errors_on_zip_without_img(tmp_path):
     deploy = tmp_path / "deploy"
     deploy.mkdir()


### PR DESCRIPTION
what: add negative test for collect_pi_image.sh
why: cover missing deploy directory case
how to test: pre-commit run --files tests/collect_pi_image_inputs_test.py && pytest -q
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68bb396def6c832fb19c2e7f8c8dacae