### PR TITLE
✅ : – fix qemu smoke test permissions

### DIFF
--- a/outages/2025-09-27-qemu-smoke-permission.json
+++ b/outages/2025-09-27-qemu-smoke-permission.json
@@ -1,0 +1,10 @@
+{
+  "id": "2025-09-27-qemu-smoke-permission",
+  "date": "2025-09-27",
+  "component": "qemu_pi_smoke_test",
+  "rootCause": "/opt/smoketest stub was written without sudo, so the mount rejected writes.",
+  "resolution": "Install stub, drop-in, and marker with sudo install so root paths stay writable.",
+  "references": [
+    "https://github.com/futuroptimist/sugarkube/actions/runs/18051658696/job/51374712951"
+  ]
+}


### PR DESCRIPTION
what: install smoke-test assets via sudo helper and add outage log
why: GitHub Actions cannot write to the mounted root fs without sudo
how to test: scripts/qemu_pi_smoke_test.py run in CI
Refs: #n/a

------
https://chatgpt.com/codex/tasks/task_e_68d7630c04f8832fa9457caca5442b95