### PR TITLE
docs: polish DSPACE evergreen wording and verification blocks

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -35,9 +35,9 @@ Use tags by purpose:
 - **Convenience/mutable tags** for fast iteration in non-prod (for example `main-latest`).
 - **Immutable deploy tags** for sign-off, promotion, and rollback (for example
   `main-<shortsha>`, `3.0.1`, `3.1.0`).
-- In this operational guide, `main` is the normal integration line that produces
+- In this operational guide, `main` is the normal steady-state integration line for
   DSPACE-derived image tags (for example `main-<shortsha>`).
-- If the DSPACE repo uses release branches, keep them short-lived stabilization branches,
+- If the DSPACE repo uses release branches, treat them as short-lived stabilization branches,
   not long-lived environment branches.
 
 Environment overlays (`dev`/`staging`/`prod`) decide host/routing. Image tags decide the
@@ -139,7 +139,7 @@ Notes:
    just dspace-oci-promote-prod tag=3.1.0
    ```
 
-   Then verify production:
+   Then verify production apex (`https://democratized.space`):
 
    ```bash
    curl -fsS https://democratized.space/config.json | jq .
@@ -157,7 +157,7 @@ Notes:
 
 Optional only: use `dspace-oci-deploy-prod-subdomain` for preview/canary checks at
 `https://prod.democratized.space` when you explicitly want a pre-apex validation endpoint.
-It is not part of the default required deploy/promotion path.
+It is not part of the default required main → staging → apex promotion path.
 
 ## Networking via Cloudflare Tunnel
 

--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -275,7 +275,7 @@ return to a clean token-mode state:
 The installer performs a teardown-and-retry if the first rollout fails, so rerunning the recipes is
 the canonical way to recover a wedged connector without losing the saved token.
 
-## Step 3 – Publish application routes (staging + prod preview + apex)
+## Step 3 – Publish application routes (staging + optional prod preview + apex)
 
 Now that the connector is running in the cluster, configure routes from your dspace hostnames to the
 internal Traefik Service.


### PR DESCRIPTION
### Motivation
- Tighten operational guidance so `main` is explicit as the steady-state integration line for DSPACE-derived images. 
- Make verification steps fully copy/paste friendly for staging and production apex checks. 
- Ensure `prod.democratized.space` is described as an optional preview/canary endpoint, not the default production path. 

### Description
- Updated `docs/apps/dspace.md` to state that `main` is the normal steady-state integration line and to call release branches short-lived stabilization branches. 
- Ensured explicit, separate fenced command blocks for staging and production apex verification that use `curl -fsS <url>/{config.json,healthz,livez} | jq .` for easy copy/paste. 
- Reworded the preview/canary references to emphasize that `prod.democratized.space` is optional and not part of the default `main → staging → apex` promotion flow. 
- Small heading wording change in `docs/cloudflare_tunnel.md` to mark the prod preview route as optional. 

### Testing
- Ran `git diff --stat` which reported the two docs files changed and a small diff (succeeded). 
- Searched docs with `rg -n "prod\.democratized\.space|preview|canary|apex|cutover|Phase A|Phase B"` to verify consistent framing (succeeded). 
- Ran the repository secret scan via `git diff --cached | ./scripts/scan-secrets.py` during commit which completed without finding issues (succeeded). 
- Attempted but unable to run local helpers and doc checks: `just --list | rg "dspace|helm-oci"`, `just docs-verify`, `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` (each failed in this environment with `command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cef7d0c784832fa7d2657aa40644e7)