### PR TITLE
📝 : document sha256 check for Pi image downloads

### DIFF
--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -19,6 +19,11 @@ Build a Raspberry Pi OS image that boots with k3s and the
    ./scripts/build_pi_image.sh
    ```
    Skip either project with `CLONE_TOKEN_PLACE=false` or `CLONE_DSPACE=false`.
+4. Verify the image to ensure it isn't corrupted:
+   ```bash
+   sha256sum -c sugarkube.img.xz.sha256
+   ```
+   The command prints `sugarkube.img.xz: OK` when the checksum matches.
 
 ## 2. Flash with Raspberry Pi Imager
 - Write `sugarkube.img.xz` to a microSD card with Raspberry Pi Imager.


### PR DESCRIPTION
what: document checksum step in pi_image_quickstart.md
why: ensure downloads are intact before flashing
test: pre-commit run --all-files
test: pyspelling -c .spellcheck.yaml
test: linkchecker --no-warnings README.md docs/
test: git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68c65b432dcc832f805d81058247f345