### PR TITLE
🔧: widen panel bracket nut clearance

### DIFF
--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -26,7 +26,7 @@ screw_nominal     = 5.0;      // nominal screw size for through-hole (mm)
 screw_clearance   = screw_nominal + 0.2; // through-hole Ø with clearance (mm)
 chamfer           = 1.0;      // lead-in chamfer (mm)
 
-nut_clearance     = 0.2;      // extra room for easier nut insertion (mm)
+nut_clearance     = 0.4;      // extra room for easier nut insertion (was 0.2)
 nut_flat          = 8.0 + nut_clearance; // across flats for M5 nut (mm)
 
 nut_thick         = 4.0;      // nut thickness (mm)


### PR DESCRIPTION
## Summary
- enlarge panel_bracket nut clearance for smoother M5 installation

## Testing
- `./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c25df13ed8832f8e21ad7344f035ed