### PR TITLE
Fix flaky docs link check

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -123,7 +123,9 @@ fi
 
 if command -v linkchecker >/dev/null 2>&1; then
   if [ -f README.md ] && [ -d docs ]; then
-    linkchecker --no-warnings README.md docs/
+    # Explicitly ignore external URLs so behaviour is consistent across
+    # LinkChecker versions which may default to checking remote links.
+    linkchecker --no-warnings --ignore-url '^https?://' README.md docs/
   else
     echo "README.md or docs/ missing, skipping link check" >&2
   fi

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -123,9 +123,7 @@ fi
 
 if command -v linkchecker >/dev/null 2>&1; then
   if [ -f README.md ] && [ -d docs ]; then
-    # LinkChecker 10 defaults to checking only internal links. Explicitly enable
-    # external link verification to catch broken URLs across the documentation.
-    linkchecker --check-extern --no-warnings README.md docs/
+    linkchecker --no-warnings README.md docs/
   else
     echo "README.md or docs/ missing, skipping link check" >&2
   fi


### PR DESCRIPTION
## Summary
- run linkchecker only against internal docs links to avoid external outages

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5d75795d8832f937493fd0fc81b18