### PR TITLE
📝 : – document checksum verification for Pi image

### DIFF
--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -9,9 +9,10 @@ Build a Raspberry Pi OS image that boots with k3s and the
 1. In GitHub, open **Actions → pi-image → Run workflow**.
    - Tick **token.place** and **dspace** to bake those repos into `/opt/projects`.
    - Wait for the run to finish; it uploads `sugarkube.img.xz` as an artifact.
-2. Download the artifact locally:
+2. Download the artifact and verify its checksum:
    ```bash
    ./scripts/download_pi_image.sh
+   sha256sum -c sugarkube.img.xz.sha256
    ```
    or grab it manually from the workflow run.
 3. Alternatively, build on your machine:


### PR DESCRIPTION
## What
- document verifying downloaded Pi image with sha256sum

## Why
- ensure image integrity before flashing

## How to test
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c65b37edcc832f9053da19d3cd691e