### PR TITLE
Add simplification templates and regression test

### DIFF
--- a/docs/templates/simplification/README.md
+++ b/docs/templates/simplification/README.md
@@ -1,0 +1,17 @@
+# Simplification Templates
+
+These templates accelerate the workstreams highlighted in
+[simplification_suggestions.md](../../simplification_suggestions.md). Copy a
+file, replace the placeholder callouts, and link the resulting artifact from the
+relevant proposal, retro, or documentation PR.
+
+- `onboarding-update.md` — summarize a change to the onboarding path before
+  updating docs or automation.
+- `prompt-refresh.md` — capture prompt deltas, rationale, and coverage before
+  opening a PR that edits `docs/prompts/`.
+- `simplification-sprint.md` — scope and align a focused simplification push,
+  including deliverables, staffing, and metrics.
+
+All templates end with an **Actions** checklist so contributors can track
+reviews, docs updates, and verification steps. Archive the completed files in
+`notes/` or the relevant project folder once the initiative wraps.

--- a/docs/templates/simplification/onboarding-update.md
+++ b/docs/templates/simplification/onboarding-update.md
@@ -1,0 +1,34 @@
+# Onboarding Update Template
+
+## Goals
+- What onboarding friction are we removing?
+- Which personas benefit (hardware, docs, automation)?
+- How will we measure success (time-to-first-change, tutorial completion, etc.)?
+
+## Required Artifacts
+- Link to the updated quickstart, handbook, or tutorial draft.
+- Evidence that automation (`make doctor`, `just start-here`, etc.) reflects the
+  new path.
+- Screenshots or recordings that walk through the refreshed flow.
+
+## Stakeholders
+- DRI:
+- Reviewers:
+- Impacted docs/scripts:
+
+## Rollout Plan
+- Dry run the new onboarding steps on a clean workstation or Codespace.
+- Capture before/after diffs for docs and automation helpers.
+- Coordinate announcements (Slack, docs site changelog, README badges).
+
+## Follow-up
+- Survey new contributors after launch and record feedback.
+- Archive evidence in `notes/onboarding/`.
+- File follow-up issues for deferred improvements.
+
+## Actions
+- [ ] Draft reviewed by stakeholders
+- [ ] Automation validated with `pre-commit run --all-files`
+- [ ] Docs checks: `pyspelling -c .spellcheck.yaml`
+- [ ] Docs checks: `linkchecker --no-warnings README.md docs/`
+- [ ] Post-launch survey scheduled

--- a/docs/templates/simplification/prompt-refresh.md
+++ b/docs/templates/simplification/prompt-refresh.md
@@ -1,0 +1,33 @@
+# Prompt Refresh Template
+
+## Current Guidance
+- Prompt file(s):
+- Linked docs or automation that rely on this guidance:
+- Known pain points or reports that triggered the refresh:
+
+## Proposed Changes
+- Summarize edits by section (additions, removals, clarifications).
+- Call out any new guardrails or checklists contributors must follow.
+- Note tooling or workflow updates (new commands, required outputs, etc.).
+
+## Verification
+- Dry run the prompt against a recent PR or simulation.
+- Confirm tests achieve 100% patch coverage on the first run.
+- Capture transcripts or artifacts proving the new flow works.
+
+## Rollout Notes
+- Update cross-links in other prompts or docs.
+- Notify affected contributor groups (automation, docs, hardware).
+- Stage follow-up work for deeper changes uncovered during review.
+
+## Follow-up
+- Monitor subsequent contributions for regressions.
+- File tracking issues for improvements deferred out of scope.
+- Record lessons learned in `docs/prompts/CHANGELOG.md` (create if missing).
+
+## Actions
+- [ ] Prompt diff reviewed and approved
+- [ ] Regression tests updated or added
+- [ ] Docs checks: `pyspelling -c .spellcheck.yaml`
+- [ ] Docs checks: `linkchecker --no-warnings README.md docs/`
+- [ ] Communication plan executed

--- a/docs/templates/simplification/simplification-sprint.md
+++ b/docs/templates/simplification/simplification-sprint.md
@@ -1,0 +1,33 @@
+# Simplification Sprint Template
+
+## Scope
+- Theme or friction targeted (e.g., flashing UX, docs onboarding, CI hygiene).
+- Timebox and participants (include on-call or async reviewers).
+- Dependencies or prerequisites that must land first.
+
+## Constraints
+- Tooling limitations, hardware availability, or access requirements.
+- Quality bars that must remain untouched (coverage, lint, reproducibility).
+- Known risks or mitigations.
+
+## Success Metrics
+- Quantitative wins (reduced steps, faster setup, fewer support tickets).
+- Qualitative wins (clearer docs, happier contributors, smoother demos).
+- Evidence collection plan (reports, recordings, surveys).
+
+## Execution Plan
+- Kickoff checklist (sync agenda, roles, tracking doc).
+- Daily/async status ritual and reporting expectations.
+- Wrap-up deliverables (demo, retro, docs PRs, changelog entry).
+
+## Follow-up
+- Archive outputs in `notes/simplification/` or the relevant project folder.
+- File follow-on tasks for backlog items out of scope.
+- Schedule a retrospective with action items.
+
+## Actions
+- [ ] Sprint brief approved
+- [ ] Tracking issue or project board created
+- [ ] Kickoff scheduled
+- [ ] Retro scheduled with facilitator
+- [ ] Metrics review completed post-sprint

--- a/simplification_suggestions.md
+++ b/simplification_suggestions.md
@@ -95,8 +95,8 @@ checks. The prompts require 100% compliance, but setup steps remain scattered.
    has regression coverage in `tests/checks_script_test.py::test_docs_only_mode_runs_docs_checks`.
 2. Extend `scripts/checks.sh` with a `--docs-only` flag that skips hardware
    toolchains when unnecessary.
-3. Bundle templates in `docs/templates/` for onboarding updates, prompt refreshes,
-   and simplification sprints so authors can focus on content.
+3. ✅ Bundle templates in `docs/templates/simplification/` for onboarding updates,
+   prompt refreshes, and simplification sprints so authors can focus on content.
 
 **Safeguards:**
 - Ensure the new targets still respect `AGENTS.md` expectations (100% patch

--- a/tests/simplification_templates_test.py
+++ b/tests/simplification_templates_test.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+
+def test_simplification_templates_exist():
+    base = Path(__file__).resolve().parents[1] / "docs" / "templates" / "simplification"
+    assert base.is_dir(), "docs/templates/simplification directory missing"
+
+    templates = {
+        "onboarding-update.md": [
+            "# Onboarding Update Template",
+            "## Goals",
+            "## Required Artifacts",
+            "## Follow-up",
+        ],
+        "prompt-refresh.md": [
+            "# Prompt Refresh Template",
+            "## Current Guidance",
+            "## Proposed Changes",
+            "## Verification",
+        ],
+        "simplification-sprint.md": [
+            "# Simplification Sprint Template",
+            "## Scope",
+            "## Constraints",
+            "## Success Metrics",
+        ],
+    }
+
+    for name, markers in templates.items():
+        path = base / name
+        assert path.is_file(), f"Missing simplification template: {name}"
+        content = path.read_text(encoding="utf-8")
+        for marker in markers:
+            assert marker in content, f"Template {name} missing section heading: {marker}"
+
+    readme = base / "README.md"
+    assert readme.is_file(), "Missing simplification templates README"
+    readme_text = readme.read_text(encoding="utf-8")
+    for expected in templates:
+        assert expected in readme_text, f"README missing reference to {expected}"


### PR DESCRIPTION
## What
- add docs/templates/simplification with onboarding, prompt, and sprint templates
- mark the simplification_suggestions.md step as complete and add coverage

## Why
- close the documented plan to bundle simplification templates for contributors

## How to test
- pre-commit run --all-files
- pytest tests/simplification_templates_test.py
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

Refs: N/A

------
https://chatgpt.com/codex/tasks/task_e_68d643f7b400832fac6ca9ad090a26bc