### PR TITLE
Fix pi-image build safe.directory failure

### DIFF
--- a/outages/2025-10-14-pi-image-build-safe-directory.json
+++ b/outages/2025-10-14-pi-image-build-safe-directory.json
@@ -1,0 +1,12 @@
+{
+  "id": "pi-image-build-safe-directory",
+  "date": "2025-10-14",
+  "component": "pi-image GitHub workflow",
+  "rootCause": "Running the build job as root hit Git's ownership guard so script aborted before cloning pi-gen.",
+  "resolution": "build_pi_image.sh now marks the workspace safe for root git and tests guard against regressions.",
+  "references": [
+    "scripts/build_pi_image.sh",
+    "tests/build_pi_image_test.py",
+    "tests/test_pi_image_tooling.py"
+  ]
+}

--- a/tests/test_pi_image_tooling.py
+++ b/tests/test_pi_image_tooling.py
@@ -52,3 +52,9 @@ def test_pi_image_workflow_checks_for_just_log():
     content = workflow_path.read_text()
     assert "grep -FH 'just command verified'" in content
     assert "find deploy -maxdepth 2 -name '*.build.log'" in content
+
+
+def test_build_script_marks_git_safe_directory():
+    script = Path("scripts/build_pi_image.sh").read_text()
+    assert "safe.directory" in script
+    assert "ensure_git_safe_directory" in script


### PR DESCRIPTION
Summary:
- mark build_pi_image.sh workspaces safe for root git before querying repo state
- add regression and e2e coverage for the safe.directory guard and log the outage

Testing:
- bash tests/artifact_detection_test.sh
- pytest tests/test_pi_image_tooling.py -q
- pytest tests/build_pi_image_test.py::test_marks_repo_safe_directory_for_root -q

------
https://chatgpt.com/codex/tasks/task_e_68edd407fd70832fbfbb5d4883f19790