### PR TITLE
🛠️ : – allow mdns self-check to tolerate address mismatch

### DIFF
--- a/outages/2025-10-24-k3s-discover-address-mismatch.json
+++ b/outages/2025-10-24-k3s-discover-address-mismatch.json
@@ -1,0 +1,11 @@
+{
+  "id": "k3s-discover-address-mismatch",
+  "date": "2025-10-24",
+  "component": "k3s-discover.sh",
+  "rootCause": "Bootstrap self-check required the Avahi advertisement to report the exact IPv4 address. On Raspberry Pi dev clusters the helper announced the host but returned a different address during the first query, so discovery aborted to avoid a perceived split brain.",
+  "resolution": "Allow the self-check to fall back to host matching when the expected address is missing while emitting a warning, gated by SUGARKUBE_MDNS_ALLOW_ADDR_MISMATCH.",
+  "references": [
+    "scripts/k3s-discover.sh",
+    "tests/scripts/test_k3s_discover_bootstrap_publish.py"
+  ]
+}

--- a/scripts/k3s-discover.sh
+++ b/scripts/k3s-discover.sh
@@ -45,6 +45,7 @@ SUGARKUBE_MDNS_BOOT_RETRIES="${SUGARKUBE_MDNS_BOOT_RETRIES:-${MDNS_SELF_CHECK_AT
 SUGARKUBE_MDNS_BOOT_DELAY="${SUGARKUBE_MDNS_BOOT_DELAY:-${MDNS_SELF_CHECK_DELAY}}"
 SUGARKUBE_MDNS_SERVER_RETRIES="${SUGARKUBE_MDNS_SERVER_RETRIES:-60}"
 SUGARKUBE_MDNS_SERVER_DELAY="${SUGARKUBE_MDNS_SERVER_DELAY:-1}"
+SUGARKUBE_MDNS_ALLOW_ADDR_MISMATCH="${SUGARKUBE_MDNS_ALLOW_ADDR_MISMATCH:-1}"
 
 PRINT_TOKEN_ONLY=0
 CHECK_TOKEN_ONLY=0
@@ -676,7 +677,7 @@ ensure_self_mdns_advertisement() {
 
   MDNS_LAST_OBSERVED=""
   local observed=""
-  local -a mdns_check=(
+  local -a mdns_check_base=(
     python3 "${SCRIPT_DIR}/mdns_helpers.py"
     --expect-host "${MDNS_HOST_RAW}"
     --cluster "${CLUSTER}"
@@ -685,13 +686,24 @@ ensure_self_mdns_advertisement() {
     --retries "${retries}"
     --delay "${delay}"
   )
+  local -a mdns_check=("${mdns_check_base[@]}")
+  local used_expect_addr=0
   if [ -n "${MDNS_ADDR_V4}" ]; then
     mdns_check+=(--expect-addr "${MDNS_ADDR_V4}")
+    used_expect_addr=1
   fi
 
   if observed="$("${mdns_check[@]}")"; then
     MDNS_LAST_OBSERVED="${observed}"
     return 0
+  fi
+
+  if [ "${used_expect_addr}" -eq 1 ] && [ "${SUGARKUBE_MDNS_ALLOW_ADDR_MISMATCH}" != "0" ]; then
+    if observed="$("${mdns_check_base[@]}")"; then
+      MDNS_LAST_OBSERVED="${observed}"
+      log "WARN: ${role} advertisement observed from ${observed} without expected addr ${MDNS_ADDR_V4}; continuing."
+      return 0
+    fi
   fi
 
   return 1

--- a/tests/scripts/test_k3s_discover_bootstrap_publish.py
+++ b/tests/scripts/test_k3s_discover_bootstrap_publish.py
@@ -214,6 +214,89 @@ def test_bootstrap_publish_handles_trailing_dot_hostname(tmp_path):
     assert expected in result.stderr
 
 
+def test_bootstrap_publish_warns_on_address_mismatch(tmp_path):
+    hostname = _hostname_short()
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_path = tmp_path / "publish.log"
+
+    stub = bin_dir / "avahi-publish-service"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"echo \"START:$*\" >> '{log_path}'\n"
+        "RUN_DIR=\"${SUGARKUBE_RUNTIME_DIR:-/run/sugarkube}\"\n"
+        "pid_file=\"${RUN_DIR}/mdns-sugar-dev-bootstrap.pid\"\n"
+        "for _ in $(seq 1 50); do\n"
+        "  if [ -f \"${pid_file}\" ] && grep -q \"$$\" \"${pid_file}\"; then\n"
+        f"    echo \"PIDFILE_OK:bootstrap\" >> '{log_path}'\n"
+        "    break\n"
+        "  fi\n"
+        "  sleep 0.05\n"
+        "done\n"
+        "trap 'echo TERM >> \"" + str(log_path) + "\"; exit 0' TERM INT\n"
+        "while true; do sleep 1; done\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+
+    _write_avahi_publish_address_stub(bin_dir, log_path)
+
+    browse = bin_dir / "avahi-browse"
+    browse.write_text(
+        (
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "cat <<'EOF'\n"
+            f"=;eth0;IPv4;k3s-sugar-dev@{hostname}.local (bootstrap);_k3s-sugar-dev._tcp;local;{hostname}.local;"
+            "198.51.100.10;6443;txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=bootstrap;"
+            f"txt=leader={hostname}.local;txt=phase=bootstrap;txt=state=pending\n"
+            "EOF\n"
+        ),
+        encoding="utf-8",
+    )
+    browse.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update({
+        "PATH": f"{bin_dir}:{env.get('PATH', '')}",
+        "SUGARKUBE_CLUSTER": "sugar",
+        "SUGARKUBE_ENV": "dev",
+        "ALLOW_NON_ROOT": "1",
+        "SUGARKUBE_AVAHI_SERVICE_DIR": str(tmp_path / "avahi"),
+        "SUGARKUBE_TOKEN": "dummy",
+        "SUGARKUBE_MDNS_BOOT_RETRIES": "1",
+        "SUGARKUBE_MDNS_BOOT_DELAY": "0",
+        "SUGARKUBE_MDNS_PUBLISH_ADDR": "192.0.2.55",
+        "SUGARKUBE_RUNTIME_DIR": str(tmp_path / "run"),
+        "SUGARKUBE_SKIP_SYSTEMCTL": "1",
+        "SUGARKUBE_MDNS_ALLOW_ADDR_MISMATCH": "1",
+    })
+
+    result = subprocess.run(
+        ["bash", SCRIPT, "--test-bootstrap-publish"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    log_contents = log_path.read_text(encoding="utf-8")
+    assert "START:" in log_contents
+    assert "PIDFILE_OK:bootstrap" in log_contents
+
+    warning = (
+        f"WARN: bootstrap advertisement observed from {hostname}.local without expected addr "
+        "192.0.2.55; continuing."
+    )
+    confirm = (
+        f"phase=self-check host={hostname}.local observed={hostname}.local; "
+        "bootstrap advertisement confirmed."
+    )
+    assert warning in result.stderr
+    assert confirm in result.stderr
+
+
 def test_publish_binds_host_and_self_check_delays(tmp_path):
     """Mixed-case hosts with trailing dots should still self-confirm after the publish delay."""
 


### PR DESCRIPTION
what: allow mdns self-check to fall back when avahi returns a
      different address and cover with a regression test plus outage
      log
why: bootstrap aborted on hardware because the mdns helper could not
     confirm its own advertisement
how to test: pytest tests/scripts/test_k3s_discover_bootstrap_publish.py


------
https://chatgpt.com/codex/tasks/task_e_68fb1106aa58832f94ca552f6b6261a9