### PR TITLE
Add tokenplace OCI values/version files and deprecate local tokenplace-relay chart

### DIFF
--- a/apps/tokenplace-relay/README.md
+++ b/apps/tokenplace-relay/README.md
@@ -1,0 +1,19 @@
+# Deprecated local tokenplace-relay chart
+
+This local chart is deprecated for steady-state Sugarkube deployments.
+
+Use the token.place-owned OCI chart instead:
+
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+
+Sugarkube-owned deploy layering lives under `docs/examples/`:
+
+- `tokenplace.values.dev.yaml` (base/shared)
+- `tokenplace.values.staging.yaml` (staging overlay)
+- `tokenplace.values.prod.yaml` (prod overlay)
+
+Keep this directory only for migration/reference until all remaining local-chart
+wiring is removed.

--- a/docs/apps/tokenplace.prod.tag
+++ b/docs/apps/tokenplace.prod.tag
@@ -1,0 +1,4 @@
+# Approved immutable production image tag for token.place relay.
+#
+# Leave this file comment-only until a production tag is approved.
+# Deployment helpers should require explicit `tag=` when no non-comment value exists here.

--- a/docs/apps/tokenplace.version
+++ b/docs/apps/tokenplace.version
@@ -1,0 +1,2 @@
+# Default tokenplace chart version. Update when new tokenplace chart releases are published.
+0.1.0

--- a/docs/examples/tokenplace.values.dev.yaml
+++ b/docs/examples/tokenplace.values.dev.yaml
@@ -1,0 +1,18 @@
+# Base values for token.place relay deployments.
+# Combine with environment overlays (for example: tokenplace.values.staging.yaml,
+# tokenplace.values.prod.yaml) when deploying.
+environment: dev
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/tokenplace-relay
+
+ingress:
+  enabled: true
+  className: traefik
+  annotations: {}
+
+env:
+  RELAY_WORKERS: "1"
+  TOKENPLACE_FRONTEND_MODE: production
+  TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH: "0"

--- a/docs/examples/tokenplace.values.prod.yaml
+++ b/docs/examples/tokenplace.values.prod.yaml
@@ -1,0 +1,11 @@
+# Production overlay values for token.place relay.
+environment: prod
+
+ingress:
+  enabled: true
+  className: traefik
+  host: token.place
+
+env:
+  TOKEN_PLACE_ENV: production
+  TOKENPLACE_RELAY_PUBLIC_URL: https://token.place

--- a/docs/examples/tokenplace.values.staging.yaml
+++ b/docs/examples/tokenplace.values.staging.yaml
@@ -1,0 +1,11 @@
+# Staging overlay values for token.place relay.
+environment: staging
+
+ingress:
+  enabled: true
+  className: traefik
+  host: staging.token.place
+
+env:
+  TOKEN_PLACE_ENV: staging
+  TOKENPLACE_RELAY_PUBLIC_URL: https://staging.token.place


### PR DESCRIPTION
### Motivation
- Provide Sugarkube-owned DSPACE-style values and version artifacts so `token.place` can be deployed from the canonical OCI chart/image rather than the stale local chart.
- Make relay-only Sugarkube deployments safe by pinning chart/version metadata and providing environment overlays for dev/staging/prod.

### Description
- Added `docs/apps/tokenplace.version` pinning the starting chart version to `0.1.0` with DSPACE-style comment guidance.
- Added `docs/apps/tokenplace.prod.tag` as a comment-only placeholder for an approved immutable production image tag to be filled when promoted.
- Added layered example values: `docs/examples/tokenplace.values.dev.yaml`, `docs/examples/tokenplace.values.staging.yaml`, and `docs/examples/tokenplace.values.prod.yaml` with the canonical image `ghcr.io/futuroptimist/tokenplace-relay`, `replicaCount: 1`, Traefik ingress settings, concrete staging/prod hostnames, and relay-safe env defaults (one worker, no required upstream health gate).
- Marked the local chart directory as deprecated by adding `apps/tokenplace-relay/README.md` that documents the canonical OCI chart (`oci://ghcr.io/futuroptimist/charts/tokenplace`) and keeps the local chart for migration/reference only.

### Testing
- Verified presence of new files with `test -f docs/apps/tokenplace.version`, `test -f docs/apps/tokenplace.prod.tag`, `test -f docs/examples/tokenplace.values.dev.yaml`, `test -f docs/examples/tokenplace.values.staging.yaml`, and `test -f docs/examples/tokenplace.values.prod.yaml`, all passing.
- Searched for disallowed references with `grep -R "ghcr.io/democratizedspace/tokenplace-relay" docs/examples docs/apps apps || true` and confirmed the new values do not reference `ghcr.io/democratizedspace/tokenplace-relay` (legacy references remain only in the deprecated local-chart files).
- Ensured no new values require `TOKENPLACE_RELAY_UPSTREAM_URL` with `grep -R "TOKENPLACE_RELAY_UPSTREAM_URL" docs/examples/tokenplace.values.*.yaml && exit 1 || true`, which returned no matches.
- Attempted repository linting with `pre-commit run --all-files`, which could not run in this environment because `pre-commit` is not installed (failure: `pre-commit: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13893667e0832f977f2797021f1c74)