### PR TITLE
📝 : – refresh CAD prompt instructions and fix test style

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -44,7 +44,7 @@ REQUEST:
 3. Render the model via:
 
    ~~~bash
-   ./scripts/openscad_render.sh path/to/model.scad  # uses default standoff_mode (heatse
+   ./scripts/openscad_render.sh path/to/model.scad  # uses default standoff_mode (heatset)
    STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad  # case-insensitive
    STANDOFF_MODE=nut ./scripts/openscad_render.sh path/to/model.scad
    ~~~
@@ -71,7 +71,7 @@ Run `pre-commit run --all-files`,
 If `package.json` defines them, also run:
 - `npm run lint`
 - `npm run format:check`
-- `npm test -- --coverage`
+- `npm run test:ci`
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -415,10 +415,20 @@ def _run_build_script(tmp_path, env):
     user_src = repo_root / "scripts" / "cloud-init" / "user-data.yaml"
     shutil.copy(user_src, ci_dir / "user-data.yaml")
 
-    compose_src = repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
-    shutil.copy(compose_src, ci_dir / "docker-compose.cloudflared.yml")
-    projects_src = repo_root / "scripts" / "cloud-init" / "docker-compose.projects.yml"
-    shutil.copy(projects_src, ci_dir / "docker-compose.projects.yml")
+    compose_src = (
+        repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
+    )
+    shutil.copy(
+        compose_src,
+        ci_dir / "docker-compose.cloudflared.yml",
+    )
+    projects_src = (
+        repo_root / "scripts" / "cloud-init" / "docker-compose.projects.yml"
+    )  # noqa: E501
+    shutil.copy(
+        projects_src,
+        ci_dir / "docker-compose.projects.yml",
+    )
 
     result = subprocess.run(
         ["/bin/bash", str(script)],


### PR DESCRIPTION
what: update prompts-codex-cad doc and wrap long test lines.
why: ensure instructions are current and pre-commit passes.
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68be3ef41c98832f897fa0ed351fe367