### PR TITLE
🔌 : note fuse orientation in power ring design

### DIFF
--- a/elex/power_ring/power_ring.kicad_pcb
+++ b/elex/power_ring/power_ring.kicad_pcb
@@ -11,6 +11,7 @@
                 (comment 1 "Keep high-current traces short")
                 (comment 2 "Confirm board outline fits enclosure")
                 (comment 3 "Add fiducial markers for board orientation.")
+                (comment 4 "Check fuse orientation before routing")
         )
         (layers
                 (0 "F.Cu" signal)

--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -12,6 +12,7 @@
                 (comment 5 "Use thick traces for high-current paths")
                 (comment 6 "Add fiducial markers for board orientation")
                 (comment 7 "Verify ground pour continuity around mounting holes")
+                (comment 8 "Document fuse ratings in BOM")
         )
         (lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/elex/power_ring/specs.md
+++ b/elex/power_ring/specs.md
@@ -21,8 +21,8 @@ The design may evolve as the project grows.
 - Fiducial markers to indicate board orientation for easier assembly
 - Title block comments record decoupling guidelines, high-current trace layout, thick traces
   for high-current paths, connector labeling, export checks, board outline fit, BOM validation,
-  clearance rules for high-voltage nets, star topology to minimize voltage drop, and now ground
-  pour continuity around mounting holes
+  clearance rules for high-voltage nets, star topology to minimize voltage drop, ground pour
+  continuity around mounting holes, and fuse orientation checks
 
 These requirements are a starting point – modify the KiCad project as needed and
 update this file when the schematic changes.

--- a/outages/2025-09-14-kicad-export-pcbnew-missing.json
+++ b/outages/2025-09-14-kicad-export-pcbnew-missing.json
@@ -1,0 +1,10 @@
+{
+  "id": "kicad-export-pcbnew-missing",
+  "date": "2025-09-14",
+  "component": "kicad-export",
+  "rootCause": "KiBot could not import pcbnew Python module even after installing KiCad 7; project requires KiCad 9",
+  "resolution": "Run KiBot in an environment with KiCad 9 and matching pcbnew Python module",
+  "references": [
+    "kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml"
+  ]
+}


### PR DESCRIPTION
## Summary
- document fuse ratings and orientation in power_ring title blocks
- mention fuse checks in hardware specs
- record pcbnew module outage for KiBot export

## Testing
- `kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml` *(fails: KiBot could not import pcbnew Python module)*
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c65b4876d8832fb69669742b3fe212