### PR TITLE
docs: refresh tests prompt links

### DIFF
--- a/docs/prompts-codex-tests.md
+++ b/docs/prompts-codex-tests.md
@@ -16,8 +16,8 @@ Improve and maintain test coverage.
 
 CONTEXT:
 - Tests live in [`tests/`](../tests/) and include Python suites run with
-  [pytest](https://docs.pytest.org/en/stable/) and shell tests written in
-  [Bats](https://bats-core.readthedocs.io/).
+  [pytest](https://docs.pytest.org/en/latest/) and shell tests written in
+  [Bats](https://bats-core.readthedocs.io/en/latest/).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository
   conventions.
 - Run `pre-commit run --all-files`; it invokes


### PR DESCRIPTION
## Summary
- point tests prompt doc to latest Pytest and Bats guides

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd1a2c4c7c832fb73a7317937065d1