### PR TITLE
🔧: widen nut recess for pi_carrier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Changed
 * panel_bracket: increase default edge radius to 2 mm for smoother corners
-* pi_carrier: reduce standoff diameter to 6.3 mm to save material
+* pi_carrier: set standoff diameter to 6.5 mm for added strength
+* pi_carrier: widen nut recess clearance to 0.3 mm for easier nut insertion
 
 ### Fixed
 * pi_carrier: standoff length increased from 20 mm to 22 mm (flush fit with PoE HAT)

--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -33,7 +33,7 @@ screw_clearance_diam = 3.2; // through-hole clearance, slightly oversize
 countersink_diam = 5.0;
 countersink_depth = 1.6;
 
-nut_clearance = 0.2; // extra room for easier nut insertion
+nut_clearance = 0.3; // extra room for easier nut insertion (was 0.2)
 nut_flat = 5.0 + nut_clearance; // across flats for M2.5 nut
 nut_thick = 2.0;
 


### PR DESCRIPTION
what: increase nut clearance to 0.3 mm and update changelog
why: allow M2.5 nuts to seat without binding
how to test:
- ./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad
- STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad
- STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad

------
https://chatgpt.com/codex/tasks/task_e_68bd194c1cf0832fae9ddfc0cde26612