### PR TITLE
📝 docs: clarify electronics prompt and clean tests

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -29,8 +29,8 @@ For a prebuilt image that already clones both projects, see
    - Single `Dockerfile`: `docker buildx build --platform linux/arm64 -t myapp . --load`
      then `docker run -d --name myapp -p 8080:8080 myapp`.
    - `docker-compose.yml`: `docker compose up -d`.
-5. Inspect container logs to confirm the service started:  
-   - Single container: `docker logs -f myapp`  
+5. Inspect container logs to confirm the service started:
+   - Single container: `docker logs -f myapp`
    - Compose project: `docker compose logs`
 6. Confirm the service responds locally, e.g.
    `curl http://localhost:5000` for token.place or

--- a/docs/prompts-codex-elex.md
+++ b/docs/prompts-codex-elex.md
@@ -7,7 +7,7 @@ slug: 'prompts-codex-elex'
 
 Use this prompt for electronics design changes.
 
-```
+```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository focused on electronics.
 
@@ -18,8 +18,8 @@ CONTEXT:
 - Electronics files live under [`elex/`](../elex/).
 - The `power_ring` project uses KiCad 9+ and KiBot ([`.kibot/power_ring.yaml`](../.kibot/power_ring.yaml)).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to lint, format, and test.
-  For documentation updates, also run:
+- Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../scripts/checks.sh)
+  for linting, formatting, and tests. For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
@@ -29,7 +29,9 @@ CONTEXT:
 REQUEST:
 1. Modify schematics or PCB layouts in `elex/power_ring`.
 2. Export artifacts locally with:
+   ```bash
    kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml
+   ```
 3. Update any related documentation.
 4. Re-run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
    `linkchecker --no-warnings README.md docs/`; scan staged changes with

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -443,7 +443,7 @@ def _run_build_script(tmp_path, env):
     git_log_path = Path(env["GIT_LOG"])
     git_args = git_log_path.read_text() if git_log_path.exists() else ""
     return result, git_args
-  
+
 
 def test_uses_default_pi_gen_branch(tmp_path):
     env = _setup_build_env(tmp_path)

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -115,7 +115,7 @@ def test_handles_img_xz(tmp_path):
     assert out_img.read_text() == "original"
 
 
-def test_errors_when_no_image_found(tmp_path):
+def test_errors_when_no_image_found_without_artifact(tmp_path):
     deploy = tmp_path / "deploy"
     deploy.mkdir()
     (deploy / "note.txt").write_text("no artifact")
@@ -136,9 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
what: refine electronics prompt formatting and remove duplicate test
why: keep docs accurate and satisfy repository checks
how to test: pre-commit run --all-files
  pyspelling -c .spellcheck.yaml
  linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68bf5049d8e4832f99fccfb2321895c1