### PR TITLE
🔒 route secret scan warnings to stderr

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ pre-commit run --all-files
 git diff --cached | ./scripts/scan-secrets.py
 ```
 `scan-secrets.py` skips scanning itself even if diff paths omit the `b/` prefix.
+Findings are printed to stderr so stdout remains clean for tooling.
 
 - If `README.md` or files under `docs/` change, also run:
 

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -3,7 +3,8 @@
 
 The script reads a unified diff from stdin and searches for high-risk patterns
 such as API keys or tokens. If `ripsecrets` is available it will be used for a
-more thorough scan; otherwise a lightweight regex-based fallback is used.
+more thorough scan; otherwise a lightweight regex-based fallback is used. Any
+findings are printed to stderr so they don't pollute stdout.
 """
 from __future__ import annotations
 
@@ -69,7 +70,7 @@ def regex_scan(lines: Iterable[str]) -> bool:
             continue
         for pattern in PATTERNS:
             if pattern.search(line):
-                print(f"Possible secret: {line.rstrip()}")
+                print(f"Possible secret: {line.rstrip()}", file=sys.stderr)
                 return True
     return False
 

--- a/tests/scan_secrets_test.py
+++ b/tests/scan_secrets_test.py
@@ -30,7 +30,7 @@ def test_regex_scan_prints_warning(scan_secrets, capsys):
     diff = ["+++ b/file.txt", "+token" ": abc"]
     assert scan_secrets.regex_scan(diff)
     captured = capsys.readouterr()
-    assert "Possible secret: +tok" "en: abc" in captured.out
+    assert "Possible secret: +tok" "en: abc" in captured.err
 
 
 def test_regex_scan_ignores_self(scan_secrets):


### PR DESCRIPTION
## Summary
- direct secret scan warnings to stderr to keep stdout clean
- document stderr output and test for it

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c65b76a4b4832fac4205dfe534d9ea