### PR TITLE
Add Pi 5 NVMe migration happy path automation

### DIFF
--- a/docs/raspi-image-spot-check.md
+++ b/docs/raspi-image-spot-check.md
@@ -1,0 +1,97 @@
+# Raspberry Pi Image Spot Check (Pi 5 + Bookworm)
+
+This guide replaces the ad-hoc checklist with a single command that captures logs,
+JSON, and Markdown summaries. It targets Raspberry Pi 5 hardware running Raspberry
+Pi OS Bookworm with `/boot/firmware`.
+
+> **Happy path:** `just migrate-to-nvme` runs the spot check, ensures the EEPROM
+> prefers NVMe, clones the SD card to NVMe, and reboots. See [Next steps](#next-steps-clone-to-nvme).
+
+## Run the automated spot check
+
+```bash
+just spot-check
+```
+
+The helper wraps `scripts/spot_check.sh` and writes artifacts to
+`artifacts/spot-check/`:
+
+- `summary.json` – machine-readable check results
+- `summary.md` – human-readable table
+- `raw/` – command outputs for audits (`uname`, `timedatectl`, ping stats, etc.)
+
+The command exits non-zero if any **required** check fails and prints a concise
+summary in the terminal:
+
+```
+Raspberry Pi image spot check summary:
+✅ System baseline — Raspberry Pi OS (Bookworm) kernel 6.12.x on aarch64 host pi5
+✅ Time & locale — TZ=America/Los_Angeles NTP=yes LANG=en_US.UTF-8
+✅ Storage layout — root=/dev/mmcblk0p2 boot=/dev/mmcblk0p1
+✅ Networking — LAN loss=0% avg=0.25ms; WAN loss=0% avg=18.3ms
+⚠️ Ethernet link — eth0 100Mb/s (warns if < 1000Mb/s or unknown)
+✅ Services & logs — No unexpected services or errors
+✅ Health — temp=43.5C throttle=0x0 mem_avail=7.3Gi
+⚠️ Repo sync — Missing repos: token.place (warn only)
+```
+
+## Pass/fail criteria
+
+| Check | Requirement |
+| --- | --- |
+| System baseline | `VERSION_CODENAME=bookworm`, `uname -m=aarch64`, kernel ≥ 6.12 |
+| Time & locale | `timedatectl` reports `NTPSynchronized=yes`; timezone populated; `LANG` set |
+| Storage | `/` on `/dev/mmcblk0p2`; `/boot/firmware` on `/dev/mmcblk0p1`; UUIDs captured |
+| Networking | LAN + WAN pings complete with 0% loss (averages recorded in artifacts) |
+| Ethernet link | Warns if `< 1000Mb/s` or unavailable (does not fail) |
+| Services/logs | No running `flywheel`, `k3s`, `cloudflared`, `containerd`; no unexpected `journalctl -b -p3` errors |
+| Health | `vcgencmd measure_temp` < 60 °C, `free --giga` > 7 Gi available on 8 GB models, `vcgencmd get_throttled=0x0` |
+| Repo sync (optional) | Warns if `/home/pi/{sugarkube,dspace,token.place}` missing |
+
+### Known benign log noise
+
+The spot check tolerates these messages when scanning `journalctl -b -p 3`:
+
+- Bluetooth `vcp/mcp/bap` plugin initialisation warnings
+- `wpa_supplicant: bgscan simple` notices
+
+Unexpected priority-3 errors remain a failure.
+
+### Troubleshooting failures
+
+| Symptom | Quick fix |
+| --- | --- |
+| Kernel < 6.12 | Update Raspberry Pi OS packages (`sudo apt full-upgrade`) and reboot |
+| `vcgencmd get_throttled` ≠ `0x0` | Use the official 27 W USB-C PSU or reduce USB peripherals |
+| WAN ping loss > 0% | Check ethernet cabling, VLAN tags, or upstream firewall |
+| Repo warnings | Clone the missing repos under `/home/pi` if your image profile expects them |
+
+## Next steps: clone to NVMe
+
+When the spot check passes, you can migrate in one command:
+
+```bash
+sudo just migrate-to-nvme
+```
+
+The happy path performs:
+
+1. `just spot-check`
+2. `just eeprom-nvme-first` *(skip with `SKIP_EEPROM=1`)*
+3. `just clone-ssd` *(autodetects `/dev/nvme0n1`; override with `TARGET=/dev/sdX`)*
+4. Automatic reboot *(skip with `NO_REBOOT=1`)*
+
+After the reboot, confirm the system runs entirely from NVMe:
+
+```bash
+just post-clone-verify  # expects / and /boot/firmware on /dev/nvme0n1p{2,1}
+```
+
+For clusters, prepare kernel knobs that k3s CNIs expect:
+
+```bash
+sudo just k3s-preflight
+```
+
+This loads `br_netfilter`, enables `net.ipv4.ip_forward=1`, and sets the bridge
+nf iptables toggles without enabling k3s yet.

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -332,7 +332,14 @@ USER_DATA="${PI_GEN_DIR}/stage2/01-sys-tweaks/user-data"
 cp "${CLOUD_INIT_PATH}" "${USER_DATA}"
 
 ensure_packages "${PI_GEN_DIR}/stage2/01-sys-tweaks/00-packages" \
-  policykit-1
+  policykit-1 \
+  rpi-eeprom \
+  libraspberrypi-bin \
+  ethtool \
+  network-manager \
+  jq \
+  parted \
+  util-linux
 
 just_path_profile="${PI_GEN_DIR}/stage2/01-sys-tweaks/files/etc/profile.d/sugarkube-path.sh"
 install -d "$(dirname "${just_path_profile}")"
@@ -505,15 +512,42 @@ install -Dm755 "${REPO_ROOT}/scripts/sugarkube_teams.py" \
 install -Dm755 "${REPO_ROOT}/scripts/sugarkube_teams.py" \
   "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/usr/local/bin/sugarkube-teams"
 
+install -Dm755 "${REPO_ROOT}/scripts/spot_check.sh" \
+  "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/opt/sugarkube/scripts/spot_check.sh"
+
+install -Dm755 "${REPO_ROOT}/scripts/detect_target_disk.sh" \
+  "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/opt/sugarkube/scripts/detect_target_disk.sh"
+
+install -Dm755 "${REPO_ROOT}/scripts/eeprom_nvme_first.sh" \
+  "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/opt/sugarkube/scripts/eeprom_nvme_first.sh"
+
+install -Dm755 "${REPO_ROOT}/scripts/clone_to_nvme.sh" \
+  "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/opt/sugarkube/scripts/clone_to_nvme.sh"
+
+install -Dm755 "${REPO_ROOT}/scripts/post_clone_verify.sh" \
+  "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/opt/sugarkube/scripts/post_clone_verify.sh"
+
+install -Dm755 "${REPO_ROOT}/scripts/k3s_preflight.sh" \
+  "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/opt/sugarkube/scripts/k3s_preflight.sh"
+
+install -Dm755 "${REPO_ROOT}/systemd/first-boot-prepare.sh" \
+  "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/opt/sugarkube/systemd/first-boot-prepare.sh"
+
 install -Dm644 "${REPO_ROOT}/scripts/systemd/first-boot.service" \
   "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/etc/systemd/system/first-boot.service"
 
 install -Dm644 "${REPO_ROOT}/scripts/systemd/ssd-clone.service" \
   "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/etc/systemd/system/ssd-clone.service"
 
+install -Dm644 "${REPO_ROOT}/systemd/first-boot-prepare.service" \
+  "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/etc/systemd/system/first-boot-prepare.service"
+
 install -d "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/etc/systemd/system/multi-user.target.wants"
 ln -sf ../first-boot.service \
   "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/etc/systemd/system/multi-user.target.wants/first-boot.service"
+
+ln -sf ../first-boot-prepare.service \
+  "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/etc/systemd/system/multi-user.target.wants/first-boot-prepare.service"
 
 
 install -Dm644 "${REPO_ROOT}/scripts/udev/99-sugarkube-ssd-clone.rules" \

--- a/scripts/clone_to_nvme.sh
+++ b/scripts/clone_to_nvme.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# clone_to_nvme.sh - Clone the running SD card to an attached NVMe/USB SSD and fix Bookworm boot UUIDs.
+# Usage: sudo scripts/clone_to_nvme.sh [TARGET=/dev/nvme0n1]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ARTIFACT_DIR="${REPO_ROOT}/artifacts/clone-to-nvme"
+mkdir -p "${ARTIFACT_DIR}"
+LOG_FILE="${ARTIFACT_DIR}/clone.log"
+exec > >(tee -a "${LOG_FILE}") 2>&1
+
+sudo_prefix=()
+if [[ $(id -u) -ne 0 ]]; then
+  sudo_prefix=(sudo)
+fi
+
+ensure_rpi_clone() {
+  if command -v rpi-clone >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "[clone] Installing geerlingguy/rpi-clone" >&2
+  if ! curl -fsSL https://raw.githubusercontent.com/geerlingguy/rpi-clone/master/install | "${sudo_prefix[@]}" bash; then
+    echo "[clone] Failed to install rpi-clone" >&2
+    exit 1
+  fi
+}
+
+resolve_target() {
+  if [[ -n "${TARGET:-}" ]]; then
+    local override="${TARGET}"
+    if [[ "${override}" != /dev/* ]]; then
+      override="/dev/${override}"
+    fi
+    printf '%s\n' "${override}"
+    return 0
+  fi
+  "${SCRIPT_DIR}/detect_target_disk.sh"
+}
+
+validate_target() {
+  local target="$1"
+  if [[ ! -b "${target}" ]]; then
+    echo "[clone] Target ${target} is not a block device" >&2
+    exit 1
+  fi
+  if [[ "${target}" == /dev/mmcblk0* ]]; then
+    echo "[clone] Refusing to operate on the boot SD card (${target})." >&2
+    exit 1
+  fi
+
+  local mounted
+  mounted=$(lsblk -nrpo NAME,MOUNTPOINT "${target}" | awk 'NR>1 && $2!="" {print $1 ":" $2}')
+  if [[ -n "${mounted}" ]]; then
+    echo "[clone] Target has mounted partitions:\n${mounted}" >&2
+    exit 1
+  fi
+}
+
+maybe_wipe() {
+  local target="$1"
+  if [[ "${WIPE:-0}" == "1" ]]; then
+    echo "[clone] Wiping filesystem signatures from ${target}" >&2
+    "${sudo_prefix[@]}" wipefs --all --force "${target}"
+  fi
+}
+
+get_clone_mount() {
+  if mountpoint -q /mnt/clone; then
+    echo "/mnt/clone"
+  else
+    echo "[clone] Expected /mnt/clone to be mounted by rpi-clone" >&2
+    exit 1
+  fi
+}
+
+extract_uuid() {
+  local device="$1" key="$2"
+  blkid -s "${key}" -o value "${device}" 2>/dev/null || true
+}
+
+update_cmdline_root() {
+  local cmdline_path="$1" new_value="$2" key="$3"
+  if [[ ! -f "${cmdline_path}" ]]; then
+    echo "[clone] cmdline.txt missing at ${cmdline_path}" >&2
+    exit 1
+  fi
+  python3 - "$cmdline_path" "$key" "$new_value" <<'PY'
+import pathlib, sys
+cmdline = pathlib.Path(sys.argv[1])
+key = sys.argv[2]
+value = sys.argv[3]
+text = cmdline.read_text(encoding="utf-8").strip()
+parts = text.split()
+found = False
+for idx, token in enumerate(parts):
+    if token.startswith("root="):
+        parts[idx] = f"root={key}={value}"
+        found = True
+        break
+if not found:
+    parts.append(f"root={key}={value}")
+cmdline.write_text(" ".join(parts) + "\n", encoding="utf-8")
+PY
+}
+
+update_fstab_entries() {
+  local fstab_path="$1" root_device="$2" boot_device="$3" root_key="$4" boot_key="$5"
+  if [[ ! -f "${fstab_path}" ]]; then
+    echo "[clone] fstab missing at ${fstab_path}" >&2
+    exit 1
+  fi
+  python3 - "$fstab_path" "$root_device" "$boot_device" "$root_key" "$boot_key" <<'PY'
+import pathlib, sys
+fstab = pathlib.Path(sys.argv[1])
+root_value, boot_value = sys.argv[2], sys.argv[3]
+root_key, boot_key = sys.argv[4], sys.argv[5]
+lines = []
+for line in fstab.read_text(encoding="utf-8").splitlines():
+    if not line.strip() or line.strip().startswith("#"):
+        lines.append(line)
+        continue
+    parts = line.split()
+    if len(parts) < 2:
+        lines.append(line)
+        continue
+    mount = parts[1]
+    if mount == "/":
+        parts[0] = f"{root_key}={root_value}"
+    elif mount in {"/boot/firmware", "/boot"}:
+        parts[0] = f"{boot_key}={boot_value}"
+    lines.append("\t".join(parts))
+fstab.write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+}
+
+main() {
+  local extra_args=("$@")
+  ensure_rpi_clone
+  local target
+  target="$(resolve_target)"
+  target="${target//$'\n'/}"
+  if [[ -z "${target}" ]]; then
+    echo "[clone] No target disk detected" >&2
+    exit 1
+  fi
+  validate_target "${target}"
+  maybe_wipe "${target}"
+
+  echo "[clone] Starting unattended clone to ${target}" >&2
+  "${sudo_prefix[@]}" rpi-clone -f -u "${target}" "${extra_args[@]}"
+
+  local clone_mount
+  clone_mount="$(get_clone_mount)"
+
+  local root_source boot_source root_key boot_key
+  root_source="$(findmnt -n -o SOURCE --target "${clone_mount}")"
+  boot_source="$(findmnt -n -o SOURCE --target "${clone_mount}/boot" 2>/dev/null || true)"
+  if [[ -z "${boot_source}" ]]; then
+    boot_source="$(findmnt -n -o SOURCE --target "${clone_mount}/boot/firmware" 2>/dev/null || true)"
+  fi
+
+  if [[ -z "${root_source}" ]]; then
+    echo "[clone] Unable to determine cloned root partition." >&2
+    exit 1
+  fi
+  if [[ -z "${boot_source}" ]]; then
+    echo "[clone] Unable to determine cloned boot partition." >&2
+    exit 1
+  fi
+
+  root_key="PARTUUID"
+  boot_key="PARTUUID"
+  local root_uuid boot_uuid
+  root_uuid="$(extract_uuid "${root_source}" "PARTUUID")"
+  boot_uuid="$(extract_uuid "${boot_source}" "PARTUUID")"
+  if [[ -z "${root_uuid}" ]]; then
+    root_uuid="$(extract_uuid "${root_source}" "UUID")"
+    root_key="UUID"
+  fi
+  if [[ -z "${boot_uuid}" ]]; then
+    boot_uuid="$(extract_uuid "${boot_source}" "UUID")"
+    boot_key="UUID"
+  fi
+
+  local firmware_dir="${clone_mount}/boot/firmware"
+  if [[ ! -d "${firmware_dir}" ]]; then
+    firmware_dir="${clone_mount}/boot"
+  fi
+
+  update_cmdline_root "${firmware_dir}/cmdline.txt" "${root_uuid}" "${root_key}"
+  update_fstab_entries "${clone_mount}/etc/fstab" "${root_uuid}" "${boot_uuid}" "${root_key}" "${boot_key}"
+
+  local bytes_cloned
+  bytes_cloned=$("${sudo_prefix[@]}" blockdev --getsize64 "${target}")
+  printf '[clone] Completed clone to %s (root %s=%s, boot %s=%s, bytes=%s)\n' \
+    "${target}" "${root_key}" "${root_uuid}" "${boot_key}" "${boot_uuid}" "${bytes_cloned}"
+}
+
+main "$@"

--- a/scripts/detect_target_disk.sh
+++ b/scripts/detect_target_disk.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# detect_target_disk.sh - Identify the first non-SD whole-disk device (prefer NVMe) for cloning.
+# Usage: scripts/detect_target_disk.sh
+set -euo pipefail
+
+prefer_device() {
+  local device="$1"
+  if [[ -b "/dev/${device}" ]]; then
+    printf '/dev/%s\n' "${device}"
+    return 0
+  fi
+  return 1
+}
+
+main() {
+  if [[ $(id -u) -ne 0 ]]; then
+    echo "This helper should run as root to ensure accurate block device visibility." >&2
+  fi
+
+  if prefer_device "nvme0n1"; then
+    return 0
+  fi
+
+  local candidates
+  mapfile -t candidates < <(lsblk -ndo NAME,TYPE | awk '$2=="disk" {print $1}')
+
+  for name in "${candidates[@]}"; do
+    if [[ -z "${name}" ]]; then
+      continue
+    fi
+    if [[ "${name}" == mmcblk0* ]]; then
+      continue
+    fi
+    # Skip loopback and mapper devices that mirror the boot media.
+    if [[ "${name}" == loop* || "${name}" == mmcblk* ]]; then
+      continue
+    fi
+    if [[ -b "/dev/${name}" ]]; then
+      printf '/dev/%s\n' "${name}"
+      return 0
+    fi
+  done
+
+  echo "Unable to detect a target disk that differs from the boot SD card." >&2
+  return 1
+}
+
+main "$@"

--- a/scripts/eeprom_nvme_first.sh
+++ b/scripts/eeprom_nvme_first.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# eeprom_nvme_first.sh - Ensure the Raspberry Pi bootloader prefers NVMe and enables PCIe probing.
+# Usage: sudo scripts/eeprom_nvme_first.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ARTIFACT_DIR="${REPO_ROOT}/artifacts/eeprom"
+mkdir -p "${ARTIFACT_DIR}"
+LOG_FILE="${ARTIFACT_DIR}/nvme-first.log"
+exec > >(tee -a "${LOG_FILE}") 2>&1
+
+trap 'echo "[eeprom] failure" >&2' ERR
+
+echo "[eeprom] Ensuring firmware utilities are available"
+if ! command -v rpi-eeprom-update >/dev/null 2>&1; then
+  echo "rpi-eeprom-update command not found. Install the rpi-eeprom package." >&2
+  exit 1
+fi
+
+sudo_prefix=()
+if [[ $(id -u) -ne 0 ]]; then
+  sudo_prefix=(sudo)
+fi
+
+update_output="$(${sudo_prefix[@]} rpi-eeprom-update -a)"
+printf '%s\n' "${update_output}"
+
+orig_config="$(mktemp)"
+trap 'rm -f "${orig_config}" "${orig_config}.new"' EXIT
+
+${sudo_prefix[@]} rpi-eeprom-config --out "${orig_config}"
+cp "${orig_config}" "${orig_config}.new"
+
+set_config_value() {
+  local key="$1" value="$2"
+  if grep -q "^${key}=" "${orig_config}.new"; then
+    sed -i "s/^${key}=.*/${key}=${value}/" "${orig_config}.new"
+  else
+    printf '%s=%s\n' "${key}" "${value}" >>"${orig_config}.new"
+  fi
+}
+
+set_config_value "BOOT_ORDER" "0xf416"
+set_config_value "PCIE_PROBE" "1"
+
+if cmp -s "${orig_config}" "${orig_config}.new"; then
+  echo "[eeprom] Bootloader already prefers NVMe with PCIe probing enabled."
+  exit 0
+fi
+
+${sudo_prefix[@]} rpi-eeprom-config --apply "${orig_config}.new"
+
+echo "[eeprom] Updated bootloader configuration to prioritize NVMe (BOOT_ORDER=0xf416, PCIE_PROBE=1)."

--- a/scripts/k3s_preflight.sh
+++ b/scripts/k3s_preflight.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# k3s_preflight.sh - Prepare kernel modules and sysctl toggles commonly required for k3s workloads.
+# Usage: sudo scripts/k3s_preflight.sh
+set -euo pipefail
+
+sudo_prefix=()
+if [[ $(id -u) -ne 0 ]]; then
+  sudo_prefix=(sudo)
+fi
+
+declare -a changes
+
+ensure_module() {
+  local module="$1"
+  if lsmod | awk '{print $1}' | grep -qx "${module}"; then
+    echo "[k3s-preflight] Kernel module ${module} already loaded"
+    return
+  fi
+  if "${sudo_prefix[@]}" modprobe "${module}"; then
+    echo "[k3s-preflight] Loaded ${module}"
+    changes+=("module:${module}")
+  else
+    echo "[k3s-preflight] Failed to load module ${module}" >&2
+  fi
+}
+
+apply_sysctl() {
+  local key="$1" value="$2"
+  local current
+  current=$(sysctl -n "${key}" 2>/dev/null || echo "missing")
+  if [[ "${current}" == "${value}" ]]; then
+    echo "[k3s-preflight] sysctl ${key} already ${value}"
+    return
+  fi
+  if "${sudo_prefix[@]}" sysctl -w "${key}=${value}" >/dev/null; then
+    echo "[k3s-preflight] Set ${key}=${value}"
+    changes+=("sysctl:${key}=${value}")
+  else
+    echo "[k3s-preflight] Failed to set ${key}" >&2
+  fi
+}
+
+ensure_module br_netfilter
+apply_sysctl net.ipv4.ip_forward 1
+apply_sysctl net.bridge.bridge-nf-call-iptables 1
+apply_sysctl net.bridge.bridge-nf-call-ip6tables 1
+
+if [[ ${#changes[@]} -eq 0 ]]; then
+  echo "[k3s-preflight] No changes required; system already k3s-ready."
+else
+  printf '[k3s-preflight] Applied %d change(s): %s\n' "${#changes[@]}" "${changes[*]}"
+fi

--- a/scripts/post_clone_verify.sh
+++ b/scripts/post_clone_verify.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# post_clone_verify.sh - Confirm the system is running from the cloned NVMe root and boot partitions.
+# Usage: scripts/post_clone_verify.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ARTIFACT_DIR="${REPO_ROOT}/artifacts/post-clone"
+mkdir -p "${ARTIFACT_DIR}"
+LOG_FILE="${ARTIFACT_DIR}/verify.log"
+exec > >(tee -a "${LOG_FILE}") 2>&1
+
+root_src="$(findmnt -n -o SOURCE / || true)"
+boot_src="$(findmnt -n -o SOURCE /boot/firmware || true)"
+
+if [[ -z "${root_src}" || -z "${boot_src}" ]]; then
+  echo "[post-clone] Unable to determine current root or boot devices." >&2
+  exit 1
+fi
+
+expected_root_prefix="/dev/nvme0n1p2"
+expected_boot_prefix="/dev/nvme0n1p1"
+
+if [[ "${TARGET:-}" =~ ^/dev/ ]]; then
+  expected_root_prefix="${TARGET}p2"
+  expected_boot_prefix="${TARGET}p1"
+fi
+
+status=0
+if [[ "${root_src}" != "${expected_root_prefix}" ]]; then
+  echo "[post-clone] Root filesystem is ${root_src}, expected ${expected_root_prefix}" >&2
+  status=1
+else
+  echo "[post-clone] Root filesystem verified on ${root_src}."
+fi
+
+if [[ "${boot_src}" != "${expected_boot_prefix}" ]]; then
+  echo "[post-clone] Boot partition is ${boot_src}, expected ${expected_boot_prefix}" >&2
+  status=1
+else
+  echo "[post-clone] Boot partition verified on ${boot_src}."
+fi
+
+if [[ ${status} -ne 0 ]]; then
+  exit ${status}
+fi
+
+echo "[post-clone] System is running entirely from NVMe (${root_src} / ${boot_src})."

--- a/scripts/spot_check.sh
+++ b/scripts/spot_check.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+# spot_check.sh - Run Pi 5 + Bookworm readiness checks with JSON and Markdown summaries.
+# Usage: scripts/spot_check.sh
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ARTIFACT_DIR="${REPO_ROOT}/artifacts/spot-check"
+mkdir -p "${ARTIFACT_DIR}"
+SUMMARY_JSON="${ARTIFACT_DIR}/summary.json"
+SUMMARY_MD="${ARTIFACT_DIR}/summary.md"
+RAW_DIR="${ARTIFACT_DIR}/raw"
+mkdir -p "${RAW_DIR}"
+
+CHECKS_FILE="$(mktemp)"
+trap 'rm -f "${CHECKS_FILE}"' EXIT
+
+declare -a SUMMARY_LINES=()
+FAILURES=0
+
+symbol_for_status() {
+  case "$1" in
+    pass) printf '✅' ;;
+    warn) printf '⚠️' ;;
+    fail) printf '❌' ;;
+    *) printf '❓' ;;
+  esac
+}
+
+record_check() {
+  local id="$1" label="$2" status="$3" required="$4" detail="$5" data="$6"
+  detail="${detail//$'\n'/ }"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$id" "$label" "$status" "$required" "$detail" "$data" >>"${CHECKS_FILE}"
+  SUMMARY_LINES+=("${status}|${label}|${detail}")
+  if [[ "$status" == "fail" && "$required" == "true" ]]; then
+    FAILURES=1
+  fi
+}
+
+save_output() {
+  local name="$1"
+  local file="${RAW_DIR}/${name}.txt"
+  shift
+  "$@" >"${file}" 2>&1 || true
+  echo "${file}"
+}
+
+check_system_baseline() {
+  local uname_out kernel arch codename version hostname status detail
+  uname_out="$(uname -a)"
+  kernel="$(uname -r)"
+  arch="$(uname -m)"
+  hostname="$(hostname)"
+  if [[ -f /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    codename="${VERSION_CODENAME:-unknown}"
+    version="${PRETTY_NAME:-${NAME:-unknown}}"
+  else
+    codename="unknown"
+    version="unknown"
+  fi
+  local kernel_ok=0
+  IFS='.-' read -r k_major k_minor _ <<<"${kernel}"
+  if [[ -n "${k_major}" && -n "${k_minor}" ]] && (( k_major > 6 || (k_major == 6 && k_minor >= 12) )); then
+    kernel_ok=1
+  fi
+  if [[ "${arch}" == "aarch64" && "${codename}" == "bookworm" && ${kernel_ok} -eq 1 ]]; then
+    status="pass"
+  else
+    status="fail"
+  fi
+  detail="${version} (${codename}) kernel ${kernel} on ${arch} host ${hostname}"
+  printf '%s\n' "${uname_out}" >"${RAW_DIR}/uname.txt"
+  record_check "system" "System baseline" "${status}" "true" "${detail}" "{}"
+}
+
+check_time_locale() {
+  local tz ntp_sync lang status detail
+  tz="$(timedatectl show -p Timezone --value 2>/dev/null || echo unknown)"
+  ntp_sync="$(timedatectl show -p NTPSynchronized --value 2>/dev/null || echo no)"
+  lang="$(locale | awk -F= '$1=="LANG" {print $2}' | head -n1)"
+  local ok=true
+  if [[ "${ntp_sync}" != "yes" ]]; then
+    ok=false
+  fi
+  if [[ -z "${tz}" || "${tz}" == "n/a" ]]; then
+    ok=false
+  fi
+  if [[ -z "${lang}" ]]; then
+    ok=false
+  fi
+  if ${ok}; then
+    status="pass"
+  else
+    status="fail"
+  fi
+  save_output "timedatectl" timedatectl status
+  save_output "locale" locale
+  detail="TZ=${tz} NTP=${ntp_sync} LANG=${lang:-unset}"
+  record_check "time" "Time & locale" "${status}" "true" "${detail}" "{}"
+}
+
+build_storage_table() {
+  python3 - <<'PY'
+import json, subprocess
+lsblk = subprocess.check_output([
+    "lsblk", "--json", "-o", "NAME,TYPE,SIZE,MOUNTPOINT,FSTYPE"
+], text=True)
+data = json.loads(lsblk)
+rows = []
+
+def walk(entries, parent=None):
+    for entry in entries:
+        if entry.get("type") == "part":
+            name = entry.get("name")
+            device = f"/dev/{name}"
+            fstype = entry.get("fstype") or ""
+            size = entry.get("size") or ""
+            mount = entry.get("mountpoint") or ""
+            uuid = ""
+            for key in ("PARTUUID", "UUID"):
+                try:
+                    uuid = subprocess.check_output(
+                        ["blkid", "-s", key, "-o", "value", device],
+                        text=True,
+                        stderr=subprocess.DEVNULL,
+                    ).strip()
+                except subprocess.CalledProcessError:
+                    continue
+                if uuid:
+                    break
+            rows.append({
+                "device": device,
+                "fstype": fstype,
+                "size": size,
+                "mount": mount,
+                "uuid": uuid,
+            })
+        if entry.get("children"):
+            walk(entry["children"], entry)
+
+walk(data.get("blockdevices", []))
+print(json.dumps(rows))
+PY
+}
+
+check_storage() {
+  local df_file lsblk_file table_json root_src boot_src status detail
+  df_file="$(save_output "df" df -h)"
+  lsblk_file="$(save_output "lsblk" lsblk -o NAME,TYPE,SIZE,MOUNTPOINT,FSTYPE)"
+  table_json="$(build_storage_table)"
+  printf '%s\n' "${table_json}" >"${ARTIFACT_DIR}/storage.json"
+  root_src="$(findmnt -n -o SOURCE / || true)"
+  boot_src="$(findmnt -n -o SOURCE /boot/firmware || true)"
+  if [[ "${root_src}" == "/dev/mmcblk0p2" && "${boot_src}" == "/dev/mmcblk0p1" ]]; then
+    status="pass"
+  else
+    status="fail"
+  fi
+  detail="root=${root_src:-unknown} boot=${boot_src:-unknown}"
+  record_check "storage" "Storage layout" "${status}" "true" "${detail}" "${table_json}"
+}
+
+run_ping() {
+  local host="$1" label="$2" outfile loss avg status
+  outfile="${RAW_DIR}/ping-${label}.txt"
+  if ping -c 4 -w 5 "${host}" >"${outfile}" 2>&1; then
+    loss="$(awk -F',' '/packets transmitted/ {gsub(/%/, "", $3); gsub(/[^0-9.]/, "", $3); print $3}' "${outfile}" | head -n1)"
+    avg="$(awk -F'/' 'END {print $5}' "${outfile}" || true)"
+    if [[ -z "${loss}" ]]; then
+      loss=0
+    fi
+    if (( ${loss%.*} == 0 )); then
+      status="pass"
+    else
+      status="fail"
+    fi
+  else
+    loss=100
+    avg=0
+    status="fail"
+  fi
+  printf '%s\t%s\t%s\n' "${label}" "${loss}" "${avg}" >>"${RAW_DIR}/ping-summary.tsv"
+  echo "${status}|loss=${loss}% avg=${avg}ms"
+}
+
+check_network() {
+  local gateway lan_result wan_result status detail
+  rm -f "${RAW_DIR}/ping-summary.tsv"
+  gateway="$(ip route | awk '/default/ {print $3; exit}')"
+  if [[ -n "${gateway}" ]]; then
+    lan_result="$(run_ping "${gateway}" "lan")"
+  else
+    lan_result="fail|no default gateway"
+  fi
+  wan_result="$(run_ping "1.1.1.1" "wan")"
+  local lan_status="${lan_result%%|*}" lan_detail="${lan_result#*|}"
+  local wan_status="${wan_result%%|*}" wan_detail="${wan_result#*|}"
+  if [[ "${lan_status}" == "pass" && "${wan_status}" == "pass" ]]; then
+    status="pass"
+  else
+    status="fail"
+  fi
+  detail="LAN ${lan_detail}; WAN ${wan_detail}"
+  record_check "network" "Networking" "${status}" "true" "${detail}" "{}"
+}
+
+check_link_speed() {
+  local speed status detail
+  speed=""
+  if command -v ethtool >/dev/null 2>&1; then
+    speed="$(ethtool eth0 2>/dev/null | awk -F': ' '/Speed:/ {print $2}' | head -n1 | tr -d ' ')"
+  fi
+  if [[ -z "${speed}" ]] && command -v nmcli >/dev/null 2>&1; then
+    speed="$(nmcli dev show eth0 2>/dev/null | awk -F': *' '/GENERAL.SPEED:/ {print $2}' | head -n1 | tr -d ' ')"
+  fi
+  if [[ -z "${speed}" ]]; then
+    status="warn"
+    detail="eth0 speed unavailable"
+  else
+    local numeric
+    numeric="${speed//[^0-9]/}"
+    if [[ -n "${numeric}" && ${numeric} -lt 1000 ]]; then
+      status="warn"
+    else
+      status="pass"
+    fi
+    detail="eth0 ${speed}"
+  fi
+  record_check "link" "Ethernet link" "${status}" "false" "${detail}" "{}"
+}
+
+check_services_logs() {
+  local offenders journal raw_journal filtered status detail
+  offenders="$(systemctl list-units --type=service --state=running 2>/dev/null | grep -E 'flywheel|k3s|cloudflared|containerd' || true)"
+  raw_journal="${RAW_DIR}/journal-priority-3.txt"
+  journalctl -b -p 3 --no-pager >"${raw_journal}" 2>&1 || true
+  filtered="$(grep -Ev -e 'Bluetooth:.*(vcp|mcp|bap)' -e 'wpa_supplicant: bgscan simple' "${raw_journal}" || true)"
+  if [[ -n "${offenders}" ]]; then
+    status="fail"
+    detail="Unexpected services active"
+  elif [[ -n "${filtered}" ]]; then
+    status="fail"
+    detail="Unexpected journal errors"
+  else
+    status="pass"
+    detail="No unexpected services or errors"
+  fi
+  record_check "services" "Services & logs" "${status}" "true" "${detail}" "{}"
+}
+
+check_health() {
+  local temp_line temp_c throttled mem_available status detail
+  if command -v vcgencmd >/dev/null 2>&1; then
+    temp_line="$(vcgencmd measure_temp 2>/dev/null || true)"
+    temp_c="$(printf '%s' "${temp_line}" | sed -E 's/.*=([0-9.]+).*/\1/')"
+  else
+    temp_c=""
+  fi
+  if command -v vcgencmd >/dev/null 2>&1; then
+    throttled="$(vcgencmd get_throttled 2>/dev/null | sed 's/throttled=//')"
+  else
+    throttled="unknown"
+  fi
+  mem_available="$(free --mebi | awk 'NR==2 {print $7}' 2>/dev/null || echo 0)"
+  status="pass"
+  if [[ -n "${temp_c}" && $(printf '%.0f' "${temp_c}") -ge 60 ]]; then
+    status="fail"
+  fi
+  if [[ "${throttled}" != "0x0" ]]; then
+    status="fail"
+  fi
+  if [[ "${mem_available}" -lt 7168 ]]; then
+    status="fail"
+  fi
+  local mem_gi
+  mem_gi=$(awk -v val="${mem_available}" 'BEGIN {printf "%.2f", val/1024}')
+  detail="temp=${temp_c:-n/a}C throttle=${throttled:-n/a} mem_avail=${mem_gi}Gi"
+  record_check "health" "Health" "${status}" "true" "${detail}" "{}"
+}
+
+check_repos() {
+  local base="/home/pi" missing=()
+  local repos=(sugarkube dspace token.place)
+  for repo in "${repos[@]}"; do
+    if [[ ! -d "${base}/${repo}" ]]; then
+      missing+=("${repo}")
+    fi
+  done
+  local status detail
+  if [[ ${#missing[@]} -eq 0 ]]; then
+    status="pass"
+    detail="All expected repos present"
+  else
+    status="warn"
+    detail="Missing repos: ${missing[*]}"
+  fi
+  record_check "repos" "Repo sync" "${status}" "false" "${detail}" "{}"
+}
+
+emit_reports() {
+  python3 - "${CHECKS_FILE}" "${SUMMARY_JSON}" "${SUMMARY_MD}" <<'PY'
+import json, sys, pathlib
+checks_file, json_path, md_path = map(pathlib.Path, sys.argv[1:4])
+rows = []
+with checks_file.open("r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        check_id, label, status, required, detail, data = line.split("\t")
+        payload = {
+            "id": check_id,
+            "label": label,
+            "status": status,
+            "required": required == "true",
+            "detail": detail,
+        }
+        if data and data != "{}":
+            try:
+                payload["data"] = json.loads(data)
+            except json.JSONDecodeError:
+                payload["data"] = data
+        rows.append(payload)
+json_path.write_text(json.dumps({"checks": rows}, indent=2) + "\n", encoding="utf-8")
+md_lines = ["| Check | Status | Detail |", "| --- | --- | --- |"]
+for row in rows:
+    emoji = {"pass": "✅", "warn": "⚠️", "fail": "❌"}.get(row["status"], "❔")
+    md_lines.append(f"| {row['label']} | {emoji} | {row['detail']} |")
+md_path.write_text("\n".join(md_lines) + "\n", encoding="utf-8")
+PY
+}
+
+print_summary() {
+  echo "Raspberry Pi image spot check summary:"
+  for summary_entry in "${SUMMARY_LINES[@]}"; do
+    IFS='|' read -r status label detail <<<"${summary_entry}"
+    printf '%s %s — %s\n' "$(symbol_for_status "${status}")" "${label}" "${detail}"
+  done
+}
+
+check_system_baseline
+check_time_locale
+check_storage
+check_network
+check_link_speed
+check_services_logs
+check_health
+check_repos
+emit_reports
+print_summary
+
+if [[ ${FAILURES} -ne 0 ]]; then
+  exit 1
+fi

--- a/systemd/first-boot-prepare.service
+++ b/systemd/first-boot-prepare.service
@@ -1,0 +1,15 @@
+# first-boot-prepare.service - Run NVMe preparation on the first boot.
+[Unit]
+Description=Run sugarkube first boot preparation
+ConditionPathExists=!/var/lib/sugarkube/first-boot-prepare.done
+After=network-online.target
+Wants=network-online.target
+Before=first-boot.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/sugarkube/systemd/first-boot-prepare.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/first-boot-prepare.sh
+++ b/systemd/first-boot-prepare.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# first-boot-prepare.sh - Prime Pi firmware tools and NVMe helpers during the first boot.
+# Usage: systemd service (first-boot-prepare.service)
+set -euo pipefail
+
+LOG_FILE="/var/log/first-boot-prepare.log"
+STATE_DIR="/var/lib/sugarkube"
+STATE_FILE="${STATE_DIR}/first-boot-prepare.done"
+export DEBIAN_FRONTEND=noninteractive
+mkdir -p "${STATE_DIR}"
+exec > >(tee -a "${LOG_FILE}") 2>&1
+
+echo "[first-boot] Starting first boot preparation at $(date --iso-8601=seconds)"
+if [[ -f "${STATE_FILE}" ]]; then
+  echo "[first-boot] Preparation already completed; exiting."
+  exit 0
+fi
+
+APT_UPDATED=0
+apt_update_once() {
+  if [[ ${APT_UPDATED} -eq 0 ]]; then
+    if apt-get update; then
+      APT_UPDATED=1
+    else
+      echo "[first-boot] apt-get update failed" >&2
+    fi
+  fi
+}
+
+ensure_package() {
+  local package="$1"
+  if dpkg-query -W -f='${Status}' "${package}" 2>/dev/null | grep -q "install ok installed"; then
+    return
+  fi
+  echo "[first-boot] Installing ${package}"
+  apt_update_once
+  if ! apt-get install -y "${package}"; then
+    echo "[first-boot] Failed to install ${package}" >&2
+  fi
+}
+
+ensure_package rpi-eeprom
+
+sudo_prefix=()
+if [[ $(id -u) -ne 0 ]]; then
+  sudo_prefix=(sudo)
+fi
+
+if ! command -v rpi-clone >/dev/null 2>&1; then
+  echo "[first-boot] Installing rpi-clone"
+  if ! curl -fsSL https://raw.githubusercontent.com/geerlingguy/rpi-clone/master/install | "${sudo_prefix[@]}" bash; then
+    echo "[first-boot] Failed to install rpi-clone" >&2
+  fi
+else
+  echo "[first-boot] rpi-clone already present"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [[ -x "${REPO_ROOT}/scripts/eeprom_nvme_first.sh" ]]; then
+  echo "[first-boot] Applying NVMe-first EEPROM configuration"
+  if ! "${REPO_ROOT}/scripts/eeprom_nvme_first.sh"; then
+    echo "[first-boot] EEPROM configuration helper failed" >&2
+  fi
+else
+  echo "[first-boot] eeprom_nvme_first.sh not found; skipping"
+fi
+
+sync
+printf '%s\n' "completed $(date --iso-8601=seconds)" >"${STATE_FILE}"
+chmod 600 "${STATE_FILE}"
+echo "[first-boot] Preparation complete"

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -619,6 +619,19 @@ def _run_build_script(tmp_path, env):
     shutil.copy(teams_src, script_dir / "sugarkube_teams.py")
     (script_dir / "sugarkube_teams.py").chmod(0o755)
 
+    for helper in (
+        "spot_check.sh",
+        "detect_target_disk.sh",
+        "eeprom_nvme_first.sh",
+        "clone_to_nvme.sh",
+        "post_clone_verify.sh",
+        "k3s_preflight.sh",
+    ):
+        helper_src = repo_root / "scripts" / helper
+        helper_dest = script_dir / helper
+        shutil.copy(helper_src, helper_dest)
+        helper_dest.chmod(0o755)
+
     token_place_replay_src = repo_root / "scripts" / "token_place_replay_samples.py"
     shutil.copy(token_place_replay_src, script_dir / "token_place_replay_samples.py")
     (script_dir / "token_place_replay_samples.py").chmod(0o755)
@@ -630,6 +643,15 @@ def _run_build_script(tmp_path, env):
 
     ssd_clone_unit_src = repo_root / "scripts" / "systemd" / "ssd-clone.service"
     shutil.copy(ssd_clone_unit_src, systemd_dir / "ssd-clone.service")
+
+    systemd_root = tmp_path / "systemd"
+    systemd_root.mkdir(exist_ok=True)
+    prepare_service_src = repo_root / "systemd" / "first-boot-prepare.service"
+    shutil.copy(prepare_service_src, systemd_root / "first-boot-prepare.service")
+    prepare_script_src = repo_root / "systemd" / "first-boot-prepare.sh"
+    prepare_script_dest = systemd_root / "first-boot-prepare.sh"
+    shutil.copy(prepare_script_src, prepare_script_dest)
+    prepare_script_dest.chmod(0o755)
 
     udev_src = repo_root / "scripts" / "udev" / "99-sugarkube-ssd-clone.rules"
     udev_dir = script_dir / "udev"

--- a/tests/test_flash_pi_justfile.py
+++ b/tests/test_flash_pi_justfile.py
@@ -66,8 +66,7 @@ def test_justfile_has_no_tabs_or_trailing_whitespace() -> None:
             "clone-ssd",
             "clone-ssd:",
             [
-                '    if [ -z "{{ clone_target }}" ]; then echo "Set CLONE_TARGET to the target device (e.g. /dev/sda) before running clone-ssd." >&2; exit 1; fi',  # noqa: E501
-                '    "{{ clone_cmd }}" --target "{{ clone_target }}" {{ clone_args }}',  # noqa: E501
+                '    TARGET="{{ clone_target }}" WIPE="{{ clone_wipe }}" "{{ clone_cmd }}" {{ clone_args }}',  # noqa: E501
             ],
         ),
         (


### PR DESCRIPTION
## Summary
- add a Pi 5 Bookworm-aware spot check script with JSON and Markdown artifacts and wire it into a new just spot-check target
- install the maintained rpi-clone flow, NVMe EEPROM helper, post-clone verifier, and k3s preflight through new scripts and first-boot preparation
- update the image build to bake in required packages/services and ship docs plus just tasks for migrate-to-nvme and related helpers

## Testing
- pytest tests/test_flash_pi_justfile.py
- pytest tests/build_pi_image_test.py

------
https://chatgpt.com/codex/tasks/task_e_68f022c24fd0832f8aaf804e552caec5