### PR TITLE
Clarify dspace staging/prod operational log access

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -173,4 +173,22 @@ For detailed instructions on creating the Cloudflare Tunnel and DNS records, see
   - `kubectl -n dspace get pods`
   - `kubectl -n dspace describe ingress`
 - Validate the Cloudflare Tunnel service and route for the chosen hostname.
-- Review cluster-wide logs for Traefik or networking issues if the ingress is not reachable.
+- Pull operator logs for app + ingress from Sugarkube (staging and prod):
+
+  ```bash
+  # one-time per workstation/node if contexts are missing
+  just kubeconfig-env env=staging
+  just kubeconfig-env env=prod
+
+  # staging: dspace pods + Traefik logs
+  just dspace-debug-logs-staging
+
+  # prod: dspace pods + Traefik logs
+  just dspace-debug-logs-prod
+  ```
+
+  These wrappers call `dspace-debug-logs` with explicit kube contexts (`sugar-staging` and
+  `sugar-prod`) so you do not need to manually switch contexts before collecting logs.
+- For follow-up commands after collecting logs, keep the same context explicit, for example:
+  - `kubectl --context sugar-staging -n dspace get events --sort-by=.lastTimestamp`
+  - `kubectl --context sugar-prod -n dspace describe pod <pod-name>`

--- a/justfile
+++ b/justfile
@@ -1201,23 +1201,35 @@ dspace-oci-redeploy env='staging' tag='':
     fi
 
 # Dump dspace and Traefik logs for debugging HTTP 500s.
-dspace-debug-logs namespace='dspace':
+dspace-debug-logs namespace='dspace' context='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
+    scripts/ensure_user_kubeconfig.sh || true
     export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
 
     ns="{{ namespace }}"
+    kube_context="{{ context }}"
+    kubectl_cmd=(kubectl)
+
+    if [ -n "${kube_context}" ]; then
+      kubectl_cmd+=(--context "${kube_context}")
+      if ! kubectl config get-contexts "${kube_context}" >/dev/null 2>&1; then
+        echo "ERROR: kube context '${kube_context}' not found in ${KUBECONFIG}." >&2
+        echo "Run 'just kubeconfig-env env=staging' or 'just kubeconfig-env env=prod' first." >&2
+        exit 1
+      fi
+    fi
 
     echo "=== dspace pods in namespace ${ns} ==="
-    kubectl get pods -n "${ns}" -o wide || {
+    "${kubectl_cmd[@]}" get pods -n "${ns}" -o wide || {
       echo "Failed to list dspace pods in namespace ${ns}" >&2
     }
 
     echo
     echo "=== dspace logs (last 200 lines per pod) ==="
     # Logs for all pods labeled as dspace
-    dspace_pods=$(kubectl get pods -n "${ns}" -l app.kubernetes.io/name=dspace -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
+    dspace_pods=$("${kubectl_cmd[@]}" get pods -n "${ns}" -l app.kubernetes.io/name=dspace -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
 
     if [ -z "${dspace_pods}" ]; then
       echo "No pods found with label app.kubernetes.io/name=dspace in namespace ${ns}" >&2
@@ -1225,7 +1237,7 @@ dspace-debug-logs namespace='dspace':
       for pod in ${dspace_pods}; do
         echo
         echo "--- dspace pod: ${pod} ---"
-        kubectl logs -n "${ns}" "${pod}" --tail=200 || {
+        "${kubectl_cmd[@]}" logs -n "${ns}" "${pod}" --tail=200 || {
           echo "Failed to fetch logs for pod ${pod}" >&2
         }
       done
@@ -1233,9 +1245,17 @@ dspace-debug-logs namespace='dspace':
 
     echo
     echo "=== Traefik logs (last 200 lines) ==="
-    kubectl logs -n kube-system -l app.kubernetes.io/name=traefik --tail=200 || {
+    "${kubectl_cmd[@]}" logs -n kube-system -l app.kubernetes.io/name=traefik --tail=200 || {
       echo "Failed to fetch Traefik logs" >&2
     }
+
+# Dump dspace+Traefik logs from the staging cluster context (sugar-staging).
+dspace-debug-logs-staging namespace='dspace':
+    @just --justfile "{{ justfile_directory() }}/justfile" dspace-debug-logs namespace='{{ namespace }}' context='sugar-staging'
+
+# Dump dspace+Traefik logs from the production cluster context (sugar-prod).
+dspace-debug-logs-prod namespace='dspace':
+    @just --justfile "{{ justfile_directory() }}/justfile" dspace-debug-logs namespace='{{ namespace }}' context='sugar-prod'
 
 # Fast redeploy of token.place relay from GHCR.
 # The default tag pins staging to the last validated `main` build; pass tag=sha-<new>


### PR DESCRIPTION
### Motivation

- Ensure operators can reliably retrieve dspace and Traefik logs for staging and production from sugarkube without introducing centralized logging.
- Make kubeconfig and context expectations explicit so follow-up `kubectl` troubleshooting is straightforward for operators.

### Description

- Make `dspace-debug-logs` context-aware by adding an optional `context=` argument and passing it as `--context` to `kubectl` calls.
- Call `scripts/ensure_user_kubeconfig.sh` at the start of the recipe and validate the requested kube context, emitting actionable guidance if it is missing.
- Add thin wrappers `dspace-debug-logs-staging` and `dspace-debug-logs-prod` that invoke the main recipe with `sugar-staging` and `sugar-prod` contexts respectively.
- Update `docs/apps/dspace.md` troubleshooting to document one-line operator workflows (`just dspace-debug-logs-staging` / `just dspace-debug-logs-prod`), one-time `just kubeconfig-env` setup, and recommended follow-up `kubectl --context ...` commands.

### Testing

- Ran the repository secret scan via `git diff --cached | ./scripts/scan-secrets.py`, which completed successfully.
- Attempted `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, `linkchecker --no-warnings README.md docs/`, and `just --check` but those tools were not available in the execution environment, so they were not run.
- No centralized logging infra was added and the changes are limited to `justfile` and `docs/apps/dspace.md` as described.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfa0a4e90c832f8e522a733e459a41)