### PR TITLE
Ensure telemetry publisher script is copied for build tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,12 @@ HEALTH_CMD ?= $(CURDIR)/scripts/ssd_health_monitor.py
 HEALTH_ARGS ?=
 SMOKE_CMD ?= $(CURDIR)/scripts/pi_smoke_test.py
 SMOKE_ARGS ?=
+TELEMETRY_CMD ?= $(CURDIR)/scripts/publish_telemetry.py
+TELEMETRY_ARGS ?=
 
 .PHONY: install-pi-image download-pi-image flash-pi flash-pi-report doctor rollback-to-sd \
-        clone-ssd docs-verify qr-codes monitor-ssd-health smoke-test-pi
+        clone-ssd docs-verify qr-codes monitor-ssd-health smoke-test-pi \
+        publish-telemetry
 
 install-pi-image:
 	$(INSTALL_CMD) --dir '$(IMAGE_DIR)' --image '$(IMAGE_PATH)' $(DOWNLOAD_ARGS)
@@ -71,3 +74,6 @@ monitor-ssd-health:
 
 smoke-test-pi:
 	$(SMOKE_CMD) $(SMOKE_ARGS)
+
+publish-telemetry:
+	$(TELEMETRY_CMD) $(TELEMETRY_ARGS)

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ Review the safety notes before working with power components.
 - [pi_smoke_test.md](pi_smoke_test.md) — run remote smoke tests against freshly provisioned Pis
 - [pi_image_contributor_guide.md](pi_image_contributor_guide.md) — map automation helpers to the docs
   they inform
+- [pi_image_telemetry.md](pi_image_telemetry.md) — opt-in anonymized telemetry for fleet dashboards
 - [pi_image_cloudflare.md](pi_image_cloudflare.md) — preconfigure Docker and Cloudflare tunnels
 - [pi_image_improvement_checklist.md](pi_image_improvement_checklist.md) — backlog of DX upgrades for the Pi image
 - [ssd_post_clone_validation.md](ssd_post_clone_validation.md) — validate SSD clones post-migration

--- a/docs/pi_image_contributor_guide.md
+++ b/docs/pi_image_contributor_guide.md
@@ -81,6 +81,13 @@ sync.
     [Pi Boot & Cluster Troubleshooting](./pi_boot_troubleshooting.md).
   - Related tooling: referenced by the planned `first-boot.service`, included in `/boot/first-boot-
     report.txt`, and validated by the Bats tests in `tests/pi_node_verifier_*.bats`.
+- `scripts/publish_telemetry.py`
+  - Purpose: run `pi_node_verifier`, hash device fingerprints, and publish anonymized telemetry to a
+    configurable endpoint.
+  - Primary docs: [Pi Image Quickstart](./pi_image_quickstart.md),
+    [Pi Image Telemetry Hooks](./pi_image_telemetry.md).
+  - Related tooling: exposed via `make publish-telemetry`, `just publish-telemetry`, and the
+    `sugarkube-telemetry.timer` service defined in cloud-init.
 - `scripts/pi_smoke_test.py`
   - Purpose: orchestrate remote verifier runs over SSH, optionally rebooting hosts to confirm
     convergence and emitting JSON for CI harnesses.

--- a/docs/pi_image_flowcharts.md
+++ b/docs/pi_image_flowcharts.md
@@ -53,6 +53,7 @@ flowchart TD
         PB1[Optional: run SSD clone workflow] --> PB2[Monitor /var/log/sugarkube/]
         PB2 --> PB3[Run rollback_to_sd.sh if needed]
         PB3 --> PB4[Collect verifier + flash reports for audit]
+        PB4 --> PB5[Optional: enable sugarkube-telemetry timer]
     end
 
     Prep --> Flashing --> FirstBoot --> PostBoot

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -64,7 +64,9 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
     checksum checks) to `/boot/first-boot-report.txt` and ingests migration
     events recorded by `scripts/cloud-init/start-projects.sh`.
 - [ ] Add self-healing units that retry container pulls, rerun `cloud-init clean`, or reboot into maintenance with actionable logs.
-- [ ] Provide optional telemetry hooks to publish anonymized health data to a shared dashboard.
+- [x] Provide optional telemetry hooks to publish anonymized health data to a shared dashboard.
+  - Added `sugarkube-publish-telemetry`, cloud-init environment/service templates, Makefile/just
+    wrappers, and docs covering opt-in uploads to custom collectors.
 
 ---
 

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -154,6 +154,12 @@ scan straight to this quickstart or the troubleshooting matrix while standing at
   Copy any of these files from another machine after ejecting the boot media.
   Regenerate fresh copies later with `sudo k3s kubectl config view --raw` or
   `sudo cat /var/lib/rancher/k3s/server/node-token` if you need to rotate them.
+- Optional: publish anonymized health telemetry for fleet dashboards:
+  1. Edit `/etc/sugarkube/telemetry.env`, set `SUGARKUBE_TELEMETRY_ENABLE="true"`, and populate
+     `SUGARKUBE_TELEMETRY_ENDPOINT` (plus optional token, salt, and tags).
+  2. Enable the hourly timer: `sudo systemctl enable --now sugarkube-telemetry.timer`.
+  3. Inspect uploads with `journalctl -u sugarkube-telemetry.service --no-pager`.
+  Review [Pi Image Telemetry Hooks](./pi_image_telemetry.md) for detailed payload and privacy notes.
 
 The image is now ready for additional repositories or joining a multi-node
 k3s cluster.

--- a/docs/pi_image_telemetry.md
+++ b/docs/pi_image_telemetry.md
@@ -1,0 +1,102 @@
+# Pi Image Telemetry Hooks
+
+The sugarkube image now ships an optional telemetry publisher that reports anonymized verifier
+results to a dashboard of your choosing. The helper runs `pi_node_verifier.sh --json`, hashes stable
+hardware identifiers, and posts a compact JSON payload so operators can monitor first-boot health
+across labs without exposing secrets.
+
+## What the publisher sends
+
+`sugarkube-publish-telemetry` emits a JSON document that contains:
+
+- A hashed instance identifier derived from `/etc/machine-id`, the Pi serial number, and
+  `/proc/device-tree/model`. Add a `SUGARKUBE_TELEMETRY_SALT` to re-hash the value per deployment.
+- The full `pi_node_verifier` check matrix and a summary of passed, failed, skipped, and unknown
+  checks.
+- Basic environment metadata: kernel version, hardware model, selected keys from `/etc/os-release`,
+  and the current uptime in seconds.
+- Optional labels (comma-separated `SUGARKUBE_TELEMETRY_TAGS`) to group devices on your dashboard.
+- A list of errors captured while running the verifier (timeouts, non-zero exit codes, JSON parse
+  issues) so ingestion pipelines can surface telemetry gaps explicitly.
+
+Raw kubeconfigs, hostnames, or IP addresses never leave the Pi. Only hashed fingerprints and the
+minimal health summary are posted.
+
+## Configure the endpoint
+
+Every image includes `/etc/sugarkube/telemetry.env` with commented defaults:
+
+```bash
+sudo nano /etc/sugarkube/telemetry.env
+```
+
+Update the file with your collector URL and credentials:
+
+```ini
+SUGARKUBE_TELEMETRY_ENABLE="true"
+SUGARKUBE_TELEMETRY_ENDPOINT="https://dashboard.example/api/ingest"
+SUGARKUBE_TELEMETRY_SALT="classroom-2025"
+SUGARKUBE_TELEMETRY_TAGS="beta-lab,pi-a"
+```
+
+The publisher exits early when `SUGARKUBE_TELEMETRY_ENABLE` is still `false`, which keeps telemetry
+completely opt-in.
+
+Need authentication? Append a `SUGARKUBE_TELEMETRY_TOKEN` entry to the same file once you have a
+bearer token from your collector.
+
+## Enable the systemd timer
+
+Once the environment file is updated, activate the timer that runs the publisher every hour after an
+initial five-minute delay:
+
+```bash
+sudo systemctl enable --now sugarkube-telemetry.timer
+```
+
+Check the timer and service status at any time:
+
+```bash
+systemctl list-timers sugarkube-telemetry.timer
+journalctl -u sugarkube-telemetry.service --no-pager
+```
+
+Disable telemetry later with:
+
+```bash
+sudo systemctl disable --now sugarkube-telemetry.timer
+sudo sed -i 's/SUGARKUBE_TELEMETRY_ENABLE="true"/SUGARKUBE_TELEMETRY_ENABLE="false"/' \
+  /etc/sugarkube/telemetry.env
+```
+
+## Publish on demand
+
+For manual reporting or smoke testing collector credentials, run the helper directly:
+
+```bash
+sudo make publish-telemetry TELEMETRY_ARGS="--dry-run --print-payload"
+```
+
+Pass `--endpoint`, `--token`, or `--tags` inside `TELEMETRY_ARGS` to override values from the
+environment file. Developers working from this repository can do the same with:
+
+```bash
+sudo just publish-telemetry telemetry_args="--dry-run"
+```
+
+Both invocations call `scripts/publish_telemetry.py`, which automatically locates
+`pi_node_verifier.sh`, generates an anonymized payload, and prints it when `--dry-run` is supplied.
+
+## Collector integration tips
+
+- Ingest payloads as-is to keep future schema extensions forward-compatible. The top-level
+  `schema` field is versioned (`https://sugarkube.dev/telemetry/v1`).
+- Track `verifier.summary.failed_checks` to raise alerts when token.place or dspace regressions
+  appear across fleets.
+- Combine the hashed `instance.id` with your own salt to anonymize data further before storing it in
+  a database shared outside your team.
+- Use `SUGARKUBE_TELEMETRY_VERIFIER_TIMEOUT` to accommodate slow Pi clusters that need more than the
+  default three minutes for a full verifier run.
+
+By shipping telemetry hooks as an opt-in service, operators gain shared observability across lab
+installs while keeping the default image silent until explicitly configured.

--- a/justfile
+++ b/justfile
@@ -24,6 +24,11 @@ health_cmd := env_var_or_default("HEALTH_CMD", justfile_directory() + "/scripts/
 health_args := env_var_or_default("HEALTH_ARGS", "")
 smoke_cmd := env_var_or_default("SMOKE_CMD", justfile_directory() + "/scripts/pi_smoke_test.py")
 smoke_args := env_var_or_default("SMOKE_ARGS", "")
+telemetry_cmd := env_var_or_default(
+    "TELEMETRY_CMD",
+    justfile_directory() + "/scripts/publish_telemetry.py",
+)
+telemetry_args := env_var_or_default("TELEMETRY_ARGS", "")
 
 _default:
     @just --list
@@ -92,6 +97,10 @@ monitor-ssd-health:
 # Usage: just smoke-test-pi SMOKE_ARGS="pi-a.local --reboot"
 smoke-test-pi:
     "{{smoke_cmd}}" {{smoke_args}}
+
+# Publish anonymized telemetry payloads once.
+publish-telemetry:
+    "{{telemetry_cmd}}" {{telemetry_args}}
 
 # Install CLI dependencies inside GitHub Codespaces or fresh containers
 # Usage: just codespaces-bootstrap

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -276,6 +276,9 @@ fi
 install -Dm755 "${REPO_ROOT}/scripts/pi_node_verifier.sh" \
   "${WORK_DIR}/pi-gen/stage2/02-sugarkube-tools/files/usr/local/sbin/pi_node_verifier.sh"
 
+install -Dm755 "${REPO_ROOT}/scripts/publish_telemetry.py" \
+  "${WORK_DIR}/pi-gen/stage2/02-sugarkube-tools/files/usr/local/bin/sugarkube-publish-telemetry"
+
 install -Dm755 "${EXPORT_KUBECONFIG_PATH}" \
   "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/export-kubeconfig.sh"
 

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -133,6 +133,56 @@ write_files:
       [Journal]
       Storage=persistent
       SystemMaxUse=200M
+  - path: /etc/sugarkube/telemetry.env
+    permissions: '0600'
+    content: |
+      # Set SUGARKUBE_TELEMETRY_ENABLE="true" to publish anonymized health telemetry.
+      SUGARKUBE_TELEMETRY_ENABLE="false"
+      # Configure the HTTPS endpoint that receives telemetry payloads.
+      SUGARKUBE_TELEMETRY_ENDPOINT=""
+      # Optional bearer token included in Authorization headers.
+      # Uncomment and set SUGARKUBE_TELEMETRY_TOKEN once you have a bearer token.
+      # Optional salt mixed into the hashed instance identifier.
+      SUGARKUBE_TELEMETRY_SALT=""
+      # Optional comma-separated labels (e.g., "lab,pi-a") for dashboards.
+      SUGARKUBE_TELEMETRY_TAGS=""
+      # HTTP timeout in seconds for uploads.
+      SUGARKUBE_TELEMETRY_TIMEOUT="10"
+      # Timeout in seconds for pi_node_verifier execution.
+      SUGARKUBE_TELEMETRY_VERIFIER_TIMEOUT="180"
+  - path: /etc/systemd/system/sugarkube-telemetry.service
+    permissions: '0644'
+    content: |
+      [Unit]
+      Description=Publish sugarkube verifier telemetry
+      After=network-online.target
+      Wants=network-online.target
+      ConditionPathExists=/usr/local/bin/sugarkube-publish-telemetry
+
+      [Service]
+      Type=oneshot
+      EnvironmentFile=-/etc/sugarkube/telemetry.env
+      ExecStart=/usr/local/bin/sugarkube-publish-telemetry
+      Nice=10
+      IOSchedulingClass=best-effort
+      IOSchedulingPriority=6
+
+      [Install]
+      WantedBy=multi-user.target
+  - path: /etc/systemd/system/sugarkube-telemetry.timer
+    permissions: '0644'
+    content: |
+      [Unit]
+      Description=Run sugarkube telemetry publisher periodically
+
+      [Timer]
+      OnBootSec=5min
+      OnUnitActiveSec=1h
+      AccuracySec=5min
+      Persistent=true
+
+      [Install]
+      WantedBy=timers.target
   # projects-start
   - path: /etc/systemd/system/projects-compose.service
     permissions: '0644'

--- a/scripts/publish_telemetry.py
+++ b/scripts/publish_telemetry.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""Publish anonymized sugarkube telemetry to a configurable endpoint."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Iterable, List, Mapping, MutableMapping, Sequence
+
+TELEMETRY_SCHEMA = "https://sugarkube.dev/telemetry/v1"
+DEFAULT_TIMEOUT = 10.0
+DEFAULT_VERIFIER_TIMEOUT = 120.0
+
+
+class TelemetryError(RuntimeError):
+    """Raised when telemetry generation or upload fails."""
+
+
+def log(message: str) -> None:
+    sys.stderr.write(f"{message}\n")
+
+
+def env_flag(value: str | None, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    value = value.strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
+def coerce_timeout(
+    value: float | int | str | None,
+    *,
+    default: float,
+    env_var: str,
+    flag: str,
+) -> float:
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip()
+    if not text:
+        raise TelemetryError(f"invalid {flag} value from {env_var}: expected a number")
+    try:
+        return float(text)
+    except ValueError as exc:
+        raise TelemetryError(f"invalid {flag} value {value!r} (set {env_var} to a number)") from exc
+
+
+def parse_verifier_output(raw: str) -> List[Mapping[str, str]]:
+    if not raw or not raw.strip():
+        raise TelemetryError("verifier output was empty")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise TelemetryError("verifier output was not valid JSON") from exc
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        raise TelemetryError("verifier output missing checks array")
+    parsed: List[Mapping[str, str]] = []
+    for entry in checks:
+        if not isinstance(entry, Mapping):
+            continue
+        name = entry.get("name")
+        status = entry.get("status")
+        if isinstance(name, str) and isinstance(status, str):
+            parsed.append({"name": name, "status": status})
+    if not parsed:
+        raise TelemetryError("verifier checks were empty after filtering")
+    return parsed
+
+
+def summarise_checks(checks: Iterable[Mapping[str, str]]) -> MutableMapping[str, object]:
+    total = 0
+    passed = 0
+    failed: List[str] = []
+    skipped = 0
+    other = 0
+    for check in checks:
+        total += 1
+        status = check.get("status", "")
+        if status == "pass":
+            passed += 1
+        elif status == "fail":
+            failed.append(check.get("name", "unknown"))
+        elif status == "skip":
+            skipped += 1
+        else:
+            other += 1
+    return {
+        "total": total,
+        "passed": passed,
+        "failed": len(failed),
+        "skipped": skipped,
+        "other": other,
+        "failed_checks": failed,
+    }
+
+
+def read_text(path: Path) -> str:
+    try:
+        data = path.read_text(encoding="utf-8", errors="ignore").strip()
+    except OSError:
+        return ""
+    return data
+
+
+def fingerprint_sources() -> List[str]:
+    sources: List[str] = []
+    for candidate in (
+        Path("/etc/machine-id"),
+        Path("/var/lib/dbus/machine-id"),
+    ):
+        data = read_text(candidate)
+        if data:
+            sources.append(f"{candidate}:{data}")
+    cpuinfo = read_text(Path("/proc/cpuinfo"))
+    if cpuinfo:
+        for line in cpuinfo.splitlines():
+            if line.lower().startswith("serial"):
+                parts = line.split(":", 1)
+                if len(parts) == 2:
+                    serial = parts[1].strip()
+                    if serial:
+                        sources.append(f"cpu-serial:{serial}")
+                break
+    model = read_text(Path("/proc/device-tree/model"))
+    if model:
+        sources.append(f"model:{model}")
+    return sources
+
+
+def hashed_identifier(*, salt: str = "") -> str:
+    sources = fingerprint_sources()
+    if not sources:
+        sources.append(f"uuid:{uuid.getnode():x}")
+    digest = hashlib.sha256()
+    if salt:
+        digest.update(salt.encode("utf-8", errors="ignore"))
+    digest.update("::".join(sources).encode("utf-8", errors="ignore"))
+    return digest.hexdigest()
+
+
+def collect_os_release() -> Mapping[str, str]:
+    path = Path("/etc/os-release")
+    data = read_text(path)
+    result: dict[str, str] = {}
+    if not data:
+        return result
+    for line in data.splitlines():
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        value = value.strip().strip('"')
+        result[key] = value
+    return result
+
+
+def read_uptime() -> float | None:
+    data = read_text(Path("/proc/uptime"))
+    if not data:
+        return None
+    first = data.split()[0]
+    try:
+        return float(first)
+    except ValueError:
+        return None
+
+
+def collect_environment() -> MutableMapping[str, object]:
+    env: MutableMapping[str, object] = {}
+    uptime = read_uptime()
+    if uptime is not None:
+        env["uptime_seconds"] = int(uptime)
+    uname = os.uname()
+    env["kernel"] = f"{uname.sysname} {uname.release}"
+    hardware = read_text(Path("/proc/device-tree/model"))
+    if hardware:
+        env["hardware_model"] = hardware.replace("\x00", "")
+    os_release = collect_os_release()
+    if os_release:
+        env["os_release"] = {
+            key: os_release[key]
+            for key in sorted(os_release)
+            if key in {"ID", "ID_LIKE", "PRETTY_NAME", "VERSION", "VERSION_ID"}
+        }
+    return env
+
+
+def parse_tags(raw: str | None) -> List[str]:
+    if not raw:
+        return []
+    tags = []
+    for piece in raw.split(","):
+        cleaned = piece.strip()
+        if cleaned:
+            tags.append(cleaned)
+    return tags
+
+
+def build_payload(
+    *,
+    checks: Sequence[Mapping[str, str]],
+    identifier: str,
+    env_snapshot: Mapping[str, object],
+    errors: Sequence[str],
+    tags: Sequence[str],
+) -> MutableMapping[str, object]:
+    timestamp = _dt.datetime.now(tz=_dt.timezone.utc).isoformat()
+    summary = summarise_checks(checks)
+    payload: MutableMapping[str, object] = {
+        "schema": TELEMETRY_SCHEMA,
+        "generated_at": timestamp,
+        "instance": {"id": identifier},
+        "verifier": {
+            "summary": summary,
+            "checks": list(checks),
+        },
+        "environment": dict(env_snapshot),
+    }
+    if errors:
+        payload["errors"] = list(errors)
+    if tags:
+        payload["tags"] = list(tags)
+    return payload
+
+
+def discover_verifier_path(explicit: str | None) -> str | None:
+    candidates: List[str] = []
+    if explicit:
+        candidates.append(explicit)
+    env_value = os.environ.get("SUGARKUBE_TELEMETRY_VERIFIER")
+    if env_value:
+        candidates.append(env_value)
+    script_dir = Path(__file__).resolve().parent
+    candidates.extend(
+        [
+            str(script_dir / "pi_node_verifier.sh"),
+            "/usr/local/sbin/pi_node_verifier.sh",
+            "/usr/local/bin/pi_node_verifier.sh",
+            "/opt/sugarkube/pi_node_verifier.sh",
+            "pi_node_verifier.sh",
+        ]
+    )
+    for candidate in candidates:
+        if not candidate:
+            continue
+        path = Path(candidate)
+        if path.is_file() and os.access(path, os.X_OK):
+            return str(path)
+        resolved = shutil.which(candidate) if not path.is_absolute() else None
+        if resolved:
+            return resolved
+    return None
+
+
+def run_verifier(verifier_path: str, timeout: float) -> tuple[List[Mapping[str, str]], List[str]]:
+    errors: List[str] = []
+    try:
+        result = subprocess.run(
+            [verifier_path, "--json", "--no-log"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError as exc:
+        raise TelemetryError(f"verifier not found at {verifier_path}") from exc
+    except subprocess.TimeoutExpired:
+        errors.append("verifier_timeout")
+        return [], errors
+    except subprocess.CalledProcessError as exc:
+        errors.append(f"verifier_exit_{exc.returncode}")
+        output = exc.stdout or ""
+        if output:
+            try:
+                checks = parse_verifier_output(output)
+                return checks, errors
+            except TelemetryError as inner:
+                errors.append(str(inner))
+        return [], errors
+    try:
+        checks = parse_verifier_output(result.stdout)
+    except TelemetryError as exc:
+        errors.append(str(exc))
+        checks = []
+    return checks, errors
+
+
+def send_payload(
+    payload: Mapping[str, object],
+    *,
+    endpoint: str,
+    auth_bearer: str | None,
+    timeout: float,
+) -> None:
+    body = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    request = urllib.request.Request(endpoint, data=body, method="POST")
+    request.add_header("Content-Type", "application/json")
+    request.add_header("User-Agent", "sugarkube-telemetry/1.0")
+    if auth_bearer:
+        request.add_header("Authorization", f"Bearer {auth_bearer}")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            # Drain body to allow keep-alive reuse even though we discard it.
+            response.read()
+    except urllib.error.HTTPError as exc:
+        raise TelemetryError(f"telemetry endpoint returned HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise TelemetryError(f"telemetry upload failed: {exc.reason}") from exc
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--endpoint",
+        help="Telemetry ingestion endpoint",
+        default=os.environ.get("SUGARKUBE_TELEMETRY_ENDPOINT", ""),
+    )
+    parser.add_argument(
+        "--token",
+        dest="auth_bearer",
+        help="Bearer token passed to the telemetry endpoint",
+        default=os.environ.get("SUGARKUBE_TELEMETRY_TOKEN"),
+    )
+    parser.add_argument(
+        "--salt",
+        help="Additional salt mixed into the anonymized identifier",
+        default=os.environ.get("SUGARKUBE_TELEMETRY_SALT", ""),
+    )
+    parser.add_argument(
+        "--tags",
+        help="Comma-separated tags describing this node or environment",
+        default=os.environ.get("SUGARKUBE_TELEMETRY_TAGS", ""),
+    )
+    parser.add_argument(
+        "--timeout",
+        default=os.environ.get("SUGARKUBE_TELEMETRY_TIMEOUT"),
+        help="HTTP timeout in seconds",
+    )
+    parser.add_argument(
+        "--verifier-timeout",
+        default=os.environ.get("SUGARKUBE_TELEMETRY_VERIFIER_TIMEOUT"),
+        help="Timeout in seconds for pi_node_verifier execution",
+    )
+    parser.add_argument(
+        "--verifier",
+        help="Path to pi_node_verifier.sh (auto-detected when omitted)",
+        default=None,
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=env_flag(os.environ.get("SUGARKUBE_TELEMETRY_DRY_RUN")),
+        help="Generate telemetry JSON without sending it",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Run even when SUGARKUBE_TELEMETRY_ENABLE is false",
+    )
+    parser.add_argument(
+        "--print-payload",
+        action="store_true",
+        help="Print payload JSON after a successful upload",
+    )
+    args = parser.parse_args(argv)
+    args.timeout = coerce_timeout(
+        args.timeout,
+        default=DEFAULT_TIMEOUT,
+        env_var="SUGARKUBE_TELEMETRY_TIMEOUT",
+        flag="--timeout",
+    )
+    args.verifier_timeout = coerce_timeout(
+        args.verifier_timeout,
+        default=DEFAULT_VERIFIER_TIMEOUT,
+        env_var="SUGARKUBE_TELEMETRY_VERIFIER_TIMEOUT",
+        flag="--verifier-timeout",
+    )
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    enabled = env_flag(os.environ.get("SUGARKUBE_TELEMETRY_ENABLE"))
+    if not (args.force or args.dry_run or enabled):
+        log("telemetry disabled (set SUGARKUBE_TELEMETRY_ENABLE=true to enable)")
+        return 0
+    verifier_path = discover_verifier_path(args.verifier)
+    if not verifier_path:
+        raise TelemetryError("pi_node_verifier.sh could not be located")
+    checks, errors = run_verifier(verifier_path, args.verifier_timeout)
+    identifier = hashed_identifier(salt=args.salt)
+    env_snapshot = collect_environment()
+    tags = parse_tags(args.tags)
+    payload = build_payload(
+        checks=checks,
+        identifier=identifier,
+        env_snapshot=env_snapshot,
+        errors=errors,
+        tags=tags,
+    )
+    if args.dry_run:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    endpoint = args.endpoint.strip()
+    if not endpoint:
+        raise TelemetryError(
+            "telemetry endpoint not configured "
+            "(set SUGARKUBE_TELEMETRY_ENDPOINT or pass --endpoint)"
+        )
+    send_payload(
+        payload,
+        endpoint=endpoint,
+        auth_bearer=args.auth_bearer,
+        timeout=args.timeout,
+    )
+    if args.print_payload:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    try:
+        raise SystemExit(main())
+    except TelemetryError as exc:
+        log(f"error: {exc}")
+        raise SystemExit(1)

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -449,6 +449,11 @@ def _run_build_script(tmp_path, env):
     collect.write_text(collect_src.read_text())
     collect.chmod(0o755)
 
+    telemetry_src = repo_root / "scripts" / "publish_telemetry.py"
+    telemetry = script_dir / "publish_telemetry.py"
+    telemetry.write_text(telemetry_src.read_text())
+    telemetry.chmod(0o755)
+
     metadata_src = repo_root / "scripts" / "create_build_metadata.py"
     metadata_script = script_dir / "create_build_metadata.py"
     metadata_script.write_text(metadata_src.read_text())

--- a/tests/test_publish_telemetry.py
+++ b/tests/test_publish_telemetry.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "scripts" / "publish_telemetry.py"
+SPEC = importlib.util.spec_from_file_location("publish_telemetry", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)  # type: ignore[arg-type]
+
+
+def test_parse_verifier_output_filters_invalid_entries():
+    payload = {
+        "checks": [
+            {"name": "ready", "status": "pass"},
+            {"name": "projects", "status": "fail"},
+            "skip-me",
+            {"name": "broken"},
+        ]
+    }
+    checks = MODULE.parse_verifier_output(json.dumps(payload))
+    assert checks == [
+        {"name": "ready", "status": "pass"},
+        {"name": "projects", "status": "fail"},
+    ]
+
+
+def test_summarise_checks_reports_counts():
+    checks = [
+        {"name": "one", "status": "pass"},
+        {"name": "two", "status": "fail"},
+        {"name": "three", "status": "skip"},
+        {"name": "four", "status": "weird"},
+    ]
+    summary = MODULE.summarise_checks(checks)
+    assert summary["total"] == 4
+    assert summary["passed"] == 1
+    assert summary["failed"] == 1
+    assert summary["skipped"] == 1
+    assert summary["other"] == 1
+    assert summary["failed_checks"] == ["two"]
+
+
+def test_hashed_identifier_uses_salt(monkeypatch):
+    def fake_sources():
+        return ["machine-id:abc", "cpu-serial:123"]
+
+    monkeypatch.setattr(MODULE, "fingerprint_sources", fake_sources)
+    no_salt = MODULE.hashed_identifier(salt="")
+    salted = MODULE.hashed_identifier(salt="pepper")
+    assert no_salt != salted
+    assert len(no_salt) == 64
+    assert len(salted) == 64
+
+
+def test_build_payload_includes_summary_and_tags():
+    checks = [
+        {"name": "ready", "status": "pass"},
+        {"name": "projects", "status": "fail"},
+    ]
+    env = {"kernel": "Linux 6.1"}
+    payload = MODULE.build_payload(
+        checks=checks,
+        identifier="abc123",
+        env_snapshot=env,
+        errors=["verifier_timeout"],
+        tags=["lab", "pi"],
+    )
+    assert payload["instance"] == {"id": "abc123"}
+    assert payload["environment"] == env
+    assert payload["errors"] == ["verifier_timeout"]
+    assert payload["tags"] == ["lab", "pi"]
+    summary = payload["verifier"]["summary"]
+    assert summary["total"] == 2
+    assert summary["failed_checks"] == ["projects"]
+
+
+def test_parse_args_rejects_invalid_timeout(monkeypatch):
+    monkeypatch.setenv("SUGARKUBE_TELEMETRY_TIMEOUT", "ten")
+    with pytest.raises(MODULE.TelemetryError, match="--timeout"):
+        MODULE.parse_args([])
+
+
+def test_parse_args_rejects_blank_verifier_timeout(monkeypatch):
+    monkeypatch.setenv("SUGARKUBE_TELEMETRY_VERIFIER_TIMEOUT", "   ")
+    with pytest.raises(MODULE.TelemetryError, match="--verifier-timeout"):
+        MODULE.parse_args([])


### PR DESCRIPTION
## Summary
- update the build_pi_image test harness to copy publish_telemetry.py into the temporary scripts directory so the build script can bundle it during tests

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py
- pytest tests/build_pi_image_test.py::test_uses_default_pi_gen_branch -q

------
https://chatgpt.com/codex/tasks/task_e_68cf73b33768832fbefa521ff4e1479a