### PR TITLE
📝 : clarify codex prompt instructions

### DIFF
--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -16,15 +16,17 @@ PURPOSE:
 Keep the project healthy by making small, well-tested improvements.
 
 CONTEXT:
-- Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
-- Run `pre-commit run --all-files` to lint, format, and test the repository via
-  [`scripts/checks.sh`](../scripts/checks.sh), which installs required tooling
-  and runs code and docs checks.
-- If `package.json` defines them, also run:
+- Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md); for
+  instruction semantics see the [AGENTS.md spec](https://agentsmd.net/).
+- Run `pre-commit run --all-files`, which executes
+  [`scripts/checks.sh`](../scripts/checks.sh) to install tooling and run
+  linters, tests, and documentation checks.
+- If a Node toolchain is present (`package.json` exists), also run:
+  - `npm ci`
   - `npm run lint`
   - `npm run test:ci`
-- If documentation files (`README.md` or [`docs/`](../docs/)) change, also run:
+- When documentation files (`README.md` or anything under
+  [`docs/`](../docs/)) change, additionally run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`
 - Scan staged changes for secrets with
@@ -50,11 +52,12 @@ Use this prompt to refine sugarkube's own prompt documentation.
 ```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
-Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md); see the
-[AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md); for
+instruction semantics see the [AGENTS.md spec](https://agentsmd.net/).
 Run `pre-commit run --all-files` (invokes
-[`scripts/checks.sh`](../scripts/checks.sh)). If `package.json` defines them,
-also run:
+[`scripts/checks.sh`](../scripts/checks.sh) to install tooling and run linters
+and tests). If a Node toolchain is present (`package.json` exists), also run:
+- `npm ci`
 - `npm run lint`
 - `npm run test:ci`
 Then run:

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -412,12 +412,13 @@ def _run_build_script(tmp_path, env):
 
     ci_dir = script_dir / "cloud-init"
     ci_dir.mkdir(parents=True)
-    user_src = repo_root / "scripts" / "cloud-init" / "user-data.yaml"
+    cloud_init_dir = repo_root / "scripts" / "cloud-init"
+    user_src = cloud_init_dir / "user-data.yaml"
     shutil.copy(user_src, ci_dir / "user-data.yaml")
 
-    compose_src = repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
+    compose_src = cloud_init_dir / "docker-compose.cloudflared.yml"
     shutil.copy(compose_src, ci_dir / "docker-compose.cloudflared.yml")
-    projects_src = repo_root / "scripts" / "cloud-init" / "docker-compose.projects.yml"
+    projects_src = cloud_init_dir / "docker-compose.projects.yml"
     shutil.copy(projects_src, ci_dir / "docker-compose.projects.yml")
 
     result = subprocess.run(


### PR DESCRIPTION
## Summary
- clarify Codex prompt with updated AGENTS.md spec link, npm guidance, and doc checks
- factor out `cloud_init_dir` in tests to satisfy lint

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68be3f1ee340832f84409950356380e3