### PR TITLE
docs: add danielsmith.io Sugarkube app docs and runbooks

### DIFF
--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -1,0 +1,71 @@
+# danielsmith.io on Sugarkube
+
+This is the canonical Sugarkube deployment model for `danielsmith.io`.
+
+## Static-site topology (current scope)
+
+Sugarkube currently runs **only** the static `danielsmith.io` web container (Vite + Three.js).
+
+- **In-cluster (Sugarkube):** one static web Deployment exposed via Traefik ingress.
+- **No in-cluster API/backend/database/queue/stateful service** is required.
+- **No GPU or compute-node workload** is required for this app on Sugarkube.
+- Cloudflare Tunnel fronts Traefik, and Traefik routes to the `danielsmith` Service.
+- Health endpoints and root page:
+  - `/livez`
+  - `/healthz`
+  - `/`
+
+## Artifact model (canonical)
+
+- Image: `ghcr.io/futuroptimist/danielsmith.io`
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Helm release: `danielsmith`
+- Namespace: `danielsmith`
+- Chart version pin file: `docs/apps/danielsmith.version`
+- Production approved tag pin: `docs/apps/danielsmith.prod.tag`
+
+## Values model
+
+- Base: `docs/examples/danielsmith.values.dev.yaml`
+- Staging overlay: `docs/examples/danielsmith.values.staging.yaml`
+- Production overlay: `docs/examples/danielsmith.values.prod.yaml`
+
+Default hosts:
+
+- Staging: `staging.danielsmith.io`
+- Production: `danielsmith.io`
+
+## Core deployment commands
+
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Preferred env wrapper:
+
+```bash
+just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+```
+
+## Cloudflare and ingress model
+
+Cloudflare Tunnel/DNS configuration is external to Helm.
+
+- Route hostnames to Traefik, typically
+  `http://traefik.kube-system.svc.cluster.local:80`.
+- Helm chart deployment does **not** create Cloudflare routes.
+- Configure routes explicitly:
+
+```bash
+just cf-tunnel-route host=staging.danielsmith.io
+just cf-tunnel-route host=danielsmith.io
+```
+
+## Related runbooks
+
+- Staging runbook: [`docs/k3s-danielsmith-staging.md`](../k3s-danielsmith-staging.md)
+- Production runbook: [`docs/k3s-danielsmith-prod.md`](../k3s-danielsmith-prod.md)

--- a/docs/k3s-danielsmith-prod.md
+++ b/docs/k3s-danielsmith-prod.md
@@ -1,0 +1,95 @@
+# k3s danielsmith.io runbook (prod)
+
+Use this runbook for static-site `danielsmith.io` production deployments on Sugarkube.
+
+## Topology and scope
+
+- Sugarkube runs only the static Vite + Three.js web container.
+- No API, backend, database, queue, GPU, compute node, or stateful service is required.
+- Cloudflare Tunnel fronts Traefik, and Traefik routes to the `danielsmith` Service.
+- Health and root endpoints:
+  - `/livez`
+  - `/healthz`
+  - `/`
+
+## Artifact and values contract
+
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Image: `ghcr.io/futuroptimist/danielsmith.io`
+- Release: `danielsmith`
+- Namespace: `danielsmith`
+- Version pin file: `docs/apps/danielsmith.version`
+- Approved prod tag file: `docs/apps/danielsmith.prod.tag`
+- Values: `docs/examples/danielsmith.values.dev.yaml` + `docs/examples/danielsmith.values.prod.yaml`
+- Default production host: `danielsmith.io`
+
+## Promotion after staging sign-off
+
+```bash
+just danielsmith-oci-promote-prod tag=main-REPLACE_APPROVED_SHORTSHA
+```
+
+## Generic production upgrade
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_APPROVED_SHORTSHA
+```
+
+## Validation
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://danielsmith.io/livez
+curl -fsS https://danielsmith.io/healthz
+curl -fsS https://danielsmith.io/
+```
+
+## Rollback options
+
+Rollback by immutable tag:
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+Rollback by Helm revision:
+
+```bash
+DANIELSMITH_REVISION=12 # replace with the known-good Helm revision
+just helm-rollback release=danielsmith namespace=danielsmith revision="$DANIELSMITH_REVISION"
+```
+
+## Cloudflare tunnel routing (external to Helm)
+
+Cloudflare routes are configured outside the chart. Route `danielsmith.io` to Traefik,
+typically `http://traefik.kube-system.svc.cluster.local:80`.
+
+```bash
+just cf-tunnel-route host=danielsmith.io
+```
+
+## Troubleshooting
+
+GHCR auth/chart checks:
+
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/danielsmith.version | head -n1)"
+```
+
+App status/logs:
+
+```bash
+just danielsmith-status
+just danielsmith-debug-logs-env env=staging
+just danielsmith-debug-logs-env env=prod
+```
+
+Ingress/tunnel checks:
+
+```bash
+just cluster-status
+just traefik-status
+just cf-tunnel-debug
+```

--- a/docs/k3s-danielsmith-staging.md
+++ b/docs/k3s-danielsmith-staging.md
@@ -1,0 +1,99 @@
+# k3s danielsmith.io runbook (staging)
+
+Use this runbook for static-site `danielsmith.io` staging deployments on Sugarkube.
+
+## Topology and scope
+
+- Sugarkube runs only the static Vite + Three.js web container.
+- No API, backend, database, queue, GPU, compute node, or stateful service is required.
+- Cloudflare Tunnel fronts Traefik, and Traefik routes to the `danielsmith` Service.
+- Health and root endpoints:
+  - `/livez`
+  - `/healthz`
+  - `/`
+
+## Artifact and values contract
+
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Image: `ghcr.io/futuroptimist/danielsmith.io`
+- Release: `danielsmith`
+- Namespace: `danielsmith`
+- Version pin file: `docs/apps/danielsmith.version`
+- Values: `docs/examples/danielsmith.values.dev.yaml` + `docs/examples/danielsmith.values.staging.yaml`
+- Default staging host: `staging.danielsmith.io`
+
+## First install
+
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+## Existing release upgrade
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Preferred wrapper:
+
+```bash
+just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+```
+
+## Validation
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+## Rollback
+
+Rollback by immutable tag:
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+Rollback by Helm revision:
+
+```bash
+DANIELSMITH_REVISION=12 # replace with the known-good Helm revision
+just helm-rollback release=danielsmith namespace=danielsmith revision="$DANIELSMITH_REVISION"
+```
+
+## Cloudflare tunnel routing (external to Helm)
+
+Cloudflare routes are configured outside the chart. Route `staging.danielsmith.io` to Traefik,
+typically `http://traefik.kube-system.svc.cluster.local:80`.
+
+```bash
+just cf-tunnel-route host=staging.danielsmith.io
+```
+
+## Troubleshooting
+
+GHCR auth/chart checks:
+
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/danielsmith.version | head -n1)"
+```
+
+App status/logs:
+
+```bash
+just danielsmith-status
+just danielsmith-debug-logs-env env=staging
+```
+
+Ingress/tunnel checks:
+
+```bash
+just cluster-status
+just traefik-status
+just cf-tunnel-debug
+```


### PR DESCRIPTION
### Motivation

- Add first-class Sugarkube documentation and runbooks for `danielsmith.io` so the static Vite + Three.js site can be deployed and operated alongside existing apps (DSPACE/token.place) using the same immutable-tag Helm OCI workflow. 
- Provide concrete artifact/values conventions, staging and production runbooks, and troubleshooting steps that match existing repo patterns without changing runtime helpers or `justfile` behavior.

### Description

- Add `docs/apps/danielsmith.md` describing the static-site-only topology, canonical artifact coordinates, values overlays, and Cloudflare/Trafik routing guidance. 
- Add `docs/k3s-danielsmith-staging.md` with first-install, upgrade, preferred wrapper (`just danielsmith-oci-deploy`), validation, rollback, Cloudflare routing, and troubleshooting steps. 
- Add `docs/k3s-danielsmith-prod.md` with promotion, generic production upgrade example, validation, rollback options, Cloudflare routing, and troubleshooting steps. 
- Update `docs/index.md` to reference the new danielsmith guide and runbooks, and ensure all docs consistently use `ghcr.io/futuroptimist/danielsmith.io`, `oci://ghcr.io/futuroptimist/charts/danielsmith`, release `danielsmith`, and namespace `danielsmith`.

### Testing

- Verified the canonical chart/image/release/namespace strings are present with `grep -R "oci://ghcr.io/futuroptimist/charts/danielsmith" docs`, `grep -R "ghcr.io/futuroptimist/danielsmith.io" docs`, and `grep -R "release=danielsmith namespace=danielsmith" docs`, which all returned matches. 
- Verified host and URL references with `grep -R "staging.danielsmith.io" docs` and `grep -R "https://danielsmith.io" docs`, which both returned matches. 
- Ran the repo secret check `git diff --cached | ./scripts/scan-secrets.py` (executed prior to committing) and it reported no findings. 
- Attempted docs validators `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` but the binaries were unavailable in the run environment (`pyspelling: command not found`, `linkchecker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14e94bd224832f89bd4e3cc35c38da)