### PR TITLE
docs: expand Pi Docker walkthrough with container checks

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -29,19 +29,22 @@ For a prebuilt image that already clones both projects, see
    - Single `Dockerfile`: `docker buildx build --platform linux/arm64 -t myapp . --load`
      then `docker run -d --name myapp -p 8080:8080 myapp`.
    - `docker-compose.yml`: `docker compose up -d`.
-5. Inspect container logs to confirm the service started:
+5. Verify the container is running:
+   - Single container: `docker ps --format '{{.Names}}' | grep myapp`
+   - Compose project: `docker compose ps`
+6. Inspect container logs to confirm the service started:
    - Single container: `docker logs -f myapp`
    - Compose project: `docker compose logs`
-6. Confirm the service responds locally, e.g.
+7. Confirm the service responds locally, e.g.
    `curl http://localhost:5000` for token.place or
    `curl http://localhost:3002` for dspace.
-7. Optionally expose ports through the Cloudflare Tunnel by editing
+8. Optionally expose ports through the Cloudflare Tunnel by editing
    `/opt/sugarkube/docker-compose.cloudflared.yml`.
-8. Visit the Cloudflare URL to verify remote access, for example
+9. Visit the Cloudflare URL to verify remote access, for example
    `curl https://tokenplace.example.com` or
    `curl https://dspace.example.com` once the tunnel restarts.
-9. Log recurring deployment failures in `outages/` using
-   [`schema.json`](../outages/schema.json).
+10. Log recurring deployment failures in `outages/` using
+    [`schema.json`](../outages/schema.json).
 
 ## Quick start
 
@@ -719,6 +722,25 @@ docker restart tokenplace
 cd /opt/projects/dspace/frontend
 git pull
 docker compose up -d --build
+```
+
+### Auto-update with Watchtower
+
+Run [Watchtower](https://github.com/containrrr/watchtower) to automatically pull and
+restart updated images:
+
+```sh
+docker run -d --name watchtower \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  containrrr/watchtower tokenplace dspace-frontend
+```
+
+Watchtower checks for updates every 24 hours by default. Trigger a manual check:
+
+```sh
+docker run --rm \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  containrrr/watchtower --run-once tokenplace dspace-frontend
 ```
 
 ## 7. Troubleshooting and outages


### PR DESCRIPTION
## Summary
- document verifying container status in Pi Docker walkthrough
- add Watchtower auto-update example for token.place and dspace

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5d75efe7c832fa607a7e2a7d21937