### PR TITLE
🛠️ : – Run pyspelling directly in spellcheck workflow

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -19,6 +19,8 @@ jobs:
           python-version: "3.12"
       - name: Install spellcheck dependencies
         run: |
+          sudo apt-get update
+          sudo apt-get install -y aspell aspell-en
           python -m pip install --upgrade pip
           python -m pip install pyspelling
       - name: Run spellcheck

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -13,9 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Install aspell
-        run: sudo apt-get update && sudo apt-get install -y aspell aspell-en
-      - name: Spell check
-        uses: rojopolis/spellcheck-github-actions@0.35.0
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          config_path: .spellcheck.yaml
+          python-version: "3.12"
+      - name: Install spellcheck dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pyspelling
+      - name: Run spellcheck
+        run: pyspelling -c .spellcheck.yaml


### PR DESCRIPTION
what: replace third-party spellcheck action with inline pyspelling
why: avoid unauthorized docker pull from private action image
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml;
  linkchecker --no-warnings README.md docs/
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68d47fb45a68832fb320b6f1ec23ca0b