### PR TITLE
🖼️ Improve Start Here power flow diagram spacing

### DIFF
--- a/docs/images/sugarkube_diagram.svg
+++ b/docs/images/sugarkube_diagram.svg
@@ -1,7 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360">
+<svg xmlns="http://www.w3.org/2000/svg" width="1020" height="520" viewBox="0 0 1020 520">
   <defs>
-    <marker id="arrow" markerWidth="10" markerHeight="8" refX="8" refY="4"
-      orient="auto" markerUnits="strokeWidth">
+    <marker id="arrow" markerWidth="10" markerHeight="8" refX="8" refY="4" orient="auto"
+      markerUnits="strokeWidth">
       <path d="M0,0 L10,4 L0,8 z" fill="#1d4ed8" />
     </marker>
     <linearGradient id="panel" x1="0" x2="1" y1="0" y2="1">
@@ -9,111 +9,117 @@
       <stop offset="1" stop-color="#1e3a8a" />
     </linearGradient>
   </defs>
-  <rect x="0" y="0" width="640" height="360" fill="#f8fafc" />
+  <rect x="0" y="0" width="1020" height="520" fill="#f8fafc" />
   <g font-family="Inter,Arial,Helvetica,sans-serif" fill="#0f172a">
-    <text x="80" y="48" font-size="18" font-weight="600" text-anchor="middle">Sunlight</text>
-    <circle cx="80" cy="100" r="46" fill="#facc15" stroke="#ca8a04" stroke-width="4" />
+    <text x="140" y="56" font-size="20" font-weight="600" text-anchor="middle">Sunlight</text>
+    <circle cx="140" cy="124" r="54" fill="#facc15" stroke="#ca8a04" stroke-width="4" />
     <g stroke="#facc15" stroke-width="3">
-      <line x1="80" y1="48" x2="80" y2="18" />
-      <line x1="80" y1="152" x2="80" y2="182" />
-      <line x1="26" y1="100" x2="-4" y2="100" />
-      <line x1="134" y1="100" x2="164" y2="100" />
-      <line x1="46" y1="66" x2="20" y2="40" />
-      <line x1="114" y1="66" x2="140" y2="40" />
-      <line x1="46" y1="134" x2="20" y2="160" />
-      <line x1="114" y1="134" x2="140" y2="160" />
+      <line x1="140" y1="70" x2="140" y2="26" />
+      <line x1="140" y1="178" x2="140" y2="222" />
+      <line x1="80" y1="124" x2="30" y2="124" />
+      <line x1="200" y1="124" x2="250" y2="124" />
+      <line x1="106" y1="86" x2="64" y2="44" />
+      <line x1="174" y1="86" x2="216" y2="44" />
+      <line x1="106" y1="162" x2="64" y2="204" />
+      <line x1="174" y1="162" x2="216" y2="204" />
     </g>
 
-    <g transform="translate(210,40)">
-      <polygon points="0,110 110,50 220,110 110,170" fill="#e2e8f0" stroke="#475569"
+    <g transform="translate(300,70)">
+      <polygon points="0,120 120,50 240,120 120,190" fill="#e2e8f0" stroke="#475569"
         stroke-width="3" />
-      <polygon points="110,50 170,20 280,80 220,110" fill="#cbd5f5" stroke="#475569"
+      <polygon points="120,50 190,16 310,90 240,120" fill="#cbd5f5" stroke="#475569"
         stroke-width="3" />
-      <polygon points="0,110 110,50 170,20 60,80" fill="#dbeafe" stroke="#475569"
+      <polygon points="0,120 120,50 190,16 70,90" fill="#dbeafe" stroke="#475569"
         stroke-width="3" />
-      <rect x="46" y="98" width="58" height="40" fill="url(#panel)" stroke="#1e3a8a"
+      <rect x="56" y="108" width="70" height="44" fill="url(#panel)" stroke="#1e3a8a"
         stroke-width="2" />
-      <rect x="118" y="74" width="58" height="40" fill="url(#panel)" stroke="#1e3a8a"
+      <rect x="138" y="80" width="70" height="44" fill="url(#panel)" stroke="#1e3a8a"
         stroke-width="2" />
-      <rect x="178" y="92" width="58" height="40" fill="url(#panel)" stroke="#1e3a8a"
+      <rect x="206" y="102" width="70" height="44" fill="url(#panel)" stroke="#1e3a8a"
         stroke-width="2" />
-      <text x="140" y="210" font-size="18" font-weight="600" text-anchor="middle">
+      <text x="160" y="230" font-size="20" font-weight="600" text-anchor="middle">
         Sugarkube frame
       </text>
-      <text x="140" y="232" font-size="14" text-anchor="middle" fill="#475569">
+      <text x="160" y="254" font-size="15" text-anchor="middle" fill="#475569">
         Solar panels &amp; Pi enclosure
       </text>
     </g>
 
-    <g transform="translate(420,60)">
-      <rect x="0" y="0" width="150" height="80" rx="12" fill="#fef08a" stroke="#f59e0b"
+    <g transform="translate(660,110)">
+      <rect x="0" y="0" width="190" height="110" rx="18" fill="#fef08a" stroke="#f59e0b"
         stroke-width="3" />
-      <text x="75" y="36" font-size="18" text-anchor="middle" font-weight="600">
+      <text x="95" y="50" font-size="20" text-anchor="middle" font-weight="600">
         Charge controller
       </text>
+      <text x="95" y="78" font-size="14" text-anchor="middle" fill="#92400e">
+        MPPT &amp; regulation
+      </text>
     </g>
 
-    <g transform="translate(420,170)">
-      <rect x="0" y="0" width="150" height="90" rx="12" fill="#bae6fd" stroke="#0284c7"
+    <g transform="translate(660,270)">
+      <rect x="0" y="0" width="190" height="120" rx="18" fill="#bae6fd" stroke="#0284c7"
         stroke-width="3" />
-      <text x="75" y="38" font-size="18" text-anchor="middle" font-weight="600">
+      <text x="95" y="52" font-size="20" text-anchor="middle" font-weight="600">
         Batteries
       </text>
-      <text x="75" y="60" font-size="14" text-anchor="middle" fill="#1f2937">
+      <text x="95" y="78" font-size="15" text-anchor="middle" fill="#1f2937">
         Energy storage bank
       </text>
+      <text x="95" y="100" font-size="14" text-anchor="middle" fill="#1f2937">
+        LiFePO₄ pack &amp; BMS
+      </text>
     </g>
 
-    <g transform="translate(420,280)">
-      <rect x="0" y="0" width="150" height="80" rx="12" fill="#fef3c7" stroke="#d97706"
+    <g transform="translate(660,400)">
+      <rect x="0" y="0" width="190" height="100" rx="18" fill="#fef3c7" stroke="#d97706"
         stroke-width="3" />
-      <text x="75" y="34" font-size="16" text-anchor="middle" font-weight="600">
+      <text x="95" y="44" font-size="18" text-anchor="middle" font-weight="600">
         DC distribution
       </text>
-      <text x="75" y="56" font-size="14" text-anchor="middle" fill="#92400e">
-        Fuses &amp; wiring harness
+      <text x="95" y="70" font-size="15" text-anchor="middle" fill="#92400e">
+        Fuses, bus bars &amp; wiring
       </text>
     </g>
 
-    <g transform="translate(120,250)">
-      <path d="M50 0 C16 0 6 30 18 54 C30 76 50 82 50 82 C50 82 70 76 82 54 C94 30 84 0 50 0"
-        fill="#bbf7d0" stroke="#15803d" stroke-width="3" />
-      <path d="M112 16 C78 16 72 44 84 66 C96 86 112 92 112 92 C112 92 128 86 140 66 C152 44 146 16 112 16"
-        fill="#a7f3d0" stroke="#15803d" stroke-width="3" />
-      <text x="96" y="120" font-size="14" text-anchor="middle" fill="#166534">
-        Climbing plants
-      </text>
-    </g>
-
-    <g transform="translate(580,200)">
-      <rect x="-40" y="0" width="130" height="70" rx="12" fill="#bbf7d0" stroke="#16a34a"
+    <g transform="translate(860,290)">
+      <rect x="0" y="0" width="140" height="100" rx="18" fill="#bbf7d0" stroke="#16a34a"
         stroke-width="3" />
-      <text x="25" y="30" font-size="16" text-anchor="middle" font-weight="600">
+      <text x="70" y="44" font-size="18" text-anchor="middle" font-weight="600">
         Pi cluster
       </text>
-      <text x="25" y="50" font-size="14" text-anchor="middle" fill="#166534">
+      <text x="70" y="70" font-size="15" text-anchor="middle" fill="#166534">
         k3s + automation
       </text>
     </g>
 
-    <g transform="translate(580,300)">
-      <rect x="-40" y="0" width="130" height="70" rx="12" fill="#fde68a" stroke="#d97706"
+    <g transform="translate(860,420)">
+      <rect x="0" y="0" width="140" height="100" rx="18" fill="#fde68a" stroke="#d97706"
         stroke-width="3" />
-      <text x="25" y="30" font-size="16" text-anchor="middle" font-weight="600">
+      <text x="70" y="44" font-size="18" text-anchor="middle" font-weight="600">
         Aeration pumps
       </text>
-      <text x="25" y="50" font-size="14" text-anchor="middle" fill="#92400e">
+      <text x="70" y="70" font-size="15" text-anchor="middle" fill="#92400e">
         DC aquarium pumps
+      </text>
+    </g>
+
+    <g transform="translate(160,300)">
+      <path d="M60 0 C20 0 8 34 22 64 C34 88 60 96 60 96 C60 96 86 88 98 64 C112 34 100 0 60 0"
+        fill="#bbf7d0" stroke="#15803d" stroke-width="3" />
+      <path d="M136 22 C96 22 86 52 100 78 C114 100 136 108 136 108 C136 108 158 100 172 78 C186 52 176 22 136 22"
+        fill="#a7f3d0" stroke="#15803d" stroke-width="3" />
+      <text x="116" y="136" font-size="15" text-anchor="middle" fill="#166534">
+        Climbing plants
       </text>
     </g>
   </g>
 
   <g stroke="#1d4ed8" stroke-width="3" fill="none" marker-end="url(#arrow)">
-    <path d="M126 100 H210" />
-    <path d="M360 150 H420" />
-    <path d="M495 140 V170" />
-    <path d="M495 260 V280" />
-    <path d="M570 320 L610 320 L610 190 L605 190 L605 200" />
-    <path d="M570 320 L610 320 L610 290 L605 290 L605 300" />
+    <path d="M194 124 H300" />
+    <path d="M610 160 H660" />
+    <path d="M755 220 V270" />
+    <path d="M755 390 V400" />
+    <path d="M850 450 C900 450 910 360 930 330 L960 330" />
+    <path d="M850 470 H980" />
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- enlarge the Start Here SVG canvas so elements stop clipping
- spread the power path blocks and clarify outbound arrows to loads

## Testing
- pre-commit run --all-files (fails: command not found)
- pyspelling -c .spellcheck.yaml (fails: command not found)
- linkchecker --no-warnings README.md docs/ (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68e82e9ecf2c832fa528e2ab4f73179a