### PR TITLE
Document Sugarkube ergonomics KPIs in status readme

### DIFF
--- a/docs/status/README.md
+++ b/docs/status/README.md
@@ -1,0 +1,72 @@
+# Sugarkube Status Dashboards
+
+Track the health of Sugarkube automation and ergonomics efforts from a single
+reference point. This index complements the existing Shields.io badges (for
+example [`docs/status/hardware-boot.json`](./hardware-boot.json)) by outlining
+which metrics matter, how they are measured, and where to publish updates so
+contributors can tell at a glance whether the platform is improving.
+
+## Ergonomics KPIs
+
+These core indicators gauge how approachable the platform feels for new and
+returning contributors. Record snapshots in release notes, internal dashboards,
+or documentation updates whenever the numbers move.
+
+### Image build duration
+
+* **What it measures:** Total runtime of the GitHub Actions `pi-image` workflow
+  from queue to artifact upload.
+* **Why it matters:** Faster builds shorten the feedback loop when iterating on
+  cloud-init hooks, bundled repositories, or base OS upgrades.
+* **How to measure:** Pull the `workflow_run.duration_ms` field from the
+  `pi-image` workflow or export the value from `scripts/publish_telemetry.py`
+  when posting build metrics.
+* **Where to log it:** Include the value in the `pi-image` release notes and any
+  dashboard cards that summarize build health.
+
+### Smoke-test pass rate
+
+* **What it measures:** Success percentage of `scripts/pi_smoke_test.py` runs
+  across physical hardware and QEMU rehearsals.
+* **Why it matters:** Catching regressions in token.place, dspace, or verifier
+  plumbing keeps first boot reliable for real deployments.
+* **How to measure:** Track the ratio of `PASS` lines in the smoke test logs or
+  record the result exported by the `pi_smoke_test` JSON summary. Combine
+  results from the scheduled QEMU job with manual hardware runs documented via
+  the hardware boot badge updates.
+* **Where to log it:** Summarize the current pass rate in `docs/status/` badge
+  descriptions or in a `status.md` snippet linked from contributor retros.
+
+### Onboarding checklist completion time
+
+* **What it measures:** The elapsed time for a new contributor to work through
+  the onboarding checklist from [docs/tutorials/index.md](../tutorials/index.md)
+  (cloning the repo, running `just codespaces-bootstrap`, generating required
+  artifacts, and opening their first PR).
+* **Why it matters:** Lower completion times signal that documentation, prompts,
+  and automation helpers remain approachable.
+* **How to measure:** Capture timestamps in tutorial artifacts (for example,
+  commit logs or notes files) and subtract the start time of Tutorial 1 from the
+  completion time of Tutorial 4’s checklist submission.
+* **Where to log it:** Record representative values in contributor retros,
+  simplification sprint reports, or a shared spreadsheet so trends stay visible.
+
+## Publishing updates
+
+* Snapshot metrics during each release and link supporting evidence (workflow
+  URLs, smoke-test reports, tutorial logs).
+* When numbers change materially, update dashboards (Markdown badges, Grafana,
+  or internal tools) and reference the delta in the next changelog entry.
+* Tie simplification proposals back to at least one KPI so reviewers can confirm
+  the expected impact.
+
+## Related resources
+
+- [docs/pi_image_quickstart.md](../pi_image_quickstart.md) — operational source
+  of truth for build, flash, and verification flows.
+- [docs/pi_smoke_test.md](../pi_smoke_test.md) — CLI usage and report formats for
+  the smoke-test harness.
+- [docs/tutorials/index.md](../tutorials/index.md) — onboarding roadmap used to
+  measure checklist completion time.
+- [scripts/publish_telemetry.py](../../scripts/publish_telemetry.py) — exporter
+  that can surface build metrics alongside other fleet telemetry.

--- a/simplification_suggestions.md
+++ b/simplification_suggestions.md
@@ -152,7 +152,7 @@ and record navigation improvements in the docs changelog.
   exporter for Pi builds.
 
 **First steps:**
-1. Define a core set of ergonomics KPIs (image build duration, smoke-test pass
+1. ✅ Define a core set of ergonomics KPIs (image build duration, smoke-test pass
    rate, onboarding checklist completion time) and document them in
    `docs/status/README.md`.
 2. Extend the telemetry publisher to emit these metrics into Grafana (or persist

--- a/tests/test_status_docs.py
+++ b/tests/test_status_docs.py
@@ -24,7 +24,7 @@ def test_status_readme_lists_core_kpis() -> None:
 def test_status_readme_calls_out_measurement_sources() -> None:
     text = DOC_PATH.read_text(encoding="utf-8")
     expected_phrases = [
-        "pi-image workflow",
+        "`pi-image` workflow",
         "pi_smoke_test",
         "tutorial artifacts",
     ]

--- a/tests/test_status_docs.py
+++ b/tests/test_status_docs.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+DOC_PATH = Path(__file__).resolve().parents[1] / "docs" / "status" / "README.md"
+
+
+def test_status_readme_exists() -> None:
+    assert DOC_PATH.exists(), "docs/status/README.md is missing"
+
+
+def test_status_readme_lists_core_kpis() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    assert "## Ergonomics KPIs" in text
+    required_sections = [
+        "### Image build duration",
+        "### Smoke-test pass rate",
+        "### Onboarding checklist completion time",
+    ]
+    for heading in required_sections:
+        assert heading in text, f"Expected heading '{heading}' in docs/status/README.md"
+
+
+def test_status_readme_calls_out_measurement_sources() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    expected_phrases = [
+        "pi-image workflow",
+        "pi_smoke_test",
+        "tutorial artifacts",
+    ]
+    for phrase in expected_phrases:
+        assert phrase in text, f"Expected phrase '{phrase}' describing measurement guidance"


### PR DESCRIPTION
what: add docs/status/README.md and tests covering required KPI sections
why: ships the simplification_suggestions.md ergonomics KPI checklist item
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/

------
https://chatgpt.com/codex/tasks/task_e_68d76b024468832fa06235e7e4d5d07b