### PR TITLE
Guard k3s bootstrap election from late server adverts

### DIFF
--- a/outages/2025-11-18-k3s-discover-mid-election-server.json
+++ b/outages/2025-11-18-k3s-discover-mid-election-server.json
@@ -1,0 +1,12 @@
+{
+  "id": "2025-11-18-k3s-discover-mid-election-server",
+  "date": "2025-11-18",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "claim_bootstrap_leadership never re-checked for newly advertised servers, so a later advert from the first node was ignored and the next Pi self-initialised, creating split brain.",
+  "resolution": "Poll for server adverts during the bootstrap election, surface the discovered host to the join path, and add an integration test that stubs avahi-browse to reproduce the mid-election hand-off.",
+  "references": [
+    "Console: sugarkube0 + sugarkube1 just up dev (2025-11-18)",
+    "scripts/k3s-discover.sh",
+    "tests/scripts/test_k3s_discover_mid_election_join.py"
+  ]
+}

--- a/scripts/k3s-discover.sh
+++ b/scripts/k3s-discover.sh
@@ -49,6 +49,7 @@ TEST_RUN_AVAHI=""
 TEST_RENDER_SERVICE=0
 TEST_WAIT_LOOP=0
 TEST_PUBLISH_BOOTSTRAP=0
+TEST_CLAIM_BOOTSTRAP=0
 declare -a TEST_RENDER_ARGS=()
 
 while [ "$#" -gt 0 ]; do
@@ -78,6 +79,9 @@ while [ "$#" -gt 0 ]; do
       ;;
     --test-bootstrap-publish)
       TEST_PUBLISH_BOOTSTRAP=1
+      ;;
+    --test-claim-bootstrap)
+      TEST_CLAIM_BOOTSTRAP=1
       ;;
     --help)
       cat <<'EOF_HELP'
@@ -194,6 +198,7 @@ AVAHI_SERVICE_FILE="${SUGARKUBE_AVAHI_SERVICE_FILE:-${AVAHI_SERVICE_DIR}/k3s-${C
 AVAHI_ROLE=""
 BOOTSTRAP_PUBLISH_PID=""
 BOOTSTRAP_PUBLISH_LOG=""
+CLAIMED_SERVER_HOST=""
 
 run_privileged() {
   if [ -n "${SUDO_CMD:-}" ]; then
@@ -567,9 +572,17 @@ publish_bootstrap_service() {
 claim_bootstrap_leadership() {
   publish_bootstrap_service
   sleep "${DISCOVERY_WAIT_SECS}"
-  local consecutive leader candidates
+  local consecutive leader candidates server
   consecutive=0
   for attempt in $(seq 1 "${DISCOVERY_ATTEMPTS}"); do
+    server="$(discover_server_host || true)"
+    if [ -n "${server}" ]; then
+      log "Server advertisement from ${server} observed during bootstrap election; deferring bootstrap."
+      CLAIMED_SERVER_HOST="${server}"
+      cleanup_avahi_bootstrap
+      return 2
+    fi
+
     mapfile -t candidates < <(discover_bootstrap_leaders || true)
     if [ "${#candidates[@]}" -eq 0 ]; then
       consecutive=0
@@ -716,6 +729,19 @@ if [ "${TEST_PUBLISH_BOOTSTRAP:-0}" -eq 1 ]; then
   exit 0
 fi
 
+if [ "${TEST_CLAIM_BOOTSTRAP:-0}" -eq 1 ]; then
+  CLAIMED_SERVER_HOST=""
+  if claim_bootstrap_leadership; then
+    printf 'bootstrap\n'
+    exit 0
+  fi
+  status=$?
+  if [ "${status}" -eq 2 ] && [ -n "${CLAIMED_SERVER_HOST:-}" ]; then
+    printf '%s\n' "${CLAIMED_SERVER_HOST}"
+  fi
+  exit "${status}"
+fi
+
 log "Discovering existing k3s API for ${CLUSTER}/${ENVIRONMENT} via mDNS..."
 server_host="$(discover_server_host || true)"
 
@@ -741,10 +767,20 @@ fi
 
 bootstrap_selected="false"
 if [ -z "${server_host:-}" ]; then
+  CLAIMED_SERVER_HOST=""
   if claim_bootstrap_leadership; then
     bootstrap_selected="true"
   else
-    server_host="$(wait_for_bootstrap_activity || true)"
+    claim_status=$?
+    if [ "${claim_status}" -eq 2 ]; then
+      if [ -n "${CLAIMED_SERVER_HOST:-}" ]; then
+        server_host="${CLAIMED_SERVER_HOST}"
+      else
+        server_host="$(discover_server_host || true)"
+      fi
+    else
+      server_host="$(wait_for_bootstrap_activity || true)"
+    fi
   fi
 fi
 

--- a/tests/scripts/test_k3s_discover_mid_election_join.py
+++ b/tests/scripts/test_k3s_discover_mid_election_join.py
@@ -1,0 +1,141 @@
+"""Regression tests for mid-election server discovery in k3s-discover."""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "k3s-discover.sh"
+
+
+def _write_stub(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_join_when_server_advertises_during_election(tmp_path: Path) -> None:
+    """A server coming online mid-election should cause a join, not bootstrap."""
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    state_file = tmp_path / "mdns-state.txt"
+    sh_log = tmp_path / "sh.log"
+    publish_log = tmp_path / "publish.log"
+
+    # Stub sleep to avoid delays in the control-flow.
+    _write_stub(bin_dir / "sleep", "#!/usr/bin/env bash\nexit 0\n")
+
+    # Stub systemctl to avoid touching the host service manager.
+    _write_stub(bin_dir / "systemctl", "#!/usr/bin/env bash\nexit 0\n")
+
+    # Pretend the API port starts listening immediately after the installer runs.
+    _write_stub(
+        bin_dir / "ss",
+        "#!/usr/bin/env bash\n" "echo 'LISTEN'\n" "exit 0\n",
+    )
+
+    # Provide a long-running avahi-publish-service implementation so the helper keeps a PID.
+    _write_stub(
+        bin_dir / "avahi-publish-service",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"echo START:\"$@\" >> '{publish_log}'\n"
+        "trap 'echo TERM >> \"" + str(publish_log) + "\"; exit 0' TERM INT\n"
+        "while true; do read -r -t 1 _ || true; done\n",
+    )
+
+    # Emit an installation script that immediately exits successfully.
+    _write_stub(
+        bin_dir / "curl",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "cat <<'SCRIPT'\n"
+        "#!/usr/bin/env sh\n"
+        "exit 0\n"
+        "SCRIPT\n",
+    )
+
+    # Capture invocations of sh -s - server ... from the installer pipeline.
+    _write_stub(
+        bin_dir / "sh",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "if [ -n \"${SH_LOG_PATH:-}\" ]; then\n"
+        "  printf '%s\\n' \"$*\" >> \"${SH_LOG_PATH}\"\n"
+        "fi\n"
+        "cat >/dev/null\n"
+        "exit 0\n",
+    )
+
+    # Simulate avahi-browse output: after enough server queries, emit a server advert.
+    _write_stub(
+        bin_dir / "avahi-browse",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'state="${SUGARKUBE_TEST_STATE}"\n'
+        'threshold="${SUGARKUBE_TEST_SERVER_THRESHOLD:-9}"\n'
+        "mode='bootstrap'\n"
+        "for arg in \"$@\"; do\n"
+        "  if [ \"$arg\" = '--ignore-local' ]; then\n"
+        "    mode='server'\n"
+        "  fi\n"
+        "done\n"
+        "if [ ! -f \"$state\" ]; then\n"
+        "  printf '0 0\n' >\"$state\"\n"
+        "fi\n"
+        "read -r server_count bootstrap_count <\"$state\"\n"
+        "if [ \"$mode\" = 'server' ]; then\n"
+        "  server_count=$((server_count + 1))\n"
+        "  if [ $server_count -ge $threshold ]; then\n"
+        "    cat <<'EOF'\n"
+        "=;eth0;IPv4;k3s API sugar/dev on sugarkube0;_https._tcp;local;"
+        "sugarkube0.local;192.168.50.10;6443;txt=k3s=1;txt=cluster=sugar;"
+        "txt=env=dev;txt=role=server\n"
+        "EOF\n"
+        "  fi\n"
+        "else\n"
+        "  bootstrap_count=$((bootstrap_count + 1))\n"
+        "fi\n"
+        "printf '%s %s\n' \"$server_count\" \"$bootstrap_count\" >\"$state\"\n"
+        "exit 0\n",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env.get('PATH', '')}",
+            "ALLOW_NON_ROOT": "1",
+            "SUGARKUBE_CLUSTER": "sugar",
+            "SUGARKUBE_ENV": "dev",
+            "SUGARKUBE_SERVERS": "3",
+            "SUGARKUBE_TOKEN": "dummy",
+            "DISCOVERY_ATTEMPTS": "3",
+            "DISCOVERY_WAIT_SECS": "0",
+            "SUGARKUBE_AVAHI_SERVICE_DIR": str(tmp_path / "avahi"),
+            "SUGARKUBE_TEST_STATE": str(state_file),
+            "SUGARKUBE_TEST_SERVER_THRESHOLD": "9",
+            "SH_LOG_PATH": str(sh_log),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "deferring bootstrap" in result.stderr
+    assert "Joining as additional HA server via https://sugarkube0.local:6443" in result.stderr
+
+    sh_log_contents = sh_log.read_text(encoding="utf-8")
+    assert "--cluster-init" not in sh_log_contents
+    assert "--server https://sugarkube0.local:6443" in sh_log_contents
+
+    publish_contents = publish_log.read_text(encoding="utf-8")
+    assert "START:" in publish_contents
+    assert "TERM" in publish_contents
+


### PR DESCRIPTION
## Summary
- detect server adverts during bootstrap leadership loop and surface the host to the join path
- add a regression test that stubs avahi-browse so later nodes join instead of re-bootstrapping
- document the incident in outages/ for future tracking

## Testing
- pytest tests/scripts/test_k3s_discover_mid_election_join.py
- pytest tests/scripts/test_k3s_discover_bootstrap_publish.py tests/test_mdns_discovery_parsing.py


------
https://chatgpt.com/codex/tasks/task_e_68f9b4d89a40832f9c8bf4fa4aa7e542