### PR TITLE
🐞 ensure bootstrap discovery retries publisher

### DIFF
--- a/outages/2025-11-15-k3s-discover-bootstrap-retry.json
+++ b/outages/2025-11-15-k3s-discover-bootstrap-retry.json
@@ -1,0 +1,12 @@
+{
+  "id": "2025-11-15-k3s-discover-bootstrap-retry",
+  "date": "2025-11-15",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "k3s-discover launched avahi-publish-service only once during bootstrap. When the daemon exited early (e.g. while avahi-daemon finished restarting) the helper never retried, so no bootstrap adverts were broadcast and subsequent nodes self-initialised, creating split brain.",
+  "resolution": "Detect when the bootstrap publisher dies, relaunch it while rewriting the Avahi service file, surface the failure in logs, and add a regression test that forces two failed launches before succeeding.",
+  "references": [
+    "scripts/k3s-discover.sh",
+    "tests/scripts/test_k3s_discover_bootstrap_publish.py"
+  ]
+}
+

--- a/tests/scripts/test_k3s_discover_bootstrap_publish.py
+++ b/tests/scripts/test_k3s_discover_bootstrap_publish.py
@@ -49,8 +49,8 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
     assert "TERM" in log_contents
 
     hostname = _hostname_short()
-    assert f"cluster=sugar" in log_contents
-    assert f"env=dev" in log_contents
+    assert "cluster=sugar" in log_contents
+    assert "env=dev" in log_contents
     assert f"leader={hostname}.local" in log_contents
     assert "role=bootstrap" in log_contents
 
@@ -60,3 +60,98 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
 
     # stderr should mention that avahi-publish-service is advertising the bootstrap role
     assert "avahi-publish-service advertising bootstrap" in result.stderr
+
+
+def test_bootstrap_claim_retries_failed_publisher(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    attempts_file = tmp_path / "publish-attempts"
+    running_flag = tmp_path / "publisher.running"
+
+    publish_stub = bin_dir / "avahi-publish-service"
+    publish_stub.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                "set -euo pipefail",
+                f"attempts_file='{attempts_file}'",
+                f"running_flag='{running_flag}'",
+                "count=0",
+                'if [ -f "$attempts_file" ]; then count=$(cat "$attempts_file"); fi',
+                "count=$((count + 1))",
+                'echo "$count" >"$attempts_file"',
+                'if [ "$count" -lt 3 ]; then',
+                "  exit 1",
+                "fi",
+                'echo $$ >"$running_flag"',
+                'trap_cmd=\'rm -f "$running_flag"; exit 0\'',
+                'trap "$trap_cmd" TERM INT',
+                "while true; do sleep 1; done",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    publish_stub.chmod(0o755)
+
+    hostname = _hostname_short()
+    browse_stub = bin_dir / "avahi-browse"
+    browse_stub.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                "set -euo pipefail",
+                f"running_flag='{running_flag}'",
+                "service=${@: -1}",
+                'if [ "${service}" != "_https._tcp" ]; then',
+                '  echo "unexpected service: ${service}" >&2',
+                "  exit 1",
+                "fi",
+                'if [ ! -f "$running_flag" ]; then',
+                "  exit 0",
+                "fi",
+                "cat <<'EOF'",
+                (
+                    f"=;eth0;IPv4;k3s API sugar/dev on {hostname};_https._tcp;local;"
+                    f"{hostname}.local;192.0.2.10;6443;txt=k3s=1;txt=cluster=sugar;"
+                    "txt=env=dev;txt=role=bootstrap;"
+                    f"txt=leader={hostname}.local"
+                ),
+                "EOF",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    browse_stub.chmod(0o755)
+
+    systemctl_stub = bin_dir / "systemctl"
+    systemctl_stub.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    systemctl_stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env.get('PATH', '')}",
+            "ALLOW_NON_ROOT": "1",
+            "SUGARKUBE_CLUSTER": "sugar",
+            "SUGARKUBE_ENV": "dev",
+            "SUGARKUBE_AVAHI_SERVICE_DIR": str(tmp_path / "avahi"),
+            "DISCOVERY_ATTEMPTS": "6",
+            "DISCOVERY_WAIT_SECS": "0",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", SCRIPT, "--test-claim-bootstrap"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert "claim-ok" in result.stdout
+    assert int(attempts_file.read_text(encoding="utf-8")) >= 3
+    assert not running_flag.exists()
+    assert "Bootstrap publisher" in result.stderr


### PR DESCRIPTION
what: retry bootstrap advertisement when avahi publisher exits early
why: prevent HA nodes from self-electing when discovery misses initial adverts
how to test: pytest tests/scripts/test_k3s_discover_bootstrap_publish.py

------
https://chatgpt.com/codex/tasks/task_e_68f9b4d89a40832f9c8bf4fa4aa7e542