### PR TITLE
Fix k3s mDNS discovery parsing

### DIFF
--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -129,6 +129,14 @@ The pattern is:
   ```
   The file lands in `~/.kube/config` with the context renamed to `sugar-dev` and the `.local` hostname preserved for TLS.
 
+#### Verify discovery
+
+```bash
+avahi-browse --all --resolve --terminate | grep -A2 '_https._tcp'
+```
+
+Confirm the output advertises port `6443` alongside `TXT` records for `k3s=1`, `cluster=<name>`, and `env=<env>`.
+
 - To manage the cluster from your workstation, copy that kubeconfig and adjust credentials as outlined in [Manage from a workstation](./network_setup.md#manage-from-a-workstation).
 
 - When you need to reset a node, run:

--- a/tests/test_avahi_service_file.py
+++ b/tests/test_avahi_service_file.py
@@ -1,0 +1,114 @@
+import os
+import shlex
+import subprocess
+import textwrap
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "k3s-discover.sh"
+
+
+@pytest.fixture()
+def avahi_env(tmp_path):
+    services_dir = tmp_path / "avahi" / "services"
+    services_dir.mkdir(parents=True)
+
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+
+    sudo_stub = stub_dir / "sudo"
+    sudo_stub.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            cmd="$1"
+            shift || true
+            case "${cmd}" in
+              install)
+                if [ "${1:-}" = "-d" ]; then
+                  dir="${SUGARKUBE_TEST_AVAHI_DIR:?}"
+                  mkdir -p "${dir}"
+                  exit 0
+                fi
+                ;;
+              rm)
+                dir="${SUGARKUBE_TEST_AVAHI_DIR:?}"
+                rm -f "${dir}/k3s-https.service" || true
+                exit 0
+                ;;
+              systemctl)
+                exit 0
+                ;;
+              tee)
+                exec tee "$@"
+                ;;
+              *)
+                exec "${cmd}" "$@"
+                ;;
+            esac
+            """
+        ),
+        encoding="utf-8",
+    )
+    sudo_stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{stub_dir}:{env['PATH']}"
+    env.setdefault("SUGARKUBE_CLUSTER", "sugar")
+    env.setdefault("SUGARKUBE_ENV", "dev")
+    env["SUGARKUBE_TEST_AVAHI_DIR"] = str(services_dir)
+    return env, services_dir
+
+
+def _call_publish_service(env: dict, service_file: Path, extra_records):
+    records = " ".join(shlex.quote(record) for record in extra_records)
+    command = (
+        f"source {shlex.quote(str(SCRIPT))}"
+        f" && AVAHI_SERVICE_FILE={shlex.quote(str(service_file))}"
+        f" publish_avahi_service server 6443 {records}"
+    )
+    return subprocess.run(
+        ["bash", "-c", command],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_publish_service_writes_valid_xml(avahi_env):
+    env, services_dir = avahi_env
+    service_file = services_dir / "k3s-sugar-dev.service"
+
+    result = _call_publish_service(env, service_file, ["leader=pi1.local", "state=ready"])
+
+    assert result.returncode == 0
+    assert service_file.exists()
+
+    content = service_file.read_text(encoding="utf-8")
+    assert "<!-- optional -->" in content
+
+    sanitized = content.replace("<!DOCTYPE service-group SYSTEM \"avahi-service.dtd\">\n", "")
+    root = ET.fromstring(sanitized)
+
+    assert root.tag == "service-group"
+    name = root.findtext("name")
+    assert name == "k3s API sugar/dev on %h"
+
+    service = root.find("service")
+    assert service is not None
+    assert service.findtext("type") == "_https._tcp"
+    assert service.findtext("port") == "6443"
+
+    records = [element.text for element in service.findall("txt-record")]
+    assert records == [
+        "k3s=1",
+        "cluster=sugar",
+        "env=dev",
+        "role=server",
+        "leader=pi1.local",
+        "state=ready",
+    ]

--- a/tests/test_mdns_discovery_parsing.py
+++ b/tests/test_mdns_discovery_parsing.py
@@ -1,0 +1,72 @@
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "k3s-discover.sh"
+
+
+@pytest.fixture()
+def mdns_env(tmp_path):
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+
+    avahi_stub = stub_dir / "avahi-browse"
+    avahi_stub.write_text(
+        (
+            "#!/usr/bin/env bash\n"
+            "cat <<'EOF'\n"
+            "=;wlan0;IPv4;k3s API sugar/dev on pi1;_https._tcp;local;pi1.local;pi1.local;6443;"
+            "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=server\n"
+            "EOF\n"
+        ),
+        encoding="utf-8",
+    )
+    avahi_stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{stub_dir}:{env['PATH']}"
+    env.setdefault("SUGARKUBE_CLUSTER", "sugar")
+    env.setdefault("SUGARKUBE_ENV", "dev")
+    return env
+
+
+def _run_function(function: str, env: dict) -> subprocess.CompletedProcess:
+    command = (
+        f"source {shlex.quote(str(SCRIPT))}"
+        f" && run_avahi_query {shlex.quote(function)}"
+    )
+    return subprocess.run(
+        ["bash", "-c", command],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_server_first_returns_host(mdns_env):
+    result = _run_function("server-first", mdns_env)
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "pi1.local"
+
+
+def test_server_count_reports_single_host(mdns_env):
+    result = _run_function("server-count", mdns_env)
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "1"
+
+
+def test_bootstrap_queries_empty_when_only_server(mdns_env):
+    hosts = _run_function("bootstrap-hosts", mdns_env)
+    leaders = _run_function("bootstrap-leaders", mdns_env)
+
+    assert hosts.returncode == 0
+    assert hosts.stdout.strip() == ""
+
+    assert leaders.returncode == 0
+    assert leaders.stdout.strip() == ""


### PR DESCRIPTION
## Summary
- update k3s-discover to tolerate resolved avahi output and expose a skip-main guard
- ensure the generated Avahi service XML is well-formed and escapes txt records
- add focused tests plus documentation for verifying discovery from the CLI

## Testing
- pytest tests/test_mdns_discovery_parsing.py tests/test_avahi_service_file.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f87b50c0f0832fa5ca3d590ff18a10