### PR TITLE
🧭 : – add start-here orientation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ the docs you will see the term used in both contexts.
 - `hardware/` — accessories like the Mac mini keyboard station cap (see
   [docs/mac_mini_station.md](docs/mac_mini_station.md))
 - `docs/` — build instructions, safety notes, and learning resources
+- [docs/start-here.md](docs/start-here.md) — quick orientation with 15-minute,
+  day-one, and advanced reference tracks
 - [docs/solar_basics.md](docs/solar_basics.md) — introduction to how solar panels generate
   power
 - [docs/electronics_basics.md](docs/electronics_basics.md) — essential circuits and tools

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ Pi cluster and aquarium aerator while the frame supports climbing plants.*
 ## Getting Started
 Review the safety notes before working with power components.
 
+- [start-here.md](start-here.md) — orientation tracks for newcomers
 - [SAFETY.md](SAFETY.md) — wiring and battery safety guidelines
 - [build_guide.md](build_guide.md) — step-by-step assembly instructions
 - [pi_cluster_carrier.md](pi_cluster_carrier.md) — details on the Raspberry Pi mounting plate

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,0 +1,54 @@
+# Start Here
+
+Kick off your Sugarkube journey from a single launchpad. This guide condenses the repository into
+three tracks so you can build context quickly, complete the onboarding chores, and know where to dive
+when you are ready for deeper automation or hardware projects.
+
+## 15-minute tour
+
+> [!TIP]
+> Skim this track the moment you clone the repository. It orients you before you touch any
+> automation.
+
+1. Read the project overview in [README.md](../README.md) to learn what "Sugarkube" means in both the
+   hardware and automation contexts.
+2. Flip through the curated sitemap in [docs/index.md](./index.md) for a directory-first view of the
+   guides.
+3. Visit the [tutorial roadmap](./tutorials/index.md) to see how the hands-on series is structured and
+   which artefacts each tutorial expects.
+4. Check the [status dashboards](./status/README.md) so you know the latest hardware boot date and the
+   ergonomics metrics we track.
+
+## Day-one contributor checklist
+
+> [!IMPORTANT]
+> Budget a focused afternoon to work through these steps. They line up with Tutorials 1–4 and leave
+> you with verified tooling plus a pull request rehearsal.
+
+1. Run either `just codespaces-bootstrap` or `make codespaces-bootstrap` to install the Python, spell
+   check, and link check prerequisites wired into `pre-commit`.
+2. Execute `pre-commit run --all-files` once locally; it shells into `scripts/checks.sh` so you see
+   the full lint, test, and docs pipeline.
+3. Follow the first four tutorials in [docs/tutorials/index.md](./tutorials/index.md) to capture lab
+   notes, network sketches, and your first automation exercise.
+4. Use [docs/pi_image_quickstart.md](./pi_image_quickstart.md) as a dry-run reference while you learn
+   the build workflow—no hardware required yet.
+5. Map helper scripts to their docs using [docs/pi_image_contributor_guide.md](./pi_image_contributor_guide.md)
+   so you can discover relevant guides quickly.
+
+## Advanced references
+
+> [!NOTE]
+> Graduate to these once you are comfortable contributing code or maintaining the physical cube.
+
+- Bookmark the full hardware launch process in [docs/pi_carrier_launch_playbook.md](./pi_carrier_launch_playbook.md).
+- Study the observability hooks documented in [docs/pi_image_telemetry.md](./pi_image_telemetry.md) before
+  enabling telemetry or extending Grafana dashboards.
+- Rehearse the recovery flows under [docs/ssd_recovery.md](./ssd_recovery.md) and
+  [docs/ssd_post_clone_validation.md](./ssd_post_clone_validation.md) so maintenance windows stay calm.
+- Use [docs/contributor_script_map.md](./contributor_script_map.md) and the changelog to keep up with new helpers.
+- Track simplification and roadmap proposals in [simplification_suggestions.md](../simplification_suggestions.md)
+  when you are ready to staff improvements.
+
+Each section references existing, maintained guides so newcomers have an immediate, documented path
+from first clone to confident contributions.

--- a/simplification_suggestions.md
+++ b/simplification_suggestions.md
@@ -59,8 +59,9 @@ others—without a "start here" narrative.
   guides.
 
 **First steps:**
-1. Draft a `docs/start-here.md` handbook with three tracks: 15-minute tour,
-   day-one contributor checklist, and advanced references.
+1. ✅ Drafted [`docs/start-here.md`](docs/start-here.md), a handbook with three
+   tracks: 15-minute tour, day-one contributor checklist, and advanced
+   references.
 2. Use tabbed callouts (matching the docs site markdown extensions) to
    differentiate hardware builders vs. software contributors.
 3. Embed a quick architecture diagram or recorded walkthrough so new folks

--- a/tests/test_start_here_doc.py
+++ b/tests/test_start_here_doc.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+DOC_PATH = Path(__file__).resolve().parents[1] / "docs" / "start-here.md"
+
+
+def test_start_here_doc_exists() -> None:
+    assert DOC_PATH.exists(), "docs/start-here.md is missing; create the onboarding entry point"
+
+
+def test_start_here_doc_lists_tracks() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    required_headings = [
+        "## 15-minute tour",
+        "## Day-one contributor checklist",
+        "## Advanced references",
+    ]
+    for heading in required_headings:
+        assert heading in text, f"Expected heading '{heading}' in docs/start-here.md"
+
+
+def test_start_here_doc_cross_links_resources() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    required_links = [
+        "docs/index.md",
+        "docs/tutorials/index.md",
+        "docs/pi_image_quickstart.md",
+        "docs/pi_image_contributor_guide.md",
+    ]
+    for link in required_links:
+        assert link in text, f"Expected reference to '{link}' in docs/start-here.md"


### PR DESCRIPTION
what: add docs/start-here.md orientation and regression test, link it from the index/README, and mark the backlog entry complete
why: ship the documented onboarding entry point promised in simplification_suggestions.md
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d7828c7ee4832f97e96563661c52d1