### PR TITLE
Improve NVMe clone fallback and tighten unit CI guardrails

### DIFF
--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -50,7 +50,24 @@ jobs:
           sudo apt-get -o Acquire::Retries=5 \
             -o Acquire::http::Timeout=30 \
             -o Acquire::https::Timeout=30 \
-            install -y --no-install-recommends libarchive-tools xz-utils
+            install -y --no-install-recommends libarchive-tools xz-utils shellcheck bats
+      - name: Run ShellCheck on scripts
+        run: shellcheck scripts/*.sh
+
+      - name: Run networking parser unit tests
+        run: bats tests/spot_check_net_parsing.bats
+
+      - name: Run clone fallback unit tests
+        run: bats tests/rpi_clone_unattended_fallback.bats
+
+      - name: Guard unattended clone fallback
+        run: |
+          if grep -Fq 'rpi-clone -f -u "${TARGET_DEVICE}"' scripts/clone_to_nvme.sh; then
+            if ! grep -Fq 'Unattended -u option not allowed when initializing' scripts/clone_to_nvme.sh; then
+              echo 'Missing unattended fallback handling in clone_to_nvme.sh' >&2
+              exit 1
+            fi
+          fi
       - name: Run artifact detection unit tests
         run: bash tests/artifact_detection_test.sh
 

--- a/tests/rpi_clone_unattended_fallback.bats
+++ b/tests/rpi_clone_unattended_fallback.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_TMPDIR="$(mktemp -d)"
+  BIN_DIR="$TEST_TMPDIR/bin"
+  mkdir -p "$BIN_DIR"
+  export PATH="$BIN_DIR:$PATH"
+
+  export SKIP_ROOT_CHECK=1
+  export WIPE=0
+
+  FAKE_DEVICE="$(mktemp -u /dev/fakeclone.XXXX)"
+  mknod "$FAKE_DEVICE" b 7 0
+  mknod "${FAKE_DEVICE}p1" b 7 1
+  mknod "${FAKE_DEVICE}p2" b 7 2
+  export FAKE_DEVICE
+  FAKE_NAME="$(basename "$FAKE_DEVICE")"
+  export FAKE_NAME
+
+  export CLONE_MOUNT="$TEST_TMPDIR/mnt"
+  mkdir -p "$CLONE_MOUNT/boot/firmware" "$CLONE_MOUNT/etc"
+  cat <<'CMDLINE' >"$CLONE_MOUNT/boot/firmware/cmdline.txt"
+console=serial0,115200 root=LABEL=ROOTFS quiet splash
+CMDLINE
+  cat <<'FSTAB' >"$CLONE_MOUNT/etc/fstab"
+UUID=old-root / ext4 defaults 0 1
+UUID=old-boot /boot/firmware vfat defaults 0 2
+FSTAB
+
+  export TARGET="$FAKE_DEVICE"
+
+  RPI_CLONE_CALLS="$TEST_TMPDIR/rpi_clone_calls.log"
+  export RPI_CLONE_CALLS
+  cat <<'STUB' >"$BIN_DIR/rpi-clone"
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$RPI_CLONE_CALLS"
+for arg in "$@"; do
+  if [[ "$arg" == "-u" ]]; then
+    echo "Unattended -u option not allowed when initializing" >&2
+    exit 1
+  fi
+done
+echo "bytes written: 123456789" >&2
+exit 0
+STUB
+  chmod +x "$BIN_DIR/rpi-clone"
+
+  REAL_LSBLK="$(command -v lsblk)"
+  export REAL_LSBLK
+  cat <<'STUB' >"$BIN_DIR/lsblk"
+#!/usr/bin/env bash
+if [[ "$1" == "-nb" && "$2" == "-o" && "$3" == "SIZE" && "$4" == "$FAKE_DEVICE" ]]; then
+  echo 21474836480
+elif [[ "$1" == "-nr" && "$2" == "-o" && "$3" == "NAME,MOUNTPOINT" && "$4" == "$FAKE_DEVICE" ]]; then
+  printf '%s %s\n' "${FAKE_NAME}p1" ""
+  printf '%s %s\n' "${FAKE_NAME}p2" ""
+elif [[ "$1" == "-nr" && "$2" == "-o" && "$3" == "NAME,TYPE" && "$4" == "$FAKE_DEVICE" ]]; then
+  printf '%s %s\n' "${FAKE_NAME}" "disk"
+  printf '%s %s\n' "${FAKE_NAME}p1" "part"
+  printf '%s %s\n' "${FAKE_NAME}p2" "part"
+else
+  exec "$REAL_LSBLK" "$@"
+fi
+STUB
+  chmod +x "$BIN_DIR/lsblk"
+
+  REAL_FINDMNT="$(command -v findmnt)"
+  export REAL_FINDMNT
+  cat <<'STUB' >"$BIN_DIR/findmnt"
+#!/usr/bin/env bash
+if [[ "$1" == "-no" && "$2" == "SOURCE" ]]; then
+  case "$3" in
+    "$CLONE_MOUNT")
+      echo "/dev/${FAKE_NAME}p2"
+      exit 0
+      ;;
+    "$CLONE_MOUNT/boot/firmware")
+      echo "/dev/${FAKE_NAME}p1"
+      exit 0
+      ;;
+  esac
+fi
+exec "$REAL_FINDMNT" "$@"
+STUB
+  chmod +x "$BIN_DIR/findmnt"
+
+  REAL_MOUNTPOINT="$(command -v mountpoint)"
+  export REAL_MOUNTPOINT
+  cat <<'STUB' >"$BIN_DIR/mountpoint"
+#!/usr/bin/env bash
+if [[ "$1" == "-q" ]]; then
+  if [[ "$2" == "$CLONE_MOUNT" || "$2" == "$CLONE_MOUNT/boot/firmware" ]]; then
+    exit 0
+  fi
+fi
+exec "$REAL_MOUNTPOINT" "$@"
+STUB
+  chmod +x "$BIN_DIR/mountpoint"
+
+  REAL_BLKID="$(command -v blkid)"
+  export REAL_BLKID
+  cat <<'STUB' >"$BIN_DIR/blkid"
+#!/usr/bin/env bash
+if [[ "$1" == "-s" && "$2" == "UUID" && "$3" == "-o" && "$4" == "value" ]]; then
+  case "$5" in
+    "/dev/${FAKE_NAME}p2") echo "root-uuid"; exit 0 ;;
+    "/dev/${FAKE_NAME}p1") echo "boot-uuid"; exit 0 ;;
+  esac
+elif [[ "$1" == "-s" && "$2" == "PARTUUID" && "$3" == "-o" && "$4" == "value" ]]; then
+  case "$5" in
+    "/dev/${FAKE_NAME}p2") echo "root-partuuid"; exit 0 ;;
+    "/dev/${FAKE_NAME}p1") echo "boot-partuuid"; exit 0 ;;
+  esac
+fi
+exec "$REAL_BLKID" "$@"
+STUB
+  chmod +x "$BIN_DIR/blkid"
+
+  cat <<'STUB' >"$BIN_DIR/wipefs"
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$BIN_DIR/wipefs"
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+  rm -f "$FAKE_DEVICE" "${FAKE_DEVICE}p1" "${FAKE_DEVICE}p2" 2>/dev/null || true
+}
+
+@test "clone_to_nvme retries with -U when unattended init fails" {
+  run bash "$BATS_TEST_DIRNAME/../scripts/clone_to_nvme.sh"
+  [ "$status" -eq 0 ]
+  clone_calls="$(cat "$RPI_CLONE_CALLS")"
+  [[ "$clone_calls" == *"-f -u"* ]]
+  [[ "$clone_calls" == *"-f -U"* ]]
+  run tail -n1 "$RPI_CLONE_CALLS"
+  [ "$status" -eq 0 ]
+  [ "$output" = "-f -U $FAKE_DEVICE" ]
+}

--- a/tests/spot_check_net_parsing.bats
+++ b/tests/spot_check_net_parsing.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+
+parse_sample() {
+  local sample="$1" host="$2" label="$3" exit_code="${4:-0}"
+  local script="$BATS_TEST_DIRNAME/../scripts/spot_check.sh"
+  local sample_file
+  sample_file="$(mktemp)"
+  printf '%s\n' "$sample" >"$sample_file"
+
+  run bash -c "set -Eeuo pipefail
+sample_file=\"\$1\"
+host=\"\$2\"
+label=\"\$3\"
+script=\"\$4\"
+exit_code=\"\$5\"
+tmp=\$(mktemp -d)
+cat <<'EOS' >\"\$tmp/ping\"
+#!/usr/bin/env bash
+cat \"\${PING_SAMPLE_FILE}\"
+status=\"\${PING_SAMPLE_STATUS:-0}\"
+exit \"\$status\"
+EOS
+chmod +x \"\$tmp/ping\"
+export PATH=\"\$tmp:\$PATH\"
+export PING_SAMPLE_FILE=\"\$sample_file\"
+export PING_SAMPLE_STATUS=\"\$exit_code\"
+export LOG_FILE=\$(mktemp)
+export ARTIFACT_DIR=\$(mktemp -d)
+export SPOT_CHECK_IMPORT=1
+export RESULT_DATA=()
+export PASSED=0 FAILED=0 WARNED=0 INFO=0 REQUIRED_FAILURES=0
+export START_TIME=\"\$(date --iso-8601=seconds)\"
+# shellcheck disable=SC1090
+source \"\$script\"
+result=\$(_parse_ping_summary \"\$host\" \"\$label\")
+printf '%s\\n' \"\$result\"
+rm -f \"\$LOG_FILE\" || true
+rm -rf \"\$ARTIFACT_DIR\" \"\$tmp\" || true
+" _ "$sample_file" "$host" "$label" "$script" "$exit_code"
+
+  rm -f "$sample_file"
+}
+
+@test "LAN parser captures zero loss low latency" {
+  parse_sample "PING 192.168.86.1 (192.168.86.1) 56(84) bytes of data.\n\n--- 192.168.86.1 ping statistics ---\n4 packets transmitted, 4 received, 0% packet loss, time 3006ms\nrtt min/avg/max/mdev = 0.352/0.402/0.487/0.045 ms" \
+    "192.168.86.1" "LAN"
+  [ "$status" -eq 0 ]
+  [ "$output" = "0 0.402" ]
+}
+
+@test "WAN parser captures zero loss moderate latency" {
+  parse_sample "PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.\n\n--- 1.1.1.1 ping statistics ---\n4 packets transmitted, 4 received, 0% packet loss, time 4005ms\nrtt min/avg/max/mdev = 5.102/5.532/6.004/0.310 ms" \
+    "1.1.1.1" "WAN"
+  [ "$status" -eq 0 ]
+  [ "$output" = "0 5.532" ]
+}
+
+@test "Parser falls back to defaults on unreachable host" {
+  parse_sample "PING 203.0.113.1 (203.0.113.1) 56(84) bytes of data.\nping: sendmsg: Network is unreachable" \
+    "203.0.113.1" "WAN" 1
+  [ "$status" -eq 0 ]
+  [ "$output" = "100 9999" ]
+}
+
+@test "Parser tolerates localized summary wording" {
+  parse_sample "PING example.com (93.184.216.34) 56(84) bytes of data.\n\n--- example.com ping statistics ---\n4 packets transmitted, 4 packets received, 0.0% packet loss, time 4004ms\nround-trip min/avg/max/stddev = 20.101/21.554/24.221/1.491 ms" \
+    "example.com" "WAN"
+  [ "$status" -eq 0 ]
+  [ "$output" = "0.0 21.554" ]
+}


### PR DESCRIPTION
## Summary
- add unattended rpi-clone fallback handling, optional mount overrides, and manual mount support in clone_to_nvme.sh
- generalize post-clone verification to detect any NVMe parent and expose skip hooks for spot_check.sh tests
- extend the unit workflow with shellcheck/static guards and new Bats coverage for networking parsing and rpi-clone retries

## Testing
- bats tests/spot_check_net_parsing.bats
- bats tests/rpi_clone_unattended_fallback.bats
- shellcheck scripts/clone_to_nvme.sh scripts/post_clone_verify.sh scripts/spot_check.sh

------
https://chatgpt.com/codex/tasks/task_e_68f1c6e50930832fa1cee900ab404ee8