### PR TITLE
Guard projects service when systemd missing

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -48,6 +48,9 @@ The image embeds `pi_node_verifier.sh` in `/usr/local/sbin` and clones the
 `token.place` and `democratizedspace/dspace` (branch `v3`) repositories into
 `/opt/projects` by default. Set `CLONE_SUGARKUBE=true` to include this repo and
 pass space-separated Git URLs in `EXTRA_REPOS` to pull additional projects.
+`start-projects.sh` enables the optional `projects-compose` systemd unit on
+first boot and now checks for `systemctl`, skipping quietly when systemd isn't
+present.
 
 Set `TUNNEL_TOKEN` or `TUNNEL_TOKEN_FILE` to bake a Cloudflare token into
 `/opt/sugarkube/.cloudflared.env`; otherwise edit the file after boot.

--- a/scripts/cloud-init/start-projects.sh
+++ b/scripts/cloud-init/start-projects.sh
@@ -2,6 +2,12 @@
 set -euo pipefail
 
 svc="projects-compose.service"
+
+if ! command -v systemctl >/dev/null 2>&1; then
+  echo "systemctl not found; skipping ${svc}" >&2
+  exit 0
+fi
+
 if systemctl list-unit-files | grep -q "^${svc}"; then
   systemctl enable --now "${svc}"
 else

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -136,11 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n"
-        "echo realpath should not be invoked >&2\n"
-        "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
## Summary
- skip enabling projects-compose when systemd is absent
- document the start-projects helper in the Pi image guide

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c11bdd816c832fb5697899c34ed238