### PR TITLE
Ensure token.place and dspace env files exist on Pi image

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -49,13 +49,13 @@ dspace. To expose them through a Cloudflare Tunnel, update
 
 ### Environment variables
 
-Each project reads an `.env` file in its directory. `init-env.sh` scans
-`/opt/projects` for `*.env.example` files and copies them to `.env` when missing,
-letting containers start with sane defaults:
+Each project reads an `.env` file in its directory. `init-env.sh` creates them on
+first boot:
 
-- `/opt/projects/token.place/.env`
-- `/opt/projects/dspace/frontend/.env`
-- any additional repo that ships an `.env.example`
+- copies any `*.env.example` to `.env`
+- ensures blank files exist for token.place and dspace even if the repos omit
+  examples
+- handles any additional repo dropped into `/opt/projects`
 
 Edit these files with real values and restart the service.
 

--- a/scripts/cloud-init/init-env.sh
+++ b/scripts/cloud-init/init-env.sh
@@ -7,6 +7,11 @@ for example in **/.env.example; do
   [ -f "$target" ] || cp "$example" "$target"
 done
 
+# Ensure token.place and dspace have .env files even without examples
+for env_path in token.place/.env dspace/frontend/.env; do
+  [ -f "$env_path" ] || touch "$env_path"
+done
+
 # extra-start
 # Add additional environment setup steps below
 # extra-end

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -136,11 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n"
-        "echo realpath should not be invoked >&2\n"
-        "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
## Summary
- create blank env files for token.place and dspace so services start
- document env file creation and extension points for new repos
- format test helper to keep pre-commit green

## Testing
- `python3 -m pre_commit run --all-files`
- `python3 -m pyspelling -c .spellcheck.yaml`
- `/root/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c11bf6418c832fb8f6eadcc2cba0c9