### PR TITLE
📝 : clarify spell-check docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pre-commit run --all-files
 
 If you update documentation, install spell-check tools and verify spelling and links.
 `pyspelling` relies on `aspell` and an English dictionary (`aspell-en`). The
-`scripts/checks.sh` helper tries to install them via `apt-get` when missing. pre-commit
+`scripts/checks.sh` helper tries to install them via `apt-get` when missing. Pre-commit
 runs these checks and fails if spelling or links are broken:
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify docs that Pre-commit runs spelling and link checks

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c25e2b00f0832fa93978ac61ede092