### PR TITLE
📝 docs+justfile: env-aware dspace log helper + runbook updates for staging/prod

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -174,3 +174,30 @@ For detailed instructions on creating the Cloudflare Tunnel and DNS records, see
   - `kubectl -n dspace describe ingress`
 - Validate the Cloudflare Tunnel service and route for the chosen hostname.
 - Review cluster-wide logs for Traefik or networking issues if the ingress is not reachable.
+
+### Operational logs (staging + prod)
+
+Use Sugarkube's dspace log helper to fetch both app logs and ingress logs from one command:
+
+```bash
+# Staging cluster context + logs
+just dspace-debug-logs-env env=staging
+
+# Production cluster context + logs
+just dspace-debug-logs-env env=prod
+```
+
+What this does:
+
+- Runs `just kubeconfig-env env=<env>` so `~/.kube/config` points at the selected environment context
+  (`sugar-staging` or `sugar-prod`).
+- Runs `just dspace-debug-logs`, which prints:
+  - dspace pod inventory in namespace `dspace`
+  - last 200 lines from each dspace pod with label `app.kubernetes.io/name=dspace`
+  - last 200 lines from Traefik in `kube-system`
+
+If your dspace namespace is different, override it:
+
+```bash
+just dspace-debug-logs-env env=staging namespace=<your-namespace>
+```

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -476,7 +476,7 @@ Quick reference for the most common recipes when operating your cluster:
 | `just save-logs env=dev` | Run cluster bring-up with `SAVE_DEBUG_LOGS=1` into `logs/up/` | Capture sanitized logs for troubleshooting, documenting cluster changes, or sharing with the community. |
 | `just cat-node-token` | Print the k3s node token for joining nodes | Retrieve the token when adding new nodes or switching to a different shell session. |
 | `just wipe` | Clean up k3s and mDNS state on a node | Recover from a failed bootstrap/join or remove a node that joined the wrong cluster. Re-run `just ha3 env=dev` afterward. |
-| `just dspace-debug-logs` | Dump dspace and Traefik logs for the last 200 lines each | Investigating 500s or routing issues for dspace. |
+| `just dspace-debug-logs-env env=staging` | Set env-scoped kubeconfig context, then dump dspace and Traefik logs (last 200 lines each) | Staging/prod dspace incident triage when you need app + ingress logs quickly. |
 
 ## Step 2: Capture and commit sanitized bring-up logs
 

--- a/justfile
+++ b/justfile
@@ -1237,6 +1237,28 @@ dspace-debug-logs namespace='dspace':
       echo "Failed to fetch Traefik logs" >&2
     }
 
+# Prepare an env-scoped kubeconfig, then dump dspace and Traefik logs.
+dspace-debug-logs-env env='staging' namespace='dspace':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    env_input="{{ env }}"
+    env_name="${env_input#env=}"
+    if [ "${env_name}" = "int" ]; then
+      printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
+      env_name="staging"
+    fi
+    if [ "${env_name}" != "staging" ] && [ "${env_name}" != "prod" ] && [ "${env_name}" != "dev" ]; then
+      echo "ERROR: env must be one of dev, staging, or prod (got: ${env_name})" >&2
+      exit 1
+    fi
+
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env env="${env_name}"
+    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+    echo "Using ${KUBECONFIG} (context sugar-${env_name})"
+
+    just --justfile "{{ justfile_directory() }}/justfile" dspace-debug-logs namespace="{{ namespace }}"
+
 # Fast redeploy of token.place relay from GHCR.
 # The default tag pins staging to the last validated `main` build; pass tag=sha-<new>
 


### PR DESCRIPTION
### Motivation
- Make it unambiguous and easy for operators to retrieve dspace application logs and Traefik ingress logs for both staging and prod without adding centralized logging infra. 
- Reduce guesswork about kubeconfig/context switching during incident triage by providing an env-aware helper and documenting the workflow.

### Description
- Added a new `just` recipe `dspace-debug-logs-env env=<env> namespace=<ns>` which validates `env` (accepts `dev|staging|prod`, maps `int` → `staging`), runs `just kubeconfig-env env=<env>` to prepare a user kubeconfig/context, and then invokes the existing `dspace-debug-logs` recipe to print dspace pod logs and Traefik logs. (change: `justfile`)
- Documented the staging/prod operator workflow in `docs/apps/dspace.md` with example commands (`just dspace-debug-logs-env env=staging` and `just dspace-debug-logs-env env=prod`), explained what logs are collected, and noted how to override the namespace. (change: `docs/apps/dspace.md`)
- Updated the operational commands cheat-sheet in `docs/raspi_cluster_operations.md` to point operators to the new env-aware helper for quick discovery. (change: `docs/raspi_cluster_operations.md`)
- No new infrastructure or centralized logging was introduced; this is a thin helper that reuses existing kubeconfig and kubectl-based log access.

### Testing
- Ran `git diff --cached | ./scripts/scan-secrets.py` on the staged changes and it completed with no secret findings. 
- Attempted to run `pre-commit run --all-files` but `pre-commit` is not available in this execution environment so it was not run here. 
- Attempted `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` but those binaries were not available in this environment so they were not executed here. 
- The new `just` recipe was added as a wrapper only and was not executed in this environment because the `just` binary is not present; it is intentionally minimal and calls existing `just` recipes so normal CI/local checks should exercise it when run in a dev/operator machine.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfa0a4e90c832f8e522a733e459a41)