### PR TITLE
Add danielsmith OCI deploy/redeploy justfile wrappers

### DIFF
--- a/justfile
+++ b/justfile
@@ -1718,6 +1718,193 @@ dspace-debug-logs-env env='staging' namespace='dspace':
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
     just --justfile "{{ justfile_directory() }}/justfile" dspace-debug-logs namespace="{{ namespace }}"
 
+
+# Install-or-upgrade danielsmith.io from OCI chart with immutable tag policy.
+danielsmith-oci-deploy env='staging' tag='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    env_input={{ quote(env) }}
+    env_name="${env_input}"
+    while [ "${env_name#env=}" != "${env_name}" ]; do
+        env_name="${env_name#env=}"
+    done
+    case "${env_name}" in
+      dev|staging|prod) ;;
+      *)
+        echo "ERROR: env must be one of dev|staging|prod." >&2
+        exit 1
+        ;;
+    esac
+
+    validate_immutable_tag() {
+      local candidate="${1}"
+      local tag_lc
+      tag_lc="$(echo "${candidate}" | tr '[:upper:]' '[:lower:]')"
+      if [[ "${tag_lc}" == *latest* ]]         || [[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]]         || [[ "${tag_lc}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]]         || ([[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] && [[ ! "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]); then
+        echo "ERROR: mutable tag '${candidate}' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
+        exit 1
+      fi
+    }
+
+    resolved_tag="$(echo '{{ tag }}' | xargs)"
+    if [ -z "${resolved_tag}" ]; then
+      echo "ERROR: tag is required for immutable deploys." >&2
+      exit 1
+    fi
+    validate_immutable_tag "${resolved_tag}"
+
+    values_chain='docs/examples/danielsmith.values.dev.yaml'
+    if [ "${env_name}" = "staging" ]; then
+      values_chain='docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml'
+    elif [ "${env_name}" = "prod" ]; then
+      values_chain='docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml'
+    fi
+
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install       release='danielsmith' namespace='danielsmith'       chart='oci://ghcr.io/futuroptimist/charts/danielsmith'       values="${values_chain}"       version_file='docs/apps/danielsmith.version'       tag="${resolved_tag}"
+
+    scripts/ensure_user_kubeconfig.sh || true
+    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+
+    echo
+    echo "Resolved images for deployment/danielsmith:"
+    kubectl -n danielsmith get deploy/danielsmith -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"="}{.image}{"\n"}{end}' || true
+
+    ingress_host="$(kubectl -n danielsmith get ingress -o jsonpath='{.items[0].spec.rules[0].host}' 2>/dev/null || true)"
+    if [ -n "${ingress_host}" ]; then
+      echo
+      echo "Post-deploy checks:"
+      echo "  curl -fsS https://${ingress_host}/"
+      echo "  curl -fsS https://${ingress_host}/livez"
+      echo "  curl -fsS https://${ingress_host}/healthz"
+    fi
+
+danielsmith-oci-promote-prod tag='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.prod.tag | head -n1 | tr -d '[:space:]'; }
+
+    resolved_tag="$(echo '{{ tag }}' | xargs)"
+    if [ -z "${resolved_tag}" ]; then
+      resolved_tag="$(read_prod_tag 2>/dev/null || true)"
+    fi
+    if [ -z "${resolved_tag}" ]; then
+      echo "ERROR: provide tag=<immutable-tag> or set docs/apps/danielsmith.prod.tag." >&2
+      exit 1
+    fi
+
+    just --justfile "{{ justfile_directory() }}/justfile" danielsmith-oci-deploy env=prod tag="${resolved_tag}"
+
+# Upgrade-only danielsmith.io OCI redeploy path.
+danielsmith-oci-redeploy env='staging' tag='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    env_input={{ quote(env) }}
+    env_name="${env_input}"
+    while [ "${env_name#env=}" != "${env_name}" ]; do
+        env_name="${env_name#env=}"
+    done
+    case "${env_name}" in
+      dev|staging|prod) ;;
+      *)
+        echo "ERROR: env must be one of dev|staging|prod." >&2
+        exit 1
+        ;;
+    esac
+
+    validate_immutable_tag() {
+      local candidate="${1}"
+      local tag_lc
+      tag_lc="$(echo "${candidate}" | tr '[:upper:]' '[:lower:]')"
+      if [[ "${tag_lc}" == *latest* ]]         || [[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]]         || [[ "${tag_lc}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]]         || ([[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] && [[ ! "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]); then
+        echo "ERROR: mutable tag '${candidate}' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
+        exit 1
+      fi
+    }
+    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.prod.tag | head -n1 | tr -d '[:space:]'; }
+
+    resolved_tag="$(echo '{{ tag }}' | xargs)"
+    if [ -z "${resolved_tag}" ] && [ "${env_name}" = "prod" ]; then
+      resolved_tag="$(read_prod_tag 2>/dev/null || true)"
+      [ -n "${resolved_tag}" ] || { echo "ERROR: prod requires tag=<immutable-tag> or docs/apps/danielsmith.prod.tag." >&2; exit 1; }
+    fi
+    if [ "${env_name}" != "prod" ] && [ -z "${resolved_tag}" ]; then
+      echo "ERROR: env=${env_name} redeploy requires explicit tag=<immutable-tag>." >&2
+      echo "Non-prod redeploy intentionally has no baked-in fallback tag so this path is reproducible and reviewable." >&2
+      exit 1
+    fi
+    [ -n "${resolved_tag}" ] && validate_immutable_tag "${resolved_tag}"
+
+    values_chain='docs/examples/danielsmith.values.dev.yaml'
+    if [ "${env_name}" = "staging" ]; then
+      values_chain='docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml'
+    elif [ "${env_name}" = "prod" ]; then
+      values_chain='docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml'
+    fi
+
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade       release='danielsmith' namespace='danielsmith'       chart='oci://ghcr.io/futuroptimist/charts/danielsmith'       values="${values_chain}"       version_file='docs/apps/danielsmith.version'       tag="${resolved_tag}"
+
+    scripts/ensure_user_kubeconfig.sh || true
+    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+    kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+
+danielsmith-status namespace='danielsmith' release='danielsmith' host_key='ingress.host':
+    @just app-status namespace='{{ namespace }}' release='{{ release }}' host_key='{{ host_key }}'
+
+danielsmith-debug-logs namespace='danielsmith':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+    ns="{{ namespace }}"
+
+    echo "=== danielsmith pods in namespace ${ns} ==="
+    kubectl get pods -n "${ns}" -o wide || true
+
+    selector='app.kubernetes.io/name=danielsmith'
+    danielsmith_pods="$(kubectl get pods -n "${ns}" -l "${selector}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)"
+    if [ -z "${danielsmith_pods}" ]; then
+      selector='app.kubernetes.io/instance=danielsmith'
+      danielsmith_pods="$(kubectl get pods -n "${ns}" -l "${selector}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)"
+    fi
+
+    echo
+    echo "=== danielsmith logs (last 200 lines per pod, selector: ${selector}) ==="
+    if [ -z "${danielsmith_pods}" ]; then
+      echo "No pods found with supported danielsmith selectors in namespace ${ns}" >&2
+    else
+      for pod in ${danielsmith_pods}; do
+        echo
+        echo "--- pod: ${pod} ---"
+        kubectl logs -n "${ns}" "${pod}" --tail='200' || true
+      done
+    fi
+
+    echo
+    echo "=== Traefik logs (last 200 lines) ==="
+    kubectl logs -n kube-system -l app.kubernetes.io/name=traefik --tail=200 || true
+
+danielsmith-debug-logs-env env='staging' namespace='danielsmith':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    env_input={{ quote(env) }}
+    env_name="${env_input}"
+    while [ "${env_name#env=}" != "${env_name}" ]; do
+        env_name="${env_name#env=}"
+    done
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+    just --justfile "{{ justfile_directory() }}/justfile" danielsmith-debug-logs namespace="{{ namespace }}"
+
 # Install-or-upgrade token.place from OCI chart with immutable tag policy.
 tokenplace-oci-deploy env='staging' tag='':
     #!/usr/bin/env bash


### PR DESCRIPTION
### Motivation
- Provide operator-friendly `danielsmith` justfile wrappers that mirror existing DSPACE/tokenplace workflows while using shared `helm-oci-install` and `helm-oci-upgrade` helpers. 
- Enforce immutable-tag deploys and predictable values overlays to avoid mutable-image drift for staging/prod. 
- Offer quick status and debugging helpers to align on-call/runbook ergonomics with other apps in the repo.

### Description
- Added `danielsmith-oci-deploy` which normalizes `env=...` input, enforces an immutable `tag`, builds the env-specific `values` chain, forces canonical kubeconfig selection, and calls `helm-oci-install` with `release='danielsmith'`, `namespace='danielsmith'`, `chart='oci://ghcr.io/futuroptimist/charts/danielsmith'`, and `version_file='docs/apps/danielsmith.version'`.
- Added `danielsmith-oci-promote-prod` which reads `docs/apps/danielsmith.prod.tag` when `tag` is omitted and delegates to `danielsmith-oci-deploy env=prod`.
- Added `danielsmith-oci-redeploy` upgrade-only path that validates immutable tags (prod fallback allowed, non-prod requires explicit tag), calls `helm-oci-upgrade`, and waits for `kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s`.
- Added `danielsmith-status` wrapper for `app-status`, and `danielsmith-debug-logs` plus `danielsmith-debug-logs-env` to list pods, tail app logs using either `app.kubernetes.io/name` or `app.kubernetes.io/instance` selectors, and tail Traefik logs, with env-scoped kubeconfig selection.
- All edits were confined to `justfile` and wired to the OCI chart; no local chart paths (e.g. `./apps/danielsmith`) were introduced.

### Testing
- Verified presence of recipes and OCI references in `justfile` using `rg`/`grep`: these checks succeeded (found `danielsmith-oci-deploy`, `danielsmith-oci-promote-prod`, `danielsmith-oci-redeploy`, `danielsmith-status`, `danielsmith-debug-logs`, `danielsmith-debug-logs-env`, and `oci://ghcr.io/futuroptimist/charts/danielsmith`).
- Attempted `just --summary` based verification but the environment lacks `just`, so `just`-based checks were not run (command failed: `just: command not found`).
- Confirmed the change was committed (`git commit`) with message `Add danielsmith OCI justfile wrappers` and only `justfile` was modified.
- Did not run `pre-commit` or repo linters in this environment; follow-up CI / local developer runs should run `pre-commit run --all-files` and `just --summary` to fully validate the recipes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1497a127b4832f9a3e13815ab98c3d)