### PR TITLE
✨ : export sanitized kubeconfig to boot

### DIFF
--- a/docs/pi_headless_provisioning.md
+++ b/docs/pi_headless_provisioning.md
@@ -35,7 +35,12 @@ Recommended options:
 - Configure Wi-Fi credentials using `wifis`.
 - Inject optional environment variables for services like Cloudflare Tunnels or token.place secrets.
 
-The default template writes a kubeconfig and cluster bootstrap token to `/boot/sugarkube/` so operators can join the cluster without SSH.
+The default template writes a kubeconfig and cluster bootstrap token to `/boot/sugarkube/`
+so operators can join the cluster without SSH. On first boot,
+`sugarkube-export-kubeconfig.service` rewrites the kubeconfig with the Pi's mDNS
+hostname (or a custom endpoint) and stores the sanitized copy at
+`/boot/sugarkube-kubeconfig`, mirroring it back into `/boot/sugarkube/kubeconfig`
+for compatibility.
 
 ## Inject secrets safely
 

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -93,7 +93,7 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
 - [ ] Provide post-boot hooks that apply pinned Helm/chart bundles and fail fast with logs if health checks fail.
 - [ ] Bundle sample datasets and token.place collections for first-launch validation.
 - [ ] Document and script multi-node join rehearsal for scaling clusters.
-- [ ] Store kubeconfig (sanitized) in `/boot/sugarkube-kubeconfig` for retrieval without SSH.
+- [x] Store kubeconfig (sanitized) in `/boot/sugarkube-kubeconfig` for retrieval without SSH.
 - [ ] Bundle lightweight exporters (Grafana Agent/Netdata/Prometheus) pre-configured for cluster observability.
 
 ---

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -116,6 +116,17 @@ Build a Raspberry Pi OS image that boots with k3s and the
   ```bash
   sudo cat /boot/first-boot-report.txt
   ```
+- A sanitized kubeconfig is written to `/boot/sugarkube-kubeconfig` and mirrored
+  to `/boot/sugarkube/kubeconfig` when the legacy directory exists. Mount the
+  boot volume on another machine and copy the file to your workstation:
+  ```bash
+  sudo mount /dev/sdX1 /mnt/pi-boot
+  sudo cp /mnt/pi-boot/sugarkube-kubeconfig ~/.kube/config
+  sudo umount /mnt/pi-boot
+  ```
+  Override the endpoint by setting `SUGARKUBE_API_HOST`, `SUGARKUBE_API_PORT`, or
+  `SUGARKUBE_API_ENDPOINT` before first boot when custom DNS entries or
+  load-balancer addresses are required.
 
 The image is now ready for additional repositories or joining a multi-node
 k3s cluster.

--- a/docs/templates/cloud-init/user-data.example
+++ b/docs/templates/cloud-init/user-data.example
@@ -21,9 +21,10 @@ write_files:
     owner: root:root
     permissions: '0600'
     content: |
-      # Upload the sanitized kubeconfig here after first boot.
-      # The provisioning scripts will replace this placeholder when the
-      # cluster is healthy.
+      # Placeholder file updated automatically by
+      # /usr/local/sbin/sugarkube-export-kubeconfig.sh.
+      # The script writes a sanitized kubeconfig to this location and to
+      # /boot/sugarkube-kubeconfig once k3s is running.
 package_update: true
 runcmd:
   - [ bash, -c, "if [ -f /boot/secrets.env ]; then set -a; source /boot/secrets.env; set +a; fi" ]

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -256,6 +256,8 @@ fi
 # Bundle pi_node_verifier and optionally clone repos into the image
 install -Dm755 "${REPO_ROOT}/scripts/pi_node_verifier.sh" \
   "${WORK_DIR}/pi-gen/stage2/02-sugarkube-tools/files/usr/local/sbin/pi_node_verifier.sh"
+install -Dm755 "${REPO_ROOT}/scripts/sugarkube_export_kubeconfig.sh" \
+  "${WORK_DIR}/pi-gen/stage2/02-sugarkube-tools/files/usr/local/sbin/sugarkube-export-kubeconfig.sh"
 
 CLONE_SUGARKUBE="${CLONE_SUGARKUBE:-false}"
 CLONE_TOKEN_PLACE="${CLONE_TOKEN_PLACE:-true}"

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -155,6 +155,35 @@ write_files:
 
       [Install]
       WantedBy=multi-user.target
+  - path: /etc/systemd/system/sugarkube-export-kubeconfig.service
+    permissions: '0644'
+    content: |
+      [Unit]
+      Description=Export sanitized kubeconfig to /boot
+      RequiresMountsFor=/boot
+      After=k3s.service
+      Wants=k3s.service
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/local/sbin/sugarkube-export-kubeconfig.sh
+      Restart=on-failure
+      RestartSec=15s
+
+      [Install]
+      WantedBy=multi-user.target
+  - path: /etc/systemd/system/sugarkube-export-kubeconfig.path
+    permissions: '0644'
+    content: |
+      [Unit]
+      Description=Monitor k3s kubeconfig for export
+
+      [Path]
+      PathExists=/etc/rancher/k3s/k3s.yaml
+      PathChanged=/etc/rancher/k3s/k3s.yaml
+
+      [Install]
+      WantedBy=multi-user.target
   # projects-end
 runcmd:
   - |
@@ -176,6 +205,7 @@ runcmd:
   - [systemctl, daemon-reexec]   # reload systemd units
   - [systemctl, enable, --now, docker]
   - [bash, -c, 'curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--disable traefik" sh -']
+  - [systemctl, enable, --now, sugarkube-export-kubeconfig.path]
   - [/opt/projects/start-projects.sh]  # projects-runcmd
   - [bash, -c, 'apt-get autoremove -y']
   - [bash, -c, 'apt-get clean && rm -rf /var/lib/apt/lists/*']

--- a/scripts/sugarkube_export_kubeconfig.sh
+++ b/scripts/sugarkube_export_kubeconfig.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  local msg="sugarkube-export-kubeconfig: $1"
+  if command -v logger >/dev/null 2>&1; then
+    logger -t sugarkube-export-kubeconfig "$1" || echo "$msg"
+  else
+    echo "$msg"
+  fi
+}
+
+SOURCE_PATH=${SUGARKUBE_KUBECONFIG_SOURCE:-/etc/rancher/k3s/k3s.yaml}
+DEST_PATH=${SUGARKUBE_KUBECONFIG_DEST:-/boot/sugarkube-kubeconfig}
+LEGACY_DEST=${SUGARKUBE_LEGACY_KUBECONFIG:-/boot/sugarkube/kubeconfig}
+WAIT_SECS=${SUGARKUBE_KUBECONFIG_WAIT_SECS:-120}
+PORT=${SUGARKUBE_API_PORT:-6443}
+ENDPOINT_OVERRIDE=${SUGARKUBE_API_ENDPOINT:-}
+
+escape_for_sed() {
+  printf '%s' "$1" | sed -e 's/[#\\&]/\\&/g'
+}
+
+wait_for_source() {
+  local waited=0
+  while [ ! -s "$SOURCE_PATH" ]; do
+    if [ "$waited" -ge "$WAIT_SECS" ]; then
+      log "source kubeconfig not found at $SOURCE_PATH after ${WAIT_SECS}s"
+      return 1
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+  return 0
+}
+
+resolve_endpoint() {
+  if [ -n "$ENDPOINT_OVERRIDE" ]; then
+    printf '%s\n' "$ENDPOINT_OVERRIDE"
+    return 0
+  fi
+  local host
+  if [ -n "${SUGARKUBE_API_HOST:-}" ]; then
+    host="$SUGARKUBE_API_HOST"
+  else
+    host=$(hostname -f 2>/dev/null || hostname 2>/dev/null || printf 'sugarkube')
+    if [[ "$host" != *.* ]]; then
+      host="${host}.local"
+    fi
+  fi
+  if [[ "$host" =~ ^https?:// ]]; then
+    printf '%s\n' "$host"
+  else
+    printf 'https://%s:%s\n' "$host" "$PORT"
+  fi
+}
+
+main() {
+  if ! wait_for_source; then
+    return 1
+  fi
+
+  if [ ! -d /boot ]; then
+    log "/boot is not mounted; cannot export kubeconfig"
+    return 1
+  fi
+
+  local endpoint
+  endpoint=$(resolve_endpoint)
+
+  umask 077
+  local tmp
+  tmp=$(mktemp)
+  local annotated
+  annotated=$(mktemp)
+  trap 'rm -f "$tmp" "$annotated"' EXIT
+
+  cp "$SOURCE_PATH" "$tmp"
+
+  if grep -q 'server: https://127.0.0.1:6443' "$tmp"; then
+    local escaped_endpoint
+    escaped_endpoint=$(escape_for_sed "$endpoint")
+    sed -i "s#server: https://127\\.0\\.0\\.1:6443#server: ${escaped_endpoint}#" "$tmp"
+  fi
+
+  {
+    printf '# Sugarkube remote kubeconfig\n'
+    printf '# Generated on %s\n' "$(date --iso-8601=seconds 2>/dev/null || date)"
+    printf '# API endpoint: %s\n\n' "$endpoint"
+    cat "$tmp"
+  } >"$annotated"
+
+  install -D -m 0600 "$annotated" "$DEST_PATH"
+  log "wrote sanitized kubeconfig to $DEST_PATH"
+
+  if [ -d "$(dirname "$LEGACY_DEST")" ] || [ -f "$LEGACY_DEST" ]; then
+    install -D -m 0600 "$annotated" "$LEGACY_DEST"
+    log "updated legacy kubeconfig at $LEGACY_DEST"
+  fi
+}
+
+main "$@"

--- a/tests/sugarkube_export_kubeconfig_test.bats
+++ b/tests/sugarkube_export_kubeconfig_test.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_TMPDIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+@test "sugarkube_export_kubeconfig rewrites server and writes legacy copy" {
+  local source="$TEST_TMPDIR/k3s.yaml"
+  cat <<'YAML' >"$source"
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: Zm9v
+    server: https://127.0.0.1:6443
+  name: default
+contexts:
+- context:
+    cluster: default
+    user: default
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: default
+  user:
+    bearer: PLACEHOLDER_VALUE
+YAML
+
+  mkdir -p "$TEST_TMPDIR/legacy"
+  local dest="$TEST_TMPDIR/exported.yaml"
+  local legacy="$TEST_TMPDIR/legacy/kubeconfig"
+
+  run env \
+    SUGARKUBE_KUBECONFIG_SOURCE="$source" \
+    SUGARKUBE_KUBECONFIG_DEST="$dest" \
+    SUGARKUBE_LEGACY_KUBECONFIG="$legacy" \
+    SUGARKUBE_API_HOST="sugarkube.example" \
+    SUGARKUBE_KUBECONFIG_WAIT_SECS=1 \
+    "$BATS_TEST_DIRNAME/../scripts/sugarkube_export_kubeconfig.sh"
+
+  [ "$status" -eq 0 ]
+  grep -q "# API endpoint: https://sugarkube.example:6443" "$dest"
+  grep -q "server: https://sugarkube.example:6443" "$dest"
+  [ -f "$legacy" ]
+  cmp -s "$dest" "$legacy"
+}
+
+@test "sugarkube_export_kubeconfig honors endpoint override" {
+  local source="$TEST_TMPDIR/k3s.yaml"
+  cat <<'YAML' >"$source"
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: Zm9v
+    server: https://127.0.0.1:6443
+  name: default
+contexts:
+- context:
+    cluster: default
+    user: default
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: default
+  user:
+    bearer: PLACEHOLDER_VALUE
+YAML
+
+  local dest="$TEST_TMPDIR/exported.yaml"
+  local endpoint="https://custom.example:7443"
+
+  run env \
+    SUGARKUBE_KUBECONFIG_SOURCE="$source" \
+    SUGARKUBE_KUBECONFIG_DEST="$dest" \
+    SUGARKUBE_API_ENDPOINT="$endpoint" \
+    SUGARKUBE_KUBECONFIG_WAIT_SECS=1 \
+    "$BATS_TEST_DIRNAME/../scripts/sugarkube_export_kubeconfig.sh"
+
+  [ "$status" -eq 0 ]
+  grep -q "# API endpoint: $endpoint" "$dest"
+  grep -q "server: $endpoint" "$dest"
+}


### PR DESCRIPTION
what: install kubeconfig export service and document retrieval
why: give operators a sanitized kubeconfig without SSH
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68ccf8ff136c832fb4a840c947970e5c