### PR TITLE
🛠️ update nut clearance for pi5 carrier

### DIFF
--- a/cad/pi_cluster/pi5_triple_carrier_rot45.scad
+++ b/cad/pi_cluster/pi5_triple_carrier_rot45.scad
@@ -57,7 +57,7 @@ screw_major     = 2.50;   // M2.5
 screw_pitch     = 0.45;   // ISO coarse
 thread_facets   = 32;     // helix resolution
 screw_clearance = 3.2;    // through-hole clearance, slightly oversize
-nut_clearance   = 0.4;    // extra room for easier nut insertion (was 0.3)
+nut_clearance   = 0.5;    // extra room for easier nut insertion (was 0.4)
 nut_flat        = 5.0 + nut_clearance; // across flats for M2.5 nut
 nut_thick       = 2.0;    // nut thickness
 


### PR DESCRIPTION
## Summary
- enlarge M2.5 nut clearance to 0.5 mm for easier insertion in pi5 triple carrier

## Testing
- `./scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `pre-commit run --all-files` *(fails: Interrupted (KeyboardInterrupt))*


------
https://chatgpt.com/codex/tasks/task_e_68c65ab9b450832fb405cdb7478a39dd