### PR TITLE
Add first boot verifier reporting

### DIFF
--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -55,7 +55,10 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
   - Waits for network, expands filesystem.
   - Runs `pi_node_verifier.sh` automatically.
   - Publishes HTML/JSON status (cloud-init, k3s, token.place, dspace) to `/boot/first-boot-report`.
-- [ ] Log verifier results and migration steps to `/boot/first-boot-report.txt`.
+- [x] Log verifier results and migration steps to `/boot/first-boot-report.txt`.
+  - `pi_node_verifier.sh` now writes Markdown summaries (hardware, cloud-init,
+    checksum checks) to `/boot/first-boot-report.txt` and ingests migration
+    events recorded by `scripts/cloud-init/start-projects.sh`.
 - [ ] Add self-healing units that retry container pulls, rerun `cloud-init clean`, or reboot into maintenance with actionable logs.
 - [ ] Provide optional telemetry hooks to publish anonymized health data to a shared dashboard.
 

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -91,6 +91,14 @@ Build a Raspberry Pi OS image that boots with k3s and the
   ```bash
   sudo journalctl -u projects-compose.service --no-pager
   ```
+- Every verifier run now appends a Markdown summary to `/boot/first-boot-report.txt`.
+  The report captures hardware details, `cloud-init` status, the results from
+  `pi_node_verifier.sh`, and any provisioning or migration steps recorded by
+  `/opt/projects/start-projects.sh`. Inspect the file locally after ejecting the
+  boot media or on the Pi itself:
+  ```bash
+  sudo cat /boot/first-boot-report.txt
+  ```
 
 The image is now ready for additional repositories or joining a multi-node
 k3s cluster.

--- a/scripts/cloud-init/start-projects.sh
+++ b/scripts/cloud-init/start-projects.sh
@@ -3,9 +3,22 @@ set -euo pipefail
 
 svc="projects-compose.service"
 compose_path="/opt/projects/docker-compose.yml"
+log_dir="/var/log/sugarkube"
+migration_log="${log_dir}/migrations.log"
+
+mkdir -p "$log_dir"
+
+log_migration_step() {
+  local ts
+  ts=$(date --iso-8601=seconds 2>/dev/null || date)
+  printf '%s %s\n' "$ts" "$1" >>"$migration_log" 2>/dev/null || true
+}
+
+log_migration_step "start-projects.sh invoked"
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker not found; skipping ${svc}" >&2
+  log_migration_step "skipped: docker not installed"
   exit 0
 fi
 
@@ -13,17 +26,23 @@ fi
 docker --version || true
 if ! docker compose version >/dev/null 2>&1; then
   echo "docker compose plugin not found; skipping ${svc}" >&2
+  log_migration_step "skipped: docker compose plugin missing"
   exit 0
 fi
 docker compose version
 
 # Seed .env files before the service starts so defaults exist
 if [ -x /opt/projects/init-env.sh ]; then
-  /opt/projects/init-env.sh || true
+  if /opt/projects/init-env.sh; then
+    log_migration_step "init-env.sh completed"
+  else
+    log_migration_step "init-env.sh failed (continuing)"
+  fi
 fi
 
 if ! command -v systemctl >/dev/null 2>&1; then
   echo "systemctl not found; skipping ${svc}" >&2
+  log_migration_step "skipped: systemctl unavailable"
   exit 0
 fi
 
@@ -34,8 +53,10 @@ fi
 
 if systemctl list-unit-files | grep -q "^${svc}"; then
   systemctl enable --now "${svc}"
+  log_migration_step "enabled ${svc}"
 else
   echo "${svc} not found; skipping" >&2
+  log_migration_step "skipped: ${svc} not installed"
 fi
 
 # extra-start

--- a/scripts/pi_node_verifier.sh
+++ b/scripts/pi_node_verifier.sh
@@ -1,23 +1,68 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+warn() {
+  printf 'warning: %s\n' "$1" >&2
+}
+
 JSON=false
-for arg in "$@"; do
-  case "$arg" in
-    --json) JSON=true ;;
+REPORT_PATH=""
+ENABLE_LOG=true
+DEFAULT_REPORT="/boot/first-boot-report.txt"
+MIGRATION_LOG=${MIGRATION_LOG:-/var/log/sugarkube/migrations.log}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json)
+      JSON=true
+      ;;
+    --log)
+      if [[ $# -lt 2 ]]; then
+        echo "--log requires a path" >&2
+        exit 1
+      fi
+      REPORT_PATH="$2"
+      shift
+      ;;
+    --log=*)
+      REPORT_PATH="${1#*=}"
+      ;;
+    --no-log)
+      ENABLE_LOG=false
+      ;;
     --help)
-      echo "Usage: $0 [--json]"
+      cat <<'EOF'
+Usage: pi_node_verifier.sh [--json] [--log PATH] [--no-log]
+
+Options:
+  --json       Emit machine-readable JSON results.
+  --log PATH   Append a Markdown summary to PATH.
+               Defaults to /boot/first-boot-report.txt when writable.
+  --no-log     Disable report generation entirely.
+  --help       Show this message.
+EOF
       exit 0
       ;;
     *)
-      echo "Unknown option: $arg" >&2
-      echo "Usage: $0 [--json]" >&2
+      echo "Unknown option: $1" >&2
+      echo "Usage: $0 [--json] [--log PATH] [--no-log]" >&2
       exit 1
       ;;
   esac
+  shift
 done
 
+if $ENABLE_LOG && [[ -z "$REPORT_PATH" ]] && [[ -d /boot ]]; then
+  if [[ -w /boot ]]; then
+    REPORT_PATH="$DEFAULT_REPORT"
+  else
+    warn "/boot exists but is not writable; skipping default report path"
+  fi
+fi
+
 json_parts=()
+check_names=()
+check_statuses=()
 print_result() {
   local name="$1"
   local status="$2"
@@ -25,6 +70,90 @@ print_result() {
     printf '%s: %s\n' "$name" "$status"
   fi
   json_parts+=('{"name":"'"$name"'","status":"'"$status"'"}')
+  check_names+=("$name")
+  check_statuses+=("$status")
+}
+
+append_report() {
+  local dest="$1"
+  local required_tools=(mktemp date hostname uname mkdir cat sed cut tr)
+  local missing=false
+  for tool in "${required_tools[@]}"; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      missing=true
+      break
+    fi
+  done
+  if $missing; then
+    return
+  fi
+
+  local timestamp
+  timestamp=$(date --iso-8601=seconds 2>/dev/null || date)
+  local host
+  host=$(hostname 2>/dev/null || echo "unknown")
+  local kernel
+  kernel=$(uname -sr 2>/dev/null || echo "unknown")
+  local model=""
+  if [[ -r /proc/device-tree/model ]]; then
+    model=$(tr -d '\0' </proc/device-tree/model)
+  elif command -v hostnamectl >/dev/null 2>&1; then
+    model=$(hostnamectl 2>/dev/null || true)
+    model=$(printf '%s\n' "$model" | head -n 1 | cut -d':' -f2- | sed 's/^ *//')
+  fi
+
+  local tmp
+  tmp=$(mktemp)
+  {
+    printf '## %s\n\n' "$timestamp"
+    printf '* Hostname: `%s`\n' "$host"
+    printf '* Kernel: `%s`\n' "$kernel"
+    if [[ -n "$model" ]]; then
+      printf '* Hardware: `%s`\n' "$model"
+    fi
+    printf '\n### Verifier Checks\n\n'
+    printf '| Check | Status |\n'
+    printf '| --- | --- |\n'
+    local idx=0
+    local total=${#check_names[@]}
+    while [[ $idx -lt $total ]]; do
+      printf '| %s | %s |\n' "${check_names[$idx]}" "${check_statuses[$idx]}"
+      idx=$((idx + 1))
+    done
+
+    printf '\n### Migration Steps\n\n'
+    if [[ -f "$MIGRATION_LOG" && -s "$MIGRATION_LOG" ]]; then
+      while IFS= read -r line; do
+        printf '* %s\n' "$line"
+      done <"$MIGRATION_LOG"
+    else
+      printf '_No migration steps recorded yet._\n'
+    fi
+
+    if command -v cloud-init >/dev/null 2>&1; then
+      printf '\n### cloud-init Status\n\n'
+      if ! cloud-init status --long 2>/dev/null | sed 's/^/    /'; then
+        printf '    (cloud-init status unavailable)\n'
+      fi
+    fi
+
+    if command -v lsblk >/dev/null 2>&1; then
+      printf '\n### Storage Snapshot\n\n'
+      if ! lsblk -o NAME,SIZE,MODEL,SERIAL 2>/dev/null | sed 's/^/    /'; then
+        printf '    (lsblk output unavailable)\n'
+      fi
+    fi
+
+    printf '\n'
+  } >"$tmp"
+
+  mkdir -p "$(dirname "$dest")" >/dev/null 2>&1 || true
+  if cat "$tmp" >>"$dest"; then
+    :
+  else
+    warn "Failed to append verifier report to $dest"
+  fi
+  rm -f "$tmp"
 }
 
 # cgroup memory
@@ -78,6 +207,10 @@ if command -v k3s >/dev/null 2>&1; then
   fi
 else
   print_result "k3s_check_config" "skip"
+fi
+
+if $ENABLE_LOG && [[ -n "$REPORT_PATH" ]]; then
+  append_report "$REPORT_PATH"
 fi
 
 if $JSON; then


### PR DESCRIPTION
## Summary
- add a Markdown report generator to `pi_node_verifier.sh` so first boot runs append to `/boot/first-boot-report.txt`
- capture provisioning and migration steps from `scripts/cloud-init/start-projects.sh`
- document the new report flow and tick the checklist item

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68ccd8eef638832f9c5d3921d1edce52