### PR TITLE
Restore make docs-verify automation and add regression test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ clone-ssd:
 	$(CLONE_CMD) --target "$(CLONE_TARGET)" $(CLONE_ARGS)
 
 docs-verify:
-        $(SUGARKUBE_CLI) docs verify $(DOCS_VERIFY_ARGS)
+	$(SUGARKUBE_CLI) docs verify $(DOCS_VERIFY_ARGS)
 
 docs-simplify:
 	$(CURDIR)/scripts/checks.sh --docs-only
@@ -110,29 +110,29 @@ monitor-ssd-health:
 	$(HEALTH_CMD) $(HEALTH_ARGS)
 
 smoke-test-pi:
-        $(SMOKE_CMD) $(SMOKE_ARGS)
+	$(SMOKE_CMD) $(SMOKE_ARGS)
 
 qemu-smoke:
-        @if [ -z "$(QEMU_SMOKE_IMAGE)" ]; then \
-                echo "Set QEMU_SMOKE_IMAGE to the built image (sugarkube.img or .img.xz)." >&2; \
-                exit 1; \
-        fi
-        sudo $(QEMU_SMOKE_CMD) --image "$(QEMU_SMOKE_IMAGE)" --artifacts-dir "$(QEMU_SMOKE_ARTIFACTS)" $(QEMU_SMOKE_ARGS)
+	@if [ -z "$(QEMU_SMOKE_IMAGE)" ]; then \
+		echo "Set QEMU_SMOKE_IMAGE to the built image (sugarkube.img or .img.xz)." >&2; \
+		exit 1; \
+	fi
+	sudo $(QEMU_SMOKE_CMD) --image "$(QEMU_SMOKE_IMAGE)" --artifacts-dir "$(QEMU_SMOKE_ARTIFACTS)" $(QEMU_SMOKE_ARGS)
 
 field-guide:
-        $(FIELD_GUIDE_CMD) $(FIELD_GUIDE_ARGS)
+	$(FIELD_GUIDE_CMD) $(FIELD_GUIDE_ARGS)
 
 publish-telemetry:
-        $(TELEMETRY_CMD) $(TELEMETRY_ARGS)
+	$(TELEMETRY_CMD) $(TELEMETRY_ARGS)
 
 notify-teams:
-        $(TEAMS_CMD) $(TEAMS_ARGS)
+	$(TEAMS_CMD) $(TEAMS_ARGS)
 
 notify-workflow:
-        $(WORKFLOW_NOTIFY_CMD) $(WORKFLOW_NOTIFY_ARGS)
+	$(WORKFLOW_NOTIFY_CMD) $(WORKFLOW_NOTIFY_ARGS)
 
 update-hardware-badge:
-        $(BADGE_CMD) $(BADGE_ARGS)
+	$(BADGE_CMD) $(BADGE_ARGS)
 
 rehearse-join:
 	$(REHEARSAL_CMD) $(REHEARSAL_ARGS)
@@ -144,11 +144,11 @@ token-place-samples:
 	$(TOKEN_PLACE_SAMPLE_CMD) $(TOKEN_PLACE_SAMPLE_ARGS)
 
 support-bundle:
-        @if [ -z "$(SUPPORT_BUNDLE_HOST)" ]; then \
-        echo "Set SUPPORT_BUNDLE_HOST to the target host (e.g. pi.local) before running support-bundle." >&2; \
-        exit 1; \
-        fi
-        $(SUPPORT_BUNDLE_CMD) "$(SUPPORT_BUNDLE_HOST)" $(SUPPORT_BUNDLE_ARGS)
+	@if [ -z "$(SUPPORT_BUNDLE_HOST)" ]; then \
+		echo "Set SUPPORT_BUNDLE_HOST to the target host (e.g. pi.local) before running support-bundle." >&2; \
+		exit 1; \
+	fi
+	$(SUPPORT_BUNDLE_CMD) "$(SUPPORT_BUNDLE_HOST)" $(SUPPORT_BUNDLE_ARGS)
 
 mac-setup:
-        $(MAC_SETUP_CMD) $(MAC_SETUP_ARGS)
+	$(MAC_SETUP_CMD) $(MAC_SETUP_ARGS)

--- a/README.md
+++ b/README.md
@@ -222,7 +222,8 @@ Prefer the unified CLI? `python -m sugarkube_toolkit docs simplify [--dry-run] [
 wraps the same `scripts/checks.sh --docs-only` helper so you can stay inside a single entry point.
 Additional arguments after `--` are forwarded directly to the script.
 Regression coverage: `tests/checks_script_test.py::test_runs_js_checks_when_package_lock_present`
-verifies the helper runs `npm run test:ci` alongside linting and formatting when Node tooling exists.
+verifies the helper runs `npm run test:ci` alongside linting and formatting when Node tooling exists, and
+`tests/test_docs_verify_wrapper.py::test_make_docs_verify_runs_cli` exercises the Make target in dry-run mode so these instructions stay accurate.
 
 The `--no-warnings` flag prevents linkchecker from returning a non-zero exit code on benign Markdown
 parsing warnings.

--- a/tests/test_docs_verify_wrapper.py
+++ b/tests/test_docs_verify_wrapper.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 
@@ -36,3 +37,20 @@ def test_docs_verify_wrappers_invoke_unified_cli() -> None:
     assert (
         '"{{sugarkube_cli}}" docs verify' in justfile_text
     ), "Just docs-verify recipe should call the CLI subcommand"
+
+
+def test_make_docs_verify_runs_cli() -> None:
+    """The Makefile target should execute the CLI in dry-run mode."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        ["make", "docs-verify", "DOCS_VERIFY_ARGS=--dry-run"],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "$ pyspelling -c .spellcheck.yaml" in result.stdout
+    assert "$ linkchecker --no-warnings README.md docs/" in result.stdout

--- a/tests/test_start_here_doc.py
+++ b/tests/test_start_here_doc.py
@@ -51,11 +51,7 @@ def test_start_here_doc_embeds_architecture_diagram() -> None:
         "images/sugarkube_diagram.svg" in text
     ), "Start-here guide should reference the shared architecture diagram asset"
     lines = text.splitlines()
-    diagram_lines = [
-        line
-        for line in lines
-        if "![Sugarkube architecture overview" in line
-    ]
+    diagram_lines = [line for line in lines if "![Sugarkube architecture overview" in line]
     assert diagram_lines, "Diagram embed should reside on a single Markdown line"
     assert all(
         ")](images/sugarkube_diagram.svg)" in line or "(images/sugarkube_diagram.svg)" in line

--- a/tests/test_svg_assets.py
+++ b/tests/test_svg_assets.py
@@ -10,11 +10,7 @@ SVG_DIRS = [
 
 
 def test_svg_assets_parse_cleanly() -> None:
-    svg_paths = [
-        path
-        for directory in SVG_DIRS
-        for path in sorted(directory.glob("*.svg"))
-    ]
+    svg_paths = [path for directory in SVG_DIRS for path in sorted(directory.glob("*.svg"))]
     assert svg_paths, "Expected at least one SVG asset to validate"
 
     for svg_path in svg_paths:


### PR DESCRIPTION
## Summary
- retab the Makefile recipes so `make docs-verify` and `make start-here` work again
- add a regression test for the Makefile docs target and reference it in the README
- format the Start Here and SVG test fixtures with black to satisfy repo checks

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68e86dd373dc832faf94ca408d1bc597