### PR TITLE
📝 clarify Pi token & dspace prompt

### DIFF
--- a/docs/prompts-codex-pi-token-dspace.md
+++ b/docs/prompts-codex-pi-token-dspace.md
@@ -24,9 +24,12 @@ CONTEXT:
   guidelines.
 - Raspberry Pi OS build script: [`scripts/build_pi_image.sh`](../scripts/build_pi_image.sh)
   (targets Raspberry Pi OS Bookworm 64‑bit).
-- Docker Engine setup: follow [Docker's Debian install guide](https://docs.docker.com/engine/install/debian/)
-  for ARM devices.
-- First-boot cloud-init configs: [`scripts/cloud-init/`](../scripts/cloud-init/).
+- Docker Engine and Compose plugin: install via Docker's Debian guide for ARM devices
+  ([Engine](https://docs.docker.com/engine/install/debian/) and
+  [Compose](https://docs.docker.com/compose/install/linux/)).
+- First-boot cloud-init configs and Compose manifests:
+  [`scripts/cloud-init/`](../scripts/cloud-init/) (for example,
+  [`docker-compose.projects.yml`](../scripts/cloud-init/docker-compose.projects.yml)).
 - Upstream apps:
   - [token.place](https://github.com/futuroptimist/token.place) — see its
     [README](https://github.com/futuroptimist/token.place#readme) for service details.
@@ -42,7 +45,7 @@ CONTEXT:
 
 REQUEST:
 1. Add or refine scripts and docs so `token.place` and `dspace` run as services on the Pi
-   image via `docker-compose.yml`.
+   image via `docker compose` and a shared `docker-compose.yml`.
 2. Document the setup steps under `docs/`, including environment variables and how to extend
    the image for new repositories.
 3. Keep hooks for adding other repositories later.

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -415,9 +415,13 @@ def _run_build_script(tmp_path, env):
     user_src = repo_root / "scripts" / "cloud-init" / "user-data.yaml"
     shutil.copy(user_src, ci_dir / "user-data.yaml")
 
-    compose_src = repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
+    compose_src = (
+        repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
+    )
     shutil.copy(compose_src, ci_dir / "docker-compose.cloudflared.yml")
-    projects_src = repo_root / "scripts" / "cloud-init" / "docker-compose.projects.yml"
+    projects_src = (repo_root / "scripts" / "cloud-init").joinpath(
+        "docker-compose.projects.yml"
+    )
     shutil.copy(projects_src, ci_dir / "docker-compose.projects.yml")
 
     result = subprocess.run(


### PR DESCRIPTION
## Summary
- clarify Docker Engine + Compose setup in Pi token.place & dspace prompt
- link to cloud-init compose manifests and use `docker compose` in instructions
- wrap long test paths to satisfy flake8 line-length

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68be3f1ee340832f84409950356380e3