### PR TITLE
📝 : Capitalize Pre-commit in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pre-commit run --all-files
 
 If you update documentation, install spell-check tools and verify spelling and links.
 `pyspelling` relies on `aspell` and an English dictionary (`aspell-en`). The
-`scripts/checks.sh` helper tries to install them via `apt-get` when missing. pre-commit
+`scripts/checks.sh` helper tries to install them via `apt-get` when missing. Pre-commit
 runs these checks and fails if spelling or links are broken:
 
 ```bash


### PR DESCRIPTION
what: capitalize "Pre-commit" in README instructions
why: keep documentation style consistent
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c25e62f494832f93c270dbb0ee2db4