### PR TITLE
🔧 : enlarge panel bracket insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * pi_carrier: set standoff diameter to 6.5 mm for added strength
 * pi_carrier: widen nut recess clearance to 0.4 mm for easier nut insertion
 * pi5_triple_carrier_rot45: widen nut recess clearance to 0.4 mm for easier nut insertion
+* panel_bracket: enlarge insert to 6.3 mm OD for common M5 heat‑set hardware
 
 ### Fixed
 * pi_carrier: standoff length increased from 20 mm to 22 mm (flush fit with PoE HAT)

--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -18,8 +18,8 @@ gusset        = true;         // add triangular support in inner corner
 gusset_size   = thickness*1.5; // leg length of gusset triangle (mm)
 
 // insert / screw parameters
-insert_od         = 5.0;      // brass insert outer Ø (mm)
-insert_length     = 5.0;
+insert_od         = 6.3;      // brass insert outer Ø (mm) for typical M5 insert
+insert_length     = 6.0;      // insert length (mm)
 insert_clearance  = 0.20;     // interference amount (mm)
 insert_hole_diam  = insert_od - insert_clearance;
 screw_nominal     = 5.0;      // nominal screw size for through-hole (mm)


### PR DESCRIPTION
## Summary
- enlarge panel bracket insert OD and length for M5 heat-set hardware
- note change in changelog

## Testing
- `./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c65ab9b450832fb405cdb7478a39dd