### PR TITLE
Add onboarding notes scaffold

### DIFF
--- a/notes/README.md
+++ b/notes/README.md
@@ -11,7 +11,10 @@ improvements and share context with reviewers.
 ## Structure
 
 - `onboarding/` — track feature briefs, lab journals, and retrospective notes
-  produced while following the onboarding update template.
+  produced while following the onboarding update template. The directory ships
+  with a `README.md` and seed `feature-brief.md` so docs referencing this path
+  stay accurate. Regression coverage lives in
+  `tests/test_notes_directory.py::test_onboarding_feature_brief_stub_exists`.
 - Additional subdirectories — feel free to add project-specific folders (for
   example, `notes/tests/` or `notes/research/`) while keeping sensitive data out
   of the repository.

--- a/notes/onboarding/README.md
+++ b/notes/onboarding/README.md
@@ -1,0 +1,23 @@
+# Onboarding Feature Briefs
+
+Use this workspace to capture the lab evidence produced while following the
+[simplification onboarding update template](../../docs/templates/simplification/onboarding-update.md).
+Each brief should summarize the feature, outline the failing or missing behavior
+observed during onboarding, and record the remediation you shipped. Keeping the
+notes alongside the codebase makes it easy to audit improvements and revisit
+decisions during retrospectives.
+
+## Getting started
+
+1. Copy `docs/templates/simplification/onboarding-update.md` into this folder and
+   tailor it for the work you are documenting (for example,
+   `feature-brief-<date>.md`).
+2. Replace placeholder prompts with concrete evidence: command transcripts,
+   screenshots, links to workflow runs, and references to supporting PRs.
+3. Remove sensitive data (tokens, hostnames, or private URLs) before committing.
+4. Link the completed brief from the corresponding pull request description so
+   reviewers can trace context quickly.
+
+A seed brief (`feature-brief.md`) lives beside this README to provide a starting
+point. Regression coverage: `tests/test_notes_directory.py::test_onboarding_feature_brief_stub_exists`
+ensures this workspace stays in sync with the documentation.

--- a/notes/onboarding/feature-brief.md
+++ b/notes/onboarding/feature-brief.md
@@ -1,0 +1,10 @@
+# Feature Brief Placeholder
+
+Start each onboarding investigation by copying
+`docs/templates/simplification/onboarding-update.md` into this workspace and
+renaming it to match the effort (for example,
+`feature-brief-2025-03-15.md`). Replace this placeholder with the populated
+brief once you have documented the context, failing behavior, reproduction
+steps, remediation plan, and follow-up actions. Keeping a committed stub ensures
+repository documentation that references `notes/onboarding/feature-brief.md`
+remains accurate until your first brief lands.

--- a/tests/test_notes_directory.py
+++ b/tests/test_notes_directory.py
@@ -21,3 +21,23 @@ def test_notes_directory_exists() -> None:
     assert (
         "tests/test_notes_directory.py" in text
     ), "notes README should record the regression coverage for this workspace"
+
+
+def test_onboarding_feature_brief_stub_exists() -> None:
+    """The onboarding workspace should provide a feature brief scaffold."""
+
+    onboarding_dir = Path("notes") / "onboarding"
+    assert onboarding_dir.is_dir(), "notes/onboarding/ should exist for onboarding feature briefs"
+
+    readme = onboarding_dir / "README.md"
+    assert readme.is_file(), "notes/onboarding/README.md should explain how to use the workspace"
+
+    feature_brief = onboarding_dir / "feature-brief.md"
+    assert (
+        feature_brief.is_file()
+    ), "Seed notes/onboarding/feature-brief.md so docs referencing it stay accurate"
+
+    text = feature_brief.read_text(encoding="utf-8")
+    assert (
+        "docs/templates/simplification/onboarding-update.md" in text
+    ), "Feature brief stub should link back to the onboarding update template"


### PR DESCRIPTION
## Summary
- seed `notes/onboarding/` with a README and feature-brief placeholder so docs pointing at the path stay accurate
- highlight the new scaffold and regression coverage in `notes/README.md`
- extend `tests/test_notes_directory.py` to guard the onboarding workspace stub

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68e992f7703c832f8a372977e9cb90cc