### PR TITLE
feat: check mdns service type before browsing

### DIFF
--- a/tests/fixtures/avahi_browse_services_present.txt
+++ b/tests/fixtures/avahi_browse_services_present.txt
@@ -1,0 +1,1 @@
+=;eth0;IPv4;_k3s-sugar-dev._tcp;local


### PR DESCRIPTION
✅ : –
what: ensure mdns self-check verifies service type before browsing
why: fail fast with a clear message when the type is absent
how to test: bats tests/bats/mdns_selfcheck.bats
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_69016ff2e64c832f8b34b6f44040532d