### PR TITLE
🔧 fix checks script dependency detection

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Ensure required Python tooling is available
-if ! command -v flake8 >/dev/null 2>&1; then
+# Ensure required Python tooling is available.  Some environments may have
+# `flake8` pre-installed but lack other dependencies like `pyspelling` or
+# `linkchecker`, which are needed later in this script.  Install the full set
+# whenever any of these tools are missing.
+if ! command -v flake8 >/dev/null 2>&1 || \
+   ! command -v pyspelling >/dev/null 2>&1 || \
+   ! command -v linkchecker >/dev/null 2>&1; then
   if command -v uv >/dev/null 2>&1; then
     uv pip install --system \
       flake8 isort black pytest pytest-cov coverage pyspelling linkchecker \


### PR DESCRIPTION
## Summary
- ensure docs tooling installs when pyspelling or linkchecker missing

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd197acc88832f813624b65ee5cd05