### PR TITLE
feat: allow skipping cloud-init validation

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -42,6 +42,8 @@ deleting it, which aids debugging failed builds.
 
 `REQUIRED_SPACE_GB` (default: `10`) controls free disk space checks on the
 temporary work directory and the output location.
+Set `SKIP_CLOUD_INIT_VALIDATION=1` to bypass cloud-init YAML validation when
+PyYAML isn't available or when speed matters.
 The script rewrites the Cloudflare apt source architecture to `armhf` when
 `ARM64=0` so 32-bit builds install the correct packages and sets `ARMHF=0` when
 `ARM64=1` to avoid generating both architectures.
@@ -68,10 +70,11 @@ connectivity. The script curls the Debian, Raspberry Pi, and pi-gen repositories
 with a 10-second timeout before building; override this via the
 `URL_CHECK_TIMEOUT` environment variable or set `SKIP_URL_CHECK=1` to bypass
 these probes when using local mirrors or working offline. Ensure `curl`, `docker`
-(with its daemon running), `git`, `sha256sum`, `stdbuf`, `timeout`, `xz`, `bsdtar`, `df`,
-and `python3` are installed before running it; `stdbuf` and `timeout` come from GNU coreutils.
-The script attempts to validate the cloud-init YAML via PyYAML and skips the check when the
-module is missing. It checks that both the temporary and output directories have at least 10 GB free
+(with its daemon running), `git`, `sha256sum`, `stdbuf`, `timeout`, `xz`, `bsdtar`, and `df`
+are installed before running it; `stdbuf` and `timeout` come from GNU coreutils.
+The script validates the cloud-init YAML via PyYAML when available unless
+`SKIP_CLOUD_INIT_VALIDATION=1` is set; python3 with PyYAML is only required when
+validation runs. It checks that both the temporary and output directories have at least 10 GB free
 before starting and verifies the resulting image exists and is non-empty before
 reporting success. Use the prepared image to deploy containerized apps. The
 companion guide [docker_repo_walkthrough.md](docker_repo_walkthrough.md)

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -41,10 +41,9 @@ check_space() {
 
 # Build a Raspberry Pi OS image with cloud-init files preloaded.
 # Requires curl, docker, git, sha256sum, stdbuf, timeout, xz, bsdtar, df and roughly
-# 10 GB of free disk space. Set PI_GEN_URL to override the default pi-gen
-# repository.
+# 10 GB of free disk space. Set PI_GEN_URL to override the default pi-gen repository.
 
-for cmd in curl docker git sha256sum stdbuf timeout xz bsdtar df python3; do
+for cmd in curl docker git sha256sum stdbuf timeout xz bsdtar df; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "$cmd is required" >&2
     exit 1
@@ -108,18 +107,23 @@ if ! head -n1 "${CLOUD_INIT_PATH}" | grep -q '^#cloud-config'; then
 fi
 
 # Validate cloud-init YAML syntax when PyYAML is available
-if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" >/dev/null 2>&1; then
-  if ! python3 - "${CLOUD_INIT_PATH}" <<'PY' >/dev/null 2>&1
+SKIP_CLOUD_INIT_VALIDATION="${SKIP_CLOUD_INIT_VALIDATION:-0}"
+if [ "${SKIP_CLOUD_INIT_VALIDATION}" -ne 1 ]; then
+  if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" >/dev/null 2>&1; then
+    if ! python3 - "${CLOUD_INIT_PATH}" <<'PY' >/dev/null 2>&1
 import sys, yaml
 with open(sys.argv[1]) as f:
     yaml.safe_load(f)
 PY
-  then
-    echo "Cloud-init file contains invalid YAML: ${CLOUD_INIT_PATH}" >&2
-    exit 1
+    then
+      echo "Cloud-init file contains invalid YAML: ${CLOUD_INIT_PATH}" >&2
+      exit 1
+    fi
+  else
+    echo "PyYAML not installed; skipping cloud-init YAML validation" >&2
   fi
 else
-  echo "PyYAML not installed; skipping cloud-init YAML validation" >&2
+  echo "Skipping cloud-init YAML validation"
 fi
 
 if [ ! -f "${CLOUDFLARED_COMPOSE_PATH}" ]; then

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -238,40 +238,6 @@ def test_requires_sha256sum(tmp_path):
     assert "sha256sum is required" in result.stderr
 
 
-def test_requires_python3(tmp_path):
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    for name in [
-        "curl",
-        "docker",
-        "git",
-        "sha256sum",
-        "stdbuf",
-        "timeout",
-        "xz",
-        "bsdtar",
-        "df",
-    ]:
-        path = fake_bin / name
-        if name == "timeout":
-            path.write_text('#!/bin/sh\nshift\nexec "$@"\n')
-        elif name == "stdbuf":
-            path.write_text('#!/bin/sh\nshift\nshift\nexec "$@"\n')
-        else:
-            path.write_text("#!/bin/sh\nexit 0\n")
-        path.chmod(0o755)
-    env = os.environ.copy()
-    env["PATH"] = str(fake_bin)
-    result = subprocess.run(
-        ["/bin/bash", "scripts/build_pi_image.sh"],
-        env=env,
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode != 0
-    assert "python3 is required" in result.stderr
-
-
 def test_docker_daemon_must_be_running(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()


### PR DESCRIPTION
## Summary
- make cloud-init YAML validation optional via SKIP_CLOUD_INIT_VALIDATION
- document new flag and remove python requirement
- drop outdated python3 requirement test

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5d772f090832fa0773d9a11d868a5