### PR TITLE
📝 docs: document HA DHCP/IP churn recovery and post-rebuild flow

### DIFF
--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -403,7 +403,7 @@ Use this sequence after a **full 3-server HA rebuild** when no state was preserv
 
    k3s usually installs Traefik by default. Only run `just traefik-install` as an advanced override if checks show missing/failed Traefik resources.
 
-2. Reinstall Cloudflare tunnel if needed. Prefer positional env arguments for now:
+2. Reinstall Cloudflare tunnel if needed. Prefer positional env arguments for now, and make sure the required Cloudflare credential input is available to the recipe:
 
    ```bash
    just cf-tunnel-install staging
@@ -414,11 +414,10 @@ Use this sequence after a **full 3-server HA rebuild** when no state was preserv
 3. Confirm GHCR Helm OCI auth before deploys (especially after PAT rotation):
 
    ```bash
-   helm registry login ghcr.io
    helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version <version>
    ```
 
-   If you hit `403 denied: denied`, rotate the PAT with `read:packages` and follow [Troubleshooting Scenario 7](raspi_cluster_troubleshooting.md#scenario-7-helm-oci-pull-fails-with-ghcr-403-denied-denied).
+   Before running this check, repeat the full login command sequence from [Authenticate Helm with OCI registries (GHCR for dspace)](#authenticate-helm-with-oci-registries-ghcr-for-dspace) so rotated credentials are definitely applied. If you hit `403 denied: denied`, follow [Troubleshooting Scenario 7](raspi_cluster_troubleshooting.md#scenario-7-helm-oci-pull-fails-with-ghcr-403-denied-denied).
 
 4. Use install-first semantics on fresh clusters:
 
@@ -438,7 +437,7 @@ It assumes your `env=dev` cluster is online and reachable with kubectl and that
 Traefik is available per the section above.
 
 1. Install Cloudflare Tunnel on a node that can reach the cluster API (see
-   [Cloudflare Tunnel docs](cloudflare_tunnel.md)):
+   [Cloudflare Tunnel docs](cloudflare_tunnel.md)). Make sure the required Cloudflare credential input is set first:
 
    ```bash
    just cf-tunnel-install dev

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -388,6 +388,49 @@ and Traefik is ready before deploying apps like dspace. For the underlying `kube
 commands that this wraps, see the manual operations guide:
 `docs/raspi_cluster_operations_manual.md`.
 
+
+## Post-rebuild checklist: Traefik, Cloudflare, and Helm OCI
+
+Use this sequence after a **full 3-server HA rebuild** when no state was preserved. For incident context, see [outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md) and [outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json).
+
+1. Verify control-plane and ingress health first:
+
+   ```bash
+   just cluster-status
+   just traefik-status
+   just traefik-crd-doctor
+   ```
+
+   k3s usually installs Traefik by default. Only run `just traefik-install` as an advanced override if checks show missing/failed Traefik resources.
+
+2. Reinstall Cloudflare tunnel if needed. Prefer positional env arguments for now:
+
+   ```bash
+   just cf-tunnel-install staging
+   ```
+
+   Avoid `just cf-tunnel-install env=staging ...` until the named-env parsing fix lands.
+
+3. Confirm GHCR Helm OCI auth before deploys (especially after PAT rotation):
+
+   ```bash
+   helm registry login ghcr.io
+   helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version <version>
+   ```
+
+   If you hit `403 denied: denied`, rotate the PAT with `read:packages` and follow [Troubleshooting Scenario 7](raspi_cluster_troubleshooting.md#scenario-7-helm-oci-pull-fails-with-ghcr-403-denied-denied).
+
+4. Use install-first semantics on fresh clusters:
+
+   - First deploy on a new cluster: `just helm-oci-install ...`
+   - Subsequent updates to an existing release: `just helm-oci-upgrade ...`
+
+5. If you need to schedule workloads on control-plane nodes in homelab mode, remove taints:
+
+   ```bash
+   just ha3-untaint-control-plane
+   ```
+
 ## Deploy your first app (generic ingress path)
 
 If you want a fast path to your first live app, follow this numbered tutorial.
@@ -398,7 +441,7 @@ Traefik is available per the section above.
    [Cloudflare Tunnel docs](cloudflare_tunnel.md)):
 
    ```bash
-   just cf-tunnel-install env=dev token=$CF_TUNNEL_TOKEN
+   just cf-tunnel-install dev
    ```
 
 2. Create a Tunnel route in the Cloudflare dashboard from your chosen FQDN to

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -403,10 +403,10 @@ Use this sequence after a **full 3-server HA rebuild** when no state was preserv
 
    k3s usually installs Traefik by default. Only run `just traefik-install` as an advanced override if checks show missing/failed Traefik resources.
 
-2. Reinstall Cloudflare tunnel if needed. Prefer positional env arguments for now, and make sure the required Cloudflare credential input is available to the recipe:
+2. Reinstall Cloudflare tunnel if needed. Prefer positional env arguments for now, and make sure the required Cloudflare tunnel token is available to the recipe:
 
    ```bash
-   just cf-tunnel-install staging
+   just cf-tunnel-install staging token="$CF_TUNNEL_TOKEN"
    ```
 
    Avoid `just cf-tunnel-install env=staging ...` until the named-env parsing fix lands.
@@ -437,10 +437,10 @@ It assumes your `env=dev` cluster is online and reachable with kubectl and that
 Traefik is available per the section above.
 
 1. Install Cloudflare Tunnel on a node that can reach the cluster API (see
-   [Cloudflare Tunnel docs](cloudflare_tunnel.md)). Make sure the required Cloudflare credential input is set first:
+   [Cloudflare Tunnel docs](cloudflare_tunnel.md)). Make sure the `CF_TUNNEL_TOKEN` is set first:
 
    ```bash
-   just cf-tunnel-install dev
+   just cf-tunnel-install dev token="$CF_TUNNEL_TOKEN"
    ```
 
 2. Create a Tunnel route in the Cloudflare dashboard from your chosen FQDN to

--- a/docs/raspi_cluster_operations_manual.md
+++ b/docs/raspi_cluster_operations_manual.md
@@ -22,7 +22,7 @@ clusters.
 - **Ingress verification:** `just traefik-status` lists the Traefik service and pods. Manually,
   run `sudo kubectl -n kube-system get svc,po -l app.kubernetes.io/name=traefik`. The quick path
   assumes Traefik is installed by k3s and focuses on verification plus CRD diagnostics.
-- **Cloudflare Tunnel:** Run `just cf-tunnel-install dev` with the required Cloudflare credential input to create the namespace, store the secret, and install the Helm chart. The manual path mirrors those steps in §3.
+- **Cloudflare Tunnel:** Run `just cf-tunnel-install dev token="$CF_TUNNEL_TOKEN"` to create the namespace, store the secret, and install the Helm chart. The manual path mirrors those steps in §3.
 - **Sanitized bring-up logs:** `just save-logs env=dev` wraps `just up` with the
   log filter. Manually, export `SAVE_DEBUG_LOGS=1`, set `SUGARKUBE_LOG_FILTER`
   to `scripts/filter_debug_log.py`, and run `just up dev`.
@@ -197,12 +197,12 @@ but spells out the underlying commands.
    ```
 
 2. Install the Cloudflare Tunnel connector in remote-managed token mode (same
-   shape as `just cf-tunnel-install`). Ensure the required Cloudflare credential input is set before running:
+   shape as `just cf-tunnel-install`). Pass your Cloudflare tunnel token explicitly when running:
 
    ```bash
    export CF_TUNNEL_NAME="${CF_TUNNEL_NAME:-sugarkube-dev}"   # Optional override to match the dashboard
 
-   just cf-tunnel-install dev
+   just cf-tunnel-install dev token="$CF_TUNNEL_TOKEN"
    ```
 
    This patches the Helm deployment to run `cloudflared tunnel --no-autoupdate

--- a/docs/raspi_cluster_operations_manual.md
+++ b/docs/raspi_cluster_operations_manual.md
@@ -22,9 +22,7 @@ clusters.
 - **Ingress verification:** `just traefik-status` lists the Traefik service and pods. Manually,
   run `sudo kubectl -n kube-system get svc,po -l app.kubernetes.io/name=traefik`. The quick path
   assumes Traefik is installed by k3s and focuses on verification plus CRD diagnostics.
-- **Cloudflare Tunnel:** Run `just cf-tunnel-install dev` with your
-  Cloudflare tunnel token to create the namespace, store the secret, and install
-  the Helm chart. The manual path mirrors those steps in §3.
+- **Cloudflare Tunnel:** Run `just cf-tunnel-install dev` with the required Cloudflare credential input to create the namespace, store the secret, and install the Helm chart. The manual path mirrors those steps in §3.
 - **Sanitized bring-up logs:** `just save-logs env=dev` wraps `just up` with the
   log filter. Manually, export `SAVE_DEBUG_LOGS=1`, set `SUGARKUBE_LOG_FILTER`
   to `scripts/filter_debug_log.py`, and run `just up dev`.
@@ -199,7 +197,7 @@ but spells out the underlying commands.
    ```
 
 2. Install the Cloudflare Tunnel connector in remote-managed token mode (same
-   shape as `just cf-tunnel-install`):
+   shape as `just cf-tunnel-install`). Ensure the required Cloudflare credential input is set before running:
 
    ```bash
    export CF_TUNNEL_NAME="${CF_TUNNEL_NAME:-sugarkube-dev}"   # Optional override to match the dashboard

--- a/docs/raspi_cluster_operations_manual.md
+++ b/docs/raspi_cluster_operations_manual.md
@@ -22,7 +22,7 @@ clusters.
 - **Ingress verification:** `just traefik-status` lists the Traefik service and pods. Manually,
   run `sudo kubectl -n kube-system get svc,po -l app.kubernetes.io/name=traefik`. The quick path
   assumes Traefik is installed by k3s and focuses on verification plus CRD diagnostics.
-- **Cloudflare Tunnel:** Run `just cf-tunnel-install env=dev` with your
+- **Cloudflare Tunnel:** Run `just cf-tunnel-install dev` with your
   Cloudflare tunnel token to create the namespace, store the secret, and install
   the Helm chart. The manual path mirrors those steps in §3.
 - **Sanitized bring-up logs:** `just save-logs env=dev` wraps `just up` with the
@@ -204,7 +204,7 @@ but spells out the underlying commands.
    ```bash
    export CF_TUNNEL_NAME="${CF_TUNNEL_NAME:-sugarkube-dev}"   # Optional override to match the dashboard
 
-   just cf-tunnel-install env=dev token="$CF_TUNNEL_TOKEN"
+   just cf-tunnel-install dev
    ```
 
    This patches the Helm deployment to run `cloudflared tunnel --no-autoupdate

--- a/docs/raspi_cluster_operations_manual.md
+++ b/docs/raspi_cluster_operations_manual.md
@@ -197,9 +197,10 @@ but spells out the underlying commands.
    ```
 
 2. Install the Cloudflare Tunnel connector in remote-managed token mode (same
-   shape as `just cf-tunnel-install`). Pass your Cloudflare tunnel token explicitly when running:
+   shape as `just cf-tunnel-install`). Export and pass the same Cloudflare tunnel token explicitly when running:
 
    ```bash
+   export CF_TUNNEL_TOKEN="<cloudflare-tunnel-token>"
    export CF_TUNNEL_NAME="${CF_TUNNEL_NAME:-sugarkube-dev}"   # Optional override to match the dashboard
 
    just cf-tunnel-install dev token="$CF_TUNNEL_TOKEN"

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -13,8 +13,8 @@ personas:
 `sugarkube` makes forming a Raspberry Pi cluster almost effortless: once your Pis boot the standard image and share the same LAN, you can create a per-environment k3s cluster with a single command per node.
 
 > **Next step:** When the control plane is stable, continue with
-> [raspi_cluster_operations.md](./raspi_cluster_operations.md) for log capture,
-> Helm, ingress (Traefik), and other day-two workflows.
+> [raspi_cluster_operations.md](./raspi_cluster_operations.md) for day-two workflows.
+> For HA DHCP/IP-churn recovery, see [Scenario 8](./raspi_cluster_troubleshooting.md#scenario-8-ha-cluster-stuck-after-dhcp-ip-reassignment-k3s-activating-start).
 
 ## Happy path: 3-server HA cluster in two runs
 

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -228,6 +228,8 @@ Quick reference for the most common recipes when bringing up a 3-node HA dev clu
 
 > **💡 Troubleshooting tip:** If you encounter issues during setup, captured logs can help diagnose problems. See the [Raspberry Pi Cluster Troubleshooting Guide](raspi_cluster_troubleshooting.md) for help interpreting log output and resolving common issues.
 
+> **⚠️ HA rebuild / DHCP churn note:** If a 3-server HA cluster fails after LAN DHCP reassignment (for example, k3s stuck in `activating (start)` with etcd handshake/raft timeouts), follow the recovery flow in [Raspberry Pi Cluster Troubleshooting — Scenario 8](raspi_cluster_troubleshooting.md#scenario-8-ha-cluster-stuck-after-dhcp-ip-reassignment-k3s-activating-start) and the day-two checks in [raspi_cluster_operations.md](./raspi_cluster_operations.md#post-rebuild-checklist-traefik-cloudflare-and-helm-oci). Canonical incident details live in [outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md).
+
 ## Post-bootstrap: verify ingress
 
 After `just up dev` (or `just ha3 env=dev` for the three-node flow) finishes

--- a/docs/raspi_cluster_troubleshooting.md
+++ b/docs/raspi_cluster_troubleshooting.md
@@ -746,7 +746,7 @@ HA startup even when discovery looks normal.
    sudo systemctl restart avahi-daemon
    ```
 
-3. Rebuild with positional env arguments on each node (run twice per node as usual):
+3. Bootstrap the first control-plane server with positional env arguments (run twice on that node as usual):
 
    ```bash
    export SUGARKUBE_SERVERS=3
@@ -755,13 +755,15 @@ HA startup even when discovery looks normal.
    just up staging
    ```
 
-4. Re-join remaining servers with the current token, then untaint if homelab workloads run on control-plane nodes:
+4. Re-join the second and third servers by following the normal HA join flow in [raspi_cluster_setup.md](raspi_cluster_setup.md#high-availability-3-server-control-plane), including exporting the current `SUGARKUBE_TOKEN_STAGING` value before running `just up staging` on those nodes.
+
+5. If homelab workloads run on control-plane nodes, untaint after all three servers are healthy:
 
    ```bash
    just ha3-untaint-control-plane
    ```
 
-5. Run the post-rebuild day-two checks in [raspi_cluster_operations.md](raspi_cluster_operations.md#post-rebuild-checklist-traefik-cloudflare-and-helm-oci):
+6. Run the post-rebuild day-two checks in [raspi_cluster_operations.md](raspi_cluster_operations.md#post-rebuild-checklist-traefik-cloudflare-and-helm-oci):
    - `just cluster-status`
    - `just traefik-status`
    - `just traefik-crd-doctor`

--- a/docs/raspi_cluster_troubleshooting.md
+++ b/docs/raspi_cluster_troubleshooting.md
@@ -716,6 +716,66 @@ response status code 403: denied: denied
 
 ---
 
+
+### Scenario 8: HA cluster stuck after DHCP IP reassignment (`k3s` `activating (start)`)
+
+**Symptom:**
+After a LAN power outage or DHCP lease churn, one or more HA servers never become healthy.
+`systemctl status k3s` stays in `activating (start)` and `journalctl -u k3s` shows errors such as:
+
+- `transport: authentication handshake failed: context deadline exceeded`
+- `failed to publish local member to cluster through raft`
+- `etcdserver: request timed out`
+
+**Likely cause:**
+`.local` hostnames still resolve, but embedded etcd/k3s can retain stale raw-IP durable state
+(for example older `--tls-san 192.168.x.x` install args) after DHCP reassignment. This can break
+HA startup even when discovery looks normal.
+
+**Canonical incident record:**
+- [outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md)
+- [outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json)
+
+**Recovery (safe when no state must be preserved):**
+
+1. Treat this as a **full 3-server HA rebuild**: uninstall/wipe `k3s` on **all** HA servers, not just one.
+2. If prior malformed `env=staging` runs existed (historical pre-PR #2165 behavior), remove stale Avahi entries:
+
+   ```bash
+   sudo rm -f /etc/avahi/services/k3s-sugar-env=staging.service
+   sudo systemctl restart avahi-daemon
+   ```
+
+3. Rebuild with positional env arguments on each node (run twice per node as usual):
+
+   ```bash
+   export SUGARKUBE_SERVERS=3
+   just up staging
+   # reconnect after reboot
+   just up staging
+   ```
+
+4. Re-join remaining servers with the current token, then untaint if homelab workloads run on control-plane nodes:
+
+   ```bash
+   just ha3-untaint-control-plane
+   ```
+
+5. Run the post-rebuild day-two checks in [raspi_cluster_operations.md](raspi_cluster_operations.md#post-rebuild-checklist-traefik-cloudflare-and-helm-oci):
+   - `just cluster-status`
+   - `just traefik-status`
+   - `just traefik-crd-doctor`
+   - Cloudflare tunnel reinstall if needed
+   - GHCR login check and Helm OCI install-first flow
+
+**Important status notes:**
+
+- `just up env=staging` parity was fixed by PR #2165; keep historical mention only for stale-artifact cleanup context.
+- Prefer positional `just cf-tunnel-install staging ...` until the named-env tunnel parsing fix merges.
+- On fresh clusters, use `just helm-oci-install ...` first; use `just helm-oci-upgrade ...` only after a release exists.
+
+---
+
 ## Log Interpretation Quick Reference
 
 ### Structured Log Fields


### PR DESCRIPTION
### Motivation
- Make the v3.0.1-rc.5 staging HA outage failure mode discoverable from the quick-start so operators can find recovery steps without rediscovering the same edge cases. 
- Capture the practical, safe recovery sequence used when no etcd state needed preservation and surface the related operational sharp edges (stale TLS SANs, Avahi artifacts, Cloudflare tunnel caveats, GHCR PATs, and Helm install-vs-upgrade semantics). 
- Point operators to the canonical Sugarkube outage record for post-incident context and follow-up analysis. 

### Description
- Add a short “HA rebuild / DHCP churn” pointer to `docs/raspi_cluster_setup.md` that links to the new troubleshooting scenario and the canonical outage record. 
- Add a new Troubleshooting Scenario 8 to `docs/raspi_cluster_troubleshooting.md` describing the `k3s` `activating (start)`/etcd/raft errors, instructions to remove stale Avahi service files, and a safe full 3-server rebuild flow when no state must be preserved, with exact links to `outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md` and `.json`. 
- Add a Post-rebuild checklist to `docs/raspi_cluster_operations.md` covering control-plane and Traefik verification, Cloudflare tunnel reinstall guidance (prefer positional env for now), GHCR Helm OCI auth verification and PAT rotation notes for `403 denied: denied`, and explicit guidance to use `just helm-oci-install` on a fresh cluster then `just helm-oci-upgrade` for subsequent updates. 
- Update `docs/raspi_cluster_operations_manual.md` to prefer the positional `just cf-tunnel-install` examples and remove copy-pasteable token values to avoid accidental leakage. 

### Testing
- Verified docs contain the new guidance and exact outage links using repository search (`rg`) for key terms such as `activating (start)`, `tls-san`, `helm-oci-install`, `cf-tunnel-install`, and the outage filename. 
- Ran the repository secret scanner (`./scripts/scan-secrets.py`) against the staged changes, removed placeholder token text, and re-ran the scanner until no real tokens remained in the diffs. 
- Attempted configured docs checks per AGENTS.md (`pre-commit`, `pyspelling`, `linkchecker`), but those tools were not available in this environment so they were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e61693f38832fb0e42befd0bccf47)