### PR TITLE
🔧 : add df requirement to image build

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -49,8 +49,9 @@ once the token is present and waits for `network-online.target` to ensure
 connectivity. The script curls the Debian, Raspberry Pi, and pi-gen repositories
 with a 10-second timeout before building; override this via the
 `URL_CHECK_TIMEOUT` environment variable. Ensure `curl`, `docker` (with its
-daemon running), `git`, `sha256sum`, `stdbuf`, `timeout`, and `xz` are installed
-before running it; `stdbuf` and `timeout` come from GNU coreutils. The script
+daemon running), `git`, `sha256sum`, `stdbuf`, `timeout`, `xz`, `bsdtar`, and `df`
+are installed before running it; `stdbuf` and `timeout` come from GNU coreutils.
+The script
 checks that both the temporary and output directories have at least 10 GB free
 before starting and verifies the resulting image exists and is non-empty before
 reporting success. Use the prepared image to deploy containerized apps. The

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -20,11 +20,11 @@ check_space() {
 }
 
 # Build a Raspberry Pi OS image with cloud-init files preloaded.
-# Requires curl, docker, git, sha256sum, stdbuf, timeout, xz, bsdtar and roughly
+# Requires curl, docker, git, sha256sum, stdbuf, timeout, xz, bsdtar, df and roughly
 # 10 GB of free disk space. Set PI_GEN_URL to override the default pi-gen
 # repository.
 
-for cmd in curl docker git sha256sum stdbuf timeout xz bsdtar; do
+for cmd in curl docker git sha256sum stdbuf timeout xz bsdtar df; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "$cmd is required" >&2
     exit 1


### PR DESCRIPTION
## Summary
- ensure build script checks for df
- document df and bsdtar prerequisites

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68bd19af6ba8832f866fa2b504e7f741