### PR TITLE
Add persona metadata and regression test for docs personas

### DIFF
--- a/docs/SAFETY.md
+++ b/docs/SAFETY.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - hardware
+---
+
 # Safety
 
 This setup uses a 12 V LiFePO4 battery and outdoor wiring. Follow these precautions:

--- a/docs/build_guide.md
+++ b/docs/build_guide.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - hardware
+---
+
 # Build Guide
 
 This project uses 20x20 aluminium extrusion to suspend four 100 W solar panels around a cube.

--- a/docs/contributor_script_map.md
+++ b/docs/contributor_script_map.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - software
+---
+
 # Sugarkube Automation Script Map
 
 Keep documentation and tooling changes aligned by using this reference when updating

--- a/docs/docker_repo_walkthrough.md
+++ b/docs/docker_repo_walkthrough.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - software
+---
+
 # Docker Repo Deployment Walkthrough
 
 This guide shows how to run any GitHub project that ships a `Dockerfile` or

--- a/docs/electronics_basics.md
+++ b/docs/electronics_basics.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - hardware
+---
+
 # Electronics Essentials
 
 Beginners can start here to learn the fundamentals needed to assemble the power system and troubleshoot issues.

--- a/docs/electronics_schematics.md
+++ b/docs/electronics_schematics.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - hardware
+---
+
 # Electronics Schematics
 
 The `elex` folder collects KiCad and Fritzing designs used throughout the Sugarkube

--- a/docs/hardware/index.md
+++ b/docs/hardware/index.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - hardware
+---
+
 # Sugarkube Hardware Index
 
 Use this page to jump straight to the physical build resources, safety notes,

--- a/docs/insert_basics.md
+++ b/docs/insert_basics.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - hardware
+---
+
 # Heat-Set Inserts and Printed Threads
 
 This project relies on M2.5 fasteners for the Pi carrier. You can use brass heat‑set inserts

--- a/docs/lcd_mount.md
+++ b/docs/lcd_mount.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - hardware
+---
+
 # Optional LCD Mount
 
 The basic Pi carrier can host a 1602 I²C LCD in the free quadrant.

--- a/docs/mac_mini_station.md
+++ b/docs/mac_mini_station.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - hardware
+---
+
 # Mac mini station
 
 Press-fit saddle cap extension for the Mac mini M4 keyboard station.

--- a/docs/network_setup.md
+++ b/docs/network_setup.md
@@ -1,3 +1,9 @@
+---
+personas:
+  - hardware
+  - software
+---
+
 # Network Setup
 
 This guide explains how to connect your Pi cluster to a home network.

--- a/docs/pi_boot_troubleshooting.md
+++ b/docs/pi_boot_troubleshooting.md
@@ -1,3 +1,9 @@
+---
+personas:
+  - hardware
+  - software
+---
+
 # Pi Boot & Cluster Troubleshooting Matrix
 
 This quick-reference collects the symptoms we see most often after flashing a

--- a/docs/pi_carrier_field_guide.md
+++ b/docs/pi_carrier_field_guide.md
@@ -1,3 +1,9 @@
+---
+personas:
+  - hardware
+  - software
+---
+
 # Sugarkube Pi Carrier Field Guide
 
 The essentials to go from download to a healthy k3s cluster. Print on US Letter

--- a/docs/pi_carrier_launch_playbook.md
+++ b/docs/pi_carrier_launch_playbook.md
@@ -1,3 +1,9 @@
+---
+personas:
+  - hardware
+  - software
+---
+
 # Pi Carrier Launch Playbook
 
 The Pi Carrier Launch Playbook stitches every quickstart, builder note, and troubleshooting

--- a/docs/pi_carrier_qr_labels.md
+++ b/docs/pi_carrier_qr_labels.md
@@ -1,3 +1,9 @@
+---
+personas:
+  - hardware
+  - software
+---
+
 # Pi Carrier QR Labels
 
 Quick-response stickers turn the physical pi_carrier into a living manual. Scan a label and jump straight to the guide you need without digging through bookmarks or the GitHub repo.

--- a/docs/pi_cluster_carrier.md
+++ b/docs/pi_cluster_carrier.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - hardware
+---
+
 # Pi Cluster Carrier
 
 This design mounts three Raspberry Pi 5 boards on a common plate. Each Pi is rotated 45° so the USB and Ethernet ports remain accessible. By default the boards are arranged in a 2×2 grid with one corner empty so the plate fits on printers with a 256 mm build area (e.g. the Bambu Lab A1). Brass heat‑set inserts can be used for durability, or you can print threads directly.

--- a/docs/pi_headless_provisioning.md
+++ b/docs/pi_headless_provisioning.md
@@ -1,3 +1,9 @@
+---
+personas:
+  - hardware
+  - software
+---
+
 # Headless Sugarkube Provisioning
 
 This guide explains how to provision a fresh sugarkube Pi image without attaching a monitor or keyboard. It uses `cloud-init` user data and a small `secrets.env` helper to inject Wi-Fi credentials, SSH keys, and optional API tokens on the first boot.

--- a/docs/pi_helm_bundles.md
+++ b/docs/pi_helm_bundles.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - software
+---
+
 # Sugarkube Helm Bundle Hooks
 
 The base image now ships with `sugarkube-helm-bundles.service`, a post-boot helper that

--- a/docs/pi_image_builder_design.md
+++ b/docs/pi_image_builder_design.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - software
+---
+
 # Pi Image Builder – Design
 
 ## Goals

--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - software
+---
+
 # Raspberry Pi Image with Cloudflare Tunnel
 
 This guide expands the [token.place](https://github.com/futuroptimist/token.place)

--- a/docs/pi_image_contributor_guide.md
+++ b/docs/pi_image_contributor_guide.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - software
+---
+
 # Pi Image Contributor Guide
 
 This guide links every Pi image automation helper to the documentation that explains how to use it.

--- a/docs/pi_image_flowcharts.md
+++ b/docs/pi_image_flowcharts.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - software
+---
+
 # Pi Image Flowcharts
 
 These flowcharts map the sugarkube Pi journey from download to a healthy k3s cluster.

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - software
+---
+
 # Pi Image Quickstart
 
 Build a Raspberry Pi OS image that boots with k3s and the

--- a/docs/pi_image_team_notifications.md
+++ b/docs/pi_image_team_notifications.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - software
+---
+
 # Sugarkube Team Notifications
 
 The Pi image now ships an optional `sugarkube-teams` helper that mirrors first boot and SSD clone

--- a/docs/pi_image_telemetry.md
+++ b/docs/pi_image_telemetry.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - software
+---
+
 # Pi Image Telemetry Hooks
 
 The sugarkube image now ships an optional telemetry publisher that reports anonymized verifier

--- a/docs/pi_multi_node_join_rehearsal.md
+++ b/docs/pi_multi_node_join_rehearsal.md
@@ -1,3 +1,9 @@
+---
+personas:
+  - hardware
+  - software
+---
+
 # Pi Multi-Node Join Rehearsal
 
 Scaling from a single Sugarkube control-plane to a multi-node k3s cluster is smoother when you

--- a/docs/pi_smoke_test.md
+++ b/docs/pi_smoke_test.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - software
+---
+
 # Pi Image Smoke Test Harness
 
 The Pi image now ships with `pi_node_verifier.sh` to validate cluster readiness on the node

--- a/docs/pi_support_bundles.md
+++ b/docs/pi_support_bundles.md
@@ -1,3 +1,9 @@
+---
+personas:
+  - hardware
+  - software
+---
+
 # Pi Support Bundles
 
 Gather a point-in-time snapshot of a running Sugarkube Pi when debugging first boot,

--- a/docs/pi_token_dspace.md
+++ b/docs/pi_token_dspace.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - software
+---
+
 # token.place and dspace Runbook
 
 This runbook walks through building the Raspberry Pi image, flashing it, booting,

--- a/docs/pi_workflow_notifications.md
+++ b/docs/pi_workflow_notifications.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - software
+---
+
 # Sugarkube Workflow Artifact Notifications
 
 Track GitHub Actions runs without keeping a browser tab open. The

--- a/docs/power_system_design.md
+++ b/docs/power_system_design.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - hardware
+---
+
 # Power System Design
 
 This section dives deeper into sizing batteries and choosing a charge controller

--- a/docs/projects-compose.md
+++ b/docs/projects-compose.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - software
+---
+
 # projects-compose Service
 
 The prebuilt Pi image includes Docker Engine, the Compose plugin and a

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -1,3 +1,9 @@
+---
+personas:
+  - hardware
+  - software
+---
+
 # Raspberry Pi Cluster Setup
 
 This expanded guide walks through building a three-node Raspberry Pi 5 cluster and installing k3s

--- a/docs/software/index.md
+++ b/docs/software/index.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - software
+---
+
 # Sugarkube Software Index
 
 Navigate software automation, release tooling, and operations guides from a

--- a/docs/solar_basics.md
+++ b/docs/solar_basics.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - hardware
+---
+
 # Solar Power Basics
 
 This primer explains how photovoltaic panels convert sunlight into electricity and how to size a simple system.

--- a/docs/ssd_health_monitor.md
+++ b/docs/ssd_health_monitor.md
@@ -1,3 +1,9 @@
+---
+personas:
+  - hardware
+  - software
+---
+
 # SSD Health Monitor
 
 The sugarkube image now ships an opt-in helper that wraps `smartctl` to record SSD health metrics,

--- a/docs/ssd_post_clone_validation.md
+++ b/docs/ssd_post_clone_validation.md
@@ -1,3 +1,9 @@
+---
+personas:
+  - hardware
+  - software
+---
+
 # SSD Post-Clone Validation
 
 When the Raspberry Pi boots from a newly cloned SSD, run the validation helper to confirm

--- a/docs/ssd_recovery.md
+++ b/docs/ssd_recovery.md
@@ -1,3 +1,9 @@
+---
+personas:
+  - hardware
+  - software
+---
+
 # SSD Recovery and Rollback
 
 When an SSD migration stalls or the cloned drive fails later, falling back to the

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,3 +1,9 @@
+---
+personas:
+  - hardware
+  - software
+---
+
 # Start Here
 
 Kick off your Sugarkube journey from a single launchpad. This guide condenses the repository into

--- a/docs/token_place_sample_datasets.md
+++ b/docs/token_place_sample_datasets.md
@@ -1,3 +1,8 @@
+---
+personas:
+  - software
+---
+
 # token.place Sample Datasets
 
 Sugarkube images now bundle HTTP request samples so operators can validate

--- a/simplification_suggestions.md
+++ b/simplification_suggestions.md
@@ -133,8 +133,10 @@ which makes it difficult to filter by persona.
 1. ✅ Introduce [`docs/hardware/index.md`](docs/hardware/index.md) and
    [`docs/software/index.md`](docs/software/index.md) pages that summarize
    relevant guides, tooling, and safety notices.
-2. Tag existing pages with front matter metadata (e.g., `persona: hardware`) so
-   the static site can build filtered navigation panes.
+2. ✅ Tag existing pages with front matter metadata (for example,
+   `personas: [hardware, software]`) so the static site can build filtered
+   navigation panes (regression coverage:
+   `tests/test_doc_personas.py::test_doc_front_matter_personas`).
 3. Move duplicated primers into a shared "Fundamentals" section referenced by
    both personas.
 

--- a/tests/test_doc_personas.py
+++ b/tests/test_doc_personas.py
@@ -1,0 +1,116 @@
+"""Verify persona metadata is defined for key documentation pages."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+PERSONA_EXPECTATIONS = {
+    Path("docs/SAFETY.md"): ["hardware"],
+    Path("docs/build_guide.md"): ["hardware"],
+    Path("docs/contributor_script_map.md"): ["software"],
+    Path("docs/docker_repo_walkthrough.md"): ["software"],
+    Path("docs/electronics_basics.md"): ["hardware"],
+    Path("docs/electronics_schematics.md"): ["hardware"],
+    Path("docs/hardware/index.md"): ["hardware"],
+    Path("docs/insert_basics.md"): ["hardware"],
+    Path("docs/lcd_mount.md"): ["hardware"],
+    Path("docs/mac_mini_station.md"): ["hardware"],
+    Path("docs/network_setup.md"): ["hardware", "software"],
+    Path("docs/pi_boot_troubleshooting.md"): ["hardware", "software"],
+    Path("docs/pi_carrier_field_guide.md"): ["hardware", "software"],
+    Path("docs/pi_carrier_launch_playbook.md"): ["hardware", "software"],
+    Path("docs/pi_carrier_qr_labels.md"): ["hardware", "software"],
+    Path("docs/pi_cluster_carrier.md"): ["hardware"],
+    Path("docs/pi_headless_provisioning.md"): ["hardware", "software"],
+    Path("docs/pi_image_builder_design.md"): ["software"],
+    Path("docs/pi_image_cloudflare.md"): ["software"],
+    Path("docs/pi_image_contributor_guide.md"): ["software"],
+    Path("docs/pi_image_flowcharts.md"): ["software"],
+    Path("docs/pi_image_quickstart.md"): ["software"],
+    Path("docs/pi_image_team_notifications.md"): ["software"],
+    Path("docs/pi_image_telemetry.md"): ["software"],
+    Path("docs/pi_multi_node_join_rehearsal.md"): ["hardware", "software"],
+    Path("docs/pi_smoke_test.md"): ["software"],
+    Path("docs/pi_support_bundles.md"): ["hardware", "software"],
+    Path("docs/pi_token_dspace.md"): ["software"],
+    Path("docs/pi_workflow_notifications.md"): ["software"],
+    Path("docs/power_system_design.md"): ["hardware"],
+    Path("docs/projects-compose.md"): ["software"],
+    Path("docs/raspi_cluster_setup.md"): ["hardware", "software"],
+    Path("docs/solar_basics.md"): ["hardware"],
+    Path("docs/software/index.md"): ["software"],
+    Path("docs/start-here.md"): ["hardware", "software"],
+    Path("docs/ssd_health_monitor.md"): ["hardware", "software"],
+    Path("docs/ssd_post_clone_validation.md"): ["hardware", "software"],
+    Path("docs/ssd_recovery.md"): ["hardware", "software"],
+    Path("docs/token_place_sample_datasets.md"): ["software"],
+}
+
+
+def _extract_front_matter(text: str, relative: Path) -> str:
+    if not text.startswith("---\n"):
+        pytest.fail(f"{relative} is missing a front matter block")
+    closing_index = text.find("\n---", 4)
+    if closing_index == -1:
+        pytest.fail(f"{relative} front matter does not terminate with '---'")
+    return text[4:closing_index]
+
+
+def _parse_personas(block: str, relative: Path) -> list[str]:
+    personas: list[str] = []
+    lines = block.splitlines()
+    idx = 0
+    while idx < len(lines):
+        raw = lines[idx]
+        stripped = raw.strip()
+        if not stripped:
+            idx += 1
+            continue
+        if stripped.startswith("personas:"):
+            _, _, remainder = stripped.partition(":")
+            remainder = remainder.strip()
+            if remainder:
+                if remainder.startswith("[") and remainder.endswith("]"):
+                    for part in remainder[1:-1].split(","):
+                        name = part.strip().strip("'\"")
+                        if name:
+                            personas.append(name)
+                else:
+                    personas.append(remainder.strip("'\""))
+            else:
+                idx += 1
+                while idx < len(lines):
+                    candidate = lines[idx].strip()
+                    if not candidate:
+                        idx += 1
+                        continue
+                    if candidate.startswith("- "):
+                        personas.append(candidate[2:].strip())
+                        idx += 1
+                        continue
+                    break
+            break
+        idx += 1
+    if not personas:
+        pytest.fail(f"{relative} front matter missing personas key")
+    return personas
+
+
+@pytest.mark.parametrize(
+    ("relative", "expected"),
+    [(path, personas) for path, personas in PERSONA_EXPECTATIONS.items()],
+)
+def test_doc_front_matter_personas(relative: Path, expected: list[str]) -> None:
+    """Ensure each documented page declares the expected personas."""
+
+    doc_path = REPO_ROOT / relative
+    text = doc_path.read_text(encoding="utf-8")
+    block = _extract_front_matter(text, relative)
+    personas = sorted(_parse_personas(block, relative))
+    assert personas == sorted(
+        expected
+    ), f"{relative} personas mismatch: expected {expected!r}, found {personas!r}"


### PR DESCRIPTION
## Summary
- add front matter persona tags to hardware and software documentation so the site can filter by audience
- document the completed backlog item for modularizing personas and add regression coverage to guard the metadata

## Testing
- ✅ pre-commit run --all-files
- ✅ pyspelling -c .spellcheck.yaml
- ✅ linkchecker --no-warnings README.md docs/
- ✅ git diff --cached | ./scripts/scan-secrets.py


------
https://chatgpt.com/codex/tasks/task_e_68da30519198832fb772e711947d5d06