### PR TITLE
🐛 : escape Cloudflare tunnel tokens in build script

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -57,7 +57,8 @@ On first boot `init-env.sh` copies each project's `.env.example` to `.env` and
 sets its mode to `0600` so secrets stay private.
 
 Set `TUNNEL_TOKEN` or `TUNNEL_TOKEN_FILE` to bake a Cloudflare token into
-`/opt/sugarkube/.cloudflared.env`; otherwise edit the file after boot.
+`/opt/sugarkube/.cloudflared.env`; tokens containing `/` or `&` are escaped
+automatically. Otherwise edit the file after boot.
 Cloud-init writes `docker-compose.cloudflared.yml` to `/opt/sugarkube`.
 This avoids downloading the file at boot.
 The image installs a `cloudflared-compose` systemd unit which starts the tunnel via Docker

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -194,7 +194,8 @@ fi
 # Embed Cloudflare token if available
 if [ -n "${TUNNEL_TOKEN:-}" ]; then
   echo "Embedding Cloudflare token into cloud-init"
-  sed -i "s|TUNNEL_TOKEN=\"\"|TUNNEL_TOKEN=\"${TUNNEL_TOKEN}\"|" "${USER_DATA}"
+  escaped_token=$(printf '%s\n' "${TUNNEL_TOKEN}" | sed -e 's/[\/&]/\\&/g')
+  sed -i "s|TUNNEL_TOKEN=\"\"|TUNNEL_TOKEN=\"${escaped_token}\"|" "${USER_DATA}"
 fi
 
 


### PR DESCRIPTION
## Summary
- escape '/' and '&' in TUNNEL_TOKEN before sed
- document automatic token escaping for Cloudflare tunnel

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`

------
https://chatgpt.com/codex/tasks/task_e_68c25e89eaa0832fb82c8ee40f189d5c