### PR TITLE
Improve mDNS self-check diagnostics and document outages

### DIFF
--- a/outages/2025-10-25-mdns-host-mismatch-logging.json
+++ b/outages/2025-10-25-mdns-host-mismatch-logging.json
@@ -1,0 +1,11 @@
+{
+  "id": "mdns-host-mismatch-logging",
+  "date": "2025-10-25",
+  "component": "scripts/mdns_helpers.py",
+  "rootCause": "The mDNS self-check collapsed all rejected records into a generic host list, hiding whether phase filtering, host normalisation, or leader comparisons failed and leading to repeated retries even when the record looked correct.",
+  "resolution": "Log the phase/role matches alongside the normalised host, leader, and stripped hostname values for every rejected record so future logs identify the exact comparison that failed.",
+  "references": [
+    "scripts/mdns_helpers.py",
+    "tests/scripts/test_mdns_helpers.py"
+  ]
+}

--- a/outages/2025-10-25-mdns-self-check-fallback-logging.json
+++ b/outages/2025-10-25-mdns-self-check-fallback-logging.json
@@ -1,0 +1,10 @@
+{
+  "id": "mdns-self-check-fallback-logging",
+  "date": "2025-10-25",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "When the IPv4 address comparison failed, k3s-discover silently reran the mDNS self-check without the address constraint, so operators saw a second wave of 20 attempts with no explanation in the logs.",
+  "resolution": "Emit an explicit log line before the fallback run to explain that the script is retrying without the IPv4 requirement after the expected address was not confirmed.",
+  "references": [
+    "scripts/k3s-discover.sh"
+  ]
+}

--- a/scripts/k3s-discover.sh
+++ b/scripts/k3s-discover.sh
@@ -742,6 +742,7 @@ ensure_self_mdns_advertisement() {
   fi
 
   if [ "${used_expect_addr}" -eq 1 ] && [ "${SUGARKUBE_MDNS_ALLOW_ADDR_MISMATCH}" != "0" ]; then
+    log "Self-check for ${role} advertisement: expected IPv4 ${MDNS_ADDR_V4} not confirmed; retrying without IPv4 requirement."
     if observed_line="$("${mdns_check_base[@]}")"; then
       local observed
       observed="$(strip_timestamp_prefix "${observed_line}")"


### PR DESCRIPTION
what: expand mdns_helpers logging, add fallback notice, record outages
why: clarify why equality checks fail and explain duplicate retry loops
how to test: pytest tests/scripts/test_mdns_helpers.py
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68fc649e0de0832fb655f64e640a6529