### PR TITLE
Improve clone_to_nvme boot remount resilience and doc sudo env fix

### DIFF
--- a/docs/raspi-image-spot-check.md
+++ b/docs/raspi-image-spot-check.md
@@ -83,13 +83,13 @@ The `clone-ssd` helper wraps `rpi-clone`, installs it on first use, captures log
 target device explicitly during the first run so the script can initialise the NVMe layout:
 
 ```bash
-TARGET=/dev/nvme0n1; WIPE=1; sudo just clone-ssd
+sudo TARGET=/dev/nvme0n1 WIPE=1 just clone-ssd
 ```
 
 Subsequent syncs only need the target argument:
 
 ```bash
-TARGET=/dev/nvme0n1; sudo just clone-ssd
+sudo TARGET=/dev/nvme0n1 just clone-ssd
 ```
 
 ### 3. Optional: one-command migration
@@ -101,6 +101,10 @@ sudo just migrate-to-nvme
 ```
 
 Check `artifacts/migrate-to-nvme/` for the run log if anything looks off.
+
+> [!NOTE]
+> Bookworm mounts the boot FAT volume at `/boot/firmware`; older images may use `/boot`.
+> The helper handles both layouts.
 
 ### One-time SD override
 

--- a/scripts/clone_to_nvme.sh
+++ b/scripts/clone_to_nvme.sh
@@ -170,10 +170,13 @@ if ! run_rpi_clone "${TARGET_DEVICE}"; then
   exit 1
 fi
 
+udevadm settle >/dev/null 2>&1 || sleep 2
+
 # Allow overriding clone mount path in tests while defaulting to the system mountpoint.
 CLONE_MOUNT="${CLONE_MOUNT:-/mnt/clone}"
 BOOT_MOUNT="${CLONE_MOUNT}/boot/firmware"
-mkdir -p "${CLONE_MOUNT}" "${BOOT_MOUNT}"
+LEGACY_BOOT_MOUNT="${CLONE_MOUNT}/boot"
+mkdir -p "${CLONE_MOUNT}" "${BOOT_MOUNT}" "${LEGACY_BOOT_MOUNT}"
 
 ensure_mount() {
   local mount_point="$1" source="$2"
@@ -210,17 +213,43 @@ if ! findmnt -rn -o TARGET "${CLONE_MOUNT}" >/dev/null 2>&1; then
   ensure_mount "${CLONE_MOUNT}" "${root_candidate:-}" || true
 fi
 
-if ! findmnt -rn -o TARGET "${BOOT_MOUNT}" >/dev/null 2>&1; then
-  boot_candidate="${TARGET_PARTITIONS[0]:-}"
-  ensure_mount "${BOOT_MOUNT}" "${boot_candidate:-}" || true
-fi
-
 if ! findmnt -rn -o TARGET "${CLONE_MOUNT}" >/dev/null 2>&1; then
   echo "Expected clone root mount ${CLONE_MOUNT} missing." >&2
   exit 1
 fi
-if ! findmnt -rn -o TARGET "${BOOT_MOUNT}" >/dev/null 2>&1; then
-  echo "Expected clone boot mount ${BOOT_MOUNT} missing." >&2
+
+# Ensure boot mount points exist inside the cloned root before mounting the boot partition.
+boot_firmware_preexisting=0
+boot_dir_preexisting=0
+if [[ -d "${BOOT_MOUNT}" ]]; then
+  boot_firmware_preexisting=1
+fi
+if [[ -d "${LEGACY_BOOT_MOUNT}" ]]; then
+  boot_dir_preexisting=1
+fi
+mkdir -p "${LEGACY_BOOT_MOUNT}" "${BOOT_MOUNT}"
+
+BOOT_MOUNT_CANDIDATE="${BOOT_MOUNT}"
+BOOT_RELATIVE_PATH="/boot/firmware"
+if [[ ${boot_firmware_preexisting} -eq 0 && ${boot_dir_preexisting} -eq 1 ]]; then
+  BOOT_MOUNT_CANDIDATE="${LEGACY_BOOT_MOUNT}"
+  BOOT_RELATIVE_PATH="/boot"
+fi
+
+if ! findmnt -rn -o TARGET "${BOOT_MOUNT_CANDIDATE}" >/dev/null 2>&1; then
+  boot_candidate="${TARGET_PARTITIONS[0]:-}"
+  if [[ -z "${boot_candidate}" ]]; then
+    echo "Unable to determine boot partition device for ${BOOT_MOUNT_CANDIDATE}" >&2
+  elif ! mount -t vfat "${boot_candidate}" "${BOOT_MOUNT_CANDIDATE}"; then
+    echo "Failed to mount ${boot_candidate} to ${BOOT_MOUNT_CANDIDATE}" >&2
+    mount -t vfat -v "${boot_candidate}" "${BOOT_MOUNT_CANDIDATE}" || true
+  else
+    echo "Mounted ${boot_candidate} to ${BOOT_MOUNT_CANDIDATE}"
+  fi
+fi
+
+if ! findmnt -rn -o TARGET "${BOOT_MOUNT_CANDIDATE}" >/dev/null 2>&1; then
+  echo "Expected clone boot mount ${BOOT_MOUNT_CANDIDATE} missing." >&2
   exit 1
 fi
 
@@ -244,7 +273,7 @@ resolve_mount_device() {
 }
 
 CLONE_ROOT_DEV=$(resolve_mount_device "${CLONE_MOUNT}")
-CLONE_BOOT_DEV=$(resolve_mount_device "${CLONE_MOUNT}/boot/firmware")
+CLONE_BOOT_DEV=$(resolve_mount_device "${BOOT_MOUNT_CANDIDATE}")
 if [[ -z "${CLONE_ROOT_DEV}" || -z "${CLONE_BOOT_DEV}" ]]; then
   echo "Unable to resolve cloned partition devices." >&2
   exit 1
@@ -255,10 +284,10 @@ ROOT_PARTUUID=$(blkid -s PARTUUID -o value "${CLONE_ROOT_DEV}" 2>/dev/null || tr
 BOOT_UUID=$(blkid -s UUID -o value "${CLONE_BOOT_DEV}" 2>/dev/null || true)
 BOOT_PARTUUID=$(blkid -s PARTUUID -o value "${CLONE_BOOT_DEV}" 2>/dev/null || true)
 
-CMDLINE_PATH="${CLONE_MOUNT}/boot/firmware/cmdline.txt"
+CMDLINE_PATH="${BOOT_MOUNT_CANDIDATE}/cmdline.txt"
 FSTAB_PATH="${CLONE_MOUNT}/etc/fstab"
 if [[ ! -f "${CMDLINE_PATH}" || ! -f "${FSTAB_PATH}" ]]; then
-  echo "Clone did not expose expected Bookworm paths." >&2
+  echo "Clone did not expose expected paths: ${CMDLINE_PATH} or ${FSTAB_PATH}." >&2
   exit 1
 fi
 
@@ -290,9 +319,9 @@ with open(cmdline_path, "w", encoding="utf-8") as fh:
     fh.write(" ".join(parts) + "\n")
 PY
 
-python3 - "${FSTAB_PATH}" "${ROOT_UUID}" "${ROOT_PARTUUID}" "${BOOT_UUID}" "${BOOT_PARTUUID}" <<'PY'
+python3 - "${FSTAB_PATH}" "${ROOT_UUID}" "${ROOT_PARTUUID}" "${BOOT_UUID}" "${BOOT_PARTUUID}" "${BOOT_RELATIVE_PATH}" <<'PY'
 import sys
-path, root_uuid, root_partuuid, boot_uuid, boot_partuuid = sys.argv[1:6]
+path, root_uuid, root_partuuid, boot_uuid, boot_partuuid, boot_mount = sys.argv[1:7]
 with open(path, "r", encoding="utf-8") as fh:
     lines = fh.readlines()
 
@@ -320,7 +349,7 @@ for line in lines:
     if mount == "/" and root_repl:
         parts[0] = root_repl
         updated.append("\t".join(parts) + "\n")
-    elif mount == "/boot/firmware" and boot_repl:
+    elif mount == boot_mount and boot_repl:
         parts[0] = boot_repl
         updated.append("\t".join(parts) + "\n")
     else:


### PR DESCRIPTION
## Summary
- ensure clone boot mountpoints exist inside the clone and mount the boot partition with an explicit vfat type
- settle udev after rpi-clone and fall back to /boot on legacy images
- document passing environment variables through sudo and note the /boot vs /boot/firmware layouts

## Testing
- `shellcheck scripts/clone_to_nvme.sh` *(fails: command not found)*
- `pre-commit run --all-files` *(fails: command not found)*
- `pyspelling -c .spellcheck.yaml` *(fails: command not found)*
- `linkchecker --no-warnings README.md docs/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f2ac265b7c832f95638ba5ed9bb58b