### PR TITLE
Ignore scan-secrets path variations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ pre-commit install
 pre-commit run --all-files
 git diff --cached | ./scripts/scan-secrets.py
 ```
+`scan-secrets.py` skips scanning itself even if diff paths omit the `b/` prefix.
 
 - If `README.md` or files under `docs/` change, also run:
 

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -15,7 +15,7 @@ import sys
 import tempfile
 from typing import Iterable
 
-SCAN_SCRIPT_PATH = "b/scripts/scan-secrets.py"
+SCAN_SCRIPT_PATH = "scripts/scan-secrets.py"
 
 PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"aws(.{0,20})?(?:secret|access)_key", re.IGNORECASE),
@@ -58,7 +58,9 @@ def regex_scan(lines: Iterable[str]) -> bool:
         if line.startswith("+++"):
             file_path = line[4:].strip()
             continue
-        if not line.startswith("+") or file_path == SCAN_SCRIPT_PATH:
+        if not line.startswith("+"):
+            continue
+        if file_path and file_path.endswith(SCAN_SCRIPT_PATH):
             continue
         for pattern in PATTERNS:
             if pattern.search(line):

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -415,7 +415,9 @@ def _run_build_script(tmp_path, env):
     user_src = repo_root / "scripts" / "cloud-init" / "user-data.yaml"
     shutil.copy(user_src, ci_dir / "user-data.yaml")
 
-    compose_src = repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
+    compose_src = (
+        repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
+    )
     shutil.copy(compose_src, ci_dir / "docker-compose.cloudflared.yml")
     projects_src = repo_root / "scripts" / "cloud-init" / "docker-compose.projects.yml"
     shutil.copy(projects_src, ci_dir / "docker-compose.projects.yml")

--- a/tests/scan_secrets_test.py
+++ b/tests/scan_secrets_test.py
@@ -31,6 +31,11 @@ def test_regex_scan_ignores_self(scan_secrets):
     assert not scan_secrets.regex_scan(diff)
 
 
+def test_regex_scan_ignores_self_without_prefix(scan_secrets):
+    diff = ["+++ scripts/scan-secrets.py", "+token" ": abc"]
+    assert not scan_secrets.regex_scan(diff)
+
+
 def test_regex_scan_ignores_removed_lines(scan_secrets):
     diff = ["+++ b/file.txt", "-pass" "word=abc"]
     assert not scan_secrets.regex_scan(diff)


### PR DESCRIPTION
## Summary
- avoid false positives when scan-secrets.py is diffed without the `b/` prefix
- document secret scan self-skip and add flake8 config

## Testing
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68be3f6a76d8832f8dce9ed09d956564