### PR TITLE
🚀 : Track mDNS publisher lifetimes and wipe dynamic adverts

### DIFF
--- a/justfile
+++ b/justfile
@@ -63,6 +63,7 @@ kubeconfig env='dev':
     python3 scripts/update_kubeconfig_scope.py "${HOME}/.kube/config" "sugar-{{ env }}"
 
 wipe:
+    @sudo --preserve-env=SUGARKUBE_CLUSTER,SUGARKUBE_ENV,DRY_RUN,ALLOW_NON_ROOT bash scripts/cleanup_mdns_publishers.sh
     @sudo --preserve-env=SUGARKUBE_CLUSTER,SUGARKUBE_ENV,DRY_RUN,ALLOW_NON_ROOT bash scripts/wipe_node.sh
 
 scripts_dir := justfile_directory() + "/scripts"

--- a/scripts/cleanup_mdns_publishers.sh
+++ b/scripts/cleanup_mdns_publishers.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER="${SUGARKUBE_CLUSTER:-sugar}"
+ENV="${SUGARKUBE_ENV:-dev}"
+DRY_RUN="${DRY_RUN:-0}"
+
+log() {
+  echo "[cleanup-mdns] $*"
+}
+
+if [ "${DRY_RUN}" = "1" ]; then
+  log "DRY_RUN=1: skipping dynamic publisher cleanup for ${CLUSTER}/${ENV}"
+  exit 0
+fi
+
+killed_any=0
+for phase in bootstrap server; do
+  pid_file="/run/sugarkube/mdns-${CLUSTER}-${ENV}-${phase}.pid"
+  if [ -f "${pid_file}" ]; then
+    pid="$(cat "${pid_file}" 2>/dev/null || true)"
+    if [ -n "${pid:-}" ] && kill -0 "${pid}" 2>/dev/null; then
+      log "killing ${phase} publisher pid=${pid}"
+      kill "${pid}" 2>/dev/null || true
+      killed_any=1
+    fi
+    rm -f "${pid_file}"
+  fi
+done
+
+svc="_k3s-${CLUSTER}-${ENV}._tcp"
+if pgrep -af "avahi-publish-service.*${svc}" >/dev/null 2>&1; then
+  log "pkill stray avahi-publish-service for ${svc}"
+  pkill -f "avahi-publish-service.*${svc}" 2>/dev/null || true
+  killed_any=1
+fi
+
+if command -v avahi-browse >/dev/null 2>&1; then
+  if avahi-browse -pt "${svc}" 2>/dev/null | grep -q "${svc}"; then
+    log "WARNING: advert for ${svc} still visible (browser cache may lag)"
+  fi
+fi
+
+if [ "${killed_any}" = 1 ]; then
+  log "dynamic publishers terminated"
+fi

--- a/tests/scripts/test_cleanup_mdns_publishers.sh
+++ b/tests/scripts/test_cleanup_mdns_publishers.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+PID_DIR="/run/sugarkube"
+mkdir -p "${PID_DIR}"
+
+CLUSTER="test$(date +%s%N)"
+ENV="spec"
+
+BOOT_PID=""
+SERVER_PID=""
+STRAY_PID=""
+DRY_BOOT_PID=""
+DRY_SERVER_PID=""
+
+BOOT_FILE=""
+SERVER_FILE=""
+DRY_BOOT_FILE=""
+DRY_SERVER_FILE=""
+
+cleanup() {
+  for pid in "${BOOT_PID}" "${SERVER_PID}" "${STRAY_PID}" "${DRY_BOOT_PID}" "${DRY_SERVER_PID}"; do
+    if [ -n "${pid}" ] && kill -0 "${pid}" 2>/dev/null; then
+      kill "${pid}" 2>/dev/null || true
+      wait "${pid}" >/dev/null 2>&1 || true
+    fi
+  done
+  rm -f "${BOOT_FILE}" "${SERVER_FILE}" "${DRY_BOOT_FILE}" "${DRY_SERVER_FILE}"
+}
+trap cleanup EXIT
+
+sleep 60 &
+BOOT_PID=$!
+sleep 60 &
+SERVER_PID=$!
+BOOT_FILE="${PID_DIR}/mdns-${CLUSTER}-${ENV}-bootstrap.pid"
+SERVER_FILE="${PID_DIR}/mdns-${CLUSTER}-${ENV}-server.pid"
+printf '%s\n' "${BOOT_PID}" >"${BOOT_FILE}"
+printf '%s\n' "${SERVER_PID}" >"${SERVER_FILE}"
+
+SUGARKUBE_CLUSTER="${CLUSTER}" \
+SUGARKUBE_ENV="${ENV}" \
+  bash "${REPO_ROOT}/scripts/cleanup_mdns_publishers.sh"
+
+for _ in $(seq 1 10); do
+  if ! kill -0 "${BOOT_PID}" 2>/dev/null && ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if kill -0 "${BOOT_PID}" 2>/dev/null; then
+  echo "bootstrap publisher still alive" >&2
+  exit 1
+fi
+if kill -0 "${SERVER_PID}" 2>/dev/null; then
+  echo "server publisher still alive" >&2
+  exit 1
+fi
+if [ -e "${BOOT_FILE}" ] || [ -e "${SERVER_FILE}" ]; then
+  echo "pid files were not removed" >&2
+  exit 1
+fi
+
+bash -c "exec -a 'avahi-publish-service _k3s-${CLUSTER}-${ENV}._tcp 6443' sleep 60" &
+STRAY_PID=$!
+sleep 0.2
+
+SUGARKUBE_CLUSTER="${CLUSTER}" \
+SUGARKUBE_ENV="${ENV}" \
+  bash "${REPO_ROOT}/scripts/cleanup_mdns_publishers.sh"
+
+for _ in $(seq 1 10); do
+  if ! kill -0 "${STRAY_PID}" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if kill -0 "${STRAY_PID}" 2>/dev/null; then
+  echo "stray publisher process still running" >&2
+  exit 1
+fi
+
+DRY_CLUSTER="${CLUSTER}-dry"
+sleep 60 &
+DRY_BOOT_PID=$!
+sleep 60 &
+DRY_SERVER_PID=$!
+DRY_BOOT_FILE="${PID_DIR}/mdns-${DRY_CLUSTER}-${ENV}-bootstrap.pid"
+DRY_SERVER_FILE="${PID_DIR}/mdns-${DRY_CLUSTER}-${ENV}-server.pid"
+printf '%s\n' "${DRY_BOOT_PID}" >"${DRY_BOOT_FILE}"
+printf '%s\n' "${DRY_SERVER_PID}" >"${DRY_SERVER_FILE}"
+
+DRY_RUN=1 \
+SUGARKUBE_CLUSTER="${DRY_CLUSTER}" \
+SUGARKUBE_ENV="${ENV}" \
+  bash "${REPO_ROOT}/scripts/cleanup_mdns_publishers.sh"
+
+if ! kill -0 "${DRY_BOOT_PID}" 2>/dev/null; then
+  echo "dry-run bootstrap publisher was killed" >&2
+  exit 1
+fi
+if ! kill -0 "${DRY_SERVER_PID}" 2>/dev/null; then
+  echo "dry-run server publisher was killed" >&2
+  exit 1
+fi
+if [ ! -f "${DRY_BOOT_FILE}" ] || [ ! -f "${DRY_SERVER_FILE}" ]; then
+  echo "dry-run pid files were removed" >&2
+  exit 1
+fi
+
+kill "${DRY_BOOT_PID}" 2>/dev/null || true
+kill "${DRY_SERVER_PID}" 2>/dev/null || true
+wait "${DRY_BOOT_PID}" >/dev/null 2>&1 || true
+wait "${DRY_SERVER_PID}" >/dev/null 2>&1 || true
+rm -f "${DRY_BOOT_FILE}" "${DRY_SERVER_FILE}"
+DRY_BOOT_PID=""
+DRY_SERVER_PID=""
+
+echo "cleanup_mdns_publishers.sh functional test passed"

--- a/tests/test_wipe_recipe_decl.py
+++ b/tests/test_wipe_recipe_decl.py
@@ -3,7 +3,12 @@ from pathlib import Path
 
 def test_wipe_recipe_invokes_wrapper_script():
     justfile = Path("justfile").read_text(encoding="utf-8")
-    assert (
-        "@sudo --preserve-env=SUGARKUBE_CLUSTER,SUGARKUBE_ENV,DRY_RUN,ALLOW_NON_ROOT bash scripts/wipe_node.sh"
-        in justfile
+    expected_cleanup = (
+        "@sudo --preserve-env=SUGARKUBE_CLUSTER,SUGARKUBE_ENV,DRY_RUN,ALLOW_NON_ROOT bash "
+        "scripts/cleanup_mdns_publishers.sh"
     )
+    expected_wipe = (
+        "@sudo --preserve-env=SUGARKUBE_CLUSTER,SUGARKUBE_ENV,DRY_RUN,ALLOW_NON_ROOT bash scripts/wipe_node.sh"
+    )
+    assert expected_cleanup in justfile
+    assert expected_wipe in justfile


### PR DESCRIPTION
what: Track bootstrap/server publisher PIDs and wire in cleanup helpers.
why: Keep phase=server adverts alive until cleanup and avoid stale mDNS.
how to test:
 - tests/scripts/test_cleanup_mdns_publishers.sh
 - pytest tests/scripts/test_k3s_discover_bootstrap_publish.py::
   test_bootstrap_publish_uses_avahi_publish -q
 - pytest tests/test_wipe_recipe_decl.py -q
 - pytest tests/test_wipe_node_script.py -q
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68f9dca63b70832f8e03c0b3cfff8543