### PR TITLE
Embed cloudflared compose via cloud-init

### DIFF
--- a/docs/pi_image_builder_design.md
+++ b/docs/pi_image_builder_design.md
@@ -9,7 +9,6 @@
 ## Inputs / Outputs
 - Inputs:
 - `scripts/cloud-init/user-data.yaml` (cloud-init seed with cloudflared systemd unit)
-- `scripts/cloud-init/docker-compose.cloudflared.yml` (Cloudflare Tunnel compose file)
   - Environment variables:
     `PI_GEN_BRANCH` (default `bookworm`),
     `IMG_NAME` (default `sugarkube`),
@@ -35,7 +34,6 @@
   - `/pi-gen/work` → persistent Docker volume `pigen-work-cache`
   - `/var/cache/apt` → persistent Docker volume `pigen-apt-cache`
   - `stage2/01-sys-tweaks/user-data` → host `scripts/cloud-init/user-data.yaml`
-  - `stage2/01-sys-tweaks/files/opt/sugarkube/docker-compose.cloudflared.yml` → host compose file
 - Env:
   - `IMG_NAME`, `ENABLE_SSH=1`, `ARM64`, `USE_QCOW2=1`
   - Mirrors: `APT_MIRROR`, `RASPBIAN_MIRROR`, `APT_MIRROR_RASPBIAN`, `APT_MIRROR_RASPBERRYPI`, `DEBIAN_MIRROR`
@@ -92,7 +90,7 @@
 - Record repeated failures as `outages/*.json` using `outages/schema.json`
 
 ## Security
-- Read-only mounts for cloud-init and compose files into container
+Read-only mount for cloud-init file into container
 - No secrets embedded; Cloudflare token remains empty by default
 
 ## Future Enhancements

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -43,8 +43,10 @@ The image embeds `pi_node_verifier.sh` in `/usr/local/sbin` and clones the
 pass space-separated Git URLs in `EXTRA_REPOS` to pull additional projects.
 
 Set `TUNNEL_TOKEN` or `TUNNEL_TOKEN_FILE` to bake a Cloudflare token into
-`/opt/sugarkube/.cloudflared.env`; otherwise edit the file after boot. The image
-installs a `cloudflared-compose` systemd unit which starts the tunnel via Docker
+`/opt/sugarkube/.cloudflared.env`; otherwise edit the file after boot.
+Cloud-init writes `docker-compose.cloudflared.yml` to `/opt/sugarkube`.
+This avoids downloading the file at boot.
+The image installs a `cloudflared-compose` systemd unit which starts the tunnel via Docker
 once the token is present and waits for `network-online.target` to ensure
 connectivity. The script curls the Debian, Raspberry Pi, and pi-gen repositories
 with a 10-second timeout before building; override this via the

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -94,7 +94,7 @@ Follow the steps above for each node so every Pi boots from its own SSD.
    ```
 
 ## 7. Expose with Cloudflare Tunnel
-1. Copy `docker-compose.cloudflared.yml` to `/opt/sugarkube/` on each node
+1. Edit `/opt/sugarkube/docker-compose.cloudflared.yml` if needed (cloud-init installs it)
 2. Store the tunnel token in `/opt/sugarkube/.cloudflared.env`
 3. Start the tunnel service:
    ```bash

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -69,7 +69,6 @@ fi
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CLOUD_INIT_DIR="${CLOUD_INIT_DIR:-${REPO_ROOT}/scripts/cloud-init}"
 CLOUD_INIT_PATH="${CLOUD_INIT_PATH:-${CLOUD_INIT_DIR}/user-data.yaml}"
-CLOUDFLARED_COMPOSE_PATH="${CLOUDFLARED_COMPOSE_PATH:-${CLOUD_INIT_DIR}/docker-compose.cloudflared.yml}"
 if [ ! -f "${CLOUD_INIT_PATH}" ]; then
   echo "Cloud-init file not found: ${CLOUD_INIT_PATH}" >&2
   exit 1
@@ -80,14 +79,6 @@ if [ ! -s "${CLOUD_INIT_PATH}" ]; then
 fi
 if ! head -n1 "${CLOUD_INIT_PATH}" | grep -q '^#cloud-config'; then
   echo "Cloud-init file missing #cloud-config header: ${CLOUD_INIT_PATH}" >&2
-  exit 1
-fi
-if [ ! -f "${CLOUDFLARED_COMPOSE_PATH}" ]; then
-  echo "Cloudflared compose file not found: ${CLOUDFLARED_COMPOSE_PATH}" >&2
-  exit 1
-fi
-if [ ! -s "${CLOUDFLARED_COMPOSE_PATH}" ]; then
-  echo "Cloudflared compose file is empty: ${CLOUDFLARED_COMPOSE_PATH}" >&2
   exit 1
 fi
 WORK_DIR=$(mktemp -d)
@@ -162,8 +153,6 @@ if [ -n "${TUNNEL_TOKEN:-}" ]; then
   sed -i "s|TUNNEL_TOKEN=\"\"|TUNNEL_TOKEN=\"${TUNNEL_TOKEN}\"|" "${USER_DATA}"
 fi
 
-install -Dm644 "${CLOUDFLARED_COMPOSE_PATH}" \
-  "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/docker-compose.cloudflared.yml"
 
 # Bundle pi_node_verifier and optionally clone repos into the image
 install -Dm755 "${REPO_ROOT}/scripts/pi_node_verifier.sh" \

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -19,6 +19,16 @@ write_files:
     content: |
       # Inject with TUNNEL_TOKEN or TUNNEL_TOKEN_FILE env var or edit after boot
       TUNNEL_TOKEN=""
+  - path: /opt/sugarkube/docker-compose.cloudflared.yml
+    permissions: '0644'
+    content: |
+      services:
+        tunnel:
+          image: cloudflare/cloudflared:latest
+          restart: unless-stopped
+          command: tunnel run
+          env_file:
+            - /opt/sugarkube/.cloudflared.env
   - path: /etc/systemd/system/cloudflared-compose.service
     permissions: '0644'
     content: |

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -221,9 +221,7 @@ def test_requires_sudo_when_non_root(tmp_path):
     assert "Run as root or install sudo" in result.stderr
 
 
-def _setup_build_env(
-    tmp_path, check_compose: bool = False, precompressed: bool = False
-):
+def _setup_build_env(tmp_path, precompressed: bool = False):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     git_log = tmp_path / "git_args.log"
@@ -263,12 +261,6 @@ fi
     mount.write_text("#!/bin/sh\nexit 0\n")
     mount.chmod(0o755)
 
-    compose_check = (
-        "[[ -f stage2/01-sys-tweaks/files/opt/sugarkube/"
-        "docker-compose.cloudflared.yml ]] || exit 1\n"
-        if check_compose
-        else ""
-    )
     image_cmd = (
         "python3 - <<'PY'\n"
         "import zipfile\n"
@@ -291,7 +283,6 @@ fi
         'mkdir -p "$target/stage2/01-sys-tweaks"\n'
         f"cat <<'EOF' > \"$target/build.sh\"\n"
         "#!/bin/bash\n"
-        f"{compose_check}"
         "mkdir -p deploy\n"
         'cp config "$OUTPUT_DIR/config.env"\n'
         f"{image_cmd}"
@@ -349,10 +340,6 @@ def _run_build_script(tmp_path, env):
     ci_dir.mkdir(parents=True)
     user_src = repo_root / "scripts" / "cloud-init" / "user-data.yaml"
     shutil.copy(user_src, ci_dir / "user-data.yaml")
-    compose_src = (
-        repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
-    )
-    shutil.copy(compose_src, ci_dir / "docker-compose.cloudflared.yml")
 
     result = subprocess.run(
         ["/bin/bash", str(script)],
@@ -398,12 +385,6 @@ def test_handles_precompressed_pi_gen_output(tmp_path):
     assert result.returncode == 0
     assert (tmp_path / "sugarkube.img.xz").exists()
     assert not (tmp_path / "sugarkube.img.xz.xz").exists()
-
-
-def test_copies_cloudflared_compose(tmp_path):
-    env = _setup_build_env(tmp_path, check_compose=True)
-    result, _ = _run_build_script(tmp_path, env)
-    assert result.returncode == 0
 
 
 def test_arm64_disables_armhf(tmp_path):
@@ -462,14 +443,6 @@ def test_requires_cloud_init_file(tmp_path):
     result, _ = _run_build_script(tmp_path, env)
     assert result.returncode != 0
     assert "Cloud-init file not found" in result.stderr
-
-
-def test_requires_cloudflared_compose_file(tmp_path):
-    env = _setup_build_env(tmp_path)
-    env["CLOUDFLARED_COMPOSE_PATH"] = str(tmp_path / "missing.yml")
-    result, _ = _run_build_script(tmp_path, env)
-    assert result.returncode != 0
-    assert "Cloudflared compose file not found" in result.stderr
 
 
 def test_requires_stage_list(tmp_path):


### PR DESCRIPTION
## Summary
- embed docker-compose.cloudflared.yml via cloud-init
- remove build script dependency on stage2 compose copy
- document preinstalled tunnel compose file and update tests

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68bd19af6ba8832f866fa2b504e7f741