### PR TITLE
🚑 : – guard pi-image workflow triggers

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -20,6 +20,8 @@ on:
   pull_request:
     paths:
       - 'scripts/collect_pi_image.sh'
+      - 'scripts/build_pi_image.sh'
+      - 'scripts/build_pi_image.ps1'
       - 'tests/**'
       - '.github/workflows/pi-image.yml'
 

--- a/outages/2025-10-31-pi-image-workflow-path-filter.json
+++ b/outages/2025-10-31-pi-image-workflow-path-filter.json
@@ -1,0 +1,12 @@
+{
+  "id": "2025-10-31-pi-image-workflow-path-filter",
+  "date": "2025-10-31",
+  "component": "pi-image workflow",
+  "rootCause": "A change to scripts/build_pi_image.sh skipped the pi-image unit job because the pull_request.paths filter did not include the build script, so regressions were not caught before the workflow-dispatch build ran and failed downstream.",
+  "resolution": "The pi-image workflow now watches the build script paths, and regression tests assert that the pull_request.paths block covers the collector and builder entrypoints. A high-level e2e test exercises tests/artifact_detection_test.sh to keep the workflow smoke coverage in CI.",
+  "references": [
+    ".github/workflows/pi-image.yml",
+    "tests/test_pi_image_tooling.py",
+    "tests/test_artifact_detection_e2e.py"
+  ]
+}

--- a/tests/test_artifact_detection_e2e.py
+++ b/tests/test_artifact_detection_e2e.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REQUIRED_TOOLS = ("xz", "bsdtar", "gzip", "sha256sum")
+
+
+def test_artifact_detection_shell_script(tmp_path: Path) -> None:
+    missing = [tool for tool in REQUIRED_TOOLS if shutil.which(tool) is None]
+    if missing:
+        pytest.skip(f"missing tools required for artifact detection test: {', '.join(missing)}")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env.setdefault("TMPDIR", str(tmp_path))
+
+    result = subprocess.run(
+        ["bash", "tests/artifact_detection_test.sh"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        pytest.fail(
+            "artifact detection script failed:\n"
+            f"stdout:\n{result.stdout}\n--- stderr ---\n{result.stderr}",
+        )

--- a/tests/test_pi_image_tooling.py
+++ b/tests/test_pi_image_tooling.py
@@ -9,6 +9,58 @@ from pathlib import Path
 from tests import build_pi_image_test as build_test
 
 
+def _extract_pull_request_paths(workflow_text: str) -> list[str]:
+    """Return the string globs under the pull_request.paths block."""
+
+    paths: list[str] = []
+    lines = workflow_text.splitlines()
+
+    in_pull_request = False
+    in_paths = False
+    pull_request_indent = 0
+    paths_indent = 0
+
+    for raw_line in lines:
+        line = raw_line.rstrip()
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+
+        if not in_pull_request:
+            if stripped.startswith("pull_request:"):
+                in_pull_request = True
+                pull_request_indent = indent
+            continue
+
+        if indent <= pull_request_indent and stripped:
+            # Finished reading the pull_request block.
+            break
+
+        if stripped.startswith("paths:"):
+            in_paths = True
+            paths_indent = indent
+            continue
+
+        if in_paths:
+            if not stripped:
+                continue
+            if indent <= paths_indent:
+                in_paths = False
+                if indent <= pull_request_indent and stripped:
+                    break
+                continue
+
+            if stripped.startswith("- "):
+                value = stripped[2:].strip()
+                if value.startswith("'") and value.endswith("'"):
+                    value = value[1:-1]
+                elif value.startswith('"') and value.endswith('"'):
+                    value = value[1:-1]
+                if value:
+                    paths.append(value)
+
+    return paths
+
+
 def _extract_work_dir(stdout: str) -> Path:
     match = re.search(r"leaving work dir: (?P<path>\S+)", stdout)
     assert match, stdout
@@ -53,6 +105,18 @@ def test_pi_image_workflow_checks_for_just_log():
     content = workflow_path.read_text()
     assert "grep -FH 'just command verified'" in content
     assert "find deploy -maxdepth 2 -name '*.build.log'" in content
+
+
+def test_pi_image_workflow_watches_build_scripts():
+    workflow_path = Path(".github/workflows/pi-image.yml")
+    content = workflow_path.read_text()
+    paths = _extract_pull_request_paths(content)
+
+    assert paths, "pull_request.paths block missing in pi-image workflow"
+    assert "scripts/collect_pi_image.sh" in paths
+    assert "scripts/build_pi_image.sh" in paths
+    assert "scripts/build_pi_image.ps1" in paths
+    assert "tests/**" in paths
 
 
 def _collect_checkout_refs(workflow_text: str) -> list[str]:


### PR DESCRIPTION
what: add pi-image workflow coverage for build scripts, outage log, and tests
why: prevent skipped unit checks on builder changes and document the incident
how to test: pytest tests/test_pi_image_tooling.py tests/test_artifact_detection_e2e.py
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68eddb91825c832f981c4c4c6b0ff1d8