### PR TITLE
docs: streamline CAD prompt upgrade instructions

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -64,15 +64,11 @@ Use this prompt to refine sugarkube's own prompt documentation.
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
 Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
-Run `pre-commit run --all-files`.
-If `package.json` defines them, also run:
-- `npm run lint`
-- `npm run test:ci`
-Then run:
-- `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; see
-  [`.spellcheck.yaml`](../.spellcheck.yaml))
-- `linkchecker --no-warnings README.md docs/`
-- `git diff --cached | ./scripts/scan-secrets.py` before committing.
+Run `pre-commit run --all-files`,
+`pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; see
+[`.spellcheck.yaml`](../.spellcheck.yaml)),
+`linkchecker --no-warnings README.md docs/`, and
+`git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).


### PR DESCRIPTION
## Summary
- clarify upgrade steps in CAD prompt doc by removing outdated npm commands

## Testing
- `pre-commit run --all-files` *(fails: F811 redefinition in tests/collect_pi_image_inputs_test.py)*
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf50a78950832f877b3fa0c9e3f834