### PR TITLE
📝: clarify openscad render usage note

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ checks.
 
 STL files are produced automatically by CI for each OpenSCAD model and can be
 downloaded from the workflow run. Provide a single `.scad` file path to render a
-variant locally. The script exits with a usage message if extra arguments are
-supplied:
+variant locally. The script accepts only one argument and prints a usage
+message if others are supplied:
 
 ```bash
 bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad


### PR DESCRIPTION
what: clarify openscad_render.sh argument usage in README
why: reduce confusion about supported file paths
how to test: pre-commit run --all-files; pyspelling; linkchecker
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68bd1a3f47a8832f9217646d995f032a