### PR TITLE
Add notes feature brief pointer and tests

### DIFF
--- a/notes/README.md
+++ b/notes/README.md
@@ -15,6 +15,10 @@ improvements and share context with reviewers.
   with a `README.md` and seed `feature-brief.md` so docs referencing this path
   stay accurate. Regression coverage lives in
   `tests/test_notes_directory.py::test_onboarding_feature_brief_stub_exists`.
+- `feature-brief.md` — top-level pointer used by tutorials that reference
+  `notes/feature-brief.md`. It links directly to the onboarding workspace and
+  is covered by
+  `tests/test_notes_directory.py::test_feature_brief_redirect_stub_exists`.
 - Additional subdirectories — feel free to add project-specific folders (for
   example, `notes/tests/` or `notes/research/`) while keeping sensitive data out
   of the repository.

--- a/notes/feature-brief.md
+++ b/notes/feature-brief.md
@@ -1,0 +1,14 @@
+# Feature Brief Index
+
+Documentation references `notes/feature-brief.md` when describing how to record
+onboarding investigations. This stub keeps those links accurate by pointing to
+the maintained template under `notes/onboarding/feature-brief.md`.
+
+Use the onboarding workspace directly:
+
+- [notes/onboarding/feature-brief.md](onboarding/feature-brief.md) — seed brief
+  that mirrors the onboarding template.
+- [docs/templates/simplification/onboarding-update.md](../docs/templates/simplification/onboarding-update.md)
+  — copy this when you start documenting a change.
+
+When you create your first brief, replace the stub inside `notes/onboarding/`.

--- a/tests/test_notes_directory.py
+++ b/tests/test_notes_directory.py
@@ -41,3 +41,15 @@ def test_onboarding_feature_brief_stub_exists() -> None:
     assert (
         "docs/templates/simplification/onboarding-update.md" in text
     ), "Feature brief stub should link back to the onboarding update template"
+
+
+def test_feature_brief_redirect_stub_exists() -> None:
+    """Docs reference notes/feature-brief.md; ensure a pointer exists."""
+
+    stub = Path("notes") / "feature-brief.md"
+    assert stub.is_file(), "Add notes/feature-brief.md so tutorial references remain accurate"
+
+    text = stub.read_text(encoding="utf-8")
+    assert (
+        "notes/onboarding/feature-brief.md" in text
+    ), "Feature brief stub should point to notes/onboarding/feature-brief.md"


### PR DESCRIPTION
## Summary
- add a top-level notes/feature-brief.md pointer so tutorial references resolve
- document the pointer in notes/README.md alongside existing regression coverage
- guard the pointer with a regression test under tests/test_notes_directory.py

## Testing
- python -m pre_commit run --all-files
- python -m pyspelling -c .spellcheck.yaml
- /root/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68e9cb7e8438832f88dcfa699d2608c7