### PR TITLE
✨ : Publish Tutorial 6 hand-off

### DIFF
--- a/docs/tutorials/tutorial-05-programming-for-operations.md
+++ b/docs/tutorials/tutorial-05-programming-for-operations.md
@@ -450,5 +450,6 @@ Use this list to confirm you met the roadmap goals. Mark each item with `[x]` wh
 
 ## Next Steps
 Proceed to [Tutorial 6: Raspberry Pi Hardware and Power Design](./index.md#tutorial-6-raspberry-pi-hardware-and-power-design).
-While the full guide is forthcoming, review the roadmap entry now and gather the required tools so you
-can transition smoothly once it is published.
+The hardware-focused guide is published—review its tool checklist and lab safety reminders so you can
+transition smoothly into the next build. Regression coverage lives in
+`tests/test_tutorial_05_next_steps.py` to keep this hand-off accurate as the tutorials evolve.

--- a/tests/test_tutorial_05_next_steps.py
+++ b/tests/test_tutorial_05_next_steps.py
@@ -1,0 +1,17 @@
+"""Ensure Tutorial 5 no longer frames Tutorial 6 as future work."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+DOC_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "docs"
+    / "tutorials"
+    / "tutorial-05-programming-for-operations.md"
+)
+
+
+def test_next_steps_reflect_published_tutorial_six() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    assert "forthcoming" not in text.lower(), "Tutorial 5 still describes Tutorial 6 as forthcoming"


### PR DESCRIPTION
what: document Tutorial 6 availability and add regression test
why: close stale "forthcoming" note in tutorial hand-off
how: pre-commit run --all-files; pyspelling -c .spellcheck.yaml;
     linkchecker --no-warnings README.md docs/;
     git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d9b49fbc88832fa75d9b1c6bfcbf21