### PR TITLE
Align checks.sh with documented npm test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ linkchecker --no-warnings README.md docs/
 Prefer the unified CLI? `python -m sugarkube_toolkit docs simplify [--dry-run] [-- args...]`
 wraps the same `scripts/checks.sh --docs-only` helper so you can stay inside a single entry point.
 Additional arguments after `--` are forwarded directly to the script.
+Regression coverage: `tests/checks_script_test.py::test_runs_js_checks_when_package_lock_present`
+verifies the helper runs `npm run test:ci` alongside linting and formatting when Node tooling exists.
 
 The `--no-warnings` flag prevents linkchecker from returning a non-zero exit code on benign Markdown
 parsing warnings.

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -435,7 +435,8 @@ if [ "$DOCS_ONLY" -eq 0 ]; then
         npx playwright install --with-deps
         npm run lint
         npm run format:check
-        npm test -- --coverage
+        # Guarded by tests/checks_script_test.py::test_runs_js_checks_when_package_lock_present.
+        npm run test:ci
       else
         echo "package-lock.json not found, skipping JS checks" >&2
       fi

--- a/tests/checks_script_test.py
+++ b/tests/checks_script_test.py
@@ -259,7 +259,7 @@ def test_runs_js_checks_when_package_lock_present(tmp_path: Path, script: Path) 
     assert "ci" in npm_lines
     assert any("run lint" in line for line in npm_lines)
     assert any("run format:check" in line for line in npm_lines)
-    assert any("test -- --coverage" in line for line in npm_lines)
+    assert any("run test:ci" in line for line in npm_lines)
     npx_lines = npx_log.read_text().splitlines()
     assert any("playwright install --with-deps" in line for line in npx_lines)
 


### PR DESCRIPTION
## Summary
- update scripts/checks.sh to invoke `npm run test:ci` so it matches the prompts that describe the JS workflow
- expand the README docs-simplify section with regression coverage details
- adjust the JS checks test to require the new command

## Testing
- `pytest tests/checks_script_test.py::test_runs_js_checks_when_package_lock_present`
- `pre-commit run --all-files`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68e6e25d8974832fbb05a8d45d24bd24