### PR TITLE
Track mDNS publishers and clean them on wipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -39,6 +39,7 @@ kubeconfig env='dev':
     python3 scripts/update_kubeconfig_scope.py "${HOME}/.kube/config" "sugar-{{ env }}"
 
 wipe:
+    @sudo -E bash scripts/cleanup_mdns_publishers.sh
     @sudo --preserve-env=SUGARKUBE_CLUSTER,SUGARKUBE_ENV,DRY_RUN,ALLOW_NON_ROOT bash scripts/wipe_node.sh
 
 scripts_dir := justfile_directory() + "/scripts"

--- a/scripts/cleanup_mdns_publishers.sh
+++ b/scripts/cleanup_mdns_publishers.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER="${SUGARKUBE_CLUSTER:-sugar}"
+ENVIRONMENT="${SUGARKUBE_ENV:-dev}"
+RUNTIME_DIR="${SUGARKUBE_RUNTIME_DIR:-/run/sugarkube}"
+
+log() {
+  printf '[cleanup-mdns] %s\n' "$*"
+}
+
+killed_any=0
+for phase in bootstrap server; do
+  pidfile="${RUNTIME_DIR}/mdns-${CLUSTER}-${ENVIRONMENT}-${phase}.pid"
+  if [ -f "${pidfile}" ]; then
+    pid="$(cat "${pidfile}" 2>/dev/null || true)"
+    if [ -n "${pid:-}" ] && kill -0 "${pid}" 2>/dev/null; then
+      log "killing ${phase} publisher pid=${pid}"
+      kill "${pid}" 2>/dev/null || true
+      killed_any=1
+    fi
+    rm -f "${pidfile}" 2>/dev/null || true
+  fi
+done
+
+svc="_k3s-${CLUSTER}-${ENVIRONMENT}._tcp"
+if pgrep -af "avahi-publish-service.*${svc}" >/dev/null 2>&1; then
+  log "pkill stray avahi-publish-service for ${svc}"
+  pkill -f "avahi-publish-service.*${svc}" 2>/dev/null || true
+  killed_any=1
+fi
+
+if command -v avahi-browse >/dev/null 2>&1; then
+  if avahi-browse -pt "${svc}" 2>/dev/null | grep -q "${svc}"; then
+    log "WARNING: advert for ${svc} still visible (browser cache may lag)"
+  fi
+fi
+
+if [ "${killed_any}" = 1 ]; then
+  log "dynamic publishers terminated"
+fi

--- a/tests/scripts/test_cleanup_mdns_publishers.py
+++ b/tests/scripts/test_cleanup_mdns_publishers.py
@@ -1,0 +1,64 @@
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "cleanup_mdns_publishers.sh"
+
+
+def test_cleanup_mdns_publishers_terminates_processes(tmp_path):
+    runtime_dir = tmp_path / "run"
+    runtime_dir.mkdir()
+
+    cluster = "sugar"
+    environment = "dev"
+
+    bootstrap_proc = subprocess.Popen(["sleep", "60"])
+    server_proc = subprocess.Popen(["sleep", "60"])
+    stray_proc = subprocess.Popen(
+        ["bash", "-c", "exec -a 'avahi-publish-service _k3s-sugar-dev._tcp' sleep 60"]
+    )
+
+    bootstrap_pidfile = runtime_dir / f"mdns-{cluster}-{environment}-bootstrap.pid"
+    server_pidfile = runtime_dir / f"mdns-{cluster}-{environment}-server.pid"
+    bootstrap_pidfile.write_text(str(bootstrap_proc.pid), encoding="utf-8")
+    server_pidfile.write_text(str(server_proc.pid), encoding="utf-8")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "SUGARKUBE_CLUSTER": cluster,
+            "SUGARKUBE_ENV": environment,
+            "SUGARKUBE_RUNTIME_DIR": str(runtime_dir),
+        }
+    )
+
+    try:
+        result = subprocess.run(
+            ["bash", str(SCRIPT)],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+    finally:
+        for proc in (bootstrap_proc, server_proc, stray_proc):
+            if proc.poll() is None:
+                proc.terminate()
+        for proc in (bootstrap_proc, server_proc, stray_proc):
+            try:
+                proc.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=1)
+
+    assert result.returncode == 0, result.stderr
+    assert "killing bootstrap publisher" in result.stdout
+    assert "killing server publisher" in result.stdout
+    assert "pkill stray avahi-publish-service" in result.stdout
+    assert "dynamic publishers terminated" in result.stdout
+
+    assert not bootstrap_pidfile.exists()
+    assert not server_pidfile.exists()
+    assert bootstrap_proc.poll() is not None
+    assert server_proc.poll() is not None
+    assert stray_proc.poll() is not None

--- a/tests/scripts/test_k3s_discover_bootstrap_publish.py
+++ b/tests/scripts/test_k3s_discover_bootstrap_publish.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import time
 from pathlib import Path
 
 SCRIPT = str(Path(__file__).resolve().parents[2] / "scripts" / "k3s-discover.sh")
@@ -14,6 +15,8 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log_path = tmp_path / "publish.log"
+    runtime_dir = tmp_path / "run"
+    runtime_dir.mkdir()
 
     stub = bin_dir / "avahi-publish-service"
     stub.write_text(
@@ -51,15 +54,39 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
         "SUGARKUBE_TOKEN": "dummy",  # bypass token requirement
         "SUGARKUBE_MDNS_SELF_CHECK_ATTEMPTS": "1",
         "SUGARKUBE_MDNS_SELF_CHECK_DELAY": "0",
+        "SUGARKUBE_RUNTIME_DIR": str(runtime_dir),
     })
 
-    result = subprocess.run(
+    proc = subprocess.Popen(
         ["bash", SCRIPT, "--test-bootstrap-publish"],
         env=env,
         text=True,
-        capture_output=True,
-        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
+
+    pidfile = runtime_dir / "mdns-sugar-dev-bootstrap.pid"
+    observed_pid = False
+    for _ in range(50):
+        if pidfile.exists():
+            pid_text = pidfile.read_text(encoding="utf-8").strip()
+            if pid_text:
+                try:
+                    pid_value = int(pid_text)
+                    os.kill(pid_value, 0)
+                except (OSError, ValueError):
+                    pass
+                else:
+                    observed_pid = True
+                    break
+        if proc.poll() is not None:
+            break
+        time.sleep(0.1)
+
+    stdout, stderr = proc.communicate()
+    assert proc.returncode == 0, stderr
+    assert observed_pid, f"bootstrap pidfile {pidfile} was not observed while publishing"
+    assert not pidfile.exists()
 
     # Ensure the helper logged its launch and termination
     log_contents = log_path.read_text(encoding="utf-8")
@@ -80,8 +107,8 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
     assert not service_file.exists()
 
     # stderr should mention that avahi-publish-service is advertising the bootstrap role
-    assert "avahi-publish-service advertising bootstrap" in result.stderr
-    assert "phase=self-check host=" in result.stderr
+    assert "avahi-publish-service advertising bootstrap" in stderr
+    assert "phase=self-check host=" in stderr
 
 
 def test_bootstrap_publish_handles_trailing_dot_hostname(tmp_path):
@@ -89,6 +116,8 @@ def test_bootstrap_publish_handles_trailing_dot_hostname(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log_path = tmp_path / "publish.log"
+    runtime_dir = tmp_path / "run"
+    runtime_dir.mkdir()
 
     stub = bin_dir / "avahi-publish-service"
     stub.write_text(
@@ -127,6 +156,7 @@ def test_bootstrap_publish_handles_trailing_dot_hostname(tmp_path):
         "SUGARKUBE_TOKEN": "dummy",
         "SUGARKUBE_MDNS_SELF_CHECK_ATTEMPTS": "1",
         "SUGARKUBE_MDNS_SELF_CHECK_DELAY": "0",
+        "SUGARKUBE_RUNTIME_DIR": str(runtime_dir),
     })
 
     result = subprocess.run(
@@ -151,6 +181,8 @@ def test_publish_binds_host_and_self_check_delays(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log_path = tmp_path / "publish.log"
+    runtime_dir = tmp_path / "run"
+    runtime_dir.mkdir()
 
     stub = bin_dir / "avahi-publish-service"
     stub.write_text(
@@ -190,6 +222,7 @@ def test_publish_binds_host_and_self_check_delays(tmp_path):
         "SUGARKUBE_MDNS_SELF_CHECK_ATTEMPTS": "1",
         "SUGARKUBE_MDNS_SELF_CHECK_DELAY": "0",
         "SUGARKUBE_MDNS_HOST": "HostMixed.LOCAL.",
+        "SUGARKUBE_RUNTIME_DIR": str(runtime_dir),
     })
 
     result = subprocess.run(


### PR DESCRIPTION
🚀 : –
what: record bootstrap/server mdns publisher pids and add server
      publisher.
what: add cleanup helper, hook wipe, and cover the flow with tests.
why: keep server adverts alive until cleanup and avoid stale mdns entries.
how to test: pytest tests/scripts/test_k3s_discover_bootstrap_publish.py
             tests/scripts/test_cleanup_mdns_publishers.py
             tests/test_wipe_node_script.py
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68f9d4997540832f8cd3c4562b7c79e7