### PR TITLE
dspace: add immutable-tag deploy helper that waits for rollout

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -1,8 +1,13 @@
 # democratized.space (dspace) on Sugarkube
 
-Use the packaged Helm chart from GHCR to install the dspace v3 stack into your cluster. The
-`justfile` exposes generic Helm helpers so you can reuse the same commands for other apps by
-changing the arguments.
+Use the packaged Helm chart from GHCR to install the dspace v3 stack into your cluster.
+
+- `helm-oci-install` / `helm-oci-upgrade` are generic helpers for many charts.
+- `dspace-oci-deploy` is the opinionated immutable-tag rollout path for dspace RC/stable
+  validation. It ensures user kubeconfig, runs Helm, waits for rollout readiness, prints the
+  deployed image, and prints follow-up verification commands.
+- `dspace-oci-redeploy` remains the fast mutable-tag convenience path (`v3-latest`) that forces a
+  restart when you want quick staging refreshes.
 
 Values files are split so you can layer staging-specific ingress settings on top of the default
 development values:
@@ -49,24 +54,22 @@ charts:
 ## Quickstart
 
 ```bash
-# Install or upgrade the release with staging ingress overrides (defaults to v3-latest image tag)
+# Immutable-tag RC/stable deploy (recommended for staging/prod validation).
+just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
+
+read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
+prod_tag="$(read_prod_tag)"
+
+# Production immutable deploy using the tracked pinned tag.
+just dspace-oci-deploy env=prod tag="${prod_tag}"
+
+# Generic helper example (advanced/manual flow; does not wait for rollout).
 just helm-oci-install \
   release=dspace namespace=dspace \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \
   values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
   version_file=docs/apps/dspace.version \
   default_tag=v3-latest
-
-read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
-prod_tag="$(read_prod_tag)"
-
-# Install production with prod ingress overrides and a pinned tag
-just helm-oci-install \
-  release=dspace namespace=dspace \
-  chart=oci://ghcr.io/democratizedspace/charts/dspace \
-  values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml \
-  version_file=docs/apps/dspace.version \
-  tag="${prod_tag}"
 
 # Check pods and ingress status with the public URL
 just app-status namespace=dspace release=dspace
@@ -89,9 +92,9 @@ just helm-oci-upgrade \
 
 - `version_file` defaults the Helm chart to the latest tested v3 release stored alongside this
   guide. You can override with `version=<semver>` when pinning a specific chart.
-- The image tag defaults to `default_tag` (`v3-latest`) for dev/staging; pass `tag=<imageTag>` to
-  target a specific build. Production deployments should use pinned tags (for example, the value in
-  `docs/apps/dspace.prod.tag` or a `v3-<immutable>` build).
+- `dspace-oci-deploy` always requires an explicit immutable `tag=...`, including staging, so rollout
+  intent is clear during RC validation.
+- The generic helpers support `default_tag` (`v3-latest`) for mutable convenience workflows.
 
 ## First deployment walkthrough
 
@@ -120,23 +123,13 @@ assumes your target cluster (for example `env=staging`) is online and reachable 
 4. Install the app:
 
    ```bash
-   just helm-oci-install \
-     release=dspace namespace=dspace \
-     chart=oci://ghcr.io/democratizedspace/charts/dspace \
-     values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
-     version_file=docs/apps/dspace.version \
-     default_tag=v3-latest
+   just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
 
    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
    prod_tag="$(read_prod_tag)"
 
    # Production example (pinned tag)
-   just helm-oci-install \
-     release=dspace namespace=dspace \
-     chart=oci://ghcr.io/democratizedspace/charts/dspace \
-     values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml \
-     version_file=docs/apps/dspace.version \
-     tag="${prod_tag}"
+   just dspace-oci-deploy env=prod tag="${prod_tag}"
    ```
 
 5. Verify everything is healthy, then browse to the FQDN on your phone or laptop:
@@ -148,12 +141,11 @@ assumes your target cluster (for example `env=staging`) is online and reachable 
 6. Iterate new builds from v3:
 
    ```bash
-   just helm-oci-upgrade \
-     release=dspace namespace=dspace \
-     chart=oci://ghcr.io/democratizedspace/charts/dspace \
-     values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
-     version_file=docs/apps/dspace.version \
-     tag=v3-<shortsha>
+   # immutable validation path
+   just dspace-oci-deploy env=staging tag=v3-<shortsha>
+
+   # mutable convenience path (forces rollout restart)
+   just dspace-oci-redeploy env=staging
    ```
 
 ## Networking via Cloudflare Tunnel

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -714,21 +714,29 @@ sets `environment: dev`, `docs/examples/dspace.values.staging.yaml` sets `enviro
 `docs/examples/dspace.values.prod.yaml` sets `environment: prod`, which show up in `/healthz` and
 the homepage build badge.
 
-If you prefer a one-liner that bakes in those arguments for dspace v3, use the helper
-recipe (defaults to staging):
+If you prefer an opinionated one-liner for immutable-tag RC/stable validation, use:
 
 ```bash
-just dspace-oci-redeploy
-# or explicitly select an environment:
+just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
+# or explicitly select production:
 read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
-just dspace-oci-redeploy env=prod tag="$(read_prod_tag)"
+just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
 ```
 
-Under the hood, both commands call the shared `_helm-oci-deploy` helper via
-`helm-oci-upgrade`, performing `helm upgrade --reuse-values` against the running release
-and then forcing a `kubectl rollout restart deploy/dspace` to ensure pods recycle even
-when `v3-latest` is republished with the same tag. The helper waits for the rollout to
-finish and exits non-zero if Kubernetes reports a failure.
+`dspace-oci-deploy` calls `helm-oci-install` with the dspace values chain, waits for
+`kubectl rollout status`, then prints the resolved deployment image plus follow-up
+`/config.json`, `/healthz`, and `/livez` checks.
+
+For fast mutable-tag convenience rollouts (for example republished `v3-latest`), keep
+using:
+
+```bash
+just dspace-oci-redeploy env=staging
+```
+
+That recipe performs `helm upgrade --reuse-values` and then forces
+`kubectl rollout restart deploy/dspace` so pods recycle even when the tag string is
+unchanged.
 
 When you pass an image tag (including the default `v3-latest`), the helper sets
 `image.pullPolicy=Always` so the nodes re-check GHCR for the latest build of that tag on

--- a/justfile
+++ b/justfile
@@ -1138,6 +1138,71 @@ helm-oci-install release='' namespace='' chart='' values='' host='' version='' v
 helm-oci-upgrade release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='':
     @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' allow_install='false' reuse_values='true'
 
+# Opinionated dspace deploy path for immutable-tag validation (RC/stable style).
+# Unlike generic helm-oci-* helpers, this recipe waits for rollout readiness and
+# prints post-deploy verification commands.
+dspace-oci-deploy env='staging' tag='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    env_input="{{ env }}"
+    env_name="${env_input}"
+    if [ "${env_input}" = "int" ]; then
+      printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
+      env_name="staging"
+    fi
+
+    deploy_tag="{{ tag }}"
+    if [ -z "${deploy_tag}" ]; then
+      echo "Set tag=<immutable-tag> (for example v3-<shortsha> or v<semver>)." >&2
+      exit 1
+    fi
+
+    if [[ "${deploy_tag}" =~ (^|[-_])latest($|[-_]) ]]; then
+      echo "tag=${deploy_tag} looks mutable. Pass an immutable tag for RC/stable validation." >&2
+      exit 1
+    fi
+
+    overlay="docs/examples/dspace.values.${env_name}.yaml"
+    if [ ! -f "${overlay}" ]; then
+      echo "No dspace values overlay found for env=${env_name} (${overlay})." >&2
+      exit 1
+    fi
+
+    values_chain="docs/examples/dspace.values.dev.yaml"
+    if [ "${env_name}" != "dev" ]; then
+      values_chain="${values_chain},${overlay}"
+    fi
+
+    scripts/ensure_user_kubeconfig.sh || true
+    export KUBECONFIG="${HOME}/.kube/config"
+
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
+      release='dspace' namespace='dspace' \
+      chart='oci://ghcr.io/democratizedspace/charts/dspace' \
+      values="${values_chain}" \
+      version_file='docs/apps/dspace.version' \
+      tag="${deploy_tag}"
+
+    echo "Waiting for dspace rollout to complete (timeout: 180s)..."
+    if ! kubectl -n dspace rollout status deploy/dspace --timeout=180s; then
+      echo "ERROR: dspace rollout did not complete successfully." >&2
+      exit 1
+    fi
+
+    deployed_image="$(kubectl -n dspace get deploy/dspace -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)"
+    if [ -n "${deployed_image}" ]; then
+      echo "Deployed image: ${deployed_image}"
+    else
+      echo "WARNING: unable to resolve deployed image from deploy/dspace" >&2
+    fi
+
+    echo
+    echo "Post-deploy verification:"
+    echo "  curl -fsS https://$(kubectl -n dspace get ingress dspace -o jsonpath='{.spec.rules[0].host}' 2>/dev/null || echo '<host>')/config.json"
+    echo "  curl -fsS https://$(kubectl -n dspace get ingress dspace -o jsonpath='{.spec.rules[0].host}' 2>/dev/null || echo '<host>')/healthz"
+    echo "  curl -fsS https://$(kubectl -n dspace get ingress dspace -o jsonpath='{.spec.rules[0].host}' 2>/dev/null || echo '<host>')/livez"
+
 # Fast redeploy of dspace v3 from GHCR (emergency push).
 dspace-oci-redeploy env='staging' tag='':
     #!/usr/bin/env bash
@@ -1176,17 +1241,15 @@ dspace-oci-redeploy env='staging' tag='':
       default_tag_value="v3-latest"
     fi
 
+    scripts/ensure_user_kubeconfig.sh || true
+    export KUBECONFIG="${HOME}/.kube/config"
+
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release='dspace' namespace='dspace' \
       chart='oci://ghcr.io/democratizedspace/charts/dspace' \
       values="${values_chain}" \
       version_file='docs/apps/dspace.version' \
       tag="${deploy_tag}" default_tag="${default_tag_value}"
-
-    scripts/ensure_user_kubeconfig.sh || true
-    if [ -z "${KUBECONFIG:-}" ]; then
-      export KUBECONFIG="${HOME}/.kube/config"
-    fi
 
     echo "Forcing rollout restart for dspace deployment..."
     if ! kubectl -n dspace rollout restart deploy/dspace; then


### PR DESCRIPTION
### Motivation
- Close the operator ergonomics gap where `helm-oci-install`/`_helm-oci-deploy` returned immediately and left immutable-tag RC deploys looking like an “instant” success. 
- Provide one obvious, opinionated recipe for RC/stable validation that performs rollout readiness verification and surfaces useful follow-up checks. 
- Improve kubeconfig/user UX so follow-up `kubectl` commands are less likely to hit permission traps on `/etc/rancher/k3s/k3s.yaml`.

### Description
- Add `dspace-oci-deploy env= tag=` to `justfile` as an immutable-tag RC/stable workflow that enforces an explicit non-`latest` tag, resolves the values chain as `docs/examples/dspace.values.dev.yaml` + env overlay, calls `scripts/ensure_user_kubeconfig.sh` and prefers `KUBECONFIG=$HOME/.kube/config`, runs the Helm OCI install, waits for rollout readiness with `kubectl rollout status`, prints the resolved deployment image, and prints post-deploy verification `curl` lines for `/config.json`, `/healthz`, and `/livez`.
- Keep the generic `_helm-oci-deploy` helper unchanged so it stays reusable and minimal (no wait flag added), and keep `dspace-oci-redeploy` as the fast mutable-tag convenience path while moving kubeconfig setup earlier in that recipe.
- Update docs (`docs/apps/dspace.md`, `docs/raspi_cluster_operations.md`) to document the distinction between the generic Helm helpers, the new opinionated immutable validation path (`dspace-oci-deploy`), and the existing mutable convenience path (`dspace-oci-redeploy`), and to show the recommended usage examples.
- Files changed: `justfile`, `docs/apps/dspace.md`, and `docs/raspi_cluster_operations.md`.

### Testing
- Ran `git diff --cached | ./scripts/scan-secrets.py` (success; no secrets flagged). 
- Attempted but unable to execute in this environment: `just --dry-run dspace-oci-deploy env=staging tag=v3-testsha` (`just` not available), `pre-commit run --all-files` (tooling not installed), `pyspelling -c .spellcheck.yaml` (tooling not installed), and `linkchecker --no-warnings README.md docs/` (tooling not installed). 
- Changes were committed to the current branch with message: "✨ add dspace immutable deploy helper".

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf9d62389c832faa7c2cd56660f3ec)