### PR TITLE
feat: make Pi image project branches configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ the docs you will see the term used in both contexts.
     without `realpath`
   - `build_pi_image.sh` — build a Raspberry Pi OS image with cloud-init and
     k3s preinstalled; embeds `pi_node_verifier.sh` and clones `token.place` and
-    `democratizedspace/dspace` (branch `v3`) by default. Set
+    `democratizedspace/dspace` by default. Customize branches with
+    `TOKEN_PLACE_BRANCH` (default `main`) and `DSPACE_BRANCH` (default `v3`). Set
     `CLONE_SUGARKUBE=true` to include this repo and pass space-separated Git URLs
     via `EXTRA_REPOS` to clone additional projects; needs a valid `user-data.yaml`
     and ~10 GB free disk space. Set `DEBUG=1` to trace script execution.

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -47,9 +47,11 @@ The script rewrites the Cloudflare apt source architecture to `armhf` when
 `ARM64=1` to avoid generating both architectures.
 
 The image embeds `pi_node_verifier.sh` in `/usr/local/sbin` and clones the
-`token.place` and `democratizedspace/dspace` (branch `v3`) repositories into
-`/opt/projects` by default. Set `CLONE_SUGARKUBE=true` to include this repo and
-pass space-separated Git URLs in `EXTRA_REPOS` to pull additional projects.
+`token.place` and `democratizedspace/dspace` repositories into
+`/opt/projects` by default. Customize branches with `TOKEN_PLACE_BRANCH`
+(default `main`) and `DSPACE_BRANCH` (default `v3`). Set `CLONE_SUGARKUBE=true`
+to include this repo and pass space-separated Git URLs in `EXTRA_REPOS` to pull
+additional projects.
 `start-projects.sh` enables the optional `projects-compose` systemd unit on
 first boot and now checks for `systemctl`, skipping quietly when systemd isn't
 present.

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -15,6 +15,8 @@ Environment variables:
   CLOUD_INIT_PATH   Path to cloud-init user-data (default scripts/cloud-init/user-data.yaml)
   OUTPUT_DIR        Directory to write the image (default repo root)
   IMG_NAME          Name for the output image (default sugarkube)
+  TOKEN_PLACE_BRANCH Branch of token.place to clone (default main)
+  DSPACE_BRANCH     Branch of dspace to clone (default v3)
 
 See docs/pi_image_cloudflare.md for details.
 EOF
@@ -242,6 +244,8 @@ CLONE_SUGARKUBE="${CLONE_SUGARKUBE:-false}"
 CLONE_TOKEN_PLACE="${CLONE_TOKEN_PLACE:-true}"
 CLONE_DSPACE="${CLONE_DSPACE:-true}"
 EXTRA_REPOS="${EXTRA_REPOS:-}"
+TOKEN_PLACE_BRANCH="${TOKEN_PLACE_BRANCH:-main}"
+DSPACE_BRANCH="${DSPACE_BRANCH:-v3}"
 
 # Prepare compose file for token.place and dspace; drop services when skipped
 PROJECTS_COMPOSE_TEMP="${WORK_DIR}/docker-compose.yml"
@@ -274,8 +278,10 @@ run_sh="${WORK_DIR}/pi-gen/stage2/02-sugarkube-tools/00-run-chroot.sh"
     echo "install -d /opt/projects"
     echo "cd /opt/projects"
     [[ "$CLONE_SUGARKUBE" == "true" ]] && echo "git clone --depth 1 https://github.com/futuroptimist/sugarkube.git"
-    [[ "$CLONE_TOKEN_PLACE" == "true" ]] && echo "git clone --depth 1 https://github.com/futuroptimist/token.place.git"
-    [[ "$CLONE_DSPACE" == "true" ]] && echo "git clone --depth 1 --branch v3 https://github.com/democratizedspace/dspace.git"
+    [[ "$CLONE_TOKEN_PLACE" == "true" ]] && \
+      echo "git clone --depth 1 --branch ${TOKEN_PLACE_BRANCH} https://github.com/futuroptimist/token.place.git"
+    [[ "$CLONE_DSPACE" == "true" ]] && \
+      echo "git clone --depth 1 --branch ${DSPACE_BRANCH} https://github.com/democratizedspace/dspace.git"
     if [[ -n "$EXTRA_REPOS" ]]; then
       for repo in $EXTRA_REPOS; do
         echo "git clone --depth 1 $repo"


### PR DESCRIPTION
## Summary
- allow selecting token.place/dspace branches via env vars
- document project branch overrides in Pi image build guide

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c5d772f090832fa0773d9a11d868a5