### PR TITLE
🧪 : – add CLI wrapper regression coverage

### DIFF
--- a/docs/pi_smoke_test.md
+++ b/docs/pi_smoke_test.md
@@ -83,8 +83,9 @@ sugarkube pi smoke --dry-run -- --json pi-a.local pi-b.local
 Drop `--dry-run` to run the verifier immediately. Everything after the standalone `--` flows to
 `scripts/pi_smoke_test.py`, so existing documentation continues to apply. Regression coverage lives
 in `tests/test_sugarkube_toolkit_cli.py::test_pi_smoke_invokes_helper`,
-`tests/test_sugarkube_toolkit_cli.py::test_pi_smoke_drops_script_separator`, and the
-new `tests/test_sugarkube_cli_entrypoint.py::test_sugarkube_script_invokes_cli` case.
+`tests/test_sugarkube_toolkit_cli.py::test_pi_smoke_drops_script_separator`, and
+`tests/test_sugarkube_cli_entrypoint.py::test_sugarkube_script_invokes_cli`, which verifies the
+legacy wrapper delegates to the unified CLI.
 
 ## Test coverage
 

--- a/tests/test_sugarkube_cli_entrypoint.py
+++ b/tests/test_sugarkube_cli_entrypoint.py
@@ -1,24 +1,51 @@
-"""Ensure the top-level sugarkube command proxies to the toolkit CLI."""
+"""Ensure the legacy wrapper script still defers to the unified CLI."""
 
 from __future__ import annotations
 
+import json
+import os
 import subprocess
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SUGARKUBE_SCRIPT = REPO_ROOT / "scripts" / "sugarkube"
 
-def test_sugarkube_script_invokes_cli() -> None:
-    """scripts/sugarkube should execute the toolkit CLI entry point."""
 
-    script = Path(__file__).resolve().parents[1] / "scripts" / "sugarkube"
-    assert script.exists(), "scripts/sugarkube entry point is missing"
+def test_sugarkube_script_invokes_cli(tmp_path: Path) -> None:
+    """scripts/sugarkube should exec ``python -m sugarkube_toolkit`` with passthrough args."""
+
+    fake_python = tmp_path / "fake-python"
+    args_file = tmp_path / "args.json"
+
+    fake_python.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+args_file = Path(os.environ["SUGARKUBE_TEST_ARGS_FILE"])
+args_file.write_text(json.dumps(sys.argv[1:]), encoding="utf-8")
+os.execv(sys.executable, [sys.executable, *sys.argv[1:]])
+""",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+
+    env = os.environ.copy()
+    env["SUGARKUBE_PYTHON"] = str(fake_python)
+    env["SUGARKUBE_TEST_ARGS_FILE"] = str(args_file)
 
     result = subprocess.run(
-        [str(script), "docs", "verify", "--dry-run"],
+        [str(SUGARKUBE_SCRIPT), "docs", "start-here", "--path-only"],
         check=False,
         capture_output=True,
         text=True,
+        env=env,
     )
 
     assert result.returncode == 0, result.stderr
-    assert "pyspelling -c .spellcheck.yaml" in result.stdout
-    assert "linkchecker --no-warnings README.md docs/" in result.stdout
+
+    recorded_args = json.loads(args_file.read_text(encoding="utf-8"))
+    assert recorded_args[:2] == ["-m", "sugarkube_toolkit"]
+    assert recorded_args[2:] == ["docs", "start-here", "--path-only"]


### PR DESCRIPTION
what: add regression coverage for scripts/sugarkube CLI wrapper
why: docs referenced nonexistent CLI test; ensure wrapper delegates
how to test: pre-commit run --all-files
Refs: N/A

------
https://chatgpt.com/codex/tasks/task_e_68e4c31d5b60832f9d4f0750ddd967d1