### PR TITLE
Align prereqs package list across automation and docs

### DIFF
--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -138,7 +138,7 @@ The pattern is:
 
 2. **Run `just up dev` twice on the first control-plane node**
 
-   The first run modifies memory cgroup settings if needed and reboots automatically. The second run installs Avahi/libnss-mdns, bootstraps k3s as an HA server, publishes the API as `_https._tcp:6443` via Bonjour/mDNS with `cluster=sugar` and `env=dev` TXT records, and taints itself (`node-role.kubernetes.io/control-plane=true:NoSchedule`) so workloads prefer agents.
+   The first run modifies memory cgroup settings if needed and reboots automatically. The second run installs the networking tooling (`avahi-daemon`, `avahi-utils`, `libnss-mdns`, `libglib2.0-bin`, `tcpdump`, `curl`, `jq`), with `libglib2.0-bin` providing `gdbus` so the D-Bus discovery path stays enabled, bootstraps k3s as an HA server, publishes the API as `_https._tcp:6443` via Bonjour/mDNS with `cluster=sugar` and `env=dev` TXT records, and taints itself (`node-role.kubernetes.io/control-plane=true:NoSchedule`) so workloads prefer agents.
 
    > **HA choice**
    >

--- a/justfile
+++ b/justfile
@@ -42,7 +42,7 @@ up env='dev': prereqs
 
 prereqs:
     sudo apt-get update
-    sudo apt-get install -y avahi-daemon avahi-utils libnss-mdns glib2.0-bin tcpdump curl jq
+    sudo apt-get install -y avahi-daemon avahi-utils libnss-mdns libglib2.0-bin tcpdump curl jq
     sudo systemctl enable --now avahi-daemon
     if ! grep -q 'mdns4_minimal' /etc/nsswitch.conf; then sudo sed -i 's/^hosts:.*/hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4/' /etc/nsswitch.conf; fi
 


### PR DESCRIPTION
what: sync prereqs apt packages with doc and automation
why: ensure libglib2.0-bin is installed for gdbus D-Bus flow
how to test: n/a

------
https://chatgpt.com/codex/tasks/task_e_690005f5cb78832fa5004af99ae454c5