### PR TITLE
Fix: enable CI for forked PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,17 @@
 name: Test Suite
-on: [push, pull_request]
+on:
+  push:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  workflow_dispatch:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -9,6 +19,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
       - name: Setup uv
         uses: astral-sh/setup-uv@v1
       - name: Setup Python
@@ -23,7 +34,10 @@ jobs:
         run: |
           pytest --cov=. --cov-report=xml --cov-report=term --maxfail=1 --disable-warnings -q
       - name: Upload coverage
-        if: ${{ hashFiles('coverage.xml') != '' && secrets.CODECOV_TOKEN != '' }}
+        if: >-
+          ${{ hashFiles('coverage.xml') != '' &&
+              secrets.CODECOV_TOKEN != '' &&
+              (github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.fork == false) }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
what: run Test Suite on pull_request_target so forks get coverage
why: new PRs were missing CI coverage until a maintainer approved runs
how to test: open a PR (from fork or branch) and confirm Test Suite triggers
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68fffebf2b1c832f8f64af468eaa7cd6