### PR TITLE
docs: streamline pi-image workflow

### DIFF
--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -5,10 +5,19 @@ Build a Raspberry Pi OS image that boots with k3s and the
 [dspace](https://github.com/democratizedspace/dspace) services.
 
 ## 1. Build or download the image
-- Run `./scripts/download_pi_image.sh` to fetch the latest artifact from the
-  `pi-image` workflow, or build locally via `./scripts/build_pi_image.sh`.
-- The builder clones token.place and dspace by default. Set
-  `CLONE_TOKEN_PLACE=false` or `CLONE_DSPACE=false` to skip either project.
+1. In GitHub, open **Actions → pi-image → Run workflow**.
+   - Tick **token.place** and **dspace** to bake those repos into `/opt/projects`.
+   - Wait for the run to finish; it uploads `sugarkube.img.xz` as an artifact.
+2. Download the artifact locally:
+   ```bash
+   scripts/download_pi_image.sh
+   ```
+   or grab it manually from the workflow run.
+3. Alternatively, build on your machine:
+   ```bash
+   ./scripts/build_pi_image.sh
+   ```
+   Skip either project with `CLONE_TOKEN_PLACE=false` or `CLONE_DSPACE=false`.
 
 ## 2. Flash with Raspberry Pi Imager
 - Write `sugarkube.img.xz` to a microSD card with Raspberry Pi Imager.

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -20,9 +20,14 @@ Linux command line.
 - Internet connection to download images and packages
 
 ## 1. Prepare the OS image
-1. Run `scripts/download_pi_image.sh` to fetch `sugarkube.img.xz` from the latest
-   [pi-image workflow run][pi-image],
-   or download it manually from the Actions tab.
+1. Trigger the build in GitHub:
+   - Open [Actions → pi-image → Run workflow][pi-image].
+   - Enable **token.place** and **dspace** if you want those repos baked in.
+   - After the run succeeds, download `sugarkube.img.xz`:
+     ```bash
+     scripts/download_pi_image.sh
+     ```
+     or grab it from the workflow run.
 
    Alternatively, build locally:
    - Linux/macOS: `./scripts/build_pi_image.sh`


### PR DESCRIPTION
## Summary
- document how to trigger the pi-image build from GitHub and download the artifact
- mention optional token.place and dspace clones in quickstart and cluster setup guides

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3974658c0832fb34f8c5ca13d1c0a