### PR TITLE
🛠️ : – Adopt Node22-ready GitHub Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install aspell dictionaries
         run: sudo apt-get update && sudo apt-get install -y aspell aspell-en
       - name: Spell check markdown & docs
@@ -24,9 +24,9 @@ jobs:
   linkcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v1
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - run: |

--- a/.github/workflows/kicad-export.yml
+++ b/.github/workflows/kicad-export.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     # KiBot action pulls its own container image with KiCad 9
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Fabricate board with KiBot
         # Use the KiBot action pinned to the k9 container tag

--- a/.github/workflows/pi-image-release.yml
+++ b/.github/workflows/pi-image-release.yml
@@ -26,7 +26,7 @@ jobs:
       CLONE_TOKEN_PLACE: true
       CLONE_DSPACE: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -27,7 +27,7 @@ jobs:
   unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - name: Install collector dependencies
@@ -55,7 +55,7 @@ jobs:
       CLONE_TOKEN_PLACE: ${{ github.event.inputs.clone_token_place }}
       CLONE_DSPACE: ${{ github.event.inputs.clone_dspace }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/scad-to-stl.yml
+++ b/.github/workflows/scad-to-stl.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # fetch full history so we can push tags/commits
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -9,7 +9,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install aspell
         run: sudo apt-get update && sudo apt-get install -y aspell aspell-en
       - name: Spell check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,13 +4,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Setup uv
         uses: astral-sh/setup-uv@v1
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * pi_carrier: widen nut recess clearance to 0.4 mm for easier nut insertion
 * pi5_triple_carrier_rot45: widen nut recess clearance to 0.4 mm for easier nut insertion
 * panel_bracket: enlarge insert to 6.3 mm OD for common M5 heat‑set hardware
+* CI: upgrade GitHub-hosted actions to Node 22-compatible majors (`actions/checkout@v5`,
+  `actions/setup-python@v6`)
 
 ### Fixed
 * pi_carrier: standoff length increased from 20 mm to 22 mm (flush fit with PoE HAT)


### PR DESCRIPTION
what: bump checkout to v5 and setup-python to v6 for Node22 runners.
why: prepare for GitHub Actions Node 20 retirement from hosted runners.
how to test: uvx pre-commit run --all-files; uvx pyspelling -c .spellcheck.yaml;
  uvx linkchecker --no-warnings README.md docs/
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68cfa15fac74832f80ec9923f68d9f8a