### PR TITLE
🔧 : enforce docs link checking

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,4 +26,4 @@ jobs:
           python-version: '3.x'
       - run: |
           uv pip install --system linkchecker
-          linkchecker README.md docs/ || true
+          linkchecker --no-warnings README.md docs/


### PR DESCRIPTION
## Summary
- ensure docs job runs linkchecker with `--no-warnings`
- drop `|| true` so broken links fail CI

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68bd197acc88832f813624b65ee5cd05