### PR TITLE
feat: improve pi image download workflow

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -219,3 +219,4 @@ wslconfig
 yaml
 yml
 yourorg
+checksums

--- a/README.md
+++ b/README.md
@@ -42,9 +42,13 @@ the docs you will see the term used in both contexts.
 - [docs/network_setup.md](docs/network_setup.md) — connect the Pi cluster to your network
 - [docs/lcd_mount.md](docs/lcd_mount.md) — optional 1602 LCD standoff locations
 - `scripts/` — helper scripts for rendering and exports
-  - `download_pi_image.sh` — fetch the latest Pi image via the GitHub CLI; requires `gh`
-    to be installed and authenticated. Uses POSIX `test -ef` instead of `realpath` for better
-    macOS compatibility
+  - `download_pi_image.sh` — resolve the latest GitHub Release artifact, resume partial
+    downloads with `curl`, verify SHA-256 checksums, and save images under
+    `~/sugarkube/images/` by default; requires authenticated `gh`, `curl`, `python3`, and
+    `sha256sum`
+  - `sugarkube_latest.sh` — convenience wrapper that calls the download script, expands the
+    `.img.xz` to `.img`, and exposes `--no-expand`, `--image-dir`, and pass-through flags for
+    advanced use
   - `collect_pi_image.sh` — normalize pi-gen output into a single `.img.xz`,
     clean up temporary work directories, use POSIX `test -ef` to compare paths
     without `realpath`, and fall back to `unzip` when `bsdtar` is unavailable

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -5,114 +5,114 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
 ---
 
 ## Release & Distribution Automation
-- [ ] Publish signed, versioned releases on every successful `main` merge, plus nightly rebuilds to keep dependencies fresh.  
-- [ ] Attach artifacts (`.img.xz`), checksums, and changelog snippets to GitHub Releases; include an “image availability” badge in `README.md` linking to the latest download and commit SHAs.  
-- [ ] Generate a machine-readable manifest (JSON/YAML) recording build inputs, git SHAs, and checksums for provenance verification. Cache pi-gen stage durations, verifier output, and commit IDs for reproducibility.  
-- [ ] Extend `scripts/download_pi_image.sh` (or `grab_pi_image.sh`) to:  
-  - Resolve the latest release automatically.  
-  - Resume partial downloads.  
-  - Verify checksums/signatures.  
-  - Emit progress bars/ETAs.  
-  - Store artifacts under `~/sugarkube/images/` by default.  
-- [ ] Provide a `sugarkube-latest` convenience wrapper for downloading + verifying in one step.  
-- [ ] Package a one-liner installer (`curl | bash`) that installs `gh` when missing, pulls the latest release, verifies checksums, and expands the image.  
+- [ ] Publish signed, versioned releases on every successful `main` merge, plus nightly rebuilds to keep dependencies fresh.
+- [ ] Attach artifacts (`.img.xz`), checksums, and changelog snippets to GitHub Releases; include an “image availability” badge in `README.md` linking to the latest download and commit SHAs.
+- [ ] Generate a machine-readable manifest (JSON/YAML) recording build inputs, git SHAs, and checksums for provenance verification. Cache pi-gen stage durations, verifier output, and commit IDs for reproducibility.
+- [x] Extend `scripts/download_pi_image.sh` (or `grab_pi_image.sh`) to:
+  - [x] Resolve the latest release automatically.
+  - [x] Resume partial downloads.
+  - [x] Verify checksums/signatures.
+  - [x] Emit progress bars/ETAs.
+  - [x] Store artifacts under `~/sugarkube/images/` by default.
+- [x] Provide a `sugarkube-latest` convenience wrapper for downloading + verifying in one step.
+- [ ] Package a one-liner installer (`curl | bash`) that installs `gh` when missing, pulls the latest release, verifies checksums, and expands the image.
 
 ---
 
 ## Flashing & Provisioning Automation
-- [ ] Ship cross-platform flashing helpers (`flash_pi_media.sh`, PowerShell twin, or CLI in Go/Rust/Node) that:  
-  - Discover SD/USB devices.  
-  - Stream `.img.xz` directly with progress (`xzcat | dd`).  
-  - Verify written bytes with SHA-256.  
-  - Auto-eject media.  
-- [ ] Ship Raspberry Pi Imager preset JSONs pre-filled with hostname, user, Wi-Fi, and SSH keys for load-and-go flashing.  
-- [ ] Provide `just`/`make` targets (e.g., `make flash-pi`) chaining download → verify → flash.  
-- [ ] Bundle a wrapper script that auto-decompresses, flashes, verifies, and reports results in HTML/Markdown (hardware IDs, checksum results, cloud-init diff).  
-- [ ] Document a headless provisioning path using `user-data` or `secrets.env` for injecting Wi-Fi/Cloudflare tokens without editing repo files.  
-- [ ] Support Codespaces or `just` recipes to build and flash media with minimal local tooling.  
+- [ ] Ship cross-platform flashing helpers (`flash_pi_media.sh`, PowerShell twin, or CLI in Go/Rust/Node) that:
+  - Discover SD/USB devices.
+  - Stream `.img.xz` directly with progress (`xzcat | dd`).
+  - Verify written bytes with SHA-256.
+  - Auto-eject media.
+- [ ] Ship Raspberry Pi Imager preset JSONs pre-filled with hostname, user, Wi-Fi, and SSH keys for load-and-go flashing.
+- [ ] Provide `just`/`make` targets (e.g., `make flash-pi`) chaining download → verify → flash.
+- [ ] Bundle a wrapper script that auto-decompresses, flashes, verifies, and reports results in HTML/Markdown (hardware IDs, checksum results, cloud-init diff).
+- [ ] Document a headless provisioning path using `user-data` or `secrets.env` for injecting Wi-Fi/Cloudflare tokens without editing repo files.
+- [ ] Support Codespaces or `just` recipes to build and flash media with minimal local tooling.
 
 ---
 
 ## First Boot Confidence & Self-Healing
-- [ ] Install `first-boot.service` that:  
-  - Waits for network, expands filesystem.  
-  - Runs `pi_node_verifier.sh` automatically.  
-  - Publishes HTML/JSON status (cloud-init, k3s, token.place, dspace) to `/boot/first-boot-report`.  
-- [ ] Log verifier results and migration steps to `/boot/first-boot-report.txt`.  
-- [ ] Add self-healing units that retry container pulls, rerun `cloud-init clean`, or reboot into maintenance with actionable logs.  
-- [ ] Provide optional telemetry hooks to publish anonymized health data to a shared dashboard.  
+- [ ] Install `first-boot.service` that:
+  - Waits for network, expands filesystem.
+  - Runs `pi_node_verifier.sh` automatically.
+  - Publishes HTML/JSON status (cloud-init, k3s, token.place, dspace) to `/boot/first-boot-report`.
+- [ ] Log verifier results and migration steps to `/boot/first-boot-report.txt`.
+- [ ] Add self-healing units that retry container pulls, rerun `cloud-init clean`, or reboot into maintenance with actionable logs.
+- [ ] Provide optional telemetry hooks to publish anonymized health data to a shared dashboard.
 
 ---
 
 ## SSD Migration & Storage Hardening
-- [ ] Automate SSD cloning via `ssd-clone.service` or `pi-clone.service`:  
-  - Detect attached SSD.  
-  - Replicate partition table (`sgdisk --replicate` or `ddrescue`).  
-  - `rsync --info=progress2` SD → SSD.  
-  - Update `/boot/cmdline.txt` and `/etc/fstab` with new UUID.  
-  - Touch `/var/log/sugarkube/ssd-clone.done`.  
-- [ ] Support dry-run + resume for cloning to reduce user hesitation.  
-- [ ] Provide post-clone validation: EEPROM boot order, fstab UUIDs, read/write stress tests.  
-- [ ] Publish a recovery guide and rollback script to fall back to SD if SSD checks fail.  
-- [ ] Offer an opt-in SSD health monitor (SMART/wear checks).  
+- [ ] Automate SSD cloning via `ssd-clone.service` or `pi-clone.service`:
+  - Detect attached SSD.
+  - Replicate partition table (`sgdisk --replicate` or `ddrescue`).
+  - `rsync --info=progress2` SD → SSD.
+  - Update `/boot/cmdline.txt` and `/etc/fstab` with new UUID.
+  - Touch `/var/log/sugarkube/ssd-clone.done`.
+- [ ] Support dry-run + resume for cloning to reduce user hesitation.
+- [ ] Provide post-clone validation: EEPROM boot order, fstab UUIDs, read/write stress tests.
+- [ ] Publish a recovery guide and rollback script to fall back to SD if SSD checks fail.
+- [ ] Offer an opt-in SSD health monitor (SMART/wear checks).
 
 ---
 
 ## k3s, token.place & dspace Reliability
-- [ ] Add a `k3s-ready.target` that depends on `projects-compose.service` and only completes when `kubectl get nodes` returns `Ready`.  
-- [ ] Extend verifier to ensure:  
-  - k3s node is `Ready`.  
-  - `projects-compose.service` is active.  
-  - `token.place` and `dspace` endpoints respond on HTTPS/GraphQL.  
-- [ ] Provide post-boot hooks that apply pinned Helm/chart bundles and fail fast with logs if health checks fail.  
-- [ ] Bundle sample datasets and token.place collections for first-launch validation.  
-- [ ] Document and script multi-node join rehearsal for scaling clusters.  
-- [ ] Store kubeconfig (sanitized) in `/boot/sugarkube-kubeconfig` for retrieval without SSH.  
-- [ ] Bundle lightweight exporters (Grafana Agent/Netdata/Prometheus) pre-configured for cluster observability.  
+- [ ] Add a `k3s-ready.target` that depends on `projects-compose.service` and only completes when `kubectl get nodes` returns `Ready`.
+- [ ] Extend verifier to ensure:
+  - k3s node is `Ready`.
+  - `projects-compose.service` is active.
+  - `token.place` and `dspace` endpoints respond on HTTPS/GraphQL.
+- [ ] Provide post-boot hooks that apply pinned Helm/chart bundles and fail fast with logs if health checks fail.
+- [ ] Bundle sample datasets and token.place collections for first-launch validation.
+- [ ] Document and script multi-node join rehearsal for scaling clusters.
+- [ ] Store kubeconfig (sanitized) in `/boot/sugarkube-kubeconfig` for retrieval without SSH.
+- [ ] Bundle lightweight exporters (Grafana Agent/Netdata/Prometheus) pre-configured for cluster observability.
 
 ---
 
 ## Testing & CI Hardening
-- [ ] Extend pi-image workflow with QEMU smoke tests that boot the image, wait for cloud-init, run verifier, and upload logs.  
-- [ ] Add contract tests asserting ports are open, health endpoints respond, and container digests remain pinned.  
-- [ ] Integrate spellcheck/linkcheck gating (`pyspelling`, `linkchecker`) for docs.  
-- [ ] Build hardware-in-the-loop test bench: USB PDU, HDMI capture, serial console, boot physical Pis, archive telemetry.  
-- [ ] Provide smoke-test harnesses (Ansible or shell) that SSH into fresh Pis, check k3s readiness, app health, and cluster convergence after reboots.  
-- [ ] Capture support bundles (`kubectl get events`, `helm list`, `systemd-analyze blame`, Compose logs, journal slices) for every pipeline run.  
-- [ ] Document how to run integration tests locally via `act`.  
-- [ ] Publish a conformance badge in the README showing last successful hardware boot.  
+- [ ] Extend pi-image workflow with QEMU smoke tests that boot the image, wait for cloud-init, run verifier, and upload logs.
+- [ ] Add contract tests asserting ports are open, health endpoints respond, and container digests remain pinned.
+- [ ] Integrate spellcheck/linkcheck gating (`pyspelling`, `linkchecker`) for docs.
+- [ ] Build hardware-in-the-loop test bench: USB PDU, HDMI capture, serial console, boot physical Pis, archive telemetry.
+- [ ] Provide smoke-test harnesses (Ansible or shell) that SSH into fresh Pis, check k3s readiness, app health, and cluster convergence after reboots.
+- [ ] Capture support bundles (`kubectl get events`, `helm list`, `systemd-analyze blame`, Compose logs, journal slices) for every pipeline run.
+- [ ] Document how to run integration tests locally via `act`.
+- [ ] Publish a conformance badge in the README showing last successful hardware boot.
 
 ---
 
 ## Documentation & Onboarding
-- [ ] Merge fragmented docs (`pi_image_quickstart.md`, `pi_image_builder_design.md`, `pi_image_cloudflare.md`, `raspi_cluster_setup.md`, etc.) into a single end-to-end “Pi Carrier Launch Playbook.”  
-- [ ] Structure guide with:  
-  - A 10-minute fast path.  
-  - Persona-based walkthroughs (solo builder, classroom, maintainer).  
-  - Deep reference sections with wiring photos.  
-- [ ] Include a printable one-page field guide/checklist (PDF) with commands, expected outputs, LED/status reference, and troubleshooting links.  
-- [ ] Embed GIFs, screencasts, or narrated clips showing download → flash → first boot → SSD clone → k3s readiness.  
-- [ ] Provide start-to-finish flowcharts mapping the journey.  
-- [ ] Expand troubleshooting tables linking LED patterns, journalctl logs, `kubectl` errors, and container health issues to fixes.  
-- [ ] Publish contributor guide mapping automation scripts to docs; enforce sync with linkchecker and spellchecker.  
+- [ ] Merge fragmented docs (`pi_image_quickstart.md`, `pi_image_builder_design.md`, `pi_image_cloudflare.md`, `raspi_cluster_setup.md`, etc.) into a single end-to-end “Pi Carrier Launch Playbook.”
+- [ ] Structure guide with:
+  - A 10-minute fast path.
+  - Persona-based walkthroughs (solo builder, classroom, maintainer).
+  - Deep reference sections with wiring photos.
+- [ ] Include a printable one-page field guide/checklist (PDF) with commands, expected outputs, LED/status reference, and troubleshooting links.
+- [ ] Embed GIFs, screencasts, or narrated clips showing download → flash → first boot → SSD clone → k3s readiness.
+- [ ] Provide start-to-finish flowcharts mapping the journey.
+- [ ] Expand troubleshooting tables linking LED patterns, journalctl logs, `kubectl` errors, and container health issues to fixes.
+- [ ] Publish contributor guide mapping automation scripts to docs; enforce sync with linkchecker and spellchecker.
 
 ---
 
 ## Developer Experience & User Refinements
-- [ ] Provide `make doctor` / `just verify` that chains download, checksum, flash dry-run, and linting.  
-- [ ] Offer a `brew install sugarkube` tap and `sugarkube setup` wizard for macOS.  
-- [ ] Package a cross-platform desktop notifier to alert when workflow artifacts are ready.  
-- [ ] Serve a web UI (via GitHub Pages) where users paste a workflow URL and get direct flashing instructions tailored to OS.  
-- [ ] Add QR codes on physical `pi_carrier` hardware pointing to quickstart and troubleshooting docs.  
-- [ ] Print cluster token and default kubeconfig to `/boot/` for recovery if first boot stalls.  
-- [ ] Provide optional `sugarkube-teams` webhook that posts boot/clone progress to Slack or Matrix for remote monitoring.  
+- [ ] Provide `make doctor` / `just verify` that chains download, checksum, flash dry-run, and linting.
+- [ ] Offer a `brew install sugarkube` tap and `sugarkube setup` wizard for macOS.
+- [ ] Package a cross-platform desktop notifier to alert when workflow artifacts are ready.
+- [ ] Serve a web UI (via GitHub Pages) where users paste a workflow URL and get direct flashing instructions tailored to OS.
+- [ ] Add QR codes on physical `pi_carrier` hardware pointing to quickstart and troubleshooting docs.
+- [ ] Print cluster token and default kubeconfig to `/boot/` for recovery if first boot stalls.
+- [ ] Provide optional `sugarkube-teams` webhook that posts boot/clone progress to Slack or Matrix for remote monitoring.
 
 ---
 
 ## Troubleshooting & Community
-- [ ] Ship a golden recovery console image or partition with CLI tools to reflash, fetch logs, and reinstall k3s without another machine.  
-- [ ] Extend `outages/` with playbooks for scenarios like cloud-init hangs, SSD clone stalls, or projects-compose failures.  
-- [ ] Add an issue template asking contributors to reference this checklist so coverage gaps are visible.  
+- [ ] Ship a golden recovery console image or partition with CLI tools to reflash, fetch logs, and reinstall k3s without another machine.
+- [ ] Extend `outages/` with playbooks for scenarios like cloud-init hangs, SSD clone stalls, or projects-compose failures.
+- [ ] Add an issue template asking contributors to reference this checklist so coverage gaps are visible.
 
 ---
 

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -9,27 +9,21 @@ Build a Raspberry Pi OS image that boots with k3s and the
 1. In GitHub, open **Actions → pi-image → Run workflow**.
    - Tick **token.place** and **dspace** to bake those repos into `/opt/projects`.
    - Wait for the run to finish; it uploads `sugarkube.img.xz` as an artifact.
-2. Download the artifact and verify its checksum:
+2. Download, verify, and expand the artifact automatically:
    ```bash
-   ./scripts/download_pi_image.sh
-   sha256sum -c sugarkube.img.xz.sha256
+   ./scripts/sugarkube_latest.sh
    ```
-   or grab it manually from the workflow run.
-3. Verify the download's checksum to ensure integrity:
-   ```bash
-   sha256sum sugarkube.img.xz
-   ```
-   Compare the output to the hash shown in the workflow run.
-4. Alternatively, build on your machine:
+   The script resolves the latest GitHub Release, resumes partial downloads, verifies the
+   SHA-256 checksum, and stores `sugarkube.img.xz` plus the expanded `sugarkube.img` under
+   `~/sugarkube/images/`. Pass `--no-expand` to keep only the compressed archive or
+   `-d <dir>` to override the destination.
+3. Alternatively, build on your machine:
    ```bash
    ./scripts/build_pi_image.sh
    ```
    Skip either project with `CLONE_TOKEN_PLACE=false` or `CLONE_DSPACE=false`.
-4. Verify the image to ensure it isn't corrupted:
-   ```bash
-   sha256sum -c sugarkube.img.xz.sha256
-   ```
-   The command prints `sugarkube.img.xz: OK` when the checksum matches.
+4. The download script already writes `sugarkube.img.xz.sha256`. Re-run
+   `sha256sum -c sugarkube.img.xz.sha256` if you need to confirm integrity later.
 
 ## 2. Flash with Raspberry Pi Imager
 - Write `sugarkube.img.xz` to a microSD card with Raspberry Pi Imager.

--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -22,11 +22,13 @@ docker compose version
 1. In GitHub, open **Actions → pi-image → Run workflow**.
    - Tick **token.place** and **dspace** to bake those repos into `/opt/projects`.
    - Wait for the run to finish; it uploads `sugarkube.img.xz` as an artifact.
-2. Download the artifact locally:
+2. Download, verify, and expand the artifact locally:
    ```sh
-   ./scripts/download_pi_image.sh
+   ./scripts/sugarkube_latest.sh
    ```
-   or grab it manually from the workflow run.
+   The helper stores the compressed and expanded images under `~/sugarkube/images/`, verifies
+   the SHA-256 checksum, and resumes interrupted downloads. Use `--no-expand` to skip writing
+   the raw `.img`.
 3. Alternatively, build on your machine:
    ```sh
    ./scripts/build_pi_image.sh

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -23,11 +23,12 @@ Linux command line.
 1. Trigger the build in GitHub:
    - Open [Actions → pi-image → Run workflow][pi-image].
    - Enable **token.place** and **dspace** if you want those repos baked in.
-   - After the run succeeds, download `sugarkube.img.xz`:
+   - After the run succeeds, download and expand `sugarkube.img.xz`:
      ```bash
-     scripts/download_pi_image.sh
+     scripts/sugarkube_latest.sh
      ```
-     or grab it from the workflow run.
+     The wrapper saves the compressed archive, verifies the checksum, and expands `sugarkube.img`
+     under `~/sugarkube/images/`. Pass `--no-expand` to keep only the `.img.xz`.
 
    Alternatively, build locally:
    - Linux/macOS: `./scripts/build_pi_image.sh`
@@ -51,7 +52,8 @@ Linux command line.
      - Requires Docker Desktop running and Git for Windows installed
      - The script auto-falls back to a Dockerized build and sets up binfmt/qemu
      - Expect 45–120 minutes on Windows; ensure ≥30 GB free disk
-2. Verify the checksum: `sha256sum -c sugarkube.img.xz.sha256`
+2. The download script writes `sugarkube.img.xz.sha256`. Re-run `sha256sum -c` on that file if you
+   need to reconfirm the checksum before flashing.
 3. Flash the image to a microSD card using Raspberry Pi Imager
    - Set a unique hostname (e.g., `sugar-01`, `sugar-02`, `sugar-03`), enable SSH, and create a user
      with a strong password.

--- a/scripts/download_pi_image.sh
+++ b/scripts/download_pi_image.sh
@@ -1,44 +1,304 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Download the latest sugarkube Pi image artifact via the GitHub CLI.
-# Requires the GitHub CLI to be authenticated with access to this repository.
+# shellcheck disable=SC2317
+cleanup() {
+  if [[ -n "${TMP_ASSET:-}" && -f "$TMP_ASSET" ]]; then
+    rm -f "$TMP_ASSET"
+  fi
+  if [[ -n "${TMP_SHA:-}" && -f "$TMP_SHA" ]]; then
+    rm -f "$TMP_SHA"
+  fi
+}
 
-if ! command -v gh >/dev/null 2>&1; then
-  echo "gh is required" >&2
+trap cleanup EXIT
+
+log() {
+  printf 'sugarkube: %s\n' "$*" >&2
+}
+
+die() {
+  log "$*"
   exit 1
+}
+
+require() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    die "$1 is required"
+  fi
+}
+
+usage() {
+  cat <<'EOF'
+Usage: download_pi_image.sh [options]
+
+Fetch the latest published sugarkube image from GitHub Releases, resume partial
+downloads, and verify the checksum.
+
+Options:
+  -o, --output PATH     Path for the compressed image (default: $HOME/sugarkube/images/sugarkube.img.xz)
+  -r, --release TAG     Release tag to download (default: latest release)
+      --repo OWNER/REPO Repository to query (default: futuroptimist/sugarkube)
+      --asset NAME      Image asset name (default: sugarkube.img.xz)
+      --checksum NAME   Checksum asset name (default: <asset>.sha256)
+      --skip-verify     Skip checksum verification
+  -f, --force           Re-download even if an existing verified file is present
+  -h, --help            Show this help message
+EOF
+}
+
+DEFAULT_REPO=${SUGARKUBE_GH_REPO:-futuroptimist/sugarkube}
+DEFAULT_ASSET="sugarkube.img.xz"
+DEFAULT_DIR=${SUGARKUBE_IMAGE_DIR:-$HOME/sugarkube/images}
+
+OUTPUT=""
+RELEASE_TAG="latest"
+REPO="$DEFAULT_REPO"
+ASSET_NAME="$DEFAULT_ASSET"
+CHECKSUM_NAME=""
+SKIP_VERIFY=0
+FORCE_DOWNLOAD=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o|--output)
+      OUTPUT="$2"
+      shift 2
+      ;;
+    -r|--release)
+      RELEASE_TAG="$2"
+      shift 2
+      ;;
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    --asset)
+      ASSET_NAME="$2"
+      shift 2
+      ;;
+    --checksum)
+      CHECKSUM_NAME="$2"
+      shift 2
+      ;;
+    --skip-verify)
+      SKIP_VERIFY=1
+      shift
+      ;;
+    -f|--force)
+      FORCE_DOWNLOAD=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      die "Unknown option: $1"
+      ;;
+    *)
+      if [[ -z "$OUTPUT" ]]; then
+        OUTPUT="$1"
+      else
+        die "Unexpected argument: $1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$OUTPUT" ]]; then
+  OUTPUT="$DEFAULT_DIR/$ASSET_NAME"
 fi
 
-OUTPUT="${1:-sugarkube.img.xz}"
-
-RUN_ID=$(gh run list --workflow pi-image.yml --branch main --json databaseId -q '.[0].databaseId')
-if [ -z "$RUN_ID" ]; then
-  echo "no pi-image workflow runs found" >&2
-  exit 1
+if [[ -z "$CHECKSUM_NAME" ]]; then
+  CHECKSUM_NAME="$ASSET_NAME.sha256"
 fi
 
-dirname=$(dirname "$OUTPUT")
-mkdir -p "$dirname"
+require gh
+require curl
+require sha256sum
+require python3
 
-gh run download "$RUN_ID" --name sugarkube-img --dir "$dirname"
-img="$dirname/sugarkube.img.xz"
-sha="$dirname/sugarkube.img.xz.sha256"
+mkdir -p "$(dirname "$OUTPUT")"
 
-# Use -ef to avoid the non-POSIX realpath command
-if [ ! -e "$OUTPUT" ] || ! [ "$img" -ef "$OUTPUT" ]; then
-  mv "$img" "$OUTPUT"
+if [[ "$RELEASE_TAG" == "latest" ]]; then
+  release_json=$(gh api "repos/$REPO/releases/latest")
+else
+  release_json=$(gh api "repos/$REPO/releases/tags/$RELEASE_TAG")
 fi
-if [ -f "$sha" ]; then
-  dest_sha="${OUTPUT}.sha256"
-  if [ ! -e "$dest_sha" ] || ! [ "$sha" -ef "$dest_sha" ]; then
-    mv "$sha" "$dest_sha"
+
+if [[ -z "$release_json" ]]; then
+  die "no release metadata found for $REPO"
+fi
+
+asset_url=$(python3 - "$ASSET_NAME" "$release_json" <<'PY'
+import json
+import sys
+
+asset_name = sys.argv[1]
+release = json.loads(sys.argv[2])
+
+for asset in release.get("assets", []):
+    if asset.get("name") == asset_name:
+        print(asset.get("browser_download_url", ""))
+        sys.exit(0)
+
+sys.exit(1)
+PY
+) || true
+
+if [[ -z "$asset_url" ]]; then
+  die "asset $ASSET_NAME not found in release"
+fi
+
+checksum_url=$(python3 - "$CHECKSUM_NAME" "$release_json" <<'PY'
+import json
+import sys
+
+asset_name = sys.argv[1]
+release = json.loads(sys.argv[2])
+
+for asset in release.get("assets", []):
+    if asset.get("name") == asset_name:
+        print(asset.get("browser_download_url", ""))
+        sys.exit(0)
+
+sys.exit(1)
+PY
+) || true
+
+dest_sha="${OUTPUT}.sha256"
+
+if auth_header_value=$(gh auth token 2>/dev/null); then
+  AUTH_HEADER=("-H" "Authorization: token $auth_header_value")
+else
+  AUTH_HEADER=()
+fi
+
+download() {
+  local url="$1"
+  local dest="$2"
+  TMP_ASSET=$(mktemp)
+  log "Downloading $(basename "$dest")"
+  if ! curl --fail --location --continue-at - --progress-bar \
+      --retry 5 --retry-delay 2 --retry-max-time 120 \
+      "${AUTH_HEADER[@]}" \
+      -H "Accept: application/octet-stream" \
+      --output "$TMP_ASSET" \
+      "$url"; then
+    rm -f "$TMP_ASSET"
+    unset TMP_ASSET
+    die "failed to download $(basename "$dest")"
+  fi
+  mv "$TMP_ASSET" "$dest"
+  unset TMP_ASSET
+}
+
+normalize_checksum() {
+  if [[ ! -f "$dest_sha" ]]; then
+    return
+  fi
+  python3 - "$dest_sha" "$(basename "$OUTPUT")" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+target = sys.argv[2]
+
+raw_lines = path.read_text().splitlines()
+
+for raw_line in raw_lines:
+    stripped = raw_line.strip()
+    if not stripped or stripped.startswith("#"):
+        continue
+    parts = stripped.split(maxsplit=1)
+    digest = parts[0]
+    remainder = parts[1] if len(parts) > 1 else ""
+    candidate = remainder.strip().lstrip("*")
+    if candidate in {target, f"./{target}"}:
+        path.write_text(f"{digest}  {target}\n")
+        break
+    candidate_name = pathlib.Path(candidate).name if candidate else ""
+    if candidate_name == target:
+        path.write_text(f"{digest}  {target}\n")
+        break
+else:
+    digests = [
+        line.strip().split()[0]
+        for line in raw_lines
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    if len(digests) == 1:
+        path.write_text(f"{digests[0]}  {target}\n")
+    else:
+        print(f"no checksum entry matched {target}", file=sys.stderr)
+        sys.exit(1)
+PY
+}
+
+download_checksum() {
+  if [[ -z "$checksum_url" ]]; then
+    log "no checksum asset available"
+    return 1
+  fi
+  TMP_SHA=$(mktemp)
+  log "Downloading checksum $(basename "$dest_sha")"
+  if ! curl --fail --location --continue-at - --progress-bar \
+      --retry 5 --retry-delay 2 --retry-max-time 120 \
+      "${AUTH_HEADER[@]}" \
+      -H "Accept: application/octet-stream" \
+      --output "$TMP_SHA" \
+      "$checksum_url"; then
+    rm -f "$TMP_SHA"
+    unset TMP_SHA
+    die "failed to download checksum"
+  fi
+  mv "$TMP_SHA" "$dest_sha"
+  unset TMP_SHA
+  normalize_checksum
+}
+
+verify_checksum() {
+  local allow_missing=${1:-0}
+  if [[ $SKIP_VERIFY -eq 1 ]]; then
+    return 0
+  fi
+  if [[ ! -f "$dest_sha" ]]; then
+    log "Skipping verification (missing checksum asset)"
+    if [[ $allow_missing -eq 1 ]]; then
+      return 0
+    fi
+    return 1
+  fi
+  (cd "$(dirname "$OUTPUT")" && sha256sum --check "$(basename "$dest_sha")")
+}
+
+if [[ $SKIP_VERIFY -eq 0 ]]; then
+  download_checksum || true
+fi
+
+if [[ -f "$OUTPUT" && $FORCE_DOWNLOAD -eq 0 ]]; then
+  if verify_checksum 0; then
+    log "Existing image verified, skipping download"
+    exit 0
+  else
+    log "Existing image failed verification; re-downloading"
   fi
 fi
 
-if [ -f "${OUTPUT}.sha256" ]; then
-  ls -lh "$OUTPUT" "${OUTPUT}.sha256"
-  echo "Image saved to $OUTPUT with checksum ${OUTPUT}.sha256"
-else
-  ls -lh "$OUTPUT"
-  echo "Image saved to $OUTPUT"
+download "$asset_url" "$OUTPUT"
+
+if [[ $SKIP_VERIFY -eq 0 ]]; then
+  download_checksum || true
+  if ! verify_checksum 1; then
+    die "checksum verification failed"
+  fi
 fi
+
+ls -lh "$OUTPUT" "${dest_sha}" 2>/dev/null || ls -lh "$OUTPUT"
+log "Image saved to $OUTPUT"

--- a/scripts/sugarkube_latest.sh
+++ b/scripts/sugarkube_latest.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+DOWNLOAD_SCRIPT="$SCRIPT_DIR/download_pi_image.sh"
+
+log() {
+  printf 'sugarkube: %s\n' "$*"
+}
+
+if [[ ! -x "$DOWNLOAD_SCRIPT" ]]; then
+  log "download script not found at $DOWNLOAD_SCRIPT"
+  exit 1
+fi
+
+if ! command -v xz >/dev/null 2>&1; then
+  log "xz is required"
+  exit 1
+fi
+
+usage() {
+  cat <<'EOF'
+Usage: sugarkube_latest.sh [options] [-- <download-args>]
+
+Download the most recent sugarkube image, verify it, and expand the archive.
+
+Options:
+  -d, --image-dir DIR    Directory to store artifacts (default: $HOME/sugarkube/images)
+  -c, --compressed PATH  Override the compressed image path (passed to download script)
+  -o, --output PATH      Expanded image output path (default: <compressed without .xz>)
+      --no-expand        Skip expanding the image after download
+  -h, --help             Show this help message
+
+Additional arguments after `--` are forwarded to download_pi_image.sh.
+EOF
+}
+
+DEFAULT_DIR=${SUGARKUBE_IMAGE_DIR:-$HOME/sugarkube/images}
+IMAGE_DIR="$DEFAULT_DIR"
+COMPRESSED_OUTPUT=""
+RAW_OUTPUT=""
+EXPAND=1
+FORWARDED=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -d|--image-dir)
+      IMAGE_DIR="$2"
+      shift 2
+      ;;
+    -c|--compressed)
+      COMPRESSED_OUTPUT="$2"
+      shift 2
+      ;;
+    -o|--output)
+      RAW_OUTPUT="$2"
+      shift 2
+      ;;
+    --no-expand)
+      EXPAND=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      while [[ $# -gt 0 ]]; do
+        FORWARDED+=("$1")
+        shift
+      done
+      break
+      ;;
+    -r|--release|--repo|--asset|--checksum)
+      FORWARDED+=("$1" "$2")
+      shift 2
+      ;;
+    -f|--force|--skip-verify)
+      FORWARDED+=("$1")
+      shift
+      ;;
+    *)
+      FORWARDED+=("$1")
+      shift
+      ;;
+  esac
+done
+
+mkdir -p "$IMAGE_DIR"
+
+if [[ -z "$COMPRESSED_OUTPUT" ]]; then
+  COMPRESSED_OUTPUT="$IMAGE_DIR/sugarkube.img.xz"
+fi
+
+mkdir -p "$(dirname "$COMPRESSED_OUTPUT")"
+
+if [[ -z "$RAW_OUTPUT" ]]; then
+  if [[ "$COMPRESSED_OUTPUT" == *.xz ]]; then
+    RAW_OUTPUT="${COMPRESSED_OUTPUT%.xz}"
+  else
+    RAW_OUTPUT="${COMPRESSED_OUTPUT}.img"
+  fi
+fi
+
+# Avoid appending duplicate output flags if passed via --
+append_output_flag=1
+for arg in "${FORWARDED[@]}"; do
+  if [[ "$arg" == "-o" || "$arg" == "--output" ]]; then
+    append_output_flag=0
+    break
+  fi
+done
+
+if [[ $append_output_flag -eq 1 ]]; then
+  FORWARDED+=("-o" "$COMPRESSED_OUTPUT")
+fi
+
+"$DOWNLOAD_SCRIPT" "${FORWARDED[@]}"
+
+if [[ $EXPAND -eq 0 ]]; then
+  log "Skipping image expansion (--no-expand specified)"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$RAW_OUTPUT")"
+
+if [[ -f "$RAW_OUTPUT" && "$COMPRESSED_OUTPUT" -ot "$RAW_OUTPUT" ]]; then
+  log "Expanded image already up to date at $RAW_OUTPUT"
+  exit 0
+fi
+
+if [[ ! -f "$COMPRESSED_OUTPUT" ]]; then
+  log "Compressed image not found at $COMPRESSED_OUTPUT"
+  exit 1
+fi
+
+tmp_raw=$(mktemp)
+trap "rm -f '$tmp_raw'" EXIT
+
+log "Expanding $COMPRESSED_OUTPUT to $RAW_OUTPUT"
+if ! xz -dc "$COMPRESSED_OUTPUT" > "$tmp_raw"; then
+  rm -f "$tmp_raw"
+  trap - EXIT
+  log "Failed to expand image"
+  exit 1
+fi
+
+mv "$tmp_raw" "$RAW_OUTPUT"
+trap - EXIT
+log "Expanded image saved to $RAW_OUTPUT"

--- a/tests/download_pi_image_test.py
+++ b/tests/download_pi_image_test.py
@@ -1,16 +1,16 @@
+import hashlib
 import os
-import shutil
 import subprocess
 from pathlib import Path
+
+from tests.download_test_utils import download_script_path, write_stub_scripts
 
 
 def test_requires_gh(tmp_path):
     env = os.environ.copy()
     env["PATH"] = str(tmp_path)
-    base = Path(__file__).resolve().parents[1]
-    script = base / "scripts" / "download_pi_image.sh"
     result = subprocess.run(
-        ["/bin/bash", str(script)],
+        ["/bin/bash", str(download_script_path())],
         env=env,
         cwd=tmp_path,
         capture_output=True,
@@ -20,175 +20,123 @@ def test_requires_gh(tmp_path):
     assert "gh is required" in result.stderr
 
 
-def test_downloads_artifact(tmp_path):
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    src = tmp_path / "src.img.xz"
-    src.write_text("data")
-    gh = fake_bin / "gh"
-    gh.write_text(
-        "#!/bin/bash\n"
-        'if [ "$1" = run ] && [ "$2" = list ]; then\n'
-        "  echo 42\n"
-        'elif [ "$1" = run ] && [ "$2" = download ]; then\n'
-        "  shift 2\n"
-        '  while [ "$1" != --dir ]; do shift; done\n'
-        "  dir=$2\n"
-        '  cp "$GH_SRC" "$dir/sugarkube.img.xz"\n'
-        "else\n"
-        "  exit 1\n"
-        "fi\n"
-    )
-    gh.chmod(0o755)
-
-    env = os.environ.copy()
-    env["PATH"] = f"{fake_bin}:{env['PATH']}"
-    env["GH_SRC"] = str(src)
-    base = Path(__file__).resolve().parents[1]
-    script = base / "scripts" / "download_pi_image.sh"
+def test_downloads_and_verifies_artifact(tmp_path):
+    env = write_stub_scripts(tmp_path)
+    out = tmp_path / "out" / "sugarkube.img.xz"
     result = subprocess.run(
-        ["/bin/bash", str(script), "out.img.xz"],
+        ["/bin/bash", str(download_script_path()), "-o", str(out)],
         env=env,
         cwd=tmp_path,
         capture_output=True,
         text=True,
     )
-    assert result.returncode == 0
-    assert (tmp_path / "out.img.xz").exists()
+    assert result.returncode == 0, result.stderr
+    assert out.exists()
+    checksum = Path(str(out) + ".sha256")
+    assert checksum.exists()
+
+
+def test_filters_combined_checksum_entries(tmp_path):
+    other_digest = hashlib.sha256(b"other-asset").hexdigest()
+    env = write_stub_scripts(
+        tmp_path,
+        checksum_entries=[
+            ("sugarkube.img.xz", None),
+            ("extra.img.xz", other_digest),
+        ],
+    )
+    out = tmp_path / "out" / "sugarkube.img.xz"
+    result = subprocess.run(
+        ["/bin/bash", str(download_script_path()), "-o", str(out)],
+        env=env,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    checksum = Path(str(out) + ".sha256")
+    assert checksum.exists()
+    lines = [line.strip() for line in checksum.read_text().splitlines() if line.strip()]
+    expected_digest = hashlib.sha256(Path(env["IMAGE_SOURCE"]).read_bytes()).hexdigest()
+    assert lines == [f"{expected_digest}  sugarkube.img.xz"]
 
 
 def test_errors_when_download_fails(tmp_path):
-    """The script should fail if the artifact download step errors."""
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    gh = fake_bin / "gh"
-    gh.write_text(
-        "#!/bin/bash\n"
-        'if [ "$1" = run ] && [ "$2" = list ]; then\n'
-        "  echo 42\n"
-        'elif [ "$1" = run ] && [ "$2" = download ]; then\n'
-        "  exit 1\n"
-        "else\n"
-        "  exit 1\n"
-        "fi\n"
-    )
-    gh.chmod(0o755)
-
-    env = os.environ.copy()
-    env["PATH"] = str(fake_bin)
-    base = Path(__file__).resolve().parents[1]
-    script = base / "scripts" / "download_pi_image.sh"
+    env = write_stub_scripts(tmp_path)
+    env["BLOCK_IMAGE_DOWNLOAD"] = "1"
+    env["FAIL_IMAGE_DOWNLOAD"] = "55"
+    out = tmp_path / "fail.img.xz"
     result = subprocess.run(
-        ["/bin/bash", str(script), "out.img.xz"],
+        ["/bin/bash", str(download_script_path()), "-o", str(out)],
         env=env,
         cwd=tmp_path,
         capture_output=True,
         text=True,
     )
     assert result.returncode != 0
-    assert not (tmp_path / "out.img.xz").exists()
+    assert not out.exists()
 
 
-def test_errors_when_no_run_found(tmp_path):
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    marker = tmp_path / "download_called"
-    gh = fake_bin / "gh"
-    gh.write_text(
-        f"#!/bin/bash\n"
-        'if [ "$1" = run ] && [ "$2" = list ]; then\n'
-        "  exit 0\n"
-        'elif [ "$1" = run ] && [ "$2" = download ]; then\n'
-        f"  echo called > {marker}\n"
-        "  exit 0\n"
-        "else\n"
-        "  exit 1\n"
-        "fi\n"
-    )
-    gh.chmod(0o755)
-
-    env = os.environ.copy()
-    env["PATH"] = str(fake_bin)
-    base = Path(__file__).resolve().parents[1]
-    script = base / "scripts" / "download_pi_image.sh"
+def test_errors_when_asset_missing(tmp_path):
+    env = write_stub_scripts(tmp_path, asset_name="other.img")
+    out = tmp_path / "missing.img.xz"
     result = subprocess.run(
-        ["/bin/bash", str(script)],
+        ["/bin/bash", str(download_script_path()), "-o", str(out)],
         env=env,
         cwd=tmp_path,
         capture_output=True,
         text=True,
     )
     assert result.returncode != 0
-    assert "no pi-image workflow runs found" in result.stderr
-    assert not marker.exists()
+    assert "asset" in result.stderr
 
 
-def test_uses_default_output(tmp_path):
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    src = tmp_path / "src.img.xz"
-    src.write_text("data")
-    gh = fake_bin / "gh"
-    gh.write_text(
-        "#!/bin/bash\n"
-        'if [ "$1" = run ] && [ "$2" = list ]; then\n'
-        "  echo 42\n"
-        'elif [ "$1" = run ] && [ "$2" = download ]; then\n'
-        "  shift 2\n"
-        '  while [ "$1" != --dir ]; do shift; done\n'
-        "  dir=$2\n"
-        '  cp "$GH_SRC" "$dir/sugarkube.img.xz"\n'
-        "else\n"
-        "  exit 1\n"
-        "fi\n"
-    )
-    gh.chmod(0o755)
-
-    env = os.environ.copy()
-    env["PATH"] = f"{fake_bin}:{env['PATH']}"
-    env["GH_SRC"] = str(src)
-    base = Path(__file__).resolve().parents[1]
-    script = base / "scripts" / "download_pi_image.sh"
+def test_uses_default_output_directory(tmp_path):
+    env = write_stub_scripts(tmp_path)
+    home = tmp_path / "home"
+    env["HOME"] = str(home)
     result = subprocess.run(
-        ["/bin/bash", str(script)],
+        ["/bin/bash", str(download_script_path())],
         env=env,
         cwd=tmp_path,
         capture_output=True,
         text=True,
     )
     assert result.returncode == 0
-    assert (tmp_path / "sugarkube.img.xz").exists()
+    default_path = home / "sugarkube" / "images" / "sugarkube.img.xz"
+    assert default_path.exists()
 
 
-def test_creates_output_directory(tmp_path):
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    src = tmp_path / "src.img.xz"
-    src.write_text("data")
-    gh = fake_bin / "gh"
-    gh.write_text(
-        "#!/bin/bash\n"
-        'if [ "$1" = run ] && [ "$2" = list ]; then\n'
-        "  echo 42\n"
-        'elif [ "$1" = run ] && [ "$2" = download ]; then\n'
-        "  shift 2\n"
-        '  while [ "$1" != --dir ]; do shift; done\n'
-        "  dir=$2\n"
-        '  cp "$GH_SRC" "$dir/sugarkube.img.xz"\n'
-        "else\n"
-        "  exit 1\n"
-        "fi\n"
-    )
-    gh.chmod(0o755)
+def test_skips_download_when_existing_file_verifies(tmp_path):
+    env = write_stub_scripts(tmp_path)
+    marker = tmp_path / "marker.txt"
+    env["IMAGE_MARKER"] = str(marker)
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    target = output_dir / "sugarkube.img.xz"
+    target.write_bytes(Path(env["IMAGE_SOURCE"]).read_bytes())
+    sha_path = Path(str(target) + ".sha256")
+    sha_path.write_text(Path(env["SHA_SOURCE"]).read_text())
 
-    env = os.environ.copy()
-    env["PATH"] = f"{fake_bin}:{env['PATH']}"
-    env["GH_SRC"] = str(src)
-    base = Path(__file__).resolve().parents[1]
-    script = base / "scripts" / "download_pi_image.sh"
-    out = tmp_path / "nested" / "out.img.xz"
+    env["BLOCK_IMAGE_DOWNLOAD"] = "1"
+    env["FAIL_IMAGE_DOWNLOAD"] = "77"
+
     result = subprocess.run(
-        ["/bin/bash", str(script), str(out)],
+        ["/bin/bash", str(download_script_path()), "-o", str(target)],
+        env=env,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert not marker.exists()
+
+
+def test_allows_missing_checksum(tmp_path):
+    env = write_stub_scripts(tmp_path, include_checksum=False)
+    out = tmp_path / "no-checksum.img.xz"
+    result = subprocess.run(
+        ["/bin/bash", str(download_script_path()), "-o", str(out)],
         env=env,
         cwd=tmp_path,
         capture_output=True,
@@ -196,157 +144,4 @@ def test_creates_output_directory(tmp_path):
     )
     assert result.returncode == 0
     assert out.exists()
-    assert (tmp_path / "nested").is_dir()
-
-
-def test_downloads_without_realpath(tmp_path):
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    src = tmp_path / "src.img.xz"
-    src.write_text("data")
-    sha = tmp_path / "src.img.xz.sha256"
-    sha.write_text("sum  sugarkube.img.xz\n")
-
-    gh = fake_bin / "gh"
-    gh.write_text(
-        "#!/bin/bash\n"
-        'if [ "$1" = run ] && [ "$2" = list ]; then\n'
-        "  echo 42\n"
-        'elif [ "$1" = run ] && [ "$2" = download ]; then\n'
-        "  shift 2\n"
-        '  while [ "$1" != --dir ]; do shift; done\n'
-        "  dir=$2\n"
-        '  cp "$GH_SRC" "$dir/sugarkube.img.xz"\n'
-        '  cp "$GH_SHA" "$dir/sugarkube.img.xz.sha256"\n'
-        "else\n"
-        "  exit 1\n"
-        "fi\n"
-    )
-    gh.chmod(0o755)
-
-    # Symlink required utilities but omit realpath
-    for cmd in ["dirname", "mkdir", "mv", "ls", "cp"]:
-        target = shutil.which(cmd)
-        assert target is not None
-        (fake_bin / cmd).symlink_to(target)
-
-    env = os.environ.copy()
-    env["PATH"] = str(fake_bin)
-    env["GH_SRC"] = str(src)
-    env["GH_SHA"] = str(sha)
-
-    base = Path(__file__).resolve().parents[1]
-    script = base / "scripts" / "download_pi_image.sh"
-    result = subprocess.run(
-        ["/bin/bash", str(script), "out.img.xz"],
-        env=env,
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode == 0
-    assert (tmp_path / "out.img.xz").exists()
-    assert (tmp_path / "out.img.xz.sha256").exists()
-
-
-def test_overwrites_existing_output_and_checksum(tmp_path):
-    """Existing files should be replaced when downloading a new image."""
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-
-    src = tmp_path / "src.img.xz"
-    src.write_text("fresh")
-    sha = tmp_path / "src.img.xz.sha256"
-    sha.write_text("newsha  sugarkube.img.xz\n")
-
-    gh = fake_bin / "gh"
-    gh.write_text(
-        "#!/bin/bash\n"
-        'if [ "$1" = run ] && [ "$2" = list ]; then\n'
-        "  echo 42\n"
-        'elif [ "$1" = run ] && [ "$2" = download ]; then\n'
-        "  shift 2\n"
-        '  while [ "$1" != --dir ]; do shift; done\n'
-        "  dir=$2\n"
-        '  cp "$GH_SRC" "$dir/sugarkube.img.xz"\n'
-        '  cp "$GH_SHA" "$dir/sugarkube.img.xz.sha256"\n'
-        "else\n"
-        "  exit 1\n"
-        "fi\n"
-    )
-    gh.chmod(0o755)
-
-    out = tmp_path / "out.img.xz"
-    out.write_text("stale")
-    out_sha = tmp_path / "out.img.xz.sha256"
-    out_sha.write_text("oldsha  out.img.xz\n")
-
-    env = os.environ.copy()
-    env["PATH"] = f"{fake_bin}:{env['PATH']}"
-    env["GH_SRC"] = str(src)
-    env["GH_SHA"] = str(sha)
-
-    base = Path(__file__).resolve().parents[1]
-    script = base / "scripts" / "download_pi_image.sh"
-    result = subprocess.run(
-        ["/bin/bash", str(script), str(out)],
-        env=env,
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode == 0, result.stderr
-    assert out.read_text() == "fresh"
-    assert out_sha.read_text() == "newsha  sugarkube.img.xz\n"
-
-
-def test_skips_mv_when_output_already_exists(tmp_path):
-    """Avoid moving the file when the output path already matches the downloaded artifact."""
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-
-    src = tmp_path / "src.img.xz"
-    src.write_text("data")
-
-    gh = fake_bin / "gh"
-    gh.write_text(
-        "#!/bin/bash\n"
-        'if [ "$1" = run ] && [ "$2" = list ]; then\n'
-        "  echo 42\n"
-        'elif [ "$1" = run ] && [ "$2" = download ]; then\n'
-        "  shift 2\n"
-        '  while [ "$1" != --dir ]; do shift; done\n'
-        "  dir=$2\n"
-        '  cp "$GH_SRC" "$dir/sugarkube.img.xz"\n'
-        "else\n"
-        "  exit 1\n"
-        "fi\n"
-    )
-    gh.chmod(0o755)
-
-    marker = tmp_path / "mv_called"
-    mv = fake_bin / "mv"
-    mv.write_text(f"#!/bin/bash\necho called > {marker}\nexit 1\n")
-    mv.chmod(0o755)
-
-    for cmd in ["dirname", "mkdir", "ls"]:
-        target = shutil.which(cmd)
-        assert target is not None
-        (fake_bin / cmd).symlink_to(target)
-
-    env = os.environ.copy()
-    env["PATH"] = f"{fake_bin}:{env['PATH']}"
-    env["GH_SRC"] = str(src)
-
-    base = Path(__file__).resolve().parents[1]
-    script = base / "scripts" / "download_pi_image.sh"
-    result = subprocess.run(
-        ["/bin/bash", str(script)],
-        env=env,
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode == 0, result.stderr
-    assert (tmp_path / "sugarkube.img.xz").exists()
-    assert not marker.exists()
+    assert not Path(str(out) + ".sha256").exists()

--- a/tests/download_test_utils.py
+++ b/tests/download_test_utils.py
@@ -1,0 +1,153 @@
+import hashlib
+import json
+import lzma
+import os
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+
+def download_script_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "scripts" / "download_pi_image.sh"
+
+
+def latest_script_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "scripts" / "sugarkube_latest.sh"
+
+
+def write_stub_scripts(
+    tmp_path: Path,
+    *,
+    asset_name: str = "sugarkube.img.xz",
+    include_checksum: bool = True,
+    checksum_entries: Optional[List[Tuple[str, Optional[str]]]] = None,
+) -> dict:
+    """Create fake gh and curl binaries for exercising download helpers."""
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    raw_payload = b"sugarkube-image" * 4
+    compressed_src = tmp_path / "source.img.xz"
+    compressed_src.write_bytes(lzma.compress(raw_payload))
+
+    sha_src = tmp_path / "source.sha256"
+    digest = hashlib.sha256(compressed_src.read_bytes()).hexdigest()
+
+    if checksum_entries is None:
+        normalized_entries: List[Tuple[str, str]] = [(asset_name, digest)]
+    else:
+        normalized_entries = []
+        seen_asset = False
+        for name, entry_digest in checksum_entries:
+            if entry_digest is None:
+                if name == asset_name:
+                    entry_digest = digest
+                else:
+                    entry_digest = hashlib.sha256(name.encode()).hexdigest()
+            if name == asset_name:
+                seen_asset = True
+            normalized_entries.append((name, entry_digest))
+        if not seen_asset:
+            normalized_entries.insert(0, (asset_name, digest))
+
+    sha_src.write_text(
+        "\n".join(f"{entry_digest}  {name}" for name, entry_digest in normalized_entries) + "\n"
+    )
+
+    image_url = "https://example.com/image"
+    checksum_url = "https://example.com/image.sha"
+
+    assets = [
+        {
+            "name": asset_name,
+            "browser_download_url": image_url,
+        }
+    ]
+    if include_checksum:
+        assets.append(
+            {
+                "name": f"{asset_name}.sha256",
+                "browser_download_url": checksum_url,
+            }
+        )
+
+    release_json = json.dumps({"tag_name": "v0.0.1", "assets": assets})
+
+    gh = bin_dir / "gh"
+    gh.write_text(
+        "#!/bin/bash\n"
+        "set -e\n"
+        'if [ "$1" = api ]; then\n'
+        '  if [ "$2" = "repos/futuroptimist/sugarkube/releases/latest" ]; then\n'
+        "    cat <<'JSON'\n"
+        f"{release_json}\n"
+        "JSON\n"
+        "    exit 0\n"
+        "  fi\n"
+        'elif [ "$1" = auth ] && [ "$2" = token ]; then\n'
+        '  if [ -n "${GH_TOKEN_OUTPUT:-}" ]; then\n'
+        '    echo "$GH_TOKEN_OUTPUT"\n'
+        "  else\n"
+        "    echo FAKE_TOKEN\n"
+        "  fi\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 1\n"
+    )
+    gh.chmod(0o755)
+
+    curl = bin_dir / "curl"
+    curl.write_text(
+        "#!/bin/bash\n"
+        "set -e\n"
+        'dest=""\n'
+        'url=""\n'
+        "while [ $# -gt 0 ]; do\n"
+        '  case "$1" in\n'
+        "    --output|-o) dest=$2; shift 2 ;;\n"
+        "    --continue-at) shift 2 ;;\n"
+        "    --retry|--retry-delay|--retry-max-time) shift 2 ;;\n"
+        "    -H) shift 2 ;;\n"
+        "    --fail|--location|--progress-bar) shift ;;\n"
+        "    *) url=$1; shift ;;\n"
+        "  esac\n"
+        "done\n"
+        'if [ -z "$dest" ]; then\n'
+        '  echo "missing destination" >&2\n'
+        "  exit 96\n"
+        "fi\n"
+        'case "$url" in\n'
+        "  $IMAGE_URL)\n"
+        '    if [ -n "$BLOCK_IMAGE_DOWNLOAD" ]; then\n'
+        '      if [ -n "$IMAGE_MARKER" ]; then\n'
+        '        echo attempted > "$IMAGE_MARKER"\n'
+        "      fi\n"
+        "      exit ${FAIL_IMAGE_DOWNLOAD:-1}\n"
+        "    fi\n"
+        '    cp "$IMAGE_SOURCE" "$dest"\n'
+        '    if [ -n "$IMAGE_MARKER" ]; then\n'
+        '      echo success > "$IMAGE_MARKER"\n'
+        "    fi\n"
+        "    ;;\n"
+        "  $SHA_URL)\n"
+        '    if [ -n "$FAIL_CHECKSUM_DOWNLOAD" ]; then\n'
+        "      exit $FAIL_CHECKSUM_DOWNLOAD\n"
+        "    fi\n"
+        '    cp "$SHA_SOURCE" "$dest"\n'
+        "    ;;\n"
+        "  *)\n"
+        '    echo "unexpected url: $url" >&2\n'
+        "    exit ${CURL_UNEXPECTED_EXIT:-1}\n"
+        "    ;;\n"
+        "esac\n"
+    )
+    curl.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["IMAGE_SOURCE"] = str(compressed_src)
+    env["SHA_SOURCE"] = str(sha_src)
+    env["IMAGE_URL"] = image_url
+    env["SHA_URL"] = checksum_url
+
+    return env

--- a/tests/pi_node_verifier_json_test.bats
+++ b/tests/pi_node_verifier_json_test.bats
@@ -49,4 +49,3 @@ EOF
   echo "$output" | jq -e '.checks[] | select(.name=="iptables_backend") | .status=="skip"' > /dev/null
   echo "$output" | jq -e '.checks[] | select(.name=="k3s_check_config") | .status=="skip"' > /dev/null
 }
-

--- a/tests/sugarkube_latest_test.py
+++ b/tests/sugarkube_latest_test.py
@@ -1,0 +1,79 @@
+import lzma
+import os
+import subprocess
+from pathlib import Path
+
+from tests.download_test_utils import latest_script_path, write_stub_scripts
+
+
+def test_downloads_and_expands(tmp_path):
+    env = write_stub_scripts(tmp_path)
+    env["HOME"] = str(tmp_path)
+    result = subprocess.run(
+        ["/bin/bash", str(latest_script_path())],
+        env=env,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    compressed = tmp_path / "sugarkube" / "images" / "sugarkube.img.xz"
+    expanded = tmp_path / "sugarkube" / "images" / "sugarkube.img"
+    assert compressed.exists()
+    assert expanded.exists()
+
+    with lzma.open(compressed, "rb") as source:
+        expected = source.read()
+    assert expanded.read_bytes() == expected
+
+
+def test_no_expand_option(tmp_path):
+    env = write_stub_scripts(tmp_path)
+    out_dir = tmp_path / "images"
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            str(latest_script_path()),
+            "-d",
+            str(out_dir),
+            "--no-expand",
+        ],
+        env=env,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    compressed = out_dir / "sugarkube.img.xz"
+    raw = out_dir / "sugarkube.img"
+    assert compressed.exists()
+    assert not raw.exists()
+
+
+def test_skips_expansion_when_up_to_date(tmp_path):
+    env = write_stub_scripts(tmp_path)
+    out_dir = tmp_path / "images"
+    out_dir.mkdir()
+    compressed = out_dir / "sugarkube.img.xz"
+    compressed.write_bytes(Path(env["IMAGE_SOURCE"]).read_bytes())
+    raw = out_dir / "sugarkube.img"
+    with lzma.open(compressed, "rb") as source:
+        raw.write_bytes(source.read())
+
+    old_mtime = raw.stat().st_mtime
+    # Ensure raw appears newer than compressed so expansion is skipped
+    os.utime(raw, None)
+    os.utime(compressed, (old_mtime - 10, old_mtime - 10))
+    before = raw.stat().st_mtime
+
+    result = subprocess.run(
+        ["/bin/bash", str(latest_script_path()), "-d", str(out_dir)],
+        env=env,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    after = raw.stat().st_mtime
+    assert after == before


### PR DESCRIPTION
## Summary
- revamp scripts/download_pi_image.sh to resolve GitHub releases, resume downloads, and enforce checksum verification with configurable output paths
- add scripts/sugarkube_latest.sh plus supporting tests to download, verify, and expand images in one step
- refresh documentation, checklist progress, and README to highlight the improved tooling
- isolate checksum normalization to the requested asset and cover combined checksum files in tests

## Testing
- pytest
- python -m pre_commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68c9ce3ee320832fade3cff9836ae3de