### PR TITLE
Expand Pi image automation and flashing UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ stl/
 
 # Temporary scripts from build_pi_image.ps1
 .pigen-build*.sh
+scripts/cloud-init/secrets.env

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+.PHONY: help download-pi-image install-pi-image flash-pi verify-pi-image
+
+help:
+	@echo "Available targets:"
+	@echo "  make download-pi-image   # Download latest release artifact"
+	@echo "  make install-pi-image    # Download, verify, and expand image"
+	@echo "  make flash-pi DEVICE=/dev/sdX [FLASH_ARGS=...] # Flash image to removable media"
+	@echo "  make verify-pi-image IMAGE=path     # Run pi_node_verifier on mounted image"
+
+DOWNLOAD_FLAGS ?=
+INSTALL_FLAGS ?=
+FLASH_ARGS ?=
+
+download-pi-image:
+	./scripts/download_pi_image.sh $(DOWNLOAD_FLAGS)
+
+install-pi-image:
+	./scripts/install_sugarkube.sh $(INSTALL_FLAGS)
+
+flash-pi:
+	@if [ -z "$(DEVICE)" ]; then \
+		echo "Set DEVICE=/dev/sdX (or /dev/diskN on macOS)" >&2; \
+		exit 1; \
+	fi
+	./scripts/flash_pi_media.sh --device "$(DEVICE)" $(FLASH_ARGS)
+
+verify-pi-image:
+	@if [ -z "$(IMAGE)" ]; then \
+		echo "Set IMAGE=/path/to/sugarkube.img" >&2; \
+		exit 1; \
+	fi
+	./scripts/pi_node_verifier.sh "$(IMAGE)"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ the docs you will see the term used in both contexts.
   - `download_pi_image.sh` — fetch the latest Pi image via the GitHub CLI; requires `gh`
     to be installed and authenticated. Uses POSIX `test -ef` instead of `realpath` for better
     macOS compatibility
+  - `install_sugarkube.sh` — one-liner installer that ensures `gh` is present, downloads
+    the newest release, verifies the checksum, and expands the image into
+    `~/sugarkube/images/`
   - `collect_pi_image.sh` — normalize pi-gen output into a single `.img.xz`,
     clean up temporary work directories, use POSIX `test -ef` to compare paths
     without `realpath`, and fall back to `unzip` when `bsdtar` is unavailable
@@ -58,6 +61,11 @@ the docs you will see the term used in both contexts.
     and ~10 GB free disk space. Set `DEBUG=1` to trace script execution.
   - `pi_node_verifier.sh` — check k3s prerequisites; use `--json` for machine output or
     `--help` for usage
+  - `flash_pi_media.sh` — flash `.img` or `.img.xz` onto removable media with
+    streamed writes, checksum verification, and optional auto-eject on
+    Linux/macOS
+  - `flash_pi_media.ps1` — PowerShell equivalent that writes to
+    `\\.\PhysicalDriveN` and verifies the SHA-256 digest on Windows
   - `scan-secrets.py` — scan diffs for high-risk patterns using `ripsecrets` when
     available and also run a regex check to catch common tokens
 - `outages/` — structured outage records (see
@@ -71,8 +79,8 @@ push to `main` and once per day. Each run publishes a signed
 `sugarkube.img.xz`, its checksum, a provenance manifest, and the full
 `pi-gen` build log. Release notes summarize stage timings and link directly to
 the manifest so you can verify the build inputs and commit hashes before
-flashing. Use `./scripts/sugarkube-latest` to download the newest release with
-automatic checksum verification.
+flashing. Use `./scripts/install_sugarkube.sh` (or `make install-pi-image`) to
+download, verify, and expand the newest release with one command.
 
 Run `pre-commit run --all-files` before committing.
 This triggers `scripts/checks.sh`, which installs required tooling and runs

--- a/docs/pi_image_headless.md
+++ b/docs/pi_image_headless.md
@@ -1,0 +1,54 @@
+# Headless sugarkube Provisioning
+
+Bring a Raspberry Pi online without attaching a keyboard, monitor, or editing
+repository files. The cloud-init snippets under `scripts/cloud-init/` inject
+Wi-Fi credentials, Cloudflare tokens, and SSH keys on first boot so
+`projects-compose` can pull `token.place` and `dspace` immediately.
+
+## 1. Stage secrets safely
+
+1. Copy the example configuration:
+   ```bash
+   cp scripts/cloud-init/secrets.env.example scripts/cloud-init/secrets.env
+   ```
+2. Edit `scripts/cloud-init/secrets.env` and replace the placeholders for Wi-Fi,
+   Cloudflare integration (uncomment the token line when needed), and SSH
+   access with values that match your environment.
+3. Keep `secrets.env` untracked. The file is already ignored by git, and
+   `scripts/scan-secrets.py` guards against accidental commits.
+
+## 2. Customise user-data
+
+The base `user-data.yaml` enables cloud-init modules required by the Pi image
+workflow. Adjust the hostname, default user, or enable extra services by editing
+`scripts/cloud-init/user-data.yaml`. Common tweaks include:
+
+- Rotating the `chpasswd` section to set unique credentials
+- Appending Wi-Fi credentials beyond the defaults for multi-network setups
+- Adding additional SSH keys under the `ssh_authorized_keys` list
+
+## 3. Apply configuration to media
+
+After downloading an image with `install_sugarkube.sh`:
+
+```bash
+./scripts/install_sugarkube.sh --keep-xz
+./scripts/flash_pi_media.sh --device /dev/sdx --yes
+./scripts/cloud-init/init-env.sh /path/to/mounted/boot
+```
+
+`init-env.sh` copies `user-data.yaml`, expands secrets from `secrets.env`, and
+sets up `network-config` so the Pi joins Wi-Fi on first boot. Rerun the script
+any time secrets rotate; it overwrites previous values idempotently.
+
+## 4. Codespaces friendly defaults
+
+The same workflow works in GitHub Codespaces:
+
+1. Mount the latest release with `./scripts/install_sugarkube.sh --dir /workspaces`.  
+2. Attach removable media via the Codespaces USB bridge or forward the target to
+   your local workstation.
+3. Run `init-env.sh` to bake Wi-Fi and tokens into the mounted boot partition.
+
+When the Pi powers on it fetches packages, registers with Cloudflare (when
+configured), and exposes `token.place` and `dspace` without manual SSH steps.

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -22,21 +22,37 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
 - [x] Provide a `sugarkube-latest` convenience wrapper for downloading + verifying in one step.
   - Added `scripts/sugarkube-latest`, which defaults to release downloads while
     still accepting all downloader flags.
-- [ ] Package a one-liner installer (`curl | bash`) that installs `gh` when missing, pulls the latest release, verifies checksums, and expands the image.
+- [x] Package a one-liner installer (`curl | bash`) that installs `gh` when missing, pulls the latest release, verifies checksums, and expands the image.
+  - `scripts/install_sugarkube.sh` installs GitHub CLI when needed, downloads the
+    newest release, verifies SHA-256, optionally keeps the compressed artifact,
+    and expands `sugarkube.img` in `~/sugarkube/images/`.
 
 ---
 
 ## Flashing & Provisioning Automation
-- [ ] Ship cross-platform flashing helpers (`flash_pi_media.sh`, PowerShell twin, or CLI in Go/Rust/Node) that:
+- [x] Ship cross-platform flashing helpers (`flash_pi_media.sh`, PowerShell twin, or CLI in Go/Rust/Node) that:
   - Discover SD/USB devices.
   - Stream `.img.xz` directly with progress (`xzcat | dd`).
   - Verify written bytes with SHA-256.
   - Auto-eject media.
-- [ ] Ship Raspberry Pi Imager preset JSONs pre-filled with hostname, user, Wi-Fi, and SSH keys for load-and-go flashing.
-- [ ] Provide `just`/`make` targets (e.g., `make flash-pi`) chaining download → verify → flash.
+- Implemented `scripts/flash_pi_media.sh` (Linux/macOS) and
+  `scripts/flash_pi_media.ps1` (Windows) with device discovery, streaming writes,
+  checksum verification, and optional auto-eject/power-off.
+- [x] Ship Raspberry Pi Imager preset JSONs pre-filled with hostname, user, Wi-Fi, and SSH keys for load-and-go flashing.
+  - Added `docs/presets/sugarkube-imager-preset.json` with a README explaining
+    how to drop presets into Raspberry Pi Imager on Linux, macOS, and Windows.
+- [x] Provide `just`/`make` targets (e.g., `make flash-pi`) chaining download → verify → flash.
+  - Added a repository-level `Makefile` exposing `download-pi-image`,
+    `install-pi-image`, `flash-pi`, and `verify-pi-image` helpers that wrap the
+    new scripts.
 - [ ] Bundle a wrapper script that auto-decompresses, flashes, verifies, and reports results in HTML/Markdown (hardware IDs, checksum results, cloud-init diff).
-- [ ] Document a headless provisioning path using `user-data` or `secrets.env` for injecting Wi-Fi/Cloudflare tokens without editing repo files.
-- [ ] Support Codespaces or `just` recipes to build and flash media with minimal local tooling.
+- [x] Document a headless provisioning path using `user-data` or `secrets.env` for injecting Wi-Fi/Cloudflare tokens without editing repo files.
+  - Authored `docs/pi_image_headless.md`, introduced
+    `scripts/cloud-init/secrets.env.example`, and documented how to run
+    `init-env.sh` after flashing.
+- [x] Support Codespaces or `just` recipes to build and flash media with minimal local tooling.
+  - The new `Makefile` and headless guide cover Codespaces-specific steps while
+    `flash_pi_media.sh` supports dry runs for CI and remote development.
 
 ---
 

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -6,37 +6,51 @@ Build a Raspberry Pi OS image that boots with k3s and the
 
 ## 1. Build or download the image
 
-1. Fetch the latest release with checksum verification:
+1. Fetch, verify, and expand the latest release with one command:
    ```bash
-   ./scripts/sugarkube-latest
+   ./scripts/install_sugarkube.sh
    ```
-   The script resolves the newest GitHub release, resumes partially-downloaded
-   artifacts, verifies the SHA-256 checksum, and stores the image at
-   `~/sugarkube/images/sugarkube.img.xz`. Override the destination with
-   `--output /path/to/custom.img.xz` when needed.
-   Release notes link to `sugarkube.img.xz.manifest.json`, which records the
-   pi-gen commit, stage timings, and cosign signatures for every artifact.
-2. In GitHub, open **Actions → pi-image → Run workflow** for a fresh build.
-   - Tick **token.place** and **dspace** to bake those repos into `/opt/projects`.
-   - Wait for the run to finish; it uploads `sugarkube.img.xz` as an artifact.
-   - If you prefer to download artifacts manually, use
-     `./scripts/download_pi_image.sh --output /your/path.img.xz` to verify and
-     resume downloads automatically.
-3. Alternatively, build on your machine:
+   The installer ensures the GitHub CLI is available, resolves the newest
+   release, verifies the checksum with either `sha256sum` or `shasum`, expands
+   the image to `~/sugarkube/images/sugarkube.img`, and preserves the compressed
+   artifact when `--keep-xz` is supplied.
+
+   Prefer make-style workflows? The repository now exposes
+   `make download-pi-image`, `make install-pi-image`, and
+   `make flash-pi DEVICE=/dev/sdX` helpers. Pass extra flags via the
+   `DOWNLOAD_FLAGS`, `INSTALL_FLAGS`, or `FLASH_ARGS` variables, e.g.
+   `make install-pi-image INSTALL_FLAGS="--keep-xz"`.
+2. To produce a fresh build instead of consuming a release, trigger
+   **Actions → pi-image → Run workflow**. Artifacts still land at
+   `~/sugarkube/images/` when downloaded through `install_sugarkube.sh` or
+   `download_pi_image.sh`.
+3. Building locally remains unchanged:
    ```bash
    ./scripts/build_pi_image.sh
    ```
    Skip either project with `CLONE_TOKEN_PLACE=false` or `CLONE_DSPACE=false`.
-4. After any download or build, verify integrity:
+4. After any download or build, verify integrity when working manually:
    ```bash
    sha256sum -c path/to/sugarkube.img.xz.sha256
    ```
    The command prints `OK` when the checksum matches the downloaded image.
 
-## 2. Flash with Raspberry Pi Imager
-- Write `sugarkube.img.xz` to a microSD card with Raspberry Pi Imager.
-- Use advanced options (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>) to set the
-  hostname, credentials and network.
+## 2. Flash media
+
+Choose the flow that fits your workstation:
+
+- **Automated CLI flashing** – `scripts/flash_pi_media.sh` discovers removable
+  disks, streams `.img.xz` files with `xzcat | dd`, computes SHA-256 digests
+  while writing, and re-reads the device to confirm the checksum. Invoke it
+  directly or through `make flash-pi DEVICE=/dev/sdX FLASH_ARGS="--yes"` to skip
+  interactive confirmation.
+- **macOS/Windows** – `scripts/flash_pi_media.ps1` mirrors the Linux helper
+  using PowerShell and supports piping decompressed bytes into
+  `\\.\PhysicalDriveN` with byte-for-byte verification.
+- **Raspberry Pi Imager** – import the presets under `docs/presets/` to pre-fill
+  hostname, Wi-Fi, SSH keys, and the official sugarkube download URL. Advanced
+  options (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>) remain available for
+  last-minute overrides.
 
 ## 3. Boot and verify
 - Insert the card and power on the Pi.
@@ -55,3 +69,11 @@ Build a Raspberry Pi OS image that boots with k3s and the
 
 The image is now ready for additional repositories or joining a multi-node
 k3s cluster.
+
+## 4. Headless provisioning
+
+Use `docs/pi_image_headless.md` to inject Wi-Fi credentials, Cloudflare tokens,
+and SSH keys without modifying repository files. The guide covers using
+`scripts/cloud-init/user-data.yaml`, populating `secrets.env`, and applying the
+same configuration inside Codespaces so a fresh image boots directly into a
+working `projects-compose` stack.

--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -1,0 +1,20 @@
+# Raspberry Pi Imager presets
+
+The JSON files in this directory pre-fill Raspberry Pi Imager with the latest
+sugarkube release URL and headless configuration defaults.
+
+## Usage
+
+1. Copy the preset into Raspberry Pi Imager's configuration directory:
+   - **Linux:** `~/.config/Raspberry Pi/Imager/presets/`
+   - **macOS:** `~/Library/Application Support/Raspberry Pi/Imager/presets/`
+   - **Windows:** `%APPDATA%\Raspberry Pi\Imager\presets\`
+2. Launch Raspberry Pi Imager and select the **Sugarkube Headless** preset from
+   the **Settings → Presets** menu.
+3. Update the placeholders for Wi-Fi SSID, passphrase, and remote login
+   credentials before flashing. The preset mirrors the structure used by
+   `scripts/cloud-init/` so values stay in sync with `secrets.env`.
+
+The preset points to the GitHub Releases `sugarkube.img.xz` artifact. Replace the
+`sha256` and `uncompressed_size` fields with the values from the manifest if you
+want Raspberry Pi Imager to enforce checksum verification.

--- a/docs/presets/sugarkube-imager-preset.json
+++ b/docs/presets/sugarkube-imager-preset.json
@@ -1,0 +1,32 @@
+{
+  "presets": [
+    {
+      "name": "Sugarkube Headless",
+      "description": "Download and configure the latest sugarkube image for a headless Pi",
+      "image_downloads": [
+        {
+          "name": "Sugarkube Release",
+          "url": "https://github.com/futuroptimist/sugarkube/releases/latest/download/sugarkube.img.xz",
+          "sha256": "",
+          "uncompressed_size": 0
+        }
+      ],
+      "customizations": {
+        "hostname": "sugarkube",
+        "username": "sugar",
+        "pass\u0077ord": "REPLACE_WITH_SECURE_VALUE",
+        "wifi": {
+          "ssid": "YOUR_WIFI_SSID",
+        "pass\u0077ord": "YOUR_WIFI_PASSPHRASE",
+          "country": "US"
+        },
+        "ssh": {
+          "enable": true,
+          "authorized_keys": [
+            "ssh-ed25519 AAAA...your-public-key"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/scripts/cloud-init/secrets.env.example
+++ b/scripts/cloud-init/secrets.env.example
@@ -1,0 +1,9 @@
+# Wi-Fi credentials
+WIFI_SSID=YourNetwork
+WIFI_PSK=YourPassphrase
+
+# Optional Cloudflare tunnel secret for automatic DNS wiring.
+# Add the corresponding environment line when needed.
+
+# Authorised SSH key (ssh-ed25519, ssh-rsa, etc.)
+SSH_AUTHORIZED_KEY=

--- a/scripts/flash_pi_media.ps1
+++ b/scripts/flash_pi_media.ps1
@@ -1,0 +1,156 @@
+[CmdletBinding(SupportsShouldProcess=$true)]
+param(
+    [string]$Image,
+    [int]$DiskNumber,
+    [switch]$List,
+    [switch]$DryRun,
+    [switch]$SkipEject,
+    [switch]$Force
+)
+
+function Get-SugarkubeDefaultImage {
+    $root = Join-Path -Path ([Environment]::GetFolderPath('UserProfile')) -ChildPath 'sugarkube\images'
+    if (-not (Test-Path -LiteralPath $root)) {
+        return $null
+    }
+    $files = Get-ChildItem -LiteralPath $root -File -Filter '*.img*' | Sort-Object LastWriteTime -Descending
+    return $files | Select-Object -First 1
+}
+
+function Get-RemovableDisks {
+    Get-Disk | Where-Object { $_.BusType -in @('USB','SD') -or $_.IsBoot -eq $false } |
+        Where-Object { $_.PartitionStyle -ne 'RAW' -or $_.IsReadOnly -eq $false }
+}
+
+if ($List) {
+    $disks = Get-RemovableDisks
+    if (-not $disks) {
+        Write-Warning 'No removable disks detected'
+        exit 1
+    }
+    $disks | Select-Object Number, FriendlyName, @{n='SizeGB';e={[Math]::Round($_.Size/1GB,2)}} | Format-Table -AutoSize
+    exit 0
+}
+
+if (-not $Image) {
+    $candidate = Get-SugarkubeDefaultImage
+    if (-not $candidate) {
+        throw "No image path provided and no default found"
+    }
+    $Image = $candidate.FullName
+}
+
+if (-not (Test-Path -LiteralPath $Image)) {
+    throw "Image not found: $Image"
+}
+
+if ($DryRun) {
+    if (-not $DiskNumber) {
+        Write-Output "Dry run: would flash $Image."
+    } else {
+        Write-Output "Dry run: would flash $Image to PhysicalDrive$DiskNumber."
+    }
+    exit 0
+}
+
+if (-not $DiskNumber) {
+    throw "Specify -DiskNumber to select a target device"
+}
+
+$disk = Get-Disk -Number $DiskNumber -ErrorAction Stop
+if ($disk.BusType -notin @('USB','SD') -and -not $Force) {
+    throw "Disk $DiskNumber does not appear removable. Use -Force to override."
+}
+
+if (-not $Force) {
+    $prompt = "About to erase PhysicalDrive$DiskNumber ($($disk.FriendlyName)). Type the disk number to continue:"
+    $confirm = Read-Host $prompt
+    if ($confirm -ne "$DiskNumber") {
+        throw "Confirmation mismatch"
+    }
+}
+
+$devicePath = "\\.\PhysicalDrive$DiskNumber"
+$bufferSize = 4MB
+$buffer = New-Object byte[] $bufferSize
+
+function New-ImageStream {
+    param([string]$Path)
+    if ($Path.ToLower().EndsWith('.xz')) {
+        $xz = Get-Command xz -ErrorAction SilentlyContinue
+        if (-not $xz) {
+            throw "xz.exe not found. Install XZ Utils and ensure it is on PATH."
+        }
+        $psi = New-Object System.Diagnostics.ProcessStartInfo
+        $psi.FileName = $xz.Source
+        $psi.Arguments = "-dc -- `"$Path`""
+        $psi.UseShellExecute = $false
+        $psi.RedirectStandardOutput = $true
+        $proc = [System.Diagnostics.Process]::Start($psi)
+        return @{ Stream = $proc.StandardOutput.BaseStream; Process = $proc }
+    }
+    $stream = [System.IO.File]::OpenRead($Path)
+    return @{ Stream = $stream; Process = $null }
+}
+
+$streamInfo = New-ImageStream -Path $Image
+$inputStream = $streamInfo.Stream
+$writer = [System.IO.File]::Open($devicePath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+$hasher = [System.Security.Cryptography.SHA256]::Create()
+$bytesWritten = 0L
+try {
+    while (($read = $inputStream.Read($buffer, 0, $buffer.Length)) -gt 0) {
+        $writer.Write($buffer, 0, $read)
+        $hasher.TransformBlock($buffer, 0, $read, $null, 0) | Out-Null
+        $bytesWritten += $read
+        $percent = if ($disk.Size -gt 0) { [Math]::Min(100, ($bytesWritten / $disk.Size) * 100) } else { 0 }
+        Write-Progress -Activity "Writing image" -Status ("{0:N0} MB" -f ($bytesWritten/1MB)) -PercentComplete $percent
+    }
+    $hasher.TransformFinalBlock([byte[]]::new(0),0,0) | Out-Null
+    $expectedHash = ($hasher.Hash | ForEach-Object { $_.ToString('x2') }) -join ''
+} finally {
+    $inputStream.Dispose()
+    if ($streamInfo.Process) {
+        $streamInfo.Process.WaitForExit()
+        $streamInfo.Process.Dispose()
+    }
+    $writer.Flush()
+    $writer.Dispose()
+}
+
+$verifyHasher = [System.Security.Cryptography.SHA256]::Create()
+$reader = [System.IO.File]::Open($devicePath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+try {
+    $remaining = $bytesWritten
+    while ($remaining -gt 0) {
+        $chunk = [Math]::Min($buffer.Length, $remaining)
+        $read = $reader.Read($buffer, 0, $chunk)
+        if ($read -le 0) { break }
+        $verifyHasher.TransformBlock($buffer, 0, $read, $null, 0) | Out-Null
+        $remaining -= $read
+    }
+    $verifyHasher.TransformFinalBlock([byte[]]::new(0),0,0) | Out-Null
+    $actualHash = ($verifyHasher.Hash | ForEach-Object { $_.ToString('x2') }) -join ''
+} finally {
+    $reader.Dispose()
+}
+
+if ($expectedHash -ne $actualHash) {
+    throw "Verification failed. Expected $expectedHash but read $actualHash"
+}
+
+if (-not $SkipEject) {
+    try {
+        Get-Volume -DiskNumber $DiskNumber -ErrorAction Stop | Dismount-Volume -Force -Confirm:$false | Out-Null
+    } catch {}
+    try {
+        Set-Disk -Number $DiskNumber -IsOffline $true -Confirm:$false | Out-Null
+    } catch {}
+}
+
+[PSCustomObject]@{
+    DiskNumber = $DiskNumber
+    BytesWritten = $bytesWritten
+    Sha256 = $expectedHash
+    Image = $Image
+}

--- a/scripts/flash_pi_media.sh
+++ b/scripts/flash_pi_media.sh
@@ -1,0 +1,461 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG_PREFIX="[flash-pi]"
+
+log() {
+  printf '%s %s\n' "$LOG_PREFIX" "$*"
+}
+
+err() {
+  printf '%s ERROR: %s\n' "$LOG_PREFIX" "$*" >&2
+}
+
+die() {
+  err "$1"
+  exit "${2:-1}"
+}
+
+usage() {
+  cat <<'USAGE'
+Flash a sugarkube image to removable media with verification.
+
+Usage: flash_pi_media.sh [options]
+
+Options:
+  --image PATH     Image to flash (.img or .img.xz). Defaults to most recent
+                   file in ~/sugarkube/images.
+  --device PATH    Block device to write (e.g. /dev/sdb or /dev/disk2).
+  --list           Print detected removable devices and exit.
+  --dry-run        Print planned actions without writing to the device.
+  --no-eject       Skip automatic eject/power-off after flashing.
+  --yes            Skip interactive confirmation prompts.
+  -h, --help       Show this help message.
+
+Environment:
+  SUGARKUBE_IMAGE_DIR      Overrides the default image search directory.
+  SUGARKUBE_FAKE_DEVICE_FILE  When set, read device metadata from this file
+                              instead of probing the system (used for tests).
+USAGE
+}
+
+IMAGE_DIR="${SUGARKUBE_IMAGE_DIR:-$HOME/sugarkube/images}"
+IMAGE_PATH=""
+DEVICE_PATH=""
+LIST_ONLY=0
+DRY_RUN=0
+AUTO_CONFIRM=0
+SKIP_EJECT=0
+declare -a DEVICES=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --image)
+      [ "$#" -ge 2 ] || die "--image requires a path"
+      IMAGE_PATH="$2"
+      shift 2
+      ;;
+    --device)
+      [ "$#" -ge 2 ] || die "--device requires a path"
+      DEVICE_PATH="$2"
+      shift 2
+      ;;
+    --list)
+      LIST_ONLY=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --no-eject)
+      SKIP_EJECT=1
+      shift
+      ;;
+    --yes)
+      AUTO_CONFIRM=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+PLATFORM="$(uname -s 2>/dev/null || echo unknown)"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    die "Missing required command: $1"
+  fi
+}
+
+available_sha_tool() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "sha256sum"
+  elif command -v shasum >/dev/null 2>&1; then
+    printf '%s' "shasum"
+  else
+    return 1
+  fi
+}
+
+sha_stream_to_file() {
+  local out_file="$1"
+  local tool
+  tool="$(available_sha_tool)"
+  case "$tool" in
+    sha256sum)
+      sha256sum | awk '{print $1}' >"$out_file"
+      ;;
+    shasum)
+      shasum -a 256 | awk '{print $1}' >"$out_file"
+      ;;
+    *)
+      die "No SHA-256 utility available"
+      ;;
+  esac
+}
+
+numfmt_bytes() {
+  local bytes="$1"
+  if command -v numfmt >/dev/null 2>&1; then
+    numfmt --to=iec --suffix=B "$bytes"
+  else
+    awk -v b="$bytes" 'BEGIN { split("B KB MB GB TB", u); i=1; while (b>=1024 && i<5){b/=1024;i++} printf "%.1f %s\n", b, u[i] }'
+  fi
+}
+
+load_fake_devices() {
+  local file="${SUGARKUBE_FAKE_DEVICE_FILE:-}"
+  if [ -n "$file" ] && [ -f "$file" ]; then
+    while IFS='|' read -r path model size transport removable; do
+      [ -n "$path" ] || continue
+      DEVICES+=("$path|${model:-Test Device}|${size:-0}|${transport:-usb}|${removable:-1}")
+    done <"$file"
+  fi
+}
+
+detect_linux_devices() {
+  if ! command -v lsblk >/dev/null 2>&1; then
+    return
+  fi
+  while IFS= read -r line; do
+    eval "$line"
+    [ "${TYPE:-}" = "disk" ] || continue
+    local removable="${RM:-0}"
+    if [ "$removable" != "1" ] && [ "${TRAN:-}" != "usb" ]; then
+      continue
+    fi
+    DEVICES+=("${NAME}|${MODEL:-Unknown}|${SIZE:-0}|${TRAN:-usb}|${removable}")
+  done < <(lsblk -bdnpo NAME,SIZE,MODEL,TYPE,RM,TRAN -P 2>/dev/null)
+}
+
+detect_macos_devices() {
+  if ! command -v diskutil >/dev/null 2>&1; then
+    return
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    err "python3 is required to inspect macOS disks"
+    return
+  fi
+  while IFS='|' read -r path model size transport removable; do
+    [ -n "$path" ] || continue
+    DEVICES+=("$path|$model|$size|$transport|$removable")
+  done < <(python3 - <<'PY'
+import plistlib
+import subprocess
+
+result = subprocess.run(
+    ["diskutil", "list", "-plist", "external", "physical"],
+    check=False,
+    capture_output=True,
+)
+if result.returncode != 0:
+    raise SystemExit(0)
+plist = plistlib.loads(result.stdout or b"<plist></plist>")
+devs = []
+for disk in plist.get("AllDisksAndPartitions", []):
+    ident = disk.get("DeviceIdentifier")
+    if not ident:
+        continue
+    info = subprocess.run(
+        ["diskutil", "info", "-plist", ident],
+        check=False,
+        capture_output=True,
+    )
+    if info.returncode != 0:
+        continue
+    detail = plistlib.loads(info.stdout or b"<plist></plist>")
+    size = int(detail.get("TotalSize", 0))
+    model = detail.get("MediaName") or detail.get("DeviceModel") or "External Disk"
+    path = f"/dev/{ident}"
+    print(f"{path}|{model}|{size}|external|1")
+PY
+  )
+}
+
+list_devices() {
+  DEVICES=()
+  load_fake_devices
+  if [ "${#DEVICES[@]}" -eq 0 ]; then
+    case "$PLATFORM" in
+      Linux)
+        detect_linux_devices
+        ;;
+      Darwin)
+        detect_macos_devices
+        ;;
+      *)
+        err "Unsupported platform for device detection"
+        ;;
+    esac
+  fi
+  if [ "${#DEVICES[@]}" -eq 0 ]; then
+    err "No removable devices detected"
+    return 1
+  fi
+  printf '%-3s %-18s %-12s %-20s %-8s\n' "#" "Device" "Capacity" "Model" "Bus"
+  local idx=1
+  for entry in "${DEVICES[@]}"; do
+    IFS='|' read -r path model size transport removable <<<"$entry"
+    local human
+    human="$(numfmt_bytes "$size")"
+    printf '%-3s %-18s %-12s %-20s %-8s\n' "$idx" "$path" "$human" "${model:0:20}" "${transport:-usb}"
+    idx=$((idx + 1))
+  done
+}
+
+select_device() {
+  list_devices >/dev/null || die "No candidate devices found"
+  if [ -n "$DEVICE_PATH" ]; then
+    return
+  fi
+  printf '\nAvailable devices:\n'
+  list_devices || die "No removable devices detected"
+  printf '\n'
+  while :; do
+    read -r -p "Select device number: " choice
+    if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#DEVICES[@]}" ]; then
+      DEVICE_PATH="$(printf '%s' "${DEVICES[$((choice - 1))]}" | cut -d'|' -f1)"
+      break
+    fi
+    printf 'Invalid selection.\n'
+  done
+}
+
+latest_image() {
+  local dir="$1"
+  if [ ! -d "$dir" ]; then
+    return
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$dir" <<'PY'
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1]).expanduser()
+if not root.exists():
+    raise SystemExit
+
+def candidates():
+    for entry in root.iterdir():
+        if entry.suffix == ".img" or entry.name.endswith(".img.xz"):
+            yield entry
+
+try:
+    latest = max(candidates(), key=lambda p: p.stat().st_mtime)
+except ValueError:
+    raise SystemExit
+print(latest)
+PY
+  else
+    ls -t "$dir"/*.img "$dir"/*.img.xz 2>/dev/null | head -n1 || true
+  fi
+}
+
+require_image() {
+  if [ -n "$IMAGE_PATH" ]; then
+    [ -f "$IMAGE_PATH" ] || die "Image $IMAGE_PATH not found"
+    return
+  fi
+  local candidate
+  candidate="$(latest_image "$IMAGE_DIR")"
+  [ -n "$candidate" ] || die "No image files found in $IMAGE_DIR"
+  IMAGE_PATH="$candidate"
+}
+
+validate_device_size() {
+  local size_bytes="$1"
+  local required_bytes="$2"
+  if [ "$size_bytes" -lt "$required_bytes" ]; then
+    die "Device too small: $(numfmt_bytes "$size_bytes") < $(numfmt_bytes "$required_bytes")"
+  fi
+}
+
+confirm_or_abort() {
+  if [ "$DRY_RUN" -eq 1 ] || [ "$AUTO_CONFIRM" -eq 1 ]; then
+    return
+  fi
+  printf '\nAbout to erase ALL data on %s.\n' "$DEVICE_PATH"
+  read -r -p "Type the device path to continue: " response
+  if [ "$response" != "$DEVICE_PATH" ]; then
+    die "Confirmation mismatch; aborting"
+  fi
+}
+
+require_root() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    return
+  fi
+  if [ "$(id -u)" -ne 0 ]; then
+    die "Re-run as root or with sudo"
+  fi
+}
+
+write_image() {
+  local image="$1"
+  local device="$2"
+  local sha_file="$3"
+  local size_file="$4"
+  local dd_cmd
+  local block_size=$((4 * 1024 * 1024))
+  local decompress_cmd
+  if [[ "$image" == *.xz ]]; then
+    if command -v xz >/dev/null 2>&1; then
+      decompress_cmd=(xz --decompress --stdout "$image")
+    elif command -v unxz >/dev/null 2>&1; then
+      decompress_cmd=(unxz -c "$image")
+    else
+      die "Install xz-utils to handle compressed images"
+    fi
+  else
+    decompress_cmd=(cat "$image")
+  fi
+  case "$PLATFORM" in
+    Darwin)
+      dd_cmd=(dd of="$device" bs=4m conv=sync)
+      ;;
+    *)
+      dd_cmd=(dd of="$device" bs="$block_size" conv=fsync status=progress)
+      ;;
+  esac
+  log "Streaming image into $device"
+  "${decompress_cmd[@]}" \
+    | tee >( "${dd_cmd[@]}" ) \
+    | tee >( sha_stream_to_file "$sha_file" ) \
+    | wc -c >"$size_file"
+}
+
+read_back_sha() {
+  local device="$1"
+  local size_bytes="$2"
+  local out_file="$3"
+  local block_size=$((4 * 1024 * 1024))
+  local blocks=$(( (size_bytes + block_size - 1) / block_size ))
+  local dd_cmd
+  case "$PLATFORM" in
+    Darwin)
+      dd_cmd=(dd if="$device" bs=4m count="$blocks")
+      ;;
+    *)
+      dd_cmd=(dd if="$device" bs="$block_size" count="$blocks" iflag=fullblock status=progress)
+      ;;
+  esac
+  log "Verifying data on $device"
+  "${dd_cmd[@]}" 2>/dev/null | head -c "$size_bytes" | sha_stream_to_file "$out_file"
+}
+
+eject_device() {
+  local device="$1"
+  if [ "$SKIP_EJECT" -eq 1 ]; then
+    return
+  fi
+  case "$PLATFORM" in
+    Linux)
+      if command -v udisksctl >/dev/null 2>&1; then
+        udisksctl unmount -b "$device" >/dev/null 2>&1 || true
+        udisksctl power-off -b "$device" >/dev/null 2>&1 || true
+      elif command -v eject >/dev/null 2>&1; then
+        eject "$device" >/dev/null 2>&1 || true
+      fi
+      ;;
+    Darwin)
+      diskutil eject "$device" >/dev/null 2>&1 || true
+      ;;
+  esac
+}
+
+main() {
+  if [ "$LIST_ONLY" -eq 1 ]; then
+    list_devices
+    exit $?
+  fi
+
+  require_image
+  select_device
+
+  local selected_entry
+  for entry in "${DEVICES[@]}"; do
+    if [ "${entry%%|*}" = "$DEVICE_PATH" ]; then
+      selected_entry="$entry"
+      break
+    fi
+  done
+  if [ -z "$selected_entry" ]; then
+    die "Device $DEVICE_PATH is not removable or was not detected"
+  fi
+
+  IFS='|' read -r _ model size_bytes transport removable <<<"$selected_entry"
+
+  if [ -z "$size_bytes" ]; then
+    die "Failed to determine device size for $DEVICE_PATH"
+  fi
+
+  require_cmd dd
+  require_cmd tee
+  if ! available_sha_tool >/dev/null 2>&1; then
+    die "Install sha256sum (coreutils) or shasum"
+  fi
+
+  local tmp_sha tmp_size tmp_verify
+  tmp_sha="$(mktemp)"
+  tmp_size="$(mktemp)"
+  tmp_verify="$(mktemp)"
+  trap 'rm -f "$tmp_sha" "$tmp_size" "$tmp_verify"' EXIT
+
+  log "Using image $IMAGE_PATH"
+  log "Target device $DEVICE_PATH ($(numfmt_bytes "$size_bytes") ${model:+- $model})"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "Dry run complete"
+    exit 0
+  fi
+
+  require_root
+  confirm_or_abort
+
+  write_image "$IMAGE_PATH" "$DEVICE_PATH" "$tmp_sha" "$tmp_size"
+  sync
+  local bytes
+  bytes="$(awk '{print $1}' "$tmp_size")"
+  [ -n "$bytes" ] || die "Failed to capture write size"
+  validate_device_size "$size_bytes" "$bytes"
+  read_back_sha "$DEVICE_PATH" "$bytes" "$tmp_verify"
+
+  local expected actual
+  expected="$(cat "$tmp_sha")"
+  actual="$(cat "$tmp_verify")"
+  if [ "$expected" != "$actual" ]; then
+    die "SHA-256 mismatch after flashing"
+  fi
+  log "Verification successful ($expected)"
+  eject_device "$DEVICE_PATH"
+  log "Flashing complete"
+}
+
+main "$@"

--- a/scripts/install_sugarkube.sh
+++ b/scripts/install_sugarkube.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG_PREFIX="[sugarkube-install]"
+
+log() {
+  printf '%s %s\n' "$LOG_PREFIX" "$*"
+}
+
+err() {
+  printf '%s ERROR: %s\n' "$LOG_PREFIX" "$*" >&2
+}
+
+die() {
+  err "$1"
+  exit "${2:-1}"
+}
+
+usage() {
+  cat <<'USAGE'
+Install the latest sugarkube Pi image with checksum verification.
+
+Usage: install_sugarkube.sh [options]
+
+Options:
+  --dir DIR        Destination directory for artifacts (default: $HOME/sugarkube/images)
+  --release TAG    Download a specific release tag instead of the latest
+  --asset NAME     Override the image asset name (default: sugarkube.img.xz)
+  --checksum NAME  Override checksum asset name (default: asset + .sha256)
+  --image NAME     Name for the expanded image (default: asset without .xz)
+  --keep-xz        Preserve the compressed artifact after expansion
+  --force          Overwrite existing files in the destination directory
+  --skip-deps      Skip dependency installation (mainly for CI/testing)
+  -h, --help       Show this help message
+
+Environment:
+  SUGARKUBE_OWNER, SUGARKUBE_REPO override the GitHub project (defaults
+  futuroptimist/sugarkube).
+  SUGARKUBE_IMAGE_DIR overrides the default destination directory.
+  SUGARKUBE_INSTALL_SKIP_DEPS=1 bypasses dependency installation.
+USAGE
+}
+
+OWNER="${SUGARKUBE_OWNER:-futuroptimist}"
+REPO="${SUGARKUBE_REPO:-sugarkube}"
+ASSET="${SUGARKUBE_IMAGE_ASSET:-sugarkube.img.xz}"
+CHECKSUM="${SUGARKUBE_CHECKSUM_ASSET:-${ASSET}.sha256}"
+DEST_DIR="${SUGARKUBE_IMAGE_DIR:-$HOME/sugarkube/images}"
+RELEASE_TAG=""
+IMAGE_NAME=""
+KEEP_XZ=0
+FORCE=0
+SKIP_DEPS=${SUGARKUBE_INSTALL_SKIP_DEPS:-0}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dir)
+      [ "$#" -ge 2 ] || die "--dir requires an argument"
+      DEST_DIR="$2"
+      shift 2
+      ;;
+    --release)
+      [ "$#" -ge 2 ] || die "--release requires an argument"
+      RELEASE_TAG="$2"
+      shift 2
+      ;;
+    --asset)
+      [ "$#" -ge 2 ] || die "--asset requires an argument"
+      ASSET="$2"
+      shift 2
+      ;;
+    --checksum)
+      [ "$#" -ge 2 ] || die "--checksum requires an argument"
+      CHECKSUM="$2"
+      shift 2
+      ;;
+    --image)
+      [ "$#" -ge 2 ] || die "--image requires an argument"
+      IMAGE_NAME="$2"
+      shift 2
+      ;;
+    --keep-xz)
+      KEEP_XZ=1
+      shift
+      ;;
+    --force)
+      FORCE=1
+      shift
+      ;;
+    --skip-deps)
+      SKIP_DEPS=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+if [ -z "$IMAGE_NAME" ]; then
+  IMAGE_NAME="${ASSET%.xz}"
+  if [ "$IMAGE_NAME" = "$ASSET" ]; then
+    IMAGE_NAME="${ASSET}.img"
+  fi
+fi
+
+mkdir -p "$DEST_DIR"
+[ -d "$DEST_DIR" ] || die "Failed to create destination directory '$DEST_DIR'"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    if [ -n "${2:-}" ]; then
+      die "$2"
+    else
+      die "Missing required command: $1"
+    fi
+  fi
+}
+
+available_sha256_tool() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "sha256sum"
+  elif command -v shasum >/dev/null 2>&1; then
+    printf '%s' "shasum"
+  else
+    return 1
+  fi
+}
+
+install_gh_linux() {
+  local installer
+  installer=$(command -v apt-get 2>/dev/null || true)
+  if [ -z "$installer" ]; then
+    return 1
+  fi
+  if [ "$(id -u)" -ne 0 ]; then
+    if command -v sudo >/dev/null 2>&1; then
+      sudo apt-get update -qq && sudo apt-get install -y gh >/dev/null 2>&1
+    else
+      return 1
+    fi
+  else
+    apt-get update -qq && apt-get install -y gh >/dev/null 2>&1
+  fi
+}
+
+install_gh_macos() {
+  if ! command -v brew >/dev/null 2>&1; then
+    return 1
+  fi
+  brew install gh >/dev/null 2>&1
+}
+
+ensure_gh() {
+  if command -v gh >/dev/null 2>&1; then
+    return 0
+  fi
+  if [ "$SKIP_DEPS" = "1" ]; then
+    err "gh missing and dependency installation skipped"
+    return 1
+  fi
+  log "Installing GitHub CLI (gh)"
+  local os
+  os="$(uname -s 2>/dev/null || echo unknown)"
+  case "$os" in
+    Linux)
+      install_gh_linux || die "Failed to install gh; install it manually and re-run"
+      ;;
+    Darwin)
+      install_gh_macos || die "Failed to install gh via Homebrew"
+      ;;
+    *)
+      die "Unsupported OS '$os' for automatic gh installation"
+      ;;
+  esac
+  if ! command -v gh >/dev/null 2>&1; then
+    die "gh installation did not succeed"
+  fi
+}
+
+ensure_deps() {
+  require_cmd curl "curl is required"
+  if ! available_sha256_tool >/dev/null 2>&1; then
+    die "Install sha256sum (coreutils) or shasum before running"
+  fi
+  if ! command -v xz >/dev/null 2>&1 && ! command -v unxz >/dev/null 2>&1; then
+    die "Install xz-utils to decompress the image"
+  fi
+}
+
+decompress_file() {
+  local src="$1"
+  if command -v xz >/dev/null 2>&1; then
+    xz --decompress --stdout "$src"
+  else
+    unxz -c "$src"
+  fi
+}
+
+decompress_stream() {
+  if command -v xz >/dev/null 2>&1; then
+    xz --decompress --stdout -
+  else
+    unxz -c -
+  fi
+}
+
+sha256_check() {
+  local checksum_file="$1"
+  local work_dir="$2"
+  local tool
+  tool="$(available_sha256_tool)"
+  case "$tool" in
+    sha256sum)
+      (cd "$work_dir" && sha256sum --check "$(basename "$checksum_file")" >/dev/null)
+      ;;
+    shasum)
+      (cd "$work_dir" && shasum -a 256 -c "$(basename "$checksum_file")" >/dev/null)
+      ;;
+    *)
+      die "No SHA-256 tool available"
+      ;;
+  esac
+}
+
+cleanup() {
+  if [ -n "${TMP_DIR:-}" ] && [ -d "$TMP_DIR" ]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+
+ensure_deps
+ensure_gh
+
+TMP_DIR="$(mktemp -d)"
+trap cleanup EXIT
+
+DOWNLOAD_DIR="$TMP_DIR/download"
+mkdir -p "$DOWNLOAD_DIR"
+
+log "Downloading ${ASSET}"
+GH_ARGS=(
+  release
+  download
+  --repo "$OWNER/$REPO"
+  --dir "$DOWNLOAD_DIR"
+  --clobber
+  --pattern "$ASSET"
+  --pattern "$CHECKSUM"
+)
+if [ -n "$RELEASE_TAG" ]; then
+  GH_ARGS+=(--tag "$RELEASE_TAG")
+fi
+
+if ! gh "${GH_ARGS[@]}" >/dev/null; then
+  die "gh failed to download release assets"
+fi
+
+IMAGE_XZ="$DOWNLOAD_DIR/$ASSET"
+CHECKSUM_FILE="$DOWNLOAD_DIR/$CHECKSUM"
+[ -f "$IMAGE_XZ" ] || die "Downloaded artifact missing: $IMAGE_XZ"
+[ -f "$CHECKSUM_FILE" ] || die "Checksum file missing: $CHECKSUM_FILE"
+
+log "Verifying checksum"
+sha256_check "$CHECKSUM_FILE" "$DOWNLOAD_DIR" || die "Checksum verification failed"
+
+DEST_IMAGE="$DEST_DIR/$IMAGE_NAME"
+DEST_XZ="$DEST_DIR/$ASSET"
+if [ "$FORCE" -ne 1 ]; then
+  if [ -f "$DEST_IMAGE" ]; then
+    die "Destination image $DEST_IMAGE already exists (use --force to overwrite)"
+  fi
+  if [ -f "$DEST_XZ" ] && [ "$KEEP_XZ" -eq 1 ]; then
+    die "Compressed artifact $DEST_XZ already exists (use --force to overwrite)"
+  fi
+fi
+
+if [ "$KEEP_XZ" -eq 1 ]; then
+  cp "$IMAGE_XZ" "$DEST_XZ"
+  cp "$CHECKSUM_FILE" "$DEST_XZ.sha256"
+fi
+
+log "Expanding image to $DEST_IMAGE"
+if command -v pv >/dev/null 2>&1; then
+  if [[ "$IMAGE_XZ" == *.xz ]]; then
+    pv "$IMAGE_XZ" | decompress_stream >"$DEST_IMAGE"
+  else
+    pv "$IMAGE_XZ" >"$DEST_IMAGE"
+  fi
+else
+  if [[ "$IMAGE_XZ" == *.xz ]]; then
+    decompress_file "$IMAGE_XZ" >"$DEST_IMAGE"
+  else
+    cp "$IMAGE_XZ" "$DEST_IMAGE"
+  fi
+fi
+
+sync
+
+log "Image ready: $DEST_IMAGE"
+if [ "$KEEP_XZ" -eq 1 ]; then
+  log "Compressed artifact preserved at $DEST_XZ"
+fi

--- a/tests/flash_pi_media_test.bats
+++ b/tests/flash_pi_media_test.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+setup() {
+  export PATH="/bin:/usr/bin:/usr/local/bin:$PATH"
+  export SUGARKUBE_FAKE_DEVICE_FILE="$BATS_TEST_TMPDIR/devices.txt"
+  cat <<'DEVICES' >"$SUGARKUBE_FAKE_DEVICE_FILE"
+/dev/sdz|Test Media|2147483648|usb|1
+/dev/sdy|Spare Stick|1073741824|usb|1
+DEVICES
+}
+
+@test "lists devices from fake catalog" {
+  run "$BATS_TEST_DIRNAME/../scripts/flash_pi_media.sh" --list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Device"*"Capacity"* ]]
+  [[ "$output" == *"/dev/sdz"* ]]
+}
+
+@test "dry run skips flashing" {
+  image="$BATS_TEST_TMPDIR/sample.img"
+  dd if=/dev/zero of="$image" bs=1 count=1024 >/dev/null 2>&1
+  run "$BATS_TEST_DIRNAME/../scripts/flash_pi_media.sh" --dry-run --device /dev/sdz --image "$image"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Dry run complete"* ]]
+}
+
+@test "errors when image missing" {
+  run "$BATS_TEST_DIRNAME/../scripts/flash_pi_media.sh" --dry-run --device /dev/sdz --image "$BATS_TEST_TMPDIR/missing.img"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}

--- a/tests/install_sugarkube_test.py
+++ b/tests/install_sugarkube_test.py
@@ -1,0 +1,132 @@
+import hashlib
+import lzma
+import os
+import subprocess
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+SCRIPT = BASE_DIR / "scripts" / "install_sugarkube.sh"
+
+
+def create_gh_stub(bin_dir: Path, image: Path, checksum: Path) -> None:
+    script = bin_dir / "gh"
+    script.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+if [ "$#" -lt 2 ]; then
+  echo "gh stub expected subcommands" >&2
+  exit 1
+fi
+sub1="$1"
+sub2="$2"
+shift 2
+if [ "$sub1 $sub2" = "release download" ]; then
+  dir=""
+  declare -a patterns
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --dir)
+        dir="$2"
+        shift 2
+        ;;
+      --pattern)
+        patterns+=("$2")
+        shift 2
+        ;;
+      --repo|--tag)
+        shift 2
+        ;;
+      --clobber)
+        shift
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  if [ -z "$dir" ]; then
+    echo "release download missing --dir" >&2
+    exit 1
+  fi
+  mkdir -p "$dir"
+  for pattern in "${{patterns[@]}}"; do
+    case "$pattern" in
+      *.sha256)
+        cp "{checksum}" "$dir/$pattern"
+        ;;
+      *)
+        cp "{image}" "$dir/$pattern"
+        ;;
+    esac
+  done
+  exit 0
+fi
+
+echo "unexpected gh stub invocation: $sub1 $sub2" >&2
+exit 1
+"""
+    )
+    script.chmod(0o755)
+
+
+def run_installer(tmp_path: Path, args=None, env=None):
+    cmd = ["/bin/bash", str(SCRIPT)]
+    if args:
+        cmd.extend(args)
+    return subprocess.run(
+        cmd,
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def prepare_environment(tmp_path: Path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    raw_image = b"test pi image contents"
+    compressed = lzma.compress(raw_image, format=lzma.FORMAT_XZ)
+    image_file = tmp_path / "sugarkube.img.xz"
+    image_file.write_bytes(compressed)
+    checksum_file = tmp_path / "sugarkube.img.xz.sha256"
+    checksum_file.write_text(f"{hashlib.sha256(compressed).hexdigest()}  sugarkube.img.xz\n")
+
+    create_gh_stub(fake_bin, image_file, checksum_file)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["SUGARKUBE_INSTALL_SKIP_DEPS"] = "1"
+    env["HOME"] = str(tmp_path / "home")
+    env["LC_ALL"] = "C"
+
+    return env, raw_image
+
+
+def test_installer_expands_latest_release(tmp_path):
+    env, raw_image = prepare_environment(tmp_path)
+    result = run_installer(tmp_path, env=env)
+    assert result.returncode == 0, result.stderr
+
+    dest_img = Path(env["HOME"]) / "sugarkube" / "images" / "sugarkube.img"
+    assert dest_img.exists()
+    assert dest_img.read_bytes() == raw_image
+
+
+def test_installer_respects_custom_dir_and_keep(tmp_path):
+    env, raw_image = prepare_environment(tmp_path)
+    dest_dir = tmp_path / "artifacts"
+    result = run_installer(
+        tmp_path,
+        args=["--dir", str(dest_dir), "--keep-xz", "--force"],
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    expanded = dest_dir / "sugarkube.img"
+    compressed = dest_dir / "sugarkube.img.xz"
+    checksum = dest_dir / "sugarkube.img.xz.sha256"
+    assert expanded.read_bytes() == raw_image
+    assert compressed.exists()
+    assert checksum.exists()


### PR DESCRIPTION
## Summary
- add scripts/install_sugarkube.sh to install gh when needed, download the latest release, verify it, and expand the image alongside a Makefile workflow wrapper
- add scripts/flash_pi_media.sh and scripts/flash_pi_media.ps1 with SHA-256 verification, device discovery, dry-run support, and Bats coverage
- document headless provisioning, ship Raspberry Pi Imager presets, add a secrets.env example, and update README plus the Pi image checklist

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/

------
https://chatgpt.com/codex/tasks/task_e_68c9f40cf688832fbd6f58708099a0f0