### PR TITLE
Update Tutorial 1 next steps to promote published Tutorial 2

### DIFF
--- a/docs/tutorials/tutorial-01-computing-foundations.md
+++ b/docs/tutorials/tutorial-01-computing-foundations.md
@@ -116,7 +116,6 @@ Check off each task when you have evidence stored in your notes folder.
 > before touching it. When in doubt, ask in the Raspberry Pi forums with a photo attached.
 
 ## Next Steps
-Continue with the roadmap by reading
-[Tutorial 2: Navigating Linux and the Terminal](./index.md#tutorial-2-navigating-linux-and-the-terminal)
-once it is published. Bring your terminal transcript and safety notes—they will inform the follow-up
-lessons on permissions, editors, and scripting.
+Continue with the roadmap by reading [Tutorial 2: Navigating Linux and the Terminal](
+./index.md#tutorial-2-navigating-linux-and-the-terminal). Bring your terminal transcript and safety
+notes—they will inform the follow-up lessons on permissions, editors, and scripting.

--- a/tests/test_tutorial_01_next_steps.py
+++ b/tests/test_tutorial_01_next_steps.py
@@ -1,0 +1,26 @@
+"""Ensure Tutorial 1 points readers to the published follow-up guide."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+DOC_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "docs"
+    / "tutorials"
+    / "tutorial-01-computing-foundations.md"
+)
+
+EXPECTED_FRAGMENT = (
+    "Continue with the roadmap by reading [Tutorial 2: Navigating Linux and the " "Terminal]"
+)
+
+
+def test_next_steps_promotes_published_tutorial_two() -> None:
+    """Tutorial 1 should acknowledge Tutorial 2 is already available."""
+
+    text = DOC_PATH.read_text(encoding="utf-8")
+    assert (
+        "once it is published" not in text
+    ), "Tutorial 1 still frames Tutorial 2 as unpublished future work"
+    assert EXPECTED_FRAGMENT in text, "Tutorial 1 should link to the published Tutorial 2 guide"


### PR DESCRIPTION
## Summary
- update Tutorial 1 so its Next Steps point to the published Tutorial 2 guide instead of future-work phrasing
- add regression coverage that fails if Tutorial 1 references Tutorial 2 as unpublished

## Testing
- python -m pre_commit run --all-files
- python -m pyspelling -c .spellcheck.yaml
- /root/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md docs/
- pytest tests/test_tutorial_01_next_steps.py
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68dc4c802a20832f95de4056c73804fb