### PR TITLE
Add token.place OCI values/version files and deprecate local tokenplace-relay chart wiring

### DIFF
--- a/apps/tokenplace-relay/README.md
+++ b/apps/tokenplace-relay/README.md
@@ -1,0 +1,13 @@
+# Deprecated local tokenplace-relay chart
+
+This local chart is deprecated for steady-state Sugarkube deployments.
+
+Use the token.place-owned OCI chart and Sugarkube-owned values overlays instead:
+
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Base values: `docs/examples/tokenplace.values.dev.yaml`
+- Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
+- Production overlay: `docs/examples/tokenplace.values.prod.yaml`
+
+The local `apps/tokenplace-relay` chart remains temporarily for migration/reference
+only and should not be preferred by new deployment workflows.

--- a/docs/apps/tokenplace.prod.tag
+++ b/docs/apps/tokenplace.prod.tag
@@ -1,0 +1,3 @@
+# Approved production image tag for token.place relay.
+# Leave empty until a specific immutable tag is promoted.
+# The deploy recipe should require explicit tag=... when this file has no non-comment value.

--- a/docs/apps/tokenplace.version
+++ b/docs/apps/tokenplace.version
@@ -1,0 +1,2 @@
+# Default tokenplace chart version. Update when new token.place chart releases are published.
+0.1.0

--- a/docs/examples/tokenplace.values.dev.yaml
+++ b/docs/examples/tokenplace.values.dev.yaml
@@ -1,0 +1,17 @@
+# Shared token.place relay defaults for Sugarkube. Compose this with an env-specific
+# overlay (staging/prod) using the generic Helm OCI helpers.
+environment: dev
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/tokenplace-relay
+
+ingress:
+  enabled: true
+  className: traefik
+  annotations: {}
+
+env:
+  RELAY_WORKERS: "1"
+  TOKENPLACE_FRONTEND_MODE: production
+  TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH: "0"

--- a/docs/examples/tokenplace.values.prod.yaml
+++ b/docs/examples/tokenplace.values.prod.yaml
@@ -1,0 +1,10 @@
+environment: prod
+
+ingress:
+  enabled: true
+  className: traefik
+  host: token.place
+
+env:
+  TOKEN_PLACE_ENV: production
+  TOKENPLACE_RELAY_PUBLIC_URL: https://token.place

--- a/docs/examples/tokenplace.values.staging.yaml
+++ b/docs/examples/tokenplace.values.staging.yaml
@@ -1,0 +1,10 @@
+environment: staging
+
+ingress:
+  enabled: true
+  className: traefik
+  host: staging.token.place
+
+env:
+  TOKEN_PLACE_ENV: staging
+  TOKENPLACE_RELAY_PUBLIC_URL: https://staging.token.place


### PR DESCRIPTION
### Motivation
- Provide Sugarkube-owned DSPACE-style values/version files so token.place can be deployed from the canonical OCI chart and image instead of the stale local chart.
- Make relay-only deployments safe by supplying conservative defaults (one replica/worker, no required upstream URL) and provide a documented production tag placeholder.
- Mark the local `apps/tokenplace-relay` chart as deprecated for steady-state deployments to avoid accidental use.

### Description
- Added `docs/apps/tokenplace.version` pinned to `0.1.0` with comment header matching the repo version-file style.
- Added `docs/apps/tokenplace.prod.tag` as a documented (comment-only) placeholder for an approved production image tag.
- Added layered DSPACE-style values overlays: `docs/examples/tokenplace.values.dev.yaml`, `docs/examples/tokenplace.values.staging.yaml`, and `docs/examples/tokenplace.values.prod.yaml` with the requested keys and conservative defaults (`replicaCount: 1`, `image.repository: ghcr.io/futuroptimist/tokenplace-relay`, traefik ingress defaults, and the `env` map including `RELAY_WORKERS` and `TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH: "0"`).
- Added `apps/tokenplace-relay/README.md` that clearly deprecates the local chart for steady-state deployments and points operators to the OCI chart `oci://ghcr.io/futuroptimist/charts/tokenplace` and the new values overlays.

### Testing
- Verified presence of new files with: `test -f docs/apps/tokenplace.version && test -f docs/apps/tokenplace.prod.tag && test -f docs/examples/tokenplace.values.dev.yaml && test -f docs/examples/tokenplace.values.staging.yaml && test -f docs/examples/tokenplace.values.prod.yaml`, which succeeded.
- Checked that the new values do not reference the old democratizedspace image or require an upstream URL with: `grep -R "ghcr.io/democratizedspace/tokenplace-relay" docs/examples docs/apps apps || true` and `grep -R "TOKENPLACE_RELAY_UPSTREAM_URL" docs/examples/tokenplace.values.*.yaml && exit 1 || true`; the first command reported legacy occurrences in existing/legacy files (not in the new values), and the second found no matches in the new values (no failures).
- Ran repository checks: attempted `pre-commit run --all-files` but it could not run in this environment because `pre-commit` is not installed (`/bin/bash: pre-commit: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13893667e0832f977f2797021f1c74)