### PR TITLE
Add skip-copy test for collect_pi_image

### DIFF
--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -182,3 +182,17 @@ def test_succeeds_when_realpath_missing(tmp_path):
     )
     assert result.returncode == 0, result.stderr
     assert out_img.exists()
+
+
+def test_skips_copy_when_source_is_output(tmp_path):
+    deploy = tmp_path / "deploy"
+    deploy.mkdir()
+    img_xz = deploy / "foo.img.xz"
+    img_xz.write_text("original")
+
+    result = _run_script(tmp_path, deploy, img_xz)
+    assert result.returncode == 0, result.stderr
+    assert img_xz.read_text() == "original"
+    sha = img_xz.with_suffix(img_xz.suffix + ".sha256")
+    assert sha.exists()
+    assert "skipping copy" in result.stdout


### PR DESCRIPTION
## Summary
- test collect_pi_image.sh skips copy when output equals source

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5d78c29c8832fab14a85fa920897d