### PR TITLE
Simplify Pi carrier render and adjust nut clearance

### DIFF
--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -33,7 +33,7 @@ screw_clearance_diam = 3.2; // through-hole clearance, slightly oversize
 countersink_diam = 5.0;
 countersink_depth = 1.6;
 
-nut_clearance = 0.4; // extra room for easier nut insertion (was 0.3)
+nut_clearance = 0.5; // extra room for easier nut insertion (was 0.4)
 nut_flat = 5.0 + nut_clearance; // across flats for M2.5 nut
 nut_thick = 2.0;
 
@@ -154,12 +154,4 @@ module pi_carrier()
     }
 }
 
-// Preview
-if ($preview) {
-    pi_carrier();
-}
-
-// Auto-render for CLI/F7
-if ($preview==false) {
-    pi_carrier();
-}
+pi_carrier();


### PR DESCRIPTION
## Summary
- increase nut clearance for captive hex standoffs
- remove preview-specific render branches in Pi carrier SCAD

## Testing
- `./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c5d7471060832f8e034ec35ac71a43