### PR TITLE
Add timeout guard to k3s mDNS discovery

### DIFF
--- a/outages/2025-10-23-k3s-discover-avahi-timeout.json
+++ b/outages/2025-10-23-k3s-discover-avahi-timeout.json
@@ -1,0 +1,12 @@
+{
+  "id": "2025-10-23-k3s-discover-avahi-timeout",
+  "date": "2025-10-23",
+  "component": "scripts/k3s_mdns_query.py",
+  "rootCause": "avahi-browse occasionally stalled indefinitely during k3s discovery, leaving just up dev hung while waiting for bootstrap adverts that never arrived.",
+  "resolution": "Wrap avahi-browse in a bounded timeout, surface the stall in debug logs, and fall back to the usual bootstrap flow so discovery recovers automatically.",
+  "references": [
+    "Console: pi@sugarkube0 just up dev (2025-10-23)",
+    "scripts/k3s_mdns_query.py",
+    "tests/scripts/test_k3s_mdns_query.py"
+  ]
+}


### PR DESCRIPTION
✅ : –
what: add env-configurable timeout around avahi-browse and log outage
why: prevent k3s-discover from hanging when avahi stalls
how to test: pytest tests/scripts/test_k3s_mdns_query.py
Refs: N/A

------
https://chatgpt.com/codex/tasks/task_e_68f9f0a928f8832fa95afec081ce1506