### PR TITLE
docs: clarify pi-gen reference and rename duplicate test

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -29,8 +29,8 @@ For a prebuilt image that already clones both projects, see
    - Single `Dockerfile`: `docker buildx build --platform linux/arm64 -t myapp . --load`
      then `docker run -d --name myapp -p 8080:8080 myapp`.
    - `docker-compose.yml`: `docker compose up -d`.
-5. Inspect container logs to confirm the service started:  
-   - Single container: `docker logs -f myapp`  
+5. Inspect container logs to confirm the service started:
+   - Single container: `docker logs -f myapp`
    - Compose project: `docker compose logs`
 6. Confirm the service responds locally, e.g.
    `curl http://localhost:5000` for token.place or

--- a/docs/pi_image_builder_design.md
+++ b/docs/pi_image_builder_design.md
@@ -68,7 +68,7 @@
   - Detects WSL (`wsl.exe`) and Git Bash (`bash.exe`); prefers Git Bash for
     Docker Desktop, falls back to WSL
   - Converts Windows paths to MSYS (`/c/...`) and WSL (`/mnt/c/...`) accurately
-  - If local shell fails, tries official `pigen` container, then Debian fallback
+  - If local shell fails, tries official `pi-gen` container, then Debian fallback
   - Sets up a dedicated Docker network and optional apt-cacher; archives site is forced DIRECT
   - Compresses with native `xz`, `7z`, WSL `xz`, or Docker `xz` as needed
   - Streams progress with clear start banner and stage logging

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -443,7 +443,7 @@ def _run_build_script(tmp_path, env):
     git_log_path = Path(env["GIT_LOG"])
     git_args = git_log_path.read_text() if git_log_path.exists() else ""
     return result, git_args
-  
+
 
 def test_uses_default_pi_gen_branch(tmp_path):
     env = _setup_build_env(tmp_path)

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -115,7 +115,7 @@ def test_handles_img_xz(tmp_path):
     assert out_img.read_text() == "original"
 
 
-def test_errors_when_no_image_found(tmp_path):
+def test_errors_when_no_image_found_note_file(tmp_path):
     deploy = tmp_path / "deploy"
     deploy.mkdir()
     (deploy / "note.txt").write_text("no artifact")
@@ -136,9 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
## Summary
- clarify pi-gen reference in Windows notes
- rename duplicate test and trim trailing whitespace

## Testing
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68bf5089e384832f99e1887e109c81a1