### PR TITLE
🛠️ : – Parse parsable avahi output

### DIFF
--- a/tests/bats/mdns_selfcheck.bats
+++ b/tests/bats/mdns_selfcheck.bats
@@ -93,6 +93,41 @@ EOS
   [[ "$output" =~ host=sugarkube0.local ]]
 }
 
+@test "mdns self-check tolerates spaces in TXT values and bootstrap role" {
+  stub_command avahi-browse <<'EOS'
+#!/usr/bin/env bash
+cat <<'TXT'
+=;eth0;IPv4;k3s-sugar-dev@sugarkube0 (bootstrap);_k3s-sugar-dev._tcp;local;sugarkube0.local;10.0.0.15;6443;txt="role=bootstrap";txt="phase=bootstrap";txt="notes=initial bootstrap"
+TXT
+EOS
+
+  stub_command avahi-resolve <<'EOS'
+#!/usr/bin/env bash
+if [ "$1" = "-n" ]; then
+  shift
+fi
+printf '%s %s\n' "$1" "10.0.0.15"
+EOS
+
+  run env \
+    SUGARKUBE_CLUSTER=sugar \
+    SUGARKUBE_ENV=dev \
+    SUGARKUBE_EXPECTED_HOST=sugarkube0.local \
+    SUGARKUBE_EXPECTED_IPV4=10.0.0.15 \
+    SUGARKUBE_EXPECTED_ROLE=bootstrap \
+    SUGARKUBE_EXPECTED_PHASE=bootstrap \
+    SUGARKUBE_SELFCHK_ATTEMPTS=1 \
+    SUGARKUBE_SELFCHK_BACKOFF_START_MS=0 \
+    SUGARKUBE_SELFCHK_BACKOFF_CAP_MS=0 \
+    SUGARKUBE_MDNS_DBUS=0 \
+    "${BATS_CWD}/scripts/mdns_selfcheck.sh"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ outcome=ok ]]
+  [[ "$output" =~ host=sugarkube0.local ]]
+  [[ "$output" =~ ipv4=10.0.0.15 ]]
+}
+
 @test "mdns self-check accepts short host when EXPECTED_HOST has .local" {
   stub_command avahi-browse <<'EOS'
 #!/usr/bin/env bash


### PR DESCRIPTION
what: parse --parsable avahi output and treat TXT as key/value bag.
why: avoid missing instances when names contain spaces or quoted TXT.
how to test: bats tests/bats/mdns_selfcheck.bats (requires bats).


------
https://chatgpt.com/codex/tasks/task_e_69015b6176e0832f933765b8754410f6