### PR TITLE
Harden mdns probes and tests

### DIFF
--- a/outages/2025-10-31-mdns-publish-static-stub-regression.json
+++ b/outages/2025-10-31-mdns-publish-static-stub-regression.json
@@ -1,0 +1,10 @@
+{
+  "id": "mdns-publish-static-stub-regression",
+  "date": "2025-10-31",
+  "component": "tests/bats/mdns_wire_probe.bats",
+  "rootCause": "Bats stubs for avahi tooling escaped runtime variables incorrectly and unconditionally reported successful name resolution, so the mdns_publish_static suite never exercised the host-file update path and journalctl expectations. The chmod/mv stubs also dropped options, preventing atomic rename markers.",
+  "resolution": "Re-quote the stubs to defer $ expansion, emulate resolver behaviour based on the generated hosts file, log journalctl messages to the fixture file, and handle mv -f so the tests observe atomic publication.",
+  "references": [
+    "tests/bats/mdns_wire_probe.bats"
+  ]
+}

--- a/outages/2025-10-31-mdns-wire-probe-dbus-fallback.json
+++ b/outages/2025-10-31-mdns-wire-probe-dbus-fallback.json
@@ -1,0 +1,11 @@
+{
+  "id": "mdns-wire-probe-dbus-fallback",
+  "date": "2025-10-31",
+  "component": "scripts/mdns_wire_probe.sh",
+  "rootCause": "The embedded D-Bus discovery helper treated gdbus call failures as silent misses, so when every introspection call failed the script still reported dbus availability and never exercised the CLI fallback path.",
+  "resolution": "Track whether any introspection succeeds and raise RuntimeError(\"avahi_dbus_unavailable\") when none do so the shell script marks the D-Bus path unavailable and falls back to CLI probing.",
+  "references": [
+    "tests/bats/mdns_wire_probe.bats",
+    "scripts/mdns_wire_probe.sh"
+  ]
+}

--- a/scripts/mdns_wire_probe.sh
+++ b/scripts/mdns_wire_probe.sh
@@ -186,6 +186,7 @@ def discover_entry_groups():
     queue = deque(["/"])
     seen = set()
     entry_groups = []
+    any_success = False
 
     while queue:
         path = queue.popleft()
@@ -205,6 +206,7 @@ def discover_entry_groups():
             continue
         if not xml_text:
             continue
+        any_success = True
         try:
             root = ET.fromstring(xml_text)
         except ET.ParseError:
@@ -220,6 +222,8 @@ def discover_entry_groups():
             queue.append(child)
             if any(segment.startswith("EntryGroup") for segment in child.split("/")):
                 entry_groups.append(child)
+    if not any_success:
+        raise RuntimeError("avahi_dbus_unavailable")
     return entry_groups
 
 def entry_group_state(path):

--- a/tests/bats/election.bats
+++ b/tests/bats/election.bats
@@ -18,7 +18,7 @@ stub_hostname() {
   local fqdn="$2"
   stub_command hostname <<EOS
 #!/usr/bin/env bash
-case "$1" in
+case "\$1" in
   -f)
     echo "$fqdn"
     ;;
@@ -39,7 +39,7 @@ stub_ip_with_mac() {
   local mac="$1"
   stub_command ip <<EOS
 #!/usr/bin/env bash
-if [ "$1" = "-o" ] && [ "$2" = "link" ]; then
+if [ "\$1" = "-o" ] && [ "\$2" = "link" ]; then
   cat <<'OUT'
 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00


### PR DESCRIPTION
what: ensure the mdns wire probe falls back when gdbus is unavailable,
update bats stubs to respect runtime values, and log new outages.
why: bats CI was failing because the wire probe never hit the CLI path
and the mdns_publish_static suite evaluated stub heredocs too early.
how to test:
 - bats tests/bats/mdns_wire_probe.bats
 - pyspelling -c .spellcheck.yaml
 - linkchecker --no-warnings README.md docs/


------
https://chatgpt.com/codex/tasks/task_e_690453bc5928832faca86928c79680d4