### PR TITLE
📝 : add buildx bake example to docker repo guide

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -5,6 +5,7 @@ Anthropic
 Avahi
 Bambu
 Bonjour
+Buildx
 CI
 CLI
 CLIs

--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -152,6 +152,36 @@ curl http://localhost:3002
 docker compose down
 ```
 
+### Build both images with Buildx Bake
+
+Use [Docker Buildx Bake](https://docs.docker.com/build/bake/) to compile
+token.place and dspace images in one step:
+
+```sh
+cd /opt/projects
+cat <<'EOF' > docker-bake.hcl
+group "default" {
+  targets = ["tokenplace", "dspace"]
+}
+
+target "tokenplace" {
+  context    = "token.place"
+  dockerfile = "docker/Dockerfile.server"
+  platforms  = ["linux/arm64"]
+  tags       = ["tokenplace:latest"]
+}
+
+target "dspace" {
+  context   = "dspace/frontend"
+  platforms = ["linux/arm64"]
+  tags      = ["dspace-frontend:latest"]
+}
+EOF
+docker buildx bake --load
+docker run -d --name tokenplace -p 5000:5000 tokenplace:latest
+docker run -d --name dspace-frontend -p 3002:3002 dspace-frontend:latest
+```
+
 ### Auto-start token.place and dspace on boot
 
 The Cloudflare-ready Pi image ships a `projects-compose` service that calls


### PR DESCRIPTION
what: document buildx bake to build token.place and dspace together
why: show parallel image builds on the raspberry pi
how to test: python -m pre_commit run --all-files
  python -m pyspelling -c .spellcheck.yaml
  linkchecker --no-warnings README.md docs/
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c65afeead8832fa4fa7804f1fa851f