### PR TITLE
📝 : clarify CAD prompt checks

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -17,14 +17,17 @@ Keep OpenSCAD models current and ensure they render cleanly.
 CONTEXT:
 - CAD files reside in [`cad/`](../cad/).
 - Use [`scripts/openscad_render.sh`](../scripts/openscad_render.sh) to export STL meshes into
-  [`stl/`](../stl/). Ensure [OpenSCAD](https://openscad.org) is installed and available in
+  [`stl/`](../stl/). Ensure [OpenSCAD](https://openscad.org/) is installed and available in
   `PATH`; the script exits early if it cannot find the binary.
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these
   models as artifacts. Do not commit `.stl` files.
-- Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`, or `nut`).  
-  `STANDOFF_MODE` is case-insensitive and defaults to the model’s `standoff_mode` value (often `heatset`).
+- Render each model in all supported `standoff_mode` variants
+  (for example, `heatset`, `printed`, or `nut`). `STANDOFF_MODE` is
+  case-insensitive and defaults to the model’s `standoff_mode` value
+  (often `heatset`).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test.  
+- Run `pre-commit run --all-files` to invoke
+  [`scripts/checks.sh`](../scripts/checks.sh) for linting, formatting, and tests.
   For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`
@@ -39,7 +42,7 @@ REQUEST:
 3. Render the model via:
 
    ```bash
-   ./scripts/openscad_render.sh path/to/model.scad  # uses model’s default standoff_mode (often heatset)
+   ./scripts/openscad_render.sh path/to/model.scad  # defaults to standoff_mode (often heatset)
    STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad  # case-insensitive
    STANDOFF_MODE=nut ./scripts/openscad_render.sh path/to/model.scad
    ```

--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -18,7 +18,7 @@ CONTEXT:
 - Docs live in [`docs/`](../docs/).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for style, testing, and repository conventions.
 - Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../scripts/checks.sh) for
-  linting, formatting, and tests.  
+  linting, formatting, and tests.
   For documentation changes, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`

--- a/docs/prompts-codex-elex.md
+++ b/docs/prompts-codex-elex.md
@@ -18,7 +18,7 @@ CONTEXT:
 - Electronics files live under [`elex/`](../elex/).
 - The `power_ring` project uses KiCad 9+ and KiBot ([`.kibot/power_ring.yaml`](../.kibot/power_ring.yaml)).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test.  
+- Run `pre-commit run --all-files` to lint, format, and test.
   For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`


### PR DESCRIPTION
what: refresh prompts-codex-cad instructions and link
why: document checks script and keep links current
how: pre-commit run --all-files
     pyspelling -c .spellcheck.yaml
     linkchecker --no-warnings README.md docs/
     git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68bb39086e84832fb504b9df0f6df531