### PR TITLE
Align lint config with 100-char limit and fix README grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An accessible [k3s](https://k3s.io/) platform for Raspberry Pis and SBCs,
 integrated with an off-grid solar setup.
 The repository also covers the solar cube art installation, which powers aquarium air pumps and
 small computers. It doubles as a living trellis—climbing plants weave through the aluminium
-extrusions while shade-loving herbs thrive beneath the panels. Hanging baskets can clip onto the
+extrusions, while shade-loving herbs thrive beneath the panels. Hanging baskets can clip onto the
 frame so the installation is surrounded by greenery.
 
 ### What's in a name?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+exclude = .venv


### PR DESCRIPTION
## Summary
- configure flake8 and black to respect 100 char line length
- insert missing comma in README

## Testing
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `pre-commit run --all-files`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68be3f2263b0832f94d766ac8ac5dd13