### PR TITLE
📝 : refresh CAD prompt instructions

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -41,10 +41,10 @@ CONTEXT:
 REQUEST:
 1. Inspect `cad/*.scad` for todo comments or needed adjustments.
 2. Modify geometry or parameters as required.
-3. Render the model via:
-
+3. Render the model via (use `~~~` fences inside this prompt to avoid breaking the outer
+   code block):
    ~~~bash
-   ./scripts/openscad_render.sh path/to/model.scad  # uses default standoff_mode (heatse
+   ./scripts/openscad_render.sh path/to/model.scad  # uses default standoff_mode (heatset)
    STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad  # case-insensitive
    STANDOFF_MODE=nut ./scripts/openscad_render.sh path/to/model.scad
    ~~~

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -415,9 +415,13 @@ def _run_build_script(tmp_path, env):
     user_src = repo_root / "scripts" / "cloud-init" / "user-data.yaml"
     shutil.copy(user_src, ci_dir / "user-data.yaml")
 
-    compose_src = repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
+    compose_src = (
+        repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
+    )  # noqa: E501
     shutil.copy(compose_src, ci_dir / "docker-compose.cloudflared.yml")
-    projects_src = repo_root / "scripts" / "cloud-init" / "docker-compose.projects.yml"
+    projects_src = (
+        repo_root / "scripts" / "cloud-init" / "docker-compose.projects.yml"
+    )  # noqa: E501
     shutil.copy(projects_src, ci_dir / "docker-compose.projects.yml")
 
     result = subprocess.run(


### PR DESCRIPTION
what: clarify OpenSCAD render steps and fix test lint warnings
why: keep CAD prompt current and maintain passing pre-commit
how to test: pre-commit run --all-files
how to test: pyspelling -c .spellcheck.yaml
how to test: linkchecker --no-warnings README.md docs/

------
https://chatgpt.com/codex/tasks/task_e_68be3ed83028832faa72ec70ff3af534