### PR TITLE
🛡️ : Add wire-level proof to k3s bootstrap guard

### DIFF
--- a/scripts/mdns_selfcheck.sh
+++ b/scripts/mdns_selfcheck.sh
@@ -24,6 +24,7 @@ ATTEMPTS="${SUGARKUBE_SELFCHK_ATTEMPTS:-12}"
 BACKOFF_START_MS="${SUGARKUBE_SELFCHK_BACKOFF_START_MS:-500}"
 BACKOFF_CAP_MS="${SUGARKUBE_SELFCHK_BACKOFF_CAP_MS:-5000}"
 JITTER_FRACTION="${JITTER:-0.2}"
+LEGACY_SERVICE_TYPE="${SUGARKUBE_LEGACY_SERVICE_TYPE:-_https._tcp}"
 
 script_start_ms="$(python3 - <<'PY'
 import time
@@ -113,6 +114,7 @@ EXPECTED_SHORT_HOST="${EXPECTED_HOST%.local}"
 
 parse_browse() {
   awk -v svc="${SERVICE_TYPE}" \
+      -v legacy="${LEGACY_SERVICE_TYPE}" \
       -v inst_pref="${INSTANCE_PREFIX}" \
       -v short_host="${EXPECTED_SHORT_HOST}" \
       -v expected_role="${EXPECTED_ROLE}" \
@@ -141,6 +143,7 @@ parse_browse() {
       type_idx = -1
       for (i = 1; i <= NF; i++) {
         if (fields[i] == svc) { type_idx = i; break }
+        if (legacy != "" && fields[i] == legacy) { type_idx = i; break }
       }
       if (type_idx < 0) next
 


### PR DESCRIPTION
what: require negative dbus plus wire sniff before self-electing servers
why: reduce split-brain risk from lingering _https._tcp answers
how to test: bash -n scripts/k3s-discover.sh; sh -n scripts/mdns_selfcheck.sh

------
https://chatgpt.com/codex/tasks/task_e_690005b81558832f9d086d101ff80517