### PR TITLE
Prevent Pi image build from clobbering existing artifacts

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -15,8 +15,11 @@ The `build_pi_image.sh` script clones `pi-gen` using
 `PI_GEN_BRANCH` (default: `bookworm` for 32-bit builds and `arm64` for
 64-bit). Set `PI_GEN_URL` to use a fork or mirror if the default repository is
 unavailable. `IMG_NAME` controls the output filename and `OUTPUT_DIR` selects
-where artifacts are written; the script creates the directory if needed. To
-reduce flaky downloads it pins the official Raspberry Pi and Debian mirrors,
+where artifacts are written; the script creates the directory if needed. To avoid
+accidental overwrites it aborts when the image already exists unless `FORCE_OVERWRITE=1`
+is set. Set `FORCE_OVERWRITE=1` when rerunning builds to replace an existing
+image. To reduce flaky downloads it pins the official Raspberry Pi and Debian
+mirrors,
 adds `APT_OPTS` (retries, timeouts, `--fix-missing`), and installs a persistent
 apt/dpkg Pre-Invoke hook that rewrites any raspbian host to a stable HTTPS
 mirror, and bypasses proxies for `archive.raspberrypi.com`. Override the Raspberry

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -21,10 +21,10 @@ CONTEXT:
   `PATH`; the script exits early if it cannot find the binary.
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these
   models as artifacts. Do not commit `.stl` files.
-- Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`, or `nut`).  
+- Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`, or `nut`).
   `STANDOFF_MODE` is case-insensitive and defaults to the model’s `standoff_mode` value (often `heatset`).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test.  
+- Run `pre-commit run --all-files` to lint, format, and test.
   For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`

--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -18,7 +18,7 @@ CONTEXT:
 - Docs live in [`docs/`](../docs/).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for style, testing, and repository conventions.
 - Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../scripts/checks.sh) for
-  linting, formatting, and tests.  
+  linting, formatting, and tests.
   For documentation changes, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`

--- a/docs/prompts-codex-elex.md
+++ b/docs/prompts-codex-elex.md
@@ -18,7 +18,7 @@ CONTEXT:
 - Electronics files live under [`elex/`](../elex/).
 - The `power_ring` project uses KiCad 9+ and KiBot ([`.kibot/power_ring.yaml`](../.kibot/power_ring.yaml)).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test.  
+- Run `pre-commit run --all-files` to lint, format, and test.
   For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -114,6 +114,12 @@ PI_GEN_BRANCH="${PI_GEN_BRANCH:-bookworm}"
 IMG_NAME="${IMG_NAME:-sugarkube}"
 OUTPUT_DIR="${OUTPUT_DIR:-${REPO_ROOT}}"
 mkdir -p "${OUTPUT_DIR}"
+OUT_IMG="${OUTPUT_DIR}/${IMG_NAME}.img.xz"
+# Abort to avoid clobbering existing images unless FORCE_OVERWRITE=1
+if [ -e "${OUT_IMG}" ] && [ "${FORCE_OVERWRITE:-0}" -ne 1 ]; then
+  echo "Output image already exists: ${OUT_IMG} (set FORCE_OVERWRITE=1 to overwrite)" >&2
+  exit 1
+fi
 export OUTPUT_DIR
 check_space "${OUTPUT_DIR}"
 
@@ -312,8 +318,6 @@ if ! docker image inspect pi-gen:latest >/dev/null 2>&1; then
   echo "pi-gen Docker image not found" >&2
   exit 1
 fi
-
-OUT_IMG="${OUTPUT_DIR}/${IMG_NAME}.img.xz"
 
 bash "${REPO_ROOT}/scripts/collect_pi_image.sh" "deploy" "${OUT_IMG}"
 if [ ! -s "${OUT_IMG}" ]; then


### PR DESCRIPTION
## Summary
- abort build when target image already exists unless FORCE_OVERWRITE=1
- document FORCE_OVERWRITE flag in Pi image guide

## Testing
- python -m pre_commit run --all-files
- python -m pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/

------
https://chatgpt.com/codex/tasks/task_e_68bb391e4278832fa3dfb30c4444cdd9