### PR TITLE
🩹 Add cf-tunnel-install named-env parity regression tests

### DIFF
--- a/tests/test_cloudflare_tunnel_token_mode.py
+++ b/tests/test_cloudflare_tunnel_token_mode.py
@@ -286,6 +286,27 @@ def test_cf_tunnel_install_flags_origin_cert_logs(cf_recipe_body: str, origin_ce
     assert "cloudflared tunnel --no-autoupdate run --token <TOKEN>" in origin_cert_guidance_text
 
 
+
+
+def test_cf_tunnel_install_normalizes_named_env_for_tunnel_name(cf_recipe_body: str) -> None:
+    assert 'while [ "${env_name#env=}" != "${env_name}" ]; do' in cf_recipe_body
+    assert 'env_name="${env_name#env=}"' in cf_recipe_body
+    assert 'if [ "${env_name}" = "int" ]; then' in cf_recipe_body
+    assert "tunnelName" in cf_recipe_body
+    assert "sugarkube-${env_name}" in cf_recipe_body
+    assert '"- Tunnel name: ${CF_TUNNEL_NAME:-sugarkube-${env_name}}"' in cf_recipe_body
+    assert 'sugarkube-env=staging' not in cf_recipe_body
+
+
+def test_cf_tunnel_install_keeps_outage_regression_context() -> None:
+    outage_text = (
+        REPO_ROOT
+        / "outages"
+        / "2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md"
+    ).read_text(encoding="utf-8")
+    assert "just up env=staging" in outage_text
+    assert "env=staging" in outage_text
+
 def test_reset_and_debug_recipes_exist_and_reset_is_safe() -> None:
     reset_body = _extract_recipe_body("cf-tunnel-reset")
     debug_body = _extract_recipe_body("cf-tunnel-debug")


### PR DESCRIPTION
### Motivation
- During HA staging outage recovery a named-arg invocation `just cf-tunnel-install env=staging` produced a literal `env=staging` token in downstream naming, so we need regression coverage to prevent reintroduction of that parsing pitfall.

### Description
- Add a focused regression test in `tests/test_cloudflare_tunnel_token_mode.py` that asserts the `cf-tunnel-install` recipe normalizes named `env` inputs (stripping repeated `env=` prefixes) and uses the normalized `env_name` for the tunnel name and printed verification output.
- Add a short test that reads `outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md` to anchor the regression to the documented outage context.
- The change only adds tests and does not modify runtime scripts or `justfile` behavior, preserving existing token handling and the `int -> staging` alias.

### Testing
- Ran `pytest tests/test_cloudflare_tunnel_token_mode.py tests/test_up_recipe_calls.py -q` and the tests passed (all new/related assertions succeeded).
- Ran the full test suite with `pytest -q` and observed success for the suite run in this environment (`1169 passed, 43 skipped` reported during the run).
- Attempted `shellcheck scripts/*.sh scripts/**/*.sh` but `shellcheck` was not available in the runner image so it was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d557fa9ec832fa9f9fcf626827792)