### PR TITLE
🛠️ : – Casefold mDNS cluster/env TXT values

### DIFF
--- a/outages/2025-10-24-k3s-discover-mdns-cluster-env-case.json
+++ b/outages/2025-10-24-k3s-discover-mdns-cluster-env-case.json
@@ -1,0 +1,15 @@
+{
+  "id": "2025-10-24-k3s-discover-mdns-cluster-env-case",
+  "date": "2025-10-24",
+  "component": "scripts/k3s_mdns_parser.py",
+  "rootCause": "Uppercase cluster/env TXT values from Avahi made the parser skip our advert, aborting self-check.",
+  "resolution": "Casefold cluster/env TXT values, normalise metadata, and add uppercase regression coverage.",
+  "references": [
+    "Console: pi@sugarkube0 just up dev (2025-10-24)",
+    "scripts/k3s_mdns_parser.py",
+    "scripts/mdns_helpers.py",
+    "tests/scripts/test_k3s_mdns_parser.py",
+    "tests/scripts/test_mdns_helpers.py",
+    "tests/scripts/test_just_up.py"
+  ]
+}

--- a/tests/scripts/test_just_up.py
+++ b/tests/scripts/test_just_up.py
@@ -213,7 +213,7 @@ def test_just_up_dev_two_nodes(tmp_path):
                 + "_k3s-sugar-dev._tcp;local;" + primary + ";"
                 + server_addr
                 + ";6443;"
-                + "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=server;"
+                + "txt=k3s=1;txt=cluster=SUGAR ;txt=ENV=DEV ;txt=role=server;"
                 + "txt=leader=" + primary + ";txt=phase=server"
             )
 

--- a/tests/scripts/test_k3s_mdns_parser.py
+++ b/tests/scripts/test_k3s_mdns_parser.py
@@ -131,3 +131,20 @@ def test_parse_normalises_txt_whitespace_and_missing_host_falls_back_to_leader()
     assert record.txt.get("leader") == "LeaderHost.local"
     assert record.txt.get("phase") == "server"
     assert record.txt.get("role") == "server"
+
+
+def test_parse_accepts_uppercase_cluster_and_env_values():
+    lines = [
+        (
+            "=;eth0;IPv4;k3s-sugar-dev@host7 (server);_k3s-sugar-dev._tcp;local;"
+            "host7.local;192.168.1.31;6443;"
+            "txt=k3s=1;txt=cluster=SUGAR ;txt=ENV=DEV ;txt=role=server;txt=phase=server"
+        )
+    ]
+
+    recs = parse_mdns_records(lines, "sugar", "dev")
+    assert len(recs) == 1
+    record = recs[0]
+    assert record.txt.get("cluster") == "sugar"
+    assert record.txt.get("env") == "dev"
+    assert record.txt.get("role") == "server"

--- a/tests/scripts/test_mdns_helpers.py
+++ b/tests/scripts/test_mdns_helpers.py
@@ -220,3 +220,28 @@ def test_ensure_self_ad_is_visible_handles_uppercase_phase_and_leader_host_fallb
     )
 
     assert observed == "host0.local"
+
+
+def test_ensure_self_ad_is_visible_accepts_uppercase_cluster_and_env():
+    record = (
+        "=;eth0;IPv4;k3s-sugar-dev@host0 (server);_k3s-sugar-dev._tcp;"
+        "local;host0.local;192.0.2.10;6443;"
+        "txt=k3s=1;txt=cluster=SUGAR ;txt=ENV=DEV ;txt=role=server;"
+        "txt=phase=server\n"
+    )
+
+    runner = _make_runner({"_k3s-sugar-dev._tcp": record})
+
+    observed = ensure_self_ad_is_visible(
+        expected_host="host0.local",
+        cluster="sugar",
+        env="dev",
+        retries=1,
+        delay=0,
+        require_phase="server",
+        expect_addr="192.0.2.10",
+        runner=runner,
+        sleep=lambda _: None,
+    )
+
+    assert observed == "host0.local"


### PR DESCRIPTION
what: Accept uppercase cluster/env TXT values and normalise metadata.
why: Avahi uppercased TXT payloads so discovery skipped our advert.
how to test: pytest tests/scripts/test_{k3s_mdns_parser,mdns_helpers,just_up}.py

------
https://chatgpt.com/codex/tasks/task_e_68fbe7f30ba8832f99a7c443821b3204