### PR TITLE
docs: add danielsmith.io Sugarkube app docs and staging/prod runbooks

### DIFF
--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -38,19 +38,21 @@ Default hosts:
 First install (or install-or-upgrade) with generic helper:
 
 ```bash
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just kubeconfig-env staging
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-deadbee
 ```
 
 Existing release upgrade with generic helper:
 
 ```bash
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just kubeconfig-env staging
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-deadbee
 ```
 
 Preferred environment wrapper:
 
 ```bash
-just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+just danielsmith-oci-deploy env=staging tag=main-deadbee
 ```
 
 ## Validation commands

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -39,7 +39,7 @@ First install (or install-or-upgrade) with generic helper:
 
 ```bash
 just kubeconfig-env staging
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_TAG=main-abcdef0 # replace with the immutable GHCR image tag to deploy
 just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
 ```
 
@@ -47,14 +47,14 @@ Existing release upgrade with generic helper:
 
 ```bash
 just kubeconfig-env staging
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_TAG=main-abcdef0 # replace with the immutable GHCR image tag to deploy
 just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
 ```
 
 Preferred environment wrapper:
 
 ```bash
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_TAG=main-abcdef0 # replace with the immutable GHCR image tag to deploy
 just danielsmith-oci-deploy env=staging tag="$DANIELSMITH_TAG"
 ```
 

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -39,7 +39,7 @@ First install (or install-or-upgrade) with generic helper:
 
 ```bash
 just kubeconfig-env staging
-DANIELSMITH_TAG=main-abcdef0 # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_TAG=<immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
 just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
 ```
 
@@ -47,14 +47,14 @@ Existing release upgrade with generic helper:
 
 ```bash
 just kubeconfig-env staging
-DANIELSMITH_TAG=main-abcdef0 # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_TAG=<immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
 just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
 ```
 
 Preferred environment wrapper:
 
 ```bash
-DANIELSMITH_TAG=main-abcdef0 # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_TAG=<immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
 just danielsmith-oci-deploy env=staging tag="$DANIELSMITH_TAG"
 ```
 

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -39,7 +39,7 @@ First install (or install-or-upgrade) with generic helper:
 
 ```bash
 just kubeconfig-env staging
-DANIELSMITH_TAG=<immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
 just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
 ```
 
@@ -47,14 +47,14 @@ Existing release upgrade with generic helper:
 
 ```bash
 just kubeconfig-env staging
-DANIELSMITH_TAG=<immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
 just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
 ```
 
 Preferred environment wrapper:
 
 ```bash
-DANIELSMITH_TAG=<immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
 just danielsmith-oci-deploy env=staging tag="$DANIELSMITH_TAG"
 ```
 

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -1,0 +1,85 @@
+# danielsmith.io on Sugarkube
+
+This is the canonical Sugarkube deployment model for `danielsmith.io`.
+
+## Topology and scope (static-site only)
+
+`danielsmith.io` is a static Vite + Three.js site. Sugarkube runs only the static web container.
+
+- **In-cluster (Sugarkube):** one static web deployment exposed through Traefik ingress.
+- **No in-cluster API/backend/database/queue/GPU/compute node/stateful service** is required.
+- **Public ingress path:** Cloudflare Tunnel fronts Traefik, and Traefik routes to the
+  `danielsmith` Kubernetes Service.
+- **Health/availability endpoints:** `/livez`, `/healthz`.
+- **Root page:** `/`.
+
+## Artifact model (canonical)
+
+- Image: `ghcr.io/futuroptimist/danielsmith.io`
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Helm release: `danielsmith`
+- Namespace: `danielsmith`
+- Chart version pin file: `docs/apps/danielsmith.version`
+- Production approved tag pin: `docs/apps/danielsmith.prod.tag`
+
+## Values model
+
+- Base: `docs/examples/danielsmith.values.dev.yaml`
+- Staging overlay: `docs/examples/danielsmith.values.staging.yaml`
+- Production overlay: `docs/examples/danielsmith.values.prod.yaml`
+
+Default hosts:
+
+- Staging: `staging.danielsmith.io`
+- Production: `danielsmith.io`
+
+## Core deployment commands
+
+First install (or install-or-upgrade) with generic helper:
+
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Existing release upgrade with generic helper:
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Preferred environment wrapper:
+
+```bash
+just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+```
+
+## Validation commands
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+For production validation, use the same checks against `https://danielsmith.io`.
+
+## Cloudflare Tunnel and ingress model
+
+Cloudflare Tunnel/DNS configuration is external to Helm.
+
+- Route hostnames to Traefik, typically
+  `http://traefik.kube-system.svc.cluster.local:80`.
+- Helm chart deployment does **not** create Cloudflare routes.
+- Configure staging and prod routes explicitly:
+
+```bash
+just cf-tunnel-route host=staging.danielsmith.io
+just cf-tunnel-route host=danielsmith.io
+```
+
+## Related runbooks
+
+- Staging runbook: [`docs/k3s-danielsmith-staging.md`](../k3s-danielsmith-staging.md)
+- Production runbook: [`docs/k3s-danielsmith-prod.md`](../k3s-danielsmith-prod.md)

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -39,20 +39,23 @@ First install (or install-or-upgrade) with generic helper:
 
 ```bash
 just kubeconfig-env staging
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-deadbee
+DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
 ```
 
 Existing release upgrade with generic helper:
 
 ```bash
 just kubeconfig-env staging
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-deadbee
+DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
 ```
 
 Preferred environment wrapper:
 
 ```bash
-just danielsmith-oci-deploy env=staging tag=main-deadbee
+DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
+just danielsmith-oci-deploy env=staging tag="$DANIELSMITH_TAG"
 ```
 
 ## Validation commands

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,9 +47,12 @@ Review the safety notes before working with power components.
   ownership boundaries, and environment mapping for token.place on Sugarkube
 - [apps/tokenplace.md](apps/tokenplace.md) — token.place app topology and operations model on Sugarkube
 - [apps/tokenplace-relay.md](apps/tokenplace-relay.md) — relay-only token.place OCI staging/prod operations guide
+- [apps/danielsmith.md](apps/danielsmith.md) — danielsmith.io static-site topology and operations model on Sugarkube
 - [k3s-tokenplace-dev.md](k3s-tokenplace-dev.md) — token.place dev runbook
 - [k3s-tokenplace-staging.md](k3s-tokenplace-staging.md) — token.place staging runbook
 - [k3s-tokenplace-prod.md](k3s-tokenplace-prod.md) — token.place production runbook
+- [k3s-danielsmith-staging.md](k3s-danielsmith-staging.md) — danielsmith.io staging runbook
+- [k3s-danielsmith-prod.md](k3s-danielsmith-prod.md) — danielsmith.io production runbook
 - [operations/security-checklist.md](operations/security-checklist.md) — track credential rotations and
   verification steps
 - [pi_token_dspace.md](pi_token_dspace.md) — build and expose token.place & dspace via Cloudflare

--- a/docs/k3s-danielsmith-prod.md
+++ b/docs/k3s-danielsmith-prod.md
@@ -27,14 +27,14 @@ Always select the production kube context before running the generic Helm instal
 
 ```bash
 just kubeconfig-env prod
-DANIELSMITH_APPROVED_TAG=<immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the approved immutable GHCR image tag
 just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_APPROVED_TAG"
 ```
 
 ## Promotion after staging sign-off
 
 ```bash
-DANIELSMITH_APPROVED_TAG=<immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the approved immutable GHCR image tag
 just danielsmith-oci-promote-prod tag="$DANIELSMITH_APPROVED_TAG"
 ```
 
@@ -42,7 +42,7 @@ just danielsmith-oci-promote-prod tag="$DANIELSMITH_APPROVED_TAG"
 
 ```bash
 just kubeconfig-env prod
-DANIELSMITH_APPROVED_TAG=<immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the approved immutable GHCR image tag
 just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_APPROVED_TAG"
 ```
 
@@ -62,7 +62,7 @@ Rollback by immutable tag:
 
 ```bash
 just kubeconfig-env prod
-DANIELSMITH_PREVIOUS_APPROVED_TAG=<previous-immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_PREVIOUS_APPROVED_TAG=main-REPLACE_PREVIOUS_APPROVED_SHORTSHA # replace with the previous approved immutable GHCR image tag
 just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_PREVIOUS_APPROVED_TAG"
 ```
 

--- a/docs/k3s-danielsmith-prod.md
+++ b/docs/k3s-danielsmith-prod.md
@@ -24,22 +24,24 @@ Use this runbook for production deployments of the static `danielsmith.io` site 
 ## First install
 
 ```bash
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_APPROVED_SHORTSHA
+just kubeconfig-env prod
+DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the immutable GHCR image tag to deploy
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_APPROVED_TAG"
 ```
 
 ## Promotion after staging sign-off
 
 ```bash
-DANIELSMITH_TAG=main-deadbee # replace with the approved immutable tag
-just danielsmith-oci-promote-prod tag="$DANIELSMITH_TAG"
+DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the immutable GHCR image tag to deploy
+just danielsmith-oci-promote-prod tag="$DANIELSMITH_APPROVED_TAG"
 ```
 
 ## Generic production upgrade
 
 ```bash
 just kubeconfig-env prod
-DANIELSMITH_TAG=main-deadbee # replace with the approved immutable tag
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
+DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the immutable GHCR image tag to deploy
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_APPROVED_TAG"
 ```
 
 ## Validation
@@ -58,8 +60,8 @@ Rollback by immutable tag:
 
 ```bash
 just kubeconfig-env prod
-DANIELSMITH_PREVIOUS_TAG=main-deadbee # replace with the prior immutable tag
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_PREVIOUS_TAG"
+DANIELSMITH_PREVIOUS_APPROVED_TAG=main-REPLACE_PREVIOUS_APPROVED_SHORTSHA # replace with the immutable GHCR image tag to deploy
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_PREVIOUS_APPROVED_TAG"
 ```
 
 Rollback by Helm revision:

--- a/docs/k3s-danielsmith-prod.md
+++ b/docs/k3s-danielsmith-prod.md
@@ -24,13 +24,14 @@ Use this runbook for production deployments of the static `danielsmith.io` site 
 ## Promotion after staging sign-off
 
 ```bash
-just danielsmith-oci-promote-prod tag=main-REPLACE_APPROVED_SHORTSHA
+just danielsmith-oci-promote-prod tag=main-deadbee
 ```
 
 ## Generic production upgrade
 
 ```bash
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_APPROVED_SHORTSHA
+just kubeconfig-env prod
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-deadbee
 ```
 
 ## Validation
@@ -48,12 +49,14 @@ curl -fsS https://danielsmith.io/
 Rollback by immutable tag:
 
 ```bash
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_PREVIOUS_APPROVED_SHORTSHA
+just kubeconfig-env prod
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-deadbee
 ```
 
 Rollback by Helm revision:
 
 ```bash
+just kubeconfig-env prod
 DANIELSMITH_REVISION=12 # replace with the known-good Helm revision
 just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$DANIELSMITH_REVISION"
 ```
@@ -72,7 +75,7 @@ just cf-tunnel-route host=danielsmith.io
 GHCR auth/chart checks:
 
 ```bash
-helm registry login ghcr.io
+echo "$GHCR_TOKEN" | helm registry login ghcr.io -u "$GHCR_USER" --password-stdin
 helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/danielsmith.version | head -n1)"
 ```
 

--- a/docs/k3s-danielsmith-prod.md
+++ b/docs/k3s-danielsmith-prod.md
@@ -30,14 +30,16 @@ just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr
 ## Promotion after staging sign-off
 
 ```bash
-just danielsmith-oci-promote-prod tag=main-deadbee
+DANIELSMITH_TAG=main-deadbee # replace with the approved immutable tag
+just danielsmith-oci-promote-prod tag="$DANIELSMITH_TAG"
 ```
 
 ## Generic production upgrade
 
 ```bash
 just kubeconfig-env prod
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-deadbee
+DANIELSMITH_TAG=main-deadbee # replace with the approved immutable tag
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
 ```
 
 ## Validation
@@ -56,7 +58,8 @@ Rollback by immutable tag:
 
 ```bash
 just kubeconfig-env prod
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-deadbee
+DANIELSMITH_PREVIOUS_TAG=main-deadbee # replace with the prior immutable tag
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_PREVIOUS_TAG"
 ```
 
 Rollback by Helm revision:

--- a/docs/k3s-danielsmith-prod.md
+++ b/docs/k3s-danielsmith-prod.md
@@ -23,6 +23,8 @@ Use this runbook for production deployments of the static `danielsmith.io` site 
 
 ## First install
 
+Always select the production kube context before running the generic Helm install command.
+
 ```bash
 just kubeconfig-env prod
 DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the immutable GHCR image tag to deploy

--- a/docs/k3s-danielsmith-prod.md
+++ b/docs/k3s-danielsmith-prod.md
@@ -1,0 +1,92 @@
+# k3s danielsmith.io runbook (prod)
+
+Use this runbook for production deployments of the static `danielsmith.io` site on Sugarkube.
+
+## Topology and scope
+
+- `danielsmith.io` is a static Vite + Three.js workload.
+- Sugarkube runs only the static web container.
+- No in-cluster API/backend/database/queue/GPU/compute node/stateful service is required.
+- Cloudflare Tunnel fronts Traefik; Traefik routes traffic to the `danielsmith` Service.
+- Probe/application endpoints: `/livez`, `/healthz`, and `/`.
+
+## Artifact and values contract
+
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Image: `ghcr.io/futuroptimist/danielsmith.io`
+- Release: `danielsmith`
+- Namespace: `danielsmith`
+- Version pin file: `docs/apps/danielsmith.version`
+- Approved prod tag file: `docs/apps/danielsmith.prod.tag`
+- Values: `docs/examples/danielsmith.values.dev.yaml` + `docs/examples/danielsmith.values.prod.yaml`
+- Default production host: `danielsmith.io`
+
+## Promotion after staging sign-off
+
+```bash
+just danielsmith-oci-promote-prod tag=main-REPLACE_APPROVED_SHORTSHA
+```
+
+## Generic production upgrade
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_APPROVED_SHORTSHA
+```
+
+## Validation
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://danielsmith.io/livez
+curl -fsS https://danielsmith.io/healthz
+curl -fsS https://danielsmith.io/
+```
+
+## Rollback options
+
+Rollback by immutable tag:
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_PREVIOUS_APPROVED_SHORTSHA
+```
+
+Rollback by Helm revision:
+
+```bash
+DANIELSMITH_REVISION=12 # replace with the known-good Helm revision
+just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$DANIELSMITH_REVISION"
+```
+
+## Cloudflare tunnel routing (external to Helm)
+
+Cloudflare routes are configured outside the chart. Route `danielsmith.io` to Traefik,
+typically `http://traefik.kube-system.svc.cluster.local:80`.
+
+```bash
+just cf-tunnel-route host=danielsmith.io
+```
+
+## Troubleshooting
+
+GHCR auth/chart checks:
+
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/danielsmith.version | head -n1)"
+```
+
+App status/logs:
+
+```bash
+just danielsmith-status
+just danielsmith-debug-logs-env env=prod
+```
+
+Ingress/tunnel checks:
+
+```bash
+just cluster-status
+just traefik-status
+just cf-tunnel-debug
+```

--- a/docs/k3s-danielsmith-prod.md
+++ b/docs/k3s-danielsmith-prod.md
@@ -27,14 +27,14 @@ Always select the production kube context before running the generic Helm instal
 
 ```bash
 just kubeconfig-env prod
-DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_APPROVED_TAG=main-abcdef0 # replace with the immutable GHCR image tag to deploy
 just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_APPROVED_TAG"
 ```
 
 ## Promotion after staging sign-off
 
 ```bash
-DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_APPROVED_TAG=main-abcdef0 # replace with the immutable GHCR image tag to deploy
 just danielsmith-oci-promote-prod tag="$DANIELSMITH_APPROVED_TAG"
 ```
 
@@ -42,7 +42,7 @@ just danielsmith-oci-promote-prod tag="$DANIELSMITH_APPROVED_TAG"
 
 ```bash
 just kubeconfig-env prod
-DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_APPROVED_TAG=main-abcdef0 # replace with the immutable GHCR image tag to deploy
 just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_APPROVED_TAG"
 ```
 
@@ -62,7 +62,7 @@ Rollback by immutable tag:
 
 ```bash
 just kubeconfig-env prod
-DANIELSMITH_PREVIOUS_APPROVED_TAG=main-REPLACE_PREVIOUS_APPROVED_SHORTSHA # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_PREVIOUS_APPROVED_TAG=main-fedcba0 # replace with the immutable GHCR image tag to deploy
 just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_PREVIOUS_APPROVED_TAG"
 ```
 

--- a/docs/k3s-danielsmith-prod.md
+++ b/docs/k3s-danielsmith-prod.md
@@ -21,6 +21,12 @@ Use this runbook for production deployments of the static `danielsmith.io` site 
 - Values: `docs/examples/danielsmith.values.dev.yaml` + `docs/examples/danielsmith.values.prod.yaml`
 - Default production host: `danielsmith.io`
 
+## First install
+
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_APPROVED_SHORTSHA
+```
+
 ## Promotion after staging sign-off
 
 ```bash
@@ -54,6 +60,8 @@ just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr
 ```
 
 Rollback by Helm revision:
+
+`tokenplace-rollback` is the repository's existing parameterized Helm rollback helper, even though the recipe name is token.place-scoped.
 
 ```bash
 just kubeconfig-env prod

--- a/docs/k3s-danielsmith-prod.md
+++ b/docs/k3s-danielsmith-prod.md
@@ -27,14 +27,14 @@ Always select the production kube context before running the generic Helm instal
 
 ```bash
 just kubeconfig-env prod
-DANIELSMITH_APPROVED_TAG=main-abcdef0 # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_APPROVED_TAG=<immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
 just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_APPROVED_TAG"
 ```
 
 ## Promotion after staging sign-off
 
 ```bash
-DANIELSMITH_APPROVED_TAG=main-abcdef0 # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_APPROVED_TAG=<immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
 just danielsmith-oci-promote-prod tag="$DANIELSMITH_APPROVED_TAG"
 ```
 
@@ -42,7 +42,7 @@ just danielsmith-oci-promote-prod tag="$DANIELSMITH_APPROVED_TAG"
 
 ```bash
 just kubeconfig-env prod
-DANIELSMITH_APPROVED_TAG=main-abcdef0 # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_APPROVED_TAG=<immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
 just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_APPROVED_TAG"
 ```
 
@@ -62,7 +62,7 @@ Rollback by immutable tag:
 
 ```bash
 just kubeconfig-env prod
-DANIELSMITH_PREVIOUS_APPROVED_TAG=main-fedcba0 # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_PREVIOUS_APPROVED_TAG=<previous-immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
 just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_PREVIOUS_APPROVED_TAG"
 ```
 

--- a/docs/k3s-danielsmith-staging.md
+++ b/docs/k3s-danielsmith-staging.md
@@ -24,7 +24,7 @@ Use this runbook for staging deployments of the static `danielsmith.io` site on 
 
 ```bash
 just kubeconfig-env staging
-DANIELSMITH_TAG=<immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
 just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
 ```
 
@@ -32,14 +32,14 @@ just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr
 
 ```bash
 just kubeconfig-env staging
-DANIELSMITH_TAG=<immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
 just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
 ```
 
 Preferred wrapper:
 
 ```bash
-DANIELSMITH_TAG=<immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
 just danielsmith-oci-deploy env=staging tag="$DANIELSMITH_TAG"
 ```
 
@@ -59,7 +59,7 @@ Rollback by immutable tag:
 
 ```bash
 just kubeconfig-env staging
-DANIELSMITH_PREVIOUS_TAG=<previous-immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_PREVIOUS_TAG=main-REPLACE_PREVIOUS_SHORTSHA # replace with the previous immutable GHCR image tag
 just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_PREVIOUS_TAG"
 ```
 

--- a/docs/k3s-danielsmith-staging.md
+++ b/docs/k3s-danielsmith-staging.md
@@ -24,7 +24,7 @@ Use this runbook for staging deployments of the static `danielsmith.io` site on 
 
 ```bash
 just kubeconfig-env staging
-DANIELSMITH_TAG=main-abcdef0 # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_TAG=<immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
 just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
 ```
 
@@ -32,14 +32,14 @@ just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr
 
 ```bash
 just kubeconfig-env staging
-DANIELSMITH_TAG=main-abcdef0 # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_TAG=<immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
 just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
 ```
 
 Preferred wrapper:
 
 ```bash
-DANIELSMITH_TAG=main-abcdef0 # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_TAG=<immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
 just danielsmith-oci-deploy env=staging tag="$DANIELSMITH_TAG"
 ```
 
@@ -59,7 +59,7 @@ Rollback by immutable tag:
 
 ```bash
 just kubeconfig-env staging
-DANIELSMITH_PREVIOUS_TAG=main-fedcba0 # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_PREVIOUS_TAG=<previous-immutable-ghcr-tag> # replace with the immutable GHCR image tag to deploy
 just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_PREVIOUS_TAG"
 ```
 

--- a/docs/k3s-danielsmith-staging.md
+++ b/docs/k3s-danielsmith-staging.md
@@ -61,6 +61,8 @@ just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr
 
 Rollback by Helm revision:
 
+`tokenplace-rollback` is the repository's existing parameterized Helm rollback helper, even though the recipe name is token.place-scoped.
+
 ```bash
 just kubeconfig-env staging
 DANIELSMITH_REVISION=12 # replace with the known-good Helm revision

--- a/docs/k3s-danielsmith-staging.md
+++ b/docs/k3s-danielsmith-staging.md
@@ -1,0 +1,97 @@
+# k3s danielsmith.io runbook (staging)
+
+Use this runbook for staging deployments of the static `danielsmith.io` site on Sugarkube.
+
+## Topology and scope
+
+- `danielsmith.io` is a static Vite + Three.js workload.
+- Sugarkube runs only the static web container.
+- No in-cluster API/backend/database/queue/GPU/compute node/stateful service is required.
+- Cloudflare Tunnel fronts Traefik; Traefik routes traffic to the `danielsmith` Service.
+- Probe/application endpoints: `/livez`, `/healthz`, and `/`.
+
+## Artifact and values contract
+
+- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
+- Image: `ghcr.io/futuroptimist/danielsmith.io`
+- Release: `danielsmith`
+- Namespace: `danielsmith`
+- Version pin file: `docs/apps/danielsmith.version`
+- Values: `docs/examples/danielsmith.values.dev.yaml` + `docs/examples/danielsmith.values.staging.yaml`
+- Default staging host: `staging.danielsmith.io`
+
+## First install
+
+```bash
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+## Existing release upgrade
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+```
+
+Preferred wrapper:
+
+```bash
+just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+```
+
+## Validation
+
+```bash
+kubectl -n danielsmith get deploy,po,svc,ingress
+kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+curl -fsS https://staging.danielsmith.io/
+```
+
+## Rollback
+
+Rollback by immutable tag:
+
+```bash
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+Rollback by Helm revision:
+
+```bash
+DANIELSMITH_REVISION=12 # replace with the known-good Helm revision
+just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$DANIELSMITH_REVISION"
+```
+
+## Cloudflare tunnel routing (external to Helm)
+
+Cloudflare routes are configured outside the chart. Route `staging.danielsmith.io` to Traefik,
+typically `http://traefik.kube-system.svc.cluster.local:80`.
+
+```bash
+just cf-tunnel-route host=staging.danielsmith.io
+```
+
+## Troubleshooting
+
+GHCR auth/chart checks:
+
+```bash
+helm registry login ghcr.io
+helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/danielsmith.version | head -n1)"
+```
+
+App status/logs:
+
+```bash
+just danielsmith-status
+just danielsmith-debug-logs-env env=staging
+```
+
+Ingress/tunnel checks:
+
+```bash
+just cluster-status
+just traefik-status
+just cf-tunnel-debug
+```

--- a/docs/k3s-danielsmith-staging.md
+++ b/docs/k3s-danielsmith-staging.md
@@ -24,7 +24,7 @@ Use this runbook for staging deployments of the static `danielsmith.io` site on 
 
 ```bash
 just kubeconfig-env staging
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_TAG=main-abcdef0 # replace with the immutable GHCR image tag to deploy
 just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
 ```
 
@@ -32,14 +32,14 @@ just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr
 
 ```bash
 just kubeconfig-env staging
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_TAG=main-abcdef0 # replace with the immutable GHCR image tag to deploy
 just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
 ```
 
 Preferred wrapper:
 
 ```bash
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_TAG=main-abcdef0 # replace with the immutable GHCR image tag to deploy
 just danielsmith-oci-deploy env=staging tag="$DANIELSMITH_TAG"
 ```
 
@@ -59,7 +59,7 @@ Rollback by immutable tag:
 
 ```bash
 just kubeconfig-env staging
-DANIELSMITH_PREVIOUS_TAG=main-REPLACE_PREVIOUS_SHORTSHA # replace with the immutable GHCR image tag to deploy
+DANIELSMITH_PREVIOUS_TAG=main-fedcba0 # replace with the immutable GHCR image tag to deploy
 just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_PREVIOUS_TAG"
 ```
 

--- a/docs/k3s-danielsmith-staging.md
+++ b/docs/k3s-danielsmith-staging.md
@@ -23,19 +23,21 @@ Use this runbook for staging deployments of the static `danielsmith.io` site on 
 ## First install
 
 ```bash
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just kubeconfig-env staging
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-deadbee
 ```
 
 ## Existing release upgrade
 
 ```bash
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_SHORTSHA
+just kubeconfig-env staging
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-deadbee
 ```
 
 Preferred wrapper:
 
 ```bash
-just danielsmith-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
+just danielsmith-oci-deploy env=staging tag=main-deadbee
 ```
 
 ## Validation
@@ -53,12 +55,14 @@ curl -fsS https://staging.danielsmith.io/
 Rollback by immutable tag:
 
 ```bash
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-REPLACE_PREVIOUS_SHORTSHA
+just kubeconfig-env staging
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-deadbee
 ```
 
 Rollback by Helm revision:
 
 ```bash
+just kubeconfig-env staging
 DANIELSMITH_REVISION=12 # replace with the known-good Helm revision
 just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$DANIELSMITH_REVISION"
 ```
@@ -77,7 +81,7 @@ just cf-tunnel-route host=staging.danielsmith.io
 GHCR auth/chart checks:
 
 ```bash
-helm registry login ghcr.io
+echo "$GHCR_TOKEN" | helm registry login ghcr.io -u "$GHCR_USER" --password-stdin
 helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/danielsmith.version | head -n1)"
 ```
 

--- a/docs/k3s-danielsmith-staging.md
+++ b/docs/k3s-danielsmith-staging.md
@@ -24,20 +24,23 @@ Use this runbook for staging deployments of the static `danielsmith.io` site on 
 
 ```bash
 just kubeconfig-env staging
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-deadbee
+DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
+just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
 ```
 
 ## Existing release upgrade
 
 ```bash
 just kubeconfig-env staging
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-deadbee
+DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
 ```
 
 Preferred wrapper:
 
 ```bash
-just danielsmith-oci-deploy env=staging tag=main-deadbee
+DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
+just danielsmith-oci-deploy env=staging tag="$DANIELSMITH_TAG"
 ```
 
 ## Validation
@@ -56,7 +59,8 @@ Rollback by immutable tag:
 
 ```bash
 just kubeconfig-env staging
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag=main-deadbee
+DANIELSMITH_PREVIOUS_TAG=main-REPLACE_PREVIOUS_SHORTSHA # replace with the immutable GHCR image tag to deploy
+just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_PREVIOUS_TAG"
 ```
 
 Rollback by Helm revision:


### PR DESCRIPTION
### Motivation

- Add first-class Sugarkube documentation and runbooks for `danielsmith.io` so the static Vite/Three.js site is operable alongside existing DSPACE and token.place workloads. 
- Keep the guidance consistent with the existing deployment model (immutable OCI Helm charts, `just` helpers, Cloudflare Tunnel -> Traefik routing) and explicitly state the static-site-only scope and required health endpoints. 

### Description

- Added `docs/apps/danielsmith.md` as the canonical app guide that documents the artifact model (`ghcr.io/futuroptimist/danielsmith.io`, `oci://ghcr.io/futuroptimist/charts/danielsmith`), namespace/release (`danielsmith`), and values overlay files. 
- Added `docs/k3s-danielsmith-staging.md` and `docs/k3s-danielsmith-prod.md` with concrete first-install, upgrade, preferred `just` wrappers, validation, rollback (immutable-tag and Helm revision) and troubleshooting steps. 
- Updated `docs/index.md` to include links to the new app guide and staging/prod runbooks so the app appears in the docs catalog. 
- Reused existing helpers and files: runbooks reference `docs/apps/danielsmith.version`, `docs/apps/danielsmith.prod.tag`, `docs/examples/danielsmith.values.*.yaml`, and the repository-wide `just` helpers (including the existing `tokenplace-rollback` helper for Helm revision rollback). 

### Testing

- Ran verification searches with `rg -n` for the key artifacts and routes (`oci://ghcr.io/futuroptimist/charts/danielsmith`, `ghcr.io/futuroptimist/danielsmith.io`, `release=danielsmith namespace=danielsmith`, `staging.danielsmith.io`, `https://danielsmith.io`) and they all returned expected matches in `docs`. 
- Attempted to run the repo-standard linters/validators: `pre-commit run --all-files` was not available in this environment (`command not found`). 
- Attempted documentation checks `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` but those tools were not available in this environment (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14e94bd224832f89bd4e3cc35c38da)