### PR TITLE
🔒 fix: verify Tailscale installer checksum before execution

### DIFF
--- a/docs/design/tailscale-remote-ops.md
+++ b/docs/design/tailscale-remote-ops.md
@@ -118,14 +118,15 @@ then validate with `just status` and `just cluster-status`.
 
 This repository now includes helper recipes for the node-local Tailscale setup flow:
 
-- `just tailscale-install` installs the upstream Tailscale package.
+- `just tailscale-install` installs the upstream Tailscale package after verifying
+  `SUGARKUBE_TAILSCALE_INSTALL_SHA256`.
 - `just tailscale-up` brings the node online with your local auth flow.
 - `just tailscale-status` verifies enrollment state.
 
 Example (placeholder-only) usage:
 
 ```bash
-just tailscale-install
+SUGARKUBE_TAILSCALE_INSTALL_SHA256='<sha256-for-install.sh>' just tailscale-install
 just tailscale-up
 just tailscale-status
 ```
@@ -206,7 +207,7 @@ Do not rewire existing cluster networking during rollout.
 The Tailscale remote-operations design is now implemented with dedicated automation in:
 
 - `scripts/tailscale_remote_ops.sh` for install/up/status/SSH probes.
-- `just tailscale-install`
+- `just tailscale-install` (requires `SUGARKUBE_TAILSCALE_INSTALL_SHA256`)
 - `just tailscale-up`
 - `just tailscale-status`
 - `just tailscale-ssh-check`
@@ -223,7 +224,7 @@ Use this sequence on each `sugarkube<n>` node after base cluster setup:
 
 ```bash
 # 1) Install Tailscale
-just tailscale-install
+SUGARKUBE_TAILSCALE_INSTALL_SHA256='<sha256-for-install.sh>' just tailscale-install
 
 # 2) Bring node online (interactive auth)
 just tailscale-up

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -73,7 +73,7 @@ If you operate the cluster remotely, follow the dedicated Tailscale design guide
 High-level operator flow (canonical commands):
 
 ```bash
-just tailscale-install
+SUGARKUBE_TAILSCALE_INSTALL_SHA256='<sha256-for-install.sh>' just tailscale-install
 just tailscale-up
 just tailscale-status
 just tailscale-ssh-check target='<operator>@sugarkube0'

--- a/scripts/tailscale_remote_ops.sh
+++ b/scripts/tailscale_remote_ops.sh
@@ -14,6 +14,7 @@ Commands:
 Environment:
   SUGARKUBE_TAILSCALE_AUTH_KEY   Optional auth key used by `up`.
   SUGARKUBE_TAILSCALE_INSTALL_URL Override install script URL.
+  SUGARKUBE_TAILSCALE_INSTALL_SHA256 Required SHA-256 checksum for install script.
 USAGE
 }
 
@@ -63,15 +64,32 @@ install_tailscale() {
   require_cmd curl
   require_cmd sh
   require_cmd mktemp
+  require_cmd sha256sum
 
   local install_url="${SUGARKUBE_TAILSCALE_INSTALL_URL:-https://tailscale.com/install.sh}"
+  local expected_sha256="${SUGARKUBE_TAILSCALE_INSTALL_SHA256:-}"
+  local actual_sha256
   local tmp_script
   validate_install_url "$install_url"
+  if [[ ! "$expected_sha256" =~ ^[0-9a-fA-F]{64}$ ]]; then
+    cat >&2 <<'EOF'
+missing or invalid SUGARKUBE_TAILSCALE_INSTALL_SHA256 (expected 64 hex chars).
+Refusing to execute a downloaded installer script without integrity verification.
+EOF
+    exit 1
+  fi
+
   tmp_script="$(mktemp)"
   trap 'rm -f "${tmp_script:-}"' RETURN
 
   log "installing tailscale from ${install_url}"
   curl -fsSL --output "$tmp_script" "$install_url"
+  actual_sha256="$(sha256sum "$tmp_script" | awk '{print $1}')"
+  if [ "$actual_sha256" != "${expected_sha256,,}" ]; then
+    printf 'tailscale install script checksum mismatch (expected %s, got %s)\n' \
+      "${expected_sha256,,}" "$actual_sha256" >&2
+    exit 1
+  fi
   run_as_root sh "$tmp_script"
   log 'install complete'
 }

--- a/scripts/tailscale_remote_ops.sh
+++ b/scripts/tailscale_remote_ops.sh
@@ -64,7 +64,19 @@ install_tailscale() {
   require_cmd curl
   require_cmd sh
   require_cmd mktemp
-  require_cmd sha256sum
+
+  local -a sha_cmd
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha_cmd=(sha256sum)
+  elif command -v shasum >/dev/null 2>&1; then
+    sha_cmd=(shasum -a 256)
+  else
+    cat >&2 <<'EOF'
+missing required command: sha256sum (or shasum -a 256)
+Install coreutils or ensure shasum is available.
+EOF
+    exit 1
+  fi
 
   local install_url="${SUGARKUBE_TAILSCALE_INSTALL_URL:-https://tailscale.com/install.sh}"
   local expected_sha256="${SUGARKUBE_TAILSCALE_INSTALL_SHA256:-}"
@@ -80,17 +92,20 @@ EOF
   fi
 
   tmp_script="$(mktemp)"
-  trap 'rm -f "${tmp_script:-}"' RETURN
+  trap 'rm -f "${tmp_script:-}"' RETURN EXIT
 
   log "installing tailscale from ${install_url}"
   curl -fsSL --output "$tmp_script" "$install_url"
-  actual_sha256="$(sha256sum "$tmp_script" | awk '{print $1}')"
+  read -r actual_sha256 _ < <("${sha_cmd[@]}" "$tmp_script")
   if [ "$actual_sha256" != "${expected_sha256,,}" ]; then
     printf 'tailscale install script checksum mismatch (expected %s, got %s)\n' \
       "${expected_sha256,,}" "$actual_sha256" >&2
+    rm -f "$tmp_script"
     exit 1
   fi
   run_as_root sh "$tmp_script"
+  rm -f "$tmp_script"
+  trap - RETURN EXIT
   log 'install complete'
 }
 

--- a/tests/test_tailscale_remote_ops_e2e.py
+++ b/tests/test_tailscale_remote_ops_e2e.py
@@ -72,6 +72,9 @@ printf 'tailscale %s\n' "$*" >> "{calls}"
     env = os.environ.copy()
     env["PATH"] = f"{fakebin}:{env.get('PATH', '')}"
     env["SUGARKUBE_TAILSCALE_AUTH_KEY"] = "tskey-test"
+    env["SUGARKUBE_TAILSCALE_INSTALL_SHA256"] = (
+        "fb99eae951f1adc14d1a4a9a186c21930db2786b3208c94c7d9af382bd1048e5"
+    )
 
     install = subprocess.run(
         [just_bin, "tailscale-install"],

--- a/tests/test_tailscale_remote_ops_script.py
+++ b/tests/test_tailscale_remote_ops_script.py
@@ -147,3 +147,100 @@ exit 0
 
     assert result.returncode != 0
     assert "contains unsafe characters" in result.stderr
+
+
+def test_install_requires_expected_checksum_env_var(tmp_path: Path) -> None:
+    fakebin = tmp_path / "bin"
+    fakebin.mkdir()
+
+    _write_executable(
+        fakebin / "curl",
+        """#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+""",
+    )
+    _write_executable(
+        fakebin / "sh",
+        """#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+""",
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fakebin}:{env.get('PATH', '')}"
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "install"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "missing or invalid SUGARKUBE_TAILSCALE_INSTALL_SHA256" in result.stderr
+
+
+def test_install_rejects_checksum_mismatch_and_cleans_tmp_file(tmp_path: Path) -> None:
+    fakebin = tmp_path / "bin"
+    fakebin.mkdir()
+    tmp_script = tmp_path / "installer.sh"
+
+    _write_executable(
+        fakebin / "mktemp",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "{tmp_script}"
+""",
+    )
+    _write_executable(
+        fakebin / "curl",
+        """#!/usr/bin/env bash
+set -euo pipefail
+outfile=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--output" ]; then
+    outfile="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+printf '%s\\n' '#!/usr/bin/env bash' 'echo from-fake-installer' > "$outfile"
+""",
+    )
+    _write_executable(
+        fakebin / "sha256sum",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s  %s\\n' 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' "$1"
+""",
+    )
+    _write_executable(
+        fakebin / "sh",
+        """#!/usr/bin/env bash
+set -euo pipefail
+exit 99
+""",
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fakebin}:{env.get('PATH', '')}"
+    env["SUGARKUBE_TAILSCALE_INSTALL_SHA256"] = (
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    )
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "install"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "checksum mismatch" in result.stderr
+    assert not tmp_script.exists()
+


### PR DESCRIPTION
### Motivation
- Prevent remote code execution and supply-chain risk from piping an unverified upstream install script into `sh` by requiring integrity verification before execution.

### Description
- Added `SUGARKUBE_TAILSCALE_INSTALL_SHA256` environment variable and require it to be a 64-hex SHA-256 in `scripts/tailscale_remote_ops.sh` before running the installer.
- Download the install script to a temporary file, compute its `sha256sum`, compare against the expected value, and refuse to run if missing or mismatched.
- Require `sha256sum` at runtime and keep install execution performed via `run_as_root sh <tmpfile>` after verification.
- Updated `docs/design/tailscale-remote-ops.md` and `docs/raspi_cluster_operations.md` to show checksum-pinned `just tailscale-install` usage and note the requirement.

### Testing
- Verified shell syntax and usage with `bash -n scripts/tailscale_remote_ops.sh` and `scripts/tailscale_remote_ops.sh --help | head -n 20`, which succeeded and shows the new env var description.
- Ran `git diff --cached | ./scripts/scan-secrets.py` against staged changes, which succeeded.
- `pre-commit`, `pyspelling`, and `linkchecker` were attempted but not available in this environment so those checks were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db2d7b55b0832f99adc26b05be302e)