### PR TITLE
📝 docs: refine Docker repo prompt instructions

### DIFF
--- a/docs/prompts-codex-docker-repo.md
+++ b/docs/prompts-codex-docker-repo.md
@@ -13,13 +13,19 @@ You are an automated contributor for the sugarkube repository.
 
 PURPOSE:
 Write step-by-step instructions for running a GitHub repo that includes a
-Dockerfile or docker-compose file on the prepared Raspberry Pi image.
+Dockerfile or Docker Compose file (`docker-compose.yml` or `compose.yml`) on the
+prepared Raspberry Pi image.
 
 CONTEXT:
 - The base image and tunnel setup live in [`pi_image_cloudflare.md`](./pi_image_cloudflare.md).
 - New walkthroughs belong in [`docker_repo_walkthrough.md`](./docker_repo_walkthrough.md).
-- Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires
-  `aspell` and `aspell-en`), `linkchecker --no-warnings README.md docs/`, and
+- Run `pre-commit run --all-files`.
+- If a Node toolchain is present (`package.json` exists), also run:
+  - `npm ci`
+  - `npm run lint`
+  - `npm run test:ci`
+- Run `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`),
+  `linkchecker --no-warnings README.md docs/`, and
   `git diff --cached | ./scripts/scan-secrets.py` before committing.
 - File recurring deployment failures in [`outages/`](../outages/) per
   [`outages/schema.json`](../outages/schema.json).


### PR DESCRIPTION
what: clarify Docker Compose wording and add Node toolchain steps
why: keep prompt instructions aligned with repository standards
how to test: pre-commit run --all-files
  pyspelling -c .spellcheck.yaml
  linkchecker --no-warnings README.md docs/
  git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68c25ef4ba00832f96eb056125f0825c