### PR TITLE
Improve mDNS TXT discovery reliability

### DIFF
--- a/justfile
+++ b/justfile
@@ -49,7 +49,21 @@ mdns-harden:
 
 mdns-selfcheck env='dev':
     export SUGARKUBE_ENV="{{ env }}"
-    python3 scripts/mdns_selfcheck.py
+    cluster="${SUGARKUBE_CLUSTER:-sugar}"
+    env_name="{{ env }}"
+    host="$(hostname).local"
+    instance="k3s-${cluster}-${env_name}@${host} (server)"
+    service_type="_k3s-${cluster}-${env_name}._tcp"
+    python3 scripts/mdns_selfcheck.py \
+      --instance "${instance}" \
+      --type "${service_type}" \
+      --domain "local" \
+      --expected-host "${host}" \
+      --require-phase server \
+      --require-role server \
+      --retries 10 \
+      --delay-ms 500 \
+      --print-json
 
 node-ip-dropin:
     sudo -E bash scripts/configure_k3s_node_ip.sh

--- a/scripts/k3s-discover.sh
+++ b/scripts/k3s-discover.sh
@@ -490,37 +490,50 @@ start_bootstrap_publisher() {
   BOOTSTRAP_PUBLISH_LOG="/tmp/sugar-publish-bootstrap.log"
   : >"${BOOTSTRAP_PUBLISH_LOG}" 2>/dev/null || true
 
-  local -a publish_cmd=(
-    avahi-publish
-    -s
-    "${publish_name}"
-    "${MDNS_SERVICE_TYPE}"
+  mapfile -t publish_cmd < <(
+    python3 - "${publish_name}" "${MDNS_SERVICE_TYPE}" "6443" "${MDNS_HOST_RAW:-}" \
+      "k3s=1" \
+      "cluster=${CLUSTER}" \
+      "env=${ENVIRONMENT}" \
+      "role=bootstrap" \
+      "leader=${MDNS_HOST_RAW}" \
+      "phase=bootstrap" \
+      "state=pending" <<'PY'
+import sys
+from mdns_helpers import build_publish_cmd
+
+instance, service_type, port, host, *txt_items = sys.argv[1:]
+port_int = int(port)
+host_value = host or None
+txt: dict[str, str] = {}
+for item in txt_items:
+    if not item:
+        continue
+    if "=" in item:
+        key, value = item.split("=", 1)
+    else:
+        key, value = item, ""
+    txt[key] = value
+cmd = build_publish_cmd(
+    instance=instance,
+    service_type=service_type,
+    port=port_int,
+    host=host_value,
+    txt=txt,
+)
+for part in cmd:
+    print(part)
+PY
   )
 
-  if [ -n "${MDNS_HOST_RAW}" ]; then
-    publish_cmd+=(-H "${MDNS_HOST_RAW}")
-  fi
-
-  publish_cmd+=(
-    6443
-    "k3s=1"
-    "cluster=${CLUSTER}"
-    "env=${ENVIRONMENT}"
-    "role=bootstrap"
-    "leader=${MDNS_HOST_RAW}"
-    "phase=bootstrap"
-    "state=pending"
-  )
-
-  local serialized=""
-  local arg=""
-  for arg in "${publish_cmd[@]}"; do
-    if [ -n "${serialized}" ]; then
-      serialized+="; "
-    fi
-    serialized+="$(printf '%q' "${arg}")"
-  done
-  log "avahi-publish bootstrap argv: [${serialized}]"
+  local publish_cmd_repr=""
+  publish_cmd_repr="$(python3 - "${publish_cmd[@]}" <<'PY'
+import shlex
+import sys
+print("[" + ", ".join(shlex.quote(arg) for arg in sys.argv[1:]) + "]")
+PY
+)"
+  log "avahi-publish bootstrap argv: ${publish_cmd_repr}"
 
   log "publishing bootstrap host=${MDNS_HOST_RAW} addr=${MDNS_ADDR_V4:-auto} type=${MDNS_SERVICE_TYPE}"
   "${publish_cmd[@]}" >"${BOOTSTRAP_PUBLISH_LOG}" 2>&1 &
@@ -559,36 +572,49 @@ start_server_publisher() {
   SERVER_PUBLISH_LOG="/tmp/sugar-publish-server.log"
   : >"${SERVER_PUBLISH_LOG}" 2>/dev/null || true
 
-  local -a publish_cmd=(
-    avahi-publish
-    -s
-    "${publish_name}"
-    "${MDNS_SERVICE_TYPE}"
+  mapfile -t publish_cmd < <(
+    python3 - "${publish_name}" "${MDNS_SERVICE_TYPE}" "6443" "${MDNS_HOST_RAW:-}" \
+      "k3s=1" \
+      "cluster=${CLUSTER}" \
+      "env=${ENVIRONMENT}" \
+      "role=server" \
+      "leader=${MDNS_HOST_RAW}" \
+      "phase=server" <<'PY'
+import sys
+from mdns_helpers import build_publish_cmd
+
+instance, service_type, port, host, *txt_items = sys.argv[1:]
+port_int = int(port)
+host_value = host or None
+txt: dict[str, str] = {}
+for item in txt_items:
+    if not item:
+        continue
+    if "=" in item:
+        key, value = item.split("=", 1)
+    else:
+        key, value = item, ""
+    txt[key] = value
+cmd = build_publish_cmd(
+    instance=instance,
+    service_type=service_type,
+    port=port_int,
+    host=host_value,
+    txt=txt,
+)
+for part in cmd:
+    print(part)
+PY
   )
 
-  if [ -n "${MDNS_HOST_RAW}" ]; then
-    publish_cmd+=(-H "${MDNS_HOST_RAW}")
-  fi
-
-  publish_cmd+=(
-    6443
-    "k3s=1"
-    "cluster=${CLUSTER}"
-    "env=${ENVIRONMENT}"
-    "role=server"
-    "leader=${MDNS_HOST_RAW}"
-    "phase=server"
-  )
-
-  local serialized=""
-  local arg=""
-  for arg in "${publish_cmd[@]}"; do
-    if [ -n "${serialized}" ]; then
-      serialized+="; "
-    fi
-    serialized+="$(printf '%q' "${arg}")"
-  done
-  log "avahi-publish server argv: [${serialized}]"
+  local publish_cmd_repr=""
+  publish_cmd_repr="$(python3 - "${publish_cmd[@]}" <<'PY'
+import shlex
+import sys
+print("[" + ", ".join(shlex.quote(arg) for arg in sys.argv[1:]) + "]")
+PY
+)"
+  log "avahi-publish server argv: ${publish_cmd_repr}"
 
   log "publishing server host=${MDNS_HOST_RAW} addr=${MDNS_ADDR_V4:-auto} type=${MDNS_SERVICE_TYPE}"
   "${publish_cmd[@]}" >"${SERVER_PUBLISH_LOG}" 2>&1 &
@@ -743,19 +769,41 @@ ensure_self_mdns_advertisement() {
 
   MDNS_LAST_OBSERVED=""
   local observed=""
+  local instance_name=""
+  instance_name="$(service_instance_name "${role}" "${MDNS_HOST_RAW}")"
+  local delay_ms=""
+  delay_ms="$(python3 - "${delay}" <<'PY'
+import sys
+
+try:
+    value = float(sys.argv[1])
+except Exception:
+    value = 0.0
+value = max(value, 0.0) * 1000.0
+print(int(round(value)))
+PY
+)"
+
   local -a mdns_check_base=(
-    python3 "${SCRIPT_DIR}/mdns_helpers.py"
-    --expect-host "${MDNS_HOST_RAW}"
-    --cluster "${CLUSTER}"
-    --env "${ENVIRONMENT}"
-    --require-phase "${require_phase}"
+    python3 "${SCRIPT_DIR}/mdns_selfcheck.py"
+    --instance "${instance_name}"
+    --type "${MDNS_SERVICE_TYPE}"
+    --domain "local"
+    --expected-host "${MDNS_HOST_RAW}"
     --retries "${retries}"
-    --delay "${delay}"
+    --delay-ms "${delay_ms}"
   )
+
+  if [ -n "${require_phase}" ]; then
+    mdns_check_base+=(--require-phase "${require_phase}")
+  fi
+  if [ -n "${role}" ]; then
+    mdns_check_base+=(--require-role "${role}")
+  fi
   local -a mdns_check=("${mdns_check_base[@]}")
   local used_expect_addr=0
   if [ -n "${MDNS_ADDR_V4}" ]; then
-    mdns_check+=(--expect-addr "${MDNS_ADDR_V4}")
+    mdns_check+=(--expected-addr "${MDNS_ADDR_V4}" --require-ipv4)
     used_expect_addr=1
   fi
 

--- a/scripts/mdns_helpers.py
+++ b/scripts/mdns_helpers.py
@@ -1,82 +1,15 @@
-"""Utilities for normalising and comparing mDNS hostnames."""
+"""Utilities for mDNS publishing and hostname normalization."""
 from __future__ import annotations
 
-import argparse
-import ipaddress
-import os
-import subprocess
-import sys
-import time
-from typing import (
-    TYPE_CHECKING,
-    Callable,
-    Final,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    TextIO,
-)
-
-if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
-    from k3s_mdns_parser import MdnsRecord
+from typing import Final, Mapping
 
 _LOCAL_SUFFIXES: Final = (".local",)
 _CONTROL_CHAR_MAP: Final = {i: None for i in range(32)}
 _CONTROL_CHAR_MAP.update({0x7F: None})
 
 
-def _determine_browse_timeout() -> float:
-    raw = os.environ.get("SUGARKUBE_MDNS_BROWSE_TIMEOUT", "")
-    if not raw:
-        return 1.5
-    try:
-        value = float(raw)
-    except ValueError:
-        return 1.5
-    return value if value > 0 else 1.5
-
-
-_DEFAULT_BROWSE_TIMEOUT: Final[float] = _determine_browse_timeout()
-
-Runner = Callable[..., subprocess.CompletedProcess[str]]
-SleepFn = Callable[[float], None]
-
-
-class _TimestampedLogger:
-    """Emit timestamped log lines to the requested streams."""
-
-    def __init__(
-        self,
-        *,
-        stderr: Optional[TextIO] = None,
-        stdout: Optional[TextIO] = None,
-    ) -> None:
-        self._stderr = stderr
-        self._stdout = stdout
-
-    @staticmethod
-    def _timestamp() -> str:
-        return time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime())
-
-    def err(self, message: str) -> None:
-        stream = self._stderr if self._stderr is not None else sys.stderr
-        print(f"{self._timestamp()} {message}", file=stream)
-
-    def out(self, message: str) -> None:
-        stream = self._stdout if self._stdout is not None else sys.stdout
-        print(f"{self._timestamp()} {message}", file=stream)
-
-
-_LOGGER = _TimestampedLogger()
-
-
-def _log(message: str) -> None:
-    _LOGGER.err(message)
-
-
-def normalize_hostname(host: str) -> str:
-    """Return a case-insensitive, dot-normalised hostname."""
+def norm_host(host: str | None) -> str:
+    """Return a lowercase hostname without a trailing period."""
 
     if not host:
         return ""
@@ -88,13 +21,19 @@ def normalize_hostname(host: str) -> str:
     return candidate.rstrip(".").lower()
 
 
-def _norm_host(host: str) -> str:
-    """Backwards-compatible alias for ``normalize_hostname``."""
+def normalize_hostname(host: str) -> str:
+    """Backwards compatible wrapper around :func:`norm_host`."""
 
-    return normalize_hostname(host)
+    return norm_host(host)
+
+
+# Backwards compatible alias for k3s_mdns_parser imports
+_norm_host = norm_host
 
 
 def _strip_local_suffix(host: str) -> str:
+    """Remove any trailing ``.local`` suffixes."""
+
     for suffix in _LOCAL_SUFFIXES:
         while host.endswith(suffix):
             host = host[: -len(suffix)]
@@ -102,10 +41,10 @@ def _strip_local_suffix(host: str) -> str:
 
 
 def _same_host(left: str, right: str) -> bool:
-    """Return True when two hosts refer to the same machine."""
+    """Return ``True`` if two host strings refer to the same machine."""
 
-    left_norm = normalize_hostname(left)
-    right_norm = normalize_hostname(right)
+    left_norm = norm_host(left)
+    right_norm = norm_host(right)
     if not left_norm or not right_norm:
         return False
 
@@ -115,443 +54,35 @@ def _same_host(left: str, right: str) -> bool:
     return _strip_local_suffix(left_norm) == _strip_local_suffix(right_norm)
 
 
-def build_publish_command(
+def build_publish_cmd(
     *,
     instance: str,
     service_type: str,
     port: int,
-    host: Optional[str],
+    host: str | None,
     txt: Mapping[str, str],
-) -> List[str]:
-    """Construct an ``avahi-publish`` command with discrete TXT arguments."""
+) -> list[str]:
+    """Construct an ``avahi-publish`` command in the documented order."""
 
-    command = ["avahi-publish", "-s", instance, service_type, str(port)]
+    command = ["avahi-publish", "-s"]
     if host:
-        command.append(host)
-
+        command.extend(["-H", host])
+    command.extend([instance, service_type, str(port)])
     if txt:
         for key, value in txt.items():
             command.append(f"{key}={value}")
-
     return command
 
 
-def _service_types(cluster: str, environment: str) -> List[str]:
-    service_type = f"_k3s-{cluster}-{environment}._tcp"
-    types = [service_type]
-    legacy = "_https._tcp"
-    if legacy not in types:
-        types.append(legacy)
-    return types
-
-
-def _categorise_addresses(addresses: Iterable[str]) -> List[str]:
-    categories: List[str] = []
-    for candidate in addresses:
-        try:
-            ip_obj = ipaddress.ip_address(candidate)
-        except ValueError:
-            categories.append("other")
-        else:
-            categories.append("ipv4" if ip_obj.version == 4 else "ipv6")
-    return categories
-
-
-def _describe_addr_mismatch(
-    expect_addr: str, observed_addrs: List[str], categories: List[str]
-) -> str:
-    if not observed_addrs:
-        return (
-            "Advertisement omitted addresses. Avahi may still be initialising or publishing via "
-            "another interface."
-        )
-
-    ipv4 = sorted({addr for addr, cat in zip(observed_addrs, categories) if cat == "ipv4"})
-    ipv6 = sorted({addr for addr, cat in zip(observed_addrs, categories) if cat == "ipv6"})
-    other = sorted({addr for addr, cat in zip(observed_addrs, categories) if cat == "other"})
-
-    if ipv4 and expect_addr not in ipv4:
-        return (
-            "Advertisement reported IPv4 address(es) %s that do not include expected %s. "
-            "Multiple interfaces (e.g. wlan0 vs eth0) or stale Avahi cache entries are likely."
-        ) % (", ".join(ipv4), expect_addr)
-
-    if not ipv4 and ipv6:
-        return (
-            "Advertisement only reported IPv6 address(es) %s. Ensure IPv4 is configured or allow IPv6 discovery."
-        ) % (", ".join(ipv6))
-
-    if other:
-        return (
-            "Advertisement reported non-IP address value(s) %s. Verify avahi-publish-address advertises IPv4."
-        ) % (", ".join(other))
-
-    return "Advertisement addresses did not match the expected value."
-
-
-def _browse_service_type(
-    service_type: str,
-    runner: Runner,
-    *,
-    resolve: bool = True,
-    timeout: float = _DEFAULT_BROWSE_TIMEOUT,
-) -> Iterable[str]:
-    command: List[str] = ["avahi-browse"]
-    flag = "-ptk"
-    if resolve:
-        flag = "-rptk"
-    command.extend([flag, service_type])
-    kwargs = {
-        "capture_output": True,
-        "text": True,
-        "check": False,
-    }
-
-    # Only pass a timeout when we are using subprocess.run directly, so that
-    # test doubles do not need to implement the parameter. Custom runners may
-    # still honour the timeout via **kwargs if they wish.
-    if runner is subprocess.run and timeout > 0:
-        kwargs["timeout"] = timeout
-
-    try:
-        result = runner(command, **kwargs)
-    except FileNotFoundError:
-        return []
-    except subprocess.TimeoutExpired as exc:
-        duration = exc.timeout if isinstance(exc.timeout, (int, float)) else timeout
-        _log(
-            (
-                "[k3s-discover mdns] WARN: avahi-browse timed out after %.1fs "
-                "while resolving %s"
-            )
-            % (duration, service_type)
-        )
-        return []
-    except TypeError:
-        # Some tests inject lightweight runners that do not accept a timeout
-        # parameter. Retry without the optional kwargs in that scenario.
-        kwargs.pop("timeout", None)
-        result = runner(command, **kwargs)
-
-    stdout = result.stdout if result.stdout else ""
-    return [line for line in stdout.splitlines() if line]
-
-
-def _collect_mdns_records(
-    cluster: str,
-    environment: str,
-    runner: Runner,
-) -> List["MdnsRecord"]:
-    from k3s_mdns_parser import parse_mdns_records
-    service_types = _service_types(cluster, environment)
-
-    resolved_lines: List[str] = []
-    for service_type in service_types:
-        lines = list(
-            _browse_service_type(
-                service_type,
-                runner,
-                resolve=True,
-                timeout=_DEFAULT_BROWSE_TIMEOUT,
-            )
-        )
-        if not lines:
-            continue
-        resolved_lines.extend(lines)
-
-    if resolved_lines:
-        records = parse_mdns_records(resolved_lines, cluster, environment)
-        if records:
-            return records
-
-    fallback_lines: List[str] = []
-    for service_type in service_types:
-        lines = list(
-            _browse_service_type(
-                service_type,
-                runner,
-                resolve=False,
-                timeout=_DEFAULT_BROWSE_TIMEOUT,
-            )
-        )
-        if not lines:
-            continue
-        fallback_lines.extend(lines)
-        # Match previous behaviour by returning as soon as unresolved records are
-        # observed for any service type. This preserves call expectations in the
-        # tests and avoids unnecessary avahi-browse invocations.
-        break
-
-    if fallback_lines:
-        records = parse_mdns_records(fallback_lines, cluster, environment)
-        if records:
-            return records
-
-    return []
-
-
-def ensure_self_ad_is_visible(
-    *,
-    expected_host: str,
-    cluster: str,
-    env: str,
-    retries: int = 5,
-    delay: float = 1.0,
-    require_phase: Optional[str] = None,
-    expect_addr: Optional[str] = None,
-    runner: Optional[Runner] = None,
-    sleep: SleepFn = time.sleep,
-) -> Optional[str]:
-    """Return the observed host when the local advertisement is visible."""
-
-    expected_norm = normalize_hostname(expected_host)
-    if not expected_norm:
-        return None
-
-    attempts = max(retries, 1)
-    delay = max(delay, 0.0)
-
-    expect_addr = (expect_addr or "").strip() or None
-
-    fallback_candidate: Optional[str] = None
-    fallback_addr: Optional[str] = None
-    host_only_candidate: Optional[str] = None
-    host_only_value: Optional[str] = None
-
-    if runner is None:
-        runner = subprocess.run  # type: ignore[assignment]
-
-    for attempt in range(1, attempts + 1):
-        records = _collect_mdns_records(cluster, env, runner)
-        if not records:
-            _log(
-                "[k3s-discover mdns] Attempt %d/%d: no mDNS records discovered for cluster=%s env=%s"
-                % (attempt, attempts, cluster, env)
-            )
-            if attempt < attempts and delay > 0:
-                _log(
-                    "[k3s-discover mdns] Attempt %d/%d: retrying in %.1fs"
-                    % (attempt, attempts, delay)
-                )
-                sleep(delay)
-            continue
-
-        _log(
-            "[k3s-discover mdns] Attempt %d/%d: collected %d record(s) for cluster=%s env=%s"
-            % (attempt, attempts, len(records), cluster, env)
-        )
-
-        host_match_found = False
-        diag_messages: List[str] = []
-        observed_hosts: List[str] = []
-
-        for record in records:
-            observed_hosts.append(record.host)
-            txt = record.txt
-
-            phase = txt.get("phase")
-            role = txt.get("role")
-            leader_raw = txt.get("leader", "")
-            record_norm = normalize_hostname(record.host)
-            leader_norm = normalize_hostname(leader_raw)
-            record_stripped = _strip_local_suffix(record_norm) if record_norm else ""
-            leader_stripped = _strip_local_suffix(leader_norm) if leader_norm else ""
-            expected_stripped = _strip_local_suffix(expected_norm)
-
-            if require_phase is not None:
-                phase_matches = phase == require_phase
-                role_matches = role == require_phase if role else False
-                if not (phase_matches or (phase is None and role_matches)):
-                    diag_messages.append(
-                        (
-                            "[k3s-discover mdns] Attempt %d/%d: skipped host %s "
-                            "because require_phase=%s (phase=%s role=%s)"
-                        )
-                        % (
-                            attempt,
-                            attempts,
-                            record.host or "<none>",
-                            require_phase,
-                            phase or "<missing>",
-                            role or "<missing>",
-                        )
-                    )
-                    continue
-            host_match = _same_host(record.host, expected_norm)
-            leader_match = _same_host(leader_raw, expected_norm)
-            if not (host_match or leader_match):
-                reason_bits: List[str] = []
-                if not host_match:
-                    reason_bits.append("host")
-                if leader_raw:
-                    if not leader_match:
-                        reason_bits.append("leader")
-                else:
-                    reason_bits.append("leader-missing")
-                reason = ", ".join(reason_bits) if reason_bits else "unknown"
-                diag_messages.append(
-                    (
-                        "[k3s-discover mdns] Attempt %d/%d: rejected host candidate %s "
-                        "(norm=%s stripped=%s) leader=%s (norm=%s stripped=%s) "
-                        "expected=%s (norm=%s stripped=%s); reason=%s"
-                    )
-                    % (
-                        attempt,
-                        attempts,
-                        record.host or "<none>",
-                        record_norm or "<empty>",
-                        record_stripped or "<empty>",
-                        leader_raw or "<none>",
-                        leader_norm or "<empty>",
-                        leader_stripped or "<empty>",
-                        expected_host,
-                        expected_norm,
-                        expected_stripped or "<empty>",
-                        reason,
-                    )
-                )
-                continue
-
-            host_match_found = True
-
-            if expect_addr:
-                record_addr = record.address.strip()
-                txt_addr = txt.get("a", "").strip()
-                txt_addr_alt = txt.get("addr", "").strip()
-                observed_addrs = [
-                    addr for addr in (record_addr, txt_addr, txt_addr_alt) if addr
-                ]
-                if expect_addr in observed_addrs:
-                    return record.host
-
-                categories = _categorise_addresses(observed_addrs)
-
-                if fallback_candidate is None and "ipv6" in categories and "ipv4" not in categories:
-                    fallback_candidate = record.host
-                    for candidate, category in zip(observed_addrs, categories):
-                        if category == "ipv6":
-                            fallback_addr = candidate
-                            break
-                if host_only_candidate is None and (
-                    not observed_addrs
-                    or (
-                        "other" in categories
-                        and "ipv4" not in categories
-                        and "ipv6" not in categories
-                    )
-                ):
-                    host_only_candidate = record.host
-                    host_only_value = observed_addrs[0] if observed_addrs else None
-
-                observed_text = ", ".join(observed_addrs) if observed_addrs else "<none>"
-                reason = _describe_addr_mismatch(expect_addr, observed_addrs, categories)
-                diag_messages.append(
-                    (
-                        "[k3s-discover mdns] Attempt %d/%d: observed host %s (phase=%s role=%s) "
-                        "with addresses %s; expected %s. %s"
-                        % (
-                            attempt,
-                            attempts,
-                            record.host,
-                            phase or "<unknown>",
-                            role or "<unknown>",
-                            observed_text,
-                            expect_addr,
-                            reason,
-                        )
-                    )
-                )
-                continue
-
-            return record.host
-
-        for message in diag_messages:
-            _log(message)
-
-        if not host_match_found:
-            unique_hosts = sorted({
-                normalize_hostname(host) for host in observed_hosts if host
-            })
-            observed_text = ", ".join(unique_hosts) if unique_hosts else "<none>"
-            _log(
-                "[k3s-discover mdns] Attempt %d/%d: observed hosts %s but none matched expected %s"
-                % (attempt, attempts, observed_text, expected_norm)
-            )
-
-        if attempt < attempts and delay > 0:
-            _log(
-                "[k3s-discover mdns] Attempt %d/%d did not confirm advertisement; retrying in %.1fs"
-                % (attempt, attempts, delay)
-            )
-            sleep(delay)
-
-    if fallback_candidate and expect_addr:
-        mismatch = fallback_addr or "<unknown>"
-        _log(
-            (
-                "[k3s-discover mdns] WARN: expected IPv4 %s for %s but "
-                "observed %s; assuming match after %d attempts"
-            )
-            % (expect_addr, expected_norm, mismatch, attempts)
-        )
-        return fallback_candidate
-
-    if host_only_candidate and expect_addr:
-        if host_only_value:
-            message = (
-                "[k3s-discover mdns] WARN: expected IPv4 %s for %s but "
-                "advertisement reported non-IP %s; assuming match after %d attempts"
-            ) % (expect_addr, expected_norm, host_only_value, attempts)
-        else:
-            message = (
-                "[k3s-discover mdns] WARN: expected IPv4 %s for %s but "
-                "advertisement omitted address; assuming match after %d attempts"
-            ) % (expect_addr, expected_norm, attempts)
-        _log(message)
-        return host_only_candidate
-
-    return None
-
-
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--expect-host", required=True)
-    parser.add_argument("--cluster", required=True)
-    parser.add_argument("--env", required=True)
-    parser.add_argument("--require-phase", choices=["bootstrap", "server"], default=None)
-    parser.add_argument("--retries", type=int, default=5)
-    parser.add_argument("--delay", type=float, default=1.0)
-    parser.add_argument("--expect-addr", default=None)
-    return parser
-
-
-def _main() -> int:
-    parser = _build_parser()
-    args = parser.parse_args()
-
-    observed = ensure_self_ad_is_visible(
-        expected_host=args.expect_host,
-        cluster=args.cluster,
-        env=args.env,
-        retries=args.retries,
-        delay=args.delay,
-        require_phase=args.require_phase,
-        expect_addr=args.expect_addr,
-    )
-    if observed:
-        _LOGGER.out(observed)
-        return 0
-    return 1
-
-
-if __name__ == "__main__":  # pragma: no cover - CLI entry point
-    raise SystemExit(_main())
+# Preserve the previous public name for compatibility with older callers.
+build_publish_command = build_publish_cmd
 
 
 __all__ = [
+    "build_publish_cmd",
+    "build_publish_command",
+    "norm_host",
+    "normalize_hostname",
     "_norm_host",
     "_same_host",
-    "ensure_self_ad_is_visible",
-    "normalize_hostname",
-    "build_publish_command",
 ]

--- a/scripts/mdns_selfcheck.py
+++ b/scripts/mdns_selfcheck.py
@@ -1,43 +1,608 @@
 #!/usr/bin/env python3
-"""List published k3s mDNS records for debugging."""
+"""Resolve k3s mDNS advertisements and verify their TXT metadata."""
+from __future__ import annotations
 
-import json
-import os
+import argparse
+import ipaddress
+import shlex
 import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Optional, Sequence
 
-from k3s_mdns_parser import parse_mdns_records
+from mdns_helpers import norm_host
+
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+Record = Dict[str, object]
+
+
+@dataclass
+class TimestampedLogger:
+    stderr: Optional[object] = None
+
+    def _stream(self) -> object:
+        return self.stderr if self.stderr is not None else sys.stderr
+
+    @staticmethod
+    def _timestamp() -> str:
+        return time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime())
+
+    def log(self, message: str) -> None:
+        print(f"{self._timestamp()} {message}", file=self._stream())
+
+
+def _strip_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    return value
+
+
+def _parse_txt_tokens(tokens: Iterable[str]) -> Dict[str, str]:
+    txt: Dict[str, str] = {}
+    for token in tokens:
+        if not token:
+            continue
+        entry = token.strip()
+        if not entry:
+            continue
+        fragments = [fragment.strip() for fragment in entry.split(",") if fragment.strip()]
+        if not fragments:
+            fragments = [entry]
+        for fragment in fragments:
+            item = fragment
+            if item.lower().startswith("txt="):
+                item = item[4:]
+            if "=" in item:
+                key, value = item.split("=", 1)
+            else:
+                key, value = item, ""
+            key = _strip_quotes(key.strip()).lower()
+            value = _strip_quotes(value.strip())
+            if key:
+                txt[key] = value
+    return txt
+
+
+def resolve_with_resolvectl(
+    instance: str,
+    service_type: str,
+    *,
+    domain: str = "local",
+    runner: Optional[Runner] = None,
+) -> List[Record]:
+    """Resolve a service instance via ``resolvectl service``."""
+
+    command = ["resolvectl", "service", instance, service_type, domain, "--legend=no"]
+    executor = runner or subprocess.run
+    try:
+        result = executor(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return []
+
+    stdout = result.stdout or ""
+    if not stdout.strip():
+        return []
+
+    records: List[Record] = []
+    current: Optional[Record] = None
+
+    def ensure_current() -> Record:
+        nonlocal current
+        if current is None:
+            current = {
+                "instance": instance,
+                "type": service_type,
+                "domain": domain,
+                "host": "",
+                "addr": "",
+                "port": None,
+                "txt": {},
+                "raw": [],
+                "addresses": [],
+            }
+        return current
+
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            if current is not None:
+                current["raw"] = "\n".join(current["raw"])  # type: ignore[index]
+                records.append(current)
+                current = None
+            continue
+
+        record = ensure_current()
+        record["raw"].append(raw_line)  # type: ignore[index]
+        lower = line.lower()
+
+        if lower.startswith("txt"):
+            payload = ""
+            if ":" in line:
+                payload = line.split(":", 1)[1].strip()
+            elif " " in line:
+                payload = line.split(None, 1)[1].strip()
+            tokens = shlex.split(payload) if payload else []
+            txt_values = _parse_txt_tokens(tokens)
+            if txt_values:
+                record_txt = record["txt"]  # type: ignore[assignment]
+                record_txt.update(txt_values)
+            continue
+
+        if any(lower.startswith(prefix) for prefix in ("target", "host")):
+            if "=" in line:
+                record["host"] = line.split("=", 1)[1].strip()
+            elif " " in line:
+                record["host"] = line.split(None, 1)[1].strip()
+            continue
+
+        if ":" in line and not line.startswith(";;"):
+            host_candidate, _, remainder = line.partition(":")
+            port_token = remainder.strip().split()[0] if remainder.strip() else ""
+            if port_token.isdigit():
+                record["host"] = host_candidate.strip()
+                record["port"] = int(port_token)
+
+        for token in line.replace("=", " ").replace(",", " ").split():
+            candidate = token.strip("[]")
+            try:
+                ip_obj = ipaddress.ip_address(candidate)
+            except ValueError:
+                continue
+            addresses: List[str] = record["addresses"]  # type: ignore[assignment]
+            addresses.append(str(ip_obj))
+            addr = record.get("addr", "")
+            if ip_obj.version == 4 or not addr:
+                record["addr"] = str(ip_obj)
+
+    if current is not None:
+        current["raw"] = "\n".join(current["raw"])  # type: ignore[index]
+        records.append(current)
+
+    for record in records:
+        if isinstance(record.get("raw"), list):
+            record["raw"] = "\n".join(record["raw"])  # type: ignore[index]
+    return records
+
+
+def _parse_avahi_line(line: str) -> Optional[Record]:
+    if not line or line[0] != "=":
+        return None
+    fields = line.split(";")
+    if len(fields) < 9:
+        return None
+
+    instance = _strip_quotes(fields[3])
+    service_type = fields[4]
+    domain = fields[5] or "local"
+    host = _strip_quotes(fields[6])
+    addr = _strip_quotes(fields[7])
+    port_field = fields[8]
+    try:
+        port = int(port_field)
+    except ValueError:
+        port = None
+
+    txt = _parse_txt_tokens(field for field in fields[9:] if field.startswith("txt="))
+    record: Record = {
+        "instance": instance,
+        "type": service_type,
+        "domain": domain,
+        "host": host,
+        "addr": addr,
+        "port": port,
+        "txt": txt,
+        "raw": line,
+    }
+    addresses: List[str] = []
+    if addr:
+        addresses.append(addr)
+    record["addresses"] = addresses
+    return record
+
+
+def resolve_with_avahi_browse(
+    service_type: str,
+    *,
+    domain: str = "local",
+    runner: Optional[Runner] = None,
+) -> List[Record]:
+    """Resolve service records using ``avahi-browse``."""
+
+    command = ["avahi-browse", "-rptk", service_type, "-d", domain]
+    executor = runner or subprocess.run
+    try:
+        result = executor(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return []
+
+    stdout = result.stdout or ""
+    records: List[Record] = []
+    for line in stdout.splitlines():
+        if not line:
+            continue
+        record = _parse_avahi_line(line)
+        if record is not None:
+            records.append(record)
+    return records
+
+
+def _has_txt(records: Sequence[Record]) -> bool:
+    for record in records:
+        txt = record.get("txt")
+        if isinstance(txt, dict) and txt:
+            return True
+    return False
+
+
+def gather_records(
+    *,
+    instance: str,
+    service_type: str,
+    domain: str,
+    resolvectl_runner: Optional[Runner],
+    avahi_runner: Optional[Runner],
+    logger: Optional[TimestampedLogger],
+) -> List[Record]:
+    records = resolve_with_resolvectl(
+        instance,
+        service_type,
+        domain=domain,
+        runner=resolvectl_runner,
+    )
+    if records and _has_txt(records):
+        return records
+
+    if logger is not None:
+        logger.log(
+            "[mdns-selfcheck] resolvectl did not return TXT data; falling back to avahi-browse"
+        )
+
+    fallback = resolve_with_avahi_browse(
+        service_type,
+        domain=domain,
+        runner=avahi_runner,
+    )
+    instance_norm = norm_host(instance)
+    filtered: List[Record] = []
+    for record in fallback:
+        observed = norm_host(str(record.get("instance", "")))
+        if observed == instance_norm:
+            filtered.append(record)
+    return filtered
+
+
+def _match_host(record: Record, expected_host: str) -> bool:
+    if not expected_host:
+        return True
+    host = str(record.get("host", ""))
+    host_norm = norm_host(host)
+    expected_norm = norm_host(expected_host)
+    if host_norm == expected_norm:
+        return True
+
+    txt = record.get("txt")
+    if isinstance(txt, dict):
+        leader = norm_host(str(txt.get("leader", "")))
+        if leader and leader == expected_norm:
+            return True
+    return False
+
+
+def _log_host_mismatch(
+    record: Record,
+    expected_host: str,
+    logger: Optional[TimestampedLogger],
+    attempt: int,
+    retries: int,
+) -> None:
+    if logger is None or not expected_host:
+        return
+    host = str(record.get("host", ""))
+    txt = record.get("txt") if isinstance(record.get("txt"), dict) else {}
+    leader = ""
+    if isinstance(txt, dict):
+        leader = str(txt.get("leader", ""))
+    message = (
+        "[mdns-selfcheck] Attempt %d/%d: skipped instance %s due to host mismatch "
+        "(host raw='%s' norm='%s', leader raw='%s' norm='%s', expected raw='%s' norm='%s')"
+        % (
+            attempt,
+            retries,
+            record.get("instance", ""),
+            host or "<missing>",
+            norm_host(host) or "<empty>",
+            leader or "<missing>",
+            norm_host(leader) or "<empty>",
+            expected_host,
+            norm_host(expected_host) or "<empty>",
+        )
+    )
+    logger.log(message)
+
+
+def _log_phase_issue(
+    *,
+    record: Record,
+    required_phase: Optional[str],
+    required_role: Optional[str],
+    logger: Optional[TimestampedLogger],
+    attempt: int,
+    retries: int,
+) -> None:
+    if logger is None:
+        return
+    txt = record.get("txt") if isinstance(record.get("txt"), dict) else {}
+    phase = txt.get("phase", "<missing>") if isinstance(txt, dict) else "<missing>"
+    role = txt.get("role", "<missing>") if isinstance(txt, dict) else "<missing>"
+    logger.log(
+        "[mdns-selfcheck] Attempt %d/%d: skipped instance %s due to phase/role mismatch "
+        "(required phase=%s role=%s, observed phase=%s role=%s)"
+        % (
+            attempt,
+            retries,
+            record.get("instance", ""),
+            required_phase or "<any>",
+            required_role or "<any>",
+            phase,
+            role,
+        )
+    )
+
+
+def _log_address_issue(
+    *,
+    record: Record,
+    expected_addr: str,
+    require_ipv4: bool,
+    logger: Optional[TimestampedLogger],
+    attempt: int,
+    retries: int,
+) -> None:
+    if logger is None:
+        return
+    addr = str(record.get("addr", ""))
+    addresses = record.get("addresses", [])
+    if isinstance(addresses, list) and addresses:
+        observed = ", ".join(addresses)
+    else:
+        observed = addr or "<missing>"
+    logger.log(
+        "[mdns-selfcheck] Attempt %d/%d: skipped instance %s due to address mismatch "
+        "(expected=%s require_ipv4=%s observed=%s)"
+        % (
+            attempt,
+            retries,
+            record.get("instance", ""),
+            expected_addr or "<none>",
+            "yes" if require_ipv4 else "no",
+            observed,
+        )
+    )
+
+
+def select_record(
+    records: Sequence[Record],
+    *,
+    expected_host: str,
+    required_phase: Optional[str],
+    required_role: Optional[str],
+    expected_addr: str,
+    require_ipv4: bool,
+    logger: Optional[TimestampedLogger],
+    attempt: int,
+    retries: int,
+) -> Optional[Record]:
+    for record in records:
+        if expected_host and not _match_host(record, expected_host):
+            _log_host_mismatch(record, expected_host, logger, attempt, retries)
+            continue
+
+        txt = record.get("txt") if isinstance(record.get("txt"), dict) else {}
+        phase = txt.get("phase") if isinstance(txt, dict) else None
+        role = txt.get("role") if isinstance(txt, dict) else None
+
+        if required_phase and phase != required_phase:
+            _log_phase_issue(
+                record=record,
+                required_phase=required_phase,
+                required_role=required_role,
+                logger=logger,
+                attempt=attempt,
+                retries=retries,
+            )
+            continue
+
+        if required_role and role != required_role:
+            _log_phase_issue(
+                record=record,
+                required_phase=required_phase,
+                required_role=required_role,
+                logger=logger,
+                attempt=attempt,
+                retries=retries,
+            )
+            continue
+
+        addr = str(record.get("addr", ""))
+        if expected_addr and addr != expected_addr:
+            _log_address_issue(
+                record=record,
+                expected_addr=expected_addr,
+                require_ipv4=require_ipv4,
+                logger=logger,
+                attempt=attempt,
+                retries=retries,
+            )
+            continue
+
+        if require_ipv4:
+            try:
+                ip_obj = ipaddress.ip_address(addr)
+            except ValueError:
+                _log_address_issue(
+                    record=record,
+                    expected_addr=expected_addr,
+                    require_ipv4=require_ipv4,
+                    logger=logger,
+                    attempt=attempt,
+                    retries=retries,
+                )
+                continue
+            if ip_obj.version != 4:
+                _log_address_issue(
+                    record=record,
+                    expected_addr=expected_addr,
+                    require_ipv4=require_ipv4,
+                    logger=logger,
+                    attempt=attempt,
+                    retries=retries,
+                )
+                continue
+
+        return record
+    return None
+
+
+def run_selfcheck(
+    *,
+    instance: str,
+    service_type: str,
+    domain: str,
+    expected_host: str,
+    required_phase: Optional[str],
+    required_role: Optional[str],
+    expected_addr: str,
+    require_ipv4: bool,
+    retries: int,
+    delay: float,
+    resolvectl_runner: Optional[Runner] = None,
+    avahi_runner: Optional[Runner] = None,
+    logger: Optional[TimestampedLogger] = None,
+) -> Optional[Record]:
+    attempts = max(retries, 1)
+    delay = max(delay, 0.0)
+    active_logger = logger or TimestampedLogger()
+
+    for attempt in range(1, attempts + 1):
+        records = gather_records(
+            instance=instance,
+            service_type=service_type,
+            domain=domain,
+            resolvectl_runner=resolvectl_runner,
+            avahi_runner=avahi_runner,
+            logger=active_logger,
+        )
+
+        if not records:
+            active_logger.log(
+                "[mdns-selfcheck] Attempt %d/%d: no records discovered for instance %s type %s"
+                % (attempt, attempts, instance, service_type)
+            )
+        else:
+            active_logger.log(
+                "[mdns-selfcheck] Attempt %d/%d: discovered %d record(s)"
+                % (attempt, attempts, len(records))
+            )
+            match = select_record(
+                records,
+                expected_host=expected_host,
+                required_phase=required_phase,
+                required_role=required_role,
+                expected_addr=expected_addr,
+                require_ipv4=require_ipv4,
+                logger=active_logger,
+                attempt=attempt,
+                retries=attempts,
+            )
+            if match is not None:
+                return match
+
+        if attempt < attempts and delay > 0:
+            active_logger.log(
+                "[mdns-selfcheck] Attempt %d/%d did not match filters; retrying in %.2fs"
+                % (attempt, attempts, delay)
+            )
+            time.sleep(delay)
+
+    return None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--instance", required=True)
+    parser.add_argument("--type", dest="service_type", required=True)
+    parser.add_argument("--domain", default="local")
+    parser.add_argument("--expected-host", default="")
+    parser.add_argument("--expected-addr", default="")
+    parser.add_argument("--require-phase", default=None)
+    parser.add_argument("--require-role", default=None)
+    parser.add_argument("--require-ipv4", action="store_true")
+    parser.add_argument("--retries", type=int, default=5)
+    parser.add_argument("--delay-ms", type=float, default=500.0)
+    parser.add_argument("--print-json", action="store_true")
+    return parser
 
 
 def main() -> int:
-    cluster = os.environ.get("SUGARKUBE_CLUSTER", "sugar")
-    environment = os.environ.get("SUGARKUBE_ENV", "dev")
-    service_type = f"_k3s-{cluster}-{environment}._tcp"
+    parser = _build_parser()
+    args = parser.parse_args()
 
-    proc = subprocess.run(
-        ["avahi-browse", "-rptk", service_type],
-        check=False,
-        capture_output=True,
-        text=True,
+    logger = TimestampedLogger()
+    match = run_selfcheck(
+        instance=args.instance,
+        service_type=args.service_type,
+        domain=args.domain,
+        expected_host=args.expected_host,
+        required_phase=args.require_phase,
+        required_role=args.require_role,
+        expected_addr=args.expected_addr,
+        require_ipv4=args.require_ipv4,
+        retries=args.retries,
+        delay=args.delay_ms / 1000.0,
+        logger=logger,
     )
 
-    lines = [line for line in proc.stdout.splitlines() if line]
-    records = parse_mdns_records(lines, cluster, environment)
+    if match is None:
+        return 1
 
-    payload = []
-    for record in records:
-        entry = {
-            "host": record.host,
-            "ipv4": record.address if record.address and ":" not in record.address else "",
-            "port": record.port,
+    if args.print_json:
+        import json
+
+        safe_match = {
+            "instance": match.get("instance"),
+            "type": match.get("type"),
+            "domain": match.get("domain"),
+            "host": match.get("host"),
+            "addr": match.get("addr"),
+            "port": match.get("port"),
+            "txt": match.get("txt"),
         }
-        for key in ("phase", "role", "leader", "host"):
-            if key in record.txt:
-                entry[key] = record.txt[key]
-        payload.append(entry)
-
-    print(json.dumps(payload, indent=2))
-    return proc.returncode
+        print(json.dumps(safe_match, indent=2))
+    else:
+        print(match.get("host", ""))
+    return 0
 
 
 if __name__ == "__main__":
     raise SystemExit(main())
+
+
+__all__ = [
+    "gather_records",
+    "resolve_with_avahi_browse",
+    "resolve_with_resolvectl",
+    "run_selfcheck",
+    "select_record",
+]

--- a/tests/scripts/test_mdns_helpers.py
+++ b/tests/scripts/test_mdns_helpers.py
@@ -1,453 +1,129 @@
-import subprocess
+import io
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
-from k3s_mdns_parser import _parse_txt_fields  # noqa: E402
-from mdns_helpers import (  # noqa: E402
-    _same_host,
-    build_publish_command,
-    ensure_self_ad_is_visible,
-    normalize_hostname,
-)
+
+import mdns_selfcheck  # noqa: E402
+from k3s_mdns_parser import parse_mdns_records  # noqa: E402
+from mdns_helpers import _same_host, build_publish_cmd, norm_host  # noqa: E402
 
 
-def _make_runner(stdout_by_service):
-    def _runner(cmd, capture_output=True, text=True, check=False, **kwargs):
-        service_type = cmd[-1]
-        stdout = stdout_by_service.get(service_type, "")
-        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
-
-    return _runner
-
-
-def test_normalize_hostname_strips_trailing_dot_and_is_case_insensitive():
-    assert normalize_hostname("Host.LOCAL.") == "host.local"
-    assert normalize_hostname("host.local.") == "host.local"
-    assert normalize_hostname("HOST") == "host"
-
-
-def test_same_host_normalises_case_and_trailing_dots():
-    assert _same_host("Host.LOCAL.", "host.local")
-    assert _same_host("host.local", "HOST")
-    assert not _same_host("host-a", "host-b")
-
-
-def test_same_host_accepts_repeated_local_suffix():
-    assert _same_host("Host.LOCAL.local", "host.local")
-    assert _same_host("host.local.local", "HOST")
-
-
-def test_same_host_strips_control_characters():
-    assert _same_host("host0.local\x00", "host0.local")
-    assert _same_host("\x07host1.local", "host1")
-
-
-def test_host_equality_uses_eq_not_identity():
-    left = "".join(["sugar", "cube", ".local"])
-    right = "sugar" + "cube" + ".local"
-    assert left is not right
-    assert _same_host(left, right)
-
-
-def test_txt_parsing_handles_multiple_trailing_args():
-    fields = [
-        "txt=phase=bootstrap",
-        "txt=role=candidate",
-        "txt=leader=sugarkube0.local",
-        "txt=host=sugarkube0.local",
-    ]
-    txt = _parse_txt_fields(fields)
-    assert txt == {
-        "phase": "bootstrap",
-        "role": "candidate",
-        "leader": "sugarkube0.local",
-        "host": "sugarkube0.local",
-    }
-
-
-def test_txt_parsing_handles_single_concatenated_string():
-    fields = ["txt=phase=bootstrap,role=candidate,leader=sugarkube0.local,host=sugarkube0.local"]
-    txt = _parse_txt_fields(fields)
-    assert txt == {
-        "phase": "bootstrap",
-        "role": "candidate",
-        "leader": "sugarkube0.local",
-        "host": "sugarkube0.local",
-    }
-
-
-def test_publish_command_includes_discrete_txt_arguments():
-    cmd = build_publish_command(
-        instance="sugar/dev bootstrap",
-        service_type="_k3s-sugar-dev._tcp",
+def test_build_publish_cmd_orders_args_correctly():
+    cmd = build_publish_cmd(
+        instance="X",
+        service_type="_http._tcp",
         port=6443,
-        host="sugarkube0.local",
-        txt={
-            "phase": "bootstrap",
-            "role": "candidate",
-            "leader": "none",
-            "host": "sugarkube0.local",
-        },
+        host="h.local",
+        txt={"phase": "bootstrap", "role": "candidate"},
     )
-    assert cmd == [
-        "avahi-publish",
-        "-s",
-        "sugar/dev bootstrap",
-        "_k3s-sugar-dev._tcp",
-        "6443",
-        "sugarkube0.local",
-        "phase=bootstrap",
-        "role=candidate",
-        "leader=none",
-        "host=sugarkube0.local",
-    ]
+    assert cmd[:3] == ["avahi-publish", "-s", "-H"]
+    assert cmd[3] == "h.local"
+    assert cmd[4:7] == ["X", "_http._tcp", "6443"]
+    assert "phase=bootstrap" in cmd and "role=candidate" in cmd
 
 
-def test_ensure_self_ad_is_visible_filters_by_phase():
-    bootstrap_record = (
-        "=;eth0;IPv4;k3s-sugar-dev@host0 (bootstrap);_k3s-sugar-dev._tcp;"
-        "local;host0.local;192.0.2.10;6443;"
-        "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=bootstrap;"
-        "txt=leader=host0.local;txt=phase=bootstrap\n"
+def test_norm_host_strips_trailing_dot_and_lowercases():
+    assert norm_host("Sugarkube0.LOCAL.") == "sugarkube0.local"
+
+
+def test_same_host_handles_control_characters():
+    assert _same_host("host0.local\x00", "HOST0.LOCAL")
+
+
+def test_parse_mdns_records_extracts_phase_and_role_from_txt():
+    line = (
+        "=;eth0;IPv4;k3s-sugar-dev@host0 (server);_k3s-sugar-dev._tcp;local;"
+        "host0.local.;192.0.2.10;6443;txt=k3s=1;txt=cluster=sugar;txt=env=dev;"
+        "txt=phase=server;txt=role"
     )
-    server_record = (
-        "=;eth0;IPv4;k3s-sugar-dev@host0 (server);_k3s-sugar-dev._tcp;"
-        "local;host0.local;192.0.2.10;6443;"
-        "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=server;"
-        "txt=leader=host0.local;txt=phase=server\n"
-    )
-
-    runner = _make_runner({
-        "_k3s-sugar-dev._tcp": bootstrap_record + server_record,
-        "_https._tcp": "",
-    })
-
-    observed_bootstrap = ensure_self_ad_is_visible(
-        expected_host="HOST0.LOCAL.",
-        cluster="sugar",
-        env="dev",
-        retries=1,
-        delay=0,
-        require_phase="bootstrap",
-        runner=runner,
-        sleep=lambda _: None,
-    )
-    assert observed_bootstrap == "host0.local"
-
-    observed_server = ensure_self_ad_is_visible(
-        expected_host="host0.local",
-        cluster="sugar",
-        env="dev",
-        retries=1,
-        delay=0,
-        require_phase="server",
-        runner=runner,
-        sleep=lambda _: None,
-    )
-    assert observed_server == "host0.local"
-
-    missing_server = ensure_self_ad_is_visible(
-        expected_host="host0.local",
-        cluster="sugar",
-        env="dev",
-        retries=1,
-        delay=0,
-        require_phase="server",
-        runner=_make_runner({"_k3s-sugar-dev._tcp": bootstrap_record}),
-        sleep=lambda _: None,
-    )
-    assert missing_server is None
+    records = parse_mdns_records([line], "sugar", "dev")
+    assert len(records) == 1
+    record = records[0]
+    assert record.txt["phase"] == "server"
+    assert record.txt["role"] == "server"
 
 
-def test_ensure_self_ad_is_visible_matches_expected_address():
-    record = (
-        "=;eth0;IPv4;k3s-sugar-dev@host0 (server);_k3s-sugar-dev._tcp;"
-        "local;host0.local;192.0.2.10;6443;"
-        "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=server;"
-        "txt=leader=host0.local;txt=phase=server\n"
-    )
-
-    runner = _make_runner({"_k3s-sugar-dev._tcp": record})
-
-    observed = ensure_self_ad_is_visible(
-        expected_host="host0.local",
-        cluster="sugar",
-        env="dev",
-        retries=1,
-        delay=0,
-        require_phase="server",
-        expect_addr="192.0.2.10",
-        runner=runner,
-        sleep=lambda _: None,
-    )
-    assert observed == "host0.local"
-
-    missing = ensure_self_ad_is_visible(
-        expected_host="host0.local",
-        cluster="sugar",
-        env="dev",
-        retries=1,
-        delay=0,
-        require_phase="server",
-        expect_addr="192.0.2.250",
-        runner=runner,
-        sleep=lambda _: None,
-    )
-    assert missing is None
-
-
-def test_ensure_self_ad_is_visible_accepts_missing_address(capsys):
-    record = (
-        "=;eth0;IPv4;k3s-sugar-dev@host0 (bootstrap);_k3s-sugar-dev._tcp;"
-        "local;host0.local;;6443;"
-        "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=bootstrap;"
-        "txt=leader=host0.local;txt=phase=bootstrap\n"
-    )
-
-    runner = _make_runner({"_k3s-sugar-dev._tcp": record})
-
-    observed = ensure_self_ad_is_visible(
-        expected_host="host0.local",
-        cluster="sugar",
-        env="dev",
-        retries=1,
-        delay=0,
-        require_phase="bootstrap",
-        expect_addr="192.0.2.10",
-        runner=runner,
-        sleep=lambda _: None,
-    )
-
-    assert observed == "host0.local"
-    warning = capsys.readouterr().err
-    assert "advertisement omitted address" in warning
-
-
-def test_ensure_self_ad_is_visible_accepts_hostname_address(capsys):
-    record = (
-        "=;eth0;IPv4;k3s-sugar-dev@host0 (server);_k3s-sugar-dev._tcp;"
-        "local;host0.local;host0.local;6443;"
-        "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=server;"
-        "txt=leader=host0.local;txt=phase=server\n"
-    )
-
-    runner = _make_runner({"_k3s-sugar-dev._tcp": record})
-
-    observed = ensure_self_ad_is_visible(
-        expected_host="host0.local",
-        cluster="sugar",
-        env="dev",
-        retries=1,
-        delay=0,
-        require_phase="server",
-        expect_addr="192.0.2.10",
-        runner=runner,
-        sleep=lambda _: None,
-    )
-
-    assert observed == "host0.local"
-    warning = capsys.readouterr().err
-    assert "advertisement reported non-IP" in warning
-
-
-def test_ensure_self_ad_is_visible_uses_role_when_phase_missing():
-    record = (
-        "=;eth0;IPv4;k3s-sugar-dev@host0 (bootstrap);_k3s-sugar-dev._tcp;"
-        "local;host0.local;192.0.2.10;6443;"
-        "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=bootstrap;"
-        "txt=leader=host0.local\n"
-    )
-
-    runner = _make_runner({"_k3s-sugar-dev._tcp": record})
-
-    observed = ensure_self_ad_is_visible(
-        expected_host="host0.local",
-        cluster="sugar",
-        env="dev",
-        retries=1,
-        delay=0,
-        require_phase="bootstrap",
-        runner=runner,
-        sleep=lambda _: None,
-    )
-
-    assert observed == "host0.local"
-
-
-def test_ensure_self_ad_is_visible_handles_uppercase_phase_and_leader_host_fallback():
-    record = (
-        "=;eth0;IPv4;k3s-sugar-dev@host0 (server);_k3s-sugar-dev._tcp;"
-        "local;;192.0.2.10;6443;"
-        "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=SERVER ;"
-        "txt=leader=HOST0.LOCAL.;txt=phase=Server \n"
-    )
-
-    runner = _make_runner({"_k3s-sugar-dev._tcp": record})
-
-    observed = ensure_self_ad_is_visible(
-        expected_host="host0.local",
-        cluster="sugar",
-        env="dev",
-        retries=1,
-        delay=0,
-        require_phase="server",
-        expect_addr="192.0.2.10",
-        runner=runner,
-        sleep=lambda _: None,
-    )
-
-    assert observed == "host0.local"
-
-
-def test_ensure_self_ad_is_visible_recovers_from_browse_timeout(capsys):
-    record = (
-        "=;eth0;IPv4;k3s-sugar-dev@host0 (server);_k3s-sugar-dev._tcp;"
-        "local;host0.local;192.0.2.10;6443;"
-        "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=server;"
-        "txt=leader=host0.local;txt=phase=server\n"
-    )
-
-    class TimeoutThenSuccess:
-        def __init__(self):
-            self.calls = 0
-
-        def __call__(self, cmd, **kwargs):
-            self.calls += 1
-            if self.calls == 1:
-                raise subprocess.TimeoutExpired(cmd, timeout=kwargs.get("timeout", 5))
-            return subprocess.CompletedProcess(cmd, 0, stdout=record, stderr="")
-
-    runner = TimeoutThenSuccess()
-
-    observed = ensure_self_ad_is_visible(
-        expected_host="host0.local",
-        cluster="sugar",
-        env="dev",
-        retries=2,
-        delay=0,
-        require_phase="server",
-        runner=runner,
-        sleep=lambda _: None,
-    )
-
-    assert observed == "host0.local"
-    warning = capsys.readouterr().err
-    assert "avahi-browse timed out" in warning
-
-
-def test_ensure_self_ad_is_visible_accepts_uppercase_cluster_and_env():
-    record = (
-        "=;eth0;IPv4;k3s-sugar-dev@host0 (server);_k3s-sugar-dev._tcp;"
-        "local;host0.local;192.0.2.10;6443;"
-        "txt=k3s=1;txt=cluster=SUGAR ;txt=ENV=DEV ;txt=role=server;"
-        "txt=phase=server\n"
-    )
-
-    runner = _make_runner({"_k3s-sugar-dev._tcp": record})
-
-    observed = ensure_self_ad_is_visible(
-        expected_host="host0.local",
-        cluster="sugar",
-        env="dev",
-        retries=1,
-        delay=0,
-        require_phase="server",
-        expect_addr="192.0.2.10",
-        runner=runner,
-        sleep=lambda _: None,
-    )
-
-    assert observed == "host0.local"
-
-
-def test_ensure_self_ad_is_visible_falls_back_without_resolve():
-    unresolved = "+;eth0;IPv4;k3s-sugar-dev@host0 (bootstrap);_k3s-sugar-dev._tcp;local\n"
-
+def test_gather_records_falls_back_when_resolvectl_lacks_txt(monkeypatch):
     calls = []
 
-    def runner(cmd, capture_output=True, text=True, check=False):
-        assert capture_output and text and not check
-        service = cmd[-1]
-        resolve = bool(cmd[1].startswith("-r"))
-        calls.append((service, resolve))
-        if service == "_k3s-sugar-dev._tcp" and not resolve:
-            stdout = unresolved
-        else:
-            stdout = ""
-        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+    def fake_resolve(*args, **kwargs):
+        calls.append("resolvectl")
+        return [
+            {
+                "instance": "k3s-sugar-dev@node.local (server)",
+                "type": "_k3s-sugar-dev._tcp",
+                "domain": "local",
+                "host": "node.local",
+                "addr": "",
+                "port": 6443,
+                "txt": {},
+                "addresses": [],
+            }
+        ]
 
-    observed = ensure_self_ad_is_visible(
-        expected_host="host0.local",
-        cluster="sugar",
-        env="dev",
+    def fake_avahi(*args, **kwargs):
+        calls.append("avahi")
+        return [
+            {
+                "instance": "k3s-sugar-dev@node.local (server)",
+                "type": "_k3s-sugar-dev._tcp",
+                "domain": "local",
+                "host": "node.local",
+                "addr": "192.0.2.10",
+                "port": 6443,
+                "txt": {"phase": "server", "role": "server"},
+                "addresses": ["192.0.2.10"],
+            }
+        ]
+
+    monkeypatch.setattr(mdns_selfcheck, "resolve_with_resolvectl", fake_resolve)
+    monkeypatch.setattr(mdns_selfcheck, "resolve_with_avahi_browse", fake_avahi)
+
+    stream = io.StringIO()
+    logger = mdns_selfcheck.TimestampedLogger(stderr=stream)
+
+    records = mdns_selfcheck.gather_records(
+        instance="k3s-sugar-dev@node.local (server)",
+        service_type="_k3s-sugar-dev._tcp",
+        domain="local",
+        resolvectl_runner=None,
+        avahi_runner=None,
+        logger=logger,
+    )
+
+    assert ["resolvectl", "avahi"] == calls
+    assert records and records[0]["txt"]["phase"] == "server"
+    assert "falling back to avahi-browse" in stream.getvalue()
+
+
+def test_select_record_logs_missing_phase():
+    record = {
+        "instance": "k3s-sugar-dev@node.local (server)",
+        "type": "_k3s-sugar-dev._tcp",
+        "domain": "local",
+        "host": "node.local",
+        "addr": "192.0.2.10",
+        "port": 6443,
+        "txt": {"role": "server"},
+        "addresses": ["192.0.2.10"],
+    }
+    stream = io.StringIO()
+    logger = mdns_selfcheck.TimestampedLogger(stderr=stream)
+
+    match = mdns_selfcheck.select_record(
+        [record],
+        expected_host="node.local",
+        required_phase="server",
+        required_role=None,
+        expected_addr="",
+        require_ipv4=False,
+        logger=logger,
+        attempt=1,
         retries=1,
-        delay=0,
-        require_phase="bootstrap",
-        expect_addr="192.0.2.10",
-        runner=runner,
-        sleep=lambda _: None,
     )
 
-    assert observed == "host0.local"
-    assert calls == [
-        ("_k3s-sugar-dev._tcp", True),
-        ("_https._tcp", True),
-        ("_k3s-sugar-dev._tcp", False),
-    ]
-
-
-def test_ensure_self_ad_is_visible_logs_phase_mismatch_details(capsys):
-    record = (
-        "=;eth0;IPv4;k3s-sugar-dev@host0 (server);_k3s-sugar-dev._tcp;"
-        "local;host0.local;192.0.2.10;6443;"
-        "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=server;"
-        "txt=leader=host0.local;txt=phase=server\n"
-    )
-
-    runner = _make_runner({"_k3s-sugar-dev._tcp": record})
-
-    observed = ensure_self_ad_is_visible(
-        expected_host="host0.local",
-        cluster="sugar",
-        env="dev",
-        retries=1,
-        delay=0,
-        require_phase="bootstrap",
-        runner=runner,
-        sleep=lambda _: None,
-    )
-
-    assert observed is None
-    error_output = capsys.readouterr().err
-    assert "skipped host host0.local" in error_output
-    assert "require_phase=bootstrap" in error_output
-    assert "phase=server" in error_output
-
-
-def test_ensure_self_ad_is_visible_logs_host_comparison_details(capsys):
-    record = (
-        "=;eth0;IPv4;k3s-sugar-dev@host1 (server);_k3s-sugar-dev._tcp;"
-        "local;host1.local;192.0.2.20;6443;"
-        "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=server;"
-        "txt=leader=host1.local;txt=phase=server\n"
-    )
-
-    runner = _make_runner({"_k3s-sugar-dev._tcp": record})
-
-    observed = ensure_self_ad_is_visible(
-        expected_host="host0.local",
-        cluster="sugar",
-        env="dev",
-        retries=1,
-        delay=0,
-        require_phase="server",
-        runner=runner,
-        sleep=lambda _: None,
-    )
-
-    assert observed is None
-    error_output = capsys.readouterr().err
-    assert "rejected host candidate host1.local" in error_output
-    assert "expected=host0.local" in error_output
-    assert "reason=host, leader" in error_output
+    assert match is None
+    output = stream.getvalue()
+    assert "phase/role mismatch" in output
+    assert "phase=<missing>" in output


### PR DESCRIPTION
## Summary
- centralize avahi publish argument construction and host normalization helpers
- add a resolvectl-first mDNS self-check with avahi fallback plus detailed logging
- update k3s-discover and the just mdns-selfcheck target to consume the new tooling and extend tests for the new flows

## Testing
- pytest tests/scripts/test_mdns_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68fc75fec8c8832faa97f28ce810427a