### PR TITLE
fix: unzip fallback in collect_pi_image

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ the docs you will see the term used in both contexts.
     to be installed and authenticated. Uses POSIX `test -ef` instead of `realpath` for better
     macOS compatibility
   - `collect_pi_image.sh` — normalize pi-gen output into a single `.img.xz`,
-    clean up temporary work directories, and use POSIX `test -ef` to compare paths
-    without `realpath`
+    clean up temporary work directories, use POSIX `test -ef` to compare paths
+    without `realpath`, and fall back to `unzip` when `bsdtar` is unavailable
   - `build_pi_image.sh` — build a Raspberry Pi OS image with cloud-init and
     k3s preinstalled; embeds `pi_node_verifier.sh` and clones `token.place` and
     `democratizedspace/dspace` (branch `v3`) by default. Set

--- a/tests/collect_pi_image_inputs_test.py
+++ b/tests/collect_pi_image_inputs_test.py
@@ -110,6 +110,21 @@ def test_handles_zip_with_img(tmp_path):
         assert f.read() == b"data"
 
 
+def test_handles_zip_with_unzip_fallback(tmp_path):
+    deploy = tmp_path / "deploy"
+    deploy.mkdir()
+    zip_path = deploy / "foo.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("foo.img", b"data")
+
+    out_img = tmp_path / "out.img.xz"
+    result = _run_script(tmp_path, deploy, out_img)
+    assert result.returncode == 0, result.stderr
+    assert out_img.exists()
+    with lzma.open(out_img, "rb") as f:
+        assert f.read() == b"data"
+
+
 def test_errors_when_no_image_found(tmp_path):  # noqa: F811
     deploy = tmp_path / "deploy"
     deploy.mkdir()


### PR DESCRIPTION
what: allow collect_pi_image.sh to unzip artifacts when bsdtar missing
why: ensure image collection works on minimal hosts
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68c5d7991340832f892064d5d2fccfcf