### PR TITLE
🛠️ : – ignore placeholder boot token files during HA bootstrap

### DIFF
--- a/tests/test_k3s_discover_token_resolution.py
+++ b/tests/test_k3s_discover_token_resolution.py
@@ -92,6 +92,29 @@ def test_missing_token_allowed_for_multi_server_first_bootstrap(default_env):
     assert result.stdout == ""
 
 
+def test_placeholder_boot_token_does_not_block_multi_server_bootstrap(
+    default_env, tmp_path
+):
+    boot_token_path = tmp_path / "boot-token"
+    boot_token_path.write_text(
+        (
+            "# Sugarkube k3s node token export (pending)\n"
+            "# Generated: 2025-01-01T00:00:00\n"
+            "# /var/lib/rancher/k3s/server/node-token was not found. Run this script again later.\n"
+        ),
+        encoding="utf-8",
+    )
+
+    env = dict(default_env)
+    env["SUGARKUBE_SERVERS"] = "3"
+    env["SUGARKUBE_BOOT_TOKEN_PATH"] = str(boot_token_path)
+
+    result = run_discover(["--check-token-only"], env)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
 def test_missing_token_rejected_for_multi_server_when_token_file_present(
     default_env, tmp_path
 ):


### PR DESCRIPTION
what: allow HA bootstrap when /boot placeholder lacks NODE_TOKEN
why: placeholder export should not block first k3s server after reboot
how to test: pytest tests/test_k3s_discover_token_resolution.py

------
https://chatgpt.com/codex/tasks/task_e_68f8740d6dfc832fbae4afcea6250860