### PR TITLE
Implement robust Tailscale remote-ops workflow

### DIFF
--- a/docs/design/tailscale-remote-ops.md
+++ b/docs/design/tailscale-remote-ops.md
@@ -194,3 +194,55 @@ Do not rewire existing cluster networking during rollout.
 - [ ] Local LAN/mDNS workflows still work as before.
 - [ ] No private values are present in docs (IPs, domains, tailnet names, usernames, tokens,
       copied private outputs).
+
+
+## Implementation status in this repository
+
+The remote-operations design is now implemented with an explicit helper script and
+`just` wrappers:
+
+- `scripts/tailscale_remote_ops.sh install` downloads and runs the upstream installer with
+  a temporary file lifecycle.
+- `scripts/tailscale_remote_ops.sh up` provides guarded argument parsing, preflight checks,
+  and safer auth-key sourcing (`--auth-key-file` or `--auth-key-env`).
+- `scripts/tailscale_remote_ops.sh status` supports both human output and `--json` output for
+  automation.
+- `just tailscale-install`, `just tailscale-up`, and `just tailscale-status` now delegate to
+  the helper script so local and CI behavior stay consistent.
+
+### Recommended auth-key handling
+
+Prefer one of these flows:
+
+```bash
+# Option A: env var (ephemeral shell)
+export TS_AUTHKEY='tskey-...'
+just tailscale-up extra_args='--ssh --accept-routes'
+
+# Option B: key file (root-readable and private)
+printf '%s' 'tskey-...' > ~/.config/sugarkube/tailscale.auth
+chmod 600 ~/.config/sugarkube/tailscale.auth
+just tailscale-up auth_key_file="$HOME/.config/sugarkube/tailscale.auth"   extra_args='--ssh --accept-routes'
+```
+
+The legacy `auth_key=...` recipe argument is still supported for compatibility, but is
+considered deprecated because it is easier to leak in shell history.
+
+## Test and verification plan
+
+Use these checks when changing tailscale remote-ops logic:
+
+```bash
+# Unit + integration-style script coverage
+pytest tests/scripts/test_tailscale_remote_ops.py
+
+# E2E recipe-level flow through `just`
+pytest tests/test_tailscale_remote_ops_e2e.py
+```
+
+These tests validate:
+
+- key-file and env-var auth key handling,
+- `tailscale up` argument forwarding,
+- JSON status output behavior, and
+- end-to-end integration between `just` recipes and the helper script.

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -34,6 +34,7 @@ logs, preparing Helm, and rolling out real workloads like
 - Deploy the democratized.space (dspace) application
 - Hook your cluster into Flux for GitOps-managed releases
 - Learn operational recipes for day-to-day cluster management
+- Add secure remote access with the Tailscale remote-ops flow
 
 ## Golden path: HA dev cluster → Helm → Traefik → workloads
 
@@ -64,6 +65,21 @@ Follow this sequence after imaging and booting the Pis:
 4. **Deploy workloads:** Continue with the workload sections in this guide (for example,
    [token.place](./pi_token_dspace.md) or [dspace](https://github.com/democratizedspace/dspace)) once
    ingress is healthy.
+
+
+## Remote operations over Tailscale (recommended)
+
+After the HA cluster is healthy, add per-node tailnet access using the design in
+[design/tailscale-remote-ops.md](./design/tailscale-remote-ops.md).
+
+```bash
+just tailscale-install
+just tailscale-up extra_args='--ssh --accept-routes'
+just tailscale-status
+```
+
+For production hygiene, prefer `auth_key_file=...` over inline keys so credentials are
+less likely to leak into shell history.
 
 ## Install Helm (prerequisite for Helm workloads)
 

--- a/docs/software/index.md
+++ b/docs/software/index.md
@@ -36,6 +36,8 @@ and supporting services stay healthy.
   debugging.
 - [operations/security-checklist.md](../operations/security-checklist.md) — record
   credential rotations and post-maintenance evidence.
+- [design/tailscale-remote-ops.md](../design/tailscale-remote-ops.md) — secure remote
+  operations topology plus `just tailscale-*` workflow details.
 - [projects-compose.md](../projects-compose.md) — run token.place and dspace via
   Docker Compose.
 - [pi_token_dspace.md](../pi_token_dspace.md) — expose token.place/dspace through

--- a/justfile
+++ b/justfile
@@ -196,19 +196,48 @@ deps:
     sudo -E scripts/install_deps.sh
 
 tailscale-install:
-    curl -fsSL https://tailscale.com/install.sh | sh
+    scripts/tailscale_remote_ops.sh install
 
-tailscale-up auth_key='' extra_args='':
+tailscale-up auth_key='' auth_key_file='' extra_args='':
     #!/usr/bin/env bash
     set -euo pipefail
-    if [ -n "{{ auth_key }}" ]; then
-        sudo tailscale up --auth-key "{{ auth_key }}" {{ extra_args }}
-    else
-        sudo tailscale up {{ extra_args }}
+
+    auth_key_input="{{ auth_key }}"
+    auth_key_file_input="{{ auth_key_file }}"
+    extra_args_input="{{ extra_args }}"
+
+    # Compatibility shim for invocation forms like:
+    #   just tailscale-up auth_key_file=/path/to/file
+    if [[ "${auth_key_input}" == auth_key_file=* ]] && [ -z "${auth_key_file_input}" ]; then
+        auth_key_file_input="${auth_key_input#auth_key_file=}"
+        auth_key_input=''
+    fi
+    if [[ "${auth_key_input}" == extra_args=* ]] && [ -z "${extra_args_input}" ]; then
+        extra_args_input="${auth_key_input#extra_args=}"
+        auth_key_input=''
+    fi
+    if [[ "${auth_key_file_input}" == extra_args=* ]] && [ -z "${extra_args_input}" ]; then
+        extra_args_input="${auth_key_file_input#extra_args=}"
+        auth_key_file_input=''
     fi
 
-tailscale-status:
-    tailscale status
+    if [ -n "${auth_key_input}" ]; then
+        printf 'WARNING: auth_key=... is deprecated; prefer auth_key_file=... or env vars.\n' >&2
+        TS_AUTHKEY="${auth_key_input}" scripts/tailscale_remote_ops.sh up --auth-key-env TS_AUTHKEY -- ${extra_args_input}
+    elif [ -n "${auth_key_file_input}" ]; then
+        scripts/tailscale_remote_ops.sh up --auth-key-file "${auth_key_file_input}" -- ${extra_args_input}
+    else
+        scripts/tailscale_remote_ops.sh up -- ${extra_args_input}
+    fi
+
+tailscale-status json='0':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ "{{ json }}" = '1' ]; then
+        scripts/tailscale_remote_ops.sh status --json
+    else
+        scripts/tailscale_remote_ops.sh status
+    fi
 
 prereqs:
     @echo "[deprecated] Use 'just deps' instead of 'just prereqs'." >&2

--- a/scripts/tailscale_remote_ops.sh
+++ b/scripts/tailscale_remote_ops.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/tailscale_remote_ops.sh install
+  scripts/tailscale_remote_ops.sh up [--auth-key-file FILE] [--auth-key-env VAR] [--reset]
+                                 [--hostname NAME] [--accept-routes]
+                                 [--advertise-tags TAGS] [--ssh]
+                                 [--extra-arg ARG ...]
+  scripts/tailscale_remote_ops.sh status [--json]
+
+Notes:
+  - Prefer --auth-key-file or --auth-key-env over passing keys in shell history.
+  - Set SUGARKUBE_TAILSCALE_BIN/SUGARKUBE_TAILSCALED_BIN to override binary names.
+USAGE
+}
+
+log() {
+    printf '[tailscale-ops] %s\n' "$*"
+}
+
+require_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        printf 'ERROR: required command not found: %s\n' "$1" >&2
+        return 1
+    fi
+}
+
+tailscale_bin() {
+    printf '%s' "${SUGARKUBE_TAILSCALE_BIN:-tailscale}"
+}
+
+tailscaled_bin() {
+    printf '%s' "${SUGARKUBE_TAILSCALED_BIN:-tailscaled}"
+}
+
+run_install() {
+    local installer_url="${SUGARKUBE_TAILSCALE_INSTALLER_URL:-https://tailscale.com/install.sh}"
+    local installer
+
+    require_cmd curl
+    require_cmd sh
+
+    installer="$(mktemp -t sugarkube-tailscale-install.XXXXXX)"
+    trap 'rm -f "${installer}"' EXIT
+
+    log "Downloading installer from ${installer_url}"
+    curl -fsSL "${installer_url}" -o "${installer}"
+
+    log "Running installer"
+    sh "${installer}"
+
+    trap - EXIT
+    rm -f "${installer}"
+}
+
+run_up() {
+    local auth_key_file=''
+    local auth_key_env=''
+    local reset='0'
+    local hostname=''
+    local accept_routes='0'
+    local advertise_tags=''
+    local ssh_mode='0'
+    local arg
+
+    local -a extra_args=()
+    local -a cmd
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --auth-key-file)
+                auth_key_file="$2"
+                shift 2
+                ;;
+            --auth-key-env)
+                auth_key_env="$2"
+                shift 2
+                ;;
+            --reset)
+                reset='1'
+                shift
+                ;;
+            --hostname)
+                hostname="$2"
+                shift 2
+                ;;
+            --accept-routes)
+                accept_routes='1'
+                shift
+                ;;
+            --advertise-tags)
+                advertise_tags="$2"
+                shift 2
+                ;;
+            --ssh)
+                ssh_mode='1'
+                shift
+                ;;
+            --extra-arg)
+                extra_args+=("$2")
+                shift 2
+                ;;
+            --)
+                shift
+                while [ "$#" -gt 0 ]; do
+                    extra_args+=("$1")
+                    shift
+                done
+                ;;
+            -h|--help)
+                usage
+                return 0
+                ;;
+            *)
+                printf 'ERROR: unknown argument for up: %s\n' "$1" >&2
+                return 1
+                ;;
+        esac
+    done
+
+    require_cmd "$(tailscale_bin)"
+    require_cmd sudo
+
+    cmd=(sudo "$(tailscale_bin)" up)
+
+    if [ -n "${auth_key_file}" ] && [ -n "${auth_key_env}" ]; then
+        printf 'ERROR: use either --auth-key-file or --auth-key-env, not both\n' >&2
+        return 1
+    fi
+
+    if [ -n "${auth_key_file}" ]; then
+        if [ ! -r "${auth_key_file}" ]; then
+            printf 'ERROR: auth key file is not readable: %s\n' "${auth_key_file}" >&2
+            return 1
+        fi
+        arg="$(tr -d '\r\n' < "${auth_key_file}")"
+        if [ -z "${arg}" ]; then
+            printf 'ERROR: auth key file is empty: %s\n' "${auth_key_file}" >&2
+            return 1
+        fi
+        cmd+=(--auth-key "${arg}")
+    elif [ -n "${auth_key_env}" ]; then
+        if [ -z "${!auth_key_env-}" ]; then
+            printf 'ERROR: environment variable %s is empty or unset\n' "${auth_key_env}" >&2
+            return 1
+        fi
+        cmd+=(--auth-key "${!auth_key_env}")
+    fi
+
+    if [ "${reset}" = '1' ]; then
+        cmd+=(--reset)
+    fi
+    if [ -n "${hostname}" ]; then
+        cmd+=(--hostname "${hostname}")
+    fi
+    if [ "${accept_routes}" = '1' ]; then
+        cmd+=(--accept-routes)
+    fi
+    if [ -n "${advertise_tags}" ]; then
+        cmd+=(--advertise-tags "${advertise_tags}")
+    fi
+    if [ "${ssh_mode}" = '1' ]; then
+        cmd+=(--ssh)
+    fi
+
+    for arg in "${extra_args[@]}"; do
+        cmd+=("${arg}")
+    done
+
+    log "Running tailscale up"
+    "${cmd[@]}"
+}
+
+run_status() {
+    local json='0'
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --json)
+                json='1'
+                shift
+                ;;
+            -h|--help)
+                usage
+                return 0
+                ;;
+            *)
+                printf 'ERROR: unknown argument for status: %s\n' "$1" >&2
+                return 1
+                ;;
+        esac
+    done
+
+    require_cmd "$(tailscale_bin)"
+
+    if [ "${json}" = '1' ]; then
+        "$(tailscale_bin)" status --json
+        return 0
+    fi
+
+    "$(tailscale_bin)" status
+}
+
+run_preflight() {
+    require_cmd "$(tailscale_bin)"
+    require_cmd "$(tailscaled_bin)"
+}
+
+main() {
+    if [ "$#" -lt 1 ]; then
+        usage
+        return 1
+    fi
+
+    case "$1" in
+        install)
+            shift
+            run_install "$@"
+            ;;
+        up)
+            shift
+            run_preflight
+            run_up "$@"
+            ;;
+        status)
+            shift
+            run_preflight
+            run_status "$@"
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            printf 'ERROR: unknown command: %s\n' "$1" >&2
+            usage
+            return 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/tests/scripts/test_tailscale_remote_ops.py
+++ b/tests/scripts/test_tailscale_remote_ops.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+SCRIPT = Path("scripts/tailscale_remote_ops.sh")
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content).lstrip("\n"), encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_up_uses_auth_key_file_and_extra_args(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "tailscale.log"
+    auth_file = tmp_path / "auth.key"
+    auth_file.write_text("tskey-auth-k8s-123\n", encoding="utf-8")
+
+    _write_executable(
+        bin_dir / "tailscaled",
+        """
+        #!/usr/bin/env bash
+        exit 0
+        """,
+    )
+
+    _write_executable(
+        bin_dir / "sudo",
+        f"""
+        #!/usr/bin/env bash
+        set -euo pipefail
+        echo "sudo:$@" >> "{log}"
+        exec "$@"
+        """,
+    )
+
+    _write_executable(
+        bin_dir / "tailscale",
+        f"""
+        #!/usr/bin/env bash
+        set -euo pipefail
+        echo "tailscale:$@" >> "{log}"
+        exit 0
+        """,
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+
+    result = subprocess.run(
+        [
+            str(SCRIPT),
+            "up",
+            "--auth-key-file",
+            str(auth_file),
+            "--accept-routes",
+            "--extra-arg",
+            "--ssh",
+            "--extra-arg",
+            "--advertise-tags=tag:ops",
+        ],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    content = log.read_text(encoding="utf-8")
+    assert "tailscale:up --auth-key tskey-auth-k8s-123 --accept-routes --ssh --advertise-tags=tag:ops" in content
+
+
+def test_up_rejects_missing_auth_env_value(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    for name in ("tailscale", "tailscaled", "sudo"):
+        _write_executable(
+            bin_dir / name,
+            """
+            #!/usr/bin/env bash
+            exit 0
+            """,
+        )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env.pop("TS_AUTHKEY", None)
+
+    result = subprocess.run(
+        [str(SCRIPT), "up", "--auth-key-env", "TS_AUTHKEY"],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "TS_AUTHKEY is empty or unset" in result.stderr
+
+
+def test_status_json_forwards_flag(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "status.log"
+
+    _write_executable(
+        bin_dir / "tailscaled",
+        """
+        #!/usr/bin/env bash
+        exit 0
+        """,
+    )
+    _write_executable(
+        bin_dir / "tailscale",
+        f"""
+        #!/usr/bin/env bash
+        set -euo pipefail
+        echo "tailscale:$@" >> "{log}"
+        if [ "$1" = "status" ] && [ "$2" = "--json" ]; then
+            printf '%s\n' '{{"BackendState":"Running"}}'
+            exit 0
+        fi
+        exit 1
+        """,
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+
+    result = subprocess.run(
+        [str(SCRIPT), "status", "--json"],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert '"BackendState":"Running"' in result.stdout
+    assert "tailscale:status --json" in log.read_text(encoding="utf-8")

--- a/tests/test_tailscale_remote_ops_e2e.py
+++ b/tests/test_tailscale_remote_ops_e2e.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("ensure_just_available")
+
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content).lstrip("\n"), encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_just_tailscale_up_and_status_with_auth_file(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "commands.log"
+    auth_file = tmp_path / "tailscale.auth"
+    auth_file.write_text("tskey-e2e-abc\n", encoding="utf-8")
+
+    _write_executable(
+        bin_dir / "sudo",
+        f"""
+        #!/usr/bin/env bash
+        set -euo pipefail
+        echo "sudo:$@" >> "{log}"
+        exec "$@"
+        """,
+    )
+
+    _write_executable(
+        bin_dir / "tailscaled",
+        """
+        #!/usr/bin/env bash
+        exit 0
+        """,
+    )
+
+    _write_executable(
+        bin_dir / "tailscale",
+        f"""
+        #!/usr/bin/env bash
+        set -euo pipefail
+        echo "tailscale:$@" >> "{log}"
+        if [ "$1" = "status" ]; then
+            if [ "${{2-}}" = "--json" ]; then
+                printf '%s\n' '{{"BackendState":"Running","Self":{{"HostName":"sugarkube0"}}}}'
+            else
+                printf '%s\n' '100.64.0.10 sugarkube0 linux active; direct 203.0.113.9:41641'
+            fi
+            exit 0
+        fi
+        exit 0
+        """,
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+
+    up = subprocess.run(
+        ["just", "--justfile", "justfile", "tailscale-up", f"auth_key_file={auth_file}"],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+    assert up.returncode == 0, up.stderr
+
+    status = subprocess.run(
+        ["just", "--justfile", "justfile", "tailscale-status"],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+    assert status.returncode == 0, status.stderr
+    assert 'sugarkube0' in status.stdout
+
+    log_data = log.read_text(encoding="utf-8")
+    assert "tailscale:up --auth-key tskey-e2e-abc" in log_data
+    assert "tailscale:status" in log_data


### PR DESCRIPTION
### Motivation
- Realize the documented Tailscale remote-operations design by providing a hardened, reproducible implementation instead of only a design doc. 
- Reduce risk of accidental credential leakage by supporting key files and env-var sourcing and adding preflight checks before invoking `tailscale`/`tailscaled`.
- Make the workflow discoverable in the docs and covered by automated unit/integration and e2e tests so future changes remain safe.

### Description
- Add a dedicated helper script `scripts/tailscale_remote_ops.sh` implementing `install`, `up`, and `status` subcommands with guarded argument parsing, preflight checks, and safer auth-key sourcing (`--auth-key-file` / `--auth-key-env`).
- Wire `just` recipes to the helper script by updating `justfile` so `tailscale-install`, `tailscale-up` (with a compatibility shim) and `tailscale-status` delegate to the script.
- Add tests: unit/integration-style `tests/scripts/test_tailscale_remote_ops.py` for argument and status handling and recipe-level e2e `tests/test_tailscale_remote_ops_e2e.py` that exercises `just` integration with stubs.
- Update docs for discoverability and runbook guidance by extending `docs/design/tailscale-remote-ops.md` with implementation notes and adding references in `docs/software/index.md` and `docs/raspi_cluster_operations.md`.

### Testing
- Ran unit + integration tests: `pytest tests/scripts/test_tailscale_remote_ops.py` and recipe e2e: `pytest tests/test_tailscale_remote_ops_e2e.py` which together passed (`4 passed`).
- Ran additional repository checks: `pytest tests/test_up_recipe_calls.py` (passed) and `pytest tests/test_docs_verify_wrapper.py` (passed).
- Ran the repository secret scan via `git diff --cached | ./scripts/scan-secrets.py` which completed with no findings.
- Note: `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` were attempted in the run but those tools are not installed in the execution environment and therefore did not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf5a308f40832f9e317e6a56225903)