### PR TITLE
Cover telemetry markdown snapshot fallbacks

### DIFF
--- a/docs/pi_image_telemetry.md
+++ b/docs/pi_image_telemetry.md
@@ -87,6 +87,14 @@ sudo just publish-telemetry telemetry_args="--dry-run"
 Both invocations call `scripts/publish_telemetry.py`, which automatically locates
 `pi_node_verifier.sh`, generates an anonymized payload, and prints it when `--dry-run` is supplied.
 
+### Capture Markdown snapshots
+
+Set `SUGARKUBE_TELEMETRY_MARKDOWN_DIR` or pass `--markdown-dir docs/status/metrics` to archive each
+payload as a Markdown snapshot alongside your dashboards. The helper writes
+`telemetry-<hash>.md` files that summarize verifier counts, failed checks, environment metadata, and
+errors so changes are easy to track during retros. Regression coverage lives in
+`tests/test_publish_telemetry.py::test_main_writes_markdown_snapshot`.
+
 ## Collector integration tips
 
 - Ingest payloads as-is to keep future schema extensions forward-compatible. The top-level

--- a/simplification_suggestions.md
+++ b/simplification_suggestions.md
@@ -157,8 +157,11 @@ and record navigation improvements in the docs changelog.
 1. ✅ Define a core set of ergonomics KPIs (image build duration, smoke-test pass
    rate, onboarding checklist completion time) and document them in
    `docs/status/README.md`.
-2. Extend the telemetry publisher to emit these metrics into Grafana (or persist
-   markdown snapshots under `docs/status/metrics/`).
+2. ✅ Extend the telemetry publisher to emit these metrics into Grafana (or
+   persist markdown snapshots under `docs/status/metrics/`). The CLI now accepts
+   `--markdown-dir`/`SUGARKUBE_TELEMETRY_MARKDOWN_DIR` to write Markdown
+   summaries with regression coverage in
+   `tests/test_publish_telemetry.py::test_main_writes_markdown_snapshot`.
 3. Add a changelog section dedicated to ergonomics improvements so momentum is
    visible across releases.
 

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,4 +1,5 @@
 """Support coverage collection in subprocesses started by tests."""
+
 import os
 
 if os.getenv("COVERAGE_PROCESS_START"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Test fixtures and configuration helpers."""
+
 from __future__ import annotations
 
 import os

--- a/tests/test_collect_support_bundle.py
+++ b/tests/test_collect_support_bundle.py
@@ -343,9 +343,7 @@ def test_main_includes_target_results(
 
     def fake_execute(args, specs, bundle_dir):
         (bundle_dir / "artifact.txt").write_text("data")
-        return [
-            {"command": {"description": "ok"}, "exit_code": 0, "status": "success"}
-        ]
+        return [{"command": {"description": "ok"}, "exit_code": 0, "status": "success"}]
 
     def fake_copy_targets(args, bundle_dir):
         return [{"path": "log.txt", "status": "success"}]

--- a/tests/test_create_build_metadata.py
+++ b/tests/test_create_build_metadata.py
@@ -170,12 +170,14 @@ def test_stage_summary_incomplete_entries(tmp_path):
 
 
 def test_parse_options_casts_and_validates():
-    result = cbm._parse_options([
-        "threads=4",
-        "ratio=0.5",
-        "enabled=true",
-        "label=sugarkube",
-    ])
+    result = cbm._parse_options(
+        [
+            "threads=4",
+            "ratio=0.5",
+            "enabled=true",
+            "label=sugarkube",
+        ]
+    )
 
     assert result == {
         "threads": 4,

--- a/tests/test_publish_telemetry.py
+++ b/tests/test_publish_telemetry.py
@@ -520,3 +520,133 @@ def test_main_requires_endpoint_when_not_dry_run(monkeypatch):
     monkeypatch.setattr(MODULE, "parse_tags", lambda raw: [])
     with pytest.raises(MODULE.TelemetryError, match="endpoint not configured"):
         MODULE.main([])
+
+
+def test_main_writes_markdown_snapshot(monkeypatch, tmp_path):
+    monkeypatch.setenv("SUGARKUBE_TELEMETRY_ENABLE", "true")
+    monkeypatch.setattr(MODULE, "discover_verifier_path", lambda value: "verifier")
+    monkeypatch.setattr(
+        MODULE,
+        "run_verifier",
+        lambda path, timeout: ([{"name": "ready", "status": "pass"}], ["warn"]),
+    )
+    monkeypatch.setattr(MODULE, "hashed_identifier", lambda **_: "abcdef1234567890")
+    monkeypatch.setattr(
+        MODULE,
+        "collect_environment",
+        lambda: {"kernel": "Linux 6.1", "uptime_seconds": 42, "hardware_model": "Pi 5"},
+    )
+    monkeypatch.setattr(MODULE, "parse_tags", lambda raw: ["lab", "pi"])
+    monkeypatch.setattr(MODULE, "send_payload", lambda payload, **kwargs: None)
+    exit_code = MODULE.main(["--endpoint", "https://example", "--markdown-dir", str(tmp_path)])
+    assert exit_code == 0
+    snapshots = list(tmp_path.glob("telemetry-*.md"))
+    assert snapshots, "expected markdown snapshot file"
+    content = snapshots[0].read_text(encoding="utf-8")
+    assert "Sugarkube Telemetry Snapshot" in content
+    assert "`lab`" in content
+    assert "warn" in content
+    assert "| Total | Passed | Failed" in content
+
+
+def test_main_handles_markdown_snapshot_failure(monkeypatch, tmp_path):
+    monkeypatch.setenv("SUGARKUBE_TELEMETRY_ENABLE", "true")
+    monkeypatch.setattr(MODULE, "discover_verifier_path", lambda value: "verifier")
+    monkeypatch.setattr(MODULE, "run_verifier", lambda path, timeout: ([], []))
+    monkeypatch.setattr(MODULE, "hashed_identifier", lambda **_: "id")
+    monkeypatch.setattr(MODULE, "collect_environment", lambda: {})
+    monkeypatch.setattr(MODULE, "parse_tags", lambda raw: [])
+    monkeypatch.setattr(MODULE, "send_payload", lambda payload, **kwargs: None)
+
+    def fail_snapshot(payload, directory):  # noqa: ANN001, ANN002
+        raise OSError("disk full")
+
+    monkeypatch.setattr(MODULE, "write_markdown_snapshot", fail_snapshot)
+    with pytest.raises(MODULE.TelemetryError, match="disk full"):
+        MODULE.main(
+            [
+                "--endpoint",
+                "https://example",
+                "--markdown-dir",
+                str(tmp_path / "snapshots"),
+            ]
+        )
+
+
+def test_markdown_summary_formats_sections():
+    payload = {
+        "instance": {"id": "NODE-01"},
+        "verifier": {
+            "summary": {
+                "total": 3,
+                "passed": 1,
+                "failed": 1,
+                "skipped": 1,
+                "other": 0,
+                "failed_checks": ["dns"],
+            }
+        },
+        "environment": {
+            "uptime_seconds": 99.9,
+            "kernel": "Linux 6.1",
+            "hardware_model": "Pi 5\x00",
+            "os_release": {"PRETTY_NAME": "Debian"},
+        },
+        "tags": ["core", 12, ""],
+        "errors": ["verifier_exit"],
+    }
+    summary = MODULE._markdown_summary(payload)
+    assert "Instance ID: `NODE-01`" in summary
+    assert "* Uptime: 99 seconds" in summary
+    assert "* Hardware: Pi 5" in summary
+    assert "* OS: Debian" in summary
+    assert "Tags: `core`" in summary
+    assert "- dns" in summary
+    assert "- verifier_exit" in summary
+
+
+def test_markdown_summary_lists_none_when_no_errors():
+    payload = {
+        "instance": {"id": "node"},
+        "verifier": {
+            "summary": {
+                "total": 1,
+                "passed": 1,
+                "failed": 0,
+                "skipped": 0,
+                "other": 0,
+                "failed_checks": [],
+            }
+        },
+        "environment": {},
+    }
+    summary = MODULE._markdown_summary(payload)
+    assert "- None" in summary
+
+
+def test_markdown_summary_handles_missing_instance():
+    payload = {
+        "verifier": {"summary": {}},
+        "errors": [],
+    }
+    summary = MODULE._markdown_summary(payload)
+    assert "Instance ID: `unknown`" in summary
+
+
+def test_write_markdown_snapshot_slugifies_identifier(tmp_path):
+    payload = {"instance": {"id": "THIS-IS-A-VERY-LONG-IDENTIFIER"}}
+    path = MODULE.write_markdown_snapshot(payload, tmp_path)
+    assert path.name == "telemetry-thisisaverylongi.md"
+    assert path.read_text(encoding="utf-8").startswith("# Sugarkube Telemetry Snapshot")
+
+
+def test_write_markdown_snapshot_handles_missing_identifier(tmp_path):
+    payload = {"instance": {"id": "!!!"}}
+    path = MODULE.write_markdown_snapshot(payload, tmp_path)
+    assert path.name == "telemetry-snapshot.md"
+
+
+def test_write_markdown_snapshot_defaults_without_instance(tmp_path):
+    payload = {"instance": None}
+    path = MODULE.write_markdown_snapshot(payload, tmp_path)
+    assert path.name == "telemetry-snapshot.md"


### PR DESCRIPTION
what: add tests that exercise the markdown snapshot fallbacks for missing instance metadata to close the remaining coverage gap
why: ensure the new telemetry snapshot support maintains 100% patch coverage
how to test: pytest tests/test_publish_telemetry.py
how to test: pre-commit run --all-files
how to test: pyspelling -c .spellcheck.yaml
how to test: linkchecker --no-warnings README.md docs/
how to test: git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d8d9a9488c832fbc9e590037c814b4