### PR TITLE
feat: streamline boot order helpers

### DIFF
--- a/docs/raspi-image-spot-check.md
+++ b/docs/raspi-image-spot-check.md
@@ -58,25 +58,68 @@ transparency.
 
 ## Next steps: clone to NVMe
 
-With the SD image validated:
+> **Before you start**
+> - `sudo just boot-order print` → If the output already shows `BOOT_ORDER=0xf461`, skip the Boot-Order step.
+> - `lsblk -e7 -o NAME,TYPE,SIZE,MOUNTPOINTS` → If `/dev/nvme0n1` already has `boot` and `root` partitions, skip initialization and jump to the verification checklist.
 
-1. Optional: update EEPROM + boot order for NVMe adapters.
-   ```bash
-   sudo just eeprom-nvme-first
-   ```
-2. Clone the SD card to the first non-SD disk (prefers `/dev/nvme0n1`).
-   ```bash
-   sudo just clone-ssd
-   ```
-3. Run the happy-path migration, which chains the above, reboots, and leaves a log in
-   `artifacts/migrate-to-nvme/`. **If you already ran steps 1 and 2 successfully, skip this step.**
-   ```bash
-   sudo just migrate-to-nvme
-   ```
-4. After the reboot, confirm the Pi is running from NVMe.
-   ```bash
-   sudo just post-clone-verify
-   ```
+### 1. Align the EEPROM boot order (optional)
+
+Prefer SD → NVMe → USB → repeat so recovery media in the SD slot always wins:
+
+```bash
+sudo just boot-order sd-nvme-usb
+```
+
+Need to surface the current configuration again? Run `sudo just boot-order print`. Adapters that require `PCIE_PROBE=1` can opt in per run:
+
+```bash
+sudo PCIE_PROBE=1 just boot-order nvme-first
+```
+
+### 2. Clone the SD card to NVMe
+
+`just clone-ssd` still wraps the process, but the resilient one-liner below works even on a blank drive. The `-U` flag initializes boot and root partitions on first use; omit it on subsequent refreshes if you want to preserve existing UUIDs.
+
+```bash
+sudo rpi-clone -f -U /dev/nvme0n1
+```
+
+When you prefer the guided workflow, run `sudo just clone-ssd TARGET=/dev/nvme0n1 WIPE=1` and follow the prompts.
+
+### 3. Optional fast path
+
+To chain the spot check, boot-order, clone, and reboot steps automatically:
+
+```bash
+sudo just migrate-to-nvme
+```
+
+> **Troubleshooting**
+> ```bash
+> sudo mkdir -p /mnt/clone
+> sudo mount /dev/nvme0n1p1 /mnt/clone
+> sudo mount /dev/nvme0n1p2 /mnt/clone/root
+> ls /mnt/clone        # cmdline.txt lives here
+> ls /mnt/clone/root   # check etc/fstab
+> ```
+> Unmount with `sudo umount /mnt/clone/root /mnt/clone` when finished.
+
+### One-time SD override
+
+Need to test a fresh SD card without unplugging the NVMe enclosure? Apply a one-shot override—the next boot will prefer SD, then the EEPROM reverts to its persistent order:
+
+```bash
+tmp=$(mktemp)
+printf 'set_reboot_order=0xf1\n' | sudo tee "$tmp" >/dev/null
+sudo rpi-eeprom-config --edit "$tmp"
+rm "$tmp"
+```
+
+### Verification checklist
+
+- Booted from NVMe (`lsblk -e7 -o NAME,MOUNTPOINTS` shows `/boot/firmware` and `/` on `/dev/nvme0n1p1/2`).
+- `sudo rpi-eeprom-config | grep -F BOOT_ORDER` reports the intended preset and PARTUUIDs in `/etc/fstab` match the NVMe partitions.
+- `sudo vclog -m tip` (or `sudo vcgencmd bootloader_config`) is free of bootloader warnings.
 
 A freshly built image ships with `first-boot-prepare.service`, ensuring `rpi-clone`,
 `rpi-eeprom`, `vcgencmd`, `ethtool`, `jq`, `parted`, `lsblk`, `wipefs`, and `just` are

--- a/scripts/boot_order.sh
+++ b/scripts/boot_order.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+main() {
+  if [[ $# -lt 1 ]]; then
+    usage >&2
+    exit 1
+  fi
+
+  case "$1" in
+    ensure_order)
+      shift
+      ensure_order "$@"
+      ;;
+    print)
+      shift
+      print_status "$@"
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+}
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  boot_order.sh ensure_order <hex>  Set BOOT_ORDER to the specified hex value.
+  boot_order.sh print               Show current BOOT_ORDER and PCIE_* keys.
+
+Set PCIE_PROBE=1 in the environment to append PCIE_PROBE=1 when applying an order.
+USAGE
+}
+
+require_binary() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "[boot-order] Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+sudo_prefix() {
+  if [[ ${EUID} -eq 0 ]]; then
+    echo ""
+  else
+    echo "sudo"
+  fi
+}
+
+ensure_order() {
+  if [[ $# -ne 1 ]]; then
+    echo "[boot-order] ensure_order expects exactly one argument (hex value)." >&2
+    usage >&2
+    exit 1
+  fi
+
+  local desired="$1"
+  validate_hex "$desired"
+  desired=$(normalize_hex "$desired")
+
+  require_binary rpi-eeprom-config
+
+  local sudo_cmd
+  sudo_cmd=$(sudo_prefix)
+
+  local tmp_dir
+  tmp_dir=$(mktemp -d)
+  trap 'rm -rf "${tmp_dir}"' EXIT
+
+  local current_conf="${tmp_dir}/current.conf"
+  local target_conf="${tmp_dir}/target.conf"
+
+  if ! ${sudo_cmd} rpi-eeprom-config >"${current_conf}"; then
+    echo "[boot-order] Failed to read current EEPROM configuration." >&2
+    exit 1
+  fi
+
+  cp "${current_conf}" "${target_conf}"
+
+  update_key "${target_conf}" "BOOT_ORDER" "${desired}"
+
+  if [[ "${PCIE_PROBE:-}" == "1" ]]; then
+    update_key "${target_conf}" "PCIE_PROBE" "1"
+  fi
+
+  if cmp -s "${current_conf}" "${target_conf}"; then
+    echo "[boot-order] BOOT_ORDER already set to ${desired} ($(describe_order "${desired}")); no changes needed."
+    print_status
+    return
+  fi
+
+  echo "[boot-order] Applying BOOT_ORDER=${desired} ($(describe_order "${desired}"))."
+  ${sudo_cmd} rpi-eeprom-config --edit "${target_conf}"
+
+  print_status
+}
+
+update_key() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+
+  if grep -qi "^${key}=" "${file}"; then
+    sed -i "s/^${key}=.*/${key}=${value}/I" "${file}"
+  else
+    printf '\n%s=%s\n' "${key}" "${value}" >>"${file}"
+  fi
+}
+
+validate_hex() {
+  local value="$1"
+  if [[ ! ${value} =~ ^0[xX][0-9a-fA-F]+$ ]]; then
+    echo "[boot-order] Invalid hex value: ${value}. Expected format 0x####." >&2
+    exit 1
+  fi
+}
+
+normalize_hex() {
+  local value="$1"
+  printf '0x%s\n' "${value#0x}" | tr '[:lower:]' '[:upper:]'
+}
+
+print_status() {
+  require_binary rpi-eeprom-config
+
+  local sudo_cmd
+  sudo_cmd=$(sudo_prefix)
+
+  local config
+  if ! config=$(${sudo_cmd} rpi-eeprom-config); then
+    echo "[boot-order] Failed to read EEPROM configuration." >&2
+    exit 1
+  fi
+
+  local order
+  order=$(printf '%s\n' "${config}" | awk -F'=' 'toupper($1)=="BOOT_ORDER" {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2; exit}')
+
+  if [[ -z ${order} ]]; then
+    echo "[boot-order] BOOT_ORDER not found in EEPROM configuration." >&2
+    exit 1
+  fi
+
+  order=$(normalize_hex "${order}")
+  echo "[boot-order] Current BOOT_ORDER=${order} ($(describe_order "${order}"))."
+
+  local pcie
+  pcie=$(printf '%s\n' "${config}" | grep -E '^PCIE_' || true)
+  if [[ -n ${pcie} ]]; then
+    echo "[boot-order] PCIE settings:\n${pcie}"
+  else
+    echo "[boot-order] No PCIE_* overrides set."
+  fi
+}
+
+describe_order() {
+  local order=$(printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]')
+  order=${order#0x}
+  if [[ -z ${order} ]]; then
+    echo "unknown order"
+    return
+  fi
+
+  local -a labels=()
+  local -i idx
+  for ((idx=${#order}-1; idx>=0; idx--)); do
+    local nibble=${order:idx:1}
+    labels+=("$(describe_nibble "${nibble}")")
+  done
+
+  local description="${labels[0]}"
+  for ((idx=1; idx<${#labels[@]}; idx++)); do
+    description+=" → ${labels[idx]}"
+  done
+
+  echo "${description}"
+}
+
+describe_nibble() {
+  local nibble=$(printf '%s\n' "$1" | tr '[:lower:]' '[:upper:]')
+  case "${nibble}" in
+    0) echo "Stop" ;;
+    1) echo "SD" ;;
+    2) echo "Network" ;;
+    3) echo "USB 2.0" ;;
+    4) echo "USB" ;;
+    5) echo "USB (retry)" ;;
+    6) echo "NVMe" ;;
+    7) echo "USB boot (type 7)" ;;
+    8) echo "USB (type 8)" ;;
+    9) echo "USB (type 9)" ;;
+    A) echo "SD (alt)" ;;
+    B) echo "Network (alt)" ;;
+    C) echo "USB (type C)" ;;
+    D) echo "USB (type D)" ;;
+    E) echo "Retry" ;;
+    F) echo "repeat" ;;
+    *) echo "0x${nibble}" ;;
+  esac
+}
+
+main "$@"

--- a/scripts/eeprom_nvme_first.sh
+++ b/scripts/eeprom_nvme_first.sh
@@ -1,66 +1,14 @@
 #!/usr/bin/env bash
-# Purpose: Ensure Raspberry Pi EEPROM prefers NVMe boot with up-to-date firmware.
-# Usage: sudo ./scripts/eeprom_nvme_first.sh
+# Deprecated wrapper for the old eeprom-nvme-first helper.
 set -Eeuo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
-ARTIFACT_DIR="${REPO_ROOT}/artifacts"
-mkdir -p "${ARTIFACT_DIR}"
-LOG_FILE="${ARTIFACT_DIR}/eeprom-nvme-first.log"
-exec > >(tee "${LOG_FILE}") 2>&1
+ORDER_HEX="0xf416"
 
-if [[ ${EUID} -ne 0 ]]; then
-  echo "This script must run with sudo/root privileges." >&2
-  exit 1
-fi
+cat <<'MSG'
+[eeprom] WARNING: eeprom-nvme-first is deprecated and will be removed in a future release.
+[eeprom] It now delegates to 'just boot-order nvme-first' to apply BOOT_ORDER=0xf416 (NVMe → SD → USB → repeat).
+[eeprom] Update your automation to call the new boot-order target directly.
+MSG
 
-if ! command -v rpi-eeprom-update >/dev/null 2>&1; then
-  echo "rpi-eeprom-update not found; install the rpi-eeprom package first." >&2
-  exit 1
-fi
-
-if ! command -v rpi-eeprom-config >/dev/null 2>&1; then
-  echo "rpi-eeprom-config not found; install the rpi-eeprom package first." >&2
-  exit 1
-fi
-
-echo "[eeprom] Checking for firmware updates (rpi-eeprom-update -a)"
-UPDATE_OUTPUT=$(rpi-eeprom-update -a 2>&1 || true)
-echo "${UPDATE_OUTPUT}"
-
-TMP_DIR=$(mktemp -d)
-CURRENT_CFG="${TMP_DIR}/current.conf"
-TARGET_CFG="${TMP_DIR}/target.conf"
-trap 'rm -rf "${TMP_DIR}"' EXIT
-
-if ! rpi-eeprom-config >"${CURRENT_CFG}"; then
-  echo "Failed to read current EEPROM configuration" >&2
-  exit 1
-fi
-cp "${CURRENT_CFG}" "${TARGET_CFG}"
-
-if grep -q '^BOOT_ORDER=' "${TARGET_CFG}"; then
-  sed -i 's/^BOOT_ORDER=.*/BOOT_ORDER=0xf416/' "${TARGET_CFG}"
-else
-  printf '\nBOOT_ORDER=0xf416\n' >>"${TARGET_CFG}"
-fi
-
-if grep -q '^PCIE_PROBE=' "${TARGET_CFG}"; then
-  sed -i 's/^PCIE_PROBE=.*/PCIE_PROBE=1/' "${TARGET_CFG}"
-else
-  printf '\nPCIE_PROBE=1\n' >>"${TARGET_CFG}"
-fi
-
-if cmp -s "${CURRENT_CFG}" "${TARGET_CFG}"; then
-  echo "[eeprom] BOOT_ORDER and PCIE_PROBE already set; no changes applied."
-  exit 0
-fi
-
-echo "[eeprom] Applying updated EEPROM configuration"
-if ! rpi-eeprom-config --apply "${TARGET_CFG}"; then
-  echo "Failed to apply EEPROM configuration" >&2
-  exit 1
-fi
-
-echo "[eeprom] EEPROM configuration updated to prefer NVMe boot (BOOT_ORDER=0xf416, PCIE_PROBE=1)."
+"${SCRIPT_DIR}/boot_order.sh" ensure_order "${ORDER_HEX}"


### PR DESCRIPTION
🚀 : –
what: add dedicated boot-order just targets and helper script
why: make NVMe cloning guidance clearer and reduce EEPROM mistakes
how to test: bash -n scripts/boot_order.sh && bash -n scripts/eeprom_nvme_first.sh

------
https://chatgpt.com/codex/tasks/task_e_68f1caa05f78832f93ee32f7c4d38829