### PR TITLE
docs: mention helper script for printed threads

### DIFF
--- a/docs/insert_basics.md
+++ b/docs/insert_basics.md
@@ -23,8 +23,11 @@ Heat‑set inserts are knurled brass cylinders that melt into a printed hole. On
 You can skip inserts by printing internal threads. The provided OpenSCAD model supports a `standoff_mode` of `"printed"` which generates an M2.5 thread using a simple helix.
 
 ```bash
-openscad -D standoff_mode="printed" -o triple_printed.stl cad/pi_cluster/pi5_triple_carrier_rot45.scad
+STANDOFF_MODE=printed bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad
 ```
+
+The helper script validates `STANDOFF_MODE` and writes the STL to
+`stl/pi5_triple_carrier_rot45_printed.stl`.
 
 Printed threads work best with a fine nozzle (0.4 mm or smaller) and four or more perimeters around each standoff. Thread the screw gently the first time to clear any leftover plastic.
 

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -415,9 +415,10 @@ def _run_build_script(tmp_path, env):
     user_src = repo_root / "scripts" / "cloud-init" / "user-data.yaml"
     shutil.copy(user_src, ci_dir / "user-data.yaml")
 
-    compose_src = repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
+    scripts_ci_dir = repo_root / "scripts" / "cloud-init"
+    compose_src = scripts_ci_dir / "docker-compose.cloudflared.yml"
     shutil.copy(compose_src, ci_dir / "docker-compose.cloudflared.yml")
-    projects_src = repo_root / "scripts" / "cloud-init" / "docker-compose.projects.yml"
+    projects_src = scripts_ci_dir / "docker-compose.projects.yml"
     shutil.copy(projects_src, ci_dir / "docker-compose.projects.yml")
 
     result = subprocess.run(


### PR DESCRIPTION
## Summary
- document STANDOFF_MODE workflow with openscad_render.sh
- wrap long paths in build_pi_image_test.py to satisfy flake8

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68be3ef56590832fb5260e5b921bbbea