### PR TITLE
Autodetect k3s token during just up bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * pi_carrier: standoff length increased from 20 mm to 22 mm (flush fit with PoE HAT)
 * panel_bracket: add chamfers to printed mounting hole for easier screw insertion
 * lint workflow test now uses `actions/checkout@v4` to avoid Node 16 deprecation warnings
+* just up: automatically fall back to the local k3s `node-token` so the first server boots without exporting secrets
 
 ### Ergonomics
 * Track ergonomics-focused updates directly in the changelog and guard the section with

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -21,7 +21,10 @@ When the first node starts `k3s` as a server, it automatically creates a secret 
 /var/lib/rancher/k3s/server/node-token
 ```
 
-That token is what other nodes must present to join. Sugarkube never invents its own tokens—it just expects you to export them before you run `just up`.
+That token is what other nodes must present to join. The `k3s-discover.sh` helper now
+automatically reads the local copy when it exists, so the very first server for an
+environment can run `just up` with zero additional setup. Additional servers or agents
+still need the token exported before they attempt to join.
 
 The pattern is:
 
@@ -69,7 +72,8 @@ After the reboot, rerun the helper to confirm the controller is available:
    just up dev
    ```
 
-   This installs Avahi/libnss-mdns, bootstraps a k3s server, publishes the API as
+   This installs Avahi/libnss-mdns, bootstraps a k3s server (automatically reading the
+   freshly-created `/var/lib/rancher/k3s/server/node-token`), publishes the API as
    `_https._tcp:6443` via Bonjour/mDNS with `cluster=sugar` and `env=dev` TXT records,
    and taints itself (`node-role.kubernetes.io/control-plane=true:NoSchedule`) so workloads prefer agents.
 
@@ -177,8 +181,9 @@ or, if that file is missing, reinstall the server (`just up dev` on a fresh node
 
 - **Error: `SUGARKUBE_TOKEN (or per-env variant) required`**
 
-  You tried to run `just up` on a node without exporting the token.
-  Retrieve it from the control-plane (`/var/lib/rancher/k3s/server/node-token`) and set the appropriate environment variable before retrying.
+  You ran `just up` without a readable token.
+  On additional nodes, export the token (or set the right `SUGARKUBE_TOKEN_*` variable) before retrying.
+  On the very first server, rerun the command once the bootstrap finishes—`k3s-discover.sh` reads `/var/lib/rancher/k3s/server/node-token` automatically when the file is present.
 
 - **Cluster discovery fails**
 

--- a/outages/2025-11-15-just-up-token-autodiscovery.json
+++ b/outages/2025-11-15-just-up-token-autodiscovery.json
@@ -1,0 +1,12 @@
+{
+  "id": "2025-11-15-just-up-token-autodiscovery",
+  "date": "2025-11-15",
+  "component": "just up dev / k3s-discover.sh",
+  "rootCause": "`k3s-discover.sh` exited before bootstrap because it demanded an exported SUGARKUBE_TOKEN even when the freshly installed server had already written `/var/lib/rancher/k3s/server/node-token`.",
+  "resolution": "Teach the helper to read existing node-token locations (and the k3s.service.env file) automatically, allow the Avahi directory to be overridden for tests, and add regression tests that confirm the install script receives the derived token.",
+  "references": [
+    "scripts/k3s-discover.sh",
+    "tests/test_k3s_discover.py",
+    "docs/raspi_cluster_setup.md"
+  ]
+}

--- a/tests/test_k3s_discover.py
+++ b/tests/test_k3s_discover.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "k3s-discover.sh"
+
+
+def _make_executable(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+    path.chmod(stat.S_IRWXU)
+
+
+def _prepare_stubbed_env(tmp_path: Path) -> tuple[dict[str, str], Path]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    call_log = tmp_path / "calls.log"
+    call_log.write_text("", encoding="utf-8")
+
+    _make_executable(
+        bin_dir / "hostname",
+        """#!/usr/bin/env bash
+        echo "hostname:$*" >>"${CALL_LOG}"
+        if [ "$#" -gt 0 ]; then
+          shift
+        fi
+        echo sugarkube0
+        """,
+    )
+
+    _make_executable(
+        bin_dir / "avahi-browse",
+        """#!/usr/bin/env bash
+        echo "avahi-browse:$*" >>"${CALL_LOG}"
+        exit 0
+        """,
+    )
+
+    _make_executable(
+        bin_dir / "sudo",
+        """#!/usr/bin/env bash
+        echo "sudo:$*" >>"${CALL_LOG}"
+        while [ "$#" -gt 0 ]; do
+          case "$1" in
+            -E|-H|-n)
+              shift
+              ;;
+            --preserve-env|--preserve-env=*)
+              shift
+              ;;
+            --)
+              shift
+              break
+              ;;
+            -* )
+              shift
+              ;;
+            *)
+              break
+              ;;
+          esac
+        done
+        if [ "$#" -eq 0 ]; then
+          exit 0
+        fi
+        exec "$@"
+        """,
+    )
+
+    _make_executable(
+        bin_dir / "systemctl",
+        """#!/usr/bin/env bash
+        echo "systemctl:$*" >>"${CALL_LOG}"
+        exit 0
+        """,
+    )
+
+    _make_executable(
+        bin_dir / "sleep",
+        """#!/usr/bin/env bash
+        echo "sleep:$*" >>"${CALL_LOG}"
+        exit 0
+        """,
+    )
+
+    _make_executable(
+        bin_dir / "curl",
+        """#!/usr/bin/env bash
+        echo "curl:$*" >>"${CALL_LOG}"
+        cat <<'SCRIPT'
+#!/usr/bin/env bash
+echo "install-env:INSTALL_K3S_CHANNEL=${INSTALL_K3S_CHANNEL:-}" >>"${CALL_LOG}"
+echo "install-env:K3S_TOKEN=${K3S_TOKEN:-}" >>"${CALL_LOG}"
+printf 'install-args:' >>"${CALL_LOG}"
+for arg in "$@"; do
+  printf ' %s' "$arg" >>"${CALL_LOG}"
+done
+echo >>"${CALL_LOG}"
+exit 0
+SCRIPT
+        """,
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "CALL_LOG": str(call_log),
+        }
+    )
+
+    return env, call_log
+
+
+def test_uses_local_node_token_when_available(tmp_path: Path) -> None:
+    env, call_log = _prepare_stubbed_env(tmp_path)
+
+    token_path = tmp_path / "state" / "node-token"
+    token_path.parent.mkdir(parents=True)
+    token_path.write_text("DEV_TOKEN_123\n", encoding="utf-8")
+
+    avahi_dir = tmp_path / "avahi"
+
+    env.update(
+        {
+            "SUGARKUBE_ENV": "dev",
+            "SUGARKUBE_SERVERS": "1",
+            "SUGARKUBE_TOKEN_PATH_HINTS": str(token_path),
+            "SUGARKUBE_AVAHI_SERVICES_DIR": str(avahi_dir),
+            "SUGARKUBE_CLUSTER": "sugar",
+        }
+    )
+    env.pop("SUGARKUBE_TOKEN", None)
+    env.pop("SUGARKUBE_TOKEN_DEV", None)
+
+    completed = subprocess.run(
+        [str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    assert f"Using join token from {token_path}" in completed.stdout
+
+    calls = call_log.read_text(encoding="utf-8").splitlines()
+    assert any("install-env:K3S_TOKEN=DEV_TOKEN_123" in line for line in calls)
+
+
+def test_errors_when_no_token_found(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env.update(
+        {
+            "SUGARKUBE_ENV": "dev",
+            "SUGARKUBE_SERVERS": "1",
+            "PATH": env["PATH"],
+        }
+    )
+    env.pop("SUGARKUBE_TOKEN", None)
+    env.pop("SUGARKUBE_TOKEN_DEV", None)
+
+    completed = subprocess.run(
+        [str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert "SUGARKUBE_TOKEN (or per-env variant) required" in completed.stdout


### PR DESCRIPTION
## Summary
- teach scripts/k3s-discover.sh to fall back to the local k3s node token or service env file and make Avahi paths configurable for tests
- document the bootstrap flow change and record an outage entry covering the regression
- add regression tests that exercise the token autodiscovery path

## Testing
- pytest tests/test_k3s_discover.py

------
https://chatgpt.com/codex/tasks/task_e_68f73dee6238832fb201ee454dd1e793