### PR TITLE
Improve mDNS self-check logging

### DIFF
--- a/outages/2025-10-25-k3s-discover-mdns-log-prefix.json
+++ b/outages/2025-10-25-k3s-discover-mdns-log-prefix.json
@@ -1,0 +1,10 @@
+{
+  "id": "k3s-discover-mdns-log-prefix",
+  "date": "2025-10-25",
+  "component": "scripts/mdns_helpers.py",
+  "rootCause": "Log messages embedded the \"[k3s-discover mdns]\" prefix manually, so future updates risked emitting lines without timestamps or with duplicated prefixes. Some diagnostics already bypassed the helper, leading to inconsistent formatting in the self-check output.",
+  "resolution": "Centralised logging through the mdns_helpers logger so every message receives the timestamp and prefix automatically, ensuring consistent formatting across all code paths.",
+  "references": [
+    "scripts/mdns_helpers.py"
+  ]
+}

--- a/outages/2025-10-25-k3s-discover-mdns-phase-mismatch-logging.json
+++ b/outages/2025-10-25-k3s-discover-mdns-phase-mismatch-logging.json
@@ -1,0 +1,11 @@
+{
+  "id": "k3s-discover-mdns-phase-mismatch-logging",
+  "date": "2025-10-25",
+  "component": "scripts/mdns_helpers.py",
+  "rootCause": "The mDNS self-check filtered advertisements by phase before evaluating the host identity. When bootstrap adverts lacked the requested phase value, the script logged that no hosts matched the expected name even though the local host was present, so discovery kept retrying unnecessarily.",
+  "resolution": "Track host/leader matches separately from the phase filter and emit a dedicated log message when the expected host appears with the wrong phase. This clarifies the situation and avoids the misleading \"none matched expected\" message.",
+  "references": [
+    "scripts/mdns_helpers.py",
+    "tests/scripts/test_mdns_helpers.py"
+  ]
+}


### PR DESCRIPTION
what: clarify mdns self-check logging and add outage records
why: phase mismatches reported as host failures and timestamps were ad-hoc
how to test: pytest tests/scripts/test_mdns_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68fc5b6d254c832f9220eaf73b7b602b