### PR TITLE
mdns: track dynamic publisher PIDs and clean them during wipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -63,6 +63,7 @@ kubeconfig env='dev':
     python3 scripts/update_kubeconfig_scope.py "${HOME}/.kube/config" "sugar-{{ env }}"
 
 wipe:
+    sudo -E bash scripts/cleanup_mdns_publishers.sh
     @sudo --preserve-env=SUGARKUBE_CLUSTER,SUGARKUBE_ENV,DRY_RUN,ALLOW_NON_ROOT bash scripts/wipe_node.sh
 
 scripts_dir := justfile_directory() + "/scripts"

--- a/scripts/cleanup_mdns_publishers.sh
+++ b/scripts/cleanup_mdns_publishers.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER="${SUGARKUBE_CLUSTER:-sugar}"
+ENV="${SUGARKUBE_ENV:-dev}"
+RUNTIME_DIR="${SUGARKUBE_RUNTIME_DIR:-/run/sugarkube}"
+
+log() { echo "[cleanup-mdns] $*"; }
+
+killed_any=0
+for phase in bootstrap server; do
+  pid_file="${RUNTIME_DIR}/mdns-${CLUSTER}-${ENV}-${phase}.pid"
+  if [ -f "${pid_file}" ]; then
+    pid="$(cat "${pid_file}" 2>/dev/null || true)"
+    if [ -n "${pid:-}" ] && kill -0 "${pid}" 2>/dev/null; then
+      log "killing ${phase} publisher pid=${pid}"
+      kill "${pid}" 2>/dev/null || true
+      killed_any=1
+    fi
+    rm -f "${pid_file}" || true
+  fi
+done
+
+svc="_k3s-${CLUSTER}-${ENV}._tcp"
+if pgrep -af "avahi-publish-service.*${svc}" >/dev/null 2>&1; then
+  log "pkill stray avahi-publish-service for ${svc}"
+  pkill -f "avahi-publish-service.*${svc}" 2>/dev/null || true
+  killed_any=1
+fi
+
+if command -v avahi-browse >/dev/null 2>&1; then
+  if avahi-browse -pt "${svc}" 2>/dev/null | grep -q "${svc}"; then
+    log "WARNING: advert for ${svc} still visible (browser cache may lag)"
+  fi
+fi
+
+if [ "${killed_any}" = 1 ]; then
+  log "dynamic publishers terminated"
+fi

--- a/tests/test_cleanup_mdns_publishers.py
+++ b/tests/test_cleanup_mdns_publishers.py
@@ -1,0 +1,65 @@
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "cleanup_mdns_publishers.sh"
+
+
+def test_cleanup_mdns_publishers_terminates_processes(tmp_path):
+    runtime_dir = tmp_path / "run"
+    runtime_dir.mkdir()
+
+    bootstrap_proc = subprocess.Popen(["sleep", "60"])
+    server_proc = subprocess.Popen(["sleep", "60"])
+
+    (runtime_dir / "mdns-sugar-dev-bootstrap.pid").write_text(
+        str(bootstrap_proc.pid),
+        encoding="utf-8",
+    )
+    (runtime_dir / "mdns-sugar-dev-server.pid").write_text(
+        str(server_proc.pid),
+        encoding="utf-8",
+    )
+
+    stray_stub = tmp_path / "avahi_stub.sh"
+    stray_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "svc=$1\n"
+        "exec -a \"avahi-publish-service ${svc}\" sleep 60\n",
+        encoding="utf-8",
+    )
+    stray_stub.chmod(0o755)
+    stray_proc = subprocess.Popen([str(stray_stub), "_k3s-sugar-dev._tcp"])
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "SUGARKUBE_CLUSTER": "sugar",
+            "SUGARKUBE_ENV": "dev",
+            "SUGARKUBE_RUNTIME_DIR": str(runtime_dir),
+            "PATH": env.get("PATH", ""),
+        }
+    )
+
+    try:
+        result = subprocess.run(
+            ["bash", str(SCRIPT)],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        for proc in (bootstrap_proc, server_proc, stray_proc):
+            proc.wait(timeout=5)
+    finally:
+        for proc in (bootstrap_proc, server_proc, stray_proc):
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+
+    assert result.returncode == 0, result.stderr
+    assert "dynamic publishers terminated" in result.stdout
+
+    assert not (runtime_dir / "mdns-sugar-dev-bootstrap.pid").exists()
+    assert not (runtime_dir / "mdns-sugar-dev-server.pid").exists()

--- a/tests/test_wipe_recipe_decl.py
+++ b/tests/test_wipe_recipe_decl.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 def test_wipe_recipe_invokes_wrapper_script():
     justfile = Path("justfile").read_text(encoding="utf-8")
+    assert "sudo -E bash scripts/cleanup_mdns_publishers.sh" in justfile
     assert (
         "@sudo --preserve-env=SUGARKUBE_CLUSTER,SUGARKUBE_ENV,DRY_RUN,ALLOW_NON_ROOT bash scripts/wipe_node.sh"
         in justfile


### PR DESCRIPTION
## Summary
- persist bootstrap and server avahi-publish-service PIDs for each cluster/env so the discover script can manage their lifecycle
- add a cleanup helper that terminates dynamic publishers and call it from the wipe script and just recipe
- extend the mdns-related tests to cover pidfile creation, cleanup, and wipe reporting

## Testing
- pytest tests/test_cleanup_mdns_publishers.py tests/scripts/test_k3s_discover_bootstrap_publish.py tests/test_wipe_node_script.py tests/test_wipe_recipe_decl.py
- pre-commit run --all-files *(fails: repository contains existing lint errors outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f9dca63b70832f8e03c0b3cfff8543