### PR TITLE
🛠️ : – shellcheck cleanup

### DIFF
--- a/scripts/boot_order.sh
+++ b/scripts/boot_order.sh
@@ -22,11 +22,11 @@ require_command() {
 }
 
 run_rpi_eeprom_config() {
-  if rpi-eeprom-config "$@"; then
+  if rpi-eeprom-config; then
     return 0
   fi
   if [[ ${EUID:-} -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
-    sudo rpi-eeprom-config "$@"
+    sudo rpi-eeprom-config
     return 0
   fi
   return 1


### PR DESCRIPTION
what: remove unused argument forwarding in run_rpi_eeprom_config
why: shellcheck flagged SC2120/SC2119 when the helper runs without args
how to test: shellcheck scripts/boot_order.sh

------
https://chatgpt.com/codex/tasks/task_e_68f1d9784e88832fa4132f10b38f8fb0