### PR TITLE
🚑 Accept Avahi registration fallback when browse misses

### DIFF
--- a/outages/2025-10-24-k3s-discover-avahi-registration-fallback.json
+++ b/outages/2025-10-24-k3s-discover-avahi-registration-fallback.json
@@ -1,0 +1,12 @@
+{
+  "id": "2025-10-24-k3s-discover-avahi-registration-fallback",
+  "date": "2025-10-24",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "k3s-discover aborted bootstrap when avahi-browse could not observe the node's own mDNS advertisement even though avahi-publish-service reported registration. On Pi hardware the Avahi daemon occasionally accepts the service but delays surfacing it back to local queries, so the strict self-check never recorded a match and the bootstrap logic bailed out to avoid split brain.",
+  "resolution": "Treat Avahi's \"Established under name\" log as confirmation when browse probes fail twice, keep the publishers alive, and extend the integration test harness to simulate hidden advertisements so the fallback stays covered.",
+  "references": [
+    "Console: pi@sugarkube0 just up dev (2025-10-24)",
+    "scripts/k3s-discover.sh",
+    "tests/scripts/test_just_up.py"
+  ]
+}


### PR DESCRIPTION
what: accept Avahi registration logs when browse probes fail
why: avahi-browse misses the local service on Pi hardware despite registration
how to test:
  - pytest tests/scripts/test_mdns_helpers.py \
    tests/scripts/test_just_up.py
  - pyspelling -c .spellcheck.yaml
  - linkchecker --no-warnings README.md docs/
  - pre-commit run --all-files (fails: repo yaml multi-doc + lint debt)
Refs: #none

------
https://chatgpt.com/codex/tasks/task_e_68fbffa403e4832f903d07400ab1c148