### PR TITLE
mdns: bind adverts to wired IPv4 and consistent .local host; use expect-addr during self-check

### DIFF
--- a/scripts/mdns_helpers.py
+++ b/scripts/mdns_helpers.py
@@ -104,6 +104,7 @@ def ensure_self_ad_is_visible(
     retries: int = 5,
     delay: float = 1.0,
     require_phase: Optional[str] = None,
+    expect_addr: Optional[str] = None,
     runner: Optional[Runner] = None,
     sleep: SleepFn = time.sleep,
 ) -> Optional[str]:
@@ -116,6 +117,8 @@ def ensure_self_ad_is_visible(
     attempts = max(retries, 1)
     delay = max(delay, 0.0)
 
+    expected_addr_norm = expect_addr.strip() if expect_addr else None
+
     if runner is None:
         runner = subprocess.run  # type: ignore[assignment]
 
@@ -125,10 +128,21 @@ def ensure_self_ad_is_visible(
             txt = record.txt
             if require_phase is not None and txt.get("phase") != require_phase:
                 continue
-            if _same_host(record.host, expected_norm) or _same_host(
-                txt.get("leader", ""), expected_norm
-            ):
-                return record.host
+            host_match = _same_host(record.host, expected_norm)
+            leader_match = _same_host(txt.get("leader", ""), expected_norm)
+            if not (host_match or leader_match):
+                continue
+            if expected_addr_norm:
+                txt_addr = txt.get("a") or txt.get("addr")
+                record_addr = record.address.strip()
+                address_match = False
+                if record_addr:
+                    address_match = record_addr == expected_addr_norm
+                if not address_match and txt_addr:
+                    address_match = txt_addr.strip() == expected_addr_norm
+                if not address_match:
+                    continue
+            return record.host
         if attempt < attempts and delay > 0:
             sleep(delay)
     return None
@@ -142,6 +156,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--require-phase", choices=["bootstrap", "server"], default=None)
     parser.add_argument("--retries", type=int, default=5)
     parser.add_argument("--delay", type=float, default=1.0)
+    parser.add_argument("--expect-addr", default=None)
     return parser
 
 
@@ -156,6 +171,7 @@ def _main() -> int:
         retries=args.retries,
         delay=args.delay,
         require_phase=args.require_phase,
+        expect_addr=args.expect_addr,
     )
     if observed:
         print(observed)


### PR DESCRIPTION
🚀 : –
What: Bind Avahi adverts to a consistent .local host and IPv4.
What: Require optional address match in mdns_helpers and cover with tests.
Why: Avoid intermittent bootstrap self-check failures from dynamic addresses.
How: pytest tests/scripts/test_mdns_helpers.py
How: pyspelling -c .spellcheck.yaml
How: linkchecker --no-warnings README.md docs/
Refs: n/a


------
https://chatgpt.com/codex/tasks/task_e_68f9ec44ad2c832fbedddf58d6423b3d