### PR TITLE
Preinstall k3s and document Pi image quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ the docs you will see the term used in both contexts.
   - `collect_pi_image.sh` — normalize pi-gen output into a single `.img.xz`,
     clean up temporary work directories, and use POSIX `test -ef` to compare paths
     without `realpath`
-  - `build_pi_image.sh` — build a Raspberry Pi OS image with cloud-init
-    preloaded; embeds `pi_node_verifier.sh` and clones `token.place` and
+  - `build_pi_image.sh` — build a Raspberry Pi OS image with cloud-init and
+    k3s preinstalled; embeds `pi_node_verifier.sh` and clones `token.place` and
     `democratizedspace/dspace` (branch `v3`) by default. Set
-    `CLONE_SUGARKUBE=true` to include this repo and pass space-separated Git
-    URLs via `EXTRA_REPOS` to clone additional projects; needs a valid `user-data.yaml`
+    `CLONE_SUGARKUBE=true` to include this repo and pass space-separated Git URLs
+    via `EXTRA_REPOS` to clone additional projects; needs a valid `user-data.yaml`
     and ~10 GB free disk space. Set `DEBUG=1` to trace script execution.
   - `pi_node_verifier.sh` — check k3s prerequisites; use `--json` for machine output or
     `--help` for usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ Review the safety notes before working with power components.
 - [network_setup.md](network_setup.md) — connect the cluster to your network
 - [mac_mini_station.md](mac_mini_station.md) — press-fit cap for the Mac mini keyboard station
 - [electronics_schematics.md](electronics_schematics.md) — KiCad and Fritzing designs
+- [pi_image_quickstart.md](pi_image_quickstart.md) — build, flash and boot the preloaded Pi image
 - [pi_image_cloudflare.md](pi_image_cloudflare.md) — preconfigure Docker and Cloudflare tunnels
 - [raspi_cluster_setup.md](raspi_cluster_setup.md) — build a three-node k3s cluster and deploy apps
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -1,0 +1,30 @@
+# Pi Image Quickstart
+
+Build a Raspberry Pi OS image that boots with k3s and the
+[token.place](https://github.com/futuroptimist/token.place) and
+[dspace](https://github.com/democratizedspace/dspace) services.
+
+## 1. Build or download the image
+- Run `./scripts/download_pi_image.sh` to fetch the latest artifact from the
+  `pi-image` workflow, or build locally via `./scripts/build_pi_image.sh`.
+- The builder clones token.place and dspace by default. Set
+  `CLONE_TOKEN_PLACE=false` or `CLONE_DSPACE=false` to skip either project.
+
+## 2. Flash with Raspberry Pi Imager
+- Write `sugarkube.img.xz` to a microSD card with Raspberry Pi Imager.
+- Use advanced options (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>) to set the
+  hostname, credentials and network.
+
+## 3. Boot and verify
+- Insert the card and power on the Pi.
+- k3s installs automatically on first boot. Confirm the node is ready:
+  ```bash
+  sudo kubectl get nodes
+  ```
+- token.place and dspace run under `projects-compose.service`. Check status:
+  ```bash
+  sudo systemctl status projects-compose.service
+  ```
+
+The image is now ready for additional repositories or joining a multi-node
+k3s cluster.

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -175,6 +175,7 @@ runcmd:
   - [bash, -c, 'mkdir -p /var/log/journal && systemctl restart systemd-journald']
   - [systemctl, daemon-reexec]   # reload systemd units
   - [systemctl, enable, --now, docker]
+  - [bash, -c, 'curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--disable traefik" sh -']
   - [/opt/projects/start-projects.sh]  # projects-runcmd
   - [bash, -c, 'apt-get autoremove -y']
   - [bash, -c, 'apt-get clean && rm -rf /var/lib/apt/lists/*']

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -583,3 +583,8 @@ def test_requires_stage_list(tmp_path):
 def test_powershell_script_mentions_cloudflared_compose():
     text = Path("scripts/build_pi_image.ps1").read_text()
     assert "docker-compose.cloudflared.yml" in text
+
+
+def test_user_data_installs_k3s():
+    text = Path("scripts/cloud-init/user-data.yaml").read_text()
+    assert "https://get.k3s.io" in text


### PR DESCRIPTION
## Summary
- install k3s during Pi image cloud-init provisioning
- add Pi image quickstart guide and link from docs
- note k3s preinstall in README and verify via test

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c38ed15284832fbdbbc5dbf754ae70