### PR TITLE
Extend pi_node_verifier with k3s and app health checks

### DIFF
--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -89,10 +89,14 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
   - The target only completes once `kubectl get nodes` reports `Ready`.
   - Added `k3s-ready.target`/`k3s-ready.service` plus a readiness script that runs `kubectl wait` before
     marking the target reached, with cloud-init wiring and docs for chaining workloads.
-- [ ] Extend verifier to ensure:
+- [x] Extend verifier to ensure:
   - k3s node is `Ready`.
   - `projects-compose.service` is active.
   - `token.place` and `dspace` endpoints respond on HTTPS/GraphQL.
+  - `scripts/pi_node_verifier.sh` now discovers a kubeconfig, runs `kubectl get nodes`,
+    checks `projects-compose.service`, and probes token.place/dspace HTTP(S)/GraphQL
+    endpoints with configurable URLs/TLS flags so reports surface regressions
+    automatically.
 - [ ] Provide post-boot hooks that apply pinned Helm/chart bundles and fail fast with logs if health checks fail.
 - [ ] Bundle sample datasets and token.place collections for first-launch validation.
 - [ ] Document and script multi-node join rehearsal for scaling clusters.

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -126,6 +126,10 @@ before diving into the commands below.
   ```bash
   sudo cat /boot/first-boot-report.txt
   ```
+- The verifier also checks for a `Ready` k3s node, confirms `projects-compose.service`
+  is `active`, and curls the token.place and dspace endpoints. Override the HTTP
+  probes by exporting `TOKEN_PLACE_HEALTH_URL`, `DSPACE_HEALTH_URL`, and related
+  `*_INSECURE` flags before invoking `/opt/sugarkube/pi_node_verifier.sh`.
 - The boot partition now includes `/boot/sugarkube-kubeconfig`, a sanitized
   kubeconfig export generated after k3s finishes installing. Secrets are
   redacted, making the file safe to hand off to operators who only need cluster

--- a/tests/pi_node_verifier_json_test.bats
+++ b/tests/pi_node_verifier_json_test.bats
@@ -30,11 +30,52 @@ exit 0
 EOF
   chmod +x "$tmp/iptables"
 
+  cat <<'EOF' > "$tmp/kubectl"
+#!/usr/bin/env bash
+if [[ "$1" == "--kubeconfig" ]]; then
+  shift 2
+fi
+if [[ "$1" == "get" && "$2" == "nodes" ]]; then
+  echo "pi NotReady control-plane 5m v1.29.0"
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$tmp/kubectl"
+
+  cat <<'EOF' > "$tmp/systemctl"
+#!/usr/bin/env bash
+if [[ "$1" == "is-active" ]]; then
+  exit 3
+fi
+exit 1
+EOF
+  chmod +x "$tmp/systemctl"
+
+  cat <<'EOF' > "$tmp/curl"
+#!/usr/bin/env bash
+exit 22
+EOF
+  chmod +x "$tmp/curl"
+
+  cat <<'EOF' > "$tmp/wget"
+#!/usr/bin/env bash
+exit 4
+EOF
+  chmod +x "$tmp/wget"
+
+  touch "$tmp/kubeconfig"
+  export KUBECONFIG="$tmp/kubeconfig"
+
   run "$BATS_TEST_DIRNAME/../scripts/pi_node_verifier.sh" --json
   [ "$status" -eq 0 ]
   echo "$output" | jq -e '.checks[] | select(.name=="cloud_init") | .status=="fail"' > /dev/null
   echo "$output" | jq -e '.checks[] | select(.name=="time_sync") | .status=="fail"' > /dev/null
   echo "$output" | jq -e '.checks[] | select(.name=="iptables_backend") | .status=="fail"' > /dev/null
+  echo "$output" | jq -e '.checks[] | select(.name=="k3s_node_ready") | .status=="fail"' > /dev/null
+  echo "$output" | jq -e '.checks[] | select(.name=="projects_compose_active") | .status=="fail"' > /dev/null
+  echo "$output" | jq -e '.checks[] | select(.name=="token_place_http") | .status=="fail"' > /dev/null
+  echo "$output" | jq -e '.checks[] | select(.name=="dspace_http") | .status=="fail"' > /dev/null
 }
 
 @test "pi_node_verifier reports skipped checks in JSON" {
@@ -48,4 +89,8 @@ EOF
   echo "$output" | jq -e '.checks[] | select(.name=="time_sync") | .status=="skip"' > /dev/null
   echo "$output" | jq -e '.checks[] | select(.name=="iptables_backend") | .status=="skip"' > /dev/null
   echo "$output" | jq -e '.checks[] | select(.name=="k3s_check_config") | .status=="skip"' > /dev/null
+  echo "$output" | jq -e '.checks[] | select(.name=="k3s_node_ready") | .status=="skip"' > /dev/null
+  echo "$output" | jq -e '.checks[] | select(.name=="projects_compose_active") | .status=="skip"' > /dev/null
+  echo "$output" | jq -e '.checks[] | select(.name=="token_place_http") | .status=="skip"' > /dev/null
+  echo "$output" | jq -e '.checks[] | select(.name=="dspace_http") | .status=="skip"' > /dev/null
 }

--- a/tests/pi_node_verifier_output_test.bats
+++ b/tests/pi_node_verifier_output_test.bats
@@ -8,6 +8,10 @@
   echo "$output" | grep "time_sync:"
   echo "$output" | grep "iptables_backend:"
   echo "$output" | grep "k3s_check_config:"
+  echo "$output" | grep "k3s_node_ready:"
+  echo "$output" | grep "projects_compose_active:"
+  echo "$output" | grep "token_place_http:"
+  echo "$output" | grep "dspace_http:"
 }
 
 @test "pi_node_verifier reports failing checks" {
@@ -34,11 +38,52 @@ exit 0
 EOF
   chmod +x "$tmp/iptables"
 
+  cat <<'EOF' > "$tmp/kubectl"
+#!/usr/bin/env bash
+if [[ "$1" == "--kubeconfig" ]]; then
+  shift 2
+fi
+if [[ "$1" == "get" && "$2" == "nodes" ]]; then
+  echo "pi NotReady control-plane 5m v1.29.0"
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$tmp/kubectl"
+
+  cat <<'EOF' > "$tmp/systemctl"
+#!/usr/bin/env bash
+if [[ "$1" == "is-active" ]]; then
+  exit 3
+fi
+exit 1
+EOF
+  chmod +x "$tmp/systemctl"
+
+  cat <<'EOF' > "$tmp/curl"
+#!/usr/bin/env bash
+exit 22
+EOF
+  chmod +x "$tmp/curl"
+
+  cat <<'EOF' > "$tmp/wget"
+#!/usr/bin/env bash
+exit 4
+EOF
+  chmod +x "$tmp/wget"
+
+  touch "$tmp/kubeconfig"
+  export KUBECONFIG="$tmp/kubeconfig"
+
   run "$BATS_TEST_DIRNAME/../scripts/pi_node_verifier.sh"
   [ "$status" -eq 0 ]
   echo "$output" | grep "cloud_init: fail"
   echo "$output" | grep "time_sync: fail"
   echo "$output" | grep "iptables_backend: fail"
+  echo "$output" | grep "k3s_node_ready: fail"
+  echo "$output" | grep "projects_compose_active: fail"
+  echo "$output" | grep "token_place_http: fail"
+  echo "$output" | grep "dspace_http: fail"
 }
 
 @test "pi_node_verifier --help shows usage" {

--- a/tests/pi_node_verifier_skip_test.bats
+++ b/tests/pi_node_verifier_skip_test.bats
@@ -10,4 +10,8 @@
   echo "$output" | grep "time_sync: skip"
   echo "$output" | grep "iptables_backend: skip"
   echo "$output" | grep "k3s_check_config: skip"
+  echo "$output" | grep "k3s_node_ready: skip"
+  echo "$output" | grep "projects_compose_active: skip"
+  echo "$output" | grep "token_place_http: skip"
+  echo "$output" | grep "dspace_http: skip"
 }


### PR DESCRIPTION
## Summary
- extend `pi_node_verifier.sh` with k3s readiness, projects-compose status, and HTTP probes for token.place and dspace
- add configuration knobs and documentation describing the new health checks and how to override them
- update bats suites and pi image checklist to cover the new verifier behaviour

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68ce4f1fc400832f8b42744bc238fb50