### PR TITLE
docs(tokenplace): add concrete relay-only staging/prod deployment runbooks

### DIFF
--- a/apps/tokenplace-relay/values.dev.yaml
+++ b/apps/tokenplace-relay/values.dev.yaml
@@ -3,7 +3,8 @@
 # commands in the justfile.
 image:
   repository: ghcr.io/futuroptimist/tokenplace-relay
-  tag: main-REPLACE_SHORTSHA
+  # Set image.tag to an immutable value (example: main-deadbee) before deploy.
+  tag: ""
 
 ingress:
   enabled: true

--- a/apps/tokenplace-relay/values.dev.yaml
+++ b/apps/tokenplace-relay/values.dev.yaml
@@ -2,8 +2,8 @@
 # These defaults mirror the dspace staging pattern and are consumed by helper
 # commands in the justfile.
 image:
-  repository: ghcr.io/democratizedspace/tokenplace-relay
-  tag: sha-684fd7f
+  repository: ghcr.io/futuroptimist/tokenplace-relay
+  tag: main-REPLACE_SHORTSHA
 
 ingress:
   enabled: true

--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -35,6 +35,7 @@ Defaults:
 First install:
 
 ```bash
+just kubeconfig-env staging
 TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
 just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
@@ -42,6 +43,7 @@ just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.i
 Existing release upgrade:
 
 ```bash
+just kubeconfig-env staging
 TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
 just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
@@ -91,6 +93,7 @@ just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.i
 Rollback to previous Helm revision:
 
 ```bash
+just kubeconfig-env prod
 TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
 just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
 ```

--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -35,19 +35,19 @@ Defaults:
 First install:
 
 ```bash
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-<7+hexsha>
 ```
 
 Existing release upgrade:
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-<7+hexsha>
 ```
 
 Preferred wrapper:
 
 ```bash
-just tokenplace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+just tokenplace-oci-deploy env=staging tag=main-<7+hexsha>
 ```
 
 ## Staging validation
@@ -65,19 +65,19 @@ curl -fsS https://staging.token.place/
 Promote approved staging image tag:
 
 ```bash
-just tokenplace-oci-promote-prod tag=main-REPLACE_APPROVED_SHORTSHA
+just tokenplace-oci-promote-prod tag=main-<approved-7+hexsha>
 ```
 
 Generic production upgrade with prod overlay:
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_APPROVED_SHORTSHA
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-<approved-7+hexsha>
 ```
 
 Rollback using previous immutable tag:
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_PREVIOUS_SHORTSHA
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-<previous-7+hexsha>
 ```
 
 Rollback to previous Helm revision:
@@ -117,7 +117,7 @@ just cf-tunnel-route host=token.place
 GHCR auth and chart visibility:
 
 ```bash
-helm registry login ghcr.io
+echo "$GHCR_TOKEN" | helm registry login ghcr.io -u "$GHCR_USER" --password-stdin
 helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
 ```
 

--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -35,19 +35,22 @@ Defaults:
 First install:
 
 ```bash
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-<7+hexsha>
+TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
 
 Existing release upgrade:
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-<7+hexsha>
+TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
 
 Preferred wrapper:
 
 ```bash
-just tokenplace-oci-deploy env=staging tag=main-<7+hexsha>
+TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
+just tokenplace-oci-deploy env=staging tag="$TOKENPLACE_TAG"
 ```
 
 ## Staging validation
@@ -65,19 +68,22 @@ curl -fsS https://staging.token.place/
 Promote approved staging image tag:
 
 ```bash
-just tokenplace-oci-promote-prod tag=main-<approved-7+hexsha>
+TOKENPLACE_TAG=main-deadbee # replace with the approved immutable tag
+just tokenplace-oci-promote-prod tag="$TOKENPLACE_TAG"
 ```
 
 Generic production upgrade with prod overlay:
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-<approved-7+hexsha>
+TOKENPLACE_TAG=main-deadbee # replace with the approved immutable tag
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
 
 Rollback using previous immutable tag:
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-<previous-7+hexsha>
+TOKENPLACE_PREVIOUS_TAG=main-deadbee # replace with the prior immutable tag
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_PREVIOUS_TAG"
 ```
 
 Rollback to previous Helm revision:

--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -1,126 +1,138 @@
 # token.place relay on Sugarkube
 
-Deploy the `token.place` relay (`relay.py`) to the Sugarkube k3s cluster with a Helm chart that
-matches the existing dspace staging patterns. The public staging host for the relay service is
-`staging.token.place`, fronted by Traefik and Cloudflare Tunnel.
+This guide documents the **relay-only** token.place deployment on Sugarkube.
 
-For full token.place onboarding and environment runbooks, see
-[`docs/tokenplace_sugarkube_onboarding.md`](../tokenplace_sugarkube_onboarding.md) and [`docs/apps/tokenplace.md`](./tokenplace.md).
+- Sugarkube runs only `relay.py`.
+- No in-cluster backend/GPU service is required.
+- Compute nodes remain external (`server.py`, Tauri desktop app, Windows/Apple Silicon/Raspberry Pi nodes, etc.).
+- Runtime is intentionally single replica, single worker, with in-memory state.
+- In-memory state loss on pod restart is accepted at this stage.
 
-Values are split so you can reuse base settings across environments and layer staging-only ingress
-overrides. Operator defaults live alongside the chart; the docs copies remain as examples for
-cut-and-paste use:
+For the broader app overview, see [`docs/apps/tokenplace.md`](./tokenplace.md).
 
-- `apps/tokenplace-relay/values.dev.yaml`: shared defaults (image repository, annotations).
-- `apps/tokenplace-relay/values.staging.yaml`: staging ingress host + TLS secret.
-- `docs/examples/tokenplace-relay.values.*.yaml`: example mirrors of the operator defaults.
+## Canonical artifacts and release IDs
 
-The Helm release runs in the `tokenplace` namespace with release name `tokenplace-relay`.
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Version pin: `docs/apps/tokenplace.version`
+- Prod approved tag pin: `docs/apps/tokenplace.prod.tag`
 
-## Prerequisites
+## Values files
 
-- A working k3s cluster with Traefik installed.
-- cert-manager with the `letsencrypt-production` ClusterIssuer ready (DNS01 via Cloudflare).
-- Cloudflare Tunnel pointing `staging.token.place` at
-  `http://traefik.kube-system.svc.cluster.local:80` (see [Cloudflare Tunnel docs](../cloudflare_tunnel.md)).
+- Base values: `docs/examples/tokenplace.values.dev.yaml`
+- Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
+- Prod overlay: `docs/examples/tokenplace.values.prod.yaml`
 
-## Container image and Helm chart
+Defaults:
 
-- Image repository: `ghcr.io/democratizedspace/tokenplace-relay`
-  - Tags: immutable `sha-<shortsha>` builds from the CI publisher (recommended) and `main` (mutable).
-  - Default staging tag: `sha-684fd7f` (set via `default_tag` in the helper); override with `tag=sha-<shortsha>` for promotions.
-- Helm chart: `./apps/tokenplace-relay`
-  - Release: `tokenplace-relay`
-  - Namespace: `tokenplace`
+- Staging host: `staging.token.place`
+- Production host: `token.place`
 
-Example values snippet:
+## Staging install/upgrade
 
-```yaml
-image:
-  repository: ghcr.io/democratizedspace/tokenplace-relay
-  tag: sha-684fd7f
-ingress:
-  className: traefik
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-production
-  host: staging.token.place
-  tls:
-    secretName: staging-tokenplace-relay-tls
-env:
-  TOKENPLACE_RELAY_UPSTREAM_URL: http://gpu-server:5015
-probes:
-  port: http
-  readiness:
-    path: /healthz
-  liveness:
-    path: /livez
-```
-
-## Quickstart (staging)
+First install:
 
 ```bash
-# Install or upgrade the relay with staging ingress + TLS (wraps helm upgrade --install)
-just tokenplace-oci-redeploy
-
-# Print ingress + pod status
-just tokenplace-status
-
-# Redeploy a new image tag (sha-<shortsha> from GHCR) after validating a build
-just tokenplace-oci-redeploy tag=sha-<shortsha>
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
-- The `default_tag` keeps staging pinned to a vetted immutable SHA tag; pass `tag=sha-<shortsha>`
-  when promoting a fresh image.
-- Health probes default to `/healthz` (readiness) and `/livez` (liveness) on the `http` port
-  (`containerPort: 5010`). Override `probes.port`, `probes.readiness.path`, or `probes.liveness.path`
-  if the relay exposes a different endpoint.
-- Expected public URL: https://staging.token.place
-- Manual Helm install uses the operator values:
+Existing release upgrade:
 
-  ```bash
-  helm upgrade --install tokenplace-relay ./apps/tokenplace-relay \
-    --namespace tokenplace --create-namespace \
-    -f apps/tokenplace-relay/values.dev.yaml \
-    -f apps/tokenplace-relay/values.staging.yaml
-  ```
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
 
-## Ingress, TLS, and Cloudflare
+Preferred wrapper:
 
-- Ingress class: `traefik`
-- Hostname: `staging.token.place`
-- TLS: cert-manager DNS01 via `letsencrypt-production`, secret `staging-tokenplace-relay-tls`
-- Cloudflare DNS:
-  1. Ensure your tunnel routes `staging.token.place` to
-     `http://traefik.kube-system.svc.cluster.local:80` (see [cloudflare_tunnel.md](../cloudflare_tunnel.md)).
-  2. In Cloudflare DNS, create a proxied CNAME for `staging.token.place` pointing at the
-     tunnel’s `<UUID>.cfargotunnel.com` target. Leave Proxy enabled so TLS terminates at Cloudflare
-     before entering Traefik.
-- TLS troubleshooting:
-  - `kubectl -n tokenplace describe certificate staging-tokenplace-relay-tls`
-  - `kubectl -n tokenplace describe challenge` (if certificates stall)
-  - `kubectl -n cert-manager logs deploy/cert-manager`
-  - `kubectl -n kube-system logs -l app.kubernetes.io/name=traefik`
+```bash
+just tokenplace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+```
 
-## Operational helpers
+## Staging validation
 
-- Deploy or roll forward: `just tokenplace-oci-redeploy [tag=sha-...]` (release `tokenplace-relay`
-  in namespace `tokenplace`, values from `apps/tokenplace-relay/values.*.yaml`)
-- Check status: `just tokenplace-status` (prints pods/ingress and the public URL)
-- Tail logs: `just tokenplace-logs`
-- Port-forward locally: `just tokenplace-port-forward` then `curl http://127.0.0.1:5010/healthz`
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/
+```
+
+## Production promotion, deploy, and rollback
+
+Promote approved staging image tag:
+
+```bash
+just tokenplace-oci-promote-prod tag=main-REPLACE_APPROVED_SHORTSHA
+```
+
+Generic production upgrade with prod overlay:
+
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_APPROVED_SHORTSHA
+```
+
+Rollback using previous immutable tag:
+
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+Rollback to previous Helm revision:
+
+```bash
+just tokenplace-rollback release=tokenplace namespace=tokenplace revision=<known-good-revision>
+```
+
+Production validation:
+
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://token.place/livez
+curl -fsS https://token.place/healthz
+curl -fsS https://token.place/
+```
+
+## Cloudflare tunnel guidance
+
+Use the same DSPACE-style tunnel model:
+
+- Cloudflare hostname routes point to Traefik, typically
+  `http://traefik.kube-system.svc.cluster.local:80`.
+- Staging/prod tunnel and DNS routes are configured outside Helm.
+- The chart deploy does not create Cloudflare routes.
+
+Helpful commands:
+
+```bash
+just cf-tunnel-route host=staging.token.place
+just cf-tunnel-route host=token.place
+```
 
 ## Troubleshooting
 
-- Inspect the release: `helm -n tokenplace status tokenplace-relay`
-- Verify ingress + certificate:
-  - `kubectl -n tokenplace get ingress`
-  - `kubectl -n tokenplace describe ingress tokenplace-relay`
-  - `kubectl -n tokenplace describe certificate staging-tokenplace-relay-tls`
-- Check relay health directly:
-  - `just tokenplace-port-forward`
-  - `curl -fsS http://127.0.0.1:5010/healthz`
-- Logs:
-  - `just tokenplace-logs`
-- Cloudflare Tunnel:
-  - Confirm the tunnel routes `staging.token.place` to Traefik (`http://traefik.kube-system.svc.cluster.local:80`)
-  - Validate DNS for `staging.token.place` in Cloudflare.
+GHCR auth and chart visibility:
+
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
+```
+
+App and logs:
+
+```bash
+just tokenplace-status
+just tokenplace-debug-logs-env env=staging
+just tokenplace-debug-logs-env env=prod
+```
+
+Ingress/Traefik/Tunnel:
+
+```bash
+just cluster-status
+just traefik-status
+just cf-tunnel-debug
+```

--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -75,6 +75,7 @@ just tokenplace-oci-promote-prod tag="$TOKENPLACE_TAG"
 Generic production upgrade with prod overlay:
 
 ```bash
+just kubeconfig-env prod
 TOKENPLACE_TAG=main-deadbee # replace with the approved immutable tag
 just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
@@ -82,6 +83,7 @@ just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.i
 Rollback using previous immutable tag:
 
 ```bash
+just kubeconfig-env prod
 TOKENPLACE_PREVIOUS_TAG=main-deadbee # replace with the prior immutable tag
 just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_PREVIOUS_TAG"
 ```
@@ -89,7 +91,8 @@ just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.i
 Rollback to previous Helm revision:
 
 ```bash
-just tokenplace-rollback release=tokenplace namespace=tokenplace revision=<known-good-revision>
+TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
+just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
 ```
 
 Production validation:

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -1,103 +1,89 @@
 # token.place on Sugarkube
 
-This guide describes the intended token.place deployment model on Sugarkube once token.place
-release artifacts are ready for formal onboarding.
+This is the canonical Sugarkube deployment model for token.place.
 
-For onboarding sequence and ownership boundaries, start with
+For onboarding ownership and environment sequencing, see
 [`docs/tokenplace_sugarkube_onboarding.md`](../tokenplace_sugarkube_onboarding.md).
 
-## Intended topology
+## Relay-only topology (current scope)
 
-token.place on Sugarkube is expected to use a split model:
+Sugarkube currently runs **only** the token.place relay service (`relay.py`).
 
-- **In-cluster (Sugarkube):** edge/API-facing components, ingress, relay-facing services,
-  environment configuration, and operational controls.
-- **External compute nodes:** heavier execution workloads that do not need to run on the Pi cluster.
+- **In-cluster (Sugarkube):** one relay deployment exposed through Traefik ingress.
+- **Out-of-cluster compute:** `server.py`, desktop Tauri app, Windows PCs, Apple Silicon Macs,
+  Raspberry Pi compute nodes, and other compute workers remain external.
+- **No in-cluster backend/GPU service** is required for steady-state relay operation.
+- **Single replica + single worker** defaults are intentional.
+- Relay state is currently **in-memory only**; pod restarts lose relay memory/state and this is
+  accepted for now.
+- Future in-memory database or multi-replica architecture is **out of scope** for this runbook.
 
-This keeps Sugarkube focused on durable control-plane and ingress responsibilities while allowing
-compute capacity to scale independently.
+## Artifact model (canonical)
 
-## Component placement guidance
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Helm release: `tokenplace`
+- Namespace: `tokenplace`
+- Chart version pin file: `docs/apps/tokenplace.version`
+- Production approved tag pin: `docs/apps/tokenplace.prod.tag`
 
-Place on Sugarkube when a component:
+## Values model
 
-- terminates external traffic,
-- requires tight integration with k3s ingress/secrets,
-- benefits from near-cluster observability and rollout controls.
+- Base: `docs/examples/tokenplace.values.dev.yaml`
+- Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
+- Production overlay: `docs/examples/tokenplace.values.prod.yaml`
 
-Prefer external compute when a component:
+Default hosts:
 
-- is CPU/GPU intensive,
-- has bursty runtime needs,
-- can tolerate network hop separation from the relay/API plane.
+- Staging: `staging.token.place`
+- Production: `token.place`
 
-## Post-API-v1 secure deployment model
+## Core deployment commands
 
-Expected steady state after API v1 convergence:
+Use concrete release/namespace/chart values for token.place relay deployments.
 
-- all component-to-component communication uses authenticated API v1 paths,
-- secrets are supplied via Kubernetes Secrets (or SOPS/Flux-managed equivalents),
-- ingress is fronted by Cloudflare + Traefik,
-- environment-specific values control hostnames, auth endpoints, and upstream compute routing.
+```bash
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
 
-## Prerequisites
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
 
-- Sugarkube k3s cluster healthy for target environment (`dev`, `staging`, or `prod`).
-- Cloudflare tunnel + DNS entries prepared for target token.place hostnames.
-- Token.place chart and image artifacts available and documented.
-- Environment values files prepared and reviewed.
+Preferred env wrapper:
 
-## Core operational workflow
+```bash
+just tokenplace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+```
 
-Use parameterized `just` recipes so unreconciled naming can be supplied at runtime:
+## Validation commands
 
-1. Deploy/install:
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/
+```
 
-   ```bash
-   just tokenplace-deploy release=<release> namespace=<namespace> chart=<chart-ref> values=<base>,<env> tag=<tag>
-   ```
+For production validation, use the same checks against `https://token.place`.
 
-2. Upgrade:
+## Cloudflare and ingress model
 
-   ```bash
-   just tokenplace-upgrade release=<release> namespace=<namespace> chart=<chart-ref> values=<base>,<env> tag=<tag>
-   ```
+Cloudflare Tunnel/DNS configuration is external to Helm.
 
-3. Rollback:
+- Route hostnames to Traefik, typically
+  `http://traefik.kube-system.svc.cluster.local:80`.
+- Helm chart deployment does **not** create Cloudflare routes.
+- Configure routes explicitly:
 
-   ```bash
-   just tokenplace-rollback release=<release> namespace=<namespace> revision=<revision>
-   ```
+```bash
+just cf-tunnel-route host=staging.token.place
+just cf-tunnel-route host=token.place
+```
 
-4. Validate:
+## Related runbooks
 
-   ```bash
-   just tokenplace-validate namespace=<namespace> release=<release> health_url=https://<host>/<health-path>
-   ```
-
-5. Inspect and debug:
-
-   ```bash
-   just tokenplace-status namespace=<namespace> release=<release>
-   just tokenplace-logs namespace=<namespace> selector=<label-selector>
-   just tokenplace-port-forward namespace=<namespace> service=<service> local_port=8080 remote_port=80
-   ```
-
-## Cloudflare and ingress expectations
-
-- Public access should terminate via Cloudflare and forward to Traefik.
-- Hostnames should be environment-specific (`dev`, `staging`, `prod`) and documented in the env
-  runbooks.
-- cert-manager issuer and TLS secret naming should be explicit per environment.
-
-## Secrets and config guidance
-
-- Keep environment-specific secrets out of docs and commit history.
-- Prefer immutable promotion tags for staging/prod.
-- Keep shared defaults separate from env overlays to reduce accidental prod drift.
-
-## Operator notes
-
-- Do not assume namespace/release/chart naming until token.place onboarding finalizes.
-- Keep recipes parameterized and runbooks explicit about what is fixed vs configurable.
-- Use relay-specific guide ([`docs/apps/tokenplace-relay.md`](./tokenplace-relay.md)) for current relay-only operations.
+- Relay-focused app guide: [`docs/apps/tokenplace-relay.md`](./tokenplace-relay.md)
+- Staging runbook: [`docs/k3s-tokenplace-staging.md`](../k3s-tokenplace-staging.md)
+- Production runbook: [`docs/k3s-tokenplace-prod.md`](../k3s-tokenplace-prod.md)

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -43,17 +43,17 @@ Default hosts:
 Use concrete release/namespace/chart values for token.place relay deployments.
 
 ```bash
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-<7+hexsha>
 ```
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-<7+hexsha>
 ```
 
 Preferred env wrapper:
 
 ```bash
-just tokenplace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+just tokenplace-oci-deploy env=staging tag=main-<7+hexsha>
 ```
 
 ## Validation commands

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -43,17 +43,20 @@ Default hosts:
 Use concrete release/namespace/chart values for token.place relay deployments.
 
 ```bash
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-<7+hexsha>
+TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-<7+hexsha>
+TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
 
 Preferred env wrapper:
 
 ```bash
-just tokenplace-oci-deploy env=staging tag=main-<7+hexsha>
+TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
+just tokenplace-oci-deploy env=staging tag="$TOKENPLACE_TAG"
 ```
 
 ## Validation commands

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -43,11 +43,13 @@ Default hosts:
 Use concrete release/namespace/chart values for token.place relay deployments.
 
 ```bash
+just kubeconfig-env staging
 TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
 just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
 
 ```bash
+just kubeconfig-env staging
 TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
 just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```

--- a/docs/examples/tokenplace-relay.values.dev.yaml
+++ b/docs/examples/tokenplace-relay.values.dev.yaml
@@ -1,8 +1,8 @@
 # Base values for deploying the token.place relay via Helm (see
 # apps/tokenplace-relay/values.dev.yaml for the operator defaults).
 image:
-  repository: ghcr.io/democratizedspace/tokenplace-relay
-  tag: sha-684fd7f
+  repository: ghcr.io/futuroptimist/tokenplace-relay
+  tag: main-REPLACE_SHORTSHA
 
 ingress:
   enabled: true

--- a/docs/examples/tokenplace-relay.values.dev.yaml
+++ b/docs/examples/tokenplace-relay.values.dev.yaml
@@ -2,7 +2,8 @@
 # apps/tokenplace-relay/values.dev.yaml for the operator defaults).
 image:
   repository: ghcr.io/futuroptimist/tokenplace-relay
-  tag: main-REPLACE_SHORTSHA
+  # Set image.tag to an immutable value (example: main-deadbee) before deploy.
+  tag: ""
 
 ingress:
   enabled: true

--- a/docs/examples/tokenplace.values.prod.yaml
+++ b/docs/examples/tokenplace.values.prod.yaml
@@ -5,6 +5,10 @@ ingress:
   enabled: true
   className: traefik
   host: token.place
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  tls:
+    secretName: tokenplace-prod-tls
 
 env:
   TOKEN_PLACE_ENV: production

--- a/docs/examples/tokenplace.values.staging.yaml
+++ b/docs/examples/tokenplace.values.staging.yaml
@@ -5,6 +5,10 @@ ingress:
   enabled: true
   className: traefik
   host: staging.token.place
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  tls:
+    secretName: tokenplace-staging-tls
 
 env:
   TOKEN_PLACE_ENV: staging

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ Review the safety notes before working with power components.
 - [tokenplace_sugarkube_onboarding.md](tokenplace_sugarkube_onboarding.md) — onboarding contract,
   ownership boundaries, and environment mapping for token.place on Sugarkube
 - [apps/tokenplace.md](apps/tokenplace.md) — token.place app topology and operations model on Sugarkube
-- [apps/tokenplace-relay.md](apps/tokenplace-relay.md) — operate the token.place relay staging deployment
+- [apps/tokenplace-relay.md](apps/tokenplace-relay.md) — relay-only token.place OCI staging/prod operations guide
 - [k3s-tokenplace-dev.md](k3s-tokenplace-dev.md) — token.place dev runbook
 - [k3s-tokenplace-staging.md](k3s-tokenplace-staging.md) — token.place staging runbook
 - [k3s-tokenplace-prod.md](k3s-tokenplace-prod.md) — token.place production runbook

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -1,71 +1,93 @@
 # k3s token.place runbook (prod)
 
-Use this runbook for `prod` token.place deployments on Sugarkube.
+Use this runbook for relay-only token.place production deployments on Sugarkube.
 
-## Purpose
+## Topology and scope
 
-- Safe production deployment, validation, and rollback.
-- Preserve availability with explicit promotion and incident-response workflow.
+- Sugarkube runs only token.place relay (`relay.py`).
+- No in-cluster backend/GPU service is required.
+- Compute nodes remain external (`server.py`, Tauri desktop app, Windows PCs, Apple Silicon Macs,
+  Raspberry Pi compute nodes, etc.).
+- Runtime model is single replica + single worker + in-memory state.
+- In-memory state loss on pod restart is accepted for now.
 
-## Topology intent (prod)
+## Artifact and values contract
 
-- Sugarkube hosts production ingress/API-facing token.place services.
-- External compute nodes execute heavy workloads and are reached through secured API v1 links.
-- Public hostnames route through Cloudflare to Traefik ingress.
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Version pin file: `docs/apps/tokenplace.version`
+- Approved prod tag file: `docs/apps/tokenplace.prod.tag`
+- Values: `docs/examples/tokenplace.values.dev.yaml` + `docs/examples/tokenplace.values.prod.yaml`
+- Default production host: `token.place`
 
-## Prerequisites
-
-- Staging validation completed for the target immutable tag.
-- Production values overlays and secrets approved.
-- Rollback revision identified before upgrade begins.
-
-## Deploy / upgrade / rollback
-
-```bash
-just tokenplace-deploy \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<prod-values> version_file=<optional-version-file> \
-  tag=<approved-immutable-tag>
-```
+## Promotion after staging sign-off
 
 ```bash
-just tokenplace-upgrade \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<prod-values> version_file=<optional-version-file> \
-  tag=<approved-immutable-tag>
+just tokenplace-oci-promote-prod tag=main-REPLACE_APPROVED_SHORTSHA
 ```
+
+## Generic production upgrade
 
 ```bash
-# List history first, then rollback if needed.
-helm -n <namespace> history <release>
-just tokenplace-rollback release=<release> namespace=<namespace> revision=<known-good-revision>
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_APPROVED_SHORTSHA
 ```
 
-## Validation checks
+## Validation
 
 ```bash
-just tokenplace-status namespace=<namespace> release=<release>
-just tokenplace-validate namespace=<namespace> release=<release> health_url=https://<prod-host>/<health>
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://token.place/livez
+curl -fsS https://token.place/healthz
+curl -fsS https://token.place/
 ```
+
+## Rollback options
+
+Rollback by immutable tag:
 
 ```bash
-just tokenplace-logs namespace=<namespace> selector=<label-selector>
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_PREVIOUS_SHORTSHA
 ```
 
-## Cloudflare / ingress expectations
+Rollback by Helm revision:
 
-- Production hostname and TLS secret names are stable and documented.
-- Cloudflare tunnel routes only expected production hosts.
-- Any emergency DNS/ingress change is logged in outage documentation.
+```bash
+just tokenplace-rollback release=tokenplace namespace=tokenplace revision=<known-good-revision>
+```
 
-## Secrets/config guidance
+## Cloudflare tunnel routing (external to Helm)
 
-- Use production-scoped credentials only; never reuse lower-environment keys.
-- Keep secret rotation cadence aligned with Sugarkube security checklist.
-- Apply least-privilege API tokens for DNS/tunnel automation.
+Cloudflare routes are configured outside the chart. Route `token.place` to Traefik,
+typically `http://traefik.kube-system.svc.cluster.local:80`.
 
-## Operator notes and caveats
+```bash
+just cf-tunnel-route host=token.place
+```
 
-- Avoid mutable tags in production.
-- Keep a known-good rollback revision and artifact digest recorded for each deploy.
-- If rollout behavior diverges from staging, pause further promotions and capture diagnostics.
+## Troubleshooting
+
+GHCR auth/chart checks:
+
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
+```
+
+App status/logs:
+
+```bash
+just tokenplace-status
+just tokenplace-debug-logs-env env=staging
+just tokenplace-debug-logs-env env=prod
+```
+
+Ingress/tunnel checks:
+
+```bash
+just cluster-status
+just traefik-status
+just cf-tunnel-debug
+```

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -25,7 +25,8 @@ Use this runbook for relay-only token.place production deployments on Sugarkube.
 ## Promotion after staging sign-off
 
 ```bash
-just tokenplace-oci-promote-prod tag=main-<approved-7+hexsha>
+TOKENPLACE_TAG=main-deadbee # replace with the approved immutable tag
+just tokenplace-oci-promote-prod tag="$TOKENPLACE_TAG"
 ```
 
 ## Generic production upgrade
@@ -39,7 +40,8 @@ just kubeconfig-env prod
 Then run the generic OCI helper:
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-<approved-7+hexsha>
+TOKENPLACE_TAG=main-deadbee # replace with the approved immutable tag
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
 
 ## Validation
@@ -57,7 +59,8 @@ curl -fsS https://token.place/
 Rollback by immutable tag:
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-<previous-7+hexsha>
+TOKENPLACE_PREVIOUS_TAG=main-deadbee # replace with the prior immutable tag
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_PREVIOUS_TAG"
 ```
 
 Rollback by Helm revision:

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -66,7 +66,8 @@ just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.i
 Rollback by Helm revision:
 
 ```bash
-just tokenplace-rollback release=tokenplace namespace=tokenplace revision=<known-good-revision>
+TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
+just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
 ```
 
 ## Cloudflare tunnel routing (external to Helm)

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -59,6 +59,7 @@ curl -fsS https://token.place/
 Rollback by immutable tag:
 
 ```bash
+just kubeconfig-env prod
 TOKENPLACE_PREVIOUS_TAG=main-deadbee # replace with the prior immutable tag
 just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_PREVIOUS_TAG"
 ```
@@ -66,6 +67,7 @@ just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.i
 Rollback by Helm revision:
 
 ```bash
+just kubeconfig-env prod
 TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
 just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
 ```

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -25,13 +25,21 @@ Use this runbook for relay-only token.place production deployments on Sugarkube.
 ## Promotion after staging sign-off
 
 ```bash
-just tokenplace-oci-promote-prod tag=main-REPLACE_APPROVED_SHORTSHA
+just tokenplace-oci-promote-prod tag=main-<approved-7+hexsha>
 ```
 
 ## Generic production upgrade
 
+Select the production kube context first (or use the wrapper above):
+
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_APPROVED_SHORTSHA
+just kubeconfig-env prod
+```
+
+Then run the generic OCI helper:
+
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-<approved-7+hexsha>
 ```
 
 ## Validation
@@ -49,7 +57,7 @@ curl -fsS https://token.place/
 Rollback by immutable tag:
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_PREVIOUS_SHORTSHA
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-<previous-7+hexsha>
 ```
 
 Rollback by Helm revision:
@@ -72,7 +80,7 @@ just cf-tunnel-route host=token.place
 GHCR auth/chart checks:
 
 ```bash
-helm registry login ghcr.io
+echo "$GHCR_TOKEN" | helm registry login ghcr.io -u "$GHCR_USER" --password-stdin
 helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
 ```
 
@@ -80,7 +88,6 @@ App status/logs:
 
 ```bash
 just tokenplace-status
-just tokenplace-debug-logs-env env=staging
 just tokenplace-debug-logs-env env=prod
 ```
 

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -24,19 +24,19 @@ Use this runbook for relay-only token.place staging deployments on Sugarkube.
 ## First install
 
 ```bash
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-<7+hexsha>
 ```
 
 ## Existing release upgrade
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-<7+hexsha>
 ```
 
 Preferred wrapper:
 
 ```bash
-just tokenplace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+just tokenplace-oci-deploy env=staging tag=main-<7+hexsha>
 ```
 
 ## Validation
@@ -54,7 +54,7 @@ curl -fsS https://staging.token.place/
 Rollback by immutable tag:
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_PREVIOUS_SHORTSHA
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-<previous-7+hexsha>
 ```
 
 Rollback by Helm revision:

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -64,7 +64,8 @@ just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.i
 Rollback by Helm revision:
 
 ```bash
-just tokenplace-rollback release=tokenplace namespace=tokenplace revision=<known-good-revision>
+TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
+just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
 ```
 
 ## Cloudflare tunnel routing (external to Helm)

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -1,66 +1,73 @@
 # k3s token.place runbook (staging)
 
-Use this runbook for `staging` token.place deployments on Sugarkube.
+Use this runbook for relay-only token.place staging deployments on Sugarkube.
 
-## Purpose
+## Topology and scope
 
-- Release-candidate validation before production promotion.
-- Full ingress + Cloudflare + TLS + API v1 behavior checks.
+- Sugarkube runs only token.place relay (`relay.py`).
+- No in-cluster backend/GPU service is required.
+- Compute nodes remain external (`server.py`, Tauri desktop app, Windows PCs, Apple Silicon Macs,
+  Raspberry Pi compute nodes, etc.).
+- Runtime model is single replica + single worker + in-memory state.
+- In-memory state loss on pod restart is accepted for now.
 
-## Topology intent (staging)
+## Artifact and values contract
 
-- Sugarkube runs ingress/API-facing token.place services and relay integration points.
-- External compute remains out-of-cluster but reachable over secured API v1 paths.
-- Staging should mirror production architecture closely, with lower traffic volume.
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Version pin file: `docs/apps/tokenplace.version`
+- Values: `docs/examples/tokenplace.values.dev.yaml` + `docs/examples/tokenplace.values.staging.yaml`
+- Default staging host: `staging.token.place`
 
-## Prerequisites
-
-- Chart/release wiring is defined for staging.
-- Staging values overlays and secrets are reviewed.
-- Cloudflare hostname routing to Traefik is configured.
-
-## Deploy / upgrade / rollback
-
-```bash
-just tokenplace-deploy \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<staging-values> version_file=<optional-version-file> \
-  tag=<immutable-tag>
-```
+## First install
 
 ```bash
-just tokenplace-upgrade \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<staging-values> version_file=<optional-version-file> \
-  tag=<immutable-tag>
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
+
+## Existing release upgrade
 
 ```bash
-just tokenplace-rollback release=<release> namespace=<namespace> revision=<helm-revision>
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
 
-## Validation checks
+Preferred wrapper:
 
 ```bash
-just tokenplace-status namespace=<namespace> release=<release>
-just tokenplace-validate namespace=<namespace> release=<release> health_url=https://<staging-host>/<health>
+just tokenplace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
 ```
 
-- Confirm ingress host and TLS certificate are ready.
-- Confirm API v1 auth and external compute connectivity are healthy.
-- Capture logs for relay/API components when validating release candidates.
+## Validation
 
 ```bash
-just tokenplace-logs namespace=<namespace> selector=<label-selector>
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/
 ```
 
-## Cloudflare / ingress expectations
+## Rollback
 
-- Staging hostname is distinct from production hostname.
-- Tunnel target points to Traefik (`kube-system` service).
-- DNS records remain proxied in Cloudflare.
+Rollback by immutable tag:
 
-## Operator caveats
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_PREVIOUS_SHORTSHA
+```
 
-- Treat staging as promotion gate; avoid ad hoc value edits.
-- Prefer immutable tags for reproducible rollback and forensic traceability.
+Rollback by Helm revision:
+
+```bash
+just tokenplace-rollback release=tokenplace namespace=tokenplace revision=<known-good-revision>
+```
+
+## Cloudflare tunnel routing (external to Helm)
+
+Cloudflare routes are configured outside the chart. Route `staging.token.place` to Traefik,
+typically `http://traefik.kube-system.svc.cluster.local:80`.
+
+```bash
+just cf-tunnel-route host=staging.token.place
+```

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -24,6 +24,7 @@ Use this runbook for relay-only token.place staging deployments on Sugarkube.
 ## First install
 
 ```bash
+just kubeconfig-env staging
 TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
 just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
@@ -31,6 +32,7 @@ just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.i
 ## Existing release upgrade
 
 ```bash
+just kubeconfig-env staging
 TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
 just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
@@ -57,6 +59,7 @@ curl -fsS https://staging.token.place/
 Rollback by immutable tag:
 
 ```bash
+just kubeconfig-env staging
 TOKENPLACE_PREVIOUS_TAG=main-deadbee # replace with the prior immutable tag
 just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_PREVIOUS_TAG"
 ```
@@ -64,6 +67,7 @@ just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.i
 Rollback by Helm revision:
 
 ```bash
+just kubeconfig-env staging
 TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
 just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
 ```

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -24,19 +24,22 @@ Use this runbook for relay-only token.place staging deployments on Sugarkube.
 ## First install
 
 ```bash
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-<7+hexsha>
+TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
 
 ## Existing release upgrade
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-<7+hexsha>
+TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
 
 Preferred wrapper:
 
 ```bash
-just tokenplace-oci-deploy env=staging tag=main-<7+hexsha>
+TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
+just tokenplace-oci-deploy env=staging tag="$TOKENPLACE_TAG"
 ```
 
 ## Validation
@@ -54,7 +57,8 @@ curl -fsS https://staging.token.place/
 Rollback by immutable tag:
 
 ```bash
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-<previous-7+hexsha>
+TOKENPLACE_PREVIOUS_TAG=main-deadbee # replace with the prior immutable tag
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_PREVIOUS_TAG"
 ```
 
 Rollback by Helm revision:

--- a/docs/software/index.md
+++ b/docs/software/index.md
@@ -50,8 +50,8 @@ and supporting services stay healthy.
   [k3s-tokenplace-staging.md](../k3s-tokenplace-staging.md), and
   [k3s-tokenplace-prod.md](../k3s-tokenplace-prod.md) — environment runbooks for day-2
   operations.
-- [apps/tokenplace-relay.md](../apps/tokenplace-relay.md) — Helm ingress/TLS guide for
-  token.place staging relay operations.
+- [apps/tokenplace-relay.md](../apps/tokenplace-relay.md) — relay-only OCI token.place
+  staging/prod operations guide.
 
 ## Developer Workflow
 - [contributor_script_map.md](../contributor_script_map.md) — keep automation docs

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -1,107 +1,47 @@
 # token.place Sugarkube onboarding
 
-This guide prepares Sugarkube to run `token.place` as a first-class workload once token.place
-release artifacts and chart wiring are finalized.
+This guide defines the concrete Sugarkube operating contract for token.place relay deployments.
 
-It is intentionally a **deployment-preparation** runbook: it defines stable interfaces,
-ownership, and operational shape without pretending that chart/release identifiers are immutable
-before the token.place onboarding cutover is complete.
+## Scope and topology
 
-## Why token.place belongs on Sugarkube
+Current scope is **relay-only** on Sugarkube:
 
-- Sugarkube already provides a repeatable k3s + ingress + Cloudflare operating model.
-- token.place already has relay operations on Sugarkube (`docs/apps/tokenplace-relay.md`), so this
-  onboarding extends an existing operational pattern instead of introducing a new stack.
-- Sugarkube gives a consistent operator interface (`just` + runbooks) across `dev`, `staging`, and
-  `prod`, reducing drift during promotion and rollback.
+- Sugarkube runs only `relay.py`.
+- No in-cluster backend/GPU service is required.
+- Compute nodes remain external (`server.py`, desktop Tauri app, Windows PCs, Apple Silicon Macs,
+  Raspberry Pi compute nodes, and other remote workers).
+- Runtime defaults are one replica and one worker with in-memory state.
+- State loss on pod restart is currently accepted.
+- Future multi-replica / in-memory database architecture is out of scope for this runbook.
 
-## Preconditions before onboarding
+## Canonical artifacts and IDs
 
-Before onboarding the full token.place workload, confirm token.place has completed:
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Version pin file: `docs/apps/tokenplace.version`
+- Production approved tag file: `docs/apps/tokenplace.prod.tag`
 
-1. Shared desktop/server compute-node runtime.
-2. Desktop parity with `server.py` behavior.
-3. Operationally mature relay service.
-4. Secure API v1 convergence across token.place components.
-5. Release artifact publication (container images + Helm chart) suitable for repeatable deployment.
+## Values model
 
-If any precondition is incomplete, keep using relay-only operations and postpone full onboarding.
+- Base defaults: `docs/examples/tokenplace.values.dev.yaml`
+- Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
+- Production overlay: `docs/examples/tokenplace.values.prod.yaml`
 
-## Release artifact expectations
+Host defaults:
 
-During onboarding, token.place should provide:
+- Staging: `staging.token.place`
+- Production: `token.place`
 
-- A Helm chart (OCI or repository path) that supports environment-specific values overlays.
-- Versioned chart metadata (or pinned chart digest/version).
-- Container image tags suitable for promotion (prefer immutable tags).
-- Health endpoints and readiness/liveness semantics documented for operator validation.
-
-## Expected Sugarkube wiring (standardized vs configurable)
-
-Standardized in Sugarkube:
-
-- Task-runner interface (recipes in `justfile`):
-  - `tokenplace-deploy`
-  - `tokenplace-upgrade`
-  - `tokenplace-rollback`
-  - `tokenplace-status`
-  - `tokenplace-logs`
-  - `tokenplace-validate`
-  - `tokenplace-port-forward`
-- Environment runbooks:
-  - `docs/k3s-tokenplace-dev.md`
-  - `docs/k3s-tokenplace-staging.md`
-  - `docs/k3s-tokenplace-prod.md`
-
-Configurable per onboarding cutover:
-
-- Namespace, release name, chart location, values files, chart version pin, and image tag strategy.
-- Ingress hosts and Cloudflare DNS/tunnel mapping.
-- Which token.place components run in-cluster vs on external compute nodes.
-
-## Environment mapping
-
-- `dev`: fast iteration, lower blast radius, relaxed SLOs.
-- `staging`: pre-production integration and release validation.
-- `prod`: public workload, strict rollback and change-control discipline.
-
-Use the environment-specific runbooks for concrete command patterns.
-
-## Ownership boundaries
-
-- **token.place team** owns chart/app semantics, release artifacts, and component-level config.
-- **Sugarkube operators** own cluster lifecycle, ingress/tunnel plumbing, secret distribution,
-  deployment execution, and rollback orchestration.
-- Shared responsibility: production cutover sequencing, health-gate criteria, and incident
-  response.
-
-## App catalog and related docs
+## Environment runbooks
 
 - App overview: `docs/apps/tokenplace.md`
-- Relay-specific operations: `docs/apps/tokenplace-relay.md`
-- Environment runbooks:
-  - `docs/k3s-tokenplace-dev.md`
-  - `docs/k3s-tokenplace-staging.md`
-  - `docs/k3s-tokenplace-prod.md`
+- Relay runbook: `docs/apps/tokenplace-relay.md`
+- Staging runbook: `docs/k3s-tokenplace-staging.md`
+- Production runbook: `docs/k3s-tokenplace-prod.md`
 
-## Baseline command templates
+## Cloudflare model
 
-Set values explicitly per environment to avoid hidden assumptions:
-
-```bash
-just tokenplace-deploy \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<env-values> version_file=<optional-version-file> \
-  tag=<image-tag>
-```
-
-```bash
-just tokenplace-upgrade \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<env-values> version_file=<optional-version-file> \
-  tag=<image-tag>
-```
-
-```bash
-just tokenplace-rollback release=<release> namespace=<namespace> revision=<helm-revision>
-```
+Cloudflare tunnels/routes are managed outside Helm. Use route mappings from hostname to Traefik
+(typically `http://traefik.kube-system.svc.cluster.local:80`) before deploy/upgrade steps.


### PR DESCRIPTION
### Motivation

- Make Sugarkube’s token.place documentation concrete and DSPACE-like for a relay-only rollout, removing stale local/chart/image defaults and clarifying operator responsibilities.  
- Standardize canonical artifact identifiers (`ghcr.io/futuroptimist/tokenplace-relay`, `oci://ghcr.io/futuroptimist/charts/tokenplace`, release `tokenplace`, namespace `tokenplace`) and provide explicit staging/prod runbooks.  
- Ensure docs do not require an in-cluster backend/GPU service and that Cloudflare Tunnel routing is described as external to Helm.

### Description

- Rewrote and consolidated the relay-focused app and onboarding docs to a canonical relay-only model, including `docs/apps/tokenplace.md`, `docs/apps/tokenplace-relay.md`, and `docs/tokenplace_sugarkube_onboarding.md`.  
- Added environment runbooks and concrete commands for staging and production in `docs/k3s-tokenplace-staging.md` and `docs/k3s-tokenplace-prod.md`, including install, upgrade, promotion, validation, and rollback examples using the Helm OCI helpers.  
- Normalized example/operator values to the new image and tag placeholders by updating `docs/examples/tokenplace-relay.values.dev.yaml` and `apps/tokenplace-relay/values.dev.yaml` to `ghcr.io/futuroptimist/tokenplace-relay` and `tag: main-REPLACE_SHORTSHA`, and removed references to `ghcr.io/democratizedspace/tokenplace-relay` and `sha-684fd7f`.  
- Clarified Cloudflare Tunnel guidance (routes point to Traefik, outside Helm) and added GHCR/Helm troubleshooting commands and smoke/validation curl checks in the runbooks.

### Testing

- Ran repository checks to validate replacements and references:  
  - `grep -R "ghcr.io/democratizedspace/tokenplace-relay" docs apps README.md || true` — returned no active matches in docs after edits.  
  - `grep -R "sha-684fd7f" docs apps README.md || true` — returned no active matches in docs after edits.  
  - `grep -R "./apps/tokenplace-relay" docs README.md || true` — left only a single deprecation/reference where the local chart is documented as deprecated (expected).  
  - `grep -R "oci://ghcr.io/futuroptimist/charts/tokenplace" docs` — confirmed the canonical chart reference is present in runbooks.  
  - `grep -R "release=tokenplace namespace=tokenplace" docs` — confirmed runbooks include the concrete release/namespace examples.  
- Attempted doc tooling but required tools were not available in this environment:  
  - `pyspelling -c .spellcheck.yaml` — not run (`pyspelling: command not found`).  
  - `linkchecker --no-warnings README.md docs/` — not run (`linkchecker: command not found`).  

Files updated (key): `docs/apps/tokenplace.md`, `docs/apps/tokenplace-relay.md`, `docs/tokenplace_sugarkube_onboarding.md`, `docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`, `docs/examples/tokenplace-relay.values.dev.yaml`, `apps/tokenplace-relay/values.dev.yaml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13e9fdbfb8832fa7bab34021c4bbfc)