### PR TITLE
🧪: ensure pi_node_verifier reports failing checks

### DIFF
--- a/tests/pi_node_verifier_output_test.bats
+++ b/tests/pi_node_verifier_output_test.bats
@@ -10,6 +10,37 @@
   echo "$output" | grep "k3s_check_config:"
 }
 
+@test "pi_node_verifier reports failing checks" {
+  tmp="$(mktemp -d)"
+  PATH="$tmp:$PATH"
+
+  cat <<'EOF' > "$tmp/cloud-init"
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$tmp/cloud-init"
+
+  cat <<'EOF' > "$tmp/timedatectl"
+#!/usr/bin/env bash
+echo "NTPSynchronized=no"
+exit 0
+EOF
+  chmod +x "$tmp/timedatectl"
+
+  cat <<'EOF' > "$tmp/iptables"
+#!/usr/bin/env bash
+echo "iptables v1.8.7 (legacy)"
+exit 0
+EOF
+  chmod +x "$tmp/iptables"
+
+  run "$BATS_TEST_DIRNAME/../scripts/pi_node_verifier.sh"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep "cloud_init: fail"
+  echo "$output" | grep "time_sync: fail"
+  echo "$output" | grep "iptables_backend: fail"
+}
+
 @test "pi_node_verifier --help shows usage" {
   run "$BATS_TEST_DIRNAME/../scripts/pi_node_verifier.sh" --help
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- test pi_node_verifier failure paths for cloud-init, time sync, iptables

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68bd1a25fc38832fa8382d0a81670bd6