### PR TITLE
docs: update tokenplace relay-only topology and staging/prod runbooks

### DIFF
--- a/apps/tokenplace-relay/values.dev.yaml
+++ b/apps/tokenplace-relay/values.dev.yaml
@@ -2,8 +2,8 @@
 # These defaults mirror the dspace staging pattern and are consumed by helper
 # commands in the justfile.
 image:
-  repository: ghcr.io/democratizedspace/tokenplace-relay
-  tag: sha-684fd7f
+  repository: ghcr.io/futuroptimist/tokenplace-relay
+  tag: main-REPLACE_SHORTSHA
 
 ingress:
   enabled: true

--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -1,126 +1,75 @@
 # token.place relay on Sugarkube
 
-Deploy the `token.place` relay (`relay.py`) to the Sugarkube k3s cluster with a Helm chart that
-matches the existing dspace staging patterns. The public staging host for the relay service is
-`staging.token.place`, fronted by Traefik and Cloudflare Tunnel.
+This page documents relay-specific operations for the canonical token.place OCI deployment.
 
-For full token.place onboarding and environment runbooks, see
-[`docs/tokenplace_sugarkube_onboarding.md`](../tokenplace_sugarkube_onboarding.md) and [`docs/apps/tokenplace.md`](./tokenplace.md).
+The local `apps/tokenplace-relay` chart is deprecated for steady-state operations. Use the
+OCI chart and values files described below.
 
-Values are split so you can reuse base settings across environments and layer staging-only ingress
-overrides. Operator defaults live alongside the chart; the docs copies remain as examples for
-cut-and-paste use:
+## Relay-only topology (current state)
 
-- `apps/tokenplace-relay/values.dev.yaml`: shared defaults (image repository, annotations).
-- `apps/tokenplace-relay/values.staging.yaml`: staging ingress host + TLS secret.
-- `docs/examples/tokenplace-relay.values.*.yaml`: example mirrors of the operator defaults.
+Sugarkube runs relay-only token.place today:
 
-The Helm release runs in the `tokenplace` namespace with release name `tokenplace-relay`.
+- Runs: `relay.py` in k3s.
+- Does not run: in-cluster backend service or GPU service.
+- External compute remains outside the cluster (`server.py`, desktop Tauri app, Windows PCs,
+  Apple Silicon Macs, Raspberry Pi compute nodes).
+- Deployment is intentionally single-replica, single-worker, in-memory state.
+- Pod restart/state loss is accepted for now.
+- Multi-replica or shared-state architecture is future work and out of scope for this runbook.
 
-## Prerequisites
+## Canonical artifacts and pins
 
-- A working k3s cluster with Traefik installed.
-- cert-manager with the `letsencrypt-production` ClusterIssuer ready (DNS01 via Cloudflare).
-- Cloudflare Tunnel pointing `staging.token.place` at
-  `http://traefik.kube-system.svc.cluster.local:80` (see [Cloudflare Tunnel docs](../cloudflare_tunnel.md)).
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Chart version pin: `docs/apps/tokenplace.version`
+- Production approved image tag: `docs/apps/tokenplace.prod.tag`
 
-## Container image and Helm chart
+## Values layering
 
-- Image repository: `ghcr.io/democratizedspace/tokenplace-relay`
-  - Tags: immutable `sha-<shortsha>` builds from the CI publisher (recommended) and `main` (mutable).
-  - Default staging tag: `sha-684fd7f` (set via `default_tag` in the helper); override with `tag=sha-<shortsha>` for promotions.
-- Helm chart: `./apps/tokenplace-relay`
-  - Release: `tokenplace-relay`
-  - Namespace: `tokenplace`
+- Base defaults: `docs/examples/tokenplace.values.dev.yaml`
+- Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
+- Production overlay: `docs/examples/tokenplace.values.prod.yaml`
 
-Example values snippet:
+## Staging deployment quick commands
 
-```yaml
-image:
-  repository: ghcr.io/democratizedspace/tokenplace-relay
-  tag: sha-684fd7f
-ingress:
-  className: traefik
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-production
-  host: staging.token.place
-  tls:
-    secretName: staging-tokenplace-relay-tls
-env:
-  TOKENPLACE_RELAY_UPSTREAM_URL: http://gpu-server:5015
-probes:
-  port: http
-  readiness:
-    path: /healthz
-  liveness:
-    path: /livez
-```
-
-## Quickstart (staging)
+Prefer wrapper:
 
 ```bash
-# Install or upgrade the relay with staging ingress + TLS (wraps helm upgrade --install)
-just tokenplace-oci-redeploy
-
-# Print ingress + pod status
-just tokenplace-status
-
-# Redeploy a new image tag (sha-<shortsha> from GHCR) after validating a build
-just tokenplace-oci-redeploy tag=sha-<shortsha>
+just tokenplace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
 ```
 
-- The `default_tag` keeps staging pinned to a vetted immutable SHA tag; pass `tag=sha-<shortsha>`
-  when promoting a fresh image.
-- Health probes default to `/healthz` (readiness) and `/livez` (liveness) on the `http` port
-  (`containerPort: 5010`). Override `probes.port`, `probes.readiness.path`, or `probes.liveness.path`
-  if the relay exposes a different endpoint.
-- Expected public URL: https://staging.token.place
-- Manual Helm install uses the operator values:
+Equivalent explicit commands:
 
-  ```bash
-  helm upgrade --install tokenplace-relay ./apps/tokenplace-relay \
-    --namespace tokenplace --create-namespace \
-    -f apps/tokenplace-relay/values.dev.yaml \
-    -f apps/tokenplace-relay/values.staging.yaml
-  ```
+```bash
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
 
-## Ingress, TLS, and Cloudflare
+```bash
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
+```
 
-- Ingress class: `traefik`
-- Hostname: `staging.token.place`
-- TLS: cert-manager DNS01 via `letsencrypt-production`, secret `staging-tokenplace-relay-tls`
-- Cloudflare DNS:
-  1. Ensure your tunnel routes `staging.token.place` to
-     `http://traefik.kube-system.svc.cluster.local:80` (see [cloudflare_tunnel.md](../cloudflare_tunnel.md)).
-  2. In Cloudflare DNS, create a proxied CNAME for `staging.token.place` pointing at the
-     tunnel’s `<UUID>.cfargotunnel.com` target. Leave Proxy enabled so TLS terminates at Cloudflare
-     before entering Traefik.
-- TLS troubleshooting:
-  - `kubectl -n tokenplace describe certificate staging-tokenplace-relay-tls`
-  - `kubectl -n tokenplace describe challenge` (if certificates stall)
-  - `kubectl -n cert-manager logs deploy/cert-manager`
-  - `kubectl -n kube-system logs -l app.kubernetes.io/name=traefik`
+## Validation commands
 
-## Operational helpers
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/
+```
 
-- Deploy or roll forward: `just tokenplace-oci-redeploy [tag=sha-...]` (release `tokenplace-relay`
-  in namespace `tokenplace`, values from `apps/tokenplace-relay/values.*.yaml`)
-- Check status: `just tokenplace-status` (prints pods/ingress and the public URL)
-- Tail logs: `just tokenplace-logs`
-- Port-forward locally: `just tokenplace-port-forward` then `curl http://127.0.0.1:5010/healthz`
+## Cloudflare tunnel guidance
 
-## Troubleshooting
+Configure tunnel routes separately from Helm. Route hosts to Traefik service:
+`http://traefik.kube-system.svc.cluster.local:80`.
 
-- Inspect the release: `helm -n tokenplace status tokenplace-relay`
-- Verify ingress + certificate:
-  - `kubectl -n tokenplace get ingress`
-  - `kubectl -n tokenplace describe ingress tokenplace-relay`
-  - `kubectl -n tokenplace describe certificate staging-tokenplace-relay-tls`
-- Check relay health directly:
-  - `just tokenplace-port-forward`
-  - `curl -fsS http://127.0.0.1:5010/healthz`
-- Logs:
-  - `just tokenplace-logs`
-- Cloudflare Tunnel:
-  - Confirm the tunnel routes `staging.token.place` to Traefik (`http://traefik.kube-system.svc.cluster.local:80`)
-  - Validate DNS for `staging.token.place` in Cloudflare.
+Helpful commands when managing routes:
+
+```bash
+just cf-tunnel-route host=staging.token.place
+just cf-tunnel-route host=token.place
+```
+
+See also [`docs/cloudflare_tunnel.md`](../cloudflare_tunnel.md).

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -1,103 +1,80 @@
 # token.place on Sugarkube
 
-This guide describes the intended token.place deployment model on Sugarkube once token.place
-release artifacts are ready for formal onboarding.
+This is the canonical operations guide for token.place on Sugarkube.
 
-For onboarding sequence and ownership boundaries, start with
+For onboarding context and environment ownership boundaries, start with
 [`docs/tokenplace_sugarkube_onboarding.md`](../tokenplace_sugarkube_onboarding.md).
 
-## Intended topology
+## Current production scope (relay-only)
 
-token.place on Sugarkube is expected to use a split model:
+Sugarkube currently runs **only** `token.place` `relay.py`.
 
-- **In-cluster (Sugarkube):** edge/API-facing components, ingress, relay-facing services,
-  environment configuration, and operational controls.
-- **External compute nodes:** heavier execution workloads that do not need to run on the Pi cluster.
+- **In-cluster (Sugarkube):** one relay deployment (`tokenplace`) behind Traefik ingress.
+- **Not in-cluster:** no backend service and no GPU service are deployed on Sugarkube.
+- **External compute nodes:** remain outside the cluster (for example `server.py`, desktop Tauri app,
+  Windows PCs, Apple Silicon Macs, Raspberry Pi compute nodes).
+- **Runtime model today:** single replica, single worker, in-memory relay state.
+- **Failure model:** state loss on pod death is accepted for now.
+- **Out of scope:** multi-replica relay coordination and in-memory database architecture.
 
-This keeps Sugarkube focused on durable control-plane and ingress responsibilities while allowing
-compute capacity to scale independently.
+## Artifact and release model
 
-## Component placement guidance
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Version pin: `docs/apps/tokenplace.version`
+- Production approved tag pin: `docs/apps/tokenplace.prod.tag`
 
-Place on Sugarkube when a component:
+## Values model
 
-- terminates external traffic,
-- requires tight integration with k3s ingress/secrets,
-- benefits from near-cluster observability and rollout controls.
+Layer values exactly like DSPACE-style OCI deploys:
 
-Prefer external compute when a component:
+- Base: `docs/examples/tokenplace.values.dev.yaml`
+- Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
+- Production overlay: `docs/examples/tokenplace.values.prod.yaml`
 
-- is CPU/GPU intensive,
-- has bursty runtime needs,
-- can tolerate network hop separation from the relay/API plane.
+Default hosts:
 
-## Post-API-v1 secure deployment model
+- Staging: `staging.token.place`
+- Production: `token.place`
 
-Expected steady state after API v1 convergence:
+## Deployment entrypoints
 
-- all component-to-component communication uses authenticated API v1 paths,
-- secrets are supplied via Kubernetes Secrets (or SOPS/Flux-managed equivalents),
-- ingress is fronted by Cloudflare + Traefik,
-- environment-specific values control hostnames, auth endpoints, and upstream compute routing.
+Primary environment-aware wrappers:
 
-## Prerequisites
+- `just tokenplace-oci-deploy env=staging tag=<immutable-tag>`
+- `just tokenplace-oci-deploy env=prod tag=<immutable-tag>`
+- `just tokenplace-oci-promote-prod tag=<approved-immutable-tag>`
 
-- Sugarkube k3s cluster healthy for target environment (`dev`, `staging`, or `prod`).
-- Cloudflare tunnel + DNS entries prepared for target token.place hostnames.
-- Token.place chart and image artifacts available and documented.
-- Environment values files prepared and reviewed.
+Generic OCI helper commands are still available as secondary references:
 
-## Core operational workflow
+- `just helm-oci-install ...`
+- `just helm-oci-upgrade ...`
 
-Use parameterized `just` recipes so unreconciled naming can be supplied at runtime:
+## Cloudflare + ingress model
 
-1. Deploy/install:
+Cloudflare tunnel routing is managed **outside** Helm charts.
 
-   ```bash
-   just tokenplace-deploy release=<release> namespace=<namespace> chart=<chart-ref> values=<base>,<env> tag=<tag>
-   ```
+- Route `staging.token.place` and `token.place` to Traefik, typically:
+  `http://traefik.kube-system.svc.cluster.local:80`
+- Helm deploys Kubernetes resources only; it does **not** create Cloudflare routes.
+- If available in your operator workflow, use:
+  - `just cf-tunnel-route host=staging.token.place`
+  - `just cf-tunnel-route host=token.place`
 
-2. Upgrade:
+## Day-2 validation and troubleshooting shortcuts
 
-   ```bash
-   just tokenplace-upgrade release=<release> namespace=<namespace> chart=<chart-ref> values=<base>,<env> tag=<tag>
-   ```
+- App status: `just tokenplace-status`
+- Logs by environment:
+  - `just tokenplace-debug-logs-env env=staging`
+  - `just tokenplace-debug-logs-env env=prod`
+- Cluster edge path checks:
+  - `just cluster-status`
+  - `just traefik-status`
+  - `just cf-tunnel-debug`
 
-3. Rollback:
+For concrete per-environment procedures, use:
 
-   ```bash
-   just tokenplace-rollback release=<release> namespace=<namespace> revision=<revision>
-   ```
-
-4. Validate:
-
-   ```bash
-   just tokenplace-validate namespace=<namespace> release=<release> health_url=https://<host>/<health-path>
-   ```
-
-5. Inspect and debug:
-
-   ```bash
-   just tokenplace-status namespace=<namespace> release=<release>
-   just tokenplace-logs namespace=<namespace> selector=<label-selector>
-   just tokenplace-port-forward namespace=<namespace> service=<service> local_port=8080 remote_port=80
-   ```
-
-## Cloudflare and ingress expectations
-
-- Public access should terminate via Cloudflare and forward to Traefik.
-- Hostnames should be environment-specific (`dev`, `staging`, `prod`) and documented in the env
-  runbooks.
-- cert-manager issuer and TLS secret naming should be explicit per environment.
-
-## Secrets and config guidance
-
-- Keep environment-specific secrets out of docs and commit history.
-- Prefer immutable promotion tags for staging/prod.
-- Keep shared defaults separate from env overlays to reduce accidental prod drift.
-
-## Operator notes
-
-- Do not assume namespace/release/chart naming until token.place onboarding finalizes.
-- Keep recipes parameterized and runbooks explicit about what is fixed vs configurable.
-- Use relay-specific guide ([`docs/apps/tokenplace-relay.md`](./tokenplace-relay.md)) for current relay-only operations.
+- [`docs/k3s-tokenplace-staging.md`](../k3s-tokenplace-staging.md)
+- [`docs/k3s-tokenplace-prod.md`](../k3s-tokenplace-prod.md)

--- a/docs/examples/tokenplace-relay.values.dev.yaml
+++ b/docs/examples/tokenplace-relay.values.dev.yaml
@@ -1,8 +1,8 @@
 # Base values for deploying the token.place relay via Helm (see
 # apps/tokenplace-relay/values.dev.yaml for the operator defaults).
 image:
-  repository: ghcr.io/democratizedspace/tokenplace-relay
-  tag: sha-684fd7f
+  repository: ghcr.io/futuroptimist/tokenplace-relay
+  tag: main-REPLACE_SHORTSHA
 
 ingress:
   enabled: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ Review the safety notes before working with power components.
 - [tokenplace_sugarkube_onboarding.md](tokenplace_sugarkube_onboarding.md) — onboarding contract,
   ownership boundaries, and environment mapping for token.place on Sugarkube
 - [apps/tokenplace.md](apps/tokenplace.md) — token.place app topology and operations model on Sugarkube
-- [apps/tokenplace-relay.md](apps/tokenplace-relay.md) — operate the token.place relay staging deployment
+- [apps/tokenplace-relay.md](apps/tokenplace-relay.md) — relay-only token.place operations (canonical OCI chart)
 - [k3s-tokenplace-dev.md](k3s-tokenplace-dev.md) — token.place dev runbook
 - [k3s-tokenplace-staging.md](k3s-tokenplace-staging.md) — token.place staging runbook
 - [k3s-tokenplace-prod.md](k3s-tokenplace-prod.md) — token.place production runbook

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -1,71 +1,77 @@
 # k3s token.place runbook (prod)
 
-Use this runbook for `prod` token.place deployments on Sugarkube.
+Use this runbook for relay-only production deployments after staging sign-off.
 
-## Purpose
+## Topology and scope
 
-- Safe production deployment, validation, and rollback.
-- Preserve availability with explicit promotion and incident-response workflow.
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Sugarkube runs only relay (`relay.py`) with single replica/worker, in-memory state.
+- No in-cluster backend or GPU service.
+- External compute remains out-of-cluster.
 
-## Topology intent (prod)
+## Values and pins
 
-- Sugarkube hosts production ingress/API-facing token.place services.
-- External compute nodes execute heavy workloads and are reached through secured API v1 links.
-- Public hostnames route through Cloudflare to Traefik ingress.
+- Base: `docs/examples/tokenplace.values.dev.yaml`
+- Overlay: `docs/examples/tokenplace.values.prod.yaml`
+- Version pin: `docs/apps/tokenplace.version`
+- Approved prod tag pin: `docs/apps/tokenplace.prod.tag`
 
-## Prerequisites
-
-- Staging validation completed for the target immutable tag.
-- Production values overlays and secrets approved.
-- Rollback revision identified before upgrade begins.
-
-## Deploy / upgrade / rollback
-
-```bash
-just tokenplace-deploy \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<prod-values> version_file=<optional-version-file> \
-  tag=<approved-immutable-tag>
-```
+## Promote after staging sign-off
 
 ```bash
-just tokenplace-upgrade \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<prod-values> version_file=<optional-version-file> \
-  tag=<approved-immutable-tag>
+just tokenplace-oci-promote-prod tag=main-REPLACE_APPROVED_SHORTSHA
 ```
+
+## Generic upgrade example (prod values)
 
 ```bash
-# List history first, then rollback if needed.
-helm -n <namespace> history <release>
-just tokenplace-rollback release=<release> namespace=<namespace> revision=<known-good-revision>
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_APPROVED_SHORTSHA
 ```
 
-## Validation checks
+## Rollback options
+
+1. Roll forward/rollback to prior immutable image tag using Helm OCI upgrade:
 
 ```bash
-just tokenplace-status namespace=<namespace> release=<release>
-just tokenplace-validate namespace=<namespace> release=<release> health_url=https://<prod-host>/<health>
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_PREVIOUS_SHORTSHA
 ```
+
+2. Helm revision rollback:
 
 ```bash
-just tokenplace-logs namespace=<namespace> selector=<label-selector>
+helm -n tokenplace history tokenplace
+just tokenplace-rollback release=tokenplace namespace=tokenplace revision=<known-good-revision>
 ```
 
-## Cloudflare / ingress expectations
+## Validation
 
-- Production hostname and TLS secret names are stable and documented.
-- Cloudflare tunnel routes only expected production hosts.
-- Any emergency DNS/ingress change is logged in outage documentation.
+```bash
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://token.place/livez
+curl -fsS https://token.place/healthz
+curl -fsS https://token.place/
+```
 
-## Secrets/config guidance
+## Troubleshooting
 
-- Use production-scoped credentials only; never reuse lower-environment keys.
-- Keep secret rotation cadence aligned with Sugarkube security checklist.
-- Apply least-privilege API tokens for DNS/tunnel automation.
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
+just tokenplace-status
+just tokenplace-debug-logs-env env=prod
+just cluster-status
+just traefik-status
+just cf-tunnel-debug
+```
 
-## Operator notes and caveats
+## Cloudflare Tunnel
 
-- Avoid mutable tags in production.
-- Keep a known-good rollback revision and artifact digest recorded for each deploy.
-- If rollout behavior diverges from staging, pause further promotions and capture diagnostics.
+Cloudflare routing is configured outside Helm. Ensure `token.place` routes to Traefik,
+typically `http://traefik.kube-system.svc.cluster.local:80`.
+
+```bash
+just cf-tunnel-route host=token.place
+```

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -1,66 +1,67 @@
 # k3s token.place runbook (staging)
 
-Use this runbook for `staging` token.place deployments on Sugarkube.
+Use this runbook for relay-only staging deployments.
 
-## Purpose
+## Topology and scope
 
-- Release-candidate validation before production promotion.
-- Full ingress + Cloudflare + TLS + API v1 behavior checks.
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Sugarkube runs only relay (`relay.py`), single replica/worker, in-memory state.
+- No in-cluster backend/GPU service is required.
+- External compute remains outside the cluster.
 
-## Topology intent (staging)
+## Values files
 
-- Sugarkube runs ingress/API-facing token.place services and relay integration points.
-- External compute remains out-of-cluster but reachable over secured API v1 paths.
-- Staging should mirror production architecture closely, with lower traffic volume.
+- Base: `docs/examples/tokenplace.values.dev.yaml`
+- Overlay: `docs/examples/tokenplace.values.staging.yaml`
+- Version pin: `docs/apps/tokenplace.version`
 
-## Prerequisites
-
-- Chart/release wiring is defined for staging.
-- Staging values overlays and secrets are reviewed.
-- Cloudflare hostname routing to Traefik is configured.
-
-## Deploy / upgrade / rollback
+## First install
 
 ```bash
-just tokenplace-deploy \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<staging-values> version_file=<optional-version-file> \
-  tag=<immutable-tag>
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
+
+## Existing release upgrade
 
 ```bash
-just tokenplace-upgrade \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<staging-values> version_file=<optional-version-file> \
-  tag=<immutable-tag>
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag=main-REPLACE_SHORTSHA
 ```
+
+## Preferred wrapper
 
 ```bash
-just tokenplace-rollback release=<release> namespace=<namespace> revision=<helm-revision>
+just tokenplace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
 ```
 
-## Validation checks
+## Validation
 
 ```bash
-just tokenplace-status namespace=<namespace> release=<release>
-just tokenplace-validate namespace=<namespace> release=<release> health_url=https://<staging-host>/<health>
+kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/
 ```
 
-- Confirm ingress host and TLS certificate are ready.
-- Confirm API v1 auth and external compute connectivity are healthy.
-- Capture logs for relay/API components when validating release candidates.
+## Troubleshooting
 
 ```bash
-just tokenplace-logs namespace=<namespace> selector=<label-selector>
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
+just tokenplace-status
+just tokenplace-debug-logs-env env=staging
+just cluster-status
+just traefik-status
+just cf-tunnel-debug
 ```
 
-## Cloudflare / ingress expectations
+## Cloudflare Tunnel
 
-- Staging hostname is distinct from production hostname.
-- Tunnel target points to Traefik (`kube-system` service).
-- DNS records remain proxied in Cloudflare.
+Cloudflare routing is managed outside Helm. Ensure `staging.token.place` points to Traefik,
+typically `http://traefik.kube-system.svc.cluster.local:80`.
 
-## Operator caveats
-
-- Treat staging as promotion gate; avoid ad hoc value edits.
-- Prefer immutable tags for reproducible rollback and forensic traceability.
+```bash
+just cf-tunnel-route host=staging.token.place
+```

--- a/docs/software/index.md
+++ b/docs/software/index.md
@@ -50,8 +50,7 @@ and supporting services stay healthy.
   [k3s-tokenplace-staging.md](../k3s-tokenplace-staging.md), and
   [k3s-tokenplace-prod.md](../k3s-tokenplace-prod.md) — environment runbooks for day-2
   operations.
-- [apps/tokenplace-relay.md](../apps/tokenplace-relay.md) — Helm ingress/TLS guide for
-  token.place staging relay operations.
+- [apps/tokenplace-relay.md](../apps/tokenplace-relay.md) — relay-only token.place operations guide.
 
 ## Developer Workflow
 - [contributor_script_map.md](../contributor_script_map.md) — keep automation docs

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -1,107 +1,46 @@
 # token.place Sugarkube onboarding
 
-This guide prepares Sugarkube to run `token.place` as a first-class workload once token.place
-release artifacts and chart wiring are finalized.
+This onboarding guide defines the stable relay-only deployment contract for Sugarkube.
 
-It is intentionally a **deployment-preparation** runbook: it defines stable interfaces,
-ownership, and operational shape without pretending that chart/release identifiers are immutable
-before the token.place onboarding cutover is complete.
+## Current deployment contract
 
-## Why token.place belongs on Sugarkube
+- Sugarkube deploys only `relay.py`.
+- No in-cluster backend/GPU service is required.
+- External compute nodes stay external (`server.py`, desktop Tauri app, Windows PCs,
+  Apple Silicon Macs, Raspberry Pi compute nodes).
+- Runtime is single replica, single worker, in-memory relay state.
+- In-memory state loss on pod death is currently accepted.
 
-- Sugarkube already provides a repeatable k3s + ingress + Cloudflare operating model.
-- token.place already has relay operations on Sugarkube (`docs/apps/tokenplace-relay.md`), so this
-  onboarding extends an existing operational pattern instead of introducing a new stack.
-- Sugarkube gives a consistent operator interface (`just` + runbooks) across `dev`, `staging`, and
-  `prod`, reducing drift during promotion and rollback.
+## Canonical release model
 
-## Preconditions before onboarding
+- Image: `ghcr.io/futuroptimist/tokenplace-relay`
+- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
+- Release: `tokenplace`
+- Namespace: `tokenplace`
+- Version pin: `docs/apps/tokenplace.version`
+- Production approved tag pin: `docs/apps/tokenplace.prod.tag`
 
-Before onboarding the full token.place workload, confirm token.place has completed:
+## Values model
 
-1. Shared desktop/server compute-node runtime.
-2. Desktop parity with `server.py` behavior.
-3. Operationally mature relay service.
-4. Secure API v1 convergence across token.place components.
-5. Release artifact publication (container images + Helm chart) suitable for repeatable deployment.
+- Base: `docs/examples/tokenplace.values.dev.yaml`
+- Staging: `docs/examples/tokenplace.values.staging.yaml`
+- Production: `docs/examples/tokenplace.values.prod.yaml`
 
-If any precondition is incomplete, keep using relay-only operations and postpone full onboarding.
+## Environment defaults
 
-## Release artifact expectations
+- Staging host: `staging.token.place`
+- Production host: `token.place`
 
-During onboarding, token.place should provide:
+## Standard operator commands
 
-- A Helm chart (OCI or repository path) that supports environment-specific values overlays.
-- Versioned chart metadata (or pinned chart digest/version).
-- Container image tags suitable for promotion (prefer immutable tags).
-- Health endpoints and readiness/liveness semantics documented for operator validation.
+- Deploy/upgrade staging: `just tokenplace-oci-deploy env=staging tag=<immutable-tag>`
+- Promote to production: `just tokenplace-oci-promote-prod tag=<approved-immutable-tag>`
+- Redeploy existing release: `just tokenplace-oci-redeploy env=<staging|prod> tag=<immutable-tag>`
+- Roll back Helm revision: `just tokenplace-rollback release=tokenplace namespace=tokenplace revision=<rev>`
 
-## Expected Sugarkube wiring (standardized vs configurable)
+## Required companion runbooks
 
-Standardized in Sugarkube:
-
-- Task-runner interface (recipes in `justfile`):
-  - `tokenplace-deploy`
-  - `tokenplace-upgrade`
-  - `tokenplace-rollback`
-  - `tokenplace-status`
-  - `tokenplace-logs`
-  - `tokenplace-validate`
-  - `tokenplace-port-forward`
-- Environment runbooks:
-  - `docs/k3s-tokenplace-dev.md`
-  - `docs/k3s-tokenplace-staging.md`
-  - `docs/k3s-tokenplace-prod.md`
-
-Configurable per onboarding cutover:
-
-- Namespace, release name, chart location, values files, chart version pin, and image tag strategy.
-- Ingress hosts and Cloudflare DNS/tunnel mapping.
-- Which token.place components run in-cluster vs on external compute nodes.
-
-## Environment mapping
-
-- `dev`: fast iteration, lower blast radius, relaxed SLOs.
-- `staging`: pre-production integration and release validation.
-- `prod`: public workload, strict rollback and change-control discipline.
-
-Use the environment-specific runbooks for concrete command patterns.
-
-## Ownership boundaries
-
-- **token.place team** owns chart/app semantics, release artifacts, and component-level config.
-- **Sugarkube operators** own cluster lifecycle, ingress/tunnel plumbing, secret distribution,
-  deployment execution, and rollback orchestration.
-- Shared responsibility: production cutover sequencing, health-gate criteria, and incident
-  response.
-
-## App catalog and related docs
-
-- App overview: `docs/apps/tokenplace.md`
-- Relay-specific operations: `docs/apps/tokenplace-relay.md`
-- Environment runbooks:
-  - `docs/k3s-tokenplace-dev.md`
-  - `docs/k3s-tokenplace-staging.md`
-  - `docs/k3s-tokenplace-prod.md`
-
-## Baseline command templates
-
-Set values explicitly per environment to avoid hidden assumptions:
-
-```bash
-just tokenplace-deploy \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<env-values> version_file=<optional-version-file> \
-  tag=<image-tag>
-```
-
-```bash
-just tokenplace-upgrade \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<env-values> version_file=<optional-version-file> \
-  tag=<image-tag>
-```
-
-```bash
-just tokenplace-rollback release=<release> namespace=<namespace> revision=<helm-revision>
-```
+- App operations: `docs/apps/tokenplace.md`
+- Relay operations: `docs/apps/tokenplace-relay.md`
+- Staging runbook: `docs/k3s-tokenplace-staging.md`
+- Production runbook: `docs/k3s-tokenplace-prod.md`


### PR DESCRIPTION
### Motivation

- Make Sugarkube token.place docs concrete and DSPACE-like for a relay-only rollout, clarifying that Sugarkube runs only the relay and that no in-cluster backend/GPU service is required. 
- Replace stale local-chart and image defaults with the canonical OCI flow so operators can reliably deploy staging and prod using immutable tags and Helm OCI helpers. 

### Description

- Updated relay and app docs to a relay-only topology and standardized artifact model using image `ghcr.io/futuroptimist/tokenplace-relay`, chart `oci://ghcr.io/futuroptimist/charts/tokenplace`, release `tokenplace`, and namespace `tokenplace` (files updated: `docs/apps/tokenplace.md`, `docs/apps/tokenplace-relay.md`, `docs/tokenplace_sugarkube_onboarding.md`, `docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`, `docs/index.md`, `docs/software/index.md`).
- Reworked staging/prod runbooks with concrete commands for first install, upgrade, validation, promotion, and rollback using the `helm-oci` helpers and tokenplace wrappers (preferred wrappers: `just tokenplace-oci-deploy`, `just tokenplace-oci-promote-prod`, and related `just` recipes). 
- Normalized values and pins to DSPACE-style overlays and pins (`docs/examples/tokenplace.values.*.yaml`, `docs/apps/tokenplace.version`, `docs/apps/tokenplace.prod.tag`) and updated operator example values (`apps/tokenplace-relay/values.dev.yaml`, `docs/examples/tokenplace-relay.values.dev.yaml`) to use `ghcr.io/futuroptimist/tokenplace-relay` and a `main-REPLACE_SHORTSHA` placeholder. 
- Removed or deprecated stale guidance referencing `ghcr.io/democratizedspace/tokenplace-relay`, `sha-684fd7f`, and passive recommendations to use `./apps/tokenplace-relay` for steady-state deployments, and clarified Cloudflare Tunnel ownership (routes are managed outside Helm). 

### Testing

- Ran repository verification greps which succeeded: `grep -R "ghcr.io/democratizedspace/tokenplace-relay" docs apps README.md && exit 1 || true` (no matches), and `grep -R "sha-684fd7f" docs apps README.md && exit 1 || true` (no matches). 
- Confirmed concrete OCI/chart refs are present with `grep -R "oci://ghcr.io/futuroptimist/charts/tokenplace" docs` and `grep -R "release=tokenplace namespace=tokenplace" docs`, both of which returned the updated docs. 
- Attempted repository quality checks but they were not runnable in this environment: `pre-commit run --all-files` (not run: `pre-commit: command not found`), `pyspelling -c .spellcheck.yaml` (not run: `pyspelling: command not found`), and `linkchecker --no-warnings README.md docs/` (not run: `linkchecker: command not found`). 
- Ran the repo secret scan step via the available helper which reported no staged diff to scan after changes were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13e9fdbfb8832fa7bab34021c4bbfc)