### PR TITLE
🐛 fix: default pi image builds to arm64 userspace

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -19,10 +19,13 @@ so logs survive reboots. After installation, it removes unused packages with
 `apt-get autoremove -y` and cleans the apt cache to keep the image small.
 
 The `build_pi_image.sh` script clones [pi-gen](https://github.com/RPi-Distro/pi-gen) using
-`PI_GEN_BRANCH` (default: `bookworm` for 32-bit builds and `arm64` for
-64-bit). Set `PI_GEN_URL` to use a fork or mirror if the default repository is
-unavailable. `IMG_NAME` controls the output filename and `OUTPUT_DIR` selects
-where artifacts are written; the script creates the directory if needed. Run
+`PI_GEN_BRANCH` (default: `arm64`, so modern Pi 4/Pi 5 nodes get a true
+64-bit `arm64` userspace by default). Set `ARM64=0 ALLOW_ARMHF=1` to opt in to
+32-bit userspace builds (`armhf`), which switch the default `PI_GEN_BRANCH` to
+`bookworm`. Set `PI_GEN_URL` to use a fork or mirror if the default repository
+is unavailable. `IMG_NAME` controls the output filename and `OUTPUT_DIR`
+selects where artifacts are written; the script creates the directory if
+needed. Run
 `scripts/build_pi_image.sh --help` for a summary of configurable environment
 variables. To avoid accidental overwrites it aborts when the image already
 exists unless `FORCE_OVERWRITE=1` is set. Set `FORCE_OVERWRITE=1` when rerunning

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -12,6 +12,8 @@ Usage: build_pi_image.sh [--help]
 Build a Raspberry Pi OS image preloaded with cloud-init.
 
 Environment variables:
+  ARM64             Build 64-bit userspace image (default 1). Set ARM64=0 for 32-bit.
+  ALLOW_ARMHF       Required when ARM64=0 (set to 1 to explicitly allow 32-bit builds)
   CLOUD_INIT_PATH   Path to cloud-init user-data (default scripts/cloud-init/user-data.yaml)
   OUTPUT_DIR        Directory to write the image (default repo root)
   IMG_NAME          Name for the output image (default sugarkube)
@@ -263,12 +265,25 @@ else
 fi
 
 ARM64="${ARM64:-1}"
+if [[ "${ARM64}" != "0" && "${ARM64}" != "1" ]]; then
+  echo "ARM64 must be 0 or 1 (got: ${ARM64})" >&2
+  exit 1
+fi
 if [ "$ARM64" -eq 1 ]; then
   ARMHF=0
+  DEFAULT_PI_GEN_BRANCH="arm64"
+  BUILD_ARCH_LABEL="arm64 (64-bit userspace)"
 else
+  if [ "${ALLOW_ARMHF:-0}" -ne 1 ]; then
+    echo "Refusing 32-bit image build: set ALLOW_ARMHF=1 with ARM64=0 to opt in" >&2
+    exit 1
+  fi
   ARMHF=1
+  DEFAULT_PI_GEN_BRANCH="bookworm"
+  BUILD_ARCH_LABEL="armhf (32-bit userspace)"
+  echo "[sugarkube] Warning: explicit 32-bit build requested (ARM64=0, ALLOW_ARMHF=1)"
 fi
-DEFAULT_PI_GEN_BRANCH="bookworm"
+echo "[sugarkube] Image userspace architecture: ${BUILD_ARCH_LABEL}"
 PI_GEN_SOURCE_DIR="${PI_GEN_SOURCE_DIR:-}"
 PI_GEN_BRANCH="${PI_GEN_BRANCH:-}"
 IMG_NAME="${IMG_NAME:-sugarkube}"

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -686,6 +686,7 @@ def _run_build_script(tmp_path, env):
 def test_uses_default_pi_gen_branch(tmp_path):
     env = _setup_build_env(tmp_path)
     env["ARM64"] = "0"
+    env["ALLOW_ARMHF"] = "1"
     result, git_args = _run_build_script(tmp_path, env)
     assert result.returncode == 0
     assert "--branch bookworm" in git_args
@@ -696,7 +697,7 @@ def test_arm64_build_uses_release_branch(tmp_path):
     env = _setup_build_env(tmp_path)
     result, git_args = _run_build_script(tmp_path, env)
     assert result.returncode == 0
-    assert "--branch bookworm" in git_args
+    assert "--branch arm64" in git_args
     assert (tmp_path / "sugarkube.img.xz").exists()
 
 
@@ -958,11 +959,20 @@ def test_arm64_disables_armhf(tmp_path):
 def test_armhf_enabled_for_32_bit(tmp_path):
     env = _setup_build_env(tmp_path)
     env["ARM64"] = "0"
+    env["ALLOW_ARMHF"] = "1"
     result, _ = _run_build_script(tmp_path, env)
     assert result.returncode == 0
     config = (tmp_path / "config.env").read_text()
     assert "ARM64=0" in config
     assert "ARMHF=1" in config
+
+
+def test_armhf_build_requires_explicit_opt_in(tmp_path):
+    env = _setup_build_env(tmp_path)
+    env["ARM64"] = "0"
+    result, _ = _run_build_script(tmp_path, env)
+    assert result.returncode != 0
+    assert "set ALLOW_ARMHF=1 with ARM64=0 to opt in" in result.stderr
 
 
 def test_build_without_timeout_binary(tmp_path):


### PR DESCRIPTION
### Motivation
- Ensure the default sugarkube Raspberry Pi image produces a true 64-bit userspace on modern Pi 4/Pi 5 hardware because 32-bit userspace on 64-bit hardware broke Playwright/Chromium in verification workflows.
- Make accidental 32-bit (`armhf`) builds harder by requiring an explicit opt-in so users don't unknowingly end up with a mismatched userspace architecture.

### Description
- Change `scripts/build_pi_image.sh` to default `ARM64=1` -> `DEFAULT_PI_GEN_BRANCH="arm64"`, set `ARMHF=0`, and emit a `[sugarkube] Image userspace architecture:` summary log line. 
- Add validation so `ARM64` must be `0` or `1`, and require `ALLOW_ARMHF=1` when `ARM64=0` to opt in to 32-bit builds while emitting a clear warning when that opt-in is used. 
- Update `docs/pi_image_cloudflare.md` to state that modern Pi images default to true 64-bit `arm64` userspace and document the explicit `ARM64=0 ALLOW_ARMHF=1` override which selects `bookworm`/`armhf` behavior. 
- Update `tests/build_pi_image_test.py` to assert the `arm64` branch is used by default, to allow and verify the explicit 32-bit opt-in path, and to add a failing test case for requesting `ARM64=0` without `ALLOW_ARMHF=1`.
- Files changed: `scripts/build_pi_image.sh`, `docs/pi_image_cloudflare.md`, `tests/build_pi_image_test.py`.

### Testing
- Ran `python -m pytest tests/build_pi_image_test.py` and all tests passed (`38 passed`), confirming default branch selection and opt-in guardrail behavior. 
- Attempted docs checks `pyspelling -c .spellcheck.yaml docs/pi_image_cloudflare.md` and `linkchecker --no-warnings docs/pi_image_cloudflare.md` but those tools were not available in the environment (`command not found`).
- Ran the repo secret scan via `git diff --cached | ./scripts/scan-secrets.py` which completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc5ff36714832f83a027136ce025d4)