### PR TITLE
🛠️ add Pi image checksum

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -21,7 +21,9 @@ where artifacts are written; the script creates the directory if needed. Run
 `scripts/build_pi_image.sh --help` for a summary of configurable environment
 variables. To avoid accidental overwrites it aborts when the image already
 exists unless `FORCE_OVERWRITE=1` is set. Set `FORCE_OVERWRITE=1` when rerunning
-builds to replace an existing image. To reduce flaky downloads it pins the
+builds to replace an existing image. After a successful build the script writes
+`<IMG_NAME>.img.xz.sha256` alongside the image so you can verify integrity.
+To reduce flaky downloads it pins the
 official Raspberry Pi and Debian mirrors, adds `APT_OPTS` (retries, timeouts,
 `-o APT::Get::Fix-Missing=true`), and installs a persistent apt/dpkg Pre-Invoke hook
 that rewrites any raspbian host to a stable HTTPS mirror and bypasses proxies for

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -434,4 +434,7 @@ if [ ! -s "${OUT_IMG}" ]; then
   echo "Output image not found or empty: ${OUT_IMG}" >&2
   exit 1
 fi
+sha256_file="${OUT_IMG}.sha256"
+sha256sum "${OUT_IMG}" > "${sha256_file}"
 echo "[sugarkube] Image written to ${OUT_IMG}"
+echo "[sugarkube] SHA256 checksum stored in ${sha256_file}"


### PR DESCRIPTION
## Summary
- write SHA256 hash alongside built image for integrity checks
- document checksum file in Pi image guide

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c5d772f090832fa0773d9a11d868a5