### PR TITLE
Add Avahi/K3s bootstrap automation and just helpers

### DIFF
--- a/justfile
+++ b/justfile
@@ -19,8 +19,21 @@ up env='dev': prereqs
 
     "{{ scripts_dir }}/check_memory_cgroup.sh"
 
+    if [ "${SUGARKUBE_CONFIGURE_AVAHI:-1}" = "1" ]; then
+      sudo -E bash scripts/configure_avahi.sh
+    fi
+    if [ "${SUGARKUBE_DISABLE_WLAN_DURING_BOOTSTRAP:-1}" = "1" ]; then
+      sudo -E bash scripts/toggle_wlan.sh --down
+    fi
+    if [ "${SUGARKUBE_SET_K3S_NODE_IP:-1}" = "1" ]; then
+      sudo -E bash scripts/configure_k3s_node_ip.sh
+    fi
+
     # Proceed with discovery/join for subsequent nodes
     sudo -E bash scripts/k3s-discover.sh
+    if [ "${SUGARKUBE_DISABLE_WLAN_DURING_BOOTSTRAP:-1}" = "1" ]; then
+      sudo -E bash scripts/toggle_wlan.sh --restore || true
+    fi
 
 prereqs:
     sudo apt-get update
@@ -31,6 +44,33 @@ prereqs:
 status:
     if ! command -v k3s >/dev/null 2>&1; then printf '%s\n' 'k3s is not installed yet.' 'Visit https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md.' 'Follow the instructions in that guide before rerunning this command.'; exit 0; fi
     sudo k3s kubectl get nodes -o wide
+
+mdns-harden:
+    sudo -E bash scripts/configure_avahi.sh
+
+node-ip-dropin:
+    sudo -E bash scripts/configure_k3s_node_ip.sh
+
+wlan-down:
+    sudo -E bash scripts/toggle_wlan.sh --down
+
+wlan-up:
+    sudo -E bash scripts/toggle_wlan.sh --restore
+
+mdns-reset:
+    sudo bash -lc '
+      set -e
+      if [ -f /etc/avahi/avahi-daemon.conf.bak ]; then
+        cp /etc/avahi/avahi-daemon.conf.bak /etc/avahi/avahi-daemon.conf
+        systemctl restart avahi-daemon
+      fi
+      for SVC in k3s.service k3s-agent.service; do
+        if systemctl list-unit-files | grep -q "^${SVC}"; then
+          rm -f "/etc/systemd/system/${SVC}.d/10-node-ip.conf" || true
+        fi
+      done
+      systemctl daemon-reload
+    '
 
 kubeconfig env='dev':
     mkdir -p ~/.kube

--- a/scripts/configure_avahi.sh
+++ b/scripts/configure_avahi.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IFACE="${SUGARKUBE_MDNS_INTERFACE:-eth0}"
+IPV4_ONLY="${SUGARKUBE_MDNS_IPV4_ONLY:-1}"
+CONF="${AVAHI_CONF_PATH:-/etc/avahi/avahi-daemon.conf}"
+BACKUP="${CONF}.bak"
+LOG_DIR="${SUGARKUBE_LOG_DIR:-/var/log/sugarkube}"
+LOG_FILE="${LOG_DIR}/configure_avahi.log"
+
+log() {
+  local timestamp
+  timestamp="$(date -Iseconds 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S')"
+  local message="$*"
+  printf '%s %s\n' "${timestamp}" "${message}"
+  printf '%s %s\n' "${timestamp}" "${message}" >>"${LOG_FILE}"
+}
+
+render_config() {
+  local dest="$1"
+  if [ ! -f "${CONF}" ]; then
+    {
+      printf '[server]\n'
+      printf 'allow-interfaces=%s\n' "${IFACE}"
+      if [ "${IPV4_ONLY}" = "1" ]; then
+        printf 'use-ipv4=yes\n'
+        printf 'use-ipv6=no\n'
+      fi
+    } >"${dest}"
+    return 0
+  fi
+
+  awk -v iface="${IFACE}" -v ipv4_only="${IPV4_ONLY}" '
+  function flush_server() {
+    if (in_server == 0) {
+      return
+    }
+    if (!allow_written) {
+      print "allow-interfaces=" iface
+    }
+    if (ipv4_only == "1") {
+      if (!ipv4_written) {
+        print "use-ipv4=yes"
+      }
+      if (!ipv6_written) {
+        print "use-ipv6=no"
+      }
+    }
+    in_server = 0
+  }
+  BEGIN {
+    server_seen = 0
+    in_server = 0
+    allow_written = 0
+    ipv4_written = 0
+    ipv6_written = 0
+  }
+  {
+    if ($0 ~ /^\[server\]/) {
+      flush_server()
+      server_seen = 1
+      in_server = 1
+      allow_written = 0
+      ipv4_written = 0
+      ipv6_written = 0
+      print $0
+      next
+    }
+    if (in_server && $0 ~ /^\[/) {
+      flush_server()
+    }
+    if (in_server) {
+      if ($0 ~ /^allow-interfaces=/) {
+        print "allow-interfaces=" iface
+        allow_written = 1
+      } else if ($0 ~ /^use-ipv4=/) {
+        if (ipv4_only == "1") {
+          print "use-ipv4=yes"
+        } else {
+          print $0
+        }
+        ipv4_written = 1
+      } else if ($0 ~ /^use-ipv6=/) {
+        if (ipv4_only == "1") {
+          print "use-ipv6=no"
+        } else {
+          print $0
+        }
+        ipv6_written = 1
+      } else {
+        print $0
+      }
+      next
+    }
+    print $0
+  }
+  END {
+    if (in_server) {
+      flush_server()
+    }
+    if (!server_seen) {
+      if (NR > 0) {
+        print ""
+      }
+      print "[server]"
+      print "allow-interfaces=" iface
+      if (ipv4_only == "1") {
+        print "use-ipv4=yes"
+        print "use-ipv6=no"
+      }
+    }
+  }
+  ' "${CONF}" >"${dest}"
+}
+
+main() {
+  mkdir -p "${LOG_DIR}"
+  touch "${LOG_FILE}"
+  log "Starting Avahi configuration: interface=${IFACE} ipv4_only=${IPV4_ONLY}"
+
+  if [ ! -f "${CONF}" ]; then
+    log "Configuration file not found: ${CONF}"
+    exit 1
+  fi
+
+  if [ ! -f "${BACKUP}" ]; then
+    cp "${CONF}" "${BACKUP}"
+    log "Created backup at ${BACKUP}"
+  else
+    log "Backup already exists at ${BACKUP}"
+  fi
+
+  local tmp
+  tmp="$(mktemp)"
+  trap 'rm -f "${tmp}"' EXIT
+
+  render_config "${tmp}"
+
+  local changed=0
+  if ! cmp -s "${tmp}" "${CONF}"; then
+    changed=1
+    local mode owner group
+    mode="$(stat -c '%a' "${CONF}" 2>/dev/null || echo '0644')"
+    owner="$(stat -c '%u' "${CONF}" 2>/dev/null || echo '0')"
+    group="$(stat -c '%g' "${CONF}" 2>/dev/null || echo '0')"
+    install -o "${owner}" -g "${group}" -m "${mode}" "${tmp}" "${CONF}"
+    log "Updated ${CONF}"
+  else
+    log "No changes required for ${CONF}"
+  fi
+
+  rm -f "${tmp}"
+  trap - EXIT
+
+  if [ "${changed}" -eq 1 ]; then
+    if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
+      log "Restarting avahi-daemon"
+      systemctl restart avahi-daemon
+      log "avahi-daemon restarted"
+    else
+      log "systemctl unavailable; skipping avahi-daemon restart"
+    fi
+  else
+    log "Skipping avahi-daemon restart"
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/configure_k3s_node_ip.sh
+++ b/scripts/configure_k3s_node_ip.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IFACE="${SUGARKUBE_MDNS_INTERFACE:-eth0}"
+LOG_DIR="${SUGARKUBE_LOG_DIR:-/var/log/sugarkube}"
+LOG_FILE="${LOG_DIR}/configure_k3s_node_ip.log"
+DROPIN_NAME="10-node-ip.conf"
+
+log() {
+  local timestamp
+  timestamp="$(date -Iseconds 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S')"
+  local message="$*"
+  printf '%s %s\n' "${timestamp}" "${message}"
+  printf '%s %s\n' "${timestamp}" "${message}" >>"${LOG_FILE}"
+}
+
+extract_primary_ipv4() {
+  local line candidate
+  while IFS= read -r line; do
+    case "${line}" in
+      *" inet "*)
+        candidate="${line#* inet }"
+        candidate="${candidate%% *}"
+        if [[ "${candidate}" == */* ]]; then
+          printf '%s\n' "${candidate%%/*}"
+          return 0
+        fi
+        ;;
+    esac
+  done
+  return 1
+}
+
+service_exists() {
+  local svc="$1"
+  if systemctl list-unit-files "${svc}" >/dev/null 2>&1; then
+    return 0
+  fi
+  if systemctl status "${svc}" >/dev/null 2>&1; then
+    return 0
+  fi
+  if [ -f "/etc/systemd/system/${svc}" ] || [ -f "/lib/systemd/system/${svc}" ]; then
+    return 0
+  fi
+  return 1
+}
+
+write_dropin() {
+  local svc="$1"
+  local ip="$2"
+  local dir="/etc/systemd/system/${svc}.d"
+  local path="${dir}/${DROPIN_NAME}"
+  local tmp
+
+  mkdir -p "${dir}"
+  tmp="$(mktemp)"
+  {
+    printf '[Service]\n'
+    printf 'Environment=K3S_NODE_IP=%s\n' "${ip}"
+  } >"${tmp}"
+
+  if [ -f "${path}" ] && cmp -s "${tmp}" "${path}"; then
+    rm -f "${tmp}"
+    return 1
+  fi
+
+  local mode owner group
+  if [ -f "${path}" ]; then
+    mode="$(stat -c '%a' "${path}" 2>/dev/null || echo '0644')"
+    owner="$(stat -c '%u' "${path}" 2>/dev/null || echo '0')"
+    group="$(stat -c '%g' "${path}" 2>/dev/null || echo '0')"
+  else
+    mode='0644'
+    owner='0'
+    group='0'
+  fi
+
+  install -o "${owner}" -g "${group}" -m "${mode}" "${tmp}" "${path}"
+  rm -f "${tmp}"
+  return 0
+}
+
+main() {
+  mkdir -p "${LOG_DIR}"
+  touch "${LOG_FILE}"
+  log "Starting k3s node IP configuration for interface ${IFACE}"
+
+  local ip_output ip_addr
+  if ! ip_output="$(ip -4 -o addr show "${IFACE}" 2>/dev/null)"; then
+    log "Failed to query IPv4 address on ${IFACE}"
+    exit 1
+  fi
+
+  if ! ip_addr="$(printf '%s\n' "${ip_output}" | extract_primary_ipv4)"; then
+    log "No IPv4 address detected on ${IFACE}"
+    exit 1
+  fi
+
+  log "Detected IPv4 address ${ip_addr} on ${IFACE}"
+
+  local reload_needed=0
+  local -a restart_services=()
+  local svc
+  for svc in k3s.service k3s-agent.service; do
+    if ! service_exists "${svc}"; then
+      log "${svc} not found; skipping drop-in"
+      continue
+    fi
+
+    if write_dropin "${svc}" "${ip_addr}"; then
+      log "Updated ${svc} drop-in with K3S_NODE_IP=${ip_addr}"
+      reload_needed=1
+      restart_services+=("${svc}")
+    else
+      log "${svc} drop-in already up to date"
+    fi
+  done
+
+  if [ "${reload_needed}" -eq 1 ]; then
+    systemctl daemon-reload
+    log "Reloaded systemd units"
+    local unit
+    for unit in "${restart_services[@]}"; do
+      if systemctl is-active --quiet "${unit}"; then
+        systemctl restart "${unit}"
+        log "Restarted ${unit}"
+      else
+        log "${unit} not active; skipping restart"
+      fi
+    done
+  else
+    log "No changes detected; skipping daemon-reload"
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/toggle_wlan.sh
+++ b/scripts/toggle_wlan.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE=""
+WLAN_IFACE="${SUGARKUBE_WLAN_INTERFACE:-wlan0}"
+RUN_DIR="${SUGARKUBE_RUN_DIR:-/run/sugarkube}"
+GUARD_FILE="${RUN_DIR}/wlan-disabled"
+LOG_DIR="${SUGARKUBE_LOG_DIR:-/var/log/sugarkube}"
+LOG_FILE="${LOG_DIR}/toggle_wlan.log"
+
+log() {
+  local timestamp
+  timestamp="$(date -Iseconds 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S')"
+  local message="$*"
+  printf '%s %s\n' "${timestamp}" "${message}"
+  printf '%s %s\n' "${timestamp}" "${message}" >>"${LOG_FILE}"
+}
+
+usage() {
+  cat <<'USAGE'
+Usage: toggle_wlan.sh [--down|--restore]
+
+  --down     Disable the wireless interface and record guard state.
+  --restore  Re-enable the wireless interface if it was disabled by this script.
+USAGE
+}
+
+parse_args() {
+  if [ "$#" -eq 0 ]; then
+    MODE="down"
+    return
+  fi
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --down)
+        MODE="down"
+        ;;
+      --restore)
+        MODE="restore"
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        printf 'Unknown option: %s\n' "$1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
+
+interface_exists() {
+  ip link show "${WLAN_IFACE}" >/dev/null 2>&1
+}
+
+disable_wlan() {
+  if ! interface_exists; then
+    log "Interface ${WLAN_IFACE} not found; skipping disable"
+    return 0
+  fi
+
+  mkdir -p "${RUN_DIR}"
+  ip link set "${WLAN_IFACE}" down
+  touch "${GUARD_FILE}"
+  log "Brought ${WLAN_IFACE} down and recorded guard at ${GUARD_FILE}"
+}
+
+enable_wlan() {
+  if [ ! -f "${GUARD_FILE}" ]; then
+    log "Guard file ${GUARD_FILE} missing; nothing to restore"
+    return 0
+  fi
+
+  if interface_exists; then
+    ip link set "${WLAN_IFACE}" up
+    log "Brought ${WLAN_IFACE} back up"
+  else
+    log "Interface ${WLAN_IFACE} missing during restore"
+  fi
+
+  rm -f "${GUARD_FILE}"
+}
+
+main() {
+  mkdir -p "${LOG_DIR}"
+  touch "${LOG_FILE}"
+  parse_args "$@"
+
+  case "${MODE}" in
+    down)
+      disable_wlan
+      ;;
+    restore)
+      enable_wlan
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/tests/scripts/test_configure_avahi.sh
+++ b/tests/scripts/test_configure_avahi.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/scripts/configure_avahi.sh"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+CONF_PATH="${TMP_DIR}/avahi-daemon.conf"
+LOG_DIR="${TMP_DIR}/logs"
+
+cat <<'CONFIG' >"${CONF_PATH}"
+[server]
+# existing comment
+enable-dbus=yes
+
+[publish]
+publish-addresses=yes
+CONFIG
+
+export SUGARKUBE_MDNS_INTERFACE="eth1"
+export SUGARKUBE_MDNS_IPV4_ONLY="1"
+export AVAHI_CONF_PATH="${CONF_PATH}"
+export SUGARKUBE_LOG_DIR="${LOG_DIR}"
+
+bash "${SCRIPT_PATH}"
+
+if [ ! -f "${CONF_PATH}.bak" ]; then
+  echo "Expected backup ${CONF_PATH}.bak to exist" >&2
+  exit 1
+fi
+
+if ! grep -q '^allow-interfaces=eth1$' "${CONF_PATH}"; then
+  echo "allow-interfaces not configured correctly" >&2
+  exit 1
+fi
+
+if [ "${SUGARKUBE_MDNS_IPV4_ONLY}" = "1" ]; then
+  if ! grep -q '^use-ipv4=yes$' "${CONF_PATH}"; then
+    echo "use-ipv4=yes missing" >&2
+    exit 1
+  fi
+  if ! grep -q '^use-ipv6=no$' "${CONF_PATH}"; then
+    echo "use-ipv6=no missing" >&2
+    exit 1
+  fi
+fi
+
+cp "${CONF_PATH}" "${TMP_DIR}/after_first.conf"
+
+bash "${SCRIPT_PATH}"
+
+if ! cmp -s "${TMP_DIR}/after_first.conf" "${CONF_PATH}"; then
+  echo "Configuration changed on second run" >&2
+  exit 1
+fi
+
+echo "configure_avahi.sh test passed"

--- a/tests/scripts/test_detect_node_ip.py
+++ b/tests/scripts/test_detect_node_ip.py
@@ -1,0 +1,59 @@
+"""Tests for the configure_k3s_node_ip helper parser."""
+
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "configure_k3s_node_ip.sh"
+
+
+def _run_parser(sample: str) -> subprocess.CompletedProcess[str]:
+    command = textwrap.dedent(
+        f"""
+        set -euo pipefail
+        source '{SCRIPT_PATH}'
+        extract_primary_ipv4 <<'IPDATA'
+        {sample}
+IPDATA
+        """
+    )
+    return subprocess.run(
+        ["bash", "-c", command],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_extract_primary_ipv4_single_address() -> None:
+    sample = """
+        2: eth0    inet 192.168.0.20/24 brd 192.168.0.255 scope global dynamic eth0
+           valid_lft 86378sec preferred_lft 86378sec
+    """
+    result = _run_parser(sample)
+    assert result.returncode == 0
+    assert result.stdout.strip() == "192.168.0.20"
+
+
+def test_extract_primary_ipv4_prefers_first_entry() -> None:
+    sample = """
+        3: eth0    inet 10.10.0.5/24 brd 10.10.0.255 scope global eth0
+           valid_lft 86388sec preferred_lft 86388sec
+        3: eth0    inet 10.10.0.6/24 brd 10.10.0.255 scope global secondary eth0
+           valid_lft 86388sec preferred_lft 86388sec
+    """
+    result = _run_parser(sample)
+    assert result.returncode == 0
+    assert result.stdout.strip() == "10.10.0.5"
+
+
+def test_extract_primary_ipv4_missing_address() -> None:
+    sample = """
+        1: lo    inet6 ::1/128 scope host
+           valid_lft forever preferred_lft forever
+    """
+    result = _run_parser(sample)
+    assert result.returncode != 0
+    assert result.stdout.strip() == ""


### PR DESCRIPTION
## Summary
- add scripts to configure Avahi, manage k3s node IP drop-ins, and toggle wlan
- integrate the helpers into `just up` and add mdns/k3s/wlan recipes plus reset tooling
- cover the new scripts with a shell idempotency check and a parser unit test

## Testing
- bash tests/scripts/test_configure_avahi.sh
- pytest tests/scripts/test_detect_node_ip.py

------
https://chatgpt.com/codex/tasks/task_e_68f9cf36418c832f950bebd945416670