### PR TITLE
docs: refresh CAD prompt instructions

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -16,15 +16,16 @@ Keep OpenSCAD models current and ensure they render cleanly.
 
 CONTEXT:
 - CAD files reside in [`cad/`](../cad/).
-- Use [`scripts/openscad_render.sh`](../scripts/openscad_render.sh) to export binary STL meshes
-  into the git-ignored [`stl/`](../stl/) directory. Ensure [OpenSCAD](https://openscad.org/) version
-  2021 or newer is installed and available in `PATH`; the script exits early if it cannot find the
-  binary.
+- Use [`scripts/openscad_render.sh`](../scripts/openscad_render.sh) to export binary STL
+  meshes into the git-ignored [`stl/`](../stl/) directory. Ensure
+  [OpenSCAD](https://openscad.org/) 2024.03 or newer is installed and available in
+  `PATH`; the script exits if the binary is missing.
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these
   models as artifacts. Do not commit `.stl` files.
-- Render each model in all supported `standoff_mode` variants (for example, `heatset`, `printed`,
-  or `nut`). `STANDOFF_MODE` is optional, case-insensitive, trims surrounding whitespace, and
-  defaults to the model’s `standoff_mode` value (often `heatset`).
+- Render each model in all supported `standoff_mode` variants such as `heatset`, `printed`,
+  or `nut`. The `STANDOFF_MODE` environment variable is optional, case-insensitive, trims
+  surrounding whitespace, and defaults to the model’s `standoff_mode` value (often
+  `heatset`).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
 - Run `pre-commit run --all-files` to lint, format, and test via
   [`scripts/checks.sh`](../scripts/checks.sh).
@@ -46,11 +47,11 @@ REQUEST:
 2. Modify geometry or parameters as required.
 3. Render the model via:
 
-   ~~~bash
-   ./scripts/openscad_render.sh path/to/model.scad  # uses model’s default standoff_mode (often heatset)
-   STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad  # case-insensitive
-   STANDOFF_MODE=nut ./scripts/openscad_render.sh path/to/model.scad
-   ~~~
+    ~~~bash
+    ./scripts/openscad_render.sh path/to/model.scad  # default standoff_mode (often heatset)
+    STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad  # case-insensitive
+    STANDOFF_MODE=nut ./scripts/openscad_render.sh path/to/model.scad
+    ~~~
 
 4. Commit updated SCAD sources and any documentation.
 


### PR DESCRIPTION
## Summary
- update CAD prompt with current OpenSCAD version and STANDOFF_MODE guidance

## Testing
- `pre-commit run --files docs/prompts-codex-cad.md` *(fails: hung, aborted)*
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd19be6e8c832fbdc9b58c34e861e8