### PR TITLE
mdns: track dynamic publisher PIDs and clean them on wipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -63,6 +63,7 @@ kubeconfig env='dev':
     python3 scripts/update_kubeconfig_scope.py "${HOME}/.kube/config" "sugar-{{ env }}"
 
 wipe:
+    @sudo --preserve-env=SUGARKUBE_CLUSTER,SUGARKUBE_ENV,DRY_RUN,ALLOW_NON_ROOT bash scripts/cleanup_mdns_publishers.sh
     @sudo --preserve-env=SUGARKUBE_CLUSTER,SUGARKUBE_ENV,DRY_RUN,ALLOW_NON_ROOT bash scripts/wipe_node.sh
 
 scripts_dir := justfile_directory() + "/scripts"

--- a/scripts/cleanup_mdns_publishers.sh
+++ b/scripts/cleanup_mdns_publishers.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DRY_RUN="${DRY_RUN:-0}"
+CLUSTER="${SUGARKUBE_CLUSTER:-sugar}"
+ENV="${SUGARKUBE_ENV:-dev}"
+
+log() { echo "[cleanup-mdns] $*"; }
+
+svc="_k3s-${CLUSTER}-${ENV}._tcp"
+
+if [ "${DRY_RUN}" = "1" ]; then
+  log "DRY_RUN=1: would clean dynamic publishers for ${svc}"
+  exit 0
+fi
+
+wait_for_pid_exit() {
+  local target="$1"
+  local attempts=0
+  while [ "${attempts}" -lt 50 ]; do
+    if ! kill -0 "${target}" 2>/dev/null; then
+      return 0
+    fi
+    attempts=$((attempts + 1))
+    sleep 0.1
+  done
+  return 1
+}
+
+wait_for_pattern_absence() {
+  local pattern="$1"
+  local attempts=0
+  while [ "${attempts}" -lt 50 ]; do
+    if ! pgrep -af "${pattern}" >/dev/null 2>&1; then
+      return 0
+    fi
+    attempts=$((attempts + 1))
+    sleep 0.1
+  done
+  return 1
+}
+
+killed_any=0
+for phase in bootstrap server; do
+  PF="/run/sugarkube/mdns-${CLUSTER}-${ENV}-${phase}.pid"
+  if [ -f "${PF}" ]; then
+    PID="$(cat "${PF}" 2>/dev/null || true)"
+    if [ -n "${PID:-}" ] && kill -0 "${PID}" 2>/dev/null; then
+      log "killing ${phase} publisher pid=${PID}"
+      kill "${PID}" 2>/dev/null || true
+      if ! wait_for_pid_exit "${PID}"; then
+        log "WARNING: pid ${PID} still running after termination request; sending SIGKILL"
+        kill -9 "${PID}" 2>/dev/null || true
+        if ! wait_for_pid_exit "${PID}"; then
+          log "WARNING: pid ${PID} persisted after SIGKILL"
+        fi
+      fi
+      killed_any=1
+    fi
+    rm -f "${PF}"
+  fi
+done
+
+if pgrep -af "avahi-publish-service.*${svc}" >/dev/null 2>&1; then
+  log "pkill stray avahi-publish-service for ${svc}"
+  pkill -f "avahi-publish-service.*${svc}" 2>/dev/null || true
+  if ! wait_for_pattern_absence "avahi-publish-service.*${svc}"; then
+    log "WARNING: avahi-publish-service processes for ${svc} still present; sending SIGKILL"
+    pkill -9 -f "avahi-publish-service.*${svc}" 2>/dev/null || true
+    if ! wait_for_pattern_absence "avahi-publish-service.*${svc}"; then
+      log "WARNING: avahi-publish-service processes for ${svc} persisted after SIGKILL"
+    fi
+  fi
+  killed_any=1
+fi
+
+if command -v avahi-browse >/dev/null 2>&1; then
+  if avahi-browse -pt "${svc}" 2>/dev/null | grep -q "${svc}"; then
+    log "WARNING: advert for ${svc} still visible (browser cache may lag)"
+  fi
+fi
+
+if [ "${killed_any}" = 1 ]; then
+  log "dynamic publishers terminated"
+fi

--- a/tests/scripts/test_cleanup_mdns_publishers.sh
+++ b/tests/scripts/test_cleanup_mdns_publishers.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+FALLBACK_DIR="$(mktemp -d)"
+trap 'cleanup' EXIT
+
+cleanup() {
+  local pid
+  for pid in ${BOOT_PID_VALUE:-} ${SERVER_PID_VALUE:-} ${FALLBACK_PID:-}; do
+    if [ -n "${pid}" ] && kill -0 "${pid}" 2>/dev/null; then
+      kill "${pid}" 2>/dev/null || true
+    fi
+  done
+  wait ${BOOT_PID_VALUE:-} 2>/dev/null || true
+  wait ${SERVER_PID_VALUE:-} 2>/dev/null || true
+  wait ${FALLBACK_PID:-} 2>/dev/null || true
+  rm -f "${BOOT_PID_FILE:-}" "${SERVER_PID_FILE:-}"
+  rm -rf "${TMP_DIR}" "${FALLBACK_DIR}"
+}
+
+CLUSTER="testcluster"
+ENVIRONMENT="testenv"
+SERVICE="_k3s-${CLUSTER}-${ENVIRONMENT}._tcp"
+PID_DIR="/run/sugarkube"
+BOOT_PID_FILE="${PID_DIR}/mdns-${CLUSTER}-${ENVIRONMENT}-bootstrap.pid"
+SERVER_PID_FILE="${PID_DIR}/mdns-${CLUSTER}-${ENVIRONMENT}-server.pid"
+
+mkdir -p "${PID_DIR}"
+
+sleep 120 &
+BOOT_PID_VALUE=$!
+printf '%s\n' "${BOOT_PID_VALUE}" >"${BOOT_PID_FILE}"
+
+sleep 120 &
+SERVER_PID_VALUE=$!
+printf '%s\n' "${SERVER_PID_VALUE}" >"${SERVER_PID_FILE}"
+
+cat <<'STUB' >"${FALLBACK_DIR}/avahi-publish-service"
+#!/usr/bin/env bash
+set -euo pipefail
+trap 'exit 0' TERM INT
+while true; do
+  sleep 1
+done
+STUB
+chmod +x "${FALLBACK_DIR}/avahi-publish-service"
+
+PATH="${FALLBACK_DIR}:${PATH}" "${FALLBACK_DIR}/avahi-publish-service" "--watch" "${SERVICE}" &
+FALLBACK_PID=$!
+
+sleep 1
+
+if [ ! -f "${BOOT_PID_FILE}" ] || [ ! -f "${SERVER_PID_FILE}" ]; then
+  echo "PID files were not created" >&2
+  exit 1
+fi
+
+if ! kill -0 "${BOOT_PID_VALUE}" 2>/dev/null; then
+  echo "Bootstrap test process exited early" >&2
+  exit 1
+fi
+
+if ! kill -0 "${SERVER_PID_VALUE}" 2>/dev/null; then
+  echo "Server test process exited early" >&2
+  exit 1
+fi
+
+OUTPUT=$(SUGARKUBE_CLUSTER="${CLUSTER}" SUGARKUBE_ENV="${ENVIRONMENT}" PATH="${PATH}" bash "${REPO_ROOT}/scripts/cleanup_mdns_publishers.sh")
+STATUS=$?
+
+echo "${OUTPUT}" | grep -q "dynamic publishers terminated"
+
+sleep 1
+
+if [ "${STATUS}" -ne 0 ]; then
+  echo "cleanup_mdns_publishers.sh failed" >&2
+  exit 1
+fi
+
+if [ -f "${BOOT_PID_FILE}" ] || [ -f "${SERVER_PID_FILE}" ]; then
+  echo "PID files were not removed" >&2
+  exit 1
+fi
+
+if kill -0 "${BOOT_PID_VALUE}" 2>/dev/null; then
+  echo "Bootstrap process still running" >&2
+  exit 1
+fi
+
+if kill -0 "${SERVER_PID_VALUE}" 2>/dev/null; then
+  echo "Server process still running" >&2
+  exit 1
+fi
+
+if kill -0 "${FALLBACK_PID}" 2>/dev/null; then
+  echo "Fallback avahi-publish-service still running" >&2
+  exit 1
+fi
+
+echo "cleanup_mdns_publishers.sh test passed"


### PR DESCRIPTION
## Summary
- persist server-phase avahi publishers by tracking PID files in `k3s-discover.sh`
- add `scripts/cleanup_mdns_publishers.sh` and wire it into `just wipe` / `scripts/wipe_node.sh`
- extend bootstrap publish tests and add a cleanup regression test for the helper

## Testing
- tests/scripts/test_cleanup_mdns_publishers.sh
- pytest tests/scripts/test_k3s_discover_bootstrap_publish.py

------
https://chatgpt.com/codex/tasks/task_e_68f9dca63b70832f8e03c0b3cfff8543