### PR TITLE
Ensure workflow flash CLI tests cover main entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,12 @@ use either `sudo make flash-pi FLASH_DEVICE=/dev/sdX` or `sudo FLASH_DEVICE=/dev
  They also provide
  `download-pi-image`, `install-pi-image`, `doctor`, and `codespaces-bootstrap` shortcuts so GitHub
  Codespaces users can install prerequisites and flash media without additional shell glue.
- `./scripts/sugarkube-latest` remains available when you only need the `.img.xz` artifact with
- checksum verification.
+`./scripts/sugarkube-latest` remains available when you only need the `.img.xz` artifact with
+checksum verification.
+
+Prefer a guided experience? Open [docs/flash-helper/](docs/flash-helper/) to paste a workflow run
+URL and receive OS-specific download, verification, and flashing steps. The same logic is also
+available via `python scripts/workflow_flash_instructions.py --help` for command-line use.
 
 Run `pre-commit run --all-files` before committing.
 This triggers `scripts/checks.sh`, which installs required tooling and runs

--- a/docs/flash-helper/index.html
+++ b/docs/flash-helper/index.html
@@ -1,0 +1,514 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Sugarkube Flash Helper</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        line-height: 1.5;
+      }
+
+      body {
+        margin: 0;
+        padding: 0;
+        background: #0f172a;
+        color: #f8fafc;
+      }
+
+      main {
+        margin: 0 auto;
+        max-width: 960px;
+        padding: 3rem 1.5rem 4rem;
+      }
+
+      h1 {
+        font-size: clamp(2.25rem, 3vw + 1rem, 3rem);
+        margin-bottom: 0.5rem;
+      }
+
+      p.lead {
+        font-size: 1.125rem;
+        opacity: 0.85;
+        margin-top: 0;
+        margin-bottom: 1.75rem;
+      }
+
+      form {
+        display: grid;
+        gap: 1rem;
+        background: rgba(15, 23, 42, 0.85);
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        border-radius: 0.75rem;
+        padding: 1.5rem;
+        box-shadow: 0 18px 48px rgba(15, 23, 42, 0.35);
+      }
+
+      label {
+        font-weight: 600;
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+      }
+
+      input[type="url"],
+      select {
+        font: inherit;
+        padding: 0.65rem 0.75rem;
+        border-radius: 0.5rem;
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        background: rgba(15, 23, 42, 0.75);
+        color: inherit;
+      }
+
+      input[type="url"]:focus,
+      select:focus {
+        outline: 2px solid #38bdf8;
+        outline-offset: 2px;
+      }
+
+      button {
+        justify-self: flex-start;
+        padding: 0.65rem 1.25rem;
+        border-radius: 999px;
+        border: none;
+        font-weight: 600;
+        background: linear-gradient(135deg, #38bdf8, #14b8a6);
+        color: #0f172a;
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+      }
+
+      button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 32px rgba(56, 189, 248, 0.45);
+      }
+
+      .result-card {
+        margin-top: 2.5rem;
+        background: rgba(15, 23, 42, 0.7);
+        border-radius: 1rem;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        padding: 1.75rem;
+        box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.15);
+      }
+
+      .result-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1.5rem;
+        font-family: "JetBrains Mono", "Fira Code", monospace;
+        font-size: 0.95rem;
+        opacity: 0.9;
+      }
+
+      .steps {
+        margin-top: 1.5rem;
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .step {
+        background: rgba(15, 23, 42, 0.75);
+        border-radius: 0.85rem;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        padding: 1.25rem;
+      }
+
+      .step h3 {
+        margin: 0 0 0.5rem;
+        font-size: 1.1rem;
+      }
+
+      .step p {
+        margin: 0.35rem 0;
+      }
+
+      pre {
+        background: rgba(15, 23, 42, 0.9);
+        border-radius: 0.65rem;
+        padding: 0.9rem;
+        overflow-x: auto;
+        font-size: 0.9rem;
+      }
+
+      code {
+        font-family: "JetBrains Mono", "Fira Code", monospace;
+      }
+
+      .error {
+        margin-top: 1rem;
+        color: #fca5a5;
+        font-weight: 600;
+      }
+
+      footer {
+        margin-top: 3rem;
+        font-size: 0.85rem;
+        opacity: 0.7;
+      }
+
+      @media (max-width: 640px) {
+        .result-meta {
+          flex-direction: column;
+          gap: 0.75rem;
+        }
+
+        form {
+          padding: 1.25rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Sugarkube Flash Helper</h1>
+      <p class="lead">
+        Paste a GitHub Actions run URL, choose your operating system, and the helper will
+        generate download → verify → flash instructions tailored to your workstation.
+      </p>
+
+      <form id="flash-form">
+        <label>
+          Workflow run URL
+          <input
+            type="url"
+            id="workflow-url"
+            name="workflow-url"
+            placeholder="https://github.com/futuroptimist/sugarkube/actions/runs/..."
+            required
+          />
+        </label>
+        <label>
+          Workstation OS
+          <select id="os" name="os">
+            <option value="linux">Linux</option>
+            <option value="mac">macOS</option>
+            <option value="windows">Windows</option>
+          </select>
+        </label>
+        <button type="submit">Generate instructions</button>
+        <p id="error" class="error" hidden></p>
+      </form>
+
+      <section id="results" class="result-card" hidden>
+        <div class="result-meta">
+          <span id="meta-repo"></span>
+          <span id="meta-run"></span>
+          <span id="meta-platform"></span>
+        </div>
+        <div id="steps" class="steps"></div>
+      </section>
+
+      <footer>
+        Looking for the command-line equivalent? Run
+        <code>python scripts/workflow_flash_instructions.py --help</code> inside the repository.
+      </footer>
+    </main>
+
+    <script>
+      const OS_LABELS = {
+        linux: "Linux",
+        mac: "macOS",
+        windows: "Windows",
+      };
+
+      const STEP_TEMPLATES = {
+        linux: [
+          {
+            title: "Install GitHub CLI and utilities",
+            body: [
+              "Install the GitHub CLI plus tools required to verify and expand the image.",
+            ],
+            commands: [
+              "sudo apt-get update",
+              "sudo apt-get install -y gh xz-utils coreutils",
+            ],
+          },
+          {
+            title: "Authenticate GitHub CLI",
+            body: [
+              'Run the interactive login once so "gh" can download workflow artifacts.',
+            ],
+            commands: ["gh auth login --web"],
+          },
+          {
+            title: "Create an images directory",
+            body: [
+              "Store the artifacts in a predictable path. Feel free to reuse an existing folder.",
+            ],
+            commands: ["mkdir -p {images_dir_unix}", "cd {images_dir_unix}"],
+          },
+          {
+            title: "Download release artifacts",
+            body: [
+              "Fetch the {artifact_name} bundle from the workflow run. The helper also works for private repositories once gh is authenticated.",
+            ],
+            commands: [
+              "gh run download {run_id} --repo {repository} --name {artifact_name} --dir .",
+              "ls -l",
+            ],
+          },
+          {
+            title: "Verify checksum before flashing",
+            body: [
+              "Always confirm the checksum matches to avoid flashing a corrupted image.",
+            ],
+            commands: ["sha256sum -c {image_name}.sha256"],
+          },
+          {
+            title: "Expand the compressed image",
+            body: [
+              "Keep the original .xz file for future flashes. The command below expands it to {expanded_image_path_unix}.",
+            ],
+            commands: ["xz -dk {image_name}"],
+          },
+          {
+            title: "Flash removable media",
+            body: [
+              "Clone the repository if you have not already, then run the flashing helper with sudo. Replace /dev/sdX with your target device.",
+            ],
+            commands: [
+              "git clone https://github.com/futuroptimist/sugarkube.git  # Skip if cloned",
+              "cd sugarkube",
+              "sudo ./scripts/flash_pi_media.sh --image {expanded_image_path_unix} --device /dev/sdX --assume-yes",
+            ],
+          },
+        ],
+        mac: [
+          {
+            title: "Install GitHub CLI and dependencies",
+            body: [
+              "Use Homebrew to install the tooling required to download, verify, and expand the image.",
+            ],
+            commands: ["brew update", "brew install gh xz coreutils"],
+          },
+          {
+            title: "Authenticate GitHub CLI",
+            body: ["Log in once via the browser to access private workflow artifacts."],
+            commands: ["gh auth login --web"],
+          },
+          {
+            title: "Prepare the images directory",
+            body: [
+              "All artifacts are saved to {images_dir_unix}. Adjust the path if you prefer a different location.",
+            ],
+            commands: ["mkdir -p {images_dir_unix}", "cd {images_dir_unix}"],
+          },
+          {
+            title: "Download workflow artifacts",
+            body: [
+              "Download the {artifact_name} archive that contains the image, checksums, and provenance metadata.",
+            ],
+            commands: [
+              "gh run download {run_id} --repo {repository} --name {artifact_name} --dir .",
+              "ls -lh",
+            ],
+          },
+          {
+            title: "Verify checksum before flashing",
+            body: [
+              "Confirm the SHA-256 hash matches the published value to guard against corruption.",
+            ],
+            commands: ["shasum -a 256 -c {image_name}.sha256"],
+          },
+          {
+            title: "Expand the compressed image",
+            body: [
+              "Retain {image_name} for reuse. The following command expands it into {expanded_image_path_unix}.",
+            ],
+            commands: ["xz -dk {image_name}"],
+          },
+          {
+            title: "Flash the target disk",
+            body: [
+              "Clone the helpers if needed, unmount the removable disk (diskutil list → diskutil unmountDisk), then flash it with sudo.",
+            ],
+            commands: [
+              "git clone https://github.com/futuroptimist/sugarkube.git  # Skip if cloned",
+              "cd sugarkube",
+              "sudo ./scripts/flash_pi_media.sh --image {expanded_image_path_unix} --device /dev/diskX --assume-yes",
+            ],
+          },
+        ],
+        windows: [
+          {
+            title: "Install GitHub CLI and Python",
+            body: [
+              "Use winget to install the GitHub CLI plus Python for checksum verification and decompression.",
+            ],
+            commands: [
+              "winget install --id GitHub.cli -e",
+              "winget install --id Python.Python.3.11 -e",
+            ],
+          },
+          {
+            title: "Authenticate GitHub CLI",
+            body: [
+              "The browser-based login allows gh to download artifacts from private runs.",
+            ],
+            commands: ["gh auth login --web"],
+          },
+          {
+            title: "Create an images directory",
+            body: [
+              "Store downloads in {images_dir_windows}. Adjust the path if necessary.",
+            ],
+            commands: [
+              "New-Item -ItemType Directory -Path {images_dir_windows} -Force | Out-Null",
+            ],
+          },
+          {
+            title: "Download workflow artifacts",
+            body: [
+              "Download {artifact_name} from the workflow run into the staging directory.",
+            ],
+            commands: [
+              "gh run download {run_id} --repo {repository} --name {artifact_name} --dir {images_dir_windows}",
+              "Get-ChildItem {images_dir_windows}",
+            ],
+          },
+          {
+            title: "Verify checksum before flashing",
+            body: [
+              "Compare the published hash with a freshly computed value before writing media.",
+            ],
+            commands: [
+              "$expected = (Get-Content {checksum_path_windows}).Split()[0]",
+              "$actual = (Get-FileHash {image_path_windows} -Algorithm SHA256).Hash.ToLower()",
+              "if ($actual -ne $expected) {{ throw 'Checksum mismatch' }}",
+              "else {{ 'Checksum OK' }}",
+            ],
+          },
+          {
+            title: "Expand the compressed image",
+            body: [
+              "Use Python's built-in lzma module to expand {image_name} into {expanded_image_path_windows}.",
+            ],
+            commands: [
+              "python -c \"import lzma, pathlib, shutil; src = pathlib.Path(r'{image_path_windows_raw}'); dst = src.with_suffix(''); print(f'Expanding {{src.name}} -> {{dst.name}}'); with lzma.open(src, 'rb') as src_f, open(dst, 'wb') as dst_f: shutil.copyfileobj(src_f, dst_f)\"",
+            ],
+          },
+          {
+            title: "Flash removable media",
+            body: [
+              "Clone helpers if needed, then flash with the PowerShell wrapper. Replace X with the correct disk number from Get-Disk.",
+            ],
+            commands: [
+              "git clone https://github.com/futuroptimist/sugarkube.git  # Skip if cloned",
+              "Set-Location sugarkube",
+              "pwsh -File scripts/flash_pi_media.ps1 --image {expanded_image_path_windows} --device \\\\.\\\\PhysicalDriveX --assume-yes",
+            ],
+          },
+        ],
+      };
+
+      function parseWorkflowUrl(url) {
+        if (!url) {
+          throw new Error("Provide a GitHub Actions run URL.");
+        }
+        const trimmed = url.trim();
+        const patterns = [
+          /^https?:\/\/github.com\/(?<owner>[^/]+)\/(?<repo>[^/]+)\/actions\/runs\/(?<run_id>\d+)(?:\/attempts\/\d+)?(?:[/?#].*)?$/i,
+          /^https?:\/\/github.com\/(?<owner>[^/]+)\/(?<repo>[^/]+)\/actions\/workflows\/[^/]+\/runs\/(?<run_id>\d+)(?:\/attempts\/\d+)?(?:[/?#].*)?$/i,
+        ];
+        for (const pattern of patterns) {
+          const match = trimmed.match(pattern);
+          if (match && match.groups) {
+            return {
+              owner: match.groups.owner,
+              repo: match.groups.repo,
+              run_id: match.groups.run_id,
+              repository: `${match.groups.owner}/${match.groups.repo}`,
+              run_url: `https://github.com/${match.groups.owner}/${match.groups.repo}/actions/runs/${match.groups.run_id}`,
+            };
+          }
+        }
+        throw new Error(`Unrecognised workflow run URL: ${trimmed}`);
+      }
+
+      function contextFor(info) {
+        const imagesDirUnix = "~/sugarkube/images";
+        const imagesDirWindows = "$env:USERPROFILE\\sugarkube\\images";
+        return {
+          repository: info.repository,
+          run_id: info.run_id,
+          artifact_name: "sugarkube-pi-image",
+          image_name: "sugarkube.img.xz",
+          images_dir_unix: imagesDirUnix,
+          expanded_image_path_unix: `${imagesDirUnix}/sugarkube.img`,
+          images_dir_windows: imagesDirWindows,
+          image_path_windows: `${imagesDirWindows}\\sugarkube.img.xz`,
+          image_path_windows_raw: `${imagesDirWindows}\\sugarkube.img.xz`,
+          expanded_image_path_windows: `${imagesDirWindows}\\sugarkube.img`,
+          checksum_path_windows: `${imagesDirWindows}\\sugarkube.img.xz.sha256`,
+        };
+      }
+
+      const TOKEN_PATTERN = /\{([a-z0-9_]+)\}/gi;
+
+      function replaceTokens(value, context) {
+        return value.replace(TOKEN_PATTERN, (_, key) => context[key] ?? `{${key}}`);
+      }
+
+      function renderSteps(osKey, info) {
+        const templates = STEP_TEMPLATES[osKey];
+        if (!templates) {
+          throw new Error(`Unsupported OS: ${osKey}`);
+        }
+        const context = contextFor(info);
+        return templates.map((template) => ({
+          title: replaceTokens(template.title, context),
+          body: template.body.map((segment) => replaceTokens(segment, context)),
+          commands: template.commands.map((command) => replaceTokens(command, context)),
+        }));
+      }
+
+      function onSubmit(event) {
+        event.preventDefault();
+        const error = document.getElementById("error");
+        error.hidden = true;
+        try {
+          const url = document.getElementById("workflow-url").value;
+          const osKey = document.getElementById("os").value;
+          const info = parseWorkflowUrl(url);
+          const steps = renderSteps(osKey, info);
+          document.getElementById("results").hidden = false;
+          document.getElementById("meta-repo").textContent = `Repo: ${info.repository}`;
+          document.getElementById("meta-run").textContent = `Run: ${info.run_url}`;
+          document.getElementById("meta-platform").textContent = `Platform: ${OS_LABELS[osKey]}`;
+          const stepsContainer = document.getElementById("steps");
+          stepsContainer.replaceChildren();
+          steps.forEach((step, index) => {
+            const article = document.createElement("article");
+            article.className = "step";
+            const title = document.createElement("h3");
+            title.textContent = `${index + 1}. ${step.title}`;
+            article.appendChild(title);
+            step.body.forEach((paragraph) => {
+              const p = document.createElement("p");
+              p.textContent = paragraph;
+              article.appendChild(p);
+            });
+            if (step.commands.length) {
+              const pre = document.createElement("pre");
+              const code = document.createElement("code");
+              code.textContent = step.commands.join("\n");
+              pre.appendChild(code);
+              article.appendChild(pre);
+            }
+            stepsContainer.appendChild(article);
+          });
+        } catch (err) {
+          error.hidden = false;
+          error.textContent = err instanceof Error ? err.message : String(err);
+          document.getElementById("results").hidden = true;
+        }
+      }
+
+      document.getElementById("flash-form").addEventListener("submit", onSubmit);
+    </script>
+  </body>
+</html>

--- a/docs/pi_image_improvement_checklist.md
+++ b/docs/pi_image_improvement_checklist.md
@@ -186,7 +186,9 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
     plus link checks via `make doctor`.
 - [ ] Offer a `brew install sugarkube` tap and `sugarkube setup` wizard for macOS.
 - [ ] Package a cross-platform desktop notifier to alert when workflow artifacts are ready.
-- [ ] Serve a web UI (via GitHub Pages) where users paste a workflow URL and get direct flashing instructions tailored to OS.
+- [x] Serve a web UI (via GitHub Pages) where users paste a workflow URL and get direct flashing instructions tailored to OS.
+  - Added [Sugarkube Flash Helper](./flash-helper/) plus `scripts/workflow_flash_instructions.py`
+    so operators can generate identical guidance from the CLI or the published page.
 - [x] Add QR codes on physical `pi_carrier` hardware pointing to quickstart and troubleshooting docs.
   - `scripts/generate_qr_codes.py` now exports SVG stickers plus a manifest, and
     `make qr-codes`/`just qr-codes` regenerate them. `docs/pi_carrier_qr_labels.md`

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -43,6 +43,11 @@ scan straight to this quickstart or the troubleshooting matrix while standing at
 3. In GitHub, open **Actions → pi-image → Run workflow** for a fresh build.
    - Tick **token.place** and **dspace** to bake those repos into `/opt/projects`.
    - Wait for the run to finish; it uploads `sugarkube.img.xz` as an artifact.
+   - Need a guided path? Launch the [Sugarkube Flash Helper](./flash-helper/) and paste the
+     workflow URL to receive OS-specific download, verification, and flashing instructions. Prefer
+     the terminal? Run
+     `python scripts/workflow_flash_instructions.py --url <run-url> --os linux|mac|windows` from the
+     repository root to print the same steps.
    - `./scripts/download_pi_image.sh --output /your/path.img.xz` still resumes
      partial downloads and verifies checksums automatically.
 4. Alternatively, build on your machine:

--- a/scripts/workflow_flash_instructions.py
+++ b/scripts/workflow_flash_instructions.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Render OS-specific flashing instructions for GitHub Actions pi-image runs."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import re
+import sys
+from typing import Iterable
+
+
+class WorkflowFlashError(RuntimeError):
+    """Raised when workflow flashing instructions cannot be generated."""
+
+
+@dataclasses.dataclass(frozen=True)
+class WorkflowInfo:
+    owner: str
+    repo: str
+    run_id: str
+
+    @property
+    def repository(self) -> str:
+        return f"{self.owner}/{self.repo}"
+
+    @property
+    def run_url(self) -> str:
+        return f"https://github.com/{self.repository}/actions/runs/{self.run_id}"
+
+
+_RUN_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"^https?://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/actions/runs/"
+        r"(?P<run_id>\d+)(?:/attempts/\d+)?(?:[/?#].*)?$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^https?://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/actions/workflows/[^/]+/runs/"
+        r"(?P<run_id>\d+)(?:/attempts/\d+)?(?:[/?#].*)?$",
+        re.IGNORECASE,
+    ),
+)
+
+SUPPORTED_OS: dict[str, str] = {
+    "linux": "Linux",
+    "mac": "macOS",
+    "windows": "Windows",
+}
+
+_ARTIFACT_NAME = "sugarkube-pi-image"
+_IMAGE_NAME = "sugarkube.img.xz"
+
+_STEP_TEMPLATES: dict[str, tuple[dict[str, Iterable[str]], ...]] = {
+    "linux": (
+        {
+            "title": "Install GitHub CLI and utilities",
+            "body": ("Install the GitHub CLI plus tools required to verify and expand the image.",),
+            "commands": (
+                "sudo apt-get update",
+                "sudo apt-get install -y gh xz-utils coreutils",
+            ),
+        },
+        {
+            "title": "Authenticate GitHub CLI",
+            "body": ('Run the interactive login once so "gh" can download workflow artifacts.',),
+            "commands": ("gh auth login --web",),
+        },
+        {
+            "title": "Create an images directory",
+            "body": (
+                "Store the artifacts in a predictable path. Feel free to reuse an existing folder.",
+            ),
+            "commands": (
+                "mkdir -p {images_dir_unix}",
+                "cd {images_dir_unix}",
+            ),
+        },
+        {
+            "title": "Download release artifacts",
+            "body": (
+                "Fetch the {artifact_name} bundle from the workflow run. The helper also works for"
+                " private repositories once gh is authenticated.",
+            ),
+            "commands": (
+                "gh run download {run_id} --repo {repository} --name {artifact_name} --dir .",
+                "ls -l",
+            ),
+        },
+        {
+            "title": "Verify checksum before flashing",
+            "body": ("Always confirm the checksum matches to avoid flashing a corrupted image.",),
+            "commands": ("sha256sum -c {image_name}.sha256",),
+        },
+        {
+            "title": "Expand the compressed image",
+            "body": (
+                "Keep the original .xz file for future flashes. The command below expands it to"
+                " {expanded_image_path_unix}.",
+            ),
+            "commands": ("xz -dk {image_name}",),
+        },
+        {
+            "title": "Flash removable media",
+            "body": (
+                "Clone the repository if you have not already, then run the flashing helper with"
+                " sudo. Replace /dev/sdX with your target device.",
+            ),
+            "commands": (
+                "git clone https://github.com/futuroptimist/sugarkube.git  # Skip if cloned",
+                "cd sugarkube",
+                (
+                    "sudo ./scripts/flash_pi_media.sh --image {expanded_image_path_unix} "
+                    "--device /dev/sdX --assume-yes"
+                ),
+            ),
+        },
+    ),
+    "mac": (
+        {
+            "title": "Install GitHub CLI and dependencies",
+            "body": (
+                "Use Homebrew to install the tooling required to download, verify, and expand the"
+                " image.",
+            ),
+            "commands": (
+                "brew update",
+                "brew install gh xz coreutils",
+            ),
+        },
+        {
+            "title": "Authenticate GitHub CLI",
+            "body": ("Log in once via the browser to access private workflow artifacts.",),
+            "commands": ("gh auth login --web",),
+        },
+        {
+            "title": "Prepare the images directory",
+            "body": (
+                "All artifacts are saved to {images_dir_unix}. Adjust the path if you prefer a"
+                " different location.",
+            ),
+            "commands": (
+                "mkdir -p {images_dir_unix}",
+                "cd {images_dir_unix}",
+            ),
+        },
+        {
+            "title": "Download workflow artifacts",
+            "body": (
+                "Download the {artifact_name} archive that contains the image, checksums, and"
+                " provenance metadata.",
+            ),
+            "commands": (
+                "gh run download {run_id} --repo {repository} --name {artifact_name} --dir .",
+                "ls -lh",
+            ),
+        },
+        {
+            "title": "Verify checksum before flashing",
+            "body": (
+                "Confirm the SHA-256 hash matches the published value to guard against corruption.",
+            ),
+            "commands": ("shasum -a 256 -c {image_name}.sha256",),
+        },
+        {
+            "title": "Expand the compressed image",
+            "body": (
+                "Retain {image_name} for reuse. The following command expands it into"
+                " {expanded_image_path_unix}.",
+            ),
+            "commands": ("xz -dk {image_name}",),
+        },
+        {
+            "title": "Flash the target disk",
+            "body": (
+                "Clone the helpers if needed, unmount the removable disk (diskutil list →"
+                " diskutil unmountDisk), then flash it with sudo.",
+            ),
+            "commands": (
+                "git clone https://github.com/futuroptimist/sugarkube.git  # Skip if cloned",
+                "cd sugarkube",
+                (
+                    "sudo ./scripts/flash_pi_media.sh --image {expanded_image_path_unix} "
+                    "--device /dev/diskX --assume-yes"
+                ),
+            ),
+        },
+    ),
+    "windows": (
+        {
+            "title": "Install GitHub CLI and Python",
+            "body": (
+                "Use winget to install the GitHub CLI plus Python for checksum verification and"
+                " decompression.",
+            ),
+            "commands": (
+                "winget install --id GitHub.cli -e",
+                "winget install --id Python.Python.3.11 -e",
+            ),
+        },
+        {
+            "title": "Authenticate GitHub CLI",
+            "body": ("The browser-based login allows gh to download artifacts from private runs.",),
+            "commands": ("gh auth login --web",),
+        },
+        {
+            "title": "Create an images directory",
+            "body": ("Store downloads in {images_dir_windows}. Adjust the path if necessary.",),
+            "commands": (
+                "New-Item -ItemType Directory -Path {images_dir_windows} -Force | Out-Null",
+            ),
+        },
+        {
+            "title": "Download workflow artifacts",
+            "body": ("Download {artifact_name} from the workflow run into the staging directory.",),
+            "commands": (
+                (
+                    "gh run download {run_id} --repo {repository} --name {artifact_name} "
+                    "--dir {images_dir_windows}"
+                ),
+                "Get-ChildItem {images_dir_windows}",
+            ),
+        },
+        {
+            "title": "Verify checksum before flashing",
+            "body": (
+                "Compare the published hash with a freshly computed value before writing media.",
+            ),
+            "commands": (
+                "$expected = (Get-Content {checksum_path_windows}).Split()[0]",
+                (
+                    "$actual = (Get-FileHash {image_path_windows} "
+                    "-Algorithm SHA256).Hash.ToLower()"
+                ),
+                "if ($actual -ne $expected) {{ throw 'Checksum mismatch' }}",
+                "else {{ 'Checksum OK' }}",
+            ),
+        },
+        {
+            "title": "Expand the compressed image",
+            "body": (
+                "Use Python's built-in lzma module to expand {image_name} into"
+                " {expanded_image_path_windows}.",
+            ),
+            "commands": (
+                (
+                    'python -c "import lzma, pathlib, shutil; '
+                    "src = pathlib.Path(r'{image_path_windows_raw}'); "
+                    "dst = src.with_suffix(''); "
+                    "print(f'Expanding {{src.name}} -> {{dst.name}}'); "
+                    "with lzma.open(src, 'rb') as src_f, open(dst, 'wb') as dst_f: "
+                    'shutil.copyfileobj(src_f, dst_f)"'
+                ),
+            ),
+        },
+        {
+            "title": "Flash removable media",
+            "body": (
+                "Clone helpers if needed, then flash with the PowerShell wrapper."
+                " Replace X with the correct disk number from Get-Disk.",
+            ),
+            "commands": (
+                "git clone https://github.com/futuroptimist/sugarkube.git  # Skip if cloned",
+                "Set-Location sugarkube",
+                (
+                    "pwsh -File scripts/flash_pi_media.ps1 --image {expanded_image_path_windows}"
+                    " --device \\\\.\\PhysicalDriveX --assume-yes"
+                ),
+            ),
+        },
+    ),
+}
+
+
+def parse_workflow_url(url: str) -> WorkflowInfo:
+    """Return workflow metadata extracted from a GitHub Actions run URL."""
+    if not url or not url.strip():
+        raise WorkflowFlashError("Provide a GitHub Actions run URL.")
+
+    trimmed = url.strip()
+    for pattern in _RUN_PATTERNS:
+        match = pattern.match(trimmed)
+        if match:
+            owner = match.group("owner")
+            repo = match.group("repo")
+            run_id = match.group("run_id")
+            return WorkflowInfo(owner=owner, repo=repo, run_id=run_id)
+
+    raise WorkflowFlashError(f"Unrecognised workflow run URL: {trimmed}")
+
+
+def _context_for(info: WorkflowInfo) -> dict[str, str]:
+    images_dir_unix = "~/sugarkube/images"
+    images_dir_windows = "$env:USERPROFILE\\sugarkube\\images"
+    expanded_image_path_unix = f"{images_dir_unix}/sugarkube.img"
+    image_path_windows = f"{images_dir_windows}\\sugarkube.img.xz"
+    expanded_image_path_windows = f"{images_dir_windows}\\sugarkube.img"
+
+    return {
+        "repository": info.repository,
+        "run_id": info.run_id,
+        "run_url": info.run_url,
+        "artifact_name": _ARTIFACT_NAME,
+        "image_name": _IMAGE_NAME,
+        "images_dir_unix": images_dir_unix,
+        "expanded_image_path_unix": expanded_image_path_unix,
+        "images_dir_windows": images_dir_windows,
+        "image_path_windows": image_path_windows,
+        "image_path_windows_raw": image_path_windows,
+        "expanded_image_path_windows": expanded_image_path_windows,
+        "checksum_path_windows": f"{images_dir_windows}\\{_IMAGE_NAME}.sha256",
+    }
+
+
+def instructions_for(os_key: str, info: WorkflowInfo) -> list[dict[str, list[str]]]:
+    """Return rendered instruction steps for the requested OS."""
+    if os_key not in SUPPORTED_OS:
+        supported = ", ".join(sorted(SUPPORTED_OS))
+        raise WorkflowFlashError(f"Unsupported OS '{os_key}'. Supported values: {supported}")
+
+    context = _context_for(info)
+    steps: list[dict[str, list[str]]] = []
+    for template in _STEP_TEMPLATES[os_key]:
+        step = {
+            "title": template["title"].format_map(context),
+            "body": [segment.format_map(context) for segment in template.get("body", ())],
+            "commands": [cmd.format_map(context) for cmd in template.get("commands", ())],
+        }
+        steps.append(step)
+    return steps
+
+
+def render_text(os_key: str, info: WorkflowInfo) -> str:
+    """Render human-readable instructions."""
+    steps = instructions_for(os_key, info)
+    lines: list[str] = [
+        f"Repository : {info.repository}",
+        f"Run URL    : {info.run_url}",
+        f"Platform   : {SUPPORTED_OS[os_key]}",
+        "",
+    ]
+
+    for index, step in enumerate(steps, start=1):
+        lines.append(f"{index}. {step['title']}")
+        for paragraph in step["body"]:
+            lines.append(f"   {paragraph}")
+        if step["commands"]:
+            lines.append("   Commands:")
+            for command in step["commands"]:
+                lines.append(f"     {command}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate OS-specific flashing instructions for a sugarkube pi-image workflow run."
+        )
+    )
+    parser.add_argument("--url", required=True, help="GitHub Actions run URL")
+    parser.add_argument(
+        "--os",
+        required=True,
+        choices=sorted(SUPPORTED_OS),
+        help="Target operating system (linux, mac, windows)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (text or json)",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        info = parse_workflow_url(args.url)
+        if args.format == "json":
+            payload = {
+                "workflow": dataclasses.asdict(info),
+                "platform": {
+                    "key": args.os,
+                    "label": SUPPORTED_OS[args.os],
+                },
+                "steps": instructions_for(args.os, info),
+            }
+            json.dump(payload, sys.stdout, indent=2)
+            sys.stdout.write("\n")
+        else:
+            sys.stdout.write(render_text(args.os, info))
+    except WorkflowFlashError as exc:
+        parser.print_usage(sys.stderr)
+        parser.exit(2, f"{parser.prog}: error: {exc}\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/test_workflow_flash_instructions.py
+++ b/tests/test_workflow_flash_instructions.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "scripts" / "workflow_flash_instructions.py"
+SPEC = importlib.util.spec_from_file_location("workflow_flash_instructions", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        (
+            "https://github.com/futuroptimist/sugarkube/actions/runs/123456789",
+            MODULE.WorkflowInfo("futuroptimist", "sugarkube", "123456789"),
+        ),
+        (
+            "https://github.com/futuroptimist/sugarkube/actions/runs/987654321/attempts/3",
+            MODULE.WorkflowInfo("futuroptimist", "sugarkube", "987654321"),
+        ),
+        (
+            "https://github.com/futuroptimist/sugarkube/actions/workflows/"
+            "pi-image-release.yml/runs/555",
+            MODULE.WorkflowInfo("futuroptimist", "sugarkube", "555"),
+        ),
+    ],
+)
+def test_parse_workflow_url_variants(url: str, expected: MODULE.WorkflowInfo) -> None:
+    assert MODULE.parse_workflow_url(url) == expected
+
+
+def test_parse_workflow_url_rejects_invalid() -> None:
+    with pytest.raises(MODULE.WorkflowFlashError):
+        MODULE.parse_workflow_url("")
+    with pytest.raises(MODULE.WorkflowFlashError):
+        MODULE.parse_workflow_url("https://example.com/not-a-run")
+
+
+@pytest.mark.parametrize("os_key", ["linux", "mac", "windows"])
+def test_instructions_include_run_id(os_key: str) -> None:
+    info = MODULE.WorkflowInfo("owner", "repo", "111")
+    steps = MODULE.instructions_for(os_key, info)
+    flattened = "\n".join(
+        [line for step in steps for line in ([step["title"], *step["body"], *step["commands"]])]
+    )
+    assert "111" in flattened
+    assert "owner/repo" in MODULE.render_text(os_key, info)
+
+
+def test_instructions_reject_unknown_os() -> None:
+    info = MODULE.WorkflowInfo("owner", "repo", "111")
+    with pytest.raises(MODULE.WorkflowFlashError):
+        MODULE.instructions_for("solaris", info)
+
+
+def test_render_text_orders_steps() -> None:
+    info = MODULE.WorkflowInfo("owner", "repo", "222")
+    text = MODULE.render_text("linux", info)
+    lines = text.splitlines()
+    first_step = next(line for line in lines if line.startswith("1. "))
+    assert first_step.startswith("1. ")
+    assert "Platform   :" in text
+
+
+def test_main_json_output(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = MODULE.main(
+        [
+            "--url",
+            "https://github.com/futuroptimist/sugarkube/actions/runs/222",
+            "--os",
+            "linux",
+            "--format",
+            "json",
+        ]
+    )
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["workflow"]["run_id"] == "222"
+    assert payload["platform"]["key"] == "linux"
+    assert payload["steps"]
+
+
+def test_main_text_output(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = MODULE.main(
+        [
+            "--url",
+            "https://github.com/futuroptimist/sugarkube/actions/runs/333",
+            "--os",
+            "mac",
+        ]
+    )
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Run URL" in captured.out
+    assert "Platform" in captured.out
+
+
+def test_main_reports_errors(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        MODULE.main(
+            [
+                "--url",
+                "not-a-url",
+                "--os",
+                "linux",
+            ]
+        )
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "error" in captured.err.lower()


### PR DESCRIPTION
## Summary
- exercise workflow_flash_instructions.main directly in pytest to cover argparse setup and error paths
- capture stdout/stderr via capsys to validate JSON, text, and failure flows without subprocesses

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- pytest tests/test_workflow_flash_instructions.py

------
https://chatgpt.com/codex/tasks/task_e_68d1c9bd72e8832f94cb615295da9433