### PR TITLE
docs: clarify CAD prompt checks

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -71,14 +71,19 @@ SYSTEM:
 You are an automated contributor for the sugarkube repository.
 Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
 Run `pre-commit run --all-files`.
+
 If `package.json` defines them, also run:
+
 - `npm ci`
 - `npm run lint`
 - `npm run test:ci`
+
 Then run:
+
 - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; see
   [`.spellcheck.yaml`](../.spellcheck.yaml))
-- `linkchecker --no-warnings README.md docs/`
+- `linkchecker --no-warnings README.md docs/` (install via
+  `pip install linkchecker`)
 - `git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 USER:

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -136,11 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n"
-        "echo realpath should not be invoked >&2\n"
-        "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
## Summary
- document linkchecker installation in CAD prompt
- format test script to satisfy Black

## Testing
- `npm ci` *(fails: The `npm ci` command can only install with an existing package-lock.json or npm-shrinkwrap.json)*
- `npm run lint` *(fails: Could not read package.json)*
- `npm run test:ci` *(fails: Could not read package.json)*
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c11c530cb0832f9d107d98e7387821