### PR TITLE
docs(dspace): clarify Phase A prod preview vs Phase B apex promotion

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -64,11 +64,11 @@ just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag>
 
 read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
 
-# Immutable-tag production deploy (pinned tag from docs/apps/dspace.prod.tag):
-just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
-
-# Alias helper for apex promotion (same effect as the env=prod command above):
+# Immutable-tag production apex promotion (Phase B):
 just dspace-oci-promote-prod tag="$(read_prod_tag)"
+
+# Equivalent explicit apex command (same as dspace-oci-promote-prod):
+just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
 
 # Check pods and ingress status with the public URL
 just app-status namespace=dspace release=dspace
@@ -142,9 +142,12 @@ assumes your target cluster (for example `env=staging`) is online and reachable 
    ```bash
    just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
 
-   # Production example (pinned tag)
+   # Production rollout Phase A (preview subdomain first)
+   just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag>
+
+   # Production rollout Phase B (apex promotion after Phase A smoke tests)
    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
-   just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
+   just dspace-oci-promote-prod tag="$(read_prod_tag)"
    ```
 
 5. Verify everything is healthy, then browse to the FQDN on your phone or laptop:
@@ -171,7 +174,7 @@ For emergency mutable-tag refreshes where you need to force pod recycle on `v3-l
 
 Use this sequence when promoting dspace v3 from staging to production:
 
-1. Deploy the immutable v3 build tag from the `v3` branch to
+1. **Phase A (preview):** Deploy the immutable v3 build tag from the `v3` branch to
    `https://prod.democratized.space`:
 
    ```bash
@@ -194,7 +197,8 @@ Use this sequence when promoting dspace v3 from staging to production:
    just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag-from-main>
    ```
 
-5. Promote to production apex after smoke tests pass:
+5. **Phase B (apex promotion):** Promote to `https://democratized.space` after
+   smoke tests pass:
 
    ```bash
    just dspace-oci-promote-prod tag=v3-<immutable-tag-from-main>


### PR DESCRIPTION
### Motivation
- Operators were being instructed to test `prod.democratized.space` but docs implied editing the apex prod values file, which caused 404s when preview traffic reached Traefik. This change makes the two-phase rollout explicit to avoid manual edits and accidental apex deploys.
- The intent is to make the production-preview (`prod.democratized.space`) a first-class, low-friction path while preserving a separate apex promotion step for `democratized.space`.

### Description
- Updated `docs/apps/dspace.md` to clearly document a two-phase rollout: **Phase A (preview)** using `dspace-oci-deploy-prod-subdomain` and **Phase B (apex promotion)** using `dspace-oci-promote-prod`, and added an explicit example apex command for clarity.
- Confirmed and left in place the recommended values-file layout so preview and apex are separate: `docs/examples/dspace.values.prod-subdomain.yaml` governs `prod.democratized.space` and `docs/examples/dspace.values.prod.yaml` governs `democratized.space`.
- Verified the existing Just recipes already implement the intended flow (`dspace-oci-deploy-prod-subdomain` uses `docs/examples/dspace.values.prod-subdomain.yaml`, and `dspace-oci-promote-prod` routes to the `env=prod` apex path), so only documentation was changed to remove operator friction.
- Operator-facing example commands were made explicit in the docs: Phase A: `just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag>` and Phase B: `just dspace-oci-promote-prod tag=v3-<immutable-tag>` (or using the pinned `read_prod_tag` helper).

### Testing
- Ran `git diff -- docs/apps/dspace.md docs/examples/ justfile` to show the documentation-only diff and it reported the intended edits (success).
- Ran `git grep -n "prod.democratized.space" docs/apps/dspace.md docs/examples justfile` and `git grep -n "democratized.space" docs/apps/dspace.md docs/examples justfile` to verify references and values-file usage, both succeeded and show the preview/apex hosts in the expected files.
- Ran `git diff --cached | ./scripts/scan-secrets.py` to check staged changes for secrets and it produced no findings (success).
- Attempted repository lint/docs checks (`pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, `linkchecker --no-warnings README.md docs/`) but those tools were not available in the execution environment and therefore did not run (not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c780d6bec0832f808f96c195a90f81)