### PR TITLE
🔧 : auto-select pi-gen branch

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -14,9 +14,10 @@ so logs survive reboots. After installation, it removes unused packages with
 `apt-get autoremove -y` and cleans the apt cache to keep the image small.
 
 The `build_pi_image.sh` script clones [pi-gen](https://github.com/RPi-Distro/pi-gen) using
-`PI_GEN_BRANCH` (default: `bookworm` for 32-bit builds and `arm64` for
-64-bit). Set `PI_GEN_URL` to use a fork or mirror if the default repository is
-unavailable. `IMG_NAME` controls the output filename and `OUTPUT_DIR` selects
+`PI_GEN_BRANCH`. If unset, it selects `arm64` when `ARM64=1` and `bookworm` for
+32-bit builds. Set `PI_GEN_BRANCH` to override the choice. Set `PI_GEN_URL` to use
+a fork or mirror if the default repository is unavailable.
+`IMG_NAME` controls the output filename and `OUTPUT_DIR` selects
 where artifacts are written; the script creates the directory if needed. To avoid
 accidental overwrites it aborts when the image already exists unless
 `FORCE_OVERWRITE=1` is set. Set `FORCE_OVERWRITE=1` when rerunning builds to

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -148,8 +148,15 @@ if [ "$ARM64" -eq 1 ]; then
 else
   ARMHF=1
 fi
-# Default to the bookworm release branch; architecture is controlled via config.
-PI_GEN_BRANCH="${PI_GEN_BRANCH:-bookworm}"
+
+# Select the pi-gen branch automatically unless PI_GEN_BRANCH is provided
+if [ -z "${PI_GEN_BRANCH:-}" ]; then
+  if [ "$ARM64" -eq 1 ]; then
+    PI_GEN_BRANCH="arm64"
+  else
+    PI_GEN_BRANCH="bookworm"
+  fi
+fi
 IMG_NAME="${IMG_NAME:-sugarkube}"
 OUTPUT_DIR="${OUTPUT_DIR:-${REPO_ROOT}}"
 mkdir -p "${OUTPUT_DIR}"


### PR DESCRIPTION
what: choose pi-gen branch based on ARM64 and document override
why: ensures 64-bit builds use correct base branch
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c38e1e70b8832f81f6891a603c504e