### PR TITLE
Add danielsmith.io app docs and staging/prod runbooks

### DIFF
--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -1,0 +1,87 @@
+# danielsmith.io on Sugarkube
+
+This is the canonical Sugarkube deployment model for **danielsmith.io**.
+
+## Topology and scope (current)
+
+The danielsmith.io workload on Sugarkube is **static-site only**.
+
+- The app is a static Vite + Three.js site.
+- Sugarkube runs only the static web container.
+- There is no API, backend, database, queue, GPU, compute node, or other stateful service in
+  this deployment scope.
+- Cloudflare Tunnel fronts Traefik, and Traefik routes traffic to the `danielsmith` Kubernetes
+  Service.
+
+Health and availability endpoints:
+
+- `/livez`
+- `/healthz`
+- `/` (root page)
+
+## Artifact model (canonical)
+
+- Image: `ghcr.io/futuroptimist/danielsmith.io`
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Helm release: `danielsmith`
+- Namespace: `danielsmith`
+- Chart version pin file: `docs/apps/danielsmith.version`
+- Production approved tag pin: `docs/apps/danielsmith.prod.tag`
+
+## Values model
+
+- Base: `docs/examples/danielsmith.values.dev.yaml`
+- Staging overlay: `docs/examples/danielsmith.values.staging.yaml`
+- Production overlay: `docs/examples/danielsmith.values.prod.yaml`
+
+Default hosts:
+
+- Staging: `staging.danielsmith.io`
+- Production: `danielsmith.io`
+
+## Core deployment commands
+
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Preferred env wrapper:
+
+```bash
+just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+```
+
+## Validation commands
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+For production validation, use the same checks against `https://danielsmith.io`.
+
+## Cloudflare and ingress model
+
+Cloudflare Tunnel and DNS configuration are external to Helm.
+
+- Route hostnames to Traefik, typically
+  `http://traefik.kube-system.svc.cluster.local:80`.
+- Helm chart deployment does **not** create Cloudflare routes.
+- Configure routes explicitly:
+
+```bash
+just cf-tunnel-route host=staging.danielsmith.io
+just cf-tunnel-route host=danielsmith.io
+```
+
+## Related runbooks
+
+- Staging runbook: [`docs/k3s-danielsmith-staging.md`](../k3s-danielsmith-staging.md)
+- Production runbook: [`docs/k3s-danielsmith-prod.md`](../k3s-danielsmith-prod.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,9 +47,12 @@ Review the safety notes before working with power components.
   ownership boundaries, and environment mapping for token.place on Sugarkube
 - [apps/tokenplace.md](apps/tokenplace.md) — token.place app topology and operations model on Sugarkube
 - [apps/tokenplace-relay.md](apps/tokenplace-relay.md) — relay-only token.place OCI staging/prod operations guide
+- [apps/danielsmith.md](apps/danielsmith.md) — danielsmith.io static-site app topology and operations model on Sugarkube
 - [k3s-tokenplace-dev.md](k3s-tokenplace-dev.md) — token.place dev runbook
 - [k3s-tokenplace-staging.md](k3s-tokenplace-staging.md) — token.place staging runbook
 - [k3s-tokenplace-prod.md](k3s-tokenplace-prod.md) — token.place production runbook
+- [k3s-danielsmith-staging.md](k3s-danielsmith-staging.md) — danielsmith.io staging runbook
+- [k3s-danielsmith-prod.md](k3s-danielsmith-prod.md) — danielsmith.io production runbook
 - [operations/security-checklist.md](operations/security-checklist.md) — track credential rotations and
   verification steps
 - [pi_token_dspace.md](pi_token_dspace.md) — build and expose token.place & dspace via Cloudflare

--- a/docs/k3s-danielsmith-prod.md
+++ b/docs/k3s-danielsmith-prod.md
@@ -1,0 +1,90 @@
+# k3s danielsmith.io runbook (prod)
+
+Use this runbook for static-site danielsmith.io production deployments on Sugarkube.
+
+## Topology and scope
+
+- Sugarkube runs only the danielsmith.io static web container.
+- No in-cluster API/backend/database/queue/GPU/compute-node/stateful service is required.
+- Cloudflare Tunnel fronts Traefik, and Traefik routes to the `danielsmith` Service.
+
+## Artifact and values contract
+
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Image: `ghcr.io/futuroptimist/danielsmith.io`
+- Release: `danielsmith`
+- Namespace: `danielsmith`
+- Version pin file: `docs/apps/danielsmith.version`
+- Approved prod tag file: `docs/apps/danielsmith.prod.tag`
+- Values: `docs/examples/danielsmith.values.dev.yaml` + `docs/examples/danielsmith.values.prod.yaml`
+- Default production host: `danielsmith.io`
+
+## Promotion after staging sign-off
+
+```bash
+just danielsmith-oci-promote-prod tag=main-REPLACE_APPROVED_SHORTSHA
+```
+
+## Generic production upgrade
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_APPROVED_SHORTSHA
+```
+
+## Validation
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://danielsmith.io/livez
+curl -fsS https://danielsmith.io/healthz
+curl -fsS https://danielsmith.io/
+```
+
+## Rollback options
+
+Rollback by immutable tag:
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+Rollback by Helm revision:
+
+```bash
+DANIELSMITH_REVISION=12 # replace with the known-good Helm revision
+just helm-rollback release=danielsmith namespace=danielsmith revision="$DANIELSMITH_REVISION"
+```
+
+## Cloudflare tunnel routing (external to Helm)
+
+Cloudflare routes are configured outside the chart. Route `danielsmith.io` to Traefik,
+typically `http://traefik.kube-system.svc.cluster.local:80`.
+
+```bash
+just cf-tunnel-route host=danielsmith.io
+```
+
+## Troubleshooting
+
+GHCR auth/chart checks:
+
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/danielsmith.version | head -n1)"
+```
+
+App status/logs:
+
+```bash
+just danielsmith-status
+just danielsmith-debug-logs-env env=prod
+```
+
+Ingress/tunnel checks:
+
+```bash
+just cluster-status
+just traefik-status
+just cf-tunnel-debug
+```

--- a/docs/k3s-danielsmith-staging.md
+++ b/docs/k3s-danielsmith-staging.md
@@ -1,0 +1,95 @@
+# k3s danielsmith.io runbook (staging)
+
+Use this runbook for static-site danielsmith.io staging deployments on Sugarkube.
+
+## Topology and scope
+
+- Sugarkube runs only the danielsmith.io static web container.
+- No in-cluster API/backend/database/queue/GPU/compute-node/stateful service is required.
+- Cloudflare Tunnel fronts Traefik, and Traefik routes to the `danielsmith` Service.
+
+## Artifact and values contract
+
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Image: `ghcr.io/futuroptimist/danielsmith.io`
+- Release: `danielsmith`
+- Namespace: `danielsmith`
+- Version pin file: `docs/apps/danielsmith.version`
+- Values: `docs/examples/danielsmith.values.dev.yaml` + `docs/examples/danielsmith.values.staging.yaml`
+- Default staging host: `staging.danielsmith.io`
+
+## First install
+
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+## Existing release upgrade
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Preferred wrapper:
+
+```bash
+just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+```
+
+## Validation
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+## Rollback
+
+Rollback by immutable tag:
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+Rollback by Helm revision:
+
+```bash
+DANIELSMITH_REVISION=12 # replace with the known-good Helm revision
+just helm-rollback release=danielsmith namespace=danielsmith revision="$DANIELSMITH_REVISION"
+```
+
+## Cloudflare tunnel routing (external to Helm)
+
+Cloudflare routes are configured outside the chart. Route `staging.danielsmith.io` to Traefik,
+typically `http://traefik.kube-system.svc.cluster.local:80`.
+
+```bash
+just cf-tunnel-route host=staging.danielsmith.io
+```
+
+## Troubleshooting
+
+GHCR auth/chart checks:
+
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/danielsmith.version | head -n1)"
+```
+
+App status/logs:
+
+```bash
+just danielsmith-status
+just danielsmith-debug-logs-env env=staging
+```
+
+Ingress/tunnel checks:
+
+```bash
+just cluster-status
+just traefik-status
+just cf-tunnel-debug
+```


### PR DESCRIPTION
### Motivation

- Provide a concrete, first-class Sugarkube docs and runbook set for the static danielsmith.io site to match existing DSPACE/token.place ops patterns.
- Capture the canonical artifact/values model (GHCR image + OCI Helm chart), environment overlays, and immutable-tag promotion flow for staging and production.
- Give operators runnable `just`/`kubectl`/`curl` runbooks and troubleshooting guidance so staging and prod can be deployed after Cloudflare routes are configured.

### Description

- Added `docs/apps/danielsmith.md` documenting topology (Vite + Three.js static site), artifact contract, values overlays, deployment commands, validation, Cloudflare/Traf﻿eik model, and runbook links. 
- Added `docs/k3s-danielsmith-staging.md` with staging first-install, upgrade, preferred wrapper (`just danielsmith-oci-deploy`), validation, rollback (tag + Helm revision), Cloudflare routing guidance, and troubleshooting commands. 
- Added `docs/k3s-danielsmith-prod.md` with promotion/upgrade examples, prod validation, rollback options, Cloudflare routing guidance, and troubleshooting commands. 
- Updated `docs/index.md` to include the new app and runbook links in the docs catalog so the app appears alongside existing app docs. 

### Testing

- Ran the verification greps which all found the new references: `grep -R "oci://ghcr.io/futuroptimist/charts/danielsmith" docs`, `grep -R "ghcr.io/futuroptimist/danielsmith.io" docs`, `grep -R "release=danielsmith namespace=danielsmith" docs`, `grep -R "staging.danielsmith.io" docs`, and `grep -R "https://danielsmith.io" docs` (all succeeded). 
- Attempted docs linters/validators but tooling is not available in this environment: `pyspelling -c .spellcheck.yaml` failed with `pyspelling: command not found`, `linkchecker --no-warnings README.md docs/` failed with `linkchecker: command not found`, and `pre-commit run --all-files` failed with `pre-commit: command not found`. 
- Ran the repository secret scan helper via `git diff --cached | ./scripts/scan-secrets.py` which had no staged diff to scan and reported skip in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14e94bd224832f89bd4e3cc35c38da)