### PR TITLE
🔧: validate cloud-init YAML

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -67,9 +67,10 @@ connectivity. The script curls the Debian, Raspberry Pi, and pi-gen repositories
 with a 10-second timeout before building; override this via the
 `URL_CHECK_TIMEOUT` environment variable or set `SKIP_URL_CHECK=1` to bypass
 these probes when using local mirrors or working offline. Ensure `curl`, `docker`
-(with its daemon running), `git`, `sha256sum`, `stdbuf`, `timeout`, `xz`, `bsdtar`, and `df`
-are installed before running it; `stdbuf` and `timeout` come from GNU coreutils. The script
-checks that both the temporary and output directories have at least 10 GB free
+(with its daemon running), `git`, `sha256sum`, `stdbuf`, `timeout`, `xz`, `bsdtar`, `df`,
+and `python3` are installed before running it; `stdbuf` and `timeout` come from GNU coreutils.
+The script attempts to validate the cloud-init YAML via PyYAML and skips the check when the
+module is missing. It checks that both the temporary and output directories have at least 10 GB free
 before starting and verifies the resulting image exists and is non-empty before
 reporting success. Use the prepared image to deploy containerized apps. The
 companion guide [docker_repo_walkthrough.md](docker_repo_walkthrough.md)

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -24,7 +24,7 @@ check_space() {
 # 10 GB of free disk space. Set PI_GEN_URL to override the default pi-gen
 # repository.
 
-for cmd in curl docker git sha256sum stdbuf timeout xz bsdtar df; do
+for cmd in curl docker git sha256sum stdbuf timeout xz bsdtar df python3; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "$cmd is required" >&2
     exit 1
@@ -85,6 +85,21 @@ fi
 if ! head -n1 "${CLOUD_INIT_PATH}" | grep -q '^#cloud-config'; then
   echo "Cloud-init file missing #cloud-config header: ${CLOUD_INIT_PATH}" >&2
   exit 1
+fi
+
+# Validate cloud-init YAML syntax when PyYAML is available
+if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" >/dev/null 2>&1; then
+  if ! python3 - "${CLOUD_INIT_PATH}" <<'PY' >/dev/null 2>&1
+import sys, yaml
+with open(sys.argv[1]) as f:
+    yaml.safe_load(f)
+PY
+  then
+    echo "Cloud-init file contains invalid YAML: ${CLOUD_INIT_PATH}" >&2
+    exit 1
+  fi
+else
+  echo "PyYAML not installed; skipping cloud-init YAML validation" >&2
 fi
 
 if [ ! -f "${CLOUDFLARED_COMPOSE_PATH}" ]; then


### PR DESCRIPTION
## Summary
- validate cloud-init YAML when PyYAML is available
- note python3/PyYAML dependency in Pi image guide
- fix here-doc and update tests for python3

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c38e1e70b8832f81f6891a603c504e