### PR TITLE
🛠️ : – fix nmcli fallback in spot check

### DIFF
--- a/scripts/spot_check.sh
+++ b/scripts/spot_check.sh
@@ -268,9 +268,11 @@ check_link_speed() {
     speed=$(< /sys/class/net/eth0/speed)
     [[ -n "${speed}" ]] && speed="${speed}Mb/s"
   fi
-  if [[ -z "${speed}" && command -v nmcli >/dev/null 2>&1 ]]; then
-    speed=$(nmcli -t -f GENERAL.SPEED device show eth0 2>/dev/null | head -n1)
-    [[ "${speed}" =~ ^[0-9]+$ ]] && speed="${speed} Mb/s"
+  if [[ -z "${speed}" ]]; then
+    if command -v nmcli >/dev/null 2>&1; then
+      speed=$(nmcli -t -f GENERAL.SPEED device show eth0 2>/dev/null | head -n1)
+      [[ "${speed}" =~ ^[0-9]+$ ]] && speed="${speed} Mb/s"
+    fi
   fi
   if [[ -z "${speed}" ]]; then
     add_result "Link speed" "warn" "false" "Unable to determine eth0 link speed"


### PR DESCRIPTION
what: guard the nmcli fallback so the spot check script stays valid bash.
why: [[ -z "$speed" && command -v nmcli ]] caused a syntax error on Pi images.
how to test: bash -n scripts/spot_check.sh

------
https://chatgpt.com/codex/tasks/task_e_68f0a6c24554832fbc2bd9120e84cf0a