### PR TITLE
Add automated Pi support bundle collection

### DIFF
--- a/.github/workflows/pi-image-release.yml
+++ b/.github/workflows/pi-image-release.yml
@@ -28,6 +28,9 @@ jobs:
       CLONE_SUGARKUBE: false
       CLONE_TOKEN_PLACE: true
       CLONE_DSPACE: true
+      SUPPORT_BUNDLE_HOSTS: ${{ secrets.SUPPORT_BUNDLE_HOSTS }}
+      SUPPORT_BUNDLE_SSH_KEY: ${{ secrets.SUPPORT_BUNDLE_SSH_KEY }}
+      SUPPORT_BUNDLE_SSH_USER: ${{ secrets.SUPPORT_BUNDLE_SSH_USER }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -161,6 +164,37 @@ jobs:
             sugarkube.img.xz.manifest.json.pem
             sugarkube.build.log
             RELEASE_NOTES.md
+
+      - name: Write support bundle SSH key
+        if: env.SUPPORT_BUNDLE_HOSTS != '' && env.SUPPORT_BUNDLE_SSH_KEY != ''
+        run: |
+          printf '%s' "${SUPPORT_BUNDLE_SSH_KEY}" > support-bundle.key
+          chmod 600 support-bundle.key
+
+      - name: Capture support bundle
+        if: env.SUPPORT_BUNDLE_HOSTS != '' && env.SUPPORT_BUNDLE_SSH_KEY != ''
+        continue-on-error: true
+        run: |
+          mkdir -p support-bundles
+          python3 scripts/pi_support_bundle.py \
+            --output-dir support-bundles \
+            --identity support-bundle.key \
+            --user "${SUPPORT_BUNDLE_SSH_USER:-pi}" \
+            --ssh-option StrictHostKeyChecking=no \
+            --ssh-option UserKnownHostsFile=/dev/null \
+            ${SUPPORT_BUNDLE_HOSTS}
+
+      - name: Remove support bundle SSH key
+        if: env.SUPPORT_BUNDLE_HOSTS != '' && env.SUPPORT_BUNDLE_SSH_KEY != ''
+        run: rm -f support-bundle.key
+
+      - name: Upload support bundle artifact
+        if: env.SUPPORT_BUNDLE_HOSTS != '' && env.SUPPORT_BUNDLE_SSH_KEY != '' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sugarkube-support-bundle
+          path: support-bundles/
+          if-no-files-found: warn
 
       - name: Publish GitHub release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -57,6 +57,9 @@ jobs:
       CLONE_SUGARKUBE: ${{ github.event.inputs.clone_sugarkube }}
       CLONE_TOKEN_PLACE: ${{ github.event.inputs.clone_token_place }}
       CLONE_DSPACE: ${{ github.event.inputs.clone_dspace }}
+      SUPPORT_BUNDLE_HOSTS: ${{ secrets.SUPPORT_BUNDLE_HOSTS }}
+      SUPPORT_BUNDLE_SSH_KEY: ${{ secrets.SUPPORT_BUNDLE_SSH_KEY }}
+      SUPPORT_BUNDLE_SSH_USER: ${{ secrets.SUPPORT_BUNDLE_SSH_USER }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -164,3 +167,34 @@ jobs:
           path: |
             ./sugarkube.img.xz
             ./sugarkube.img.xz.sha256
+
+      - name: Write support bundle SSH key
+        if: env.SUPPORT_BUNDLE_HOSTS != '' && env.SUPPORT_BUNDLE_SSH_KEY != ''
+        run: |
+          printf '%s' "${SUPPORT_BUNDLE_SSH_KEY}" > support-bundle.key
+          chmod 600 support-bundle.key
+
+      - name: Capture support bundle
+        if: env.SUPPORT_BUNDLE_HOSTS != '' && env.SUPPORT_BUNDLE_SSH_KEY != ''
+        continue-on-error: true
+        run: |
+          mkdir -p support-bundles
+          python3 scripts/pi_support_bundle.py \
+            --output-dir support-bundles \
+            --identity support-bundle.key \
+            --user "${SUPPORT_BUNDLE_SSH_USER:-pi}" \
+            --ssh-option StrictHostKeyChecking=no \
+            --ssh-option UserKnownHostsFile=/dev/null \
+            ${SUPPORT_BUNDLE_HOSTS}
+
+      - name: Remove support bundle SSH key
+        if: env.SUPPORT_BUNDLE_HOSTS != '' && env.SUPPORT_BUNDLE_SSH_KEY != ''
+        run: rm -f support-bundle.key
+
+      - name: Upload support bundle artifact
+        if: env.SUPPORT_BUNDLE_HOSTS != '' && env.SUPPORT_BUNDLE_SSH_KEY != '' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sugarkube-support-bundle
+          path: support-bundles/
+          if-no-files-found: warn

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,12 @@ REHEARSAL_CMD ?= $(CURDIR)/scripts/pi_multi_node_join_rehearsal.py
 REHEARSAL_ARGS ?=
 TOKEN_PLACE_SAMPLE_CMD ?= $(CURDIR)/scripts/token_place_replay_samples.py
 TOKEN_PLACE_SAMPLE_ARGS ?= --samples-dir $(CURDIR)/samples/token_place
+SUPPORT_BUNDLE_CMD ?= $(CURDIR)/scripts/pi_support_bundle.py
+SUPPORT_BUNDLE_ARGS ?=
 
 .PHONY: install-pi-image download-pi-image flash-pi flash-pi-report doctor rollback-to-sd \
         clone-ssd docs-verify qr-codes monitor-ssd-health smoke-test-pi \
-        publish-telemetry update-hardware-badge rehearse-join \
+        publish-telemetry update-hardware-badge rehearse-join support-bundle \
         token-place-samples
 
 install-pi-image:
@@ -92,4 +94,7 @@ rehearse-join:
 	$(REHEARSAL_CMD) $(REHEARSAL_ARGS)
 
 token-place-samples:
-	$(TOKEN_PLACE_SAMPLE_CMD) $(TOKEN_PLACE_SAMPLE_ARGS)
+        $(TOKEN_PLACE_SAMPLE_CMD) $(TOKEN_PLACE_SAMPLE_ARGS)
+
+support-bundle:
+        $(SUPPORT_BUNDLE_CMD) $(SUPPORT_BUNDLE_ARGS)

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ the docs you will see the term used in both contexts.
     `--help` for usage
   - `pi_smoke_test.py` — SSH wrapper that runs the verifier remotely, supports reboot checks,
     and emits JSON summaries for CI harnesses
+  - `pi_support_bundle.py` — capture Kubernetes, `systemd`, and docker compose diagnostics into
+    timestamped archives; the release workflow uploads a `sugarkube-support-bundle` artifact when
+    support bundle secrets are configured. See [Pi Support Bundles](docs/pi_support_bundles.md).
   - `scan-secrets.py` — scan diffs for high-risk patterns using `ripsecrets` when
     available and also run a regex check to catch common tokens
 - `outages/` — structured outage records (see

--- a/docs/pi_image_contributor_guide.md
+++ b/docs/pi_image_contributor_guide.md
@@ -105,6 +105,13 @@ sync.
     [Pi Image Smoke Test Harness](./pi_smoke_test.md).
   - Related tooling: wrapped by `make smoke-test-pi` and `just smoke-test-pi` so operators can pass
     flags through `SMOKE_ARGS` without remembering the Python entry point.
+- `scripts/pi_support_bundle.py`
+  - Purpose: capture Kubernetes, Helm, Compose, and journal diagnostics into timestamped
+    archives for incident triage and CI artifacts.
+  - Primary docs: [Pi Support Bundles](./pi_support_bundles.md),
+    [Pi Image Quickstart](./pi_image_quickstart.md).
+  - Related tooling: exposed via `make support-bundle`, `just support-bundle`, and invoked from the
+    release workflow when `SUPPORT_BUNDLE_*` secrets are present.
 - `scripts/update_hardware_boot_badge.py`
   - Purpose: generate shields.io endpoint JSON so the README hardware boot badge reflects the
     latest physical verification run.

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -152,7 +152,11 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
   - Added `scripts/pi_smoke_test.py` plus Makefile/just wrappers so operators can run
     verifier checks over SSH, optionally rebooting hosts to confirm convergence and
     emitting JSON summaries for CI pipelines.
-- [ ] Capture support bundles (`kubectl get events`, `helm list`, `systemd-analyze blame`, Compose logs, journal slices) for every pipeline run.
+- [x] Capture support bundles (`kubectl get events`, `helm list`, `systemd-analyze blame`, Compose logs, journal slices) for every pipeline run.
+  - `scripts/pi_support_bundle.py` gathers Kubernetes, Helm, Compose, and journal data into
+    timestamped archives, `make support-bundle`/`just support-bundle` forward flags, and the
+    release workflow now uploads a `sugarkube-support-bundle` artifact whenever the
+    `SUPPORT_BUNDLE_*` secrets are present.
 - [x] Document how to run integration tests locally via `act`.
   - `docs/pi_image_builder_design.md` now includes a quick recipe for dry-running the release workflow with `act`.
 - [x] Publish a conformance badge in the README showing last successful hardware boot.

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -335,6 +335,21 @@ stores backups and writes a Markdown report to `/boot/sugarkube-rollback-report.
 See [SSD Recovery and Rollback](./ssd_recovery.md) for the full walkthrough and
 Makefile/justfile shortcuts.
 
+## Capture support bundles for debugging
+
+When a node misbehaves, collect a support bundle so Kubernetes events, Helm state, and journal logs
+travel with your bug report:
+
+```bash
+./scripts/pi_support_bundle.py pi-a.local --identity ~/.ssh/pi-support
+```
+
+The helper writes timestamped folders under `~/sugarkube/support-bundles/` and archives each run as
+`<timestamp>-<host>.tar.gz`. Prefer wrappers? Export
+`SUPPORT_BUNDLE_ARGS="pi-a.local --identity ~/.ssh/pi-support"` and run either
+`make support-bundle` or `just support-bundle`. See [Pi Support Bundles](./pi_support_bundles.md)
+for flag details and the CI integration notes.
+
 ## Codespaces-friendly automation
 
 - Launch a new GitHub Codespace on this repository using the default Ubuntu image.

--- a/docs/pi_support_bundles.md
+++ b/docs/pi_support_bundles.md
@@ -1,0 +1,59 @@
+# Pi Support Bundles
+
+`scripts/pi_support_bundle.py` captures Kubernetes events, Helm releases, Compose logs, and
+`systemd` journals from remote Pi nodes so every CI run and incident report ships with the same
+context. Bundles land in timestamped folders under `~/sugarkube/support-bundles/` (or a custom
+path) and the script archives each run as `<timestamp>-<host>.tar.gz` for quick attachment to issue
+threads.
+
+## Collecting bundles manually
+
+```bash
+./scripts/pi_support_bundle.py pi-a.local \
+  --identity ~/.ssh/pi-support \
+  --ssh-option StrictHostKeyChecking=no \
+  --ssh-option UserKnownHostsFile=/dev/null
+```
+
+The command above gathers:
+
+- `kubectl get events --all-namespaces -o yaml` plus pod, node, and service summaries.
+- `helm list --all-namespaces --output yaml` so pinned release versions travel with the bundle.
+- `docker compose` logs from `/opt/projects` alongside `journalctl -u projects-compose.service`.
+- `systemd-analyze blame`/`critical-chain` output for boot timing analysis.
+- `journalctl` slices for `k3s`, cloud-init phases, and the self-heal units.
+- `/boot/first-boot-report` (when present) packaged as `boot/first-boot-report.tar.gz`.
+
+Additional flags:
+
+- `--since "6 hours ago"` narrows journal slices when you only need the latest boot.
+- `--skip-first-boot-report` speeds up captures when the boot partition is not mounted.
+- `--strict` flips the exit code to non-zero if **any** remote command fails.
+- Pass multiple hosts (`pi-a.local pi-b.local`) to build one archive per node in a single run.
+
+Prefer wrappers? Use the new task runner hooks:
+
+```bash
+SUPPORT_BUNDLE_ARGS="pi-a.local --identity ~/.ssh/pi-support" make support-bundle
+# or
+SUPPORT_BUNDLE_ARGS="pi-a.local --identity ~/.ssh/pi-support" just support-bundle
+```
+
+Both targets pass arguments verbatim to `scripts/pi_support_bundle.py` so you can reuse saved shell
+snippets without editing the Makefile.
+
+## CI integration
+
+The release pipeline now uploads a `sugarkube-support-bundle` artifact whenever the following secrets
+are configured:
+
+- `SUPPORT_BUNDLE_HOSTS` – space- or newline-separated hostnames/IPs reachable from the runner.
+- `SUPPORT_BUNDLE_SSH_KEY` – private key used for the SSH connection.
+- `SUPPORT_BUNDLE_SSH_USER` (optional) – overrides the default `pi` user.
+
+Each run writes the key to `support-bundle.key`, invokes the collector with the hardened SSH options,
+and publishes the resulting archives as workflow artifacts. Missing secrets simply skip the step, so
+existing builds continue to succeed without additional setup.
+
+Set the secrets, verify connectivity with a manual run, then inspect the `sugarkube-support-bundle`
+artifact on subsequent `pi-image-release` builds to confirm the captured logs match expectations.

--- a/justfile
+++ b/justfile
@@ -47,6 +47,11 @@ token_place_sample_args := env_var_or_default(
     "TOKEN_PLACE_SAMPLE_ARGS",
     "--samples-dir " + justfile_directory() + "/samples/token_place",
 )
+support_bundle_cmd := env_var_or_default(
+    "SUPPORT_BUNDLE_CMD",
+    justfile_directory() + "/scripts/pi_support_bundle.py",
+)
+support_bundle_args := env_var_or_default("SUPPORT_BUNDLE_ARGS", "")
 
 _default:
     @just --list
@@ -152,3 +157,8 @@ qr-codes:
 # Usage: just token-place-samples TOKEN_PLACE_SAMPLE_ARGS="--dry-run"
 token-place-samples:
     "{{token_place_sample_cmd}}" {{token_place_sample_args}}
+
+# Collect support bundles over SSH for one or more hosts
+# Usage: just support-bundle SUPPORT_BUNDLE_ARGS="pi-a.local --identity ~/.ssh/key"
+support-bundle:
+    "{{support_bundle_cmd}}" {{support_bundle_args}}

--- a/scripts/pi_support_bundle.py
+++ b/scripts/pi_support_bundle.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""Collect Pi support bundles over SSH for CI and incident response."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import shlex
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+DEFAULT_OUTPUT_DIR = Path.home() / "sugarkube" / "support-bundles"
+DEFAULT_USER = "pi"
+DEFAULT_PORT = 22
+DEFAULT_CONNECT_TIMEOUT = 10
+DEFAULT_COMMAND_TIMEOUT = 120
+DEFAULT_SINCE = "12 hours ago"
+
+
+@dataclass
+class RemoteCommand:
+    """Definition for a remote command collected in the support bundle."""
+
+    path: Path
+    command: str
+    description: str
+    binary: bool = False
+
+
+@dataclass
+class CommandResult:
+    """Metadata recorded for each captured command."""
+
+    path: str
+    command: str
+    description: str
+    returncode: int
+    stderr: str
+    bytes_written: int
+    note: str | None = None
+
+
+@dataclass
+class CommandCapture:
+    """Pair command metadata with the captured data payload."""
+
+    result: CommandResult
+    data: bytes
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Connect to Raspberry Pis over SSH, gather Kubernetes/systemd/Compose diagnostics, "
+            "and package them into timestamped support bundles."
+        )
+    )
+    parser.add_argument(
+        "hosts",
+        nargs="+",
+        help=(
+            "Hostname or IP address of the Pi to inspect. Accept multiple hosts separated by "
+            "spaces or newlines."
+        ),
+    )
+    parser.add_argument(
+        "--user",
+        default=DEFAULT_USER,
+        help=f"SSH user. Defaults to '{DEFAULT_USER}'.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=DEFAULT_PORT,
+        help=f"SSH port. Defaults to {DEFAULT_PORT}.",
+    )
+    parser.add_argument(
+        "--identity",
+        help="Path to the private key passed to ssh -i.",
+    )
+    parser.add_argument(
+        "--connect-timeout",
+        type=int,
+        default=DEFAULT_CONNECT_TIMEOUT,
+        metavar="SECONDS",
+        help=(
+            "Timeout (in seconds) for establishing each SSH connection. "
+            f"Defaults to {DEFAULT_CONNECT_TIMEOUT}."
+        ),
+    )
+    parser.add_argument(
+        "--command-timeout",
+        type=int,
+        default=DEFAULT_COMMAND_TIMEOUT,
+        metavar="SECONDS",
+        help=(
+            "Timeout (in seconds) for each remote command execution. "
+            f"Defaults to {DEFAULT_COMMAND_TIMEOUT}."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help=(
+            "Directory where support bundles are written. "
+            "Defaults to ~/sugarkube/support-bundles."
+        ),
+    )
+    parser.add_argument(
+        "--since",
+        default=DEFAULT_SINCE,
+        help=(
+            "Time window passed to journalctl when collecting logs. "
+            "Quote values with spaces. Defaults to '12 hours ago'."
+        ),
+    )
+    parser.add_argument(
+        "--ssh-option",
+        action="append",
+        default=[],
+        metavar="OPTION",
+        help="Additional -o options passed directly to ssh (repeatable).",
+    )
+    parser.add_argument(
+        "--skip-first-boot-report",
+        action="store_true",
+        help="Skip archiving /boot/first-boot-report when absent or unnecessary.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero when any remote command fails. Default is to succeed with warnings.",
+    )
+    return parser.parse_args(argv)
+
+
+def sanitize_host(host: str) -> str:
+    return "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in host)
+
+
+def build_remote_commands(since: str) -> List[RemoteCommand]:
+    since_q = shlex.quote(since)
+    commands: List[RemoteCommand] = [
+        RemoteCommand(
+            path=Path("kubernetes/nodes.txt"),
+            command="sudo kubectl get nodes -o wide",
+            description="Kubernetes node status",
+        ),
+        RemoteCommand(
+            path=Path("kubernetes/pods.txt"),
+            command="sudo kubectl get pods --all-namespaces -o wide",
+            description="All pods across namespaces",
+        ),
+        RemoteCommand(
+            path=Path("kubernetes/events.yaml"),
+            command=(
+                "sudo kubectl get events --all-namespaces "
+                "--sort-by=.metadata.creationTimestamp -o yaml"
+            ),
+            description="Cluster events sorted by timestamp",
+        ),
+        RemoteCommand(
+            path=Path("kubernetes/services.txt"),
+            command="sudo kubectl get svc --all-namespaces -o wide",
+            description="Service overview",
+        ),
+        RemoteCommand(
+            path=Path("kubernetes/describe-nodes.txt"),
+            command="sudo kubectl describe nodes",
+            description="Detailed node descriptions",
+        ),
+        RemoteCommand(
+            path=Path("kubernetes/version.yaml"),
+            command="sudo kubectl version --output=yaml",
+            description="Kubectl client and server versions",
+        ),
+        RemoteCommand(
+            path=Path("helm/list.yaml"),
+            command="sudo helm list --all-namespaces --output yaml",
+            description="Installed Helm releases",
+        ),
+        RemoteCommand(
+            path=Path("compose/projects-compose.log"),
+            command=(
+                "cd /opt/projects 2>/dev/null && "
+                "sudo docker compose -f docker-compose.yml logs --no-color --tail=500"
+            ),
+            description="docker compose logs for token.place and dspace",
+        ),
+        RemoteCommand(
+            path=Path("systemd/blame.txt"),
+            command="sudo systemd-analyze blame",
+            description="Systemd unit startup timings",
+        ),
+        RemoteCommand(
+            path=Path("systemd/critical-chain.txt"),
+            command="sudo systemd-analyze critical-chain",
+            description="Critical path analysis",
+        ),
+        RemoteCommand(
+            path=Path("systemd/failed-units.txt"),
+            command="sudo systemctl --failed",
+            description="Failed systemd units",
+        ),
+        RemoteCommand(
+            path=Path("journal/k3s.log"),
+            command=("sudo journalctl --no-pager --output=short-iso " f"--since {since_q} -u k3s"),
+            description="k3s journal excerpt",
+        ),
+        RemoteCommand(
+            path=Path("journal/projects-compose.log"),
+            command=(
+                "sudo journalctl --no-pager --output=short-iso "
+                f"--since {since_q} -u projects-compose.service"
+            ),
+            description="projects-compose.service journal excerpt",
+        ),
+        RemoteCommand(
+            path=Path("journal/self-heal.log"),
+            command=(
+                "sudo journalctl --no-pager --output=short-iso "
+                f"--since {since_q} -u 'sugarkube-self-heal@*'"
+            ),
+            description="Self-heal journal excerpt",
+        ),
+        RemoteCommand(
+            path=Path("journal/cloud-init.log"),
+            command=(
+                "sudo journalctl --no-pager --output=short-iso "
+                f"--since {since_q} -u cloud-init -u cloud-final -u cloud-config"
+            ),
+            description="cloud-init journal excerpt",
+        ),
+        RemoteCommand(
+            path=Path("system/df.txt"),
+            command="df -h",
+            description="Filesystem usage",
+        ),
+        RemoteCommand(
+            path=Path("system/free.txt"),
+            command="free -h",
+            description="Memory usage",
+        ),
+        RemoteCommand(
+            path=Path("system/uptime.txt"),
+            command="uptime",
+            description="Uptime and load average",
+        ),
+    ]
+    return commands
+
+
+class SupportBundleCollector:
+    """Collect support bundles from Pi hosts."""
+
+    def __init__(
+        self,
+        args: argparse.Namespace,
+        runner: callable | None = None,
+        now_fn: callable | None = None,
+    ) -> None:
+        self.args = args
+        self.runner = runner or subprocess.run
+        self.now_fn = now_fn or dt.datetime.utcnow
+        self.failures: List[str] = []
+
+    def collect(self) -> bool:
+        output_root = Path(self.args.output_dir).expanduser()
+        output_root.mkdir(parents=True, exist_ok=True)
+        commands = build_remote_commands(self.args.since)
+        overall_success = True
+
+        for host in self.args.hosts:
+            host_success = self._collect_for_host(host, output_root, commands)
+            if not host_success:
+                overall_success = False
+                message = f"[{host}] one or more commands returned a non-zero exit code"
+                self.failures.append(message)
+                print(message, file=sys.stderr)
+
+        return overall_success
+
+    def _collect_for_host(
+        self,
+        host: str,
+        output_root: Path,
+        commands: Iterable[RemoteCommand],
+    ) -> bool:
+        safe_host = sanitize_host(host)
+        timestamp = self.now_fn().replace(microsecond=0).isoformat().replace(":", "")
+        host_dir = output_root / f"{timestamp}-{safe_host}"
+        host_dir.mkdir(parents=True, exist_ok=True)
+        metadata: List[CommandResult] = []
+        host_success = True
+
+        for remote in commands:
+            capture = self._run_remote(host, remote)
+            self._write_capture(host_dir / remote.path, capture)
+            metadata.append(capture.result)
+            if capture.result.returncode != 0:
+                host_success = False
+            print(
+                f"[{host}] captured {remote.path} (exit {capture.result.returncode}, "
+                f"{capture.result.bytes_written} bytes)",
+            )
+
+        if not self.args.skip_first_boot_report:
+            fb_capture = self._capture_first_boot_report(host)
+            boot_archive = host_dir / Path("boot/first-boot-report.tar.gz")
+            self._write_capture(
+                boot_archive,
+                fb_capture,
+                allow_placeholder=False,
+            )
+            metadata.append(fb_capture.result)
+            if fb_capture.result.returncode != 0:
+                host_success = False
+            print(
+                f"[{host}] captured {boot_archive.relative_to(host_dir)} "
+                f"(exit {fb_capture.result.returncode}, {fb_capture.result.bytes_written} bytes)",
+            )
+
+        collected_at = self.now_fn().isoformat() + "Z"
+        metadata_path = host_dir / "metadata.json"
+        metadata_path.write_text(
+            json.dumps(
+                {
+                    "host": host,
+                    "collected_at": collected_at,
+                    "commands": [asdict(result) for result in metadata],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        archive_path = shutil.make_archive(
+            str(host_dir), "gztar", root_dir=host_dir.parent, base_dir=host_dir.name
+        )
+        print(f"[{host}] wrote archive {archive_path}")
+        return host_success
+
+    def _run_remote(self, host: str, remote: RemoteCommand) -> CommandCapture:
+        ssh_command = self._build_ssh_command(host)
+        remote_command = f"set -o pipefail; {remote.command}"
+        try:
+            completed = self.runner(  # type: ignore[misc]
+                [*ssh_command, remote_command],
+                capture_output=True,
+                text=not remote.binary,
+                timeout=self.args.command_timeout,
+            )
+        except subprocess.TimeoutExpired as exc:  # pragma: no cover - defensive
+            stderr = str(exc)
+            note = "timeout"
+            stdout = exc.stdout or (b"" if remote.binary else "")
+            if remote.binary and isinstance(stdout, (bytes, bytearray)):
+                data = bytes(stdout)
+            else:
+                if isinstance(stdout, (bytes, bytearray)):
+                    decoded = stdout.decode("utf-8", "replace")
+                else:
+                    decoded = "" if stdout is None else str(stdout)
+                data = decoded.encode("utf-8") if decoded else b""
+            result = CommandResult(
+                path=str(remote.path),
+                command=remote.command,
+                description=remote.description,
+                returncode=-1,
+                stderr=stderr,
+                bytes_written=0,
+                note=note,
+            )
+            return CommandCapture(result=result, data=data)
+
+        stderr_text = completed.stderr
+        if isinstance(stderr_text, bytes):
+            stderr_text = stderr_text.decode("utf-8", "replace")
+        elif stderr_text is None:
+            stderr_text = ""
+
+        note = None
+        if completed.returncode != 0:
+            note = f"exit-{completed.returncode}"
+
+        if remote.binary:
+            stdout_value = completed.stdout
+            if isinstance(stdout_value, (bytes, bytearray)):
+                data = bytes(stdout_value)
+            else:
+                data = b""
+        else:
+            stdout_text = completed.stdout if isinstance(completed.stdout, str) else ""
+            if completed.returncode != 0 and stderr_text:
+                stripped_stdout = stdout_text.rstrip("\n")
+                combined = f"{stripped_stdout}\n\n[stderr]\n{stderr_text}".rstrip("\n") + "\n"
+            else:
+                combined = stdout_text
+            data = combined.encode("utf-8")
+
+        result = CommandResult(
+            path=str(remote.path),
+            command=remote.command,
+            description=remote.description,
+            returncode=completed.returncode,
+            stderr=stderr_text,
+            bytes_written=0,
+            note=note,
+        )
+        return CommandCapture(result=result, data=data)
+
+    def _capture_first_boot_report(self, host: str) -> CommandCapture:
+        remote = RemoteCommand(
+            path=Path("boot/first-boot-report.tar.gz"),
+            command=(
+                "if [ -d /boot/first-boot-report ]; then "
+                "sudo tar -C /boot -czf - first-boot-report; "
+                "else echo 'first-boot-report directory missing' >&2; fi"
+            ),
+            description="Archive of /boot/first-boot-report",
+            binary=True,
+        )
+        return self._run_remote(host, remote)
+
+    def _write_capture(
+        self,
+        path: Path,
+        capture: CommandCapture,
+        *,
+        allow_placeholder: bool = True,
+    ) -> None:
+        data = capture.data
+        if not data:
+            self._append_note(capture.result, "no-output")
+            if not allow_placeholder:
+                capture.result.bytes_written = 0
+                return
+            data = b"(no output captured)\n"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+        capture.result.bytes_written = len(data)
+
+    def _append_note(self, result: CommandResult, message: str) -> None:
+        if result.note:
+            if message not in result.note:
+                result.note = f"{result.note}; {message}"
+        else:
+            result.note = message
+
+    def _build_ssh_command(self, host: str) -> List[str]:
+        base: List[str] = [
+            "ssh",
+            "-p",
+            str(self.args.port),
+            "-o",
+            f"ConnectTimeout={self.args.connect_timeout}",
+            "-o",
+            "BatchMode=yes",
+        ]
+        for option in self.args.ssh_option:
+            base.extend(["-o", option])
+        if self.args.identity:
+            base.extend(["-i", self.args.identity])
+        target = host if "@" in host else f"{self.args.user}@{host}"
+        base.append(target)
+        base.extend(["bash", "-lc"])
+        return base
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    collector = SupportBundleCollector(args)
+    success = collector.collect()
+    if not success and args.strict:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/tests/test_pi_support_bundle.py
+++ b/tests/test_pi_support_bundle.py
@@ -1,0 +1,75 @@
+import datetime as dt
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "scripts" / "pi_support_bundle.py"
+SPEC = importlib.util.spec_from_file_location("pi_support_bundle", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def test_sanitize_host_replaces_invalid_characters():
+    assert MODULE.sanitize_host("pi-a.local") == "pi-a_local"
+    assert MODULE.sanitize_host("pi#a+1") == "pi_a_1"
+
+
+def test_build_remote_commands_includes_since_clause():
+    commands = MODULE.build_remote_commands("24 hours ago")
+    journal_command = next(cmd for cmd in commands if cmd.path == Path("journal/k3s.log"))
+    assert "--since '24 hours ago'" in journal_command.command
+    compose_command = next(
+        cmd for cmd in commands if cmd.path == Path("compose/projects-compose.log")
+    )
+    assert "docker compose" in compose_command.command
+
+
+def test_collector_writes_bundles_and_metadata(tmp_path):
+    args = MODULE.parse_args(
+        [
+            "pi.local",
+            "--output-dir",
+            str(tmp_path),
+            "--skip-first-boot-report",
+        ]
+    )
+
+    def fake_runner(cmd, capture_output, text, timeout):
+        remote = cmd[-1]
+        if "docker compose" in remote:
+            stdout = "" if text else b""
+            stderr = "compose exploded" if text else b"compose exploded"
+            return subprocess.CompletedProcess(cmd, 1, stdout=stdout, stderr=stderr)
+        if text:
+            stdout = f"ok: {remote}"
+            stderr = ""
+        else:
+            stdout = f"ok: {remote}".encode()
+            stderr = b""
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=stderr)
+
+    collector = MODULE.SupportBundleCollector(
+        args,
+        runner=fake_runner,
+        now_fn=lambda: dt.datetime(2025, 1, 1, 0, 0, 0),
+    )
+    success = collector.collect()
+    assert not success  # compose command returned exit 1
+
+    host_dir = next(p for p in tmp_path.iterdir() if p.is_dir())
+    metadata_path = host_dir / "metadata.json"
+    assert metadata_path.exists()
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata["host"] == "pi.local"
+    compose_entry = next(
+        item for item in metadata["commands"] if item["path"] == "compose/projects-compose.log"
+    )
+    assert compose_entry["note"] == "exit-1"
+    log_contents = (host_dir / "compose/projects-compose.log").read_text()
+    assert "compose exploded" in log_contents
+
+    archives = list(tmp_path.glob("*.tar.gz"))
+    assert archives, "expected tar archive to be created"


### PR DESCRIPTION
## Summary
- add `scripts/pi_support_bundle.py` to capture Kubernetes/systemd/Compose diagnostics with unit coverage
- document manual usage, make/just wrappers, and quickstart guidance for support bundles
- upload a `sugarkube-support-bundle` artifact from pi-image workflows and tick the checklist item

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68d0d6a41b4c832f90b652172e5e1ff6