### PR TITLE
📝 : tidy word list

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1,4 +1,3 @@
-< htmlcontent >
 AES
 AGM
 AWG
@@ -126,7 +125,6 @@ github
 heatmap
 heatset
 hostname
-htmlcontent
 http
 https
 idempotency


### PR DESCRIPTION
what: remove stray placeholder from .wordlist.txt so spell checks use only
  valid terms
why: keep documentation spell list accurate
how to test: pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/;
  pre-commit run --all-files
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68c25ee654cc832f936dccecdc1dbea3