### PR TITLE
Add Sugarkube HA outage record and remove default raw-IP TLS SAN coupling

### DIFF
--- a/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json
+++ b/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json
@@ -1,0 +1,19 @@
+{
+  "id": "2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment",
+  "date": "2026-05-18",
+  "component": "k3s-discover",
+  "rootCause": "After a home power outage reassigned DHCP leases for sugarkube3/4/5, Sugarkube durable install/config paths still carried avoidable raw IPv4 identity coupling (for example raw-IP TLS SAN), leaving stale values after address churn.",
+  "resolution": "Rotated expired GHCR PAT, then fully rebuilt k3s HA staging across sugarkube3.local, sugarkube4.local, and sugarkube5.local; used positional env invocation (just up staging), removed malformed env=staging Avahi artifacts, restored Traefik/tunnel, and redeployed DSPACE via install path.",
+  "longForm": "outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md",
+  "references": [
+    "scripts/k3s-discover.sh",
+    "scripts/configure_k3s_node_ip.sh",
+    "tests/scripts/test_detect_node_ip.py",
+    "outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md"
+  ],
+  "affectedNodes": [
+    "sugarkube3.local",
+    "sugarkube4.local",
+    "sugarkube5.local"
+  ]
+}

--- a/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md
+++ b/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md
@@ -1,0 +1,86 @@
+# Sugarkube HA staging outage after DHCP IP reassignment (2026-05-18)
+
+## Summary
+On **2026-05-18**, Sugarkube staging HA control-plane availability degraded after a home power outage caused DHCP lease reassignment across all three staging control-plane nodes:
+
+- `sugarkube3.local`
+- `sugarkube4.local`
+- `sugarkube5.local`
+
+The incident exposed a Sugarkube defect: durable k3s bootstrap/join identity still carried avoidable raw LAN IP coupling (for example via `--tls-san <old-ip>`), which became stale after DHCP churn.
+
+## Impact
+- Embedded etcd quorum became unhealthy.
+- k3s remained in `activating (start)` on affected nodes.
+- Kubernetes API became unreachable for staging operations.
+- Staging deployment and operational workflows were blocked until full cluster rebuild.
+
+Observed etcd/k3s errors included:
+- `transport: authentication handshake failed: context deadline exceeded`
+- `failed to publish local member to cluster through raft`
+- `etcdserver: request timed out`
+
+## Timeline and incident journey
+1. GHCR Helm chart pull initially failed with `403 denied: denied` due to an expired classic GitHub PAT missing valid `read:packages` access.
+2. PAT was rotated and GHCR Helm auth was restored.
+3. Pull access verified with:
+   - `helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0`
+4. Despite chart access recovery, Kubernetes remained unavailable because the HA k3s control-plane was unhealthy.
+5. Since no state needed preservation, k3s was fully wiped and rebuilt across all HA servers (not a single-node fix):
+   - `sugarkube3.local`
+   - `sugarkube4.local`
+   - `sugarkube5.local`
+6. Cluster recovery used positional environment invocation as immediate mitigation:
+   - `just up staging`
+   - `just save-logs staging`
+7. Control-plane taints were removed (`just ha3-untaint-control-plane`).
+8. Traefik reinstall/verification completed.
+9. Cloudflare tunnel reinstall/verification completed.
+10. On fresh cluster, first attempt using OCI upgrade path failed as expected for no prior release:
+    - `UPGRADE FAILED: "dspace" has no deployed releases`
+11. Corrected to first-install path (`helm-oci-install`), then deployed DSPACE `v3.0.1-rc.5` to staging.
+12. Staging UI reflected expected deployed SHA/tag (example: `main-92a1bcb`).
+13. Production/apex intentionally remained on `v3.0.0`.
+
+## Additional nuance captured from Task 1
+A separate command-parsing issue increased recovery friction:
+
+- `just up env=staging` was parsed literally as environment `env=staging`.
+- This created malformed discovery state, including:
+  - `environment=env=staging`
+  - `service_type=_k3s-sugar-env=staging._tcp`
+  - `<txt-record>env=env=staging</txt-record>`
+  - `/etc/avahi/services/k3s-sugar-env=staging.service`
+
+Immediate workaround:
+- `just up staging`
+- `just save-logs staging`
+
+Cleanup required for malformed stale Avahi service files:
+- `sudo rm -f /etc/avahi/services/k3s-sugar-env=staging.service`
+- `sudo systemctl restart avahi-daemon`
+
+## Root cause
+Primary root cause is owned by Sugarkube internals:
+
+- Home power outage triggered DHCP reassignment for staging HA nodes.
+- Sugarkube installation/discovery behavior allowed durable k3s identity data to include stale raw LAN IPv4 values (for example `--tls-san 192.168.86.37`) that no longer matched node runtime address (for example node now on `192.168.86.40` on `eth0`).
+- Stable `.local` node names existed, but avoidable durable IP identity coupling remained in generated configuration and install flags.
+
+## Resolution
+- Recovered service by full HA cluster reinstall/rejoin on all three staging control-plane nodes.
+- Restored Helm/GHCR authentication by rotating expired PAT.
+- Reinstalled staging ingress/tunnel dependencies and redeployed application workload.
+
+## Prevention and follow-up direction
+Sugarkube prevention work (Task 2 scope):
+- Prefer stable host identity (`<hostname>.local` and short hostname) for durable TLS SAN and discovery/client endpoint identity.
+- Remove DHCP-derived raw IPv4 TLS SAN defaults.
+- Keep any required raw IP usage limited to runtime internals (`--node-ip`, `--advertise-address`, peer URLs), sourced deterministically from current interface state and regenerated safely.
+- Keep optional raw-IP SAN support opt-in only.
+- Add regression coverage so stale `192.168.x.x` durable SAN identity does not return as default.
+
+Related later tasks:
+- Task 3: `just cf-tunnel-install env=staging ...` parsing/tunnel naming hardening.
+- Task 4: fresh-cluster OCI install-vs-upgrade behavior.
+- Task 5/6: cross-repo operational documentation updates linking to this Sugarkube outage record.

--- a/scripts/k3s-discover.sh
+++ b/scripts/k3s-discover.sh
@@ -287,6 +287,7 @@ DISCOVERY_FAILOPEN_DEFAULT=0
 DISCOVERY_FAILOPEN_TIMEOUT_DEFAULT=300
 DISCOVERY_FAILOPEN="${SUGARKUBE_DISCOVERY_FAILOPEN:-${DISCOVERY_FAILOPEN_DEFAULT}}"
 DISCOVERY_FAILOPEN_TIMEOUT_SECS="${SUGARKUBE_DISCOVERY_FAILOPEN_TIMEOUT:-${DISCOVERY_FAILOPEN_TIMEOUT_DEFAULT}}"
+TLS_SAN_INCLUDE_NODE_IP="${SUGARKUBE_TLS_SAN_INCLUDE_NODE_IP:-0}"
 DISCOVERY_FAILOPEN_STARTED=0
 DISCOVERY_FAILOPEN_START_TIME=0
 DISCOVERY_FAILOPEN_USED=0
@@ -4192,7 +4193,7 @@ install_server_single() {
       --tls-san "${MDNS_HOST}"
       --tls-san "${HN}"
     )
-    if [ -n "${node_ip}" ]; then
+    if [ "${TLS_SAN_INCLUDE_NODE_IP}" = "1" ] && [ -n "${node_ip}" ]; then
       install_args+=(--tls-san "${node_ip}")
     fi
     install_args+=(
@@ -4275,7 +4276,7 @@ install_server_cluster_init() {
       --tls-san "${MDNS_HOST}"
       --tls-san "${HN}"
     )
-    if [ -n "${node_ip}" ]; then
+    if [ "${TLS_SAN_INCLUDE_NODE_IP}" = "1" ] && [ -n "${node_ip}" ]; then
       install_args+=(--tls-san "${node_ip}")
     fi
     install_args+=(
@@ -4485,10 +4486,10 @@ install_server_join() {
     log_info discover event=join outcome=fast_path host="${MDNS_HOST_RAW}" server="${server}" mode=fast >&2
     return 0
   fi
-  # Use IP address for server URL when available to avoid mDNS resolution issues in systemd context
-  # Keep hostname in TLS SANs for certificate verification
+  # Prefer stable hostname identity for durable join endpoints.
+  # SERVER_IP remains available for runtime checks and diagnostics.
   local server_url_target="${server}"
-  if [ -n "${ip_hint}" ]; then
+  if [ "${SUGARKUBE_SERVER_URL_PREFER_IP:-0}" = "1" ] && [ -n "${ip_hint}" ]; then
     server_url_target="${ip_hint}"
     log_info discover event=install_join server_url_type=ip server_url="${server_url_target}" hostname="${server}" >&2
   else
@@ -4521,7 +4522,7 @@ install_server_join() {
       --tls-san "${MDNS_HOST}"
       --tls-san "${HN}"
     )
-    if [ -n "${node_ip}" ]; then
+    if [ "${TLS_SAN_INCLUDE_NODE_IP}" = "1" ] && [ -n "${node_ip}" ]; then
       install_args+=(--tls-san "${node_ip}")
     fi
     install_args+=(

--- a/tests/scripts/test_k3s_tls_san_identity.py
+++ b/tests/scripts/test_k3s_tls_san_identity.py
@@ -1,0 +1,20 @@
+"""Regression coverage for durable TLS SAN identity defaults."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "k3s-discover.sh"
+
+
+def test_outage_regression_tls_san_raw_ip_not_default() -> None:
+    text = SCRIPT_PATH.read_text(encoding="utf-8")
+    assert 'TLS_SAN_INCLUDE_NODE_IP="${SUGARKUBE_TLS_SAN_INCLUDE_NODE_IP:-0}"' in text
+    assert 'install_args+=(--tls-san "${node_ip}")' in text
+    assert '[ "${TLS_SAN_INCLUDE_NODE_IP}" = "1" ]' in text
+
+
+def test_outage_regression_join_prefers_hostname_server_url() -> None:
+    text = SCRIPT_PATH.read_text(encoding="utf-8")
+    assert 'local server_url_target="${server}"' in text
+    assert 'SUGARKUBE_SERVER_URL_PREFER_IP:-0' in text


### PR DESCRIPTION
### Motivation
- Record the 2026-05-18 HA staging outage in the Sugarkube repo and make Sugarkube the owner of the root-cause and prevention narrative. 
- Prevent future outages where DHCP churn causes stale durable raw-IP identity (for example `--tls-san 192.168.x.x`) to be baked into k3s installs.
- Prefer stable `.local` hostname identity for durable TLS SANs and discovery endpoints while keeping raw-IP usage explicit and opt-in.

### Description
- Added outage report files `outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md` and `outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json` capturing the full incident journey, Task 1 `env=staging` parsing nuance, recovery steps, and prevention guidance. 
- Changed `scripts/k3s-discover.sh` to make inclusion of the node IPv4 in TLS SANs opt-in by introducing `SUGARKUBE_TLS_SAN_INCLUDE_NODE_IP` (default `0`), and to prefer hostname-based join URLs by default with `SUGARKUBE_SERVER_URL_PREFER_IP=1` as an opt-in for IP-first join. 
- Ensured `SERVER_IP` remains populated for runtime diagnostics while durable install flags default to hostname identity. 
- Added a focused regression test `tests/scripts/test_k3s_tls_san_identity.py` that asserts the new opt-in gates and hostname-first join behavior are present in the script.

### Testing
- Validated outage JSON syntactically with `python -m json.tool outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json` which succeeded. 
- Ran targeted tests: `pytest tests/scripts/test_detect_node_ip.py tests/scripts/test_k3s_discover_node_ip_binding.py tests/scripts/test_k3s_tls_san_identity.py` which passed (`8 passed`). 
- Ran the repository secret scan (`git diff --cached | ./scripts/scan-secrets.py`) which completed without flagging credentials; `shellcheck` and `pre-commit` were not available in the execution environment so those checks were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b6aa61cb8832f99fbc27963c65a20)