### PR TITLE
📝 Prepare token.place onboarding docs and parameterized justfile recipes

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -209,6 +209,7 @@ roadmap
 roundtrip
 rpi
 runbook
+runbooks
 runtime
 sed
 sfL

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
 - **[Raspberry Pi cluster series](docs/index.md#raspberry-pi-cluster-series)** — Part 1/Part 2
   quick-starts plus manual walkthroughs when you want the raw commands.
 
+## Application runbooks
+
+- **[token.place onboarding contract](docs/tokenplace_sugarkube_onboarding.md)** — prerequisites,
+  ownership boundaries, and environment mapping for first-class token.place operations.
+- **[token.place app operations](docs/apps/tokenplace.md)** — topology and deployment workflow
+  patterns for token.place on Sugarkube.
+- **[token.place env runbooks](docs/k3s-tokenplace-dev.md)** — environment-specific guides for
+  dev, staging, and production operations.
+
 ## Repository layout
 
 - `cad/` — OpenSCAD models of structural parts. See

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
   ownership boundaries, and environment mapping for first-class token.place operations.
 - **[token.place app operations](docs/apps/tokenplace.md)** — topology and deployment workflow
   patterns for token.place on Sugarkube.
-- **[token.place env runbooks](docs/k3s-tokenplace-dev.md)** — environment-specific guides for
-  dev, staging, and production operations.
+- **[token.place env runbooks](docs/index.md)** — environment-specific guides for
+  [dev](docs/k3s-tokenplace-dev.md), [staging](docs/k3s-tokenplace-staging.md), and
+  [production](docs/k3s-tokenplace-prod.md) operations.
 
 ## Repository layout
 

--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -5,7 +5,7 @@ matches the existing dspace staging patterns. The public staging host for the re
 `staging.token.place`, fronted by Traefik and Cloudflare Tunnel.
 
 For full token.place onboarding and environment runbooks, see
-`docs/tokenplace_sugarkube_onboarding.md` and `docs/apps/tokenplace.md`.
+[`docs/tokenplace_sugarkube_onboarding.md`](../tokenplace_sugarkube_onboarding.md) and [`docs/apps/tokenplace.md`](./tokenplace.md).
 
 Values are split so you can reuse base settings across environments and layer staging-only ingress
 overrides. Operator defaults live alongside the chart; the docs copies remain as examples for

--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -4,6 +4,9 @@ Deploy the `token.place` relay (`relay.py`) to the Sugarkube k3s cluster with a 
 matches the existing dspace staging patterns. The public staging host for the relay service is
 `staging.token.place`, fronted by Traefik and Cloudflare Tunnel.
 
+For full token.place onboarding and environment runbooks, see
+`docs/tokenplace_sugarkube_onboarding.md` and `docs/apps/tokenplace.md`.
+
 Values are split so you can reuse base settings across environments and layer staging-only ingress
 overrides. Operator defaults live alongside the chart; the docs copies remain as examples for
 cut-and-paste use:

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -1,0 +1,103 @@
+# token.place on Sugarkube
+
+This guide describes the intended token.place deployment model on Sugarkube once token.place
+release artifacts are ready for formal onboarding.
+
+For onboarding sequence and ownership boundaries, start with
+`docs/tokenplace_sugarkube_onboarding.md`.
+
+## Intended topology
+
+token.place on Sugarkube is expected to use a split model:
+
+- **In-cluster (Sugarkube):** edge/API-facing components, ingress, relay-facing services,
+  environment configuration, and operational controls.
+- **External compute nodes:** heavier execution workloads that do not need to run on the Pi cluster.
+
+This keeps Sugarkube focused on durable control-plane and ingress responsibilities while allowing
+compute capacity to scale independently.
+
+## Component placement guidance
+
+Place on Sugarkube when a component:
+
+- terminates external traffic,
+- requires tight integration with k3s ingress/secrets,
+- benefits from near-cluster observability and rollout controls.
+
+Prefer external compute when a component:
+
+- is CPU/GPU intensive,
+- has bursty runtime needs,
+- can tolerate network hop separation from the relay/API plane.
+
+## Post-API-v1 secure deployment model
+
+Expected steady state after API v1 convergence:
+
+- all component-to-component communication uses authenticated API v1 paths,
+- secrets are supplied via Kubernetes Secrets (or SOPS/Flux-managed equivalents),
+- ingress is fronted by Cloudflare + Traefik,
+- environment-specific values control hostnames, auth endpoints, and upstream compute routing.
+
+## Prerequisites
+
+- Sugarkube k3s cluster healthy for target environment (`dev`, `staging`, or `prod`).
+- Cloudflare tunnel + DNS entries prepared for target token.place hostnames.
+- Token.place chart and image artifacts available and documented.
+- Environment values files prepared and reviewed.
+
+## Core operational workflow
+
+Use parameterized `just` recipes so unreconciled naming can be supplied at runtime:
+
+1. Deploy/install:
+
+   ```bash
+   just tokenplace-deploy release=<release> namespace=<namespace> chart=<chart-ref> values=<base>,<env> tag=<tag>
+   ```
+
+2. Upgrade:
+
+   ```bash
+   just tokenplace-upgrade release=<release> namespace=<namespace> chart=<chart-ref> values=<base>,<env> tag=<tag>
+   ```
+
+3. Rollback:
+
+   ```bash
+   just tokenplace-rollback release=<release> namespace=<namespace> revision=<revision>
+   ```
+
+4. Validate:
+
+   ```bash
+   just tokenplace-validate namespace=<namespace> release=<release> health_url=https://<host>/<health-path>
+   ```
+
+5. Inspect and debug:
+
+   ```bash
+   just tokenplace-status namespace=<namespace> release=<release>
+   just tokenplace-logs namespace=<namespace> selector=<label-selector>
+   just tokenplace-port-forward namespace=<namespace> service=<service> local_port=8080 remote_port=80
+   ```
+
+## Cloudflare and ingress expectations
+
+- Public access should terminate via Cloudflare and forward to Traefik.
+- Hostnames should be environment-specific (`dev`, `staging`, `prod`) and documented in the env
+  runbooks.
+- cert-manager issuer and TLS secret naming should be explicit per environment.
+
+## Secrets and config guidance
+
+- Keep environment-specific secrets out of docs and commit history.
+- Prefer immutable promotion tags for staging/prod.
+- Keep shared defaults separate from env overlays to reduce accidental prod drift.
+
+## Operator notes
+
+- Do not assume namespace/release/chart naming until token.place onboarding finalizes.
+- Keep recipes parameterized and runbooks explicit about what is fixed vs configurable.
+- Use relay-specific guide (`docs/apps/tokenplace-relay.md`) for current relay-only operations.

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -4,7 +4,7 @@ This guide describes the intended token.place deployment model on Sugarkube once
 release artifacts are ready for formal onboarding.
 
 For onboarding sequence and ownership boundaries, start with
-`docs/tokenplace_sugarkube_onboarding.md`.
+[`docs/tokenplace_sugarkube_onboarding.md`](../tokenplace_sugarkube_onboarding.md).
 
 ## Intended topology
 
@@ -100,4 +100,4 @@ Use parameterized `just` recipes so unreconciled naming can be supplied at runti
 
 - Do not assume namespace/release/chart naming until token.place onboarding finalizes.
 - Keep recipes parameterized and runbooks explicit about what is fixed vs configurable.
-- Use relay-specific guide (`docs/apps/tokenplace-relay.md`) for current relay-only operations.
+- Use relay-specific guide ([`docs/apps/tokenplace-relay.md`](./tokenplace-relay.md)) for current relay-only operations.

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,13 @@ Review the safety notes before working with power components.
   verify Traefik ingress, and roll out workloads
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
 - [projects-compose.md](projects-compose.md) — run token.place & dspace via docker compose
+- [tokenplace_sugarkube_onboarding.md](tokenplace_sugarkube_onboarding.md) — onboarding contract,
+  ownership boundaries, and environment mapping for token.place on Sugarkube
+- [apps/tokenplace.md](apps/tokenplace.md) — token.place app topology and operations model on Sugarkube
 - [apps/tokenplace-relay.md](apps/tokenplace-relay.md) — operate the token.place relay staging deployment
+- [k3s-tokenplace-dev.md](k3s-tokenplace-dev.md) — token.place dev runbook
+- [k3s-tokenplace-staging.md](k3s-tokenplace-staging.md) — token.place staging runbook
+- [k3s-tokenplace-prod.md](k3s-tokenplace-prod.md) — token.place production runbook
 - [operations/security-checklist.md](operations/security-checklist.md) — track credential rotations and
   verification steps
 - [pi_token_dspace.md](pi_token_dspace.md) — build and expose token.place & dspace via Cloudflare

--- a/docs/k3s-tokenplace-dev.md
+++ b/docs/k3s-tokenplace-dev.md
@@ -1,0 +1,70 @@
+# k3s token.place runbook (dev)
+
+Use this runbook for `dev` token.place deployments on Sugarkube.
+
+## Purpose
+
+- Fast feedback for onboarding and integration changes.
+- Validate chart wiring and values layering before staging.
+
+## Topology intent (dev)
+
+- Sugarkube hosts ingress/API-facing token.place components.
+- External compute handles heavy runtime jobs.
+- Routing and upstream credentials are dev-scoped.
+
+## Prerequisites
+
+- `kubectl`, `helm`, and `just` installed.
+- Kubeconfig points to the dev environment cluster/context.
+- token.place chart + image tag available.
+- Dev values files prepared.
+
+## Deploy / upgrade / rollback
+
+```bash
+just tokenplace-deploy \
+  release=<release> namespace=<namespace> chart=<chart-ref> \
+  values=<base-values>,<dev-values> version_file=<optional-version-file> \
+  tag=<tag>
+```
+
+```bash
+just tokenplace-upgrade \
+  release=<release> namespace=<namespace> chart=<chart-ref> \
+  values=<base-values>,<dev-values> version_file=<optional-version-file> \
+  tag=<tag>
+```
+
+```bash
+just tokenplace-rollback release=<release> namespace=<namespace> revision=<helm-revision>
+```
+
+## Validation
+
+```bash
+just tokenplace-status namespace=<namespace> release=<release>
+just tokenplace-validate namespace=<namespace> release=<release> health_url=https://<dev-host>/<health>
+```
+
+```bash
+just tokenplace-logs namespace=<namespace> selector=<label-selector>
+```
+
+## Local verification helper
+
+```bash
+just tokenplace-port-forward namespace=<namespace> service=<service> local_port=8080 remote_port=80
+curl -fsS http://127.0.0.1:8080/<health>
+```
+
+## Ingress / Cloudflare expectations
+
+- Dev hostname should be isolated from staging/prod.
+- Cloudflare tunnel/DNS should target Traefik for dev hostnames.
+- TLS secrets should not be shared across environments.
+
+## Notes
+
+- Dev may tolerate mutable convenience tags, but staging/prod should prefer immutable tags.
+- Keep compute-node endpoint and auth config explicitly dev-scoped.

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -1,0 +1,71 @@
+# k3s token.place runbook (prod)
+
+Use this runbook for `prod` token.place deployments on Sugarkube.
+
+## Purpose
+
+- Safe production deployment, validation, and rollback.
+- Preserve availability with explicit promotion and incident-response workflow.
+
+## Topology intent (prod)
+
+- Sugarkube hosts production ingress/API-facing token.place services.
+- External compute nodes execute heavy workloads and are reached through secured API v1 links.
+- Public hostnames route through Cloudflare to Traefik ingress.
+
+## Prerequisites
+
+- Staging validation completed for the target immutable tag.
+- Production values overlays and secrets approved.
+- Rollback revision identified before upgrade begins.
+
+## Deploy / upgrade / rollback
+
+```bash
+just tokenplace-deploy \
+  release=<release> namespace=<namespace> chart=<chart-ref> \
+  values=<base-values>,<prod-values> version_file=<optional-version-file> \
+  tag=<approved-immutable-tag>
+```
+
+```bash
+just tokenplace-upgrade \
+  release=<release> namespace=<namespace> chart=<chart-ref> \
+  values=<base-values>,<prod-values> version_file=<optional-version-file> \
+  tag=<approved-immutable-tag>
+```
+
+```bash
+# List history first, then rollback if needed.
+helm -n <namespace> history <release>
+just tokenplace-rollback release=<release> namespace=<namespace> revision=<known-good-revision>
+```
+
+## Validation checks
+
+```bash
+just tokenplace-status namespace=<namespace> release=<release>
+just tokenplace-validate namespace=<namespace> release=<release> health_url=https://<prod-host>/<health>
+```
+
+```bash
+just tokenplace-logs namespace=<namespace> selector=<label-selector>
+```
+
+## Cloudflare / ingress expectations
+
+- Production hostname and TLS secret names are stable and documented.
+- Cloudflare tunnel routes only expected production hosts.
+- Any emergency DNS/ingress change is logged in outage documentation.
+
+## Secrets/config guidance
+
+- Use production-scoped credentials only; never reuse lower-environment keys.
+- Keep secret rotation cadence aligned with Sugarkube security checklist.
+- Apply least-privilege API tokens for DNS/tunnel automation.
+
+## Operator notes and caveats
+
+- Avoid mutable tags in production.
+- Keep a known-good rollback revision and artifact digest recorded for each deploy.
+- If rollout behavior diverges from staging, pause further promotions and capture diagnostics.

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -1,0 +1,66 @@
+# k3s token.place runbook (staging)
+
+Use this runbook for `staging` token.place deployments on Sugarkube.
+
+## Purpose
+
+- Release-candidate validation before production promotion.
+- Full ingress + Cloudflare + TLS + API v1 behavior checks.
+
+## Topology intent (staging)
+
+- Sugarkube runs ingress/API-facing token.place services and relay integration points.
+- External compute remains out-of-cluster but reachable over secured API v1 paths.
+- Staging should mirror production architecture closely, with lower traffic volume.
+
+## Prerequisites
+
+- Chart/release wiring is defined for staging.
+- Staging values overlays and secrets are reviewed.
+- Cloudflare hostname routing to Traefik is configured.
+
+## Deploy / upgrade / rollback
+
+```bash
+just tokenplace-deploy \
+  release=<release> namespace=<namespace> chart=<chart-ref> \
+  values=<base-values>,<staging-values> version_file=<optional-version-file> \
+  tag=<immutable-tag>
+```
+
+```bash
+just tokenplace-upgrade \
+  release=<release> namespace=<namespace> chart=<chart-ref> \
+  values=<base-values>,<staging-values> version_file=<optional-version-file> \
+  tag=<immutable-tag>
+```
+
+```bash
+just tokenplace-rollback release=<release> namespace=<namespace> revision=<helm-revision>
+```
+
+## Validation checks
+
+```bash
+just tokenplace-status namespace=<namespace> release=<release>
+just tokenplace-validate namespace=<namespace> release=<release> health_url=https://<staging-host>/<health>
+```
+
+- Confirm ingress host and TLS certificate are ready.
+- Confirm API v1 auth and external compute connectivity are healthy.
+- Capture logs for relay/API components when validating release candidates.
+
+```bash
+just tokenplace-logs namespace=<namespace> selector=<label-selector>
+```
+
+## Cloudflare / ingress expectations
+
+- Staging hostname is distinct from production hostname.
+- Tunnel target points to Traefik (`kube-system` service).
+- DNS records remain proxied in Cloudflare.
+
+## Operator caveats
+
+- Treat staging as promotion gate; avoid ad hoc value edits.
+- Prefer immutable tags for reproducible rollback and forensic traceability.

--- a/docs/software/index.md
+++ b/docs/software/index.md
@@ -42,8 +42,16 @@ and supporting services stay healthy.
   Docker Compose.
 - [pi_token_dspace.md](../pi_token_dspace.md) — expose token.place/dspace through
   Cloudflare tunnels.
+- [tokenplace_sugarkube_onboarding.md](../tokenplace_sugarkube_onboarding.md) — onboarding
+  contract for token.place artifacts, ownership, and environment wiring.
+- [apps/tokenplace.md](../apps/tokenplace.md) — primary token.place app operations guide on
+  Sugarkube.
+- [k3s-tokenplace-dev.md](../k3s-tokenplace-dev.md),
+  [k3s-tokenplace-staging.md](../k3s-tokenplace-staging.md), and
+  [k3s-tokenplace-prod.md](../k3s-tokenplace-prod.md) — environment runbooks for day-2
+  operations.
 - [apps/tokenplace-relay.md](../apps/tokenplace-relay.md) — Helm ingress/TLS guide for
-  token.place staging.
+  token.place staging relay operations.
 
 ## Developer Workflow
 - [contributor_script_map.md](../contributor_script_map.md) — keep automation docs

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -1,0 +1,107 @@
+# token.place Sugarkube onboarding
+
+This guide prepares Sugarkube to run `token.place` as a first-class workload once token.place
+release artifacts and chart wiring are finalized.
+
+It is intentionally a **deployment-preparation** runbook: it defines stable interfaces,
+ownership, and operational shape without pretending that chart/release identifiers are immutable
+before the token.place onboarding cutover is complete.
+
+## Why token.place belongs on Sugarkube
+
+- Sugarkube already provides a repeatable k3s + ingress + Cloudflare operating model.
+- token.place already has relay operations on Sugarkube (`docs/apps/tokenplace-relay.md`), so this
+  onboarding extends an existing operational pattern instead of introducing a new stack.
+- Sugarkube gives a consistent operator interface (`just` + runbooks) across `dev`, `staging`, and
+  `prod`, reducing drift during promotion and rollback.
+
+## Preconditions before onboarding
+
+Before onboarding the full token.place workload, confirm token.place has completed:
+
+1. Shared desktop/server compute-node runtime.
+2. Desktop parity with `server.py` behavior.
+3. Operationally mature relay service.
+4. Secure API v1 convergence across token.place components.
+5. Release artifact publication (container images + Helm chart) suitable for repeatable deployment.
+
+If any precondition is incomplete, keep using relay-only operations and postpone full onboarding.
+
+## Release artifact expectations
+
+During onboarding, token.place should provide:
+
+- A Helm chart (OCI or repository path) that supports environment-specific values overlays.
+- Versioned chart metadata (or pinned chart digest/version).
+- Container image tags suitable for promotion (prefer immutable tags).
+- Health endpoints and readiness/liveness semantics documented for operator validation.
+
+## Expected Sugarkube wiring (standardized vs configurable)
+
+Standardized in Sugarkube:
+
+- Task-runner interface (recipes in `justfile`):
+  - `tokenplace-deploy`
+  - `tokenplace-upgrade`
+  - `tokenplace-rollback`
+  - `tokenplace-status`
+  - `tokenplace-logs`
+  - `tokenplace-validate`
+  - `tokenplace-port-forward`
+- Environment runbooks:
+  - `docs/k3s-tokenplace-dev.md`
+  - `docs/k3s-tokenplace-staging.md`
+  - `docs/k3s-tokenplace-prod.md`
+
+Configurable per onboarding cutover:
+
+- Namespace, release name, chart location, values files, chart version pin, and image tag strategy.
+- Ingress hosts and Cloudflare DNS/tunnel mapping.
+- Which token.place components run in-cluster vs on external compute nodes.
+
+## Environment mapping
+
+- `dev`: fast iteration, lower blast radius, relaxed SLOs.
+- `staging`: pre-production integration and release validation.
+- `prod`: public workload, strict rollback and change-control discipline.
+
+Use the environment-specific runbooks for concrete command patterns.
+
+## Ownership boundaries
+
+- **token.place team** owns chart/app semantics, release artifacts, and component-level config.
+- **Sugarkube operators** own cluster lifecycle, ingress/tunnel plumbing, secret distribution,
+  deployment execution, and rollback orchestration.
+- Shared responsibility: production cutover sequencing, health-gate criteria, and incident
+  response.
+
+## App catalog and related docs
+
+- App overview: `docs/apps/tokenplace.md`
+- Relay-specific operations: `docs/apps/tokenplace-relay.md`
+- Environment runbooks:
+  - `docs/k3s-tokenplace-dev.md`
+  - `docs/k3s-tokenplace-staging.md`
+  - `docs/k3s-tokenplace-prod.md`
+
+## Baseline command templates
+
+Set values explicitly per environment to avoid hidden assumptions:
+
+```bash
+just tokenplace-deploy \
+  release=<release> namespace=<namespace> chart=<chart-ref> \
+  values=<base-values>,<env-values> version_file=<optional-version-file> \
+  tag=<image-tag>
+```
+
+```bash
+just tokenplace-upgrade \
+  release=<release> namespace=<namespace> chart=<chart-ref> \
+  values=<base-values>,<env-values> version_file=<optional-version-file> \
+  tag=<image-tag>
+```
+
+```bash
+just tokenplace-rollback release=<release> namespace=<namespace> revision=<helm-revision>
+```

--- a/justfile
+++ b/justfile
@@ -1587,8 +1587,31 @@ tokenplace-rollback release='' namespace='' revision='':
       echo "Usage: just tokenplace-rollback release=<name> namespace=<ns> revision=<helm_revision>" >&2
       exit 1
     fi
-    helm -n '{{ namespace }}' rollback '{{ release }}' '{{ revision }}'
-    kubectl -n '{{ namespace }}' rollout status deploy/'{{ release }}' --timeout=180s || true
+    ns='{{ namespace }}'
+    release='{{ release }}'
+
+    helm -n "${ns}" rollback "${release}" '{{ revision }}'
+
+    workloads="$(
+      {
+        kubectl -n "${ns}" get deploy,statefulset \
+          -l "app.kubernetes.io/instance=${release}" \
+          -o jsonpath='{range .items[*]}{.kind}/{.metadata.name}{"\n"}{end}'
+        kubectl -n "${ns}" get deploy,statefulset \
+          -l "release=${release}" \
+          -o jsonpath='{range .items[*]}{.kind}/{.metadata.name}{"\n"}{end}'
+      } | sed '/^$/d' | sort -u
+    )"
+
+    if [ -z "${workloads}" ]; then
+      echo "No Deployment or StatefulSet found for Helm release ${release} in namespace ${ns}" >&2
+      exit 1
+    fi
+
+    while IFS= read -r workload; do
+      [ -n "${workload}" ] || continue
+      kubectl -n "${ns}" rollout status "${workload}" --timeout=180s
+    done <<< "${workloads}"
 
 tokenplace-logs namespace='tokenplace' selector='app.kubernetes.io/name=tokenplace-relay' tail='200':
     #!/usr/bin/env bash
@@ -1596,22 +1619,23 @@ tokenplace-logs namespace='tokenplace' selector='app.kubernetes.io/name=tokenpla
 
     export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
     ns="{{ namespace }}"
+    selector="{{ selector }}"
 
-    echo "=== token.place relay pods in namespace ${ns} ==="
-    kubectl get pods -n "${ns}" -o wide || {
-      echo "Failed to list tokenplace-relay pods in namespace ${ns}" >&2
+    echo "=== token.place pods in namespace ${ns} matching selector ${selector} ==="
+    kubectl get pods -n "${ns}" -l "${selector}" -o wide || {
+      echo "Failed to list token.place pods with selector ${selector} in namespace ${ns}" >&2
     }
 
     echo
-    echo "=== token.place relay logs (last 200 lines per pod) ==="
-    relay_pods=$(kubectl get pods -n "${ns}" -l '{{ selector }}' -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
+    echo "=== token.place logs (last {{ tail }} lines per pod, selector: ${selector}) ==="
+    relay_pods=$(kubectl get pods -n "${ns}" -l "${selector}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
 
     if [ -z "${relay_pods}" ]; then
       echo "No pods found with selector {{ selector }} in namespace ${ns}" >&2
     else
       for pod in ${relay_pods}; do
         echo
-        echo "--- tokenplace-relay pod: ${pod} ---"
+        echo "--- pod: ${pod} ---"
         kubectl logs -n "${ns}" "${pod}" --tail='{{ tail }}' || {
           echo "Failed to fetch logs for pod ${pod}" >&2
         }
@@ -1627,7 +1651,8 @@ tokenplace-validate namespace='tokenplace' release='tokenplace-relay' health_url
 
     kubectl -n '{{ namespace }}' get pods -l '{{ selector }}'
     if [ -n '{{ health_url }}' ]; then
-      curl -fsS '{{ health_url }}' | head -c 400 || true
+      health_response="$(curl -fsS '{{ health_url }}')"
+      printf '%.400s\n' "${health_response}"
       echo
     else
       echo "No health_url provided; skipping HTTP health check."

--- a/justfile
+++ b/justfile
@@ -1516,8 +1516,8 @@ dspace-debug-logs-env env='staging' namespace='dspace':
 
 # Fast redeploy of token.place relay from GHCR.
 # The default tag pins staging to the last validated `main` build; pass tag=sha-<new>
-
 # after promoting a fresh image.
+# See docs/apps/tokenplace-relay.md for relay-specific operations.
 tokenplace-oci-redeploy tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
@@ -1542,10 +1542,55 @@ tokenplace-oci-redeploy tag='':
 
     echo "token.place relay available at: https://staging.token.place"
 
-tokenplace-status:
-    @just app-status namespace=tokenplace release=tokenplace-relay host_key='ingress.host'
+# token.place app status helper.
+# Parameters are intentionally configurable because chart/release wiring can vary.
+# See docs/tokenplace_sugarkube_onboarding.md and docs/apps/tokenplace.md.
+tokenplace-status namespace='tokenplace' release='tokenplace-relay' host_key='ingress.host':
+    @just app-status namespace='{{ namespace }}' release='{{ release }}' host_key='{{ host_key }}'
 
-tokenplace-logs namespace='tokenplace':
+# Install-or-upgrade token.place via configurable Helm OCI wiring.
+# Uses helm upgrade --install underneath via the shared helper.
+tokenplace-deploy release='' namespace='' chart='' values='' version_file='' version='' tag='' default_tag='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    if [ -z '{{ release }}' ] || [ -z '{{ namespace }}' ] || [ -z '{{ chart }}' ] || [ -z '{{ values }}' ]; then
+      echo "Usage: just tokenplace-deploy release=<name> namespace=<ns> chart=<oci|path> values=<file1,file2>" >&2
+      echo "See docs/tokenplace_sugarkube_onboarding.md for expected parameter wiring." >&2
+      exit 1
+    fi
+
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
+      release='{{ release }}' namespace='{{ namespace }}' chart='{{ chart }}' values='{{ values }}' \
+      version_file='{{ version_file }}' version='{{ version }}' tag='{{ tag }}' default_tag='{{ default_tag }}'
+
+# Upgrade-only path for existing token.place releases.
+tokenplace-upgrade release='' namespace='' chart='' values='' version_file='' version='' tag='' default_tag='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    if [ -z '{{ release }}' ] || [ -z '{{ namespace }}' ] || [ -z '{{ chart }}' ] || [ -z '{{ values }}' ]; then
+      echo "Usage: just tokenplace-upgrade release=<name> namespace=<ns> chart=<oci|path> values=<file1,file2>" >&2
+      echo "See docs/tokenplace_sugarkube_onboarding.md for expected parameter wiring." >&2
+      exit 1
+    fi
+
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
+      release='{{ release }}' namespace='{{ namespace }}' chart='{{ chart }}' values='{{ values }}' \
+      version_file='{{ version_file }}' version='{{ version }}' tag='{{ tag }}' default_tag='{{ default_tag }}'
+
+tokenplace-rollback release='' namespace='' revision='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    if [ -z '{{ release }}' ] || [ -z '{{ namespace }}' ] || [ -z '{{ revision }}' ]; then
+      echo "Usage: just tokenplace-rollback release=<name> namespace=<ns> revision=<helm_revision>" >&2
+      exit 1
+    fi
+    helm -n '{{ namespace }}' rollback '{{ release }}' '{{ revision }}'
+    kubectl -n '{{ namespace }}' rollout status deploy/'{{ release }}' --timeout=180s || true
+
+tokenplace-logs namespace='tokenplace' selector='app.kubernetes.io/name=tokenplace-relay' tail='200':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1559,29 +1604,44 @@ tokenplace-logs namespace='tokenplace':
 
     echo
     echo "=== token.place relay logs (last 200 lines per pod) ==="
-    relay_pods=$(kubectl get pods -n "${ns}" -l app.kubernetes.io/name=tokenplace-relay -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
+    relay_pods=$(kubectl get pods -n "${ns}" -l '{{ selector }}' -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
 
     if [ -z "${relay_pods}" ]; then
-      echo "No pods found with label app.kubernetes.io/name=tokenplace-relay in namespace ${ns}" >&2
+      echo "No pods found with selector {{ selector }} in namespace ${ns}" >&2
     else
       for pod in ${relay_pods}; do
         echo
         echo "--- tokenplace-relay pod: ${pod} ---"
-        kubectl logs -n "${ns}" "${pod}" --tail=200 || {
+        kubectl logs -n "${ns}" "${pod}" --tail='{{ tail }}' || {
           echo "Failed to fetch logs for pod ${pod}" >&2
         }
       done
     fi
 
-tokenplace-port-forward local_port='5010':
+tokenplace-validate namespace='tokenplace' release='tokenplace-relay' health_url='' selector='app.kubernetes.io/name=tokenplace-relay':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    just --justfile "{{ justfile_directory() }}/justfile" tokenplace-status \
+      namespace='{{ namespace }}' release='{{ release }}'
+
+    kubectl -n '{{ namespace }}' get pods -l '{{ selector }}'
+    if [ -n '{{ health_url }}' ]; then
+      curl -fsS '{{ health_url }}' | head -c 400 || true
+      echo
+    else
+      echo "No health_url provided; skipping HTTP health check."
+    fi
+
+tokenplace-port-forward namespace='tokenplace' service='tokenplace-relay' local_port='5010' remote_port='80':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
     export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-    svc="tokenplace-relay"
+    svc='{{ service }}'
 
     echo "Port-forwarding ${svc} to localhost:{{ local_port }} (Ctrl+C to stop)..."
-    kubectl -n tokenplace port-forward svc/${svc} {{ local_port }}:80
+    kubectl -n '{{ namespace }}' port-forward svc/${svc} {{ local_port }}:{{ remote_port }}
 
 app-status namespace='' release='' host_key='ingress.host':
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -1542,8 +1542,8 @@ tokenplace-oci-redeploy tag='':
 
     echo "token.place relay available at: https://staging.token.place"
 
-# token.place app status helper.
-# Parameters are intentionally configurable because chart/release wiring can vary.
+# token.place app status helper (generic/parameterized defaults, not final release wiring).
+# Override namespace/release/host_key per environment until onboarding locks chart naming.
 # See docs/tokenplace_sugarkube_onboarding.md and docs/apps/tokenplace.md.
 tokenplace-status namespace='tokenplace' release='tokenplace-relay' host_key='ingress.host':
     @just app-status namespace='{{ namespace }}' release='{{ release }}' host_key='{{ host_key }}'
@@ -1642,6 +1642,8 @@ tokenplace-logs namespace='tokenplace' selector='app.kubernetes.io/name=tokenpla
       done
     fi
 
+# Validation helper keeps generic defaults as placeholders; set selector/release/health_url per deployment.
+# Do not treat tokenplace-relay defaults here as final token.place production naming.
 tokenplace-validate namespace='tokenplace' release='tokenplace-relay' health_url='' selector='app.kubernetes.io/name=tokenplace-relay':
     #!/usr/bin/env bash
     set -Eeuo pipefail
@@ -1658,6 +1660,8 @@ tokenplace-validate namespace='tokenplace' release='tokenplace-relay' health_url
       echo "No health_url provided; skipping HTTP health check."
     fi
 
+# Port-forward helper uses placeholder defaults for convenience; override service/ports for real app components.
+# Keep this recipe generic while token.place release/service naming is still being finalized.
 tokenplace-port-forward namespace='tokenplace' service='tokenplace-relay' local_port='5010' remote_port='80':
     #!/usr/bin/env bash
     set -Eeuo pipefail

--- a/justfile
+++ b/justfile
@@ -1517,6 +1517,7 @@ dspace-debug-logs-env env='staging' namespace='dspace':
 # Fast redeploy of token.place relay from GHCR.
 # The default tag pins staging to the last validated `main` build; pass tag=sha-<new>
 # after promoting a fresh image.
+
 # See docs/apps/tokenplace-relay.md for relay-specific operations.
 tokenplace-oci-redeploy tag='':
     #!/usr/bin/env bash
@@ -1544,11 +1545,13 @@ tokenplace-oci-redeploy tag='':
 
 # token.place app status helper (generic/parameterized defaults, not final release wiring).
 # Override namespace/release/host_key per environment until onboarding locks chart naming.
+
 # See docs/tokenplace_sugarkube_onboarding.md and docs/apps/tokenplace.md.
 tokenplace-status namespace='tokenplace' release='tokenplace-relay' host_key='ingress.host':
     @just app-status namespace='{{ namespace }}' release='{{ release }}' host_key='{{ host_key }}'
 
 # Install-or-upgrade token.place via configurable Helm OCI wiring.
+
 # Uses helm upgrade --install underneath via the shared helper.
 tokenplace-deploy release='' namespace='' chart='' values='' version_file='' version='' tag='' default_tag='':
     #!/usr/bin/env bash
@@ -1643,6 +1646,7 @@ tokenplace-logs namespace='tokenplace' selector='app.kubernetes.io/name=tokenpla
     fi
 
 # Validation helper keeps generic defaults as placeholders; set selector/release/health_url per deployment.
+
 # Do not treat tokenplace-relay defaults here as final token.place production naming.
 tokenplace-validate namespace='tokenplace' release='tokenplace-relay' health_url='' selector='app.kubernetes.io/name=tokenplace-relay':
     #!/usr/bin/env bash
@@ -1661,6 +1665,7 @@ tokenplace-validate namespace='tokenplace' release='tokenplace-relay' health_url
     fi
 
 # Port-forward helper uses placeholder defaults for convenience; override service/ports for real app components.
+
 # Keep this recipe generic while token.place release/service naming is still being finalized.
 tokenplace-port-forward namespace='tokenplace' service='tokenplace-relay' local_port='5010' remote_port='80':
     #!/usr/bin/env bash


### PR DESCRIPTION
### Motivation
- Prepare Sugarkube to host token.place as a first-class app once token.place publishes images and a chart, without hardcoding final chart/release names. 
- Provide operator-facing runbooks and a lightweight contract that mirror existing DSPACE patterns so operators can follow a familiar workflow. 
- Expose parameterized task-runner recipes so onboarding and deployments are reproducible while leaving release wiring configurable. 
- Improve discoverability by linking the new runbooks from the docs index and README. 

### Description
- Added an onboarding contract `docs/tokenplace_sugarkube_onboarding.md` describing prerequisites, ownership boundaries, artifact expectations, and environment mapping. 
- Added app and environment runbooks `docs/apps/tokenplace.md`, `docs/k3s-tokenplace-dev.md`, `docs/k3s-tokenplace-staging.md`, and `docs/k3s-tokenplace-prod.md` that mirror the existing operational shape and cover topology, ingress/Cloudflare expectations, secrets guidance, and validation patterns. 
- Extended `justfile` with parameterized token.place recipes: `tokenplace-deploy`, `tokenplace-upgrade`, `tokenplace-rollback`, `tokenplace-status`, `tokenplace-logs`, `tokenplace-validate`, and `tokenplace-port-forward`, and kept the existing relay helpers intact and referenced from docs. 
- Updated `docs/index.md` and `README.md` to surface the new onboarding and runbook documents and added a short cross-link from `docs/apps/tokenplace-relay.md` to the new onboarding/app guides. 

### Testing
- Ran `pytest -q tests/test_flash_pi_justfile.py tests/test_status_recipe.py`, which passed (8 tests, all green). 
- Ran `git diff --cached | ./scripts/scan-secrets.py` to validate there are no obvious secret leaks (passed). 
- `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` could not be executed in this environment because the tool binaries were not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4ab2ef678832faeae931c331f362b)