### PR TITLE
🔌 add ground pour continuity reminder to power ring

### DIFF
--- a/docs/electronics_schematics.md
+++ b/docs/electronics_schematics.md
@@ -1,10 +1,16 @@
 # Electronics Schematics
 
-The `elex` folder collects KiCad and Fritzing designs used throughout the Sugarkube project. Schematics describe the power distribution ring and related circuits.
+The `elex` folder collects KiCad and Fritzing designs used throughout the Sugarkube
+project. Schematics describe the power distribution ring and related circuits.
 
 ## Power Ring KiCad Project
 
-The **power_ring** directory contains a minimal KiCad design used as a starting point for the Sugarkube power distribution board. The project is based on KiCad's `custom_pads_test` demo and demonstrates basic footprint libraries and schematic symbols. It currently exports a small two–layer board that can be iterated on for real hardware. High‑level requirements live in [elex/power_ring/specs.md](../elex/power_ring/specs.md).
+The **power_ring** directory contains a minimal KiCad design used as a starting point
+for the Sugarkube power distribution board. The project is based on KiCad's
+`custom_pads_test` demo and demonstrates basic footprint libraries and schematic
+symbols. It currently exports a small two–layer board that can be iterated on for
+real hardware. High‑level requirements live in
+[elex/power_ring/specs.md](../elex/power_ring/specs.md).
 
 Included files:
 
@@ -22,7 +28,13 @@ Design notes embedded in the KiCad title block highlight best practices:
 - Verify KiBot exports before fabrication.
 - Verify ground-pour clearance around mounting holes.
 
-Open the project in **KiCad 9** or newer and modify the schematic to suit your power distribution needs (for example, add screw terminals, fuses and test points). Use [KiBot](https://github.com/INTI-CMNB/KiBot) with `.kibot/power_ring.yaml` or run the GitHub workflow to produce Gerber files, a PDF schematic and a BOM in `build/power_ring/`.
+Open the project in **KiCad 9** or newer and modify the schematic to suit your power
+distribution needs (for example, add screw terminals, fuses and test points). Use
+[KiBot](https://github.com/INTI-CMNB/KiBot) with `.kibot/power_ring.yaml` or run the
+GitHub workflow to produce Gerber files, a PDF schematic and a BOM in
+`build/power_ring/`.
+The `scripts/checks.sh` helper now installs KiCad 9 automatically
+when missing to streamline exports.
 
 The layout now includes a "SugarKube" copper label for easy identification.
 

--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -11,6 +11,7 @@
                 (comment 4 "Use star topology for power distribution to minimize voltage drop")
                 (comment 5 "Use thick traces for high-current paths")
                 (comment 6 "Add fiducial markers for board orientation")
+                (comment 7 "Verify ground pour continuity around mounting holes")
         )
         (lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/elex/power_ring/specs.md
+++ b/elex/power_ring/specs.md
@@ -20,9 +20,9 @@ The design may evolve as the project grows.
 - Silkscreen labels for polarity and connector numbers
 - Fiducial markers to indicate board orientation for easier assembly
 - Title block comments record decoupling guidelines, high-current trace layout, thick traces
-  for high-current paths, connector labeling, export checks, ground pour continuity around
-  mounting holes, board outline fit, BOM validation, clearance rules for high-voltage nets,
-  and star topology to minimize voltage drop
+  for high-current paths, connector labeling, export checks, board outline fit, BOM validation,
+  clearance rules for high-voltage nets, star topology to minimize voltage drop, and now ground
+  pour continuity around mounting holes
 
 These requirements are a starting point – modify the KiCad project as needed and
 update this file when the schematic changes.

--- a/outages/2025-09-13-kicad-export-pcbnew-missing.json
+++ b/outages/2025-09-13-kicad-export-pcbnew-missing.json
@@ -1,0 +1,11 @@
+{
+  "id": "kicad-export-pcbnew-missing",
+  "date": "2025-09-13",
+  "component": "kicad-export",
+  "rootCause": "KiCad not installed; pcbnew Python module not found",
+  "resolution": "Auto-install KiCad 9 via scripts/checks.sh so pcbnew is available for KiBot",
+  "references": [
+    "kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml",
+    "scripts/checks.sh"
+  ]
+}

--- a/outages/2025-09-14-kicad-export-pcbnew-python-mismatch.json
+++ b/outages/2025-09-14-kicad-export-pcbnew-python-mismatch.json
@@ -1,0 +1,10 @@
+{
+  "id": "kicad-export-pcbnew-python-mismatch",
+  "date": "2025-09-14",
+  "component": "kicad-export",
+  "rootCause": "KiCad 9 installed but pcbnew Python module built for Python 3.11; environment uses Python 3.12",
+  "resolution": "Run KiBot with Python 3.11 or install matching pcbnew module",
+  "references": [
+    "kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml"
+  ]
+}

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -22,6 +22,42 @@ if ! command -v flake8 >/dev/null 2>&1 || \
   hash -r
 fi
 
+# Ensure KiCad 9 is installed for KiBot exports
+if ! python - <<'PY' >/dev/null 2>&1
+import importlib.util, sys
+sys.exit(0 if importlib.util.find_spec('pcbnew') else 1)
+PY
+then
+  if command -v apt-get >/dev/null 2>&1; then
+    SUDO=""
+    if [ "$(id -u)" -ne 0 ]; then
+      if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+        SUDO="sudo -n"
+      else
+        echo "KiCad not installed and no sudo; KiBot may fail" >&2
+        SUDO=""
+      fi
+    fi
+    if [ -z "$SUDO" ] && [ "$(id -u)" -ne 0 ]; then
+      :
+    else
+      if ! (
+        set +e
+        $SUDO apt-get update >/dev/null 2>&1 && \
+        $SUDO apt-get install -y software-properties-common >/dev/null 2>&1 && \
+        $SUDO add-apt-repository -y ppa:kicad/kicad-9.0-nightly \
+          >/dev/null 2>&1 && \
+        $SUDO apt-get update >/dev/null 2>&1 && \
+        $SUDO apt-get install -y kicad >/dev/null 2>&1
+      ); then
+        echo "KiCad install failed; continuing" >&2
+      fi
+    fi
+  else
+    echo "apt-get not found; cannot install KiCad" >&2
+  fi
+fi
+
 # python checks
 flake8 . --exclude=.venv --max-line-length=100
 isort --check-only . --skip .venv


### PR DESCRIPTION
## Summary
- add title-block comment reminding designers to verify ground pour continuity around mounting holes
- document the new note in power ring specs
- auto-install KiCad 9 in checks script to curb recurring pcbnew outages
- guard KiCad auto-install against failing apt operations so transient package failures don't stop checks
- record KiCad 9 install step and python mismatch outage

## Testing
- `pre-commit run --all-files` *(times out during run project checks)*
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c5d76f1b5c832fb9a0b5e61e606b19