### PR TITLE
📝: include npm ci in docs prompt instructions

### DIFF
--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -21,6 +21,7 @@ CONTEXT:
 - Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../scripts/checks.sh) for
   linting, formatting, and tests.
 - If a Node toolchain is present (`package.json` exists), also run:
+  - `npm ci`
   - `npm run lint`
   - `npm run test:ci`
   For documentation changes, also run:
@@ -36,7 +37,7 @@ REQUEST:
 3. Re-run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`,
    `linkchecker --no-warnings README.md docs/`, and
    `git diff --cached | ./scripts/scan-secrets.py`.
-   If `package.json` exists, also run `npm run lint` and `npm run test:ci`.
+   If `package.json` exists, also run `npm ci`, `npm run lint`, and `npm run test:ci`.
    Confirm all checks pass.
 
 OUTPUT:
@@ -54,6 +55,7 @@ You are an automated contributor for the sugarkube repository.
 Follow [AGENTS.md](../AGENTS.md) and [README.md](../README.md).
 Run `pre-commit run --all-files`.
 If a Node toolchain exists, also run:
+- `npm ci`
 - `npm run lint`
 - `npm run test:ci`
 Then run `pyspelling -c .spellcheck.yaml`,

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -136,11 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n"
-        "echo realpath should not be invoked >&2\n"
-        "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
## Summary
- clarify Node instructions in docs prompt
- format collect_pi_image_inputs_test.py

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c11bdfce34832fafe5311affa1b8c3