### PR TITLE
k3s on Pis with one just up <env>: mDNS discovery + DHCP-friendly .local + env-scoped clustering

### DIFF
--- a/docs/raspi-image-spot-check.md
+++ b/docs/raspi-image-spot-check.md
@@ -12,6 +12,8 @@ sudo just spot-check
 The console output lists each section with ✅/⚠️/❌ markers; the same information is
 mirrored in `artifacts/spot-check/summary.{json,md}` for archival.
 
+> Next step: [cluster bring-up](raspi_cluster_setup.md)
+
 ## Required success criteria
 
 | Area | Expectation |

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -6,180 +6,75 @@ personas:
 
 # Raspberry Pi Cluster Setup
 
-This expanded guide walks through building a three-node Raspberry Pi 5 cluster and installing k3s
-so you can run [token.place](https://github.com/futuroptimist/token.place) and
-[dspace](https://github.com/democratizedspace/dspace). It assumes basic familiarity with the
-Linux command line.
+This quick path keeps sugarkube's "syntactic sugar" promise: one command per node and sane
+defaults. The detailed, step-by-step walkthrough now lives in
+[raspi_cluster_setup_manual.md](raspi_cluster_setup_manual.md).
 
-## Bill of Materials
-- 3 × Raspberry Pi 5 (8 GB recommended)
-- 3 × official Raspberry Pi M.2 HAT with NVMe SSDs
-- 1 × triple Pi carrier plate (see [pi_cluster_carrier.md](pi_cluster_carrier.md))
-- Active airflow. If you skip the carrier stack's built-in fan, position a small desk fan so the
-  boards stay below 60 °C—thermal throttling starts at 80 °C and spot-checks fail above 60 °C.
-- Power supplies, standoffs, and required cables
-- MicroSD card for each node (8 GB minimum)
-- Optional KVM for shared keyboard, video, and mouse access
+## Quick Start (same subnet; DHCP OK)
 
-## Prerequisites
-- A workstation with [Raspberry Pi Imager](https://www.raspberrypi.com/software/) installed
-- Basic networking knowledge. Review [network_setup.md](network_setup.md) for static IPs
-- SSH client (e.g. `ssh` on macOS/Linux or PuTTY on Windows)
-- Internet connection to download images and packages
+These steps assume all Pis sit on the same Layer 2 network where multicast (UDP port 5353) is
+permitted for mDNS. Provide a unique registration token for each environment (`dev`, `int`,
+`prod`) by exporting it before running the commands below (for example
+`export SUGARKUBE_TOKEN_DEV=...`).
 
-## Fast path: bootstrap all three nodes automatically
-1. Copy [`samples/pi-cluster/three-node.toml`](../samples/pi-cluster/three-node.toml) to a
-   writable directory and edit it to match your hardware:
-   - Update `device` entries with the removable drives for each Pi.
-   - Set `hostname`, Wi-Fi credentials, and SSH keys once and reuse them across nodes.
-   - Adjust the `cluster.join` section with your control-plane hostname or IPs.
-   - The sample now ships with `[image.workflow] trigger = true`, so the helper automatically
-     dispatches the `pi-image` workflow, waits for the run to finish, and downloads the artifact
-     without leaving the terminal. Disable it (`trigger = false`) when you already have a fresh
-     image cached locally.
-2. Preview the workflow without touching hardware:
+1. Power on a Raspberry Pi and sign in. The first `just up <env>` invocation on that environment
+   bootstraps the control-plane:
+
    ```bash
-   python -m sugarkube_toolkit pi cluster --config ./cluster.toml --dry-run
-   ```
-   The helper prints the commands it would execute (download, flash, join) so you can validate
-   device paths and arguments before proceeding.
-3. Drop `--dry-run` when you're ready:
-   ```bash
-   python -m sugarkube_toolkit pi cluster --config ./cluster.toml
-   ```
-   The automation dispatches the `pi-image` workflow (when `image.workflow.trigger` is enabled),
-   waits for the build to complete, downloads the artifact (or reuses an existing
-   `install_sugarkube_image.sh` cache), flashes each SD card via `flash_pi_media_report.py`, copies
-   per-node cloud-init overrides that inject the hostnames and Wi-Fi credentials you supplied, and
-   finally runs `pi_multi_node_join_rehearsal.py --apply` to bring the workers online. Use
-   `just cluster-bootstrap CLUSTER_BOOTSTRAP_ARGS="--config ./cluster.toml"` when you prefer Just
-   recipes.
-
-Skip to [§5](#5-form-the-k3s-cluster) after the helper completes—the control-plane and workers
-will already share the same image, hostname overrides, and join token.
-
-## 1. Prepare the OS image
-1. Trigger the build in GitHub:
-   - If you used the `[image.workflow] trigger = true` default, the cluster bootstrapper already
-     dispatched the workflow and downloaded the artifact for you—skip to step 2.
-   - Otherwise open [Actions → pi-image → Run workflow][pi-image], enable **token.place** and
-     **dspace** if you want those repos baked in, then download `sugarkube.img.xz` with
-     `scripts/download_pi_image.sh` or from the workflow run page.
-
-   Alternatively, build locally:
-   - Linux/macOS: `./scripts/build_pi_image.sh`
-   - Windows (PowerShell):
-     ```powershell
-     # Optional: increase WSL/WSL2 resources for Docker Desktop (recommended)
-     # File: C:\Users\<you>\.wslconfig
-     # [wsl2]
-     # memory=64GB
-     # processors=24
-     # swap=16GB
-     # localhostForwarding=true
-     # vmIdleTimeout=7200
-     # Then apply and rerun build:
-     wsl --shutdown
-
-     # Build the image
-     powershell -ExecutionPolicy Bypass -File .\scripts\build_pi_image.ps1
-     ```
-     Notes:
-     - Requires Docker Desktop running and Git for Windows installed
-     - The script auto-falls back to a Dockerized build and sets up binfmt/qemu
-     - Expect 45–120 minutes on Windows; ensure ≥30 GB free disk
-2. Verify the checksum: `sha256sum -c sugarkube.img.xz.sha256`
-3. Flash the image to a microSD card using Raspberry Pi Imager
-   - Set a unique hostname (e.g., `sugar-01`, `sugar-02`, `sugar-03`), enable SSH, and create a user
-     with a strong password.
-   - Press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd> to open advanced options and configure the
-     WiFi SSID, password, and locale.
-   - The same image can be reused for all nodes.
-
-## 2. Boot and clone to SSD
-1. Insert the card into a Pi on the carrier and power on with monitor or KVM attached
-2. Verify the NVMe drive shows up: `lsblk`
-3. Preview the clone plan: `sudo ./scripts/ssd_clone.py --target /dev/sda --dry-run`
-   (replace `/dev/sda` with your NVMe target).
-4. Execute the clone once you're comfortable with the plan: `sudo ./scripts/ssd_clone.py --target /dev/sda`
-   - If power hiccups or cables disconnect mid-transfer, rerun with `--resume` to continue
-     from the last completed step without restarting the whole clone.
-5. Shut down the Pi, remove the SD card, and power back on to confirm the SSD boots.
-
-## 3. Enable SSD boot (if needed)
-1. Run `sudo raspi-config` → Advanced Options → Boot Order → `NVMe/USB`
-2. Reboot and confirm `lsblk` shows the root filesystem on the SSD
-
-## 4. Repeat for remaining Pis
-Follow the steps above for each node so every Pi boots from its own SSD.
-
-## 5. Form the k3s cluster
-1. On the first Pi (control plane):
-   ```bash
-   curl -sfL https://get.k3s.io | sh -
-   ```
-2. Note the node token in `/var/lib/rancher/k3s/server/node-token` (it is also copied
-   to `/boot/sugarkube-node-token`) and the Pi's IP address
-3. Before inviting other nodes, run a rehearsal from your workstation to confirm the token is
-   mirrored and workers can reach the API:
-   ```bash
-   make rehearse-join REHEARSAL_ARGS="sugar-control.local --agents sugar-worker-a.local sugar-worker-b.local"
-   ```
-   The helper prints the join command template and checks each worker for network reachability,
-   existing `k3s-agent` state, and leftover registration files.
-4. Happy path for a three-node cluster (one control-plane plus two workers):
-   ```bash
-   make cluster-up CLUSTER_ARGS="sugar-control.local --agents sugar-worker-a.local sugar-worker-b.local --apply --apply-wait"
-   ```
-   The automation aborts if a worker fails the preflight, executes the join command remotely when
-   the checks pass, and waits up to five minutes for every node to report `Ready`. Override the
-   timeout with `--apply-wait-timeout` when slower networks need more time.
-5. Prefer a manual join? Run the command emitted during the rehearsal on each worker:
-   ```bash
-   curl -sfL https://get.k3s.io | \
-   K3S_URL=https://<control-ip>:6443 K3S_TOKEN=<token> sh -
-   ```
-6. Check that all nodes are ready:
-   ```bash
-   sudo kubectl get nodes
-   ```
-7. (Optional) Copy `/boot/sugarkube-kubeconfig-full` to your workstation for remote
-   `kubectl` access.
-
-## 6. Deploy applications
-1. Clone the repositories:
-   ```bash
-   git clone https://github.com/futuroptimist/token.place.git
-   git clone https://github.com/democratizedspace/dspace.git
-   cd dspace && git checkout v3
-   ```
-2. Apply Kubernetes manifests or Helm charts to launch services:
-   ```bash
-   kubectl apply -f k8s/
+   just up dev
    ```
 
-## 7. Expose with Cloudflare Tunnel
-1. Edit `/opt/sugarkube/docker-compose.cloudflared.yml` if needed (cloud-init installs it)
-2. Store the tunnel token in `/opt/sugarkube/.cloudflared.env`
-3. Start the tunnel service:
-   ```bash
-   sudo systemctl enable --now cloudflared-compose
-   ```
-4. Confirm the service is active:
-   ```bash
-   systemctl status cloudflared-compose --no-pager
-   ```
+2. Repeat `just up dev` on two more Pis. They discover the control-plane over mDNS, then join as
+   agents. The server advertises itself as `<hostname>.local` and agents keep following it even if
+   the DHCP lease changes.
+3. For `int` and `prod`, rerun the same command with the matching environment. Each environment
+   uses its own join token, hostname scope, and node labels, so clusters remain isolated even on the
+   same switch.
 
-## 8. Create environments
-Use k3s namespaces `dev`, `int`, and `prod` to separate deployments.
-CI can promote images between namespaces after validation.
+### Handy helpers
 
-## 9. Promote to production
-Tag a release in the integration namespace as golden and deploy that tag to `prod`.
-Roll back by redeploying the previous known-good tag if needed.
+- `just status` — display node readiness with wide columns (requires running on a server).
+- `just kubeconfig` — copy `/etc/rancher/k3s/k3s.yaml` into `~/.kube/config` and chown it to the
+  logged-in user.
+- `just wipe` — remove k3s binaries, stop advertising the API over mDNS, and
+  reset Avahi. Useful when repurposing a node.
 
-## Next steps
-Explore [network_setup.md](network_setup.md) for networking tips and
-[pi_image_cloudflare.md](pi_image_cloudflare.md) for details on exposing services securely.
+## Configuration
 
-[pi-image]: https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml
+All knobs are exported via the Justfile and can be overridden through environment variables:
+
+- `SUGARKUBE_CLUSTER` — cluster name advertised over mDNS and stored in node labels. Defaults to
+  `sugar`.
+- `SUGARKUBE_SERVERS` — desired control-plane count per environment. Defaults to `1` (single server
+  on SQLite). Set to `3` or more to enable embedded etcd.
+- `K3S_CHANNEL` — release channel passed to the official `get.k3s.io` installer. Defaults to
+  `stable`.
+- `SUGARKUBE_TOKEN_DEV`, `SUGARKUBE_TOKEN_INT`, `SUGARKUBE_TOKEN_PROD` — preferred join tokens per
+  environment. If unset, the automation falls back to `SUGARKUBE_TOKEN`.
+
+Tokens gate node registration; rotate them when recycling hardware between environments.
+
+## Networking Notes
+
+- Each run installs Avahi (`avahi-daemon`, `avahi-utils`) and `libnss-mdns` so `.local` hostnames
+  resolve correctly. The Just recipe also updates `/etc/nsswitch.conf` to include `mdns4_minimal
+  [NOTFOUND=return]` before DNS.
+- The control-plane publishes the Kubernetes API via Bonjour/mDNS as `_https._tcp` on port 6443
+  with TXT records identifying the cluster, environment, and server role.
+- Servers add their own `<hostname>.local` entry to the TLS Subject Alternative Names list so
+  clients remain trusted after DHCP leases move.
+- Agents initially target the discovered server's hostname, then rely on k3s' embedded
+  client-side load balancer to learn about every server endpoint and fail over automatically.
+
+## Topologies
+
+- **Single server (default)** — when `SUGARKUBE_SERVERS=1`, k3s stays on SQLite and avoids
+  `--cluster-init`. The server taints itself
+  (`node-role.kubernetes.io/control-plane=true:NoSchedule`) so workloads land on agents by default.
+- **Highly available control-plane** — set `SUGARKUBE_SERVERS` to `3` (or any odd number ≥3). The
+  first server in that environment starts with `--cluster-init` to launch embedded etcd; subsequent
+  servers join via the discovered hostname. Use SSDs instead of SD cards for the etcd datastore on
+  Raspberry Pis to keep latency and write endurance in a safe range.
+
+Need the full nuts-and-bolts procedure? Jump to
+[raspi_cluster_setup_manual.md](raspi_cluster_setup_manual.md).

--- a/docs/raspi_cluster_setup_manual.md
+++ b/docs/raspi_cluster_setup_manual.md
@@ -1,0 +1,191 @@
+---
+personas:
+  - hardware
+  - software
+---
+
+# Raspberry Pi Cluster Setup (Manual Path)
+
+Prefer the sugar-coated flow? Start with [raspi_cluster_setup.md](raspi_cluster_setup.md) for the
+one-command bring-up. This manual retains the previous deep-dive with every preparatory and
+verification step spelled out.
+
+## Bill of Materials
+- 3 × Raspberry Pi 5 (8 GB recommended)
+- 3 × official Raspberry Pi M.2 HAT with NVMe SSDs
+- 1 × triple Pi carrier plate (see [pi_cluster_carrier.md](pi_cluster_carrier.md))
+- Active airflow. If you skip the carrier stack's built-in fan, position a small desk fan so the
+  boards stay below 60 °C—thermal throttling starts at 80 °C and spot-checks fail above 60 °C.
+- Power supplies, standoffs, and required cables
+- MicroSD card for each node (8 GB minimum)
+- Optional KVM for shared keyboard, video, and mouse access
+
+## Prerequisites
+- A workstation with [Raspberry Pi Imager](https://www.raspberrypi.com/software/) installed
+- Basic networking knowledge. Review [network_setup.md](network_setup.md) for static IPs
+- SSH client (e.g. `ssh` on macOS/Linux or PuTTY on Windows)
+- Internet connection to download images and packages
+
+## Fast path: bootstrap all three nodes automatically
+1. Copy [`samples/pi-cluster/three-node.toml`](../samples/pi-cluster/three-node.toml) to a
+   writable directory and edit it to match your hardware:
+   - Update `device` entries with the removable drives for each Pi.
+   - Set `hostname`, Wi-Fi credentials, and SSH keys once and reuse them across nodes.
+   - Adjust the `cluster.join` section with your control-plane hostname or IPs.
+   - The sample now ships with `[image.workflow] trigger = true`, so the helper automatically
+     dispatches the `pi-image` workflow, waits for the run to finish, and downloads the artifact
+     without leaving the terminal. Disable it (`trigger = false`) when you already have a fresh
+     image cached locally.
+2. Preview the workflow without touching hardware:
+   ```bash
+   python -m sugarkube_toolkit pi cluster --config ./cluster.toml --dry-run
+   ```
+   The helper prints the commands it would execute (download, flash, join) so you can validate
+   device paths and arguments before proceeding.
+3. Drop `--dry-run` when you're ready:
+   ```bash
+   python -m sugarkube_toolkit pi cluster --config ./cluster.toml
+   ```
+   The automation dispatches the `pi-image` workflow (when `image.workflow.trigger` is enabled),
+   waits for the build to complete, downloads the artifact (or reuses an existing
+   `install_sugarkube_image.sh` cache), flashes each SD card via `flash_pi_media_report.py`, copies
+   per-node cloud-init overrides that inject the hostnames and Wi-Fi credentials you supplied, and
+   finally runs `pi_multi_node_join_rehearsal.py --apply` to bring the workers online. Use
+   `just cluster-bootstrap CLUSTER_BOOTSTRAP_ARGS="--config ./cluster.toml"` when you prefer Just
+   recipes.
+
+Skip to [§5](#5-form-the-k3s-cluster) after the helper completes—the control-plane and workers
+will already share the same image, hostname overrides, and join token.
+
+## 1. Prepare the OS image
+1. Trigger the build in GitHub:
+   - If you used the `[image.workflow] trigger = true` default, the cluster bootstrapper already
+     dispatched the workflow and downloaded the artifact for you—skip to step 2.
+   - Otherwise open [Actions → pi-image → Run workflow][pi-image], enable **token.place** and
+     **dspace** if you want those repos baked in, then download `sugarkube.img.xz` with
+     `scripts/download_pi_image.sh` or from the workflow run page.
+
+   Alternatively, build locally:
+   - Linux/macOS: `./scripts/build_pi_image.sh`
+   - Windows (PowerShell):
+     ```powershell
+     # Optional: increase WSL/WSL2 resources for Docker Desktop (recommended)
+     # File: C:\Users\<you>\.wslconfig
+     # [wsl2]
+     # memory=64GB
+     # processors=24
+     # swap=16GB
+     # localhostForwarding=true
+     # vmIdleTimeout=7200
+     # Then apply and rerun build:
+     wsl --shutdown
+
+     # Build the image
+     powershell -ExecutionPolicy Bypass -File .\scripts\build_pi_image.ps1
+     ```
+     Notes:
+     - Requires Docker Desktop running and Git for Windows installed
+     - The script auto-falls back to a Dockerized build and sets up binfmt/qemu
+     - Expect 45–120 minutes on Windows; ensure ≥30 GB free disk
+2. Verify the checksum: `sha256sum -c sugarkube.img.xz.sha256`
+3. Flash the image to a microSD card using Raspberry Pi Imager
+   - Set a unique hostname (e.g., `sugar-01`, `sugar-02`, `sugar-03`), enable SSH, and create a user
+     with a strong password.
+   - Press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd> to open advanced options and configure the
+     WiFi SSID, password, and locale.
+   - The same image can be reused for all nodes.
+
+## 2. Boot and clone to SSD
+1. Insert the card into a Pi on the carrier and power on with monitor or KVM attached
+2. Verify the NVMe drive shows up: `lsblk`
+3. Preview the clone plan: `sudo ./scripts/ssd_clone.py --target /dev/sda --dry-run`
+   (replace `/dev/sda` with your NVMe target).
+4. Execute the clone once you're comfortable with the plan:
+   ```bash
+   sudo ./scripts/ssd_clone.py --target /dev/sda
+   ```
+   - If power hiccups or cables disconnect mid-transfer, rerun with `--resume` to continue
+     from the last completed step without restarting the whole clone.
+5. Shut down the Pi, remove the SD card, and power back on to confirm the SSD boots.
+
+## 3. Enable SSD boot (if needed)
+1. Run `sudo raspi-config` → Advanced Options → Boot Order → `NVMe/USB`
+2. Reboot and confirm `lsblk` shows the root filesystem on the SSD
+
+## 4. Repeat for remaining Pis
+Follow the steps above for each node so every Pi boots from its own SSD.
+
+## 5. Form the k3s cluster
+1. On the first Pi (control plane):
+   ```bash
+   curl -sfL https://get.k3s.io | sh -
+   ```
+2. Note the node token in `/var/lib/rancher/k3s/server/node-token` (it is also copied
+   to `/boot/sugarkube-node-token`) and the Pi's IP address
+3. Before inviting other nodes, run a rehearsal from your workstation to confirm the token is
+   mirrored and workers can reach the API:
+    ```bash
+    make rehearse-join \
+      REHEARSAL_ARGS="sugar-control.local --agents sugar-worker-a.local "\
+      "sugar-worker-b.local"
+    ```
+   The helper prints the join command template and checks each worker for network reachability,
+   existing `k3s-agent` state, and leftover registration files.
+4. Happy path for a three-node cluster (one control-plane plus two workers):
+    ```bash
+    make cluster-up \
+      CLUSTER_ARGS="sugar-control.local --agents sugar-worker-a.local sugar-worker-b.local "\
+      "--apply --apply-wait"
+    ```
+   The automation aborts if a worker fails the preflight, executes the join command remotely when
+   the checks pass, and waits up to five minutes for every node to report `Ready`. Override the
+   timeout with `--apply-wait-timeout` when slower networks need more time.
+5. Prefer a manual join? Run the command emitted during the rehearsal on each worker:
+   ```bash
+   curl -sfL https://get.k3s.io | \
+   K3S_URL=https://<control-ip>:6443 K3S_TOKEN=<token> sh -
+   ```
+6. Check that all nodes are ready:
+   ```bash
+   sudo kubectl get nodes
+   ```
+7. (Optional) Copy `/boot/sugarkube-kubeconfig-full` to your workstation for remote
+   `kubectl` access.
+
+## 6. Deploy applications
+1. Clone the repositories:
+   ```bash
+   git clone https://github.com/futuroptimist/token.place.git
+   git clone https://github.com/democratizedspace/dspace.git
+   cd dspace && git checkout v3
+   ```
+2. Apply Kubernetes manifests or Helm charts to launch services:
+   ```bash
+   kubectl apply -f k8s/
+   ```
+
+## 7. Expose with Cloudflare Tunnel
+1. Edit `/opt/sugarkube/docker-compose.cloudflared.yml` if needed (cloud-init installs it)
+2. Store the tunnel token in `/opt/sugarkube/.cloudflared.env`
+3. Start the tunnel service:
+   ```bash
+   sudo systemctl enable --now cloudflared-compose
+   ```
+4. Confirm the service is active:
+   ```bash
+   systemctl status cloudflared-compose --no-pager
+   ```
+
+## 8. Create environments
+Use k3s namespaces `dev`, `int`, and `prod` to separate deployments.
+CI can promote images between namespaces after validation.
+
+## 9. Promote to production
+Tag a release in the integration namespace as golden and deploy that tag to `prod`.
+Roll back by redeploying the previous known-good tag if needed.
+
+## Next steps
+Explore [network_setup.md](network_setup.md) for networking tips and
+[pi_image_cloudflare.md](pi_image_cloudflare.md) for details on exposing services securely.
+
+[pi-image]: https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml

--- a/scripts/k3s-discover.sh
+++ b/scripts/k3s-discover.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER="${SUGARKUBE_CLUSTER:-sugar}"
+ENVIRONMENT="${SUGARKUBE_ENV:-dev}"
+SERVERS_DESIRED="${SUGARKUBE_SERVERS:-1}"
+
+case "${ENVIRONMENT}" in
+  dev)
+    TOKEN="${SUGARKUBE_TOKEN_DEV:-${SUGARKUBE_TOKEN:-}}"
+    ;;
+  int)
+    TOKEN="${SUGARKUBE_TOKEN_INT:-${SUGARKUBE_TOKEN:-}}"
+    ;;
+  prod)
+    TOKEN="${SUGARKUBE_TOKEN_PROD:-${SUGARKUBE_TOKEN:-}}"
+    ;;
+  *)
+    TOKEN="${SUGARKUBE_TOKEN:-}"
+    ;;
+esac
+
+if [ -z "${TOKEN:-}" ]; then
+  echo "SUGARKUBE_TOKEN (or per-env variant) required" >&2
+  exit 1
+fi
+
+HN="$(hostname -s)"
+MDNS_HOST="${HN}.local"
+
+log() {
+  echo "[sugarkube ${CLUSTER}/${ENVIRONMENT}] $*"
+}
+
+discover_server_host() {
+  avahi-browse -rt _https._tcp 2>/dev/null \
+    | awk -F';' '/;_https._tcp;/{print}' \
+    | while IFS=';' read -r _ _ _ _ _ _ _ host _ port txt; do
+        if [ "${port}" = "6443" ] \
+          && echo "${txt}" | grep -q 'k3s=1' \
+          && echo "${txt}" | grep -q "cluster=${CLUSTER}" \
+          && echo "${txt}" | grep -q "env=${ENVIRONMENT}" \
+          && echo "${txt}" | grep -q 'role=server'; then
+          echo "${host}"
+          break
+        fi
+      done \
+    | head -n1
+}
+
+count_servers() {
+  avahi-browse -rt _https._tcp 2>/dev/null \
+    | awk -F';' -v cluster="${CLUSTER}" -v env="${ENVIRONMENT}" '
+        /;_https._tcp;/ {
+          port = $10
+          txt = $0
+          if (port == "6443" &&
+              index(txt, "k3s=1") &&
+              index(txt, "cluster=" cluster) &&
+              index(txt, "env=" env) &&
+              index(txt, "role=server")) {
+            count++
+          }
+        }
+        END { print count + 0 }
+      '
+}
+
+publish_avahi_service() {
+  sudo tee /etc/avahi/services/k3s-https.service >/dev/null <<EOF
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">k3s API ${CLUSTER}/${ENVIRONMENT} on %h</name>
+  <service>
+    <type>_https._tcp</type>
+    <port>6443</port>
+    <txt-record>k3s=1</txt-record>
+    <txt-record>cluster=${CLUSTER}</txt-record>
+    <txt-record>env=${ENVIRONMENT}</txt-record>
+    <txt-record>role=server</txt-record>
+  </service>
+</service-group>
+EOF
+  sudo systemctl reload avahi-daemon || sudo systemctl restart avahi-daemon
+}
+
+install_server_single() {
+  log "Bootstrapping single-server (SQLite) ${CLUSTER}/${ENVIRONMENT} on ${MDNS_HOST}"
+  curl -sfL https://get.k3s.io \
+    | INSTALL_K3S_CHANNEL="${K3S_CHANNEL:-stable}" \
+      K3S_TOKEN="${TOKEN}" sh -s - server \
+      --tls-san "${MDNS_HOST}" \
+      --node-label "sugarkube.cluster=${CLUSTER}" \
+      --node-label "sugarkube.env=${ENVIRONMENT}" \
+      --node-taint "node-role.kubernetes.io/control-plane=true:NoSchedule"
+  publish_avahi_service
+}
+
+install_server_cluster_init() {
+  log "Bootstrapping first HA server (embedded etcd) ${CLUSTER}/${ENVIRONMENT} on ${MDNS_HOST}"
+  curl -sfL https://get.k3s.io \
+    | INSTALL_K3S_CHANNEL="${K3S_CHANNEL:-stable}" \
+      K3S_TOKEN="${TOKEN}" sh -s - server \
+      --cluster-init \
+      --tls-san "${MDNS_HOST}" \
+      --node-label "sugarkube.cluster=${CLUSTER}" \
+      --node-label "sugarkube.env=${ENVIRONMENT}" \
+      --node-taint "node-role.kubernetes.io/control-plane=true:NoSchedule"
+  publish_avahi_service
+}
+
+install_server_join() {
+  local server="$1"
+  log "Joining HA server via https://${server}:6443 (target=${SERVERS_DESIRED})"
+  curl -sfL https://get.k3s.io \
+    | INSTALL_K3S_CHANNEL="${K3S_CHANNEL:-stable}" \
+      K3S_TOKEN="${TOKEN}" sh -s - server \
+      --server "https://${server}:6443" \
+      --tls-san "${server}" \
+      --tls-san "${MDNS_HOST}" \
+      --node-label "sugarkube.cluster=${CLUSTER}" \
+      --node-label "sugarkube.env=${ENVIRONMENT}" \
+      --node-taint "node-role.kubernetes.io/control-plane=true:NoSchedule"
+  publish_avahi_service
+}
+
+install_agent() {
+  local server="$1"
+  log "Joining as agent via https://${server}:6443"
+  curl -sfL https://get.k3s.io \
+    | INSTALL_K3S_CHANNEL="${K3S_CHANNEL:-stable}" \
+      K3S_URL="https://${server}:6443" \
+      K3S_TOKEN="${TOKEN}" sh -s - agent \
+      --node-label "sugarkube.cluster=${CLUSTER}" \
+      --node-label "sugarkube.env=${ENVIRONMENT}"
+}
+
+log "Discovering existing k3s API for ${CLUSTER}/${ENVIRONMENT} via mDNS..."
+server_host="$(discover_server_host || true)"
+if [ -z "${server_host:-}" ]; then
+  sleep $((RANDOM % 20 + 5))
+  server_host="$(discover_server_host || true)"
+fi
+
+if [ -z "${server_host:-}" ]; then
+  if [ "${SERVERS_DESIRED}" = "1" ]; then
+    install_server_single
+  else
+    install_server_cluster_init
+  fi
+else
+  servers_now="$(count_servers)"
+  if [ "${servers_now}" -lt "${SERVERS_DESIRED}" ]; then
+    install_server_join "${server_host}"
+  else
+    install_agent "${server_host}"
+  fi
+fi
+
+if [ -f /etc/rancher/k3s/k3s.yaml ]; then
+  sudo mkdir -p /root/.kube
+  sudo cp /etc/rancher/k3s/k3s.yaml /root/.kube/config
+fi


### PR DESCRIPTION
## Summary
- add env-scoped `just up` flow with exported defaults and helper recipes
- add `k3s-discover.sh` to bootstrap or join nodes via mDNS with hostname SANs
- streamline Raspberry Pi cluster docs; move detailed walkthrough into a manual

## Testing
- `shellcheck scripts/k3s-discover.sh`
- `just --list`
- `pyspelling -c .spellcheck.yaml`
- `linkchecker --no-warnings README.md docs/`
- `pre-commit run --all-files` *(fails: existing line-length errors in scripts/ssd_clone.py)*
- `SKIP=run-checks pre-commit run --all-files`

## Security
- Node registration still requires per-environment tokens; rotate them when recycling Pis.
- Agents seed from one hostname and rely on the K3s client-side load balancer for failover.

## References
- [K3s server CLI](https://docs.k3s.io/cli/server)
- [K3s agent CLI](https://docs.k3s.io/cli/agent)
- [K3s architecture](https://docs.k3s.io/architecture)
- [K3s HA with embedded etcd](https://docs.k3s.io/datastore/ha-embedded)
- [K3s cluster load balancer](https://docs.k3s.io/datastore/cluster-loadbalancer)
- [K3s datastore HA guidance](https://docs.k3s.io/datastore/ha)
- [K3s install env vars & quick start](https://docs.k3s.io/reference/env-variables)
- [K3s installation requirements](https://docs.k3s.io/installation/requirements)
- [Avahi overview](https://wiki.archlinux.org/title/Avahi)
- [.local mDNS (RFC 6762)](https://www.rfc-editor.org/rfc/rfc6762)
- [Just functions](https://just.systems/man/en/functions.html)
- [Just recipe parameters](https://just.systems/man/en/recipe-parameters.html)
- [Just default recipe](https://just.systems/man/en/the-default-recipe.html)


------
https://chatgpt.com/codex/tasks/task_e_68f5be723988832fae7fc2b7221dbb4b