### PR TITLE
🐛 Fix cf-tunnel-install named env parity regression coverage

### DIFF
--- a/tests/scripts/test_k3s_discover_tls_san_policy.py
+++ b/tests/scripts/test_k3s_discover_tls_san_policy.py
@@ -288,6 +288,9 @@ def _run_remote_tls_san_check(
                 if [ "${exit_code}" != "0" ]; then
                   exit "${exit_code}"
                 fi
+                if [ ! -t 0 ]; then
+                  cat >/dev/null
+                fi
                 printf '%s\n' "${SUGARKUBE_TEST_SAN_OUTPUT}"
                 ;;
               *)

--- a/tests/test_cloudflare_tunnel_token_mode.py
+++ b/tests/test_cloudflare_tunnel_token_mode.py
@@ -188,7 +188,13 @@ def _run_cf_tunnel_install_recipe(env: str) -> subprocess.CompletedProcess[str]:
                 sed 's/^/HELM_STDIN:/' <&0
             fi
         }
-        kubectl() { printf 'KUBECTL:%s\n' "$*"; return 0; }
+        kubectl() {
+            printf 'KUBECTL:%s\n' "$*"
+            if [ ! -t 0 ]; then
+                sed 's/^/KUBECTL_STDIN:/' <&0 >/dev/null
+            fi
+            return 0
+        }
 
         """
     ) + rendered_body + "\n"

--- a/tests/test_cloudflare_tunnel_token_mode.py
+++ b/tests/test_cloudflare_tunnel_token_mode.py
@@ -175,6 +175,34 @@ def test_cf_tunnel_install_shell_syntax_is_valid(cf_recipe_body: str) -> None:
         Path(path).unlink(missing_ok=True)
 
 
+def _run_cf_tunnel_install_recipe(env: str) -> subprocess.CompletedProcess[str]:
+    rendered_body = _extract_cf_recipe_body().replace("{{ quote(env) }}", json.dumps(env))
+    script = textwrap.dedent(
+        """#!/usr/bin/env bash
+        set -euo pipefail
+
+        export CF_TUNNEL_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature
+        helm() {
+            printf 'HELM:%s\n' "$*"
+            if [ ! -t 0 ]; then
+                sed 's/^/HELM_STDIN:/' <&0
+            fi
+        }
+        kubectl() { printf 'KUBECTL:%s\n' "$*"; return 0; }
+
+        """
+    ) + rendered_body + "\n"
+
+    with tempfile.NamedTemporaryFile("w", delete=False) as f:
+        f.write(script)
+        path = f.name
+
+    try:
+        return subprocess.run(["bash", path], capture_output=True, text=True)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
 def test_configmap_creation_removed_in_token_mode(cf_recipe_body: str) -> None:
     assert "configmap_yaml" not in cf_recipe_body
     assert "kind: ConfigMap" not in cf_recipe_body
@@ -283,11 +311,33 @@ def test_cf_tunnel_install_normalizes_named_env_arguments(cf_recipe_body: str) -
     # was propagated literally into the tunnel name (`sugarkube-env=staging`).
     assert "env_input={{ quote(env) }}" in cf_recipe_body
     assert 'while [ "${env_name#env=}" != "${env_name}" ]; do' in cf_recipe_body
+    assert 'env_name="${env_name#env=}"' in cf_recipe_body
     assert 'if [ "${env_name}" = "int" ]; then' in cf_recipe_body
-    assert '"  tunnelName: \\"${CF_TUNNEL_NAME:-sugarkube-${env_name}}\\""' in cf_recipe_body
-    assert '"- Tunnel name: ${CF_TUNNEL_NAME:-sugarkube-${env_name}}"' in cf_recipe_body
-    assert "sugarkube-${env_input}" not in cf_recipe_body
-    assert "sugarkube-env=staging" not in cf_recipe_body
+    assert 'env_name="staging"' in cf_recipe_body
+
+    runtime_cases = {
+        "env=staging": "staging",
+        "env=env=staging": "staging",
+        "int": "staging",
+    }
+
+    for supplied_env, normalized_env in runtime_cases.items():
+        result = _run_cf_tunnel_install_recipe(supplied_env)
+        assert result.returncode == 0, result.stderr
+
+        combined_output = result.stdout + result.stderr
+        assert re.search(
+            r"HELM:upgrade --install cloudflare-tunnel cloudflare/cloudflare-tunnel .* --values -",
+            result.stdout,
+        )
+        assert f'HELM_STDIN:  tunnelName: "sugarkube-{normalized_env}"' in combined_output
+        assert f"- Tunnel name: sugarkube-{normalized_env}" in combined_output
+        assert "sugarkube-env=staging" not in combined_output
+        assert "sugarkube-env=env=staging" not in combined_output
+
+    alias_result = _run_cf_tunnel_install_recipe("int")
+    assert alias_result.returncode == 0, alias_result.stderr
+    assert 'WARNING: env name "int" is deprecated; using env=staging.' in alias_result.stderr
 
 
 def test_cf_tunnel_install_flags_origin_cert_logs(cf_recipe_body: str, origin_cert_guidance_text: str) -> None:

--- a/tests/test_cloudflare_tunnel_token_mode.py
+++ b/tests/test_cloudflare_tunnel_token_mode.py
@@ -316,6 +316,7 @@ def test_cf_tunnel_install_normalizes_named_env_arguments(cf_recipe_body: str) -
     assert 'env_name="staging"' in cf_recipe_body
 
     runtime_cases = {
+        "staging": "staging",
         "env=staging": "staging",
         "env=env=staging": "staging",
         "int": "staging",

--- a/tests/test_cloudflare_tunnel_token_mode.py
+++ b/tests/test_cloudflare_tunnel_token_mode.py
@@ -278,6 +278,18 @@ def test_cf_tunnel_install_validates_token_shape(cf_recipe_body: str) -> None:
     assert "does not look like a JWT" in cf_recipe_body
 
 
+def test_cf_tunnel_install_normalizes_named_env_arguments(cf_recipe_body: str) -> None:
+    # Outage regression: during 2026-05-18 staging recovery, `env=staging`
+    # was propagated literally into the tunnel name (`sugarkube-env=staging`).
+    assert "env_input={{ quote(env) }}" in cf_recipe_body
+    assert 'while [ "${env_name#env=}" != "${env_name}" ]; do' in cf_recipe_body
+    assert 'if [ "${env_name}" = "int" ]; then' in cf_recipe_body
+    assert '"  tunnelName: \\"${CF_TUNNEL_NAME:-sugarkube-${env_name}}\\""' in cf_recipe_body
+    assert '"- Tunnel name: ${CF_TUNNEL_NAME:-sugarkube-${env_name}}"' in cf_recipe_body
+    assert "sugarkube-${env_input}" not in cf_recipe_body
+    assert "sugarkube-env=staging" not in cf_recipe_body
+
+
 def test_cf_tunnel_install_flags_origin_cert_logs(cf_recipe_body: str, origin_cert_guidance_text: str) -> None:
     assert "Cannot determine default origin certificate path" in cf_recipe_body
     assert "origin_cert_guidance" in cf_recipe_body


### PR DESCRIPTION
### Motivation
- Prevent the regression observed during the 2026-05-18 HA staging recovery where `just cf-tunnel-install env=staging ...` could propagate the literal `env=staging` into the Cloudflare tunnel name (see `outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md`).

### Description
- Add a focused regression test `test_cf_tunnel_install_normalizes_named_env_arguments` in `tests/test_cloudflare_tunnel_token_mode.py` that asserts the recipe strips `env=` prefixes, applies the `int -> staging` alias, and uses the normalized `env_name` for the chart `tunnelName` and printed verification output so no literal `env=staging` appears in tunnel names.

### Testing
- Ran `pytest tests/test_cloudflare_tunnel_token_mode.py` which passed (13 passed).
- Ran the full `pytest` suite which passed (1168 passed, 43 skipped). 
- Attempted `shellcheck` on scripts but the `shellcheck` binary was not available in this environment so it was not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d557fa9ec832fa9f9fcf626827792)