### PR TITLE
🛠️: allow overriding apt rewrite mirror

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -24,8 +24,9 @@ replace an existing image. To reduce flaky downloads it pins the official
 Raspberry Pi and Debian mirrors, adds `APT_OPTS` (retries, timeouts,
 `-o APT::Get::Fix-Missing=true`), and installs a persistent apt/dpkg Pre-Invoke hook that rewrites
 any raspbian host to a stable HTTPS mirror and bypasses proxies for
-`archive.raspberrypi.com`. Set `SKIP_MIRROR_REWRITE=1` to disable these rewrites
-when your network already uses a reliable mirror. Use `APT_RETRIES` and
+`archive.raspberrypi.com`. Use `APT_REWRITE_MIRROR` to change the rewrite target
+(default: `https://mirror.fcix.net/raspbian/raspbian`). Set `SKIP_MIRROR_REWRITE=1`
+to disable these rewrites when your network already uses a reliable mirror. Use `APT_RETRIES` and
 `APT_TIMEOUT` to tune the retry count and per-request timeout. Override the
 Raspberry Pi packages mirror with `RPI_MIRROR` (mapped to pi-gen's
 `APT_MIRROR_RASPBERRYPI`) and the Debian mirror with `DEBIAN_MIRROR`. Use

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -266,6 +266,7 @@ APT_OPTS="-o Acquire::Retries=${APT_RETRIES} -o Acquire::http::Timeout=${APT_TIM
 APT_OPTS+=" -o APT::Install-Recommends=false -o APT::Install-Suggests=false"
 
 SKIP_MIRROR_REWRITE="${SKIP_MIRROR_REWRITE:-0}"
+APT_REWRITE_MIRROR="${APT_REWRITE_MIRROR:-https://mirror.fcix.net/raspbian/raspbian}"
 
 if [ "$SKIP_MIRROR_REWRITE" -ne 1 ]; then
   # --- Reliability hooks: mirror rewrites and proxy exceptions ---
@@ -275,12 +276,14 @@ if [ "$SKIP_MIRROR_REWRITE" -ne 1 ]; then
 #!/usr/bin/env bash
 set -euo pipefail
 shopt -s nullglob
-target="https://mirror.fcix.net/raspbian/raspbian"
+target="__APT_REWRITE_MIRROR__"
 for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
   [ -f "$f" ] || continue
   sed -i -E "s#https?://[^/[:space:]]+/raspbian#${target}#g" "$f" || true
 done
 EOSH
+  sed -i "s|__APT_REWRITE_MIRROR__|${APT_REWRITE_MIRROR}|g" \
+    stage0/00-configure-apt/files/usr/local/sbin/apt-rewrite-mirrors
   chmod +x stage0/00-configure-apt/files/usr/local/sbin/apt-rewrite-mirrors
   mkdir -p stage0/00-configure-apt/files/etc/apt/apt.conf.d
   cat > stage0/00-configure-apt/files/etc/apt/apt.conf.d/10-rewrite-mirrors <<'EOC'
@@ -300,12 +303,14 @@ EOP
 #!/usr/bin/env bash
 set -euo pipefail
 shopt -s nullglob
-target="https://mirror.fcix.net/raspbian/raspbian"
+target="__APT_REWRITE_MIRROR__"
 for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
   [ -f "$f" ] || continue
   sed -i -E "s#https?://[^/[:space:]]+/raspbian#${target}#g" "$f" || true
 done
 EOSH
+  sed -i "s|__APT_REWRITE_MIRROR__|${APT_REWRITE_MIRROR}|g" \
+    stage0/00-configure-apt/00-run-00-pre.sh
   chmod +x stage0/00-configure-apt/00-run-00-pre.sh
 
   # 4) Stage2 safeguard rewrite
@@ -314,13 +319,15 @@ EOSH
 #!/usr/bin/env bash
 set -euo pipefail
 shopt -s nullglob
-target="https://mirror.fcix.net/raspbian/raspbian"
+target="__APT_REWRITE_MIRROR__"
 for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
   [ -f "$f" ] || continue
   sed -i -E "s#https?://[^/[:space:]]+/raspbian#${target}#g" "$f" || true
 done
 apt-get -o Acquire::Retries=10 update || true
 EOSH
+  sed -i "s|__APT_REWRITE_MIRROR__|${APT_REWRITE_MIRROR}|g" \
+    stage2/00-configure-apt/01-run.sh
   chmod +x stage2/00-configure-apt/01-run.sh
 
   # 5) Export-image post-rewrite after 02-set-sources resets lists
@@ -329,13 +336,15 @@ EOSH
 #!/usr/bin/env bash
 set -euo pipefail
 shopt -s nullglob
-target="https://mirror.fcix.net/raspbian/raspbian"
+target="__APT_REWRITE_MIRROR__"
 for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
   [ -f "$f" ] || continue
   sed -i -E "s#https?://[^/[:space:]]+/raspbian#${target}#g" "$f" || true
 done
 apt-get -o Acquire::Retries=10 update || true
 EOSH
+  sed -i "s|__APT_REWRITE_MIRROR__|${APT_REWRITE_MIRROR}|g" \
+    export-image/02-set-sources/02-run.sh
   chmod +x export-image/02-set-sources/02-run.sh
 else
   echo "Skipping apt mirror rewrites"

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -136,11 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n"
-        "echo realpath should not be invoked >&2\n"
-        "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
what: make apt mirror rewrite target configurable via APT_REWRITE_MIRROR.
why: enable custom mirrors when fcix.net is unreachable.
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/

Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68c11bdd816c832fb5697899c34ed238