### PR TITLE
📝 docs: clarify Pi image service hooks

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -17,36 +17,29 @@ repositories.
 ./scripts/build_pi_image.sh
 ```
 
-### Build-time flags
+### Build-time environment variables
 
-The build script accepts environment variables to trim or extend the stack:
+The build script reads the variables below to trim or extend the stack:
 
-- `CLONE_TOKEN_PLACE` (default `true`) — clone the `token.place` repository.
-- `CLONE_DSPACE` (default `true`) — clone the `dspace` repository.
-- `EXTRA_REPOS` — space-separated Git URLs for additional projects.
+| Variable | Default | Description |
+| --- | --- | --- |
+| `CLONE_TOKEN_PLACE` | `true` | Clone the `token.place` repository. |
+| `CLONE_DSPACE` | `true` | Clone the `dspace` repository. |
+| `CLONE_SUGARKUBE` | `false` | Include this repo in the image. |
+| `EXTRA_REPOS` | _(empty)_ | Space-separated Git URLs for extra projects. |
 
-`build_pi_image.sh` clones `token.place` and `dspace` by default. Adjust the stack before
-building by editing
+Adjust the stack before building by editing
 [`scripts/cloud-init/docker-compose.yml`](../scripts/cloud-init/docker-compose.yml)
-and dropping new services under the `# extra-start` marker.
-
-### Build-time variables
-
-Configure the image builder with environment variables:
-
-- `CLONE_TOKEN_PLACE=false` — skip cloning token.place
-- `CLONE_DSPACE=false` — skip cloning dspace
-- `CLONE_SUGARKUBE=true` — include this repo in the image
-- `EXTRA_REPOS="https://github.com/example/repo.git"` — clone additional projects
+and inserting services between the `# extra-start` and `# extra-end` markers.
+Each project is cloned into `/opt/projects`.
 
 ```sh
 EXTRA_REPOS="https://github.com/example/repo.git" ./scripts/build_pi_image.sh
 ```
 
-The script clones each repo into `/opt/projects` and assigns ownership to the `pi`
-user. Cloud-init adds Docker's apt repository and installs `docker-ce`,
-`docker-ce-cli`, `containerd.io`, `docker-buildx-plugin` and `docker-compose-plugin`
-so the services run with the upstream Engine and Compose plugin.
+The script assigns ownership of `/opt/projects` to the `pi` user. Cloud-init then
+installs Docker Engine and the Compose plugin from the official repository so the
+services run with upstream bits.
 
 ## Run the apps
 

--- a/scripts/cloud-init/docker-compose.yml
+++ b/scripts/cloud-init/docker-compose.yml
@@ -26,5 +26,11 @@ services:
     restart: unless-stopped
   # dspace-end
   # extra-start
-  # Add additional services below
+  # Add additional services below. Example:
+  # myapp:
+  #   build:
+  #     context: /opt/projects/myapp
+  #   env_file:
+  #     - /opt/projects/myapp/.env
+  #   restart: unless-stopped
   # extra-end

--- a/scripts/cloud-init/init-env.sh
+++ b/scripts/cloud-init/init-env.sh
@@ -18,5 +18,6 @@ for env_path in token.place/.env dspace/frontend/.env; do
 done
 
 # extra-start
-# Add additional environment setup steps below
+# Add additional environment setup steps below. Example:
+# echo "FOO=bar" >> myapp/.env
 # extra-end


### PR DESCRIPTION
## What
- document build-time environment variables and extension hooks
- add sample service snippet for future repos

## Why
- make it easier to run token.place and dspace via shared compose

## How to test
- `npm run lint` (fails: package.json missing)
- `npm run test:ci` (fails: package.json missing)
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c38e2361bc832f9d52fc50b66d207e