### PR TITLE
Add Tailscale remote-ops helper script, justfile integration, docs and tests

### DIFF
--- a/docs/design/tailscale-remote-ops.md
+++ b/docs/design/tailscale-remote-ops.md
@@ -116,11 +116,20 @@ then validate with `just status` and `just cluster-status`.
 
 ### 2) Add Tailscale on each node as a post-provisioning step
 
-This repository now includes helper recipes for the node-local Tailscale setup flow:
+This repository includes a dedicated helper wrapper (`scripts/tailscale_remote_ops.sh`) and
+`just` recipes for the node-local setup flow:
 
 - `just tailscale-install` installs the upstream Tailscale package.
 - `just tailscale-up` brings the node online with your local auth flow.
 - `just tailscale-status` verifies enrollment state.
+
+To avoid putting keys directly in shell history, use environment variables for non-interactive runs:
+
+```bash
+TS_AUTHKEY_FILE=~/.config/sugarkube/tailscale-authkey just tailscale-up extra_args='--ssh'
+```
+
+If no auth key is provided, `just tailscale-up` uses interactive `tailscale up` login.
 
 Example (placeholder-only) usage:
 
@@ -185,6 +194,15 @@ Adopt incrementally to avoid disruption:
 4. Repeat for the next node.
 
 Do not rewire existing cluster networking during rollout.
+
+## Test coverage in this repository
+
+The Tailscale remote-ops helpers are now covered by both unit and e2e-style tests:
+
+- `tests/test_tailscale_remote_ops.py` validates argument handling, auth-key sourcing, and
+  justfile wiring.
+- `tests/bats/tailscale_remote_ops.bats` validates end-to-end shell execution with stubbed
+  `sudo`/`tailscale` commands, matching CI's Bats execution model.
 
 ## Verification checklist
 

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -477,6 +477,25 @@ Quick reference for the most common recipes when operating your cluster:
 | `just cat-node-token` | Print the k3s node token for joining nodes | Retrieve the token when adding new nodes or switching to a different shell session. |
 | `just wipe` | Clean up k3s and mDNS state on a node | Recover from a failed bootstrap/join or remove a node that joined the wrong cluster. Re-run `just ha3 env=dev` afterward. |
 | `just dspace-debug-logs` | Dump dspace and Traefik logs for the last 200 lines each | Investigating 500s or routing issues for dspace. |
+| `just tailscale-install` / `just tailscale-up` / `just tailscale-status` | Install, enroll, and inspect per-node Tailscale remote access | Enabling secure off-LAN SSH and operator maintenance without exposing services publicly. |
+
+
+### Optional: Tailscale remote operations
+
+If you operate the cluster from outside your LAN, follow the
+[Tailscale Remote Operations Design](design/tailscale-remote-ops.md) to add Tailscale as an
+additive management plane.
+
+Use these helper recipes on each node:
+
+```bash
+just tailscale-install
+TS_AUTHKEY_FILE=~/.config/sugarkube/tailscale-authkey just tailscale-up extra_args='--ssh'
+just tailscale-status extra_args='--json'
+```
+
+This keeps your day-two workflow (`just status`, `just cluster-status`, `just kubeconfig-env`) the
+same while adding secure remote operator transport.
 
 ## Step 2: Capture and commit sanitized bring-up logs
 

--- a/docs/software/index.md
+++ b/docs/software/index.md
@@ -42,6 +42,8 @@ and supporting services stay healthy.
   Cloudflare tunnels.
 - [apps/tokenplace-relay.md](../apps/tokenplace-relay.md) — Helm ingress/TLS guide for
   token.place staging.
+- [design/tailscale-remote-ops.md](../design/tailscale-remote-ops.md) — additive remote-ops
+  topology for secure off-LAN node access.
 
 ## Developer Workflow
 - [contributor_script_map.md](../contributor_script_map.md) — keep automation docs

--- a/justfile
+++ b/justfile
@@ -196,19 +196,25 @@ deps:
     sudo -E scripts/install_deps.sh
 
 tailscale-install:
-    curl -fsSL https://tailscale.com/install.sh | sh
+    bash scripts/tailscale_remote_ops.sh install
 
-tailscale-up auth_key='' extra_args='':
+tailscale-up extra_args='':
     #!/usr/bin/env bash
     set -euo pipefail
-    if [ -n "{{ auth_key }}" ]; then
-        sudo tailscale up --auth-key "{{ auth_key }}" {{ extra_args }}
+    if [ -n "{{ extra_args }}" ]; then
+        bash scripts/tailscale_remote_ops.sh up -- {{ extra_args }}
     else
-        sudo tailscale up {{ extra_args }}
+        bash scripts/tailscale_remote_ops.sh up
     fi
 
-tailscale-status:
-    tailscale status
+tailscale-status extra_args='':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -n "{{ extra_args }}" ]; then
+        bash scripts/tailscale_remote_ops.sh status -- {{ extra_args }}
+    else
+        bash scripts/tailscale_remote_ops.sh status
+    fi
 
 prereqs:
     @echo "[deprecated] Use 'just deps' instead of 'just prereqs'." >&2

--- a/scripts/tailscale_remote_ops.sh
+++ b/scripts/tailscale_remote_ops.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/tailscale_remote_ops.sh install
+  scripts/tailscale_remote_ops.sh up [-- <extra tailscale up args>]
+  scripts/tailscale_remote_ops.sh status [-- <tailscale status args>]
+
+Environment:
+  TS_AUTHKEY           Optional auth key for non-interactive enrollment.
+  TS_AUTHKEY_FILE      File containing auth key (preferred for local automation).
+
+Notes:
+  - Set only one of TS_AUTHKEY or TS_AUTHKEY_FILE.
+  - If neither is set, `up` uses interactive local auth.
+USAGE
+}
+
+require_cmd() {
+  local bin="$1"
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    printf 'ERROR: required command not found: %s\n' "$bin" >&2
+    exit 1
+  fi
+}
+
+load_auth_key() {
+  local key="${TS_AUTHKEY:-}"
+
+  if [ -n "${TS_AUTHKEY_FILE:-}" ] && [ -n "$key" ]; then
+    printf 'ERROR: set only one of TS_AUTHKEY or TS_AUTHKEY_FILE\n' >&2
+    exit 1
+  fi
+
+  if [ -n "${TS_AUTHKEY_FILE:-}" ]; then
+    if [ ! -r "$TS_AUTHKEY_FILE" ]; then
+      printf 'ERROR: TS_AUTHKEY_FILE is not readable: %s\n' "$TS_AUTHKEY_FILE" >&2
+      exit 1
+    fi
+    key="$(head -n 1 "$TS_AUTHKEY_FILE" | tr -d '\r\n')"
+  fi
+
+  printf '%s' "$key"
+}
+
+cmd_install() {
+  require_cmd curl
+  require_cmd sh
+  curl -fsSL https://tailscale.com/install.sh | sh
+}
+
+cmd_up() {
+  require_cmd sudo
+  require_cmd tailscale
+
+  local auth_key
+  auth_key="$(load_auth_key)"
+
+  local -a args=(up)
+  if [ -n "$auth_key" ]; then
+    args+=(--auth-key "$auth_key")
+  fi
+
+  if [ "$#" -gt 0 ]; then
+    args+=("$@")
+  fi
+
+  sudo tailscale "${args[@]}"
+}
+
+cmd_status() {
+  require_cmd tailscale
+  if [ "$#" -gt 0 ]; then
+    tailscale status "$@"
+  else
+    tailscale status
+  fi
+}
+
+main() {
+  if [ "$#" -lt 1 ]; then
+    usage >&2
+    exit 1
+  fi
+
+  local action="$1"
+  shift
+
+  case "$action" in
+    install)
+      cmd_install
+      ;;
+    up)
+      if [ "${1:-}" = "--" ]; then
+        shift
+      fi
+      cmd_up "$@"
+      ;;
+    status)
+      if [ "${1:-}" = "--" ]; then
+        shift
+      fi
+      cmd_status "$@"
+      ;;
+    -h|--help|help)
+      usage
+      ;;
+    *)
+      printf 'ERROR: unknown action: %s\n\n' "$action" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/tests/bats/tailscale_remote_ops.bats
+++ b/tests/bats/tailscale_remote_ops.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+load helpers/path_stub
+
+setup() {
+  ORIGINAL_PATH="$PATH"
+  unset _BATS_PATH_STUB_DIR
+  PATH="$ORIGINAL_PATH"
+  setup_path_stub_dir
+}
+
+teardown() {
+  PATH="$ORIGINAL_PATH"
+}
+
+@test "tailscale remote ops status delegates to tailscale status" {
+  stub_command tailscale <<'EOS'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >"${BATS_TEST_TMPDIR}/tailscale-args.log"
+EOS
+
+  run env PATH="$PATH" "${BATS_CWD}/scripts/tailscale_remote_ops.sh" status -- --json
+
+  [ "$status" -eq 0 ]
+  [ "$(cat "${BATS_TEST_TMPDIR}/tailscale-args.log")" = "status --json" ]
+}
+
+@test "tailscale remote ops up loads key from file and uses sudo tailscale" {
+  cat <<'KEY' >"${BATS_TEST_TMPDIR}/authkey"
+tskey-auth-e2e
+KEY
+
+  stub_command tailscale <<'EOS'
+#!/usr/bin/env bash
+exit 0
+EOS
+
+  stub_command sudo <<'EOS'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >"${BATS_TEST_TMPDIR}/sudo-args.log"
+EOS
+
+  run env \
+    PATH="$PATH" \
+    TS_AUTHKEY_FILE="${BATS_TEST_TMPDIR}/authkey" \
+    "${BATS_CWD}/scripts/tailscale_remote_ops.sh" up -- --ssh
+
+  [ "$status" -eq 0 ]
+  [ "$(cat "${BATS_TEST_TMPDIR}/sudo-args.log")" = "tailscale up --auth-key tskey-auth-e2e --ssh" ]
+}

--- a/tests/test_tailscale_docs_discoverability.py
+++ b/tests/test_tailscale_docs_discoverability.py
@@ -1,0 +1,24 @@
+"""Guardrails for Tailscale remote-ops docs discoverability."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_design_doc_is_linked_from_primary_indexes() -> None:
+    docs_index = (REPO_ROOT / "docs" / "index.md").read_text(encoding="utf-8")
+    software_index = (REPO_ROOT / "docs" / "software" / "index.md").read_text(encoding="utf-8")
+
+    expected_link = "design/tailscale-remote-ops.md"
+    assert expected_link in docs_index
+    assert "../design/tailscale-remote-ops.md" in software_index
+
+
+def test_operations_guide_surfaces_tailscale_remote_ops_entrypoint() -> None:
+    operations = (REPO_ROOT / "docs" / "raspi_cluster_operations.md").read_text(encoding="utf-8")
+
+    assert "Optional: Tailscale remote operations" in operations
+    assert "just tailscale-install" in operations
+    assert "TS_AUTHKEY_FILE=" in operations

--- a/tests/test_tailscale_remote_ops.py
+++ b/tests/test_tailscale_remote_ops.py
@@ -1,0 +1,111 @@
+"""Tests for scripts/tailscale_remote_ops.sh."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "tailscale_remote_ops.sh"
+
+
+def _write_stub(stub_dir: Path, name: str, body: str) -> None:
+    path = stub_dir / name
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run(
+    *args: str,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    merged_env = os.environ.copy()
+    if env:
+        merged_env.update(env)
+    return subprocess.run(
+        [str(SCRIPT), *args],
+        cwd=REPO_ROOT,
+        env=merged_env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_up_uses_interactive_login_when_no_authkey(tmp_path: Path) -> None:
+    calls = tmp_path / "calls.log"
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+
+    _write_stub(
+        stub_dir,
+        "sudo",
+        f"#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" > {calls}\n",
+    )
+    _write_stub(stub_dir, "tailscale", "#!/usr/bin/env bash\nexit 0\n")
+
+    result = _run("up", env={"PATH": f"{stub_dir}:{os.environ['PATH']}"})
+
+    assert result.returncode == 0, result.stderr
+    assert calls.read_text(encoding="utf-8").strip() == "tailscale up"
+
+
+def test_up_reads_authkey_from_file(tmp_path: Path) -> None:
+    calls = tmp_path / "calls.log"
+    authkey_path = tmp_path / "authkey.txt"
+    authkey_path.write_text("tskey-auth-abc123\n", encoding="utf-8")
+
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    _write_stub(
+        stub_dir,
+        "sudo",
+        f"#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" > {calls}\n",
+    )
+    _write_stub(stub_dir, "tailscale", "#!/usr/bin/env bash\nexit 0\n")
+
+    result = _run(
+        "up",
+        "--",
+        "--ssh",
+        env={
+            "PATH": f"{stub_dir}:{os.environ['PATH']}",
+            "TS_AUTHKEY_FILE": str(authkey_path),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert calls.read_text(encoding="utf-8").strip() == "tailscale up --auth-key tskey-auth-abc123 --ssh"
+
+
+def test_up_rejects_conflicting_authkey_inputs(tmp_path: Path) -> None:
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    _write_stub(stub_dir, "sudo", "#!/usr/bin/env bash\nexit 0\n")
+    _write_stub(stub_dir, "tailscale", "#!/usr/bin/env bash\nexit 0\n")
+
+    authkey_path = tmp_path / "authkey.txt"
+    authkey_path.write_text("tskey-auth-file\n", encoding="utf-8")
+
+    result = _run(
+        "up",
+        env={
+            "PATH": f"{stub_dir}:{os.environ['PATH']}",
+            "TS_AUTHKEY": "tskey-auth-env",
+            "TS_AUTHKEY_FILE": str(authkey_path),
+        },
+    )
+
+    assert result.returncode != 0
+    assert "set only one of TS_AUTHKEY or TS_AUTHKEY_FILE" in result.stderr
+
+
+def test_justfile_tailscale_recipes_delegate_to_script() -> None:
+    content = (REPO_ROOT / "justfile").read_text(encoding="utf-8")
+    assert "tailscale-install:" in content
+    assert "bash scripts/tailscale_remote_ops.sh install" in content
+    assert "tailscale-up extra_args=''" in content
+    assert "bash scripts/tailscale_remote_ops.sh up" in content
+    assert "tailscale-status extra_args=''" in content
+    assert "bash scripts/tailscale_remote_ops.sh status" in content


### PR DESCRIPTION
### Motivation
- Make the Tailscale remote-ops design actionable by providing a single, testable helper that operators can use on each node. 
- Centralize and harden auth-key handling to avoid pasting secrets into shell history and to support non-interactive enrollments. 
- Improve discoverability so day-two operators find the remote-ops guidance from the existing operations and software indexes. 

### Description
- Add `scripts/tailscale_remote_ops.sh`, a small CLI wrapper implementing `install`, `up`, and `status` with required-command checks and mutually-exclusive `TS_AUTHKEY` / `TS_AUTHKEY_FILE` support. 
- Route `just` recipes through the wrapper by updating the `justfile` so `tailscale-install`, `tailscale-up`, and `tailscale-status` delegate to the script. 
- Update docs by expanding `docs/design/tailscale-remote-ops.md`, adding an “Optional: Tailscale remote operations” section to `docs/raspi_cluster_operations.md`, and linking the design doc from `docs/software/index.md`. 
- Add automated coverage: `tests/test_tailscale_remote_ops.py` (pytest unit-style tests), `tests/bats/tailscale_remote_ops.bats` (Bats e2e-style stubs), and `tests/test_tailscale_docs_discoverability.py` (docs guardrails). 

### Testing
- Ran `pytest -q tests/test_tailscale_remote_ops.py tests/test_tailscale_docs_discoverability.py`, which completed successfully (`6 passed`). 
- Attempted `bats --recursive tests/bats/tailscale_remote_ops.bats` but the `bats` binary was not available in this environment so Bats-based tests were not executed here. 
- `pre-commit`, `pyspelling`, and `linkchecker` were attempted but those tools were not present in the environment so those checks were not run here. 
- Ran the repository secrets check via `git diff --cached | ./scripts/scan-secrets.py`, which completed without reporting issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf5a308f40832f9e317e6a56225903)