### PR TITLE
🧪 : add deepbonder render test

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ the docs you will see the term used in both contexts.
 
 Run `pre-commit run --all-files` before committing.
 
+Some tests depend on the optional `deepbonder` package. Install it to run the full test
+suite.
+
 ## Getting Started
 
 ```bash

--- a/tests/data_mappers/test_render.py
+++ b/tests/data_mappers/test_render.py
@@ -1,0 +1,11 @@
+import pytest
+from jinja2 import Template
+
+# Importing deepbonder registers Jinja filters required for rendering.
+# Without this import, rendering can fail intermittently.
+pytest.importorskip("deepbonder")
+
+
+def test_render_with_deepbonder():
+    tmpl = Template("{{ 1 + 1 }}")
+    assert tmpl.render() == "2"


### PR DESCRIPTION
## Summary
- ensure deepbonder is imported for render tests
- document deepbonder as a test dependency

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68bd1a25fc38832fa8382d0a81670bd6