### PR TITLE
✨ : – add shared fundamentals hub

### DIFF
--- a/docs/fundamentals/index.md
+++ b/docs/fundamentals/index.md
@@ -1,0 +1,35 @@
+---
+personas:
+  - hardware
+  - software
+---
+
+# Sugarkube Fundamentals
+
+Use this index whenever you need to revisit the shared concepts that power both the physical enclosure
+and the automation that runs on top of it. Each primer below stays focused on foundational knowledge
+so persona-specific guides can reference them without repeating content.
+
+## Core Primers
+- [Electronics Basics](../electronics_basics.md) — refresh component terminology, measurement
+  techniques, and safety habits before soldering or probing circuits.
+- [Solar Basics](../solar_basics.md) — understand how panel output, charge controllers, and battery
+  chemistry interact so you can right-size off-grid deployments.
+- [Insert Basics](../insert_basics.md) — review heat-set insert tooling and best practices shared by
+  enclosure fixtures across the hardware build.
+
+## Planning References
+- [Power System Design](../power_system_design.md) — calculate loads, cable runs, and protection
+  components for new installations.
+- [Networking Fundamentals](../tutorials/tutorial-03-networking-internet-basics.md) — rehearse IP
+  addressing, routing, and bandwidth planning before scaling the cluster.
+- [Computing Foundations](../tutorials/tutorial-01-computing-foundations.md) — revisit shell fluency,
+  version control, and scripting patterns that the automation stack expects.
+
+## How to Use This Section
+1. Start here when onboarding new contributors so they develop a consistent vocabulary before diving
+   into persona-specific runbooks.
+2. Link back to this page from new guides whenever you introduce a concept covered in these primers
+   instead of duplicating the explanation.
+3. Propose additional fundamentals through pull requests when you discover repeated background
+   content that would benefit both hardware and software audiences.

--- a/docs/hardware/index.md
+++ b/docs/hardware/index.md
@@ -9,12 +9,14 @@ Use this page to jump straight to the physical build resources, safety notes,
 and maintenance routines that keep the enclosure healthy. Cross-link the guides
 you touch in PRs so hardware and documentation stay in sync.
 
+## Shared Fundamentals
+- [Sugarkube Fundamentals](../fundamentals/index.md) — review background primers
+  once before diving into persona-specific hardware checklists.
+
 ## Safety and Planning
 - [SAFETY.md](../SAFETY.md) — wiring, battery handling, and workbench checklists.
 - [power_system_design.md](../power_system_design.md) — plan panel, charge controller,
   and battery sizing.
-- [electronics_basics.md](../electronics_basics.md) — refresh core terminology before
-  soldering or probing circuits.
 
 ## Build Guides and Fixtures
 - [build_guide.md](../build_guide.md) — step-by-step frame assembly and wiring.

--- a/docs/software/index.md
+++ b/docs/software/index.md
@@ -9,6 +9,10 @@ Navigate software automation, release tooling, and operations guides from a
 single hub. Each section links back to the docs that explain how the Pi image
 and supporting services stay healthy.
 
+## Shared Fundamentals
+- [Sugarkube Fundamentals](../fundamentals/index.md) — keep core concepts fresh
+  so automation guides can skip repeated primers.
+
 ## Image Tooling
 - [pi_image_quickstart.md](../pi_image_quickstart.md) — build, flash, and verify the
   published image.

--- a/simplification_suggestions.md
+++ b/simplification_suggestions.md
@@ -142,8 +142,9 @@ which makes it difficult to filter by persona.
    `personas: [hardware, software]`) so the static site can build filtered
    navigation panes (regression coverage:
    `tests/test_doc_personas.py::test_doc_front_matter_personas`).
-3. Move duplicated primers into a shared "Fundamentals" section referenced by
-   both personas.
+3. ✅ Move duplicated primers into a shared "Fundamentals" section referenced by
+   both personas (`docs/fundamentals/index.md`; regression coverage:
+   `tests/test_doc_fundamentals.py`).
 
 **Safeguards:**
 - Maintain canonical URLs by adding redirect stubs or shortlinks when pages move.

--- a/tests/test_doc_fundamentals.py
+++ b/tests/test_doc_fundamentals.py
@@ -1,0 +1,35 @@
+"""Tests for the shared fundamentals documentation section."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_fundamentals_doc_exists_and_links_key_primers() -> None:
+    """Ensure the fundamentals index lists shared primers."""
+
+    fundamentals_doc = REPO_ROOT / "docs" / "fundamentals" / "index.md"
+    assert fundamentals_doc.exists(), "docs/fundamentals/index.md should exist"
+
+    text = fundamentals_doc.read_text(encoding="utf-8")
+    assert "personas:" in text and "hardware" in text and "software" in text
+
+    for primer in (
+        "../electronics_basics.md",
+        "../solar_basics.md",
+        "../insert_basics.md",
+    ):
+        assert primer in text, f"Fundamentals doc should link to {primer}"
+
+
+def test_persona_indices_reference_fundamentals() -> None:
+    """Hardware and software indices should direct readers to shared fundamentals."""
+
+    fundamentals_link = "../fundamentals/index.md"
+    hardware_text = (REPO_ROOT / "docs" / "hardware" / "index.md").read_text(encoding="utf-8")
+    software_text = (REPO_ROOT / "docs" / "software" / "index.md").read_text(encoding="utf-8")
+
+    assert fundamentals_link in hardware_text, "Hardware index should link to fundamentals"
+    assert fundamentals_link in software_text, "Software index should link to fundamentals"


### PR DESCRIPTION
What:
- add docs/fundamentals/index.md to host shared primers for both personas
- point hardware/software indices at the shared hub and mark the backlog item complete
- cover the new doc with tests that assert required links and persona wiring

Why:
- simplification_suggestions.md promised a shared "Fundamentals" section that both persona hubs could reference

How to test:
- pre-commit run --all-files
- pytest tests/test_doc_fundamentals.py
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68db6a86f950832f8018e320951bd2e0