### PR TITLE
Tighten telemetry markdown snapshot coverage

### DIFF
--- a/docs/pi_image_telemetry.md
+++ b/docs/pi_image_telemetry.md
@@ -87,6 +87,14 @@ sudo just publish-telemetry telemetry_args="--dry-run"
 Both invocations call `scripts/publish_telemetry.py`, which automatically locates
 `pi_node_verifier.sh`, generates an anonymized payload, and prints it when `--dry-run` is supplied.
 
+### Capture Markdown snapshots
+
+Set `SUGARKUBE_TELEMETRY_MARKDOWN_DIR` or pass `--markdown-dir docs/status/metrics` to archive each
+payload as a Markdown snapshot alongside your dashboards. The helper writes
+`telemetry-<hash>.md` files that summarize verifier counts, failed checks, environment metadata, and
+errors so changes are easy to track during retros. Regression coverage lives in
+`tests/test_publish_telemetry.py::test_main_writes_markdown_snapshot`.
+
 ## Collector integration tips
 
 - Ingest payloads as-is to keep future schema extensions forward-compatible. The top-level

--- a/simplification_suggestions.md
+++ b/simplification_suggestions.md
@@ -157,8 +157,11 @@ and record navigation improvements in the docs changelog.
 1. ✅ Define a core set of ergonomics KPIs (image build duration, smoke-test pass
    rate, onboarding checklist completion time) and document them in
    `docs/status/README.md`.
-2. Extend the telemetry publisher to emit these metrics into Grafana (or persist
-   markdown snapshots under `docs/status/metrics/`).
+2. ✅ Extend the telemetry publisher to emit these metrics into Grafana (or
+   persist markdown snapshots under `docs/status/metrics/`). The CLI now accepts
+   `--markdown-dir`/`SUGARKUBE_TELEMETRY_MARKDOWN_DIR` to write Markdown
+   summaries with regression coverage in
+   `tests/test_publish_telemetry.py::test_main_writes_markdown_snapshot`.
 3. Add a changelog section dedicated to ergonomics improvements so momentum is
    visible across releases.
 

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,4 +1,5 @@
 """Support coverage collection in subprocesses started by tests."""
+
 import os
 
 if os.getenv("COVERAGE_PROCESS_START"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Test fixtures and configuration helpers."""
+
 from __future__ import annotations
 
 import os

--- a/tests/test_collect_support_bundle.py
+++ b/tests/test_collect_support_bundle.py
@@ -343,9 +343,7 @@ def test_main_includes_target_results(
 
     def fake_execute(args, specs, bundle_dir):
         (bundle_dir / "artifact.txt").write_text("data")
-        return [
-            {"command": {"description": "ok"}, "exit_code": 0, "status": "success"}
-        ]
+        return [{"command": {"description": "ok"}, "exit_code": 0, "status": "success"}]
 
     def fake_copy_targets(args, bundle_dir):
         return [{"path": "log.txt", "status": "success"}]

--- a/tests/test_create_build_metadata.py
+++ b/tests/test_create_build_metadata.py
@@ -170,12 +170,14 @@ def test_stage_summary_incomplete_entries(tmp_path):
 
 
 def test_parse_options_casts_and_validates():
-    result = cbm._parse_options([
-        "threads=4",
-        "ratio=0.5",
-        "enabled=true",
-        "label=sugarkube",
-    ])
+    result = cbm._parse_options(
+        [
+            "threads=4",
+            "ratio=0.5",
+            "enabled=true",
+            "label=sugarkube",
+        ]
+    )
 
     assert result == {
         "threads": 4,


### PR DESCRIPTION
what: add --markdown-dir snapshots plus docs/test coverage; add markdown summary regression tests for full coverage; cover markdown snapshot failure path
why: satisfy backlog request to persist telemetry markdown snapshots; ensure markdown snapshot helpers are fully tested
how to test: pytest tests/test_publish_telemetry.py
how to test: pre-commit run --all-files
how to test: pyspelling -c .spellcheck.yaml
how to test: linkchecker --no-warnings README.md docs/
how to test: git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d8d9a9488c832fbc9e590037c814b4