### PR TITLE
📝 : – publish tutorial 10 first boot verification guide

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -199,6 +199,12 @@ stale virtual environments or missing system packages, and document troubleshoot
 
 ## Tutorial 9: Building and Flashing the Sugarkube Pi Image
 
+**Status:** Published — [Read the tutorial](./tutorial-09-building-flashing-pi-image.md)
+
+**Prerequisites satisfied:** Tutorials 1–8 artefacts (safety notes, lab journals, network
+diagram, Git workspace, automation toolkit, hardware build, Kubernetes sandbox, and local
+development environment) plus access to Docker and at least 20 GB of free disk space.
+
 This tutorial provides an end-to-end walkthrough of generating the Pi image. We will explain the
 pi-gen stages we customize, how configuration overlays are applied, and where build metadata is
 recorded. Learners will run the build locally or via GitHub Actions, monitor progress, and collect the
@@ -217,14 +223,20 @@ tutorial.
 
 ## Tutorial 10: First Boot, Verification, and Self-Healing
 
-Here we detail what happens the first time a Sugarkube Pi boots. Learners will explore `first_boot_service.py`,
-understand the generated reports, and practice interpreting logs under `/boot/first-boot-report/`.
-Step-by-step exercises will validate k3s readiness, confirm token.place and dspace health, and trigger
-the self-healing services to see how automated recovery behaves.
+**Status:** Published — [Read the tutorial](./tutorial-10-first-boot-verification-self-healing.md)
 
-We will also demonstrate retrieving kubeconfig and other artifacts without SSH, showing how the
-workflow supports classroom or remote deployments. Troubleshooting scenarios will teach learners how
-to respond when services fail, encouraging them to gather support bundles before escalating issues.
+**Prerequisites satisfied:** Tutorials 1–9 artefacts (safety notes, lab journals, network diagram,
+Git workspace, automation toolkit, hardware build, Kubernetes sandbox, development environment, and
+bootable media) plus physical access to a Sugarkube Pi on a trusted network.
+
+Here we detail what happens the first time a Sugarkube Pi boots. Learners will explore
+`first_boot_service.py`, understand the generated reports, and practice interpreting logs under
+`/boot/first-boot-report/`. Step-by-step exercises validate k3s readiness, confirm token.place and
+dspace health, and trigger the self-healing services to see how automated recovery behaves.
+
+We also demonstrate retrieving kubeconfig and other artifacts over the network, showing how the
+workflow supports classroom or remote deployments. Troubleshooting scenarios teach learners how to
+respond when services fail, encouraging them to gather support bundles before escalating issues.
 
 ### Milestones
 

--- a/docs/tutorials/tutorial-09-building-flashing-pi-image.md
+++ b/docs/tutorials/tutorial-09-building-flashing-pi-image.md
@@ -1,0 +1,259 @@
+# Tutorial 9: Building and Flashing the Sugarkube Pi Image
+
+## Overview
+This guide continues the
+[Sugarkube Tutorial Roadmap](./index.md#tutorial-9-building-and-flashing-the-sugarkube-pi-image)
+by walking you through the entire image lifecycle. You will run the pi-gen based
+builder, normalize the resulting artifacts, capture provenance metadata, and
+flash the image onto removable media. The lab mirrors what the automation bots do
+so you can rehearse the process locally and understand every safety check.
+
+By the end you will have:
+* Confirmed your workstation meets the disk space, Docker, and network
+  prerequisites for pi-gen.
+* Generated a fresh `sugarkube.img.xz`, checksum, build log, and metadata bundle.
+* Practiced flashing the image safely—either in dry-run mode or to a real SD
+  card/SSD—with transcripts and screenshots captured for review.
+
+## Prerequisites
+* Completed artefacts from [Tutorial 1](./tutorial-01-computing-foundations.md)
+  through [Tutorial 8](./tutorial-08-preparing-development-environment.md),
+  including your lab journal, network diagrams, Kubernetes sandbox, and local
+  clone of the Sugarkube repository.
+* A workstation with administrative access, Docker Desktop or Docker Engine
+  running, and at least **20 GB** of free disk space.
+* Optional but recommended: a spare SD card, USB SSD, or a blank image file to
+  practice flashing without risking production media.
+
+> [!WARNING]
+> Building and flashing images will erase the target media. Double-check device
+> names before running destructive commands. Unplug any drives you do not intend
+> to re-image to avoid surprises.
+
+## Lab: Build, Collect, and Flash the Sugarkube Image
+Create a new evidence directory `~/sugarkube-labs/tutorial-09/` for this lab. All
+logs, screenshots, and transcripts should live under that path so reviewers can
+trace your work.
+
+### 1. Prepare the build workspace
+1. Open a terminal and create dedicated folders for notes, logs, images, and
+   reports:
+
+   ```bash
+   mkdir -p ~/sugarkube-labs/tutorial-09/{notes,logs,images,reports}
+   cd ~/sugarkube-labs/tutorial-09
+   ```
+
+2. Record your starting system state for provenance:
+
+   ```bash
+   {
+     echo "# Tutorial 9 System Snapshot"
+     date --iso-8601=seconds
+     uname -a
+     docker --version
+     df -h .
+   } > logs/system-snapshot.txt
+   ```
+
+3. Verify Docker can run privileged containers (pi-gen needs binfmt):
+
+   ```bash
+   docker info --format '{{.ServerVersion}}'
+   ```
+
+   If this command fails, restart Docker Desktop or the Docker daemon before
+   continuing.
+
+> [!TIP]
+> Capture a screenshot of Docker Desktop (or `systemctl status docker`) showing
+> it is running. Store the file in `screenshots/` or note its path inside
+> `notes/README.md`.
+
+### 2. Sync the Sugarkube sources and stage output directories
+1. Reuse the repository clone from Tutorial 8 or clone it again into the lab
+   workspace:
+
+   ```bash
+   cd ~/sugarkube-labs/tutorial-09
+   git clone https://github.com/futuroptimist/sugarkube.git workspace
+   cd workspace
+   ```
+
+   If you already have a clone elsewhere, document the path in
+   `../notes/README.md` and ensure it is up to date (`git pull origin main`).
+
+2. Create a directory to hold build artifacts outside the repository checkout so
+   large files do not pollute your Git working tree:
+
+   ```bash
+   mkdir -p ../images/build-output
+   export OUTPUT_DIR="$(pwd)/../images/build-output"
+   ```
+
+3. Examine the available pi-image helper scripts so you know what will run:
+
+   ```bash
+   ls scripts | grep pi_image
+   ```
+
+   Skim `scripts/build_pi_image.sh` and `docs/pi_image_builder_design.md` to see
+   the stages and safety checks the builder performs.
+
+### 3. Run the pi-gen build
+1. Start a transcript using `script` so you have a full log later:
+
+   ```bash
+   cd ~/sugarkube-labs/tutorial-09/workspace
+   script ../logs/build-session.txt
+   ```
+
+   The shell prompt will change to indicate logging is active.
+
+2. Launch the build. Set `OUTPUT_DIR` so logs, metadata, and the compressed image
+   land in `~/sugarkube-labs/tutorial-09/images/build-output/`:
+
+   ```bash
+   OUTPUT_DIR="$OUTPUT_DIR" ./scripts/build_pi_image.sh | tee ../logs/pi-gen-live.log
+   ```
+
+   Expect the build to run 30–90 minutes depending on your machine and network.
+   The `tee` command mirrors stdout into `../logs/pi-gen-live.log` while still
+   displaying progress in the terminal.
+
+> [!NOTE]
+> The builder installs ARM binfmt handlers inside Docker. If you are on macOS
+> with Colima or Lima, ensure the VM is started and `docker context use default`
+> points at the correct daemon.
+
+3. When the build completes, exit the `script` session to finalize the transcript:
+
+   ```bash
+   exit
+   ```
+
+   Confirm that the following files exist in `../images/build-output/`:
+
+   * `sugarkube.img.xz`
+   * `sugarkube.img.xz.sha256`
+   * `sugarkube.img.xz.metadata.json`
+   * `build.log`
+
+### 4. Review and archive build artifacts
+1. Copy a summary of the output directory into your notes:
+
+   ```bash
+   ls -lh ../images/build-output > ../notes/artifacts-summary.txt
+   ```
+
+2. Inspect the metadata JSON to understand what was captured:
+
+   ```bash
+   jq '. | {pi_gen_commit, duration_seconds, options}' \
+     ../images/build-output/sugarkube.img.xz.metadata.json
+   ```
+
+   Record key values (pi-gen commit, duration, token.place branch) in your lab
+   journal so future builds can be compared.
+
+3. Validate the checksum matches the compressed image:
+
+   ```bash
+   cd ../images/build-output
+   sha256sum --check sugarkube.img.xz.sha256
+   cd -
+   ```
+
+   Save the command output to `../logs/checksum-verify.txt` using redirection or
+   by copying the terminal transcript.
+
+> [!WARNING]
+> If the checksum verification fails, do **not** flash the image. Rerun the build
+> or investigate disk space, network interruptions, and the pi-gen logs before
+> proceeding.
+
+### 5. Practice flashing the image
+1. List removable devices detected on your system. This is safe to run without
+   sudo and helps you identify the correct path:
+
+   ```bash
+   python3 scripts/flash_pi_media.py --list
+   ```
+
+   If you are rehearsing without hardware, create a sparse file to act as a fake
+   device:
+
+   ```bash
+   truncate -s 8G ~/sugarkube-labs/tutorial-09/images/fake-device.img
+   ```
+
+2. Perform a dry run first to understand the workflow without touching disks:
+
+   ```bash
+   sudo python3 scripts/flash_pi_media.py \
+     --image ~/sugarkube-labs/tutorial-09/images/build-output/sugarkube.img.xz \
+     --device ~/sugarkube-labs/tutorial-09/images/fake-device.img \
+     --dry-run --assume-yes
+   ```
+
+   Review the output and save it to `../logs/flash-dry-run.txt`.
+
+3. When you are ready to flash real media, repeat the command **without**
+   `--dry-run` and with the correct `/dev/sdX` (Linux), `/dev/diskN` (macOS), or
+   `\\.\PhysicalDriveN` (Windows, run from PowerShell). Keep `--assume-yes` so
+   the helper prompts for confirmation only when required.
+
+> [!WARNING]
+> Triple-check the device path before running the destructive flash step. Use
+> `lsblk` (Linux) or `diskutil list` (macOS) to confirm capacity and model. If in
+> doubt, stop and re-run the dry-run command while you verify cabling.
+
+4. Generate an HTML evidence report that captures the flashing session, checksum
+   validation, and media details:
+
+   ```bash
+   python3 scripts/flash_pi_media_report.py \
+     --image ~/sugarkube-labs/tutorial-09/images/build-output/sugarkube.img.xz \
+     --device <your-device-path-or-fake-file> \
+     --output-dir ~/sugarkube-labs/tutorial-09/reports \
+     --assume-yes
+   ```
+
+   The script will prompt you to confirm the target if it is a real disk. When it
+   finishes, open the generated `.html` file in a browser and capture a
+   screenshot for your notes.
+
+### 6. Package evidence for reviewers
+1. Update `~/sugarkube-labs/tutorial-09/notes/README.md` with:
+   * The commands you ran and timestamps.
+   * Links to transcripts (`build-session.txt`, `pi-gen-live.log`).
+   * Checksums, device identifiers, and any troubleshooting you performed.
+
+2. Create a compressed archive so you can share the lab bundle during reviews:
+
+   ```bash
+   cd ~/sugarkube-labs
+   tar -czf tutorial-09-evidence.tar.gz tutorial-09
+   ```
+
+   Store the archive in a safe location or upload it to your team’s evidence
+   storage, following the security practices from earlier tutorials.
+
+## Milestone Checklist
+Use this list to confirm you met each objective before moving on. Check off items
+as you complete them.
+
+- [ ] Executed a full pi-gen build, archived the compressed image, build log,
+      checksum, and metadata in your lab workspace.
+- [ ] Flashed the image using two methods (dry-run or fake device counts as one),
+      verified checksums, and documented any deviations.
+- [ ] Published a reusable flashing checklist or evidence package others can
+      follow, including screenshots and transcripts.
+
+## Next Steps
+Proceed to Tutorial 10:
+[First Boot, Verification, and Self-Healing][tutorial-10-roadmap]
+to boot the image you created here, run the verifier, and observe Sugarkube’s
+self-healing services in action.
+
+[tutorial-10-roadmap]: ./index.md#tutorial-10-first-boot-verification-and-self-healing

--- a/docs/tutorials/tutorial-10-first-boot-verification-self-healing.md
+++ b/docs/tutorials/tutorial-10-first-boot-verification-self-healing.md
@@ -1,0 +1,224 @@
+# Tutorial 10: First Boot, Verification, and Self-Healing
+
+## Overview
+This guide continues the
+[Sugarkube Tutorial Roadmap](./index.md#tutorial-10-first-boot-verification-and-self-healing)
+by showing you how to take the freshly flashed media from Tutorial 9, perform a safe first boot,
+collect the automatically generated health reports, and rehearse the self-healing workflows.
+You will learn how `first_boot_service.py`, the bundled verifier, and supporting systemd units
+collaborate to prove the cluster is ready for use.
+
+By the end you will have:
+* Captured console evidence for the very first boot, including LEDs, serial output, and timings.
+* Exported `/boot/first-boot-report/` artifacts (Markdown, HTML, JSON, and logs) to your lab
+  notebook and annotated what each file proves.
+* Exercised the self-healing routines by re-running the verifier, investigating simulated failures,
+  and confirming the Pi recovers without manual intervention.
+
+## Prerequisites
+* Completed artefacts from [Tutorial 1](./tutorial-01-computing-foundations.md) through
+  [Tutorial 9](./tutorial-09-building-flashing-pi-image.md), including the bootable SD card or SSD
+  created in Tutorial 9.
+* Physical access to your Sugarkube Pi, carrier board, or equivalent lab hardware, plus Ethernet and
+  power as specified in [Tutorial 6](./tutorial-06-raspberry-pi-hardware-power.md).
+* A workstation on the same network with SSH access, `scp`, and the Sugarkube repository cloned.
+* Optional but recommended: a USB-to-serial adapter or HDMI capture device so you can log the entire
+  boot sequence.
+
+> [!WARNING]
+> Keep the Pi on an isolated or trusted network segment for these rehearsals. The image enables
+> remote services on first boot—never expose it to production or guest Wi-Fi until you confirm the
+> verifier marks everything healthy.
+
+## Lab: Boot, Verify, and Exercise Self-Healing
+Create a fresh evidence workspace at `~/sugarkube-labs/tutorial-10/`. Store every log, screenshot,
+and transcript there so reviewers can trace each action.
+
+### 1. Prepare your evidence workspace
+1. On your workstation, create dedicated directories:
+
+   ```bash
+   mkdir -p ~/sugarkube-labs/tutorial-10/{notes,logs,media,reports}
+   cd ~/sugarkube-labs/tutorial-10
+   ```
+
+2. Capture baseline metadata before powering the Pi:
+
+   ```bash
+   {
+     echo "# Tutorial 10 First Boot Baseline"
+     date --iso-8601=seconds
+     ip addr show
+     arp -an
+   } > logs/workstation-baseline.txt
+   ```
+
+3. If you have a serial console, start recording the session now so the entire boot is captured:
+
+   ```bash
+   screen -L -Logfile logs/pi-serial.log /dev/ttyUSB0 115200
+   ```
+
+   Press `Ctrl+A` then `D` to detach and keep recording in the background.
+
+> [!TIP]
+> Take a still photo or short video of the hardware layout (power brick, cables, SD card) and save
+> it under `media/`. Annotated visuals help reviewers understand your setup when issues arise.
+
+### 2. Cable the Pi and set expectations
+1. Connect Ethernet to the same VLAN you prepared in earlier tutorials. Plug in HDMI or your serial
+   adapter if available.
+2. Insert the SD card or SSD you imaged during Tutorial 9. Double-check it seats firmly in the slot.
+3. Review the expected LED pattern: steady red for power, flashing green while the bootloader and
+   verifier run, and a heartbeat once the system reaches multi-user mode.
+
+> [!NOTE]
+> If the green LED never appears, remove power immediately and re-seat the storage media. Document
+> the observation in `notes/README.md` before trying again.
+
+### 3. Power on and monitor first boot
+1. Apply power to the Pi. Start a stopwatch so you can timestamp key transitions.
+2. Watch the console (serial or HDMI) for `[first-boot]` log lines. When you see
+   `first boot automation started`, note the elapsed time in `notes/README.md`.
+3. After 5–10 minutes, the Pi should reboot automatically once the filesystem is expanded and
+   services are deployed. If you lose console output, wait for network reachability instead of
+   unplugging the device.
+4. From your workstation, probe the Pi’s IP (replace `192.0.2.10` with the address you assigned):
+
+   ```bash
+   ping -c 4 192.0.2.10
+   ssh -o StrictHostKeyChecking=accept-new pi@192.0.2.10 'uname -a'
+   ```
+
+   Record the SSH fingerprint in `notes/README.md`.
+
+> [!TROUBLESHOOT]
+> SSH refusal or timeouts usually mean cloud-init is still applying packages. Run
+> `arp -an | grep -i <mac>` from another device to confirm the Pi stays online. If it vanishes,
+> check `logs/pi-serial.log` for kernel panics and capture a screenshot before power-cycling.
+
+### 4. Collect `/boot/first-boot-report/`
+1. Once logged in, list the report directory:
+
+   ```bash
+   sudo ls -R /boot/first-boot-report
+   ```
+
+   Expect files such as `summary.md`, `summary.html`, `summary.json`, `self-heal/`, and
+   `helm-bundles/`.
+
+2. Copy the reports to your workstation for archival:
+
+   ```bash
+   cd ~/sugarkube-labs/tutorial-10
+   scp -r pi@192.0.2.10:/boot/first-boot-report reports/pi-first-boot-report
+   ```
+
+3. Add quick annotations so future you understands each artifact:
+
+   ```bash
+   cat <<'MARKDOWN' > notes/report-index.md
+   # First Boot Report Index
+   - summary.md — Human-readable checklist from pi_node_verifier.sh.
+   - summary.json — Machine-readable status for automation.
+   - helm-bundles/*.log — Output from Helm bundle apply hooks.
+   - self-heal/ — Journal extracts and retry logs captured by self-healing.
+   MARKDOWN
+   ```
+
+> [!TIP]
+> Open `reports/pi-first-boot-report/summary.html` in a browser and capture a PDF printout or
+> screenshot for evidence. Attach the annotated file under `media/`.
+
+### 5. Re-run the verifier and self-heal routines
+1. Trigger the bundled verifier again to prove it’s idempotent:
+
+   ```bash
+   ssh pi@192.0.2.10 \
+     'sudo /opt/sugarkube/pi_node_verifier.sh --log /boot/first-boot-report/manual-rerun.txt'
+   ```
+
+   Compare timestamps between `summary.md` and the new log.
+
+2. Inspect the systemd service responsible for first boot:
+
+   ```bash
+   ssh pi@192.0.2.10 'sudo systemctl status first-boot.service --no-pager'
+   ssh pi@192.0.2.10 'sudo journalctl -u first-boot.service --no-pager | tail -n 200'
+   ```
+
+   Save the outputs to `logs/first-boot-service-status.txt` for long-term reference.
+
+3. Review Kubernetes readiness and core services:
+
+   ```bash
+   ssh pi@192.0.2.10 'sudo kubectl get nodes'
+   ssh pi@192.0.2.10 'sudo kubectl get pods -A'
+   ssh pi@192.0.2.10 'sudo docker compose -f /opt/sugarkube/projects/docker-compose.yml ps'
+   ```
+
+   Redirect each command with `| tee` if you want inline logs.
+
+> [!WARNING]
+> Resist the urge to `sudo systemctl stop first-boot.service` unless you are debugging a hang. The
+> self-heal logic relies on that unit to restart dependent services when failures occur.
+
+### 6. Simulate a failure and observe recovery
+1. Introduce a harmless error by temporarily disabling token.place:
+
+   ```bash
+   ssh pi@192.0.2.10 'sudo systemctl stop token-place.service'
+   sleep 30
+   ssh pi@192.0.2.10 'sudo systemctl status token-place.service --no-pager'
+   ```
+
+2. The self-healing supervisor should restart the service within a minute. Confirm via:
+
+   ```bash
+   ssh pi@192.0.2.10 'sudo journalctl -u first-boot.service --no-pager | tail -n 100'
+   ssh pi@192.0.2.10 'ls /boot/first-boot-report/self-heal'
+   ```
+
+3. Restart the service manually to clear the simulation:
+
+   ```bash
+   ssh pi@192.0.2.10 'sudo systemctl start token-place.service'
+   ```
+
+4. Document the timestamps, automatic retries, and any new files under `self-heal/` in
+   `notes/README.md`.
+
+> [!TROUBLESHOOT]
+> If the service does not recover, run `sudo systemctl restart first-boot.service` and inspect
+> `/boot/first-boot-report/self-heal/*.log`. Capture the findings and create a remediation plan
+> before proceeding.
+
+### 7. Package your evidence
+1. Update `notes/README.md` with:
+   * Power-on timestamps and LED observations.
+   * SSH fingerprints, IP assignments, and verifier results.
+   * Any troubleshooting steps, including commands that failed and how you resolved them.
+
+2. Archive the entire lab bundle:
+
+   ```bash
+   cd ~/sugarkube-labs
+   tar -czf tutorial-10-evidence.tar.gz tutorial-10
+   ```
+
+   Store the archive with restricted permissions or upload it to your team’s secure evidence store.
+
+## Milestone Checklist
+Use this checklist to verify you achieved each objective before moving on.
+
+- [ ] Captured first boot observations (console log, LED notes, timestamps) and stored them under
+      `~/sugarkube-labs/tutorial-10/`.
+- [ ] Archived `/boot/first-boot-report/` plus manual verifier rerun logs with annotations that
+      explain each artifact’s purpose.
+- [ ] Simulated a recoverable failure, observed the self-healing response, and documented the
+      outcome in your lab notes.
+
+## Next Steps
+When you are satisfied with the evidence, continue to [Tutorial 11: Storage Migration and Long-Term
+Maintenance](./index.md#tutorial-11-storage-migration-and-long-term-maintenance) (once published).
+You will clone the boot media, validate SSD migrations, and build a sustainable maintenance cadence.


### PR DESCRIPTION
what: add tutorial 10 covering first boot verification and self-healing drills.
why: deliver the next roadmap milestone so learners can validate freshly built images.
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68d475458ae8832fbdcffe3f633a8d0f