### PR TITLE
Automate Avahi interface pinning, K3s node IP drop-in, and WLAN toggles

### DIFF
--- a/scripts/configure_avahi.sh
+++ b/scripts/configure_avahi.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IFACE="${SUGARKUBE_MDNS_INTERFACE:-eth0}"
+IPV4_ONLY="${SUGARKUBE_MDNS_IPV4_ONLY:-1}"
+CONF_PATH="${AVAHI_CONF_PATH:-/etc/avahi/avahi-daemon.conf}"
+LOG_DIR="${SUGARKUBE_LOG_DIR:-/var/log/sugarkube}"
+LOG_FILE="${LOG_DIR}/configure_avahi.log"
+
+mkdir -p "${LOG_DIR}"
+
+log() {
+  local ts
+  ts="$(date +'%Y-%m-%dT%H:%M:%S%z')"
+  printf '%s %s\n' "${ts}" "$*" | tee -a "${LOG_FILE}"
+}
+
+if [ ! -f "${CONF_PATH}" ]; then
+  log "Avahi configuration not found at ${CONF_PATH}"
+  exit 1
+fi
+
+if [ ! -f "${CONF_PATH}.bak" ]; then
+  cp "${CONF_PATH}" "${CONF_PATH}.bak"
+  log "Backed up ${CONF_PATH} to ${CONF_PATH}.bak"
+fi
+
+tmp_file="$(mktemp)"
+cleanup() {
+  rm -f "${tmp_file}"
+}
+trap cleanup EXIT
+
+awk -v iface="${IFACE}" -v ipv4_only="${IPV4_ONLY}" '
+function flush_server() {
+  if (!inside_server) {
+    return
+  }
+  if (!allow_written) {
+    print "allow-interfaces=" iface
+  }
+  if (ipv4_only == "1") {
+    if (!ipv4_written) {
+      print "use-ipv4=yes"
+    }
+    if (!ipv6_written) {
+      print "use-ipv6=no"
+    }
+  }
+}
+BEGIN {
+  inside_server = 0
+  seen_server = 0
+  allow_written = 0
+  ipv4_written = 0
+  ipv6_written = 0
+}
+/^[ \t]*\[.*\][ \t]*$/ {
+  if (inside_server) {
+    flush_server()
+  }
+  print
+  if ($0 ~ /^[ \t]*\[server\][ \t]*$/) {
+    inside_server = 1
+    seen_server = 1
+    allow_written = 0
+    ipv4_written = 0
+    ipv6_written = 0
+  } else {
+    inside_server = 0
+  }
+  next
+}
+{
+  if (inside_server) {
+    if ($0 ~ /^[ \t]*allow-interfaces[ \t]*=/) {
+      print "allow-interfaces=" iface
+      allow_written = 1
+      next
+    }
+    if (ipv4_only == "1" && $0 ~ /^[ \t]*use-ipv4[ \t]*=/) {
+      print "use-ipv4=yes"
+      ipv4_written = 1
+      next
+    }
+    if (ipv4_only == "1" && $0 ~ /^[ \t]*use-ipv6[ \t]*=/) {
+      print "use-ipv6=no"
+      ipv6_written = 1
+      next
+    }
+  }
+  print
+}
+END {
+  if (inside_server) {
+    flush_server()
+  } else if (!seen_server) {
+    if (NR > 0 && $0 !~ /^[ \t]*$/) {
+      print ""
+    }
+    print "[server]"
+    print "allow-interfaces=" iface
+    if (ipv4_only == "1") {
+      print "use-ipv4=yes"
+      print "use-ipv6=no"
+    }
+  }
+}
+' "${CONF_PATH}" >"${tmp_file}"
+
+changed=0
+if cmp -s "${CONF_PATH}" "${tmp_file}"; then
+  log "No changes required for ${CONF_PATH}"
+else
+  cat "${tmp_file}" >"${CONF_PATH}"
+  changed=1
+  log "Updated ${CONF_PATH} with allow-interfaces=${IFACE}"
+  if [ "${IPV4_ONLY}" = "1" ]; then
+    log "Pinned Avahi to IPv4 on ${IFACE}"
+  fi
+fi
+
+if [ "${changed}" -eq 1 ]; then
+  if [ "${AVAHI_SKIP_SYSTEMCTL:-0}" = "1" ]; then
+    log "AVAHI_SKIP_SYSTEMCTL=1; skipping avahi-daemon restart"
+  elif command -v systemctl >/dev/null 2>&1; then
+    if systemctl is-active --quiet avahi-daemon; then
+      log "Restarting avahi-daemon"
+      systemctl restart avahi-daemon
+    else
+      log "avahi-daemon is not active; skipping restart"
+    fi
+  else
+    log "systemctl not found; skipping avahi-daemon restart"
+  fi
+fi
+
+log "configure_avahi.sh completed"

--- a/scripts/configure_k3s_node_ip.sh
+++ b/scripts/configure_k3s_node_ip.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+select_primary_ipv4() {
+  awk '
+    $3 == "inet" {
+      split($4, addr, "/")
+      if (addr[1] != "") {
+        print addr[1]
+        exit
+      }
+    }
+  '
+}
+
+if [[ "${1:-}" == "--detect-ip-from-stdin" ]]; then
+  select_primary_ipv4
+  exit 0
+fi
+
+IFACE="${SUGARKUBE_MDNS_INTERFACE:-eth0}"
+LOG_DIR="${SUGARKUBE_LOG_DIR:-/var/log/sugarkube}"
+LOG_FILE="${LOG_DIR}/configure_k3s_node_ip.log"
+
+mkdir -p "${LOG_DIR}"
+
+log() {
+  local ts
+  ts="$(date +'%Y-%m-%dT%H:%M:%S%z')"
+  printf '%s %s\n' "${ts}" "$*" | tee -a "${LOG_FILE}"
+}
+
+log "Resolving primary IPv4 for ${IFACE}"
+
+ip_output=""
+if [ -n "${SUGARKUBE_IP_MOCK_DATA:-}" ]; then
+  ip_output="${SUGARKUBE_IP_MOCK_DATA}"
+else
+  if ! command -v ip >/dev/null 2>&1; then
+    log "ip command not available"
+    exit 1
+  fi
+  ip_output="$(ip -4 -o addr show "${IFACE}" 2>/dev/null || true)"
+fi
+
+if [ -z "${ip_output}" ]; then
+  log "No IPv4 addresses reported for ${IFACE}"
+  exit 1
+fi
+
+PRIMARY_IP="$(printf '%s\n' "${ip_output}" | select_primary_ipv4 || true)"
+if [ -z "${PRIMARY_IP}" ]; then
+  log "Failed to parse IPv4 address for ${IFACE}"
+  exit 1
+fi
+
+log "Detected IPv4 ${PRIMARY_IP} on ${IFACE}"
+
+update_dropin() {
+  local service="$1"
+  local unit_dir="/etc/systemd/system/${service}.d"
+  local dropin_file="${unit_dir}/10-node-ip.conf"
+  local tmp
+  tmp="$(mktemp)"
+  printf '[Service]\nEnvironment=K3S_NODE_IP=%s\n' "${PRIMARY_IP}" >"${tmp}"
+  mkdir -p "${unit_dir}"
+  if [ -f "${dropin_file}" ] && cmp -s "${dropin_file}" "${tmp}"; then
+    rm -f "${tmp}"
+    return 1
+  fi
+  cat "${tmp}" >"${dropin_file}"
+  rm -f "${tmp}"
+  return 0
+}
+
+declare -a services=()
+if command -v systemctl >/dev/null 2>&1; then
+  unit_files="$(systemctl list-unit-files | awk '{print $1}' || true)"
+  if printf '%s\n' "${unit_files}" | grep -qx 'k3s.service'; then
+    services+=("k3s.service")
+  fi
+  if printf '%s\n' "${unit_files}" | grep -qx 'k3s-agent.service'; then
+    services+=("k3s-agent.service")
+  fi
+else
+  for candidate in k3s.service k3s-agent.service; do
+    if [ -f "/etc/systemd/system/${candidate}" ] || \
+       [ -f "/lib/systemd/system/${candidate}" ] || \
+       [ -d "/etc/systemd/system/${candidate}.d" ]; then
+      services+=("${candidate}")
+    fi
+  done
+fi
+
+if [ ${#services[@]} -eq 0 ]; then
+  services=("k3s.service")
+fi
+
+declare -a updated_services=()
+any_updated=0
+for svc in "${services[@]}"; do
+  if update_dropin "${svc}"; then
+    log "Updated ${svc} drop-in with K3S_NODE_IP=${PRIMARY_IP}"
+    updated_services+=("${svc}")
+    any_updated=1
+  else
+    log "Drop-in for ${svc} already set to ${PRIMARY_IP}"
+  fi
+done
+
+if [ "${any_updated}" -eq 1 ]; then
+  if [ "${K3S_SKIP_SYSTEMCTL:-0}" = "1" ]; then
+    log "K3S_SKIP_SYSTEMCTL=1; skipping daemon-reload"
+  elif command -v systemctl >/dev/null 2>&1; then
+    log "Reloading systemd manager configuration"
+    systemctl daemon-reload
+    for svc in "${updated_services[@]}"; do
+      if systemctl is-active --quiet "${svc}"; then
+        log "Restarting ${svc} to apply node IP"
+        systemctl restart "${svc}"
+      else
+        log "${svc} is not active; skipping restart"
+      fi
+    done
+  else
+    log "systemctl not available; skipping reload and restart"
+  fi
+else
+  log "All drop-ins already configured; no reload required"
+fi
+
+log "configure_k3s_node_ip.sh completed"

--- a/scripts/toggle_wlan.sh
+++ b/scripts/toggle_wlan.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-}" 
+if [ -z "${MODE}" ]; then
+  echo "Usage: toggle_wlan.sh --down|--restore" >&2
+  exit 2
+fi
+
+WLAN_IF="${SUGARKUBE_WLAN_INTERFACE:-wlan0}"
+LOG_DIR="${SUGARKUBE_LOG_DIR:-/var/log/sugarkube}"
+LOG_FILE="${LOG_DIR}/toggle_wlan.log"
+RUN_DIR="${SUGARKUBE_RUN_DIR:-/run/sugarkube}"
+GUARD_FILE="${RUN_DIR}/wlan-disabled"
+
+mkdir -p "${LOG_DIR}"
+mkdir -p "${RUN_DIR}"
+
+action_log() {
+  local ts
+  ts="$(date +'%Y-%m-%dT%H:%M:%S%z')"
+  printf '%s %s\n' "${ts}" "$*" | tee -a "${LOG_FILE}"
+}
+
+interface_exists() {
+  ip link show "${WLAN_IF}" >/dev/null 2>&1
+}
+
+case "${MODE}" in
+  --down)
+    if ! interface_exists; then
+      action_log "Interface ${WLAN_IF} not present; skipping shutdown"
+      exit 0
+    fi
+    if [ -f "${GUARD_FILE}" ]; then
+      action_log "Guard ${GUARD_FILE} already present; ${WLAN_IF} assumed down"
+      exit 0
+    fi
+    if ip link set "${WLAN_IF}" down; then
+      action_log "Brought ${WLAN_IF} down"
+      touch "${GUARD_FILE}"
+    else
+      action_log "Failed to bring ${WLAN_IF} down"
+      exit 1
+    fi
+    ;;
+  --restore|--up)
+    if [ ! -f "${GUARD_FILE}" ]; then
+      action_log "No guard file at ${GUARD_FILE}; nothing to restore"
+      exit 0
+    fi
+    if ! interface_exists; then
+      action_log "Interface ${WLAN_IF} missing; removing guard"
+      rm -f "${GUARD_FILE}"
+      exit 0
+    fi
+    if ip link set "${WLAN_IF}" up; then
+      action_log "Brought ${WLAN_IF} up"
+      rm -f "${GUARD_FILE}"
+    else
+      action_log "Failed to bring ${WLAN_IF} up"
+      exit 1
+    fi
+    ;;
+  *)
+    echo "Unknown mode: ${MODE}" >&2
+    echo "Usage: toggle_wlan.sh --down|--restore" >&2
+    exit 2
+    ;;
+esac
+
+action_log "toggle_wlan.sh completed"

--- a/tests/scripts/test_configure_avahi.sh
+++ b/tests/scripts/test_configure_avahi.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+CONF_PATH="${TMP_DIR}/avahi-daemon.conf"
+LOG_DIR="${TMP_DIR}/logs"
+
+cat >"${CONF_PATH}" <<'CONF'
+# Sample config without server section
+[wide-area]
+enable-wide-area=yes
+CONF
+
+ORIGINAL_CONTENT="$(cat "${CONF_PATH}")"
+
+SUGARKUBE_MDNS_INTERFACE="eno1" \
+SUGARKUBE_MDNS_IPV4_ONLY="1" \
+AVAHI_CONF_PATH="${CONF_PATH}" \
+SUGARKUBE_LOG_DIR="${LOG_DIR}" \
+AVAHI_SKIP_SYSTEMCTL="1" \
+"${REPO_ROOT}/scripts/configure_avahi.sh"
+
+grep -q '^\[server\]' "${CONF_PATH}"
+grep -q '^allow-interfaces=eno1$' "${CONF_PATH}"
+grep -q '^use-ipv4=yes$' "${CONF_PATH}"
+grep -q '^use-ipv6=no$' "${CONF_PATH}"
+
+if [ ! -f "${CONF_PATH}.bak" ]; then
+  echo "Expected backup file ${CONF_PATH}.bak to exist" >&2
+  exit 1
+fi
+
+if ! diff -u <(printf '%s\n' "${ORIGINAL_CONTENT}") "${CONF_PATH}.bak" >/dev/null; then
+  echo "Backup file does not match original contents" >&2
+  exit 1
+fi
+
+first_hash="$(sha256sum "${CONF_PATH}" | awk '{print $1}')"
+
+SUGARKUBE_MDNS_INTERFACE="eno1" \
+SUGARKUBE_MDNS_IPV4_ONLY="1" \
+AVAHI_CONF_PATH="${CONF_PATH}" \
+SUGARKUBE_LOG_DIR="${LOG_DIR}" \
+AVAHI_SKIP_SYSTEMCTL="1" \
+"${REPO_ROOT}/scripts/configure_avahi.sh"
+
+second_hash="$(sha256sum "${CONF_PATH}" | awk '{print $1}')"
+
+if [ "${first_hash}" != "${second_hash}" ]; then
+  echo "Configuration changed on second run" >&2
+  exit 1
+fi
+
+echo "configure_avahi.sh test passed"

--- a/tests/scripts/test_detect_node_ip.py
+++ b/tests/scripts/test_detect_node_ip.py
@@ -1,0 +1,31 @@
+import subprocess
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "configure_k3s_node_ip.sh"
+
+
+def detect_ip(sample: str) -> str:
+    result = subprocess.run(
+        ["bash", str(SCRIPT_PATH), "--detect-ip-from-stdin"],
+        input=sample.encode(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    return result.stdout.decode().strip()
+
+
+def test_selects_first_ipv4_address():
+    sample = """2: eth0    inet 192.168.10.5/24 brd 192.168.10.255 scope global eth0\n"""
+    assert detect_ip(sample) == "192.168.10.5"
+
+
+def test_ignores_additional_addresses_after_first_match():
+    sample = """2: eth0    inet 192.168.10.5/24 brd 192.168.10.255 scope global eth0\n""" """
+3: eth0    inet 192.168.10.25/24 brd 192.168.10.255 scope global secondary eth0\n"""
+    assert detect_ip(sample) == "192.168.10.5"
+
+
+def test_handles_leading_whitespace_and_tabs():
+    sample = """  2: eth0\tinet 10.0.0.2/16 brd 10.0.255.255 scope global eth0\n"""
+    assert detect_ip(sample) == "10.0.0.2"


### PR DESCRIPTION
## Summary
- add configure_avahi.sh to back up Avahi config, pin the chosen interface, and enforce IPv4-only mode with logging
- add configure_k3s_node_ip.sh to detect the wired IPv4 and manage systemd drop-ins for k3s/k3s-agent
- add toggle_wlan.sh plus justfile automation, helper targets, and tests for idempotency and IP parsing

## Testing
- bash tests/scripts/test_configure_avahi.sh
- pytest tests/scripts/test_detect_node_ip.py


------
https://chatgpt.com/codex/tasks/task_e_68f9cf36418c832f950bebd945416670