### PR TITLE
✨ capture flash hardware ids on linux

### DIFF
--- a/docs/pi_image_contributor_guide.md
+++ b/docs/pi_image_contributor_guide.md
@@ -67,7 +67,8 @@ sync.
     parity across platforms.
 - `scripts/flash_pi_media_report.py`
   - Purpose: generate Markdown, HTML, and JSON flash reports that capture hardware IDs, checksum
-    results, and optional cloud-init diffs.
+    results, and optional cloud-init diffs (regression coverage:
+    `tests/flash_pi_media_linux_test.py::test_resolve_linux_system_id_prefers_by_id`).
   - Primary docs: [Pi Image Quickstart](./pi_image_quickstart.md),
     [Pi Boot & Cluster Troubleshooting](./pi_boot_troubleshooting.md).
   - Related tooling: exposed through `make flash-pi-report`, `just flash-pi-report`, and archived by

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -127,8 +127,10 @@ sync without modifying the host.
     --cloud-init ~/sugarkube/cloud-init/user-data.yaml
   ```
   The wrapper stores Markdown/HTML/JSON logs under
-  `~/sugarkube/reports/flash-*/flash-report.*`, capturing hardware IDs, checksum
-  verification, and optional cloud-init diffs. Use
+  `~/sugarkube/reports/flash-*/flash-report.*`, capturing hardware IDs (resolved
+  from `/dev/disk/by-id` symlinks or serials), checksum verification, and
+  optional cloud-init diffs (regression coverage:
+  `tests/flash_pi_media_linux_test.py::test_list_linux_devices_falls_back_to_by_id`). Use
   ```bash
   sudo FLASH_DEVICE=/dev/sdX FLASH_REPORT_ARGS="--cloud-init ~/override.yaml" make flash-pi-report
   ```

--- a/tests/flash_pi_media_linux_test.py
+++ b/tests/flash_pi_media_linux_test.py
@@ -1,0 +1,122 @@
+"""Linux-specific flash_pi_media hardware ID coverage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import flash_pi_media as flash
+
+
+class DummyCompletedProcess:
+    def __init__(self, stdout: str):
+        self.returncode = 0
+        self.stdout = stdout
+
+
+def _make_device(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+    return path
+
+
+def test_resolve_linux_system_id_prefers_by_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    device = _make_device(tmp_path / "dev" / "sda")
+    by_id = tmp_path / "by-id"
+    by_id.mkdir()
+    (by_id / "usb-TestDisk-123").symlink_to(device)
+
+    monkeypatch.setattr(flash, "LINUX_BY_ID_ROOT", by_id)
+    monkeypatch.setattr(flash, "LINUX_SYS_BLOCK_ROOT", tmp_path / "sys-block")
+
+    identifier = flash._resolve_linux_system_id(str(device))
+    assert identifier == "usb-TestDisk-123"
+
+
+def test_resolve_linux_system_id_reads_sysfs_serial(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    device = _make_device(tmp_path / "dev" / "sdb")
+    by_id = tmp_path / "empty-by-id"
+    by_id.mkdir()
+    sys_block = tmp_path / "sys-block"
+    serial_path = sys_block / "sdb" / "device" / "serial"
+    serial_path.parent.mkdir(parents=True, exist_ok=True)
+    serial_path.write_text("SER123\n", encoding="utf-8")
+
+    monkeypatch.setattr(flash, "LINUX_BY_ID_ROOT", by_id)
+    monkeypatch.setattr(flash, "LINUX_SYS_BLOCK_ROOT", sys_block)
+
+    identifier = flash._resolve_linux_system_id(str(device))
+    assert identifier == "SER123"
+
+
+def test_list_linux_devices_uses_serial_from_lsblk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = {
+        "blockdevices": [
+            {
+                "type": "disk",
+                "name": "sdc",
+                "path": "/dev/sdc",
+                "size": "1048576",
+                "model": "TestDisk",
+                "rm": 1,
+                "tran": "usb",
+                "serial": "SERIAL-XYZ",
+            }
+        ]
+    }
+    monkeypatch.setattr(flash.shutil, "which", lambda _: "/bin/lsblk")
+    monkeypatch.setattr(
+        flash,
+        "_run",
+        lambda *args, **kwargs: DummyCompletedProcess(json.dumps(payload)),
+    )
+    monkeypatch.setattr(flash, "LINUX_BY_ID_ROOT", tmp_path / "by-id")
+    monkeypatch.setattr(flash, "LINUX_SYS_BLOCK_ROOT", tmp_path / "sys-block")
+
+    devices = flash._list_linux_devices()
+    assert devices
+    assert devices[0].system_id == "SERIAL-XYZ"
+
+
+def test_list_linux_devices_falls_back_to_by_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = {
+        "blockdevices": [
+            {
+                "type": "disk",
+                "name": "sdd",
+                "path": "/dev/sdd",
+                "size": "2097152",
+                "model": "TestDisk",
+                "rm": 1,
+                "tran": "usb",
+            }
+        ]
+    }
+    by_id = tmp_path / "by-id"
+    by_id.mkdir()
+    device_path = tmp_path / "dev" / "sdd"
+    _make_device(device_path)
+    (by_id / "usb-TestDisk-999").symlink_to(device_path)
+
+    monkeypatch.setattr(flash.shutil, "which", lambda _: "/bin/lsblk")
+    monkeypatch.setattr(
+        flash,
+        "_run",
+        lambda *args, **kwargs: DummyCompletedProcess(json.dumps(payload)),
+    )
+    monkeypatch.setattr(flash, "LINUX_BY_ID_ROOT", by_id)
+    monkeypatch.setattr(flash, "LINUX_SYS_BLOCK_ROOT", tmp_path / "sys-block")
+
+    devices = flash._list_linux_devices()
+    assert devices
+    assert devices[0].system_id == "usb-TestDisk-999"


### PR DESCRIPTION
what: ensure flash reports record Linux hardware IDs and add tests
why: docs promised hardware ID coverage for flash reports
how: pre-commit run --all-files
     pyspelling -c .spellcheck.yaml
     linkchecker --no-warnings README.md docs/
secrets: git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68da30519198832fb772e711947d5d06