### PR TITLE
📝 : – Document mDNS instance matching guidance

### DIFF
--- a/docs/DBUS.md
+++ b/docs/DBUS.md
@@ -57,6 +57,11 @@ described in [docs/runbook.md](runbook.md#mdns-readiness-gates).
 possible, providing more reliable mDNS validation during the bootstrap and
 server advertisement phases.
 
+RFC 6763 treats the service instance string as a user-facing label. Rich names
+with spaces or punctuation are permitted and should not be used for matching.
+Resolvers must instead confirm the service type, inspect the TXT payload, and
+follow the SRV target that Avahi resolves.
+
 When cleaning up a node (`just wipe`), the discovery flow performs a
 double-negative absence check: it waits for mDNS advertisements to disappear,
 then confirms the absence twice before continuing. This guards against transient

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -28,6 +28,11 @@ Values under 200 ms are typical on a quiet LAN with K3s’ default
 Flannel VXLAN overlay; spikes or timeouts point to multicast flooding or
 pod-network reachability issues that need investigation.
 
+RFC 6763 explicitly allows human-readable service instance names with spaces
+and punctuation. Treat the instance string as display text only—matching must
+verify the service type, TXT attributes, and the SRV record that resolves to
+the authoritative host.
+
 ## Usage examples
 
 Set variables for a single command:

--- a/tests/test_mdns_discovery_parsing.py
+++ b/tests/test_mdns_discovery_parsing.py
@@ -1,5 +1,11 @@
 """Tests for the k3s-discover mDNS helpers."""
 
+# Developer note: RFC 6763 and 6762 expose instance names as display strings,
+# so Avahi may emit spaces and punctuation between the label boundaries that DNS
+# still enforces. The script calls `avahi-browse --parsable` to keep the
+# semicolon field separators intact, ensuring tests exercise the same parsing
+# path instead of relying on naive whitespace splits.
+
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
what: note RFC 6763 instance label expectations in docs and tests
why: ensure developers avoid matching on display strings
how to test: pytest tests/test_mdns_discovery_parsing.py

------
https://chatgpt.com/codex/tasks/task_e_690191586324832fa168b6dd12e04b80