### PR TITLE
🔧 : – confirm Avahi liveness before absence probes

### DIFF
--- a/tests/bats/join_gate.bats
+++ b/tests/bats/join_gate.bats
@@ -16,6 +16,11 @@ teardown() {
 @test "join gate acquire and release manage publisher state" {
   stub_command avahi-browse <<'EOS'
 #!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "--all" ]; then
+  echo "=;eth0;IPv4;dummy;_dummy._tcp;local;dummy.local;192.0.2.1;1234;"
+  exit 0
+fi
 exit 1
 EOS
 
@@ -76,6 +81,10 @@ EOS
   stub_command avahi-browse <<'EOS'
 #!/usr/bin/env bash
 set -euo pipefail
+if [ "$1" = "--all" ]; then
+  echo "=;eth0;IPv4;dummy;_dummy._tcp;local;dummy.local;192.0.2.1;1234;"
+  exit 0
+fi
 count_file="${BATS_TEST_TMPDIR}/browse-count"
 count=0
 if [ -f "${count_file}" ]; then


### PR DESCRIPTION
what: wait for avahi dbus + browse output before absence/self-checks
why: avoid flaking immediately after avahi reloads completes
how to test: bats tests/bats/discover_flow.bats (requires bats)


------
https://chatgpt.com/codex/tasks/task_e_6901c07d0b4c832fa4f6eea831fbdcbc