### PR TITLE
🩹 : – Fix start-here diagram SVG parsing

### DIFF
--- a/docs/images/power_ring_wiring.svg
+++ b/docs/images/power_ring_wiring.svg
@@ -13,12 +13,12 @@
   </style>
   <rect class="node" x="40" y="120" width="120" height="80" />
   <text class="label" x="100" y="150" text-anchor="middle">J1</text>
-  <text class="note" x="100" y="170" text-anchor="middle">12&nbsp;V input</text>
+  <text class="note" x="100" y="170" text-anchor="middle">12&#160;V input</text>
   <text class="note" x="100" y="190" text-anchor="middle">Screw terminal</text>
 
   <rect class="node" x="200" y="110" width="100" height="60" />
   <text class="label" x="250" y="140" text-anchor="middle">F1</text>
-  <text class="note" x="250" y="160" text-anchor="middle">10&nbsp;A fuse</text>
+  <text class="note" x="250" y="160" text-anchor="middle">10&#160;A fuse</text>
 
   <line class="positive" x1="160" y1="150" x2="200" y2="140" />
   <line class="negative" x1="160" y1="170" x2="360" y2="220" />

--- a/docs/images/sugarkube_diagram.svg
+++ b/docs/images/sugarkube_diagram.svg
@@ -41,7 +41,7 @@
         Sugarkube frame
       </text>
       <text x="140" y="232" font-size="14" text-anchor="middle" fill="#475569">
-        Solar panels & Pi enclosure
+        Solar panels &amp; Pi enclosure
       </text>
     </g>
 
@@ -71,7 +71,7 @@
         DC distribution
       </text>
       <text x="75" y="56" font-size="14" text-anchor="middle" fill="#92400e">
-        Fuses & wiring harness
+        Fuses &amp; wiring harness
       </text>
     </g>
 

--- a/outages/2025-10-09-start-here-diagram-ampersand.json
+++ b/outages/2025-10-09-start-here-diagram-ampersand.json
@@ -1,0 +1,13 @@
+{
+  "id": "start-here-diagram-ampersand",
+  "date": "2025-10-09",
+  "component": "Documentation site rendering",
+  "rootCause": "The architecture diagram SVG used literal ampersands in labels, so GitHub's XML parser aborted.",
+  "resolution": "Escaped the ampersands and added tests to parse SVG assets and ensure the Markdown embed stays on one line.",
+  "references": [
+    "docs/images/sugarkube_diagram.svg",
+    "docs/start-here.md",
+    "tests/test_svg_assets.py",
+    "tests/test_start_here_doc.py"
+  ]
+}

--- a/tests/test_start_here_doc.py
+++ b/tests/test_start_here_doc.py
@@ -50,3 +50,14 @@ def test_start_here_doc_embeds_architecture_diagram() -> None:
     assert (
         "images/sugarkube_diagram.svg" in text
     ), "Start-here guide should reference the shared architecture diagram asset"
+    lines = text.splitlines()
+    diagram_lines = [
+        line
+        for line in lines
+        if "![Sugarkube architecture overview" in line
+    ]
+    assert diagram_lines, "Diagram embed should reside on a single Markdown line"
+    assert all(
+        ")](images/sugarkube_diagram.svg)" in line or "(images/sugarkube_diagram.svg)" in line
+        for line in diagram_lines
+    ), "Diagram embed must reference the SVG on the same line to avoid broken links"

--- a/tests/test_svg_assets.py
+++ b/tests/test_svg_assets.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+from xml.etree import ElementTree
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SVG_DIRS = [
+    REPO_ROOT / "docs" / "images",
+]
+
+
+def test_svg_assets_parse_cleanly() -> None:
+    svg_paths = [
+        path
+        for directory in SVG_DIRS
+        for path in sorted(directory.glob("*.svg"))
+    ]
+    assert svg_paths, "Expected at least one SVG asset to validate"
+
+    for svg_path in svg_paths:
+        try:
+            ElementTree.parse(svg_path)
+        except ElementTree.ParseError as exc:  # pragma: no cover - explicit assertion path
+            raise AssertionError(
+                f"Failed to parse SVG asset {svg_path.relative_to(REPO_ROOT)}: {exc}"
+            ) from exc


### PR DESCRIPTION
what:
- escape invalid entities in the start-here architecture diagram svg
- fix the markdown embed and record the outage details
- add regression tests that parse svg assets and guard the embed format
why:
- github could not render the diagram due to ampersands and html entities
how to test:
- pytest tests/test_start_here_doc.py tests/test_svg_assets.py

Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68e76f48863c832fa3015507f061882b