### PR TITLE
Add Make validate-ssd-clone wrapper and regression test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ DOCS_VERIFY_ARGS ?=
 DOCS_SIMPLIFY_ARGS ?=
 
 .PHONY: install-pi-image download-pi-image flash-pi flash-pi-report doctor start-here rollback-to-sd \
-        clone-ssd docs-verify docs-simplify qr-codes monitor-ssd-health smoke-test-pi qemu-smoke field-guide \
+        clone-ssd validate-ssd-clone docs-verify docs-simplify qr-codes monitor-ssd-health smoke-test-pi qemu-smoke field-guide \
         publish-telemetry notify-teams notify-workflow update-hardware-badge rehearse-join \
         token-place-samples support-bundle mac-setup cluster-up cluster-bootstrap codespaces-bootstrap
 
@@ -93,6 +93,9 @@ clone-ssd:
 		exit 1; \
 	fi
 	$(CLONE_CMD) --target "$(CLONE_TARGET)" $(CLONE_ARGS)
+
+validate-ssd-clone:
+	$(VALIDATE_CMD) $(VALIDATE_ARGS)
 
 docs-verify:
 	$(SUGARKUBE_CLI) docs verify $(DOCS_VERIFY_ARGS)

--- a/docs/ssd_post_clone_validation.md
+++ b/docs/ssd_post_clone_validation.md
@@ -59,6 +59,9 @@ reports elsewhere:
 sudo VALIDATE_ARGS='--stress-mb 512 --report-dir /mnt/ssd-reports' make validate-ssd-clone
 ```
 
+Regression coverage: `tests/test_validate_ssd_make_target.py` ensures the Make wrapper remains wired
+up.
+
 ## Customize the run
 
 Key flags exposed by `ssd_post_clone_validate.py`:

--- a/tests/test_validate_ssd_make_target.py
+++ b/tests/test_validate_ssd_make_target.py
@@ -1,0 +1,21 @@
+"""Ensure the Makefile exposes the SSD validation helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_makefile_includes_validate_ssd_clone_target() -> None:
+    """The Makefile wrapper should mirror the documented sudo make command."""
+
+    makefile_text = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+
+    assert "validate-ssd-clone:" in makefile_text, "Add a validate-ssd-clone target to the Makefile"
+    assert (
+        "$(VALIDATE_CMD) $(VALIDATE_ARGS)" in makefile_text
+    ), "Make validate-ssd-clone target should invoke the validation helper"
+    assert (
+        "validate-ssd-clone" in makefile_text.split(".PHONY:", maxsplit=1)[1]
+    ), ".PHONY list should include validate-ssd-clone"


### PR DESCRIPTION
What:
- add a validate-ssd-clone Make target that shells into the validator
- document the regression coverage guarding the wrapper
- assert the promised Make target exists via a new pytest

Why:
- docs already instruct sudo make validate-ssd-clone but the target was
  missing

How to test:
- python -m pre_commit run --all-files
- python -m pyspelling -c .spellcheck.yaml
- python -m linkcheck --no-warnings README.md docs/
- pytest tests/test_validate_ssd_make_target.py
- git diff --cached | ./scripts/scan-secrets.py


------
https://chatgpt.com/codex/tasks/task_e_68eb5cd89d1c832f93fd1d1240cfad8c