### PR TITLE
🛡️ fix: verify pinned Helm install artifacts

### DIFF
--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -375,7 +375,7 @@ Example (abbreviated) output:
 ip-10-0-0-1   Ready    control-plane,etcd   v1.28.7+k3s1   10.0.0.1   ...
 
 === Helm status (CLI on this node) ===
-v3.13.0+gXXXXXXXX
+v3.18.0+gXXXXXXXX
 ```
 
 If `kubectl` cannot reach the cluster (for example, kubeconfig is not set yet), the command

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -97,8 +97,8 @@ working with a minimal OS, use the `just` recipes from the repository root:
    just helm-install
    ```
 
-   This detects whether Helm is already present. If missing, it installs Helm 3 using the official
-   `get-helm-3` script and prints the installed version on success.
+   This detects whether Helm is already present. If missing, it installs a pinned Helm 3 release by
+   downloading the archive from `get.helm.sh` and validating its SHA-256 checksum before installing.
 
 2. Verify Helm is working:
 

--- a/docs/raspi_cluster_operations_manual.md
+++ b/docs/raspi_cluster_operations_manual.md
@@ -49,10 +49,24 @@ clusters.
 
 ## 1. Install Helm manually
 
-If Helm is missing, install it with the official script used by the `just` recipe:
+If Helm is missing, install a pinned release archive and verify its checksum:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+HELM_VERSION=v3.18.0
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+case "${ARCH}" in
+  x86_64) ARCH=amd64 ;;
+  aarch64|arm64) ARCH=arm64 ;;
+  armv7l) ARCH=arm ;;
+  *) echo "Unsupported architecture: ${ARCH}" >&2; exit 1 ;;
+esac
+FILE="helm-${HELM_VERSION}-${OS}-${ARCH}.tar.gz"
+curl -fsSL "https://get.helm.sh/${FILE}" -o "/tmp/${FILE}"
+curl -fsSL "https://get.helm.sh/${FILE}.sha256sum" -o "/tmp/${FILE}.sha256sum"
+(cd /tmp && sha256sum -c "${FILE}.sha256sum")
+tar -xzf "/tmp/${FILE}" -C /tmp
+sudo install -m 0755 "/tmp/${OS}-${ARCH}/helm" /usr/local/bin/helm
 ```
 
 Verify the binary is available and on your path:

--- a/docs/raspi_cluster_operations_manual.md
+++ b/docs/raspi_cluster_operations_manual.md
@@ -76,7 +76,7 @@ helm version
 which helm
 ```
 
-**What you should see:** A Helm 3 version string (e.g., `version.BuildInfo{Version:"v3.13.0", ...}`)
+**What you should see:** A Helm 3 version string (e.g., `version.BuildInfo{Version:"v3.18.0", ...}`)
 and a path such as `/usr/local/bin/helm`.
 
 If you prefer to use the high-level Just recipes instead of running these commands manually, see the

--- a/docs/tutorials/tutorial-07-kubernetes-container-fundamentals.md
+++ b/docs/tutorials/tutorial-07-kubernetes-container-fundamentals.md
@@ -76,7 +76,21 @@ Store all work under `~/sugarkube-tutorials/tutorial-07/`. Create subdirectories
    sudo mv kubectl /usr/local/bin/
    kubectl version --client --output=yaml
 
-   curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+   HELM_VERSION=v3.18.0
+   HELM_OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+   HELM_ARCH="$(uname -m)"
+   case "${HELM_ARCH}" in
+     x86_64) HELM_ARCH=amd64 ;;
+     aarch64|arm64) HELM_ARCH=arm64 ;;
+     armv6l|armv7l) HELM_ARCH=arm ;;
+     *) echo "Unsupported architecture: ${HELM_ARCH}" >&2; exit 1 ;;
+   esac
+   HELM_FILE="helm-${HELM_VERSION}-${HELM_OS}-${HELM_ARCH}.tar.gz"
+   curl -fsSL "https://get.helm.sh/${HELM_FILE}" -o "/tmp/${HELM_FILE}"
+   curl -fsSL "https://get.helm.sh/${HELM_FILE}.sha256sum" -o "/tmp/${HELM_FILE}.sha256sum"
+   (cd /tmp && sha256sum -c "${HELM_FILE}.sha256sum")
+   tar -xzf "/tmp/${HELM_FILE}" -C /tmp
+   sudo install -m 0755 "/tmp/${HELM_OS}-${HELM_ARCH}/helm" /usr/local/bin/helm
    helm version
    ```
 

--- a/justfile
+++ b/justfile
@@ -702,6 +702,7 @@ cf-tunnel-debug:
     fi
 
 # Install the Helm CLI on the current node (idempotent; safe to re-run).
+
 # Downloads a pinned release archive and verifies checksum before install.
 helm-install:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -713,13 +713,20 @@ helm-install:
         exit 0
     fi
 
-    helm_version="${HELM_VERSION:-v3.18.0}"
+    raw_helm_version="${HELM_VERSION:-v3.18.0}"
+    helm_version="${raw_helm_version#v}"
+    helm_version="v${helm_version}"
+    if [[ ! "${helm_version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$ ]]; then
+        echo "Invalid HELM_VERSION '${raw_helm_version}'. Use formats like '3.18.0' or 'v3.18.0'." >&2
+        exit 1
+    fi
+
     os="$(uname -s | tr '[:upper:]' '[:lower:]')"
     arch="$(uname -m)"
     case "${arch}" in
         x86_64) arch="amd64" ;;
         aarch64 | arm64) arch="arm64" ;;
-        armv7l) arch="arm" ;;
+        armv6l | armv7l) arch="arm" ;;
         *)
             echo "Unsupported architecture: ${arch}" >&2
             exit 1
@@ -736,7 +743,20 @@ helm-install:
     curl -fsSL "${base_url}/${filename}.sha256sum" -o "${tmpdir}/${filename}.sha256sum"
     (
         cd "${tmpdir}"
-        sha256sum -c "${filename}.sha256sum"
+        if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum -c "${filename}.sha256sum"
+        elif command -v shasum >/dev/null 2>&1; then
+            expected_checksum="$(cut -d" " -f1 "${filename}.sha256sum")"
+            actual_checksum="$(shasum -a 256 "${filename}" | awk '{print $1}')"
+            if [ "${actual_checksum}" != "${expected_checksum}" ]; then
+                echo "Checksum verification failed for ${filename}." >&2
+                exit 1
+            fi
+            echo "${filename}: OK"
+        else
+            echo "No checksum tool found (need sha256sum or shasum)." >&2
+            exit 1
+        fi
     )
 
     tar -xzf "${tmpdir}/${filename}" -C "${tmpdir}"
@@ -744,6 +764,8 @@ helm-install:
     if [ ! -w "${install_dir}" ]; then
         install_dir="${HOME}/.local/bin"
         mkdir -p "${install_dir}"
+        echo "Note: /usr/local/bin is not writable; installing Helm to ${install_dir}." >&2
+        echo "Add \"export PATH=\\\"${install_dir}:\\$PATH\\\"\" to your shell profile if Helm is not found in new sessions." >&2
     fi
     install -m 0755 "${tmpdir}/${os}-${arch}/helm" "${install_dir}/helm"
     export PATH="${install_dir}:${PATH}"

--- a/justfile
+++ b/justfile
@@ -702,6 +702,7 @@ cf-tunnel-debug:
     fi
 
 # Install the Helm CLI on the current node (idempotent; safe to re-run).
+# Downloads a pinned release archive and verifies checksum before install.
 helm-install:
     #!/usr/bin/env bash
     set -Eeuo pipefail
@@ -712,8 +713,40 @@ helm-install:
         exit 0
     fi
 
-    echo "Helm not found; installing Helm 3 via the official script..."
-    curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+    helm_version="${HELM_VERSION:-v3.18.0}"
+    os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    arch="$(uname -m)"
+    case "${arch}" in
+        x86_64) arch="amd64" ;;
+        aarch64 | arm64) arch="arm64" ;;
+        armv7l) arch="arm" ;;
+        *)
+            echo "Unsupported architecture: ${arch}" >&2
+            exit 1
+            ;;
+    esac
+    filename="helm-${helm_version}-${os}-${arch}.tar.gz"
+    base_url="https://get.helm.sh"
+
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "${tmpdir}"' EXIT
+
+    echo "Helm not found; installing ${helm_version} (${os}/${arch})..."
+    curl -fsSL "${base_url}/${filename}" -o "${tmpdir}/${filename}"
+    curl -fsSL "${base_url}/${filename}.sha256sum" -o "${tmpdir}/${filename}.sha256sum"
+    (
+        cd "${tmpdir}"
+        sha256sum -c "${filename}.sha256sum"
+    )
+
+    tar -xzf "${tmpdir}/${filename}" -C "${tmpdir}"
+    install_dir="/usr/local/bin"
+    if [ ! -w "${install_dir}" ]; then
+        install_dir="${HOME}/.local/bin"
+        mkdir -p "${install_dir}"
+    fi
+    install -m 0755 "${tmpdir}/${os}-${arch}/helm" "${install_dir}/helm"
+    export PATH="${install_dir}:${PATH}"
 
     echo "Helm installed:"
     helm version --short


### PR DESCRIPTION
### Motivation
- Remove a supply-chain RCE by eliminating the unverified `curl | bash` installer in the `helm-install` recipe and replace it with a checksum-verified, pinned artifact install.
- Preserve the recipe's idempotent behavior and multi-architecture support while preventing remote-script execution from `raw.githubusercontent.com`.

### Description
- Replace `just helm-install` implementation to download a pinned Helm tarball (`HELM_VERSION`, default `v3.18.0`), verify the published SHA-256 checksum, extract the binary, and install it into `/usr/local/bin` or fall back to `~/.local/bin` when unwritable.
- Map common `uname -m` values to Helm release architecture names to support `amd64`, `arm64`, and `arm` (Raspberry Pi) platforms and fail fast on unknown architectures.
- Update `docs/raspi_cluster_operations.md` and `docs/raspi_cluster_operations_manual.md` to document the checksum-verified installation flow and replace instructions that previously recommended `curl -fsSL ... | bash`.

### Testing
- Ran `git diff --cached | ./scripts/scan-secrets.py`, which completed with no secret findings reported.
- Searched for the vulnerable pattern using `rg` to ensure no remaining `raw.githubusercontent.com/.../get-helm-3 | bash` usages, and the search returned no matches in the updated files.
- Attempted `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` but those tools were not available in the execution environment (commands not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d84b6c98832fac037144a47c27b1)