### PR TITLE
📝 docs: refresh CAD prompt instructions

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -44,7 +44,7 @@ REQUEST:
 3. Render the model via:
 
    ~~~bash
-   ./scripts/openscad_render.sh path/to/model.scad  # uses default standoff_mode (heatse
+   ./scripts/openscad_render.sh path/to/model.scad  # uses default standoff_mode (heatset)
    STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad  # case-insensitive
    STANDOFF_MODE=nut ./scripts/openscad_render.sh path/to/model.scad
    ~~~
@@ -70,8 +70,7 @@ Run `pre-commit run --all-files`,
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
 If `package.json` defines them, also run:
 - `npm run lint`
-- `npm run format:check`
-- `npm test -- --coverage`
+- `npm run test:ci`
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -415,10 +415,16 @@ def _run_build_script(tmp_path, env):
     user_src = repo_root / "scripts" / "cloud-init" / "user-data.yaml"
     shutil.copy(user_src, ci_dir / "user-data.yaml")
 
-    compose_src = repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
-    shutil.copy(compose_src, ci_dir / "docker-compose.cloudflared.yml")
-    projects_src = repo_root / "scripts" / "cloud-init" / "docker-compose.projects.yml"
-    shutil.copy(projects_src, ci_dir / "docker-compose.projects.yml")
+    compose_src = (
+        repo_root / "scripts" / "cloud-init" / "docker-compose.cloudflared.yml"
+    )
+    compose_dest = ci_dir / "docker-compose.cloudflared.yml"
+    shutil.copy(compose_src, compose_dest)
+    projects_src = repo_root / Path(
+        "scripts/cloud-init/docker-compose.projects.yml"
+    )  # noqa: E501
+    projects_dest = ci_dir / "docker-compose.projects.yml"
+    shutil.copy(projects_src, projects_dest)
 
     result = subprocess.run(
         ["/bin/bash", str(script)],


### PR DESCRIPTION
## Summary
- fix truncated OpenSCAD render example in CAD prompt
- clarify Node.js steps in upgrade instructions
- wrap long test paths to satisfy flake8

## Testing
- `python -m pre_commit run --all-files`
- `python -m pyspelling -c .spellcheck.yaml`
- `python -m linkcheck --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68be3ee4ec30832f897b38cdf0943e67