### PR TITLE
📝 : add bind mount example to Docker walkthrough

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -221,6 +221,33 @@ docker volume ls | grep dspace-data
 ```
 
 Adjust container paths to match each project's documentation.
+### Develop with bind mounts
+
+Mount the source tree into a container to test changes without rebuilding images.
+
+- token.place:
+
+```sh
+cd /opt/projects/token.place
+docker run -d --name tokenplace-dev -p 5000:5000 -v "$(pwd)":/app tokenplace
+docker exec -it tokenplace-dev python -m pytest
+```
+
+- dspace frontend:
+
+```sh
+cd /opt/projects/dspace/frontend
+docker compose run --service-ports -v "$(pwd)":/app frontend npm test -- --watch
+```
+
+Stop the containers when finished:
+
+```sh
+docker stop tokenplace-dev
+docker compose down
+```
+
+
 
 Proceed with the detailed steps below to adapt the process for other repositories.
 


### PR DESCRIPTION
what: expand docker_repo_walkthrough.md with bind mount instructions for token.place and dspace.
why: demonstrate live code iteration on the Raspberry Pi image.
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/; git diff --cached | ./scripts/scan-secrets.py.
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c25e6a5ef0832fb769715ce1800c56