### PR TITLE
📝 docs: clarify STANDOFF_MODE wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,10 @@ STANDOFF_MODE=nut bash scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carr
 ```
 
 By default the script uses the model's `standoff_mode` value (`heatset`).
-Set `STANDOFF_MODE=printed` to generate 3D-printed threads or `STANDOFF_MODE=nut` for a captive hex recess. Values are case-insensitive and ignore
-surrounding whitespace; `heatset`, `printed`, and `nut` are accepted. Supplying only
-whitespace uses the model's default `standoff_mode`.
+Set `STANDOFF_MODE=printed` to generate 3D-printed threads or `STANDOFF_MODE=nut` for a
+captive hex recess. Values are case-insensitive and ignore surrounding whitespace;
+`heatset`, `printed`, and `nut` are accepted. Supplying only whitespace uses the model's
+default `standoff_mode`.
 
 The helper script validates that the provided `.scad` file exists and that
 OpenSCAD is available in `PATH`, printing a helpful error if either check fails.


### PR DESCRIPTION
what: fix README line break splitting "case-insensitive"
why: keep STANDOFF_MODE description readable
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68c65b76a4b4832fac4205dfe534d9ea