### PR TITLE
🔧 : – allow nested indentation in just recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,5 +1,6 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
 set export := true
+set recipe-indent-alternatives := ["    ", "\t", "        "]
 
 export SUGARKUBE_CLUSTER := env('SUGARKUBE_CLUSTER', 'sugar')
 export SUGARKUBE_SERVERS := env('SUGARKUBE_SERVERS', '1')


### PR DESCRIPTION
what: add recipe-indent-alternatives to support nested spaces in justfile
why: just up dev failed when encountering eight-space indentation
how to test: run just --list or just up dev on a host with just installed

------
https://chatgpt.com/codex/tasks/task_e_68f71ece5c04832facaf41c9f6aef2fa