### PR TITLE
✅ : – tutorial Next Steps links resolve

### DIFF
--- a/docs/tutorials/tutorial-11-storage-migration-maintenance.md
+++ b/docs/tutorials/tutorial-11-storage-migration-maintenance.md
@@ -327,10 +327,10 @@ Use this list to confirm you met every objective before moving on:
 - [ ] Authored a monthly maintenance checklist and synced supporting logs to your lab notebook.
 
 ## Next Steps
-Continue to [Tutorial 12: Contributing New Features and Automation](./tutorial-12-contributing-new-features-and-automation.md)
+Continue to [Tutorial 12: Contributing New Features and Automation](./tutorial-12-contributing-new-features-automation.md)
 to learn how to propose improvements, extend automation, and collaborate on future Sugarkube
 releases.
 
 > [!NOTE]
 > Automated coverage in `tests/test_tutorial_11_12_next_steps.py` keeps this section pointing to the
-> published Tutorial 12 guide.
+> published Tutorial 12 guide, and `tests/test_tutorial_next_steps_links.py` ensures the link resolves.

--- a/tests/test_tutorial_next_steps_links.py
+++ b/tests/test_tutorial_next_steps_links.py
@@ -1,0 +1,56 @@
+"""Validate that tutorial "Next Steps" links resolve to existing guides."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable
+
+DOCS_DIR = Path(__file__).resolve().parents[1] / "docs" / "tutorials"
+
+
+def _extract_reference_definitions(text: str) -> dict[str, str]:
+    pattern = re.compile(r"^\[(?P<key>[^\]]+)\]:\s*(?P<value>\S+)", re.MULTILINE)
+    return {match.group("key"): match.group("value") for match in pattern.finditer(text)}
+
+
+def _iter_next_steps_links(text: str) -> Iterable[str]:
+    start = text.find("## Next Steps")
+    if start == -1:
+        return []
+
+    end = text.find("\n## ", start + len("## Next Steps"))
+    if end == -1:
+        end = len(text)
+
+    block = text[start:end]
+    definitions = _extract_reference_definitions(text)
+
+    inline_pattern = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+    reference_pattern = re.compile(r"\[[^\]]+\]\[([^\]]+)\]")
+
+    for match in inline_pattern.finditer(block):
+        yield match.group(1).strip()
+
+    for match in reference_pattern.finditer(block):
+        reference = match.group(1).strip()
+        if reference in definitions:
+            yield definitions[reference].strip()
+
+
+def test_next_steps_links_reference_existing_files() -> None:
+    for path in sorted(DOCS_DIR.glob("tutorial-*.md")):
+        text = path.read_text(encoding="utf-8")
+
+        for link in _iter_next_steps_links(text):
+            if not link or link.startswith("http://") or link.startswith("https://"):
+                continue
+            if link.startswith("mailto:") or link.startswith("#"):
+                continue
+
+            target, _, _ = link.partition("#")
+            if not target:
+                continue
+
+            resolved = (path.parent / target).resolve()
+            assert resolved.exists(), f"{path.name} Next Steps references missing guide: {link}"


### PR DESCRIPTION
what: add regression coverage verifying tutorial Next Steps links resolve
 and fix the tutorial 11 pointer to tutorial 12
why: tutorial 11 promised ./tutorial-12-contributing-new-features-and-
 automation.md which never shipped; the published tutorial 12 doc already
 covers that scope so we can ship the correction now
inventory: only tutorial 11 referenced an unpublished path, so this patch
 closes the loop in a single PR
how to test:
- python -m pre_commit run --all-files
- python -m pyspelling -c .spellcheck.yaml
- /root/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py


------
https://chatgpt.com/codex/tasks/task_e_68dcd48912e4832f98a6bf7e589c4ba7