### PR TITLE
🔧 : widen panel bracket nut clearance

### DIFF
--- a/cad/solar_cube/panel_bracket.scad
+++ b/cad/solar_cube/panel_bracket.scad
@@ -26,7 +26,7 @@ screw_nominal     = 5.0;      // nominal screw size for through-hole (mm)
 screw_clearance   = screw_nominal + 0.2; // through-hole Ø with clearance (mm)
 chamfer           = 1.0;      // lead-in chamfer (mm)
 
-nut_clearance     = 0.4;      // extra room for easier nut insertion (was 0.2)
+nut_clearance     = 0.5;      // extra room for easier nut insertion (was 0.4)
 nut_flat          = 8.0 + nut_clearance; // across flats for M5 nut (mm)
 
 nut_thick         = 4.0;      // nut thickness (mm)


### PR DESCRIPTION
## Summary
- allow 0.5 mm of play around M5 nuts in solar panel bracket

## Testing
- `./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/solar_cube/panel_bracket.scad`
- `pre-commit run --all-files` *(failed: Interrupted (KeyboardInterrupt))*


------
https://chatgpt.com/codex/tasks/task_e_68c65a6c2c34832fa1c7ab955717ed66