### PR TITLE
Add power rail test point note to power ring

### DIFF
--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -12,6 +12,7 @@
                 (comment 5 "Use thick traces for high-current paths")
                 (comment 6 "Add fiducial markers for board orientation")
                 (comment 7 "Verify ground pour continuity around mounting holes")
+                (comment 8 "Ensure test points on each power rail for debugging")
         )
         (lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/elex/power_ring/specs.md
+++ b/elex/power_ring/specs.md
@@ -16,13 +16,13 @@ The design may evolve as the project grows.
 
 ## Extras
 
-- Test points for measuring battery voltage
+- Test points for measuring battery voltage and key power rails
 - Silkscreen labels for polarity and connector numbers
 - Fiducial markers to indicate board orientation for easier assembly
 - Title block comments record decoupling guidelines, high-current trace layout, thick traces
   for high-current paths, connector labeling, export checks, board outline fit, BOM validation,
-  clearance rules for high-voltage nets, star topology to minimize voltage drop, and now ground
-  pour continuity around mounting holes
+  clearance rules for high-voltage nets, star topology to minimize voltage drop, ground pour
+  continuity around mounting holes, and test points on each power rail for debugging
 
 These requirements are a starting point – modify the KiCad project as needed and
 update this file when the schematic changes.

--- a/outages/2025-09-14-kicad-export-unknown-file-type.json
+++ b/outages/2025-09-14-kicad-export-unknown-file-type.json
@@ -1,0 +1,10 @@
+{
+  "id": "2025-09-14-kicad-export-unknown-file-type",
+  "date": "2025-09-14",
+  "component": "kicad",
+  "rootCause": "KiCad 9 not installed so KiBot cannot parse KiCad 9 project files and reports unknown file type",
+  "resolution": "Install KiCad 9 or run KiBot with the v2_k9 container to export outputs",
+  "references": [
+    "kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml"
+  ]
+}


### PR DESCRIPTION
## Summary
- document power rail test points in schematic title block and specs
- log KiCad export failure due to missing KiCad 9 environment

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml` *(fails: Unknown file type)*

------
https://chatgpt.com/codex/tasks/task_e_68c65b4876d8832fb69669742b3fe212