### PR TITLE
🛠️ : – Fix Justfile formatter workflow and document outages

### DIFF
--- a/.github/workflows/verify-justfile.yml
+++ b/.github/workflows/verify-justfile.yml
@@ -20,4 +20,4 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y just
       - name: Check Justfile formatting
-        run: just --fmt --unstable --check
+        run: just --unstable --fmt --check

--- a/outages/2025-10-18-pi-image-shellcheck-cleanup-handler.json
+++ b/outages/2025-10-18-pi-image-shellcheck-cleanup-handler.json
@@ -1,0 +1,12 @@
+{
+  "id": "2025-10-18-pi-image-shellcheck-cleanup-handler",
+  "date": "2025-10-18",
+  "component": "pi-image workflow",
+  "rootCause": "ShellCheck flagged the new SD→NVMe helpers. `cleanup_handler` in `scripts/cleanup_clone_mounts.sh` exited with an unquoted status and no suppression for its trap-only control flow, triggering SC2086/SC2317, and `scripts/finalize_nvme.sh` kept an unused `SCRIPT_NAME` constant (SC2034). The workflow treats any ShellCheck warning as a failure, so the unit job stopped before running the remaining tests.",
+  "resolution": "Quote the exit statuses in `cleanup_handler`, document the trap-only function with `shellcheck disable=SC2317`, and drop the unused constant from `scripts/finalize_nvme.sh` so the shellcheck step runs cleanly.",
+  "references": [
+    "scripts/cleanup_clone_mounts.sh",
+    "scripts/finalize_nvme.sh",
+    ".github/workflows/pi-image.yml"
+  ]
+}

--- a/outages/2025-10-18-verify-justfile-unstable-flag.json
+++ b/outages/2025-10-18-verify-justfile-unstable-flag.json
@@ -1,0 +1,10 @@
+{
+  "id": "2025-10-18-verify-justfile-unstable-flag",
+  "date": "2025-10-18",
+  "component": "Verify Justfile formatting workflow",
+  "rootCause": "The workflow invoked `just --fmt --unstable --check`, but `just` expects global flags before the subcommand. The incorrect order made the formatter exit immediately with a CLI usage error, so the formatting check failed every run.",
+  "resolution": "Reordered the invocation to `just --unstable --fmt --check` so the unstable flag is applied before the formatter executes, allowing the check to run normally.",
+  "references": [
+    ".github/workflows/verify-justfile.yml"
+  ]
+}


### PR DESCRIPTION
what:
- reorder the Justfile formatting workflow to pass --unstable before --fmt
- add outage records for the formatter failure and the pi-image shellcheck regression

why:
- just exits with a usage error if --unstable is placed after the subcommand
- shellcheck warnings in the cleanup handler and finalize helper blocked pi-image unit tests

how to test:
- just --unstable --fmt --check
- shellcheck scripts/*.sh


------
https://chatgpt.com/codex/tasks/task_e_68f41d906b74832f8d8d9a9a4fad11f2