### PR TITLE
🔌: document connector polarity in power_ring

### DIFF
--- a/elex/power_ring/power_ring.kicad_pcb
+++ b/elex/power_ring/power_ring.kicad_pcb
@@ -7,9 +7,10 @@
 		(legacy_teardrops no)
 	)
         (paper "A4")
-        (title_block
-                (comment 1 "Keep high-current traces short")
-        )
+       (title_block
+               (comment 1 "Keep high-current traces short")
+               (comment 2 "Label polarity and voltage on connectors")
+       )
         (layers
                 (0 "F.Cu" signal)
 		(2 "B.Cu" signal)

--- a/elex/power_ring/specs.md
+++ b/elex/power_ring/specs.md
@@ -18,6 +18,7 @@ The design may evolve as the project grows.
 
 - Test points for measuring battery voltage
 - Silkscreen labels for polarity and connector numbers
+- KiCad title block notes remind labeling connector polarity and voltage
 - Title block comments record decoupling guidelines, high-current trace layout, connector
   labeling, export checks, ground pour continuity around mounting holes, and BOM validation
 

--- a/outages/2025-09-07-kicad-export-pcbnew-missing.json
+++ b/outages/2025-09-07-kicad-export-pcbnew-missing.json
@@ -1,0 +1,8 @@
+{
+  "id": "2025-09-07-kicad-export-pcbnew-missing",
+  "date": "2025-09-07",
+  "component": "kicad-export",
+  "rootCause": "KiBot failed to import pcbnew; installed KiCad lacks Python module or version >=9",
+  "resolution": "Install KiCad 9 with pcbnew Python bindings and rerun KiBot",
+  "references": ["https://github.com/INTI-CMNB/KiBot", "https://docs.kicad.org/9.0/en/pcbnew/pcbnew.html"]
+}


### PR DESCRIPTION
## Summary
- note connector polarity in power_ring PCB title block
- mention polarity note in specs
- record pcbnew module outage for KiBot

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml` *(fails: pcbnew module missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd19a3ac98832fafd0f9fce2003c0c