### PR TITLE
📝 : – Rehome prompt docs under docs/prompts

### DIFF
--- a/docs/archived/prompt-codex-tutorials.md
+++ b/docs/archived/prompt-codex-tutorials.md
@@ -1,28 +1,28 @@
 ---
 title: 'Sugarkube Tutorials Implementation Prompt'
-slug: 'prompts-codex-tutorials'
+slug: 'codex-tutorials'
 ---
 
 # Codex Tutorials Implementation Prompt
 
-Use this prompt to turn each roadmap entry in [`docs/tutorials/index.md`](../docs/tutorials/index.md)
+Use this prompt to turn each roadmap entry in [`docs/tutorials/index.md`](../tutorials/index.md)
 into a fully fledged, interactive tutorial.
 
 ```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository focused on delivering the
-complete tutorial series described in [`docs/tutorials/index.md`](../docs/tutorials/index.md).
+complete tutorial series described in [`docs/tutorials/index.md`](../tutorials/index.md).
 
 PURPOSE:
 Author high-utility, hands-on tutorials that teach Sugarkube from first principles through advanced
 operations.
 
 CONTEXT:
-- Follow [`AGENTS.md`](../AGENTS.md), [`README.md`](../README.md), and
-  [`CONTRIBUTING.md`](../CONTRIBUTING.md) for repository conventions.
-- Review [`docs/index.md`](../docs/index.md) for the overall documentation map and use
-  [`docs/tutorials/index.md`](../docs/tutorials/index.md) as the canonical syllabus.
-- Every tutorial lives under [`docs/tutorials/`](../docs/tutorials/). Create a new `*.md` file per
+- Follow [`AGENTS.md`](../../AGENTS.md), [`README.md`](../../README.md), and
+  [`CONTRIBUTING.md`](../../CONTRIBUTING.md) for repository conventions.
+- Review [`docs/index.md`](../index.md) for the overall documentation map and use
+  [`docs/tutorials/index.md`](../tutorials/index.md) as the canonical syllabus.
+- Every tutorial lives under [`docs/tutorials/`](../tutorials/). Create a new `*.md` file per
   tutorial using the naming pattern `tutorial-XX-<slug>.md` (e.g. `tutorial-01-computing-foundations.md`).
 - Each tutorial must include:
   1. An overview that restates the learning goals in your own words and links back to the roadmap.
@@ -37,14 +37,14 @@ CONTEXT:
 - Update cross-links so the new tutorial is discoverable from `docs/tutorials/index.md` and any other
   relevant hub pages.
 - When you modify documentation, run:
-  - `pre-commit run --all-files` (invokes [`scripts/checks.sh`](../scripts/checks.sh) to lint and test).
+  - `pre-commit run --all-files` (invokes [`scripts/checks.sh`](../../scripts/checks.sh) to lint and test).
   - `pyspelling -c .spellcheck.yaml`
   - `linkchecker --no-warnings README.md docs/`
 - Before committing, scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`.
 - Design any accompanying code or scripts so they achieve **100% patch coverage on the first test run**.
-- Record persistent automation failures in [`outages/`](../outages/) using
-  [`schema.json`](../outages/schema.json).
+- Record persistent automation failures in [`outages/`](../../outages/) using
+  [`schema.json`](../../outages/schema.json).
 
 REQUEST:
 1. Determine the next tutorial to implement by scanning `docs/tutorials/index.md` top-to-bottom and
@@ -69,9 +69,9 @@ Use this prompt to keep the tutorials implementation workflow current.
 ```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
-Follow [`AGENTS.md`](../AGENTS.md), [`README.md`](../README.md), and
-[`CONTRIBUTING.md`](../CONTRIBUTING.md).
-Run `pre-commit run --all-files` (invokes [`scripts/checks.sh`](../scripts/checks.sh)). When
+Follow [`AGENTS.md`](../../AGENTS.md), [`README.md`](../../README.md), and
+[`CONTRIBUTING.md`](../../CONTRIBUTING.md).
+Run `pre-commit run --all-files` (invokes [`scripts/checks.sh`](../../scripts/checks.sh)). When
 `package.json` is present, that script automatically executes `npm ci`, `npm run lint`, and
 `npm run test:ci`.
 Then run:
@@ -82,7 +82,7 @@ Ensure the prompt continues to require contributors to reach **100% patch covera
 run** without retries.
 
 USER:
-1. Review `docs/prompts-codex-tutorials.md` for stale instructions, missing context, or broken links.
+1. Review `docs/archived/prompt-codex-tutorials.md` for stale instructions, missing context, or broken links.
 2. Update references, reinforce coverage expectations, and clarify workflow steps.
 3. Run the commands above and fix any reported issues.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,13 +51,17 @@ Review the safety notes before working with power components.
 Start with the basics and progress toward a fully autonomous solar cube.
 
 ## LLM Prompts
-- [prompts-codex.md](prompts-codex.md) — baseline Codex instructions for maintaining the repo
-- [prompts-codex-cad.md](prompts-codex-cad.md) — keep OpenSCAD models rendering cleanly
-- [prompts-codex-docs.md](prompts-codex-docs.md) — refine build guides and reference docs
-- [prompts-codex-pi-image.md](prompts-codex-pi-image.md) — maintain the Pi image tooling
-- [prompts-codex-pi-token-dspace.md](prompts-codex-pi-token-dspace.md) —
+- [prompts/codex/automation.md](prompts/codex/automation.md) — baseline Codex instructions for maintaining the repo
+- [prompts/codex/cad.md](prompts/codex/cad.md) — keep OpenSCAD models rendering cleanly
+- [prompts/codex/docs.md](prompts/codex/docs.md) — refine build guides and reference docs
+- [prompts/codex/pi-image.md](prompts/codex/pi-image.md) — maintain the Pi image tooling
+- [prompts/codex/pi-token-dspace.md](prompts/codex/pi-token-dspace.md) —
   bootstrap token.place & dspace on Pi
-- [prompts-codex-docker-repo.md](prompts-codex-docker-repo.md) — improve Docker repo guides
-- [prompts-codex-ci-fix.md](prompts-codex-ci-fix.md) — diagnose and fix failing checks
-- [prompts-codex-spellcheck.md](prompts-codex-spellcheck.md) — correct spelling in docs
-- [prompts-codex-tutorials.md](prompts-codex-tutorials.md) — build the full interactive tutorial series
+- [prompts/codex/docker-repo.md](prompts/codex/docker-repo.md) — improve Docker repo guides
+- [prompts/codex/ci-fix.md](prompts/codex/ci-fix.md) — diagnose and fix failing checks
+- [prompts/codex/tests.md](prompts/codex/tests.md) — strengthen automated test coverage
+- [prompts/codex/spellcheck.md](prompts/codex/spellcheck.md) — correct spelling in docs
+- [prompts/codex/implement.md](prompts/codex/implement.md) — grow features with a tests-first workflow
+- [prompts/codex/elex.md](prompts/codex/elex.md) — keep electronics documentation current
+- [prompts/codex/observability.md](prompts/codex/observability.md) — expand monitoring and alerting
+- [archived/prompt-codex-tutorials.md](archived/prompt-codex-tutorials.md) — build the full interactive tutorial series (archived)

--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -1,6 +1,6 @@
 ---
 title: 'Sugarkube Codex Prompt'
-slug: 'prompts-codex'
+slug: 'codex-automation'
 ---
 
 # Codex Automation Prompt
@@ -17,32 +17,32 @@ Keep the project healthy by making small, well-tested improvements.
 
 CONTEXT:
 - Sugarkube combines hardware and helper scripts for a solar-powered
-  k3s cluster; see [`docs/index.md`](../docs/index.md) for an overview and
-  [`llms.txt`](../llms.txt) for a machine-readable summary.
-- Contribution guidelines are in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
-- Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md); for
+  k3s cluster; see [`docs/index.md`](../../../docs/index.md) for an overview and
+  [`llms.txt`](../../../llms.txt) for a machine-readable summary.
+- Contribution guidelines are in [`CONTRIBUTING.md`](../../../CONTRIBUTING.md).
+- Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md); for
   instruction semantics, see the [AGENTS.md spec](https://agentsmd.net/AGENTS.md).
-- Inspect [`.github/workflows/`](../.github/workflows/) to understand CI checks and
+- Inspect [`.github/workflows/`](../../../.github/workflows/) to understand CI checks and
   run them locally.
 - Run `pre-commit run --all-files`, which executes
-  [`scripts/checks.sh`](../scripts/checks.sh) to install tooling and run
+  [`scripts/checks.sh`](../../../scripts/checks.sh) to install tooling and run
   formatters, linters, tests, and documentation checks. Pre-commit is configured via
-  [`.pre-commit-config.yaml`](../.pre-commit-config.yaml). `scripts/checks.sh`
+  [`.pre-commit-config.yaml`](../../../.pre-commit-config.yaml). `scripts/checks.sh`
   automatically runs `npm ci`, `npm run lint`, and `npm run test:ci` when a
   `package.json` is present.
 - Design your code and tests so the resulting diff achieves **100% patch coverage on
   the first test run**—no retries.
 - When documentation files (`README.md` or anything under
-  [`docs/`](../docs/)) change, additionally run:
+  [`docs/`](../../../docs/)) change, additionally run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; config in
-    [`.spellcheck.yaml`](../.spellcheck.yaml)). Add new words to
-    [`.wordlist.txt`](../.wordlist.txt).
+    [`.spellcheck.yaml`](../../../.spellcheck.yaml)). Add new words to
+    [`.wordlist.txt`](../../../.wordlist.txt).
   - `linkchecker --no-warnings README.md docs/`
 - Scan staged changes for secrets with
-  [`scripts/scan-secrets.py`](../scripts/scan-secrets.py) via
+  [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py) via
   `git diff --cached | ./scripts/scan-secrets.py` before committing.
-- Log persistent failures in [`outages/`](../outages/) as JSON per
-  [`outages/schema.json`](../outages/schema.json).
+- Log persistent failures in [`outages/`](../../../outages/) as JSON per
+  [`outages/schema.json`](../../../outages/schema.json).
 
 REQUEST:
 1. Identify a small bug fix or documentation clarification.
@@ -62,26 +62,26 @@ Use this prompt to refine Sugarkube's own prompt documentation.
 ```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
-Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md); for
+Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md); for
 instruction semantics see the [AGENTS.md spec](https://agentsmd.net/AGENTS.md).
-Consult [`llms.txt`](../llms.txt) for a machine-readable repository summary.
+Consult [`llms.txt`](../../../llms.txt) for a machine-readable repository summary.
 Run `pre-commit run --all-files` (invokes
-[`scripts/checks.sh`](../scripts/checks.sh) to install tooling and run linters
-and tests). Review [`.github/workflows/`](../.github/workflows/) to mirror CI
+[`scripts/checks.sh`](../../../scripts/checks.sh) to install tooling and run linters
+and tests). Review [`.github/workflows/`](../../../.github/workflows/) to mirror CI
 checks. `scripts/checks.sh` automatically runs `npm ci`, `npm run lint`, and
 `npm run test:ci` when a `package.json` is present. Then run:
 - `pyspelling -c .spellcheck.yaml` (requires `aspell`
   and `aspell-en`)
 - `linkchecker --no-warnings README.md docs/`
 - `git diff --cached | ./scripts/scan-secrets.py`
-  (script: [`scripts/scan-secrets.py`](../scripts/scan-secrets.py)) to avoid
+  (script: [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py)) to avoid
   committing credentials
 - Ensure the prompt instructs contributors to achieve **100% patch coverage on the first
   test run** without retries.
 Fix any issues reported by these tools.
 
 USER:
-1. Choose a `docs/prompts-*.md` file to update (for example, `prompts-codex-cad.md`).
+1. Choose a `docs/prompts/codex/*.md` file to update (for example, `docs/prompts/codex/cad.md`).
 2. Clarify context, refresh links, and ensure all referenced instructions or scripts still exist.
 3. Explicitly direct contributors to deliver 100% patch coverage on the first test execution.
 4. Run the commands above and address any failures.

--- a/docs/prompts/codex/cad.md
+++ b/docs/prompts/codex/cad.md
@@ -1,6 +1,6 @@
 ---
 title: 'Sugarkube Codex CAD Prompt'
-slug: 'prompts-codex-cad'
+slug: 'codex-cad'
 ---
 
 # Sugarkube Codex CAD Prompt
@@ -15,23 +15,23 @@ PURPOSE:
 Keep OpenSCAD models current and ensure they render cleanly.
 
 CONTEXT:
-- CAD files reside in [`cad/`](../cad/).
-- [`scripts/openscad_render.sh`](../scripts/openscad_render.sh) wraps
+- CAD files reside in [`cad/`](../../../cad/).
+- [`scripts/openscad_render.sh`](../../../scripts/openscad_render.sh) wraps
   `openscad -o stl/... --export-format binstl`. Run it from the repository root so meshes land
-  in the git-ignored [`stl/`](../stl/) directory (see [`.gitignore`](../.gitignore)). Ensure
+  in the git-ignored [`stl/`](../../../stl/) directory (see [`.gitignore`](../../../.gitignore)). Ensure
   [OpenSCAD](https://openscad.org/) is installed and available on `PATH`; the script exits
   early if the binary is missing.
-- The CI workflow [`scad-to-stl.yml`](../.github/workflows/scad-to-stl.yml) regenerates these
+- The CI workflow [`scad-to-stl.yml`](../../../.github/workflows/scad-to-stl.yml) regenerates these
   models as artifacts. Do not commit `.stl` files.
 - Render each model in all supported `standoff_mode` variants—e.g., `heatset`, `printed`,
   or `nut`. `STANDOFF_MODE` is optional; the script normalizes the value
   (case-insensitive, trims whitespace) and defaults to the model’s `standoff_mode`
   value (often `heatset`). Invalid values cause the render script to exit with an error.
-- Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md); see the
+- Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md); see the
   [AGENTS.md spec](https://agentsmd.net/) for instruction semantics.
-- Inspect [`.github/workflows/`](../.github/workflows/) to see which checks run in CI.
+- Inspect [`.github/workflows/`](../../../.github/workflows/) to see which checks run in CI.
 - Run `pre-commit run --all-files` from the repository root to lint, format, and test via
-  [`scripts/checks.sh`](../scripts/checks.sh).
+  [`scripts/checks.sh`](../../../scripts/checks.sh).
 - Ensure code, scripts, and tests yield **100% patch coverage on the first test run**—no retries.
 - If `package.json` defines them, run:
   - `npm ci`
@@ -40,14 +40,14 @@ CONTEXT:
   - `npm run test:ci`
 - For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; see
-    [`.spellcheck.yaml`](../.spellcheck.yaml))
+    [`.spellcheck.yaml`](../../../.spellcheck.yaml))
   - `linkchecker --no-warnings README.md docs/` to verify links in
-    [`README.md`](../README.md) and [`docs/`](../docs/) (installed by
-    [`scripts/checks.sh`](../scripts/checks.sh))
+    [`README.md`](../../../README.md) and [`docs/`](../../../docs/) (installed by
+    [`scripts/checks.sh`](../../../scripts/checks.sh))
 - Scan staged changes for secrets before committing using
   `git diff --cached | ./scripts/scan-secrets.py`.
-- Log tool failures in [`outages/`](../outages/) using
-  [`outages/schema.json`](../outages/schema.json).
+- Log tool failures in [`outages/`](../../../outages/) using
+  [`outages/schema.json`](../../../outages/schema.json).
 
 REQUEST:
 1. Inspect `cad/*.scad` for todo comments or needed adjustments.
@@ -77,7 +77,7 @@ Use this prompt to refine sugarkube's own prompt documentation.
 ```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
-Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
+Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md).
 Run `pre-commit run --all-files`.
 
 If `package.json` exists, also run:
@@ -90,15 +90,15 @@ If `package.json` exists, also run:
 Then run:
 
 - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; see
-  [`.spellcheck.yaml`](../.spellcheck.yaml))
+  [`.spellcheck.yaml`](../../../.spellcheck.yaml))
 - `linkchecker --no-warnings README.md docs/` (installed by
-  [`scripts/checks.sh`](../scripts/checks.sh))
+  [`scripts/checks.sh`](../../../scripts/checks.sh))
 - `git diff --cached | ./scripts/scan-secrets.py` before committing.
 - Ensure the revised prompt explicitly directs contributors to secure **100% patch coverage on
   the first test execution** without retries.
 
 USER:
-1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
+1. Pick one prompt doc under `docs/prompts/codex/` (for example, `docs/prompts/codex/cad.md`).
 2. Fix outdated instructions, links, or formatting.
 3. Add or reinforce guidance that requires 100% patch coverage on the first test run.
 4. Run the commands above.

--- a/docs/prompts/codex/ci-fix.md
+++ b/docs/prompts/codex/ci-fix.md
@@ -1,6 +1,6 @@
 ---
 title: 'Sugarkube Codex CI-Failure Fix Prompt'
-slug: 'prompts-codex-ci-fix'
+slug: 'codex-ci-fix'
 ---
 
 # Codex CI-Failure Fix Prompt
@@ -15,8 +15,8 @@ PURPOSE:
 Diagnose and fix continuous integration failures so all checks pass.
 
 CONTEXT:
-- Follow [AGENTS.md](../AGENTS.md) and [README.md](../README.md) for workflow and testing requirements.
-- Inspect [`.github/workflows/`](../.github/workflows/) to understand the checks run in continuous integration.
+- Follow [AGENTS.md](../../../AGENTS.md) and [README.md](../../../README.md) for workflow and testing requirements.
+- Inspect [`.github/workflows/`](../../../.github/workflows/) to understand the checks run in continuous integration.
 - JavaScript-based actions run with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` so CI surfaces
   incompatibilities before GitHub switches runners to Node24 by default.
 - Run `pre-commit run --all-files` from the repository root; it executes `scripts/checks.sh`.
@@ -49,7 +49,7 @@ Use this prompt to refine sugarkube's own prompt documentation.
 ```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
-Follow [AGENTS.md](../AGENTS.md) and [README.md](../README.md).
+Follow [AGENTS.md](../../../AGENTS.md) and [README.md](../../../README.md).
 Run `pre-commit run --all-files`.
 If a Node toolchain exists (`package.json` is present), also run:
 - `npm ci`
@@ -63,7 +63,7 @@ Then run:
   test run** without reruns.
 
 USER:
-1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
+1. Pick one prompt doc under `docs/prompts/codex/` (for example, `docs/prompts/codex/cad.md`).
 2. Fix outdated instructions, links, or formatting.
 3. Add or reinforce guidance about achieving 100% patch coverage on the first test execution.
 4. Run the commands above.

--- a/docs/prompts/codex/docker-repo.md
+++ b/docs/prompts/codex/docker-repo.md
@@ -1,6 +1,6 @@
 ---
 title: 'Sugarkube Codex Docker Repo Prompt'
-slug: 'prompts-codex-docker-repo'
+slug: 'codex-docker-repo'
 ---
 
 # Codex Docker Repo Prompt
@@ -23,8 +23,8 @@ CONTEXT:
   `git diff --cached | ./scripts/scan-secrets.py` before committing.
 - Ensure walkthrough updates and supporting tests yield **100% patch coverage on the first test
   run**—no retries.
-- File recurring deployment failures in [`outages/`](../outages/) per
-  [`outages/schema.json`](../outages/schema.json).
+- File recurring deployment failures in [`outages/`](../../../outages/) per
+  [`outages/schema.json`](../../../outages/schema.json).
 
 REQUEST:
 1. Expand the walkthrough or add examples.
@@ -44,7 +44,7 @@ Use this prompt to refine sugarkube's own prompt documentation.
 ```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
-Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
+Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md).
 Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires
 `aspell` and `aspell-en`), `linkchecker --no-warnings README.md docs/`, and
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
@@ -52,7 +52,7 @@ Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires
   without retries.
 
 USER:
-1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
+1. Pick one prompt doc under `docs/prompts/codex/` (for example, `docs/prompts/codex/cad.md`).
 2. Fix outdated instructions, links, or formatting.
 3. Add or reinforce guidance that mandates 100% patch coverage on the first test execution.
 4. Run the commands above.

--- a/docs/prompts/codex/docs.md
+++ b/docs/prompts/codex/docs.md
@@ -1,6 +1,6 @@
 ---
 title: 'Sugarkube Codex Docs Prompt'
-slug: 'prompts-codex-docs'
+slug: 'codex-docs'
 ---
 
 # Codex Documentation Prompt
@@ -16,21 +16,21 @@ Keep the documentation clear and accurate.
 
 CONTEXT:
 - Docs live in [`docs/`](./).
-- Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for style,
+- Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md) for style,
   testing, and repository conventions.
-- Inspect [`.github/workflows/`](../.github/workflows/) to see which checks run in CI.
-- Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../scripts/checks.sh) for
+- Inspect [`.github/workflows/`](../../../.github/workflows/) to see which checks run in CI.
+- Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../../../scripts/checks.sh) for
   linting, formatting, and tests. If `package.json` exists, the script automatically
   runs `npm ci`, `npm run lint`, and `npm run test:ci`.
 - Structure edits and any supporting tests so the diff achieves **100% patch coverage on the first
   test execution**—no reruns.
 - For documentation changes, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; see
-    [`.spellcheck.yaml`](../.spellcheck.yaml))
+    [`.spellcheck.yaml`](../../../.spellcheck.yaml))
   - `linkchecker --no-warnings README.md docs/`
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
-- Record recurring issues in [`outages/`](../outages/) using the
-  [`schema.json`](../outages/schema.json).
+- Record recurring issues in [`outages/`](../../../outages/) using the
+  [`schema.json`](../../../outages/schema.json).
 
 REQUEST:
 1. Choose a markdown file in `docs/` that needs clarification or an update.
@@ -57,18 +57,18 @@ Use this prompt to refine sugarkube's own prompt documentation.
 ```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
-Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
-Run `pre-commit run --all-files` (invokes [`scripts/checks.sh`](../scripts/checks.sh) for
+Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md).
+Run `pre-commit run --all-files` (invokes [`scripts/checks.sh`](../../../scripts/checks.sh) for
 linting, formatting, and tests; it automatically runs `npm ci`, `npm run lint`, and
 `npm run test:ci` when `package.json` exists). Then run `pyspelling -c .spellcheck.yaml`
-(requires `aspell` and `aspell-en`; see [`.spellcheck.yaml`](../.spellcheck.yaml)),
+(requires `aspell` and `aspell-en`; see [`.spellcheck.yaml`](../../../.spellcheck.yaml)),
 `linkchecker --no-warnings README.md docs/`, and
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
 - Ensure the refreshed prompt explicitly directs contributors to deliver **100% patch coverage on
   the first test run** without retries.
 
 USER:
-1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
+1. Pick one prompt doc under `docs/prompts/codex/` (for example, `docs/prompts/codex/cad.md`).
 2. Fix outdated instructions, links, or formatting.
 3. Add or reinforce guidance requiring 100% patch coverage on the first test execution.
 4. Run the commands above.

--- a/docs/prompts/codex/elex.md
+++ b/docs/prompts/codex/elex.md
@@ -1,6 +1,6 @@
 ---
 title: 'Sugarkube Codex Electronics Prompt'
-slug: 'prompts-codex-elex'
+slug: 'codex-elex'
 ---
 
 # Codex Electronics Prompt
@@ -15,11 +15,11 @@ PURPOSE:
 Maintain KiCad and Fritzing sources for the hardware.
 
 CONTEXT:
-- Electronics files live under [`elex/`](../elex/).
+- Electronics files live under [`elex/`](../../../elex/).
 - The `power_ring` project uses KiCad 9+ and [KiBot](https://github.com/INTI-CMNB/kibot)
-  ([`.kibot/power_ring.yaml`](../.kibot/power_ring.yaml)).
-- Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
-- Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../scripts/checks.sh)
+  ([`.kibot/power_ring.yaml`](../../../.kibot/power_ring.yaml)).
+- Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md) for repository conventions.
+- Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../../../scripts/checks.sh)
   for linting, formatting, and tests. The script auto-installs KiCad 9 whenever
   `.kicad_*` or `.kibot/` assets change (or when you set
   `SUGARKUBE_FORCE_KICAD_INSTALL=1`), so KiBot exports succeed without manual
@@ -35,8 +35,8 @@ CONTEXT:
   execution**—no retries.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py` before committing.
-- Log persistent tool failures in [`outages/`](../outages/) per
-  [`outages/schema.json`](../outages/schema.json).
+- Log persistent tool failures in [`outages/`](../../../outages/) per
+  [`outages/schema.json`](../../../outages/schema.json).
 
 REQUEST:
 1. Modify schematics or PCB layouts in `elex/power_ring`.
@@ -62,7 +62,7 @@ Use this prompt to refine sugarkube's own prompt documentation.
 ```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
-Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
+Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md).
 Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires
 `aspell` and `aspell-en`), `linkchecker --no-warnings README.md docs/`, and
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
@@ -70,7 +70,7 @@ Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires
   without retries.
 
 USER:
-1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
+1. Pick one prompt doc under `docs/prompts/codex/` (for example, `docs/prompts/codex/cad.md`).
 2. Fix outdated instructions, links, or formatting.
 3. Add or reinforce guidance that requires 100% patch coverage on the first test execution.
 4. Run the commands above.

--- a/docs/prompts/codex/implement.md
+++ b/docs/prompts/codex/implement.md
@@ -1,6 +1,6 @@
 ---
 title: 'Sugarkube Codex Implement Prompt'
-slug: 'prompts-codex-implement'
+slug: 'codex-implement'
 ---
 
 # Codex Implement Prompt
@@ -31,17 +31,17 @@ USAGE NOTES:
 - Copy this block whenever converting planned Sugarkube work into reality.
 
 CONTEXT:
-- Follow [README.md](../README.md), [CONTRIBUTING.md](../CONTRIBUTING.md), and
+- Follow [README.md](../../../README.md), [CONTRIBUTING.md](../../../CONTRIBUTING.md), and
   the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
-- Review [.github/workflows/](../.github/workflows/) so local checks mirror CI.
-- Consult [`llms.txt`](../llms.txt), [`docs/index.md`](../docs/index.md), and
+- Review [.github/workflows/](../../../.github/workflows/) so local checks mirror CI.
+- Consult [`llms.txt`](../../../llms.txt), [`docs/index.md`](../../../docs/index.md), and
   neighboring source files to understand module intent before extending them.
-- Tests live in [`tests/`](../tests/). Python suites run via
+- Tests live in [`tests/`](../../../tests/). Python suites run via
   [pytest](https://docs.pytest.org/en/stable/) and shell suites use
   [Bats](https://bats-core.readthedocs.io/). Match existing patterns when
   adding new coverage.
 - Run `pre-commit run --all-files`; it invokes
-  [`scripts/checks.sh`](../scripts/checks.sh) to install tooling, format code,
+  [`scripts/checks.sh`](../../../scripts/checks.sh) to install tooling, format code,
   lint, and execute tests. When documentation changes, also run
   `pyspelling -c .spellcheck.yaml` and
   `linkchecker --no-warnings README.md docs/`.
@@ -54,14 +54,14 @@ CONTEXT:
   single PR.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py` (script lives at
-  [`scripts/scan-secrets.py`](../scripts/scan-secrets.py)).
-- Log persistent failures in [`outages/`](../outages/) as JSON per
-  [`outages/schema.json`](../outages/schema.json).
+  [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py)).
+- Log persistent failures in [`outages/`](../../../outages/) as JSON per
+  [`outages/schema.json`](../../../outages/schema.json).
 
 REQUEST:
 1. Inventory existing future-work references and justify why the chosen item can
    ship in a single PR right now.
-2. Add a failing automated test in [`tests/`](../tests/) (or an equivalent
+2. Add a failing automated test in [`tests/`](../../../tests/) (or an equivalent
    scripted check) that captures the promised behavior. Once it passes, expand
    coverage for edge cases and regressions.
 3. Implement the smallest change that fulfills the promise, remove or update
@@ -83,17 +83,17 @@ SYSTEM:
 You are an automated contributor for the sugarkube repository.
 
 PURPOSE:
-Improve or expand `docs/prompts-codex-implement.md`.
+Improve or expand `docs/prompts/codex/implement.md`.
 
 USAGE NOTES:
-- Use this prompt to refine `docs/prompts-codex-implement.md`.
+- Use this prompt to refine `docs/prompts/codex/implement.md`.
 
 CONTEXT:
-- Follow [README.md](../README.md), [CONTRIBUTING.md](../CONTRIBUTING.md), and
+- Follow [README.md](../../../README.md), [CONTRIBUTING.md](../../../CONTRIBUTING.md), and
   the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
-- Review [.github/workflows/](../.github/workflows/) to anticipate CI checks.
+- Review [.github/workflows/](../../../.github/workflows/) to anticipate CI checks.
 - Run `pre-commit run --all-files` (invokes
-  [`scripts/checks.sh`](../scripts/checks.sh)). For documentation updates, also
+  [`scripts/checks.sh`](../../../scripts/checks.sh)). For documentation updates, also
   run `pyspelling -c .spellcheck.yaml` and
   `linkchecker --no-warnings README.md docs/`.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
@@ -107,5 +107,5 @@ REQUEST:
 3. Run the commands above and resolve any failures.
 
 OUTPUT:
-A pull request that updates `docs/prompts-codex-implement.md` with passing checks.
+A pull request that updates `docs/prompts/codex/implement.md` with passing checks.
 ```

--- a/docs/prompts/codex/observability.md
+++ b/docs/prompts/codex/observability.md
@@ -1,6 +1,6 @@
 ---
 title: 'Sugarkube Codex Observability Prompt'
-slug: 'prompts-codex-observability'
+slug: 'codex-observability'
 ---
 
 # Codex — Observability Bootstrap

--- a/docs/prompts/codex/pi-image.md
+++ b/docs/prompts/codex/pi-image.md
@@ -1,6 +1,6 @@
 ---
 title: 'Sugarkube Codex Pi Image Prompt'
-slug: 'prompts-codex-pi-image'
+slug: 'codex-pi-image'
 ---
 
 # Codex Pi Image Prompt
@@ -15,12 +15,12 @@ PURPOSE:
 Improve the Pi image build tooling and deployment docs.
 
 CONTEXT:
-- Cloud-init config lives under [`scripts/cloud-init/`](../scripts/cloud-init/).
-- [`scripts/build_pi_image.sh`](../scripts/build_pi_image.sh) builds an image locally or in CI.
+- Cloud-init config lives under [`scripts/cloud-init/`](../../../scripts/cloud-init/).
+- [`scripts/build_pi_image.sh`](../../../scripts/build_pi_image.sh) builds an image locally or in CI.
 - [`pi_image_cloudflare.md`](./pi_image_cloudflare.md) is the user guide.
-- Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository conventions.
+- Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md) for repository conventions.
 - Run `pre-commit run --all-files` to invoke
-  [`scripts/checks.sh`](../scripts/checks.sh) for linting, formatting, and tests.
+  [`scripts/checks.sh`](../../../scripts/checks.sh) for linting, formatting, and tests.
   For documentation changes, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`
@@ -28,8 +28,8 @@ CONTEXT:
   without retries.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py` before committing.
-- Log persistent build issues in [`outages/`](../outages/) per
-  [`outages/schema.json`](../outages/schema.json).
+- Log persistent build issues in [`outages/`](../../../outages/) per
+  [`outages/schema.json`](../../../outages/schema.json).
 
 REQUEST:
 1. Refine the image build script or cloud-init files.
@@ -52,7 +52,7 @@ Use this prompt to refine sugarkube's own prompt documentation.
 ```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
-Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
+Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md).
 Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`
 (requires `aspell` and `aspell-en`),
 `linkchecker --no-warnings README.md docs/`, and
@@ -61,7 +61,7 @@ Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`
   first test run** without retries.
 
 USER:
-1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
+1. Pick one prompt doc under `docs/prompts/codex/` (for example, `docs/prompts/codex/cad.md`).
 2. Fix outdated instructions, links, or formatting.
 3. Add or reinforce guidance that demands 100% patch coverage on the first test execution.
 4. Run the commands above.

--- a/docs/prompts/codex/pi-token-dspace.md
+++ b/docs/prompts/codex/pi-token-dspace.md
@@ -1,6 +1,6 @@
 ---
 title: 'Sugarkube Codex Pi token.place & dspace Prompt'
-slug: 'prompts-codex-pi-token-dspace'
+slug: 'codex-pi-token-dspace'
 ---
 
 # Codex Pi token.place & dspace Prompt
@@ -22,32 +22,32 @@ Reduce the end-to-end steps to build and deploy a Pi image ready for
 `token.place` and `dspace`, leaving extension points for future repos.
 
 CONTEXT:
-- Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for workflow
+- Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md) for workflow
   guidelines.
-- Raspberry Pi OS build script: [`scripts/build_pi_image.sh`](../scripts/build_pi_image.sh)
+- Raspberry Pi OS build script: [`scripts/build_pi_image.sh`](../../../scripts/build_pi_image.sh)
   (targets Raspberry Pi OS Bookworm 64‑bit).
 - Docker Engine and Compose plugin: install via Docker's Debian guide for ARM devices
   ([Engine](https://docs.docker.com/engine/install/debian/) and
   [Compose plugin](https://docs.docker.com/compose/install/linux/#install-using-the-repository)).
   Confirm with `docker --version` and `docker compose version`.
 - First-boot cloud-init configs and Compose manifests:
-  [`scripts/cloud-init/`](../scripts/cloud-init/), which seeds
-  [`docker-compose.yml`](../scripts/cloud-init/docker-compose.yml) for `token.place`
+  [`scripts/cloud-init/`](../../../scripts/cloud-init/), which seeds
+  [`docker-compose.yml`](../../../scripts/cloud-init/docker-compose.yml) for `token.place`
   and `dspace`.
 - Upstream apps:
   - [token.place](https://github.com/futuroptimist/token.place) — see its
     [README](https://github.com/futuroptimist/token.place#readme) for service details.
   - [dspace](https://github.com/democratizedspace/dspace) — see its
     [README](https://github.com/democratizedspace/dspace#readme).
-- Existing Pi image prompt: [`prompts-codex-pi-image.md`](./prompts-codex-pi-image.md).
+- Existing Pi image prompt: [`pi-image.md`](pi-image.md).
 - Repository checks:
-  - `pre-commit run --all-files` (executes [`scripts/checks.sh`](../scripts/checks.sh))
+  - `pre-commit run --all-files` (executes [`scripts/checks.sh`](../../../scripts/checks.sh))
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`
   - `git diff --cached | ./scripts/scan-secrets.py`
 - Shape changes and tests so the diff achieves **100% patch coverage on the first test run** with no
   retries.
-- Review [CI workflows](../.github/workflows/) to anticipate automated checks.
+- Review [CI workflows](../../../.github/workflows/) to anticipate automated checks.
 
 REQUEST:
 1. Add or refine scripts and docs so `token.place` and `dspace` run as services on the Pi
@@ -70,7 +70,7 @@ Use this prompt to refine sugarkube's own prompt documentation.
 ```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
-Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
+Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md).
 Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires
 `aspell` and `aspell-en`), `linkchecker --no-warnings README.md docs/`, and
 `git diff --cached | ./scripts/scan-secrets.py` before committing.

--- a/docs/prompts/codex/spellcheck.md
+++ b/docs/prompts/codex/spellcheck.md
@@ -1,6 +1,6 @@
 ---
 title: 'Sugarkube Codex Spellcheck Prompt'
-slug: 'prompts-codex-spellcheck'
+slug: 'codex-spellcheck'
 ---
 
 # Sugarkube Codex Spellcheck Prompt
@@ -17,9 +17,9 @@ Keep Markdown documentation free of spelling errors.
 CONTEXT:
 - Run `pyspelling -c .spellcheck.yaml` to scan `README.md` and `docs/`
   (requires the `aspell` and `aspell-en` packages).
-- Add legitimate new words to [`.wordlist.txt`](../.wordlist.txt).
-- Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
-- Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../scripts/checks.sh) for
+- Add legitimate new words to [`.wordlist.txt`](../../../.wordlist.txt).
+- Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md).
+- Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../../../scripts/checks.sh) for
   linting, formatting, and tests.
 - Ensure edits and any accompanying tests achieve **100% patch coverage on the first test run** with
   no retries.
@@ -48,7 +48,7 @@ Use this prompt to refine sugarkube's own prompt documentation.
 ```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
-Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
+Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md).
 Run `pre-commit run --all-files`.
 If `package.json` defines them, also run:
 - `npm ci`
@@ -56,14 +56,14 @@ If `package.json` defines them, also run:
 - `npm run test:ci`
 Then run:
 - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; see
-  [`.spellcheck.yaml`](../.spellcheck.yaml))
+  [`.spellcheck.yaml`](../../../.spellcheck.yaml))
 - `linkchecker --no-warnings README.md docs/`
 - `git diff --cached | ./scripts/scan-secrets.py` before committing.
 - Ensure the prompt clearly requires contributors to maintain **100% patch coverage on the first
   test run** without retries.
 
 USER:
-1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
+1. Pick one prompt doc under `docs/prompts/codex/` (for example, `docs/prompts/codex/cad.md`).
 2. Fix outdated instructions, links, or formatting.
 3. Add or reinforce guidance directing contributors to achieve 100% patch coverage on the first test
    execution.

--- a/docs/prompts/codex/tests.md
+++ b/docs/prompts/codex/tests.md
@@ -1,6 +1,6 @@
 ---
 title: 'Sugarkube Codex Tests Prompt'
-slug: 'prompts-codex-tests'
+slug: 'codex-tests'
 ---
 
 # Codex Tests Prompt
@@ -15,32 +15,32 @@ PURPOSE:
 Improve and maintain test coverage.
 
 CONTEXT:
-- Tests live in [`tests/`](../tests/). Python modules end with `*_test.py`
+- Tests live in [`tests/`](../../../tests/). Python modules end with `*_test.py`
   while shell suites use `*_test.bats`. Python tests run with
   [pytest](https://docs.pytest.org/en/stable/) and shell checks use
   [Bats](https://bats-core.readthedocs.io/).
 - For quick iteration, invoke `pytest tests/` or run an individual Bats file such as
   `bats tests/pi_node_verifier_output_test.bats` directly.
-- Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md) for repository
+- Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md) for repository
   conventions.
 - Run `pre-commit run --all-files`; it invokes
-  [`scripts/checks.sh`](../scripts/checks.sh) for linting, formatting, and executing both
+  [`scripts/checks.sh`](../../../scripts/checks.sh) for linting, formatting, and executing both
   test frameworks. The script installs missing tools—including `bats`—so tests run
   consistently.
 - Ensure new and updated tests drive **100% patch coverage on the first test run**; design fixes so
   no reruns are needed.
-- The CI workflow [`tests.yml`](../.github/workflows/tests.yml) runs the test suite on
+- The CI workflow [`tests.yml`](../../../.github/workflows/tests.yml) runs the test suite on
   each push.
 - For documentation updates, also run `pyspelling -c .spellcheck.yaml` (requires
   `aspell` and `aspell-en`) and `linkchecker --no-warnings README.md docs/`.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`
-  before committing (script: [`scripts/scan-secrets.py`](../scripts/scan-secrets.py)).
-- Record persistent test issues in [`outages/`](../outages/) using
-  [`schema.json`](../outages/schema.json).
+  before committing (script: [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py)).
+- Record persistent test issues in [`outages/`](../../../outages/) using
+  [`schema.json`](../../../outages/schema.json).
 
 REQUEST:
 1. Identify missing or flaky test cases.
-2. Write or update tests in [`tests/`](../tests/).
+2. Write or update tests in [`tests/`](../../../tests/).
 3. Adjust implementation if a test exposes a bug.
 4. Re-run `pre-commit run --all-files`; for docs changes also run
    `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/`, confirming
@@ -59,7 +59,7 @@ Use this prompt to refine sugarkube's own prompt documentation.
 ```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
-Follow [`AGENTS.md`](../AGENTS.md) and [`README.md`](../README.md).
+Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md).
 Run `pre-commit run --all-files`.
 If `package.json` defines them, also run:
 - `npm ci`
@@ -73,7 +73,7 @@ Then run:
   run** without retries.
 
 USER:
-1. Pick one prompt doc under `docs/` (for example, `prompts-codex-cad.md`).
+1. Pick one prompt doc under `docs/prompts/codex/` (for example, `docs/prompts/codex/cad.md`).
 2. Fix outdated instructions, links, or formatting.
 3. Add or reinforce guidance directing contributors to attain 100% patch coverage on the first test
    execution.

--- a/docs/prompts/simplification.md
+++ b/docs/prompts/simplification.md
@@ -1,21 +1,21 @@
 ---
 title: 'Sugarkube Simplification Prompt'
-slug: 'prompts-simplification'
+slug: 'simplification'
 ---
 
 # Codebase Simplification Prompt
 
 Use this prompt when you want an automated contributor to simplify the sugarkube
 repository **without** reducing existing capabilities. It pairs well with the
-roadmap in [`simplification_suggestions.md`](../simplification_suggestions.md),
+roadmap in [`simplification_suggestions.md`](../../simplification_suggestions.md),
 which captures current opportunities and ready-made follow-up tasks.
 
 ## Before you run the prompt
 
-* Confirm you understand the repo topology from [`README.md`](../README.md) and
-  the contributor map in [`docs/contributor_script_map.md`](../docs/contributor_script_map.md).
-* Review the automation stack described in [`llms.txt`](../llms.txt) and the
-  active workflows inside [`.github/workflows/`](../.github/workflows/) so local
+* Confirm you understand the repo topology from [`README.md`](../../README.md) and
+  the contributor map in [`docs/contributor_script_map.md`](../contributor_script_map.md).
+* Review the automation stack described in [`llms.txt`](../../llms.txt) and the
+  active workflows inside [`.github/workflows/`](../../.github/workflows/) so local
   runs mirror CI expectations.
 * Skim the simplification backlog above and log any new ideas you discover so
   they remain actionable for future iterations.
@@ -29,14 +29,14 @@ Retain the repo's functionality while simplifying framing, onboarding,
 maintenance chores, and the learning curve.
 
 CONTEXT:
-- Sugarkube blends hardware (see [`cad/`](../cad/) and [`elex/`](../elex/)) with
+- Sugarkube blends hardware (see [`cad/`](../../cad/) and [`elex/`](../../elex/)) with
   software helpers (`scripts/`, `Formula/`, and automation under
-  [`docs/`](../docs/)). Start with the contributor story in
-  [`docs/index.md`](../docs/index.md) and the script map linked above.
-- Follow [`AGENTS.md`](../AGENTS.md), [`CONTRIBUTING.md`](../CONTRIBUTING.md),
-  and [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md).
+  [`docs/`](../)). Start with the contributor story in
+  [`docs/index.md`](../index.md) and the script map linked above.
+- Follow [`AGENTS.md`](../../AGENTS.md), [`CONTRIBUTING.md`](../../CONTRIBUTING.md),
+  and [`CODE_OF_CONDUCT.md`](../../CODE_OF_CONDUCT.md).
 - Run `pre-commit run --all-files`, which shells into
-  [`scripts/checks.sh`](../scripts/checks.sh) to install tooling, lint, format,
+  [`scripts/checks.sh`](../../scripts/checks.sh) to install tooling, lint, format,
   and execute tests. The helper triggers `npm ci`, `npm run lint`, and
   `npm run test:ci` whenever a `package.json` is present.
 - When documentation changes (`README.md` or files under `docs/`), additionally
@@ -45,10 +45,10 @@ CONTEXT:
   - `linkchecker --no-warnings README.md docs/`
 - Before committing, scan staged changes with
   `git diff --cached | ./scripts/scan-secrets.py` (script lives at
-  [`scripts/scan-secrets.py`](../scripts/scan-secrets.py)).
+  [`scripts/scan-secrets.py`](../../scripts/scan-secrets.py)).
 - Demand **100% patch coverage on the first test run**—no retries.
 - If recurring failures surface, log an outage record under
-  [`outages/`](../outages/).
+  [`outages/`](../../outages/).
 
 REQUEST:
 1. Audit onboarding flows, contributor ergonomics, and redundant scaffolding.
@@ -62,7 +62,7 @@ REQUEST:
 OUTPUT:
 A pull request summarizing simplifications, test results, and follow-up ideas
 for future cleanups. Cross-link relevant entries in
-[`simplification_suggestions.md`](../simplification_suggestions.md) or add new
+[`simplification_suggestions.md`](../../simplification_suggestions.md) or add new
 ones so the backlog stays fresh.
 ```
 
@@ -75,11 +75,11 @@ expectations change.
 ```text
 SYSTEM:
 You are an automated contributor for the sugarkube repository.
-Follow [`AGENTS.md`](../AGENTS.md), [`CONTRIBUTING.md`](../CONTRIBUTING.md), and
-[`README.md`](../README.md). Consult [`llms.txt`](../llms.txt) for the current
+Follow [`AGENTS.md`](../../AGENTS.md), [`CONTRIBUTING.md`](../../CONTRIBUTING.md), and
+[`README.md`](../../README.md). Consult [`llms.txt`](../../llms.txt) for the current
 component map.
 Run `pre-commit run --all-files` (invokes
-[`scripts/checks.sh`](../scripts/checks.sh) to install tooling and execute
+[`scripts/checks.sh`](../../scripts/checks.sh) to install tooling and execute
 linters, formatters, and tests). When docs change also run:
 - `pyspelling -c .spellcheck.yaml`
 - `linkchecker --no-warnings README.md docs/`
@@ -88,7 +88,7 @@ Ensure the final diff delivers **100% patch coverage on the first test run**.
 
 USER:
 1. Review this prompt for stale context, missing onboarding cues, or redundant
-   instructions compared to other `docs/prompts-*.md` files.
+   instructions compared to other prompt docs under `docs/prompts/`.
 2. Refresh links, command references, and expectations so they align with the
    current repository workflow and the simplification backlog.
 3. Tighten the language to emphasize simplification outcomes and safety checks
@@ -96,6 +96,6 @@ USER:
 4. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request that modernizes `docs/prompts-simplification.md` while preserving
+A pull request that modernizes `docs/prompts/simplification.md` while preserving
 its focus on safe simplification.
 ```

--- a/simplification_suggestions.md
+++ b/simplification_suggestions.md
@@ -2,7 +2,7 @@
 
 _Last reviewed: 2025-09-24_
 
-Use this backlog alongside [`docs/prompts-simplification.md`](docs/prompts-simplification.md)
+Use this backlog alongside [`docs/prompts/simplification.md`](docs/prompts/simplification.md)
 when you staff simplification-focused PRs. Every initiative keeps existing
 hardware and software workflows intact while removing friction for new
 contributors.
@@ -85,7 +85,7 @@ checks. The prompts require 100% compliance, but setup steps remain scattered.
 **Current assets:**
 - [`scripts/checks.sh`](scripts/checks.sh) – orchestrates repo-wide tooling.
 - [`justfile`](justfile) and [`Makefile`](Makefile) – existing task runners.
-- [`docs/prompts-codex-docs.md`](docs/prompts-codex-docs.md) – sets doc-quality
+- [`docs/prompts/codex/docs.md`](docs/prompts/codex/docs.md) – sets doc-quality
   expectations for automated contributors.
 
 **First steps:**


### PR DESCRIPTION
what: move codex prompt docs into docs/prompts/codex and fix links
why: align sugarkube prompts with flywheel layout for easier reuse
how to test: pre-commit run --all-files;
  pyspelling -c .spellcheck.yaml;
  linkchecker --no-warnings README.md docs/

------
https://chatgpt.com/codex/tasks/task_e_68d628dc6f98832fae3b286584a82ee2