### PR TITLE
docs: clarify dspace Phase A (prod subdomain) vs Phase B (apex) rollout

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -59,16 +59,16 @@ charts:
 # Immutable-tag staging deploy (recommended for RC/stable validation):
 just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
 
-# Immutable-tag production preview deploy (prod subdomain canary):
+# Phase A: immutable-tag production preview deploy (prod subdomain canary):
 just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag>
 
 read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
 
-# Immutable-tag production deploy (pinned tag from docs/apps/dspace.prod.tag):
-just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
-
-# Alias helper for apex promotion (same effect as the env=prod command above):
+# Phase B: immutable-tag apex promotion (democratized.space) using the pinned production tag:
 just dspace-oci-promote-prod tag="$(read_prod_tag)"
+
+# Equivalent explicit apex command (same effect as the helper above):
+just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
 
 # Check pods and ingress status with the public URL
 just app-status namespace=dspace release=dspace
@@ -142,9 +142,14 @@ assumes your target cluster (for example `env=staging`) is online and reachable 
    ```bash
    just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
 
-   # Production example (pinned tag)
+   # Production rollout examples (pinned tag)
    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
-   just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
+
+   # Phase A preview endpoint
+   just dspace-oci-deploy-prod-subdomain tag="$(read_prod_tag)"
+
+   # Phase B apex promotion
+   just dspace-oci-promote-prod tag="$(read_prod_tag)"
    ```
 
 5. Verify everything is healthy, then browse to the FQDN on your phone or laptop:

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -681,7 +681,9 @@ deployment's defaults.
 Pick the values overlay for your target environment and prefer immutable image tags for production:
 
 - Staging: `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`
-- Production: `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`
+- Production preview (Phase A):
+  `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod-subdomain.yaml`
+- Production apex (Phase B): `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`
 
 ```bash
 # From the sugarkube repo root on a cluster node (staging):
@@ -730,14 +732,19 @@ and then forcing a `kubectl rollout restart deploy/dspace` to ensure pods recycl
 when `v3-latest` is republished with the same tag. The helper waits for the rollout to
 finish and exits non-zero if Kubernetes reports a failure.
 
-For immutable RC/stable validation (recommended for staging and prod), use the dedicated
-helper instead:
+For immutable RC/stable validation (recommended for staging and production rollout), use the
+dedicated helpers instead:
 
 ```bash
 just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
 
 read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
-just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
+
+# Phase A: production preview
+just dspace-oci-deploy-prod-subdomain tag="$(read_prod_tag)"
+
+# Phase B: production apex
+just dspace-oci-promote-prod tag="$(read_prod_tag)"
 ```
 
 `dspace-oci-deploy` intentionally keeps the same values chain as the generic path


### PR DESCRIPTION
### Motivation

- Operators were being instructed to test `prod.democratized.space` but some docs implied editing `docs/examples/dspace.values.prod.yaml`, causing 404s; the rollout UX must make the preview path first-class and low-friction.

### Description

- Updated `docs/apps/dspace.md` to explicitly label the two-phase production flow as Phase A (production preview) and Phase B (apex promotion) and to show the explicit commands for each phase (`just dspace-oci-deploy-prod-subdomain` for preview and `just dspace-oci-promote-prod` for apex). 
- Updated `docs/raspi_cluster_operations.md` to align examples with the two-phase flow and to call out the preview values overlay (`docs/examples/dspace.values.prod-subdomain.yaml`) vs the apex overlay (`docs/examples/dspace.values.prod.yaml`).
- Verified the dedicated preview values file and apex values file already exist and contain the correct hosts (`prod.democratized.space` in `dspace.values.prod-subdomain.yaml` and `democratized.space` in `dspace.values.prod.yaml`), and the Just recipes are already wired to use the preview overlay and the apex promotion helper; no changes to `justfile` or values files were required.
- Kept the change minimal and documentation-only so unrelated deployment flows were not altered.

### Testing

- Ran `git diff -- docs/apps/dspace.md docs/examples/ justfile` to confirm the doc changes are limited to the intended files (diff produced and inspected). (succeeded)
- Ran `git grep -n "prod.democratized.space" docs/apps/dspace.md docs/examples justfile` and `git grep -n "democratized.space" docs/apps/dspace.md docs/examples justfile` to verify the preview and apex hosts are referenced in the expected places (succeeded).
- Attempted repository linters/docs checks: `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` but those tools are not available in the execution environment (commands not found).
- Ran `git diff --cached | ./scripts/scan-secrets.py` after staging changes to ensure no secrets were introduced (succeeded).

Operator commands to use now:

- Phase A (production preview deploy): `just dspace-oci-deploy-prod-subdomain tag="$(read_prod_tag)"`
- Phase B (apex promotion): `just dspace-oci-promote-prod tag="$(read_prod_tag)"`

Files changed and why:

- `docs/apps/dspace.md` — clarify Quickstart and First deployment walkthrough to make preview-vs-apex steps unambiguous.
- `docs/raspi_cluster_operations.md` — align examples with the two-phase rollout and show the correct values overlays for preview vs apex.

All changes are documentation-only and preserve existing values files and Just recipes; no unrelated refactors were performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c780d6bec0832f808f96c195a90f81)