### PR TITLE
🛠️ : – ensure bootstrap block runs in single shell

### DIFF
--- a/justfile
+++ b/justfile
@@ -18,9 +18,9 @@ up env='dev': prereqs
     export SUGARKUBE_SERVERS="{{ SUGARKUBE_SERVERS }}"
 
     # --- FIX: bootstrap if no existing token ---
-    if [ ! -f /var/lib/rancher/k3s/server/node-token ]; then
-    echo "[sugarkube] No existing cluster detected — bootstrapping k3s server..."
-    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --cluster-init" sh -
+    if [ ! -f /var/lib/rancher/k3s/server/node-token ]; then \
+        echo "[sugarkube] No existing cluster detected — bootstrapping k3s server..."; \
+        curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --cluster-init" sh -; \
     fi
 
     # Proceed with discovery/join for subsequent nodes


### PR DESCRIPTION
what: wrap the k3s bootstrap if block in a single shell invocation
why: avoid syntax errors when running `just up dev` on a node without a
     token
how to test: just up dev
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68f721327960832fb28fa3edaa2e7e45