### PR TITLE
Add cloud-init override support to flash helper

### DIFF
--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -180,7 +180,11 @@ sync without modifying the host.
   `python -m sugarkube_toolkit pi flash --dry-run -- --image ~/sugarkube/images/sugarkube.img --device /dev/sdX --assume-yes`,
   then drop `--dry-run` when you're ready. Everything after the `--` flows
   straight to `scripts/flash_pi_media.sh`, so `--cloud-init` and other
-  documented flags work unchanged.
+  documented flags work unchanged. Regression coverage:
+  `tests/flash_pi_media_test.py::test_cloud_init_override_copies_user_data`
+  confirms the override lands in `/boot/user-data`, while
+  `tests/flash_pi_media_report_test.py::test_run_flash_forwards_cloud_init`
+  ensures the reporting wrapper forwards the same flag.
   ```powershell
   pwsh -File scripts/flash_pi_media.ps1 --image $env:USERPROFILE\sugarkube\images\sugarkube.img --device \\.\PhysicalDrive1
   ```

--- a/scripts/flash_pi_media.py
+++ b/scripts/flash_pi_media.py
@@ -26,19 +26,23 @@ testing and dry-runs possible without touching real hardware.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import hashlib
 import io
 import json
 import os
 import platform
+import re
 import shutil
 import stat
 import subprocess
 import sys
+import tempfile
+import textwrap
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Optional, Sequence
+from typing import Iterable, Iterator, List, Optional, Sequence
 
 CHUNK_SIZE = 4 * 1024 * 1024  # 4 MiB to balance throughput and memory usage.
 PROGRESS_INTERVAL = 1.0  # seconds
@@ -107,6 +111,16 @@ class Device:
     @property
     def human_size(self) -> str:
         return _format_size(self.size)
+
+
+@dataclass
+class BootPartition:
+    """Metadata about a boot partition used for cloud-init overrides."""
+
+    path: str | None
+    mountpoint: str | None = None
+    identifier: str | None = None
+    disk_number: str | None = None
 
 
 def _run(cmd: Sequence[str], **kwargs) -> subprocess.CompletedProcess:
@@ -341,6 +355,238 @@ def filter_candidates(devices: Sequence[Device]) -> List[Device]:
     return candidates
 
 
+def _resolve_boot_partition_linux(device: Device) -> BootPartition | None:
+    if not device.path:
+        return None
+    if not shutil.which("lsblk"):
+        return None
+    proc = _run(["lsblk", "-J", "-O", device.path])
+    if proc.returncode != 0 or not proc.stdout:
+        return None
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        warn("lsblk returned unexpected output while resolving boot partition")
+        return None
+
+    for entry in payload.get("blockdevices", []):
+        entry_path = entry.get("path") or f"/dev/{entry.get('name')}"
+        if entry_path != device.path:
+            continue
+        children = entry.get("children") or []
+        if not children:
+            return None
+
+        def _start(child: dict) -> int:
+            try:
+                return int(child.get("start", 0))
+            except (TypeError, ValueError):
+                return 0
+
+        first = sorted(children, key=_start)[0]
+        part_path = first.get("path")
+        if not part_path:
+            return None
+        mountpoint = first.get("mountpoint") or None
+        return BootPartition(path=part_path, mountpoint=mountpoint)
+
+    return None
+
+
+def _resolve_boot_partition_macos(device: Device) -> BootPartition | None:
+    if not device.system_id and not device.path:
+        return None
+    proc = _run(["/usr/sbin/diskutil", "list", "-plist"])
+    if proc.returncode != 0 or not proc.stdout:
+        return None
+    try:  # pragma: no cover - plistlib import only when available
+        import plistlib
+    except Exception:  # pragma: no cover - defensive guard
+        return None
+
+    try:
+        data = plistlib.loads(proc.stdout.encode("utf-8"))
+    except Exception:  # pragma: no cover - defensive parse
+        return None
+
+    for disk in data.get("AllDisksAndPartitions", []):
+        identifier = disk.get("DeviceIdentifier")
+        path = f"/dev/{identifier}" if identifier else None
+        if identifier and (identifier == device.system_id or path == device.path):
+            partitions = disk.get("Partitions", [])
+            if not partitions:
+                return None
+            part = sorted(
+                partitions,
+                key=lambda item: item.get("PartitionNumber", 0) or 0,
+            )[0]
+            part_id = part.get("DeviceIdentifier")
+            if not part_id:
+                return None
+            mountpoint = part.get("MountPoint") or None
+            return BootPartition(
+                path=f"/dev/{part_id}",
+                mountpoint=mountpoint,
+                identifier=part_id,
+            )
+    return None
+
+
+def _resolve_boot_partition_windows(device: Device) -> BootPartition | None:
+    disk_number = device.system_id
+    if not disk_number and device.path:
+        match = re.search(r"PhysicalDrive(\d+)", device.path)
+        if match:
+            disk_number = match.group(1)
+    if not disk_number:
+        return None
+    return BootPartition(path=None, disk_number=str(disk_number))
+
+
+def _resolve_boot_partition(device: Device) -> BootPartition | None:
+    system = platform.system()
+    if system == "Linux":
+        return _resolve_boot_partition_linux(device)
+    if system == "Darwin":
+        return _resolve_boot_partition_macos(device)
+    if system == "Windows":
+        return _resolve_boot_partition_windows(device)
+    return None
+
+
+@contextlib.contextmanager
+def _mount_boot_partition(partition: BootPartition) -> Iterator[Path]:
+    system = platform.system()
+    if system == "Linux":
+        if not partition.path:
+            die("Unable to determine boot partition path for --cloud-init override")
+        if partition.mountpoint:
+            yield Path(partition.mountpoint)
+            return
+        mount_dir = Path(tempfile.mkdtemp(prefix="sugarkube-boot-"))
+        proc = _run(["mount", partition.path, str(mount_dir)])
+        if proc.returncode != 0:
+            shutil.rmtree(mount_dir, ignore_errors=True)
+            stderr = (proc.stderr or "").strip()
+            die(f"Failed to mount {partition.path}: {stderr or 'unknown error'}")
+        try:
+            yield mount_dir
+        finally:
+            _run(["umount", str(mount_dir)])
+            shutil.rmtree(mount_dir, ignore_errors=True)
+        return
+
+    if system == "Darwin":
+        if not partition.identifier:
+            die("Unable to determine macOS partition identifier for cloud-init override")
+        if partition.mountpoint:
+            yield Path(partition.mountpoint)
+            return
+        proc = _run(["/usr/sbin/diskutil", "mount", partition.identifier])
+        if proc.returncode != 0:
+            stderr = (proc.stderr or "").strip()
+            die(f"diskutil could not mount {partition.identifier}: {stderr or 'unknown error'}")
+        try:
+            info_proc = _run(["/usr/sbin/diskutil", "info", "-plist", partition.identifier])
+            if info_proc.returncode != 0 or not info_proc.stdout:
+                die(f"diskutil info failed for {partition.identifier}")
+            import plistlib  # pragma: no cover - macOS only
+
+            info_data = plistlib.loads(info_proc.stdout.encode("utf-8"))
+            mountpoint = info_data.get("MountPoint")
+            if not mountpoint:
+                die(f"diskutil did not report a mount point for {partition.identifier}")
+            yield Path(mountpoint)
+        finally:
+            _run(["/usr/sbin/diskutil", "unmount", partition.identifier])
+        return
+
+    if system == "Windows":
+        if not partition.disk_number:
+            die("Unable to determine disk number for cloud-init override")
+        command = textwrap.dedent(
+            f"""
+            $partition = Get-Partition -DiskNumber {partition.disk_number} |
+              Sort-Object PartitionNumber |
+              Select-Object -First 1;
+            if (-not $partition) {{ exit 1 }}
+            $volume = $partition | Get-Volume -ErrorAction SilentlyContinue;
+            $assigned = $false;
+            if (-not $volume) {{
+              $used = Get-Volume |
+                Where-Object DriveLetter |
+                Select-Object -ExpandProperty DriveLetter;
+              $letters = [char[]](65..90) |
+                ForEach-Object {{ [string]$_ }};
+              $free = $letters |
+                Where-Object {{ $used -notcontains $_ }} |
+                Select-Object -First 1;
+              if (-not $free) {{ exit 2 }}
+              $partition |
+                Set-Partition -NewDriveLetter $free -ErrorAction Stop;
+              $assigned = $true;
+              $volume = $partition |
+                Get-Volume -ErrorAction Stop;
+            }}
+            $path = if ($volume.DriveLetter) {{
+              $volume.DriveLetter + ':\\'
+            }} elseif ($volume.Path) {{
+              $volume.Path
+            }} else {{ '' }};
+            if (-not $path) {{ exit 3 }}
+            $result = [pscustomobject]@{{{{
+              Path = $path;
+              DriveLetter = $volume.DriveLetter;
+              Assigned = $assigned;
+            }}}}
+            $result | ConvertTo-Json -Compress
+            """
+        )
+
+        payload = _powershell_json(command)
+        if not payload:
+            die("Unable to mount Windows boot partition for cloud-init override")
+        mount_path = Path(payload["Path"])
+        assigned = bool(payload.get("Assigned"))
+        drive_letter = payload.get("DriveLetter")
+        try:
+            yield mount_path
+        finally:
+            if assigned and drive_letter:
+                cleanup = textwrap.dedent(
+                    f"""
+                    $partition = Get-Partition -DiskNumber {partition.disk_number} `
+                      -PartitionNumber 1 -ErrorAction SilentlyContinue;
+                    if ($partition) {{
+                      $partition |
+                        Remove-PartitionAccessPath `
+                          -DriveLetter {drive_letter} `
+                          -ErrorAction SilentlyContinue;
+                    }}
+                    """
+                )
+                _run(["powershell", "-NoProfile", "-Command", cleanup])
+        return
+
+    die("--cloud-init overrides are not supported on this platform")
+
+
+def _apply_cloud_init_override(device: Device, override: Path) -> None:
+    partition = _resolve_boot_partition(device)
+    if partition is None:
+        die(
+            "Unable to locate the boot partition for --cloud-init. "
+            "Copy user-data manually or rerun with explicit device info."
+        )
+    with _mount_boot_partition(partition) as mountpoint:
+        destination = mountpoint / "user-data"
+        try:
+            shutil.copyfile(override, destination)
+        except OSError as exc:
+            die(f"Failed to copy cloud-init override to {destination}: {exc}")
+        info(f"Copied cloud-init override to {destination}")
+
+
 def summarize_devices(devices: Sequence[Device]) -> None:
     if not devices:
         info("No removable drives detected. Pass --device explicitly if one is attached.")
@@ -532,6 +778,10 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         help="Validate inputs and read the image without writing to the device.",
     )
     parser.add_argument(
+        "--cloud-init",
+        help="Path to a cloud-init user-data file to copy onto the boot partition after flashing.",
+    )
+    parser.add_argument(
         "--bytes",
         type=int,
         default=0,
@@ -573,6 +823,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     if not image_path.exists():
         die(f"Image not found: {image_path}")
+
+    cloud_init_path: Path | None = None
+    if getattr(args, "cloud_init", None):
+        candidate = Path(args.cloud_init).expanduser().resolve()
+        if not candidate.exists():
+            die(f"Cloud-init override not found: {candidate}")
+        cloud_init_path = candidate
 
     if not args.device:
         summarize_devices(candidates)
@@ -661,6 +918,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             f"Expected {expected_hash}, got {actual_hash}."
         )
     info(f"Verified device SHA-256: {actual_hash}")
+
+    if cloud_init_path is not None:
+        _apply_cloud_init_override(target_device, cloud_init_path)
 
     if not args.no_eject:
         _auto_eject(target_device)

--- a/scripts/flash_pi_media_report.py
+++ b/scripts/flash_pi_media_report.py
@@ -136,6 +136,8 @@ def _run_flash(
         argv.append("--keep-mounted")
     if args.dry_run:
         argv.append("--dry-run")
+    if args.cloud_init:
+        argv.extend(["--cloud-init", str(args.cloud_init)])
     if not device.path:
         raise FlashReportError("Device path is required for flashing.")
     stdout_buffer = io.StringIO()

--- a/tests/flash_pi_media_report_test.py
+++ b/tests/flash_pi_media_report_test.py
@@ -31,7 +31,7 @@ def test_run_flash_forwards_cloud_init(monkeypatch: pytest.MonkeyPatch) -> None:
         recorded["argv"] = argv
         return 0
 
-    monkeypatch.setattr(flash, "main", fake_main)
+    monkeypatch.setattr(report.flash, "main", fake_main)
 
     args = SimpleNamespace(
         no_eject=False,

--- a/tests/flash_pi_media_report_test.py
+++ b/tests/flash_pi_media_report_test.py
@@ -1,6 +1,12 @@
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import flash_pi_media as flash
+from scripts import flash_pi_media_report as report
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 SCRIPT = BASE_DIR / "scripts" / "flash_pi_media_report.py"
@@ -16,3 +22,26 @@ def test_list_devices_without_image_exits_cleanly():
     assert result.returncode == 0, result.stderr
     assert "Provide --image" not in result.stderr
     assert "No removable drives detected" in result.stdout or "Device" in result.stdout
+
+
+def test_run_flash_forwards_cloud_init(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded: dict[str, list[str]] = {}
+
+    def fake_main(argv: list[str]) -> int:
+        recorded["argv"] = argv
+        return 0
+
+    monkeypatch.setattr(flash, "main", fake_main)
+
+    args = SimpleNamespace(
+        no_eject=False,
+        keep_mounted=False,
+        dry_run=False,
+        cloud_init="override.yaml",
+    )
+    device = flash.Device(path="/dev/sdz", description="disk", size=0, is_removable=True)
+
+    stdout, stderr, expected, verified = report._run_flash(Path("image.img"), args, device)
+
+    assert recorded["argv"].count("--cloud-init") == 1
+    assert "override.yaml" in recorded["argv"]

--- a/tests/flash_pi_media_test.py
+++ b/tests/flash_pi_media_test.py
@@ -1,3 +1,4 @@
+import contextlib
 import lzma
 import os
 import subprocess
@@ -5,6 +6,8 @@ import sys
 from pathlib import Path
 
 import pytest
+
+from scripts import flash_pi_media as flash
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 
@@ -76,3 +79,81 @@ def test_requires_root_without_override(tmp_path):
 
     assert result.returncode != 0
     assert "Run as root or with sudo" in result.stderr
+
+
+def test_cloud_init_override_copies_user_data(tmp_path, monkeypatch):
+    content = b"override" * 2048
+    img, archive = make_image(tmp_path, content)
+    device = tmp_path / "device.bin"
+    device.touch()
+
+    env = os.environ.copy()
+    env["SUGARKUBE_FLASH_ALLOW_NONROOT"] = "1"
+
+    override = tmp_path / "user-data.yaml"
+    override.write_text("hostname: sugarkube\n", encoding="utf-8")
+
+    mount_dir = tmp_path / "boot"
+    mount_dir.mkdir()
+
+    monkeypatch.setattr(
+        flash,
+        "_resolve_boot_partition",
+        lambda _device: flash.BootPartition(path="/dev/mock", mountpoint=str(mount_dir)),
+    )
+
+    @contextlib.contextmanager
+    def fake_mount(partition):
+        yield Path(partition.mountpoint)
+
+    monkeypatch.setattr(flash, "_mount_boot_partition", fake_mount)
+
+    result = run_flash(
+        [
+            "--image",
+            str(archive),
+            "--device",
+            str(device),
+            "--assume-yes",
+            "--no-eject",
+            "--cloud-init",
+            str(override),
+        ],
+        env=env,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    expected_override = override.read_text(encoding="utf-8")
+    assert (mount_dir / "user-data").read_text(encoding="utf-8") == expected_override
+    assert "Copied cloud-init override" in result.stdout
+
+
+def test_cloud_init_missing_file_errors(tmp_path):
+    content = b"data" * 2048
+    img, archive = make_image(tmp_path, content)
+    device = tmp_path / "device.raw"
+    device.touch()
+
+    env = os.environ.copy()
+    env["SUGARKUBE_FLASH_ALLOW_NONROOT"] = "1"
+
+    missing = tmp_path / "missing.yaml"
+
+    result = run_flash(
+        [
+            "--image",
+            str(archive),
+            "--device",
+            str(device),
+            "--assume-yes",
+            "--no-eject",
+            "--cloud-init",
+            str(missing),
+        ],
+        env=env,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode != 0
+    assert "Cloud-init override not found" in result.stderr


### PR DESCRIPTION
## Summary
- scanned the repo for documented TODO/FIXME/future-work references and prioritized the promised `--cloud-init` flashing flow
- add cross-platform boot-partition resolution so flashing can copy cloud-init overrides
- extend the reporter, docs, and regression tests to cover the forwarded `--cloud-init` flag

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68e311479ab8832fbcfa1a6bef81c1cd