### PR TITLE
Avoid blocking boot when SSD clone service waits for media

### DIFF
--- a/docs/contributor_script_map.md
+++ b/docs/contributor_script_map.md
@@ -41,7 +41,8 @@ confirm the quickstart stays accurate.
 
 | Script | Purpose | Primary docs | Supporting automation |
 | --- | --- | --- | --- |
-| `scripts/ssd_clone.py` | Clone the active SD card to an SSD with dry-run previews and resumable steps. | [Pi Image Quickstart](./pi_image_quickstart.md) §"Clone the SD card to SSD with confidence" | `make clone-ssd`, `just clone-ssd` |
+| `scripts/ssd_clone.py` | Clone the active SD card with dry-run previews, auto-target selection, and resumable steps. | [Pi Image Quickstart](./pi_image_quickstart.md) §"Automatic SSD cloning" | `make clone-ssd`, `just clone-ssd` |
+| `scripts/ssd_clone_service.py` + `scripts/systemd/ssd-clone.service` | Wait for a hot-plugged SSD, invoke the clone helper, and stop once `/var/log/sugarkube/ssd-clone.done` exists. | [Pi Image Quickstart](./pi_image_quickstart.md) §"Automatic SSD cloning" | Installed in pi image builds; triggered by the udev helper without blocking boot |
 | `scripts/ssd_post_clone_validate.py` | Validate cloned SSDs, compare boot config, and run stress tests. | [Pi Image Quickstart](./pi_image_quickstart.md) §"Validate SSD clones", [SSD Post-Clone Validation](./ssd_post_clone_validation.md) | `make validate-ssd-clone`, `just validate-ssd-clone` |
 | `scripts/ssd_health_monitor.py` | Collect SMART metrics, temperatures, and wear indicators with optional reporting. | [Pi Image Quickstart](./pi_image_quickstart.md) §"Monitor SSD health", [SSD Health Monitor](./ssd_health_monitor.md) | `make monitor-ssd-health`, `just monitor-ssd-health` |
 

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -77,12 +77,16 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
 ---
 
 ## SSD Migration & Storage Hardening
-- [ ] Automate SSD cloning via `ssd-clone.service` or `pi-clone.service`:
+- [x] Automate SSD cloning via `ssd-clone.service` or `pi-clone.service`:
   - Detect attached SSD.
   - Replicate partition table (`sgdisk --replicate` or `ddrescue`).
   - `rsync --info=progress2` SD → SSD.
   - Update `/boot/cmdline.txt` and `/etc/fstab` with new UUID.
   - Touch `/var/log/sugarkube/ssd-clone.done`.
+  - Implemented via `scripts/ssd_clone_service.py`, `scripts/systemd/ssd-clone.service`, and a
+    udev rule that starts the helper whenever a USB/NVMe disk appears. The service auto-selects the
+    target disk, resumes partial runs, respects manual overrides, installs alongside
+    `ssd_clone.py` during image builds, and avoids multi-user.target so boot never stalls when no SSD is present.
 - [x] Support dry-run + resume for cloning to reduce user hesitation.
   - Added `scripts/ssd_clone.py` plus Makefile/justfile wrappers that replicate partitions,
     support `--dry-run` previews, persist state, and resume clones via `--resume`.

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -282,12 +282,24 @@ install -Dm755 "${REPO_ROOT}/scripts/first_boot_service.py" \
 install -Dm755 "${REPO_ROOT}/scripts/self_heal_service.py" \
   "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/self_heal_service.py"
 
+install -Dm755 "${REPO_ROOT}/scripts/ssd_clone.py" \
+  "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/ssd_clone.py"
+
+install -Dm755 "${REPO_ROOT}/scripts/ssd_clone_service.py" \
+  "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/ssd_clone_service.py"
+
 install -Dm644 "${REPO_ROOT}/scripts/systemd/first-boot.service" \
   "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/etc/systemd/system/first-boot.service"
+
+install -Dm644 "${REPO_ROOT}/scripts/systemd/ssd-clone.service" \
+  "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/etc/systemd/system/ssd-clone.service"
 
 install -d "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/etc/systemd/system/multi-user.target.wants"
 ln -sf ../first-boot.service \
   "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/etc/systemd/system/multi-user.target.wants/first-boot.service"
+
+install -Dm644 "${REPO_ROOT}/scripts/udev/99-sugarkube-ssd-clone.rules" \
+  "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/etc/udev/rules.d/99-sugarkube-ssd-clone.rules"
 
 install -Dm755 "${EXPORT_KUBECONFIG_PATH}" \
   "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/export-kubeconfig.sh"

--- a/scripts/ssd_clone_service.py
+++ b/scripts/ssd_clone_service.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Automate SSD cloning using the existing ssd_clone.py helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shlex
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location("ssd_clone_module", SCRIPT_ROOT / "ssd_clone.py")
+ssd_clone = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(ssd_clone)  # type: ignore[attr-defined]
+
+DONE_FILE = ssd_clone.DONE_FILE
+STATE_FILE = ssd_clone.STATE_FILE
+STATE_DIR = ssd_clone.STATE_DIR
+CLONE_HELPER = SCRIPT_ROOT / "ssd_clone.py"
+POLL_INTERVAL = int(os.environ.get("SUGARKUBE_SSD_CLONE_POLL_SECS", "10"))
+MAX_WAIT = int(os.environ.get("SUGARKUBE_SSD_CLONE_WAIT_SECS", "900"))
+EXTRA_ARGS = os.environ.get("SUGARKUBE_SSD_CLONE_EXTRA_ARGS", "")
+AUTO_TARGET = os.environ.get(ssd_clone.ENV_TARGET)
+LOG_PREFIX = "[ssd-clone-service]"
+
+
+def log(message: str) -> None:
+    print(f"{LOG_PREFIX} {message}", flush=True)
+
+
+def ensure_root() -> None:
+    if os.geteuid() != 0:
+        raise SystemExit("ssd_clone_service.py must run as root.")
+
+
+def pick_target() -> Optional[str]:
+    if AUTO_TARGET:
+        path = Path(AUTO_TARGET)
+        if path.exists():
+            return AUTO_TARGET
+        log(f"Environment target {AUTO_TARGET} missing; waiting for the device to appear.")
+        return None
+    try:
+        return ssd_clone.auto_select_target()
+    except SystemExit as error:
+        log(str(error))
+        return None
+
+
+def run_clone(target: str) -> int:
+    command = [str(CLONE_HELPER), "--target", target, "--resume"]
+    if EXTRA_ARGS:
+        command.extend(shlex.split(EXTRA_ARGS))
+    log(f"Invoking {shlex.join(command)}")
+    result = subprocess.run(command, check=False)
+    if result.returncode == 0:
+        log("SSD clone completed successfully.")
+    else:
+        log(f"SSD clone helper exited with status {result.returncode}.")
+    return result.returncode
+
+
+def main() -> None:
+    ensure_root()
+    if DONE_FILE.exists():
+        log("Clone already marked complete; exiting.")
+        return
+    if not CLONE_HELPER.exists():
+        raise SystemExit("/opt/sugarkube/ssd_clone.py not found; aborting.")
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    elapsed = 0
+    target: Optional[str] = None
+    while elapsed <= MAX_WAIT:
+        target = pick_target()
+        if target:
+            break
+        time.sleep(POLL_INTERVAL)
+        elapsed += POLL_INTERVAL
+    if not target:
+        log(
+            "Timed out waiting for an SSD. Insert a target disk or set "
+            "SUGARKUBE_SSD_CLONE_TARGET before restarting the service."
+        )
+        raise SystemExit(0)
+    returncode = run_clone(target)
+    if returncode != 0 and not STATE_FILE.exists():
+        raise SystemExit(returncode)
+    if DONE_FILE.exists():
+        log("Clone marker present; nothing else to do.")
+        return
+    raise SystemExit(returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/systemd/ssd-clone.service
+++ b/scripts/systemd/ssd-clone.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Sugarkube SSD clone automation
+After=first-boot.service systemd-udevd.service
+Wants=first-boot.service
+ConditionPathExists=/opt/sugarkube/ssd_clone.py
+ConditionPathExists=!/var/log/sugarkube/ssd-clone.done
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/udevadm settle --timeout=30
+ExecStart=/opt/sugarkube/ssd_clone_service.py
+StandardOutput=journal
+StandardError=journal

--- a/scripts/udev/99-sugarkube-ssd-clone.rules
+++ b/scripts/udev/99-sugarkube-ssd-clone.rules
@@ -1,0 +1,4 @@
+ACTION=="add", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", ENV{ID_BUS}=="usb", \
+  RUN+="/bin/systemctl start ssd-clone.service"
+ACTION=="add", SUBSYSTEM=="block", KERNEL=="nvme*n1", ENV{DEVTYPE}=="disk", \
+  RUN+="/bin/systemctl start ssd-clone.service"

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -510,10 +511,26 @@ def _run_build_script(tmp_path, env):
     shutil.copy(self_heal_src, script_dir / "self_heal_service.py")
     (script_dir / "self_heal_service.py").chmod(0o755)
 
+    ssd_clone_src = repo_root / "scripts" / "ssd_clone.py"
+    shutil.copy(ssd_clone_src, script_dir / "ssd_clone.py")
+    (script_dir / "ssd_clone.py").chmod(0o755)
+
+    ssd_clone_service_src = repo_root / "scripts" / "ssd_clone_service.py"
+    shutil.copy(ssd_clone_service_src, script_dir / "ssd_clone_service.py")
+    (script_dir / "ssd_clone_service.py").chmod(0o755)
+
     systemd_src = repo_root / "scripts" / "systemd" / "first-boot.service"
     systemd_dir = script_dir / "systemd"
     systemd_dir.mkdir(exist_ok=True)
     shutil.copy(systemd_src, systemd_dir / "first-boot.service")
+
+    ssd_clone_unit_src = repo_root / "scripts" / "systemd" / "ssd-clone.service"
+    shutil.copy(ssd_clone_unit_src, systemd_dir / "ssd-clone.service")
+
+    udev_src = repo_root / "scripts" / "udev" / "99-sugarkube-ssd-clone.rules"
+    udev_dir = script_dir / "udev"
+    udev_dir.mkdir(exist_ok=True)
+    shutil.copy(udev_src, udev_dir / "99-sugarkube-ssd-clone.rules")
 
     result = subprocess.run(
         ["/bin/bash", str(script)],
@@ -558,6 +575,27 @@ def test_handles_precompressed_pi_gen_output(tmp_path):
     result, _ = _run_build_script(tmp_path, env)
     assert result.returncode == 0
     assert (tmp_path / "sugarkube.img.xz").exists()
+
+
+def test_installs_ssd_clone_service(tmp_path):
+    env = _setup_build_env(tmp_path)
+    env["KEEP_WORK_DIR"] = "1"
+    result, _ = _run_build_script(tmp_path, env)
+    assert result.returncode == 0
+    match = re.search(r"leaving work dir: (?P<path>\S+)", result.stdout)
+    assert match, result.stdout
+    work_dir = Path(match.group("path"))
+    stage_root = work_dir / "pi-gen" / "stage2" / "01-sys-tweaks" / "files"
+    assert (stage_root / "opt" / "sugarkube" / "ssd_clone.py").exists()
+    assert (stage_root / "opt" / "sugarkube" / "ssd_clone_service.py").exists()
+    service_path = stage_root / "etc" / "systemd" / "system" / "ssd-clone.service"
+    assert service_path.exists()
+    wants_dir = stage_root / "etc" / "systemd" / "system" / "multi-user.target.wants"
+    assert wants_dir.exists()
+    assert not (wants_dir / "ssd-clone.service").exists()
+    udev_rule = stage_root / "etc" / "udev" / "rules.d" / "99-sugarkube-ssd-clone.rules"
+    assert udev_rule.exists()
+    shutil.rmtree(work_dir)
     assert not (tmp_path / "sugarkube.img.xz.xz").exists()
 
 

--- a/tests/ssd_clone_auto_target_test.py
+++ b/tests/ssd_clone_auto_target_test.py
@@ -1,0 +1,100 @@
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "ssd_clone.py"
+SPEC = importlib.util.spec_from_file_location("ssd_clone", MODULE_PATH)
+ssd_clone = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules["ssd_clone"] = ssd_clone
+SPEC.loader.exec_module(ssd_clone)  # type: ignore[attr-defined]
+
+
+@pytest.fixture(autouse=True)
+def _clear_env():
+    original = os.environ.pop(ssd_clone.ENV_TARGET, None)
+    try:
+        yield
+    finally:
+        if original is not None:
+            os.environ[ssd_clone.ENV_TARGET] = original
+
+
+@pytest.fixture
+def fake_disk_layout(monkeypatch):
+    monkeypatch.setattr(ssd_clone, "resolve_mount_device", lambda _: "/dev/mmcblk0p2")
+    monkeypatch.setattr(ssd_clone, "parent_disk", lambda _: "/dev/mmcblk0")
+    monkeypatch.setattr(ssd_clone.os.path, "realpath", lambda path: path)
+    monkeypatch.setattr(ssd_clone, "device_size_bytes", lambda _: 32 * 1024 * 1024 * 1024)
+    devices = {
+        "blockdevices": [
+            {"name": "mmcblk0", "type": "disk", "size": 32 * 1024 * 1024 * 1024},
+            {
+                "name": "sda",
+                "type": "disk",
+                "size": 128 * 1024 * 1024 * 1024,
+                "hotplug": 1,
+                "tran": "usb",
+                "model": "FastSSD",
+            },
+            {
+                "name": "sdb",
+                "type": "disk",
+                "size": 64 * 1024 * 1024 * 1024,
+                "hotplug": 0,
+                "tran": "sata",
+            },
+        ]
+    }
+    monkeypatch.setattr(ssd_clone, "lsblk_json", lambda _: devices)
+
+
+def test_auto_select_target_prefers_hotplug(fake_disk_layout):
+    target = ssd_clone.auto_select_target()
+    assert target == "/dev/sda"
+
+
+def test_auto_select_target_honors_env_override(monkeypatch, fake_disk_layout):
+    override = "/dev/sdz"
+    monkeypatch.setattr(Path, "exists", lambda self: str(self) == override)
+    os.environ[ssd_clone.ENV_TARGET] = override
+    target = ssd_clone.auto_select_target()
+    assert target == override
+
+
+def test_resolve_env_target_missing_device(monkeypatch):
+    os.environ[ssd_clone.ENV_TARGET] = "/dev/missing"
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+    with pytest.raises(SystemExit, match="does not exist"):
+        ssd_clone.resolve_env_target()
+
+
+def test_resolve_env_target_rejects_source_disk(monkeypatch):
+    os.environ[ssd_clone.ENV_TARGET] = "/dev/mmcblk0"
+    monkeypatch.setattr(Path, "exists", lambda self: True)
+    monkeypatch.setattr(ssd_clone, "resolve_mount_device", lambda _: "/dev/mmcblk0p2")
+    monkeypatch.setattr(ssd_clone, "parent_disk", lambda _: "/dev/mmcblk0")
+    monkeypatch.setattr(ssd_clone.os.path, "realpath", lambda path: path)
+    with pytest.raises(SystemExit, match="source disk"):
+        ssd_clone.resolve_env_target()
+
+
+def test_auto_select_target_requires_list(monkeypatch, fake_disk_layout):
+    monkeypatch.setattr(ssd_clone, "lsblk_json", lambda _: {"blockdevices": {}})
+    with pytest.raises(SystemExit, match="Unexpected lsblk JSON structure"):
+        ssd_clone.auto_select_target()
+
+
+def test_auto_select_target_errors_without_candidates(monkeypatch, fake_disk_layout):
+    monkeypatch.setattr(
+        ssd_clone,
+        "lsblk_json",
+        lambda _: {
+            "blockdevices": [{"name": "mmcblk0", "type": "disk", "size": 32 * 1024 * 1024 * 1024}]
+        },
+    )
+    with pytest.raises(SystemExit, match="Unable to automatically determine"):
+        ssd_clone.auto_select_target()

--- a/tests/ssd_clone_workflow_test.py
+++ b/tests/ssd_clone_workflow_test.py
@@ -1,0 +1,214 @@
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "ssd_clone.py"
+
+if "ssd_clone" in sys.modules:
+    ssd_clone = sys.modules["ssd_clone"]
+else:
+    SPEC = importlib.util.spec_from_file_location("ssd_clone", MODULE_PATH)
+    assert SPEC and SPEC.loader
+    ssd_clone = importlib.util.module_from_spec(SPEC)
+    sys.modules["ssd_clone"] = ssd_clone
+    SPEC.loader.exec_module(ssd_clone)  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def ctx(tmp_path):
+    context = ssd_clone.CloneContext(
+        target_disk="/dev/sdz",
+        dry_run=False,
+        verbose=False,
+        resume=False,
+        state_file=tmp_path / "state.json",
+    )
+    context.state = {}
+    return context
+
+
+def test_step_run_skips_completed(ctx):
+    ctx.state = {"completed": {"partition": True}}
+    step = ssd_clone.Step("partition", "Replicating partition table")
+
+    def fail(_ctx):
+        raise AssertionError("step should not run when already completed")
+
+    step.run(ctx, fail)
+
+
+def test_step_run_marks_completion(monkeypatch, ctx):
+    invoked = {"count": 0}
+
+    def fake_save_state(local_ctx):
+        invoked["count"] += 1
+        assert local_ctx.state["completed"]["format"] is True
+
+    monkeypatch.setattr(ssd_clone, "save_state", fake_save_state)
+
+    step = ssd_clone.Step("format", "Formatting target partitions")
+
+    def noop(local_ctx):
+        local_ctx.state.setdefault("ran", True)
+
+    step.run(ctx, noop)
+    assert ctx.state.get("ran") is True
+    assert invoked["count"] == 1
+
+
+def test_run_command_dry_run(tmp_path):
+    context = ssd_clone.CloneContext(
+        target_disk="/dev/sdy",
+        dry_run=True,
+        verbose=False,
+        resume=False,
+        state_file=tmp_path / "state.json",
+    )
+    result = ssd_clone.run_command(context, ["echo", "hello"])
+    assert result.returncode == 0
+
+
+def test_run_command_streams_output(monkeypatch, capsys, ctx):
+    ctx.verbose = True
+
+    def fake_run(*args, **kwargs):
+        command = args[0]
+        return subprocess.CompletedProcess(command, 0, "stdout-data", "stderr-data")
+
+    monkeypatch.setattr(ssd_clone.subprocess, "run", fake_run)
+
+    result = ssd_clone.run_command(ctx, ["true"])
+    assert result.returncode == 0
+    captured = capsys.readouterr()
+    assert "stdout-data" in captured.out
+    assert "stderr-data" in captured.err
+
+
+def test_run_command_raises(monkeypatch, ctx):
+    def fake_run(*args, **kwargs):
+        command = args[0]
+        return subprocess.CompletedProcess(command, 1, "", "boom")
+
+    monkeypatch.setattr(ssd_clone.subprocess, "run", fake_run)
+
+    with pytest.raises(ssd_clone.CommandError):
+        ssd_clone.run_command(ctx, ["false"])
+
+
+def test_randomize_disk_identifiers_falls_back(monkeypatch, ctx):
+    calls = []
+
+    def fake_run(local_ctx, command, *, input_text=None):
+        calls.append(command)
+        if command[:2] == ["sgdisk", "-G"]:
+            raise ssd_clone.CommandError("fail")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(ssd_clone, "run_command", fake_run)
+    ssd_clone.randomize_disk_identifiers(ctx)
+    assert any(cmd[:2] == ["sfdisk", "--disk-id"] for cmd in calls)
+
+
+def test_ensure_state_ready_requires_resume(tmp_path, ctx):
+    ctx.state_file.write_text("{}", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        ssd_clone.ensure_state_ready(ctx)
+
+
+def test_ensure_state_ready_resume_loads(tmp_path):
+    state_file = tmp_path / "state.json"
+    state = {"target": "/dev/sdz", "completed": {}}
+    state_file.write_text(json.dumps(state), encoding="utf-8")
+    context = ssd_clone.CloneContext(
+        target_disk="/dev/sdz",
+        dry_run=False,
+        verbose=False,
+        resume=True,
+        state_file=state_file,
+    )
+    ssd_clone.ensure_state_ready(context)
+    assert context.state == state
+
+
+def test_ensure_state_ready_resume_rejects_mismatch(tmp_path):
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"target": "/dev/sdb"}), encoding="utf-8")
+    context = ssd_clone.CloneContext(
+        target_disk="/dev/sdz",
+        dry_run=False,
+        verbose=False,
+        resume=True,
+        state_file=state_file,
+    )
+    with pytest.raises(SystemExit):
+        ssd_clone.ensure_state_ready(context)
+
+
+def test_gather_source_metadata(monkeypatch, tmp_path):
+    context = ssd_clone.CloneContext(
+        target_disk="/dev/sdz",
+        dry_run=False,
+        verbose=False,
+        resume=False,
+        state_file=tmp_path / "state.json",
+    )
+    context.state = {}
+
+    def fake_resolve(mountpoint):
+        return "/dev/mmcblk0p2" if mountpoint == "/" else "/dev/mmcblk0p1"
+
+    monkeypatch.setattr(ssd_clone, "resolve_mount_device", fake_resolve)
+    monkeypatch.setattr(ssd_clone, "parent_disk", lambda device: device[:-2])
+    monkeypatch.setattr(ssd_clone.os.path, "realpath", lambda value: value)
+    monkeypatch.setattr(
+        ssd_clone,
+        "partition_suffix",
+        lambda device: "1" if device.endswith("p1") else "2",
+    )
+    monkeypatch.setattr(ssd_clone, "get_partuuid", lambda device: f"uuid-{device}")
+    monkeypatch.setattr(
+        ssd_clone,
+        "detect_filesystem",
+        lambda device: "vfat" if device.endswith("p1") else "ext4",
+    )
+
+    saved = {"called": False}
+
+    def fake_save_state(local_ctx):
+        saved["called"] = True
+        assert local_ctx.state["source_disk"] == "/dev/mmcblk0"
+
+    monkeypatch.setattr(ssd_clone, "save_state", fake_save_state)
+
+    ssd_clone.gather_source_metadata(context)
+    assert context.state["source_root_partuuid"] == "uuid-/dev/mmcblk0p2"
+    assert context.state["source_boot_partuuid"] == "uuid-/dev/mmcblk0p1"
+    assert context.state["source_root_fs"] == "ext4"
+    assert context.state["source_boot_fs"] == "vfat"
+    assert saved["called"] is True
+
+
+def test_main_rejects_missing_target(monkeypatch, tmp_path):
+    monkeypatch.setattr(ssd_clone, "ensure_root", lambda: None)
+    monkeypatch.setattr(
+        ssd_clone,
+        "parse_args",
+        lambda: argparse.Namespace(
+            target="/dev/missing",
+            auto_target=False,
+            dry_run=False,
+            resume=False,
+            state_file=tmp_path / "state.json",
+            mount_root=tmp_path / "mnt",
+            verbose=False,
+        ),
+    )
+    monkeypatch.setattr(ssd_clone.Path, "exists", lambda self: str(self) != "/dev/missing")
+
+    with pytest.raises(SystemExit):
+        ssd_clone.main()


### PR DESCRIPTION
## Summary
- remove the multi-user.target install for ssd-clone.service and stop symlinking it during image builds so boot no longer waits for missing SSDs
- document the udev-triggered activation in the quickstart and contributor guide while noting the multi-user.target exclusion in the checklist
- add workflow tests for ssd_clone.py and update the build script test expectations to keep SSD automation covered

## Testing
- pytest tests/ssd_clone_auto_target_test.py tests/ssd_clone_workflow_test.py tests/build_pi_image_test.py::test_installs_ssd_clone_service
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68d08f756e2c832f8dd7f68153b8ac16