### PR TITLE
✅ : add test for output directory creation

### DIFF
--- a/tests/download_pi_image_test.py
+++ b/tests/download_pi_image_test.py
@@ -128,6 +128,45 @@ def test_uses_default_output(tmp_path):
     assert (tmp_path / "sugarkube.img.xz").exists()
 
 
+def test_creates_output_directory(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    src = tmp_path / "src.img.xz"
+    src.write_text("data")
+    gh = fake_bin / "gh"
+    gh.write_text(
+        "#!/bin/bash\n"
+        'if [ "$1" = run ] && [ "$2" = list ]; then\n'
+        "  echo 42\n"
+        'elif [ "$1" = run ] && [ "$2" = download ]; then\n'
+        "  shift 2\n"
+        '  while [ "$1" != --dir ]; do shift; done\n'
+        "  dir=$2\n"
+        '  cp "$GH_SRC" "$dir/sugarkube.img.xz"\n'
+        "else\n"
+        "  exit 1\n"
+        "fi\n"
+    )
+    gh.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["GH_SRC"] = str(src)
+    base = Path(__file__).resolve().parents[1]
+    script = base / "scripts" / "download_pi_image.sh"
+    out = tmp_path / "nested" / "out.img.xz"
+    result = subprocess.run(
+        ["/bin/bash", str(script), str(out)],
+        env=env,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert out.exists()
+    assert (tmp_path / "nested").is_dir()
+
+
 def test_downloads_without_realpath(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()


### PR DESCRIPTION
what: add regression test for download script directory creation
why: ensure gh artifact download handles nested paths
how to test: pre-commit run --all-files
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bd1a25fc38832fa8382d0a81670bd6