### PR TITLE
Ensure secret regex runs after ripsecrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ the docs you will see the term used in both contexts.
     and ~10 GB free disk space. Set `DEBUG=1` to trace script execution.
   - `pi_node_verifier.sh` — check k3s prerequisites; use `--json` for machine output or
     `--help` for usage
-  - `scan-secrets.py` — scan diffs for high-risk patterns with `ripsecrets` when available
-    and gracefully fall back to regex matching if `ripsecrets` fails to execute
+  - `scan-secrets.py` — scan diffs for high-risk patterns using `ripsecrets` when
+    available and also run a regex check to catch common tokens
 - `outages/` — structured outage records (see
   [docs/outage_catalog.md](docs/outage_catalog.md))
 - `tests/` — quick checks for helper scripts and documentation

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -82,8 +82,6 @@ def main() -> int:
     rip = run_ripsecrets(diff)
     if rip is True:
         return 1
-    if rip is False:
-        return 0
     if regex_scan(diff.splitlines()):
         return 1
     return 0

--- a/tests/scan_secrets_test.py
+++ b/tests/scan_secrets_test.py
@@ -88,6 +88,20 @@ def test_main_ripsecrets_clean(monkeypatch, scan_secrets):
     assert scan_secrets.main() == 0
 
 
+def test_main_ripsecrets_missed_secret(monkeypatch, scan_secrets):
+    monkeypatch.setattr(
+        scan_secrets,
+        "run_ripsecrets",
+        lambda diff_text: False,
+    )
+    monkeypatch.setattr(
+        scan_secrets.sys,
+        "stdin",
+        io.StringIO("+++ b/file\n+token: abc\n"),
+    )
+    assert scan_secrets.main() == 1
+
+
 def test_run_ripsecrets_returns_none_when_missing(monkeypatch, scan_secrets):
     monkeypatch.setattr(scan_secrets.shutil, "which", lambda _: None)
     assert scan_secrets.run_ripsecrets("diff") is None


### PR DESCRIPTION
## Summary
- test: cover case where ripsecrets misses a token
- fix: always run regex-based scan even if ripsecrets reports clean
- docs: document combined ripsecrets and regex scanning

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: Possible secret: +        io.StringIO("+++ b/file\n+token: abc\n"),)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d78c29c8832fab14a85fa920897d