### PR TITLE
🧪 Fix cf-tunnel named env parity regression coverage

### DIFF
--- a/tests/test_cloudflare_tunnel_token_mode.py
+++ b/tests/test_cloudflare_tunnel_token_mode.py
@@ -313,3 +313,13 @@ def test_debug_recipe_surfaces_origin_cert_guidance(origin_cert_guidance_text: s
     assert "origin_cert_guidance" in debug_body
     assert "behaving like a locally-managed tunnel" in origin_cert_guidance_text
     assert 'config_src="cloudflare"' in origin_cert_guidance_text
+
+
+def test_cf_tunnel_install_uses_normalized_env_for_tunnel_name(cf_recipe_body: str) -> None:
+    # Regression for outage recovery path in
+    # outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md:
+    # `just cf-tunnel-install env=staging ...` must not produce `sugarkube-env=staging`.
+    assert '"  tunnelName: \\"${CF_TUNNEL_NAME:-sugarkube-${env_name}}\\""' in cf_recipe_body
+    assert '"- Tunnel name: ${CF_TUNNEL_NAME:-sugarkube-${env_name}}"' in cf_recipe_body
+    assert "sugarkube-${env_input}" not in cf_recipe_body
+    assert "sugarkube-env=staging" not in cf_recipe_body


### PR DESCRIPTION
### Motivation
- Prevent regressions where `just cf-tunnel-install env=staging ...` could propagate the literal `env=staging` into tunnel names (observed during the 2026-05-18 HA staging DHCP/IP reassignment outage: `outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md`).

### Description
- Add a focused regression assertion in `tests/test_cloudflare_tunnel_token_mode.py` that verifies the `cf-tunnel-install` recipe references the normalized `${env_name}` for `tunnelName` and printed verification output and that no literal `sugarkube-env=staging` form exists.

### Testing
- Ran `pytest tests/test_cloudflare_tunnel_token_mode.py tests/test_up_recipe_calls.py` which passed (`27 passed` for the targeted runs).
- Ran repository checks: `rg` assertions for leftover literal patterns and `git diff --cached | ./scripts/scan-secrets.py` passed; `shellcheck` was unavailable in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d557fa9ec832fa9f9fcf626827792)