### PR TITLE
📝 : clarify codex prompt context and references

### DIFF
--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -16,20 +16,25 @@ PURPOSE:
 Keep the project healthy by making small, well-tested improvements.
 
 CONTEXT:
+- Sugarkube automates a Pi-based k3s cluster; see [`README.md`](../README.md).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md); for
   instruction semantics see the [AGENTS.md spec](https://agentsmd.net/AGENTS.md).
 - Run `pre-commit run --all-files`, which executes
   [`scripts/checks.sh`](../scripts/checks.sh) to install tooling and run
-  linters, tests, and documentation checks.
+  linters, tests, and documentation checks. Pre-commit is configured via
+  [`.pre-commit-config.yaml`](../.pre-commit-config.yaml).
 - If a Node toolchain is present (`package.json` exists), also run:
   - `npm ci`
   - `npm run lint`
   - `npm run test:ci`
 - When documentation files (`README.md` or anything under
   [`docs/`](../docs/)) change, additionally run:
-  - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
+  - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; config in
+    [`.spellcheck.yaml`](../.spellcheck.yaml)). Add new words to
+    [`.wordlist.txt`](../.wordlist.txt).
   - `linkchecker --no-warnings README.md docs/`
 - Scan staged changes for secrets with
+  [`scripts/scan-secrets.py`](../scripts/scan-secrets.py) via
   `git diff --cached | ./scripts/scan-secrets.py` before committing.
 - Log persistent failures in [`outages/`](../outages/) as JSON per
   [`outages/schema.json`](../outages/schema.json).
@@ -38,7 +43,7 @@ REQUEST:
 1. Identify a small bug fix or documentation clarification.
 2. Implement the change following the project's existing style.
 3. Update relevant documentation when needed.
-4. Run `pre-commit run --all-files` after changes.
+4. Run all checks above and ensure they pass.
 
 OUTPUT:
 A pull request describing the change and summarizing test results.

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -136,11 +136,7 @@ def test_succeeds_when_realpath_missing(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_realpath = fake_bin / "realpath"
-    fake_realpath.write_text(
-        "#!/bin/sh\n"
-        "echo realpath should not be invoked >&2\n"
-        "exit 1\n"
-    )
+    fake_realpath.write_text("#!/bin/sh\n" "echo realpath should not be invoked >&2\n" "exit 1\n")
     fake_realpath.chmod(0o755)
 
     result = _run_script(


### PR DESCRIPTION
what: clarify codex prompt links and context; format test file
why: keep instructions current and satisfy linters
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py


------
https://chatgpt.com/codex/tasks/task_e_68c11c05109c832f9736210e0bd72366