### PR TITLE
Make kubectl usable without sudo on Pi by default

### DIFF
--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -249,7 +249,26 @@ Verification steps and troubleshooting live in
 
 ### Configure kubectl for the `pi` user on the cluster nodes
 
-`k3s` writes its kubeconfig to `/etc/rancher/k3s/k3s.yaml` as `root`, so `kubectl` defaults to requiring `sudo` on the Pis. Copy the kubeconfig into the `pi` home directory, fix ownership, and lock down permissions to use `kubectl` without `sudo` on each node:
+`just up <env>` now configures rootless `kubectl` automatically by:
+
+- installing k3s with `K3S_KUBECONFIG_MODE=644` (so `/etc/rancher/k3s/k3s.yaml` is readable), and
+- copying kubeconfig to `~/.kube/config` for the invoking user while persisting
+  `export KUBECONFIG=$HOME/.kube/config` in shell init files.
+
+On a freshly provisioned Pi, this means you can usually run `kubectl` directly
+right after install (or after opening a new shell):
+
+```bash
+kubectl get nodes
+```
+
+If you need to re-apply kubeconfig setup manually on an existing node, run:
+
+```bash
+just kubeconfig
+```
+
+Equivalent manual commands are:
 
 ```bash
 # As root or via sudo on the node:
@@ -258,19 +277,9 @@ sudo cp /etc/rancher/k3s/k3s.yaml /home/pi/.kube/config
 sudo chown pi:pi /home/pi/.kube/config
 sudo chmod 600 /home/pi/.kube/config
 
-# Then as pi:
-kubectl get nodes
-```
-
-By default, `k3s kubectl` looks at `/etc/rancher/k3s/k3s.yaml`. To tell `kubectl` to use the
-copy in your home directory, set `KUBECONFIG` for the `pi` user:
-
-```bash
-# As pi:
+# Persist kubeconfig for new shells:
 echo 'export KUBECONFIG=$HOME/.kube/config' >> ~/.bashrc
-source ~/.bashrc
-
-kubectl get nodes
+echo 'export KUBECONFIG=$HOME/.kube/config' >> ~/.profile
 ```
 
 After this, `kubectl` (and `k3s kubectl`) reads `~/.kube/config` for `pi` and no longer needs

--- a/justfile
+++ b/justfile
@@ -195,7 +195,9 @@ prereqs:
 # Check cluster health by displaying all nodes (guards against running before k3s is installed).
 status:
     if ! command -v k3s >/dev/null 2>&1; then printf '%s\n' 'k3s is not installed yet.' 'Visit https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md.' 'Follow the instructions in that guide before rerunning this command.'; exit 0; fi
-    sudo k3s kubectl get nodes -o wide
+    scripts/ensure_user_kubeconfig.sh || true
+    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+    kubectl get nodes -o wide
 
 # Show a summarized status of the HA cluster, Helm CLI, and Traefik ingress.
 

--- a/scripts/k3s-discover.sh
+++ b/scripts/k3s-discover.sh
@@ -3819,7 +3819,10 @@ ensure_time_sync() {
 
 build_install_env() {
   local -n _target=$1
-  _target=("INSTALL_K3S_CHANNEL=${K3S_CHANNEL:-stable}")
+  _target=(
+    "INSTALL_K3S_CHANNEL=${K3S_CHANNEL:-stable}"
+    "K3S_KUBECONFIG_MODE=${SUGARKUBE_K3S_KUBECONFIG_MODE:-644}"
+  )
   if [ -n "${TOKEN:-}" ]; then
     _target+=("K3S_TOKEN=${TOKEN}")
   fi

--- a/scripts/lib/kubeconfig.sh
+++ b/scripts/lib/kubeconfig.sh
@@ -56,7 +56,8 @@ kubeconfig::resolve_home() {
 #   - Creates ~/.kube directory if missing, copies k3s.yaml to ~/.kube/config if
 #     missing or stale.
 #   - Sets ownership and permissions on ~/.kube/config and ~/.kube.
-#   - Adds 'export KUBECONFIG=$HOME/.kube/config' to ~/.bashrc if not present.
+#   - Adds 'export KUBECONFIG=$HOME/.kube/config' to common shell init files
+#     (for example ~/.bashrc and ~/.profile) if not present.
 #
 # Supported environment variables:
 #   - SUGARKUBE_KUBECONFIG_USER: Username to own the kubeconfig.
@@ -71,7 +72,7 @@ kubeconfig::ensure_user_kubeconfig() {
     return 0
   fi
 
-  local target_user target_home kubeconfig_path kube_dir bashrc_path uid gid
+  local target_user target_home kubeconfig_path kube_dir uid gid
 
   target_user="${SUGARKUBE_KUBECONFIG_USER:-${SUDO_USER:-$(id -un)}}"
   target_home="$(kubeconfig::resolve_home "${target_user}")"
@@ -82,7 +83,6 @@ kubeconfig::ensure_user_kubeconfig() {
 
   kube_dir="${target_home%/}/.kube"
   kubeconfig_path="${kube_dir}/config"
-  bashrc_path="${target_home%/}/.bashrc"
 
   if ! uid="$(id -u "${target_user}" 2>/dev/null)"; then
     return 0
@@ -103,20 +103,21 @@ kubeconfig::ensure_user_kubeconfig() {
   kubeconfig::_with_privilege chmod 600 "${kubeconfig_path}"
   kubeconfig::_with_privilege chmod 700 "${kube_dir}"
 
-  if [ -n "${bashrc_path}" ]; then
-    if [ ! -e "${bashrc_path}" ]; then
-      kubeconfig::_with_privilege touch "${bashrc_path}"
-      kubeconfig::_with_privilege chown "${uid}:${gid}" "${bashrc_path}"
+  local shell_init_path
+  for shell_init_path in "${target_home%/}/.bashrc" "${target_home%/}/.profile"; do
+    if [ ! -e "${shell_init_path}" ]; then
+      kubeconfig::_with_privilege touch "${shell_init_path}"
+      kubeconfig::_with_privilege chown "${uid}:${gid}" "${shell_init_path}"
     fi
 
     if ! grep -qE '^\s*export\s+KUBECONFIG=\$HOME/\.kube/config\s*$' \
-      "${bashrc_path}" 2>/dev/null; then
-      kubeconfig::_with_privilege tee -a "${bashrc_path}" >/dev/null <<'EOF'
+      "${shell_init_path}" 2>/dev/null; then
+      kubeconfig::_with_privilege tee -a "${shell_init_path}" >/dev/null <<'EOF'
 export KUBECONFIG=$HOME/.kube/config
 EOF
-      kubeconfig::_with_privilege chown "${uid}:${gid}" "${bashrc_path}"
+      kubeconfig::_with_privilege chown "${uid}:${gid}" "${shell_init_path}"
     fi
-  fi
+  done
 
   return 0
 }

--- a/tests/scripts/test_kubectl_default_access.py
+++ b/tests/scripts/test_kubectl_default_access.py
@@ -1,0 +1,29 @@
+"""Regression tests for rootless kubectl defaults on Pi nodes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+K3S_DISCOVER = Path(__file__).resolve().parents[2] / "scripts" / "k3s-discover.sh"
+KUBECONFIG_LIB = Path(__file__).resolve().parents[2] / "scripts" / "lib" / "kubeconfig.sh"
+JUSTFILE = Path(__file__).resolve().parents[2] / "justfile"
+
+
+def test_k3s_install_sets_world_readable_kubeconfig_mode() -> None:
+    script = K3S_DISCOVER.read_text(encoding="utf-8")
+
+    assert '"K3S_KUBECONFIG_MODE=${SUGARKUBE_K3S_KUBECONFIG_MODE:-644}"' in script
+
+
+def test_ensure_user_kubeconfig_persists_env_in_profile_and_bashrc() -> None:
+    script = KUBECONFIG_LIB.read_text(encoding="utf-8")
+
+    assert 'for shell_init_path in "${target_home%/}/.bashrc" "${target_home%/}/.profile"' in script
+    assert "export KUBECONFIG=$HOME/.kube/config" in script
+
+
+def test_status_recipe_uses_user_kubectl_without_sudo() -> None:
+    justfile = JUSTFILE.read_text(encoding="utf-8")
+
+    assert "scripts/ensure_user_kubeconfig.sh || true" in justfile
+    assert "kubectl get nodes -o wide" in justfile


### PR DESCRIPTION
### Motivation
- Users must currently run `sudo` to use `kubectl` on a freshly-provisioned Pi because k3s writes `/etc/rancher/k3s/k3s.yaml` as root and kubeconfig is not exported into the invoking user environment.
- The goal is to make `kubectl` available to the invoking user immediately after `just up <env>` with minimal manual steps.

### Description
- Set `K3S_KUBECONFIG_MODE=${SUGARKUBE_K3S_KUBECONFIG_MODE:-644}` in the shared install environment in `scripts/k3s-discover.sh` so k3s writes a world-readable kubeconfig by default (`build_install_env`).
- Improve `scripts/lib/kubeconfig.sh::kubeconfig::ensure_user_kubeconfig` to persist `KUBECONFIG=$HOME/.kube/config` into common shell init files (`~/.bashrc` and `~/.profile`) and to iterate those files when ensuring the export is present.
- Update the `status` recipe in `justfile` to call `scripts/ensure_user_kubeconfig.sh || true`, export `KUBECONFIG` to the user path, and run `kubectl get nodes -o wide` instead of `sudo k3s kubectl ...` so the plain `kubectl` path works without `sudo`.
- Document the new behavior in `docs/raspi_cluster_setup.md` and add regression tests in `tests/scripts/test_kubectl_default_access.py` to lock the behavior in place.

### Testing
- Ran `pytest -q tests/scripts/test_kubectl_default_access.py` and it passed (`3 passed`).
- Ran `pytest -q tests/test_up_recipe_calls.py` and it passed (`1 passed`).
- Attempted `pre-commit run --all-files` but `pre-commit` was not available in the execution environment (`/bin/bash: line 1: pre-commit: command not found`).
- Executed `git diff --cached | ./scripts/scan-secrets.py` (repository secret scan) with no failures reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf07c1e554832fafc26022a4d855c0)