### PR TITLE
docs: expand Pi Docker walkthrough

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -25,19 +25,24 @@ For a prebuilt image that already clones both projects, see
    git clone https://github.com/futuroptimist/token.place
    git clone https://github.com/democratizedspace/dspace
    ```
-4. Build or start containers:
+4. Read the repository's README for environment variables and build paths.
+   `token.place` keeps its server `Dockerfile` in `docker/Dockerfile.server` and
+   exposes settings like `TOKEN_PLACE_ENV`; dspace's compose file lives in
+   `frontend/` and uses vars such as `NODE_ENV` and `PORT`. Copy `.env.example`
+   to `.env` when provided.
+5. Build or start containers:
    - Single `Dockerfile`: `docker buildx build --platform linux/arm64 -t myapp . --load`
      then `docker run -d --name myapp -p 8080:8080 myapp`.
    - `docker-compose.yml`: `docker compose up -d`.
-5. Inspect container logs to confirm the service started:  
-   - Single container: `docker logs -f myapp`  
+6. Inspect container logs to confirm the service started:
+   - Single container: `docker logs -f myapp`
    - Compose project: `docker compose logs`
-6. Confirm the service responds locally, e.g.
+7. Confirm the service responds locally, e.g.
    `curl http://localhost:5000` for token.place or
    `curl http://localhost:3000` for dspace.
-7. Optionally expose ports through the Cloudflare Tunnel by editing
+8. Optionally expose ports through the Cloudflare Tunnel by editing
    `/opt/sugarkube/docker-compose.cloudflared.yml`.
-8. Log recurring deployment failures in `outages/` using
+9. Log recurring deployment failures in `outages/` using
    [`schema.json`](../outages/schema.json).
 
 ## Quick start
@@ -77,6 +82,7 @@ curl http://localhost:5000
 cd /opt/projects
 git clone https://github.com/futuroptimist/token.place
 cd token.place
+cp .env.example .env  # load defaults
 docker compose up -d
 docker compose ps
 curl http://localhost:5000  # relay
@@ -316,6 +322,7 @@ their own `docker-compose.yml`.
 
 ```sh
 cd /opt/projects/token.place
+cp .env.example .env  # load defaults
 docker compose -f docker-compose.tokenplace.yml up -d
 docker compose -f docker-compose.tokenplace.yml ps
 docker compose -f docker-compose.tokenplace.yml logs -f

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -443,7 +443,7 @@ def _run_build_script(tmp_path, env):
     git_log_path = Path(env["GIT_LOG"])
     git_args = git_log_path.read_text() if git_log_path.exists() else ""
     return result, git_args
-  
+
 
 def test_uses_default_pi_gen_branch(tmp_path):
     env = _setup_build_env(tmp_path)

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -115,7 +115,7 @@ def test_handles_img_xz(tmp_path):
     assert out_img.read_text() == "original"
 
 
-def test_errors_when_no_image_found(tmp_path):
+def test_errors_when_no_image_found_note(tmp_path):
     deploy = tmp_path / "deploy"
     deploy.mkdir()
     (deploy / "note.txt").write_text("no artifact")
@@ -136,9 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
## Summary
- document env setup for token.place and dspace in Pi Docker guide
- add docker-compose examples that copy .env.example first
- rename duplicate test to satisfy lint checks

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68bf5046a75c832fa31afdc76bdf9a22