### PR TITLE
📝 docs: refresh CAD prompt references

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -29,8 +29,8 @@ For a prebuilt image that already clones both projects, see
    - Single `Dockerfile`: `docker buildx build --platform linux/arm64 -t myapp . --load`
      then `docker run -d --name myapp -p 8080:8080 myapp`.
    - `docker-compose.yml`: `docker compose up -d`.
-5. Inspect container logs to confirm the service started:  
-   - Single container: `docker logs -f myapp`  
+5. Inspect container logs to confirm the service started:
+   - Single container: `docker logs -f myapp`
    - Compose project: `docker compose logs`
 6. Confirm the service responds locally, e.g.
    `curl http://localhost:5000` for token.place or

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -28,6 +28,8 @@ CONTEXT:
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
 - Run `pre-commit run --all-files` to lint, format, and test via
   [`scripts/checks.sh`](../scripts/checks.sh).
+- If `package.json` exists, also run `npm ci`, `npm run lint`, and
+  `npm run test:ci`.
 - For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and
     `aspell-en`; see [`.spellcheck.yaml`](../.spellcheck.yaml))
@@ -66,6 +68,7 @@ You are an automated contributor for the sugarkube repository.
 Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
 Run `pre-commit run --all-files`.
 If `package.json` defines them, also run:
+- `npm ci`
 - `npm run lint`
 - `npm run test:ci`
 Then run:

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -443,7 +443,7 @@ def _run_build_script(tmp_path, env):
     git_log_path = Path(env["GIT_LOG"])
     git_args = git_log_path.read_text() if git_log_path.exists() else ""
     return result, git_args
-  
+
 
 def test_uses_default_pi_gen_branch(tmp_path):
     env = _setup_build_env(tmp_path)

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -115,7 +115,7 @@ def test_handles_img_xz(tmp_path):
     assert out_img.read_text() == "original"
 
 
-def test_errors_when_no_image_found(tmp_path):
+def test_errors_when_no_image_found_note(tmp_path):
     deploy = tmp_path / "deploy"
     deploy.mkdir()
     (deploy / "note.txt").write_text("no artifact")
@@ -136,9 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
What: document npm checks in CAD prompt, rename duplicate test, trim whitespace.
Why: keep prompts accurate and satisfy repository linters.
How to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68bf50af5134832fab1e3094f0fb8c7c