### PR TITLE
🧪 : install bats automatically in checks script

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -50,6 +50,22 @@ if command -v pytest >/dev/null 2>&1; then
 fi
 
 # run bats tests when available
+if ! command -v bats >/dev/null 2>&1; then
+  if command -v apt-get >/dev/null 2>&1; then
+    SUDO=""
+    if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
+      SUDO="sudo"
+    fi
+    if $SUDO apt-get update >/dev/null 2>&1 && \
+      $SUDO apt-get install -y bats >/dev/null 2>&1; then
+      :
+    else
+      echo "bats install failed; skipping" >&2
+    fi
+  elif command -v brew >/dev/null 2>&1; then
+    brew install bats >/dev/null 2>&1 || true
+  fi
+fi
 if command -v bats >/dev/null 2>&1 && ls tests/*.bats >/dev/null 2>&1; then
   bats tests/*.bats
 else


### PR DESCRIPTION
## Summary
- install bats when missing so shell tests always run
- skip bats install on permission errors instead of aborting checks

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `bats tests/*.bats`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bd197acc88832f813624b65ee5cd05