### PR TITLE
✨ Add fan hole helper and regression coverage

### DIFF
--- a/cad/pi_cluster/fan_patterns.scad
+++ b/cad/pi_cluster/fan_patterns.scad
@@ -8,4 +8,7 @@ function fan_hole_spacing(size) =
 
 function fan_mount_clearance(size) = 3.4; // Through hole for M3 screws with margin.
 
+function fan_hole_circle_d(size) =
+    4.5; // M4/#6 pass-through (oversize for M3 screws per stack doc guidance).
+
 function fan_face_extent(size) = size + 24; // Adds a 12 mm rim on each edge for stiffness.

--- a/cad/pi_cluster/fan_wall.scad
+++ b/cad/pi_cluster/fan_wall.scad
@@ -20,7 +20,10 @@ column_alignment_tolerance =
     is_undef(column_alignment_tolerance) ? 0.2 : column_alignment_tolerance;
 expected_column_spacing = [58, 49];
 
-fan_clearance_radius = fan_mount_clearance(fan_size) / 2;
+mount_hole_diameter = include_bosses
+    ? fan_mount_clearance(fan_size)
+    : fan_hole_circle_d(fan_size);
+fan_clearance_radius = mount_hole_diameter / 2;
 boss_radius = fan_insert_od / 2 + 1.2;
 boss_height = fan_insert_L + 0.8;
 wall_width = fan_face_extent(fan_size);

--- a/docs/pi_cluster_stack.md
+++ b/docs/pi_cluster_stack.md
@@ -172,6 +172,9 @@ function fan_hole_circle_d(size) = 4.5; // M4/#6 pass-through (oversize for M3 s
 Values are derived from common PC fan datasheets (Noctua NF-A12x25, Arctic F9, 80 mm guards). Add an
 optional helper for square patterns if future fans require it.
 
+Regression coverage: `tests/test_fan_patterns_scad.py` ensures the helper stays defined and
+continues returning the documented diameters.
+
 ### 4.2 `fan_wall.scad`
 
 The fan wall is a separate part printed on its side so the screw loads act across layers.

--- a/tests/test_fan_patterns_scad.py
+++ b/tests/test_fan_patterns_scad.py
@@ -1,0 +1,66 @@
+"""Ensure fan_patterns.scad exposes documented helper functions."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SCAD_FILE = Path("cad/pi_cluster/fan_patterns.scad")
+OPENSCAD = shutil.which("openscad")
+
+
+def test_fan_patterns_declares_circle_helper() -> None:
+    """Docs promise a fan_hole_circle_d helper—ensure it exists."""
+
+    source = SCAD_FILE.read_text(encoding="utf-8")
+    assert (
+        "function fan_hole_circle_d" in source
+    ), "docs/pi_cluster_stack.md describes fan_hole_circle_d; add it to fan_patterns.scad"
+
+
+@pytest.mark.skipif(not OPENSCAD, reason="OpenSCAD is not available")
+def test_fan_hole_circle_helper_returns_expected_diameters(tmp_path: Path) -> None:
+    """Evaluate the helper in OpenSCAD to confirm documented diameters."""
+
+    probe = tmp_path / "probe.scad"
+    output = tmp_path / "probe.stl"
+    probe.write_text(
+        textwrap.dedent(
+            f"""
+            include <{SCAD_FILE.resolve().as_posix()}>;
+
+            echo(d80 = fan_hole_circle_d(80));
+            echo(d92 = fan_hole_circle_d(92));
+            echo(d120 = fan_hole_circle_d(120));
+            echo(d_other = fan_hole_circle_d(127));
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["openscad", "-o", str(output), str(probe)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    echoes: dict[str, float] = {}
+    for line in result.stderr.splitlines():
+        if "ECHO:" not in line or "=" not in line:
+            continue
+        _, remainder = line.split("ECHO:", 1)
+        key_part, value_part = remainder.split("=", 1)
+        key = key_part.strip()
+        value = float(value_part.strip())
+        echoes[key] = value
+
+    assert echoes, "OpenSCAD did not emit any echo values for fan_hole_circle_d"
+    assert echoes["d80"] == pytest.approx(4.5, rel=1e-6)
+    assert echoes["d92"] == pytest.approx(4.5, rel=1e-6)
+    assert echoes["d120"] == pytest.approx(4.5, rel=1e-6)
+    assert echoes["d_other"] == pytest.approx(4.5, rel=1e-6)


### PR DESCRIPTION
## Summary
- expose the fan_hole_circle_d helper promised by docs and reuse it
  from fan_wall when inserts are disabled
- document the new regression coverage alongside the helper section
- add tests/test_fan_patterns_scad.py to keep the helper defined and
  returning the documented diameters

## Testing
- python3 -m pre_commit run --all-files *(fails: check-yaml rejects
  multi-document manifests and isort flags existing repository import
  spacing)*
- python3 -m pyspelling -c .spellcheck.yaml
- /root/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md
  docs/
- pytest tests/test_fan_patterns_scad.py
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68f87a4bc6f4832f9a463ab32322e1d9