### PR TITLE
📝 : – clarify docs prompt instructions

### DIFF
--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -15,15 +15,12 @@ PURPOSE:
 Keep the documentation clear and accurate.
 
 CONTEXT:
-- Docs live in [`docs/`](../docs/).
+- Docs live in [`docs/`](./).
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for style,
   testing, and repository conventions.
 - Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../scripts/checks.sh) for
-  linting, formatting, and tests.
-- If a Node toolchain is present (`package.json` exists), also run:
-  - `npm ci`
-  - `npm run lint`
-  - `npm run test:ci`
+  linting, formatting, and tests. If `package.json` exists, the script automatically
+  runs `npm ci`, `npm run lint`, and `npm run test:ci`.
 - For documentation changes, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; see
     [`.spellcheck.yaml`](../.spellcheck.yaml))
@@ -37,12 +34,7 @@ REQUEST:
 2. Improve wording, fix links, or add missing steps.
 3. Re-run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`,
    `linkchecker --no-warnings README.md docs/`, and
-   `git diff --cached | ./scripts/scan-secrets.py`.
-   If `package.json` exists, also run:
-   - `npm ci`
-   - `npm run lint`
-   - `npm run test:ci`
-   Confirm all checks pass.
+   `git diff --cached | ./scripts/scan-secrets.py`. Confirm all checks pass.
 
 OUTPUT:
 A pull request with the refined documentation and passing checks.
@@ -57,13 +49,11 @@ Use this prompt to refine sugarkube's own prompt documentation.
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
 Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
-Run `pre-commit run --all-files`.
-If a Node toolchain exists, also run:
-- `npm ci`
-- `npm run lint`
-- `npm run test:ci`
-Then run `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; see
-[`.spellcheck.yaml`](../.spellcheck.yaml)), `linkchecker --no-warnings README.md docs/`, and
+Run `pre-commit run --all-files` (invokes [`scripts/checks.sh`](../scripts/checks.sh) for
+linting, formatting, and tests; it automatically runs `npm ci`, `npm run lint`, and
+`npm run test:ci` when `package.json` exists). Then run `pyspelling -c .spellcheck.yaml`
+(requires `aspell` and `aspell-en`; see [`.spellcheck.yaml`](../.spellcheck.yaml)),
+`linkchecker --no-warnings README.md docs/`, and
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 USER:


### PR DESCRIPTION
what: refresh docs prompt to link docs folder correctly and note that scripts/checks.sh auto-runs npm checks when package.json is present
why: keep prompt aligned with current tooling and references
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68c25f2be7e8832f87abeadf2a0adb18