### PR TITLE
🔐 : lock env examples and doc init-env

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -49,6 +49,9 @@ The image embeds `pi_node_verifier.sh` in `/usr/local/sbin` and clones the
 `/opt/projects` by default. Set `CLONE_SUGARKUBE=true` to include this repo and
 pass space-separated Git URLs in `EXTRA_REPOS` to pull additional projects.
 
+On first boot `init-env.sh` copies each project's `.env.example` to `.env` and
+sets its mode to `0600` so secrets stay private.
+
 Set `TUNNEL_TOKEN` or `TUNNEL_TOKEN_FILE` to bake a Cloudflare token into
 `/opt/sugarkube/.cloudflared.env`; otherwise edit the file after boot.
 Cloud-init writes `docker-compose.cloudflared.yml` to `/opt/sugarkube`.

--- a/scripts/cloud-init/init-env.sh
+++ b/scripts/cloud-init/init-env.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 shopt -s globstar nullglob
 for example in **/.env.example; do
   target="${example%.example}"
-  [ -f "$target" ] || cp "$example" "$target"
+  if [ ! -f "$target" ]; then
+    cp "$example" "$target"
+    chmod 600 "$target"
+  fi
 done
 
 # extra-start

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -136,11 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n"
-        "echo realpath should not be invoked >&2\n"
-        "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
what: set .env files to 0600 on boot and document init-env behavior
why: protect credentials and clarify image setup
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68c11bdd816c832fb5697899c34ed238