### PR TITLE
📝: document outage catalog validation

### DIFF
--- a/docs/outage_catalog.md
+++ b/docs/outage_catalog.md
@@ -4,12 +4,18 @@ Structured archive of past outages. Each outage is stored as a JSON file using t
 
 File naming: `YYYY-MM-DD-<slug>.json`.
 
-Required fields:
+Populate each file with these fields:
 - `id`: unique identifier
 - `date`: ISO date
 - `component`: affected subsystem
 - `rootCause`: brief description of failure cause
 - `resolution`: how it was fixed
 - `references`: array of related links (PRs, issues, docs)
+
+Validate new entries against the schema before committing:
+
+```sh
+python -m jsonschema -i outages/<file>.json outages/schema.json
+```
 
 Agents can parse these files to learn from previous incidents.

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -412,12 +412,13 @@ def _run_build_script(tmp_path, env):
 
     ci_dir = script_dir / "cloud-init"
     ci_dir.mkdir(parents=True)
-    user_src = repo_root / "scripts" / "cloud-init" / "user-data.yaml"
+    ci_src = repo_root / "scripts" / "cloud-init"
+    user_src = ci_src / "user-data.yaml"
     shutil.copy(user_src, ci_dir / "user-data.yaml")
 
-    compose_src = repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
+    compose_src = ci_src / "docker-compose.cloudflared.yml"
     shutil.copy(compose_src, ci_dir / "docker-compose.cloudflared.yml")
-    projects_src = repo_root / "scripts" / "cloud-init" / "docker-compose.projects.yml"
+    projects_src = ci_src / "docker-compose.projects.yml"
     shutil.copy(projects_src, ci_dir / "docker-compose.projects.yml")
 
     result = subprocess.run(


### PR DESCRIPTION
## Summary
- clarify outage record fields and add schema validation example
- refactor build script test to reuse cloud-init source path

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68be3ef56590832fb5260e5b921bbbea