### PR TITLE
docs: add projects-compose service guidance

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ Review the safety notes before working with power components.
 - [pi_image_cloudflare.md](pi_image_cloudflare.md) — preconfigure Docker and Cloudflare tunnels
 - [raspi_cluster_setup.md](raspi_cluster_setup.md) — build a three-node k3s cluster and deploy apps
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
+- [projects-compose.md](projects-compose.md) — run token.place & dspace via docker compose
 - [pi_token_dspace.md](pi_token_dspace.md) — build and expose token.place & dspace via Cloudflare
 - [pi_image_builder_design.md](pi_image_builder_design.md) — design and reliability features of the image builder
 

--- a/docs/projects-compose.md
+++ b/docs/projects-compose.md
@@ -1,0 +1,38 @@
+# projects-compose Service
+
+The prebuilt Pi image includes Docker Engine, the Compose plugin and a
+systemd unit called `projects-compose.service`. On first boot the unit builds
+and starts [token.place](https://github.com/futuroptimist/token.place) and
+[dspace](https://github.com/democratizedspace/dspace) from the shared
+`/opt/projects/docker-compose.yml` file.
+
+## Environment files
+
+Each project reads an `.env` file from its directory. `init-env.sh` seeds these
+files so containers start with sensible defaults:
+
+| Service | `.env` location | Default |
+| --- | --- | --- |
+| token.place | `/opt/projects/token.place/.env` | `PORT=5000` |
+| dspace | `/opt/projects/dspace/frontend/.env` | `PORT=3000` |
+
+Edit the files to add variables described in each project's README, such as API
+keys or upstream URLs.
+
+## Extend the stack
+
+Grow the compose stack with additional repositories:
+
+1. Clone the repository into `/opt/projects` (set `EXTRA_REPOS` when building
+   the image or clone after boot).
+2. Add a service definition to `/opt/projects/docker-compose.yml` between
+   `# extra-start` and `# extra-end`.
+3. Append an `ensure_env <repo>/.env` line under the matching marker in
+   `/opt/projects/init-env.sh`.
+4. Restart the unit:
+   ```sh
+   sudo systemctl restart projects-compose.service
+   ```
+
+These hooks keep the Pi image ready for new services without editing existing
+entries.

--- a/scripts/cloud-init/start-projects.sh
+++ b/scripts/cloud-init/start-projects.sh
@@ -16,16 +16,14 @@ if ! docker compose version >/dev/null 2>&1; then
 fi
 docker compose version || true
 
+# Seed .env files before the service starts so defaults exist
+if [ -x /opt/projects/init-env.sh ]; then
+  /opt/projects/init-env.sh || true
+fi
+
 if ! command -v systemctl >/dev/null 2>&1; then
   echo "systemctl not found; skipping ${svc}" >&2
   exit 0
-fi
-
-if command -v docker >/dev/null 2>&1; then
-  docker --version
-  docker compose version
-else
-  echo "docker not found; skipping version checks" >&2
 fi
 
 if systemctl list-unit-files | grep -q "^${svc}"; then


### PR DESCRIPTION
## Summary
- seed `.env` files before enabling projects-compose
- document `projects-compose` service and how to extend it
- link compose guide from docs index

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `~/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c65b53f960832fb5a84a38d773cd08