### PR TITLE
Add danielsmith version, prod-tag placeholder, and Helm values files

### DIFF
--- a/docs/apps/danielsmith.prod.tag
+++ b/docs/apps/danielsmith.prod.tag
@@ -1,0 +1,5 @@
+# Approved production image tag for danielsmith.io.
+#
+# Leave empty until an image tag is explicitly approved for production.
+# Later deployment wrappers should require tag=<value> when this file has no
+# non-comment content.

--- a/docs/apps/danielsmith.prod.tag
+++ b/docs/apps/danielsmith.prod.tag
@@ -1,5 +1,4 @@
 # Approved production image tag for danielsmith.io.
 #
 # Leave empty until an image tag is explicitly approved for production.
-# Later deployment wrappers should require tag=<value> when this file has no
-# non-comment content.
+# Deployment wrappers may consume this file to enforce release policy.

--- a/docs/apps/danielsmith.version
+++ b/docs/apps/danielsmith.version
@@ -1,0 +1,2 @@
+# Default danielsmith chart version. Update when new chart releases are published.
+0.1.0

--- a/docs/examples/danielsmith.values.dev.yaml
+++ b/docs/examples/danielsmith.values.dev.yaml
@@ -6,7 +6,7 @@ image:
   repository: ghcr.io/futuroptimist/danielsmith.io
 
 ingress:
-  enabled: true
+  enabled: false
   className: traefik
   annotations: {}
 

--- a/docs/examples/danielsmith.values.dev.yaml
+++ b/docs/examples/danielsmith.values.dev.yaml
@@ -1,0 +1,19 @@
+# Base/shared danielsmith.io values consumed alongside environment overlays.
+environment: dev
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/danielsmith.io
+
+ingress:
+  enabled: true
+  className: traefik
+  annotations: {}
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi

--- a/docs/examples/danielsmith.values.prod.yaml
+++ b/docs/examples/danielsmith.values.prod.yaml
@@ -5,3 +5,7 @@ ingress:
   enabled: true
   className: traefik
   host: danielsmith.io
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  tls:
+    secretName: danielsmith-prod-tls

--- a/docs/examples/danielsmith.values.prod.yaml
+++ b/docs/examples/danielsmith.values.prod.yaml
@@ -1,0 +1,7 @@
+# Production overlay values layered on top of danielsmith.values.dev.yaml.
+environment: prod
+
+ingress:
+  enabled: true
+  className: traefik
+  host: danielsmith.io

--- a/docs/examples/danielsmith.values.prod.yaml
+++ b/docs/examples/danielsmith.values.prod.yaml
@@ -8,4 +8,5 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
   tls:
+    enabled: true
     secretName: danielsmith-prod-tls

--- a/docs/examples/danielsmith.values.staging.yaml
+++ b/docs/examples/danielsmith.values.staging.yaml
@@ -1,0 +1,7 @@
+# Staging overlay values layered on top of danielsmith.values.dev.yaml.
+environment: staging
+
+ingress:
+  enabled: true
+  className: traefik
+  host: staging.danielsmith.io

--- a/docs/examples/danielsmith.values.staging.yaml
+++ b/docs/examples/danielsmith.values.staging.yaml
@@ -5,3 +5,7 @@ ingress:
   enabled: true
   className: traefik
   host: staging.danielsmith.io
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  tls:
+    secretName: danielsmith-staging-tls

--- a/docs/examples/danielsmith.values.staging.yaml
+++ b/docs/examples/danielsmith.values.staging.yaml
@@ -8,4 +8,5 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
   tls:
+    enabled: true
     secretName: danielsmith-staging-tls


### PR DESCRIPTION
### Motivation
- Provide Sugarkube-owned DSPACE-style metadata and Helm values so `danielsmith.io` can be deployed using the repo's generic Helm/OCI helpers.
- Follow the established pattern used for `dspace` and `token.place` (separate chart version, production tag placeholder, and layered dev/staging/prod values).

### Description
- Add `docs/apps/danielsmith.version` pinning the default chart version to `0.1.0`.
- Add `docs/apps/danielsmith.prod.tag` as a comment-only placeholder for an approved production image tag.
- Add `docs/examples/danielsmith.values.dev.yaml` with `environment: dev`, `replicaCount: 1`, `image.repository: ghcr.io/futuroptimist/danielsmith.io`, Traefik ingress defaults, and conservative `resources` requests/limits.
- Add `docs/examples/danielsmith.values.staging.yaml` and `docs/examples/danielsmith.values.prod.yaml` overlays that enable ingress and set `host` to `staging.danielsmith.io` and `danielsmith.io` respectively.

### Testing
- Ran file-existence checks: `test -f docs/apps/danielsmith.version && test -f docs/apps/danielsmith.prod.tag && test -f docs/examples/danielsmith.values.dev.yaml && test -f docs/examples/danielsmith.values.staging.yaml && test -f docs/examples/danielsmith.values.prod.yaml` (passed).
- Verified image repository presence with `rg "ghcr.io/futuroptimist/danielsmith.io" docs/examples/danielsmith.values.*.yaml` (passed).
- Verified staging host with `rg "staging.danielsmith.io" docs/examples/danielsmith.values.staging.yaml` and prod host with `rg "danielsmith.io" docs/examples/danielsmith.values.prod.yaml` (both passed).
- Ran repository secret scan via `git diff --cached | ./scripts/scan-secrets.py` after staging the new files (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148ba14c50832f88e85050243f93d7)