### PR TITLE
Add pi_node_verifier --full flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ the docs you will see the term used in both contexts.
   - `flash_pi_media.sh` — stream `.img` or `.img.xz` directly to removable
     media with SHA-256 verification and automatic eject. A PowerShell wrapper
     (`flash_pi_media.ps1`) shells out to the same Python core on Windows.
-  - `pi_node_verifier.sh` — check k3s prerequisites; use `--json` for machine output or
-    `--help` for usage
+  - `pi_node_verifier.sh` — check k3s prerequisites; use `--json` for machine output,
+    `--full` to print text plus the JSON summary in one run, or `--help` for usage
   - `pi_smoke_test.py` — SSH wrapper that runs the verifier remotely, supports reboot checks,
     and emits JSON summaries for CI harnesses
   - `render_field_guide_pdf.py` — build the Markdown field guide into a single-page PDF without

--- a/docs/pi_headless_provisioning.md
+++ b/docs/pi_headless_provisioning.md
@@ -86,6 +86,11 @@ ssh sugaradmin@sugarkube-node01.local
 sudo /usr/local/bin/pi_node_verifier.sh --full
 ```
 
+The `--full` flag emits both the standard text table and a JSON payload in one invocation, making
+it easy to refresh `/boot/first-boot-report.txt` while feeding structured output into follow-up
+automation. Regression coverage lives in
+`tests/pi_node_verifier_output_test.bats::pi_node_verifier --full emits text and JSON`.
+
 5. (Optional) Copy `/boot/sugarkube-kubeconfig-full` (or the sanitized
    `/boot/sugarkube-kubeconfig`) from another machine to share cluster endpoints with teammates.
    The sanitized export redacts client keys and tokens—prefer the `-full` variant when you need

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -198,10 +198,11 @@ sync without modifying the host.
   regressions in the compose file. They assert that token.place stays on port
   **5000**, dspace on **3000**, and that every bundled observability container
   sticks to its pinned SHA-256 digest. Run `pytest` after editing
-  `scripts/cloud-init/docker-compose.yml` to exercise the checks locally. The
-  Bats suite (`tests/pi_node_verifier_output_test.bats`) now also spins up a
-  temporary HTTP server so the verifier's health probes must report `pass`
-  before changes merge.
+    `scripts/cloud-init/docker-compose.yml` to exercise the checks locally. The
+    Bats suite (`tests/pi_node_verifier_output_test.bats`) now also spins up a
+    temporary HTTP server so the verifier's health probes must report `pass`
+    before changes merge, and verifies that `--full` emits both text output and
+    a JSON payload for downstream automation.
 - systemd now ships a `k3s-ready.target` that depends on the compose service and waits for
   `kubectl get nodes` to report `Ready`. Inspect the target to confirm the cluster finished
   bootstrapping:

--- a/scripts/pi_node_verifier.sh
+++ b/scripts/pi_node_verifier.sh
@@ -9,6 +9,7 @@ JSON=false
 REPORT_PATH=""
 ENABLE_LOG=true
 SKIP_COMPOSE=${SKIP_COMPOSE:-false}
+FULL=false
 DEFAULT_REPORT="/boot/first-boot-report.txt"
 MIGRATION_LOG=${MIGRATION_LOG:-/var/log/sugarkube/migrations.log}
 TOKEN_PLACE_HEALTH_URL=${TOKEN_PLACE_HEALTH_URL:-http://127.0.0.1:5000/}
@@ -60,18 +61,23 @@ while [[ $# -gt 0 ]]; do
     --skip-compose=*)
       set_skip_compose "${1#*=}"
       ;;
+    --full)
+      FULL=true
+      JSON=true
+      ;;
     --no-log)
       ENABLE_LOG=false
       ;;
     --help)
       cat <<'EOF'
-Usage: pi_node_verifier.sh [--json] [--log PATH] [--no-log] [--skip-compose[=BOOL]]
+Usage: pi_node_verifier.sh [--json] [--log PATH] [--no-log] [--skip-compose[=BOOL]] [--full]
 
 Options:
   --json       Emit machine-readable JSON results.
   --log PATH   Append a Markdown summary to PATH.
                Defaults to /boot/first-boot-report.txt when writable.
   --no-log     Disable report generation entirely.
+  --full       Print text output and a JSON summary (implies --json).
   --skip-compose[=BOOL]
                Skip the projects-compose.service health check. Defaults to false.
   --help       Show this message.
@@ -101,7 +107,7 @@ check_statuses=()
 print_result() {
   local name="$1"
   local status="$2"
-  if ! $JSON; then
+  if ! $JSON || $FULL; then
     printf '%s: %s\n' "$name" "$status"
   fi
   json_parts+=('{"name":"'"$name"'","status":"'"$status"'"}')

--- a/tests/pi_node_verifier_output_test.bats
+++ b/tests/pi_node_verifier_output_test.bats
@@ -14,6 +14,20 @@
   echo "$output" | grep "dspace_http:"
 }
 
+@test "pi_node_verifier --full emits text and JSON" {
+  run "$BATS_TEST_DIRNAME/../scripts/pi_node_verifier.sh" --full
+  [ "$status" -eq 0 ]
+  echo "$output" | grep "cloud_init:"
+  json_line="$(printf '%s\n' "$output" | grep '"checks"')"
+  [ -n "$json_line" ]
+  JSON_LINE="$json_line" python - <<'PY'
+import json
+import os
+
+json.loads(os.environ["JSON_LINE"])
+PY
+}
+
 @test "pi_node_verifier marks HTTP checks as pass when endpoints respond" {
   port=$(python - <<'PY'
 import socket


### PR DESCRIPTION
## Summary
- add a --full mode to `scripts/pi_node_verifier.sh` that keeps the text table while emitting the JSON summary
- cover the new flag in `tests/pi_node_verifier_output_test.bats` and document the behavior in the provisioning guides
- refresh README and quickstart guidance so reruns mention the combined output and new regression test

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d8f0edff6c832fa60e02eb4c3fa78c