### PR TITLE
Add Avahi self-check to k3s discovery to prevent split brain

### DIFF
--- a/outages/2025-11-16-k3s-mdns-self-check.json
+++ b/outages/2025-11-16-k3s-mdns-self-check.json
@@ -1,0 +1,13 @@
+{
+  "id": "2025-11-16-k3s-mdns-self-check",
+  "date": "2025-11-16",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "k3s-discover trusted Avahi service reloads without verifying that local bootstrap or server adverts were visible, so when avahi-browse returned no records each node self-initialized and created a split-brain control plane.",
+  "resolution": "Add an mDNS self-check that confirms our bootstrap and server adverts appear via avahi-browse before proceeding, aborting if they do not, and cover the behaviour with regression tests for both success and failure paths.",
+  "references": [
+    "scripts/k3s-discover.sh",
+    "scripts/k3s_mdns_query.py",
+    "tests/scripts/test_k3s_discover_bootstrap_publish.py",
+    "tests/scripts/test_k3s_mdns_query.py"
+  ]
+}

--- a/scripts/k3s_mdns_query.py
+++ b/scripts/k3s_mdns_query.py
@@ -105,6 +105,18 @@ def _render_mode(mode: str, records: Iterable[MdnsRecord]) -> List[str]:
             outputs.append(record.host)
         return outputs
 
+    if mode == "server-hosts":
+        seen = set()
+        outputs: List[str] = []
+        for record in records:
+            if record.txt.get("role") != "server":
+                continue
+            if record.host in seen:
+                continue
+            seen.add(record.host)
+            outputs.append(record.host)
+        return outputs
+
     if mode == "bootstrap-leaders":
         seen = set()
         outputs: List[str] = []

--- a/tests/scripts/test_k3s_discover_bootstrap_publish.py
+++ b/tests/scripts/test_k3s_discover_bootstrap_publish.py
@@ -10,6 +10,7 @@ def _hostname_short() -> str:
 
 
 def test_bootstrap_publish_uses_avahi_publish(tmp_path):
+    hostname = _hostname_short()
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log_path = tmp_path / "publish.log"
@@ -25,6 +26,21 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
     )
     stub.chmod(0o755)
 
+    browse = bin_dir / "avahi-browse"
+    browse.write_text(
+        (
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "cat <<'EOF'\n"
+            f"=;eth0;IPv4;k3s API sugar/dev on {hostname};_https._tcp;local;{hostname}.local;192.0.2.10;6443;"
+            "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=bootstrap;"
+            f"txt=leader={hostname}.local;txt=state=pending\n"
+            "EOF\n"
+        ),
+        encoding="utf-8",
+    )
+    browse.chmod(0o755)
+
     env = os.environ.copy()
     env.update({
         "PATH": f"{bin_dir}:{env.get('PATH', '')}",
@@ -33,6 +49,8 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
         "ALLOW_NON_ROOT": "1",
         "SUGARKUBE_AVAHI_SERVICE_DIR": str(tmp_path / "avahi"),
         "SUGARKUBE_TOKEN": "dummy",  # bypass token requirement
+        "SUGARKUBE_MDNS_SELF_CHECK_ATTEMPTS": "1",
+        "SUGARKUBE_MDNS_SELF_CHECK_DELAY": "0",
     })
 
     result = subprocess.run(
@@ -48,7 +66,6 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
     assert "START:" in log_contents
     assert "TERM" in log_contents
 
-    hostname = _hostname_short()
     assert f"cluster=sugar" in log_contents
     assert f"env=dev" in log_contents
     assert f"leader={hostname}.local" in log_contents
@@ -60,3 +77,55 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
 
     # stderr should mention that avahi-publish-service is advertising the bootstrap role
     assert "avahi-publish-service advertising bootstrap" in result.stderr
+
+
+def test_bootstrap_publish_fails_without_mdns(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_path = tmp_path / "publish.log"
+
+    stub = bin_dir / "avahi-publish-service"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"echo \"START:$*\" >> '{log_path}'\n"
+        "trap 'echo TERM >> \"" + str(log_path) + "\"; exit 0' TERM INT\n"
+        "while true; do sleep 1; done\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+
+    browse = bin_dir / "avahi-browse"
+    browse.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "# Emit nothing to simulate missing adverts\n",
+        encoding="utf-8",
+    )
+    browse.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update({
+        "PATH": f"{bin_dir}:{env.get('PATH', '')}",
+        "SUGARKUBE_CLUSTER": "sugar",
+        "SUGARKUBE_ENV": "dev",
+        "ALLOW_NON_ROOT": "1",
+        "SUGARKUBE_AVAHI_SERVICE_DIR": str(tmp_path / "avahi"),
+        "SUGARKUBE_TOKEN": "dummy",
+        "SUGARKUBE_MDNS_SELF_CHECK_ATTEMPTS": "2",
+        "SUGARKUBE_MDNS_SELF_CHECK_DELAY": "0",
+    })
+
+    result = subprocess.run(
+        ["bash", SCRIPT, "--test-bootstrap-publish"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "Avahi did not report bootstrap advertisement" in result.stderr
+
+    service_file = tmp_path / "avahi" / "k3s-sugar-dev.service"
+    assert not service_file.exists()

--- a/tests/scripts/test_k3s_mdns_query.py
+++ b/tests/scripts/test_k3s_mdns_query.py
@@ -79,3 +79,29 @@ def test_query_mdns_handles_missing_avahi():
 
     assert results == []
     assert any("not found" in message for message in messages)
+
+
+def test_query_mdns_server_hosts_returns_unique_hosts(tmp_path):
+    fixture = tmp_path / "servers.txt"
+    fixture.write_text(
+        (
+            "=;eth0;IPv4;k3s API sugar/dev on host0;_https._tcp;local;host0.local;"
+            "192.168.1.10;6443;txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=server\n"
+            "=;eth0;IPv6;k3s API sugar/dev on host0;_https._tcp;local;host0.local;"
+            "fe80::1;6443;txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=server\n"
+            "=;eth0;IPv4;k3s API sugar/dev on host1;_https._tcp;local;host1.local;"
+            "192.168.1.11;6443;txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=server\n"
+            "=;eth0;IPv4;k3s API sugar/dev on host2;_https._tcp;local;host2.local;"
+            "192.168.1.12;6443;txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=bootstrap\n"
+        ),
+        encoding="utf-8",
+    )
+
+    results = query_mdns(
+        "server-hosts",
+        "sugar",
+        "dev",
+        fixture_path=str(fixture),
+    )
+
+    assert results == ["host0.local", "host1.local"]


### PR DESCRIPTION
what: verify local Avahi bootstrap/server adverts and new tests
why: discovery missed adverts so multiple Pi servers self-initialized
how to test: pytest tests/scripts tests/test_mdns_parsing.py tests/test_mdns_discovery_parsing.py

------
https://chatgpt.com/codex/tasks/task_e_68f9b4d89a40832f9c8bf4fa4aa7e542