### PR TITLE
docs: clarify CAD prompt tooling instructions

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -19,8 +19,8 @@ CONTEXT:
 - [`scripts/openscad_render.sh`](../scripts/openscad_render.sh) wraps
   `openscad -o stl/... --export-format binstl`. Run it from the repository root so meshes land
   in the git-ignored [`stl/`](../stl/) directory (see [`.gitignore`](../.gitignore)). Ensure
-  [OpenSCAD](https://openscad.org/) is installed and on `PATH`; the script exits early if the
-  binary is missing.
+  [OpenSCAD](https://openscad.org/) is installed and available on `PATH`; the script fails fast
+  if the binary is missing.
 - The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these
   models as artifacts. Do not commit `.stl` files.
 - Render each model in all supported `standoff_mode` variants—e.g., `heatset`, `printed`, or
@@ -29,10 +29,10 @@ CONTEXT:
   cause the render script to exit with an error.
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
 - Inspect [`.github/workflows/`](../.github/workflows/) to see which checks run in CI.
-- Run `pre-commit run --all-files` to lint, format, and test via
+- Run `pre-commit run --all-files` from the repository root to lint, format, and test via
   [`scripts/checks.sh`](../scripts/checks.sh).
-- If a Node toolchain is present (`package.json` exists), also run:
-  - `npm ci`
+- If a Node toolchain is present (`package.json` exists), first run `npm ci` to install
+  dependencies, then run:
   - `npm run lint`
   - `npm run test:ci`
 - For documentation updates, also run:
@@ -40,8 +40,8 @@ CONTEXT:
     [`.spellcheck.yaml`](../.spellcheck.yaml))
   - `linkchecker --no-warnings README.md docs/` to verify links in
     [`README.md`](../README.md) and [`docs/`](../docs/)
-- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` before
-  committing.
+- Scan staged changes for secrets before committing using
+  `git diff --cached | ./scripts/scan-secrets.py`.
 - Log tool failures in [`outages/`](../outages/) using
   [`outages/schema.json`](../outages/schema.json).
 

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -136,11 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n"
-        "echo realpath should not be invoked >&2\n"
-        "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
## Summary
- clarify OpenSCAD and Node toolchain steps in CAD prompt
- format collect_pi_image_inputs_test.py to satisfy pre-commit

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c11c614c94832f9559a838e069137f