### PR TITLE
docs: refine token.place and dspace compose setup

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -1,9 +1,9 @@
 # token.place and dspace Quickstart
 
-Build a Raspberry Pi 5 image that includes the
+Build a Raspberry Pi 5 image that includes the
 [token.place](https://github.com/futuroptimist/token.place) and
 [dspace](https://github.com/democratizedspace/dspace) repositories so you can run
-both apps out of the box. The image builder clones these projects, drops a
+both apps out of the box. The image builder clones these projects, drops a shared
 `docker-compose.yml` under `/opt/projects` and installs a single
 `projects-compose.service` to manage them. Each service uses `restart: unless-stopped`
 so the containers stay up across reboots. Hooks remain for additional repositories.
@@ -15,9 +15,11 @@ so the containers stay up across reboots. Hooks remain for additional repositori
 ./scripts/build_pi_image.sh
 ```
 
-`build_pi_image.sh` clones `token.place` and `dspace` by default. To skip either
-repo, set `CLONE_TOKEN_PLACE=false` or `CLONE_DSPACE=false`. Add more projects by
-passing their Git URLs via `EXTRA_REPOS`:
+`build_pi_image.sh` clones `token.place` and `dspace` by default. Adjust the stack before
+building by editing [`scripts/cloud-init/docker-compose.yml`](../scripts/cloud-init/docker-compose.yml)
+and dropping new services under the `# extra-start` marker. To skip cloning either
+repo, set `CLONE_TOKEN_PLACE=false` or `CLONE_DSPACE=false`. Add more projects by passing
+their Git URLs via `EXTRA_REPOS`:
 
 ```sh
 EXTRA_REPOS="https://github.com/example/repo.git" ./scripts/build_pi_image.sh
@@ -51,23 +53,24 @@ dspace. To expose them through a Cloudflare Tunnel, update
 
 Each project reads an `.env` file in its directory. `init-env.sh` scans
 `/opt/projects` for `*.env.example` files and copies them to `.env` when missing,
-letting containers start with sane defaults:
+letting containers start with sane defaults. Edit these files to set variables like
+`PORT`, API URLs or secrets:
 
 - `/opt/projects/token.place/.env`
 - `/opt/projects/dspace/frontend/.env`
 - any additional repo that ships an `.env.example`
 
-Edit these files with real values and restart the service.
+Update the placeholders with real values and restart the service:
 
 See each repository's README for the full list of configuration options.
 
 ## Extend with new repositories
 
-Pass Git URLs via `EXTRA_REPOS` to clone additional projects into
-`/opt/projects`. Add services to `/opt/projects/docker-compose.yml` (use the
-`# extra-start` marker) and extend `init-env.sh` with any new `.env` files,
-following the token.place and dspace examples. The image builder drops the
-token.place or dspace definitions when the corresponding `CLONE_*` flag is
-`false`, letting you build a minimal image and expand it later.
+Pass Git URLs via `EXTRA_REPOS` to clone additional projects into `/opt/projects`.
+Add services to `/opt/projects/docker-compose.yml` between `# extra-start` and
+`# extra-end`, and extend `init-env.sh` with any new `.env` files, following the
+token.place and dspace examples. The image builder drops the token.place or dspace
+definitions when the corresponding `CLONE_*` flag is `false`, letting you build a
+minimal image and expand it later.
 
 Use these hooks to experiment with other projects and grow the image over time.

--- a/docs/prompts-codex-pi-token-dspace.md
+++ b/docs/prompts-codex-pi-token-dspace.md
@@ -29,7 +29,7 @@ CONTEXT:
   [Compose](https://docs.docker.com/compose/install/linux/)).
 - First-boot cloud-init configs and Compose manifests:
   [`scripts/cloud-init/`](../scripts/cloud-init/) (for example,
-  [`docker-compose.projects.yml`](../scripts/cloud-init/docker-compose.projects.yml)).
+  [`docker-compose.yml`](../scripts/cloud-init/docker-compose.yml)).
 - Upstream apps:
   - [token.place](https://github.com/futuroptimist/token.place) — see its
     [README](https://github.com/futuroptimist/token.place#readme) for service details.

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -70,7 +70,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CLOUD_INIT_DIR="${CLOUD_INIT_DIR:-${REPO_ROOT}/scripts/cloud-init}"
 CLOUD_INIT_PATH="${CLOUD_INIT_PATH:-${CLOUD_INIT_DIR}/user-data.yaml}"
 CLOUDFLARED_COMPOSE_PATH="${CLOUDFLARED_COMPOSE_PATH:-${CLOUD_INIT_DIR}/docker-compose.cloudflared.yml}"
-PROJECTS_COMPOSE_PATH="${PROJECTS_COMPOSE_PATH:-${CLOUD_INIT_DIR}/docker-compose.projects.yml}"
+PROJECTS_COMPOSE_PATH="${PROJECTS_COMPOSE_PATH:-${CLOUD_INIT_DIR}/docker-compose.yml}"
 START_PROJECTS_PATH="${START_PROJECTS_PATH:-${CLOUD_INIT_DIR}/start-projects.sh}"
 INIT_ENV_PATH="${INIT_ENV_PATH:-${CLOUD_INIT_DIR}/init-env.sh}"
 
@@ -208,7 +208,7 @@ CLONE_DSPACE="${CLONE_DSPACE:-true}"
 EXTRA_REPOS="${EXTRA_REPOS:-}"
 
 # Prepare compose file for token.place and dspace; drop services when skipped
-PROJECTS_COMPOSE_TEMP="${WORK_DIR}/docker-compose.projects.yml"
+PROJECTS_COMPOSE_TEMP="${WORK_DIR}/docker-compose.yml"
 cp "${PROJECTS_COMPOSE_PATH}" "${PROJECTS_COMPOSE_TEMP}"
 if [[ "$CLONE_TOKEN_PLACE" != "true" ]]; then
   sed -i '/# tokenplace-start/,/# tokenplace-end/d' "${PROJECTS_COMPOSE_TEMP}"

--- a/scripts/cloud-init/docker-compose.yml
+++ b/scripts/cloud-init/docker-compose.yml
@@ -1,3 +1,4 @@
+# token.place and dspace services; extend via # extra-start markers
 version: '3'
 services:
   # tokenplace-start

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -455,8 +455,8 @@ def _run_build_script(tmp_path, env):
     compose_src = cloud_init_src / "docker-compose.cloudflared.yml"
     shutil.copy(compose_src, ci_dir / "docker-compose.cloudflared.yml")
 
-    projects_src = cloud_init_src / "docker-compose.projects.yml"
-    shutil.copy(projects_src, ci_dir / "docker-compose.projects.yml")
+    projects_src = cloud_init_src / "docker-compose.yml"
+    shutil.copy(projects_src, ci_dir / "docker-compose.yml")
 
     start_projects_src = cloud_init_src / "start-projects.sh"
     start_projects_dest = ci_dir / "start-projects.sh"

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -136,11 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n"
-        "echo realpath should not be invoked >&2\n"
-        "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
## Summary
- rename projects compose manifest to docker-compose.yml
- document env hooks and extension points for new repos
- adjust build script and tests for new compose path

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c11bf6418c832fb8f6eadcc2cba0c9