### PR TITLE
📝 : – Document airflow requirement in Pi cluster guide

### DIFF
--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -15,6 +15,8 @@ Linux command line.
 - 3 × Raspberry Pi 5 (8 GB recommended)
 - 3 × official Raspberry Pi M.2 HAT with NVMe SSDs
 - 1 × triple Pi carrier plate (see [pi_cluster_carrier.md](pi_cluster_carrier.md))
+- Active airflow. If you skip the carrier stack's built-in fan, position a small desk fan so the
+  boards stay below 60 °C—thermal throttling starts at 80 °C and spot-checks fail above 60 °C.
 - Power supplies, standoffs, and required cables
 - MicroSD card for each node (8 GB minimum)
 - Optional KVM for shared keyboard, video, and mouse access


### PR DESCRIPTION
what: document the need for active airflow in the Raspberry Pi cluster BoM.
why: prevent spot-check failures and thermal throttling above 60-80 °C.
how to test: pyspelling -c .spellcheck.yaml (missing)
how to test: linkchecker --no-warnings README.md docs/ (missing)
how to test: git diff --cached | ./scripts/scan-secrets.py
Refs: N/A

------
https://chatgpt.com/codex/tasks/task_e_68f576773ef8832fb2bdafcd50cac98d