### PR TITLE
Update pi-image checkout to Node24-compatible v5

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -36,7 +36,7 @@ jobs:
   unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.3.0
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - name: Install collector dependencies
@@ -70,7 +70,7 @@ jobs:
       CLONE_TOKEN_PLACE: ${{ github.event.inputs.clone_token_place }}
       CLONE_DSPACE: ${{ github.event.inputs.clone_dspace }}
     steps:
-      - uses: actions/checkout@v4.3.0
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/outages/2025-11-10-pi-image-checkout-node24-revival.json
+++ b/outages/2025-11-10-pi-image-checkout-node24-revival.json
@@ -1,0 +1,11 @@
+{
+  "id": "2025-11-10-pi-image-checkout-node24-revival",
+  "date": "2025-11-10",
+  "component": "pi-image workflow",
+  "rootCause": "GitHub runners now execute JavaScript actions on Node 24 when FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 is set. actions/checkout@v4.3.0 still shipped a Node 20 runtime bundle, so the unit job aborted before cloning the repository.",
+  "resolution": "Upgrade pi-image.yml to actions/checkout@v5, which bundles a Node 24-compatible runtime, and extend workflow tooling tests to assert the new tag.",
+  "references": [
+    ".github/workflows/pi-image.yml",
+    "tests/test_pi_image_tooling.py"
+  ]
+}

--- a/tests/test_pi_image_tooling.py
+++ b/tests/test_pi_image_tooling.py
@@ -151,7 +151,7 @@ def test_pi_image_workflow_pins_checkout_version():
     assert refs, "No actions/checkout references found in pi-image workflow"
 
     for ref in refs:
-        assert ref == "v4.3.0", f"Expected actions/checkout@v4.3.0, found {ref}"
+        assert ref == "v5", f"Expected actions/checkout@v5, found {ref}"
 
 
 def test_pi_image_workflow_checkout_refs_exist_upstream():


### PR DESCRIPTION
## Summary
- bump the pi-image workflow to actions/checkout@v5 so Node24 runs succeed
- record the Node24 regression in outages and update tooling tests to guard the tag

## Testing
- pytest tests/test_pi_image_tooling.py

------
https://chatgpt.com/codex/tasks/task_e_68edf929d6b0832f8161c780775266cd