### PR TITLE
📝 docs/just: prep DSPACE v3 prod cutover with prod-subdomain & host override

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -14,12 +14,12 @@ development values:
 - `docs/examples/dspace.values.staging.yaml`: staging-only ingress host and class targeting
   `staging.democratized.space`.
 - `docs/examples/dspace.values.prod.yaml`: production ingress host and class targeting
-  `democratized.space`.
+  `prod.democratized.space` until final apex cutover.
 
 The public staging environment for dspace defaults to the `staging.democratized.space`
 hostname. You can substitute a different hostname if your Cloudflare Tunnel and DNS are
 configured accordingly. For production, use the prod values file and your production hostname
-(defaults to `democratized.space` in this repo).
+(defaults to `prod.democratized.space` in this repo).
 
 ## Prerequisites
 
@@ -60,6 +60,9 @@ read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod
 # Immutable-tag production deploy (pinned tag from docs/apps/dspace.prod.tag):
 just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
 
+# Final apex cutover (override host per deploy):
+just dspace-oci-deploy env=prod tag="$(read_prod_tag)" host=democratized.space
+
 # Check pods and ingress status with the public URL
 just app-status namespace=dspace release=dspace
 
@@ -83,6 +86,7 @@ just helm-oci-upgrade \
   release=dspace namespace=dspace \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \
   values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml \
+  host=democratized.space \
   version_file=docs/apps/dspace.version \
   tag=v3-<immutable-tag>
 ```
@@ -92,9 +96,41 @@ just helm-oci-upgrade \
 - The image tag defaults to `default_tag` (`v3-latest`) for dev/staging in the generic helpers.
   Production deployments should use pinned tags (for example, the value in
   `docs/apps/dspace.prod.tag` or a `v3-<immutable>` build).
+- `dspace-oci-deploy` and `dspace-oci-redeploy` now accept `host=<fqdn>` so you can keep the
+  production release on `prod.democratized.space` during validation, then override to
+  `democratized.space` for apex cutover without editing values files.
 - `dspace-oci-deploy` always requires an explicit immutable tag (rejects mutable forms such as
   `latest` and `main`), calls `helm-oci-install` so first-time deploys work, and waits for
   `kubectl rollout status` before returning.
+
+## v3 production rollout sequence (sugarkube)
+
+Use this sequence for the prod launch where `sugarkube0` through `sugarkube2` host production and
+`sugarkube3` through `sugarkube5` remain dedicated to staging:
+
+1. Provision prod nodes (`sugarkube0`, `sugarkube1`, `sugarkube2`) and confirm they are `Ready`.
+2. Deploy dspace v3 from the dspace `v3` branch to `prod.democratized.space`:
+
+   ```bash
+   just dspace-oci-deploy env=prod tag=v3-<immutable-tag> host=prod.democratized.space
+   ```
+
+3. Run smoke tests against `https://prod.democratized.space`.
+4. Merge dspace `v3` into `main`.
+5. Deploy from `main` to the same prod subdomain and re-run smoke tests:
+
+   ```bash
+   just dspace-oci-deploy env=prod tag=v3-<new-immutable-tag> host=prod.democratized.space
+   ```
+
+6. Cut over ingress to the apex domain:
+
+   ```bash
+   just dspace-oci-deploy env=prod tag=v3-<new-immutable-tag> host=democratized.space
+   ```
+
+7. In Cloudflare, convert `prod.democratized.space` to a redirect that points to
+   `https://democratized.space`.
 
 ## First deployment walkthrough
 

--- a/docs/examples/dspace.values.prod.yaml
+++ b/docs/examples/dspace.values.prod.yaml
@@ -5,4 +5,6 @@ environment: prod
 ingress:
   enabled: true
   className: traefik
-  host: democratized.space
+  # Keep production deploys on a prod subdomain until final apex cutover.
+  # Override with host=democratized.space in just commands during cutover.
+  host: prod.democratized.space

--- a/justfile
+++ b/justfile
@@ -1153,7 +1153,7 @@ helm-oci-upgrade release='' namespace='' chart='' values='' host='' version='' v
 # Opinionated immutable-tag dspace deploy with rollout verification.
 
 # Use this for RC/stable validation flows where explicit image pinning matters.
-dspace-oci-deploy env='staging' tag='':
+dspace-oci-deploy env='staging' tag='' host='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1182,6 +1182,7 @@ dspace-oci-deploy env='staging' tag='':
       echo "Refusing mutable tag '${deploy_tag}'. Use an immutable RC/stable image tag." >&2
       exit 1
     fi
+    deploy_host="$(echo "{{ host }}" | xargs)"
 
     overlay=""
     if [ "${env_name}" != "dev" ]; then
@@ -1208,6 +1209,7 @@ dspace-oci-deploy env='staging' tag='':
       release='dspace' namespace='dspace' \
       chart='oci://ghcr.io/democratizedspace/charts/dspace' \
       values="${values_chain}" \
+      host="${deploy_host}" \
       version_file='docs/apps/dspace.version' \
       tag="${deploy_tag}"
 
@@ -1241,7 +1243,7 @@ dspace-oci-deploy env='staging' tag='':
     fi
 
 # Fast redeploy of dspace v3 from GHCR (emergency push).
-dspace-oci-redeploy env='staging' tag='':
+dspace-oci-redeploy env='staging' tag='' host='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1265,6 +1267,7 @@ dspace-oci-redeploy env='staging' tag='':
     fi
 
     deploy_tag="{{ tag }}"
+    deploy_host="$(echo "{{ host }}" | xargs)"
     default_tag_value=""
     if [ "${env_name}" = "prod" ]; then
       if [ -z "${deploy_tag}" ] && [ -f "docs/apps/dspace.prod.tag" ]; then
@@ -1282,6 +1285,7 @@ dspace-oci-redeploy env='staging' tag='':
       release='dspace' namespace='dspace' \
       chart='oci://ghcr.io/democratizedspace/charts/dspace' \
       values="${values_chain}" \
+      host="${deploy_host}" \
       version_file='docs/apps/dspace.version' \
       tag="${deploy_tag}" default_tag="${default_tag_value}"
 


### PR DESCRIPTION
### Motivation

- Prepare sugarkube for a staged DSPACE v3 production rollout that validates on a prod subdomain before switching the apex domain. 
- Make the deployment workflow explicit and repeatable so operators can validate on `prod.democratized.space` and then cut over to `democratized.space` without editing values files.

### Description

- Add an optional `host=` parameter to `dspace-oci-deploy` and `dspace-oci-redeploy` in the `justfile` and pass it through to the underlying `helm-oci-install`/`helm-oci-upgrade` calls so deploys can target an explicit FQDN. 
- Change the prod values example in `docs/examples/dspace.values.prod.yaml` to default to `prod.democratized.space` (keep apex cutover as an explicit override). 
- Update `docs/apps/dspace.md` to document the new rollout sequence for sugarkube (`sugarkube0`–`sugarkube2` for prod, `sugarkube3`–`sugarkube5` for staging), include example `just` invocations with `host=...`, and explain the Cloudflare redirect step for final cutover. 
- These are documentation and recipe changes only; no runtime application logic was modified.

### Testing

- Ran `git diff --cached | ./scripts/scan-secrets.py` against the staged changes and it completed successfully. 
- Attempted to run linting/docs checks, but `pre-commit`, `pyspelling`, and `linkchecker` were not available in this environment and reported `command not found` so they could not be executed here. 
- Could not run `just` recipes end-to-end in this container because the `just` binary was not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c62427b574832f9637237a5383f30b)