### PR TITLE
Add danielsmith values and version pin files

### DIFF
--- a/docs/apps/danielsmith.prod.tag
+++ b/docs/apps/danielsmith.prod.tag
@@ -1,0 +1,5 @@
+# Approved production image tag for danielsmith.io.
+#
+# Leave empty until an image tag is explicitly approved for production.
+# Later deployment wrappers should require tag=<value> when this file has no
+# non-comment content.

--- a/docs/apps/danielsmith.version
+++ b/docs/apps/danielsmith.version
@@ -1,0 +1,2 @@
+# Default danielsmith chart version. Update when new chart releases are published.
+0.1.0

--- a/docs/examples/danielsmith.values.dev.yaml
+++ b/docs/examples/danielsmith.values.dev.yaml
@@ -1,0 +1,19 @@
+# Base/shared danielsmith.io values consumed alongside environment overlays.
+environment: dev
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/danielsmith.io
+
+ingress:
+  enabled: true
+  className: traefik
+  annotations: {}
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi

--- a/docs/examples/danielsmith.values.prod.yaml
+++ b/docs/examples/danielsmith.values.prod.yaml
@@ -1,0 +1,7 @@
+# Production overlay values layered on top of danielsmith.values.dev.yaml.
+environment: prod
+
+ingress:
+  enabled: true
+  className: traefik
+  host: danielsmith.io

--- a/docs/examples/danielsmith.values.staging.yaml
+++ b/docs/examples/danielsmith.values.staging.yaml
@@ -1,0 +1,7 @@
+# Staging overlay values layered on top of danielsmith.values.dev.yaml.
+environment: staging
+
+ingress:
+  enabled: true
+  className: traefik
+  host: staging.danielsmith.io


### PR DESCRIPTION
### Motivation

- Provide DSPACE/token.place-style Helm metadata so `danielsmith.io` can be deployed with the repo's generic Helm OCI helpers and follow existing layering conventions.

### Description

- Add `docs/apps/danielsmith.version` and pin the initial chart version to `0.1.0` using the same comment style as other apps.
- Add `docs/apps/danielsmith.prod.tag` as a comment-only placeholder for the approved production image tag (no hard-coded tag value).
- Add `docs/examples/danielsmith.values.dev.yaml` with shared base values including `environment: dev`, `replicaCount: 1`, `image.repository: ghcr.io/futuroptimist/danielsmith.io`, ingress defaults, and conservative static-site resource requests/limits.
- Add `docs/examples/danielsmith.values.staging.yaml` with `environment: staging` and `ingress.host: staging.danielsmith.io` and `docs/examples/danielsmith.values.prod.yaml` with `environment: prod` and `ingress.host: danielsmith.io`.

### Testing

- Verified presence of new files with `test -f docs/apps/danielsmith.version && test -f docs/apps/danielsmith.prod.tag && test -f docs/examples/danielsmith.values.dev.yaml && test -f docs/examples/danielsmith.values.staging.yaml && test -f docs/examples/danielsmith.values.prod.yaml` — passed.
- Verified image repository and host values with `rg "ghcr.io/futuroptimist/danielsmith.io" docs/examples/danielsmith.values.*.yaml` and `rg "staging.danielsmith.io" docs/examples/danielsmith.values.staging.yaml` and `rg "danielsmith.io" docs/examples/danielsmith.values.prod.yaml` — passed.
- Ran the repository secret scan with `git diff --cached | ./scripts/scan-secrets.py` — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148ba14c50832f88e85050243f93d7)