### PR TITLE
Document unified CLI repo-root execution and guard docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ the docs you will see the term used in both contexts.
     instead of `realpath` so macOS-friendly symlinks work without extra tooling.
     Invoke it from the unified CLI with
     `python -m sugarkube_toolkit pi download [--dry-run] [helper args...]` when you prefer
-    a consistent entry point across automation helpers.
+    a consistent entry point across automation helpers. The unified CLI always runs helpers
+    from the repository root so relative paths to `scripts/` and docs work even when you
+    launch it from nested directories (`tests/test_cli_docs_repo_root.py` guards the docs
+    call-out).
   - `install_sugarkube_image.sh` — install the GitHub CLI when missing, download the
     latest release, verify checksums, expand the `.img.xz`, and emit a new
     `.img.sha256`; safe to run via `curl | bash`. Invoke it from the unified CLI with
@@ -119,7 +122,9 @@ Codespaces users can install prerequisites and flash media without additional sh
 `./scripts/sugarkube-latest` remains available when you only need the `.img.xz` artifact with
 checksum verification.
 Prefer a unified entry point? `python -m sugarkube_toolkit pi download --dry-run` previews the
-release helper. Need the combined installer that downloads and expands the image? Run
+release helper. The CLI forces the working directory to the repository root before invoking
+helpers, so you can run it from anywhere inside the clone. Need the combined installer that
+downloads and expands the image? Run
 
 ```bash
 python -m sugarkube_toolkit pi install --dry-run -- --dir ~/sugarkube/images --image ~/sugarkube/images/sugarkube.img

--- a/docs/contributor_script_map.md
+++ b/docs/contributor_script_map.md
@@ -10,6 +10,12 @@ scripts or guides. Each table row links a helper to the documentation that intro
 plus any supporting automation. After editing a script or doc, rerun the docs checks to
 confirm the quickstart stays accurate.
 
+> **Note:** The unified CLI forces helpers to run from the repository root so relative
+> paths stay stable even when you invoke it from nested directories. Use the CLI entries
+> below when you want consistent automation regardless of your current working directory.
+> The reminder is enforced by `tests/test_cli_docs_repo_root.py` so contributors keep the
+> documentation aligned.
+
 ## Image download and install helpers
 
 | Script | Purpose | Primary docs | Supporting automation |

--- a/sugarkube_toolkit/cli.py
+++ b/sugarkube_toolkit/cli.py
@@ -150,7 +150,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def _handle_docs_verify(args: argparse.Namespace) -> int:
     try:
-        runner.run_commands(DOC_VERIFY_COMMANDS, dry_run=args.dry_run)
+        runner.run_commands(DOC_VERIFY_COMMANDS, dry_run=args.dry_run, cwd=REPO_ROOT)
     except runner.CommandError as exc:
         print(exc, file=sys.stderr)
         return 1
@@ -173,7 +173,7 @@ def _handle_docs_simplify(args: argparse.Namespace) -> int:
         *_normalize_script_args(getattr(args, "script_args", [])),
     ]
     try:
-        runner.run_commands([command], dry_run=args.dry_run)
+        runner.run_commands([command], dry_run=args.dry_run, cwd=REPO_ROOT)
     except runner.CommandError as exc:
         print(exc, file=sys.stderr)
         return 1
@@ -199,7 +199,7 @@ def _handle_pi_download(args: argparse.Namespace) -> int:
 
     command = ["bash", str(script), *_normalize_script_args(getattr(args, "script_args", []))]
     try:
-        runner.run_commands([command], dry_run=args.dry_run)
+        runner.run_commands([command], dry_run=args.dry_run, cwd=REPO_ROOT)
     except runner.CommandError as exc:
         print(exc, file=sys.stderr)
         return 1
@@ -218,7 +218,7 @@ def _handle_pi_install(args: argparse.Namespace) -> int:
 
     command = ["bash", str(script), *_normalize_script_args(getattr(args, "script_args", []))]
     try:
-        runner.run_commands([command], dry_run=args.dry_run)
+        runner.run_commands([command], dry_run=args.dry_run, cwd=REPO_ROOT)
     except runner.CommandError as exc:
         print(exc, file=sys.stderr)
         return 1
@@ -237,7 +237,7 @@ def _handle_pi_flash(args: argparse.Namespace) -> int:
 
     command = ["bash", str(script), *_normalize_script_args(getattr(args, "script_args", []))]
     try:
-        runner.run_commands([command], dry_run=args.dry_run)
+        runner.run_commands([command], dry_run=args.dry_run, cwd=REPO_ROOT)
     except runner.CommandError as exc:
         print(exc, file=sys.stderr)
         return 1
@@ -260,7 +260,7 @@ def _handle_pi_report(args: argparse.Namespace) -> int:
         *_normalize_script_args(getattr(args, "script_args", [])),
     ]
     try:
-        runner.run_commands([command], dry_run=args.dry_run)
+        runner.run_commands([command], dry_run=args.dry_run, cwd=REPO_ROOT)
     except runner.CommandError as exc:
         print(exc, file=sys.stderr)
         return 1
@@ -283,7 +283,7 @@ def _handle_pi_smoke(args: argparse.Namespace) -> int:
         *_normalize_script_args(getattr(args, "script_args", [])),
     ]
     try:
-        runner.run_commands([command], dry_run=args.dry_run)
+        runner.run_commands([command], dry_run=args.dry_run, cwd=REPO_ROOT)
     except runner.CommandError as exc:
         print(exc, file=sys.stderr)
         return 1
@@ -306,7 +306,7 @@ def _handle_pi_rehearse(args: argparse.Namespace) -> int:
         *_normalize_script_args(getattr(args, "script_args", [])),
     ]
     try:
-        runner.run_commands([command], dry_run=args.dry_run)
+        runner.run_commands([command], dry_run=args.dry_run, cwd=REPO_ROOT)
     except runner.CommandError as exc:
         print(exc, file=sys.stderr)
         return 1

--- a/sugarkube_toolkit/cli.py
+++ b/sugarkube_toolkit/cli.py
@@ -329,7 +329,7 @@ def _handle_pi_support_bundle(args: argparse.Namespace) -> int:
         *_normalize_script_args(getattr(args, "script_args", [])),
     ]
     try:
-        runner.run_commands([command], dry_run=args.dry_run)
+        runner.run_commands([command], dry_run=args.dry_run, cwd=REPO_ROOT)
     except runner.CommandError as exc:
         print(exc, file=sys.stderr)
         return 1

--- a/sugarkube_toolkit/runner.py
+++ b/sugarkube_toolkit/runner.py
@@ -45,6 +45,7 @@ def run_commands(
     *,
     dry_run: bool = False,
     env: Mapping[str, str] | None = None,
+    cwd: os.PathLike[str] | str | None = None,
 ) -> None:
     """Run each command, stopping at the first failure.
 
@@ -64,6 +65,7 @@ def run_commands(
             check=False,
             text=True,
             stderr=subprocess.PIPE,
+            cwd=str(cwd) if cwd is not None else None,
         )
         if result.returncode != 0:
             raise CommandError(command, result.returncode, stderr=result.stderr)

--- a/tests/test_cli_docs_repo_root.py
+++ b/tests/test_cli_docs_repo_root.py
@@ -1,0 +1,21 @@
+"""Ensure docs explain the CLI's repository-root working directory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_readme_calls_out_repo_root_execution() -> None:
+    """The README should mention the enforced repository-root working directory."""
+
+    readme_text = Path("README.md").read_text(encoding="utf-8")
+
+    assert "repository root" in readme_text and "CLI" in readme_text
+
+
+def test_contributor_map_calls_out_repo_root_execution() -> None:
+    """The contributor script map should reiterate the repository-root requirement."""
+
+    doc_text = Path("docs/contributor_script_map.md").read_text(encoding="utf-8")
+
+    assert "repository root" in doc_text and "CLI" in doc_text

--- a/tests/test_sugarkube_toolkit_cli.py
+++ b/tests/test_sugarkube_toolkit_cli.py
@@ -17,9 +17,14 @@ def test_docs_verify_invokes_doc_checks(monkeypatch: pytest.MonkeyPatch) -> None
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -66,9 +71,14 @@ def test_docs_simplify_invokes_checks_helper(monkeypatch: pytest.MonkeyPatch) ->
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -97,9 +107,14 @@ def test_docs_simplify_drops_script_separator(monkeypatch: pytest.MonkeyPatch) -
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -148,9 +163,14 @@ def test_pi_download_invokes_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -168,9 +188,14 @@ def test_pi_download_forwards_additional_args(monkeypatch: pytest.MonkeyPatch) -
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -236,9 +261,14 @@ def test_pi_download_drops_script_separator(monkeypatch: pytest.MonkeyPatch) -> 
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -261,9 +291,14 @@ def test_pi_install_invokes_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -281,9 +316,14 @@ def test_pi_install_forwards_additional_args(monkeypatch: pytest.MonkeyPatch) ->
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -357,9 +397,14 @@ def test_pi_install_drops_script_separator(monkeypatch: pytest.MonkeyPatch) -> N
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -382,9 +427,14 @@ def test_pi_flash_invokes_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -402,9 +452,14 @@ def test_pi_flash_forwards_additional_args(monkeypatch: pytest.MonkeyPatch) -> N
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -470,9 +525,14 @@ def test_pi_flash_drops_script_separator(monkeypatch: pytest.MonkeyPatch) -> Non
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -494,9 +554,14 @@ def test_pi_report_invokes_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -514,9 +579,14 @@ def test_pi_report_forwards_additional_args(monkeypatch: pytest.MonkeyPatch) -> 
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -590,9 +660,14 @@ def test_pi_report_drops_script_separator(monkeypatch: pytest.MonkeyPatch) -> No
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -614,9 +689,14 @@ def test_pi_support_bundle_invokes_helper(monkeypatch: pytest.MonkeyPatch) -> No
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -634,9 +714,14 @@ def test_pi_support_bundle_forwards_additional_args(monkeypatch: pytest.MonkeyPa
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -708,9 +793,14 @@ def test_pi_support_bundle_drops_script_separator(monkeypatch: pytest.MonkeyPatc
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -744,9 +834,14 @@ def test_pi_smoke_invokes_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -764,9 +859,14 @@ def test_pi_smoke_forwards_additional_args(monkeypatch: pytest.MonkeyPatch) -> N
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -830,9 +930,14 @@ def test_pi_smoke_drops_script_separator(monkeypatch: pytest.MonkeyPatch) -> Non
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -854,9 +959,14 @@ def test_pi_rehearse_invokes_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -876,9 +986,14 @@ def test_pi_rehearse_forwards_additional_args(monkeypatch: pytest.MonkeyPatch) -
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 
@@ -976,3 +1091,25 @@ def test_pi_rehearse_drops_script_separator(monkeypatch: pytest.MonkeyPatch) -> 
             "--json",
         ]
     ]
+
+
+def test_docs_simplify_runs_from_repo_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    """docs simplify should execute from the repository root."""
+
+    captured_cwd: list[Path | None] = []
+
+    def fake_run(
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
+    ) -> None:
+        captured_cwd.append(cwd)
+
+    monkeypatch.setattr(runner, "run_commands", fake_run)
+
+    exit_code = cli.main(["docs", "simplify", "--dry-run"])
+
+    assert exit_code == 0
+    assert captured_cwd and captured_cwd[0] == cli.REPO_ROOT

--- a/tests/test_sugarkube_toolkit_cli.py
+++ b/tests/test_sugarkube_toolkit_cli.py
@@ -1073,9 +1073,14 @@ def test_pi_rehearse_drops_script_separator(monkeypatch: pytest.MonkeyPatch) -> 
     recorded: list[list[str]] = []
 
     def fake_run(
-        commands: list[list[str]], *, dry_run: bool = False, env: Mapping[str, str] | None = None
+        commands: list[list[str]],
+        *,
+        dry_run: bool = False,
+        env: Mapping[str, str] | None = None,
+        cwd: Path | None = None,
     ) -> None:
         recorded.extend(commands)
+        assert cwd == cli.REPO_ROOT
 
     monkeypatch.setattr(runner, "run_commands", fake_run)
 

--- a/tests/test_sugarkube_toolkit_runner.py
+++ b/tests/test_sugarkube_toolkit_runner.py
@@ -47,7 +47,7 @@ def test_run_commands_merges_environment(monkeypatch: pytest.MonkeyPatch):
 
     recorded = {}
 
-    def fake_run(command, *, env, check, text, stderr):
+    def fake_run(command, *, env, check, text, stderr, cwd=None):
         recorded.update(
             {
                 "command": command,
@@ -55,6 +55,7 @@ def test_run_commands_merges_environment(monkeypatch: pytest.MonkeyPatch):
                 "check": check,
                 "text": text,
                 "stderr": stderr,
+                "cwd": cwd,
             }
         )
         return SimpleNamespace(returncode=0)
@@ -67,6 +68,7 @@ def test_run_commands_merges_environment(monkeypatch: pytest.MonkeyPatch):
     assert recorded["check"] is False
     assert recorded["text"] is True
     assert recorded["stderr"] is runner.subprocess.PIPE
+    assert recorded["cwd"] is None
     assert recorded["env"]["EXTRA"] == "value"
     assert recorded["env"]["MERGE_TEST"] == "override"
     assert os.environ["MERGE_TEST"] == "original"


### PR DESCRIPTION
## Summary
- add docs call-outs that the unified CLI forces helpers to run from the repository root
- add regression coverage so README and the contributor script map keep the repo-root reminder
- keep the CLI, runner, and tests aligned now that helpers always run from REPO_ROOT

## Testing
- python -m pre_commit run --all-files
- python -m pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- pytest tests/test_cli_docs_repo_root.py
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68e311479ab8832fbcfa1a6bef81c1cd