### PR TITLE
🧪: add pi_node_verifier edge case tests

### DIFF
--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -136,11 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n"
-        "echo realpath should not be invoked >&2\n"
-        "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(

--- a/tests/pi_node_verifier_json_test.bats
+++ b/tests/pi_node_verifier_json_test.bats
@@ -5,3 +5,34 @@
   [ "$status" -eq 0 ]
   echo "$output" | jq -e '.checks | length > 0' > /dev/null
 }
+
+@test "pi_node_verifier reports failing checks in JSON" {
+  tmp="$(mktemp -d)"
+  PATH="$tmp:$PATH"
+
+  cat <<'EOF' > "$tmp/cloud-init"
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$tmp/cloud-init"
+
+  cat <<'EOF' > "$tmp/timedatectl"
+#!/usr/bin/env bash
+echo "NTPSynchronized=no"
+exit 0
+EOF
+  chmod +x "$tmp/timedatectl"
+
+  cat <<'EOF' > "$tmp/iptables"
+#!/usr/bin/env bash
+echo "iptables v1.8.7 (legacy)"
+exit 0
+EOF
+  chmod +x "$tmp/iptables"
+
+  run "$BATS_TEST_DIRNAME/../scripts/pi_node_verifier.sh" --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.checks[] | select(.name=="cloud_init") | .status=="fail"' > /dev/null
+  echo "$output" | jq -e '.checks[] | select(.name=="time_sync") | .status=="fail"' > /dev/null
+  echo "$output" | jq -e '.checks[] | select(.name=="iptables_backend") | .status=="fail"' > /dev/null
+}

--- a/tests/pi_node_verifier_output_test.bats
+++ b/tests/pi_node_verifier_output_test.bats
@@ -47,3 +47,10 @@ EOF
   [[ "$output" == Usage:* ]]
   [[ "$output" == *"--json"* ]]
 }
+
+@test "pi_node_verifier rejects unknown options" {
+  run "$BATS_TEST_DIRNAME/../scripts/pi_node_verifier.sh" --bad-flag
+  [ "$status" -eq 1 ]
+  echo "$output" | grep "Unknown option: --bad-flag"
+  echo "$output" | grep "Usage:"
+}


### PR DESCRIPTION
## Summary
- cover pi_node_verifier unknown option handling
- assert failing statuses in pi_node_verifier JSON mode
- reformat collect_pi_image_inputs_test for latest black

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68c11c077e44832fab1e7597e84c4972