### PR TITLE
Disable auto-enable of kubeconfig/node-token export path units

### DIFF
--- a/docs/pi_headless_provisioning.md
+++ b/docs/pi_headless_provisioning.md
@@ -41,11 +41,10 @@ Recommended options:
 - Configure Wi-Fi credentials using `wifis`.
 - Inject optional environment variables for services like Cloudflare Tunnels or token.place secrets.
 
-The base image now writes sanitized and full kubeconfigs (`/boot/sugarkube-kubeconfig*`) plus the
-k3s node token (`/boot/sugarkube-node-token`) once k3s is online, so you can collect cluster
-credentials without SSH. The baked-in `sugarkube-export-kubeconfig.path` and
-`sugarkube-export-node-token.path` units re-run the exporters whenever the kubeconfig or node token
-appears later in the boot process, replacing any `*(pending)` placeholders automatically. The
+The base image ships the kubeconfig and node-token export scripts and companion systemd units, but
+the path units are **not enabled by default**. This avoids automatically writing full credentials
+to `/boot` on every change. If you accept that risk for your environment, you can manually enable
+`sugarkube-export-kubeconfig.path` and `sugarkube-export-node-token.path` after first boot. The
 default template still seeds `/boot/sugarkube/` with placeholders for bootstrap tokens or
 additional secrets you may want to mirror on first boot.
 

--- a/scripts/build_pi_image.sh
+++ b/scripts/build_pi_image.sh
@@ -590,10 +590,6 @@ install -Dm644 "${REPO_ROOT}/scripts/systemd/sugarkube-export-node-token.path" \
 install -d "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/etc/systemd/system/multi-user.target.wants"
 ln -sf ../first-boot.service \
   "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/etc/systemd/system/multi-user.target.wants/first-boot.service"
-ln -sf ../sugarkube-export-kubeconfig.path \
-  "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/etc/systemd/system/multi-user.target.wants/sugarkube-export-kubeconfig.path"
-ln -sf ../sugarkube-export-node-token.path \
-  "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/etc/systemd/system/multi-user.target.wants/sugarkube-export-node-token.path"
 install -Dm755 "${REPO_ROOT}/systemd/first-boot-prepare.sh" \
   "${PI_GEN_DIR}/stage2/01-sys-tweaks/files/usr/local/sbin/first-boot-prepare.sh"
 install -Dm644 "${REPO_ROOT}/systemd/first-boot-prepare.service" \

--- a/tests/build_pi_image_test.py
+++ b/tests/build_pi_image_test.py
@@ -871,7 +871,7 @@ def test_installs_ssd_clone_service(tmp_path):
     assert not (tmp_path / "sugarkube.img.xz.xz").exists()
 
 
-def test_installs_path_units_for_kube_artifacts(tmp_path):
+def test_installs_but_does_not_enable_path_units_for_kube_artifacts(tmp_path):
     env = _setup_build_env(tmp_path)
     env["KEEP_WORK_DIR"] = "1"
 
@@ -898,7 +898,7 @@ def test_installs_path_units_for_kube_artifacts(tmp_path):
         "sugarkube-export-kubeconfig.path",
         "sugarkube-export-node-token.path",
     ):
-        assert (wants_dir / unit_name).exists(), f"{unit_name} not enabled"
+        assert not (wants_dir / unit_name).exists(), f"{unit_name} should be opt-in"
 
     shutil.rmtree(work_dir)
     assert not (tmp_path / "sugarkube.img.xz.xz").exists()


### PR DESCRIPTION
### Motivation

- A build change installed and enabled `sugarkube-export-*.path` units by default, which caused full admin kubeconfig and node join tokens to be written to `/boot` automatically and increased credential exposure risk. 
- The intent is to keep the exporter tools available but avoid automatic credential leakage on images where `/boot` is broadly readable, making export behavior opt-in.

### Description

- Stop creating symlinks that enable `sugarkube-export-kubeconfig.path` and `sugarkube-export-node-token.path` in `multi-user.target.wants` by removing the `ln -sf` enablement lines in `scripts/build_pi_image.sh`. 
- Keep the export unit files installed so operators can manually enable them if desired. 
- Update the build regression test by renaming it to `test_installs_but_does_not_enable_path_units_for_kube_artifacts` and asserting the path units are present but not enabled in `tests/build_pi_image_test.py`. 
- Update `docs/pi_headless_provisioning.md` to document that the path units are not enabled by default and must be opted into manually.

### Testing

- Ran `pytest -q tests/build_pi_image_test.py -k path_units` and the targeted test passed (`1 passed, 38 deselected`).
- Ran the repository secret scanner via `git diff --cached | ./scripts/scan-secrets.py` with no findings. 
- `pre-commit`, `pyspelling`, and `linkchecker` were not available in this environment so those checks were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db2d7b0170832f8d0162146146456f)