### PR TITLE
storage: add sd-to-nvme workflow tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,11 +87,11 @@ rollback-to-sd:
 	$(ROLLBACK_CMD) $(ROLLBACK_ARGS)
 
 clone-ssd:
-	@if [ -z "$(CLONE_TARGET)" ]; then \
-		echo "Set CLONE_TARGET to the target device (e.g. /dev/sda)." >&2; \
-		exit 1; \
-	fi
-	$(CLONE_CMD) --target "$(CLONE_TARGET)" $(CLONE_ARGS)
+        @if [ -z "$(TARGET)" ]; then \
+                echo "Set TARGET to the target device (e.g. /dev/nvme0n1)." >&2; \
+                exit 1; \
+        fi
+        $(CLONE_CMD) --target "$(TARGET)" $(CLONE_ARGS)
 
 validate-ssd-clone:
 	$(VALIDATE_CMD) $(VALIDATE_ARGS)

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@ Review the safety notes before working with power components.
   notifications for first boot and SSD cloning
 - [pi_image_cloudflare.md](pi_image_cloudflare.md) — preconfigure Docker and Cloudflare tunnels
 - [archived/pi_image_improvement_checklist.md](archived/pi_image_improvement_checklist.md) — backlog of DX upgrades for the Pi image
+- [storage/sd-to-nvme.md](storage/sd-to-nvme.md) — safe SD → NVMe cloning and validation workflow
 - [ssd_post_clone_validation.md](ssd_post_clone_validation.md) — validate SSD clones post-migration
 - [raspi_cluster_setup.md](raspi_cluster_setup.md) — build a three-node k3s cluster and deploy apps
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo

--- a/docs/storage/sd-to-nvme.md
+++ b/docs/storage/sd-to-nvme.md
@@ -1,0 +1,97 @@
+# SD → NVMe cloning workflow
+
+> **Safety rails**
+> - Never run the clone pipeline against the disk that is currently hosting `/`.
+> - Use `WIPE=1` only for first-time initialization or when you deliberately want to reformat a reused NVMe drive.
+> - Always double-check identifiers with `just show-disks` before touching block devices.
+
+The workflow is designed to be idempotent: you can rerun any step without leaving partially mounted filesystems behind. Each task assumes you run it with `sudo --preserve-env` as shown below.
+
+## Core path
+
+### 1. Preflight the target NVMe
+
+```bash
+sudo TARGET=/dev/nvme0n1 WIPE=1 just preflight
+```
+
+Expected output:
+- The active root device (typically `/dev/mmcblk0p2`) is shown alongside the target NVMe disk.
+- Any mounted partitions on the target cause the task to abort with a pointer to `just clean-mounts-hard`.
+- When `WIPE=1`, `wipefs -a` runs once to clear conflicting signatures and the checklist highlights the clean state.
+
+### 2. Clone the SD card to NVMe
+
+```bash
+sudo TARGET=/dev/nvme0n1 WIPE=1 just clone-ssd
+```
+
+Expected output:
+- `rpi-clone` streams the SD contents to the NVMe drive (first run uses the unattended `-U` fallback).
+- `/boot/cmdline.txt` and `/etc/fstab` on the clone are rewritten to use `PARTUUID`/`UUID` entries for the NVMe partitions.
+- The summary line shows the resolved identifiers for the cloned boot and root partitions.
+
+### 3. Validate the clone
+
+```bash
+sudo TARGET=/dev/nvme0n1 MOUNT_BASE=/mnt/clone just verify-clone
+```
+
+Expected output:
+- The script mounts the NVMe root under `/mnt/clone` and the boot partition under `/mnt/clone/boot` or `/mnt/clone/boot/firmware`.
+- The validation report lists each check (cmdline, fstab, labels) as `[PASS]` or `[FAIL]`.
+- Labels are confirmed as `BOOTFS` (FAT) and `rootfs` (ext4); any mismatch leaves the mounts in place so you can inspect before rerunning `just clean-mounts-hard`.
+
+## Optional helpers
+
+### Snapshot disks and mountpoints
+
+```bash
+just show-disks
+```
+
+Displays `lsblk -e7 -o NAME,MAJ:MIN,SIZE,TYPE,FSTYPE,LABEL,UUID,PARTUUID,MOUNTPOINTS` so you can confirm source (SD) and target (NVMe) devices before cloning.
+
+### Aggressive mount cleanup
+
+```bash
+sudo TARGET=/dev/nvme0n1 MOUNT_BASE=/mnt/clone just clean-mounts-hard
+```
+
+Performs `umount -R`, falls back to lazy unmounts if needed, prints blocking PIDs via `fuser`, and removes only empty mount directories. Use this to recover from interrupted validations or manual tweaks.
+
+### Finalize NVMe boot priority
+
+```bash
+sudo just finalize-nvme
+```
+
+Reads the EEPROM bootloader configuration (Pi 4/5). If the current `BOOT_ORDER` is not `0xF416`, it launches `rpi-eeprom-config --edit` with inline guidance so you can update the value manually. After saving, it prints the new order and a reminder to confirm with `sudo rpi-eeprom-config | grep BOOT_ORDER`.
+
+### Roll back to the SD card
+
+```bash
+just rollback-to-sd
+```
+
+Prints a reversible plan that:
+1. Runs `scripts/rollback_to_sd.sh --dry-run` so you can preview the changes.
+2. Shows the exact commands to restore `cmdline.txt` and `/etc/fstab` to the SD defaults.
+3. Points to `sudo just boot-order sd-nvme-usb` so the EEPROM prefers the SD card on the next boot.
+
+## Reference snippets
+
+- List filesystem identifiers: `lsblk --fs` or `blkid`
+- Confirm the active root device: `findmnt -no SOURCE /`
+- Inspect BOOT_ORDER without editing: `sudo rpi-eeprom-config | grep BOOT_ORDER`
+
+`BOOT_ORDER` controls the sequence the Pi bootloader tries devices. `0xF416` means “NVMe → SD → USB → repeat,” while `0xF461` prefers “SD → NVMe → USB → repeat.”
+
+## Acceptance checks
+
+- `just show-disks` lists the SD (`mmcblk0`) and NVMe (`nvme0n1`) devices with their PARTUUIDs and mountpoints.
+- `just preflight TARGET=/dev/nvme0n1` fails fast if `TARGET` matches the active root device reported by `findmnt -no SOURCE /`.
+- A first-time clone with `WIPE=1` logs the `rpi-clone` initialization path (`dd` header followed by `mkfs` and `rsync`).
+- `just verify-clone TARGET=/dev/nvme0n1` succeeds immediately after cloning and again after a reboot.
+- `just clean-mounts-hard` leaves no mounts under `$MOUNT_BASE` and prints any blocking PIDs before exiting.
+- `just finalize-nvme` reports the current `BOOT_ORDER` and opens an interactive editor instead of applying firmware changes silently.

--- a/scripts/cleanup_clone_mounts.sh
+++ b/scripts/cleanup_clone_mounts.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 IFS=$'\n\t'
 
 DRY_RUN=0
 VERBOSE=0
 FORCE=0
 KEEP_DIRS=0
-TARGET="${TARGET:-/dev/nvme0n1}"
-MOUNT_BASE="${MOUNT_BASE:-/mnt/clone}"
+TARGET=${TARGET:-/dev/nvme0n1}
+MOUNT_BASE=${MOUNT_BASE:-/mnt/clone}
+CLEANUP_READY=0
+cleanup_invoked=0
 
 log() {
   local IFS=' '
@@ -15,26 +17,18 @@ log() {
 }
 
 vlog() {
-  if [ "$VERBOSE" -eq 1 ]; then
+  if (( VERBOSE )); then
     log "$@"
   fi
 }
 
 usage() {
   cat <<USAGE
-Usage: $(basename "$0") [--dry-run] [--verbose|-v] [--force] [--keep-dirs]
-       $(basename "$0") --help
+Usage: $(basename "$0") [--dry-run] [--verbose|-v] [--force] [--keep-dirs] [--help]
 
 Environment variables:
   TARGET      Target block device (default: ${TARGET})
   MOUNT_BASE  Base directory for clone mounts (default: ${MOUNT_BASE})
-
-Flags:
-  --dry-run     Only log intended actions without making changes
-  --verbose|-v  Increase logging verbosity
-  --force       Terminate processes holding the mounts if required
-  --keep-dirs   Preserve empty mount directories (skip cleanup)
-  --help        Show this help and exit
 USAGE
 }
 
@@ -45,32 +39,8 @@ require_command() {
   fi
 }
 
-join_args() {
-  local IFS=' '
-  printf '%s' "$*"
-}
-
-run_cmd() {
-  if [ "$DRY_RUN" -eq 1 ]; then
-    log "DRY-RUN: $(join_args "$@")"
-    return 0
-  fi
-  if [ "$VERBOSE" -eq 1 ]; then
-    log "RUN: $(join_args "$@")"
-  fi
-  "$@"
-}
-
-sleep_maybe() {
-  if [ "$DRY_RUN" -eq 1 ]; then
-    log "DRY-RUN: sleep $1"
-    return 0
-  fi
-  sleep "$1"
-}
-
 parse_args() {
-  while [ "$#" -gt 0 ]; do
+  while (($#)); do
     case "$1" in
       --dry-run)
         DRY_RUN=1
@@ -101,383 +71,245 @@ parse_args() {
     shift
   done
 
-  if [ "$#" -gt 0 ]; then
+  if (($#)); then
     log "Unexpected argument: $1"
     usage
     exit 1
   fi
 }
 
-parse_args "$@"
-require_command findmnt
-
-declare -a BASE_POINTS=()
-declare -a TARGET_SOURCES=()
-declare -a TARGET_POINTS=()
-declare -a MOUNT_DEVICES=()
-declare -a MOUNT_POINTS=()
-declare -A SEEN_MOUNTS=()
-
-add_mount() {
-  local device="$1"
-  local point="$2"
-  local key="${device}::${point}"
-  if [ -z "$device" ] || [ -z "$point" ]; then
-    return 0
-  fi
-  if [ -n "${SEEN_MOUNTS[$key]:-}" ]; then
-    return 0
-  fi
-  SEEN_MOUNTS[$key]=1
-  MOUNT_DEVICES+=("$device")
-  MOUNT_POINTS+=("$point")
-}
-
-collect_base_mounts() {
-  mapfile -t BASE_POINTS < <(findmnt -rn -o TARGET --submounts "$MOUNT_BASE" 2>/dev/null || true)
-  local point
-  for point in "${BASE_POINTS[@]}"; do
-    if [ -z "$point" ]; then
-      continue
-    fi
-    local src
-    src=$(findmnt -rn -o SOURCE --target "$point" 2>/dev/null || true)
-    if [ -z "$src" ]; then
-      continue
-    fi
-    add_mount "$src" "$point"
-  done
-}
-
-collect_target_mounts() {
-  if [ ! -e "$TARGET" ]; then
-    vlog "Target device $TARGET not present; skipping partition scan."
-    return
-  fi
-  mapfile -t TARGET_SOURCES < <(findmnt -rn -o SOURCE -S "${TARGET}p*" 2>/dev/null || true)
-  local src
-  for src in "${TARGET_SOURCES[@]}"; do
-    if [ -z "$src" ]; then
-      continue
-    fi
-    mapfile -t TARGET_POINTS < <(findmnt -rn -o TARGET --source "$src" 2>/dev/null || true)
-    local point
-    for point in "${TARGET_POINTS[@]}"; do
-      if [ -z "$point" ]; then
-        continue
-      fi
-      add_mount "$src" "$point"
-    done
-  done
-}
-
-collect_base_mounts
-collect_target_mounts
-
-if [ "${#MOUNT_POINTS[@]}" -eq 0 ]; then
-  log "No mounts detected under $MOUNT_BASE or sourced from ${TARGET}p*."
-else
-  log "Detected mounts:"
-  printf '  %-32s %s\n' "DEVICE" "MOUNTPOINT"
-  for idx in "${!MOUNT_POINTS[@]}"; do
-    printf '  %-32s %s\n' "${MOUNT_DEVICES[$idx]}" "${MOUNT_POINTS[$idx]}"
-  done
-fi
-
-stop_systemd_units() {
-  if ! command -v systemctl >/dev/null 2>&1; then
-    vlog "systemctl not available; skipping automount stop."
-    return
-  fi
-
-  local escaped
-  escaped=$(systemd-escape --path "$MOUNT_BASE")
-  local units=("mnt-clone.automount" "mnt-clone.mount" "${escaped}.automount" "${escaped}.mount")
-
-  local seen=()
-  local unit
-  for unit in "${units[@]}"; do
-    if [ -z "$unit" ]; then
-      continue
-    fi
-    if [ "${#seen[@]}" -gt 0 ] && printf '%s\n' "${seen[@]}" | grep -Fxq "$unit"; then
-      continue
-    fi
-    seen+=("$unit")
-    if [ "$DRY_RUN" -eq 1 ]; then
-      log "DRY-RUN: systemctl stop $unit"
-      continue
-    fi
-    if systemctl stop "$unit" >/dev/null 2>&1; then
-      vlog "Stopped $unit"
-    else
-      vlog "Unit $unit not active or failed to stop (ignored)."
-    fi
-  done
-}
-
-stop_systemd_units
-
-declare BLOCKER_TOOL=""
-declare BLOCKER_OUTPUT=""
-declare -a BLOCKER_PIDS=()
-
-collect_blockers() {
+show_blockers() {
   local path="$1"
-  BLOCKER_TOOL=""
-  BLOCKER_OUTPUT=""
-  BLOCKER_PIDS=()
-
   if command -v fuser >/dev/null 2>&1; then
     local output
-    if output=$(fuser -vm "$path" 2>&1); then
-      BLOCKER_TOOL="fuser"
-      BLOCKER_OUTPUT="$output"
-      mapfile -t BLOCKER_PIDS < <(printf '%s\n' "$output" | awk 'NR>1 {print $2}' | sort -u)
-      if [ "${#BLOCKER_PIDS[@]}" -gt 0 ]; then
-        return 0
-      fi
-    else
-      local status=$?
-      if [ "$status" -gt 1 ]; then
-        log "fuser reported an error on $path (exit $status)."
-      fi
-      if [ "$status" -eq 0 ]; then
-        # Should not happen because success implies output; treat as blockers.
-        BLOCKER_TOOL="fuser"
-        BLOCKER_OUTPUT="$output"
-        mapfile -t BLOCKER_PIDS < <(printf '%s\n' "$output" | awk 'NR>1 {print $2}' | sort -u)
-        if [ "${#BLOCKER_PIDS[@]}" -gt 0 ]; then
-          return 0
-        fi
-      fi
-    fi
-  fi
-
-  if [ -z "$BLOCKER_TOOL" ] && command -v lsof >/dev/null 2>&1; then
-    local output
-    output=$(lsof +f -- "$path" 2>/dev/null || true)
-    if [ -n "$output" ]; then
-      BLOCKER_TOOL="lsof"
-      BLOCKER_OUTPUT="$output"
-      mapfile -t BLOCKER_PIDS < <(printf '%s\n' "$output" | awk 'NR>1 {print $2}' | sort -u)
-      if [ "${#BLOCKER_PIDS[@]}" -gt 0 ]; then
-        return 0
-      fi
-    fi
-  fi
-
-  return 1
-}
-
-send_signal() {
-  local signal="$1"
-  shift
-  local pid
-  for pid in "$@"; do
-    if [ -z "$pid" ]; then
-      continue
-    fi
-    if [ "$DRY_RUN" -eq 1 ]; then
-      log "DRY-RUN: kill -$signal $pid"
-    else
-      if kill "-$signal" "$pid" 2>/dev/null; then
-        vlog "Sent SIG$signal to PID $pid"
-      else
-        vlog "Failed to send SIG$signal to PID $pid (ignored)."
-      fi
-    fi
-  done
-}
-
-ensure_unblocked() {
-  local path="$1"
-  if ! collect_blockers "$path"; then
-    return 0
-  fi
-
-  log "Mount at $path is busy (detected via $BLOCKER_TOOL):"
-  printf '%s\n' "$BLOCKER_OUTPUT"
-
-  if [ "$FORCE" -eq 0 ]; then
-    log "Re-run with --force to terminate blocking processes."
-    return 1
-  fi
-
-  if [ "${#BLOCKER_PIDS[@]}" -eq 0 ]; then
-    log "No PIDs parsed from blocker output; cannot forcefully clear $path."
-    return 1
-  fi
-
-  log "Attempting graceful termination of ${#BLOCKER_PIDS[@]} process(es) holding $path."
-  send_signal TERM "${BLOCKER_PIDS[@]}"
-  sleep_maybe 2
-
-  if collect_blockers "$path"; then
-    log "Processes still holding $path after SIGTERM; escalating to SIGKILL."
-    send_signal KILL "${BLOCKER_PIDS[@]}"
-    sleep_maybe 1
-    if collect_blockers "$path"; then
-      log "Unable to clear blockers for $path even after SIGKILL."
-      return 1
-    fi
-  fi
-
-  log "Cleared blockers for $path."
-  return 0
-}
-
-resolve_all_blockers() {
-  local point
-  local -A checked=()
-  for point in "${MOUNT_POINTS[@]}"; do
-    if [ -z "$point" ]; then
-      continue
-    fi
-    if [ -n "${checked[$point]:-}" ]; then
-      continue
-    fi
-    checked[$point]=1
-    if ! ensure_unblocked "$point"; then
-      exit 1
-    fi
-  done
-}
-
-resolve_all_blockers
-
-attempt_umount() {
-  local mount_point="$1"
-  local source="$2"
-
-  if [ "$DRY_RUN" -eq 1 ]; then
-    log "DRY-RUN: umount $mount_point"
-    return 0
-  fi
-
-  if umount "$mount_point" 2>/dev/null; then
-    log "Unmounted $mount_point"
-    return 0
-  fi
-
-  local status=$?
-  log "umount $mount_point failed with status $status"
-
-  if [ -n "$source" ] && [ ! -e "$source" ]; then
-    log "Source $source is missing; attempting lazy unmount of $mount_point."
-    if umount -l "$mount_point" 2>/dev/null; then
-      log "Lazy unmounted $mount_point"
+    if output=$(fuser -vm "$path" 2>/dev/null); then
+      printf '%s\n' "$output"
       return 0
     fi
   fi
-
-  if [ "$FORCE" -eq 1 ]; then
-    log "Force flag set; retrying lazy unmount of $mount_point."
-    if umount -l "$mount_point" 2>/dev/null; then
-      log "Lazy unmounted $mount_point"
-      return 0
-    fi
-  fi
-
-  if collect_blockers "$mount_point"; then
-    log "Mount at $mount_point remains busy after unmount attempt:"
-    printf '%s\n' "$BLOCKER_OUTPUT"
-  fi
-  return 1
-}
-
-if [ "${#BASE_POINTS[@]}" -gt 0 ]; then
-  if [ "$DRY_RUN" -eq 1 ]; then
-    log "DRY-RUN: umount -R $MOUNT_BASE"
+  if command -v lsof >/dev/null 2>&1; then
+    lsof +f -- "$path" 2>/dev/null || true
   else
-    if umount -R "$MOUNT_BASE" 2>/dev/null; then
-      log "Recursively unmounted mounts under $MOUNT_BASE"
-    else
-      status=$?
-      log "umount -R $MOUNT_BASE failed with status $status"
-      if collect_blockers "$MOUNT_BASE"; then
-        log "$MOUNT_BASE remains busy after recursive unmount attempt:"
-        printf '%s\n' "$BLOCKER_OUTPUT"
-      fi
-      fallback_required=0
-      if [ "$FORCE" -eq 1 ]; then
-        fallback_required=1
-      elif ! command -v findmnt >/dev/null 2>&1; then
-        fallback_required=1
-      elif findmnt -rn --target "$MOUNT_BASE" >/dev/null 2>&1; then
-        fallback_required=1
-      fi
-
-      if [ "$fallback_required" -eq 1 ]; then
-        log "Falling back to lazy recursive unmount of $MOUNT_BASE."
-        if umount -Rl "$MOUNT_BASE" 2>/dev/null; then
-          log "Lazy-recursively unmounted $MOUNT_BASE"
-        else
-          log "Lazy recursive unmount of $MOUNT_BASE failed."
-        fi
-      fi
-    fi
+    log "Install 'psmisc' for fuser output or 'lsof' for detailed handles."
   fi
-fi
+}
 
-# Individually unmount any remaining TARGET partitions still mounted elsewhere.
-cleanup_target_mounts() {
-  if [ ! -e "$TARGET" ]; then
+collect_blocker_pids() {
+  local path="$1"
+  if ! command -v fuser >/dev/null 2>&1; then
+    return 1
+  fi
+  fuser -vm "$path" 2>/dev/null | awk 'NR>1 {print $2}' | sort -u
+}
+
+terminate_blockers() {
+  local path="$1"
+  local -a pids=()
+  mapfile -t pids < <(collect_blocker_pids "$path" || true)
+  if ((${#pids[@]} == 0)); then
+    return 1
+  fi
+  log "Force flag set; sending SIGTERM to ${#pids[@]} process(es) holding ${path}."
+  if (( DRY_RUN )); then
+    log "DRY-RUN: kill -TERM ${pids[*]}"
+  else
+    kill -TERM "${pids[@]}" 2>/dev/null || true
+    sleep 2
+  fi
+  mapfile -t pids < <(collect_blocker_pids "$path" || true)
+  if ((${#pids[@]} == 0)); then
+    return 0
+  fi
+  log "Escalating to SIGKILL for ${#pids[@]} process(es) still using ${path}."
+  if (( DRY_RUN )); then
+    log "DRY-RUN: kill -KILL ${pids[*]}"
+  else
+    kill -KILL "${pids[@]}" 2>/dev/null || true
+    sleep 1
+  fi
+  mapfile -t pids < <(collect_blocker_pids "$path" || true)
+  ((${#pids[@]} == 0))
+}
+
+print_mount_table() {
+  local label="$1" query="$2"
+  mapfile -t table < <(eval "$query" 2>/dev/null || true)
+  if ((${#table[@]} == 0)); then
+    vlog "No ${label} mounts detected."
     return
   fi
-  mapfile -t TARGET_SOURCES < <(findmnt -rn -o SOURCE -S "${TARGET}p*" 2>/dev/null || true)
+  log "${label}:"
+  printf '  %-35s %s\n' "DEVICE" "MOUNTPOINT"
+  local entry device point
+  for entry in "${table[@]}"; do
+    device=${entry%%:::*}
+    point=${entry##*:::}
+    printf '  %-35s %s\n' "$device" "$point"
+  done
+}
+
+format_mounts() {
+  local target="$1"
+  findmnt -rn -o SOURCE,TARGET --submounts "$target" 2>/dev/null |
+    awk '{print $1":::"$2}'
+}
+
+format_target_mounts() {
+  local disk="$1"
+  mapfile -t partitions < <(lsblk -nr -o PATH "$disk" 2>/dev/null || true)
   local part
-  for part in "${TARGET_SOURCES[@]}"; do
+  for part in "${partitions[@]:1}"; do
     if [ -z "$part" ]; then
       continue
     fi
-    mapfile -t TARGET_POINTS < <(findmnt -rn -o TARGET --source "$part" 2>/dev/null || true)
-    local point
-    for point in "${TARGET_POINTS[@]}"; do
-      if [ -z "$point" ]; then
-        continue
-      fi
-      if attempt_umount "$point" "$part"; then
-        continue
-      fi
-      log "Failed to unmount $point (source $part)."
-      exit 1
-    done
+    findmnt -rn -o SOURCE,TARGET --source "$part" 2>/dev/null |
+      awk '{print $1":::"$2}'
   done
 }
 
-cleanup_target_mounts
-
-if command -v findmnt >/dev/null 2>&1; then
-  if findmnt -rn --submounts "$MOUNT_BASE" >/dev/null 2>&1; then
-    log "Some mounts still remain under $MOUNT_BASE after cleanup."
-    exit 1
+attempt_umount() {
+  local mountpoint="$1"
+  local label="$2"
+  if (( DRY_RUN )); then
+    log "DRY-RUN: umount ${mountpoint}"
+    return 0
   fi
-fi
-
-if command -v udevadm >/dev/null 2>&1; then
-  run_cmd udevadm settle
-else
-  vlog "udevadm not available; skipping device settle."
-fi
-
-if [ "$KEEP_DIRS" -eq 0 ]; then
-  if [ "$DRY_RUN" -eq 1 ]; then
-    log "DRY-RUN: find $MOUNT_BASE -mindepth 1 -type d -empty -delete"
-  else
-    if [ -d "$MOUNT_BASE" ]; then
-      find "$MOUNT_BASE" -mindepth 1 -type d -empty -delete 2>/dev/null || true
+  if umount "$mountpoint" 2>/dev/null; then
+    log "Unmounted ${mountpoint} (${label})."
+    return 0
+  fi
+  local status=$?
+  log "umount ${mountpoint} (${label}) failed with status ${status}."
+  show_blockers "$mountpoint"
+  if (( FORCE )); then
+    terminate_blockers "$mountpoint" || true
+    if umount "$mountpoint" 2>/dev/null; then
+      log "Unmounted ${mountpoint} after terminating blockers."
+      return 0
     fi
   fi
-else
-  vlog "Preserving empty mount directories as requested."
-fi
+  return 1
+}
 
-if [ "$DRY_RUN" -eq 1 ]; then
-  log "DRY-RUN: mkdir -p $MOUNT_BASE/boot/firmware"
-else
-  run_cmd mkdir -p "$MOUNT_BASE/boot/firmware"
-fi
+lazy_umount() {
+  local mountpoint="$1"
+  if (( DRY_RUN )); then
+    log "DRY-RUN: umount -l ${mountpoint}"
+    return 0
+  fi
+  if umount -l "$mountpoint" 2>/dev/null; then
+    log "Lazy unmounted ${mountpoint}; detaching when idle."
+    return 0
+  fi
+  return 1
+}
 
-log "Cleanup complete."
+perform_cleanup() {
+  local status=0
+
+  print_mount_table "Mounts under ${MOUNT_BASE}" "format_mounts '${MOUNT_BASE}'"
+  print_mount_table "Mounts sourced from ${TARGET}" "format_target_mounts '${TARGET}'"
+
+  if findmnt -rn --submounts "$MOUNT_BASE" >/dev/null 2>&1; then
+    if (( DRY_RUN )); then
+      log "DRY-RUN: umount -R ${MOUNT_BASE}"
+    else
+      if ! umount -R "$MOUNT_BASE" 2>/dev/null; then
+        log "Recursive unmount of ${MOUNT_BASE} failed."
+        show_blockers "$MOUNT_BASE"
+        if (( FORCE )); then
+          terminate_blockers "$MOUNT_BASE" || true
+          if ! umount -R "$MOUNT_BASE" 2>/dev/null; then
+            log "Retrying lazy recursive unmount of ${MOUNT_BASE}."
+            lazy_umount "$MOUNT_BASE" || status=1
+          fi
+        else
+          log "Falling back to lazy recursive unmount of ${MOUNT_BASE}."
+          lazy_umount "$MOUNT_BASE" || status=1
+        fi
+      else
+        log "Recursively unmounted ${MOUNT_BASE}."
+      fi
+    fi
+  fi
+
+  mapfile -t partitions < <(lsblk -nr -o PATH "$TARGET" 2>/dev/null || true)
+  local part
+  for part in "${partitions[@]:1}"; do
+    if [ -z "$part" ]; then
+      continue
+    fi
+    mapfile -t points < <(findmnt -rn -o TARGET --source "$part" 2>/dev/null || true)
+    local point
+    for point in "${points[@]}"; do
+      if [ -z "$point" ]; then
+        continue
+      fi
+      if ! attempt_umount "$point" "$part"; then
+        log "Unable to unmount ${point} sourced from ${part}."
+        if ! lazy_umount "$point"; then
+          status=1
+        fi
+      fi
+    done
+  done
+
+  if findmnt -rn --submounts "$MOUNT_BASE" >/dev/null 2>&1; then
+    log "Some mounts remain under ${MOUNT_BASE} after cleanup."
+    show_blockers "$MOUNT_BASE"
+    status=1
+  fi
+
+  if (( KEEP_DIRS )); then
+    vlog "Preserving mount directories as requested."
+  else
+    if (( DRY_RUN )); then
+      log "DRY-RUN: find ${MOUNT_BASE} -mindepth 1 -type d -empty -delete"
+      log "DRY-RUN: rmdir ${MOUNT_BASE}"
+    else
+      if [ -d "$MOUNT_BASE" ]; then
+        find "$MOUNT_BASE" -mindepth 1 -type d -empty -delete 2>/dev/null || true
+        rmdir "$MOUNT_BASE" 2>/dev/null || true
+      fi
+    fi
+  fi
+
+  if (( status == 0 )); then
+    log "Cleanup complete."
+  else
+    log "Cleanup finished with outstanding mounts or busy resources."
+  fi
+  return "$status"
+}
+
+cleanup() {
+  local exit_code=$1
+  if (( cleanup_invoked )); then
+    exit "$exit_code"
+  fi
+  cleanup_invoked=1
+  set +e
+  local status=0
+  if (( CLEANUP_READY )); then
+    perform_cleanup
+    status=$?
+  fi
+  trap - EXIT
+  if (( exit_code == 0 )) && (( status != 0 )); then
+    exit_code=$status
+  fi
+  exit "$exit_code"
+}
+
+trap 'cleanup "$?"' EXIT
+
+parse_args "$@"
+require_command findmnt
+require_command lsblk
+if ! [ -b "$TARGET" ]; then
+  log "Target device ${TARGET} not present; continuing with mount cleanup only."
+fi
+CLEANUP_READY=1
+log "Requested cleanup for TARGET=${TARGET} under ${MOUNT_BASE}."
+
 exit 0

--- a/scripts/finalize_nvme_boot.sh
+++ b/scripts/finalize_nvme_boot.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+log() {
+  printf '[finalize-nvme] %s\n' "$*"
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    log "Required command '$1' not found."
+    exit 1
+  fi
+}
+
+human_boot_order() {
+  local order="${1,,}"
+  case "${order}" in
+    0xf416)
+      echo "NVMe → SD → USB → repeat"
+      ;;
+    0xf461)
+      echo "SD → NVMe → USB → repeat"
+      ;;
+    *)
+      echo "Boot order ${1}"
+      ;;
+  esac
+}
+
+require_command rpi-eeprom-config
+
+current_config=$(rpi-eeprom-config 2>/dev/null || true)
+if [[ -z "${current_config}" ]]; then
+  log "Unable to read current EEPROM configuration."
+  log "Ensure this command is run on a Raspberry Pi 4/5 with rpi-eeprom-config installed."
+  exit 1
+fi
+
+current_order=$(printf '%s\n' "${current_config}" | awk -F= '/^BOOT_ORDER=/ {print $2}' | tr -d '[:space:]')
+current_order=${current_order:-unknown}
+recommended_order="0xF416"
+
+log "Current BOOT_ORDER: ${current_order} ($(human_boot_order "${current_order}"))"
+log "Recommended NVMe-first order: ${recommended_order} ($(human_boot_order "${recommended_order}"))"
+
+if [[ "${current_order^^}" == "${recommended_order^^}" ]]; then
+  log "EEPROM already prioritizes NVMe/USB before SD."
+  log "Confirm anytime with: sudo rpi-eeprom-config | grep BOOT_ORDER"
+  exit 0
+fi
+
+log "NVMe boot requires BOOT_ORDER=${recommended_order}. This keeps the SD card available as a fallback."
+log "Launching rpi-eeprom-config --edit so you can update BOOT_ORDER manually."
+
+editor_real=${EDITOR:-nano}
+wrapper=$(mktemp)
+cat <<'WRAP' >"${wrapper}"
+#!/usr/bin/env bash
+set -Eeuo pipefail
+cat <<'MSG'
+# Sugarkube finalize-nvme guidance
+# 1. Locate the BOOT_ORDER line and set it to 0xF416 (NVMe → SD → USB → repeat).
+# 2. Save and exit to let rpi-eeprom-config apply the change.
+# 3. Confirm afterwards with: sudo rpi-eeprom-config | grep BOOT_ORDER
+MSG
+exec "${FINALIZE_NVME_EDITOR_REAL}" "$@"
+WRAP
+chmod +x "${wrapper}"
+trap 'rm -f "${wrapper}"' EXIT
+
+FINALIZE_NVME_EDITOR_REAL="${editor_real}" EDITOR="${wrapper}" rpi-eeprom-config --edit
+
+updated_config=$(rpi-eeprom-config 2>/dev/null || true)
+updated_order=$(printf '%s\n' "${updated_config}" | awk -F= '/^BOOT_ORDER=/ {print $2}' | tr -d '[:space:]')
+updated_order=${updated_order:-unknown}
+
+log "Updated BOOT_ORDER: ${updated_order} ($(human_boot_order "${updated_order}"))"
+log "Reboot when ready and verify with 'sudo rpi-eeprom-config | grep BOOT_ORDER'."

--- a/scripts/migrate_to_nvme.sh
+++ b/scripts/migrate_to_nvme.sh
@@ -15,7 +15,7 @@ CLONE_ARGS=${CLONE_ARGS:-}
 MIGRATE_ARTIFACTS=${MIGRATE_ARTIFACTS:-"${REPO_ROOT}/artifacts/migrate-to-nvme"}
 SKIP_EEPROM=${SKIP_EEPROM:-0}
 NO_REBOOT=${NO_REBOOT:-0}
-CLONE_TARGET=${CLONE_TARGET:-${TARGET:-}}
+TARGET_DEVICE=${TARGET:-${CLONE_TARGET:-}}
 CLONE_WIPE=${CLONE_WIPE:-${WIPE:-}}
 
 mkdir -p "${MIGRATE_ARTIFACTS}"
@@ -50,8 +50,8 @@ log_step() {
 
 run_clone() {
   local -a env_vars=()
-  if [[ -n "${CLONE_TARGET}" ]]; then
-    env_vars+=("TARGET=${CLONE_TARGET}")
+  if [[ -n "${TARGET_DEVICE}" ]]; then
+    env_vars+=("TARGET=${TARGET_DEVICE}")
   fi
   if [[ -n "${CLONE_WIPE}" ]]; then
     env_vars+=("WIPE=${CLONE_WIPE}")

--- a/scripts/preflight_clone.sh
+++ b/scripts/preflight_clone.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+log() {
+  printf '[preflight] %s\n' "$*"
+}
+
+fail() {
+  local message="$1"
+  local hint="${2:-}"
+  printf '[preflight] ERROR: %s\n' "${message}" >&2
+  if [ -n "${hint}" ]; then
+    printf '[preflight] Hint: %s\n' "${hint}" >&2
+  fi
+  exit 1
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    fail "Required command '$1' is missing from PATH."
+  fi
+}
+
+resolve_device() {
+  local source="$1"
+  if [[ -z "${source}" ]]; then
+    return 1
+  fi
+  case "${source}" in
+    /dev/*)
+      printf '%s\n' "${source}"
+      ;;
+    PARTUUID=*)
+      blkid -o device -t "${source}" || return 1
+      ;;
+    UUID=*)
+      blkid -U "${source#UUID=}" || return 1
+      ;;
+    LABEL=*)
+      blkid -L "${source#LABEL=}" || return 1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+ensure_disk_type() {
+  local device="$1"
+  local type
+  type=$(lsblk -no TYPE "${device}" 2>/dev/null || true)
+  if [[ "${type}" != "disk" ]]; then
+    fail "${device} is not a disk (detected TYPE='${type}')." "Pass the whole disk (e.g. /dev/nvme0n1) as TARGET."
+  fi
+}
+
+collect_mounts() {
+  local device="$1"
+  lsblk -J -o PATH,MOUNTPOINT "${device}" 2>/dev/null |
+    python3 - <<'PY'
+import json
+import sys
+
+def walk(node):
+    if isinstance(node, dict):
+        if 'path' in node:
+            yield node
+        for child in node.get('children', []):
+            yield from walk(child)
+    elif isinstance(node, list):
+        for item in node:
+            yield from walk(item)
+
+try:
+    payload = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+for entry in walk(payload):
+    mount = entry.get('mountpoint')
+    if mount:
+        print(f"{entry['path']}::{mount}")
+PY
+}
+
+require_command findmnt
+require_command lsblk
+require_command blkid
+require_command python3
+require_command wipefs
+
+TARGET=${TARGET:-${CLONE_TARGET:-}}
+if [[ -z "${TARGET}" ]]; then
+  fail "TARGET is not set." "Invoke with TARGET=/dev/nvme0n1 just preflight."
+fi
+
+TARGET=$(readlink -f "${TARGET}" 2>/dev/null || printf '%s\n' "${TARGET}")
+if [[ ! -b "${TARGET}" ]]; then
+  fail "${TARGET} is not a block device." "Confirm the device path with just show-disks."
+fi
+
+ensure_disk_type "${TARGET}"
+
+declare -a checklist=()
+
+default_summary() {
+  local label="$1"
+  checklist+=("[✔] ${label}")
+}
+
+boot_source=$(findmnt -no SOURCE / 2>/dev/null || true)
+if [[ -z "${boot_source}" ]]; then
+  fail "Unable to determine the boot device for /." "Verify that findmnt is available and rerun."
+fi
+
+boot_partition=$(resolve_device "${boot_source}" || true)
+if [[ -z "${boot_partition}" ]]; then
+  fail "Could not resolve boot source '${boot_source}'." "Use findmnt -no SOURCE / to inspect the current root mount."
+fi
+
+boot_disk_name=$(lsblk -no PKNAME "${boot_partition}" 2>/dev/null || true)
+if [[ -n "${boot_disk_name}" ]]; then
+  boot_disk="/dev/${boot_disk_name}"
+else
+  boot_disk="${boot_partition}"
+fi
+
+TARGET_DISK_NAME=$(lsblk -no PKNAME "${TARGET}" 2>/dev/null || true)
+if [[ -n "${TARGET_DISK_NAME}" ]]; then
+  target_disk="/dev/${TARGET_DISK_NAME}"
+else
+  target_disk="${TARGET}"
+fi
+
+target_real=$(readlink -f "${target_disk}" 2>/dev/null || printf '%s\n' "${target_disk}")
+boot_disk_real=$(readlink -f "${boot_disk}" 2>/dev/null || printf '%s\n' "${boot_disk}")
+boot_partition_real=$(readlink -f "${boot_partition}" 2>/dev/null || printf '%s\n' "${boot_partition}")
+
+if [[ "${target_real}" == "${boot_disk_real}" ]]; then
+  fail "TARGET ${TARGET} resolves to the active boot disk (${boot_disk_real})." "Choose an attached NVMe/USB disk that is not hosting /."
+fi
+
+if [[ "${target_real}" == "${boot_partition_real}" ]]; then
+  fail "TARGET ${TARGET} points at the live root partition (${boot_partition_real})." "Pass the parent disk instead (e.g. /dev/mmcblk0 → /dev/mmcblk0p2)."
+fi
+
+default_summary "Boot disk ${boot_disk_real} will not be touched."
+
+mapfile -t mounted_parts < <(collect_mounts "${TARGET}" || true)
+if (( ${#mounted_parts[@]} > 0 )); then
+  printf '[preflight] Mounted partitions detected on %s:%s' "${TARGET}" "\n" >&2
+  for entry in "${mounted_parts[@]}"; do
+    printf '  %s\n' "${entry}" >&2
+  done
+  fail "Target partitions are mounted." "Run just clean-mounts-hard first."
+fi
+
+default_summary "No target partitions are currently mounted."
+
+signatures=$(wipefs -n --noheadings "${TARGET}" 2>/dev/null || true)
+if [[ -n "${signatures}" && "${WIPE:-0}" != "1" ]]; then
+  printf '[preflight] Existing signatures on %s:%s' "${TARGET}" "\n" >&2
+  printf '%s\n' "${signatures}" >&2
+  fail "Found existing filesystem/partition signatures on ${TARGET}." "Re-run with WIPE=1 TARGET=${TARGET} just preflight."
+fi
+
+if [[ "${WIPE:-0}" == "1" ]]; then
+  if [[ "${WIPE_CONFIRM:-0}" != "1" ]]; then
+    fail "WIPE=1 requested without WIPE_CONFIRM=1." "The just task sets WIPE_CONFIRM automatically; export it if running manually."
+  fi
+  if [[ -n "${signatures}" ]]; then
+    log "Clearing existing signatures from ${TARGET}"
+  else
+    log "WIPE=1 set; ensuring ${TARGET} is blank before cloning"
+  fi
+  wipefs -a "${TARGET}"
+  default_summary "wipefs -a executed for a clean starting point."
+else
+  default_summary "Existing signatures are acceptable (WIPE=0)."
+fi
+
+size=$(lsblk -dn -o SIZE "${TARGET}" 2>/dev/null || printf 'unknown')
+model=$(lsblk -dn -o MODEL "${TARGET}" 2>/dev/null | sed -e 's/^ *//' -e 's/ *$//')
+model=${model:-unknown}
+
+root_usage=$(df -h --output=used / | tail -n1 | sed -e 's/^ *//' -e 's/ *$//')
+mount_base_hint=${MOUNT_BASE:-/mnt/clone}
+
+log "Target: ${TARGET} (size=${size}, model=${model})"
+log "Boot root: ${boot_partition_real} (disk ${boot_disk_real})"
+log "Root filesystem currently uses: ${root_usage}"
+
+log "Checklist:"
+for item in "${checklist[@]}"; do
+  log "  ${item}"
+  done
+
+log "Next steps:"
+log "  1. sudo TARGET=${TARGET} WIPE=${WIPE:-0} just clone-ssd"
+log "  2. sudo TARGET=${TARGET} MOUNT_BASE=${mount_base_hint} just verify-clone"
+log "  3. sudo just finalize-nvme"
+log "Use just show-disks to double-check identifiers before cloning."
+
+exit 0

--- a/scripts/rollback_to_sd_plan.sh
+++ b/scripts/rollback_to_sd_plan.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+log() {
+  printf '[rollback-plan] %s\n' "$*"
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    return 1
+  fi
+  return 0
+}
+
+root_source=$(findmnt -no SOURCE / 2>/dev/null || echo "unknown")
+boot_order="unknown"
+if require_command rpi-eeprom-config; then
+  boot_order=$(rpi-eeprom-config 2>/dev/null | awk -F= '/^BOOT_ORDER=/ {print $2}' | tr -d '[:space:]')
+  boot_order=${boot_order:-unknown}
+fi
+
+log "Current root filesystem source: ${root_source}"
+log "Current EEPROM BOOT_ORDER: ${boot_order}"
+log "The steps below prefer the SD card on the next boot without applying changes automatically."
+
+cat <<'STEPS'
+1) Preview the SD fallback changes (no modifications):
+     sudo scripts/rollback_to_sd.sh --dry-run
+
+2) Apply the cmdline.txt and fstab updates to point back to the SD card:
+     sudo scripts/rollback_to_sd.sh
+
+3) Prefer the SD card in the EEPROM boot order (Pi 4/5):
+     sudo just boot-order sd-nvme-usb
+
+4) Confirm the BOOT_ORDER and the updated files:
+     sudo rpi-eeprom-config | grep BOOT_ORDER
+     ls -lh /boot/cmdline.txt /etc/fstab
+
+Reboot when ready. You can restore NVMe priority later with:
+     sudo just finalize-nvme
+STEPS

--- a/scripts/verify_clone.sh
+++ b/scripts/verify_clone.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+log() {
+  printf '[verify-clone] %s\n' "$*"
+}
+
+record_pass() {
+  success_checks+=("$1")
+}
+
+record_fail() {
+  error_checks+=("$1")
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf '[verify-clone] ERROR: Required command "%s" not found.\n' "$1" >&2
+    exit 1
+  fi
+}
+
+partition_path() {
+  local disk="$1"
+  local index="$2"
+  if [[ "${disk}" =~ [0-9]$ ]]; then
+    printf '%sp%s\n' "${disk}" "${index}"
+  else
+    printf '%s%s\n' "${disk}" "${index}"
+  fi
+}
+
+cleanup() {
+  local exit_code=$1
+  set +e
+  if [[ -n "${boot_mount:-}" ]] && mountpoint -q "${boot_mount}" 2>/dev/null; then
+    umount "${boot_mount}" 2>/dev/null || umount -l "${boot_mount}" 2>/dev/null || true
+  fi
+  if [[ -n "${root_mount:-}" ]] && mountpoint -q "${root_mount}" 2>/dev/null; then
+    umount "${root_mount}" 2>/dev/null || umount -l "${root_mount}" 2>/dev/null || true
+  fi
+  if [[ -n "${boot_mount:-}" ]] && [ -d "${boot_mount}" ]; then
+    rmdir "${boot_mount}" 2>/dev/null || true
+  fi
+  if [[ -n "${root_mount:-}" ]] && [ -d "${root_mount}" ]; then
+    find "${root_mount}" -mindepth 1 -maxdepth 1 -type d -empty -delete 2>/dev/null || true
+    rmdir "${root_mount}" 2>/dev/null || true
+  fi
+  trap - EXIT
+  exit "${exit_code}"
+}
+
+trap 'cleanup "$?"' EXIT
+
+require_command mount
+require_command umount
+require_command lsblk
+require_command blkid
+require_command python3
+require_command fatlabel
+require_command e2label
+
+declare -a success_checks=()
+declare -a error_checks=()
+
+TARGET=${TARGET:-${CLONE_TARGET:-}}
+if [[ -z "${TARGET}" ]]; then
+  printf '[verify-clone] ERROR: TARGET is not set.\n' >&2
+  exit 1
+fi
+
+TARGET=$(readlink -f "${TARGET}" 2>/dev/null || printf '%s\n' "${TARGET}")
+if [[ ! -b "${TARGET}" ]]; then
+  printf '[verify-clone] ERROR: %s is not a block device.\n' "${TARGET}" >&2
+  exit 1
+fi
+
+root_part=$(partition_path "${TARGET}" 2)
+boot_part=$(partition_path "${TARGET}" 1)
+
+if [[ ! -b "${root_part}" ]]; then
+  printf '[verify-clone] ERROR: Root partition %s not found.\n' "${root_part}" >&2
+  exit 1
+fi
+if [[ ! -b "${boot_part}" ]]; then
+  printf '[verify-clone] ERROR: Boot partition %s not found.\n' "${boot_part}" >&2
+  exit 1
+fi
+
+MOUNT_BASE=${MOUNT_BASE:-/mnt/clone}
+mkdir -p "${MOUNT_BASE}"
+root_mount="${MOUNT_BASE}"
+boot_mount=""
+
+if mountpoint -q "${root_mount}" 2>/dev/null; then
+  printf '[verify-clone] ERROR: %s is already mounted; run just clean-mounts-hard first.\n' "${root_mount}" >&2
+  exit 1
+fi
+
+if ! mount -o ro "${root_part}" "${root_mount}"; then
+  printf '[verify-clone] ERROR: Failed to mount %s at %s.\n' "${root_part}" "${root_mount}" >&2
+  exit 1
+fi
+
+firmware_dir="${root_mount}/boot/firmware"
+if [[ -d "${firmware_dir}" ]]; then
+  boot_mount="${firmware_dir}"
+else
+  boot_mount="${root_mount}/boot"
+fi
+
+if [[ ! -d "${boot_mount}" ]]; then
+  printf '[verify-clone] ERROR: Expected boot mount directory %s missing.\n' "${boot_mount}" >&2
+  exit 1
+fi
+
+if mountpoint -q "${boot_mount}" 2>/dev/null; then
+  printf '[verify-clone] ERROR: %s is already mounted; run just clean-mounts-hard first.\n' "${boot_mount}" >&2
+  exit 1
+fi
+
+if ! mount -o ro -t vfat "${boot_part}" "${boot_mount}"; then
+  printf '[verify-clone] ERROR: Failed to mount %s at %s.\n' "${boot_part}" "${boot_mount}" >&2
+  exit 1
+fi
+
+root_partuuid=$(blkid -s PARTUUID -o value "${root_part}" 2>/dev/null || true)
+root_uuid=$(blkid -s UUID -o value "${root_part}" 2>/dev/null || true)
+boot_partuuid=$(blkid -s PARTUUID -o value "${boot_part}" 2>/dev/null || true)
+boot_uuid=$(blkid -s UUID -o value "${boot_part}" 2>/dev/null || true)
+
+log "Target ${TARGET}: root=${root_part} (PARTUUID=${root_partuuid:-n/a}), boot=${boot_part} (PARTUUID=${boot_partuuid:-n/a})"
+
+if [[ -n "${root_partuuid}" ]]; then
+  record_pass "Detected root PARTUUID ${root_partuuid}."
+else
+  record_fail "Missing PARTUUID for ${root_part}."
+fi
+
+cmdline_path="${boot_mount}/cmdline.txt"
+if [[ -f "${cmdline_path}" ]]; then
+  cmdline=$(tr '\n' ' ' <"${cmdline_path}" | sed -e 's/  */ /g')
+  if [[ -n "${root_partuuid}" && "${cmdline}" =~ root=PARTUUID=${root_partuuid} ]]; then
+    record_pass "cmdline.txt root=PARTUUID=${root_partuuid}."
+  else
+    record_fail "cmdline.txt root entry does not match PARTUUID=${root_partuuid}."
+  fi
+else
+  record_fail "${cmdline_path} missing."
+fi
+
+fstab_path="${root_mount}/etc/fstab"
+boot_mount_rel="/boot"
+if [[ "${boot_mount}" == "${root_mount}/boot/firmware" ]]; then
+  boot_mount_rel="/boot/firmware"
+fi
+
+if [[ -f "${fstab_path}" ]]; then
+  fstab_output=$(python3 - <<'PY'
+import sys
+from pathlib import Path
+
+path, root_partuuid, root_uuid, boot_partuuid, boot_uuid, boot_mount = sys.argv[1:7]
+root_ok = False
+boot_ok = False
+root_pref = f"PARTUUID={root_partuuid}" if root_partuuid else None
+root_alt = f"UUID={root_uuid}" if root_uuid else None
+boot_pref = f"UUID={boot_uuid}" if boot_uuid else None
+boot_alt = f"PARTUUID={boot_partuuid}" if boot_partuuid else None
+for raw in Path(path).read_text(encoding='utf-8').splitlines():
+    stripped = raw.strip()
+    if not stripped or stripped.startswith('#'):
+        continue
+    parts = stripped.split()
+    if len(parts) < 2:
+        continue
+    mount = parts[1]
+    device = parts[0]
+    if mount == '/':
+        if root_pref and device == root_pref:
+            root_ok = True
+        elif root_alt and device == root_alt:
+            root_ok = True
+    elif mount == boot_mount:
+        if boot_pref and device == boot_pref:
+            boot_ok = True
+        elif boot_alt and device == boot_alt:
+            boot_ok = True
+print('PASS' if root_ok else 'FAIL')
+print('PASS' if boot_ok else 'FAIL')
+PY
+    "${fstab_path}" "${root_partuuid}" "${root_uuid}" "${boot_partuuid}" "${boot_uuid}" "${boot_mount_rel}" 2>/dev/null)
+  python_status=$?
+  if [[ ${python_status} -ne 0 ]]; then
+    record_fail "Failed to parse ${fstab_path}."
+  else
+    read -r root_status boot_status <<<"${fstab_output}" || true
+    if [[ "${root_status}" == "PASS" && -n "${root_partuuid}" ]]; then
+      record_pass "fstab root entry matches PARTUUID=${root_partuuid}."
+    elif [[ "${root_status}" == "PASS" ]]; then
+      record_pass "fstab root entry matches available identifier."
+    else
+      record_fail "fstab root entry missing or mismatched."
+    fi
+    if [[ "${boot_status}" == "PASS" ]]; then
+      record_pass "fstab ${boot_mount_rel} entry matches target identifiers."
+    else
+      record_fail "fstab ${boot_mount_rel} entry missing or mismatched."
+    fi
+  fi
+else
+  record_fail "${fstab_path} missing."
+fi
+
+boot_label=$(fatlabel "${boot_part}" 2>/dev/null | tr -d '\n' | sed -e 's/ *$//')
+root_label=$(e2label "${root_part}" 2>/dev/null | tr -d '\n')
+
+if [[ -z "${boot_label}" ]]; then
+  record_fail "Unable to read FAT label for ${boot_part}."
+elif [[ "${boot_label}" != "${boot_label^^}" ]]; then
+  record_fail "Boot label '${boot_label}' is not upper-case."
+elif [[ "${boot_label}" != "BOOTFS" ]]; then
+  record_fail "Boot label '${boot_label}' should be BOOTFS."
+else
+  record_pass "Boot label BOOTFS confirmed."
+fi
+
+if [[ -z "${root_label}" ]]; then
+  record_fail "Unable to read ext4 label for ${root_part}."
+elif [[ "${root_label}" != "rootfs" ]]; then
+  record_fail "Root label '${root_label}' should be rootfs."
+else
+  record_pass "Root label rootfs confirmed."
+fi
+
+log "Validation report:"
+for item in "${success_checks[@]}"; do
+  log "  [PASS] ${item}"
+  done
+for item in "${error_checks[@]}"; do
+  log "  [FAIL] ${item}"
+  done
+
+if (( ${#error_checks[@]} > 0 )); then
+  log "Run just clean-mounts-hard to clear mounts and address the failures above."
+  cleanup 1
+fi
+
+log "All checks passed."
+cleanup 0


### PR DESCRIPTION
## Summary
- add just targets for show-disks, preflight, verify-clone, finalize-nvme, rollback-to-sd, and clean-mounts-hard while standardizing on TARGET
- implement preflight, verification, finalize, and rollback helper scripts plus a more robust cleanup_clone_mounts.sh
- document the SD→NVMe workflow and link it from the docs index

## Testing
- bash -n scripts/preflight_clone.sh scripts/verify_clone.sh scripts/cleanup_clone_mounts.sh scripts/finalize_nvme_boot.sh scripts/rollback_to_sd_plan.sh
- shellcheck scripts/preflight_clone.sh scripts/verify_clone.sh scripts/cleanup_clone_mounts.sh scripts/finalize_nvme_boot.sh scripts/rollback_to_sd_plan.sh *(fails: command not found in container)*


------
https://chatgpt.com/codex/tasks/task_e_68f3368df788832f9767c48044a386f1