### PR TITLE
🐛: clarify bsdtar requirement for image collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ the docs you will see the term used in both contexts.
     macOS compatibility
   - `collect_pi_image.sh` — normalize pi-gen output into a single `.img.xz`,
     clean up temporary work directories, and use POSIX `test -ef` to compare paths
-    without `realpath`
+    without `realpath`. Requires `bsdtar` (from `libarchive-tools`) to extract `.zip`
+    archives
   - `build_pi_image.sh` — build a Raspberry Pi OS image with cloud-init and
     k3s preinstalled; embeds `pi_node_verifier.sh` and clones `token.place` and
     `democratizedspace/dspace` (branch `v3`) by default. Set

--- a/scripts/collect_pi_image.sh
+++ b/scripts/collect_pi_image.sh
@@ -38,6 +38,10 @@ if [ -z "${found}" ]; then
   # Accept zip bundles containing a .img
   zipfile="$(_find_first '*.zip' || true)"
   if [ -n "${zipfile}" ]; then
+    if ! command -v bsdtar >/dev/null 2>&1; then
+      echo "ERROR: bsdtar is required to extract zip archives" >&2
+      exit 1
+    fi
     tmpdir="$(mktemp -d)"
     tmpdirs+=("$tmpdir")
     # Use bsdtar from libarchive-tools (handles zip); avoid needing 'unzip'


### PR DESCRIPTION
## Summary
- warn when bsdtar is missing while collecting Pi images
- document bsdtar dependency for zip extraction

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c5d7991340832f892064d5d2fccfcf