### PR TITLE
Tighten Pi carrier spacing to 10 mm

### DIFF
--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -38,7 +38,7 @@ nut_flat = 5.0 + nut_clearance; // across flats for M2.5 nut
 nut_thick = 2.0;
 
 board_angle = 0;
-gap_between_boards = 45;
+gap_between_boards = 10;
 edge_margin = 5;
 port_clearance = 6;
 

--- a/docs/lcd_mount.md
+++ b/docs/lcd_mount.md
@@ -3,6 +3,7 @@
 The basic Pi carrier can host a 1602 I²C LCD in the free quadrant.
 Its standoffs match the common 80×36 mm module with holes 3 mm from each
 edge (75 mm × 31 mm spacing).
+The base plate spaces each Raspberry Pi 10 mm apart for cable clearance while keeping the footprint compact.
 
 The base plate includes rounded corners set by `corner_radius` (default 5 mm)
 to make handling safer. Standoff pillars now use a 6.5 mm diameter to conserve


### PR DESCRIPTION
## Summary
- shrink Raspberry Pi spacing to 10 mm in `pi_carrier.scad`
- document new spacing in LCD mount guide

## Testing
- `./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `./scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `./scripts/openscad_render.sh cad/solar_cube/frame.scad`
- `./scripts/openscad_render.sh cad/solar_cube/sugarkube.scad`
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68bd194c1cf0832fae9ddfc0cde26612