### PR TITLE
🐛 Normalize named up env arguments

### DIFF
--- a/justfile
+++ b/justfile
@@ -28,11 +28,21 @@ up env='dev':
     set -Eeuo pipefail
 
     env_input="{{ env }}"
-    env_name="${env_input}"
-    if [ "${env_input}" = "int" ]; then
-        printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
-        env_name="staging"
-    fi
+    normalize_env_name() {
+        local value="${1}"
+
+        value="$(echo "${value}" | xargs)"
+        while [[ "${value}" == env=* ]]; do
+            value="${value#env=}"
+        done
+        if [ "${value}" = "int" ]; then
+            printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
+            value="staging"
+        fi
+
+        printf '%s' "${value}"
+    }
+    env_name="$(normalize_env_name "${env_input}")"
 
     # Select per-environment token if available
     if [ "${env_name}" = "dev" ] && [ -n "${SUGARKUBE_TOKEN_DEV-}" ]; then

--- a/tests/test_up_recipe_calls.py
+++ b/tests/test_up_recipe_calls.py
@@ -54,14 +54,19 @@ def main() -> None:
         capture = os.environ.get("TEST_CAPTURE_ENV_FILE")
         if capture:
             path = pathlib.Path(capture)
-            path.write_text(
-                "SUGARKUBE_KUBECONFIG_USER="
-                + os.environ.get("SUGARKUBE_KUBECONFIG_USER", "")
-                + "\\nSUGARKUBE_KUBECONFIG_HOME="
-                + os.environ.get("SUGARKUBE_KUBECONFIG_HOME", "")
-                + "\\n",
-                encoding="utf-8",
-            )
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(
+                    "command=k3s-discover\\n"
+                    + "SUGARKUBE_ENV="
+                    + os.environ.get("SUGARKUBE_ENV", "")
+                    + "\\nSUGARKUBE_SERVERS="
+                    + os.environ.get("SUGARKUBE_SERVERS", "")
+                    + "\\nSUGARKUBE_KUBECONFIG_USER="
+                    + os.environ.get("SUGARKUBE_KUBECONFIG_USER", "")
+                    + "\\nSUGARKUBE_KUBECONFIG_HOME="
+                    + os.environ.get("SUGARKUBE_KUBECONFIG_HOME", "")
+                    + "\\n---\\n"
+                )
         sys.exit(0)
 
     # No-op for all other sudo calls in `just up`.
@@ -75,6 +80,72 @@ if __name__ == "__main__":
         encoding="utf-8",
     )
     script.chmod(0o755)
+
+
+@pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")
+@pytest.mark.parametrize(
+    ("recipe", "arg", "expected_env", "expected_servers"),
+    [
+        ("up", "staging", "staging", "1"),
+        ("up", "env=staging", "staging", "1"),
+        ("up", "env=env=staging", "staging", "1"),
+        ("up", "int", "staging", "1"),
+        ("up", "dev", "dev", "1"),
+        ("up", "prod", "prod", "1"),
+        ("save-logs", "env=staging", "staging", "1"),
+        ("ha3", "env=staging", "staging", "3"),
+    ],
+)
+def test_up_wrappers_normalize_named_env_arguments(
+    tmp_path: Path, recipe: str, arg: str, expected_env: str, expected_servers: str
+) -> None:
+    """Guard the DSPACE outage regression where env=staging leaked into mDNS names."""
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_sudo(bin_dir)
+
+    capture = tmp_path / "captured.env"
+    state_dir = tmp_path / "state"
+    systemd_dir = tmp_path / "systemd"
+    state_dir.mkdir()
+    systemd_dir.mkdir()
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            "HOME": str(tmp_path / "home"),
+            "TEST_CAPTURE_ENV_FILE": str(capture),
+            "SUGARKUBE_SUMMARY_LIB": "/nonexistent/summary.sh",
+            "SUGARKUBE_CONFIGURE_AVAHI": "0",
+            "SUGARKUBE_DISABLE_WLAN_DURING_BOOTSTRAP": "0",
+            "SUGARKUBE_SET_K3S_NODE_IP": "0",
+            "SUGARKUBE_STATE_DIR": str(state_dir),
+            "SUGARKUBE_SYSTEMD_DIR": str(systemd_dir),
+            "SUGARKUBE_MEMCTRL_FORCE": "active",
+            "ALLOW_NON_ROOT": "1",
+            "SAVE_DEBUG_LOGS_DIR": str(tmp_path / "logs"),
+        }
+    )
+
+    result = subprocess.run(
+        ["just", "--justfile", "justfile", recipe, arg],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+    captured = capture.read_text(encoding="utf-8")
+    assert f"SUGARKUBE_ENV={expected_env}" in captured
+    assert f"SUGARKUBE_SERVERS={expected_servers}" in captured
+    assert "SUGARKUBE_ENV=env=" not in captured
+
+    service_type = f"_k3s-sugar-{expected_env}._tcp"
+    assert service_type != "_k3s-sugar-env=staging._tcp"
 
 
 @pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")


### PR DESCRIPTION
### Motivation
- A production outage record showed `just up env=staging` was parsed as the literal env name `env=staging`, which produced malformed Avahi/mDNS names and required manual cleanup. 
- The change aims to make named-style invocation parity with positional invocation so `just up staging` and `just up env=staging` both export `SUGARKUBE_ENV=staging` while preserving the `int` alias.

### Description
- Add a small `normalize_env_name` helper inside the `up` recipe in the `justfile` that strips repeated `env=` prefixes and trims whitespace, and maps `int` to `staging`. 
- Use `env_name="$(normalize_env_name "${env_input}")"` before selecting tokens and exporting `SUGARKUBE_ENV` so downstream discovery/Avahi consumers never receive `env=...` values. 
- Extend the existing test sudo stub to capture the effective `SUGARKUBE_ENV` and `SUGARKUBE_SERVERS` at the `k3s-discover` boundary and add a parametrized test that exercises `staging`, `env=staging`, `env=env=staging`, `int`, `dev`, `prod`, plus wrapper calls for `save-logs` and `ha3` to guard the regression. 
- Keep all positional behavior intact and do not change unrelated Avahi, k3s, Helm, or Cloudflare logic. 

### Testing
- Ran `pytest tests/test_up_recipe_calls.py tests/scripts/test_just_up.py -q` and all tests passed. 
- Ran `just --unstable --fmt --check` and the justfile formatting check passed. 
- Ran repository checks including `git diff --cached | ./scripts/scan-secrets.py` and the scan passed locally, while `pre-commit`, `pyspelling`, `linkchecker`, and `shellcheck` were not available in the container so those tools were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b55175574832fac6b50b5cba6375e)