### PR TITLE
Harden k3s bootstrap mDNS publish self-check

### DIFF
--- a/outages/2025-10-23-k3s-mdns-trailing-dot-self-check.json
+++ b/outages/2025-10-23-k3s-mdns-trailing-dot-self-check.json
@@ -8,5 +8,14 @@
     "scripts/k3s_mdns_parser.py",
     "tests/scripts/test_k3s_discover_bootstrap_publish.py",
     "tests/scripts/test_k3s_mdns_parser.py"
+  ],
+  "notes": [
+    "Symptom: bootstrap publisher logged a PID but avahi-browse never surfaced a _k3s advert.",
+    "Impact: just up dev aborted and risked a split-brain when node 2 attempted to join.",
+    "Fix: bind avahi-publish-service with -H <FQDN>, add a 1s settle delay, and tee output to /tmp/sugar-publish.log.",
+    "Phase: bootstrap self-check now logs phase=self-check host=<fqdn> to make retries explicit.",
+    "Quick triage: avahi-browse -rt _k3s-sugar-dev._tcp --parsable | sed -n '1,80p'",
+    "Quick triage: pgrep -a avahi-publish || true",
+    "Quick triage: sed -n '1,80p' /tmp/sugar-publish.log || true"
   ]
 }

--- a/scripts/k3s_mdns_parser.py
+++ b/scripts/k3s_mdns_parser.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 import re
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
+from mdns_helpers import _norm_host
+
 
 _SERVICE_NAME_RE = re.compile(
     r"^k3s API (?P<cluster>[^/]+)/(?P<environment>\S+)"
@@ -177,7 +179,8 @@ def parse_mdns_records(
         if txt.get("role") == "bootstrap" and "leader" not in txt:
             txt["leader"] = host
 
-        key = (host, txt.get("role", ""))
+        host_key = _norm_host(host)
+        key = (host_key, txt.get("role", ""))
 
         record = MdnsRecord(
             host=host,

--- a/scripts/k3s_mdns_query.py
+++ b/scripts/k3s_mdns_query.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Callable, Iterable, List, Optional
 
 from k3s_mdns_parser import MdnsRecord, parse_mdns_records
+from mdns_helpers import _same_host
 
 DebugFn = Optional[Callable[[str], None]]
 
@@ -94,39 +95,39 @@ def _render_mode(mode: str, records: Iterable[MdnsRecord]) -> List[str]:
         return [str(count)]
 
     if mode == "bootstrap-hosts":
-        seen = set()
+        seen: List[str] = []
         outputs: List[str] = []
         for record in records:
             if record.txt.get("role") != "bootstrap":
                 continue
-            if record.host in seen:
+            if any(_same_host(record.host, existing) for existing in seen):
                 continue
-            seen.add(record.host)
+            seen.append(record.host)
             outputs.append(record.host)
         return outputs
 
     if mode == "server-hosts":
-        seen = set()
+        seen: List[str] = []
         outputs: List[str] = []
         for record in records:
             if record.txt.get("role") != "server":
                 continue
-            if record.host in seen:
+            if any(_same_host(record.host, existing) for existing in seen):
                 continue
-            seen.add(record.host)
+            seen.append(record.host)
             outputs.append(record.host)
         return outputs
 
     if mode == "bootstrap-leaders":
-        seen = set()
+        seen: List[str] = []
         outputs: List[str] = []
         for record in records:
             if record.txt.get("role") != "bootstrap":
                 continue
             leader = record.txt.get("leader", record.host)
-            if leader in seen:
+            if any(_same_host(leader, existing) for existing in seen):
                 continue
-            seen.add(leader)
+            seen.append(leader)
             outputs.append(leader)
         return outputs
 

--- a/scripts/mdns_helpers.py
+++ b/scripts/mdns_helpers.py
@@ -1,0 +1,50 @@
+"""Common helpers for mDNS host normalization."""
+from __future__ import annotations
+
+from typing import Optional
+
+
+def _norm_host(host: str) -> str:
+    """Return a lowercase, trailing-dot-free representation of ``host``."""
+
+    host = host.strip().lower()
+    while host.endswith("."):
+        host = host[:-1]
+    return host
+
+
+def _strip_suffix(host: str, suffix: str) -> str:
+    suffix = suffix.strip().lower()
+    if not suffix:
+        return host
+    dot_suffix = f".{suffix.lstrip('.')}"
+    if host.endswith(dot_suffix):
+        return host[: -len(dot_suffix)]
+    return host
+
+
+def _same_host(lhs: str, rhs: str, *, domain: Optional[str] = None) -> bool:
+    """Compare host labels, tolerating case, trailing dots, and .local suffixes."""
+
+    lhs_norm = _norm_host(lhs)
+    rhs_norm = _norm_host(rhs)
+    if lhs_norm == rhs_norm:
+        return True
+
+    suffixes = []
+    if domain:
+        domain_norm = domain.strip().rstrip(".").lower()
+        if domain_norm:
+            suffixes.append(domain_norm)
+    suffixes.append("local")
+
+    for suffix in suffixes:
+        lhs_trimmed = _strip_suffix(lhs_norm, suffix)
+        rhs_trimmed = _strip_suffix(rhs_norm, suffix)
+        if lhs_trimmed == rhs_trimmed:
+            return True
+
+    return False
+
+
+__all__ = ["_norm_host", "_same_host"]

--- a/tests/scripts/test_k3s_discover_bootstrap_publish.py
+++ b/tests/scripts/test_k3s_discover_bootstrap_publish.py
@@ -34,7 +34,7 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
             "cat <<'EOF'\n"
             f"=;eth0;IPv4;k3s API sugar/dev on {hostname};_https._tcp;local;{hostname}.local;192.0.2.10;6443;"
             "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=bootstrap;"
-            f"txt=leader={hostname}.local;txt=state=pending\n"
+            f"txt=leader={hostname}.local;txt=phase=bootstrap;txt=state=pending\n"
             "EOF\n"
         ),
         encoding="utf-8",
@@ -69,6 +69,8 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
     assert f"cluster=sugar" in log_contents
     assert f"env=dev" in log_contents
     assert f"leader={hostname}.local" in log_contents
+    assert "phase=bootstrap" in log_contents
+    assert f"-H {hostname}.local" in log_contents
     assert "role=bootstrap" in log_contents
 
     # Service file should have been cleaned up by the EXIT trap
@@ -105,7 +107,7 @@ def test_bootstrap_publish_handles_trailing_dot_hostname(tmp_path):
             f"=;eth0;IPv4;k3s API sugar/dev on {hostname}.local.;_https._tcp;local.;"
             f"{hostname}.local.;192.0.2.10;6443;"
             "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=bootstrap;"
-            f"txt=leader={hostname}.local.;txt=state=pending\n"
+            f"txt=leader={hostname}.local.;txt=phase=bootstrap;txt=state=pending\n"
             "EOF\n"
         ),
         encoding="utf-8",
@@ -136,8 +138,83 @@ def test_bootstrap_publish_handles_trailing_dot_hostname(tmp_path):
     assert "START:" in log_contents
     assert "TERM" in log_contents
     assert f"leader={hostname}.local" in log_contents
+    assert "phase=bootstrap" in log_contents
+    assert f"-H {hostname}.local" in log_contents
 
     assert "Avahi did not report bootstrap advertisement" not in result.stderr
+
+
+def test_publish_binds_host_and_self_check_delays(tmp_path):
+    mixed_case_host = "HostMixedCase"
+    fqdn = f"{mixed_case_host}.Local"
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_path = tmp_path / "publish.log"
+    browse_counter = tmp_path / "browse-count"
+
+    stub = bin_dir / "avahi-publish-service"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"echo \"START:$*\" >> '{log_path}'\n"
+        "trap 'echo TERM >> \"" + str(log_path) + "\"; exit 0' TERM INT\n"
+        "while true; do sleep 1; done\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+
+    browse = bin_dir / "avahi-browse"
+    browse.write_text(
+        (
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            f"count=0\nif [ -f '{browse_counter}' ]; then count=$(cat '{browse_counter}'); fi\n"
+            "count=$((count + 1))\n"
+            f"echo $count > '{browse_counter}'\n"
+            'if [ "$count" -eq 1 ]; then exit 0; fi\n'
+            "cat <<'EOF'\n"
+            "=;eth0;IPv4;k3s API sugar/dev on HOSTMIXEDCASE.local.;_https._tcp;local.;"
+            "HOSTMIXEDCASE.local.;192.0.2.20;6443;"
+            "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=bootstrap;"
+            "txt=leader=HOSTMIXEDCASE.LOCAL.;txt=phase=bootstrap;txt=state=pending\n"
+            "EOF\n"
+        ),
+        encoding="utf-8",
+    )
+    browse.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env.get('PATH', '')}",
+            "SUGARKUBE_CLUSTER": "sugar",
+            "SUGARKUBE_ENV": "dev",
+            "ALLOW_NON_ROOT": "1",
+            "SUGARKUBE_AVAHI_SERVICE_DIR": str(tmp_path / "avahi"),
+            "SUGARKUBE_TOKEN": "dummy",
+            "SUGARKUBE_MDNS_HOST": fqdn,
+            "SUGARKUBE_MDNS_SELF_CHECK_ATTEMPTS": "2",
+            "SUGARKUBE_MDNS_SELF_CHECK_DELAY": "0",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", SCRIPT, "--test-bootstrap-publish"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    log_contents = log_path.read_text(encoding="utf-8")
+    assert f"-H {fqdn}" in log_contents
+    assert "phase=bootstrap" in log_contents
+
+    assert browse_counter.read_text(encoding="utf-8").strip() == "2"
+    assert "phase=self-check" in result.stderr
+    assert f"host={fqdn}" in result.stderr
+    assert "attempt=1/2" in result.stderr
 
 
 def test_bootstrap_publish_fails_without_mdns(tmp_path):

--- a/tests/scripts/test_k3s_discover_render_xml.py
+++ b/tests/scripts/test_k3s_discover_render_xml.py
@@ -16,7 +16,7 @@ def _render(role, *txt):
 
 
 def test_render_bootstrap_xml_has_required_txt_records():
-    root = _render("bootstrap", "leader=host0.local", "state=pending")
+    root = _render("bootstrap", "leader=host0.local", "phase=bootstrap", "state=pending")
     name = root.find("./name")
     assert name is not None and "sugar/dev" in name.text
 
@@ -27,8 +27,15 @@ def test_render_bootstrap_xml_has_required_txt_records():
 
     txts = [e.text for e in svc.findall("./txt-record")]
     # Must include required baseline and our extras
-    for expected in ["k3s=1", "cluster=sugar", "env=dev", "role=bootstrap",
-                     "leader=host0.local", "state=pending"]:
+    for expected in [
+        "k3s=1",
+        "cluster=sugar",
+        "env=dev",
+        "role=bootstrap",
+        "leader=host0.local",
+        "phase=bootstrap",
+        "state=pending",
+    ]:
         assert expected in txts
 
 


### PR DESCRIPTION
## Summary
- bind the bootstrap avahi publisher to the chosen FQDN, capture its output in /tmp/sugar-publish.log, and add a one-second settle before the self-check
- normalize host comparisons for bootstrap/server discovery, tighten self-check logging, and ensure bootstrap TXT records carry the phase marker
- extend the parser/query helpers and add regression tests plus outage notes covering mixed-case and trailing-dot host advertisements

## Testing
- pytest tests/scripts/test_k3s_discover_bootstrap_publish.py tests/scripts/test_k3s_discover_render_xml.py tests/scripts/test_k3s_mdns_parser.py tests/scripts/test_k3s_mdns_query.py

------
https://chatgpt.com/codex/tasks/task_e_68f9c42f3180832f823becc5645f9afa