### PR TITLE
🔌: document power ring orientation fiducials

### DIFF
--- a/elex/power_ring/power_ring.kicad_pcb
+++ b/elex/power_ring/power_ring.kicad_pcb
@@ -10,6 +10,7 @@
         (title_block
                 (comment 1 "Keep high-current traces short")
                 (comment 2 "Confirm board outline fits enclosure")
+                (comment 3 "Add fiducial markers for board orientation.")
         )
         (layers
                 (0 "F.Cu" signal)

--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -10,6 +10,7 @@
                 (comment 3 "Label polarity and voltage on connectors")
                 (comment 4 "Use star topology for power distribution to minimize voltage drop")
                 (comment 5 "Use thick traces for high-current paths")
+                (comment 6 "Add fiducial markers for board orientation")
         )
         (lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/elex/power_ring/specs.md
+++ b/elex/power_ring/specs.md
@@ -18,6 +18,7 @@ The design may evolve as the project grows.
 
 - Test points for measuring battery voltage
 - Silkscreen labels for polarity and connector numbers
+- Fiducial markers to indicate board orientation for easier assembly
 - Title block comments record decoupling guidelines, high-current trace layout, thick traces
   for high-current paths, connector labeling, export checks, ground pour continuity around
   mounting holes, board outline fit, BOM validation, clearance rules for high-voltage nets,

--- a/outages/2025-09-11-kicad-export-pcbnew-missing.json
+++ b/outages/2025-09-11-kicad-export-pcbnew-missing.json
@@ -1,0 +1,10 @@
+{
+  "id": "kicad-export-pcbnew-missing",
+  "date": "2025-09-11",
+  "component": "kicad-export",
+  "rootCause": "KiCad not installed; pcbnew Python module not found",
+  "resolution": "Install KiCad 9 and ensure pcbnew is available via PYTHONPATH",
+  "references": [
+    "kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml"
+  ]
+}


### PR DESCRIPTION
## Summary
- note orientation fiducials in schematic and PCB title blocks
- mention fiducials in power ring specs
- record pcbnew module outage blocking KiBot export

## Testing
- ⚠️ `npm run lint` (package.json missing)
- ⚠️ `npm run test:ci` (package.json missing)
- ✅ `pre-commit run --all-files`
- ✅ `pyspelling -c .spellcheck.yaml`
- ✅ `linkchecker --no-warnings README.md docs/`
- ⚠️ `kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml` (pcbnew module not found)
- ✅ `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c25e79066c832f93e0b56b9c24026e