### PR TITLE
Detect runtime memory cgroup disable during just up

### DIFF
--- a/outages/2025-10-21-just-up-memory-cgroup-reboot.json
+++ b/outages/2025-10-21-just-up-memory-cgroup-reboot.json
@@ -1,0 +1,11 @@
+{
+  "id": "2025-10-21-just-up-memory-cgroup-reboot",
+  "date": "2025-10-21",
+  "component": "just up dev / check_memory_cgroup.sh",
+  "rootCause": "Pi reboot skipped after removing cgroup_disable=memory, leaving the runtime kernel without the memory controller and causing k3s to abort.",
+  "resolution": "Detect cgroup_disable=memory in the active kernel cmdline, persist env, trigger a managed reboot, and add regression tests to ensure the bootstrap resumes automatically.",
+  "references": [
+    "scripts/check_memory_cgroup.sh",
+    "tests/test_check_memory_cgroup.py"
+  ]
+}


### PR DESCRIPTION
what: detect active cgroup_disable=memory, persist env, reboot, and test
why: just up aborted after removing cgroup_disable=memory without reboot
how to test: pytest tests/test_check_memory_cgroup.py
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68f73a5cc84c832f9409524b8d27f486