### PR TITLE
Add architecture diagram to Start Here onboarding guide

### DIFF
--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -4,6 +4,11 @@ Kick off your Sugarkube journey from a single launchpad. This guide condenses th
 three tracks so you can build context quickly, complete the onboarding chores, and know where to dive
 when you are ready for deeper automation or hardware projects.
 
+![Sugarkube architecture overview linking solar, Pi cluster, and CI automation](images/sugarkube_diagram.svg)
+
+*Figure: Solar panels feed the charge controller and batteries powering the Pi cluster while CI
+automation keeps the image, tooling, and observability assets in sync.*
+
 ## Persona quick links
 
 Use the tabs below to jump straight to the references that match how you plan to contribute today.
@@ -35,8 +40,8 @@ docs apply to you.
 ## 15-minute tour
 
 > [!TIP]
-> Run `just start-here` (or `make start-here`) to print this handbook directly in your terminal.  
-> Append `--path-only` to either command when you simply need the absolute path for note-taking or automation evidence.  
+> Run `just start-here` (or `make start-here`) to print this handbook directly in your terminal.
+> Append `--path-only` to either command when you simply need the absolute path for note-taking or automation evidence.
 > Skim this track the moment you clone the repository. It orients you before you touch any
 > automation.
 

--- a/simplification_suggestions.md
+++ b/simplification_suggestions.md
@@ -66,8 +66,10 @@ others—without a "start here" narrative.
    differentiate hardware builders vs. software contributors (see
    `docs/start-here.md`; regression coverage:
    `tests/test_start_here_doc.py::test_start_here_doc_includes_persona_tabs`).
-3. Embed a quick architecture diagram or recorded walkthrough so new folks
-   understand how the Pi image, solar hardware, and CI fit together.
+3. ✅ Embed a quick architecture diagram so new folks understand how the Pi
+   image, solar hardware, and CI fit together (see `docs/start-here.md`; regression
+   coverage:
+   `tests/test_start_here_doc.py::test_start_here_doc_embeds_architecture_diagram`).
 
 **Safeguards:**
 - Cross-link safety notices and ESD guidelines from the new handbook to avoid

--- a/tests/test_start_here_doc.py
+++ b/tests/test_start_here_doc.py
@@ -40,3 +40,13 @@ def test_start_here_doc_includes_persona_tabs() -> None:
     assert (
         '=== "Software contributors"' in text
     ), "Start-here guide should present a tab for software contributors"
+
+
+def test_start_here_doc_embeds_architecture_diagram() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    assert (
+        "![Sugarkube architecture overview" in text
+    ), "Start-here guide should embed an architecture diagram for quick orientation"
+    assert (
+        "images/sugarkube_diagram.svg" in text
+    ), "Start-here guide should reference the shared architecture diagram asset"


### PR DESCRIPTION
what:
- embed the shared architecture diagram in docs/start-here.md and explain the data flow
- note the new regression check in simplification_suggestions.md and add a test that locks the diagram in place

why:
- close the simplification backlog item requesting an architecture overview for newcomers

how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68da1d9705e4832fa380e9d5643a52dd