### PR TITLE
Fix mDNS server self-check parsing

### DIFF
--- a/outages/2025-10-24-k3s-discover-mdns-server-self-check.json
+++ b/outages/2025-10-24-k3s-discover-mdns-server-self-check.json
@@ -1,0 +1,14 @@
+{
+  "id": "2025-10-24-k3s-discover-mdns-server-self-check",
+  "date": "2025-10-24",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "Server self-check aborted because mdns parser skipped adverts when Avahi returned uppercase TXT keys, trailing spaces, and omitted the resolved host field.",
+  "resolution": "Normalise TXT payloads (trim whitespace, lower-case phase/role), fall back to leader host when the resolved host is blank, lower-case local domains, and add regression tests covering the server advertisement path.",
+  "references": [
+    "Console: pi@sugarkube0 just up dev (2025-10-24)",
+    "scripts/k3s_mdns_parser.py",
+    "scripts/mdns_helpers.py",
+    "tests/scripts/test_k3s_mdns_parser.py",
+    "tests/scripts/test_mdns_helpers.py"
+  ]
+}

--- a/tests/scripts/test_k3s_mdns_parser.py
+++ b/tests/scripts/test_k3s_mdns_parser.py
@@ -112,3 +112,22 @@ def test_parse_preserves_mixed_case_hostnames():
     record = recs[0]
     assert record.host == "HostMixed.local"
     assert record.txt.get("leader") == "HostMixed.local"
+
+
+def test_parse_normalises_txt_whitespace_and_missing_host_falls_back_to_leader():
+    lines = [
+        (
+            "=;eth0;IPv4;k3s-sugar-dev@LeaderHost (server);_k3s-sugar-dev._tcp;local;"
+            ";192.168.1.30;6443;"
+            "txt=k3s=1;txt=cluster=sugar;txt=ENV=dev;txt=role=SERVER ;"
+            "txt=leader=LeaderHost.LOCAL.;txt=phase=Server "
+        )
+    ]
+
+    recs = parse_mdns_records(lines, "sugar", "dev")
+    assert len(recs) == 1
+    record = recs[0]
+    assert record.host == "LeaderHost.local"
+    assert record.txt.get("leader") == "LeaderHost.local"
+    assert record.txt.get("phase") == "server"
+    assert record.txt.get("role") == "server"

--- a/tests/scripts/test_mdns_helpers.py
+++ b/tests/scripts/test_mdns_helpers.py
@@ -168,3 +168,28 @@ def test_ensure_self_ad_is_visible_uses_role_when_phase_missing():
     )
 
     assert observed == "host0.local"
+
+
+def test_ensure_self_ad_is_visible_handles_uppercase_phase_and_leader_host_fallback():
+    record = (
+        "=;eth0;IPv4;k3s-sugar-dev@host0 (server);_k3s-sugar-dev._tcp;"
+        "local;;192.0.2.10;6443;"
+        "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=SERVER ;"
+        "txt=leader=HOST0.LOCAL.;txt=phase=Server \n"
+    )
+
+    runner = _make_runner({"_k3s-sugar-dev._tcp": record})
+
+    observed = ensure_self_ad_is_visible(
+        expected_host="host0.local",
+        cluster="sugar",
+        env="dev",
+        retries=1,
+        delay=0,
+        require_phase="server",
+        expect_addr="192.0.2.10",
+        runner=runner,
+        sleep=lambda _: None,
+    )
+
+    assert observed == "host0.local"


### PR DESCRIPTION
what: Normalize k3s mDNS parsing, trim TXT noise, and add regression tests.
why: Avahi uppercase TXT data and missing hosts caused server self-check aborts.
how: pytest tests/scripts/test_mdns_helpers.py tests/scripts/test_k3s_mdns_parser.py
     pytest tests/scripts/test_k3s_discover_bootstrap_publish.py
     pytest tests/scripts/test_k3s_discover_mid_election_join.py
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68fbdf3a4a78832faa0e899dd78e1048