### PR TITLE
📝 docs: add GHCR 401/403 troubleshooting & discoverability for Helm OCI pulls

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -76,6 +76,10 @@ just app-status namespace=dspace release=dspace
 
 ## Generic Helm OCI examples
 
+If `helm pull`, `just helm-oci-install`, or `just helm-oci-upgrade` fails with GHCR `401`/`403`
+errors, use the canonical recovery steps in
+[Raspberry Pi Cluster Troubleshooting — Scenario 7](../raspi_cluster_troubleshooting.md#scenario-7-helm-oci-pull-fails-with-ghcr-403-denied-denied).
+
 ```bash
 # Install-or-upgrade staging with mutable convenience tag
 just helm-oci-install \
@@ -176,6 +180,9 @@ For tunnel and DNS setup details, see [Cloudflare Tunnel docs](../cloudflare_tun
 
 ## Troubleshooting
 
+- GHCR/OCI auth errors (`401 authentication required` or `403 denied: denied`) for
+  `helm pull`/`helm-oci-*` helpers:
+  [Raspberry Pi Cluster Troubleshooting — Scenario 7](../raspi_cluster_troubleshooting.md#scenario-7-helm-oci-pull-fails-with-ghcr-403-denied-denied).
 - Collect dspace + ingress logs with environment-aware helper:
 
   ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,8 @@ Review the safety notes before working with power components.
 - [raspi_cluster_setup.md](raspi_cluster_setup.md) — **start here** to image SD cards, boot the Pis, and form the HA k3s cluster
 - [raspi_cluster_operations.md](raspi_cluster_operations.md) — **next step** to install Helm,
   verify Traefik ingress, and roll out workloads
+- [raspi_cluster_troubleshooting.md](raspi_cluster_troubleshooting.md) — diagnose common cluster
+  and Helm OCI issues, including GHCR `401/403` chart pull failures
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
 - [projects-compose.md](projects-compose.md) — run token.place & dspace via docker compose
 - [tokenplace_sugarkube_onboarding.md](tokenplace_sugarkube_onboarding.md) — onboarding contract,

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -125,6 +125,9 @@ Error: failed to perform "FetchReference" on source:
   response status code 401: unauthorized: authentication required
 ```
 
+If Helm OCI auth fails with either `401` or `403 denied: denied`, see the canonical fix flow in
+[Raspberry Pi Cluster Troubleshooting Guide — Scenario 7](raspi_cluster_troubleshooting.md#scenario-7-helm-oci-pull-fails-with-ghcr-403-denied-denied).
+
 Authenticate once per node that will pull OCI charts:
 
 ```bash
@@ -159,6 +162,10 @@ Common errors:
 
 - **401 / `authentication required`:** Run `helm registry login ghcr.io` with a PAT that has the
   `read:packages` scope.
+- **403 / `denied: denied`:** Usually an expired or wrong PAT, missing `read:packages`, stale Helm
+  GHCR login state, or package visibility mismatch. Follow
+  [Troubleshooting Scenario 7](raspi_cluster_troubleshooting.md#scenario-7-helm-oci-pull-fails-with-ghcr-403-denied-denied)
+  to clear stale credentials, re-login, and verify with a direct `helm pull`.
 - **`...:3.0.0: not found`:** The requested chart version is absent—check the version documented in
   the dspace repo (for example, `docs/apps/dspace.version`) and pull that version instead.
 

--- a/docs/raspi_cluster_troubleshooting.md
+++ b/docs/raspi_cluster_troubleshooting.md
@@ -683,18 +683,21 @@ response status code 403: denied: denied
    helm registry logout ghcr.io || true
    ```
 
-3. **If failures persist, clear stale Helm registry config** (Helm will recreate it on next login):
+3. **If failures persist, clear stale Helm registry config** (Helm will recreate it on next
+   login). **Warning: this removes ALL OCI registry credentials, not just GHCR — re-login to
+   any other registries you use after this step.**
 
    ```bash
    rm -f ~/.config/helm/registry/config.json
    ```
 
-4. **Login again with the fresh PAT:**
+4. **Login again with `--password-stdin`** (matching the auth flow used elsewhere in these
+   docs):
 
    ```bash
    export GHCR_USERNAME="<github-username>"
-   helm registry login ghcr.io --username "${GHCR_USERNAME}"
-   # Paste a PAT with read:packages when prompted.
+   export GHCR_TOKEN="<token-with-read:packages>"
+   printf '%s\n' "${GHCR_TOKEN}" | helm registry login ghcr.io --username "${GHCR_USERNAME}" --password-stdin
    ```
 
 5. **Verify direct chart pull before rerunning `just`:**

--- a/docs/raspi_cluster_troubleshooting.md
+++ b/docs/raspi_cluster_troubleshooting.md
@@ -696,8 +696,8 @@ response status code 403: denied: denied
 
    ```bash
    export GHCR_USERNAME="<github-username>"
-   export GHCR_TOKEN="<token-with-read:packages>"
-   printf '%s\n' "${GHCR_TOKEN}" | helm registry login ghcr.io --username "${GHCR_USERNAME}" --password-stdin
+   export GHCR_PAT="<pat-with-read-packages>"
+   printf '%s\n' "${GHCR_PAT}" | helm registry login ghcr.io --username "${GHCR_USERNAME}" --password-stdin
    ```
 
 5. **Verify direct chart pull before rerunning `just`:**

--- a/docs/raspi_cluster_troubleshooting.md
+++ b/docs/raspi_cluster_troubleshooting.md
@@ -640,6 +640,79 @@ Firewall or routing is blocking the connection.
 
 ---
 
+### Scenario 7: Helm OCI pull fails with GHCR `403 denied: denied`
+
+**Symptom:**
+Helm OCI pulls fail even though the chart exists. This commonly appears while running:
+
+- `helm pull oci://ghcr.io/democratizedspace/charts/dspace --version <version>`
+- `just helm-oci-install ...`
+- `just helm-oci-upgrade ...`
+- dspace OCI helpers such as `just dspace-oci-deploy ...`
+
+Typical error shape:
+
+```text
+Error: failed to perform "FetchReference" on source:
+GET "https://ghcr.io/v2/democratizedspace/charts/dspace/manifests/<version>":
+GET "https://ghcr.io/token?scope=repository%3Ademocratizedspace%2Fcharts%2Fdspace%3Apull&service=ghcr.io":
+response status code 403: denied: denied
+```
+
+**What this usually means:**
+
+- Your GitHub PAT is expired.
+- The PAT is wrong for the account being used.
+- The PAT is missing `read:packages` scope.
+- Helm is reusing stale GHCR credentials from a previous login.
+- The package/repo visibility does not allow this account to pull.
+
+**How this differs from nearby failures:**
+
+- `401 unauthorized: authentication required` usually means not logged in or no credential was sent.
+- `...: not found` (manifest/chart/version not found) usually means the chart reference or version is wrong,
+  not an auth token issue.
+
+**Recovery steps (operator sequence):**
+
+1. **Create or reuse a valid PAT** with at least `read:packages` for the account that can access the
+   chart.
+2. **Clear Helm's current GHCR session:**
+
+   ```bash
+   helm registry logout ghcr.io || true
+   ```
+
+3. **If failures persist, clear stale Helm registry config** (Helm will recreate it on next login):
+
+   ```bash
+   rm -f ~/.config/helm/registry/config.json
+   ```
+
+4. **Login again with the fresh PAT:**
+
+   ```bash
+   export GHCR_USERNAME="<github-username>"
+   helm registry login ghcr.io --username "${GHCR_USERNAME}"
+   # Paste a PAT with read:packages when prompted.
+   ```
+
+5. **Verify direct chart pull before rerunning `just`:**
+
+   ```bash
+   helm pull oci://ghcr.io/democratizedspace/charts/dspace --version <version>
+   ```
+
+6. **Rerun the original deploy/upgrade command** (for example `just helm-oci-install ...`).
+
+**Where stale credentials often hide:**
+
+- `~/.config/helm/registry/config.json`
+- shell profile exports (`~/.bashrc`, `~/.profile`, etc.)
+- local operator notes or helper scripts that set outdated `GHCR_PAT` values
+
+---
+
 ## Log Interpretation Quick Reference
 
 ### Structured Log Fields


### PR DESCRIPTION
### Motivation
- Operators hit a real-world failure where `helm pull` / `just helm-oci-install` returned a `403 denied: denied` from GHCR when the Personal Access Token (PAT) was expired or invalid, and the existing docs only focused on `401` cases. 
- The goal is to add a single canonical troubleshooting entry describing the `403` failure mode, and make it discoverable from high-visibility guides so operators following the golden path can find the fix quickly. 

### Description
- Added a canonical troubleshooting section `Scenario 7` in `docs/raspi_cluster_troubleshooting.md` that documents the `403 denied: denied` symptom, likely causes (expired/wrong PAT, missing `read:packages`, stale Helm registry state, visibility mismatch), differences from `401`/not-found errors, and an operator-oriented recovery sequence including `helm registry logout`, optional removal of `~/.config/helm/registry/config.json`, re-login, and verification via `helm pull`. 
- Linked the troubleshooting scenario from `docs/raspi_cluster_operations.md` (GHCR/OCI auth section) and from `docs/apps/dspace.md` (near Helm OCI examples and Troubleshooting) so the golden-path docs point to the canonical guidance. 
- Added a high-visibility entry to `docs/index.md` referencing the troubleshooting guide and GHCR `401/403` chart-pull issues; adjusted wording to avoid embedding credential-like strings and kept examples as placeholders. 

### Testing
- Ran a repository search `rg -n "403 denied|expired PAT|read:packages|helm registry login|ghcr.io/token" docs` to verify new text and links are present and it succeeded. 
- Ran the project's secret-scan on the staged diff (`./scripts/scan-secrets.py` against the changed content) which initially flagged an inline password hint, then the docs were adjusted to remove the literal prompt and the scan passed. 
- Attempted repo doc checks referenced by `AGENTS.md` (`just --list`, `just docs-verify`, `pyspelling -c .spellcheck.yaml`, `linkchecker --no-warnings README.md docs/`) but those tools are not installed in this execution environment so they could not be run here; they should be run by CI or locally before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d899c57104832f82040c6cb007f889)