### PR TITLE
Align support-bundle dry-run preview with docs

### DIFF
--- a/docs/pi_support_bundles.md
+++ b/docs/pi_support_bundles.md
@@ -49,8 +49,10 @@ Drop `--dry-run` to collect artefacts immediately. Arguments after the standalon
 `scripts/collect_support_bundle.py`, matching the behaviour described above.
 Regression coverage in
 `tests/test_sugarkube_toolkit_cli.py::test_pi_support_bundle_invokes_helper`
-ensures the CLI forwards `--dry-run` to the helper so the preview matches the
-documented workflow.
+prints the helper invocation with `--dry-run` so the preview matches the
+documented workflow, while
+`tests/test_sugarkube_toolkit_cli.py::test_pi_support_bundle_filters_helper_dry_run_flag`
+keeps the flag deduplicated when callers forward their own `--` arguments.
 
 The script stores results under `support-bundles/<host>-<timestamp>/` and also emits a matching
 `.tar.gz`. Override `--no-archive` to keep only the raw directory, and `--spec` to append extra

--- a/sugarkube_toolkit/cli.py
+++ b/sugarkube_toolkit/cli.py
@@ -443,10 +443,13 @@ def _handle_pi_support_bundle(args: argparse.Namespace) -> int:
         return 1
 
     script_args = _normalize_script_args(getattr(args, "script_args", []))
+    command: list[str] = [sys.executable, str(script)]
+
     if args.dry_run:
         script_args = [arg for arg in script_args if arg != "--dry-run"]
+        command.append("--dry-run")
 
-    command = [sys.executable, str(script), *script_args]
+    command.extend(script_args)
 
     dry_run = args.dry_run
     try:

--- a/tests/test_sugarkube_toolkit_cli.py
+++ b/tests/test_sugarkube_toolkit_cli.py
@@ -1087,7 +1087,7 @@ def test_pi_support_bundle_invokes_helper(monkeypatch: pytest.MonkeyPatch) -> No
     expected_script = Path(__file__).resolve().parents[1] / "scripts" / "collect_support_bundle.py"
 
     assert exit_code == 0
-    assert recorded == [[sys.executable, str(expected_script), "pi.local"]]
+    assert recorded == [[sys.executable, str(expected_script), "--dry-run", "pi.local"]]
     assert dry_run_flags == [True]
 
 
@@ -1115,6 +1115,7 @@ def test_pi_support_bundle_forwards_additional_args(monkeypatch: pytest.MonkeyPa
             "pi",
             "support-bundle",
             "--dry-run",
+            "--dry-run",
             "pi-a.local",
             "--identity",
             "~/.ssh/id_ed25519",
@@ -1126,6 +1127,7 @@ def test_pi_support_bundle_forwards_additional_args(monkeypatch: pytest.MonkeyPa
         [
             sys.executable,
             str(Path(__file__).resolve().parents[1] / "scripts" / "collect_support_bundle.py"),
+            "--dry-run",
             "pi-a.local",
             "--identity",
             "~/.ssh/id_ed25519",
@@ -1198,6 +1200,7 @@ def test_pi_support_bundle_drops_script_separator(monkeypatch: pytest.MonkeyPatc
             "support-bundle",
             "--dry-run",
             "--",
+            "--dry-run",
             "pi-b.local",
             "--output-dir",
             "~/support-bundles",
@@ -1209,6 +1212,7 @@ def test_pi_support_bundle_drops_script_separator(monkeypatch: pytest.MonkeyPatc
         [
             sys.executable,
             str(Path(__file__).resolve().parents[1] / "scripts" / "collect_support_bundle.py"),
+            "--dry-run",
             "pi-b.local",
             "--output-dir",
             "~/support-bundles",
@@ -1218,7 +1222,7 @@ def test_pi_support_bundle_drops_script_separator(monkeypatch: pytest.MonkeyPatc
 
 
 def test_pi_support_bundle_filters_helper_dry_run_flag(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Drop helper-level --dry-run during CLI previews to avoid script errors."""
+    """Preview should include --dry-run exactly once even when callers forward it."""
 
     recorded: list[list[str]] = []
     dry_run_flags: list[bool] = []
@@ -1252,6 +1256,7 @@ def test_pi_support_bundle_filters_helper_dry_run_flag(monkeypatch: pytest.Monke
         [
             sys.executable,
             str(Path(__file__).resolve().parents[1] / "scripts" / "collect_support_bundle.py"),
+            "--dry-run",
             "pi-c.local",
         ]
     ]


### PR DESCRIPTION
what: ensure the support-bundle CLI preview prints --dry-run and keep docs/tests in sync.
why: docs promised the preview forwarded --dry-run so contributors could copy the command verbatim.
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/; git diff --cached | ./scripts/scan-secrets.py.


------
https://chatgpt.com/codex/tasks/task_e_68e9cb7e8438832f88dcfa699d2608c7