### PR TITLE
Fix bootstrap mDNS self-check for trailing dots

### DIFF
--- a/outages/2025-11-19-k3s-discover-bootstrap-mdns.json
+++ b/outages/2025-11-19-k3s-discover-bootstrap-mdns.json
@@ -1,0 +1,13 @@
+{
+  "id": "2025-11-19-k3s-discover-bootstrap-mdns",
+  "date": "2025-11-19",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "k3s-discover's mDNS self-check aborted bootstrap because avahi-browse returned hostnames with a trailing dot, the parser appended the domain again (host.local..local), and the bootstrap advert never matched the expected host.",
+  "resolution": "Strip trailing dots and normalise case in the mDNS parser before appending the domain, then add regression tests that cover avahi outputs ending with trailing dots so bootstrap self-check accepts the advert.",
+  "references": [
+    "Console: sugarkube0 just up dev (2025-11-19)",
+    "scripts/k3s_mdns_parser.py",
+    "tests/scripts/test_k3s_mdns_parser.py",
+    "tests/scripts/test_k3s_discover_bootstrap_publish.py"
+  ]
+}

--- a/scripts/k3s_mdns_parser.py
+++ b/scripts/k3s_mdns_parser.py
@@ -19,7 +19,8 @@ def _normalize_role(role: Optional[str]) -> Optional[str]:
 
 
 def _normalize_host(host: str, domain: str) -> str:
-    host = host.strip()
+    host = host.strip().rstrip(".").lower()
+    domain = domain.strip().rstrip(".").lower()
     if not host:
         return ""
     if domain and not host.endswith(f".{domain}"):
@@ -27,7 +28,10 @@ def _normalize_host(host: str, domain: str) -> str:
     return host
 
 
-def _parse_service_name(service_name: str, domain: str) -> Tuple[Optional[str], Optional[str], Optional[str], str]:
+def _parse_service_name(
+    service_name: str,
+    domain: str,
+) -> Tuple[Optional[str], Optional[str], Optional[str], str]:
     match = _SERVICE_NAME_RE.match(service_name)
     if not match:
         return None, None, None, ""
@@ -132,7 +136,7 @@ def parse_mdns_records(
 
         host = ""
         if len(fields) > 6 and fields[6]:
-            host = fields[6]
+            host = _normalize_host(fields[6], domain)
         elif service_host:
             host = service_host
         if not host:

--- a/tests/scripts/test_k3s_discover_bootstrap_publish.py
+++ b/tests/scripts/test_k3s_discover_bootstrap_publish.py
@@ -32,7 +32,8 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
             "#!/usr/bin/env bash\n"
             "set -euo pipefail\n"
             "cat <<'EOF'\n"
-            f"=;eth0;IPv4;k3s API sugar/dev on {hostname};_https._tcp;local;{hostname}.local;192.0.2.10;6443;"
+            f"=;eth0;IPv4;k3s API sugar/dev on {hostname};"
+            f"_https._tcp;local;{hostname}.local.;192.0.2.10;6443;"
             "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=bootstrap;"
             f"txt=leader={hostname}.local;txt=state=pending\n"
             "EOF\n"
@@ -66,8 +67,8 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
     assert "START:" in log_contents
     assert "TERM" in log_contents
 
-    assert f"cluster=sugar" in log_contents
-    assert f"env=dev" in log_contents
+    assert "cluster=sugar" in log_contents
+    assert "env=dev" in log_contents
     assert f"leader={hostname}.local" in log_contents
     assert "role=bootstrap" in log_contents
 


### PR DESCRIPTION
what:
- normalise trailing-dot mDNS hostnames and reuse the helper for resolved hosts
- add regression tests for bootstrap fixtures with trailing dots in avahi output
- record the bootstrap self-check outage in outages/

why:
- avahi advertised host.local. so the parser produced host.local..local and the self-check aborted

how to test:
- pytest tests/scripts/test_k3s_mdns_parser.py tests/scripts/test_k3s_discover_bootstrap_publish.py


------
https://chatgpt.com/codex/tasks/task_e_68f9bcbbf5f8832fa866afc65b1be8b7