### PR TITLE
📝: refresh linkchecker install guidance in CAD prompt

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -83,8 +83,8 @@ Then run:
 
 - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; see
   [`.spellcheck.yaml`](../.spellcheck.yaml))
-- `linkchecker --no-warnings README.md docs/` (install via
-  `pip install linkchecker`)
+- `linkchecker --no-warnings README.md docs/` (requires `linkchecker`; install with
+  `pipx install linkchecker` if needed)
 - `git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 USER:


### PR DESCRIPTION
what: steer CAD prompt toward pipx for installing linkchecker
why: keep docs aligned with current dependency practice
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c25e94451c832f87fa2259f73d1ce2