### PR TITLE
🔧: make pi_node_verifier optional

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -44,7 +44,8 @@ The script rewrites the Cloudflare apt source architecture to `armhf` when
 `ARM64=0` so 32-bit builds install the correct packages and sets `ARMHF=0` when
 `ARM64=1` to avoid generating both architectures.
 
-The image embeds `pi_node_verifier.sh` in `/usr/local/sbin` and clones the
+The image embeds `pi_node_verifier.sh` in `/usr/local/sbin` by default.
+Set `INSTALL_PI_NODE_VERIFIER=false` to omit the script. It also clones the
 `token.place` and `democratizedspace/dspace` (branch `v3`) repositories into
 `/opt/projects` by default. Set `CLONE_SUGARKUBE=true` to include this repo and
 pass space-separated Git URLs in `EXTRA_REPOS` to pull additional projects.

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -198,9 +198,12 @@ if [ -n "${TUNNEL_TOKEN:-}" ]; then
 fi
 
 
-# Bundle pi_node_verifier and optionally clone repos into the image
-install -Dm755 "${REPO_ROOT}/scripts/pi_node_verifier.sh" \
-  "${WORK_DIR}/pi-gen/stage2/02-sugarkube-tools/files/usr/local/sbin/pi_node_verifier.sh"
+# Optionally bundle pi_node_verifier and optionally clone repos into the image
+INSTALL_PI_NODE_VERIFIER="${INSTALL_PI_NODE_VERIFIER:-true}"
+if [[ "$INSTALL_PI_NODE_VERIFIER" == "true" ]]; then
+  install -Dm755 "${REPO_ROOT}/scripts/pi_node_verifier.sh" \
+    "${WORK_DIR}/pi-gen/stage2/02-sugarkube-tools/files/usr/local/sbin/pi_node_verifier.sh"
+fi
 
 CLONE_SUGARKUBE="${CLONE_SUGARKUBE:-false}"
 CLONE_TOKEN_PLACE="${CLONE_TOKEN_PLACE:-true}"

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -136,11 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n"
-        "echo realpath should not be invoked >&2\n"
-        "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
what: add INSTALL_PI_NODE_VERIFIER env to build script and docs
why: allow skipping verifier to keep images lean
how to test:
  pre-commit run --all-files
  pyspelling -c .spellcheck.yaml
  linkchecker --no-warnings README.md docs/
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c11bdd816c832fb5697899c34ed238