### PR TITLE
Add test for missing Pi image artifacts

### DIFF
--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -415,10 +415,17 @@ def _run_build_script(tmp_path, env):
     user_src = repo_root / "scripts" / "cloud-init" / "user-data.yaml"
     shutil.copy(user_src, ci_dir / "user-data.yaml")
 
-    compose_src = repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
-    shutil.copy(compose_src, ci_dir / "docker-compose.cloudflared.yml")
-    projects_src = repo_root / "scripts" / "cloud-init" / "docker-compose.projects.yml"
-    shutil.copy(projects_src, ci_dir / "docker-compose.projects.yml")
+    cloud_init_src = repo_root / "scripts" / "cloud-init"
+    compose_src = cloud_init_src / "docker-compose.cloudflared.yml"
+    shutil.copy(
+        compose_src,
+        ci_dir / "docker-compose.cloudflared.yml",
+    )
+    projects_src = cloud_init_src / "docker-compose.projects.yml"
+    shutil.copy(
+        projects_src,
+        ci_dir / "docker-compose.projects.yml",
+    )
 
     result = subprocess.run(
         ["/bin/bash", str(script)],

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -102,3 +102,14 @@ def test_handles_img_xz(tmp_path):
     assert out_img.exists()
     assert (out_img.with_suffix(out_img.suffix + ".sha256")).exists()
     assert out_img.read_text() == "original"
+
+
+def test_errors_when_no_image_found(tmp_path):
+    deploy = tmp_path / "deploy"
+    deploy.mkdir()
+    (deploy / "note.txt").write_text("no artifact")
+
+    out_img = tmp_path / "out.img.xz"
+    result = _run_script(tmp_path, deploy, out_img)
+    assert result.returncode != 0
+    assert "No image file found" in result.stderr


### PR DESCRIPTION
## Summary
- add regression test covering collect_pi_image.sh when no image is present
- refactor build_pi_image_test path setup to satisfy lint

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68be3f4c24bc832f8769d9b6414e98e9