### PR TITLE
Align Tutorial 10 Next Steps with published guide

### DIFF
--- a/docs/tutorials/tutorial-10-first-boot-verification-self-healing.md
+++ b/docs/tutorials/tutorial-10-first-boot-verification-self-healing.md
@@ -250,6 +250,9 @@ Use this checklist to verify you achieved each objective before moving on.
       self-healing response, and documented the outcome in your lab notes.
 
 ## Next Steps
-When you are satisfied with the evidence, continue to [Tutorial 11: Storage Migration and Long-Term
-Maintenance](./index.md#tutorial-11-storage-migration-and-long-term-maintenance) (once published).
-You will clone the boot media, validate SSD migrations, and build a sustainable maintenance cadence.
+Advance to [Tutorial 11: Storage Migration and Long-Term Maintenance](./tutorial-11-storage-migration-maintenance.md)
+to clone the boot media, validate SSD migrations, and build a sustainable maintenance cadence.
+
+> [!NOTE]
+> Automated coverage in `tests/test_tutorial_next_steps.py` keeps this "Next Steps" section aligned
+> with the published tutorial roadmap.

--- a/tests/test_tutorial_next_steps.py
+++ b/tests/test_tutorial_next_steps.py
@@ -10,6 +10,10 @@ DOCS_DIR = Path(__file__).resolve().parents[1] / "docs" / "tutorials"
 
 TUTORIAL_NEXT_STEPS = (
     (
+        "tutorial-10-first-boot-verification-self-healing.md",
+        "Advance to [Tutorial 11: Storage Migration and Long-Term Maintenance]",
+    ),
+    (
         "tutorial-04-version-control-collaboration.md",
         "Advance to [Tutorial 5: Programming for Operations with Python and Bash]",
     ),
@@ -31,3 +35,7 @@ def test_next_steps_reference_published_tutorial(filename: str, expected_fragmen
         "when it becomes available" not in text
     ), "Next Steps should highlight published follow-up tutorials"
     assert expected_fragment in text, "Next Steps should link directly to the follow-up tutorial"
+    if filename == "tutorial-10-first-boot-verification-self-healing.md":
+        assert (
+            "./tutorial-11-storage-migration-maintenance.md" in text
+        ), "Tutorial 10 should link directly to the published Tutorial 11 guide"


### PR DESCRIPTION
## Summary
- Inventory showed Tutorial 10 still labeled Tutorial 11 as "(once
  published)" even though the follow-up guide ships today
- Extend the Next Steps regression test matrix to cover Tutorial 10 and
  require the direct link to the published storage migration guide
- Refresh Tutorial 10 so it links the published Tutorial 11 guide and
  calls out the automated coverage that protects the roadmap

## Testing
- ~/.local/bin/pre-commit run --all-files
- pytest tests/test_tutorial_next_steps.py
- ~/.local/bin/pyspelling -c .spellcheck.yaml
- ~/.local/bin/linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py


------
https://chatgpt.com/codex/tasks/task_e_68db63caa014832f896d35688ef2739c