### PR TITLE
📝 docs: document GHCR Helm OCI 403 denied failure mode

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -76,6 +76,10 @@ just app-status namespace=dspace release=dspace
 
 ## Generic Helm OCI examples
 
+If GHCR auth fails with `401 authentication required` or
+`ghcr.io/token ... 403 denied: denied`, see the canonical fix in
+[Scenario 7: GHCR OCI Helm Pull Fails with 401 or 403 Denied](../raspi_cluster_troubleshooting.md#scenario-7-ghcr-oci-helm-pull-fails-with-401-or-403-denied).
+
 ```bash
 # Install-or-upgrade staging with mutable convenience tag
 just helm-oci-install \
@@ -183,6 +187,9 @@ For tunnel and DNS setup details, see [Cloudflare Tunnel docs](../cloudflare_tun
   just dspace-debug-logs-env env=prod
   ```
 
+- For GHCR OCI auth failures (`401`/`403 denied`) during `helm pull`, `helm-oci-install`, or
+  `helm-oci-upgrade`, use
+  [Scenario 7: GHCR OCI Helm Pull Fails with 401 or 403 Denied](../raspi_cluster_troubleshooting.md#scenario-7-ghcr-oci-helm-pull-fails-with-401-or-403-denied).
 - Inspect Helm release state:
   - `helm -n dspace status dspace`
   - `helm -n dspace get values dspace`

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,6 +82,8 @@ Pi hardware:
    things go wrong.
 4. [raspi_cluster_operations_manual.md](raspi_cluster_operations_manual.md) — Manual counterpart to
    Part 2 with raw commands for ingress, Cloudflare Tunnel, Helm apps, and Flux.
+5. [raspi_cluster_troubleshooting.md](raspi_cluster_troubleshooting.md) — Canonical troubleshooting,
+   including GHCR OCI Helm pull auth failures (`401`/`403 denied`) and recovery steps.
 
 ## LLM Prompts
 - [prompts/codex/automation.md](prompts/codex/automation.md) — baseline Codex instructions for maintaining the repo

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -159,6 +159,9 @@ Common errors:
 
 - **401 / `authentication required`:** Run `helm registry login ghcr.io` with a PAT that has the
   `read:packages` scope.
+- **403 / `denied: denied` (including `ghcr.io/token ... 403`):** Usually an expired PAT, wrong PAT,
+  missing `read:packages`, stale Helm login state, or package visibility mismatch. See
+  [Troubleshooting GHCR OCI 401/403 pull failures](raspi_cluster_troubleshooting.md#scenario-7-ghcr-oci-helm-pull-fails-with-401-or-403-denied).
 - **`...:3.0.0: not found`:** The requested chart version is absent—check the version documented in
   the dspace repo (for example, `docs/apps/dspace.version`) and pull that version instead.
 

--- a/docs/raspi_cluster_troubleshooting.md
+++ b/docs/raspi_cluster_troubleshooting.md
@@ -640,6 +640,90 @@ Firewall or routing is blocking the connection.
 
 ---
 
+### Scenario 7: GHCR OCI Helm Pull Fails with 401 or 403 Denied
+
+**Symptom:**
+Helm OCI pulls fail when using commands such as:
+
+- `helm pull oci://ghcr.io/democratizedspace/charts/dspace --version <version>`
+- `just helm-oci-install ...`
+- `just helm-oci-upgrade ...`
+- dspace OCI wrappers (`just dspace-oci-deploy ...`, `just dspace-oci-promote-prod ...`)
+
+Typical error signatures include one of the following:
+
+```text
+Error: failed to perform "FetchReference" on source:
+  GET "https://ghcr.io/v2/.../manifests/<version>":
+  GET "https://ghcr.io/token?...":
+  response status code 403: denied: denied
+```
+
+or:
+
+```text
+response status code 401: unauthorized: authentication required
+```
+
+**What 401 vs 403 usually means:**
+
+- **401 `authentication required`:** Helm is not logged in to GHCR, or login was never completed.
+- **403 `denied: denied`:** Credentials were presented but are not valid for pull access right now,
+  commonly due to:
+  - expired GitHub PAT
+  - wrong PAT or wrong GitHub account
+  - missing `read:packages` scope
+  - stale Helm registry login state
+  - package visibility/access mismatch for the authenticated identity
+
+**Distinguish this from chart/version issues:**
+
+- Auth errors fail at the GHCR token or manifest fetch step (`ghcr.io/token`, `403 denied`, `401`).
+- Wrong chart/version typically returns not found errors (for example `...:<version>: not found`).
+
+**Recovery steps (canonical):**
+
+1. **Create or confirm a valid PAT with `read:packages`.**
+   Use a PAT from the GitHub account that should have access to the chart.
+
+2. **Clear stale Helm GHCR login state:**
+   ```bash
+   helm registry logout ghcr.io || true
+   ```
+
+3. **If failures persist, remove stale local registry config and re-login:**
+   ```bash
+   rm -f ~/.config/helm/registry/config.json
+   ```
+
+4. **Login again with the known-good PAT:**
+   ```bash
+   export GHCR_USERNAME="your_github_username"
+   export GHCR_PAT="your_pat_with_read_packages"
+
+   helm registry login ghcr.io --username "${GHCR_USERNAME}"
+   # When prompted, paste GHCR_PAT as the credential.
+   ```
+
+5. **Verify auth with a direct pull before rerunning `just` helpers:**
+   ```bash
+   helm pull oci://ghcr.io/democratizedspace/charts/dspace --version <version>
+   ```
+
+6. **Rerun your original command:**
+   ```bash
+   just helm-oci-install ...
+   # or
+   just helm-oci-upgrade ...
+   ```
+
+**Where stale credentials often hide:**
+
+- `~/.config/helm/registry/config.json`
+- shell profile exports (`~/.bashrc`, `~/.zshrc`)
+- local operator notes/scripts that export old `GHCR_PAT` values
+
+
 ## Log Interpretation Quick Reference
 
 ### Structured Log Fields


### PR DESCRIPTION
### Motivation
- Operators encountered `ghcr.io/token ... 403: denied: denied` when `just helm-oci-install` or `helm pull` failed due to expired/invalid GHCR PATs and the docs only emphasized `401` errors. 
- The change centralises a canonical troubleshooting flow so the fix is discoverable from the golden-path docs without duplicating guidance. 
- Keep edits documentation-only, operator-focused, and minimally invasive to existing doc structure and tone. 

### Description
- Added a canonical troubleshooting entry `Scenario 7: GHCR OCI Helm Pull Fails with 401 or 403 Denied` in `docs/raspi_cluster_troubleshooting.md` describing symptoms, `401` vs `403` interpretation, likely causes (expired/wrong PAT, missing `read:packages`, stale Helm login, visibility), recovery steps, and locations of stale credentials. 
- Added discoverability links from `docs/raspi_cluster_operations.md` (GHCR/OCI auth common errors) and `docs/apps/dspace.md` (near generic OCI examples and troubleshooting) to the new Scenario 7, and added a pointer to the troubleshooting guide in `docs/index.md`. 
- Replaced the inline `echo "${GHCR_PAT}" | helm registry login ... --password-stdin` example with a safer interactive `helm registry login ghcr.io --username "${GHCR_USERNAME}"` prompt-style variant to avoid committing a pattern flagged by the repo secrets scan. 

### Testing
- Searched for the new strings to validate coverage with `rg -n "403 denied|expired PAT|read:packages|helm registry login|ghcr.io/token" docs` and confirmed the updated files contain the expected references. (succeeded) 
- Ran the repository secrets check on the staged diff with `git diff --cached | ./scripts/scan-secrets.py` and addressed the detected pattern by switching to the interactive login form; the scan then passed for the staged file. (succeeded) 
- Attempted the repo doc-tooling checks (`just --list`, `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, `linkchecker --no-warnings README.md docs/`) but those tools were not available in this environment so they were not executed here; their absence prevented running those automated checks locally. (not run)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d899c57104832f82040c6cb007f889)