### PR TITLE
docs(dspace): add prod-preview just alias and clarify Phase A/B rollout

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -59,16 +59,15 @@ charts:
 # Immutable-tag staging deploy (recommended for RC/stable validation):
 just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
 
-# Immutable-tag production preview deploy (prod subdomain canary):
-just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag>
+# Phase A preview deploy on prod.democratized.space (uses prod-subdomain values):
+just dspace-oci-deploy-prod-preview tag=v3-<immutable-tag>
+# (Equivalent legacy helper name: just dspace-oci-deploy-prod-subdomain ...)
 
 read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
 
-# Immutable-tag production deploy (pinned tag from docs/apps/dspace.prod.tag):
-just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
-
-# Alias helper for apex promotion (same effect as the env=prod command above):
+# Phase B apex promotion on democratized.space (uses prod values):
 just dspace-oci-promote-prod tag="$(read_prod_tag)"
+# (Equivalent explicit helper: just dspace-oci-deploy env=prod ...)
 
 # Check pods and ingress status with the public URL
 just app-status namespace=dspace release=dspace
@@ -142,9 +141,12 @@ assumes your target cluster (for example `env=staging`) is online and reachable 
    ```bash
    just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
 
-   # Production example (pinned tag)
+   # Production preview example (Phase A on prod.democratized.space)
+   just dspace-oci-deploy-prod-preview tag=v3-<immutable-tag>
+
+   # Apex production example (Phase B on democratized.space)
    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
-   just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
+   just dspace-oci-promote-prod tag="$(read_prod_tag)"
    ```
 
 5. Verify everything is healthy, then browse to the FQDN on your phone or laptop:
@@ -171,11 +173,12 @@ For emergency mutable-tag refreshes where you need to force pod recycle on `v3-l
 
 Use this sequence when promoting dspace v3 from staging to production:
 
-1. Deploy the immutable v3 build tag from the `v3` branch to
-   `https://prod.democratized.space`:
+1. **Phase A (preview):** Deploy the immutable v3 build tag from the `v3` branch to
+   `https://prod.democratized.space` using
+   `docs/examples/dspace.values.prod-subdomain.yaml`:
 
    ```bash
-   just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag-from-v3-branch>
+   just dspace-oci-deploy-prod-preview tag=v3-<immutable-tag-from-v3-branch>
    ```
 
 2. Run smoke tests:
@@ -188,13 +191,15 @@ Use this sequence when promoting dspace v3 from staging to production:
 
 3. Merge `v3` into `main`.
 
-4. Deploy the immutable `main` tag to `https://prod.democratized.space`:
+4. Still in **Phase A**, deploy the immutable `main` tag to
+   `https://prod.democratized.space`:
 
    ```bash
-   just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag-from-main>
+   just dspace-oci-deploy-prod-preview tag=v3-<immutable-tag-from-main>
    ```
 
-5. Promote to production apex after smoke tests pass:
+5. **Phase B (apex promotion):** promote to `https://democratized.space` after smoke tests pass,
+   using `docs/examples/dspace.values.prod.yaml`:
 
    ```bash
    just dspace-oci-promote-prod tag=v3-<immutable-tag-from-main>

--- a/docs/examples/dspace.values.prod-subdomain.yaml
+++ b/docs/examples/dspace.values.prod-subdomain.yaml
@@ -1,5 +1,5 @@
-# Example values for deploying democratized.space v3 to the production preview subdomain.
-# Use this during rollout validation before apex cutover.
+# Example values for Phase A production-preview deploys.
+# Use this file for prod.democratized.space before apex cutover.
 environment: prod
 
 ingress:

--- a/docs/examples/dspace.values.prod.yaml
+++ b/docs/examples/dspace.values.prod.yaml
@@ -1,5 +1,5 @@
-# Example values for deploying democratized.space to production via Helm.
-# The ingress host is set by the installer command or this file.
+# Example values for apex production deploys via Helm.
+# This file is for Phase B promotion to democratized.space.
 environment: prod
 
 ingress:

--- a/justfile
+++ b/justfile
@@ -1295,6 +1295,10 @@ dspace-oci-deploy-prod-subdomain tag='':
     echo "  curl -fsS https://prod.democratized.space/healthz | jq ."
     echo "  curl -fsS https://prod.democratized.space/livez | jq ."
 
+# Alias for production preview deploys on prod.democratized.space.
+dspace-oci-deploy-prod-preview tag='':
+    just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy-prod-subdomain tag='{{ tag }}'
+
 # Promote dspace to production apex (democratized.space) using immutable tags.
 
 # If tag is omitted, this reads the pinned value from docs/apps/dspace.prod.tag.


### PR DESCRIPTION
### Motivation
- Prevent operators from having to edit `docs/examples/dspace.values.prod.yaml` to run production-preview smoke tests by making `prod.democratized.space` a first-class, low-friction path. 
- Separate the Phase A preview and Phase B apex promotion flows so preview deploys use a dedicated values overlay and apex promotion remains an explicit, separate step.

### Description
- Add a `dspace-oci-deploy-prod-preview` Just alias that invokes the existing prod-subdomain deploy path so operators can run Phase A without editing values files. 
- Update `docs/apps/dspace.md` to document an explicit two-phase rollout: Phase A (preview on `prod.democratized.space` using `docs/examples/dspace.values.prod-subdomain.yaml`) and Phase B (apex promotion to `democratized.space` using `docs/examples/dspace.values.prod.yaml`).
- Clarify comments in `docs/examples/dspace.values.prod-subdomain.yaml` and `docs/examples/dspace.values.prod.yaml` to show Phase A vs Phase B ownership while preserving `ingress.host` values (`prod.democratized.space` and `democratized.space` respectively).

### Testing
- Ran `git diff -- docs/apps/dspace.md docs/examples/ justfile` to verify the diff of targeted files and it returned the expected changes. 
- Ran `git grep -n "prod.democratized.space" docs/apps/dspace.md docs/examples justfile` and `git grep -n "democratized.space" docs/apps/dspace.md docs/examples justfile` to confirm references were updated and both hostnames are present in the correct contexts. 
- Ran `git diff --cached | ./scripts/scan-secrets.py` which completed with no secret findings. 
- Tooling checks were attempted but unavailable in this environment: `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, `linkchecker --no-warnings README.md docs/`, and `just --fmt --check justfile` were skipped due to missing executables.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c780d6bec0832f808f96c195a90f81)