### PR TITLE
📝 docs: refine CAD prompt and fix duplicate test

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -17,17 +17,17 @@ Keep OpenSCAD models current and ensure they render cleanly.
 CONTEXT:
 - CAD files reside in [`cad/`](../cad/).
 - Use [`scripts/openscad_render.sh`](../scripts/openscad_render.sh) to export binary STL meshes
-  into the git-ignored [`stl/`](../stl/) directory. Ensure
+  into the git-ignored [`stl/`](../stl/) directory (see [`.gitignore`](../.gitignore)). The CI
+  workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these models
+  as artifacts, so never commit `.stl` files. Ensure
   [OpenSCAD](https://openscad.org/) is installed and available in `PATH`; the script exits early
   if it cannot find the binary.
-- The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these
-  models as artifacts. Do not commit `.stl` files.
 - Render each model in all supported `standoff_mode` variants—e.g., `heatset`, `printed`, or
   `nut`. The `STANDOFF_MODE` environment variable is optional, case-insensitive, trims
   surrounding whitespace, and defaults to the model’s `standoff_mode` value (often `heatset`).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test via
-  [`scripts/checks.sh`](../scripts/checks.sh).
+- Run `pre-commit run --all-files` before committing; it invokes
+  [`scripts/checks.sh`](../scripts/checks.sh) for linting, formatting, and tests.
 - For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and
     `aspell-en`; see [`.spellcheck.yaml`](../.spellcheck.yaml))
@@ -41,10 +41,10 @@ CONTEXT:
 REQUEST:
 1. Inspect `cad/*.scad` for todo comments or needed adjustments.
 2. Modify geometry or parameters as required.
-3. Render the model via (use `~~~` fences inside this prompt to avoid breaking the outer
-   code block):
+3. Render the model using the script:
+
    ~~~bash
-   ./scripts/openscad_render.sh path/to/model.scad  # uses default standoff_mode (heatset)
+   ./scripts/openscad_render.sh path/to/model.scad  # default standoff_mode (heatset)
    STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad  # case-insensitive
    STANDOFF_MODE=nut ./scripts/openscad_render.sh path/to/model.scad
    ~~~

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -75,7 +75,7 @@ def test_errors_on_zip_without_img(tmp_path):
     assert "Zip contained no .img" in result.stderr
 
 
-def test_errors_when_no_image_found(tmp_path):
+def test_errors_when_no_image_found_with_note(tmp_path):
     deploy = tmp_path / "deploy"
     deploy.mkdir()
     (deploy / "foo.txt").write_text("data")
@@ -136,9 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
what: clarify CAD prompt instructions and rename duplicate test
why: keep docs accurate and lint/tests passing
how to test: pre-commit run --all-files, pyspelling -c .spellcheck.yaml, linkchecker --no-warnings README.md docs/

------
https://chatgpt.com/codex/tasks/task_e_68bf505b0eb4832f94d3e48cd2ba839e