### PR TITLE
docs: make DSPACE docs and just recipes evergreen for steady-state promotions

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -1,279 +1,153 @@
 # democratized.space (dspace) on Sugarkube
 
-Use the packaged Helm chart from GHCR to install the dspace v3 stack into your cluster.
-The `justfile` exposes both:
+This guide covers steady-state DSPACE operations on Sugarkube: repeated staging and production
+releases, optional preview deploys, and rollback-safe immutable tag usage.
+
+The `justfile` exposes:
 
 - generic Helm OCI helpers (`helm-oci-install`, `helm-oci-upgrade`) for any app; and
-- a dspace-specific immutable deploy helper (`dspace-oci-deploy`) for RC/stable validation with
-  rollout status and post-deploy checks.
+- DSPACE-focused helpers (`dspace-oci-deploy`, `dspace-oci-promote-prod`,
+  `dspace-oci-redeploy`) that encode common operations.
 
-Values files are split so you can layer environment-specific ingress settings on top of the
-default development values:
+## Environment topology
 
-- `docs/examples/dspace.values.dev.yaml`: shared defaults for local/dev environments.
-- `docs/examples/dspace.values.staging.yaml`: staging-only ingress host and class targeting
+Current/future topology in this repo:
+
+- **staging** (`env=staging`): HA on `sugarkube3`, `sugarkube4`, `sugarkube5`, served at
   `staging.democratized.space`.
-- `docs/examples/dspace.values.prod-subdomain.yaml`: **Phase A production-preview** host and class
-  targeting `prod.democratized.space` for pre-cutover smoke tests.
-- `docs/examples/dspace.values.prod.yaml`: **Phase B production apex** host and class targeting
+- **prod** (`env=prod`): HA on `sugarkube0`, `sugarkube1`, `sugarkube2`, served at
   `democratized.space`.
+- **dev** (`env=dev`, planned): single-node non-HA target on `sugarkube6`.
 
-Safe two-phase production rollout mapping:
+Values overlays:
 
-- **Phase A (preview/canary):** `just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag>`
-  (uses `docs/examples/dspace.values.prod-subdomain.yaml`).
-- **Phase B (apex promotion):** `just dspace-oci-promote-prod tag=v3-<immutable-tag>`
-  (uses `docs/examples/dspace.values.prod.yaml` via `dspace-oci-deploy env=prod`).
+- `docs/examples/dspace.values.dev.yaml`: shared defaults and `environment: dev` baseline.
+- `docs/examples/dspace.values.staging.yaml`: staging ingress host/class overlay.
+- `docs/examples/dspace.values.prod.yaml`: production apex ingress host/class overlay.
+- `docs/examples/dspace.values.prod-subdomain.yaml`: optional production preview overlay for
+  `prod.democratized.space` (canary/smoke tests when desired).
 
-For safety, do not use `docs/examples/dspace.values.prod.yaml` for Phase A preview deploys and
-do not manually edit values files to switch hosts.
+## Image tags and release terminology
 
-The public staging environment for dspace defaults to the `staging.democratized.space`
-hostname. You can substitute a different hostname if your Cloudflare Tunnel and DNS are
-configured accordingly. For production, this repo supports both:
+- `main-latest`: mutable convenience tag for fast iteration (non-prod by default).
+- `main-<shortsha>`: immutable commit-derived tag for promotion testing.
+- `v<semver>` (for example `v3.0.1`, `v3.1.0`): immutable release tag for formal rollout and
+  rollback points.
 
-- `prod.democratized.space` (preview/canary endpoint during rollout); and
-- `democratized.space` (apex cutover target).
+Use immutable tags for sign-off, production deploys, and rollback safety.
 
-## Prerequisites
-
-- A working k3s cluster with Traefik Ingress available.
-- Cloudflare Tunnel client installed on the node that can reach the cluster API.
-- A Cloudflare Tunnel route created for the public hostname that will front dspace (defaults to
-  `staging.democratized.space`).
-
-## Container image and Helm chart
-
-- Image repository: `ghcr.io/democratizedspace/dspace`
-  - Example tag: `ghcr.io/democratizedspace/dspace:v3-latest`
-  - Additional tags such as `v3-<short-sha>` or `v<semver>` can be used for specific builds.
-- Helm chart: `oci://ghcr.io/democratizedspace/charts/dspace:<chartVersion>`
-  - Example: `oci://ghcr.io/democratizedspace/charts/dspace:3.0.0` (chartVersion comes from
-    `Chart.yaml`).
-
-Example Sugarkube values snippet targeting the staging environment:
-
-```yaml
-images:
-  dspace: ghcr.io/democratizedspace/dspace:v3-latest
-
-charts:
-  dspace:
-    chart: oci://ghcr.io/democratizedspace/charts/dspace:3.0.0
-    host: staging.democratized.space
-```
-
-## Quickstart
+## Quick commands
 
 ```bash
-# Immutable-tag staging deploy (recommended for RC/stable validation):
-just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
+# Staging deploy (recommended path for release validation):
+just dspace-oci-deploy env=staging tag=main-<shortsha>
 
-# Immutable-tag production preview deploy (prod subdomain canary):
-just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag>
+# Production deploy to apex (normal steady-state path):
+just dspace-oci-promote-prod tag=v<semver>
 
-read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
+# Equivalent explicit prod command:
+just dspace-oci-deploy env=prod tag=v<semver>
 
-# Immutable-tag production deploy (pinned tag from docs/apps/dspace.prod.tag):
-just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
+# Optional preview/canary endpoint (not required for every release):
+just dspace-oci-deploy-prod-subdomain tag=v<semver>
 
-# Alias helper for apex promotion (same effect as the env=prod command above):
-just dspace-oci-promote-prod tag="$(read_prod_tag)"
-
-# Check pods and ingress status with the public URL
+# Inspect release status:
 just app-status namespace=dspace release=dspace
+```
 
-# Generic helper examples (does not wait for rollout):
+If you track an approved prod tag in `docs/apps/dspace.prod.tag`:
+
+```bash
+read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
+just dspace-oci-promote-prod tag="$(read_prod_tag)"
+```
+
+## When to use each helper
+
+- `helm-oci-install`: install-or-upgrade generic path (`helm upgrade --install`), no DSPACE-specific
+  validation messaging.
+- `helm-oci-upgrade`: upgrade existing release with `--reuse-values`, useful for quick/manual ops.
+- `dspace-oci-deploy`: opinionated DSPACE deploy that requires an explicit immutable tag,
+  applies correct env overlays, waits for rollout, and prints post-deploy checks.
+- `dspace-oci-promote-prod`: thin wrapper for `dspace-oci-deploy env=prod`, using an explicit tag
+  or `docs/apps/dspace.prod.tag`.
+- `dspace-oci-deploy-prod-subdomain`: optional preview deploy for `prod.democratized.space`.
+- `dspace-oci-redeploy`: emergency mutable-tag refresh path that forces a rollout restart.
+
+## Generic Helm OCI examples
+
+```bash
+# First install (or idempotent install-or-upgrade):
 just helm-oci-install \
   release=dspace namespace=dspace \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \
   values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
   version_file=docs/apps/dspace.version \
-  default_tag=v3-latest
+  default_tag=main-latest
 
-# Bump the image tag with generic Helm helper (optionally override chart version)
+# Upgrade existing release to an immutable tag:
 just helm-oci-upgrade \
   release=dspace namespace=dspace \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \
   values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
   version_file=docs/apps/dspace.version \
-  tag=v3-<shortsha>
+  tag=main-<shortsha>
 
-just helm-oci-upgrade \
-  release=dspace namespace=dspace \
-  chart=oci://ghcr.io/democratizedspace/charts/dspace \
-  values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod-subdomain.yaml \
-  version_file=docs/apps/dspace.version \
-  tag=v3-<immutable-tag>
-
+# Upgrade production with prod overlay:
 just helm-oci-upgrade \
   release=dspace namespace=dspace \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \
   values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml \
   version_file=docs/apps/dspace.version \
-  tag=v3-<immutable-tag>
+  tag=v<semver>
 ```
 
-- `version_file` defaults the Helm chart to the latest tested v3 release stored alongside this
-  guide. You can override with `version=<semver>` when pinning a specific chart.
-- The image tag defaults to `default_tag` (`v3-latest`) for dev/staging in the generic helpers.
-  Production and production-preview deployments should use pinned tags (for example, the value in
-  `docs/apps/dspace.prod.tag` or a `v3-<immutable>` build).
-- `dspace-oci-deploy` always requires an explicit immutable tag (rejects mutable forms such as
-  `latest` and `main`), calls `helm-oci-install` so first-time deploys work, and waits for
-  `kubectl rollout status` before returning.
+Notes:
 
-## First deployment walkthrough
+- `version_file=docs/apps/dspace.version` pins the chart version by default; override with
+  `version=<semver>` when needed.
+- Environment overlays (`dev/staging/prod/prod-subdomain`) select ingress and app environment values;
+  they do **not** represent release versions.
+- `dspace-oci-deploy` rejects mutable tags such as `latest`/`main` to preserve reproducibility.
 
-Follow this numbered tutorial for a fresh dspace v3 rollout behind Traefik. It
-assumes your target cluster (for example `env=staging`) is online and reachable with kubectl.
+## Release/promotion pattern (evergreen)
 
-1. Confirm Traefik is present:
+Use this loop for each release:
 
-   ```bash
-   kubectl -n kube-system get svc -l app.kubernetes.io/name=traefik
-   ```
-
-2. Install Cloudflare Tunnel (see [Cloudflare Tunnel docs](../cloudflare_tunnel.md)). Ensure
-   `CF_TUNNEL_TOKEN` is exported from the Cloudflare connector snippet, then run:
-
-   ```bash
-   just cf-tunnel-install env=staging  # swap env=prod or env=dev as needed
-   ```
-
-3. Create a Tunnel route in the Cloudflare dashboard from your FQDN to
-   `http://traefik.kube-system.svc.cluster.local:80`. Cluster DNS makes the
-   `traefik.kube-system.svc.cluster.local` hostname resolvable from every node,
-   so the tunnel can reach Traefik reliably. The default public FQDN for the
-   staging environment is `staging.democratized.space`.
-
-4. Install the app:
-
-   ```bash
-   # Choose the command that matches your target environment:
-   # Staging:
-   just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
-
-   # Production preview (Phase A) example using prod.democratized.space:
-   just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag>
-
-   # Production apex (Phase B) example using democratized.space:
-   read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
-   just dspace-oci-promote-prod tag="$(read_prod_tag)"
-   ```
-
-5. Verify everything is healthy, then browse to the FQDN on your phone or laptop:
-
-   ```bash
-   kubectl -n dspace get ingress,pods,svc
-   ```
-
-6. Iterate new builds from v3:
-
-   ```bash
-   just helm-oci-upgrade \
-     release=dspace namespace=dspace \
-     chart=oci://ghcr.io/democratizedspace/charts/dspace \
-     values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
-     version_file=docs/apps/dspace.version \
-     tag=v3-<shortsha>
-   ```
-
-For emergency mutable-tag refreshes where you need to force pod recycle on `v3-latest`, keep using
-`just dspace-oci-redeploy env=staging` (or `env=prod tag=...`).
-
-## Production rollout runbook (v3 cutover)
-
-Use this sequence when promoting dspace v3 from staging to production:
-
-1. Deploy the immutable v3 build tag from the `v3` branch to
-   `https://prod.democratized.space`:
-
-   ```bash
-   just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag-from-v3-branch>
-   ```
-
-2. Run smoke tests:
-
-   ```bash
-   curl -fsS https://prod.democratized.space/config.json | jq .
-   curl -fsS https://prod.democratized.space/healthz | jq .
-   curl -fsS https://prod.democratized.space/livez | jq .
-   ```
-
-3. Merge `v3` into `main`.
-
-4. Deploy the immutable `main` tag to `https://prod.democratized.space`:
-
-   ```bash
-   just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag-from-main>
-   ```
-
-5. Promote to production apex after smoke tests pass:
-
-   ```bash
-   just dspace-oci-promote-prod tag=v3-<immutable-tag-from-main>
-   ```
-
-6. Update Cloudflare so `prod.democratized.space` becomes a simple redirect to
-   `https://democratized.space` once apex is serving v3 successfully.
+1. Build and publish candidate image tags from `main` (for example `main-<shortsha>`).
+2. Deploy to staging with `dspace-oci-deploy env=staging tag=...`.
+3. Run smoke checks (`/config.json`, `/healthz`, `/livez`) on `staging.democratized.space`.
+4. Optionally deploy same immutable tag to `prod.democratized.space` for preview/canary checks.
+5. Promote approved immutable tag to apex with `dspace-oci-promote-prod` (or `dspace-oci-deploy env=prod`).
+6. For rollback, redeploy the previous known-good immutable tag.
 
 ## Networking via Cloudflare Tunnel
 
-This guide assumes you expose the cluster through a persistent Cloudflare Tunnel. The expected
-public hostname is typically `https://staging.democratized.space` (staging),
-`https://prod.democratized.space` (production preview), or `https://democratized.space` (apex).
+Common public hostnames are:
 
-For detailed instructions on creating the Cloudflare Tunnel and DNS records, see:
-../cloudflare_tunnel.md
+- `https://staging.democratized.space` (staging)
+- `https://democratized.space` (production apex)
+- `https://prod.democratized.space` (optional preview endpoint)
+
+For tunnel setup and DNS records, see `docs/cloudflare_tunnel.md`.
 
 ## Troubleshooting
 
-- Retrieve operator logs (staging/prod):
-  1. `just dspace-debug-logs-env env=<staging|prod>` first runs `just kubeconfig-env`
-     and rewrites `~/.kube/config` to the selected `sugar-<env>` context.
-  2. Run the bundled log collector to fetch both app and ingress logs.
+- Retrieve combined app + ingress logs:
 
   ```bash
-  # Staging
   just dspace-debug-logs-env env=staging
-
-  # Production
   just dspace-debug-logs-env env=prod
   ```
 
-  This prints:
-  - dspace pod inventory in `namespace=dspace`
-  - dspace container logs (`--tail=200` for each dspace pod)
-  - Traefik ingress logs in `kube-system` (`--tail=200`)
-
-  If dspace is not in the default namespace, override it on the helper command:
-
-  ```bash
-  just dspace-debug-logs-env env=staging namespace=my-dspace-namespace
-  ```
-
-  If you already manage `KUBECONFIG` manually, you can run:
+- Direct collector (if `KUBECONFIG` is already managed):
 
   ```bash
   just dspace-debug-logs namespace=dspace
   ```
 
-  Common next steps after the bundled snapshot:
+- Live tail:
 
   ```bash
-  # Live-tail dspace logs
   kubectl -n dspace logs deploy/dspace --follow
-
-  # Re-check Traefik logs
-  kubectl -n kube-system logs -l app.kubernetes.io/name=traefik --tail=200
   ```
-
-- Inspect the release values and history:
-  - `helm -n dspace status dspace`
-  - `helm -n dspace get values dspace`
-- Check the dspace namespace for failing pods or missing ingress resources:
-  - `kubectl -n dspace get pods`
-  - `kubectl -n dspace describe ingress`
-- Validate the Cloudflare Tunnel service and route for the chosen hostname.
-- Review cluster-wide logs for Traefik or networking issues if the ingress is not reachable.

--- a/docs/apps/dspace.prod.tag
+++ b/docs/apps/dspace.prod.tag
@@ -1,3 +1,3 @@
 # Default immutable image tag for production dspace deploys.
-# Override with a newer pinned tag when promoting releases.
+# Override with a newer pinned tag for each promotion.
 v3.0.0

--- a/docs/apps/dspace.version
+++ b/docs/apps/dspace.version
@@ -1,2 +1,2 @@
-# Default dspace chart version (v3 series). Update when new v3 releases are published.
+# Default dspace chart version. Update when new chart releases are published.
 3.0.0

--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -318,9 +318,9 @@ Only create this manually if the CNAME is missing:
    - **Proxy status**: **Proxied** (orange cloud)
 4. Save the record.
 
-## Step 5 – Post-cutover redirect for `prod.` (optional finalization)
+## Step 5 – Optional redirect for `prod.` preview hostname
 
-After dspace v3 is fully promoted on `democratized.space`, convert `prod.democratized.space` to a
+After the apex site is stable on `democratized.space`, you can convert `prod.democratized.space` to a
 simple redirect (Cloudflare Redirect Rule or Page Rule) to avoid maintaining duplicate origins:
 
 - **Source**: `https://prod.democratized.space/*`
@@ -347,6 +347,6 @@ for temporary local development. See
   `http://traefik.<namespace>.svc.cluster.local:80` inside the cluster.
 - Cloudflare DNS has (or auto-created) proxied records pointing rollout hostnames to the tunnel’s
   `*.cfargotunnel.com` name.
-- After apex cutover, `prod.democratized.space` can be converted to a redirect to
+- After apex promotion, `prod.democratized.space` can be converted to a redirect to
   `https://democratized.space`.
 - The Sugarkube dspace app expects this persistent tunnel setup to be in place.

--- a/docs/examples/dspace.values.prod-subdomain.yaml
+++ b/docs/examples/dspace.values.prod-subdomain.yaml
@@ -1,5 +1,5 @@
-# Example values for deploying democratized.space v3 to the production preview subdomain.
-# Use this during rollout validation before apex cutover.
+# Example values for deploying democratized.space to the optional production preview subdomain.
+# Use this for optional canary/smoke validation before or alongside apex deploys.
 environment: prod
 
 ingress:

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -383,7 +383,7 @@ Traefik is available per the section above.
    so the tunnel can reach Traefik reliably.
 
 3. Install your app using its Helm or `just` recipe. For example, the
-   [dspace app guide](apps/dspace.md) shows how to deploy dspace v3 with a
+   [dspace app guide](apps/dspace.md) shows how to deploy dspace with a
    Traefik ingress host and tested values.
 
 4. Verify everything is healthy, then browse to the FQDN on your phone or
@@ -394,7 +394,7 @@ Traefik is available per the section above.
    ```
 
 5. Iterate new builds using your app's upgrade instructions (e.g., the dspace
-   guide covers rolling new `v3-<shortsha>` images).
+   guide covers rolling new immutable images such as `main-<shortsha>`).
 
 ## Step 1: Verify your 3-node control plane is healthy
 
@@ -597,7 +597,7 @@ companion application for your cluster.
 > **Note:** There are two ways to deploy dspace:
 > - **Manual Helm install** (documented below) by cloning the dspace repo and running
 >   `helm upgrade --install ...` directly.
-> - **Sugarkube + OCI Helm chart path** using `helm-oci-install` and the dspace v3 guide in the
+> - **Sugarkube + OCI Helm chart path** using `helm-oci-install` and the dspace guide in the
 >   dspace repo (recommended once Helm and GHCR login are working).
 >
 > For the sugarkube-centric path, see:
@@ -676,17 +676,17 @@ serving ingress, and the dspace OCI chart is already published to GHCR. The goal
 roll pods quickly without extra ceremony—Kubernetes handles the rolling update using the
 deployment's defaults.
 
-**Quick redeploy for dspace v3 (generic helper for staging, dspace helpers for production):**
+**Quick redeploy for dspace (generic helper for staging, dspace helpers for production):**
 
 Pick the values overlay for your target environment and prefer immutable image tags for production:
 
 - Staging: `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`
-- Production preview (Phase A):
+- Production preview (optional canary):
   `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod-subdomain.yaml`
-- Production apex (Phase B): `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`
+- Production apex: `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`
 
-Do not use `docs/examples/dspace.values.prod-subdomain.yaml` for Phase B apex promotion; keep that
-overlay only for Phase A preview deploys at `prod.democratized.space`.
+Do not use `docs/examples/dspace.values.prod-subdomain.yaml` for apex promotion; keep that
+overlay only for optional preview deploys at `prod.democratized.space`.
 
 ```bash
 # From the sugarkube repo root on a cluster node (staging):
@@ -695,18 +695,18 @@ just helm-oci-upgrade \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \
   values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
   version_file=docs/apps/dspace.version \
-  default_tag=v3-latest
+  default_tag=main-latest
 ```
 
-For production preview (Phase A), this guide intentionally switches from the generic
+For production preview (optional canary), this guide intentionally switches from the generic
 `helm-oci-upgrade` example to the dspace-specific helper so rollout verification and
 post-deploy checks are included by default:
 
 ```bash
-just dspace-oci-deploy-prod-subdomain tag=v3-<immutable-tag>
+just dspace-oci-deploy-prod-subdomain tag=v<semver>
 ```
 
-For production apex promotion (Phase B), use `dspace-oci-promote-prod` with a pinned tag (for example the
+For production apex promotion, use `dspace-oci-promote-prod` with a pinned tag (for example the
 value stored in `docs/apps/dspace.prod.tag`). This helper wraps `dspace-oci-deploy env=prod`, which keeps
 the same values chain as the generic path (`docs/examples/dspace.values.dev.yaml` +
 `docs/examples/dspace.values.prod.yaml`) while adding rollout/status checks:
@@ -722,7 +722,7 @@ sets `environment: dev`, `docs/examples/dspace.values.staging.yaml` sets `enviro
 `docs/examples/dspace.values.prod.yaml` sets `environment: prod`, which show up in `/healthz` and
 the homepage build badge.
 
-If you prefer a one-liner that bakes in those arguments for dspace v3, use the helper
+If you prefer a one-liner that bakes in those arguments for dspace, use the helper
 recipe (defaults to staging):
 
 ```bash
@@ -735,14 +735,14 @@ just dspace-oci-redeploy env=prod tag="$(read_prod_tag)"
 Under the hood, both commands call the shared `_helm-oci-deploy` helper via
 `helm-oci-upgrade`, performing `helm upgrade --reuse-values` against the running release
 and then forcing a `kubectl rollout restart deploy/dspace` to ensure pods recycle even
-when `v3-latest` is republished with the same tag. The helper waits for the rollout to
+when `main-latest` is republished with the same tag. The helper waits for the rollout to
 finish and exits non-zero if Kubernetes reports a failure.
 
 For immutable RC/stable validation (recommended for staging and prod), use the dedicated
 helper instead:
 
 ```bash
-just dspace-oci-deploy env=staging tag=v3-<immutable-tag>
+just dspace-oci-deploy env=staging tag=main-<shortsha>
 
 read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
 just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
@@ -754,9 +754,9 @@ just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
 `kubectl rollout status`, and prints post-deploy verification commands for `config.json`,
 `/healthz`, and `/livez` using the live ingress host (or `<dspace-host>` when none is discoverable).
 
-When you pass an image tag (including the default `v3-latest`), the helper sets
+When you pass an image tag (including the default `main-latest`), the helper sets
 `image.pullPolicy=Always` so the nodes re-check GHCR for the latest build of that tag on
-each redeploy. For production, prefer immutable tags (for example, `v3-<sha>`) if you want
+each redeploy. For production, prefer immutable tags (for example, `main-<sha>` or `v<semver>`) if you want
 to pin a specific image.
 
 **Emergency redeploy checklist:**
@@ -767,7 +767,7 @@ to pin a specific image.
     just cluster-status
     ```
 
-2. Ensure your new image is pushed and `v3-latest` (or the tag you pass via `tag=`)
+2. Ensure your new image is pushed and `main-latest` (or the tag you pass via `tag=`)
    points at the desired build (see the dspace repo docs for image build/publish steps).
 3. Run the redeploy command (`just helm-oci-upgrade ...` or `just dspace-oci-redeploy`).
 4. Verify pods and logs:
@@ -899,8 +899,8 @@ As you continue operating your cluster, these recipes will be helpful:
   use `just wipe` to clean it up, then rerun `just ha3 env=dev` to rejoin correctly.
 
 - **Emergency dspace redeploy:** Run `just dspace-oci-redeploy` to pull the latest
-  dspace v3 chart from GHCR and force a rollout restart so pods refresh to the newest
-  `v3-latest` image digest without retyping chart arguments.
+  dspace chart from GHCR and force a rollout restart so pods refresh to the newest
+  `main-latest` image digest without retyping chart arguments.
 
 ### Document outages and incidents
 

--- a/docs/raspi_cluster_operations_manual.md
+++ b/docs/raspi_cluster_operations_manual.md
@@ -204,7 +204,7 @@ but spells out the underlying commands.
    service name.
 
 4. Deploy your application (for example, follow [apps/dspace.md](apps/dspace.md)
-   to install dspace v3 with a Traefik Ingress host) and verify ingress and
+   to install dspace with a Traefik Ingress host) and verify ingress and
    pod health:
 
    ```bash

--- a/justfile
+++ b/justfile
@@ -953,7 +953,7 @@ cf-tunnel-route host='':
     set -Eeuo pipefail
 
     if [ -z "{{ host }}" ]; then
-        echo "Set host=<FQDN> (e.g., dspace-v3.example.com)." >&2
+        echo "Set host=<FQDN> (e.g., dspace-main.example.com)." >&2
         exit 1
     fi
 
@@ -1235,7 +1235,7 @@ dspace-oci-deploy env='staging' tag='':
 
     deploy_tag="$(echo "{{ tag }}" | xargs)"
     if [ -z "${deploy_tag}" ]; then
-      echo "Set tag=<immutable-tag> (for example v3-<shortsha>) for dspace immutable deploys." >&2
+      echo "Set tag=<immutable-tag> (for example main-<shortsha> or v<semver>) for dspace immutable deploys." >&2
       exit 1
     fi
     tag_lc="$(echo "${deploy_tag}" | tr '[:upper:]' '[:lower:]')"
@@ -1294,16 +1294,16 @@ dspace-oci-deploy env='staging' tag='':
       echo "  curl -fsS https://${verify_host}/livez | jq ."
     fi
 
-# Deploy dspace v3 to the production preview subdomain (prod.democratized.space).
+# Deploy dspace to the optional production preview subdomain (prod.democratized.space).
 
-# Use this before apex cutover to validate rollout and run smoke tests.
+# Use this for optional canary/smoke checks before (or alongside) apex deploys.
 dspace-oci-deploy-prod-subdomain tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
     deploy_tag="$(echo "{{ tag }}" | xargs)"
     if [ -z "${deploy_tag}" ]; then
-      echo "Set tag=<immutable-tag> (for example v3-<shortsha>) for prod subdomain deploys." >&2
+      echo "Set tag=<immutable-tag> (for example main-<shortsha> or v<semver>) for prod subdomain deploys." >&2
       exit 1
     fi
     tag_lc="$(echo "${deploy_tag}" | tr '[:upper:]' '[:lower:]')"
@@ -1362,7 +1362,7 @@ dspace-oci-promote-prod tag='':
 
     just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy env=prod tag="${deploy_tag}"
 
-# Fast redeploy of dspace v3 from GHCR (emergency push).
+# Fast redeploy of dspace from GHCR (emergency mutable-tag refresh).
 dspace-oci-redeploy env='staging' tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
@@ -1397,7 +1397,7 @@ dspace-oci-redeploy env='staging' tag='':
         exit 1
       fi
     else
-      default_tag_value="v3-latest"
+      default_tag_value="main-latest"
     fi
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \


### PR DESCRIPTION
### Motivation

- Remove one-time `v3` cutover wording and stale branch assumptions and document an ongoing promotion workflow for repeated releases.
- Align sugarkube-side operator guidance with the real cluster topology (staging on `sugarkube3/4/5`, prod on `sugarkube0/1/2`, and planned dev on `sugarkube6`).
- Encourage immutable-tag sign-offs and clear distinction between convenience tags and release tags so rollbacks and audits remain safe.

### Description

- Rewrote the DSPACE runbook at `docs/apps/dspace.md` into an evergreen steady-state guide that favors `main-<shortsha>`, `main-latest`, and `v<semver>` immutable tags and documents `prod.democratized.space` as an optional preview endpoint.
- Updated dspace-related `justfile` messaging and examples for `dspace-oci-deploy`, `dspace-oci-deploy-prod-subdomain`, `dspace-oci-promote-prod`, and `dspace-oci-redeploy` to remove `v3`-specific wording and to keep behavior backward-compatible while switching non-prod defaults from `v3-latest` to `main-latest` where appropriate.
- Adjusted example overlays and metadata files (`docs/examples/dspace.values.prod-subdomain.yaml`, `docs/apps/dspace.version`, `docs/apps/dspace.prod.tag`) and aligned nearby operational docs (`docs/raspi_cluster_operations.md`, `docs/cloudflare_tunnel.md`, `docs/raspi_cluster_operations_manual.md`) to use evergreen terminology and the actual host/env mappings.
- Preserved key safety behavior: `dspace-oci-deploy` still refuses mutable tags such as `latest` or `main` and the helper still waits for rollout/status checks; changed only comments, examples, and a small default-tag string for non-prod redeploys.

### Testing

- Searched repo for stale wording with `rg -n "v3 branch|merge v3 into main|v3-latest|v3-|cutover|Phase A|Phase B|prod.democratized.space" docs justfile` to locate and update references. 
- Ran the repository secret scan with `git diff --cached | ./scripts/scan-secrets.py`, which completed with no findings. 
- Attempted verification commands that rely on local tooling (`just --list`, `just docs-verify`, `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, `linkchecker --no-warnings README.md docs/`) but these were blocked in the current execution environment because the tools are not installed. 
- Changes are intentionally lightweight and kept backward-compatible so runtime behavior can be validated by running the normal `just` recipes on a host with `just`/Helm/kubectl available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce0e993050832f9d25a01150945962)