### PR TITLE
Add test for missing PI image artifact

### DIFF
--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -415,9 +415,12 @@ def _run_build_script(tmp_path, env):
     user_src = repo_root / "scripts" / "cloud-init" / "user-data.yaml"
     shutil.copy(user_src, ci_dir / "user-data.yaml")
 
-    compose_src = repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
+    compose_src = (
+        repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
+    )
     shutil.copy(compose_src, ci_dir / "docker-compose.cloudflared.yml")
-    projects_src = repo_root / "scripts" / "cloud-init" / "docker-compose.projects.yml"
+    projects_src = repo_root / "scripts" / "cloud-init"
+    projects_src /= "docker-compose.projects.yml"
     shutil.copy(projects_src, ci_dir / "docker-compose.projects.yml")
 
     result = subprocess.run(

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -75,6 +75,17 @@ def test_errors_on_zip_without_img(tmp_path):
     assert "Zip contained no .img" in result.stderr
 
 
+def test_errors_when_no_image_found(tmp_path):
+    deploy = tmp_path / "deploy"
+    deploy.mkdir()
+    (deploy / "foo.txt").write_text("data")
+
+    out_img = tmp_path / "out.img.xz"
+    result = _run_script(tmp_path, deploy, out_img)
+    assert result.returncode != 0
+    assert "No image file found" in result.stderr
+
+
 def test_handles_raw_img(tmp_path):
     deploy = tmp_path / "deploy"
     deploy.mkdir()


### PR DESCRIPTION
## Summary
- add test ensuring collect_pi_image.sh errors when no image artifact exists
- tweak build_pi_image_test to satisfy flake8 line length

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68be3f4c24bc832f8769d9b6414e98e9