### PR TITLE
🔒 fix: enforce strict SSH host key checking

### DIFF
--- a/docs/design/tailscale-remote-ops.md
+++ b/docs/design/tailscale-remote-ops.md
@@ -245,6 +245,11 @@ unset TS_AUTH_KEY
 
 `just tailscale-ssh-check` uses SSH `StrictHostKeyChecking=yes`, so operators must verify host keys
 before first connection (or pre-seed `known_hosts`) to prevent trust-on-first-use MITM risk.
+For example, after validating the fingerprint out-of-band, you can pre-seed:
+
+```bash
+ssh-keyscan sugarkube0 >> ~/.ssh/known_hosts
+```
 
 ## Failure modes and remediation
 

--- a/docs/design/tailscale-remote-ops.md
+++ b/docs/design/tailscale-remote-ops.md
@@ -243,9 +243,8 @@ SUGARKUBE_TAILSCALE_AUTH_KEY="$TS_AUTH_KEY" just tailscale-up
 unset TS_AUTH_KEY
 ```
 
-`just tailscale-ssh-check` uses SSH `StrictHostKeyChecking=accept-new` for first-connection
-convenience. This is a trust-on-first-use trade-off: run the first probe from a trusted network and
-prefer pre-provisioned host keys if your environment requires strict anti-MITM guarantees.
+`just tailscale-ssh-check` uses SSH `StrictHostKeyChecking=yes`, so operators must verify host keys
+before first connection (or pre-seed `known_hosts`) to prevent trust-on-first-use MITM risk.
 
 ## Failure modes and remediation
 

--- a/scripts/tailscale_remote_ops.sh
+++ b/scripts/tailscale_remote_ops.sh
@@ -126,7 +126,7 @@ ssh_check() {
   log "probing ssh to ${target}"
   ssh \
     -o BatchMode=yes \
-    -o StrictHostKeyChecking=accept-new \
+    -o StrictHostKeyChecking=yes \
     -o ConnectTimeout=8 \
     "$target" true
 }

--- a/tests/test_tailscale_remote_ops_script.py
+++ b/tests/test_tailscale_remote_ops_script.py
@@ -175,6 +175,7 @@ exit 0
     )
 
     assert result.returncode == 0, result.stderr
+    assert calls.exists(), "fake ssh was never invoked — ssh_check() did not call ssh"
     logged = calls.read_text(encoding="utf-8")
     assert "StrictHostKeyChecking=yes" in logged
     assert "StrictHostKeyChecking=accept-new" not in logged

--- a/tests/test_tailscale_remote_ops_script.py
+++ b/tests/test_tailscale_remote_ops_script.py
@@ -147,3 +147,34 @@ exit 0
 
     assert result.returncode != 0
     assert "contains unsafe characters" in result.stderr
+
+
+def test_ssh_check_enforces_strict_host_key_checking(tmp_path: Path) -> None:
+    fakebin = tmp_path / "bin"
+    fakebin.mkdir()
+    calls = tmp_path / "ssh_calls.log"
+
+    _write_executable(
+        fakebin / "ssh",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" > "{calls}"
+exit 0
+""",
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fakebin}:{env.get('PATH', '')}"
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "ssh-check", "pi@sugarkube0"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    logged = calls.read_text(encoding="utf-8")
+    assert "StrictHostKeyChecking=yes" in logged
+    assert "StrictHostKeyChecking=accept-new" not in logged


### PR DESCRIPTION
### Motivation
- Prevent trust-on-first-use host-key poisoning by removing `StrictHostKeyChecking=accept-new` from the SSH probe and requiring verified host keys.
- Ensure the `ssh-check` helper enforces conservative, non-TOFU defaults so an attacker cannot silently register a spoofed host key on first probe.

### Description
- Change `scripts/tailscale_remote_ops.sh` `ssh_check()` to use `-o StrictHostKeyChecking=yes` instead of `accept-new` so unknown host keys are not auto-accepted.
- Add a regression unit test in `tests/test_tailscale_remote_ops_script.py` that stubs `ssh` and asserts `StrictHostKeyChecking=yes` is used and `accept-new` is not present.
- Update `docs/design/tailscale-remote-ops.md` to document the hardened behavior and advise operators to verify or pre-seed `known_hosts` before first connection.

### Testing
- Ran `pytest -q tests/test_tailscale_remote_ops_script.py tests/test_tailscale_remote_ops_docs.py tests/test_tailscale_remote_ops_e2e.py`, and all tests passed (`9 passed`).
- Attempted `pre-commit run --all-files`, but `pre-commit` was not available in the environment so it did not run.
- Attempted `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/`, but those tools were not present in the environment so they did not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db2c5c4800832f8b6c368a339b3cd0)