### PR TITLE
📝 : pluralize extrusion reference in index doc

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 Welcome to **sugarkube**, a solar-powered off-grid platform for Raspberry Pis and aquarium aeration.
 This repo tracks CAD models, electronics schematics, and documentation
 so anyone can replicate the setup.
-Greenery is encouraged around the cube. Vines can climb the extrusion while
+Greenery is encouraged around the cube. Vines can climb the extrusions while
 herbs and shade-loving plants enjoy the cover of the solar panels.
 
 ![solar cube](images/solar_cube.jpg)


### PR DESCRIPTION
what: fix grammar in docs/index.md
why: mention cube has multiple extrusions
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c25f2aa334832fbf1c71086621cbb2