### PR TITLE
✨ : add Pi Imager presets and renderer

### DIFF
--- a/docs/network_setup.md
+++ b/docs/network_setup.md
@@ -9,7 +9,10 @@ It assumes you are using Raspberry Pi 5 boards in a small k3s setup.
 2. Press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd> to open **advanced options**.
 3. Enter your WiFi **SSID** and **password**, enable **SSH**, and set a unique
    hostname and user for each Pi. Optionally paste your SSH public key into the
-   *authorized keys* field to allow key-based logins on first boot.
+   *authorized keys* field to allow key-based logins on first boot. To skip
+   manual typing, render one of the JSON presets in
+   `docs/templates/pi-imager/` with `scripts/render_pi_imager_preset.py` so
+   Raspberry Pi Imager opens with your answers pre-filled.
 4. Set the wireless LAN **country** to match your location so WiFi channels are enabled correctly.
 5. Write the image to an SD card or M.2 drive and repeat for the other boards.
 6. Boot each Pi once to confirm it connects. From another machine run

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -34,7 +34,10 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
   - Verify written bytes with SHA-256.
   - Auto-eject media.
   - Implemented via `scripts/flash_pi_media.py` with bash and PowerShell wrappers.
-- [ ] Ship Raspberry Pi Imager preset JSONs pre-filled with hostname, user, Wi-Fi, and SSH keys for load-and-go flashing.
+- [x] Ship Raspberry Pi Imager preset JSONs pre-filled with hostname, user, Wi-Fi, and SSH keys for load-and-go flashing.
+  - Added `docs/templates/pi-imager/` presets plus
+    `scripts/render_pi_imager_preset.py` to merge secrets and write Raspberry Pi
+    Imager configuration snippets.
 - [x] Provide `just`/`make` targets (e.g., `make flash-pi`) chaining download → verify → flash.
   - Added a root `Makefile` with `flash-pi`, `install-pi-image`, and `download-pi-image` targets that wrap the new installer and flashing helpers.
 - [ ] Bundle a wrapper script that auto-decompresses, flashes, verifies, and reports results in HTML/Markdown (hardware IDs, checksum results, cloud-init diff).

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -58,6 +58,16 @@ Build a Raspberry Pi OS image that boots with k3s and the
 - Raspberry Pi Imager remains a friendly alternative.
   Use advanced options (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>) to set the
   hostname, credentials and network when flashing `sugarkube.img.xz` manually.
+  The repository now ships presets under `docs/templates/pi-imager/` plus a
+  renderer script:
+  ```bash
+  python3 scripts/render_pi_imager_preset.py \
+    --preset docs/templates/pi-imager/sugarkube-controller.preset.json \
+    --secrets ~/sugarkube/secrets.env \
+    --apply
+  ```
+  The command writes your secrets into Raspberry Pi Imager's configuration so
+  the advanced options open pre-populated for the next flash.
 
 ## 3. Boot and verify
 - Insert the card and power on the Pi.

--- a/docs/templates/pi-imager/README.md
+++ b/docs/templates/pi-imager/README.md
@@ -1,0 +1,63 @@
+# Raspberry Pi Imager presets
+
+These presets pre-populate Raspberry Pi Imager's advanced options so each Pi
+boots with the right hostname, user, Wi-Fi, and SSH keys. Copy one JSON file per
+node, adjust the secrets, then render it into the Imager configuration with
+`scripts/render_pi_imager_preset.py`.
+
+## Folder layout
+
+- `sugarkube-controller.preset.json` – control-plane defaults.
+- `sugarkube-worker1.preset.json` – first worker defaults.
+- `sugarkube-worker2.preset.json` – second worker defaults.
+
+Each JSON file ships with safe placeholders (`ExampleNetwork`,
+`ssh-ed25519 AAAA...ExampleOnly`) and a SHA-512 password hash for the string
+`changeme`. Replace them before flashing.
+
+## Rendering a preset
+
+```bash
+# 1. Prepare a secrets file so the CLI history never captures credentials
+SSH_AUTHORIZED_KEY="$(cat ~/.ssh/id_ed25519.pub)"
+cat <<EOF > ~/sugarkube/secrets.env
+WIFI_SSID="your-ssid"
+WIFI_PASSWORD="your-passphrase"
+WIFI_COUNTRY=US
+SSH_AUTHORIZED_KEY="$SSH_AUTHORIZED_KEY"
+PI_PASSWORD="supers3cret"  # optional; hashes automatically
+TIMEZONE=America/Los_Angeles
+KEYBOARD_LAYOUT=us
+EOF
+
+# 2. Render the controller preset and apply it to Raspberry Pi Imager
+python3 scripts/render_pi_imager_preset.py \
+  --preset docs/templates/pi-imager/sugarkube-controller.preset.json \
+  --secrets ~/sugarkube/secrets.env \
+  --output ~/sugarkube/imager-presets/sugarkube-controller.ini \
+  --apply
+```
+
+The script reads the JSON template, merges overrides from `secrets.env` and CLI
+flags, hashes any plain-text password, then:
+
+1. Writes an `.ini` snippet you can track in Git or share internally.
+2. Updates `~/.config/Raspberry Pi/Imager.conf` so Raspberry Pi Imager pre-fills
+   the advanced options for the next flash.
+
+Repeat the command with the worker preset(s); pass `--hostname` to override the
+value inside the JSON without editing it in place.
+
+## Updating placeholders
+
+- **Wi-Fi:** `--wifi-ssid`, `--wifi-password`, and `--wifi-country` flags override
+  the JSON to avoid leaking credentials into Git history.
+- **SSH keys:** provide one or more `--ssh-key-file` arguments, or populate
+  `SSH_AUTHORIZED_KEYS` in `secrets.env` separated by newlines.
+- **Password hashes:** supply either `PI_PASSWORD_HASH` (already hashed) or
+  `PI_PASSWORD` (plain text). The script uses `sha512-crypt` so Raspberry Pi OS
+  accepts the value on first boot.
+- **Time zone & keyboard:** override with `--timezone`, `--keyboard-layout`, and
+  `--keyboard-variant`.
+
+Run `python3 scripts/render_pi_imager_preset.py --help` for all switches.

--- a/docs/templates/pi-imager/sugarkube-controller.preset.json
+++ b/docs/templates/pi-imager/sugarkube-controller.preset.json
@@ -1,0 +1,25 @@
+{
+  "hostname": "sugarkube-controller",
+  "username": "sugar",
+  "password_hash": "$6$nBjVYMUWj.1dkWfT$grIvniYJI7nM3.NLF0UW9LPWzAhSur5EzAYHXRhRQW89vIVV.8RucgBIj/YGxq4AoMNxFI.VuQo6dRA9iIFtt/",
+  "wifi": {
+    "ssid": "ExampleNetwork",
+    "password": "ExamplePass123",
+    "country": "US",
+    "hidden": false
+  },
+  "ssh": {
+    "authorized_keys": [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAISugarkubeExampleKeyGeneratedForDocs== sugarkube@example"
+    ],
+    "password_authentication": true,
+    "enabled": true
+  },
+  "locale": {
+    "timezone": "America/Los_Angeles",
+    "keyboard_layout": "us",
+    "keyboard_variant": "",
+    "language": "en",
+    "country": "US"
+  }
+}

--- a/docs/templates/pi-imager/sugarkube-worker1.preset.json
+++ b/docs/templates/pi-imager/sugarkube-worker1.preset.json
@@ -1,0 +1,25 @@
+{
+  "hostname": "sugarkube-worker1",
+  "username": "sugar",
+  "password_hash": "$6$nBjVYMUWj.1dkWfT$grIvniYJI7nM3.NLF0UW9LPWzAhSur5EzAYHXRhRQW89vIVV.8RucgBIj/YGxq4AoMNxFI.VuQo6dRA9iIFtt/",
+  "wifi": {
+    "ssid": "ExampleNetwork",
+    "password": "ExamplePass123",
+    "country": "US",
+    "hidden": false
+  },
+  "ssh": {
+    "authorized_keys": [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAISugarkubeExampleKeyGeneratedForDocs== sugarkube@example"
+    ],
+    "password_authentication": true,
+    "enabled": true
+  },
+  "locale": {
+    "timezone": "America/Los_Angeles",
+    "keyboard_layout": "us",
+    "keyboard_variant": "",
+    "language": "en",
+    "country": "US"
+  }
+}

--- a/docs/templates/pi-imager/sugarkube-worker2.preset.json
+++ b/docs/templates/pi-imager/sugarkube-worker2.preset.json
@@ -1,0 +1,25 @@
+{
+  "hostname": "sugarkube-worker2",
+  "username": "sugar",
+  "password_hash": "$6$nBjVYMUWj.1dkWfT$grIvniYJI7nM3.NLF0UW9LPWzAhSur5EzAYHXRhRQW89vIVV.8RucgBIj/YGxq4AoMNxFI.VuQo6dRA9iIFtt/",
+  "wifi": {
+    "ssid": "ExampleNetwork",
+    "password": "ExamplePass123",
+    "country": "US",
+    "hidden": false
+  },
+  "ssh": {
+    "authorized_keys": [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAISugarkubeExampleKeyGeneratedForDocs== sugarkube@example"
+    ],
+    "password_authentication": true,
+    "enabled": true
+  },
+  "locale": {
+    "timezone": "America/Los_Angeles",
+    "keyboard_layout": "us",
+    "keyboard_variant": "",
+    "language": "en",
+    "country": "US"
+  }
+}

--- a/scripts/render_pi_imager_preset.py
+++ b/scripts/render_pi_imager_preset.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Render Raspberry Pi Imager presets from sugarkube JSON templates."""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import json
+import os
+import sys
+import warnings
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+warnings.filterwarnings("ignore", category=DeprecationWarning, module="crypt")
+warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*crypt.*")
+try:  # Python 3.13 removes crypt; guard so we can error gracefully.
+    import crypt  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover - crypt is present on Linux images we ship.
+    crypt = None  # type: ignore[assignment]
+
+
+def parse_key_value_file(path: Path) -> Dict[str, str]:
+    data: Dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            raise ValueError(f"Invalid line in {path}: {raw_line!r}")
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if (value.startswith('"') and value.endswith('"')) or (
+            value.startswith("'") and value.endswith("'")
+        ):
+            value = value[1:-1]
+        data[key] = value
+    return data
+
+
+def parse_bool(value: object, *, field: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        raise ValueError(f"Missing boolean value for {field}")
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    if text in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"Could not interpret {value!r} as a boolean for {field}")
+
+
+def maybe_bool(value: object, *, field: str) -> Optional[bool]:
+    if value is None:
+        return None
+    try:
+        return parse_bool(value, field=field)
+    except ValueError as exc:  # pragma: no cover - exercised at runtime
+        raise ValueError(f"{exc}") from exc
+
+
+def hash_password(password: str) -> str:
+    if not password:
+        raise ValueError("Password cannot be empty when hashing")
+    if crypt is None:
+        raise RuntimeError(
+            "Python's crypt module is unavailable. Provide PI_PASSWORD_HASH instead."
+        )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=DeprecationWarning)
+        return crypt.crypt(password, crypt.mksalt(crypt.METHOD_SHA512))
+
+
+def collect_ssh_keys(values: Iterable[str]) -> List[str]:
+    seen = set()
+    keys: List[str] = []
+    for value in values:
+        if not value:
+            continue
+        for candidate in str(value).replace("\r", "").splitlines():
+            key = candidate.strip()
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            keys.append(key)
+    return keys
+
+
+def format_value(value: object) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def write_ini(settings: Dict[str, object], destination: Path) -> None:
+    config = configparser.ConfigParser(interpolation=None)
+    config.optionxform = str  # preserve camelCase keys expected by Imager
+    config["imagecustomization"] = {k: format_value(v) for k, v in settings.items()}
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("w", encoding="utf-8") as handle:
+        config.write(handle)
+
+
+def apply_to_imager_conf(settings: Dict[str, object]) -> Path:
+    config_home = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+    target = config_home / "Raspberry Pi" / "Imager.conf"
+    parser = configparser.ConfigParser(interpolation=None)
+    parser.optionxform = str
+    if target.exists():
+        parser.read(target, encoding="utf-8")
+    if "imagecustomization" not in parser:
+        parser["imagecustomization"] = {}
+    for key, value in settings.items():
+        parser["imagecustomization"][key] = format_value(value)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("w", encoding="utf-8") as handle:
+        parser.write(handle)
+    return target
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Render a sugarkube Raspberry Pi Imager preset JSON into the format "
+            "used by Imager's advanced options."
+        )
+    )
+    parser.add_argument("--preset", required=True, help="Path to preset JSON file.")
+    parser.add_argument(
+        "--secrets",
+        help="Optional KEY=VALUE file providing Wi-Fi credentials or overrides.",
+    )
+    parser.add_argument("--output", help="Write an INI snippet to this path.")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Update ~/.config/Raspberry Pi/Imager.conf with the rendered preset.",
+    )
+    parser.add_argument("--hostname")
+    parser.add_argument("--username")
+    parser.add_argument("--password", help="Plain-text password to hash with sha512-crypt.")
+    parser.add_argument("--password-hash", help="Pre-computed sha512-crypt password hash.")
+    parser.add_argument(
+        "--ssh-authorized-key",
+        action="append",
+        dest="ssh_authorized_keys",
+        help="Append an SSH public key to the preset.",
+    )
+    parser.add_argument(
+        "--ssh-key-file",
+        action="append",
+        help="Read one or more SSH keys from these files and add them to the preset.",
+    )
+    parser.add_argument(
+        "--ssh-enabled",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Toggle SSH in the rendered preset (defaults to the JSON value).",
+    )
+    parser.add_argument(
+        "--ssh-password-auth",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Toggle password authentication. Disable to rely on SSH keys only.",
+    )
+    parser.add_argument("--wifi-ssid")
+    parser.add_argument("--wifi-password")
+    parser.add_argument("--wifi-country")
+    parser.add_argument(
+        "--wifi-hidden",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Mark the Wi-Fi network as hidden.",
+    )
+    parser.add_argument("--timezone")
+    parser.add_argument("--keyboard-layout")
+    parser.add_argument("--keyboard-variant")
+    args = parser.parse_args(argv)
+
+    preset_path = Path(args.preset)
+    if not preset_path.exists():
+        parser.error(f"Preset {preset_path} does not exist")
+
+    preset = json.loads(preset_path.read_text(encoding="utf-8"))
+
+    secrets: Dict[str, str] = {}
+    if args.secrets:
+        secrets_path = Path(args.secrets)
+        if not secrets_path.exists():
+            parser.error(f"Secrets file {secrets_path} does not exist")
+        secrets = parse_key_value_file(secrets_path)
+
+    def pick(key: str, *fallback_keys: str, default: Optional[str] = None) -> Optional[str]:
+        value = getattr(args, key)
+        if value is not None:
+            return value
+        for candidate in fallback_keys:
+            if candidate in secrets:
+                return secrets[candidate]
+        return default
+
+    hostname = pick("hostname", "PI_HOSTNAME", default=preset.get("hostname"))
+    username = pick("username", "PI_USERNAME", default=preset.get("username", ""))
+    wifi_ssid = pick("wifi_ssid", "WIFI_SSID", default=preset.get("wifi", {}).get("ssid"))
+    wifi_password = pick(
+        "wifi_password", "WIFI_PASSWORD", default=preset.get("wifi", {}).get("password")
+    )
+    wifi_country = pick(
+        "wifi_country", "WIFI_COUNTRY", default=preset.get("wifi", {}).get("country")
+    )
+    keyboard_layout = pick(
+        "keyboard_layout",
+        "KEYBOARD_LAYOUT",
+        default=preset.get("locale", {}).get("keyboard_layout"),
+    )
+    keyboard_variant = pick(
+        "keyboard_variant",
+        "KEYBOARD_VARIANT",
+        default=preset.get("locale", {}).get("keyboard_variant"),
+    )
+    timezone_value = pick("timezone", "TIMEZONE", default=preset.get("locale", {}).get("timezone"))
+
+    wifi_hidden = args.wifi_hidden
+    if wifi_hidden is None and "WIFI_HIDDEN" in secrets:
+        wifi_hidden = maybe_bool(secrets["WIFI_HIDDEN"], field="WIFI_HIDDEN")
+    if wifi_hidden is None:
+        wifi_hidden = preset.get("wifi", {}).get("hidden")
+
+    ssh_enabled = args.ssh_enabled
+    if ssh_enabled is None and "SSH_ENABLED" in secrets:
+        ssh_enabled = maybe_bool(secrets["SSH_ENABLED"], field="SSH_ENABLED")
+    if ssh_enabled is None:
+        ssh_enabled = preset.get("ssh", {}).get("enabled", True)
+
+    ssh_password_auth = args.ssh_password_auth
+    if ssh_password_auth is None and "SSH_PASSWORD_AUTH" in secrets:
+        ssh_password_auth = maybe_bool(secrets["SSH_PASSWORD_AUTH"], field="SSH_PASSWORD_AUTH")
+    if ssh_password_auth is None:
+        ssh_password_auth = preset.get("ssh", {}).get("password_authentication", True)
+
+    password_hash = pick("password_hash", "PI_PASSWORD_HASH", default=preset.get("password_hash"))
+    plain_password = pick("password", "PI_PASSWORD")
+    if plain_password:
+        password_hash = hash_password(plain_password)
+    if not ssh_password_auth:
+        password_hash = None
+
+    ssh_keys: List[str] = []
+    ssh_keys.extend(preset.get("ssh", {}).get("authorized_keys", []))
+    if "SSH_AUTHORIZED_KEY" in secrets:
+        ssh_keys.append(secrets["SSH_AUTHORIZED_KEY"])
+    if "SSH_AUTHORIZED_KEYS" in secrets:
+        ssh_keys.append(secrets["SSH_AUTHORIZED_KEYS"])
+    ssh_keys.extend(args.ssh_authorized_keys or [])
+    for key_file in args.ssh_key_file or []:
+        content = Path(key_file).read_text(encoding="utf-8")
+        ssh_keys.append(content)
+    ssh_keys = collect_ssh_keys(ssh_keys)
+
+    if not hostname:
+        parser.error("Hostname is required (set in JSON or via --hostname/PI_HOSTNAME)")
+    if not username:
+        parser.error("Username is required (set in JSON or via --username/PI_USERNAME)")
+    if ssh_enabled and not (password_hash or ssh_keys):
+        parser.error(
+            "SSH is enabled but no password or authorized key was provided. "
+            "Disable SSH or supply credentials."
+        )
+
+    settings: Dict[str, object] = {"sshEnabled": bool(ssh_enabled)}
+    settings["hostname"] = hostname
+    settings["sshUserName"] = username
+    if password_hash:
+        settings["sshUserPassword"] = password_hash
+    if ssh_keys:
+        settings["sshAuthorizedKeys"] = "\n".join(ssh_keys)
+    if wifi_ssid:
+        settings["wifiSSID"] = wifi_ssid
+        if wifi_password is not None:
+            settings["wifiPassword"] = wifi_password
+        if wifi_country:
+            settings["wifiCountry"] = wifi_country
+        if wifi_hidden is not None:
+            settings["wifiSSIDHidden"] = bool(wifi_hidden)
+    if timezone_value:
+        settings["timezone"] = timezone_value
+    if keyboard_layout:
+        settings["keyboardLayout"] = keyboard_layout
+    if keyboard_variant:
+        settings["keyboardVariant"] = keyboard_variant
+
+    if not args.output and not args.apply:
+        parser.error("Specify --output, --apply, or both.")
+
+    if args.output:
+        output_path = Path(args.output)
+        write_ini(settings, output_path)
+        print(f"Wrote preset snippet to {output_path}")
+
+    if args.apply:
+        updated_path = apply_to_imager_conf(settings)
+        print(f"Updated Raspberry Pi Imager configuration at {updated_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/render_pi_imager_preset.py
+++ b/scripts/render_pi_imager_preset.py
@@ -20,6 +20,19 @@ except ImportError:  # pragma: no cover - crypt is present on Linux images we sh
     crypt = None  # type: ignore[assignment]
 
 
+def _strip_inline_comment(value: str) -> str:
+    in_single = False
+    in_double = False
+    for index, char in enumerate(value):
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        elif char == "#" and not in_single and not in_double:
+            return value[:index]
+    return value
+
+
 def parse_key_value_file(path: Path) -> Dict[str, str]:
     data: Dict[str, str] = {}
     for raw_line in path.read_text(encoding="utf-8").splitlines():
@@ -30,7 +43,7 @@ def parse_key_value_file(path: Path) -> Dict[str, str]:
             raise ValueError(f"Invalid line in {path}: {raw_line!r}")
         key, value = line.split("=", 1)
         key = key.strip()
-        value = value.strip()
+        value = _strip_inline_comment(value).strip()
         if (value.startswith('"') and value.endswith('"')) or (
             value.startswith("'") and value.endswith("'")
         ):

--- a/tests/test_render_pi_imager_preset.py
+++ b/tests/test_render_pi_imager_preset.py
@@ -1,0 +1,31 @@
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "render_pi_imager_preset.py"
+MODULE_SPEC = importlib.util.spec_from_file_location("render_pi_imager_preset", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(MODULE_SPEC)
+assert MODULE_SPEC and MODULE_SPEC.loader  # narrow types for mypy/pyright
+MODULE_SPEC.loader.exec_module(MODULE)  # type: ignore[union-attr]
+
+parse_key_value_file = MODULE.parse_key_value_file
+
+
+def test_parse_key_value_file_strips_inline_comments(tmp_path: Path) -> None:
+    secrets_path = tmp_path / "secrets.env"
+    secrets_path.write_text(
+        "\n".join(
+            [
+                'PI_PASSWORD="supers3cret"  # optional; hashes automatically',
+                'WIFI_SSID="Cafe #1"  # keep the hash in quotes',
+                "PLAIN=value-without-quotes  # trailing comment",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    secrets = parse_key_value_file(secrets_path)
+
+    assert secrets["PI_PASSWORD"] == "supers3cret"
+    assert secrets["WIFI_SSID"] == "Cafe #1"
+    assert secrets["PLAIN"] == "value-without-quotes"


### PR DESCRIPTION
## Summary
- add Raspberry Pi Imager preset JSON templates for the controller and worker Pis with documented placeholders
- ship render_pi_imager_preset.py to merge secrets, hash passwords, and write Imager configuration snippets
- refresh quickstart and network docs plus the checklist to highlight the new presets and script

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68cccc2631f0832f97921c2417022a86