### PR TITLE
🛠️ : – align bootstrap block with just indentation rules

### DIFF
--- a/justfile
+++ b/justfile
@@ -19,8 +19,8 @@ up env='dev': prereqs
 
     # --- FIX: bootstrap if no existing token ---
     if [ ! -f /var/lib/rancher/k3s/server/node-token ]; then
-        echo "[sugarkube] No existing cluster detected — bootstrapping k3s server..."
-        curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --cluster-init" sh -
+    echo "[sugarkube] No existing cluster detected — bootstrapping k3s server..."
+    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --cluster-init" sh -
     fi
 
     # Proceed with discovery/join for subsequent nodes


### PR DESCRIPTION
what: align bootstrap block indentation in justfile.
why: fix `just up dev` failure caused by extra leading whitespace.
how to test: run `just --list` (requires just CLI).

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68f71ece5c04832facaf41c9f6aef2fa