### PR TITLE
Fix stdout logging for readiness utilities

### DIFF
--- a/outages/2025-10-30-check-apiready-stdout-regression.json
+++ b/outages/2025-10-30-check-apiready-stdout-regression.json
@@ -1,0 +1,11 @@
+{
+  "id": "2025-10-30-check-apiready-stdout-regression",
+  "date": "2025-10-30",
+  "component": "scripts/check_apiready.sh",
+  "rootCause": "Structured readiness logs were redirected to stderr, so callers waiting on stdout never observed apiready events and automated tests failed.",
+  "resolution": "Emit info-level apiready success and timeout events on stdout while keeping debug retries on stderr to restore the contract expected by scripts and tests.",
+  "references": [
+    "scripts/check_apiready.sh",
+    "tests/bats/api_readyz_gate.bats"
+  ]
+}

--- a/outages/2025-10-30-join-gate-stdout-regression.json
+++ b/outages/2025-10-30-join-gate-stdout-regression.json
@@ -1,0 +1,11 @@
+{
+  "id": "2025-10-30-join-gate-stdout-regression",
+  "date": "2025-10-30",
+  "component": "scripts/join_gate.sh",
+  "rootCause": "join_gate routed structured info logs to stderr via helper wrappers, leaving stdout empty so automation could not observe acquire/release outcomes.",
+  "resolution": "Update the join_gate logging helpers to emit info-level records on stdout and reserve stderr for debug-only output, matching the expectations baked into the Bats suite.",
+  "references": [
+    "scripts/join_gate.sh",
+    "tests/bats/join_gate.bats"
+  ]
+}

--- a/outages/2025-10-30-mdns-selfcheck-stdout-regression.json
+++ b/outages/2025-10-30-mdns-selfcheck-stdout-regression.json
@@ -1,0 +1,12 @@
+{
+  "id": "2025-10-30-mdns-selfcheck-stdout-regression",
+  "date": "2025-10-30",
+  "component": "scripts/mdns_selfcheck.sh",
+  "rootCause": "Numerous info-level mdns_selfcheck outcomes were redirected to stderr, which broke the contract relied on by the CLI and exhaustive Bats coverage suite.",
+  "resolution": "Return success, warning, and failure events to stdout while leaving verbose trace/debug output on stderr so downstream tooling and tests can parse structured fields again.",
+  "references": [
+    "scripts/mdns_selfcheck.sh",
+    "tests/bats/mdns_selfcheck.bats",
+    "tests/bats/mdns_wire_probe.bats"
+  ]
+}

--- a/scripts/check_apiready.sh
+++ b/scripts/check_apiready.sh
@@ -154,7 +154,7 @@ while :; do
       if [ -n "${SERVER_IP}" ]; then
         log_fields+=("ip=\"$(escape_log_value "${SERVER_IP}")\"")
       fi
-      log_kv info apiready "${log_fields[@]}" >&2
+      log_kv info apiready "${log_fields[@]}"
       exit 0
     fi
     last_reason="body_not_ok"
@@ -195,7 +195,7 @@ while :; do
     if [ -n "${SERVER_IP}" ]; then
       failure_fields+=("ip=\"$(escape_log_value "${SERVER_IP}")\"")
     fi
-    log_kv info apiready "${failure_fields[@]}" >&2
+    log_kv info apiready "${failure_fields[@]}"
     exit 1
   fi
 

--- a/scripts/join_gate.sh
+++ b/scripts/join_gate.sh
@@ -21,11 +21,11 @@ HOSTNAME=""
 AVAHI_LIVENESS_CONFIRMED=0
 
 log_join_gate() {
-  log_info join_gate "$@" >&2
+  log_info join_gate "$@"
 }
 
 log_join_gate_error() {
-  log_kv info join_gate "$@" >&2
+  log_kv info join_gate "$@"
 }
 
 ensure_tools() {

--- a/scripts/mdns_selfcheck.sh
+++ b/scripts/mdns_selfcheck.sh
@@ -249,7 +249,7 @@ esac
 
 if [ -z "${EXPECTED_HOST}" ]; then
   elapsed_ms="$(elapsed_since_start_ms "${script_start_ms}")"
-  log_info mdns_selfcheck_failure outcome=miss reason=missing_expected_host attempt=0 ms_elapsed="${elapsed_ms}" >&2
+  log_info mdns_selfcheck_failure outcome=miss reason=missing_expected_host attempt=0 ms_elapsed="${elapsed_ms}"
   exit 2
 fi
 
@@ -311,13 +311,13 @@ if [ "${AVAHI_WAIT_ATTEMPTED}" -eq 0 ]; then
           log_debug mdns_selfcheck_dbus outcome=skip reason=avahi_dbus_wait_systemd_unavailable fallback=cli
         else
           elapsed_ms="$(elapsed_since_start_ms "${script_start_ms}")"
-          log_info mdns_selfcheck_failure outcome=miss reason=avahi_dbus_wait_failed attempt=0 ms_elapsed="${elapsed_ms}" >&2
+          log_info mdns_selfcheck_failure outcome=miss reason=avahi_dbus_wait_failed attempt=0 ms_elapsed="${elapsed_ms}"
           exit "${status}"
         fi
         ;;
       *)
         elapsed_ms="$(elapsed_since_start_ms "${script_start_ms}")"
-        log_info mdns_selfcheck_failure outcome=miss reason=avahi_dbus_wait_failed attempt=0 ms_elapsed="${elapsed_ms}" >&2
+        log_info mdns_selfcheck_failure outcome=miss reason=avahi_dbus_wait_failed attempt=0 ms_elapsed="${elapsed_ms}"
         exit "${status}"
         ;;
     esac
@@ -328,12 +328,12 @@ fi
 
 if ! command -v avahi-browse >/dev/null 2>&1; then
   elapsed_ms="$(elapsed_since_start_ms "${script_start_ms}")"
-  log_info mdns_selfcheck_failure outcome=miss reason=avahi_browse_missing attempt=0 ms_elapsed="${elapsed_ms}" >&2
+  log_info mdns_selfcheck_failure outcome=miss reason=avahi_browse_missing attempt=0 ms_elapsed="${elapsed_ms}"
   exit 3
 fi
 if ! command -v avahi-resolve >/dev/null 2>&1; then
   elapsed_ms="$(elapsed_since_start_ms "${script_start_ms}")"
-  log_info mdns_selfcheck_failure outcome=miss reason=avahi_resolve_missing attempt=0 ms_elapsed="${elapsed_ms}" >&2
+  log_info mdns_selfcheck_failure outcome=miss reason=avahi_resolve_missing attempt=0 ms_elapsed="${elapsed_ms}"
   exit 3
 fi
 
@@ -708,7 +708,7 @@ self_resolve_attempt() {
     return 3
   fi
 
-  local host="${SELF_LOCAL_HOST:-}" 
+  local host="${SELF_LOCAL_HOST:-}"
   if [ -z "${host}" ]; then
     self_resolve_log "${stage}" "${attempt}"
     return 3
@@ -746,7 +746,7 @@ self_resolve_handle_success() {
   local attempt="$1"
   local stage="$2"
 
-  local host="${SELF_RESOLVE_HOST:-}" 
+  local host="${SELF_RESOLVE_HOST:-}"
   if [ -z "${host}" ]; then
     host="${EXPECTED_HOST:-}"
   fi
@@ -1436,7 +1436,7 @@ while [ "${attempt}" -le "${ATTEMPTS}" ]; do
           last_reason="ipv4_mismatch"
           log_debug mdns_selfcheck outcome=miss attempt="${attempt}" reason="${last_reason}" service_type="${SERVICE_TYPE}"
           elapsed_ms="$(elapsed_since_start_ms "${script_start_ms}")"
-          log_info mdns_selfcheck outcome=fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" >&2
+          log_info mdns_selfcheck outcome=fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}"
           mdns_resolution_status_emit fail attempt="${attempt}" host="${srv_host}" reason="${last_reason}"
           exit 5
         fi
@@ -1524,13 +1524,13 @@ while [ "${attempt}" -le "${ATTEMPTS}" ]; do
             fail_duration_kv="command_duration_ms=${MDNS_LAST_FAILURE_DURATION}"
           fi
           if [ -n "${fail_command_kv}" ] && [ -n "${fail_duration_kv}" ]; then
-            log_info mdns_selfcheck outcome=fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" "${fail_command_kv}" "${fail_duration_kv}" >&2
+            log_info mdns_selfcheck outcome=fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" "${fail_command_kv}" "${fail_duration_kv}"
           elif [ -n "${fail_command_kv}" ]; then
-            log_info mdns_selfcheck outcome=fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" "${fail_command_kv}" >&2
+            log_info mdns_selfcheck outcome=fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" "${fail_command_kv}"
           elif [ -n "${fail_duration_kv}" ]; then
-            log_info mdns_selfcheck outcome=fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" "${fail_duration_kv}" >&2
+            log_info mdns_selfcheck outcome=fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" "${fail_duration_kv}"
           else
-            log_info mdns_selfcheck outcome=fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" >&2
+            log_info mdns_selfcheck outcome=fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}"
           fi
           exit 5
         elif [ "${status}" -eq 0 ] && [ "${handshake_failed}" -eq 1 ]; then
@@ -1548,7 +1548,7 @@ while [ "${attempt}" -le "${ATTEMPTS}" ]; do
     else
       browse_reason="instance_not_found"
     fi
-    MDNS_LAST_FAILURE_COMMAND="${browse_command:-}" 
+    MDNS_LAST_FAILURE_COMMAND="${browse_command:-}"
     MDNS_LAST_FAILURE_DURATION="${browse_duration:-}"
     if self_resolve_attempt browse "${attempt}" >/dev/null 2>&1; then
       :
@@ -1583,13 +1583,13 @@ while [ "${attempt}" -le "${ATTEMPTS}" ]; do
           mismatch_duration_kv="command_duration_ms=${SELF_RESOLVE_DURATION}"
         fi
         if [ -n "${mismatch_command_kv}" ] && [ -n "${mismatch_duration_kv}" ]; then
-          log_info mdns_selfcheck outcome=fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" "${mismatch_command_kv}" "${mismatch_duration_kv}" >&2
+          log_info mdns_selfcheck outcome=fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" "${mismatch_command_kv}" "${mismatch_duration_kv}"
         elif [ -n "${mismatch_command_kv}" ]; then
-          log_info mdns_selfcheck outcome=fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" "${mismatch_command_kv}" >&2
+          log_info mdns_selfcheck outcome=fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" "${mismatch_command_kv}"
         elif [ -n "${mismatch_duration_kv}" ]; then
-          log_info mdns_selfcheck outcome=fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" "${mismatch_duration_kv}" >&2
+          log_info mdns_selfcheck outcome=fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" "${mismatch_duration_kv}"
         else
-          log_info mdns_selfcheck outcome=fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" >&2
+          log_info mdns_selfcheck outcome=fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}"
         fi
         mdns_resolution_status_emit fail attempts="${attempt}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}"
         exit 5
@@ -1701,16 +1701,16 @@ if [ "${MDNS_RESOLUTION_STATUS_BROWSE}" = "1" ] && [ "${MDNS_RESOLUTION_STATUS_R
   fi
   if [ -n "${warn_command_kv}" ] && [ -n "${warn_duration_kv}" ]; then
     mdns_resolution_status_emit warn attempts="${ATTEMPTS}" misses="${miss_count}" ms_elapsed="${elapsed_ms}" host="${EXPECTED_HOST}" "${warn_command_kv}" "${warn_duration_kv}"
-    log_info mdns_selfcheck outcome=warn attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" "${warn_command_kv}" "${warn_duration_kv}" >&2
+    log_info mdns_selfcheck outcome=warn attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" "${warn_command_kv}" "${warn_duration_kv}"
   elif [ -n "${warn_command_kv}" ]; then
     mdns_resolution_status_emit warn attempts="${ATTEMPTS}" misses="${miss_count}" ms_elapsed="${elapsed_ms}" host="${EXPECTED_HOST}" "${warn_command_kv}"
-    log_info mdns_selfcheck outcome=warn attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" "${warn_command_kv}" >&2
+    log_info mdns_selfcheck outcome=warn attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" "${warn_command_kv}"
   elif [ -n "${warn_duration_kv}" ]; then
     mdns_resolution_status_emit warn attempts="${ATTEMPTS}" misses="${miss_count}" ms_elapsed="${elapsed_ms}" host="${EXPECTED_HOST}" "${warn_duration_kv}"
-    log_info mdns_selfcheck outcome=warn attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" "${warn_duration_kv}" >&2
+    log_info mdns_selfcheck outcome=warn attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" "${warn_duration_kv}"
   else
     mdns_resolution_status_emit warn attempts="${ATTEMPTS}" misses="${miss_count}" ms_elapsed="${elapsed_ms}" host="${EXPECTED_HOST}"
-    log_info mdns_selfcheck outcome=warn attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}" >&2
+    log_info mdns_selfcheck outcome=warn attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason}" ms_elapsed="${elapsed_ms}"
   fi
   exit 0
 fi
@@ -1723,16 +1723,16 @@ if [ -n "${MDNS_LAST_FAILURE_DURATION}" ]; then
   fail_duration_kv="command_duration_ms=${MDNS_LAST_FAILURE_DURATION}"
 fi
 if [ -n "${fail_command_kv}" ] && [ -n "${fail_duration_kv}" ]; then
-  log_info mdns_selfcheck outcome=fail attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason:-unknown}" ms_elapsed="${elapsed_ms}" "${fail_command_kv}" "${fail_duration_kv}" >&2
+  log_info mdns_selfcheck outcome=fail attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason:-unknown}" ms_elapsed="${elapsed_ms}" "${fail_command_kv}" "${fail_duration_kv}"
   mdns_resolution_status_emit fail attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason:-unknown}" ms_elapsed="${elapsed_ms}" "${fail_command_kv}" "${fail_duration_kv}"
 elif [ -n "${fail_command_kv}" ]; then
-  log_info mdns_selfcheck outcome=fail attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason:-unknown}" ms_elapsed="${elapsed_ms}" "${fail_command_kv}" >&2
+  log_info mdns_selfcheck outcome=fail attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason:-unknown}" ms_elapsed="${elapsed_ms}" "${fail_command_kv}"
   mdns_resolution_status_emit fail attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason:-unknown}" ms_elapsed="${elapsed_ms}" "${fail_command_kv}"
 elif [ -n "${fail_duration_kv}" ]; then
-  log_info mdns_selfcheck outcome=fail attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason:-unknown}" ms_elapsed="${elapsed_ms}" "${fail_duration_kv}" >&2
+  log_info mdns_selfcheck outcome=fail attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason:-unknown}" ms_elapsed="${elapsed_ms}" "${fail_duration_kv}"
   mdns_resolution_status_emit fail attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason:-unknown}" ms_elapsed="${elapsed_ms}" "${fail_duration_kv}"
 else
-  log_info mdns_selfcheck outcome=fail attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason:-unknown}" ms_elapsed="${elapsed_ms}" >&2
+  log_info mdns_selfcheck outcome=fail attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason:-unknown}" ms_elapsed="${elapsed_ms}"
   mdns_resolution_status_emit fail attempts="${ATTEMPTS}" misses="${miss_count}" reason="${last_reason:-unknown}" ms_elapsed="${elapsed_ms}"
 fi
 


### PR DESCRIPTION
## Summary
- emit apiready gate success/timeout logs on stdout so callers observe readiness events
- update join_gate logging helpers to write structured info messages to stdout instead of stderr
- restore mdns_selfcheck stdout logging for info/warn/fail outcomes and record outages for each regression

## Testing
- pre-commit run --all-files *(fails: repo contains existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_6903bb0dca9c832f956b57770bd806d1