### PR TITLE
Harden clone-ssd workflow

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,23 @@
+name: Shellcheck
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Lint shell scripts
+        run: |
+          shopt -s globstar nullglob
+          files=(scripts/**/*.sh scripts/*.sh)
+          if [ ${#files[@]} -gt 0 ]; then
+            shellcheck -S style "${files[@]}"
+          else
+            echo "No shell scripts to check."
+          fi

--- a/justfile
+++ b/justfile
@@ -1,5 +1,6 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
+CWD := justfile_directory()
 scripts_dir := justfile_directory() + "/scripts"
 image_dir := env_var_or_default("IMAGE_DIR", env_var("HOME") + "/sugarkube/images")
 image_name := env_var_or_default("IMAGE_NAME", "sugarkube.img")
@@ -139,10 +140,13 @@ eeprom-nvme-first:
     just --justfile "{{ justfile_directory() }}/justfile" boot-order nvme-first
 
 # Clone the active SD card to the preferred NVMe/USB target
-
-# Usage: sudo just clone-ssd TARGET=/dev/nvme0n1 WIPE=1
+# Usage:
+#   TARGET=/dev/nvme0n1 WIPE=1 just clone-ssd
+# Defaults: TARGET=/dev/nvme0n1, WIPE=0
 clone-ssd:
-    TARGET="{{ clone_target }}" WIPE="{{ clone_wipe }}" "{{ clone_cmd }}" {{ clone_args }}
+    TARGET ?= /dev/nvme0n1
+    WIPE ?= 0
+    sudo --preserve-env=TARGET,WIPE env TARGET=$(TARGET) WIPE=$(WIPE) "{{ CWD }}/scripts/clone_to_nvme.sh" {{ clone_args }}
 
 # One-command happy path: spot-check → EEPROM (optional) → clone → reboot
 

--- a/scripts/recover_clone_mount.sh
+++ b/scripts/recover_clone_mount.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+TARGET="${TARGET:-/dev/nvme0n1}"
+ROOT="${TARGET}p2"
+BOOT="${TARGET}p1"
+
+sudo umount -R /mnt/clone 2>/dev/null || true
+target_base=$(basename "${TARGET}")
+if [[ "${target_base}" =~ [0-9]$ ]]; then
+  part_glob=(/dev/"${target_base}"p*)
+else
+  part_glob=(/dev/"${target_base}"[0-9]*)
+fi
+for p in "${part_glob[@]}"; do
+  [[ -e "${p}" ]] || continue
+  sudo umount "$p" 2>/dev/null || true
+done
+sudo systemctl stop mnt-clone.mount mnt-clone.automount 2>/dev/null || true
+sudo mkdir -p /mnt/clone/boot/firmware
+
+if command -v udevadm >/dev/null 2>&1; then
+  sudo udevadm settle
+fi
+
+# Root mount
+if ! sudo mount "$ROOT" /mnt/clone; then
+  sudo e2fsck -f -y "$ROOT" || true
+  if command -v udevadm >/dev/null 2>&1; then
+    sudo udevadm settle
+  fi
+  sudo mount "$ROOT" /mnt/clone
+fi
+
+# Boot mount with recovery
+if ! sudo mount "$BOOT" /mnt/clone/boot/firmware; then
+  sudo fsck.vfat -a "$BOOT" || true
+  if command -v udevadm >/dev/null 2>&1; then
+    sudo udevadm settle
+  fi
+  if ! sudo mount "$BOOT" /mnt/clone/boot/firmware; then
+    sudo mkfs.vfat -F 32 -n bootfs "$BOOT"
+    if command -v udevadm >/dev/null 2>&1; then
+      sudo udevadm settle
+    fi
+    sudo mount "$BOOT" /mnt/clone/boot/firmware
+    sudo rsync -aHAX /boot/firmware/ /mnt/clone/boot/firmware/
+  fi
+fi
+
+sync
+echo "Recovery completed; unmounting."
+sudo umount /mnt/clone/boot/firmware || true
+sudo umount /mnt/clone || true


### PR DESCRIPTION
what: Harden the NVMe clone workflow with retries, recovery helper, docs, and CI.
why: Make `just clone-ssd` idempotent and add lint coverage for shell scripts.
how to test:
- pre-commit run --all-files # fails: existing scripts/ssd_clone.py E501
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
- shellcheck scripts/clone_to_nvme.sh scripts/recover_clone_mount.sh


------
https://chatgpt.com/codex/tasks/task_e_68f317262e04832f992035706f33d00b