### PR TITLE
sugarkube: finalize Flux sync wiring, imagePullSecrets coverage, and k3s etcd S3 guide

### DIFF
--- a/docs/k3s/etcd-s3-backups.md
+++ b/docs/k3s/etcd-s3-backups.md
@@ -1,0 +1,60 @@
+# k3s etcd snapshots and S3 offload
+
+k3s embeds etcd and can manage scheduled snapshots without any external controller. Snapshots can be
+stored locally on the server and, when enabled, uploaded to an S3-compatible object store for
+long-term retention. The configuration below keeps local copies for fast recovery while pushing
+archives to S3 every 12 hours.
+
+## Example server configuration
+
+```yaml
+# /etc/rancher/k3s/config.yaml
+disable:
+  - servicelb    # kube-vip provides L4
+# etcd snapshots every 12h, keep 28, and push to S3
+etcd-snapshot-schedule-cron: "0 */12 * * *"
+etcd-snapshot-retention: 28
+etcd-s3: true
+etcd-s3-bucket: "sugarkube-k3s-backups"
+etcd-s3-region: "us-east-1"
+# either IAM on node or env file with creds:
+# etcd-s3-access-key, etcd-s3-secret-key
+```
+
+## Ensure snapshot directory on boot
+
+Add a simple oneshot unit on the first server node so that the snapshot directory exists before the
+scheduler runs:
+
+```ini
+[Unit]
+Description=Ensure k3s snapshot dir
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/mkdir -p /var/lib/rancher/k3s/server/db/snapshots
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable the unit and restart the node if needed:
+
+```bash
+sudo cp ensure-k3s-snapshots.service /etc/systemd/system/
+sudo systemctl enable --now ensure-k3s-snapshots.service
+```
+
+## Restore quickstart
+
+To restore the cluster, stop k3s on all nodes, copy the desired snapshot to the first control-plane,
+and run k3s in reset mode pointing at the snapshot file:
+
+```bash
+sudo k3s server --cluster-init --cluster-reset \
+  --cluster-reset-restore-path /var/lib/rancher/k3s/server/db/snapshots/<snapshot>
+```
+
+After the reset completes, remove the reset flags from `/etc/rancher/k3s/config.yaml`, restart k3s on
+the remaining nodes, and confirm the etcd members rejoin.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -55,6 +55,11 @@ operator workstation with the `just`, `flux`, `kubectl`, and `sops` CLIs install
 
 ## 4. Bootstrap Flux and secrets
 
+`scripts/flux-bootstrap.sh` defaults the `flux-system` Kustomization to the production overlay
+(`./clusters/prod`). Pass an environment argument (for example `./scripts/flux-bootstrap.sh dev`)
+or export `CLUSTER_ENV=dev` before running the script to patch Flux so it syncs a different
+overlay.
+
 ### High-level command
 
 Run the high-level Just recipe to install Flux, apply Git sources, and reconcile the platform.
@@ -65,9 +70,9 @@ just platform-apply env=dev
 ```
 
 Replace `dev` with `int` or `prod` for the target environment. `flux-bootstrap` wraps
-`scripts/flux-bootstrap.sh` (safe to run multiple times) and templates the Flux `Kustomization`
-path with the selected environment before applying it. `platform-apply` requests an immediate Flux
-reconciliation of the platform stack.
+`scripts/flux-bootstrap.sh` (safe to run multiple times) and patches the Flux `Kustomization`
+path with the selected environment after the controllers and CRDs are installed. `platform-apply`
+requests an immediate Flux reconciliation of the platform stack.
 
 To rotate age keys or rewrap secrets after editing them with `sops`, run:
 
@@ -85,12 +90,16 @@ If you prefer to execute each step manually, follow the procedure in
 
 1. Create the `flux-system` namespace.
 2. Export and apply the Flux controllers using `flux install --export`.
-3. Template and apply `flux/gotk-sync.yaml` so that the `spec.path` resolves to the desired
-   environment, then apply `flux/gotk-components.yaml` with server-side apply:
+3. Apply `flux/gotk-sync.yaml` and `flux/gotk-components.yaml` with server-side apply, then patch the
+   `flux-system` Kustomization path once the CRD is established:
 
    ```bash
-   CLUSTER_ENV=dev envsubst < flux/gotk-sync.yaml | kubectl apply -f - --server-side --force-conflicts
+   kubectl apply -f flux/gotk-sync.yaml --server-side --force-conflicts
    kubectl apply -f flux/gotk-components.yaml --server-side --force-conflicts
+   kubectl -n flux-system wait --for=condition=Established \
+     crd/kustomizations.kustomize.toolkit.fluxcd.io --timeout=60s || true
+   kubectl -n flux-system patch kustomization flux-system --type=merge -p \
+     '{"spec":{"path":"./clusters/dev"}}'
    ```
 4. Create (or rotate) the `sops-age` secret containing the private age key.
 5. Reconcile the `flux-system` Git source and the `platform` Kustomization.

--- a/flux/gotk-sync.yaml
+++ b/flux/gotk-sync.yaml
@@ -23,8 +23,8 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-  # The bootstrap script templates this manifest with envsubst before apply.
-  path: ./clusters/${CLUSTER_ENV}
+  # Default to the production overlay; bootstrap script patches for other envs.
+  path: ./clusters/prod
   decryption:
     provider: sops
     secretRef:

--- a/platform/kustomization.yaml
+++ b/platform/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespaces.yaml
+  - namespaces-sa.yaml
   - repos.yaml
   - kube-vip/
   - cert-manager/

--- a/platform/namespaces-sa.yaml
+++ b/platform/namespaces-sa.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: List
+metadata:
+  name: platform-namespace-service-accounts
+items:
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: default
+      namespace: cert-manager
+    imagePullSecrets:
+      - name: ghcr-pull-secret
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: default
+      namespace: cloudflared
+    imagePullSecrets:
+      - name: ghcr-pull-secret
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: default
+      namespace: longhorn-system
+    imagePullSecrets:
+      - name: ghcr-pull-secret
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: default
+      namespace: monitoring
+    imagePullSecrets:
+      - name: ghcr-pull-secret


### PR DESCRIPTION
## Summary
- default the gotk-sync manifest to prod and patch the Flux path during bootstrap
- include default service accounts with ghcr-pull-secret across platform namespaces
- document the bootstrap patch behavior and add a k3s etcd snapshot + S3 guide

## Testing
- pre-commit run --all-files *(fails: repo multi-doc YAML + flake8 in scripts/ssd_clone.py)*
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_68f6c4601828832f90919f4ba397c272