### PR TITLE
Clarify CLI wrapper guidance for nested directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,12 @@ the docs you will see the term used in both contexts.
     instead of `realpath` so macOS-friendly symlinks work without extra tooling.
     Invoke it from the unified CLI with
     `python -m sugarkube_toolkit pi download [--dry-run] [helper args...]` when you prefer
-    a consistent entry point across automation helpers. The unified CLI always runs helpers
-    from the repository root so relative paths to `scripts/` and docs work even when you
-    launch it from nested directories (`tests/test_cli_docs_repo_root.py` guards the docs
-    call-out).
+    a consistent entry point across automation helpers. Run `python -m` commands from the
+    repository root so the package can be imported cleanly; if you are working from a
+    nested directory, call `./scripts/sugarkube ...` (or add `scripts/` to `PATH`) so the
+    wrapper bootstraps `PYTHONPATH` before forwarding to the CLI. The CLI still executes
+    helpers from the repository root so relative paths to `scripts/` and docs remain
+    stable (`tests/test_cli_docs_repo_root.py` guards the docs call-out).
   - `install_sugarkube_image.sh` — install the GitHub CLI when missing, download the
     latest release, verify checksums, expand the `.img.xz`, and emit a new
     `.img.sha256`; safe to run via `curl | bash`. Invoke it from the unified CLI with

--- a/docs/contributor_script_map.md
+++ b/docs/contributor_script_map.md
@@ -10,11 +10,12 @@ scripts or guides. Each table row links a helper to the documentation that intro
 plus any supporting automation. After editing a script or doc, rerun the docs checks to
 confirm the quickstart stays accurate.
 
-> **Note:** The unified CLI forces helpers to run from the repository root so relative
-> paths stay stable even when you invoke it from nested directories. Use the CLI entries
-> below when you want consistent automation regardless of your current working directory.
-> The reminder is enforced by `tests/test_cli_docs_repo_root.py` so contributors keep the
-> documentation aligned.
+> **Note:** Run `python -m sugarkube_toolkit ...` from the repository root so the module can
+> be imported. When you're working from a nested directory, call `./scripts/sugarkube ...`
+> (or add `scripts/` to `PATH`) and the wrapper will bootstrap `PYTHONPATH` before
+> forwarding to the CLI. The wrapper still forces helpers to execute from the repository
+> root so relative paths stay stable. The reminder is enforced by
+> `tests/test_cli_docs_repo_root.py` so contributors keep the documentation aligned.
 
 ## Image download and install helpers
 

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -99,11 +99,18 @@ sync without modifying the host.
      repository root to print the same steps.
    - `./scripts/download_pi_image.sh --output /your/path.img.xz` still resumes
      partial downloads and verifies checksums automatically.
-  - Prefer a unified entry point? `python -m sugarkube_toolkit pi download --dry-run` shows the
-    underlying helper, then runs `scripts/download_pi_image.sh --dry-run` with the flags you provide.
-    Pass the same arguments (`--dir`, `--release`, `--asset`, etc.) to the CLI and they flow straight
-    to the shell script, including the preview mode so you can inspect the exact `curl` commands
-    without fetching the artifact.
+  - Prefer a unified entry point? Run `python -m sugarkube_toolkit pi download --dry-run` from the
+    repository root to preview the helper. When you're in a nested directory, call
+    `./scripts/sugarkube pi download --dry-run` so the wrapper bootstraps `PYTHONPATH`. Both
+    commands invoke `scripts/download_pi_image.sh --dry-run` with the flags you provide.
+    Pass the same arguments (`--dir`, `--release`, `--asset`, etc.) to the CLI and they flow
+    straight to the shell script, including the preview mode so you can inspect the exact
+    `curl` commands without fetching the artifact.
+
+> [!NOTE]
+> The same repository-root rule applies to other `python -m sugarkube_toolkit ...` examples below.
+> Use the `./scripts/sugarkube` wrapper (or add `scripts/` to `PATH`) whenever you're launching
+> commands from a nested directory so the CLI can import correctly.
    - Want a hands-off alert when the artifacts land? Run
     ```bash
     make notify-workflow \

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -47,8 +47,10 @@ docs apply to you.
 
 > [!TIP]
 > Run `just start-here` (or `make start-here`) to print this handbook directly in your terminal.
-> Need just the absolute path? Run `python -m sugarkube_toolkit docs start-here --path-only`.
-> This prints the location without extra tooling.
+> Need just the absolute path? Run `python -m sugarkube_toolkit docs start-here --path-only`
+> from the repository root. When you're working out of a nested directory, call
+> `./scripts/sugarkube docs start-here --path-only` (or add `scripts/` to `PATH`) so the
+> wrapper bootstraps `PYTHONPATH` before forwarding to the CLI.
 > When using the Make/Just wrappers, forward `START_HERE_ARGS="--path-only"`
 > so they pass the flag through (for example, `make start-here START_HERE_ARGS="--path-only"`).
 > Skim this track the moment you clone the repository. It orients you before you touch any

--- a/docs/templates/simplification/onboarding-update.md
+++ b/docs/templates/simplification/onboarding-update.md
@@ -9,8 +9,9 @@
 - Link to the updated quickstart, handbook, or tutorial draft.
 - Evidence that automation (`make doctor`, `START_HERE_ARGS="--path-only" just start-here`,
   `START_HERE_ARGS="--path-only" make start-here`,
-  `python -m sugarkube_toolkit docs start-here --path-only`) reflects the new path and prints the
-  updated guidance.
+  `python -m sugarkube_toolkit docs start-here --path-only` from the repo root or
+  `./scripts/sugarkube docs start-here --path-only` when working in a subdirectory)
+  reflects the new path and prints the updated guidance.
 - Screenshots or recordings that walk through the refreshed flow.
 
 ## Stakeholders

--- a/tests/test_cli_docs_repo_root.py
+++ b/tests/test_cli_docs_repo_root.py
@@ -19,3 +19,11 @@ def test_contributor_map_calls_out_repo_root_execution() -> None:
     doc_text = Path("docs/contributor_script_map.md").read_text(encoding="utf-8")
 
     assert "repository root" in doc_text and "CLI" in doc_text
+
+
+def test_readme_points_to_sugarkube_wrapper_for_nested_usage() -> None:
+    """Readers should learn to use scripts/sugarkube when not at repo root."""
+
+    readme_text = Path("README.md").read_text(encoding="utf-8")
+
+    assert "scripts/sugarkube" in readme_text, "README should mention the wrapper for nested usage"

--- a/tests/test_sugarkube_cli_entrypoint.py
+++ b/tests/test_sugarkube_cli_entrypoint.py
@@ -22,3 +22,22 @@ def test_sugarkube_script_invokes_cli() -> None:
     assert result.returncode == 0, result.stderr
     assert "pyspelling -c .spellcheck.yaml" in result.stdout
     assert "linkchecker --no-warnings README.md docs/" in result.stdout
+
+
+def test_sugarkube_script_sets_repo_root_from_subdirectory() -> None:
+    """The wrapper should work even when launched outside the repository root."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "scripts" / "sugarkube"
+    assert script.exists(), "scripts/sugarkube entry point is missing"
+
+    result = subprocess.run(
+        [str(script), "docs", "start-here", "--path-only"],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=repo_root / "tests",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().endswith("docs/start-here.md"), result.stdout


### PR DESCRIPTION
what: document scripts/sugarkube wrapper usage when not at repo root
  and ensure tests cover the wrapper from nested directories.
why: align CLI documentation with actual python -m behaviour and
  keep contributors from hitting import errors outside the repo root.
how to test: python -m pre_commit run --all-files
             python -m pyspelling -c .spellcheck.yaml
             /root/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md docs/
             git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68e4c31d5b60832f9d4f0750ddd967d1