### PR TITLE
Add persona index docs for hardware and software knowledge bases

### DIFF
--- a/docs/hardware/index.md
+++ b/docs/hardware/index.md
@@ -1,0 +1,36 @@
+# Sugarkube Hardware Index
+
+Use this page to jump straight to the physical build resources, safety notes,
+and maintenance routines that keep the enclosure healthy. Cross-link the guides
+you touch in PRs so hardware and documentation stay in sync.
+
+## Safety and Planning
+- [SAFETY.md](../SAFETY.md) — wiring, battery handling, and workbench checklists.
+- [power_system_design.md](../power_system_design.md) — plan panel, charge controller,
+  and battery sizing.
+- [electronics_basics.md](../electronics_basics.md) — refresh core terminology before
+  soldering or probing circuits.
+
+## Build Guides and Fixtures
+- [build_guide.md](../build_guide.md) — step-by-step frame assembly and wiring.
+- [pi_cluster_carrier.md](../pi_cluster_carrier.md) — Raspberry Pi carrier plate.
+- [lcd_mount.md](../lcd_mount.md) — optional 1602 LCD placement.
+- [mac_mini_station.md](../mac_mini_station.md) — keyboard station for the lab bench.
+- [insert_basics.md](../insert_basics.md) — heat-set insert techniques used across
+  the enclosure.
+
+## Field References and Playbooks
+- [Pi Carrier Field Guide](../pi_carrier_field_guide.md) — printable one-page
+  checklist for on-site work.
+- [pi_carrier_launch_playbook.md](../pi_carrier_launch_playbook.md) — full
+  walkthrough from inventory to powered-on cluster.
+- [pi_boot_troubleshooting.md](../pi_boot_troubleshooting.md) — LED cues and
+  triage steps when the hardware refuses to boot.
+
+## Storage and Power Maintenance
+- [ssd_post_clone_validation.md](../ssd_post_clone_validation.md) — confirm SSD
+  migrations succeed before decommissioning the SD card.
+- [ssd_health_monitor.md](../ssd_health_monitor.md) — schedule SMART snapshots to
+  catch failing drives early.
+- [docs/tutorials/tutorial-06-raspberry-pi-hardware-power.md](../tutorials/tutorial-06-raspberry-pi-hardware-power.md)
+  — hands-on exercises for validating solar and battery wiring.

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,8 @@ Review the safety notes before working with power components.
 - [token_place_sample_datasets.md](token_place_sample_datasets.md) — replay bundled
   token.place health and chat samples
 - [pi_image_builder_design.md](pi_image_builder_design.md) — design and reliability features of the image builder
+- [hardware/index.md](hardware/index.md) — curated hub for safety notes and hardware build guides
+- [software/index.md](software/index.md) — single stop for automation, playbooks, and contributor tooling
 
 ## Learn the Fundamentals
 - [solar_basics.md](solar_basics.md) — how photovoltaic panels work

--- a/docs/software/index.md
+++ b/docs/software/index.md
@@ -1,0 +1,39 @@
+# Sugarkube Software Index
+
+Navigate software automation, release tooling, and operations guides from a
+single hub. Each section links back to the docs that explain how the Pi image
+and supporting services stay healthy.
+
+## Image Tooling
+- [pi_image_quickstart.md](../pi_image_quickstart.md) — build, flash, and verify the
+  published image.
+- [pi_image_builder_design.md](../pi_image_builder_design.md) — architecture of the
+  pi-gen workflow and CI release jobs.
+- [pi_image_contributor_guide.md](../pi_image_contributor_guide.md) — map scripts
+  to the docs they power.
+
+## Automation and Monitoring
+- [pi_smoke_test.md](../pi_smoke_test.md) — remote verifier runs and reporting
+  formats.
+- [pi_image_team_notifications.md](../pi_image_team_notifications.md) — Slack and
+  Matrix boot/migration alerts.
+- [pi_image_telemetry.md](../pi_image_telemetry.md) — opt-in health reporting for
+  fleet dashboards.
+
+## Operations Playbooks
+- [pi_carrier_launch_playbook.md](../pi_carrier_launch_playbook.md) — end-to-end
+  rollout covering hardware prep through k3s readiness.
+- [Pi Support Bundles](../pi_support_bundles.md) — collect evidence for
+  debugging.
+- [projects-compose.md](../projects-compose.md) — run token.place and dspace via
+  Docker Compose.
+- [pi_token_dspace.md](../pi_token_dspace.md) — expose token.place/dspace through
+  Cloudflare tunnels.
+
+## Developer Workflow
+- [contributor_script_map.md](../contributor_script_map.md) — keep automation docs
+  aligned with helper scripts.
+- [prompts/codex/tests.md](../prompts/codex/tests.md) — expectations for growing
+  test coverage.
+- [simplification_suggestions.md](../simplification_suggestions.md) — backlog of
+  DX improvements and persona-aware initiatives.

--- a/simplification_suggestions.md
+++ b/simplification_suggestions.md
@@ -122,8 +122,9 @@ which makes it difficult to filter by persona.
   rollups.
 
 **First steps:**
-1. Introduce `docs/hardware/index.md` and `docs/software/index.md` pages that
-   summarize relevant guides, tooling, and safety notices.
+1. ✅ Introduce [`docs/hardware/index.md`](docs/hardware/index.md) and
+   [`docs/software/index.md`](docs/software/index.md) pages that summarize
+   relevant guides, tooling, and safety notices.
 2. Tag existing pages with front matter metadata (e.g., `persona: hardware`) so
    the static site can build filtered navigation panes.
 3. Move duplicated primers into a shared "Fundamentals" section referenced by

--- a/tests/test_persona_index_docs.py
+++ b/tests/test_persona_index_docs.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HARDWARE_INDEX = REPO_ROOT / "docs" / "hardware" / "index.md"
+SOFTWARE_INDEX = REPO_ROOT / "docs" / "software" / "index.md"
+
+
+def test_hardware_index_exists_and_lists_core_guides() -> None:
+    assert HARDWARE_INDEX.exists(), "docs/hardware/index.md is missing"
+    text = HARDWARE_INDEX.read_text(encoding="utf-8")
+    expected_snippets = [
+        "# Sugarkube Hardware Index",
+        "[SAFETY.md]",
+        "[build_guide.md]",
+        "Pi Carrier Field Guide",
+    ]
+    for snippet in expected_snippets:
+        assert snippet in text, f"Expected '{snippet}' in hardware index"
+
+
+def test_software_index_exists_and_lists_core_guides() -> None:
+    assert SOFTWARE_INDEX.exists(), "docs/software/index.md is missing"
+    text = SOFTWARE_INDEX.read_text(encoding="utf-8")
+    expected_snippets = [
+        "# Sugarkube Software Index",
+        "[pi_image_quickstart.md]",
+        "[pi_image_contributor_guide.md]",
+        "Pi Support Bundles",
+    ]
+    for snippet in expected_snippets:
+        assert snippet in text, f"Expected '{snippet}' in software index"


### PR DESCRIPTION
## Summary
- inventoried future-work references and selected the modular persona backlog item in `simplification_suggestions.md` because the missing hardware/software index docs were self-contained and ready to ship
- added dedicated hardware and software index pages that collect safety, build, automation, and operations guides for each persona and linked them from the main docs index
- codified coverage with a persona index regression test and marked the backlog item complete

## Testing
- python3 -m pre_commit run --all-files
- python3 -m pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- pytest tests/test_persona_index_docs.py
- git diff --cached | ./scripts/scan-secrets.py


------
https://chatgpt.com/codex/tasks/task_e_68d7828c7ee4832f97e96563661c52d1