### PR TITLE
Add TLS SAN template and SAN checks for k3s bootstrap

### DIFF
--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -41,6 +41,12 @@ Copy the long `K10…` string to a safe place—you will export it on every join
 > the initial control-plane bootstrap to run without one so it can mint the token
 > above for the rest of the cluster.
 
+> **TLS SAN for mDNS**
+> The bootstrap step also writes `/etc/rancher/k3s/config.yaml.d/10-sugarkube-tls.yaml`
+> so the API certificate covers `sugarkube0.local`. Set `SUGARKUBE_API_REGADDR`
+> before running `just up` if you advertise a VIP or load balancer—the address is
+> added as an extra SAN to avoid TLS warnings when joining via that endpoint.
+
 ### Remaining control-plane peers or agents
 
 Each additional Pi repeats the same two `just up dev` runs. After the reboot, export the saved token before the second run so it can join the cluster:

--- a/systemd/etc/rancher/k3s/config.yaml.d/10-sugarkube-tls.yaml
+++ b/systemd/etc/rancher/k3s/config.yaml.d/10-sugarkube-tls.yaml
@@ -1,0 +1,3 @@
+tls-san:
+  - "sugarkube0.local"
+  - "${SUGARKUBE_API_REGADDR:-}"

--- a/tests/scripts/test_detect_node_ip.py
+++ b/tests/scripts/test_detect_node_ip.py
@@ -1,9 +1,19 @@
+import os
 import subprocess
 from pathlib import Path
 import shlex
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "configure_k3s_node_ip.sh"
+TLS_TEMPLATE = (
+    REPO_ROOT
+    / "systemd"
+    / "etc"
+    / "rancher"
+    / "k3s"
+    / "config.yaml.d"
+    / "10-sugarkube-tls.yaml"
+)
 
 
 def run_parser(sample: str) -> str:
@@ -40,3 +50,43 @@ def test_select_primary_ipv4_skips_ipv6_and_secondary_entries():
 def test_select_primary_ipv4_handles_extra_spacing():
     sample = "5: eth1    inet   172.16.1.20/24   brd 172.16.1.255   scope global   eth1"
     assert run_parser(sample) == "172.16.1.20"
+
+
+def render_tls_config(tmp_path, regaddr):
+    env = os.environ.copy()
+    env.update(
+        {
+            "LOG_DIR": str(tmp_path / "log"),
+            "TLS_SAN_TEMPLATE_PATH": str(TLS_TEMPLATE),
+            "K3S_CONFIG_DIR": str(tmp_path / "etc" / "rancher" / "k3s"),
+        }
+    )
+    env.pop("SUGARKUBE_API_REGADDR", None)
+    if regaddr is not None:
+        env["SUGARKUBE_API_REGADDR"] = regaddr
+    command = (
+        f"source {shlex.quote(str(SCRIPT_PATH))} >/dev/null 2>&1; "
+        "render_tls_san_config"
+    )
+    subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", command],
+        check=True,
+        env=env,
+        text=True,
+    )
+    dest = tmp_path / "etc" / "rancher" / "k3s" / "config.yaml.d" / "10-sugarkube-tls.yaml"
+    return dest.read_text().splitlines()
+
+
+def test_render_tls_config_skips_empty_registration(tmp_path):
+    lines = render_tls_config(tmp_path, None)
+    assert lines == ["tls-san:", '  - "sugarkube0.local"']
+
+
+def test_render_tls_config_includes_registration_address(tmp_path):
+    lines = render_tls_config(tmp_path, "vip.internal")
+    assert lines == [
+        "tls-san:",
+        '  - "sugarkube0.local"',
+        '  - "vip.internal"',
+    ]


### PR DESCRIPTION
## Summary
- add TLS SAN config template and render it before k3s starts
- warn when the remote server certificate SANs miss the join hostname
- document the optional VIP registration address for TLS SANs

## Testing
- pytest tests/scripts/test_detect_node_ip.py

------
https://chatgpt.com/codex/tasks/task_e_69006174f6dc832fadc5b22e2e4b2d00