### PR TITLE
Bundle token.place sample datasets for first boot validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,13 @@ BADGE_CMD ?= $(CURDIR)/scripts/update_hardware_boot_badge.py
 BADGE_ARGS ?=
 REHEARSAL_CMD ?= $(CURDIR)/scripts/pi_multi_node_join_rehearsal.py
 REHEARSAL_ARGS ?=
+TOKEN_PLACE_SAMPLE_CMD ?= $(CURDIR)/scripts/token_place_replay_samples.py
+TOKEN_PLACE_SAMPLE_ARGS ?= --samples-dir $(CURDIR)/samples/token_place
 
 .PHONY: install-pi-image download-pi-image flash-pi flash-pi-report doctor rollback-to-sd \
         clone-ssd docs-verify qr-codes monitor-ssd-health smoke-test-pi \
-        publish-telemetry update-hardware-badge rehearse-join
+        publish-telemetry update-hardware-badge rehearse-join \
+        token-place-samples
 
 install-pi-image:
 	$(INSTALL_CMD) --dir '$(IMAGE_DIR)' --image '$(IMAGE_PATH)' $(DOWNLOAD_ARGS)
@@ -80,10 +83,13 @@ smoke-test-pi:
 	$(SMOKE_CMD) $(SMOKE_ARGS)
 
 publish-telemetry:
-$(TELEMETRY_CMD) $(TELEMETRY_ARGS)
+	$(TELEMETRY_CMD) $(TELEMETRY_ARGS)
 
 update-hardware-badge:
-$(BADGE_CMD) $(BADGE_ARGS)
+	$(BADGE_CMD) $(BADGE_ARGS)
 
 rehearse-join:
-$(REHEARSAL_CMD) $(REHEARSAL_ARGS)
+	$(REHEARSAL_CMD) $(REHEARSAL_ARGS)
+
+token-place-samples:
+	$(TOKEN_PLACE_SAMPLE_CMD) $(TOKEN_PLACE_SAMPLE_ARGS)

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,8 @@ Review the safety notes before working with power components.
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
 - [projects-compose.md](projects-compose.md) — run token.place & dspace via docker compose
 - [pi_token_dspace.md](pi_token_dspace.md) — build and expose token.place & dspace via Cloudflare
+- [token_place_sample_datasets.md](token_place_sample_datasets.md) — replay bundled
+  token.place health and chat samples
 - [pi_image_builder_design.md](pi_image_builder_design.md) — design and reliability features of the image builder
 
 ## Learn the Fundamentals

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -124,7 +124,10 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
     and bail out through the self-heal unit when rollouts or health probes fail. Markdown reports
     now land under `/boot/first-boot-report/helm-bundles/` for air-gapped debugging, and the
     workflow is documented in [Sugarkube Helm Bundle Hooks](./pi_helm_bundles.md).
-- [ ] Bundle sample datasets and token.place collections for first-launch validation.
+- [x] Bundle sample datasets and token.place collections for first-launch validation.
+  - Added `samples/token_place/` plus a replay helper that the image copies into
+    `/opt/sugarkube/` and `/opt/projects/token.place/` so first boot can confirm
+    health, model listings, and chat completions with a single command.
 - [x] Document and script multi-node join rehearsal for scaling clusters.
   - Added `scripts/pi_multi_node_join_rehearsal.py`, `make rehearse-join`/`just rehearse-join`
     wrappers, and the [Pi Multi-Node Join Rehearsal](./pi_multi_node_join_rehearsal.md) guide to

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -122,6 +122,14 @@ scan straight to this quickstart or the troubleshooting matrix while standing at
   ```bash
   sudo systemctl status projects-compose.service
   ```
+- Replay the bundled token.place sample dataset to confirm the relay answers
+  health, model, and chat requests:
+  ```bash
+  /opt/sugarkube/token_place_replay_samples.py
+  ```
+  The helper stores JSON responses under
+  `~/sugarkube/reports/token-place-samples/`. Expect the chat reply to mention
+  "Mock response" when `USE_MOCK_LLM=1` is set in `/opt/projects/token.place/.env`.
 - Metrics and dashboards are available immediately:
   - `curl http://<pi-host>:9100/metrics` for the node exporter.
   - `curl http://<pi-host>:12345/metrics` for the aggregated Grafana Agent feed.

--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -66,10 +66,14 @@ docker compose version
    sudo systemctl status k3s-ready.target
    ```
 4. Verify each app on the LAN:
-   ```sh
-   curl http://<pi-host>:5000  # token.place
-   curl http://<pi-host>:3000  # dspace
-   ```
+ ```sh
+ curl http://<pi-host>:5000  # token.place
+ curl http://<pi-host>:3000  # dspace
+ ```
+- The image now ships sample payloads under
+  `/opt/projects/token.place/samples/`. Run
+  `/opt/sugarkube/token_place_replay_samples.py` to capture JSON health/model/chat
+  reports in `~/sugarkube/reports/token-place-samples/` without leaving SSH.
 
 ### Automate health verification
 

--- a/docs/token_place_sample_datasets.md
+++ b/docs/token_place_sample_datasets.md
@@ -1,0 +1,44 @@
+# token.place Sample Datasets
+
+Sugarkube images now bundle HTTP request samples so operators can validate
+`token.place` before exposing the cluster. The payloads live alongside the
+source tree under [`samples/token_place/`](../samples/token_place/) and the build
+pipeline copies them into two runtime locations:
+
+- `/opt/projects/token.place/samples/` inside the token.place workspace
+- `/opt/sugarkube/samples/token-place/` next to the helper scripts
+
+## Contents
+
+| Artifact | Description |
+| --- | --- |
+| `openai-chat-demo.json` | OpenAI-compatible chat completion body that exercises the bundled mock model. |
+| `postman/tokenplace-first-boot.postman_collection.json` | Postman collection with health, model list, and chat requests using the `{{baseUrl}}` variable. |
+| `http/tokenplace-quickcheck.http` | VS Code REST Client snippet mirroring the Postman requests. |
+
+The sample chat request expects the mock model to respond. Set `USE_MOCK_LLM=1`
+in `/opt/projects/token.place/.env` when you need deterministic replies during
+demos.
+
+## Automated replay script
+
+`/opt/sugarkube/token_place_replay_samples.py` reads the JSON payload and issues
+three probes against the relay:
+
+1. `GET /v1/health`
+2. `GET /v1/models`
+3. `POST /v1/chat/completions`
+
+The script falls back to the `/api/v1/*` paths automatically and writes the
+responses to `~/sugarkube/reports/token-place-samples/`.
+
+Run it locally with the `make` or `just` wrappers:
+
+```sh
+make token-place-samples
+# or
+just token-place-samples
+```
+
+Pass `TOKEN_PLACE_SAMPLE_ARGS="--dry-run"` (or `TOKEN_PLACE_URL` / `--base-url`)
+when targeting a different host.

--- a/justfile
+++ b/justfile
@@ -39,6 +39,14 @@ rehearsal_cmd := env_var_or_default(
     justfile_directory() + "/scripts/pi_multi_node_join_rehearsal.py",
 )
 rehearsal_args := env_var_or_default("REHEARSAL_ARGS", "")
+token_place_sample_cmd := env_var_or_default(
+    "TOKEN_PLACE_SAMPLE_CMD",
+    justfile_directory() + "/scripts/token_place_replay_samples.py",
+)
+token_place_sample_args := env_var_or_default(
+    "TOKEN_PLACE_SAMPLE_ARGS",
+    "--samples-dir " + justfile_directory() + "/samples/token_place",
+)
 
 _default:
     @just --list
@@ -139,3 +147,8 @@ docs-verify:
 # Usage: just qr-codes QR_ARGS="--output-dir ~/qr"
 qr-codes:
     "{{qr_cmd}}" {{qr_args}}
+
+# Replay bundled token.place sample payloads and write reports
+# Usage: just token-place-samples TOKEN_PLACE_SAMPLE_ARGS="--dry-run"
+token-place-samples:
+    "{{token_place_sample_cmd}}" {{token_place_sample_args}}

--- a/samples/token_place/README.md
+++ b/samples/token_place/README.md
@@ -1,0 +1,35 @@
+# token.place Sample Datasets
+
+The sugarkube Pi image now bundles small HTTP request samples so you can verify
+`token.place` immediately after the first boot. Import the Postman collection,
+run the REST Client snippets, or replay the JSON payloads with
+`scripts/token_place_replay_samples.py` to confirm the relay answers requests.
+
+## Contents
+
+- [`openai-chat-demo.json`](./openai-chat-demo.json) — Minimal OpenAI-compatible
+  chat completion request that works with the bundled mock model.
+- [`postman/tokenplace-first-boot.postman_collection.json`](./postman/tokenplace-first-boot.postman_collection.json)
+  — Postman collection with health, models, and chat probes using the
+  `{{baseUrl}}` variable.
+- [`http/tokenplace-quickcheck.http`](./http/tokenplace-quickcheck.http) — VS
+  Code REST Client snippet mirroring the Postman requests.
+
+Each Pi image copies this folder to both `/opt/projects/token.place/samples` and
+`/opt/sugarkube/samples/token-place`. The replay script stores results under
+`~/sugarkube/reports/token-place-samples/` by default.
+
+## Usage
+
+1. Ensure `projects-compose.service` is running on the Pi so `token.place` is
+   available on port 5000.
+2. Run the helper script:
+   ```sh
+   /opt/sugarkube/token_place_replay_samples.py
+   ```
+3. Inspect the generated health/model/chat JSON files in the reports directory.
+   The chat response should include "Mock response" when the mock LLM is
+   enabled.
+
+Set `TOKEN_PLACE_URL` or pass `--base-url` to target a different host. Use
+`--dry-run` to simply validate that the sample payloads are present.

--- a/samples/token_place/http/tokenplace-quickcheck.http
+++ b/samples/token_place/http/tokenplace-quickcheck.http
@@ -1,0 +1,26 @@
+@baseUrl = http://127.0.0.1:5000
+
+### Health
+GET {{baseUrl}}/v1/health
+
+### List models
+GET {{baseUrl}}/v1/models
+
+### Chat completion (mock)
+POST {{baseUrl}}/v1/chat/completions
+Content-Type: application/json
+
+{
+  "model": "llama-3-8b-instruct",
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are a helpful assistant that keeps replies under 40 words."
+    },
+    {
+      "role": "user",
+      "content": "Say hello from the sugarkube Pi image sample dataset."
+    }
+  ],
+  "temperature": 0.2
+}

--- a/samples/token_place/openai-chat-demo.json
+++ b/samples/token_place/openai-chat-demo.json
@@ -1,0 +1,14 @@
+{
+  "model": "llama-3-8b-instruct",
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are a helpful assistant that keeps replies under 40 words."
+    },
+    {
+      "role": "user",
+      "content": "Say hello from the sugarkube Pi image sample dataset."
+    }
+  ],
+  "temperature": 0.2
+}

--- a/samples/token_place/postman/tokenplace-first-boot.postman_collection.json
+++ b/samples/token_place/postman/tokenplace-first-boot.postman_collection.json
@@ -1,0 +1,80 @@
+{
+  "info": {
+    "_postman_id": "c4f1976f-8b77-4d0e-8e93-0a5dd1cd1f3b",
+    "name": "sugarkube token.place first boot checks",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": "Health and chat probes for the bundled token.place instance."
+  },
+  "item": [
+    {
+      "name": "Health",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/v1/health",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "v1",
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "List models",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/v1/models",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "v1",
+            "models"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Chat completion (mock)",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"model\": \"llama-3-8b-instruct\",\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"You are a helpful assistant that keeps replies under 40 words.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Say hello from the sugarkube Pi image sample dataset.\"\n    }\n  ],\n  \"temperature\": 0.2\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/v1/chat/completions",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "v1",
+            "chat",
+            "completions"
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://127.0.0.1:5000"
+    }
+  ]
+}

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -314,6 +314,16 @@ install -Dm755 "${APPLY_HELM_BUNDLES_PATH}" \
 
 install -Dm755 "${K3S_READY_PATH}" \
   "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/k3s-ready.sh"
+install -Dm755 "${REPO_ROOT}/scripts/token_place_replay_samples.py" \
+  "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/token_place_replay_samples.py"
+
+TOKEN_PLACE_SAMPLES_SRC="${REPO_ROOT}/samples/token_place"
+TOKEN_PLACE_SAMPLES_DEST="${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/sugarkube/samples/token-place"
+if [ -d "${TOKEN_PLACE_SAMPLES_SRC}" ]; then
+  rm -rf "${TOKEN_PLACE_SAMPLES_DEST}"
+  mkdir -p "${TOKEN_PLACE_SAMPLES_DEST}"
+  cp -a "${TOKEN_PLACE_SAMPLES_SRC}/." "${TOKEN_PLACE_SAMPLES_DEST}/"
+fi
 
 CLONE_SUGARKUBE="${CLONE_SUGARKUBE:-false}"
 CLONE_TOKEN_PLACE="${CLONE_TOKEN_PLACE:-true}"
@@ -347,6 +357,12 @@ else
     "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/projects/observability/grafana-agent.env.example"
   install -Dm644 "${REPO_ROOT}/scripts/cloud-init/observability/netdata.env.example" \
     "${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/projects/observability/netdata.env.example"
+  if [[ "$CLONE_TOKEN_PLACE" == "true" && -d "${TOKEN_PLACE_SAMPLES_SRC}" ]]; then
+    token_place_samples_project="${WORK_DIR}/pi-gen/stage2/01-sys-tweaks/files/opt/projects/token.place/samples"
+    rm -rf "${token_place_samples_project}"
+    mkdir -p "${token_place_samples_project}"
+    cp -a "${TOKEN_PLACE_SAMPLES_SRC}/." "${token_place_samples_project}/"
+  fi
 fi
 
 run_sh="${WORK_DIR}/pi-gen/stage2/02-sugarkube-tools/00-run-chroot.sh"

--- a/scripts/token_place_replay_samples.py
+++ b/scripts/token_place_replay_samples.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+
+"""Replay bundled token.place sample requests for first-boot validation."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+from urllib import error, request
+
+DEFAULT_BASE_URL = "http://127.0.0.1:5000"
+DEFAULT_SAMPLE = "openai-chat-demo.json"
+DEFAULT_REPORT_DIR = Path.home() / "sugarkube" / "reports" / "token-place-samples"
+DEFAULT_TIMEOUT = 10
+
+
+class ReplayError(RuntimeError):
+    """Raised when a probe fails."""
+
+
+def _load_sample(sample_path: Path) -> dict:
+    try:
+        with sample_path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except FileNotFoundError as exc:  # pragma: no cover - handled by caller
+        raise ReplayError(f"Sample payload not found: {sample_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ReplayError(f"Sample payload is invalid JSON: {sample_path}") from exc
+
+
+def _candidate_urls(base_url: str, paths: Iterable[str]) -> Iterable[str]:
+    for path in paths:
+        yield base_url.rstrip("/") + path
+
+
+def _http_request(
+    url: str,
+    *,
+    method: str = "GET",
+    timeout: int,
+    payload: Optional[dict] = None,
+) -> dict:
+    data = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(payload).encode("utf-8")
+    req = request.Request(url, data=data, headers=headers, method=method)
+    with request.urlopen(req, timeout=timeout) as response:
+        charset = response.headers.get_content_charset("utf-8")
+        body = response.read().decode(charset)
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise ReplayError(f"Non-JSON response from {url}: {body[:120]}") from exc
+
+
+def _probe_first(base_url: str, candidates: Iterable[str], **kwargs) -> tuple[str, dict]:
+    last_error: Optional[Exception] = None
+    for candidate in candidates:
+        try:
+            payload = _http_request(candidate, **kwargs)
+            return candidate, payload
+        except (ReplayError, error.URLError, error.HTTPError) as exc:
+            last_error = exc
+    if last_error is None:
+        raise ReplayError("No candidates provided for probe")
+    raise ReplayError(str(last_error))
+
+
+def replay_samples(*, base_url: str, samples_dir: Path, output_dir: Path, timeout: int) -> None:
+    sample_payload = _load_sample(samples_dir / DEFAULT_SAMPLE)
+
+    health_url, health = _probe_first(
+        base_url,
+        _candidate_urls(base_url, ("/v1/health", "/api/v1/health", "/health")),
+        timeout=timeout,
+    )
+    models_url, models = _probe_first(
+        base_url,
+        _candidate_urls(base_url, ("/v1/models", "/api/v1/models")),
+        timeout=timeout,
+    )
+    chat_url, chat = _probe_first(
+        base_url,
+        _candidate_urls(base_url, ("/v1/chat/completions", "/api/v1/chat/completions")),
+        timeout=timeout,
+        payload=sample_payload,
+        method="POST",
+    )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for name, url_used, payload in (
+        ("health", health_url, health),
+        ("models", models_url, models),
+        ("chat", chat_url, chat),
+    ):
+        target = output_dir / f"{name}.json"
+        with target.open("w", encoding="utf-8") as handle:
+            json.dump({"url": url_used, "data": payload}, handle, indent=2)
+            handle.write("\n")
+
+    chat_choices = chat.get("choices", [])
+    assistant_msg = None
+    if chat_choices:
+        assistant_msg = chat_choices[0].get("message", {}).get("content")
+    if not assistant_msg:
+        raise ReplayError(
+            "Chat completion response did not include an assistant message; "
+            "check container logs for token.place"
+        )
+
+    print("token.place sample replay complete:")
+    print(f"  Health URL: {health_url}")
+    print(f"  Models URL: {models_url} (returned {len(models.get('data', []))} models)")
+    preview = assistant_msg.strip().splitlines()[0]
+    print(f"  Chat URL: {chat_url} -> {preview}")
+
+
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-url",
+        default=DEFAULT_BASE_URL,
+        help=f"token.place base URL (default: {DEFAULT_BASE_URL})",
+    )
+    parser.add_argument(
+        "--samples-dir",
+        default=str(Path("/opt/sugarkube/samples/token-place")),
+        help="Directory containing sample payloads",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_REPORT_DIR),
+        help="Where to write replay results",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        help="HTTP timeout in seconds",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Check for sample payloads without issuing HTTP requests",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = parse_args(argv)
+    samples_dir = Path(args.samples_dir)
+    sample_path = samples_dir / DEFAULT_SAMPLE
+    if not sample_path.exists():
+        print(f"Sample payload missing: {sample_path}", file=sys.stderr)
+        return 1
+    if args.dry_run:
+        print(f"Dry run OK — found {sample_path}")
+        return 0
+
+    try:
+        replay_samples(
+            base_url=args.base_url,
+            samples_dir=samples_dir,
+            output_dir=Path(args.output_dir),
+            timeout=args.timeout,
+        )
+    except ReplayError as exc:
+        print(f"Replay failed: {exc}", file=sys.stderr)
+        return 2
+    except (error.URLError, error.HTTPError) as exc:
+        print(f"Replay failed: {exc}", file=sys.stderr)
+        return 3
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -532,6 +532,10 @@ def _run_build_script(tmp_path, env):
     shutil.copy(ssd_clone_service_src, script_dir / "ssd_clone_service.py")
     (script_dir / "ssd_clone_service.py").chmod(0o755)
 
+    token_place_replay_src = repo_root / "scripts" / "token_place_replay_samples.py"
+    shutil.copy(token_place_replay_src, script_dir / "token_place_replay_samples.py")
+    (script_dir / "token_place_replay_samples.py").chmod(0o755)
+
     systemd_src = repo_root / "scripts" / "systemd" / "first-boot.service"
     systemd_dir = script_dir / "systemd"
     systemd_dir.mkdir(exist_ok=True)

--- a/tests/pi_multi_node_join_rehearsal_test.py
+++ b/tests/pi_multi_node_join_rehearsal_test.py
@@ -459,7 +459,9 @@ def test_main_success(monkeypatch, capsys, sample_nodes, tmp_path):
             nodes=sample_nodes,
         )
 
-    def fake_collect_agent_status(host: str, args: argparse.Namespace, api_host: str) -> rehearsal.AgentStatus:
+    def fake_collect_agent_status(
+        host: str, args: argparse.Namespace, api_host: str
+    ) -> rehearsal.AgentStatus:
         return rehearsal.AgentStatus(host=host, payload={"api_reachable": True})
 
     saved: list[tuple[str, str]] = []
@@ -496,7 +498,9 @@ def test_main_returns_warning_exit(monkeypatch, capsys, sample_nodes):
             nodes=sample_nodes,
         )
 
-    def fake_collect_agent_status(host: str, args: argparse.Namespace, api_host: str) -> rehearsal.AgentStatus:
+    def fake_collect_agent_status(
+        host: str, args: argparse.Namespace, api_host: str
+    ) -> rehearsal.AgentStatus:
         return rehearsal.AgentStatus(host=host, payload={}, error="unreachable")
 
     monkeypatch.setattr(rehearsal, "collect_server_status", fake_collect_server_status)

--- a/tests/test_token_place_samples.py
+++ b/tests/test_token_place_samples.py
@@ -1,0 +1,265 @@
+"""Validate bundled token.place sample assets and replay helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Iterable, Tuple
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SAMPLES_DIR = ROOT / "samples" / "token_place"
+SCRIPT = ROOT / "scripts" / "token_place_replay_samples.py"
+
+spec = importlib.util.spec_from_file_location("token_place_replay_samples", SCRIPT)
+assert spec and spec.loader
+replay = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(replay)  # type: ignore[misc]
+
+
+def test_openai_sample_payload_round_trips() -> None:
+    payload_path = SAMPLES_DIR / "openai-chat-demo.json"
+    with payload_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    assert payload["model"]
+    assert payload["messages"], "messages array must not be empty"
+    assert payload["messages"][0]["role"] == "system"
+
+
+def test_postman_collection_has_requests() -> None:
+    collection_path = SAMPLES_DIR / "postman" / "tokenplace-first-boot.postman_collection.json"
+    with collection_path.open("r", encoding="utf-8") as handle:
+        collection = json.load(handle)
+    names = [item["name"] for item in collection.get("item", [])]
+    assert {"Health", "List models", "Chat completion (mock)"}.issubset(set(names))
+
+
+def test_replay_script_dry_run(tmp_path: Path) -> None:
+    proc = subprocess.run(
+        [
+            str(SCRIPT),
+            "--dry-run",
+            "--samples-dir",
+            str(SAMPLES_DIR),
+            "--output-dir",
+            str(tmp_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "Dry run OK" in proc.stdout
+
+
+def test_load_sample_invalid_json(tmp_path: Path) -> None:
+    bad_sample = tmp_path / "bad.json"
+    bad_sample.write_text("not json", encoding="utf-8")
+    with pytest.raises(replay.ReplayError):
+        replay._load_sample(bad_sample)  # noqa: SLF001
+
+
+def test_candidate_urls_strips_trailing_slash() -> None:
+    urls = list(replay._candidate_urls("http://host/", ("/one", "/two")))  # noqa: SLF001
+    assert urls == ["http://host/one", "http://host/two"]
+
+
+def _fake_headers(charset: str = "utf-8") -> Any:
+    return SimpleNamespace(
+        get_content_charset=lambda default="utf-8": charset or default,
+    )
+
+
+class DummyResponse:
+    def __init__(self, body: str, *, charset: str = "utf-8") -> None:
+        self._body = body
+        self.headers = _fake_headers(charset)
+
+    def read(self) -> bytes:
+        return self._body.encode(self.headers.get_content_charset())
+
+    def __enter__(self) -> "DummyResponse":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+def test_http_request_get(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_urlopen(req: Any, timeout: int) -> DummyResponse:
+        captured["method"] = req.method
+        captured["headers"] = req.headers
+        captured["timeout"] = timeout
+        return DummyResponse("{}")
+
+    monkeypatch.setattr(replay.request, "urlopen", fake_urlopen)
+    result = replay._http_request("http://example", timeout=5)  # noqa: SLF001
+    assert result == {}
+    assert captured["method"] == "GET"
+    assert captured["timeout"] == 5
+    assert captured["headers"]["Accept"] == "application/json"
+
+
+def test_http_request_post(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_urlopen(req: Any, timeout: int) -> DummyResponse:
+        captured["method"] = req.method
+        captured["data"] = req.data
+        captured["headers"] = req.headers
+        captured["timeout"] = timeout
+        return DummyResponse("{}")
+
+    monkeypatch.setattr(replay.request, "urlopen", fake_urlopen)
+    result = replay._http_request(  # noqa: SLF001
+        "http://example",
+        timeout=4,
+        payload={"hello": "world"},
+        method="POST",
+    )
+    assert result == {}
+    assert json.loads(captured["data"]) == {"hello": "world"}
+    lowered = {key.lower(): value for key, value in captured["headers"].items()}
+    assert lowered["content-type"] == "application/json"
+    assert captured["timeout"] == 4
+
+
+def test_http_request_non_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(req: Any, timeout: int) -> DummyResponse:
+        return DummyResponse("not json")
+
+    monkeypatch.setattr(replay.request, "urlopen", fake_urlopen)
+    with pytest.raises(replay.ReplayError):
+        replay._http_request("http://example", timeout=3)  # noqa: SLF001
+
+
+def test_probe_first_tries_candidates(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts: list[str] = []
+
+    def fake_http(url: str, **_: Any) -> dict[str, str]:
+        attempts.append(url)
+        if "second" in url:
+            return {"ok": "yes"}
+        raise replay.ReplayError("nope")
+
+    monkeypatch.setattr(replay, "_http_request", fake_http)  # noqa: SLF001
+    url, payload = replay._probe_first("base", ["first", "second"])  # noqa: SLF001
+    assert url == "second"
+    assert payload == {"ok": "yes"}
+    assert attempts == ["first", "second"]
+
+
+def test_probe_first_no_candidates() -> None:
+    with pytest.raises(replay.ReplayError):
+        replay._probe_first("base", [])  # noqa: SLF001
+
+
+def test_replay_samples_writes_reports(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    sample_payload = {"model": "demo", "messages": [{"role": "system", "content": "x"}]}
+    sample_file = tmp_path / replay.DEFAULT_SAMPLE
+    sample_file.write_text(json.dumps(sample_payload), encoding="utf-8")
+
+    calls: list[tuple[str, Iterable[str]]] = []
+
+    def fake_probe(
+        base_url: str,
+        candidates: Iterable[str],
+        **_: Any,
+    ) -> Tuple[str, dict[str, Any]]:
+        calls.append((base_url, tuple(candidates)))
+        if len(calls) == 3:
+            return "chat", {"choices": [{"message": {"content": "hello world"}}]}
+        if len(calls) == 1:
+            return "health", {"status": "ok"}
+        return "models", {"data": [1, 2]}
+
+    monkeypatch.setattr(replay, "_probe_first", fake_probe)  # noqa: SLF001
+    replay.replay_samples(
+        base_url="http://token.place",
+        samples_dir=tmp_path,
+        output_dir=tmp_path / "reports",
+        timeout=9,
+    )
+
+    outputs = sorted((tmp_path / "reports").glob("*.json"))
+    assert [path.name for path in outputs] == ["chat.json", "health.json", "models.json"]
+    chat_payload = json.loads(outputs[0].read_text(encoding="utf-8"))
+    assert chat_payload["url"] == "chat"
+    assert "hello world" in chat_payload["data"]["choices"][0]["message"]["content"]
+
+
+def test_replay_samples_requires_assistant(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    sample_payload = {"model": "demo", "messages": [{"role": "system", "content": "x"}]}
+    sample_file = tmp_path / replay.DEFAULT_SAMPLE
+    sample_file.write_text(json.dumps(sample_payload), encoding="utf-8")
+
+    def fake_probe(*_: Any, **__: Any) -> tuple[str, dict[str, Any]]:
+        return "chat", {"choices": []}
+
+    monkeypatch.setattr(replay, "_probe_first", fake_probe)  # noqa: SLF001
+    with pytest.raises(replay.ReplayError):
+        replay.replay_samples(
+            base_url="http://token.place",
+            samples_dir=tmp_path,
+            output_dir=tmp_path / "reports",
+            timeout=9,
+        )
+
+
+def test_parse_args_defaults() -> None:
+    args = replay.parse_args([])
+    assert args.base_url == replay.DEFAULT_BASE_URL
+    assert args.timeout == replay.DEFAULT_TIMEOUT
+
+
+def test_main_missing_sample(tmp_path: Path) -> None:
+    missing_dir = tmp_path / "samples"
+    exit_code = replay.main(["--samples-dir", str(missing_dir)])
+    assert exit_code == 1
+
+
+def test_main_replay_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    samples_dir = tmp_path / "samples"
+    samples_dir.mkdir()
+    (samples_dir / replay.DEFAULT_SAMPLE).write_text("{}", encoding="utf-8")
+
+    def fake_replay(**_: Any) -> None:
+        raise replay.ReplayError("boom")
+
+    monkeypatch.setattr(replay, "replay_samples", fake_replay)
+    exit_code = replay.main(["--samples-dir", str(samples_dir)])
+    assert exit_code == 2
+
+
+def test_main_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    samples_dir = tmp_path / "samples"
+    samples_dir.mkdir()
+    (samples_dir / replay.DEFAULT_SAMPLE).write_text("{}", encoding="utf-8")
+
+    called: dict[str, Any] = {}
+
+    def fake_replay(**kwargs: Any) -> None:
+        called.update(kwargs)
+
+    monkeypatch.setattr(replay, "replay_samples", fake_replay)
+    exit_code = replay.main(
+        [
+            "--samples-dir",
+            str(samples_dir),
+            "--base-url",
+            "http://custom",
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--timeout",
+            "7",
+        ]
+    )
+    assert exit_code == 0
+    assert called["base_url"] == "http://custom"
+    assert called["timeout"] == 7


### PR DESCRIPTION
## Summary
- bundle token.place sample payloads and install them into the Pi image
- add a replay helper plus make/just targets so first boot can confirm health
- document the samples, update quickstart guidance, and tick the checklist item
- ensure the pi-image build test harness copies the replay helper so CI passes
- add targeted unit coverage for `token_place_replay_samples.py` so patch coverage stays at 100%

## Testing
- uv tool run pre-commit run --all-files
- uv tool run pyspelling -c .spellcheck.yaml
- uv tool run linkchecker --no-warnings README.md docs/
- pytest tests/test_token_place_samples.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d0b9036cc0832fad09735d4c37b406