### PR TITLE
Add TTY-aware summary API and update k3s discover integration

### DIFF
--- a/scripts/k3s-discover.sh
+++ b/scripts/k3s-discover.sh
@@ -16,7 +16,63 @@ elif [ -f "${SUMMARY_LIB}" ]; then
   # shellcheck disable=SC1090,SC1091  # Runtime-configured summary helper
   . "${SUMMARY_LIB}"
 fi
+
+SUMMARY_API_READY=0
+if command -v summary::init >/dev/null 2>&1; then
+  summary::init
+  SUMMARY_API_READY=1
+fi
+
+SUMMARY_SECTION_AVAHI=0
+SUMMARY_SECTION_MDNS=0
+SUMMARY_SECTION_K3S=0
+SUMMARY_SECTION_DISCOVERY=0
 SUMMARY_DBUS_RECORDED="${SUMMARY_DBUS_RECORDED:-0}"
+
+summary_section_once() {
+  if [ "${SUMMARY_API_READY}" -ne 1 ]; then
+    return 0
+  fi
+  local var_name="$1"
+  local title="$2"
+  local current="${!var_name:-0}"
+  if [ "${current}" -eq 0 ]; then
+    summary::section "${title}"
+    printf -v "${var_name}" '%s' '1'
+  fi
+}
+
+summary_record_event() {
+  if [ "${SUMMARY_API_READY}" -ne 1 ]; then
+    return 0
+  fi
+  local status="$1"
+  local label="$2"
+  local note="${3:-}"
+  local section_var="SUMMARY_SECTION_DISCOVERY"
+  local section_title="Discovery"
+
+  case "${label}" in
+    'D-Bus readiness')
+      section_var="SUMMARY_SECTION_AVAHI"
+      section_title="Avahi"
+      ;;
+    'Self-check (mDNS)'|"Publish "*)
+      section_var="SUMMARY_SECTION_MDNS"
+      section_title="mDNS"
+      ;;
+    'k3s install')
+      section_var="SUMMARY_SECTION_K3S"
+      section_title="k3s"
+      ;;
+  esac
+
+  summary_section_once "${section_var}" "${section_title}"
+  summary::step "${status}" "${label}"
+  if [ -n "${note}" ]; then
+    summary::kv "${label}" "${note}"
+  fi
+}
 
 log_message() {
   local level="$1"
@@ -984,21 +1040,10 @@ cleanup_avahi_publishers() {
 }
 
 ensure_avahi_liveness_signal() {
-  local summary_active=0
-  local summary_start=0
-  local summary_recorded=0
-  local summary_note=""
-
-  if command -v summary_enabled >/dev/null 2>&1 && summary_enabled && [ "${SUMMARY_DBUS_RECORDED}" -eq 0 ]; then
-    summary_active=1
-    summary_start="$(summary_now_ms)"
-  fi
-
   if [ "${AVAHI_LIVENESS_READY}" -eq 1 ]; then
-    if [ "${summary_active}" -eq 1 ]; then
-      summary_step "D-Bus readiness" "OK" "$(summary_elapsed_ms "${summary_start}")" "cached=1"
+    if [ "${SUMMARY_DBUS_RECORDED}" -eq 0 ]; then
+      summary_record_event "OK" "D-Bus readiness" "cached=1"
       SUMMARY_DBUS_RECORDED=1
-      summary_recorded=1
     fi
     return 0
   fi
@@ -1036,16 +1081,13 @@ ensure_avahi_liveness_signal() {
     lines="$(printf '%s\n' "${browse_output}" | sed '/^$/d' | wc -l | tr -d ' ')"
     if [ "${status}" -eq 0 ] && [ -n "${lines}" ] && [ "${lines}" -gt 0 ]; then
       log_info discover event=avahi_liveness outcome=ok attempt="${attempt}" lines="${lines}" >&2
-      if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-        summary_note="attempt=${attempt} lines=${lines}"
+      if [ "${SUMMARY_DBUS_RECORDED}" -eq 0 ]; then
+        local summary_note="attempt=${attempt} lines=${lines}"
         if [ -n "${dbus_note}" ]; then
           summary_note+=" ${dbus_note}"
         fi
-        summary_step "D-Bus readiness" "OK" \
-          "$(summary_elapsed_ms "${summary_start}")" \
-          "${summary_note}"
+        summary_record_event "OK" "D-Bus readiness" "${summary_note}"
         SUMMARY_DBUS_RECORDED=1
-        summary_recorded=1
       fi
       AVAHI_LIVENESS_READY=1
       return 0
@@ -1056,19 +1098,16 @@ ensure_avahi_liveness_signal() {
     fi
   done
 
-  if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-    summary_note="attempts=2 status=${status}"
+  if [ "${SUMMARY_DBUS_RECORDED}" -eq 0 ]; then
+    local summary_note="attempts=2 status=${status}"
     if [ -n "${dbus_note}" ]; then
       summary_note+=" ${dbus_note}"
     fi
     if [ "${wait_status}" -ne 0 ] && [ -z "${dbus_note}" ]; then
       summary_note+=" wait_status=${wait_status}"
     fi
-    summary_step "D-Bus readiness" "FAIL" \
-      "$(summary_elapsed_ms "${summary_start}")" \
-      "${summary_note}"
+    summary_record_event "FAIL" "D-Bus readiness" "${summary_note}"
     SUMMARY_DBUS_RECORDED=1
-    summary_recorded=1
   fi
 
   log_error_msg discover "Avahi liveness probe failed" "event=avahi_liveness" >&2
@@ -1886,23 +1925,11 @@ join_target_host() {
 
 ensure_self_mdns_advertisement() {
   local role="$1"
-  local summary_active=0
-  local summary_start=0
-  local summary_recorded=0
   local summary_note="role=${role}"
-
-  if command -v summary_enabled >/dev/null 2>&1 && summary_enabled; then
-    summary_active=1
-    summary_start="$(summary_now_ms)"
-  fi
 
   if [ "${SKIP_MDNS_SELF_CHECK}" = "1" ]; then
     MDNS_LAST_OBSERVED="${MDNS_HOST_RAW}"
-    if [ "${summary_active}" -eq 1 ]; then
-      summary_step "Self-check (mDNS)" "SKIP" "$(summary_elapsed_ms "${summary_start}")" \
-        "${summary_note} reason=skip"
-      summary_recorded=1
-    fi
+    summary_record_event "SKIP" "Self-check (mDNS)" "${summary_note} reason=skip"
     return 0
   fi
 
@@ -1917,11 +1944,7 @@ ensure_self_mdns_advertisement() {
       delay="${SUGARKUBE_MDNS_SERVER_DELAY}"
       ;;
     *)
-      if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-        summary_step "Self-check (mDNS)" "SKIP" "$(summary_elapsed_ms "${summary_start}")" \
-          "${summary_note} reason=unknown-role"
-        summary_recorded=1
-      fi
+      summary_record_event "SKIP" "Self-check (mDNS)" "${summary_note} reason=unknown-role"
       return 0
       ;;
   esac
@@ -2055,15 +2078,11 @@ PY
         "--tag" "mode=strict" \
         "--tag" "status=0"
     fi
-    if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-      local summary_extra="attempts=${summary_attempts}"
-      if [ -n "${summary_elapsed}" ]; then
-        summary_extra+=" ms=${summary_elapsed}"
-      fi
-      summary_step "Self-check (mDNS)" "OK" "$(summary_elapsed_ms "${summary_start}")" \
-        "${summary_note} ${summary_extra}"
-      summary_recorded=1
+    local summary_extra="attempts=${summary_attempts}"
+    if [ -n "${summary_elapsed}" ]; then
+      summary_extra+=" ms=${summary_elapsed}"
     fi
+    summary_record_event "OK" "Self-check (mDNS)" "${summary_note} ${summary_extra}"
     return 0
   else
     status=$?
@@ -2106,11 +2125,7 @@ PY
           "--tag" "status=0" \
           "--tag" "strict_status=${status}"
       fi
-      if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-        summary_step "Self-check (mDNS)" "WARN" "$(summary_elapsed_ms "${summary_start}")" \
-          "${summary_note} attempts=${retries} relaxed=1"
-        summary_recorded=1
-      fi
+      summary_record_event "WARN" "Self-check (mDNS)" "${summary_note} attempts=${retries} relaxed=1"
       return 0
     else
       relaxed_status="$?"
@@ -2134,15 +2149,11 @@ PY
       "--tag" "strict_status=${status}" \
       "--tag" "relaxed_attempted=0"
   fi
-  if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-    local failure_note="status=${status}"
-    if [ "${relaxed_attempted}" -eq 1 ]; then
-      failure_note+=" relaxed_status=${relaxed_status}"
-    fi
-    summary_step "Self-check (mDNS)" "FAIL" "$(summary_elapsed_ms "${summary_start}")" \
-      "${summary_note} ${failure_note}"
-    summary_recorded=1
+  local failure_note="status=${status}"
+  if [ "${relaxed_attempted}" -eq 1 ]; then
+    failure_note+=" relaxed_status=${relaxed_status}"
   fi
+  summary_record_event "FAIL" "Self-check (mDNS)" "${summary_note} ${failure_note}"
   return "${MDNS_SELF_CHECK_FAILURE_CODE}"
 }
 
@@ -2317,8 +2328,6 @@ publish_avahi_service() {
 
   AVAHI_LIVENESS_READY=0
   local publish_status=0
-  local publish_summary_active=0
-  local publish_summary_start=0
   local publish_note="role=${role}"
   if [ -n "${phase}" ]; then
     publish_note+=" phase=${phase}"
@@ -2326,28 +2335,17 @@ publish_avahi_service() {
   if [ -n "${leader}" ]; then
     publish_note+=" leader=${leader}"
   fi
-  if command -v summary_enabled >/dev/null 2>&1 && summary_enabled; then
-    publish_summary_active=1
-    publish_summary_start="$(summary_now_ms)"
-  fi
 
   if ! run_privileged env "${publish_env[@]}" "${SCRIPT_DIR}/mdns_publish_static.sh"; then
     publish_status=$?
   fi
 
-  if [ "${publish_summary_active}" -eq 1 ]; then
-    local publish_status_label="OK"
-    if [ "${publish_status}" -ne 0 ]; then
-      publish_status_label="FAIL"
-    fi
-    summary_step "Publish ${MDNS_SERVICE_TYPE}" "${publish_status_label}" \
-      "$(summary_elapsed_ms "${publish_summary_start}")" "${publish_note}"
-  fi
-
   if [ "${publish_status}" -ne 0 ]; then
+    summary_record_event "FAIL" "Publish ${MDNS_SERVICE_TYPE}" "${publish_note} code=${publish_status}"
     return "${publish_status}"
   fi
 
+  summary_record_event "OK" "Publish ${MDNS_SERVICE_TYPE}" "${publish_note}"
   ensure_avahi_liveness_signal || return 1
 }
 
@@ -2800,15 +2798,8 @@ server_flag_parity_sources_available() {
 }
 
 install_server_single() {
-  local summary_active=0
-  local summary_start=0
-  local summary_recorded=0
   local summary_status="OK"
   local summary_note="mode=single"
-  if command -v summary_enabled >/dev/null 2>&1 && summary_enabled; then
-    summary_active=1
-    summary_start="$(summary_now_ms)"
-  fi
   ensure_iptables_tools
   log_info discover phase=install_single cluster="${CLUSTER}" environment="${ENVIRONMENT}" host="${MDNS_HOST_RAW}" datastore=sqlite >&2
   local env_assignments
@@ -2825,11 +2816,7 @@ install_server_single() {
   if wait_for_api; then
     if ! publish_api_service; then
       log_error_msg discover "Failed to confirm Avahi server advertisement" "host=${MDNS_HOST_RAW}" "phase=install_single"
-      if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-        summary_step "k3s install" "FAIL" "$(summary_elapsed_ms "${summary_start}")" \
-          "${summary_note} reason=mdns"
-        summary_recorded=1
-      fi
+      summary_record_event "FAIL" "k3s install" "${summary_note} reason=mdns"
       exit 1
     fi
   else
@@ -2837,24 +2824,12 @@ install_server_single() {
     summary_status="WARN"
     summary_note+=" reason=api-timeout"
   fi
-  if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-    summary_step "k3s install" "${summary_status}" \
-      "$(summary_elapsed_ms "${summary_start}")" \
-      "${summary_note}"
-    summary_recorded=1
-  fi
+  summary_record_event "${summary_status}" "k3s install" "${summary_note}"
 }
 
 install_server_cluster_init() {
-  local summary_active=0
-  local summary_start=0
-  local summary_recorded=0
   local summary_status="OK"
   local summary_note="mode=cluster-init"
-  if command -v summary_enabled >/dev/null 2>&1 && summary_enabled; then
-    summary_active=1
-    summary_start="$(summary_now_ms)"
-  fi
   ensure_iptables_tools
   log_info discover phase=install_cluster_init cluster="${CLUSTER}" environment="${ENVIRONMENT}" host="${MDNS_HOST_RAW}" datastore=etcd >&2
   local env_assignments
@@ -2872,11 +2847,7 @@ install_server_cluster_init() {
   if wait_for_api; then
     if ! publish_api_service; then
       log_error_msg discover "Failed to confirm Avahi server advertisement" "host=${MDNS_HOST_RAW}" "phase=install_cluster_init"
-      if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-        summary_step "k3s install" "FAIL" "$(summary_elapsed_ms "${summary_start}")" \
-          "${summary_note} reason=mdns"
-        summary_recorded=1
-      fi
+      summary_record_event "FAIL" "k3s install" "${summary_note} reason=mdns"
       exit 1
     fi
   else
@@ -2884,12 +2855,7 @@ install_server_cluster_init() {
     summary_status="WARN"
     summary_note+=" reason=api-timeout"
   fi
-  if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-    summary_step "k3s install" "${summary_status}" \
-      "$(summary_elapsed_ms "${summary_start}")" \
-      "${summary_note}"
-    summary_recorded=1
-  fi
+  summary_record_event "${summary_status}" "k3s install" "${summary_note}"
 }
 
 install_server_join() {
@@ -2897,35 +2863,20 @@ install_server_join() {
   local server
   server="$(join_target_host "${discovered_server}")"
   local probe_host="${server}"
-  local summary_active=0
-  local summary_start=0
-  local summary_recorded=0
   local summary_status="OK"
   local summary_note="mode=join"
-  if command -v summary_enabled >/dev/null 2>&1 && summary_enabled; then
-    summary_active=1
-    summary_start="$(summary_now_ms)"
-  fi
   if [ -n "${API_REGADDR:-}" ] && [ -n "${discovered_server:-}" ]; then
     probe_host="${discovered_server}"
   fi
   if [ -z "${TOKEN:-}" ]; then
     log_error_msg discover "Join token missing; cannot join existing HA server" "phase=install_join" "host=${MDNS_HOST_RAW}"
-    if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-      summary_step "k3s install" "FAIL" "$(summary_elapsed_ms "${summary_start}")" \
-        "${summary_note} reason=token"
-      summary_recorded=1
-    fi
+    summary_record_event "FAIL" "k3s install" "${summary_note} reason=token"
     exit 1
   fi
   local required_ports="6443,2379,2380"
   if [ ! -x "${L4_PROBE_BIN}" ]; then
     log_error_msg discover "Port connectivity helper missing" "phase=install_join" "server=${server}" "script=${L4_PROBE_BIN}"
-    if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-      summary_step "k3s install" "FAIL" "$(summary_elapsed_ms "${summary_start}")" \
-        "${summary_note} reason=l4-probe"
-      summary_recorded=1
-    fi
+    summary_record_event "FAIL" "k3s install" "${summary_note} reason=l4-probe"
     exit 1
   fi
   local probe_output=""
@@ -2958,46 +2909,26 @@ install_server_join() {
       "ports=${required_ports}"
     log_error_msg discover "Ensure TCP 6443, 2379, and 2380 are open between control-plane nodes before retrying" \
       "phase=install_join" "server=${server}"
-    if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-      summary_step "k3s install" "FAIL" "$(summary_elapsed_ms "${summary_start}")" \
-        "${summary_note} reason=ports"
-      summary_recorded=1
-    fi
+    summary_record_event "FAIL" "k3s install" "${summary_note} reason=ports"
     exit 1
   fi
   if ! wait_for_remote_api_ready "${server}"; then
-    if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-      summary_step "k3s install" "FAIL" "$(summary_elapsed_ms "${summary_start}")" \
-        "${summary_note} reason=remote-api"
-      summary_recorded=1
-    fi
+    summary_record_event "FAIL" "k3s install" "${summary_note} reason=remote-api"
     exit 1
   fi
   if ! ensure_server_flag_parity "${server}" "install_join"; then
     log_error_msg discover "Server flag parity validation failed" \
       "phase=install_join" "host=${MDNS_HOST_RAW}" "server=${server}"
-    if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-      summary_step "k3s install" "FAIL" "$(summary_elapsed_ms "${summary_start}")" \
-        "${summary_note} reason=flag-parity"
-      summary_recorded=1
-    fi
+    summary_record_event "FAIL" "k3s install" "${summary_note} reason=flag-parity"
     exit 1
   fi
   if ! ensure_time_sync "install_join"; then
-    if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-      summary_step "k3s install" "FAIL" "$(summary_elapsed_ms "${summary_start}")" \
-        "${summary_note} reason=time-sync"
-      summary_recorded=1
-    fi
+    summary_record_event "FAIL" "k3s install" "${summary_note} reason=time-sync"
     exit 1
   fi
   check_remote_server_tls_sans "${server}"
   if ! acquire_join_gate; then
-    if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-      summary_step "k3s install" "FAIL" "$(summary_elapsed_ms "${summary_start}")" \
-        "${summary_note} reason=join-gate"
-      summary_recorded=1
-    fi
+    summary_record_event "FAIL" "k3s install" "${summary_note} reason=join-gate"
     exit 1
   fi
   ensure_iptables_tools
@@ -3027,20 +2958,12 @@ install_server_join() {
   if wait_for_api; then
     if ! publish_api_service; then
       log_error_msg discover "Failed to confirm Avahi server advertisement" "host=${MDNS_HOST_RAW}" "phase=install_join"
-      if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-        summary_step "k3s install" "FAIL" "$(summary_elapsed_ms "${summary_start}")" \
-          "${summary_note} reason=mdns"
-        summary_recorded=1
-      fi
+      summary_record_event "FAIL" "k3s install" "${summary_note} reason=mdns"
       exit 1
     fi
     if ! release_join_gate_if_needed; then
       log_error_msg discover "Failed to release join gate" "phase=install_join"
-      if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-        summary_step "k3s install" "FAIL" "$(summary_elapsed_ms "${summary_start}")" \
-          "${summary_note} reason=join-gate-release"
-        summary_recorded=1
-      fi
+      summary_record_event "FAIL" "k3s install" "${summary_note} reason=join-gate-release"
       exit 1
     fi
   else
@@ -3048,59 +2971,31 @@ install_server_join() {
     summary_status="WARN"
     summary_note+=" reason=api-timeout"
   fi
-  if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-    summary_step "k3s install" "${summary_status}" \
-      "$(summary_elapsed_ms "${summary_start}")" \
-      "${summary_note}"
-    summary_recorded=1
-  fi
+  summary_record_event "${summary_status}" "k3s install" "${summary_note}"
 }
 
 install_agent() {
   local discovered_server="$1"
   local server
   server="$(join_target_host "${discovered_server}")"
-  local summary_active=0
-  local summary_start=0
-  local summary_recorded=0
   local summary_note="mode=agent"
-  if command -v summary_enabled >/dev/null 2>&1 && summary_enabled; then
-    summary_active=1
-    summary_start="$(summary_now_ms)"
-  fi
   if [ -z "${TOKEN:-}" ]; then
     log_error_msg discover "Join token missing; cannot join agent to existing server" "phase=install_agent" "host=${MDNS_HOST_RAW}"
-    if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-      summary_step "k3s install" "FAIL" "$(summary_elapsed_ms "${summary_start}")" \
-        "${summary_note} reason=token"
-      summary_recorded=1
-    fi
+    summary_record_event "FAIL" "k3s install" "${summary_note} reason=token"
     exit 1
   fi
   if ! wait_for_remote_api_ready "${server}"; then
-    if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-      summary_step "k3s install" "FAIL" "$(summary_elapsed_ms "${summary_start}")" \
-        "${summary_note} reason=remote-api"
-      summary_recorded=1
-    fi
+    summary_record_event "FAIL" "k3s install" "${summary_note} reason=remote-api"
     exit 1
   fi
   if ! ensure_server_flag_parity "${server}" "install_agent"; then
     log_error_msg discover "Server flag parity validation failed" \
       "phase=install_agent" "host=${MDNS_HOST_RAW}" "server=${server}"
-    if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-      summary_step "k3s install" "FAIL" "$(summary_elapsed_ms "${summary_start}")" \
-        "${summary_note} reason=flag-parity"
-      summary_recorded=1
-    fi
+    summary_record_event "FAIL" "k3s install" "${summary_note} reason=flag-parity"
     exit 1
   fi
   if ! ensure_time_sync "install_agent"; then
-    if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-      summary_step "k3s install" "FAIL" "$(summary_elapsed_ms "${summary_start}")" \
-        "${summary_note} reason=time-sync"
-      summary_recorded=1
-    fi
+    summary_record_event "FAIL" "k3s install" "${summary_note} reason=time-sync"
     exit 1
   fi
   ensure_iptables_tools
@@ -3121,12 +3016,7 @@ install_agent() {
       sh -s - agent \
       --node-label "sugarkube.cluster=${CLUSTER}" \
       --node-label "sugarkube.env=${ENVIRONMENT}"
-  if [ "${summary_active}" -eq 1 ] && [ "${summary_recorded}" -eq 0 ]; then
-    summary_step "k3s install" "OK" \
-      "$(summary_elapsed_ms "${summary_start}")" \
-      "${summary_note}"
-    summary_recorded=1
-  fi
+  summary_record_event "OK" "k3s install" "${summary_note}"
 }
 
 if [ -n "${TEST_RUN_AVAHI:-}" ]; then

--- a/scripts/lib/summary.sh
+++ b/scripts/lib/summary.sh
@@ -1,367 +1,275 @@
 #!/usr/bin/env bash
 
-# Summary reporting helpers. Designed to be sourced by interactive shells and
-# non-interactive scripts alike. The functions are safe to call even when the
-# summary feature is disabled (SUGARKUBE_SUMMARY_FILE unset or unwritable).
+# Summary reporting helpers used by sugarkube shell recipes. The public API is the
+# summary::* namespace which exposes a tiny set of functions that are safe to call
+# from both interactive shells and unattended automation.
 
 if [ -n "${SUGARKUBE_SUMMARY_LOADED:-}" ]; then
   return 0 2>/dev/null || exit 0
 fi
-export SUGARKUBE_SUMMARY_LOADED=1
+SUGARKUBE_SUMMARY_LOADED=1
 
-summary_enabled() {
-  [ -n "${SUGARKUBE_SUMMARY_FILE:-}" ] && [ "${SUGARKUBE_SUMMARY_SUPPRESS:-0}" != "1" ]
+SUMMARY_DATA=""
+SUMMARY_HAS_ITEMS=0
+SUMMARY_EMITTED=0
+SUMMARY_INITIALIZED=0
+SUMMARY_TRAP_SET=0
+SUMMARY_IS_TTY=0
+SUMMARY_COLOR_RESET=""
+SUMMARY_COLOR_SECTION=""
+SUMMARY_COLOR_DIM=""
+SUMMARY_COLOR_OK=""
+SUMMARY_COLOR_WARN=""
+SUMMARY_COLOR_FAIL=""
+SUMMARY_COLOR_SKIP=""
+
+summary__call_with_safe_opts() {
+  local __restore __rc
+  __restore="$(set +o)"
+  set -Eeuo pipefail
+  "$@"
+  __rc=$?
+  eval "${__restore}"
+  return "${__rc}"
 }
 
-summary__ensure_file() {
-  if ! summary_enabled; then
+summary__clean_text() {
+  local text="${1:-}"
+  text="${text//$'\r'/ }"
+  text="${text//$'\n'/ }"
+  text="${text//$'\t'/ }"
+  text="${text//|/∣}"
+  printf '%s' "${text}"
+}
+
+summary__append_line() {
+  SUMMARY_DATA+="${1}"$'\n'
+  SUMMARY_HAS_ITEMS=1
+}
+
+summary__status_symbol() {
+  case "${1}" in
+    OK) printf '✅' ;;
+    WARN) printf '⚠️' ;;
+    FAIL) printf '❌' ;;
+    SKIP) printf '⏭️' ;;
+    *) printf '%s' "${1}" ;;
+  esac
+}
+
+summary__status_color() {
+  case "${1}" in
+    OK) printf '%s' "${SUMMARY_COLOR_OK}" ;;
+    WARN) printf '%s' "${SUMMARY_COLOR_WARN}" ;;
+    FAIL) printf '%s' "${SUMMARY_COLOR_FAIL}" ;;
+    SKIP) printf '%s' "${SUMMARY_COLOR_SKIP}" ;;
+    *) printf '' ;;
+  esac
+}
+
+summary__colorize() {
+  local color="${1:-}"
+  local text="${2:-}"
+  if [ "${SUMMARY_IS_TTY}" -eq 1 ] && [ -n "${color}" ]; then
+    printf '%s%s%s' "${color}" "${text}" "${SUMMARY_COLOR_RESET}"
+  else
+    printf '%s' "${text}"
+  fi
+}
+
+summary__render_section() {
+  local title="${1:-}"
+  if [ -z "${title}" ]; then
+    return 0
+  fi
+  summary__colorize "${SUMMARY_COLOR_SECTION}" "${title}"
+}
+
+summary__render_step() {
+  local status="${1}" label="${2}"
+  local symbol color text
+  symbol="$(summary__status_symbol "${status}")"
+  text="${symbol} ${label}"
+  color="$(summary__status_color "${status}")"
+  printf '  %s\n' "$(summary__colorize "${color}" "${text}")"
+}
+
+summary__render_kv() {
+  local key="${1}" value="${2}"
+  local key_text
+  if [ "${SUMMARY_IS_TTY}" -eq 1 ] && [ -n "${SUMMARY_COLOR_DIM}" ]; then
+    key_text="$(summary__colorize "${SUMMARY_COLOR_DIM}" "${key}")"
+  else
+    key_text="${key}"
+  fi
+  printf '    %s: %s\n' "${key_text}" "${value}"
+}
+
+summary__render() {
+  local output='' line type rest status label key value after_header=1
+  local data="${SUMMARY_DATA%$'\n'}"
+
+  output+='Summary'$'\n'
+  output+='======='$'\n'
+
+  while IFS= read -r line; do
+    [ -n "${line}" ] || continue
+    type="${line%%|*}"
+    rest="${line#*|}"
+    case "${type}" in
+      S)
+        if [ "${after_header}" -eq 1 ]; then
+          output+=$'\n'
+          after_header=0
+        else
+          output+=$'\n'
+        fi
+        output+="$(summary__render_section "${rest}")"$'\n'
+        ;;
+      T)
+        if [ "${after_header}" -eq 1 ]; then
+          output+=$'\n'
+          after_header=0
+        fi
+        status="${rest%%|*}"
+        label="${rest#*|}"
+        output+="$(summary__render_step "${status}" "${label}")"
+        ;;
+      K)
+        if [ "${after_header}" -eq 1 ]; then
+          output+=$'\n'
+          after_header=0
+        fi
+        key="${rest%%|*}"
+        value="${rest#*|}"
+        output+="$(summary__render_kv "${key}" "${value}")"
+        ;;
+      *)
+        ;;
+    esac
+  done <<< "${data}"
+
+  printf '%s' "${output}"
+}
+
+summary__ensure_summary_file() {
+  if [ -z "${SUGARKUBE_SUMMARY_FILE:-}" ]; then
     return 1
   fi
   local dir
   dir="$(dirname "${SUGARKUBE_SUMMARY_FILE}")"
   if [ ! -d "${dir}" ]; then
-    mkdir -p "${dir}" 2>/dev/null || true
-  fi
-  if [ ! -f "${SUGARKUBE_SUMMARY_FILE}" ]; then
-    : >"${SUGARKUBE_SUMMARY_FILE}" 2>/dev/null || return 1
+    mkdir -p "${dir}"
   fi
   return 0
 }
 
-summary_now_ms() {
-  python3 - <<'PY' 2>/dev/null || date +%s%3N
-import time
-print(int(time.time() * 1000))
-PY
-}
-
-summary_elapsed_ms() {
-  local start_ms="$1"
-  local now
-  now="$(summary_now_ms)"
-  case "${start_ms}" in
-    ''|*[!0-9-]*) start_ms=0 ;;
-  esac
-  case "${now}" in
-    ''|*[!0-9-]*) now=0 ;;
-  esac
-  if [ "${now}" -lt "${start_ms}" ]; then
-    now="${start_ms}"
-  fi
-  printf '%d\n' $((now - start_ms))
-}
-
-summary_sanitize_note() {
-  local note="$1"
-  note="${note//$'\n'/' '}"
-  note="${note//$'\r'/' '}"
-  printf '%s' "${note}"
-}
-
-summary_step() {
-  local name="$1"
-  local status="${2:-OK}"
-  local duration_ms="${3:-0}"
-  local note="${4:-}"
-
-  if ! summary_enabled; then
+summary__emit_impl() {
+  if [ "${SUMMARY_EMITTED}" -eq 1 ]; then
     return 0
   fi
-  if ! summary__ensure_file; then
+  SUMMARY_EMITTED=1
+
+  if [ "${SUMMARY_HAS_ITEMS}" -eq 0 ]; then
     return 0
   fi
 
-  case "${status}" in
-    ok|Ok|oK) status="OK" ;;
-    warn|Warn) status="WARN" ;;
-    fail|Fail) status="FAIL" ;;
-    skip|Skip) status="SKIP" ;;
-    OK|WARN|FAIL|SKIP) ;;
-    *) status="${status^^}" ;;
-  esac
-
-  case "${duration_ms}" in
-    ''|*[!0-9-]*) duration_ms=0 ;;
-  esac
-
-  local timestamp
-  timestamp="$(summary_now_ms)"
-  note="$(summary_sanitize_note "${note}")"
-
-  printf '%s\t%s\t%s\t%s\t%s\n' \
-    "${timestamp}" "${duration_ms}" "${status}" "${name}" "${note}" \
-    >>"${SUGARKUBE_SUMMARY_FILE}" 2>/dev/null || true
-}
-
-summary_skip() {
-  local name="$1"
-  local note="${2:-}"
-  summary_step "${name}" "SKIP" 0 "${note}"
-}
-
-summary_run() {
-  local note=""
-  while [ "$#" -gt 0 ]; do
-    case "$1" in
-      --note)
-        shift
-        note="${1:-}"
-        shift || true
-        ;;
-      --)
-        shift
-        break
-        ;;
-      --*)
-        break
-        ;;
-      *)
-        break
-        ;;
-    esac
-  done
-
-  if [ "$#" -lt 1 ]; then
+  local rendered
+  rendered="$(summary__render)"
+  if [ -z "${rendered}" ]; then
     return 0
   fi
 
-  local name="$1"
-  shift
-
-  local start_ms status duration exit_code
-  start_ms="$(summary_now_ms)"
-
-  set +e
-  "$@"
-  exit_code=$?
-  set -e
-
-  duration="$(summary_elapsed_ms "${start_ms}")"
-  status="OK"
-  if [ "${exit_code}" -ne 0 ]; then
-    status="FAIL"
-  fi
-
-  summary_step "${name}" "${status}" "${duration}" "${note}"
-  return "${exit_code}"
-}
-
-summary_display_width() {
-  SUMMARY_TMP_TEXT="${1-}" python3 - <<'PY'
-import os
-import re
-import sys
-import unicodedata
-text = os.environ.get("SUMMARY_TMP_TEXT", "")
-ansi_re = re.compile(r"\x1B\[[0-9;]*m")
-text = ansi_re.sub("", text)
-width = 0
-for ch in text:
-    if unicodedata.category(ch) in ("Mn", "Me", "Cf"):
-        continue
-    if unicodedata.combining(ch):
-        continue
-    if unicodedata.east_asian_width(ch) in ("F", "W"):
-        width += 2
-    else:
-        width += 1
-print(width)
-PY
-}
-
-summary_repeat_char() {
-  local char="$1"
-  local count="$2"
-  local result=""
-  while [ "${count}" -gt 0 ]; do
-    result+="${char}"
-    count=$((count - 1))
-  done
-  printf '%s' "${result}"
-}
-
-summary_format_duration() {
-  local ms="$1"
-  python3 - <<'PY' "${ms}"
-import sys
-try:
-    value = int(sys.argv[1])
-except (IndexError, ValueError):
-    value = 0
-if value < 0:
-    value = 0
-seconds, millis = divmod(value, 1000)
-minutes, seconds = divmod(seconds, 60)
-if minutes:
-    rem = seconds + millis / 1000.0
-    print(f"{minutes}m {rem:.1f}s")
-elif value >= 1000:
-    print(f"{seconds + millis / 1000.0:.1f}s")
-else:
-    print(f"{value}ms")
-PY
-}
-
-summary_status_display() {
-  local status="$1"
-  case "${status}" in
-    OK)
-      printf '\033[32m✅ OK\033[0m'
-      ;;
-    WARN)
-      printf '\033[33m⚠️ WARN\033[0m'
-      ;;
-    FAIL)
-      printf '\033[31m❌ FAIL\033[0m'
-      ;;
-    SKIP)
-      printf '\033[34m⏭️ SKIP\033[0m'
-      ;;
-    *)
-      printf '%s' "${status}"
-      ;;
-  esac
-}
-
-summary_status_plain() {
-  local status="$1"
-  case "${status}" in
-    OK) printf '✅ OK' ;;
-    WARN) printf '⚠️ WARN' ;;
-    FAIL) printf '❌ FAIL' ;;
-    SKIP) printf '⏭️ SKIP' ;;
-    *) printf '%s' "${status}" ;;
-  esac
-}
-
-summary_pad() {
-  local text="$1"
-  local width="$2"
-  local actual padding
-  actual="$(summary_display_width "${text}")"
-  case "${actual}" in
-    ''|*[!0-9]*) actual=0 ;;
-  esac
-  padding=$((width - actual))
-  if [ "${padding}" -lt 0 ]; then
-    padding=0
-  fi
-  printf '%s' "${text}"
-  if [ "${padding}" -gt 0 ]; then
-    printf '%*s' "${padding}" ''
+  if [ -n "${SUGARKUBE_SUMMARY_FILE:-}" ]; then
+    summary__ensure_summary_file || true
+    printf '%s\n' "${rendered}" | tee -a "${SUGARKUBE_SUMMARY_FILE}" >&1
+  else
+    printf '%s\n' "${rendered}"
   fi
 }
 
-summary_finalize() {
-  if ! summary_enabled; then
-    return 0
-  fi
-  if [ ! -s "${SUGARKUBE_SUMMARY_FILE}" ]; then
-    return 0
-  fi
+summary__emit_trap() {
+  summary::emit || true
+}
 
-  local -a names=()
-  local -a status_codes=()
-  local -a status_display=()
-  local -a status_plain=()
-  local -a durations=()
-  local -a notes=()
+summary__init_impl() {
+  SUMMARY_DATA=""
+  SUMMARY_HAS_ITEMS=0
+  SUMMARY_EMITTED=0
 
-  local line
-  while IFS=$'\t' read -r _start_ms duration status name note; do
-    [ -n "${name}" ] || continue
-    names+=("${name}")
-    status_codes+=("${status}")
-    status_display+=("$(summary_status_display "${status}")")
-    status_plain+=("$(summary_status_plain "${status}")")
-    durations+=("$(summary_format_duration "${duration}")")
-    notes+=("${note}")
-  done <"${SUGARKUBE_SUMMARY_FILE}"
-
-  local count="${#names[@]}"
-  if [ "${count}" -eq 0 ]; then
-    return 0
+  if [ -t 1 ] && [ "${TERM:-}" != "dumb" ]; then
+    SUMMARY_IS_TTY=1
+  else
+    SUMMARY_IS_TTY=0
   fi
 
-  local step_width status_width duration_width
-  step_width="$(summary_display_width "Step")"
-  status_width="$(summary_display_width "Status")"
-  duration_width="$(summary_display_width "Duration")"
+  SUMMARY_COLOR_RESET=""
+  SUMMARY_COLOR_SECTION=""
+  SUMMARY_COLOR_DIM=""
+  SUMMARY_COLOR_OK=""
+  SUMMARY_COLOR_WARN=""
+  SUMMARY_COLOR_FAIL=""
+  SUMMARY_COLOR_SKIP=""
 
-  local idx note extra step_label plain_status
-  for idx in "${!names[@]}"; do
-    step_label="${names[idx]}"
-    note="${notes[idx]}"
-    if [ -n "${note}" ]; then
-      step_label+=" "
-      step_label+="\033[2m(${note})\033[0m"
-    fi
-    names[idx]="${step_label}"
-    extra="$(summary_display_width "${step_label}")"
-    if [ "${extra}" -gt "${step_width}" ]; then
-      step_width="${extra}"
-    fi
-    plain_status="${status_plain[idx]}"
-    extra="$(summary_display_width "${plain_status}")"
-    if [ "${extra}" -gt "${status_width}" ]; then
-      status_width="${extra}"
-    fi
-    extra="$(summary_display_width "${durations[idx]}")"
-    if [ "${extra}" -gt "${duration_width}" ]; then
-      duration_width="${extra}"
-    fi
-  done
+  if [ "${SUMMARY_IS_TTY}" -eq 1 ] && command -v tput >/dev/null 2>&1; then
+    SUMMARY_COLOR_RESET="$(tput sgr0 2>/dev/null || printf '')"
+    SUMMARY_COLOR_SECTION="$(tput bold 2>/dev/null || printf '')"
+    SUMMARY_COLOR_DIM="$(tput dim 2>/dev/null || printf '')"
+    SUMMARY_COLOR_OK="$(tput setaf 2 2>/dev/null || printf '')"
+    SUMMARY_COLOR_WARN="$(tput setaf 3 2>/dev/null || printf '')"
+    SUMMARY_COLOR_FAIL="$(tput setaf 1 2>/dev/null || printf '')"
+    SUMMARY_COLOR_SKIP="$(tput setaf 4 2>/dev/null || printf '')"
+  fi
 
-  local step_total status_total duration_total
-  step_total=$((step_width + 2))
-  status_total=$((status_width + 2))
-  duration_total=$((duration_width + 2))
+  SUMMARY_INITIALIZED=1
 
-  printf '\n'
-  printf '┏%s┳%s┳%s┓\n' \
-    "$(summary_repeat_char '━' "${step_total}")" \
-    "$(summary_repeat_char '━' "${status_total}")" \
-    "$(summary_repeat_char '━' "${duration_total}")"
-  printf '┃ '
-  summary_pad "Step" "${step_width}"
-  printf ' ┃ '
-  summary_pad "Status" "${status_width}"
-  printf ' ┃ '
-  summary_pad "Duration" "${duration_width}"
-  printf ' ┃\n'
-  printf '┣%s╋%s╋%s┫\n' \
-    "$(summary_repeat_char '━' "${step_total}")" \
-    "$(summary_repeat_char '━' "${status_total}")" \
-    "$(summary_repeat_char '━' "${duration_total}")"
+  if [ "${SUMMARY_TRAP_SET}" -eq 0 ]; then
+    trap 'summary__emit_trap' EXIT
+    SUMMARY_TRAP_SET=1
+  fi
+}
 
-  for idx in "${!names[@]}"; do
-    printf '┃ '
-    summary_pad "${names[idx]}" "${step_width}"
-    printf ' ┃ '
-    summary_pad "${status_display[idx]}" "${status_width}"
-    printf ' ┃ '
-    summary_pad "${durations[idx]}" "${duration_width}"
-    printf ' ┃\n'
-  done
-
-  printf '┗%s┻%s┻%s┛\n' \
-    "$(summary_repeat_char '━' "${step_total}")" \
-    "$(summary_repeat_char '━' "${status_total}")" \
-    "$(summary_repeat_char '━' "${duration_total}")"
+summary__ensure_initialized() {
+  if [ "${SUMMARY_INITIALIZED}" -eq 0 ]; then
+    summary::init
+  fi
 }
 
 summary::init() {
-  summary__ensure_file || true
+  summary__call_with_safe_opts summary__init_impl
 }
 
-summary::section() { :; }
+summary::section() {
+  summary__ensure_initialized
+  local title
+  title="$(summary__clean_text "${1:-}")"
+  [ -n "${title}" ] || return 0
+  summary__append_line "S|${title}"
+}
 
 summary::step() {
-  summary_step "$@"
+  summary__ensure_initialized
+  local status_raw="${1:-}" label_raw="${2:-}"
+  [ -n "${label_raw}" ] || return 0
+  local status="${status_raw^^}"
+  case "${status}" in
+    OK|WARN|FAIL|SKIP) ;;
+    *) status="WARN" ;;
+  esac
+  local label
+  label="$(summary__clean_text "${label_raw}")"
+  summary__append_line "T|${status}|${label}"
 }
 
-summary::kv() { :; }
+summary::kv() {
+  summary__ensure_initialized
+  local key value
+  key="$(summary__clean_text "${1:-}")"
+  value="$(summary__clean_text "${2:-}")"
+  [ -n "${key}" ] || return 0
+  summary__append_line "K|${key}|${value}"
+}
 
 summary::emit() {
-  summary_finalize
+  summary__call_with_safe_opts summary__emit_impl
 }

--- a/tests/bats/summary.bats
+++ b/tests/bats/summary.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+run_summary_script() {
+  local term_value="$1"
+  shift
+  local script="${BATS_CWD}/scripts/lib/summary.sh"
+  TERM="${term_value}" bash -c "\
+set -euo pipefail\n\
+. '${script}'\n\
+summary::init\n\
+summary::section 'Demo'\n\
+summary::step OK 'Alpha'\n\
+summary::kv 'Alpha' 'note=1'\n\
+summary::step FAIL 'Beta'\n\
+summary::emit\n"
+}
+
+@test "summary emit produces non-empty output" {
+  run run_summary_script "xterm"
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -gt 0 ]
+  [[ "${output}" =~ Summary ]]
+  [[ "${output}" =~ Alpha ]]
+  [[ "${output}" =~ Beta ]]
+  [[ "${output}" =~ ✅ ]]
+}
+
+@test "summary output omits ANSI escapes when TERM=dumb" {
+  run run_summary_script "dumb"
+  [ "$status" -eq 0 ]
+  [[ ! "${output}" =~ $'\u001b' ]]
+}


### PR DESCRIPTION
🚀 : Add TTY-aware summary API and tests

what:
- introduce summary::init/section/step/kv/emit with TTY-aware colour handling
- update k3s-discover to record events via the new API and streamline notes
- add a Bats test covering summary output in TTY and TERM=dumb scenarios

why:
- provide a stable summary helper for both interactive recipes and CI logs

how to test:
- bats tests/bats/summary.bats


------
https://chatgpt.com/codex/tasks/task_e_6903132ab948832fb64cd7adb544a9f0