### PR TITLE
✨ : – add shared glossary for tutorials

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,45 @@
+---
+personas:
+  - hardware
+  - software
+---
+
+# Sugarkube Glossary
+
+The tutorials reference a consistent set of core terms. Use this glossary to align on vocabulary
+before diving into the roadmap so later guides can assume a shared foundation.
+
+## CPU
+
+The **Central Processing Unit** is the Pi's "brain". It reads instructions from memory, performs the
+math or logic they describe, and coordinates peripherals. When tutorials mention "processor load"
+or "cores", they are referring to how busy the CPU is.
+
+## Memory
+
+**Random-access memory (RAM)** is short-term workspace for the CPU. Programs place data here while
+running so it can be accessed quickly. Low available memory can make commands sluggish or cause
+processes to restart.
+
+## Storage
+
+**Persistent storage** retains data even after power is removed. On Sugarkube this usually means the
+microSD card or SSD that holds the operating system, configuration, and logs referenced throughout
+the guides.
+
+## Operating System
+
+An **operating system (OS)** manages hardware resources and exposes common services—filesystems,
+process scheduling, networking—to software. Sugarkube relies on Raspberry Pi OS with additional
+cloud-init automation layered on top.
+
+## Shell
+
+The **command shell** (e.g., `bash`) lets you interact with the OS through text commands. Tutorials
+reference shell prompts, scripts, and transcripts; they all stem from learning to navigate and
+automate via the shell.
+
+---
+
+Regression coverage: `tests/test_glossary_doc.py` keeps this glossary referenced from the tutorial
+roadmap and ensures the headings above remain available for cross-linking.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ Pi cluster and aquarium aerator while the frame supports climbing plants.*
 Review the safety notes before working with power components.
 
 - [start-here.md](start-here.md) — orientation tracks for newcomers
+- [glossary.md](glossary.md) — shared vocabulary for the tutorials and docs
 - [SAFETY.md](SAFETY.md) — wiring and battery safety guidelines
 - [build_guide.md](build_guide.md) — step-by-step assembly instructions
 - [pi_cluster_carrier.md](pi_cluster_carrier.md) — details on the Raspberry Pi mounting plate

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -40,7 +40,8 @@ directories, run simple commands, and begin building muscle memory with shell pr
    workstation.
 2. Practice in a browser sandbox: run file inspection commands, create directories, and capture the
    transcript for later reference.
-3. Summarize key terms in a shared glossary so future tutorials can link to an agreed vocabulary.
+3. Summarize key terms in the [Sugarkube Glossary](../glossary.md) so future tutorials can link to
+   an agreed vocabulary.
 
 ## Tutorial 2: Navigating Linux and the Terminal
 

--- a/tests/test_glossary_doc.py
+++ b/tests/test_glossary_doc.py
@@ -1,0 +1,36 @@
+"""Ensure the shared glossary exists for tutorial references."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GLOSSARY_DOC = REPO_ROOT / "docs" / "glossary.md"
+TUTORIAL_INDEX = REPO_ROOT / "docs" / "tutorials" / "index.md"
+
+EXPECTED_HEADINGS = [
+    "## CPU",
+    "## Memory",
+    "## Storage",
+    "## Operating System",
+    "## Shell",
+]
+
+
+def test_glossary_defines_core_terms() -> None:
+    """The glossary should exist and define the core terminology."""
+
+    assert GLOSSARY_DOC.exists(), "docs/glossary.md is missing; publish the shared glossary."
+
+    text = GLOSSARY_DOC.read_text(encoding="utf-8")
+    for heading in EXPECTED_HEADINGS:
+        assert heading in text, f"Glossary should document the heading: {heading}"
+
+
+def test_tutorial_index_links_glossary() -> None:
+    """Tutorial roadmap should link to the shared glossary."""
+
+    text = TUTORIAL_INDEX.read_text(encoding="utf-8")
+    assert (
+        "[Sugarkube Glossary](../glossary.md)" in text
+    ), "Tutorial roadmap should reference the shared glossary for milestone vocabulary."


### PR DESCRIPTION
what: add docs/glossary.md, link the roadmap/index, and add regression tests
why: inventory found Tutorial 1 promised a shared glossary but none existed
how to test:
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py


------
https://chatgpt.com/codex/tasks/task_e_68e55d32b944832fa0e512381c464e15