### PR TITLE
fix: pin tokenplace-relay default image tag

### DIFF
--- a/apps/tokenplace-relay/values.dev.yaml
+++ b/apps/tokenplace-relay/values.dev.yaml
@@ -3,7 +3,7 @@
 # commands in the justfile.
 image:
   repository: ghcr.io/democratizedspace/tokenplace-relay
-  tag: main
+  tag: sha-684fd7f
 
 ingress:
   enabled: true

--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -27,8 +27,8 @@ The Helm release runs in the `tokenplace` namespace with release name `tokenplac
 ## Container image and Helm chart
 
 - Image repository: `ghcr.io/democratizedspace/tokenplace-relay`
-  - Tags: `main` (latest build) or immutable `sha-<shortsha>` builds from the CI publisher.
-  - Default staging tag: `main` (set via `default_tag` in the helper); prefer `tag=sha-<sha>` for promoted releases.
+  - Tags: immutable `sha-<shortsha>` builds from the CI publisher (recommended) and `main` (mutable).
+  - Default staging tag: `sha-684fd7f` (set via `default_tag` in the helper); override with `tag=sha-<sha>` for promotions.
 - Helm chart: `./apps/tokenplace-relay`
   - Release: `tokenplace-relay`
   - Namespace: `tokenplace`
@@ -38,7 +38,7 @@ Example values snippet:
 ```yaml
 image:
   repository: ghcr.io/democratizedspace/tokenplace-relay
-  tag: main
+  tag: sha-684fd7f
 ingress:
   className: traefik
   annotations:
@@ -60,7 +60,7 @@ probes:
 
 ```bash
 # Install or upgrade the relay with staging ingress + TLS (wraps helm upgrade --install)
-just tokenplace-oci-redeploy tag=main
+just tokenplace-oci-redeploy
 
 # Print ingress + pod status
 just tokenplace-status
@@ -69,7 +69,7 @@ just tokenplace-status
 just tokenplace-oci-redeploy tag=sha-<shortsha>
 ```
 
-- The `default_tag` keeps staging pinned to the latest validated `main` build; pass `tag=sha-<new>`
+- The `default_tag` keeps staging pinned to a vetted immutable SHA tag; pass `tag=sha-<new>`
   when promoting a fresh image.
 - Health probes default to `/healthz` (readiness) and `/livez` (liveness) on the `http` port
   (`containerPort: 5010`). Override `probes.port`, `probes.readiness.path`, or `probes.liveness.path`
@@ -103,7 +103,7 @@ just tokenplace-oci-redeploy tag=sha-<shortsha>
 
 ## Operational helpers
 
-- Deploy or roll forward: `just tokenplace-oci-redeploy tag=<main|sha-...>` (release `tokenplace-relay`
+- Deploy or roll forward: `just tokenplace-oci-redeploy [tag=sha-...]` (release `tokenplace-relay`
   in namespace `tokenplace`, values from `apps/tokenplace-relay/values.*.yaml`)
 - Check status: `just tokenplace-status` (prints pods/ingress and the public URL)
 - Tail logs: `just tokenplace-logs`

--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -28,7 +28,7 @@ The Helm release runs in the `tokenplace` namespace with release name `tokenplac
 
 - Image repository: `ghcr.io/democratizedspace/tokenplace-relay`
   - Tags: immutable `sha-<shortsha>` builds from the CI publisher (recommended) and `main` (mutable).
-  - Default staging tag: `sha-684fd7f` (set via `default_tag` in the helper); override with `tag=sha-<sha>` for promotions.
+  - Default staging tag: `sha-684fd7f` (set via `default_tag` in the helper); override with `tag=sha-<shortsha>` for promotions.
 - Helm chart: `./apps/tokenplace-relay`
   - Release: `tokenplace-relay`
   - Namespace: `tokenplace`
@@ -69,7 +69,7 @@ just tokenplace-status
 just tokenplace-oci-redeploy tag=sha-<shortsha>
 ```
 
-- The `default_tag` keeps staging pinned to a vetted immutable SHA tag; pass `tag=sha-<new>`
+- The `default_tag` keeps staging pinned to a vetted immutable SHA tag; pass `tag=sha-<shortsha>`
   when promoting a fresh image.
 - Health probes default to `/healthz` (readiness) and `/livez` (liveness) on the `http` port
   (`containerPort: 5010`). Override `probes.port`, `probes.readiness.path`, or `probes.liveness.path`

--- a/docs/examples/tokenplace-relay.values.dev.yaml
+++ b/docs/examples/tokenplace-relay.values.dev.yaml
@@ -2,7 +2,7 @@
 # apps/tokenplace-relay/values.dev.yaml for the operator defaults).
 image:
   repository: ghcr.io/democratizedspace/tokenplace-relay
-  tag: main
+  tag: sha-684fd7f
 
 ingress:
   enabled: true

--- a/justfile
+++ b/justfile
@@ -1584,7 +1584,7 @@ tokenplace-oci-redeploy tag='':
       chart='./apps/tokenplace-relay' \
       values='apps/tokenplace-relay/values.dev.yaml,apps/tokenplace-relay/values.staging.yaml' \
       version_file='' \
-      tag='{{ tag }}' default_tag='main'
+      tag='{{ tag }}' default_tag='sha-684fd7f'
 
     scripts/ensure_user_kubeconfig.sh || true
     if [ -z "${KUBECONFIG:-}" ]; then

--- a/justfile
+++ b/justfile
@@ -1571,7 +1571,7 @@ dspace-debug-logs-env env='staging' namespace='dspace':
     just --justfile "{{ justfile_directory() }}/justfile" dspace-debug-logs namespace="{{ namespace }}"
 
 # Fast redeploy of token.place relay from GHCR.
-# The default tag pins staging to the last validated `main` build; pass tag=sha-<new>
+# The default tag pins staging to a vetted immutable SHA build; pass tag=sha-<shortsha>
 # after promoting a fresh image.
 
 # See docs/apps/tokenplace-relay.md for relay-specific operations.


### PR DESCRIPTION
### Motivation
- Operator defaults and the redeploy helper used the mutable tag `main`, which allows silent image replacement if the registry tag is overwritten. 
- The change hardens supply-chain integrity by preferring an immutable SHA-style tag for staging defaults.

### Description
- Changed `apps/tokenplace-relay/values.dev.yaml` to set `image.tag: sha-684fd7f` instead of `main` to avoid a mutable default. 
- Updated `justfile` to use `default_tag='sha-684fd7f'` for the `tokenplace-oci-redeploy` helper so redeploys default to the immutable tag. 
- Updated the example values file `docs/examples/tokenplace-relay.values.dev.yaml` to mirror the pinned tag. 
- Updated `docs/apps/tokenplace-relay.md` to document the immutable default tag and adjust quickstart/redeploy guidance accordingly.

### Testing
- Ran `git diff --cached | ./scripts/scan-secrets.py` which completed without finding secret-like strings. 
- Ran `git diff --cached --check` which reported no whitespace or patch errors. 
- `pre-commit run --all-files` was not executed because `pre-commit` is not installed in this environment (`pre-commit: command not found`). 
- `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` were not executed because the tools are not available in this environment (`pyspelling: command not found`, `linkchecker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db2d7b67b8832fa0f8c53f29a108d1)