### PR TITLE
Recover just verification logs from pi-gen stage outputs

### DIFF
--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -344,6 +344,7 @@ def _setup_build_env(
     precompressed: bool = False,
     nested_log: bool = False,
     compressed_log: bool = False,
+    stage_log: bool = False,
 ):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
@@ -424,7 +425,14 @@ fi
         "mkdir -p deploy\n"
         'cp config "$OUTPUT_DIR/config.env"\n'
         f"{image_cmd}"
-        "if [ \"${PI_GEN_NESTED_BUILD_LOG:-0}\" -eq 1 ]; then\n"
+        "if [ \"${PI_GEN_STAGE_JUST_LOG:-0}\" -eq 1 ]; then\n"
+        "  mkdir -p work/sugarkube/logs/stage2/01-sys-tweaks\n"
+        "  printf '[sugarkube] just command verified\\n[sugarkube] just version: stub\\n' > "
+        "work/sugarkube/logs/stage2/01-sys-tweaks/03-run-chroot.log\n"
+        "  mkdir -p work/sugarkube\n"
+        "  printf '[sugarkube] stage logs archived\\n' > work/sugarkube/build.log\n"
+        "  build_log_path=work/sugarkube/build.log\n"
+        "elif [ \"${PI_GEN_NESTED_BUILD_LOG:-0}\" -eq 1 ]; then\n"
         "  mkdir -p work/sugarkube/logs/2025-10-31\n"
         "  printf '[sugarkube] just command verified\\n[sugarkube] just version: stub\\n' > "
         "work/sugarkube/logs/2025-10-31/build.log\n"
@@ -476,6 +484,8 @@ fi
         env["PI_GEN_NESTED_BUILD_LOG"] = "1"
     if compressed_log:
         env["PI_GEN_COMPRESSED_BUILD_LOG"] = "1"
+    if stage_log:
+        env["PI_GEN_STAGE_JUST_LOG"] = "1"
     return env
 
 
@@ -677,6 +687,20 @@ def test_build_log_handles_compressed_logs(tmp_path):
     log_text = deploy_log.read_text()
     assert "[sugarkube] just command verified" in log_text
     assert "build.log.xz" in log_text
+    host_log = tmp_path / "sugarkube.build.log"
+    assert host_log.exists()
+    assert host_log.read_text() == log_text
+
+
+def test_build_log_recovers_stage_just_log(tmp_path):
+    env = _setup_build_env(tmp_path, stage_log=True)
+    result, _ = _run_build_script(tmp_path, env)
+    assert result.returncode == 0
+    deploy_log = tmp_path / "deploy" / "sugarkube.build.log"
+    assert deploy_log.exists()
+    log_text = deploy_log.read_text()
+    assert "[sugarkube] just command verified" in log_text
+    assert "stage log appended" in log_text
     host_log = tmp_path / "sugarkube.build.log"
     assert host_log.exists()
     assert host_log.read_text() == log_text


### PR DESCRIPTION
## Summary
- backfill the just verification line when pi-gen moves logs into stage files
- add coverage to ensure stage log recovery keeps the marker in final logs

## Testing
- pytest tests/build_pi_image_test.py::test_build_log_recovers_stage_just_log


------
https://chatgpt.com/codex/tasks/task_e_68eed5c0116c832fa3dbb7c9de571f53