### PR TITLE
🚀 : – serialize k3s server joins via Avahi gate

### DIFF
--- a/scripts/join_gate.sh
+++ b/scripts/join_gate.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/log.sh
+. "${SCRIPT_DIR}/log.sh"
+
+SERVICE_TYPE="_k3s-join-lock._tcp"
+SERVICE_NAME="${SUGARKUBE_JOIN_GATE_NAME:-k3s join gate}" # Avahi display name
+RUNTIME_DIR="${SUGARKUBE_RUNTIME_DIR:-/run/sugarkube}"
+PID_FILE="${SUGARKUBE_JOIN_GATE_PID_FILE:-${RUNTIME_DIR}/join-gate.pid}"
+AVAHI_PUBLISH_BIN="${SUGARKUBE_AVAHI_PUBLISH_BIN:-avahi-publish-service}"
+AVAHI_BROWSE_BIN="${SUGARKUBE_AVAHI_BROWSE_BIN:-avahi-browse}"
+HOSTNAME_SHORT="$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo 'unknown')"
+
+log_join_gate() {
+  log_kv info join_gate "$@" >&2
+}
+
+usage() {
+  cat <<'USAGE' >&2
+Usage: join_gate.sh <command>
+Commands:
+  acquire   Acquire the join gate lock by publishing an mDNS service
+  release   Release the join gate lock if held
+  wait      Block until no join gate lock advertisement is visible
+USAGE
+}
+
+ensure_runtime_dir() {
+  if [ ! -d "${RUNTIME_DIR}" ]; then
+    mkdir -p "${RUNTIME_DIR}"
+  fi
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    log_join_gate "action=$2" "outcome=error" "reason=${1}_missing"
+    exit 1
+  fi
+}
+
+service_visible() {
+  local output
+  output="$(${AVAHI_BROWSE_BIN} --parsable --terminate "${SERVICE_TYPE}" 2>/dev/null || true)"
+  if [ -n "${output}" ]; then
+    return 0
+  fi
+  return 1
+}
+
+generate_lock_id() {
+  printf '%04x%04x' "$RANDOM" "$RANDOM"
+}
+
+random_port() {
+  local base=$((RANDOM % 16384))
+  printf '%d' $((base + 49152))
+}
+
+acquire_lock() {
+  ensure_runtime_dir
+  require_command "${AVAHI_BROWSE_BIN}" acquire
+  require_command "${AVAHI_PUBLISH_BIN}" acquire
+
+  local attempt=0
+  local sleep_secs=1
+  while service_visible; do
+    attempt=$((attempt + 1))
+    log_join_gate "action=acquire" "outcome=blocked" "attempt=${attempt}" "sleep=${sleep_secs}"
+    sleep "${sleep_secs}"
+    if [ "${sleep_secs}" -lt 8 ]; then
+      sleep_secs=$((sleep_secs * 2))
+      if [ "${sleep_secs}" -gt 8 ]; then
+        sleep_secs=8
+      fi
+    fi
+  done
+
+  local port
+  port="$(random_port)"
+  local lock_id
+  lock_id="$(generate_lock_id)"
+
+  if command -v nohup >/dev/null 2>&1; then
+    nohup "${AVAHI_PUBLISH_BIN}" \
+      "${SERVICE_NAME} on ${HOSTNAME_SHORT}" \
+      "${SERVICE_TYPE}" \
+      "${port}" \
+      "txt=lock_id=${lock_id}" \
+      >/dev/null 2>&1 &
+  else
+    "${AVAHI_PUBLISH_BIN}" \
+      "${SERVICE_NAME} on ${HOSTNAME_SHORT}" \
+      "${SERVICE_TYPE}" \
+      "${port}" \
+      "txt=lock_id=${lock_id}" \
+      >/dev/null 2>&1 &
+  fi
+  local pub_pid=$!
+  disown 2>/dev/null || true
+  sleep 0.1
+  if ! kill -0 "${pub_pid}" 2>/dev/null; then
+    log_join_gate "action=acquire" "outcome=error" "reason=publish_failed"
+    exit 1
+  fi
+
+  printf '%s\n' "${pub_pid}" >"${PID_FILE}"
+  log_join_gate "action=acquire" "outcome=ok" "pid=${pub_pid}" "lock_id=${lock_id}" "port=${port}"
+  exit 0
+}
+
+release_lock() {
+  ensure_runtime_dir
+  require_command "${AVAHI_PUBLISH_BIN}" release
+  if [ ! -f "${PID_FILE}" ]; then
+    log_join_gate "action=release" "outcome=skip" "reason=no_pid_file"
+    exit 0
+  fi
+
+  local pid
+  pid="$(cat "${PID_FILE}" 2>/dev/null || true)"
+  if [ -z "${pid}" ]; then
+    log_join_gate "action=release" "outcome=skip" "reason=empty_pid"
+    rm -f "${PID_FILE}"
+    exit 0
+  fi
+
+  if [ ! -d "/proc/${pid}" ]; then
+    log_join_gate "action=release" "outcome=skip" "reason=not_running" "pid=${pid}"
+    rm -f "${PID_FILE}"
+    exit 0
+  fi
+
+  kill "${pid}" 2>/dev/null || true
+
+  for _ in 1 2 3 4 5; do
+    if kill -0 "${pid}" 2>/dev/null; then
+      sleep 0.1
+    else
+      break
+    fi
+  done
+
+  if kill -0 "${pid}" 2>/dev/null; then
+    kill -9 "${pid}" 2>/dev/null || true
+  fi
+
+  rm -f "${PID_FILE}"
+  log_join_gate "action=release" "outcome=ok" "pid=${pid}"
+  exit 0
+}
+
+wait_for_lock() {
+  require_command "${AVAHI_BROWSE_BIN}" wait
+  local attempt=0
+  local sleep_secs=1
+  while service_visible; do
+    attempt=$((attempt + 1))
+    log_join_gate "action=wait" "outcome=blocked" "attempt=${attempt}" "sleep=${sleep_secs}"
+    sleep "${sleep_secs}"
+    if [ "${sleep_secs}" -lt 8 ]; then
+      sleep_secs=$((sleep_secs * 2))
+      if [ "${sleep_secs}" -gt 8 ]; then
+        sleep_secs=8
+      fi
+    fi
+  done
+  log_join_gate "action=wait" "outcome=ok"
+  exit 0
+}
+
+if [ "$#" -lt 1 ]; then
+  usage
+  exit 2
+fi
+
+case "$1" in
+  acquire)
+    acquire_lock
+    ;;
+  release)
+    release_lock
+    ;;
+  wait)
+    wait_for_lock
+    ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/tests/bats/join_gate.bats
+++ b/tests/bats/join_gate.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+load helpers/path_stub
+
+setup() {
+  ORIGINAL_PATH="$PATH"
+  unset _BATS_PATH_STUB_DIR
+  PATH="$ORIGINAL_PATH"
+  setup_path_stub_dir
+  export SUGARKUBE_RUNTIME_DIR="${BATS_TEST_TMPDIR}/run"
+  mkdir -p "${SUGARKUBE_RUNTIME_DIR}"
+}
+
+teardown() {
+  PATH="$ORIGINAL_PATH"
+}
+
+@test "join gate acquires and releases lock" {
+  publish_log="${BATS_TEST_TMPDIR}/publish.log"
+  stub_command avahi-browse <<'EOS'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 1
+EOS
+
+  stub_command avahi-publish-service <<EOS
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$@" >> "${publish_log}"
+trap 'exit 0' TERM INT
+while true; do sleep 1; done
+EOS
+
+  run "${BATS_CWD}/scripts/join_gate.sh" acquire
+  [ "$status" -eq 0 ]
+
+  pid_file="${SUGARKUBE_RUNTIME_DIR}/join-gate.pid"
+  [ -f "${pid_file}" ]
+  lock_pid="$(cat "${pid_file}")"
+  [ -n "${lock_pid}" ]
+  kill -0 "${lock_pid}"
+
+  run "${BATS_CWD}/scripts/join_gate.sh" release
+  [ "$status" -eq 0 ]
+  [ ! -f "${pid_file}" ]
+  ! kill -0 "${lock_pid}" 2>/dev/null
+
+  publish_contents="$(cat "${publish_log}" 2>/dev/null || true)"
+  [[ "${publish_contents}" =~ _k3s-join-lock._tcp ]]
+}
+
+@test "join gate wait blocks until lock clears" {
+  counter_file="${BATS_TEST_TMPDIR}/counter"
+  stub_command avahi-browse <<EOS
+#!/usr/bin/env bash
+set -euo pipefail
+counter_file="${counter_file}"
+release_after="\${JOIN_GATE_STUB_RELEASE_AFTER:-3}"
+count=0
+if [ -f "${counter_file}" ]; then
+  count="\$(cat "${counter_file}")"
+fi
+count=$((count + 1))
+printf '%s' "${count}" >"${counter_file}"
+if [ "${count}" -lt "${release_after}" ]; then
+  cat <<'OUT'
+=;eth0;IPv4;k3s join gate;_k3s-join-lock._tcp;local;host.local;192.0.2.1;5555
+OUT
+  exit 0
+fi
+exit 1
+EOS
+
+  run env JOIN_GATE_STUB_RELEASE_AFTER=4 "${BATS_CWD}/scripts/join_gate.sh" wait
+  [ "$status" -eq 0 ]
+  attempts="$(cat "${counter_file}")"
+  [ "${attempts}" -eq 4 ]
+}

--- a/tests/scripts/test_k3s_discover_mid_election_join.py
+++ b/tests/scripts/test_k3s_discover_mid_election_join.py
@@ -37,16 +37,17 @@ def test_join_when_server_advertises_during_election(tmp_path: Path) -> None:
         "#!/usr/bin/env bash\n" "echo 'LISTEN'\n" "exit 0\n",
     )
 
-    # Provide a long-running avahi-publish-service implementation so the helper keeps a PID.
-    _write_stub(
-        bin_dir / "avahi-publish-service",
+    # Provide long-running Avahi publisher implementations so the helper keeps a PID.
+    publisher_stub = (
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
         f"echo START:\"$@\" >> '{publish_log}'\n"
         f"if [[ \"$*\" == *\"phase=server\"* ]]; then touch '{server_flag}'; fi\n"
         "trap 'echo TERM >> \"" + str(publish_log) + "\"; exit 0' TERM INT\n"
-        "while true; do read -r -t 1 _ || true; done\n",
+        "while true; do read -r -t 1 _ || true; done\n"
     )
+    _write_stub(bin_dir / "avahi-publish-service", publisher_stub)
+    _write_stub(bin_dir / "avahi-publish", publisher_stub)
 
     # Emit an installation script that immediately exits successfully.
     _write_stub(
@@ -57,6 +58,23 @@ def test_join_when_server_advertises_during_election(tmp_path: Path) -> None:
         "#!/usr/bin/env sh\n"
         "exit 0\n"
         "SCRIPT\n",
+    )
+
+    _write_stub(
+        bin_dir / "apt-get",
+        "#!/usr/bin/env bash\n"
+        "exit 0\n",
+    )
+
+    _write_stub(
+        bin_dir / "avahi-resolve",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "if [ $# -ge 2 ]; then\n"
+        "  echo \"$2 192.0.2.10\"\n"
+        "else\n"
+        "  exit 1\n"
+        "fi\n",
     )
 
     # Capture invocations of sh -s - server ... from the installer pipeline.
@@ -78,35 +96,61 @@ def test_join_when_server_advertises_during_election(tmp_path: Path) -> None:
         "set -euo pipefail\n"
         'state="${SUGARKUBE_TEST_STATE}"\n'
         'threshold="${SUGARKUBE_TEST_SERVER_THRESHOLD:-9}"\n'
+        'server_flag="${SUGARKUBE_TEST_SERVER_FLAG}"\n'
+        "service_type=''\n"
+        "for arg in \"$@\"; do\n"
+        "  case \"$arg\" in\n"
+        "    _k3s-join-lock._tcp)\n"
+        "      exit 1\n"
+        "      ;;\n"
+        "    -*|--*)\n"
+        "      continue\n"
+        "      ;;\n"
+        "    *)\n"
+        "      service_type=\"$arg\"\n"
+        "      ;;\n"
+        "  esac\n"
+        "done\n"
+        "cluster=${SUGARKUBE_CLUSTER:-sugar}\n"
+        "environment=${SUGARKUBE_ENV:-dev}\n"
+        "target_type=\"_k3s-${cluster}-${environment}._tcp\"\n"
+        "if [ \"$service_type\" = \"$target_type\" ] && [ -n \"${SUGARKUBE_EXPECTED_HOST:-}\" ] "
+        "&& [ -f \"$server_flag\" ]; then\n"
+        "  expected_host=\"${SUGARKUBE_EXPECTED_HOST}\"\n"
+        "  cat <<EOF\n"
+        "=;eth0;IPv4;k3s-${cluster}-${environment}@${expected_host} (server);"
+        "$target_type;local;${expected_host};192.0.2.20;6443;txt=k3s=1;"
+        "txt=cluster=${cluster};txt=env=${environment};txt=role=server;"
+        "txt=leader=${expected_host};txt=phase=server\n"
+        "EOF\n"
+        "  exit 0\n"
+        "fi\n"
+        "if [ ! -f \"$state\" ]; then\n"
+        "  printf '0 0\n' >\"$state\"\n"
+        "fi\n"
+        "read -r server_count bootstrap_count <\"$state\"\n"
         "mode='bootstrap'\n"
-        f"flag='{server_flag}'\n"
+        "if [ \"$service_type\" = \"$target_type\" ]; then\n"
+        "  mode='server'\n"
+        "fi\n"
         "for arg in \"$@\"; do\n"
         "  if [ \"$arg\" = '--ignore-local' ]; then\n"
         "    mode='server'\n"
         "  fi\n"
         "done\n"
-        "if [ ! -f \"$state\" ]; then\n"
-        "  printf '0 0\n' >\"$state\"\n"
-        "fi\n"
-        "read -r server_count bootstrap_count <\"$state\"\n"
         "if [ \"$mode\" = 'server' ]; then\n"
         "  server_count=$((server_count + 1))\n"
         "  if [ $server_count -ge $threshold ]; then\n"
-        "    cat <<'EOF'\n"
-        "=;eth0;IPv4;k3s API sugar/dev on sugarkube0;_https._tcp;local;"
-        "sugarkube0.local;192.168.50.10;6443;txt=k3s=1;txt=cluster=sugar;"
-        "txt=env=dev;txt=role=server;txt=leader=sugarkube0.local;txt=phase=server\n"
+        "    local_host=sugarkube0\n"
+        "    cat <<EOF\n"
+        "=;eth0;IPv4;k3s-${cluster}-${environment}@${local_host}.local (server);"
+        "$target_type;local;${local_host}.local;192.0.2.10;6443;txt=k3s=1;"
+        "txt=cluster=${cluster};txt=env=${environment};txt=role=server;"
+        "txt=leader=${local_host}.local;txt=phase=server\n"
         "EOF\n"
         "  fi\n"
         "else\n"
         "  bootstrap_count=$((bootstrap_count + 1))\n"
-        "fi\n"
-        "local_host=$(hostname -s)\n"
-        "if [ -f \"$flag\" ]; then\n"
-        "  cat <<EOF\n"
-        "=;eth0;IPv4;k3s-sugar-dev@${local_host}.local (server);_k3s-sugar-dev._tcp;local;${local_host}.local;192.0.2.10;6443;"
-        "txt=k3s=1;txt=cluster=sugar;txt=env=dev;txt=role=server;txt=leader=${local_host}.local;txt=phase=server\n"
-        "EOF\n"
         "fi\n"
         "printf '%s %s\n' \"$server_count\" \"$bootstrap_count\" >\"$state\"\n"
         "exit 0\n",
@@ -127,6 +171,7 @@ def test_join_when_server_advertises_during_election(tmp_path: Path) -> None:
             "SUGARKUBE_RUNTIME_DIR": str(tmp_path / "run"),
             "SUGARKUBE_TEST_STATE": str(state_file),
             "SUGARKUBE_TEST_SERVER_THRESHOLD": "9",
+            "SUGARKUBE_TEST_SERVER_FLAG": str(server_flag),
             "SH_LOG_PATH": str(sh_log),
             "SUGARKUBE_MDNS_DBUS": "0",
         }
@@ -141,8 +186,20 @@ def test_join_when_server_advertises_during_election(tmp_path: Path) -> None:
     )
 
     assert result.returncode == 0, result.stderr
-    assert "server advertisement confirmed" in result.stderr
-    assert "Joining as additional HA server via https://sugarkube0.local:6443" in result.stderr
+    assert "event=mdns_selfcheck outcome=confirmed" in result.stderr
+    assert "phase=install_join" in result.stderr
+
+    wait_idx = result.stderr.find("event=join_gate action=wait outcome=ok")
+    acquire_idx = result.stderr.find("event=join_gate action=acquire outcome=ok")
+    release_idx = result.stderr.find("event=join_gate action=release outcome=ok")
+
+    assert wait_idx != -1, result.stderr
+    assert acquire_idx != -1, result.stderr
+    assert release_idx != -1, result.stderr
+    assert wait_idx < acquire_idx < release_idx
+    join_log_idx = result.stderr.find("phase=install_join")
+    assert join_log_idx != -1, result.stderr
+    assert acquire_idx < join_log_idx < release_idx
 
     sh_log_contents = sh_log.read_text(encoding="utf-8")
     assert "--cluster-init" not in sh_log_contents


### PR DESCRIPTION
what:
- add join gate script and wire it into k3s-discover
- cover serialization via bats and pytest suites

why:
- prevent concurrent server joins that exceed etcd learner limits

how to test:
- pytest tests/scripts/test_k3s_discover_mid_election_join.py
- bats tests/bats/join_gate.bats


------
https://chatgpt.com/codex/tasks/task_e_69001ff4d350832f9bbbf33fe17d954e