### PR TITLE
Add fallback for silent Avahi browse checks

### DIFF
--- a/outages/2025-10-24-k3s-discover-mdns-publisher-fallback.json
+++ b/outages/2025-10-24-k3s-discover-mdns-publisher-fallback.json
@@ -1,0 +1,13 @@
+{
+  "id": "2025-10-24-k3s-discover-mdns-publisher-fallback",
+  "date": "2025-10-24",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "Avahi sometimes accepts the publish request but the local browse never shows the advert, causing the bootstrap guard to abort even though the publisher reported success.",
+  "resolution": "Detect established Avahi publishers via their log output when browse checks fail twice, proceed with a warning, and extend bootstrap publish tests to cover the new fallback.",
+  "references": [
+    "Console: pi@sugarkube0 just up dev (2025-10-24)",
+    "scripts/k3s-discover.sh",
+    "tests/scripts/test_k3s_discover_bootstrap_publish.py",
+    "tests/scripts/test_just_up.py"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a publisher log fallback in `k3s-discover.sh` so bootstrap/server adverts can continue when browse checks miss them
- extend the mdns bootstrap publish and `just up` tests to cover the new behaviour
- document the regression in `outages/2025-10-24-k3s-discover-mdns-publisher-fallback.json`

## Testing
- pytest tests/scripts/test_mdns_helpers.py tests/scripts/test_k3s_discover_bootstrap_publish.py
- pytest tests/scripts/test_just_up.py

------
https://chatgpt.com/codex/tasks/task_e_68fbffa403e4832f903d07400ab1c148