### PR TITLE
📝 docs: clarify OpenSCAD version in CAD prompt

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -16,10 +16,10 @@ Keep OpenSCAD models current and ensure they render cleanly.
 
 CONTEXT:
 - CAD files reside in [`cad/`](../cad/).
-- Use [`scripts/openscad_render.sh`](../scripts/openscad_render.sh) to export binary STL meshes
-  into the git-ignored [`stl/`](../stl/) directory. Ensure [OpenSCAD](https://openscad.org/) version
-  2021 or newer is installed and available in `PATH`; the script exits early if it cannot find the
-  binary.
+- Use [`scripts/openscad_render.sh`](../scripts/openscad_render.sh) to export binary STL
+  meshes into the git-ignored [`stl/`](../stl/) directory. Ensure
+  [OpenSCAD 2021.01](https://github.com/openscad/openscad/releases/tag/openscad-2021.01) or newer
+  is installed and available in `PATH`; the script exits early if it cannot find the binary.
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these
   models as artifacts. Do not commit `.stl` files.
 - Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`,
@@ -47,8 +47,8 @@ REQUEST:
 3. Render the model via:
 
    ~~~bash
-   ./scripts/openscad_render.sh path/to/model.scad  # uses model’s default standoff_mode (often heatset)
-   STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad  # case-insensitive
+   ./scripts/openscad_render.sh path/to/model.scad
+   STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad
    STANDOFF_MODE=nut ./scripts/openscad_render.sh path/to/model.scad
    ~~~
 


### PR DESCRIPTION
what: link CAD prompt to specific OpenSCAD 2021.01 release and tidy rendering examples
why: ensure instructions mention current version and stay within line-length limits
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68bd1a2c4c7c832fb73a7317937065d1