### PR TITLE
auto-provision kubeconfig for pi so `kubectl` works without sudo

### DIFF
--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -249,33 +249,27 @@ Verification steps and troubleshooting live in
 
 ### Configure kubectl for the `pi` user on the cluster nodes
 
-`k3s` writes its kubeconfig to `/etc/rancher/k3s/k3s.yaml` as `root`, so `kubectl` defaults to requiring `sudo` on the Pis. Copy the kubeconfig into the `pi` home directory, fix ownership, and lock down permissions to use `kubectl` without `sudo` on each node:
+`just up <env>` now auto-configures a user kubeconfig for both the invoking user
+and the default `pi` account whenever `/etc/rancher/k3s/k3s.yaml` is present.
+That means `kubectl` should work without `sudo` by default after bootstrap:
 
 ```bash
-# As root or via sudo on the node:
-sudo mkdir -p /home/pi/.kube
-sudo cp /etc/rancher/k3s/k3s.yaml /home/pi/.kube/config
-sudo chown pi:pi /home/pi/.kube/config
-sudo chmod 600 /home/pi/.kube/config
-
-# Then as pi:
+# As pi (or the user that ran just up):
 kubectl get nodes
 ```
 
-By default, `k3s kubectl` looks at `/etc/rancher/k3s/k3s.yaml`. To tell `kubectl` to use the
-copy in your home directory, set `KUBECONFIG` for the `pi` user:
+If a node was installed before this automation landed, run:
 
 ```bash
-# As pi:
-echo 'export KUBECONFIG=$HOME/.kube/config' >> ~/.bashrc
-source ~/.bashrc
-
-kubectl get nodes
+just kubeconfig
 ```
 
-After this, `kubectl` (and `k3s kubectl`) reads `~/.kube/config` for `pi` and no longer needs
-`sudo` on that node. On your workstation, `just kubeconfig-env env=dev` remains the recommended way
-to download the kubeconfig from the cluster.
+This syncs `/etc/rancher/k3s/k3s.yaml` into `~/.kube/config`, ensures file ownership and
+permissions are correct, and appends `export KUBECONFIG=$HOME/.kube/config` to `~/.bashrc`
+when missing.
+
+On your workstation, `just kubeconfig-env env=dev` remains the recommended way to download
+the kubeconfig from the cluster.
 
 ## How Discovery Works
 

--- a/scripts/lib/kubeconfig.sh
+++ b/scripts/lib/kubeconfig.sh
@@ -31,7 +31,9 @@ kubeconfig::resolve_home() {
   local target_user
   target_user="$1"
 
-  if [ -n "${SUGARKUBE_KUBECONFIG_HOME:-}" ]; then
+  if [ -n "${SUGARKUBE_KUBECONFIG_HOME:-}" ] && \
+    { [ -z "${SUGARKUBE_KUBECONFIG_USER:-}" ] || \
+      [ "${target_user}" = "${SUGARKUBE_KUBECONFIG_USER:-}" ]; }; then
     printf '%s' "${SUGARKUBE_KUBECONFIG_HOME}"
     return 0
   fi
@@ -61,20 +63,25 @@ kubeconfig::resolve_home() {
 # Supported environment variables:
 #   - SUGARKUBE_KUBECONFIG_USER: Username to own the kubeconfig.
 #   - SUGARKUBE_KUBECONFIG_HOME: Home directory to use for kubeconfig.
+#   - SUGARKUBE_KUBECONFIG_ADDITIONAL_USERS: Space-delimited users that should
+#     also receive kubeconfig copies. Defaults to "pi".
 #   - SUDO_USER: Used as fallback for target user if running under sudo.
 #
 # Return behavior:
 #   - Always returns 0, even on failure, for graceful degradation.
 #   - This allows scripts to proceed even if kubeconfig setup is incomplete.
-kubeconfig::ensure_user_kubeconfig() {
-  if ! kubeconfig::_with_privilege test -e /etc/rancher/k3s/k3s.yaml; then
+kubeconfig::_ensure_for_target() {
+  local target_user="$1"
+  local target_home="${2:-}"
+  local kubeconfig_path kube_dir bashrc_path uid gid
+
+  if [ -z "${target_user}" ]; then
     return 0
   fi
 
-  local target_user target_home kubeconfig_path kube_dir bashrc_path uid gid
-
-  target_user="${SUGARKUBE_KUBECONFIG_USER:-${SUDO_USER:-$(id -un)}}"
-  target_home="$(kubeconfig::resolve_home "${target_user}")"
+  if [ -z "${target_home}" ]; then
+    target_home="$(kubeconfig::resolve_home "${target_user}")"
+  fi
 
   if [ -z "${target_home}" ]; then
     return 0
@@ -117,6 +124,31 @@ EOF
       kubeconfig::_with_privilege chown "${uid}:${gid}" "${bashrc_path}"
     fi
   fi
+
+  return 0
+}
+
+kubeconfig::ensure_user_kubeconfig() {
+  if ! kubeconfig::_with_privilege test -e /etc/rancher/k3s/k3s.yaml; then
+    return 0
+  fi
+
+  local target_user target_home additional_users extra_user
+  target_user="${SUGARKUBE_KUBECONFIG_USER:-${SUDO_USER:-$(id -un)}}"
+  target_home="${SUGARKUBE_KUBECONFIG_HOME:-}"
+  additional_users="${SUGARKUBE_KUBECONFIG_ADDITIONAL_USERS:-pi}"
+
+  kubeconfig::_ensure_for_target "${target_user}" "${target_home}"
+
+  for extra_user in ${additional_users}; do
+    if [ -z "${extra_user}" ] || [ "${extra_user}" = "${target_user}" ]; then
+      continue
+    fi
+    if ! id -u "${extra_user}" >/dev/null 2>&1; then
+      continue
+    fi
+    kubeconfig::_ensure_for_target "${extra_user}"
+  done
 
   return 0
 }

--- a/tests/test_kubeconfig_lib.py
+++ b/tests/test_kubeconfig_lib.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def _write_fake_id(bin_dir: Path) -> None:
+    script = bin_dir / "id"
+    script.write_text(
+        textwrap.dedent(
+            """#!/usr/bin/env python3
+import sys
+
+USERS = {"tester": ("1000", "1000"), "pi": ("1001", "1001")}
+
+args = sys.argv[1:]
+if args == ["-un"]:
+    print("tester")
+    sys.exit(0)
+if len(args) == 2 and args[0] == "-u" and args[1] in USERS:
+    print(USERS[args[1]][0])
+    sys.exit(0)
+if len(args) == 2 and args[0] == "-g" and args[1] in USERS:
+    print(USERS[args[1]][1])
+    sys.exit(0)
+sys.exit(1)
+"""
+        ),
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+
+
+def _write_fake_getent(bin_dir: Path, tester_home: Path, pi_home: Path) -> None:
+    script = bin_dir / "getent"
+    script.write_text(
+        textwrap.dedent(
+            f"""#!/usr/bin/env python3
+import sys
+
+if len(sys.argv) == 3 and sys.argv[1] == "passwd":
+    if sys.argv[2] == "tester":
+        print("tester:x:1000:1000::" + {str(tester_home)!r} + ":/bin/bash")
+        sys.exit(0)
+    if sys.argv[2] == "pi":
+        print("pi:x:1001:1001::" + {str(pi_home)!r} + ":/bin/bash")
+        sys.exit(0)
+sys.exit(2)
+"""
+        ),
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+
+
+def _write_fake_sudo(bin_dir: Path) -> None:
+    script = bin_dir / "sudo"
+    script.write_text(
+        textwrap.dedent(
+            """#!/usr/bin/env python3
+import os
+import subprocess
+import sys
+
+args = sys.argv[1:]
+if not args:
+    sys.exit(1)
+
+if args[0] == "chown":
+    sys.exit(0)
+
+source = os.environ.get("TEST_K3S_SOURCE")
+if source:
+    remapped = []
+    for item in args:
+        if item == "/etc/rancher/k3s/k3s.yaml":
+            remapped.append(source)
+        else:
+            remapped.append(item)
+    args = remapped
+
+result = subprocess.run(args, env=os.environ)
+sys.exit(result.returncode)
+"""
+        ),
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+
+
+def test_kubeconfig_syncs_additional_pi_user(tmp_path: Path) -> None:
+    tester_home = tmp_path / "tester-home"
+    pi_home = tmp_path / "pi-home"
+    tester_home.mkdir()
+    pi_home.mkdir()
+
+    source_config = tmp_path / "k3s.yaml"
+    source_config.write_text(
+        textwrap.dedent(
+            """apiVersion: v1
+clusters:
+- name: sugar
+  cluster:
+    server: https://127.0.0.1:6443
+"""
+        ),
+        encoding="utf-8",
+    )
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_id(bin_dir)
+    _write_fake_getent(bin_dir, tester_home, pi_home)
+    _write_fake_sudo(bin_dir)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            "HOME": str(tester_home),
+            "TEST_K3S_SOURCE": str(source_config),
+            "SUGARKUBE_KUBECONFIG_USER": "tester",
+            "SUGARKUBE_KUBECONFIG_HOME": str(tester_home),
+            "SUGARKUBE_KUBECONFIG_ADDITIONAL_USERS": "pi",
+        }
+    )
+
+    result = subprocess.run(
+        [
+            "bash",
+            "-lc",
+            "source scripts/lib/kubeconfig.sh && kubeconfig::ensure_user_kubeconfig",
+        ],
+        cwd=Path(__file__).resolve().parent.parent,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+    tester_cfg = tester_home / ".kube" / "config"
+    pi_cfg = pi_home / ".kube" / "config"
+    assert tester_cfg.exists()
+    assert pi_cfg.exists()
+    assert tester_cfg.read_text(encoding="utf-8") == source_config.read_text(encoding="utf-8")
+    assert pi_cfg.read_text(encoding="utf-8") == source_config.read_text(encoding="utf-8")
+
+    assert "export KUBECONFIG=$HOME/.kube/config" in (tester_home / ".bashrc").read_text(
+        encoding="utf-8"
+    )
+    assert "export KUBECONFIG=$HOME/.kube/config" in (pi_home / ".bashrc").read_text(
+        encoding="utf-8"
+    )


### PR DESCRIPTION
### Motivation
- On Pi nodes `k3s` writes the admin kubeconfig to `/etc/rancher/k3s/k3s.yaml` which leaves `kubectl` requiring `sudo` for normal users, so the cluster bring-up should provision a user-owned kubeconfig by default.

### Description
- Refactor and introduce `kubeconfig::_ensure_for_target` in `scripts/lib/kubeconfig.sh` to perform per-user provisioning and home resolution. 
- Make `kubeconfig::ensure_user_kubeconfig` copy `/etc/rancher/k3s/k3s.yaml` into the invoking user and additional users (controlled by `SUGARKUBE_KUBECONFIG_ADDITIONAL_USERS`, default `pi`).
- Scope `SUGARKUBE_KUBECONFIG_HOME` so it only applies to the explicitly targeted user to avoid incorrect home reuse for fallback users. 
- Add `tests/test_kubeconfig_lib.py` exercising multi-user sync and update `docs/raspi_cluster_setup.md` to document the new default behavior and remediation via `just kubeconfig`.

### Testing
- Ran `python -m pytest tests/test_kubeconfig_lib.py tests/test_kubeconfig_recipe.py` and the suite returned `1 passed, 1 skipped`.
- Attempted to run `pre-commit`, `pyspelling`, and `linkchecker` but those tools are not installed in the execution environment so they were skipped. 
- Ran the repository secret scan via `git diff --cached | ./scripts/scan-secrets.py` which completed without findings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf07c1e554832fafc26022a4d855c0)