### PR TITLE
docs: add GHCR 403 Helm OCI troubleshooting and cross-links

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -107,6 +107,9 @@ Notes:
 - `version_file=docs/apps/dspace.version` keeps chart version pinning centralized.
 - For prod, prefer immutable tags and persist the approved one in `docs/apps/dspace.prod.tag`.
 - `dspace-oci-deploy` rejects mutable tags (`latest`, `main`) by design.
+- If `helm pull`/`helm-oci-*` fails with GHCR `401` or `403 denied: denied`, follow
+  [Raspberry Pi Cluster Troubleshooting Scenario 6](../raspi_cluster_troubleshooting.md#scenario-6-helm-oci-pulls-from-ghcr-fail-with-403-denied-denied)
+  before retrying deploy helpers.
 
 ## Evergreen release/promotion flow
 
@@ -176,6 +179,9 @@ For tunnel and DNS setup details, see [Cloudflare Tunnel docs](../cloudflare_tun
 
 ## Troubleshooting
 
+- GHCR OCI auth failures (`helm pull`, `just helm-oci-install`, `just helm-oci-upgrade`,
+  `dspace-oci-deploy`) with `401` or `403 denied: denied`:
+  [see canonical recovery runbook](../raspi_cluster_troubleshooting.md#scenario-6-helm-oci-pulls-from-ghcr-fail-with-403-denied-denied).
 - Collect dspace + ingress logs with environment-aware helper:
 
   ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,8 @@ Review the safety notes before working with power components.
 - [raspi_cluster_setup.md](raspi_cluster_setup.md) — **start here** to image SD cards, boot the Pis, and form the HA k3s cluster
 - [raspi_cluster_operations.md](raspi_cluster_operations.md) — **next step** to install Helm,
   verify Traefik ingress, and roll out workloads
+- [raspi_cluster_troubleshooting.md](raspi_cluster_troubleshooting.md) — diagnose common Pi cluster
+  failures, including GHCR Helm OCI `401`/`403 denied` authentication issues
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
 - [projects-compose.md](projects-compose.md) — run token.place & dspace via docker compose
 - [tokenplace_sugarkube_onboarding.md](tokenplace_sugarkube_onboarding.md) — onboarding contract,
@@ -77,10 +79,12 @@ Pi hardware:
 2. [raspi_cluster_operations.md](raspi_cluster_operations.md) — Day-two operations including Helm,
    Traefik ingress verification, workload management (token.place, dspace), and Flux GitOps
    integration.
-3. [raspi_cluster_setup_manual.md](raspi_cluster_setup_manual.md) — Full manual setup with detailed
+3. [raspi_cluster_troubleshooting.md](raspi_cluster_troubleshooting.md) — Canonical troubleshooting
+   guide for setup/operations failures, including GHCR OCI pull auth recovery.
+4. [raspi_cluster_setup_manual.md](raspi_cluster_setup_manual.md) — Full manual setup with detailed
    explanations of each step to understand what the quick-start automates and to troubleshoot when
    things go wrong.
-4. [raspi_cluster_operations_manual.md](raspi_cluster_operations_manual.md) — Manual counterpart to
+5. [raspi_cluster_operations_manual.md](raspi_cluster_operations_manual.md) — Manual counterpart to
    Part 2 with raw commands for ingress, Cloudflare Tunnel, Helm apps, and Flux.
 
 ## LLM Prompts

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -159,8 +159,14 @@ Common errors:
 
 - **401 / `authentication required`:** Run `helm registry login ghcr.io` with a PAT that has the
   `read:packages` scope.
+- **403 / `denied: denied` from `ghcr.io/token`:** Usually an expired/invalid PAT, missing
+  `read:packages`, stale Helm login state, or visibility/access mismatch. See
+  [Troubleshooting Scenario 6: Helm OCI pulls from GHCR fail with `403 denied: denied`](raspi_cluster_troubleshooting.md#scenario-6-helm-oci-pulls-from-ghcr-fail-with-403-denied-denied).
 - **`...:3.0.0: not found`:** The requested chart version is absent—check the version documented in
   the dspace repo (for example, `docs/apps/dspace.version`) and pull that version instead.
+
+For a step-by-step recovery flow covering both **401** and **403** GHCR OCI pull failures, use
+[Raspberry Pi Cluster Troubleshooting](raspi_cluster_troubleshooting.md#scenario-6-helm-oci-pulls-from-ghcr-fail-with-403-denied-denied).
 
 ## Verify Traefik ingress (k3s default)
 

--- a/docs/raspi_cluster_troubleshooting.md
+++ b/docs/raspi_cluster_troubleshooting.md
@@ -517,7 +517,86 @@ System time: 1.234 seconds slow of NTP time
 
 ---
 
-### Scenario 6: Firewall or Network Policy Blocking Cluster Traffic
+### Scenario 6: Helm OCI pulls from GHCR fail with `403 denied: denied`
+
+**Symptom:**
+Helm OCI commands fail even though the chart reference and version look correct. This can happen with
+direct pulls and with Sugarkube helpers:
+
+- `helm pull oci://ghcr.io/democratizedspace/charts/dspace --version <version>`
+- `just helm-oci-install ...`
+- `just helm-oci-upgrade ...`
+- dspace wrappers built on those helpers (`dspace-oci-deploy`, `dspace-oci-promote-prod`)
+
+Typical error shape:
+
+```text
+Error: failed to perform "FetchReference" on source:
+  GET "https://ghcr.io/v2/.../manifests/<version>":
+  GET "https://ghcr.io/token?...":
+  response status code 403: denied: denied
+```
+
+**What this usually means:**
+
+- The PAT used for Helm registry auth is expired.
+- The PAT is wrong (copied incorrectly, revoked, or from the wrong account).
+- The token is missing `read:packages`.
+- Helm is using stale login state from an old token.
+- Package visibility or account access does not permit pulls.
+
+**How this differs from nearby errors:**
+
+- **`401 authentication required`** usually means you are not logged in (or login never succeeded).
+- **`not found` / manifest unknown / bad version** usually means chart name or version is wrong.
+- **`403 denied: denied`** on `ghcr.io/token` often points to credentials/scope/access issues even if
+  you previously logged in.
+
+**Recovery steps (operator runbook):**
+
+1. Create or rotate a GitHub PAT that includes **`read:packages`**.
+2. Clear stale Helm login state:
+
+   ```bash
+   helm registry logout ghcr.io || true
+   ```
+
+3. If the node still appears to use old credentials, remove cached Helm registry auth and log in
+   again:
+
+   ```bash
+   rm -f ~/.config/helm/registry/config.json
+   ```
+
+4. Log in with the current PAT:
+
+   ```bash
+   export GHCR_USERNAME="your_github_username"
+   export GHCR_PAT="your_pat_with_read_packages"
+   helm registry login ghcr.io --username "${GHCR_USERNAME}"
+   # when prompted, paste the GHCR token value
+   ```
+
+5. Verify pull access directly before re-running higher-level helpers:
+
+   ```bash
+   helm pull oci://ghcr.io/democratizedspace/charts/dspace --version <version>
+   ```
+
+6. Re-run the original command:
+   - `just helm-oci-install ...` or
+   - `just helm-oci-upgrade ...` or
+   - `just dspace-oci-deploy ...`
+
+**Where stale credentials commonly hide:**
+
+- `~/.config/helm/registry/config.json`
+- shell profile exports (`~/.bashrc`, `~/.profile`, local operator notes)
+- local scripts that export an outdated `GHCR_PAT`
+
+---
+
+### Scenario 7: Firewall or Network Policy Blocking Cluster Traffic
 
 **Symptom:**
 Nodes can ping each other and resolve `.local` hostnames, but cluster formation fails. Discovery may succeed, but k3s service timeouts occur with connection refused or timeout errors.


### PR DESCRIPTION
### Motivation
- Operators hit an observed Helm/GHCR failure where `helm pull` or Sugarkube helpers returned a `403 denied: denied` from `ghcr.io/token` when a PAT was expired/invalid, and this case was not discoverable in the existing docs.
- The change provides a single canonical recovery runbook and surfaces it from the high-visibility Helm/OCI and dspace docs so operators following the golden path can find the fix without external searches.

### Description
- Add a new troubleshooting scenario explaining the `403 denied: denied` failure, likely causes (expired/invalid PAT, missing `read:packages`, stale Helm login state, visibility/access), and a concrete recovery runbook including `helm registry logout`, optional `~/.config/helm/registry/config.json` removal, re-login, and `helm pull` verification (`docs/raspi_cluster_troubleshooting.md`).
- Link the canonical troubleshooting entry from the Helm/OCI auth section in `docs/raspi_cluster_operations.md` to call out the `403` case alongside `401` guidance.
- Add discoverability links from `docs/apps/dspace.md` (near Helm OCI examples and the dspace troubleshooting section) and surface the troubleshooting doc in `docs/index.md` so the recovery path is easier to find.
- Small wording change to the GHCR login example to avoid embedding a password piping pattern in the docs and reduce accidental secret-like patterns.

### Testing
- Searched the docs for the new failure-mode text and links with `rg -n "403 denied|expired PAT|read:packages|helm registry login|ghcr.io/token"` and confirmed the new text and cross-links are present (success).
- Ran the repository secret scanner on the staged diff via `git diff --cached | ./scripts/scan-secrets.py`, addressed a documented secret-like pattern in the docs, and re-ran the scan which passed (success).
- Attempted to run repo doc tooling referenced by `AGENTS.md` (`just --list`, `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, `linkchecker --no-warnings README.md docs/`) but those commands were not available in the execution environment so they were not run here (skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d899c57104832f82040c6cb007f889)