### PR TITLE
docs: add danielsmith.io Sugarkube app docs and staging/prod runbooks

### DIFF
--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -1,0 +1,85 @@
+# danielsmith.io on Sugarkube
+
+This is the canonical Sugarkube deployment model for `danielsmith.io`.
+
+## Static-site-only topology (current scope)
+
+Sugarkube currently runs **only** the danielsmith.io static web container (Vite + Three.js).
+
+- **In-cluster (Sugarkube):** one static web deployment exposed through Traefik ingress.
+- **No API/backend/database/queue/GPU/compute node/stateful service** is required for this
+  workload.
+- Cloudflare Tunnel fronts Traefik, and Traefik routes requests to the `danielsmith` Kubernetes
+  Service.
+- Health/readiness endpoints:
+  - `/livez`
+  - `/healthz`
+- Root page:
+  - `/`
+
+## Artifact model (canonical)
+
+- Image: `ghcr.io/futuroptimist/danielsmith.io`
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Helm release: `danielsmith`
+- Namespace: `danielsmith`
+- Chart version pin file: `docs/apps/danielsmith.version`
+- Production approved tag pin: `docs/apps/danielsmith.prod.tag`
+
+## Values model
+
+- Base: `docs/examples/danielsmith.values.dev.yaml`
+- Staging overlay: `docs/examples/danielsmith.values.staging.yaml`
+- Production overlay: `docs/examples/danielsmith.values.prod.yaml`
+
+Default hosts:
+
+- Staging: `staging.danielsmith.io`
+- Production: `danielsmith.io`
+
+## Core deployment commands
+
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Preferred environment wrapper:
+
+```bash
+just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+```
+
+## Validation commands
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+For production validation, use the same checks against `https://danielsmith.io`.
+
+## Cloudflare and ingress model
+
+Cloudflare Tunnel/DNS configuration is external to Helm.
+
+- Route hostnames to Traefik, typically
+  `http://traefik.kube-system.svc.cluster.local:80`.
+- Helm chart deployment does **not** create Cloudflare routes.
+- Configure staging and production routes explicitly:
+
+```bash
+just cf-tunnel-route host=staging.danielsmith.io
+just cf-tunnel-route host=danielsmith.io
+```
+
+## Related runbooks
+
+- Staging runbook: [`docs/k3s-danielsmith-staging.md`](../k3s-danielsmith-staging.md)
+- Production runbook: [`docs/k3s-danielsmith-prod.md`](../k3s-danielsmith-prod.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,9 @@ Review the safety notes before working with power components.
   ownership boundaries, and environment mapping for token.place on Sugarkube
 - [apps/tokenplace.md](apps/tokenplace.md) — token.place app topology and operations model on Sugarkube
 - [apps/tokenplace-relay.md](apps/tokenplace-relay.md) — relay-only token.place OCI staging/prod operations guide
+- [apps/danielsmith.md](apps/danielsmith.md) — danielsmith.io static-site topology and deployment model on Sugarkube
+- [k3s-danielsmith-staging.md](k3s-danielsmith-staging.md) — danielsmith.io staging runbook
+- [k3s-danielsmith-prod.md](k3s-danielsmith-prod.md) — danielsmith.io production runbook
 - [k3s-tokenplace-dev.md](k3s-tokenplace-dev.md) — token.place dev runbook
 - [k3s-tokenplace-staging.md](k3s-tokenplace-staging.md) — token.place staging runbook
 - [k3s-tokenplace-prod.md](k3s-tokenplace-prod.md) — token.place production runbook

--- a/docs/k3s-danielsmith-prod.md
+++ b/docs/k3s-danielsmith-prod.md
@@ -1,0 +1,91 @@
+# k3s danielsmith.io runbook (prod)
+
+Use this runbook for static-site-only danielsmith.io production deployments on Sugarkube.
+
+## Topology and scope
+
+- Sugarkube runs only the danielsmith.io static web container (Vite + Three.js).
+- No API/backend/database/queue/GPU/compute node/stateful service is required.
+- Cloudflare Tunnel fronts Traefik, and Traefik routes traffic to the `danielsmith` Service.
+- Health endpoints: `/livez`, `/healthz`.
+- Root page: `/`.
+
+## Artifact and values contract
+
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Image: `ghcr.io/futuroptimist/danielsmith.io`
+- Release: `danielsmith`
+- Namespace: `danielsmith`
+- Version pin file: `docs/apps/danielsmith.version`
+- Approved prod tag file: `docs/apps/danielsmith.prod.tag`
+- Values: `docs/examples/danielsmith.values.dev.yaml` + `docs/examples/danielsmith.values.prod.yaml`
+- Default production host: `danielsmith.io`
+
+## Promotion after staging sign-off
+
+```bash
+just danielsmith-oci-promote-prod tag=main-REPLACE_APPROVED_SHORTSHA
+```
+
+## Generic production upgrade
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_APPROVED_SHORTSHA
+```
+
+## Validation
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://danielsmith.io/livez
+curl -fsS https://danielsmith.io/healthz
+curl -fsS https://danielsmith.io/
+```
+
+## Rollback options
+
+Rollback by immutable tag:
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+Rollback by Helm revision:
+
+```bash
+just helm-rollback release=danielsmith namespace=danielsmith revision=REPLACE_REVISION
+```
+
+## Cloudflare tunnel routing (external to Helm)
+
+Cloudflare routes are configured outside the chart. Route `danielsmith.io` to Traefik,
+typically `http://traefik.kube-system.svc.cluster.local:80`.
+
+```bash
+just cf-tunnel-route host=danielsmith.io
+```
+
+## Troubleshooting
+
+GHCR auth/chart checks:
+
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/danielsmith.version | head -n1)"
+```
+
+App status/logs:
+
+```bash
+just danielsmith-status
+just danielsmith-debug-logs-env env=prod
+```
+
+Ingress/tunnel checks:
+
+```bash
+just cluster-status
+just traefik-status
+just cf-tunnel-debug
+```

--- a/docs/k3s-danielsmith-staging.md
+++ b/docs/k3s-danielsmith-staging.md
@@ -1,0 +1,96 @@
+# k3s danielsmith.io runbook (staging)
+
+Use this runbook for static-site-only danielsmith.io staging deployments on Sugarkube.
+
+## Topology and scope
+
+- Sugarkube runs only the danielsmith.io static web container (Vite + Three.js).
+- No API/backend/database/queue/GPU/compute node/stateful service is required.
+- Cloudflare Tunnel fronts Traefik, and Traefik routes traffic to the `danielsmith` Service.
+- Health endpoints: `/livez`, `/healthz`.
+- Root page: `/`.
+
+## Artifact and values contract
+
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Image: `ghcr.io/futuroptimist/danielsmith.io`
+- Release: `danielsmith`
+- Namespace: `danielsmith`
+- Version pin file: `docs/apps/danielsmith.version`
+- Values: `docs/examples/danielsmith.values.dev.yaml` + `docs/examples/danielsmith.values.staging.yaml`
+- Default staging host: `staging.danielsmith.io`
+
+## First install
+
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+## Existing release upgrade
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Preferred wrapper:
+
+```bash
+just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+```
+
+## Validation
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+## Rollback
+
+Rollback by immutable tag:
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+Rollback by Helm revision:
+
+```bash
+just helm-rollback release=danielsmith namespace=danielsmith revision=REPLACE_REVISION
+```
+
+## Cloudflare tunnel routing (external to Helm)
+
+Cloudflare routes are configured outside the chart. Route `staging.danielsmith.io` to Traefik,
+typically `http://traefik.kube-system.svc.cluster.local:80`.
+
+```bash
+just cf-tunnel-route host=staging.danielsmith.io
+```
+
+## Troubleshooting
+
+GHCR auth/chart checks:
+
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/danielsmith.version | head -n1)"
+```
+
+App status/logs:
+
+```bash
+just danielsmith-status
+just danielsmith-debug-logs-env env=staging
+```
+
+Ingress/tunnel checks:
+
+```bash
+just cluster-status
+just traefik-status
+just cf-tunnel-debug
+```


### PR DESCRIPTION
### Motivation
- Add a concrete, first-class Sugarkube application guide and environment runbooks for `danielsmith.io` that match the existing DSPACE/token.place operational model. 
- Make staging and production deploys repeatable and verifiable with pinned artifact/chart references, overlay values, validation, rollback, and troubleshooting steps. 

### Description
- Add `docs/apps/danielsmith.md` documenting the static-site-only topology, artifact model, values overlays, core deploy commands, validation checks, and Cloudflare/Traefik guidance. 
- Add `docs/k3s-danielsmith-staging.md` with a staging runbook including first-install, upgrade, preferred `just` wrapper, validation, rollback (immutable tag and Helm revision), and troubleshooting steps. 
- Add `docs/k3s-danielsmith-prod.md` with a production runbook including promotion, generic upgrade, validation, rollback options, and troubleshooting steps. 
- Update `docs/index.md` to include catalog links for the new danielsmith docs and keep Cloudflare routing explicitly external to Helm. 

### Testing
- Verified presence with ripgrep: `rg "oci://ghcr.io/futuroptimist/charts/danielsmith" docs`, `rg "ghcr.io/futuroptimist/danielsmith.io" docs`, `rg "release=danielsmith namespace=danielsmith" docs`, `rg "staging.danielsmith.io" docs`, and `rg "https://danielsmith.io" docs` all succeeded. 
- Attempted repo checks `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` but those commands were unavailable in this environment so they were not run here. 
- Files added and staged in the working tree: `docs/apps/danielsmith.md`, `docs/k3s-danielsmith-staging.md`, `docs/k3s-danielsmith-prod.md`, and `docs/index.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14e94bd224832f89bd4e3cc35c38da)