### PR TITLE
⚙️ : add just recipes for pi image automation

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -220,3 +220,4 @@ yaml
 yml
 yourorg
 checksums
+Codespaces

--- a/README.md
+++ b/README.md
@@ -81,12 +81,15 @@ push to `main` and once per day. Each run publishes a signed
 `sugarkube.img.xz`, its checksum, a provenance manifest, and the full
 `pi-gen` build log. Release notes summarize stage timings and link directly to
 the manifest so you can verify the build inputs and commit hashes before
-flashing. Run `./scripts/install_sugarkube_image.sh` (or fetch the same helper
-via `curl -fsSL https://raw.githubusercontent.com/futuroptimist/sugarkube/main/scripts/install_sugarkube_image.sh | bash`) to
-download, verify, and expand the latest release, or run `make flash-pi
-FLASH_DEVICE=/dev/sdX` to chain download → verification → flashing with the new
-streaming helper. `./scripts/sugarkube-latest` remains available when you only
-need the `.img.xz` artifact with checksum verification.
+ flashing. Run `./scripts/install_sugarkube_image.sh` (or fetch the same helper
+ via `curl -fsSL https://raw.githubusercontent.com/futuroptimist/sugarkube/main/scripts/install_sugarkube_image.sh | bash`) to
+ download, verify, and expand the latest release. When you prefer a task runner,
+ use either `make flash-pi FLASH_DEVICE=/dev/sdX` or `just flash-pi FLASH_DEVICE=/dev/sdX` to
+ chain download → verification → flashing with the streaming helper. `just` recipes also provide
+ `download-pi-image`, `install-pi-image`, `doctor`, and `codespaces-bootstrap` shortcuts so GitHub
+ Codespaces users can install prerequisites and flash media without additional shell glue.
+ `./scripts/sugarkube-latest` remains available when you only need the `.img.xz` artifact with
+ checksum verification.
 
 Run `pre-commit run --all-files` before committing.
 This triggers `scripts/checks.sh`, which installs required tooling and runs

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -44,7 +44,9 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
 - [x] Document a headless provisioning path using `user-data` or `secrets.env` for injecting Wi-Fi/Cloudflare tokens without editing repo files.
   - Added `docs/pi_headless_provisioning.md` plus `docs/templates/cloud-init/user-data.example` for
     reusable `secrets.env` workflows and verifier integration.
-- [ ] Support Codespaces or `just` recipes to build and flash media with minimal local tooling.
+- [x] Support Codespaces or `just` recipes to build and flash media with minimal local tooling.
+  - Added a root `justfile` mirroring the Makefile helpers plus a `codespaces-bootstrap` target so
+    Codespaces environments can install prerequisites and flash media using the same scripts.
 
 ---
 

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -53,8 +53,15 @@ Build a Raspberry Pi OS image that boots with k3s and the
   ```bash
   sudo make flash-pi FLASH_DEVICE=/dev/sdX
   ```
-  `flash-pi` calls `install_sugarkube_image.sh` to keep the local cache fresh
-  before writing the media with `flash_pi_media.sh`.
+  or use the new [`just`](https://github.com/casey/just) recipes when you prefer a
+  minimal runner without GNU Make:
+  ```bash
+  sudo just flash-pi FLASH_DEVICE=/dev/sdX
+  ```
+  Both invocations call `install_sugarkube_image.sh` to keep the local cache fresh before
+  writing the media with `flash_pi_media.sh`.
+  Set `DOWNLOAD_ARGS="--release vX.Y.Z"` (or any other flags) in the environment to forward
+  custom options into the installer when using `just`.
 - Raspberry Pi Imager remains a friendly alternative.
   Use advanced options (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>) to set the
   hostname, credentials and network when flashing `sugarkube.img.xz` manually.
@@ -86,3 +93,14 @@ Build a Raspberry Pi OS image that boots with k3s and the
 
 The image is now ready for additional repositories or joining a multi-node
 k3s cluster.
+
+## Codespaces-friendly automation
+
+- Launch a new GitHub Codespace on this repository using the default Ubuntu image.
+- Run `just codespaces-bootstrap` once to install `gh`, `pv`, and other helpers that the
+  download + flash scripts expect.
+- Use `just install-pi-image` or `just download-pi-image` to populate `~/sugarkube/images` with
+  the latest release, or trigger `sudo just flash-pi FLASH_DEVICE=/dev/sdX` when you attach a USB
+  flasher to the Codespace via the browser or VS Code desktop.
+- `just doctor` remains available to validate tooling from within the Codespace without juggling
+  Makefiles or bespoke shell aliases.


### PR DESCRIPTION
what: add a justfile mirroring make targets and codespaces bootstrap docs
why: deliver the checklist item for minimal-tooling flashing automation
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68ccd3ce8378832f8313503c01f6efcc