### PR TITLE
🛠️: add URL check skip flag for Pi image build

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -32,7 +32,8 @@ the cloud-init configuration with `CLOUD_INIT_PATH` or point `CLOUD_INIT_DIR` an
 they're already present or when the build environment disallows privileged
 containers. Set `DEBUG=1` to trace script execution for troubleshooting.
 
-`REQUIRED_SPACE_GB` (default: `10`) controls the free disk space check.
+`REQUIRED_SPACE_GB` (default: `10`) controls free disk space checks on the
+temporary work directory and the output location.
 The script rewrites the Cloudflare apt source architecture to `armhf` when
 `ARM64=0` so 32-bit builds install the correct packages and sets `ARMHF=0` when
 `ARM64=1` to avoid generating both architectures.
@@ -48,9 +49,10 @@ installs a `cloudflared-compose` systemd unit which starts the tunnel via Docker
 once the token is present and waits for `network-online.target` to ensure
 connectivity. The script curls the Debian, Raspberry Pi, and pi-gen repositories
 with a 10-second timeout before building; override this via the
-`URL_CHECK_TIMEOUT` environment variable. Ensure `curl`, `docker` (with its
-daemon running), `git`, `sha256sum`, `stdbuf`, `timeout`, and `xz` are installed
-before running it; `stdbuf` and `timeout` come from GNU coreutils. The script
+`URL_CHECK_TIMEOUT` environment variable or set `SKIP_URL_CHECK=1` to bypass
+these probes when using local mirrors or working offline. Ensure `curl`, `docker`
+(with its daemon running), `git`, `sha256sum`, `stdbuf`, `timeout`, and `xz` are
+installed before running it; `stdbuf` and `timeout` come from GNU coreutils. The script
 checks that both the temporary and output directories have at least 10 GB free
 before starting and verifies the resulting image exists and is non-empty before
 reporting success. Use the prepared image to deploy containerized apps. The

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -100,12 +100,17 @@ PI_GEN_URL="${PI_GEN_URL:-https://github.com/RPi-Distro/pi-gen.git}"
 DEBIAN_MIRROR="${DEBIAN_MIRROR:-https://deb.debian.org/debian}"
 RPI_MIRROR="${RPI_MIRROR:-https://archive.raspberrypi.com/debian}"
 URL_CHECK_TIMEOUT="${URL_CHECK_TIMEOUT:-10}"
-for url in "$DEBIAN_MIRROR" "$RPI_MIRROR" "$PI_GEN_URL"; do
-  if ! curl -fsIL --connect-timeout "${URL_CHECK_TIMEOUT}" --max-time "${URL_CHECK_TIMEOUT}" "$url" >/dev/null; then
-    echo "Cannot reach $url" >&2
-    exit 1
-  fi
-done
+SKIP_URL_CHECK="${SKIP_URL_CHECK:-0}"
+if [ "$SKIP_URL_CHECK" -ne 1 ]; then
+  for url in "$DEBIAN_MIRROR" "$RPI_MIRROR" "$PI_GEN_URL"; do
+    if ! curl -fsIL --connect-timeout "${URL_CHECK_TIMEOUT}" --max-time "${URL_CHECK_TIMEOUT}" "$url" >/dev/null; then
+      echo "Cannot reach $url" >&2
+      exit 1
+    fi
+  done
+else
+  echo "Skipping URL reachability checks"
+fi
 
 ARM64="${ARM64:-1}"
 if [ "$ARM64" -eq 1 ]; then


### PR DESCRIPTION
what: allow SKIP_URL_CHECK in build script and clarify disk space checks
why: support offline builds and document required free space
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bd19af6ba8832f866fa2b504e7f741