### PR TITLE
Add token.place OCI values/version files and deprecate local tokenplace-relay chart

### DIFF
--- a/apps/tokenplace-relay/README.md
+++ b/apps/tokenplace-relay/README.md
@@ -1,0 +1,13 @@
+# DEPRECATED: local tokenplace-relay chart
+
+This local chart is deprecated for steady-state Sugarkube deployments.
+
+Use the token.place-owned OCI chart instead:
+
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Values layering: `docs/examples/tokenplace.values.dev.yaml` plus staging/prod overlays
+
+The local chart remains only as a temporary compatibility artifact while automation and docs
+are migrated. New deployments and routine upgrades should not target `./apps/tokenplace-relay`.

--- a/docs/apps/tokenplace.prod.tag
+++ b/docs/apps/tokenplace.prod.tag
@@ -1,0 +1,3 @@
+# Approved production image tag for token.place relay.
+# Leave this file comment-only until a release tag is explicitly approved.
+# Deployment recipes should require passing tag=... when no non-comment tag is present.

--- a/docs/apps/tokenplace.version
+++ b/docs/apps/tokenplace.version
@@ -1,0 +1,2 @@
+# Default token.place chart version (v0 series). Update when new releases are published.
+0.1.0

--- a/docs/examples/tokenplace.values.dev.yaml
+++ b/docs/examples/tokenplace.values.dev.yaml
@@ -1,0 +1,18 @@
+# Shared/base values for token.place relay deployments.
+# Layer this file with environment overlays (for example, staging/prod) to set hostnames and
+# public environment metadata.
+environment: dev
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/tokenplace-relay
+
+ingress:
+  enabled: true
+  className: traefik
+  annotations: {}
+
+env:
+  RELAY_WORKERS: "1"
+  TOKENPLACE_FRONTEND_MODE: production
+  TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH: "0"

--- a/docs/examples/tokenplace.values.prod.yaml
+++ b/docs/examples/tokenplace.values.prod.yaml
@@ -1,0 +1,10 @@
+environment: prod
+
+ingress:
+  enabled: true
+  className: traefik
+  host: token.place
+
+env:
+  TOKEN_PLACE_ENV: production
+  TOKENPLACE_RELAY_PUBLIC_URL: https://token.place

--- a/docs/examples/tokenplace.values.staging.yaml
+++ b/docs/examples/tokenplace.values.staging.yaml
@@ -1,0 +1,10 @@
+environment: staging
+
+ingress:
+  enabled: true
+  className: traefik
+  host: staging.token.place
+
+env:
+  TOKEN_PLACE_ENV: staging
+  TOKENPLACE_RELAY_PUBLIC_URL: https://staging.token.place


### PR DESCRIPTION
### Motivation
- Move Sugarkube token.place deployment metadata to the canonical token.place OCI chart/image and DSPACE-style Helm layering so steady-state deployments do not depend on the local `./apps/tokenplace-relay` chart. 
- Provide operator-facing version/tag pins and environment overlays so staging/prod deployments are predictable and easy to validate.

### Description
- Added a chart-version pin at `docs/apps/tokenplace.version` (default `0.1.0`) following the DSPACE-style comment pattern. 
- Added a comment-only production tag placeholder at `docs/apps/tokenplace.prod.tag` that intentionally contains no active tag and documents that `tag=` should be required if no approved tag is present. 
- Added DSPACE-style values layering files: `docs/examples/tokenplace.values.dev.yaml` (shared/base dev defaults, `environment: dev`, `replicaCount: 1`, `image.repository: ghcr.io/futuroptimist/tokenplace-relay`, ingress defaults, and `env` map including `RELAY_WORKERS: "1"` and `TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH: "0"`), `docs/examples/tokenplace.values.staging.yaml` (staging overlay with `ingress.host: staging.token.place` and staging env vars), and `docs/examples/tokenplace.values.prod.yaml` (prod overlay with `ingress.host: token.place` and production env vars). 
- Added `apps/tokenplace-relay/README.md` that deprecates the local chart for steady-state deployments and points operators to the canonical OCI chart (`oci://ghcr.io/futuroptimist/charts/tokenplace`) and the new values files; the local chart is retained only as a temporary compatibility artifact.

### Testing
- Ran existence checks: `test -f docs/apps/tokenplace.version`, `test -f docs/apps/tokenplace.prod.tag`, `test -f docs/examples/tokenplace.values.dev.yaml`, `test -f docs/examples/tokenplace.values.staging.yaml`, and `test -f docs/examples/tokenplace.values.prod.yaml` — all files exist (PASS). 
- Ran legacy-image scan: `grep -R "ghcr.io/democratizedspace/tokenplace-relay" docs/examples docs/apps apps || true` — found only pre-existing references in old local-chart files (`docs/examples/tokenplace-relay.values.dev.yaml`, `docs/apps/tokenplace-relay.md`, `apps/tokenplace-relay/values.dev.yaml`), and no new files reference the legacy image (EXPECTED). 
- Ensured no new values require an upstream URL: `grep -R "TOKENPLACE_RELAY_UPSTREAM_URL" docs/examples/tokenplace.values.*.yaml && exit 1 || true` — no matches (PASS). 

Notes and follow-ups: `./apps/tokenplace-relay` files remain in the repo for compatibility and are explicitly marked deprecated; subsequent prompts will update justfile recipes and operator docs to prefer the OCI chart and remove or fully replace local-chart wiring. Pre-commit and repo-wide linting were not executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13893667e0832f977f2797021f1c74)