### PR TITLE
🔩 Relax nut clearance in CAD standoffs

### DIFF
--- a/cad/pi_cluster/pi5_triple_carrier_rot45.scad
+++ b/cad/pi_cluster/pi5_triple_carrier_rot45.scad
@@ -57,7 +57,7 @@ screw_major     = 2.50;   // M2.5
 screw_pitch     = 0.45;   // ISO coarse
 thread_facets   = 32;     // helix resolution
 screw_clearance = 3.2;    // through-hole clearance, slightly oversize
-nut_clearance   = 0.4;    // extra room for easier nut insertion (was 0.3)
+nut_clearance   = 0.5;    // extra room for easier nut insertion
 nut_flat        = 5.0 + nut_clearance; // across flats for M2.5 nut
 nut_thick       = 2.0;    // nut thickness
 

--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -33,7 +33,7 @@ screw_clearance_diam = 3.2; // through-hole clearance, slightly oversize
 countersink_diam = 5.0;
 countersink_depth = 1.6;
 
-nut_clearance = 0.4; // extra room for easier nut insertion (was 0.3)
+nut_clearance = 0.5; // extra room for easier nut insertion
 nut_flat = 5.0 + nut_clearance; // across flats for M2.5 nut
 nut_thick = 2.0;
 

--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -26,7 +26,7 @@ screw_nominal     = 5.0;      // nominal screw size for through-hole (mm)
 screw_clearance   = screw_nominal + 0.2; // through-hole Ø with clearance (mm)
 chamfer           = 1.0;      // lead-in chamfer (mm)
 
-nut_clearance     = 0.4;      // extra room for easier nut insertion (was 0.2)
+nut_clearance     = 0.5;      // extra room for easier nut insertion
 nut_flat          = 8.0 + nut_clearance; // across flats for M5 nut (mm)
 
 nut_thick         = 4.0;      // nut thickness (mm)


### PR DESCRIPTION
## Summary
- widen `nut_clearance` to 0.5 mm in standoff-based models for easier nut insertion

## Testing
- `./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `./scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `pre-commit run --all-files`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5d7471060832f8e034ec35ac71a43