### PR TITLE
Bind mDNS adverts to wired IPv4 and enforce self-check address matching

### DIFF
--- a/scripts/k3s-discover.sh
+++ b/scripts/k3s-discover.sh
@@ -33,6 +33,7 @@ fi
 
 CLUSTER="${SUGARKUBE_CLUSTER:-sugar}"
 ENVIRONMENT="${SUGARKUBE_ENV:-dev}"
+MDNS_INTERFACE="${SUGARKUBE_MDNS_INTERFACE:-eth0}"
 SERVERS_DESIRED="${SUGARKUBE_SERVERS:-1}"
 NODE_TOKEN_PATH="${SUGARKUBE_NODE_TOKEN_PATH:-/var/lib/rancher/k3s/server/node-token}"
 BOOT_TOKEN_PATH="${SUGARKUBE_BOOT_TOKEN_PATH:-/boot/sugarkube-node-token}"
@@ -202,12 +203,29 @@ if [ "${CHECK_TOKEN_ONLY}" -eq 1 ]; then
   exit 0
 fi
 
-HN="$(hostname -s)"
-MDNS_HOST_RAW="${SUGARKUBE_MDNS_HOST:-${HN}.local}"
+HN="$(hostname -s 2>/dev/null || hostname)"
+if [ -n "${SUGARKUBE_MDNS_HOST:-}" ]; then
+  MDNS_HOST_RAW="${SUGARKUBE_MDNS_HOST}"
+else
+  case "${HN}" in
+    *.local) MDNS_HOST_RAW="${HN}" ;;
+    *) MDNS_HOST_RAW="${HN}.local" ;;
+  esac
+fi
 while [[ "${MDNS_HOST_RAW}" == *"." ]]; do
   MDNS_HOST_RAW="${MDNS_HOST_RAW%.}"
 done
 MDNS_HOST="${MDNS_HOST_RAW,,}"
+MDNS_ADDR_V4="${SUGARKUBE_MDNS_PUBLISH_ADDR:-$(
+  ip -4 -o addr show "${MDNS_INTERFACE}" 2>/dev/null |
+    awk '{print \$4}' |
+    cut -d/ -f1 |
+    head -n1 || true
+)}"
+if [ -z "${MDNS_ADDR_V4}" ]; then
+  printf '[sugarkube %s/%s] WARN: no IPv4 found on %s; publishing without -a\n' \
+    "${CLUSTER}" "${ENVIRONMENT}" "${MDNS_INTERFACE}"
+fi
 MDNS_SERVICE_NAME="k3s-${CLUSTER}-${ENVIRONMENT}"
 MDNS_SERVICE_TYPE="_${MDNS_SERVICE_NAME}._tcp"
 AVAHI_SERVICE_DIR="${SUGARKUBE_AVAHI_SERVICE_DIR:-/etc/avahi/services}"
@@ -365,19 +383,27 @@ start_bootstrap_publisher() {
   BOOTSTRAP_PUBLISH_LOG="/tmp/sugar-publish-bootstrap.log"
   : >"${BOOTSTRAP_PUBLISH_LOG}" 2>/dev/null || true
 
-  avahi-publish-service \
-    -H "${MDNS_HOST_RAW}" \
-    "${publish_name}" \
-    "${MDNS_SERVICE_TYPE}" \
-    6443 \
-    "k3s=1" \
-    "cluster=${CLUSTER}" \
-    "env=${ENVIRONMENT}" \
-    "role=bootstrap" \
-    "leader=${MDNS_HOST_RAW}" \
-    "phase=bootstrap" \
-    "state=pending" \
-    >"${BOOTSTRAP_PUBLISH_LOG}" 2>&1 &
+  log "publishing bootstrap host=${MDNS_HOST_RAW} addr=${MDNS_ADDR_V4:-auto} type=${MDNS_SERVICE_TYPE}"
+  local -a publish_cmd=(
+    avahi-publish-service
+    -H "${MDNS_HOST_RAW}"
+  )
+  if [ -n "${MDNS_ADDR_V4}" ]; then
+    publish_cmd+=(-a "${MDNS_ADDR_V4}")
+  fi
+  publish_cmd+=(
+    "${publish_name}"
+    "${MDNS_SERVICE_TYPE}"
+    6443
+    "k3s=1"
+    "cluster=${CLUSTER}"
+    "env=${ENVIRONMENT}"
+    "role=bootstrap"
+    "leader=${MDNS_HOST_RAW}"
+    "phase=bootstrap"
+    "state=pending"
+  )
+  "${publish_cmd[@]}" >"${BOOTSTRAP_PUBLISH_LOG}" 2>&1 &
   BOOTSTRAP_PUBLISH_PID=$!
 
   sleep 1
@@ -392,7 +418,8 @@ start_bootstrap_publisher() {
     return 1
   fi
 
-  log "avahi-publish-service advertising bootstrap as ${MDNS_HOST_RAW} on ${MDNS_SERVICE_TYPE} (pid ${BOOTSTRAP_PUBLISH_PID})"
+  log "avahi-publish-service advertising bootstrap as ${MDNS_HOST_RAW} addr=${MDNS_ADDR_V4:-auto}"
+  log "  type=${MDNS_SERVICE_TYPE} pid=${BOOTSTRAP_PUBLISH_PID}"
   printf '%s\n' "${BOOTSTRAP_PUBLISH_PID}" | write_privileged_file "${BOOTSTRAP_PID_FILE}"
   return 0
 }
@@ -412,18 +439,26 @@ start_server_publisher() {
   SERVER_PUBLISH_LOG="/tmp/sugar-publish-server.log"
   : >"${SERVER_PUBLISH_LOG}" 2>/dev/null || true
 
-  avahi-publish-service \
-    -H "${MDNS_HOST_RAW}" \
-    "${publish_name}" \
-    "${MDNS_SERVICE_TYPE}" \
-    6443 \
-    "k3s=1" \
-    "cluster=${CLUSTER}" \
-    "env=${ENVIRONMENT}" \
-    "role=server" \
-    "leader=${MDNS_HOST_RAW}" \
-    "phase=server" \
-    >"${SERVER_PUBLISH_LOG}" 2>&1 &
+  log "publishing server host=${MDNS_HOST_RAW} addr=${MDNS_ADDR_V4:-auto} type=${MDNS_SERVICE_TYPE}"
+  local -a publish_cmd=(
+    avahi-publish-service
+    -H "${MDNS_HOST_RAW}"
+  )
+  if [ -n "${MDNS_ADDR_V4}" ]; then
+    publish_cmd+=(-a "${MDNS_ADDR_V4}")
+  fi
+  publish_cmd+=(
+    "${publish_name}"
+    "${MDNS_SERVICE_TYPE}"
+    6443
+    "k3s=1"
+    "cluster=${CLUSTER}"
+    "env=${ENVIRONMENT}"
+    "role=server"
+    "leader=${MDNS_HOST_RAW}"
+    "phase=server"
+  )
+  "${publish_cmd[@]}" >"${SERVER_PUBLISH_LOG}" 2>&1 &
   SERVER_PUBLISH_PID=$!
 
   sleep 1
@@ -438,7 +473,8 @@ start_server_publisher() {
     return 1
   fi
 
-  log "avahi-publish-service advertising server as ${MDNS_HOST_RAW} on ${MDNS_SERVICE_TYPE} (pid ${SERVER_PUBLISH_PID})"
+  log "avahi-publish-service advertising server as ${MDNS_HOST_RAW} addr=${MDNS_ADDR_V4:-auto}"
+  log "  type=${MDNS_SERVICE_TYPE} pid=${SERVER_PUBLISH_PID}"
   printf '%s\n' "${SERVER_PUBLISH_PID}" | write_privileged_file "${SERVER_PID_FILE}"
   return 0
 }
@@ -573,15 +609,20 @@ ensure_self_mdns_advertisement() {
 
   MDNS_LAST_OBSERVED=""
   local observed=""
-  if observed="$(
-    python3 "${SCRIPT_DIR}/mdns_helpers.py" \
-      --expect-host "${MDNS_HOST_RAW}" \
-      --cluster "${CLUSTER}" \
-      --env "${ENVIRONMENT}" \
-      --require-phase "${require_phase}" \
-      --retries "${retries}" \
-      --delay "${delay}"
-  )"; then
+  local -a helper_cmd=(
+    python3 "${SCRIPT_DIR}/mdns_helpers.py"
+    --expect-host "${MDNS_HOST_RAW}"
+    --cluster "${CLUSTER}"
+    --env "${ENVIRONMENT}"
+    --require-phase "${require_phase}"
+    --retries "${retries}"
+    --delay "${delay}"
+  )
+  if [ -n "${MDNS_ADDR_V4}" ]; then
+    helper_cmd+=(--expect-addr "${MDNS_ADDR_V4}")
+  fi
+
+  if observed="$("${helper_cmd[@]}")"; then
     MDNS_LAST_OBSERVED="${observed}"
     return 0
   fi

--- a/scripts/mdns_helpers.py
+++ b/scripts/mdns_helpers.py
@@ -104,6 +104,7 @@ def ensure_self_ad_is_visible(
     retries: int = 5,
     delay: float = 1.0,
     require_phase: Optional[str] = None,
+    expect_addr: Optional[str] = None,
     runner: Optional[Runner] = None,
     sleep: SleepFn = time.sleep,
 ) -> Optional[str]:
@@ -119,16 +120,29 @@ def ensure_self_ad_is_visible(
     if runner is None:
         runner = subprocess.run  # type: ignore[assignment]
 
+    expected_addr = expect_addr.strip() if expect_addr else None
+
     for attempt in range(1, attempts + 1):
         records = _collect_mdns_records(cluster, env, runner)
         for record in records:
             txt = record.txt
             if require_phase is not None and txt.get("phase") != require_phase:
                 continue
-            if _same_host(record.host, expected_norm) or _same_host(
-                txt.get("leader", ""), expected_norm
-            ):
-                return record.host
+            host_match = _same_host(record.host, expected_norm)
+            leader_match = _same_host(txt.get("leader", ""), expected_norm)
+            if not (host_match or leader_match):
+                continue
+
+            if expected_addr:
+                candidate_addr = record.address.strip()
+                if not candidate_addr:
+                    candidate_addr = (txt.get("a") or "").strip()
+                if not candidate_addr:
+                    candidate_addr = (txt.get("addr") or "").strip()
+                if candidate_addr != expected_addr:
+                    continue
+
+            return record.host
         if attempt < attempts and delay > 0:
             sleep(delay)
     return None
@@ -142,6 +156,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--require-phase", choices=["bootstrap", "server"], default=None)
     parser.add_argument("--retries", type=int, default=5)
     parser.add_argument("--delay", type=float, default=1.0)
+    parser.add_argument("--expect-addr", default=None)
     return parser
 
 
@@ -156,6 +171,7 @@ def _main() -> int:
         retries=args.retries,
         delay=args.delay,
         require_phase=args.require_phase,
+        expect_addr=args.expect_addr,
     )
     if observed:
         print(observed)

--- a/tests/scripts/test_mdns_helpers.py
+++ b/tests/scripts/test_mdns_helpers.py
@@ -71,3 +71,41 @@ def test_ensure_self_ad_is_visible_filters_by_phase():
         sleep=lambda _: None,
     )
     assert missing_server is None
+
+
+def test_ensure_self_ad_is_visible_requires_expected_addr_match():
+    record = (
+        "=;eth0;IPv4;k3s-sugar-dev@host0 (bootstrap);_k3s-sugar-dev._tcp;local;host0.local;192.0.2.10;6443;"
+        "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=bootstrap;txt=leader=host0.local;txt=phase=bootstrap\n"
+    )
+
+    runner = _make_runner({
+        "_k3s-sugar-dev._tcp": record,
+        "_https._tcp": "",
+    })
+
+    observed = ensure_self_ad_is_visible(
+        expected_host="host0.local",
+        cluster="sugar",
+        env="dev",
+        retries=1,
+        delay=0,
+        require_phase="bootstrap",
+        expect_addr="192.0.2.10",
+        runner=runner,
+        sleep=lambda _: None,
+    )
+    assert observed == "host0.local"
+
+    mismatch = ensure_self_ad_is_visible(
+        expected_host="host0.local",
+        cluster="sugar",
+        env="dev",
+        retries=1,
+        delay=0,
+        require_phase="bootstrap",
+        expect_addr="192.0.2.11",
+        runner=runner,
+        sleep=lambda _: None,
+    )
+    assert mismatch is None


### PR DESCRIPTION
## Summary
- derive a stable `.local` host and detect the wired IPv4 before starting Avahi publishers
- advertise bootstrap/server services with explicit host/address logging and expect-addr self checks
- extend the mDNS helper to gate on the expected address and cover it with tests

## Testing
- pytest tests/scripts/test_mdns_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68f9ec44ad2c832fbedddf58d6423b3d