### PR TITLE
📝 docs: document HA DHCP churn recovery path for k3s clusters

### DIFF
--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -398,7 +398,7 @@ Traefik is available per the section above.
    [Cloudflare Tunnel docs](cloudflare_tunnel.md)):
 
    ```bash
-   just cf-tunnel-install env=dev token=$CF_TUNNEL_TOKEN
+   just cf-tunnel-install dev
    ```
 
 2. Create a Tunnel route in the Cloudflare dashboard from your chosen FQDN to
@@ -419,6 +419,50 @@ Traefik is available per the section above.
 
 5. Iterate new builds using your app's upgrade instructions (e.g., the dspace
    guide covers rolling new `main-<shortsha>` images).
+
+## Post-rebuild checklist: Traefik, Cloudflare, and Helm OCI
+
+Use this checklist after a **full 3-server HA rebuild** (all control-plane nodes), especially after
+DHCP/IP churn incidents like the May 18, 2026 staging outage documented in
+[`outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md`](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md)
+and
+[`outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json`](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json).
+
+1. **Verify cluster and ingress health first:**
+
+   ```bash
+   just cluster-status
+   just traefik-status
+   just traefik-crd-doctor
+   ```
+
+   Use `just traefik-install` only as an advanced override when the default k3s Traefik addon is
+   intentionally disabled or missing.
+
+2. **Reinstall/verify Cloudflare Tunnel using positional env args:**
+
+   ```bash
+   just cf-tunnel-install staging
+   ```
+
+   `just up env=staging` parity was fixed in PR #2165, but until the separate Cloudflare tunnel
+   named-env parsing fix lands, prefer positional env arguments for tunnel install commands.
+
+3. **Use install-first semantics for fresh clusters:**
+
+   - First deploy on a fresh cluster: `just helm-oci-install ...`
+   - Subsequent releases for the same deployed release: `just helm-oci-upgrade ...`
+
+4. **If OCI pulls fail with GHCR auth errors (`403 denied: denied`):** rotate a PAT with
+   `read:packages`, then re-auth and verify before rerunning deploy commands:
+
+   ```bash
+   helm registry login ghcr.io
+   helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version <version>
+   ```
+
+   For the full credential-reset flow, see
+   [Troubleshooting Scenario 7](./raspi_cluster_troubleshooting.md#scenario-7-helm-oci-pull-fails-with-ghcr-403-denied-denied).
 
 ## Step 1: Verify your 3-node control plane is healthy
 

--- a/docs/raspi_cluster_operations_manual.md
+++ b/docs/raspi_cluster_operations_manual.md
@@ -22,7 +22,7 @@ clusters.
 - **Ingress verification:** `just traefik-status` lists the Traefik service and pods. Manually,
   run `sudo kubectl -n kube-system get svc,po -l app.kubernetes.io/name=traefik`. The quick path
   assumes Traefik is installed by k3s and focuses on verification plus CRD diagnostics.
-- **Cloudflare Tunnel:** Run `just cf-tunnel-install env=dev` with your
+- **Cloudflare Tunnel:** Run `just cf-tunnel-install dev` with your
   Cloudflare tunnel token to create the namespace, store the secret, and install
   the Helm chart. The manual path mirrors those steps in §3.
 - **Sanitized bring-up logs:** `just save-logs env=dev` wraps `just up` with the
@@ -204,7 +204,7 @@ but spells out the underlying commands.
    ```bash
    export CF_TUNNEL_NAME="${CF_TUNNEL_NAME:-sugarkube-dev}"   # Optional override to match the dashboard
 
-   just cf-tunnel-install env=dev token="$CF_TUNNEL_TOKEN"
+   just cf-tunnel-install dev
    ```
 
    This patches the Helm deployment to run `cloudflared tunnel --no-autoupdate

--- a/docs/raspi_cluster_setup.md
+++ b/docs/raspi_cluster_setup.md
@@ -95,6 +95,16 @@ and reboots, second pass bootstraps or joins k3s).
     [raspi_cluster_operations.md](./raspi_cluster_operations.md) for Helm, Traefik ingress, and
     workload deployment.
 
+> **HA rebuild / DHCP churn recovery notes:** If a 3-server HA cluster is stuck in
+> `activating (start)` after a LAN power event or DHCP lease churn, do not keep retrying the happy
+> path on one node. Use the clean-rebuild troubleshooting scenario and outage record:
+> [Scenario 8 in raspi_cluster_troubleshooting.md](./raspi_cluster_troubleshooting.md#scenario-8-ha-cluster-stuck-after-dhcp-ip-reassignment-clean-rebuild-when-no-state-must-be-preserved),
+> [operations rebuild checklist](./raspi_cluster_operations.md#post-rebuild-checklist-traefik-cloudflare-and-helm-oci),
+> and the canonical incident docs
+> [`outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md`](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md)
+> +
+> [`outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json`](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json).
+
 [pi-image-workflow]: https://github.com/futuroptimist/sugarkube/actions/workflows/pi-image.yml
 
 <a id="happy-path-3-server-dev-cluster-in-two-runs"></a>

--- a/docs/raspi_cluster_troubleshooting.md
+++ b/docs/raspi_cluster_troubleshooting.md
@@ -716,6 +716,94 @@ response status code 403: denied: denied
 
 ---
 
+### Scenario 8: HA cluster stuck after DHCP IP reassignment (clean rebuild when no state must be preserved)
+
+**Symptom:**
+A 3-server HA cluster (for example `sugarkube3.local`, `sugarkube4.local`, `sugarkube5.local`) was
+healthy before a LAN/power event, then fails to recover after DHCP lease reassignment. `k3s` can
+remain in `activating (start)` and etcd never stabilizes.
+
+Common log/journal patterns include:
+
+- `transport: authentication handshake failed: context deadline exceeded`
+- `failed to publish local member to cluster through raft`
+- `etcdserver: request timed out`
+- stale config showing old IP SANs (for example `--tls-san 192.168.86.37`)
+
+Canonical incident record (source of truth):
+
+- [`outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md`](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md)
+- [`outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json`](../outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.json)
+
+**Context and sharp edges:**
+
+- `.local` hostnames are the intended operator-facing identity, but k3s/etcd still consume
+  concrete IPs internally.
+- If durable k3s config captures stale raw IPs, DHCP churn can break HA startup.
+- `just up env=staging` parity is fixed (PR #2165). Historical malformed `env=staging` artifacts
+  may still exist on nodes from old runs.
+
+**Recovery when no state must be preserved (full 3-server rebuild):**
+
+1. **Confirm this is an HA-etcd startup failure on each server node:**
+
+   ```bash
+   sudo systemctl status k3s
+   sudo journalctl -u k3s -n 200 --no-pager | egrep -i 'activating|handshake|raft|etcdserver|tls-san|timed out'
+   ```
+
+2. **Uninstall k3s on *all three* HA servers** (not just one):
+
+   ```bash
+   sudo /usr/local/bin/k3s-uninstall.sh || true
+   ```
+
+3. **Remove stale malformed Avahi service files left by old named-env parsing bugs** (if present):
+
+   ```bash
+   sudo rm -f /etc/avahi/services/k3s-sugar-env=staging.service
+   ```
+
+4. **Rebuild the HA cluster with positional environment arguments:**
+
+   ```bash
+   export SUGARKUBE_SERVERS=3
+   just up staging
+   # reconnect after reboot
+   just up staging
+   ```
+
+   Join the remaining servers with the staging token and the same positional env form.
+
+5. **Untaint control-plane nodes when you intentionally schedule homelab workloads there.**
+
+6. **Run post-rebuild day-two checks:**
+
+   ```bash
+   just cluster-status
+   just traefik-status
+   just traefik-crd-doctor
+   just cf-tunnel-install staging
+   ```
+
+7. **Use Helm OCI install/upgrade in the correct order:**
+
+   - Fresh cluster or release absent: `just helm-oci-install ...`
+   - Existing deployed release: `just helm-oci-upgrade ...`
+
+8. **If GHCR OCI pulls fail with `403 denied: denied`:**
+   rotate PAT (`read:packages`), re-run `helm registry login ghcr.io`, and verify with
+   `helm show chart ...` before retrying deploys (see Scenario 7).
+
+**Mitigations to reduce repeat incidents:**
+
+- Keep DHCP reservations for HA nodes where possible.
+- Prefer `.local` hostnames in operator workflows.
+- If symptoms recur after IP churn, assume stale durable node identity and perform a clean
+  full-server rebuild when workload state is disposable.
+
+---
+
 ## Log Interpretation Quick Reference
 
 ### Structured Log Fields


### PR DESCRIPTION
### Motivation
- Capture the learnings from the May 18, 2026 staging HA outage caused by DHCP IP reassignment so operators can recover quickly without rediscovering the same failure path.
- Surface a concise recovery pointer from the quick-start happy path to a fuller operations checklist and the canonical outage record so the incident is discoverable where operators expect it.
- Clarify related sharp edges (Cloudflare tunnel env parsing, `just up env=staging` historical fix, GHCR/Helm OCI semantics, and stale Avahi artifacts) to reduce troubleshooting time.

### Description
- Added a short HA rebuild / DHCP churn pointer to `docs/raspi_cluster_setup.md` that links to the new troubleshooting scenario, operations checklist, and the canonical outage files (`outages/2026-05-18-sugarkube-ha-staging-dhcp-ip-reassignment.md` and `.json`).
- Added a `Post-rebuild checklist: Traefik, Cloudflare, and Helm OCI` section to `docs/raspi_cluster_operations.md` covering `just cluster-status`, `just traefik-status`, `just traefik-crd-doctor`, positional `cf-tunnel-install` usage, `helm-oci-install` vs `helm-oci-upgrade` ordering, and GHCR PAT/verification guidance.
- Updated `docs/raspi_cluster_operations_manual.md` to prefer the positional Cloudflare tunnel form (`just cf-tunnel-install dev`) in manual examples to avoid implying the old `env=` parsing behavior is still required.
- Added `Scenario 8` to `docs/raspi_cluster_troubleshooting.md` that documents the `k3s`/etcd failure signatures (`activating (start)`, handshake/raft/etcd timeouts), stale `--tls-san` suspicion, removal of malformed Avahi service files (e.g. `/etc/avahi/services/k3s-sugar-env=staging.service`), a safe full 3-server clean-rebuild flow when no state must be preserved, post-rebuild verification steps, and direct links to the outage record.

### Testing
- Ran repository searches with `rg` to verify new guidance and references (`activating (start)`, `transport: authentication handshake failed`, `helm-oci-install`, `helm-oci-upgrade`, `cf-tunnel-install`, `env=staging`, `DHCP`, `tls-san`, and the outage slug) and confirmed matches in the updated docs and outage files.
- Executed the repository secret scan `git diff --cached | ./scripts/scan-secrets.py`, addressed an initial CF token placeholder match by replacing inline token examples with positional usage and non-secret placeholders, and re-ran the scanner to confirm no secrets are staged.
- Attempted doc validation steps (`pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, `linkchecker --no-warnings README.md docs/`) but those commands were not available in the execution environment so they were not run here; please run them as part of CI or locally before merging.
- Committed changes as `📝 docs: add HA DHCP churn recovery guidance` (commit `37ee41b2`) and reviewed the diff to ensure the outage links and command examples contain no real secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e61693f38832fb0e42befd0bccf47)