### PR TITLE
Generalize env bootstrap for compose services

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -73,19 +73,21 @@ dspace. To expose them through a Cloudflare Tunnel, update
 
 Each project reads an `.env` file in its directory. `init-env.sh` scans
 `/opt/projects` for `*.env.example` files and copies them to `.env` when missing,
-letting containers start with sane defaults. Edit these files to set variables like
-`PORT`, API URLs or secrets:
+then looks at `docker-compose.yml` to create blank `.env` files for any services
+that reference them. Edit these files to set variables like `PORT`, API URLs or
+secrets:
 
 - copies any `*.env.example` to `.env`
-- ensures blank files exist for token.place and dspace even if the repos omit
-  examples
-- handles any additional repo dropped into `/opt/projects`
+- touches `.env` files referenced by `docker-compose.yml`
 
 Update the placeholders with real values and restart the service:
 
 ```ini
 # /opt/projects/token.place/.env
 PORT=5000
+
+# /opt/projects/dspace/frontend/.env
+PORT=3000
 ```
 
 See each repository's README for the full list of configuration options.
@@ -94,9 +96,9 @@ See each repository's README for the full list of configuration options.
 
 Pass Git URLs via `EXTRA_REPOS` to clone additional projects into `/opt/projects`.
 Add services to `/opt/projects/docker-compose.yml` between `# extra-start` and
-`# extra-end`, and extend `init-env.sh` with any new `.env` files, following the
-token.place and dspace examples. The image builder drops the token.place or dspace
-definitions when the corresponding `CLONE_*` flag is `false`, letting you build a
-minimal image and expand it later.
+`# extra-end`; `init-env.sh` reads this compose file and creates blank `.env` files
+for any `env_file` entries, so new repos fit into the boot flow without extra edits.
+The image builder drops the token.place or dspace definitions when the corresponding
+`CLONE_*` flag is `false`, letting you build a minimal image and expand it later.
 
 Use these hooks to experiment with other projects and grow the image over time.

--- a/scripts/cloud-init/init-env.sh
+++ b/scripts/cloud-init/init-env.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 shopt -s globstar nullglob
+
+# Copy any example env files to .env with restricted permissions
 for example in **/.env.example; do
   target="${example%.example}"
   if [ ! -f "$target" ]; then
@@ -10,12 +12,25 @@ for example in **/.env.example; do
   fi
 done
 
-# Ensure token.place and dspace have .env files even without examples
-for env_path in token.place/.env dspace/frontend/.env; do
-  dir="$(dirname "$env_path")"
-  [ -d "$dir" ] || continue
-  [ -f "$env_path" ] || touch "$env_path"
-done
+# Touch env files referenced in docker-compose.yml when missing. This keeps
+# token.place, dspace and any future services aligned with the compose stack.
+if [ -f docker-compose.yml ]; then
+  grep -oE '[- ]+[./A-Za-z0-9_/-]+\.env' docker-compose.yml \
+    | sed -E 's/^[- ]+//; s/^\.\///' \
+    | sort -u \
+    | while read -r env_path; do
+        case "$env_path" in
+          /*) target="$env_path" ;;
+          *)  target="$(pwd)/$env_path" ;;
+        esac
+        dir="$(dirname "$target")"
+        [ -d "$dir" ] || continue
+        if [ ! -f "$target" ]; then
+          touch "$target"
+          chmod 600 "$target"
+        fi
+      done
+fi
 
 # extra-start
 # Add additional environment setup steps below


### PR DESCRIPTION
## Summary
- touch env files from docker-compose.yml
- document runtime env handling for token.place and dspace

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c38e2361bc832f9d52fc50b66d207e