### PR TITLE
Fix CLI install dry-run forwarding

### DIFF
--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -85,13 +85,15 @@ sync without modifying the host.
    ```
    Drop `--dry-run` when you're ready. Everything after the standalone `--`
    flows to `scripts/install_sugarkube_image.sh`, so `--release` and other
-   documented flags work unchanged. The CLI forwards `--dry-run` to the
-   installer, mirroring the preview printed by running the shell helper
-   directly. Regression coverage in
-   `tests/test_sugarkube_toolkit_cli.py::test_pi_install_invokes_helper`
-   and `tests/test_sugarkube_toolkit_cli.py::test_pi_install_respects_existing_dry_run`
-   (plus neighbouring `test_pi_install_*` cases) ensures the CLI forwards
-   arguments exactly as documented.
+  documented flags work unchanged. The CLI forwards `--dry-run` to the
+  installer, mirroring the preview printed by running the shell helper
+  directly. Regression coverage in
+  `tests/test_sugarkube_toolkit_cli.py::test_pi_install_invokes_helper`
+  and
+  `tests/test_sugarkube_toolkit_cli.py::test_pi_install_respects_existing_dry_run`
+  (plus neighbouring `test_pi_install_*` cases) now asserts the CLI calls
+  the installer with `--dry-run` while still avoiding duplicate flags when
+  you forward them manually.
 3. In GitHub, open **Actions → pi-image → Run workflow** for a fresh build.
    - Tick **token.place** and **dspace** to bake those repos into `/opt/projects`.
    - Wait for the run to finish; it uploads `sugarkube.img.xz` as an artifact.

--- a/sugarkube_toolkit/cli.py
+++ b/sugarkube_toolkit/cli.py
@@ -308,9 +308,11 @@ def _handle_pi_install(args: argparse.Namespace) -> int:
     script_dry_run = "--dry-run" in script_args
 
     command = ["bash", str(script)]
+    if args.dry_run and not script_dry_run:
+        command.append("--dry-run")
     command.extend(script_args)
 
-    dry_run = args.dry_run or script_dry_run
+    dry_run = False if args.dry_run or script_dry_run else args.dry_run
     try:
         runner.run_commands([command], dry_run=dry_run, cwd=REPO_ROOT)
     except runner.CommandError as exc:

--- a/tests/test_sugarkube_toolkit_cli.py
+++ b/tests/test_sugarkube_toolkit_cli.py
@@ -452,8 +452,8 @@ def test_pi_install_invokes_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     expected_script = Path(__file__).resolve().parents[1] / "scripts" / "install_sugarkube_image.sh"
 
     assert exit_code == 0
-    assert recorded == [["bash", str(expected_script)]]
-    assert dry_run_flags == [True]
+    assert recorded == [["bash", str(expected_script), "--dry-run"]]
+    assert dry_run_flags == [False]
 
 
 def test_pi_install_forwards_additional_args(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -492,13 +492,14 @@ def test_pi_install_forwards_additional_args(monkeypatch: pytest.MonkeyPatch) ->
         [
             "bash",
             str(Path(__file__).resolve().parents[1] / "scripts" / "install_sugarkube_image.sh"),
+            "--dry-run",
             "--dir",
             "~/sugarkube/images",
             "--image",
             "~/sugarkube/images/sugarkube.img",
         ]
     ]
-    assert dry_run_flags == [True]
+    assert dry_run_flags == [False]
 
 
 def test_pi_install_reports_missing_script(
@@ -566,11 +567,12 @@ def test_pi_install_drops_script_separator(monkeypatch: pytest.MonkeyPatch) -> N
         [
             "bash",
             str(Path(__file__).resolve().parents[1] / "scripts" / "install_sugarkube_image.sh"),
+            "--dry-run",
             "--dir",
             "~/sugarkube/images",
         ]
     ]
-    assert dry_run_flags == [True]
+    assert dry_run_flags == [False]
 
 
 def test_pi_install_respects_existing_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -606,7 +608,7 @@ def test_pi_install_respects_existing_dry_run(monkeypatch: pytest.MonkeyPatch) -
             "~/images",
         ]
     ]
-    assert dry_run_flags == [True]
+    assert dry_run_flags == [False]
 
 
 def test_pi_install_uses_script_dry_run_without_cli_flag(
@@ -643,7 +645,7 @@ def test_pi_install_uses_script_dry_run_without_cli_flag(
             "~/images",
         ]
     ]
-    assert dry_run_flags == [True]
+    assert dry_run_flags == [False]
 
 
 def test_pi_flash_invokes_helper(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- inventory via `rg` flagged docs/pi_image_quickstart.md promising that the
  CLI forwards `--dry-run` to the installer, so we aligned the code with the
  documented behaviour
- ensure `_handle_pi_install` appends `--dry-run` to the helper invocation and
  executes the preview instead of short-circuiting in runner dry-run mode
- extend the CLI tests to assert the installer sees the flag and adjust the
  quickstart docs to highlight the new regression coverage

## Testing
- python -m pre_commit run --all-files
- python -m pyspelling -c .spellcheck.yaml
- python -m linkcheck --no-warnings README.md docs/

------
https://chatgpt.com/codex/tasks/task_e_68e765e57fb8832f98cea1242e4aeef2