### PR TITLE
📝: expand Docker repo walkthrough

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -16,9 +16,15 @@ For a prebuilt image that already clones both projects, see
    [pi_image_cloudflare.md](pi_image_cloudflare.md).
 2. SSH in and verify Docker and the Cloudflare Tunnel are active:
    `ssh pi@<hostname>.local` then `systemctl status docker cloudflared-compose`.
-3. Clone a repository under `/opt/projects` such as
+3. Create `/opt/projects` and clone a repo such as
    [`token.place`](https://github.com/futuroptimist/token.place) or
-   [`dspace`](https://github.com/democratizedspace/dspace).
+   [`dspace`](https://github.com/democratizedspace/dspace):
+   ```sh
+   sudo mkdir -p /opt/projects && sudo chown pi:pi /opt/projects
+   cd /opt/projects
+   git clone https://github.com/futuroptimist/token.place
+   git clone https://github.com/democratizedspace/dspace
+   ```
 4. Build or start containers:
    - Single `Dockerfile`: `docker buildx build --platform linux/arm64 -t myapp . --load`
      then `docker run -d --name myapp -p 8080:8080 myapp`.
@@ -34,6 +40,20 @@ For a prebuilt image that already clones both projects, see
 ## Quick start
 
 Try one of these example projects to confirm the image works:
+
+### hello-world
+
+```sh
+ssh pi@<hostname>.local
+cd /opt/projects
+git clone https://github.com/docker-library/hello-world
+cd hello-world
+docker buildx build --platform linux/arm64 -t hello . --load
+docker run --rm hello
+```
+
+Once the container prints the "Hello from Docker!" message, move on to
+token.place or dspace.
 
 ### token.place
 

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -415,9 +415,10 @@ def _run_build_script(tmp_path, env):
     user_src = repo_root / "scripts" / "cloud-init" / "user-data.yaml"
     shutil.copy(user_src, ci_dir / "user-data.yaml")
 
-    compose_src = repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
+    cloud_init_dir = repo_root / "scripts" / "cloud-init"
+    compose_src = cloud_init_dir / "docker-compose.cloudflared.yml"
     shutil.copy(compose_src, ci_dir / "docker-compose.cloudflared.yml")
-    projects_src = repo_root / "scripts" / "cloud-init" / "docker-compose.projects.yml"
+    projects_src = cloud_init_dir / "docker-compose.projects.yml"
     shutil.copy(projects_src, ci_dir / "docker-compose.projects.yml")
 
     result = subprocess.run(


### PR DESCRIPTION
## Summary
- guide users to create `/opt/projects` and clone token.place and dspace
- add hello-world example to verify Docker works on Pi image
- refactor test paths to satisfy flake8 line length

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68be3eec4694832fab1df746f1b89887