### PR TITLE
Fix hardware smoke badge configuration

### DIFF
--- a/docs/status/hardware-boot.json
+++ b/docs/status/hardware-boot.json
@@ -1,11 +1,7 @@
 {
   "cacheSeconds": 900,
   "color": "brightgreen",
-  "description": "Most recent manual verification against physical hardware.",
   "label": "hardware boot",
-  "link": [
-    "https://github.com/futuroptimist/sugarkube/blob/main/docs/pi_smoke_test.md"
-  ],
   "message": "passing \u2022 2025-02-15 16:00 UTC \u2022 Pi 4B cluster",
   "namedLogo": "raspberry-pi",
   "schemaVersion": 1


### PR DESCRIPTION
🩹 : –
what: remove unsupported fields from hardware smoke badge JSON
why: shields endpoint rejected the badge schema as invalid
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml;
  linkchecker --no-warnings README.md docs/
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68e76893ec80832f93aaff4934a4e032