### PR TITLE
Use guard file to restore WLAN during bootstrap

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,19 +17,20 @@ up env='dev': prereqs
     export SUGARKUBE_ENV="{{ env }}"
     export SUGARKUBE_SERVERS="{{ SUGARKUBE_SERVERS }}"
 
-    WLAN_DISABLED=0
-    trap $'if [ "${SUGARKUBE_DISABLE_WLAN_DURING_BOOTSTRAP:-1}" = "1" ] && [ "$WLAN_DISABLED" = "1" ]; then\n  sudo -E bash scripts/toggle_wlan.sh --restore || true\n  WLAN_DISABLED=0\nfi' EXIT INT TERM
+    # Restore WLAN on exit iff we actually disabled it (guard file written by toggle_wlan.sh)
+    trap 'if [ "${SUGARKUBE_DISABLE_WLAN_DURING_BOOTSTRAP:-1}" = "1" ] && [ -f "${SUGARKUBE_RUNTIME_DIR:-/run/sugarkube}/wlan-disabled" ]; then sudo -E bash scripts/toggle_wlan.sh --restore || true; fi' EXIT INT TERM
 
     "{{ scripts_dir }}/check_memory_cgroup.sh"
 
     # Preflight network/mDNS configuration
     if [ "${SUGARKUBE_CONFIGURE_AVAHI:-1}" = "1" ]; then sudo -E bash scripts/configure_avahi.sh; fi
-    if [ "${SUGARKUBE_DISABLE_WLAN_DURING_BOOTSTRAP:-1}" = "1" ]; then WLAN_DISABLED=1; sudo -E bash scripts/toggle_wlan.sh --down; fi
+    if [ "${SUGARKUBE_DISABLE_WLAN_DURING_BOOTSTRAP:-1}" = "1" ]; then
+      sudo -E bash scripts/toggle_wlan.sh --down
+    fi
     if [ "${SUGARKUBE_SET_K3S_NODE_IP:-1}" = "1" ]; then sudo -E bash scripts/configure_k3s_node_ip.sh; fi
 
     # Proceed with discovery/join for subsequent nodes
     sudo -E bash scripts/k3s-discover.sh
-    if [ "$WLAN_DISABLED" = "1" ]; then sudo -E bash scripts/toggle_wlan.sh --restore || true; WLAN_DISABLED=0; fi
 
 prereqs:
     sudo apt-get update

--- a/scripts/toggle_wlan.sh
+++ b/scripts/toggle_wlan.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 
 LOG_DIR="${SUGARKUBE_LOG_DIR:-/var/log/sugarkube}"
 LOG_FILE="${LOG_DIR}/toggle_wlan.log"
-RUN_DIR="${SUGARKUBE_RUN_DIR:-/run/sugarkube}"
+RUNTIME_DIR="${SUGARKUBE_RUNTIME_DIR:-/run/sugarkube}"
 WLAN_IFACE="${SUGARKUBE_WLAN_INTERFACE:-wlan0}"
-GUARD_FILE="${RUN_DIR}/wlan-disabled"
+GUARD_FILE="${RUNTIME_DIR}/wlan-disabled"
 
 log() {
   local ts
@@ -23,7 +23,7 @@ bring_down() {
     log "Interface ${WLAN_IFACE} not present; skipping disable"
     return 0
   fi
-  mkdir -p "${RUN_DIR}"
+  mkdir -p "${RUNTIME_DIR}"
   if [ -f "${GUARD_FILE}" ]; then
     log "Guard ${GUARD_FILE} already present; ${WLAN_IFACE} assumed down"
   fi


### PR DESCRIPTION
🔧 : –

what:
- swap justfile WLAN trap to guard-file check and gate --down
- point toggle_wlan.sh guard to ${SUGARKUBE_RUNTIME_DIR}/wlan-disabled

why:
- avoid set -u failures and restore WLAN only when script disabled it

how to test:
- pre-commit run --all-files (fails: legacy lint errors)
- pyspelling -c .spellcheck.yaml
- linkchecker --no-warnings README.md docs/
Refs: none

------
https://chatgpt.com/codex/tasks/task_e_68f9e5568d2c832fa43bcf2462af1724