### PR TITLE
Add k3s-ready target gating cluster readiness

### DIFF
--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -85,7 +85,10 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
 ---
 
 ## k3s, token.place & dspace Reliability
-- [ ] Add a `k3s-ready.target` that depends on `projects-compose.service` and only completes when `kubectl get nodes` returns `Ready`.
+- [x] Add a `k3s-ready.target` that depends on `projects-compose.service`.
+  - The target only completes once `kubectl get nodes` reports `Ready`.
+  - Added `k3s-ready.target`/`k3s-ready.service` plus a readiness script that runs `kubectl wait` before
+    marking the target reached, with cloud-init wiring and docs for chaining workloads.
 - [ ] Extend verifier to ensure:
   - k3s node is `Ready`.
   - `projects-compose.service` is active.

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -104,6 +104,12 @@ Build a Raspberry Pi OS image that boots with k3s and the
   ```bash
   sudo systemctl status projects-compose.service
   ```
+- systemd now ships a `k3s-ready.target` that depends on the compose service and waits for
+  `kubectl get nodes` to report `Ready`. Inspect the target to confirm the cluster finished
+  bootstrapping:
+  ```bash
+  sudo systemctl status k3s-ready.target
+  ```
 - If the service fails, inspect logs to troubleshoot:
   ```bash
   sudo journalctl -u projects-compose.service --no-pager

--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -63,6 +63,7 @@ docker compose version
    docker --version
    docker compose version
    sudo systemctl status projects-compose.service
+   sudo systemctl status k3s-ready.target
    ```
 4. Verify each app on the LAN:
    ```sh

--- a/docs/projects-compose.md
+++ b/docs/projects-compose.md
@@ -6,6 +6,21 @@ and starts [token.place](https://github.com/futuroptimist/token.place) and
 [dspace](https://github.com/democratizedspace/dspace) from the shared
 `/opt/projects/docker-compose.yml` file.
 
+## Wait for k3s before chaining workloads
+
+Downstream services can now depend on `k3s-ready.target`, a systemd target that
+requires both `projects-compose.service` and a successful `kubectl wait` for the
+cluster's nodes. The `k3s-ready.service` helper polls until `kubectl get nodes`
+returns `Ready`, then marks the target `active (reached)`. Hook additional
+units into the boot flow by declaring `After=k3s-ready.target` or `Requires=` to
+ensure workloads start only after the cluster and compose stack stabilize.
+
+Inspect the current state with:
+
+```sh
+sudo systemctl status k3s-ready.target
+```
+
 ## Environment files
 
 Each project reads an `.env` file from its directory. `init-env.sh` seeds these

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -99,6 +99,7 @@ PROJECTS_COMPOSE_PATH="${PROJECTS_COMPOSE_PATH:-${CLOUD_INIT_DIR}/docker-compose
 START_PROJECTS_PATH="${START_PROJECTS_PATH:-${CLOUD_INIT_DIR}/start-projects.sh}"
 INIT_ENV_PATH="${INIT_ENV_PATH:-${CLOUD_INIT_DIR}/init-env.sh}"
 EXPORT_KUBECONFIG_PATH="${EXPORT_KUBECONFIG_PATH:-${CLOUD_INIT_DIR}/export-kubeconfig.sh}"
+K3S_READY_PATH="${K3S_READY_PATH:-${CLOUD_INIT_DIR}/k3s-ready.sh}"
 
 if [ ! -f "${CLOUD_INIT_PATH}" ]; then
   echo "Cloud-init file not found: ${CLOUD_INIT_PATH}" >&2
@@ -163,6 +164,14 @@ if [ ! -f "${INIT_ENV_PATH}" ]; then
 fi
 if [ ! -s "${INIT_ENV_PATH}" ]; then
   echo "Init env script is empty: ${INIT_ENV_PATH}" >&2
+  exit 1
+fi
+if [ ! -f "${K3S_READY_PATH}" ]; then
+  echo "k3s readiness script not found: ${K3S_READY_PATH}" >&2
+  exit 1
+fi
+if [ ! -s "${K3S_READY_PATH}" ]; then
+  echo "k3s readiness script is empty: ${K3S_READY_PATH}" >&2
   exit 1
 fi
 if [ ! -f "${EXPORT_KUBECONFIG_PATH}" ]; then
@@ -268,6 +277,9 @@ install -Dm755 "${REPO_ROOT}/scripts/pi_node_verifier.sh" \
 
 install -Dm755 "${EXPORT_KUBECONFIG_PATH}" \
   "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/export-kubeconfig.sh"
+
+install -Dm755 "${K3S_READY_PATH}" \
+  "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/k3s-ready.sh"
 
 CLONE_SUGARKUBE="${CLONE_SUGARKUBE:-false}"
 CLONE_TOKEN_PLACE="${CLONE_TOKEN_PLACE:-true}"

--- a/scripts/cloud-init/k3s-ready.sh
+++ b/scripts/cloud-init/k3s-ready.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_dir="/var/log/sugarkube"
+log_file="${log_dir}/k3s-ready.log"
+mkdir -p "${log_dir}"
+
+log() {
+  local ts
+  ts=$(date --iso-8601=seconds 2>/dev/null || date)
+  printf '%s %s\n' "$ts" "$1" | tee -a "$log_file"
+}
+
+select_kubectl() {
+  if command -v kubectl >/dev/null 2>&1; then
+    echo "kubectl"
+    return 0
+  fi
+  if command -v k3s >/dev/null 2>&1; then
+    echo "k3s kubectl"
+    return 0
+  fi
+  return 1
+}
+
+kubectl_cmd=$(select_kubectl)
+if [[ -z "${kubectl_cmd:-}" ]]; then
+  log "kubectl not found; cannot verify k3s readiness"
+  exit 1
+fi
+
+# shellcheck disable=SC2206 # intentional word splitting into array
+kubectl_arr=($kubectl_cmd)
+
+ready_timeout="${K3S_READY_TIMEOUT:-900}"
+retry_interval="${K3S_READY_RETRY:-15}"
+
+declare -i elapsed=0
+log "Waiting for kubernetes node readiness (timeout: ${ready_timeout}s)"
+
+while (( elapsed < ready_timeout )); do
+  if "${kubectl_arr[@]}" wait --for=condition=Ready node --all \
+    --timeout="${retry_interval}s" >/tmp/k3s-ready.out 2>/tmp/k3s-ready.err; then
+    log "k3s reported Ready nodes"
+    cat /tmp/k3s-ready.out >>"$log_file" 2>/dev/null || true
+    rm -f /tmp/k3s-ready.out /tmp/k3s-ready.err
+    exit 0
+  fi
+
+  if grep -qi "no matching resources" /tmp/k3s-ready.err 2>/dev/null; then
+    log "kubectl reports no nodes yet; retrying"
+  else
+    log "kubectl wait failed: $(tr '\n' ' ' </tmp/k3s-ready.err)"
+  fi
+
+  sleep "$retry_interval"
+  elapsed=$((elapsed + retry_interval))
+done
+
+log "Timed out waiting for k3s nodes to become Ready after ${ready_timeout}s"
+exit 2

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -155,6 +155,35 @@ write_files:
 
       [Install]
       WantedBy=multi-user.target
+  - path: /etc/systemd/system/k3s-ready.service
+    permissions: '0644'
+    content: |
+      [Unit]
+      Description=Wait for k3s node readiness
+      Requires=k3s.service
+      Wants=network-online.target projects-compose.service
+      After=k3s.service network-online.target projects-compose.service
+
+      [Service]
+      Type=oneshot
+      ExecStart=/opt/sugarkube/k3s-ready.sh
+      TimeoutStartSec=900
+      RemainAfterExit=yes
+
+      [Install]
+      WantedBy=k3s-ready.target
+  - path: /etc/systemd/system/k3s-ready.target
+    permissions: '0644'
+    content: |
+      [Unit]
+      Description=Projects compose and k3s readiness target
+      Requires=projects-compose.service k3s-ready.service
+      Wants=projects-compose.service k3s-ready.service
+      After=projects-compose.service k3s-ready.service
+      AllowIsolate=yes
+
+      [Install]
+      WantedBy=multi-user.target
   # projects-end
 runcmd:
   - |
@@ -177,6 +206,8 @@ runcmd:
   - [systemctl, enable, --now, docker]
   - [bash, -c, 'curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--disable traefik" sh -']
   - [/opt/projects/start-projects.sh]  # projects-runcmd
+  - [systemctl, enable, k3s-ready.target]
+  - [systemctl, start, k3s-ready.target]
   - [/opt/sugarkube/export-kubeconfig.sh]
   - [bash, -c, 'apt-get autoremove -y']
   - [bash, -c, 'apt-get clean && rm -rf /var/lib/apt/lists/*']

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -487,6 +487,11 @@ def _run_build_script(tmp_path, env):
     shutil.copy(export_kubeconfig_src, export_kubeconfig_dest)
     export_kubeconfig_dest.chmod(0o755)
 
+    k3s_ready_src = cloud_init_src / "k3s-ready.sh"
+    k3s_ready_dest = ci_dir / "k3s-ready.sh"
+    shutil.copy(k3s_ready_src, k3s_ready_dest)
+    k3s_ready_dest.chmod(0o755)
+
     result = subprocess.run(
         ["/bin/bash", str(script)],
         env=env,


### PR DESCRIPTION
## What
- add a k3s-ready target/service and readiness script that waits for kubectl
  to report Ready nodes before marking boot complete
- wire the new units into cloud-init and the image builder, plus update docs
  and tests to describe the new boot target

## Why
- complete the checklist task for gating workloads on projects-compose until
  the k3s node reports Ready

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68ce406bee5c832fa098c7c70b0bb00a