### PR TITLE
feat: reuse pi carrier stack base

### DIFF
--- a/cad/pi_cluster/pi_carrier.scad
+++ b/cad/pi_cluster/pi_carrier.scad
@@ -2,7 +2,7 @@
 // "heatset" → blind hole sized for brass insert
 // "printed" → simple through-hole
 // "nut"     → through-hole with hex recess
-standoff_mode = "heatset";
+standoff_mode = is_undef(standoff_mode) ? "heatset" : standoff_mode;
 variation = standoff_mode == "printed" ? "through"
           : standoff_mode == "heatset" ? "blind"
           : standoff_mode;
@@ -154,4 +154,6 @@ module pi_carrier()
     }
 }
 
-pi_carrier();
+if (is_undef(_pi_carrier_auto_render) ? true : _pi_carrier_auto_render) {
+    pi_carrier();
+}

--- a/cad/pi_cluster/pi_carrier_stack.scad
+++ b/cad/pi_cluster/pi_carrier_stack.scad
@@ -1,3 +1,5 @@
+_pi_carrier_auto_render = false;
+include <pi_carrier.scad>;
 use <pi_carrier_column.scad>;
 use <fan_wall.scad>;
 
@@ -15,14 +17,11 @@ fan_insert_L = is_undef(fan_insert_L) ? 4.0 : fan_insert_L;
 fan_offset_from_stack = is_undef(fan_offset_from_stack) ? 15 : fan_offset_from_stack;
 column_spacing = is_undef(column_spacing) ? [58, 49] : column_spacing;
 export_part = is_undef(export_part) ? "assembly" : export_part;
-
-plate_len = column_spacing[0] + 80;
-plate_wid = column_spacing[1] + 90;
-plate_thickness = 4;
+stack_standoff_mode = is_undef(standoff_mode) ? "heatset" : standoff_mode;
 
 module _carrier(level) {
-    translate([0, 0, level * z_gap_clear])
-        cube([plate_len, plate_wid, plate_thickness], center = true);
+    translate([-plate_len / 2, -plate_wid / 2, level * z_gap_clear])
+        let(standoff_mode = stack_standoff_mode) pi_carrier();
 }
 
 module _columns() {
@@ -59,6 +58,8 @@ module pi_carrier_stack_assembly() {
         _carrier(level);
     _fan_wall();
 }
+
+echo("pi_carrier_stack", levels = levels, fan_size = fan_size, column_mode = column_mode);
 
 if (export_part == "columns") {
     pi_carrier_column(

--- a/tests/test_pi_carrier_stack_scad.py
+++ b/tests/test_pi_carrier_stack_scad.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCAD_PATH = REPO_ROOT / "cad" / "pi_cluster" / "pi_carrier_stack.scad"
+
+
+def test_pi_carrier_stack_imports_pi_carrier_module() -> None:
+    """pi_carrier_stack should reuse the base module instead of cubes."""
+
+    source = SCAD_PATH.read_text(encoding="utf-8")
+    assert "pi_carrier.scad" in source, "pi_carrier_stack should import pi_carrier.scad"
+    assert re.search(r"\bpi_carrier\s*\(", source), "pi_carrier_stack should call pi_carrier()"


### PR DESCRIPTION
## Summary
- reuse pi_carrier() inside pi_carrier_stack to render carriers
- gate pi_carrier.scad auto-rendering and forward standoff overrides
- update docs and add tests/test_pi_carrier_stack_scad.py coverage

## Testing
- python -m pre_commit run --all-files
  (fails: existing E501 lines in scripts/ssd_clone.py)
- pytest tests/test_pi_carrier_stack_scad.py
- python -m pyspelling -c .spellcheck.yaml
- /root/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md
  docs/
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68f47f906a9c832fbf46755163da377a