### PR TITLE
Add Pi image contributor guide and docs verification helpers

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -141,6 +141,7 @@ kube
 kubeconfig
 kubectl
 lcd
+linkcheck
 linkchecker
 linters
 htmlcontent
@@ -169,6 +170,7 @@ preconfigure
 preloaded
 prettierrc
 pyspelling
+quickstart
 qcow
 qcow2
 raspi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,17 @@ git diff --cached | ./scripts/scan-secrets.py
 `scan-secrets.py` skips scanning itself even if diff paths omit the `b/` prefix.
 Findings are printed to stderr so stdout remains clean for tooling.
 
-- If `README.md` or files under `docs/` change, also run:
+- If `README.md` or files under `docs/` change, run the combined helper so spellcheck and link checks
+  stay in sync:
+
+```bash
+make docs-verify
+# or
+just docs-verify
+```
+
+- When `pyspelling` or `linkchecker` are missing locally, install prerequisites and rerun the
+  individual commands:
 
 ```bash
 pyspelling -c .spellcheck.yaml

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ FLASH_ARGS ?= --assume-yes
 FLASH_REPORT_ARGS ?=
 ROLLBACK_ARGS ?=
 
-.PHONY: install-pi-image download-pi-image flash-pi flash-pi-report doctor rollback-to-sd
+.PHONY: install-pi-image download-pi-image flash-pi flash-pi-report doctor rollback-to-sd \
+	docs-verify
 
 install-pi-image:
 	$(INSTALL_CMD) --dir '$(IMAGE_DIR)' --image '$(IMAGE_PATH)' $(DOWNLOAD_ARGS)
@@ -40,3 +41,7 @@ doctor:
 
 rollback-to-sd:
 	$(ROLLBACK_CMD) $(ROLLBACK_ARGS)
+
+docs-verify:
+	pyspelling -c .spellcheck.yaml
+	linkchecker --no-warnings README.md docs/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ the docs you will see the term used in both contexts.
 - [docs/lcd_mount.md](docs/lcd_mount.md) — optional 1602 LCD standoff locations
 - [docs/pi_headless_provisioning.md](docs/pi_headless_provisioning.md) — headless boot playbook covering
   `secrets.env` usage
+- [docs/pi_image_quickstart.md](docs/pi_image_quickstart.md) — build, flash and boot the preloaded Pi image
+- [docs/pi_image_contributor_guide.md](docs/pi_image_contributor_guide.md) — map automation helpers to
+  the docs that describe them
 - [docs/templates/cloud-init/user-data.example](docs/templates/cloud-init/user-data.example) — cloud-init
   template for SSH keys and `Wi-Fi` credentials
 - `scripts/` — helper scripts for rendering and exports
@@ -110,9 +113,20 @@ pre-commit run --all-files
 ```
 
 If you update documentation, install `aspell` and verify spelling and links.
-`pyspelling` relies on `aspell` and an English dictionary (`aspell-en`). The
-`scripts/checks.sh` helper tries to install them via `apt-get` when missing. Pre-commit
-runs these checks and fails if spelling or links are broken:
+Run the combined helper after editing Markdown so spellcheck and link checks stay aligned with the
+automation mapping surfaced in [docs/pi_image_contributor_guide.md](docs/pi_image_contributor_guide.md):
+
+```bash
+make docs-verify
+# or
+just docs-verify
+```
+
+Both commands execute `pyspelling -c .spellcheck.yaml` and
+`linkchecker --no-warnings README.md docs/`. `pyspelling` relies on `aspell` and the English
+dictionary (`aspell-en`); install them manually when the helper cannot. The `scripts/checks.sh`
+helper attempts to install the dependencies via `apt-get` when missing. When you need to run the
+commands directly:
 
 ```bash
 sudo apt-get install aspell aspell-en  # Debian/Ubuntu
@@ -121,8 +135,8 @@ pyspelling -c .spellcheck.yaml
 linkchecker --no-warnings README.md docs/
 ```
 
-The `--no-warnings` flag prevents linkchecker from returning a non-zero exit
-code on benign Markdown parsing warnings.
+The `--no-warnings` flag prevents linkchecker from returning a non-zero exit code on benign Markdown
+parsing warnings.
 
 Scan staged changes for secrets before committing:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,8 @@ Review the safety notes before working with power components.
 - [mac_mini_station.md](mac_mini_station.md) — press-fit cap for the Mac mini keyboard station
 - [electronics_schematics.md](electronics_schematics.md) — KiCad and Fritzing designs
 - [pi_image_quickstart.md](pi_image_quickstart.md) — build, flash and boot the preloaded Pi image
+- [pi_image_contributor_guide.md](pi_image_contributor_guide.md) — map automation helpers to the docs
+  they inform
 - [pi_image_cloudflare.md](pi_image_cloudflare.md) — preconfigure Docker and Cloudflare tunnels
 - [pi_image_improvement_checklist.md](pi_image_improvement_checklist.md) — backlog of DX upgrades for the Pi image
 - [raspi_cluster_setup.md](raspi_cluster_setup.md) — build a three-node k3s cluster and deploy apps

--- a/docs/pi_image_contributor_guide.md
+++ b/docs/pi_image_contributor_guide.md
@@ -1,0 +1,118 @@
+# Pi Image Contributor Guide
+
+This guide links every Pi image automation helper to the documentation that explains how to use it.
+Use it when updating scripts or docs so releases, flashing workflows, and verifier reports stay in
+sync.
+
+## Keep docs and automation aligned
+
+- Touching any file in `docs/` or `README.md`? Run the synchronized checks:
+  ```bash
+  make docs-verify
+  # or
+  just docs-verify
+  ```
+  Both commands execute `pyspelling -c .spellcheck.yaml` and
+  `linkchecker --no-warnings README.md docs/` so every update keeps the documentation consistent
+  with the automation helpers.
+- Use `pre-commit run --all-files` to exercise `scripts/checks.sh`, which installs spellcheck and
+  link-check dependencies automatically when missing.
+- When adding a new helper, update this mapping and reference it from the relevant guide so the
+  quick-start and recovery docs stay authoritative.
+
+## Automation map
+
+### Download and release helpers
+
+- `scripts/install_sugarkube_image.sh`
+  - Purpose: one-line installer that resolves the latest release, verifies checksums, and expands
+    the `.img.xz` locally.
+  - Primary docs: [Pi Image Quickstart](./pi_image_quickstart.md),
+    [Pi Image Flowcharts](./pi_image_flowcharts.md).
+  - Related tooling: exposed via `make install-pi-image`, `just install-pi-image`, and tested by
+    `tests/install_sugarkube_image_test.py`.
+- `scripts/download_pi_image.sh`
+  - Purpose: resumable GitHub release downloads with checksum verification and progress output.
+  - Primary docs: [Pi Image Quickstart](./pi_image_quickstart.md),
+    [Pi Image Builder Design](./pi_image_builder_design.md).
+  - Related tooling: wrapped by `make download-pi-image`, `just download-pi-image`, and consumed by
+    the installer script above.
+- `scripts/collect_pi_image.sh`
+  - Purpose: normalize pi-gen output and compress it into the release artifact layout.
+  - Primary docs: [Pi Image Builder Design](./pi_image_builder_design.md).
+  - Related tooling: invoked in the CI pipelines that publish release assets.
+- `scripts/create_build_metadata.py` and `scripts/generate_release_manifest.py`
+  - Purpose: capture build inputs, pi-gen SHAs, and stage timings, then export a signed manifest for
+    releases.
+  - Primary docs: [Pi Image Builder Design](./pi_image_builder_design.md).
+  - Related tooling: referenced from the release workflow and validated by tests under
+    `tests/test_create_build_metadata.py` and `tests/test_generate_release_manifest.py`.
+- `scripts/sugarkube-latest`
+  - Purpose: minimal wrapper for `download_pi_image.sh` when you only need the compressed artifact.
+  - Primary docs: [Pi Image Quickstart](./pi_image_quickstart.md).
+
+### Flashing and reporting helpers
+
+- `scripts/flash_pi_media.py`, `scripts/flash_pi_media.sh`, and `scripts/flash_pi_media.ps1`
+  - Purpose: stream `.img` or `.img.xz` directly to removable media with checksum verification and
+    automatic eject.
+  - Primary docs: [Pi Image Quickstart](./pi_image_quickstart.md),
+    [Pi Image Flowcharts](./pi_image_flowcharts.md).
+  - Related tooling: exercised by `make flash-pi`, `just flash-pi`, and the Windows wrapper to keep
+    parity across platforms.
+- `scripts/flash_pi_media_report.py`
+  - Purpose: generate Markdown, HTML, and JSON flash reports that capture hardware IDs, checksum
+    results, and optional cloud-init diffs.
+  - Primary docs: [Pi Image Quickstart](./pi_image_quickstart.md),
+    [Pi Boot & Cluster Troubleshooting](./pi_boot_troubleshooting.md).
+  - Related tooling: exposed through `make flash-pi-report`, `just flash-pi-report`, and archived by
+    release consumers under `~/sugarkube/reports/`.
+- `scripts/render_pi_imager_preset.py`
+  - Purpose: merge secrets into Raspberry Pi Imager presets for headless provisioning.
+  - Primary docs: [Pi Image Quickstart](./pi_image_quickstart.md),
+    [Pi Headless Provisioning](./pi_headless_provisioning.md).
+
+### Verification and recovery helpers
+
+- `scripts/pi_node_verifier.sh`
+  - Purpose: verify k3s readiness, compose services, and token.place/dspace health during first
+    boot.
+  - Primary docs: [Pi Image Quickstart](./pi_image_quickstart.md),
+    [Pi Boot & Cluster Troubleshooting](./pi_boot_troubleshooting.md).
+  - Related tooling: referenced by the planned `first-boot.service`, included in `/boot/first-boot-
+    report.txt`, and validated by the Bats tests in `tests/pi_node_verifier_*.bats`.
+- `scripts/sugarkube_doctor.sh`
+  - Purpose: dry-run downloads, flash media in a synthetic environment, and optionally run
+    repository linters.
+  - Primary docs: [Pi Image Quickstart](./pi_image_quickstart.md),
+    [Pi Image Flowcharts](./pi_image_flowcharts.md).
+  - Related tooling: executed via `make doctor` or `just doctor` and prints hints when `pyspelling`
+    or `linkchecker` are missing locally.
+- `scripts/rollback_to_sd.sh`
+  - Purpose: undo SSD migrations by restoring `/boot/cmdline.txt` and `/etc/fstab` to SD defaults,
+    writing a Markdown report alongside the boot partition.
+  - Primary docs: [SSD Recovery and Rollback](./ssd_recovery.md).
+  - Related tooling: surfaced as `make rollback-to-sd` and `just rollback-to-sd` helpers.
+- `scripts/cloud-init/export-kubeconfig.sh` and friends under `scripts/cloud-init/`
+  - Purpose: capture kubeconfigs, start token.place/dspace projects, and log provisioning milestones
+    for inclusion in `/boot/first-boot-report.txt`.
+  - Primary docs: [Pi Headless Provisioning](./pi_headless_provisioning.md),
+    [Pi Token + dspace](./pi_token_dspace.md).
+
+### Build workflows
+
+- `scripts/build_pi_image.sh` and `scripts/build_pi_image.ps1`
+  - Purpose: orchestrate pi-gen builds with cloud-init, token.place, and dspace baked into the
+    image.
+  - Primary docs: [Pi Image Quickstart](./pi_image_quickstart.md),
+    [Pi Image Builder Design](./pi_image_builder_design.md).
+  - Related tooling: triggered manually via shell or by the GitHub Actions release workflow.
+- `scripts/checks.sh`
+  - Purpose: unify linting, spellcheck, link-check, CAD, and KiCad validations in CI and local
+    development.
+  - Primary docs: [Pi Image Quickstart](./pi_image_quickstart.md),
+    [README](../README.md), and [CONTRIBUTING](../CONTRIBUTING.md).
+  - Related tooling: run via `pre-commit run --all-files` and from `scripts/sugarkube_doctor.sh`.
+
+When you adjust any helper above, update the referenced docs and regenerate spellcheck/link-check via
+`make docs-verify` to keep the automation story coherent for new contributors.

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -133,7 +133,10 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
 - [x] Expand troubleshooting tables linking LED patterns, journalctl logs, `kubectl` errors, and container health issues to fixes.
   - Added `docs/pi_boot_troubleshooting.md` plus quickstart references covering
     LED cues, critical commands, and recovery steps.
-- [ ] Publish contributor guide mapping automation scripts to docs; enforce sync with linkchecker and spellchecker.
+- [x] Publish contributor guide mapping automation scripts to docs; enforce sync with linkchecker and spellchecker.
+  - Added [Pi Image Contributor Guide](./pi_image_contributor_guide.md) mapping automation helpers to their
+    documentation and introduced `make docs-verify`/`just docs-verify` wrappers to run spellcheck and
+    link-check together.
 
 ---
 

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -8,6 +8,10 @@ Need a visual overview first? Start with the
 [Pi Image Flowcharts](./pi_image_flowcharts.md) to map the journey from download to first boot
 before diving into the commands below.
 
+Maintainers updating scripts or docs should cross-reference the
+[Pi Image Contributor Guide](./pi_image_contributor_guide.md) to keep automation helpers and
+guidance aligned.
+
 ## 1. Build or download the image
 
 1. Use the one-line installer to bootstrap everything in one step:

--- a/justfile
+++ b/justfile
@@ -63,3 +63,10 @@ rollback-to-sd:
 codespaces-bootstrap:
     sudo apt-get update
     sudo apt-get install -y curl gh jq pv unzip xz-utils
+
+# Run spellcheck and linkcheck to keep docs automation aligned
+# Usage: just docs-verify
+docs-verify:
+    pyspelling -c "{{justfile_directory()}}/.spellcheck.yaml"
+    linkchecker --no-warnings "{{justfile_directory()}}/README.md" \
+        "{{justfile_directory()}}/docs/"


### PR DESCRIPTION
## Summary
- document how each Pi image automation helper maps to the guides that describe it
- add make/just `docs-verify` commands and refresh README/CONTRIBUTING instructions
- tick the Pi image checklist item for the contributor guide and link-check enforcement

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/

------
https://chatgpt.com/codex/tasks/task_e_68ce54ea810c832f86dd9300f3fe388c