### PR TITLE
docs: expand docker repo walkthrough

### DIFF
--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -34,6 +34,9 @@ For a prebuilt image that already clones both projects, see
    - Single `Dockerfile`: `docker buildx build --platform linux/arm64 -t myapp . --load`
      then `docker run -d --name myapp -p 8080:8080 myapp`.
    - `docker-compose.yml`: `docker compose up -d`.
+   - `token.place`: `docker buildx build --platform linux/arm64 -f docker/Dockerfile.server \
+     -t tokenplace . --load` then `docker run -d --name tokenplace -p 5000:5000 tokenplace`.
+   - `dspace`: `cd dspace/frontend && docker compose up -d`.
 6. Verify the container is running:
    - Single container: `docker ps --format '{{.Names}}' | grep myapp`
    - Compose project: `docker compose ps`


### PR DESCRIPTION
## Summary
- add explicit token.place and dspace build commands to Raspberry Pi Docker walkthrough

## Testing
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c65afeead8832fa4fa7804f1fa851f