### PR TITLE
🛡️ : Guard pi-image permissions helper

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -23,6 +23,7 @@ on:
       - 'scripts/build_pi_image.sh'
       - 'scripts/build_pi_image.ps1'
       - 'scripts/create_build_metadata.py'
+      - 'scripts/fix_pi_image_permissions.sh'
       - 'tests/create_build_metadata_e2e.sh'
       - 'tests/**'
       - '.github/workflows/pi-image.yml'

--- a/outages/2025-11-08-pi-image-fix-script-paths.json
+++ b/outages/2025-11-08-pi-image-fix-script-paths.json
@@ -1,0 +1,12 @@
+{
+  "id": "2025-11-08-pi-image-fix-script-paths",
+  "date": "2025-11-08",
+  "component": "pi-image workflow",
+  "rootCause": "pull_request.paths omitted the fix script, so bugs merged and builds failed.",
+  "resolution": "Added the script to the path filter and guarded it via workflow tests.",
+  "references": [
+    ".github/workflows/pi-image.yml",
+    "scripts/fix_pi_image_permissions.sh",
+    "tests/test_pi_image_tooling.py"
+  ]
+}

--- a/tests/test_pi_image_tooling.py
+++ b/tests/test_pi_image_tooling.py
@@ -123,6 +123,7 @@ def test_pi_image_workflow_fixes_artifact_permissions():
     paths = _extract_pull_request_paths(content)
     assert "scripts/create_build_metadata.py" in paths
     assert "tests/create_build_metadata_e2e.sh" in paths
+    assert "scripts/fix_pi_image_permissions.sh" in paths
 
 
 def _collect_checkout_refs(workflow_text: str) -> list[str]:


### PR DESCRIPTION
what:
- add scripts/fix_pi_image_permissions.sh to pi-image path filter
- extend pi-image tooling test and record outage context

why:
- ensure permissions helper edits trigger unit coverage

how to test:
- pytest tests/test_pi_image_tooling.py
- pytest tests/test_fix_pi_image_permissions.py

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68ede7deeabc832fac462b240a2b2343