### PR TITLE
Fail fast for helm-oci-upgrade on fresh clusters without a deployed release

### DIFF
--- a/justfile
+++ b/justfile
@@ -1236,6 +1236,16 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
         exit 1
     fi
 
+    if [ "${allow_install}" != "true" ]; then
+        if ! helm -n "${namespace}" status "${release}" >/dev/null 2>&1; then
+            echo "ERROR: helm-oci-upgrade requires an existing deployed release." >&2
+            echo "Release '${release}' was not found as deployed in namespace '${namespace}'." >&2
+            echo "If this is a fresh cluster recovery (see outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md), run:" >&2
+            echo "  just helm-oci-install release=${release} namespace=${namespace} chart=${chart} [values=...] [version_file=...] [default_tag=...]" >&2
+            exit 1
+        fi
+    fi
+
     wait_for_rollouts() {
         local rollout_timeout="${SUGARKUBE_HELM_ROLLOUT_TIMEOUT:-180s}"
 

--- a/scripts/test-helm-oci-install.sh
+++ b/scripts/test-helm-oci-install.sh
@@ -67,6 +67,16 @@ if [ ! -f "${FAKE_HELM_REGISTRY_CHART:-}" ]; then
 fi
 
 echo "helm $*" | tee -a "${HELM_TEST_LOG:-/dev/null}"
+
+if [ "${FAKE_HELM_STATUS_MODE:-deployed}" = "missing" ] && [ "$1" = "-n" ] && [ "$2" = "dspace" ] && [ "$3" = "status" ] && [ "$4" = "dspace" ]; then
+    echo "Error: release: not found" >&2
+    exit 1
+fi
+
+if [ "$1" = "-n" ] && [ "$2" = "dspace" ] && [ "$3" = "status" ] && [ "$4" = "dspace" ]; then
+    echo "STATUS: deployed"
+    exit 0
+fi
 SH
 chmod +x "${tmp_bin}/helm"
 
@@ -98,10 +108,13 @@ exit 0
 SH
 chmod +x "${tmp_bin}/kubectl"
 
-command_output="$(
+run_with_stubbed_tools() {
     PATH="${tmp_bin}:${PATH}" HELM_TEST_LOG="${helm_log}" KUBECTL_TEST_LOG="${kubectl_log}" \
-        FAKE_HELM_REGISTRY_CHART="${fixture_registry}" KUBECONFIG="${tmp_bin}/kubeconfig" \
-        just helm-oci-install \
+        FAKE_HELM_REGISTRY_CHART="${fixture_registry}" KUBECONFIG="${tmp_bin}/kubeconfig" "$@"
+}
+
+command_output="$(
+    run_with_stubbed_tools just helm-oci-install \
         release=dspace namespace=dspace \
         chart=oci://registry.test/charts/dspace \
         values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
@@ -149,4 +162,57 @@ if ! grep -q "rollout status deployment.apps/dspace" "${kubectl_log}"; then
     exit 1
 fi
 
-printf 'helm-oci-install emits normalized chart argument and rollout feedback.\n'
+: >"${helm_log}"
+: >"${kubectl_log}"
+if run_with_stubbed_tools FAKE_HELM_STATUS_MODE=missing just helm-oci-upgrade \
+    release=dspace namespace=dspace \
+    chart=oci://registry.test/charts/dspace \
+    values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
+    version_file=docs/apps/dspace.version \
+    default_tag=v3-latest >"${tmp_bin}/upgrade-missing.out" 2>"${tmp_bin}/upgrade-missing.err"; then
+    printf 'Expected helm-oci-upgrade to fail when no deployed release exists.\n' >&2
+    exit 1
+fi
+
+if ! grep -q "fresh cluster" "${tmp_bin}/upgrade-missing.err"; then
+    printf 'Expected actionable fresh-cluster guidance missing.\nStderr:\n%s\n' "$(cat "${tmp_bin}/upgrade-missing.err")" >&2
+    exit 1
+fi
+
+if ! grep -q "just helm-oci-install" "${tmp_bin}/upgrade-missing.err"; then
+    printf 'Expected helm-oci-install suggestion missing for no-release upgrade path.\nStderr:\n%s\n' "$(cat "${tmp_bin}/upgrade-missing.err")" >&2
+    exit 1
+fi
+
+if grep -q "helm upgrade" "${helm_log}"; then
+    printf 'Upgrade should fail before calling helm upgrade when release is missing.\nLog:\n%s\n' "$(cat "${helm_log}")" >&2
+    exit 1
+fi
+
+: >"${helm_log}"
+: >"${kubectl_log}"
+upgrade_output="$(
+    run_with_stubbed_tools just helm-oci-upgrade \
+        release=release=dspace namespace=namespace=dspace \
+        chart=chart=oci://registry.test/charts/dspace \
+        values=values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
+        version_file=version_file=docs/apps/dspace.version \
+        default_tag=default_tag=v3-latest
+)"
+
+if ! grep -q -- "--reuse-values" "${helm_log}"; then
+    printf 'Expected upgrade path to pass --reuse-values.\nLog:\n%s\n' "$(cat "${helm_log}")" >&2
+    exit 1
+fi
+
+if grep -q -- "--install" "${helm_log}"; then
+    printf 'Upgrade path should not pass --install by default.\nLog:\n%s\n' "$(cat "${helm_log}")" >&2
+    exit 1
+fi
+
+if ! grep -q "oci://registry.test/charts/dspace" <<<"${upgrade_output}"; then
+    printf 'Expected normalized chart argument in upgrade output.\nOutput:\n%s\n' "${upgrade_output}" >&2
+    exit 1
+fi
+
+printf 'helm-oci-install/upgrade fresh-cluster and steady-state behavior verified.\n'


### PR DESCRIPTION
### Motivation
- Operators recovering a wiped cluster hit `Error: UPGRADE FAILED: "<release>" has no deployed releases` when running `just helm-oci-upgrade`, which is confusing during outage recovery and led to the 2026-05-18 Sugarkube HA staging incident notes.
- The helper should detect the fresh-cluster case and provide a clear next step without changing steady-state upgrade semantics or performing a silent install.

### Description
- Add an upgrade-only preflight in `_helm-oci-deploy` that runs `helm -n "${namespace}" status "${release}"` when `allow_install` is not `true`, and fail early with a Sugarkube-specific error that references `outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md` and prints the equivalent `just helm-oci-install ...` command.
- Preserve existing behavior for `helm-oci-install` and do not pass `--install` during the default upgrade path; `--reuse-values` behavior is kept for upgrades.
- Extend `scripts/test-helm-oci-install.sh` to stub `helm` status responses (`FAKE_HELM_STATUS_MODE`) and add regression checks for: missing-release + upgrade-only failing with actionable guidance, existing-release upgrade passing `--reuse-values` (no `--install`), install path rollout feedback, and argument normalization for prefixed inputs.
- Avoid logging chart credentials or secrets in outputs (test harness uses fake fixtures and environment variables to avoid leaking real credentials).

### Testing
- Ran the full Python test suite with `pytest -q`, which passed: `1168 passed, 43 skipped`.
- Updated Helm regression script `scripts/test-helm-oci-install.sh`; invoking it directly in this environment failed because `just` is not installed here, but the script adds the focused mock-helm checks that CI will exercise during workflow runs.
- Attempted `shellcheck` on the touched script but `shellcheck` is not available in the local environment; CI is expected to run shellcheck as part of linting.
- Ran repository secret scan via `./scripts/scan-secrets.py` on staged changes and it found no credential leakage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e29bcd40c832fa4126a234166784a)