### PR TITLE
feat: solidify Tutorial 4 pre-commit guidance

### DIFF
--- a/docs/tutorials/tutorial-04-version-control-collaboration.md
+++ b/docs/tutorials/tutorial-04-version-control-collaboration.md
@@ -263,7 +263,7 @@ become part of your milestone evidence.
 
    ## Local checks
    - `git status` to confirm a clean worktree before commits.
-   - `pre-commit run --all-files` (planned for Sugarkube contributions).
+   - `pre-commit run --all-files` to execute the repository checks before every PR.
 
    ## GitHub checks
    - Pull requests trigger documentation linting and spell checking.
@@ -275,6 +275,10 @@ become part of your milestone evidence.
    - Update the pull request with findings and request help if needed.
    CI
    ```
+
+> [!NOTE]
+> Sugarkube's automated tests verify this tutorial keeps `pre-commit run --all-files`
+> in the checklist so future contributors learn to run the project checks locally.
 
 3. Commit and push the notes:
 

--- a/tests/test_tutorial_04_ci_notes.py
+++ b/tests/test_tutorial_04_ci_notes.py
@@ -1,0 +1,26 @@
+"""Ensure Tutorial 4 reflects current CI expectations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+DOC_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "docs"
+    / "tutorials"
+    / "tutorial-04-version-control-collaboration.md"
+)
+
+
+def test_ci_notes_references_pre_commit_command() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    assert (
+        "`pre-commit run --all-files`" in text
+    ), "Tutorial 4 should direct readers to run pre-commit"
+
+
+def test_ci_notes_no_longer_mark_pre_commit_as_planned() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    assert (
+        "planned for Sugarkube contributions" not in text
+    ), "Tutorial 4 still labels pre-commit usage as future work"


### PR DESCRIPTION
## Summary
- promote the Tutorial 4 CI checklist entry for `pre-commit run --all-files` from a future plan to an explicit requirement and add a note about automated coverage
- add regression tests that ensure the tutorial continues to document the `pre-commit` command and no longer calls it "planned"

## Testing
- `pytest tests/test_tutorial_04_ci_notes.py`
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68d8f0edff6c832fa60e02eb4c3fa78c