### PR TITLE
📝 : – refresh CAD prompt instructions

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -35,8 +35,7 @@ CONTEXT:
 - If `package.json` defines them, run:
   - `npm ci`
   - `npm run lint`
-  - `npm run format:check`
-  - `npm test -- --coverage`
+  - `npm run test:ci`
 - For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; see
     [`.spellcheck.yaml`](../.spellcheck.yaml))
@@ -53,11 +52,10 @@ REQUEST:
 2. Modify geometry or parameters as required.
 3. Render the model via (use `~~~` fences in this prompt to avoid breaking the outer block):
    ~~~bash
-   ./scripts/openscad_render.sh path/to/model.scad  # default standoff_mode (model-defined, often heatset)
+   ./scripts/openscad_render.sh path/to/model.scad  # default standoff_mode (often heatset)
    STANDOFF_MODE=printed ./scripts/openscad_render.sh path/to/model.scad  # case-insensitive
    STANDOFF_MODE=nut ./scripts/openscad_render.sh path/to/model.scad
    ~~~
-   ````
 
 4. Run `pre-commit run --all-files`; for docs changes also run
    `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/`.
@@ -83,10 +81,9 @@ If `package.json` exists, also run:
 
 - `npm ci`
 - `npm run lint`
-- `npm run format:check`
-- `npm test -- --coverage`
+- `npm run test:ci`
 
- Then run:
+Then run:
 
 - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; see
   [`.spellcheck.yaml`](../.spellcheck.yaml))


### PR DESCRIPTION
what: update CAD prompt doc to drop deprecated node commands and tidy render example
why: align with current tooling and improve readability
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68c38e1fbed4832fbeb231e03fa789a7