### PR TITLE
Clarify pre-commit checks doc

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -142,6 +142,8 @@ kubeconfig
 kubectl
 lcd
 linkchecker
+linters
+htmlcontent
 llms
 localhost
 localhostForwarding

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ the docs you will see the term used in both contexts.
 - `tests/` — quick checks for helper scripts and documentation
 
 Run `pre-commit run --all-files` before committing.
+This triggers `scripts/checks.sh`, which installs required tooling and runs
+linters, tests, and documentation checks.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- document that `pre-commit run --all-files` invokes `scripts/checks.sh`
- allow `linters` and `htmlcontent` terms for spellcheck

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c5d7991340832f892064d5d2fccfcf