### PR TITLE
💡 : – remind LED orientation in power_ring docs and schematic

### DIFF
--- a/docs/electronics_schematics.md
+++ b/docs/electronics_schematics.md
@@ -27,6 +27,7 @@ Design notes embedded in the KiCad title block highlight best practices:
 - Label polarity and voltage on connectors to avoid wiring mistakes.
 - Verify KiBot exports before fabrication.
 - Verify ground-pour clearance around mounting holes.
+- Double-check LED orientation during assembly.
 
 Open the project in **KiCad 9** or newer and modify the schematic to suit your power
 distribution needs (for example, add screw terminals, fuses and test points). Use

--- a/elex/power_ring/power_ring.kicad_sch
+++ b/elex/power_ring/power_ring.kicad_sch
@@ -12,6 +12,7 @@
                 (comment 5 "Use thick traces for high-current paths")
                 (comment 6 "Add fiducial markers for board orientation")
                 (comment 7 "Verify ground pour continuity around mounting holes")
+                (comment 8 "Double-check LED orientation during assembly")
         )
         (lib_symbols
 		(symbol "custom_pads_test:Antenna"

--- a/elex/power_ring/specs.md
+++ b/elex/power_ring/specs.md
@@ -19,10 +19,10 @@ The design may evolve as the project grows.
 - Test points for measuring battery voltage
 - Silkscreen labels for polarity and connector numbers
 - Fiducial markers to indicate board orientation for easier assembly
-- Title block comments record decoupling guidelines, high-current trace layout, thick traces
-  for high-current paths, connector labeling, export checks, board outline fit, BOM validation,
-  clearance rules for high-voltage nets, star topology to minimize voltage drop, and now ground
-  pour continuity around mounting holes
+ - Title block comments record decoupling guidelines, high-current trace layout, thick traces
+   for high-current paths, connector labeling, export checks, board outline fit, BOM validation,
+   clearance rules for high-voltage nets, star topology to minimize voltage drop, ground
+   pour continuity around mounting holes, and LED orientation reminders
 
 These requirements are a starting point – modify the KiCad project as needed and
 update this file when the schematic changes.

--- a/outages/2025-09-14-kicad-export-kicad9-missing.json
+++ b/outages/2025-09-14-kicad-export-kicad9-missing.json
@@ -1,0 +1,8 @@
+{
+  "id": "2025-09-14-kicad-export-kicad9-missing",
+  "date": "2025-09-14",
+  "component": "kicad-export",
+  "rootCause": "KiBot could not load the PCB due to missing KiCad 9; installed KiCad 7 reports unknown file type",
+  "resolution": "Install KiCad 9 (v2_k9 container tag) so KiBot can process the project",
+  "references": []
+}


### PR DESCRIPTION
what: document LED orientation and log KiCad export outage
why: keep assembly notes current and track missing KiCad 9
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- PYTHONPATH=/usr/lib/python3/dist-packages kibot -b elex/power_ring/power_ring.kicad_pro -c .kibot/power_ring.yaml # fails: KiCad 9 missing

------
https://chatgpt.com/codex/tasks/task_e_68c65b4876d8832fb69669742b3fe212