### PR TITLE
docs: enforce 100% patch coverage in prompts

### DIFF
--- a/docs/prompt-pi-image-improvement-checklist.md
+++ b/docs/prompt-pi-image-improvement-checklist.md
@@ -27,6 +27,10 @@ CONTEXT:
   - `pyspelling -c .spellcheck.yaml`
   - `linkchecker --no-warnings README.md docs/`
   - `git diff --cached | ./scripts/scan-secrets.py`
+- Ensure the refined prompt explicitly instructs contributors to attain **100% patch coverage on the
+  first test run** without retries.
+- Design changes and supporting tests to achieve **100% patch coverage on the first test run** with
+  no retries.
 
 REQUEST:
 1. Choose one unchecked checklist task and implement it end-to-end (code, docs, tooling as
@@ -34,7 +38,7 @@ REQUEST:
 2. Update any affected documentation, samples, or automation scripts to match the new behavior.
 3. Tick the corresponding checkbox in `docs/pi_image_improvement_checklist.md` and summarize the
    change in relevant docs.
-4. Run the commands above and ensure they succeed.
+4. Run the commands above and ensure they succeed with 100% patch coverage on the first attempt.
 5. Commit with a concise message and prepare a PR summary highlighting the checklist item you
    completed.
 
@@ -71,7 +75,8 @@ CONTEXT:
 USER:
 1. Identify confusing, outdated, or missing guidance in the implementation prompt above.
 2. Update the prompt so agents consistently implement unchecked checklist items end-to-end.
-3. Run the commands listed under CONTEXT and confirm they succeed.
+3. Emphasize the need for 100% patch coverage on the first test execution.
+4. Run the commands listed under CONTEXT and confirm they succeed.
 
 OUTPUT:
 A pull request with an improved checklist implementation prompt and passing checks.

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -32,6 +32,7 @@ CONTEXT:
 - Inspect [`.github/workflows/`](../.github/workflows/) to see which checks run in CI.
 - Run `pre-commit run --all-files` from the repository root to lint, format, and test via
   [`scripts/checks.sh`](../scripts/checks.sh).
+- Ensure code, scripts, and tests yield **100% patch coverage on the first test run**—no retries.
 - If `package.json` defines them, run:
   - `npm ci`
   - `npm run lint`
@@ -58,8 +59,9 @@ REQUEST:
    STANDOFF_MODE=nut ./scripts/openscad_render.sh path/to/model.scad
    ~~~
 
-4. Run `pre-commit run --all-files`; for docs changes also run
-   `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/`.
+4. Run `pre-commit run --all-files` and confirm the resulting diff reports 100% patch coverage on
+   the first attempt; for docs changes also run `pyspelling -c .spellcheck.yaml` and
+   `linkchecker --no-warnings README.md docs/`.
 5. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`
    before committing updated SCAD sources and any documentation.
 
@@ -92,11 +94,14 @@ Then run:
 - `linkchecker --no-warnings README.md docs/` (installed by
   [`scripts/checks.sh`](../scripts/checks.sh))
 - `git diff --cached | ./scripts/scan-secrets.py` before committing.
+- Ensure the revised prompt explicitly directs contributors to secure **100% patch coverage on
+  the first test execution** without retries.
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
 2. Fix outdated instructions, links, or formatting.
-3. Run the commands above.
+3. Add or reinforce guidance that requires 100% patch coverage on the first test run.
+4. Run the commands above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -20,6 +20,8 @@ CONTEXT:
 - JavaScript-based actions run with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` so CI surfaces
   incompatibilities before GitHub switches runners to Node24 by default.
 - Run `pre-commit run --all-files` from the repository root; it executes `scripts/checks.sh`.
+- Craft fixes and tests so the resulting diff achieves **100% patch coverage on the first test run**
+  with no retries.
 - If a Node toolchain is present (`package.json` exists), run:
   - `npm ci`
   - `npm run lint`
@@ -33,7 +35,7 @@ CONTEXT:
 REQUEST:
 1. Re-run the failing check locally.
 2. Investigate and apply minimal fixes.
-3. Re-run all checks until they succeed.
+3. Re-run all checks until they succeed with 100% patch coverage on the first attempt.
 
 OUTPUT:
 A pull request describing the fix and showing passing checks.
@@ -57,11 +59,14 @@ Then run:
 - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
 - `linkchecker --no-warnings README.md docs/`
 - `git diff --cached | ./scripts/scan-secrets.py` before committing.
+- Ensure the updated prompt requires contributors to deliver **100% patch coverage on the first
+  test run** without reruns.
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
 2. Fix outdated instructions, links, or formatting.
-3. Run the commands above.
+3. Add or reinforce guidance about achieving 100% patch coverage on the first test execution.
+4. Run the commands above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts-codex-docker-repo.md
+++ b/docs/prompts-codex-docker-repo.md
@@ -21,13 +21,16 @@ CONTEXT:
 - Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires
   `aspell` and `aspell-en`), `linkchecker --no-warnings README.md docs/`, and
   `git diff --cached | ./scripts/scan-secrets.py` before committing.
+- Ensure walkthrough updates and supporting tests yield **100% patch coverage on the first test
+  run**—no retries.
 - File recurring deployment failures in [`outages/`](../outages/) per
   [`outages/schema.json`](../outages/schema.json).
 
 REQUEST:
 1. Expand the walkthrough or add examples.
 2. Reference token.place and dspace where helpful.
-3. Verify all commands and links.
+3. Verify all commands and links and confirm the diff achieves 100% patch coverage on the first
+   test execution.
 
 OUTPUT:
 A pull request with passing checks and a concise summary.
@@ -45,11 +48,14 @@ Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
 Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires
 `aspell` and `aspell-en`), `linkchecker --no-warnings README.md docs/`, and
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
+- Ensure the revised prompt emphasizes achieving **100% patch coverage on the first test run**
+  without retries.
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
 2. Fix outdated instructions, links, or formatting.
-3. Run the commands above.
+3. Add or reinforce guidance that mandates 100% patch coverage on the first test execution.
+4. Run the commands above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -22,6 +22,8 @@ CONTEXT:
 - Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../scripts/checks.sh) for
   linting, formatting, and tests. If `package.json` exists, the script automatically
   runs `npm ci`, `npm run lint`, and `npm run test:ci`.
+- Structure edits and any supporting tests so the diff achieves **100% patch coverage on the first
+  test execution**—no reruns.
 - For documentation changes, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; see
     [`.spellcheck.yaml`](../.spellcheck.yaml))
@@ -35,12 +37,13 @@ REQUEST:
 2. Improve wording, fix links, or add missing steps.
 3. Re-run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`,
    `linkchecker --no-warnings README.md docs/`, and
-   `git diff --cached | ./scripts/scan-secrets.py`. Confirm all checks pass.
+   `git diff --cached | ./scripts/scan-secrets.py`. Confirm all checks pass with 100% patch
+   coverage on the first attempt.
    If `package.json` exists, also run:
    - `npm ci`
    - `npm run lint`
    - `npm run test:ci`
-   Confirm all checks pass.
+   Confirm all checks pass with 100% patch coverage on the first run.
 
 OUTPUT:
 A pull request with the refined documentation and passing checks.
@@ -61,11 +64,14 @@ linting, formatting, and tests; it automatically runs `npm ci`, `npm run lint`, 
 (requires `aspell` and `aspell-en`; see [`.spellcheck.yaml`](../.spellcheck.yaml)),
 `linkchecker --no-warnings README.md docs/`, and
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
+- Ensure the refreshed prompt explicitly directs contributors to deliver **100% patch coverage on
+  the first test run** without retries.
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
 2. Fix outdated instructions, links, or formatting.
-3. Run the commands above.
+3. Add or reinforce guidance requiring 100% patch coverage on the first test execution.
+4. Run the commands above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts-codex-elex.md
+++ b/docs/prompts-codex-elex.md
@@ -31,6 +31,8 @@ CONTEXT:
   commit is available. For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`
+- Ensure schematic, PCB, and script updates land with **100% patch coverage on the first test
+  execution**—no retries.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py` before committing.
 - Log persistent tool failures in [`outages/`](../outages/) per
@@ -45,7 +47,8 @@ REQUEST:
 3. Update any related documentation.
 4. Re-run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
    `linkchecker --no-warnings README.md docs/`; scan staged changes with
-   `git diff --cached | ./scripts/scan-secrets.py`.
+   `git diff --cached | ./scripts/scan-secrets.py` and confirm 100% patch coverage on the first
+   attempt.
 
 OUTPUT:
 A pull request summarizing electronics updates and confirming KiBot export.
@@ -63,11 +66,14 @@ Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
 Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires
 `aspell` and `aspell-en`), `linkchecker --no-warnings README.md docs/`, and
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
+- Ensure the updated prompt explicitly mandates **100% patch coverage on the first test run**
+  without retries.
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
 2. Fix outdated instructions, links, or formatting.
-3. Run the commands above.
+3. Add or reinforce guidance that requires 100% patch coverage on the first test execution.
+4. Run the commands above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts-codex-observability.md
+++ b/docs/prompts-codex-observability.md
@@ -13,6 +13,8 @@ SYSTEM:
 You are building the “Sugarkube Dashboard” capability for a k3s-based platform.
 Produce production-grade code, manifests, Helm values, and docs.
 Optimize for simplicity, reproducibility, and security by default.
+Achieve **100% patch coverage on the first test run**—design code and tests so no reruns are
+required.
 
 GOAL:
 Create a complete, minimal, and extensible observability + kiosk solution:

--- a/docs/prompts-codex-pi-image.md
+++ b/docs/prompts-codex-pi-image.md
@@ -24,6 +24,8 @@ CONTEXT:
   For documentation changes, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`
+- Shape code and test edits so the diff delivers **100% patch coverage on the first test run**
+  without retries.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py` before committing.
 - Log persistent build issues in [`outages/`](../outages/) per
@@ -35,7 +37,8 @@ REQUEST:
 3. Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`
    (requires `aspell` and `aspell-en`),
    `linkchecker --no-warnings README.md docs/`, and
-   `git diff --cached | ./scripts/scan-secrets.py`, confirming success.
+   `git diff --cached | ./scripts/scan-secrets.py`, confirming success with 100% patch coverage on
+   the first attempt.
 
 OUTPUT:
 A pull request with passing checks and a concise summary.
@@ -54,11 +57,14 @@ Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`
 (requires `aspell` and `aspell-en`),
 `linkchecker --no-warnings README.md docs/`, and
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
+- Ensure the revised prompt explicitly compels contributors to achieve **100% patch coverage on the
+  first test run** without retries.
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
 2. Fix outdated instructions, links, or formatting.
-3. Run the commands above.
+3. Add or reinforce guidance that demands 100% patch coverage on the first test execution.
+4. Run the commands above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts-codex-pi-token-dspace.md
+++ b/docs/prompts-codex-pi-token-dspace.md
@@ -45,6 +45,8 @@ CONTEXT:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`
   - `git diff --cached | ./scripts/scan-secrets.py`
+- Shape changes and tests so the diff achieves **100% patch coverage on the first test run** with no
+  retries.
 - Review [CI workflows](../.github/workflows/) to anticipate automated checks.
 
 REQUEST:
@@ -53,7 +55,7 @@ REQUEST:
 2. Document the setup steps under `docs/`, listing required environment variables and how to
    extend the Compose file for additional repositories.
 3. Keep hooks for adding other repositories later.
-4. Run the commands above and confirm success.
+4. Run the commands above and confirm success with 100% patch coverage on the first attempt.
 
 OUTPUT:
 A pull request with updated scripts and docs enabling `token.place` and
@@ -72,11 +74,14 @@ Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
 Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires
 `aspell` and `aspell-en`), `linkchecker --no-warnings README.md docs/`, and
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
+- Ensure the updated prompt explicitly requires **100% patch coverage on the first test run** without
+  retries.
 
 USER:
 1. Improve this prompt by clarifying context, links, or instructions.
 2. Ensure references stay current.
-3. Run the commands above.
+3. Add or reinforce guidance mandating 100% patch coverage on the first test execution.
+4. Run the commands above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -21,6 +21,8 @@ CONTEXT:
 - Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
 - Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../scripts/checks.sh) for
   linting, formatting, and tests.
+- Ensure edits and any accompanying tests achieve **100% patch coverage on the first test run** with
+  no retries.
 - If a Node toolchain is present (`package.json` exists), also run:
   - `npm ci`
   - `npm run lint`
@@ -31,7 +33,8 @@ CONTEXT:
 REQUEST:
 1. Run the spellcheck and review results.
 2. Fix misspellings or update `.wordlist.txt`.
-3. Re-run spellcheck and link checks until clean.
+3. Re-run spellcheck and link checks until clean and confirm 100% patch coverage on the first
+   attempt.
 
 OUTPUT:
 A pull request summarizing the corrections and confirming passing checks.
@@ -56,11 +59,15 @@ Then run:
   [`.spellcheck.yaml`](../.spellcheck.yaml))
 - `linkchecker --no-warnings README.md docs/`
 - `git diff --cached | ./scripts/scan-secrets.py` before committing.
+- Ensure the prompt clearly requires contributors to maintain **100% patch coverage on the first
+  test run** without retries.
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
 2. Fix outdated instructions, links, or formatting.
-3. Run the commands above.
+3. Add or reinforce guidance directing contributors to achieve 100% patch coverage on the first test
+   execution.
+4. Run the commands above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts-codex-tests.md
+++ b/docs/prompts-codex-tests.md
@@ -27,6 +27,8 @@ CONTEXT:
   [`scripts/checks.sh`](../scripts/checks.sh) for linting, formatting, and executing both
   test frameworks. The script installs missing tools—including `bats`—so tests run
   consistently.
+- Ensure new and updated tests drive **100% patch coverage on the first test run**; design fixes so
+  no reruns are needed.
 - The CI workflow [`tests.yml`](../.github/workflows/tests.yml) runs the test suite on
   each push.
 - For documentation updates, also run `pyspelling -c .spellcheck.yaml` (requires
@@ -41,7 +43,8 @@ REQUEST:
 2. Write or update tests in [`tests/`](../tests/).
 3. Adjust implementation if a test exposes a bug.
 4. Re-run `pre-commit run --all-files`; for docs changes also run
-   `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/`.
+   `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/`, confirming
+   100% patch coverage on the first attempt.
 5. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 OUTPUT:
@@ -66,11 +69,15 @@ Then run:
 - `pyspelling -c .spellcheck.yaml`
 - `linkchecker --no-warnings README.md docs/`
 - `git diff --cached | ./scripts/scan-secrets.py` before committing.
+- Ensure the prompt explicitly requires contributors to reach **100% patch coverage on the first test
+  run** without retries.
 
 USER:
 1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
 2. Fix outdated instructions, links, or formatting.
-3. Run the commands above.
+3. Add or reinforce guidance directing contributors to attain 100% patch coverage on the first test
+   execution.
+4. Run the commands above.
 
 OUTPUT:
 A pull request with the improved prompt doc and passing checks.

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -30,6 +30,8 @@ CONTEXT:
   [`.pre-commit-config.yaml`](../.pre-commit-config.yaml). `scripts/checks.sh`
   automatically runs `npm ci`, `npm run lint`, and `npm run test:ci` when a
   `package.json` is present.
+- Design your code and tests so the resulting diff achieves **100% patch coverage on
+  the first test run**—no retries.
 - When documentation files (`README.md` or anything under
   [`docs/`](../docs/)) change, additionally run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; config in
@@ -46,7 +48,7 @@ REQUEST:
 1. Identify a small bug fix or documentation clarification.
 2. Implement the change following the project's existing style.
 3. Update relevant documentation when needed.
-4. Run all checks above and ensure they pass.
+4. Run all checks above and ensure they pass with 100% patch coverage on the first attempt.
 
 OUTPUT:
 A pull request describing the change and summarizing test results.
@@ -74,12 +76,15 @@ checks. `scripts/checks.sh` automatically runs `npm ci`, `npm run lint`, and
 - `git diff --cached | ./scripts/scan-secrets.py`
   (script: [`scripts/scan-secrets.py`](../scripts/scan-secrets.py)) to avoid
   committing credentials
+- Ensure the prompt instructs contributors to achieve **100% patch coverage on the first
+  test run** without retries.
 Fix any issues reported by these tools.
 
 USER:
 1. Choose a `docs/prompts-*.md` file to update (for example, `prompts-codex-cad.md`).
 2. Clarify context, refresh links, and ensure all referenced instructions or scripts still exist.
-3. Run the commands above and address any failures.
+3. Explicitly direct contributors to deliver 100% patch coverage on the first test execution.
+4. Run the commands above and address any failures.
 
 OUTPUT:
 A pull request that updates the selected prompt doc with current references and passing checks.


### PR DESCRIPTION
## Summary
- require automated contributors to deliver 100% patch coverage on the first test run in the core Codex prompt
- propagate the first-run patch coverage directive across all domain-specific Codex prompt docs

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68d1c5559adc832fa92ac50a4fbd36a1