### PR TITLE
tests: add regression coverage for cf-tunnel-install env=... normalization

### DIFF
--- a/tests/test_cloudflare_tunnel_token_mode.py
+++ b/tests/test_cloudflare_tunnel_token_mode.py
@@ -254,6 +254,19 @@ def test_deployment_patch_does_not_reference_credentials_file(deployment_patch_o
     assert "cloudflare-tunnel-config" not in patch_text
 
 
+
+
+def test_cf_tunnel_install_normalizes_named_env_inputs(cf_recipe_body: str) -> None:
+    """Regression: outage recovery used ``env=staging`` and must resolve to ``staging``."""
+
+    assert 'env_input={{ quote(env) }}' in cf_recipe_body
+    assert 'while [ "${env_name#env=}" != "${env_name}" ]; do' in cf_recipe_body
+    assert 'env_name="${env_name#env=}"' in cf_recipe_body
+    assert 'tunnelName:' in cf_recipe_body
+    assert '${CF_TUNNEL_NAME:-sugarkube-${env_name}}' in cf_recipe_body
+    assert '${CF_TUNNEL_NAME:-sugarkube-${env_input}}' not in cf_recipe_body
+    assert 'sugarkube-env=staging' not in cf_recipe_body
+
 def test_cloudflare_tunnel_docs_call_out_token_mode() -> None:
     text = CLOUDFLARE_DOC.read_text(encoding="utf-8")
     for phrase in (


### PR DESCRIPTION
### Motivation
- Add a focused regression test so `just cf-tunnel-install env=staging` normalizes to `staging` and does not propagate the literal `env=staging` string, addressing the outage documented in `outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md` where named-arg parsing produced malformed tunnel and discovery names.

### Description
- Add `test_cf_tunnel_install_normalizes_named_env_inputs` to `tests/test_cloudflare_tunnel_token_mode.py` that asserts the `cf-tunnel-install` recipe contains the env-normalization loop, uses `${env_name}` for the default `CF_TUNNEL_NAME`, and does not contain `${env_input}`-derived or `sugarkube-env=staging` literals.

### Testing
- Ran `pytest tests/test_cloudflare_tunnel_token_mode.py` which passed, ran the full `pytest` suite which passed (1168 passed, 43 skipped), attempted `shellcheck` (not installed in this environment), and ran `rg`/`./scripts/scan-secrets.py` checks which found no secrets or remaining literal `env_input` tunnel-name patterns.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d557fa9ec832fa9f9fcf626827792)