### PR TITLE
sugarkube: finalize Flux sync wiring, imagePullSecrets coverage, and k3s etcd S3 guide

### DIFF
--- a/docs/k3s/etcd-s3-backups.md
+++ b/docs/k3s/etcd-s3-backups.md
@@ -1,0 +1,61 @@
+# k3s etcd snapshots and S3 offload
+
+This guide documents how the sugarkube cluster schedules embedded etcd snapshots and exports them to
+an object store. k3s can write recurring snapshots to local disk and, when configured, mirror each
+archive to an S3-compatible bucket for off-cluster retention.
+
+## Server configuration example
+
+The following configuration keeps the embedded etcd snapshots enabled, disables the bundled
+ServiceLB in favor of kube-vip, and pushes snapshots to S3 every 12 hours:
+
+```yaml
+# /etc/rancher/k3s/config.yaml
+disable:
+  - servicelb    # kube-vip provides L4
+# etcd snapshots every 12h, keep 28, and push to S3
+etcd-snapshot-schedule-cron: "0 */12 * * *"
+etcd-snapshot-retention: 28
+etcd-s3: true
+etcd-s3-bucket: "sugarkube-k3s-backups"
+etcd-s3-region: "us-east-1"
+# either IAM on node or env file with creds:
+# etcd-s3-access-key, etcd-s3-secret-key
+```
+
+Populate the access key and secret via node IAM credentials, an instance profile, or an environment
+file referenced by `k3s.service`. The bucket must exist prior to enabling the snapshot sync.
+
+## Ensure snapshot directory on boot
+
+Create a oneshot unit on the first control-plane node so that the snapshot directory exists before
+k3s writes to it:
+
+```ini
+[Unit]
+Description=Ensure k3s snapshot dir
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/mkdir -p /var/lib/rancher/k3s/server/db/snapshots
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable the unit with `sudo systemctl enable --now ensure-k3s-snapshot-dir.service`.
+
+## Restore quickstart
+
+1. Stop k3s on all control-plane nodes (`sudo systemctl stop k3s`).
+2. Copy the desired snapshot to `/var/lib/rancher/k3s/server/db/snapshots/` or download it from the
+   configured bucket.
+3. Start a single control-plane node in reset mode to replay the snapshot:
+
+   ```bash
+   sudo k3s server --cluster-init --cluster-reset --cluster-reset-restore-path /var/lib/rancher/k3s/server/db/snapshots/<snapshot>
+   ```
+
+4. Remove the reset flags from `/etc/rancher/k3s/config.yaml`, restart k3s normally, and allow the
+   remaining control-plane nodes to rejoin the restored cluster.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -57,7 +57,9 @@ operator workstation with the `just`, `flux`, `kubectl`, and `sops` CLIs install
 
 ### High-level command
 
-Run the high-level Just recipe to install Flux, apply Git sources, and reconcile the platform.
+Run the high-level Just recipe to install Flux, apply Git sources, and reconcile the platform. The
+bootstrap script defaults to the production overlay (`./clusters/prod`) and accepts a `CLUSTER_ENV`
+argument (or environment variable) to target `dev` or `int` clusters without editing manifests.
 
 ```bash
 just flux-bootstrap env=dev
@@ -65,9 +67,9 @@ just platform-apply env=dev
 ```
 
 Replace `dev` with `int` or `prod` for the target environment. `flux-bootstrap` wraps
-`scripts/flux-bootstrap.sh` (safe to run multiple times) and templates the Flux `Kustomization`
-path with the selected environment before applying it. `platform-apply` requests an immediate Flux
-reconciliation of the platform stack.
+`scripts/flux-bootstrap.sh` (safe to run multiple times) and patches the Flux `Kustomization`
+path after installation so the controller reconciles the requested overlay. `platform-apply`
+requests an immediate Flux reconciliation of the platform stack.
 
 To rotate age keys or rewrap secrets after editing them with `sops`, run:
 
@@ -85,12 +87,14 @@ If you prefer to execute each step manually, follow the procedure in
 
 1. Create the `flux-system` namespace.
 2. Export and apply the Flux controllers using `flux install --export`.
-3. Template and apply `flux/gotk-sync.yaml` so that the `spec.path` resolves to the desired
-   environment, then apply `flux/gotk-components.yaml` with server-side apply:
+3. Apply `flux/gotk-sync.yaml` and `flux/gotk-components.yaml` with server-side apply, then patch
+   the Kustomization to the desired environment once the CRD is established:
 
    ```bash
-   CLUSTER_ENV=dev envsubst < flux/gotk-sync.yaml | kubectl apply -f - --server-side --force-conflicts
+   kubectl apply -f flux/gotk-sync.yaml --server-side --force-conflicts
    kubectl apply -f flux/gotk-components.yaml --server-side --force-conflicts
+   kubectl -n flux-system wait --for=condition=Established crd/kustomizations.kustomize.toolkit.fluxcd.io --timeout=60s || true
+   kubectl -n flux-system patch kustomization flux-system --type=merge -p '{"spec":{"path":"./clusters/dev"}}'
    ```
 4. Create (or rotate) the `sops-age` secret containing the private age key.
 5. Reconcile the `flux-system` Git source and the `platform` Kustomization.
@@ -111,8 +115,9 @@ After Flux begins reconciling, verify the critical components:
 
 ### Scheduled snapshots
 
-Etcd snapshots are scheduled via the k3s configuration (`0 */12 * * *`) and retained for five
-iterations. Longhorn additionally manages volume snapshots according to application policies.
+Etcd snapshots are scheduled via the k3s configuration (`0 */12 * * *`) and retained for 28
+iterations. Longhorn additionally manages volume snapshots according to application policies. See
+`docs/k3s/etcd-s3-backups.md` for the S3 offload configuration and restoration workflow.
 
 ### Off-cluster archive
 

--- a/flux/gotk-sync.yaml
+++ b/flux/gotk-sync.yaml
@@ -1,35 +1,37 @@
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: GitRepository
-metadata:
-  name: flux-system
-  namespace: flux-system
-spec:
-  interval: 1m
-  ref:
-    branch: main
-  url: ssh://git@github.com/sugarkube/platform.git
-  secretRef:
-    name: flux-git-deploy
----
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: platform
-  namespace: flux-system
-spec:
-  interval: 5m
-  prune: true
-  wait: true
-  sourceRef:
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: source.toolkit.fluxcd.io/v1
     kind: GitRepository
-    name: flux-system
-  # The bootstrap script templates this manifest with envsubst before apply.
-  path: ./clusters/${CLUSTER_ENV}
-  decryption:
-    provider: sops
-    secretRef:
-      name: sops-age
-  postBuild:
-    substituteFrom:
-      - kind: Secret
-        name: platform-settings
+    metadata:
+      name: flux-system
+      namespace: flux-system
+    spec:
+      interval: 1m
+      ref:
+        branch: main
+      url: ssh://git@github.com/sugarkube/platform.git
+      secretRef:
+        name: flux-git-deploy
+  - apiVersion: kustomize.toolkit.fluxcd.io/v1
+    kind: Kustomization
+    metadata:
+      name: platform
+      namespace: flux-system
+    spec:
+      interval: 5m
+      prune: true
+      wait: true
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+      # The bootstrap script patches this path to the selected environment after bootstrap.
+      path: ./clusters/prod
+      decryption:
+        provider: sops
+        secretRef:
+          name: sops-age
+      postBuild:
+        substituteFrom:
+          - kind: Secret
+            name: platform-settings

--- a/platform/kustomization.yaml
+++ b/platform/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespaces.yaml
+  - namespaces-sa.yaml
   - repos.yaml
   - kube-vip/
   - cert-manager/

--- a/platform/namespaces-sa.yaml
+++ b/platform/namespaces-sa.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: default
+      namespace: cert-manager
+    imagePullSecrets:
+      - name: ghcr-pull-secret
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: default
+      namespace: cloudflared
+    imagePullSecrets:
+      - name: ghcr-pull-secret
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: default
+      namespace: longhorn-system
+    imagePullSecrets:
+      - name: ghcr-pull-secret
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: default
+      namespace: monitoring
+    imagePullSecrets:
+      - name: ghcr-pull-secret
+

--- a/scripts/flux-bootstrap.sh
+++ b/scripts/flux-bootstrap.sh
@@ -5,7 +5,10 @@ set -euo pipefail
 # The script is idempotent: rerunning it updates Flux components and syncs Git state.
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-CLUSTER_ENV="${1:-dev}"
+: "${CLUSTER_ENV:=prod}"
+if [ "$#" -ge 1 ]; then
+  CLUSTER_ENV="$1"
+fi
 
 if ! command -v flux >/dev/null 2>&1; then
   echo "flux CLI is required. Install from https://fluxcd.io/flux/ before running." >&2
@@ -38,15 +41,15 @@ if [ ! -d "$KUSTOMIZE_ENV_PATH" ]; then
   exit 1
 fi
 
-export CLUSTER_ENV
-TMP_SYNC="$(mktemp)"
-trap 'rm -f "${TMP_SYNC}"' EXIT
-envsubst <"${REPO_ROOT}/flux/gotk-sync.yaml" >"${TMP_SYNC}"
-
-kubectl apply -f "${TMP_SYNC}" \
+kubectl apply -f "${REPO_ROOT}/flux/gotk-sync.yaml" \
   --server-side --force-conflicts
 kubectl apply -f "${REPO_ROOT}/flux/gotk-components.yaml" \
   --server-side --force-conflicts
+
+kubectl -n flux-system wait --for=condition=Established \
+  crd/kustomizations.kustomize.toolkit.fluxcd.io --timeout=60s || true
+kubectl -n flux-system patch kustomization flux-system --type=merge -p \
+  "{\"spec\":{\"path\":\"./clusters/${CLUSTER_ENV}\"}}"
 
 if kubectl get secret -n flux-system sops-age >/dev/null 2>&1; then
   echo ":: sops-age secret already present"


### PR DESCRIPTION
what: default flux sync path to prod, patch via bootstrap script, add
  namespace imagePullSecrets, and document k3s etcd S3 backups.
why: drop envsubst from manifests, keep pulls working across namespaces,
  and capture restore guidance.
how to test: pre-commit run --all-files (fails: existing repo lint),
  pyspelling -c .spellcheck.yaml (fails: missing aspell),
  linkchecker --no-warnings README.md docs/
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68f6c4601828832f90919f4ba397c272