### PR TITLE
📝 docs: add docker stats example

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -473,6 +473,7 @@ already supports arm64.
 - Stop a container: `docker stop tokenplace`.
 - Stop a compose stack: `docker compose down`.
 - View logs: `docker compose logs -f`.
+- Monitor CPU and memory: `docker stats tokenplace dspace`.
 - Remove a container: `docker rm tokenplace`.
 - Shut down a compose project: `docker compose down`.
 - Delete old images and networks: `docker system prune`.

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -136,11 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n"
-        "echo realpath should not be invoked >&2\n"
-        "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
what: document docker stats for token.place and dspace
why: help monitor container resource usage
test: pre-commit run --all-files
      pyspelling -c .spellcheck.yaml
      linkchecker --no-warnings README.md docs/
      git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68c11c44056c832f8576d158d19855ee