### PR TITLE
Add thick-trace guidance to power ring schematic

### DIFF
--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -9,6 +9,7 @@
                 (comment 2 "Keep high-current traces short")
                 (comment 3 "Label polarity and voltage on connectors")
                 (comment 4 "Use star topology for power distribution to minimize voltage drop")
+                (comment 5 "Use thick traces for high-current paths")
         )
         (lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/elex/power_ring/specs.md
+++ b/elex/power_ring/specs.md
@@ -18,9 +18,10 @@ The design may evolve as the project grows.
 
 - Test points for measuring battery voltage
 - Silkscreen labels for polarity and connector numbers
-- Title block comments record decoupling guidelines, high-current trace layout, connector
-  labeling, export checks, ground pour continuity around mounting holes, board outline fit,
-  BOM validation, clearance rules for high-voltage nets, and star topology to minimize voltage drop
+- Title block comments record decoupling guidelines, high-current trace layout, thick traces
+  for high-current paths, connector labeling, export checks, ground pour continuity around
+  mounting holes, board outline fit, BOM validation, clearance rules for high-voltage nets,
+  and star topology to minimize voltage drop
 
 These requirements are a starting point – modify the KiCad project as needed and
 update this file when the schematic changes.


### PR DESCRIPTION
## Summary
- document thick traces for high-current paths
- note same guidance in power ring spec

## Testing
- `kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml` (fails: Unknown file type)
- `npm run lint` (fails: missing package.json)
- `npm run test:ci` (fails: missing package.json)
- `pre-commit run --all-files` (fails: F811 in tests)
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68bf5054a0d0832f86202ae63c1cba88