### PR TITLE
🚑 : – Retry mDNS server self-check and cover regression

### DIFF
--- a/outages/2025-10-24-k3s-discover-mdns-server-retry.json
+++ b/outages/2025-10-24-k3s-discover-mdns-server-retry.json
@@ -1,0 +1,12 @@
+{
+  "id": "2025-10-24-k3s-discover-mdns-server-retry",
+  "date": "2025-10-24",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "Self-check aborted when Avahi temporarily failed to surface the local server advertisement even though the publishers were running, so bootstrap stopped on the first attempt.",
+  "resolution": "Restart the Avahi address and service publishers once before giving up, confirm the advert after the restart, and extend the just up two-node e2e test to cover the regression and recovery path.",
+  "references": [
+    "Console: pi@sugarkube0 just up dev (2025-10-24)",
+    "scripts/k3s-discover.sh",
+    "tests/scripts/test_just_up.py"
+  ]
+}


### PR DESCRIPTION
what: restart Avahi publishers when server self-check misses advert
why: Avahi sometimes lags on Pi so discovery aborted before joining
how: bounce publishers once, log the recovery, extend two-node just up e2e,
     and record the outage
test: pytest tests/scripts/test_mdns_helpers.py
      pytest tests/scripts/test_k3s_discover_bootstrap_publish.py::test_bootstrap_publish_uses_avahi_publish
      pytest tests/scripts/test_just_up.py::test_just_up_dev_two_nodes
Refs: #none

------
https://chatgpt.com/codex/tasks/task_e_68fbe7f30ba8832f99a7c443821b3204