### PR TITLE
Handle hostname-only mDNS addresses during server self-check

### DIFF
--- a/outages/2025-10-24-k3s-discover-mdns-hostname-address.json
+++ b/outages/2025-10-24-k3s-discover-mdns-hostname-address.json
@@ -1,0 +1,14 @@
+{
+  "id": "2025-10-24-k3s-discover-mdns-hostname-address",
+  "date": "2025-10-24",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "Self-check required IPv4 but Avahi reported our host name in the address field, so discovery never confirmed the server advert.",
+  "resolution": "Teach mdns_helpers.ensure_self_ad_is_visible to treat non-IP addresses as host-only fallbacks, surface warnings, and cover the regression with tests.",
+  "references": [
+    "Console: pi@sugarkube0 just up dev (2025-10-24)",
+    "scripts/mdns_helpers.py",
+    "scripts/k3s-discover.sh",
+    "tests/scripts/test_mdns_helpers.py",
+    "tests/scripts/test_k3s_discover_bootstrap_publish.py"
+  ]
+}

--- a/tests/scripts/test_mdns_helpers.py
+++ b/tests/scripts/test_mdns_helpers.py
@@ -146,6 +146,33 @@ def test_ensure_self_ad_is_visible_accepts_missing_address(capsys):
     assert "advertisement omitted address" in warning
 
 
+def test_ensure_self_ad_is_visible_accepts_hostname_address(capsys):
+    record = (
+        "=;eth0;IPv4;k3s-sugar-dev@host0 (server);_k3s-sugar-dev._tcp;"
+        "local;host0.local;host0.local;6443;"
+        "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=server;"
+        "txt=leader=host0.local;txt=phase=server\n"
+    )
+
+    runner = _make_runner({"_k3s-sugar-dev._tcp": record})
+
+    observed = ensure_self_ad_is_visible(
+        expected_host="host0.local",
+        cluster="sugar",
+        env="dev",
+        retries=1,
+        delay=0,
+        require_phase="server",
+        expect_addr="192.0.2.10",
+        runner=runner,
+        sleep=lambda _: None,
+    )
+
+    assert observed == "host0.local"
+    warning = capsys.readouterr().err
+    assert "advertisement reported non-IP" in warning
+
+
 def test_ensure_self_ad_is_visible_uses_role_when_phase_missing():
     record = (
         "=;eth0;IPv4;k3s-sugar-dev@host0 (bootstrap);_k3s-sugar-dev._tcp;"


### PR DESCRIPTION
## Summary
- treat non-IP mDNS addresses as host-only fallbacks so self-checks pass
- extend mdns helper and k3s-discover tests for hostname address adverts
- log the regression scenario in outages/

## Testing
- pytest tests/scripts/test_mdns_helpers.py tests/scripts/test_k3s_discover_bootstrap_publish.py

------
https://chatgpt.com/codex/tasks/task_e_68fbdf3a4a78832faa0e899dd78e1048