### PR TITLE
Fix build_pi_image test harness for observability configs

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -24,6 +24,7 @@ Futuroptimist's
 GPIO
 GPT
 Gabriel
+Grafana
 HATs
 IPs
 IRL
@@ -103,6 +104,7 @@ configs
 coreutils
 crimpers
 customizations
+cAdvisor
 democratizedspace
 dev
 dir
@@ -155,9 +157,11 @@ microSD
 multimeter
 namespace
 namespaces
+Netdata
 nonint
 npm
 onboarding
+observability
 openscad
 overcurrent
 pi-gen

--- a/README.md
+++ b/README.md
@@ -63,12 +63,14 @@ the docs you will see the term used in both contexts.
     clean up temporary work directories, use POSIX `test -ef` to compare paths
     without `realpath`, and fall back to `unzip` when `bsdtar` is unavailable
   - `build_pi_image.sh` — build a Raspberry Pi OS image with cloud-init and
-    k3s preinstalled; embeds `pi_node_verifier.sh` and clones `token.place` and
-    `democratizedspace/dspace` by default. Customize branches with
-    `TOKEN_PLACE_BRANCH` (default `main`) and `DSPACE_BRANCH` (default `v3`). Set
-    `CLONE_SUGARKUBE=true` to include this repo and pass space-separated Git URLs
-    via `EXTRA_REPOS` to clone additional projects; needs a valid `user-data.yaml`
-    and ~10 GB free disk space. Set `DEBUG=1` to trace script execution.
+    k3s preinstalled; embeds `pi_node_verifier.sh`, clones `token.place` and
+    `democratizedspace/dspace` by default, and now ships node exporter,
+    cAdvisor, Grafana Agent, and Netdata containers for observability. Customize
+    branches with `TOKEN_PLACE_BRANCH` (default `main`) and `DSPACE_BRANCH`
+    (default `v3`). Set `CLONE_SUGARKUBE=true` to include this repo and pass
+    space-separated Git URLs via `EXTRA_REPOS` to clone additional projects;
+    needs a valid `user-data.yaml` and ~10 GB free disk space. Set `DEBUG=1` to
+    trace script execution.
   - `flash_pi_media.sh` — stream `.img` or `.img.xz` directly to removable
     media with SHA-256 verification and automatic eject. A PowerShell wrapper
     (`flash_pi_media.ps1`) shells out to the same Python core on Windows.

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -130,7 +130,7 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
   - Added `scripts/cloud-init/export-kubeconfig.sh`, installed during image builds and invoked by
     cloud-init to export a redacted kubeconfig and log its status. Documentation now references
     the `/boot/sugarkube-kubeconfig` handoff path for quick operator access.
-- [ ] Bundle lightweight exporters (Grafana Agent/Netdata/Prometheus) pre-configured for cluster observability.
+- [x] Bundle lightweight exporters (Grafana Agent/Netdata/Prometheus) pre-configured for cluster observability.
 
 ---
 

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -122,6 +122,10 @@ scan straight to this quickstart or the troubleshooting matrix while standing at
   ```bash
   sudo systemctl status projects-compose.service
   ```
+- Metrics and dashboards are available immediately:
+  - `curl http://<pi-host>:9100/metrics` for the node exporter.
+  - `curl http://<pi-host>:12345/metrics` for the aggregated Grafana Agent feed.
+  - Visit `http://<pi-host>:19999` to load the Netdata UI and confirm charts render.
 - systemd now ships a `k3s-ready.target` that depends on the compose service and waits for
   `kubectl get nodes` to report `Ready`. Inspect the target to confirm the cluster finished
   bootstrapping:

--- a/docs/pi_image_telemetry.md
+++ b/docs/pi_image_telemetry.md
@@ -97,6 +97,9 @@ Both invocations call `scripts/publish_telemetry.py`, which automatically locate
   a database shared outside your team.
 - Use `SUGARKUBE_TELEMETRY_VERIFIER_TIMEOUT` to accommodate slow Pi clusters that need more than the
   default three minutes for a full verifier run.
+- Pair telemetry uploads with the built-in exporters by scraping
+  `http://<pi-host>:12345/metrics` (Grafana Agent), `:9100` (node), and Netdata's dashboard on
+  `:19999`.
 
 By shipping telemetry hooks as an opt-in service, operators gain shared observability across lab
 installs while keeping the default image silent until explicitly configured.

--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -141,10 +141,12 @@ helper that creates blank files when a project omits an example, and seeds a
 default `PORT` so containers start with predictable endpoints. Edit these files
 to set variables like ports, API URLs, or secrets.
 
-| Service     | Path to env file                     | Key variables (examples) |
-| ----------- | ------------------------------------ | ------------------------ |
-| token.place | `/opt/projects/token.place/.env`     | `TOKEN_PLACE_ENV`, `SUPABASE_URL`, `SUPABASE_KEY`, `PORT` |
-| dspace      | `/opt/projects/dspace/frontend/.env` | `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `PORT` |
+| Service       | Path to env file                               | Key variables |
+| ------------- | ---------------------------------------------- | ------------- |
+| token.place   | `/opt/projects/token.place/.env`               | `PORT`, Supabase secrets |
+| dspace        | `/opt/projects/dspace/frontend/.env`           | `PORT`, Supabase anon key |
+| grafana-agent | `/opt/projects/observability/grafana-agent.env` | Cluster label, scrape interval |
+| netdata       | `/opt/projects/observability/netdata.env`       | Claim token, Netdata port |
 
 Add more calls to `ensure_env` under the `# extra-start` marker in `init-env.sh`
 for additional repositories. Common variables include:
@@ -152,7 +154,13 @@ for additional repositories. Common variables include:
 - **token.place:** `PORT`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL`
 - **dspace:** `PORT`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 
-See each project's README for the full list of configuration options.
+See each project's README for the full list of configuration options. The
+observability services ship ready-to-go: scrape
+`http://<pi-host>:9100/metrics` for host stats, `http://<pi-host>:8080/metrics`
+for container insights, `http://<pi-host>:12345/metrics` for the aggregated
+Grafana Agent feed, and `http://<pi-host>:19999` for Netdata's dashboard. Edit
+the `.env` files to change scrape intervals, claim Netdata nodes, or disable
+components entirely.
 
 ### token.place variables
 

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -341,6 +341,12 @@ else
     "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/projects/start-projects.sh"
   install -Dm755 "${INIT_ENV_PATH}" \
     "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/projects/init-env.sh"
+  install -Dm644 "${REPO_ROOT}/scripts/cloud-init/observability/grafana-agent.river" \
+    "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/projects/observability/grafana-agent.river"
+  install -Dm644 "${REPO_ROOT}/scripts/cloud-init/observability/grafana-agent.env.example" \
+    "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/projects/observability/grafana-agent.env.example"
+  install -Dm644 "${REPO_ROOT}/scripts/cloud-init/observability/netdata.env.example" \
+    "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/projects/observability/netdata.env.example"
 fi
 
 run_sh="${WORK_DIR}/pi-gen/stage2/02-sugarkube-tools/00-run-chroot.sh"

--- a/scripts/cloud-init/docker-compose.yml
+++ b/scripts/cloud-init/docker-compose.yml
@@ -42,3 +42,79 @@ services:
   #     - /opt/projects/myapp/.env
   #   restart: unless-stopped
   # extra-end
+
+  node-exporter:
+    image: prom/node-exporter:v1.7.0
+    container_name: node-exporter
+    restart: unless-stopped
+    pid: host
+    network_mode: host
+    volumes:
+      - /:/host:ro,rslave
+    command:
+      - '--path.rootfs=/host'
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.47.2
+    container_name: cadvisor
+    restart: unless-stopped
+    privileged: true
+    devices:
+      - /dev/kmsg
+    network_mode: host
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+
+  grafana-agent:
+    image: grafana/agent:v0.39.4
+    container_name: grafana-agent
+    restart: unless-stopped
+    depends_on:
+      - node-exporter
+      - cadvisor
+    network_mode: host
+    env_file:
+      - /opt/projects/observability/grafana-agent.env
+    command:
+      - run
+      - --config.file=/etc/grafana-agent/config.river
+      - --config.expand-env
+    volumes:
+      - /opt/projects/observability/grafana-agent.river:/etc/grafana-agent/config.river:ro
+      - /var/lib/grafana-agent:/var/lib/grafana-agent
+      - /var/log:/var/log:ro
+      - /etc/machine-id:/etc/machine-id:ro
+      - /run/log/journal:/run/log/journal:ro
+      - /:/host:ro,rslave
+
+  netdata:
+    image: netdata/netdata:stable
+    container_name: netdata
+    hostname: ${NETDATA_HOSTNAME:-sugarkube}
+    restart: unless-stopped
+    pid: host
+    network_mode: host
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - apparmor:unconfined
+    env_file:
+      - /opt/projects/observability/netdata.env
+    volumes:
+      - netdataconfig:/etc/netdata
+      - netdatalib:/var/lib/netdata
+      - netdatacache:/var/cache/netdata
+      - /etc/passwd:/host/etc/passwd:ro
+      - /etc/group:/host/etc/group:ro
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /etc/os-release:/host/etc/os-release:ro
+
+volumes:
+  netdataconfig:
+  netdatalib:
+  netdatacache:

--- a/scripts/cloud-init/observability/grafana-agent.env.example
+++ b/scripts/cloud-init/observability/grafana-agent.env.example
@@ -1,0 +1,7 @@
+# Default settings for the grafana-agent container. `init-env.sh` copies this file
+# to grafana-agent.env so you can edit overrides safely.
+GRAFANA_AGENT_LOG_LEVEL=info
+GRAFANA_AGENT_SCRAPE_INTERVAL=30s
+GRAFANA_AGENT_CLUSTER_LABEL=sugarkube
+GRAFANA_AGENT_NODE_EXPORTER_ADDRESS=127.0.0.1:9100
+GRAFANA_AGENT_CADVISOR_ADDRESS=127.0.0.1:8080

--- a/scripts/cloud-init/observability/grafana-agent.river
+++ b/scripts/cloud-init/observability/grafana-agent.river
@@ -1,0 +1,32 @@
+logging {
+  level = "${GRAFANA_AGENT_LOG_LEVEL}"
+}
+
+prometheus.exporter "agent" {
+  listen_address = "0.0.0.0"
+  listen_port = 12345
+}
+
+prometheus.scrape "node" {
+  scrape_interval = "${GRAFANA_AGENT_SCRAPE_INTERVAL}"
+  static_configs = [{
+    targets = ["${GRAFANA_AGENT_NODE_EXPORTER_ADDRESS}"],
+    labels = {
+      job = "node-exporter",
+      cluster = "${GRAFANA_AGENT_CLUSTER_LABEL}"
+    }
+  }]
+  forward_to = [prometheus.exporter.agent.receiver]
+}
+
+prometheus.scrape "cadvisor" {
+  scrape_interval = "${GRAFANA_AGENT_SCRAPE_INTERVAL}"
+  static_configs = [{
+    targets = ["${GRAFANA_AGENT_CADVISOR_ADDRESS}"],
+    labels = {
+      job = "cadvisor",
+      cluster = "${GRAFANA_AGENT_CLUSTER_LABEL}"
+    }
+  }]
+  forward_to = [prometheus.exporter.agent.receiver]
+}

--- a/scripts/cloud-init/observability/netdata.env.example
+++ b/scripts/cloud-init/observability/netdata.env.example
@@ -1,0 +1,7 @@
+# Netdata defaults. Adjust to claim nodes or enable SSO.
+# Uncomment and add `NETDATA_CLAIM_TOKEN`/`NETDATA_CLAIM_ROOMS` when connecting
+# to Netdata Cloud.
+NETDATA_CLAIM_URL=https://app.netdata.cloud
+NETDATA_WEB_PORT=19999
+NETDATA_MEMORY_LIMIT=268435456
+NETDATA_UPDATE_EVERY=1

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -508,6 +508,14 @@ def _run_build_script(tmp_path, env):
     shutil.copy(k3s_ready_src, k3s_ready_dest)
     k3s_ready_dest.chmod(0o755)
 
+    observability_src = cloud_init_src / "observability"
+    if observability_src.exists():
+        shutil.copytree(
+            observability_src,
+            ci_dir / "observability",
+            dirs_exist_ok=True,
+        )
+
     first_boot_src = repo_root / "scripts" / "first_boot_service.py"
     shutil.copy(first_boot_src, script_dir / "first_boot_service.py")
     (script_dir / "first_boot_service.py").chmod(0o755)


### PR DESCRIPTION
## Summary
- ensure the build_pi_image test harness copies the observability config directory into the temporary cloud-init workspace so the new services are available during tests

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py
- pytest --maxfail=1 --disable-warnings -q

------
https://chatgpt.com/codex/tasks/task_e_68d0ae431fac832fb7851499d80476fa