### PR TITLE
🛡️ : – Add resilient pi-gen cache key helper

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Run build metadata smoke test
         run: bash tests/create_build_metadata_e2e.sh
 
+      - name: Run pi-gen cache key e2e test
+        run: bash tests/compute_pi_gen_cache_key_e2e.sh
+
       - name: Run fix permissions e2e test
         run: bash tests/fix_pi_image_permissions_e2e.sh
 
@@ -109,10 +112,12 @@ jobs:
 
       - name: Compute pi-gen cache key
         id: pigen-key
+        env:
+          PI_GEN_BRANCH: bookworm
+          PI_GEN_REMOTE: https://github.com/RPi-Distro/pi-gen.git
         run: |
-          branch=bookworm
-          ref=$(git ls-remote https://github.com/RPi-Distro/pi-gen.git "refs/heads/${branch}" | cut -f1)
-          echo "key=pigen-${RUNNER_OS}-${branch}-${ref}-$(date +'%Y-%m')" >> "$GITHUB_OUTPUT"
+          key=$(bash scripts/compute_pi_gen_cache_key.sh "${PI_GEN_BRANCH}" "${PI_GEN_REMOTE}")
+          echo "key=${key}" >> "$GITHUB_OUTPUT"
 
       - name: Restore pi-gen Docker image
         id: cache-pigen

--- a/outages/2025-11-10-pi-image-cache-key-fallback.json
+++ b/outages/2025-11-10-pi-image-cache-key-fallback.json
@@ -1,0 +1,13 @@
+{
+  "id": "2025-11-10-pi-image-cache-key-fallback",
+  "date": "2025-11-10",
+  "component": "pi-image workflow",
+  "rootCause": "Cache warmup ran git ls-remote with no retry/fallback; throttling killed it.",
+  "resolution": "Add a helper that warns and falls back to offline key when git ls-remote fails.",
+  "references": [
+    ".github/workflows/pi-image.yml",
+    "scripts/compute_pi_gen_cache_key.sh",
+    "tests/compute_pi_gen_cache_key_e2e.sh",
+    "tests/test_pi_image_tooling.py"
+  ]
+}

--- a/scripts/compute_pi_gen_cache_key.sh
+++ b/scripts/compute_pi_gen_cache_key.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Compute the cache key for the pi-gen Docker image with a graceful fallback.
+set -euo pipefail
+
+BRANCH="${1:-bookworm}"
+REMOTE="${2:-https://github.com/RPi-Distro/pi-gen.git}"
+RUNNER_OS_NAME="${RUNNER_OS:-Linux}"
+
+month="$(date -u +'%Y-%m')"
+ref=""
+
+if ref=$(git ls-remote "${REMOTE}" "refs/heads/${BRANCH}" 2>/dev/null | cut -f1); then
+  if [ -z "${ref}" ]; then
+    echo "warning: git ls-remote succeeded but returned no ref for ${REMOTE} ${BRANCH}" >&2
+    ref="unknown"
+  fi
+else
+  echo "warning: git ls-remote failed for ${REMOTE} ${BRANCH}; falling back to offline cache key" >&2
+  ref="offline"
+fi
+
+printf 'pigen-%s-%s-%s-%s\n' "${RUNNER_OS_NAME}" "${BRANCH}" "${ref}" "${month}"

--- a/tests/compute_pi_gen_cache_key_e2e.sh
+++ b/tests/compute_pi_gen_cache_key_e2e.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Validate scripts/compute_pi_gen_cache_key.sh against success and failure scenarios.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${ROOT_DIR}/scripts/compute_pi_gen_cache_key.sh"
+
+if [ ! -x "${SCRIPT}" ]; then
+  echo "compute_pi_gen_cache_key.sh missing or not executable" >&2
+  exit 1
+fi
+
+tmpdir="$(mktemp -d)"
+cleanup() {
+  rm -rf "${tmpdir}"
+}
+trap cleanup EXIT
+
+remote_repo="${tmpdir}/pi-gen-remote.git"
+work_repo="${tmpdir}/work"
+
+git init --bare "${remote_repo}" >/dev/null 2>&1
+
+git init "${work_repo}" >/dev/null 2>&1
+(
+  cd "${work_repo}"
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  printf 'cache-key-e2e' > README.md
+  git add README.md
+  git commit -m "initial" >/dev/null 2>&1
+  git branch -M main
+  git push "${remote_repo}" main:bookworm >/dev/null 2>&1
+)
+
+commit_ref="$(git --git-dir="${remote_repo}" rev-parse bookworm)"
+expected_month="$(date -u +'%Y-%m')"
+
+runner_label="TestOS"
+key_output="$(RUNNER_OS="${runner_label}" bash "${SCRIPT}" bookworm "${remote_repo}")"
+expected_key="pigen-${runner_label}-bookworm-${commit_ref}-${expected_month}"
+if [ "${key_output}" != "${expected_key}" ]; then
+  printf 'unexpected cache key: got %s expected %s\n' "${key_output}" "${expected_key}" >&2
+  exit 1
+fi
+
+offline_output="$(RUNNER_OS="OfflineOS" bash "${SCRIPT}" bookworm "${tmpdir}/missing.git" 2>"${tmpdir}/stderr.log")"
+if [[ "${offline_output}" != pigen-OfflineOS-bookworm-offline-${expected_month} ]]; then
+  printf 'offline cache key mismatch: %s\n' "${offline_output}" >&2
+  exit 1
+fi
+
+if ! grep -q "falling back to offline cache key" "${tmpdir}/stderr.log"; then
+  echo "expected fallback warning not emitted" >&2
+  exit 1
+fi
+
+echo "compute_pi_gen_cache_key e2e test passed"

--- a/tests/test_pi_image_tooling.py
+++ b/tests/test_pi_image_tooling.py
@@ -245,6 +245,20 @@ def test_pi_image_workflow_upload_artifact_refs_exist_upstream():
         assert result.stdout.strip(), f"actions/upload-artifact tag {ref} missing upstream"
 
 
+def test_pi_image_workflow_uses_cache_key_script():
+    workflow_path = Path(".github/workflows/pi-image.yml")
+    content = workflow_path.read_text()
+    assert "scripts/compute_pi_gen_cache_key.sh" in content
+    assert "key=$(bash scripts/compute_pi_gen_cache_key.sh" in content
+
+
+def test_compute_pi_gen_cache_key_script_has_fallback():
+    script_path = Path("scripts/compute_pi_gen_cache_key.sh")
+    script_text = script_path.read_text()
+    assert "falling back to offline cache key" in script_text
+    assert "git ls-remote" in script_text
+
+
 def test_collect_pi_image_scan_depth_configurable():
     script_path = Path("scripts/collect_pi_image.sh")
     script_text = script_path.read_text()


### PR DESCRIPTION
what: add cache key helper script and wire it into pi-image workflow
why: git ls-remote failures should not abort the build outright
how to test: bash tests/compute_pi_gen_cache_key_e2e.sh && pytest tests/test_pi_image_tooling.py -q

------
https://chatgpt.com/codex/tasks/task_e_68edf929d6b0832f8161c780775266cd