### PR TITLE
Gate joins on API readyz readiness

### DIFF
--- a/scripts/check_apiready.sh
+++ b/scripts/check_apiready.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/log.sh
+. "${SCRIPT_DIR}/log.sh"
+
+SERVER_HOST="${SERVER_HOST:-${1:-}}"
+if [ -n "${SERVER_HOST}" ] && [ "$#" -gt 0 ]; then
+  shift || true
+fi
+SERVER_PORT="${SERVER_PORT:-${1:-6443}}"
+if [ "$#" -gt 0 ]; then
+  shift || true
+fi
+SERVER_IP="${SERVER_IP:-}"
+TIMEOUT_RAW="${TIMEOUT:-120}"
+POLL_INTERVAL_RAW="${POLL_INTERVAL:-2}"
+
+cleanup_files() {
+  if [ -n "${body_file:-}" ] && [ -f "${body_file}" ]; then
+    rm -f "${body_file}"
+  fi
+  if [ -n "${error_file:-}" ] && [ -f "${error_file}" ]; then
+    rm -f "${error_file}"
+  fi
+}
+
+trap cleanup_files EXIT
+
+escape_log_value() {
+  printf '%s' "$1" | sed 's/"/\\"/g'
+}
+
+require_server_host() {
+  if [ -z "${SERVER_HOST}" ]; then
+    echo "SERVER_HOST is required" >&2
+    exit 2
+  fi
+}
+
+resolve_positive_int() {
+  local value="$1"
+  python3 - "$value" <<'PY'
+import math
+import sys
+
+raw = sys.argv[1]
+try:
+    numeric = float(raw)
+except ValueError:
+    print("INVALID")
+    sys.exit(0)
+if numeric <= 0:
+    print("INVALID")
+    sys.exit(0)
+print(str(int(math.ceil(numeric))))
+PY
+}
+
+resolve_positive_float() {
+  local value="$1"
+  python3 - "$value" <<'PY'
+import sys
+raw = sys.argv[1]
+try:
+    numeric = float(raw)
+except ValueError:
+    print("INVALID")
+    sys.exit(0)
+if numeric <= 0:
+    print("INVALID")
+    sys.exit(0)
+print(str(numeric))
+PY
+}
+
+validate_ready_body() {
+  python3 - <<'PY'
+import sys
+
+lines = [line.strip() for line in sys.stdin.read().splitlines()]
+seen_ok = False
+for line in lines:
+    if not line:
+        continue
+    if line == "readyz check passed":
+        seen_ok = True
+        continue
+    if line == "ok":
+        seen_ok = True
+        continue
+    if line.endswith(" ok"):
+        seen_ok = True
+        continue
+    sys.exit(1)
+if not seen_ok:
+    sys.exit(1)
+PY
+}
+
+require_server_host
+
+body_file="$(mktemp)"
+error_file="$(mktemp)"
+
+TIMEOUT_SECS="$(resolve_positive_int "${TIMEOUT_RAW}")"
+if [ "${TIMEOUT_SECS}" = "INVALID" ]; then
+  echo "Invalid TIMEOUT: ${TIMEOUT_RAW}" >&2
+  exit 2
+fi
+
+POLL_INTERVAL="$(resolve_positive_float "${POLL_INTERVAL_RAW}")"
+if [ "${POLL_INTERVAL}" = "INVALID" ]; then
+  echo "Invalid POLL_INTERVAL: ${POLL_INTERVAL_RAW}" >&2
+  exit 2
+fi
+
+start_epoch="$(date +%s)"
+end_epoch=$((start_epoch + TIMEOUT_SECS))
+
+attempt=0
+last_status=""
+last_reason=""
+
+while :; do
+  attempt=$((attempt + 1))
+  : >"${body_file}"
+  : >"${error_file}"
+
+  curl_status=0
+  curl_args=(-k -sS --show-error -o "${body_file}" -w '%{http_code}')
+  if [ -n "${SERVER_IP}" ]; then
+    curl_args+=(--resolve "${SERVER_HOST}:${SERVER_PORT}:${SERVER_IP}")
+  fi
+  curl_args+=("https://${SERVER_HOST}:${SERVER_PORT}/readyz?verbose")
+
+  http_code="$(curl "${curl_args[@]}" 2>"${error_file}")" || curl_status=$?
+  if [ -z "${http_code}" ]; then
+    http_code="000"
+  fi
+
+  if [ "${curl_status}" -eq 0 ] && [ "${http_code}" = "200" ]; then
+    if validate_ready_body <"${body_file}"; then
+      elapsed=$(( $(date +%s) - start_epoch ))
+      log_fields=(
+        "outcome=ok"
+        "host=\"$(escape_log_value "${SERVER_HOST}")\""
+        "port=\"$(escape_log_value "${SERVER_PORT}")\""
+        "attempts=${attempt}"
+        "elapsed=${elapsed}"
+        "status=${http_code}"
+      )
+      if [ -n "${SERVER_IP}" ]; then
+        log_fields+=("ip=\"$(escape_log_value "${SERVER_IP}")\"")
+      fi
+      log_kv info apiready "${log_fields[@]}" >&2
+      exit 0
+    fi
+    last_reason="body_not_ok"
+  else
+    last_reason="curl_failed"
+  fi
+  last_status="${http_code}:${curl_status}"
+
+  retry_fields=(
+    "outcome=retry"
+    "host=\"$(escape_log_value "${SERVER_HOST}")\""
+    "port=\"$(escape_log_value "${SERVER_PORT}")\""
+    "attempt=${attempt}"
+    "status=${http_code}"
+    "curl_status=${curl_status}"
+    "reason=${last_reason}"
+  )
+  if [ -n "${SERVER_IP}" ]; then
+    retry_fields+=("ip=\"$(escape_log_value "${SERVER_IP}")\"")
+  fi
+  log_kv debug apiready "${retry_fields[@]}" >&2
+
+  now="$(date +%s)"
+  if [ "${now}" -ge "${end_epoch}" ]; then
+    elapsed=$((now - start_epoch))
+    if [ -z "${last_reason}" ]; then
+      last_reason="timeout"
+    fi
+    failure_fields=(
+      "outcome=timeout"
+      "host=\"$(escape_log_value "${SERVER_HOST}")\""
+      "port=\"$(escape_log_value "${SERVER_PORT}")\""
+      "attempts=${attempt}"
+      "elapsed=${elapsed}"
+      "last_status=\"$(escape_log_value "${last_status}")\""
+      "reason=${last_reason}"
+    )
+    if [ -n "${SERVER_IP}" ]; then
+      failure_fields+=("ip=\"$(escape_log_value "${SERVER_IP}")\"")
+    fi
+    log_kv info apiready "${failure_fields[@]}" >&2
+    exit 1
+  fi
+
+  sleep "${POLL_INTERVAL}"
+done

--- a/tests/bats/api_readyz_gate.bats
+++ b/tests/bats/api_readyz_gate.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+
+setup() {
+  SERVER_PID=""
+  ATTEMPT_FILE="${BATS_TEST_TMPDIR}/attempts"
+}
+
+teardown() {
+  if [ -n "${SERVER_PID:-}" ]; then
+    kill "${SERVER_PID}" 2>/dev/null || true
+    wait "${SERVER_PID}" 2>/dev/null || true
+  fi
+}
+
+start_readyz_server() {
+  local port="$1"
+  local cert="${BATS_TEST_TMPDIR}/server.crt"
+  local key="${BATS_TEST_TMPDIR}/server.key"
+  openssl req -x509 -nodes -newkey rsa:2048 \
+    -subj '/CN=localhost' \
+    -keyout "${key}" -out "${cert}" -days 1 >/dev/null 2>&1
+  cat <<'PY' >"${BATS_TEST_TMPDIR}/ready_server.py"
+import http.server
+import os
+import ssl
+import sys
+from pathlib import Path
+
+RESPONSES = [
+    (503, "service unavailable"),
+    (200, "[+]etcd failed\n"),
+    (200, "[+]etcd ok\n[+]log ok\nreadyz check passed\n"),
+]
+
+attempts = 0
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self):
+        global attempts
+        attempts += 1
+        index = min(attempts - 1, len(RESPONSES) - 1)
+        status, body = RESPONSES[index]
+        if self.path.startswith("/readyz"):
+            self.send_response(status)
+            encoded = body.encode("utf-8")
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+        else:
+            self.send_response(404)
+            self.end_headers()
+        Path(os.environ["ATTEMPT_FILE"]).write_text(str(attempts), encoding="utf-8")
+
+    def log_message(self, *_args, **_kwargs):
+        return
+
+
+def main() -> None:
+    port = int(sys.argv[1])
+    cert = sys.argv[2]
+    key = sys.argv[3]
+    attempt_file = sys.argv[4]
+    os.environ["ATTEMPT_FILE"] = attempt_file
+    server = http.server.HTTPServer(("127.0.0.1", port), Handler)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(certfile=cert, keyfile=key)
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()
+PY
+  python3 "${BATS_TEST_TMPDIR}/ready_server.py" "${port}" "${cert}" "${key}" "${ATTEMPT_FILE}" &
+  SERVER_PID=$!
+  sleep 0.5
+}
+
+@test "api ready gate waits for readyz ok" {
+  local port=9443
+  start_readyz_server "${port}"
+
+  run env \
+    SERVER_HOST=localhost \
+    SERVER_PORT="${port}" \
+    SERVER_IP=127.0.0.1 \
+    TIMEOUT=10 \
+    POLL_INTERVAL=0.2 \
+    "${BATS_CWD}/scripts/check_apiready.sh"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ event=apiready ]]
+  [[ "$output" =~ outcome=ok ]]
+  [[ "$output" =~ attempts=3 ]]
+  [ -f "${ATTEMPT_FILE}" ]
+  [ "$(cat "${ATTEMPT_FILE}")" -eq 3 ]
+}

--- a/tests/scripts/test_k3s_discover_mid_election_join.py
+++ b/tests/scripts/test_k3s_discover_mid_election_join.py
@@ -25,6 +25,18 @@ def test_join_when_server_advertises_during_election(tmp_path: Path) -> None:
     publish_log = tmp_path / "publish.log"
     server_flag = tmp_path / "server-published"
 
+    _write_stub(
+        bin_dir / "check_apiready.sh",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "if [ -n \"${SERVER_HOST:-}\" ]; then\n"
+        "  printf 'ts=stub level=info event=apiready outcome=ok host=\"%s\"\\n' \"${SERVER_HOST}\" >&2\n"
+        "else\n"
+        "  printf 'ts=stub level=info event=apiready outcome=ok\\n' >&2\n"
+        "fi\n"
+        "exit 0\n",
+    )
+
     # Stub sleep to avoid delays in the control-flow.
     _write_stub(bin_dir / "sleep", "#!/usr/bin/env bash\nexit 0\n")
 
@@ -155,6 +167,7 @@ def test_join_when_server_advertises_during_election(tmp_path: Path) -> None:
             "SUGARKUBE_TEST_SERVER_THRESHOLD": "1",
             "SH_LOG_PATH": str(sh_log),
             "SUGARKUBE_MDNS_DBUS": "0",
+            "SUGARKUBE_API_READY_CHECK_BIN": str(bin_dir / "check_apiready.sh"),
         }
     )
 


### PR DESCRIPTION
what: add API ready check script, gate server/agent joins, extend tests
why: prevent joining servers before the apiserver and etcd are ready
how: pytest tests/scripts/test_k3s_discover_mid_election_join.py

------
https://chatgpt.com/codex/tasks/task_e_690059b7ee34832f9a060d8c4eaa2737