### PR TITLE
📝 : clarify Mac mini station build path

### DIFF
--- a/docs/mac_mini_station.md
+++ b/docs/mac_mini_station.md
@@ -1,17 +1,24 @@
 # Mac mini station
 
-Press-fit saddle cap extension for the Mac mini M4 keyboard station. The cap slides over the existing top saddle and widens the keyboard tray so a Magic Keyboard or TKL board will not tip off when bumped.
+Press-fit saddle cap extension for the Mac mini M4 keyboard station.
+The cap slides over the existing top saddle and widens the keyboard tray so a Magic Keyboard
+or TKL board will not tip off when bumped.
 
 ## Usage
 
 1. Pick a keyboard width preset in `hardware/mac-mini-station/scad/mac_mini_station.scad`.
-2. Run `scripts/build.sh` to export STL files.
+2. Run `hardware/mac-mini-station/scripts/build.sh` from the repository root to export STL files
+   into `hardware/mac-mini-station/stl/`.
 3. Print the cap upside down without supports.
 4. Start with `press_fit_clearance_mm = 0.35` and adjust after a test fit.
 
 ## Attribution
 
-Inspired by [Magic Tray – Holder for Apple's Magic Keyboard and Trackpad](https://archive.org/details/thingiverse-4910431) (Thingiverse 4910431) by reddit user **CaptainDarwin**, licensed under CC BY-NC-SA 4.0. This repository links to the original design and does not redistribute their files.
+Inspired by [Magic Tray – Holder for Apple's Magic Keyboard and Trackpad][magic-tray]
+(Thingiverse 4910431) by reddit user **CaptainDarwin**, licensed under CC BY-NC-SA 4.0.
+This repository links to the original design and does not redistribute their files.
+
+[magic-tray]: https://archive.org/details/thingiverse-4910431
 
 ## License
 


### PR DESCRIPTION
what: clarify STL export steps in mac mini station doc
why: make build script path and output folder explicit
how: pre-commit run --all-files
how: pyspelling -c .spellcheck.yaml
how: linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68bd1991ea38832f8e8eda1fa1eb1363