### PR TITLE
Fix first boot report writes on read-only /boot

### DIFF
--- a/outages/2025-10-19-qemu-smoke-boot-ro.json
+++ b/outages/2025-10-19-qemu-smoke-boot-ro.json
@@ -1,0 +1,10 @@
+{
+  "id": "2025-10-19-qemu-smoke-boot-ro",
+  "date": "2025-10-19",
+  "component": "first_boot_service",
+  "rootCause": "Raspberry Pi OS now mounts /boot read-only on first boot, causing first_boot_service.py to crash while creating /boot/first-boot-report.",
+  "resolution": "Remount /boot read-write before generating reports and retry on EROFS so QEMU smoke tests succeed.",
+  "references": [
+    "https://github.com/futuroptimist/sugarkube/actions/runs/18458002805/job/52586441528"
+  ]
+}


### PR DESCRIPTION
## Summary
- remount /boot read-write before writing first boot reports
- add regression test for the remount helper and outage record

## Testing
- pytest tests/test_first_boot_service.py


------
https://chatgpt.com/codex/tasks/task_e_68ed77fee0e4832fa3c749c537264957