### PR TITLE
🛠️ : – mdns selfcheck fallback to cli

### DIFF
--- a/scripts/mdns_selfcheck.sh
+++ b/scripts/mdns_selfcheck.sh
@@ -50,11 +50,14 @@ if [ "${dbus_mode}" != "0" ]; then
     fi
     status=$?
     case "${status}" in
+      # 0=ok, 1=transient fail, 2=unsupported -> CLI fallback
       1)
-        exit 1
+        log_debug mdns_selfcheck_dbus outcome=skip reason=dbus_first_attempt_failed fallback=cli
         ;;
       2)
         log_debug mdns_selfcheck_dbus outcome=skip reason=dbus_unsupported fallback=cli
+        ;;
+      0)
         ;;
       *)
         exit "${status}"


### PR DESCRIPTION
what: allow mdns selfcheck to log transient dbus errors then fall back to cli
why: dbus helper can fail to launch browsers transiently but cli path still works
how to test: run mdns selfcheck with dbus helper returning 1 and confirm cli runs

------
https://chatgpt.com/codex/tasks/task_e_68fffa4a40e4832f9ceb34900218c1d3