### PR TITLE
🧪: validate pi_node_verifier JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ the docs you will see the term used in both contexts.
     `CLONE_SUGARKUBE=true` to include this repo and pass space-separated Git URLs
     via `EXTRA_REPOS` to clone additional projects; needs a valid `user-data.yaml`
     and ~10 GB free disk space. Set `DEBUG=1` to trace script execution.
-  - `pi_node_verifier.sh` — check k3s prerequisites; use `--json` for machine output or
-    `--help` for usage
+  - `pi_node_verifier.sh` — check k3s prerequisites; use `--json` for machine output
+    (fails fast on malformed JSON) or `--help` for usage
   - `scan-secrets.py` — scan diffs for high-risk patterns with `ripsecrets` when available
     and gracefully fall back to regex matching if `ripsecrets` fails to execute
 - `outages/` — structured outage records (see

--- a/scripts/pi_node_verifier.sh
+++ b/scripts/pi_node_verifier.sh
@@ -81,5 +81,16 @@ else
 fi
 
 if $JSON; then
-  printf '{"checks":[%s]}\n' "$(IFS=,; echo "${json_parts[*]}")"
+  json_output=$(printf '{"checks":[%s]}\n' "$(IFS=,; echo "${json_parts[*]}")")
+
+  if [[ "${PI_NODE_VERIFIER_CORRUPT_JSON:-}" == "1" ]]; then
+    json_output="${json_output}corrupt"
+  fi
+
+  if ! echo "$json_output" | jq -e . >/dev/null 2>&1; then
+    echo "Invalid JSON produced" >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$json_output"
 fi

--- a/tests/pi_node_verifier_corrupt_json_test.bats
+++ b/tests/pi_node_verifier_corrupt_json_test.bats
@@ -1,0 +1,7 @@
+#!/usr/bin/env bats
+
+@test "pi_node_verifier exits on corrupted JSON" {
+  PI_NODE_VERIFIER_CORRUPT_JSON=1 run "$BATS_TEST_DIRNAME/../scripts/pi_node_verifier.sh" --json
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "Invalid JSON" ]]
+}


### PR DESCRIPTION
what: add JSON corruption test and fail-fast validation.
why: detect malformed output from pi_node_verifier.
how to test: pre-commit run --all-files


------
https://chatgpt.com/codex/tasks/task_e_68c5d78c29c8832fab14a85fa920897d