### PR TITLE
🐞 : – Normalize mDNS service type handling

### DIFF
--- a/outages/2025-10-24-k3s-discover-mdns-service-type-suffix.json
+++ b/outages/2025-10-24-k3s-discover-mdns-service-type-suffix.json
@@ -1,0 +1,13 @@
+{
+  "id": "2025-10-24-k3s-discover-mdns-service-type-suffix",
+  "date": "2025-10-24",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "mDNS self-check skipped adverts when Avahi appended the local domain to the service type, so the parser ignored the server records and discovery aborted.",
+  "resolution": "Normalize service types before extracting the cluster/env slug, cover the regression with parser unit tests, and exercise the domain-suffixed browse output in the two-node e2e flow.",
+  "references": [
+    "Console: pi@sugarkube0 just up dev (2025-10-24)",
+    "scripts/k3s_mdns_parser.py",
+    "tests/scripts/test_k3s_mdns_parser.py",
+    "tests/scripts/test_just_up.py"
+  ]
+}

--- a/scripts/k3s_mdns_parser.py
+++ b/scripts/k3s_mdns_parser.py
@@ -156,14 +156,19 @@ def parse_mdns_records(
         if len(fields) < 6:
             continue
 
-        service_type = fields[4]
+        service_type = fields[4].strip()
+        normalized_type = service_type
+        tcp_index = normalized_type.find("._tcp")
+        if tcp_index != -1:
+            normalized_type = normalized_type[: tcp_index + len("._tcp")]
+
         type_cluster: Optional[str] = None
         type_environment: Optional[str] = None
 
-        if service_type == "_https._tcp":
+        if normalized_type == "_https._tcp":
             pass
-        elif service_type.startswith("_k3s-") and service_type.endswith("._tcp"):
-            slug = service_type[len("_k3s-") : -len("._tcp")]
+        elif normalized_type.startswith("_k3s-") and normalized_type.endswith("._tcp"):
+            slug = normalized_type[len("_k3s-") : -len("._tcp")]
             if "-" in slug:
                 type_cluster, type_environment = slug.rsplit("-", 1)
         else:

--- a/tests/scripts/test_k3s_mdns_parser.py
+++ b/tests/scripts/test_k3s_mdns_parser.py
@@ -131,3 +131,23 @@ def test_parse_normalises_txt_whitespace_and_missing_host_falls_back_to_leader()
     assert record.txt.get("leader") == "LeaderHost.local"
     assert record.txt.get("phase") == "server"
     assert record.txt.get("role") == "server"
+
+
+def test_parse_handles_service_type_domain_suffix():
+    lines = [
+        (
+            "=;eth0;IPv4;k3s-sugar-dev@host7 (server);_k3s-sugar-dev._tcp.local;local;"
+            "host7.local;192.168.1.31;6443;"
+            "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=server;txt=phase=server;"
+            "txt=leader=host7.local"
+        ),
+        (
+            "=;eth0;IPv4;k3s API sugar/dev [server] on host8;_https._tcp.local.;local;"
+            "host8.local;192.168.1.32;6443;txt=cluster=sugar;txt=env=dev;txt=role=server"
+        ),
+    ]
+
+    recs = parse_mdns_records(lines, "sugar", "dev")
+    hosts = {record.host for record in recs}
+    assert "host7.local" in hosts
+    assert "host8.local" in hosts


### PR DESCRIPTION
what: normalize mDNS service types and cover domain-suffix browse output
why: avahi appended .local to the service type so server adverts were skipped
how to test: pytest tests/scripts/test_k3s_mdns_parser.py tests/scripts/test_mdns_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68fbe7f30ba8832f99a7c443821b3204