### PR TITLE
Default Pi image builds to arm64 userspace with explicit 32-bit opt-in

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -19,8 +19,9 @@ so logs survive reboots. After installation, it removes unused packages with
 `apt-get autoremove -y` and cleans the apt cache to keep the image small.
 
 The `build_pi_image.sh` script clones [pi-gen](https://github.com/RPi-Distro/pi-gen) using
-`PI_GEN_BRANCH` (default: `bookworm` for 32-bit builds and `arm64` for
-64-bit). Set `PI_GEN_URL` to use a fork or mirror if the default repository is
+`PI_GEN_BRANCH` (default: `bookworm`). The default sugarkube image build uses a
+64-bit userspace (`ARM64=1`, `ARMHF=0`) so modern Pi 4/Pi 5 nodes report
+`dpkg --print-architecture=arm64`. Set `PI_GEN_URL` to use a fork or mirror if the default repository is
 unavailable. `IMG_NAME` controls the output filename and `OUTPUT_DIR` selects
 where artifacts are written; the script creates the directory if needed. Run
 `scripts/build_pi_image.sh --help` for a summary of configurable environment
@@ -65,7 +66,9 @@ Set `SKIP_CLOUD_INIT_VALIDATION=1` to bypass cloud-init YAML validation when
 PyYAML isn't available or when speed matters.
 The script rewrites the Cloudflare apt source architecture to `armhf` when
 `ARM64=0` so 32-bit builds install the correct packages and sets `ARMHF=0` when
-`ARM64=1` to avoid generating both architectures.
+`ARM64=1` to avoid generating both architectures. 32-bit userspace builds are
+still supported, but require explicit opt-in: set both `ARM64=0` and
+`ALLOW_ARMHF=1`.
 
 The image embeds `pi_node_verifier.sh` in `/usr/local/sbin` and clones the
 `token.place` and `democratizedspace/dspace` repositories into

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -18,6 +18,8 @@ Environment variables:
   PI_GEN_SOURCE_DIR Path to an existing pi-gen checkout to copy instead of cloning
   TOKEN_PLACE_BRANCH Branch of token.place to clone (default main)
   DSPACE_BRANCH     Branch of dspace to clone (default v3)
+  ARM64             Build a 64-bit userspace image when set to 1 (default 1)
+  ALLOW_ARMHF       Required opt-in for 32-bit userspace builds (set to 1 with ARM64=0)
 
 See docs/pi_image_cloudflare.md for details.
 EOF
@@ -263,11 +265,22 @@ else
 fi
 
 ARM64="${ARM64:-1}"
-if [ "$ARM64" -eq 1 ]; then
-  ARMHF=0
-else
-  ARMHF=1
+if ! [[ "${ARM64}" =~ ^[01]$ ]]; then
+  echo "ARM64 must be either 0 (32-bit userspace) or 1 (64-bit userspace)" >&2
+  exit 1
 fi
+if [ "${ARM64}" -eq 1 ]; then
+  ARMHF=0
+  ARCH_USERSPACE="arm64"
+else
+  if [ "${ALLOW_ARMHF:-0}" -ne 1 ]; then
+    echo "Refusing 32-bit userspace build: set ALLOW_ARMHF=1 with ARM64=0 to opt in" >&2
+    exit 1
+  fi
+  ARMHF=1
+  ARCH_USERSPACE="armhf"
+fi
+echo "[sugarkube] Image userspace architecture: ${ARCH_USERSPACE} (ARM64=${ARM64} ARMHF=${ARMHF})"
 DEFAULT_PI_GEN_BRANCH="bookworm"
 PI_GEN_SOURCE_DIR="${PI_GEN_SOURCE_DIR:-}"
 PI_GEN_BRANCH="${PI_GEN_BRANCH:-}"
@@ -1266,6 +1279,7 @@ metadata_args=(
   --runner-arch "${RUNNER_ARCH_VALUE}"
   --option "arm64=${ARM64}"
   --option "armhf=${ARMHF}"
+  --option "userspace_arch=${ARCH_USERSPACE}"
   --option "clone_sugarkube=${CLONE_SUGARKUBE}"
   --option "clone_token_place=${CLONE_TOKEN_PLACE}"
   --option "clone_dspace=${CLONE_DSPACE}"

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -686,6 +686,7 @@ def _run_build_script(tmp_path, env):
 def test_uses_default_pi_gen_branch(tmp_path):
     env = _setup_build_env(tmp_path)
     env["ARM64"] = "0"
+    env["ALLOW_ARMHF"] = "1"
     result, git_args = _run_build_script(tmp_path, env)
     assert result.returncode == 0
     assert "--branch bookworm" in git_args
@@ -953,16 +954,37 @@ def test_arm64_disables_armhf(tmp_path):
     config = (tmp_path / "config.env").read_text()
     assert "ARM64=1" in config
     assert "ARMHF=0" in config
+    metadata = (tmp_path / "sugarkube.img.xz.metadata.json").read_text()
+    assert '"userspace_arch": "arm64"' in metadata
 
 
 def test_armhf_enabled_for_32_bit(tmp_path):
     env = _setup_build_env(tmp_path)
     env["ARM64"] = "0"
+    env["ALLOW_ARMHF"] = "1"
     result, _ = _run_build_script(tmp_path, env)
     assert result.returncode == 0
     config = (tmp_path / "config.env").read_text()
     assert "ARM64=0" in config
     assert "ARMHF=1" in config
+    metadata = (tmp_path / "sugarkube.img.xz.metadata.json").read_text()
+    assert '"userspace_arch": "armhf"' in metadata
+
+
+def test_32_bit_build_requires_explicit_opt_in(tmp_path):
+    env = _setup_build_env(tmp_path)
+    env["ARM64"] = "0"
+    result, _ = _run_build_script(tmp_path, env)
+    assert result.returncode != 0
+    assert "Refusing 32-bit userspace build" in result.stderr
+
+
+def test_invalid_arm64_value_fails_fast(tmp_path):
+    env = _setup_build_env(tmp_path)
+    env["ARM64"] = "true"
+    result, _ = _run_build_script(tmp_path, env)
+    assert result.returncode != 0
+    assert "ARM64 must be either 0" in result.stderr
 
 
 def test_build_without_timeout_binary(tmp_path):


### PR DESCRIPTION
### Motivation
- Modern Pi 4/Pi 5 devices were ending up with a 32-bit userspace (`armhf`) despite running on 64-bit hardware, which broke components (e.g. Playwright/Chromium) that require a true 64-bit userspace.
- The intent is to make the repository produce a true 64-bit userspace by default while still preserving deliberate opt-in for legacy 32-bit images.

### Description
- Validate and normalize `ARM64` in `scripts/build_pi_image.sh` and fail fast on invalid values using `ARM64` only `0`/`1` semantics. 
- Keep the default to a true 64-bit userspace (`ARM64=1`) and set `ARMHF=0` by default, while requiring `ALLOW_ARMHF=1` together with `ARM64=0` to permit 32-bit userspace builds. 
- Emit an explicit userspace architecture string (`userspace_arch`) to logs and include it in the build metadata options for downstream verification. 
- Update documentation and tests to reflect the new default and guardrail by changing `docs/pi_image_cloudflare.md` and extending `tests/build_pi_image_test.py` accordingly.
- Files changed: `scripts/build_pi_image.sh`, `docs/pi_image_cloudflare.md`, and `tests/build_pi_image_test.py`.

### Testing
- Ran `python -m pytest tests/build_pi_image_test.py` and all tests passed (`39 passed`).
- Doc checks attempted: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings` were attempted but the tools are not installed in this environment; the docs were updated to state the default is 64-bit userspace and how to opt into 32-bit.
- Ran the repository secrets scan (`git diff --cached | ./scripts/scan-secrets.py`) as part of the submission and it produced no findings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc5ff36714832f83a027136ce025d4)