### PR TITLE
Publish server-phase mDNS advert after k3s start

### DIFF
--- a/outages/2025-10-23-k3s-mdns-trailing-dot-self-check.json
+++ b/outages/2025-10-23-k3s-mdns-trailing-dot-self-check.json
@@ -3,7 +3,7 @@
   "date": "2025-10-23",
   "component": "scripts/k3s_mdns_parser.py",
   "rootCause": "The Avahi parser left trailing dots on hostnames and TXT leader values when avahi-browse emitted a domain of 'local.', so the mDNS self-check never matched the bootstrap advertisement for the local node.",
-  "resolution": "Trim trailing dots, normalise case, and reuse the hostname normaliser for both resolved hosts and TXT leader fields so bootstrap self-checks accept Avahi responses with domain suffixes.\n\n2025-12-08 follow-up: Bound avahi-publish-service with -H to the FQDN, added a 1s self-check delay, and capture output in /tmp/sugar-publish.log to prevent bootstrap races.\nQuick triage:\n- avahi-browse -rt _k3s-sugar-dev._tcp --parsable | sed -n '1,80p'\n- pgrep -a avahi-publish || true\n- sed -n '1,120p' /tmp/sugar-publish.log || true",
+  "resolution": "Trim trailing dots, normalise case, and reuse the hostname normaliser for both resolved hosts and TXT leader fields so bootstrap self-checks accept Avahi responses with domain suffixes.\n\n2025-12-08 follow-up: Bound avahi-publish-service with -H to the FQDN, added a 1s self-check delay, and capture output in /tmp/sugar-publish.log to prevent bootstrap races.\nSymptom: \"bootstrap advert OK; server advert never seen post systemd: Starting k3s within 5s window.\"\nFix: publish phase=server advert explicitly, wait up to 60s, only then retire bootstrap advert.\nQuick triage:\n- avahi-browse -rt _k3s-sugar-dev._tcp --parsable | grep 'txt=.*phase='\n- pgrep -a avahi-publish\n- sed -n '1,120p' /tmp/sugar-publish-bootstrap.log /tmp/sugar-publish-server.log",
   "references": [
     "scripts/k3s_mdns_parser.py",
     "tests/scripts/test_k3s_discover_bootstrap_publish.py",

--- a/scripts/k3s-discover.sh
+++ b/scripts/k3s-discover.sh
@@ -38,8 +38,10 @@ NODE_TOKEN_PATH="${SUGARKUBE_NODE_TOKEN_PATH:-/var/lib/rancher/k3s/server/node-t
 BOOT_TOKEN_PATH="${SUGARKUBE_BOOT_TOKEN_PATH:-/boot/sugarkube-node-token}"
 DISCOVERY_WAIT_SECS="${DISCOVERY_WAIT_SECS:-9}"
 DISCOVERY_ATTEMPTS="${DISCOVERY_ATTEMPTS:-15}"
-MDNS_SELF_CHECK_ATTEMPTS="${SUGARKUBE_MDNS_SELF_CHECK_ATTEMPTS:-5}"
-MDNS_SELF_CHECK_DELAY="${SUGARKUBE_MDNS_SELF_CHECK_DELAY:-1}"
+MDNS_BOOT_RETRIES="${SUGARKUBE_MDNS_BOOT_RETRIES:-5}"
+MDNS_BOOT_DELAY="${SUGARKUBE_MDNS_BOOT_DELAY:-1}"
+MDNS_SERVER_RETRIES="${SUGARKUBE_MDNS_SERVER_RETRIES:-60}"
+MDNS_SERVER_DELAY="${SUGARKUBE_MDNS_SERVER_DELAY:-1}"
 SKIP_MDNS_SELF_CHECK="${SUGARKUBE_SKIP_MDNS_SELF_CHECK:-0}"
 
 PRINT_TOKEN_ONLY=0
@@ -52,6 +54,7 @@ TEST_RUN_AVAHI=""
 TEST_RENDER_SERVICE=0
 TEST_WAIT_LOOP=0
 TEST_PUBLISH_BOOTSTRAP=0
+TEST_PUBLISH_SERVER=0
 TEST_CLAIM_BOOTSTRAP=0
 declare -a TEST_RENDER_ARGS=()
 
@@ -82,6 +85,9 @@ while [ "$#" -gt 0 ]; do
       ;;
     --test-bootstrap-publish)
       TEST_PUBLISH_BOOTSTRAP=1
+      ;;
+    --test-server-publish)
+      TEST_PUBLISH_SERVER=1
       ;;
     --test-claim-bootstrap)
       TEST_CLAIM_BOOTSTRAP=1
@@ -207,6 +213,8 @@ AVAHI_SERVICE_FILE="${SUGARKUBE_AVAHI_SERVICE_FILE:-${AVAHI_SERVICE_DIR}/k3s-${C
 AVAHI_ROLE=""
 BOOTSTRAP_PUBLISH_PID=""
 BOOTSTRAP_PUBLISH_LOG=""
+SERVER_PUBLISH_PID=""
+SERVER_PUBLISH_LOG=""
 CLAIMED_SERVER_HOST=""
 
 run_privileged() {
@@ -256,8 +264,20 @@ stop_bootstrap_publisher() {
   fi
 }
 
+stop_server_publisher() {
+  if [ -n "${SERVER_PUBLISH_PID:-}" ]; then
+    if kill -0 "${SERVER_PUBLISH_PID}" >/dev/null 2>&1; then
+      kill "${SERVER_PUBLISH_PID}" >/dev/null 2>&1 || true
+    fi
+    wait "${SERVER_PUBLISH_PID}" >/dev/null 2>&1 || true
+    SERVER_PUBLISH_PID=""
+    SERVER_PUBLISH_LOG=""
+  fi
+}
+
 cleanup_avahi_bootstrap() {
   stop_bootstrap_publisher
+  stop_server_publisher
   if [ "${AVAHI_ROLE}" = "bootstrap" ]; then
     remove_privileged_file "${AVAHI_SERVICE_FILE}" || true
     reload_avahi_daemon || true
@@ -309,7 +329,7 @@ start_bootstrap_publisher() {
   local publish_name
   publish_name="$(service_instance_name bootstrap "${MDNS_HOST_RAW}")"
 
-  BOOTSTRAP_PUBLISH_LOG="/tmp/sugar-publish.log"
+  BOOTSTRAP_PUBLISH_LOG="/tmp/sugar-publish-bootstrap.log"
   : >"${BOOTSTRAP_PUBLISH_LOG}" 2>/dev/null || true
 
   avahi-publish-service \
@@ -340,6 +360,50 @@ start_bootstrap_publisher() {
   fi
 
   log "avahi-publish-service advertising bootstrap as ${MDNS_HOST_RAW} on ${MDNS_SERVICE_TYPE} (pid ${BOOTSTRAP_PUBLISH_PID})"
+  return 0
+}
+
+start_server_publisher() {
+  if ! command -v avahi-publish-service >/dev/null 2>&1; then
+    return 1
+  fi
+  if [ -n "${SERVER_PUBLISH_PID:-}" ] && kill -0 "${SERVER_PUBLISH_PID}" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local publish_name
+  publish_name="$(service_instance_name server "${MDNS_HOST_RAW}")"
+
+  SERVER_PUBLISH_LOG="/tmp/sugar-publish-server.log"
+  : >"${SERVER_PUBLISH_LOG}" 2>/dev/null || true
+
+  avahi-publish-service \
+    -H "${MDNS_HOST_RAW}" \
+    "${publish_name}" \
+    "${MDNS_SERVICE_TYPE}" \
+    6443 \
+    "k3s=1" \
+    "cluster=${CLUSTER}" \
+    "env=${ENVIRONMENT}" \
+    "role=server" \
+    "leader=${MDNS_HOST_RAW}" \
+    "phase=server" \
+    >"${SERVER_PUBLISH_LOG}" 2>&1 &
+  SERVER_PUBLISH_PID=$!
+
+  sleep 1
+  if ! kill -0 "${SERVER_PUBLISH_PID}" >/dev/null 2>&1; then
+    if [ -s "${SERVER_PUBLISH_LOG}" ]; then
+      while IFS= read -r line; do
+        log "server publisher error: ${line}"
+      done <"${SERVER_PUBLISH_LOG}"
+    fi
+    SERVER_PUBLISH_PID=""
+    SERVER_PUBLISH_LOG=""
+    return 1
+  fi
+
+  log "avahi-publish-service advertising server as ${MDNS_HOST_RAW} on ${MDNS_SERVICE_TYPE} (pid ${SERVER_PUBLISH_PID})"
   return 0
 }
 
@@ -448,47 +512,61 @@ discover_bootstrap_leaders() {
 }
 
 ensure_self_mdns_advertisement() {
-  local role="$1"
+  local phase="$1"
   if [ "${SKIP_MDNS_SELF_CHECK}" = "1" ]; then
     return 0
   fi
 
-  local query_mode=""
-  case "${role}" in
+  local retries="${MDNS_BOOT_RETRIES}"
+  local delay="${MDNS_BOOT_DELAY}"
+  local require_arg=()
+
+  case "${phase}" in
     bootstrap)
-      query_mode="bootstrap-hosts"
+      require_arg=(--require-phase bootstrap)
       ;;
     server)
-      query_mode="server-hosts"
+      retries="${MDNS_SERVER_RETRIES}"
+      delay="${MDNS_SERVER_DELAY}"
+      require_arg=(--require-phase server)
       ;;
     *)
-      return 0
+      phase=""
       ;;
   esac
 
-  local attempts="${MDNS_SELF_CHECK_ATTEMPTS}"
-  local delay="${MDNS_SELF_CHECK_DELAY}"
-  local attempt
-  for attempt in $(seq 1 "${attempts}"); do
-    mapfile -t hosts < <(run_avahi_query "${query_mode}" || true)
-    if [ "${#hosts[@]}" -gt 0 ]; then
-      local observed=""
-      for observed in "${hosts[@]}"; do
-        if same_host "${observed}" "${MDNS_HOST_RAW}"; then
-          log "phase=self-check host=${MDNS_HOST_RAW} observed=${observed} attempt=${attempt}/${attempts}; advertisement confirmed."
-          return 0
-        fi
-      done
-    fi
+  local observed=""
+  local status=0
 
-    if [ "${attempt}" -lt "${attempts}" ]; then
-      log "phase=self-check host=${MDNS_HOST_RAW} attempt=${attempt}/${attempts}; retrying in ${delay}s."
-      sleep "${delay}"
-    fi
-  done
+  set +e
+  observed="$(python3 "${SCRIPT_DIR}/mdns_helpers.py" \
+    --expect-host "${MDNS_HOST_RAW}" \
+    --cluster "${CLUSTER}" \
+    --env "${ENVIRONMENT}" \
+    --retries "${retries}" \
+    --delay "${delay}" \
+    "${require_arg[@]}")"
+  status=$?
+  set -e
 
-  log "phase=self-check host=${MDNS_HOST_RAW} attempts=${attempts}; advertisement not reported."
-  return 1
+  if [ "${status}" -eq 0 ]; then
+    if [ -z "${observed}" ]; then
+      observed="${MDNS_HOST_RAW}"
+    fi
+    if [ -n "${phase}" ]; then
+      log "phase=self-check host=${MDNS_HOST_RAW} observed=${observed}; ${phase} advertisement confirmed."
+    else
+      log "phase=self-check host=${MDNS_HOST_RAW} observed=${observed}; advertisement confirmed."
+    fi
+    return 0
+  fi
+
+  if [ -n "${phase}" ]; then
+    log "phase=self-check host=${MDNS_HOST_RAW} attempts=${retries}; ${phase} advertisement not reported."
+  else
+    log "phase=self-check host=${MDNS_HOST_RAW} attempts=${retries}; advertisement not reported."
+  fi
+  return "${status}"
 }
 
 count_servers() {
@@ -616,10 +694,6 @@ publish_avahi_service() {
   local port="6443"
   if [ "$#" -gt 0 ]; then port="$1"; shift; fi
 
-  if [ "${role}" != "bootstrap" ]; then
-    stop_bootstrap_publisher
-  fi
-
   run_privileged install -d -m 755 "${AVAHI_SERVICE_DIR}"
   if [ -f "${AVAHI_SERVICE_DIR}/k3s-https.service" ]; then
     remove_privileged_file "${AVAHI_SERVICE_DIR}/k3s-https.service" || true
@@ -640,12 +714,26 @@ publish_api_service() {
   fi
 
   local xml
-  xml="$(render_avahi_service_xml server 6443)"
+  xml="$(render_avahi_service_xml server 6443 "leader=${MDNS_HOST_RAW}" "phase=server")"
   printf '%s\n' "${xml}" | write_privileged_file "${AVAHI_SERVICE_FILE}"
 
   reload_avahi_daemon || true
   AVAHI_ROLE="server"
-  ensure_self_mdns_advertisement server
+  start_server_publisher || true
+  if ensure_self_mdns_advertisement server; then
+    stop_bootstrap_publisher
+    return 0
+  fi
+
+  log "Failed to confirm Avahi server advertisement for ${MDNS_HOST_RAW}; printing diagnostics:"
+  pgrep -a avahi-publish || true
+  if [ -n "${BOOTSTRAP_PUBLISH_LOG:-}" ] && [ -f "${BOOTSTRAP_PUBLISH_LOG}" ]; then
+    sed -n '1,120p' "${BOOTSTRAP_PUBLISH_LOG}" || true
+  fi
+  if [ -n "${SERVER_PUBLISH_LOG:-}" ] && [ -f "${SERVER_PUBLISH_LOG}" ]; then
+    sed -n '1,120p' "${SERVER_PUBLISH_LOG}" || true
+  fi
+  return 1
 }
 
 publish_bootstrap_service() {
@@ -825,6 +913,16 @@ fi
 
 if [ "${TEST_PUBLISH_BOOTSTRAP:-0}" -eq 1 ]; then
   if publish_bootstrap_service; then
+    exit 0
+  fi
+  exit 1
+fi
+
+if [ "${TEST_PUBLISH_SERVER:-0}" -eq 1 ]; then
+  if ! publish_bootstrap_service; then
+    exit 1
+  fi
+  if publish_api_service; then
     exit 0
   fi
   exit 1

--- a/scripts/mdns_helpers.py
+++ b/scripts/mdns_helpers.py
@@ -1,19 +1,23 @@
-"""Utilities for normalising and comparing mDNS hostnames."""
+"""Utilities for normalising and verifying mDNS advertisements."""
+
 from __future__ import annotations
 
-from typing import Final
+import argparse
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Final, Iterable, List, Optional, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover
+    from k3s_mdns_parser import MdnsRecord
 
 _LOCAL_SUFFIXES: Final = (".local",)
+_LEGACY_SERVICE: Final = "_https._tcp"
 
 
 def _norm_host(host: str) -> str:
-    """Normalise a hostname for comparison.
-
-    Avahi is relaxed about emitting trailing dots and mixed case. The
-    sugarkube mDNS checks treat hostnames as case-insensitive, so this helper
-    ensures callers can compare values without mutating the original string
-    used for publication.
-    """
+    """Normalise a hostname for comparison."""
 
     host = host.strip()
     if not host:
@@ -46,4 +50,157 @@ def _same_host(left: str, right: str) -> bool:
     return _strip_local_suffix(left_norm) == _strip_local_suffix(right_norm)
 
 
-__all__ = ["_norm_host", "_same_host"]
+def _service_types(cluster: str, environment: str) -> List[str]:
+    service = f"_k3s-{cluster}-{environment}._tcp"
+    if service == _LEGACY_SERVICE:
+        return [service]
+    return [service, _LEGACY_SERVICE]
+
+
+def _load_lines_from_fixture(fixture_path: str) -> Iterable[str]:
+    try:
+        text = Path(fixture_path).read_text(encoding="utf-8")
+    except OSError:
+        return []
+    return [line for line in text.splitlines() if line]
+
+
+def _run_avahi(
+    command: List[str],
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return runner(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return subprocess.CompletedProcess(command, returncode=127, stdout="", stderr="")
+
+
+def _load_lines_from_avahi(
+    cluster: str,
+    environment: str,
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> Iterable[str]:
+    lines: List[str] = []
+    for service_type in _service_types(cluster, environment):
+        command = [
+            "avahi-browse",
+            "--parsable",
+            "--terminate",
+            "--resolve",
+            service_type,
+        ]
+        result = _run_avahi(command, runner)
+        if result.returncode == 0 and result.stdout:
+            lines.extend(line for line in result.stdout.splitlines() if line)
+        elif result.stdout:
+            lines.extend(line for line in result.stdout.splitlines() if line)
+    return lines
+
+
+def _discover_records(
+    cluster: str,
+    environment: str,
+    *,
+    runner: Optional[Callable[..., subprocess.CompletedProcess[str]]] = None,
+    fixture_path: Optional[str] = None,
+) -> List["MdnsRecord"]:
+    if runner is None:
+        runner = subprocess.run  # type: ignore[assignment]
+
+    if fixture_path:
+        lines = _load_lines_from_fixture(fixture_path)
+    else:
+        lines = _load_lines_from_avahi(cluster, environment, runner)
+
+    from k3s_mdns_parser import parse_mdns_records
+
+    return parse_mdns_records(lines, cluster, environment)
+
+
+def ensure_self_ad_is_visible(
+    expected_host: str,
+    cluster: str,
+    env: str,
+    *,
+    retries: int = 5,
+    delay: float = 1.0,
+    require_phase: Optional[str] = None,
+    runner: Optional[Callable[..., subprocess.CompletedProcess[str]]] = None,
+    fixture_path: Optional[str] = None,
+) -> Tuple[bool, str]:
+    """Return ``(True, host)`` when the expected advertisement becomes visible."""
+
+    expected_norm = _norm_host(expected_host)
+    last_observed = ""
+
+    for _ in range(max(retries, 1)):
+        records = _discover_records(
+            cluster,
+            env,
+            runner=runner,
+            fixture_path=fixture_path,
+        )
+        for record in records:
+            leader = record.txt.get("leader", "")
+            phase_ok = require_phase is None or record.txt.get("phase") == require_phase
+            if not phase_ok:
+                if record.host:
+                    last_observed = record.host
+                elif leader:
+                    last_observed = leader
+                continue
+
+            if _same_host(record.host, expected_norm):
+                return True, record.host
+            if leader and _same_host(leader, expected_norm):
+                return True, leader
+
+            if record.host:
+                last_observed = record.host
+            elif leader:
+                last_observed = leader
+
+        time.sleep(delay)
+
+    return False, last_observed
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expect-host", required=True)
+    parser.add_argument("--cluster", required=True)
+    parser.add_argument("--env", required=True)
+    parser.add_argument("--require-phase", choices=["bootstrap", "server"], default=None)
+    parser.add_argument("--retries", type=int, default=5)
+    parser.add_argument("--delay", type=float, default=1.0)
+    args = parser.parse_args()
+
+    fixture_path = os.environ.get("SUGARKUBE_MDNS_FIXTURE_FILE")
+
+    ok, observed = ensure_self_ad_is_visible(
+        expected_host=args.expect_host,
+        cluster=args.cluster,
+        env=args.env,
+        retries=args.retries,
+        delay=args.delay,
+        require_phase=args.require_phase,
+        fixture_path=fixture_path,
+    )
+
+    if ok:
+        if observed:
+            print(observed)
+        return 0
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(_main())
+
+
+__all__ = ["_norm_host", "_same_host", "ensure_self_ad_is_visible"]

--- a/tests/scripts/test_k3s_discover_bootstrap_publish.py
+++ b/tests/scripts/test_k3s_discover_bootstrap_publish.py
@@ -19,8 +19,14 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
     stub.write_text(
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
+        "phase=unknown\n"
+        "for arg in \"$@\"; do\n"
+        "  if [[ \"${arg}\" == phase=* ]]; then\n"
+        "    phase=\"${arg#phase=}\"\n"
+        "  fi\n"
+        "done\n"
         f"echo \"START:$*\" >> '{log_path}'\n"
-        "trap 'echo TERM >> \"" + str(log_path) + "\"; exit 0' TERM INT\n"
+        f"trap 'echo \"TERM:$phase\" >> \"{log_path}\"; exit 0' TERM INT\n"
         "while true; do sleep 1; done\n",
         encoding="utf-8",
     )
@@ -49,8 +55,8 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
         "ALLOW_NON_ROOT": "1",
         "SUGARKUBE_AVAHI_SERVICE_DIR": str(tmp_path / "avahi"),
         "SUGARKUBE_TOKEN": "dummy",  # bypass token requirement
-        "SUGARKUBE_MDNS_SELF_CHECK_ATTEMPTS": "1",
-        "SUGARKUBE_MDNS_SELF_CHECK_DELAY": "0",
+        "SUGARKUBE_MDNS_BOOT_RETRIES": "1",
+        "SUGARKUBE_MDNS_BOOT_DELAY": "0",
     })
 
     result = subprocess.run(
@@ -64,7 +70,7 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
     # Ensure the helper logged its launch and termination
     log_contents = log_path.read_text(encoding="utf-8")
     assert "START:" in log_contents
-    assert "TERM" in log_contents
+    assert "TERM:bootstrap" in log_contents
 
     assert "-H" in log_contents
     assert f"-H {hostname}.local" in log_contents
@@ -81,7 +87,7 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
 
     # stderr should mention that avahi-publish-service is advertising the bootstrap role
     assert "avahi-publish-service advertising bootstrap" in result.stderr
-    assert "phase=self-check host=" in result.stderr
+    assert "bootstrap advertisement confirmed" in result.stderr
 
 
 def test_bootstrap_publish_handles_trailing_dot_hostname(tmp_path):
@@ -94,8 +100,14 @@ def test_bootstrap_publish_handles_trailing_dot_hostname(tmp_path):
     stub.write_text(
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
+        "phase=unknown\n"
+        "for arg in \"$@\"; do\n"
+        "  if [[ \"${arg}\" == phase=* ]]; then\n"
+        "    phase=\"${arg#phase=}\"\n"
+        "  fi\n"
+        "done\n"
         f"echo \"START:$*\" >> '{log_path}'\n"
-        "trap 'echo TERM >> \"" + str(log_path) + "\"; exit 0' TERM INT\n"
+        f"trap 'echo \"TERM:$phase\" >> \"{log_path}\"; exit 0' TERM INT\n"
         "while true; do sleep 1; done\n",
         encoding="utf-8",
     )
@@ -125,8 +137,8 @@ def test_bootstrap_publish_handles_trailing_dot_hostname(tmp_path):
         "ALLOW_NON_ROOT": "1",
         "SUGARKUBE_AVAHI_SERVICE_DIR": str(tmp_path / "avahi"),
         "SUGARKUBE_TOKEN": "dummy",
-        "SUGARKUBE_MDNS_SELF_CHECK_ATTEMPTS": "1",
-        "SUGARKUBE_MDNS_SELF_CHECK_DELAY": "0",
+        "SUGARKUBE_MDNS_BOOT_RETRIES": "1",
+        "SUGARKUBE_MDNS_BOOT_DELAY": "0",
     })
 
     result = subprocess.run(
@@ -139,7 +151,7 @@ def test_bootstrap_publish_handles_trailing_dot_hostname(tmp_path):
 
     log_contents = log_path.read_text(encoding="utf-8")
     assert "START:" in log_contents
-    assert "TERM" in log_contents
+    assert "TERM:bootstrap" in log_contents
     assert f"leader={hostname}.local" in log_contents
 
     assert "Avahi did not report bootstrap advertisement" not in result.stderr
@@ -156,8 +168,14 @@ def test_publish_binds_host_and_self_check_delays(tmp_path):
     stub.write_text(
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
+        "phase=unknown\n"
+        "for arg in \"$@\"; do\n"
+        "  if [[ \"${arg}\" == phase=* ]]; then\n"
+        "    phase=\"${arg#phase=}\"\n"
+        "  fi\n"
+        "done\n"
         f"echo \"START:$*\" >> '{log_path}'\n"
-        "trap 'echo TERM >> \"" + str(log_path) + "\"; exit 0' TERM INT\n"
+        f"trap 'echo \"TERM:$phase\" >> \"{log_path}\"; exit 0' TERM INT\n"
         "while true; do sleep 1; done\n",
         encoding="utf-8",
     )
@@ -187,8 +205,8 @@ def test_publish_binds_host_and_self_check_delays(tmp_path):
         "ALLOW_NON_ROOT": "1",
         "SUGARKUBE_AVAHI_SERVICE_DIR": str(tmp_path / "avahi"),
         "SUGARKUBE_TOKEN": "dummy",
-        "SUGARKUBE_MDNS_SELF_CHECK_ATTEMPTS": "1",
-        "SUGARKUBE_MDNS_SELF_CHECK_DELAY": "0",
+        "SUGARKUBE_MDNS_BOOT_RETRIES": "1",
+        "SUGARKUBE_MDNS_BOOT_DELAY": "0",
         "SUGARKUBE_MDNS_HOST": "HostMixed.LOCAL.",
     })
 
@@ -202,12 +220,116 @@ def test_publish_binds_host_and_self_check_delays(tmp_path):
 
     log_contents = log_path.read_text(encoding="utf-8")
     assert "START:" in log_contents
-    assert "TERM" in log_contents
+    assert "TERM:bootstrap" in log_contents
     assert "-H HostMixed.LOCAL" in log_contents
     assert "leader=HostMixed.LOCAL" in log_contents
 
     assert "phase=self-check host=HostMixed.LOCAL" in result.stderr
     assert "observed=hostmixed.local" in result.stderr
+
+
+def test_server_publish_waits_for_server_phase(tmp_path):
+    hostname = _hostname_short()
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_path = tmp_path / "publish.log"
+    counter_path = tmp_path / "browse-count"
+    counter_path.write_text("0", encoding="utf-8")
+
+    stub = bin_dir / "avahi-publish-service"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "phase=unknown\n"
+        "for arg in \"$@\"; do\n"
+        "  if [[ \"${arg}\" == phase=* ]]; then\n"
+        "    phase=\"${arg#phase=}\"\n"
+        "  fi\n"
+        "done\n"
+        f"echo \"START:$*\" >> '{log_path}'\n"
+        f"trap 'echo \"TERM:$phase\" >> \"{log_path}\"; exit 0' TERM INT\n"
+        "while true; do sleep 1; done\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+
+    browse = bin_dir / "avahi-browse"
+    browse.write_text(
+        (
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "service=${@: -1}\n"
+            "if [[ \"${service}\" != '_k3s-sugar-dev._tcp' ]]; then\n"
+            "  exit 0\n"
+            "fi\n"
+            "count_file=${SUGARKUBE_TEST_BROWSE_COUNT:-}\n"
+            "if [[ -z ${count_file} ]]; then\n"
+            "  exit 0\n"
+            "fi\n"
+            "count=0\n"
+            "if [[ -f ${count_file} ]]; then\n"
+            "  count=$(<\"${count_file}\")\n"
+            "fi\n"
+            "if [[ ${count} -eq 0 ]]; then\n"
+            "  cat <<'EOF'\n"
+            f"=;eth0;IPv4;k3s-sugar-dev@{hostname}.local (bootstrap);_k3s-sugar-dev._tcp;local;{hostname}.local;"
+            "192.0.2.10;6443;txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=bootstrap;"
+            f"txt=leader={hostname}.local;txt=phase=bootstrap;txt=state=pending\n"
+            "EOF\n"
+            "elif [[ ${count} -eq 1 ]]; then\n"
+            "  :\n"
+            "else\n"
+            "  cat <<'EOF'\n"
+            f"=;eth0;IPv4;k3s-sugar-dev@{hostname}.local (server);_k3s-sugar-dev._tcp;local;{hostname}.local;"
+            "192.0.2.10;6443;txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=server;"
+            f"txt=leader={hostname}.local;txt=phase=server\n"
+            "EOF\n"
+            "fi\n"
+            "echo $((count + 1)) > \"${count_file}\"\n"
+        ),
+        encoding="utf-8",
+    )
+    browse.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env.get('PATH', '')}",
+            "SUGARKUBE_CLUSTER": "sugar",
+            "SUGARKUBE_ENV": "dev",
+            "ALLOW_NON_ROOT": "1",
+            "SUGARKUBE_AVAHI_SERVICE_DIR": str(tmp_path / "avahi"),
+            "SUGARKUBE_TOKEN": "dummy",
+            "SUGARKUBE_MDNS_BOOT_RETRIES": "1",
+            "SUGARKUBE_MDNS_BOOT_DELAY": "0",
+            "SUGARKUBE_MDNS_SERVER_RETRIES": "3",
+            "SUGARKUBE_MDNS_SERVER_DELAY": "0",
+            "SUGARKUBE_TEST_BROWSE_COUNT": str(counter_path),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", SCRIPT, "--test-server-publish"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    log_contents = log_path.read_text(encoding="utf-8")
+    lines = [line for line in log_contents.splitlines() if line]
+    starts = [line for line in lines if line.startswith("START:")]
+    assert any("phase=bootstrap" in line for line in starts)
+    assert any("phase=server" in line for line in starts)
+
+    term_bootstrap = next(i for i, line in enumerate(lines) if line == "TERM:bootstrap")
+    term_server = next(i for i, line in enumerate(lines) if line == "TERM:server")
+    assert term_bootstrap < term_server
+
+    assert "bootstrap advertisement confirmed" in result.stderr
+    assert "server advertisement confirmed" in result.stderr
+
+    assert counter_path.read_text(encoding="utf-8").strip() == "3"
 
 
 def test_bootstrap_publish_fails_without_mdns(tmp_path):
@@ -219,8 +341,14 @@ def test_bootstrap_publish_fails_without_mdns(tmp_path):
     stub.write_text(
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
+        "phase=unknown\n"
+        "for arg in \"$@\"; do\n"
+        "  if [[ \"${arg}\" == phase=* ]]; then\n"
+        "    phase=\"${arg#phase=}\"\n"
+        "  fi\n"
+        "done\n"
         f"echo \"START:$*\" >> '{log_path}'\n"
-        "trap 'echo TERM >> \"" + str(log_path) + "\"; exit 0' TERM INT\n"
+        f"trap 'echo \"TERM:$phase\" >> \"{log_path}\"; exit 0' TERM INT\n"
         "while true; do sleep 1; done\n",
         encoding="utf-8",
     )
@@ -243,8 +371,8 @@ def test_bootstrap_publish_fails_without_mdns(tmp_path):
         "ALLOW_NON_ROOT": "1",
         "SUGARKUBE_AVAHI_SERVICE_DIR": str(tmp_path / "avahi"),
         "SUGARKUBE_TOKEN": "dummy",
-        "SUGARKUBE_MDNS_SELF_CHECK_ATTEMPTS": "2",
-        "SUGARKUBE_MDNS_SELF_CHECK_DELAY": "0",
+        "SUGARKUBE_MDNS_BOOT_RETRIES": "2",
+        "SUGARKUBE_MDNS_BOOT_DELAY": "0",
     })
 
     result = subprocess.run(

--- a/tests/scripts/test_mdns_helpers.py
+++ b/tests/scripts/test_mdns_helpers.py
@@ -1,0 +1,77 @@
+import sys
+import textwrap
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from mdns_helpers import ensure_self_ad_is_visible  # noqa: E402
+
+
+def _write_fixture(tmp_path, payload):
+    path = tmp_path / "mdns.txt"
+    path.write_text(textwrap.dedent(payload).strip() + "\n", encoding="utf-8")
+    return path
+
+
+def test_ensure_self_visible_matches_phase_and_host(tmp_path):
+    fixture = _write_fixture(
+        tmp_path,
+        "=;eth0;IPv4;k3s-sugar-dev@host0 (bootstrap);_k3s-sugar-dev._tcp;local;host0.local;192.0.2.10;6443;"
+        "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=bootstrap;txt=leader=host0.local;txt=phase=bootstrap",
+    )
+
+    ok, observed = ensure_self_ad_is_visible(
+        expected_host="HOST0.LOCAL.",
+        cluster="sugar",
+        env="dev",
+        retries=1,
+        delay=0,
+        require_phase="bootstrap",
+        fixture_path=str(fixture),
+    )
+
+    assert ok is True
+    assert observed == "host0.local"
+
+
+def test_ensure_self_visible_requires_phase(tmp_path):
+    fixture = _write_fixture(
+        tmp_path,
+        "=;eth0;IPv4;k3s-sugar-dev@host0 (bootstrap);_k3s-sugar-dev._tcp;local;host0.local;192.0.2.10;6443;"
+        "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=bootstrap;txt=leader=host0.local;txt=phase=bootstrap",
+    )
+
+    ok, observed = ensure_self_ad_is_visible(
+        expected_host="host0.local",
+        cluster="sugar",
+        env="dev",
+        retries=2,
+        delay=0,
+        require_phase="server",
+        fixture_path=str(fixture),
+    )
+
+    assert ok is False
+    assert observed == "host0.local"
+
+
+def test_ensure_self_visible_matches_leader(tmp_path):
+    fixture = _write_fixture(
+        tmp_path,
+        "=;eth0;IPv4;k3s-sugar-dev@host1 (server);_k3s-sugar-dev._tcp;local;host1.local;192.0.2.11;6443;"
+        "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=server;txt=leader=hostLeader.local;txt=phase=server",
+    )
+
+    ok, observed = ensure_self_ad_is_visible(
+        expected_host="HOSTLEADER.LOCAL.",
+        cluster="sugar",
+        env="dev",
+        retries=1,
+        delay=0,
+        require_phase="server",
+        fixture_path=str(fixture),
+    )
+
+    assert ok is True
+    assert observed == "hostLeader.local"


### PR DESCRIPTION
## Summary
- keep the bootstrap avahi publisher alive until a server-phase advertisement is visible, then retire it once confirmed
- extend mdns_helpers with a phase-aware self-check CLI and add tests that exercise the two-phase bootstrap/server flow
- document the outage follow-up with updated triage commands for the new log files

## Testing
- pytest tests/scripts/test_k3s_discover_bootstrap_publish.py tests/scripts/test_mdns_helpers.py
- linkchecker --no-warnings README.md docs/

------
https://chatgpt.com/codex/tasks/task_e_68f9d1cdffdc832f97de90778d65e055