### PR TITLE
Include just CLI in Pi image builds

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -130,6 +130,21 @@ jobs:
             CLONE_DSPACE="${CLONE_DSPACE}" \
             ./scripts/build_pi_image.sh
 
+      - name: pi-image-verify-just
+        if: always()
+        run: |
+          log=$(find deploy -maxdepth 2 -name '*.build.log' -print -quit)
+          if [ -z "$log" ]; then
+            echo "pi-gen build log missing" >&2
+            exit 1
+          fi
+          echo '--- just verification ---'
+          if ! grep -F '✅ just command verified' "$log"; then
+            echo "just verification line missing" >&2
+            exit 1
+          fi
+          grep -F '[sugarkube] just version' "$log" || true
+
       - name: Verify pi-gen Docker image
         run: |
           if ! docker image inspect pi-gen:latest > /dev/null 2>&1; then

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -147,6 +147,10 @@ sync without modifying the host.
    ./scripts/build_pi_image.sh
    ```
    Skip either project with `CLONE_TOKEN_PLACE=false` or `CLONE_DSPACE=false`.
+   All workflow-built images now ship with the [`just`](https://just.systems/)
+   CLI preinstalled at `/usr/local/bin/just`, so you can immediately run helpers
+   such as `just clone-ssd`, `just validate-ssd-clone`, and `just smoke-test-pi`
+   right after first boot without installing additional tooling.
 5. After any download or build, verify integrity:
    ```bash
    sha256sum -c path/to/sugarkube.img.xz.sha256

--- a/scripts/first_boot_service.py
+++ b/scripts/first_boot_service.py
@@ -32,6 +32,7 @@ without needing root privileges:
 
 from __future__ import annotations
 
+import errno
 import html
 import json
 import os
@@ -42,7 +43,6 @@ import subprocess
 import sys
 import textwrap
 import time
-import errno
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -105,7 +105,7 @@ def _ensure_boot_writable(target: Path) -> None:
             raise
 
         result = subprocess.run(
-            ["mount", "-o", f"remount,rw", str(BOOT_DIR)],
+            ["mount", "-o", "remount,rw", str(BOOT_DIR)],
             capture_output=True,
             text=True,
             check=False,

--- a/tests/test_first_boot_service.py
+++ b/tests/test_first_boot_service.py
@@ -1,6 +1,6 @@
+import errno
 import importlib.util
 import json
-import errno
 import sys
 from pathlib import Path
 

--- a/tests/test_pi_image_tooling.py
+++ b/tests/test_pi_image_tooling.py
@@ -1,0 +1,47 @@
+"""Regression tests for Pi image tooling additions."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from tests import build_pi_image_test as build_test
+
+
+def _extract_work_dir(stdout: str) -> Path:
+    match = re.search(r"leaving work dir: (?P<path>\S+)", stdout)
+    assert match, stdout
+    return Path(match.group("path"))
+
+
+def test_just_installation_script_includes_fallback(tmp_path):
+    env = build_test._setup_build_env(tmp_path)
+    env["KEEP_WORK_DIR"] = "1"
+    result, _ = build_test._run_build_script(tmp_path, env)
+    assert result.returncode == 0
+
+    work_dir = _extract_work_dir(result.stdout)
+    script_path = work_dir / "pi-gen" / "stage2" / "01-sys-tweaks" / "03-run-chroot-just.sh"
+    assert script_path.exists(), script_path
+    script_text = script_path.read_text()
+
+    assert 'apt-get "${APT_OPTS[@]}" install -y --no-install-recommends just' in script_text
+    assert "https://just.systems/install.sh" in script_text
+    assert "✅ just command verified" in script_text
+    assert "just --version" in script_text
+    assert "just --list" in script_text
+
+    profile_path = (
+        work_dir
+        / "pi-gen"
+        / "stage2"
+        / "01-sys-tweaks"
+        / "files"
+        / "etc"
+        / "profile.d"
+        / "sugarkube-path.sh"
+    )
+    assert profile_path.exists(), profile_path
+    profile_text = profile_path.read_text()
+    assert "/usr/local/bin" in profile_text
+    assert "export PATH" in profile_text


### PR DESCRIPTION
## Summary
- install the just CLI during pi-gen builds with apt fallback to upstream installer
- ensure /usr/local/bin is on PATH and surface verification logs/artifacts
- document the bundled just tool and add regression coverage for the chroot script

## Testing
- pytest tests/test_pi_image_tooling.py
- pre-commit run --all-files
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68ed81ede984832f927416684af7f78e