### PR TITLE
Honor SUGARKUBE_SSD_CLONE_EXTRA_ARGS in manual clone runs

### DIFF
--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -375,7 +375,9 @@ journalctl -u ssd-clone.service
 Override detection by exporting `SUGARKUBE_SSD_CLONE_TARGET=/dev/sdX` or extend the helper
 flags (for example, `--dry-run`) with `SUGARKUBE_SSD_CLONE_EXTRA_ARGS`. Both environment
 variables are respected by the systemd unit and by manual invocations of
-`scripts/ssd_clone.py --auto-target`. Adjust the discovery window with
+`scripts/ssd_clone.py --auto-target`, and automated coverage in
+`tests/ssd_clone_auto_target_test.py::test_parse_args_appends_extra_env` keeps the manual
+path honest. Adjust the discovery window with
 `SUGARKUBE_SSD_CLONE_WAIT_SECS` (default: 900 seconds) or poll frequency with
 `SUGARKUBE_SSD_CLONE_POLL_SECS` when slower storage bridges are involved
 (regression coverage:

--- a/scripts/ssd_clone_service.py
+++ b/scripts/ssd_clone_service.py
@@ -30,7 +30,7 @@ STATE_DIR = ssd_clone.STATE_DIR
 CLONE_HELPER = SCRIPT_ROOT / "ssd_clone.py"
 POLL_INTERVAL = int(os.environ.get("SUGARKUBE_SSD_CLONE_POLL_SECS", "10"))
 MAX_WAIT = int(os.environ.get("SUGARKUBE_SSD_CLONE_WAIT_SECS", "900"))
-EXTRA_ARGS = os.environ.get("SUGARKUBE_SSD_CLONE_EXTRA_ARGS", "")
+EXTRA_ARGS = os.environ.get(ssd_clone.ENV_EXTRA_ARGS, "")
 AUTO_TARGET = os.environ.get(ssd_clone.ENV_TARGET)
 LOG_PREFIX = "[ssd-clone-service]"
 


### PR DESCRIPTION
## Summary
- Docs/pi_image_quickstart.md still promised that `SUGARKUBE_SSD_CLONE_EXTRA_ARGS` affects manual `scripts/ssd_clone.py --auto-target` runs, but the helper ignored that environment variable outside the systemd wrapper, so the note represented documented-but-unshipped behavior.
- Add unit tests that demonstrate `parse_args` now appends the configured extra arguments and rejects malformed shell fragments so the feature stays covered.
- Extend `scripts/ssd_clone.py` to merge `SUGARKUBE_SSD_CLONE_EXTRA_ARGS` into the parsed CLI arguments, update the service wrapper to reuse the shared constant, and refresh the quickstart docs with the new regression link.

## Testing
- python -m pre_commit run --all-files
- python -m pyspelling -c .spellcheck.yaml
- python -m linkcheck --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68e1b6d016fc832fb6fb2451d71479ef