### PR TITLE
🔧 deepen counterbores for Pi carriers

### DIFF
--- a/cad/pi_cluster/pi5_triple_carrier_rot45.scad
+++ b/cad/pi_cluster/pi5_triple_carrier_rot45.scad
@@ -139,7 +139,7 @@ difference()
 
     /* screw-head relief */
     head_r = 2.5;  // counterbore radius (5 mm diameter)
-    head_h = 1.6;  // depth of screw head recess
+    head_h = 1.8;  // deeper counterbore fully seats M2.5 pan-head screws
 
     for (pos = pi_positions) {
         pcb_cx = edge_margin + rotX/2 + pos[0]*board_spacing_x;

--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -31,7 +31,7 @@ assert(standoff_diam >= insert_od + 2,
 screw_clearance_diam = 3.2; // through-hole clearance, slightly oversize
 
 countersink_diam = 5.5; // enlarged to 5.5 mm for easier screw head clearance
-countersink_depth = 1.6;
+countersink_depth = 1.8; // deeper counterbore fully seats M2.5 pan-head screws
 
 nut_clearance = 0.5; // extra room for easier nut insertion (was 0.4)
 nut_flat = 5.0 + nut_clearance; // across flats for M2.5 nut


### PR DESCRIPTION
## Summary
- deepen Pi carrier countersinks for fully recessed M2.5 screws
- run OpenSCAD renders for default, printed, and nut standoff modes

## Testing
- `./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `./scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/pi_cluster/pi5_triple_carrier_rot45.scad`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68c65ab9b450832fb405cdb7478a39dd