### PR TITLE
📝 : clarify Codex CAD prompt

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -29,8 +29,8 @@ For a prebuilt image that already clones both projects, see
    - Single `Dockerfile`: `docker buildx build --platform linux/arm64 -t myapp . --load`
      then `docker run -d --name myapp -p 8080:8080 myapp`.
    - `docker-compose.yml`: `docker compose up -d`.
-5. Inspect container logs to confirm the service started:  
-   - Single container: `docker logs -f myapp`  
+5. Inspect container logs to confirm the service started:
+   - Single container: `docker logs -f myapp`
    - Compose project: `docker compose logs`
 6. Confirm the service responds locally, e.g.
    `curl http://localhost:5000` for token.place or

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -3,7 +3,7 @@ title: 'Sugarkube Codex CAD Prompt'
 slug: 'prompts-codex-cad'
 ---
 
-# Sugarkube Codex CAD Prompt
+# Codex CAD Prompt
 
 Use this prompt to update or verify OpenSCAD models.
 
@@ -17,13 +17,13 @@ Keep OpenSCAD models current and ensure they render cleanly.
 CONTEXT:
 - CAD files reside in [`cad/`](../cad/).
 - Use [`scripts/openscad_render.sh`](../scripts/openscad_render.sh) to export binary STL meshes
-  into the git-ignored [`stl/`](../stl/) directory. Ensure
-  [OpenSCAD](https://openscad.org/) is installed and available in `PATH`; the script exits early
-  if it cannot find the binary.
-- The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these
-  models as artifacts. Do not commit `.stl` files.
+  into the git-ignored [`stl/`](../stl/) directory with a mode-specific suffix when
+  `STANDOFF_MODE` is set. Ensure [OpenSCAD](https://openscad.org/) is installed and available in
+  `PATH`; the script exits early if it cannot find the binary.
+- The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) rebuilds these models
+  as artifacts; do not commit `.stl` files.
 - Render each model in all supported `standoff_mode` variants—e.g., `heatset`, `printed`, or
-  `nut`. The `STANDOFF_MODE` environment variable is optional, case-insensitive, trims
+  `nut`. The `STANDOFF_MODE` environment variable is optional—case-insensitive, trims
   surrounding whitespace, and defaults to the model’s `standoff_mode` value (often `heatset`).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
 - Run `pre-commit run --all-files` to lint, format, and test via
@@ -41,8 +41,8 @@ CONTEXT:
 REQUEST:
 1. Inspect `cad/*.scad` for todo comments or needed adjustments.
 2. Modify geometry or parameters as required.
-3. Render the model via (use `~~~` fences inside this prompt to avoid breaking the outer
-   code block):
+3. Render the model using commands like (use `~~~` fences inside this prompt to avoid breaking the
+   outer code block):
    ~~~bash
    ./scripts/openscad_render.sh path/to/model.scad  # uses default standoff_mode (heatset)
    STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad  # case-insensitive

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -443,7 +443,7 @@ def _run_build_script(tmp_path, env):
     git_log_path = Path(env["GIT_LOG"])
     git_args = git_log_path.read_text() if git_log_path.exists() else ""
     return result, git_args
-  
+
 
 def test_uses_default_pi_gen_branch(tmp_path):
     env = _setup_build_env(tmp_path)

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -115,7 +115,7 @@ def test_handles_img_xz(tmp_path):
     assert out_img.read_text() == "original"
 
 
-def test_errors_when_no_image_found(tmp_path):
+def test_errors_when_no_image_found_in_directory(tmp_path):
     deploy = tmp_path / "deploy"
     deploy.mkdir()
     (deploy / "note.txt").write_text("no artifact")
@@ -136,9 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
## Summary
- document mode-specific suffix in Codex CAD prompt
- deduplicate pi image input test name to satisfy lint

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf505b0eb4832f94d3e48cd2ba839e