### PR TITLE
✨ Harden Tailscale remote-ops helpers, tests, and docs

### DIFF
--- a/docs/design/tailscale-remote-ops.md
+++ b/docs/design/tailscale-remote-ops.md
@@ -135,6 +135,49 @@ just tailscale-status
 Use `just` recipes for cluster lifecycle and diagnostics. Use tailnet connectivity as the secure
 transport path for remote operator access.
 
+
+### Implementation status in this repository
+
+The design is implemented with a dedicated helper script and `just` wrappers:
+
+- `scripts/tailscale_remote_ops.sh` provides the operational entrypoints:
+  - `install` (idempotent install path with command checks),
+  - `up` (supports auth key via environment variable or file), and
+  - `status` (for enrollment/state verification).
+- `just tailscale-install` delegates to `scripts/tailscale_remote_ops.sh install`.
+- `just tailscale-up` delegates to `scripts/tailscale_remote_ops.sh up` and forwards optional
+  auth-key + extra args.
+- `just tailscale-status` delegates to `scripts/tailscale_remote_ops.sh status` and forwards
+  optional status args.
+
+This keeps Tailscale-specific logic centralized in one script while preserving a simple operator UX.
+
+### Testing and validation coverage
+
+This feature now has both unit-level and end-to-end regression coverage:
+
+- `tests/test_tailscale_remote_ops.py::test_tailscale_install_dry_run_reports_install_url`
+  validates the install flow and dry-run behavior.
+- `tests/test_tailscale_remote_ops.py::test_tailscale_up_uses_auth_key_file_and_redacts_in_dry_run`
+  verifies auth-key file support and output redaction.
+- `tests/test_tailscale_remote_ops.py::test_tailscale_status_recipe_e2e_with_stubs`
+  exercises `just tailscale-status` end-to-end with command stubs.
+- `tests/test_tailscale_remote_ops.py::test_tailscale_up_recipe_e2e_invokes_sudo_and_up`
+  exercises `just tailscale-up` end-to-end with `sudo` + `tailscale` stubs.
+
+These tests are designed to run in CI without real network enrollment while still asserting
+command wiring and safety behavior.
+
+### Troubleshooting
+
+- If `tailscale` is already installed, `just tailscale-install` exits successfully without reinstall.
+- If `sudo`, `curl`, `bash`, or `tailscale` are missing, helper commands fail fast with explicit
+  error messages.
+- For non-interactive testing, set `TAILSCALE_DRY_RUN=1` to print the effective commands without
+  making system changes.
+- To avoid shell-history leaks, prefer `TAILSCALE_AUTH_KEY_FILE` over inline key arguments whenever
+  possible.
+
 ## Security and privacy considerations
 
 - Never commit auth keys, tokens, or private tailnet metadata.

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -65,6 +65,22 @@ Follow this sequence after imaging and booting the Pis:
    [token.place](./pi_token_dspace.md) or [dspace](https://github.com/democratizedspace/dspace)) once
    ingress is healthy.
 
+## Remote operations over Tailscale (optional but recommended)
+
+For remote day-two administration without exposing cluster services publicly, follow the
+[Tailscale Remote Operations Design](./design/tailscale-remote-ops.md).
+
+At a high level:
+
+```bash
+just tailscale-install
+just tailscale-up
+just tailscale-status
+```
+
+Use this as an additive management plane: keep `just` recipes as the primary cluster interface and
+use Tailscale transport for secure remote SSH and operator access.
+
 ## Install Helm (prerequisite for Helm workloads)
 
 Helm simplifies Kubernetes application deployment by packaging manifests, providing templating, and

--- a/docs/software/index.md
+++ b/docs/software/index.md
@@ -36,6 +36,8 @@ and supporting services stay healthy.
   debugging.
 - [operations/security-checklist.md](../operations/security-checklist.md) — record
   credential rotations and post-maintenance evidence.
+- [design/tailscale-remote-ops.md](../design/tailscale-remote-ops.md) — remote operator
+  access model, rollout guidance, and validation checks for Tailscale-based operations.
 - [projects-compose.md](../projects-compose.md) — run token.place and dspace via
   Docker Compose.
 - [pi_token_dspace.md](../pi_token_dspace.md) — expose token.place/dspace through

--- a/justfile
+++ b/justfile
@@ -196,19 +196,13 @@ deps:
     sudo -E scripts/install_deps.sh
 
 tailscale-install:
-    curl -fsSL https://tailscale.com/install.sh | sh
+    "{{ scripts_dir }}/tailscale_remote_ops.sh" install
 
 tailscale-up auth_key='' extra_args='':
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [ -n "{{ auth_key }}" ]; then
-        sudo tailscale up --auth-key "{{ auth_key }}" {{ extra_args }}
-    else
-        sudo tailscale up {{ extra_args }}
-    fi
+    TAILSCALE_AUTH_KEY="{{ auth_key }}" "{{ scripts_dir }}/tailscale_remote_ops.sh" up {{ extra_args }}
 
-tailscale-status:
-    tailscale status
+tailscale-status extra_args='':
+    "{{ scripts_dir }}/tailscale_remote_ops.sh" status {{ extra_args }}
 
 prereqs:
     @echo "[deprecated] Use 'just deps' instead of 'just prereqs'." >&2

--- a/scripts/tailscale_remote_ops.sh
+++ b/scripts/tailscale_remote_ops.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  tailscale_remote_ops.sh install
+  tailscale_remote_ops.sh up [tailscale-up-args...]
+  tailscale_remote_ops.sh status [tailscale-status-args...]
+
+Environment:
+  TAILSCALE_AUTH_KEY       Optional auth key used by the up command.
+  TAILSCALE_AUTH_KEY_FILE  Optional file path containing auth key (trimmed).
+  TAILSCALE_INSTALL_URL    Override install script URL.
+  TAILSCALE_DRY_RUN=1      Print commands instead of executing them.
+USAGE
+}
+
+log() {
+    printf '%s\n' "$*" >&2
+}
+
+require_cmd() {
+    local cmd="$1"
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        log "ERROR: required command '$cmd' was not found in PATH."
+        return 1
+    fi
+}
+
+run_cmd() {
+    if [ "${TAILSCALE_DRY_RUN:-0}" = "1" ]; then
+        printf 'DRY-RUN:' >&2
+        printf ' %q' "$@" >&2
+        printf '\n' >&2
+        return 0
+    fi
+    "$@"
+}
+
+maybe_sudo() {
+    if [ "$(id -u)" -eq 0 ]; then
+        run_cmd "$@"
+    else
+        require_cmd sudo
+        run_cmd sudo "$@"
+    fi
+}
+
+read_auth_key() {
+    if [ -n "${TAILSCALE_AUTH_KEY:-}" ]; then
+        printf '%s' "${TAILSCALE_AUTH_KEY}"
+        return 0
+    fi
+
+    if [ -n "${TAILSCALE_AUTH_KEY_FILE:-}" ]; then
+        if [ ! -r "${TAILSCALE_AUTH_KEY_FILE}" ]; then
+            log "ERROR: TAILSCALE_AUTH_KEY_FILE is set but not readable: ${TAILSCALE_AUTH_KEY_FILE}"
+            return 1
+        fi
+        tr -d '\r\n' <"${TAILSCALE_AUTH_KEY_FILE}"
+    fi
+}
+
+install_tailscale() {
+    local install_url="${TAILSCALE_INSTALL_URL:-https://tailscale.com/install.sh}"
+
+    if command -v tailscale >/dev/null 2>&1; then
+        log 'tailscale is already installed; skipping installation.'
+        return 0
+    fi
+
+    require_cmd curl
+    require_cmd bash
+    if [ "${TAILSCALE_DRY_RUN:-0}" = "1" ]; then
+        log "DRY-RUN: would fetch installer from ${install_url} and execute it with sudo."
+        return 0
+    fi
+
+    maybe_sudo bash -c "
+        set -euo pipefail
+        curl -fsSL '${install_url}' | bash
+    "
+}
+
+up_tailscale() {
+    require_cmd tailscale
+
+    local auth_key
+    auth_key="$(read_auth_key || true)"
+
+    local args=(tailscale up)
+    if [ -n "${auth_key}" ]; then
+        args+=(--auth-key "${auth_key}")
+    fi
+    if [ "$#" -gt 0 ]; then
+        args+=("$@")
+    fi
+
+    if [ "${TAILSCALE_DRY_RUN:-0}" = "1" ] && [ -n "${auth_key}" ]; then
+        local redacted=(tailscale up --auth-key '***redacted***')
+        if [ "$#" -gt 0 ]; then
+            redacted+=("$@")
+        fi
+        printf 'DRY-RUN:' >&2
+        printf ' %q' sudo "${redacted[@]}" >&2
+        printf '\n' >&2
+        return 0
+    fi
+
+    maybe_sudo "${args[@]}"
+}
+
+status_tailscale() {
+    require_cmd tailscale
+    run_cmd tailscale status "$@"
+}
+
+main() {
+    local cmd="${1:-}"
+    if [ -z "${cmd}" ]; then
+        usage
+        return 1
+    fi
+    shift
+
+    case "${cmd}" in
+        install) install_tailscale "$@" ;;
+        up) up_tailscale "$@" ;;
+        status) status_tailscale "$@" ;;
+        -h|--help|help) usage ;;
+        *)
+            log "ERROR: unknown command '${cmd}'"
+            usage
+            return 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/tests/test_tailscale_remote_ops.py
+++ b/tests/test_tailscale_remote_ops.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "tailscale_remote_ops.sh"
+JUSTFILE_PATH = REPO_ROOT / "justfile"
+
+pytestmark = pytest.mark.usefixtures("ensure_just_available")
+
+
+def _write_exec(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_justfile_tailscale_recipes_use_helper_script() -> None:
+    text = JUSTFILE_PATH.read_text(encoding="utf-8")
+
+    assert '"{{ scripts_dir }}/tailscale_remote_ops.sh" install' in text
+    assert '"{{ scripts_dir }}/tailscale_remote_ops.sh" up' in text
+    assert '"{{ scripts_dir }}/tailscale_remote_ops.sh" status' in text
+    assert "tailscale.com/install.sh | sh" not in text
+
+
+def test_tailscale_install_dry_run_reports_install_url() -> None:
+    result = subprocess.run(
+        [str(SCRIPT_PATH), "install"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        env={**os.environ, "TAILSCALE_DRY_RUN": "1", "TAILSCALE_INSTALL_URL": "https://example.invalid/install.sh"},
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "https://example.invalid/install.sh" in result.stderr
+
+
+def test_tailscale_up_uses_auth_key_file_and_redacts_in_dry_run(tmp_path: Path) -> None:
+    key_file = tmp_path / "auth.key"
+    key_file.write_text("tskey-auth-abc123\n", encoding="utf-8")
+
+    _write_exec(
+        tmp_path / "tailscale",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "exit 0\n",
+    )
+
+    result = subprocess.run(
+        [str(SCRIPT_PATH), "up", "--ssh", "--accept-dns=false"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        env={
+            **os.environ,
+            "TAILSCALE_DRY_RUN": "1",
+            "TAILSCALE_AUTH_KEY_FILE": str(key_file),
+            "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        },
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "redacted" in result.stderr
+    assert "tskey-auth-abc123" not in result.stderr
+
+
+def test_tailscale_status_recipe_e2e_with_stubs(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_path = tmp_path / "commands.log"
+
+    _write_exec(
+        bin_dir / "tailscale",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"echo tailscale:$@ >> '{log_path}'\n"
+        "if [ \"${1:-}\" = \"status\" ]; then\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 0\n",
+    )
+
+    result = subprocess.run(
+        ["just", "tailscale-status", "--peers=false"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"},
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    logged = log_path.read_text(encoding="utf-8")
+    assert "tailscale:status --peers=false" in logged
+
+
+def test_tailscale_up_recipe_e2e_invokes_sudo_and_up(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_path = tmp_path / "commands.log"
+
+    _write_exec(
+        bin_dir / "sudo",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"echo sudo:$@ >> '{log_path}'\n"
+        "exec \"$@\"\n",
+    )
+    _write_exec(
+        bin_dir / "tailscale",
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"echo tailscale:$@ >> '{log_path}'\n"
+        "exit 0\n",
+    )
+
+    result = subprocess.run(
+        ["just", "tailscale-up", "tskey-auth-placeholder", "--ssh"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"},
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    logged = log_path.read_text(encoding="utf-8")
+    assert "tailscale:up --auth-key tskey-auth-placeholder --ssh" in logged


### PR DESCRIPTION
### Motivation

- Implement the previously-proposed Tailscale remote-ops design so operators can securely manage nodes from outside the LAN using a reproducible, repository-driven flow. 
- Centralize Tailscale-related logic to reduce duplication, improve safety (dry-run/redaction/guards), and make behavior easier to test. 
- Make the remote-ops guidance discoverable from the existing operations and software doc hubs so users can find and follow the recommended workflow.

### Description

- Add a dedicated helper script `scripts/tailscale_remote_ops.sh` that implements idempotent `install`, `up`, and `status` subcommands with dependency checks, support for `TAILSCALE_AUTH_KEY`/`TAILSCALE_AUTH_KEY_FILE`, `TAILSCALE_DRY_RUN`, and redacted dry-run output. 
- Route `just` recipes to the helper by updating `justfile` so `tailscale-install`, `tailscale-up`, and `tailscale-status` delegate to the centralized script. 
- Add `tests/test_tailscale_remote_ops.py` with unit and e2e-style regression checks that validate dry-run install reporting, auth-key file handling and redaction, and `just` recipe wiring using command stubs. 
- Update docs for discoverability and status: expand `docs/design/tailscale-remote-ops.md` with an "Implementation status" and testing guidance, and add cross-links into `docs/raspi_cluster_operations.md` and `docs/software/index.md` so the flow is easier to find.

### Testing

- Ran `pytest -q tests/test_tailscale_remote_ops.py tests/test_justfile_formatting.py` and all tests passed locally (`6 passed`).
- Ran the repository secret scan via `git diff --cached | ./scripts/scan-secrets.py` and the scan completed without finding tracked secrets in the staged changes. 
- Attempted standard docs/lint checks (`pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, `linkchecker --no-warnings README.md docs/`) but those commands were not available in this environment and therefore were not executed; CI should run them.
- Tests are designed to run in CI without real Tailscale enrollment by using dry-run and local command stubs, so the suite asserts command wiring and safety behavior without network side effects.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf5a308f40832f9e317e6a56225903)