### PR TITLE
Fallback to Avahi log for server self-check

### DIFF
--- a/outages/2025-10-24-k3s-discover-mdns-server-self-check.json
+++ b/outages/2025-10-24-k3s-discover-mdns-server-self-check.json
@@ -1,0 +1,12 @@
+{
+  "id": "2025-10-24-k3s-discover-mdns-server-self-check",
+  "date": "2025-10-24",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "Server self-check relied solely on mDNS browse results and aborted even though avahi-publish-service had already established the advertisement.",
+  "resolution": "Accept avahi-publish-service confirmations as a fallback source, record the origin in logs, and add a regression test that exercises the fallback.",
+  "references": [
+    "Console: pi@sugarkube0 just up dev (2025-10-24)",
+    "scripts/k3s-discover.sh",
+    "tests/scripts/test_k3s_discover_bootstrap_publish.py"
+  ]
+}

--- a/tests/scripts/test_k3s_discover_bootstrap_publish.py
+++ b/tests/scripts/test_k3s_discover_bootstrap_publish.py
@@ -708,6 +708,112 @@ def test_bootstrap_publish_waits_for_server_advert_before_retiring_bootstrap(tmp
     browse_calls = int(count_path.read_text(encoding="utf-8").strip())
     assert browse_calls >= 2
 
+
+def test_server_self_check_falls_back_to_avahi_log(tmp_path):
+    hostname = _hostname_short()
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_path = tmp_path / "publish.log"
+
+    stub = bin_dir / "avahi-publish-service"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"echo \"START:$*\" >> '{log_path}'\n"
+        "RUN_DIR=\"${SUGARKUBE_RUNTIME_DIR:-/run/sugarkube}\"\n"
+        "phase_label=bootstrap\n"
+        "if [[ \"$*\" == *\"phase=server\"* ]]; then\n"
+        "  phase_label=server\n"
+        "fi\n"
+        "pid_file=\"${RUN_DIR}/mdns-sugar-dev-${phase_label}.pid\"\n"
+        "for _ in $(seq 1 50); do\n"
+        "  if [ -f \"${pid_file}\" ] && grep -q \"$$\" \"${pid_file}\"; then\n"
+        f"    echo \"PIDFILE_OK:${{phase_label}}\" >> '{log_path}'\n"
+        "    break\n"
+        "  fi\n"
+        "  sleep 0.05\n"
+        "done\n"
+        "service_name=\"$4\"\n"
+        f"echo \"Established under name '${{service_name}}'\" >> '{log_path}'\n"
+        "echo \"Established under name '${service_name}'\"\n"
+        "trap 'echo TERM >> \"" + str(log_path) + "\"; exit 0' TERM INT\n"
+        "while true; do sleep 1; done\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+
+    _write_avahi_publish_address_stub(bin_dir, log_path)
+
+    browse = bin_dir / "avahi-browse"
+    browse.write_text(
+        (
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "cat <<'EOF'\n"
+            f"=;eth0;IPv4;k3s-sugar-dev@{hostname}.local (bootstrap);_k3s-sugar-dev._tcp;local;{hostname}.local;"
+            f"192.0.2.55;6443;txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=bootstrap;txt=leader={hostname}.local;"
+            "txt=phase=bootstrap;txt=state=pending\n"
+            "EOF\n"
+        ),
+        encoding="utf-8",
+    )
+    browse.chmod(0o755)
+
+    systemctl_stub = bin_dir / "systemctl"
+    systemctl_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    systemctl_stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update({
+        "PATH": f"{bin_dir}:{env.get('PATH', '')}",
+        "SUGARKUBE_CLUSTER": "sugar",
+        "SUGARKUBE_ENV": "dev",
+        "ALLOW_NON_ROOT": "1",
+        "SUGARKUBE_AVAHI_SERVICE_DIR": str(tmp_path / "avahi"),
+        "SUGARKUBE_TOKEN": "dummy",
+        "SUGARKUBE_MDNS_BOOT_RETRIES": "1",
+        "SUGARKUBE_MDNS_BOOT_DELAY": "0",
+        "SUGARKUBE_MDNS_SERVER_RETRIES": "2",
+        "SUGARKUBE_MDNS_SERVER_DELAY": "0",
+        "SUGARKUBE_MDNS_PUBLISH_ADDR": "192.0.2.55",
+        "SUGARKUBE_RUNTIME_DIR": str(tmp_path / "run"),
+        "SUGARKUBE_SKIP_SYSTEMCTL": "1",
+    })
+
+    result = subprocess.run(
+        ["bash", SCRIPT, "--test-bootstrap-server-flow"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    runtime_dir = tmp_path / "run"
+    server_pid_file = runtime_dir / "mdns-sugar-dev-server.pid"
+    server_pid = int(server_pid_file.read_text(encoding="utf-8").strip())
+    assert server_pid > 0
+    os.kill(server_pid, 0)
+
+    stderr = result.stderr
+    assert "WARN: server advertisement not observed via mDNS" in stderr
+    assert "server advertisement confirmed (source=avahi-log)" in stderr
+
+    cleanup_env = env.copy()
+    subprocess.run(
+        ["bash", str(Path(__file__).resolve().parents[2] / "scripts" / "cleanup_mdns_publishers.sh")],
+        env=cleanup_env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert not server_pid_file.exists()
+
 def test_bootstrap_publish_fails_without_mdns(tmp_path):
     hostname = _hostname_short()
     bin_dir = tmp_path / "bin"


### PR DESCRIPTION
what: trust avahi-publish-service when mDNS lookup misses server advert
why: bootstrap aborted after publishing but browse never observed local record
how to test: pytest tests/scripts/test_k3s_discover_bootstrap_publish.py -q

------
https://chatgpt.com/codex/tasks/task_e_68fbdf3a4a78832faa0e899dd78e1048