### PR TITLE
Add k3s join token export to boot volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ the docs you will see the term used in both contexts.
     (`flash_pi_media.ps1`) shells out to the same Python core on Windows.
   - `pi_node_verifier.sh` — check k3s prerequisites; use `--json` for machine output or
     `--help` for usage
+  - `scripts/cloud-init/export-node-token.sh` — copy the k3s join token to
+    `/boot/sugarkube-node-token` for offline recovery; runs automatically on first boot
   - `scan-secrets.py` — scan diffs for high-risk patterns using `ripsecrets` when
     available and also run a regex check to catch common tokens
 - `outages/` — structured outage records (see

--- a/docs/network_setup.md
+++ b/docs/network_setup.md
@@ -127,7 +127,9 @@ cluster.
 
 > Tip: You can also grab `/boot/sugarkube-kubeconfig` from the boot volume without SSH.
 > The export redacts client keys while preserving cluster endpoints, making it safe to share
-> connection details with operators who only need the cluster address and CA bundle.
+> connection details with operators who only need the cluster address and CA bundle. When you need
+> to add agents, mount the boot volume and read `/boot/sugarkube-node-token`, then rotate it with
+> `sudo k3s token rotate` after use.
 
 See the deployment guide at
 [token.place](https://github.com/futuroptimist/token.place) for a detailed

--- a/docs/pi_headless_provisioning.md
+++ b/docs/pi_headless_provisioning.md
@@ -36,9 +36,10 @@ Recommended options:
 - Inject optional environment variables for services like Cloudflare Tunnels or token.place secrets.
 
 The base image now writes a sanitized kubeconfig to `/boot/sugarkube-kubeconfig` once k3s is
-online, so you can collect cluster endpoints without SSH. The default template still seeds
-`/boot/sugarkube/` with placeholders for bootstrap tokens or additional secrets you may want to
-mirror on first boot.
+online, so you can collect cluster endpoints without SSH. It also copies the join token to
+`/boot/sugarkube-node-token` after provisioning completes, giving you a physical backup when SSH
+is unavailable. The default template still seeds `/boot/sugarkube/` with placeholders for
+bootstrap tokens or additional secrets you may want to mirror on first boot.
 
 ## Inject secrets safely
 
@@ -85,7 +86,9 @@ sudo /usr/local/bin/pi_node_verifier.sh --full
 
 5. (Optional) Copy `/boot/sugarkube-kubeconfig` from another machine to share cluster endpoints
    with teammates. The export redacts client keys and tokens—regenerate a full admin config later
-   using `sudo k3s kubectl config view --raw` before authenticating from a workstation.
+   using `sudo k3s kubectl config view --raw` before authenticating from a workstation. Grab the
+   join secret from `/boot/sugarkube-node-token` when you need to add or recover agents, then rotate
+   it with `sudo k3s token rotate`.
 
 Successful runs leave `/boot/first-boot-report.json` and `/var/log/sugarkube/first-boot.ok` for later auditing.
 

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -139,7 +139,10 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
 - [ ] Package a cross-platform desktop notifier to alert when workflow artifacts are ready.
 - [ ] Serve a web UI (via GitHub Pages) where users paste a workflow URL and get direct flashing instructions tailored to OS.
 - [ ] Add QR codes on physical `pi_carrier` hardware pointing to quickstart and troubleshooting docs.
-- [ ] Print cluster token and default kubeconfig to `/boot/` for recovery if first boot stalls.
+- [x] Print cluster token and default kubeconfig to `/boot/` for recovery if first boot stalls.
+  - `/opt/sugarkube/export-node-token.sh` mirrors the k3s join secret to
+    `/boot/sugarkube-node-token` alongside the existing sanitized kubeconfig. The quickstart,
+    headless provisioning, and network guides document how to retrieve and rotate the token.
 - [ ] Provide optional `sugarkube-teams` webhook that posts boot/clone progress to Slack or Matrix for remote monitoring.
 
 ---

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -132,6 +132,10 @@ before diving into the commands below.
   endpoints and certificate authorities. Copy it from another machine after
   ejecting the media, then merge real credentials using `sudo k3s kubectl
   config view --raw` when ready to manage the cluster remotely.
+- `/boot/sugarkube-node-token` captures the k3s join token once the server
+  finishes provisioning. Use the token to recover a stuck node or add agents by
+  running `sudo cat /boot/sugarkube-node-token` on the Pi or mounting the boot
+  volume elsewhere. Rotate the secret with `sudo k3s token rotate` after use.
 
 The image is now ready for additional repositories or joining a multi-node
 k3s cluster.

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -99,6 +99,7 @@ PROJECTS_COMPOSE_PATH="${PROJECTS_COMPOSE_PATH:-${CLOUD_INIT_DIR}/docker-compose
 START_PROJECTS_PATH="${START_PROJECTS_PATH:-${CLOUD_INIT_DIR}/start-projects.sh}"
 INIT_ENV_PATH="${INIT_ENV_PATH:-${CLOUD_INIT_DIR}/init-env.sh}"
 EXPORT_KUBECONFIG_PATH="${EXPORT_KUBECONFIG_PATH:-${CLOUD_INIT_DIR}/export-kubeconfig.sh}"
+EXPORT_NODE_TOKEN_PATH="${EXPORT_NODE_TOKEN_PATH:-${CLOUD_INIT_DIR}/export-node-token.sh}"
 K3S_READY_PATH="${K3S_READY_PATH:-${CLOUD_INIT_DIR}/k3s-ready.sh}"
 
 if [ ! -f "${CLOUD_INIT_PATH}" ]; then
@@ -277,6 +278,9 @@ install -Dm755 "${REPO_ROOT}/scripts/pi_node_verifier.sh" \
 
 install -Dm755 "${EXPORT_KUBECONFIG_PATH}" \
   "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/export-kubeconfig.sh"
+
+install -Dm755 "${EXPORT_NODE_TOKEN_PATH}" \
+  "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/export-node-token.sh"
 
 install -Dm755 "${K3S_READY_PATH}" \
   "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/k3s-ready.sh"

--- a/scripts/cloud-init/export-node-token.sh
+++ b/scripts/cloud-init/export-node-token.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SRC="/var/lib/rancher/k3s/server/node-token"
+DEST="/boot/sugarkube-node-token"
+LOG_DIR="/var/log/sugarkube"
+LOG_FILE="${LOG_DIR}/node-token-export.log"
+WAIT_SECONDS=${WAIT_SECONDS:-120}
+SLEEP_INTERVAL=${SLEEP_INTERVAL:-3}
+
+mkdir -p "$LOG_DIR" >/dev/null 2>&1 || true
+
+log() {
+  local ts
+  ts=$(date --iso-8601=seconds 2>/dev/null || date)
+  printf '%s %s\n' "$ts" "$1" >>"$LOG_FILE" 2>/dev/null || true
+}
+
+if [ ! -d /boot ]; then
+  log "/boot not mounted; skipping k3s token export"
+  exit 0
+fi
+
+attempts=$(( WAIT_SECONDS / SLEEP_INTERVAL ))
+if [ $attempts -lt 1 ]; then
+  attempts=1
+fi
+
+for ((i=0; i<attempts; i++)); do
+  if [ -s "$SRC" ]; then
+    break
+  fi
+  sleep "$SLEEP_INTERVAL"
+done
+
+if [ ! -s "$SRC" ]; then
+  log "k3s node token missing after ${WAIT_SECONDS}s; wrote placeholder"
+  {
+    printf '# Sugarkube k3s join token (pending)\n'
+    printf '# Generated: %s\n' "$(date --iso-8601=seconds 2>/dev/null || date)"
+    printf '# k3s has not yet created %s. Run this script again later.\n' "$SRC"
+  } >"$DEST" 2>/dev/null || true
+  exit 0
+fi
+
+join_secret=$(tr -d '\n' <"$SRC" 2>/dev/null || true)
+
+if [ -z "$join_secret" ]; then
+  log "k3s node token empty; wrote placeholder"
+  {
+    printf '# Sugarkube k3s join token (unavailable)\n'
+    printf '# Generated: %s\n' "$(date --iso-8601=seconds 2>/dev/null || date)"
+    printf '# %s exists but appears empty. Re-run the export script manually.\n' "$SRC"
+  } >"$DEST" 2>/dev/null || true
+  exit 0
+fi
+
+{
+  printf '# Sugarkube k3s join token\n'
+  printf '# Generated: %s\n' "$(date --iso-8601=seconds 2>/dev/null || date)"
+  printf '# This token grants new agents access to the cluster. Keep it offline\n'
+  printf '# and rotate it with:\n'
+  printf '#   sudo k3s token rotate\n'
+  printf '# Retrieve a fresh token afterwards with:\n'
+  printf '#   sudo cat %s\n' "$SRC"
+  printf '\n%s\n' "$join_secret"
+} >"$DEST" 2>/dev/null || true
+
+if ! sync "$DEST" 2>/dev/null; then
+  sync
+fi
+
+log "Wrote k3s node token to $DEST"

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -209,6 +209,7 @@ runcmd:
   - [systemctl, enable, k3s-ready.target]
   - [systemctl, start, k3s-ready.target]
   - [/opt/sugarkube/export-kubeconfig.sh]
+  - [/opt/sugarkube/export-node-token.sh]
   - [bash, -c, 'apt-get autoremove -y']
   - [bash, -c, 'apt-get clean && rm -rf /var/lib/apt/lists/*']
   - |


### PR DESCRIPTION
what: mirror the k3s node token into /boot and document retrieval paths
why: provide an offline recovery path per the Pi image improvement checklist
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68ce4f1fc400832f8b42744bc238fb50