### PR TITLE
Improve mDNS publishing reliability

### DIFF
--- a/scripts/cleanup_mdns_publishers.sh
+++ b/scripts/cleanup_mdns_publishers.sh
@@ -39,12 +39,12 @@ for phase in bootstrap server; do
 done
 
 svc="_k3s-${CLUSTER}-${ENV}._tcp"
-if pgrep -af "avahi-publish-service.*${svc}" >/dev/null 2>&1; then
+if pgrep -af "avahi-publish.*${svc}" >/dev/null 2>&1; then
   if [ "${DRY_RUN}" = "1" ]; then
-    log "DRY_RUN=1: would pkill stray avahi-publish-service for ${svc}"
+    log "DRY_RUN=1: would pkill stray avahi-publish for ${svc}"
   else
-    log "pkill stray avahi-publish-service for ${svc}"
-    pkill -f "avahi-publish-service.*${svc}" 2>/dev/null || true
+    log "pkill stray avahi-publish for ${svc}"
+    pkill -f "avahi-publish.*${svc}" 2>/dev/null || true
   fi
   killed_any=1
 fi

--- a/scripts/k3s_mdns_parser.py
+++ b/scripts/k3s_mdns_parser.py
@@ -97,18 +97,23 @@ def _is_candidate_line(line: str) -> bool:
 def _parse_txt_fields(fields: Sequence[str]) -> Dict[str, str]:
     txt: Dict[str, str] = {}
     for field in fields:
-        if not field.startswith("txt="):
+        if not field:
             continue
-        payload = field[4:]
+        payload = field[4:] if field.startswith("txt=") else field
+        payload = payload.strip()
         if not payload:
             continue
-        payload = payload.strip()
-        if "=" not in payload:
-            continue
-        key, value = payload.split("=", 1)
-        key = key.strip().lower()
-        value = value.strip()
-        txt[key] = value
+        tokens = [payload]
+        if "," in payload:
+            tokens = [segment.strip() for segment in payload.split(",")]
+        for token in tokens:
+            if not token or "=" not in token:
+                continue
+            key, value = token.split("=", 1)
+            key = key.strip().lower()
+            if not key:
+                continue
+            txt[key] = value.strip()
     return txt
 
 

--- a/scripts/k3s_mdns_query.py
+++ b/scripts/k3s_mdns_query.py
@@ -41,13 +41,9 @@ def _service_types(cluster: str, environment: str) -> List[str]:
 
 
 def _build_command(mode: str, service_type: str, *, resolve: bool = True) -> List[str]:
-    command = [
-        "avahi-browse",
-        "--parsable",
-        "--terminate",
-    ]
+    command = ["avahi-browse", "-p", "-t", "-k"]
     if resolve:
-        command.append("--resolve")
+        command.insert(1, "-r")
     if mode in {"server-first", "server-count"}:
         command.append("--ignore-local")
     command.append(service_type)

--- a/tests/scripts/test_cleanup_mdns_publishers.sh
+++ b/tests/scripts/test_cleanup_mdns_publishers.sh
@@ -78,7 +78,7 @@ fi
 
 echo 99999 >"${BOOT_FILE}"
 
-FAKE_PUBLISHER="${TMP_DIR}/avahi-publish-service"
+FAKE_PUBLISHER="${TMP_DIR}/avahi-publish"
 cat <<'PUB' >"${FAKE_PUBLISHER}"
 #!/usr/bin/env bash
 set -euo pipefail

--- a/tests/scripts/test_just_up.py
+++ b/tests/scripts/test_just_up.py
@@ -133,10 +133,10 @@ def test_just_up_dev_two_nodes(tmp_path):
     )
 
     _write_executable(
-        bin_dir / "avahi-publish-service",
+        bin_dir / "avahi-publish",
         f"""#!/usr/bin/env bash
         set -euo pipefail
-        echo "avahi-publish-service:$@" >> "{log_path}"
+        echo "avahi-publish:$@" >> "{log_path}"
         run_dir="${{SUGARKUBE_RUNTIME_DIR:-/run/sugarkube}}"
         phase="bootstrap"
         if [[ "$*" == *"phase=server"* ]]; then
@@ -164,7 +164,7 @@ def test_just_up_dev_two_nodes(tmp_path):
         if [ -n "${{service_name}}" ]; then
           echo "Established under name '${{service_name}}'" >&2
         fi
-        trap 'echo "avahi-publish-service:TERM:${{phase}}" >> "{log_path}"; exit 0' TERM INT
+        trap 'echo "avahi-publish:TERM:${{phase}}" >> "{log_path}"; exit 0' TERM INT
         while true; do sleep 1; done
         """,
     )
@@ -451,7 +451,7 @@ def test_just_up_dev_two_nodes(tmp_path):
     )
 
     log_contents = log_path.read_text(encoding="utf-8")
-    assert "avahi-publish-service:" in log_contents
+    assert "avahi-publish:" in log_contents
     assert "-a" not in log_contents
     assert "avahi-publish-address:" in log_contents
     assert "sudo:apt-get update" in log_contents

--- a/tests/scripts/test_k3s_discover_bootstrap_publish.py
+++ b/tests/scripts/test_k3s_discover_bootstrap_publish.py
@@ -29,7 +29,7 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
     bin_dir.mkdir()
     log_path = tmp_path / "publish.log"
 
-    stub = bin_dir / "avahi-publish-service"
+    stub = bin_dir / "avahi-publish"
     stub.write_text(
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
@@ -105,24 +105,24 @@ def test_bootstrap_publish_uses_avahi_publish(tmp_path):
     log_contents = log_path.read_text(encoding="utf-8")
     assert "START:" in log_contents
     assert "TERM" in log_contents
-    assert "-s -H" in log_contents
+    assert "START:-s" in log_contents
     assert "PIDFILE_OK:bootstrap" in log_contents
 
-    assert "-H" in log_contents
-    assert f"-H {hostname}.local" in log_contents
+    assert f" {hostname}.local" in log_contents
     assert f"_k3s-sugar-dev._tcp" in log_contents
     assert f"cluster=sugar" in log_contents
     assert f"env=dev" in log_contents
     assert f"leader={hostname}.local" in log_contents
     assert "role=bootstrap" in log_contents
     assert "phase=bootstrap" in log_contents
+    assert f"host={hostname}.local" in log_contents
 
     # Service file should have been cleaned up by the EXIT trap
     service_file = tmp_path / "avahi" / "k3s-sugar-dev.service"
     assert not service_file.exists()
 
-    # stderr should mention that avahi-publish-service is advertising the bootstrap role
-    assert "avahi-publish-service advertising bootstrap" in result.stderr
+    # stderr should mention that avahi-publish is advertising the bootstrap role
+    assert "avahi-publish advertising bootstrap" in result.stderr
     expected = (
         f"phase=self-check host={hostname}.local observed={hostname}.local; "
         "bootstrap advertisement confirmed."
@@ -136,7 +136,7 @@ def test_bootstrap_publish_handles_trailing_dot_hostname(tmp_path):
     bin_dir.mkdir()
     log_path = tmp_path / "publish.log"
 
-    stub = bin_dir / "avahi-publish-service"
+    stub = bin_dir / "avahi-publish"
     stub.write_text(
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
@@ -203,7 +203,7 @@ def test_bootstrap_publish_handles_trailing_dot_hostname(tmp_path):
     log_contents = log_path.read_text(encoding="utf-8")
     assert "START:" in log_contents
     assert "TERM" in log_contents
-    assert "-s -H" in log_contents
+    assert "START:-s" in log_contents
     assert f"leader={hostname}.local" in log_contents
     assert "PIDFILE_OK:bootstrap" in log_contents
 
@@ -220,7 +220,7 @@ def test_bootstrap_publish_warns_on_address_mismatch(tmp_path):
     bin_dir.mkdir()
     log_path = tmp_path / "publish.log"
 
-    stub = bin_dir / "avahi-publish-service"
+    stub = bin_dir / "avahi-publish"
     stub.write_text(
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
@@ -304,7 +304,7 @@ def test_publish_binds_host_and_self_check_delays(tmp_path):
     bin_dir.mkdir()
     log_path = tmp_path / "publish.log"
 
-    stub = bin_dir / "avahi-publish-service"
+    stub = bin_dir / "avahi-publish"
     stub.write_text(
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
@@ -372,8 +372,9 @@ def test_publish_binds_host_and_self_check_delays(tmp_path):
     log_contents = log_path.read_text(encoding="utf-8")
     assert "START:" in log_contents
     assert "TERM" in log_contents
-    assert "-s -H" in log_contents
-    assert "-H HostMixed.LOCAL" in log_contents
+    assert "START:-s" in log_contents
+    assert " 6443 HostMixed.LOCAL" in log_contents
+    assert "host=HostMixed.LOCAL" in log_contents
     assert "leader=HostMixed.LOCAL" in log_contents
     assert "PIDFILE_OK:bootstrap" in log_contents
 
@@ -390,7 +391,7 @@ def test_bootstrap_publish_omits_address_flag(tmp_path):
     bin_dir.mkdir()
     log_path = tmp_path / "publish.log"
 
-    stub = bin_dir / "avahi-publish-service"
+    stub = bin_dir / "avahi-publish"
     stub.write_text(
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
@@ -455,7 +456,7 @@ def test_bootstrap_publish_retries_until_mdns_visible(tmp_path):
     log_path = tmp_path / "publish.log"
     count_path = tmp_path / "browse.count"
 
-    stub = bin_dir / "avahi-publish-service"
+    stub = bin_dir / "avahi-publish"
     stub.write_text(
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
@@ -557,7 +558,7 @@ def test_bootstrap_publish_waits_for_server_advert_before_retiring_bootstrap(tmp
     flag_path = tmp_path / "server.ready"
     count_path = tmp_path / "browse.count"
 
-    stub = bin_dir / "avahi-publish-service"
+    stub = bin_dir / "avahi-publish"
     stub.write_text(
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
@@ -657,7 +658,7 @@ def test_bootstrap_publish_waits_for_server_advert_before_retiring_bootstrap(tmp
 
     log_contents = log_path.read_text(encoding="utf-8")
     assert log_contents.count("START:") >= 2
-    assert "-s -H" in log_contents
+    assert "START:-s" in log_contents
     assert "phase=bootstrap" in log_contents
     assert "phase=server" in log_contents
     assert "PIDFILE_OK:bootstrap" in log_contents
@@ -722,7 +723,7 @@ def test_bootstrap_publish_fails_without_mdns(tmp_path):
     bin_dir.mkdir()
     log_path = tmp_path / "publish.log"
 
-    stub = bin_dir / "avahi-publish-service"
+    stub = bin_dir / "avahi-publish"
     stub.write_text(
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"

--- a/tests/scripts/test_k3s_discover_mid_election_join.py
+++ b/tests/scripts/test_k3s_discover_mid_election_join.py
@@ -37,9 +37,9 @@ def test_join_when_server_advertises_during_election(tmp_path: Path) -> None:
         "#!/usr/bin/env bash\n" "echo 'LISTEN'\n" "exit 0\n",
     )
 
-    # Provide a long-running avahi-publish-service implementation so the helper keeps a PID.
+    # Provide a long-running avahi-publish implementation so the helper keeps a PID.
     _write_stub(
-        bin_dir / "avahi-publish-service",
+        bin_dir / "avahi-publish",
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
         f"echo START:\"$@\" >> '{publish_log}'\n"


### PR DESCRIPTION
what: switch scripts to avahi-publish argv form, normalize hostname comparisons, expand TXT parsing and tests, add mdns-selfcheck just target
why: ensure mDNS TXT records round-trip accurately and self-check diagnostics point at the right issues
how to test: pytest tests/scripts/test_mdns_helpers.py tests/scripts/test_k3s_discover_bootstrap_publish.py tests/scripts/test_k3s_discover_mid_election_join.py tests/scripts/test_just_up.py

------
https://chatgpt.com/codex/tasks/task_e_68fc6c4ca5e4832f9393a317813ba72a