### PR TITLE
Guard pi-image workflow against Node24 checkout crash

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -34,7 +34,7 @@ jobs:
   unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v4.3.0
         with:
           fetch-depth: 1
       - name: Install collector dependencies
@@ -65,7 +65,7 @@ jobs:
       CLONE_TOKEN_PLACE: ${{ github.event.inputs.clone_token_place }}
       CLONE_DSPACE: ${{ github.event.inputs.clone_dspace }}
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v4.3.0
         with:
           fetch-depth: 1
 

--- a/outages/2025-10-14-pi-image-checkout-node24-regression.json
+++ b/outages/2025-10-14-pi-image-checkout-node24-regression.json
@@ -1,0 +1,11 @@
+{
+  "id": "pi-image-checkout-node24-regression",
+  "date": "2025-10-14",
+  "component": "pi-image GitHub workflow",
+  "rootCause": "checkout@v4.2.2 used Node 20. Forcing Node24 crashed checkout before clone.",
+  "resolution": "Updated to actions/checkout@v4.3.0 for Node24 support. Tests pin tag and release.",
+  "references": [
+    ".github/workflows/pi-image.yml",
+    "tests/test_pi_image_tooling.py"
+  ]
+}

--- a/tests/test_pi_image_tooling.py
+++ b/tests/test_pi_image_tooling.py
@@ -135,15 +135,14 @@ def _collect_action_refs(workflow_text: str, action: str) -> list[str]:
     return pattern.findall(workflow_text)
 
 
-def test_pi_image_workflow_pins_checkout_major_version():
+def test_pi_image_workflow_pins_checkout_version():
     workflow_path = Path(".github/workflows/pi-image.yml")
     content = workflow_path.read_text()
     refs = _collect_checkout_refs(content)
     assert refs, "No actions/checkout references found in pi-image workflow"
 
     for ref in refs:
-        major = ref.split(".", 1)[0]
-        assert major == "v4", f"Expected actions/checkout v4.*, found {ref}"
+        assert ref == "v4.3.0", f"Expected actions/checkout@v4.3.0, found {ref}"
 
 
 def test_pi_image_workflow_checkout_refs_exist_upstream():


### PR DESCRIPTION
## Summary
- bump the pi-image workflow to actions/checkout@v4.3.0 so Node24 runs no longer abort during checkout
- add an outage record documenting the Node24 regression and tighten the regression test to enforce the new checkout tag

## Testing
- pytest tests/test_pi_image_tooling.py
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68ede7deeabc832fac462b240a2b2343