### PR TITLE
✨ : – Handle Start Here BOM stripping

### DIFF
--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -55,7 +55,8 @@ docs apply to you.
 > wrapper bootstraps `PYTHONPATH` before forwarding to the CLI.
 > When using the Make/Just wrappers, forward `START_HERE_ARGS="--path-only"`
 > so they pass the flag through (for example, `make start-here START_HERE_ARGS="--path-only"`).
-> The CLI hides the YAML front matter so you only see the handbook content in your terminal output.
+> The CLI hides the YAML front matter so you only see the handbook content in your terminal output,
+> even when a UTF-8 BOM slips in from Windows editors.
 > Skim this track the moment you clone the repository. It orients you before you touch any
 > automation.
 

--- a/scripts/start_here.py
+++ b/scripts/start_here.py
@@ -51,6 +51,9 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _strip_front_matter(text: str) -> str:
+    if text.startswith("\ufeff"):
+        text = text[1:]
+
     if not text.lstrip().startswith("---"):
         return text
 

--- a/sugarkube_toolkit/cli.py
+++ b/sugarkube_toolkit/cli.py
@@ -254,6 +254,9 @@ def _normalize_script_args(args: Sequence[str]) -> list[str]:
 
 
 def _strip_front_matter(text: str) -> str:
+    if text.startswith("\ufeff"):
+        text = text[1:]
+
     if not text.lstrip().startswith("---"):
         return text
 

--- a/tests/test_start_here_command.py
+++ b/tests/test_start_here_command.py
@@ -71,6 +71,14 @@ def test_strip_front_matter_returns_original_when_unclosed() -> None:
     assert start_here._strip_front_matter(text) == text
 
 
+def test_strip_front_matter_handles_bom() -> None:
+    """Leading UTF-8 BOM markers should be ignored when stripping metadata."""
+
+    text = "\ufeff---\nowner: start-here\n---\nWelcome"
+
+    assert start_here._strip_front_matter(text) == "Welcome"
+
+
 def test_start_here_main_path_only_alias(tmp_path, capsys, monkeypatch) -> None:
     """The deprecated --no-content flag should continue to emit the path."""
 

--- a/tests/test_sugarkube_toolkit_cli.py
+++ b/tests/test_sugarkube_toolkit_cli.py
@@ -274,6 +274,14 @@ def test_docs_strip_front_matter_passthrough_when_unclosed() -> None:
     assert cli._strip_front_matter(text) == text
 
 
+def test_docs_strip_front_matter_handles_bom() -> None:
+    """The CLI should drop UTF-8 BOM markers before removing metadata."""
+
+    text = "\ufeff---\nowner: cli\n---\nHello Sugarkube"
+
+    assert cli._strip_front_matter(text) == "Hello Sugarkube"
+
+
 def test_docs_start_here_handles_missing_doc(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
what: ensure start-here CLI/script strip BOM before metadata
why: docs promise front matter stays hidden even on Windows saves
how to test: pre-commit run --all-files
  pyspelling -c .spellcheck.yaml
  linkchecker --no-warnings README.md docs/
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68e992f7703c832f8a372977e9cb90cc