### PR TITLE
summary: TTY-aware summary API and tests

### DIFF
--- a/tests/bats/summary.bats
+++ b/tests/bats/summary.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+setup() {
+  SUMMARY_LIB_PATH="${BATS_CWD}/scripts/lib/summary.sh"
+}
+
+@test "summary emit produces output" {
+  run bash -c 'source "$1"; summary::init; summary::section "Demo"; summary::step OK "Sample"; summary::emit' "summary" "${SUMMARY_LIB_PATH}"
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+  [[ "$output" =~ Sample ]]
+}
+
+@test "summary emit is plain text for non-tty outputs" {
+  run bash -c 'source "$1"; summary::init; summary::section "TTY"; summary::step OK "Color"; summary::emit' "summary" "${SUMMARY_LIB_PATH}"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *$'\033'* ]]
+
+  TERM=dumb run bash -c 'source "$1"; summary::init; summary::section "TTY"; summary::step OK "Color"; summary::emit' "summary" "${SUMMARY_LIB_PATH}"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *$'\033'* ]]
+}


### PR DESCRIPTION
## Summary
- introduce a summary:: API that detects TTYs, emits colour when available, and always prints on exit
- switch k3s-discover to record environment, Avahi, mDNS, and k3s steps via summary::section/step/kv helpers
- add bats coverage to ensure the summary output exists and stays plain text on non-TTY or TERM=dumb runs

## Testing
- bats tests/bats/summary.bats *(fails: bats executable not present in container)*

------
https://chatgpt.com/codex/tasks/task_e_6903132ab948832fb64cd7adb544a9f0