### PR TITLE
🔧 : seed default ports for Pi services

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -73,22 +73,24 @@ dspace. To expose them through a Cloudflare Tunnel, update
 
 Each project reads an `.env` file in its directory. `init-env.sh` scans
 `/opt/projects` for `*.env.example` files and copies them to `.env` when missing,
-letting containers start with sane defaults. Edit these files to set variables like
-`PORT`, API URLs or secrets:
+letting containers start with sane defaults. If a repo omits an example file the
+script seeds a minimal one with a `PORT` that matches the compose file so the
+container listens on the expected interface. Edit these files to set variables
+like API URLs or secrets:
 
 - copies any `*.env.example` to `.env`
-- ensures blank files exist for token.place and dspace even if the repos omit
-  examples
+- seeds token.place with `PORT=5000` and dspace with `PORT=3000`
 - handles any additional repo dropped into `/opt/projects`
 
 Update the placeholders with real values and restart the service:
 
 ```ini
-# /opt/projects/token.place/.env
+# token.place listens on :5000
 PORT=5000
 ```
 
-See each repository's README for the full list of configuration options.
+If you change the port, update the mapping in `docker-compose.yml` to match. See
+each repository's README for the full list of configuration options.
 
 ## Extend with new repositories
 

--- a/scripts/cloud-init/docker-compose.yml
+++ b/scripts/cloud-init/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: docker/Dockerfile.server
     container_name: tokenplace
     ports:
-      - "5000:5000"
+      - "5000:5000"  # host:container; sync with PORT in .env if changed
     env_file:
       - /opt/projects/token.place/.env
     restart: unless-stopped
@@ -20,7 +20,7 @@ services:
     working_dir: /opt/projects/dspace/frontend
     container_name: dspace
     ports:
-      - "3000:3000"
+      - "3000:3000"  # host:container; sync with PORT in .env if changed
     env_file:
       - /opt/projects/dspace/frontend/.env
     restart: unless-stopped

--- a/scripts/cloud-init/init-env.sh
+++ b/scripts/cloud-init/init-env.sh
@@ -11,10 +11,24 @@ for example in **/.env.example; do
 done
 
 # Ensure token.place and dspace have .env files even without examples
+# Seed a basic PORT so each app listens on the expected interface
 for env_path in token.place/.env dspace/frontend/.env; do
   dir="$(dirname "$env_path")"
   [ -d "$dir" ] || continue
-  [ -f "$env_path" ] || touch "$env_path"
+  if [ ! -f "$env_path" ]; then
+    case "$env_path" in
+      token.place/.env)
+        printf "PORT=5000\n" > "$env_path"
+        ;;
+      dspace/frontend/.env)
+        printf "PORT=3000\n" > "$env_path"
+        ;;
+      *)
+        :
+        ;;
+    esac
+    chmod 600 "$env_path"
+  fi
 done
 
 # extra-start


### PR DESCRIPTION
## Summary
- seed token.place and dspace `.env` files with default PORT values
- clarify compose port mapping comments and doc runtime variables

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`

Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68c38e2361bc832f9d52fc50b66d207e