### PR TITLE
Ensure clone-ssd just recipe runs under sudo

### DIFF
--- a/justfile
+++ b/justfile
@@ -142,7 +142,14 @@ eeprom-nvme-first:
 # Usage: sudo TARGET=/dev/nvme0n1 WIPE=1 just clone-ssd
 clone-ssd:
     if [ -z "{{ clone_target }}" ]; then echo "Set CLONE_TARGET to the target device (e.g. /dev/sda) before running clone-ssd." >&2; exit 1; fi
-    sudo --preserve-env=TARGET,WIPE,ALLOW_NON_ROOT,ALLOW_FAKE_BLOCK,CLONE_MOUNT "{{ clone_cmd }}" --target "{{ clone_target }}" {{ clone_args }}
+    sudo --preserve-env=TARGET,WIPE,ALLOW_NON_ROOT,ALLOW_FAKE_BLOCK,CLONE_MOUNT \
+      env \
+        TARGET="{{ clone_target }}" \
+        WIPE="${WIPE-}" \
+        ALLOW_NON_ROOT="${ALLOW_NON_ROOT-}" \
+        ALLOW_FAKE_BLOCK="${ALLOW_FAKE_BLOCK-}" \
+        CLONE_MOUNT="${CLONE_MOUNT-}" \
+        "{{ clone_cmd }}" --target "{{ clone_target }}" {{ clone_args }}
 
 # One-command happy path: spot-check → EEPROM (optional) → clone → reboot
 

--- a/scripts/clone_to_nvme.sh
+++ b/scripts/clone_to_nvme.sh
@@ -14,7 +14,13 @@ exec > >(tee "${LOG_FILE}") 2>&1
 ALLOW_NON_ROOT="${ALLOW_NON_ROOT:-0}"
 if [[ "${ALLOW_NON_ROOT}" != "1" && ${EUID} -ne 0 ]]; then
   if command -v sudo >/dev/null 2>&1; then
-    exec sudo WIPE="${WIPE:-0}" TARGET="${TARGET:-}" "$0" "$@"
+    exec sudo \
+      WIPE="${WIPE:-0}" \
+      TARGET="${TARGET:-}" \
+      ALLOW_NON_ROOT="${ALLOW_NON_ROOT:-0}" \
+      ALLOW_FAKE_BLOCK="${ALLOW_FAKE_BLOCK:-0}" \
+      CLONE_MOUNT="${CLONE_MOUNT:-/mnt/clone}" \
+      "$0" "$@"
   fi
   echo "This script requires root privileges." >&2
   exit 1

--- a/tests/test_flash_pi_justfile.py
+++ b/tests/test_flash_pi_justfile.py
@@ -67,7 +67,14 @@ def test_justfile_has_no_tabs_or_trailing_whitespace() -> None:
             "clone-ssd:",
             [
                 '    if [ -z "{{ clone_target }}" ]; then echo "Set CLONE_TARGET to the target device (e.g. /dev/sda) before running clone-ssd." >&2; exit 1; fi',  # noqa: E501
-                '    sudo --preserve-env=TARGET,WIPE,ALLOW_NON_ROOT,ALLOW_FAKE_BLOCK,CLONE_MOUNT "{{ clone_cmd }}" --target "{{ clone_target }}" {{ clone_args }}',  # noqa: E501
+                '    sudo --preserve-env=TARGET,WIPE,ALLOW_NON_ROOT,ALLOW_FAKE_BLOCK,CLONE_MOUNT \\',  # noqa: E501
+                '      env \\',  # noqa: E501
+                '        TARGET="{{ clone_target }}" \\',  # noqa: E501
+                '        WIPE="${WIPE-}" \\',  # noqa: E501
+                '        ALLOW_NON_ROOT="${ALLOW_NON_ROOT-}" \\',  # noqa: E501
+                '        ALLOW_FAKE_BLOCK="${ALLOW_FAKE_BLOCK-}" \\',  # noqa: E501
+                '        CLONE_MOUNT="${CLONE_MOUNT-}" \\',  # noqa: E501
+                '        "{{ clone_cmd }}" --target "{{ clone_target }}" {{ clone_args }}',  # noqa: E501
             ],
         ),
         (


### PR DESCRIPTION
what: run clone-ssd via sudo without an unprivileged pre-call.
why: avoids double execution when clone_to_nvme re-execs under sudo.
how to test: pytest tests/test_flash_pi_justfile.py

------
https://chatgpt.com/codex/tasks/task_e_68f31d8674b4832f9396208ca8e0ef68