### PR TITLE
Add boot-order helper script and refresh NVMe clone docs

### DIFF
--- a/scripts/boot_order.sh
+++ b/scripts/boot_order.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Purpose: Inspect or enforce Raspberry Pi EEPROM boot order presets.
+# Usage:
+#   sudo scripts/boot_order.sh ensure_order 0xf461
+#   sudo scripts/boot_order.sh print
+set -Eeuo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  boot_order.sh ensure_order <hex>
+  boot_order.sh print
+
+Examples:
+  sudo boot_order.sh ensure_order 0xf461
+  boot_order.sh print
+USAGE
+}
+
+require_commands() {
+  for cmd in "$@"; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      echo "Missing required command: $cmd" >&2
+      exit 1
+    fi
+  done
+}
+
+normalize_hex() {
+  local input="$1"
+  input=${input^^}
+  if [[ $input != 0X* ]]; then
+    input="0x${input}"
+  fi
+  echo "$input"
+}
+
+describe_nibble() {
+  case "$1" in
+    0) echo "retry" ;;
+    1) echo "SD" ;;
+    2) echo "network" ;;
+    3) echo "USB (bootrom)" ;;
+    4) echo "USB" ;;
+    5) echo "reserved" ;;
+    6) echo "NVMe" ;;
+    7) echo "eMMC" ;;
+    8) echo "USB (alt)" ;;
+    9) echo "EEPROM" ;;
+    A) echo "SD (safe)" ;;
+    B) echo "stop" ;;
+    C) echo "shutdown" ;;
+    D) echo "restart" ;;
+    E) echo "reserved" ;;
+    F) echo "repeat" ;;
+    *) echo "0x$1" ;;
+  esac
+}
+
+human_readable_order() {
+  local hex="$1"
+  local trimmed=${hex#0x}
+  trimmed=${trimmed^^}
+  local length=${#trimmed}
+  local parts=()
+  for ((i=length-1; i>=0; i--)); do
+    parts+=("$(describe_nibble "${trimmed:i:1}")")
+  done
+  if ((${#parts[@]} == 0)); then
+    echo "n/a"
+    return
+  fi
+  local joined
+  printf -v joined '%s → ' "${parts[@]}"
+  # remove trailing arrow and space
+  echo "${joined% → }"
+}
+
+print_effective() {
+  local current
+  if ! current=$(rpi-eeprom-config 2>/dev/null); then
+    echo "Failed to read EEPROM configuration" >&2
+    exit 1
+  fi
+  local boot_order
+  boot_order=$(grep -E '^BOOT_ORDER=' <<<"$current" | tail -n1 | cut -d'=' -f2 || true)
+  if [[ -z "$boot_order" ]]; then
+    echo "BOOT_ORDER is not set in EEPROM configuration" >&2
+    exit 1
+  fi
+  boot_order=$(normalize_hex "$boot_order")
+  echo "BOOT_ORDER=${boot_order} ($(human_readable_order "$boot_order"))"
+  local pcie_lines
+  pcie_lines=$(grep -E '^PCIE_' <<<"$current" || true)
+  if [[ -n "$pcie_lines" ]]; then
+    echo "$pcie_lines"
+  fi
+}
+
+ensure_order() {
+  local desired_hex
+  desired_hex=$(normalize_hex "$1")
+  require_commands rpi-eeprom-config mktemp cmp
+  if [[ ${EUID} -ne 0 ]]; then
+    echo "This command must be run as root (sudo)." >&2
+    exit 1
+  fi
+  local tmp_dir
+  tmp_dir=$(mktemp -d)
+  trap 'rm -rf "${tmp_dir}"' EXIT
+  local current_conf="${tmp_dir}/current.conf"
+  local target_conf="${tmp_dir}/boot.conf"
+  if ! rpi-eeprom-config >"${current_conf}"; then
+    echo "Failed to read current EEPROM configuration" >&2
+    exit 1
+  fi
+  cp "${current_conf}" "${target_conf}"
+  if grep -q '^BOOT_ORDER=' "${target_conf}"; then
+    sed -i "s/^BOOT_ORDER=.*/BOOT_ORDER=${desired_hex}/" "${target_conf}"
+  else
+    printf '\nBOOT_ORDER=%s\n' "${desired_hex}" >>"${target_conf}"
+  fi
+  if [[ ${PCIE_PROBE:-} == 1 ]]; then
+    if grep -q '^PCIE_PROBE=' "${target_conf}"; then
+      sed -i 's/^PCIE_PROBE=.*/PCIE_PROBE=1/' "${target_conf}"
+    else
+      printf '\nPCIE_PROBE=1\n' >>"${target_conf}"
+    fi
+  fi
+  if cmp -s "${current_conf}" "${target_conf}"; then
+    echo "BOOT_ORDER already set to ${desired_hex} ($(human_readable_order "${desired_hex}")); no changes applied."
+  else
+    echo "Applying EEPROM boot configuration: BOOT_ORDER=${desired_hex} ($(human_readable_order "${desired_hex}"))"
+    if ! rpi-eeprom-config --apply "${target_conf}"; then
+      echo "Failed to apply EEPROM configuration" >&2
+      exit 1
+    fi
+  fi
+  print_effective
+}
+
+main() {
+  if [[ $# -lt 1 ]]; then
+    usage >&2
+    exit 1
+  fi
+  case "$1" in
+    ensure_order)
+      if [[ $# -ne 2 ]]; then
+        usage >&2
+        exit 1
+      fi
+      ensure_order "$2"
+      ;;
+    print)
+      require_commands rpi-eeprom-config
+      print_effective
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/eeprom_nvme_first.sh
+++ b/scripts/eeprom_nvme_first.sh
@@ -1,66 +1,15 @@
 #!/usr/bin/env bash
-# Purpose: Ensure Raspberry Pi EEPROM prefers NVMe boot with up-to-date firmware.
-# Usage: sudo ./scripts/eeprom_nvme_first.sh
+# Deprecated stub: prefer scripts/boot_order.sh via `just boot-order nvme-first`.
 set -Eeuo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
-ARTIFACT_DIR="${REPO_ROOT}/artifacts"
-mkdir -p "${ARTIFACT_DIR}"
-LOG_FILE="${ARTIFACT_DIR}/eeprom-nvme-first.log"
-exec > >(tee "${LOG_FILE}") 2>&1
+BOOT_ORDER_SCRIPT="${SCRIPT_DIR}/boot_order.sh"
 
-if [[ ${EUID} -ne 0 ]]; then
-  echo "This script must run with sudo/root privileges." >&2
+if [[ ! -x "${BOOT_ORDER_SCRIPT}" ]]; then
+  echo "Missing helper: ${BOOT_ORDER_SCRIPT}" >&2
   exit 1
 fi
 
-if ! command -v rpi-eeprom-update >/dev/null 2>&1; then
-  echo "rpi-eeprom-update not found; install the rpi-eeprom package first." >&2
-  exit 1
-fi
-
-if ! command -v rpi-eeprom-config >/dev/null 2>&1; then
-  echo "rpi-eeprom-config not found; install the rpi-eeprom package first." >&2
-  exit 1
-fi
-
-echo "[eeprom] Checking for firmware updates (rpi-eeprom-update -a)"
-UPDATE_OUTPUT=$(rpi-eeprom-update -a 2>&1 || true)
-echo "${UPDATE_OUTPUT}"
-
-TMP_DIR=$(mktemp -d)
-CURRENT_CFG="${TMP_DIR}/current.conf"
-TARGET_CFG="${TMP_DIR}/target.conf"
-trap 'rm -rf "${TMP_DIR}"' EXIT
-
-if ! rpi-eeprom-config >"${CURRENT_CFG}"; then
-  echo "Failed to read current EEPROM configuration" >&2
-  exit 1
-fi
-cp "${CURRENT_CFG}" "${TARGET_CFG}"
-
-if grep -q '^BOOT_ORDER=' "${TARGET_CFG}"; then
-  sed -i 's/^BOOT_ORDER=.*/BOOT_ORDER=0xf416/' "${TARGET_CFG}"
-else
-  printf '\nBOOT_ORDER=0xf416\n' >>"${TARGET_CFG}"
-fi
-
-if grep -q '^PCIE_PROBE=' "${TARGET_CFG}"; then
-  sed -i 's/^PCIE_PROBE=.*/PCIE_PROBE=1/' "${TARGET_CFG}"
-else
-  printf '\nPCIE_PROBE=1\n' >>"${TARGET_CFG}"
-fi
-
-if cmp -s "${CURRENT_CFG}" "${TARGET_CFG}"; then
-  echo "[eeprom] BOOT_ORDER and PCIE_PROBE already set; no changes applied."
-  exit 0
-fi
-
-echo "[eeprom] Applying updated EEPROM configuration"
-if ! rpi-eeprom-config --apply "${TARGET_CFG}"; then
-  echo "Failed to apply EEPROM configuration" >&2
-  exit 1
-fi
-
-echo "[eeprom] EEPROM configuration updated to prefer NVMe boot (BOOT_ORDER=0xf416, PCIE_PROBE=1)."
+echo "[deprecated] eeprom-nvme-first is deprecated and will be removed in a future release."
+echo "[deprecated] Redirecting to BOOT_ORDER=0xf416 (NVMe → SD → USB → repeat)."
+exec "${BOOT_ORDER_SCRIPT}" ensure_order 0xf416


### PR DESCRIPTION
## Summary
- add scripts/boot_order.sh to inspect or enforce EEPROM boot order presets with optional PCIE_PROBE control
- expose new `just boot-order` presets, update the migration flow, and keep a deprecation stub for `eeprom-nvme-first`
- rewrite the NVMe cloning guide with skip conditions, resilient cloning flags, troubleshooting steps, and SD override guidance

## Testing
- `pre-commit run --all-files` *(fails: existing line-length violations in scripts/ssd_clone.py)*
- `pyspelling -c .spellcheck.yaml` *(fails: missing aspell binary in container)*
- `linkchecker --no-warnings README.md docs/`


------
https://chatgpt.com/codex/tasks/task_e_68f1caa05f78832f93ee32f7c4d38829