### PR TITLE
📝 chore: clarify dspace staging/prod log workflow

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -164,6 +164,41 @@ public hostname is `https://staging.democratized.space`.
 For detailed instructions on creating the Cloudflare Tunnel and DNS records, see:
 ../cloudflare_tunnel.md
 
+## Operational logs (staging + prod)
+
+Use `just dspace-debug-logs` to collect both application logs (`dspace` namespace) and ingress
+logs (Traefik in `kube-system`) in one command.
+
+```bash
+# Staging
+just dspace-debug-logs env=staging
+
+# Production
+just dspace-debug-logs env=prod
+```
+
+The recipe uses `KUBECONFIG` (default: `~/.kube/config`) and warns if your active context does not
+match the expected scope (`sugar-staging` / `sugar-prod`). If needed, switch first:
+
+```bash
+kubectl config use-context sugar-staging
+# or
+kubectl config use-context sugar-prod
+```
+
+By default, the command prints:
+
+- dspace pod inventory in namespace `dspace`
+- last 200 lines from each dspace pod (`app.kubernetes.io/name=dspace`)
+- last 200 lines from Traefik (`app.kubernetes.io/name=traefik`, namespace `kube-system`)
+
+For deeper follow-up after the initial snapshot, use the same kubeconfig/context:
+
+```bash
+kubectl -n dspace logs deploy/dspace --follow
+kubectl -n kube-system logs -l app.kubernetes.io/name=traefik --follow
+```
+
 ## Troubleshooting
 
 - Inspect the release values and history:

--- a/justfile
+++ b/justfile
@@ -1201,13 +1201,36 @@ dspace-oci-redeploy env='staging' tag='':
     fi
 
 # Dump dspace and Traefik logs for debugging HTTP 500s.
-dspace-debug-logs namespace='dspace':
+dspace-debug-logs env='' namespace='dspace':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
+    scripts/ensure_user_kubeconfig.sh || true
     export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
 
+    env_input="{{ env }}"
+    env_name="${env_input#env=}"
+    if [ "${env_name}" = "int" ]; then
+      printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
+      env_name="staging"
+    fi
+
     ns="{{ namespace }}"
+    expected_context=""
+    if [ -n "${env_name}" ]; then
+      expected_context="sugar-${env_name}"
+      current_context="$(kubectl config current-context 2>/dev/null || true)"
+      if [ -n "${current_context}" ] && [ "${current_context}" != "${expected_context}" ]; then
+        echo "WARNING: current kubectl context is '${current_context}', expected '${expected_context}' for env=${env_name}." >&2
+        echo "Use 'kubectl config use-context ${expected_context}' or set KUBECONFIG to the target cluster before collecting logs." >&2
+      fi
+    fi
+
+    if [ -n "${expected_context}" ]; then
+      echo "Collecting logs for env=${env_name} (expected context: ${expected_context}) using KUBECONFIG=${KUBECONFIG}"
+    else
+      echo "Collecting logs using KUBECONFIG=${KUBECONFIG}"
+    fi
 
     echo "=== dspace pods in namespace ${ns} ==="
     kubectl get pods -n "${ns}" -o wide || {


### PR DESCRIPTION
### Motivation
- Make it straightforward for operators to collect dspace application logs and Traefik ingress logs for both staging and production without adding centralized logging infrastructure.
- Reduce risk of collecting logs from the wrong cluster by surfacing kubeconfig/context expectations in the helper command.
- Keep changes minimal and backward-compatible so existing workflows continue to work.

### Description
- Make `dspace-debug-logs` env-aware by adding an optional `env=` argument and bootstrap the user kubeconfig via `scripts/ensure_user_kubeconfig.sh` when present (file updated: `justfile`).
- Warn when `kubectl config current-context` does not match the expected `sugar-<env>` context and print which `KUBECONFIG` is being used to avoid cross-environment confusion (file updated: `justfile`).
- Add an "Operational logs (staging + prod)" section to the dspace runbook that documents `just dspace-debug-logs env=staging` / `env=prod`, the expected kubeconfig contexts, and follow-up `kubectl` commands for live tails (file updated: `docs/apps/dspace.md`).
- Changes target only runbook and helper usability; no platform or centralized logging components were added.

### Testing
- Attempted `pre-commit run --all-files`, but `pre-commit` is not installed in this environment so the check could not be executed here (local CI will run this).
- Attempted `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/`, but the binaries are not installed in this environment so those checks could not be executed here.
- Attempted `just --fmt --unstable`, but `just` is not installed in this environment so formatting could not be run here.
- Ran `git diff --cached | ./scripts/scan-secrets.py` which produced no output, indicating no credential-like strings were staged (scan succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfa0a4e90c832f8e522a733e459a41)