### PR TITLE
Refine compose startup checks and document token.place/dspace env hooks

### DIFF
--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -109,10 +109,10 @@ helper that creates blank files when a project omits an example, and seeds a
 default `PORT` so containers start with predictable endpoints. Edit these files
 to set variables like ports, API URLs, or secrets.
 
-| Service     | Path to env file                     | Example     |
-| ----------- | ------------------------------------ | ----------- |
-| token.place | `/opt/projects/token.place/.env`     | `PORT=5000` |
-| dspace      | `/opt/projects/dspace/frontend/.env` | `PORT=3000` |
+| Service     | Path to env file                     | Required vars |
+| ----------- | ------------------------------------ | ------------- |
+| token.place | `/opt/projects/token.place/.env`     | `PORT` (default `5000`) |
+| dspace      | `/opt/projects/dspace/frontend/.env` | `PORT` (default `3000`) |
 
 Add more calls to `ensure_env` under the `# extra-start` marker in `init-env.sh`
 for additional repositories. See each project's README for the full list of
@@ -122,8 +122,22 @@ configuration options.
 
 Pass Git URLs via `EXTRA_REPOS` to clone additional projects into `/opt/projects`.
 Add services to `/opt/projects/docker-compose.yml` between `# extra-start` and
-`# extra-end`, and extend `init-env.sh` with any new `.env` files, following the
-token.place and dspace examples. The image builder drops the token.place or
+`# extra-end`:
+
+```yaml
+# extra-start
+myapp:
+  build:
+    context: /opt/projects/myapp
+  container_name: myapp
+  env_file:
+    - /opt/projects/myapp/.env
+  restart: unless-stopped
+# extra-end
+```
+
+Create matching `.env` files in `init-env.sh` using the same markers, following
+the token.place and dspace examples. The image builder drops the token.place or
 dspace definitions when the corresponding `CLONE_*` flag is `false`, letting you
 build a minimal image and expand it later.
 

--- a/scripts/cloud-init/start-projects.sh
+++ b/scripts/cloud-init/start-projects.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 svc="projects-compose.service"
+compose_path="/opt/projects/docker-compose.yml"
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker not found; skipping ${svc}" >&2
@@ -15,6 +16,11 @@ if ! docker compose version >/dev/null 2>&1; then
   exit 0
 fi
 docker compose version || true
+
+if [ ! -f "${compose_path}" ]; then
+  echo "${compose_path} not found; skipping ${svc}" >&2
+  exit 0
+fi
 
 if ! command -v systemctl >/dev/null 2>&1; then
   echo "systemctl not found; skipping ${svc}" >&2
@@ -33,3 +39,7 @@ if systemctl list-unit-files | grep -q "^${svc}"; then
 else
   echo "${svc} not found; skipping" >&2
 fi
+
+# extra-start
+# Additional startup hooks can be inserted here.
+# extra-end


### PR DESCRIPTION
## Summary
- verify `/opt/projects/docker-compose.yml` before enabling compose service and leave extension hook
- document required env vars and compose extension example for token.place & dspace

## Testing
- `scripts/checks.sh`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c65b617a74832f910dbeedbc38250a