### PR TITLE
📝 : – clarify optional docs checks in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,14 @@ pre-commit install
 
 ```bash
 pre-commit run --all-files
+git diff --cached | ./scripts/scan-secrets.py
+```
+
+- If `README.md` or files under `docs/` change, also run:
+
+```bash
 pyspelling -c .spellcheck.yaml
 linkchecker --no-warnings README.md docs/
-git diff --cached | ./scripts/scan-secrets.py
 ```
 
 The `--no-warnings` flag suppresses parse warnings so the command exits cleanly.


### PR DESCRIPTION
what: document that spell and link checks only run when docs change
why: avoid extra steps on code-only commits
how to test: pre-commit run --all-files && pyspelling -c .spellcheck.yaml && linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68bd1a3f47a8832f9217646d995f032a