### PR TITLE
🔧 Smooth panel bracket corners

### DIFF
--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -12,6 +12,7 @@ size          = 40;           // leg length (mm)
 thickness     = 8;            // plate thickness (mm)
 beam_width    = 20;           // width to match 2020 extrusion (mm)
 edge_radius   = 4;            // default 4 mm outer-edge rounding
+corner_segments = 32;         // sphere resolution for rounded edges
 hole_offset   = [0,0];        // XY offset of mounting hole from centre (mm)
 gusset        = true;         // add triangular support in inner corner
 gusset_size   = thickness*1.5; // leg length of gusset triangle (mm)
@@ -52,7 +53,7 @@ module rounded_cube(dims, r)
   else
     minkowski() {
       cube([dims[0]-2*r, dims[1]-2*r, dims[2]-2*r]);
-      sphere(r);
+      sphere(r, $fn=corner_segments);
     }
 }
 


### PR DESCRIPTION
## Summary
- refine panel_bracket.scad with configurable corner_segments for smoother rounded edges

## Testing
- `./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `pre-commit run --files cad/solar_cube/panel_bracket.scad` *(fails: F811 redefinition in tests/collect_pi_image_inputs_test.py)*


------
https://chatgpt.com/codex/tasks/task_e_68bf5000d7b8832fbab95c200673ad4e