### PR TITLE
🔌: note star routing in power_ring

### DIFF
--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -10,6 +10,7 @@
                 (comment 3 "Label polarity and voltage on connectors")
                 (comment 4 "Verify KiBot exports and BOM before fabrication")
                 (comment 5 "Check ground pour continuity around mounting holes")
+                (comment 6 "Use star topology for power distribution")
         )
         (lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/elex/power_ring/specs.md
+++ b/elex/power_ring/specs.md
@@ -19,7 +19,8 @@ The design may evolve as the project grows.
 - Test points for measuring battery voltage
 - Silkscreen labels for polarity and connector numbers
 - Title block comments record decoupling guidelines, high-current trace layout, connector
-  labeling, export checks, ground pour continuity around mounting holes, and BOM validation
+  labeling, export checks, ground pour continuity around mounting holes, star topology for
+  power distribution, and BOM validation
 
 These requirements are a starting point – modify the KiCad project as needed and
 update this file when the schematic changes.

--- a/outages/2025-09-07-kicad-export-pcbnew-missing.json
+++ b/outages/2025-09-07-kicad-export-pcbnew-missing.json
@@ -1,0 +1,10 @@
+{
+  "id": "kicad-export-pcbnew-missing",
+  "date": "2025-09-07",
+  "component": "kicad-export",
+  "rootCause": "KiCad not installed; pcbnew Python module not found",
+  "resolution": "Install KiCad 9 and ensure pcbnew is available via PYTHONPATH",
+  "references": [
+    "kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml"
+  ]
+}


### PR DESCRIPTION
what: add star-topology note to schematic and specs
why: document power distribution practice; note KiCad export issue
how to test: pre-commit run --all-files; pyspelling; linkchecker; kibot (fails: pcbnew missing)
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68bd19a3ac98832fafd0f9fce2003c0c