### PR TITLE
🔌 add ground pour continuity reminder to power ring

### DIFF
--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -11,6 +11,7 @@
                 (comment 4 "Use star topology for power distribution to minimize voltage drop")
                 (comment 5 "Use thick traces for high-current paths")
                 (comment 6 "Add fiducial markers for board orientation")
+                (comment 7 "Verify ground pour continuity around mounting holes")
         )
         (lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/elex/power_ring/specs.md
+++ b/elex/power_ring/specs.md
@@ -20,9 +20,9 @@ The design may evolve as the project grows.
 - Silkscreen labels for polarity and connector numbers
 - Fiducial markers to indicate board orientation for easier assembly
 - Title block comments record decoupling guidelines, high-current trace layout, thick traces
-  for high-current paths, connector labeling, export checks, ground pour continuity around
-  mounting holes, board outline fit, BOM validation, clearance rules for high-voltage nets,
-  and star topology to minimize voltage drop
+  for high-current paths, connector labeling, export checks, board outline fit, BOM validation,
+  clearance rules for high-voltage nets, star topology to minimize voltage drop, and now ground
+  pour continuity around mounting holes
 
 These requirements are a starting point – modify the KiCad project as needed and
 update this file when the schematic changes.

--- a/outages/2025-09-13-kicad-export-pcbnew-missing.json
+++ b/outages/2025-09-13-kicad-export-pcbnew-missing.json
@@ -1,0 +1,10 @@
+{
+  "id": "kicad-export-pcbnew-missing",
+  "date": "2025-09-13",
+  "component": "kicad-export",
+  "rootCause": "KiCad not installed; pcbnew Python module not found",
+  "resolution": "Install KiCad 9 and ensure pcbnew is available via PYTHONPATH",
+  "references": [
+    "kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml"
+  ]
+}


### PR DESCRIPTION
## Summary
- add title-block comment reminding designers to verify ground pour continuity around mounting holes
- document the new note in power ring specs
- record kibot failure due to missing KiCad

## Testing
- `kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml` *(fails: pcbnew Python module missing)*
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`

------
https://chatgpt.com/codex/tasks/task_e_68c5d76f1b5c832fb9a0b5e61e606b19