### PR TITLE
✨ chore: prepare dspace v3 production cutover workflow

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -13,13 +13,17 @@ development values:
 - `docs/examples/dspace.values.dev.yaml`: shared defaults for local/dev environments.
 - `docs/examples/dspace.values.staging.yaml`: staging-only ingress host and class targeting
   `staging.democratized.space`.
+- `docs/examples/dspace.values.prod_preview.yaml`: production-cluster preview ingress host and
+  class targeting `prod.democratized.space` before apex cutover.
 - `docs/examples/dspace.values.prod.yaml`: production ingress host and class targeting
   `democratized.space`.
 
 The public staging environment for dspace defaults to the `staging.democratized.space`
 hostname. You can substitute a different hostname if your Cloudflare Tunnel and DNS are
-configured accordingly. For production, use the prod values file and your production hostname
-(defaults to `democratized.space` in this repo).
+configured accordingly. For production, this repo supports a two-step rollout:
+
+1. `prod.democratized.space` preview validation (`prod_preview` values).
+2. Apex cutover to `democratized.space` (`prod` values).
 
 ## Prerequisites
 
@@ -57,7 +61,10 @@ just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
 
 read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
 
-# Immutable-tag production deploy (pinned tag from docs/apps/dspace.prod.tag):
+# Immutable-tag production preview deploy (pinned tag from docs/apps/dspace.prod.tag):
+just dspace-oci-deploy env=prod-preview tag="$(read_prod_tag)"
+
+# Immutable-tag production apex deploy:
 just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
 
 # Check pods and ingress status with the public URL
@@ -78,6 +85,13 @@ just helm-oci-upgrade \
   values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
   version_file=docs/apps/dspace.version \
   tag=v3-<shortsha>
+
+just helm-oci-upgrade \
+  release=dspace namespace=dspace \
+  chart=oci://ghcr.io/democratizedspace/charts/dspace \
+  values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod_preview.yaml \
+  version_file=docs/apps/dspace.version \
+  tag=v3-<immutable-tag>
 
 just helm-oci-upgrade \
   release=dspace namespace=dspace \
@@ -147,13 +161,48 @@ assumes your target cluster (for example `env=staging`) is online and reachable 
      tag=v3-<shortsha>
    ```
 
+## v3 production rollout plan (staging → prod preview → apex)
+
+Use this sequence when onboarding dspace v3 to production while keeping staging online.
+
+1. **Provision the prod cluster nodes**: ensure `sugarkube0`, `sugarkube1`, and `sugarkube2`
+   are active for production. Keep `sugarkube3` through `sugarkube5` on
+   `staging.democratized.space`.
+2. **Deploy v3 branch to prod preview host**:
+   ```bash
+   just kubeconfig-env env=prod
+   just dspace-oci-deploy env=prod-preview tag=v3-<immutable-tag>
+   ```
+3. **Run smoke tests against preview**:
+   ```bash
+   curl -fsS https://prod.democratized.space/config.json | jq .
+   curl -fsS https://prod.democratized.space/healthz | jq .
+   curl -fsS https://prod.democratized.space/livez | jq .
+   ```
+4. **Merge dspace v3 into `main`** in the dspace repository.
+5. **Deploy from `main` to prod preview** with a new immutable tag:
+   ```bash
+   just dspace-oci-deploy env=prod-preview tag=v3-<immutable-main-tag>
+   ```
+6. **Switch production ingress to apex**:
+   ```bash
+   just dspace-oci-deploy env=prod tag=v3-<immutable-main-tag>
+   ```
+7. **Cloudflare cutover**:
+   - Keep `democratized.space` pointing to the production Traefik route.
+   - Convert `prod.democratized.space` to a simple redirect to `https://democratized.space`.
+
 For emergency mutable-tag refreshes where you need to force pod recycle on `v3-latest`, keep using
-`just dspace-oci-redeploy env=staging` (or `env=prod tag=...`).
+`just dspace-oci-redeploy env=staging` (or `env=prod-preview|prod tag=...`).
 
 ## Networking via Cloudflare Tunnel
 
-This guide assumes you expose the cluster through a persistent Cloudflare Tunnel. The expected
-public hostname is `https://staging.democratized.space`.
+This guide assumes you expose the cluster through a persistent Cloudflare Tunnel. Expected public
+hostnames:
+
+- staging: `https://staging.democratized.space`
+- prod preview: `https://prod.democratized.space`
+- prod apex: `https://democratized.space`
 
 For detailed instructions on creating the Cloudflare Tunnel and DNS records, see:
 ../cloudflare_tunnel.md

--- a/docs/examples/dspace.values.prod_preview.yaml
+++ b/docs/examples/dspace.values.prod_preview.yaml
@@ -1,0 +1,8 @@
+# Example values for deploying democratized.space v3 to the production preview hostname.
+# Use this during cutover validation before switching apex DNS.
+environment: prod-preview
+
+ingress:
+  enabled: true
+  className: traefik
+  host: prod.democratized.space

--- a/justfile
+++ b/justfile
@@ -1153,7 +1153,7 @@ helm-oci-upgrade release='' namespace='' chart='' values='' host='' version='' v
 # Opinionated immutable-tag dspace deploy with rollout verification.
 
 # Use this for RC/stable validation flows where explicit image pinning matters.
-dspace-oci-deploy env='staging' tag='':
+dspace-oci-deploy env='staging' tag='' host='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1165,9 +1165,9 @@ dspace-oci-deploy env='staging' tag='':
     fi
 
     case "${env_name}" in
-      dev|staging|prod) ;;
+      dev|staging|prod|prod-preview) ;;
       *)
-        echo "Unsupported env=${env_name}. Use env=dev|staging|prod." >&2
+        echo "Unsupported env=${env_name}. Use env=dev|staging|prod-preview|prod." >&2
         exit 1
         ;;
     esac
@@ -1184,8 +1184,12 @@ dspace-oci-deploy env='staging' tag='':
     fi
 
     overlay=""
+    overlay_env="${env_name}"
+    if [ "${env_name}" = "prod-preview" ]; then
+      overlay_env="prod_preview"
+    fi
     if [ "${env_name}" != "dev" ]; then
-      overlay="docs/examples/dspace.values.${env_name}.yaml"
+      overlay="docs/examples/dspace.values.${overlay_env}.yaml"
       if [ ! -f "${overlay}" ]; then
         echo "No dspace values overlay found for env=${env_name} (${overlay})." >&2
         exit 1
@@ -1204,12 +1208,19 @@ dspace-oci-deploy env='staging' tag='':
       export KUBECONFIG="${HOME}/.kube/config"
     fi
 
+    deploy_host="$(echo "{{ host }}" | xargs)"
+    host_arg=()
+    if [ -n "${deploy_host}" ]; then
+      host_arg=(host="${deploy_host}")
+    fi
+
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='dspace' namespace='dspace' \
       chart='oci://ghcr.io/democratizedspace/charts/dspace' \
       values="${values_chain}" \
       version_file='docs/apps/dspace.version' \
-      tag="${deploy_tag}"
+      tag="${deploy_tag}" \
+      "${host_arg[@]}"
 
     echo "Waiting for dspace rollout to complete (timeout: 180s)..."
     if ! kubectl -n dspace rollout status deploy/dspace --timeout=180s; then
@@ -1241,7 +1252,7 @@ dspace-oci-deploy env='staging' tag='':
     fi
 
 # Fast redeploy of dspace v3 from GHCR (emergency push).
-dspace-oci-redeploy env='staging' tag='':
+dspace-oci-redeploy env='staging' tag='' host='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1254,7 +1265,11 @@ dspace-oci-redeploy env='staging' tag='':
 
     read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
 
-    overlay="docs/examples/dspace.values.${env_name}.yaml"
+    overlay_env="${env_name}"
+    if [ "${env_name}" = "prod-preview" ]; then
+      overlay_env="prod_preview"
+    fi
+    overlay="docs/examples/dspace.values.${overlay_env}.yaml"
     if [ ! -f "${overlay}" ]; then
       echo "No dspace values overlay found for env=${env_name} (${overlay})." >&2
       exit 1
@@ -1278,12 +1293,19 @@ dspace-oci-redeploy env='staging' tag='':
       default_tag_value="v3-latest"
     fi
 
+    deploy_host="$(echo "{{ host }}" | xargs)"
+    host_arg=()
+    if [ -n "${deploy_host}" ]; then
+      host_arg=(host="${deploy_host}")
+    fi
+
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release='dspace' namespace='dspace' \
       chart='oci://ghcr.io/democratizedspace/charts/dspace' \
       values="${values_chain}" \
       version_file='docs/apps/dspace.version' \
-      tag="${deploy_tag}" default_tag="${default_tag_value}"
+      tag="${deploy_tag}" default_tag="${default_tag_value}" \
+      "${host_arg[@]}"
 
     scripts/ensure_user_kubeconfig.sh || true
     if [ -z "${KUBECONFIG:-}" ]; then


### PR DESCRIPTION
### Motivation

- Provide a safe, two-step production rollout for DSPACE v3 that validates on a prod subdomain before switching the apex DNS. 
- Make operational deploys repeatable by adding a `prod-preview` environment and allowing a `host=` override for controlled cutovers.

### Description

- Add `docs/examples/dspace.values.prod_preview.yaml` to target the preview hostname `prod.democratized.space` for prod-cluster validation. 
- Update `docs/apps/dspace.md` with the new `prod-preview` overlay, example commands for `env=prod-preview`, and a concrete rollout checklist (staging → prod preview → merge → apex cutover → Cloudflare redirect). 
- Extend `dspace-oci-deploy` and `dspace-oci-redeploy` in the `justfile` to accept `env=prod-preview` and an optional `host=` override, map `prod-preview` to the new overlay, and forward `host` into the underlying `helm-oci-install` / `helm-oci-upgrade` calls. 

### Testing

- Ran `pytest -q tests/test_justfile_formatting.py`, which passed. 
- Verified `just --list` to confirm updated recipes are exposed. 
- Ran `git diff --cached | ./scripts/scan-secrets.py` against staged changes with no secret warnings. 
- `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` could not be executed in this container because those binaries are not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c62427b574832f9637237a5383f30b)