### PR TITLE
🩹 : – Accept bootstrap records missing phase TXT

### DIFF
--- a/outages/2025-10-24-k3s-discover-mdns-missing-phase.json
+++ b/outages/2025-10-24-k3s-discover-mdns-missing-phase.json
@@ -1,0 +1,12 @@
+{
+  "id": "2025-10-24-k3s-discover-mdns-missing-phase",
+  "date": "2025-10-24",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "Self-checks skipped our mDNS ad when Avahi omitted phase TXT key and bootstrap discovery timed out.",
+  "resolution": "Relax mdns_helpers.ensure_self_ad_is_visible to accept role matches without phase and add tests.",
+  "references": [
+    "Console: pi@sugarkube0 just up dev (2025-10-24)",
+    "scripts/mdns_helpers.py",
+    "tests/scripts/test_mdns_helpers.py"
+  ]
+}

--- a/scripts/mdns_helpers.py
+++ b/scripts/mdns_helpers.py
@@ -131,8 +131,14 @@ def ensure_self_ad_is_visible(
         records = _collect_mdns_records(cluster, env, runner)
         for record in records:
             txt = record.txt
-            if require_phase is not None and txt.get("phase") != require_phase:
-                continue
+
+            phase = txt.get("phase")
+            role = txt.get("role")
+            if require_phase is not None:
+                phase_matches = phase == require_phase
+                role_matches = role == require_phase if role else False
+                if not (phase_matches or (phase is None and role_matches)):
+                    continue
             host_match = _same_host(record.host, expected_norm)
             leader_match = _same_host(txt.get("leader", ""), expected_norm)
             if not (host_match or leader_match):

--- a/tests/scripts/test_mdns_helpers.py
+++ b/tests/scripts/test_mdns_helpers.py
@@ -139,3 +139,27 @@ def test_ensure_self_ad_is_visible_accepts_missing_address(capsys):
     assert observed == "host0.local"
     warning = capsys.readouterr().err
     assert "advertisement omitted address" in warning
+
+
+def test_ensure_self_ad_is_visible_uses_role_when_phase_missing():
+    record = (
+        "=;eth0;IPv4;k3s-sugar-dev@host0 (bootstrap);_k3s-sugar-dev._tcp;"
+        "local;host0.local;192.0.2.10;6443;"
+        "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=bootstrap;"
+        "txt=leader=host0.local\n"
+    )
+
+    runner = _make_runner({"_k3s-sugar-dev._tcp": record})
+
+    observed = ensure_self_ad_is_visible(
+        expected_host="host0.local",
+        cluster="sugar",
+        env="dev",
+        retries=1,
+        delay=0,
+        require_phase="bootstrap",
+        runner=runner,
+        sleep=lambda _: None,
+    )
+
+    assert observed == "host0.local"


### PR DESCRIPTION
what: allow bootstrap self-check to accept role fallback and add coverage
why: Avahi sometimes omits phase and bootstrap aborts without seeing itself
how: pytest tests/scripts/test_mdns_helpers.py tests/scripts/test_k3s_discover_bootstrap_publish.py -q

------
https://chatgpt.com/codex/tasks/task_e_68fb21c84604832f9b747a22f8978534