### PR TITLE
Retire future-work phrasing from tutorials 11 and 12

### DIFF
--- a/docs/tutorials/tutorial-11-storage-migration-maintenance.md
+++ b/docs/tutorials/tutorial-11-storage-migration-maintenance.md
@@ -328,5 +328,9 @@ Use this list to confirm you met every objective before moving on:
 
 ## Next Steps
 Continue to [Tutorial 12: Contributing New Features and Automation](./tutorial-12-contributing-new-features-and-automation.md)
-(once published) to learn how to propose improvements, extend automation, and collaborate on future
-Sugarkube releases.
+to learn how to propose improvements, extend automation, and collaborate on future Sugarkube
+releases.
+
+> [!NOTE]
+> Automated coverage in `tests/test_tutorial_11_12_next_steps.py` keeps this section pointing to the
+> published Tutorial 12 guide.

--- a/docs/tutorials/tutorial-12-contributing-new-features-automation.md
+++ b/docs/tutorials/tutorial-12-contributing-new-features-automation.md
@@ -245,5 +245,10 @@ supporting evidence (issue links, commit hashes, transcripts, or screenshots).
 
 ## Next Steps
 Advance to [Tutorial 13: Advanced Operations and Future Directions](./index.md#tutorial-13-advanced-operations-and-future-directions)
-when it becomes available. Bring the contribution evidence you just produced—future experiments will
-build on your ability to plan, implement, and communicate complex changes.
+to continue expanding your operational toolkit. Bring the contribution evidence you just
+produced—future experiments will build on your ability to plan, implement, and communicate complex
+changes.
+
+> [!NOTE]
+> `tests/test_tutorial_11_12_next_steps.py` ensures this section always references the published
+> Tutorial 13 follow-up guide.

--- a/tests/test_tutorial_11_12_next_steps.py
+++ b/tests/test_tutorial_11_12_next_steps.py
@@ -1,0 +1,43 @@
+"""Ensure tutorials 11 and 12 no longer reference unpublished guides."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+DOC_11 = (
+    Path(__file__).resolve().parents[1]
+    / "docs"
+    / "tutorials"
+    / "tutorial-11-storage-migration-maintenance.md"
+)
+
+DOC_12 = (
+    Path(__file__).resolve().parents[1]
+    / "docs"
+    / "tutorials"
+    / "tutorial-12-contributing-new-features-automation.md"
+)
+
+
+def test_tutorial_11_promotes_available_tutorial_12() -> None:
+    """Tutorial 11 should acknowledge Tutorial 12 is already published."""
+
+    text = DOC_11.read_text(encoding="utf-8")
+    assert (
+        "(once published)" not in text
+    ), "Tutorial 11 still frames Tutorial 12 as unpublished future work"
+    assert (
+        "Continue to [Tutorial 12: Contributing New Features and Automation]" in text
+    ), "Tutorial 11 should direct readers to the published Tutorial 12 guide"
+
+
+def test_tutorial_12_promotes_available_tutorial_13() -> None:
+    """Tutorial 12 should acknowledge Tutorial 13 is already published."""
+
+    text = DOC_12.read_text(encoding="utf-8")
+    assert (
+        "when it becomes available" not in text
+    ), "Tutorial 12 still frames Tutorial 13 as future work"
+    assert (
+        "Advance to [Tutorial 13: Advanced Operations and Future Directions]" in text
+    ), "Tutorial 12 should direct readers to the published Tutorial 13 guide"


### PR DESCRIPTION
## Summary
- retire future-work phrasing in tutorials 11 and 12 now that follow-ups ship
- add regression test ensuring tutorials reference published successors
- document automated coverage in the Next Steps sections

## Future work inventory
- tutorials 11 and 12 still said their follow-up guides were future work; they
  already exist, so removing the wording ships in one PR

## Testing
- pre-commit run --all-files (pass)
- pyspelling -c .spellcheck.yaml (pass)
- linkchecker --no-warnings README.md docs/ (pass)
- pytest tests/test_tutorial_11_12_next_steps.py (pass)
- git diff --cached | ./scripts/scan-secrets.py (clean)


------
https://chatgpt.com/codex/tasks/task_e_68d9b49fbc88832fa75d9b1c6bfcbf21