### PR TITLE
Add CLI helper backing the start-here onboarding note

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,10 @@ FIELD_GUIDE_CMD ?= $(CURDIR)/scripts/render_field_guide_pdf.py
 FIELD_GUIDE_ARGS ?=
 MAC_SETUP_CMD ?= $(CURDIR)/scripts/sugarkube_setup.py
 MAC_SETUP_ARGS ?=
+START_HERE_CMD ?= $(CURDIR)/scripts/start_here.py
+START_HERE_ARGS ?=
 
-.PHONY: install-pi-image download-pi-image flash-pi flash-pi-report doctor rollback-to-sd \
+.PHONY: install-pi-image download-pi-image flash-pi flash-pi-report doctor start-here rollback-to-sd \
         clone-ssd docs-verify docs-simplify qr-codes monitor-ssd-health smoke-test-pi qemu-smoke field-guide \
         publish-telemetry notify-teams notify-workflow update-hardware-badge rehearse-join \
         token-place-samples support-bundle mac-setup cluster-up codespaces-bootstrap
@@ -75,6 +77,9 @@ flash-pi-report: install-pi-image
 
 doctor:
 	$(CURDIR)/scripts/sugarkube_doctor.sh
+
+start-here:
+	$(START_HERE_CMD) $(START_HERE_ARGS)
 
 rollback-to-sd:
 	$(ROLLBACK_CMD) $(ROLLBACK_ARGS)

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -4,6 +4,11 @@ Kick off your Sugarkube journey from a single launchpad. This guide condenses th
 three tracks so you can build context quickly, complete the onboarding chores, and know where to dive
 when you are ready for deeper automation or hardware projects.
 
+> [!TIP]
+> Run `just start-here` (or `make start-here`) to print this handbook directly in your terminal.
+> Append `--path-only` to either command when you simply need the absolute path for note-taking or
+> automation evidence.
+
 ## 15-minute tour
 
 > [!TIP]

--- a/docs/templates/simplification/onboarding-update.md
+++ b/docs/templates/simplification/onboarding-update.md
@@ -7,8 +7,8 @@
 
 ## Required Artifacts
 - Link to the updated quickstart, handbook, or tutorial draft.
-- Evidence that automation (`make doctor`, `just start-here`, etc.) reflects the
-  new path.
+- Evidence that automation (`make doctor`, `just start-here`, `make start-here --path-only`) reflects
+  the new path and prints the updated guidance.
 - Screenshots or recordings that walk through the refreshed flow.
 
 ## Stakeholders

--- a/justfile
+++ b/justfile
@@ -88,6 +88,11 @@ mac_setup_cmd := env_var_or_default(
     justfile_directory() + "/scripts/sugarkube_setup.py",
 )
 mac_setup_args := env_var_or_default("MAC_SETUP_ARGS", "")
+start_here_cmd := env_var_or_default(
+    "START_HERE_CMD",
+    justfile_directory() + "/scripts/start_here.py",
+)
+start_here_args := env_var_or_default("START_HERE_ARGS", "")
 
 _default:
     @just --list
@@ -127,6 +132,11 @@ flash-pi-report: install-pi-image
 # Usage: just doctor
 doctor:
     "{{justfile_directory()}}/scripts/sugarkube_doctor.sh"
+
+# Surface the Start Here handbook in the terminal
+# Usage: just start-here START_HERE_ARGS="--path-only"
+start-here:
+    "{{start_here_cmd}}" {{start_here_args}}
 
 # Revert cmdline.txt and fstab entries back to the SD card defaults
 # Usage: sudo just rollback-to-sd

--- a/scripts/start_here.py
+++ b/scripts/start_here.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Display the Start Here guide path or contents for quick reference."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+DOC_PATH = Path(__file__).resolve().parents[1] / "docs" / "start-here.md"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the CLI argument parser."""
+
+    parser = argparse.ArgumentParser(
+        description="Surface the Sugarkube Start Here handbook from the command line.",
+    )
+    parser.add_argument(
+        "--path-only",
+        action="store_true",
+        help="Print just the absolute path to docs/start-here.md.",
+    )
+    parser.add_argument(
+        "--no-content",
+        action="store_true",
+        help=(
+            "Deprecated alias for --path-only; kept for forwards compatibility with early drafts."
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the start-here helper."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if not DOC_PATH.exists():
+        parser.error("docs/start-here.md is missing; re-run after restoring the handbook.")
+
+    if args.path_only or args.no_content:
+        print(DOC_PATH)
+        return 0
+
+    print(f"Sugarkube Start Here guide: {DOC_PATH}")
+    print()
+    print(DOC_PATH.read_text(encoding="utf-8"))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via CLI
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_start_here_command.py
+++ b/tests/test_start_here_command.py
@@ -1,0 +1,51 @@
+"""Ensure the start-here automation promised in docs exists."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "start_here.py"
+DOC_PATH = REPO_ROOT / "docs" / "start-here.md"
+
+
+def test_start_here_script_exists() -> None:
+    """The CLI helper should exist so contributors can surface the Start Here guide."""
+
+    assert (
+        SCRIPT_PATH.exists()
+    ), "scripts/start_here.py should exist to mirror the documented workflow"
+
+
+def test_start_here_script_reports_doc_path() -> None:
+    """The helper should emit the Start Here path for tooling or shell usage."""
+
+    assert SCRIPT_PATH.exists(), "scripts/start_here.py should exist before invoking it"
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--path-only"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert result.stdout.strip() == str(DOC_PATH), "Expected the CLI to print docs/start-here.md"
+
+
+def test_justfile_exposes_start_here_target() -> None:
+    """The justfile should provide a start-here recipe like the docs describe."""
+
+    text = (REPO_ROOT / "justfile").read_text(encoding="utf-8")
+    assert (
+        "start-here:" in text
+    ), "Add a start-here recipe to the justfile so automation can call it"
+    assert "scripts/start_here.py" in text, "The just target should invoke scripts/start_here.py"
+
+
+def test_makefile_exposes_start_here_target() -> None:
+    """Make parity keeps docs accurate for contributors who prefer Make."""
+
+    text = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+    assert "start-here:" in text, "Add a start-here target to the Makefile"
+    assert "scripts/start_here.py" in text, "The Make target should invoke scripts/start_here.py"


### PR DESCRIPTION
## what
- add scripts/start_here.py to print the Start Here handbook or its path
- expose start-here targets in the Makefile/justfile and document the shortcut
- cover the automation with tests and update the onboarding template guidance

## why
- docs/templates/simplification/onboarding-update.md already referenced `just start-here`
  but no automation existed

## how to test
- python -m pre_commit run --all-files
- python -m pre_commit run --files Makefile
- pytest tests/test_start_here_command.py
- python -m pyspelling -c .spellcheck.yaml
- /root/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68da12de2bf8832f970679909d8ee462