### PR TITLE
✅ : – align mdns helpers with bash

### DIFF
--- a/scripts/log.sh
+++ b/scripts/log.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env sh
-# shellcheck shell=sh
+#!/usr/bin/env bash
+# shellcheck shell=bash
 
 # Shared structured logging helper for shell scripts.
 # Provides level-aware logging helpers that emit key=value pairs with

--- a/scripts/mdns_selfcheck_dbus.sh
+++ b/scripts/mdns_selfcheck_dbus.sh
@@ -1,14 +1,8 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # shellcheck disable=SC3040,SC3041,SC3043
-set -eu
+set -euo pipefail
 
-if (set -o pipefail) 2>/dev/null; then
-  set -o pipefail
-fi
-
-if (set -E) 2>/dev/null; then
-  set -E
-fi
+set -E
 
 SCRIPT_DIR="$(CDPATH='' cd "$(dirname "$0")" && pwd)"
 # shellcheck source=scripts/log.sh

--- a/scripts/wait_for_avahi_dbus.sh
+++ b/scripts/wait_for_avahi_dbus.sh
@@ -1,14 +1,8 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # shellcheck disable=SC3040,SC3041,SC3043
-set -eu
+set -euo pipefail
 
-if (set -o pipefail) 2>/dev/null; then
-  set -o pipefail
-fi
-
-if (set -E) 2>/dev/null; then
-  set -E
-fi
+set -E
 
 SCRIPT_DIR="$(CDPATH='' cd "$(dirname "$0")" && pwd)"
 # shellcheck source=scripts/log.sh


### PR DESCRIPTION
what: retarget dbus helpers and log library to bash shebangs
why: ensure invoked scripts satisfy repo bash requirement
how to test: pytest tests/scripts/test_k3s_mdns_query.py

------
https://chatgpt.com/codex/tasks/task_e_6907fe675754832f869ff31201fba5e8