### PR TITLE
📝 : add dspace Dockerfile example

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -83,7 +83,18 @@ curl http://localhost:5000  # relay
 curl http://localhost:3000  # server
 ```
 
-### dspace
+### dspace (Dockerfile)
+
+```sh
+cd /opt/projects
+git clone https://github.com/democratizedspace/dspace
+cd dspace/frontend
+docker buildx build --platform linux/arm64 -t dspace-frontend . --load
+docker run -d --name dspace-frontend -p 3002:3002 dspace-frontend
+curl http://localhost:3002
+```
+
+### dspace (docker-compose)
 
 ```sh
 cd /opt/projects

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -136,11 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n"
-        "echo realpath should not be invoked >&2\n"
-        "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
## Summary
- document building and running dspace from a Dockerfile on the Pi image
- reformat test module to satisfy black

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c11c44056c832f8576d158d19855ee