### PR TITLE
🔧: validate cloud-init YAML

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -67,9 +67,10 @@ connectivity. The script curls the Debian, Raspberry Pi, and pi-gen repositories
 with a 10-second timeout before building; override this via the
 `URL_CHECK_TIMEOUT` environment variable or set `SKIP_URL_CHECK=1` to bypass
 these probes when using local mirrors or working offline. Ensure `curl`, `docker`
-(with its daemon running), `git`, `sha256sum`, `stdbuf`, `timeout`, `xz`, `bsdtar`, and `df`
-are installed before running it; `stdbuf` and `timeout` come from GNU coreutils. The script
-checks that both the temporary and output directories have at least 10 GB free
+(with its daemon running), `git`, `sha256sum`, `stdbuf`, `timeout`, `xz`, `bsdtar`, `df`,
+and `python3` are installed before running it; `stdbuf` and `timeout` come from GNU coreutils.
+The script attempts to validate the cloud-init YAML via PyYAML and skips the check when the
+module is missing. It checks that both the temporary and output directories have at least 10 GB free
 before starting and verifies the resulting image exists and is non-empty before
 reporting success. Use the prepared image to deploy containerized apps. The
 companion guide [docker_repo_walkthrough.md](docker_repo_walkthrough.md)


### PR DESCRIPTION
## Summary
- ensure build script validates cloud-init YAML when PyYAML is available
- note python3/PyYAML dependency in Pi image guide

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c38e1e70b8832f81f6891a603c504e