### PR TITLE
Add sanitized kubeconfig export on first boot

### DIFF
--- a/docs/network_setup.md
+++ b/docs/network_setup.md
@@ -125,6 +125,10 @@ IP. Appending the `KUBECONFIG` line to your shell profile makes the setting
 persistent, and `kubectl get nodes` confirms your workstation can reach the
 cluster.
 
+> Tip: You can also grab `/boot/sugarkube-kubeconfig` from the boot volume without SSH.
+> The export redacts client keys while preserving cluster endpoints, making it safe to share
+> connection details with operators who only need the cluster address and CA bundle.
+
 See the deployment guide at
 [token.place](https://github.com/futuroptimist/token.place) for a detailed
 walkthrough. For more options consult the

--- a/docs/pi_headless_provisioning.md
+++ b/docs/pi_headless_provisioning.md
@@ -35,7 +35,10 @@ Recommended options:
 - Configure Wi-Fi credentials using `wifis`.
 - Inject optional environment variables for services like Cloudflare Tunnels or token.place secrets.
 
-The default template writes a kubeconfig and cluster bootstrap token to `/boot/sugarkube/` so operators can join the cluster without SSH.
+The base image now writes a sanitized kubeconfig to `/boot/sugarkube-kubeconfig` once k3s is
+online, so you can collect cluster endpoints without SSH. The default template still seeds
+`/boot/sugarkube/` with placeholders for bootstrap tokens or additional secrets you may want to
+mirror on first boot.
 
 ## Inject secrets safely
 
@@ -79,6 +82,10 @@ ssh sugaradmin@sugarkube-node01.local
 ```bash
 sudo /usr/local/bin/pi_node_verifier.sh --full
 ```
+
+5. (Optional) Copy `/boot/sugarkube-kubeconfig` from another machine to share cluster endpoints
+   with teammates. The export redacts client keys and tokens—regenerate a full admin config later
+   using `sudo k3s kubectl config view --raw` before authenticating from a workstation.
 
 Successful runs leave `/boot/first-boot-report.json` and `/var/log/sugarkube/first-boot.ok` for later auditing.
 

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -93,7 +93,10 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
 - [ ] Provide post-boot hooks that apply pinned Helm/chart bundles and fail fast with logs if health checks fail.
 - [ ] Bundle sample datasets and token.place collections for first-launch validation.
 - [ ] Document and script multi-node join rehearsal for scaling clusters.
-- [ ] Store kubeconfig (sanitized) in `/boot/sugarkube-kubeconfig` for retrieval without SSH.
+- [x] Store kubeconfig (sanitized) in `/boot/sugarkube-kubeconfig` for retrieval without SSH.
+  - Added `scripts/cloud-init/export-kubeconfig.sh`, installed during image builds and invoked by
+    cloud-init to export a redacted kubeconfig and log its status. Documentation now references
+    the `/boot/sugarkube-kubeconfig` handoff path for quick operator access.
 - [ ] Bundle lightweight exporters (Grafana Agent/Netdata/Prometheus) pre-configured for cluster observability.
 
 ---

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -116,6 +116,12 @@ Build a Raspberry Pi OS image that boots with k3s and the
   ```bash
   sudo cat /boot/first-boot-report.txt
   ```
+- The boot partition now includes `/boot/sugarkube-kubeconfig`, a sanitized
+  kubeconfig export generated after k3s finishes installing. Secrets are
+  redacted, making the file safe to hand off to operators who only need cluster
+  endpoints and certificate authorities. Copy it from another machine after
+  ejecting the media, then merge real credentials using `sudo k3s kubectl
+  config view --raw` when ready to manage the cluster remotely.
 
 The image is now ready for additional repositories or joining a multi-node
 k3s cluster.

--- a/docs/templates/cloud-init/user-data.example
+++ b/docs/templates/cloud-init/user-data.example
@@ -21,9 +21,10 @@ write_files:
     owner: root:root
     permissions: '0600'
     content: |
-      # Upload the sanitized kubeconfig here after first boot.
-      # The provisioning scripts will replace this placeholder when the
-      # cluster is healthy.
+      # Optional: copy /boot/sugarkube-kubeconfig here after first boot if you
+      # want a dedicated directory for operator handoffs. The image now writes
+      # the sanitized kubeconfig to the root of the boot partition
+      # automatically once k3s is healthy.
 package_update: true
 runcmd:
   - [ bash, -c, "if [ -f /boot/secrets.env ]; then set -a; source /boot/secrets.env; set +a; fi" ]

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -98,6 +98,7 @@ CLOUDFLARED_COMPOSE_PATH="${CLOUDFLARED_COMPOSE_PATH:-${CLOUD_INIT_DIR}/docker-c
 PROJECTS_COMPOSE_PATH="${PROJECTS_COMPOSE_PATH:-${CLOUD_INIT_DIR}/docker-compose.yml}"
 START_PROJECTS_PATH="${START_PROJECTS_PATH:-${CLOUD_INIT_DIR}/start-projects.sh}"
 INIT_ENV_PATH="${INIT_ENV_PATH:-${CLOUD_INIT_DIR}/init-env.sh}"
+EXPORT_KUBECONFIG_PATH="${EXPORT_KUBECONFIG_PATH:-${CLOUD_INIT_DIR}/export-kubeconfig.sh}"
 
 if [ ! -f "${CLOUD_INIT_PATH}" ]; then
   echo "Cloud-init file not found: ${CLOUD_INIT_PATH}" >&2
@@ -162,6 +163,14 @@ if [ ! -f "${INIT_ENV_PATH}" ]; then
 fi
 if [ ! -s "${INIT_ENV_PATH}" ]; then
   echo "Init env script is empty: ${INIT_ENV_PATH}" >&2
+  exit 1
+fi
+if [ ! -f "${EXPORT_KUBECONFIG_PATH}" ]; then
+  echo "Export kubeconfig script not found: ${EXPORT_KUBECONFIG_PATH}" >&2
+  exit 1
+fi
+if [ ! -s "${EXPORT_KUBECONFIG_PATH}" ]; then
+  echo "Export kubeconfig script is empty: ${EXPORT_KUBECONFIG_PATH}" >&2
   exit 1
 fi
 
@@ -256,6 +265,9 @@ fi
 # Bundle pi_node_verifier and optionally clone repos into the image
 install -Dm755 "${REPO_ROOT}/scripts/pi_node_verifier.sh" \
   "${WORK_DIR}/pi-gen/stage2/02-sugarkube-tools/files/usr/local/sbin/pi_node_verifier.sh"
+
+install -Dm755 "${EXPORT_KUBECONFIG_PATH}" \
+  "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/export-kubeconfig.sh"
 
 CLONE_SUGARKUBE="${CLONE_SUGARKUBE:-false}"
 CLONE_TOKEN_PLACE="${CLONE_TOKEN_PLACE:-true}"

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -177,6 +177,7 @@ runcmd:
   - [systemctl, enable, --now, docker]
   - [bash, -c, 'curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--disable traefik" sh -']
   - [/opt/projects/start-projects.sh]  # projects-runcmd
+  - [/opt/sugarkube/export-kubeconfig.sh]
   - [bash, -c, 'apt-get autoremove -y']
   - [bash, -c, 'apt-get clean && rm -rf /var/lib/apt/lists/*']
   - |

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -482,6 +482,11 @@ def _run_build_script(tmp_path, env):
     shutil.copy(init_env_src, init_env_dest)
     init_env_dest.chmod(0o755)
 
+    export_kubeconfig_src = cloud_init_src / "export-kubeconfig.sh"
+    export_kubeconfig_dest = ci_dir / "export-kubeconfig.sh"
+    shutil.copy(export_kubeconfig_src, export_kubeconfig_dest)
+    export_kubeconfig_dest.chmod(0o755)
+
     result = subprocess.run(
         ["/bin/bash", str(script)],
         env=env,


### PR DESCRIPTION
## Summary
- export a sanitized kubeconfig to /boot via cloud-init
- install the exporter during image builds, update docs and tests
- tick the checklist item for /boot/sugarkube-kubeconfig handoffs

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68ccf8ff136c832fb4a840c947970e5c