### PR TITLE
Add collect support bundle shell wrapper

### DIFF
--- a/docs/pi_boot_troubleshooting.md
+++ b/docs/pi_boot_troubleshooting.md
@@ -43,10 +43,18 @@ guide the moment a boot hiccup appears.
 ## When to escalate
 
 If the table does not cover your scenario, collect the following bundle and
-attach it to an issue or outage report:
+attach it to an issue or outage report. The `.sh` wrapper delegates to the
+Python helper so older runbooks keep working while the CLI remains a single
+source of truth:
 
 ```bash
 sudo ./scripts/collect_support_bundle.sh --output ~/sugarkube/support-$(date +%Y%m%d).tar.gz
+```
+
+You can invoke the Python entrypoint directly if you prefer:
+
+```bash
+sudo ./scripts/collect_support_bundle.py --output ~/sugarkube/support-$(date +%Y%m%d).tar.gz
 ```
 
 The archive gathers `journalctl`, compose logs, `kubectl get all -A`, and the

--- a/docs/pi_support_bundles.md
+++ b/docs/pi_support_bundles.md
@@ -21,7 +21,10 @@ humans can detect missing data quickly.
 
 ## Collect bundles locally
 
-Run the helper directly when you have SSH access to a Pi:
+Run the helper directly when you have SSH access to a Pi. A
+`collect_support_bundle.sh` wrapper ships alongside it for runbooks that still
+reference the historical shell entrypoint; both commands execute the same
+Python implementation:
 
 ```bash
 ./scripts/collect_support_bundle.py pi-a.local \

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -35,8 +35,8 @@ docs apply to you.
 ## 15-minute tour
 
 > [!TIP]
-> Run `just start-here` (or `make start-here`) to print this handbook directly in your terminal.  
-> Append `--path-only` to either command when you simply need the absolute path for note-taking or automation evidence.  
+> Run `just start-here` (or `make start-here`) to print this handbook directly in your terminal.
+> Append `--path-only` to either command when you simply need the absolute path for note-taking or automation evidence.
 > Skim this track the moment you clone the repository. It orients you before you touch any
 > automation.
 

--- a/scripts/collect_support_bundle.sh
+++ b/scripts/collect_support_bundle.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/collect_support_bundle.py" "$@"

--- a/tests/test_collect_support_bundle.py
+++ b/tests/test_collect_support_bundle.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 from argparse import Namespace
 from datetime import datetime, timezone
 from pathlib import Path
@@ -198,6 +200,20 @@ def test_copy_targets_handles_timeout_and_duplicate_names(
     assert results[0]["local_path"].endswith("targets/var_log")
     assert results[1]["local_path"].endswith("targets/etc_config")
     assert results[2]["local_path"].endswith("targets/etc_config-2")
+
+
+def test_shell_wrapper_exposes_python_cli() -> None:
+    script = Path(__file__).resolve().parents[1] / "scripts" / "collect_support_bundle.sh"
+    assert script.exists(), "collect_support_bundle.sh wrapper should ship alongside the docs"
+    assert os.access(script, os.X_OK), "collect_support_bundle.sh must be executable"
+    result = subprocess.run(
+        [str(script), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "collect_support_bundle.py" in result.stdout
 
 
 def test_execute_specs_writes_logs(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- inventory: docs referenced missing collect_support_bundle.sh wrapper
- add shell wrapper delegating to the Python CLI and regression coverage
- document the wrapper, mention direct Python usage, and tidy tip spacing

## Testing
- pipx run pre-commit run --all-files
- pipx run pyspelling -c .spellcheck.yaml
- pipx run linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68da1d9705e4832fa380e9d5643a52dd