### PR TITLE
Add pi-gen stage summary export

### DIFF
--- a/docs/pi_image_builder_design.md
+++ b/docs/pi_image_builder_design.md
@@ -100,7 +100,9 @@
 - `build_pi_image.sh` now writes `sugarkube.img.xz.metadata.json` with the pi-gen
   commit, stage durations parsed from `work/<img>/build.log`, the git ref used for
   the build, and all toggles passed to the script. The log itself is copied to
-  `sugarkube.build.log` alongside the artifacts.
+  `sugarkube.build.log` alongside the artifacts, and a companion
+  `sugarkube.img.xz.stages.json` file enumerates each pi-gen stage with its
+  start/end timestamps and elapsed seconds for quick progress summaries.
 - `scripts/generate_release_manifest.py` converts the metadata into a
   provenance manifest (`sugarkube.img.xz.manifest.json`) and Markdown release notes.
   The manifest captures workflow run IDs, release channel (stable vs nightly),
@@ -135,6 +137,3 @@
 ## Security
 Read-only mount for cloud-init file into container
 - No secrets embedded; Cloudflare token remains empty by default
-
-## Future Enhancements
-- Structured logs from `pi-gen` stages to summarize progress/time

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -744,6 +744,7 @@ else
 fi
 
 METADATA_PATH="${OUT_IMG}.metadata.json"
+STAGE_SUMMARY_PATH="${OUT_IMG}.stages.json"
 metadata_args=(
   --output "${METADATA_PATH}"
   --image "${OUT_IMG}"
@@ -775,7 +776,11 @@ if [ -n "${PI_GEN_SOURCE_DIR}" ]; then
 fi
 if [ -n "${OUT_LOG}" ]; then
   metadata_args+=(--build-log "${OUT_LOG}")
+  metadata_args+=(--stage-summary "${STAGE_SUMMARY_PATH}")
 fi
 
 python3 "${REPO_ROOT}/scripts/create_build_metadata.py" "${metadata_args[@]}"
 echo "[sugarkube] Build metadata captured at ${METADATA_PATH}"
+if [ -f "${STAGE_SUMMARY_PATH}" ]; then
+  echo "[sugarkube] Stage summary written to ${STAGE_SUMMARY_PATH}"
+fi


### PR DESCRIPTION
## Summary
- inventoried future-work references and found the pi_image_builder_design.md note about structured pi-gen stage logs ready to ship in a single PR
- emit structured stage summaries from create_build_metadata.py, persist them to metadata and a stages.json artifact, and surface the path in build_pi_image.sh
- update release automation docs to describe the new stages.json output and remove the stale future enhancement entry

## Testing
- pipx run pre-commit run --all-files
- pipx run pyspelling -c .spellcheck.yaml
- pipx run linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py


------
https://chatgpt.com/codex/tasks/task_e_68d643f7b400832fac6ca9ad090a26bc