### PR TITLE
🛠️ : – Ensure pi_node_verifier JSON output excludes warnings

### DIFF
--- a/outages/2025-11-01-pi-node-verifier-json.json
+++ b/outages/2025-11-01-pi-node-verifier-json.json
@@ -1,0 +1,11 @@
+{
+  "id": "pi-node-verifier-json",
+  "date": "2025-11-01",
+  "component": "scripts/pi_node_verifier.sh",
+  "rootCause": "The pi_node_verifier --json mode interleaved human-readable warnings on stderr, which Bats captures, causing invalid JSON output and failing jq assertions.",
+  "resolution": "When JSON output is requested, accumulate warnings in-memory and emit them inside a warnings array alongside the checks payload, keeping stdout valid JSON while preserving diagnostics.",
+  "references": [
+    "scripts/pi_node_verifier.sh",
+    "tests/pi_node_verifier_json_test.bats"
+  ]
+}


### PR DESCRIPTION
what: keep pi_node_verifier JSON output machine-friendly and log outage entry
why: Bats jq assertions failed when stderr warnings preceded JSON payload
how to test: bats tests/*.bats

------
https://chatgpt.com/codex/tasks/task_e_69069b254ccc832fb9c9b8b170ff31b1