### PR TITLE
Track dynamic mDNS publishers and clean them during wipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -39,6 +39,7 @@ kubeconfig env='dev':
     python3 scripts/update_kubeconfig_scope.py "${HOME}/.kube/config" "sugar-{{ env }}"
 
 wipe:
+    @sudo --preserve-env=SUGARKUBE_CLUSTER,SUGARKUBE_ENV,DRY_RUN,ALLOW_NON_ROOT bash scripts/cleanup_mdns_publishers.sh
     @sudo --preserve-env=SUGARKUBE_CLUSTER,SUGARKUBE_ENV,DRY_RUN,ALLOW_NON_ROOT bash scripts/wipe_node.sh
 
 scripts_dir := justfile_directory() + "/scripts"

--- a/scripts/cleanup_mdns_publishers.sh
+++ b/scripts/cleanup_mdns_publishers.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DRY_RUN="${DRY_RUN:-0}"
+CLUSTER="${SUGARKUBE_CLUSTER:-sugar}"
+ENVIRONMENT="${SUGARKUBE_ENV:-dev}"
+RUNTIME_DIR="${SUGARKUBE_RUNTIME_DIR:-/run/sugarkube}"
+
+log() {
+  printf '[cleanup-mdns %s/%s] %s\n' "${CLUSTER}" "${ENVIRONMENT}" "$*"
+}
+
+maybe_remove_pid_file() {
+  local phase="$1"
+  local pid_file="$2"
+  if [ "${DRY_RUN}" = "1" ]; then
+    log "DRY_RUN=1: would remove ${pid_file}"
+    return 0
+  fi
+  rm -f "${pid_file}" >/dev/null 2>&1 || true
+}
+
+maybe_kill_pid() {
+  local phase="$1"
+  local pid="$2"
+  if [ "${DRY_RUN}" = "1" ]; then
+    log "DRY_RUN=1: would kill ${phase} publisher pid=${pid}"
+    return 1
+  fi
+  if kill -0 "${pid}" >/dev/null 2>&1; then
+    log "killing ${phase} publisher pid=${pid}"
+    kill "${pid}" >/dev/null 2>&1 || true
+    return 0
+  fi
+  return 1
+}
+
+killed_any=0
+if [ -d "${RUNTIME_DIR}" ]; then
+  for phase in bootstrap server; do
+    pid_file="${RUNTIME_DIR}/mdns-${CLUSTER}-${ENVIRONMENT}-${phase}.pid"
+    if [ ! -f "${pid_file}" ]; then
+      continue
+    fi
+    pid="$(cat "${pid_file}" 2>/dev/null || true)"
+    if [ -z "${pid}" ]; then
+      log "removing empty ${phase} pidfile"
+      maybe_remove_pid_file "${phase}" "${pid_file}"
+      continue
+    fi
+    if kill -0 "${pid}" >/dev/null 2>&1; then
+      if maybe_kill_pid "${phase}" "${pid}"; then
+        killed_any=1
+      fi
+    else
+      log "removing stale ${phase} pidfile pid=${pid}"
+    fi
+    maybe_remove_pid_file "${phase}" "${pid_file}"
+  done
+else
+  log "runtime dir ${RUNTIME_DIR} missing; skipping pidfile cleanup"
+fi
+
+svc="_k3s-${CLUSTER}-${ENVIRONMENT}._tcp"
+if pgrep -af "avahi-publish-service.*${svc}" >/dev/null 2>&1; then
+  if [ "${DRY_RUN}" = "1" ]; then
+    log "DRY_RUN=1: would pkill stray avahi-publish-service for ${svc}"
+  else
+    log "pkill stray avahi-publish-service for ${svc}"
+    pkill -f "avahi-publish-service.*${svc}" >/dev/null 2>&1 || true
+    killed_any=1
+  fi
+fi
+
+if [ "${DRY_RUN}" != "1" ] && command -v avahi-browse >/dev/null 2>&1; then
+  if avahi-browse -pt "${svc}" 2>/dev/null | grep -q "${svc}"; then
+    log "WARNING: advert for ${svc} still visible (browser cache may lag)"
+  fi
+fi
+
+if [ "${killed_any}" = "1" ]; then
+  log "dynamic publishers terminated"
+fi

--- a/tests/scripts/test_cleanup_mdns_publishers.sh
+++ b/tests/scripts/test_cleanup_mdns_publishers.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="${ROOT_DIR}/scripts/cleanup_mdns_publishers.sh"
+
+if [ ! -x "${SCRIPT}" ]; then
+  echo "cleanup_mdns_publishers.sh missing or not executable" >&2
+  exit 1
+fi
+
+TMPDIR="$(mktemp -d)"
+runtime_dir="${TMPDIR}/run"
+mkdir -p "${runtime_dir}"
+
+boot_pid=""
+server_pid=""
+stray_pid=""
+cleanup() {
+  for pid in "${boot_pid}" "${server_pid}" "${stray_pid}"; do
+    if [ -n "${pid}" ] && kill -0 "${pid}" >/dev/null 2>&1; then
+      kill "${pid}" >/dev/null 2>&1 || true
+    fi
+  done
+  rm -rf "${TMPDIR}"
+}
+trap cleanup EXIT
+
+sleep 30 &
+boot_pid=$!
+sleep 30 &
+server_pid=$!
+bash -c "exec -a 'avahi-publish-service _k3s-berry-test._tcp stray' sleep 30" &
+stray_pid=$!
+
+printf '%s\n' "${boot_pid}" >"${runtime_dir}/mdns-berry-test-bootstrap.pid"
+printf '%s\n' "${server_pid}" >"${runtime_dir}/mdns-berry-test-server.pid"
+
+SUGARKUBE_CLUSTER="berry" \
+SUGARKUBE_ENV="test" \
+SUGARKUBE_RUNTIME_DIR="${runtime_dir}" \
+bash "${SCRIPT}" >"${TMPDIR}/cleanup.log" 2>&1
+
+sleep 0.2
+
+if kill -0 "${boot_pid}" >/dev/null 2>&1; then
+  echo "bootstrap publisher process still running" >&2
+  exit 1
+fi
+if kill -0 "${server_pid}" >/dev/null 2>&1; then
+  echo "server publisher process still running" >&2
+  exit 1
+fi
+if kill -0 "${stray_pid}" >/dev/null 2>&1; then
+  echo "stray publisher process still running" >&2
+  exit 1
+fi
+
+if [ -f "${runtime_dir}/mdns-berry-test-bootstrap.pid" ]; then
+  echo "bootstrap pidfile still present" >&2
+  exit 1
+fi
+if [ -f "${runtime_dir}/mdns-berry-test-server.pid" ]; then
+  echo "server pidfile still present" >&2
+  exit 1
+fi
+
+if ! grep -q "dynamic publishers terminated" "${TMPDIR}/cleanup.log"; then
+  echo "expected termination log not found" >&2
+  exit 1
+fi
+
+echo "cleanup_mdns_publishers script test passed"

--- a/tests/test_wipe_recipe_decl.py
+++ b/tests/test_wipe_recipe_decl.py
@@ -4,6 +4,10 @@ from pathlib import Path
 def test_wipe_recipe_invokes_wrapper_script():
     justfile = Path("justfile").read_text(encoding="utf-8")
     assert (
+        "@sudo --preserve-env=SUGARKUBE_CLUSTER,SUGARKUBE_ENV,DRY_RUN,ALLOW_NON_ROOT bash scripts/cleanup_mdns_publishers.sh"
+        in justfile
+    )
+    assert (
         "@sudo --preserve-env=SUGARKUBE_CLUSTER,SUGARKUBE_ENV,DRY_RUN,ALLOW_NON_ROOT bash scripts/wipe_node.sh"
         in justfile
     )


### PR DESCRIPTION
What:
- track bootstrap/server avahi-publish-service pids via /run/sugarkube
- add cleanup_mdns_publishers helper and call it from wipe workflows
- extend bootstrap tests and add cleanup test coverage

Why:
- keep phase=server adverts running until an explicit cleanup and avoid stale mdns

How to test:
- pytest tests/scripts/test_k3s_discover_bootstrap_publish.py tests/test_wipe_node_script.py tests/test_wipe_recipe_decl.py
- bash tests/scripts/test_cleanup_mdns_publishers.sh

------
https://chatgpt.com/codex/tasks/task_e_68f9d4997540832f8cd3c4562b7c79e7