### PR TITLE
Make kubectl work without sudo by default

### DIFF
--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -422,8 +422,11 @@ prints a helpful reminder if the control plane is missing.
 ### Fix kubectl config on a node
 
 On fresh k3s installs, the admin kubeconfig at `/etc/rancher/k3s/k3s.yaml` is
-root-owned. If you run `kubectl` as `pi`, it falls back to `localhost:8080` and
-fails. Fix that per node with:
+root-owned. Sugarkube now auto-copies this file to the default user kubeconfig
+(`~/.kube/config`) during `just up <env>` and when running `just status`, so
+plain `kubectl` should work without `sudo` by default.
+
+If you ever need to repair it manually per node, run:
 
 ```bash
 just kubeconfig

--- a/justfile
+++ b/justfile
@@ -195,7 +195,13 @@ prereqs:
 # Check cluster health by displaying all nodes (guards against running before k3s is installed).
 status:
     if ! command -v k3s >/dev/null 2>&1; then printf '%s\n' 'k3s is not installed yet.' 'Visit https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md.' 'Follow the instructions in that guide before rerunning this command.'; exit 0; fi
-    sudo k3s kubectl get nodes -o wide
+    scripts/ensure_user_kubeconfig.sh || true
+    if [ -z "${KUBECONFIG:-}" ]; then export KUBECONFIG="${HOME}/.kube/config"; fi
+    if command -v kubectl >/dev/null 2>&1 && [ -r "${KUBECONFIG}" ]; then
+        kubectl get nodes -o wide
+    else
+        sudo k3s kubectl get nodes -o wide
+    fi
 
 # Show a summarized status of the HA cluster, Helm CLI, and Traefik ingress.
 

--- a/scripts/lib/kubeconfig.sh
+++ b/scripts/lib/kubeconfig.sh
@@ -44,19 +44,50 @@ kubeconfig::resolve_home() {
   getent passwd "${target_user}" 2>/dev/null | cut -d: -f6 | head -n1
 }
 
+kubeconfig::_user_exists() {
+  local username
+  username="$1"
+  id -u "${username}" >/dev/null 2>&1
+}
+
+kubeconfig::resolve_target_user() {
+  if [ -n "${SUGARKUBE_KUBECONFIG_USER:-}" ]; then
+    printf '%s' "${SUGARKUBE_KUBECONFIG_USER}"
+    return 0
+  fi
+
+  if [ -n "${SUDO_USER:-}" ] && kubeconfig::_user_exists "${SUDO_USER}"; then
+    printf '%s' "${SUDO_USER}"
+    return 0
+  fi
+
+  if [ "$(id -u)" -ne 0 ]; then
+    id -un
+    return 0
+  fi
+
+  if kubeconfig::_user_exists pi; then
+    printf 'pi'
+    return 0
+  fi
+
+  id -un
+}
+
 # Ensures that the target user's kubeconfig file (~/.kube/config) exists and is
 # properly owned.
 #
 # Behavior:
 #   - If /etc/rancher/k3s/k3s.yaml is missing, does nothing and returns 0.
 #   - Determines the target user using (in order): SUGARKUBE_KUBECONFIG_USER,
-#     SUDO_USER, or current user.
+#     SUDO_USER, current user, or "pi" when running as root on Pi images.
 #   - Determines the target home directory using SUGARKUBE_KUBECONFIG_HOME, or
 #     system/user lookup.
 #   - Creates ~/.kube directory if missing, copies k3s.yaml to ~/.kube/config if
 #     missing or stale.
 #   - Sets ownership and permissions on ~/.kube/config and ~/.kube.
-#   - Adds 'export KUBECONFIG=$HOME/.kube/config' to ~/.bashrc if not present.
+#   - Adds 'export KUBECONFIG=$HOME/.kube/config' to ~/.bashrc and ~/.profile
+#     if not present.
 #
 # Supported environment variables:
 #   - SUGARKUBE_KUBECONFIG_USER: Username to own the kubeconfig.
@@ -71,9 +102,9 @@ kubeconfig::ensure_user_kubeconfig() {
     return 0
   fi
 
-  local target_user target_home kubeconfig_path kube_dir bashrc_path uid gid
+  local target_user target_home kubeconfig_path kube_dir bashrc_path profile_path uid gid
 
-  target_user="${SUGARKUBE_KUBECONFIG_USER:-${SUDO_USER:-$(id -un)}}"
+  target_user="$(kubeconfig::resolve_target_user)"
   target_home="$(kubeconfig::resolve_home "${target_user}")"
 
   if [ -z "${target_home}" ]; then
@@ -83,6 +114,7 @@ kubeconfig::ensure_user_kubeconfig() {
   kube_dir="${target_home%/}/.kube"
   kubeconfig_path="${kube_dir}/config"
   bashrc_path="${target_home%/}/.bashrc"
+  profile_path="${target_home%/}/.profile"
 
   if ! uid="$(id -u "${target_user}" 2>/dev/null)"; then
     return 0
@@ -103,20 +135,20 @@ kubeconfig::ensure_user_kubeconfig() {
   kubeconfig::_with_privilege chmod 600 "${kubeconfig_path}"
   kubeconfig::_with_privilege chmod 700 "${kube_dir}"
 
-  if [ -n "${bashrc_path}" ]; then
-    if [ ! -e "${bashrc_path}" ]; then
-      kubeconfig::_with_privilege touch "${bashrc_path}"
-      kubeconfig::_with_privilege chown "${uid}:${gid}" "${bashrc_path}"
+  for shell_file in "${bashrc_path}" "${profile_path}"; do
+    if [ ! -e "${shell_file}" ]; then
+      kubeconfig::_with_privilege touch "${shell_file}"
+      kubeconfig::_with_privilege chown "${uid}:${gid}" "${shell_file}"
     fi
 
     if ! grep -qE '^\s*export\s+KUBECONFIG=\$HOME/\.kube/config\s*$' \
-      "${bashrc_path}" 2>/dev/null; then
-      kubeconfig::_with_privilege tee -a "${bashrc_path}" >/dev/null <<'EOF'
+      "${shell_file}" 2>/dev/null; then
+      kubeconfig::_with_privilege tee -a "${shell_file}" >/dev/null <<'EOF'
 export KUBECONFIG=$HOME/.kube/config
 EOF
-      kubeconfig::_with_privilege chown "${uid}:${gid}" "${bashrc_path}"
+      kubeconfig::_with_privilege chown "${uid}:${gid}" "${shell_file}"
     fi
-  fi
+  done
 
   return 0
 }

--- a/tests/test_kubeconfig_recipe.py
+++ b/tests/test_kubeconfig_recipe.py
@@ -109,3 +109,6 @@ users:
     assert "sugar-dev" in contents
     assert "current-context: sugar-dev" in contents
     assert "PLACEHOLDER" not in contents
+
+    profile_contents = (home / ".profile").read_text(encoding="utf-8")
+    assert "export KUBECONFIG=$HOME/.kube/config" in profile_contents

--- a/tests/test_status_recipe.py
+++ b/tests/test_status_recipe.py
@@ -88,8 +88,8 @@ def test_status_recipe_handles_missing_k3s(tmp_path: Path) -> None:
     assert "sudo should not run" not in result.stderr
 
 
-def test_status_recipe_invokes_k3s_when_available(tmp_path: Path) -> None:
-    """Once k3s is on the PATH the recipe should call through to kubectl."""
+def test_status_recipe_prefers_user_kubectl_when_available(tmp_path: Path) -> None:
+    """Once kubeconfig is prepared, status should use plain kubectl."""
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -106,39 +106,61 @@ def test_status_recipe_invokes_k3s_when_available(tmp_path: Path) -> None:
     )
     sudo.chmod(0o755)
 
-    k3s_log = tmp_path / "k3s.log"
     k3s = bin_dir / "k3s"
     k3s.write_text(
         textwrap.dedent(
             """\
-            #!/usr/bin/env python3
-            import os
-            import sys
-
-
-            def main() -> None:
-                log_path = os.environ["TEST_K3S_LOG"]
-                with open(log_path, "w", encoding="utf-8") as handle:
-                    handle.write(" ".join(sys.argv[1:]))
-                print("fake k3s output")
-
-
-            if __name__ == "__main__":
-                main()
+            #!/usr/bin/env bash
+            exit 0
             """
         ),
         encoding="utf-8",
     )
     k3s.chmod(0o755)
 
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    ensure = scripts_dir / "ensure_user_kubeconfig.sh"
+    ensure.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            mkdir -p "${HOME}/.kube"
+            printf 'apiVersion: v1\\nclusters: []\\ncontexts: []\\nusers: []\\n' > "${HOME}/.kube/config"
+            """
+        ),
+        encoding="utf-8",
+    )
+    ensure.chmod(0o755)
+
+    kubectl_log = tmp_path / "kubectl.log"
+    kubectl = bin_dir / "kubectl"
+    kubectl.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import os
+            import sys
+
+            with open(os.environ["TEST_KUBECTL_LOG"], "w", encoding="utf-8") as handle:
+                handle.write(" ".join(sys.argv[1:]))
+            print("fake kubectl output")
+            """
+        ),
+        encoding="utf-8",
+    )
+    kubectl.chmod(0o755)
+
     env = os.environ.copy()
     env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
-    env["TEST_K3S_LOG"] = str(k3s_log)
+    env["TEST_KUBECTL_LOG"] = str(kubectl_log)
 
     script = _write_status_script(tmp_path)
 
     result = subprocess.run(
         [str(script)],
+        cwd=tmp_path,
         env=env,
         capture_output=True,
         text=True,
@@ -146,6 +168,6 @@ def test_status_recipe_invokes_k3s_when_available(tmp_path: Path) -> None:
     )
 
     assert result.returncode == 0, result.stderr
-    assert "fake k3s output" in result.stdout
+    assert "fake kubectl output" in result.stdout
     assert "raspi_cluster_setup.md" not in result.stdout
-    assert k3s_log.read_text(encoding="utf-8") == "kubectl get nodes -o wide"
+    assert kubectl_log.read_text(encoding="utf-8") == "get nodes -o wide"


### PR DESCRIPTION
### Motivation
- Users on Pi images must currently run `sudo k3s kubectl` because the admin kubeconfig is root-owned; the change ensures plain `kubectl` works for the intended non-root operator by default.

### Description
- Add `kubeconfig::resolve_target_user` and supporting `_user_exists` to prefer `SUGARKUBE_KUBECONFIG_USER`, `SUDO_USER`, the current non-root user, and a `pi` fallback when running as root.
- Auto-copy `/etc/rancher/k3s/k3s.yaml` into the resolved user's `~/.kube/config`, set appropriate ownership and mode, and persist `export KUBECONFIG=$HOME/.kube/config` into both `~/.bashrc` and `~/.profile`.
- Change the `status` recipe in `justfile` to call `scripts/ensure_user_kubeconfig.sh`, export a default `KUBECONFIG` and prefer plain `kubectl get nodes` when usable, falling back to `sudo k3s kubectl` otherwise.
- Update tests (`tests/test_status_recipe.py`, `tests/test_kubeconfig_recipe.py`) and documentation (`docs/raspi_cluster_operations.md`) to cover and describe the new behavior.

### Testing
- Ran `pytest -q tests/test_status_recipe.py tests/test_kubeconfig_recipe.py` which passed with `2 passed, 1 skipped`.
- Attempted `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/`, but those tools were not available in the execution environment so they did not run here.
- Ran the repository secrets scan via `git diff --cached | ./scripts/scan-secrets.py` which completed without reporting issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf07c1e554832fafc26022a4d855c0)