### PR TITLE
🔧 : – Guard Codecov upload on forks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           pytest --cov=. --cov-report=xml --cov-report=term --maxfail=1 --disable-warnings -q
       - name: Upload coverage
-        if: hashFiles('coverage.xml') != ''
+        if: hashFiles('coverage.xml') != '' && secrets.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
what: skip the Codecov upload step when no CODECOV_TOKEN is provided.
why: forks cannot access CODECOV_TOKEN so the tests workflow failed on upload.
how to test: run the tests workflow on a forked PR and see the upload step skip.


------
https://chatgpt.com/codex/tasks/task_e_68ec932733ec832fb8ba330277d5740b