### PR TITLE
Support Bash 3 in OpenSCAD renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ The helper script validates that the provided `.scad` file exists and that
 OpenSCAD is available in `PATH`, printing a helpful error if either check fails.
 It separates options from the file path with `--` and handles filenames
 that begin with a dash, whether absolute or relative.
-The `.scad` extension is matched case-insensitively, so `MODEL.SCAD` works too.
+The `.scad` extension is matched case-insensitively without Bash 4 features, so
+`MODEL.SCAD` works even on macOS default Bash 3.2.
 
 ## Community
 

--- a/scripts/openscad_render.sh
+++ b/scripts/openscad_render.sh
@@ -12,20 +12,34 @@ if [ ! -f "$FILE" ]; then
   exit 1
 fi
 ext="${FILE##*.}"
-if [[ "${ext,,}" != scad ]]; then
-  echo "Expected .scad file: $FILE" >&2
-  exit 1
-fi
+# Pattern match for extension to support Bash 3 without `${var,,}`
+case "$ext" in
+  [Ss][Cc][Aa][Dd]) ;;
+  *)
+    echo "Expected .scad file: $FILE" >&2
+    exit 1
+    ;;
+esac
 
 base=$(basename -- "$FILE" ".$ext")
 mode_suffix=""
 standoff_mode=""
 if [ -n "${STANDOFF_MODE:-}" ]; then
-  standoff_mode="$(printf '%s' "${STANDOFF_MODE,,}" | xargs)"
+  # Trim and normalize without Bash 4 string lowering
+  standoff_mode="$(printf '%s' "$STANDOFF_MODE" | xargs)"
   if [ -n "$standoff_mode" ]; then
     case "$standoff_mode" in
-      heatset|printed|nut)
-        mode_suffix="_$standoff_mode"
+      [Hh][Ee][Aa][Tt][Ss][Ee][Tt])
+        standoff_mode="heatset"
+        mode_suffix="_heatset"
+        ;;
+      [Pp][Rr][Ii][Nn][Tt][Ee][Dd])
+        standoff_mode="printed"
+        mode_suffix="_printed"
+        ;;
+      [Nn][Uu][Tt])
+        standoff_mode="nut"
+        mode_suffix="_nut"
         ;;
       *)
         echo "Invalid STANDOFF_MODE: $STANDOFF_MODE (expected 'heatset', 'printed', or 'nut')" >&2


### PR DESCRIPTION
## Summary
- drop Bash 4 string lowering in `openscad_render.sh`
- note Bash 3 compatibility in README
## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c25f2aa334832fbf1c71086621cbb2