### PR TITLE
🧪 : – mark carrier deliverables as shipped

### DIFF
--- a/docs/pi_cluster_stack.md
+++ b/docs/pi_cluster_stack.md
@@ -377,7 +377,10 @@ module pi_carrier_stack(levels = 3, zgap = 32, fan_size = 120) {
 
 ---
 
-## 12. Deliverables checklist (for future implementation)
+## 12. Deliverables checklist
+
+All deliverables below now ship with the repository; treat the list as a quick
+regression checklist when refreshing the stacked carrier design.
 
 - [x] Add `fan_patterns.scad`, `fan_wall.scad`, `pi_carrier_column.scad`, `pi_carrier_stack.scad`
       under `cad/pi_cluster/`.

--- a/tests/test_pi_cluster_stack_doc.py
+++ b/tests/test_pi_cluster_stack_doc.py
@@ -22,3 +22,16 @@ def test_stack_doc_links_carrier_reference() -> None:
 
     text = DOC_PATH.read_text(encoding="utf-8")
     assert "pi_cluster_carrier.md" in text, "Stack doc should cross-link the carrier field guide"
+
+
+def test_stack_doc_deliverables_marked_shipped() -> None:
+    """Deliverables section should no longer be labeled as future work."""
+
+    text = DOC_PATH.read_text(encoding="utf-8")
+    lowered = text.lower()
+    assert (
+        "## 12. deliverables checklist (for future implementation)" not in lowered
+    ), "Stack doc still frames deliverables as future implementation"
+    assert (
+        "## 12. Deliverables checklist" in text
+    ), "Stack doc should keep the deliverables checklist header"


### PR DESCRIPTION
## Summary
- inventory future-work markers via `rg -n "future implementation" docs/pi_cluster_stack.md`
- mark the stacked carrier deliverables checklist as shipped in the doc
- add a regression test that prevents the heading from regressing to a future-work label

## Testing
- ⚠️ `pre-commit run --all-files` (fails: check-yaml and run-checks flag existing multi-document YAML and unrelated lint errors)
- ⚠️ `pyspelling -c .spellcheck.yaml` (fails: `aspell` binary unavailable in container)
- ✅ `linkchecker --no-warnings README.md docs/`
- ✅ `pytest tests/test_pi_cluster_stack_doc.py`
- ✅ `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68f9ec35ccf8832fac399a8b4cebd40b