### PR TITLE
Add printable Pi carrier field guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,11 @@ TOKEN_PLACE_SAMPLE_ARGS ?= --samples-dir $(CURDIR)/samples/token_place
 SUPPORT_BUNDLE_CMD ?= $(CURDIR)/scripts/collect_support_bundle.py
 SUPPORT_BUNDLE_ARGS ?=
 SUPPORT_BUNDLE_HOST ?=
+FIELD_GUIDE_CMD ?= $(CURDIR)/scripts/render_field_guide_pdf.py
+FIELD_GUIDE_ARGS ?=
 
 .PHONY: install-pi-image download-pi-image flash-pi flash-pi-report doctor rollback-to-sd \
-        clone-ssd docs-verify qr-codes monitor-ssd-health smoke-test-pi \
+        clone-ssd docs-verify qr-codes monitor-ssd-health smoke-test-pi field-guide \
         publish-telemetry notify-teams update-hardware-badge rehearse-join \
         token-place-samples support-bundle
 
@@ -86,6 +88,9 @@ monitor-ssd-health:
 
 smoke-test-pi:
 	$(SMOKE_CMD) $(SMOKE_ARGS)
+
+field-guide:
+	$(FIELD_GUIDE_CMD) $(FIELD_GUIDE_ARGS)
 
 publish-telemetry:
         $(TELEMETRY_CMD) $(TELEMETRY_ARGS)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ the docs you will see the term used in both contexts.
 - [docs/pi_image_quickstart.md](docs/pi_image_quickstart.md) — build, flash and boot the preloaded Pi image
 - [docs/pi_image_contributor_guide.md](docs/pi_image_contributor_guide.md) — map automation helpers to
   the docs that describe them
+- [docs/pi_carrier_field_guide.md](docs/pi_carrier_field_guide.md) — one-page printable checklist with a
+  PDF companion (`docs/pi_carrier_field_guide.pdf`) for the workbench
 - [docs/templates/cloud-init/user-data.example](docs/templates/cloud-init/user-data.example) — cloud-init
   template for SSH keys and `Wi-Fi` credentials
 - `scripts/` — helper scripts for rendering and exports. See
@@ -78,6 +80,8 @@ the docs you will see the term used in both contexts.
     `--help` for usage
   - `pi_smoke_test.py` — SSH wrapper that runs the verifier remotely, supports reboot checks,
     and emits JSON summaries for CI harnesses
+  - `render_field_guide_pdf.py` — build the Markdown field guide into a single-page PDF without
+    extra pip dependencies so releases can refresh the printable checklist automatically
   - `scan-secrets.py` — scan diffs for high-risk patterns using `ripsecrets` when
     available and also run a regex check to catch common tokens
 - `outages/` — structured outage records (see

--- a/docs/contributor_script_map.md
+++ b/docs/contributor_script_map.md
@@ -49,6 +49,12 @@ confirm the quickstart stays accurate.
 | `scripts/ssd_post_clone_validate.py` | Validate cloned SSDs, compare boot config, and run stress tests. | [Pi Image Quickstart](./pi_image_quickstart.md) §"Validate SSD clones", [SSD Post-Clone Validation](./ssd_post_clone_validation.md) | `make validate-ssd-clone`, `just validate-ssd-clone` |
 | `scripts/ssd_health_monitor.py` | Collect SMART metrics, temperatures, and wear indicators with optional reporting. | [Pi Image Quickstart](./pi_image_quickstart.md) §"Monitor SSD health", [SSD Health Monitor](./ssd_health_monitor.md) | `make monitor-ssd-health`, `just monitor-ssd-health` |
 
+## Printable references
+
+| Script | Purpose | Primary docs | Supporting automation |
+| --- | --- | --- | --- |
+| `scripts/render_field_guide_pdf.py` | Build the one-page Pi carrier field guide PDF without extra dependencies. | [Pi Carrier Field Guide](./pi_carrier_field_guide.md), [Pi Image Quickstart](./pi_image_quickstart.md) | `make field-guide`, `just field-guide` |
+
 ## Keeping docs and automation in sync
 
 - Update both the script *and* its corresponding guide when behaviour changes.

--- a/docs/pi_carrier_field_guide.md
+++ b/docs/pi_carrier_field_guide.md
@@ -1,0 +1,42 @@
+# Sugarkube Pi Carrier Field Guide
+
+The essentials to go from download to a healthy k3s cluster. Print on US Letter
+or A4 and keep near the build bench.
+
+## Fast Path (≈10 minutes)
+1. Download: `just download-pi-image` (or `make download-pi-image`). Expect a
+   `.img.xz` plus `.sha256` in `~/sugarkube/images/`.
+2. Flash: `sudo just flash-pi FLASH_DEVICE=/dev/sdX` and watch for
+   `Sync complete` with zero write errors.
+3. Boot: Insert media, power the Pi, and wait for the green ACT LED to settle
+   into a steady heartbeat (~1 Hz) after the first minute.
+4. Verify: `ssh pi@pi.local sudo /usr/local/bin/pi_node_verifier.sh --json`. The
+   `status` field should be `ok` and include `k3s_ready=true`.
+5. Snapshot: Run `just clone-ssd CLONE_TARGET=/dev/sdX --resume` once an SSD is
+   attached. Expect a final `Clone complete` message.
+
+## Command Outputs
+- `curl http://pi.local:12345/metrics` → HTTP 200 with Prometheus metrics lines
+  such as `up 1` and `sugarkube_first_boot_status 1`.
+- `kubectl --kubeconfig /boot/sugarkube-kubeconfig get nodes` → all nodes in
+  `Ready` state within 3 retries.
+- `journalctl -u ssd-clone --since -10m` → shows `ssd-clone.service completed`
+  after a successful SSD migration.
+
+## LED + Status Quick Reference
+- Power steady, ACT blinking rapidly → booting; wait for ACT heartbeat before
+  interacting.
+- Power steady, ACT solid on >30s → check HDMI/serial; likely kernel panic.
+- Power steady, ACT off → re-seat storage or reflash; Pi is not reading media.
+- Ethernet steady + ACT heartbeat but no SSH → run `sugarkube-teams` or check
+  `/boot/first-boot-report/` for verifier output.
+
+## If Something Fails
+- Re-run `just flash-pi-report FLASH_DEVICE=/dev/sdX` to capture Markdown/HTML
+  logs under `~/sugarkube/reports/`.
+- Review `/boot/first-boot-report/self-heal/` on the Pi for automated recovery
+  attempts and escalations.
+- Pull a support bundle: `just support-bundle SUPPORT_BUNDLE_HOST=pi.local` and
+  attach the resulting archive to issues.
+- More guidance: [Pi Image Quickstart](./pi_image_quickstart.md) and
+  [Pi Boot Troubleshooting](./pi_boot_troubleshooting.md).

--- a/docs/pi_carrier_field_guide.pdf
+++ b/docs/pi_carrier_field_guide.pdf
@@ -1,0 +1,166 @@
+%PDF-1.4
+%
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 612 792] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 2831 >>
+stream
+BT
+/F1 10 Tf
+11 TL
+1 0 0 1 36 746 Tm
+(SUGARKUBE PI CARRIER FIELD GUIDE) Tj
+T*
+(================================) Tj
+T*
+() Tj
+T*
+(The essentials to go from download to a healthy k3s cluster. Print on US) Tj
+T*
+(Letter) Tj
+T*
+(or A4 and keep near the build bench.) Tj
+T*
+() Tj
+T*
+(FAST PATH \(≈10 MINUTES\)) Tj
+T*
+(-----------------------) Tj
+T*
+() Tj
+T*
+( 1. Download: just download-pi-image \(or make download-pi-image\). Expect a) Tj
+T*
+(.img.xz plus .sha256 in ~/sugarkube/images/.) Tj
+T*
+( 2. Flash: sudo just flash-pi FLASH_DEVICE=/dev/sdX and watch for) Tj
+T*
+(Sync complete with zero write errors.) Tj
+T*
+( 3. Boot: Insert media, power the Pi, and wait for the green ACT LED to) Tj
+T*
+(    settle) Tj
+T*
+(into a steady heartbeat \(~1 Hz\) after the first minute.) Tj
+T*
+( 4. Verify: ssh pi@pi.local sudo /usr/local/bin/pi_node_verifier.sh) Tj
+T*
+(    --json. The) Tj
+T*
+(status field should be ok and include k3s_ready=true.) Tj
+T*
+( 5. Snapshot: Run just clone-ssd CLONE_TARGET=/dev/sdX --resume once an) Tj
+T*
+(    SSD is) Tj
+T*
+(attached. Expect a final Clone complete message.) Tj
+T*
+() Tj
+T*
+(COMMAND OUTPUTS) Tj
+T*
+(---------------) Tj
+T*
+() Tj
+T*
+(  • curl http://pi.local:12345/metrics → HTTP 200 with Prometheus metrics) Tj
+T*
+(    lines) Tj
+T*
+(such as up 1 and sugarkube_first_boot_status 1.) Tj
+T*
+(  • kubectl --kubeconfig /boot/sugarkube-kubeconfig get nodes → all nodes) Tj
+T*
+(    in) Tj
+T*
+(Ready state within 3 retries.) Tj
+T*
+(  • journalctl -u ssd-clone --since -10m → shows ssd-clone.service) Tj
+T*
+(    completed) Tj
+T*
+(after a successful SSD migration.) Tj
+T*
+() Tj
+T*
+(LED + STATUS QUICK REFERENCE) Tj
+T*
+(----------------------------) Tj
+T*
+() Tj
+T*
+(  • Power steady, ACT blinking rapidly → booting; wait for ACT heartbeat) Tj
+T*
+(    before) Tj
+T*
+(interacting.) Tj
+T*
+(  • Power steady, ACT solid on >30s → check HDMI/serial; likely kernel) Tj
+T*
+(    panic.) Tj
+T*
+(  • Power steady, ACT off → re-seat storage or reflash; Pi is not reading) Tj
+T*
+(    media.) Tj
+T*
+(  • Ethernet steady + ACT heartbeat but no SSH → run sugarkube-teams or) Tj
+T*
+(    check) Tj
+T*
+(/boot/first-boot-report/ for verifier output.) Tj
+T*
+() Tj
+T*
+(IF SOMETHING FAILS) Tj
+T*
+(------------------) Tj
+T*
+() Tj
+T*
+(  • Re-run just flash-pi-report FLASH_DEVICE=/dev/sdX to capture) Tj
+T*
+(    Markdown/HTML) Tj
+T*
+(logs under ~/sugarkube/reports/.) Tj
+T*
+(  • Review /boot/first-boot-report/self-heal/ on the Pi for automated) Tj
+T*
+(    recovery) Tj
+T*
+(attempts and escalations.) Tj
+T*
+(  • Pull a support bundle: just support-bundle) Tj
+T*
+(    SUPPORT_BUNDLE_HOST=pi.local and) Tj
+T*
+(attach the resulting archive to issues.) Tj
+T*
+(  • More guidance: Pi Image Quickstart \(./pi_image_quickstart.md\) and) Tj
+T*
+(Pi Boot Troubleshooting \(./pi_boot_troubleshooting.md\).) Tj
+ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000145 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+3199
+%%EOF

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -167,7 +167,10 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
   - A 10-minute fast path.
   - Persona-based walkthroughs (solo builder, classroom, maintainer).
   - Deep reference sections with wiring photos.
-- [ ] Include a printable one-page field guide/checklist (PDF) with commands, expected outputs, LED/status reference, and troubleshooting links.
+- [x] Include a printable one-page field guide/checklist (PDF) with commands, expected outputs, LED/status reference, and troubleshooting links.
+  - Added [Pi Carrier Field Guide](./pi_carrier_field_guide.md) with a companion PDF renderer
+    (`scripts/render_field_guide_pdf.py`) plus quickstart/README links so a single sheet stays
+    in sync with tooling expectations at the workbench.
 - [ ] Embed GIFs, screencasts, or narrated clips showing download → flash → first boot → SSD clone → k3s readiness.
 - [x] Provide start-to-finish flowcharts mapping the journey.
 - [x] Expand troubleshooting tables linking LED patterns, journalctl logs, `kubectl` errors, and container health issues to fixes.

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -21,6 +21,10 @@ refresh the badge after exercising physical clusters.
 Need a hands-on reminder next to the hardware? Print the
 [Pi carrier QR labels](./pi_carrier_qr_labels.md) and stick them to the enclosure so anyone can
 scan straight to this quickstart or the troubleshooting matrix while standing at the workbench.
+Pair them with the [Pi Carrier Field Guide](./pi_carrier_field_guide.md) and its generated
+[`pi_carrier_field_guide.pdf`](./pi_carrier_field_guide.pdf) to keep a one-page checklist beside the
+cluster.
+Run `make field-guide` or `just field-guide` after editing the Markdown to refresh the PDF copy.
 
 ## 1. Build or download the image
 

--- a/justfile
+++ b/justfile
@@ -30,6 +30,11 @@ support_bundle_cmd := env_var_or_default(
 )
 support_bundle_args := env_var_or_default("SUPPORT_BUNDLE_ARGS", "")
 support_bundle_host := env_var_or_default("SUPPORT_BUNDLE_HOST", "")
+field_guide_cmd := env_var_or_default(
+    "FIELD_GUIDE_CMD",
+    justfile_directory() + "/scripts/render_field_guide_pdf.py",
+)
+field_guide_args := env_var_or_default("FIELD_GUIDE_ARGS", "")
 telemetry_cmd := env_var_or_default(
     "TELEMETRY_CMD",
     justfile_directory() + "/scripts/publish_telemetry.py",
@@ -126,6 +131,11 @@ monitor-ssd-health:
 # Usage: just smoke-test-pi SMOKE_ARGS="pi-a.local --reboot"
 smoke-test-pi:
     "{{smoke_cmd}}" {{smoke_args}}
+
+# Render the printable Pi carrier field guide PDF
+# Usage: just field-guide FIELD_GUIDE_ARGS="--wrap 70"
+field-guide:
+    "{{field_guide_cmd}}" {{field_guide_args}}
 
 # Publish anonymized telemetry payloads once.
 publish-telemetry:

--- a/scripts/render_field_guide_pdf.py
+++ b/scripts/render_field_guide_pdf.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Render the Pi carrier field guide Markdown into a single-page PDF.
+
+The generator intentionally avoids heavyweight dependencies so it can run in
+automation without extra apt or pip installs. It supports a constrained subset
+of Markdown that matches ``docs/pi_carrier_field_guide.md`` and exposes a small
+CLI wrapper so ``make``/``just`` targets can refresh the PDF before releases.
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import pathlib
+import re
+import textwrap
+from dataclasses import dataclass
+from typing import Iterable, List
+
+PDF_HEADER = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n"
+PAGE_WIDTH = 612  # 8.5" * 72 pt
+PAGE_HEIGHT = 792  # 11" * 72 pt
+DEFAULT_MARGIN = 36
+DEFAULT_FONT_SIZE = 10
+LINE_SPACING = 11  # pts between lines
+DEFAULT_WRAP = 74
+
+
+@dataclass(frozen=True)
+class Layout:
+    """Layout controls for the single-page PDF."""
+
+    width: int = PAGE_WIDTH
+    height: int = PAGE_HEIGHT
+    margin: int = DEFAULT_MARGIN
+    font_size: int = DEFAULT_FONT_SIZE
+    leading: int = LINE_SPACING
+
+    @property
+    def usable_height(self) -> int:
+        return self.height - 2 * self.margin
+
+    @property
+    def max_lines(self) -> int:
+        return max(0, math.floor(self.usable_height / self.leading))
+
+    @property
+    def baseline_y(self) -> int:
+        return self.height - self.margin - self.font_size
+
+
+_HEADING_UNDERLINES = {1: "=", 2: "-"}
+
+_INLINE_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_CODE_RE = re.compile(r"`([^`]+)`")
+_STRONG_RE = re.compile(r"\*\*([^*]+)\*\*")
+_EM_RE = re.compile(r"\*([^*]+)\*")
+_ORDERED_RE = re.compile(r"^(\d+)\.\s+(.*)$")
+
+
+def _strip_markdown_markup(text: str) -> str:
+    """Convert simple inline Markdown to printable text."""
+
+    def _link_sub(match: re.Match[str]) -> str:
+        label, url = match.group(1).strip(), match.group(2).strip()
+        if url.startswith("http"):
+            return f"{label} ({url})"
+        return f"{label} ({url})"
+
+    text = _INLINE_LINK_RE.sub(_link_sub, text)
+    text = _CODE_RE.sub(lambda m: m.group(1), text)
+    text = _STRONG_RE.sub(lambda m: m.group(1), text)
+    text = _EM_RE.sub(lambda m: m.group(1), text)
+    return text
+
+
+def markdown_to_lines(markdown: str, wrap: int = DEFAULT_WRAP) -> List[str]:
+    """Convert constrained Markdown into wrapped plaintext lines."""
+
+    lines: List[str] = []
+    previous_blank = True
+
+    for raw_line in markdown.splitlines():
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if not stripped:
+            if not previous_blank:
+                lines.append("")
+            previous_blank = True
+            continue
+
+        if stripped.startswith("#"):
+            level = len(stripped) - len(stripped.lstrip("#"))
+            heading_text = stripped[level:].strip()
+            heading_text = _strip_markdown_markup(heading_text).upper()
+            underline_char = _HEADING_UNDERLINES.get(level, "-")
+            underline = underline_char * min(len(heading_text), wrap)
+            if not previous_blank and lines and lines[-1] != "":
+                lines.append("")
+            lines.append(heading_text)
+            lines.append(underline)
+            lines.append("")
+            previous_blank = True
+            continue
+
+        bullet_prefix = None
+        if stripped.startswith("- "):
+            bullet_prefix = "  • "
+            body = stripped[2:].strip()
+        else:
+            ordered_match = _ORDERED_RE.match(stripped)
+            if ordered_match:
+                bullet_prefix = f" {ordered_match.group(1)}. "
+                body = ordered_match.group(2).strip()
+
+        if bullet_prefix is not None:
+            body_text = _strip_markdown_markup(body)
+            wrapped = textwrap.wrap(body_text, width=max(8, wrap - len(bullet_prefix)))
+            if not wrapped:
+                lines.append(bullet_prefix.rstrip())
+            else:
+                lines.append(bullet_prefix + wrapped[0])
+                for cont in wrapped[1:]:
+                    lines.append(" " * len(bullet_prefix) + cont)
+            previous_blank = False
+            continue
+
+        paragraph_text = _strip_markdown_markup(stripped)
+        wrapped = textwrap.wrap(paragraph_text, width=wrap)
+        if not wrapped:
+            wrapped = [""]
+        lines.extend(wrapped)
+        previous_blank = False
+
+    while lines and lines[-1] == "":
+        lines.pop()
+    return lines
+
+
+def _escape_pdf_text(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+
+def lines_to_pdf_bytes(lines: Iterable[str], layout: Layout = Layout()) -> bytes:
+    """Render wrapped lines into a single-page PDF and return the bytes."""
+
+    lines_list = list(lines)
+    if len(lines_list) > layout.max_lines:
+        raise ValueError(
+            "Field guide contains "
+            f"{len(lines_list)} lines but only {layout.max_lines} fit on one page"
+        )
+
+    text_commands = [
+        "BT",
+        f"/F1 {layout.font_size} Tf",
+        f"{layout.leading} TL",
+        f"1 0 0 1 {layout.margin} {layout.baseline_y} Tm",
+    ]
+
+    for index, line in enumerate(lines_list):
+        escaped = _escape_pdf_text(line)
+        text_commands.append(f"({escaped}) Tj")
+        if index != len(lines_list) - 1:
+            text_commands.append("T*")
+
+    text_commands.append("ET")
+    text_stream = "\n".join(text_commands) + "\n"
+    text_bytes = text_stream.encode("utf-8")
+
+    objects: List[bytes] = []
+    objects.append(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n")
+    objects.append(
+        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 "
+        + str(layout.width).encode("ascii")
+        + b" "
+        + str(layout.height).encode("ascii")
+        + b"] >>\nendobj\n"
+    )
+    objects.append(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> "
+        b"/Contents 5 0 R >>\nendobj\n"
+    )
+    objects.append(b"4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n")
+    objects.append(
+        b"5 0 obj\n<< /Length "
+        + str(len(text_bytes)).encode("ascii")
+        + b" >>\nstream\n"
+        + text_bytes
+        + b"endstream\nendobj\n"
+    )
+
+    pdf = bytearray()
+    pdf.extend(PDF_HEADER)
+    offsets = [0]  # object 0 is the free object at offset 0 per PDF spec
+
+    for obj in objects:
+        offsets.append(len(pdf))
+        pdf.extend(obj)
+
+    startxref = len(pdf)
+    obj_count = len(objects)
+    pdf.extend(f"xref\n0 {obj_count + 1}\n".encode("ascii"))
+    pdf.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        pdf.extend(f"{offset:010} 00000 n \n".encode("ascii"))
+
+    pdf.extend(b"trailer\n<< /Size " + str(obj_count + 1).encode("ascii") + b" /Root 1 0 R >>\n")
+    pdf.extend(b"startxref\n" + str(startxref).encode("ascii") + b"\n%%EOF\n")
+    return bytes(pdf)
+
+
+def render_field_guide_pdf(
+    source: pathlib.Path, output: pathlib.Path, wrap: int = DEFAULT_WRAP
+) -> None:
+    markdown = source.read_text(encoding="utf-8")
+    lines = markdown_to_lines(markdown, wrap=wrap)
+    pdf_bytes = lines_to_pdf_bytes(lines)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(pdf_bytes)
+
+
+def parse_args(args: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Render the Sugarkube field guide PDF")
+    parser.add_argument(
+        "--source",
+        type=pathlib.Path,
+        default=pathlib.Path("docs/pi_carrier_field_guide.md"),
+        help="Path to the Markdown source document.",
+    )
+    parser.add_argument(
+        "--output",
+        type=pathlib.Path,
+        default=pathlib.Path("docs/pi_carrier_field_guide.pdf"),
+        help="Destination PDF path.",
+    )
+    parser.add_argument(
+        "--wrap",
+        type=int,
+        default=DEFAULT_WRAP,
+        help="Column width used when wrapping Markdown paragraphs.",
+    )
+    return parser.parse_args(args=args)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    opts = parse_args(argv)
+    render_field_guide_pdf(opts.source, opts.output, wrap=opts.wrap)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI shim
+    main()

--- a/tests/render_field_guide_pdf_test.py
+++ b/tests/render_field_guide_pdf_test.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+MODULE_PATH = pathlib.Path("scripts/render_field_guide_pdf.py")
+spec = importlib.util.spec_from_file_location("render_field_guide_pdf", MODULE_PATH)
+assert spec and spec.loader
+render_field_guide_pdf = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = render_field_guide_pdf
+spec.loader.exec_module(render_field_guide_pdf)
+
+
+def test_markdown_to_lines_formats_headings_lists():
+    markdown = "\n".join(
+        [
+            "# Title",
+            "",
+            "## Tasks",
+            "- First bullet with a [link](https://example.com).",
+            "- Second bullet.",
+            "1. Ordered step with `code`.",
+            "",
+            "Plain paragraph after lists.",
+        ]
+    )
+    lines = render_field_guide_pdf.markdown_to_lines(markdown, wrap=60)
+    assert lines[0] == "TITLE"
+    assert lines[1] == "====="
+    assert any("• First bullet" in line for line in lines)
+    assert any("https://example.com" in line for line in lines)
+    assert any(line.startswith(" 1.") for line in lines)
+    assert any("code" in line for line in lines)
+
+
+def test_lines_to_pdf_bytes_produces_pdf():
+    layout = render_field_guide_pdf.Layout(height=200, margin=20, font_size=9, leading=11)
+    lines = ["Header", "", "Line with (parentheses) and \\ slashes."]
+    pdf = render_field_guide_pdf.lines_to_pdf_bytes(lines, layout=layout)
+    assert pdf.startswith(b"%PDF-1.4")
+    assert b"Header" in pdf
+    assert b"parentheses" in pdf
+
+
+def test_lines_to_pdf_bytes_overflow():
+    layout = render_field_guide_pdf.Layout(height=100, margin=10, leading=10)
+    lines = ["x"] * (layout.max_lines + 1)
+    with pytest.raises(ValueError):
+        render_field_guide_pdf.lines_to_pdf_bytes(lines, layout=layout)
+
+
+def test_render_field_guide_pdf_round_trip(tmp_path: pathlib.Path):
+    markdown = """# Heading\n\nParagraph with content."""
+    source = tmp_path / "guide.md"
+    output = tmp_path / "guide.pdf"
+    source.write_text(markdown, encoding="utf-8")
+    render_field_guide_pdf.render_field_guide_pdf(source, output, wrap=40)
+    data = output.read_bytes()
+    assert data.startswith(b"%PDF-1.4")
+    assert b"HEADING" in data
+
+
+def test_parse_args_overrides_paths(tmp_path: pathlib.Path):
+    src = tmp_path / "a.md"
+    dst = tmp_path / "b.pdf"
+    args = render_field_guide_pdf.parse_args(
+        [
+            "--source",
+            str(src),
+            "--output",
+            str(dst),
+            "--wrap",
+            "42",
+        ]
+    )
+    assert args.source == src
+    assert args.output == dst
+    assert args.wrap == 42


### PR DESCRIPTION
## Summary
- add a printable Pi carrier field guide with a PDF renderer and tests
- surface the new one-pager in automation targets, docs, and the checklist

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68d1c9bd72e8832f94cb615295da9433