### PR TITLE
Handle double .local hostnames in mDNS self-check

### DIFF
--- a/outages/2025-10-24-k3s-discover-mdns-double-local.json
+++ b/outages/2025-10-24-k3s-discover-mdns-double-local.json
@@ -1,0 +1,14 @@
+{
+  "id": "2025-10-24-k3s-discover-mdns-double-local",
+  "date": "2025-10-24",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "Self-check removed one '.local'; Avahi returned sugarkube0.local.local so we aborted.",
+  "resolution": "Trim repeated '.local' suffixes, normalise logged hosts, and add tests for double '.local' adverts.",
+  "references": [
+    "Console: pi@sugarkube0 just up dev (2025-10-24)",
+    "scripts/mdns_helpers.py",
+    "scripts/k3s-discover.sh",
+    "tests/scripts/test_mdns_helpers.py",
+    "tests/scripts/test_k3s_discover_bootstrap_publish.py"
+  ]
+}

--- a/scripts/mdns_helpers.py
+++ b/scripts/mdns_helpers.py
@@ -31,8 +31,8 @@ def _norm_host(host: str) -> str:
 
 def _strip_local_suffix(host: str) -> str:
     for suffix in _LOCAL_SUFFIXES:
-        if host.endswith(suffix):
-            return host[: -len(suffix)]
+        while host.endswith(suffix):
+            host = host[: -len(suffix)]
     return host
 
 

--- a/tests/scripts/test_k3s_discover_bootstrap_publish.py
+++ b/tests/scripts/test_k3s_discover_bootstrap_publish.py
@@ -336,10 +336,10 @@ def test_publish_binds_host_and_self_check_delays(tmp_path):
             "#!/usr/bin/env bash\n"
             "set -euo pipefail\n"
             "cat <<'EOF'\n"
-            "=;eth0;IPv4;k3s-sugar-dev@HostMixed.LOCAL (bootstrap);_k3s-sugar-dev._tcp;local.;"
-            "hostmixed.local.;192.0.2.10;6443;"
+            "=;eth0;IPv4;k3s-sugar-dev@HostMixed.LOCAL.local (bootstrap);_k3s-sugar-dev._tcp;local.;"
+            "hostmixed.local.local.;192.0.2.10;6443;"
             "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=bootstrap;"
-            "txt=leader=hostmixed.local.;txt=phase=bootstrap;txt=state=pending\n"
+            "txt=leader=hostmixed.local.local.;txt=phase=bootstrap;txt=state=pending\n"
             "EOF\n"
         ),
         encoding="utf-8",

--- a/tests/scripts/test_mdns_helpers.py
+++ b/tests/scripts/test_mdns_helpers.py
@@ -21,6 +21,11 @@ def test_same_host_normalises_case_and_trailing_dots():
     assert not _same_host("host-a", "host-b")
 
 
+def test_same_host_accepts_repeated_local_suffix():
+    assert _same_host("Host.LOCAL.local", "host.local")
+    assert _same_host("host.local.local", "HOST")
+
+
 def test_ensure_self_ad_is_visible_filters_by_phase():
     bootstrap_record = (
         "=;eth0;IPv4;k3s-sugar-dev@host0 (bootstrap);_k3s-sugar-dev._tcp;"


### PR DESCRIPTION
what: strip repeated .local suffixes in helpers and scripts
why: avahi returned host.local.local so bootstrap self-check aborted
how to test: pytest tests/scripts -q

------
https://chatgpt.com/codex/tasks/task_e_68fb21c84604832f9b747a22f8978534