### PR TITLE
Add CLI wrapper for sugarkube command

### DIFF
--- a/docs/pi_smoke_test.md
+++ b/docs/pi_smoke_test.md
@@ -70,17 +70,21 @@ directly.
 
 ## Unified CLI entrypoint
 
-Prefer the consolidated Sugarkube CLI? Run the smoke test via the new `sugarkube pi smoke`
-subcommand:
+Prefer the consolidated Sugarkube CLI? The repository ships a `scripts/sugarkube` launcher that
+forwards to `python -m sugarkube_toolkit`, letting you run the smoke test via the documented
+`sugarkube pi smoke` subcommand:
 
 ```bash
-python -m sugarkube_toolkit pi smoke --dry-run -- --json pi-a.local pi-b.local
+./scripts/sugarkube pi smoke --dry-run -- --json pi-a.local pi-b.local
+# or, after adding scripts/ to PATH:
+sugarkube pi smoke --dry-run -- --json pi-a.local pi-b.local
 ```
 
 Drop `--dry-run` to run the verifier immediately. Everything after the standalone `--` flows to
 `scripts/pi_smoke_test.py`, so existing documentation continues to apply. Regression coverage lives
-in `tests/test_sugarkube_toolkit_cli.py::test_pi_smoke_invokes_helper` and the surrounding
-`test_pi_smoke_*` cases.
+in `tests/test_sugarkube_toolkit_cli.py::test_pi_smoke_invokes_helper`,
+`tests/test_sugarkube_toolkit_cli.py::test_pi_smoke_drops_script_separator`, and the
+new `tests/test_sugarkube_cli_entrypoint.py::test_sugarkube_script_invokes_cli` case.
 
 ## Test coverage
 

--- a/scripts/sugarkube
+++ b/scripts/sugarkube
@@ -23,4 +23,18 @@ find_python() {
 
 PYTHON_INTERPRETER="$(find_python)"
 
+# Ensure the repository root is available on PYTHONPATH even when the
+# wrapper is launched from a different working directory. This mirrors the
+# behavior suggested in the documentation where `scripts/` is added to PATH.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ -d "$PROJECT_ROOT" ]; then
+  if [ -n "${PYTHONPATH:-}" ]; then
+    export PYTHONPATH="$PROJECT_ROOT:$PYTHONPATH"
+  else
+    export PYTHONPATH="$PROJECT_ROOT"
+  fi
+fi
+
 exec "$PYTHON_INTERPRETER" -m sugarkube_toolkit "$@"

--- a/scripts/sugarkube
+++ b/scripts/sugarkube
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+find_python() {
+  if [ -n "${SUGARKUBE_PYTHON:-}" ]; then
+    echo "$SUGARKUBE_PYTHON"
+    return 0
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    echo python3
+    return 0
+  fi
+
+  if command -v python >/dev/null 2>&1; then
+    echo python
+    return 0
+  fi
+
+  echo "Unable to find a Python interpreter for sugarkube_toolkit." >&2
+  return 1
+}
+
+PYTHON_INTERPRETER="$(find_python)"
+
+exec "$PYTHON_INTERPRETER" -m sugarkube_toolkit "$@"

--- a/tests/test_sugarkube_cli_entrypoint.py
+++ b/tests/test_sugarkube_cli_entrypoint.py
@@ -1,0 +1,24 @@
+"""Ensure the top-level sugarkube command proxies to the toolkit CLI."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_sugarkube_script_invokes_cli() -> None:
+    """scripts/sugarkube should execute the toolkit CLI entry point."""
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "sugarkube"
+    assert script.exists(), "scripts/sugarkube entry point is missing"
+
+    result = subprocess.run(
+        [str(script), "docs", "verify", "--dry-run"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "pyspelling -c .spellcheck.yaml" in result.stdout
+    assert "linkchecker --no-warnings README.md docs/" in result.stdout


### PR DESCRIPTION
## Summary
- confirm docs/pi_smoke_test.md promised a `sugarkube pi smoke` command and supply the missing wrapper
- add a reusable `scripts/sugarkube` launcher that proxies to `python -m sugarkube_toolkit` with pytest coverage
- document the launcher in the smoke-test guide and cross-link the new regression test

## Testing
- python -m pre_commit run --all-files
- python -m pyspelling -c .spellcheck.yaml
- python -m linkcheck --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68e311479ab8832fbcfa1a6bef81c1cd