### PR TITLE
Add scripts to pin Avahi interface, toggle wlan, and set K3s node IP

### DIFF
--- a/justfile
+++ b/justfile
@@ -19,8 +19,22 @@ up env='dev': prereqs
 
     "{{ scripts_dir }}/check_memory_cgroup.sh"
 
+    if [ "${SUGARKUBE_CONFIGURE_AVAHI:-1}" = "1" ]; then
+      sudo -E bash scripts/configure_avahi.sh
+    fi
+    if [ "${SUGARKUBE_DISABLE_WLAN_DURING_BOOTSTRAP:-1}" = "1" ]; then
+      sudo -E bash scripts/toggle_wlan.sh --down
+    fi
+    if [ "${SUGARKUBE_SET_K3S_NODE_IP:-1}" = "1" ]; then
+      sudo -E bash scripts/configure_k3s_node_ip.sh
+    fi
+
     # Proceed with discovery/join for subsequent nodes
     sudo -E bash scripts/k3s-discover.sh
+
+    if [ "${SUGARKUBE_DISABLE_WLAN_DURING_BOOTSTRAP:-1}" = "1" ]; then
+      sudo -E bash scripts/toggle_wlan.sh --restore || true
+    fi
 
 prereqs:
     sudo apt-get update
@@ -31,6 +45,33 @@ prereqs:
 status:
     if ! command -v k3s >/dev/null 2>&1; then printf '%s\n' 'k3s is not installed yet.' 'Visit https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md.' 'Follow the instructions in that guide before rerunning this command.'; exit 0; fi
     sudo k3s kubectl get nodes -o wide
+
+mdns-harden:
+    sudo -E bash scripts/configure_avahi.sh
+
+node-ip-dropin:
+    sudo -E bash scripts/configure_k3s_node_ip.sh
+
+wlan-down:
+    sudo -E bash scripts/toggle_wlan.sh --down
+
+wlan-up:
+    sudo -E bash scripts/toggle_wlan.sh --restore
+
+mdns-reset:
+    sudo bash -lc '
+      set -e
+      if [ -f /etc/avahi/avahi-daemon.conf.bak ]; then
+        cp /etc/avahi/avahi-daemon.conf.bak /etc/avahi/avahi-daemon.conf
+        systemctl restart avahi-daemon
+      fi
+      for SVC in k3s.service k3s-agent.service; do
+        if systemctl list-unit-files "${SVC}" >/dev/null 2>&1; then
+          rm -f "/etc/systemd/system/${SVC}.d/10-node-ip.conf"
+        fi
+      done
+      systemctl daemon-reload
+    '
 
 kubeconfig env='dev':
     mkdir -p ~/.kube

--- a/scripts/configure_avahi.sh
+++ b/scripts/configure_avahi.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IFACE="${SUGARKUBE_MDNS_INTERFACE:-eth0}"
+IPV4_ONLY="${SUGARKUBE_MDNS_IPV4_ONLY:-1}"
+CONF="${AVAHI_CONF_PATH:-/etc/avahi/avahi-daemon.conf}"
+BACKUP_PATH="${CONF}.bak"
+LOG_DIR="${SUGARKUBE_LOG_DIR:-/var/log/sugarkube}"
+LOG_FILE="${LOG_DIR}/configure_avahi.log"
+if [ -z "${SYSTEMCTL_BIN+x}" ]; then
+  SYSTEMCTL_BIN="systemctl"
+fi
+
+mkdir -p "${LOG_DIR}"
+
+log() {
+  local timestamp
+  timestamp="$(date '+%Y-%m-%dT%H:%M:%S%z')"
+  printf '%s %s\n' "${timestamp}" "$*" | tee -a "${LOG_FILE}" >/dev/null
+}
+
+ensure_conf_exists() {
+  local conf_dir
+  conf_dir="$(dirname "${CONF}")"
+  if [ ! -d "${conf_dir}" ]; then
+    mkdir -p "${conf_dir}"
+    log "Created directory ${conf_dir}"
+  fi
+  if [ ! -e "${CONF}" ]; then
+    : >"${CONF}"
+    log "Created empty ${CONF}"
+  fi
+}
+
+backup_conf() {
+  if [ -f "${BACKUP_PATH}" ]; then
+    return
+  fi
+  if [ -f "${CONF}" ]; then
+    cp "${CONF}" "${BACKUP_PATH}"
+    log "Backed up ${CONF} to ${BACKUP_PATH}"
+  fi
+}
+
+render_config() {
+  awk -v iface="${IFACE}" -v ipv4_only="${IPV4_ONLY}" '
+    function flush_server() {
+      if (in_server) {
+        if (allow_written == 0) {
+          print "allow-interfaces=" iface
+          allow_written = 1
+          last_line_blank = 0
+        }
+        if (ipv4_only == "1") {
+          if (use_ipv4_written == 0) {
+            print "use-ipv4=yes"
+            use_ipv4_written = 1
+            last_line_blank = 0
+          }
+          if (use_ipv6_written == 0) {
+            print "use-ipv6=no"
+            use_ipv6_written = 1
+            last_line_blank = 0
+          }
+        }
+      }
+    }
+    BEGIN {
+      in_server = 0
+      found_server = 0
+      allow_written = 0
+      use_ipv4_written = 0
+      use_ipv6_written = 0
+      last_line_blank = 1
+    }
+    /^[[:space:]]*\[.*\][[:space:]]*$/ {
+      if (in_server) {
+        flush_server()
+      }
+      in_server = ($0 ~ /^[[:space:]]*\[server\][[:space:]]*$/)
+      if (in_server) {
+        found_server = 1
+        allow_written = 0
+        use_ipv4_written = 0
+        use_ipv6_written = 0
+      }
+      print $0
+      last_line_blank = ($0 ~ /^[[:space:]]*$/)
+      next
+    }
+    {
+      if (in_server) {
+        if ($0 ~ /^[[:space:]]*allow-interfaces[[:space:]]*=/) {
+          print "allow-interfaces=" iface
+          allow_written = 1
+          last_line_blank = 0
+          next
+        }
+        if (ipv4_only == "1" && $0 ~ /^[[:space:]]*use-ipv4[[:space:]]*=/) {
+          print "use-ipv4=yes"
+          use_ipv4_written = 1
+          last_line_blank = 0
+          next
+        }
+        if (ipv4_only == "1" && $0 ~ /^[[:space:]]*use-ipv6[[:space:]]*=/) {
+          print "use-ipv6=no"
+          use_ipv6_written = 1
+          last_line_blank = 0
+          next
+        }
+      }
+      print $0
+      last_line_blank = ($0 ~ /^[[:space:]]*$/)
+    }
+    END {
+      if (in_server) {
+        flush_server()
+      }
+      if (found_server == 0) {
+        if (NR > 0 && last_line_blank == 0) {
+          print ""
+        }
+        print "[server]"
+        print "allow-interfaces=" iface
+        if (ipv4_only == "1") {
+          print "use-ipv4=yes"
+          print "use-ipv6=no"
+        }
+      }
+    }
+  ' "${CONF}"
+}
+
+replace_if_changed() {
+  local tmp new_path mode owner group
+  tmp="$(mktemp)"
+  new_path="${CONF}.sugarkube.$$"
+  trap 'rm -f "${tmp}" "${new_path}"' EXIT
+  render_config >"${tmp}"
+  if [ -f "${CONF}" ] && cmp -s "${tmp}" "${CONF}"; then
+    rm -f "${tmp}"
+    trap - EXIT
+    log "${CONF} already configured for ${IFACE}"
+    return 1
+  fi
+  mode=644
+  owner=0
+  group=0
+  if [ -e "${CONF}" ]; then
+    mode="$(stat -c '%a' "${CONF}")"
+    owner="$(stat -c '%u' "${CONF}")"
+    group="$(stat -c '%g' "${CONF}")"
+  fi
+  install -m "${mode}" "${tmp}" "${new_path}"
+  chown "${owner}:${group}" "${new_path}"
+  mv "${new_path}" "${CONF}"
+  rm -f "${tmp}"
+  trap - EXIT
+  log "Updated ${CONF} for interface ${IFACE}"
+  return 0
+}
+
+restart_avahi() {
+  if [ "${SYSTEMCTL_BIN}" = "" ]; then
+    log "SYSTEMCTL_BIN unset; skipping avahi-daemon restart"
+    return
+  fi
+  if ! command -v "${SYSTEMCTL_BIN}" >/dev/null 2>&1; then
+    log "${SYSTEMCTL_BIN} not available; skipping avahi-daemon restart"
+    return
+  fi
+  if "${SYSTEMCTL_BIN}" is-active --quiet avahi-daemon; then
+    "${SYSTEMCTL_BIN}" restart avahi-daemon
+    log "Restarted avahi-daemon"
+  else
+    log "avahi-daemon inactive; skipping restart"
+  fi
+}
+
+log "Configuring Avahi to use ${IFACE} (IPv4 only=${IPV4_ONLY})"
+ensure_conf_exists
+backup_conf
+if replace_if_changed; then
+  restart_avahi
+else
+  log "No Avahi restart required"
+fi

--- a/scripts/configure_k3s_node_ip.sh
+++ b/scripts/configure_k3s_node_ip.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IFACE="${SUGARKUBE_MDNS_INTERFACE:-eth0}"
+LOG_DIR="${SUGARKUBE_LOG_DIR:-/var/log/sugarkube}"
+LOG_FILE="${LOG_DIR}/configure_k3s_node_ip.log"
+if [ -z "${SYSTEMCTL_BIN+x}" ]; then
+  SYSTEMCTL_BIN="systemctl"
+fi
+
+log() {
+  local timestamp
+  timestamp="$(date '+%Y-%m-%dT%H:%M:%S%z')"
+  printf '%s %s\n' "${timestamp}" "$*" | tee -a "${LOG_FILE}" >/dev/null
+}
+
+select_primary_ipv4_from_input() {
+  awk '
+    {
+      for (i = 1; i <= NF; i++) {
+        if ($i == "inet" && (i + 1) <= NF) {
+          split($(i + 1), parts, "/")
+          if (parts[1] != "") {
+            print parts[1]
+            exit
+          }
+        }
+      }
+    }
+  '
+}
+
+detect_primary_ipv4() {
+  local iface="$1"
+  local output
+  if ! command -v ip >/dev/null 2>&1; then
+    log "ip command not available; cannot detect IPv4 address"
+    return 1
+  fi
+  output="$(ip -4 -o addr show "${iface}" 2>/dev/null || true)"
+  if [ -z "${output}" ]; then
+    return 1
+  fi
+  printf '%s\n' "${output}" | select_primary_ipv4_from_input
+}
+
+service_exists() {
+  local svc="$1"
+  local dropin_dir="/etc/systemd/system/${svc}.d"
+  local dropin_file="${dropin_dir}/10-node-ip.conf"
+  if [ -d "${dropin_dir}" ] || [ -f "${dropin_file}" ]; then
+    return 0
+  fi
+  if [ -f "/etc/systemd/system/${svc}" ] || [ -f "/lib/systemd/system/${svc}" ]; then
+    return 0
+  fi
+  if [ -n "${SYSTEMCTL_BIN}" ] && command -v "${SYSTEMCTL_BIN}" >/dev/null 2>&1; then
+    local listing
+    if listing="$(${SYSTEMCTL_BIN} list-unit-files "${svc}" 2>/dev/null)"; then
+      if printf '%s\n' "${listing}" | awk -v svc="${svc}" 'NR>1 && $1 == svc { found = 1 } END { exit(found ? 0 : 1) }'; then
+        return 0
+      fi
+    fi
+  fi
+  return 1
+}
+
+write_dropin() {
+  local svc="$1"
+  local dir="/etc/systemd/system/${svc}.d"
+  local target="${dir}/10-node-ip.conf"
+  local tmp tmp_dest mode owner group
+
+  mkdir -p "${dir}"
+  tmp="$(mktemp)"
+  printf '[Service]\nEnvironment=K3S_NODE_IP=%s\n' "${NODE_IP}" >"${tmp}"
+
+  if [ -f "${target}" ] && cmp -s "${tmp}" "${target}"; then
+    log "${target} already sets K3S_NODE_IP=${NODE_IP}"
+    rm -f "${tmp}"
+    return
+  fi
+
+  mode=644
+  owner=0
+  group=0
+  if [ -e "${target}" ]; then
+    mode="$(stat -c '%a' "${target}")"
+    owner="$(stat -c '%u' "${target}")"
+    group="$(stat -c '%g' "${target}")"
+  fi
+
+  tmp_dest="${target}.tmp.$$"
+  install -m "${mode}" "${tmp}" "${tmp_dest}"
+  chown "${owner}:${group}" "${tmp_dest}"
+  mv "${tmp_dest}" "${target}"
+  rm -f "${tmp}"
+
+  UPDATED_SERVICES+=("${svc}")
+  log "Updated ${target} with node IP ${NODE_IP}"
+}
+
+if [ "${1:-}" = "--parse-stdin" ]; then
+  shift || true
+  if NODE_IP="$(select_primary_ipv4_from_input)"; then
+    if [ -n "${NODE_IP}" ]; then
+      printf '%s\n' "${NODE_IP}"
+      exit 0
+    fi
+  fi
+  exit 1
+fi
+
+mkdir -p "${LOG_DIR}"
+log "Configuring k3s node IP for interface ${IFACE}"
+
+NODE_IP="$(detect_primary_ipv4 "${IFACE}" || true)"
+if [ -z "${NODE_IP}" ]; then
+  log "No IPv4 address detected on ${IFACE}; skipping drop-in creation"
+  exit 1
+fi
+log "Detected IPv4 ${NODE_IP} on ${IFACE}"
+
+CANDIDATES=("k3s.service" "k3s-agent.service")
+SERVICES=()
+for svc in "${CANDIDATES[@]}"; do
+  if service_exists "${svc}"; then
+    SERVICES+=("${svc}")
+  else
+    log "${svc} not present; skipping"
+  fi
+done
+
+if [ "${#SERVICES[@]}" -eq 0 ]; then
+  log "No k3s unit files found; nothing to configure"
+  exit 0
+fi
+
+declare -a UPDATED_SERVICES=()
+for svc in "${SERVICES[@]}"; do
+  write_dropin "${svc}"
+done
+
+if [ "${#UPDATED_SERVICES[@]}" -eq 0 ]; then
+  log "Existing node IP drop-ins already match ${NODE_IP}"
+  exit 0
+fi
+
+if [ -z "${SYSTEMCTL_BIN}" ] || ! command -v "${SYSTEMCTL_BIN}" >/dev/null 2>&1; then
+  log "${SYSTEMCTL_BIN:-systemctl} not available; skipping daemon-reload and restarts"
+  exit 0
+fi
+
+if "${SYSTEMCTL_BIN}" daemon-reload >/dev/null 2>&1; then
+  log "Reloaded systemd unit definitions"
+else
+  log "systemctl daemon-reload failed"
+fi
+
+for svc in "${UPDATED_SERVICES[@]}"; do
+  if "${SYSTEMCTL_BIN}" is-active --quiet "${svc}"; then
+    if "${SYSTEMCTL_BIN}" restart "${svc}"; then
+      log "Restarted ${svc}"
+    else
+      log "Failed to restart ${svc}"
+    fi
+  else
+    log "${svc} inactive; restart skipped"
+  fi
+done

--- a/scripts/toggle_wlan.sh
+++ b/scripts/toggle_wlan.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WLAN_IFACE="${SUGARKUBE_WLAN_INTERFACE:-wlan0}"
+LOG_DIR="${SUGARKUBE_LOG_DIR:-/var/log/sugarkube}"
+LOG_FILE="${LOG_DIR}/toggle_wlan.log"
+RUN_DIR="${SUGARKUBE_RUN_DIR:-/run/sugarkube}"
+GUARD_FILE="${SUGARKUBE_WLAN_GUARD:-${RUN_DIR}/wlan-disabled}"
+
+log() {
+  local timestamp
+  timestamp="$(date '+%Y-%m-%dT%H:%M:%S%z')"
+  printf '%s %s\n' "${timestamp}" "$*" | tee -a "${LOG_FILE}" >/dev/null
+}
+
+usage() {
+  cat <<'USAGE'
+Usage: toggle_wlan.sh [--down|--restore]
+
+  --down     Bring the wireless interface down and mark it disabled.
+  --restore  Bring the interface back up when previously disabled.
+USAGE
+}
+
+ensure_tools() {
+  if ! command -v ip >/dev/null 2>&1; then
+    log "ip command not available; skipping wlan toggle"
+    return 1
+  fi
+  return 0
+}
+
+bring_down() {
+  if ! ensure_tools; then
+    return 0
+  fi
+  if ! ip link show "${WLAN_IFACE}" >/dev/null 2>&1; then
+    log "Interface ${WLAN_IFACE} not found; nothing to disable"
+    return 0
+  fi
+  if ip link show "${WLAN_IFACE}" | grep -q "state DOWN"; then
+    log "${WLAN_IFACE} already down"
+  else
+    if ip link set "${WLAN_IFACE}" down; then
+      log "Brought ${WLAN_IFACE} down"
+    else
+      log "Failed to bring ${WLAN_IFACE} down"
+      return 1
+    fi
+  fi
+  mkdir -p "${RUN_DIR}"
+  if [ ! -f "${GUARD_FILE}" ]; then
+    touch "${GUARD_FILE}"
+    log "Created guard ${GUARD_FILE}"
+  else
+    log "Guard ${GUARD_FILE} already present"
+  fi
+  return 0
+}
+
+restore_iface() {
+  if [ ! -f "${GUARD_FILE}" ]; then
+    log "Guard ${GUARD_FILE} missing; nothing to restore"
+    return 0
+  fi
+  if ! ensure_tools; then
+    rm -f "${GUARD_FILE}"
+    return 0
+  fi
+  if ! ip link show "${WLAN_IFACE}" >/dev/null 2>&1; then
+    log "Interface ${WLAN_IFACE} not found during restore"
+    rm -f "${GUARD_FILE}"
+    return 0
+  fi
+  if ip link set "${WLAN_IFACE}" up; then
+    log "Brought ${WLAN_IFACE} up"
+  else
+    log "Failed to bring ${WLAN_IFACE} up"
+    return 1
+  fi
+  rm -f "${GUARD_FILE}"
+  log "Removed guard ${GUARD_FILE}"
+  return 0
+}
+
+ACTION=""
+if [ "$#" -gt 0 ]; then
+  case "$1" in
+    --down)
+      ACTION="down"
+      ;;
+    --restore)
+      ACTION="restore"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+fi
+
+if [ -z "${ACTION}" ]; then
+  usage >&2
+  exit 2
+fi
+
+mkdir -p "${LOG_DIR}"
+
+case "${ACTION}" in
+  down)
+    bring_down
+    ;;
+  restore)
+    restore_iface
+    ;;
+esac

--- a/tests/scripts/test_configure_avahi.sh
+++ b/tests/scripts/test_configure_avahi.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+cd "${repo_root}"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+conf_path="${tmp_dir}/avahi-daemon.conf"
+log_dir="${tmp_dir}/logs"
+
+cat >"${conf_path}" <<'CONF'
+[wide-area]
+enable-wide-area=yes
+CONF
+
+env \
+  AVAHI_CONF_PATH="${conf_path}" \
+  SUGARKUBE_LOG_DIR="${log_dir}" \
+  SYSTEMCTL_BIN= \
+  SUGARKUBE_MDNS_INTERFACE=eth1 \
+  SUGARKUBE_MDNS_IPV4_ONLY=1 \
+  bash scripts/configure_avahi.sh
+
+grep -q '^\[server\]' "${conf_path}"
+grep -q '^allow-interfaces=eth1$' "${conf_path}"
+grep -q '^use-ipv4=yes$' "${conf_path}"
+grep -q '^use-ipv6=no$' "${conf_path}"
+
+if [ ! -f "${conf_path}.bak" ]; then
+  echo "Backup was not created" >&2
+  exit 1
+fi
+
+initial_hash="$(sha256sum "${conf_path}" | awk '{print $1}')"
+
+env \
+  AVAHI_CONF_PATH="${conf_path}" \
+  SUGARKUBE_LOG_DIR="${log_dir}" \
+  SYSTEMCTL_BIN= \
+  SUGARKUBE_MDNS_INTERFACE=eth1 \
+  SUGARKUBE_MDNS_IPV4_ONLY=1 \
+  bash scripts/configure_avahi.sh
+
+second_hash="$(sha256sum "${conf_path}" | awk '{print $1}')"
+
+if [ "${initial_hash}" != "${second_hash}" ]; then
+  echo "Configuration changed on second run" >&2
+  diff -u <(printf '%s\n' "${initial_hash}") <(printf '%s\n' "${second_hash}") || true
+  exit 1
+fi
+
+if [ ! -f "${log_dir}/configure_avahi.log" ]; then
+  echo "Log file was not created" >&2
+  exit 1
+fi

--- a/tests/scripts/test_detect_node_ip.py
+++ b/tests/scripts/test_detect_node_ip.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "configure_k3s_node_ip.sh"
+
+
+def _run_parser(sample: str, tmp_path: Path) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["SYSTEMCTL_BIN"] = ""
+    env["SUGARKUBE_LOG_DIR"] = str(tmp_path / "logs")
+    return subprocess.run(
+        ["bash", str(SCRIPT), "--parse-stdin"],
+        input=sample,
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_selects_first_ipv4_address(tmp_path: Path) -> None:
+    sample = (
+        "2: eth0    inet 10.0.0.5/24 brd 10.0.0.255 scope global eth0\n"
+        "    valid_lft forever preferred_lft forever\n"
+        "3: eth0    inet 10.0.0.6/24 brd 10.0.0.255 scope global secondary eth0\n"
+        "    valid_lft forever preferred_lft forever\n"
+    )
+
+    result = _run_parser(sample, tmp_path)
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "10.0.0.5"
+
+
+def test_returns_error_when_no_ipv4_found(tmp_path: Path) -> None:
+    sample = "2: eth0    link/ether aa:bb:cc:dd:ee:ff brd ff:ff:ff:ff:ff:ff\n"
+
+    result = _run_parser(sample, tmp_path)
+
+    assert result.returncode != 0
+    assert result.stdout.strip() == ""


### PR DESCRIPTION
## Summary
- add scripts to configure Avahi, set the K3s node IP drop-in, and toggle wlan guard files with logging
- wire the new scripts into `just up` defaults and expose helper recipes including an mDNS reset
- cover configure_avahi idempotency and the K3s IP parser with lightweight tests

## Testing
- bash tests/scripts/test_configure_avahi.sh
- pytest tests/scripts/test_detect_node_ip.py

------
https://chatgpt.com/codex/tasks/task_e_68f9cf36418c832f950bebd945416670