### PR TITLE
Fix Tutorial 8 Next Steps link formatting

### DIFF
--- a/docs/tutorials/tutorial-08-preparing-development-environment.md
+++ b/docs/tutorials/tutorial-08-preparing-development-environment.md
@@ -320,7 +320,12 @@ Use this section to verify progress against the roadmap. Mark each item as you c
 
 ## Next Steps
 Once you are comfortable running local automation, continue with the roadmap entry for
-[Tutorial 9: Building and Flashing the Sugarkube Pi Image]
-(./index.md#tutorial-9-building-and-flashing-the-sugarkube-pi-image).
+[Tutorial 9: Building and Flashing the Sugarkube Pi Image][tutorial-9-roadmap].
 Publish your lab evidence alongside your pull requests so reviewers can trust the environment you
 used.
+
+> [!NOTE]
+> Regression coverage in `tests/test_tutorial_next_steps_links.py::test_next_steps_inline_links_are_compact`
+> keeps this Next Steps link formatted on a single line so Markdown renders it correctly.
+
+[tutorial-9-roadmap]: ./index.md#tutorial-9-building-and-flashing-the-sugarkube-pi-image


### PR DESCRIPTION
## Summary
- add a regression test to ensure tutorial Next Steps inline links stay on one line so Markdown renders them
- update Tutorial 8 to use a reference-style link for the Next Steps hand-off and document the new coverage

## Testing
- python -m pre_commit run --all-files
- python -m pyspelling -c .spellcheck.yaml
- /root/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68e6e25d8974832fbb05a8d45d24bd24