### PR TITLE
Add QEMU smoke metadata to release manifest

### DIFF
--- a/.github/workflows/pi-image-release.yml
+++ b/.github/workflows/pi-image-release.yml
@@ -136,7 +136,8 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --run-id "${GITHUB_RUN_ID}" \
             --run-attempt "${GITHUB_RUN_ATTEMPT}" \
-            --workflow "${GITHUB_WORKFLOW}"
+            --workflow "${GITHUB_WORKFLOW}" \
+            --qemu-artifacts "qemu-smoke-artifacts"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.5.0

--- a/docs/pi_image_builder_design.md
+++ b/docs/pi_image_builder_design.md
@@ -113,6 +113,10 @@
   on the serial console, and then copies `/boot/first-boot-report` plus
   `/var/log/sugarkube` into uploadable artifacts so every release ships with the
   same telemetry operators would retrieve from hardware.
+- `scripts/generate_release_manifest.py` now records a `qemu_smoke` section with the
+  smoke-test status and SHA-256 digests for the serial log and copied reports so
+  downstream tooling can validate virtualization results without downloading the
+  entire artifact bundle.
 
 ### Local GitHub Actions dry-run
 - Install [act](https://github.com/nektos/act) and run `act workflow-dispatch --workflows
@@ -136,5 +140,3 @@ Read-only mount for cloud-init file into container
 ## Future Enhancements
 - Parametrize mirror list and implement automatic mirror failover
 - Structured logs from `pi-gen` stages to summarize progress/time
-- Surface QEMU smoke-test metadata (serial logs, report hashes) directly in the
-  release manifest alongside the core artifacts


### PR DESCRIPTION
## Summary
- Reviewed future-work notes: docs/backlog.md remains multi-commit work, while docs/pi_image_builder_design.md called out surfacing QEMU smoke metadata as a shippable enhancement.
- Capture QEMU smoke-test status and artifact digests in scripts/generate_release_manifest.py and wire the workflow to pass the artifact directory.
- Extend the release manifest test suite and design doc to describe the new qemu_smoke section.

## Testing
- pytest tests/test_generate_release_manifest.py
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d397d3f7f8832f8189c23514c4336d