### PR TITLE
🛠️ : enlarge pi carrier countersink diameter

### DIFF
--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -30,7 +30,7 @@ assert(standoff_diam >= insert_od + 2,
        "standoff_diam must be ≥ insert_od + 2");
 screw_clearance_diam = 3.2; // through-hole clearance, slightly oversize
 
-countersink_diam = 5.0;
+countersink_diam = 5.5; // enlarged to 5.5 mm for easier screw head clearance
 countersink_depth = 1.6;
 
 nut_clearance = 0.4; // extra room for easier nut insertion (was 0.3)


### PR DESCRIPTION
## Summary
- enlarge pi carrier countersink to 5.5 mm for better screw clearance

## Testing
- `./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c5d7471060832f8e034ec35ac71a43