### PR TITLE
📝 : note sshd reload and align lint to 100 cols

### DIFF
--- a/docs/network_setup.md
+++ b/docs/network_setup.md
@@ -31,7 +31,8 @@ It assumes you are using Raspberry Pi 5 boards in a small k3s setup.
 12. Harden SSH by disabling password authentication once key-based logins work:
     ```sh
     sudo sed -i 's/^#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
-    sudo systemctl reload ssh
+    # Reload the SSH service; some distros use "sshd"
+    sudo systemctl reload ssh || sudo systemctl reload sshd
     ```
 
 ## Switch and PoE

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -23,9 +23,9 @@ if ! command -v flake8 >/dev/null 2>&1 || \
 fi
 
 # python checks
-flake8 . --exclude=.venv
+flake8 . --exclude=.venv --max-line-length=100
 isort --check-only . --skip .venv
-black --check . --exclude ".venv/"
+black --check . --line-length=100 --exclude ".venv/"
 
 # js checks
 if [ -f package.json ]; then


### PR DESCRIPTION
## Summary
- document sshd as alternate service name when reloading SSH
- ensure flake8 and black use 100-column line length

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68be3f6a76d8832f8dce9ed09d956564