### PR TITLE
🔌 : document test point spacing

### DIFF
--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -12,6 +12,7 @@
                 (comment 5 "Use thick traces for high-current paths")
                 (comment 6 "Add fiducial markers for board orientation")
                 (comment 7 "Verify ground pour continuity around mounting holes")
+                (comment 8 "Review test point spacing for probe clearance")
         )
         (lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/elex/power_ring/specs.md
+++ b/elex/power_ring/specs.md
@@ -21,8 +21,8 @@ The design may evolve as the project grows.
 - Fiducial markers to indicate board orientation for easier assembly
 - Title block comments record decoupling guidelines, high-current trace layout, thick traces
   for high-current paths, connector labeling, export checks, board outline fit, BOM validation,
-  clearance rules for high-voltage nets, star topology to minimize voltage drop, and now ground
-  pour continuity around mounting holes
+  clearance rules for high-voltage nets, star topology to minimize voltage drop, ground
+  pour continuity around mounting holes, and test point spacing for probe clearance
 
 These requirements are a starting point – modify the KiCad project as needed and
 update this file when the schematic changes.

--- a/outages/2025-09-14-kicad-export-pcbnew-missing.json
+++ b/outages/2025-09-14-kicad-export-pcbnew-missing.json
@@ -1,0 +1,10 @@
+{
+  "id": "kicad-export-pcbnew-missing",
+  "date": "2025-09-14",
+  "component": "kicad-export",
+  "rootCause": "KiCad not installed; pcbnew Python module not found",
+  "resolution": "Install KiCad 9 so pcbnew is available for KiBot",
+  "references": [
+    "~/.local/bin/kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml"
+  ]
+}


### PR DESCRIPTION
## Summary
- note test point spacing in power ring schematic title block
- document test point spacing guideline in specs
- record missing KiCad outage after Kibot export failed

## Testing
- `kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml` *(fails: KiCad not installed)*
- `pre-commit run --all-files` *(fails: Interrupted)*
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c65b4876d8832fb69669742b3fe212