### PR TITLE
Add reusable just log verifier and fast unit test

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Run pi-gen cache key e2e test
         run: bash tests/compute_pi_gen_cache_key_e2e.sh
 
+      - name: Run just verification log harvester test
+        run: bash tests/verify_just_in_logs_test.sh
+
       - name: Run fix permissions e2e test
         run: bash tests/fix_pi_image_permissions_e2e.sh
 
@@ -162,49 +165,8 @@ jobs:
       - name: pi-image-verify-just
         if: always()
         run: |
-          mapfile -t logs < <(find deploy -maxdepth 6 -name '*.build.log' -print | sort)
-          if [ "${#logs[@]}" -eq 0 ]; then
-            echo "pi-gen build log missing" >&2
-            exit 1
-          fi
-          echo '--- just verification ---'
-          echo "Found ${#logs[@]} build log(s) in $(pwd)/deploy"
-          for log in "${logs[@]}"; do
-            if [ -f "${log}" ]; then
-              size=$(stat -c '%s' "${log}" 2>/dev/null || wc -c <"${log}")
-              echo "  • ${log} (${size} bytes)"
-            else
-              echo "  • ${log} (missing)"
-            fi
-          done
-          found=0
-          for log in "${logs[@]}"; do
-            echo "::group::Checking ${log}"
-            if grep -FH 'just command verified' "${log}"; then
-              found=1
-              grep -FH '[sugarkube] just version' "${log}" || true
-            else
-              echo "[warn] 'just command verified' not present in ${log}"
-              echo '--- tail (40 lines) ---'
-              tail -n 40 "${log}" || true
-            fi
-            echo "::endgroup::"
-          done
-          if [ "${found}" -eq 0 ]; then
-            echo 'just verification line missing in logs:' >&2
-            printf '  %s\n' "${logs[@]}" >&2
-            echo '--- grep just summary ---' >&2
-            for log in "${logs[@]}"; do
-              echo "::group::grep just ${log}"
-              if [ -f "${log}" ]; then
-                grep -n "just" "${log}" || true
-              else
-                echo "file missing"
-              fi
-              echo "::endgroup::"
-            done
-            exit 1
-          fi
+          # Search both aggregate and per-stage logs for the just marker.
+          bash scripts/verify_just_in_logs.sh deploy
 
       - name: Verify pi-gen Docker image
         run: |

--- a/scripts/verify_just_in_logs.sh
+++ b/scripts/verify_just_in_logs.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Inspect both aggregate build logs and per-stage logs for the just verification marker.
+# pi-gen stopped always copying the marker into build.log (see PR #1247), so we scan both.
+set -euo pipefail
+
+DEPLOY_DIR_INPUT="${1:-deploy}"
+HAS_REALPATH=0
+if command -v realpath >/dev/null 2>&1; then
+  HAS_REALPATH=1
+fi
+
+resolve_path() {
+  if [ "${HAS_REALPATH}" -eq 1 ]; then
+    realpath -m -- "$1"
+  else
+    python3 -c 'import os,sys; print(os.path.abspath(sys.argv[1]))' "$1"
+  fi
+}
+
+if [ ! -d "${DEPLOY_DIR_INPUT}" ]; then
+  printf 'Deploy directory not found: %s\n' "${DEPLOY_DIR_INPUT}" >&2
+  printf 'No log files to inspect.\n' >&2
+  exit 2
+fi
+
+DEPLOY_DIR="$(resolve_path "${DEPLOY_DIR_INPUT}")"
+
+printf 'Scanning log files under %s\n' "${DEPLOY_DIR}"
+
+mapfile -d '' -t LOG_FILES < <(
+  find "${DEPLOY_DIR}" -maxdepth 8 -type f \
+    \( -name '*.build.log' -o -name 'build.log' -o -path '*/log/*.log' \) -print0
+)
+
+if [ "${#LOG_FILES[@]}" -eq 0 ]; then
+  printf 'No matching log files found in %s\n' "${DEPLOY_DIR}" >&2
+  exit 2
+fi
+
+printf 'Found %d log file(s):\n' "${#LOG_FILES[@]}"
+for log in "${LOG_FILES[@]}"; do
+  log_path="$(resolve_path "${log}")"
+  if size=$(stat -c '%s' "${log}" 2>/dev/null); then
+    :
+  else
+    size=$(wc -c <"${log}")
+  fi
+  printf '  • %s (%s bytes)\n' "${log_path}" "${size}"
+done
+
+marker_found=0
+marker_log=""
+for log in "${LOG_FILES[@]}"; do
+  if grep -Fq 'just command verified' "${log}"; then
+    marker_found=1
+    marker_log="${log}"
+    break
+  fi
+done
+
+if [ "${marker_found}" -eq 1 ]; then
+  marker_log_path="$(resolve_path "${marker_log}")"
+  printf 'just verification marker found in %s\n' "${marker_log_path}"
+  grep -hF '[sugarkube] just version' -- "${LOG_FILES[@]}" || true
+  exit 0
+fi
+
+printf 'just verification marker missing.\n' >&2
+printf 'Checked logs:\n' >&2
+for log in "${LOG_FILES[@]}"; do
+  log_path="$(resolve_path "${log}")"
+  printf '  %s\n' "${log_path}" >&2
+done
+printf '%s\n' '--- grep just summary ---' >&2
+if ! grep -HnF 'just' -- "${LOG_FILES[@]}" >&2; then
+  printf 'No occurrences of "just" found in logs.\n' >&2
+fi
+exit 1

--- a/tests/fixtures/logs-aggregate/deploy/sample-image/build.log
+++ b/tests/fixtures/logs-aggregate/deploy/sample-image/build.log
@@ -1,0 +1,5 @@
+[stage-info] Starting stage: system tweaks
+[sugarkube] preparing environment
+just command verified
+[sugarkube] just version: just 1.12.0
+[stage-info] Stage completed successfully

--- a/tests/fixtures/logs-missing/deploy/sample-image/build.log
+++ b/tests/fixtures/logs-missing/deploy/sample-image/build.log
@@ -1,0 +1,4 @@
+[stage-info] Starting stage: system tweaks
+[sugarkube] preparing environment
+[sugarkube] just version: unavailable
+[stage-info] Stage completed successfully

--- a/tests/fixtures/logs-stage/deploy/sample-image/log/00-run-chroot.log
+++ b/tests/fixtures/logs-stage/deploy/sample-image/log/00-run-chroot.log
@@ -1,0 +1,5 @@
+[2025-02-01T10:00:00Z] entering chroot for stage 2
+[sugarkube] installer starting
+just command verified
+[sugarkube] just version: just 1.13.0
+[2025-02-01T10:05:00Z] leaving chroot

--- a/tests/verify_just_in_logs_test.sh
+++ b/tests/verify_just_in_logs_test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Validate scripts/verify_just_in_logs.sh against positive and negative fixtures.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${ROOT_DIR}/scripts/verify_just_in_logs.sh"
+FIXTURES_DIR="${ROOT_DIR}/tests/fixtures"
+
+if [ ! -x "${SCRIPT}" ]; then
+  echo "verify_just_in_logs.sh missing or not executable" >&2
+  exit 1
+fi
+
+run_expect_success() {
+  local label="$1"
+  local fixture_dir="$2"
+  echo "--- ${label} ---"
+  if ! bash "${SCRIPT}" "${fixture_dir}/deploy"; then
+    echo "Expected success for ${label}" >&2
+    exit 1
+  fi
+}
+
+run_expect_failure() {
+  local label="$1"
+  local fixture_dir="$2"
+  echo "--- ${label} ---"
+  set +e
+  bash "${SCRIPT}" "${fixture_dir}/deploy"
+  status=$?
+  set -e
+  if [ "${status}" -ne 1 ]; then
+    echo "Expected failure exit code 1 for ${label}, got ${status}" >&2
+    exit 1
+  fi
+}
+
+run_expect_success "aggregate log fixture" "${FIXTURES_DIR}/logs-aggregate"
+run_expect_success "stage log fixture" "${FIXTURES_DIR}/logs-stage"
+run_expect_failure "missing marker fixture" "${FIXTURES_DIR}/logs-missing"
+
+echo "verify_just_in_logs tests passed"


### PR DESCRIPTION
what: factor out the just log verification into scripts/verify_just_in_logs.sh,
  add fixtures + tests, and call it from pi-image workflow
why: pi-gen sometimes emits the verification marker only in stage logs and we
  want unit CI to catch regressions before the heavy build
how to test: shellcheck scripts/verify_just_in_logs.sh
  shellcheck tests/verify_just_in_logs_test.sh
  bash tests/verify_just_in_logs_test.sh

------
https://chatgpt.com/codex/tasks/task_e_68f07434ed9c832f9f3194d813d18588