### PR TITLE
🐛 : – respect DBus flag in mdns liveness

### DIFF
--- a/outages/2025-10-31-mdns-selfcheck-dbus.json
+++ b/outages/2025-10-31-mdns-selfcheck-dbus.json
@@ -1,0 +1,10 @@
+{
+  "id": "mdns-selfcheck-dbus",
+  "date": "2025-10-31",
+  "component": "scripts/mdns_selfcheck.sh",
+  "rootCause": "The mdns_liveness_probe helper always executed gdbus lookups even when SUGARKUBE_MDNS_DBUS was set to 0. In CI this reached the host Avahi daemon, producing real discovery output that broke the bats fixtures and caused mdns_* tests to fail.",
+  "resolution": "Respect the DBus mode flag inside mdns_liveness_probe so the gdbus hostname check is skipped when DBus is disabled, preserving the fixture-driven CLI path.",
+  "references": [
+    "https://github.com/futuroptimist/sugarkube/actions/runs/18987646472/job/54234523569"
+  ]
+}


### PR DESCRIPTION
what: skip the gdbus hostname probe when DBus mode is disabled and record an outage entry
why: mdns self-check bats fixtures expect the CLI-only path but the DBus probe hit the host daemon and returned unexpected data
how to test: bats --filter "mdns self-check warns when enumeration misses but browse succeeds" tests/bats/mdns_selfcheck.bats
Refs: #none

------
https://chatgpt.com/codex/tasks/task_e_690548ece488832f98f5f043581a677f