### PR TITLE
📝 docs: document HA DHCP churn recovery flow

### DIFF
--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -398,7 +398,7 @@ Traefik is available per the section above.
    [Cloudflare Tunnel docs](cloudflare_tunnel.md)):
 
    ```bash
-   just cf-tunnel-install env=dev token=$CF_TUNNEL_TOKEN
+   just cf-tunnel-install dev
    ```
 
 2. Create a Tunnel route in the Cloudflare dashboard from your chosen FQDN to
@@ -419,6 +419,53 @@ Traefik is available per the section above.
 
 5. Iterate new builds using your app's upgrade instructions (e.g., the dspace
    guide covers rolling new `main-<shortsha>` images).
+
+## Post-rebuild checklist (Traefik, Cloudflare, and Helm OCI)
+
+Use this when you performed a clean HA rebuild (for example, after DHCP/IP churn and no state was
+preserved).
+
+1. Verify cluster and ingress baseline:
+
+   ```bash
+   just cluster-status
+   just traefik-status
+   just traefik-crd-doctor
+   ```
+
+   Only use `just traefik-install` as an advanced override if the default k3s Traefik addon is
+   missing or intentionally disabled.
+
+2. Reinstall or verify Cloudflare Tunnel:
+
+   ```bash
+   just cf-tunnel-install staging
+   ```
+
+   Prefer positional env arguments for now. Use `env=...` form only if you have confirmed the
+   named-env parsing fix is merged for your checkout.
+
+3. Re-authenticate Helm to GHCR if OCI pulls fail (for example `403 denied: denied`), then verify:
+
+   ```bash
+   helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version "$(cat docs/apps/dspace.version)"
+   ```
+
+   See [Troubleshooting Scenario 7](raspi_cluster_troubleshooting.md#scenario-7-helm-oci-pull-fails-with-ghcr-403-denied-denied)
+   for PAT rotation and stale-credential cleanup details.
+
+4. Use install first on a fresh cluster, then upgrade on existing releases:
+
+   ```bash
+   just helm-oci-install ...
+   # later releases on the same cluster:
+   just helm-oci-upgrade ...
+   ```
+
+5. Incident context and root-cause details are documented in:
+   [`outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md`](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md)
+   and
+   [`outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json`](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json).
 
 ## Step 1: Verify your 3-node control plane is healthy
 

--- a/docs/raspi_cluster_operations_manual.md
+++ b/docs/raspi_cluster_operations_manual.md
@@ -22,7 +22,7 @@ clusters.
 - **Ingress verification:** `just traefik-status` lists the Traefik service and pods. Manually,
   run `sudo kubectl -n kube-system get svc,po -l app.kubernetes.io/name=traefik`. The quick path
   assumes Traefik is installed by k3s and focuses on verification plus CRD diagnostics.
-- **Cloudflare Tunnel:** Run `just cf-tunnel-install env=dev` with your
+- **Cloudflare Tunnel:** Run `just cf-tunnel-install dev` with your
   Cloudflare tunnel token to create the namespace, store the secret, and install
   the Helm chart. The manual path mirrors those steps in §3.
 - **Sanitized bring-up logs:** `just save-logs env=dev` wraps `just up` with the
@@ -204,7 +204,7 @@ but spells out the underlying commands.
    ```bash
    export CF_TUNNEL_NAME="${CF_TUNNEL_NAME:-sugarkube-dev}"   # Optional override to match the dashboard
 
-   just cf-tunnel-install env=dev token="$CF_TUNNEL_TOKEN"
+   just cf-tunnel-install dev
    ```
 
    This patches the Helm deployment to run `cloudflared tunnel --no-autoupdate

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -95,6 +95,17 @@ and reboots, second pass bootstraps or joins k3s).
     [raspi_cluster_operations.md](./raspi_cluster_operations.md) for Helm, Traefik ingress, and
     workload deployment.
 
+> **HA rebuild / DHCP churn notes (important):**
+> If a 3-server HA control plane later gets stuck after DHCP/IP churn (for example, `k3s` stays in
+> `activating (start)` with etcd handshake/raft timeouts), use the recovery flow in
+> [raspi_cluster_troubleshooting.md](./raspi_cluster_troubleshooting.md#scenario-8-ha-control-plane-stuck-after-dhcp-ip-churn-k3s-activating-start)
+> and the day-two rebuild checks in
+> [raspi_cluster_operations.md](./raspi_cluster_operations.md#post-rebuild-checklist-traefik-cloudflare-and-helm-oci).
+> Canonical incident record:
+> [`outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md`](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md)
+> and
+> [`outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json`](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json).
+
 [pi-image-workflow]: https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml
 
 <a id="happy-path-3-server-dev-cluster-in-two-runs"></a>

--- a/docs/raspi_cluster_troubleshooting.md
+++ b/docs/raspi_cluster_troubleshooting.md
@@ -716,6 +716,80 @@ response status code 403: denied: denied
 
 ---
 
+### Scenario 8: HA control plane stuck after DHCP/IP churn (`k3s` `activating (start)`)
+
+**Symptom:**
+On a 3-server HA cluster (for example `sugarkube3.local`, `sugarkube4.local`, `sugarkube5.local`)
+after a power/network event, `k3s` never becomes healthy and systemd stays at
+`activating (start)`. Journals often show etcd transport/raft failures such as:
+
+- `transport: authentication handshake failed: context deadline exceeded`
+- `failed to publish local member to cluster through raft`
+- `etcdserver: request timed out`
+
+**Why this can happen:**
+
+- `.local` hostnames are the operator-facing stable identity and should remain the default.
+- k3s/etcd still use concrete runtime IPs internally.
+- If durable install config contains stale raw IP identity (for example old `--tls-san <ip>` data),
+  DHCP reassignment can leave control-plane peers unable to re-form a healthy etcd quorum.
+
+**Historical footgun status (`just up env=staging`):**
+
+- The `just up env=staging` parity issue was fixed in PR #2165.
+- During older runs (pre-fix), malformed env values could leak into Avahi metadata.
+- If you suspect an old malformed run, check for and remove:
+
+  ```bash
+  sudo rm -f /etc/avahi/services/k3s-sugar-env=staging.service
+  sudo systemctl restart avahi-daemon
+  ```
+
+**Recovery when no state must be preserved (recommended outage playbook):**
+
+1. Confirm failure signatures on each server:
+
+   ```bash
+   sudo systemctl status k3s
+   sudo journalctl -u k3s -n 200 --no-pager | grep -Ei "activating|etcd|raft|handshake|timed out"
+   ```
+
+2. Uninstall/wipe k3s on **all three HA servers** (not just one), then reboot/re-run bring-up.
+3. Rebuild the HA cluster using positional environment args (`just up staging`), re-joining all
+   three servers with the correct token flow.
+4. Remove control-plane taints if this homelab schedules workloads on server nodes:
+
+   ```bash
+   just ha3-untaint-control-plane
+   ```
+
+5. Re-verify day-two dependencies:
+
+   ```bash
+   just cluster-status
+   just traefik-status
+   just traefik-crd-doctor
+   just cf-tunnel-install staging
+   ```
+
+6. For fresh-cluster OCI app deploys, run install first:
+
+   ```bash
+   just helm-oci-install ...
+   # only after a release exists:
+   just helm-oci-upgrade ...
+   ```
+
+7. If GHCR returns `403 denied: denied`, follow Scenario 7 to rotate PAT
+   (`read:packages`), re-login, and validate with `helm show chart ...`.
+
+**Canonical incident record (source of truth):**
+
+- `outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md`
+- `outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json`
+
+---
+
 ## Log Interpretation Quick Reference
 
 ### Structured Log Fields


### PR DESCRIPTION
### Motivation

- Make the HA cluster failure/recovery path discovered during the v3.0.1-rc.5 staging outage easy to find from the quick-start and day-two docs and point operators to the canonical outage record. 
- Explain the practical clean-rebuild flow for a 3-server HA cluster when no state must be preserved and record known sharp edges (raw-IP TLS SANs, `just up env=staging` historical parsing, Cloudflare tunnel named-env caveat, and Helm OCI install-vs-upgrade behavior).
- Avoid forcing operators to rediscover the same outage workarounds and ensure docs reflect the fixes already landed (PR #2165 parity fix) where appropriate.

### Description

- Added a short "HA rebuild / DHCP churn notes" pointer to `docs/raspi_cluster_setup.md` linking to the new troubleshooting scenario and the canonical outage files (`outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md` and `.json`).
- Added a Post-rebuild checklist to `docs/raspi_cluster_operations.md` that covers `just cluster-status`, Traefik checks, Cloudflare tunnel reinstall guidance (prefer positional env usage), GHCR/Helm OCI verification, and `helm-oci-install` vs `helm-oci-upgrade` guidance.
- Updated `docs/raspi_cluster_operations_manual.md` to prefer the positional `just cf-tunnel-install dev` form in manual examples, and added a concrete Scenario 8 to `docs/raspi_cluster_troubleshooting.md` for k3s/etcd failures after DHCP/IP churn describing symptoms, root causes, stale Avahi cleanup, and the recommended 3-node clean rebuild flow.

Files changed: `docs/raspi_cluster_setup.md`, `docs/raspi_cluster_operations.md`, `docs/raspi_cluster_operations_manual.md`, and `docs/raspi_cluster_troubleshooting.md`.

### Testing

- Ran the repository search-based checks (`rg`) to verify the new scenario text and links appear and to find any stale language; these searches succeeded and confirmed the outage links were included. 
- Ran the repository secret scan wrapper `./scripts/scan-secrets.py` during staging of the changes; an inline token example was detected and the docs were edited to remove literal placeholders, after which `./scripts/scan-secrets.py` reported no issues.
- Attempted automated doc checks: `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` but these commands are not available in the current environment and therefore could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e61693f38832fb0e42befd0bccf47)