### PR TITLE
docs: make dspace runbooks and justfile messaging evergreen (post-v3)

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -1,279 +1,177 @@
 # democratized.space (dspace) on Sugarkube
 
-Use the packaged Helm chart from GHCR to install the dspace v3 stack into your cluster.
-The `justfile` exposes both:
+This guide documents **steady-state dspace operations** on Sugarkube after the v3 launch period.
+Use it for repeated staging/prod releases, rollbacks, and emergency redeploys.
 
-- generic Helm OCI helpers (`helm-oci-install`, `helm-oci-upgrade`) for any app; and
-- a dspace-specific immutable deploy helper (`dspace-oci-deploy`) for RC/stable validation with
-  rollout status and post-deploy checks.
+## Environment topology
 
-Values files are split so you can layer environment-specific ingress settings on top of the
-default development values:
+Current and planned dspace environments:
 
-- `docs/examples/dspace.values.dev.yaml`: shared defaults for local/dev environments.
-- `docs/examples/dspace.values.staging.yaml`: staging-only ingress host and class targeting
-  `staging.democratized.space`.
-- `docs/examples/dspace.values.prod-subdomain.yaml`: **Phase A production-preview** host and class
-  targeting `prod.democratized.space` for pre-cutover smoke tests.
-- `docs/examples/dspace.values.prod.yaml`: **Phase B production apex** host and class targeting
-  `democratized.space`.
+- **staging** (`env=staging`): live HA environment on `sugarkube3`, `sugarkube4`, `sugarkube5`,
+  served at `https://staging.democratized.space`.
+- **prod** (`env=prod`): live HA environment on `sugarkube0`, `sugarkube1`, `sugarkube2`,
+  served at `https://democratized.space`.
+- **dev** (`env=dev`): planned future non-HA environment on `sugarkube6`.
 
-Safe two-phase production rollout mapping:
+`main` is the default dspace branch. The old `v3` branch cutover flow is no longer used.
 
-- **Phase A (preview/canary):** `just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag>`
-  (uses `docs/examples/dspace.values.prod-subdomain.yaml`).
-- **Phase B (apex promotion):** `just dspace-oci-promote-prod tag=v3-<immutable-tag>`
-  (uses `docs/examples/dspace.values.prod.yaml` via `dspace-oci-deploy env=prod`).
+## Values overlays and what they mean
 
-For safety, do not use `docs/examples/dspace.values.prod.yaml` for Phase A preview deploys and
-do not manually edit values files to switch hosts.
+Values files define environment-specific settings (mainly ingress host/class):
 
-The public staging environment for dspace defaults to the `staging.democratized.space`
-hostname. You can substitute a different hostname if your Cloudflare Tunnel and DNS are
-configured accordingly. For production, this repo supports both:
+- `docs/examples/dspace.values.dev.yaml`: base defaults (`environment: dev`)
+- `docs/examples/dspace.values.staging.yaml`: staging overlay (`environment: staging`,
+  `host: staging.democratized.space`)
+- `docs/examples/dspace.values.prod.yaml`: production overlay (`environment: prod`,
+  `host: democratized.space`)
+- `docs/examples/dspace.values.prod-subdomain.yaml`: optional production preview/canary overlay
+  (`environment: prod`, `host: prod.democratized.space`)
 
-- `prod.democratized.space` (preview/canary endpoint during rollout); and
-- `democratized.space` (apex cutover target).
+Use environment overlays to choose destination hostnames. Use image tags to choose release version.
 
-## Prerequisites
+## Tags: convenience vs immutable
 
-- A working k3s cluster with Traefik Ingress available.
-- Cloudflare Tunnel client installed on the node that can reach the cluster API.
-- A Cloudflare Tunnel route created for the public hostname that will front dspace (defaults to
-  `staging.democratized.space`).
+- **Convenience tags** (for quick refreshes):
+  - `main-latest`
+- **Immutable deploy tags** (for sign-off, promotion, and rollback):
+  - `main-<shortsha>`
+  - `v<semver>` (for example `v3.0.1`, `v3.1.0`)
 
-## Container image and Helm chart
+For staging/prod sign-off and rollback safety, deploy immutable tags.
 
-- Image repository: `ghcr.io/democratizedspace/dspace`
-  - Example tag: `ghcr.io/democratizedspace/dspace:v3-latest`
-  - Additional tags such as `v3-<short-sha>` or `v<semver>` can be used for specific builds.
-- Helm chart: `oci://ghcr.io/democratizedspace/charts/dspace:<chartVersion>`
-  - Example: `oci://ghcr.io/democratizedspace/charts/dspace:3.0.0` (chartVersion comes from
-    `Chart.yaml`).
+## Command reference
 
-Example Sugarkube values snippet targeting the staging environment:
+### dspace-specific wrappers
 
-```yaml
-images:
-  dspace: ghcr.io/democratizedspace/dspace:v3-latest
+- `just dspace-oci-deploy env=<dev|staging|prod> tag=<immutable-tag>`
+  - install-or-upgrade flow for dspace
+  - rejects mutable tags (for example `latest`, `main`)
+  - waits for rollout and prints verification commands
+- `just dspace-oci-promote-prod tag=<immutable-tag>`
+  - alias for prod promotion (reads `docs/apps/dspace.prod.tag` when `tag` is omitted)
+- `just dspace-oci-deploy-prod-subdomain tag=<immutable-tag>`
+  - optional preview/canary deploy to `prod.democratized.space`
+- `just dspace-oci-redeploy env=<staging|prod|dev> [tag=...]`
+  - emergency restart path that reuses values and forces pod recycle
+  - defaults to `main-latest` outside prod; prod requires immutable tag (explicit or
+    `docs/apps/dspace.prod.tag`)
 
-charts:
-  dspace:
-    chart: oci://ghcr.io/democratizedspace/charts/dspace:3.0.0
-    host: staging.democratized.space
-```
+### generic Helm OCI wrappers
+
+- `just helm-oci-install ...` → install or upgrade
+- `just helm-oci-upgrade ...` → upgrade with `--reuse-values`
+
+Use generic wrappers when you need custom chart/value wiring. Use dspace wrappers for standard
+operator workflows.
 
 ## Quickstart
 
 ```bash
-# Immutable-tag staging deploy (recommended for RC/stable validation):
-just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
+# Staging immutable release deploy (recommended)
+just dspace-oci-deploy env=staging tag=main-<shortsha>
 
-# Immutable-tag production preview deploy (prod subdomain canary):
-just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag>
+# Optional production preview/canary deploy
+just dspace-oci-deploy-prod-subdomain tag=main-<shortsha>
 
+# Promote immutable release to production apex
 read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
-
-# Immutable-tag production deploy (pinned tag from docs/apps/dspace.prod.tag):
-just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
-
-# Alias helper for apex promotion (same effect as the env=prod command above):
 just dspace-oci-promote-prod tag="$(read_prod_tag)"
 
-# Check pods and ingress status with the public URL
+# Status check
 just app-status namespace=dspace release=dspace
+```
 
-# Generic helper examples (does not wait for rollout):
+## Evergreen promotion workflow
+
+Use this loop for each release candidate (`main-<shortsha>`) or release tag (`v<semver>`):
+
+1. Deploy immutable tag to staging:
+
+   ```bash
+   just dspace-oci-deploy env=staging tag=main-<shortsha>
+   ```
+
+2. Verify staging:
+
+   ```bash
+   curl -fsS https://staging.democratized.space/config.json | jq .
+   curl -fsS https://staging.democratized.space/healthz | jq .
+   curl -fsS https://staging.democratized.space/livez | jq .
+   ```
+
+3. Optionally run preview/canary checks:
+
+   ```bash
+   just dspace-oci-deploy-prod-subdomain tag=main-<shortsha>
+   curl -fsS https://prod.democratized.space/healthz | jq .
+   ```
+
+4. Promote same immutable tag to production apex:
+
+   ```bash
+   just dspace-oci-promote-prod tag=main-<shortsha>
+   ```
+
+5. Roll back by redeploying the previous known-good immutable tag:
+
+   ```bash
+   just dspace-oci-promote-prod tag=<previous-main-sha-or-semver-tag>
+   ```
+
+## Generic helper examples
+
+```bash
+# Install/upgrade with explicit staging overlays
 just helm-oci-install \
   release=dspace namespace=dspace \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \
   values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
   version_file=docs/apps/dspace.version \
-  default_tag=v3-latest
+  default_tag=main-latest
 
-# Bump the image tag with generic Helm helper (optionally override chart version)
+# Upgrade staging to an immutable release tag
 just helm-oci-upgrade \
   release=dspace namespace=dspace \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \
   values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
   version_file=docs/apps/dspace.version \
-  tag=v3-<shortsha>
+  tag=main-<shortsha>
 
-just helm-oci-upgrade \
-  release=dspace namespace=dspace \
-  chart=oci://ghcr.io/democratizedspace/charts/dspace \
-  values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod-subdomain.yaml \
-  version_file=docs/apps/dspace.version \
-  tag=v3-<immutable-tag>
-
+# Upgrade production to an immutable release tag
 just helm-oci-upgrade \
   release=dspace namespace=dspace \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \
   values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml \
   version_file=docs/apps/dspace.version \
-  tag=v3-<immutable-tag>
+  tag=v<semver>
 ```
-
-- `version_file` defaults the Helm chart to the latest tested v3 release stored alongside this
-  guide. You can override with `version=<semver>` when pinning a specific chart.
-- The image tag defaults to `default_tag` (`v3-latest`) for dev/staging in the generic helpers.
-  Production and production-preview deployments should use pinned tags (for example, the value in
-  `docs/apps/dspace.prod.tag` or a `v3-<immutable>` build).
-- `dspace-oci-deploy` always requires an explicit immutable tag (rejects mutable forms such as
-  `latest` and `main`), calls `helm-oci-install` so first-time deploys work, and waits for
-  `kubectl rollout status` before returning.
-
-## First deployment walkthrough
-
-Follow this numbered tutorial for a fresh dspace v3 rollout behind Traefik. It
-assumes your target cluster (for example `env=staging`) is online and reachable with kubectl.
-
-1. Confirm Traefik is present:
-
-   ```bash
-   kubectl -n kube-system get svc -l app.kubernetes.io/name=traefik
-   ```
-
-2. Install Cloudflare Tunnel (see [Cloudflare Tunnel docs](../cloudflare_tunnel.md)). Ensure
-   `CF_TUNNEL_TOKEN` is exported from the Cloudflare connector snippet, then run:
-
-   ```bash
-   just cf-tunnel-install env=staging  # swap env=prod or env=dev as needed
-   ```
-
-3. Create a Tunnel route in the Cloudflare dashboard from your FQDN to
-   `http://traefik.kube-system.svc.cluster.local:80`. Cluster DNS makes the
-   `traefik.kube-system.svc.cluster.local` hostname resolvable from every node,
-   so the tunnel can reach Traefik reliably. The default public FQDN for the
-   staging environment is `staging.democratized.space`.
-
-4. Install the app:
-
-   ```bash
-   # Choose the command that matches your target environment:
-   # Staging:
-   just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
-
-   # Production preview (Phase A) example using prod.democratized.space:
-   just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag>
-
-   # Production apex (Phase B) example using democratized.space:
-   read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
-   just dspace-oci-promote-prod tag="$(read_prod_tag)"
-   ```
-
-5. Verify everything is healthy, then browse to the FQDN on your phone or laptop:
-
-   ```bash
-   kubectl -n dspace get ingress,pods,svc
-   ```
-
-6. Iterate new builds from v3:
-
-   ```bash
-   just helm-oci-upgrade \
-     release=dspace namespace=dspace \
-     chart=oci://ghcr.io/democratizedspace/charts/dspace \
-     values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
-     version_file=docs/apps/dspace.version \
-     tag=v3-<shortsha>
-   ```
-
-For emergency mutable-tag refreshes where you need to force pod recycle on `v3-latest`, keep using
-`just dspace-oci-redeploy env=staging` (or `env=prod tag=...`).
-
-## Production rollout runbook (v3 cutover)
-
-Use this sequence when promoting dspace v3 from staging to production:
-
-1. Deploy the immutable v3 build tag from the `v3` branch to
-   `https://prod.democratized.space`:
-
-   ```bash
-   just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag-from-v3-branch>
-   ```
-
-2. Run smoke tests:
-
-   ```bash
-   curl -fsS https://prod.democratized.space/config.json | jq .
-   curl -fsS https://prod.democratized.space/healthz | jq .
-   curl -fsS https://prod.democratized.space/livez | jq .
-   ```
-
-3. Merge `v3` into `main`.
-
-4. Deploy the immutable `main` tag to `https://prod.democratized.space`:
-
-   ```bash
-   just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag-from-main>
-   ```
-
-5. Promote to production apex after smoke tests pass:
-
-   ```bash
-   just dspace-oci-promote-prod tag=v3-<immutable-tag-from-main>
-   ```
-
-6. Update Cloudflare so `prod.democratized.space` becomes a simple redirect to
-   `https://democratized.space` once apex is serving v3 successfully.
 
 ## Networking via Cloudflare Tunnel
 
-This guide assumes you expose the cluster through a persistent Cloudflare Tunnel. The expected
-public hostname is typically `https://staging.democratized.space` (staging),
-`https://prod.democratized.space` (production preview), or `https://democratized.space` (apex).
+Expected public hostnames:
 
-For detailed instructions on creating the Cloudflare Tunnel and DNS records, see:
-../cloudflare_tunnel.md
+- staging: `https://staging.democratized.space`
+- production preview (optional): `https://prod.democratized.space`
+- production apex: `https://democratized.space`
+
+For tunnel and DNS setup details, see [Cloudflare Tunnel docs](../cloudflare_tunnel.md).
 
 ## Troubleshooting
 
-- Retrieve operator logs (staging/prod):
-  1. `just dspace-debug-logs-env env=<staging|prod>` first runs `just kubeconfig-env`
-     and rewrites `~/.kube/config` to the selected `sugar-<env>` context.
-  2. Run the bundled log collector to fetch both app and ingress logs.
+- Retrieve operator logs by environment:
 
   ```bash
-  # Staging
   just dspace-debug-logs-env env=staging
-
-  # Production
   just dspace-debug-logs-env env=prod
   ```
 
-  This prints:
-  - dspace pod inventory in `namespace=dspace`
-  - dspace container logs (`--tail=200` for each dspace pod)
-  - Traefik ingress logs in `kube-system` (`--tail=200`)
-
-  If dspace is not in the default namespace, override it on the helper command:
-
-  ```bash
-  just dspace-debug-logs-env env=staging namespace=my-dspace-namespace
-  ```
-
-  If you already manage `KUBECONFIG` manually, you can run:
-
-  ```bash
-  just dspace-debug-logs namespace=dspace
-  ```
-
-  Common next steps after the bundled snapshot:
-
-  ```bash
-  # Live-tail dspace logs
-  kubectl -n dspace logs deploy/dspace --follow
-
-  # Re-check Traefik logs
-  kubectl -n kube-system logs -l app.kubernetes.io/name=traefik --tail=200
-  ```
-
-- Inspect the release values and history:
+- Inspect release state:
   - `helm -n dspace status dspace`
   - `helm -n dspace get values dspace`
-- Check the dspace namespace for failing pods or missing ingress resources:
-  - `kubectl -n dspace get pods`
-  - `kubectl -n dspace describe ingress`
-- Validate the Cloudflare Tunnel service and route for the chosen hostname.
-- Review cluster-wide logs for Traefik or networking issues if the ingress is not reachable.
+  - `kubectl -n dspace get ingress,pods,svc`
+
+- Emergency mutable-tag refresh (non-prod default):
+
+  ```bash
+  just dspace-oci-redeploy env=staging
+  ```

--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -318,9 +318,9 @@ Only create this manually if the CNAME is missing:
    - **Proxy status**: **Proxied** (orange cloud)
 4. Save the record.
 
-## Step 5 – Post-cutover redirect for `prod.` (optional finalization)
+## Step 5 – Optional redirect for `prod.` after apex validation
 
-After dspace v3 is fully promoted on `democratized.space`, convert `prod.democratized.space` to a
+After dspace is fully validated on `democratized.space`, convert `prod.democratized.space` to a
 simple redirect (Cloudflare Redirect Rule or Page Rule) to avoid maintaining duplicate origins:
 
 - **Source**: `https://prod.democratized.space/*`

--- a/docs/examples/dspace.values.dev.yaml
+++ b/docs/examples/dspace.values.dev.yaml
@@ -1,5 +1,5 @@
-# Example values for deploying democratized.space via Helm.
-# The ingress host is set by the installer command.
+# Base/shared dspace values (dev profile) layered into all environments.
+# Keep this file host-agnostic; environment overlays set public hostnames.
 environment: dev
 
 ingress:

--- a/docs/examples/dspace.values.prod-subdomain.yaml
+++ b/docs/examples/dspace.values.prod-subdomain.yaml
@@ -1,5 +1,5 @@
-# Example values for deploying democratized.space v3 to the production preview subdomain.
-# Use this during rollout validation before apex cutover.
+# Optional production preview/canary overlay.
+# Use when validating immutable tags on prod.democratized.space.
 environment: prod
 
 ingress:

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -383,7 +383,7 @@ Traefik is available per the section above.
    so the tunnel can reach Traefik reliably.
 
 3. Install your app using its Helm or `just` recipe. For example, the
-   [dspace app guide](apps/dspace.md) shows how to deploy dspace v3 with a
+   [dspace app guide](apps/dspace.md) shows how to deploy dspace with a
    Traefik ingress host and tested values.
 
 4. Verify everything is healthy, then browse to the FQDN on your phone or
@@ -394,7 +394,7 @@ Traefik is available per the section above.
    ```
 
 5. Iterate new builds using your app's upgrade instructions (e.g., the dspace
-   guide covers rolling new `v3-<shortsha>` images).
+   guide covers rolling new `main-<shortsha>` or `v<semver>` images).
 
 ## Step 1: Verify your 3-node control plane is healthy
 
@@ -676,17 +676,17 @@ serving ingress, and the dspace OCI chart is already published to GHCR. The goal
 roll pods quickly without extra ceremony—Kubernetes handles the rolling update using the
 deployment's defaults.
 
-**Quick redeploy for dspace v3 (generic helper for staging, dspace helpers for production):**
+**Quick redeploy for dspace (generic helper for staging, dspace helpers for production):**
 
 Pick the values overlay for your target environment and prefer immutable image tags for production:
 
 - Staging: `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`
-- Production preview (Phase A):
+- Production preview (optional canary):
   `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod-subdomain.yaml`
-- Production apex (Phase B): `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`
+- Production apex (standard): `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`
 
-Do not use `docs/examples/dspace.values.prod-subdomain.yaml` for Phase B apex promotion; keep that
-overlay only for Phase A preview deploys at `prod.democratized.space`.
+Do not use `docs/examples/dspace.values.prod-subdomain.yaml` for apex promotion; keep that
+overlay only for optional preview deploys at `prod.democratized.space`.
 
 ```bash
 # From the sugarkube repo root on a cluster node (staging):
@@ -695,18 +695,18 @@ just helm-oci-upgrade \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \
   values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
   version_file=docs/apps/dspace.version \
-  default_tag=v3-latest
+  default_tag=main-latest
 ```
 
-For production preview (Phase A), this guide intentionally switches from the generic
+For production preview (optional canary), this guide intentionally switches from the generic
 `helm-oci-upgrade` example to the dspace-specific helper so rollout verification and
 post-deploy checks are included by default:
 
 ```bash
-just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag>
+just dspace-oci-deploy-prod-subdomain tag=main-<immutable-tag>
 ```
 
-For production apex promotion (Phase B), use `dspace-oci-promote-prod` with a pinned tag (for example the
+For production apex promotion, use `dspace-oci-promote-prod` with a pinned tag (for example the
 value stored in `docs/apps/dspace.prod.tag`). This helper wraps `dspace-oci-deploy env=prod`, which keeps
 the same values chain as the generic path (`docs/examples/dspace.values.dev.yaml` +
 `docs/examples/dspace.values.prod.yaml`) while adding rollout/status checks:
@@ -722,7 +722,7 @@ sets `environment: dev`, `docs/examples/dspace.values.staging.yaml` sets `enviro
 `docs/examples/dspace.values.prod.yaml` sets `environment: prod`, which show up in `/healthz` and
 the homepage build badge.
 
-If you prefer a one-liner that bakes in those arguments for dspace v3, use the helper
+If you prefer a one-liner that bakes in those arguments for dspace, use the helper
 recipe (defaults to staging):
 
 ```bash
@@ -735,14 +735,14 @@ just dspace-oci-redeploy env=prod tag="$(read_prod_tag)"
 Under the hood, both commands call the shared `_helm-oci-deploy` helper via
 `helm-oci-upgrade`, performing `helm upgrade --reuse-values` against the running release
 and then forcing a `kubectl rollout restart deploy/dspace` to ensure pods recycle even
-when `v3-latest` is republished with the same tag. The helper waits for the rollout to
+when `main-latest` is republished with the same tag. The helper waits for the rollout to
 finish and exits non-zero if Kubernetes reports a failure.
 
 For immutable RC/stable validation (recommended for staging and prod), use the dedicated
 helper instead:
 
 ```bash
-just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
+just dspace-oci-deploy env=staging tag=main-<immutable-tag>
 
 read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
 just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
@@ -754,9 +754,9 @@ just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
 `kubectl rollout status`, and prints post-deploy verification commands for `config.json`,
 `/healthz`, and `/livez` using the live ingress host (or `<dspace-host>` when none is discoverable).
 
-When you pass an image tag (including the default `v3-latest`), the helper sets
+When you pass an image tag (including the default `main-latest`), the helper sets
 `image.pullPolicy=Always` so the nodes re-check GHCR for the latest build of that tag on
-each redeploy. For production, prefer immutable tags (for example, `v3-<sha>`) if you want
+each redeploy. For production, prefer immutable tags (for example, `main-<sha>` or `v<semver>`) if you want
 to pin a specific image.
 
 **Emergency redeploy checklist:**
@@ -767,7 +767,7 @@ to pin a specific image.
     just cluster-status
     ```
 
-2. Ensure your new image is pushed and `v3-latest` (or the tag you pass via `tag=`)
+2. Ensure your new image is pushed and `main-latest` (or the tag you pass via `tag=`)
    points at the desired build (see the dspace repo docs for image build/publish steps).
 3. Run the redeploy command (`just helm-oci-upgrade ...` or `just dspace-oci-redeploy`).
 4. Verify pods and logs:
@@ -899,8 +899,8 @@ As you continue operating your cluster, these recipes will be helpful:
   use `just wipe` to clean it up, then rerun `just ha3 env=dev` to rejoin correctly.
 
 - **Emergency dspace redeploy:** Run `just dspace-oci-redeploy` to pull the latest
-  dspace v3 chart from GHCR and force a rollout restart so pods refresh to the newest
-  `v3-latest` image digest without retyping chart arguments.
+  dspace chart from GHCR and force a rollout restart so pods refresh to the newest
+  `main-latest` image digest without retyping chart arguments.
 
 ### Document outages and incidents
 

--- a/justfile
+++ b/justfile
@@ -1212,8 +1212,8 @@ helm-oci-upgrade release='' namespace='' chart='' values='' host='' version='' v
     @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' allow_install='false' reuse_values='true'
 
 # Opinionated immutable-tag dspace deploy with rollout verification.
-
-# Use this for RC/stable validation flows where explicit image pinning matters.
+#
+# Use this for routine staging/prod releases where explicit image pinning matters.
 dspace-oci-deploy env='staging' tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
@@ -1235,7 +1235,7 @@ dspace-oci-deploy env='staging' tag='':
 
     deploy_tag="$(echo "{{ tag }}" | xargs)"
     if [ -z "${deploy_tag}" ]; then
-      echo "Set tag=<immutable-tag> (for example v3-<shortsha>) for dspace immutable deploys." >&2
+      echo "Set tag=<immutable-tag> (for example main-<shortsha> or v<semver>) for dspace immutable deploys." >&2
       exit 1
     fi
     tag_lc="$(echo "${deploy_tag}" | tr '[:upper:]' '[:lower:]')"
@@ -1294,16 +1294,16 @@ dspace-oci-deploy env='staging' tag='':
       echo "  curl -fsS https://${verify_host}/livez | jq ."
     fi
 
-# Deploy dspace v3 to the production preview subdomain (prod.democratized.space).
-
-# Use this before apex cutover to validate rollout and run smoke tests.
+# Optional: deploy dspace to the production preview subdomain (prod.democratized.space).
+#
+# Use this for canary/smoke testing before or alongside normal apex deploys.
 dspace-oci-deploy-prod-subdomain tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
     deploy_tag="$(echo "{{ tag }}" | xargs)"
     if [ -z "${deploy_tag}" ]; then
-      echo "Set tag=<immutable-tag> (for example v3-<shortsha>) for prod subdomain deploys." >&2
+      echo "Set tag=<immutable-tag> (for example main-<shortsha> or v<semver>) for prod subdomain deploys." >&2
       exit 1
     fi
     tag_lc="$(echo "${deploy_tag}" | tr '[:upper:]' '[:lower:]')"
@@ -1362,7 +1362,7 @@ dspace-oci-promote-prod tag='':
 
     just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy env=prod tag="${deploy_tag}"
 
-# Fast redeploy of dspace v3 from GHCR (emergency push).
+# Fast redeploy of dspace from GHCR (emergency push).
 dspace-oci-redeploy env='staging' tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
@@ -1397,7 +1397,7 @@ dspace-oci-redeploy env='staging' tag='':
         exit 1
       fi
     else
-      default_tag_value="v3-latest"
+      default_tag_value="main-latest"
     fi
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \


### PR DESCRIPTION
### Motivation

- Remove v3-era cutover runbook language and make DSPACE docs reflect ongoing, repeatable release operations. 
- Align operator guidance with the real Sugarkube topology and hostnames for dev/staging/prod. 
- Prefer an evergreen promotion workflow using `main-<shortsha>`, `main-latest`, and semver tags rather than one-time v3 cutover wording.

### Description

- Rewrote `docs/apps/dspace.md` as a steady-state operations guide that documents env topology (`staging` on sugarkube3-5 at `staging.democratized.space`, `prod` on sugarkube0-2 at `democratized.space`, planned `dev` on sugarkube6), tag guidance (convenience `main-latest` vs immutable `main-<shortsha>`/`v<semver>`), and an evergreen promotion loop. 
- Updated `justfile` dspace recipes and help text (`dspace-oci-deploy`, `dspace-oci-deploy-prod-subdomain`, `dspace-oci-promote-prod`, `dspace-oci-redeploy`) to remove v3-specific examples and to show `main-<shortsha>`/semver examples; preserved immutable-tag enforcement and install/upgrade behavior. 
- Small behavioral adjustment: changed the non-prod default convenience tag used by `dspace-oci-redeploy` from `v3-latest` to `main-latest` while keeping other recipe semantics unchanged. 
- Revised example values and surrounding docs (`docs/examples/dspace.values.*`, `docs/raspi_cluster_operations.md`, `docs/cloudflare_tunnel.md`) to describe optional prod-subdomain (canary) usage and to remove cutover-phase phrasing.

### Testing

- Searched the tree to verify stale v3 wording was removed with `rg -n "v3 branch|merge v3 into main|v3-latest|v3-|cutover|Phase A|Phase B|prod.democratized.space" docs justfile` and confirmed matches were updated where appropriate. 
- Ran the repository secret scan via `./scripts/scan-secrets.py` against the staged changes and it reported no findings. 
- Attempted docs checks (`pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, `linkchecker --no-warnings README.md docs/`) and `just` recipes (`just --list`, `just docs-verify`) but those tools are not installed in this environment so they could not be executed here. 
- No other automated tests failed and no functional behavior was altered except the documented default convenience tag change for emergency redeploys.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce0e993050832f9d25a01150945962)