### PR TITLE
🧪 : add skip-case test for pi_node_verifier

### DIFF
--- a/tests/pi_node_verifier_skip_test.bats
+++ b/tests/pi_node_verifier_skip_test.bats
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats
+
+@test "pi_node_verifier skips missing tools" {
+  tmp="$(mktemp -d)"
+  ln -s "$(command -v bash)" "$tmp/bash"
+  ln -s "$(command -v grep)" "$tmp/grep"
+  PATH="$tmp" run "$BATS_TEST_DIRNAME/../scripts/pi_node_verifier.sh"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep "cloud_init: skip"
+  echo "$output" | grep "time_sync: skip"
+  echo "$output" | grep "iptables_backend: skip"
+  echo "$output" | grep "k3s_check_config: skip"
+}


### PR DESCRIPTION
what: add Bats test ensuring pi_node_verifier skips checks when tools absent
why: cover previously untested skip paths to prevent regressions
how to test:
 - pre-commit run --all-files
 - pyspelling -c .spellcheck.yaml
 - linkchecker --no-warnings README.md docs/
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c25ef8fc84832f9d774fdac7c616c9