### PR TITLE
🔧: add nut clearance to panel bracket

### DIFF
--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -24,7 +24,8 @@ insert_hole_diam  = insert_od - insert_clearance;
 screw_nominal     = 5.0;      // nominal screw size for through-hole (mm)
 screw_clearance   = screw_nominal + 0.2; // through-hole Ø with clearance (mm)
 chamfer           = 0.8;      // lead-in chamfer (mm)
-nut_flat          = 8.0;      // across flats for M5 nut (mm)
+nut_clearance     = 0.2;      // extra room for easier nut insertion (mm)
+nut_flat          = 8.0 + nut_clearance; // across flats for M5 nut (mm)
 nut_thick         = 4.0;      // nut thickness (mm)
 
 assert(insert_length < thickness,


### PR DESCRIPTION
what: add nut clearance parameter to solar panel bracket
why: allow hex nuts to fit without interference
how to test: pre-commit run --all-files && pyspelling -c .spellcheck.yaml && linkchecker --no-warnings README.md docs/ && ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad && STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad && STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bd194c1cf0832fae9ddfc0cde26612