### PR TITLE
Adjust workflows for Node 20 deprecation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install aspell dictionaries
         run: sudo apt-get update && sudo apt-get install -y aspell aspell-en
       - name: Spell check markdown & docs
@@ -24,9 +24,12 @@ jobs:
   linkcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v1
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v5
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh -s -- --no-modify-path
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - run: |

--- a/.github/workflows/kicad-export.yml
+++ b/.github/workflows/kicad-export.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     # KiBot action pulls its own container image with KiCad 9
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Fabricate board with KiBot
         # Use the KiBot action pinned to the k9 container tag

--- a/.github/workflows/pi-image-release.yml
+++ b/.github/workflows/pi-image-release.yml
@@ -26,7 +26,7 @@ jobs:
       CLONE_TOKEN_PLACE: true
       CLONE_DSPACE: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -160,25 +160,51 @@ jobs:
             RELEASE_NOTES.md
 
       - name: Publish GitHub release
-        uses: ncipollo/release-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ steps.manifest.outputs.tag }}
-          name: ${{ steps.manifest.outputs.name }}
-          bodyFile: ${{ steps.manifest.outputs.notes_path }}
-          draft: false
-          prerelease: ${{ steps.manifest.outputs.prerelease == 'true' }}
-          allowUpdates: true
-          removeArtifacts: true
-          makeLatest: ${{ steps.manifest.outputs.make_latest == 'true' }}
-          artifacts: |
-            sugarkube.img.xz
-            sugarkube.img.xz.sha256
-            sugarkube.img.xz.metadata.json
-            sugarkube.img.xz.manifest.json
-            sugarkube.img.xz.sig
-            sugarkube.img.xz.pem
-            sugarkube.img.xz.manifest.json.sig
-            sugarkube.img.xz.manifest.json.pem
-            sugarkube.build.log
-            RELEASE_NOTES.md
+        run: |
+          set -euo pipefail
+          tag="${{ steps.manifest.outputs.tag }}"
+          name="${{ steps.manifest.outputs.name }}"
+          notes="${{ steps.manifest.outputs.notes_path }}"
+          prerelease="${{ steps.manifest.outputs.prerelease }}"
+          make_latest="${{ steps.manifest.outputs.make_latest }}"
+          assets=(
+            "sugarkube.img.xz"
+            "sugarkube.img.xz.sha256"
+            "sugarkube.img.xz.metadata.json"
+            "sugarkube.img.xz.manifest.json"
+            "sugarkube.img.xz.sig"
+            "sugarkube.img.xz.pem"
+            "sugarkube.img.xz.manifest.json.sig"
+            "sugarkube.img.xz.manifest.json.pem"
+            "sugarkube.build.log"
+            "RELEASE_NOTES.md"
+          )
+
+          if [ "$prerelease" = "true" ]; then
+            prerelease_args=(--prerelease)
+          else
+            prerelease_args=(--prerelease=false)
+          fi
+
+          if [ "$make_latest" = "true" ]; then
+            latest_args=(--latest)
+          else
+            latest_args=(--latest=false)
+          fi
+
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release edit "$tag" \
+              --title "$name" \
+              --notes-file "$notes" \
+              --draft=false \
+              "${prerelease_args[@]}" \
+              "${latest_args[@]}"
+            gh release upload "$tag" "${assets[@]}" --clobber
+          else
+            gh release create "$tag" "${assets[@]}" \
+              --title "$name" \
+              --notes-file "$notes" \
+              --draft=false \
+              "${prerelease_args[@]}" \
+              "${latest_args[@]}"
+          fi

--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -27,7 +27,7 @@ jobs:
   unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - name: Install collector dependencies
@@ -55,7 +55,7 @@ jobs:
       CLONE_TOKEN_PLACE: ${{ github.event.inputs.clone_token_place }}
       CLONE_DSPACE: ${{ github.event.inputs.clone_dspace }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/scad-to-stl.yml
+++ b/.github/workflows/scad-to-stl.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # fetch full history so we can push tags/commits
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -9,7 +9,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install aspell
         run: sudo apt-get update && sudo apt-get install -y aspell aspell-en
       - name: Spell check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,13 +4,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: Setup uv
-        uses: astral-sh/setup-uv@v1
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh -s -- --no-modify-path
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Install dependencies
@@ -22,7 +24,7 @@ jobs:
           pytest --cov=. --cov-report=xml --cov-report=term --maxfail=1 --disable-warnings -q
       - name: Upload coverage
         if: hashFiles('coverage.xml') != ''
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5.5.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml


### PR DESCRIPTION
what: bump github actions to node 22+ runtimes and inline uv install
why: stay ahead of github actions node 20 removal
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml;
  linkchecker --no-warnings README.md docs/
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68cfa15fac74832f80ec9923f68d9f8a