### PR TITLE
Fix pi image tests to include iptables script

### DIFF
--- a/outages/2025-11-01-pi-image-tests-missing-iptables-script.json
+++ b/outages/2025-11-01-pi-image-tests-missing-iptables-script.json
@@ -1,0 +1,11 @@
+{
+  "id": "pi-image-tests-missing-iptables-script",
+  "date": "2025-11-01",
+  "component": "pi-image",
+  "rootCause": "Fixture omitted scripts/k3s-install-iptables.sh, so the build script exited ENOENT",
+  "resolution": "Stage scripts/k3s-install-iptables.sh in the fixture with execute perms pre-run",
+  "references": [
+    "tests/build_pi_image_test.py",
+    "scripts/build_pi_image.sh"
+  ]
+}

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -643,6 +643,7 @@ def _run_build_script(tmp_path, env):
         ("scripts/clone_to_nvme.sh", 0o755),
         ("scripts/post_clone_verify.sh", 0o755),
         ("scripts/k3s_preflight.sh", 0o755),
+        ("scripts/k3s-install-iptables.sh", 0o755),
         ("systemd/first-boot-prepare.sh", 0o755),
         ("systemd/first-boot-prepare.service", 0o644),
     ]


### PR DESCRIPTION
## Summary
- copy scripts/k3s-install-iptables.sh into the pi image test fixture
- log the missing k3s-install-iptables test asset in outages

## Testing
- pytest tests/build_pi_image_test.py -x


------
https://chatgpt.com/codex/tasks/task_e_6905ad49dbf0832f9c2be4c554cc521f