### PR TITLE
🐛 Fix mDNS self-check host normalization and timestamps

### DIFF
--- a/outages/2025-10-25-mdns-helper-timestamps.json
+++ b/outages/2025-10-25-mdns-helper-timestamps.json
@@ -1,0 +1,11 @@
+{
+  "id": "mdns-helper-timestamps",
+  "date": "2025-10-25",
+  "component": "scripts/mdns_helpers.py",
+  "rootCause": "mdns_helpers.py wrote its diagnostic messages with timestamps but emitted the successful hostname to stdout without any prefix. When the discovery flow surfaced that line to operators it appeared timestamp-less, making it difficult to correlate with surrounding log output.",
+  "resolution": "Introduce a reusable timestamped logging helper that covers both stderr diagnostics and stdout results so every emitted line carries a timestamp. Update k3s-discover.sh to strip the timestamp before consuming the hostname.",
+  "references": [
+    "scripts/k3s-discover.sh",
+    "scripts/mdns_helpers.py"
+  ]
+}

--- a/outages/2025-10-25-mdns-self-check-control-char.json
+++ b/outages/2025-10-25-mdns-self-check-control-char.json
@@ -1,0 +1,10 @@
+{
+  "id": "mdns-self-check-control-char",
+  "date": "2025-10-25",
+  "component": "scripts/mdns_helpers.py",
+  "rootCause": "Avahi's avahi-browse output occasionally appends NUL or other control characters to hostnames, causing mdns_helpers._same_host to treat the observed host as distinct from the expected host despite their visual match. The self-check loop therefore never observed a match and retried until exhausting all attempts.",
+  "resolution": "Strip ASCII control characters during hostname normalisation so that mDNS advertisements with trailing NULs or other control bytes are compared correctly. Added regression coverage for control-character handling.",
+  "references": [
+    "tests/scripts/test_mdns_helpers.py::test_same_host_strips_control_characters"
+  ]
+}

--- a/tests/scripts/test_mdns_helpers.py
+++ b/tests/scripts/test_mdns_helpers.py
@@ -26,6 +26,11 @@ def test_same_host_accepts_repeated_local_suffix():
     assert _same_host("host.local.local", "HOST")
 
 
+def test_same_host_strips_control_characters():
+    assert _same_host("host0.local\x00", "host0.local")
+    assert _same_host("\x07host1.local", "host1")
+
+
 def test_ensure_self_ad_is_visible_filters_by_phase():
     bootstrap_record = (
         "=;eth0;IPv4;k3s-sugar-dev@host0 (bootstrap);_k3s-sugar-dev._tcp;"


### PR DESCRIPTION
🐛 : –

what:
- add a reusable timestamped logger in mdns_helpers and strip control characters during hostname normalization
- update k3s-discover self-check parsing for timestamped CLI output
- document the control-character and timestamp regressions under outages/

why:
- mDNS records containing hidden control characters prevented the self-check loop from detecting its own advertisements
- stdout lines without timestamps made discovery logs harder to correlate

how to test:
- pytest tests/scripts/test_mdns_helpers.py


------
https://chatgpt.com/codex/tasks/task_e_68fc5b6d254c832f9220eaf73b7b602b