### PR TITLE
feat: improve k3s discover readiness

### DIFF
--- a/scripts/k3s-discover.sh
+++ b/scripts/k3s-discover.sh
@@ -2479,7 +2479,9 @@ wait_for_api() {
 
   local output=""
   local status=0
-  if ! output="$(env "${check_env[@]}" "${API_READY_CHECK_BIN}")"; then
+  if output="$(env "${check_env[@]}" "${API_READY_CHECK_BIN}")"; then
+    status=0
+  else
     status=$?
   fi
 


### PR DESCRIPTION
## Summary
- propagate Sugarkube cluster/env/token to Python mDNS helpers and normalize Avahi parsing
- integrate check_apiready.sh for local readiness with structured logging from stdout
- refresh server install warnings to reflect configured API timeout

## Testing
- pytest -k "k3s_discover_" -q

------
https://chatgpt.com/codex/tasks/task_e_6908060214f4832fb7976deb2171adb4