### PR TITLE
📝 docs: evergreen dspace deployment guidance

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -1,61 +1,55 @@
 # democratized.space (dspace) on Sugarkube
 
-Use the packaged Helm chart from GHCR to install the dspace v3 stack into your cluster.
+Use the packaged Helm chart from GHCR to run dspace across Sugarkube environments.
+This guide is for **steady-state operations**: repeated deploys, promotions, and rollbacks.
+
 The `justfile` exposes both:
 
 - generic Helm OCI helpers (`helm-oci-install`, `helm-oci-upgrade`) for any app; and
-- a dspace-specific immutable deploy helper (`dspace-oci-deploy`) for RC/stable validation with
-  rollout status and post-deploy checks.
+- dspace-specific wrappers (`dspace-oci-deploy`, `dspace-oci-promote-prod`,
+  `dspace-oci-redeploy`) that encode safer defaults for immutable-tag rollouts.
 
-Values files are split so you can layer environment-specific ingress settings on top of the
-default development values:
+## Environment topology
 
-- `docs/examples/dspace.values.dev.yaml`: shared defaults for local/dev environments.
-- `docs/examples/dspace.values.staging.yaml`: staging-only ingress host and class targeting
-  `staging.democratized.space`.
-- `docs/examples/dspace.values.prod-subdomain.yaml`: **Phase A production-preview** host and class
-  targeting `prod.democratized.space` for pre-cutover smoke tests.
-- `docs/examples/dspace.values.prod.yaml`: **Phase B production apex** host and class targeting
-  `democratized.space`.
+Current and planned dspace topology:
 
-Safe two-phase production rollout mapping:
+- **staging (live, HA):** `staging.democratized.space` on `sugarkube3`, `sugarkube4`, `sugarkube5`
+  with `env=staging`.
+- **prod (live, HA):** `democratized.space` on `sugarkube0`, `sugarkube1`, `sugarkube2` with
+  `env=prod`.
+- **dev (planned):** future non-HA single-node deployment on `sugarkube6` with `env=dev`.
 
-- **Phase A (preview/canary):** `just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag>`
-  (uses `docs/examples/dspace.values.prod-subdomain.yaml`).
-- **Phase B (apex promotion):** `just dspace-oci-promote-prod tag=v3-<immutable-tag>`
-  (uses `docs/examples/dspace.values.prod.yaml` via `dspace-oci-deploy env=prod`).
+Values files are layered by environment:
 
-For safety, do not use `docs/examples/dspace.values.prod.yaml` for Phase A preview deploys and
-do not manually edit values files to switch hosts.
+- `docs/examples/dspace.values.dev.yaml`: shared baseline and the future `env=dev` base values.
+- `docs/examples/dspace.values.staging.yaml`: staging ingress host/class.
+- `docs/examples/dspace.values.prod.yaml`: production apex ingress host/class (`democratized.space`).
+- `docs/examples/dspace.values.prod-subdomain.yaml`: optional production preview/canary host
+  (`prod.democratized.space`).
 
-The public staging environment for dspace defaults to the `staging.democratized.space`
-hostname. You can substitute a different hostname if your Cloudflare Tunnel and DNS are
-configured accordingly. For production, this repo supports both:
+## Tags and release hygiene
 
-- `prod.democratized.space` (preview/canary endpoint during rollout); and
-- `democratized.space` (apex cutover target).
+- `main-latest`: convenience tag for rapid non-prod refreshes.
+- `main-<shortsha>`: immutable commit-derived tag for RC validation.
+- `v<semver>` (for example `v3.1.0`): immutable release tag suitable for sign-off and rollback.
 
-## Prerequisites
-
-- A working k3s cluster with Traefik Ingress available.
-- Cloudflare Tunnel client installed on the node that can reach the cluster API.
-- A Cloudflare Tunnel route created for the public hostname that will front dspace (defaults to
-  `staging.democratized.space`).
+Prefer immutable tags for staging sign-off and all production deploys. Mutable tags are convenient
+for development, but they are weaker for auditability and rollback precision.
 
 ## Container image and Helm chart
 
 - Image repository: `ghcr.io/democratizedspace/dspace`
-  - Example tag: `ghcr.io/democratizedspace/dspace:v3-latest`
-  - Additional tags such as `v3-<short-sha>` or `v<semver>` can be used for specific builds.
+  - Examples: `ghcr.io/democratizedspace/dspace:main-latest`,
+    `ghcr.io/democratizedspace/dspace:main-<shortsha>`,
+    `ghcr.io/democratizedspace/dspace:v3.1.0`
 - Helm chart: `oci://ghcr.io/democratizedspace/charts/dspace:<chartVersion>`
-  - Example: `oci://ghcr.io/democratizedspace/charts/dspace:3.0.0` (chartVersion comes from
-    `Chart.yaml`).
+  - Example: `oci://ghcr.io/democratizedspace/charts/dspace:3.0.0`
 
-Example Sugarkube values snippet targeting the staging environment:
+Example values snippet targeting staging:
 
 ```yaml
 images:
-  dspace: ghcr.io/democratizedspace/dspace:v3-latest
+  dspace: ghcr.io/democratizedspace/dspace:main-latest
 
 charts:
   dspace:
@@ -63,217 +57,162 @@ charts:
     host: staging.democratized.space
 ```
 
-## Quickstart
+## Quickstart commands
 
 ```bash
-# Immutable-tag staging deploy (recommended for RC/stable validation):
-just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
+# Immutable staging deploy (recommended for sign-off):
+just dspace-oci-deploy env=staging tag=main-<immutable-tag>
 
-# Immutable-tag production preview deploy (prod subdomain canary):
-just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag>
+# Optional immutable production preview deploy (prod subdomain canary):
+just dspace-oci-deploy-prod-subdomain tag=main-<immutable-tag>
 
 read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
 
-# Immutable-tag production deploy (pinned tag from docs/apps/dspace.prod.tag):
+# Immutable production apex deploy (pinned tag file):
 just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
 
-# Alias helper for apex promotion (same effect as the env=prod command above):
+# Alias helper for apex promotion (same effect as command above):
 just dspace-oci-promote-prod tag="$(read_prod_tag)"
 
-# Check pods and ingress status with the public URL
+# Check pods and ingress status:
 just app-status namespace=dspace release=dspace
+```
 
-# Generic helper examples (does not wait for rollout):
+### Generic helper examples (when you need direct Helm control)
+
+Use `helm-oci-install` for first install / install-if-missing behavior.
+Use `helm-oci-upgrade` for upgrade-only operations that should fail if not installed.
+
+```bash
+# Install (or upgrade with --install) against staging overlay
 just helm-oci-install \
   release=dspace namespace=dspace \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \
   values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
   version_file=docs/apps/dspace.version \
-  default_tag=v3-latest
+  default_tag=main-latest
 
-# Bump the image tag with generic Helm helper (optionally override chart version)
+# Upgrade with an immutable staging candidate tag
 just helm-oci-upgrade \
   release=dspace namespace=dspace \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \
   values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
   version_file=docs/apps/dspace.version \
-  tag=v3-<shortsha>
+  tag=main-<shortsha>
 
+# Optional preview-subdomain canary upgrade
 just helm-oci-upgrade \
   release=dspace namespace=dspace \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \
   values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod-subdomain.yaml \
   version_file=docs/apps/dspace.version \
-  tag=v3-<immutable-tag>
+  tag=v<semver>
 
+# Production apex upgrade
 just helm-oci-upgrade \
   release=dspace namespace=dspace \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \
   values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml \
   version_file=docs/apps/dspace.version \
-  tag=v3-<immutable-tag>
+  tag=v<semver>
 ```
 
-- `version_file` defaults the Helm chart to the latest tested v3 release stored alongside this
-  guide. You can override with `version=<semver>` when pinning a specific chart.
-- The image tag defaults to `default_tag` (`v3-latest`) for dev/staging in the generic helpers.
-  Production and production-preview deployments should use pinned tags (for example, the value in
-  `docs/apps/dspace.prod.tag` or a `v3-<immutable>` build).
-- `dspace-oci-deploy` always requires an explicit immutable tag (rejects mutable forms such as
-  `latest` and `main`), calls `helm-oci-install` so first-time deploys work, and waits for
-  `kubectl rollout status` before returning.
+Notes:
 
-## First deployment walkthrough
+- `dspace-oci-deploy` always requires an explicit immutable tag and rejects mutable forms.
+- `dspace-oci-deploy` uses `helm-oci-install` internally so first-time deploys work.
+- `docs/apps/dspace.version` pins the default tested chart version.
+- `docs/apps/dspace.prod.tag` is the pinned default immutable image tag for production deploys.
 
-Follow this numbered tutorial for a fresh dspace v3 rollout behind Traefik. It
-assumes your target cluster (for example `env=staging`) is online and reachable with kubectl.
+## Evergreen promotion workflow
 
-1. Confirm Traefik is present:
+Use this for each release cycle (for example `v3.0.1`, `v3.1.0`, `v3.1.1`):
+
+1. Deploy immutable candidate to staging:
 
    ```bash
-   kubectl -n kube-system get svc -l app.kubernetes.io/name=traefik
+   just dspace-oci-deploy env=staging tag=main-<shortsha>
    ```
 
-2. Install Cloudflare Tunnel (see [Cloudflare Tunnel docs](../cloudflare_tunnel.md)). Ensure
-   `CF_TUNNEL_TOKEN` is exported from the Cloudflare connector snippet, then run:
+2. Run staging smoke tests:
 
    ```bash
-   just cf-tunnel-install env=staging  # swap env=prod or env=dev as needed
+   curl -fsS https://staging.democratized.space/config.json | jq .
+   curl -fsS https://staging.democratized.space/healthz | jq .
+   curl -fsS https://staging.democratized.space/livez | jq .
    ```
 
-3. Create a Tunnel route in the Cloudflare dashboard from your FQDN to
-   `http://traefik.kube-system.svc.cluster.local:80`. Cluster DNS makes the
-   `traefik.kube-system.svc.cluster.local` hostname resolvable from every node,
-   so the tunnel can reach Traefik reliably. The default public FQDN for the
-   staging environment is `staging.democratized.space`.
-
-4. Install the app:
+3. Choose production immutable tag (`main-<shortsha>` or `v<semver>`) and pin it:
 
    ```bash
-   # Choose the command that matches your target environment:
-   # Staging:
-   just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
+   printf '%s\n' 'v3.1.0' > docs/apps/dspace.prod.tag
+   ```
 
-   # Production preview (Phase A) example using prod.democratized.space:
-   just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag>
+4. Optional preview-subdomain canary before apex:
 
-   # Production apex (Phase B) example using democratized.space:
-   read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
+   ```bash
+   just dspace-oci-deploy-prod-subdomain tag="$(read_prod_tag)"
+   ```
+
+5. Promote to production apex:
+
+   ```bash
    just dspace-oci-promote-prod tag="$(read_prod_tag)"
    ```
 
-5. Verify everything is healthy, then browse to the FQDN on your phone or laptop:
+6. Verify production:
 
    ```bash
-   kubectl -n dspace get ingress,pods,svc
+   curl -fsS https://democratized.space/config.json | jq .
+   curl -fsS https://democratized.space/healthz | jq .
+   curl -fsS https://democratized.space/livez | jq .
    ```
 
-6. Iterate new builds from v3:
+## Emergency redeploy (mutable refresh)
 
-   ```bash
-   just helm-oci-upgrade \
-     release=dspace namespace=dspace \
-     chart=oci://ghcr.io/democratizedspace/charts/dspace \
-     values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
-     version_file=docs/apps/dspace.version \
-     tag=v3-<shortsha>
-   ```
+For emergency refreshes where you intentionally want the newest digest behind `main-latest`:
 
-For emergency mutable-tag refreshes where you need to force pod recycle on `v3-latest`, keep using
-`just dspace-oci-redeploy env=staging` (or `env=prod tag=...`).
+```bash
+# Non-prod convenience flow
+just dspace-oci-redeploy env=staging
 
-## Production rollout runbook (v3 cutover)
-
-Use this sequence when promoting dspace v3 from staging to production:
-
-1. Deploy the immutable v3 build tag from the `v3` branch to
-   `https://prod.democratized.space`:
-
-   ```bash
-   just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag-from-v3-branch>
-   ```
-
-2. Run smoke tests:
-
-   ```bash
-   curl -fsS https://prod.democratized.space/config.json | jq .
-   curl -fsS https://prod.democratized.space/healthz | jq .
-   curl -fsS https://prod.democratized.space/livez | jq .
-   ```
-
-3. Merge `v3` into `main`.
-
-4. Deploy the immutable `main` tag to `https://prod.democratized.space`:
-
-   ```bash
-   just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag-from-main>
-   ```
-
-5. Promote to production apex after smoke tests pass:
-
-   ```bash
-   just dspace-oci-promote-prod tag=v3-<immutable-tag-from-main>
-   ```
-
-6. Update Cloudflare so `prod.democratized.space` becomes a simple redirect to
-   `https://democratized.space` once apex is serving v3 successfully.
+# Production always requires an immutable tag (or docs/apps/dspace.prod.tag)
+just dspace-oci-redeploy env=prod tag=v3.1.0
+```
 
 ## Networking via Cloudflare Tunnel
 
-This guide assumes you expose the cluster through a persistent Cloudflare Tunnel. The expected
-public hostname is typically `https://staging.democratized.space` (staging),
-`https://prod.democratized.space` (production preview), or `https://democratized.space` (apex).
+This guide assumes dspace is exposed through Cloudflare Tunnel. Common hostnames:
 
-For detailed instructions on creating the Cloudflare Tunnel and DNS records, see:
-../cloudflare_tunnel.md
+- staging: `https://staging.democratized.space`
+- optional production preview: `https://prod.democratized.space`
+- production apex: `https://democratized.space`
+
+For tunnel setup details, see `../cloudflare_tunnel.md`.
 
 ## Troubleshooting
 
-- Retrieve operator logs (staging/prod):
-  1. `just dspace-debug-logs-env env=<staging|prod>` first runs `just kubeconfig-env`
-     and rewrites `~/.kube/config` to the selected `sugar-<env>` context.
-  2. Run the bundled log collector to fetch both app and ingress logs.
+- Retrieve operator logs:
 
   ```bash
-  # Staging
   just dspace-debug-logs-env env=staging
-
-  # Production
   just dspace-debug-logs-env env=prod
   ```
 
-  This prints:
-  - dspace pod inventory in `namespace=dspace`
-  - dspace container logs (`--tail=200` for each dspace pod)
-  - Traefik ingress logs in `kube-system` (`--tail=200`)
-
-  If dspace is not in the default namespace, override it on the helper command:
+- If namespace differs, override it:
 
   ```bash
   just dspace-debug-logs-env env=staging namespace=my-dspace-namespace
   ```
 
-  If you already manage `KUBECONFIG` manually, you can run:
+- If managing kubeconfig manually:
 
   ```bash
   just dspace-debug-logs namespace=dspace
   ```
 
-  Common next steps after the bundled snapshot:
-
-  ```bash
-  # Live-tail dspace logs
-  kubectl -n dspace logs deploy/dspace --follow
-
-  # Re-check Traefik logs
-  kubectl -n kube-system logs -l app.kubernetes.io/name=traefik --tail=200
-  ```
-
-- Inspect the release values and history:
+- Additional checks:
   - `helm -n dspace status dspace`
   - `helm -n dspace get values dspace`
-- Check the dspace namespace for failing pods or missing ingress resources:
-  - `kubectl -n dspace get pods`
-  - `kubectl -n dspace describe ingress`
-- Validate the Cloudflare Tunnel service and route for the chosen hostname.
-- Review cluster-wide logs for Traefik or networking issues if the ingress is not reachable.
+  - `kubectl -n dspace get pods,svc,ingress`
+  - `kubectl -n kube-system logs -l app.kubernetes.io/name=traefik --tail=200`

--- a/docs/apps/dspace.prod.tag
+++ b/docs/apps/dspace.prod.tag
@@ -1,3 +1,3 @@
 # Default immutable image tag for production dspace deploys.
-# Override with a newer pinned tag when promoting releases.
+# Override with a newer pinned immutable tag when promoting releases.
 v3.0.0

--- a/docs/apps/dspace.version
+++ b/docs/apps/dspace.version
@@ -1,2 +1,2 @@
-# Default dspace chart version (v3 series). Update when new v3 releases are published.
+# Default dspace chart version. Update when new chart releases are published.
 3.0.0

--- a/docs/examples/dspace.values.prod-subdomain.yaml
+++ b/docs/examples/dspace.values.prod-subdomain.yaml
@@ -1,5 +1,5 @@
-# Example values for deploying democratized.space v3 to the production preview subdomain.
-# Use this during rollout validation before apex cutover.
+# Example values for deploying democratized.space to the optional production preview subdomain.
+# Use this for canary validation before (or between) apex promotions.
 environment: prod
 
 ingress:

--- a/justfile
+++ b/justfile
@@ -1235,7 +1235,7 @@ dspace-oci-deploy env='staging' tag='':
 
     deploy_tag="$(echo "{{ tag }}" | xargs)"
     if [ -z "${deploy_tag}" ]; then
-      echo "Set tag=<immutable-tag> (for example v3-<shortsha>) for dspace immutable deploys." >&2
+      echo "Set tag=<immutable-tag> (for example main-<shortsha> or v<semver>) for dspace immutable deploys." >&2
       exit 1
     fi
     tag_lc="$(echo "${deploy_tag}" | tr '[:upper:]' '[:lower:]')"
@@ -1294,16 +1294,16 @@ dspace-oci-deploy env='staging' tag='':
       echo "  curl -fsS https://${verify_host}/livez | jq ."
     fi
 
-# Deploy dspace v3 to the production preview subdomain (prod.democratized.space).
+# Deploy dspace to the optional production preview subdomain (prod.democratized.space).
 
-# Use this before apex cutover to validate rollout and run smoke tests.
+# Use this optional preview endpoint for canary/smoke tests before or between apex promotions.
 dspace-oci-deploy-prod-subdomain tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
     deploy_tag="$(echo "{{ tag }}" | xargs)"
     if [ -z "${deploy_tag}" ]; then
-      echo "Set tag=<immutable-tag> (for example v3-<shortsha>) for prod subdomain deploys." >&2
+      echo "Set tag=<immutable-tag> (for example main-<shortsha> or v<semver>) for prod subdomain deploys." >&2
       exit 1
     fi
     tag_lc="$(echo "${deploy_tag}" | tr '[:upper:]' '[:lower:]')"
@@ -1362,7 +1362,7 @@ dspace-oci-promote-prod tag='':
 
     just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy env=prod tag="${deploy_tag}"
 
-# Fast redeploy of dspace v3 from GHCR (emergency push).
+# Fast dspace redeploy from GHCR (emergency mutable-tag refresh).
 dspace-oci-redeploy env='staging' tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
@@ -1397,7 +1397,7 @@ dspace-oci-redeploy env='staging' tag='':
         exit 1
       fi
     else
-      default_tag_value="v3-latest"
+      default_tag_value="main-latest"
     fi
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \


### PR DESCRIPTION
### Motivation

- Remove stale v3-branch / one-time cutover wording and make the DSPACE runbook evergreen for repeated releases and promotions.
- Align sugarkube-side docs and recipes with the real environment topology (staging/prod HA + planned single-node dev on sugarkube6) and current release practice.
- Keep operator-friendly guidance and immutable-tag safety while avoiding coupling operational steps to a single past release.

### Description

- Rewrote `docs/apps/dspace.md` into a steady-state operations guide that documents current topology, hostnames, promotion flow, and preferred tag semantics (`main-latest`, `main-<shortsha>`, `v<semver>`), with copy-paste friendly commands and verification steps.
- Updated `justfile` help text and examples for `dspace-oci-deploy`, `dspace-oci-deploy-prod-subdomain`, `dspace-oci-promote-prod`, and `dspace-oci-redeploy` to remove `v3`-branch assumptions and use evergreen tag examples; retained the immutable-tag refusal checks.
- Made one small behavior-aligned tweak: the `dspace-oci-redeploy` default mutable convenience tag was changed to `main-latest` (previously `v3-latest`) to reflect the current non-prod convenience flow while keeping production redeploys pinned to immutable tags.
- Refreshed nearby files and comments: `docs/examples/dspace.values.prod-subdomain.yaml`, `docs/apps/dspace.version`, and `docs/apps/dspace.prod.tag` to use evergreen phrasing and to mark the prod-subdomain flow as optional/canary.

### Testing

- Ran targeted searches to verify removal of stale wording: `rg -n "v3 branch|merge v3 into main|v3-latest|v3-|cutover|Phase A|Phase B|prod.democratized.space" docs/apps/dspace.md docs/examples/dspace*.yaml justfile` (succeeded).
- Verified updated references with additional `rg` checks for common v3 tokens (succeeded).
- Ran the repository secret-scan over staged changes with `git diff --cached | ./scripts/scan-secrets.py` (succeeded).
- Attempted to run `just --list`, `just docs-verify`, `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` but those tools are not installed in this environment so they were not executed here (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce0e993050832f9d25a01150945962)