### PR TITLE
Add dspace-oci-deploy helper for immutable-tag deploys with rollout verification

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -2,7 +2,8 @@
 
 Use the packaged Helm chart from GHCR to install the dspace v3 stack into your cluster. The
 `justfile` exposes generic Helm helpers so you can reuse the same commands for other apps by
-changing the arguments.
+changing the arguments. For dspace immutable-tag validation rollouts, prefer the dedicated
+`just dspace-oci-deploy` helper; it waits for rollout readiness and prints verification checks.
 
 Values files are split so you can layer staging-specific ingress settings on top of the default
 development values:
@@ -49,24 +50,14 @@ charts:
 ## Quickstart
 
 ```bash
-# Install or upgrade the release with staging ingress overrides (defaults to v3-latest image tag)
-just helm-oci-install \
-  release=dspace namespace=dspace \
-  chart=oci://ghcr.io/democratizedspace/charts/dspace \
-  values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
-  version_file=docs/apps/dspace.version \
-  default_tag=v3-latest
+# Immutable-tag staging validation deploy (waits for rollout status)
+just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
 
 read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
 prod_tag="$(read_prod_tag)"
 
-# Install production with prod ingress overrides and a pinned tag
-just helm-oci-install \
-  release=dspace namespace=dspace \
-  chart=oci://ghcr.io/democratizedspace/charts/dspace \
-  values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml \
-  version_file=docs/apps/dspace.version \
-  tag="${prod_tag}"
+# Immutable-tag production deploy
+just dspace-oci-deploy env=prod tag="${prod_tag}"
 
 # Check pods and ingress status with the public URL
 just app-status namespace=dspace release=dspace
@@ -89,6 +80,9 @@ just helm-oci-upgrade \
 
 - `version_file` defaults the Helm chart to the latest tested v3 release stored alongside this
   guide. You can override with `version=<semver>` when pinning a specific chart.
+- `dspace-oci-deploy` always uses the intentional values chain:
+  - staging: `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`
+  - prod: `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`
 - The image tag defaults to `default_tag` (`v3-latest`) for dev/staging; pass `tag=<imageTag>` to
   target a specific build. Production deployments should use pinned tags (for example, the value in
   `docs/apps/dspace.prod.tag` or a `v3-<immutable>` build).
@@ -120,23 +114,13 @@ assumes your target cluster (for example `env=staging`) is online and reachable 
 4. Install the app:
 
    ```bash
-   just helm-oci-install \
-     release=dspace namespace=dspace \
-     chart=oci://ghcr.io/democratizedspace/charts/dspace \
-     values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
-     version_file=docs/apps/dspace.version \
-     default_tag=v3-latest
+   just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
 
    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
    prod_tag="$(read_prod_tag)"
 
    # Production example (pinned tag)
-   just helm-oci-install \
-     release=dspace namespace=dspace \
-     chart=oci://ghcr.io/democratizedspace/charts/dspace \
-     values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml \
-     version_file=docs/apps/dspace.version \
-     tag="${prod_tag}"
+   just dspace-oci-deploy env=prod tag="${prod_tag}"
    ```
 
 5. Verify everything is healthy, then browse to the FQDN on your phone or laptop:
@@ -148,12 +132,7 @@ assumes your target cluster (for example `env=staging`) is online and reachable 
 6. Iterate new builds from v3:
 
    ```bash
-   just helm-oci-upgrade \
-     release=dspace namespace=dspace \
-     chart=oci://ghcr.io/democratizedspace/charts/dspace \
-     values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
-     version_file=docs/apps/dspace.version \
-     tag=v3-<shortsha>
+   just dspace-oci-deploy env=staging tag=v3-<shortsha>
    ```
 
 ## Networking via Cloudflare Tunnel

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -684,28 +684,19 @@ Pick the values overlay for your target environment and prefer immutable image t
 - Production: `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`
 
 ```bash
-# From the sugarkube repo root on a cluster node (staging):
-just helm-oci-upgrade \
-  release=dspace namespace=dspace \
-  chart=oci://ghcr.io/democratizedspace/charts/dspace \
-  values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
-  version_file=docs/apps/dspace.version \
-  default_tag=v3-latest
+# Mutable-tag convenience flow (staging default):
+just dspace-oci-redeploy
 ```
 
-For production, swap in the prod values file and pin to an immutable tag (for example the value
-stored in `docs/apps/dspace.prod.tag`):
+For immutable-tag RC/stable validation, use the dedicated deploy helper. It ensures user kubeconfig,
+applies the intentional values chain, waits for rollout readiness, and prints verification commands:
 
 ```bash
 read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
 prod_tag="$(read_prod_tag)"
 
-just helm-oci-upgrade \
-  release=dspace namespace=dspace \
-  chart=oci://ghcr.io/democratizedspace/charts/dspace \
-  values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml \
-  version_file=docs/apps/dspace.version \
-  tag="${prod_tag}"
+just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
+just dspace-oci-deploy env=prod tag="${prod_tag}"
 ```
 
 The dspace chart also exposes a `DSPACE_ENV` environment variable (set via the top-level
@@ -714,7 +705,7 @@ sets `environment: dev`, `docs/examples/dspace.values.staging.yaml` sets `enviro
 `docs/examples/dspace.values.prod.yaml` sets `environment: prod`, which show up in `/healthz` and
 the homepage build badge.
 
-If you prefer a one-liner that bakes in those arguments for dspace v3, use the helper
+If you prefer a one-liner that bakes in mutable-tag redeploy behavior for dspace v3, use the helper
 recipe (defaults to staging):
 
 ```bash
@@ -734,6 +725,12 @@ When you pass an image tag (including the default `v3-latest`), the helper sets
 `image.pullPolicy=Always` so the nodes re-check GHCR for the latest build of that tag on
 each redeploy. For production, prefer immutable tags (for example, `v3-<sha>`) if you want
 to pin a specific image.
+
+Use `dspace-oci-deploy` for immutable-tag rollouts where you want explicit Helm values overlays
+and rollout verification:
+
+- Staging: `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`
+- Production: `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`
 
 **Emergency redeploy checklist:**
 

--- a/justfile
+++ b/justfile
@@ -1135,8 +1135,77 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
 helm-oci-install release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='':
     @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' allow_install='true' reuse_values='false'
 
+# Generic helper: runs Helm and exits after Helm completes.
 helm-oci-upgrade release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='':
     @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' allow_install='false' reuse_values='true'
+
+# Opinionated immutable-tag path for dspace validation environments.
+dspace-oci-deploy env='staging' tag='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    env_input="{{ env }}"
+    env_name="${env_input}"
+    if [ "${env_input}" = "int" ]; then
+      printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
+      env_name="staging"
+    fi
+
+    deploy_tag="{{ tag }}"
+    if [ -z "${deploy_tag}" ]; then
+      echo "Set tag=<immutable-tag> (required for dspace-oci-deploy)." >&2
+      exit 1
+    fi
+    if [ "${deploy_tag}" = "v3-latest" ] || [ "${deploy_tag}" = "latest" ]; then
+      echo "dspace-oci-deploy requires an immutable tag; got '${deploy_tag}'." >&2
+      exit 1
+    fi
+
+    overlay="docs/examples/dspace.values.${env_name}.yaml"
+    if [ ! -f "${overlay}" ]; then
+      echo "No dspace values overlay found for env=${env_name} (${overlay})." >&2
+      exit 1
+    fi
+    values_chain="docs/examples/dspace.values.dev.yaml"
+    if [ "${env_name}" != "dev" ]; then
+      values_chain="${values_chain},${overlay}"
+    fi
+
+    scripts/ensure_user_kubeconfig.sh || true
+    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
+      release='dspace' namespace='dspace' \
+      chart='oci://ghcr.io/democratizedspace/charts/dspace' \
+      values="${values_chain}" \
+      version_file='docs/apps/dspace.version' \
+      tag="${deploy_tag}"
+
+    echo "Waiting for dspace rollout to complete (timeout: 180s)..."
+    kubectl -n dspace rollout status deploy/dspace --timeout=180s
+
+    resolved_image="$(
+      kubectl -n dspace get deploy dspace \
+        -o jsonpath='{.spec.template.spec.containers[?(@.name=="dspace")].image}'
+    )"
+    if [ -z "${resolved_image}" ]; then
+      echo "WARNING: could not resolve dspace container image from deployment." >&2
+    else
+      echo "Resolved deploy image: ${resolved_image}"
+    fi
+
+    host_hint="staging.democratized.space"
+    if [ "${env_name}" = "prod" ]; then
+      host_hint="democratized.space"
+    elif [ "${env_name}" = "dev" ]; then
+      host_hint="dev.democratized.space"
+    fi
+
+    echo
+    echo "Post-deploy verification commands:"
+    echo "  curl -fsS https://${host_hint}/config.json | jq ."
+    echo "  curl -fsS https://${host_hint}/healthz | jq ."
+    echo "  curl -fsS https://${host_hint}/livez | jq ."
 
 # Fast redeploy of dspace v3 from GHCR (emergency push).
 dspace-oci-redeploy env='staging' tag='':


### PR DESCRIPTION
### Motivation
- Close the observability/ergonomics gap where generic `helm-oci-*` helpers return as soon as Helm finishes, which is confusing for immutable-tag RC/stable validation workflows.
- Improve operator kubeconfig UX by preferring a user kubeconfig and running the existing kubeconfig setup helper before follow-up `kubectl` checks.
- Make the dspace values-overlay chain intentional and consistent for staging and prod deployments.

### Description
- Add a new opinionated recipe `dspace-oci-deploy env=<env> tag=<immutable>` to the `justfile` that requires an explicit immutable `tag`, resolves the values chain (`docs/examples/dspace.values.dev.yaml` + env overlay), and rejects mutable/default tags for validation deploys.
- The new helper runs `scripts/ensure_user_kubeconfig.sh` and sets `KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"`, invokes the Helm OCI install (`helm-oci-install`), waits for rollout readiness with `kubectl -n dspace rollout status deploy/dspace --timeout=180s`, prints the resolved container image from the deployment, and emits post-deploy verification commands (`/config.json`, `/healthz`, `/livez`).
- Leave the shared `_helm-oci-deploy`/`helm-oci-upgrade` helper behavior unchanged (keeps generic Helm semantics and quick returns), and document the distinction between the generic Helm helper and the opinionated dspace validation path.
- Update `docs/apps/dspace.md` and `docs/raspi_cluster_operations.md` to recommend `dspace-oci-deploy` for immutable-tag RC/stable validation, to preserve `dspace-oci-redeploy` as the mutable-tag convenience flow, and to explicitly state the staging/prod values-chain used by the new helper.

### Testing
- Ran `git diff --cached | ./scripts/scan-secrets.py` and it completed successfully with no secret findings.
- Attempted `pre-commit run --all-files` but it could not run in this environment because `pre-commit` is not installed (tooling unavailable here).
- Attempted documentation checks (`pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/`) but both could not run because the required tools are not present in this environment.
- Attempted `just --list` to validate recipe list but `just` is not installed in this environment so the command could not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf9d62389c832faa7c2cd56660f3ec)