### PR TITLE
🛠️ fix: wait for helm OCI release rollouts

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -83,7 +83,7 @@ just dspace-oci-promote-prod tag="$(read_prod_tag)"
 # Check pods and ingress status with the public URL
 just app-status namespace=dspace release=dspace
 
-# Generic helper examples (does not wait for rollout):
+# Generic helper examples (waits for release rollout before returning):
 just helm-oci-install \
   release=dspace namespace=dspace \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \

--- a/justfile
+++ b/justfile
@@ -1142,7 +1142,38 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
         helm_args+=("${version_args[@]}")
     fi
 
+    echo "Running Helm deploy: helm ${helm_args[*]}"
     helm "${helm_args[@]}"
+
+    if ! command -v kubectl >/dev/null 2>&1; then
+        echo "WARNING: kubectl not found on PATH; skipping rollout status checks." >&2
+        exit 0
+    fi
+
+    echo "Inspecting workloads for release '${release}' in namespace '${namespace}'..."
+    deployment_names="$(
+        kubectl -n "${namespace}" get deploy \
+            -l "app.kubernetes.io/instance=${release}" \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true
+    )"
+
+    if [ -z "${deployment_names}" ]; then
+        echo "No deployments found for release '${release}'. Helm apply finished."
+        exit 0
+    fi
+
+    rollout_timeout="${SUGARKUBE_HELM_ROLLOUT_TIMEOUT:-180s}"
+    echo "Waiting for Helm release '${release}' rollout(s) to complete (timeout: ${rollout_timeout})..."
+    while IFS= read -r deployment_name; do
+        [ -n "${deployment_name}" ] || continue
+        echo "  - deploy/${deployment_name}"
+        if ! kubectl -n "${namespace}" rollout status "deploy/${deployment_name}" --timeout "${rollout_timeout}"; then
+            echo "ERROR: rollout status failed for deploy/${deployment_name} in namespace '${namespace}'." >&2
+            exit 1
+        fi
+    done <<< "${deployment_names}"
+
+    echo "Helm release '${release}' rollout checks passed."
 
 helm-oci-install release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='':
     @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' allow_install='true' reuse_values='false'

--- a/outages/2026-03-31-helm-oci-install-rollout-feedback-gap.json
+++ b/outages/2026-03-31-helm-oci-install-rollout-feedback-gap.json
@@ -1,0 +1,13 @@
+{
+  "id": "2026-03-31-helm-oci-install-rollout-feedback-gap",
+  "date": "2026-03-31",
+  "component": "helm-oci-install / _helm-oci-deploy",
+  "rootCause": "The generic Helm OCI path returned immediately after helm upgrade/install and did not run kubectl rollout status checks, so operators could not tell from command output when workloads were actually ready.",
+  "resolution": "Added release-scoped deployment discovery and rollout status waiting to _helm-oci-deploy, emitted explicit progress logs, and expanded the helm-oci-install regression fixture to simulate an OCI chart deploy with fake helm/kubectl binaries that assert rollout feedback behavior.",
+  "references": [
+    "justfile",
+    "scripts/test-helm-oci-install.sh",
+    "docs/apps/dspace.md",
+    "just helm-oci-install release=dspace namespace=dspace chart=oci://registry.test.local/charts/dspace values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.version default_tag=v3-latest"
+  ]
+}

--- a/scripts/test-helm-oci-install.sh
+++ b/scripts/test-helm-oci-install.sh
@@ -12,6 +12,8 @@ fi
 tmp_bin="$(mktemp -d)"
 trap 'rm -rf "${tmp_bin}"' EXIT
 helm_log="${tmp_bin}/helm.log"
+kubectl_log="${tmp_bin}/kubectl.log"
+fake_registry="oci://registry.test.local/charts/dspace"
 
 cat >"${tmp_bin}/helm" <<'SH'
 #!/usr/bin/env bash
@@ -21,17 +23,37 @@ echo "helm $*" | tee -a "${HELM_TEST_LOG:-/dev/null}"
 SH
 chmod +x "${tmp_bin}/helm"
 
+cat >"${tmp_bin}/kubectl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "kubectl $*" >> "${KUBECTL_TEST_LOG:-/dev/null}"
+
+if [[ "${1:-}" == "-n" && "${3:-}" == "get" && "${4:-}" == "deploy" ]]; then
+    printf 'dspace\n'
+    exit 0
+fi
+
+if [[ "${1:-}" == "-n" && "${3:-}" == "rollout" && "${4:-}" == "status" ]]; then
+    exit 0
+fi
+
+exit 0
+SH
+chmod +x "${tmp_bin}/kubectl"
+
 command_output="$(
     PATH="${tmp_bin}:${PATH}" HELM_TEST_LOG="${helm_log}" \
+        KUBECTL_TEST_LOG="${kubectl_log}" \
         just helm-oci-install \
         release=dspace namespace=dspace \
-        chart=oci://ghcr.io/democratizedspace/charts/dspace \
+        chart="${fake_registry}" \
         values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
         version_file=docs/apps/dspace.version \
         default_tag=v3-latest
 )"
 
-if ! grep -q "oci://ghcr.io/democratizedspace/charts/dspace" <<<"${command_output}"; then
+if ! grep -q "${fake_registry}" <<<"${command_output}"; then
     printf 'Expected chart argument missing from generated output.\nOutput:\n%s\n' "${command_output}" >&2
     exit 1
 fi
@@ -41,7 +63,7 @@ if grep -Eq "chart=oci://|chart=chart=oci://" <<<"${command_output}"; then
     exit 1
 fi
 
-if ! grep -q "oci://ghcr.io/democratizedspace/charts/dspace" "${helm_log}"; then
+if ! grep -q "${fake_registry}" "${helm_log}"; then
     printf 'Stubbed helm did not receive expected chart argument.\nLog:\n%s\n' "$(cat "${helm_log}" 2>/dev/null || true)" >&2
     exit 1
 fi
@@ -51,4 +73,14 @@ if grep -Eq "chart=oci://|chart=chart=oci://" "${helm_log}"; then
     exit 1
 fi
 
-printf 'helm-oci-install emits normalized chart argument.\n'
+if ! grep -q "Waiting for Helm release 'dspace' rollout(s) to complete" <<<"${command_output}"; then
+    printf 'Expected rollout feedback missing from output.\nOutput:\n%s\n' "${command_output}" >&2
+    exit 1
+fi
+
+if ! grep -q "kubectl -n dspace rollout status deploy/dspace --timeout 180s" "${kubectl_log}"; then
+    printf 'Expected rollout status check not observed.\nLog:\n%s\n' "$(cat "${kubectl_log}" 2>/dev/null || true)" >&2
+    exit 1
+fi
+
+printf 'helm-oci-install emits normalized OCI chart argument and rollout feedback.\n'


### PR DESCRIPTION
### Motivation
- The generic OCI Helm helper returned as soon as `helm upgrade/install` finished, so operators had no reliable command-line feedback that workloads were actually ready. 
- This gap made `helm-oci-install` behave differently from `dspace-oci-redeploy` which explicitly waits for rollouts, causing uncertainty after upgrades. 
- The change aims to provide immediate, human-readable rollout progress and parity with the opinionated dspace helper.

### Description
- The `_helm-oci-deploy` recipe now prints the executed Helm command, discovers deployments for the release by `app.kubernetes.io/instance=<release>`, and waits on each deployment with `kubectl -n <ns> rollout status` before returning. 
- Rollout waiting honors a timeout via `SUGARKUBE_HELM_ROLLOUT_TIMEOUT` (default `180s`) and emits progress/error messages when checks run or fail. 
- `scripts/test-helm-oci-install.sh` was extended to simulate an OCI deploy with stubbed `helm` and `kubectl` binaries and to assert that rollout feedback and `kubectl rollout status` calls are observed. 
- Added an outage record at `outages/2026-03-31-helm-oci-install-rollout-feedback-gap.json` and updated `docs/apps/dspace.md` to document that the generic OCI helper waits for rollout completion.

### Testing
- Ran the regression fixture `./scripts/test-helm-oci-install.sh`, which passed and verified both normalized OCI chart argument handling and rollout-status behavior. 
- Installed `just` and validated `just --version` to enable the test harness. 
- Ran `git diff --cached | ./scripts/scan-secrets.py` to validate no secret-like strings were staged successfully. 
- `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` were not available in this execution environment and therefore were not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb689d380c832fa847946173967cb0)