### PR TITLE
🛠️ : – Harden clone-ssd workflow

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,23 @@
+name: Shellcheck
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Lint shell scripts
+        run: |
+          shopt -s globstar nullglob
+          files=(scripts/**/*.sh scripts/*.sh)
+          if [ ${#files[@]} -gt 0 ]; then
+            shellcheck -S style "${files[@]}"
+          else
+            echo "No shell scripts to check."
+          fi

--- a/docs/raspi-image-spot-check.md
+++ b/docs/raspi-image-spot-check.md
@@ -83,17 +83,56 @@ The `clone-ssd` helper wraps `rpi-clone`, installs it on first use, captures log
 target device explicitly during the first run so the script can initialise the NVMe layout:
 
 ```bash
-sudo TARGET=/dev/nvme0n1 WIPE=1 just clone-ssd
+TARGET=/dev/nvme0n1 WIPE=1 just clone-ssd
 ```
 
 Subsequent syncs only need the target argument:
 
 ```bash
-sudo TARGET=/dev/nvme0n1 just clone-ssd
+TARGET=/dev/nvme0n1 just clone-ssd
 ```
 
 Bookworm mounts the boot FAT volume at `/boot/firmware`; older images may use `/boot`. The helper
 handles both.
+
+#### Troubleshooting
+
+Detect current mounts:
+
+```
+findmnt /mnt/clone
+mount | grep nvme0n1 || true
+```
+
+Clean up stale mounts and automount units:
+
+```
+sudo umount -R /mnt/clone || true
+for p in /dev/nvme0n1p*; do sudo umount "$p" 2>/dev/null || true; done
+sudo systemctl stop mnt-clone.mount mnt-clone.automount 2>/dev/null || true
+sudo udevadm settle
+```
+
+Run the recovery helper if the boot partition was missed:
+
+```
+TARGET=/dev/nvme0n1 scripts/recover_clone_mount.sh
+```
+
+Re-run the clone with environment variables preserved:
+
+```
+TARGET=/dev/nvme0n1 WIPE=1 sudo --preserve-env=TARGET,WIPE just clone-ssd
+```
+
+> [!TIP] Troubleshooting
+> Mount the clone and inspect the boot files when something fails early:
+> ```bash
+> sudo mount /dev/nvme0n1p1 /mnt/clone
+> sudo sed -n '1,120p' /mnt/clone/cmdline.txt
+> sudo sed -n '1,120p' /mnt/clone/etc/fstab
+> sudo umount /mnt/clone
+> ```
 
 ### 3. Optional: one-command migration
 

--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
+CWD := justfile_directory()
 
 scripts_dir := justfile_directory() + "/scripts"
 image_dir := env_var_or_default("IMAGE_DIR", env_var("HOME") + "/sugarkube/images")
@@ -140,9 +141,13 @@ eeprom-nvme-first:
 
 # Clone the active SD card to the preferred NVMe/USB target
 
-# Usage: sudo just clone-ssd TARGET=/dev/nvme0n1 WIPE=1
+# Usage:
+#   TARGET=/dev/nvme0n1 WIPE=1 just clone-ssd
+# Defaults: TARGET=/dev/nvme0n1, WIPE=0
 clone-ssd:
-    TARGET="{{ clone_target }}" WIPE="{{ clone_wipe }}" "{{ clone_cmd }}" {{ clone_args }}
+    TARGET="${TARGET:-/dev/nvme0n1}"
+    WIPE="${WIPE:-0}"
+    sudo --preserve-env=TARGET,WIPE env TARGET="${TARGET}" WIPE="${WIPE}" "{{ CWD }}/scripts/clone_to_nvme.sh" {{ clone_args }}
 
 # One-command happy path: spot-check → EEPROM (optional) → clone → reboot
 

--- a/scripts/recover_clone_mount.sh
+++ b/scripts/recover_clone_mount.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+TARGET="${TARGET:-/dev/nvme0n1}"
+ROOT="${TARGET}p2"
+BOOT="${TARGET}p1"
+
+sudo umount -R /mnt/clone 2>/dev/null || true
+for p in /dev/"$(basename "${TARGET}")"p*; do
+  [[ -e "${p}" ]] || continue
+  sudo umount "${p}" 2>/dev/null || true
+done
+sudo systemctl stop mnt-clone.mount mnt-clone.automount 2>/dev/null || true
+sudo mkdir -p /mnt/clone/boot/firmware
+
+sudo udevadm settle
+
+if ! sudo mount "${ROOT}" /mnt/clone; then
+  sudo e2fsck -f -y "${ROOT}" || true
+  sudo udevadm settle
+  sudo mount "${ROOT}" /mnt/clone
+fi
+
+if ! sudo mount "${BOOT}" /mnt/clone/boot/firmware; then
+  sudo fsck.vfat -a "${BOOT}" || true
+  sudo udevadm settle
+  if ! sudo mount "${BOOT}" /mnt/clone/boot/firmware; then
+    sudo mkfs.vfat -F 32 -n bootfs "${BOOT}"
+    sudo udevadm settle
+    sudo mount "${BOOT}" /mnt/clone/boot/firmware
+    sudo rsync -aHAX /boot/firmware/ /mnt/clone/boot/firmware/
+  fi
+fi
+
+sync
+echo "Recovery completed; unmounting."
+sudo umount /mnt/clone/boot/firmware || true
+sudo umount /mnt/clone || true


### PR DESCRIPTION
what: Harden clone workflow with recovery helper, docs, and shellcheck CI
why: Ensure NVMe cloning reruns cleanly and document recovery steps
how to test: shellcheck scripts/clone_to_nvme.sh scripts/recover_clone_mount.sh

------
https://chatgpt.com/codex/tasks/task_e_68f317262e04832f992035706f33d00b