### PR TITLE
Expose NVMe helper flags in the CLI

### DIFF
--- a/docs/nvme-health-check.md
+++ b/docs/nvme-health-check.md
@@ -64,6 +64,10 @@ sudo NVME_JSON_PATH=/var/log/sugarkube/nvme-smart.json ./scripts/nvme_health_che
 sudo sugarkube nvme health --json-path /var/log/sugarkube/nvme-smart.json
 ```
 
+> **Tip:** `python -m sugarkube_toolkit nvme health --help` now lists the same
+> device, threshold, logger, and JSON export flags as the underlying helper so
+> you can discover supported options without leaving the CLI.
+
 Regression coverage: `tests/test_sugarkube_toolkit_cli.py::test_nvme_health_invokes_helper`,
 `tests/test_nvme_health_workflow.py`, and
 `tests/nvme_health_check_test.py::test_nvme_health_writes_json_snapshot` keep the CLI, Make,

--- a/sugarkube_toolkit/cli.py
+++ b/sugarkube_toolkit/cli.py
@@ -189,6 +189,37 @@ def build_parser() -> argparse.ArgumentParser:
         help="Collect NVMe SMART metrics via scripts/nvme_health_check.sh.",
     )
     nvme_health_parser.add_argument(
+        "--device",
+        help="NVMe namespace to inspect (for example, /dev/nvme0n1).",
+    )
+    nvme_health_parser.add_argument(
+        "--pct-thresh",
+        type=int,
+        help="Percentage used threshold that triggers an alert.",
+    )
+    nvme_health_parser.add_argument(
+        "--tbw-limit",
+        help="Terabytes written threshold (accepts integer or float values).",
+    )
+    nvme_health_parser.add_argument(
+        "--media-errors",
+        type=int,
+        help="Maximum media error count before the helper exits non-zero.",
+    )
+    nvme_health_parser.add_argument(
+        "--unsafe-shutdowns",
+        type=int,
+        help="Maximum unsafe shutdown count before flagging an alert.",
+    )
+    nvme_health_parser.add_argument(
+        "--logger-tag",
+        help="Custom syslog tag when forwarding output via logger.",
+    )
+    nvme_health_parser.add_argument(
+        "--json-path",
+        help="Write nvme smart-log --output-format=json payload to this path.",
+    )
+    nvme_health_parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print the helper invocation without executing it.",
@@ -498,6 +529,22 @@ def _handle_pi_support_bundle(args: argparse.Namespace) -> int:
 
 
 def _handle_nvme_health(args: argparse.Namespace) -> int:
+    prefix: list[str] = []
+    if getattr(args, "device", None):
+        prefix.extend(["--device", args.device])
+    if getattr(args, "pct_thresh", None) is not None:
+        prefix.extend(["--pct-thresh", str(args.pct_thresh)])
+    if getattr(args, "tbw_limit", None):
+        prefix.extend(["--tbw-limit", str(args.tbw_limit)])
+    if getattr(args, "media_errors", None) is not None:
+        prefix.extend(["--media-errors", str(args.media_errors)])
+    if getattr(args, "unsafe_shutdowns", None) is not None:
+        prefix.extend(["--unsafe-shutdowns", str(args.unsafe_shutdowns)])
+    if getattr(args, "logger_tag", None):
+        prefix.extend(["--logger-tag", args.logger_tag])
+    if getattr(args, "json_path", None):
+        prefix.extend(["--json-path", args.json_path])
+
     return _forward_to_helper(
         script=NVME_HEALTH_CHECK_SCRIPT,
         args=args,
@@ -506,6 +553,7 @@ def _handle_nvme_health(args: argparse.Namespace) -> int:
             "scripts/nvme_health_check.sh is missing. "
             "Run from the repository root or reinstall the tooling."
         ),
+        prefix=prefix,
         auto_dry_run=False,
         always_execute=False,
     )

--- a/tests/test_sugarkube_toolkit_cli.py
+++ b/tests/test_sugarkube_toolkit_cli.py
@@ -271,6 +271,17 @@ def test_nvme_health_reports_missing_script(
     assert "scripts/nvme_health_check.sh is missing" in captured.err
 
 
+def test_nvme_health_help_lists_script_flags(capsys: pytest.CaptureFixture[str]) -> None:
+    """The NVMe help output should surface the forwarded helper flags."""
+
+    with pytest.raises(SystemExit):
+        cli.main(["nvme", "health", "--help"])
+
+    captured = capsys.readouterr()
+    assert "--json-path" in captured.out
+    assert "--device" in captured.out
+
+
 def test_docs_start_here_prints_path_only(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- add explicit NVMe health options to the sugarkube CLI so the helper flags appear in `--help`
- forward the parsed options to `nvme_health_check.sh` and document the CLI tip in the NVMe guide
- add regression coverage ensuring the NVMe help output advertises the forwarded flags

## Testing
- python -m pre_commit run --all-files *(fails: repository-level lint issues unrelated to this change; see log)*
- python -m pyspelling -c .spellcheck.yaml
- /root/.pyenv/versions/3.12.10/bin/linkchecker --no-warnings README.md docs/
- pytest tests/test_sugarkube_toolkit_cli.py::test_nvme_health_help_lists_script_flags
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68f9ec35ccf8832fac399a8b4cebd40b