### PR TITLE
Add outage markdown companion support

### DIFF
--- a/outages/2025-10-25-avahi-baseline.json
+++ b/outages/2025-10-25-avahi-baseline.json
@@ -9,5 +9,6 @@
     "outages/2025-10-25-avahi-baseline.md",
     "https://manpages.debian.org/bookworm/avahi-daemon/avahi-daemon.conf.5.en.html",
     "https://www.raspberrypi.com/documentation/computers/os.html#bookworm"
-  ]
+  ],
+  "longForm": "2025-10-25-avahi-baseline.md"
 }

--- a/outages/2025-10-25-mdns-selfcheck-invisible.json
+++ b/outages/2025-10-25-mdns-selfcheck-invisible.json
@@ -1,0 +1,13 @@
+{
+  "id": "mdns-selfcheck-invisible",
+  "date": "2025-10-25",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "k3s-discover trusted avahi-publish log lines even when the Python self-check failed, so bootstrap advertisements stayed invisible to peers.",
+  "resolution": "Replaced the Python helper with scripts/mdns_selfcheck.sh, propagated failures in k3s-discover, and added regression coverage for the shell helper.",
+  "references": [
+    "scripts/mdns_selfcheck.sh",
+    "scripts/k3s-discover.sh",
+    "tests/bats/mdns_selfcheck.bats"
+  ],
+  "longForm": "2025-10-25-mdns-selfcheck-invisible.md"
+}

--- a/outages/2025-10-25-split-brain-bootstrap-election.json
+++ b/outages/2025-10-25-split-brain-bootstrap-election.json
@@ -1,0 +1,12 @@
+{
+  "id": "split-brain-bootstrap-election",
+  "date": "2025-10-25",
+  "component": "scripts/k3s-discover.sh",
+  "rootCause": "Bootstrap nodes relied on opportunistic mDNS and raced to advertise, letting multiple control-plane nodes initialise etcd concurrently and trigger split-brain.",
+  "resolution": "Added scripts/elect_leader.sh, introduced a bootstrap holdoff, and kept non-winners polling until a server appears.",
+  "references": [
+    "scripts/elect_leader.sh",
+    "scripts/k3s-discover.sh"
+  ],
+  "longForm": "2025-10-25-split-brain-bootstrap-election.md"
+}

--- a/outages/schema.json
+++ b/outages/schema.json
@@ -13,6 +13,10 @@
       "type": "array",
       "items": { "type": "string" }
     },
+    "longForm": {
+      "type": "string",
+      "pattern": "^.+\\.md$"
+    },
     "dateRanges": {
       "type": "array",
       "items": {

--- a/tests/test_outage_dates.py
+++ b/tests/test_outage_dates.py
@@ -67,3 +67,21 @@ def test_outage_dates_are_not_in_the_future() -> None:
         assert (
             expected_prefix == recorded_date
         ), f"Filename {outage_file.name} should start with outage date {recorded_date}"
+
+
+def test_markdown_outages_require_json_companions() -> None:
+    """Every long-form outage narrative must have a JSON record and link back to it."""
+
+    outages_dir = Path("outages")
+    assert outages_dir.is_dir(), "outages/ directory must exist for outage records"
+
+    for md_file in sorted(outages_dir.glob("*.md")):
+        json_file = md_file.with_suffix(".json")
+        assert json_file.exists(), f"Missing JSON outage record for {md_file.name}"
+
+        payload = json.loads(json_file.read_text(encoding="utf-8"))
+        long_form = payload.get("longForm")
+        assert long_form, f"{json_file.name} must declare its long-form companion"
+        assert (
+            Path(long_form).name == md_file.name
+        ), f"{json_file.name} should reference {md_file.name} via longForm"


### PR DESCRIPTION
what: allow optional longForm metadata and backfill md-only outages
why: keep narrative outage reports paired with schema-validated JSON
how to test: pytest tests/test_outage_dates.py

------
https://chatgpt.com/codex/tasks/task_e_68fee9023118832fbeb386f84f82756c