### PR TITLE
Add CLI wrapper for Pi smoke test harness

### DIFF
--- a/docs/pi_smoke_test.md
+++ b/docs/pi_smoke_test.md
@@ -68,6 +68,20 @@ SMOKE_ARGS="pi-a.local" just smoke-test-pi
 Both helpers call the Python harness, so they support the same flags as invoking the script
 directly.
 
+## Unified CLI entrypoint
+
+Prefer the consolidated Sugarkube CLI? Run the smoke test via the new `sugarkube pi smoke`
+subcommand:
+
+```bash
+python -m sugarkube_toolkit pi smoke --dry-run -- --json pi-a.local pi-b.local
+```
+
+Drop `--dry-run` to run the verifier immediately. Everything after the standalone `--` flows to
+`scripts/pi_smoke_test.py`, so existing documentation continues to apply. Regression coverage lives
+in `tests/test_sugarkube_toolkit_cli.py::test_pi_smoke_invokes_helper` and the surrounding
+`test_pi_smoke_*` cases.
+
 ## Test coverage
 
 Automated assurance for the CLI lives in

--- a/simplification_suggestions.md
+++ b/simplification_suggestions.md
@@ -47,6 +47,9 @@ before they can automate common tasks.
 5. ✅ Extend the CLI with `sugarkube pi flash` so contributors can stream images
    without leaving the unified entrypoint (regression coverage:
    `tests/test_sugarkube_toolkit_cli.py::test_pi_flash_invokes_helper`).
+6. ✅ Wrap the Pi smoke test harness behind `sugarkube pi smoke` so the unified CLI
+   now covers download, flashing, and post-boot verification (regression
+   coverage: `tests/test_sugarkube_toolkit_cli.py::test_pi_smoke_invokes_helper`).
 
 **Safeguards:**
 - Mirror existing exit codes and output formats so CI and human workflows do not


### PR DESCRIPTION
## Summary
- add a `sugarkube pi smoke` subcommand that invokes the existing smoke test helper via the unified CLI
- expand CLI regression coverage for the new entrypoint and its error handling
- document the CLI workflow and mark the roadmap item as shipped in the simplification suggestions

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- pytest tests/test_sugarkube_toolkit_cli.py
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68dcd48912e4832f98a6bf7e589c4ba7