### PR TITLE
Add operations security checklist and regression test

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,8 @@ Review the safety notes before working with power components.
 - [raspi_cluster_setup.md](raspi_cluster_setup.md) — build a three-node k3s cluster and deploy apps
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
 - [projects-compose.md](projects-compose.md) — run token.place & dspace via docker compose
+- [operations/security-checklist.md](operations/security-checklist.md) — track credential rotations and
+  verification steps
 - [pi_token_dspace.md](pi_token_dspace.md) — build and expose token.place & dspace via Cloudflare
 - [token_place_sample_datasets.md](token_place_sample_datasets.md) — replay bundled
   token.place health and chat samples

--- a/docs/operations/security-checklist.md
+++ b/docs/operations/security-checklist.md
@@ -1,0 +1,65 @@
+---
+personas:
+  - software
+---
+
+# Sugarkube Operations Security Checklist
+
+Use this checklist when rotating credentials, auditing access, or closing out Tutorial 13's
+"Optimise and secure the expanded cluster" milestone. Copy the template into your lab evidence
+repository (for example, `~/sugarkube-labs/tutorial-13/operations/security-checklist.md`) so every
+rotation leaves an auditable trail you can reference during incident reviews or future proposals.
+
+## How to Use This Checklist
+- Print or copy this file before starting a maintenance window.
+- Record the date, operators involved, and the target nodes in the evidence log below.
+- Mark each checkbox as you complete the tasks. Capture command output in your lab repo or support
+  bundle archives.
+- When running in production, coordinate changes in the team's Slack channel and link the run log
+  from the relevant pull request or outage ticket.
+
+## Rotation Checklist
+- [ ] Announce the rotation window and confirm observers are monitoring `kubectl get events -A`.
+- [ ] Generate fresh host keys and admin key pairs:
+  ```bash
+  sudo ssh-keygen -A
+  ssh-keygen -t ed25519 -f ~/.ssh/sugarkube-admin-$(date +%Y%m%d) -C "sugarkube admin"
+  ```
+- [ ] Replace stale `authorized_keys` entries and remove any unused local accounts.
+- [ ] Capture fingerprints for the new host keys and publish them in the run log:
+  ```bash
+  sudo ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub
+  ```
+- [ ] Restart SSHD and confirm the unit is healthy: `sudo systemctl restart ssh && sudo systemctl
+  status ssh`.
+- [ ] Update downstream automation secrets (for example, GitHub deploy keys, CI runners, or
+  Cloudflare tunnels) with the refreshed credentials.
+
+## Verification Checklist
+- [ ] Connect with `ssh -o StrictHostKeyChecking=yes` from a clean workstation to validate the new
+  fingerprint.
+- [ ] Run `kubectl get nodes -o wide` and `kubectl top nodes` to confirm cluster health after the
+  rotation.
+- [ ] Review `sudo journalctl -u ssh --since "-15 minutes"` for authentication failures or restart
+  loops.
+- [ ] Spot-check `projects-compose.service` and other long-running workloads:
+  `sudo systemctl status projects-compose.service`.
+- [ ] Trigger a short `fio` read test (matching Tutorial 13) to ensure storage throughput remains in
+  the expected range.
+
+## Evidence Log
+Document every rotation so future audits and proposals can trace the changes.
+
+| Date | Host | Fingerprint | Method | Notes |
+| --- | --- | --- | --- | --- |
+| YYYY-MM-DD | pi-controller | SHA256:examplefingerprint | ssh-keygen -lf | Rotated during Tutorial 13 |
+
+| Date | Activity | Impact | Follow-up |
+| --- | --- | --- | --- |
+| YYYY-MM-DD | Restarted sshd | No downtime | Schedule quarterly rotation reminders |
+
+## References
+- [Pi Support Bundles](../pi_support_bundles.md) — capture evidence before and after rotations.
+- [projects-compose.md](../projects-compose.md) — verify compose workloads after credential updates.
+- [pi_multi_node_join_rehearsal.md](../pi_multi_node_join_rehearsal.md) — rehearse recovery joins with
+  the new tokens.

--- a/docs/software/index.md
+++ b/docs/software/index.md
@@ -34,6 +34,8 @@ and supporting services stay healthy.
   rollout covering hardware prep through k3s readiness.
 - [Pi Support Bundles](../pi_support_bundles.md) — collect evidence for
   debugging.
+- [operations/security-checklist.md](../operations/security-checklist.md) — record
+  credential rotations and post-maintenance evidence.
 - [projects-compose.md](../projects-compose.md) — run token.place and dspace via
   Docker Compose.
 - [pi_token_dspace.md](../pi_token_dspace.md) — expose token.place/dspace through

--- a/docs/tutorials/tutorial-13-advanced-operations-future-directions.md
+++ b/docs/tutorials/tutorial-13-advanced-operations-future-directions.md
@@ -504,7 +504,8 @@ can reference them while writing future proposals.
 
 4. Harden remote access by replacing SSH credential pairs and disabling keyboard-interactive logins.
    Follow the procedure you documented in Tutorial 11 and update
-   `operations/security-checklist.md` with the date and fingerprint details.
+   [`operations/security-checklist.md`](../operations/security-checklist.md) with the date and
+   fingerprint details.
 
 5. Take a final cluster snapshot:
 
@@ -525,7 +526,8 @@ Use this checklist to confirm you met the roadmap milestones.
 - [ ] Failure-injection exercise: simulated node disruption recovered without data loss,
       with findings logged in `storage/failover-report.md`.
 - [ ] Advanced roadmap update: drafted `edge-ai/tuning-experiments.md` and
-      `operations/security-checklist.md` summarising optimisation insights and proposed next steps.
+      [`operations/security-checklist.md`](../operations/security-checklist.md) summarising
+      optimisation insights and proposed next steps.
 
 ## Next Steps
 You now possess the full Sugarkube lifecycle—from first boot to advanced experimentation. Continue

--- a/tests/test_doc_personas.py
+++ b/tests/test_doc_personas.py
@@ -38,6 +38,7 @@ PERSONA_EXPECTATIONS = {
     Path("docs/pi_support_bundles.md"): ["hardware", "software"],
     Path("docs/pi_token_dspace.md"): ["software"],
     Path("docs/pi_workflow_notifications.md"): ["software"],
+    Path("docs/operations/security-checklist.md"): ["software"],
     Path("docs/power_system_design.md"): ["hardware"],
     Path("docs/projects-compose.md"): ["software"],
     Path("docs/raspi_cluster_setup.md"): ["hardware", "software"],

--- a/tests/test_operations_security_checklist.py
+++ b/tests/test_operations_security_checklist.py
@@ -1,0 +1,22 @@
+"""Ensure the operations security checklist delivers the promised guidance."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_operations_security_checklist_exists_and_guides_rotations() -> None:
+    """Tutorial 13 references the checklist; it must exist with key sections."""
+
+    checklist = Path("docs/operations/security-checklist.md")
+    text = checklist.read_text(encoding="utf-8")
+
+    assert "# Sugarkube Operations Security Checklist" in text
+    assert "## Rotation Checklist" in text
+    assert "ssh-keygen -lf" in text, "Fingerprint capture guidance missing"
+    assert (
+        "~/sugarkube-labs/tutorial-13/operations/security-checklist.md" in text
+    ), "Tutorial 13 run log location missing"
+    assert "## Verification Checklist" in text
+    assert "| Date | Host | Fingerprint | Method | Notes |" in text
+    assert "## Evidence Log" in text


### PR DESCRIPTION
## Summary
- add the missing `docs/operations/security-checklist.md` that Tutorial 13 references so operators can log SSH rotations and verification evidence
- link the new checklist from the main docs index, the software hub, and the tutorial steps that instruct users to update it
- add regression coverage ensuring the checklist exists, includes rotation and verification guidance, and tag the page in the persona expectations table

## Testing
- `python -m pre_commit run --all-files`
- `pytest tests/test_operations_security_checklist.py`
- `python -m pyspelling -c .spellcheck.yaml`
- `/root/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md docs/`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68e9cb7e8438832f88dcfa699d2608c7