### PR TITLE
Normalize mDNS host parsing for k3s bootstrap self-check

### DIFF
--- a/outages/2025-11-19-k3s-mdns-trailing-dot.json
+++ b/outages/2025-11-19-k3s-mdns-trailing-dot.json
@@ -1,0 +1,13 @@
+{
+  "id": "2025-11-19-k3s-mdns-trailing-dot",
+  "date": "2025-11-19",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "avahi-browse returned sugarkube0.local. so bootstrap aborted early.",
+  "resolution": "Trim trailing dots in mDNS parsing and add parser/bootstrap regression tests.",
+  "references": [
+    "scripts/k3s_mdns_parser.py",
+    "scripts/k3s-discover.sh",
+    "tests/scripts/test_k3s_mdns_query.py",
+    "tests/scripts/test_k3s_discover_bootstrap_publish.py"
+  ]
+}

--- a/tests/scripts/test_k3s_mdns_query.py
+++ b/tests/scripts/test_k3s_mdns_query.py
@@ -63,6 +63,34 @@ def test_query_mdns_bootstrap_leaders_uses_txt_leader(tmp_path):
     assert results == ["leader0.local", "host2.local"]
 
 
+def test_query_mdns_strips_trailing_dot_hosts(tmp_path):
+    fixture = tmp_path / "mdns.txt"
+    fixture.write_text(
+        (
+            "=;eth0;IPv4;k3s API sugar/dev [bootstrap] on host3;_https._tcp;local;host3.local.;"
+            "192.168.1.13;6443;txt=k3s=1;txt=cluster=sugar;txt=env=dev;"
+            "txt=role=bootstrap;txt=leader=host3.local.\n"
+        ),
+        encoding="utf-8",
+    )
+
+    hosts = query_mdns(
+        "bootstrap-hosts",
+        "sugar",
+        "dev",
+        fixture_path=str(fixture),
+    )
+    leaders = query_mdns(
+        "bootstrap-leaders",
+        "sugar",
+        "dev",
+        fixture_path=str(fixture),
+    )
+
+    assert hosts == ["host3.local"]
+    assert leaders == ["host3.local"]
+
+
 def test_query_mdns_uses_service_name_when_unresolved(tmp_path):
     fixture = tmp_path / "mdns.txt"
     fixture.write_text(


### PR DESCRIPTION
what: normalize Avahi host parsing and cover trailing dots
why: bootstrap aborted when avahi returned sugarkube0.local.
how: trim/lower host+leader fields and add regression tests
tests: pytest tests/scripts/test_k3s_mdns_query.py
tests: pytest tests/scripts/test_k3s_discover_bootstrap_publish.py
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68f9bcbbf5f8832fa866afc65b1be8b7