### PR TITLE
✨ : – align tutorial next steps with published guides

### DIFF
--- a/docs/tutorials/tutorial-04-version-control-collaboration.md
+++ b/docs/tutorials/tutorial-04-version-control-collaboration.md
@@ -321,7 +321,10 @@ Use this list to verify you met the roadmap milestones. Mark each box when you h
 > `git add <file>` followed by `git rebase --continue` or `git merge --continue`.
 
 ## Next Steps
-Continue your journey with
-[Tutorial 5: Programming for Operations with Python and Bash](./index.md#tutorial-5-programming-for-operations-with-python-and-bash)
-when it becomes available. Bring the repositories and notes you created here—they provide a working
-sandbox for scripting and automation practice.
+Advance to [Tutorial 5: Programming for Operations with Python and Bash](./index.md#tutorial-5-programming-for-operations-with-python-and-bash).
+Bring the repositories and notes you created here—they provide a working sandbox for scripting and
+automation practice.
+
+> [!NOTE]
+> Automated coverage in `tests/test_tutorial_next_steps.py` keeps this "Next Steps" section aligned
+> with the published tutorial roadmap.

--- a/docs/tutorials/tutorial-07-kubernetes-container-fundamentals.md
+++ b/docs/tutorials/tutorial-07-kubernetes-container-fundamentals.md
@@ -439,5 +439,9 @@ repository README or tracking spreadsheet.
 
 ## Next Steps
 Advance to [Tutorial 8: Preparing a Sugarkube Development Environment](./index.md#tutorial-8-preparing-a-sugarkube-development-environment)
-when it becomes available. That guide will translate your Kubernetes sandbox experience into the
-exact automation workflow used inside the Sugarkube repository.
+to translate your Kubernetes sandbox experience into the exact automation workflow used inside the
+Sugarkube repository.
+
+> [!NOTE]
+> Automated coverage in `tests/test_tutorial_next_steps.py` keeps this "Next Steps" section aligned
+> with the published tutorial roadmap.

--- a/docs/tutorials/tutorial-12-contributing-new-features-automation.md
+++ b/docs/tutorials/tutorial-12-contributing-new-features-automation.md
@@ -245,5 +245,10 @@ supporting evidence (issue links, commit hashes, transcripts, or screenshots).
 
 ## Next Steps
 Advance to [Tutorial 13: Advanced Operations and Future Directions](./index.md#tutorial-13-advanced-operations-and-future-directions)
-when it becomes available. Bring the contribution evidence you just produced—future experiments will
-build on your ability to plan, implement, and communicate complex changes.
+to extend the contribution workflow into long-term platform stewardship. Bring the contribution
+evidence you just produced—future experiments will build on your ability to plan, implement, and
+communicate complex changes.
+
+> [!NOTE]
+> Automated coverage in `tests/test_tutorial_next_steps.py` keeps this "Next Steps" section aligned
+> with the published tutorial roadmap.

--- a/tests/test_tutorial_next_steps.py
+++ b/tests/test_tutorial_next_steps.py
@@ -1,0 +1,33 @@
+"""Ensure tutorial "Next Steps" sections point to published guides."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+DOCS_DIR = Path(__file__).resolve().parents[1] / "docs" / "tutorials"
+
+TUTORIAL_NEXT_STEPS = (
+    (
+        "tutorial-04-version-control-collaboration.md",
+        "Advance to [Tutorial 5: Programming for Operations with Python and Bash]",
+    ),
+    (
+        "tutorial-07-kubernetes-container-fundamentals.md",
+        "Advance to [Tutorial 8: Preparing a Sugarkube Development Environment]",
+    ),
+    (
+        "tutorial-12-contributing-new-features-automation.md",
+        "Advance to [Tutorial 13: Advanced Operations and Future Directions]",
+    ),
+)
+
+
+@pytest.mark.parametrize("filename, expected_fragment", TUTORIAL_NEXT_STEPS)
+def test_next_steps_reference_published_tutorial(filename: str, expected_fragment: str) -> None:
+    text = (DOCS_DIR / filename).read_text(encoding="utf-8")
+    assert (
+        "when it becomes available" not in text
+    ), "Next Steps should highlight published follow-up tutorials"
+    assert expected_fragment in text, "Next Steps should link directly to the follow-up tutorial"


### PR DESCRIPTION
what:
- add regression test ensuring tutorial next steps link to published guides
- revise tutorials 4, 7, and 12 next steps to remove future tense and add test note

why:
- `rg "when it becomes available"` flagged stale copy even though tutorials 5, 8, and 13 ship
- keeps the roadmap consistent with already published material

how to test:
- pytest tests/test_tutorial_next_steps.py
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d9b49fbc88832fa75d9b1c6bfcbf21