### PR TITLE
docs: add volume backup example for token.place and dspace

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -275,6 +275,20 @@ docker volume ls | grep dspace-data
 ```
 
 Adjust container paths to match each project's documentation.
+
+### Backup container data
+
+Create compressed backups of the token.place and dspace volumes:
+
+```sh
+cd /opt/projects
+docker run --rm -v tokenplace-data:/data -v "$(pwd)":/backup alpine \
+  tar czf /backup/tokenplace-data.tar.gz -C /data .
+docker run --rm -v dspace-data:/data -v "$(pwd)":/backup alpine \
+  tar czf /backup/dspace-data.tar.gz -C /data .
+ls -lh tokenplace-data.tar.gz dspace-data.tar.gz
+```
+
 ### Auto-restart containers with Docker restart policies
 
 Keep token.place and dspace running after crashes or reboots by adding


### PR DESCRIPTION
## Summary
- document backing up token.place and dspace volumes on the Pi

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5d75efe7c832fa607a7e2a7d21937