### PR TITLE
docs: add CLI abbreviations to wordlist

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -108,6 +108,7 @@ dev
 dir
 dropdown
 dspace
+ef
 elex
 env
 eslint
@@ -121,6 +122,7 @@ frontend
 fstab
 futuroptimist
 gabriel
+gh
 github
 heatmap
 heatset


### PR DESCRIPTION
## Summary
- add `gh` and `ef` to custom wordlist to avoid false positives

## Testing
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `pre-commit run --all-files`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c65b649ae4832f8dbbd20a33e6390d