### PR TITLE
Restore QEMU smoke test serial markers

### DIFF
--- a/outages/2025-10-13-qemu-smoke-missing-serial-markers.json
+++ b/outages/2025-10-13-qemu-smoke-missing-serial-markers.json
@@ -1,0 +1,10 @@
+{
+  "id": "2025-10-13-qemu-smoke-missing-serial-markers",
+  "date": "2025-10-13",
+  "component": "qemu_pi_smoke_test",
+  "rootCause": "first-boot.service logged only to journald after console forwarding was disabled.",
+  "resolution": "Smoketest drop-in now forces journal+console output and sets PYTHONUNBUFFERED.",
+  "references": [
+    "https://github.com/futuroptimist/sugarkube/actions/runs/18458002805/job/52586441528"
+  ]
+}

--- a/scripts/qemu_pi_smoke_test.py
+++ b/scripts/qemu_pi_smoke_test.py
@@ -250,6 +250,9 @@ def _install_dropin(root_dir: Path) -> None:
         Environment=FIRST_BOOT_CLOUD_INIT_TIMEOUT=180
         Environment=TOKEN_PLACE_HEALTH_URL=skip
         Environment=DSPACE_HEALTH_URL=skip
+        Environment=PYTHONUNBUFFERED=1
+        StandardOutput=journal+console
+        StandardError=journal+console
         """
     ).strip()
     dropin_path = Path("etc/systemd/system/first-boot.service.d") / DROPIN_NAME

--- a/tests/test_qemu_pi_smoke_test.py
+++ b/tests/test_qemu_pi_smoke_test.py
@@ -163,7 +163,11 @@ def test_prepare_image_installs_stub_and_dropin(
     assert stub.exists()
     assert "Sugarkube smoke verifier" in stub.read_text()
     assert dropin.exists()
-    assert f"Environment=FIRST_BOOT_VERIFIER={MODULE.STUB_VERIFIER_PATH}" in dropin.read_text()
+    dropin_text = dropin.read_text()
+    assert f"Environment=FIRST_BOOT_VERIFIER={MODULE.STUB_VERIFIER_PATH}" in dropin_text
+    assert "Environment=PYTHONUNBUFFERED=1" in dropin_text
+    assert "StandardOutput=journal+console" in dropin_text
+    assert "StandardError=journal+console" in dropin_text
     assert prepared.kernel.name == "kernel8.img"
     assert prepared.dtb.name == "bcm2711-rpi-4-b.dtb"
     assert "root=/dev/mmcblk0p2" in prepared.cmdline


### PR DESCRIPTION
## Summary
- mirror first-boot.service stdout/stderr to the QEMU serial console
- document the recurring smoketest outage in outages/

## Testing
- pytest tests/test_qemu_pi_smoke_test.py
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68ed77fee0e4832fa3c749c537264957