### PR TITLE
docs: add token.place and dspace runbook

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Review the safety notes before working with power components.
 - [pi_image_cloudflare.md](pi_image_cloudflare.md) — preconfigure Docker and Cloudflare tunnels
 - [raspi_cluster_setup.md](raspi_cluster_setup.md) — build a three-node k3s cluster and deploy apps
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
-- [pi_token_dspace.md](pi_token_dspace.md) — run token.place and dspace on the Pi image
+- [pi_token_dspace.md](pi_token_dspace.md) — build and expose token.place & dspace via Cloudflare
 - [pi_image_builder_design.md](pi_image_builder_design.md) — design and reliability features of the image builder
 
 ## Learn the Fundamentals

--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -1,98 +1,112 @@
-# token.place and dspace Quickstart
+# token.place and dspace Runbook
 
-Build a Raspberry Pi 5 image that includes the
-[token.place](https://github.com/futuroptimist/token.place) and
-[dspace](https://github.com/democratizedspace/dspace) repositories so you can run
-both apps out of the box. The image builder clones these projects, drops a shared
+This runbook walks through building the Raspberry Pi image, flashing it, booting,
+and confirming both [token.place](https://github.com/futuroptimist/token.place)
+and [dspace](https://github.com/democratizedspace/dspace) work locally and via a
+Cloudflare Tunnel. The image builder clones each repository, drops a shared
 `docker-compose.yml` under `/opt/projects` and installs a single
-`projects-compose.service` to manage them. Each service uses `restart: unless-stopped`
-so the containers stay up across reboots. The first boot uses Docker's Debian
-repository to install the Engine and Compose plugin. Hooks remain for additional
-repositories.
+`projects-compose.service` to manage the stack. Services use `restart:
+unless-stopped` so containers relaunch across reboots.
 
-## Build the image
+## 1. Build or download the image
 
-```sh
-# inside the sugarkube repo
-./scripts/build_pi_image.sh
-```
+1. In GitHub, open **Actions → pi-image → Run workflow**.
+   - Tick **token.place** and **dspace** to bake those repos into `/opt/projects`.
+   - Wait for the run to finish; it uploads `sugarkube.img.xz` as an artifact.
+2. Download the artifact locally:
+   ```sh
+   ./scripts/download_pi_image.sh
+   ```
+   or grab it manually from the workflow run.
+3. Alternatively, build on your machine:
+   ```sh
+   ./scripts/build_pi_image.sh
+   ```
+   Control the stack with environment variables:
 
-### Build-time environment variables
+   | Variable | Default | Description |
+   | --- | --- | --- |
+   | `CLONE_TOKEN_PLACE` | `true` | Clone the `token.place` repository. |
+   | `CLONE_DSPACE` | `true` | Clone the `dspace` repository. |
+   | `CLONE_SUGARKUBE` | `false` | Include this repo in the image. |
+   | `EXTRA_REPOS` | _(empty)_ | Space-separated Git URLs for extra projects. |
 
-The build script reads the variables below to trim or extend the stack:
+   Adjust the stack before building by editing
+   [`scripts/cloud-init/docker-compose.yml`](../scripts/cloud-init/docker-compose.yml)
+   and inserting services between the `# extra-start` and `# extra-end` markers.
 
-| Variable | Default | Description |
-| --- | --- | --- |
-| `CLONE_TOKEN_PLACE` | `true` | Clone the `token.place` repository. |
-| `CLONE_DSPACE` | `true` | Clone the `dspace` repository. |
-| `CLONE_SUGARKUBE` | `false` | Include this repo in the image. |
-| `EXTRA_REPOS` | _(empty)_ | Space-separated Git URLs for extra projects. |
+## 2. Flash with Raspberry Pi Imager
 
-Adjust the stack before building by editing
-[`scripts/cloud-init/docker-compose.yml`](../scripts/cloud-init/docker-compose.yml)
-and inserting services between the `# extra-start` and `# extra-end` markers.
-Each project is cloned into `/opt/projects`.
+- Write `sugarkube.img.xz` to a microSD card with Raspberry Pi Imager.
+- Use advanced options (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>) to set the
+  hostname, credentials and network.
 
-```sh
-EXTRA_REPOS="https://github.com/example/repo.git" ./scripts/build_pi_image.sh
-```
+## 3. Boot and verify locally
 
-The script assigns ownership of `/opt/projects` to the `pi` user. Cloud-init then
-installs Docker Engine and the Compose plugin from the official repository so the
-services run with upstream bits.
+1. Insert the card and power on the Pi.
+2. On first boot the Pi builds the containers defined in
+   `/opt/projects/docker-compose.yml` and enables `projects-compose.service`.
+3. Confirm the stack is running:
+   ```sh
+   sudo systemctl status projects-compose.service
+   ```
+4. Verify each app on the LAN:
+   ```sh
+   curl http://<pi-host>:5000  # token.place
+   curl http://<pi-host>:3000  # dspace
+   ```
 
-## Run the apps
+## 4. Expose through Cloudflare Tunnel
 
-On first boot the Pi builds the containers defined in
-`/opt/projects/docker-compose.yml`. Each service uses `restart: unless-stopped`
-so it relaunches after reboots or crashes. The `start-projects.sh` helper enables
-the `projects-compose.service` unit which starts the stack automatically. Manage
-the services with `systemctl`:
+1. Add your tunnel token to `/opt/sugarkube/.cloudflared.env`.
+2. Map hostnames to local services by editing
+   `/opt/sugarkube/docker-compose.cloudflared.yml`:
+   ```yaml
+   ingress:
+     - hostname: tokenplace.example.com
+       service: http://localhost:5000
+     - hostname: dspace.example.com
+       service: http://localhost:3000
+     - service: http_status:404
+   ```
+3. Restart the tunnel:
+   ```sh
+   sudo systemctl restart cloudflared-compose
+   ```
+4. Verify remote access:
+   ```sh
+   curl https://tokenplace.example.com
+   curl https://dspace.example.com
+   ```
 
-```sh
-# check service status
-sudo systemctl status projects-compose.service
-
-# restart the stack
-sudo systemctl restart projects-compose.service
-```
-
-Visit `http://<pi-host>:5000` for token.place and `http://<pi-host>:3000` for
-dspace. To expose them through a Cloudflare Tunnel, update
-`/opt/sugarkube/docker-compose.cloudflared.yml` as shown in
-[docker_repo_walkthrough.md](docker_repo_walkthrough.md).
-
-### Runtime environment variables
+## 5. Runtime environment variables
 
 Each project reads an `.env` file in its directory. `init-env.sh` scans
-`/opt/projects` for `*.env.example` files and copies them to `.env` when
-missing, letting containers start with sane defaults. The script also ships an
-`ensure_env` helper that creates blank files when a project omits an example.
-Edit these files to set variables like `PORT`, API URLs or secrets:
+`/opt/projects` for `*.env.example` files and copies them to `.env` when missing,
+letting containers start with sane defaults. The script ships an `ensure_env`
+helper that creates blank files when a project omits an example. Edit these files
+to set variables like `PORT`, API URLs or secrets:
 
 - `/opt/projects/token.place/.env` — example:
-
   ```ini
   PORT=5000
   ```
-
 - `/opt/projects/dspace/frontend/.env` — example:
-
   ```ini
   PORT=3000
   ```
 
-Add more calls to `ensure_env` under the `# extra-start` marker in
-`init-env.sh` for additional repositories. See each project's README for the
-full list of configuration options.
+Add more calls to `ensure_env` under the `# extra-start` marker in `init-env.sh`
+for additional repositories. See each project's README for the full list of
+configuration options.
 
-## Extend with new repositories
+## 6. Extend with new repositories
 
 Pass Git URLs via `EXTRA_REPOS` to clone additional projects into `/opt/projects`.
 Add services to `/opt/projects/docker-compose.yml` between `# extra-start` and
 `# extra-end`, and extend `init-env.sh` with any new `.env` files, following the
-token.place and dspace examples. The image builder drops the token.place or dspace
-definitions when the corresponding `CLONE_*` flag is `false`, letting you build a
-minimal image and expand it later.
+token.place and dspace examples. The image builder drops the token.place or
+dspace definitions when the corresponding `CLONE_*` flag is `false`, letting you
+build a minimal image and expand it later.
 
 Use these hooks to experiment with other projects and grow the image over time.


### PR DESCRIPTION
## What
- consolidate pi-image build and token.place/dspace verification steps
- expose apps via Cloudflare in a single runbook
- update docs index

## Why
- provide cohesive guide from image build to cloud access

## How to test
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c4b01da0c0832f96f803a3314647ad