### PR TITLE
Add onboarding notes workspace guard

### DIFF
--- a/docs/templates/simplification/onboarding-update.md
+++ b/docs/templates/simplification/onboarding-update.md
@@ -13,6 +13,9 @@
   `./scripts/sugarkube docs start-here --path-only` when working in a subdirectory)
   reflects the new path and prints the updated guidance. The Make/Just wrappers now
   defer to `sugarkube docs start-here`, keeping their output aligned with the CLI.
+- Update `notes/README.md` (guarded by `tests/test_notes_directory.py`) with links to
+  any onboarding evidence you add under `notes/` so collaborators can follow the
+  breadcrumbs left by this template.
 - Screenshots or recordings that walk through the refreshed flow.
 
 ## Stakeholders

--- a/notes/README.md
+++ b/notes/README.md
@@ -1,0 +1,27 @@
+# Sugarkube Notes Workspace
+
+Use this directory to capture working notes that tutorials and simplification
+prompts reference. Templates such as
+[`docs/templates/simplification/onboarding-update.md`](../docs/templates/simplification/onboarding-update.md)
+expect onboarding updates, retrospective summaries, and other lab evidence to
+live under `notes/` (for example, `notes/onboarding/feature-brief.md`). Keeping
+these artifacts versioned alongside the codebase makes it easier to audit
+improvements and share context with reviewers.
+
+## Structure
+
+- `onboarding/` — track feature briefs, lab journals, and retrospective notes
+  produced while following the onboarding update template.
+- Additional subdirectories — feel free to add project-specific folders (for
+  example, `notes/tests/` or `notes/research/`) while keeping sensitive data out
+  of the repository.
+
+## Maintenance
+
+- Reference the onboarding update template when adding new material so the
+  evidence matches expectations.
+- Leave clear README files inside newly created subdirectories that explain
+  their purpose and any redaction requirements.
+- Regression coverage:
+  `tests/test_notes_directory.py` ensures this workspace and index remain in
+  place.

--- a/tests/test_notes_directory.py
+++ b/tests/test_notes_directory.py
@@ -1,0 +1,23 @@
+"""Ensure the notes workspace exists for onboarding evidence."""
+
+from pathlib import Path
+
+
+def test_notes_directory_exists() -> None:
+    """notes/ should exist so templates referencing it remain accurate."""
+
+    notes_dir = Path("notes")
+    assert notes_dir.is_dir(), "notes/ directory should exist for onboarding archives"
+
+    readme = notes_dir / "README.md"
+    assert readme.is_file(), "notes/README.md should document the workspace"
+
+    text = readme.read_text(encoding="utf-8")
+    lower = text.lower()
+    assert "onboarding" in lower, "notes README should call out onboarding evidence"
+    assert (
+        "docs/templates/simplification/onboarding-update.md" in text
+    ), "notes README should point to the onboarding update template"
+    assert (
+        "tests/test_notes_directory.py" in text
+    ), "notes README should record the regression coverage for this workspace"

--- a/tests/test_start_here_doc.py
+++ b/tests/test_start_here_doc.py
@@ -51,11 +51,7 @@ def test_start_here_doc_embeds_architecture_diagram() -> None:
         "images/sugarkube_diagram.svg" in text
     ), "Start-here guide should reference the shared architecture diagram asset"
     lines = text.splitlines()
-    diagram_lines = [
-        line
-        for line in lines
-        if "![Sugarkube architecture overview" in line
-    ]
+    diagram_lines = [line for line in lines if "![Sugarkube architecture overview" in line]
     assert diagram_lines, "Diagram embed should reside on a single Markdown line"
     assert all(
         ")](images/sugarkube_diagram.svg)" in line or "(images/sugarkube_diagram.svg)" in line

--- a/tests/test_svg_assets.py
+++ b/tests/test_svg_assets.py
@@ -10,11 +10,7 @@ SVG_DIRS = [
 
 
 def test_svg_assets_parse_cleanly() -> None:
-    svg_paths = [
-        path
-        for directory in SVG_DIRS
-        for path in sorted(directory.glob("*.svg"))
-    ]
+    svg_paths = [path for directory in SVG_DIRS for path in sorted(directory.glob("*.svg"))]
     assert svg_paths, "Expected at least one SVG asset to validate"
 
     for svg_path in svg_paths:


### PR DESCRIPTION
## Summary
- add a notes/ README that explains how to file onboarding evidence alongside the docs
- guard the workspace with tests/test_notes_directory.py so the template reference stays accurate
- note the regression coverage in the onboarding update template and align existing comprehension formatting with black

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py


------
https://chatgpt.com/codex/tasks/task_e_68e86dd373dc832faf94ca408d1bc597