### PR TITLE
⚙️ : – Force Node24 runtime in CI workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,9 @@ on:
       - 'README.md'
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   spellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/kicad-export.yml
+++ b/.github/workflows/kicad-export.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   kibot:
     runs-on: ubuntu-latest

--- a/.github/workflows/pi-image-release.yml
+++ b/.github/workflows/pi-image-release.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: '0 6 * * *'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: pi-image-release
   cancel-in-progress: false

--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -23,6 +23,9 @@ on:
       - 'tests/**'
       - '.github/workflows/pi-image.yml'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/scad-to-stl.yml
+++ b/.github/workflows/scad-to-stl.yml
@@ -6,6 +6,9 @@ on:
 
 # No special permissions required
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-stl:
     runs-on: ubuntu-latest

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - '**.md'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,7 @@
 name: Test Suite
 on: [push, pull_request]
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -17,6 +17,8 @@ Diagnose and fix continuous integration failures so all checks pass.
 CONTEXT:
 - Follow [AGENTS.md](../AGENTS.md) and [README.md](../README.md) for workflow and testing requirements.
 - Inspect [`.github/workflows/`](../.github/workflows/) to understand the checks run in continuous integration.
+- JavaScript-based actions run with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` so CI surfaces
+  incompatibilities before GitHub switches runners to Node24 by default.
 - Run `pre-commit run --all-files` from the repository root; it executes `scripts/checks.sh`.
 - If a Node toolchain is present (`package.json` exists), run:
   - `npm ci`


### PR DESCRIPTION
what: set FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 in workflows and docs
why: get ahead of GitHub Actions Node20 deprecation and surface issues
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68cfa15fac74832f80ec9923f68d9f8a