### PR TITLE
📝 docs: clarify CAD prompt instructions

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -5,7 +5,7 @@ slug: 'prompts-codex-cad'
 
 # Sugarkube Codex CAD Prompt
 
-Use this prompt to update or verify OpenSCAD models.
+Use this prompt to update or verify [OpenSCAD](https://openscad.org/) models.
 
 ```text
 SYSTEM:
@@ -17,14 +17,14 @@ Keep OpenSCAD models current and ensure they render cleanly.
 CONTEXT:
 - CAD files reside in [`cad/`](../cad/).
 - Use [`scripts/openscad_render.sh`](../scripts/openscad_render.sh) to export binary STL meshes
-  into the git-ignored [`stl/`](../stl/) directory. Ensure
-  [OpenSCAD](https://openscad.org/) is installed and available in `PATH`; the script exits early
-  if it cannot find the binary.
+  into the git-ignored [`stl/`](../stl/) directory. The script requires a `.scad` file, validates
+  `STANDOFF_MODE`, and exits early if OpenSCAD is missing or the value is invalid.
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these
   models as artifacts. Do not commit `.stl` files.
 - Render each model in all supported `standoff_mode` variants—e.g., `heatset`, `printed`, or
   `nut`. The `STANDOFF_MODE` environment variable is optional, case-insensitive, trims
   surrounding whitespace, and defaults to the model’s `standoff_mode` value (often `heatset`).
+  Any other value results in an error.
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
 - Run `pre-commit run --all-files` to lint, format, and test via
   [`scripts/checks.sh`](../scripts/checks.sh).


### PR DESCRIPTION
what: link to OpenSCAD and note render script validates inputs
why: keep CAD workflow guidance accurate
how to test:
- pre-commit run --all-files (fails: W293 in tests/build_pi_image_test.py)
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bf5049d8e4832f99fccfb2321895c1