### PR TITLE
📝 docs: add secret scan step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ linkchecker --no-warnings README.md docs/
 The `--no-warnings` flag prevents linkchecker from returning a non-zero exit
 code on benign Markdown parsing warnings.
 
+Scan staged changes for secrets before committing:
+
+```bash
+git diff --cached | ./scripts/scan-secrets.py
+```
+
 If the repository includes a `package.json` but `npm` or `package-lock.json`
 are missing, `scripts/checks.sh` will warn and skip JavaScript-specific
 checks.


### PR DESCRIPTION
what: document scanning staged diffs for secrets
why: prevent accidental token commits
how to test: git diff --cached | ./scripts/scan-secrets.py
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c65b76a4b4832fac4205dfe534d9ea