### PR TITLE
Add danielsmith deployment values and version/tag placeholders

### DIFF
--- a/docs/apps/danielsmith.prod.tag
+++ b/docs/apps/danielsmith.prod.tag
@@ -1,0 +1,5 @@
+# Approved production image tag for danielsmith.io.
+#
+# Leave empty until an image tag is explicitly approved for production.
+# Later deployment wrappers should require tag=<value> when this file has no
+# non-comment content.

--- a/docs/apps/danielsmith.version
+++ b/docs/apps/danielsmith.version
@@ -1,0 +1,2 @@
+# Default danielsmith chart version. Update when new chart releases are published.
+0.1.0

--- a/docs/examples/danielsmith.values.dev.yaml
+++ b/docs/examples/danielsmith.values.dev.yaml
@@ -1,0 +1,19 @@
+# Base/shared danielsmith.io values consumed alongside environment overlays.
+environment: dev
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/danielsmith.io
+
+ingress:
+  enabled: true
+  className: traefik
+  annotations: {}
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 256Mi

--- a/docs/examples/danielsmith.values.prod.yaml
+++ b/docs/examples/danielsmith.values.prod.yaml
@@ -1,0 +1,7 @@
+# Production overlay values layered on top of danielsmith.values.dev.yaml.
+environment: prod
+
+ingress:
+  enabled: true
+  className: traefik
+  host: danielsmith.io

--- a/docs/examples/danielsmith.values.staging.yaml
+++ b/docs/examples/danielsmith.values.staging.yaml
@@ -1,0 +1,7 @@
+# Staging overlay values layered on top of danielsmith.values.dev.yaml.
+environment: staging
+
+ingress:
+  enabled: true
+  className: traefik
+  host: staging.danielsmith.io


### PR DESCRIPTION
### Motivation
- Provide Sugarkube-owned Helm values and chart pinning so `danielsmith.io` can be deployed via the existing generic Helm OCI helpers used for other sites. 
- Match the DSPACE/token.place layering convention (base dev values + staging/prod overlays) and avoid introducing backend/API/database dependencies. 

### Description
- Add `docs/apps/danielsmith.version` pinned to `0.1.0` to pin the canonical chart version. 
- Add `docs/apps/danielsmith.prod.tag` as an intentionally comment-only placeholder that requires an explicit approved production tag. 
- Add base/shared values in `docs/examples/danielsmith.values.dev.yaml` with `environment: dev`, `replicaCount: 1`, `image.repository: ghcr.io/futuroptimist/danielsmith.io`, ingress enabled (`traefik`), empty `ingress.annotations`, and conservative `resources` requests/limits. 
- Add staging and prod overlays as `docs/examples/danielsmith.values.staging.yaml` (host `staging.danielsmith.io`) and `docs/examples/danielsmith.values.prod.yaml` (host `danielsmith.io`). 

### Testing
- Presence checks using `test -f docs/apps/danielsmith.version && test -f docs/apps/danielsmith.prod.tag && test -f docs/examples/danielsmith.values.dev.yaml && test -f docs/examples/danielsmith.values.staging.yaml && test -f docs/examples/danielsmith.values.prod.yaml` succeeded. 
- Content checks with `rg "ghcr.io/futuroptimist/danielsmith.io" docs/examples/danielsmith.values.*.yaml` and `rg "staging.danielsmith.io" docs/examples/danielsmith.values.staging.yaml` and `rg "danielsmith.io" docs/examples/danielsmith.values.prod.yaml` all succeeded. 
- Running `pre-commit run --all-files` could not be completed in this environment because `pre-commit` is not installed (`/bin/bash: pre-commit: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148ba14c50832f88e85050243f93d7)