### PR TITLE
🗂️ : – archive pi checklist and tutorials roadmap

### DIFF
--- a/docs/archived/pi_image_improvement_checklist.md
+++ b/docs/archived/pi_image_improvement_checklist.md
@@ -100,7 +100,7 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
     workflow in `docs/ssd_recovery.md` with dry-run guidance and report expectations.
 - [x] Offer an opt-in SSD health monitor (SMART/wear checks).
   - Added `scripts/ssd_health_monitor.py`, Makefile/just wrappers, and
-    [`SSD Health Monitor`](./ssd_health_monitor.md) docs covering manual runs and an optional
+    [`SSD Health Monitor`](../ssd_health_monitor.md) docs covering manual runs and an optional
     systemd timer for recurring SMART snapshots.
 
 ---
@@ -123,14 +123,14 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
     install Helm, read `/etc/sugarkube/helm-bundles.d/*.env`, run `helm upgrade --install --atomic`,
     and bail out through the self-heal unit when rollouts or health probes fail. Markdown reports
     now land under `/boot/first-boot-report/helm-bundles/` for air-gapped debugging, and the
-    workflow is documented in [Sugarkube Helm Bundle Hooks](./pi_helm_bundles.md).
+    workflow is documented in [Sugarkube Helm Bundle Hooks](../pi_helm_bundles.md).
 - [x] Bundle sample datasets and token.place collections for first-launch validation.
   - Added `samples/token_place/` plus a replay helper that the image copies into
     `/opt/sugarkube/` and `/opt/projects/token.place/` so first boot can confirm
     health, model listings, and chat completions with a single command.
 - [x] Document and script multi-node join rehearsal for scaling clusters.
   - Added `scripts/pi_multi_node_join_rehearsal.py`, `make rehearse-join`/`just rehearse-join`
-    wrappers, and the [Pi Multi-Node Join Rehearsal](./pi_multi_node_join_rehearsal.md) guide to
+    wrappers, and the [Pi Multi-Node Join Rehearsal](../pi_multi_node_join_rehearsal.md) guide to
     walk operators through join-secret retrieval and agent preflight checks.
 - [x] Store kubeconfig (sanitized) in `/boot/sugarkube-kubeconfig` for retrieval without SSH.
   - Added `scripts/cloud-init/export-kubeconfig.sh`, installed during image builds and invoked by
@@ -158,7 +158,7 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
     emitting JSON summaries for CI pipelines.
 - [x] Capture support bundles (`kubectl get events`, `helm list`, `systemd-analyze blame`, Compose logs, journal slices) for every pipeline run.
   - Added `scripts/collect_support_bundle.py` plus `make`/`just support-bundle` wrappers and wired
-    the release workflow to archive bundles (documented in [Pi Support Bundles](./pi_support_bundles.md)).
+    the release workflow to archive bundles (documented in [Pi Support Bundles](../pi_support_bundles.md)).
 - [x] Document how to run integration tests locally via `act`.
   - `docs/pi_image_builder_design.md` now includes a quick recipe for dry-running the release workflow with `act`.
 - [x] Publish a conformance badge in the README showing last successful hardware boot.
@@ -167,7 +167,7 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
 
 ## Documentation & Onboarding
 - [x] Merge fragmented docs (`pi_image_quickstart.md`, `pi_image_builder_design.md`, `pi_image_cloudflare.md`, `raspi_cluster_setup.md`, etc.) into a single end-to-end “Pi Carrier Launch Playbook.”
-  - Added [Pi Carrier Launch Playbook](./pi_carrier_launch_playbook.md) and linked it from the
+  - Added [Pi Carrier Launch Playbook](../pi_carrier_launch_playbook.md) and linked it from the
     quickstart and README.
 - [x] Structure guide with:
   - A 10-minute fast path.
@@ -176,7 +176,7 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
   - Implemented within the new playbook alongside cross-links back to detailed
     references.
 - [x] Include a printable one-page field guide/checklist (PDF) with commands, expected outputs, LED/status reference, and troubleshooting links.
-  - Added [Pi Carrier Field Guide](./pi_carrier_field_guide.md) with a companion PDF renderer
+  - Added [Pi Carrier Field Guide](../pi_carrier_field_guide.md) with a companion PDF renderer
     (`scripts/render_field_guide_pdf.py`) plus quickstart/README links so a single sheet stays
     in sync with tooling expectations at the workbench.
 - [ ] Embed GIFs, screencasts, or narrated clips showing download → flash → first boot → SSD clone → k3s readiness.
@@ -185,7 +185,7 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
   - Added `docs/pi_boot_troubleshooting.md` plus quickstart references covering
     LED cues, critical commands, and recovery steps.
 - [x] Publish contributor guide mapping automation scripts to docs; enforce sync with linkchecker and spellchecker.
-  - Added [Pi Image Contributor Guide](./pi_image_contributor_guide.md) mapping automation helpers to their
+  - Added [Pi Image Contributor Guide](../pi_image_contributor_guide.md) mapping automation helpers to their
     documentation and introduced `make docs-verify`/`just docs-verify` wrappers to run spellcheck and
     link-check together.
 
@@ -202,10 +202,10 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
   - Added `scripts/workflow_artifact_notifier.py`, a GitHub CLI-backed poller exposed via
     `make notify-workflow` / `just notify-workflow` that posts native notifications on Linux, macOS,
     and Windows (with console fallbacks) when release artifacts finish uploading. Documented in
-    [Sugarkube Workflow Artifact Notifications](./pi_workflow_notifications.md) with 100% patch
+    [Sugarkube Workflow Artifact Notifications](../pi_workflow_notifications.md) with 100% patch
     coverage guaranteed by `tests/test_workflow_artifact_notifier.py`.
 - [x] Serve a web UI (via GitHub Pages) where users paste a workflow URL and get direct flashing instructions tailored to OS.
-  - Added [Sugarkube Flash Helper](./flash-helper/) plus `scripts/workflow_flash_instructions.py`
+  - Added [Sugarkube Flash Helper](../flash-helper/) plus `scripts/workflow_flash_instructions.py`
     so operators can generate identical guidance from the CLI or the published page.
 - [x] Add QR codes on physical `pi_carrier` hardware pointing to quickstart and troubleshooting docs.
   - `scripts/generate_qr_codes.py` now exports SVG stickers plus a manifest, and
@@ -216,7 +216,7 @@ The `pi_carrier` cluster should feel "plug in and go." This checklist combines a
 - [x] Provide optional `sugarkube-teams` webhook that posts boot/clone progress to Slack or Matrix for remote monitoring.
   - Added `scripts/sugarkube_teams.py`, systemd integrations in `first_boot_service.py` and
     `ssd_clone_service.py`, a `/usr/local/bin/sugarkube-teams` CLI, Makefile/justfile wrappers, and
-    the [Sugarkube Team Notifications](./pi_image_team_notifications.md) guide covering Slack/Matrix
+    the [Sugarkube Team Notifications](../pi_image_team_notifications.md) guide covering Slack/Matrix
     setup and troubleshooting.
 
 ---

--- a/docs/archived/prompt-pi-image-improvement-checklist.md
+++ b/docs/archived/prompt-pi-image-improvement-checklist.md
@@ -19,9 +19,9 @@ CONTEXT:
 - Review the checklist in [`docs/pi_image_improvement_checklist.md`](./pi_image_improvement_checklist.md)
   and pick one actionable item.
 - Inspect related guides and scripts such as
-  [`docs/pi_image_quickstart.md`](./pi_image_quickstart.md), [`scripts/`](../scripts/), and the
-  root [`Makefile`](../Makefile) to understand current behavior.
-- Follow [`AGENTS.md`](../AGENTS.md) and repository conventions in [`README.md`](../README.md).
+  [`docs/pi_image_quickstart.md`](../pi_image_quickstart.md), [`scripts/`](../../scripts/), and the
+  root [`Makefile`](../../Makefile) to understand current behavior.
+- Follow [`AGENTS.md`](../../AGENTS.md) and repository conventions in [`README.md`](../../README.md).
 - Before committing, run:
   - `pre-commit run --all-files`
   - `pyspelling -c .spellcheck.yaml`
@@ -63,9 +63,9 @@ CONTEXT:
 - Review the prompt text directly above this one and ensure it is accurate, actionable, and
   aligned with the checklist workflow.
 - Cross-check supporting docs and automation referenced in that prompt (for example,
-  [`docs/pi_image_quickstart.md`](./pi_image_quickstart.md), [`scripts/`](../scripts/), and the root
-  [`Makefile`](../Makefile)).
-- Follow [`AGENTS.md`](../AGENTS.md) and repository conventions in [`README.md`](../README.md).
+  [`docs/pi_image_quickstart.md`](../pi_image_quickstart.md), [`scripts/`](../../scripts/), and the root
+  [`Makefile`](../../Makefile)).
+- Follow [`AGENTS.md`](../../AGENTS.md) and repository conventions in [`README.md`](../../README.md).
 - Before committing, run:
   - `pre-commit run --all-files`
   - `pyspelling -c .spellcheck.yaml`

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,0 +1,38 @@
+# Sugarkube Backlog
+
+The comprehensive Pi image improvement checklist now lives in [`docs/archived/pi_image_improvement_checklist.md`](./archived/pi_image_improvement_checklist.md).
+This backlog captures the remaining high-effort work that still requires dedicated time, specialized
+hardware, or multimedia production. Each section is written so it can be linked directly from a
+GitHub issue when we are ready to tackle that initiative.
+
+## Hardware-in-the-Loop Test Bench
+
+We still need a fully automated validation rig that can exercise real Raspberry Pi hardware. The
+bench should combine a USB-controllable PDU for power cycling, HDMI capture so we can archive boot
+output, and a serial console for kernel logs. It must orchestrate image flashing, boot verification,
+telemetry collection, and regression reporting so nightly builds prove the cluster survives real
+world reboots. Capturing wiring diagrams, bill of materials, and control software (likely a Python
+harness that drives the PDU, capture card, and USB-UART) is essential so contributors can reproduce
+the setup in other labs. Success criteria include publishing captured logs as CI artifacts and
+raising automated GitHub issues when a build fails physical validation.
+
+## End-to-End Walkthrough Media
+
+The written guides are complete, but the docs still lack narrated visuals that demonstrate the full
+journey from download to k3s readiness. We need a script, screen captures, and optionally voiceover
+that cover every milestone: grabbing the latest release, flashing removable media, first boot
+validation, SSD migration, verifier runs, and post-clone health checks. The production plan should
+include tooling choices (e.g., OBS, ffmpeg, or Descript), storage for raw footage, and an editing
+workflow that keeps future refreshes efficient. Deliverables are GIFs for quick-start embeds, a full
+narrated demo hosted on a streaming platform, and short clips that can be sprinkled throughout
+playbooks for contextual help.
+
+## Golden Recovery Console Image
+
+Operators still need a fall-back environment they can boot when a cluster becomes unrecoverable. The
+goal is to publish a lightweight rescue image or partition that bundles reflashing utilities,
+network diagnostics, kubeconfig retrieval helpers, and shortcuts for reinstalling k3s. Scoping this
+project involves defining supported hardware, ensuring secure defaults (no embedded secrets), and
+writing automation to build and release the artifact alongside the primary Pi image. Documentation
+must explain how to switch into the rescue environment, capture support bundles, and return to a
+healthy state once repairs are complete.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ Review the safety notes before working with power components.
 - [pi_image_team_notifications.md](pi_image_team_notifications.md) — optional Slack/Matrix progress
   notifications for first boot and SSD cloning
 - [pi_image_cloudflare.md](pi_image_cloudflare.md) — preconfigure Docker and Cloudflare tunnels
-- [pi_image_improvement_checklist.md](pi_image_improvement_checklist.md) — backlog of DX upgrades for the Pi image
+- [archived/pi_image_improvement_checklist.md](archived/pi_image_improvement_checklist.md) — backlog of DX upgrades for the Pi image
 - [ssd_post_clone_validation.md](ssd_post_clone_validation.md) — validate SSD clones post-migration
 - [raspi_cluster_setup.md](raspi_cluster_setup.md) — build a three-node k3s cluster and deploy apps
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,247 @@
+# Sugarkube Tutorial Roadmap
+
+Sugarkube combines hardware, software, and operational practices into a cohesive home-lab scale
+platform. This roadmap outlines the tutorials we plan to write, sequenced so a newcomer with no prior
+technical background can progress from first principles to confidently maintaining and extending the
+platform. Each entry will eventually become its own standalone guide; for now, the descriptions below
+capture the narrative arc, learning goals, and practical exercises we intend to include.
+
+## Tutorial 1: Computing Foundations Without Jargon
+
+We start by explaining the core ideas behind computers—what a CPU, memory, and storage device do—and
+how those pieces collaborate to run everyday applications. The tutorial will rely on real-world
+analogies rather than acronyms, making sure readers feel comfortable with concepts like files,
+processes, and networks. Hands-on moments will include exploring a Raspberry Pi diagram and
+identifying each component, setting expectations for how delicate hardware should be handled, and
+highlighting basic electrical safety tips before we ever plug anything in.
+
+The second half introduces operating systems at a conceptual level. We will cover why Linux is a good
+fit for Sugarkube, what distinguishes it from Windows or macOS, and how the command line empowers
+automation. Readers will perform a guided exercise using an online Linux sandbox to navigate
+directories, run simple commands, and begin building muscle memory with shell prompts.
+
+### Milestones
+
+1. Tour real hardware: label Pi components, document safety notes, and assemble a static-safe
+   workstation.
+2. Practice in a browser sandbox: run file inspection commands, create directories, and capture the
+   transcript for later reference.
+3. Summarize key terms in a shared glossary so future tutorials can link to an agreed vocabulary.
+
+## Tutorial 2: Navigating Linux and the Terminal
+
+This tutorial deepens shell skills by introducing the filesystem hierarchy, package managers, and
+text editors. We will demystify permissions, explain why `sudo` needs to be respected, and teach
+problem solving strategies like reading manual pages. Exercises will have learners install tools,
+inspect running processes, and manipulate files so they feel confident when instructions mention
+commands later in the series.
+
+We will close with a primer on scripting fundamentals. Readers will write a short Bash script that
+prints status information, discuss the difference between scripts and interactive commands, and learn
+how to document their work using Markdown so future collaborators can follow along.
+
+### Milestones
+
+1. Build a "day in the life" command map that documents filesystem, package, and editor workflows.
+2. Complete a permissions troubleshooting lab where a mock service fails until modes and owners are
+   corrected.
+3. Script a reusable status report, publish it to a gist or repository, and request feedback from a
+   peer.
+
+## Tutorial 3: Networking and the Internet Basics
+
+Sugarkube relies on reliable networking, so we dedicate a tutorial to the fundamentals. We will
+introduce IP addresses, DNS, routing, and ports, using diagrams that connect home router concepts to
+Kubernetes services. Readers will experiment with diagnostic tools like `ping`, `traceroute`, and
+`curl` against public endpoints, learning how to interpret latency, packet loss, and HTTP status
+codes.
+
+The second half bridges networking theory with Sugarkube needs. Learners will review how Raspberry
+Pis connect over Ethernet or Wi-Fi, how VLANs and subnets can segregate lab traffic, and what it means
+to expose services securely. The tutorial will set expectations for the network configuration tasks
+they will perform in later guides, including firewall adjustments and static DHCP reservations.
+
+### Milestones
+
+1. Diagram a home network, annotate IP ranges, and mark where Sugarkube gear will connect.
+2. Run latency and bandwidth measurements between two devices, interpret results, and record them in
+   a lab notebook.
+3. Configure a sample firewall rule or router reservation in a simulator to cement networking
+   vocabulary.
+
+## Tutorial 4: Version Control and Collaboration Fundamentals
+
+Before touching the Sugarkube repository, readers need to understand Git and GitHub. This tutorial
+walks through initializing repositories, making commits, branching, and submitting pull requests. We
+will emphasize commit hygiene, writing descriptive messages, and reviewing diffs with confidence.
+Interactive labs will have learners fork a practice repo, open a documentation fix, and respond to
+review feedback.
+
+We also explain how Sugarkube uses automation bots, continuous integration, and the AGENTS.md
+workflow. By the end, readers will know which checks to run locally, how to interpret CI failures, and
+where to find contribution guidelines for both code and documentation changes.
+
+### Milestones
+
+1. Fork and clone a sandbox repository, open a pull request, and request review from a partner.
+2. Resolve a simulated merge conflict while keeping commit history clean and well described.
+3. Document the CI workflow they executed, including which checks ran locally versus in the cloud.
+
+## Tutorial 5: Programming for Operations with Python and Bash
+
+With collaboration basics covered, we introduce lightweight programming tailored to Sugarkube scripts.
+The tutorial will contrast Bash and Python, explaining when each is preferred and how they interact
+with system utilities. Learners will dissect existing helper scripts, annotate them for clarity, and
+extend small examples to reinforce concepts like functions, loops, and environment variables.
+
+We conclude by demonstrating how to set up a Python virtual environment, install dependencies with
+`pip`, and run unit tests. The exercises will prepare readers to modify Sugarkube automation without
+fear of breaking packaging or linting rules.
+
+### Milestones
+
+1. Instrument an existing script with logging statements, then run it to observe and interpret output.
+2. Write a small Python helper that wraps a CLI command, ship it with tests, and lint it using
+   `pre-commit`.
+3. Publish a troubleshooting guide documenting errors encountered and how they were resolved.
+
+## Tutorial 6: Raspberry Pi Hardware and Power Design
+
+This tutorial returns to hardware, giving a guided tour of the Sugarkube enclosure, power regulation,
+and accessory boards. Readers will learn how to select microSD cards and SSDs, identify compatible USB
+to serial adapters, and respect thermal and electrical constraints. We will cover cable management,
+mounting considerations, and best practices for handling ribbon cables and GPIO headers.
+
+Hands-on sections will include assembling a mock Pi stack, routing power through recommended hubs,
+and verifying voltage with a multimeter. We will emphasize safety, documenting any optional tools or
+fixtures that can simplify the build process for classroom or maker-space deployments.
+
+### Milestones
+
+1. Assemble the enclosure using a build checklist and record a time-lapse or photo log for reference.
+2. Perform voltage and continuity checks with a multimeter, logging expected versus measured values.
+3. Stress-test thermal management with a controlled workload and document mitigation strategies.
+
+## Tutorial 7: Kubernetes and Container Fundamentals
+
+Before tackling Sugarkube-specific automation, learners need to understand the orchestration layer.
+We will explain containers, images, pods, deployments, and services, using diagrams and analogies that
+don't assume prior DevOps knowledge. Readers will use `kind` or `k3d` on their workstation to deploy a
+sample application, scale it, and observe how Kubernetes maintains desired state.
+
+The tutorial will then map those ideas to Sugarkube. We will preview the workloads shipped on the Pi
+image, explain why k3s was chosen, and show how Helm charts bundle configuration. Exercises will have
+learners inspect manifests, modify a value, and watch the resulting rollout from `kubectl`.
+
+### Milestones
+
+1. Launch a local Kubernetes cluster, deploy a sample app, and scale it while observing pod churn.
+2. Customize a Helm values file, upgrade the release, and capture before/after resource footprints.
+3. Simulate a failure by deleting a pod and verifying self-healing while narrating the reconciliation
+   loop.
+
+## Tutorial 8: Preparing a Sugarkube Development Environment
+
+Now that the foundational pieces are in place, we describe how to clone the repository, install
+prerequisites, and run project automation locally. This tutorial will guide readers through the
+`justfile` and `Makefile`, demonstrate how to run `pre-commit`, and explain the purpose of each script
+under `scripts/`. We will also cover managing secrets using `.env` files, GitHub CLI authentication,
+and the layout of build artifacts on disk.
+
+To reinforce the workflow, learners will perform a dry-run image download, execute the verifier in a
+container, and interpret the resulting reports. The exercises will highlight common pitfalls, like
+stale virtual environments or missing system packages, and document troubleshooting steps.
+
+### Milestones
+
+1. Clone the repository, bootstrap tooling with `just` or `make`, and confirm all local checks pass.
+2. Create a personal runbook describing credential management, secrets handling, and directory layout.
+3. Record a screen-captured walkthrough that future contributors can replay while setting up.
+
+## Tutorial 9: Building and Flashing the Sugarkube Pi Image
+
+This tutorial provides an end-to-end walkthrough of generating the Pi image. We will explain the
+pi-gen stages we customize, how configuration overlays are applied, and where build metadata is
+recorded. Learners will run the build locally or via GitHub Actions, monitor progress, and collect the
+resulting artifacts for inspection.
+
+With an image in hand, the guide transitions into flashing workflows. We will compare the CLI helper,
+PowerShell wrapper, and Raspberry Pi Imager presets, ensuring readers know how to verify checksums and
+handle common flashing errors. By the end, they will have a bootable SD card or SSD ready for the next
+tutorial.
+
+### Milestones
+
+1. Execute a full image build, archive the artifacts, and summarize build metadata in a changelog.
+2. Flash the image using two distinct methods, validate checksums, and log any deviations encountered.
+3. Share a templated flashing checklist that can be reused by teammates or classroom cohorts.
+
+## Tutorial 10: First Boot, Verification, and Self-Healing
+
+Here we detail what happens the first time a Sugarkube Pi boots. Learners will explore `first_boot_service.py`,
+understand the generated reports, and practice interpreting logs under `/boot/first-boot-report/`.
+Step-by-step exercises will validate k3s readiness, confirm token.place and dspace health, and trigger
+the self-healing services to see how automated recovery behaves.
+
+We will also demonstrate retrieving kubeconfig and other artifacts without SSH, showing how the
+workflow supports classroom or remote deployments. Troubleshooting scenarios will teach learners how
+to respond when services fail, encouraging them to gather support bundles before escalating issues.
+
+### Milestones
+
+1. Boot the Pi, collect first-boot reports, and annotate them with commentary on expected behaviors.
+2. Run the verification suite, remediate any failures, and track actions in an incident log.
+3. Publish a resilience drill that intentionally restarts services and documents recovery timelines.
+
+## Tutorial 11: Storage Migration and Long-Term Maintenance
+
+This tutorial covers SSD cloning, validation, and rollback strategies. Readers will execute the
+`ssd_clone.py` helper, review generated reports, and run the health monitor to gauge drive longevity.
+We will cover backup strategies, log rotation, and proactive maintenance tasks like updating Helm
+bundles or applying OS patches.
+
+The second half explores telemetry and observability. Learners will enable optional metrics exporters,
+integrate dashboards, and configure remote notifications so they stay ahead of failures. We will also
+share best practices for documenting maintenance windows and communicating status to collaborators.
+
+### Milestones
+
+1. Execute an SSD migration in a lab environment, validate clone integrity, and draft a rollback plan.
+2. Configure backup jobs, verify restore procedures, and capture screenshots or logs as evidence.
+3. Deploy observability tools, define alert thresholds, and test notification pathways end to end.
+
+## Tutorial 12: Contributing New Features and Automation
+
+Once readers can operate Sugarkube, we show them how to extend it. The tutorial will highlight the
+pi-image release workflow, explain how to design checklist-driven improvements, and teach strategies
+for writing tests before shipping changes. Learners will practice updating documentation, adding
+scripts, and verifying everything with local CI commands before opening a pull request.
+
+We conclude with guidance on reviewing contributions from others, triaging issues, and planning larger
+initiatives. By reinforcing collaborative habits, we ensure the community can keep the platform
+healthy as it evolves.
+
+### Milestones
+
+1. Draft a feature proposal, break it into issues, and align milestones with community priorities.
+2. Implement a small automation improvement, validate it with tests, and shepherd the pull request to
+   merge.
+3. Run a retrospective on the change, capturing lessons learned and potential follow-up work.
+
+## Tutorial 13: Advanced Operations and Future Directions
+
+The final tutorial explores topics for power users: multi-node expansions, integrating external
+storage arrays, and experimenting with edge AI workloads. We will dive into customizing Helm bundles,
+writing bespoke self-healing units, and tuning Kubernetes for performance or energy efficiency.
+
+We close the series by outlining research questions and stretch goals—hardware-in-the-loop testing,
+recovery console images, and advanced observability pipelines—so motivated readers know where they can
+push the platform next. The tutorial will encourage knowledge sharing, inviting graduates to document
+their experiments and feed improvements back into Sugarkube.
+
+### Milestones
+
+1. Prototype a multi-node expansion or edge workload, measure performance, and share reproducible
+   configs.
+2. Conduct a failure-injection exercise, observe recovery, and document tuning insights for others.
+3. Present a roadmap update that ties advanced experiments back to Sugarkube's long-term vision.


### PR DESCRIPTION
what: archive the checklist prompt/docs, add backlog/tutorial stubs, and layer in interactive tutorial milestones
why: track manual follow-ups, document the learning journey, and ensure each tutorial maps to actionable outcomes
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68d3209e18d0832fa7a4e65e5ddfba33