### PR TITLE
Add dry-run preview for installer workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ the docs you will see the term used in both contexts.
     helpers from the repository root so relative paths to scripts and docs remain stable.
   - `install_sugarkube_image.sh` — install the GitHub CLI when missing, download the
     latest release, verify checksums, expand the `.img.xz`, and emit a new
-    `.img.sha256`; safe to run via `curl | bash`. Invoke it from the unified CLI with
+    `.img.sha256`; safe to run via `curl | bash`. Pass `--dry-run` to print the
+    download/expansion plan without touching disk. Invoke it from the unified CLI with
     `python -m sugarkube_toolkit pi install [--dry-run] [helper args...]` when you want
     the same behavior without leaving the `sugarkube` entry point.
   - `collect_pi_image.sh` — normalize pi-gen output into a single `.img.xz`,

--- a/docs/contributor_script_map.md
+++ b/docs/contributor_script_map.md
@@ -25,7 +25,7 @@ confirm the quickstart stays accurate.
 | --- | --- | --- | --- |
 | `scripts/download_pi_image.sh` | Resolve the latest release, resume partial downloads, and verify checksums/signatures. | [Pi Image Quickstart](./pi_image_quickstart.md) §1 | `Makefile` `download-pi-image` / `just download-pi-image` targets |
 | `scripts/sugarkube-latest` | Convenience wrapper that defaults to release downloads. | [Pi Image Quickstart](./pi_image_quickstart.md) §1 | Works with the same flags as `download_pi_image.sh`. |
-| `scripts/install_sugarkube_image.sh` | One-line installer that bootstraps `gh`, downloads, verifies, and expands the latest release. | [Pi Image Quickstart](./pi_image_quickstart.md) §1 | `Makefile` `install-pi-image`, `just install-pi-image`, curl one-liner |
+| `scripts/install_sugarkube_image.sh` | One-line installer that bootstraps `gh`, downloads, verifies, and expands the latest release (`--dry-run` prints the planned steps). | [Pi Image Quickstart](./pi_image_quickstart.md) §1 | `Makefile` `install-pi-image`, `just install-pi-image`, curl one-liner |
 | `scripts/collect_pi_image.sh` | Normalize pi-gen output, clean staging directories, and compress images for release. | [Pi Image Builder Design](./pi_image_builder_design.md) | Used inside GitHub Actions and local builds via `make build-pi-image`. |
 | `scripts/build_pi_image.sh` | Build the Raspberry Pi OS image with cloud-init, k3s, and bundled repos. | [Pi Image Builder Design](./pi_image_builder_design.md) | Called by `Makefile`/`just` build targets and the pi-image workflow. |
 

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -85,13 +85,14 @@ sync without modifying the host.
    ```
    Drop `--dry-run` when you're ready. Everything after the standalone `--`
    flows to `scripts/install_sugarkube_image.sh`, so `--release` and other
-   documented flags work unchanged. The CLI forwards `--dry-run` to the
-   installer, mirroring the preview printed by running the shell helper
-   directly. Regression coverage in
-   `tests/test_sugarkube_toolkit_cli.py::test_pi_install_invokes_helper`
-   and `tests/test_sugarkube_toolkit_cli.py::test_pi_install_respects_existing_dry_run`
+   documented flags work unchanged. The helper prints a preview when `--dry-run`
+   is present ("Dry run: would download …", "Dry run: would expand archive …")
+   so you can verify destinations without mutating disk. Regression coverage in
+   `tests/test_sugarkube_toolkit_cli.py::test_pi_install_invokes_helper`,
+   `tests/test_sugarkube_toolkit_cli.py::test_pi_install_respects_existing_dry_run`,
+   and `tests/install_sugarkube_image_test.py::test_install_dry_run_previews_actions`
    (plus neighbouring `test_pi_install_*` cases) ensures the CLI forwards
-   arguments exactly as documented.
+   arguments exactly as documented and the shell helper emits the preview.
 3. In GitHub, open **Actions → pi-image → Run workflow** for a fresh build.
    - Tick **token.place** and **dspace** to bake those repos into `/opt/projects`.
    - Wait for the run to finish; it uploads `sugarkube.img.xz` as an artifact.

--- a/scripts/install_sugarkube_image.sh
+++ b/scripts/install_sugarkube_image.sh
@@ -223,6 +223,7 @@ Options:
       --checksum NAME     Override the checksum asset name (default: asset + .sha256).
       --mode MODE         Pass through to download helper (auto, release, workflow).
       --download-only     Skip expansion; leave only the .img.xz and checksum.
+      --dry-run           Print the actions that would run without downloading or expanding.
       --skip-gh-install   Do not attempt to bootstrap the GitHub CLI automatically.
       --download-script PATH
                           Use a local download_pi_image.sh instead of fetching from GitHub.
@@ -251,8 +252,37 @@ OUTPUT_ARCHIVE=""
 IMAGE_DEST=""
 DEST_DIR_OVERRIDE=""
 DOWNLOAD_ONLY=0
+DRY_RUN=0
 SKIP_GH_INSTALL=0
 HELPER_OVERRIDE="${SUGARKUBE_INSTALL_HELPER:-}"
+
+print_dry_run_plan() {
+  log "Dry run: would install GitHub CLI if missing (skipped)."
+
+  if [ -n "$HELPER_OVERRIDE" ]; then
+    log "Dry run: would use $HELPER_OVERRIDE to download $ASSET_NAME into $OUTPUT_ARCHIVE."
+  else
+    local raw_base
+    raw_base="${SUGARKUBE_RAW_BASE_URL:-https://raw.githubusercontent.com/${OWNER}/${REPO}/main}"
+    log "Dry run: would download helper from ${raw_base}/scripts/download_pi_image.sh."
+    if [ "${#DOWNLOAD_ARGS[@]}" -gt 0 ]; then
+      local formatted
+      formatted="$(printf ' %q' "${DOWNLOAD_ARGS[@]}")"
+      formatted="${formatted# }"
+      log "Dry run: would run download helper with args: ${formatted}"
+    else
+      log "Dry run: would run download helper with default arguments."
+    fi
+  fi
+
+  log "Dry run: would verify checksum $CHECKSUM_NAME."
+  if [ "$DOWNLOAD_ONLY" -eq 1 ]; then
+    log "Dry run: would skip expansion (--download-only)."
+  else
+    log "Dry run: would expand archive to $IMAGE_DEST."
+  fi
+  log "Dry run: would write checksum to ${IMAGE_DEST}.sha256."
+}
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -318,6 +348,10 @@ while [ "$#" -gt 0 ]; do
       DOWNLOAD_ONLY=1
       shift
       ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
     --skip-gh-install)
       SKIP_GH_INSTALL=1
       shift
@@ -361,6 +395,11 @@ if [ -z "$IMAGE_DEST" ]; then
   else
     IMAGE_DEST="${OUTPUT_ARCHIVE}.img"
   fi
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  print_dry_run_plan
+  exit 0
 fi
 
 DEST_DIR="$(dirname "$OUTPUT_ARCHIVE")"

--- a/sugarkube_toolkit/cli.py
+++ b/sugarkube_toolkit/cli.py
@@ -308,9 +308,12 @@ def _handle_pi_install(args: argparse.Namespace) -> int:
     script_dry_run = "--dry-run" in script_args
 
     command = ["bash", str(script)]
+    if args.dry_run and not script_dry_run:
+        command.append("--dry-run")
     command.extend(script_args)
 
-    dry_run = args.dry_run or script_dry_run
+    # Always execute the helper so it can render its own dry-run preview.
+    dry_run = False
     try:
         runner.run_commands([command], dry_run=dry_run, cwd=REPO_ROOT)
     except runner.CommandError as exc:

--- a/tests/install_sugarkube_image_test.py
+++ b/tests/install_sugarkube_image_test.py
@@ -66,6 +66,23 @@ def make_release_payload(image: Path, checksum: Path) -> str:
     )
 
 
+def test_install_dry_run_previews_actions(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env.update({"HOME": str(tmp_path / "home")})
+
+    result = run_install(
+        args=["--dry-run", "--dir", str(tmp_path / "images")],
+        env=env,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    stdout = result.stdout
+    assert "Dry run: would download" in stdout
+    assert "Dry run: would expand archive" in stdout
+    assert not (tmp_path / "images").exists()
+
+
 def test_install_downloads_and_expands(tmp_path):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()

--- a/tests/test_sugarkube_toolkit_cli.py
+++ b/tests/test_sugarkube_toolkit_cli.py
@@ -452,8 +452,8 @@ def test_pi_install_invokes_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     expected_script = Path(__file__).resolve().parents[1] / "scripts" / "install_sugarkube_image.sh"
 
     assert exit_code == 0
-    assert recorded == [["bash", str(expected_script)]]
-    assert dry_run_flags == [True]
+    assert recorded == [["bash", str(expected_script), "--dry-run"]]
+    assert dry_run_flags == [False]
 
 
 def test_pi_install_forwards_additional_args(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -492,13 +492,14 @@ def test_pi_install_forwards_additional_args(monkeypatch: pytest.MonkeyPatch) ->
         [
             "bash",
             str(Path(__file__).resolve().parents[1] / "scripts" / "install_sugarkube_image.sh"),
+            "--dry-run",
             "--dir",
             "~/sugarkube/images",
             "--image",
             "~/sugarkube/images/sugarkube.img",
         ]
     ]
-    assert dry_run_flags == [True]
+    assert dry_run_flags == [False]
 
 
 def test_pi_install_reports_missing_script(
@@ -566,11 +567,12 @@ def test_pi_install_drops_script_separator(monkeypatch: pytest.MonkeyPatch) -> N
         [
             "bash",
             str(Path(__file__).resolve().parents[1] / "scripts" / "install_sugarkube_image.sh"),
+            "--dry-run",
             "--dir",
             "~/sugarkube/images",
         ]
     ]
-    assert dry_run_flags == [True]
+    assert dry_run_flags == [False]
 
 
 def test_pi_install_respects_existing_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -606,7 +608,7 @@ def test_pi_install_respects_existing_dry_run(monkeypatch: pytest.MonkeyPatch) -
             "~/images",
         ]
     ]
-    assert dry_run_flags == [True]
+    assert dry_run_flags == [False]
 
 
 def test_pi_install_uses_script_dry_run_without_cli_flag(
@@ -643,7 +645,7 @@ def test_pi_install_uses_script_dry_run_without_cli_flag(
             "~/images",
         ]
     ]
-    assert dry_run_flags == [True]
+    assert dry_run_flags == [False]
 
 
 def test_pi_flash_invokes_helper(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- teach `install_sugarkube_image.sh` to accept `--dry-run` and print the planned download/expand actions
- forward the CLI `--dry-run` flag to the installer and extend regression coverage
- refresh README, the script map, and the quickstart to document the preview behavior

## Testing
- python -m pre_commit run --all-files
- python -m pyspelling -c .spellcheck.yaml
- /root/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68e765e57fb8832f98cea1242e4aeef2