### PR TITLE
✅ : – Fix k3s mDNS multi-line parsing

### DIFF
--- a/outages/2025-11-01-k3s-mdns-multiline-records.json
+++ b/outages/2025-11-01-k3s-mdns-multiline-records.json
@@ -1,0 +1,11 @@
+{
+  "id": "2025-11-01-k3s-mdns-multiline-records",
+  "date": "2025-11-01",
+  "component": "scripts/k3s_mdns_query.py",
+  "rootCause": "k3s-discover's regression suite stalled because the mDNS helper discarded Avahi output that arrived as multi-line records, leaving discovery loops waiting forever for a server advert.",
+  "resolution": "Normalize Avahi browse output by collapsing continuation lines so each record is parsed correctly, allowing the fast join scenario to detect the stubbed server and exit.",
+  "references": [
+    "scripts/k3s_mdns_query.py",
+    "tests/scripts/test_k3s_discover_mid_election_join.py"
+  ]
+}

--- a/scripts/k3s_mdns_query.py
+++ b/scripts/k3s_mdns_query.py
@@ -115,6 +115,25 @@ def _load_lines_from_fixture(fixture_path: str) -> Iterable[str]:
     return [line for line in text.splitlines() if line]
 
 
+def _normalize_record_lines(lines: Iterable[str]) -> List[str]:
+    """Collapse Avahi output so each record occupies a single line."""
+
+    collapsed: List[str] = []
+
+    for raw in lines:
+        line = raw.strip()
+        if not line:
+            continue
+
+        if line[0] in {"=", "+", "@"} or not collapsed:
+            collapsed.append(line)
+            continue
+
+        collapsed[-1] += line
+
+    return collapsed
+
+
 def _load_lines_from_avahi(
     mode: str,
     cluster: str,
@@ -135,7 +154,7 @@ def _load_lines_from_avahi(
             timeout,
             resolve=resolve,
         )
-        new_lines = [line for line in result.stdout.splitlines() if line]
+        new_lines = _normalize_record_lines(result.stdout.splitlines())
         if debug is not None and not new_lines and result.stdout:
             try:
                 _DUMP_PATH.write_text(result.stdout, encoding="utf-8")


### PR DESCRIPTION
what: collapse multi-line Avahi output before parsing
why: mid-election join tests hung waiting for server adverts
how to test: pytest tests/scripts/test_k3s_mdns_query.py::test_query_mdns_queries_legacy_service_type_when_needed -q

------
https://chatgpt.com/codex/tasks/task_e_69068784dc34832fa38f10717c382b9e