### PR TITLE
🎨 : – Expand start-here diagram spacing

### DIFF
--- a/docs/images/sugarkube_diagram.svg
+++ b/docs/images/sugarkube_diagram.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1020" height="520" viewBox="0 0 1020 520">
+<svg xmlns="http://www.w3.org/2000/svg" width="1160" height="600" viewBox="0 0 1160 600">
   <defs>
     <marker id="arrow" markerWidth="10" markerHeight="8" refX="8" refY="4" orient="auto"
       markerUnits="strokeWidth">
@@ -9,7 +9,7 @@
       <stop offset="1" stop-color="#1e3a8a" />
     </linearGradient>
   </defs>
-  <rect x="0" y="0" width="1020" height="520" fill="#f8fafc" />
+  <rect x="0" y="0" width="1160" height="600" fill="#f8fafc" />
   <g font-family="Inter,Arial,Helvetica,sans-serif" fill="#0f172a">
     <text x="140" y="56" font-size="20" font-weight="600" text-anchor="middle">Sunlight</text>
     <circle cx="140" cy="124" r="54" fill="#facc15" stroke="#ca8a04" stroke-width="4" />
@@ -45,7 +45,7 @@
       </text>
     </g>
 
-    <g transform="translate(660,110)">
+    <g transform="translate(660,120)">
       <rect x="0" y="0" width="190" height="110" rx="18" fill="#fef08a" stroke="#f59e0b"
         stroke-width="3" />
       <text x="95" y="50" font-size="20" text-anchor="middle" font-weight="600">
@@ -56,7 +56,7 @@
       </text>
     </g>
 
-    <g transform="translate(660,270)">
+    <g transform="translate(660,290)">
       <rect x="0" y="0" width="190" height="120" rx="18" fill="#bae6fd" stroke="#0284c7"
         stroke-width="3" />
       <text x="95" y="52" font-size="20" text-anchor="middle" font-weight="600">
@@ -70,7 +70,7 @@
       </text>
     </g>
 
-    <g transform="translate(660,400)">
+    <g transform="translate(660,440)">
       <rect x="0" y="0" width="190" height="100" rx="18" fill="#fef3c7" stroke="#d97706"
         stroke-width="3" />
       <text x="95" y="44" font-size="18" text-anchor="middle" font-weight="600">
@@ -81,7 +81,7 @@
       </text>
     </g>
 
-    <g transform="translate(860,290)">
+    <g transform="translate(940,300)">
       <rect x="0" y="0" width="140" height="100" rx="18" fill="#bbf7d0" stroke="#16a34a"
         stroke-width="3" />
       <text x="70" y="44" font-size="18" text-anchor="middle" font-weight="600">
@@ -92,7 +92,7 @@
       </text>
     </g>
 
-    <g transform="translate(860,420)">
+    <g transform="translate(940,460)">
       <rect x="0" y="0" width="140" height="100" rx="18" fill="#fde68a" stroke="#d97706"
         stroke-width="3" />
       <text x="70" y="44" font-size="18" text-anchor="middle" font-weight="600">
@@ -116,10 +116,10 @@
 
   <g stroke="#1d4ed8" stroke-width="3" fill="none" marker-end="url(#arrow)">
     <path d="M194 124 H300" />
-    <path d="M610 160 H660" />
-    <path d="M755 220 V270" />
-    <path d="M755 390 V400" />
-    <path d="M850 450 C900 450 910 360 930 330 L960 330" />
-    <path d="M850 470 H980" />
+    <path d="M610 175 H660" />
+    <path d="M755 230 V290" />
+    <path d="M755 410 V440" />
+    <path d="M850 490 C910 490 930 390 940 350" />
+    <path d="M850 510 H940" />
   </g>
 </svg>


### PR DESCRIPTION
what: Space out start-here diagram nodes and enlarge canvas.
why: Prevent arrows from overlapping Pi cluster and pumps.
how to test: View docs/start-here.md diagram render.
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68ec940cd55c832f8a71788f68b9b65b