### PR TITLE
k3s on Pis with one just up <env>: mDNS discovery + DHCP-friendly .local + env-scoped clustering

### DIFF
--- a/docs/raspi-image-spot-check.md
+++ b/docs/raspi-image-spot-check.md
@@ -48,6 +48,12 @@ If any required check fails, the script exits non-zero and prints the artifact p
 deeper investigation. Capture `artifacts/spot-check/` in the build report before moving
 on.
 
+## Next step: cluster bring-up
+
+Spot check complete? Jump to the streamlined
+[`raspi_cluster_setup.md`](raspi_cluster_setup.md) guide for the mDNS-enabled
+`just up <env>` workflow.
+
 ## Known benign noise
 
 * `bluetoothd` plugin initialization failures when the radio is disabled.
@@ -65,7 +71,8 @@ first, then pick any optional helpers that match your scenario.
 
 > [!IMPORTANT]
 > Skip Step&nbsp;1 if `sudo rpi-eeprom-config | grep BOOT_ORDER` already returns `0xf461`.
-> Skip directly to **Step&nbsp;3 (Verification)** if `lsblk` already shows NVMe boot and root partitions.
+> Skip directly to **Step&nbsp;3 (Verification)** if `lsblk` already shows NVMe
+> boot and root partitions.
 
 #### Step 1. Align the boot order (only if needed)
 

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -6,180 +6,82 @@ personas:
 
 # Raspberry Pi Cluster Setup
 
-This expanded guide walks through building a three-node Raspberry Pi 5 cluster and installing k3s
-so you can run [token.place](https://github.com/futuroptimist/token.place) and
-[dspace](https://github.com/democratizedspace/dspace). It assumes basic familiarity with the
-Linux command line.
+Sugarkube promises syntactic sugar, so the high-level path stays short. Dive into
+[`raspi_cluster_setup_manual.md`](raspi_cluster_setup_manual.md) when you need the
+full step-by-step playbook for imaging media, cloning to NVMe, and hand-running
+k3s commands.
 
-## Bill of Materials
-- 3 × Raspberry Pi 5 (8 GB recommended)
-- 3 × official Raspberry Pi M.2 HAT with NVMe SSDs
-- 1 × triple Pi carrier plate (see [pi_cluster_carrier.md](pi_cluster_carrier.md))
-- Active airflow. If you skip the carrier stack's built-in fan, position a small desk fan so the
-  boards stay below 60 °C—thermal throttling starts at 80 °C and spot-checks fail above 60 °C.
-- Power supplies, standoffs, and required cables
-- MicroSD card for each node (8 GB minimum)
-- Optional KVM for shared keyboard, video, and mouse access
+## Quick Start (same subnet; DHCP OK)
 
-## Prerequisites
-- A workstation with [Raspberry Pi Imager](https://www.raspberrypi.com/software/) installed
-- Basic networking knowledge. Review [network_setup.md](network_setup.md) for static IPs
-- SSH client (e.g. `ssh` on macOS/Linux or PuTTY on Windows)
-- Internet connection to download images and packages
+> All nodes must share the same L2 network segment with multicast enabled so mDNS
+> (`_https._tcp` on UDP 5353) works. Run these commands over SSH from each Pi once
+> the sugarkube repo is cloned locally.
 
-## Fast path: bootstrap all three nodes automatically
-1. Copy [`samples/pi-cluster/three-node.toml`](../samples/pi-cluster/three-node.toml) to a
-   writable directory and edit it to match your hardware:
-   - Update `device` entries with the removable drives for each Pi.
-   - Set `hostname`, Wi-Fi credentials, and SSH keys once and reuse them across nodes.
-   - Adjust the `cluster.join` section with your control-plane hostname or IPs.
-   - The sample now ships with `[image.workflow] trigger = true`, so the helper automatically
-     dispatches the `pi-image` workflow, waits for the run to finish, and downloads the artifact
-     without leaving the terminal. Disable it (`trigger = false`) when you already have a fresh
-     image cached locally.
-2. Preview the workflow without touching hardware:
+1. Pick an environment label—`dev`, `int`, or `prod`—and export a join token for
+   that environment on every Pi. The first node to run `just up <env>` becomes the
+   control-plane server; the next two become agents.
    ```bash
-   python -m sugarkube_toolkit pi cluster --config ./cluster.toml --dry-run
+   cd ~/sugarkube
+   export SUGARKUBE_TOKEN_DEV='change-me-dev'   # or INT/PROD as appropriate
+   just up dev
    ```
-   The helper prints the commands it would execute (download, flash, join) so you can validate
-   device paths and arguments before proceeding.
-3. Drop `--dry-run` when you're ready:
+2. Repeat on two more Pis to form the default three-node cluster. The helper:
+   - Installs Avahi + libnss-mdns so `.local` hostnames resolve via mDNS.
+   - Discovers an existing `${SUGARKUBE_CLUSTER}/${SUGARKUBE_ENV}` API over mDNS
+     and joins it automatically.
+   - Boots the first server on SQLite by default, taints it `NoSchedule`, and labels
+     every node with `sugarkube.cluster` and `sugarkube.env`.
+3. Check cluster health from any node:
    ```bash
-   python -m sugarkube_toolkit pi cluster --config ./cluster.toml
+   just status
    ```
-   The automation dispatches the `pi-image` workflow (when `image.workflow.trigger` is enabled),
-   waits for the build to complete, downloads the artifact (or reuses an existing
-   `install_sugarkube_image.sh` cache), flashes each SD card via `flash_pi_media_report.py`, copies
-   per-node cloud-init overrides that inject the hostnames and Wi-Fi credentials you supplied, and
-   finally runs `pi_multi_node_join_rehearsal.py --apply` to bring the workers online. Use
-   `just cluster-bootstrap CLUSTER_BOOTSTRAP_ARGS="--config ./cluster.toml"` when you prefer Just
-   recipes.
-
-Skip to [§5](#5-form-the-k3s-cluster) after the helper completes—the control-plane and workers
-will already share the same image, hostname overrides, and join token.
-
-## 1. Prepare the OS image
-1. Trigger the build in GitHub:
-   - If you used the `[image.workflow] trigger = true` default, the cluster bootstrapper already
-     dispatched the workflow and downloaded the artifact for you—skip to step 2.
-   - Otherwise open [Actions → pi-image → Run workflow][pi-image], enable **token.place** and
-     **dspace** if you want those repos baked in, then download `sugarkube.img.xz` with
-     `scripts/download_pi_image.sh` or from the workflow run page.
-
-   Alternatively, build locally:
-   - Linux/macOS: `./scripts/build_pi_image.sh`
-   - Windows (PowerShell):
-     ```powershell
-     # Optional: increase WSL/WSL2 resources for Docker Desktop (recommended)
-     # File: C:\Users\<you>\.wslconfig
-     # [wsl2]
-     # memory=64GB
-     # processors=24
-     # swap=16GB
-     # localhostForwarding=true
-     # vmIdleTimeout=7200
-     # Then apply and rerun build:
-     wsl --shutdown
-
-     # Build the image
-     powershell -ExecutionPolicy Bypass -File .\scripts\build_pi_image.ps1
-     ```
-     Notes:
-     - Requires Docker Desktop running and Git for Windows installed
-     - The script auto-falls back to a Dockerized build and sets up binfmt/qemu
-     - Expect 45–120 minutes on Windows; ensure ≥30 GB free disk
-2. Verify the checksum: `sha256sum -c sugarkube.img.xz.sha256`
-3. Flash the image to a microSD card using Raspberry Pi Imager
-   - Set a unique hostname (e.g., `sugar-01`, `sugar-02`, `sugar-03`), enable SSH, and create a user
-     with a strong password.
-   - Press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd> to open advanced options and configure the
-     WiFi SSID, password, and locale.
-   - The same image can be reused for all nodes.
-
-## 2. Boot and clone to SSD
-1. Insert the card into a Pi on the carrier and power on with monitor or KVM attached
-2. Verify the NVMe drive shows up: `lsblk`
-3. Preview the clone plan: `sudo ./scripts/ssd_clone.py --target /dev/sda --dry-run`
-   (replace `/dev/sda` with your NVMe target).
-4. Execute the clone once you're comfortable with the plan: `sudo ./scripts/ssd_clone.py --target /dev/sda`
-   - If power hiccups or cables disconnect mid-transfer, rerun with `--resume` to continue
-     from the last completed step without restarting the whole clone.
-5. Shut down the Pi, remove the SD card, and power back on to confirm the SSD boots.
-
-## 3. Enable SSD boot (if needed)
-1. Run `sudo raspi-config` → Advanced Options → Boot Order → `NVMe/USB`
-2. Reboot and confirm `lsblk` shows the root filesystem on the SSD
-
-## 4. Repeat for remaining Pis
-Follow the steps above for each node so every Pi boots from its own SSD.
-
-## 5. Form the k3s cluster
-1. On the first Pi (control plane):
+4. On a server, copy the kubeconfig for workstation use:
    ```bash
-   curl -sfL https://get.k3s.io | sh -
+   just kubeconfig
    ```
-2. Note the node token in `/var/lib/rancher/k3s/server/node-token` (it is also copied
-   to `/boot/sugarkube-node-token`) and the Pi's IP address
-3. Before inviting other nodes, run a rehearsal from your workstation to confirm the token is
-   mirrored and workers can reach the API:
-   ```bash
-   make rehearse-join REHEARSAL_ARGS="sugar-control.local --agents sugar-worker-a.local sugar-worker-b.local"
-   ```
-   The helper prints the join command template and checks each worker for network reachability,
-   existing `k3s-agent` state, and leftover registration files.
-4. Happy path for a three-node cluster (one control-plane plus two workers):
-   ```bash
-   make cluster-up CLUSTER_ARGS="sugar-control.local --agents sugar-worker-a.local sugar-worker-b.local --apply --apply-wait"
-   ```
-   The automation aborts if a worker fails the preflight, executes the join command remotely when
-   the checks pass, and waits up to five minutes for every node to report `Ready`. Override the
-   timeout with `--apply-wait-timeout` when slower networks need more time.
-5. Prefer a manual join? Run the command emitted during the rehearsal on each worker:
-   ```bash
-   curl -sfL https://get.k3s.io | \
-   K3S_URL=https://<control-ip>:6443 K3S_TOKEN=<token> sh -
-   ```
-6. Check that all nodes are ready:
-   ```bash
-   sudo kubectl get nodes
-   ```
-7. (Optional) Copy `/boot/sugarkube-kubeconfig-full` to your workstation for remote
-   `kubectl` access.
+5. Need a fresh start? Run `just wipe` on the node you want to reset. This removes
+   k3s, tears down the Avahi advertisement, and restarts `avahi-daemon`.
 
-## 6. Deploy applications
-1. Clone the repositories:
-   ```bash
-   git clone https://github.com/futuroptimist/token.place.git
-   git clone https://github.com/democratizedspace/dspace.git
-   cd dspace && git checkout v3
-   ```
-2. Apply Kubernetes manifests or Helm charts to launch services:
-   ```bash
-   kubectl apply -f k8s/
-   ```
+Repeat the same flow for `int` and `prod` environments. Each label seeds a distinct
+cluster even on the same LAN because tokens and mDNS TXT markers stay scoped per
+environment.
 
-## 7. Expose with Cloudflare Tunnel
-1. Edit `/opt/sugarkube/docker-compose.cloudflared.yml` if needed (cloud-init installs it)
-2. Store the tunnel token in `/opt/sugarkube/.cloudflared.env`
-3. Start the tunnel service:
-   ```bash
-   sudo systemctl enable --now cloudflared-compose
-   ```
-4. Confirm the service is active:
-   ```bash
-   systemctl status cloudflared-compose --no-pager
-   ```
+## Configuration
 
-## 8. Create environments
-Use k3s namespaces `dev`, `int`, and `prod` to separate deployments.
-CI can promote images between namespaces after validation.
+Override these environment variables as needed:
 
-## 9. Promote to production
-Tag a release in the integration namespace as golden and deploy that tag to `prod`.
-Roll back by redeploying the previous known-good tag if needed.
+- `SUGARKUBE_CLUSTER` (default `sugar`): logical cluster prefix shared across
+  environments.
+- `SUGARKUBE_SERVERS` (default `1`): desired control-plane count per
+  environment. `1` keeps SQLite; three or more triggers embedded etcd.
+- `K3S_CHANNEL` (default `stable`): release channel passed to the
+  `get.k3s.io` installer.
+- `SUGARKUBE_TOKEN_{DEV,INT,PROD}`: per-environment join tokens. When unset the
+  helper falls back to `SUGARKUBE_TOKEN`.
 
-## Next steps
-Explore [network_setup.md](network_setup.md) for networking tips and
-[pi_image_cloudflare.md](pi_image_cloudflare.md) for details on exposing services securely.
+Set these inline with the `just` command or export them in `/etc/environment`
+when you want persistent defaults. Tokens gate registration, so generate
+distinct secrets per environment (for example with `openssl rand -hex 16`).
 
-[pi-image]: https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml
+## Networking Notes
+
+Avahi handles mDNS advertisements while `libnss-mdns` makes `.local` names resolve
+through NSS using the `mdns4_minimal` plugin. Keep UDP 5353 unblocked so discovery
+works. Servers publish themselves as `_https._tcp` port 6443 with TXT markers that
+include `cluster=<name>`, `env=<label>`, and `role=server`. Agents seed from the
+first discovered server hostname and then rely on K3s's embedded client-side load
+balancer to learn every control-plane endpoint, so DHCP address churn is safe as
+long as TLS SANs cover the `.local` names.
+
+## Topologies
+
+The default `SUGARKUBE_SERVERS=1` path brings up a single server backed by
+SQLite—no `--cluster-init`—which is ideal for quick dev clusters. When you need a
+high-availability control plane, set `SUGARKUBE_SERVERS=3` (or more) and run the
+same `just up <env>` command on each server-class Pi. The first node bootstraps
+embedded etcd with `--cluster-init`; subsequent servers join via the advertised
+`.local` hostname. Use NVMe SSDs (not SD cards) for etcd durability per the K3s
+requirements.
+
+For wiring diagrams, inventory, and manual recovery steps, continue to the
+[manual guide](raspi_cluster_setup_manual.md).

--- a/docs/raspi_cluster_setup_manual.md
+++ b/docs/raspi_cluster_setup_manual.md
@@ -1,0 +1,198 @@
+---
+personas:
+  - hardware
+  - software
+---
+
+# Raspberry Pi Cluster Setup Manual
+
+Looking for the shortest path? Start with
+[`raspi_cluster_setup.md`](raspi_cluster_setup.md). This companion manual preserves
+the full bill of materials, imaging steps, and manual k3s walkthrough for folks
+who prefer a detailed playbook or need recovery procedures.
+
+## Bill of Materials
+- 3 × Raspberry Pi 5 (8 GB recommended)
+- 3 × official Raspberry Pi M.2 HAT with NVMe SSDs
+- 1 × triple Pi carrier plate (see [pi_cluster_carrier.md](pi_cluster_carrier.md))
+- Active airflow. If you skip the carrier stack's built-in fan, position a small
+  desk fan so the boards stay below 60 °C—thermal throttling starts at 80 °C and
+  spot-checks fail above 60 °C.
+- Power supplies, standoffs, and required cables
+- MicroSD card for each node (8 GB minimum)
+- Optional KVM for shared keyboard, video, and mouse access
+
+## Prerequisites
+- A workstation with [Raspberry Pi Imager](https://www.raspberrypi.com/software/) installed
+- Basic networking knowledge. Review [network_setup.md](network_setup.md) for static IPs
+- SSH client (for example `ssh` on macOS/Linux or PuTTY on Windows)
+- Internet connection to download images and packages
+
+## Fast path: bootstrap all three nodes automatically
+1. Copy [`samples/pi-cluster/three-node.toml`](../samples/pi-cluster/three-node.toml)
+   to a writable directory and edit it to match your hardware:
+   - Update `device` entries with the removable drives for each Pi.
+   - Set `hostname`, Wi-Fi credentials, and SSH keys once and reuse them across nodes.
+   - Adjust the `cluster.join` section with your control-plane hostname or IPs.
+   - The sample ships with `[image.workflow] trigger = true`, so the helper
+     automatically dispatches the `pi-image` workflow, waits for the run to
+     finish, and downloads the artifact without leaving the terminal. Disable it
+     (`trigger = false`) when you already have a fresh image cached locally.
+2. Preview the workflow without touching hardware:
+   ```bash
+   python -m sugarkube_toolkit pi cluster --config ./cluster.toml --dry-run
+   ```
+   The helper prints the commands it would execute (download, flash, join) so you
+   can validate device paths and arguments before proceeding.
+3. Drop `--dry-run` when you're ready:
+   ```bash
+   python -m sugarkube_toolkit pi cluster --config ./cluster.toml
+   ```
+   The automation dispatches the `pi-image` workflow (when `image.workflow.trigger`
+   is enabled), waits for the build to complete, downloads the artifact (or reuses
+   an existing `install_sugarkube_image.sh` cache), flashes each SD card via
+   `flash_pi_media_report.py`, copies per-node cloud-init overrides that inject the
+   hostnames and Wi-Fi credentials you supplied, and finally runs
+   `pi_multi_node_join_rehearsal.py --apply` to bring the workers online. Use
+   `just cluster-bootstrap CLUSTER_BOOTSTRAP_ARGS="--config ./cluster.toml"` when
+   you prefer Just recipes.
+
+Skip to [§5](#5-form-the-k3s-cluster) after the helper completes—the control-plane
+and workers will already share the same image, hostname overrides, and join token.
+
+## 1. Prepare the OS image
+1. Trigger the build in GitHub:
+   - If you used the `[image.workflow] trigger = true` default, the cluster
+     bootstrapper already dispatched the workflow and downloaded the artifact for
+     you—skip to step 2.
+   - Otherwise open [Actions → pi-image → Run workflow][pi-image], enable
+     **token.place** and **dspace** if you want those repos baked in, then download
+     `sugarkube.img.xz` with `scripts/download_pi_image.sh` or from the workflow
+     run page.
+2. Alternatively, build locally:
+   - Linux/macOS: `./scripts/build_pi_image.sh`
+   - Windows (PowerShell):
+     ```powershell
+     # Optional: increase WSL/WSL2 resources for Docker Desktop (recommended)
+     # File: C:\\Users\\<you>\\.wslconfig
+     # [wsl2]
+     # memory=64GB
+     # processors=24
+     # swap=16GB
+     # localhostForwarding=true
+     # vmIdleTimeout=7200
+     # Then apply and rerun build:
+     wsl --shutdown
+
+     # Build the image
+     powershell -ExecutionPolicy Bypass -File .\\scripts\\build_pi_image.ps1
+     ```
+     Notes:
+     - Requires Docker Desktop running and Git for Windows installed
+     - The script auto-falls back to a Dockerized build and sets up binfmt/qemu
+     - Expect 45–120 minutes on Windows; ensure ≥30 GB free disk
+3. Verify the checksum: `sha256sum -c sugarkube.img.xz.sha256`
+4. Flash the image to a microSD card using Raspberry Pi Imager:
+   - Set a unique hostname (for example `sugar-01`, `sugar-02`, `sugar-03`),
+     enable SSH, and create a user with a strong password.
+   - Press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd> to open advanced options
+     and configure the Wi-Fi SSID, password, and locale.
+   - The same image can be reused for all nodes.
+
+## 2. Boot and clone to SSD
+1. Insert the card into a Pi on the carrier and power on with monitor or KVM attached.
+2. Verify the NVMe drive shows up: `lsblk`.
+3. Preview the clone plan:
+   ```bash
+   sudo ./scripts/ssd_clone.py --target /dev/sda --dry-run
+   ```
+   Replace `/dev/sda` with your NVMe target.
+4. Execute the clone once you're comfortable with the plan:
+   ```bash
+   sudo ./scripts/ssd_clone.py --target /dev/sda
+   ```
+   If power hiccups or cables disconnect mid-transfer, rerun with `--resume` to
+   continue from the last completed step without restarting the whole clone.
+5. Shut down the Pi, remove the SD card, and power back on to confirm the SSD boots.
+
+## 3. Enable SSD boot (if needed)
+1. Run `sudo raspi-config` → Advanced Options → Boot Order → `NVMe/USB`.
+2. Reboot and confirm `lsblk` shows the root filesystem on the SSD.
+
+## 4. Repeat for remaining Pis
+Follow the steps above for each node so every Pi boots from its own SSD.
+
+## 5. Form the k3s cluster
+1. On the first Pi (control plane):
+   ```bash
+   curl -sfL https://get.k3s.io | sh -
+   ```
+2. Note the node token in `/var/lib/rancher/k3s/server/node-token` (it is also
+   copied to `/boot/sugarkube-node-token`) and the Pi's IP address.
+3. Before inviting other nodes, run a rehearsal from your workstation to confirm
+   the token is mirrored and workers can reach the API:
+   ```bash
+   make rehearse-join REHEARSAL_ARGS="sugar-control.local --agents \
+   sugar-worker-a.local sugar-worker-b.local"
+   ```
+   The helper prints the join command template and checks each worker for network
+   reachability, existing `k3s-agent` state, and leftover registration files.
+4. Happy path for a three-node cluster (one control plane plus two workers):
+   ```bash
+   make cluster-up CLUSTER_ARGS="sugar-control.local --agents \
+   sugar-worker-a.local sugar-worker-b.local --apply --apply-wait"
+   ```
+   The automation aborts if a worker fails the preflight, executes the join
+   command remotely when the checks pass, and waits up to five minutes for every
+   node to report `Ready`. Override the timeout with `--apply-wait-timeout` when
+   slower networks need more time.
+5. Prefer a manual join? Run the command emitted during the rehearsal on each worker:
+   ```bash
+   curl -sfL https://get.k3s.io | \
+   K3S_URL=https://<control-ip>:6443 K3S_TOKEN=<token> sh -
+   ```
+6. Check that all nodes are ready:
+   ```bash
+   sudo kubectl get nodes
+   ```
+7. (Optional) Copy `/boot/sugarkube-kubeconfig-full` to your workstation for
+   remote `kubectl` access.
+
+## 6. Deploy applications
+1. Clone the repositories:
+   ```bash
+   git clone https://github.com/futuroptimist/token.place.git
+   git clone https://github.com/democratizedspace/dspace.git
+   cd dspace && git checkout v3
+   ```
+2. Apply Kubernetes manifests or Helm charts to launch services:
+   ```bash
+   kubectl apply -f k8s/
+   ```
+
+## 7. Expose with Cloudflare Tunnel
+1. Edit `/opt/sugarkube/docker-compose.cloudflared.yml` if needed (cloud-init installs it).
+2. Store the tunnel token in `/opt/sugarkube/.cloudflared.env`.
+3. Start the tunnel service:
+   ```bash
+   sudo systemctl enable --now cloudflared-compose
+   ```
+4. Confirm the service is active:
+   ```bash
+   systemctl status cloudflared-compose --no-pager
+   ```
+
+## 8. Create environments
+Use k3s namespaces `dev`, `int`, and `prod` to separate deployments. CI can
+promote images between namespaces after validation.
+
+## 9. Promote to production
+Tag a release in the integration namespace as golden and deploy that tag to
+`prod`. Roll back by redeploying the previous known-good tag if needed.
+
+## Next steps
+Explore [network_setup.md](network_setup.md) for networking tips and
+[pi_image_cloudflare.md](pi_image_cloudflare.md) for details on exposing services
+securely.
+
+[pi-image]: https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml

--- a/justfile
+++ b/justfile
@@ -1,4 +1,44 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
+set export
+
+export SUGARKUBE_CLUSTER := env('SUGARKUBE_CLUSTER', 'sugar')
+export SUGARKUBE_SERVERS := env('SUGARKUBE_SERVERS', '1')
+export K3S_CHANNEL := env('K3S_CHANNEL', 'stable')
+
+default: up
+
+up env='dev': prereqs
+    if [ "{{env}}" = "dev" ] && [ -n "${SUGARKUBE_TOKEN_DEV:-}" ]; then export SUGARKUBE_TOKEN="$SUGARKUBE_TOKEN_DEV"; fi
+    if [ "{{env}}" = "int" ] && [ -n "${SUGARKUBE_TOKEN_INT:-}" ]; then export SUGARKUBE_TOKEN="$SUGARKUBE_TOKEN_INT"; fi
+    if [ "{{env}}" = "prod" ] && [ -n "${SUGARKUBE_TOKEN_PROD:-}" ]; then export SUGARKUBE_TOKEN="$SUGARKUBE_TOKEN_PROD"; fi
+    export SUGARKUBE_ENV="{{env}}"
+    export SUGARKUBE_SERVERS="{{SUGARKUBE_SERVERS}}"
+    sudo -E bash scripts/k3s-discover.sh
+
+prereqs:
+    sudo apt-get update
+    sudo apt-get install -y \
+        avahi-daemon \
+        avahi-utils \
+        libnss-mdns \
+        curl \
+        jq
+    sudo systemctl enable --now avahi-daemon
+    if ! grep -q 'mdns4_minimal' /etc/nsswitch.conf; then sudo sed -i 's/^hosts:.*/hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4/' /etc/nsswitch.conf; fi
+
+status:
+    sudo k3s kubectl get nodes -o wide
+
+kubeconfig:
+    mkdir -p ~/.kube
+    sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+    sudo chown "$USER":"$USER" ~/.kube/config
+
+wipe:
+    if command -v k3s-uninstall.sh >/dev/null; then sudo k3s-uninstall.sh; fi
+    if command -v k3s-agent-uninstall.sh >/dev/null; then sudo k3s-agent-uninstall.sh; fi
+    sudo rm -f /etc/avahi/services/k3s-https.service || true
+    sudo systemctl restart avahi-daemon || true
 
 scripts_dir := justfile_directory() + "/scripts"
 image_dir := env_var_or_default("IMAGE_DIR", env_var("HOME") + "/sugarkube/images")
@@ -72,7 +112,7 @@ simplify_docs_args := env_var_or_default("SIMPLIFY_DOCS_ARGS", "")
 nvme_health_args := env_var_or_default("NVME_HEALTH_ARGS", "")
 
 _default:
-    @just --list
+    @just default
 
 help:
     @just --list

--- a/scripts/k3s-discover.sh
+++ b/scripts/k3s-discover.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER="${SUGARKUBE_CLUSTER:-sugar}"
+ENVIRONMENT="${SUGARKUBE_ENV:-dev}"
+SERVERS_DESIRED="${SUGARKUBE_SERVERS:-1}"
+
+case "${ENVIRONMENT}" in
+  dev) TOKEN="${SUGARKUBE_TOKEN_DEV:-${SUGARKUBE_TOKEN:-}}" ;;
+  int) TOKEN="${SUGARKUBE_TOKEN_INT:-${SUGARKUBE_TOKEN:-}}" ;;
+  prod) TOKEN="${SUGARKUBE_TOKEN_PROD:-${SUGARKUBE_TOKEN:-}}" ;;
+  *) TOKEN="${SUGARKUBE_TOKEN:-}" ;;
+esac
+
+if [ -z "${TOKEN:-}" ]; then
+  echo "SUGARKUBE_TOKEN (or per-env variant) required"
+  exit 1
+fi
+
+HN="$(hostname -s)"
+MDNS_HOST="${HN}.local"
+
+log() {
+  echo "[sugarkube ${CLUSTER}/${ENVIRONMENT}] $*"
+}
+
+discover_server_host() {
+  avahi-browse -rt _https._tcp 2>/dev/null \
+    | awk -F';' '/;_https._tcp;/{print}' \
+    | while IFS=';' read -r _ _ _ _ _ _ _ host _ port txt; do
+        if [ "${port}" = "6443" ] \
+          && echo "${txt}" | grep -q 'k3s=1' \
+          && echo "${txt}" | grep -q "cluster=${CLUSTER}" \
+          && echo "${txt}" | grep -q "env=${ENVIRONMENT}" \
+          && echo "${txt}" | grep -q 'role=server'; then
+          echo "${host}"
+          break
+        fi
+      done | head -n1
+}
+
+count_servers() {
+  avahi-browse -rt _https._tcp 2>/dev/null \
+    | awk -F';' '/;_https._tcp;/{print}' \
+    | grep ';6443;' \
+    | grep 'k3s=1' \
+    | grep "cluster=${CLUSTER}" \
+    | grep "env=${ENVIRONMENT}" \
+    | grep -c 'role=server'
+}
+
+publish_avahi_service() {
+  sudo tee /etc/avahi/services/k3s-https.service >/dev/null <<EOF_SERVICE
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">k3s API ${CLUSTER}/${ENVIRONMENT} on %h</name>
+  <service>
+    <type>_https._tcp</type>
+    <port>6443</port>
+    <txt-record>k3s=1</txt-record>
+    <txt-record>cluster=${CLUSTER}</txt-record>
+    <txt-record>env=${ENVIRONMENT}</txt-record>
+    <txt-record>role=server</txt-record>
+  </service>
+</service-group>
+EOF_SERVICE
+  sudo systemctl reload avahi-daemon || sudo systemctl restart avahi-daemon
+}
+
+install_server_single() {
+  log "Bootstrapping single-server (SQLite) ${CLUSTER}/${ENVIRONMENT} on ${MDNS_HOST}"
+  curl -sfL https://get.k3s.io \
+    | INSTALL_K3S_CHANNEL="${K3S_CHANNEL:-stable}" \
+      K3S_TOKEN="${TOKEN}" sh -s - server \
+      --tls-san "${MDNS_HOST}" \
+      --node-label "sugarkube.cluster=${CLUSTER}" \
+      --node-label "sugarkube.env=${ENVIRONMENT}" \
+      --node-taint "node-role.kubernetes.io/control-plane=true:NoSchedule"
+  publish_avahi_service
+}
+
+install_server_cluster_init() {
+  log "Bootstrapping first HA server (embedded etcd) ${CLUSTER}/${ENVIRONMENT} on ${MDNS_HOST}"
+  curl -sfL https://get.k3s.io \
+    | INSTALL_K3S_CHANNEL="${K3S_CHANNEL:-stable}" \
+      K3S_TOKEN="${TOKEN}" sh -s - server \
+      --cluster-init \
+      --tls-san "${MDNS_HOST}" \
+      --node-label "sugarkube.cluster=${CLUSTER}" \
+      --node-label "sugarkube.env=${ENVIRONMENT}" \
+      --node-taint "node-role.kubernetes.io/control-plane=true:NoSchedule"
+  publish_avahi_service
+}
+
+install_server_join() {
+  local server="$1"
+  log "Joining as additional HA server via https://${server}:6443 (desired servers=${SERVERS_DESIRED})"
+  curl -sfL https://get.k3s.io \
+    | INSTALL_K3S_CHANNEL="${K3S_CHANNEL:-stable}" \
+      K3S_TOKEN="${TOKEN}" sh -s - server \
+      --server "https://${server}:6443" \
+      --tls-san "${server}" \
+      --tls-san "${MDNS_HOST}" \
+      --node-label "sugarkube.cluster=${CLUSTER}" \
+      --node-label "sugarkube.env=${ENVIRONMENT}" \
+      --node-taint "node-role.kubernetes.io/control-plane=true:NoSchedule"
+  publish_avahi_service
+}
+
+install_agent() {
+  local server="$1"
+  log "Joining as agent via https://${server}:6443"
+  curl -sfL https://get.k3s.io \
+    | INSTALL_K3S_CHANNEL="${K3S_CHANNEL:-stable}" \
+      K3S_URL="https://${server}:6443" \
+      K3S_TOKEN="${TOKEN}" sh -s - agent \
+      --node-label "sugarkube.cluster=${CLUSTER}" \
+      --node-label "sugarkube.env=${ENVIRONMENT}"
+}
+
+log "Discovering existing k3s API for ${CLUSTER}/${ENVIRONMENT} via mDNS..."
+server_host="$(discover_server_host || true)"
+if [ -z "${server_host:-}" ]; then
+  sleep $((RANDOM % 20 + 5))
+  server_host="$(discover_server_host || true)"
+fi
+
+if [ -z "${server_host:-}" ]; then
+  if [ "${SERVERS_DESIRED}" = "1" ]; then
+    install_server_single
+  else
+    install_server_cluster_init
+  fi
+else
+  servers_now="$(count_servers)"
+  if [ "${servers_now}" -lt "${SERVERS_DESIRED}" ]; then
+    install_server_join "${server_host}"
+  else
+    install_agent "${server_host}"
+  fi
+fi
+
+if [ -f /etc/rancher/k3s/k3s.yaml ]; then
+  sudo mkdir -p /root/.kube
+  sudo cp /etc/rancher/k3s/k3s.yaml /root/.kube/config
+fi


### PR DESCRIPTION
## Summary
- add an environment-scoped `just up <env>` workflow with exported cluster defaults, prereqs, and helpers
- teach Pis to discover and advertise k3s APIs over mDNS with TLS SANs so DHCP churn is safe, tainting servers automatically
- streamline the Raspberry Pi cluster docs into a quick-start plus detailed manual and link the flow from the spot-check guide

## Testing
- `shellcheck scripts/k3s-discover.sh`
- `just --list`

## Security & Operability
- Node registration still requires tokens; set distinct values via `SUGARKUBE_TOKEN_{DEV,INT,PROD}` to scope access per environment.
- Agents learn all servers after initial join; add a VIP or DNS alias later if you want a fixed registration endpoint.

## References
- https://docs.k3s.io/cli/server
- https://docs.k3s.io/cli/agent
- https://docs.k3s.io/architecture
- https://docs.k3s.io/datastore/ha-embedded
- https://docs.k3s.io/datastore/cluster-loadbalancer
- https://docs.k3s.io/datastore/ha
- https://docs.k3s.io/reference/env-variables
- https://wiki.archlinux.org/title/Avahi
- https://www.rfc-editor.org/rfc/rfc6762
- https://docs.k3s.io/installation/requirements
- https://just.systems/man/en/functions.html
- https://just.systems/man/en/recipe-parameters.html
- https://just.systems/man/en/the-default-recipe.html

------
https://chatgpt.com/codex/tasks/task_e_68f5be723988832fae7fc2b7221dbb4b