### PR TITLE
Fix pi-image metadata timestamp deprecation

### DIFF
--- a/outages/2025-11-09-pi-image-metadata-utc-deprecation.json
+++ b/outages/2025-11-09-pi-image-metadata-utc-deprecation.json
@@ -1,0 +1,13 @@
+{
+  "id": "2025-11-09-pi-image-metadata-utc-deprecation",
+  "date": "2025-11-09",
+  "component": "pi-image workflow",
+  "rootCause": "scripts/create_build_metadata.py relied on datetime.utcnow(), which is slated for removal in Python 3.13. When GitHub Actions updates its Python runtimes, the pi-image unit job's metadata smoke test crashes before writing metadata, causing the workflow to fail.",
+  "resolution": "Switched metadata timestamp generation to timezone-aware datetime.now(datetime.timezone.utc) via a shared helper and forced the e2e smoke test to treat DeprecationWarning as fatal so future regressions are caught ahead of time.",
+  "references": [
+    ".github/workflows/pi-image.yml",
+    "scripts/create_build_metadata.py",
+    "tests/create_build_metadata_e2e.sh",
+    "tests/test_create_build_metadata.py"
+  ]
+}

--- a/scripts/create_build_metadata.py
+++ b/scripts/create_build_metadata.py
@@ -22,6 +22,16 @@ from typing import Dict, Iterable, List, Tuple
 _STAGE_RE = re.compile(r"^\[(\d+):(\d+):(\d+)\]\s+(Begin|End)\s+([^/]+)$")
 
 
+def _now_utc_timestamp() -> str:
+    """Return an ISO-8601 timestamp with second precision in UTC."""
+
+    now = dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
+    iso = now.isoformat()
+    if iso.endswith("+00:00"):
+        return iso[:-6] + "Z"
+    return iso
+
+
 @dataclasses.dataclass(frozen=True)
 class StageSpan:
     name: str
@@ -248,7 +258,7 @@ def _write_stage_summary(
         "observed_elapsed_seconds": int(round(timer.elapsed())),
         "stages": stage_entries,
         "incomplete_stages": incomplete_entries,
-        "generated_at": dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+        "generated_at": _now_utc_timestamp(),
     }
     output_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
@@ -311,7 +321,7 @@ def main(argv: List[str]) -> int:
         },
         "options": options,
         "verifier": _load_verifier(args.verifier_json),
-        "generated_at": dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+        "generated_at": _now_utc_timestamp(),
     }
 
     output_path.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tests/create_build_metadata_e2e.sh
+++ b/tests/create_build_metadata_e2e.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 TMPDIR_ROOT="$(mktemp -d)"
 trap 'rm -rf "${TMPDIR_ROOT}"' EXIT
 
+export PYTHONWARNINGS="error::DeprecationWarning"
+
 RAW_IMAGE="${TMPDIR_ROOT}/image.raw"
 printf 'sugarkube-metadata-smoke-test' > "${RAW_IMAGE}"
 

--- a/tests/test_create_build_metadata.py
+++ b/tests/test_create_build_metadata.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime as dt
 import hashlib
 import json
 import sys
@@ -117,6 +118,12 @@ def test_metadata_contains_stage_durations(tmp_path):
     assert data["options"]["clone_token_place"] is False
     assert data["verifier"]["status"] == "not_run"
 
+    generated_at = data["generated_at"]
+    assert generated_at.endswith("Z")
+    parsed = dt.datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+    assert parsed.tzinfo is not None
+    assert parsed.tzinfo.utcoffset(parsed) == dt.timedelta(0)
+
 
 def test_stage_summary_outputs_timelines(tmp_path):
     summary_path = tmp_path / "stage-summary.json"
@@ -143,6 +150,12 @@ def test_stage_summary_outputs_timelines(tmp_path):
     assert stages[2]["start_offset_seconds"] == 66
     assert stages[2]["end_offset_seconds"] == 96
     assert summary["incomplete_stages"] == []
+
+    summary_generated_at = summary["generated_at"]
+    assert summary_generated_at.endswith("Z")
+    summary_parsed = dt.datetime.fromisoformat(summary_generated_at.replace("Z", "+00:00"))
+    assert summary_parsed.tzinfo is not None
+    assert summary_parsed.tzinfo.utcoffset(summary_parsed) == dt.timedelta(0)
 
 
 def test_stage_summary_incomplete_entries(tmp_path):


### PR DESCRIPTION
## Summary
- replace deprecated datetime.utcnow usage in create_build_metadata with a timezone-aware helper to keep the pi-image workflow compatible with future Python releases
- force the metadata e2e smoke test to treat DeprecationWarning as fatal and document the outage scenario

## Testing
- pytest tests/test_create_build_metadata.py
- bash tests/create_build_metadata_e2e.sh

------
https://chatgpt.com/codex/tasks/task_e_68edf17bdbf4832faf30dd7764b208ac