### PR TITLE
📝 docs: add health check example

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -260,6 +260,34 @@ docker compose down
 
 
 
+### Add health checks
+
+Use Docker health checks so the stack reports ready only after both endpoints respond.
+
+```sh
+cd /opt/projects
+cat <<'EOF' >> docker-compose.yml
+services:
+  tokenplace:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+  dspace:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3002"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+EOF
+docker compose up -d
+docker inspect --format='{{json .State.Health}}' tokenplace
+docker inspect --format='{{json .State.Health}}' dspace
+```
+
+
+
 ### Toggle services with Docker Compose profiles
 
 Enable just token.place or dspace without editing the compose file:


### PR DESCRIPTION
what: document Docker health checks for token.place and dspace.
why: show readiness gating before tunnel routes traffic.
how to test: pre-commit run --all-files
             pyspelling -c .spellcheck.yaml
             linkchecker --no-warnings README.md docs/
             git diff --cached | ./scripts/scan-secrets.py
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c38e160a8c832f8677c5d3db719936