### PR TITLE
🛠️ : – guard pi-image metadata workflow

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -22,6 +22,8 @@ on:
       - 'scripts/collect_pi_image.sh'
       - 'scripts/build_pi_image.sh'
       - 'scripts/build_pi_image.ps1'
+      - 'scripts/create_build_metadata.py'
+      - 'tests/create_build_metadata_e2e.sh'
       - 'tests/**'
       - '.github/workflows/pi-image.yml'
 
@@ -47,6 +49,9 @@ jobs:
             install -y --no-install-recommends libarchive-tools xz-utils
       - name: Run artifact detection unit tests
         run: bash tests/artifact_detection_test.sh
+
+      - name: Run build metadata smoke test
+        run: bash tests/create_build_metadata_e2e.sh
 
   build:
     # Only run the expensive image build when manually dispatched

--- a/outages/2025-11-02-pi-image-metadata-tests-missing.json
+++ b/outages/2025-11-02-pi-image-metadata-tests-missing.json
@@ -1,0 +1,12 @@
+{
+  "id": "2025-11-02-pi-image-metadata-tests-missing",
+  "date": "2025-11-02",
+  "component": "pi-image workflow",
+  "rootCause": "Changes to scripts/create_build_metadata.py were not covered by the pi-image unit job. The workflow only executed tests/artifact_detection_test.sh, so a metadata regression merged on a pull request and the next manual pi-image build failed when create_build_metadata.py crashed.",
+  "resolution": "Add a fast smoke test that exercises scripts/create_build_metadata.py alongside the existing artifact detection checks and ensure the workflow watches the metadata entrypoints so the unit job runs on relevant pull requests.",
+  "references": [
+    ".github/workflows/pi-image.yml",
+    "tests/create_build_metadata_e2e.sh",
+    "tests/test_pi_image_tooling.py"
+  ]
+}

--- a/tests/create_build_metadata_e2e.sh
+++ b/tests/create_build_metadata_e2e.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# End-to-end smoke test for scripts/create_build_metadata.py.
+# Creates a minimal fake pi-gen output and verifies metadata generation succeeds.
+set -euo pipefail
+
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR_ROOT}"' EXIT
+
+RAW_IMAGE="${TMPDIR_ROOT}/image.raw"
+printf 'sugarkube-metadata-smoke-test' > "${RAW_IMAGE}"
+
+LOCAL_XZ_OPT="${XZ_OPT:--T0 -0}"
+IMAGE_PATH="${TMPDIR_ROOT}/sugarkube.img.xz"
+XZ_OPT="${LOCAL_XZ_OPT}" xz -c "${RAW_IMAGE}" > "${IMAGE_PATH}"
+rm -f "${RAW_IMAGE}"
+
+(
+  cd "${TMPDIR_ROOT}"
+  sha256sum "$(basename "${IMAGE_PATH}")" > "$(basename "${IMAGE_PATH}").sha256"
+)
+CHECKSUM_PATH="${IMAGE_PATH}.sha256"
+
+BUILD_LOG="${TMPDIR_ROOT}/build.log"
+cat <<'LOG' > "${BUILD_LOG}"
+[00:00:00] Begin stage0
+[00:00:05] End stage0
+[00:00:05] Begin stage1
+[00:01:05] End stage1
+[00:01:06] Begin export-image
+[00:01:36] End export-image
+LOG
+
+STAGE_SUMMARY="${TMPDIR_ROOT}/stage-summary.json"
+METADATA_PATH="${TMPDIR_ROOT}/metadata.json"
+
+python3 scripts/create_build_metadata.py \
+  --output "${METADATA_PATH}" \
+  --image "${IMAGE_PATH}" \
+  --checksum "${CHECKSUM_PATH}" \
+  --pi-gen-branch "bookworm" \
+  --pi-gen-url "https://github.com/RPi-Distro/pi-gen.git" \
+  --pi-gen-commit "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" \
+  --pi-gen-stages "stage0 stage1 export-image" \
+  --repo-commit "cafebabecafebabecafebabecafebabecafebabe" \
+  --repo-ref "refs/heads/test" \
+  --build-start "2024-01-01T00:00:00Z" \
+  --build-end "2024-01-01T00:10:00Z" \
+  --duration-seconds "600" \
+  --runner-os "Linux" \
+  --runner-arch "x86_64" \
+  --option "arm64=1" \
+  --option "clone_sugarkube=false" \
+  --build-log "${BUILD_LOG}" \
+  --stage-summary "${STAGE_SUMMARY}"
+
+python3 - <<'PY' "${METADATA_PATH}" "${STAGE_SUMMARY}"
+import json
+import pathlib
+import sys
+
+metadata_path = pathlib.Path(sys.argv[1])
+summary_path = pathlib.Path(sys.argv[2])
+
+if not metadata_path.is_file():
+    raise SystemExit(f"metadata missing: {metadata_path}")
+if not summary_path.is_file():
+    raise SystemExit(f"stage summary missing: {summary_path}")
+
+metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+summary = json.loads(summary_path.read_text(encoding="utf-8"))
+
+assert metadata["image"]["sha256"], "missing image sha256"
+assert metadata["build"]["stage_durations"]["stage0"] == 5
+assert metadata["build"]["stage_durations"]["stage1"] == 60
+assert summary["stage_count"] == 3
+assert summary["incomplete_stages"] == []
+PY
+
+echo "create_build_metadata smoke test passed"

--- a/tests/test_pi_image_tooling.py
+++ b/tests/test_pi_image_tooling.py
@@ -115,6 +115,13 @@ def test_pi_image_workflow_preserves_node_runtime():
     assert "node --version" in content
 
 
+def test_pi_image_workflow_watches_metadata_artifacts():
+    workflow_path = Path(".github/workflows/pi-image.yml")
+    paths = _extract_pull_request_paths(workflow_path.read_text())
+    assert "scripts/create_build_metadata.py" in paths
+    assert "tests/create_build_metadata_e2e.sh" in paths
+
+
 def _collect_checkout_refs(workflow_text: str) -> list[str]:
     pattern = re.compile(r"uses:\s*actions/checkout@(?P<ref>[^\s]+)")
     return pattern.findall(workflow_text)


### PR DESCRIPTION
what: add a metadata smoke test to the pi-image workflow, log the outage
why: metadata regressions merged without unit coverage and broke manual builds
how to test:
  bash tests/create_build_metadata_e2e.sh
  bash tests/artifact_detection_test.sh
  pytest tests/test_pi_image_tooling.py -q
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68ede0b6d2f0832f9a5bc667c299708d