### PR TITLE
🔩: add nut standoff mode to triple Pi carrier

### DIFF
--- a/cad/pi_cluster/pi5_triple_carrier_rot45.scad
+++ b/cad/pi_cluster/pi5_triple_carrier_rot45.scad
@@ -41,6 +41,7 @@ standoff_diam   = 6.5;           // increased for added strength (mm)
 /* Choose one of:
  *  "printed"   → generate printable ISO metric threads (M2.5)
  *  "heatset"   → leave a blind hole sized for a brass M2 insert
+ *  "nut"       → through-hole with captive hex recess
  */
 standoff_mode   = "heatset";
 
@@ -52,9 +53,13 @@ insert_hole_diam  = insert_od - insert_clearance; // about 2.8 mm
 insert_chamfer    = 0.5;         // chamfer to guide the soldering tip
 
 /* ---- screw / printed thread geometry (unchanged) ---- */
-screw_major   = 2.50;   // M2.5
-screw_pitch   = 0.45;   // ISO coarse
-thread_facets = 32;     // helix resolution
+screw_major     = 2.50;   // M2.5
+screw_pitch     = 0.45;   // ISO coarse
+thread_facets   = 32;     // helix resolution
+screw_clearance = 3.2;    // through-hole clearance, slightly oversize
+nut_clearance   = 0.3;    // extra room for easier nut insertion
+nut_flat        = 5.0 + nut_clearance; // across flats for M2.5 nut
+nut_thick       = 2.0;    // nut thickness
 
 /* ---------- DERIVED DIMENSIONS ---------- */
 /* footprint of a single PCB after rotation */
@@ -112,6 +117,13 @@ module standoff(pos=[0,0])
                 cylinder(h=insert_chamfer,
                          r1=insert_hole_diam/2 + insert_chamfer,
                          r2=insert_hole_diam/2, $fn=32);
+        }
+        else if (standoff_mode == "nut") {
+            /* through-hole with captive hex recess */
+            translate([0,0,-0.01])
+                cylinder(h=standoff_height + 0.02, r=screw_clearance/2, $fn=32);
+            translate([0,0,-nut_thick])
+                cylinder(h=nut_thick, r=nut_flat/(2*cos(30)), $fn=6);
         }
     }
 }

--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -29,8 +29,8 @@ For a prebuilt image that already clones both projects, see
    - Single `Dockerfile`: `docker buildx build --platform linux/arm64 -t myapp . --load`
      then `docker run -d --name myapp -p 8080:8080 myapp`.
    - `docker-compose.yml`: `docker compose up -d`.
-5. Inspect container logs to confirm the service started:  
-   - Single container: `docker logs -f myapp`  
+5. Inspect container logs to confirm the service started:
+   - Single container: `docker logs -f myapp`
    - Compose project: `docker compose logs`
 6. Confirm the service responds locally, e.g.
    `curl http://localhost:5000` for token.place or

--- a/docs/pi_cluster_carrier.md
+++ b/docs/pi_cluster_carrier.md
@@ -4,8 +4,11 @@ This design mounts three Raspberry Pi 5 boards on a common plate. Each Pi is rot
 
 The base corners are rounded with a configurable `corner_radius` parameter (default 5 mm) to soften sharp edges.
 
-The model lives at `cad/pi_cluster/pi5_triple_carrier_rot45.scad`. STL files for both heat‑set and printed‑thread variants are produced by GitHub Actions and published as artifacts whenever the SCAD file changes.
-You can edit the `pi_positions` array near the top of the file to tweak the arrangement if your printer allows a larger build area.
+The model lives at `cad/pi_cluster/pi5_triple_carrier_rot45.scad`. STL files for
+heat‑set, printed-thread, and captive-nut variants are produced by GitHub Actions and
+published as artifacts whenever the SCAD file changes. You can edit the `pi_positions`
+array near the top of the file to tweak the arrangement if your printer allows a larger
+build area.
 For an overview of insert installation and printed threads see [insert_basics.md](insert_basics.md).
 
 
@@ -19,9 +22,14 @@ To render one variant manually:
 
 ```bash
 # brass insert version
-openscad -D standoff_mode="heatset" -o triple.stl cad/pi_cluster/pi5_triple_carrier_rot45.scad
+openscad -D standoff_mode="heatset" \
+  -o triple.stl cad/pi_cluster/pi5_triple_carrier_rot45.scad
 # printed-thread version
-openscad -D standoff_mode="printed"  -o triple_printed.stl cad/pi_cluster/pi5_triple_carrier_rot45.scad
+openscad -D standoff_mode="printed" \
+  -o triple_printed.stl cad/pi_cluster/pi5_triple_carrier_rot45.scad
+# captive-nut version
+openscad -D standoff_mode="nut" \
+  -o triple_nut.stl cad/pi_cluster/pi5_triple_carrier_rot45.scad
 ```
 
 See the main [build guide](build_guide.md) for assembly details.

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -443,7 +443,7 @@ def _run_build_script(tmp_path, env):
     git_log_path = Path(env["GIT_LOG"])
     git_args = git_log_path.read_text() if git_log_path.exists() else ""
     return result, git_args
-  
+
 
 def test_uses_default_pi_gen_branch(tmp_path):
     env = _setup_build_env(tmp_path)

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -115,7 +115,7 @@ def test_handles_img_xz(tmp_path):
     assert out_img.read_text() == "original"
 
 
-def test_errors_when_no_image_found(tmp_path):
+def test_errors_when_no_image_found_in_dir(tmp_path):
     deploy = tmp_path / "deploy"
     deploy.mkdir()
     (deploy / "note.txt").write_text("no artifact")
@@ -136,9 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
what: add nut-mode option to pi5 triple carrier, update docs and test
why: support captive hex standoffs and keep checks passing
how to test:
- ./scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad
- STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad
- STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68bf5000d7b8832fbab95c200673ad4e