### PR TITLE
docs: auto-start token.place and dspace on Pi image

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -146,8 +146,25 @@ docker compose down
 
 ### Auto-start token.place and dspace on boot
 
-Keep the stack running after reboots by wrapping the compose file with a systemd
-unit:
+The Cloudflare-ready Pi image ships a `projects-compose` service that calls
+`docker compose` in `/opt/projects`. After cloning token.place and dspace and
+adding the combined `docker-compose.yml`, enable it so the apps restart on boot:
+
+```sh
+sudo systemctl enable --now projects-compose
+# or run the helper script installed with the image
+sudo /opt/sugarkube/start-projects.sh
+sudo reboot
+```
+
+Reconnect and verify both services:
+
+```sh
+curl http://localhost:5000
+curl http://localhost:3002
+```
+
+For custom setups, wrap the compose file with a dedicated systemd unit:
 
 ```sh
 sudo tee /etc/systemd/system/tokenplace-dspace.service <<'EOF'


### PR DESCRIPTION
## Summary
- document built-in `projects-compose` systemd unit to auto-start token.place and dspace
- note helper script for enabling service and verifying after reboot

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c38e160a8c832f8677c5d3db719936