### PR TITLE
📝 docs: improve safety wiring guidance

### DIFF
--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -11,7 +11,8 @@ This setup uses a 12 V LiFePO4 battery and outdoor wiring. Follow these precau
 - Verify polarity with a multimeter before powering devices.
 - Disconnect the battery before working on wiring and remove metal jewelry to avoid shorts.
 - Add a DC-rated disconnect switch on the battery positive lead so you can kill power quickly and isolate it during maintenance.
-- Route cables so water cannot drip onto connectors; use cable glands and strain relief.
+- Route cables with drip loops so water cannot run into connectors; use cable glands and strain relief.
+- Bond the aluminium frame and charge controller to earth ground where local code requires.
 - Use tinned copper lugs and UV-resistant wiring for outdoor runs.
 - Refer to [Power System Design](power_system_design.md) for wire and fuse sizing guidelines.
 - Wear eye protection while crimping and avoid short circuits when working on the battery.

--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -29,8 +29,8 @@ For a prebuilt image that already clones both projects, see
    - Single `Dockerfile`: `docker buildx build --platform linux/arm64 -t myapp . --load`
      then `docker run -d --name myapp -p 8080:8080 myapp`.
    - `docker-compose.yml`: `docker compose up -d`.
-5. Inspect container logs to confirm the service started:  
-   - Single container: `docker logs -f myapp`  
+5. Inspect container logs to confirm the service started:
+   - Single container: `docker logs -f myapp`
    - Compose project: `docker compose logs`
 6. Confirm the service responds locally, e.g.
    `curl http://localhost:5000` for token.place or

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -443,7 +443,7 @@ def _run_build_script(tmp_path, env):
     git_log_path = Path(env["GIT_LOG"])
     git_args = git_log_path.read_text() if git_log_path.exists() else ""
     return result, git_args
-  
+
 
 def test_uses_default_pi_gen_branch(tmp_path):
     env = _setup_build_env(tmp_path)

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -115,7 +115,7 @@ def test_handles_img_xz(tmp_path):
     assert out_img.read_text() == "original"
 
 
-def test_errors_when_no_image_found(tmp_path):
+def test_errors_when_no_image_found_note(tmp_path):
     deploy = tmp_path / "deploy"
     deploy.mkdir()
     (deploy / "note.txt").write_text("no artifact")
@@ -136,9 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
## Summary
- clarify cable routing with drip loops and add grounding note in safety guide
- rename duplicate test and strip trailing whitespace so pre-commit passes

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68bf504ee9f4832fbd604af544d8f161