### PR TITLE
📐 bound panel bracket hole offset and sync docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 * panel_bracket: add `nut` standoff_mode for captive hex recess
 
 ### Changed
-* panel_bracket: increase default edge radius to 2 mm for smoother corners
+* panel_bracket: increase default edge radius to 4 mm for smoother corners
+* panel_bracket: validate `hole_offset` stays within bracket bounds
 * pi_carrier: set standoff diameter to 6.5 mm for added strength
 * pi_carrier: widen nut recess clearance to 0.3 mm for easier nut insertion
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ the docs you will see the term used in both contexts.
 - `cad/` — OpenSCAD models of structural parts. See
   [docs/pi_cluster_carrier.md](docs/pi_cluster_carrier.md) for the Pi carrier plate,
   [cad/solar_cube/panel_bracket.scad](cad/solar_cube/panel_bracket.scad) for the solar
-  panel bracket with an `edge_radius` parameter (default 3 mm) to round its outer edges,
+  panel bracket with an `edge_radius` parameter (default 4 mm) to round its outer edges,
   and [cad/solar_cube/frame.scad](cad/solar_cube/frame.scad) for a parametric 2020 cube frame.
 - `elex/` — KiCad and Fritzing electronics schematics including the `power_ring`
   board (see [elex/power_ring/specs.md](elex/power_ring/specs.md) and

--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -41,6 +41,10 @@ assert(edge_radius*2 <= min([beam_width, size, thickness]),
        "edge_radius too large for given dimensions");
 assert(nut_thick <= thickness,
        "nut_thick must be ≤ thickness");
+assert(abs(hole_offset[0]) <= beam_width/2 - screw_clearance/2 - edge_radius,
+       "hole_offset[0] exceeds base width");
+assert(abs(hole_offset[1]) <= size/2 - screw_clearance/2 - edge_radius,
+       "hole_offset[1] exceeds leg length");
 
 // read from CLI (-D standoff_mode="printed"/"heatset"/"nut")
 standoff_mode = "heatset";


### PR DESCRIPTION
## Summary
- assert panel_bracket hole_offset stays within bracket
- document 4 mm default edge radius

## Testing
- `./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `python -m pre_commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c25df13ed8832f8e21ad7344f035ed