### PR TITLE
Add CLI support for flashing via sugarkube pi flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ shortcuts so GitHub
 Codespaces users can install prerequisites and flash media without additional shell glue.
 `./scripts/sugarkube-latest` remains available when you only need the `.img.xz` artifact with
 checksum verification.
+Prefer a unified entry point? `python -m sugarkube_toolkit pi download --dry-run` previews the
+release helper. Reuse the streaming helper via:
+
+```bash
+python -m sugarkube_toolkit pi flash --dry-run -- --image ~/sugarkube/images/sugarkube.img --device /dev/sdX
+```
+
+Drop `--dry-run` when you're ready to write media.
 
 Prefer a guided experience? Open [docs/flash-helper/](docs/flash-helper/) to paste a workflow run
 URL and receive OS-specific download, verification, and flashing steps. The same logic is also

--- a/docs/contributor_script_map.md
+++ b/docs/contributor_script_map.md
@@ -66,6 +66,7 @@ confirm the quickstart stays accurate.
 | --- | --- | --- | --- |
 | `python -m sugarkube_toolkit docs verify [--dry-run]` | Run `pyspelling` and `linkchecker` together, mirroring the contribution workflow expectations. | [simplification_suggestions.md](../simplification_suggestions.md) §1 | `scripts/toolkit/` shared runner, `tests/test_sugarkube_toolkit_cli.py` |
 | `python -m sugarkube_toolkit pi download [--dry-run] [args...]` | Download the latest release via `scripts/download_pi_image.sh` without leaving the unified CLI. | [Pi Image Quickstart](./pi_image_quickstart.md) §1 | `scripts/download_pi_image.sh`, `tests/test_sugarkube_toolkit_cli.py` |
+| `python -m sugarkube_toolkit pi flash [--dry-run] [args...]` | Flash removable media via `scripts/flash_pi_media.sh` with the same CLI used for downloads. | [Pi Image Quickstart](./pi_image_quickstart.md) §2 | `scripts/flash_pi_media.sh`, `tests/test_sugarkube_toolkit_cli.py::test_pi_flash_invokes_helper` |
 | `scripts/docs_verify.sh` / `scripts/docs_verify.ps1` | Print a deprecation notice before forwarding to the unified CLI. | [simplification_suggestions.md](../simplification_suggestions.md) §1 | `tests/test_docs_verify_wrapper.py` |
 
 ## Keeping docs and automation in sync

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -157,6 +157,11 @@ sync without modifying the host.
   The helper auto-detects removable drives, streams `.img` or `.img.xz`
   without temporary files, verifies the written bytes with SHA-256, and
   powers the media off when complete. On Windows, run the PowerShell wrapper:
+  Prefer the unified CLI? Preview the helper with
+  `python -m sugarkube_toolkit pi flash --dry-run -- --image ~/sugarkube/images/sugarkube.img --device /dev/sdX --assume-yes`,
+  then drop `--dry-run` when you're ready. Everything after the `--` flows
+  straight to `scripts/flash_pi_media.sh`, so `--cloud-init` and other
+  documented flags work unchanged.
   ```powershell
   pwsh -File scripts/flash_pi_media.ps1 --image $env:USERPROFILE\sugarkube\images\sugarkube.img --device \\.\PhysicalDrive1
   ```

--- a/simplification_suggestions.md
+++ b/simplification_suggestions.md
@@ -44,6 +44,9 @@ before they can automate common tasks.
    from the unified CLI (regression coverage:
    `tests/test_sugarkube_toolkit_cli.py::test_pi_download_invokes_helper`). Follow-up
    subcommands will continue wrapping the remaining automation.
+5. ✅ Extend the CLI with `sugarkube pi flash` so contributors can stream images
+   without leaving the unified entrypoint (regression coverage:
+   `tests/test_sugarkube_toolkit_cli.py::test_pi_flash_invokes_helper`).
 
 **Safeguards:**
 - Mirror existing exit codes and output formats so CI and human workflows do not


### PR DESCRIPTION
## Summary
- add `python -m sugarkube_toolkit pi flash` to wrap `scripts/flash_pi_media.sh`
  and follow the CLI roadmap documented in `simplification_suggestions.md`
- cover the new handler with unit tests for argument passthrough and failures
- document the subcommand in the README, quickstart guide, and script map

## Testing
- pytest
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py


------
https://chatgpt.com/codex/tasks/task_e_68dc4c802a20832f95de4056c73804fb