### PR TITLE
🛠️ : – replace docker spellcheck action

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,19 +1,23 @@
 name: Spellcheck
+
 on:
   workflow_dispatch:
   pull_request:
     paths:
       - '**.md'
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
+  spellcheck:
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
-      - name: Set up Python
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/outages/2025-09-24-spellcheck-docker-auth.json
+++ b/outages/2025-09-24-spellcheck-docker-auth.json
@@ -1,0 +1,11 @@
+{
+  "id": "spellcheck-docker-auth-required",
+  "date": "2025-09-24",
+  "component": "spellcheck workflow",
+  "rootCause": "rojopolis/spellcheck-github-actions used a Docker Hub image that now needs authentication.",
+  "resolution": "Replaced the Docker action with an inline pyspelling job on hosted Ubuntu runners to avoid private pulls.",
+  "references": [
+    "https://github.com/futuroptimist/sugarkube/actions/workflows/spellcheck.yml",
+    "https://hub.docker.com/r/jonasbn/github-action-spellcheck"
+  ]
+}


### PR DESCRIPTION
what: run pyspelling directly in CI and add an outage record
why: Docker Hub now requires auth for jonasbn/github-action-spellcheck
how to test: pre-commit run --all-files
             pyspelling -c .spellcheck.yaml
             linkchecker --no-warnings README.md docs/
Refs: #0000

------
https://chatgpt.com/codex/tasks/task_e_68d485cd52a0832f99ccaec883e18f03