### PR TITLE
📝 : – document systemd auto-start for token.place and dspace

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -88,6 +88,35 @@ curl http://localhost:3000
 docker compose down
 ```
 
+### Auto-start token.place and dspace on boot
+
+Keep the stack running after reboots by wrapping the compose file with a systemd
+unit:
+
+```sh
+sudo tee /etc/systemd/system/tokenplace-dspace.service <<'EOF'
+[Unit]
+Description=token.place and dspace
+Requires=docker.service
+After=network-online.target docker.service
+
+[Service]
+WorkingDirectory=/opt/projects
+ExecStart=/usr/bin/docker compose up -d
+ExecStop=/usr/bin/docker compose down
+TimeoutStartSec=0
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+sudo systemctl enable --now tokenplace-dspace.service
+sudo systemctl status tokenplace-dspace.service --no-pager
+```
+
+This example assumes the combined `docker-compose.yml` above lives in
+`/opt/projects`.
+
 Proceed with the detailed steps below to adapt the process for other repositories.
 
 ## 1. Prepare the Pi

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -415,9 +415,10 @@ def _run_build_script(tmp_path, env):
     user_src = repo_root / "scripts" / "cloud-init" / "user-data.yaml"
     shutil.copy(user_src, ci_dir / "user-data.yaml")
 
-    compose_src = repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
+    cloud_init_dir = repo_root / "scripts" / "cloud-init"
+    compose_src = cloud_init_dir / "docker-compose.cloudflared.yml"
     shutil.copy(compose_src, ci_dir / "docker-compose.cloudflared.yml")
-    projects_src = repo_root / "scripts" / "cloud-init" / "docker-compose.projects.yml"
+    projects_src = cloud_init_dir / "docker-compose.projects.yml"
     shutil.copy(projects_src, ci_dir / "docker-compose.projects.yml")
 
     result = subprocess.run(


### PR DESCRIPTION
## Summary
- show how to run token.place and dspace via systemd on boot
- tidy test paths to satisfy pre-commit

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68be3eec4694832fab1df746f1b89887