### PR TITLE
Enable token.place and dspace services via compose

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -29,9 +29,9 @@ user.
 ## Run the apps
 
 On first boot the Pi builds the containers defined in
-`/opt/projects/docker-compose.yml`. The `projects-compose.service` unit starts the
-stack automatically when the compose file exists. Manage the services with
-`systemctl`:
+`/opt/projects/docker-compose.yml`. The `start-projects.sh` helper enables the
+`projects-compose.service` unit which starts the stack automatically. Manage the
+services with `systemctl`:
 
 ```sh
 # check service status
@@ -48,9 +48,9 @@ dspace. To expose them through a Cloudflare Tunnel, update
 
 ### Environment variables
 
-Each project reads an `.env` file in its directory. On first boot the system
-copies `*.env.example` to `.env` when present so the compose stack starts with
-defaults:
+Each project reads an `.env` file in its directory. The `init-env.sh` script runs
+before the compose stack and copies `*.env.example` to `.env` when present so the
+containers start with defaults:
 
 - `/opt/projects/token.place/.env`
 - `/opt/projects/dspace/frontend/.env`
@@ -60,9 +60,10 @@ Edit these files with real values and restart the service.
 ## Extend with new repositories
 
 Pass Git URLs via `EXTRA_REPOS` to clone additional projects into
-`/opt/projects`. Add services to `/opt/projects/docker-compose.yml` following the
-token.place and dspace examples. The image builder drops the token.place or
-dspace definitions when the corresponding `CLONE_*` flag is `false`, letting you
-build a minimal image and expand it later.
+`/opt/projects`. Add services to `/opt/projects/docker-compose.yml` and extend
+`init-env.sh` with any new `.env` files, following the token.place and dspace
+examples. The image builder drops the token.place or dspace definitions when the
+corresponding `CLONE_*` flag is `false`, letting you build a minimal image and
+expand it later.
 
 Use these hooks to experiment with other projects and grow the image over time.

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -71,6 +71,8 @@ CLOUD_INIT_DIR="${CLOUD_INIT_DIR:-${REPO_ROOT}/scripts/cloud-init}"
 CLOUD_INIT_PATH="${CLOUD_INIT_PATH:-${CLOUD_INIT_DIR}/user-data.yaml}"
 CLOUDFLARED_COMPOSE_PATH="${CLOUDFLARED_COMPOSE_PATH:-${CLOUD_INIT_DIR}/docker-compose.cloudflared.yml}"
 PROJECTS_COMPOSE_PATH="${PROJECTS_COMPOSE_PATH:-${CLOUD_INIT_DIR}/docker-compose.projects.yml}"
+START_PROJECTS_PATH="${START_PROJECTS_PATH:-${CLOUD_INIT_DIR}/start-projects.sh}"
+INIT_ENV_PATH="${INIT_ENV_PATH:-${CLOUD_INIT_DIR}/init-env.sh}"
 
 if [ ! -f "${CLOUD_INIT_PATH}" ]; then
   echo "Cloud-init file not found: ${CLOUD_INIT_PATH}" >&2
@@ -99,6 +101,14 @@ if [ ! -f "${PROJECTS_COMPOSE_PATH}" ]; then
 fi
 if [ ! -s "${PROJECTS_COMPOSE_PATH}" ]; then
   echo "Projects compose file is empty: ${PROJECTS_COMPOSE_PATH}" >&2
+  exit 1
+fi
+if [ ! -f "${START_PROJECTS_PATH}" ]; then
+  echo "Start projects script not found: ${START_PROJECTS_PATH}" >&2
+  exit 1
+fi
+if [ ! -f "${INIT_ENV_PATH}" ]; then
+  echo "Init env script not found: ${INIT_ENV_PATH}" >&2
   exit 1
 fi
 
@@ -204,6 +214,10 @@ if [[ "$CLONE_TOKEN_PLACE" != "true" && "$CLONE_DSPACE" != "true" && -z "$EXTRA_
 else
   install -Dm644 "${PROJECTS_COMPOSE_TEMP}" \
     "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/projects/docker-compose.yml"
+  install -Dm755 "${START_PROJECTS_PATH}" \
+    "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/projects/start-projects.sh"
+  install -Dm755 "${INIT_ENV_PATH}" \
+    "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/projects/init-env.sh"
 fi
 
 run_sh="${WORK_DIR}/pi-gen/stage2/02-sugarkube-tools/00-run-chroot.sh"

--- a/scripts/cloud-init/init-env.sh
+++ b/scripts/cloud-init/init-env.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# tokenplace-start
+if [ -d token.place ] && [ -f token.place/.env.example ] && [ ! -f token.place/.env ]; then
+  cp token.place/.env.example token.place/.env
+fi
+# tokenplace-end
+
+# dspace-start
+if [ -d dspace/frontend ] && [ -f dspace/frontend/.env.example ] && [ ! -f dspace/frontend/.env ]; then
+  cp dspace/frontend/.env.example dspace/frontend/.env
+fi
+# dspace-end
+
+# extra-start
+# Add additional environment setup steps below
+# extra-end

--- a/scripts/cloud-init/start-projects.sh
+++ b/scripts/cloud-init/start-projects.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+svc="projects-compose.service"
+if systemctl list-unit-files | grep -q "^${svc}"; then
+  systemctl enable --now "${svc}"
+else
+  echo "${svc} not found; skipping" >&2
+fi

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -415,9 +415,13 @@ def _run_build_script(tmp_path, env):
     user_src = repo_root / "scripts" / "cloud-init" / "user-data.yaml"
     shutil.copy(user_src, ci_dir / "user-data.yaml")
 
-    compose_src = repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
+    compose_src = repo_root.joinpath(
+        "scripts", "cloud-init", "docker-compose.cloudflared.yml"
+    )
     shutil.copy(compose_src, ci_dir / "docker-compose.cloudflared.yml")
-    projects_src = repo_root / "scripts" / "cloud-init" / "docker-compose.projects.yml"
+    projects_src = repo_root.joinpath(
+        "scripts", "cloud-init", "docker-compose.projects.yml"
+    )
     shutil.copy(projects_src, ci_dir / "docker-compose.projects.yml")
 
     result = subprocess.run(


### PR DESCRIPTION
what: add docker-compose hooks to run token.place and dspace on Pi images
why: ensure projects launch as services with room for future repos
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68be3f1b0de0832f8cd595ce689873a2