### PR TITLE
🛠️: add debug toggle for Pi image build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ the docs you will see the term used in both contexts.
     `democratizedspace/dspace` (branch `v3`) by default. Set
     `CLONE_SUGARKUBE=true` to include this repo and pass space-separated Git
     URLs via `EXTRA_REPOS` to clone additional projects; needs a valid `user-data.yaml`
-    and ~10 GB free disk space
+    and ~10 GB free disk space. Set `DEBUG=1` to trace script execution.
   - `pi_node_verifier.sh` — check k3s prerequisites; use `--json` for machine output
 - `outages/` — structured outage records (see
   [docs/outage_catalog.md](docs/outage_catalog.md))

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -27,7 +27,8 @@ to adjust the maximum build duration. Customize the cloud-init configuration wit
 `CLOUD_INIT_PATH` or point `CLOUD_INIT_DIR` and `CLOUDFLARED_COMPOSE_PATH` at
 alternate files; the defaults read from `scripts/cloud-init/`. Set `SKIP_BINFMT=1`
 to skip installing binfmt handlers when they're already present or when the build
-environment disallows privileged containers.
+environment disallows privileged containers. Set `DEBUG=1` to trace script
+execution for troubleshooting.
 
 `REQUIRED_SPACE_GB` (default: `10`) controls the free disk space check.
 The script rewrites the Cloudflare apt source architecture to `armhf` when

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ "${DEBUG:-0}" == "1" ]]; then
+  set -x
+fi
+
 REQUIRED_SPACE_GB="${REQUIRED_SPACE_GB:-10}"
 
 check_space() {


### PR DESCRIPTION
what: allow DEBUG=1 to trace build_pi_image.sh and document usage
why: simplify troubleshooting when building Pi images
how to test: DEBUG=1 ./scripts/build_pi_image.sh # verify trace output
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bb391e4278832fa3dfb30c4444cdd9