### PR TITLE
ci: harvest per-stage logs for just marker & add fast tests

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Run pi-gen cache key e2e test
         run: bash tests/compute_pi_gen_cache_key_e2e.sh
 
+      - name: Run verify just logs test
+        run: bash tests/verify_just_in_logs_test.sh
+
       - name: Run fix permissions e2e test
         run: bash tests/fix_pi_image_permissions_e2e.sh
 
@@ -162,49 +165,8 @@ jobs:
       - name: pi-image-verify-just
         if: always()
         run: |
-          mapfile -t logs < <(find deploy -maxdepth 6 -name '*.build.log' -print | sort)
-          if [ "${#logs[@]}" -eq 0 ]; then
-            echo "pi-gen build log missing" >&2
-            exit 1
-          fi
-          echo '--- just verification ---'
-          echo "Found ${#logs[@]} build log(s) in $(pwd)/deploy"
-          for log in "${logs[@]}"; do
-            if [ -f "${log}" ]; then
-              size=$(stat -c '%s' "${log}" 2>/dev/null || wc -c <"${log}")
-              echo "  • ${log} (${size} bytes)"
-            else
-              echo "  • ${log} (missing)"
-            fi
-          done
-          found=0
-          for log in "${logs[@]}"; do
-            echo "::group::Checking ${log}"
-            if grep -FH 'just command verified' "${log}"; then
-              found=1
-              grep -FH '[sugarkube] just version' "${log}" || true
-            else
-              echo "[warn] 'just command verified' not present in ${log}"
-              echo '--- tail (40 lines) ---'
-              tail -n 40 "${log}" || true
-            fi
-            echo "::endgroup::"
-          done
-          if [ "${found}" -eq 0 ]; then
-            echo 'just verification line missing in logs:' >&2
-            printf '  %s\n' "${logs[@]}" >&2
-            echo '--- grep just summary ---' >&2
-            for log in "${logs[@]}"; do
-              echo "::group::grep just ${log}"
-              if [ -f "${log}" ]; then
-                grep -n "just" "${log}" || true
-              else
-                echo "file missing"
-              fi
-              echo "::endgroup::"
-            done
-            exit 1
-          fi
+          # Search both aggregate and per-stage logs for the just marker.
+          bash scripts/verify_just_in_logs.sh deploy
 
       - name: Verify pi-gen Docker image
         run: |

--- a/scripts/verify_just_in_logs.sh
+++ b/scripts/verify_just_in_logs.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Inspect both aggregate and per-stage pi-gen logs for the "just" verification marker.
+# pi-gen no longer guarantees the stage output is copied into deploy/*.build.log (see PR #1247),
+# so we search both the root build log and nested stage logs for "just command verified".
+set -euo pipefail
+
+DEPLOY_DIR=${1:-deploy}
+if [ ! -d "${DEPLOY_DIR}" ]; then
+  echo "Deploy directory not found: ${DEPLOY_DIR}" >&2
+  exit 2
+fi
+
+DEPLOY_REALPATH=$(realpath "${DEPLOY_DIR}")
+echo "Scanning logs under: ${DEPLOY_REALPATH}"
+
+logs=()
+while IFS= read -r -d '' log; do
+  logs+=("${log}")
+done < <(
+  find "${DEPLOY_DIR}" -maxdepth 8 -type f \
+    \( -name '*.build.log' -o -name 'build.log' -o -path '*/log/*.log' \) -print0 | sort -z
+)
+
+if [ "${#logs[@]}" -eq 0 ]; then
+  echo "No build logs found under ${DEPLOY_REALPATH}" >&2
+  exit 2
+fi
+
+echo "Found ${#logs[@]} log file(s):"
+for log in "${logs[@]}"; do
+  log_realpath=$(realpath "${log}")
+  log_size=$(stat -c '%s' "${log}")
+  printf '  - %s (%s bytes)\n' "${log_realpath}" "${log_size}"
+done
+
+marker_found=0
+marker_log=""
+for log in "${logs[@]}"; do
+  if grep -Fqs 'just command verified' "${log}"; then
+    marker_found=1
+    marker_log=$(realpath "${log}")
+    break
+  fi
+done
+
+if [ "${marker_found}" -eq 1 ]; then
+  echo "Marker found in: ${marker_log}"
+  version_lines=$(grep -Fh '[sugarkube] just version' "${logs[@]}" || true)
+  if [ -n "${version_lines}" ]; then
+    echo "[sugarkube] just version lines:"
+    printf '%s\n' "${version_lines}" | sort -u
+  else
+    echo "No [sugarkube] just version lines present in logs."
+  fi
+  exit 0
+fi
+
+echo "just command verified marker missing from logs" >&2
+echo "--- grep just summary ---" >&2
+for log in "${logs[@]}"; do
+  log_realpath=$(realpath "${log}")
+  echo "# ${log_realpath}" >&2
+  if ! grep -Fn 'just' "${log}" >&2; then
+    echo "(no matches)" >&2
+  fi
+  echo >&2
+done
+exit 1

--- a/tests/fixtures/logs-aggregate/deploy/sample-image/build.log
+++ b/tests/fixtures/logs-aggregate/deploy/sample-image/build.log
@@ -1,0 +1,3 @@
+[2025-01-01 00:00:00] stage start
+just command verified
+[sugarkube] just version: just 1.18.1

--- a/tests/fixtures/logs-missing/deploy/sample-image/build.log
+++ b/tests/fixtures/logs-missing/deploy/sample-image/build.log
@@ -1,0 +1,1 @@
+[sugarkube] build completed without just marker

--- a/tests/fixtures/logs-stage/deploy/sample-image/log/00-run-chroot.log
+++ b/tests/fixtures/logs-stage/deploy/sample-image/log/00-run-chroot.log
@@ -1,0 +1,4 @@
+[sugarkube] entering stage
+some unrelated output
+just command verified
+[sugarkube] just version: just 1.18.1

--- a/tests/verify_just_in_logs_test.sh
+++ b/tests/verify_just_in_logs_test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Validate scripts/verify_just_in_logs.sh against aggregate and per-stage log layouts.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${ROOT_DIR}/scripts/verify_just_in_logs.sh"
+
+if [ ! -x "${SCRIPT}" ]; then
+  echo "verify_just_in_logs.sh missing or not executable" >&2
+  exit 1
+fi
+
+run_success_case() {
+  local fixture_name="$1"
+  local fixture_dir="${ROOT_DIR}/tests/fixtures/${fixture_name}/deploy"
+  local output
+  if ! output=$(bash "${SCRIPT}" "${fixture_dir}" 2>&1); then
+    echo "expected ${fixture_name} to succeed" >&2
+    echo "--- output ---" >&2
+    echo "${output}" >&2
+    exit 1
+  fi
+  if ! grep -Fq '[sugarkube] just version:' <<<"${output}"; then
+    echo "missing just version line in ${fixture_name} output" >&2
+    echo "--- output ---" >&2
+    echo "${output}" >&2
+    exit 1
+  fi
+}
+
+run_failure_case() {
+  local fixture_name="$1"
+  local fixture_dir="${ROOT_DIR}/tests/fixtures/${fixture_name}/deploy"
+  local output
+  set +e
+  output=$(bash "${SCRIPT}" "${fixture_dir}" 2>&1)
+  status=$?
+  set -e
+  if [ "${status}" -eq 0 ]; then
+    echo "expected ${fixture_name} to fail" >&2
+    echo "--- output ---" >&2
+    echo "${output}" >&2
+    exit 1
+  fi
+  if [ "${status}" -ne 1 ]; then
+    echo "expected exit code 1 for ${fixture_name}, got ${status}" >&2
+    echo "--- output ---" >&2
+    echo "${output}" >&2
+    exit 1
+  fi
+  if ! grep -Fq 'grep just summary' <<<"${output}"; then
+    echo "missing grep summary in ${fixture_name} output" >&2
+    echo "--- output ---" >&2
+    echo "${output}" >&2
+    exit 1
+  fi
+}
+
+run_success_case "logs-aggregate"
+run_success_case "logs-stage"
+run_failure_case "logs-missing"
+
+echo "verify_just_in_logs tests passed"


### PR DESCRIPTION
## Summary
- add a reusable verify_just_in_logs.sh helper that scans aggregate and per-stage pi-gen logs
- update the pi-image workflow to use the helper and add fixtures plus a fast unit test
- cover aggregate, stage, and missing log layouts so regressions fail before the heavy build

## Testing
- shellcheck scripts/verify_just_in_logs.sh tests/verify_just_in_logs_test.sh
- bash tests/verify_just_in_logs_test.sh

------
https://chatgpt.com/codex/tasks/task_e_68f07434ed9c832f9f3194d813d18588