### PR TITLE
docs: document mDNS toggles and absence gates

### DIFF
--- a/docs/DBUS.md
+++ b/docs/DBUS.md
@@ -37,6 +37,24 @@ If the environment does not expose `gdbus`, or Avahi rejects the D-Bus calls,
 the helper exits with status `2` and `mdns_selfcheck.sh` transparently falls
 back to the CLI implementation.
 
+## Related toggles and diagnostics
+
+- `SUGARKUBE_DEBUG_MDNS=1` elevates mDNS logging across the discovery helpers so every
+  RFC 6762 probe/response cycle that the D-Bus client observes is surfaced in `discover`
+  logs. Combine it with `LOG_LEVEL=trace` (see [LOGGING.md](LOGGING.md)) when you need a
+  packet-by-packet narrative of Avahi's answers.
+- `SUGARKUBE_MDNS_WIRE_PROOF=1` (default) asks the helper to corroborate D-Bus results by
+  running the "wire proof" capture. When `tcpdump` is available the script records a
+  short, passive sniff on UDP/5353 and verifies that no multicast responses contradict
+  the D-Bus browser's view. Set the toggle to `0` to skip the capture on constrained
+  nodes that cannot run `tcpdump`.
+
+When both toggles are active you get structured logs that align D-Bus events with the
+wire-observed packets. The `ms_elapsed` field included in those log entries measures the
+time in milliseconds since the helper started; on a quiet LAN the D-Bus browse+resolve
+cycle typically closes within 150–400 ms, whereas congested networks might stretch above
+one second as the script waits for RFC 6762 retransmissions.
+
 ## Integration with discovery flow
 
 `scripts/k3s-discover.sh` automatically opts into the D-Bus validator when

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -15,9 +15,30 @@ machine-parseable while still being readable during interactive debugging.
 
 - `SUGARKUBE_DEBUG_MDNS=1` enables detailed network diagnostics in
   `k3s-discover.sh`, dumping Avahi traces whenever a self-check fails or falls
-  back to a relaxed match.
+  back to a relaxed match. The flag also emits per-attempt timing so you can
+  differentiate between RFC 6762 retransmissions and genuine packet loss.
 - `SUGARKUBE_MDNS_DBUS=0` forces the CLI mDNS validator; omit or set to `1`
   to keep the default D-Bus backend (see [DBUS.md](DBUS.md)).
+- `SUGARKUBE_MDNS_WIRE_PROOF=1` (default) requires the discovery flow to
+  confirm D-Bus answers with a passive capture of UDP/5353. Logs show the
+  `mdns_wire_proof` event so you can trace when Sugarkube trusted or rejected
+  multicast responses.
+
+## Structured log fields
+
+Most discovery and absence-gate messages share a common set of fields:
+
+- `attempts` – ordinal counter for retry loops, usually capped at 5 by the
+  helpers.
+- `last_method` – whether the D-Bus or CLI backend produced the most recent
+  result.
+- `ms_elapsed` – milliseconds elapsed since the helper started. Successful
+  mDNS resolves on a quiet LAN typically land between 150 and 400 ms while
+  the absence gate (triggered after `just wipe`) may run 2–5 seconds to
+  collect the required consecutive misses.
+- `wire_proof_status` – summary of the RFC 6762 wire capture. Expect `absent`
+  when `SUGARKUBE_MDNS_WIRE_PROOF=1` and the passive sniff finds no stray
+  responses.
 
 ## Usage examples
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -66,6 +66,20 @@ Verify discovery (mDNS):
 avahi-browse --all --resolve --terminate | grep -A2 '_https._tcp'
 ```
 
+If discovery still returns stale records, export the debug toggles before rerunning `just up`:
+
+```bash
+export SUGARKUBE_DEBUG_MDNS=1
+export SUGARKUBE_MDNS_DBUS=1
+export SUGARKUBE_MDNS_WIRE_PROOF=1
+LOG_LEVEL=trace just up dev
+```
+
+The trio surfaces the D-Bus transactions, requests a passive RFC 6762 wire proof, and records
+per-attempt timings (`ms_elapsed`). On a healthy, quiet LAN you should see resolution within
+approximately 150–400 ms. Longer spans indicate the helper is retrying because multicast responses
+are delayed or suppressed by the network.
+
 ## 4. Bootstrap Flux and secrets
 
 Flux bootstrapping defaults to the production overlay. Pass `env=<env>` to the Just recipes or set


### PR DESCRIPTION
what: document mDNS toggles, readiness gates, and ms_elapsed ranges
why: help operators interpret discovery logs and toggles during recovery
how to test: pre-commit run --all-files (fails: existing lint violations)
  pyspelling -c .spellcheck.yaml (blocked: aspell missing)
  linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_69001dc87b24832f804f6b93b62cf009