### PR TITLE
chore: reduce bracket edge radius

### DIFF
--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -11,7 +11,7 @@
 size          = 40;           // leg length (mm)
 thickness     = 8;            // plate thickness (mm)
 beam_width    = 20;           // width to match 2020 extrusion (mm)
-edge_radius   = 4;            // default 4 mm outer-edge rounding
+edge_radius   = 3.5;          // default 3.5 mm radius avoids zero-thickness cores
 corner_segments = 48;         // higher sphere resolution for smoother edges
 hole_offset   = [0,0];        // XY offset of mounting hole from centre (mm)
 gusset        = true;         // add triangular support in inner corner


### PR DESCRIPTION
## Summary
- avoid zero-thickness core in panel bracket rounded edges

## Testing
- `./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c65ab9b450832fb405cdb7478a39dd