### PR TITLE
📝 docs: document HA DHCP churn recovery and post-rebuild flow

### DIFF
--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -65,6 +65,55 @@ Follow this sequence after imaging and booting the Pis:
    [token.place](./pi_token_dspace.md) or [dspace](https://github.com/democratizedspace/dspace)) once
    ingress is healthy.
 
+## Post-rebuild checklist: Traefik, Cloudflare, and Helm OCI
+
+Use this checklist after rebuilding an HA cluster (especially after DHCP/IP churn incidents) when no state was preserved.
+
+1. **Verify control-plane and ingress health first:**
+
+   ```bash
+   just cluster-status
+   just traefik-status
+   just traefik-crd-doctor
+   ```
+
+   k3s usually installs Traefik by default. Only use `just traefik-install` as an advanced override when addon verification fails.
+
+2. **Cloudflare tunnel install syntax:**
+
+   Prefer positional env form:
+
+   ```bash
+   just cf-tunnel-install dev
+   ```
+
+   Historical note: `just up env=staging` parity was fixed in PR #2165, but until the dedicated Cloudflare named-env parsing fix lands, avoid relying on `just cf-tunnel-install env=...` syntax.
+
+3. **Helm OCI auth and GHCR checks:**
+
+   If you see `403 denied: denied`, rotate the PAT with `read:packages`, run `helm registry login ghcr.io`, and verify pullability with:
+
+   ```bash
+   helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.0
+   ```
+
+4. **Fresh cluster deploy semantics:**
+
+   On a fresh cluster, install first, then upgrade later:
+
+   ```bash
+   just helm-oci-install ...
+   # subsequent rollouts once release exists:
+   just helm-oci-upgrade ...
+   ```
+
+   `helm-oci-upgrade` expects an already deployed release.
+
+5. **Read the canonical incident write-up:**
+
+   - [outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md)
+   - [outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json)
+
 ### Optional (recommended): Tailscale remote-ops access
 
 If you operate the cluster remotely, follow the dedicated Tailscale design guide:
@@ -398,7 +447,7 @@ Traefik is available per the section above.
    [Cloudflare Tunnel docs](cloudflare_tunnel.md)):
 
    ```bash
-   just cf-tunnel-install env=dev token=$CF_TUNNEL_TOKEN
+   just cf-tunnel-install dev
    ```
 
 2. Create a Tunnel route in the Cloudflare dashboard from your chosen FQDN to

--- a/docs/raspi_cluster_operations_manual.md
+++ b/docs/raspi_cluster_operations_manual.md
@@ -22,7 +22,7 @@ clusters.
 - **Ingress verification:** `just traefik-status` lists the Traefik service and pods. Manually,
   run `sudo kubectl -n kube-system get svc,po -l app.kubernetes.io/name=traefik`. The quick path
   assumes Traefik is installed by k3s and focuses on verification plus CRD diagnostics.
-- **Cloudflare Tunnel:** Run `just cf-tunnel-install env=dev` with your
+- **Cloudflare Tunnel:** Run `just cf-tunnel-install dev` with your
   Cloudflare tunnel token to create the namespace, store the secret, and install
   the Helm chart. The manual path mirrors those steps in §3.
 - **Sanitized bring-up logs:** `just save-logs env=dev` wraps `just up` with the
@@ -204,8 +204,10 @@ but spells out the underlying commands.
    ```bash
    export CF_TUNNEL_NAME="${CF_TUNNEL_NAME:-sugarkube-dev}"   # Optional override to match the dashboard
 
-   just cf-tunnel-install env=dev token="$CF_TUNNEL_TOKEN"
+   just cf-tunnel-install dev
    ```
+
+   Prefer positional env arguments here (`dev`, `staging`, `prod`) until the named `env=...` tunnel parser path is fully aligned.
 
    This patches the Helm deployment to run `cloudflared tunnel --no-autoupdate
    --metrics 0.0.0.0:2000 run` with `TUNNEL_TOKEN` from the `tunnel-token`

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -95,6 +95,17 @@ and reboots, second pass bootstraps or joins k3s).
     [raspi_cluster_operations.md](./raspi_cluster_operations.md) for Helm, Traefik ingress, and
     workload deployment.
 
+> **HA rebuild / DHCP churn recovery notes**
+> If a 3-server HA cluster becomes unhealthy after a LAN DHCP reassignment (for example, k3s stuck
+> in `activating (start)` with etcd handshake/raft timeouts), use the clean-rebuild flow in
+> [raspi_cluster_troubleshooting.md](./raspi_cluster_troubleshooting.md#scenario-8-ha-cluster-stuck-after-dhcp-ip-reassignment-k3s-activating-start)
+> and the day-two post-rebuild checklist in
+> [raspi_cluster_operations.md](./raspi_cluster_operations.md#post-rebuild-checklist-traefik-cloudflare-and-helm-oci).
+> Canonical incident record:
+> [outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md)
+> and
+> [outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json).
+
 [pi-image-workflow]: https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml
 
 <a id="happy-path-3-server-dev-cluster-in-two-runs"></a>

--- a/docs/raspi_cluster_troubleshooting.md
+++ b/docs/raspi_cluster_troubleshooting.md
@@ -876,3 +876,78 @@ If you've tried the troubleshooting steps above and still can't resolve your iss
 - [mDNS Troubleshooting Guide](mdns_troubleshooting.md) — Deep dive into mDNS-specific issues
 - [Runbook](runbook.md) — Operational procedures and SRE playbooks
 - [Outage Catalog](outage_catalog.md) — Historical issues and resolutions
+
+
+---
+
+### Scenario 8: HA cluster stuck after DHCP IP reassignment (`k3s` `activating (start)`)
+
+**Symptom:**
+After a power outage or router lease churn, one or more HA server nodes (`sugarkube*.local`) never become healthy. `systemctl status k3s` stays at `activating (start)` and `journalctl -u k3s` includes errors such as:
+
+- `transport: authentication handshake failed: context deadline exceeded`
+- `failed to publish local member to cluster through raft`
+- `etcdserver: request timed out`
+
+This usually indicates stale durable raw IP state (for example old `--tls-san 192.168.x.x`) no longer matches current DHCP assignments.
+
+**Important context:**
+
+- `.local` hostnames improve operator discovery and day-to-day commands.
+- k3s/embedded etcd can still use concrete IPs internally.
+- If durable config still references stale raw IPs, HA startup can fail after DHCP churn.
+
+See canonical incident details:
+
+- [outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md)
+- [outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json)
+
+**When no cluster state must be preserved (safe clean rebuild):**
+
+1. Confirm the failure signature on each HA server node:
+
+   ```bash
+   sudo systemctl status k3s
+   sudo journalctl -u k3s -n 200 --no-pager
+   ```
+
+2. Uninstall/wipe **all three HA server nodes** (not just one).
+
+3. If older malformed runs were used, remove stale Avahi artifacts (if present):
+
+   ```bash
+   sudo rm -f /etc/avahi/services/k3s-sugar-env=staging.service
+   sudo systemctl restart avahi-daemon
+   ```
+
+4. Rebuild with positional env args on each node:
+
+   ```bash
+   export SUGARKUBE_SERVERS=3
+   just up staging
+   # reconnect after reboot, then run again on each node
+   just up staging
+   ```
+
+5. Re-apply post-bootstrap operational steps:
+
+   ```bash
+   just ha3-untaint-control-plane
+   just cluster-status
+   just traefik-status
+   just traefik-crd-doctor
+   ```
+
+6. Reinstall/verify Cloudflare tunnel and workloads. For fresh Helm OCI clusters, install first:
+
+   ```bash
+   just helm-oci-install ...
+   # then only after a release exists
+   just helm-oci-upgrade ...
+   ```
+
+**Historical syntax note:**
+
+- `just up env=staging` parity was fixed by PR #2165.
+- Until the Cloudflare named-env parser fix merges, prefer positional tunnel invocation:
+  `just cf-tunnel-install staging`.


### PR DESCRIPTION
### Motivation
- Capture the v3.0.1-rc.5 staging HA outage where DHCP lease churn left k3s/etcd with stale raw-IP TLS/SAN state and provide a discoverable operator recovery path. 
- Make the canonical outage record discoverable from quick-start setup and day-two operations docs so operators can follow an audited recovery flow. 
- Surface related sharp edges (historical `just up env=staging` parity, Cloudflare tunnel named-env caveat, GHCR/Helm OCI sequencing, and stale Avahi artifacts) to avoid repeat debugging. 

### Description
- Add a short pointer in `docs/raspi_cluster_setup.md` titled “HA rebuild / DHCP churn recovery notes” linking to the troubleshooting scenario and the canonical outage files `outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md` and `.json`. 
- Add a `Scenario 8` entry to `docs/raspi_cluster_troubleshooting.md` that documents the `k3s` `activating (start)` signature, representative error strings, stale `--tls-san`/raw-IP suspicion, a safe clean-rebuild flow for 3-server HA clusters (when no state must be preserved), and stale Avahi service cleanup steps. 
- Add a `Post-rebuild checklist` to `docs/raspi_cluster_operations.md` that covers Traefik verification, Cloudflare tunnel invocation guidance, GHCR/Helm OCI `403` remediation and verification, and the `helm-oci-install` vs `helm-oci-upgrade` sequencing for fresh clusters. 
- Update `docs/raspi_cluster_operations_manual.md` to prefer positional Cloudflare env invocation (`just cf-tunnel-install dev`) and include the named-env caveat until the dedicated parser fix lands. 

### Testing
- Ran repository grep checks that search for the outage/error patterns and references; the expected instances were found in `docs` and `outages` (success). 
- Ran the repository secret scanner against the staged changes (`./scripts/scan-secrets.py`) and iteratively removed token-like inline examples so the staged diff passes the scanner (success). 
- Attempted `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` but these tools are not available in this execution environment (could not run). 
- Verified the edited docs use copy-paste-ready command examples and do not include real secrets or PATs (manual verification in the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e61693f38832fb0e42befd0bccf47)