### PR TITLE
docs: add token.place+dspace compose example

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -37,6 +37,36 @@ docker compose up -d
 curl http://localhost:3000
 ```
 
+### token.place and dspace together
+
+Spin up both projects with a single `docker-compose.yml` to verify the Pi can
+run multiple apps:
+
+```sh
+ssh pi@<hostname>.local
+cd /opt/projects
+git clone https://github.com/futuroptimist/token.place
+git clone https://github.com/democratizedspace/dspace
+cat <<'EOF' > docker-compose.yml
+services:
+  tokenplace:
+    build:
+      context: ./token.place
+      dockerfile: docker/Dockerfile.server
+    ports:
+      - "5000:5000"
+  dspace:
+    build:
+      context: ./dspace/frontend
+    ports:
+      - "3000:3000"
+EOF
+docker compose up -d
+curl http://localhost:5000
+curl http://localhost:3000
+docker compose down
+```
+
 Proceed with the detailed steps below to adapt the process for other repositories.
 
 ## 1. Prepare the Pi


### PR DESCRIPTION
## Summary
- add quick-start compose example to run token.place and dspace together on the Pi image

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd198898b0832fafae505b5e9fd57c