### PR TITLE
🛠️ : – Fix Pi NVMe migration helpers

### DIFF
--- a/docs/raspi-image-spot-check.md
+++ b/docs/raspi-image-spot-check.md
@@ -79,6 +79,11 @@ sudo PCIE_PROBE=1 just boot-order nvme-first
 ### 2. Clone the SD card to NVMe
 
 Use `-U` once to create the NVMe partitions, then rerun without it for incremental clones.
+Install `rpi-clone` the first time you run this step:
+
+```bash
+sudo just install-rpi-clone
+```
 
 ```bash
 sudo rpi-clone -f -U /dev/nvme0n1

--- a/justfile
+++ b/justfile
@@ -127,18 +127,7 @@ spot-check:
 
 # Usage: sudo just boot-order sd-nvme-usb
 boot-order preset:
-    if [ "{{ preset }}" = "sd-nvme-usb" ]; then
-    order="0xF461"
-    human="SD → NVMe → USB → repeat"
-    elif [ "{{ preset }}" = "nvme-first" ]; then
-    order="0xF416"
-    human="NVMe → SD → USB → repeat"
-    else
-    echo "Unknown boot-order preset '{{ preset }}'. Use sd-nvme-usb or nvme-first." >&2
-    exit 1
-    fi
-    echo "[boot-order] Target preset '{{ preset }}' => BOOT_ORDER=${order} (${human})."
-    "{{ boot_order_cmd }}" ensure_order "${order}"
+    "{{ scripts_dir }}/apply_boot_order_preset.sh" "{{ preset }}"
 
 # Deprecated wrapper retained for one release; prefer `just boot-order nvme-first`
 
@@ -159,33 +148,21 @@ clone-ssd:
 
 # Usage: sudo just migrate-to-nvme SKIP_EEPROM=1 NO_REBOOT=1
 migrate-to-nvme:
-    artifacts_dir="{{ migrate_artifacts }}"
-    mkdir -p "${artifacts_dir}"
-    log_file="${artifacts_dir}/migrate.log"
-    (
-    set -o pipefail
-    run_step() {
-    local label="$1"
-    shift
-    printf '[migrate] >>> %s\n' "${label}"
-    "$@"
-    }
-    run_step spot-check "{{ spot_check_cmd }}" {{ spot_check_args }}
-    if [ "{{ migrate_skip_eeprom }}" != "1" ]; then
-    run_step eeprom "{{ eeprom_cmd }}" {{ eeprom_args }}
-    else
-    printf '[migrate] SKIP_EEPROM=1, skipping EEPROM update\n'
-    fi
-    run_step clone env TARGET="{{ clone_target }}" WIPE="{{ clone_wipe }}" "{{ clone_cmd }}" {{ clone_args }}
-    if [ "{{ migrate_no_reboot }}" != "1" ]; then
-    printf '[migrate] Rebooting to complete migration\n'
-    sync
-    reboot
-    else
-    printf '[migrate] NO_REBOOT=1 set; not rebooting automatically\n'
-    fi
-    printf '[migrate] Log captured at %s\n' "${log_file}"
-    ) | tee "${log_file}"
+    MIGRATE_ARTIFACTS="{{ migrate_artifacts }}" \
+    SPOT_CHECK_ARGS="{{ spot_check_args }}" \
+    EEPROM_ARGS="{{ eeprom_args }}" \
+    CLONE_ARGS="{{ clone_args }}" \
+    TARGET="{{ clone_target }}" \
+    WIPE="{{ clone_wipe }}" \
+    SKIP_EEPROM="{{ migrate_skip_eeprom }}" \
+    NO_REBOOT="{{ migrate_no_reboot }}" \
+    "{{ scripts_dir }}/migrate_to_nvme.sh"
+
+# Install or update rpi-clone utility
+
+# Usage: sudo just install-rpi-clone
+install-rpi-clone:
+    "{{ scripts_dir }}/install_rpi_clone.sh"
 
 # Post-migration verification ensuring both partitions boot from NVMe
 

--- a/scripts/apply_boot_order_preset.sh
+++ b/scripts/apply_boot_order_preset.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Purpose: Map friendly boot-order presets to EEPROM hex values.
+# Usage: sudo ./scripts/apply_boot_order_preset.sh sd-nvme-usb
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+BOOT_ORDER_CMD=${BOOT_ORDER_CMD:-"${SCRIPT_DIR}/boot_order.sh"}
+
+usage() {
+  cat <<'USAGE'
+Usage: apply_boot_order_preset.sh <preset>
+
+Presets:
+  sd-nvme-usb  SD → NVMe → USB → repeat (0xF461)
+  nvme-first   NVMe → SD → USB → repeat (0xF416)
+USAGE
+}
+
+if [[ $# -ne 1 ]]; then
+  usage >&2
+  exit 1
+fi
+
+preset=$1
+case "${preset}" in
+  sd-nvme-usb)
+    order="0xF461"
+    human="SD → NVMe → USB → repeat"
+    ;;
+  nvme-first)
+    order="0xF416"
+    human="NVMe → SD → USB → repeat"
+    ;;
+  *)
+    echo "Unknown boot-order preset '${preset}'. Use sd-nvme-usb or nvme-first." >&2
+    exit 1
+    ;;
+esac
+
+echo "[boot-order] Target preset '${preset}' => BOOT_ORDER=${order} (${human})."
+"${BOOT_ORDER_CMD}" ensure_order "${order}"

--- a/scripts/install_rpi_clone.sh
+++ b/scripts/install_rpi_clone.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Purpose: Ensure the rpi-clone utility is installed and up to date.
+# Usage: sudo ./scripts/install_rpi_clone.sh
+set -Eeuo pipefail
+
+INSTALL_URL="https://raw.githubusercontent.com/geerlingguy/rpi-clone/master/install"
+
+if command -v rpi-clone >/dev/null 2>&1; then
+  location=$(command -v rpi-clone)
+  echo "[install-rpi-clone] rpi-clone already installed at ${location}" \
+    "(skip installation)."
+  exit 0
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required to install rpi-clone" >&2
+  exit 1
+fi
+
+if [[ ${EUID:-0} -ne 0 ]]; then
+  if command -v sudo >/dev/null 2>&1; then
+    exec sudo "$0" "$@"
+  fi
+  echo "This script requires root privileges." >&2
+  exit 1
+fi
+
+echo "[install-rpi-clone] Installing rpi-clone from ${INSTALL_URL}" >&2
+if curl -fsSL "${INSTALL_URL}" | bash; then
+  echo "[install-rpi-clone] Installation complete"
+else
+  echo "[install-rpi-clone] Installation failed" >&2
+  exit 1
+fi

--- a/scripts/migrate_to_nvme.sh
+++ b/scripts/migrate_to_nvme.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Purpose: Orchestrate spot-check, boot-order alignment, clone, and reboot migration flow.
+# Usage: sudo ./scripts/migrate_to_nvme.sh
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+MIGRATE_ARTIFACTS=${MIGRATE_ARTIFACTS:-"${REPO_ROOT}/artifacts/migrate-to-nvme"}
+SPOT_CHECK_CMD=${SPOT_CHECK_CMD:-"${SCRIPT_DIR}/spot_check.sh"}
+SPOT_CHECK_ARGS=${SPOT_CHECK_ARGS:-}
+EEPROM_CMD=${EEPROM_CMD:-"${SCRIPT_DIR}/eeprom_nvme_first.sh"}
+EEPROM_ARGS=${EEPROM_ARGS:-}
+CLONE_CMD=${CLONE_CMD:-"${SCRIPT_DIR}/clone_to_nvme.sh"}
+CLONE_ARGS=${CLONE_ARGS:-}
+CLONE_TARGET=${TARGET:-${CLONE_TARGET:-}}
+CLONE_WIPE=${WIPE:-${CLONE_WIPE:-0}}
+SKIP_EEPROM=${SKIP_EEPROM:-0}
+NO_REBOOT=${NO_REBOOT:-0}
+
+mkdir -p "${MIGRATE_ARTIFACTS}"
+LOG_FILE="${MIGRATE_ARTIFACTS}/migrate.log"
+: >"${LOG_FILE}"
+exec > >(tee "${LOG_FILE}") 2>&1
+
+run_step() {
+  local label=$1
+  shift
+  printf '[migrate] >>> %s\n' "${label}"
+  "$@"
+}
+
+if [[ ${EUID:-0} -ne 0 ]]; then
+  if [[ "${ALLOW_NON_ROOT:-0}" == "1" ]]; then
+    printf '[migrate] ALLOW_NON_ROOT=1 set; continuing without sudo re-exec\n'
+  elif command -v sudo >/dev/null 2>&1; then
+    exec sudo \
+      MIGRATE_ARTIFACTS="${MIGRATE_ARTIFACTS}" \
+      SPOT_CHECK_CMD="${SPOT_CHECK_CMD}" \
+      SPOT_CHECK_ARGS="${SPOT_CHECK_ARGS}" \
+      EEPROM_CMD="${EEPROM_CMD}" \
+      EEPROM_ARGS="${EEPROM_ARGS}" \
+      CLONE_CMD="${CLONE_CMD}" \
+      CLONE_ARGS="${CLONE_ARGS}" \
+      TARGET="${CLONE_TARGET}" \
+      WIPE="${CLONE_WIPE}" \
+      SKIP_EEPROM="${SKIP_EEPROM}" \
+      NO_REBOOT="${NO_REBOOT}" \
+      "$0" "$@"
+  else
+    echo "This script requires root privileges." >&2
+    exit 1
+  fi
+fi
+
+run_step spot-check "${SPOT_CHECK_CMD}" ${SPOT_CHECK_ARGS}
+
+if [[ "${SKIP_EEPROM}" != "1" ]]; then
+  run_step eeprom "${EEPROM_CMD}" ${EEPROM_ARGS}
+else
+  printf '[migrate] SKIP_EEPROM=1, skipping EEPROM update\n'
+fi
+
+run_step clone env TARGET="${CLONE_TARGET}" WIPE="${CLONE_WIPE}" "${CLONE_CMD}" ${CLONE_ARGS}
+
+if [[ "${NO_REBOOT}" != "1" ]]; then
+  printf '[migrate] Rebooting to complete migration\n'
+  sync
+  reboot
+else
+  printf '[migrate] NO_REBOOT=1 set; not rebooting automatically\n'
+fi
+
+printf '[migrate] Log captured at %s\n' "${LOG_FILE}"

--- a/tests/boot_order_preset_test.bats
+++ b/tests/boot_order_preset_test.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+
+setup() {
+  cd "${BATS_TEST_DIRNAME}/.."
+  export TEST_BIN="${BATS_TEST_TMPDIR}/bin"
+  mkdir -p "${TEST_BIN}"
+  export PATH="${TEST_BIN}:$PATH"
+  export BOOT_ORDER_CALL_LOG="${BATS_TEST_TMPDIR}/boot_order_calls.log"
+  : >"${BOOT_ORDER_CALL_LOG}"
+
+  cat >"${TEST_BIN}/boot_order_stub.sh" <<'STUB'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+echo "$@" >>"${BOOT_ORDER_CALL_LOG}"
+if [[ -n "${PCIE_PROBE:-}" ]]; then
+  echo "PCIE_PROBE=${PCIE_PROBE}" >>"${BOOT_ORDER_CALL_LOG}"
+fi
+STUB
+  chmod +x "${TEST_BIN}/boot_order_stub.sh"
+  export BOOT_ORDER_CMD="${TEST_BIN}/boot_order_stub.sh"
+}
+
+@test "apply_boot_order_preset maps sd-nvme-usb" {
+  run scripts/apply_boot_order_preset.sh sd-nvme-usb
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Target preset 'sd-nvme-usb' => BOOT_ORDER=0xF461"* ]]
+
+  mapfile -t calls <"${BOOT_ORDER_CALL_LOG}"
+  [ "${#calls[@]}" -eq 1 ]
+  [[ "${calls[0]}" == "ensure_order 0xF461" ]]
+}
+
+@test "apply_boot_order_preset maps nvme-first and forwards PCIE_PROBE" {
+  run PCIE_PROBE=1 scripts/apply_boot_order_preset.sh nvme-first
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Target preset 'nvme-first' => BOOT_ORDER=0xF416"* ]]
+
+  mapfile -t calls <"${BOOT_ORDER_CALL_LOG}"
+  [ "${#calls[@]}" -eq 2 ]
+  [[ "${calls[0]}" == "ensure_order 0xF416" ]]
+  [[ "${calls[1]}" == "PCIE_PROBE=1" ]]
+}
+
+@test "apply_boot_order_preset rejects unknown preset" {
+  run scripts/apply_boot_order_preset.sh unsupported
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown boot-order preset"* ]]
+}

--- a/tests/migrate_to_nvme_test.bats
+++ b/tests/migrate_to_nvme_test.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+
+setup() {
+  cd "${BATS_TEST_DIRNAME}/.."
+  export TEST_BIN="${BATS_TEST_TMPDIR}/bin"
+  mkdir -p "${TEST_BIN}"
+  export PATH="${TEST_BIN}:$PATH"
+  export MIGRATE_CALL_LOG="${BATS_TEST_TMPDIR}/migrate_calls.log"
+  : >"${MIGRATE_CALL_LOG}"
+  export ALLOW_NON_ROOT=1
+
+  cat >"${TEST_BIN}/spot-check" <<'STUB'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+echo "spot-check:$*" >>"${MIGRATE_CALL_LOG}"
+STUB
+  chmod +x "${TEST_BIN}/spot-check"
+
+  cat >"${TEST_BIN}/eeprom" <<'STUB'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+echo "eeprom:$*" >>"${MIGRATE_CALL_LOG}"
+STUB
+  chmod +x "${TEST_BIN}/eeprom"
+
+  cat >"${TEST_BIN}/clone" <<'STUB'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+if [[ "${TARGET:-}" != "/dev/testdisk" ]]; then
+  echo "TARGET not forwarded" >&2
+  exit 1
+fi
+if [[ "${WIPE:-}" != "1" ]]; then
+  echo "WIPE not forwarded" >&2
+  exit 1
+fi
+echo "clone:$*" >>"${MIGRATE_CALL_LOG}"
+STUB
+  chmod +x "${TEST_BIN}/clone"
+
+  cat >"${TEST_BIN}/reboot" <<'STUB'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+echo "reboot:$*" >>"${MIGRATE_CALL_LOG}"
+STUB
+  chmod +x "${TEST_BIN}/reboot"
+}
+
+@test "migrate_to_nvme runs all steps" {
+  export MIGRATE_ARTIFACTS="${BATS_TEST_TMPDIR}/artifacts"
+  export SPOT_CHECK_CMD="${TEST_BIN}/spot-check"
+  export EEPROM_CMD="${TEST_BIN}/eeprom"
+  export CLONE_CMD="${TEST_BIN}/clone"
+  export TARGET="/dev/testdisk"
+  export WIPE=1
+  run scripts/migrate_to_nvme.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[migrate] >>> spot-check"* ]]
+  [[ "$output" == *"[migrate] >>> eeprom"* ]]
+  [[ "$output" == *"[migrate] >>> clone"* ]]
+  [[ "$output" == *"[migrate] Rebooting to complete migration"* ]]
+
+  [ -f "${MIGRATE_ARTIFACTS}/migrate.log" ]
+  mapfile -t calls <"${MIGRATE_CALL_LOG}"
+  [ "${#calls[@]}" -eq 4 ]
+  [[ "${calls[0]}" == "spot-check:"* ]]
+  [[ "${calls[1]}" == "eeprom:"* ]]
+  [[ "${calls[2]}" == "clone:"* ]]
+  [[ "${calls[3]}" == "reboot:"* ]]
+}
+
+@test "migrate_to_nvme honors SKIP_EEPROM and NO_REBOOT" {
+  export MIGRATE_ARTIFACTS="${BATS_TEST_TMPDIR}/artifacts2"
+  export SPOT_CHECK_CMD="${TEST_BIN}/spot-check"
+  export EEPROM_CMD="${TEST_BIN}/eeprom"
+  export CLONE_CMD="${TEST_BIN}/clone"
+  export TARGET="/dev/testdisk"
+  export WIPE=1
+  export SKIP_EEPROM=1
+  export NO_REBOOT=1
+  run scripts/migrate_to_nvme.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"SKIP_EEPROM=1"* ]]
+  [[ "$output" == *"NO_REBOOT=1 set"* ]]
+
+  mapfile -t calls <"${MIGRATE_CALL_LOG}"
+  [ "${#calls[@]}" -eq 2 ]
+  [[ "${calls[0]}" == "spot-check:"* ]]
+  [[ "${calls[1]}" == "clone:"* ]]
+}

--- a/tests/test_flash_pi_justfile.py
+++ b/tests/test_flash_pi_justfile.py
@@ -66,8 +66,14 @@ def test_justfile_has_no_tabs_or_trailing_whitespace() -> None:
             "clone-ssd",
             "clone-ssd:",
             [
-                '    if [ -z "{{ clone_target }}" ]; then echo "Set CLONE_TARGET to the target device (e.g. /dev/sda) before running clone-ssd." >&2; exit 1; fi',  # noqa: E501
-                '    "{{ clone_cmd }}" --target "{{ clone_target }}" {{ clone_args }}',  # noqa: E501
+                '    TARGET="{{ clone_target }}" WIPE="{{ clone_wipe }}" "{{ clone_cmd }}" {{ clone_args }}',  # noqa: E501
+            ],
+        ),
+        (
+            "boot-order preset",
+            "boot-order preset:",
+            [
+                '    "{{ scripts_dir }}/apply_boot_order_preset.sh" "{{ preset }}"',
             ],
         ),
         (
@@ -84,6 +90,13 @@ def test_justfile_has_no_tabs_or_trailing_whitespace() -> None:
             [
                 '    if [ -z "{{ support_bundle_host }}" ]; then echo "Set SUPPORT_BUNDLE_HOST to the target host before running support-bundle." >&2; exit 1; fi',  # noqa: E501
                 '    "{{ support_bundle_cmd }}" "{{ support_bundle_host }}" {{ support_bundle_args }}',  # noqa: E501
+            ],
+        ),
+        (
+            "install-rpi-clone",
+            "install-rpi-clone:",
+            [
+                '    "{{ scripts_dir }}/install_rpi_clone.sh"',
             ],
         ),
     ],

--- a/tests/test_raspi_image_spot_check_doc.py
+++ b/tests/test_raspi_image_spot_check_doc.py
@@ -1,0 +1,68 @@
+"""Verify the Raspberry Pi spot-check guide stays in sync with automation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+DOC_PATH = Path(__file__).resolve().parents[1] / "docs" / "raspi-image-spot-check.md"
+
+
+def _extract_command_blocks(text: str) -> list[str]:
+    blocks: list[str] = []
+    current: list[str] = []
+    in_block = False
+    for line in text.splitlines():
+        stripped = line.lstrip("> ")
+        if stripped.startswith("```"):
+            if in_block:
+                block_text = "\n".join(current).strip()
+                if block_text and (
+                    block_text.startswith("cd ") or block_text.startswith("sudo ")
+                ):
+                    blocks.append(block_text)
+                current = []
+                in_block = False
+            else:
+                in_block = True
+            continue
+        if in_block:
+            current.append(stripped)
+    return blocks
+
+
+def test_spot_check_doc_commands_are_expected() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    blocks = _extract_command_blocks(text)
+    expected = [
+        "cd ~/sugarkube\nsudo just spot-check",
+        "sudo just boot-order sd-nvme-usb",
+        "sudo PCIE_PROBE=1 just boot-order nvme-first",
+        "sudo just install-rpi-clone",
+        "sudo rpi-clone -f -U /dev/nvme0n1",
+        "sudo just migrate-to-nvme",
+        "sudo rpi-eeprom-config --set 'set_reboot_order=0xf1'",
+        "sudo mount /dev/nvme0n1p1 /mnt/clone\n"
+        "sudo sed -n '1,120p' /mnt/clone/cmdline.txt\n"
+        "sudo sed -n '1,120p' /mnt/clone/etc/fstab\n"
+        "sudo umount /mnt/clone",
+    ]
+    assert blocks == expected, (
+        "docs/raspi-image-spot-check.md code snippets changed; "
+        "update tests/test_raspi_image_spot_check_doc.py accordingly"
+    )
+
+
+def test_spot_check_doc_key_sections_present() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    required_sections = [
+        "# Raspberry Pi 5 Image Spot Check (Bookworm)",
+        "## Required success criteria",
+        "## Known benign noise",
+        "## Next steps: clone to NVMe",
+        "### 1. Align the boot order (only if needed)",
+        "### 2. Clone the SD card to NVMe",
+        "### 3. Optional: one-command migration",
+        "### Verification checklist",
+    ]
+    for section in required_sections:
+        assert section in text, f"Missing section '{section}' in raspi-image-spot-check.md"


### PR DESCRIPTION
what:
- replace fragile just recipes with dedicated scripts for boot-order and migration
- add install helper plus doc updates for rpi-clone instructions
- add regression tests covering doc commands and NVMe flow

why:
- `just boot-order` and `migrate-to-nvme` failed due to shell syntax issues
- Pi docs promised rpi-clone availability but the binary was missing on fresh images
- guard future regressions by syncing docs, recipes, and automation

how to test:
- pytest tests/test_raspi_image_spot_check_doc.py tests/test_flash_pi_justfile.py
- bats tests/boot_order_preset_test.bats tests/migrate_to_nvme_test.bats (requires bats)

Refs: #n/a

------
https://chatgpt.com/codex/tasks/task_e_68f1ef11a0c0832fba5391c16775f012