### PR TITLE
Add timeout handling to mDNS self-check helper

### DIFF
--- a/outages/2025-10-24-k3s-discover-mdns-timeout.json
+++ b/outages/2025-10-24-k3s-discover-mdns-timeout.json
@@ -1,0 +1,11 @@
+{
+  "id": "k3s-discover-mdns-timeout",
+  "date": "2025-10-24",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "mdns_helpers ran avahi-browse without timeout; a stalled daemon blocked discovery.",
+  "resolution": "Added a timeout in mdns_helpers.py so avahi-browse exits and fallback proceeds.",
+  "references": [
+    "scripts/mdns_helpers.py",
+    "tests/scripts/test_mdns_helpers.py"
+  ]
+}


### PR DESCRIPTION
what: add avahi-browse timeouts to mdns_helpers and cover with tests; log outage
why: prevent k3s discovery from hanging when avahi-browse stalls
how: pytest tests/scripts/test_mdns_helpers.py tests/scripts/test_k3s_mdns_query.py

------
https://chatgpt.com/codex/tasks/task_e_68fc0975a58c832f971b6e9edb953ea6