### PR TITLE
📝 docs: clarify pi image mirror options

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -19,15 +19,16 @@ where artifacts are written; the script creates the directory if needed. To
 reduce flaky downloads it pins the official Raspberry Pi and Debian mirrors,
 adds `APT_OPTS` (retries, timeouts, `--fix-missing`), and installs a persistent
 apt/dpkg Pre-Invoke hook that rewrites any raspbian host to a stable HTTPS
-mirror, and bypasses proxies for `archive.raspberrypi.com`. Override the Raspberry
-Use `APT_RETRIES` and `APT_TIMEOUT` to tune the retry count and per-request timeout.
+mirror and bypasses proxies for `archive.raspberrypi.com`. Override the Raspberry
 Pi packages mirror with `RPI_MIRROR` (mapped to pi-gen's `APT_MIRROR_RASPBERRYPI`)
-and the Debian mirror with `DEBIAN_MIRROR`. Use `BUILD_TIMEOUT` (default: `4h`)
-to adjust the maximum build duration. Customize the cloud-init configuration with
-`CLOUD_INIT_PATH` or point `CLOUD_INIT_DIR` and `CLOUDFLARED_COMPOSE_PATH` at
-alternate files; the defaults read from `scripts/cloud-init/`. Set `SKIP_BINFMT=1`
-to skip installing binfmt handlers when they're already present or when the build
-environment disallows privileged containers.
+and the Debian mirror with `DEBIAN_MIRROR`. Use `APT_RETRIES` and `APT_TIMEOUT`
+to tune the retry count and per-request timeout. Use `BUILD_TIMEOUT` (default:
+`4h`) to adjust the maximum build duration. Customize the cloud-init
+configuration with `CLOUD_INIT_PATH` or point `CLOUD_INIT_DIR` and
+`CLOUDFLARED_COMPOSE_PATH` at alternate files; the defaults read from
+`scripts/cloud-init/`. Set `SKIP_BINFMT=1` to skip installing binfmt handlers
+when they're already present or when the build environment disallows privileged
+containers.
 
 `REQUIRED_SPACE_GB` (default: `10`) controls the free disk space check.
 The script rewrites the Cloudflare apt source architecture to `armhf` when

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -21,10 +21,10 @@ CONTEXT:
   `PATH`; the script exits early if it cannot find the binary.
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these
   models as artifacts. Do not commit `.stl` files.
-- Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`, or `nut`).  
+- Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`, or `nut`).
   `STANDOFF_MODE` is case-insensitive and defaults to the model’s `standoff_mode` value (often `heatset`).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test.  
+- Run `pre-commit run --all-files` to lint, format, and test.
   For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`

--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -18,7 +18,7 @@ CONTEXT:
 - Docs live in [`docs/`](../docs/).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for style, testing, and repository conventions.
 - Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../scripts/checks.sh) for
-  linting, formatting, and tests.  
+  linting, formatting, and tests.
   For documentation changes, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`

--- a/docs/prompts-codex-elex.md
+++ b/docs/prompts-codex-elex.md
@@ -18,7 +18,7 @@ CONTEXT:
 - Electronics files live under [`elex/`](../elex/).
 - The `power_ring` project uses KiCad 9+ and KiBot ([`.kibot/power_ring.yaml`](../.kibot/power_ring.yaml)).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test.  
+- Run `pre-commit run --all-files` to lint, format, and test.
   For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`


### PR DESCRIPTION
## Summary
- fix truncated RPI_MIRROR paragraph in pi_image_cloudflare.md
- trim trailing whitespace in codex prompt docs

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68bb390bca98832fb377d96fa19d7289