### PR TITLE
🛠️: generalize env file init for compose services

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -53,15 +53,9 @@ dspace. To expose them through a Cloudflare Tunnel, update
 
 Each project reads an `.env` file in its directory. `init-env.sh` scans
 `/opt/projects` for `*.env.example` files and copies them to `.env` when missing,
-letting containers start with sane defaults. Edit these files to set variables like
-`PORT`, API URLs or secrets:
-
-- copies any `*.env.example` to `.env`
-- ensures blank files exist for token.place and dspace even if the repos omit
-  examples
-- handles any additional repo dropped into `/opt/projects`
-
-Update the placeholders with real values and restart the service:
+then parses `docker-compose.yml` to create blank env files for any service that
+references one. Edit these files to set variables like `PORT`, API URLs or
+secrets. Update the placeholders with real values and restart the service.
 
 See each repository's README for the full list of configuration options.
 
@@ -69,8 +63,8 @@ See each repository's README for the full list of configuration options.
 
 Pass Git URLs via `EXTRA_REPOS` to clone additional projects into `/opt/projects`.
 Add services to `/opt/projects/docker-compose.yml` between `# extra-start` and
-`# extra-end`, and extend `init-env.sh` with any new `.env` files, following the
-token.place and dspace examples. The image builder drops the token.place or dspace
+`# extra-end`; `init-env.sh` will automatically create any env files those
+services reference. The image builder drops the token.place or dspace
 definitions when the corresponding `CLONE_*` flag is `false`, letting you build a
 minimal image and expand it later.
 

--- a/scripts/cloud-init/docker-compose.yml
+++ b/scripts/cloud-init/docker-compose.yml
@@ -4,23 +4,23 @@ services:
   # tokenplace-start
   tokenplace:
     build:
-      context: /opt/projects/token.place
+      context: ./token.place
       dockerfile: docker/Dockerfile.server
     ports:
       - "5000:5000"
     env_file:
-      - /opt/projects/token.place/.env
+      - token.place/.env
     restart: unless-stopped
   # tokenplace-end
   # dspace-start
   dspace:
     build:
-      context: /opt/projects/dspace/frontend
+      context: ./dspace/frontend
     working_dir: /opt/projects/dspace/frontend
     ports:
       - "3000:3000"
     env_file:
-      - /opt/projects/dspace/frontend/.env
+      - dspace/frontend/.env
     restart: unless-stopped
   # dspace-end
   # extra-start

--- a/scripts/cloud-init/init-env.sh
+++ b/scripts/cloud-init/init-env.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+compose_dir="$(cd "$(dirname "$0")" && pwd)"
+compose_file="${compose_dir}/docker-compose.yml"
+
+# Copy any *.env.example to .env and secure permissions
 shopt -s globstar nullglob
-for example in **/.env.example; do
+for example in "${compose_dir}"/**/.env.example; do
   target="${example%.example}"
   if [ ! -f "$target" ]; then
     cp "$example" "$target"
@@ -10,12 +14,29 @@ for example in **/.env.example; do
   fi
 done
 
-# Ensure token.place and dspace have .env files even without examples
-for env_path in token.place/.env dspace/frontend/.env; do
-  dir="$(dirname "$env_path")"
-  [ -d "$dir" ] || continue
-  [ -f "$env_path" ] || touch "$env_path"
-done
+# Touch env files referenced in docker-compose.yml so services start with defaults
+if [ -f "$compose_file" ]; then
+  in_env=0
+  while IFS= read -r line; do
+    if [[ $line =~ env_file: ]]; then
+      in_env=1
+      continue
+    fi
+    if [[ $in_env -eq 1 ]]; then
+      if [[ $line =~ ^[[:space:]]*-[[:space:]]*(.*) ]]; then
+        env_file="${BASH_REMATCH[1]}"
+        env_path="$env_file"
+        [[ $env_path != /* ]] && env_path="${compose_dir}/${env_path}"
+        dir="$(dirname "$env_path")"
+        [ -d "$dir" ] || mkdir -p "$dir"
+        [ -f "$env_path" ] || touch "$env_path"
+        chmod 600 "$env_path"
+      else
+        in_env=0
+      fi
+    fi
+  done <"$compose_file"
+fi
 
 # extra-start
 # Add additional environment setup steps below


### PR DESCRIPTION
what: auto-create env files for compose services and update docs.
why: token.place and dspace start with defaults; easier to extend image.
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68c25eaa2884832fbc6d74b4be010ebe