### PR TITLE
Harvest just verification markers from all pi-gen logs

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Run Pi Imager preset e2e test
         run: bash tests/render_pi_imager_preset_e2e.sh
 
+      - name: Run just log harvester unit test
+        run: bash tests/verify_just_in_logs_test.sh
+
   build:
     # Only run the expensive image build when manually dispatched
     if: github.event_name == 'workflow_dispatch'
@@ -162,49 +165,8 @@ jobs:
       - name: pi-image-verify-just
         if: always()
         run: |
-          mapfile -t logs < <(find deploy -maxdepth 6 -name '*.build.log' -print | sort)
-          if [ "${#logs[@]}" -eq 0 ]; then
-            echo "pi-gen build log missing" >&2
-            exit 1
-          fi
-          echo '--- just verification ---'
-          echo "Found ${#logs[@]} build log(s) in $(pwd)/deploy"
-          for log in "${logs[@]}"; do
-            if [ -f "${log}" ]; then
-              size=$(stat -c '%s' "${log}" 2>/dev/null || wc -c <"${log}")
-              echo "  • ${log} (${size} bytes)"
-            else
-              echo "  • ${log} (missing)"
-            fi
-          done
-          found=0
-          for log in "${logs[@]}"; do
-            echo "::group::Checking ${log}"
-            if grep -FH 'just command verified' "${log}"; then
-              found=1
-              grep -FH '[sugarkube] just version' "${log}" || true
-            else
-              echo "[warn] 'just command verified' not present in ${log}"
-              echo '--- tail (40 lines) ---'
-              tail -n 40 "${log}" || true
-            fi
-            echo "::endgroup::"
-          done
-          if [ "${found}" -eq 0 ]; then
-            echo 'just verification line missing in logs:' >&2
-            printf '  %s\n' "${logs[@]}" >&2
-            echo '--- grep just summary ---' >&2
-            for log in "${logs[@]}"; do
-              echo "::group::grep just ${log}"
-              if [ -f "${log}" ]; then
-                grep -n "just" "${log}" || true
-              else
-                echo "file missing"
-              fi
-              echo "::endgroup::"
-            done
-            exit 1
-          fi
+          # Search both aggregate and per-stage logs for the just marker.
+          bash scripts/verify_just_in_logs.sh deploy
 
       - name: Verify pi-gen Docker image
         run: |

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -443,6 +443,7 @@ if [ -z "${just_path}" ]; then
   exit 1
 fi
 
+log_build 'just command verified'
 log_build "[sugarkube] just command verified at ${just_path}"
 just_version=$(just --version 2>&1 | head -n1 || true)
 if [ -n "${just_version}" ]; then

--- a/scripts/verify_just_in_logs.sh
+++ b/scripts/verify_just_in_logs.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Harvest pi-gen logs for the "just command verified" marker.
+# Newer pi-gen releases sometimes omit stage output from deploy/*/build.log.
+# See PR #1247 for context—scan both aggregate and per-stage logs.
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: verify_just_in_logs.sh [DEPLOY_DIR]
+
+Search DEPLOY_DIR (default: deploy) for pi-gen logs containing the
+"just command verified" marker. Returns 0 if found, 1 if missing, 2 if no logs.
+USAGE
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+deploy_dir=${1:-deploy}
+if [[ -z ${deploy_dir} ]]; then
+  echo "Deploy directory argument must not be empty" >&2
+  exit 2
+fi
+
+if [[ ! -d ${deploy_dir} ]]; then
+  echo "Deploy directory not found: ${deploy_dir}" >&2
+  exit 2
+fi
+
+deploy_realpath=$(realpath "${deploy_dir}")
+
+mapfile -d '' logs < <(
+  find "${deploy_realpath}" -maxdepth 8 -type f \
+    \( -name '*.build.log' -o -name 'build.log' -o -path '*/log/*.log' \) \
+    -print0 | sort -z
+)
+
+if [[ ${#logs[@]} -eq 0 ]]; then
+  echo "No log files under ${deploy_realpath} matching '*.build.log', 'build.log', or '*/log/*.log'" >&2
+  exit 2
+fi
+
+echo "Inspecting logs under ${deploy_realpath}:"
+for log in "${logs[@]}"; do
+  size=$(du -h "${log}" | awk '{print $1}')
+  printf '  • %s (%s)\n' "${log}" "${size}"
+done
+
+declare -i found=0
+if grep -Fq 'just command verified' "${logs[@]}"; then
+  found=1
+fi
+
+if (( found == 1 )); then
+  echo "just marker located. Captured just version lines:"
+  if ! grep -Fh '[sugarkube] just version' "${logs[@]}"; then
+    echo "(no [sugarkube] just version lines found)"
+  fi
+  exit 0
+fi
+
+echo "'just command verified' marker missing across inspected logs." >&2
+echo "Grep summary for 'just':" >&2
+mapfile -t just_lines < <(grep -FHi -n 'just' "${logs[@]}" || true)
+if (( ${#just_lines[@]} > 0 )); then
+  limit=${#just_lines[@]}
+  if (( limit > 20 )); then
+    limit=20
+  fi
+  for ((i = 0; i < limit; i++)); do
+    printf '%s\n' "${just_lines[i]}" >&2
+  done
+  if (( ${#just_lines[@]} > limit )); then
+    echo "... (truncated)" >&2
+  fi
+else
+  echo "No other 'just' references found." >&2
+fi
+exit 1

--- a/tests/fixtures/logs-aggregate/deploy/sample-image/build.log
+++ b/tests/fixtures/logs-aggregate/deploy/sample-image/build.log
@@ -1,0 +1,4 @@
+[2024-11-01T12:00:00Z] Starting stage summary
+just command verified
+[sugarkube] just version: just 1.12.0
+[2024-11-01T12:05:00Z] Stage complete

--- a/tests/fixtures/logs-missing/deploy/sample-image/build.log
+++ b/tests/fixtures/logs-missing/deploy/sample-image/build.log
@@ -1,0 +1,3 @@
+[2024-11-01T12:00:00Z] Starting stage summary
+[sugarkube] setup completed successfully
+[2024-11-01T12:05:00Z] Stage complete without just marker

--- a/tests/fixtures/logs-stage/deploy/sample-image/log/00-run-chroot.log
+++ b/tests/fixtures/logs-stage/deploy/sample-image/log/00-run-chroot.log
@@ -1,0 +1,4 @@
+[2024-11-01T12:00:00Z] Entering chroot
+[sugarkube] installing tools
+[sugarkube] just command verified at /usr/bin/just
+[sugarkube] just version: just 1.12.0

--- a/tests/verify_just_in_logs_test.sh
+++ b/tests/verify_just_in_logs_test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+VERIFY_SCRIPT="${REPO_ROOT}/scripts/verify_just_in_logs.sh"
+
+run_positive_fixture() {
+  local fixture=$1
+  echo "--- running positive fixture: ${fixture} ---"
+  if ! (cd "${REPO_ROOT}/tests/fixtures/${fixture}" && bash "${VERIFY_SCRIPT}" deploy); then
+    echo "Expected success for fixture ${fixture}" >&2
+    exit 1
+  fi
+}
+
+echo "[verify-just] ensuring script handles aggregate logs"
+run_positive_fixture "logs-aggregate"
+
+echo "[verify-just] ensuring script handles stage logs"
+run_positive_fixture "logs-stage"
+
+echo "--- running negative fixture: logs-missing ---"
+if (cd "${REPO_ROOT}/tests/fixtures/logs-missing" && bash "${VERIFY_SCRIPT}" deploy); then
+  echo "Expected failure for fixture logs-missing" >&2
+  exit 1
+fi
+
+echo "All verify_just_in_logs fixtures behaved as expected."


### PR DESCRIPTION
## Summary
- add scripts/verify_just_in_logs.sh to search aggregate and per-stage pi-gen logs for the just marker
- run the new verify_just_in_logs test fixture suite as part of the pi-image unit job
- emit a plain "just command verified" line from the stage script for compatibility

## Testing
- shellcheck scripts/verify_just_in_logs.sh tests/verify_just_in_logs_test.sh
- bash tests/verify_just_in_logs_test.sh

------
https://chatgpt.com/codex/tasks/task_e_68f07434ed9c832f9f3194d813d18588