### PR TITLE
Make helm-oci-upgrade fail fast on fresh clusters

### DIFF
--- a/justfile
+++ b/justfile
@@ -1236,6 +1236,20 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
         exit 1
     fi
 
+    has_deployed_release() {
+        local status_output=""
+
+        if ! status_output="$(helm -n "${namespace}" status "${release}" -o json 2>&1)"; then
+            return 1
+        fi
+
+        if printf '%s' "${status_output}" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"deployed"'; then
+            return 0
+        fi
+
+        return 1
+    }
+
     wait_for_rollouts() {
         local rollout_timeout="${SUGARKUBE_HELM_ROLLOUT_TIMEOUT:-180s}"
 
@@ -1304,6 +1318,14 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
 
     if [ "${reuse_values}" = "true" ]; then
         helm_args+=(--reuse-values)
+    fi
+
+    if [ "${allow_install}" != "true" ] && ! has_deployed_release; then
+        echo "ERROR: helm-oci-upgrade requires an existing deployed release." >&2
+        echo "Release '${release}' in namespace '${namespace}' is not currently deployed." >&2
+        echo "Fresh-cluster recovery path: run just helm-oci-install with the same release/namespace/chart/values inputs." >&2
+        echo "Outage reference: outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md" >&2
+        exit 1
     fi
 
     if [ ${#value_args[@]} -gt 0 ]; then

--- a/scripts/test-helm-oci-upgrade-fresh-cluster.sh
+++ b/scripts/test-helm-oci-upgrade-fresh-cluster.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+if ! command -v just >/dev/null 2>&1; then
+    echo "The 'just' command is required to run this test." >&2
+    exit 1
+fi
+
+tmp_bin="$(mktemp -d)"
+trap 'rm -rf "${tmp_bin}"' EXIT
+helm_log="${tmp_bin}/helm.log"
+kubectl_log="${tmp_bin}/kubectl.log"
+
+cat >"${tmp_bin}/helm" <<'EOS'
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "helm $*" >> "${HELM_TEST_LOG:-/dev/null}"
+
+if [ "${1:-}" = "-n" ] && [ "${2:-}" = "dspace" ] && [ "${3:-}" = "status" ] && [ "${4:-}" = "missing" ]; then
+    echo 'Error: release: not found' >&2
+    exit 1
+fi
+
+if [ "${1:-}" = "-n" ] && [ "${2:-}" = "dspace" ] && [ "${3:-}" = "status" ] && [ "${4:-}" = "dspace" ]; then
+    echo '{"info":{"status":"deployed"}}'
+    exit 0
+fi
+
+if [ "${1:-}" = "upgrade" ]; then
+    exit 0
+fi
+
+exit 0
+EOS
+chmod +x "${tmp_bin}/helm"
+
+cat >"${tmp_bin}/kubectl" <<'EOS'
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "kubectl $*" >> "${KUBECTL_TEST_LOG:-/dev/null}"
+if [ "${1:-}" = "-n" ] && [ "${2:-}" = "dspace" ] && [ "${3:-}" = "get" ] && [ "${4:-}" = "deploy,statefulset,daemonset" ] && [ "${5:-}" = "-l" ] && [ "${6:-}" = "app.kubernetes.io/instance=dspace" ]; then
+    echo "deployment.apps/dspace"
+    exit 0
+fi
+if [ "${1:-}" = "-n" ] && [ "${2:-}" = "dspace" ] && [ "${3:-}" = "rollout" ] && [ "${4:-}" = "status" ]; then
+    exit 0
+fi
+exit 0
+EOS
+chmod +x "${tmp_bin}/kubectl"
+
+set +e
+fresh_output="$({
+    PATH="${tmp_bin}:${PATH}" HELM_TEST_LOG="${helm_log}" KUBECTL_TEST_LOG="${kubectl_log}" \
+        KUBECONFIG="${tmp_bin}/kubeconfig" \
+        just helm-oci-upgrade release=missing namespace=dspace chart=oci://registry.test/charts/dspace 2>&1
+}; echo "__CODE:$?")"
+set -e
+
+if ! grep -q "__CODE:1" <<<"${fresh_output}"; then
+    printf 'Expected fresh-cluster upgrade path to fail. Output:\n%s\n' "${fresh_output}" >&2
+    exit 1
+fi
+
+if ! grep -q "helm-oci-upgrade requires an existing deployed release" <<<"${fresh_output}"; then
+    printf 'Expected actionable fresh-cluster message not found. Output:\n%s\n' "${fresh_output}" >&2
+    exit 1
+fi
+
+if ! grep -q "just helm-oci-install" <<<"${fresh_output}"; then
+    printf 'Expected install guidance missing. Output:\n%s\n' "${fresh_output}" >&2
+    exit 1
+fi
+
+if grep -q "helm upgrade missing" "${helm_log}"; then
+    printf 'Upgrade command should not run for missing release. Log:\n%s\n' "$(cat "${helm_log}" 2>/dev/null || true)" >&2
+    exit 1
+fi
+
+existing_output="$({
+    PATH="${tmp_bin}:${PATH}" HELM_TEST_LOG="${helm_log}" KUBECTL_TEST_LOG="${kubectl_log}" \
+        KUBECONFIG="${tmp_bin}/kubeconfig" \
+        just helm-oci-upgrade release=dspace namespace=dspace chart=oci://registry.test/charts/dspace
+} 2>&1)"
+
+if ! grep -q "helm upgrade dspace oci://registry.test/charts/dspace --namespace dspace --reuse-values" <<<"${existing_output}"; then
+    printf 'Expected upgrade command output missing. Output:\n%s\n' "${existing_output}" >&2
+    exit 1
+fi
+
+install_output="$({
+    PATH="${tmp_bin}:${PATH}" HELM_TEST_LOG="${helm_log}" KUBECTL_TEST_LOG="${kubectl_log}" \
+        KUBECONFIG="${tmp_bin}/kubeconfig" \
+        just helm-oci-install release=release=dspace namespace=namespace=dspace chart=chart=oci://registry.test/charts/dspace
+} 2>&1)"
+
+if ! grep -q -- "--install --create-namespace" <<<"${install_output}"; then
+    printf 'Expected install flags missing from install path. Output:\n%s\n' "${install_output}" >&2
+    exit 1
+fi
+
+if ! grep -q "helm -n dspace status dspace -o json" "${helm_log}"; then
+    printf 'Expected prefixed argument normalization to feed status check. Log:\n%s\n' "$(cat "${helm_log}" 2>/dev/null || true)" >&2
+    exit 1
+fi
+
+printf 'helm-oci-upgrade fresh-cluster guardrails and install/upgrade paths validated.\n'


### PR DESCRIPTION
### Motivation
- During the 2026-05-18 HA staging outage recovery operators hit Helm's opaque `has no deployed releases` error when running the steady-state `helm-oci-upgrade` against a freshly rebuilt cluster. 
- The helper should provide a clear, actionable failure path that points operators to the install flow rather than leaving them to interpret Helm's error. 
- Keep install semantics unchanged and avoid silently installing during an upgrade while preserving normal upgrade behavior for deployed releases.

### Description
- Add a preflight check `has_deployed_release()` in `_helm-oci-deploy` that runs `helm -n "${namespace}" status "${release}" -o json` and verifies a `deployed` status before running `helm upgrade` for upgrade-only flows. 
- If `allow_install` is not `true` and no deployed release exists, fail early with a Sugarkube-specific error that instructs the operator to run `just helm-oci-install ...` and references `outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md` for context. 
- Preserve `helm-oci-install` behavior (still calls `_helm-oci-deploy` with `allow_install='true'`) and do not change default upgrade semantics or perform silent installs. 
- Add `scripts/test-helm-oci-upgrade-fresh-cluster.sh` which stubs `helm`/`kubectl` to exercise: missing-release + upgrade-only failing path, existing-release + upgrade path, and install-path flags and prefixed-argument normalization.

### Testing
- Ran repository secret scan via `git diff --cached | ./scripts/scan-secrets.py` which passed. 
- Created and committed the new regression script `scripts/test-helm-oci-upgrade-fresh-cluster.sh` and verified its logic locally; executing the script in this environment failed early because the test harness requires the `just` binary (not present here). 
- Launched `pytest` against the repo; the test run started and many tests executed successfully in this session, but the full suite could not be completed here due to runtime/session limits and was not observed to fail because of these changes. 
- `shellcheck` was not available in the execution environment so shell linting for the new script could not be run here; CI should run `shellcheck` and the repository `pre-commit` checks (including `pre-commit run --all-files`) will validate formatting and scripts in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e29bcd40c832fa4126a234166784a)