### PR TITLE
🩺 : add optional SSD SMART health monitor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,11 @@ FLASH_REPORT_ARGS ?=
 ROLLBACK_ARGS ?=
 VALIDATE_CMD ?= $(CURDIR)/scripts/ssd_post_clone_validate.py
 VALIDATE_ARGS ?=
+MONITOR_CMD ?= $(CURDIR)/scripts/ssd_health_monitor.py
+MONITOR_ARGS ?=
 
 .PHONY: install-pi-image download-pi-image flash-pi flash-pi-report doctor rollback-to-sd \
-	docs-verify
+        docs-verify monitor-ssd-health
 
 install-pi-image:
 	$(INSTALL_CMD) --dir '$(IMAGE_DIR)' --image '$(IMAGE_PATH)' $(DOWNLOAD_ARGS)
@@ -47,3 +49,6 @@ rollback-to-sd:
 docs-verify:
 	pyspelling -c .spellcheck.yaml
 	linkchecker --no-warnings README.md docs/
+
+monitor-ssd-health:
+	$(MONITOR_CMD) $(MONITOR_ARGS)

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ Review the safety notes before working with power components.
 - [pi_image_cloudflare.md](pi_image_cloudflare.md) — preconfigure Docker and Cloudflare tunnels
 - [pi_image_improvement_checklist.md](pi_image_improvement_checklist.md) — backlog of DX upgrades for the Pi image
 - [ssd_post_clone_validation.md](ssd_post_clone_validation.md) — validate SSD clones post-migration
+- [ssd_health_monitor.md](ssd_health_monitor.md) — capture SMART wear/temperature telemetry over time
 - [raspi_cluster_setup.md](raspi_cluster_setup.md) — build a three-node k3s cluster and deploy apps
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
 - [projects-compose.md](projects-compose.md) — run token.place & dspace via docker compose

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -83,7 +83,9 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
 - [x] Publish a recovery guide and rollback script to fall back to SD if SSD checks fail.
   - Added `scripts/rollback_to_sd.sh` plus Makefile/just wrappers, and documented the
     workflow in `docs/ssd_recovery.md` with dry-run guidance and report expectations.
-- [ ] Offer an opt-in SSD health monitor (SMART/wear checks).
+- [x] Offer an opt-in SSD health monitor (SMART/wear checks).
+  - Added `scripts/ssd_health_monitor.py`, Makefile/just wrappers, and docs for scheduling SMART
+    telemetry collection with Markdown/JSON reports and thresholded warnings.
 
 ---
 

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -163,6 +163,21 @@ mounts, then performs a configurable read/write stress test. Reports are stored 
 `VALIDATE_ARGS`. See [`SSD Post-Clone Validation`](./ssd_post_clone_validation.md) for flag details
 and sample outputs.
 
+### Monitor SSD health over time
+
+Capture temperature and wear data regularly so you can react before an SSD fails. The new health
+monitor wraps `smartctl` and stores Markdown/JSON snapshots under `~/sugarkube/reports/ssd-health/`.
+Run it manually after big migrations or schedule it via systemd using the recipes in
+[`SSD Health Monitor`](./ssd_health_monitor.md):
+
+```bash
+sudo ./scripts/ssd_health_monitor.py --print-json
+```
+
+Use the Makefile/justfile wrappers (`sudo make monitor-ssd-health` or `sudo just monitor-ssd-health`)
+to pass custom thresholds with `MONITOR_ARGS`. Combine the `--fail-on-warn` flag with CI or timers so
+you receive alerts once temperature or wear crosses the configured limit.
+
 ### Recover from SSD issues
 
 If an SSD migration fails or you need to boot from the original SD card again,

--- a/docs/ssd_health_monitor.md
+++ b/docs/ssd_health_monitor.md
@@ -1,0 +1,123 @@
+# SSD Health Monitor
+
+The Sugarkube image now ships with an optional SSD/NVMe health monitor that wraps
+[`smartctl`](https://manpages.debian.org/smartmontools/smartctl.8.en.html) so operators can
+capture wear, temperature, and SMART results after migrating to solid-state storage.
+The helper stores JSON and Markdown reports under `~/sugarkube/reports/ssd-health/` so the
+history survives across reboots and can be exported when filing support requests.
+
+## Requirements
+
+- Raspberry Pi running the Sugarkube image with the SSD or NVMe device attached.
+- `smartmontools` installed. Pi images generated from this repository already include it. If
+  you're running on a downstream system, install it manually:
+
+  ```bash
+  sudo apt update
+  sudo apt install -y smartmontools
+  ```
+
+- Root access. `smartctl` requires elevated privileges to query device telemetry.
+
+## Run a One-Off Health Capture
+
+Invoke the helper with `sudo` so it can talk to the storage controller. By default it discovers
+the root filesystem device and writes reports to `~/sugarkube/reports/ssd-health/`:
+
+```bash
+sudo ./scripts/ssd_health_monitor.py
+```
+
+You can target a specific device (for example if the SSD is attached but not yet booted from):
+
+```bash
+sudo ./scripts/ssd_health_monitor.py --device /dev/sda
+```
+
+The script prints a short summary to stdout, then writes detailed JSON/Markdown snapshots you can
+reference later. Set `--print-json` to also stream the JSON payload to the terminal or pass
+`--no-markdown`/`--no-json` to disable individual outputs.
+
+## Thresholds & Exit Codes
+
+The monitor applies two guardrails out of the box:
+
+- Warn when drive wear reaches 80% consumed life (`--warn-percentage`).
+- Warn when temperature reaches 70 °C (`--warn-temperature`).
+
+If the SMART controller reports an overall failure the warning list includes it automatically.
+Combine `--fail-on-warn` with a systemd unit (see below) to fail CI/CD or health checks when the
+wear/temperature threshold trips.
+
+## Automate With systemd
+
+Create a service and timer so the monitor captures telemetry daily. These units live in
+`/etc/systemd/system/` and can be dropped in via `sudo tee`:
+
+```bash
+sudo tee /etc/systemd/system/sugarkube-ssd-health.service <<'SERVICE'
+[Unit]
+Description=Collect SSD SMART metrics for Sugarkube
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/sugarkube-ssd-health.sh
+SERVICE
+
+sudo tee /usr/local/bin/sugarkube-ssd-health.sh <<'SCRIPT'
+#!/bin/bash
+set -euo pipefail
+/usr/local/bin/python3 /opt/sugarkube/scripts/ssd_health_monitor.py --fail-on-warn --print-json
+SCRIPT
+sudo chmod +x /usr/local/bin/sugarkube-ssd-health.sh
+
+sudo tee /etc/systemd/system/sugarkube-ssd-health.timer <<'TIMER'
+[Unit]
+Description=Schedule Sugarkube SSD SMART collection
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=15m
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+TIMER
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now sugarkube-ssd-health.timer
+```
+
+Adjust the script path if you install Sugarkube somewhere other than `/opt/sugarkube`. The timer
+runs once per day and records telemetry in the standard report directory so trends are easy to
+spot.
+
+## Make & just Integration
+
+To run the helper without remembering the full path, use the new shortcuts:
+
+```bash
+sudo make monitor-ssd-health
+# or
+sudo just monitor-ssd-health
+```
+
+Pass custom flags via `MONITOR_ARGS`:
+
+```bash
+sudo MONITOR_ARGS='--warn-percentage 70 --print-json' make monitor-ssd-health
+```
+
+These wrappers make it easy to integrate the monitor into your own automation or recovery
+playbooks.
+
+## Troubleshooting
+
+- **`smartctl` missing:** install the `smartmontools` package or run the monitor on a Sugarkube
+  image built after this change.
+- **`Unable to determine the block device`**: specify the device manually with `--device`. USB
+  adapters that expose multiple logical units sometimes confuse the auto-detection.
+- **Warnings about wear/temperature:** inspect the generated JSON to confirm the reading, then
+  plan a replacement SSD or improve airflow.

--- a/justfile
+++ b/justfile
@@ -15,6 +15,8 @@ rollback_cmd := env_var_or_default("ROLLBACK_CMD", justfile_directory() + "/scri
 rollback_args := env_var_or_default("ROLLBACK_ARGS", "")
 validate_cmd := env_var_or_default("VALIDATE_CMD", justfile_directory() + "/scripts/ssd_post_clone_validate.py")
 validate_args := env_var_or_default("VALIDATE_ARGS", "")
+monitor_cmd := env_var_or_default("MONITOR_CMD", justfile_directory() + "/scripts/ssd_health_monitor.py")
+monitor_args := env_var_or_default("MONITOR_ARGS", "")
 
 _default:
     @just --list
@@ -64,6 +66,11 @@ rollback-to-sd:
 # Usage: sudo just validate-ssd-clone VALIDATE_ARGS="--stress-mb 256"
 validate-ssd-clone:
     "{{validate_cmd}}" {{validate_args}}
+
+# Collect SMART / wear metrics from the active SSD or supplied device
+# Usage: sudo just monitor-ssd-health MONITOR_ARGS="--device /dev/sdb"
+monitor-ssd-health:
+    "{{monitor_cmd}}" {{monitor_args}}
 
 # Install CLI dependencies inside GitHub Codespaces or fresh containers
 # Usage: just codespaces-bootstrap

--- a/scripts/ssd_health_monitor.py
+++ b/scripts/ssd_health_monitor.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""Collect SMART health metrics for Sugarkube SSDs."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+DEFAULT_REPORT_DIR = Path.home() / "sugarkube" / "reports" / "ssd-health"
+DEFAULT_TAG = "ssd-health"
+SMARTCTL_EXIT_OK = {0, 2}
+DEFAULT_WARN_PERCENT_USED = 80
+DEFAULT_WARN_TEMPERATURE = 70
+
+
+class MonitorError(RuntimeError):
+    """Raised when health monitoring cannot proceed."""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inspect an SSD or NVMe device with smartctl, store structured reports, and "
+            "surface warnings when wear or temperature crosses configured thresholds."
+        )
+    )
+    parser.add_argument(
+        "--device",
+        help=(
+            "Block device to inspect (e.g. /dev/sda). If omitted, the script attempts to "
+            "discover the root filesystem device."
+        ),
+    )
+    parser.add_argument(
+        "--report-dir",
+        type=Path,
+        default=DEFAULT_REPORT_DIR,
+        help="Directory where JSON/Markdown reports are written (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--tag",
+        default=DEFAULT_TAG,
+        help="Prefix for generated report files (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--warn-percentage",
+        type=int,
+        default=DEFAULT_WARN_PERCENT_USED,
+        help=(
+            "Warn when percentage used is greater than or equal to this value. "
+            "Only applies when wear metrics are reported (default: %(default)s)."
+        ),
+    )
+    parser.add_argument(
+        "--warn-temperature",
+        type=int,
+        default=DEFAULT_WARN_TEMPERATURE,
+        help=(
+            "Warn when the drive temperature in °C is greater than or equal to this "
+            "value (default: %(default)s)."
+        ),
+    )
+    parser.add_argument(
+        "--fail-on-warn",
+        action="store_true",
+        help="Exit with status 2 if warnings are detected.",
+    )
+    parser.add_argument(
+        "--no-markdown",
+        action="store_true",
+        help="Skip generating a Markdown report alongside JSON output.",
+    )
+    parser.add_argument(
+        "--no-json",
+        action="store_true",
+        help="Skip generating a JSON report and only print to stdout/Markdown.",
+    )
+    parser.add_argument(
+        "--print-json",
+        action="store_true",
+        help="Also print the JSON report to stdout after writing it to disk.",
+    )
+    return parser.parse_args()
+
+
+def run_command(command: List[str]) -> subprocess.CompletedProcess[str]:
+    """Run a command and capture stdout/stderr."""
+
+    return subprocess.run(command, check=False, capture_output=True, text=True)
+
+
+def find_mount_source(mountpoint: Path) -> Optional[str]:
+    """Return the source device for a mountpoint."""
+
+    result = run_command(["findmnt", "-no", "SOURCE", str(mountpoint)])
+    if result.returncode == 0:
+        source = result.stdout.strip()
+        if source:
+            return source
+
+    try:
+        with open("/proc/self/mounts", "r", encoding="utf-8") as handle:
+            for line in handle:
+                parts = line.split()
+                if len(parts) >= 2 and parts[1] == str(mountpoint):
+                    return parts[0]
+    except OSError:
+        return None
+    return None
+
+
+def resolve_block_device(specifier: str) -> Optional[str]:
+    """Resolve a mount specifier or partition path to a base block device."""
+
+    if specifier.startswith("PARTUUID=") or specifier.startswith("UUID="):
+        result = run_command(["blkid", "-t", specifier, "-o", "device"])
+        if result.returncode == 0:
+            device = result.stdout.strip().splitlines()
+            if device:
+                return resolve_block_device(device[0])
+        return None
+
+    if specifier.startswith("/dev/"):
+        real_path = os.path.realpath(specifier)
+        lsblk = run_command(["lsblk", "-no", "PKNAME", real_path])
+        if lsblk.returncode == 0:
+            parent = lsblk.stdout.strip()
+            if parent:
+                return f"/dev/{parent}"
+        return real_path
+
+    return None
+
+
+def detect_root_device() -> Optional[str]:
+    """Best-effort detection of the primary root filesystem device."""
+
+    source = find_mount_source(Path("/"))
+    if not source:
+        return None
+    return resolve_block_device(source)
+
+
+def ensure_smartctl_available() -> None:
+    """Ensure smartctl is installed before continuing."""
+
+    if not shutil.which("smartctl"):
+        raise MonitorError(
+            "smartctl is required but was not found in PATH. Install smartmontools first."
+        )
+
+
+def collect_smart_data(device: str) -> Tuple[Dict[str, Any], List[str]]:
+    """Run smartctl in JSON mode and return parsed data plus warnings."""
+
+    process = run_command(["smartctl", "-a", "-j", device])
+    if process.returncode not in SMARTCTL_EXIT_OK:
+        message = process.stderr.strip() or process.stdout.strip() or "smartctl failed"
+        raise MonitorError(message)
+
+    try:
+        data = json.loads(process.stdout)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive coding
+        raise MonitorError(f"Failed to parse smartctl JSON output: {exc}") from exc
+
+    warnings: List[str] = []
+    smart_status = data.get("smart_status", {})
+    if smart_status.get("passed") is False:
+        warnings.append("SMART overall-health self-assessment reported a failure.")
+
+    return data, warnings
+
+
+def _attribute_value(attribute: Dict[str, Any]) -> Optional[float]:
+    raw = attribute.get("raw")
+    if isinstance(raw, dict):
+        if "value" in raw:
+            try:
+                return float(raw["value"])
+            except (TypeError, ValueError):
+                return None
+        if "string" in raw:
+            try:
+                return float(raw["string"].strip())
+            except (TypeError, ValueError):
+                return None
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    return None
+
+
+def _find_attribute(
+    data: Dict[str, Any],
+    *,
+    names: Iterable[str] = (),
+    ids: Iterable[int] = (),
+) -> Optional[Dict[str, Any]]:
+    table = data.get("ata_smart_attributes", {}).get("table", [])
+    for entry in table:
+        if entry.get("name") in names or entry.get("id") in ids:
+            return entry
+    return None
+
+
+def summarise_metrics(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract useful metrics from smartctl JSON output."""
+
+    device_info = data.get("device", {})
+    nvme_log = data.get("nvme_smart_health_information_log", {})
+    temperature = data.get("temperature", {})
+    power_on = data.get("power_on_time", {})
+
+    metrics: Dict[str, Any] = {
+        "model_name": device_info.get("model_name") or device_info.get("name"),
+        "serial_number": device_info.get("serial_number"),
+        "firmware_version": device_info.get("firmware_version"),
+    }
+
+    if "hours" in power_on:
+        metrics["power_on_hours"] = power_on["hours"]
+    else:
+        attr = _find_attribute(data, names=["Power_On_Hours"], ids=[9])
+        value = _attribute_value(attr) if attr else None
+        if value is not None:
+            metrics["power_on_hours"] = int(value)
+
+    if "current" in temperature:
+        metrics["temperature_celsius"] = temperature["current"]
+    elif nvme_log.get("temperature") is not None:
+        metrics["temperature_celsius"] = nvme_log["temperature"]
+
+    if nvme_log.get("percentage_used") is not None:
+        metrics["percentage_used"] = nvme_log["percentage_used"]
+    else:
+        wear_attr = _find_attribute(
+            data,
+            names=[
+                "Media_Wearout_Indicator",
+                "Remaining_Lifetime_Perc",
+                "Wear_Leveling_Count",
+                "Percent_Lifetime_Remain",
+            ],
+        )
+        wear_value = _attribute_value(wear_attr) if wear_attr else None
+        if wear_value is not None:
+            if wear_attr and wear_attr.get("name") in {
+                "Percent_Lifetime_Remain",
+                "Remaining_Lifetime_Perc",
+            }:
+                metrics["percentage_used"] = max(0, min(100, 100 - wear_value))
+            elif wear_attr and wear_attr.get("name") == "Wear_Leveling_Count":
+                metrics["wear_leveling_count"] = wear_value
+            else:
+                metrics["percentage_used"] = max(0, min(100, 100 - wear_value))
+
+    smart_status = data.get("smart_status", {})
+    if "passed" in smart_status:
+        metrics["smart_passed"] = smart_status["passed"]
+    if "self_test" in smart_status:
+        metrics["self_test"] = smart_status["self_test"]
+
+    return metrics
+
+
+def format_markdown(
+    *,
+    device: str,
+    timestamp: dt.datetime,
+    metrics: Dict[str, Any],
+    warnings: List[str],
+    report_path: Path,
+) -> str:
+    """Render a Markdown report string."""
+
+    table_rows = ["| Field | Value |", "| --- | --- |"]
+    for field, label in (
+        ("model_name", "Model"),
+        ("serial_number", "Serial"),
+        ("firmware_version", "Firmware"),
+        ("power_on_hours", "Power-On Hours"),
+        ("temperature_celsius", "Temperature (°C)"),
+        ("percentage_used", "Percentage Used"),
+        ("wear_leveling_count", "Wear Level Count"),
+        ("smart_passed", "SMART Passed"),
+    ):
+        value = metrics.get(field)
+        if value is None:
+            continue
+        table_rows.append(f"| {label} | {value} |")
+
+    warning_section = (
+        "\n".join(f"- ⚠️ {item}" for item in warnings) if warnings else "- ✅ No warnings"
+    )
+
+    lines = [
+        f"# SSD Health Report for `{device}`",
+        "",
+        f"Generated: {timestamp.isoformat()} UTC",
+        f"Report path: `{report_path}`",
+        "",
+        "## Summary",
+        "",
+        *table_rows,
+        "",
+        "## Warnings",
+        "",
+        warning_section,
+        "",
+        "## smartctl Command",
+        "",
+        "```bash",
+        f"smartctl -a -j {device}",
+        "```",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def build_report(
+    *,
+    device: str,
+    data: Dict[str, Any],
+    metrics: Dict[str, Any],
+    warnings: List[str],
+    report_dir: Path,
+    tag: str,
+    generate_json: bool,
+    generate_markdown: bool,
+    print_json: bool,
+) -> Tuple[Optional[Path], Optional[Path], Dict[str, Any]]:
+    """Persist reports to disk and optionally return their paths."""
+
+    timestamp = dt.datetime.utcnow()
+    report_dir.mkdir(parents=True, exist_ok=True)
+    stem = f"{tag}-{timestamp.strftime('%Y%m%dT%H%M%SZ')}"
+
+    payload = {
+        "device": device,
+        "timestamp": timestamp.isoformat() + "Z",
+        "metrics": metrics,
+        "warnings": warnings,
+        "smartctl": data,
+    }
+
+    json_path: Optional[Path] = None
+    if generate_json:
+        json_path = report_dir / f"{stem}.json"
+        json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        if print_json:
+            json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+            sys.stdout.write("\n")
+
+    markdown_path: Optional[Path] = None
+    if generate_markdown:
+        markdown_path = report_dir / f"{stem}.md"
+        markdown_content = format_markdown(
+            device=device,
+            timestamp=timestamp,
+            metrics=metrics,
+            warnings=warnings,
+            report_path=json_path or markdown_path,
+        )
+        markdown_path.write_text(markdown_content, encoding="utf-8")
+
+    return json_path, markdown_path, payload
+
+
+def evaluate_thresholds(
+    *,
+    metrics: Dict[str, Any],
+    warnings: List[str],
+    warn_percentage: int,
+    warn_temperature: int,
+) -> None:
+    """Append warnings based on configured thresholds."""
+
+    percentage = metrics.get("percentage_used")
+    if isinstance(percentage, (int, float)) and percentage >= warn_percentage:
+        warnings.append(
+            (
+                f"Drive wear is at {percentage:.0f}% which meets or exceeds "
+                f"the {warn_percentage}% threshold."
+            )
+        )
+
+    temperature = metrics.get("temperature_celsius")
+    if isinstance(temperature, (int, float)) and temperature >= warn_temperature:
+        warnings.append(
+            f"Drive temperature is {temperature:.0f}°C which meets or exceeds the "
+            f"{warn_temperature}°C threshold."
+        )
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        ensure_smartctl_available()
+        device = args.device or detect_root_device()
+        if not device:
+            raise MonitorError(
+                "Unable to determine the block device. Specify one with --device (e.g. /dev/sda)."
+            )
+
+        data, warnings = collect_smart_data(device)
+        metrics = summarise_metrics(data)
+        metrics["device_path"] = device
+        evaluate_thresholds(
+            metrics=metrics,
+            warnings=warnings,
+            warn_percentage=args.warn_percentage,
+            warn_temperature=args.warn_temperature,
+        )
+        json_path, markdown_path, _ = build_report(
+            device=device,
+            data=data,
+            metrics=metrics,
+            warnings=warnings,
+            report_dir=args.report_dir,
+            tag=args.tag,
+            generate_json=not args.no_json,
+            generate_markdown=not args.no_markdown,
+            print_json=args.print_json,
+        )
+    except MonitorError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    summary_lines = [
+        f"Device: {device}",
+        f"Model: {metrics.get('model_name', 'unknown')}",
+    ]
+    if "temperature_celsius" in metrics:
+        summary_lines.append(f"Temperature: {metrics['temperature_celsius']}°C")
+    if "percentage_used" in metrics:
+        summary_lines.append(f"Wear used: {metrics['percentage_used']:.0f}%")
+    if warnings:
+        summary_lines.append("Warnings:")
+        summary_lines.extend(f"  - {item}" for item in warnings)
+    else:
+        summary_lines.append("Warnings: none")
+
+    print("\n".join(summary_lines))
+    if json_path:
+        print(f"JSON report: {json_path}")
+    if markdown_path:
+        print(f"Markdown report: {markdown_path}")
+
+    if warnings and args.fail_on_warn:
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What
- add scripts/ssd_health_monitor.py for SMART telemetry, reports, thresholds
- wire Makefile/just wrappers and document usage plus systemd automation
- tick the SSD health monitor checklist item and link the new guide in docs index

## Why
- provide an opt-in wear/temperature monitor so operators can catch SSD issues early

## How to test
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/

------
https://chatgpt.com/codex/tasks/task_e_68ce5adfaac0832f8766f2ce0561eab3