### PR TITLE
Handle Avahi DBus readiness fallback for missing method

### DIFF
--- a/outages/2025-10-31-wait-for-avahi-dbus-unknown-method.json
+++ b/outages/2025-10-31-wait-for-avahi-dbus-unknown-method.json
@@ -1,0 +1,11 @@
+{
+  "id": "wait-for-avahi-dbus-unknown-method",
+  "date": "2025-10-31",
+  "component": "scripts/wait_for_avahi_dbus.sh",
+  "rootCause": "Avahi 0.9 removed org.freedesktop.Avahi.Server.GetVersionString, so the readiness probe treated UnknownMethod as a timeout and never unblocked the mDNS tests.",
+  "resolution": "Treat UnknownMethod as a success by querying Server.State (or GetState) so newer Avahi builds still mark the bus ready.",
+  "references": [
+    "scripts/wait_for_avahi_dbus.sh",
+    "tests/bats/mdns_selfcheck.bats"
+  ]
+}

--- a/scripts/wait_for_avahi_dbus.sh
+++ b/scripts/wait_for_avahi_dbus.sh
@@ -247,6 +247,59 @@ while :; do
     busctl_status=$?
     last_bus_code="${busctl_status}"
     bus_error_name="$(printf '%s\n' "${busctl_output}" | awk 'match($0, /org\.freedesktop\.DBus\.Error\.[A-Za-z0-9]+/) { print substr($0, RSTART, RLENGTH); exit }')"
+
+    fallback_success=0
+    fallback_hint=""
+    if [ "${busctl_status}" -ne 0 ]; then
+      case "${bus_error_name}" in
+        org.freedesktop.DBus.Error.UnknownMethod)
+          fallback_hint="unknown_method"
+          ;;
+      esac
+      if [ -z "${fallback_hint}" ] && printf '%s' "${busctl_output}" \
+        | grep -Fqi 'GetVersionString'; then
+        fallback_hint="missing_get_version_string"
+      fi
+      if [ -n "${fallback_hint}" ]; then
+        if busctl --system --timeout=2 get-property \
+          org.freedesktop.Avahi \
+          /org/freedesktop/Avahi/Server \
+          org.freedesktop.Avahi.Server \
+          State >/dev/null 2>&1; then
+          fallback_success=1
+          fallback_hint="get_property_state"
+        elif busctl --system --timeout=2 call \
+          org.freedesktop.Avahi \
+          /org/freedesktop/Avahi/Server \
+          org.freedesktop.Avahi.Server \
+          GetState >/dev/null 2>&1; then
+          fallback_success=1
+          fallback_hint="call_get_state"
+        fi
+      fi
+    fi
+
+    if [ "${fallback_success}" -eq 1 ]; then
+      last_bus_status="ok"
+      last_bus_error=""
+      last_bus_code=0
+      elapsed_ms="$(elapsed_since_start_ms "${script_start_ms}")"
+      systemd_state_log="$(sanitize_kv "${last_systemctl_state}")"
+      [ -n "${systemd_state_log}" ] || systemd_state_log=unknown
+      set -- \
+        avahi_dbus_ready \
+        outcome=ok \
+        "ms_elapsed=${elapsed_ms}" \
+        "systemd_state=${systemd_state_log}" \
+        bus_status=ok
+      fallback_log="$(sanitize_kv "${fallback_hint}")"
+      if [ -n "${fallback_log}" ]; then
+        set -- "$@" "bus_fallback=${fallback_log}"
+      fi
+      log_info "$@"
+      exit 0
+    fi
+
     if [ -n "${bus_error_name}" ]; then
       last_bus_error="${bus_error_name}"
       case "${bus_error_name}" in


### PR DESCRIPTION
what: teach wait_for_avahi_dbus.sh to fall back when GetVersionString is missing and log the outage.
why: Avahi 0.9 dropped that D-Bus method, so readiness timed out and mDNS tests failed.
how to test: bats tests/bats/mdns_selfcheck.bats

------
https://chatgpt.com/codex/tasks/task_e_690463e0b5a8832f88ad3399e9fae8f9