### PR TITLE
Allow mDNS self-check to accept missing phase records

### DIFF
--- a/outages/2025-10-24-k3s-discover-mdns-phase-omission.json
+++ b/outages/2025-10-24-k3s-discover-mdns-phase-omission.json
@@ -1,0 +1,13 @@
+{
+  "id": "2025-10-24-k3s-discover-mdns-phase-omission",
+  "date": "2025-10-24",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "The bootstrap self-check insisted on mDNS TXT phase=bootstrap. On pi@sugarkube0 Avahi sometimes emitted role=bootstrap without phase, so ensure_self_ad_is_visible dropped our own record and discovery aborted to avoid split brain.",
+  "resolution": "Teach mdns_helpers.ensure_self_ad_is_visible to accept matching role=bootstrap/server records when phase is missing, and extend unit coverage to lock in the regression fix.",
+  "references": [
+    "Console: pi@sugarkube0 just up dev (2025-10-24)",
+    "scripts/mdns_helpers.py",
+    "tests/scripts/test_mdns_helpers.py",
+    "tests/scripts/test_k3s_discover_bootstrap_publish.py"
+  ]
+}


### PR DESCRIPTION
what: teach ensure_self_ad_is_visible to accept matching role when phase is missing.
why: avahi on pi@sugarkube0 dropped the phase TXT and self-check aborted the bootstrap.
how: pytest tests/scripts/test_mdns_helpers.py tests/scripts/test_k3s_discover_bootstrap_publish.py tests/scripts/test_just_up.py

------
https://chatgpt.com/codex/tasks/task_e_68fb21c84604832f9b747a22f8978534