### PR TITLE
fix: run mdns selfcheck under bash

### DIFF
--- a/outages/2025-10-31-mdns-selfcheck-shebang.json
+++ b/outages/2025-10-31-mdns-selfcheck-shebang.json
@@ -1,0 +1,10 @@
+{
+  "id": "mdns-selfcheck-shebang",
+  "date": "2025-10-31",
+  "component": "scripts/mdns_selfcheck.sh",
+  "rootCause": "The script declared a /bin/sh shebang while using bash-specific features such as [[, {, and local, so dash exited early during the mdns bats suite on GitHub Actions.",
+  "resolution": "Switch the shebang to /usr/bin/env bash so mdns_selfcheck.sh runs with the shell it requires.",
+  "references": [
+    "https://github.com/futuroptimist/sugarkube/actions/runs/18986984283/job/54232665670"
+  ]
+}

--- a/scripts/mdns_selfcheck.sh
+++ b/scripts/mdns_selfcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # shellcheck disable=SC3040,SC3041,SC3043
 set -eu
 


### PR DESCRIPTION
fix: run mdns selfcheck under bash

what: update mdns_selfcheck.sh to use a bash shebang and log the outage.
why: the script relies on bash features, so running under /bin/sh caused CI failures.
how to test: SKIP=check-yaml pre-commit run --all-files
how to test: pyspelling -c .spellcheck.yaml
how to test: linkchecker --no-warnings README.md docs/
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_690540857bfc832f8314c0ad6c3e4bfd