### PR TITLE
📝 : sync CAD prompt with current npm tasks

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -35,7 +35,8 @@ CONTEXT:
 - If a Node toolchain is present (`package.json` exists), first run `npm ci` to install
   dependencies, then run:
   - `npm run lint`
-  - `npm run test:ci`
+  - `npm run format:check`
+  - `npm test -- --coverage`
 - For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; see
     [`.spellcheck.yaml`](../.spellcheck.yaml))
@@ -77,7 +78,8 @@ If `package.json` defines them, also run:
 
 - `npm ci`
 - `npm run lint`
-- `npm run test:ci`
+- `npm run format:check`
+- `npm test -- --coverage`
 
 Then run:
 


### PR DESCRIPTION
what: include format:check and coverage steps in CAD prompt
why: match scripts/checks.sh workflow
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml;
  linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68c25e77c7a4832f9dbdc099850898a5