### PR TITLE
feat: bootstrap flux-managed platform stack

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,8 @@
+creation_rules:
+  - path_regex: platform/secrets/.*\.enc\.ya?ml
+    age:
+      - age1w3q0u5l2d9k3ym8n0exampleexampleexampleexampleexamplex
+      - age1k3sopsrecipientexampleexampleexampleexampleexamplehq
+  - path_regex: flux/secrets/.*\.enc\.ya?ml
+    age:
+      - age1w3q0u5l2d9k3ym8n0exampleexampleexampleexampleexamplex

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,5 @@
+# Sugarkube application manifests
+
+This directory is intentionally empty. Application teams should publish their own
+HelmRelease or Kustomize overlays in dedicated repositories and reference them via Flux
+`GitRepository` or `HelmRepository` sources.

--- a/clusters/dev/config/cloudflared-values.yaml
+++ b/clusters/dev/config/cloudflared-values.yaml
@@ -1,0 +1,10 @@
+cloudflared:
+  tunnelName: sugarkube-dev
+  metrics:
+    enabled: true
+ingress:
+  - hostname: traefik.dev.sugarkube.ops.example.com
+    service: https://traefik.kube-system.svc.cluster.local:443
+    originRequest:
+      originServerName: traefik.dev.sugarkube.internal
+  - service: http_status:404

--- a/clusters/dev/kustomization.yaml
+++ b/clusters/dev/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../platform
+patchesStrategicMerge:
+  - patches/kube-vip.yaml
+  - patches/issuers.yaml
+configMapGenerator:
+  - name: cloudflared-settings
+    namespace: cloudflared
+    behavior: replace
+    files:
+      - values.yaml=config/cloudflared-values.yaml

--- a/clusters/dev/patches/issuers.yaml
+++ b/clusters/dev/patches/issuers.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    email: ops+dev@sugarkube.example
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production
+spec:
+  acme:
+    email: ops+dev@sugarkube.example

--- a/clusters/dev/patches/kube-vip.yaml
+++ b/clusters/dev/patches/kube-vip.yaml
@@ -1,0 +1,16 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: kube-vip
+  namespace: kube-system
+spec:
+  values:
+    config:
+      address: 10.10.0.40
+    env:
+      - name: vip_interface
+        value: eth0
+      - name: address
+        value: 10.10.0.40
+      - name: lb_enable
+        value: "false"

--- a/clusters/int/config/cloudflared-values.yaml
+++ b/clusters/int/config/cloudflared-values.yaml
@@ -1,0 +1,10 @@
+cloudflared:
+  tunnelName: sugarkube-int
+  metrics:
+    enabled: true
+ingress:
+  - hostname: traefik.int.sugarkube.ops.example.com
+    service: https://traefik.kube-system.svc.cluster.local:443
+    originRequest:
+      originServerName: traefik.int.sugarkube.internal
+  - service: http_status:404

--- a/clusters/int/config/nfs-values.yaml
+++ b/clusters/int/config/nfs-values.yaml
@@ -1,0 +1,7 @@
+nfs:
+  server: 10.20.0.50
+  path: /export/sugarkube-int
+storageClass:
+  name: nfs-client
+  defaultClass: true
+  reclaimPolicy: Delete

--- a/clusters/int/kustomization.yaml
+++ b/clusters/int/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../platform/overlays/storage-nfs
+patchesStrategicMerge:
+  - patches/kube-vip.yaml
+  - patches/issuers.yaml
+configMapGenerator:
+  - name: cloudflared-settings
+    namespace: cloudflared
+    behavior: replace
+    files:
+      - values.yaml=config/cloudflared-values.yaml
+  - name: nfs-provisioner-settings
+    namespace: nfs-provisioner
+    behavior: replace
+    files:
+      - values.yaml=config/nfs-values.yaml

--- a/clusters/int/patches/issuers.yaml
+++ b/clusters/int/patches/issuers.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    email: ops+int@sugarkube.example
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production
+spec:
+  acme:
+    email: ops+int@sugarkube.example

--- a/clusters/int/patches/kube-vip.yaml
+++ b/clusters/int/patches/kube-vip.yaml
@@ -1,0 +1,16 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: kube-vip
+  namespace: kube-system
+spec:
+  values:
+    config:
+      address: 10.20.0.40
+    env:
+      - name: vip_interface
+        value: eth0
+      - name: address
+        value: 10.20.0.40
+      - name: lb_enable
+        value: "false"

--- a/clusters/prod/config/cloudflared-values.yaml
+++ b/clusters/prod/config/cloudflared-values.yaml
@@ -1,0 +1,10 @@
+cloudflared:
+  tunnelName: sugarkube-prod
+  metrics:
+    enabled: true
+ingress:
+  - hostname: traefik.prod.sugarkube.ops.example.com
+    service: https://traefik.kube-system.svc.cluster.local:443
+    originRequest:
+      originServerName: traefik.prod.sugarkube.internal
+  - service: http_status:404

--- a/clusters/prod/config/external-dns-values.yaml
+++ b/clusters/prod/config/external-dns-values.yaml
@@ -1,0 +1,9 @@
+provider: cloudflare
+policy: sync
+domainFilters:
+  - prod.sugarkube.ops.example.com
+txtOwnerId: sugarkube-prod
+sources:
+  - service
+  - ingress
+interval: 1m

--- a/clusters/prod/kustomization.yaml
+++ b/clusters/prod/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../platform/overlays/external-dns
+patchesStrategicMerge:
+  - patches/kube-vip.yaml
+  - patches/issuers.yaml
+configMapGenerator:
+  - name: cloudflared-settings
+    namespace: cloudflared
+    behavior: replace
+    files:
+      - values.yaml=config/cloudflared-values.yaml
+  - name: external-dns-settings
+    namespace: external-dns
+    behavior: replace
+    files:
+      - values.yaml=config/external-dns-values.yaml

--- a/clusters/prod/patches/issuers.yaml
+++ b/clusters/prod/patches/issuers.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    email: ops+prod@sugarkube.example
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production
+spec:
+  acme:
+    email: ops+prod@sugarkube.example

--- a/clusters/prod/patches/kube-vip.yaml
+++ b/clusters/prod/patches/kube-vip.yaml
@@ -1,0 +1,16 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: kube-vip
+  namespace: kube-system
+spec:
+  values:
+    config:
+      address: 10.30.0.40
+    env:
+      - name: vip_interface
+        value: eth0
+      - name: address
+        value: 10.30.0.40
+      - name: lb_enable
+        value: "false"

--- a/docs/k3s/config-examples/server-first.yaml
+++ b/docs/k3s/config-examples/server-first.yaml
@@ -1,0 +1,35 @@
+# Example configuration for the first k3s server node in an HA control plane.
+# Apply to /etc/rancher/k3s/config.yaml before starting k3s.
+# Provide the shared bootstrap token via a file mounted at this path.
+token-file: /etc/rancher/k3s/token
+write-kubeconfig-mode: "0644"
+tls-san:
+  - api.dev.sugarkube.internal
+  - api.int.sugarkube.internal
+  - api.prod.sugarkube.internal
+  - 10.10.0.40  # dev VIP
+  - 10.20.0.40  # int VIP
+  - 10.30.0.40  # prod VIP
+cluster-init: true
+disable:
+  - servicelb
+  # keep traefik enabled by default
+node-taint:
+  - "CriticalAddonsOnly=true:NoExecute"
+  - "node-role.kubernetes.io/control-plane=true:NoSchedule"
+node-label:
+  - "node-role.kubernetes.io/control-plane=true"
+write-kubeconfig: /etc/rancher/k3s/k3s.yaml
+kube-controller-manager-arg:
+  - "terminated-pod-gc-threshold=10"
+protect-kernel-defaults: true
+etcd-snapshot-schedule-cron: "0 */12 * * *"
+etcd-snapshot-retention: 5
+etcd-snapshot-dir: /var/lib/rancher/k3s/server/db/snapshots
+# Enable these when ready to offload snapshots to S3. Secrets provided by SOPS.
+# etcd-s3: true
+# etcd-s3-endpoint: ${ETCD_S3_ENDPOINT}
+# etcd-s3-bucket: ${ETCD_S3_BUCKET}
+# etcd-s3-region: ${ETCD_S3_REGION}
+# etcd-s3-access-key: ${ETCD_S3_ACCESS_KEY}
+# etcd-s3-secret-key: ${ETCD_S3_SECRET_KEY}

--- a/docs/k3s/config-examples/server-join.yaml
+++ b/docs/k3s/config-examples/server-join.yaml
@@ -1,0 +1,23 @@
+# Configuration for subsequent k3s server nodes joining the HA control plane.
+# Ensure the first server is online and kube-vip is serving the VIP before running k3s.
+# Provide the shared bootstrap token via a file mounted at this path.
+token-file: /etc/rancher/k3s/token
+server: https://10.10.0.40:6443  # VIP served by kube-vip
+write-kubeconfig-mode: "0644"
+tls-san:
+  - api.dev.sugarkube.internal
+  - api.int.sugarkube.internal
+  - api.prod.sugarkube.internal
+  - 10.10.0.40
+  - 10.20.0.40
+  - 10.30.0.40
+disable:
+  - servicelb
+node-taint:
+  - "CriticalAddonsOnly=true:NoExecute"
+  - "node-role.kubernetes.io/control-plane=true:NoSchedule"
+node-label:
+  - "node-role.kubernetes.io/control-plane=true"
+# Keep snapshots aligned across servers for consistent retention windows.
+etcd-snapshot-schedule-cron: "0 */12 * * *"
+etcd-snapshot-retention: 5

--- a/docs/k3s/config-examples/server-taints.md
+++ b/docs/k3s/config-examples/server-taints.md
@@ -1,0 +1,22 @@
+# Control-plane taints
+
+To keep workloads off the Raspberry Pi control-plane nodes, apply the following taint
+once kube-vip and the initial server are online:
+
+```bash
+kubectl taint nodes <node-name> \
+  node-role.kubernetes.io/control-plane=true:NoSchedule
+```
+
+You can confirm the taint is in place with:
+
+```bash
+kubectl get nodes -o custom-columns=NAME:.metadata.name,TAINTS:.spec.taints
+```
+
+If you later decide to schedule workloads onto the control-plane, remove the taint:
+
+```bash
+kubectl taint nodes <node-name> \
+  node-role.kubernetes.io/control-plane:NoSchedule-
+```

--- a/docs/prompts/codex/sugarkube-platform.md
+++ b/docs/prompts/codex/sugarkube-platform.md
@@ -1,0 +1,118 @@
+# One-click repo task: bootstrap a Pi5-backed k3s HA platform (prod/int/dev) with GitOps
+
+You are a senior platform engineer. Implement the following in this repo **in one atomic PR**.
+
+CONTEXT
+- Hardware: Raspberry Pi 5 (3 nodes per env), each with NVMe via M.2 HAT+.
+- Cluster topology (ALL ENVS): **k3s HA with embedded etcd** using **three server nodes**; optional workers may be added later.
+- Control-plane VIP: **kube-vip** in ARP/L2 so agents join via a stable API endpoint.
+- Ingress & exposure: keep k3s **Traefik**; terminate TLS via **cert-manager** (DNS-01 Cloudflare); publish through **cloudflared** (Cloudflare Tunnel) to avoid opening WAN ports. `external-dns` for Cloudflare is optional.
+- Storage: default to **Longhorn** (works on arm64); allow a toggle to use **nfs-subdir-external-provisioner**.
+- Observability: **kube-prometheus-stack** (Prometheus/Alertmanager/Grafana) + **Loki** for logs.
+- GitOps & secrets: **Flux** drives all deployments; **SOPS/age** for secrets.
+- Backups: enable **scheduled etcd snapshots** and include S3-compatible offload config (values-only; no credentials in plain text).
+- Networking notes: If we run MetalLB later, disable ServiceLB in k3s server flags across all servers.
+
+DELIVERABLES
+1) **Repo layout (kustomize + Flux)**
+   - Create:
+     - `clusters/prod/`, `clusters/int/`, `clusters/dev/`
+     - `platform/` (shared stack: kube-vip, traefik config, cloudflared, cert-manager, issuers, external-dns [optional], storage, monitoring)
+     - `apps/` (left empty here; app repos own their charts)
+     - `infra/` (bootstrap helpers)
+   - Each env directory contains `kustomization.yaml` that composes `platform/` and env-specific overlays (hostnames, cert issuers, tunnel names, image policies, etc.).
+
+2) **Flux bootstrap manifests**
+   - Add `flux/` with `gotk-components.yaml`, `gotk-sync.yaml` and decryption stanza for SOPS/age.
+   - Create `scripts/flux-bootstrap.sh` with idempotent bootstrap steps and comments.
+
+3) **SOPS/age integration**
+   - Add `.sops.yaml` at repo root with AGE recipients.
+   - Place **sample encrypted** secrets for:
+     - Cloudflare API Token (DNS-01)
+     - cloudflared Tunnel credentials (JSON)
+     - GHCR read credentials (if needed)
+     - S3 snapshot offload (endpoint/keys)
+   - Do **NOT** commit any plaintext secrets.
+
+4) **Platform stack (Helm/HelmRelease or Kustomize)**
+   - `kube-vip`: control-plane VIP for k3s servers (DaemonSet on masters). Provide values for ARP/L2; VIP is env-specific.
+   - `cert-manager` + `ClusterIssuer` (Let’s Encrypt staging + prod) using **Cloudflare DNS-01** via API Token Secret.
+   - `cloudflared` (Helm): route public hostnames to Traefik; the tunnel Secret comes from SOPS.
+   - `external-dns` (optional): Cloudflare provider; off by default behind a Kustomize overlay flag.
+   - Storage:
+     - Default: **Longhorn** Helm chart + a `StorageClass` named `longhorn` as default.
+     - Alternate overlay: **nfs-subdir-external-provisioner** with an env-specific NFS server/path.
+   - Observability:
+     - **kube-prometheus-stack** (with minimal values), **Loki** (single-binary or simple-scalable) + Promtail/Alloy DaemonSet.
+   - Network policy: provide a default `deny-all` and a `platform-allow` set for kube-system/monitoring/ingress.
+
+5) **k3s server configuration examples**
+   - Add `docs/k3s/config-examples/` with:
+     - `server-first.yaml` (cluster-init; tls-san includes VIP; **disable ServiceLB** if MetalLB is used later; etcd snapshot schedule & retention; S3 offload placeholders)
+     - `server-join.yaml` (join via VIP; same critical flags as first server)
+   - Include a `server-taints.md` note showing how to taint control-plane nodes (`NoSchedule`) if we want to keep them workload-free.
+
+6) **Runbook & acceptance**
+   - `docs/runbook.md`: first server bootstrap → kube-vip → join 2nd/3rd servers → Flux bootstrap → platform reconcile → restore/backup procedures for etcd.
+   - `docs/prompts/codex/sugarkube-platform.md`: keep THIS prompt + the acceptance checklist below.
+
+SNIPPETS (examples; keep minimal and generic)
+
+- Example **k3s server config** (`/etc/rancher/k3s/config.yaml`):
+```yaml
+# First server (prod)
+token: ${K3S_TOKEN}
+write-kubeconfig-mode: "0644"
+tls-san:
+  - api.sugarkube.prod.local
+  - 10.0.0.40  # kube-vip VIP
+cluster-init: true
+disable:
+  - servicelb        # if using MetalLB later
+  # keep traefik enabled by default
+etcd-snapshot-schedule-cron: "0 */12 * * *"
+etcd-snapshot-retention: 5
+# Optional S3 offload; secrets provided via SOPS references
+# etcd-s3: true
+# etcd-s3-endpoint: s3.example.com
+# etcd-s3-bucket: k3s-etcd
+# etcd-s3-access-key: ${S3_ACCESS}
+# etcd-s3-secret-key: ${S3_SECRET}
+```
+
+- Minimal **ClusterIssuer** using Cloudflare DNS-01 (token secret name is illustrative):
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-dns01
+spec:
+  acme:
+    email: ops@example.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: acme-account-key
+    solvers:
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: cloudflare-api-token
+              key: api-token
+```
+
+ACCEPTANCE CHECKLIST (tick before merging)
+- [ ] k3s HA topology documented and reflected in `server-first.yaml` / `server-join.yaml` (three servers with embedded etcd, join via kube-vip VIP).
+- [ ] kube-vip deployed; API reachable via VIP; agents can join using VIP.
+- [ ] Flux bootstraps and reconciles: Traefik, cert-manager (+ ClusterIssuer), cloudflared; optional external-dns gated by overlay.
+- [ ] Default StorageClass present (Longhorn) and binds PVCs on arm64; NFS overlay works with env vars for server/path.
+- [ ] kube-prometheus-stack + Loki up; sample dashboards/logs visible.
+- [ ] SOPS/age in place; no plaintext secrets; Cloudflare token and tunnel creds stored encrypted; GHCR creds if needed.
+- [ ] etcd snapshots scheduled; retention set; S3 offload values wired (no creds in clear).
+- [ ] NetworkPolicies applied (default deny + platform allow).
+- [ ] `docs/runbook.md` covers bootstrap, upgrades, backup/restore, and promotion (see Flux notes below).
+- [ ] `clusters/{dev,int,prod}` overlays differ only where needed (hostnames, VIPs, tunnel name, issuers).
+
+NOTES
+- Promotion model: pin container images by immutable digest, then **promote** by merging the pinned digest from `int` → `prod` (Flux will reconcile).
+- Leave Traefik enabled in k3s unless there’s a hard requirement to swap to NGINX; if you later adopt MetalLB, ensure `--disable=servicelb` on **all** k3s servers.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,131 @@
+# Sugarkube platform runbook
+
+This runbook documents the happy-path for bootstrapping and operating the Pi 5 backed
+k3s HA platform across dev, int, and prod. Each high-level task also includes the
+low-level manual procedure for verification and debugging.
+
+## Prerequisites
+- Three Raspberry Pi 5 servers with NVMe storage per environment.
+- Ubuntu 22.04 LTS or Raspberry Pi OS Lite 64-bit with `k3s` packages uninstalled.
+- Shared GitOps repository cloned to an operator workstation with `kubectl`, `flux`,
+  `sops`, and `age` installed.
+- Control-plane nodes connected to the same L2 segment as the kube-vip virtual IPs.
+
+## 1. Bootstrap the first server
+
+### High-level (`just`)
+```bash
+just platform-bootstrap env=dev  # runs after OS preparation and k3s install
+```
+
+### Low-level steps
+1. Copy `docs/k3s/config-examples/server-first.yaml` to `/etc/rancher/k3s/config.yaml`.
+2. Populate `${K3S_TOKEN}` with a shared secret for the entire cluster.
+3. Review optional S3 snapshot offload values and ensure corresponding SOPS secrets
+   exist (`platform/secrets/s3-snapshot-offload.enc.yaml`).
+4. Start k3s: `sudo systemctl enable --now k3s`.
+5. Confirm the control-plane is healthy: `sudo k3s kubectl get nodes -o wide`.
+
+## 2. Deploy kube-vip on the first server
+
+### High-level (`just`)
+`just platform-bootstrap env=dev` also applies the Flux manifests that deploy kube-vip.
+
+### Low-level steps
+1. Export the VIP defined in `clusters/<env>/patches/kube-vip.yaml` to your notes.
+2. Verify kube-vip DaemonSet is running on the control-plane nodes:
+   ```bash
+   sudo k3s kubectl get pods -n kube-system -l app.kubernetes.io/name=kube-vip
+   ```
+3. Ensure the virtual IP responds to ARP on the management network.
+
+## 3. Join additional servers
+
+### High-level (`just`)
+No dedicated recipe; repeat OS preparation and use the shared `just cluster-up` helper
+if desired.
+
+### Low-level steps
+1. Copy `docs/k3s/config-examples/server-join.yaml` to `/etc/rancher/k3s/config.yaml` on
+   each joining server and adjust the `server:` field if using the int or prod VIP.
+2. Use the same `${K3S_TOKEN}` and restart k3s: `sudo systemctl enable --now k3s`.
+3. Confirm three servers are present and Ready: `sudo k3s kubectl get nodes`.
+
+## 4. Bootstrap Flux
+
+### High-level (`just`)
+```bash
+just platform-bootstrap env=<env>
+```
+This wraps `scripts/flux-bootstrap.sh` and wires the Git repository to Flux.
+
+### Low-level steps
+1. Place your age private key at `.age.key` in the repository root.
+2. Apply the Flux components and sync manifests:
+   ```bash
+   kubectl apply -k flux
+   flux create source git sugarkube \
+     --namespace flux-system \
+     --url <git-url> \
+     --branch main \
+     --interval 1m \
+     --export | kubectl apply -f -
+   flux create kustomization platform \
+     --namespace flux-system \
+     --source GitRepository/sugarkube \
+     --path ./clusters/<env> \
+     --prune true \
+     --interval 5m \
+     --decryption-provider sops \
+     --decryption-secret sops-age \
+     --export | kubectl apply -f -
+   ```
+3. Wait for controllers to report Ready: `kubectl -n flux-system get deployments`.
+
+## 5. Platform reconciliation
+
+### High-level (`just`)
+The Flux bootstrap recipe continuously reconciles the `clusters/<env>` kustomization.
+
+### Low-level checks
+- Validate `kube-system/kube-vip` pods are running on all servers.
+- Ensure `cert-manager`, `cloudflared`, Longhorn (or NFS overlay), Prometheus, Grafana,
+  Alertmanager, Loki, and Promtail pods are ready.
+- Confirm network policies are enforced:
+  ```bash
+  kubectl get networkpolicies -A
+  ```
+
+## 6. Backups and restore
+
+### Scheduled snapshots
+- Snapshot schedule and retention are defined in the server configs. Verify with:
+  ```bash
+  sudo journalctl -u k3s | grep snapshot
+  ```
+- To offload snapshots to S3, decrypt `platform/secrets/s3-snapshot-offload.enc.yaml`,
+  configure the endpoint, and uncomment the `etcd-s3` options in the k3s configs.
+
+### Restoring etcd
+1. Stop k3s on all servers: `sudo systemctl stop k3s`.
+2. Choose a snapshot (local or S3) and copy it to the restoring node.
+3. Run `k3s server --cluster-reset --cluster-reset-restore-path <snapshot>` once.
+4. Remove the reset flag from `/etc/systemd/system/k3s.service` if added, then start k3s.
+5. Rejoin the other servers after the restored leader is healthy.
+
+## 7. Promotion workflow
+- Pin application and platform images via immutable digests in `clusters/int`.
+- Validate in int, then merge the digest updates into `clusters/prod`.
+- Flux reconciles prod automatically after the merge.
+
+## 8. Upgrades
+- Upgrade k3s nodes one at a time using the upstream guidance.
+- Allow Flux to apply HelmRelease upgrades; watch `flux get hr -A` for status.
+- Pause HelmRelease reconciliation if a manual maintenance window is required:
+  `flux suspend hr <release> -n <namespace>`.
+
+## 9. Troubleshooting tips
+- Decrypt secrets locally with `sops -d platform/secrets/<secret>.enc.yaml`.
+- Inspect Flux events: `flux events --for Kustomization/sugarkube-cluster`.
+- For cloudflared, use `kubectl logs -n cloudflared deploy/cloudflared` to confirm
+  tunnel registration.

--- a/flux/gotk-components.yaml
+++ b/flux/gotk-components.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/fluxcd/flux2/releases/download/v2.3.0/install.yaml

--- a/flux/gotk-sync.yaml
+++ b/flux/gotk-sync.yaml
@@ -1,0 +1,32 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: GitRepository
+metadata:
+  name: sugarkube
+  namespace: flux-system
+spec:
+  interval: 1m
+  ref:
+    branch: main
+  url: ssh://git@github.com/example/sugarkube.git
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: sugarkube-cluster
+  namespace: flux-system
+spec:
+  interval: 5m
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: sugarkube
+  path: ./clusters/dev
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: flux-system
+      namespace: flux-system

--- a/flux/kustomization.yaml
+++ b/flux/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - gotk-components.yaml
+  - secrets/sops-age.enc.yaml
+  - gotk-sync.yaml

--- a/flux/secrets/sops-age.enc.yaml
+++ b/flux/secrets/sops-age.enc.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sops-age
+  namespace: flux-system
+type: Opaque
+stringData:
+  age.agekey: ENC[AES256_GCM,data:YWdlLWFnZWtleS12MS4wCmtleT0wMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwCnRhZz1leGFtcGxlCg==,iv:ageSecretIv=,tag:ageSecretTag=,type:str]
+sops:
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1w3q0u5l2d9k3ym8n0exampleexampleexampleexampleexamplex
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        U29tZUVuY3J5cHRlZEFHRUtleQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2024-07-01T00:00:00Z"
+  mac: ENC[AES256_GCM,data:ageMac=,iv:ageMacIv=,tag:ageMacTag=,type:str]
+  version: 3.7.3

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,5 @@
+# Sugarkube infrastructure helpers
+
+Store environment provisioning scripts, bootstrap inventories, and per-site overrides in
+this directory. The Flux bootstrap script lives in `scripts/flux-bootstrap.sh` and is
+surfaced through `just platform-bootstrap` for day-to-day operators.

--- a/justfile
+++ b/justfile
@@ -315,6 +315,11 @@ cluster-up:
 cluster-bootstrap:
     "{{ sugarkube_cli }}" pi cluster {{ cluster_bootstrap_args }}
 
+# Bootstrap Flux and reconcile the shared platform stack for the selected environment.
+# Usage: just platform-bootstrap ENVIRONMENT
+platform-bootstrap env='dev':
+    scripts/flux-bootstrap.sh {{ env }}
+
 # Install CLI dependencies inside GitHub Codespaces or fresh containers
 
 # Usage: just codespaces-bootstrap

--- a/platform/cert-manager/helmrelease.yaml
+++ b/platform/cert-manager/helmrelease.yaml
@@ -1,0 +1,26 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+spec:
+  interval: 30m
+  releaseName: cert-manager
+  chart:
+    spec:
+      chart: cert-manager
+      version: v1.15.1
+      sourceRef:
+        kind: HelmRepository
+        name: jetstack
+        namespace: flux-system
+  install:
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    installCRDs: true
+    global:
+      leaderElection:
+        namespace: cert-manager

--- a/platform/cloudflared/helmrelease.yaml
+++ b/platform/cloudflared/helmrelease.yaml
@@ -1,0 +1,39 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: cloudflared
+  namespace: cloudflared
+spec:
+  interval: 30m
+  releaseName: cloudflared
+  chart:
+    spec:
+      chart: cloudflared
+      version: 1.12.0
+      sourceRef:
+        kind: HelmRepository
+        name: cloudflare
+        namespace: flux-system
+  install:
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: cloudflared-settings
+      valuesKey: values.yaml
+      optional: true
+  values:
+    cloudflared:
+      image:
+        pullPolicy: IfNotPresent
+      tunnelSecret:
+        create: false
+        existingSecret: cloudflared-tunnel-credentials
+    ingress:
+      - hostname: placeholder.sugarkube.example
+        service: https://traefik.kube-system.svc.cluster.local:443
+        originRequest:
+          originServerName: traefik.sugarkube.example
+      - service: http_status:404

--- a/platform/external-dns/helmrelease.yaml
+++ b/platform/external-dns/helmrelease.yaml
@@ -1,0 +1,41 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: external-dns
+  namespace: external-dns
+spec:
+  interval: 30m
+  releaseName: external-dns
+  chart:
+    spec:
+      chart: external-dns
+      version: 1.14.4
+      sourceRef:
+        kind: HelmRepository
+        name: external-dns
+        namespace: flux-system
+  install:
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: external-dns-settings
+      valuesKey: values.yaml
+      optional: true
+  values:
+    provider: cloudflare
+    policy: sync
+    sources:
+      - service
+      - ingress
+    txtOwnerId: sugarkube
+    domainFilters:
+      - sugarkube.example
+    extraEnv:
+      - name: CF_API_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: cloudflare-api-token
+            key: api-token

--- a/platform/issuers/clusterissuers.yaml
+++ b/platform/issuers/clusterissuers.yaml
@@ -1,0 +1,33 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    email: ops@sugarkube.example
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: acme-account-key-staging
+    solvers:
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: cloudflare-api-token
+              key: api-token
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production
+spec:
+  acme:
+    email: ops@sugarkube.example
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: acme-account-key-production
+    solvers:
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: cloudflare-api-token
+              key: api-token

--- a/platform/kube-vip/helmrelease.yaml
+++ b/platform/kube-vip/helmrelease.yaml
@@ -1,0 +1,42 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: kube-vip
+  namespace: kube-system
+spec:
+  interval: 30m
+  releaseName: kube-vip
+  chart:
+    spec:
+      chart: kube-vip
+      version: 0.5.12
+      sourceRef:
+        kind: HelmRepository
+        name: kube-vip
+        namespace: flux-system
+  values:
+    config:
+      address: 0.0.0.0
+      interface: eth0
+      vip_leadership: true
+      arp: true
+    image:
+      pullPolicy: IfNotPresent
+    env:
+      - name: vip_interface
+        value: eth0
+      - name: address
+        value: 0.0.0.0
+      - name: lb_enable
+        value: "false"
+    nodeSelector:
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: "true"
+    tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1

--- a/platform/kustomization.yaml
+++ b/platform/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - repositories.yaml
+  - secrets
+  - kube-vip/helmrelease.yaml
+  - cert-manager/helmrelease.yaml
+  - issuers/clusterissuers.yaml
+  - cloudflared/helmrelease.yaml
+  - storage/longhorn/helmrelease.yaml
+  - observability/kube-prometheus-stack/helmrelease.yaml
+  - observability/loki/helmrelease.yaml
+  - network-policies

--- a/platform/network-policies/allow-platform.yaml
+++ b/platform/network-policies/allow-platform.yaml
@@ -1,0 +1,106 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-platform-traffic
+  namespace: kube-system
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              sugarkube.io/network: platform
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              sugarkube.io/network: platform
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-platform-traffic
+  namespace: monitoring
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              sugarkube.io/network: platform
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              sugarkube.io/network: platform
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-platform-traffic
+  namespace: cloudflared
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              sugarkube.io/network: platform
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              sugarkube.io/network: platform
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-platform-traffic
+  namespace: longhorn-system
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              sugarkube.io/network: platform
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              sugarkube.io/network: platform
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/platform/network-policies/deny-all.yaml
+++ b/platform/network-policies/deny-all.yaml
@@ -1,0 +1,43 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: kube-system
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: monitoring
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: cloudflared
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: longhorn-system
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/platform/network-policies/kustomization.yaml
+++ b/platform/network-policies/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespaces.yaml
+  - deny-all.yaml
+  - allow-platform.yaml

--- a/platform/network-policies/namespaces.yaml
+++ b/platform/network-policies/namespaces.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-system
+  labels:
+    sugarkube.io/network: platform
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+  labels:
+    sugarkube.io/network: platform
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloudflared
+  labels:
+    sugarkube.io/network: platform
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: longhorn-system
+  labels:
+    sugarkube.io/network: platform

--- a/platform/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/platform/observability/kube-prometheus-stack/helmrelease.yaml
@@ -1,0 +1,56 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+  namespace: monitoring
+spec:
+  interval: 30m
+  releaseName: kube-prometheus-stack
+  chart:
+    spec:
+      chart: kube-prometheus-stack
+      version: 62.3.0
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: flux-system
+  install:
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    fullnameOverride: kube-prometheus
+    prometheus:
+      prometheusSpec:
+        retention: 15d
+        scrapeInterval: 30s
+        storageSpec:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: longhorn
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 50Gi
+    grafana:
+      adminUser: admin
+      adminPassword: admin
+      persistence:
+        enabled: true
+        storageClassName: longhorn
+        size: 10Gi
+      ingress:
+        enabled: false
+    alertmanager:
+      alertmanagerSpec:
+        storage:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: longhorn
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 10Gi

--- a/platform/observability/loki/helmrelease.yaml
+++ b/platform/observability/loki/helmrelease.yaml
@@ -1,0 +1,38 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: loki-stack
+  namespace: monitoring
+spec:
+  interval: 30m
+  releaseName: loki-stack
+  chart:
+    spec:
+      chart: loki-stack
+      version: 2.10.2
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: flux-system
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    loki:
+      isDefault: true
+      persistence:
+        enabled: true
+        storageClassName: longhorn
+        size: 20Gi
+    promtail:
+      enabled: true
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+      extraScrapeConfigs: []
+    grafana:
+      enabled: false
+    prometheus:
+      enabled: false

--- a/platform/overlays/external-dns/kustomization.yaml
+++ b/platform/overlays/external-dns/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../
+  - ../../external-dns/helmrelease.yaml

--- a/platform/overlays/storage-nfs/kustomization.yaml
+++ b/platform/overlays/storage-nfs/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../
+  - ../../storage/nfs-subdir-external-provisioner/helmrelease.yaml
+patches:
+  - target:
+      kind: HelmRelease
+      name: longhorn
+      namespace: longhorn-system
+    patch: |
+      apiVersion: helm.toolkit.fluxcd.io/v2beta2
+      kind: HelmRelease
+      metadata:
+        name: longhorn
+        namespace: longhorn-system
+      spec:
+        suspend: true

--- a/platform/repositories.yaml
+++ b/platform/repositories.yaml
@@ -1,0 +1,71 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: kube-vip
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://kube-vip.github.io/helm-charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: jetstack
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://charts.jetstack.io
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: cloudflare
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://cloudflare.github.io/helm-charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: longhorn
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://charts.longhorn.io
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: prometheus-community
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://prometheus-community.github.io/helm-charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: grafana
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://grafana.github.io/helm-charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: external-dns
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://kubernetes-sigs.github.io/external-dns/
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: nfs-subdir-external-provisioner
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/

--- a/platform/secrets/cloudflare-api-token.enc.yaml
+++ b/platform/secrets/cloudflare-api-token.enc.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflare-api-token
+  namespace: cert-manager
+  annotations:
+    kustomize.config.k8s.io/behavior: replace
+type: Opaque
+stringData:
+  api-token: ENC[AES256_GCM,data:wkX0exampleu7b,iv:Qexample=,tag:jexample=,type:str]
+sops:
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1w3q0u5l2d9k3ym8n0exampleexampleexampleexampleexamplex
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRlZC1kYXRhLXBheWxvYWQKZXhhbXBsZUVuY3J5cHRlZFN0cmluZwotLS0tLUVORCBBR0UgRU5DUllQVEVEIEZJTEUtLS0tLQo=
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1k3sopsrecipientexampleexampleexampleexampleexamplehq
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YW5vdGhlckV4YW1wbGVFbmNyeXB0ZWRTdHJpbmcKLS0tLS1FTkQgQUdFIEVOQ1JZUFRFRCBGSUxFLS0tLS0K
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2024-07-01T00:00:00Z"
+  mac: ENC[AES256_GCM,data:mcExampleMac=,iv:RANDOMIVEXAMPLE=,tag:TAGEXAMPLE=,type:str]
+  version: 3.7.3

--- a/platform/secrets/cloudflared-tunnel.enc.yaml
+++ b/platform/secrets/cloudflared-tunnel.enc.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflared-tunnel-credentials
+  namespace: cloudflared
+type: Opaque
+stringData:
+  credentials.json: ENC[AES256_GCM,data:eyJ0dW5uZWwiOiJleGFtcGxlIn0=,iv:IvExample=,tag:TagExample=,type:str]
+sops:
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1w3q0u5l2d9k3ym8n0exampleexampleexampleexampleexamplex
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        ZXhhbXBsZVR1bm5lbENyZWRz
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1k3sopsrecipientexampleexampleexampleexampleexamplehq
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        ZXhhbXBsZVNlY29uZFR1bm5lbENyZWRz
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2024-07-01T00:00:00Z"
+  mac: ENC[AES256_GCM,data:anotherMacExample=,iv:AnotherIv=,tag:AnotherTag=,type:str]
+  version: 3.7.3

--- a/platform/secrets/ghcr-read-credentials.enc.yaml
+++ b/platform/secrets/ghcr-read-credentials.enc.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ghcr-read-credentials
+  namespace: flux-system
+type: kubernetes.io/dockerconfigjson
+stringData:
+  .dockerconfigjson: ENC[AES256_GCM,data:e30=,iv:dockerIv=,tag:dockerTag=,type:str]
+sops:
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1w3q0u5l2d9k3ym8n0exampleexampleexampleexampleexamplex
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        ZG9ja2VyQ29uZmln
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2024-07-01T00:00:00Z"
+  mac: ENC[AES256_GCM,data:dockerMac=,iv:dockerIvMac=,tag:dockerTagMac=,type:str]
+  version: 3.7.3

--- a/platform/secrets/kustomization.yaml
+++ b/platform/secrets/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cloudflare-api-token.enc.yaml
+  - cloudflared-tunnel.enc.yaml
+  - ghcr-read-credentials.enc.yaml
+  - s3-snapshot-offload.enc.yaml

--- a/platform/secrets/s3-snapshot-offload.enc.yaml
+++ b/platform/secrets/s3-snapshot-offload.enc.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: k3s-etcd-s3
+  namespace: kube-system
+type: Opaque
+stringData:
+  endpoint: ENC[AES256_GCM,data:c3MuZXhhbXBsZS5sb2NhbA==,iv:s3Iv=,tag:s3Tag=,type:str]
+  bucket: ENC[AES256_GCM,data:azNzLWV0Y2Q=,iv:s3Iv2=,tag:s3Tag2=,type:str]
+  access-key: ENC[AES256_GCM,data:QUtJRVhBTVBMRA==,iv:s3Iv3=,tag:s3Tag3=,type:str]
+  secret-key: ENC[AES256_GCM,data:U0VDUkVURVhBTVBMRA==,iv:s3Iv4=,tag:s3Tag4=,type:str]
+sops:
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1w3q0u5l2d9k3ym8n0exampleexampleexampleexampleexamplex
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        UzMgZW5jcnlwdGVkIHZhbHVlcw==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2024-07-01T00:00:00Z"
+  mac: ENC[AES256_GCM,data:s3Mac=,iv:s3MacIv=,tag:s3MacTag=,type:str]
+  version: 3.7.3

--- a/platform/storage/longhorn/helmrelease.yaml
+++ b/platform/storage/longhorn/helmrelease.yaml
@@ -1,0 +1,30 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: longhorn
+  namespace: longhorn-system
+spec:
+  interval: 30m
+  releaseName: longhorn
+  chart:
+    spec:
+      chart: longhorn
+      version: 1.6.2
+      sourceRef:
+        kind: HelmRepository
+        name: longhorn
+        namespace: flux-system
+  install:
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    defaultSettings:
+      defaultDataPath: /var/lib/longhorn
+      defaultDataLocality: best-effort
+    persistence:
+      defaultClass: true
+      defaultClassReplicaCount: 2
+    preUpgradeChecker:
+      jobEnabled: false

--- a/platform/storage/nfs-subdir-external-provisioner/helmrelease.yaml
+++ b/platform/storage/nfs-subdir-external-provisioner/helmrelease.yaml
@@ -1,0 +1,30 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: nfs-subdir-external-provisioner
+  namespace: nfs-provisioner
+spec:
+  interval: 30m
+  releaseName: nfs-subdir-external-provisioner
+  chart:
+    spec:
+      chart: nfs-subdir-external-provisioner
+      version: 4.0.18
+      sourceRef:
+        kind: HelmRepository
+        name: nfs-subdir-external-provisioner
+        namespace: flux-system
+  install:
+    createNamespace: true
+  upgrade:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: nfs-provisioner-settings
+      valuesKey: values.yaml
+  values:
+    storageClass:
+      name: nfs-client
+      defaultClass: true
+      reclaimPolicy: Delete

--- a/scripts/flux-bootstrap.sh
+++ b/scripts/flux-bootstrap.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bootstrap Flux into a new or rebuilt k3s control plane. The script is idempotent and safe
+# to re-run; it only applies manifests and secrets that live in this repository.
+#
+# Requirements:
+#   - flux v2.3.0+
+#   - kubectl with access to the target cluster
+#   - sops + age private key matching flux/secrets/sops-age.enc.yaml
+#
+# Usage:
+#   scripts/flux-bootstrap.sh <environment>
+#
+# Example:
+#   scripts/flux-bootstrap.sh dev
+#
+ENVIRONMENT="${1:-}"
+if [[ -z "${ENVIRONMENT}" ]]; then
+  echo "Usage: $0 <environment>" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if ! command -v flux >/dev/null 2>&1; then
+  echo "flux CLI is required" >&2
+  exit 2
+fi
+
+if ! command -v sops >/dev/null 2>&1; then
+  echo "sops is required to decrypt secrets" >&2
+  exit 3
+fi
+
+export SOPS_AGE_KEY_FILE="${REPO_ROOT}/.age.key"
+if [[ ! -f "${SOPS_AGE_KEY_FILE}" ]]; then
+  echo "Copy your age private key to ${SOPS_AGE_KEY_FILE} before running." >&2
+  exit 4
+fi
+
+kubectl apply -k "${REPO_ROOT}/flux"
+
+GIT_URL="$(git -C "${REPO_ROOT}" remote get-url origin 2>/dev/null || echo "")"
+if [[ -n "${GIT_URL}" ]]; then
+  flux create source git sugarkube \
+    --namespace flux-system \
+    --url "${GIT_URL}" \
+    --branch main \
+    --interval 1m \
+    --export | kubectl apply -f -
+fi
+
+flux create kustomization platform \
+  --namespace flux-system \
+  --source GitRepository/sugarkube \
+  --path "./clusters/${ENVIRONMENT}" \
+  --prune true \
+  --interval 5m \
+  --decryption-provider sops \
+  --decryption-secret sops-age \
+  --export | kubectl apply -f -
+
+kubectl -n flux-system rollout status deploy/source-controller --timeout=2m || true
+kubectl -n flux-system rollout status deploy/kustomize-controller --timeout=2m || true
+kubectl -n flux-system rollout status deploy/helm-controller --timeout=2m || true


### PR DESCRIPTION
## Summary
- scaffold Flux repo layout with per-environment kustomizations
- add HelmReleases for kube-vip, cert-manager, storage, and observability
- document k3s configs, Flux bootstrap steps, and the operations runbook

## Testing
- ~/.local/bin/pre-commit run --all-files (fails: existing lint errors in scripts/ssd_clone.py)
- ~/.local/bin/pyspelling -c .spellcheck.yaml (fails: aspell not installed in container)
- ~/.local/bin/linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68f5df149b80832fbee7fc3d180631f0