### PR TITLE
🛠️ : – Repair build_pi_image test dependencies

### DIFF
--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -33,7 +33,11 @@ REQUIRED_SPACE_GB="${REQUIRED_SPACE_GB:-10}"
 check_space() {
   local dir="$1"
   local avail_kb required_kb avail_gb
-  avail_kb=$(df -Pk "$dir" | awk 'NR==2 {print $4}')
+  avail_kb=$(df -Pk "$dir" 2>/dev/null | awk 'NR==2 {print $4}')
+  if ! [[ "$avail_kb" =~ ^[0-9]+$ ]]; then
+    echo "warning: unable to determine available disk space for $dir; skipping check" >&2
+    return 0
+  fi
   required_kb=$((REQUIRED_SPACE_GB * 1024 * 1024))
   if [ "$avail_kb" -lt "$required_kb" ]; then
     avail_gb=$(awk "BEGIN {printf \"%.2f\", $avail_kb/1024/1024}")

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -636,6 +636,28 @@ def _run_build_script(tmp_path, env):
     udev_dir.mkdir(exist_ok=True)
     shutil.copy(udev_src, udev_dir / "99-sugarkube-ssd-clone.rules")
 
+    extra_files = [
+        ("scripts/spot_check.sh", 0o755),
+        ("scripts/detect_target_disk.sh", 0o755),
+        ("scripts/eeprom_nvme_first.sh", 0o755),
+        ("scripts/clone_to_nvme.sh", 0o755),
+        ("scripts/post_clone_verify.sh", 0o755),
+        ("scripts/k3s_preflight.sh", 0o755),
+        ("systemd/first-boot-prepare.sh", 0o755),
+        ("systemd/first-boot-prepare.service", 0o644),
+    ]
+    for rel_path, mode in extra_files:
+        src = repo_root / rel_path
+        dest = tmp_path / rel_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(src, dest)
+        os.chmod(dest, mode)
+
+    token_samples_src = repo_root / "samples" / "token_place"
+    token_samples_dest = tmp_path / "samples" / "token_place"
+    if token_samples_src.exists():
+        shutil.copytree(token_samples_src, token_samples_dest, dirs_exist_ok=True)
+
     result = subprocess.run(
         ["/bin/bash", str(script)],
         env=env,


### PR DESCRIPTION
what: guard disk space checks when df output is missing and copy
      required helper scripts for the build_pi_image tests
why: build_pi_image CI coverage regressed after new script assets
how to test: pytest tests/build_pi_image_test.py -vv

------
https://chatgpt.com/codex/tasks/task_e_68f067981ae4832fa310218325548272