### PR TITLE
Add memory cgroup preflight to k3s bootstrap

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,6 +17,8 @@ up env='dev': prereqs
     export SUGARKUBE_ENV="{{ env }}"
     export SUGARKUBE_SERVERS="{{ SUGARKUBE_SERVERS }}"
 
+    "{{ scripts_dir }}/check_memory_cgroup.sh"
+
     # --- FIX: bootstrap if no existing token ---
     if [ ! -f /var/lib/rancher/k3s/server/node-token ]; then \
         echo "[sugarkube] No existing cluster detected — bootstrapping k3s server..."; \

--- a/scripts/check_memory_cgroup.sh
+++ b/scripts/check_memory_cgroup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $(uname -s) != "Linux" ]]; then
+  exit 0
+fi
+
+have_memory_cgroup() {
+  if [[ -d /sys/fs/cgroup/memory ]]; then
+    return 0
+  fi
+  if [[ -f /sys/fs/cgroup/cgroup.controllers ]] && \
+     grep -qw memory /sys/fs/cgroup/cgroup.controllers; then
+    return 0
+  fi
+  return 1
+}
+
+if have_memory_cgroup; then
+  exit 0
+fi
+
+err() {
+  echo "[sugarkube] $*" >&2
+}
+
+err "k3s requires the Linux memory cgroup controller, but it is not active."
+
+missing_flags=()
+if [[ -r /proc/cmdline ]]; then
+  if ! grep -qw 'cgroup_memory=1' /proc/cmdline; then
+    missing_flags+=("cgroup_memory=1")
+  fi
+  if ! grep -qw 'cgroup_enable=memory' /proc/cmdline; then
+    missing_flags+=("cgroup_enable=memory")
+  fi
+fi
+
+if ((${#missing_flags[@]})); then
+  err "Add the following kernel parameters to /boot/firmware/cmdline.txt: ${missing_flags[*]}"
+else
+  err "Enable the memory controller in your boot configuration and reboot the node."
+fi
+err "After updating, reboot the Raspberry Pi and rerun 'just up'."
+
+exit 1


### PR DESCRIPTION
🔧 : –
what: run a memory cgroup check before bootstrapping k3s
why: prevent k3s install failures when memory cgroups are disabled
how to test: scripts/check_memory_cgroup.sh


------
https://chatgpt.com/codex/tasks/task_e_68f722faa82c832f9117e1aeeb883ccc