### PR TITLE
docs: include doc lint deps in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ git clone https://github.com/futuroptimist/sugarkube.git
 # or with SSH:
 # git clone git@github.com:futuroptimist/sugarkube.git
 cd sugarkube
-pip install pre-commit
+pip install pre-commit pyspelling linkchecker
 pre-commit install
 pre-commit run --all-files
 ```


### PR DESCRIPTION
## Summary
- document installing pyspelling and linkchecker alongside pre-commit

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c25e62f494832f93c270dbb0ee2db4