### PR TITLE
📝 : streamline CAD prompt and fix duplicate test

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -29,8 +29,8 @@ For a prebuilt image that already clones both projects, see
    - Single `Dockerfile`: `docker buildx build --platform linux/arm64 -t myapp . --load`
      then `docker run -d --name myapp -p 8080:8080 myapp`.
    - `docker-compose.yml`: `docker compose up -d`.
-5. Inspect container logs to confirm the service started:  
-   - Single container: `docker logs -f myapp`  
+5. Inspect container logs to confirm the service started:
+   - Single container: `docker logs -f myapp`
    - Compose project: `docker compose logs`
 6. Confirm the service responds locally, e.g.
    `curl http://localhost:5000` for token.place or

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -64,15 +64,11 @@ Use this prompt to refine sugarkube's own prompt documentation.
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
 Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
-Run `pre-commit run --all-files`.
-If `package.json` defines them, also run:
-- `npm run lint`
-- `npm run test:ci`
-Then run:
-- `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; see
-  [`.spellcheck.yaml`](../.spellcheck.yaml))
-- `linkchecker --no-warnings README.md docs/`
-- `git diff --cached | ./scripts/scan-secrets.py` before committing.
+Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`
+(requires `aspell` and `aspell-en`; see
+ [`.spellcheck.yaml`](../.spellcheck.yaml)),
+`linkchecker --no-warnings README.md docs/`, and
+`git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -443,7 +443,7 @@ def _run_build_script(tmp_path, env):
     git_log_path = Path(env["GIT_LOG"])
     git_args = git_log_path.read_text() if git_log_path.exists() else ""
     return result, git_args
-  
+
 
 def test_uses_default_pi_gen_branch(tmp_path):
     env = _setup_build_env(tmp_path)

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -115,17 +115,6 @@ def test_handles_img_xz(tmp_path):
     assert out_img.read_text() == "original"
 
 
-def test_errors_when_no_image_found(tmp_path):
-    deploy = tmp_path / "deploy"
-    deploy.mkdir()
-    (deploy / "note.txt").write_text("no artifact")
-
-    out_img = tmp_path / "out.img.xz"
-    result = _run_script(tmp_path, deploy, out_img)
-    assert result.returncode != 0
-    assert "No image file found" in result.stderr
-
-
 def test_succeeds_when_realpath_missing(tmp_path):
     deploy = tmp_path / "deploy"
     deploy.mkdir()
@@ -136,9 +125,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
what: drop outdated npm instructions, remove duplicate test, clean whitespace
why: ensure docs reflect current workflow and pre-commit passes
how to test: python -m pre_commit run --all-files
            pyspelling -c .spellcheck.yaml
            linkchecker --no-warnings README.md docs/
            git diff --cached | ./scripts/scan-secrets.py
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bf5061ad38832f9a9e75ef877276c5