### PR TITLE
Add JSON companions for Markdown outages

### DIFF
--- a/outages/2025-10-25-avahi-baseline.json
+++ b/outages/2025-10-25-avahi-baseline.json
@@ -2,6 +2,7 @@
   "id": "2025-10-25-avahi-baseline",
   "date": "2025-10-25",
   "component": "scripts/configure_avahi.sh",
+  "longForm": "outages/2025-10-25-avahi-baseline.md",
   "rootCause": "Avahi defaulted to omitting workstation adverts and automatically selected down or unintended interfaces, so peers on Raspberry Pi OS Bookworm could not resolve the node via mDNS.",
   "resolution": "Force publish-workstation=yes by default while keeping it configurable, auto-detect a single active interface (preferring Ethernet) or honor overrides to pin allow-interfaces, and restart avahi-daemon only when the configuration changes.",
   "references": [

--- a/outages/2025-10-25-mdns-selfcheck-invisible.json
+++ b/outages/2025-10-25-mdns-selfcheck-invisible.json
@@ -1,0 +1,14 @@
+{
+  "id": "2025-10-25-mdns-selfcheck-invisible",
+  "date": "2025-10-25",
+  "component": "scripts/k3s-discover.sh",
+  "longForm": "outages/2025-10-25-mdns-selfcheck-invisible.md",
+  "rootCause": "k3s discovery trusted avahi-publish logs and muted mdns self-checks, letting missing adverts linger.",
+  "resolution": "Ship scripts/mdns_selfcheck.sh, make k3s-discover fail on self-check errors, and add Bats coverage.",
+  "references": [
+    "scripts/k3s-discover.sh",
+    "scripts/mdns_selfcheck.sh",
+    "tests/bats/mdns_selfcheck.bats",
+    "outages/2025-10-25-mdns-selfcheck-invisible.md"
+  ]
+}

--- a/outages/2025-10-25-split-brain-bootstrap-election.json
+++ b/outages/2025-10-25-split-brain-bootstrap-election.json
@@ -1,0 +1,13 @@
+{
+  "id": "2025-10-25-split-brain-bootstrap-election",
+  "date": "2025-10-25",
+  "component": "scripts/k3s-discover.sh",
+  "longForm": "outages/2025-10-25-split-brain-bootstrap-election.md",
+  "rootCause": "Bootstrap relied on mdns races, so stalled browsing let multiple nodes initialize etcd and collide.",
+  "resolution": "Ship scripts/elect_leader.sh so k3s-discover elects one bootstrap node and keeps followers polling.",
+  "references": [
+    "scripts/elect_leader.sh",
+    "scripts/k3s-discover.sh",
+    "outages/2025-10-25-split-brain-bootstrap-election.md"
+  ]
+}

--- a/outages/schema.json
+++ b/outages/schema.json
@@ -7,6 +7,11 @@
     "id": { "type": "string" },
     "date": { "type": "string", "format": "date" },
     "component": { "type": "string" },
+    "longForm": {
+      "type": "string",
+      "pattern": ".*\\.md$",
+      "description": "Path to a companion Markdown outage report"
+    },
     "rootCause": { "type": "string" },
     "resolution": { "type": "string" },
     "references": {

--- a/tests/test_outage_dates.py
+++ b/tests/test_outage_dates.py
@@ -67,3 +67,16 @@ def test_outage_dates_are_not_in_the_future() -> None:
         assert (
             expected_prefix == recorded_date
         ), f"Filename {outage_file.name} should start with outage date {recorded_date}"
+
+
+def test_markdown_outages_have_json_counterparts() -> None:
+    """Every long-form Markdown report should have a matching JSON record."""
+
+    outages_dir = Path("outages")
+    assert outages_dir.is_dir(), "outages/ directory must exist for outage records"
+
+    for markdown_file in sorted(outages_dir.glob("*.md")):
+        json_file = markdown_file.with_suffix(".json")
+        assert json_file.exists(), (
+            f"Missing JSON outage record for {markdown_file.name}; add {json_file.name}"
+        )


### PR DESCRIPTION
## What
- allow outages to reference optional long-form markdown companions
- add json records for markdown-only outages and validate schema
- fail tests when markdown reports are missing their json files

## Why
- keep outage history machine-readable while enabling detailed reports

## How to test
- pytest tests/test_outage_dates.py


------
https://chatgpt.com/codex/tasks/task_e_68fee9023118832fbeb386f84f82756c