### PR TITLE
Align codespaces bootstrap with documented prerequisites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,19 @@ docs-simplify:
 
 codespaces-bootstrap:
 	sudo apt-get update
-	sudo apt-get install -y curl gh jq pv unzip xz-utils
+	sudo apt-get install -y \
+		aspell \\
+		aspell-en \\
+		curl \\
+		gh \\
+		jq \\
+		pv \\
+		python3 \\
+		python3-pip \\
+		python3-venv \\
+		unzip \\
+		xz-utils
+	python3 -m pip install --user --upgrade pip pre-commit pyspelling linkchecker
 
 qr-codes:
 	$(QR_CMD) $(QR_ARGS)

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -35,8 +35,8 @@ docs apply to you.
 ## 15-minute tour
 
 > [!TIP]
-> Run `just start-here` (or `make start-here`) to print this handbook directly in your terminal.  
-> Append `--path-only` to either command when you simply need the absolute path for note-taking or automation evidence.  
+> Run `just start-here` (or `make start-here`) to print this handbook directly in your terminal.
+> Append `--path-only` to either command when you simply need the absolute path for note-taking or automation evidence.
 > Skim this track the moment you clone the repository. It orients you before you touch any
 > automation.
 
@@ -55,8 +55,10 @@ docs apply to you.
 > Budget a focused afternoon to work through these steps. They line up with Tutorials 1–4 and leave
 > you with verified tooling plus a pull request rehearsal.
 
-1. Run either `just codespaces-bootstrap` or `make codespaces-bootstrap` to install the Python, spell
-   check, and link check prerequisites wired into `pre-commit`.
+1. Run either `just codespaces-bootstrap` or `make codespaces-bootstrap` to install CLI essentials
+   (`curl`, `gh`, `jq`, `pv`, `unzip`, `xz-utils`), Python tooling (`python3`, `python3-pip`,
+   `python3-venv`), and the documentation prerequisites (`aspell`, `aspell-en`, `pre-commit`,
+   `pyspelling`, `linkchecker`) wired into `pre-commit`.
 2. Execute `pre-commit run --all-files` once locally; it shells into `scripts/checks.sh` so you see
    the full lint, test, and docs pipeline.
 3. Follow the first four tutorials in [docs/tutorials/index.md](./tutorials/index.md) to capture lab

--- a/justfile
+++ b/justfile
@@ -213,7 +213,19 @@ cluster-up:
 # Usage: just codespaces-bootstrap
 codespaces-bootstrap:
     sudo apt-get update
-    sudo apt-get install -y curl gh jq pv unzip xz-utils
+    sudo apt-get install -y \
+        aspell \
+        aspell-en \
+        curl \
+        gh \
+        jq \
+        pv \
+        python3 \
+        python3-pip \
+        python3-venv \
+        unzip \
+        xz-utils
+    python3 -m pip install --user --upgrade pip pre-commit pyspelling linkchecker
 
 # Run spellcheck and linkcheck to keep docs automation aligned
 # Usage: just docs-verify

--- a/tests/test_codespaces_bootstrap.py
+++ b/tests/test_codespaces_bootstrap.py
@@ -1,0 +1,67 @@
+"""Ensure codespaces bootstrap installs documented prerequisites."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _extract_makefile_target(target: str) -> list[str]:
+    text = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+    pattern = rf"^{target}:\n((?:\t.+\n)+)"
+    match = re.search(pattern, text, flags=re.MULTILINE)
+    if not match:
+        pytest.fail(f"{target} target missing from Makefile")
+    return [line.strip() for line in match.group(1).strip().splitlines()]
+
+
+def _extract_justfile_recipe(target: str) -> list[str]:
+    text = (REPO_ROOT / "justfile").read_text(encoding="utf-8")
+    pattern = rf"^{target}:\n((?:\s{{4,}}.+\n)+)"
+    match = re.search(pattern, text, flags=re.MULTILINE)
+    if not match:
+        pytest.fail(f"{target} recipe missing from justfile")
+    return [line.strip() for line in match.group(1).strip().splitlines()]
+
+
+def test_codespaces_bootstrap_installs_doc_prereqs() -> None:
+    make_cmds = _extract_makefile_target("codespaces-bootstrap")
+    just_cmds = _extract_justfile_recipe("codespaces-bootstrap")
+
+    apt_packages = {"aspell", "aspell-en", "python3", "python3-pip", "python3-venv"}
+    pip_packages = {"pre-commit", "pyspelling", "linkchecker"}
+
+    def collect_apt_packages(commands: list[str]) -> set[str]:
+        for idx, cmd in enumerate(commands):
+            if cmd.startswith("sudo apt-get install"):
+                tokens: list[str] = []
+                remainder = cmd.split("sudo apt-get install", 1)[1]
+                tokens.extend(remainder.replace("-y", "").replace("\\", " ").split())
+                next_idx = idx + 1
+                while next_idx < len(commands):
+                    part = commands[next_idx]
+                    tokens.extend(part.replace("\\", " ").split())
+                    if not part.endswith("\\"):
+                        break
+                    next_idx += 1
+                return {token for token in tokens if token}
+        pytest.fail("apt-get install command missing")
+
+    make_apt_packages = collect_apt_packages(make_cmds)
+    just_apt_packages = collect_apt_packages(just_cmds)
+
+    for package in apt_packages:
+        assert package in make_apt_packages, f"{package} missing from Makefile apt install"
+        assert package in just_apt_packages, f"{package} missing from justfile apt install"
+
+    make_pip = next((cmd for cmd in make_cmds if "pip install" in cmd), None)
+    just_pip = next((cmd for cmd in just_cmds if "pip install" in cmd), None)
+    assert make_pip and just_pip, "codespaces bootstrap must install Python tooling via pip"
+
+    for package in pip_packages:
+        assert package in make_pip, f"{package} missing from Makefile pip install"
+        assert package in just_pip, f"{package} missing from justfile pip install"


### PR DESCRIPTION
## Summary
- install CLI, Python, and documentation prerequisites via codespaces-bootstrap targets in both the Makefile and justfile
- add regression coverage ensuring the bootstrap recipes install the documented packages
- clarify the Start Here checklist so it lists the tooling the bootstrap command now provides

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/

------
https://chatgpt.com/codex/tasks/task_e_68da1d9705e4832fa380e9d5643a52dd