### PR TITLE
🔧 : – fix pi-gen just log regression

### DIFF
--- a/outages/2025-10-24-pi-image-just-stage-script.json
+++ b/outages/2025-10-24-pi-image-just-stage-script.json
@@ -1,0 +1,10 @@
+{
+  "id": "2025-10-24-pi-image-just-stage-script",
+  "date": "2025-10-24",
+  "component": "pi-image workflow",
+  "rootCause": "An upstream pi-gen refactor now only executes files named 'NN-run-chroot.sh'. Our just installer stayed at stage2/01-sys-tweaks/03-run-chroot-just.sh, so the script never ran, 'just' was missing from the image, and the '[sugarkube] just command verified' log line stopped appearing.",
+  "resolution": "Install the script as 03-run-chroot.sh and symlink the legacy 03-run-chroot-just.sh path so pi-gen executes it while tests keep their context. Added regression coverage to assert the canonical script exists and the symlink resolves to it.",
+  "references": [
+    "https://github.com/futuroptimist/sugarkube/actions/runs/18489293807"
+  ]
+}

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -353,8 +353,9 @@ esac
 export PATH
 EOSH
 
-just_install_script="${PI_GEN_DIR}/stage2/01-sys-tweaks/03-run-chroot-just.sh"
-install -d "$(dirname "${just_install_script}")"
+just_install_dir="${PI_GEN_DIR}/stage2/01-sys-tweaks"
+install -d "${just_install_dir}"
+just_install_script="${just_install_dir}/03-run-chroot.sh"
 cat >"${just_install_script}" <<'EOSH'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -454,6 +455,9 @@ if [ -f /opt/sugarkube/justfile ]; then
 fi
 EOSH
 chmod +x "${just_install_script}"
+
+# Provide a suffixed symlink for clarity and backward-compatible tests.
+ln -sf "03-run-chroot.sh" "${just_install_dir}/03-run-chroot-just.sh"
 
 # If a TUNNEL_TOKEN_FILE is provided but TUNNEL_TOKEN is not, load it from file
 if [ -n "${TUNNEL_TOKEN_FILE:-}" ] && [ -z "${TUNNEL_TOKEN:-}" ]; then

--- a/tests/test_pi_image_tooling.py
+++ b/tests/test_pi_image_tooling.py
@@ -74,8 +74,15 @@ def test_just_installation_script_includes_fallback(tmp_path):
     assert result.returncode == 0
 
     work_dir = _extract_work_dir(result.stdout)
-    script_path = work_dir / "pi-gen" / "stage2" / "01-sys-tweaks" / "03-run-chroot-just.sh"
+    script_dir = work_dir / "pi-gen" / "stage2" / "01-sys-tweaks"
+    script_path = script_dir / "03-run-chroot.sh"
+    legacy_script = script_dir / "03-run-chroot-just.sh"
+
     assert script_path.exists(), script_path
+    if legacy_script.exists():
+        assert legacy_script.is_symlink(), legacy_script
+        assert legacy_script.readlink() == Path("03-run-chroot.sh")
+
     script_text = script_path.read_text()
 
     assert 'apt-get "${APT_OPTS[@]}" install -y --no-install-recommends just' in script_text


### PR DESCRIPTION
what: install 03-run-chroot.sh with a -just symlink and update tests.
why: pi-gen requires 03-run-chroot.sh and skipped our suffixed script.
how to test: pytest tests/test_pi_image_tooling.py
how to test: bash tests/artifact_detection_test.sh
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68eec1d0f0dc832fa6789cba5bd6ae9e