### PR TITLE
Fix mdns CLI mode from waiting on dbus

### DIFF
--- a/outages/2025-10-31-mdns-selfcheck-dbus-disabled-wait.json
+++ b/outages/2025-10-31-mdns-selfcheck-dbus-disabled-wait.json
@@ -1,0 +1,11 @@
+{
+  "id": "mdns-selfcheck-dbus-disabled-wait",
+  "date": "2025-10-31",
+  "component": "mdns_selfcheck.sh",
+  "rootCause": "CLI-only runs still waited on Avahi D-Bus even when disabled, triggering timeouts and failing bats coverage runs.",
+  "resolution": "Skip wait_for_avahi_dbus.sh when SUGARKUBE_MDNS_DBUS is 0 so CLI mode avoids D-Bus interactions.",
+  "references": [
+    "scripts/mdns_selfcheck.sh",
+    "tests/bats/mdns_selfcheck.bats"
+  ]
+}

--- a/scripts/mdns_selfcheck.sh
+++ b/scripts/mdns_selfcheck.sh
@@ -286,7 +286,7 @@ else
   log_debug mdns_selfcheck_dbus outcome=skip reason=dbus_disabled fallback=cli
 fi
 
-if [ "${AVAHI_WAIT_ATTEMPTED}" -eq 0 ]; then
+if [ "${AVAHI_WAIT_ATTEMPTED}" -eq 0 ] && [ "${dbus_mode}" != "0" ]; then
   avahi_wait_output=""
   if ! avahi_wait_output="$("${SCRIPT_DIR}/wait_for_avahi_dbus.sh" 2>&1)"; then
     status=$?


### PR DESCRIPTION
what:
- gate wait_for_avahi_dbus.sh behind the dbus mode flag
- record the timeout regression in outages/

why:
- cli-only coverage runs still waited on dbus and timed out under kcov

how to test:
- bats tests/bats/mdns_selfcheck.bats


------
https://chatgpt.com/codex/tasks/task_e_690463e0b5a8832f88ad3399e9fae8f9