### PR TITLE
📝 docs(ops): document GHCR Helm OCI 403 denied troubleshooting

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -176,6 +176,9 @@ For tunnel and DNS setup details, see [Cloudflare Tunnel docs](../cloudflare_tun
 
 ## Troubleshooting
 
+- GHCR Helm OCI auth failures (`401 authentication required` or `403 denied: denied`) for
+  `helm pull`, `just helm-oci-install`, `just helm-oci-upgrade`, or dspace OCI helpers:
+  [Raspberry Pi Cluster Troubleshooting: GHCR 401/403 OCI pull failures](../raspi_cluster_troubleshooting.md#scenario-7-helm-oci-pull-fails-on-ghcr-with-403-denied-denied).
 - Collect dspace + ingress logs with environment-aware helper:
 
   ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,8 @@ Review the safety notes before working with power components.
 - [raspi_cluster_setup.md](raspi_cluster_setup.md) — **start here** to image SD cards, boot the Pis, and form the HA k3s cluster
 - [raspi_cluster_operations.md](raspi_cluster_operations.md) — **next step** to install Helm,
   verify Traefik ingress, and roll out workloads
+- [raspi_cluster_troubleshooting.md](raspi_cluster_troubleshooting.md) — canonical troubleshooting
+  for cluster setup/operations, including GHCR Helm OCI `401`/`403 denied` pull failures
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
 - [projects-compose.md](projects-compose.md) — run token.place & dspace via docker compose
 - [tokenplace_sugarkube_onboarding.md](tokenplace_sugarkube_onboarding.md) — onboarding contract,

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -159,6 +159,9 @@ Common errors:
 
 - **401 / `authentication required`:** Run `helm registry login ghcr.io` with a PAT that has the
   `read:packages` scope.
+- **403 / `denied: denied` (including `ghcr.io/token` failures):** Most often an expired/invalid
+  PAT, missing `read:packages`, stale Helm login state, or package-access mismatch. See
+  [Raspberry Pi Cluster Troubleshooting: GHCR 401/403 OCI pull failures](raspi_cluster_troubleshooting.md#scenario-7-helm-oci-pull-fails-on-ghcr-with-403-denied-denied).
 - **`...:3.0.0: not found`:** The requested chart version is absent—check the version documented in
   the dspace repo (for example, `docs/apps/dspace.version`) and pull that version instead.
 

--- a/docs/raspi_cluster_troubleshooting.md
+++ b/docs/raspi_cluster_troubleshooting.md
@@ -640,6 +640,72 @@ Firewall or routing is blocking the connection.
 
 ---
 
+### Scenario 7: Helm OCI Pull Fails on GHCR with `403 denied: denied`
+
+**Symptom:**
+`helm pull oci://...`, `just helm-oci-install`, `just helm-oci-upgrade`, or dspace OCI wrappers
+fail while fetching from GHCR. You may see errors ending in `403 denied: denied`, often at the
+token endpoint:
+
+```text
+Error: failed to perform "FetchReference" on source:
+  GET "https://ghcr.io/v2/democratizedspace/charts/dspace/manifests/3.0.0":
+  GET "https://ghcr.io/token?scope=repository%3Ademocratizedspace%2Fcharts%2Fdspace%3Apull&service=ghcr.io":
+  response status code 403: denied: denied
+```
+
+**Likely meanings:**
+
+- The GitHub PAT used for `helm registry login ghcr.io` is expired.
+- The PAT is wrong for the intended account.
+- The PAT is missing the `read:packages` scope.
+- Helm is using stale cached login state from a previous credential.
+- The chart/package visibility does not grant this identity pull access.
+
+**How this differs from nearby failures:**
+
+- **401 / `authentication required`:** usually means no valid GHCR login is present yet.
+- **Chart or version not found** (for example `...: not found`): authentication may be fine, but the
+  chart reference or version is wrong.
+
+**Recovery steps (operator sequence):**
+
+1. Create or reuse a valid GitHub PAT with `read:packages`.
+2. Clear stale Helm auth state:
+
+   ```bash
+   helm registry logout ghcr.io || true
+   ```
+
+3. If failures persist, remove stale Helm registry config and re-login:
+
+   ```bash
+   rm -f ~/.config/helm/registry/config.json
+   helm registry login ghcr.io --username "${GHCR_USERNAME}"
+   ```
+
+4. Verify the pull directly before rerunning higher-level helpers:
+
+   ```bash
+   helm pull oci://ghcr.io/democratizedspace/charts/dspace --version <version>
+   ```
+
+5. Re-run your original command:
+   - `just helm-oci-install ...`
+   - `just helm-oci-upgrade ...`
+   - `just dspace-oci-deploy ...`
+
+**Where stale credentials commonly live:**
+
+- `~/.config/helm/registry/config.json`
+- Shell profile exports (`~/.bashrc`, `~/.zshrc`)
+- Local operator notes or scripts that still reference old `GHCR_PAT` values
+
+See also the GHCR auth overview in
+[Raspberry Pi Cluster Operations](raspi_cluster_operations.md#authenticate-helm-with-oci-registries-ghcr-for-dspace).
+
+---
+
 ## Log Interpretation Quick Reference
 
 ### Structured Log Fields


### PR DESCRIPTION
### Motivation
- Operators hit a GHCR/Helm failure where `helm pull` or `just helm-oci-install` failed with a `403 denied: denied` from the `ghcr.io/token` endpoint due to expired/invalid GH PATs or stale Helm login state. 
- The existing docs mentioned `401 authentication required` but did not explain the `403 denied` expired-token case or provide a single canonical recovery path. 
- Make the failure mode discoverable from high-visibility docs so an operator following the golden path can find the fix quickly. 

### Description
- Add a canonical Scenario 7 in `docs/raspi_cluster_troubleshooting.md` explaining the `403 denied: denied` symptom, likely causes (expired/wrong PAT, missing `read:packages`, stale Helm login state, access mismatch), and an operator-oriented recovery sequence including `helm registry logout`, removing `~/.config/helm/registry/config.json`, `helm registry login ghcr.io`, and a direct `helm pull` verification step. 
- Update `docs/raspi_cluster_operations.md` to call out `403 denied` failures and link to the new canonical troubleshooting scenario. 
- Add a concise troubleshooting cross-link in `docs/apps/dspace.md` pointing to the canonical GHCR 401/403 guidance. 
- Add `docs/raspi_cluster_troubleshooting.md` to `docs/index.md` for discoverability and note the GHCR Helm OCI `401`/`403` pull failure coverage. 

### Testing
- Ran a targeted search to verify new text and links with `rg -n "403 denied|expired PAT|read:packages|helm registry login|ghcr.io/token" docs` and found the new occurrences. 
- Validated staged changes with the repository secret scan via `git diff --cached | ./scripts/scan-secrets.py` and adjusted the guidance to avoid echoing PATs into commits (the staged scan returned clean after the change). 
- Attempted to run repository doc/tooling checks (`just --list`, `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, `linkchecker --no-warnings README.md docs/`) but those tools are not installed in this environment so they could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d899c57104832f82040c6cb007f889)