### PR TITLE
Add self-heal service README and docs coverage

### DIFF
--- a/docs/pi_carrier_launch_playbook.md
+++ b/docs/pi_carrier_launch_playbook.md
@@ -192,7 +192,9 @@ needs customization or when debugging an unfamiliar scenario.
   reporting.
 - [`sugarkube-self-heal@.service`](../scripts/systemd/self-heal-service/README.md) and
   [`self_heal_service.py`](../scripts/self_heal_service.py) document automated remediation flows
-  when container pulls or cloud-init runs fail.
+  when container pulls or cloud-init runs fail. The README now calls out log locations and links to
+  regression coverage (`tests/self_heal_service_docs_test.py`) so operators know where to start
+  their incident response.
 - [`ssd_post_clone_validate.py`](../scripts/ssd_post_clone_validate.py) checks EEPROM boot order,
   `/etc/fstab`, and stress tests new storage.
 - [`rollback_to_sd.sh`](../scripts/rollback_to_sd.sh) provides a guided rollback if SSD validation

--- a/scripts/systemd/self-heal-service/README.md
+++ b/scripts/systemd/self-heal-service/README.md
@@ -1,0 +1,53 @@
+# Sugarkube Self-Heal Service
+
+`sugarkube-self-heal@.service` wraps `scripts/self_heal_service.py` so failed boot-
+critical units retry with useful telemetry before escalating to rescue mode. The
+helper is installed on every image build and watches for units that declare
+`OnFailure=sugarkube-self-heal@%n.service` (for example
+`projects-compose.service`, `cloud-final.service`, and
+`sugarkube-helm-bundles.service`).
+
+When a monitored unit fails the helper:
+
+1. Records the failure inside `/var/log/sugarkube/self-heal/<unit>.json` with
+   timestamps, retry counts, and exit codes.
+2. Copies Markdown summaries, the most recent journal excerpt, and Docker/Kubernetes
+   command output to `/boot/first-boot-report/self-heal/<unit>/` for air-gapped
+   debugging.
+3. Retries the unit up to the configured limit (default three attempts) before
+   isolating the host into `rescue.target` so operators can intervene safely.
+
+## Manual invocation
+
+Run the helper directly to rehearse recovery flows without waiting for a real
+failure:
+
+```sh
+sudo /opt/sugarkube/self_heal_service.py --unit projects-compose.service \
+  --reason "dry run"
+```
+
+Supply `--state-dir` and `--boot-dir` to redirect logs when testing from a
+workstation. The Python entrypoint honours environment variables like
+`SUGARKUBE_SELF_HEAL_MAX_ATTEMPTS` and `SUGARKUBE_SELF_HEAL_RETRY_DELAY` so you
+can shorten loops during rehearsals.
+
+## Debugging tips
+
+- Inspect `/boot/first-boot-report/self-heal/<unit>/` first; it mirrors the
+  Markdown summaries uploaded to CI artifacts.
+- Check `/var/log/sugarkube/self-heal/<unit>.json` for the retry history and the
+  final decision (`retry`, `succeeded`, `rescued`).
+- Use `journalctl -u "sugarkube-self-heal@<unit>.service" --no-pager` to watch
+  live progress while the helper runs.
+- Pair the logs with `make support-bundle` to archive additional context during
+  post-mortems.
+
+## Regression coverage
+
+Automated coverage for the helper lives in:
+
+- `tests/self_heal_service_test.py` – exercises retry limits, rescue mode, and
+  logging behavior.
+- `tests/self_heal_service_docs_test.py` – ensures this README documents the key
+  locations operators rely on during incidents.

--- a/tests/self_heal_service_docs_test.py
+++ b/tests/self_heal_service_docs_test.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_self_heal_service_readme_exists_and_highlights_paths() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    readme = repo_root / "scripts" / "systemd" / "self-heal-service" / "README.md"
+    assert readme.exists(), "Expected self-heal service README to be present"
+
+    contents = readme.read_text()
+    assert "sugarkube-self-heal@.service" in contents
+    assert "self_heal_service.py" in contents
+    assert "/boot/first-boot-report/self-heal/" in contents
+    assert "/var/log/sugarkube/self-heal/" in contents

--- a/tests/test_create_build_metadata.py
+++ b/tests/test_create_build_metadata.py
@@ -9,7 +9,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from scripts import create_build_metadata as cbm
+from scripts import create_build_metadata as cbm  # noqa: E402
 
 
 def _create_command_args(
@@ -164,6 +164,4 @@ def test_stage_summary_incomplete_entries(tmp_path):
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     assert summary["stage_count"] == 1
     assert summary["observed_elapsed_seconds"] == 5
-    assert summary["incomplete_stages"] == [
-        {"name": "stage1", "start_offset_seconds": 5}
-    ]
+    assert summary["incomplete_stages"] == [{"name": "stage1", "start_offset_seconds": 5}]


### PR DESCRIPTION
## Summary
- add a README for the self-heal service with log locations and manual usage
- guard the README with a pytest that checks the documented paths stay present
- note the coverage in the launch playbook and satisfy flake8 formatting

## Testing
- PYTHONPATH=. python -m pre_commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- pytest tests/self_heal_service_docs_test.py
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d715ba2ba0832fbd87d6724d8a20a6