### PR TITLE
📝 : clarify spellcheck prompt instructions

### DIFF
--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -16,7 +16,7 @@ Keep Markdown documentation free of spelling errors.
 
 CONTEXT:
 - Run `pyspelling -c .spellcheck.yaml` to scan `README.md` and `docs/`
-  (requires `aspell` and `aspell-en`).
+  (requires the `aspell` and `aspell-en` packages).
 - Add legitimate new words to [`.wordlist.txt`](../.wordlist.txt).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
 - Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../scripts/checks.sh) for
@@ -44,6 +44,7 @@ You are an automated contributor for the sugarkube repository.
 Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
 Run `pre-commit run --all-files`.
 If `package.json` defines them, also run:
+- `npm ci`
 - `npm run lint`
 - `npm run test:ci`
 Then run:


### PR DESCRIPTION
what: document npm ci step and clarify aspell dependencies
why: keep prompt instructions aligned with repository practices
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68c11c530cb0832f9d107d98e7387821