### PR TITLE
🛠️ fix: wait for OCI helm rollout completion

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -83,7 +83,7 @@ just dspace-oci-promote-prod tag="$(read_prod_tag)"
 # Check pods and ingress status with the public URL
 just app-status namespace=dspace release=dspace
 
-# Generic helper examples (does not wait for rollout):
+# Generic helper examples (now waits for rollout-managed workloads):
 just helm-oci-install \
   release=dspace namespace=dspace \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \

--- a/justfile
+++ b/justfile
@@ -1144,6 +1144,44 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
 
     helm "${helm_args[@]}"
 
+    wait_for_rollout_targets() {
+        local -a targets=()
+        local selector=""
+        local -a selectors=(
+            "app.kubernetes.io/instance=${release}"
+            "release=${release}"
+        )
+
+        for selector in "${selectors[@]}"; do
+            mapfile -t targets < <(
+                kubectl -n "${namespace}" get deploy,statefulset,daemonset \
+                    -l "${selector}" -o name 2>/dev/null || true
+            )
+            if [ "${#targets[@]}" -gt 0 ]; then
+                break
+            fi
+        done
+
+        if [ "${#targets[@]}" -eq 0 ]; then
+            echo "No rollout-managed workloads found for release '${release}' in namespace '${namespace}'."
+            return 0
+        fi
+
+        echo "Waiting for rollout completion in namespace '${namespace}' (timeout per workload: 300s)..."
+
+        local rollout_target=""
+        for rollout_target in "${targets[@]}"; do
+            echo "  - ${rollout_target}"
+            kubectl -n "${namespace}" rollout status "${rollout_target}" --timeout=300s
+        done
+    }
+
+    if ! command -v kubectl >/dev/null 2>&1; then
+        echo "WARNING: kubectl is not available; skipping rollout status checks." >&2
+    else
+        wait_for_rollout_targets
+    fi
+
 helm-oci-install release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='':
     @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' allow_install='true' reuse_values='false'
 

--- a/outages/2026-03-31-helm-oci-install-rollout-feedback-gap.json
+++ b/outages/2026-03-31-helm-oci-install-rollout-feedback-gap.json
@@ -1,0 +1,12 @@
+{
+  "id": "2026-03-31-helm-oci-install-rollout-feedback-gap",
+  "date": "2026-03-31",
+  "component": "helm-oci-install / _helm-oci-deploy",
+  "rootCause": "The generic OCI helper stopped after invoking Helm and never observed Kubernetes rollout progress, so operators did not receive blocking feedback that workloads had actually restarted and become ready.",
+  "resolution": "Added rollout-status tracking after Helm operations by discovering Deployments/StatefulSets/DaemonSets for the release label and waiting on each workload before returning; added a regression test that simulates an OCI deploy with a fake registry chart URL and stubbed kubectl rollout responses.",
+  "references": [
+    "justfile",
+    "tests/test_helm_oci_install_rollout_feedback.py",
+    "just helm-oci-install release=demo namespace=demo chart=oci://registry.test.local:5000/charts/demo values=docs/examples/dspace.values.dev.yaml version=1.2.3 default_tag=v3-latest"
+  ]
+}

--- a/tests/test_helm_oci_install_rollout_feedback.py
+++ b/tests/test_helm_oci_install_rollout_feedback.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+JUSTFILE = REPO_ROOT / "justfile"
+
+
+@pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")
+def test_helm_oci_install_waits_for_rollout_with_fake_oci_registry(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    helm_log = tmp_path / "helm.log"
+    kubectl_log = tmp_path / "kubectl.log"
+
+    (tmp_path / "kubeconfig").write_text("apiVersion: v1\nkind: Config\n", encoding="utf-8")
+
+    (bin_dir / "helm").write_text(
+        textwrap.dedent(
+            """#!/usr/bin/env bash
+set -euo pipefail
+
+echo "$*" >> "${HELM_TEST_LOG}"
+if [[ "$*" != *"oci://registry.test.local:5000/charts/demo"* ]]; then
+  echo "expected fake OCI registry chart URL" >&2
+  exit 1
+fi
+"""
+        ),
+        encoding="utf-8",
+    )
+    (bin_dir / "helm").chmod(0o755)
+
+    (bin_dir / "kubectl").write_text(
+        textwrap.dedent(
+            """#!/usr/bin/env bash
+set -euo pipefail
+
+echo "$*" >> "${KUBECTL_TEST_LOG}"
+if [[ "$1" == "-n" && "$3" == "get" ]]; then
+  if [[ "$6" == "app.kubernetes.io/instance=demo" ]]; then
+    printf 'deployment.apps/demo\nstatefulset.apps/demo-worker\n'
+    exit 0
+  fi
+  exit 0
+fi
+if [[ "$1" == "-n" && "$3" == "rollout" && "$4" == "status" ]]; then
+  echo "rollout complete for $5"
+  exit 0
+fi
+"""
+        ),
+        encoding="utf-8",
+    )
+    (bin_dir / "kubectl").chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            "HELM_TEST_LOG": str(helm_log),
+            "KUBECTL_TEST_LOG": str(kubectl_log),
+            "KUBECONFIG": str(tmp_path / "kubeconfig"),
+        }
+    )
+
+    result = subprocess.run(
+        [
+            "just",
+            "--justfile",
+            str(JUSTFILE),
+            "helm-oci-install",
+            "release=demo",
+            "namespace=demo",
+            "chart=oci://registry.test.local:5000/charts/demo",
+            "values=docs/examples/dspace.values.dev.yaml",
+            "version=1.2.3",
+            "default_tag=v3-latest",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Waiting for rollout completion" in result.stdout
+    assert "deployment.apps/demo" in result.stdout
+    assert "statefulset.apps/demo-worker" in result.stdout
+
+    kubectl_calls = kubectl_log.read_text(encoding="utf-8")
+    assert "rollout status deployment.apps/demo --timeout=300s" in kubectl_calls
+    assert "rollout status statefulset.apps/demo-worker --timeout=300s" in kubectl_calls


### PR DESCRIPTION
### Motivation
- Operators running the generic OCI helpers (`helm-oci-install` / `helm-oci-upgrade`) received no blocking feedback after Helm finished, so deploys could be reported as complete while workloads were still rolling out.
- The intent is to provide the same rollout-observability that `dspace-oci-redeploy` offers so users can inspect the app immediately after the command returns.

### Description
- Add `wait_for_rollout_targets` to `_helm-oci-deploy` in `justfile`, which discovers Deployments/StatefulSets/DaemonSets by the `app.kubernetes.io/instance=<release>` and `release=<release>` labels and runs `kubectl -n <namespace> rollout status <target> --timeout=300s` for each workload.
- Emit per-workload progress lines and return early with a helpful message when no rollout-managed workloads are found, and warn if `kubectl` is missing so the helper remains usable in minimal environments.
- Add `tests/test_helm_oci_install_rollout_feedback.py`, a regression test that stubs `helm` and `kubectl` in a temporary `PATH`, simulates an OCI chart URL (`oci://registry.test.local:5000/charts/demo`), and asserts the helper prints the rollout wait messages and invokes `kubectl rollout status` for discovered targets.
- Add an outage record `outages/2026-03-31-helm-oci-install-rollout-feedback-gap.json` documenting the root cause and the remediation, and update `docs/apps/dspace.md` to note that the generic OCI helpers now wait for rollout-managed workloads.

### Testing
- `pytest -q tests/test_helm_oci_install_rollout_feedback.py` was executed and reported `1 skipped` because the test is gated by a `shutil.which("just")` skip guard in environments where `just` is not installed. (The test exists and is runnable in CI where `just` is available.)
- `python -m py_compile tests/test_helm_oci_install_rollout_feedback.py` succeeded to verify test syntax.
- `git diff --cached | ./scripts/scan-secrets.py` ran successfully to check for secrets.
- `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` were invoked but not available in this environment (commands not found) and therefore did not complete here; CI is expected to run those checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb689d380c832fa847946173967cb0)