### PR TITLE
Add self-healing automation for compose/cloud-init failures

### DIFF
--- a/docs/pi_image_contributor_guide.md
+++ b/docs/pi_image_contributor_guide.md
@@ -89,6 +89,15 @@ sync.
     [Pi Boot & Cluster Troubleshooting](./pi_boot_troubleshooting.md).
   - Related tooling: bundled by `build_pi_image.sh`, enabled via systemd, and covered by
     `tests/first_boot_service_test.py`.
+- `scripts/self_heal_service.py` + `sugarkube-self-heal@.service`
+  - Purpose: respond to `projects-compose` and `cloud-init` failures by retrying Docker Compose pulls,
+    running `cloud-init clean --logs`, and escalating to `rescue.target` with Markdown summaries under
+    `/boot/first-boot-report/self-heal/`.
+  - Primary docs: [Pi Image Quickstart](./pi_image_quickstart.md),
+    [Pi Boot & Cluster Troubleshooting](./pi_boot_troubleshooting.md),
+    [projects-compose Service](./projects-compose.md).
+  - Related tooling: installed by `build_pi_image.sh`, invoked via `OnFailure`, and validated by
+    `tests/self_heal_service_test.py`.
 - `scripts/pi_smoke_test.py`
   - Purpose: orchestrate remote verifier runs over SSH, optionally rebooting hosts to confirm
     convergence and emitting JSON for CI harnesses.

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -66,7 +66,10 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
   - `pi_node_verifier.sh` now writes Markdown summaries (hardware, cloud-init,
     checksum checks) to `/boot/first-boot-report.txt` and ingests migration
     events recorded by `scripts/cloud-init/start-projects.sh`.
-- [ ] Add self-healing units that retry container pulls, rerun `cloud-init clean`, or reboot into maintenance with actionable logs.
+- [x] Add self-healing units that retry container pulls, rerun `cloud-init clean`, or reboot into maintenance with actionable logs.
+  - Added `sugarkube-self-heal@.service` and `self_heal_service.py`, which retry Docker Compose pulls,
+    restart failed units, clean `cloud-init`, capture journals under `/boot/first-boot-report/self-heal/`,
+    and escalate to `rescue.target` after repeated failures.
 - [x] Provide optional telemetry hooks to publish anonymized health data to a shared dashboard.
   - Added `sugarkube-publish-telemetry`, cloud-init environment/service templates, Makefile/just
     wrappers, and docs covering opt-in uploads to custom collectors.

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -144,6 +144,11 @@ scan straight to this quickstart or the troubleshooting matrix while standing at
   is `active`, and curls the token.place and dspace endpoints. Override the HTTP
   probes by exporting `TOKEN_PLACE_HEALTH_URL`, `DSPACE_HEALTH_URL`, and related
   `*_INSECURE` flags before invoking `/opt/sugarkube/pi_node_verifier.sh`.
+- When `cloud-init` or `projects-compose.service` fail, `sugarkube-self-heal@.service`
+  retries Docker Compose pulls, runs `cloud-init clean --logs`, and restarts the units.
+  After three unsuccessful attempts it stores escalation summaries under
+  `/boot/first-boot-report/self-heal/` and isolates the system in `rescue.target` so you
+  can review logs with a console attached.
 - The boot partition now includes recovery hand-offs generated once k3s
   finishes installing:
   - `/boot/sugarkube-kubeconfig` is a sanitized kubeconfig whose secrets are

--- a/docs/projects-compose.md
+++ b/docs/projects-compose.md
@@ -51,3 +51,12 @@ Grow the compose stack with additional repositories:
 
 These hooks keep the Pi image ready for new services without editing existing
 entries.
+
+## Self-healing retries
+
+`projects-compose.service` now declares an `OnFailure` hook that starts
+`sugarkube-self-heal@projects-compose.service`. The helper reruns `docker compose`
+pulls, restarts the unit, and captures logs in `/boot/first-boot-report/self-heal/`.
+After three failed attempts the Pi isolates into `rescue.target` so you can
+review the Markdown summary and fix credentials or network issues before trying
+again.

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -279,6 +279,9 @@ install -Dm755 "${REPO_ROOT}/scripts/pi_node_verifier.sh" \
 install -Dm755 "${REPO_ROOT}/scripts/first_boot_service.py" \
   "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/first_boot_service.py"
 
+install -Dm755 "${REPO_ROOT}/scripts/self_heal_service.py" \
+  "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/self_heal_service.py"
+
 install -Dm644 "${REPO_ROOT}/scripts/systemd/first-boot.service" \
   "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/etc/systemd/system/first-boot.service"
 

--- a/scripts/cloud-init/user-data.yaml
+++ b/scripts/cloud-init/user-data.yaml
@@ -183,6 +183,20 @@ write_files:
 
       [Install]
       WantedBy=timers.target
+  - path: /etc/systemd/system/sugarkube-self-heal@.service
+    permissions: '0644'
+    content: |
+      [Unit]
+      Description=Self-heal automation for %I failures
+      After=network-online.target
+
+      [Service]
+      Type=oneshot
+      Environment=PYTHONUNBUFFERED=1
+      ExecStart=/opt/sugarkube/self_heal_service.py --unit %I --reason "%I failure"
+      StandardOutput=journal
+      StandardError=journal
+      SyslogIdentifier=sugarkube-self-heal
   # projects-start
   - path: /etc/systemd/system/projects-compose.service
     permissions: '0644'
@@ -192,6 +206,8 @@ write_files:
       Requires=docker.service
       After=docker.service network-online.target
       Wants=network-online.target
+      OnFailure=sugarkube-self-heal@%n.service
+      OnFailureJobMode=replace-irreversibly
 
       [Service]
       Type=oneshot
@@ -205,6 +221,24 @@ write_files:
 
       [Install]
       WantedBy=multi-user.target
+  - path: /etc/systemd/system/cloud-init.service.d/99-sugarkube-self-heal.conf
+    permissions: '0644'
+    content: |
+      [Unit]
+      OnFailure=sugarkube-self-heal@%n.service
+      OnFailureJobMode=replace-irreversibly
+  - path: /etc/systemd/system/cloud-config.service.d/99-sugarkube-self-heal.conf
+    permissions: '0644'
+    content: |
+      [Unit]
+      OnFailure=sugarkube-self-heal@%n.service
+      OnFailureJobMode=replace-irreversibly
+  - path: /etc/systemd/system/cloud-final.service.d/99-sugarkube-self-heal.conf
+    permissions: '0644'
+    content: |
+      [Unit]
+      OnFailure=sugarkube-self-heal@%n.service
+      OnFailureJobMode=replace-irreversibly
   - path: /etc/systemd/system/k3s-ready.service
     permissions: '0644'
     content: |

--- a/scripts/self_heal_service.py
+++ b/scripts/self_heal_service.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+
+"""Systemd self-healing helper for sugarkube Pi images.
+
+This helper is invoked by ``sugarkube-self-heal@.service`` when a critical unit
+fails (for example ``projects-compose.service`` or ``cloud-final.service``).
+It retries automated recovery steps, captures diagnostic logs, and escalates to
+maintenance mode after repeated failures.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_STATE_DIR = Path("/var/log/sugarkube/self-heal")
+DEFAULT_BOOT_DIR = Path("/boot/first-boot-report/self-heal")
+DEFAULT_LOG_DIR = DEFAULT_STATE_DIR
+DEFAULT_MAX_ATTEMPTS = 3
+DEFAULT_TIMEOUT = 120
+
+
+@dataclass
+class CommandResult:
+    cmd: list[str]
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+class CommandRunner:
+    """Execute commands with optional test-mode overrides."""
+
+    def __init__(self, logger: "SelfHealLogger") -> None:
+        self.logger = logger
+        self.test_mode = os.environ.get("SELF_HEAL_TEST_MODE", "0") != "0"
+        failures = os.environ.get("SELF_HEAL_TEST_FAILURES", "")
+        self.failure_patterns = {
+            pattern.strip() for pattern in failures.split(",") if pattern.strip()
+        }
+
+    def run(self, cmd: Iterable[str], check: bool = False) -> CommandResult:
+        args = list(cmd)
+        if not args:
+            raise ValueError("command must not be empty")
+
+        cmd_str = " ".join(args)
+        if self.test_mode:
+            result = self._run_test_mode(args, cmd_str)
+        else:
+            result = self._run_real(args)
+
+        self.logger.log(f"ran: {cmd_str} (rc={result.returncode})")
+        if result.stdout.strip():
+            self.logger.log(f"stdout: {result.stdout.strip()}")
+        if result.stderr.strip():
+            self.logger.log(f"stderr: {result.stderr.strip()}")
+
+        if check and result.returncode != 0:
+            raise subprocess.CalledProcessError(
+                result.returncode, args, output=result.stdout, stderr=result.stderr
+            )
+        return result
+
+    def _run_real(self, args: list[str]) -> CommandResult:
+        try:
+            completed = subprocess.run(
+                args,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=DEFAULT_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired as exc:
+            stdout = exc.stdout or ""
+            stderr = exc.stderr or ""
+            return CommandResult(args, 124, stdout, stderr)
+        return CommandResult(args, completed.returncode, completed.stdout, completed.stderr)
+
+    def _run_test_mode(self, args: list[str], cmd_str: str) -> CommandResult:
+        for pattern in self.failure_patterns:
+            if pattern and pattern in cmd_str:
+                stdout = ""
+                stderr = f"forced failure via {pattern}"
+                return CommandResult(args, 1, stdout, stderr)
+
+        stdout = ""
+        if len(args) >= 3 and args[0] == "systemctl" and args[1] == "is-active":
+            stdout = "active\n"
+        elif len(args) >= 2 and args[0] == "cloud-init" and args[1] == "status":
+            stdout = "status: done\n"
+        return CommandResult(args, 0, stdout, "")
+
+
+class SelfHealLogger:
+    """Append structured logs to an on-disk file."""
+
+    def __init__(self, log_file: Path) -> None:
+        self.log_file = log_file
+        self.log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    def log(self, message: str) -> None:
+        timestamp = datetime.now(timezone.utc).isoformat()
+        line = f"{timestamp} {message}"
+        print(line)
+        with self.log_file.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+
+
+@dataclass
+class SelfHealConfig:
+    unit: str
+    state_dir: Path
+    boot_dir: Path
+    log_dir: Path
+    max_attempts: int
+
+    @classmethod
+    def from_env(cls, unit: str) -> "SelfHealConfig":
+        state_dir = Path(os.environ.get("SELF_HEAL_STATE_DIR", str(DEFAULT_STATE_DIR)))
+        boot_dir = Path(os.environ.get("SELF_HEAL_BOOT_DIR", str(DEFAULT_BOOT_DIR)))
+        log_dir = Path(os.environ.get("SELF_HEAL_LOG_DIR", str(DEFAULT_LOG_DIR)))
+        max_attempts = int(os.environ.get("SELF_HEAL_MAX_ATTEMPTS", DEFAULT_MAX_ATTEMPTS))
+        return cls(
+            unit=unit,
+            state_dir=state_dir,
+            boot_dir=boot_dir,
+            log_dir=log_dir,
+            max_attempts=max_attempts,
+        )
+
+    @property
+    def unit_slug(self) -> str:
+        return self.unit.replace("/", "-")
+
+    @property
+    def state_file(self) -> Path:
+        return self.state_dir / f"{self.unit_slug}.json"
+
+    @property
+    def log_file(self) -> Path:
+        return self.log_dir / f"{self.unit_slug}.log"
+
+
+def load_state(path: Path) -> dict:
+    if not path.exists():
+        return {"attempts": 0, "updated": None}
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except (json.JSONDecodeError, OSError):
+        return {"attempts": 0, "updated": None}
+
+
+def save_state(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data["updated"] = datetime.now(timezone.utc).isoformat()
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, sort_keys=True)
+
+
+def capture_logs(runner: CommandRunner, logger: SelfHealLogger, unit: str) -> str:
+    journal_output = ""
+    if shutil.which("journalctl") or runner.test_mode:
+        result = runner.run(["journalctl", "-u", unit, "--no-pager", "-n", "200"])
+        journal_output = result.stdout
+    else:
+        logger.log("journalctl not available; skipping unit logs")
+    return journal_output
+
+
+def write_boot_summary(
+    config: SelfHealConfig,
+    logger: SelfHealLogger,
+    journal: str,
+    reason: str,
+) -> Path | None:
+    try:
+        config.boot_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.log(f"failed to create boot directory {config.boot_dir}: {exc}")
+        return None
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    summary_path = config.boot_dir / f"{config.unit_slug}-maintenance-{timestamp}.md"
+    try:
+        with summary_path.open("w", encoding="utf-8") as handle:
+            handle.write(f"# Self-heal escalation for {config.unit}\n\n")
+            handle.write(f"- Timestamp: {datetime.now(timezone.utc).isoformat()}\n")
+            handle.write(f"- Reason: {reason}\n")
+            handle.write(f"- Attempts: escalated after {config.max_attempts} failures\n")
+            handle.write(
+                "- Next steps: connect via console, review logs below, and re-run the verifier.\n\n"
+            )
+            if journal.strip():
+                handle.write("## Recent journalctl output\n\n`````\n")
+                handle.write(journal.strip())
+                handle.write("\n`````\n")
+            else:
+                handle.write("No journal output was captured.\n")
+    except OSError as exc:
+        logger.log(f"failed to write boot summary {summary_path}: {exc}")
+        return None
+
+    logger.log(f"wrote escalation summary to {summary_path}")
+    return summary_path
+
+
+def enter_maintenance(runner: CommandRunner, logger: SelfHealLogger) -> None:
+    logger.log("entering maintenance mode via rescue.target")
+    if runner.test_mode:
+        logger.log("test mode enabled; skipping systemctl isolate rescue.target")
+        return
+    runner.run(["systemctl", "isolate", "rescue.target"])
+
+
+def handle_projects_compose(
+    config: SelfHealConfig,
+    runner: CommandRunner,
+    logger: SelfHealLogger,
+) -> bool:
+    compose_file = "/opt/projects/docker-compose.yml"
+    if not Path(compose_file).exists() and not runner.test_mode:
+        logger.log(f"compose file missing: {compose_file}")
+        return False
+
+    if shutil.which("docker") or runner.test_mode:
+        runner.run(["docker", "compose", "-f", compose_file, "pull"])
+        runner.run(["docker", "compose", "-f", compose_file, "up", "-d"])
+    else:
+        logger.log("docker not available; cannot refresh containers")
+        return False
+
+    if shutil.which("systemctl") or runner.test_mode:
+        runner.run(["systemctl", "reset-failed", config.unit])
+        runner.run(["systemctl", "restart", config.unit])
+        status = runner.run(["systemctl", "is-active", config.unit])
+        return status.returncode == 0 and "active" in status.stdout.lower()
+
+    logger.log("systemctl not available; cannot restart compose unit")
+    return False
+
+
+def handle_cloud_init(
+    config: SelfHealConfig,
+    runner: CommandRunner,
+    logger: SelfHealLogger,
+) -> bool:
+    if not shutil.which("cloud-init") and not runner.test_mode:
+        logger.log("cloud-init missing; cannot clean state")
+        return False
+
+    runner.run(["cloud-init", "status", "--long"])
+    runner.run(["cloud-init", "clean", "--logs"])
+
+    if shutil.which("systemctl") or runner.test_mode:
+        runner.run(["systemctl", "reset-failed", "cloud-init.target"])
+        runner.run(["systemctl", "start", "cloud-init.target"])
+    else:
+        logger.log("systemctl not available; skipping cloud-init target restart")
+        return False
+
+    status = runner.run(["cloud-init", "status", "--wait", "--long"])
+    if status.returncode != 0:
+        return False
+    return "status: done" in status.stdout.lower()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Sugarkube self-heal helper")
+    parser.add_argument("--unit", required=True, help="systemd unit that triggered self-heal")
+    parser.add_argument("--reason", default="unit failure", help="optional failure reason")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    config = SelfHealConfig.from_env(args.unit)
+    logger = SelfHealLogger(config.log_file)
+    runner = CommandRunner(logger)
+
+    state = load_state(config.state_file)
+    attempts = int(state.get("attempts", 0)) + 1
+    state["attempts"] = attempts
+    save_state(config.state_file, state)
+    logger.log(f"self-heal attempt {attempts}/{config.max_attempts} for {config.unit}")
+
+    success = False
+    if args.unit == "projects-compose.service":
+        success = handle_projects_compose(config, runner, logger)
+    elif args.unit in {"cloud-final.service", "cloud-init.service", "cloud-config.service"}:
+        success = handle_cloud_init(config, runner, logger)
+    else:
+        logger.log(f"no self-heal recipe for {args.unit}")
+
+    if success:
+        logger.log(f"recovery succeeded for {config.unit}; resetting attempt counter")
+        save_state(config.state_file, {"attempts": 0})
+        return 0
+
+    logger.log(f"recovery failed for {config.unit}")
+    if attempts >= config.max_attempts:
+        journal = capture_logs(runner, logger, config.unit)
+        summary = write_boot_summary(config, logger, journal, args.reason)
+        if summary is not None:
+            logger.log(f"summary available at {summary}")
+        enter_maintenance(runner, logger)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -506,6 +506,10 @@ def _run_build_script(tmp_path, env):
     shutil.copy(first_boot_src, script_dir / "first_boot_service.py")
     (script_dir / "first_boot_service.py").chmod(0o755)
 
+    self_heal_src = repo_root / "scripts" / "self_heal_service.py"
+    shutil.copy(self_heal_src, script_dir / "self_heal_service.py")
+    (script_dir / "self_heal_service.py").chmod(0o755)
+
     systemd_src = repo_root / "scripts" / "systemd" / "first-boot.service"
     systemd_dir = script_dir / "systemd"
     systemd_dir.mkdir(exist_ok=True)

--- a/tests/self_heal_service_test.py
+++ b/tests/self_heal_service_test.py
@@ -1,0 +1,100 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "self_heal_service.py"
+
+
+def _run(
+    unit: str,
+    tmp_path: Path,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env.update(
+        {
+            "SELF_HEAL_STATE_DIR": str(tmp_path / "state"),
+            "SELF_HEAL_BOOT_DIR": str(tmp_path / "boot"),
+            "SELF_HEAL_LOG_DIR": str(tmp_path / "logs"),
+            "SELF_HEAL_TEST_MODE": "1",
+        }
+    )
+    if extra_env:
+        env.update(extra_env)
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--unit", unit],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    return result
+
+
+def _load_state(tmp_path: Path, unit: str) -> dict:
+    state_file = tmp_path / "state" / f"{unit}.json"
+    assert state_file.exists()
+    with state_file.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def test_projects_compose_success(tmp_path: Path) -> None:
+    result = _run("projects-compose.service", tmp_path)
+    assert result.returncode == 0
+
+    state = _load_state(tmp_path, "projects-compose.service")
+    assert state["attempts"] == 0
+
+    log_file = tmp_path / "logs" / "projects-compose.service.log"
+    contents = log_file.read_text(encoding="utf-8")
+    assert "recovery succeeded" in contents
+    assert "docker compose" in contents
+
+
+def test_projects_compose_escalates_after_threshold(tmp_path: Path) -> None:
+    env = {
+        "SELF_HEAL_MAX_ATTEMPTS": "2",
+        "SELF_HEAL_TEST_FAILURES": "systemctl is-active projects-compose",
+    }
+    first = _run("projects-compose.service", tmp_path, env)
+    assert first.returncode == 1
+    state = _load_state(tmp_path, "projects-compose.service")
+    assert state["attempts"] == 1
+
+    boot_dir = tmp_path / "boot"
+    assert not list(boot_dir.glob("*.md"))
+
+    second = _run("projects-compose.service", tmp_path, env)
+    assert second.returncode == 1
+    state = _load_state(tmp_path, "projects-compose.service")
+    assert state["attempts"] == 2
+
+    summaries = list(boot_dir.glob("*.md"))
+    assert summaries, "expected escalation summary to be written"
+    summary_text = summaries[0].read_text(encoding="utf-8")
+    assert "Self-heal escalation" in summary_text
+
+    log_file = tmp_path / "logs" / "projects-compose.service.log"
+    contents = log_file.read_text(encoding="utf-8")
+    assert "entering maintenance" in contents
+
+
+@pytest.mark.parametrize(
+    "unit",
+    ["cloud-final.service", "cloud-config.service", "cloud-init.service"],
+)
+def test_cloud_init_recipes_run(unit: str, tmp_path: Path) -> None:
+    result = _run(unit, tmp_path)
+    assert result.returncode == 0
+
+    state = _load_state(tmp_path, unit)
+    assert state["attempts"] == 0
+
+    log_file = tmp_path / "logs" / f"{unit}.log"
+    contents = log_file.read_text(encoding="utf-8")
+    assert "cloud-init clean --logs" in contents
+    assert "status: done" in contents


### PR DESCRIPTION
## Summary
- add `self_heal_service.py` and a `sugarkube-self-heal@.service` template that retry compose pulls, clean cloud-init, and escalate with boot logs
- wire the new helper into the cloud-init user-data, bundle it during image builds, and document the self-healing flow across guides
- cover the automation with unit tests, including copying the helper into the build harness used by `build_pi_image` tests, and tick the Pi image improvement checklist item

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- pytest tests/build_pi_image_test.py::test_uses_default_pi_gen_branch


------
https://chatgpt.com/codex/tasks/task_e_68cf986abec8832f8d62e141bb0ef9f6