### PR TITLE
📝 docs: clarify test prompt references

### DIFF
--- a/docs/prompts-codex-tests.md
+++ b/docs/prompts-codex-tests.md
@@ -15,9 +15,10 @@ PURPOSE:
 Improve and maintain test coverage.
 
 CONTEXT:
-- Tests live in [`tests/`](../tests/) and include Python suites run with
-  [pytest](https://docs.pytest.org/en/latest/) and shell tests written in
-  [Bats](https://bats-core.readthedocs.io/en/latest/).
+- Tests live in [`tests/`](../tests/). Python suites run with
+  [pytest](https://docs.pytest.org/en/stable/) and shell checks use
+  [Bats](https://bats-core.readthedocs.io/en/stable/).
+- For quick iteration, invoke `pytest tests/` or `bats tests/*.bats` directly.
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository
   conventions.
 - Run `pre-commit run --all-files`; it invokes

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -412,12 +412,13 @@ def _run_build_script(tmp_path, env):
 
     ci_dir = script_dir / "cloud-init"
     ci_dir.mkdir(parents=True)
-    user_src = repo_root / "scripts" / "cloud-init" / "user-data.yaml"
+    src_ci_dir = repo_root / "scripts" / "cloud-init"
+    user_src = src_ci_dir / "user-data.yaml"
     shutil.copy(user_src, ci_dir / "user-data.yaml")
 
-    compose_src = repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
+    compose_src = src_ci_dir / "docker-compose.cloudflared.yml"
     shutil.copy(compose_src, ci_dir / "docker-compose.cloudflared.yml")
-    projects_src = repo_root / "scripts" / "cloud-init" / "docker-compose.projects.yml"
+    projects_src = src_ci_dir / "docker-compose.projects.yml"
     shutil.copy(projects_src, ci_dir / "docker-compose.projects.yml")
 
     result = subprocess.run(


### PR DESCRIPTION
## What
- modernize links in tests prompt and add quick-run tips
- trim long paths in build_pi_image_test to satisfy linter

## Why
- keep guidance current
- ensure pre-commit checks succeed

## How to Test
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68be3f1ee340832f84409950356380e3