### PR TITLE
docs: remind prompts why 100% patch coverage matters

### DIFF
--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -31,7 +31,8 @@ CONTEXT:
   automatically runs `npm ci`, `npm run lint`, and `npm run test:ci` when a
   `package.json` is present.
 - Design your code and tests so the resulting diff achieves **100% patch coverage on
-  the first test run**—no retries.
+  the first test run**—no retries—to minimize the chance of regressions or unexpected
+  functionality being introduced.
 - When documentation files (`README.md` or anything under
   [`docs/`](../../../docs/)) change, additionally run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; config in
@@ -48,7 +49,9 @@ REQUEST:
 1. Identify a small bug fix or documentation clarification.
 2. Implement the change following the project's existing style.
 3. Update relevant documentation when needed.
-4. Run all checks above and ensure they pass with 100% patch coverage on the first attempt.
+4. Run all checks above and ensure they pass with 100% patch coverage on the first
+   attempt to minimize the chance of regressions or unexpected functionality being
+   introduced.
 
 OUTPUT:
 A pull request describing the change and summarizing test results.
@@ -76,14 +79,17 @@ checks. `scripts/checks.sh` automatically runs `npm ci`, `npm run lint`, and
 - `git diff --cached | ./scripts/scan-secrets.py`
   (script: [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py)) to avoid
   committing credentials
-- Ensure the prompt instructs contributors to achieve **100% patch coverage on the first
-  test run** without retries.
+- Ensure the prompt instructs contributors to achieve **100% patch coverage on the
+  first test run** without retries to minimize the chance of regressions or unexpected
+  functionality being introduced.
 Fix any issues reported by these tools.
 
 USER:
 1. Choose a `docs/prompts/codex/*.md` file to update (for example, `docs/prompts/codex/cad.md`).
 2. Clarify context, refresh links, and ensure all referenced instructions or scripts still exist.
-3. Explicitly direct contributors to deliver 100% patch coverage on the first test execution.
+3. Explicitly direct contributors to deliver 100% patch coverage on the first test
+   execution to minimize the chance of regressions or unexpected functionality being
+   introduced.
 4. Run the commands above and address any failures.
 
 OUTPUT:

--- a/docs/prompts/codex/cad.md
+++ b/docs/prompts/codex/cad.md
@@ -32,7 +32,9 @@ CONTEXT:
 - Inspect [`.github/workflows/`](../../../.github/workflows/) to see which checks run in CI.
 - Run `pre-commit run --all-files` from the repository root to lint, format, and test via
   [`scripts/checks.sh`](../../../scripts/checks.sh).
-- Ensure code, scripts, and tests yield **100% patch coverage on the first test run**—no retries.
+- Ensure code, scripts, and tests yield **100% patch coverage on the first test run**—no
+  retries to minimize the chance of regressions or unexpected functionality being
+  introduced.
 - If `package.json` defines them, run:
   - `npm ci`
   - `npm run lint`
@@ -59,9 +61,10 @@ REQUEST:
    STANDOFF_MODE=nut ./scripts/openscad_render.sh path/to/model.scad
    ~~~
 
-4. Run `pre-commit run --all-files` and confirm the resulting diff reports 100% patch coverage on
-   the first attempt; for docs changes also run `pyspelling -c .spellcheck.yaml` and
-   `linkchecker --no-warnings README.md docs/`.
+4. Run `pre-commit run --all-files` and confirm the resulting diff reports 100% patch
+   coverage on the first attempt to minimize the chance of regressions or unexpected
+   functionality being introduced; for docs changes also run `pyspelling -c
+   .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/`.
 5. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`
    before committing updated SCAD sources and any documentation.
 
@@ -94,13 +97,15 @@ Then run:
 - `linkchecker --no-warnings README.md docs/` (installed by
   [`scripts/checks.sh`](../../../scripts/checks.sh))
 - `git diff --cached | ./scripts/scan-secrets.py` before committing.
-- Ensure the revised prompt explicitly directs contributors to secure **100% patch coverage on
-  the first test execution** without retries.
+- Ensure the revised prompt explicitly directs contributors to secure **100% patch
+  coverage on the first test execution** without retries to minimize the chance of
+  regressions or unexpected functionality being introduced.
 
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/` (for example, `docs/prompts/codex/cad.md`).
 2. Fix outdated instructions, links, or formatting.
-3. Add or reinforce guidance that requires 100% patch coverage on the first test run.
+3. Add or reinforce guidance that requires 100% patch coverage on the first test run to
+   minimize the chance of regressions or unexpected functionality being introduced.
 4. Run the commands above.
 
 OUTPUT:

--- a/docs/prompts/codex/ci-fix.md
+++ b/docs/prompts/codex/ci-fix.md
@@ -20,8 +20,9 @@ CONTEXT:
 - JavaScript-based actions run with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` so CI surfaces
   incompatibilities before GitHub switches runners to Node24 by default.
 - Run `pre-commit run --all-files` from the repository root; it executes `scripts/checks.sh`.
-- Craft fixes and tests so the resulting diff achieves **100% patch coverage on the first test run**
-  with no retries.
+- Craft fixes and tests so the resulting diff achieves **100% patch coverage on the
+  first test run** with no retries to minimize the chance of regressions or unexpected
+  functionality being introduced.
 - If a Node toolchain is present (`package.json` exists), run:
   - `npm ci`
   - `npm run lint`
@@ -35,7 +36,9 @@ CONTEXT:
 REQUEST:
 1. Re-run the failing check locally.
 2. Investigate and apply minimal fixes.
-3. Re-run all checks until they succeed with 100% patch coverage on the first attempt.
+3. Re-run all checks until they succeed with 100% patch coverage on the first attempt
+   to minimize the chance of regressions or unexpected functionality being
+   introduced.
 
 OUTPUT:
 A pull request describing the fix and showing passing checks.
@@ -59,13 +62,16 @@ Then run:
 - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
 - `linkchecker --no-warnings README.md docs/`
 - `git diff --cached | ./scripts/scan-secrets.py` before committing.
-- Ensure the updated prompt requires contributors to deliver **100% patch coverage on the first
-  test run** without reruns.
+- Ensure the updated prompt requires contributors to deliver **100% patch coverage
+  on the first test run** without reruns to minimize the chance of regressions or
+  unexpected functionality being introduced.
 
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/` (for example, `docs/prompts/codex/cad.md`).
 2. Fix outdated instructions, links, or formatting.
-3. Add or reinforce guidance about achieving 100% patch coverage on the first test execution.
+3. Add or reinforce guidance about achieving 100% patch coverage on the first test
+   execution to minimize the chance of regressions or unexpected functionality being
+   introduced.
 4. Run the commands above.
 
 OUTPUT:

--- a/docs/prompts/codex/docker-repo.md
+++ b/docs/prompts/codex/docker-repo.md
@@ -21,16 +21,18 @@ CONTEXT:
 - Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires
   `aspell` and `aspell-en`), `linkchecker --no-warnings README.md docs/`, and
   `git diff --cached | ./scripts/scan-secrets.py` before committing.
-- Ensure walkthrough updates and supporting tests yield **100% patch coverage on the first test
-  run**—no retries.
+- Ensure walkthrough updates and supporting tests yield **100% patch coverage on the
+  first test run**—no retries to minimize the chance of regressions or unexpected
+  functionality being introduced.
 - File recurring deployment failures in [`outages/`](../../../outages/) per
   [`outages/schema.json`](../../../outages/schema.json).
 
 REQUEST:
 1. Expand the walkthrough or add examples.
 2. Reference token.place and dspace where helpful.
-3. Verify all commands and links and confirm the diff achieves 100% patch coverage on the first
-   test execution.
+3. Verify all commands and links and confirm the diff achieves 100% patch coverage on
+   the first test execution to minimize the chance of regressions or unexpected
+   functionality being introduced.
 
 OUTPUT:
 A pull request with passing checks and a concise summary.
@@ -48,13 +50,16 @@ Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md).
 Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires
 `aspell` and `aspell-en`), `linkchecker --no-warnings README.md docs/`, and
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
-- Ensure the revised prompt emphasizes achieving **100% patch coverage on the first test run**
-  without retries.
+- Ensure the revised prompt emphasizes achieving **100% patch coverage on the first
+  test run** without retries to minimize the chance of regressions or unexpected
+  functionality being introduced.
 
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/` (for example, `docs/prompts/codex/cad.md`).
 2. Fix outdated instructions, links, or formatting.
-3. Add or reinforce guidance that mandates 100% patch coverage on the first test execution.
+3. Add or reinforce guidance that mandates 100% patch coverage on the first test
+   execution to minimize the chance of regressions or unexpected functionality being
+   introduced.
 4. Run the commands above.
 
 OUTPUT:

--- a/docs/prompts/codex/docs.md
+++ b/docs/prompts/codex/docs.md
@@ -22,8 +22,9 @@ CONTEXT:
 - Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../../../scripts/checks.sh) for
   linting, formatting, and tests. If `package.json` exists, the script automatically
   runs `npm ci`, `npm run lint`, and `npm run test:ci`.
-- Structure edits and any supporting tests so the diff achieves **100% patch coverage on the first
-  test execution**—no reruns.
+- Structure edits and any supporting tests so the diff achieves **100% patch coverage
+  on the first test execution**—no reruns—to minimize the chance of regressions or
+  unexpected functionality being introduced.
 - For documentation changes, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`; see
     [`.spellcheck.yaml`](../../../.spellcheck.yaml))
@@ -37,13 +38,15 @@ REQUEST:
 2. Improve wording, fix links, or add missing steps.
 3. Re-run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`,
    `linkchecker --no-warnings README.md docs/`, and
-   `git diff --cached | ./scripts/scan-secrets.py`. Confirm all checks pass with 100% patch
-   coverage on the first attempt.
+   `git diff --cached | ./scripts/scan-secrets.py`. Confirm all checks pass with 100%
+   patch coverage on the first attempt to minimize the chance of regressions or
+   unexpected functionality being introduced.
    If `package.json` exists, also run:
    - `npm ci`
    - `npm run lint`
    - `npm run test:ci`
-   Confirm all checks pass with 100% patch coverage on the first run.
+   Confirm all checks pass with 100% patch coverage on the first run to minimize the
+   chance of regressions or unexpected functionality being introduced.
 
 OUTPUT:
 A pull request with the refined documentation and passing checks.
@@ -64,13 +67,15 @@ linting, formatting, and tests; it automatically runs `npm ci`, `npm run lint`, 
 (requires `aspell` and `aspell-en`; see [`.spellcheck.yaml`](../../../.spellcheck.yaml)),
 `linkchecker --no-warnings README.md docs/`, and
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
-- Ensure the refreshed prompt explicitly directs contributors to deliver **100% patch coverage on
-  the first test run** without retries.
+- Ensure the refreshed prompt explicitly directs contributors to deliver **100% patch
+  coverage on the first test run** without retries to minimize the chance of
+  regressions or unexpected functionality being introduced.
 
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/` (for example, `docs/prompts/codex/cad.md`).
 2. Fix outdated instructions, links, or formatting.
-3. Add or reinforce guidance requiring 100% patch coverage on the first test execution.
+3. Add or reinforce guidance requiring 100% patch coverage on the first test execution
+   to minimize the chance of regressions or unexpected functionality being introduced.
 4. Run the commands above.
 
 OUTPUT:

--- a/docs/prompts/codex/elex.md
+++ b/docs/prompts/codex/elex.md
@@ -31,8 +31,9 @@ CONTEXT:
   commit is available. For documentation updates, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`
-- Ensure schematic, PCB, and script updates land with **100% patch coverage on the first test
-  execution**—no retries.
+- Ensure schematic, PCB, and script updates land with **100% patch coverage on the
+  first test execution**—no retries to minimize the chance of regressions or
+  unexpected functionality being introduced.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py` before committing.
 - Log persistent tool failures in [`outages/`](../../../outages/) per
@@ -47,8 +48,9 @@ REQUEST:
 3. Update any related documentation.
 4. Re-run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and
    `linkchecker --no-warnings README.md docs/`; scan staged changes with
-   `git diff --cached | ./scripts/scan-secrets.py` and confirm 100% patch coverage on the first
-   attempt.
+   `git diff --cached | ./scripts/scan-secrets.py` and confirm 100% patch
+   coverage on the first attempt to minimize the chance of regressions or unexpected
+   functionality being introduced.
 
 OUTPUT:
 A pull request summarizing electronics updates and confirming KiBot export.
@@ -66,13 +68,16 @@ Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md).
 Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires
 `aspell` and `aspell-en`), `linkchecker --no-warnings README.md docs/`, and
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
-- Ensure the updated prompt explicitly mandates **100% patch coverage on the first test run**
-  without retries.
+- Ensure the updated prompt explicitly mandates **100% patch coverage on the first
+  test run** without retries to minimize the chance of regressions or unexpected
+  functionality being introduced.
 
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/` (for example, `docs/prompts/codex/cad.md`).
 2. Fix outdated instructions, links, or formatting.
-3. Add or reinforce guidance that requires 100% patch coverage on the first test execution.
+3. Add or reinforce guidance that requires 100% patch coverage on the first test
+   execution to minimize the chance of regressions or unexpected functionality being
+   introduced.
 4. Run the commands above.
 
 OUTPUT:

--- a/docs/prompts/codex/implement.md
+++ b/docs/prompts/codex/implement.md
@@ -48,7 +48,8 @@ CONTEXT:
 - Install missing Node dependencies with `npm ci` before invoking any npm
   scripts.
 - Ensure the resulting diff achieves **100% patch coverage on the first test
-  run**—design tests so reruns are unnecessary.
+  run**—design tests so reruns are unnecessary to minimize the chance of
+  regressions or unexpected functionality being introduced.
 - Use `rg` (ripgrep) to inventory TODO, FIXME, and "future work" markers across
   code, tests, and docs. Prioritize items that deliver immediate user value in a
   single PR.
@@ -97,6 +98,8 @@ CONTEXT:
   run `pyspelling -c .spellcheck.yaml` and
   `linkchecker --no-warnings README.md docs/`.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Aim for **100% patch coverage on the first test run** to minimize the chance of
+  regressions or unexpected functionality being introduced.
 - Confirm referenced files exist and update related prompt indexes if needed.
 
 REQUEST:

--- a/docs/prompts/codex/observability.md
+++ b/docs/prompts/codex/observability.md
@@ -13,8 +13,9 @@ SYSTEM:
 You are building the “Sugarkube Dashboard” capability for a k3s-based platform.
 Produce production-grade code, manifests, Helm values, and docs.
 Optimize for simplicity, reproducibility, and security by default.
-Achieve **100% patch coverage on the first test run**—design code and tests so no reruns are
-required.
+Achieve **100% patch coverage on the first test run**—design code and tests so no
+reruns are required to minimize the chance of regressions or unexpected
+functionality being introduced.
 
 GOAL:
 Create a complete, minimal, and extensible observability + kiosk solution:

--- a/docs/prompts/codex/pi-image.md
+++ b/docs/prompts/codex/pi-image.md
@@ -24,8 +24,9 @@ CONTEXT:
   For documentation changes, also run:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`
-- Shape code and test edits so the diff delivers **100% patch coverage on the first test run**
-  without retries.
+- Shape code and test edits so the diff delivers **100% patch coverage on the first
+  test run** without retries to minimize the chance of regressions or unexpected
+  functionality being introduced.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py` before committing.
 - Log persistent build issues in [`outages/`](../../../outages/) per
@@ -37,8 +38,9 @@ REQUEST:
 3. Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`
    (requires `aspell` and `aspell-en`),
    `linkchecker --no-warnings README.md docs/`, and
-   `git diff --cached | ./scripts/scan-secrets.py`, confirming success with 100% patch coverage on
-   the first attempt.
+   `git diff --cached | ./scripts/scan-secrets.py`, confirming success with 100% patch
+   coverage on the first attempt to minimize the chance of regressions or unexpected
+   functionality being introduced.
 
 OUTPUT:
 A pull request with passing checks and a concise summary.
@@ -57,13 +59,16 @@ Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`
 (requires `aspell` and `aspell-en`),
 `linkchecker --no-warnings README.md docs/`, and
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
-- Ensure the revised prompt explicitly compels contributors to achieve **100% patch coverage on the
-  first test run** without retries.
+- Ensure the revised prompt explicitly compels contributors to achieve **100% patch
+  coverage on the first test run** without retries to minimize the chance of
+  regressions or unexpected functionality being introduced.
 
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/` (for example, `docs/prompts/codex/cad.md`).
 2. Fix outdated instructions, links, or formatting.
-3. Add or reinforce guidance that demands 100% patch coverage on the first test execution.
+3. Add or reinforce guidance that demands 100% patch coverage on the first test
+   execution to minimize the chance of regressions or unexpected functionality being
+   introduced.
 4. Run the commands above.
 
 OUTPUT:

--- a/docs/prompts/codex/pi-token-dspace.md
+++ b/docs/prompts/codex/pi-token-dspace.md
@@ -45,8 +45,9 @@ CONTEXT:
   - `pyspelling -c .spellcheck.yaml` (requires `aspell` and `aspell-en`)
   - `linkchecker --no-warnings README.md docs/`
   - `git diff --cached | ./scripts/scan-secrets.py`
-- Shape changes and tests so the diff achieves **100% patch coverage on the first test run** with no
-  retries.
+- Shape changes and tests so the diff achieves **100% patch coverage on the first
+  test run** with no retries to minimize the chance of regressions or unexpected
+  functionality being introduced.
 - Review [CI workflows](../../../.github/workflows/) to anticipate automated checks.
 
 REQUEST:
@@ -55,7 +56,9 @@ REQUEST:
 2. Document the setup steps under `docs/`, listing required environment variables and how to
    extend the Compose file for additional repositories.
 3. Keep hooks for adding other repositories later.
-4. Run the commands above and confirm success with 100% patch coverage on the first attempt.
+4. Run the commands above and confirm success with 100% patch coverage on the first
+   attempt to minimize the chance of regressions or unexpected functionality being
+   introduced.
 
 OUTPUT:
 A pull request with updated scripts and docs enabling `token.place` and
@@ -74,13 +77,16 @@ Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md).
 Run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml` (requires
 `aspell` and `aspell-en`), `linkchecker --no-warnings README.md docs/`, and
 `git diff --cached | ./scripts/scan-secrets.py` before committing.
-- Ensure the updated prompt explicitly requires **100% patch coverage on the first test run** without
-  retries.
+- Ensure the updated prompt explicitly requires **100% patch coverage on the first
+  test run** without retries to minimize the chance of regressions or unexpected
+  functionality being introduced.
 
 USER:
 1. Improve this prompt by clarifying context, links, or instructions.
 2. Ensure references stay current.
-3. Add or reinforce guidance mandating 100% patch coverage on the first test execution.
+3. Add or reinforce guidance mandating 100% patch coverage on the first test
+   execution to minimize the chance of regressions or unexpected functionality being
+   introduced.
 4. Run the commands above.
 
 OUTPUT:

--- a/docs/prompts/codex/spellcheck.md
+++ b/docs/prompts/codex/spellcheck.md
@@ -21,8 +21,9 @@ CONTEXT:
 - Follow [`AGENTS.md`](../../../AGENTS.md) and [`README.md`](../../../README.md).
 - Run `pre-commit run --all-files` to invoke [`scripts/checks.sh`](../../../scripts/checks.sh) for
   linting, formatting, and tests.
-- Ensure edits and any accompanying tests achieve **100% patch coverage on the first test run** with
-  no retries.
+- Ensure edits and any accompanying tests achieve **100% patch coverage on the first
+  test run** with no retries to minimize the chance of regressions or unexpected
+  functionality being introduced.
 - If a Node toolchain is present (`package.json` exists), also run:
   - `npm ci`
   - `npm run lint`
@@ -33,8 +34,9 @@ CONTEXT:
 REQUEST:
 1. Run the spellcheck and review results.
 2. Fix misspellings or update `.wordlist.txt`.
-3. Re-run spellcheck and link checks until clean and confirm 100% patch coverage on the first
-   attempt.
+3. Re-run spellcheck and link checks until clean and confirm 100% patch coverage on
+   the first attempt to minimize the chance of regressions or unexpected
+   functionality being introduced.
 
 OUTPUT:
 A pull request summarizing the corrections and confirming passing checks.
@@ -59,14 +61,16 @@ Then run:
   [`.spellcheck.yaml`](../../../.spellcheck.yaml))
 - `linkchecker --no-warnings README.md docs/`
 - `git diff --cached | ./scripts/scan-secrets.py` before committing.
-- Ensure the prompt clearly requires contributors to maintain **100% patch coverage on the first
-  test run** without retries.
+- Ensure the prompt clearly requires contributors to maintain **100% patch
+  coverage on the first test run** without retries to minimize the chance of
+  regressions or unexpected functionality being introduced.
 
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/` (for example, `docs/prompts/codex/cad.md`).
 2. Fix outdated instructions, links, or formatting.
-3. Add or reinforce guidance directing contributors to achieve 100% patch coverage on the first test
-   execution.
+3. Add or reinforce guidance directing contributors to achieve 100% patch
+   coverage on the first test execution to minimize the chance of regressions or
+   unexpected functionality being introduced.
 4. Run the commands above.
 
 OUTPUT:

--- a/docs/prompts/codex/tests.md
+++ b/docs/prompts/codex/tests.md
@@ -27,8 +27,9 @@ CONTEXT:
   [`scripts/checks.sh`](../../../scripts/checks.sh) for linting, formatting, and executing both
   test frameworks. The script installs missing tools—including `bats`—so tests run
   consistently.
-- Ensure new and updated tests drive **100% patch coverage on the first test run**; design fixes so
-  no reruns are needed.
+- Ensure new and updated tests drive **100% patch coverage on the first test
+  run**; design fixes so no reruns are needed to minimize the chance of
+  regressions or unexpected functionality being introduced.
 - The CI workflow [`tests.yml`](../../../.github/workflows/tests.yml) runs the test suite on
   each push.
 - For documentation updates, also run `pyspelling -c .spellcheck.yaml` (requires
@@ -43,8 +44,9 @@ REQUEST:
 2. Write or update tests in [`tests/`](../../../tests/).
 3. Adjust implementation if a test exposes a bug.
 4. Re-run `pre-commit run --all-files`; for docs changes also run
-   `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/`, confirming
-   100% patch coverage on the first attempt.
+   `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/`,
+   confirming 100% patch coverage on the first attempt to minimize the chance of
+   regressions or unexpected functionality being introduced.
 5. Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` before committing.
 
 OUTPUT:
@@ -69,14 +71,16 @@ Then run:
 - `pyspelling -c .spellcheck.yaml`
 - `linkchecker --no-warnings README.md docs/`
 - `git diff --cached | ./scripts/scan-secrets.py` before committing.
-- Ensure the prompt explicitly requires contributors to reach **100% patch coverage on the first test
-  run** without retries.
+- Ensure the prompt explicitly requires contributors to reach **100% patch
+  coverage on the first test run** without retries to minimize the chance of
+  regressions or unexpected functionality being introduced.
 
 USER:
 1. Pick one prompt doc under `docs/prompts/codex/` (for example, `docs/prompts/codex/cad.md`).
 2. Fix outdated instructions, links, or formatting.
-3. Add or reinforce guidance directing contributors to attain 100% patch coverage on the first test
-   execution.
+3. Add or reinforce guidance directing contributors to attain 100% patch
+   coverage on the first test execution to minimize the chance of regressions or
+   unexpected functionality being introduced.
 4. Run the commands above.
 
 OUTPUT:

--- a/docs/prompts/simplification.md
+++ b/docs/prompts/simplification.md
@@ -46,7 +46,8 @@ CONTEXT:
 - Before committing, scan staged changes with
   `git diff --cached | ./scripts/scan-secrets.py` (script lives at
   [`scripts/scan-secrets.py`](../../scripts/scan-secrets.py)).
-- Demand **100% patch coverage on the first test run**—no retries.
+- Demand **100% patch coverage on the first test run**—no retries to minimize the
+  chance of regressions or unexpected functionality being introduced.
 - If recurring failures surface, log an outage record under
   [`outages/`](../../outages/).
 
@@ -84,7 +85,9 @@ linters, formatters, and tests). When docs change also run:
 - `pyspelling -c .spellcheck.yaml`
 - `linkchecker --no-warnings README.md docs/`
 - `git diff --cached | ./scripts/scan-secrets.py`
-Ensure the final diff delivers **100% patch coverage on the first test run**.
+Ensure the final diff delivers **100% patch coverage on the first test run** to
+minimize the chance of regressions or unexpected functionality being
+introduced.
 
 USER:
 1. Review this prompt for stale context, missing onboarding cues, or redundant


### PR DESCRIPTION
what: add regression-prevention rationale to patch coverage guidance
why: set clear safety expectation for automated contributors
how to test: pre-commit run --all-files (fails: run-checks would reformat unrelated files); pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68d8e8393488832fa61fdad96a2d2e94