### PR TITLE
🚑 : – Expand pi-image workflow coverage

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -24,6 +24,8 @@ on:
       - 'scripts/build_pi_image.ps1'
       - 'scripts/fix_pi_image_permissions.sh'
       - 'scripts/create_build_metadata.py'
+      - 'scripts/download_pi_image.sh'
+      - 'scripts/render_pi_imager_preset.py'
       - 'scripts/fix_pi_image_permissions.sh'
       - 'tests/create_build_metadata_e2e.sh'
       - 'tests/**'
@@ -57,6 +59,9 @@ jobs:
 
       - name: Run fix permissions e2e test
         run: bash tests/fix_pi_image_permissions_e2e.sh
+
+      - name: Run Pi Imager preset e2e test
+        run: bash tests/render_pi_imager_preset_e2e.sh
 
   build:
     # Only run the expensive image build when manually dispatched

--- a/outages/2025-11-10-pi-image-preset-coverage-gap.json
+++ b/outages/2025-11-10-pi-image-preset-coverage-gap.json
@@ -1,0 +1,14 @@
+{
+  "id": "2025-11-10-pi-image-preset-coverage-gap",
+  "date": "2025-11-10",
+  "component": "pi-image workflow",
+  "rootCause": "Changes to scripts/download_pi_image.sh and scripts/render_pi_imager_preset.py did not trigger the pi-image unit job because the pull_request.paths filter omitted both files. The preset helper lost coverage, so a regression merged unnoticed and the next manual pi-image build failed when the preset renderer exited early.",
+  "resolution": "Expanded the pi-image workflow path filters to cover the download helper and preset renderer, and added a render_pi_imager_preset end-to-end test with workflow assertions to guarantee the coverage stays in place.",
+  "references": [
+    ".github/workflows/pi-image.yml",
+    "scripts/render_pi_imager_preset.py",
+    "scripts/download_pi_image.sh",
+    "tests/render_pi_imager_preset_e2e.sh",
+    "tests/test_pi_image_tooling.py"
+  ]
+}

--- a/tests/render_pi_imager_preset_e2e.sh
+++ b/tests/render_pi_imager_preset_e2e.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Exercise scripts/render_pi_imager_preset.py end-to-end.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${ROOT_DIR}/scripts/render_pi_imager_preset.py"
+
+if [ ! -x "${SCRIPT}" ]; then
+  echo "render_pi_imager_preset.py missing or not executable" >&2
+  exit 1
+fi
+
+tmpdir="$(mktemp -d)"
+cleanup() {
+  rm -rf "${tmpdir}"
+}
+trap cleanup EXIT
+
+preset_path="${tmpdir}/preset.json"
+cat >"${preset_path}" <<'JSON'
+{
+  "hostname": "default-host",
+  "username": "pi",
+  "ssh": {
+    "enabled": true,
+    "password_authentication": true,
+    "authorized_keys": [
+      "ssh-ed25519 AAAAdefault default@example"
+    ]
+  },
+  "wifi": {
+    "ssid": "DefaultSSID",
+    "password": "default-pass",
+    "country": "US"
+  },
+  "locale": {
+    "timezone": "UTC",
+    "keyboard_layout": "us",
+    "keyboard_variant": ""
+  }
+}
+JSON
+
+secrets_path="${tmpdir}/secrets.env"
+cat >"${secrets_path}" <<'EOFVARS'
+PI_HOSTNAME=secrets-host
+PI_USERNAME=secrets-user
+SSH_ENABLED=true
+SSH_PASSWORD_AUTH=false
+SSH_AUTHORIZED_KEYS=ssh-ed25519 AAAAsecrets secrets@example
+WIFI_SSID=SecretsSSID
+WIFI_PASSWORD=secrets-pass
+WIFI_COUNTRY=CA
+WIFI_HIDDEN=true
+TIMEZONE=America/Toronto
+KEYBOARD_LAYOUT=us
+KEYBOARD_VARIANT=altgr-intl
+EOFVARS
+
+key_file="${tmpdir}/ssh_key.pub"
+cat >"${key_file}" <<'EOFKEY'
+ssh-ed25519 AAAAkeyfile keyfile@example
+EOFKEY
+
+export XDG_CONFIG_HOME="${tmpdir}/config-home"
+output_ini="${tmpdir}/output.ini"
+config_path="${XDG_CONFIG_HOME}/Raspberry Pi/Imager.conf"
+
+python3 "${SCRIPT}" \
+  --preset "${preset_path}" \
+  --secrets "${secrets_path}" \
+  --output "${output_ini}" \
+  --apply \
+  --ssh-authorized-key "ssh-ed25519 AAAAcli cli@example" \
+  --ssh-key-file "${key_file}" \
+  --wifi-ssid "CliSSID" \
+  --wifi-password "cli-pass" \
+  --timezone "America/Chicago"
+
+python3 - <<'PY' "${output_ini}" "${config_path}"
+import configparser
+import pathlib
+import sys
+
+output_path = pathlib.Path(sys.argv[1])
+config_path = pathlib.Path(sys.argv[2])
+
+if not output_path.exists():
+    raise SystemExit(f"output.ini missing: {output_path}")
+if not config_path.exists():
+    raise SystemExit(f"Imager.conf missing: {config_path}")
+
+expected_keys = {
+    "ssh-ed25519 AAAAdefault default@example",
+    "ssh-ed25519 AAAAsecrets secrets@example",
+    "ssh-ed25519 AAAAcli cli@example",
+    "ssh-ed25519 AAAAkeyfile keyfile@example",
+}
+
+parser = configparser.ConfigParser()
+parser.optionxform = str
+parser.read(output_path, encoding="utf-8")
+settings = parser["imagecustomization"]
+
+assert settings["sshEnabled"] == "true"
+assert settings["hostname"] == "secrets-host"
+assert settings["sshUserName"] == "secrets-user"
+assert settings["wifiSSID"] == "CliSSID"
+assert settings["wifiPassword"] == "cli-pass"
+assert settings["wifiCountry"] == "CA"
+assert settings["wifiSSIDHidden"] == "true"
+assert settings["timezone"] == "America/Chicago"
+assert settings["keyboardLayout"] == "us"
+assert settings["keyboardVariant"] == "altgr-intl"
+
+actual_keys = set(settings["sshAuthorizedKeys"].splitlines())
+assert actual_keys == expected_keys, actual_keys
+
+imager_parser = configparser.ConfigParser()
+imager_parser.optionxform = str
+imager_parser.read(config_path, encoding="utf-8")
+imager_settings = imager_parser["imagecustomization"]
+
+assert dict(imager_settings) == dict(settings)
+PY
+
+echo "render_pi_imager_preset e2e test passed"

--- a/tests/test_pi_image_tooling.py
+++ b/tests/test_pi_image_tooling.py
@@ -134,6 +134,17 @@ def test_pi_image_workflow_collects_from_deploy_root():
     assert "bash scripts/collect_pi_image.sh . ./sugarkube.img.xz" not in content
 
 
+def test_pi_image_workflow_covers_preset_and_download_scripts():
+    workflow_path = Path(".github/workflows/pi-image.yml")
+    content = workflow_path.read_text()
+    paths = _extract_pull_request_paths(content)
+
+    assert "scripts/download_pi_image.sh" in paths
+    assert "scripts/render_pi_imager_preset.py" in paths
+    assert "tests/render_pi_imager_preset_e2e.sh" in content
+    assert "Run Pi Imager preset e2e test" in content
+
+
 def _collect_checkout_refs(workflow_text: str) -> list[str]:
     pattern = re.compile(r"uses:\s*actions/checkout@(?P<ref>[^\s]+)")
     return pattern.findall(workflow_text)


### PR DESCRIPTION
what: add preset/download helpers to the pi-image path filter, wire in a
      render_pi_imager_preset e2e script, and document the outage.
why: pi-image changes to the download and preset helpers skipped the unit
     job, so regressions merged unnoticed and broke the manual build.
how to test: bash tests/render_pi_imager_preset_e2e.sh && pytest
             tests/test_pi_image_tooling.py
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68edf929d6b0832f8161c780775266cd