### PR TITLE
✅ : strengthen secret scan tests

### DIFF
--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -415,9 +415,10 @@ def _run_build_script(tmp_path, env):
     user_src = repo_root / "scripts" / "cloud-init" / "user-data.yaml"
     shutil.copy(user_src, ci_dir / "user-data.yaml")
 
-    compose_src = repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
+    ci_src = repo_root / "scripts" / "cloud-init"
+    compose_src = ci_src / "docker-compose.cloudflared.yml"
     shutil.copy(compose_src, ci_dir / "docker-compose.cloudflared.yml")
-    projects_src = repo_root / "scripts" / "cloud-init" / "docker-compose.projects.yml"
+    projects_src = ci_src / "docker-compose.projects.yml"
     shutil.copy(projects_src, ci_dir / "docker-compose.projects.yml")
 
     result = subprocess.run(

--- a/tests/scan_secrets_test.py
+++ b/tests/scan_secrets_test.py
@@ -26,6 +26,13 @@ def test_regex_scan_detects_patterns(scan_secrets, line):
     assert scan_secrets.regex_scan(diff)
 
 
+def test_regex_scan_prints_warning(scan_secrets, capsys):
+    diff = ["+++ b/file.txt", "+token" ": abc"]
+    assert scan_secrets.regex_scan(diff)
+    captured = capsys.readouterr()
+    assert "Possible secret: +tok" "en: abc" in captured.out
+
+
 def test_regex_scan_ignores_self(scan_secrets):
     diff = ["+++ b/scripts/scan-secrets.py", "+api" "_key=123"]
     assert not scan_secrets.regex_scan(diff)


### PR DESCRIPTION
## Summary
- add regression test confirming scan-secrets emits warning
- shorten path lines in build_pi_image_test to satisfy flake8

## Testing
- `pre-commit run --all-files`
- `git diff --cached | ./scripts/scan-secrets.py`
- `npm run lint` *(fails: could not find package.json)*
- `npm run test:ci` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be3f4c24bc832f8769d9b6414e98e9