### PR TITLE
docs: align tokenplace relay docs with OCI staging/prod rollout

### DIFF
--- a/apps/tokenplace-relay/values.dev.yaml
+++ b/apps/tokenplace-relay/values.dev.yaml
@@ -2,8 +2,8 @@
 # These defaults mirror the dspace staging pattern and are consumed by helper
 # commands in the justfile.
 image:
-  repository: ghcr.io/democratizedspace/tokenplace-relay
-  tag: sha-684fd7f
+  repository: ghcr.io/futuroptimist/tokenplace-relay
+  tag: main-REPLACE_SHORTSHA
 
 ingress:
   enabled: true

--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -1,126 +1,139 @@
 # token.place relay on Sugarkube
 
-Deploy the `token.place` relay (`relay.py`) to the Sugarkube k3s cluster with a Helm chart that
-matches the existing dspace staging patterns. The public staging host for the relay service is
-`staging.token.place`, fronted by Traefik and Cloudflare Tunnel.
+This is the concrete relay-only runbook for Sugarkube.
 
-For full token.place onboarding and environment runbooks, see
-[`docs/tokenplace_sugarkube_onboarding.md`](../tokenplace_sugarkube_onboarding.md) and [`docs/apps/tokenplace.md`](./tokenplace.md).
+## Current topology
 
-Values are split so you can reuse base settings across environments and layer staging-only ingress
-overrides. Operator defaults live alongside the chart; the docs copies remain as examples for
-cut-and-paste use:
+Sugarkube runs only `token.place` `relay.py`.
 
-- `apps/tokenplace-relay/values.dev.yaml`: shared defaults (image repository, annotations).
-- `apps/tokenplace-relay/values.staging.yaml`: staging ingress host + TLS secret.
-- `docs/examples/tokenplace-relay.values.*.yaml`: example mirrors of the operator defaults.
+- No in-cluster backend service.
+- No in-cluster GPU service.
+- External compute nodes remain external (`server.py`, desktop Tauri app, Windows PCs,
+  Apple Silicon Macs, Raspberry Pi compute nodes, and related workers).
+- Runtime shape: single relay replica, single worker, in-memory state.
+- State loss on pod death is accepted at this stage.
+- Future multi-replica/stateful architecture is out of scope for this runbook.
 
-The Helm release runs in the `tokenplace` namespace with release name `tokenplace-relay`.
+## Canonical artifacts
 
-## Prerequisites
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Version pin: `docs/apps/tokenplace.version`
+- Prod approved tag pin: `docs/apps/tokenplace.prod.tag`
 
-- A working k3s cluster with Traefik installed.
-- cert-manager with the `letsencrypt-production` ClusterIssuer ready (DNS01 via Cloudflare).
-- Cloudflare Tunnel pointing `staging.token.place` at
-  `http://traefik.kube-system.svc.cluster.local:80` (see [Cloudflare Tunnel docs](../cloudflare_tunnel.md)).
+## Values model
 
-## Container image and Helm chart
+- Base values: `docs/examples/tokenplace.values.dev.yaml`
+- Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
+- Prod overlay: `docs/examples/tokenplace.values.prod.yaml`
 
-- Image repository: `ghcr.io/democratizedspace/tokenplace-relay`
-  - Tags: immutable `sha-<shortsha>` builds from the CI publisher (recommended) and `main` (mutable).
-  - Default staging tag: `sha-684fd7f` (set via `default_tag` in the helper); override with `tag=sha-<shortsha>` for promotions.
-- Helm chart: `./apps/tokenplace-relay`
-  - Release: `tokenplace-relay`
-  - Namespace: `tokenplace`
+Default hosts:
 
-Example values snippet:
+- Staging host: `staging.token.place`
+- Prod host: `token.place`
 
-```yaml
-image:
-  repository: ghcr.io/democratizedspace/tokenplace-relay
-  tag: sha-684fd7f
-ingress:
-  className: traefik
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-production
-  host: staging.token.place
-  tls:
-    secretName: staging-tokenplace-relay-tls
-env:
-  TOKENPLACE_RELAY_UPSTREAM_URL: http://gpu-server:5015
-probes:
-  port: http
-  readiness:
-    path: /healthz
-  liveness:
-    path: /livez
-```
+## Staging deployment
 
-## Quickstart (staging)
+### First install
 
 ```bash
-# Install or upgrade the relay with staging ingress + TLS (wraps helm upgrade --install)
-just tokenplace-oci-redeploy
-
-# Print ingress + pod status
-just tokenplace-status
-
-# Redeploy a new image tag (sha-<shortsha> from GHCR) after validating a build
-just tokenplace-oci-redeploy tag=sha-<shortsha>
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
-- The `default_tag` keeps staging pinned to a vetted immutable SHA tag; pass `tag=sha-<shortsha>`
-  when promoting a fresh image.
-- Health probes default to `/healthz` (readiness) and `/livez` (liveness) on the `http` port
-  (`containerPort: 5010`). Override `probes.port`, `probes.readiness.path`, or `probes.liveness.path`
-  if the relay exposes a different endpoint.
-- Expected public URL: https://staging.token.place
-- Manual Helm install uses the operator values:
+### Existing release upgrade
 
-  ```bash
-  helm upgrade --install tokenplace-relay ./apps/tokenplace-relay \
-    --namespace tokenplace --create-namespace \
-    -f apps/tokenplace-relay/values.dev.yaml \
-    -f apps/tokenplace-relay/values.staging.yaml
-  ```
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
 
-## Ingress, TLS, and Cloudflare
+### Preferred wrapper
 
-- Ingress class: `traefik`
-- Hostname: `staging.token.place`
-- TLS: cert-manager DNS01 via `letsencrypt-production`, secret `staging-tokenplace-relay-tls`
-- Cloudflare DNS:
-  1. Ensure your tunnel routes `staging.token.place` to
-     `http://traefik.kube-system.svc.cluster.local:80` (see [cloudflare_tunnel.md](../cloudflare_tunnel.md)).
-  2. In Cloudflare DNS, create a proxied CNAME for `staging.token.place` pointing at the
-     tunnel’s `<UUID>.cfargotunnel.com` target. Leave Proxy enabled so TLS terminates at Cloudflare
-     before entering Traefik.
-- TLS troubleshooting:
-  - `kubectl -n tokenplace describe certificate staging-tokenplace-relay-tls`
-  - `kubectl -n tokenplace describe challenge` (if certificates stall)
-  - `kubectl -n cert-manager logs deploy/cert-manager`
-  - `kubectl -n kube-system logs -l app.kubernetes.io/name=traefik`
+```bash
+just tokenplace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+```
 
-## Operational helpers
+### Staging validation
 
-- Deploy or roll forward: `just tokenplace-oci-redeploy [tag=sha-...]` (release `tokenplace-relay`
-  in namespace `tokenplace`, values from `apps/tokenplace-relay/values.*.yaml`)
-- Check status: `just tokenplace-status` (prints pods/ingress and the public URL)
-- Tail logs: `just tokenplace-logs`
-- Port-forward locally: `just tokenplace-port-forward` then `curl http://127.0.0.1:5010/healthz`
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/
+```
+
+## Production rollout and rollback
+
+### Promote approved staging tag
+
+```bash
+just tokenplace-oci-promote-prod tag=main-REPLACE_APPROVED_SHORTSHA
+```
+
+### Generic production upgrade
+
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_APPROVED_SHORTSHA
+```
+
+### Roll back to previous immutable tag
+
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+### Roll back Helm revision
+
+```bash
+just tokenplace-rollback
+```
+
+### Production validation
+
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://token.place/livez
+curl -fsS https://token.place/healthz
+curl -fsS https://token.place/
+```
+
+## Cloudflare Tunnel guidance
+
+Cloudflare Tunnel/DNS is configured outside Helm.
+
+- Route hostnames to Traefik, typically `http://traefik.kube-system.svc.cluster.local:80`.
+- Helm chart deployment does not create Cloudflare routes.
+- Suggested helper commands (if configured in your environment):
+
+```bash
+just cf-tunnel-route host=staging.token.place
+just cf-tunnel-route host=token.place
+```
 
 ## Troubleshooting
 
-- Inspect the release: `helm -n tokenplace status tokenplace-relay`
-- Verify ingress + certificate:
-  - `kubectl -n tokenplace get ingress`
-  - `kubectl -n tokenplace describe ingress tokenplace-relay`
-  - `kubectl -n tokenplace describe certificate staging-tokenplace-relay-tls`
-- Check relay health directly:
-  - `just tokenplace-port-forward`
-  - `curl -fsS http://127.0.0.1:5010/healthz`
-- Logs:
-  - `just tokenplace-logs`
-- Cloudflare Tunnel:
-  - Confirm the tunnel routes `staging.token.place` to Traefik (`http://traefik.kube-system.svc.cluster.local:80`)
-  - Validate DNS for `staging.token.place` in Cloudflare.
+### GHCR auth and chart availability
+
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
+```
+
+### App status and logs
+
+```bash
+just tokenplace-status
+just tokenplace-debug-logs-env env=staging
+just tokenplace-debug-logs-env env=prod
+```
+
+### Ingress, Traefik, and tunnel diagnostics
+
+```bash
+just cluster-status
+just traefik-status
+just cf-tunnel-debug
+```

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -1,103 +1,64 @@
 # token.place on Sugarkube
 
-This guide describes the intended token.place deployment model on Sugarkube once token.place
-release artifacts are ready for formal onboarding.
+This guide defines the canonical relay-only token.place deployment on Sugarkube.
 
-For onboarding sequence and ownership boundaries, start with
-[`docs/tokenplace_sugarkube_onboarding.md`](../tokenplace_sugarkube_onboarding.md).
+For onboarding and environment runbooks, see
+[`docs/tokenplace_sugarkube_onboarding.md`](../tokenplace_sugarkube_onboarding.md),
+[`docs/k3s-tokenplace-staging.md`](../k3s-tokenplace-staging.md), and
+[`docs/k3s-tokenplace-prod.md`](../k3s-tokenplace-prod.md).
 
-## Intended topology
+## Relay-only topology (current scope)
 
-token.place on Sugarkube is expected to use a split model:
+Sugarkube currently runs only `token.place` `relay.py`.
 
-- **In-cluster (Sugarkube):** edge/API-facing components, ingress, relay-facing services,
-  environment configuration, and operational controls.
-- **External compute nodes:** heavier execution workloads that do not need to run on the Pi cluster.
+- **In-cluster (Sugarkube):** one relay deployment, one replica, one worker, in-memory state.
+- **Not in-cluster:** no backend service and no GPU service are deployed on Sugarkube.
+- **External compute remains external:** `server.py`, the desktop Tauri app, Windows PCs,
+  Apple Silicon Macs, Raspberry Pi compute nodes, and other compute workers run outside the
+  Sugarkube cluster.
 
-This keeps Sugarkube focused on durable control-plane and ingress responsibilities while allowing
-compute capacity to scale independently.
+Operational constraints for this phase:
 
-## Component placement guidance
+- Pod state loss on restart/eviction is accepted.
+- Multi-replica state sharing and an in-memory DB layer are explicitly out of scope for now.
 
-Place on Sugarkube when a component:
+## Canonical artifacts and release identity
 
-- terminates external traffic,
-- requires tight integration with k3s ingress/secrets,
-- benefits from near-cluster observability and rollout controls.
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Chart version pin: `docs/apps/tokenplace.version`
+- Production approved image tag pin: `docs/apps/tokenplace.prod.tag`
 
-Prefer external compute when a component:
+## Values model
 
-- is CPU/GPU intensive,
-- has bursty runtime needs,
-- can tolerate network hop separation from the relay/API plane.
+Use DSPACE-style layered values:
 
-## Post-API-v1 secure deployment model
+- Base: `docs/examples/tokenplace.values.dev.yaml`
+- Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
+- Prod overlay: `docs/examples/tokenplace.values.prod.yaml`
 
-Expected steady state after API v1 convergence:
+Host defaults:
 
-- all component-to-component communication uses authenticated API v1 paths,
-- secrets are supplied via Kubernetes Secrets (or SOPS/Flux-managed equivalents),
-- ingress is fronted by Cloudflare + Traefik,
-- environment-specific values control hostnames, auth endpoints, and upstream compute routing.
+- Staging: `staging.token.place`
+- Prod: `token.place`
 
-## Prerequisites
+## Cloudflare + ingress model
 
-- Sugarkube k3s cluster healthy for target environment (`dev`, `staging`, or `prod`).
-- Cloudflare tunnel + DNS entries prepared for target token.place hostnames.
-- Token.place chart and image artifacts available and documented.
-- Environment values files prepared and reviewed.
+Cloudflare routing is configured outside Helm.
 
-## Core operational workflow
+- Helm deploys Kubernetes resources only.
+- Cloudflare Tunnel/DNS must route public hosts to Traefik, typically:
+  `http://traefik.kube-system.svc.cluster.local:80`
+- Use existing helper guidance where available:
+  - `just cf-tunnel-route host=staging.token.place`
+  - `just cf-tunnel-route host=token.place`
 
-Use parameterized `just` recipes so unreconciled naming can be supplied at runtime:
+See also [`docs/cloudflare_tunnel.md`](../cloudflare_tunnel.md).
 
-1. Deploy/install:
+## Primary operator flow
 
-   ```bash
-   just tokenplace-deploy release=<release> namespace=<namespace> chart=<chart-ref> values=<base>,<env> tag=<tag>
-   ```
-
-2. Upgrade:
-
-   ```bash
-   just tokenplace-upgrade release=<release> namespace=<namespace> chart=<chart-ref> values=<base>,<env> tag=<tag>
-   ```
-
-3. Rollback:
-
-   ```bash
-   just tokenplace-rollback release=<release> namespace=<namespace> revision=<revision>
-   ```
-
-4. Validate:
-
-   ```bash
-   just tokenplace-validate namespace=<namespace> release=<release> health_url=https://<host>/<health-path>
-   ```
-
-5. Inspect and debug:
-
-   ```bash
-   just tokenplace-status namespace=<namespace> release=<release>
-   just tokenplace-logs namespace=<namespace> selector=<label-selector>
-   just tokenplace-port-forward namespace=<namespace> service=<service> local_port=8080 remote_port=80
-   ```
-
-## Cloudflare and ingress expectations
-
-- Public access should terminate via Cloudflare and forward to Traefik.
-- Hostnames should be environment-specific (`dev`, `staging`, `prod`) and documented in the env
-  runbooks.
-- cert-manager issuer and TLS secret naming should be explicit per environment.
-
-## Secrets and config guidance
-
-- Keep environment-specific secrets out of docs and commit history.
-- Prefer immutable promotion tags for staging/prod.
-- Keep shared defaults separate from env overlays to reduce accidental prod drift.
-
-## Operator notes
-
-- Do not assume namespace/release/chart naming until token.place onboarding finalizes.
-- Keep recipes parameterized and runbooks explicit about what is fixed vs configurable.
-- Use relay-specific guide ([`docs/apps/tokenplace-relay.md`](./tokenplace-relay.md)) for current relay-only operations.
+- Staging deploy and validation: [`docs/k3s-tokenplace-staging.md`](../k3s-tokenplace-staging.md)
+- Production promotion/deploy/rollback: [`docs/k3s-tokenplace-prod.md`](../k3s-tokenplace-prod.md)
+- Relay app specifics and troubleshooting: [`docs/apps/tokenplace-relay.md`](./tokenplace-relay.md)

--- a/docs/examples/tokenplace-relay.values.dev.yaml
+++ b/docs/examples/tokenplace-relay.values.dev.yaml
@@ -1,8 +1,8 @@
 # Base values for deploying the token.place relay via Helm (see
 # apps/tokenplace-relay/values.dev.yaml for the operator defaults).
 image:
-  repository: ghcr.io/democratizedspace/tokenplace-relay
-  tag: sha-684fd7f
+  repository: ghcr.io/futuroptimist/tokenplace-relay
+  tag: main-REPLACE_SHORTSHA
 
 ingress:
   enabled: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ Review the safety notes before working with power components.
 - [tokenplace_sugarkube_onboarding.md](tokenplace_sugarkube_onboarding.md) — onboarding contract,
   ownership boundaries, and environment mapping for token.place on Sugarkube
 - [apps/tokenplace.md](apps/tokenplace.md) — token.place app topology and operations model on Sugarkube
-- [apps/tokenplace-relay.md](apps/tokenplace-relay.md) — operate the token.place relay staging deployment
+- [apps/tokenplace-relay.md](apps/tokenplace-relay.md) — concrete relay-only token.place deploy/validate/rollback guide (staging + prod)
 - [k3s-tokenplace-dev.md](k3s-tokenplace-dev.md) — token.place dev runbook
 - [k3s-tokenplace-staging.md](k3s-tokenplace-staging.md) — token.place staging runbook
 - [k3s-tokenplace-prod.md](k3s-tokenplace-prod.md) — token.place production runbook

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -1,71 +1,78 @@
 # k3s token.place runbook (prod)
 
-Use this runbook for `prod` token.place deployments on Sugarkube.
+Use this runbook for `prod` relay-only token.place deployments on Sugarkube.
 
-## Purpose
+## Scope
 
-- Safe production deployment, validation, and rollback.
-- Preserve availability with explicit promotion and incident-response workflow.
+- In-cluster workload: `relay.py` only.
+- No in-cluster backend/GPU service.
+- External compute remains out-of-cluster.
 
-## Topology intent (prod)
+## Canonical identifiers
 
-- Sugarkube hosts production ingress/API-facing token.place services.
-- External compute nodes execute heavy workloads and are reached through secured API v1 links.
-- Public hostnames route through Cloudflare to Traefik ingress.
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Version pin: `docs/apps/tokenplace.version`
+- Prod tag pin: `docs/apps/tokenplace.prod.tag`
+- Values: `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml`
+- Prod host: `token.place`
 
-## Prerequisites
-
-- Staging validation completed for the target immutable tag.
-- Production values overlays and secrets approved.
-- Rollback revision identified before upgrade begins.
-
-## Deploy / upgrade / rollback
-
-```bash
-just tokenplace-deploy \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<prod-values> version_file=<optional-version-file> \
-  tag=<approved-immutable-tag>
-```
+## Promotion after staging sign-off
 
 ```bash
-just tokenplace-upgrade \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<prod-values> version_file=<optional-version-file> \
-  tag=<approved-immutable-tag>
+just tokenplace-oci-promote-prod tag=main-REPLACE_APPROVED_SHORTSHA
 ```
+
+## Generic production upgrade
 
 ```bash
-# List history first, then rollback if needed.
-helm -n <namespace> history <release>
-just tokenplace-rollback release=<release> namespace=<namespace> revision=<known-good-revision>
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_APPROVED_SHORTSHA
 ```
 
-## Validation checks
+## Rollback options
+
+### Roll back by immutable image tag
 
 ```bash
-just tokenplace-status namespace=<namespace> release=<release>
-just tokenplace-validate namespace=<namespace> release=<release> health_url=https://<prod-host>/<health>
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_PREVIOUS_SHORTSHA
 ```
+
+### Roll back by Helm revision
 
 ```bash
-just tokenplace-logs namespace=<namespace> selector=<label-selector>
+just tokenplace-rollback
 ```
 
-## Cloudflare / ingress expectations
+## Validation
 
-- Production hostname and TLS secret names are stable and documented.
-- Cloudflare tunnel routes only expected production hosts.
-- Any emergency DNS/ingress change is logged in outage documentation.
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://token.place/livez
+curl -fsS https://token.place/healthz
+curl -fsS https://token.place/
+```
 
-## Secrets/config guidance
+## Cloudflare Tunnel expectations
 
-- Use production-scoped credentials only; never reuse lower-environment keys.
-- Keep secret rotation cadence aligned with Sugarkube security checklist.
-- Apply least-privilege API tokens for DNS/tunnel automation.
+- Cloudflare route/tunnel configuration is outside Helm.
+- Route `token.place` to Traefik, typically
+  `http://traefik.kube-system.svc.cluster.local:80`.
+- If available, use:
 
-## Operator notes and caveats
+```bash
+just cf-tunnel-route host=token.place
+```
 
-- Avoid mutable tags in production.
-- Keep a known-good rollback revision and artifact digest recorded for each deploy.
-- If rollout behavior diverges from staging, pause further promotions and capture diagnostics.
+## Troubleshooting
+
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
+just tokenplace-status
+just tokenplace-debug-logs-env env=prod
+just cluster-status
+just traefik-status
+just cf-tunnel-debug
+```

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -1,66 +1,69 @@
 # k3s token.place runbook (staging)
 
-Use this runbook for `staging` token.place deployments on Sugarkube.
+Use this runbook for `staging` relay-only token.place deployments on Sugarkube.
 
-## Purpose
+## Scope
 
-- Release-candidate validation before production promotion.
-- Full ingress + Cloudflare + TLS + API v1 behavior checks.
+- In-cluster workload: `relay.py` only.
+- No in-cluster backend/GPU service.
+- External compute remains out-of-cluster.
 
-## Topology intent (staging)
+## Canonical identifiers
 
-- Sugarkube runs ingress/API-facing token.place services and relay integration points.
-- External compute remains out-of-cluster but reachable over secured API v1 paths.
-- Staging should mirror production architecture closely, with lower traffic volume.
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Version pin: `docs/apps/tokenplace.version`
+- Values: `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml`
+- Staging host: `staging.token.place`
 
-## Prerequisites
-
-- Chart/release wiring is defined for staging.
-- Staging values overlays and secrets are reviewed.
-- Cloudflare hostname routing to Traefik is configured.
-
-## Deploy / upgrade / rollback
+## First install
 
 ```bash
-just tokenplace-deploy \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<staging-values> version_file=<optional-version-file> \
-  tag=<immutable-tag>
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
+
+## Existing release upgrade
 
 ```bash
-just tokenplace-upgrade \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<staging-values> version_file=<optional-version-file> \
-  tag=<immutable-tag>
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
+
+## Preferred wrapper
 
 ```bash
-just tokenplace-rollback release=<release> namespace=<namespace> revision=<helm-revision>
+just tokenplace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
 ```
 
-## Validation checks
+## Validation
 
 ```bash
-just tokenplace-status namespace=<namespace> release=<release>
-just tokenplace-validate namespace=<namespace> release=<release> health_url=https://<staging-host>/<health>
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/
 ```
 
-- Confirm ingress host and TLS certificate are ready.
-- Confirm API v1 auth and external compute connectivity are healthy.
-- Capture logs for relay/API components when validating release candidates.
+## Cloudflare Tunnel expectations
+
+- Cloudflare route/tunnel configuration is outside Helm.
+- Route `staging.token.place` to Traefik, typically
+  `http://traefik.kube-system.svc.cluster.local:80`.
+- If available, use:
 
 ```bash
-just tokenplace-logs namespace=<namespace> selector=<label-selector>
+just cf-tunnel-route host=staging.token.place
 ```
 
-## Cloudflare / ingress expectations
+## Troubleshooting
 
-- Staging hostname is distinct from production hostname.
-- Tunnel target points to Traefik (`kube-system` service).
-- DNS records remain proxied in Cloudflare.
-
-## Operator caveats
-
-- Treat staging as promotion gate; avoid ad hoc value edits.
-- Prefer immutable tags for reproducible rollback and forensic traceability.
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
+just tokenplace-status
+just tokenplace-debug-logs-env env=staging
+just cluster-status
+just traefik-status
+just cf-tunnel-debug
+```

--- a/docs/software/index.md
+++ b/docs/software/index.md
@@ -50,8 +50,7 @@ and supporting services stay healthy.
   [k3s-tokenplace-staging.md](../k3s-tokenplace-staging.md), and
   [k3s-tokenplace-prod.md](../k3s-tokenplace-prod.md) — environment runbooks for day-2
   operations.
-- [apps/tokenplace-relay.md](../apps/tokenplace-relay.md) — Helm ingress/TLS guide for
-  token.place staging relay operations.
+- [apps/tokenplace-relay.md](../apps/tokenplace-relay.md) — relay-only token.place runbook with OCI chart/image flow, validation, and rollback.
 
 ## Developer Workflow
 - [contributor_script_map.md](../contributor_script_map.md) — keep automation docs

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -1,107 +1,46 @@
 # token.place Sugarkube onboarding
 
-This guide prepares Sugarkube to run `token.place` as a first-class workload once token.place
-release artifacts and chart wiring are finalized.
+This onboarding guide is now aligned to the relay-only Sugarkube deployment model.
 
-It is intentionally a **deployment-preparation** runbook: it defines stable interfaces,
-ownership, and operational shape without pretending that chart/release identifiers are immutable
-before the token.place onboarding cutover is complete.
+## Deployment scope now
 
-## Why token.place belongs on Sugarkube
+Sugarkube runs only `token.place` `relay.py` as the in-cluster workload.
 
-- Sugarkube already provides a repeatable k3s + ingress + Cloudflare operating model.
-- token.place already has relay operations on Sugarkube (`docs/apps/tokenplace-relay.md`), so this
-  onboarding extends an existing operational pattern instead of introducing a new stack.
-- Sugarkube gives a consistent operator interface (`just` + runbooks) across `dev`, `staging`, and
-  `prod`, reducing drift during promotion and rollback.
+- No in-cluster backend/GPU service is required.
+- External compute nodes remain external (`server.py`, desktop Tauri app, Windows PCs,
+  Apple Silicon Macs, Raspberry Pi compute nodes, etc.).
+- Relay runtime for Sugarkube is a single replica with one worker and in-memory state.
+- Pod restart state loss is currently accepted.
+- Multi-replica stateful architecture is intentionally out of scope.
 
-## Preconditions before onboarding
+## Canonical release model
 
-Before onboarding the full token.place workload, confirm token.place has completed:
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Version pin: `docs/apps/tokenplace.version`
+- Prod tag pin: `docs/apps/tokenplace.prod.tag`
 
-1. Shared desktop/server compute-node runtime.
-2. Desktop parity with `server.py` behavior.
-3. Operationally mature relay service.
-4. Secure API v1 convergence across token.place components.
-5. Release artifact publication (container images + Helm chart) suitable for repeatable deployment.
+## Values model
 
-If any precondition is incomplete, keep using relay-only operations and postpone full onboarding.
+- Base: `docs/examples/tokenplace.values.dev.yaml`
+- Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
+- Prod overlay: `docs/examples/tokenplace.values.prod.yaml`
 
-## Release artifact expectations
+## Runbooks
 
-During onboarding, token.place should provide:
-
-- A Helm chart (OCI or repository path) that supports environment-specific values overlays.
-- Versioned chart metadata (or pinned chart digest/version).
-- Container image tags suitable for promotion (prefer immutable tags).
-- Health endpoints and readiness/liveness semantics documented for operator validation.
-
-## Expected Sugarkube wiring (standardized vs configurable)
-
-Standardized in Sugarkube:
-
-- Task-runner interface (recipes in `justfile`):
-  - `tokenplace-deploy`
-  - `tokenplace-upgrade`
-  - `tokenplace-rollback`
-  - `tokenplace-status`
-  - `tokenplace-logs`
-  - `tokenplace-validate`
-  - `tokenplace-port-forward`
-- Environment runbooks:
-  - `docs/k3s-tokenplace-dev.md`
-  - `docs/k3s-tokenplace-staging.md`
-  - `docs/k3s-tokenplace-prod.md`
-
-Configurable per onboarding cutover:
-
-- Namespace, release name, chart location, values files, chart version pin, and image tag strategy.
-- Ingress hosts and Cloudflare DNS/tunnel mapping.
-- Which token.place components run in-cluster vs on external compute nodes.
-
-## Environment mapping
-
-- `dev`: fast iteration, lower blast radius, relaxed SLOs.
-- `staging`: pre-production integration and release validation.
-- `prod`: public workload, strict rollback and change-control discipline.
-
-Use the environment-specific runbooks for concrete command patterns.
-
-## Ownership boundaries
-
-- **token.place team** owns chart/app semantics, release artifacts, and component-level config.
-- **Sugarkube operators** own cluster lifecycle, ingress/tunnel plumbing, secret distribution,
-  deployment execution, and rollback orchestration.
-- Shared responsibility: production cutover sequencing, health-gate criteria, and incident
-  response.
-
-## App catalog and related docs
-
+- Staging: `docs/k3s-tokenplace-staging.md`
+- Production: `docs/k3s-tokenplace-prod.md`
+- Relay app details: `docs/apps/tokenplace-relay.md`
 - App overview: `docs/apps/tokenplace.md`
-- Relay-specific operations: `docs/apps/tokenplace-relay.md`
-- Environment runbooks:
-  - `docs/k3s-tokenplace-dev.md`
-  - `docs/k3s-tokenplace-staging.md`
-  - `docs/k3s-tokenplace-prod.md`
 
-## Baseline command templates
+## Cloudflare boundary
 
-Set values explicitly per environment to avoid hidden assumptions:
+Cloudflare tunnels/routes are not managed by the Helm chart.
 
-```bash
-just tokenplace-deploy \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<env-values> version_file=<optional-version-file> \
-  tag=<image-tag>
-```
-
-```bash
-just tokenplace-upgrade \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<env-values> version_file=<optional-version-file> \
-  tag=<image-tag>
-```
-
-```bash
-just tokenplace-rollback release=<release> namespace=<namespace> revision=<helm-revision>
-```
+- Route staging/prod hosts to Traefik (typically
+  `http://traefik.kube-system.svc.cluster.local:80`).
+- Use helpers where available:
+  - `just cf-tunnel-route host=staging.token.place`
+  - `just cf-tunnel-route host=token.place`


### PR DESCRIPTION
### Motivation

- Make Sugarkube's token.place documentation concrete and DSPACE-like for a relay-only rollout, describing an OCI image/chart flow and staging→prod promotion model.
- Record the current operational scope (relay.py only, single replica/worker, in-memory state, no in-cluster backend/GPU) so operators have a clear, low-risk steady-state guide.
- Replace stale local-chart/image defaults and vague examples with canonical artifact names, version/tag pins, and exact `just`/`helm-oci` commands for install/upgrade/promotion/rollback.

### Description

- Rewrote and consolidated runbooks to a relay-only model in `docs/apps/tokenplace.md`, `docs/apps/tokenplace-relay.md`, and `docs/tokenplace_sugarkube_onboarding.md` with explicit topology, artifact model, values model, Cloudflare boundary, and operator flows.
- Added concrete staging and prod runbooks and commands in `docs/k3s-tokenplace-staging.md` and `docs/k3s-tokenplace-prod.md` using the OCI chart `oci://ghcr.io/futuroptimist/charts/tokenplace`, release `tokenplace`, namespace `tokenplace`, pinned `docs/apps/tokenplace.version`, and prod tag `docs/apps/tokenplace.prod.tag`.
- Replaced stale image/chart/value references in example/operator value files by changing `ghcr.io/democratizedspace/tokenplace-relay` → `ghcr.io/futuroptimist/tokenplace-relay` and `sha-684fd7f` → `main-REPLACE_SHORTSHA` in `apps/tokenplace-relay/values.dev.yaml` and `docs/examples/tokenplace-relay.values.dev.yaml` for migration/reference.
- Updated docs indices (`docs/index.md`, `docs/software/index.md`) and runbook links to advertise the new relay-only OCI chart/image flow and validation/rollback helper commands.

### Testing

- Verified stale references were removed by running the repository search checks such as `grep -R "ghcr.io/democratizedspace/tokenplace-relay" docs apps README.md && exit 1 || true` and `grep -R "sha-684fd7f" docs apps README.md && exit 1 || true`, which passed after the changes.
- Confirmed canonical chart and release examples are present via `grep -R "oci://ghcr.io/futuroptimist/charts/tokenplace" docs` and `grep -R "release=tokenplace namespace=tokenplace" docs`, which returned the updated runbook lines.
- Attempted docs validation steps `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` but both tools were unavailable in this environment (`command not found`), so spell/link checks were not run here.
- Commit recorded with message `docs: update tokenplace relay-only staging/prod runbooks` including the modified files listed above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13e9fdbfb8832fa7bab34021c4bbfc)