### PR TITLE
Add support bundle automation to pi-image release workflow

### DIFF
--- a/.github/workflows/pi-image-release.yml
+++ b/.github/workflows/pi-image-release.yml
@@ -162,6 +162,36 @@ jobs:
             sugarkube.build.log
             RELEASE_NOTES.md
 
+      - name: Collect support bundle
+        if: always()
+        env:
+          SUPPORT_BUNDLE_HOST: ${{ secrets.SUPPORT_BUNDLE_HOST }}
+          SUPPORT_BUNDLE_USER: ${{ secrets.SUPPORT_BUNDLE_USER }}
+          SUPPORT_BUNDLE_SSH_KEY: ${{ secrets.SUPPORT_BUNDLE_SSH_KEY }}
+        run: |
+          if [ -z "${SUPPORT_BUNDLE_HOST}" ] || [ -z "${SUPPORT_BUNDLE_SSH_KEY}" ]; then
+            echo "Support bundle host not configured; skipping"
+            exit 0
+          fi
+          mkdir -p ~/.ssh
+          key_path=~/.ssh/support-bundle
+          printf '%s\n' "${SUPPORT_BUNDLE_SSH_KEY}" >"${key_path}"
+          chmod 600 "${key_path}"
+          user="${SUPPORT_BUNDLE_USER:-pi}"
+          python3 scripts/collect_support_bundle.py \
+            --identity "${key_path}" \
+            --user "${user}" \
+            --output-dir support-bundles \
+            "${SUPPORT_BUNDLE_HOST}"
+
+      - name: Upload support bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sugarkube-support-bundle
+          path: support-bundles
+          if-no-files-found: ignore
+
       - name: Publish GitHub release
         uses: ncipollo/release-action@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,14 @@ REHEARSAL_CMD ?= $(CURDIR)/scripts/pi_multi_node_join_rehearsal.py
 REHEARSAL_ARGS ?=
 TOKEN_PLACE_SAMPLE_CMD ?= $(CURDIR)/scripts/token_place_replay_samples.py
 TOKEN_PLACE_SAMPLE_ARGS ?= --samples-dir $(CURDIR)/samples/token_place
+SUPPORT_BUNDLE_CMD ?= $(CURDIR)/scripts/collect_support_bundle.py
+SUPPORT_BUNDLE_ARGS ?=
+SUPPORT_BUNDLE_HOST ?=
 
 .PHONY: install-pi-image download-pi-image flash-pi flash-pi-report doctor rollback-to-sd \
         clone-ssd docs-verify qr-codes monitor-ssd-health smoke-test-pi \
         publish-telemetry notify-teams update-hardware-badge rehearse-join \
-        token-place-samples
+        token-place-samples support-bundle
 
 install-pi-image:
 	$(INSTALL_CMD) --dir '$(IMAGE_DIR)' --image '$(IMAGE_PATH)' $(DOWNLOAD_ARGS)
@@ -98,3 +101,10 @@ rehearse-join:
 
 token-place-samples:
 	$(TOKEN_PLACE_SAMPLE_CMD) $(TOKEN_PLACE_SAMPLE_ARGS)
+
+support-bundle:
+	@if [ -z "$(SUPPORT_BUNDLE_HOST)" ]; then \
+		echo "Set SUPPORT_BUNDLE_HOST to the target host (e.g. pi.local) before running support-bundle." >&2; \
+		exit 1; \
+	fi
+	$(SUPPORT_BUNDLE_CMD) "$(SUPPORT_BUNDLE_HOST)" $(SUPPORT_BUNDLE_ARGS)

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ Review the safety notes before working with power components.
 - [pi_smoke_test.md](pi_smoke_test.md) — run remote smoke tests against freshly provisioned Pis
 - [pi_image_contributor_guide.md](pi_image_contributor_guide.md) — map automation helpers to the docs
   they inform
+- [pi_support_bundles.md](pi_support_bundles.md) — collect diagnostics into shareable archives
 - [pi_image_telemetry.md](pi_image_telemetry.md) — opt-in anonymized telemetry for fleet dashboards
 - [pi_image_team_notifications.md](pi_image_team_notifications.md) — optional Slack/Matrix progress
   notifications for first boot and SSD cloning

--- a/docs/pi_image_contributor_guide.md
+++ b/docs/pi_image_contributor_guide.md
@@ -112,6 +112,14 @@ sync.
     [Pi Image Smoke Test Harness](./pi_smoke_test.md).
   - Related tooling: wrapped by `make smoke-test-pi` and `just smoke-test-pi` so operators can pass
     flags through `SMOKE_ARGS` without remembering the Python entry point.
+- `scripts/collect_support_bundle.py`
+  - Purpose: collect Kubernetes, systemd, and Docker Compose diagnostics into a reusable
+    support bundle for CI artifacts or manual triage.
+  - Primary docs: [Pi Support Bundles](./pi_support_bundles.md),
+    [Pi Image Quickstart](./pi_image_quickstart.md).
+  - Related tooling: invoked via `make support-bundle` / `just support-bundle`, supports
+    `SUPPORT_BUNDLE_ARGS` overrides, and publishes artifacts from `pi-image-release.yml` when
+    bundle secrets are configured.
 - `scripts/update_hardware_boot_badge.py`
   - Purpose: generate shields.io endpoint JSON so the README hardware boot badge reflects the
     latest physical verification run.

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -152,7 +152,9 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
   - Added `scripts/pi_smoke_test.py` plus Makefile/just wrappers so operators can run
     verifier checks over SSH, optionally rebooting hosts to confirm convergence and
     emitting JSON summaries for CI pipelines.
-- [ ] Capture support bundles (`kubectl get events`, `helm list`, `systemd-analyze blame`, Compose logs, journal slices) for every pipeline run.
+- [x] Capture support bundles (`kubectl get events`, `helm list`, `systemd-analyze blame`, Compose logs, journal slices) for every pipeline run.
+  - Added `scripts/collect_support_bundle.py` plus `make`/`just support-bundle` wrappers and wired
+    the release workflow to archive bundles (documented in [Pi Support Bundles](./pi_support_bundles.md)).
 - [x] Document how to run integration tests locally via `act`.
   - `docs/pi_image_builder_design.md` now includes a quick recipe for dry-running the release workflow with `act`.
 - [x] Publish a conformance badge in the README showing last successful hardware boot.

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -155,6 +155,14 @@ scan straight to this quickstart or the troubleshooting matrix while standing at
 - When symptoms fall outside the happy path, use the
   [Pi Boot & Cluster Troubleshooting Matrix](./pi_boot_troubleshooting.md) to map
   LED patterns, log locations, and fixes.
+- Need deeper diagnostics? Capture a support bundle over SSH:
+  ```bash
+  SUPPORT_BUNDLE_HOST=pi-a.local \
+  SUPPORT_BUNDLE_ARGS="--identity ~/.ssh/id_ed25519" \
+    make support-bundle
+  ```
+  Swap in `just support-bundle` when you prefer Just. The helper saves transcripts under
+  `support-bundles/` alongside `summary.json` so you can attach the archive to issues or CI logs.
 - A new `first-boot.service` waits for `cloud-init` to finish, expands the root
   filesystem when needed, then runs `pi_node_verifier.sh` (with retries) and
   writes Markdown, HTML, and JSON snapshots under `/boot/first-boot-report/`.

--- a/docs/pi_support_bundles.md
+++ b/docs/pi_support_bundles.md
@@ -1,0 +1,67 @@
+# Pi Support Bundles
+
+Gather a point-in-time snapshot of a running Sugarkube Pi when debugging first boot,
+projects-compose, or cluster regressions. The `collect_support_bundle.py` helper connects over
+SSH, executes a curated set of Kubernetes, systemd, and Docker Compose commands, and writes
+everything to a compressed archive so the artifacts can be attached to GitHub issues or stored
+alongside CI runs.
+
+The bundle captures the commands highlighted in the Pi Image UX & Automation checklist:
+
+- `kubectl get events --all-namespaces --sort-by=.lastTimestamp -o wide`
+- `helm list -A`
+- `systemd-analyze blame` and `systemd-analyze critical-chain`
+- `docker compose logs` and `docker compose ps` for `/opt/projects/docker-compose.yml`
+- Journals for `projects-compose.service`, `first-boot.service`, `k3s.service`,
+  `sugarkube-self-heal@*`, and the current boot (`journalctl -b`)
+
+Each command writes a Markdown preamble (description, command, exit code) before the captured
+output. Failures are noted inline, and `summary.json` records the status of every probe so CI or
+humans can detect missing data quickly.
+
+## Collect bundles locally
+
+Run the helper directly when you have SSH access to a Pi:
+
+```bash
+./scripts/collect_support_bundle.py pi-a.local \
+  --identity ~/.ssh/id_ed25519 \
+  --output-dir ~/sugarkube/support-bundles
+```
+
+The script stores results under `support-bundles/<host>-<timestamp>/` and also emits a matching
+`.tar.gz`. Override `--no-archive` to keep only the raw directory, and `--spec` to append extra
+commands (`output/path.txt:command:description`).
+
+Make and Just wrappers mirror the CLI:
+
+```bash
+SUPPORT_BUNDLE_HOST=pi-a.local \
+SUPPORT_BUNDLE_ARGS="--identity ~/.ssh/id_ed25519" \
+  make support-bundle
+
+# or
+SUPPORT_BUNDLE_HOST=pi-a.local \
+SUPPORT_BUNDLE_ARGS="--identity ~/.ssh/id_ed25519" \
+  just support-bundle
+```
+
+Set `SUPPORT_BUNDLE_CMD` if you need to point the wrappers at a forked script or containerized entry
+point.
+
+## CI integration
+
+The `pi-image-release.yml` workflow now uploads a support bundle after every build when the
+following secrets are configured:
+
+- `SUPPORT_BUNDLE_HOST` — hostname or IP address of the validation Pi.
+- `SUPPORT_BUNDLE_USER` — SSH username (defaults to `pi` when unset).
+- `SUPPORT_BUNDLE_SSH_KEY` — private key contents with access to the host.
+
+During the job the workflow writes the key to `~/.ssh/support-bundle`, runs
+`collect_support_bundle.py`, and publishes the resulting archive as an artifact named
+`sugarkube-support-bundle`. Missing secrets simply skip the step, preventing release failures on
+self-hosted forks while still enabling full telemetry on the canonical pipeline.
+
+Every bundle ships with the JSON summary, raw command transcripts, and the compressed archive so
+operators can share just the relevant pieces when reporting regressions.

--- a/justfile
+++ b/justfile
@@ -24,6 +24,12 @@ health_cmd := env_var_or_default("HEALTH_CMD", justfile_directory() + "/scripts/
 health_args := env_var_or_default("HEALTH_ARGS", "")
 smoke_cmd := env_var_or_default("SMOKE_CMD", justfile_directory() + "/scripts/pi_smoke_test.py")
 smoke_args := env_var_or_default("SMOKE_ARGS", "")
+support_bundle_cmd := env_var_or_default(
+    "SUPPORT_BUNDLE_CMD",
+    justfile_directory() + "/scripts/collect_support_bundle.py",
+)
+support_bundle_args := env_var_or_default("SUPPORT_BUNDLE_ARGS", "")
+support_bundle_host := env_var_or_default("SUPPORT_BUNDLE_HOST", "")
 telemetry_cmd := env_var_or_default(
     "TELEMETRY_CMD",
     justfile_directory() + "/scripts/publish_telemetry.py",
@@ -161,3 +167,12 @@ qr-codes:
 # Usage: just token-place-samples TOKEN_PLACE_SAMPLE_ARGS="--dry-run"
 token-place-samples:
     "{{token_place_sample_cmd}}" {{token_place_sample_args}}
+
+# Collect Kubernetes, systemd, and compose diagnostics from a running Pi
+# Usage: just support-bundle SUPPORT_BUNDLE_HOST=pi.local
+support-bundle:
+    if [ -z "{{support_bundle_host}}" ]; then
+        echo "Set SUPPORT_BUNDLE_HOST to the target host before running support-bundle." >&2
+        exit 1
+    fi
+    "{{support_bundle_cmd}}" "{{support_bundle_host}}" {{support_bundle_args}}

--- a/scripts/collect_support_bundle.py
+++ b/scripts/collect_support_bundle.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Collect Kubernetes, systemd, and compose diagnostics from a Sugarkube Pi."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+import tarfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+DEFAULT_COMMAND_TIMEOUT = 120
+DEFAULT_CONNECT_TIMEOUT = 10
+DEFAULT_OUTPUT_DIR = "support-bundles"
+DEFAULT_USER = "pi"
+KUBECONFIG_PATH = "/etc/rancher/k3s/k3s.yaml"
+COMPOSE_FILE = "/opt/projects/docker-compose.yml"
+COMPOSE_PROJECT_DIR = "/opt/projects"
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    """Description of a remote command to capture."""
+
+    output_path: Path
+    remote_command: str
+    description: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "output_path": self.output_path.as_posix(),
+            "remote_command": self.remote_command,
+            "description": self.description,
+        }
+
+
+def default_specs() -> List[CommandSpec]:
+    """Return the default commands captured in every bundle."""
+
+    kube_env = "sudo env KUBECONFIG=" + shlex.quote(KUBECONFIG_PATH) + " "
+    docker_base = (
+        "sudo docker compose --project-directory "
+        + shlex.quote(COMPOSE_PROJECT_DIR)
+        + " -f "
+        + shlex.quote(COMPOSE_FILE)
+    )
+
+    return [
+        CommandSpec(
+            Path("kubernetes/events.txt"),
+            f"{kube_env} kubectl get events --all-namespaces --sort-by=.lastTimestamp -o wide",
+            "Chronological Kubernetes events to pinpoint regressions.",
+        ),
+        CommandSpec(
+            Path("kubernetes/pods.txt"),
+            f"{kube_env} kubectl get pods --all-namespaces -o wide",
+            "Running workloads across namespaces.",
+        ),
+        CommandSpec(
+            Path("kubernetes/nodes.txt"),
+            f"{kube_env} kubectl describe nodes",
+            "Node inventory with taints, addresses, and resource pressure.",
+        ),
+        CommandSpec(
+            Path("helm/releases.txt"),
+            f"{kube_env} helm list -A",
+            "Helm release summary for the cluster.",
+        ),
+        CommandSpec(
+            Path("systemd/systemd-analyze-blame.txt"),
+            "sudo systemd-analyze blame",
+            "Boot timing to surface slow units.",
+        ),
+        CommandSpec(
+            Path("systemd/systemd-critical-chain.txt"),
+            "sudo systemd-analyze critical-chain",
+            "Critical boot path for stalled services.",
+        ),
+        CommandSpec(
+            Path("systemd/failed-units.txt"),
+            "sudo systemctl list-units --failed",
+            "Failed systemd units after boot.",
+        ),
+        CommandSpec(
+            Path("compose/projects-compose.log"),
+            ("sudo journalctl --no-pager --output=short-precise " "-u projects-compose.service"),
+            "projects-compose service journal.",
+        ),
+        CommandSpec(
+            Path("compose/projects-compose-status.txt"),
+            "sudo systemctl status projects-compose.service",
+            "Systemd status for the compose stack.",
+        ),
+        CommandSpec(
+            Path("compose/docker-compose-logs.txt"),
+            f"{docker_base} logs --tail=400 --timestamps",
+            "Docker Compose logs for token.place, dspace, and observability exporters.",
+        ),
+        CommandSpec(
+            Path("compose/docker-compose-ps.txt"),
+            f"{docker_base} ps",
+            "Current container status reported by docker compose.",
+        ),
+        CommandSpec(
+            Path("journals/journalctl-boot.txt"),
+            "sudo journalctl -b --no-pager --output=short-precise",
+            "Complete journal for the current boot.",
+        ),
+        CommandSpec(
+            Path("journals/self-heal.log"),
+            "sudo journalctl --no-pager --output=short-precise -u 'sugarkube-self-heal@*'",
+            "Self-heal escalation attempts and captured failures.",
+        ),
+        CommandSpec(
+            Path("journals/first-boot.log"),
+            "sudo journalctl --no-pager --output=short-precise -u first-boot.service",
+            "first-boot.service retries and verifier output.",
+        ),
+        CommandSpec(
+            Path("journals/k3s.log"),
+            "sudo journalctl --no-pager --output=short-precise -u k3s.service",
+            "k3s control-plane journal entries.",
+        ),
+        CommandSpec(
+            Path("storage/df.txt"),
+            "df -h",
+            "Filesystem usage snapshot.",
+        ),
+        CommandSpec(
+            Path("storage/mounts.txt"),
+            "mount",
+            "Mounted filesystems and options.",
+        ),
+        CommandSpec(
+            Path("reports/first-boot-report-tree.txt"),
+            "ls -R /boot/first-boot-report",
+            "List of generated first-boot reports for quick inspection.",
+        ),
+    ]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=("SSH into a Sugarkube Pi and collect diagnostics into a support bundle.")
+    )
+    parser.add_argument("host", help="Hostname or IP address of the Pi to inspect.")
+    parser.add_argument(
+        "--user",
+        default=DEFAULT_USER,
+        help=f"SSH username. Defaults to '{DEFAULT_USER}'.",
+    )
+    parser.add_argument(
+        "--identity",
+        help="Path to an SSH private key passed to ssh -i.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=22,
+        help="SSH port. Defaults to 22.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=DEFAULT_OUTPUT_DIR,
+        help="Directory where support bundles are stored. Defaults to support-bundles.",
+    )
+    parser.add_argument(
+        "--command-timeout",
+        type=int,
+        default=DEFAULT_COMMAND_TIMEOUT,
+        metavar="SECONDS",
+        help=(
+            "Timeout for each remote command (seconds). " f"Defaults to {DEFAULT_COMMAND_TIMEOUT}."
+        ),
+    )
+    parser.add_argument(
+        "--connect-timeout",
+        type=int,
+        default=DEFAULT_CONNECT_TIMEOUT,
+        metavar="SECONDS",
+        help=(
+            "Timeout for establishing the SSH connection (seconds). "
+            f"Defaults to {DEFAULT_CONNECT_TIMEOUT}."
+        ),
+    )
+    parser.add_argument(
+        "--ssh-option",
+        action="append",
+        default=[],
+        metavar="OPTION",
+        help="Extra -o options passed directly to ssh (repeatable).",
+    )
+    parser.add_argument(
+        "--no-archive",
+        action="store_true",
+        help="Skip creating a compressed tarball (leave raw files on disk).",
+    )
+    parser.add_argument(
+        "--spec",
+        action="append",
+        default=[],
+        metavar="PATH:COMMAND:DESCRIPTION",
+        help=("Extra command to capture (repeatable). Format: output/path.txt:command:description"),
+    )
+    return parser.parse_args(argv)
+
+
+def parse_extra_specs(entries: Iterable[str]) -> List[CommandSpec]:
+    specs: List[CommandSpec] = []
+    for entry in entries:
+        parts = entry.split(":", 2)
+        if len(parts) != 3:
+            raise ValueError("Invalid --spec entry. Expected output_path:command:description")
+        output_str, command, description = parts
+        output_path = Path(output_str)
+        if output_path.is_absolute():
+            raise ValueError("Support bundle paths must be relative")
+        specs.append(CommandSpec(output_path, command, description))
+    return specs
+
+
+def build_bundle_dir(base: Path, host: str, timestamp: datetime) -> Path:
+    safe_host = host.replace("/", "_").replace(":", "_")
+    name = f"{safe_host}-{timestamp.strftime('%Y%m%dT%H%M%SZ')}"
+    bundle_dir = base / name
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    return bundle_dir
+
+
+def build_ssh_command(args: argparse.Namespace, remote_command: str) -> List[str]:
+    destination = f"{args.user}@{args.host}" if args.user else args.host
+    cmd: List[str] = [
+        "ssh",
+        "-o",
+        f"ConnectTimeout={args.connect_timeout}",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=no",
+    ]
+    if args.identity:
+        cmd.extend(["-i", args.identity])
+    if args.port and args.port != 22:
+        cmd.extend(["-p", str(args.port)])
+    for option in args.ssh_option:
+        cmd.extend(["-o", option])
+    cmd.append(destination)
+    cmd.extend(["bash", "-lc", f"set -o pipefail; {remote_command}"])
+    return cmd
+
+
+def write_command_output(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def execute_specs(
+    args: argparse.Namespace,
+    specs: Sequence[CommandSpec],
+    bundle_dir: Path,
+) -> list[dict[str, object]]:
+    results: list[dict[str, object]] = []
+    for spec in specs:
+        output_path = bundle_dir / spec.output_path
+        ssh_cmd = build_ssh_command(args, spec.remote_command)
+        try:
+            completed = subprocess.run(
+                ssh_cmd,
+                check=False,
+                text=True,
+                capture_output=True,
+                timeout=args.command_timeout,
+            )
+            stdout = completed.stdout
+            stderr = completed.stderr
+            status = "success" if completed.returncode == 0 else "failed"
+            payload_lines = [
+                f"# {spec.description}\n",
+                f"# Command: {spec.remote_command}\n",
+                f"# Exit status: {completed.returncode}\n",
+                "\n",
+                stdout or "(no output)\n",
+            ]
+            if stderr:
+                payload_lines.extend(
+                    [
+                        "\n# stderr\n\n",
+                        stderr,
+                    ]
+                )
+            write_command_output(output_path, "".join(payload_lines))
+            results.append(
+                {
+                    "command": spec.to_dict(),
+                    "exit_code": completed.returncode,
+                    "status": status,
+                }
+            )
+        except subprocess.TimeoutExpired:
+            write_command_output(
+                output_path,
+                (
+                    f"# {spec.description}\n# Command: {spec.remote_command}\n"
+                    f"# Timed out after {args.command_timeout} seconds\n"
+                ),
+            )
+            results.append(
+                {
+                    "command": spec.to_dict(),
+                    "exit_code": None,
+                    "status": "timeout",
+                }
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            write_command_output(
+                output_path,
+                (f"# {spec.description}\n# Command: {spec.remote_command}\n" f"# Error: {exc}\n"),
+            )
+            results.append(
+                {
+                    "command": spec.to_dict(),
+                    "exit_code": None,
+                    "status": "error",
+                    "error": str(exc),
+                }
+            )
+    return results
+
+
+def archive_bundle(bundle_dir: Path) -> Path:
+    tar_path = bundle_dir.with_suffix(".tar.gz")
+    with tarfile.open(tar_path, "w:gz") as tar:
+        tar.add(bundle_dir, arcname=bundle_dir.name)
+    return tar_path
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        extra_specs = parse_extra_specs(args.spec)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    specs = default_specs() + extra_specs
+
+    output_root = Path(args.output_dir)
+    timestamp = datetime.now(timezone.utc)
+    bundle_dir = build_bundle_dir(output_root, args.host, timestamp)
+
+    results = execute_specs(args, specs, bundle_dir)
+
+    summary = {
+        "host": args.host,
+        "user": args.user,
+        "timestamp": timestamp.isoformat(),
+        "bundle": bundle_dir.name,
+        "results": results,
+    }
+    write_command_output(bundle_dir / "summary.json", json.dumps(summary, indent=2))
+
+    any_success = any(item["status"] == "success" for item in results)
+    if not args.no_archive:
+        tar_path = archive_bundle(bundle_dir)
+    else:
+        tar_path = None
+
+    if tar_path:
+        print(f"Support bundle saved to {tar_path}")
+    else:
+        print(f"Support bundle saved to {bundle_dir}")
+
+    if not any_success:
+        print("warning: no commands succeeded", file=sys.stderr)
+        return 1
+
+    failed = [item for item in results if item["status"] != "success"]
+    if failed:
+        print(
+            f"warning: {len(failed)} command(s) failed; see summary.json for details",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    sys.exit(main())

--- a/tests/test_collect_support_bundle.py
+++ b/tests/test_collect_support_bundle.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from scripts import collect_support_bundle
+
+
+def test_default_specs_cover_required_commands() -> None:
+    specs = {
+        spec.output_path.as_posix(): spec.remote_command
+        for spec in collect_support_bundle.default_specs()
+    }
+    required = {
+        "kubernetes/events.txt": "kubectl get events",
+        "helm/releases.txt": "helm list -A",
+        "systemd/systemd-analyze-blame.txt": "systemd-analyze blame",
+        "compose/docker-compose-logs.txt": "docker compose",
+        "journals/journalctl-boot.txt": "journalctl -b",
+    }
+    for path, snippet in required.items():
+        assert path in specs, f"expected {path} in default specs"
+        assert snippet in specs[path]
+
+
+@pytest.mark.parametrize(
+    "entry, expected_path",
+    [
+        ("extra/foo.txt:echo hi:Extra command", Path("extra/foo.txt")),
+    ],
+)
+def test_parse_extra_specs(entry: str, expected_path: Path) -> None:
+    spec = collect_support_bundle.parse_extra_specs([entry])[0]
+    assert spec.output_path == expected_path
+    assert spec.remote_command == "echo hi"
+    assert spec.description == "Extra command"
+
+
+def test_build_bundle_dir_sanitises_host(tmp_path: Path) -> None:
+    ts = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    bundle = collect_support_bundle.build_bundle_dir(tmp_path, "pi.local:2222", ts)
+    assert bundle.exists()
+    assert bundle.name.startswith("pi.local_2222-20240102T030405Z")
+
+
+def test_parse_extra_specs_invalid_format() -> None:
+    with pytest.raises(ValueError, match="Invalid --spec entry"):
+        collect_support_bundle.parse_extra_specs(["missing:description"])
+
+
+def test_parse_extra_specs_rejects_absolute_path() -> None:
+    with pytest.raises(ValueError, match="relative"):
+        collect_support_bundle.parse_extra_specs(["/abs/path:echo hi:desc"])
+
+
+def test_parse_args_supports_all_flags(tmp_path: Path) -> None:
+    args = collect_support_bundle.parse_args(
+        [
+            "--user",
+            "admin",
+            "--identity",
+            str(tmp_path / "id_ed25519"),
+            "--port",
+            "2222",
+            "--output-dir",
+            str(tmp_path / "bundles"),
+            "--command-timeout",
+            "45",
+            "--connect-timeout",
+            "8",
+            "--ssh-option",
+            "StrictHostKeyChecking=yes",
+            "--ssh-option",
+            "LogLevel=DEBUG",
+            "--no-archive",
+            "--spec",
+            "extra/out.txt:echo hi:Extra",
+            "pi.local",
+        ]
+    )
+    assert args.user == "admin"
+    assert args.identity.endswith("id_ed25519")
+    assert args.port == 2222
+    assert args.output_dir.endswith("bundles")
+    assert args.command_timeout == 45
+    assert args.connect_timeout == 8
+    assert args.ssh_option == ["StrictHostKeyChecking=yes", "LogLevel=DEBUG"]
+    assert args.no_archive is True
+    assert args.spec == ["extra/out.txt:echo hi:Extra"]
+    assert args.host == "pi.local"
+
+
+def test_build_ssh_command_includes_customisations(tmp_path: Path) -> None:
+    args = argparse.Namespace(
+        user="admin",
+        host="pi.local",
+        connect_timeout=7,
+        identity=str(tmp_path / "id"),
+        port=2022,
+        ssh_option=["StrictHostKeyChecking=yes", "LogLevel=DEBUG"],
+    )
+    cmd = collect_support_bundle.build_ssh_command(args, "echo hi")
+    assert cmd[:6] == [
+        "ssh",
+        "-o",
+        "ConnectTimeout=7",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+    ]
+    assert "-i" in cmd and args.identity in cmd
+    assert "-p" in cmd and "2022" in cmd
+    assert cmd.count("-o") >= 5  # base options + custom ones
+    assert cmd[-3:] == ["bash", "-lc", "set -o pipefail; echo hi"]
+
+
+def test_write_command_output_creates_parents(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "out.txt"
+    collect_support_bundle.write_command_output(target, "payload")
+    assert target.read_text(encoding="utf-8") == "payload"
+
+
+def test_execute_specs_handles_success_failure_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    args = argparse.Namespace(
+        user="pi",
+        host="pi.local",
+        command_timeout=5,
+        identity=None,
+        port=22,
+        ssh_option=[],
+        connect_timeout=3,
+    )
+    specs = [
+        collect_support_bundle.CommandSpec(Path("ok.txt"), "echo ok", "Success"),
+        collect_support_bundle.CommandSpec(Path("fail.txt"), "echo fail", "Failure"),
+        collect_support_bundle.CommandSpec(Path("slow.txt"), "echo slow", "Slow"),
+    ]
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+
+    outcomes = iter(
+        [
+            dict(returncode=0, stdout="ok output\n", stderr=""),
+            dict(returncode=5, stdout="", stderr="boom\n"),
+            "timeout",
+        ]
+    )
+
+    class DummyCompleted:
+        def __init__(self, returncode: int, stdout: str, stderr: str) -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def fake_run(cmd: list[str], **kwargs: object) -> DummyCompleted:
+        outcome = next(outcomes)
+        if outcome == "timeout":
+            raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout"))
+        assert kwargs["text"] is True
+        assert kwargs["capture_output"] is True
+        return DummyCompleted(**outcome)
+
+    monkeypatch.setattr(collect_support_bundle.subprocess, "run", fake_run)
+
+    results = collect_support_bundle.execute_specs(args, specs, bundle_dir)
+
+    statuses = [item["status"] for item in results]
+    assert statuses == ["success", "failed", "timeout"]
+
+    ok_content = (bundle_dir / "ok.txt").read_text(encoding="utf-8")
+    assert "Success" in ok_content and "ok output" in ok_content
+
+    fail_content = (bundle_dir / "fail.txt").read_text(encoding="utf-8")
+    assert "Failure" in fail_content
+    assert "(no output)" in fail_content
+    assert "boom" in fail_content
+
+    timeout_content = (bundle_dir / "slow.txt").read_text(encoding="utf-8")
+    assert "Timed out after 5 seconds" in timeout_content
+
+
+def test_main_handles_bad_spec(capsys: pytest.CaptureFixture[str]) -> None:
+    code = collect_support_bundle.main(["--spec", "bad", "pi.local"])
+    captured = capsys.readouterr()
+    assert code == 2
+    assert "error:" in captured.err
+
+
+def test_main_success_creates_tar(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    summary_dir = tmp_path / "bundles"
+
+    monkeypatch.setattr(collect_support_bundle, "default_specs", lambda: [])
+
+    def fake_execute(args: argparse.Namespace, specs, bundle_dir: Path):
+        collect_support_bundle.write_command_output(bundle_dir / "extra.txt", "data")
+        return [
+            {"command": {}, "status": "success", "exit_code": 0},
+            {"command": {}, "status": "failed", "exit_code": 1},
+        ]
+
+    monkeypatch.setattr(collect_support_bundle, "execute_specs", fake_execute)
+
+    code = collect_support_bundle.main(["--output-dir", str(summary_dir), "pi.local"])
+    captured = capsys.readouterr()
+
+    assert code == 0
+    assert "Support bundle saved to" in captured.out
+    assert "failed;" in captured.err
+
+    bundles = list(summary_dir.iterdir())
+    assert len(bundles) == 2  # directory + archive
+    directory = [p for p in bundles if p.is_dir()][0]
+    tarball = [p for p in bundles if p.suffixes == [".tar", ".gz"]][0]
+
+    summary = json.loads((directory / "summary.json").read_text(encoding="utf-8"))
+    assert summary["results"][0]["status"] == "success"
+    assert tarball.exists()
+
+
+def test_main_returns_failure_when_no_command_success(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(collect_support_bundle, "default_specs", lambda: [])
+    monkeypatch.setattr(collect_support_bundle, "execute_specs", lambda *a, **k: [])
+
+    code = collect_support_bundle.main(["--output-dir", str(tmp_path), "--no-archive", "pi.local"])
+    captured = capsys.readouterr()
+
+    assert code == 1
+    assert "warning: no commands succeeded" in captured.err
+    bundle_dirs = [p for p in tmp_path.iterdir() if p.is_dir()]
+    assert len(bundle_dirs) == 1


### PR DESCRIPTION
## Summary
- add a collect_support_bundle.py CLI plus Make/Just wrappers and docs for Pi support bundles
- collect support bundles during the pi-image-release workflow and upload them as artifacts
- cover the new helper with unit tests and document the checklist completion
- fix the Makefile support-bundle target indentation and extend collect_support_bundle tests for full coverage

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1bcfebdc8832f9ddf1f82e4b2d9b0