### PR TITLE
Add DSPACE-style tokenplace OCI justfile wrappers

### DIFF
--- a/justfile
+++ b/justfile
@@ -1892,32 +1892,60 @@ tokenplace-status namespace='tokenplace' release='tokenplace' host_key='ingress.
 # Prefer tokenplace-oci-deploy/tokenplace-oci-redeploy for env-aware kubeconfig
 # selection; these generic helpers require explicit values + tag/default_tag to
 # avoid active-kubeconfig environment drift.
-tokenplace-deploy release='tokenplace' namespace='tokenplace' chart='oci://ghcr.io/futuroptimist/charts/tokenplace' values='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml' version_file='docs/apps/tokenplace.version' version='' tag='' default_tag='':
+tokenplace-deploy release='tokenplace' namespace='tokenplace' chart='oci://ghcr.io/futuroptimist/charts/tokenplace' values='' version_file='docs/apps/tokenplace.version' version='' tag='' default_tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    if [ -z "{{ values }}" ] || { [ -z "{{ tag }}" ] && [ -z "{{ default_tag }}" ]; }; then
+    validate_immutable_tag() {
+      local candidate="$(echo "$1" | tr '[:upper:]' '[:lower:]')"
+      if [[ "${candidate}" == *latest* ]] || [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] || [[ "${candidate}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] || [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[^0-9a-f]*$ ]] || [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{1,6}$ ]]; then
+        echo "ERROR: mutable tag '$1' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
+        exit 1
+      fi
+    }
+
+    resolved_tag="$(echo "{{ tag }}" | xargs || true)"
+    resolved_default_tag="$(echo "{{ default_tag }}" | xargs || true)"
+
+    if [ -z "{{ values }}" ] || { [ -z "${resolved_tag}" ] && [ -z "${resolved_default_tag}" ]; }; then
       echo "ERROR: tokenplace-deploy requires explicit values=<...> and tag=<immutable-tag> or default_tag=<immutable-tag>." >&2
       exit 1
     fi
 
+    [ -n "${resolved_tag}" ] && validate_immutable_tag "${resolved_tag}"
+    [ -n "${resolved_default_tag}" ] && validate_immutable_tag "${resolved_default_tag}"
+
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='{{ release }}' namespace='{{ namespace }}' chart='{{ chart }}' values='{{ values }}' \
-      version_file='{{ version_file }}' version='{{ version }}' tag='{{ tag }}' default_tag='{{ default_tag }}'
+      version_file='{{ version_file }}' version='{{ version }}' tag='${resolved_tag}' default_tag='${resolved_default_tag}'
 
 # Upgrade-only path for existing token.place releases.
-tokenplace-upgrade release='tokenplace' namespace='tokenplace' chart='oci://ghcr.io/futuroptimist/charts/tokenplace' values='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml' version_file='docs/apps/tokenplace.version' version='' tag='' default_tag='':
+tokenplace-upgrade release='tokenplace' namespace='tokenplace' chart='oci://ghcr.io/futuroptimist/charts/tokenplace' values='' version_file='docs/apps/tokenplace.version' version='' tag='' default_tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    if [ -z "{{ values }}" ] || { [ -z "{{ tag }}" ] && [ -z "{{ default_tag }}" ]; }; then
+    validate_immutable_tag() {
+      local candidate="$(echo "$1" | tr '[:upper:]' '[:lower:]')"
+      if [[ "${candidate}" == *latest* ]] || [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] || [[ "${candidate}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] || [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[^0-9a-f]*$ ]] || [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{1,6}$ ]]; then
+        echo "ERROR: mutable tag '$1' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
+        exit 1
+      fi
+    }
+
+    resolved_tag="$(echo "{{ tag }}" | xargs || true)"
+    resolved_default_tag="$(echo "{{ default_tag }}" | xargs || true)"
+
+    if [ -z "{{ values }}" ] || { [ -z "${resolved_tag}" ] && [ -z "${resolved_default_tag}" ]; }; then
       echo "ERROR: tokenplace-upgrade requires explicit values=<...> and tag=<immutable-tag> or default_tag=<immutable-tag>." >&2
       exit 1
     fi
 
+    [ -n "${resolved_tag}" ] && validate_immutable_tag "${resolved_tag}"
+    [ -n "${resolved_default_tag}" ] && validate_immutable_tag "${resolved_default_tag}"
+
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release='{{ release }}' namespace='{{ namespace }}' chart='{{ chart }}' values='{{ values }}' \
-      version_file='{{ version_file }}' version='{{ version }}' tag='{{ tag }}' default_tag='{{ default_tag }}'
+      version_file='{{ version_file }}' version='{{ version }}' tag='${resolved_tag}' default_tag='${resolved_default_tag}'
 
 tokenplace-rollback release='tokenplace' namespace='tokenplace' revision='':
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -1899,7 +1899,7 @@ tokenplace-deploy release='tokenplace' namespace='tokenplace' chart='oci://ghcr.
 
     validate_immutable_tag() {
       local candidate="$(echo "$1" | tr '[:upper:]' '[:lower:]')"
-      if [[ "${candidate}" == *latest* ]] || [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] || [[ "${candidate}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] || [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[^0-9a-f]*$ ]] || [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{1,6}$ ]]; then
+      if [[ "${candidate}" == *latest* ]] || [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] || [[ "${candidate}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] || { [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] && ! [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]; }; then
         echo "ERROR: mutable tag '$1' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
         exit 1
       fi
@@ -1918,7 +1918,7 @@ tokenplace-deploy release='tokenplace' namespace='tokenplace' chart='oci://ghcr.
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='{{ release }}' namespace='{{ namespace }}' chart='{{ chart }}' values='{{ values }}' \
-      version_file='{{ version_file }}' version='{{ version }}' tag='${resolved_tag}' default_tag='${resolved_default_tag}'
+      version_file='{{ version_file }}' version='{{ version }}' tag="${resolved_tag}" default_tag="${resolved_default_tag}"
 
 # Upgrade-only path for existing token.place releases.
 tokenplace-upgrade release='tokenplace' namespace='tokenplace' chart='oci://ghcr.io/futuroptimist/charts/tokenplace' values='' version_file='docs/apps/tokenplace.version' version='' tag='' default_tag='':
@@ -1927,7 +1927,7 @@ tokenplace-upgrade release='tokenplace' namespace='tokenplace' chart='oci://ghcr
 
     validate_immutable_tag() {
       local candidate="$(echo "$1" | tr '[:upper:]' '[:lower:]')"
-      if [[ "${candidate}" == *latest* ]] || [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] || [[ "${candidate}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] || [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[^0-9a-f]*$ ]] || [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{1,6}$ ]]; then
+      if [[ "${candidate}" == *latest* ]] || [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] || [[ "${candidate}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] || { [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] && ! [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]; }; then
         echo "ERROR: mutable tag '$1' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
         exit 1
       fi
@@ -1946,7 +1946,7 @@ tokenplace-upgrade release='tokenplace' namespace='tokenplace' chart='oci://ghcr
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release='{{ release }}' namespace='{{ namespace }}' chart='{{ chart }}' values='{{ values }}' \
-      version_file='{{ version_file }}' version='{{ version }}' tag='${resolved_tag}' default_tag='${resolved_default_tag}'
+      version_file='{{ version_file }}' version='{{ version }}' tag="${resolved_tag}" default_tag="${resolved_default_tag}"
 
 tokenplace-rollback release='tokenplace' namespace='tokenplace' revision='':
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -1608,7 +1608,7 @@ dspace-oci-redeploy env='staging' tag='':
       values_chain="${values_chain},${overlay}"
     fi
 
-    # NOTE: Prompt 7 is tokenplace-scoped; leave existing dspace kubeconfig behavior unchanged here.
+    # NOTE: This tokenplace-scoped change intentionally leaves dspace kubeconfig behavior unchanged here.
     # If dspace needs env-scoped kubeconfig selection before Helm, handle that in a separate DSPACE PR.
     deploy_tag="{{ tag }}"
     default_tag_value=""

--- a/justfile
+++ b/justfile
@@ -1891,6 +1891,7 @@ tokenplace-status namespace='tokenplace' release='tokenplace' host_key='ingress.
 # Install-or-upgrade token.place via configurable Helm OCI wiring.
 # Prefer tokenplace-oci-deploy/tokenplace-oci-redeploy for env-aware kubeconfig
 # selection; these generic helpers require explicit values + tag/default_tag to
+
 # avoid active-kubeconfig environment drift.
 tokenplace-deploy release='tokenplace' namespace='tokenplace' chart='oci://ghcr.io/futuroptimist/charts/tokenplace' values='' version_file='docs/apps/tokenplace.version' version='' tag='' default_tag='':
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -1480,7 +1480,7 @@ dspace-oci-deploy env='staging' tag='':
     fi
 
     export KUBECONFIG="${HOME}/.kube/config"
-    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "prod"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='dspace' namespace='dspace' \

--- a/justfile
+++ b/justfile
@@ -1622,9 +1622,6 @@ dspace-oci-redeploy env='staging' tag='':
       default_tag_value="main-latest"
     fi
 
-    export KUBECONFIG="${HOME}/.kube/config"
-    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
-
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release='dspace' namespace='dspace' \
       chart='oci://ghcr.io/democratizedspace/charts/dspace' \
@@ -1899,7 +1896,15 @@ tokenplace-deploy release='tokenplace' namespace='tokenplace' chart='oci://ghcr.
 
     validate_immutable_tag() {
       local candidate="$(echo "$1" | tr '[:upper:]' '[:lower:]')"
-      if [[ "${candidate}" == *latest* ]] || [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] || [[ "${candidate}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] || { [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] && ! [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]; }; then
+      # Branch-prefixed tags are allowed only as branch-<7+ hex SHA>; branch
+      # names or branch-like moving tags stay rejected.
+      if [[ "${candidate}" == *latest* ]] ||
+        [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] ||
+        [[ "${candidate}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] ||
+        {
+          [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] &&
+            ! [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]
+        }; then
         echo "ERROR: mutable tag '$1' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
         exit 1
       fi
@@ -1927,7 +1932,15 @@ tokenplace-upgrade release='tokenplace' namespace='tokenplace' chart='oci://ghcr
 
     validate_immutable_tag() {
       local candidate="$(echo "$1" | tr '[:upper:]' '[:lower:]')"
-      if [[ "${candidate}" == *latest* ]] || [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] || [[ "${candidate}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] || { [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] && ! [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]; }; then
+      # Branch-prefixed tags are allowed only as branch-<7+ hex SHA>; branch
+      # names or branch-like moving tags stay rejected.
+      if [[ "${candidate}" == *latest* ]] ||
+        [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] ||
+        [[ "${candidate}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] ||
+        {
+          [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] &&
+            ! [[ "${candidate}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]
+        }; then
         echo "ERROR: mutable tag '$1' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
         exit 1
       fi

--- a/justfile
+++ b/justfile
@@ -1480,7 +1480,7 @@ dspace-oci-deploy env='staging' tag='':
     fi
 
     export KUBECONFIG="${HOME}/.kube/config"
-    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "prod"
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='dspace' namespace='dspace' \
@@ -1544,7 +1544,7 @@ dspace-oci-deploy-prod-subdomain tag='':
     fi
 
     export KUBECONFIG="${HOME}/.kube/config"
-    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "prod"
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='dspace' namespace='dspace' \

--- a/justfile
+++ b/justfile
@@ -1479,9 +1479,6 @@ dspace-oci-deploy env='staging' tag='':
       export KUBECONFIG="${HOME}/.kube/config"
     fi
 
-    export KUBECONFIG="${HOME}/.kube/config"
-    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
-
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='dspace' namespace='dspace' \
       chart='oci://ghcr.io/democratizedspace/charts/dspace' \
@@ -1542,9 +1539,6 @@ dspace-oci-deploy-prod-subdomain tag='':
     if [ -z "${KUBECONFIG:-}" ]; then
       export KUBECONFIG="${HOME}/.kube/config"
     fi
-
-    export KUBECONFIG="${HOME}/.kube/config"
-    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "prod"
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='dspace' namespace='dspace' \
@@ -1743,16 +1737,26 @@ tokenplace-oci-deploy env='staging' tag='':
         ;;
     esac
 
+    # Shared immutable-tag guard for deploy/redeploy paths avoids moving-target tags.
+    validate_immutable_tag() {
+      local candidate="${1}"
+      local tag_lc
+      tag_lc="$(echo "${candidate}" | tr '[:upper:]' '[:lower:]')"
+      if [[ "${tag_lc}" == *latest* ]] \
+        || [[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] \
+        || [[ "${tag_lc}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] \
+        || ([[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] && [[ ! "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]); then
+        echo "ERROR: mutable tag '${candidate}' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
+        exit 1
+      fi
+    }
+
     resolved_tag="$(echo '{{ tag }}' | xargs)"
     if [ -z "${resolved_tag}" ]; then
       echo "ERROR: tag is required for immutable deploys." >&2
       exit 1
     fi
-    tag_lc="$(echo "${resolved_tag}" | tr '[:upper:]' '[:lower:]')"
-    if [[ "${tag_lc}" == *latest* ]] || [ "${tag_lc}" = "main" ] || [[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] || [[ "${tag_lc}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]]; then
-      echo "ERROR: mutable tag '${resolved_tag}' is not allowed. Use an immutable branch-sha tag." >&2
-      exit 1
-    fi
+    validate_immutable_tag "${resolved_tag}"
 
     values_chain='docs/examples/tokenplace.values.dev.yaml'
     if [ "${env_name}" = "staging" ]; then
@@ -1761,6 +1765,9 @@ tokenplace-oci-deploy env='staging' tag='':
       values_chain='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml'
     fi
 
+    # Intentional: tokenplace OCI wrappers select kubeconfig from env before Helm
+    # so prod/staging values cannot be applied to an unrelated active context.
+    # This is tokenplace-scoped; do not copy into DSPACE from this PR.
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
 
@@ -1791,9 +1798,11 @@ tokenplace-oci-promote-prod tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
+    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.prod.tag | head -n1 | tr -d '[:space:]'; }
+
     resolved_tag="$(echo '{{ tag }}' | xargs)"
     if [ -z "${resolved_tag}" ]; then
-      resolved_tag="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.prod.tag 2>/dev/null | head -n1 | xargs || true)"
+      resolved_tag="$(read_prod_tag 2>/dev/null || true)"
     fi
     if [ -z "${resolved_tag}" ]; then
       echo "ERROR: provide tag=<immutable-tag> or set docs/apps/tokenplace.prod.tag." >&2
@@ -1820,28 +1829,44 @@ tokenplace-oci-redeploy env='staging' tag='':
         ;;
     esac
 
-    resolved_tag="$(echo '{{ tag }}' | xargs)"
-    if [ -z "${resolved_tag}" ] && [ "${env_name}" = "prod" ]; then
-      resolved_tag="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.prod.tag 2>/dev/null | head -n1 | xargs || true)"
-      [ -n "${resolved_tag}" ] || { echo "ERROR: prod requires tag=<immutable-tag> or docs/apps/tokenplace.prod.tag." >&2; exit 1; }
-    fi
-    if [ -n "${resolved_tag}" ]; then
-      tag_lc="$(echo "${resolved_tag}" | tr '[:upper:]' '[:lower:]')"
-      if [[ "${tag_lc}" == *latest* ]] || [ "${tag_lc}" = "main" ] || [[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] || [[ "${tag_lc}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]]; then
-        echo "ERROR: mutable tag '${resolved_tag}' is not allowed. Use an immutable branch-sha tag." >&2
+    # Shared immutable-tag guard for deploy/redeploy paths avoids moving-target tags.
+    validate_immutable_tag() {
+      local candidate="${1}"
+      local tag_lc
+      tag_lc="$(echo "${candidate}" | tr '[:upper:]' '[:lower:]')"
+      if [[ "${tag_lc}" == *latest* ]] \
+        || [[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] \
+        || [[ "${tag_lc}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] \
+        || ([[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] && [[ ! "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]); then
+        echo "ERROR: mutable tag '${candidate}' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
         exit 1
       fi
+    }
+    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.prod.tag | head -n1 | tr -d '[:space:]'; }
+
+    resolved_tag="$(echo '{{ tag }}' | xargs)"
+    if [ -z "${resolved_tag}" ] && [ "${env_name}" = "prod" ]; then
+      resolved_tag="$(read_prod_tag 2>/dev/null || true)"
+      [ -n "${resolved_tag}" ] || { echo "ERROR: prod requires tag=<immutable-tag> or docs/apps/tokenplace.prod.tag." >&2; exit 1; }
     fi
+    if [ "${env_name}" != "prod" ] && [ -z "${resolved_tag}" ]; then
+      echo "ERROR: env=${env_name} redeploy requires explicit tag=<immutable-tag>." >&2
+      echo "Non-prod redeploy intentionally has no baked-in fallback tag so this path is reproducible and reviewable." >&2
+      exit 1
+    fi
+    [ -n "${resolved_tag}" ] && validate_immutable_tag "${resolved_tag}"
 
     values_chain='docs/examples/tokenplace.values.dev.yaml'
     default_tag=''
     if [ "${env_name}" = "staging" ]; then
       values_chain='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml'
-      default_tag='main-684fd7f'
     elif [ "${env_name}" = "prod" ]; then
       values_chain='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml'
     fi
 
+    # Intentional: tokenplace OCI wrappers select kubeconfig from env before Helm
+    # so prod/staging values cannot be applied to an unrelated active context.
+    # This is tokenplace-scoped; do not copy into DSPACE from this PR.
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
 
@@ -1864,14 +1889,15 @@ tokenplace-status namespace='tokenplace' release='tokenplace' host_key='ingress.
     @just app-status namespace='{{ namespace }}' release='{{ release }}' host_key='{{ host_key }}'
 
 # Install-or-upgrade token.place via configurable Helm OCI wiring.
-
-# Uses helm upgrade --install underneath via the shared helper.
+# Prefer tokenplace-oci-deploy/tokenplace-oci-redeploy for env-aware kubeconfig
+# selection; these generic helpers require explicit values + tag/default_tag to
+# avoid active-kubeconfig environment drift.
 tokenplace-deploy release='tokenplace' namespace='tokenplace' chart='oci://ghcr.io/futuroptimist/charts/tokenplace' values='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml' version_file='docs/apps/tokenplace.version' version='' tag='' default_tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    if [ -z "{{ tag }}" ] && [ -z "{{ default_tag }}" ]; then
-      echo "ERROR: tokenplace-deploy requires tag=<immutable-tag> or default_tag=<immutable-tag>." >&2
+    if [ -z "{{ values }}" ] || { [ -z "{{ tag }}" ] && [ -z "{{ default_tag }}" ]; }; then
+      echo "ERROR: tokenplace-deploy requires explicit values=<...> and tag=<immutable-tag> or default_tag=<immutable-tag>." >&2
       exit 1
     fi
 
@@ -1884,8 +1910,8 @@ tokenplace-upgrade release='tokenplace' namespace='tokenplace' chart='oci://ghcr
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    if [ -z "{{ tag }}" ] && [ -z "{{ default_tag }}" ]; then
-      echo "ERROR: tokenplace-upgrade requires tag=<immutable-tag> or default_tag=<immutable-tag>." >&2
+    if [ -z "{{ values }}" ] || { [ -z "{{ tag }}" ] && [ -z "{{ default_tag }}" ]; }; then
+      echo "ERROR: tokenplace-upgrade requires explicit values=<...> and tag=<immutable-tag> or default_tag=<immutable-tag>." >&2
       exit 1
     fi
 

--- a/justfile
+++ b/justfile
@@ -1608,6 +1608,8 @@ dspace-oci-redeploy env='staging' tag='':
       values_chain="${values_chain},${overlay}"
     fi
 
+    # NOTE: Prompt 7 is tokenplace-scoped; leave existing dspace kubeconfig behavior unchanged here.
+    # If dspace needs env-scoped kubeconfig selection before Helm, handle that in a separate DSPACE PR.
     deploy_tag="{{ tag }}"
     default_tag_value=""
     if [ "${env_name}" = "prod" ]; then

--- a/justfile
+++ b/justfile
@@ -1479,6 +1479,9 @@ dspace-oci-deploy env='staging' tag='':
       export KUBECONFIG="${HOME}/.kube/config"
     fi
 
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='dspace' namespace='dspace' \
       chart='oci://ghcr.io/democratizedspace/charts/dspace' \
@@ -1539,6 +1542,9 @@ dspace-oci-deploy-prod-subdomain tag='':
     if [ -z "${KUBECONFIG:-}" ]; then
       export KUBECONFIG="${HOME}/.kube/config"
     fi
+
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='dspace' namespace='dspace' \
@@ -1621,6 +1627,9 @@ dspace-oci-redeploy env='staging' tag='':
     else
       default_tag_value="main-latest"
     fi
+
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release='dspace' namespace='dspace' \
@@ -1734,12 +1743,13 @@ tokenplace-oci-deploy env='staging' tag='':
         ;;
     esac
 
-    resolved_tag='{{ tag }}'
+    resolved_tag="$(echo '{{ tag }}' | xargs)"
     if [ -z "${resolved_tag}" ]; then
       echo "ERROR: tag is required for immutable deploys." >&2
       exit 1
     fi
-    if [[ "${resolved_tag}" == *latest* ]] || [ "${resolved_tag}" = "main" ] || [[ "${resolved_tag}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] || [[ "${resolved_tag}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]]; then
+    tag_lc="$(echo "${resolved_tag}" | tr '[:upper:]' '[:lower:]')"
+    if [[ "${tag_lc}" == *latest* ]] || [ "${tag_lc}" = "main" ] || [[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] || [[ "${tag_lc}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]]; then
       echo "ERROR: mutable tag '${resolved_tag}' is not allowed. Use an immutable branch-sha tag." >&2
       exit 1
     fi
@@ -1750,6 +1760,9 @@ tokenplace-oci-deploy env='staging' tag='':
     elif [ "${env_name}" = "prod" ]; then
       values_chain='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml'
     fi
+
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='tokenplace' namespace='tokenplace' \
@@ -1778,9 +1791,9 @@ tokenplace-oci-promote-prod tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    resolved_tag='{{ tag }}'
+    resolved_tag="$(echo '{{ tag }}' | xargs)"
     if [ -z "${resolved_tag}" ]; then
-      resolved_tag="$(awk 'NF && $1 !~ /^#/ {print; exit}' docs/apps/tokenplace.prod.tag 2>/dev/null || true)"
+      resolved_tag="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.prod.tag 2>/dev/null | head -n1 | xargs || true)"
     fi
     if [ -z "${resolved_tag}" ]; then
       echo "ERROR: provide tag=<immutable-tag> or set docs/apps/tokenplace.prod.tag." >&2
@@ -1807,10 +1820,17 @@ tokenplace-oci-redeploy env='staging' tag='':
         ;;
     esac
 
-    resolved_tag='{{ tag }}'
+    resolved_tag="$(echo '{{ tag }}' | xargs)"
     if [ -z "${resolved_tag}" ] && [ "${env_name}" = "prod" ]; then
-      resolved_tag="$(awk 'NF && $1 !~ /^#/ {print; exit}' docs/apps/tokenplace.prod.tag 2>/dev/null || true)"
+      resolved_tag="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.prod.tag 2>/dev/null | head -n1 | xargs || true)"
       [ -n "${resolved_tag}" ] || { echo "ERROR: prod requires tag=<immutable-tag> or docs/apps/tokenplace.prod.tag." >&2; exit 1; }
+    fi
+    if [ -n "${resolved_tag}" ]; then
+      tag_lc="$(echo "${resolved_tag}" | tr '[:upper:]' '[:lower:]')"
+      if [[ "${tag_lc}" == *latest* ]] || [ "${tag_lc}" = "main" ] || [[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] || [[ "${tag_lc}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]]; then
+        echo "ERROR: mutable tag '${resolved_tag}' is not allowed. Use an immutable branch-sha tag." >&2
+        exit 1
+      fi
     fi
 
     values_chain='docs/examples/tokenplace.values.dev.yaml'
@@ -1821,6 +1841,9 @@ tokenplace-oci-redeploy env='staging' tag='':
     elif [ "${env_name}" = "prod" ]; then
       values_chain='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml'
     fi
+
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release='tokenplace' namespace='tokenplace' \
@@ -1847,6 +1870,11 @@ tokenplace-deploy release='tokenplace' namespace='tokenplace' chart='oci://ghcr.
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
+    if [ -z "{{ tag }}" ] && [ -z "{{ default_tag }}" ]; then
+      echo "ERROR: tokenplace-deploy requires tag=<immutable-tag> or default_tag=<immutable-tag>." >&2
+      exit 1
+    fi
+
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='{{ release }}' namespace='{{ namespace }}' chart='{{ chart }}' values='{{ values }}' \
       version_file='{{ version_file }}' version='{{ version }}' tag='{{ tag }}' default_tag='{{ default_tag }}'
@@ -1855,6 +1883,11 @@ tokenplace-deploy release='tokenplace' namespace='tokenplace' chart='oci://ghcr.
 tokenplace-upgrade release='tokenplace' namespace='tokenplace' chart='oci://ghcr.io/futuroptimist/charts/tokenplace' values='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml' version_file='docs/apps/tokenplace.version' version='' tag='' default_tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
+
+    if [ -z "{{ tag }}" ] && [ -z "{{ default_tag }}" ]; then
+      echo "ERROR: tokenplace-upgrade requires tag=<immutable-tag> or default_tag=<immutable-tag>." >&2
+      exit 1
+    fi
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release='{{ release }}' namespace='{{ namespace }}' chart='{{ chart }}' values='{{ values }}' \
@@ -1905,18 +1938,18 @@ tokenplace-debug-logs namespace='tokenplace':
     kubectl get pods -n "${ns}" -o wide || true
 
     selector='app.kubernetes.io/name=tokenplace'
-    relay_pods="$(kubectl get pods -n "${ns}" -l "${selector}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)"
-    if [ -z "${relay_pods}" ]; then
+    tokenplace_pods="$(kubectl get pods -n "${ns}" -l "${selector}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)"
+    if [ -z "${tokenplace_pods}" ]; then
       selector='app.kubernetes.io/instance=tokenplace'
-      relay_pods="$(kubectl get pods -n "${ns}" -l "${selector}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)"
+      tokenplace_pods="$(kubectl get pods -n "${ns}" -l "${selector}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)"
     fi
 
     echo
     echo "=== token.place logs (last 200 lines per pod, selector: ${selector}) ==="
-    if [ -z "${relay_pods}" ]; then
+    if [ -z "${tokenplace_pods}" ]; then
       echo "No pods found with supported token.place selectors in namespace ${ns}" >&2
     else
-      for pod in ${relay_pods}; do
+      for pod in ${tokenplace_pods}; do
         echo
         echo "--- pod: ${pod} ---"
         kubectl logs -n "${ns}" "${pod}" --tail='200' || true
@@ -1955,12 +1988,12 @@ tokenplace-logs namespace='tokenplace' selector='app.kubernetes.io/name=tokenpla
 
     echo
     echo "=== token.place logs (last {{ tail }} lines per pod, selector: ${selector}) ==="
-    relay_pods=$(kubectl get pods -n "${ns}" -l "${selector}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
+    tokenplace_pods=$(kubectl get pods -n "${ns}" -l "${selector}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
 
-    if [ -z "${relay_pods}" ]; then
+    if [ -z "${tokenplace_pods}" ]; then
       echo "No pods found with selector {{ selector }} in namespace ${ns}" >&2
     else
-      for pod in ${relay_pods}; do
+      for pod in ${tokenplace_pods}; do
         echo
         echo "--- pod: ${pod} ---"
         kubectl logs -n "${ns}" "${pod}" --tail='{{ tail }}' || {

--- a/justfile
+++ b/justfile
@@ -1716,75 +1716,151 @@ dspace-debug-logs-env env='staging' namespace='dspace':
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
     just --justfile "{{ justfile_directory() }}/justfile" dspace-debug-logs namespace="{{ namespace }}"
 
-# Fast redeploy of token.place relay from GHCR.
-# The default tag pins staging to a vetted immutable SHA build; pass tag=sha-<shortsha>
-# after promoting a fresh image.
-
-# See docs/apps/tokenplace-relay.md for relay-specific operations.
-tokenplace-oci-redeploy tag='':
+# Install-or-upgrade token.place from OCI chart with immutable tag policy.
+tokenplace-oci-deploy env='staging' tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
-      release='tokenplace-relay' namespace='tokenplace' \
-      chart='./apps/tokenplace-relay' \
-      values='apps/tokenplace-relay/values.dev.yaml,apps/tokenplace-relay/values.staging.yaml' \
-      version_file='' \
-      tag='{{ tag }}' default_tag='sha-684fd7f'
+    env_input={{ quote(env) }}
+    env_name="${env_input}"
+    while [ "${env_name#env=}" != "${env_name}" ]; do
+        env_name="${env_name#env=}"
+    done
+    case "${env_name}" in
+      dev|staging|prod) ;;
+      *)
+        echo "ERROR: env must be one of dev|staging|prod." >&2
+        exit 1
+        ;;
+    esac
 
-    scripts/ensure_user_kubeconfig.sh || true
-    if [ -z "${KUBECONFIG:-}" ]; then
-      export KUBECONFIG="${HOME}/.kube/config"
+    resolved_tag='{{ tag }}'
+    if [ -z "${resolved_tag}" ]; then
+      echo "ERROR: tag is required for immutable deploys." >&2
+      exit 1
     fi
-
-    echo "Waiting for tokenplace-relay rollout to complete (timeout: 120s)..."
-    if ! kubectl -n tokenplace rollout status deploy/tokenplace-relay --timeout=120s; then
-      echo "ERROR: tokenplace-relay rollout did not complete successfully." >&2
+    if [[ "${resolved_tag}" == *latest* ]] || [ "${resolved_tag}" = "main" ] || [[ "${resolved_tag}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] || [[ "${resolved_tag}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]]; then
+      echo "ERROR: mutable tag '${resolved_tag}' is not allowed. Use an immutable branch-sha tag." >&2
       exit 1
     fi
 
-    echo "token.place relay available at: https://staging.token.place"
+    values_chain='docs/examples/tokenplace.values.dev.yaml'
+    if [ "${env_name}" = "staging" ]; then
+      values_chain='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml'
+    elif [ "${env_name}" = "prod" ]; then
+      values_chain='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml'
+    fi
+
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
+      release='tokenplace' namespace='tokenplace' \
+      chart='oci://ghcr.io/futuroptimist/charts/tokenplace' \
+      values="${values_chain}" \
+      version_file='docs/apps/tokenplace.version' \
+      tag="${resolved_tag}"
+
+    scripts/ensure_user_kubeconfig.sh || true
+    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+
+    echo
+    echo "Resolved images for deployment/tokenplace:"
+    kubectl -n tokenplace get deploy/tokenplace -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"="}{.image}{"\n"}{end}' || true
+
+    ingress_host="$(kubectl -n tokenplace get ingress -o jsonpath='{.items[0].spec.rules[0].host}' 2>/dev/null || true)"
+    if [ -n "${ingress_host}" ]; then
+      echo
+      echo "Post-deploy checks:"
+      echo "  curl -fsS https://${ingress_host}/"
+      echo "  curl -fsS https://${ingress_host}/livez"
+      echo "  curl -fsS https://${ingress_host}/healthz"
+    fi
+
+tokenplace-oci-promote-prod tag='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    resolved_tag='{{ tag }}'
+    if [ -z "${resolved_tag}" ]; then
+      resolved_tag="$(awk 'NF && $1 !~ /^#/ {print; exit}' docs/apps/tokenplace.prod.tag 2>/dev/null || true)"
+    fi
+    if [ -z "${resolved_tag}" ]; then
+      echo "ERROR: provide tag=<immutable-tag> or set docs/apps/tokenplace.prod.tag." >&2
+      exit 1
+    fi
+
+    just --justfile "{{ justfile_directory() }}/justfile" tokenplace-oci-deploy env=prod tag="${resolved_tag}"
+
+# Upgrade-only token.place OCI redeploy path.
+tokenplace-oci-redeploy env='staging' tag='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    env_input={{ quote(env) }}
+    env_name="${env_input}"
+    while [ "${env_name#env=}" != "${env_name}" ]; do
+        env_name="${env_name#env=}"
+    done
+    case "${env_name}" in
+      dev|staging|prod) ;;
+      *)
+        echo "ERROR: env must be one of dev|staging|prod." >&2
+        exit 1
+        ;;
+    esac
+
+    resolved_tag='{{ tag }}'
+    if [ -z "${resolved_tag}" ] && [ "${env_name}" = "prod" ]; then
+      resolved_tag="$(awk 'NF && $1 !~ /^#/ {print; exit}' docs/apps/tokenplace.prod.tag 2>/dev/null || true)"
+      [ -n "${resolved_tag}" ] || { echo "ERROR: prod requires tag=<immutable-tag> or docs/apps/tokenplace.prod.tag." >&2; exit 1; }
+    fi
+
+    values_chain='docs/examples/tokenplace.values.dev.yaml'
+    default_tag=''
+    if [ "${env_name}" = "staging" ]; then
+      values_chain='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml'
+      default_tag='main-684fd7f'
+    elif [ "${env_name}" = "prod" ]; then
+      values_chain='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml'
+    fi
+
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
+      release='tokenplace' namespace='tokenplace' \
+      chart='oci://ghcr.io/futuroptimist/charts/tokenplace' \
+      values="${values_chain}" \
+      version_file='docs/apps/tokenplace.version' \
+      tag="${resolved_tag}" default_tag="${default_tag}"
+
+    scripts/ensure_user_kubeconfig.sh || true
+    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+    kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
 
 # token.place app status helper (generic/parameterized defaults, not final release wiring).
 # Override namespace/release/host_key per environment until onboarding locks chart naming.
 
 # See docs/tokenplace_sugarkube_onboarding.md and docs/apps/tokenplace.md.
-tokenplace-status namespace='tokenplace' release='tokenplace-relay' host_key='ingress.host':
+tokenplace-status namespace='tokenplace' release='tokenplace' host_key='ingress.host':
     @just app-status namespace='{{ namespace }}' release='{{ release }}' host_key='{{ host_key }}'
 
 # Install-or-upgrade token.place via configurable Helm OCI wiring.
 
 # Uses helm upgrade --install underneath via the shared helper.
-tokenplace-deploy release='' namespace='' chart='' values='' version_file='' version='' tag='' default_tag='':
+tokenplace-deploy release='tokenplace' namespace='tokenplace' chart='oci://ghcr.io/futuroptimist/charts/tokenplace' values='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml' version_file='docs/apps/tokenplace.version' version='' tag='' default_tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
-
-    if [ -z '{{ release }}' ] || [ -z '{{ namespace }}' ] || [ -z '{{ chart }}' ] || [ -z '{{ values }}' ]; then
-      echo "Usage: just tokenplace-deploy release=<name> namespace=<ns> chart=<oci|path> values=<file1,file2>" >&2
-      echo "See docs/tokenplace_sugarkube_onboarding.md for expected parameter wiring." >&2
-      exit 1
-    fi
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='{{ release }}' namespace='{{ namespace }}' chart='{{ chart }}' values='{{ values }}' \
       version_file='{{ version_file }}' version='{{ version }}' tag='{{ tag }}' default_tag='{{ default_tag }}'
 
 # Upgrade-only path for existing token.place releases.
-tokenplace-upgrade release='' namespace='' chart='' values='' version_file='' version='' tag='' default_tag='':
+tokenplace-upgrade release='tokenplace' namespace='tokenplace' chart='oci://ghcr.io/futuroptimist/charts/tokenplace' values='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml' version_file='docs/apps/tokenplace.version' version='' tag='' default_tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
-
-    if [ -z '{{ release }}' ] || [ -z '{{ namespace }}' ] || [ -z '{{ chart }}' ] || [ -z '{{ values }}' ]; then
-      echo "Usage: just tokenplace-upgrade release=<name> namespace=<ns> chart=<oci|path> values=<file1,file2>" >&2
-      echo "See docs/tokenplace_sugarkube_onboarding.md for expected parameter wiring." >&2
-      exit 1
-    fi
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release='{{ release }}' namespace='{{ namespace }}' chart='{{ chart }}' values='{{ values }}' \
       version_file='{{ version_file }}' version='{{ version }}' tag='{{ tag }}' default_tag='{{ default_tag }}'
 
-tokenplace-rollback release='' namespace='' revision='':
+tokenplace-rollback release='tokenplace' namespace='tokenplace' revision='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1818,7 +1894,53 @@ tokenplace-rollback release='' namespace='' revision='':
       kubectl -n "${ns}" rollout status "${workload}" --timeout=180s
     done <<< "${workloads}"
 
-tokenplace-logs namespace='tokenplace' selector='app.kubernetes.io/name=tokenplace-relay' tail='200':
+tokenplace-debug-logs namespace='tokenplace':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+    ns="{{ namespace }}"
+
+    echo "=== token.place pods in namespace ${ns} ==="
+    kubectl get pods -n "${ns}" -o wide || true
+
+    selector='app.kubernetes.io/name=tokenplace'
+    relay_pods="$(kubectl get pods -n "${ns}" -l "${selector}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)"
+    if [ -z "${relay_pods}" ]; then
+      selector='app.kubernetes.io/instance=tokenplace'
+      relay_pods="$(kubectl get pods -n "${ns}" -l "${selector}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)"
+    fi
+
+    echo
+    echo "=== token.place logs (last 200 lines per pod, selector: ${selector}) ==="
+    if [ -z "${relay_pods}" ]; then
+      echo "No pods found with supported token.place selectors in namespace ${ns}" >&2
+    else
+      for pod in ${relay_pods}; do
+        echo
+        echo "--- pod: ${pod} ---"
+        kubectl logs -n "${ns}" "${pod}" --tail='200' || true
+      done
+    fi
+
+    echo
+    echo "=== Traefik logs (last 200 lines) ==="
+    kubectl logs -n kube-system -l app.kubernetes.io/name=traefik --tail=200 || true
+
+tokenplace-debug-logs-env env='staging' namespace='tokenplace':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    env_input={{ quote(env) }}
+    env_name="${env_input}"
+    while [ "${env_name#env=}" != "${env_name}" ]; do
+        env_name="${env_name#env=}"
+    done
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+    just --justfile "{{ justfile_directory() }}/justfile" tokenplace-debug-logs namespace="{{ namespace }}"
+
+tokenplace-logs namespace='tokenplace' selector='app.kubernetes.io/name=tokenplace' tail='200':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1850,7 +1972,7 @@ tokenplace-logs namespace='tokenplace' selector='app.kubernetes.io/name=tokenpla
 # Validation helper keeps generic defaults as placeholders; set selector/release/health_url per deployment.
 
 # Do not treat tokenplace-relay defaults here as final token.place production naming.
-tokenplace-validate namespace='tokenplace' release='tokenplace-relay' health_url='' selector='app.kubernetes.io/name=tokenplace-relay':
+tokenplace-validate namespace='tokenplace' release='tokenplace' health_url='' selector='app.kubernetes.io/name=tokenplace':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1869,7 +1991,7 @@ tokenplace-validate namespace='tokenplace' release='tokenplace-relay' health_url
 # Port-forward helper uses placeholder defaults for convenience; override service/ports for real app components.
 
 # Keep this recipe generic while token.place release/service naming is still being finalized.
-tokenplace-port-forward namespace='tokenplace' service='tokenplace-relay' local_port='5010' remote_port='80':
+tokenplace-port-forward namespace='tokenplace' service='tokenplace' local_port='5010' remote_port='80':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 


### PR DESCRIPTION
### Motivation
- Provide DSPACE-like `just` recipes to deploy `tokenplace` from the canonical GHCR OCI chart while preserving existing `helm-oci-install`/`helm-oci-upgrade` helpers. 
- Enforce immutable-tag deployment semantics for staging/prod and normalize `env=` invocation styles to match other DSPACE wrappers. 
- Replace or deprecate the local `./apps/tokenplace-relay` preferred-path wiring and make generic tokenplace recipe defaults consistent with the canonical release/namespace naming.

### Description
- Added `tokenplace-oci-deploy env='staging' tag=''` which normalizes `env=env=...`, rejects empty or mutable tags (e.g. `latest`, `main`, branch-like tags), computes the env-specific values chain, and calls `helm-oci-install` with `release='tokenplace'`, `namespace='tokenplace'`, `chart='oci://ghcr.io/futuroptimist/charts/tokenplace'`, and `version_file='docs/apps/tokenplace.version'`, then prints resolved images and ingress curl checks. 
- Added `tokenplace-oci-promote-prod tag=''` which reads the first non-comment non-empty line from `docs/apps/tokenplace.prod.tag` when `tag` is omitted, fails with a helpful message if nothing resolves, and delegates to `tokenplace-oci-deploy env=prod`. 
- Reworked `tokenplace-oci-redeploy env='staging' tag=''` as an upgrade-only path that calls `helm-oci-upgrade`, supports env-normalized values chains, uses a safe `default_tag` for non-prod where documented, requires explicit/prod-file tag for prod, and waits on `kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s`. 
- Added `tokenplace-debug-logs` and `tokenplace-debug-logs-env` which list namespace pods, tail logs using either `app.kubernetes.io/name=tokenplace` or fallback `app.kubernetes.io/instance=tokenplace`, include Traefik logs, and `tokenplace-debug-logs-env` forces canonical kubeconfig and calls `kubeconfig-env` first. 
- Updated generic tokenplace recipes (`tokenplace-status`, `tokenplace-deploy`, `tokenplace-upgrade`, `tokenplace-rollback`, `tokenplace-logs`/debug, `tokenplace-validate`, `tokenplace-port-forward`) to default to `tokenplace` release/service/deployment naming and `ingress.host`, and removed the preferred `chart='./apps/tokenplace-relay'` wiring from the OCI paths. All changes are in the top-level `justfile`.

### Testing
- Verified new recipe symbols are present via ripgrep: `rg -n "^tokenplace-oci-deploy|^tokenplace-oci-promote-prod|^tokenplace-oci-redeploy|^tokenplace-debug-logs|^tokenplace-debug-logs-env" justfile` (succeeded). 
- Verified no preferred recipe still references the local relay chart with `grep -n "chart='./apps/tokenplace-relay'" justfile && exit 1 || true` (succeeded). 
- Verified `just --summary` checks could not be run in this environment because `just` is not installed (command failed: `just: command not found`). 
- Committed the changes (`git commit`) on the feature branch and recorded the PR; no CI/test-suite runs were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13b76f2a34832f9430a2409a6da8d3)