### PR TITLE
🛠️ : – Restore QEMU smoke markers

### DIFF
--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -42,6 +42,20 @@ check_space() {
   fi
 }
 
+ensure_packages() {
+  local packages_file="$1"
+  shift || true
+  if [ ! -d "$(dirname "$packages_file")" ]; then
+    mkdir -p "$(dirname "$packages_file")"
+  fi
+  touch "$packages_file"
+  for pkg in "$@"; do
+    if [ -n "$pkg" ] && ! grep -qxF "$pkg" "$packages_file"; then
+      echo "$pkg" >>"$packages_file"
+    fi
+  done
+}
+
 # Build a Raspberry Pi OS image with cloud-init files preloaded.
 # Requires curl, docker, git, sha256sum, stdbuf, timeout, xz, bsdtar, df and roughly
 # 10 GB of free disk space. Set PI_GEN_URL to override the default pi-gen repository.
@@ -297,6 +311,9 @@ PI_GEN_BRANCH="${PI_GEN_BRANCH:-${DEFAULT_PI_GEN_BRANCH}}"
 
 USER_DATA="${PI_GEN_DIR}/stage2/01-sys-tweaks/user-data"
 cp "${CLOUD_INIT_PATH}" "${USER_DATA}"
+
+ensure_packages "${PI_GEN_DIR}/stage2/01-sys-tweaks/00-packages" \
+  policykit-1
 
 # If a TUNNEL_TOKEN_FILE is provided but TUNNEL_TOKEN is not, load it from file
 if [ -n "${TUNNEL_TOKEN_FILE:-}" ] && [ -z "${TUNNEL_TOKEN:-}" ]; then

--- a/scripts/first_boot_service.py
+++ b/scripts/first_boot_service.py
@@ -471,9 +471,14 @@ def main() -> int:
         log_exit = _invoke_verifier_log(verifier, log_path)
 
     payload = _render_summary(result, metadata, cloud_init_text)
-    _write_json(report_dir / "summary.json", payload)
-    _write_markdown(report_dir / "summary.md", payload)
-    _write_html(report_dir / "summary.html", payload)
+    summary_json = report_dir / "summary.json"
+    summary_md = report_dir / "summary.md"
+    summary_html = report_dir / "summary.html"
+
+    _write_json(summary_json, payload)
+    _write_markdown(summary_md, payload)
+    _write_html(summary_html, payload)
+    _log(f"summary.json written to {summary_json}")
 
     if cloud_init_text is not None:
         (report_dir / "cloud-init.log").write_text(cloud_init_text + "\n")

--- a/scripts/qemu_pi_smoke_test.py
+++ b/scripts/qemu_pi_smoke_test.py
@@ -242,7 +242,6 @@ def _install_dropin(root_dir: Path) -> None:
         f"""
         [Service]
         Environment=FIRST_BOOT_VERIFIER={STUB_VERIFIER_PATH}
-        Environment=FIRST_BOOT_SKIP_LOG=1
         Environment=FIRST_BOOT_ATTEMPTS=1
         Environment=FIRST_BOOT_RETRY_DELAY=5
         Environment=FIRST_BOOT_CLOUD_INIT_TIMEOUT=180


### PR DESCRIPTION
what: ensure policykit installs during image build and restore first-boot logging the smoke test expects.
why: pi-image-release failed because qemu never saw the expected serial markers and policykitd was missing.
how to test: pytest tests/test_qemu_pi_smoke_test.py tests/test_first_boot_service.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e1aa988878832f9840ff1132183f76