### PR TITLE
Fix pi-image just verification log detection

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -142,7 +142,7 @@ jobs:
           found=0
           for log in "${logs[@]}"; do
             echo "Checking ${log}"
-            if grep -FH '✅ just command verified' "${log}"; then
+            if grep -FH 'just command verified' "${log}"; then
               found=1
               grep -FH '[sugarkube] just version' "${log}" || true
             fi

--- a/outages/2025-10-23-pi-image-just-log-verification.json
+++ b/outages/2025-10-23-pi-image-just-log-verification.json
@@ -1,0 +1,10 @@
+{
+  "id": "2025-10-23-pi-image-just-log-verification",
+  "date": "2025-10-23",
+  "component": "pi-image workflow",
+  "rootCause": "The verification step searched build logs for the exact UTF-8 string '✅ just command verified', but the pi-gen chroot runs under a POSIX locale that renders the emoji as '??', so the grep never matched even though the just verification succeeded.",
+  "resolution": "Updated the builder to emit an ASCII '[sugarkube] just command verified' log line and relaxed the workflow check to search for the emoji-free substring. Added unit tests to keep the workflow and build script in sync.",
+  "references": [
+    "https://github.com/futuroptimist/sugarkube/actions/runs/18484262428/job/52664737848"
+  ]
+}

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -409,7 +409,7 @@ if [ -z "${just_path}" ]; then
   exit 1
 fi
 
-printf '✅ just command verified at %s\n' "${just_path}" | tee -a "${BUILD_LOG}"
+printf '[sugarkube] just command verified at %s\n' "${just_path}" | tee -a "${BUILD_LOG}"
 just_version=$(just --version 2>&1 | head -n1 || true)
 if [ -n "${just_version}" ]; then
   printf '[sugarkube] just version: %s\n' "${just_version}" | tee -a "${BUILD_LOG}"

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -406,7 +406,7 @@ fi
         'cp config "$OUTPUT_DIR/config.env"\n'
         f"{image_cmd}"
         "mkdir -p work/sugarkube\n"
-        "printf '✅ just command verified\\n[sugarkube] just version: stub\\n' > "
+        "printf '[sugarkube] just command verified\\n[sugarkube] just version: stub\\n' > "
         "work/sugarkube/build.log\n"
         "EOF\n"
         'chmod +x "$target/build.sh"\n'
@@ -608,7 +608,7 @@ def test_build_log_written_to_deploy(tmp_path):
     deploy_log = tmp_path / "deploy" / "sugarkube.build.log"
     assert deploy_log.exists()
     log_text = deploy_log.read_text()
-    assert "✅ just command verified" in log_text
+    assert "[sugarkube] just command verified" in log_text
     host_log = tmp_path / "sugarkube.build.log"
     assert host_log.exists()
     assert host_log.read_text() == log_text

--- a/tests/test_pi_image_tooling.py
+++ b/tests/test_pi_image_tooling.py
@@ -27,7 +27,7 @@ def test_just_installation_script_includes_fallback(tmp_path):
 
     assert 'apt-get "${APT_OPTS[@]}" install -y --no-install-recommends just' in script_text
     assert "https://just.systems/install.sh" in script_text
-    assert "✅ just command verified" in script_text
+    assert "[sugarkube] just command verified" in script_text
     assert "just --version" in script_text
     assert "just --list" in script_text
 
@@ -45,3 +45,10 @@ def test_just_installation_script_includes_fallback(tmp_path):
     profile_text = profile_path.read_text()
     assert "/usr/local/bin" in profile_text
     assert "export PATH" in profile_text
+
+
+def test_pi_image_workflow_checks_for_just_log():
+    workflow_path = Path(".github/workflows/pi-image.yml")
+    content = workflow_path.read_text()
+    assert "grep -FH 'just command verified'" in content
+    assert "find deploy -maxdepth 2 -name '*.build.log'" in content


### PR DESCRIPTION
what: make just verification log ASCII, relax workflow grep,
 add outage entry, add regression tests.
why: pi-gen chroot prints emoji as ?? so the workflow missed the
 verification line and failed builds.
how to test: pytest tests/build_pi_image_test.py tests/test_pi_image_tooling.py
Refs: #18484262428

------
https://chatgpt.com/codex/tasks/task_e_68edcf985d04832fae0b581e824ada9a