### PR TITLE
Improve clone_to_nvme boot remount handling

### DIFF
--- a/docs/raspi-image-spot-check.md
+++ b/docs/raspi-image-spot-check.md
@@ -83,14 +83,17 @@ The `clone-ssd` helper wraps `rpi-clone`, installs it on first use, captures log
 target device explicitly during the first run so the script can initialise the NVMe layout:
 
 ```bash
-TARGET=/dev/nvme0n1; WIPE=1; sudo just clone-ssd
+sudo TARGET=/dev/nvme0n1 WIPE=1 just clone-ssd
 ```
 
 Subsequent syncs only need the target argument:
 
 ```bash
-TARGET=/dev/nvme0n1; sudo just clone-ssd
+sudo TARGET=/dev/nvme0n1 just clone-ssd
 ```
+
+> [!NOTE]
+> Bookworm mounts the boot FAT volume at `/boot/firmware`; older images may use `/boot`. The helper handles both.
 
 ### 3. Optional: one-command migration
 


### PR DESCRIPTION
## Summary
- settle udev after rpi-clone and ensure boot mount paths exist under the clone
- force vfat when remounting the boot partition and fall back to /boot on older images
- update docs to pass env vars through sudo and note the /boot vs /boot/firmware layout

## Testing
- shellcheck scripts/clone_to_nvme.sh *(fails: package unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f2ac265b7c832f95638ba5ed9bb58b