### PR TITLE
docs: document compose env for token.place and dspace

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -109,22 +109,25 @@ helper that creates blank files when a project omits an example, and seeds a
 default `PORT` so containers start with predictable endpoints. Edit these files
 to set variables like ports, API URLs, or secrets.
 
-| Service     | Path to env file                     | Example     |
-| ----------- | ------------------------------------ | ----------- |
-| token.place | `/opt/projects/token.place/.env`     | `PORT=5000` |
-| dspace      | `/opt/projects/dspace/frontend/.env` | `PORT=3000` |
+| Service     | Path to env file                     | Key variables (examples) |
+| ----------- | ------------------------------------ | ------------------------ |
+| token.place | `/opt/projects/token.place/.env`     | `TOKEN_PLACE_ENV`, `SUPABASE_URL`, `SUPABASE_KEY`, `PORT` |
+| dspace      | `/opt/projects/dspace/frontend/.env` | `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `PORT` |
 
-Add more calls to `ensure_env` under the `# extra-start` marker in `init-env.sh`
-for additional repositories. See each project's README for the full list of
-configuration options.
+Populate these files with values from each project's README. Add more calls to
+`ensure_env` under the `# extra-start` marker in `init-env.sh` for additional
+repositories.
 
 ## 6. Extend with new repositories
 
-Pass Git URLs via `EXTRA_REPOS` to clone additional projects into `/opt/projects`.
-Add services to `/opt/projects/docker-compose.yml` between `# extra-start` and
-`# extra-end`, and extend `init-env.sh` with any new `.env` files, following the
-token.place and dspace examples. The image builder drops the token.place or
-dspace definitions when the corresponding `CLONE_*` flag is `false`, letting you
-build a minimal image and expand it later.
+1. Pass Git URLs via `EXTRA_REPOS` to clone additional projects into
+   `/opt/projects`.
+2. Add services to `/opt/projects/docker-compose.yml` between `# extra-start`
+   and `# extra-end`.
+3. Extend `init-env.sh` with `ensure_env` calls for new `.env` files.
+4. Reboot or run `sudo systemctl restart projects-compose` to apply changes.
 
-Use these hooks to experiment with other projects and grow the image over time.
+The image builder drops the token.place or dspace definitions when the
+corresponding `CLONE_*` flag is `false`, letting you build a minimal image and
+expand it later. Use these hooks to experiment with other projects and grow the
+image over time.

--- a/scripts/cloud-init/docker-compose.yml
+++ b/scripts/cloud-init/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     ports:
       - "5000:5000"
     env_file:
+      # Define TOKEN_PLACE_ENV, SUPABASE_URL, SUPABASE_KEY and PORT in this file
       - /opt/projects/token.place/.env
     restart: unless-stopped
   # tokenplace-end
@@ -22,6 +23,7 @@ services:
     ports:
       - "3000:3000"
     env_file:
+      # Define NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY and PORT here
       - /opt/projects/dspace/frontend/.env
     restart: unless-stopped
   # dspace-end


### PR DESCRIPTION
## Summary
- note env vars for token.place and dspace in shared compose
- outline how to extend compose for additional services

## Testing
- `SKIP=run-checks python3 -m pre_commit run --all-files`
- `python3 -m pyspelling -c .spellcheck.yaml`
- `/root/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c65b53f960832fb5a84a38d773cd08