### PR TITLE
🔧: enlarge Pi carrier countersink

### DIFF
--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -30,7 +30,7 @@ assert(standoff_diam >= insert_od + 2,
        "standoff_diam must be ≥ insert_od + 2");
 screw_clearance_diam = 3.2; // through-hole clearance, slightly oversize
 
-countersink_diam = 5.5; // enlarged to 5.5 mm for easier screw head clearance
+countersink_diam = 6.0; // enlarged to 6 mm for easier screw head clearance
 countersink_depth = 1.6;
 
 nut_clearance = 0.5; // extra room for easier nut insertion (was 0.4)


### PR DESCRIPTION
## Summary
- enlarge Pi carrier countersink to 6 mm for better screw clearance

## Testing
- `./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68c65a6c2c34832fa1c7ab955717ed66