### PR TITLE
Add DSPACE-style danielsmith values and version files

### DIFF
--- a/docs/apps/danielsmith.prod.tag
+++ b/docs/apps/danielsmith.prod.tag
@@ -1,0 +1,5 @@
+# Approved production image tag for danielsmith.io.
+#
+# Leave empty until an image tag is explicitly approved for production.
+# Later deployment wrappers should require tag=<value> when this file has no
+# non-comment content.

--- a/docs/apps/danielsmith.version
+++ b/docs/apps/danielsmith.version
@@ -1,0 +1,2 @@
+# Default danielsmith chart version. Update when new chart releases are published.
+0.1.0

--- a/docs/examples/danielsmith.values.dev.yaml
+++ b/docs/examples/danielsmith.values.dev.yaml
@@ -1,0 +1,19 @@
+# Base/shared danielsmith.io values consumed alongside environment overlays.
+environment: dev
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/danielsmith.io
+
+ingress:
+  enabled: true
+  className: traefik
+  annotations: {}
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi

--- a/docs/examples/danielsmith.values.prod.yaml
+++ b/docs/examples/danielsmith.values.prod.yaml
@@ -1,0 +1,7 @@
+# Production overlay values layered on top of danielsmith.values.dev.yaml.
+environment: prod
+
+ingress:
+  enabled: true
+  className: traefik
+  host: danielsmith.io

--- a/docs/examples/danielsmith.values.staging.yaml
+++ b/docs/examples/danielsmith.values.staging.yaml
@@ -1,0 +1,7 @@
+# Staging overlay values layered on top of danielsmith.values.dev.yaml.
+environment: staging
+
+ingress:
+  enabled: true
+  className: traefik
+  host: staging.danielsmith.io


### PR DESCRIPTION
### Motivation
- Provide Sugarkube-owned Helm/values metadata for the `danielsmith` app so the same Helm OCI deployment wrappers used for DSPACE/token.place can deploy danielsmith.io.

### Description
- Added `docs/apps/danielsmith.version` and pinned the initial chart version to `0.1.0`.
- Added `docs/apps/danielsmith.prod.tag` as a comment-only placeholder for an approved production image tag (no fake tag is hard-coded).
- Added `docs/examples/danielsmith.values.dev.yaml` with `environment: dev`, `replicaCount: 1`, `image.repository: ghcr.io/futuroptimist/danielsmith.io`, ingress defaults (`enabled`, `className: traefik`, empty `annotations`), and conservative `resources` requests/limits suitable for a static site.
- Added `docs/examples/danielsmith.values.staging.yaml` and `docs/examples/danielsmith.values.prod.yaml` overlays with `environment: staging` / `environment: prod` and ingress hosts `staging.danielsmith.io` and `danielsmith.io` respectively, and no backend/API/database configuration.

### Testing
- Ran presence checks with `test -f docs/apps/danielsmith.version` and `test -f docs/apps/danielsmith.prod.tag` and overlay checks with `test -f docs/examples/danielsmith.values.dev.yaml` `test -f docs/examples/danielsmith.values.staging.yaml` `test -f docs/examples/danielsmith.values.prod.yaml`, all of which passed.
- Verified image and host strings with `rg "ghcr.io/futuroptimist/danielsmith.io" docs/examples/danielsmith.values.*.yaml`, `rg "staging.danielsmith.io" docs/examples/danielsmith.values.staging.yaml`, and `rg "danielsmith.io" docs/examples/danielsmith.values.prod.yaml`, and all searches returned the expected matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148ba14c50832f88e85050243f93d7)