### PR TITLE
docs: expand Docker repo walkthrough with token.place compose example

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -138,6 +138,22 @@ docker exec -it tokenplace python -m pytest  # optional tests
 curl http://localhost:5000  # should return HTML
 ```
 
+#### token.place (docker-compose)
+
+The Pi image includes a minimal compose file so token.place can start with a
+single command. The same approach works for repos like dspace that provide
+their own `docker-compose.yml`.
+
+```sh
+cd /opt/projects/token.place
+docker compose -f docker-compose.tokenplace.yml up -d
+docker compose -f docker-compose.tokenplace.yml ps
+docker compose -f docker-compose.tokenplace.yml logs -f
+curl http://localhost:5000
+```
+Use `docker compose -f docker-compose.tokenplace.yml logs -f` to watch
+token.place start up and confirm it binds to port 5000.
+
 #### dspace (docker-compose)
 
 ```sh


### PR DESCRIPTION
## Summary
- add token.place docker-compose example with log tailing
- highlight pattern for dspace and other repos

## Testing
- `pre-commit run --files docs/docker_repo_walkthrough.md`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb390468ac832f806ddc5229c7a547