### PR TITLE
fix: normalize up env arguments

### DIFF
--- a/justfile
+++ b/justfile
@@ -27,12 +27,24 @@ up env='dev':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
+    normalize_env_name() {
+        local value="$1"
+
+        value="$(echo "${value}" | xargs)"
+        while [[ "${value}" == env=* ]]; do
+            value="${value#env=}"
+        done
+
+        if [ "${value}" = "int" ]; then
+            printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
+            value="staging"
+        fi
+
+        printf '%s' "${value}"
+    }
+
     env_input="{{ env }}"
-    env_name="${env_input}"
-    if [ "${env_input}" = "int" ]; then
-        printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
-        env_name="staging"
-    fi
+    env_name="$(normalize_env_name "${env_input}")"
 
     # Select per-environment token if available
     if [ "${env_name}" = "dev" ] && [ -n "${SUGARKUBE_TOKEN_DEV-}" ]; then

--- a/tests/test_up_recipe_calls.py
+++ b/tests/test_up_recipe_calls.py
@@ -59,6 +59,10 @@ def main() -> None:
                 + os.environ.get("SUGARKUBE_KUBECONFIG_USER", "")
                 + "\\nSUGARKUBE_KUBECONFIG_HOME="
                 + os.environ.get("SUGARKUBE_KUBECONFIG_HOME", "")
+                + "\\nSUGARKUBE_ENV="
+                + os.environ.get("SUGARKUBE_ENV", "")
+                + "\\nSUGARKUBE_SERVERS="
+                + os.environ.get("SUGARKUBE_SERVERS", "")
                 + "\\n",
                 encoding="utf-8",
             )
@@ -107,3 +111,106 @@ def test_up_recipe_forwards_sudo_caller_kubeconfig_user_to_discovery(tmp_path: P
     captured = capture.read_text(encoding="utf-8").splitlines()
     assert "SUGARKUBE_KUBECONFIG_USER=alice" in captured
     assert "SUGARKUBE_KUBECONFIG_HOME=" in captured
+
+
+def test_up_normalize_env_name_strips_named_prefixes_without_just():
+    lines = Path("justfile").read_text(encoding="utf-8").splitlines()
+    body = _extract_recipe(lines, "up env='dev':")
+    function_lines: list[str] = []
+    collecting = False
+    for line in body:
+        stripped = line[4:] if line.startswith("    ") else line
+        if stripped.startswith("normalize_env_name()"):
+            collecting = True
+        if collecting:
+            function_lines.append(stripped)
+            if stripped == "}":
+                break
+
+    assert function_lines, "normalize_env_name helper not found in the up recipe"
+
+    script = "\n".join(
+        [
+            "set -Eeuo pipefail",
+            *function_lines,
+            "normalize_env_name staging",
+            "printf '\\n'",
+            "normalize_env_name env=staging",
+            "printf '\\n'",
+            "normalize_env_name env=env=staging",
+            "printf '\\n'",
+            "normalize_env_name int",
+            "printf '\\n'",
+        ]
+    )
+    result = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["staging", "staging", "staging", "staging"]
+
+
+def test_up_recipe_exports_only_normalized_env_to_discovery_path():
+    # Regression coverage for the 2026-05-18 DSPACE outage where `env=staging` reached
+    # mDNS/Avahi as `_k3s-sugar-env=staging._tcp` instead of `_k3s-sugar-staging._tcp`.
+    lines = Path("justfile").read_text(encoding="utf-8").splitlines()
+    body = _extract_recipe(lines, "up env='dev':")
+    body_text = "\n".join(body)
+    normalize_index = body_text.index('env_name="$(normalize_env_name "${env_input}")"')
+    export_index = body_text.index('export SUGARKUBE_ENV="${env_name}"')
+    discover_index = body_text.index("sudo -E bash scripts/k3s-discover.sh")
+    assert normalize_index < export_index < discover_index
+    assert 'export SUGARKUBE_ENV="${env_input}"' not in body_text
+
+
+@pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")
+@pytest.mark.parametrize(
+    ("command", "expected_env", "expected_servers"),
+    [
+        (["up", "staging"], "staging", "1"),
+        (["up", "env=staging"], "staging", "1"),
+        (["up", "env=env=staging"], "staging", "1"),
+        (["up", "int"], "staging", "1"),
+        (["up", "dev"], "dev", "1"),
+        (["up", "prod"], "prod", "1"),
+        (["save-logs", "staging"], "staging", "1"),
+        (["save-logs", "env=staging"], "staging", "1"),
+        (["ha3", "env=staging"], "staging", "3"),
+    ],
+)
+def test_up_family_normalizes_named_env_arguments(
+    tmp_path: Path, command: list[str], expected_env: str, expected_servers: str
+):
+    # Regression coverage for the 2026-05-18 DSPACE outage where `just up env=staging`
+    # propagated the literal value into Avahi names such as `_k3s-sugar-env=staging._tcp`.
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_sudo(bin_dir)
+
+    capture = tmp_path / "captured.env"
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            "HOME": str(tmp_path / "home"),
+            "TEST_CAPTURE_ENV_FILE": str(capture),
+            # Keep the recipe path deterministic and avoid local sourcing / log filtering.
+            "SUGARKUBE_SUMMARY_LIB": "/nonexistent/summary.sh",
+            "SUGARKUBE_LOG_FILTER": "/nonexistent/filter_debug_log.py",
+        }
+    )
+
+    result = subprocess.run(
+        ["just", "--justfile", "justfile", *command],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    captured = capture.read_text(encoding="utf-8").splitlines()
+    assert f"SUGARKUBE_ENV={expected_env}" in captured
+    assert f"SUGARKUBE_SERVERS={expected_servers}" in captured
+    assert "SUGARKUBE_ENV=env=staging" not in captured
+    assert "SUGARKUBE_ENV=env=env=staging" not in captured
+    assert "_k3s-sugar-env=staging._tcp" not in result.stdout + result.stderr


### PR DESCRIPTION
### Motivation
- Ensure `just up env=staging` behaves identically to `just up staging` so `SUGARKUBE_ENV` never contains literal `env=` prefixes and malformed Avahi/mDNS names are not produced; this addresses the regression observed in `outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md`.

### Description
- Add a `normalize_env_name` helper inside the `up` recipe that strips repeated `env=` prefixes and maps the deprecated `int` alias to `staging` before exporting `SUGARKUBE_ENV`.
- Replace the prior direct export with `env_name="$(normalize_env_name "${env_input}")"` so positional and named invocations are normalized uniformly while preserving existing behavior for `dev`, `staging`, `prod`, and the `int` alias.
- Extend the test harness: the fake `sudo` test helper now captures forwarded `SUGARKUBE_ENV` and `SUGARKUBE_SERVERS`, and add parametrized regression tests covering `staging`, `env=staging`, repeated `env=env=staging`, `int`, `dev`, `prod`, `save-logs`, and `ha3` cases.
- Scope kept minimal: only normalizes env argument handling in `up` and directly delegated wrappers, no changes to Avahi publishing, discovery, Helm, Cloudflare, or raw-IP logic.

### Testing
- Ran `pytest tests/test_up_recipe_calls.py -q` and the new tests passed (suite run shown in CI); full test run `pytest` completed successfully (1173 passed, 19 skipped).
- Verified `just` availability with `scripts/install_just.sh` + `just --list` to confirm recipes present and callable.
- Attempted `pre-commit run --all-files` and `pre-commit run --files justfile tests/test_up_recipe_calls.py`; those pre-commit project checks exercised hooks but failed on unrelated, pre-existing flake8/check-yaml issues in the repository (these failures are repository-wide and not caused by the env normalization change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b55175574832fac6b50b5cba6375e)