### PR TITLE
Add Makefile codespaces bootstrap target and docs updates

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -229,3 +229,6 @@ yourorg
 checksums
 Codespaces
 verifier
+<htmlcontent>
+justfile
+justfiles

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ MAC_SETUP_ARGS ?=
 .PHONY: install-pi-image download-pi-image flash-pi flash-pi-report doctor rollback-to-sd \
         clone-ssd docs-verify docs-simplify qr-codes monitor-ssd-health smoke-test-pi qemu-smoke field-guide \
         publish-telemetry notify-teams notify-workflow update-hardware-badge rehearse-join \
-        token-place-samples support-bundle mac-setup cluster-up
+        token-place-samples support-bundle mac-setup cluster-up codespaces-bootstrap
 
 install-pi-image:
 	$(INSTALL_CMD) --dir '$(IMAGE_DIR)' --image '$(IMAGE_PATH)' $(DOWNLOAD_ARGS)
@@ -92,6 +92,10 @@ docs-verify:
 
 docs-simplify:
 	$(CURDIR)/scripts/checks.sh --docs-only
+
+codespaces-bootstrap:
+	sudo apt-get update
+	sudo apt-get install -y curl gh jq pv unzip xz-utils
 
 qr-codes:
 	$(QR_CMD) $(QR_ARGS)

--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ the manifest so you can verify the build inputs and commit hashes before
  via `curl -fsSL https://raw.githubusercontent.com/futuroptimist/sugarkube/main/scripts/install_sugarkube_image.sh | bash`) to
  download, verify, and expand the latest release. When you prefer a task runner,
 use either `sudo make flash-pi FLASH_DEVICE=/dev/sdX` or `sudo FLASH_DEVICE=/dev/sdX just flash-pi` to
- chain download → verification → flashing with the streaming helper. The `just` recipes read
- `FLASH_DEVICE` (and optional `DOWNLOAD_ARGS`) from the environment, so prefix the variable as shown.
- They also provide
- `download-pi-image`, `install-pi-image`, `doctor`, and `codespaces-bootstrap` shortcuts so GitHub
- Codespaces users can install prerequisites and flash media without additional shell glue.
+chain download → verification → flashing with the streaming helper. The recipe variables read
+`FLASH_DEVICE` (and optional `DOWNLOAD_ARGS`) from the environment, so prefix the variable as shown. Both the
+Makefile and justfile expose `download-pi-image`, `install-pi-image`, `doctor`, and `codespaces-bootstrap`
+shortcuts so GitHub
+Codespaces users can install prerequisites and flash media without additional shell glue.
 `./scripts/sugarkube-latest` remains available when you only need the `.img.xz` artifact with
 checksum verification.
 

--- a/docs/pi_carrier_launch_playbook.md
+++ b/docs/pi_carrier_launch_playbook.md
@@ -26,8 +26,9 @@ work; the downloads and flash runs are unattended.
    cd sugarkube
    just codespaces-bootstrap
    ```
-   The bootstrap target installs `gh`, `curl`, flashing dependencies, and Python requirements. Skip
-   this step inside Codespaces where the bootstrap happens automatically.
+   The bootstrap target installs `gh`, `curl`, flashing dependencies, and Python requirements. Prefer
+   `make codespaces-bootstrap` when you would rather stay inside the Makefile. Skip this step inside
+   Codespaces where the bootstrap happens automatically.
 
 2. **Grab the latest release:**
    ```bash

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -426,8 +426,8 @@ Makefile/justfile shortcuts.
 ## Codespaces-friendly automation
 
 - Launch a new GitHub Codespace on this repository using the default Ubuntu image.
-- Run `just codespaces-bootstrap` once to install `gh`, `pv`, and other helpers that the
-  download + flash scripts expect.
+- Run `just codespaces-bootstrap` (or `make codespaces-bootstrap`) once to install `gh`, `pv`, and
+  other helpers that the download + flash scripts expect.
 - Use `just install-pi-image` or `just download-pi-image` to populate `~/sugarkube/images` with
   the latest release, or trigger `sudo FLASH_DEVICE=/dev/sdX just flash-pi` when you attach a USB
   flasher to the Codespace via the browser or VS Code desktop.

--- a/docs/status/README.md
+++ b/docs/status/README.md
@@ -41,7 +41,7 @@ or documentation updates whenever the numbers move.
 
 * **What it measures:** The elapsed time for a new contributor to work through
   the onboarding checklist from [docs/tutorials/index.md](../tutorials/index.md)
-  (cloning the repo, running `just codespaces-bootstrap`, generating required
+  (cloning the repo, running `just codespaces-bootstrap` or `make codespaces-bootstrap`, generating required
   artifacts, and opening their first PR).
 * **Why it matters:** Lower completion times signal that documentation, prompts,
   and automation helpers remain approachable.

--- a/tests/test_make_codespaces_bootstrap.py
+++ b/tests/test_make_codespaces_bootstrap.py
@@ -1,0 +1,20 @@
+"""Ensure Makefile exposes the codespaces bootstrap helper."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MAKEFILE = ROOT / "Makefile"
+
+
+def test_makefile_defines_codespaces_bootstrap_target() -> None:
+    text = MAKEFILE.read_text(encoding="utf-8")
+    pattern = (
+        r"^codespaces-bootstrap:\n"
+        r"\tsudo apt-get update\n"
+        r"\tsudo apt-get install -y curl gh jq pv unzip xz-utils"
+    )
+    match = re.search(pattern, text, flags=re.MULTILINE)
+    assert match, "Makefile is missing the codespaces bootstrap recipe"


### PR DESCRIPTION
## Summary
- add a `codespaces-bootstrap` recipe to the Makefile so the documented helper exists alongside the justfile
- update onboarding docs to mention the Makefile variant and extend the spelling dictionary for new terminology
- add regression coverage that verifies the Makefile recipe matches the expected `apt-get` commands

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d9a6c8ae3c832f896bfb3b6db564b4