### PR TITLE
fix: default Pi image userspace to arm64 and gate 32-bit builds

### DIFF
--- a/docs/pi_image_cloudflare.md
+++ b/docs/pi_image_cloudflare.md
@@ -19,8 +19,8 @@ so logs survive reboots. After installation, it removes unused packages with
 `apt-get autoremove -y` and cleans the apt cache to keep the image small.
 
 The `build_pi_image.sh` script clones [pi-gen](https://github.com/RPi-Distro/pi-gen) using
-`PI_GEN_BRANCH` (default: `bookworm` for 32-bit builds and `arm64` for
-64-bit). Set `PI_GEN_URL` to use a fork or mirror if the default repository is
+`PI_GEN_BRANCH` (default: `bookworm`). By default it builds a **true 64-bit userspace**
+image (`ARM64=1`, `ARMHF=0`) for modern Pi 4/Pi 5 nodes. Set `PI_GEN_URL` to use a fork or mirror if the default repository is
 unavailable. `IMG_NAME` controls the output filename and `OUTPUT_DIR` selects
 where artifacts are written; the script creates the directory if needed. Run
 `scripts/build_pi_image.sh --help` for a summary of configurable environment
@@ -63,9 +63,10 @@ keeps the mirror failover and configuration behavior locked in.
 temporary work directory and the output location.
 Set `SKIP_CLOUD_INIT_VALIDATION=1` to bypass cloud-init YAML validation when
 PyYAML isn't available or when speed matters.
-The script rewrites the Cloudflare apt source architecture to `armhf` when
-`ARM64=0` so 32-bit builds install the correct packages and sets `ARMHF=0` when
-`ARM64=1` to avoid generating both architectures.
+For intentional 32-bit builds, set `ARM64=0 ALLOW_32BIT=1`. The script refuses
+`ARM64=0` without `ALLOW_32BIT=1` so accidental 32-bit images are harder to produce.
+When building 32-bit userspace, it rewrites the Cloudflare apt source architecture
+to `armhf` and sets `ARMHF=1`; when building 64-bit userspace it sets `ARMHF=0`.
 
 The image embeds `pi_node_verifier.sh` in `/usr/local/sbin` and clones the
 `token.place` and `democratizedspace/dspace` repositories into

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -15,6 +15,8 @@ Environment variables:
   CLOUD_INIT_PATH   Path to cloud-init user-data (default scripts/cloud-init/user-data.yaml)
   OUTPUT_DIR        Directory to write the image (default repo root)
   IMG_NAME          Name for the output image (default sugarkube)
+  ARM64             Build 64-bit userspace when 1 (default 1)
+  ALLOW_32BIT       Required explicit opt-in when ARM64=0 (set to 1)
   PI_GEN_SOURCE_DIR Path to an existing pi-gen checkout to copy instead of cloning
   TOKEN_PLACE_BRANCH Branch of token.place to clone (default main)
   DSPACE_BRANCH     Branch of dspace to clone (default v3)
@@ -263,10 +265,25 @@ else
 fi
 
 ARM64="${ARM64:-1}"
+ALLOW_32BIT="${ALLOW_32BIT:-0}"
+if [[ "${ARM64}" != "0" && "${ARM64}" != "1" ]]; then
+  echo "ARM64 must be 0 or 1 (got: ${ARM64})" >&2
+  exit 1
+fi
 if [ "$ARM64" -eq 1 ]; then
   ARMHF=0
 else
+  if [ "${ALLOW_32BIT}" -ne 1 ]; then
+    echo "Refusing 32-bit userspace build (ARM64=0) without ALLOW_32BIT=1" >&2
+    exit 1
+  fi
+  echo "[sugarkube] WARNING: building 32-bit userspace image (ARM64=0, ARMHF=1)"
   ARMHF=1
+fi
+if [ "$ARM64" -eq 1 ]; then
+  echo "[sugarkube] Target userspace architecture: arm64 (ARM64=1, ARMHF=0)"
+else
+  echo "[sugarkube] Target userspace architecture: armhf (ARM64=0, ARMHF=1)"
 fi
 DEFAULT_PI_GEN_BRANCH="bookworm"
 PI_GEN_SOURCE_DIR="${PI_GEN_SOURCE_DIR:-}"

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -686,6 +686,7 @@ def _run_build_script(tmp_path, env):
 def test_uses_default_pi_gen_branch(tmp_path):
     env = _setup_build_env(tmp_path)
     env["ARM64"] = "0"
+    env["ALLOW_32BIT"] = "1"
     result, git_args = _run_build_script(tmp_path, env)
     assert result.returncode == 0
     assert "--branch bookworm" in git_args
@@ -950,16 +951,28 @@ def test_arm64_disables_armhf(tmp_path):
     env = _setup_build_env(tmp_path)
     result, _ = _run_build_script(tmp_path, env)
     assert result.returncode == 0
+    assert "Target userspace architecture: arm64" in result.stdout
     config = (tmp_path / "config.env").read_text()
     assert "ARM64=1" in config
     assert "ARMHF=0" in config
 
 
-def test_armhf_enabled_for_32_bit(tmp_path):
+def test_arm64_zero_requires_explicit_opt_in(tmp_path):
     env = _setup_build_env(tmp_path)
     env["ARM64"] = "0"
     result, _ = _run_build_script(tmp_path, env)
+    assert result.returncode != 0
+    assert "Refusing 32-bit userspace build (ARM64=0) without ALLOW_32BIT=1" in result.stderr
+
+
+def test_armhf_enabled_for_32_bit(tmp_path):
+    env = _setup_build_env(tmp_path)
+    env["ARM64"] = "0"
+    env["ALLOW_32BIT"] = "1"
+    result, _ = _run_build_script(tmp_path, env)
     assert result.returncode == 0
+    assert "WARNING: building 32-bit userspace image" in result.stdout
+    assert "Target userspace architecture: armhf" in result.stdout
     config = (tmp_path / "config.env").read_text()
     assert "ARM64=0" in config
     assert "ARMHF=1" in config


### PR DESCRIPTION
### Motivation
- Modern Pi 4/Pi 5 nodes should default to a true 64-bit userspace to avoid runtime breakage where `uname -m` is `aarch64` but `dpkg --print-architecture` is `armhf`.
- The build flow needed a minimal, targeted guardrail so accidental 32-bit userspace images are harder to produce.
- Documentation and tests must reflect and lock in the intended default architecture behavior.

### Description
- Validate and document the new environment variables by updating `scripts/build_pi_image.sh` to add `ARM64` (default `1`) and `ALLOW_32BIT` (default `0`), require `ARM64` be `0` or `1`, and require `ALLOW_32BIT=1` to permit `ARM64=0` builds.
- Keep the default behavior as a true 64-bit userspace (`ARM64=1`, `ARMHF=0`) and emit a clear summary line `Target userspace architecture: ...` and a warning when intentionally building 32-bit images.
- Update `docs/pi_image_cloudflare.md` to state the default image is 64-bit userspace and document the explicit 32-bit opt-in: `ARM64=0 ALLOW_32BIT=1`.
- Extend `tests/build_pi_image_test.py` to assert the new summary/warning output, require `ALLOW_32BIT` for the 32-bit path, and add a negative test verifying `ARM64=0` without `ALLOW_32BIT=1` fails.

Files changed: `scripts/build_pi_image.sh`, `docs/pi_image_cloudflare.md`, `tests/build_pi_image_test.py`.

### Testing
- Ran `python -m pytest tests/build_pi_image_test.py` and received all tests passing: "38 passed".
- The updated test suite now verifies default `ARM64=1` produces `ARMHF=0` in `config.env`, that `ARM64=0` is refused without `ALLOW_32BIT=1`, and that `ARM64=0 ALLOW_32BIT=1` succeeds and emits the 32-bit warning.
- Attempted repository checks `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/`, but those tools were not available in the current environment and were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc5ff36714832f83a027136ce025d4)