### PR TITLE
Add dimension metadata checks for pi carrier stack

### DIFF
--- a/cad/pi_cluster/pi_carrier_stack.scad
+++ b/cad/pi_cluster/pi_carrier_stack.scad
@@ -59,7 +59,15 @@ module pi_carrier_stack_assembly() {
     _fan_wall();
 }
 
-echo("pi_carrier_stack", levels = levels, fan_size = fan_size, column_mode = column_mode);
+echo(
+    "pi_carrier_stack",
+    levels = levels,
+    fan_size = fan_size,
+    column_mode = column_mode,
+    z_gap_clear = z_gap_clear,
+    column_spacing = column_spacing,
+    fan_offset_from_stack = fan_offset_from_stack
+);
 
 if (export_part == "columns") {
     pi_carrier_column(

--- a/docs/pi_cluster_stack.md
+++ b/docs/pi_cluster_stack.md
@@ -383,7 +383,8 @@ module pi_carrier_stack(levels = 3, zgap = 32, fan_size = 120) {
 - [ ] Create user-facing assembly/BOM documentation once the physical prototype is validated.
 - [ ] Verify column alignment with the 58 mm × 49 mm hole rectangle and fan wall spacing within
       ±0.2 mm.
-- [ ] Add optional OpenSCAD tests (e.g., `echo()` dimension checks) to aid regression testing.
+- [x] Add optional OpenSCAD tests (e.g., `echo()` dimension checks) to aid regression testing.
+      (Regression coverage: `tests/test_pi_carrier_stack_scad.py::test_pi_carrier_stack_echo_includes_dimension_metadata`.)
 
 ---
 

--- a/tests/test_pi_carrier_stack_scad.py
+++ b/tests/test_pi_carrier_stack_scad.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 import re
 
@@ -13,3 +14,46 @@ def test_pi_carrier_stack_imports_pi_carrier_module() -> None:
     source = SCAD_PATH.read_text(encoding="utf-8")
     assert "pi_carrier.scad" in source, "pi_carrier_stack should import pi_carrier.scad"
     assert re.search(r"\bpi_carrier\s*\(", source), "pi_carrier_stack should call pi_carrier()"
+
+
+def _parse_default_assignments(source: str) -> dict[str, object]:
+    """Extract default values from `is_undef()` guard assignments."""
+
+    defaults: dict[str, object] = {}
+    pattern = re.compile(
+        r"^(?P<name>\w+)\s*=\s*is_undef\(\s*(?P<ref>\w+)\s*\)\s*\?\s*(?P<default>[^:;]+)\s*:\s*\2;",
+        re.MULTILINE,
+    )
+    for match in pattern.finditer(source):
+        default = match.group("default").strip()
+        try:
+            defaults[match.group("name")] = ast.literal_eval(default)
+        except (SyntaxError, ValueError):
+            defaults[match.group("name")] = default
+    return defaults
+
+
+def test_pi_carrier_stack_echo_includes_dimension_metadata() -> None:
+    """Ensure the SCAD exports emit dimensional context for regression checks."""
+
+    source = SCAD_PATH.read_text(encoding="utf-8")
+
+    echo_match = re.search(r"echo\s*\(([^;]+)\);", source)
+    assert echo_match, "pi_carrier_stack.scad should expose an echo() call"
+    echo_args = echo_match.group(1)
+
+    for key in ("z_gap_clear", "column_spacing", "fan_offset_from_stack"):
+        assert re.search(rf"{key}\s*=", echo_args), (
+            f"Expected {key} to appear in the echo metadata"
+        )
+
+    defaults = _parse_default_assignments(source)
+    assert defaults.get("z_gap_clear") == 32, (
+        "Default z-gap clearance should remain 32 mm"
+    )
+    assert defaults.get("fan_offset_from_stack") == 15, (
+        "Default fan offset should remain 15 mm"
+    )
+    assert defaults.get("column_spacing") == [58, 49], (
+        "Column spacing should track Pi mount pattern"
+    )


### PR DESCRIPTION
## Summary
- add regression coverage that inspects the pi_carrier_stack echo metadata
- emit z-gap, column spacing, and fan offset fields from pi_carrier_stack.scad
- mark the deliverables checklist entry complete with the new test reference

## Testing
- python -m pre_commit run --all-files *(fails: flake8 E501 in scripts/ssd_clone.py)*
- pytest tests/test_pi_carrier_stack_scad.py
- python -m pyspelling -c .spellcheck.yaml
- /root/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md docs/
- bash scripts/openscad_render.sh cad/pi_cluster/pi_carrier_stack.scad *(fails: OpenSCAD not available)*

------
https://chatgpt.com/codex/tasks/task_e_68f48f6869ac832fba441f5236c573d7