### PR TITLE
Add dimension-report toggles for pi cluster CAD modules

### DIFF
--- a/cad/pi_cluster/fan_wall.scad
+++ b/cad/pi_cluster/fan_wall.scad
@@ -11,6 +11,8 @@ column_tab_width = is_undef(column_tab_width) ? 12 : column_tab_width;
 column_tab_thickness = is_undef(column_tab_thickness) ? 6 : column_tab_thickness;
 column_tab_offset = is_undef(column_tab_offset) ? 6 : column_tab_offset;
 include_bosses = is_undef(include_bosses) ? true : include_bosses;
+emit_dimension_report =
+    is_undef(emit_dimension_report) ? false : emit_dimension_report;
 
 fan_clearance_radius = fan_mount_clearance(fan_size) / 2;
 boss_radius = fan_insert_od / 2 + 1.2;
@@ -40,7 +42,8 @@ module fan_wall(
     fan_insert_L = fan_insert_L,
     levels = levels,
     z_gap_clear = z_gap_clear,
-    column_spacing = column_spacing
+    column_spacing = column_spacing,
+    emit_dimension_report = emit_dimension_report
 ) {
     difference() {
         translate([-wall_width / 2, -fan_plate_t / 2, 0])
@@ -74,6 +77,18 @@ module fan_wall(
                         cylinder(h = tab_depth + 0.4, r = 1.6, $fn = 30);
             }
         }
+    }
+
+    if (emit_dimension_report) {
+        echo(
+            "fan_wall",
+            fan_size = fan_size,
+            hole_spacing = hole_spacing,
+            column_spacing = column_spacing,
+            levels = levels,
+            z_gap_clear = z_gap_clear,
+            include_bosses = include_bosses
+        );
     }
 }
 

--- a/cad/pi_cluster/pi_carrier_column.scad
+++ b/cad/pi_cluster/pi_carrier_column.scad
@@ -8,6 +8,8 @@ carrier_insert_L = is_undef(carrier_insert_L) ? 4.0 : carrier_insert_L;
 foot_diameter = is_undef(foot_diameter) ? 22 : foot_diameter;
 foot_height = is_undef(foot_height) ? 3 : foot_height;
 cap_height = is_undef(cap_height) ? 3 : cap_height;
+emit_dimension_report =
+    is_undef(emit_dimension_report) ? false : emit_dimension_report;
 
 column_radius = column_od / 2;
 inner_radius = column_radius - column_wall;
@@ -47,7 +49,8 @@ module pi_carrier_column(
     column_od = column_od,
     column_wall = column_wall,
     carrier_insert_od = carrier_insert_od,
-    carrier_insert_L = carrier_insert_L
+    carrier_insert_L = carrier_insert_L,
+    emit_dimension_report = emit_dimension_report
 ) {
     difference() {
         _column_shell();
@@ -60,6 +63,19 @@ module pi_carrier_column(
     // Add a locating chamfer on top for easier carrier placement.
     translate([0, 0, foot_height + column_height - 1])
         cylinder(h = 1.2, r1 = column_radius - 0.6, r2 = column_radius, $fn = 60);
+
+    if (emit_dimension_report) {
+        echo(
+            "pi_carrier_column",
+            levels = levels,
+            z_gap_clear = z_gap_clear,
+            column_height = column_height,
+            column_od = column_od,
+            column_wall = column_wall,
+            foot_diameter = foot_diameter,
+            column_mode = column_mode
+        );
+    }
 }
 
 pi_carrier_column();

--- a/cad/pi_cluster/pi_carrier_stack.scad
+++ b/cad/pi_cluster/pi_carrier_stack.scad
@@ -18,6 +18,8 @@ fan_offset_from_stack = is_undef(fan_offset_from_stack) ? 15 : fan_offset_from_s
 column_spacing = is_undef(column_spacing) ? [58, 49] : column_spacing;
 export_part = is_undef(export_part) ? "assembly" : export_part;
 stack_standoff_mode = is_undef(standoff_mode) ? "heatset" : standoff_mode;
+emit_dimension_report =
+    is_undef(emit_dimension_report) ? false : emit_dimension_report;
 
 module _carrier(level) {
     translate([-plate_len / 2, -plate_wid / 2, level * z_gap_clear])
@@ -35,7 +37,8 @@ module _columns() {
                     column_od = column_od,
                     column_wall = column_wall,
                     carrier_insert_od = carrier_insert_od,
-                    carrier_insert_L = carrier_insert_L
+                    carrier_insert_L = carrier_insert_L,
+                    emit_dimension_report = emit_dimension_report
                 );
 }
 
@@ -48,7 +51,8 @@ module _fan_wall() {
             fan_insert_L = fan_insert_L,
             levels = levels,
             z_gap_clear = z_gap_clear,
-            column_spacing = column_spacing
+            column_spacing = column_spacing,
+            emit_dimension_report = emit_dimension_report
         );
 }
 
@@ -59,7 +63,18 @@ module pi_carrier_stack_assembly() {
     _fan_wall();
 }
 
-echo("pi_carrier_stack", levels = levels, fan_size = fan_size, column_mode = column_mode);
+if (emit_dimension_report) {
+    stack_height = levels * z_gap_clear;
+    echo(
+        "pi_carrier_stack",
+        levels = levels,
+        fan_size = fan_size,
+        column_mode = column_mode,
+        column_spacing = column_spacing,
+        stack_height = stack_height,
+        export_part = export_part
+    );
+}
 
 if (export_part == "columns") {
     pi_carrier_column(
@@ -69,7 +84,8 @@ if (export_part == "columns") {
         column_od = column_od,
         column_wall = column_wall,
         carrier_insert_od = carrier_insert_od,
-        carrier_insert_L = carrier_insert_L
+        carrier_insert_L = carrier_insert_L,
+        emit_dimension_report = emit_dimension_report
     );
 } else if (export_part == "fan_wall") {
     fan_wall(
@@ -79,7 +95,8 @@ if (export_part == "columns") {
         fan_insert_L = fan_insert_L,
         levels = levels,
         z_gap_clear = z_gap_clear,
-        column_spacing = column_spacing
+        column_spacing = column_spacing,
+        emit_dimension_report = emit_dimension_report
     );
 } else {
     pi_carrier_stack_assembly();

--- a/docs/pi_cluster_stack.md
+++ b/docs/pi_cluster_stack.md
@@ -376,14 +376,18 @@ module pi_carrier_stack(levels = 3, zgap = 32, fan_size = 120) {
 
 ## 12. Deliverables checklist (for future implementation)
 
-- [ ] Add `fan_patterns.scad`, `fan_wall.scad`, `pi_carrier_column.scad`, `pi_carrier_stack.scad`.
+- [x] Add `fan_patterns.scad`, `fan_wall.scad`, `pi_carrier_column.scad`, `pi_carrier_stack.scad`
+      under `cad/pi_cluster/`.
 - [x] Ensure `pi_carrier_stack.scad` imports `pi_carrier.scad` instead of duplicating parameters.
       (Regression coverage: `tests/test_pi_carrier_stack_scad.py`.)
 - [ ] Render six STL variants (columns: `printed`, `brass_chain`; fan sizes: 80/92/120) via CI.
 - [ ] Create user-facing assembly/BOM documentation once the physical prototype is validated.
 - [ ] Verify column alignment with the 58 mm × 49 mm hole rectangle and fan wall spacing within
       ±0.2 mm.
-- [ ] Add optional OpenSCAD tests (e.g., `echo()` dimension checks) to aid regression testing.
+- [x] Add optional OpenSCAD tests (e.g., `echo()` dimension checks) to aid regression
+      testing. (Regression coverage:
+      `tests/test_pi_cluster_dimension_reports.py::test_dimension_report_echo_is_declared`,
+      `tests/test_pi_cluster_dimension_reports.py::test_dimension_report_echo_outputs_expected_keys`.)
 
 ---
 

--- a/tests/test_pi_cluster_dimension_reports.py
+++ b/tests/test_pi_cluster_dimension_reports.py
@@ -1,0 +1,70 @@
+"""Ensure pi cluster CAD modules expose dimension echoes for regression tests."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCAD_ROOT = Path("cad/pi_cluster")
+OPENSCAD = shutil.which("openscad")
+
+
+@pytest.mark.parametrize(
+    ("filename", "label"),
+    [
+        ("pi_carrier_column.scad", '"pi_carrier_column"'),
+        ("fan_wall.scad", '"fan_wall"'),
+        ("pi_carrier_stack.scad", '"pi_carrier_stack"'),
+    ],
+)
+def test_dimension_report_echo_is_declared(filename: str, label: str) -> None:
+    """Each SCAD entry point should expose an echo for dimension reporting."""
+
+    source = (SCAD_ROOT / filename).read_text(encoding="utf-8")
+    assert "emit_dimension_report" in source, "dimension report toggle missing"
+    assert label in source, f"{filename} should include a dimension echo"
+
+
+@pytest.mark.skipif(not OPENSCAD, reason="OpenSCAD is not available")
+@pytest.mark.parametrize(
+    ("filename", "expected_keys", "extra_defs"),
+    [
+        (
+            "pi_carrier_column.scad",
+            ["levels", "z_gap_clear", "column_height", "column_od", "column_mode"],
+            [],
+        ),
+        (
+            "fan_wall.scad",
+            ["fan_size", "hole_spacing", "column_spacing", "levels", "include_bosses"],
+            [],
+        ),
+        (
+            "pi_carrier_stack.scad",
+            ["levels", "fan_size", "column_mode", "column_spacing", "stack_height"],
+            [],
+        ),
+    ],
+)
+def test_dimension_report_echo_outputs_expected_keys(
+    tmp_path, filename: str, expected_keys: list[str], extra_defs: list[str]
+) -> None:
+    """Running the SCAD file with emits should surface the expected echo keys."""
+
+    out_file = tmp_path / f"{Path(filename).stem}.stl"
+    cmd = ["openscad", "-o", str(out_file)]
+    for definition in ["emit_dimension_report=true", *extra_defs]:
+        cmd.extend(["-D", definition])
+    cmd.append(str(SCAD_ROOT / filename))
+
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+
+    echoes = [line for line in result.stderr.splitlines() if "ECHO:" in line]
+    assert echoes, "OpenSCAD did not emit any dimension report"
+
+    last_echo = echoes[-1]
+    for key in expected_keys:
+        assert f"{key} =" in last_echo, f"{key} missing from dimension report"


### PR DESCRIPTION
## Summary
- add an `emit_dimension_report` toggle and echo instrumentation across the pi cluster SCAD modules
- cover the new reporting behavior with pytest, including optional OpenSCAD-backed dimension checks
- update the pi cluster stack deliverables checklist to mark the dimension-report tests complete

## Testing
- python -m pre_commit run --all-files *(fails: flake8 reports existing E501 violations in scripts/ssd_clone.py)*
- python -m pyspelling -c .spellcheck.yaml
- python -m linkcheck --no-warnings README.md docs/
- pytest tests/test_pi_cluster_dimension_reports.py
- pytest -q *(fails: existing docs wrapper and CLI expectations in Makefile/justfile)*
- git diff --cached | ./scripts/scan-secrets.py *(no staged diff after commit)*

------
https://chatgpt.com/codex/tasks/task_e_68f48f6869ac832fba441f5236c573d7