### PR TITLE
Restore Just CLI moustache forwarding

### DIFF
--- a/justfile
+++ b/justfile
@@ -282,7 +282,7 @@ doctor:
 
 # Usage: just start-here START_HERE_ARGS="--path-only"
 start-here:
-    "{{sugarkube_cli}}" docs start-here {{start_here_args}}
+    "{{ sugarkube_cli }}" docs start-here {{ start_here_args }}
 
 # Revert cmdline.txt and fstab entries back to the SD card defaults
 # Usage: sudo just rollback-to-sd
@@ -387,7 +387,7 @@ monitor-ssd-health:
 
 # Usage: sudo NVME_HEALTH_ARGS="--device /dev/nvme1n1" just nvme-health
 nvme-health:
-    "{{sugarkube_cli}}" nvme health {{nvme_health_args}}
+    "{{ sugarkube_cli }}" nvme health {{ nvme_health_args }}
 
 # Run pi_node_verifier remotely over SSH
 
@@ -442,7 +442,7 @@ cluster-up:
 
 # Usage: just cluster-bootstrap CLUSTER_BOOTSTRAP_ARGS="--config cluster.toml"
 cluster-bootstrap:
-    "{{sugarkube_cli}}" pi cluster {{cluster_bootstrap_args}}
+    "{{ sugarkube_cli }}" pi cluster {{ cluster_bootstrap_args }}
 
 # Install CLI dependencies inside GitHub Codespaces or fresh containers
 
@@ -467,13 +467,13 @@ codespaces-bootstrap:
 
 # Usage: just docs-verify
 docs-verify:
-    "{{sugarkube_cli}}" docs verify {{docs_verify_args}}
+    "{{ sugarkube_cli }}" docs verify {{ docs_verify_args }}
 
 # Install documentation prerequisites and run spell/link checks without touching
 
 # code linters. Usage: just simplify-docs (forwards to sugarkube docs simplify)
 simplify-docs:
-    "{{sugarkube_cli}}" docs simplify {{simplify_docs_args}}
+    "{{ sugarkube_cli }}" docs simplify {{ simplify_docs_args }}
 
 # Generate printable QR codes that link to the quickstart and troubleshooting docs
 
@@ -485,7 +485,7 @@ qr-codes:
 
 # Usage: just token-place-samples TOKEN_PLACE_SAMPLE_ARGS="--dry-run"
 token-place-samples:
-    "{{sugarkube_cli}}" token-place samples {{token_place_sample_args}}
+    "{{ sugarkube_cli }}" token-place samples {{ token_place_sample_args }}
 
 # Run the macOS setup wizard to install brew formulas and scaffold directories
 


### PR DESCRIPTION
## Summary
- tighten the Just CLI recipes to call "{{sugarkube_cli}}" and keep
  the argument forwards visible to our guard tests
- document the regression in outages/2025-11-02-justfile-cli-arg-forwarding-regression.json

## Testing
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_6906dd63fc5c832f8e2481039203037e