### PR TITLE
Normalize env arg for `just up` / wrappers to prevent `env=...` leakage

### DIFF
--- a/justfile
+++ b/justfile
@@ -28,11 +28,32 @@ up env='dev':
     set -Eeuo pipefail
 
     env_input="{{ env }}"
-    env_name="${env_input}"
-    if [ "${env_input}" = "int" ]; then
-        printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
-        env_name="staging"
+    if [ -z "${SUGARKUBE_ENV_LIB:-}" ] && [ -f "{{ invocation_directory() }}/scripts/lib/env.sh" ]; then
+        SUGARKUBE_ENV_LIB="{{ invocation_directory() }}/scripts/lib/env.sh"
     fi
+    : "${SUGARKUBE_ENV_LIB:=/home/pi/sugarkube/scripts/lib/env.sh}"
+    if [ ! -f "${SUGARKUBE_ENV_LIB}" ] && [ -f "/home/pi/sugarkube/scripts/lib/env.sh" ]; then
+        SUGARKUBE_ENV_LIB="/home/pi/sugarkube/scripts/lib/env.sh"
+    fi
+    if [ -f "${SUGARKUBE_ENV_LIB}" ]; then
+        # shellcheck disable=SC1090
+        source "${SUGARKUBE_ENV_LIB}"
+    else
+        sugarkube_normalize_env() {
+            local env_name="${1:-dev}"
+            env_name="$(printf '%s' "${env_name}" | xargs)"
+            while [[ "${env_name}" == env=* ]]; do
+                env_name="${env_name#env=}"
+            done
+            if [ "${env_name}" = "int" ]; then
+                printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
+                env_name="staging"
+            fi
+            printf '%s\n' "${env_name}"
+        }
+    fi
+    env_name="$(sugarkube_normalize_env "${env_input}")"
+    export SUGARKUBE_ENV_LIB
 
     # Select per-environment token if available
     if [ "${env_name}" = "dev" ] && [ -n "${SUGARKUBE_TOKEN_DEV-}" ]; then
@@ -277,7 +298,14 @@ cluster-status:
 
 # Run twice per server during initial bring-up to build a 3-node HA control plane.
 ha3 env='dev':
-    SUGARKUBE_SERVERS=3 just --justfile "{{ justfile_directory() }}/justfile" up {{ env }}
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    env_input="{{ env }}"
+    # shellcheck disable=SC1091
+    source "{{ justfile_directory() }}/scripts/lib/env.sh"
+    env_name="$(sugarkube_normalize_env "${env_input}")"
+    SUGARKUBE_SERVERS=3 just --justfile "{{ justfile_directory() }}/justfile" up "${env_name}"
 
 ha3-dev:
     just --justfile "{{ justfile_directory() }}/justfile" ha3 env=dev
@@ -367,7 +395,14 @@ ha3-untaint-control-plane:
 
 # Capture sanitized logs to logs/up/ during cluster bring-up (useful for troubleshooting and documentation).
 save-logs env='dev':
-    SAVE_DEBUG_LOGS=1 just --justfile "{{ justfile_directory() }}/justfile" up {{ env }}
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    env_input="{{ env }}"
+    # shellcheck disable=SC1091
+    source "{{ justfile_directory() }}/scripts/lib/env.sh"
+    env_name="$(sugarkube_normalize_env "${env_input}")"
+    SAVE_DEBUG_LOGS=1 just --justfile "{{ justfile_directory() }}/justfile" up "${env_name}"
 
 save-logs-dev:
     just --justfile "{{ justfile_directory() }}/justfile" save-logs env=dev

--- a/scripts/lib/env.sh
+++ b/scripts/lib/env.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Shared environment-name normalization for just recipes and shell helpers.
+
+sugarkube_normalize_env() {
+  local env_input="${1:-dev}"
+  local env_name
+
+  env_name="$(printf '%s' "${env_input}" | xargs)"
+  while [[ "${env_name}" == env=* ]]; do
+    env_name="${env_name#env=}"
+  done
+
+  if [ "${env_name}" = "int" ]; then
+    printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
+    env_name="staging"
+  fi
+
+  printf '%s\n' "${env_name}"
+}

--- a/tests/scripts/test_env_normalization.py
+++ b/tests/scripts/test_env_normalization.py
@@ -1,0 +1,70 @@
+"""Regression tests for Sugarkube environment argument normalization."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENV_LIB = REPO_ROOT / "scripts" / "lib" / "env.sh"
+
+
+def _normalize_env(value: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "bash",
+            "-c",
+            "source \"$1\"; sugarkube_normalize_env \"$2\"",
+            "bash",
+            str(ENV_LIB),
+            value,
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_normalize_env_accepts_positional_and_named_forms() -> None:
+    """The outage regression was `env=staging` leaking into k3s mDNS names."""
+    cases = {
+        "staging": "staging",
+        "env=staging": "staging",
+        "env=env=staging": "staging",
+        "dev": "dev",
+        "prod": "prod",
+    }
+
+    for raw, expected in cases.items():
+        result = _normalize_env(raw)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout == f"{expected}\n"
+        assert "env=staging" not in result.stdout
+
+
+def test_normalize_env_preserves_int_alias_to_staging() -> None:
+    result = _normalize_env("int")
+
+    assert result.returncode == 0
+    assert result.stdout == "staging\n"
+    assert 'env name "int" is deprecated' in result.stderr
+
+
+def test_normalized_staging_does_not_build_malformed_discovery_names() -> None:
+    """Guard the DSPACE outage case that produced `_k3s-sugar-env=staging._tcp`."""
+    result = _normalize_env("env=env=staging")
+    assert result.returncode == 0, result.stderr
+
+    env_name = result.stdout.strip()
+    service_type = f"_k3s-sugar-{env_name}._tcp"
+    txt_record = f"env={env_name}"
+    service_file = f"/etc/avahi/services/k3s-sugar-{env_name}.service"
+
+    assert env_name == "staging"
+    assert service_type == "_k3s-sugar-staging._tcp"
+    assert txt_record == "env=staging"
+    assert service_file == "/etc/avahi/services/k3s-sugar-staging.service"
+    assert "env=staging" not in service_type
+    assert "env=env=staging" not in txt_record
+    assert "k3s-sugar-env=staging" not in service_file

--- a/tests/test_helper_recipes.py
+++ b/tests/test_helper_recipes.py
@@ -47,8 +47,8 @@ def test_ha3_recipe_has_correct_purpose(justfile_text: str) -> None:
         ha3_start = justfile_text.find("ha3:")
     assert ha3_start != -1, "ha3 recipe not found"
 
-    # Get the recipe body (next ~300 characters after the recipe declaration)
-    ha3_section = justfile_text[ha3_start : ha3_start + 300]
+    # Get the recipe body (next ~600 characters after the recipe declaration)
+    ha3_section = justfile_text[ha3_start : ha3_start + 600]
 
     assert "SUGARKUBE_SERVERS=3" in ha3_section
     assert "just" in ha3_section and "up" in ha3_section
@@ -66,11 +66,31 @@ def test_save_logs_recipe_has_correct_purpose(justfile_text: str) -> None:
         save_logs_start = justfile_text.find("save-logs:")
     assert save_logs_start != -1, "save-logs recipe not found"
 
-    # Get the recipe body (next ~300 characters after the recipe declaration)
-    save_logs_section = justfile_text[save_logs_start : save_logs_start + 300]
+    # Get the recipe body (next ~600 characters after the recipe declaration)
+    save_logs_section = justfile_text[save_logs_start : save_logs_start + 600]
 
     assert "SAVE_DEBUG_LOGS=1" in save_logs_section
     assert "just" in save_logs_section and "up" in save_logs_section
+
+
+def test_ha3_recipe_normalizes_named_env_before_delegating(justfile_text: str) -> None:
+    """The ha3 wrapper should not pass env=env=staging into just up."""
+    ha3_start = justfile_text.find("ha3 env='dev':")
+    assert ha3_start != -1, "ha3 recipe not found"
+    ha3_section = justfile_text[ha3_start : ha3_start + 600]
+
+    assert "sugarkube_normalize_env" in ha3_section
+    assert 'up "${env_name}"' in ha3_section
+
+
+def test_save_logs_recipe_normalizes_named_env_before_delegating(justfile_text: str) -> None:
+    """The save-logs wrapper should follow the same env path as just up."""
+    save_logs_start = justfile_text.find("save-logs env='dev':")
+    assert save_logs_start != -1, "save-logs recipe not found"
+    save_logs_section = justfile_text[save_logs_start : save_logs_start + 600]
+
+    assert "sugarkube_normalize_env" in save_logs_section
+    assert 'up "${env_name}"' in save_logs_section
 
 
 def test_cat_node_token_recipe_exists(justfile_text: str) -> None:


### PR DESCRIPTION
### Motivation
- Fix a regression where named-style invocation like `just up env=staging` set `SUGARKUBE_ENV` to the literal `env=staging`, producing malformed Avahi/mDNS names (documented by the DSPACE outage record). 
- Keep positional behavior and the existing `int` → `staging` alias while avoiding changes to unrelated discovery, Helm, Cloudflare, or raw-IP logic. 

### Description
- Add a small shared helper `sugarkube_normalize_env` at `scripts/lib/env.sh` that strips repeated `env=` prefixes, trims whitespace, and maps `int` to `staging` with the existing deprecation warning. 
- Update the `up env='dev'` recipe in `justfile` to source/use the helper and export the normalized value into `SUGARKUBE_ENV` so named and positional forms are equivalent. 
- Update the `ha3` and `save-logs` wrapper recipes in `justfile` to normalize the `env` argument before delegating to `just up`, preventing wrappers from passing `env=...` through. 
- Add regression tests at `tests/scripts/test_env_normalization.py` covering `staging`, `env=staging`, `env=env=staging`, `dev`, `prod`, and the `int` alias, and extend `tests/test_helper_recipes.py` to assert wrappers normalize before delegating. 

### Testing
- Ran the full Python test suite with `python -m pytest`, which completed successfully (1167 passed, 19 skipped). 
- Ran targeted tests `tests/scripts/test_env_normalization.py` and `tests/test_helper_recipes.py`, both passed. 
- Verified `shellcheck scripts/lib/env.sh` and `just --unstable --fmt --check` locally; both checks passed for the touched files. 
- Performed `just --dry-run` on `up env=staging`, `ha3 env=staging`, and `save-logs env=staging` to confirm normalized invocation strings; outputs show normalized `staging`. 
- A full `pre-commit run --all-files` is currently blocked by unrelated repository-wide historical hook failures (Helm-template YAML parsing and existing flake8/whitespace issues) and therefore was not completed for all files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b55175574832fac6b50b5cba6375e)