### PR TITLE
Add outage record and make node-IP TLS SAN opt-in to avoid durable DHCP-IP coupling

### DIFF
--- a/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json
+++ b/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json
@@ -1,0 +1,14 @@
+{
+  "id": "2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment",
+  "date": "2026-05-18",
+  "component": "sugarkube k3s HA install/discovery",
+  "longForm": "outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md",
+  "rootCause": "A power outage triggered DHCP reassignment for sugarkube3/4/5, exposing that Sugarkube persisted raw LAN IPs into durable k3s identity inputs (including TLS SAN-related install args) instead of primarily using stable .local hostnames. A separate operator hazard (`just up env=staging` parsed literally) also generated malformed Avahi discovery state that had to be cleaned up.",
+  "resolution": "Rotated expired GHCR PAT, validated chart pull, then wiped/rebuilt k3s across all three HA servers using positional env invocation (`just up staging`). Removed stale malformed Avahi service file and restarted avahi-daemon, untainted control-plane nodes, and restored Traefik + Cloudflare tunnel. Updated Sugarkube internals so hostname-based TLS SAN identity is default and raw node IP TLS SAN is opt-in only, reducing stale DHCP-IP coupling.",
+  "references": [
+    "democratizedspace/dspace outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md",
+    "democratizedspace/dspace outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json",
+    "scripts/k3s-discover.sh",
+    "scripts/configure_k3s_node_ip.sh"
+  ]
+}

--- a/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md
+++ b/outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md
@@ -1,0 +1,59 @@
+# Sugarkube HA staging outage: DHCP IP reassignment and stale durable IP coupling
+
+- **Date:** 2026-05-18
+- **Scope:** Sugarkube HA staging cluster (`sugarkube3.local`, `sugarkube4.local`, `sugarkube5.local`)
+- **Impact:** staging control plane unhealthy; DSPACE staging unavailable until cluster rebuild and redeploy
+
+## Summary
+A home power outage caused DHCP to reassign LAN IPs for all three HA staging control-plane nodes. Sugarkube automation had persisted raw LAN IP values into durable k3s identity/config paths (including TLS SAN inputs) where stable hostname identity (`<host>.local`) should have been preferred. After DHCP churn, k3s and embedded etcd could not converge cleanly, leaving control-plane services stuck and Kubernetes unavailable.
+
+A second, parallel operator hazard also surfaced: `just up env=staging` was parsed literally as `env=staging` (not as named argument syntax), generating malformed discovery state and stale Avahi service files that required manual cleanup before stable discovery resumed.
+
+## Detection and symptoms
+- `k3s` on HA nodes stuck in `activating (start)`.
+- embedded etcd emitted repeated errors, including:
+  - `transport: authentication handshake failed: context deadline exceeded`
+  - `failed to publish local member to cluster through raft`
+  - `etcdserver: request timed out`
+- one installed node had stale raw-IP SAN input like `--tls-san 192.168.86.37` while current `eth0` was e.g. `192.168.86.40`.
+
+## Contributing issue: named-env parsing footgun
+`just up env=staging` was treated as a positional literal string instead of named argument semantics, causing malformed discovery values such as:
+- `environment=env=staging`
+- `service_type=_k3s-sugar-env=staging._tcp`
+- `<txt-record>env=env=staging</txt-record>`
+- `/etc/avahi/services/k3s-sugar-env=staging.service`
+
+Immediate workaround used during recovery:
+- `just up staging`
+- `just save-logs staging`
+
+Required cleanup for stale malformed Avahi service file:
+- `sudo rm -f /etc/avahi/services/k3s-sugar-env=staging.service`
+- `sudo systemctl restart avahi-daemon`
+
+## Recovery journey
+1. GHCR chart pull initially failed with `403 denied: denied` due to expired GitHub classic PAT (`read:packages`).
+2. PAT rotated; GHCR login restored.
+3. Chart access confirmed with:
+   - `helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0`
+4. Kubernetes still unreachable because k3s control plane remained unhealthy.
+5. Since state preservation was unnecessary, k3s was wiped and rebuilt across **all three** HA servers (not single-node repair):
+   - `sugarkube3.local`, `sugarkube4.local`, `sugarkube5.local`
+6. Rebuild used positional env invocation (`just up staging`).
+7. Post-rebuild operations:
+   - `just ha3-untaint-control-plane`
+   - Traefik reinstall/verification
+   - Cloudflare tunnel reinstall/verification
+8. Fresh-cluster Helm nuance observed: `helm-oci-upgrade` failed with `UPGRADE FAILED: "dspace" has no deployed releases`; first path required `helm-oci-install`.
+9. DSPACE `v3.0.1-rc.5` deployed successfully to staging; staging UI showed expected SHA/tag (e.g. `main-92a1bcb`).
+10. Prod/apex intentionally remained on `v3.0.0`.
+
+## Root cause
+Sugarkube used DHCP-derived raw IPv4 values as part of durable cluster identity/certificate configuration where stable hostname identity should be primary. This made recovery sensitive to routine LAN address churn after power events.
+
+## Prevention and corrective action in Sugarkube
+- Default durable TLS SAN identity now uses hostname forms (`<hostname>.local` and short hostname) rather than raw LAN DHCP IPs.
+- Raw node IP SAN support is retained only as explicit opt-in (`SUGARKUBE_TLS_SAN_INCLUDE_NODE_IP=1`) for deployments that require it.
+- Discovery and operator-facing endpoints continue to prefer `.local` identities.
+- Runtime node networking IP selection remains interface-based/deterministic where needed, but is not treated as durable identity.

--- a/scripts/k3s-discover.sh
+++ b/scripts/k3s-discover.sh
@@ -3893,6 +3893,8 @@ resolve_server_ip_hint() {
   return 1
 }
 
+TLS_SAN_INCLUDE_NODE_IP="${SUGARKUBE_TLS_SAN_INCLUDE_NODE_IP:-0}"
+
 detect_node_primary_ipv4() {
   # Detect the primary IPv4 address of this node on the primary interface
   # Used for adding IP address to TLS SANs during k3s installation
@@ -4172,14 +4174,6 @@ install_server_single() {
   ensure_iptables_tools
   log_info discover phase=install_single cluster="${CLUSTER}" environment="${ENVIRONMENT}" host="${MDNS_HOST_RAW}" datastore=sqlite >&2
 
-  # Detect node IP for TLS SAN
-  local node_ip=""
-  if node_ip="$(detect_node_primary_ipv4)"; then
-    log_info discover event=node_ip_detected ip="${node_ip}" phase=install_single >&2
-  else
-    log_warn_msg discover "Failed to detect node IP; TLS certificate will not include IP address" phase=install_single
-  fi
-
   local env_assignments
   build_install_env env_assignments
   (
@@ -4192,8 +4186,14 @@ install_server_single() {
       --tls-san "${MDNS_HOST}"
       --tls-san "${HN}"
     )
-    if [ -n "${node_ip}" ]; then
-      install_args+=(--tls-san "${node_ip}")
+    if [ "${TLS_SAN_INCLUDE_NODE_IP}" = "1" ]; then
+      local node_ip=""
+      if node_ip="$(detect_node_primary_ipv4)"; then
+        install_args+=(--tls-san "${node_ip}")
+        log_info discover event=node_ip_tls_san_opt_in ip="${node_ip}" phase=install_single >&2
+      else
+        log_warn_msg discover "Opt-in node IP TLS SAN requested but IPv4 detection failed" phase=install_single
+      fi
     fi
     install_args+=(
       --kubelet-arg "node-labels=sugarkube.cluster=${CLUSTER},sugarkube.env=${ENVIRONMENT}"
@@ -4254,14 +4254,6 @@ install_server_cluster_init() {
   ensure_iptables_tools
   log_info discover phase=install_cluster_init cluster="${CLUSTER}" environment="${ENVIRONMENT}" host="${MDNS_HOST_RAW}" datastore=etcd >&2
 
-  # Detect node IP for TLS SAN
-  local node_ip=""
-  if node_ip="$(detect_node_primary_ipv4)"; then
-    log_info discover event=node_ip_detected ip="${node_ip}" phase=install_cluster_init >&2
-  else
-    log_warn_msg discover "Failed to detect node IP; TLS certificate will not include IP address" phase=install_cluster_init
-  fi
-
   local env_assignments
   build_install_env env_assignments
   (
@@ -4275,8 +4267,14 @@ install_server_cluster_init() {
       --tls-san "${MDNS_HOST}"
       --tls-san "${HN}"
     )
-    if [ -n "${node_ip}" ]; then
-      install_args+=(--tls-san "${node_ip}")
+    if [ "${TLS_SAN_INCLUDE_NODE_IP}" = "1" ]; then
+      local node_ip=""
+      if node_ip="$(detect_node_primary_ipv4)"; then
+        install_args+=(--tls-san "${node_ip}")
+        log_info discover event=node_ip_tls_san_opt_in ip="${node_ip}" phase=install_cluster_init >&2
+      else
+        log_warn_msg discover "Opt-in node IP TLS SAN requested but IPv4 detection failed" phase=install_cluster_init
+      fi
     fi
     install_args+=(
       --kubelet-arg "node-labels=sugarkube.cluster=${CLUSTER},sugarkube.env=${ENVIRONMENT}"
@@ -4495,14 +4493,6 @@ install_server_join() {
     log_info discover event=install_join server_url_type=hostname server_url="${server_url_target}" >&2
   fi
 
-  # Detect node IP for TLS SAN
-  local node_ip=""
-  if node_ip="$(detect_node_primary_ipv4)"; then
-    log_info discover event=node_ip_detected ip="${node_ip}" phase=install_join >&2
-  else
-    log_warn_msg discover "Failed to detect node IP; TLS certificate will not include IP address" phase=install_join
-  fi
-
   local env_assignments
   build_install_env env_assignments
   env_assignments+=("K3S_URL=https://${server_url_target}:${selected_port}")
@@ -4521,8 +4511,14 @@ install_server_join() {
       --tls-san "${MDNS_HOST}"
       --tls-san "${HN}"
     )
-    if [ -n "${node_ip}" ]; then
-      install_args+=(--tls-san "${node_ip}")
+    if [ "${TLS_SAN_INCLUDE_NODE_IP}" = "1" ]; then
+      local node_ip=""
+      if node_ip="$(detect_node_primary_ipv4)"; then
+        install_args+=(--tls-san "${node_ip}")
+        log_info discover event=node_ip_tls_san_opt_in ip="${node_ip}" phase=install_join >&2
+      else
+        log_warn_msg discover "Opt-in node IP TLS SAN requested but IPv4 detection failed" phase=install_join
+      fi
     fi
     install_args+=(
       --kubelet-arg "node-labels=sugarkube.cluster=${CLUSTER},sugarkube.env=${ENVIRONMENT}"


### PR DESCRIPTION
### Motivation
- Move the HA staging outage record into the Sugarkube repo and capture the full incident journey and the `just up env=staging` named-env parsing nuance and workaround. 
- Eliminate avoidable durable coupling to DHCP-assigned LAN IPs by making raw node-IP inclusion in TLS SANs opt-in and preferring stable hostnames (`.local`) as durable identity.

### Description
- Add outage artifacts `outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md` and `outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json` that preserve the DSPACE incident narrative and operator cleanup notes. 
- Modify `scripts/k3s-discover.sh` to introduce `SUGARKUBE_TLS_SAN_INCLUDE_NODE_IP` (default `0`) so raw node IPv4 addresses are no longer added to `--tls-san` by default. 
- Keep hostname-based TLS SANs (`${MDNS_HOST}` and `${HN}`) in all server/install flows and only add a detected interface IP when `SUGARKUBE_TLS_SAN_INCLUDE_NODE_IP=1`. 
- Preserve existing `detect_node_primary_ipv4()` behavior and deterministic interface selection, and log when opt-in IP SANs are used or when detection fails.

### Testing
- Validated the outage JSON with `python -m json.tool outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json` which succeeded. 
- Ran targeted unit tests with `pytest -q tests/test_publish_api_service.py tests/test_avahi_service_file.py` and both tests passed. 
- Ran the repository secret-scan on the staged diff via `git diff --cached | ./scripts/scan-secrets.py` which produced no findings. 
- Attempted `shellcheck scripts/k3s-discover.sh scripts/configure_k3s_node_ip.sh` but `shellcheck` is not available in the execution environment so linting should be run in CI or locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b6aa61cb8832f99fbc27963c65a20)