### PR TITLE
Add go-task aliases for pi image helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,12 @@ variable as shown. Both the Makefile, justfile, and Taskfile expose `download-pi
 `doctor`, and `codespaces-bootstrap`
 shortcuts so GitHub
 Codespaces users can install prerequisites and flash media without additional shell glue—pick the runner
-you prefer (`make codespaces-bootstrap`, `just codespaces-bootstrap`, or `task codespaces-bootstrap`).
-Regression coverage: `tests/test_codespaces_bootstrap.py` keeps the package lists aligned across each
-wrapper.
+you prefer (`make codespaces-bootstrap`, `just codespaces-bootstrap`, or `task codespaces-bootstrap`). Go-task
+users can also call the hyphenated aliases directly (`task download-pi-image`, `task install-pi-image`),
+which forward `DOWNLOAD_ARGS` the same way as the Make and just wrappers. Regression coverage:
+`tests/test_codespaces_bootstrap.py` keeps the package lists aligned across each wrapper, and
+`tests/test_taskfile.py::test_taskfile_includes_make_style_aliases` ensures the Taskfile mirrors the
+documented shortcuts.
 `./scripts/sugarkube-latest` remains available when you only need the `.img.xz` artifact with
 checksum verification.
 Prefer a unified entry point? Run `python -m sugarkube_toolkit pi download --dry-run` from the

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -86,18 +86,44 @@ tasks:
     dir: '{{.REPO_ROOT}}'
     vars:
       PI_DOWNLOAD_ARGS: '{{default "" .PI_DOWNLOAD_ARGS}}'
+      DOWNLOAD_ARGS: '{{default "" .DOWNLOAD_ARGS}}'
     cmds:
       - |
-        {{.SUGARKUBE_CLI}} pi download{{if ne .PI_DOWNLOAD_ARGS ""}} {{.PI_DOWNLOAD_ARGS}}{{end}}
+        {{- $downloadArgs := default .DOWNLOAD_ARGS .PI_DOWNLOAD_ARGS -}}
+        {{.SUGARKUBE_CLI}} pi download{{if ne $downloadArgs ""}} {{$downloadArgs}}{{end}}
 
   pi:install:
     desc: Install the Sugarkube image via scripts/install_sugarkube_image.sh.
     dir: '{{.REPO_ROOT}}'
     vars:
       PI_INSTALL_ARGS: '{{default "" .PI_INSTALL_ARGS}}'
+      PI_DOWNLOAD_ARGS: '{{default "" .PI_DOWNLOAD_ARGS}}'
+      DOWNLOAD_ARGS: '{{default "" .DOWNLOAD_ARGS}}'
     cmds:
       - |
-        {{.SUGARKUBE_CLI}} pi install{{if ne .PI_INSTALL_ARGS ""}} {{.PI_INSTALL_ARGS}}{{end}}
+        {{- $installArgs := default (default .DOWNLOAD_ARGS .PI_DOWNLOAD_ARGS) .PI_INSTALL_ARGS -}}
+        {{.SUGARKUBE_CLI}} pi install{{if ne $installArgs ""}} {{$installArgs}}{{end}}
+
+  download-pi-image:
+    desc: Mirror the download helper exposed by the Makefile and justfile.
+    vars:
+      DOWNLOAD_ARGS: '{{default "" .DOWNLOAD_ARGS}}'
+      PI_DOWNLOAD_ARGS: '{{default "" .PI_DOWNLOAD_ARGS}}'
+    cmds:
+      - task: pi:download
+        vars:
+          PI_DOWNLOAD_ARGS: '{{default .DOWNLOAD_ARGS .PI_DOWNLOAD_ARGS}}'
+
+  install-pi-image:
+    desc: Mirror the install helper exposed by the Makefile and justfile.
+    vars:
+      DOWNLOAD_ARGS: '{{default "" .DOWNLOAD_ARGS}}'
+      PI_DOWNLOAD_ARGS: '{{default "" .PI_DOWNLOAD_ARGS}}'
+      PI_INSTALL_ARGS: '{{default "" .PI_INSTALL_ARGS}}'
+    cmds:
+      - task: pi:install
+        vars:
+          PI_INSTALL_ARGS: '{{default (default .DOWNLOAD_ARGS .PI_DOWNLOAD_ARGS) .PI_INSTALL_ARGS}}'
 
   pi:flash:
     desc: Flash removable media with the Sugarkube image helper.

--- a/tests/test_taskfile.py
+++ b/tests/test_taskfile.py
@@ -37,6 +37,26 @@ def test_taskfile_exposes_cli_wrappers() -> None:
         assert snippet in text, f"Taskfile {task_name} command should include `{snippet}`"
 
 
+def test_taskfile_includes_make_style_aliases() -> None:
+    """Taskfile should mirror the download/install shortcuts documented in the README."""
+
+    text = TASKFILE.read_text(encoding="utf-8")
+
+    assert (
+        "download-pi-image:" in text
+    ), "Taskfile should expose a download-pi-image alias for go-task users"
+    assert (
+        "task: pi:download" in text
+    ), "download-pi-image alias should delegate to the pi:download helper"
+
+    assert (
+        "install-pi-image:" in text
+    ), "Taskfile should expose an install-pi-image alias for go-task users"
+    assert (
+        "task: pi:install" in text
+    ), "install-pi-image alias should delegate to the pi:install helper"
+
+
 def test_docs_reference_taskfile_shortcuts() -> None:
     """Docs should point readers to the Taskfile equivalents."""
 


### PR DESCRIPTION
## Summary
- add go-task aliases that mirror the existing download/install helpers while preserving CLI forwarding
- update the pi download/install tasks to honour DOWNLOAD_ARGS fallbacks and document the coverage in the README
- extend Taskfile tests to confirm the documented aliases stay wired up

## Testing
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68ec87b9cd0c832fa5868b4452f76893