### PR TITLE
Add dspace immutable OCI deploy helper with rollout verification

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -2,7 +2,8 @@
 
 Use the packaged Helm chart from GHCR to install the dspace v3 stack into your cluster. The
 `justfile` exposes generic Helm helpers so you can reuse the same commands for other apps by
-changing the arguments.
+changing the arguments, plus a dspace-specific immutable-tag deploy helper for RC/stable
+validation.
 
 Values files are split so you can layer staging-specific ingress settings on top of the default
 development values:
@@ -48,6 +49,18 @@ charts:
 
 ## Quickstart
 
+For staging/prod-style immutable deployments, use the opinionated dspace helper. It validates
+the values chain, ensures user kubeconfig, waits for rollout completion, and prints follow-up
+checks:
+
+```bash
+just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
+just dspace-oci-deploy env=prod tag="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]')"
+```
+
+Generic Helm helpers are still available and intentionally stay generic (manifest apply behavior,
+no rollout waiting):
+
 ```bash
 # Install or upgrade the release with staging ingress overrides (defaults to v3-latest image tag)
 just helm-oci-install \
@@ -92,6 +105,9 @@ just helm-oci-upgrade \
 - The image tag defaults to `default_tag` (`v3-latest`) for dev/staging; pass `tag=<imageTag>` to
   target a specific build. Production deployments should use pinned tags (for example, the value in
   `docs/apps/dspace.prod.tag` or a `v3-<immutable>` build).
+- dspace values layering is intentional and consistent: `dev` uses only
+  `docs/examples/dspace.values.dev.yaml`; `staging` and `prod` use
+  `docs/examples/dspace.values.dev.yaml` plus their environment overlay.
 
 ## First deployment walkthrough
 
@@ -120,23 +136,11 @@ assumes your target cluster (for example `env=staging`) is online and reachable 
 4. Install the app:
 
    ```bash
-   just helm-oci-install \
-     release=dspace namespace=dspace \
-     chart=oci://ghcr.io/democratizedspace/charts/dspace \
-     values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
-     version_file=docs/apps/dspace.version \
-     default_tag=v3-latest
+   # Immutable-tag validation flow (recommended for staging/prod)
+   just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
 
    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
-   prod_tag="$(read_prod_tag)"
-
-   # Production example (pinned tag)
-   just helm-oci-install \
-     release=dspace namespace=dspace \
-     chart=oci://ghcr.io/democratizedspace/charts/dspace \
-     values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml \
-     version_file=docs/apps/dspace.version \
-     tag="${prod_tag}"
+   just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
    ```
 
 5. Verify everything is healthy, then browse to the FQDN on your phone or laptop:

--- a/justfile
+++ b/justfile
@@ -1138,6 +1138,73 @@ helm-oci-install release='' namespace='' chart='' values='' host='' version='' v
 helm-oci-upgrade release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='':
     @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' allow_install='false' reuse_values='true'
 
+# Opinionated immutable-tag deploy path for dspace RC/stable validation.
+# Unlike the generic Helm helper recipes, this waits for rollout readiness and
+# prints post-deploy verification commands.
+dspace-oci-deploy env='staging' tag='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    env_input="{{ env }}"
+    env_name="${env_input}"
+    if [ "${env_input}" = "int" ]; then
+      printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
+      env_name="staging"
+    fi
+
+    if [ -z "{{ tag }}" ]; then
+      echo "Set tag=<immutable-tag> (for example: v3-<shortsha>)." >&2
+      exit 1
+    fi
+
+    deploy_tag="{{ tag }}"
+    if [[ "${deploy_tag}" == *latest* ]] || [[ "${deploy_tag}" == "main" ]]; then
+      echo "Tag '${deploy_tag}' looks mutable. Use an immutable dspace image tag." >&2
+      exit 1
+    fi
+
+    overlay="docs/examples/dspace.values.${env_name}.yaml"
+    if [ ! -f "${overlay}" ]; then
+      echo "No dspace values overlay found for env=${env_name} (${overlay})." >&2
+      exit 1
+    fi
+
+    values_chain="docs/examples/dspace.values.dev.yaml"
+    if [ "${env_name}" != "dev" ]; then
+      values_chain="${values_chain},${overlay}"
+    fi
+
+    scripts/ensure_user_kubeconfig.sh || true
+    export KUBECONFIG="${HOME}/.kube/config"
+
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
+      release='dspace' namespace='dspace' \
+      chart='oci://ghcr.io/democratizedspace/charts/dspace' \
+      values="${values_chain}" \
+      version_file='docs/apps/dspace.version' \
+      tag="${deploy_tag}"
+
+    echo "Waiting for dspace rollout to complete (timeout: 180s)..."
+    if ! kubectl -n dspace rollout status deploy/dspace --timeout=180s; then
+      echo "ERROR: dspace rollout did not complete successfully." >&2
+      exit 1
+    fi
+
+    resolved_image="$(
+      kubectl -n dspace get deploy/dspace -o jsonpath='{.spec.template.spec.containers[0].image}'
+    )"
+    echo "Resolved deployment image: ${resolved_image}"
+
+    ingress_host="$(kubectl -n dspace get ingress dspace -o jsonpath='{.spec.rules[0].host}' 2>/dev/null || true)"
+    if [ -z "${ingress_host}" ]; then
+      ingress_host="<your-dspace-host>"
+    fi
+
+    echo "Post-deploy verification:"
+    echo "  curl -fsS https://${ingress_host}/config.json"
+    echo "  curl -fsS https://${ingress_host}/healthz"
+    echo "  curl -fsS https://${ingress_host}/livez"
+
 # Fast redeploy of dspace v3 from GHCR (emergency push).
 dspace-oci-redeploy env='staging' tag='':
     #!/usr/bin/env bash


### PR DESCRIPTION
### Motivation
- The generic Helm OCI helpers return as soon as Helm finishes which is confusing for immutable-tag RC deploys because operators expect rollout progress/verification. 
- Follow-up `kubectl` calls can fail due to kubeconfig UX (permissions on `/etc/rancher/k3s/k3s.yaml`) and the flow should prefer the user kubeconfig at `~/.kube/config`.
- The dspace values-chain behavior needed to be intentional and clearly documented so `dev`, `staging`, and `prod` overlays are consistent.

### Description
- Added a new opinionated recipe `dspace-oci-deploy env=... tag=...` in `justfile` that requires an explicit immutable `tag`, rejects mutable-looking tags (for example `*latest*` or `main`), and validates the presence of the environment overlay file.
- The new recipe resolves the values chain to `docs/examples/dspace.values.dev.yaml` plus the environment overlay for `staging`/`prod`, runs `scripts/ensure_user_kubeconfig.sh` and sets `KUBECONFIG=${HOME}/.kube/config`, calls the existing Helm helper via `helm-oci-install`, then waits for rollout readiness with `kubectl rollout status`.
- After rollout it prints the resolved deployment image (via `kubectl get deploy/dspace -o jsonpath=...`) and prints recommended post-deploy verification commands (`curl -fsS https://<host>/config.json`, `/healthz`, `/livez`).
- Kept `_helm-oci-deploy` generic (no global `wait=` flag added) and updated `docs/apps/dspace.md` to point operators to the new immutable RC/stable helper and to clarify the intended values-layering and the distinction between generic Helm helpers (manifest-apply) and the opinionated dspace workflow (rollout+verification). The files changed are `justfile` and `docs/apps/dspace.md`.

### Testing
- Ran `git diff --cached | ./scripts/scan-secrets.py` to check for credential-like strings and it completed with no findings. 
- Attempted `pre-commit run --all-files` but the command was not available in this environment so linting/format checks could not be executed here. 
- Attempted `just --dry-run dspace-oci-deploy env=staging tag=v3-deadbeef` and `just --dry-run dspace-oci-redeploy ...` but `just` is not installed in this environment so command construction verification was not executed here. 
- `pyspelling` and `linkchecker` checks were attempted but not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf9d62389c832faa7c2cd56660f3ec)