### PR TITLE
Add SD rollback helper and recovery guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,12 @@ IMAGE_PATH := $(IMAGE_DIR)/$(IMAGE_NAME)
 INSTALL_CMD ?= $(CURDIR)/scripts/install_sugarkube_image.sh
 FLASH_CMD ?= $(CURDIR)/scripts/flash_pi_media.sh
 DOWNLOAD_CMD ?= $(CURDIR)/scripts/download_pi_image.sh
+ROLLBACK_CMD ?= $(CURDIR)/scripts/rollback_to_sd.sh
 DOWNLOAD_ARGS ?=
 FLASH_ARGS ?= --assume-yes
+ROLLBACK_ARGS ?=
 
-.PHONY: install-pi-image download-pi-image flash-pi doctor
+.PHONY: install-pi-image download-pi-image flash-pi doctor rollback-to-sd
 
 install-pi-image:
 	$(INSTALL_CMD) --dir '$(IMAGE_DIR)' --image '$(IMAGE_PATH)' $(DOWNLOAD_ARGS)
@@ -26,3 +28,6 @@ flash-pi: install-pi-image
 
 doctor:
 	$(CURDIR)/scripts/sugarkube_doctor.sh
+
+rollback-to-sd:
+	$(ROLLBACK_CMD) $(ROLLBACK_ARGS)

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -70,7 +70,9 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
   - Touch `/var/log/sugarkube/ssd-clone.done`.
 - [ ] Support dry-run + resume for cloning to reduce user hesitation.
 - [ ] Provide post-clone validation: EEPROM boot order, fstab UUIDs, read/write stress tests.
-- [ ] Publish a recovery guide and rollback script to fall back to SD if SSD checks fail.
+- [x] Publish a recovery guide and rollback script to fall back to SD if SSD checks fail.
+  - Added `scripts/rollback_to_sd.sh` plus Makefile/just wrappers, and documented the
+    workflow in `docs/ssd_recovery.md` with dry-run guidance and report expectations.
 - [ ] Offer an opt-in SSD health monitor (SMART/wear checks).
 
 ---

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -95,6 +95,21 @@ Build a Raspberry Pi OS image that boots with k3s and the
 The image is now ready for additional repositories or joining a multi-node
 k3s cluster.
 
+### Recover from SSD issues
+
+If an SSD migration fails or you need to boot from the original SD card again,
+run the rollback helper to restore `/boot/cmdline.txt` and `/etc/fstab` to the
+SD defaults:
+
+```bash
+sudo ./scripts/rollback_to_sd.sh --dry-run
+```
+
+Review the planned changes, drop `--dry-run` when ready, then reboot. The script
+stores backups and writes a Markdown report to `/boot/sugarkube-rollback-report.md`.
+See [SSD Recovery and Rollback](./ssd_recovery.md) for the full walkthrough and
+Makefile/justfile shortcuts.
+
 ## Codespaces-friendly automation
 
 - Launch a new GitHub Codespace on this repository using the default Ubuntu image.

--- a/docs/ssd_recovery.md
+++ b/docs/ssd_recovery.md
@@ -1,0 +1,113 @@
+# SSD Recovery and Rollback
+
+When an SSD migration stalls or the cloned drive fails later, falling back to the
+original SD card helps the cluster boot cleanly while you investigate.
+This guide explains how to inspect the current boot device, run the automated
+rollback helper, and verify the system is back on the SD root filesystem.
+
+## Before you begin
+
+1. Make sure you still have the SD card that shipped with the `sugarkube`
+   image inserted in the Raspberry Pi.
+2. Connect a keyboard/monitor or SSH session so you can run commands locally.
+3. Identify whether you are already booted from the SD card:
+   ```bash
+   findmnt /
+   ```
+   If the source column shows `mmcblk0p2` or `PARTUUID` that matches the SD
+   card, you are already on the SD card and no rollback is necessary.
+
+## Preview the rollback
+
+The repository now ships `scripts/rollback_to_sd.sh`, which rewrites
+`/boot/cmdline.txt` and `/etc/fstab` to point at the SD card and records the
+current configuration for auditing. Run a dry run first to confirm what the
+script will touch:
+
+```bash
+sudo ./scripts/rollback_to_sd.sh --dry-run
+```
+
+The helper reports:
+
+- The current root and boot sources (and their PARTUUIDs).
+- The detected SD card devices (`/dev/mmcblk0p1` and `/dev/mmcblk0p2` by
+  default) and their PARTUUIDs.
+- The backup directory under `/var/log/sugarkube/rollback/` that would store
+  copies of `cmdline.txt` and `fstab`.
+
+If your SD card is exposed on different device nodes (for example `mmcblk1` on
+Compute Module carriers) override the defaults:
+
+```bash
+sudo ./scripts/rollback_to_sd.sh \
+  --dry-run \
+  --sd-boot-device /dev/mmcblk1p1 \
+  --sd-root-device /dev/mmcblk1p2
+```
+
+## Apply the rollback
+
+When you are satisfied with the dry run, remove `--dry-run` (and keep any
+custom device overrides):
+
+```bash
+sudo ./scripts/rollback_to_sd.sh
+```
+
+Key behavior:
+
+1. Backups of `/boot/cmdline.txt` and `/etc/fstab` are stored in
+   `/var/log/sugarkube/rollback/<timestamp>/` before any edits.
+2. `root=PARTUUID` in `cmdline.txt` is set to the SD card's root partition.
+3. The `/` and `/boot` entries in `/etc/fstab` are rewritten to the SD card
+   PARTUUIDs while other entries remain untouched.
+4. A Markdown report is written to `/boot/sugarkube-rollback-report.md` that
+   summarizes the changes and the detected devices.
+5. `sync` is called to flush writes before exiting.
+
+Finally, reboot the Raspberry Pi:
+
+```bash
+sudo reboot
+```
+
+After the system comes back, confirm the rollback succeeded:
+
+```bash
+findmnt /
+cat /boot/sugarkube-rollback-report.md
+```
+
+The root filesystem should now point to `mmcblk0p2` (or your equivalent SD
+partition). Review the report for the recorded devices, backup path, and next
+steps.
+
+## Using the Makefile and justfile shortcuts
+
+Two convenience wrappers call the new helper:
+
+- GNU Make:
+  ```bash
+  sudo make rollback-to-sd
+  ```
+- [just](https://github.com/casey/just):
+  ```bash
+  sudo just rollback-to-sd
+  ```
+
+Both commands respect the `ROLLBACK_ARGS` environment variable. For example, to
+preview with a different SD root device:
+
+```bash
+sudo ROLLBACK_ARGS='--dry-run --sd-root-device /dev/mmcblk1p2' make rollback-to-sd
+```
+
+## Next steps after rolling back
+
+- Investigate SSD health using `smartctl`, vendor dashboards, or by connecting
+  the drive to another system.
+- If you reattempt cloning later, keep the rollback backups around so you can
+  compare the new configuration.
+- Update your troubleshooting notes with the Markdown report stored on `/boot`
+  so future incidents are easier to triage.

--- a/justfile
+++ b/justfile
@@ -9,6 +9,8 @@ download_cmd := env_var_or_default("DOWNLOAD_CMD", justfile_directory() + "/scri
 download_args := env_var_or_default("DOWNLOAD_ARGS", "")
 flash_args := env_var_or_default("FLASH_ARGS", "--assume-yes")
 flash_device := env_var_or_default("FLASH_DEVICE", "")
+rollback_cmd := env_var_or_default("ROLLBACK_CMD", justfile_directory() + "/scripts/rollback_to_sd.sh")
+rollback_args := env_var_or_default("ROLLBACK_ARGS", "")
 
 _default:
     @just --list
@@ -39,6 +41,11 @@ flash-pi: install-pi-image
 # Usage: just doctor
 doctor:
     "{{justfile_directory()}}/scripts/sugarkube_doctor.sh"
+
+# Revert cmdline.txt and fstab entries back to the SD card defaults
+# Usage: sudo just rollback-to-sd
+rollback-to-sd:
+    "{{rollback_cmd}}" {{rollback_args}}
 
 # Install CLI dependencies inside GitHub Codespaces or fresh containers
 # Usage: just codespaces-bootstrap

--- a/scripts/rollback_to_sd.sh
+++ b/scripts/rollback_to_sd.sh
@@ -129,6 +129,19 @@ PYCODE
   mv "$tmp" "$source"
 }
 
+backup_file() {
+  local source="$1"
+  local destination="$2"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] Would copy $source to $destination"
+    return
+  fi
+
+  mkdir -p "$(dirname "$destination")"
+  cp -- "$source" "$destination"
+}
+
 write_report() {
   local path="$1"
   local content="$2"

--- a/scripts/rollback_to_sd.sh
+++ b/scripts/rollback_to_sd.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: rollback_to_sd.sh [options]
+
+Revert /boot/cmdline.txt and /etc/fstab to boot from the onboard SD card.
+
+Options:
+  --sd-boot-device PATH   Override SD boot partition device (default: /dev/mmcblk0p1)
+  --sd-root-device PATH   Override SD root partition device (default: /dev/mmcblk0p2)
+  --boot-dir PATH         Path where /boot is mounted (default: /boot)
+  --cmdline PATH          Path to cmdline.txt (default: BOOT_DIR/cmdline.txt)
+  --fstab PATH            Path to fstab (default: /etc/fstab)
+  --report PATH           Write a Markdown report to PATH (default: /boot/sugarkube-rollback-report.md)
+  --dry-run               Show actions without modifying files
+  -h, --help              Show this help message
+USAGE
+}
+
+log() {
+  printf '==> %s\n' "$*"
+}
+
+err() {
+  printf 'error: %s\n' "$*" >&2
+}
+
+die() {
+  err "$1"
+  exit "${2:-1}"
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    die "Missing required command: $1"
+  fi
+}
+
+get_partuuid() {
+  local source="$1"
+  if [[ "$source" == PARTUUID=* ]]; then
+    printf '%s\n' "${source#PARTUUID=}"
+    return
+  fi
+  if [[ "$source" == /dev/* ]]; then
+    blkid -s PARTUUID -o value "$source"
+    return
+  fi
+  printf '\n'
+}
+
+rewrite_cmdline() {
+  local source="$1"
+  local target_uuid="$2"
+  local tmp
+
+  tmp="$(mktemp)"
+  python3 - "$source" "$target_uuid" "$tmp" <<'PYCODE'
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+uuid = sys.argv[2]
+tmp = pathlib.Path(sys.argv[3])
+content = path.read_text()
+pattern = re.compile(r"root=PARTUUID=\S+")
+if not pattern.search(content):
+    print("cmdline.txt does not contain a root=PARTUUID entry", file=sys.stderr)
+    sys.exit(1)
+updated = pattern.sub(f"root=PARTUUID={uuid}", content, count=1)
+tmp.write_text(updated)
+PYCODE
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] Would set root PARTUUID to $target_uuid in $source"
+    rm -f "$tmp"
+    return
+  fi
+
+  mv "$tmp" "$source"
+}
+
+rewrite_fstab() {
+  local source="$1"
+  local boot_uuid="$2"
+  local root_uuid="$3"
+  local tmp
+
+  tmp="$(mktemp)"
+  python3 - "$source" "$boot_uuid" "$root_uuid" "$tmp" <<'PYCODE'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+boot_uuid = sys.argv[2]
+root_uuid = sys.argv[3]
+tmp = pathlib.Path(sys.argv[4])
+lines = path.read_text().splitlines()
+updated = []
+for line in lines:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        updated.append(line)
+        continue
+    parts = line.split()
+    if len(parts) < 2:
+        updated.append(line)
+        continue
+    mountpoint = parts[1]
+    if mountpoint == "/":
+        parts[0] = f"PARTUUID={root_uuid}"
+        line = "\t".join(parts)
+    elif mountpoint == "/boot":
+        parts[0] = f"PARTUUID={boot_uuid}"
+        line = "\t".join(parts)
+    updated.append(line)
+tmp.write_text("\n".join(updated) + "\n")
+PYCODE
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] Would update / and /boot PARTUUIDs in $source"
+    rm -f "$tmp"
+    return
+  fi
+
+  mv "$tmp" "$source"
+}
+
+write_report() {
+  local path="$1"
+  local content="$2"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] Would write rollback report to $path"
+    return
+  fi
+
+  printf '%s\n' "$content" >"$path"
+}
+
+SD_BOOT_DEVICE="/dev/mmcblk0p1"
+SD_ROOT_DEVICE="/dev/mmcblk0p2"
+BOOT_DIR="/boot"
+CMDLINE_FILE=""
+FSTAB_FILE="/etc/fstab"
+REPORT_PATH="/boot/sugarkube-rollback-report.md"
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sd-boot-device)
+      [[ $# -ge 2 ]] || die "--sd-boot-device requires a value"
+      SD_BOOT_DEVICE="$2"
+      shift 2
+      ;;
+    --sd-root-device)
+      [[ $# -ge 2 ]] || die "--sd-root-device requires a value"
+      SD_ROOT_DEVICE="$2"
+      shift 2
+      ;;
+    --boot-dir)
+      [[ $# -ge 2 ]] || die "--boot-dir requires a value"
+      BOOT_DIR="$2"
+      shift 2
+      ;;
+    --cmdline)
+      [[ $# -ge 2 ]] || die "--cmdline requires a value"
+      CMDLINE_FILE="$2"
+      shift 2
+      ;;
+    --fstab)
+      [[ $# -ge 2 ]] || die "--fstab requires a value"
+      FSTAB_FILE="$2"
+      shift 2
+      ;;
+    --report)
+      [[ $# -ge 2 ]] || die "--report requires a value"
+      REPORT_PATH="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      die "Unknown option: $1"
+      ;;
+  esac
+done
+
+if [ -z "$CMDLINE_FILE" ]; then
+  CMDLINE_FILE="$BOOT_DIR/cmdline.txt"
+fi
+
+if [ "$DRY_RUN" -ne 1 ] && [ "$(id -u)" -ne 0 ]; then
+  die "Run as root or pass --dry-run to preview changes"
+fi
+
+require_cmd blkid
+require_cmd findmnt
+require_cmd python3
+
+if [ ! -b "$SD_BOOT_DEVICE" ]; then
+  die "SD boot device not found: $SD_BOOT_DEVICE"
+fi
+if [ ! -b "$SD_ROOT_DEVICE" ]; then
+  die "SD root device not found: $SD_ROOT_DEVICE"
+fi
+if [ ! -f "$CMDLINE_FILE" ]; then
+  die "cmdline file not found: $CMDLINE_FILE"
+fi
+if [ ! -f "$FSTAB_FILE" ]; then
+  die "fstab file not found: $FSTAB_FILE"
+fi
+
+SD_BOOT_UUID="$(blkid -s PARTUUID -o value "$SD_BOOT_DEVICE" || true)"
+SD_ROOT_UUID="$(blkid -s PARTUUID -o value "$SD_ROOT_DEVICE" || true)"
+if [ -z "$SD_BOOT_UUID" ] || [ -z "$SD_ROOT_UUID" ]; then
+  die "Unable to read PARTUUIDs for $SD_BOOT_DEVICE or $SD_ROOT_DEVICE"
+fi
+
+CURRENT_ROOT_SOURCE="$(findmnt -no SOURCE /)"
+CURRENT_BOOT_SOURCE="$(findmnt -no SOURCE "$BOOT_DIR" 2>/dev/null || true)"
+CURRENT_ROOT_UUID="$(get_partuuid "$CURRENT_ROOT_SOURCE" || true)"
+CURRENT_BOOT_UUID="$(get_partuuid "$CURRENT_BOOT_SOURCE" || true)"
+
+log "Detected SD boot device: $SD_BOOT_DEVICE (PARTUUID=$SD_BOOT_UUID)"
+log "Detected SD root device: $SD_ROOT_DEVICE (PARTUUID=$SD_ROOT_UUID)"
+if [ -n "$CURRENT_ROOT_SOURCE" ]; then
+  log "Current root source: $CURRENT_ROOT_SOURCE"
+fi
+if [ -n "$CURRENT_ROOT_UUID" ]; then
+  log "Current root PARTUUID: $CURRENT_ROOT_UUID"
+fi
+if [ -n "$CURRENT_BOOT_SOURCE" ]; then
+  log "Current boot source: $CURRENT_BOOT_SOURCE"
+fi
+if [ -n "$CURRENT_BOOT_UUID" ]; then
+  log "Current boot PARTUUID: $CURRENT_BOOT_UUID"
+fi
+
+BACKUP_DIR="/var/log/sugarkube/rollback/$(date -u +%Y%m%dT%H%M%SZ)"
+if [ "$DRY_RUN" -eq 1 ]; then
+  log "[dry-run] Would create backup directory $BACKUP_DIR"
+else
+  mkdir -p "$BACKUP_DIR"
+fi
+
+backup_file "$CMDLINE_FILE" "$BACKUP_DIR/cmdline.txt"
+backup_file "$FSTAB_FILE" "$BACKUP_DIR/fstab"
+
+rewrite_cmdline "$CMDLINE_FILE" "$SD_ROOT_UUID"
+rewrite_fstab "$FSTAB_FILE" "$SD_BOOT_UUID" "$SD_ROOT_UUID"
+
+if [ "$DRY_RUN" -ne 1 ]; then
+  sync
+fi
+
+timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+read -r -d '' REPORT <<EOF_REPORT || true
+# Sugarkube SD Rollback
+
+- Timestamp: $timestamp UTC
+- Backup directory: $BACKUP_DIR
+- Previous root source: ${CURRENT_ROOT_SOURCE:-unknown}
+- Previous root PARTUUID: ${CURRENT_ROOT_UUID:-unknown}
+- Previous boot source: ${CURRENT_BOOT_SOURCE:-unknown}
+- Previous boot PARTUUID: ${CURRENT_BOOT_UUID:-unknown}
+- Target SD boot PARTUUID: $SD_BOOT_UUID
+- Target SD root PARTUUID: $SD_ROOT_UUID
+- Updated files:
+  - $CMDLINE_FILE
+  - $FSTAB_FILE
+
+Next steps:
+1. Reboot the Raspberry Pi.
+2. Confirm the system is running from the SD card with `findmnt /`.
+3. Investigate SSD health before attempting another migration.
+EOF_REPORT
+
+write_report "$REPORT_PATH" "$REPORT"
+
+log "Rollback complete. Reboot to finish applying changes."
+if [ "$DRY_RUN" -eq 1 ]; then
+  log "Dry run complete; no files were changed."
+else
+  log "Report written to $REPORT_PATH"
+fi


### PR DESCRIPTION
## Summary
- add rollback_to_sd.sh for restoring cmdline.txt and fstab to the SD card
- document the recovery workflow and surface it from the quickstart
- wire the helper into make/just targets and tick the checklist item

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68ccd8eef638832f9c5d3921d1edce52