### PR TITLE
✨ : – Add persona tabs to start-here guide

### DIFF
--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -4,6 +4,34 @@ Kick off your Sugarkube journey from a single launchpad. This guide condenses th
 three tracks so you can build context quickly, complete the onboarding chores, and know where to dive
 when you are ready for deeper automation or hardware projects.
 
+## Persona quick links
+
+Use the tabs below to jump straight to the references that match how you plan to contribute today.
+Each list links to maintained guides and tooling so you can gather context without guessing which
+docs apply to you.
+
+=== "Hardware builders"
+
+    - Print the [Pi carrier launch playbook](./pi_carrier_launch_playbook.md) to prepare the enclosure
+      build, wiring harness, and solar checks.
+    - Stage the [hardware index](./hardware/index.md) for diagrams, bill of materials, and safety
+      notes before you open a toolkit.
+    - Bookmark [tutorial 6](./tutorials/tutorial-06-raspberry-pi-hardware-power.md) to rehearse power
+      budgeting and enclosure assembly.
+    - Keep [docs/ssd_recovery.md](./ssd_recovery.md) handy for contingency plans when a boot device
+      misbehaves during testing.
+
+=== "Software contributors"
+
+    - Start with the [software index](./software/index.md) for quick access to automation guides and
+      helper scripts.
+    - Review [docs/pi_image_quickstart.md](./pi_image_quickstart.md) to understand the build pipeline
+      before you edit cloud-init or verifier hooks.
+    - Practice the contribution workflow by following
+      [tutorial 12](./tutorials/tutorial-12-contributing-new-features-automation.md).
+    - Skim [docs/prompts/codex/tests.md](./prompts/codex/tests.md) so you know which checks run in CI
+      and how to extend regression coverage.
+
 ## 15-minute tour
 
 > [!TIP]

--- a/simplification_suggestions.md
+++ b/simplification_suggestions.md
@@ -62,8 +62,10 @@ others—without a "start here" narrative.
 1. ✅ Drafted [`docs/start-here.md`](docs/start-here.md), a handbook with three
    tracks: 15-minute tour, day-one contributor checklist, and advanced
    references.
-2. Use tabbed callouts (matching the docs site markdown extensions) to
-   differentiate hardware builders vs. software contributors.
+2. ✅ Use tabbed callouts (matching the docs site markdown extensions) to
+   differentiate hardware builders vs. software contributors (see
+   `docs/start-here.md`; regression coverage:
+   `tests/test_start_here_doc.py::test_start_here_doc_includes_persona_tabs`).
 3. Embed a quick architecture diagram or recorded walkthrough so new folks
    understand how the Pi image, solar hardware, and CI fit together.
 

--- a/tests/test_start_here_doc.py
+++ b/tests/test_start_here_doc.py
@@ -30,3 +30,13 @@ def test_start_here_doc_cross_links_resources() -> None:
     ]
     for link in required_links:
         assert link in text, f"Expected reference to '{link}' in docs/start-here.md"
+
+
+def test_start_here_doc_includes_persona_tabs() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    assert (
+        '=== "Hardware builders"' in text
+    ), "Start-here guide should present a tab for hardware builders"
+    assert (
+        '=== "Software contributors"' in text
+    ), "Start-here guide should present a tab for software contributors"


### PR DESCRIPTION
what: add persona tabs in docs/start-here.md and regression coverage
why: ship simplification_suggestions.md item 2 tabbed callout guidance
how to test: pytest tests/test_start_here_doc.py
how to test: pre-commit run --all-files
how to test: pyspelling -c .spellcheck.yaml
how to test: linkchecker --no-warnings README.md docs/
how to test: git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68da12de2bf8832f970679909d8ee462