### PR TITLE
🖼️ : – restore docs hero image

### DIFF
--- a/docs/images/sugarkube_diagram.svg
+++ b/docs/images/sugarkube_diagram.svg
@@ -1,0 +1,153 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="8" refX="8" refY="4"
+      orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,4 L0,8 z" fill="#2563eb" />
+    </marker>
+    <linearGradient id="panel" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#60a5fa" />
+      <stop offset="1" stop-color="#1e3a8a" />
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="640" height="360" fill="#f8fafc" />
+  <g font-family="Inter,Arial,Helvetica,sans-serif" fill="#0f172a">
+    <text x="60" y="60" font-size="18" font-weight="600">Sunlight</text>
+    <circle cx="80" cy="110" r="40" fill="#fbbf24" stroke="#b45309" stroke-width="4" />
+    <g stroke="#fbbf24" stroke-width="3">
+      <line x1="80" y1="60" x2="80" y2="30" />
+      <line x1="80" y1="160" x2="80" y2="190" />
+      <line x1="30" y1="110" x2="0" y2="110" />
+      <line x1="130" y1="110" x2="160" y2="110" />
+      <line x1="45" y1="75" x2="20" y2="50" />
+      <line x1="115" y1="75" x2="140" y2="50" />
+      <line x1="45" y1="145" x2="20" y2="170" />
+      <line x1="115" y1="145" x2="140" y2="170" />
+    </g>
+
+    <g transform="translate(240,60)">
+      <polygon
+        points="0,80 80,40 160,80 80,120"
+        fill="#e2e8f0"
+        stroke="#475569"
+        stroke-width="3"
+      />
+      <polygon
+        points="80,40 140,10 220,50 160,80"
+        fill="#cbd5f5"
+        stroke="#475569"
+        stroke-width="3"
+      />
+      <polygon
+        points="0,80 80,40 140,10 60,50"
+        fill="#dbeafe"
+        stroke="#475569"
+        stroke-width="3"
+      />
+      <rect
+        x="28"
+        y="70"
+        width="45"
+        height="35"
+        fill="url(#panel)"
+        stroke="#1e3a8a"
+        stroke-width="2"
+      />
+      <rect
+        x="90"
+        y="50"
+        width="45"
+        height="35"
+        fill="url(#panel)"
+        stroke="#1e3a8a"
+        stroke-width="2"
+      />
+      <rect
+        x="135"
+        y="65"
+        width="45"
+        height="35"
+        fill="url(#panel)"
+        stroke="#1e3a8a"
+        stroke-width="2"
+      />
+      <text x="80" y="150" font-size="18" font-weight="600" text-anchor="middle">
+        Sugarkube frame
+      </text>
+      <text x="80" y="172" font-size="14" text-anchor="middle" fill="#475569">
+        Solar panels + Pi cluster inside
+      </text>
+    </g>
+
+    <g transform="translate(440,40)">
+      <rect x="0" y="0" width="120" height="70" rx="10" fill="#fef08a" stroke="#f59e0b"
+        stroke-width="3" />
+      <text x="60" y="28" font-size="16" text-anchor="middle" font-weight="600">
+        Charge
+      </text>
+      <text x="60" y="48" font-size="16" text-anchor="middle" font-weight="600">
+        controller
+      </text>
+    </g>
+
+    <g transform="translate(460,150)">
+      <rect x="0" y="0" width="150" height="80" rx="12" fill="#bae6fd" stroke="#0284c7"
+        stroke-width="3" />
+      <text x="75" y="32" font-size="18" text-anchor="middle" font-weight="600">
+        Batteries
+      </text>
+      <text x="75" y="54" font-size="14" text-anchor="middle" fill="#1f2937">
+        Energy storage
+      </text>
+    </g>
+
+    <g transform="translate(260,250)">
+      <rect x="-20" y="0" width="120" height="70" rx="12" fill="#bbf7d0"
+        stroke="#16a34a" stroke-width="3" />
+      <text x="40" y="30" font-size="16" text-anchor="middle" font-weight="600">
+        Pi cluster
+      </text>
+      <text x="40" y="50" font-size="14" text-anchor="middle" fill="#166534">
+        k3s + apps
+      </text>
+    </g>
+
+    <g transform="translate(420,250)">
+      <rect x="-10" y="0" width="130" height="70" rx="12" fill="#fde68a"
+        stroke="#d97706" stroke-width="3" />
+      <text x="55" y="30" font-size="16" text-anchor="middle" font-weight="600">
+        Aeration
+      </text>
+      <text x="55" y="50" font-size="14" text-anchor="middle" fill="#92400e">
+        Aquarium pumps
+      </text>
+    </g>
+
+    <g transform="translate(120,240)">
+      <path
+        d="M40 0 C10 0 0 25 10 45 C20 65 40 70 40 70 C40 70 60 65 70 45 C80 25 70 0 40 0"
+        fill="#bbf7d0"
+        stroke="#15803d"
+        stroke-width="3"
+      />
+      <path
+        d="M90 10 C60 10 55 35 65 55 C75 70 90 75 90 75 C90 75 105 70 115 55 C125 35 120 10 90 10"
+        fill="#a7f3d0"
+        stroke="#15803d"
+        stroke-width="3"
+      />
+      <text x="70" y="98" font-size="14" text-anchor="middle" fill="#166534">
+        Climbing plants
+      </text>
+    </g>
+  </g>
+
+  <g stroke="#2563eb" stroke-width="3" fill="none" marker-end="url(#arrow)">
+    <path d="M120 110 H220" />
+    <path d="M400 100 H430 V70" />
+    <path d="M400 120 H470" />
+    <path d="M510 120 V150" />
+    <path d="M335 210 V240" />
+    <path d="M410 210 V240" />
+    <path d="M305 285 H395" />
+  </g>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,10 @@ so anyone can replicate the setup.
 Greenery is encouraged around the cube. Vines can climb the extrusions while
 herbs and shade-loving plants enjoy the cover of the solar panels.
 
-![solar cube](images/solar_cube.jpg)
+![Diagram of the Sugarkube solar cube showing panels, electronics, and greenery](images/sugarkube_diagram.svg)
+
+*Figure: Power from the solar panels flows through the charge controller and batteries to the
+Pi cluster and aquarium aerator while the frame supports climbing plants.*
 
 ## Getting Started
 Review the safety notes before working with power components.


### PR DESCRIPTION
what: add inline svg diagram and caption for the landing page
why: replace the broken reference to a missing jpg
how to test: pre-commit run --files docs/index.md docs/images/sugarkube_diagram.svg

------
https://chatgpt.com/codex/tasks/task_e_68c9cdeb439c832f83eb7f154cf8dc05