### PR TITLE
Broaden Pi carrier standoff for countersink support

### DIFF
--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -16,7 +16,7 @@ hole_spacing_y = 49;
 plate_thickness = 2.0;
 corner_radius   = 5.0;  // round base corners to avoid sharp edges
 standoff_height = 6.0;
-standoff_diam = 6.5;   // match Pi5 carrier standoffs for extra strength
+standoff_diam = 7.0;   // widened to keep a ≥0.4 mm flange around the 5.8 mm countersink
 
 insert_od         = 3.5;         // outer Ø for common brass inserts
 insert_length     = 4.0;         // full length of the insert
@@ -30,7 +30,7 @@ assert(standoff_diam >= insert_od + 2,
        "standoff_diam must be ≥ insert_od + 2");
 screw_clearance_diam = 3.2; // through-hole clearance, slightly oversize
 
-countersink_diam = 5.5; // enlarged to 5.5 mm for easier screw head clearance
+countersink_diam = 5.8; // widened to 5.8 mm for improved screw head clearance
 countersink_depth = 1.6;
 
 nut_clearance = 0.5; // extra room for easier nut insertion (was 0.4)


### PR DESCRIPTION
## Summary
- increase the Pi carrier standoff diameter to 7.0 mm so the 5.8 mm countersink keeps at least one nozzle-width flange for strength

## Testing
- `./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=printed ./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `STANDOFF_MODE=nut ./scripts/openscad_render.sh cad/pi_cluster/pi_carrier.scad`
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c65a6c2c34832fa1c7ab955717ed66