### PR TITLE
Support custom work dir in Pi image builder

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -38,9 +38,12 @@ the cloud-init configuration with `CLOUD_INIT_PATH` or point `CLOUD_INIT_DIR` an
 `CLOUDFLARED_COMPOSE_PATH` at alternate files; the defaults read from
 `scripts/cloud-init/`. Set `SKIP_BINFMT=1` to skip installing binfmt handlers when
 they're already present or when the build environment disallows privileged
-containers. Set `DEBUG=1` to trace script execution for troubleshooting.
-Set `KEEP_WORK_DIR=1` to retain the temporary pi-gen work directory instead of
-deleting it, which aids debugging failed builds.
+containers. Set `DEBUG=1` to trace script execution for troubleshooting. Set
+`WORK_DIR=/path` to reuse a specific work directory; otherwise the script creates a
+temporary one. It only deletes the directory when it created it and
+`KEEP_WORK_DIR` isn't `1`, so custom paths are always preserved. Set
+`KEEP_WORK_DIR=1` to retain the temporary pi-gen work directory, which aids
+debugging failed builds.
 
 `REQUIRED_SPACE_GB` (default: `10`) controls free disk space checks on the
 temporary work directory and the output location.

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -17,6 +17,8 @@ Environment variables:
   IMG_NAME          Name for the output image (default sugarkube)
   TOKEN_PLACE_BRANCH Branch of token.place to clone (default main)
   DSPACE_BRANCH     Branch of dspace to clone (default v3)
+  WORK_DIR          Directory to use for pi-gen's work files (default: temp)
+  KEEP_WORK_DIR     Leave work dir after build (default: 0)
 
 See docs/pi_image_cloudflare.md for details.
 EOF
@@ -162,12 +164,19 @@ if [ ! -s "${INIT_ENV_PATH}" ]; then
 fi
 
 KEEP_WORK_DIR="${KEEP_WORK_DIR:-0}"
-WORK_DIR=$(mktemp -d)
+CLEANUP_WORK_DIR=1
+WORK_DIR="${WORK_DIR:-}"
+if [[ -z "${WORK_DIR}" ]]; then
+  WORK_DIR=$(mktemp -d)
+else
+  mkdir -p "${WORK_DIR}"
+  CLEANUP_WORK_DIR=0
+fi
 cleanup() {
-  if [[ "${KEEP_WORK_DIR}" != "1" ]]; then
+  if [[ "${KEEP_WORK_DIR}" != "1" && "${CLEANUP_WORK_DIR}" -eq 1 ]]; then
     rm -rf "${WORK_DIR}"
   else
-    echo "[sugarkube] KEEP_WORK_DIR=1; leaving work dir: ${WORK_DIR}"
+    echo "[sugarkube] leaving work dir: ${WORK_DIR}"
   fi
 }
 trap cleanup EXIT


### PR DESCRIPTION
## Summary
- allow specifying WORK_DIR to reuse build folders
- document WORK_DIR in Cloudflare Pi image guide

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68c65b4c8e78832f8dab056497fef9b2