### PR TITLE
Add structured log levels and compress bootstrap output

### DIFF
--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -1,0 +1,23 @@
+# Sugarkube logging overview
+
+Sugarkube shell utilities emit structured `key=value` pairs so logs are
+machine-parseable while still being readable during interactive debugging.
+
+## Runtime toggles
+
+- `LOG_LEVEL` controls verbosity for scripts that source `scripts/log.sh`.
+  - Valid values: `info` (default), `debug`, `trace`.
+  - `debug` enables per-attempt summaries such as mDNS discovery retries.
+  - `trace` includes the raw Avahi command output and backoff calculations.
+- `SUGARKUBE_DEBUG_MDNS=1` keeps the existing network diagnostics behaviour in
+  `k3s-discover.sh`, dumping detailed Avahi traces whenever a self-check fails or
+  falls back to a relaxed match.
+
+Set the variables just for a single command:
+
+```bash
+LOG_LEVEL=debug SUGARKUBE_DEBUG_MDNS=1 scripts/k3s-discover.sh
+```
+
+The `info` level keeps successful bootstrap runs to a handful of high-signal
+lines while still surfacing warnings and errors.

--- a/scripts/log.sh
+++ b/scripts/log.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+# shellcheck shell=sh
+
+# Shared structured logging helper for shell scripts.
+# Provides level-aware logging helpers that emit key=value pairs with
+# ISO-8601 timestamps.
+
+: "${LOG_LEVEL:=info}"
+
+log__level_to_num() {
+  case "${1}" in
+    trace) echo 3 ;;
+    debug) echo 2 ;;
+    info) echo 1 ;;
+    *) echo 1 ;;
+  esac
+}
+
+log__should_emit() {
+  local desired current
+  desired="$(log__level_to_num "$1" 2>/dev/null || echo 1)"
+  current="$(log__level_to_num "${LOG_LEVEL}" 2>/dev/null || echo 1)"
+  [ "${desired}" -le "${current}" ]
+}
+
+log__timestamp() {
+  date -Is 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S%z'
+}
+
+log_kv() {
+  local level event
+  level="$1"
+  shift
+  event="$1"
+  shift
+  if ! log__should_emit "${level}"; then
+    return 0
+  fi
+
+  local message="ts=$(log__timestamp) level=${level} event=${event}"
+  local kv
+  for kv in "$@"; do
+    [ -n "${kv}" ] || continue
+    message="${message} ${kv}"
+  done
+  printf '%s\n' "${message}"
+}
+
+log_info() {
+  log_kv info "$@"
+}
+
+log_debug() {
+  log_kv debug "$@" >&2
+}
+
+log_trace() {
+  log_kv trace "$@" >&2
+}
+


### PR DESCRIPTION
## Summary
- add a shared scripts/log.sh helper that emits structured key=value log entries gated by LOG_LEVEL
- refactor mdns_selfcheck and k3s-discover to use log_info/log_debug/log_trace, collapsing success-path output to concise summaries
- document LOG_LEVEL and SUGARKUBE_DEBUG_MDNS toggles in docs/LOGGING.md

## Testing
- bash -n scripts/k3s-discover.sh
- sh -n scripts/mdns_selfcheck.sh

------
https://chatgpt.com/codex/tasks/task_e_68fee9e61cb4832fb65ef4f1c6856000