### PR TITLE
🛠️ : Add documentation note to power_ring schematic

### DIFF
--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -10,6 +10,7 @@
                 (comment 3 "Label polarity and voltage on connectors")
                 (comment 4 "Verify KiBot exports and BOM before fabrication")
                 (comment 5 "Check ground pour continuity around mounting holes")
+                (comment 6 "Document schematic updates in specs.md")
         )
         (lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/elex/power_ring/specs.md
+++ b/elex/power_ring/specs.md
@@ -19,7 +19,8 @@ The design may evolve as the project grows.
 - Test points for measuring battery voltage
 - Silkscreen labels for polarity and connector numbers
 - Title block comments record decoupling guidelines, high-current trace layout, connector
-  labeling, export checks, ground pour continuity around mounting holes, and BOM validation
+  labeling, export checks, ground pour continuity around mounting holes, BOM validation, and
+  documentation reminders
 
 These requirements are a starting point – modify the KiCad project as needed and
 update this file when the schematic changes.


### PR DESCRIPTION
what: add comment reminding to document schematic updates and sync specs
why: keep design notes in design files and docs aligned
how to test: open power_ring.kicad_sch and check title block comment 6
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bd19a3ac98832fafd0f9fce2003c0c