### PR TITLE
Ensure first-boot.service logs reach the serial console

### DIFF
--- a/scripts/systemd/first-boot.service
+++ b/scripts/systemd/first-boot.service
@@ -7,8 +7,8 @@ ConditionPathExists=!/var/log/sugarkube/first-boot.ok
 [Service]
 Type=oneshot
 ExecStart=/opt/sugarkube/first_boot_service.py
-StandardOutput=journal
-StandardError=journal
+StandardOutput=journal+console
+StandardError=journal+console
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
what: route first-boot.service stdout/stderr to journal+console.
why: serial capture in QEMU missed [first-boot] markers once journald stopped forwarding to tty, tripping the smoke test.
how to test: pre-commit run --all-files; pyspelling -c .spellcheck.yaml; linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68ed77fee0e4832fa3c749c537264957