### PR TITLE
Add support bundle target copying

### DIFF
--- a/docs/pi_carrier_launch_playbook.md
+++ b/docs/pi_carrier_launch_playbook.md
@@ -104,8 +104,9 @@ fast path above.
   [`pi_headless_provisioning.md`](./pi_headless_provisioning.md) to stage Wi-Fi credentials and
   tokens in `secrets.env` files consumed by cloud-init so SD cards stay clean of long-lived secrets.
 - **Verify before leaving the site:** Run `make support-bundle` or
-  `./scripts/collect_support_bundle.py --target /boot/first-boot-report/support-bundles` to archive
-  logs for future debugging.
+  `./scripts/collect_support_bundle.py --target /boot/first-boot-report` to archive first-boot logs
+  for future debugging. The helper stores copied directories under `targets/` in the bundle so the
+  exported reports remain alongside the captured command output.
 
 ### Classroom facilitator (multiple Pis, shared bench)
 

--- a/docs/pi_support_bundles.md
+++ b/docs/pi_support_bundles.md
@@ -33,6 +33,12 @@ The script stores results under `support-bundles/<host>-<timestamp>/` and also e
 `.tar.gz`. Override `--no-archive` to keep only the raw directory, and `--spec` to append extra
 commands (`output/path.txt:command:description`).
 
+Pass `--target` to copy remote files or directories into the bundle. Each path is stored beneath
+`targets/` using a sanitized directory name so artefacts like `/boot/first-boot-report/` travel with
+the captured command output. Failures are logged to stderr and recorded in `summary.json` under the
+`targets` key for quick triage. Automated coverage lives in
+`tests/test_collect_support_bundle.py::test_copy_targets_captures_paths`.
+
 Make and Just wrappers mirror the CLI:
 
 ```bash

--- a/tests/test_collect_support_bundle.py
+++ b/tests/test_collect_support_bundle.py
@@ -41,6 +41,12 @@ def test_parse_extra_specs(entry: str, expected_path: Path) -> None:
     assert spec.description == "Extra command"
 
 
+def test_parse_args_includes_target_flag() -> None:
+    args = collect_support_bundle.parse_args(["pi.local"])
+    assert hasattr(args, "target")
+    assert args.target == []
+
+
 def test_build_bundle_dir_sanitises_host(tmp_path: Path) -> None:
     ts = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
     bundle = collect_support_bundle.build_bundle_dir(tmp_path, "pi.local:2222", ts)
@@ -56,6 +62,7 @@ def test_parse_args_defaults() -> None:
     assert args.command_timeout == collect_support_bundle.DEFAULT_COMMAND_TIMEOUT
     assert args.connect_timeout == collect_support_bundle.DEFAULT_CONNECT_TIMEOUT
     assert args.spec == []
+    assert args.target == []
 
 
 def test_parse_extra_specs_invalid_format() -> None:
@@ -76,6 +83,7 @@ def test_build_ssh_command_includes_identity_and_options() -> None:
         port=2022,
         connect_timeout=5,
         ssh_option=["LogLevel=ERROR", "Compression=yes"],
+        target=[],
     )
     cmd = collect_support_bundle.build_ssh_command(args, "echo hi")
     assert cmd[:2] == ["ssh", "-o"]
@@ -89,6 +97,49 @@ def test_write_command_output_creates_parent_dirs(tmp_path: Path) -> None:
     target = tmp_path / "nested" / "output.txt"
     collect_support_bundle.write_command_output(target, "payload")
     assert target.read_text() == "payload"
+
+
+def test_copy_targets_captures_paths(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    commands: list[list[str]] = []
+
+    class DummyCompleted:
+        def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    responses = [
+        DummyCompleted(0, stdout="ok"),
+        DummyCompleted(5, stderr="denied"),
+    ]
+
+    def fake_run(cmd: list[str], **_kwargs):
+        commands.append(cmd)
+        return responses.pop(0)
+
+    monkeypatch.setattr(collect_support_bundle.subprocess, "run", fake_run)
+
+    args = Namespace(
+        user="pi",
+        host="pi.local",
+        identity="/tmp/id_ed25519",
+        port=2222,
+        connect_timeout=7,
+        ssh_option=["LogLevel=ERROR"],
+        command_timeout=30,
+        target=["/boot/first-boot-report", "/var/log/syslog"],
+    )
+
+    results = collect_support_bundle.copy_targets(args, tmp_path)
+
+    assert len(results) == 2
+    assert results[0]["status"] == "success"
+    assert results[0]["path"] == "/boot/first-boot-report"
+    assert "local_path" in results[0]
+    assert results[1]["status"] == "failed"
+    assert results[1]["path"] == "/var/log/syslog"
+    assert results[1]["exit_code"] == 5
+    assert commands and commands[0][0] == "scp"
 
 
 def test_execute_specs_writes_logs(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
@@ -118,6 +169,7 @@ def test_execute_specs_writes_logs(tmp_path: Path, monkeypatch: MonkeyPatch) -> 
         connect_timeout=10,
         ssh_option=[],
         command_timeout=30,
+        target=[],
     )
     specs = [
         collect_support_bundle.CommandSpec(Path("foo.txt"), "echo foo", "first"),
@@ -147,6 +199,7 @@ def test_execute_specs_handles_timeout(tmp_path: Path, monkeypatch: MonkeyPatch)
         connect_timeout=10,
         ssh_option=[],
         command_timeout=10,
+        target=[],
     )
     spec = collect_support_bundle.CommandSpec(Path("foo.txt"), "echo foo", "desc")
     results = collect_support_bundle.execute_specs(args, [spec], tmp_path)

--- a/tests/test_create_build_metadata.py
+++ b/tests/test_create_build_metadata.py
@@ -9,7 +9,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from scripts import create_build_metadata as cbm
+from scripts import create_build_metadata as cbm  # noqa: E402
 
 
 def _create_command_args(
@@ -164,6 +164,4 @@ def test_stage_summary_incomplete_entries(tmp_path):
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     assert summary["stage_count"] == 1
     assert summary["observed_elapsed_seconds"] == 5
-    assert summary["incomplete_stages"] == [
-        {"name": "stage1", "start_offset_seconds": 5}
-    ]
+    assert summary["incomplete_stages"] == [{"name": "stage1", "start_offset_seconds": 5}]


### PR DESCRIPTION
🚀 : –
what: add --target syncing to collect_support_bundle.py with docs/tests
why: match docs that promise bundling first-boot reports for offline triage
how to test:
 - PYTHONPATH=. pre-commit run --all-files
 - pyspelling -c .spellcheck.yaml
 - linkchecker --no-warnings README.md docs/
 - git diff --cached | ./scripts/scan-secrets.py
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68d715ba2ba0832fbd87d6724d8a20a6