### PR TITLE
Document shipped CLI follow-ups in simplification backlog

### DIFF
--- a/simplification_suggestions.md
+++ b/simplification_suggestions.md
@@ -34,8 +34,9 @@ before they can automate common tasks.
    `tests/test_sugarkube_toolkit_cli.py::test_docs_verify_invokes_doc_checks`).
 2. ✅ Expose a unified `sugarkube` CLI via `python -m sugarkube_toolkit` with an
    initial `docs verify` subcommand that chains `pyspelling` and `linkchecker`
-   (`tests/test_sugarkube_toolkit_cli.py`). Follow-up subcommands will wrap the
-   image and Pi automation.
+   (`tests/test_sugarkube_toolkit_cli.py`). Follow-up subcommands now wrap the
+   image download, install, flashing, reporting, smoke, and rehearsal workflows
+   (regression coverage: `tests/test_sugarkube_toolkit_cli.py`).
 3. ✅ Provide thin wrapper scripts that print a deprecation notice before handing
    off to the new CLI so existing docs remain valid during the transition
    (regression coverage: `tests/test_docs_verify_wrapper.py`).

--- a/tests/test_simplification_suggestions.py
+++ b/tests/test_simplification_suggestions.py
@@ -1,0 +1,19 @@
+"""Ensure simplification_suggestions.md reflects shipped CLI coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+DOC_PATH = Path(__file__).resolve().parents[1] / "simplification_suggestions.md"
+
+
+def test_cli_follow_up_subcommands_documented_as_shipped() -> None:
+    """The backlog entry should no longer frame CLI subcommands as future work."""
+
+    text = DOC_PATH.read_text(encoding="utf-8")
+    assert (
+        "Follow-up subcommands will wrap the image and Pi automation" not in text
+    ), "Simplification backlog still frames CLI wrappers as future work"
+    assert (
+        "Follow-up subcommands now wrap" in text
+    ), "Simplification backlog should confirm CLI wrappers are already available"


### PR DESCRIPTION
## What
- align simplification_suggestions.md with shipped CLI coverage
- add regression test verifying the backlog no longer references future work

## Why
- remove stale future-work notes now that CLI subcommands exist
- guard against regressions that reintroduce future-tense language

## How to test
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68df7dc92158832fa3349ab531448d68