### PR TITLE
fix: pin gh bootstrap download and scope workflow fallback

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -219,3 +219,4 @@ wslconfig
 yaml
 yml
 yourorg
+checksums

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+SHELL := /bin/bash
+
+IMAGE_DIR ?= $(HOME)/sugarkube/images
+IMAGE_NAME ?= sugarkube.img
+IMAGE_PATH := $(IMAGE_DIR)/$(IMAGE_NAME)
+INSTALL_CMD ?= $(CURDIR)/scripts/install_sugarkube_image.sh
+FLASH_CMD ?= $(CURDIR)/scripts/flash_pi_media.sh
+DOWNLOAD_CMD ?= $(CURDIR)/scripts/download_pi_image.sh
+DOWNLOAD_ARGS ?=
+FLASH_ARGS ?= --assume-yes
+
+.PHONY: install-pi-image download-pi-image flash-pi
+
+install-pi-image:
+	$(INSTALL_CMD) --dir '$(IMAGE_DIR)' --image '$(IMAGE_PATH)' $(DOWNLOAD_ARGS)
+
+download-pi-image:
+	$(DOWNLOAD_CMD) --dir '$(IMAGE_DIR)' $(DOWNLOAD_ARGS)
+
+flash-pi: install-pi-image
+	@if [ -z "$(FLASH_DEVICE)" ]; then \
+		echo "Set FLASH_DEVICE to the target device (e.g. /dev/sdX)." >&2; \
+		exit 1; \
+	fi
+	$(FLASH_CMD) --image '$(IMAGE_PATH)' --device "$(FLASH_DEVICE)" $(FLASH_ARGS)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ the docs you will see the term used in both contexts.
   - `download_pi_image.sh` — fetch the latest Pi image via the GitHub CLI; requires `gh`
     to be installed and authenticated. Uses POSIX `test -ef` instead of `realpath` for better
     macOS compatibility
+  - `install_sugarkube_image.sh` — install the GitHub CLI when missing, download the
+    latest release, verify checksums, expand the `.img.xz`, and emit a new
+    `.img.sha256`; safe to run via `curl | bash`
   - `collect_pi_image.sh` — normalize pi-gen output into a single `.img.xz`,
     clean up temporary work directories, use POSIX `test -ef` to compare paths
     without `realpath`, and fall back to `unzip` when `bsdtar` is unavailable
@@ -56,6 +59,9 @@ the docs you will see the term used in both contexts.
     `CLONE_SUGARKUBE=true` to include this repo and pass space-separated Git URLs
     via `EXTRA_REPOS` to clone additional projects; needs a valid `user-data.yaml`
     and ~10 GB free disk space. Set `DEBUG=1` to trace script execution.
+  - `flash_pi_media.sh` — stream `.img` or `.img.xz` directly to removable
+    media with SHA-256 verification and automatic eject. A PowerShell wrapper
+    (`flash_pi_media.ps1`) shells out to the same Python core on Windows.
   - `pi_node_verifier.sh` — check k3s prerequisites; use `--json` for machine output or
     `--help` for usage
   - `scan-secrets.py` — scan diffs for high-risk patterns using `ripsecrets` when
@@ -71,8 +77,12 @@ push to `main` and once per day. Each run publishes a signed
 `sugarkube.img.xz`, its checksum, a provenance manifest, and the full
 `pi-gen` build log. Release notes summarize stage timings and link directly to
 the manifest so you can verify the build inputs and commit hashes before
-flashing. Use `./scripts/sugarkube-latest` to download the newest release with
-automatic checksum verification.
+flashing. Run `./scripts/install_sugarkube_image.sh` (or fetch the same helper
+via `curl -fsSL https://raw.githubusercontent.com/futuroptimist/sugarkube/main/scripts/install_sugarkube_image.sh | bash`) to
+download, verify, and expand the latest release, or run `make flash-pi
+FLASH_DEVICE=/dev/sdX` to chain download → verification → flashing with the new
+streaming helper. `./scripts/sugarkube-latest` remains available when you only
+need the `.img.xz` artifact with checksum verification.
 
 Run `pre-commit run --all-files` before committing.
 This triggers `scripts/checks.sh`, which installs required tooling and runs

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -22,18 +22,21 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
 - [x] Provide a `sugarkube-latest` convenience wrapper for downloading + verifying in one step.
   - Added `scripts/sugarkube-latest`, which defaults to release downloads while
     still accepting all downloader flags.
-- [ ] Package a one-liner installer (`curl | bash`) that installs `gh` when missing, pulls the latest release, verifies checksums, and expands the image.
+- [x] Package a one-liner installer (`curl | bash`) that installs `gh` when missing, pulls the latest release, verifies checksums, and expands the image.
+  - `scripts/install_sugarkube_image.sh` is safe to run via `curl | bash`; it bootstraps `gh`, downloads the release, verifies checksums, expands to `.img`, and writes a new `.img.sha256`.
 
 ---
 
 ## Flashing & Provisioning Automation
-- [ ] Ship cross-platform flashing helpers (`flash_pi_media.sh`, PowerShell twin, or CLI in Go/Rust/Node) that:
+- [x] Ship cross-platform flashing helpers (`flash_pi_media.sh`, PowerShell twin, or CLI in Go/Rust/Node) that:
   - Discover SD/USB devices.
   - Stream `.img.xz` directly with progress (`xzcat | dd`).
   - Verify written bytes with SHA-256.
   - Auto-eject media.
+  - Implemented via `scripts/flash_pi_media.py` with bash and PowerShell wrappers.
 - [ ] Ship Raspberry Pi Imager preset JSONs pre-filled with hostname, user, Wi-Fi, and SSH keys for load-and-go flashing.
-- [ ] Provide `just`/`make` targets (e.g., `make flash-pi`) chaining download → verify → flash.
+- [x] Provide `just`/`make` targets (e.g., `make flash-pi`) chaining download → verify → flash.
+  - Added a root `Makefile` with `flash-pi`, `install-pi-image`, and `download-pi-image` targets that wrap the new installer and flashing helpers.
 - [ ] Bundle a wrapper script that auto-decompresses, flashes, verifies, and reports results in HTML/Markdown (hardware IDs, checksum results, cloud-init diff).
 - [ ] Document a headless provisioning path using `user-data` or `secrets.env` for injecting Wi-Fi/Cloudflare tokens without editing repo files.
 - [ ] Support Codespaces or `just` recipes to build and flash media with minimal local tooling.

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -6,37 +6,58 @@ Build a Raspberry Pi OS image that boots with k3s and the
 
 ## 1. Build or download the image
 
-1. Fetch the latest release with checksum verification:
+1. Use the one-line installer to bootstrap everything in one step:
    ```bash
-   ./scripts/sugarkube-latest
+   curl -fsSL https://raw.githubusercontent.com/futuroptimist/sugarkube/main/scripts/install_sugarkube_image.sh | bash
    ```
-   The script resolves the newest GitHub release, resumes partially-downloaded
-   artifacts, verifies the SHA-256 checksum, and stores the image at
-   `~/sugarkube/images/sugarkube.img.xz`. Override the destination with
-   `--output /path/to/custom.img.xz` when needed.
-   Release notes link to `sugarkube.img.xz.manifest.json`, which records the
-   pi-gen commit, stage timings, and cosign signatures for every artifact.
-2. In GitHub, open **Actions → pi-image → Run workflow** for a fresh build.
+   The script installs the GitHub CLI when missing, downloads the latest
+   release, verifies the `.img.xz` checksum, expands it to
+   `~/sugarkube/images/sugarkube.img`, and records a fresh `.img.sha256` hash.
+   Pass `--download-only` to keep just the compressed archive or `--dir` to
+   change the destination.
+2. When working from a cloned repository, run the same helper locally:
+   ```bash
+   ./scripts/install_sugarkube_image.sh --dir ~/sugarkube/images --image ~/sugarkube/images/sugarkube.img
+   ```
+   All flags supported by `download_pi_image.sh` are forwarded, so `--release`
+   and `--asset` continue to work. `./scripts/sugarkube-latest` remains
+   available if you only need the compressed artifact.
+3. In GitHub, open **Actions → pi-image → Run workflow** for a fresh build.
    - Tick **token.place** and **dspace** to bake those repos into `/opt/projects`.
    - Wait for the run to finish; it uploads `sugarkube.img.xz` as an artifact.
-   - If you prefer to download artifacts manually, use
-     `./scripts/download_pi_image.sh --output /your/path.img.xz` to verify and
-     resume downloads automatically.
-3. Alternatively, build on your machine:
+   - `./scripts/download_pi_image.sh --output /your/path.img.xz` still resumes
+     partial downloads and verifies checksums automatically.
+4. Alternatively, build on your machine:
    ```bash
    ./scripts/build_pi_image.sh
    ```
    Skip either project with `CLONE_TOKEN_PLACE=false` or `CLONE_DSPACE=false`.
-4. After any download or build, verify integrity:
+5. After any download or build, verify integrity:
    ```bash
    sha256sum -c path/to/sugarkube.img.xz.sha256
    ```
    The command prints `OK` when the checksum matches the downloaded image.
 
-## 2. Flash with Raspberry Pi Imager
-- Write `sugarkube.img.xz` to a microSD card with Raspberry Pi Imager.
-- Use advanced options (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>) to set the
-  hostname, credentials and network.
+## 2. Flash the image
+- Stream the expanded image (or the `.img.xz`) directly to removable media:
+  ```bash
+  sudo ./scripts/flash_pi_media.sh --image ~/sugarkube/images/sugarkube.img --device /dev/sdX --assume-yes
+  ```
+  The helper auto-detects removable drives, streams `.img` or `.img.xz`
+  without temporary files, verifies the written bytes with SHA-256, and
+  powers the media off when complete. On Windows, run the PowerShell wrapper:
+  ```powershell
+  pwsh -File scripts/flash_pi_media.ps1 --image $env:USERPROFILE\sugarkube\images\sugarkube.img --device \\.\PhysicalDrive1
+  ```
+- To combine download + verify + flash in one command, run from the repo root:
+  ```bash
+  sudo make flash-pi FLASH_DEVICE=/dev/sdX
+  ```
+  `flash-pi` calls `install_sugarkube_image.sh` to keep the local cache fresh
+  before writing the media with `flash_pi_media.sh`.
+- Raspberry Pi Imager remains a friendly alternative.
+  Use advanced options (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>) to set the
+  hostname, credentials and network when flashing `sugarkube.img.xz` manually.
 
 ## 3. Boot and verify
 - Insert the card and power on the Pi.

--- a/scripts/download_pi_image.sh
+++ b/scripts/download_pi_image.sh
@@ -285,14 +285,14 @@ download_from_release() {
 download_from_workflow() {
   log "Falling back to latest successful pi-image workflow artifact"
   local run_id
-  run_id=$(gh run list --workflow pi-image.yml --branch main --json databaseId -q '.[0].databaseId') || run_id=""
+  run_id=$(gh run list --repo "${OWNER}/${REPO}" --workflow pi-image.yml --branch main --json databaseId -q '.[0].databaseId') || run_id=""
   if [ -z "$run_id" ]; then
     die "no pi-image workflow runs found"
   fi
   local tmp_dir
   tmp_dir="$(mktemp -d)"
   trap 'rm -rf "${tmp_dir}"' RETURN
-  if ! gh run download "$run_id" --name sugarkube-img --dir "$tmp_dir"; then
+  if ! gh run download --repo "${OWNER}/${REPO}" "$run_id" --name sugarkube-img --dir "$tmp_dir"; then
     die "Failed to download workflow artifact"
   fi
   local artifact_img="$tmp_dir/sugarkube.img.xz"

--- a/scripts/flash_pi_media.ps1
+++ b/scripts/flash_pi_media.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $Args
+)
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$python = Get-Command python3 -ErrorAction SilentlyContinue
+if (-not $python) {
+    $python = Get-Command python -ErrorAction SilentlyContinue
+}
+if (-not $python) {
+    Write-Error "python3 is required to run flash_pi_media"
+    exit 1
+}
+
+& $python.Path (Join-Path $scriptDir 'flash_pi_media.py') @Args
+exit $LASTEXITCODE

--- a/scripts/flash_pi_media.py
+++ b/scripts/flash_pi_media.py
@@ -1,0 +1,609 @@
+#!/usr/bin/env python3
+"""Stream Raspberry Pi images directly to removable media with verification.
+
+The helper intentionally avoids shell pipelines so it works on Linux, macOS,
+and Windows without additional tooling.  It discovers removable drives,
+prompts for confirmation, streams `.img` or `.img.xz` images to the selected
+device, verifies the written bytes with SHA-256, and finally ejects/offlines
+the media.
+
+Examples
+--------
+
+List candidate devices only::
+
+    python scripts/flash_pi_media.py --list
+
+Flash to an explicit device (non-interactive)::
+
+    sudo python scripts/flash_pi_media.py --image ~/sugarkube/images/sugarkube.img.xz \
+        --device /dev/sdX --assume-yes
+
+Regular files are accepted as ``--device`` targets which makes automated
+testing and dry-runs possible without touching real hardware.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import platform
+import shutil
+import stat
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence
+
+CHUNK_SIZE = 4 * 1024 * 1024  # 4 MiB to balance throughput and memory usage.
+PROGRESS_INTERVAL = 1.0  # seconds
+
+
+def _supports_color(stream: io.TextIOBase) -> bool:
+    return bool(stream.isatty()) and platform.system() != "Windows"
+
+
+def _color(text: str, color_code: str) -> str:
+    if not _supports_color(sys.stdout):
+        return text
+    return f"\033[{color_code}m{text}\033[0m"
+
+
+def info(message: str) -> None:
+    sys.stdout.write(f"==> {message}\n")
+
+
+def warn(message: str) -> None:
+    sys.stderr.write(_color(f"warning: {message}\n", "33"))
+
+
+def err(message: str) -> None:
+    sys.stderr.write(_color(f"error: {message}\n", "31"))
+
+
+def die(message: str, code: int = 1) -> None:
+    err(message)
+    raise SystemExit(code)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        die(message)
+
+
+def _bytes_to_gib(size: int) -> float:
+    return size / (1024**3)
+
+
+def _format_size(size: int) -> str:
+    if size < 1024:
+        return f"{size} B"
+    for unit in ["KiB", "MiB", "GiB", "TiB"]:
+        size /= 1024.0
+        if size < 1024:
+            return f"{size:.2f} {unit}"
+    return f"{size:.2f} PiB"
+
+
+@dataclass
+class Device:
+    """A removable storage device candidate."""
+
+    path: str
+    description: str
+    size: int
+    is_removable: bool
+    bus: Optional[str] = None
+    system_id: Optional[str] = None  # disk number on Windows, identifier on macOS
+    mountpoints: Sequence[str] | None = None
+
+    @property
+    def human_size(self) -> str:
+        return _format_size(self.size)
+
+
+def _run(cmd: Sequence[str], **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, check=False, capture_output=True, text=True, **kwargs)
+
+
+def _list_linux_devices() -> List[Device]:
+    lsblk = shutil.which("lsblk")
+    devices: List[Device] = []
+    if lsblk:
+        proc = _run(
+            [
+                lsblk,
+                "-b",
+                "-J",
+                "-O",
+                "-o",
+                "NAME,KNAME,PATH,SIZE,MODEL,TYPE,TRAN,RM,MOUNTPOINT",
+            ]
+        )
+        if proc.returncode == 0 and proc.stdout:
+            try:
+                payload = json.loads(proc.stdout)
+                for entry in payload.get("blockdevices", []):
+                    if entry.get("type") != "disk":
+                        continue
+                    path = entry.get("path") or f"/dev/{entry.get('name')}"
+                    size = int(entry.get("size") or 0)
+                    desc = entry.get("model") or entry.get("name") or "disk"
+                    rm = bool(entry.get("rm"))
+                    tran = entry.get("tran")
+                    mounts: List[str] = []
+                    if "children" in entry:
+                        for child in entry["children"]:
+                            mp = child.get("mountpoint")
+                            if mp:
+                                mounts.append(str(mp))
+                    devices.append(
+                        Device(
+                            path=path,
+                            description=str(desc).strip(),
+                            size=size,
+                            is_removable=rm or (tran in {"usb", "mmc"}),
+                            bus=tran,
+                            mountpoints=tuple(mounts),
+                        )
+                    )
+                return devices
+            except json.JSONDecodeError:
+                warn("lsblk returned non-JSON output; falling back to /sys probing")
+
+    sys_block = Path("/sys/block")
+    if not sys_block.exists():
+        return devices
+    for device in sys_block.iterdir():
+        if not (sys_block / device.name / "device").exists():
+            continue
+        path = f"/dev/{device.name}"
+        size_path = sys_block / device.name / "size"
+        size = int(size_path.read_text().strip()) * 512 if size_path.exists() else 0
+        model_path = sys_block / device.name / "device/model"
+        model = model_path.read_text().strip() if model_path.exists() else device.name
+        removable_path = sys_block / device.name / "removable"
+        removable = removable_path.read_text().strip() == "1" if removable_path.exists() else False
+        devices.append(
+            Device(
+                path=path,
+                description=model,
+                size=size,
+                is_removable=removable,
+            )
+        )
+    return devices
+
+
+def _list_macos_devices() -> List[Device]:
+    proc = _run(["/usr/sbin/diskutil", "list", "-plist"])
+    if proc.returncode != 0 or not proc.stdout:
+        return []
+    try:
+        import plistlib
+
+        data = plistlib.loads(proc.stdout.encode("utf-8"))
+    except Exception as exc:  # pragma: no cover - defensive logging
+        warn(f"Failed to parse diskutil output: {exc}")
+        return []
+
+    result: List[Device] = []
+    for disk in data.get("AllDisksAndPartitions", []):
+        identifier = disk.get("DeviceIdentifier")
+        if not identifier:
+            continue
+        path = f"/dev/{identifier}"
+        size = int(disk.get("Size", 0))
+        desc = disk.get("VolumeName") or disk.get("MediaName") or identifier
+        removable = bool(disk.get("RemovableMedia"))
+        bus = disk.get("BusProtocol")
+        mountpoints: List[str] = []
+        for partition in disk.get("Partitions", []):
+            mp = partition.get("MountPoint")
+            if mp:
+                mountpoints.append(str(mp))
+        result.append(
+            Device(
+                path=path,
+                description=str(desc).strip(),
+                size=size,
+                is_removable=removable or (bus and "USB" in bus.upper()),
+                bus=bus,
+                system_id=identifier,
+                mountpoints=tuple(mountpoints),
+            )
+        )
+    return result
+
+
+def _powershell_json(command: str) -> Optional[object]:
+    proc = _run(["powershell", "-NoProfile", "-Command", command])
+    if proc.returncode != 0 or not proc.stdout:
+        return None
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        warn(f"PowerShell JSON parse failure: {exc}")
+        return None
+
+
+def _list_windows_devices() -> List[Device]:
+    command = (
+        "Get-CimInstance -Namespace root/Microsoft/Windows/Storage -ClassName MSFT_Disk "
+        "| Select-Object Number,FriendlyName,Size,BusType,IsBoot,IsSystem,"
+        "IsVirtual,IsOffline,IsRemovable "
+        "| ConvertTo-Json -Depth 3 -Compress"
+    )
+    payload = _powershell_json(command)
+    if payload is None:
+        return []
+    items: Iterable[dict]
+    if isinstance(payload, list):
+        items = payload
+    else:
+        items = [payload]
+
+    result: List[Device] = []
+    for item in items:
+        try:
+            number = int(item.get("Number"))
+        except (TypeError, ValueError):
+            continue
+        path = f"\\\\.\\PhysicalDrive{number}"
+        name = item.get("FriendlyName") or f"PhysicalDrive{number}"
+        size = int(item.get("Size") or 0)
+        bus = item.get("BusType")
+        removable = bool(item.get("IsRemovable")) or (bus and bus.upper() == "USB")
+        # Virtual disks or system disks should be excluded by default.
+        is_system = bool(item.get("IsSystem")) or bool(item.get("IsBoot"))
+        is_virtual = bool(item.get("IsVirtual"))
+        result.append(
+            Device(
+                path=path,
+                description=str(name).strip(),
+                size=size,
+                is_removable=removable and not is_system and not is_virtual,
+                bus=bus,
+                system_id=str(number),
+            )
+        )
+    return result
+
+
+def discover_devices() -> List[Device]:
+    system = platform.system()
+    if system == "Linux":
+        return _list_linux_devices()
+    if system == "Darwin":
+        return _list_macos_devices()
+    if system == "Windows":
+        return _list_windows_devices()
+    return []
+
+
+def filter_candidates(devices: Sequence[Device]) -> List[Device]:
+    candidates: List[Device] = []
+    for dev in devices:
+        if dev.is_removable:
+            candidates.append(dev)
+        elif dev.bus and dev.bus.lower() in {"usb", "mmc"}:
+            candidates.append(dev)
+    return candidates
+
+
+def summarize_devices(devices: Sequence[Device]) -> None:
+    if not devices:
+        info("No removable drives detected. Pass --device explicitly if one is attached.")
+        return
+    header = f"{'#':>2}  {'Device':<20} {'Size':>10}  Description"
+    info(header)
+    for idx, dev in enumerate(devices, start=1):
+        desc = dev.description or "(unknown)"
+        line = f"{idx:>2}  {dev.path:<20} {dev.human_size:>10}  {desc}"
+        if dev.mountpoints:
+            mounts = ", ".join(dev.mountpoints)
+            line += f"  [mounted at {mounts}]"
+        print(line)
+
+
+def _confirm(prompt: str, assume_yes: bool = False) -> bool:
+    if assume_yes:
+        return True
+    reply = input(f"{prompt} [y/N]: ").strip().lower()
+    return reply in {"y", "yes"}
+
+
+def _device_exists(path: str) -> bool:
+    try:
+        os.stat(path)
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def _is_block_device(path: str) -> bool:
+    try:
+        mode = os.stat(path).st_mode
+    except FileNotFoundError:
+        return False
+    return stat.S_ISBLK(mode)
+
+
+def _check_not_root_device(path: str) -> None:
+    if platform.system() != "Linux":
+        return
+    if not _is_block_device(path):
+        return
+    try:
+        root_stat = os.stat("/")
+        dev_stat = os.stat(path)
+    except FileNotFoundError:
+        return
+    if os.major(root_stat.st_dev) == os.major(dev_stat.st_rdev):
+        warn(
+            "The selected device shares a major number with the root filesystem. "
+            "Ensure you did not select the boot drive."
+        )
+
+
+def _open_device(path: str, write: bool) -> io.BufferedIOBase:
+    flags = os.O_RDONLY
+    mode = "rb"
+    if write:
+        flags = os.O_WRONLY
+        mode = "wb"
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    if write and hasattr(os, "O_SYNC"):
+        flags |= os.O_SYNC
+    fd = os.open(path, flags)
+    return os.fdopen(fd, mode)
+
+
+def _open_image(path: Path) -> tuple[io.BufferedReader, bool]:
+    if path.suffix == ".xz":
+        import lzma
+
+        return io.BufferedReader(lzma.open(path, "rb")), True
+    return io.BufferedReader(open(path, "rb")), False
+
+
+def _stream_write(src: io.BufferedReader, dest: io.BufferedRandom) -> tuple[int, str]:
+    sha = hashlib.sha256()
+    total = 0
+    last_report = time.monotonic()
+    while True:
+        chunk = src.read(CHUNK_SIZE)
+        if not chunk:
+            break
+        dest.write(chunk)
+        total += len(chunk)
+        sha.update(chunk)
+        now = time.monotonic()
+        if now - last_report >= PROGRESS_INTERVAL:
+            info(f"Wrote {_format_size(total)} so far")
+            last_report = now
+    dest.flush()
+    os.fsync(dest.fileno())
+    info(f"Finished writing {_format_size(total)}")
+    return total, sha.hexdigest()
+
+
+def _read_and_hash(device: io.BufferedRandom, size: int) -> str:
+    sha = hashlib.sha256()
+    remaining = size
+    while remaining > 0:
+        chunk = device.read(min(CHUNK_SIZE, remaining))
+        if not chunk:
+            break
+        sha.update(chunk)
+        remaining -= len(chunk)
+    if remaining != 0:
+        die("Device read was shorter than expected during verification")
+    return sha.hexdigest()
+
+
+def _auto_eject(device: Device) -> None:
+    system = platform.system()
+    if system == "Linux":
+        path = device.path
+        if shutil.which("udisksctl"):
+            proc = _run(["udisksctl", "power-off", "-b", path])
+            if proc.returncode == 0:
+                info(f"Powered off {path}")
+                return
+        if shutil.which("eject"):
+            proc = _run(["eject", path])
+            if proc.returncode == 0:
+                info(f"Ejected {path}")
+                return
+        warn("Unable to auto-eject. Remove the media manually once LEDs stop blinking.")
+    elif system == "Darwin":
+        identifier = device.system_id or device.path
+        proc = _run(["/usr/sbin/diskutil", "eject", identifier])
+        if proc.returncode == 0:
+            info(f"Ejected {identifier}")
+        else:
+            warn("diskutil could not eject the media. Remove it manually when safe.")
+    elif system == "Windows":
+        if device.system_id and device.system_id.isdigit():
+            command = (
+                f"$disk = Get-Disk -Number {device.system_id} -ErrorAction SilentlyContinue; "
+                "if ($disk) {"
+                "  Get-Volume -DiskNumber $disk.Number -ErrorAction SilentlyContinue | "
+                "    ForEach-Object { Dismount-Volume -InputObject $_ -Force -Confirm:$false }; "
+                "  $disk | Set-Disk -IsOffline $true -Confirm:$false"
+                "}"
+            )
+            proc = _run(["powershell", "-NoProfile", "-Command", command])
+            if proc.returncode == 0:
+                info(f"Disk {device.system_id} set offline. It is safe to remove the media.")
+                return
+        warn("Unable to offline the disk automatically. Use 'Safely Remove Hardware'.")
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--image",
+        required=False,
+        help=(
+            "Path to the .img or .img.xz image. Defaults to the expanded release in "
+            "~/sugarkube/images."
+        ),
+    )
+    parser.add_argument(
+        "--device",
+        help=("Target device (e.g. /dev/sdX or \\.\\PhysicalDrive1). Prompts when omitted."),
+    )
+    parser.add_argument(
+        "--assume-yes",
+        action="store_true",
+        help="Do not prompt for confirmation before flashing.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List detected removable devices and exit.",
+    )
+    parser.add_argument(
+        "--keep-mounted",
+        action="store_true",
+        help="Skip automatic unmount detection. Useful for loopback files in tests.",
+    )
+    parser.add_argument(
+        "--no-eject",
+        action="store_true",
+        help="Skip automatic eject/offline after flashing.",
+    )
+    parser.add_argument(
+        "--bytes",
+        type=int,
+        default=0,
+        help=argparse.SUPPRESS,
+    )
+    return parser.parse_args(argv)
+
+
+def _default_image_path() -> Optional[Path]:
+    candidate = Path.home() / "sugarkube" / "images" / "sugarkube.img"
+    if candidate.exists():
+        return candidate
+    xz = candidate.with_suffix(".img.xz")
+    if xz.exists():
+        return xz
+    return None
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    devices = discover_devices()
+    candidates = filter_candidates(devices)
+
+    if args.list:
+        summarize_devices(candidates)
+        return 0
+
+    image_path: Optional[Path]
+    if args.image:
+        image_path = Path(args.image).expanduser().resolve()
+    else:
+        default = _default_image_path()
+        if default is None:
+            die(
+                "Provide --image pointing to the sugarkube release "
+                "(sugarkube.img or sugarkube.img.xz)."
+            )
+        image_path = default
+
+    if not image_path.exists():
+        die(f"Image not found: {image_path}")
+
+    if not args.device:
+        summarize_devices(candidates)
+        if not candidates:
+            die("No removable devices detected. Re-run with --device once media is attached.")
+        selection = input("Enter the device number to flash: ").strip()
+        try:
+            index = int(selection) - 1
+        except ValueError:
+            die("Expected a numeric selection.")
+        if index < 0 or index >= len(candidates):
+            die("Selection out of range")
+        target_device = candidates[index]
+    else:
+        target_path = args.device
+        matching = [dev for dev in candidates if dev.path == target_path]
+        if matching:
+            target_device = matching[0]
+        else:
+            size_hint = 0
+            if args.bytes:
+                size_hint = args.bytes
+            target_device = Device(
+                path=target_path,
+                description="(custom device)",
+                size=size_hint,
+                is_removable=True,
+            )
+
+    if not _device_exists(target_device.path):
+        die(f"Device not found: {target_device.path}")
+
+    _check_not_root_device(target_device.path)
+
+    if target_device.mountpoints and not args.keep_mounted:
+        mounts = ", ".join(target_device.mountpoints)
+        die(
+            f"{target_device.path} has mounted partitions ({mounts}). Unmount them before flashing "
+            "or pass --keep-mounted to override."
+        )
+
+    allow_nonroot = os.environ.get("SUGARKUBE_FLASH_ALLOW_NONROOT") == "1"
+    if hasattr(os, "geteuid"):
+        if not allow_nonroot and os.geteuid() != 0:
+            die("Run as root or with sudo")
+    elif not allow_nonroot:
+        warn(
+            "Cannot determine effective user ID on this platform; "
+            "ensure you have permissions to write the device."
+        )
+
+    if not _confirm(
+        f"About to erase and flash {target_device.path} with {image_path.name}. Continue?",
+        args.assume_yes,
+    ):
+        info("Aborted by user")
+        return 0
+
+    src, compressed = _open_image(image_path)
+    info(f"Opening {'compressed ' if compressed else ''}image {image_path}")
+    with src:
+        with _open_device(target_device.path, write=True) as dest:
+            total_bytes, expected_hash = _stream_write(src, dest)
+
+    info(f"Expected SHA-256 for written bytes: {expected_hash}")
+
+    with _open_device(target_device.path, write=False) as reader:
+        actual_hash = _read_and_hash(reader, total_bytes)
+    if actual_hash != expected_hash:
+        die(
+            "Verification failed: device SHA-256 does not match the image. "
+            f"Expected {expected_hash}, got {actual_hash}."
+        )
+    info(f"Verified device SHA-256: {actual_hash}")
+
+    if not args.no_eject:
+        _auto_eject(target_device)
+
+    info("Flash complete")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    raise SystemExit(main())

--- a/scripts/flash_pi_media.sh
+++ b/scripts/flash_pi_media.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR: python3 is required to run flash_pi_media" >&2
+  exit 1
+fi
+
+exec python3 "$SCRIPT_DIR/flash_pi_media.py" "$@"

--- a/scripts/install_sugarkube_image.sh
+++ b/scripts/install_sugarkube_image.sh
@@ -1,0 +1,407 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '==> %s\n' "$*"
+}
+
+err() {
+  printf 'error: %s\n' "$*" >&2
+}
+
+die() {
+  err "$1"
+  exit "${2:-1}"
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    if [ -n "${2:-}" ]; then
+      die "$2"
+    fi
+    die "Missing required command: $1"
+  fi
+}
+
+detect_os_arch() {
+  local uname_s uname_m
+  uname_s=$(uname -s)
+  uname_m=$(uname -m)
+
+  case "$uname_s" in
+    Linux)
+      BOOTSTRAP_OS="linux"
+      ARCHIVE_EXT="tar.gz"
+      ;;
+    Darwin)
+      BOOTSTRAP_OS="macOS"
+      ARCHIVE_EXT="zip"
+      ;;
+    *)
+      die "Unsupported operating system '$uname_s' for automatic gh installation"
+      ;;
+  esac
+
+  case "$uname_m" in
+    x86_64|amd64)
+      BOOTSTRAP_ARCH="amd64"
+      ;;
+    arm64|aarch64)
+      BOOTSTRAP_ARCH="arm64"
+      ;;
+    armv7l)
+      BOOTSTRAP_ARCH="armv7"
+      ;;
+    armv6l)
+      BOOTSTRAP_ARCH="armv6"
+      ;;
+    *)
+      die "Unsupported architecture '$uname_m' for automatic gh installation"
+      ;;
+  esac
+}
+
+hash_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print tolower($1)}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print tolower($1)}'
+  else
+    die "sha256sum or shasum is required to compute checksums"
+  fi
+}
+
+expand_archive() {
+  local archive="$1"
+  local destination="$2"
+  local tmp="$destination.tmp.$$"
+
+  if command -v xz >/dev/null 2>&1; then
+    if ! xz -T0 -dc "$archive" >"$tmp"; then
+      rm -f "$tmp"
+      die "Failed to expand $archive"
+    fi
+  else
+    require_cmd python3 "python3 or xz is required to expand .xz archives"
+    if ! python3 - "$archive" "$tmp" <<'PYCODE'; then
+  import lzma
+  import shutil
+  import sys
+
+  source, dest = sys.argv[1:3]
+  with lzma.open(source, "rb") as src, open(dest, "wb") as dst:
+      shutil.copyfileobj(src, dst)
+PYCODE
+      rm -f "$tmp"
+      die "Failed to expand $archive"
+    fi
+  fi
+
+  mv "$tmp" "$destination"
+}
+
+install_gh() {
+  if command -v gh >/dev/null 2>&1; then
+    return
+  fi
+  if [ "${SUGARKUBE_SKIP_GH_INSTALL:-0}" = "1" ]; then
+    die "gh is required but installation was skipped via SUGARKUBE_SKIP_GH_INSTALL"
+  fi
+
+  if [ -n "${SUGARKUBE_GH_INSTALL_HOOK:-}" ]; then
+    log "Installing GitHub CLI via hook"
+    if ! bash -c "$SUGARKUBE_GH_INSTALL_HOOK"; then
+      die "Custom GitHub CLI installation hook failed"
+    fi
+    if command -v gh >/dev/null 2>&1; then
+      return
+    fi
+    die "GitHub CLI not found after running hook"
+  fi
+
+  detect_os_arch
+  require_cmd curl "curl is required to install gh"
+  if [ "$ARCHIVE_EXT" = "tar.gz" ]; then
+    require_cmd tar "tar is required to install gh"
+  else
+    require_cmd unzip "unzip is required to install gh"
+  fi
+
+  local gh_version
+  gh_version="${SUGARKUBE_GH_VERSION:-2.58.0}"
+  if [[ "$gh_version" != v* ]]; then
+    gh_version="v${gh_version}"
+  fi
+
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "${tmp_dir}"' RETURN
+
+  local archive_url
+  local version="${gh_version#v}"
+  archive_url="https://github.com/cli/cli/releases/download/${gh_version}/gh_${version}_${BOOTSTRAP_OS}_${BOOTSTRAP_ARCH}.${ARCHIVE_EXT}"
+  local archive_path="$tmp_dir/gh.${ARCHIVE_EXT}"
+
+  log "Downloading GitHub CLI from $archive_url"
+  if ! curl -fsSL "$archive_url" -o "$archive_path"; then
+    die "Failed to download GitHub CLI archive"
+  fi
+
+  local extract_dir
+  extract_dir="$tmp_dir/extracted"
+  mkdir -p "$extract_dir"
+  if [ "$ARCHIVE_EXT" = "tar.gz" ]; then
+    if ! tar -xzf "$archive_path" -C "$extract_dir"; then
+      die "Failed to extract GitHub CLI archive"
+    fi
+  else
+    if ! unzip -q "$archive_path" -d "$extract_dir"; then
+      die "Failed to extract GitHub CLI archive"
+    fi
+  fi
+
+  local gh_dir
+  gh_dir="$(find "$extract_dir" -maxdepth 1 -type d -name 'gh*' | head -n 1)"
+  if [ -z "$gh_dir" ]; then
+    die "Unable to locate gh binary in extracted archive"
+  fi
+
+  local install_dir
+  install_dir="${SUGARKUBE_GH_INSTALL_DIR:-$HOME/.local/bin}"
+  mkdir -p "$install_dir"
+  if ! install "$gh_dir/bin/gh" "$install_dir/gh"; then
+    die "Failed to install gh binary"
+  fi
+  chmod +x "$install_dir/gh"
+  PATH="$install_dir:$PATH"
+  export PATH
+  log "Installed GitHub CLI to $install_dir/gh"
+
+  if ! command -v gh >/dev/null 2>&1; then
+    die "GitHub CLI installation failed"
+  fi
+
+  rm -rf "$tmp_dir"
+  trap - RETURN
+}
+
+usage() {
+  cat <<'USAGE'
+Install the latest sugarkube Pi image, verify checksums, and expand it to a raw
+.img file. Intended to be used as a one-liner: curl -fsSL .../install_sugarkube_image.sh | bash
+
+Usage: install_sugarkube_image.sh [options]
+
+Options:
+  -o, --output PATH       Destination for the compressed image (.img.xz). Defaults to
+                          ~/sugarkube/images/sugarkube.img.xz
+      --image PATH        Destination for the expanded .img file. Defaults to the
+                          compressed path without the .xz suffix.
+      --dir DIR           Directory to store downloads (shortcut to change the default
+                          for both --output and --image).
+      --release TAG       Download a specific release tag.
+      --asset NAME        Override the release asset name (default: sugarkube.img.xz).
+      --checksum NAME     Override the checksum asset name (default: asset + .sha256).
+      --mode MODE         Pass through to download helper (auto, release, workflow).
+      --download-only     Skip expansion; leave only the .img.xz and checksum.
+      --skip-gh-install   Do not attempt to bootstrap the GitHub CLI automatically.
+      --download-script PATH
+                          Use a local download_pi_image.sh instead of fetching from GitHub.
+  -h, --help              Show this help message and exit.
+
+Environment variables:
+  SUGARKUBE_INSTALL_HELPER   Override the helper script path for tests/custom builds.
+  SUGARKUBE_SKIP_GH_INSTALL  Skip automatic gh installation when set to 1.
+  SUGARKUBE_GH_INSTALL_HOOK  Shell snippet used to install gh when it is missing.
+  SUGARKUBE_GH_INSTALL_DIR   Directory to install gh into (default: ~/.local/bin).
+  SUGARKUBE_GH_VERSION       GitHub CLI version or tag to install (default: 2.58.0).
+  SUGARKUBE_IMAGE_DIR        Default image directory (default: ~/sugarkube/images).
+  SUGARKUBE_IMAGE_ASSET      Default asset name (default: sugarkube.img.xz).
+  SUGARKUBE_CHECKSUM_ASSET   Default checksum asset name.
+  SUGARKUBE_RAW_BASE_URL     Base URL for fetching helper scripts (default: GitHub main).
+USAGE
+}
+
+OWNER="${SUGARKUBE_OWNER:-futuroptimist}"
+REPO="${SUGARKUBE_REPO:-sugarkube}"
+DEFAULT_DIR="${SUGARKUBE_IMAGE_DIR:-$HOME/sugarkube/images}"
+ASSET_NAME="${SUGARKUBE_IMAGE_ASSET:-sugarkube.img.xz}"
+CHECKSUM_NAME="${SUGARKUBE_CHECKSUM_ASSET:-${ASSET_NAME}.sha256}"
+
+DOWNLOAD_ARGS=()
+OUTPUT_ARCHIVE=""
+IMAGE_DEST=""
+DEST_DIR_OVERRIDE=""
+DOWNLOAD_ONLY=0
+SKIP_GH_INSTALL=0
+HELPER_OVERRIDE="${SUGARKUBE_INSTALL_HELPER:-}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -o|--output)
+      if [ "$#" -lt 2 ]; then
+        die "--output requires a path"
+      fi
+      OUTPUT_ARCHIVE="$2"
+      DOWNLOAD_ARGS+=("--output" "$2")
+      shift 2
+      ;;
+    --image)
+      if [ "$#" -lt 2 ]; then
+        die "--image requires a path"
+      fi
+      IMAGE_DEST="$2"
+      shift 2
+      ;;
+    --dir)
+      if [ "$#" -lt 2 ]; then
+        die "--dir requires a value"
+      fi
+      DEST_DIR_OVERRIDE="$2"
+      DOWNLOAD_ARGS+=("--dir" "$2")
+      shift 2
+      ;;
+    --release)
+      if [ "$#" -lt 2 ]; then
+        die "--release requires a tag"
+      fi
+      DOWNLOAD_ARGS+=("--release" "$2")
+      shift 2
+      ;;
+    --asset)
+      if [ "$#" -lt 2 ]; then
+        die "--asset requires a value"
+      fi
+      ASSET_NAME="$2"
+      DOWNLOAD_ARGS+=("--asset" "$2")
+      shift 2
+      ;;
+    --checksum)
+      if [ "$#" -lt 2 ]; then
+        die "--checksum requires a value"
+      fi
+      CHECKSUM_NAME="$2"
+      DOWNLOAD_ARGS+=("--checksum" "$2")
+      shift 2
+      ;;
+    --mode)
+      if [ "$#" -lt 2 ]; then
+        die "--mode requires a value"
+      fi
+      MODE_OVERRIDE="$2"
+      DOWNLOAD_ARGS+=("--mode" "$2")
+      shift 2
+      ;;
+    --download-only)
+      DOWNLOAD_ONLY=1
+      shift
+      ;;
+    --skip-gh-install)
+      SKIP_GH_INSTALL=1
+      shift
+      ;;
+    --download-script)
+      if [ "$#" -lt 2 ]; then
+        die "--download-script requires a path"
+      fi
+      HELPER_OVERRIDE="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      die "Unknown option: $1"
+      ;;
+    *)
+      die "Unexpected argument: $1"
+      ;;
+  esac
+done
+
+if [ "$SKIP_GH_INSTALL" -eq 1 ]; then
+  SUGARKUBE_SKIP_GH_INSTALL=1
+fi
+
+if [ -n "$DEST_DIR_OVERRIDE" ]; then
+  DEFAULT_DIR="$DEST_DIR_OVERRIDE"
+fi
+
+if [ -z "$OUTPUT_ARCHIVE" ]; then
+  OUTPUT_ARCHIVE="${DEFAULT_DIR%/}/${ASSET_NAME}"
+  DOWNLOAD_ARGS+=("--output" "$OUTPUT_ARCHIVE")
+fi
+
+if [ -z "$IMAGE_DEST" ]; then
+  if [[ "$OUTPUT_ARCHIVE" == *.xz ]]; then
+    IMAGE_DEST="${OUTPUT_ARCHIVE%.xz}"
+  else
+    IMAGE_DEST="${OUTPUT_ARCHIVE}.img"
+  fi
+fi
+
+DEST_DIR="$(dirname "$OUTPUT_ARCHIVE")"
+mkdir -p "$DEST_DIR"
+mkdir -p "$(dirname "$IMAGE_DEST")"
+
+if [ "$SKIP_GH_INSTALL" -eq 0 ]; then
+  install_gh
+else
+  if ! command -v gh >/dev/null 2>&1; then
+    die "gh is required; rerun without --skip-gh-install once it is installed"
+  fi
+fi
+
+require_cmd curl "curl is required to download the helper"
+
+HELPER_SCRIPT=""
+HELPER_TMP=""
+cleanup_helper() {
+  if [ -n "$HELPER_TMP" ] && [ -f "$HELPER_TMP" ]; then
+    rm -f "$HELPER_TMP"
+  fi
+}
+trap cleanup_helper EXIT
+
+if [ -n "$HELPER_OVERRIDE" ]; then
+  if [ ! -x "$HELPER_OVERRIDE" ]; then
+    die "Download helper '$HELPER_OVERRIDE' is not executable"
+  fi
+  HELPER_SCRIPT="$HELPER_OVERRIDE"
+else
+  RAW_BASE="${SUGARKUBE_RAW_BASE_URL:-https://raw.githubusercontent.com/${OWNER}/${REPO}/main}"
+  HELPER_TMP="$(mktemp)"
+  if ! curl -fsSL "$RAW_BASE/scripts/download_pi_image.sh" -o "$HELPER_TMP"; then
+    die "Failed to fetch download helper from $RAW_BASE"
+  fi
+  chmod +x "$HELPER_TMP"
+  HELPER_SCRIPT="$HELPER_TMP"
+fi
+
+log "Downloading sugarkube image to $OUTPUT_ARCHIVE"
+if ! "$HELPER_SCRIPT" "${DOWNLOAD_ARGS[@]}"; then
+  die "Download helper failed"
+fi
+
+if [ "$DOWNLOAD_ONLY" -eq 1 ]; then
+  log "Download complete. Skipping expansion (--download-only)."
+  exit 0
+fi
+
+if [ ! -f "$OUTPUT_ARCHIVE" ]; then
+  die "Expected archive $OUTPUT_ARCHIVE was not created"
+fi
+
+log "Expanding $(basename "$OUTPUT_ARCHIVE") to $IMAGE_DEST"
+expand_archive "$OUTPUT_ARCHIVE" "$IMAGE_DEST"
+
+local_sha="$(hash_file "$IMAGE_DEST")"
+printf '%s  %s\n' "$local_sha" "$IMAGE_DEST" >"${IMAGE_DEST}.sha256"
+log "Expanded image checksum: $local_sha"
+
+log "Done. Image available at $IMAGE_DEST"

--- a/tests/download_pi_image_test.py
+++ b/tests/download_pi_image_test.py
@@ -75,11 +75,12 @@ case "$cmd" in
     esac
     ;;
   auth)
-    sub="${1:-}"
-    if [ "$sub" = token ] && [ -n "${GH_TOKEN:-}" ]; then
-      echo "$GH_TOKEN"
-      exit 0
-    fi
+    case "${1:-}" in
+      token)
+        echo "stub-gh-token"
+        exit 0
+        ;;
+    esac
     ;;
 esac
 

--- a/tests/flash_pi_media_test.py
+++ b/tests/flash_pi_media_test.py
@@ -1,0 +1,78 @@
+import lzma
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+
+
+def run_flash(args, env=None, cwd=None):
+    cmd = [sys.executable, str(BASE_DIR / "scripts" / "flash_pi_media.py")]
+    cmd.extend(args)
+    return subprocess.run(cmd, capture_output=True, text=True, env=env, cwd=cwd)
+
+
+def make_image(tmp_path: Path, content: bytes) -> tuple[Path, Path]:
+    img = tmp_path / "sugarkube.img"
+    img.write_bytes(content)
+    archive = img.with_suffix(".img.xz")
+    with lzma.open(archive, "wb") as fh:
+        fh.write(content)
+    return img, archive
+
+
+def test_flash_imgxz_to_regular_file(tmp_path):
+    content = b"sugarkube" * 2048
+    img, archive = make_image(tmp_path, content)
+    device = tmp_path / "device.bin"
+    device.touch()
+
+    env = os.environ.copy()
+    env["SUGARKUBE_FLASH_ALLOW_NONROOT"] = "1"
+
+    result = run_flash(
+        [
+            "--image",
+            str(archive),
+            "--device",
+            str(device),
+            "--assume-yes",
+            "--keep-mounted",
+            "--no-eject",
+        ],
+        env=env,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert device.read_bytes() == content
+    assert "Finished writing" in result.stdout
+    assert "Verified device SHA-256" in result.stdout
+
+
+def test_requires_root_without_override(tmp_path):
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("Running as root; cannot exercise the permission check")
+    content = b"data" * 512
+    img, archive = make_image(tmp_path, content)
+    device = tmp_path / "device.raw"
+    device.touch()
+
+    result = run_flash(
+        [
+            "--image",
+            str(archive),
+            "--device",
+            str(device),
+            "--assume-yes",
+            "--keep-mounted",
+            "--no-eject",
+        ],
+        env=os.environ.copy(),
+    )
+
+    assert result.returncode != 0
+    assert "Run as root or with sudo" in result.stderr

--- a/tests/install_sugarkube_image_test.py
+++ b/tests/install_sugarkube_image_test.py
@@ -1,0 +1,167 @@
+import hashlib
+import json
+import lzma
+import os
+import subprocess
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+
+
+def run_install(args=None, env=None, cwd=None):
+    cmd = ["/bin/bash", str(BASE_DIR / "scripts" / "install_sugarkube_image.sh")]
+    if args:
+        cmd.extend(args)
+    return subprocess.run(cmd, capture_output=True, text=True, env=env, cwd=cwd)
+
+
+def create_gh_stub(bin_dir: Path) -> None:
+    script = bin_dir / "gh"
+    script.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+cmd="${1:-}"
+if [ $# -gt 0 ]; then
+  shift
+fi
+case "$cmd" in
+  api)
+    if [ -n "${GH_RELEASE_PAYLOAD:-}" ]; then
+      printf '%s' "$GH_RELEASE_PAYLOAD"
+      exit 0
+    fi
+    exit 1
+    ;;
+  auth)
+    case "${1:-}" in
+      token)
+        echo "stub-gh-token"
+        exit 0
+        ;;
+    esac
+    ;;
+esac
+echo "unexpected gh call: $cmd $*" >&2
+exit 1
+"""
+    )
+    script.chmod(0o755)
+
+
+def make_release_payload(image: Path, checksum: Path) -> str:
+    return json.dumps(
+        {
+            "tag_name": "v9.9.9",
+            "assets": [
+                {
+                    "name": "sugarkube.img.xz",
+                    "browser_download_url": f"file://{image}",
+                },
+                {
+                    "name": "sugarkube.img.xz.sha256",
+                    "browser_download_url": f"file://{checksum}",
+                },
+            ],
+        }
+    )
+
+
+def test_install_downloads_and_expands(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    create_gh_stub(fake_bin)
+
+    image_bytes = b"sugarkube" * 1024
+    archive = tmp_path / "sugarkube.img.xz"
+    with lzma.open(archive, "wb") as fh:
+        fh.write(image_bytes)
+    archive_bytes = archive.read_bytes()
+    sha = hashlib.sha256(archive_bytes).hexdigest()
+    checksum = tmp_path / "sugarkube.img.xz.sha256"
+    checksum.write_text(f"{sha}\n")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "GH_RELEASE_PAYLOAD": make_release_payload(archive, checksum),
+            "GH_TOKEN": "dummy",
+            "GITHUB_TOKEN": "dummy",
+            "HOME": str(tmp_path / "home"),
+            "SUGARKUBE_INSTALL_HELPER": str(BASE_DIR / "scripts" / "download_pi_image.sh"),
+            "SUGARKUBE_SKIP_GH_INSTALL": "0",
+        }
+    )
+
+    result = run_install(env=env, cwd=tmp_path)
+    assert result.returncode == 0, result.stderr
+
+    image_dir = Path(env["HOME"]) / "sugarkube" / "images"
+    archive_path = image_dir / "sugarkube.img.xz"
+    expanded = image_dir / "sugarkube.img"
+
+    assert archive_path.read_bytes() == archive_bytes
+    assert expanded.exists()
+    assert expanded.read_bytes() == image_bytes
+    checksum_path = Path(str(expanded) + ".sha256")
+    assert checksum_path.exists()
+
+
+def test_install_uses_custom_gh_hook(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    image_bytes = b"hook" * 1024
+    archive = tmp_path / "hook.img.xz"
+    with lzma.open(archive, "wb") as fh:
+        fh.write(image_bytes)
+    archive_bytes = archive.read_bytes()
+    sha = hashlib.sha256(archive_bytes).hexdigest()
+    checksum = tmp_path / "hook.img.xz.sha256"
+    checksum.write_text(f"{sha}\n")
+
+    hook_script = tmp_path / "gh_hook.sh"
+    hook_script.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+cat <<'EOF' >"${HOOK_DEST}/gh"
+#!/usr/bin/env bash
+set -euo pipefail
+cmd="${1:-}"
+if [ $# -gt 0 ]; then
+  shift
+fi
+case "$cmd" in
+  api)
+    if [ -n "${GH_RELEASE_PAYLOAD:-}" ]; then
+      printf '%s' "$GH_RELEASE_PAYLOAD"
+      exit 0
+    fi
+    exit 1
+    ;;
+esac
+echo "unexpected gh call: $cmd $*" >&2
+exit 1
+EOF
+chmod +x "${HOOK_DEST}/gh"
+"""
+    )
+    hook_script.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "GH_RELEASE_PAYLOAD": make_release_payload(archive, checksum),
+            "HOOK_DEST": str(fake_bin),
+            "SUGARKUBE_GH_INSTALL_HOOK": f". '{hook_script}'",
+            "SUGARKUBE_INSTALL_HELPER": str(BASE_DIR / "scripts" / "download_pi_image.sh"),
+            "HOME": str(tmp_path / "home"),
+            "GITHUB_TOKEN": "dummy",
+            "GH_TOKEN": "dummy",
+        }
+    )
+
+    result = run_install(env=env, cwd=tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert (fake_bin / "gh").exists()


### PR DESCRIPTION
## Summary
- pin the automated GitHub CLI bootstrap to a configurable release (default v2.58.0) so curl hits valid assets
- document the new SUGARKUBE_GH_VERSION override in the installer help text
- scope workflow fallbacks in download_pi_image.sh to OWNER/REPO so gh works without a local git checkout

## Testing
- pre-commit run --all-files
- pytest tests/install_sugarkube_image_test.py
- pytest tests/flash_pi_media_test.py
- pytest tests/download_pi_image_test.py

------
https://chatgpt.com/codex/tasks/task_e_68c9f40cf688832fbd6f58708099a0f0