### PR TITLE
✅ ensure pi-image logs capture just marker

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -43,8 +43,12 @@ jobs:
             -o Acquire::http::Timeout=30 \
             -o Acquire::https::Timeout=30 \
             install -y --no-install-recommends libarchive-tools xz-utils
+      - name: Install Python test dependencies
+        run: python3 -m pip install --disable-pip-version-check --no-cache-dir pytest
       - name: Run artifact detection unit tests
         run: bash tests/artifact_detection_test.sh
+      - name: Run pi-image regression tests
+        run: python3 -m pytest tests/build_pi_image_test.py tests/test_pi_image_tooling.py -k "pi_image"
 
   build:
     # Only run the expensive image build when manually dispatched

--- a/outages/2025-10-23-pi-image-just-verification-missing.json
+++ b/outages/2025-10-23-pi-image-just-verification-missing.json
@@ -1,0 +1,10 @@
+{
+  "id": "2025-10-23-pi-image-just-verification-missing",
+  "date": "2025-10-23",
+  "component": "pi-image workflow",
+  "rootCause": "pi-gen stopped copying stage chroot output into work/<image>/build.log, leaving the just verification marker only in stage logs.",
+  "resolution": "Updated build_pi_image.sh to scan stage logs, fail fast when the marker is missing, and added targeted regression tests plus CI coverage.",
+  "references": [
+    "https://github.com/futuroptimist/sugarkube/actions/runs/18484262428/job/52664737848"
+  ]
+}


### PR DESCRIPTION
what: harvest stage logs when build.log misses the just marker, fail
  fast, add regression coverage, and log the outage.
why: pi-gen stopped copying the just verification line into build.log,
  letting the workflow pass without confirming just availability.
how to test: python3 -m pytest tests/build_pi_image_test.py \
  tests/test_pi_image_tooling.py -k "pi_image"
  bash tests/artifact_detection_test.sh
Refs: #n/a

------
https://chatgpt.com/codex/tasks/task_e_68edcf985d04832fae0b581e824ada9a