### PR TITLE
Align telemetry verifier timeout default with docs

### DIFF
--- a/docs/pi_image_telemetry.md
+++ b/docs/pi_image_telemetry.md
@@ -101,5 +101,8 @@ Both invocations call `scripts/publish_telemetry.py`, which automatically locate
   `http://<pi-host>:12345/metrics` (Grafana Agent), `:9100` (node), and Netdata's dashboard on
   `:19999`.
 
+Regression tests in `tests/test_publish_telemetry.py` guard this three-minute default so the CLI and
+documentation stay aligned as the helper evolves.
+
 By shipping telemetry hooks as an opt-in service, operators gain shared observability across lab
 installs while keeping the default image silent until explicitly configured.

--- a/scripts/publish_telemetry.py
+++ b/scripts/publish_telemetry.py
@@ -19,7 +19,7 @@ from typing import Iterable, List, Mapping, MutableMapping, Sequence
 
 TELEMETRY_SCHEMA = "https://sugarkube.dev/telemetry/v1"
 DEFAULT_TIMEOUT = 10.0
-DEFAULT_VERIFIER_TIMEOUT = 120.0
+DEFAULT_VERIFIER_TIMEOUT = 180.0
 
 
 class TelemetryError(RuntimeError):

--- a/tests/test_publish_telemetry.py
+++ b/tests/test_publish_telemetry.py
@@ -224,6 +224,12 @@ def test_parse_args_uses_env_defaults(monkeypatch):
     assert args.tags == "one,two"
 
 
+def test_parse_args_defaults_to_three_minute_verifier_timeout(monkeypatch):
+    monkeypatch.delenv("SUGARKUBE_TELEMETRY_VERIFIER_TIMEOUT", raising=False)
+    args = MODULE.parse_args([])
+    assert args.verifier_timeout == pytest.approx(180.0)
+
+
 def test_discover_verifier_path_prefers_explicit(tmp_path, monkeypatch):
     executable = tmp_path / "verifier.sh"
     executable.write_text("#!/bin/sh\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- add regression coverage asserting the telemetry CLI keeps a three-minute default for the verifier timeout
- update publish_telemetry to honour the documented three-minute timeout
- document that the new regression test guards the timeout default

## Future Work Inventory
- Searched the repository for TODO/FIXME/future-work markers; none were present.
- docs/pi_image_telemetry.md already promised a three-minute verifier timeout, but scripts/publish_telemetry.py still used a two-minute default. The mismatch is self-contained and fixable with a constant update plus tests, so it fits in a single PR.

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- npm run lint *(fails: repository has no package.json)*
- npm run test:ci *(fails: repository has no package.json)*
- pytest tests/test_publish_telemetry.py::test_parse_args_defaults_to_three_minute_verifier_timeout


------
https://chatgpt.com/codex/tasks/task_e_68d397d3f7f8832f8189c23514c4336d