### PR TITLE
docs: canonical token.place relay-only runbooks and OCI artifact guidance

### DIFF
--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -1,126 +1,52 @@
 # token.place relay on Sugarkube
 
-Deploy the `token.place` relay (`relay.py`) to the Sugarkube k3s cluster with a Helm chart that
-matches the existing dspace staging patterns. The public staging host for the relay service is
-`staging.token.place`, fronted by Traefik and Cloudflare Tunnel.
+This runbook covers relay-only token.place operations on Sugarkube.
 
-For full token.place onboarding and environment runbooks, see
-[`docs/tokenplace_sugarkube_onboarding.md`](../tokenplace_sugarkube_onboarding.md) and [`docs/apps/tokenplace.md`](./tokenplace.md).
+For the canonical app model, read [`docs/apps/tokenplace.md`](./tokenplace.md).
+For onboarding context, read
+[`docs/tokenplace_sugarkube_onboarding.md`](../tokenplace_sugarkube_onboarding.md).
 
-Values are split so you can reuse base settings across environments and layer staging-only ingress
-overrides. Operator defaults live alongside the chart; the docs copies remain as examples for
-cut-and-paste use:
+## Scope
 
-- `apps/tokenplace-relay/values.dev.yaml`: shared defaults (image repository, annotations).
-- `apps/tokenplace-relay/values.staging.yaml`: staging ingress host + TLS secret.
-- `docs/examples/tokenplace-relay.values.*.yaml`: example mirrors of the operator defaults.
+- Sugarkube runs only token.place `relay.py`.
+- No in-cluster backend/GPU service is required.
+- External compute nodes continue to run elsewhere (`server.py`, desktop Tauri app, Windows PCs,
+  Apple Silicon Macs, Raspberry Pi compute nodes, etc.).
+- Deployment is intentionally single-replica, single-worker, and in-memory.
+- State loss on pod restart/eviction is currently accepted.
 
-The Helm release runs in the `tokenplace` namespace with release name `tokenplace-relay`.
+## Canonical deployment identifiers
 
-## Prerequisites
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Version pin: `docs/apps/tokenplace.version`
+- Prod tag pin: `docs/apps/tokenplace.prod.tag`
 
-- A working k3s cluster with Traefik installed.
-- cert-manager with the `letsencrypt-production` ClusterIssuer ready (DNS01 via Cloudflare).
-- Cloudflare Tunnel pointing `staging.token.place` at
-  `http://traefik.kube-system.svc.cluster.local:80` (see [Cloudflare Tunnel docs](../cloudflare_tunnel.md)).
+## Values layering
 
-## Container image and Helm chart
+- Base: `docs/examples/tokenplace.values.dev.yaml`
+- Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
+- Prod overlay: `docs/examples/tokenplace.values.prod.yaml`
 
-- Image repository: `ghcr.io/democratizedspace/tokenplace-relay`
-  - Tags: immutable `sha-<shortsha>` builds from the CI publisher (recommended) and `main` (mutable).
-  - Default staging tag: `sha-684fd7f` (set via `default_tag` in the helper); override with `tag=sha-<shortsha>` for promotions.
-- Helm chart: `./apps/tokenplace-relay`
-  - Release: `tokenplace-relay`
-  - Namespace: `tokenplace`
+Do not prefer `./apps/tokenplace-relay` for steady-state deployments.
 
-Example values snippet:
+## Cloudflare + Traefik model
 
-```yaml
-image:
-  repository: ghcr.io/democratizedspace/tokenplace-relay
-  tag: sha-684fd7f
-ingress:
-  className: traefik
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-production
-  host: staging.token.place
-  tls:
-    secretName: staging-tokenplace-relay-tls
-env:
-  TOKENPLACE_RELAY_UPSTREAM_URL: http://gpu-server:5015
-probes:
-  port: http
-  readiness:
-    path: /healthz
-  liveness:
-    path: /livez
-```
+- Staging host default: `staging.token.place`
+- Production host default: `token.place`
+- Cloudflare routes are managed outside Helm and should target Traefik:
+  `http://traefik.kube-system.svc.cluster.local:80`
+- Helper examples:
+  - `just cf-tunnel-route host=staging.token.place`
+  - `just cf-tunnel-route host=token.place`
 
-## Quickstart (staging)
+## Common operational commands
 
-```bash
-# Install or upgrade the relay with staging ingress + TLS (wraps helm upgrade --install)
-just tokenplace-oci-redeploy
-
-# Print ingress + pod status
-just tokenplace-status
-
-# Redeploy a new image tag (sha-<shortsha> from GHCR) after validating a build
-just tokenplace-oci-redeploy tag=sha-<shortsha>
-```
-
-- The `default_tag` keeps staging pinned to a vetted immutable SHA tag; pass `tag=sha-<shortsha>`
-  when promoting a fresh image.
-- Health probes default to `/healthz` (readiness) and `/livez` (liveness) on the `http` port
-  (`containerPort: 5010`). Override `probes.port`, `probes.readiness.path`, or `probes.liveness.path`
-  if the relay exposes a different endpoint.
-- Expected public URL: https://staging.token.place
-- Manual Helm install uses the operator values:
-
-  ```bash
-  helm upgrade --install tokenplace-relay ./apps/tokenplace-relay \
-    --namespace tokenplace --create-namespace \
-    -f apps/tokenplace-relay/values.dev.yaml \
-    -f apps/tokenplace-relay/values.staging.yaml
-  ```
-
-## Ingress, TLS, and Cloudflare
-
-- Ingress class: `traefik`
-- Hostname: `staging.token.place`
-- TLS: cert-manager DNS01 via `letsencrypt-production`, secret `staging-tokenplace-relay-tls`
-- Cloudflare DNS:
-  1. Ensure your tunnel routes `staging.token.place` to
-     `http://traefik.kube-system.svc.cluster.local:80` (see [cloudflare_tunnel.md](../cloudflare_tunnel.md)).
-  2. In Cloudflare DNS, create a proxied CNAME for `staging.token.place` pointing at the
-     tunnel’s `<UUID>.cfargotunnel.com` target. Leave Proxy enabled so TLS terminates at Cloudflare
-     before entering Traefik.
-- TLS troubleshooting:
-  - `kubectl -n tokenplace describe certificate staging-tokenplace-relay-tls`
-  - `kubectl -n tokenplace describe challenge` (if certificates stall)
-  - `kubectl -n cert-manager logs deploy/cert-manager`
-  - `kubectl -n kube-system logs -l app.kubernetes.io/name=traefik`
-
-## Operational helpers
-
-- Deploy or roll forward: `just tokenplace-oci-redeploy [tag=sha-...]` (release `tokenplace-relay`
-  in namespace `tokenplace`, values from `apps/tokenplace-relay/values.*.yaml`)
-- Check status: `just tokenplace-status` (prints pods/ingress and the public URL)
-- Tail logs: `just tokenplace-logs`
-- Port-forward locally: `just tokenplace-port-forward` then `curl http://127.0.0.1:5010/healthz`
-
-## Troubleshooting
-
-- Inspect the release: `helm -n tokenplace status tokenplace-relay`
-- Verify ingress + certificate:
-  - `kubectl -n tokenplace get ingress`
-  - `kubectl -n tokenplace describe ingress tokenplace-relay`
-  - `kubectl -n tokenplace describe certificate staging-tokenplace-relay-tls`
-- Check relay health directly:
-  - `just tokenplace-port-forward`
-  - `curl -fsS http://127.0.0.1:5010/healthz`
-- Logs:
-  - `just tokenplace-logs`
-- Cloudflare Tunnel:
-  - Confirm the tunnel routes `staging.token.place` to Traefik (`http://traefik.kube-system.svc.cluster.local:80`)
-  - Validate DNS for `staging.token.place` in Cloudflare.
+- Deploy staging: `just tokenplace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA`
+- Promote prod: `just tokenplace-oci-promote-prod tag=main-REPLACE_APPROVED_SHORTSHA`
+- Status: `just tokenplace-status`
+- Debug logs:
+  - `just tokenplace-debug-logs-env env=staging`
+  - `just tokenplace-debug-logs-env env=prod`

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -1,103 +1,82 @@
 # token.place on Sugarkube
 
-This guide describes the intended token.place deployment model on Sugarkube once token.place
-release artifacts are ready for formal onboarding.
+This is the canonical Sugarkube operations guide for token.place relay-only deployments.
 
-For onboarding sequence and ownership boundaries, start with
+For onboarding + environment runbooks, start with
 [`docs/tokenplace_sugarkube_onboarding.md`](../tokenplace_sugarkube_onboarding.md).
 
-## Intended topology
+## Current supported topology (relay-only)
 
-token.place on Sugarkube is expected to use a split model:
+Sugarkube currently runs only `relay.py` for token.place.
 
-- **In-cluster (Sugarkube):** edge/API-facing components, ingress, relay-facing services,
-  environment configuration, and operational controls.
-- **External compute nodes:** heavier execution workloads that do not need to run on the Pi cluster.
+- **In-cluster (Sugarkube):** one relay deployment behind Traefik ingress.
+- **Out-of-cluster compute:** `server.py`, desktop Tauri app, Windows PCs, Apple Silicon Macs,
+  Raspberry Pi compute nodes, and other compute workers.
+- **No in-cluster backend/GPU service:** this is intentional for the current rollout.
+- **Single replica / single worker / in-memory state:** accepted for now.
+- **Pod death can drop relay state:** accepted for now.
+- **Out of scope for this phase:** multi-replica relay and in-memory database architectures.
 
-This keeps Sugarkube focused on durable control-plane and ingress responsibilities while allowing
-compute capacity to scale independently.
+## Canonical artifact model
 
-## Component placement guidance
+Use these fixed identifiers for staging and production operations:
 
-Place on Sugarkube when a component:
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Chart version pin: `docs/apps/tokenplace.version`
+- Production-approved image tag pin: `docs/apps/tokenplace.prod.tag`
 
-- terminates external traffic,
-- requires tight integration with k3s ingress/secrets,
-- benefits from near-cluster observability and rollout controls.
+## Values model
 
-Prefer external compute when a component:
+Layer values in this order:
 
-- is CPU/GPU intensive,
-- has bursty runtime needs,
-- can tolerate network hop separation from the relay/API plane.
+1. Base shared defaults: `docs/examples/tokenplace.values.dev.yaml`
+2. Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
+3. Production overlay: `docs/examples/tokenplace.values.prod.yaml`
 
-## Post-API-v1 secure deployment model
+Default ingress hosts:
 
-Expected steady state after API v1 convergence:
+- Staging: `staging.token.place`
+- Production: `token.place`
 
-- all component-to-component communication uses authenticated API v1 paths,
-- secrets are supplied via Kubernetes Secrets (or SOPS/Flux-managed equivalents),
-- ingress is fronted by Cloudflare + Traefik,
-- environment-specific values control hostnames, auth endpoints, and upstream compute routing.
+## Deployment workflow (OCI chart/image)
 
-## Prerequisites
+Preferred deployment wrappers:
 
-- Sugarkube k3s cluster healthy for target environment (`dev`, `staging`, or `prod`).
-- Cloudflare tunnel + DNS entries prepared for target token.place hostnames.
-- Token.place chart and image artifacts available and documented.
-- Environment values files prepared and reviewed.
+- Staging deploy: `just tokenplace-oci-deploy env=staging tag=<immutable-tag>`
+- Production promote/deploy: `just tokenplace-oci-promote-prod tag=<immutable-tag>`
+- Debug logs by env:
+  - `just tokenplace-debug-logs-env env=staging`
+  - `just tokenplace-debug-logs-env env=prod`
 
-## Core operational workflow
+Generic Helm OCI helpers are still available as secondary references, but token.place operations
+should default to the tokenplace-specific wrappers above.
 
-Use parameterized `just` recipes so unreconciled naming can be supplied at runtime:
+## Cloudflare + ingress model
 
-1. Deploy/install:
+Cloudflare Tunnel routes are configured **outside Helm**.
 
-   ```bash
-   just tokenplace-deploy release=<release> namespace=<namespace> chart=<chart-ref> values=<base>,<env> tag=<tag>
-   ```
+- Cloudflare routes should point app hostnames to Traefik, typically:
+  `http://traefik.kube-system.svc.cluster.local:80`
+- Helm deploys Kubernetes resources only; it does not create Cloudflare routes.
+- Common helper commands:
+  - `just cf-tunnel-route host=staging.token.place`
+  - `just cf-tunnel-route host=token.place`
 
-2. Upgrade:
+## Validation and troubleshooting quick reference
 
-   ```bash
-   just tokenplace-upgrade release=<release> namespace=<namespace> chart=<chart-ref> values=<base>,<env> tag=<tag>
-   ```
+- App status: `just tokenplace-status`
+- Cluster/ingress status:
+  - `just cluster-status`
+  - `just traefik-status`
+  - `just cf-tunnel-debug`
+- GHCR auth / chart verify:
+  - `helm registry login ghcr.io`
+  - `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"`
 
-3. Rollback:
+For step-by-step commands, use:
 
-   ```bash
-   just tokenplace-rollback release=<release> namespace=<namespace> revision=<revision>
-   ```
-
-4. Validate:
-
-   ```bash
-   just tokenplace-validate namespace=<namespace> release=<release> health_url=https://<host>/<health-path>
-   ```
-
-5. Inspect and debug:
-
-   ```bash
-   just tokenplace-status namespace=<namespace> release=<release>
-   just tokenplace-logs namespace=<namespace> selector=<label-selector>
-   just tokenplace-port-forward namespace=<namespace> service=<service> local_port=8080 remote_port=80
-   ```
-
-## Cloudflare and ingress expectations
-
-- Public access should terminate via Cloudflare and forward to Traefik.
-- Hostnames should be environment-specific (`dev`, `staging`, `prod`) and documented in the env
-  runbooks.
-- cert-manager issuer and TLS secret naming should be explicit per environment.
-
-## Secrets and config guidance
-
-- Keep environment-specific secrets out of docs and commit history.
-- Prefer immutable promotion tags for staging/prod.
-- Keep shared defaults separate from env overlays to reduce accidental prod drift.
-
-## Operator notes
-
-- Do not assume namespace/release/chart naming until token.place onboarding finalizes.
-- Keep recipes parameterized and runbooks explicit about what is fixed vs configurable.
-- Use relay-specific guide ([`docs/apps/tokenplace-relay.md`](./tokenplace-relay.md)) for current relay-only operations.
+- [`docs/k3s-tokenplace-staging.md`](../k3s-tokenplace-staging.md)
+- [`docs/k3s-tokenplace-prod.md`](../k3s-tokenplace-prod.md)

--- a/docs/examples/tokenplace-relay.values.dev.yaml
+++ b/docs/examples/tokenplace-relay.values.dev.yaml
@@ -1,8 +1,11 @@
-# Base values for deploying the token.place relay via Helm (see
-# apps/tokenplace-relay/values.dev.yaml for the operator defaults).
+# Deprecated local-chart example values retained for migration reference only.
+# Steady-state Sugarkube deployments should use:
+# - docs/examples/tokenplace.values.dev.yaml
+# - docs/examples/tokenplace.values.staging.yaml
+# - docs/examples/tokenplace.values.prod.yaml
 image:
-  repository: ghcr.io/democratizedspace/tokenplace-relay
-  tag: sha-684fd7f
+  repository: ghcr.io/futuroptimist/tokenplace-relay
+  tag: main-REPLACE_SHORTSHA
 
 ingress:
   enabled: true

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -1,71 +1,73 @@
 # k3s token.place runbook (prod)
 
-Use this runbook for `prod` token.place deployments on Sugarkube.
+Use this runbook for relay-only production token.place operations on Sugarkube.
 
-## Purpose
+## Scope and topology
 
-- Safe production deployment, validation, and rollback.
-- Preserve availability with explicit promotion and incident-response workflow.
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Runtime model: single relay replica + single worker + in-memory state.
+- No in-cluster backend/GPU service is required.
 
-## Topology intent (prod)
+## Values and host
 
-- Sugarkube hosts production ingress/API-facing token.place services.
-- External compute nodes execute heavy workloads and are reached through secured API v1 links.
-- Public hostnames route through Cloudflare to Traefik ingress.
+- Base values: `docs/examples/tokenplace.values.dev.yaml`
+- Production overlay: `docs/examples/tokenplace.values.prod.yaml`
+- Production host default: `token.place`
 
-## Prerequisites
-
-- Staging validation completed for the target immutable tag.
-- Production values overlays and secrets approved.
-- Rollback revision identified before upgrade begins.
-
-## Deploy / upgrade / rollback
+## Promotion after staging sign-off
 
 ```bash
-just tokenplace-deploy \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<prod-values> version_file=<optional-version-file> \
-  tag=<approved-immutable-tag>
+just tokenplace-oci-promote-prod tag=main-REPLACE_APPROVED_SHORTSHA
 ```
+
+## Generic production upgrade (explicit Helm OCI)
 
 ```bash
-just tokenplace-upgrade \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<prod-values> version_file=<optional-version-file> \
-  tag=<approved-immutable-tag>
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_APPROVED_SHORTSHA
 ```
+
+## Rollback options
+
+1. **Rollback by redeploying previous immutable tag:**
+
+   ```bash
+   just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_PREVIOUS_SHORTSHA
+   ```
+
+2. **Rollback to previous Helm revision:**
+
+   ```bash
+   helm -n tokenplace history tokenplace
+   just tokenplace-rollback release=tokenplace namespace=tokenplace revision=<known-good-revision>
+   ```
+
+## Validation
 
 ```bash
-# List history first, then rollback if needed.
-helm -n <namespace> history <release>
-just tokenplace-rollback release=<release> namespace=<namespace> revision=<known-good-revision>
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://token.place/livez
+curl -fsS https://token.place/healthz
+curl -fsS https://token.place/
 ```
 
-## Validation checks
+## Cloudflare Tunnel expectations
+
+- Production route is managed outside Helm.
+- Route `token.place` to Traefik (typically `http://traefik.kube-system.svc.cluster.local:80`).
+- Helper example: `just cf-tunnel-route host=token.place`
+
+## Troubleshooting
 
 ```bash
-just tokenplace-status namespace=<namespace> release=<release>
-just tokenplace-validate namespace=<namespace> release=<release> health_url=https://<prod-host>/<health>
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
+just tokenplace-status
+just tokenplace-debug-logs-env env=prod
+just cluster-status
+just traefik-status
+just cf-tunnel-debug
 ```
-
-```bash
-just tokenplace-logs namespace=<namespace> selector=<label-selector>
-```
-
-## Cloudflare / ingress expectations
-
-- Production hostname and TLS secret names are stable and documented.
-- Cloudflare tunnel routes only expected production hosts.
-- Any emergency DNS/ingress change is logged in outage documentation.
-
-## Secrets/config guidance
-
-- Use production-scoped credentials only; never reuse lower-environment keys.
-- Keep secret rotation cadence aligned with Sugarkube security checklist.
-- Apply least-privilege API tokens for DNS/tunnel automation.
-
-## Operator notes and caveats
-
-- Avoid mutable tags in production.
-- Keep a known-good rollback revision and artifact digest recorded for each deploy.
-- If rollout behavior diverges from staging, pause further promotions and capture diagnostics.

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -1,66 +1,76 @@
 # k3s token.place runbook (staging)
 
-Use this runbook for `staging` token.place deployments on Sugarkube.
+Use this runbook to deploy relay-only token.place to staging on Sugarkube.
 
-## Purpose
+## Scope and topology
 
-- Release-candidate validation before production promotion.
-- Full ingress + Cloudflare + TLS + API v1 behavior checks.
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Runtime model: single relay replica + single worker + in-memory state.
+- No in-cluster backend/GPU service is required.
 
-## Topology intent (staging)
+## Values and host
 
-- Sugarkube runs ingress/API-facing token.place services and relay integration points.
-- External compute remains out-of-cluster but reachable over secured API v1 paths.
-- Staging should mirror production architecture closely, with lower traffic volume.
+- Base values: `docs/examples/tokenplace.values.dev.yaml`
+- Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
+- Staging host default: `staging.token.place`
 
 ## Prerequisites
 
-- Chart/release wiring is defined for staging.
-- Staging values overlays and secrets are reviewed.
-- Cloudflare hostname routing to Traefik is configured.
+- Cloudflare Tunnel route for `staging.token.place` points to Traefik
+  (`http://traefik.kube-system.svc.cluster.local:80`).
+- GHCR auth is available for Helm OCI pull when required.
 
-## Deploy / upgrade / rollback
-
-```bash
-just tokenplace-deploy \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<staging-values> version_file=<optional-version-file> \
-  tag=<immutable-tag>
-```
+## First install
 
 ```bash
-just tokenplace-upgrade \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<staging-values> version_file=<optional-version-file> \
-  tag=<immutable-tag>
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
+
+## Existing release upgrade
 
 ```bash
-just tokenplace-rollback release=<release> namespace=<namespace> revision=<helm-revision>
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
-## Validation checks
+## Preferred wrapper
 
 ```bash
-just tokenplace-status namespace=<namespace> release=<release>
-just tokenplace-validate namespace=<namespace> release=<release> health_url=https://<staging-host>/<health>
+just tokenplace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
 ```
 
-- Confirm ingress host and TLS certificate are ready.
-- Confirm API v1 auth and external compute connectivity are healthy.
-- Capture logs for relay/API components when validating release candidates.
+## Validation
 
 ```bash
-just tokenplace-logs namespace=<namespace> selector=<label-selector>
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/
 ```
 
-## Cloudflare / ingress expectations
+## Troubleshooting
 
-- Staging hostname is distinct from production hostname.
-- Tunnel target points to Traefik (`kube-system` service).
-- DNS records remain proxied in Cloudflare.
+- GHCR auth + chart check:
 
-## Operator caveats
+  ```bash
+  helm registry login ghcr.io
+  helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
+  ```
 
-- Treat staging as promotion gate; avoid ad hoc value edits.
-- Prefer immutable tags for reproducible rollback and forensic traceability.
+- App diagnostics:
+
+  ```bash
+  just tokenplace-status
+  just tokenplace-debug-logs-env env=staging
+  ```
+
+- Ingress/Tunnel diagnostics:
+
+  ```bash
+  just cluster-status
+  just traefik-status
+  just cf-tunnel-debug
+  ```

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -1,107 +1,50 @@
 # token.place Sugarkube onboarding
 
-This guide prepares Sugarkube to run `token.place` as a first-class workload once token.place
-release artifacts and chart wiring are finalized.
+This onboarding guide defines the relay-only operating contract for token.place on Sugarkube.
 
-It is intentionally a **deployment-preparation** runbook: it defines stable interfaces,
-ownership, and operational shape without pretending that chart/release identifiers are immutable
-before the token.place onboarding cutover is complete.
+## Deployment contract
 
-## Why token.place belongs on Sugarkube
+Sugarkube token.place deployments currently use the following fixed model:
 
-- Sugarkube already provides a repeatable k3s + ingress + Cloudflare operating model.
-- token.place already has relay operations on Sugarkube (`docs/apps/tokenplace-relay.md`), so this
-  onboarding extends an existing operational pattern instead of introducing a new stack.
-- Sugarkube gives a consistent operator interface (`just` + runbooks) across `dev`, `staging`, and
-  `prod`, reducing drift during promotion and rollback.
+- Runtime scope: relay-only (`relay.py`) on Sugarkube.
+- In-cluster services: no required backend/GPU service.
+- External compute scope: `server.py`, desktop Tauri app, Windows PCs, Apple Silicon Macs,
+  Raspberry Pi compute nodes, and other external workers.
+- Current HA/state model: one relay replica, one worker, in-memory state.
+- Accepted behavior: state may be lost on pod death/recreation.
+- Out of scope for this phase: multi-replica relay and in-memory database architecture.
 
-## Preconditions before onboarding
+## Canonical artifacts and pins
 
-Before onboarding the full token.place workload, confirm token.place has completed:
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Chart version pin file: `docs/apps/tokenplace.version`
+- Production-approved image tag file: `docs/apps/tokenplace.prod.tag`
 
-1. Shared desktop/server compute-node runtime.
-2. Desktop parity with `server.py` behavior.
-3. Operationally mature relay service.
-4. Secure API v1 convergence across token.place components.
-5. Release artifact publication (container images + Helm chart) suitable for repeatable deployment.
+## Values contract
 
-If any precondition is incomplete, keep using relay-only operations and postpone full onboarding.
+Use environment overlays on top of shared defaults:
 
-## Release artifact expectations
+- Base: `docs/examples/tokenplace.values.dev.yaml`
+- Staging: `docs/examples/tokenplace.values.staging.yaml`
+- Production: `docs/examples/tokenplace.values.prod.yaml`
 
-During onboarding, token.place should provide:
+## Cloudflare contract
 
-- A Helm chart (OCI or repository path) that supports environment-specific values overlays.
-- Versioned chart metadata (or pinned chart digest/version).
-- Container image tags suitable for promotion (prefer immutable tags).
-- Health endpoints and readiness/liveness semantics documented for operator validation.
+Cloudflare Tunnel + DNS routing is managed outside Helm.
 
-## Expected Sugarkube wiring (standardized vs configurable)
+- Hostnames are routed to Traefik (typically
+  `http://traefik.kube-system.svc.cluster.local:80`).
+- Helm chart deployment does not create Cloudflare routes.
+- Suggested helpers:
+  - `just cf-tunnel-route host=staging.token.place`
+  - `just cf-tunnel-route host=token.place`
 
-Standardized in Sugarkube:
+## Where to run operations
 
-- Task-runner interface (recipes in `justfile`):
-  - `tokenplace-deploy`
-  - `tokenplace-upgrade`
-  - `tokenplace-rollback`
-  - `tokenplace-status`
-  - `tokenplace-logs`
-  - `tokenplace-validate`
-  - `tokenplace-port-forward`
-- Environment runbooks:
-  - `docs/k3s-tokenplace-dev.md`
-  - `docs/k3s-tokenplace-staging.md`
-  - `docs/k3s-tokenplace-prod.md`
-
-Configurable per onboarding cutover:
-
-- Namespace, release name, chart location, values files, chart version pin, and image tag strategy.
-- Ingress hosts and Cloudflare DNS/tunnel mapping.
-- Which token.place components run in-cluster vs on external compute nodes.
-
-## Environment mapping
-
-- `dev`: fast iteration, lower blast radius, relaxed SLOs.
-- `staging`: pre-production integration and release validation.
-- `prod`: public workload, strict rollback and change-control discipline.
-
-Use the environment-specific runbooks for concrete command patterns.
-
-## Ownership boundaries
-
-- **token.place team** owns chart/app semantics, release artifacts, and component-level config.
-- **Sugarkube operators** own cluster lifecycle, ingress/tunnel plumbing, secret distribution,
-  deployment execution, and rollback orchestration.
-- Shared responsibility: production cutover sequencing, health-gate criteria, and incident
-  response.
-
-## App catalog and related docs
-
-- App overview: `docs/apps/tokenplace.md`
-- Relay-specific operations: `docs/apps/tokenplace-relay.md`
-- Environment runbooks:
-  - `docs/k3s-tokenplace-dev.md`
-  - `docs/k3s-tokenplace-staging.md`
-  - `docs/k3s-tokenplace-prod.md`
-
-## Baseline command templates
-
-Set values explicitly per environment to avoid hidden assumptions:
-
-```bash
-just tokenplace-deploy \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<env-values> version_file=<optional-version-file> \
-  tag=<image-tag>
-```
-
-```bash
-just tokenplace-upgrade \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<env-values> version_file=<optional-version-file> \
-  tag=<image-tag>
-```
-
-```bash
-just tokenplace-rollback release=<release> namespace=<namespace> revision=<helm-revision>
-```
+- App guide: `docs/apps/tokenplace.md`
+- Relay guide: `docs/apps/tokenplace-relay.md`
+- Staging runbook: `docs/k3s-tokenplace-staging.md`
+- Production runbook: `docs/k3s-tokenplace-prod.md`


### PR DESCRIPTION
### Motivation
- Make Sugarkube token.place docs concrete and DSPACE-like for a relay-only staging/prod rollout using an OCI chart/image model.
- Ensure operator runbooks show exact commands for install, upgrade, validation, promotion and rollback without requiring an in-cluster backend/GPU service.
- Remove or deprecate active guidance that referenced the old `democratizedspace` image/tag and local chart path so operators use `ghcr.io/futuroptimist` OCI artifacts.

### Description
- Rewrote and standardized the main app/relay docs to the relay-only topology and canonical artifacts: `ghcr.io/futuroptimist/tokenplace-relay`, `oci://ghcr.io/futuroptimist/charts/tokenplace`, release `tokenplace`, namespace `tokenplace`, `docs/apps/tokenplace.version`, and `docs/apps/tokenplace.prod.tag` (files changed: `docs/apps/tokenplace.md`, `docs/apps/tokenplace-relay.md`).
- Added concrete staging/prod runbook commands and validation/rollback recipes that use the `just` wrappers and generic Helm OCI helpers (files changed: `docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`).
- Updated onboarding doc to record the relay-only contract, artifact pins, values overlay model, and explicit Cloudflare-Traefik ownership guidance (file changed: `docs/tokenplace_sugarkube_onboarding.md`).
- Marked the deprecated local-chart example values as migration-only and replaced stale example image/tag with `ghcr.io/futuroptimist/tokenplace-relay` and `main-REPLACE_SHORTSHA` in `docs/examples/tokenplace-relay.values.dev.yaml` while keeping the local chart directory for migration/reference.

### Testing
- Searched the repo for residual stale references and findings: `grep -R "ghcr.io/democratizedspace/tokenplace-relay" docs apps README.md` returned matches only in the deprecated local chart under `apps/tokenplace-relay/values.dev.yaml` and `apps/tokenplace-relay/values.dev.yaml` still contains `tag: sha-684fd7f` (intentional; kept for migration reference).
- Verified canonical references are present with `grep -R "oci://ghcr.io/futuroptimist/charts/tokenplace" docs` and `grep -R "release=tokenplace namespace=tokenplace" docs` which succeeded.
- Attempted repo checks: `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` could not be run in this environment because the commands are not installed (errors: `pre-commit: command not found`, `pyspelling: command not found`, `linkchecker: command not found`).
- Commit created a documented change set (6 files changed, commit message `docs: update tokenplace relay staging/prod runbooks`), and follow-up recommended action is to remove or update `apps/tokenplace-relay/*` operator defaults when ready to fully delete the deprecated local chart.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13e9fdbfb8832fa7bab34021c4bbfc)