### PR TITLE
🔧: widen triple carrier nut clearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### Changed
 * panel_bracket: increase default edge radius to 2 mm for smoother corners
 * pi_carrier: set standoff diameter to 6.5 mm for added strength
-* pi_carrier: widen nut recess clearance to 0.3 mm for easier nut insertion
+* pi_carrier: widen nut recess clearance to 0.4 mm for easier nut insertion
+* pi5_triple_carrier_rot45: widen nut recess clearance to 0.4 mm for easier nut insertion
 
 ### Fixed
 * pi_carrier: standoff length increased from 20 mm to 22 mm (flush fit with PoE HAT)

--- a/cad/pi_cluster/pi5_triple_carrier_rot45.scad
+++ b/cad/pi_cluster/pi5_triple_carrier_rot45.scad
@@ -57,7 +57,7 @@ screw_major     = 2.50;   // M2.5
 screw_pitch     = 0.45;   // ISO coarse
 thread_facets   = 32;     // helix resolution
 screw_clearance = 3.2;    // through-hole clearance, slightly oversize
-nut_clearance   = 0.3;    // extra room for easier nut insertion
+nut_clearance   = 0.4;    // extra room for easier nut insertion (was 0.3)
 nut_flat        = 5.0 + nut_clearance; // across flats for M2.5 nut
 nut_thick       = 2.0;    // nut thickness
 

--- a/docs/pi_cluster_carrier.md
+++ b/docs/pi_cluster_carrier.md
@@ -9,6 +9,7 @@ heat‑set, printed-thread, and captive-nut variants are produced by GitHub Acti
 published as artifacts whenever the SCAD file changes. You can edit the `pi_positions`
 array near the top of the file to tweak the arrangement if your printer allows a larger
 build area.
+Captive-nut pockets include 0.4 mm of extra clearance to make nut insertion easier.
 For an overview of insert installation and printed threads see [insert_basics.md](insert_basics.md).
 
 


### PR DESCRIPTION
## Summary
- expand captive-nut pocket clearance in pi5_triple_carrier_rot45.scad
- document 0.4 mm nut clearance and changelog entry

## Testing
- `./scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c25df13ed8832f8e21ad7344f035ed