### PR TITLE
Ensure pi-gen just verification writes to LOG_FILE

### DIFF
--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -421,8 +421,11 @@ if ! command -v just >/dev/null 2>&1; then
 fi
 
 log_build() {
-  if [ -n "${BUILD_LOG:-}" ]; then
-    printf '%s\n' "$1" | tee -a "${BUILD_LOG}"
+  local log_target="${BUILD_LOG:-${LOG_FILE:-}}"
+  if [ -n "${log_target}" ] && [ -d "$(dirname "${log_target}")" ]; then
+    if ! printf '%s\n' "$1" | tee -a "${log_target}"; then
+      printf '%s\n' "$1"
+    fi
   else
     printf '%s\n' "$1"
   fi

--- a/tests/test_pi_image_tooling.py
+++ b/tests/test_pi_image_tooling.py
@@ -79,6 +79,8 @@ def test_just_installation_script_includes_fallback(tmp_path):
     script_text = script_path.read_text()
 
     assert 'apt-get "${APT_OPTS[@]}" install -y --no-install-recommends just' in script_text
+    assert "${BUILD_LOG:-${LOG_FILE:-}}" in script_text
+    assert 'tee -a "${log_target}"' in script_text
     assert "https://just.systems/install.sh" in script_text
     assert "[sugarkube] just command verified" in script_text
     assert "just --version" in script_text


### PR DESCRIPTION
what:
- add a LOG_FILE fallback when logging the just verification in chroot
- extend the tooling test to assert the new logging fallback

why:
- recent pi-gen builds expose LOG_FILE instead of BUILD_LOG in chroot
  so the verification log line was missing from deploy artifacts

how to test:
- pytest tests/test_pi_image_tooling.py::test_just_installation_script_includes_fallback
- pre-commit run --all-files (fails: existing E501 violations in tests/test_flash_pi_justfile.py)
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68edf9a4c374832fa57b66d2464d787b