### PR TITLE
feat: collect support bundles in pi workflows

### DIFF
--- a/.github/workflows/pi-image-release.yml
+++ b/.github/workflows/pi-image-release.yml
@@ -162,6 +162,43 @@ jobs:
             sugarkube.build.log
             RELEASE_NOTES.md
 
+      - name: Collect support bundle
+        if: always()
+        env:
+          SUPPORT_BUNDLE_HOST: ${{ secrets.SUPPORT_BUNDLE_HOST }}
+          SUPPORT_BUNDLE_USER: ${{ secrets.SUPPORT_BUNDLE_USER }}
+          SUPPORT_BUNDLE_KEY: ${{ secrets.SUPPORT_BUNDLE_KEY }}
+        run: |
+          set -euo pipefail
+          args=("--output" "support-bundle.tar.gz")
+          if [[ -n "${SUPPORT_BUNDLE_HOST:-}" ]]; then
+            args+=("--host" "${SUPPORT_BUNDLE_HOST}")
+          fi
+          if [[ -n "${SUPPORT_BUNDLE_USER:-}" ]]; then
+            args+=("--user" "${SUPPORT_BUNDLE_USER}")
+          fi
+          key_path=""
+          if [[ -n "${SUPPORT_BUNDLE_KEY:-}" ]]; then
+            key_path="$(mktemp)"
+            printf '%s\n' "${SUPPORT_BUNDLE_KEY}" >"${key_path}"
+            chmod 600 "${key_path}"
+            args+=("--identity" "${key_path}")
+          fi
+          if [[ -n "${SUPPORT_BUNDLE_HOST:-}" ]]; then
+            args+=("--include-first-boot-report")
+          fi
+          python3 scripts/collect_support_bundle.py "${args[@]}"
+          if [[ -n "${key_path}" ]]; then
+            shred -u "${key_path}"
+          fi
+
+      - name: Upload support bundle artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: support-bundle
+          path: support-bundle.tar.gz
+
       - name: Publish GitHub release
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -164,3 +164,40 @@ jobs:
           path: |
             ./sugarkube.img.xz
             ./sugarkube.img.xz.sha256
+
+      - name: Collect support bundle
+        if: always()
+        env:
+          SUPPORT_BUNDLE_HOST: ${{ secrets.SUPPORT_BUNDLE_HOST }}
+          SUPPORT_BUNDLE_USER: ${{ secrets.SUPPORT_BUNDLE_USER }}
+          SUPPORT_BUNDLE_KEY: ${{ secrets.SUPPORT_BUNDLE_KEY }}
+        run: |
+          set -euo pipefail
+          args=("--output" "support-bundle.tar.gz")
+          if [[ -n "${SUPPORT_BUNDLE_HOST:-}" ]]; then
+            args+=("--host" "${SUPPORT_BUNDLE_HOST}")
+          fi
+          if [[ -n "${SUPPORT_BUNDLE_USER:-}" ]]; then
+            args+=("--user" "${SUPPORT_BUNDLE_USER}")
+          fi
+          key_path=""
+          if [[ -n "${SUPPORT_BUNDLE_KEY:-}" ]]; then
+            key_path="$(mktemp)"
+            printf '%s\n' "${SUPPORT_BUNDLE_KEY}" >"${key_path}"
+            chmod 600 "${key_path}"
+            args+=("--identity" "${key_path}")
+          fi
+          if [[ -n "${SUPPORT_BUNDLE_HOST:-}" ]]; then
+            args+=("--include-first-boot-report")
+          fi
+          python3 scripts/collect_support_bundle.py "${args[@]}"
+          if [[ -n "${key_path}" ]]; then
+            shred -u "${key_path}"
+          fi
+
+      - name: Upload support bundle artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: support-bundle
+          path: support-bundle.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,13 @@ REHEARSAL_CMD ?= $(CURDIR)/scripts/pi_multi_node_join_rehearsal.py
 REHEARSAL_ARGS ?=
 TOKEN_PLACE_SAMPLE_CMD ?= $(CURDIR)/scripts/token_place_replay_samples.py
 TOKEN_PLACE_SAMPLE_ARGS ?= --samples-dir $(CURDIR)/samples/token_place
+SUPPORT_BUNDLE_CMD ?= $(CURDIR)/scripts/collect_support_bundle.py
+SUPPORT_BUNDLE_ARGS ?=
 
 .PHONY: install-pi-image download-pi-image flash-pi flash-pi-report doctor rollback-to-sd \
         clone-ssd docs-verify qr-codes monitor-ssd-health smoke-test-pi \
         publish-telemetry update-hardware-badge rehearse-join \
-        token-place-samples
+        token-place-samples collect-support-bundle
 
 install-pi-image:
 	$(INSTALL_CMD) --dir '$(IMAGE_DIR)' --image '$(IMAGE_PATH)' $(DOWNLOAD_ARGS)
@@ -92,4 +94,7 @@ rehearse-join:
 	$(REHEARSAL_CMD) $(REHEARSAL_ARGS)
 
 token-place-samples:
-	$(TOKEN_PLACE_SAMPLE_CMD) $(TOKEN_PLACE_SAMPLE_ARGS)
+        $(TOKEN_PLACE_SAMPLE_CMD) $(TOKEN_PLACE_SAMPLE_ARGS)
+
+collect-support-bundle:
+        $(SUPPORT_BUNDLE_CMD) $(SUPPORT_BUNDLE_ARGS)

--- a/docs/pi_image_contributor_guide.md
+++ b/docs/pi_image_contributor_guide.md
@@ -105,6 +105,12 @@ sync.
     [Pi Image Smoke Test Harness](./pi_smoke_test.md).
   - Related tooling: wrapped by `make smoke-test-pi` and `just smoke-test-pi` so operators can pass
     flags through `SMOKE_ARGS` without remembering the Python entry point.
+- `scripts/collect_support_bundle.py`
+  - Purpose: capture kubectl, Helm, docker compose, journal, and first-boot artifacts into a
+    tarball for CI runs and manual troubleshooting.
+  - Primary docs: [Pi Support Bundle Collector](./pi_support_bundle.md).
+  - Related tooling: exposed via `make collect-support-bundle`, `just support-bundle`, and executed
+    automatically from the pi-image workflows to publish artifacts on every run.
 - `scripts/update_hardware_boot_badge.py`
   - Purpose: generate shields.io endpoint JSON so the README hardware boot badge reflects the
     latest physical verification run.

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -152,7 +152,11 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
   - Added `scripts/pi_smoke_test.py` plus Makefile/just wrappers so operators can run
     verifier checks over SSH, optionally rebooting hosts to confirm convergence and
     emitting JSON summaries for CI pipelines.
-- [ ] Capture support bundles (`kubectl get events`, `helm list`, `systemd-analyze blame`, Compose logs, journal slices) for every pipeline run.
+- [x] Capture support bundles (`kubectl get events`, `helm list`, `systemd-analyze blame`, Compose logs, journal slices) for every pipeline run.
+  - `scripts/collect_support_bundle.py` gathers kubectl/Helm/Compose/journal output plus optional
+    `/boot/first-boot-report` archives. `make collect-support-bundle` and `just support-bundle`
+    expose it locally, and both `pi-image` workflows now upload `support-bundle.tar.gz` artifacts on
+    every run (using remote SSH credentials when secrets are present).
 - [x] Document how to run integration tests locally via `act`.
   - `docs/pi_image_builder_design.md` now includes a quick recipe for dry-running the release workflow with `act`.
 - [x] Publish a conformance badge in the README showing last successful hardware boot.

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -155,6 +155,10 @@ scan straight to this quickstart or the troubleshooting matrix while standing at
 - When symptoms fall outside the happy path, use the
   [Pi Boot & Cluster Troubleshooting Matrix](./pi_boot_troubleshooting.md) to map
   LED patterns, log locations, and fixes.
+- Need to escalate a failure? Generate a tarball snapshot with
+  [`collect_support_bundle.py`](../scripts/collect_support_bundle.py) or
+  `just support-bundle` and review the outputs documented in the
+  [Pi Support Bundle Collector](./pi_support_bundle.md) guide before filing an issue.
 - A new `first-boot.service` waits for `cloud-init` to finish, expands the root
   filesystem when needed, then runs `pi_node_verifier.sh` (with retries) and
   writes Markdown, HTML, and JSON snapshots under `/boot/first-boot-report/`.

--- a/docs/pi_support_bundle.md
+++ b/docs/pi_support_bundle.md
@@ -1,0 +1,64 @@
+# Pi Support Bundle Collector
+
+Use the support bundle helper to capture cluster state, service logs, and first-boot reports
+whenever a pipeline run or operator session needs additional context. The script works against
+both the local host (for CI runners) and remote Raspberry Pis reached over SSH.
+
+## Quick start
+
+Run the helper locally to gather diagnostics from the active shell:
+
+```bash
+python3 scripts/collect_support_bundle.py --output support-bundle.tar.gz
+```
+
+To collect from a remote node, provide SSH connection details. The command below gathers
+Kubernetes events, Helm releases, Compose logs, relevant journal slices, and the most recent
+`pi_node_verifier` output. Passing `--include-first-boot-report` also archives the boot hand-off
+artifacts from `/boot/first-boot-report`.
+
+```bash
+python3 scripts/collect_support_bundle.py \
+  --host pi-a.local \
+  --user pi \
+  --identity ~/.ssh/id_ed25519 \
+  --include-first-boot-report \
+  --output ~/sugarkube/reports/pi-a-support-bundle.tar.gz
+```
+
+Use `just support-bundle` or `make collect-support-bundle` when you prefer task runners:
+
+```bash
+SUPPORT_BUNDLE_ARGS="--host pi-a.local --include-first-boot-report" just support-bundle
+```
+
+## What lands in the bundle?
+
+Each support bundle is a `.tar.gz` containing timestamped command output alongside metadata that
+records exit codes and stderr for every command. The defaults capture:
+
+- `kubectl get events -A --sort-by=.lastTimestamp`
+- `kubectl get pods -A -o wide`
+- `helm list -A`
+- `systemd-analyze blame`
+- `docker compose -f /opt/projects/docker-compose.yml ps`
+- `docker compose -f /opt/projects/docker-compose.yml logs --tail 400`
+- `journalctl -u projects-compose.service --since -6h`
+- `journalctl -u k3s.service --since -6h`
+- `pi_node_verifier` JSON output (if present)
+- Optional `/boot/first-boot-report` archives when `--include-first-boot-report` is provided
+
+Add more snippets with repeated `--extra-command NAME='command'` flags. The helper stores stdout
+and stderr for every snippet even when binaries are missing, helping CI runs surface missing tools
+without failing the entire bundle.
+
+## Pipeline integration
+
+`pi-image-release.yml` now calls the collector as a post-build step and uploads the resulting
+`support-bundle.tar.gz` artifact for **every** release or nightly image build. When CI environment
+variables `SUPPORT_BUNDLE_HOST`, `SUPPORT_BUNDLE_USER`, or `SUPPORT_BUNDLE_KEY` are set, the
+workflow automatically switches to remote collection. Otherwise it defaults to a local sweep so
+maintainers still get build logs, environment metadata, and error placeholders in the artifact.
+
+Store long-running bundles under `~/sugarkube/reports/` when troubleshooting manually so they sit
+alongside flash, clone, and verifier reports.

--- a/justfile
+++ b/justfile
@@ -47,6 +47,11 @@ token_place_sample_args := env_var_or_default(
     "TOKEN_PLACE_SAMPLE_ARGS",
     "--samples-dir " + justfile_directory() + "/samples/token_place",
 )
+support_bundle_cmd := env_var_or_default(
+    "SUPPORT_BUNDLE_CMD",
+    justfile_directory() + "/scripts/collect_support_bundle.py",
+)
+support_bundle_args := env_var_or_default("SUPPORT_BUNDLE_ARGS", "")
 
 _default:
     @just --list
@@ -152,3 +157,8 @@ qr-codes:
 # Usage: just token-place-samples TOKEN_PLACE_SAMPLE_ARGS="--dry-run"
 token-place-samples:
     "{{token_place_sample_cmd}}" {{token_place_sample_args}}
+
+# Collect Kubernetes, Helm, compose, and journal diagnostics into a tarball support bundle
+# Usage: just support-bundle SUPPORT_BUNDLE_ARGS="--host pi-a.local --include-first-boot-report"
+support-bundle:
+    "{{support_bundle_cmd}}" {{support_bundle_args}}

--- a/scripts/collect_support_bundle.py
+++ b/scripts/collect_support_bundle.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Collect observability and troubleshooting data into a tarball support bundle."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import shlex
+import subprocess
+import sys
+import tarfile
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+DEFAULT_REMOTE_USER = "pi"
+DEFAULT_REMOTE_PORT = 22
+DEFAULT_FIRST_BOOT_REPORT = "/boot/first-boot-report"
+DEFAULT_OUTPUT = "support-bundle.tar.gz"
+
+
+class SupportBundleError(RuntimeError):
+    """Raised when the support bundle collection cannot proceed."""
+
+
+@dataclass
+class CommandSpec:
+    name: str
+    command: Sequence[str]
+    description: str
+    sudo: bool = True
+    optional: bool = True
+
+
+DEFAULT_COMMANDS: List[CommandSpec] = [
+    CommandSpec(
+        name="kubectl-events",
+        description="Recent Kubernetes events across namespaces",
+        command=("kubectl", "get", "events", "-A", "--sort-by=.lastTimestamp"),
+    ),
+    CommandSpec(
+        name="kubectl-pods",
+        description="All pods with wide output for debugging scheduling",
+        command=("kubectl", "get", "pods", "-A", "-o", "wide"),
+    ),
+    CommandSpec(
+        name="helm-list",
+        description="Installed Helm releases",
+        command=("helm", "list", "-A"),
+    ),
+    CommandSpec(
+        name="systemd-analyze",
+        description="systemd-analyze blame to highlight slow units",
+        command=("systemd-analyze", "blame"),
+    ),
+    CommandSpec(
+        name="compose-ps",
+        description="Docker compose service status",
+        command=("docker", "compose", "-f", "/opt/projects/docker-compose.yml", "ps"),
+    ),
+    CommandSpec(
+        name="compose-logs",
+        description="Recent docker compose logs for bundled projects",
+        command=(
+            "docker",
+            "compose",
+            "-f",
+            "/opt/projects/docker-compose.yml",
+            "logs",
+            "--tail",
+            "400",
+        ),
+    ),
+    CommandSpec(
+        name="journal-projects-compose",
+        description="projects-compose.service journal excerpt",
+        command=(
+            "journalctl",
+            "-u",
+            "projects-compose.service",
+            "--no-pager",
+            "--since",
+            "-6h",
+        ),
+    ),
+    CommandSpec(
+        name="journal-k3s",
+        description="k3s service journal excerpt",
+        command=("journalctl", "-u", "k3s.service", "--no-pager", "--since", "-6h"),
+    ),
+    CommandSpec(
+        name="pi-node-verifier",
+        description="Latest pi_node_verifier run output",
+        command=(
+            "bash",
+            "-lc",
+            "if [ -x /opt/sugarkube/pi_node_verifier.sh ]; then "
+            "sudo /opt/sugarkube/pi_node_verifier.sh --json --quiet || true; "
+            "elif [ -x /usr/local/sbin/pi_node_verifier.sh ]; then "
+            "sudo /usr/local/sbin/pi_node_verifier.sh --json --quiet || true; "
+            "else echo 'pi_node_verifier.sh not installed'; fi",
+        ),
+        sudo=False,
+    ),
+]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Collect kubectl, helm, docker compose, and journal outputs into a support "
+            "bundle tarball."
+        )
+    )
+    parser.add_argument(
+        "--host",
+        help="Remote host to SSH into. When omitted, run commands locally.",
+    )
+    parser.add_argument(
+        "--user",
+        default=DEFAULT_REMOTE_USER,
+        help=f"SSH user. Defaults to {DEFAULT_REMOTE_USER}.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=DEFAULT_REMOTE_PORT,
+        help=f"SSH port. Defaults to {DEFAULT_REMOTE_PORT}.",
+    )
+    parser.add_argument(
+        "--identity",
+        help="Path to SSH identity file passed to ssh -i.",
+    )
+    parser.add_argument(
+        "--output",
+        default=DEFAULT_OUTPUT,
+        help=f"Destination tar.gz path. Defaults to {DEFAULT_OUTPUT}.",
+    )
+    parser.add_argument(
+        "--first-boot-report",
+        default=DEFAULT_FIRST_BOOT_REPORT,
+        help=(
+            "Path to the first boot report directory to archive. "
+            f"Defaults to {DEFAULT_FIRST_BOOT_REPORT}."
+        ),
+    )
+    parser.add_argument(
+        "--include-first-boot-report",
+        action="store_true",
+        help="Archive the first boot report directory when present.",
+    )
+    parser.add_argument(
+        "--extra-command",
+        action="append",
+        default=[],
+        metavar="NAME=COMMAND",
+        help=(
+            "Additional commands to run. Provide NAME=COMMAND where COMMAND is a shell "
+            "snippet executed via bash -lc. Repeat for multiple commands."
+        ),
+    )
+    parser.add_argument(
+        "--no-sudo",
+        action="store_true",
+        help="Do not prefix default commands with sudo when running locally.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=120,
+        help="Command timeout in seconds for each collected snippet.",
+    )
+    return parser.parse_args(argv)
+
+
+@dataclass
+class CommandResult:
+    name: str
+    description: str
+    command: Sequence[str]
+    returncode: int | None
+    stdout_path: str
+    stderr_path: str
+    error: str | None = None
+
+
+def build_ssh_prefix(args: argparse.Namespace) -> List[str]:
+    if not args.host:
+        return []
+    prefix = [
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-p",
+        str(args.port),
+    ]
+    if args.identity:
+        prefix.extend(["-i", args.identity])
+    prefix.append(f"{args.user}@{args.host}")
+    return prefix
+
+
+def run_command(
+    spec: CommandSpec,
+    args: argparse.Namespace,
+    workdir: Path,
+    ssh_prefix: Sequence[str],
+) -> CommandResult:
+    stdout_path = workdir / f"{spec.name}.stdout.txt"
+    stderr_path = workdir / f"{spec.name}.stderr.txt"
+
+    command: Sequence[str]
+    if args.host:
+        remote_command = list(spec.command)
+        if spec.sudo and not args.no_sudo:
+            remote_command = ["sudo", "-n", *remote_command]
+        quoted = " ".join(shlex.quote(part) for part in remote_command)
+        ssh_command = [*ssh_prefix, f"set -o pipefail; {quoted}"]
+        exec_command = ssh_command
+    else:
+        command = list(spec.command)
+        if spec.sudo and not args.no_sudo:
+            command = ["sudo", "-n", *command]
+        exec_command = command
+
+    try:
+        completed = subprocess.run(
+            exec_command,
+            capture_output=True,
+            text=True,
+            timeout=args.timeout,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        stdout_path.write_text("")
+        stderr_path.write_text(str(exc))
+        return CommandResult(
+            name=spec.name,
+            description=spec.description,
+            command=list(exec_command),
+            returncode=None,
+            stdout_path=str(stdout_path),
+            stderr_path=str(stderr_path),
+            error=f"executable not found: {exc}",
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout_path.write_text(exc.stdout or "")
+        stderr_path.write_text((exc.stderr or "") + "\ncommand timed out")
+        return CommandResult(
+            name=spec.name,
+            description=spec.description,
+            command=list(exec_command),
+            returncode=None,
+            stdout_path=str(stdout_path),
+            stderr_path=str(stderr_path),
+            error="timeout",
+        )
+
+    stdout_path.write_text(completed.stdout)
+    stderr_path.write_text(completed.stderr)
+
+    error: str | None = None
+    if completed.returncode != 0:
+        if spec.optional:
+            error = f"non-zero exit code: {completed.returncode}"
+        else:
+            error = f"command failed with exit code {completed.returncode}"
+
+    return CommandResult(
+        name=spec.name,
+        description=spec.description,
+        command=list(exec_command),
+        returncode=completed.returncode,
+        stdout_path=str(stdout_path),
+        stderr_path=str(stderr_path),
+        error=error,
+    )
+
+
+def parse_extra_commands(definitions: Iterable[str]) -> List[CommandSpec]:
+    specs: List[CommandSpec] = []
+    for entry in definitions:
+        if "=" not in entry:
+            raise SupportBundleError(
+                f"Invalid --extra-command '{entry}'. Expected NAME=COMMAND format."
+            )
+        name, command = entry.split("=", 1)
+        name = name.strip()
+        command = command.strip()
+        if not name or not command:
+            raise SupportBundleError(
+                f"Invalid --extra-command '{entry}'. Name and command must be non-empty."
+            )
+        specs.append(
+            CommandSpec(
+                name=name,
+                description=f"Custom command: {command}",
+                command=("bash", "-lc", command),
+                sudo=False,
+                optional=True,
+            )
+        )
+    return specs
+
+
+def archive_first_boot_report(
+    args: argparse.Namespace,
+    workdir: Path,
+    ssh_prefix: Sequence[str],
+) -> str | None:
+    if not args.include_first_boot_report:
+        return None
+    archive_path = workdir / "first-boot-report.tar.gz"
+    if args.host:
+        remote = shlex.quote(args.first_boot_report)
+        remote_cmd = 'sudo tar -C $(dirname "' + remote + '") -czf - $(basename "' + remote + '")'
+        ssh_command = [*ssh_prefix, remote_cmd]
+        try:
+            with archive_path.open("wb") as fh:
+                completed = subprocess.run(
+                    ssh_command,
+                    check=False,
+                    stdout=fh,
+                    stderr=subprocess.PIPE,
+                )
+        except FileNotFoundError as exc:
+            archive_path.write_text(str(exc))
+            return str(archive_path)
+        if completed.returncode != 0:
+            archive_path.write_bytes(completed.stderr)
+            return str(archive_path)
+    else:
+        target = Path(args.first_boot_report)
+        if not target.exists():
+            archive_path.write_text(
+                f"first boot report directory '{target}' not found on local host"
+            )
+            return str(archive_path)
+        with tarfile.open(archive_path, "w:gz") as bundle:
+            bundle.add(target, arcname=target.name)
+    return str(archive_path)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    ssh_prefix = build_ssh_prefix(args)
+
+    command_specs = list(DEFAULT_COMMANDS)
+    command_specs.extend(parse_extra_commands(args.extra_command))
+
+    timestamp = dt.datetime.now(dt.timezone.utc).isoformat()
+
+    with tempfile.TemporaryDirectory(prefix="sugarkube-support-") as tmp:
+        workdir = Path(tmp)
+        metadata: dict[str, object] = {
+            "generated_at": timestamp,
+            "host": args.host or "local",
+            "commands": [],
+        }
+
+        for spec in command_specs:
+            result = run_command(spec, args, workdir, ssh_prefix)
+            metadata["commands"].append(asdict(result))
+
+        fb_archive = archive_first_boot_report(args, workdir, ssh_prefix)
+        if fb_archive:
+            metadata["first_boot_report"] = fb_archive
+
+        metadata_path = workdir / "metadata.json"
+        metadata_path.write_text(json.dumps(metadata, indent=2, sort_keys=True))
+
+        output_path = Path(args.output).resolve()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(output_path, "w:gz") as bundle:
+            for item in workdir.iterdir():
+                bundle.add(item, arcname=item.name)
+
+    print(f"Support bundle written to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
🚀 : –
what: add support bundle collector script, docs, and workflow steps
why: publish troubleshooting bundles on every pi-image pipeline run
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68d0d6a41b4c832f90b652172e5e1ff6