### PR TITLE
Clarify README python -m usage and guard docs with a test

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,12 @@ shortcuts so GitHub
 Codespaces users can install prerequisites and flash media without additional shell glue.
 `./scripts/sugarkube-latest` remains available when you only need the `.img.xz` artifact with
 checksum verification.
-Prefer a unified entry point? `python -m sugarkube_toolkit pi download --dry-run` previews the
-release helper. The CLI forces the working directory to the repository root before invoking
-helpers, so you can run it from anywhere inside the clone. Need the combined installer that
-downloads and expands the image? Run
+Prefer a unified entry point? Run `python -m sugarkube_toolkit pi download --dry-run` from the
+repository root to preview the release helper. Once running, the CLI forces the working directory to
+the repository root before invoking helpers. Working from a nested directory? Call
+`./scripts/sugarkube pi download --dry-run` (or add `scripts/` to your `PATH`) so the wrapper
+bootstraps `PYTHONPATH` before forwarding to the CLI. Need the combined installer that downloads and
+expands the image? Run
 
 ```bash
 python -m sugarkube_toolkit pi install --dry-run -- --dir ~/sugarkube/images --image ~/sugarkube/images/sugarkube.img

--- a/tests/test_cli_docs_repo_root.py
+++ b/tests/test_cli_docs_repo_root.py
@@ -74,3 +74,24 @@ def test_readme_points_to_sugarkube_wrapper_for_nested_usage() -> None:
     readme_text = Path("README.md").read_text(encoding="utf-8")
 
     assert "scripts/sugarkube" in readme_text, "README should mention the wrapper for nested usage"
+
+
+def test_readme_python_module_section_mentions_repo_root() -> None:
+    """README should spell out that python -m invocations start from the repo root."""
+
+    readme_text = Path("README.md").read_text(encoding="utf-8")
+
+    marker = "python -m sugarkube_toolkit pi download --dry-run"
+    assert marker in readme_text, "README should document the python -m entry point"
+
+    start = readme_text.index(marker)
+    begin = max(0, start - 120)
+    end = start + 500
+    snippet = readme_text[begin:end]
+
+    assert (
+        "repository root" in snippet
+    ), "Clarify that python -m commands run from the repository root"
+    assert (
+        "scripts/sugarkube" in snippet
+    ), "Mention scripts/sugarkube alongside the python -m guidance"


### PR DESCRIPTION
## Summary
- clarify the README so python -m invocations are documented as repo-root workflows and point readers to scripts/sugarkube for nested directories
- extend the README CLI expectations test suite with coverage that enforces the new guidance

## Testing
- python -m pre_commit run --all-files
- python -m pyspelling -c .spellcheck.yaml
- /root/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68e55d32b944832fa0e512381c464e15