### PR TITLE
Add sugarkube pi download CLI wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ the docs you will see the term used in both contexts.
   contributor-facing map that ties each helper to the guide that explains it.
   - `download_pi_image.sh` — fetch the latest Pi image via the GitHub CLI; supports `--dry-run`
     metadata checks and reconciles `--dir`/`--output` directories with POSIX `test -ef`
-    instead of `realpath` so macOS-friendly symlinks work without extra tooling
+    instead of `realpath` so macOS-friendly symlinks work without extra tooling.
+    Invoke it from the unified CLI with
+    `python -m sugarkube_toolkit pi download [--dry-run] [helper args...]` when you prefer
+    a consistent entry point across automation helpers.
   - `install_sugarkube_image.sh` — install the GitHub CLI when missing, download the
     latest release, verify checksums, expand the `.img.xz`, and emit a new
     `.img.sha256`; safe to run via `curl | bash`

--- a/docs/contributor_script_map.md
+++ b/docs/contributor_script_map.md
@@ -65,6 +65,7 @@ confirm the quickstart stays accurate.
 | Command | Purpose | Primary docs | Supporting automation |
 | --- | --- | --- | --- |
 | `python -m sugarkube_toolkit docs verify [--dry-run]` | Run `pyspelling` and `linkchecker` together, mirroring the contribution workflow expectations. | [simplification_suggestions.md](../simplification_suggestions.md) §1 | `scripts/toolkit/` shared runner, `tests/test_sugarkube_toolkit_cli.py` |
+| `python -m sugarkube_toolkit pi download [--dry-run] [args...]` | Download the latest release via `scripts/download_pi_image.sh` without leaving the unified CLI. | [Pi Image Quickstart](./pi_image_quickstart.md) §1 | `scripts/download_pi_image.sh`, `tests/test_sugarkube_toolkit_cli.py` |
 | `scripts/docs_verify.sh` / `scripts/docs_verify.ps1` | Print a deprecation notice before forwarding to the unified CLI. | [simplification_suggestions.md](../simplification_suggestions.md) §1 | `tests/test_docs_verify_wrapper.py` |
 
 ## Keeping docs and automation in sync

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -89,6 +89,10 @@ sync without modifying the host.
      repository root to print the same steps.
    - `./scripts/download_pi_image.sh --output /your/path.img.xz` still resumes
      partial downloads and verifies checksums automatically.
+   - Prefer a unified entry point? `python -m sugarkube_toolkit pi download --dry-run` shows the
+     underlying helper, then runs `scripts/download_pi_image.sh` with the flags you provide. Pass the
+     same arguments (`--dir`, `--release`, `--asset`, etc.) to the CLI and they flow straight to the
+     shell script.
    - Want a hands-off alert when the artifacts land? Run
     ```bash
     make notify-workflow \

--- a/scripts/docs_verify.ps1
+++ b/scripts/docs_verify.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 
-Write-Warning "[DEPRECATED] scripts/docs_verify.ps1 will be removed once callers migrate to 'python -m sugarkube_toolkit docs verify'." 
+Write-Warning "[DEPRECATED] scripts/docs_verify.ps1 will be removed once callers migrate to 'python -m sugarkube_toolkit docs verify'."
 Write-Host "Forwarding to the unified CLI—update your workflow to call it directly." -ForegroundColor Yellow
 
 $python = $env:SUGARKUBE_PYTHON

--- a/simplification_suggestions.md
+++ b/simplification_suggestions.md
@@ -39,6 +39,11 @@ before they can automate common tasks.
 3. ✅ Provide thin wrapper scripts that print a deprecation notice before handing
    off to the new CLI so existing docs remain valid during the transition
    (regression coverage: `tests/test_docs_verify_wrapper.py`).
+4. ✅ Add a `sugarkube pi download` subcommand that proxies to
+   `scripts/download_pi_image.sh`, keeping the first Pi image workflow available
+   from the unified CLI (regression coverage:
+   `tests/test_sugarkube_toolkit_cli.py::test_pi_download_invokes_helper`). Follow-up
+   subcommands will continue wrapping the remaining automation.
 
 **Safeguards:**
 - Mirror existing exit codes and output formats so CI and human workflows do not

--- a/tests/test_sugarkube_toolkit_cli.py
+++ b/tests/test_sugarkube_toolkit_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from pathlib import Path
 
 import pytest
 
@@ -56,3 +57,74 @@ def test_docs_verify_surfaces_failures(
     captured = capsys.readouterr()
     assert exit_code == 1
     assert "missing dictionary" in captured.err
+
+
+def test_pi_download_invokes_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    """pi download should wrap the documented helper script."""
+
+    recorded: list[list[str]] = []
+
+    def fake_run(
+        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+    ) -> None:
+        recorded.extend(commands)
+
+    monkeypatch.setattr(runner, "run_commands", fake_run)
+
+    exit_code = cli.main(["pi", "download", "--dry-run"])
+
+    expected_script = Path(__file__).resolve().parents[1] / "scripts" / "download_pi_image.sh"
+
+    assert exit_code == 0
+    assert recorded == [["bash", str(expected_script)]]
+
+
+def test_pi_download_forwards_additional_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Forward CLI arguments to the helper script for parity with docs."""
+
+    recorded: list[list[str]] = []
+
+    def fake_run(
+        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+    ) -> None:
+        recorded.extend(commands)
+
+    monkeypatch.setattr(runner, "run_commands", fake_run)
+
+    exit_code = cli.main(
+        [
+            "pi",
+            "download",
+            "--dry-run",
+            "--dir",
+            "~/sugarkube/images",
+            "--output",
+            "~/sugarkube/images/custom.img.xz",
+        ]
+    )
+
+    assert exit_code == 0
+    assert recorded == [
+        [
+            "bash",
+            str(Path(__file__).resolve().parents[1] / "scripts" / "download_pi_image.sh"),
+            "--dir",
+            "~/sugarkube/images",
+            "--output",
+            "~/sugarkube/images/custom.img.xz",
+        ]
+    ]
+
+
+def test_pi_download_reports_missing_script(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Missing helper scripts should surface an actionable error."""
+
+    monkeypatch.setattr(cli, "DOWNLOAD_PI_IMAGE_SCRIPT", Path("/nonexistent/download_pi_image.sh"))
+
+    exit_code = cli.main(["pi", "download", "--dry-run"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "scripts/download_pi_image.sh is missing" in captured.err


### PR DESCRIPTION
## Summary
- add a `pi download` subcommand to the unified CLI to proxy the documented helper
- extend CLI tests to cover the new subcommand, argument forwarding, and missing-script messaging
- update docs and backlog notes to advertise the CLI entry point

## Testing
- pytest tests/test_sugarkube_toolkit_cli.py
- python -m pre_commit run --all-files
- python -m pyspelling -c .spellcheck.yaml
- /root/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68db6a86f950832f8018e320951bd2e0