### PR TITLE
🔧 : publish and verify server-phase mdns advert

### DIFF
--- a/outages/2025-10-23-k3s-mdns-trailing-dot-self-check.json
+++ b/outages/2025-10-23-k3s-mdns-trailing-dot-self-check.json
@@ -3,10 +3,13 @@
   "date": "2025-10-23",
   "component": "scripts/k3s_mdns_parser.py",
   "rootCause": "The Avahi parser left trailing dots on hostnames and TXT leader values when avahi-browse emitted a domain of 'local.', so the mDNS self-check never matched the bootstrap advertisement for the local node.",
-  "resolution": "Trim trailing dots, normalise case, and reuse the hostname normaliser for both resolved hosts and TXT leader fields so bootstrap self-checks accept Avahi responses with domain suffixes.\n\n2025-12-08 follow-up: Bound avahi-publish-service with -H to the FQDN, added a 1s self-check delay, and capture output in /tmp/sugar-publish.log to prevent bootstrap races.\nQuick triage:\n- avahi-browse -rt _k3s-sugar-dev._tcp --parsable | sed -n '1,80p'\n- pgrep -a avahi-publish || true\n- sed -n '1,120p' /tmp/sugar-publish.log || true",
+  "resolution": "Trim trailing dots, normalise case, and reuse the hostname normaliser for both resolved hosts and TXT leader fields so bootstrap self-checks accept Avahi responses with domain suffixes.\n\n2025-12-08 follow-up: Bound avahi-publish-service with -H to the FQDN, added a 1s self-check delay, and capture output in /tmp/sugar-publish.log to prevent bootstrap races.\n\nSymptom: \"bootstrap advert OK; server advert never seen post systemd: Starting k3s within 5s window.\"\nFix: publish phase=server advert explicitly, wait up to 60s, only then retire bootstrap advert.\nQuick triage:\n- avahi-browse -rt _k3s-sugar-dev._tcp --parsable | grep 'txt=.*phase='\n- pgrep -a avahi-publish\n- sed -n '1,120p' /tmp/sugar-publish-{bootstrap,server}.log",
   "references": [
+    "scripts/k3s-discover.sh",
     "scripts/k3s_mdns_parser.py",
+    "scripts/mdns_helpers.py",
     "tests/scripts/test_k3s_discover_bootstrap_publish.py",
-    "tests/scripts/test_k3s_mdns_parser.py"
+    "tests/scripts/test_k3s_mdns_parser.py",
+    "tests/scripts/test_mdns_helpers.py"
   ]
 }

--- a/scripts/k3s-discover.sh
+++ b/scripts/k3s-discover.sh
@@ -38,8 +38,10 @@ NODE_TOKEN_PATH="${SUGARKUBE_NODE_TOKEN_PATH:-/var/lib/rancher/k3s/server/node-t
 BOOT_TOKEN_PATH="${SUGARKUBE_BOOT_TOKEN_PATH:-/boot/sugarkube-node-token}"
 DISCOVERY_WAIT_SECS="${DISCOVERY_WAIT_SECS:-9}"
 DISCOVERY_ATTEMPTS="${DISCOVERY_ATTEMPTS:-15}"
-MDNS_SELF_CHECK_ATTEMPTS="${SUGARKUBE_MDNS_SELF_CHECK_ATTEMPTS:-5}"
-MDNS_SELF_CHECK_DELAY="${SUGARKUBE_MDNS_SELF_CHECK_DELAY:-1}"
+MDNS_BOOT_RETRIES="${SUGARKUBE_MDNS_BOOT_RETRIES:-5}"
+MDNS_BOOT_DELAY="${SUGARKUBE_MDNS_BOOT_DELAY:-1}"
+MDNS_SERVER_RETRIES="${SUGARKUBE_MDNS_SERVER_RETRIES:-60}"
+MDNS_SERVER_DELAY="${SUGARKUBE_MDNS_SERVER_DELAY:-1}"
 SKIP_MDNS_SELF_CHECK="${SUGARKUBE_SKIP_MDNS_SELF_CHECK:-0}"
 
 PRINT_TOKEN_ONLY=0
@@ -52,6 +54,7 @@ TEST_RUN_AVAHI=""
 TEST_RENDER_SERVICE=0
 TEST_WAIT_LOOP=0
 TEST_PUBLISH_BOOTSTRAP=0
+TEST_PUBLISH_SERVER=0
 TEST_CLAIM_BOOTSTRAP=0
 declare -a TEST_RENDER_ARGS=()
 
@@ -82,6 +85,9 @@ while [ "$#" -gt 0 ]; do
       ;;
     --test-bootstrap-publish)
       TEST_PUBLISH_BOOTSTRAP=1
+      ;;
+    --test-server-publish)
+      TEST_PUBLISH_SERVER=1
       ;;
     --test-claim-bootstrap)
       TEST_CLAIM_BOOTSTRAP=1
@@ -207,6 +213,8 @@ AVAHI_SERVICE_FILE="${SUGARKUBE_AVAHI_SERVICE_FILE:-${AVAHI_SERVICE_DIR}/k3s-${C
 AVAHI_ROLE=""
 BOOTSTRAP_PUBLISH_PID=""
 BOOTSTRAP_PUBLISH_LOG=""
+SERVER_PUBLISH_PID=""
+SERVER_PUBLISH_LOG=""
 CLAIMED_SERVER_HOST=""
 
 run_privileged() {
@@ -256,8 +264,20 @@ stop_bootstrap_publisher() {
   fi
 }
 
+stop_server_publisher() {
+  if [ -n "${SERVER_PUBLISH_PID:-}" ]; then
+    if kill -0 "${SERVER_PUBLISH_PID}" >/dev/null 2>&1; then
+      kill "${SERVER_PUBLISH_PID}" >/dev/null 2>&1 || true
+    fi
+    wait "${SERVER_PUBLISH_PID}" >/dev/null 2>&1 || true
+    SERVER_PUBLISH_PID=""
+    SERVER_PUBLISH_LOG=""
+  fi
+}
+
 cleanup_avahi_bootstrap() {
   stop_bootstrap_publisher
+  stop_server_publisher
   if [ "${AVAHI_ROLE}" = "bootstrap" ]; then
     remove_privileged_file "${AVAHI_SERVICE_FILE}" || true
     reload_avahi_daemon || true
@@ -309,7 +329,7 @@ start_bootstrap_publisher() {
   local publish_name
   publish_name="$(service_instance_name bootstrap "${MDNS_HOST_RAW}")"
 
-  BOOTSTRAP_PUBLISH_LOG="/tmp/sugar-publish.log"
+  BOOTSTRAP_PUBLISH_LOG="/tmp/sugar-publish-bootstrap.log"
   : >"${BOOTSTRAP_PUBLISH_LOG}" 2>/dev/null || true
 
   avahi-publish-service \
@@ -340,6 +360,51 @@ start_bootstrap_publisher() {
   fi
 
   log "avahi-publish-service advertising bootstrap as ${MDNS_HOST_RAW} on ${MDNS_SERVICE_TYPE} (pid ${BOOTSTRAP_PUBLISH_PID})"
+  return 0
+}
+
+start_server_publisher() {
+  if ! command -v avahi-publish-service >/dev/null 2>&1; then
+    return 1
+  fi
+  if [ -n "${SERVER_PUBLISH_PID:-}" ] && kill -0 "${SERVER_PUBLISH_PID}" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local publish_name
+  publish_name="$(service_instance_name server "${MDNS_HOST_RAW}")"
+
+  SERVER_PUBLISH_LOG="/tmp/sugar-publish-server.log"
+  : >"${SERVER_PUBLISH_LOG}" 2>/dev/null || true
+
+  avahi-publish-service \
+    -H "${MDNS_HOST_RAW}" \
+    "${publish_name}" \
+    "${MDNS_SERVICE_TYPE}" \
+    6443 \
+    "k3s=1" \
+    "cluster=${CLUSTER}" \
+    "env=${ENVIRONMENT}" \
+    "role=server" \
+    "leader=${MDNS_HOST_RAW}" \
+    "phase=server" \
+    "state=ready" \
+    >"${SERVER_PUBLISH_LOG}" 2>&1 &
+  SERVER_PUBLISH_PID=$!
+
+  sleep 1
+  if ! kill -0 "${SERVER_PUBLISH_PID}" >/dev/null 2>&1; then
+    if [ -s "${SERVER_PUBLISH_LOG}" ]; then
+      while IFS= read -r line; do
+        log "server publisher error: ${line}"
+      done <"${SERVER_PUBLISH_LOG}"
+    fi
+    SERVER_PUBLISH_PID=""
+    SERVER_PUBLISH_LOG=""
+    return 1
+  fi
+
+  log "avahi-publish-service advertising server as ${MDNS_HOST_RAW} on ${MDNS_SERVICE_TYPE} (pid ${SERVER_PUBLISH_PID})"
   return 0
 }
 
@@ -448,46 +513,47 @@ discover_bootstrap_leaders() {
 }
 
 ensure_self_mdns_advertisement() {
-  local role="$1"
+  local phase_required="$1"
+  local retries="$2"
+  local delay="$3"
   if [ "${SKIP_MDNS_SELF_CHECK}" = "1" ]; then
     return 0
   fi
 
-  local query_mode=""
-  case "${role}" in
-    bootstrap)
-      query_mode="bootstrap-hosts"
-      ;;
-    server)
-      query_mode="server-hosts"
-      ;;
-    *)
-      return 0
-      ;;
-  esac
+  local args=(
+    "${SCRIPT_DIR}/mdns_helpers.py"
+    --expect-host
+    "${MDNS_HOST_RAW}"
+    --cluster
+    "${CLUSTER}"
+    --env
+    "${ENVIRONMENT}"
+    --retries
+    "${retries}"
+    --delay
+    "${delay}"
+  )
+  if [ -n "${phase_required}" ]; then
+    args+=(--require-phase "${phase_required}")
+  fi
 
-  local attempts="${MDNS_SELF_CHECK_ATTEMPTS}"
-  local delay="${MDNS_SELF_CHECK_DELAY}"
-  local attempt
-  for attempt in $(seq 1 "${attempts}"); do
-    mapfile -t hosts < <(run_avahi_query "${query_mode}" || true)
-    if [ "${#hosts[@]}" -gt 0 ]; then
-      local observed=""
-      for observed in "${hosts[@]}"; do
-        if same_host "${observed}" "${MDNS_HOST_RAW}"; then
-          log "phase=self-check host=${MDNS_HOST_RAW} observed=${observed} attempt=${attempt}/${attempts}; advertisement confirmed."
-          return 0
-        fi
-      done
+  local observed_output=""
+  if observed_output="$(python3 "${args[@]}")"; then
+    local observed="${observed_output%% *}"
+    observed="${observed#observed=}"
+    local attempt="${observed_output##* }"
+    attempt="${attempt#attempt=}"
+    if [ -z "${observed}" ] || [ "${observed}" = "${observed_output}" ]; then
+      observed="${MDNS_HOST_RAW}"
     fi
-
-    if [ "${attempt}" -lt "${attempts}" ]; then
-      log "phase=self-check host=${MDNS_HOST_RAW} attempt=${attempt}/${attempts}; retrying in ${delay}s."
-      sleep "${delay}"
+    if [ -z "${attempt}" ] || [ "${attempt}" = "${observed_output}" ]; then
+      attempt="${retries}"
     fi
-  done
+    log "phase=self-check target-phase=${phase_required:-any} host=${MDNS_HOST_RAW} observed=${observed} attempt=${attempt}/${retries}; advertisement confirmed."
+    return 0
+  fi
 
-  log "phase=self-check host=${MDNS_HOST_RAW} attempts=${attempts}; advertisement not reported."
+  log "phase=self-check target-phase=${phase_required:-any} host=${MDNS_HOST_RAW} retries=${retries}; advertisement not reported."
   return 1
 }
 
@@ -616,10 +682,6 @@ publish_avahi_service() {
   local port="6443"
   if [ "$#" -gt 0 ]; then port="$1"; shift; fi
 
-  if [ "${role}" != "bootstrap" ]; then
-    stop_bootstrap_publisher
-  fi
-
   run_privileged install -d -m 755 "${AVAHI_SERVICE_DIR}"
   if [ -f "${AVAHI_SERVICE_DIR}/k3s-https.service" ]; then
     remove_privileged_file "${AVAHI_SERVICE_DIR}/k3s-https.service" || true
@@ -645,7 +707,21 @@ publish_api_service() {
 
   reload_avahi_daemon || true
   AVAHI_ROLE="server"
-  ensure_self_mdns_advertisement server
+  start_server_publisher || true
+  if ensure_self_mdns_advertisement server "${MDNS_SERVER_RETRIES}" "${MDNS_SERVER_DELAY}"; then
+    stop_bootstrap_publisher
+    return 0
+  fi
+
+  log "Failed to confirm Avahi server advertisement for ${MDNS_HOST_RAW}; printing diagnostics"
+  pgrep -a avahi-publish || true
+  if [ -n "${BOOTSTRAP_PUBLISH_LOG:-}" ] && [ -s "${BOOTSTRAP_PUBLISH_LOG}" ]; then
+    sed -n '1,120p' "${BOOTSTRAP_PUBLISH_LOG}" || true
+  fi
+  if [ -n "${SERVER_PUBLISH_LOG:-}" ] && [ -s "${SERVER_PUBLISH_LOG}" ]; then
+    sed -n '1,120p' "${SERVER_PUBLISH_LOG}" || true
+  fi
+  return 1
 }
 
 publish_bootstrap_service() {
@@ -653,7 +729,7 @@ publish_bootstrap_service() {
   start_bootstrap_publisher || true
   publish_avahi_service bootstrap 6443 "leader=${MDNS_HOST_RAW}" "phase=bootstrap" "state=pending"
   sleep 1
-  ensure_self_mdns_advertisement bootstrap
+  ensure_self_mdns_advertisement bootstrap "${MDNS_BOOT_RETRIES}" "${MDNS_BOOT_DELAY}"
 }
 
 claim_bootstrap_leadership() {
@@ -825,6 +901,13 @@ fi
 
 if [ "${TEST_PUBLISH_BOOTSTRAP:-0}" -eq 1 ]; then
   if publish_bootstrap_service; then
+    exit 0
+  fi
+  exit 1
+fi
+
+if [ "${TEST_PUBLISH_SERVER:-0}" -eq 1 ]; then
+  if publish_bootstrap_service && publish_api_service; then
     exit 0
   fi
   exit 1

--- a/scripts/mdns_helpers.py
+++ b/scripts/mdns_helpers.py
@@ -1,19 +1,23 @@
-"""Utilities for normalising and comparing mDNS hostnames."""
+"""Utilities for normalising and confirming sugarkube mDNS advertisements."""
 from __future__ import annotations
 
-from typing import Final
+import argparse
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Final, Iterable, List, Optional, Sequence, Tuple
+
+if TYPE_CHECKING:
+    from k3s_mdns_parser import MdnsRecord
 
 _LOCAL_SUFFIXES: Final = (".local",)
 
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
 
 def _norm_host(host: str) -> str:
-    """Normalise a hostname for comparison.
-
-    Avahi is relaxed about emitting trailing dots and mixed case. The
-    sugarkube mDNS checks treat hostnames as case-insensitive, so this helper
-    ensures callers can compare values without mutating the original string
-    used for publication.
-    """
+    """Normalise a hostname for comparison."""
 
     host = host.strip()
     if not host:
@@ -46,4 +50,126 @@ def _same_host(left: str, right: str) -> bool:
     return _strip_local_suffix(left_norm) == _strip_local_suffix(right_norm)
 
 
-__all__ = ["_norm_host", "_same_host"]
+def _service_types(cluster: str, environment: str) -> Sequence[str]:
+    service = f"_k3s-{cluster}-{environment}._tcp"
+    types = [service]
+    legacy = "_https._tcp"
+    if legacy not in types:
+        types.append(legacy)
+    return types
+
+
+def _browse_once(service_type: str, *, runner: Runner) -> Iterable[str]:
+    command = [
+        "avahi-browse",
+        "--parsable",
+        "--terminate",
+        "--resolve",
+        service_type,
+    ]
+    try:
+        result = runner(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return []
+    if result.stdout:
+        return [line for line in result.stdout.splitlines() if line]
+    return []
+
+
+def _load_lines(cluster: str, environment: str, *, runner: Optional[Runner] = None) -> List[str]:
+    fixture_path = os.environ.get("SUGARKUBE_MDNS_FIXTURE_FILE")
+    if fixture_path:
+        try:
+            text = Path(fixture_path).read_text(encoding="utf-8")
+        except OSError:
+            return []
+        return [line for line in text.splitlines() if line]
+
+    if runner is None:
+        runner = subprocess.run  # type: ignore[assignment]
+
+    lines: List[str] = []
+    for service_type in _service_types(cluster, environment):
+        lines.extend(_browse_once(service_type, runner=runner))
+    return lines
+
+
+def _find_records(
+    cluster: str,
+    environment: str,
+    *,
+    runner: Optional[Runner] = None,
+) -> List["MdnsRecord"]:
+    lines = _load_lines(cluster, environment, runner=runner)
+    if not lines:
+        return []
+    from k3s_mdns_parser import parse_mdns_records  # Local import to avoid circular dependency
+
+    return parse_mdns_records(lines, cluster, environment)
+
+
+def ensure_self_ad_is_visible(
+    *,
+    expected_host: str,
+    cluster: str,
+    env: str,
+    retries: int = 5,
+    delay: float = 1.0,
+    require_phase: Optional[str] = None,
+    runner: Optional[Runner] = None,
+) -> Optional[Tuple[str, int]]:
+    """Confirm that the expected host advertises itself via mDNS."""
+
+    expected_norm = _norm_host(expected_host)
+    for attempt in range(1, retries + 1):
+        for record in _find_records(cluster, env, runner=runner):
+            if require_phase is not None and record.txt.get("phase") != require_phase:
+                continue
+
+            host_match = _same_host(record.host, expected_norm)
+            leader_match = _same_host(record.txt.get("leader", ""), expected_norm)
+            if host_match or leader_match:
+                observed = record.host if host_match else record.txt.get("leader", record.host)
+                return observed or record.host, attempt
+
+        time.sleep(delay)
+
+    return None
+
+
+def _main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--expect-host", required=True)
+    ap.add_argument("--cluster", required=True)
+    ap.add_argument("--env", required=True)
+    ap.add_argument("--require-phase", choices=["bootstrap", "server"], default=None)
+    ap.add_argument("--retries", type=int, default=5)
+    ap.add_argument("--delay", type=float, default=1.0)
+    args = ap.parse_args(argv)
+
+    result = ensure_self_ad_is_visible(
+        expected_host=args.expect_host,
+        cluster=args.cluster,
+        env=args.env,
+        retries=args.retries,
+        delay=args.delay,
+        require_phase=args.require_phase,
+    )
+    if result is None:
+        return 1
+
+    observed, attempt = result
+    print(f"observed={observed} attempt={attempt}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI exercised in tests
+    raise SystemExit(_main())
+
+
+__all__ = ["_norm_host", "_same_host", "ensure_self_ad_is_visible"]

--- a/tests/scripts/test_mdns_helpers.py
+++ b/tests/scripts/test_mdns_helpers.py
@@ -1,0 +1,91 @@
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from mdns_helpers import _norm_host, _same_host, ensure_self_ad_is_visible  # noqa: E402
+
+
+class FakeRunner:
+    def __init__(self, responses):
+        self._responses = responses
+        self._calls = {}
+
+    def __call__(self, command, capture_output, text, check):
+        service = command[-1]
+        idx = self._calls.get(service, 0)
+        self._calls[service] = idx + 1
+        stdout_values = self._responses.get(service, [])
+        stdout = stdout_values[idx] if idx < len(stdout_values) else ""
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+
+def test_same_host_handles_case_and_suffix():
+    assert _same_host("Host.Local.", "host.local")
+    assert _same_host("HOST", "host.local")
+    assert not _same_host("host-a", "host-b.local")
+
+
+def test_ensure_self_ad_is_visible_requires_phase():
+    bootstrap_record = (
+        "=;eth0;IPv4;k3s-sugar-dev@host0 (bootstrap);_k3s-sugar-dev._tcp;local;host0.local;"
+        "192.0.2.10;6443;txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=bootstrap;"
+        "txt=leader=host0.local;txt=phase=bootstrap\n"
+    )
+    server_record = (
+        "=;eth0;IPv4;k3s-sugar-dev@host0 (server);_k3s-sugar-dev._tcp;local;host0.local;"
+        "192.0.2.10;6443;txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=server;"
+        "txt=leader=host0.local;txt=phase=server\n"
+    )
+    responses = {
+        "_k3s-sugar-dev._tcp": ["", bootstrap_record, "", server_record],
+        "_https._tcp": ["", "", "", ""],
+    }
+    runner = FakeRunner(responses)
+
+    result = ensure_self_ad_is_visible(
+        expected_host="host0.local",
+        cluster="sugar",
+        env="dev",
+        retries=4,
+        delay=0.0,
+        require_phase="server",
+        runner=runner,
+    )
+    assert result is not None
+    observed, attempt = result
+    assert observed == "host0.local"
+    assert attempt == 4
+
+
+def test_ensure_self_ad_matches_leader_when_host_differs():
+    server_record = (
+        "=;eth0;IPv4;k3s-sugar-dev@host1 (server);_k3s-sugar-dev._tcp;local;host1.local;"
+        "192.0.2.11;6443;txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=server;"
+        "txt=leader=expected.local;txt=phase=server\n"
+    )
+    responses = {
+        "_k3s-sugar-dev._tcp": [server_record],
+        "_https._tcp": [""],
+    }
+    runner = FakeRunner(responses)
+
+    result = ensure_self_ad_is_visible(
+        expected_host="expected.local",
+        cluster="sugar",
+        env="dev",
+        retries=1,
+        delay=0.0,
+        require_phase="server",
+        runner=runner,
+    )
+    assert result is not None
+    observed, attempt = result
+    assert observed == "expected.local"
+    assert attempt == 1
+
+
+def test_norm_host_strips_trailing_dots():
+    assert _norm_host("Host.LOCAL.") == "host.local"
+    assert _norm_host("example.com...") == "example.com"


### PR DESCRIPTION
what: keep bootstrap advert alive until server advert is confirmed
why: avoid races where k3s server publish lags mdns verification
how to test: pytest tests/scripts/test_mdns_helpers.py tests/scripts/test_k3s_discover_bootstrap_publish.py
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68f9d1cdffdc832f97de90778d65e055