### PR TITLE
✨ : – tutorial roadmap reflects published guides

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,10 +1,14 @@
 # Sugarkube Tutorial Roadmap
 
 Sugarkube combines hardware, software, and operational practices into a cohesive home-lab scale
-platform. This roadmap outlines the tutorials we plan to write, sequenced so a newcomer with no prior
-technical background can progress from first principles to confidently maintaining and extending the
-platform. Each entry will eventually become its own standalone guide; for now, the descriptions below
-capture the narrative arc, learning goals, and practical exercises we intend to include.
+platform. This roadmap outlines the published tutorials so a newcomer with no prior technical
+background can progress from first principles to confidently maintaining and extending the platform.
+Every entry links to a maintained standalone guide, with the summaries below highlighting the
+narrative arc, learning goals, and practical exercises they cover.
+
+> [!NOTE]
+> Automated coverage in `tests/test_tutorial_index_publication.py` ensures this roadmap keeps
+> acknowledging the published guides.
 
 Throughout the series we keep our eye on the real-world goal: installing the aluminium extrusion
 Sugarkube cube in an outdoor setting (like a backyard pergola), wiring its solar array and charge

--- a/tests/test_tutorial_index_publication.py
+++ b/tests/test_tutorial_index_publication.py
@@ -1,0 +1,17 @@
+"""Ensure the tutorial roadmap reflects shipped guides."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+DOC_PATH = Path(__file__).resolve().parents[1] / "docs" / "tutorials" / "index.md"
+
+
+def test_tutorial_index_acknowledges_published_guides() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    assert (
+        "Each entry will eventually become its own standalone guide" not in text
+    ), "Tutorial roadmap still frames guides as future work"
+    assert (
+        "Every entry links to a maintained standalone guide" in text
+    ), "Tutorial roadmap should confirm each guide is already published"


### PR DESCRIPTION
## what
- add a regression test that asserts the tutorial roadmap acknowledges the published guides
- refresh docs/tutorials/index.md to remove the "future work" language and mention the new coverage

## why
- docs/tutorials/index.md still claimed each tutorial "will eventually" become a standalone guide even though they already ship, so this closes the documented future-work item in a single PR

## how to test
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py


------
https://chatgpt.com/codex/tasks/task_e_68d9a6c8ae3c832f896bfb3b6db564b4