### PR TITLE
Add --host flag to pi smoke test CLI

### DIFF
--- a/docs/pi_smoke_test.md
+++ b/docs/pi_smoke_test.md
@@ -18,6 +18,10 @@ scripts/pi_smoke_test.py 192.168.1.50
 
 # Test multiple hosts and emit JSON for CI consumers
 scripts/pi_smoke_test.py --json pi-a.local pi-b.local
+
+# Supply hosts via repeatable --host flags when positional arguments are
+# awkward (for example when templating commands)
+scripts/pi_smoke_test.py --host pi-a.local --host pi-b.local --json
 ```
 
 The script prints a PASS/FAIL line for each host. When `--json` is supplied the final line
@@ -58,3 +62,9 @@ SMOKE_ARGS="pi-a.local" just smoke-test-pi
 
 Both helpers call the Python harness, so they support the same flags as invoking the script
 directly.
+
+## Test coverage
+
+Automated assurance for the CLI lives in
+`tests/pi_smoke_test_unit_test.py::test_parse_args_accepts_host_flag`, which
+guards the `--host` flag support documented above.

--- a/scripts/pi_smoke_test.py
+++ b/scripts/pi_smoke_test.py
@@ -45,9 +45,19 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "hosts",
-        nargs="+",
-        help="Hostname or IP address of the Pi to verify."
-        " Accept multiple values to test several nodes in sequence.",
+        nargs="*",
+        metavar="HOST",
+        help=(
+            "Hostname or IP address of the Pi to verify. "
+            "Accept multiple values to test several nodes in sequence."
+        ),
+    )
+    parser.add_argument(
+        "--host",
+        dest="hosts_from_flag",
+        action="append",
+        metavar="HOST",
+        help="Add a host to the verification list (repeatable).",
     )
     parser.add_argument(
         "--user",
@@ -149,7 +159,19 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Emit a machine-readable JSON summary in addition to human-readable output.",
     )
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    hosts: List[str] = []
+    if args.hosts:
+        hosts.extend(args.hosts)
+    if args.hosts_from_flag:
+        hosts.extend(args.hosts_from_flag)
+
+    if not hosts:
+        parser.error("provide at least one host via positional arguments or --host")
+
+    args.hosts = hosts
+    delattr(args, "hosts_from_flag")
+    return args
 
 
 def parse_verifier_output(output: str) -> List[Dict[str, str]]:

--- a/tests/pi_smoke_test_unit_test.py
+++ b/tests/pi_smoke_test_unit_test.py
@@ -33,6 +33,17 @@ def test_parse_args_accepts_host_flag():
     assert args.json is True
 
 
+def test_parse_args_combines_positional_and_flag_hosts():
+    args = MODULE.parse_args(["pi-a.local", "--host", "pi-b.local"])
+    assert args.hosts == ["pi-a.local", "pi-b.local"]
+
+
+def test_parse_args_requires_at_least_one_host():
+    with pytest.raises(SystemExit) as excinfo:
+        MODULE.parse_args([])
+    assert excinfo.value.code == 2
+
+
 def test_parse_verifier_output_errors_on_empty():
     with pytest.raises(MODULE.SmokeTestError):
         MODULE.parse_verifier_output("\n \n")

--- a/tests/pi_smoke_test_unit_test.py
+++ b/tests/pi_smoke_test_unit_test.py
@@ -27,6 +27,12 @@ def test_parse_verifier_output_success():
     assert checks == payload["checks"]
 
 
+def test_parse_args_accepts_host_flag():
+    args = MODULE.parse_args(["--host", "pi.local", "--json"])
+    assert args.hosts == ["pi.local"]
+    assert args.json is True
+
+
 def test_parse_verifier_output_errors_on_empty():
     with pytest.raises(MODULE.SmokeTestError):
         MODULE.parse_verifier_output("\n \n")


### PR DESCRIPTION
## Summary
- align scripts/pi_smoke_test.py with the playbook guidance that already documents `scripts/pi_smoke_test.py --host <pi>`
- accept repeatable `--host` flags alongside positional hosts and note the regression test guarding the behavior in the smoke test guide
- record the new `test_parse_args_accepts_host_flag` coverage so the docs point at the automated assurance

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d7828c7ee4832f97e96563661c52d1