### PR TITLE
✨ : – add -s flag for avahi service publishing

### DIFF
--- a/outages/2025-10-24-k3s-discover-avahi-service-flag.json
+++ b/outages/2025-10-24-k3s-discover-avahi-service-flag.json
@@ -1,0 +1,12 @@
+{
+  "id": "2025-10-24-k3s-discover-avahi-service-flag",
+  "date": "2025-10-24",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "k3s-discover invoked avahi-publish-service without the -s flag, so Avahi rejected the call with 'Bad number of arguments' and the bootstrap advertisement never started.",
+  "resolution": "Include -s when launching avahi-publish-service for both bootstrap and server roles and extend the bootstrap publish tests to assert the flag is present.",
+  "references": [
+    "Console: pi@sugarkube0 just up dev (2025-10-24)",
+    "scripts/k3s-discover.sh",
+    "tests/scripts/test_k3s_discover_bootstrap_publish.py"
+  ]
+}

--- a/scripts/k3s-discover.sh
+++ b/scripts/k3s-discover.sh
@@ -395,6 +395,7 @@ start_bootstrap_publisher() {
 
   local -a publish_cmd=(
     avahi-publish-service
+    -s
     -H "${MDNS_HOST_RAW}"
   )
   if [ -n "${MDNS_ADDR_V4}" ]; then
@@ -452,6 +453,7 @@ start_server_publisher() {
 
   local -a publish_cmd=(
     avahi-publish-service
+    -s
     -H "${MDNS_HOST_RAW}"
   )
   if [ -n "${MDNS_ADDR_V4}" ]; then

--- a/tests/scripts/test_k3s_discover_bootstrap_publish.py
+++ b/tests/scripts/test_k3s_discover_bootstrap_publish.py
@@ -80,6 +80,7 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
     log_contents = log_path.read_text(encoding="utf-8")
     assert "START:" in log_contents
     assert "TERM" in log_contents
+    assert "-s -H" in log_contents
     assert "PIDFILE_OK:bootstrap" in log_contents
 
     assert "-H" in log_contents
@@ -174,6 +175,7 @@ def test_bootstrap_publish_handles_trailing_dot_hostname(tmp_path):
     log_contents = log_path.read_text(encoding="utf-8")
     assert "START:" in log_contents
     assert "TERM" in log_contents
+    assert "-s -H" in log_contents
     assert f"leader={hostname}.local" in log_contents
     assert "PIDFILE_OK:bootstrap" in log_contents
 
@@ -256,6 +258,7 @@ def test_publish_binds_host_and_self_check_delays(tmp_path):
     log_contents = log_path.read_text(encoding="utf-8")
     assert "START:" in log_contents
     assert "TERM" in log_contents
+    assert "-s -H" in log_contents
     assert "-H HostMixed.LOCAL" in log_contents
     assert "leader=HostMixed.LOCAL" in log_contents
     assert "PIDFILE_OK:bootstrap" in log_contents
@@ -370,6 +373,7 @@ def test_bootstrap_publish_waits_for_server_advert_before_retiring_bootstrap(tmp
 
     log_contents = log_path.read_text(encoding="utf-8")
     assert log_contents.count("START:") >= 2
+    assert "-s -H" in log_contents
     assert "phase=bootstrap" in log_contents
     assert "phase=server" in log_contents
     assert "PIDFILE_OK:bootstrap" in log_contents


### PR DESCRIPTION
what: add the -s service flag when launching avahi-publish-service and assert it in bootstrap publish tests
why: avahi reported "Bad number of arguments" without -s, so the bootstrap advertisement never started
how to test: pytest tests/scripts/test_k3s_discover_bootstrap_publish.py
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68fb02445770832faaaac7c94bd39103