### PR TITLE
Guard WLAN toggle via runtime file during bootstrap

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,19 +17,27 @@ up env='dev': prereqs
     export SUGARKUBE_ENV="{{ env }}"
     export SUGARKUBE_SERVERS="{{ SUGARKUBE_SERVERS }}"
 
-    WLAN_DISABLED=0
-    trap $'if [ "${SUGARKUBE_DISABLE_WLAN_DURING_BOOTSTRAP:-1}" = "1" ] && [ "$WLAN_DISABLED" = "1" ]; then\n  sudo -E bash scripts/toggle_wlan.sh --restore || true\n  WLAN_DISABLED=0\nfi' EXIT INT TERM
+    GUARD_PATH="${SUGARKUBE_RUNTIME_DIR:-/run/sugarkube}/wlan-disabled"
+    # Restore WLAN on exit iff we actually disabled it (guard file written by toggle_wlan.sh)
+    trap "if [ '${SUGARKUBE_DISABLE_WLAN_DURING_BOOTSTRAP:-1}' = '1' ] &&
+          [ -f '${GUARD_PATH}' ]; then
+            sudo -E bash scripts/toggle_wlan.sh --restore || true
+          fi" EXIT INT TERM
 
     "{{ scripts_dir }}/check_memory_cgroup.sh"
 
     # Preflight network/mDNS configuration
     if [ "${SUGARKUBE_CONFIGURE_AVAHI:-1}" = "1" ]; then sudo -E bash scripts/configure_avahi.sh; fi
-    if [ "${SUGARKUBE_DISABLE_WLAN_DURING_BOOTSTRAP:-1}" = "1" ]; then WLAN_DISABLED=1; sudo -E bash scripts/toggle_wlan.sh --down; fi
+    if [ "${SUGARKUBE_DISABLE_WLAN_DURING_BOOTSTRAP:-1}" = "1" ]; then
+      sudo -E bash scripts/toggle_wlan.sh --down
+    fi
     if [ "${SUGARKUBE_SET_K3S_NODE_IP:-1}" = "1" ]; then sudo -E bash scripts/configure_k3s_node_ip.sh; fi
 
     # Proceed with discovery/join for subsequent nodes
     sudo -E bash scripts/k3s-discover.sh
-    if [ "$WLAN_DISABLED" = "1" ]; then sudo -E bash scripts/toggle_wlan.sh --restore || true; WLAN_DISABLED=0; fi
+    if [ -f "${GUARD_PATH}" ]; then
+      sudo -E bash scripts/toggle_wlan.sh --restore || true
+    fi
 
 prereqs:
     sudo apt-get update


### PR DESCRIPTION
## Summary
- swap WLAN trap to guard file in `just up`
- gate `toggle_wlan.sh --down` behind env
- update toggle script to use runtime dir guard

## Testing
- pre-commit run --all-files (missing: command not found)
- pyspelling -c .spellcheck.yaml (missing: command not found)
- linkchecker --no-warnings README.md docs/ (missing: command not found)
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68f9e5568d2c832fa43bcf2462af1724