### PR TITLE
🔧: validate init scripts in image build

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -52,7 +52,8 @@ The image embeds `pi_node_verifier.sh` in `/usr/local/sbin` and clones the
 pass space-separated Git URLs in `EXTRA_REPOS` to pull additional projects.
 `start-projects.sh` enables the optional `projects-compose` systemd unit on
 first boot and now checks for `systemctl`, skipping quietly when systemd isn't
-present.
+present. The build script also verifies `start-projects.sh` and `init-env.sh`
+are non-empty to avoid embedding blank hooks.
 
 On first boot `init-env.sh` copies each project's `.env.example` to `.env` and
 sets its mode to `0600` so secrets stay private.

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -142,8 +142,16 @@ if [ ! -f "${START_PROJECTS_PATH}" ]; then
   echo "Start projects script not found: ${START_PROJECTS_PATH}" >&2
   exit 1
 fi
+if [ ! -s "${START_PROJECTS_PATH}" ]; then
+  echo "Start projects script is empty: ${START_PROJECTS_PATH}" >&2
+  exit 1
+fi
 if [ ! -f "${INIT_ENV_PATH}" ]; then
   echo "Init env script not found: ${INIT_ENV_PATH}" >&2
+  exit 1
+fi
+if [ ! -s "${INIT_ENV_PATH}" ]; then
+  echo "Init env script is empty: ${INIT_ENV_PATH}" >&2
   exit 1
 fi
 


### PR DESCRIPTION
what: verify init scripts are non-empty and document the check
why: avoid embedding blank hooks in Pi images
how to test: pre-commit run --all-files
            pyspelling -c .spellcheck.yaml
            linkchecker --no-warnings README.md docs/
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c5d772f090832fa0773d9a11d868a5