### PR TITLE
Rightsize bootstrap docs and add kubeconfig smoke test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * pi_carrier: rounded base corners via new `corner_radius` parameter
 * panel_bracket: parameterise screw size via `screw_nominal`
 * panel_bracket: add `nut` standoff_mode for captive hex recess
+* tests: add kubeconfig recipe smoke coverage to guard context rewrites
 
 ### Changed
 * panel_bracket: increase default edge radius to 4 mm for smoother corners
@@ -13,6 +14,7 @@
 * panel_bracket: enlarge insert to 6.3 mm OD for common M5 heat‑set hardware
 * CI: upgrade GitHub-hosted actions to Node 22-compatible majors (`actions/checkout@v5`,
   `actions/setup-python@v6`)
+* docs: streamline Raspberry Pi bootstrap quick start and cross-link the runbook/Flux bootstrap
 
 ### Fixed
 * pi_carrier: standoff length increased from 20 mm to 22 mm (flush fit with PoE HAT)

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -145,15 +145,18 @@ stable hostnames to avoid churn.
 
 ### Validation commands
 
-Run the following after each reconciliation to confirm the new hardening landed:
+Use these quick checks after bootstrap or recovery (run the first two directly on a control-plane node, then use your kubeconfig for the Kubernetes queries):
 
 ```bash
+just status
+sudo k3s kubectl get nodes -o wide
+kubectl -n kube-system get daemonset kube-vip
 kubectl -n kube-system get deploy traefik
-kubectl -n cloudflared get deploy
-kubectl -n monitoring get servicemonitors,prometheusrules
-kubectl -n monitoring get prometheusrules app-uptime-rules -o yaml | \
-  grep ServiceMonitorTargetDown
+# Optional: confirm the VIP responds
+ping -c3 <kube-vip-address-from-clusters/dev/patches/kube-vip-values.yaml>
 ```
+
+Swap `dev` for `int` or `prod` when targeting other environments and substitute the VIP defined in the corresponding overlay.
 
 ## 6. Backups and restore procedures
 

--- a/tests/test_k3s_discover_token_resolution.py
+++ b/tests/test_k3s_discover_token_resolution.py
@@ -46,6 +46,16 @@ def test_prefers_env_specific_token(default_env):
     assert result.stdout.strip() == "dev-specific-token"
 
 
+def test_falls_back_to_generic_token(default_env):
+    env = dict(default_env)
+    env["SUGARKUBE_TOKEN"] = "fallback-token"
+
+    result = run_discover(["--print-resolved-token"], env)
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "fallback-token"
+
+
 def test_reads_node_token_file(default_env, tmp_path):
     node_token_path = tmp_path / "node-token"
     node_token_path.write_text("K10node::server:abc123\n", encoding="utf-8")

--- a/tests/test_kubeconfig_recipe.py
+++ b/tests/test_kubeconfig_recipe.py
@@ -1,0 +1,90 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+JUSTFILE = REPO_ROOT / "justfile"
+
+
+K3S_SAMPLE_CONFIG = """apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: FAKE
+    server: https://127.0.0.1:6443
+  name: default
+contexts:
+- context:
+    cluster: default
+    namespace: default
+    user: default
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: default
+  user:
+    username: placeholder
+"""
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="just recipes are tested on POSIX hosts")
+def test_kubeconfig_recipe_rewrites_scope(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+
+    fake_etc = tmp_path / "etc" / "rancher" / "k3s"
+    fake_etc.mkdir(parents=True)
+    source_config = fake_etc / "k3s.yaml"
+    source_config.write_text(K3S_SAMPLE_CONFIG, encoding="utf-8")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    sudo_script = fake_bin / "sudo"
+    sudo_script.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "cp" && "$2" == "/etc/rancher/k3s/k3s.yaml" ]]; then
+  cp "${TEST_K3S_SOURCE:?}" "$3"
+elif [[ "$1" == "chown" ]]; then
+  exit 0
+else
+  "$@"
+fi
+""",
+        encoding="utf-8",
+    )
+    sudo_script.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home_dir),
+            "PATH": f"{fake_bin}:{env.get('PATH', '')}",
+            "TEST_K3S_SOURCE": str(source_config),
+            "USER": env.get("USER", "tester"),
+        }
+    )
+
+    result = subprocess.run(
+        ["just", "--justfile", str(JUSTFILE), "kubeconfig"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    kubeconfig_path = home_dir / ".kube" / "config"
+    assert kubeconfig_path.exists()
+
+    content = kubeconfig_path.read_text(encoding="utf-8")
+    assert "current-context: sugar-dev" in content
+    assert "name: sugar-dev" in content
+


### PR DESCRIPTION
what: align raspi quick start with HA guidance, runbook links, and kubeconfig export notes; add kubeconfig recipe smoke test and extend token fallback coverage
why: keep bootstrap docs authoritative and guard kubeconfig context rewrites
how to test: pytest tests/test_kubeconfig_recipe.py tests/test_k3s_discover_token_resolution.py; just --unstable --fmt --check

------
https://chatgpt.com/codex/tasks/task_e_68f858a02970832fbd0fa77e06025793