### PR TITLE
🧪: cover skip statuses in pi_node_verifier JSON output

### DIFF
--- a/tests/pi_node_verifier_json_test.bats
+++ b/tests/pi_node_verifier_json_test.bats
@@ -36,3 +36,15 @@ EOF
   echo "$output" | jq -e '.checks[] | select(.name=="time_sync") | .status=="fail"' > /dev/null
   echo "$output" | jq -e '.checks[] | select(.name=="iptables_backend") | .status=="fail"' > /dev/null
 }
+
+@test "pi_node_verifier reports skipped checks in JSON" {
+  tmp="$(mktemp -d)"
+  ln -s "$(command -v bash)" "$tmp/bash"
+  ln -s "$(command -v grep)" "$tmp/grep"
+  PATH="$tmp" run "$BATS_TEST_DIRNAME/../scripts/pi_node_verifier.sh" --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.checks[] | select(.name=="cloud_init") | .status=="skip"' > /dev/null
+  echo "$output" | jq -e '.checks[] | select(.name=="time_sync") | .status=="skip"' > /dev/null
+  echo "$output" | jq -e '.checks[] | select(.name=="iptables_backend") | .status=="skip"' > /dev/null
+  echo "$output" | jq -e '.checks[] | select(.name=="k3s_check_config") | .status=="skip"' > /dev/null
+}


### PR DESCRIPTION
## Summary
- test JSON skip statuses when required tools are absent

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68c65b72c6e0832f8a242a29a9e1604c