### PR TITLE
docs: verify Docker for token.place and dspace services

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -46,11 +46,16 @@ unless-stopped` so containers relaunch across reboots.
 1. Insert the card and power on the Pi.
 2. On first boot the Pi builds the containers defined in
    `/opt/projects/docker-compose.yml` and enables `projects-compose.service`.
-3. Confirm the stack is running:
+3. Check Docker is available:
+   ```sh
+   docker --version
+   docker compose version
+   ```
+4. Confirm the stack is running:
    ```sh
    sudo systemctl status projects-compose.service
    ```
-4. Verify each app on the LAN:
+5. Verify each app on the LAN:
    ```sh
    curl http://<pi-host>:5000  # token.place
    curl http://<pi-host>:3000  # dspace
@@ -90,24 +95,17 @@ unless-stopped` so containers relaunch across reboots.
 
 ## 5. Runtime environment variables
 
-Each project reads an `.env` file in its directory. `init-env.sh` scans
-`/opt/projects` for `*.env.example` files and copies them to `.env` when missing,
-letting containers start with sane defaults. The script ships an `ensure_env`
-helper that creates blank files when a project omits an example. Edit these files
-to set variables like `PORT`, API URLs or secrets:
+Each project reads an `.env` file. `init-env.sh` copies any `*.env.example` to
+`.env` and uses an `ensure_env` helper for projects without examples.
 
-- `/opt/projects/token.place/.env` — example:
-  ```ini
-  PORT=5000
-  ```
-- `/opt/projects/dspace/frontend/.env` — example:
-  ```ini
-  PORT=3000
-  ```
+| Service      | File                     | Variable | Default | Description             |
+| ------------ | ------------------------ | -------- | ------- | ----------------------- |
+| token.place  | token.place/.env         | `PORT`   | `5000`  | Web server port.        |
+| dspace       | dspace/frontend/.env     | `PORT`   | `3000`  | Web server port.        |
 
-Add more calls to `ensure_env` under the `# extra-start` marker in `init-env.sh`
-for additional repositories. See each project's README for the full list of
-configuration options.
+Add calls to `ensure_env` under the `# extra-start` marker in `init-env.sh` for
+more repositories. See each project's README for additional environment
+variables.
 
 ## 6. Extend with new repositories
 

--- a/scripts/cloud-init/start-projects.sh
+++ b/scripts/cloud-init/start-projects.sh
@@ -3,6 +3,19 @@ set -euo pipefail
 
 svc="projects-compose.service"
 
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker not found; skipping ${svc}" >&2
+  exit 0
+fi
+
+# Show engine and compose versions for diagnostics
+docker --version || true
+if ! docker compose version >/dev/null 2>&1; then
+  echo "docker compose plugin not found; skipping ${svc}" >&2
+  exit 0
+fi
+docker compose version || true
+
 if ! command -v systemctl >/dev/null 2>&1; then
   echo "systemctl not found; skipping ${svc}" >&2
   exit 0


### PR DESCRIPTION
what: log docker engine/compose versions and expand runbook env table
why: ensure Pi image has docker compose and document env hooks
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68c5d77982e0832fb2e8e9a573301f23