### PR TITLE
mdns: track dynamic publisher PIDs and make just wipe terminate them

### DIFF
--- a/justfile
+++ b/justfile
@@ -39,6 +39,7 @@ kubeconfig env='dev':
     python3 scripts/update_kubeconfig_scope.py "${HOME}/.kube/config" "sugar-{{ env }}"
 
 wipe:
+    sudo -E bash scripts/cleanup_mdns_publishers.sh
     @sudo --preserve-env=SUGARKUBE_CLUSTER,SUGARKUBE_ENV,DRY_RUN,ALLOW_NON_ROOT bash scripts/wipe_node.sh
 
 scripts_dir := justfile_directory() + "/scripts"

--- a/scripts/cleanup_mdns_publishers.sh
+++ b/scripts/cleanup_mdns_publishers.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER="${SUGARKUBE_CLUSTER:-sugar}"
+ENVIRONMENT="${SUGARKUBE_ENV:-dev}"
+RUNTIME_DIR="${SUGARKUBE_RUNTIME_DIR:-/run/sugarkube}"
+
+log() {
+  printf '[cleanup-mdns] %s\n' "$*"
+}
+
+killed_any=0
+
+if [ -d "${RUNTIME_DIR}" ]; then
+  for phase in bootstrap server; do
+    pid_file="${RUNTIME_DIR}/mdns-${CLUSTER}-${ENVIRONMENT}-${phase}.pid"
+    if [ -f "${pid_file}" ]; then
+      pid="$(cat "${pid_file}" 2>/dev/null || true)"
+      if [ -n "${pid:-}" ] && kill -0 "${pid}" 2>/dev/null; then
+        log "killing ${phase} publisher pid=${pid}"
+        kill "${pid}" 2>/dev/null || true
+        for _ in 1 2 3 4 5; do
+          if ! kill -0 "${pid}" 2>/dev/null; then
+            break
+          fi
+          sleep 0.1
+        done
+        if kill -0 "${pid}" 2>/dev/null; then
+          kill -9 "${pid}" 2>/dev/null || true
+        fi
+        killed_any=1
+      fi
+      rm -f "${pid_file}" || true
+    fi
+  done
+fi
+
+svc="_k3s-${CLUSTER}-${ENVIRONMENT}._tcp"
+pattern="avahi-publish-service.*${svc}"
+
+if command -v pkill >/dev/null 2>&1; then
+  if command -v pgrep >/dev/null 2>&1; then
+    if pgrep -af "${pattern}" >/dev/null 2>&1; then
+      log "pkill stray avahi-publish-service for ${svc}"
+      pkill -f "${pattern}" 2>/dev/null || true
+      killed_any=1
+    fi
+  else
+    if pkill -f "${pattern}" 2>/dev/null; then
+      log "pkill stray avahi-publish-service for ${svc}"
+      killed_any=1
+    fi
+  fi
+fi
+
+if command -v avahi-browse >/dev/null 2>&1; then
+  if avahi-browse -pt "${svc}" 2>/dev/null | grep -q "${svc}"; then
+    log "WARNING: advert for ${svc} still visible (browser cache may lag)"
+  fi
+fi
+
+if [ "${killed_any}" -eq 1 ]; then
+  log "dynamic publishers terminated"
+fi
+

--- a/tests/scripts/test_cleanup_mdns_publishers.sh
+++ b/tests/scripts/test_cleanup_mdns_publishers.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+helper="${repo_root}/scripts/cleanup_mdns_publishers.sh"
+
+runtime_base="$(mktemp -d)"
+trap 'rc=$?; for pid in "${pids[@]:-}"; do
+  if kill -0 "$pid" 2>/dev/null; then kill "$pid" 2>/dev/null || true; fi
+ done; rm -rf "${runtime_base}"; exit "$rc"' EXIT
+
+runtime_dir="${runtime_base}/run"
+mkdir -p "${runtime_dir}"
+
+declare -a pids=()
+
+sleep 60 &
+pids+=($!)
+bootstrap_pid=${pids[-1]}
+printf '%s\n' "${bootstrap_pid}" >"${runtime_dir}/mdns-sugar-dev-bootstrap.pid"
+
+sleep 60 &
+pids+=($!)
+server_pid=${pids[-1]}
+printf '%s\n' "${server_pid}" >"${runtime_dir}/mdns-sugar-dev-server.pid"
+
+# Launch a stray publisher-style process so the fallback pkill path triggers.
+bash -c 'exec -a "avahi-publish-service stray _k3s-sugar-dev._tcp" sleep 60' &
+pids+=($!)
+stray_pid=${pids[-1]}
+
+output="$(
+  SUGARKUBE_CLUSTER=sugar \
+  SUGARKUBE_ENV=dev \
+  SUGARKUBE_RUNTIME_DIR="${runtime_dir}" \
+    bash "${helper}"
+)"
+
+printf '%s' "${output}" | grep -q "dynamic publishers terminated"
+
+if [ -f "${runtime_dir}/mdns-sugar-dev-bootstrap.pid" ]; then
+  echo "bootstrap pidfile still present" >&2
+  exit 1
+fi
+
+if [ -f "${runtime_dir}/mdns-sugar-dev-server.pid" ]; then
+  echo "server pidfile still present" >&2
+  exit 1
+fi
+
+if kill -0 "${bootstrap_pid}" 2>/dev/null; then
+  echo "bootstrap publisher still running" >&2
+  exit 1
+fi
+
+if kill -0 "${server_pid}" 2>/dev/null; then
+  echo "server publisher still running" >&2
+  exit 1
+fi
+
+if kill -0 "${stray_pid}" 2>/dev/null; then
+  echo "stray publisher still running" >&2
+  exit 1
+fi
+

--- a/tests/scripts/test_k3s_discover_bootstrap_publish.py
+++ b/tests/scripts/test_k3s_discover_bootstrap_publish.py
@@ -1,8 +1,12 @@
 import os
 import subprocess
+import time
 from pathlib import Path
 
+import pytest
+
 SCRIPT = str(Path(__file__).resolve().parents[2] / "scripts" / "k3s-discover.sh")
+CLEANUP_SCRIPT = str(Path(__file__).resolve().parents[2] / "scripts" / "cleanup_mdns_publishers.sh")
 
 
 def _hostname_short() -> str:
@@ -14,6 +18,7 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log_path = tmp_path / "publish.log"
+    runtime_dir = tmp_path / "run"
 
     stub = bin_dir / "avahi-publish-service"
     stub.write_text(
@@ -48,18 +53,43 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
         "SUGARKUBE_ENV": "dev",
         "ALLOW_NON_ROOT": "1",
         "SUGARKUBE_AVAHI_SERVICE_DIR": str(tmp_path / "avahi"),
+        "SUGARKUBE_RUNTIME_DIR": str(runtime_dir),
         "SUGARKUBE_TOKEN": "dummy",  # bypass token requirement
         "SUGARKUBE_MDNS_SELF_CHECK_ATTEMPTS": "1",
         "SUGARKUBE_MDNS_SELF_CHECK_DELAY": "0",
     })
 
-    result = subprocess.run(
+    proc = subprocess.Popen(
         ["bash", SCRIPT, "--test-bootstrap-publish"],
         env=env,
         text=True,
-        capture_output=True,
-        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
+
+    pid_file = runtime_dir / "mdns-sugar-dev-bootstrap.pid"
+    deadline = time.time() + 5
+    pid_value = ""
+    while time.time() < deadline:
+        if pid_file.exists():
+            pid_value = pid_file.read_text(encoding="utf-8").strip()
+            if pid_value:
+                break
+        if proc.poll() is not None:
+            break
+        time.sleep(0.05)
+
+    assert pid_value, "bootstrap PID file was not created"
+    os.kill(int(pid_value), 0)
+
+    stdout, stderr = proc.communicate(timeout=10)
+    assert proc.returncode == 0, stderr
+
+    deadline = time.time() + 5
+    while pid_file.exists() and time.time() < deadline:
+        time.sleep(0.05)
+
+    assert not pid_file.exists()
 
     # Ensure the helper logged its launch and termination
     log_contents = log_path.read_text(encoding="utf-8")
@@ -80,8 +110,8 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
     assert not service_file.exists()
 
     # stderr should mention that avahi-publish-service is advertising the bootstrap role
-    assert "avahi-publish-service advertising bootstrap" in result.stderr
-    assert "phase=self-check host=" in result.stderr
+    assert "avahi-publish-service advertising bootstrap" in stderr
+    assert "phase=self-check host=" in stderr
 
 
 def test_bootstrap_publish_handles_trailing_dot_hostname(tmp_path):
@@ -89,6 +119,7 @@ def test_bootstrap_publish_handles_trailing_dot_hostname(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log_path = tmp_path / "publish.log"
+    runtime_dir = tmp_path / "run"
 
     stub = bin_dir / "avahi-publish-service"
     stub.write_text(
@@ -124,6 +155,7 @@ def test_bootstrap_publish_handles_trailing_dot_hostname(tmp_path):
         "SUGARKUBE_ENV": "dev",
         "ALLOW_NON_ROOT": "1",
         "SUGARKUBE_AVAHI_SERVICE_DIR": str(tmp_path / "avahi"),
+        "SUGARKUBE_RUNTIME_DIR": str(runtime_dir),
         "SUGARKUBE_TOKEN": "dummy",
         "SUGARKUBE_MDNS_SELF_CHECK_ATTEMPTS": "1",
         "SUGARKUBE_MDNS_SELF_CHECK_DELAY": "0",
@@ -151,6 +183,7 @@ def test_publish_binds_host_and_self_check_delays(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log_path = tmp_path / "publish.log"
+    runtime_dir = tmp_path / "run"
 
     stub = bin_dir / "avahi-publish-service"
     stub.write_text(
@@ -186,6 +219,7 @@ def test_publish_binds_host_and_self_check_delays(tmp_path):
         "SUGARKUBE_ENV": "dev",
         "ALLOW_NON_ROOT": "1",
         "SUGARKUBE_AVAHI_SERVICE_DIR": str(tmp_path / "avahi"),
+        "SUGARKUBE_RUNTIME_DIR": str(runtime_dir),
         "SUGARKUBE_TOKEN": "dummy",
         "SUGARKUBE_MDNS_SELF_CHECK_ATTEMPTS": "1",
         "SUGARKUBE_MDNS_SELF_CHECK_DELAY": "0",
@@ -214,6 +248,7 @@ def test_bootstrap_publish_fails_without_mdns(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log_path = tmp_path / "publish.log"
+    runtime_dir = tmp_path / "run"
 
     stub = bin_dir / "avahi-publish-service"
     stub.write_text(
@@ -242,6 +277,7 @@ def test_bootstrap_publish_fails_without_mdns(tmp_path):
         "SUGARKUBE_ENV": "dev",
         "ALLOW_NON_ROOT": "1",
         "SUGARKUBE_AVAHI_SERVICE_DIR": str(tmp_path / "avahi"),
+        "SUGARKUBE_RUNTIME_DIR": str(runtime_dir),
         "SUGARKUBE_TOKEN": "dummy",
         "SUGARKUBE_MDNS_SELF_CHECK_ATTEMPTS": "2",
         "SUGARKUBE_MDNS_SELF_CHECK_DELAY": "0",
@@ -260,3 +296,84 @@ def test_bootstrap_publish_fails_without_mdns(tmp_path):
 
     service_file = tmp_path / "avahi" / "k3s-sugar-dev.service"
     assert not service_file.exists()
+
+
+def test_server_publisher_persists_until_cleanup(tmp_path):
+    hostname = _hostname_short()
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_path = tmp_path / "server.log"
+    runtime_dir = tmp_path / "run"
+
+    stub = bin_dir / "avahi-publish-service"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"echo \"START:$*\" >> '{log_path}'\n"
+        "trap 'echo TERM >> \"" + str(log_path) + "\"; exit 0' TERM INT\n"
+        "while true; do sleep 1; done\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env.get('PATH', '')}",
+            "SUGARKUBE_CLUSTER": "sugar",
+            "SUGARKUBE_ENV": "dev",
+            "ALLOW_NON_ROOT": "1",
+            "SUGARKUBE_RUNTIME_DIR": str(runtime_dir),
+            "SUGARKUBE_AVAHI_SERVICE_DIR": str(tmp_path / "avahi"),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", SCRIPT, "--test-server-publish"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    log_contents = log_path.read_text(encoding="utf-8")
+    assert "START:" in log_contents
+    assert "phase=server" in log_contents
+    assert "role=server" in log_contents
+    assert f"-H {hostname}.local" in log_contents
+
+    pid_file = runtime_dir / "mdns-sugar-dev-server.pid"
+    assert pid_file.exists()
+    pid_value = pid_file.read_text(encoding="utf-8").strip()
+    assert pid_value
+    os.kill(int(pid_value), 0)
+
+    cleanup_result = subprocess.run(
+        ["bash", CLEANUP_SCRIPT],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert "dynamic publishers terminated" in cleanup_result.stdout
+
+    deadline = time.time() + 5
+    while pid_file.exists() and time.time() < deadline:
+        time.sleep(0.05)
+    assert not pid_file.exists()
+
+    end_time = time.time() + 5
+    proc_path = Path("/proc") / pid_value
+    while proc_path.exists():
+        status_path = proc_path / "status"
+        if status_path.exists():
+            status = status_path.read_text(encoding="utf-8")
+            if "State:\tZ" in status:
+                break
+        if time.time() >= end_time:
+            pytest.fail("server publisher process still running after cleanup")
+        time.sleep(0.05)
+
+    log_contents = log_path.read_text(encoding="utf-8")
+    assert "avahi-publish-service advertising server" in result.stderr


### PR DESCRIPTION
## Summary
- record bootstrap/server avahi-publish-service PIDs under /run/sugarkube and clean stale files on startup
- add scripts/cleanup_mdns_publishers.sh and call it from just wipe and wipe_node.sh to terminate dynamic adverts
- extend mdns tests to cover PID files, add cleanup shell test, and provide a server-publish test hook

## Testing
- pytest tests/scripts/test_k3s_discover_bootstrap_publish.py tests/scripts/test_k3s_discover_mid_election_join.py
- bash tests/scripts/test_cleanup_mdns_publishers.sh

------
https://chatgpt.com/codex/tasks/task_e_68f9d4997540832f8cd3c4562b7c79e7