### PR TITLE
🛠️ fix: decouple durable k3s identity from DHCP SAN defaults and add outage record

### DIFF
--- a/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json
+++ b/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json
@@ -1,0 +1,19 @@
+{
+  "id": "2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment",
+  "date": "2026-05-18",
+  "component": "k3s-discover / HA staging control-plane",
+  "longForm": "outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md",
+  "rootCause": "Durable k3s install/discovery identity included DHCP-derived raw LAN IP context (for example raw IP TLS SANs) rather than defaulting to stable hostname-based identity, so post-outage lease churn left stale address coupling.",
+  "resolution": "Rotated expired GHCR PAT, then fully rebuilt the three-node HA staging control plane (sugarkube3/4/5.local) using positional environment commands, repaired malformed Avahi artifacts from env=staging parsing, reinstalled ingress/tunnel components, and redeployed staging via initial helm OCI install path.",
+  "references": [
+    "outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md",
+    "scripts/k3s-discover.sh",
+    "justfile"
+  ],
+  "dateRanges": [
+    {
+      "start": "2026-05-18",
+      "end": "2026-05-18"
+    }
+  ]
+}

--- a/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md
+++ b/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md
@@ -1,0 +1,61 @@
+# Sugarkube outage: HA staging control-plane failure after DHCP IP reassignment
+
+- **Date:** 2026-05-18 (UTC)
+- **Owner:** Sugarkube
+- **Component:** k3s HA staging control-plane discovery/install path
+- **Impact:** Staging control plane became unhealthy; Kubernetes API unavailable until cluster rebuild.
+
+## Summary
+A home power outage caused DHCP lease reassignment for `sugarkube3.local`, `sugarkube4.local`, and `sugarkube5.local`.
+Sugarkube still persisted raw LAN IPs into durable k3s server install arguments (notably TLS SANs), so rebuilt/runtime assumptions diverged from stable `.local` identities. Once addresses changed, etcd/k3s stability degraded and the HA staging cluster could not recover in-place.
+
+## What happened
+1. Power returned and nodes came back with new LAN addresses.
+2. Existing durable k3s state still referenced prior DHCP IP context (example: `--tls-san 192.168.86.37` persisted while host later owned `192.168.86.40` on `eth0`).
+3. k3s stalled in `activating (start)` and etcd emitted:
+   - `transport: authentication handshake failed: context deadline exceeded`
+   - `failed to publish local member to cluster through raft`
+   - `etcdserver: request timed out`
+4. During recovery, GHCR chart pull initially failed (`403 denied: denied`) because a GitHub classic PAT with `read:packages` had expired.
+5. After PAT rotation, GHCR access worked again (`helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0`), but Kubernetes remained unreachable because control-plane health was still broken.
+
+## Additional nuance discovered during recovery
+A separate argument-parsing bug amplified confusion in staging runs:
+
+- `just up env=staging` was parsed literally as `env=staging`.
+- This produced malformed discovery state:
+  - `environment=env=staging`
+  - `service_type=_k3s-sugar-env=staging._tcp`
+  - `<txt-record>env=env=staging</txt-record>`
+  - `/etc/avahi/services/k3s-sugar-env=staging.service`
+- Immediate workaround:
+  - `just up staging`
+  - `just save-logs staging`
+- Required cleanup:
+  - `sudo rm -f /etc/avahi/services/k3s-sugar-env=staging.service`
+  - `sudo systemctl restart avahi-daemon`
+
+## Recovery actions
+1. Rotated GitHub PAT and restored GHCR auth.
+2. Verified chart pull path independently of cluster health.
+3. Confirmed control plane was unhealthy and state preservation was unnecessary.
+4. Uninstalled/wiped/rebuilt **all three HA servers**, not just one:
+   - `sugarkube3.local`
+   - `sugarkube4.local`
+   - `sugarkube5.local`
+5. Rebuilt using positional environment invocations.
+6. Removed control-plane taints: `just ha3-untaint-control-plane`.
+7. Reinstalled/verified Traefik.
+8. Reinstalled/verified Cloudflare tunnel.
+9. On fresh cluster, `helm-oci-upgrade` failed with `UPGRADE FAILED: "dspace" has no deployed releases`; first deployment correctly used `helm-oci-install`.
+10. Deployed DSPACE `v3.0.1-rc.5` to staging and verified expected staged SHA/tag (`main-92a1bcb`).
+11. Left prod/apex intentionally pinned at `v3.0.0`.
+
+## Root cause
+Sugarkube conflated stable node identity with ephemeral network addressing by persisting DHCP-derived raw LAN IPs in durable k3s install/config surfaces where hostname-based identity (`<host>.local`, short hostname) should be default.
+
+## Prevention and follow-up
+- Sugarkube should treat hostname identity as durable default for TLS SANs/discovery endpoints.
+- DHCP-derived raw IPv4 SANs must be opt-in only.
+- Any required raw IP for runtime internals (`--node-ip`, `--advertise-address`, peer transport) must be deterministic, current, and regenerated at install/rebuild time.
+- Keep Task 1 (`just up env=staging` parity) tracked separately and avoid named-form invocation until fixed.

--- a/scripts/k3s-discover.sh
+++ b/scripts/k3s-discover.sh
@@ -3893,6 +3893,16 @@ resolve_server_ip_hint() {
   return 1
 }
 
+
+should_include_node_ip_tls_san() {
+  # Stable node identity should remain hostname-based by default.
+  # Opt-in is available for environments that explicitly require IPv4 SANs.
+  case "${SUGARKUBE_INCLUDE_NODE_IP_TLS_SAN:-0}" in
+    1|true|TRUE|yes|YES|on|ON) return 0 ;;&
+    *) return 1 ;;&
+  esac
+}
+
 detect_node_primary_ipv4() {
   # Detect the primary IPv4 address of this node on the primary interface
   # Used for adding IP address to TLS SANs during k3s installation
@@ -4172,12 +4182,13 @@ install_server_single() {
   ensure_iptables_tools
   log_info discover phase=install_single cluster="${CLUSTER}" environment="${ENVIRONMENT}" host="${MDNS_HOST_RAW}" datastore=sqlite >&2
 
-  # Detect node IP for TLS SAN
   local node_ip=""
-  if node_ip="$(detect_node_primary_ipv4)"; then
-    log_info discover event=node_ip_detected ip="${node_ip}" phase=install_single >&2
-  else
-    log_warn_msg discover "Failed to detect node IP; TLS certificate will not include IP address" phase=install_single
+  if should_include_node_ip_tls_san; then
+    if node_ip="$(detect_node_primary_ipv4)"; then
+      log_info discover event=node_ip_detected ip="${node_ip}" phase=install_single >&2
+    else
+      log_warn_msg discover "Failed to detect node IP for opt-in TLS SAN" phase=install_single
+    fi
   fi
 
   local env_assignments
@@ -4254,12 +4265,13 @@ install_server_cluster_init() {
   ensure_iptables_tools
   log_info discover phase=install_cluster_init cluster="${CLUSTER}" environment="${ENVIRONMENT}" host="${MDNS_HOST_RAW}" datastore=etcd >&2
 
-  # Detect node IP for TLS SAN
   local node_ip=""
-  if node_ip="$(detect_node_primary_ipv4)"; then
-    log_info discover event=node_ip_detected ip="${node_ip}" phase=install_cluster_init >&2
-  else
-    log_warn_msg discover "Failed to detect node IP; TLS certificate will not include IP address" phase=install_cluster_init
+  if should_include_node_ip_tls_san; then
+    if node_ip="$(detect_node_primary_ipv4)"; then
+      log_info discover event=node_ip_detected ip="${node_ip}" phase=install_cluster_init >&2
+    else
+      log_warn_msg discover "Failed to detect node IP for opt-in TLS SAN" phase=install_cluster_init
+    fi
   fi
 
   local env_assignments
@@ -4495,12 +4507,13 @@ install_server_join() {
     log_info discover event=install_join server_url_type=hostname server_url="${server_url_target}" >&2
   fi
 
-  # Detect node IP for TLS SAN
   local node_ip=""
-  if node_ip="$(detect_node_primary_ipv4)"; then
-    log_info discover event=node_ip_detected ip="${node_ip}" phase=install_join >&2
-  else
-    log_warn_msg discover "Failed to detect node IP; TLS certificate will not include IP address" phase=install_join
+  if should_include_node_ip_tls_san; then
+    if node_ip="$(detect_node_primary_ipv4)"; then
+      log_info discover event=node_ip_detected ip="${node_ip}" phase=install_join >&2
+    else
+      log_warn_msg discover "Failed to detect node IP for opt-in TLS SAN" phase=install_join
+    fi
   fi
 
   local env_assignments

--- a/tests/scripts/test_k3s_tls_san_identity_defaults.py
+++ b/tests/scripts/test_k3s_tls_san_identity_defaults.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "k3s-discover.sh"
+
+
+def test_node_ip_tls_san_is_opt_in_by_default() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "SUGARKUBE_INCLUDE_NODE_IP_TLS_SAN:-0" in text
+
+
+def test_hostname_tls_sans_remain_default_identity() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert '--tls-san "${MDNS_HOST}"' in text
+    assert '--tls-san "${HN}"' in text
+
+
+def test_install_paths_gate_ipv4_tls_san_with_opt_in_helper() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "should_include_node_ip_tls_san" in text
+    assert text.count("if should_include_node_ip_tls_san;") >= 3


### PR DESCRIPTION
### Motivation
- Move the HA-staging outage source-of-truth into Sugarkube and preserve the full incident journey including the `just up env=staging` parsing fallout and Avahi cleanup steps. 
- Prevent future outages where DHCP churn leaves stale raw LAN IPs baked into durable k3s identity surfaces (notably TLS SANs). 
- Make stable hostname-based identity the default while allowing intentionally-scoped raw-IP usage at install/runtime.

### Description
- Add Sugarkube outage artifacts `outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md` and `outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json` that mirror the DSPACE entry but mark Sugarkube as owner and include the Task 1 `env=staging` nuance. 
- Introduce `should_include_node_ip_tls_san()` and gate IPv4 TLS SAN insertion behind the opt-in environment variable `SUGARKUBE_INCLUDE_NODE_IP_TLS_SAN` (default `0`) in `scripts/k3s-discover.sh`, applied to `install_server_single`, `install_server_cluster_init`, and `install_server_join`. 
- Preserve default inclusion of hostname SANs (`${MDNS_HOST}` and `${HN}`) and retain deterministic IP selection via the existing `detect_node_primary_ipv4()` logic when opted in. 
- Add focused regression tests `tests/scripts/test_k3s_tls_san_identity_defaults.py` to assert the opt-in gating and default hostname SAN behavior and keep existing node-IP detection tests.

### Testing
- Validated the outage JSON with `python -m json.tool outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json`, which succeeded. 
- Ran `pytest -q tests/scripts/test_k3s_tls_san_identity_defaults.py tests/scripts/test_detect_node_ip.py`, and the test suite passed (`8 passed`). 
- Ran the repository secret scan `git diff --cached | ./scripts/scan-secrets.py` with no findings. 
- Attempted `shellcheck scripts/k3s-discover.sh`, but `shellcheck` was not installed in the execution environment so it was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b6aa61cb8832f99fbc27963c65a20)