### PR TITLE
📝 Add token.place onboarding docs and parameterized just recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
 - `hardware/` — accessories like the Mac mini keyboard station cap (see
   [docs/mac_mini_station.md](docs/mac_mini_station.md))
 - `docs/` — build instructions, safety notes, and learning resources
+- [docs/index.md](docs/index.md) — central docs catalog, including token.place onboarding
+  and environment runbooks
 - [docs/start-here.md](docs/start-here.md) — quick orientation with 15-minute,
   day-one, and advanced reference tracks
 - [docs/solar_basics.md](docs/solar_basics.md) — introduction to how solar panels generate

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -1,0 +1,96 @@
+# token.place on Sugarkube
+
+This runbook defines the **target operating model** for onboarding token.place onto
+Sugarkube once token.place-side migration work is complete.
+
+## Intended topology
+
+Sugarkube hosts the internet-facing and control-plane-facing token.place pieces,
+while heavy compute remains external.
+
+- **On Sugarkube (k3s):** ingress-facing token.place service(s), relay/control
+  surface, environment routing, and app-adjacent observability.
+- **External compute nodes:** model/runtime workers and hardware-dependent
+  execution where GPU/accelerator locality matters.
+- **Boundary:** relay-to-compute communication is authenticated, encrypted, and
+  constrained to API v1 contracts.
+
+## Components expected on Sugarkube
+
+The exact chart structure may evolve, but onboarding assumes these categories:
+
+1. Token.place API/edge workload(s)
+2. Relay component(s) where cluster-side routing is required
+3. Kubernetes-native ingress, TLS, and service discovery config
+4. Optional in-cluster queues/caches only when app architecture requires them
+
+Use parameterized just recipes so chart/release wiring can be finalized without
+rewriting operator workflows.
+
+## Secure post-API-v1 deployment model
+
+- All relay↔compute traffic uses API v1 with explicit auth material.
+- Secrets are injected through Kubernetes secret references, not committed YAML.
+- Environment overlays control routing and non-secret config.
+- Production releases use immutable tags and rollback via Helm history.
+
+## Prerequisites
+
+- k3s cluster reachable with `kubectl` and `helm`
+- Traefik ingress and cert-manager functioning
+- Cloudflare tunnel + DNS in place for environment hostnames
+- token.place chart and values overlays published or available locally
+- Secrets provisioned out-of-band (e.g., `kubectl create secret ...`)
+
+## Deployment and lifecycle workflows
+
+```bash
+# Install (first deployment in an env)
+just tokenplace-install env=staging chart='<chart-ref>' \
+  values='path/base.yaml,path/staging.yaml' tag=<immutable-tag>
+
+# Upgrade (existing release)
+just tokenplace-upgrade env=staging chart='<chart-ref>' \
+  values='path/base.yaml,path/staging.yaml' tag=<immutable-tag>
+
+# Rollback
+just tokenplace-rollback env=staging revision=<helm-revision>
+
+# Status and validation
+just tokenplace-status env=staging
+TOKENPLACE_VALIDATE_URL='https://staging.token.place' just tokenplace-validate env=staging
+
+# Logs and local verification helpers
+just tokenplace-logs namespace=tokenplace
+just tokenplace-port-forward-app namespace=tokenplace service=<service-name> local_port=5010 remote_port=80
+```
+
+## Cloudflare and ingress expectations
+
+- One hostname per environment (`dev`, `staging`, `prod`) mapped via Cloudflare tunnel.
+- Ingress class should match cluster standard (`traefik` unless explicitly changed).
+- TLS certificates managed by cert-manager with environment-specific secrets.
+- DNS records should remain proxied unless incident handling requires temporary bypass.
+
+## Secrets and config guidance
+
+Standardize in docs/reviews:
+
+- Secret names, key names, and owning team
+- Rotation interval and emergency rotation playbook
+- Minimum required env vars per component
+
+Keep configurable in deployment:
+
+- Release name, namespace, chart URL/path
+- Values overlays and hostnames
+- Optional feature flags for environment-specific behavior
+
+## Operator caveats
+
+- Do not assume relay-only topology for all future token.place releases.
+- Treat compute nodes as separately managed infrastructure; avoid coupling their
+  lifecycle to k3s rollout cadence.
+- Rehearse rollback and smoke tests in staging before prod promotion.
+- Keep this guide aligned with [tokenplace_sugarkube_onboarding.md](../tokenplace_sugarkube_onboarding.md)
+  and environment runbooks.

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,12 @@ Review the safety notes before working with power components.
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
 - [projects-compose.md](projects-compose.md) — run token.place & dspace via docker compose
 - [apps/tokenplace-relay.md](apps/tokenplace-relay.md) — operate the token.place relay staging deployment
+- [apps/tokenplace.md](apps/tokenplace.md) — token.place app operations model on Sugarkube
+- [tokenplace_sugarkube_onboarding.md](tokenplace_sugarkube_onboarding.md) — onboarding contract
+  and ownership boundaries for first-class token.place hosting
+- [k3s-tokenplace-dev.md](k3s-tokenplace-dev.md) — token.place dev runbook for k3s
+- [k3s-tokenplace-staging.md](k3s-tokenplace-staging.md) — token.place staging runbook for k3s
+- [k3s-tokenplace-prod.md](k3s-tokenplace-prod.md) — token.place production runbook for k3s
 - [operations/security-checklist.md](operations/security-checklist.md) — track credential rotations and
   verification steps
 - [pi_token_dspace.md](pi_token_dspace.md) — build and expose token.place & dspace via Cloudflare

--- a/docs/k3s-tokenplace-dev.md
+++ b/docs/k3s-tokenplace-dev.md
@@ -1,0 +1,53 @@
+# k3s token.place runbook (dev)
+
+Development environment runbook for token.place on Sugarkube.
+
+## Purpose
+
+- Fast iteration and integration testing.
+- Accepts mutable tags when needed, but immutable tags are still preferred.
+
+## Suggested defaults
+
+- Environment: `dev`
+- Namespace: `tokenplace` (configurable)
+- Release: `tokenplace` (configurable)
+- Hostname: `dev.token.place` (example placeholder)
+
+## Prerequisites
+
+- `just kubeconfig-env env=dev`
+- token.place chart reference available (`TOKENPLACE_CHART` or `chart=`)
+- dev values overlays available
+
+## Deploy / upgrade / rollback
+
+```bash
+TOKENPLACE_CHART='<chart-ref>' \
+TOKENPLACE_VALUES_DEV='path/base.yaml,path/dev.yaml' \
+just tokenplace-install env=dev tag=<tag>
+
+just tokenplace-upgrade env=dev tag=<tag>
+
+just tokenplace-rollback env=dev revision=<helm-revision>
+```
+
+## Validation
+
+```bash
+just tokenplace-status env=dev
+TOKENPLACE_VALIDATE_URL='https://dev.token.place' just tokenplace-validate env=dev
+just tokenplace-logs namespace=tokenplace
+```
+
+## Local verification helper
+
+```bash
+just tokenplace-port-forward-app namespace=tokenplace service=<service-name> local_port=5010 remote_port=80
+curl -fsS http://127.0.0.1:5010/healthz
+```
+
+## Notes
+
+- Dev may point at non-production compute nodes.
+- Keep credentials/test data separate from staging/prod.

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -1,0 +1,60 @@
+# k3s token.place runbook (prod)
+
+Production runbook for token.place on Sugarkube.
+
+## Purpose
+
+- Stable public serving and controlled promotion from validated staging artifacts.
+- Explicit operational ownership, auditability, and rollback readiness.
+
+## Suggested defaults
+
+- Environment: `prod`
+- Namespace: `tokenplace` (configurable)
+- Release: `tokenplace` (configurable)
+- Hostname: `token.place` (or org-approved production host)
+
+## Prerequisites
+
+- Approved immutable tag already validated in staging
+- Production values overlays reviewed
+- Production secrets rotated/validated for release window
+- Cloudflare + ingress + TLS paths verified
+
+## Deploy / upgrade /rollback
+
+```bash
+TOKENPLACE_CHART='<chart-ref>' \
+TOKENPLACE_VALUES_PROD='path/base.yaml,path/prod.yaml' \
+just tokenplace-install env=prod tag=<immutable-tag>
+
+just tokenplace-upgrade env=prod tag=<immutable-tag>
+
+just tokenplace-rollback env=prod revision=<helm-revision>
+```
+
+## Validation checks
+
+```bash
+just tokenplace-status env=prod
+TOKENPLACE_VALIDATE_URL='https://token.place' just tokenplace-validate env=prod
+just tokenplace-logs namespace=tokenplace
+```
+
+## Cloudflare / ingress expectations
+
+- Production DNS stays proxied through Cloudflare tunnel.
+- Ingress host/annotation conventions match cluster policy.
+- Certificate expiry and renewal are monitored.
+
+## Secrets and config guidance
+
+- Never commit production secrets to this repository.
+- Keep secret names stable across releases where possible.
+- Record secret ownership and last rotation in the security checklist.
+
+## Operator caveats
+
+- Perform upgrades inside approved maintenance windows unless emergency response
+  requires immediate action.
+- Keep prior known-good immutable tag and Helm revision handy before promotion.

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -1,0 +1,60 @@
+# k3s token.place runbook (staging)
+
+Staging runbook for token.place on Sugarkube. Use this environment for release
+validation before production promotion.
+
+## Purpose
+
+- Candidate validation with production-like routing and security controls.
+- Rehearsal for rollback, secret rotation, and operator runbook execution.
+
+## Suggested defaults
+
+- Environment: `staging`
+- Namespace: `tokenplace` (configurable)
+- Release: `tokenplace` (configurable)
+- Hostname: `staging.token.place`
+
+## Prerequisites
+
+- `just kubeconfig-env env=staging`
+- Immutable image tag available for candidate release
+- Staging values overlays published
+- Cloudflare tunnel + DNS + TLS cert flow confirmed
+
+## Deploy / upgrade / rollback
+
+```bash
+TOKENPLACE_CHART='<chart-ref>' \
+TOKENPLACE_VALUES_STAGING='path/base.yaml,path/staging.yaml' \
+just tokenplace-install env=staging tag=<immutable-tag>
+
+just tokenplace-upgrade env=staging tag=<immutable-tag>
+
+just tokenplace-rollback env=staging revision=<helm-revision>
+```
+
+## Validation checks
+
+```bash
+just tokenplace-status env=staging
+TOKENPLACE_VALIDATE_URL='https://staging.token.place' just tokenplace-validate env=staging
+just tokenplace-logs namespace=tokenplace
+```
+
+Recommended additional checks:
+
+- `helm -n <namespace> history <release>` before and after deploy
+- `kubectl -n <namespace> get ingress,svc,pods`
+- Relay-to-compute smoke test for API v1 auth and latency expectations
+
+## Cloudflare / ingress expectations
+
+- Cloudflare tunnel routes `staging.token.place` to Traefik service.
+- Ingress annotations for cert-manager are present.
+- TLS secret exists and refreshes automatically.
+
+## Notes
+
+- Staging should mirror prod topology as closely as practical.
+- Use immutable tags for reproducible incident response.

--- a/docs/software/index.md
+++ b/docs/software/index.md
@@ -44,6 +44,12 @@ and supporting services stay healthy.
   Cloudflare tunnels.
 - [apps/tokenplace-relay.md](../apps/tokenplace-relay.md) — Helm ingress/TLS guide for
   token.place staging.
+- [tokenplace_sugarkube_onboarding.md](../tokenplace_sugarkube_onboarding.md) — onboarding contract,
+  release expectations, and ownership split for token.place on Sugarkube.
+- [apps/tokenplace.md](../apps/tokenplace.md) — token.place operating model and lifecycle workflows.
+- [k3s-tokenplace-dev.md](../k3s-tokenplace-dev.md) — environment-specific dev runbook.
+- [k3s-tokenplace-staging.md](../k3s-tokenplace-staging.md) — environment-specific staging runbook.
+- [k3s-tokenplace-prod.md](../k3s-tokenplace-prod.md) — environment-specific production runbook.
 
 ## Developer Workflow
 - [contributor_script_map.md](../contributor_script_map.md) — keep automation docs

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -1,0 +1,89 @@
+# token.place onboarding on Sugarkube
+
+This document prepares Sugarkube for **first-class token.place operations** after
+`token.place` completed API v1 convergence and relay hardening. It intentionally
+focuses on onboarding contracts and operator workflow, not app implementation details.
+
+## Why token.place belongs on Sugarkube
+
+- Sugarkube already runs HA k3s, ingress, cert-manager, and Cloudflare tunnel routing.
+- The platform has established Helm/Just operational conventions used for dspace and
+  tokenplace-relay.
+- token.place benefits from the same environment split (dev/staging/prod), release
+  promotion flow, and operational runbooks.
+
+## Preconditions before onboarding
+
+token.place should be considered onboarding-ready when all are true:
+
+1. API v1 is the canonical interface for relay + compute node traffic.
+2. Relay behavior is production-grade (timeouts, retries, auth, telemetry).
+3. Build/release artifacts are reproducible and environment-agnostic.
+4. Secrets inventory exists with owners, rotation policy, and bootstrap path.
+5. Rollback has been rehearsed in staging with immutable artifacts.
+
+## Release artifact expectations
+
+Sugarkube intentionally does **not** hard-code the final token.place chart/release
+wiring yet. Instead, operators should provide:
+
+- Helm chart reference (`TOKENPLACE_CHART`) — local path or OCI chart URL.
+- Image tags (`tag=` or `TOKENPLACE_DEFAULT_TAG`) — immutable for promotions.
+- Environment values files (`TOKENPLACE_VALUES_DEV|STAGING|PROD`) layered over
+  shared defaults.
+
+## Naming and environment mapping contract
+
+Standardized in Sugarkube:
+
+- Environment names: `dev`, `staging`, `prod`
+- Task entry points: `just tokenplace-install|upgrade|rollback|status|validate`
+- App-level documentation: `docs/apps/tokenplace.md`
+
+Configurable per onboarding:
+
+- Namespace (`TOKENPLACE_NAMESPACE`, default `tokenplace`)
+- Release (`TOKENPLACE_RELEASE`, default `tokenplace`)
+- Chart ref (`TOKENPLACE_CHART`, required)
+- Service name used for port-forward (`TOKENPLACE_SERVICE`)
+
+## Operational ownership boundaries
+
+- **token.place app team:** chart contents, image publishing, app config schema,
+  app-level SLOs, compute-node runtime behavior.
+- **Sugarkube platform operators:** cluster health, ingress/TLS, namespace policy,
+  release execution, rollback execution, and observability plumbing.
+- **Shared responsibility:** secret lifecycle, incident response, and release
+  sign-off gates.
+
+## Environment runbooks
+
+- [docs/k3s-tokenplace-dev.md](k3s-tokenplace-dev.md)
+- [docs/k3s-tokenplace-staging.md](k3s-tokenplace-staging.md)
+- [docs/k3s-tokenplace-prod.md](k3s-tokenplace-prod.md)
+- [docs/apps/tokenplace.md](apps/tokenplace.md)
+
+## Operator quickstart
+
+```bash
+# 1) Inspect status in staging (with env-aware kubeconfig)
+just tokenplace-status env=staging
+
+# 2) First install once chart wiring is finalized
+TOKENPLACE_CHART='<oci-or-local-chart>' \
+TOKENPLACE_VALUES_STAGING='path/to/base.yaml,path/to/staging.yaml' \
+just tokenplace-install env=staging tag=<immutable-tag>
+
+# 3) Routine upgrade
+just tokenplace-upgrade env=staging tag=<new-immutable-tag>
+
+# 4) Validate + optional external health URL
+TOKENPLACE_VALIDATE_URL='https://staging.token.place' \
+just tokenplace-validate env=staging
+```
+
+## Notes
+
+- Keep production deployment pinned to immutable tags.
+- Avoid embedding credentials in values files committed to this repository.
+- Keep relay + compute-node trust boundaries explicit; see app runbook for topology.

--- a/justfile
+++ b/justfile
@@ -1542,7 +1542,7 @@ tokenplace-oci-redeploy tag='':
 
     echo "token.place relay available at: https://staging.token.place"
 
-tokenplace-status:
+tokenplace-relay-status:
     @just app-status namespace=tokenplace release=tokenplace-relay host_key='ingress.host'
 
 tokenplace-logs namespace='tokenplace':
@@ -1582,6 +1582,154 @@ tokenplace-port-forward local_port='5010':
 
     echo "Port-forwarding ${svc} to localhost:{{ local_port }} (Ctrl+C to stop)..."
     kubectl -n tokenplace port-forward svc/${svc} {{ local_port }}:80
+
+# Token.place onboarding helpers (parameterized so Sugarkube can onboard finalized
+# release/chart wiring without hard-coding assumptions in this repository).
+#
+# See docs/tokenplace_sugarkube_onboarding.md and docs/k3s-tokenplace-*.md.
+tokenplace-install env='staging' release='' namespace='' chart='' values='' tag='' host='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    env_name="{{ env }}"
+    case "${env_name}" in dev|staging|prod) ;; *)
+      echo "Unsupported env=${env_name}. Use env=dev|staging|prod." >&2; exit 1 ;;
+    esac
+
+    release_name="{{ release }}"
+    namespace_name="{{ namespace }}"
+    chart_ref="{{ chart }}"
+    values_chain="{{ values }}"
+    tag_value="{{ tag }}"
+    host_value="{{ host }}"
+
+    if [ -z "${release_name}" ]; then release_name="${TOKENPLACE_RELEASE:-tokenplace}"; fi
+    if [ -z "${namespace_name}" ]; then namespace_name="${TOKENPLACE_NAMESPACE:-tokenplace}"; fi
+    if [ -z "${chart_ref}" ]; then chart_ref="${TOKENPLACE_CHART:-}"; fi
+    if [ -z "${values_chain}" ]; then
+      values_chain_var="TOKENPLACE_VALUES_${env_name^^}"
+      values_chain="${TOKENPLACE_VALUES:-${!values_chain_var:-}}"
+    fi
+    if [ -z "${host_value}" ]; then
+      host_var="TOKENPLACE_HOST_${env_name^^}"
+      host_value="${TOKENPLACE_HOST:-${!host_var:-}}"
+    fi
+    if [ -z "${chart_ref}" ]; then
+      echo "Set chart=<helm-chart-ref> or TOKENPLACE_CHART before install." >&2
+      exit 1
+    fi
+
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
+      release="${release_name}" namespace="${namespace_name}" chart="${chart_ref}" \
+      values="${values_chain}" host="${host_value}" \
+      tag="${tag_value}" default_tag="${TOKENPLACE_DEFAULT_TAG:-}"
+
+tokenplace-upgrade env='staging' release='' namespace='' chart='' values='' tag='' host='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    env_name="{{ env }}"
+    case "${env_name}" in dev|staging|prod) ;; *)
+      echo "Unsupported env=${env_name}. Use env=dev|staging|prod." >&2; exit 1 ;;
+    esac
+
+    release_name="{{ release }}"
+    namespace_name="{{ namespace }}"
+    chart_ref="{{ chart }}"
+    values_chain="{{ values }}"
+    tag_value="{{ tag }}"
+    host_value="{{ host }}"
+
+    if [ -z "${release_name}" ]; then release_name="${TOKENPLACE_RELEASE:-tokenplace}"; fi
+    if [ -z "${namespace_name}" ]; then namespace_name="${TOKENPLACE_NAMESPACE:-tokenplace}"; fi
+    if [ -z "${chart_ref}" ]; then chart_ref="${TOKENPLACE_CHART:-}"; fi
+    if [ -z "${values_chain}" ]; then
+      values_chain_var="TOKENPLACE_VALUES_${env_name^^}"
+      values_chain="${TOKENPLACE_VALUES:-${!values_chain_var:-}}"
+    fi
+    if [ -z "${host_value}" ]; then
+      host_var="TOKENPLACE_HOST_${env_name^^}"
+      host_value="${TOKENPLACE_HOST:-${!host_var:-}}"
+    fi
+    if [ -z "${chart_ref}" ]; then
+      echo "Set chart=<helm-chart-ref> or TOKENPLACE_CHART before upgrade." >&2
+      exit 1
+    fi
+
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
+      release="${release_name}" namespace="${namespace_name}" chart="${chart_ref}" \
+      values="${values_chain}" host="${host_value}" \
+      tag="${tag_value}" default_tag="${TOKENPLACE_DEFAULT_TAG:-}"
+
+tokenplace-rollback env='staging' release='' namespace='' revision='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    env_name="{{ env }}"
+    case "${env_name}" in dev|staging|prod) ;; *)
+      echo "Unsupported env=${env_name}. Use env=dev|staging|prod." >&2; exit 1 ;;
+    esac
+
+    release_name="{{ release }}"
+    namespace_name="{{ namespace }}"
+    revision_value="$(echo "{{ revision }}" | xargs)"
+    if [ -z "${release_name}" ]; then release_name="${TOKENPLACE_RELEASE:-tokenplace}"; fi
+    if [ -z "${namespace_name}" ]; then namespace_name="${TOKENPLACE_NAMESPACE:-tokenplace}"; fi
+
+    if [ -z "${revision_value}" ]; then
+      echo "Set revision=<helm-revision> (see: helm history ${release_name} -n ${namespace_name})." >&2
+      exit 1
+    fi
+
+    helm -n "${namespace_name}" rollback "${release_name}" "${revision_value}"
+
+tokenplace-validate env='staging' namespace='' release='' health_path='/healthz':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    env_name="{{ env }}"
+    case "${env_name}" in dev|staging|prod) ;; *)
+      echo "Unsupported env=${env_name}. Use env=dev|staging|prod." >&2; exit 1 ;;
+    esac
+
+    namespace_name="{{ namespace }}"
+    release_name="{{ release }}"
+    if [ -z "${namespace_name}" ]; then namespace_name="${TOKENPLACE_NAMESPACE:-tokenplace}"; fi
+    if [ -z "${release_name}" ]; then release_name="${TOKENPLACE_RELEASE:-tokenplace}"; fi
+
+    just --justfile "{{ justfile_directory() }}/justfile" tokenplace-status \
+      env="${env_name}" namespace="${namespace_name}" release="${release_name}"
+    echo
+    echo "Optional external health check (set TOKENPLACE_VALIDATE_URL to enable):"
+    if [ -n "${TOKENPLACE_VALIDATE_URL:-}" ]; then
+      curl -fsS "${TOKENPLACE_VALIDATE_URL%/}{{ health_path }}"
+    else
+      echo "  TOKENPLACE_VALIDATE_URL is not set; skipping curl."
+    fi
+
+tokenplace-status env='' namespace='tokenplace' release='tokenplace-relay' host_key='ingress.host':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    env_name="{{ env }}"
+    if [ -n "${env_name}" ]; then
+      just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env env="${env_name}"
+    fi
+
+    just --justfile "{{ justfile_directory() }}/justfile" app-status \
+      namespace="{{ namespace }}" release="{{ release }}" host_key="{{ host_key }}"
+
+tokenplace-port-forward-app namespace='' service='' local_port='5010' remote_port='80':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    namespace_name="{{ namespace }}"
+    service_name="{{ service }}"
+    if [ -z "${namespace_name}" ]; then namespace_name="${TOKENPLACE_NAMESPACE:-tokenplace}"; fi
+    if [ -z "${service_name}" ]; then service_name="${TOKENPLACE_SERVICE:-tokenplace-relay}"; fi
+
+    echo "Port-forwarding svc/${service_name} in ${namespace_name} to localhost:{{ local_port }}..."
+    kubectl -n "${namespace_name}" port-forward "svc/${service_name}" {{ local_port }}:{{ remote_port }}
 
 app-status namespace='' release='' host_key='ingress.host':
     #!/usr/bin/env bash


### PR DESCRIPTION
### Motivation
- Prepare Sugarkube to host and operate token.place once token.place has converged on API v1 and release artifacts, by providing onboarding contracts and operator-facing runbooks. 
- Provide task-runner recipes that match existing DSPACE patterns while avoiding hard-coding chart/release names so onboarding wiring can be finalized without repo churn.

### Description
- Added a focused onboarding contract `docs/tokenplace_sugarkube_onboarding.md` describing prerequisites, artifact expectations, naming conventions, and ownership boundaries. 
- Added an app-level runbook `docs/apps/tokenplace.md` and environment-specific k3s runbooks `docs/k3s-tokenplace-dev.md`, `docs/k3s-tokenplace-staging.md`, and `docs/k3s-tokenplace-prod.md` that mirror existing dspace-style operational guidance. 
- Updated discoverability links in `docs/index.md`, `docs/software/index.md`, and `README.md` so token.place onboarding and runbooks are visible from the top-level docs. 
- Introduced parameterized `just` recipes in `justfile` to manage token.place lifecycle without asserting final chart names: `tokenplace-install`, `tokenplace-upgrade`, `tokenplace-rollback`, `tokenplace-validate`, `tokenplace-status` (env-aware), and `tokenplace-port-forward-app`, and renamed the existing relay helper to `tokenplace-relay-status` to avoid a recipe name collision while keeping `tokenplace-oci-redeploy`, `tokenplace-logs`, and the original `tokenplace-port-forward` intact. 

### Testing
- Ran `pytest -q tests/test_docs_guardrails.py` which passed (`3 passed`).
- Attempted repository doc/lint checks: `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` were not available in the container and were not executed (commands unavailable). 
- Ran `./scripts/checks.sh` which failed due to pre-existing repository lint/style issues not introduced by this change. 
- Ran `just --unstable --fmt --check` which reported repository justfile formatting drift unrelated to the added recipes; the new recipes were added in a parameterized form to avoid hard-coded assumptions. 
- Executed `git diff --cached | ./scripts/scan-secrets.py` (staged changes) which completed with no secret findings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4ab2ef678832faeae931c331f362b)