### PR TITLE
✨ : – Document CI notes spell/link commands

### DIFF
--- a/docs/tutorials/tutorial-04-version-control-collaboration.md
+++ b/docs/tutorials/tutorial-04-version-control-collaboration.md
@@ -264,6 +264,8 @@ become part of your milestone evidence.
    ## Local checks
    - `git status` to confirm a clean worktree before commits.
    - `pre-commit run --all-files` to execute the repository checks before every PR.
+   - `pyspelling -c .spellcheck.yaml` to confirm documentation changes pass the spell checker.
+   - `linkchecker --no-warnings README.md docs/` to validate links across the handbook.
 
    ## GitHub checks
    - Pull requests trigger documentation linting and spell checking.
@@ -277,7 +279,8 @@ become part of your milestone evidence.
    ```
 
 > [!NOTE]
-> Sugarkube's automated tests verify this tutorial keeps `pre-commit run --all-files`
+> Sugarkube's automated tests verify this tutorial keeps `pre-commit run --all-files`,
+> `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/`
 > in the checklist so future contributors learn to run the project checks locally.
 
 3. Commit and push the notes:

--- a/tests/test_tutorial_04_ci_notes.py
+++ b/tests/test_tutorial_04_ci_notes.py
@@ -24,3 +24,17 @@ def test_ci_notes_no_longer_mark_pre_commit_as_planned() -> None:
     assert (
         "planned for Sugarkube contributions" not in text
     ), "Tutorial 4 still labels pre-commit usage as future work"
+
+
+def test_ci_notes_reference_pyspelling_command() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    assert (
+        "`pyspelling -c .spellcheck.yaml`" in text
+    ), "Tutorial 4 should direct readers to run pyspelling with the project config"
+
+
+def test_ci_notes_reference_linkchecker_command() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    assert (
+        "`linkchecker --no-warnings README.md docs/`" in text
+    ), "Tutorial 4 should remind readers to run linkchecker before opening a PR"


### PR DESCRIPTION
✨ : – Document CI notes spell/link commands

what: add Tutorial 4 guidance for pyspelling/linkchecker and tests
why: close documented CI checklist gap for tutorial contributors
how to test:
- pytest tests/test_tutorial_04_ci_notes.py
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d9a6c8ae3c832f896bfb3b6db564b4