### PR TITLE
docs: update CAD prompt instructions

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -17,9 +17,9 @@ Keep OpenSCAD models current and ensure they render cleanly.
 CONTEXT:
 - CAD files reside in [`cad/`](../cad/).
 - Use [`scripts/openscad_render.sh`](../scripts/openscad_render.sh) to export binary STL meshes
-  into the git-ignored [`stl/`](../stl/) directory. Ensure [OpenSCAD](https://openscad.org/) version
-  2021 or newer is installed and available in `PATH`; the script exits early if it cannot find the
-  binary.
+  into the git-ignored [`stl/`](../stl/) directory.
+  Ensure [OpenSCAD](https://openscad.org/) 2021 or newer is installed and available in `PATH`;
+  the script exits early if it cannot find the binary.
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these
   models as artifacts. Do not commit `.stl` files.
 - Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`,
@@ -30,7 +30,8 @@ CONTEXT:
   [`scripts/checks.sh`](../scripts/checks.sh).
   If `package.json` defines them, also run:
   - `npm run lint`
-  - `npm run test:ci`
+  - `npm run format:check`
+  - `npm test -- --coverage`
 - For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`;
     see [`.spellcheck.yaml`](../.spellcheck.yaml))
@@ -47,7 +48,7 @@ REQUEST:
 3. Render the model via:
 
    ~~~bash
-   ./scripts/openscad_render.sh path/to/model.scad  # uses model’s default standoff_mode (often heatset)
+   ./scripts/openscad_render.sh path/to/model.scad  # default standoff_mode (heatset)
    STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad  # case-insensitive
    STANDOFF_MODE=nut ./scripts/openscad_render.sh path/to/model.scad
    ~~~
@@ -70,6 +71,10 @@ Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
 Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires `aspell` and
 `aspell-en`), `linkchecker --no-warnings README.md docs/`, and
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
+If `package.json` defines them, also run:
+- `npm run lint`
+- `npm run format:check`
+- `npm test -- --coverage`
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).


### PR DESCRIPTION
## Summary
- clarify OpenSCAD requirement
- document npm format and test commands
- streamline render example comment

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd1a2c4c7c832fb73a7317937065d1