### PR TITLE
docs+justfile: add prod-canary rollout support for DSPACE v3

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -13,13 +13,15 @@ development values:
 - `docs/examples/dspace.values.dev.yaml`: shared defaults for local/dev environments.
 - `docs/examples/dspace.values.staging.yaml`: staging-only ingress host and class targeting
   `staging.democratized.space`.
+- `docs/examples/dspace.values.prod-canary.yaml`: production-cluster canary host and class targeting
+  `prod.democratized.space` for cutover smoke tests.
 - `docs/examples/dspace.values.prod.yaml`: production ingress host and class targeting
   `democratized.space`.
 
 The public staging environment for dspace defaults to the `staging.democratized.space`
 hostname. You can substitute a different hostname if your Cloudflare Tunnel and DNS are
-configured accordingly. For production, use the prod values file and your production hostname
-(defaults to `democratized.space` in this repo).
+configured accordingly. For production, use `prod-canary` first (`prod.democratized.space`) during
+cutover validation, then switch to the apex `democratized.space` values file.
 
 ## Prerequisites
 
@@ -60,6 +62,9 @@ read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod
 # Immutable-tag production deploy (pinned tag from docs/apps/dspace.prod.tag):
 just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
 
+# Immutable-tag production canary deploy (prod cluster, prod. subdomain):
+just dspace-oci-deploy env=prod-canary tag="$(read_prod_tag)"
+
 # Check pods and ingress status with the public URL
 just app-status namespace=dspace release=dspace
 
@@ -95,6 +100,33 @@ just helm-oci-upgrade \
 - `dspace-oci-deploy` always requires an explicit immutable tag (rejects mutable forms such as
   `latest` and `main`), calls `helm-oci-install` so first-time deploys work, and waits for
   `kubectl rollout status` before returning.
+- `env=prod-canary` is an explicit rollout stage that uses
+  `docs/examples/dspace.values.prod-canary.yaml` and the `prod.democratized.space` host.
+
+## DSPACE v3 rollout plan (staging → prod canary → apex)
+
+This matches the production plan documented in the dspace `v3` branch and the Sugarkube rollout
+sequence:
+
+1. Keep `sugarkube3..5` serving `staging.democratized.space`.
+2. Stand up `sugarkube0..2` as the production cluster (`env=prod`).
+3. Deploy dspace v3 from the dspace `v3` branch to the production canary host:
+
+   ```bash
+   read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
+   just dspace-oci-deploy env=prod-canary tag="$(read_prod_tag)"
+   ```
+
+4. Run smoke tests against `https://prod.democratized.space`.
+5. Merge dspace `v3` into `main`, publish an immutable `main-*` or semver tag, and deploy that
+   same immutable tag to `env=prod-canary`.
+6. Move the production apex host by deploying with `env=prod`:
+
+   ```bash
+   just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
+   ```
+
+7. In Cloudflare, convert `prod.democratized.space` to a redirect once apex traffic is stable.
 
 ## First deployment walkthrough
 
@@ -148,7 +180,7 @@ assumes your target cluster (for example `env=staging`) is online and reachable 
    ```
 
 For emergency mutable-tag refreshes where you need to force pod recycle on `v3-latest`, keep using
-`just dspace-oci-redeploy env=staging` (or `env=prod tag=...`).
+`just dspace-oci-redeploy env=staging` (or `env=prod-canary tag=...` / `env=prod tag=...`).
 
 ## Networking via Cloudflare Tunnel
 
@@ -161,7 +193,7 @@ For detailed instructions on creating the Cloudflare Tunnel and DNS records, see
 ## Troubleshooting
 
 - Retrieve operator logs (staging/prod):
-  1. `just dspace-debug-logs-env env=<staging|prod>` first runs `just kubeconfig-env`
+  1. `just dspace-debug-logs-env env=<dev|staging|prod>` first runs `just kubeconfig-env`
      and rewrites `~/.kube/config` to the selected `sugar-<env>` context.
   2. Run the bundled log collector to fetch both app and ingress logs.
 

--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -1,4 +1,4 @@
-# Cloudflare Tunnel (cloudflared) for staging
+# Cloudflare Tunnel (cloudflared) for dspace staging + production cutover
 
 We use **Cloudflare Tunnel** to expose the k3s/Sugarkube cluster to the internet without opening
 inbound firewall ports. The canonical staging hostname for dspace is
@@ -7,9 +7,9 @@ inbound firewall ports. The canonical staging hostname for dspace is
 https://staging.democratized.space
 ```
 
-The tunnel routes this hostname to Traefik (or another ingress controller) running inside the k3s
-cluster. You do **not** need to install or run `cloudflared` on your workstation; the connector runs
-inside the cluster.
+The tunnel routes this hostname (and production hosts during cutover) to Traefik running inside the
+k3s cluster. You do **not** need to install or run `cloudflared` on your workstation; the connector
+runs inside the cluster.
 
 > Cloudflare has two big modes for tunnels: **remotely-managed** (token-only, created in the
 > dashboard) and **locally-managed** (requires `cloudflared login` and a `cert.pem`). Sugarkube uses
@@ -24,6 +24,9 @@ inside the cluster.
   `just cf-tunnel-install env=dev token="$CF_TUNNEL_TOKEN"`.
 - In the tunnel UI, configure a Public hostname routing `staging.democratized.space` →
   `http://traefik.<namespace>.svc.cluster.local:80`.
+- During v3 production rollout, also configure:
+  - `prod.democratized.space` → `http://traefik.kube-system.svc.cluster.local:80` (canary)
+  - `democratized.space` → `http://traefik.kube-system.svc.cluster.local:80` (apex cutover)
 - Confirm readiness: use the port-forward + curl check shown below to hit `/ready` on port 2000.
 
 ## Prerequisites

--- a/docs/examples/dspace.values.prod-canary.yaml
+++ b/docs/examples/dspace.values.prod-canary.yaml
@@ -1,0 +1,8 @@
+# Example values for dspace v3 cutover validation on the production subdomain.
+# Use this before the apex host switch so rollout smoke tests run on prod.democratized.space.
+environment: prod
+
+ingress:
+  enabled: true
+  className: traefik
+  host: prod.democratized.space

--- a/justfile
+++ b/justfile
@@ -1165,9 +1165,9 @@ dspace-oci-deploy env='staging' tag='':
     fi
 
     case "${env_name}" in
-      dev|staging|prod) ;;
+      dev|staging|prod|prod-canary) ;;
       *)
-        echo "Unsupported env=${env_name}. Use env=dev|staging|prod." >&2
+        echo "Unsupported env=${env_name}. Use env=dev|staging|prod|prod-canary." >&2
         exit 1
         ;;
     esac
@@ -1184,12 +1184,20 @@ dspace-oci-deploy env='staging' tag='':
     fi
 
     overlay=""
-    if [ "${env_name}" != "dev" ]; then
-      overlay="docs/examples/dspace.values.${env_name}.yaml"
-      if [ ! -f "${overlay}" ]; then
-        echo "No dspace values overlay found for env=${env_name} (${overlay})." >&2
-        exit 1
-      fi
+    case "${env_name}" in
+      dev)
+        overlay=""
+        ;;
+      prod-canary)
+        overlay="docs/examples/dspace.values.prod-canary.yaml"
+        ;;
+      *)
+        overlay="docs/examples/dspace.values.${env_name}.yaml"
+        ;;
+    esac
+    if [ -n "${overlay}" ] && [ ! -f "${overlay}" ]; then
+      echo "No dspace values overlay found for env=${env_name} (${overlay})." >&2
+      exit 1
     fi
 
     values_chain="docs/examples/dspace.values.dev.yaml"
@@ -1252,9 +1260,20 @@ dspace-oci-redeploy env='staging' tag='':
       env_name="staging"
     fi
 
+    case "${env_name}" in
+      dev|staging|prod|prod-canary) ;;
+      *)
+        echo "Unsupported env=${env_name}. Use env=dev|staging|prod|prod-canary." >&2
+        exit 1
+        ;;
+    esac
+
     read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
 
     overlay="docs/examples/dspace.values.${env_name}.yaml"
+    if [ "${env_name}" = "prod-canary" ]; then
+      overlay="docs/examples/dspace.values.prod-canary.yaml"
+    fi
     if [ ! -f "${overlay}" ]; then
       echo "No dspace values overlay found for env=${env_name} (${overlay})." >&2
       exit 1
@@ -1266,7 +1285,7 @@ dspace-oci-redeploy env='staging' tag='':
 
     deploy_tag="{{ tag }}"
     default_tag_value=""
-    if [ "${env_name}" = "prod" ]; then
+    if [ "${env_name}" = "prod" ] || [ "${env_name}" = "prod-canary" ]; then
       if [ -z "${deploy_tag}" ] && [ -f "docs/apps/dspace.prod.tag" ]; then
         deploy_tag="$(read_prod_tag)"
       fi


### PR DESCRIPTION
### Motivation
- Provide a safe production cutover path that validates DSPACE v3 on a production subdomain before switching the apex host. 
- Align Sugarkube helpers and documentation with the DSPACE v3 rollout plan (staging → prod subdomain smoke test → apex cutover). 

### Description
- Add `env=prod-canary` support to `dspace-oci-deploy` and `dspace-oci-redeploy` in the `justfile`, including env validation, overlay selection and immutable-tag handling parity with `prod`.
- Add a new values overlay `docs/examples/dspace.values.prod-canary.yaml` that targets `prod.democratized.space` for canary smoke tests.
- Update `docs/apps/dspace.md` with the new values file, `env=prod-canary` examples, and an explicit DSPACE v3 rollout sequence covering staging → prod-canary → apex.
- Update `docs/cloudflare_tunnel.md` to document creating Cloudflare Tunnel routes for the canary host (`prod.democratized.space`) and the apex host (`democratized.space`) during the cutover.

### Testing
- Ran `pre-commit run --all-files`, which failed because `pre-commit` is not available in this environment.
- Ran `pyspelling -c .spellcheck.yaml`, which failed because `pyspelling` is not available in this environment.
- Ran `linkchecker --no-warnings README.md docs/`, which failed because `linkchecker` is not available in this environment.
- Ran the repository secret scan `git diff --cached | ./scripts/scan-secrets.py`, which completed with no findings reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c62427b574832f9637237a5383f30b)