### PR TITLE
codex: document Docker repo usage for Pi services

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -7,6 +7,7 @@ both apps out of the box. The image builder clones these projects, drops a share
 `docker-compose.yml` under `/opt/projects` and installs a single
 `projects-compose.service` to manage them. Each service uses `restart: unless-stopped`
 so the containers stay up across reboots. Hooks remain for additional repositories.
+Docker Engine and the Compose plugin come from Docker's Debian repository for up-to-date ARM builds.
 
 ## Build the image
 
@@ -14,6 +15,14 @@ so the containers stay up across reboots. Hooks remain for additional repositori
 # inside the sugarkube repo
 ./scripts/build_pi_image.sh
 ```
+
+### Build-time flags
+
+The build script accepts environment variables to trim or extend the stack:
+
+- `CLONE_TOKEN_PLACE` (default `true`) — clone the `token.place` repository.
+- `CLONE_DSPACE` (default `true`) — clone the `dspace` repository.
+- `EXTRA_REPOS` — space-separated Git URLs for additional projects.
 
 `build_pi_image.sh` clones `token.place` and `dspace` by default. Adjust the stack before
 building by editing [`scripts/cloud-init/docker-compose.yml`](../scripts/cloud-init/docker-compose.yml)

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -3,16 +3,26 @@ package_update: true
 package_upgrade: true
 apt:
   sources:
+    docker:
+      # Official Docker repository for Engine and Compose
+      source: "deb [arch=arm64] https://download.docker.com/linux/debian bookworm stable"
+      keyid: 8D81803C0EBFCD88
+      keyserver: https://keyserver.ubuntu.com
     cloudflare:
       source: "deb [arch=arm64] https://pkg.cloudflare.com/ bookworm main"
       keyid: FBA8C0EE63617C5EED695C43254B391D8CACCBF8
       keyserver: https://keyserver.ubuntu.com
 packages:
-  - docker.io
-  - docker-compose-plugin
+  - ca-certificates
   - curl
+  - gnupg
   - git
   - cloudflared
+  - docker-ce
+  - docker-ce-cli
+  - containerd.io
+  - docker-buildx-plugin
+  - docker-compose-plugin
 write_files:
   - path: /opt/sugarkube/.cloudflared.env
     permissions: '0600'


### PR DESCRIPTION
## Summary
- install Docker Engine and Compose from Docker's Debian repo
- document build-time flags for token.place and dspace image
- note official Docker apt source in cloud-init

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c25eaa2884832fbc6d74b4be010ebe