### PR TITLE
Add power ring wiring guide with assets and doc test

### DIFF
--- a/docs/electronics_schematics.md
+++ b/docs/electronics_schematics.md
@@ -49,4 +49,37 @@ The layout now includes a "SugarKube" copper label for easy identification.
 
 ## Fritzing Sketch
 
-Placeholder for wiring diagrams created with Fritzing.
+Use the wiring map below to reproduce the power ring harness in
+[Fritzing](https://fritzing.org/) or during bench assembly. The repository now
+ships a structured connection list at
+[`docs/fritzing/power_ring_wiring.csv`](./fritzing/power_ring_wiring.csv) that
+records every net, suggested wire colour, and safety note. Import it into a
+spreadsheet while you route traces so each jumper is accounted for.
+
+![Power ring wiring diagram](images/power_ring_wiring.svg)
+
+| Connector | Function | Suggested Wire | Notes |
+| --- | --- | --- | --- |
+| J1 | 12&nbsp;V DC input screw terminal | 16&nbsp;AWG red (positive) / 16&nbsp;AWG black (return) | Feed from a regulated supply or charge controller and keep leads short. |
+| F1 | 10&nbsp;A blade fuse | Inline with J1 positive lead | Protects the entire ring; carry spares for field swaps. |
+| TP1 / TP2 | Voltage test points | 22&nbsp;AWG jumpers | Clip a multimeter here before powering downstream loads. |
+| J2&nbsp;–&nbsp;J5 | 2-pin JST-VH branch outputs | 18&nbsp;AWG red/black pairs | Power Raspberry Pi nodes, fans, or lighting; label each lead to match the project. |
+| LED1 + R1 | Power indicator LED and series resistor | 26&nbsp;AWG | Choose the resistor footprint that matches your LED forward voltage/current. |
+
+### Recreate or customise the sketch
+
+1. Launch Fritzing 1.0 or newer and create a **New Sketch**.
+2. In the **Parts** bin, drag a 2-pin screw terminal, four 2-pin JST-VH
+   connectors, a mini blade fuse, two test points, and an LED with a series
+   resistor onto the breadboard view.
+3. Use the table above together with the CSV manifest to route positive leads in
+   red and returns in black. Add labels such as `OUT1`–`OUT4` so the layout
+   mirrors the KiCad schematic.
+4. (Optional) Set the breadboard background image to
+   `docs/images/power_ring_wiring.svg` for a quick reference while wiring.
+5. Export the updated design via **File → Export → Image (SVG)** to refresh the
+   diagram in this repository and attach the `.fzz` sketch to build logs or
+   design reviews.
+
+Because the wiring list lives alongside the KiCad project, any connector or fuse
+changes can be captured in both files during the same pull request.

--- a/docs/fritzing/power_ring_wiring.csv
+++ b/docs/fritzing/power_ring_wiring.csv
@@ -1,0 +1,14 @@
+From,To,Wire Color,Notes
+J1(+),F1,Red 16 AWG,Main positive feed from charge controller
+F1,J2(+),Red 18 AWG,Branch output 1
+F1,J3(+),Red 18 AWG,Branch output 2
+F1,J4(+),Red 18 AWG,Branch output 3
+F1,J5(+),Red 18 AWG,Branch output 4
+J1(-),J2(-),Black 18 AWG,Shared return bus
+J1(-),J3(-),Black 18 AWG,Shared return bus
+J1(-),J4(-),Black 18 AWG,Shared return bus
+J1(-),J5(-),Black 18 AWG,Shared return bus
+J1(+),TP1,Red 22 AWG,Voltage measurement point
+J1(-),TP2,Black 22 AWG,Voltage measurement point
+J1(+),LED1(+),Red 26 AWG,Route through R1 to limit current
+LED1(-),J1(-),Black 26 AWG,Return path for indicator LED

--- a/docs/images/power_ring_wiring.svg
+++ b/docs/images/power_ring_wiring.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="320" viewBox="0 0 760 320" role="img" aria-labelledby="title desc">
+  <title id="title">Sugarkube power ring wiring overview</title>
+  <desc id="desc">Diagram showing the 12 V input fuse, branch connectors, test points, and LED indicator wiring.</desc>
+  <style>
+    .bus { stroke:#1f2933; stroke-width:4; fill:none; }
+    .positive { stroke:#dc2626; stroke-width:4; fill:none; }
+    .negative { stroke:#0f766e; stroke-width:4; fill:none; }
+    .node { fill:#f8fafc; stroke:#1f2933; stroke-width:2; rx:8; ry:8; }
+    text { font-family:"Inter","Segoe UI",sans-serif; font-size:14px; fill:#1f2933; }
+    .label { font-weight:600; }
+    .note { font-size:12px; fill:#475569; }
+  </style>
+  <rect class="node" x="40" y="120" width="120" height="80" />
+  <text class="label" x="100" y="150" text-anchor="middle">J1</text>
+  <text class="note" x="100" y="170" text-anchor="middle">12&nbsp;V input</text>
+  <text class="note" x="100" y="190" text-anchor="middle">Screw terminal</text>
+
+  <rect class="node" x="200" y="110" width="100" height="60" />
+  <text class="label" x="250" y="140" text-anchor="middle">F1</text>
+  <text class="note" x="250" y="160" text-anchor="middle">10&nbsp;A fuse</text>
+
+  <line class="positive" x1="160" y1="150" x2="200" y2="140" />
+  <line class="negative" x1="160" y1="170" x2="360" y2="220" />
+
+  <rect class="node" x="360" y="60" width="110" height="60" />
+  <text class="label" x="415" y="90" text-anchor="middle">J2</text>
+  <text class="note" x="415" y="110" text-anchor="middle">Branch 1</text>
+
+  <rect class="node" x="360" y="130" width="110" height="60" />
+  <text class="label" x="415" y="160" text-anchor="middle">J3</text>
+  <text class="note" x="415" y="180" text-anchor="middle">Branch 2</text>
+
+  <rect class="node" x="360" y="200" width="110" height="60" />
+  <text class="label" x="415" y="230" text-anchor="middle">J4</text>
+  <text class="note" x="415" y="250" text-anchor="middle">Branch 3</text>
+
+  <rect class="node" x="360" y="270" width="110" height="60" />
+  <text class="label" x="415" y="300" text-anchor="middle">J5</text>
+  <text class="note" x="415" y="320" text-anchor="middle">Branch 4</text>
+
+  <line class="positive" x1="300" y1="140" x2="360" y2="90" />
+  <line class="positive" x1="300" y1="140" x2="360" y2="160" />
+  <line class="positive" x1="300" y1="140" x2="360" y2="230" />
+  <line class="positive" x1="300" y1="140" x2="360" y2="300" />
+
+  <line class="negative" x1="160" y1="190" x2="360" y2="120" />
+  <line class="negative" x1="160" y1="190" x2="360" y2="190" />
+  <line class="negative" x1="160" y1="190" x2="360" y2="260" />
+  <line class="negative" x1="160" y1="190" x2="360" y2="330" />
+
+  <rect class="node" x="520" y="100" width="110" height="60" />
+  <text class="label" x="575" y="130" text-anchor="middle">TP1</text>
+  <text class="note" x="575" y="150" text-anchor="middle">+ test</text>
+
+  <rect class="node" x="520" y="190" width="110" height="60" />
+  <text class="label" x="575" y="220" text-anchor="middle">TP2</text>
+  <text class="note" x="575" y="240" text-anchor="middle">– test</text>
+
+  <line class="positive" x1="300" y1="140" x2="520" y2="130" />
+  <line class="negative" x1="160" y1="190" x2="520" y2="220" />
+
+  <rect class="node" x="640" y="140" width="100" height="80" />
+  <text class="label" x="690" y="170" text-anchor="middle">LED1</text>
+  <text class="note" x="690" y="190" text-anchor="middle">+ R1 indicator</text>
+
+  <line class="positive" x1="300" y1="140" x2="640" y2="180" />
+  <line class="negative" x1="160" y1="190" x2="640" y2="200" />
+
+  <text class="note" x="250" y="90" text-anchor="middle">Route positive leads in red</text>
+  <text class="note" x="250" y="250" text-anchor="middle">Route returns in teal/black</text>
+</svg>

--- a/tests/test_electronics_schematics_doc.py
+++ b/tests/test_electronics_schematics_doc.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_fritzing_section_provides_real_assets() -> None:
+    doc = Path("docs/electronics_schematics.md").read_text(encoding="utf-8")
+    assert "Placeholder" not in doc
+    assert "images/power_ring_wiring.svg" in doc
+    assert "| Connector | Function | Suggested Wire |" in doc


### PR DESCRIPTION
## Summary
- replace the Fritzing placeholder with actionable wiring guidance
- add a CSV connection manifest and embed the exported SVG diagram
- guard the documentation with a regression test for the diagram/table

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68d76b024468832fa06235e7e4d5d07b