### PR TITLE
Add LED orientation note to power ring schematic

### DIFF
--- a/docs/electronics_schematics.md
+++ b/docs/electronics_schematics.md
@@ -19,6 +19,7 @@ Design notes embedded in the KiCad title block highlight best practices:
 - Place decoupling capacitors near power pins.
 - Keep high-current traces short for better performance.
 - Label polarity and voltage on connectors to avoid wiring mistakes.
+- Verify LED orientation during assembly.
 - Verify KiBot exports before fabrication.
 - Check ground-pour continuity around mounting holes.
 

--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -9,6 +9,7 @@
                 (comment 2 "Keep high-current traces short")
                 (comment 3 "Label polarity and voltage on connectors")
                 (comment 4 "Use star topology for power distribution to minimize voltage drop")
+                (comment 5 "Verify LED orientation during assembly")
         )
         (lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/elex/power_ring/specs.md
+++ b/elex/power_ring/specs.md
@@ -17,7 +17,7 @@ The design may evolve as the project grows.
 ## Extras
 
 - Test points for measuring battery voltage
-- Silkscreen labels for polarity and connector numbers
+- Silkscreen labels for polarity, connector numbers, and LED orientation
 - Title block comments record decoupling guidelines, high-current trace layout, connector
   labeling, export checks, ground pour continuity around mounting holes, board outline fit,
   BOM validation, clearance rules for high-voltage nets, and star topology to minimize voltage drop


### PR DESCRIPTION
## What
- document LED orientation in schematic title block
- mention LED polarity in specs and design notes

## Why
- clarify assembly instructions

## How to test
- `kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml`

Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68bf5054a0d0832f86202ae63c1cba88