### PR TITLE
✨ : skip non-http pi-gen reachability checks

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -16,7 +16,8 @@ so logs survive reboots. After installation, it removes unused packages with
 The `build_pi_image.sh` script clones [pi-gen](https://github.com/RPi-Distro/pi-gen) using
 `PI_GEN_BRANCH` (default: `bookworm` for 32-bit builds and `arm64` for
 64-bit). Set `PI_GEN_URL` to use a fork or mirror if the default repository is
-unavailable. `IMG_NAME` controls the output filename and `OUTPUT_DIR` selects
+unavailable; non-HTTP(S) URLs (for example `git@` or `file://` paths) skip the
+preflight curl check automatically. `IMG_NAME` controls the output filename and `OUTPUT_DIR` selects
 where artifacts are written; the script creates the directory if needed. Run
 `scripts/build_pi_image.sh --help` for a summary of configurable environment
 variables. To avoid accidental overwrites it aborts when the image already

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -204,11 +204,23 @@ DEBIAN_MIRROR="${DEBIAN_MIRROR:-https://deb.debian.org/debian}"
 RPI_MIRROR="${RPI_MIRROR:-https://archive.raspberrypi.com/debian}"
 URL_CHECK_TIMEOUT="${URL_CHECK_TIMEOUT:-10}"
 SKIP_URL_CHECK="${SKIP_URL_CHECK:-0}"
+is_http_url() {
+  case "$1" in
+    http://*|https://*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 if [ "$SKIP_URL_CHECK" -ne 1 ]; then
   for url in "$DEBIAN_MIRROR" "$RPI_MIRROR" "$PI_GEN_URL"; do
-    if ! curl -fsIL --connect-timeout "${URL_CHECK_TIMEOUT}" --max-time "${URL_CHECK_TIMEOUT}" "$url" >/dev/null; then
-      echo "Cannot reach $url" >&2
-      exit 1
+    if is_http_url "$url"; then
+      if ! curl -fsIL --connect-timeout "${URL_CHECK_TIMEOUT}" --max-time "${URL_CHECK_TIMEOUT}" \
+        "$url" >/dev/null; then
+        echo "Cannot reach $url" >&2
+        exit 1
+      fi
+    else
+      echo "Skipping URL reachability check for non-HTTP source: $url"
     fi
   done
 else


### PR DESCRIPTION
what: skip curl reachability probes for non-http pi-gen sources and document the
      behavior.
why: unblock git@ or file:// overrides that cannot answer HTTP(S) HEAD requests.
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml;
             linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68d4c0313338832f954ff6d5639f49f6