### PR TITLE
feat: seed default ports for Pi services

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -44,10 +44,12 @@ unless-stopped` so containers relaunch across reboots.
 ## 3. Boot and verify locally
 
 1. Insert the card and power on the Pi.
-2. On first boot the Pi builds the containers defined in
+2. On first boot the Pi installs Docker, builds the containers defined in
    `/opt/projects/docker-compose.yml` and enables `projects-compose.service`.
-3. Confirm the stack is running:
+3. Confirm Docker and the stack are running:
    ```sh
+   docker --version
+   docker compose version
    sudo systemctl status projects-compose.service
    ```
 4. Verify each app on the LAN:
@@ -91,10 +93,10 @@ unless-stopped` so containers relaunch across reboots.
 ## 5. Runtime environment variables
 
 Each project reads an `.env` file in its directory. `init-env.sh` scans
-`/opt/projects` for `*.env.example` files and copies them to `.env` when missing,
-letting containers start with sane defaults. The script ships an `ensure_env`
-helper that creates blank files when a project omits an example. Edit these files
-to set variables like `PORT`, API URLs or secrets:
+`/opt/projects` for `*.env.example` files and copies them to `.env` when missing.
+When a repository omits an example file, `ensure_env` creates a blank one and the
+script seeds a default `PORT` so containers start with predictable endpoints.
+Edit these files to set variables like API URLs or secrets:
 
 - `/opt/projects/token.place/.env` — example:
   ```ini

--- a/scripts/cloud-init/init-env.sh
+++ b/scripts/cloud-init/init-env.sh
@@ -23,6 +23,15 @@ ensure_env() {
 ensure_env token.place/.env
 ensure_env dspace/frontend/.env
 
+# Seed default ports when not already set so the containers expose predictable
+# endpoints on first boot. token.place defaults to 5000 and dspace to 3000.
+if [ -f token.place/.env ] && ! grep -q '^PORT=' token.place/.env 2>/dev/null; then
+  echo 'PORT=5000' >> token.place/.env
+fi
+if [ -f dspace/frontend/.env ] && ! grep -q '^PORT=' dspace/frontend/.env 2>/dev/null; then
+  echo 'PORT=3000' >> dspace/frontend/.env
+fi
+
 # extra-start
 # Add additional environment setup steps below. Example:
 # ensure_env other_repo/.env


### PR DESCRIPTION
## Summary
- seed default PORT values for token.place and dspace env files
- document Docker verification and default env seeding for Pi image

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `npm run lint` *(fails: ENOENT package.json)*
- `npm run test:ci` *(fails: ENOENT package.json)*
- `git diff --cached | ./scripts/scan-secrets.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5d77982e0832fb2e8e9a573301f23