### PR TITLE
🔌: note enclosure fit in power ring

### DIFF
--- a/elex/power_ring/power_ring.kicad_pcb
+++ b/elex/power_ring/power_ring.kicad_pcb
@@ -9,6 +9,7 @@
         (paper "A4")
         (title_block
                 (comment 1 "Keep high-current traces short")
+                (comment 2 "Confirm board outline fits enclosure")
         )
         (layers
                 (0 "F.Cu" signal)

--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -10,6 +10,7 @@
                 (comment 3 "Label polarity and voltage on connectors")
                 (comment 4 "Verify KiBot exports and BOM before fabrication")
                 (comment 5 "Check ground pour continuity around mounting holes")
+                (comment 6 "Confirm board outline fits enclosure")
         )
         (lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/elex/power_ring/specs.md
+++ b/elex/power_ring/specs.md
@@ -19,7 +19,7 @@ The design may evolve as the project grows.
 - Test points for measuring battery voltage
 - Silkscreen labels for polarity and connector numbers
 - Title block comments record decoupling guidelines, high-current trace layout, connector
-  labeling, export checks, ground pour continuity around mounting holes, and BOM validation
+  labeling, export checks, ground pour continuity around mounting holes, board outline fit, and BOM validation
 
 These requirements are a starting point – modify the KiCad project as needed and
 update this file when the schematic changes.


### PR DESCRIPTION
## Summary
- note enclosure clearance in power ring schematic and PCB
- document board outline fit reminder

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml # Failed: Failed to import pcbnew Python module. Is KiCad installed?


------
https://chatgpt.com/codex/tasks/task_e_68bd19a3ac98832fafd0f9fce2003c0c