### PR TITLE
Harvest per-stage just logs in pi-image workflow

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Run Pi Imager preset e2e test
         run: bash tests/render_pi_imager_preset_e2e.sh
 
+      - name: Run verify just log harvester test
+        run: bash tests/verify_just_in_logs_test.sh
+
   build:
     # Only run the expensive image build when manually dispatched
     if: github.event_name == 'workflow_dispatch'
@@ -162,49 +165,8 @@ jobs:
       - name: pi-image-verify-just
         if: always()
         run: |
-          mapfile -t logs < <(find deploy -maxdepth 6 -name '*.build.log' -print | sort)
-          if [ "${#logs[@]}" -eq 0 ]; then
-            echo "pi-gen build log missing" >&2
-            exit 1
-          fi
-          echo '--- just verification ---'
-          echo "Found ${#logs[@]} build log(s) in $(pwd)/deploy"
-          for log in "${logs[@]}"; do
-            if [ -f "${log}" ]; then
-              size=$(stat -c '%s' "${log}" 2>/dev/null || wc -c <"${log}")
-              echo "  • ${log} (${size} bytes)"
-            else
-              echo "  • ${log} (missing)"
-            fi
-          done
-          found=0
-          for log in "${logs[@]}"; do
-            echo "::group::Checking ${log}"
-            if grep -FH 'just command verified' "${log}"; then
-              found=1
-              grep -FH '[sugarkube] just version' "${log}" || true
-            else
-              echo "[warn] 'just command verified' not present in ${log}"
-              echo '--- tail (40 lines) ---'
-              tail -n 40 "${log}" || true
-            fi
-            echo "::endgroup::"
-          done
-          if [ "${found}" -eq 0 ]; then
-            echo 'just verification line missing in logs:' >&2
-            printf '  %s\n' "${logs[@]}" >&2
-            echo '--- grep just summary ---' >&2
-            for log in "${logs[@]}"; do
-              echo "::group::grep just ${log}"
-              if [ -f "${log}" ]; then
-                grep -n "just" "${log}" || true
-              else
-                echo "file missing"
-              fi
-              echo "::endgroup::"
-            done
-            exit 1
-          fi
+          # Search both aggregate and per-stage logs for the just marker.
+          bash scripts/verify_just_in_logs.sh deploy
 
       - name: Verify pi-gen Docker image
         run: |

--- a/scripts/verify_just_in_logs.sh
+++ b/scripts/verify_just_in_logs.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Search pi-gen build logs for the just verification marker. pi-gen stopped copying the
+# marker into the top-level build.log (see PR #1247), so inspect both aggregate and
+# per-stage logs.
+set -euo pipefail
+
+readonly deploy_root="${1:-deploy}"
+
+if ! deploy_realpath=$(realpath "${deploy_root}" 2>/dev/null); then
+  echo "Deploy directory '${deploy_root}' not found" >&2
+  exit 2
+fi
+
+if [ ! -d "${deploy_realpath}" ]; then
+  echo "Deploy directory '${deploy_realpath}' not found" >&2
+  exit 2
+fi
+
+mapfile -d '' -t logs < <(find "${deploy_realpath}" -maxdepth 8 -type f \
+  \( -name '*.build.log' -o -name 'build.log' -o -path '*/log/*.log' \) -print0 | sort -z)
+
+if [ "${#logs[@]}" -eq 0 ]; then
+  echo "No build logs found under ${deploy_realpath}" >&2
+  exit 2
+fi
+
+echo "Scanning $((${#logs[@]})) log(s) under ${deploy_realpath}" >&2
+for log in "${logs[@]}"; do
+  if [ -f "${log}" ]; then
+    if ! size=$(stat -c '%s' "${log}" 2>/dev/null); then
+      size=$(wc -c <"${log}")
+    fi
+    printf '  • %s (%s bytes)\n' "$(realpath "${log}")" "${size}" >&2
+  else
+    printf '  • %s (missing)\n' "${log}" >&2
+  fi
+done
+
+found=0
+for log in "${logs[@]}"; do
+  if grep -Fq 'just command verified' "${log}"; then
+    if [ "${found}" -eq 0 ]; then
+      echo "just verification marker found:" >&2
+    fi
+    found=1
+    printf '  %s\n' "$(realpath "${log}")"
+    grep -F '[sugarkube] just version' "${log}" || true
+  fi
+done
+
+if [ "${found}" -eq 1 ]; then
+  exit 0
+fi
+
+echo "just verification marker missing under ${deploy_realpath}" >&2
+echo "--- grep summary for 'just' ---" >&2
+for log in "${logs[@]}"; do
+  echo "# ${log}" >&2
+  if ! grep -nF 'just' "${log}" >&2; then
+    echo "(no occurrences)" >&2
+  fi
+  echo >&2
+done
+
+exit 1

--- a/tests/fixtures/logs-aggregate/deploy/example-image/build.log
+++ b/tests/fixtures/logs-aggregate/deploy/example-image/build.log
@@ -1,0 +1,3 @@
+[sugarkube] build start
+[sugarkube] just command verified at /usr/bin/just
+[sugarkube] just version: just 1.14.0

--- a/tests/fixtures/logs-missing/deploy/example-image/build.log
+++ b/tests/fixtures/logs-missing/deploy/example-image/build.log
@@ -1,0 +1,3 @@
+[sugarkube] build start
+just command executed but not verified
+[sugarkube] build end

--- a/tests/fixtures/logs-stage/deploy/example-image/log/00-run-chroot.log
+++ b/tests/fixtures/logs-stage/deploy/example-image/log/00-run-chroot.log
@@ -1,0 +1,4 @@
+[sugarkube] stage enter
+[sugarkube] just command verified at /usr/bin/just
+[sugarkube] just version: just 1.14.0
+[sugarkube] stage exit

--- a/tests/verify_just_in_logs_test.sh
+++ b/tests/verify_just_in_logs_test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script_path="${repo_root}/scripts/verify_just_in_logs.sh"
+fixtures_root="${repo_root}/tests/fixtures"
+
+run_success() {
+  local fixture=$1
+  local deploy_dir="${fixtures_root}/${fixture}/deploy"
+  echo "[test] expecting success for ${fixture}"
+  if ! bash "${script_path}" "${deploy_dir}" >/dev/null; then
+    echo "[fail] ${fixture} should succeed" >&2
+    exit 1
+  fi
+  echo "[pass] ${fixture} succeeded"
+}
+
+run_failure() {
+  local fixture=$1
+  local deploy_dir="${fixtures_root}/${fixture}/deploy"
+  echo "[test] expecting failure for ${fixture}"
+  if bash "${script_path}" "${deploy_dir}" >/dev/null; then
+    echo "[fail] ${fixture} should have failed" >&2
+    exit 1
+  else
+    local status=$?
+    if [ "${status}" -ne 1 ]; then
+      echo "[fail] ${fixture} exited with ${status}, expected 1" >&2
+      exit 1
+    fi
+  fi
+  echo "[pass] ${fixture} failed as expected"
+}
+
+run_success "logs-aggregate"
+run_success "logs-stage"
+run_failure "logs-missing"
+
+echo "verify_just_in_logs_test: all scenarios covered"


### PR DESCRIPTION
## Summary
- add scripts/verify_just_in_logs.sh to search both aggregate and per-stage just logs
- update the pi-image workflow to invoke the shared verifier script
- include fixtures and a unit test so the unit job fails if the marker is missing

## Testing
- shellcheck scripts/verify_just_in_logs.sh
- bash tests/verify_just_in_logs_test.sh

------
https://chatgpt.com/codex/tasks/task_e_68f07434ed9c832f9f3194d813d18588