### PR TITLE
📝 Prepare token.place onboarding docs and operational just recipes

### DIFF
--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -4,6 +4,10 @@ Deploy the `token.place` relay (`relay.py`) to the Sugarkube k3s cluster with a 
 matches the existing dspace staging patterns. The public staging host for the relay service is
 `staging.token.place`, fronted by Traefik and Cloudflare Tunnel.
 
+For first-class token.place onboarding and multi-environment runbooks, see
+[../tokenplace_sugarkube_onboarding.md](../tokenplace_sugarkube_onboarding.md) and
+[./tokenplace.md](tokenplace.md).
+
 Values are split so you can reuse base settings across environments and layer staging-only ingress
 overrides. Operator defaults live alongside the chart; the docs copies remain as examples for
 cut-and-paste use:

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -1,0 +1,76 @@
+# token.place on Sugarkube
+
+This guide defines the intended **operating model** for token.place on Sugarkube after
+secure API v1 convergence. It complements the environment runbooks:
+
+- [token.place dev runbook](../k3s-tokenplace-dev.md)
+- [token.place staging runbook](../k3s-tokenplace-staging.md)
+- [token.place production runbook](../k3s-tokenplace-prod.md)
+- [token.place Sugarkube onboarding](../tokenplace_sugarkube_onboarding.md)
+
+## Intended topology
+
+Sugarkube hosts ingress-facing and control-plane components; compute stays external.
+
+- In-cluster (Sugarkube):
+  - token.place ingress/API services
+  - token.place relay/control services
+  - observability hooks (logs/events/health checks)
+- External compute nodes:
+  - model/runtime workers
+  - high-variance CPU/GPU tasks
+
+This split keeps Sugarkube focused on stable routing, deploy safety, and operations.
+
+## Deployment model (post API v1)
+
+- API v1 is the only supported public contract for Sugarkube onboarding.
+- Deployments use Helm with values layering (`base + env overlay`).
+- Staging and production should use immutable image tags.
+- Rollback uses Helm revision history or redeploying a previous immutable tag.
+
+## Prerequisites
+
+- Healthy k3s cluster with working kubeconfig and Helm.
+- Traefik ingress path verified.
+- Cloudflare Tunnel/DNS configured for selected token.place hosts.
+- token.place chart, release naming, and values files prepared by token.place maintainers.
+- Secrets available via your chosen secure delivery workflow.
+
+## Standard workflows
+
+The `justfile` intentionally provides parameterized recipes instead of hard-coded app wiring:
+
+- Status/health overview: `just tokenplace-status namespace=<ns> release=<release>`
+- Install/deploy: `just tokenplace-deploy chart=<chart> namespace=<ns> release=<release> values=<files> ...`
+- Upgrade: `just tokenplace-upgrade chart=<chart> namespace=<ns> release=<release> values=<files> ...`
+- Rollback: `just tokenplace-rollback namespace=<ns> release=<release> revision=<rev>`
+- Logs: `just tokenplace-logs namespace=<ns> selector='<label-selector>'`
+- Validation: `just tokenplace-validate namespace=<ns> release=<release> host=<https://host>`
+- Local verify helper: `just tokenplace-port-forward namespace=<ns> resource=<svc/name> ...`
+
+## Cloudflare / ingress expectations
+
+- Cloudflare Tunnel should route token.place hostnames to Traefik.
+- TLS and certificate automation should follow the existing Sugarkube ingress pattern.
+- Staging and production hosts should be separated clearly (no shared DNS target by mistake).
+
+See [cloudflare_tunnel.md](../cloudflare_tunnel.md) for tunnel baseline guidance.
+
+## Secrets and configuration guidance
+
+Keep application secrets out of Git. Prefer:
+
+- secret managers or sealed-secret workflows,
+- per-environment secret scopes,
+- rotation records in operational change logs.
+
+At minimum, document where each required token.place secret is sourced, who owns it,
+and how to rotate it without downtime.
+
+## Operator notes and caveats
+
+- Sugarkube is intentionally generic; avoid over-coupling core tooling to token.place internals.
+- If chart/release names are unsettled, keep using parameterized `just` inputs.
+- Require explicit host checks in staging and prod before promotions.
+- Treat compute-node incidents and ingress incidents as separate triage tracks.

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,11 @@ Review the safety notes before working with power components.
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
 - [projects-compose.md](projects-compose.md) — run token.place & dspace via docker compose
 - [apps/tokenplace-relay.md](apps/tokenplace-relay.md) — operate the token.place relay staging deployment
+- [tokenplace_sugarkube_onboarding.md](tokenplace_sugarkube_onboarding.md) — onboarding prerequisites and
+  ownership boundaries for first-class token.place hosting
+- [apps/tokenplace.md](apps/tokenplace.md) — token.place topology and operations model on Sugarkube
+- [k3s-tokenplace-dev.md](k3s-tokenplace-dev.md), [k3s-tokenplace-staging.md](k3s-tokenplace-staging.md),
+  [k3s-tokenplace-prod.md](k3s-tokenplace-prod.md) — environment-specific token.place runbooks
 - [operations/security-checklist.md](operations/security-checklist.md) — track credential rotations and
   verification steps
 - [pi_token_dspace.md](pi_token_dspace.md) — build and expose token.place & dspace via Cloudflare

--- a/docs/k3s-tokenplace-dev.md
+++ b/docs/k3s-tokenplace-dev.md
@@ -1,0 +1,52 @@
+# k3s token.place (dev)
+
+Development runbook for token.place on Sugarkube.
+
+## Scope
+
+- Environment: `dev`
+- Goal: safe iteration and integration validation
+- SLA posture: non-production
+
+## Topology expectations
+
+- Sugarkube hosts ingress/API and relay services.
+- External compute nodes provide runtime workloads.
+- API contract is API v1.
+
+## Prerequisites
+
+- kubeconfig points to dev cluster/context.
+- token.place chart/release/value files prepared.
+- Dev hostname/DNS and ingress route configured.
+
+## Deploy / upgrade / rollback
+
+```bash
+just tokenplace-deploy env=dev chart=<chart> namespace=<ns> release=<release> values=<base,dev> tag=<tag>
+just tokenplace-upgrade env=dev chart=<chart> namespace=<ns> release=<release> values=<base,dev> tag=<tag>
+just tokenplace-rollback namespace=<ns> release=<release> revision=<rev>
+```
+
+## Validation checks
+
+```bash
+just tokenplace-status namespace=<ns> release=<release>
+just tokenplace-validate namespace=<ns> release=<release> host=https://<dev-host>
+just tokenplace-port-forward namespace=<ns> resource=svc/<service> local_port=8080 remote_port=80
+```
+
+## Cloudflare / ingress
+
+- Dev may use internal-only ingress or restricted Cloudflare routes.
+- Keep hostnames clearly separated from staging/prod.
+
+## Secrets/config
+
+- Use dev-scoped secrets only.
+- Never reuse production credentials in dev.
+
+## Caveats
+
+- Mutable tags can be allowed in dev only when explicitly documented.
+- If release wiring changes frequently, prefer scriptable parameter files rather than ad-hoc commands.

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -1,0 +1,53 @@
+# k3s token.place (prod)
+
+Production runbook for token.place on Sugarkube.
+
+## Scope
+
+- Environment: `prod`
+- Goal: stable public operations with controlled change windows
+- SLA posture: production
+
+## Topology expectations
+
+- Sugarkube hosts token.place ingress/API and relay/control-plane services.
+- External compute nodes supply runtime capacity and can scale separately.
+- API v1 is mandatory for compatibility and support.
+
+## Prerequisites
+
+- Production kubeconfig/context verified.
+- Approved immutable image tag selected from staging validation.
+- Production DNS/Cloudflare route and TLS posture ready.
+- Rollback revision/tag identified before deployment starts.
+
+## Deploy / upgrade / rollback
+
+```bash
+just tokenplace-deploy env=prod chart=<chart> namespace=<ns> release=<release> values=<base,prod> tag=<immutable-tag>
+just tokenplace-upgrade env=prod chart=<chart> namespace=<ns> release=<release> values=<base,prod> tag=<immutable-tag>
+just tokenplace-rollback namespace=<ns> release=<release> revision=<rev>
+```
+
+## Validation checks
+
+```bash
+just tokenplace-status namespace=<ns> release=<release>
+just tokenplace-validate namespace=<ns> release=<release> host=https://<prod-host>
+just tokenplace-logs namespace=<ns> selector='app.kubernetes.io/instance=<release>'
+```
+
+## Cloudflare / ingress
+
+- Cloudflare hostnames should map deterministically to Traefik entrypoints.
+- Monitor cert status and ingress events immediately after each upgrade.
+
+## Secrets/config
+
+- Production secrets must be independently stored, audited, and rotated.
+- Keep change records for secret rotation and config toggles.
+
+## Caveats
+
+- Do not deploy mutable tags in production.
+- Keep rollback mechanics tested in staging before production use.

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -1,0 +1,52 @@
+# k3s token.place (staging)
+
+Staging runbook for token.place on Sugarkube.
+
+## Scope
+
+- Environment: `staging`
+- Goal: production-like validation and release gating
+- SLA posture: pre-production
+
+## Topology expectations
+
+- Sugarkube hosts ingress/API and relay services.
+- External compute nodes provide runtime workloads.
+- API v1 behavior should match production assumptions.
+
+## Prerequisites
+
+- kubeconfig points to staging cluster/context.
+- Immutable token.place image tags available.
+- Staging values overlay and hostname routing validated.
+
+## Deploy / upgrade / rollback
+
+```bash
+just tokenplace-deploy env=staging chart=<chart> namespace=<ns> release=<release> values=<base,staging> tag=<immutable-tag>
+just tokenplace-upgrade env=staging chart=<chart> namespace=<ns> release=<release> values=<base,staging> tag=<immutable-tag>
+just tokenplace-rollback namespace=<ns> release=<release> revision=<rev>
+```
+
+## Validation checks
+
+```bash
+just tokenplace-status namespace=<ns> release=<release>
+just tokenplace-validate namespace=<ns> release=<release> host=https://<staging-host>
+just tokenplace-logs namespace=<ns> selector='app.kubernetes.io/instance=<release>'
+```
+
+## Cloudflare / ingress
+
+- Staging host should be distinct and never reused for prod.
+- Validate cert provisioning and HTTP route behavior before promotion.
+
+## Secrets/config
+
+- Use staging-specific credentials and quotas.
+- Confirm secrets are rotated independently from production.
+
+## Caveats
+
+- Staging is the sign-off lane for immutable tags.
+- Promotion to prod should only happen after explicit validation evidence.

--- a/docs/software/index.md
+++ b/docs/software/index.md
@@ -44,6 +44,11 @@ and supporting services stay healthy.
   Cloudflare tunnels.
 - [apps/tokenplace-relay.md](../apps/tokenplace-relay.md) — Helm ingress/TLS guide for
   token.place staging.
+- [tokenplace_sugarkube_onboarding.md](../tokenplace_sugarkube_onboarding.md) — onboarding prerequisites,
+  ownership boundaries, and environment mapping
+- [apps/tokenplace.md](../apps/tokenplace.md) — topology and standard token.place operations model
+- [k3s-tokenplace-dev.md](../k3s-tokenplace-dev.md), [k3s-tokenplace-staging.md](../k3s-tokenplace-staging.md),
+  [k3s-tokenplace-prod.md](../k3s-tokenplace-prod.md) — per-environment token.place runbooks
 
 ## Developer Workflow
 - [contributor_script_map.md](../contributor_script_map.md) — keep automation docs

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -1,0 +1,99 @@
+---
+personas:
+  - software
+---
+
+# token.place Sugarkube onboarding
+
+This guide prepares Sugarkube operators to onboard **token.place** as a first-class
+k3s workload once token.place release artifacts, chart packaging, and API v1 hardening
+are complete.
+
+For environment runbooks, see:
+
+- [k3s-tokenplace-dev.md](k3s-tokenplace-dev.md)
+- [k3s-tokenplace-staging.md](k3s-tokenplace-staging.md)
+- [k3s-tokenplace-prod.md](k3s-tokenplace-prod.md)
+- [apps/tokenplace.md](apps/tokenplace.md)
+
+## Why token.place belongs on Sugarkube
+
+- Sugarkube already provides repeatable k3s environment lanes (`dev`, `staging`, `prod`).
+- Existing Traefik + Cloudflare Tunnel patterns map directly to token.place ingress needs.
+- Existing `just`/Helm workflows match immutable-tag promotion and rollback operations.
+- Keeping token.place ingress and relay control-plane services on Sugarkube allows compute
+  workers to stay external and independently scalable.
+
+## Readiness gates before onboarding
+
+Do not perform production onboarding until token.place has all of the following:
+
+1. Stable API v1 contract between ingress-facing services and compute-node runtime.
+2. Release artifact discipline (immutable image tags, chart packaging, changelog/release notes).
+3. Operationally mature relay behavior (timeouts, retries, backpressure, health probes).
+4. Secret inventory and rotation process documented by token.place maintainers.
+5. Environment-specific values files ready for Sugarkube routing.
+
+## Release artifact expectations
+
+Sugarkube onboarding assumes token.place publishes:
+
+- OCI images with immutable tags (`sha-...`, semver, or equivalent).
+- A Helm chart (or chart path) suitable for `helm upgrade --install` workflows.
+- Values overlays for environment-specific routing and scale.
+- Health/readiness endpoints used by `just tokenplace-validate` checks.
+
+If any artifact is not finalized, keep `just` recipes parameterized and avoid hard-coding
+names in Sugarkube.
+
+## Namespace, release, and chart expectations
+
+Sugarkube intentionally keeps token.place deploy details configurable.
+
+Required operator decisions (per environment):
+
+- Kubernetes namespace (for example `tokenplace`, `tokenplace-staging`, etc.).
+- Helm release name.
+- Chart reference (`oci://...` or local chart path).
+- Ordered values files for base + environment overlays.
+
+Use the token.place recipes in the root `justfile` with explicit parameters. When teams settle
+on canonical names, promote them from operator notes into repo defaults in a follow-up PR.
+
+## Environment mapping model
+
+Recommended split:
+
+- **dev**: fast iteration lane, lower SLA, can tolerate convenience tags if explicitly allowed.
+- **staging**: production-like topology and ingress, immutable tag validation gate.
+- **prod**: immutable-only promotions and explicit rollback procedure.
+
+Compute-node workers can remain outside Sugarkube while relay/API ingress services run in-cluster.
+This keeps heavy compute scaling independent from ingress/control-plane operations.
+
+## Ownership boundaries
+
+- **Sugarkube operators** own k3s cluster operations, ingress, Helm rollout/rollback mechanics,
+  Cloudflare route health, and secret delivery plumbing.
+- **token.place maintainers** own chart/schema correctness, service-level runtime behavior,
+  API compatibility, and application-level incident response.
+
+During incidents, split triage into:
+
+1. Cluster/ingress path (Sugarkube).
+2. Application behavior and upstream compute interactions (token.place).
+
+## Operator workflow entry points
+
+Use the following recipes after setting environment-specific parameters:
+
+- `just tokenplace-status ...`
+- `just tokenplace-deploy ...`
+- `just tokenplace-upgrade ...`
+- `just tokenplace-rollback ...`
+- `just tokenplace-logs ...`
+- `just tokenplace-validate ...`
+- `just tokenplace-port-forward ...`
+
+Recipe interfaces are intentionally generic so Sugarkube can onboard token.place without pretending
+chart/release details are already fixed in this repository.

--- a/justfile
+++ b/justfile
@@ -1542,46 +1542,102 @@ tokenplace-oci-redeploy tag='':
 
     echo "token.place relay available at: https://staging.token.place"
 
-tokenplace-status:
-    @just app-status namespace=tokenplace release=tokenplace-relay host_key='ingress.host'
+tokenplace-deploy env='staging' chart='' namespace='' release='' values='' tag='' default_tag='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
 
-tokenplace-logs namespace='tokenplace':
+    if [ -z "{{ chart }}" ] || [ -z "{{ namespace }}" ] || [ -z "{{ release }}" ] || [ -z "{{ values }}" ]; then
+      echo "Usage: just tokenplace-deploy env=<dev|staging|prod> chart=<chart> namespace=<ns> release=<release> values=<file1,file2> [tag=<tag>] [default_tag=<tag>]" >&2
+      echo "See docs/tokenplace_sugarkube_onboarding.md for onboarding expectations." >&2
+      exit 1
+    fi
+
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
+      release='{{ release }}' namespace='{{ namespace }}' \
+      chart='{{ chart }}' values='{{ values }}' \
+      tag='{{ tag }}' default_tag='{{ default_tag }}'
+
+tokenplace-upgrade env='staging' chart='' namespace='' release='' values='' tag='' default_tag='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    if [ -z "{{ chart }}" ] || [ -z "{{ namespace }}" ] || [ -z "{{ release }}" ] || [ -z "{{ values }}" ]; then
+      echo "Usage: just tokenplace-upgrade env=<dev|staging|prod> chart=<chart> namespace=<ns> release=<release> values=<file1,file2> [tag=<tag>] [default_tag=<tag>]" >&2
+      echo "See docs/tokenplace_sugarkube_onboarding.md for onboarding expectations." >&2
+      exit 1
+    fi
+
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
+      release='{{ release }}' namespace='{{ namespace }}' \
+      chart='{{ chart }}' values='{{ values }}' \
+      tag='{{ tag }}' default_tag='{{ default_tag }}'
+
+tokenplace-rollback namespace='' release='' revision='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    if [ -z "{{ namespace }}" ] || [ -z "{{ release }}" ] || [ -z "{{ revision }}" ]; then
+      echo "Usage: just tokenplace-rollback namespace=<ns> release=<release> revision=<helm-revision>" >&2
+      exit 1
+    fi
+    helm -n "{{ namespace }}" rollback "{{ release }}" "{{ revision }}"
+
+tokenplace-status namespace='tokenplace' release='tokenplace-relay' host_key='ingress.host':
+    @just app-status namespace='{{ namespace }}' release='{{ release }}' host_key='{{ host_key }}'
+
+tokenplace-logs namespace='tokenplace' selector='app.kubernetes.io/name=tokenplace-relay':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
     export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
     ns="{{ namespace }}"
+    selector="{{ selector }}"
 
-    echo "=== token.place relay pods in namespace ${ns} ==="
+    echo "=== token.place pods in namespace ${ns} ==="
     kubectl get pods -n "${ns}" -o wide || {
-      echo "Failed to list tokenplace-relay pods in namespace ${ns}" >&2
+      echo "Failed to list token.place pods in namespace ${ns}" >&2
     }
 
     echo
-    echo "=== token.place relay logs (last 200 lines per pod) ==="
-    relay_pods=$(kubectl get pods -n "${ns}" -l app.kubernetes.io/name=tokenplace-relay -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
+    echo "=== token.place logs (last 200 lines per pod) ==="
+    relay_pods=$(kubectl get pods -n "${ns}" -l "${selector}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
 
     if [ -z "${relay_pods}" ]; then
-      echo "No pods found with label app.kubernetes.io/name=tokenplace-relay in namespace ${ns}" >&2
+      echo "No pods found with selector '${selector}' in namespace ${ns}" >&2
     else
       for pod in ${relay_pods}; do
         echo
-        echo "--- tokenplace-relay pod: ${pod} ---"
+        echo "--- token.place pod: ${pod} ---"
         kubectl logs -n "${ns}" "${pod}" --tail=200 || {
           echo "Failed to fetch logs for pod ${pod}" >&2
         }
       done
     fi
 
-tokenplace-port-forward local_port='5010':
+tokenplace-validate namespace='tokenplace' release='tokenplace-relay' host='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    ns="{{ namespace }}"
+    rel="{{ release }}"
+    host="{{ host }}"
+
+    just --justfile "{{ justfile_directory() }}/justfile" tokenplace-status namespace="${ns}" release="${rel}"
+    if [ -n "${host}" ]; then
+      echo "Running host checks against ${host}"
+      curl -fsS "${host}/healthz" >/dev/null
+      curl -fsS "${host}/livez" >/dev/null || true
+    else
+      echo "No host provided. Pass host=https://<tokenplace-host> to include HTTP checks."
+    fi
+
+tokenplace-port-forward namespace='tokenplace' resource='svc/tokenplace-relay' local_port='5010' remote_port='80':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
     export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-    svc="tokenplace-relay"
-
-    echo "Port-forwarding ${svc} to localhost:{{ local_port }} (Ctrl+C to stop)..."
-    kubectl -n tokenplace port-forward svc/${svc} {{ local_port }}:80
+    echo "Port-forwarding {{ resource }} in namespace {{ namespace }} to localhost:{{ local_port }} (Ctrl+C to stop)..."
+    kubectl -n "{{ namespace }}" port-forward "{{ resource }}" "{{ local_port }}":"{{ remote_port }}"
 
 app-status namespace='' release='' host_key='ingress.host':
     #!/usr/bin/env bash


### PR DESCRIPTION
### Motivation
- Prepare Sugarkube to host token.place by adding discoverable onboarding/runbook docs and operator-facing task recipes that are parameterized so they don't hard-code token.place chart/release names before those are finalized.
- Mirror existing DSPACE runbook shape and Helm/OCI promotion patterns so operators can reuse familiar workflows for deploy/upgrade/rollback and validation.

### Description
- Add onboarding and runbooks: `docs/tokenplace_sugarkube_onboarding.md`, `docs/apps/tokenplace.md`, and environment-specific runbooks `docs/k3s-tokenplace-dev.md`, `docs/k3s-tokenplace-staging.md`, and `docs/k3s-tokenplace-prod.md` describing topology, prerequisites, workflows, secrets guidance, Cloudflare/ingress expectations, and operator caveats.
- Extend `justfile` with parameterized token.place recipes: `tokenplace-deploy`, `tokenplace-upgrade`, `tokenplace-rollback`, `tokenplace-validate`, `tokenplace-status`, `tokenplace-logs`, and `tokenplace-port-forward`, while preserving the existing `tokenplace-oci-redeploy` relay helper; recipes intentionally accept `chart/namespace/release/values/tag` inputs or clearly document required placeholders.
- Update docs navigation and references so the new onboarding/runbook docs are discoverable and link `docs/apps/tokenplace-relay.md` to the new onboarding material.
- Keep changes conservative and non-prescriptive so Sugarkube remains generic and future follow-ups can promote canonical chart/release names once token.place maintainers settle them.

### Testing
- Ran `just --list | rg tokenplace` to verify recipe visibility and the new token.place entries were listed successfully.
- Ran `pytest -q tests/test_docs_guardrails.py` which completed successfully (`3 passed`).
- Ran `pytest -q tests/test_taskfile.py::test_taskfile_includes_make_style_aliases` which completed successfully (`1 passed`).
- Executed `git diff --cached | ./scripts/scan-secrets.py` (secret scan) with no findings in the staged changes.
- Attempted repository checks (`pre-commit`, `pyspelling`, `linkchecker`) but the environment lacked those tools so direct invocations failed; `./scripts/checks.sh` ran but reported pre-existing lint issues (line-length/whitespace) unrelated to these additions and not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4ab2ef678832faeae931c331f362b)