### PR TITLE
✅ : – Add mDNS regression tests for Avahi permissions

### DIFF
--- a/tests/bats/mdns_wire_probe.bats
+++ b/tests/bats/mdns_wire_probe.bats
@@ -90,3 +90,109 @@ STUB
   [[ "${lines[0]}" =~ reason=dbus_error ]]
   [[ "${lines[0]}" =~ browse_output= ]]
 }
+
+@test "mdns publish static reports permission issues and writes readable service" {
+  service_dir="${BATS_TEST_TMPDIR}/avahi/services"
+  hosts_path="${BATS_TEST_TMPDIR}/avahi/hosts"
+  mkdir -p "${service_dir}"
+  mkdir -p "$(dirname "${hosts_path}")"
+  service_file="${service_dir}/k3s-sugar-dev.service"
+  journal_log="${BATS_TEST_TMPDIR}/journal.log"
+
+  cat "${BATS_CWD}/tests/fixtures/avahi_service_bootstrap.xml" >"${service_file}"
+  chmod 0600 "${service_file}"
+
+  stub_command journalctl <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${TEST_SERVICE_FILE:?}"
+: "${TEST_SERVICE_DISPLAY:?}"
+: "${TEST_SERVICE_TYPE:?}"
+: "${TEST_JOURNAL_LOG:?}"
+
+mode="$(stat -c '%a' "${TEST_SERVICE_FILE}")"
+if [ "${mode}" = "600" ]; then
+  msg="Failed to add service \"${TEST_SERVICE_DISPLAY}\" of type \"${TEST_SERVICE_TYPE}\": Permission denied"
+  printf '%s\n' "${msg}" | tee -a "${TEST_JOURNAL_LOG}"
+else
+  msg="Service \"${TEST_SERVICE_DISPLAY}\" successfully established."
+  printf '%s\n' "${msg}" | tee -a "${TEST_JOURNAL_LOG}"
+fi
+STUB
+
+  run env \
+    TEST_SERVICE_FILE="${service_file}" \
+    TEST_SERVICE_DISPLAY="k3s-sugar-dev@sugarkube0.local (bootstrap)" \
+    TEST_SERVICE_TYPE="_k3s-sugar-dev._tcp" \
+    TEST_JOURNAL_LOG="${journal_log}" \
+    journalctl -u avahi-daemon --since "@0" --no-pager
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ Permission\ denied ]]
+
+  rm -f "${service_file}"
+
+  stub_command getent <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "hosts" ]; then
+  printf '192.0.2.10 sugarkube0.local\n'
+  exit 0
+fi
+exit 1
+STUB
+
+  stub_command avahi-resolve-host-name <<'STUB'
+#!/usr/bin/env bash
+host="$1"
+shift || true
+if [ "${host}" = "sugarkube0.local" ]; then
+  printf '%s\t%s\n' "${host}" "192.0.2.10"
+  exit 0
+fi
+exit 2
+STUB
+
+  stub_command avahi-set-host-name <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+
+  stub_command systemctl <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+
+  run env \
+    SUGARKUBE_CLUSTER=sugar \
+    SUGARKUBE_ENV=dev \
+    HOSTNAME=sugarkube0.local \
+    ROLE=bootstrap \
+    PORT=6443 \
+    SUGARKUBE_AVAHI_SERVICE_DIR="${service_dir}" \
+    SUGARKUBE_AVAHI_HOSTS_PATH="${hosts_path}" \
+    SUGARKUBE_EXPECTED_IPV4=192.0.2.10 \
+    SUGARKUBE_SKIP_SYSTEMCTL=1 \
+    SUGARKUBE_AVAHI_WAIT_TIMEOUT=1 \
+    TEST_SERVICE_FILE="${service_file}" \
+    TEST_SERVICE_DISPLAY="k3s-sugar-dev@sugarkube0.local (bootstrap)" \
+    TEST_SERVICE_TYPE="_k3s-sugar-dev._tcp" \
+    TEST_JOURNAL_LOG="${journal_log}" \
+    "${BATS_CWD}/scripts/mdns_publish_static.sh"
+
+  [ "$status" -eq 0 ]
+  [ -f "${service_file}" ]
+  [ "$(stat -c '%a' "${service_file}")" = "644" ]
+
+  run diff -u "${BATS_CWD}/tests/fixtures/avahi_service_bootstrap.xml" "${service_file}"
+  [ "$status" -eq 0 ]
+
+  if grep -F "Permission denied" "${journal_log}" >/dev/null 2>&1; then
+    echo "Unexpected permission denial in journal output" >&2
+    return 1
+  fi
+  if grep -F "vanished" "${journal_log}" >/dev/null 2>&1; then
+    echo "Unexpected vanished entry in journal output" >&2
+    return 1
+  fi
+  grep -F "successfully established" "${journal_log}" >/dev/null
+}

--- a/tests/fixtures/avahi_hosts_expected.txt
+++ b/tests/fixtures/avahi_hosts_expected.txt
@@ -1,0 +1,1 @@
+10.0.0.10 test-node.local

--- a/tests/fixtures/avahi_service_bootstrap.xml
+++ b/tests/fixtures/avahi_service_bootstrap.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">k3s-sugar-dev@sugarkube0.local (bootstrap)</name>
+  <service>
+    <type>_k3s-sugar-dev._tcp</type>
+    <host-name>sugarkube0.local</host-name>
+    <port>6443</port>
+    <txt-record>k3s=1</txt-record>
+    <txt-record>cluster=sugar</txt-record>
+    <txt-record>env=dev</txt-record>
+    <txt-record>role=bootstrap</txt-record>
+    <txt-record>phase=bootstrap</txt-record>
+    <txt-record>leader=sugarkube0.local</txt-record>
+  </service>
+</service-group>

--- a/tests/scripts/test_configure_avahi.sh
+++ b/tests/scripts/test_configure_avahi.sh
@@ -66,6 +66,13 @@ if ! grep -q '^10.0.0.10 test-node.local$' "${AVAHI_HOSTS_PATH}"; then
   exit 1
 fi
 
+HOSTS_FIXTURE="${REPO_ROOT}/tests/fixtures/avahi_hosts_expected.txt"
+if ! diff -u "${HOSTS_FIXTURE}" "${AVAHI_HOSTS_PATH}" >/dev/null 2>&1; then
+  echo "Avahi hosts file differed from expected fixture" >&2
+  diff -u "${HOSTS_FIXTURE}" "${AVAHI_HOSTS_PATH}" || true
+  exit 1
+fi
+
 if [ ! -f "${CONF_PATH}.bak" ]; then
   echo "Backup was not created" >&2
   exit 1


### PR DESCRIPTION
what: add fixtures and bats coverage for avahi permission/journal flows
why: reproduce regressions for perms/race and warn downgrade
how to test: bats tests/bats/mdns_wire_probe.bats && bats tests/bats/mdns_selfcheck.bats

------
https://chatgpt.com/codex/tasks/task_e_690301217514832fae8d3d50e772b201