### PR TITLE
Enable fix-missing during Pi image builds

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -7,8 +7,8 @@ including [dspace](https://github.com/democratizedspace/dspace).
 It uses `cloud-init` to update and upgrade packages, bake Docker, the compose
 plugin, the Cloudflare apt repository, and a
 [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/)
-into the OS image. Cloud-init also drops an apt config with five retries and
-30-second timeouts to smooth over flaky networks.
+into the OS image. Cloud-init also drops an apt config with five retries,
+30-second timeouts, and `APT::Get::Fix-Missing` enabled to smooth over flaky networks.
 The `build_pi_image.sh` script clones [pi-gen](https://github.com/RPi-Distro/pi-gen) using
 `PI_GEN_BRANCH` (default: `bookworm` for 32-bit builds and `arm64` for
 64-bit). Set `PI_GEN_URL` to use a fork or mirror if the default repository is
@@ -18,7 +18,7 @@ accidental overwrites it aborts when the image already exists unless
 `FORCE_OVERWRITE=1` is set. Set `FORCE_OVERWRITE=1` when rerunning builds to
 replace an existing image. To reduce flaky downloads it pins the official
 Raspberry Pi and Debian mirrors, adds `APT_OPTS` (retries, timeouts,
-`--fix-missing`), and installs a persistent apt/dpkg Pre-Invoke hook that rewrites
+`-o APT::Get::Fix-Missing=true`), and installs a persistent apt/dpkg Pre-Invoke hook that rewrites
 any raspbian host to a stable HTTPS mirror and bypasses proxies for
 `archive.raspberrypi.com`. Set `SKIP_MIRROR_REWRITE=1` to disable these rewrites
 when your network already uses a reliable mirror. Use `APT_RETRIES` and

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -217,7 +217,8 @@ BUILD_TIMEOUT="${BUILD_TIMEOUT:-4h}"
 APT_RETRIES="${APT_RETRIES:-5}"
 APT_TIMEOUT="${APT_TIMEOUT:-30}"
 APT_OPTS="-o Acquire::Retries=${APT_RETRIES} -o Acquire::http::Timeout=${APT_TIMEOUT} \
--o Acquire::https::Timeout=${APT_TIMEOUT} -o Acquire::http::NoCache=true"
+-o Acquire::https::Timeout=${APT_TIMEOUT} -o Acquire::http::NoCache=true \
+-o APT::Get::Fix-Missing=true"
 APT_OPTS+=" -o APT::Install-Recommends=false -o APT::Install-Suggests=false"
 
 SKIP_MIRROR_REWRITE="${SKIP_MIRROR_REWRITE:-0}"

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -45,6 +45,7 @@ write_files:
       Acquire::Retries "5";
       Acquire::http::Timeout "30";
       Acquire::https::Timeout "30";
+      APT::Get::Fix-Missing "true";
 # tokenplace-start
   - path: /opt/projects/token.place/docker-compose.tokenplace.yml
     permissions: '0644'


### PR DESCRIPTION
## Summary
- enable `APT::Get::Fix-Missing=true` in build script and cloud-init
- document apt fix-missing and mirror options for Pi image guide

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `npm run lint` (fails: Could not read package.json)
- `npm run test:ci` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68bd19af6ba8832f866fa2b504e7f741