### PR TITLE
Enable token.place Ingress TLS rendering, document Recreate rollout, and keep v0.1.0 alignment

### DIFF
--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -148,3 +148,12 @@ just cluster-status
 just traefik-status
 just cf-tunnel-debug
 ```
+
+## 0.1.0 release alignment
+
+- Chart version pin (`docs/apps/tokenplace.version`): `0.1.0`
+- Expected chart `appVersion`: `0.1.0`
+- token.place release tag: `v0.1.0`
+- Production release image tag: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Staging candidate image tags: immutable `main-<shortsha>`
+

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -75,6 +75,8 @@ For production validation, use the same checks against `https://token.place`.
 
 ## Cloudflare and ingress model
 
+Staging/prod overlays must set `ingress.tls.enabled: true` so Kubernetes Ingress `spec.tls` renders; `secretName` alone is not sufficient on charts that gate TLS blocks with an explicit enabled flag.
+
 Cloudflare Tunnel/DNS configuration is external to Helm.
 
 - Route hostnames to Traefik, typically
@@ -92,3 +94,12 @@ just cf-tunnel-route host=token.place
 - Relay-focused app guide: [`docs/apps/tokenplace-relay.md`](./tokenplace-relay.md)
 - Staging runbook: [`docs/k3s-tokenplace-staging.md`](../k3s-tokenplace-staging.md)
 - Production runbook: [`docs/k3s-tokenplace-prod.md`](../k3s-tokenplace-prod.md)
+
+## 0.1.0 release alignment
+
+- Chart version pin (`docs/apps/tokenplace.version`): `0.1.0`
+- Expected chart `appVersion`: `0.1.0`
+- token.place release tag: `v0.1.0`
+- Production release image tag: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Staging candidate image tags: immutable `main-<shortsha>`
+

--- a/docs/examples/tokenplace.values.prod.yaml
+++ b/docs/examples/tokenplace.values.prod.yaml
@@ -8,6 +8,7 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
   tls:
+    enabled: true
     secretName: tokenplace-prod-tls
 
 env:

--- a/docs/examples/tokenplace.values.staging.yaml
+++ b/docs/examples/tokenplace.values.staging.yaml
@@ -8,6 +8,7 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
   tls:
+    enabled: true
     secretName: tokenplace-staging-tls
 
 env:

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -9,6 +9,7 @@ Use this runbook for relay-only token.place production deployments on Sugarkube.
 - Compute nodes remain external (`server.py`, Tauri desktop app, Windows PCs, Apple Silicon Macs,
   Raspberry Pi compute nodes, etc.).
 - Runtime model is single replica + single worker + in-memory state.
+- Deployments use strict `strategy.type: Recreate` to preserve single-pod relay behavior.
 - In-memory state loss on pod restart is accepted for now.
 
 ## Artifact and values contract
@@ -22,7 +23,21 @@ Use this runbook for relay-only token.place production deployments on Sugarkube.
 - Values: `docs/examples/tokenplace.values.dev.yaml` + `docs/examples/tokenplace.values.prod.yaml`
 - Default production host: `token.place`
 
+## Pre-flight checks
+
+- `docs/apps/tokenplace.version` is pinned to `0.1.0` and remains the launch chart pin.
+- Verify the `0.1.0` OCI chart exists only after token.place publishes the current chart.
+- If `helm show chart ... --version 0.1.0` succeeds before final token.place chart publish, confirm the chart is not stale before deploying.
+- Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes.
+- cert-manager and the referenced ClusterIssuer are assumed to already exist.
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+```
+
 ## Promotion after staging sign-off
+
+After token.place Git tag push (`v0.1.0`), production promotion should use `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`.
 
 ```bash
 TOKENPLACE_TAG=main-deadbee # replace with the approved immutable tag
@@ -46,12 +61,26 @@ just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.i
 
 ## Validation
 
+Render and contract checks before cluster apply:
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.prod.yaml --set image.tag=v0.1.0 > /tmp/tokenplace-prod-render.yaml
+grep -n "spec:" -A40 /tmp/tokenplace-prod-render.yaml | grep -n "tls"
+grep -n "token.place" /tmp/tokenplace-prod-render.yaml
+grep -n "tokenplace-prod-tls" /tmp/tokenplace-prod-render.yaml
+grep -n "type: Recreate" /tmp/tokenplace-prod-render.yaml
+```
+
+Runtime checks after deploy:
+
 ```bash
 kubectl -n tokenplace get deploy,po,svc,ingress
 kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+kubectl -n tokenplace get ingress tokenplace -o yaml
+curl -vI https://token.place/
 curl -fsS https://token.place/livez
 curl -fsS https://token.place/healthz
-curl -fsS https://token.place/
 ```
 
 ## Rollback options

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -9,9 +9,12 @@ Use this runbook for relay-only token.place staging deployments on Sugarkube.
 - Compute nodes remain external (`server.py`, Tauri desktop app, Windows PCs, Apple Silicon Macs,
   Raspberry Pi compute nodes, etc.).
 - Runtime model is single replica + single worker + in-memory state.
+- Deployments use strict `strategy.type: Recreate` to preserve single-pod relay behavior.
 - In-memory state loss on pod restart is accepted for now.
 
 ## Artifact and values contract
+
+- Ingress TLS now renders `spec.tls` from staging/prod overlays via `ingress.tls.enabled: true` plus environment-specific `secretName`.
 
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
@@ -20,6 +23,18 @@ Use this runbook for relay-only token.place staging deployments on Sugarkube.
 - Version pin file: `docs/apps/tokenplace.version`
 - Values: `docs/examples/tokenplace.values.dev.yaml` + `docs/examples/tokenplace.values.staging.yaml`
 - Default staging host: `staging.token.place`
+
+## Pre-flight checks
+
+- `docs/apps/tokenplace.version` is pinned to `0.1.0` and must remain `0.1.0` for launch alignment.
+- Verify the `0.1.0` OCI chart exists only after token.place publishes the current chart.
+- If `helm show chart ... --version 0.1.0` succeeds before final token.place chart publish, confirm the chart is not stale before deploying.
+- Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes.
+- cert-manager and the referenced ClusterIssuer are assumed to already exist.
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+```
 
 ## First install
 
@@ -46,12 +61,26 @@ just tokenplace-oci-deploy env=staging tag="$TOKENPLACE_TAG"
 
 ## Validation
 
+Render and contract checks before cluster apply:
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.staging.yaml --set image.tag=main-deadbee > /tmp/tokenplace-staging-render.yaml
+grep -n "spec:" -A40 /tmp/tokenplace-staging-render.yaml | grep -n "tls"
+grep -n "staging.token.place" /tmp/tokenplace-staging-render.yaml
+grep -n "tokenplace-staging-tls" /tmp/tokenplace-staging-render.yaml
+grep -n "type: Recreate" /tmp/tokenplace-staging-render.yaml
+```
+
+Runtime checks after deploy:
+
 ```bash
 kubectl -n tokenplace get deploy,po,svc,ingress
 kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+kubectl -n tokenplace get ingress tokenplace -o yaml
+curl -vI https://staging.token.place/
 curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
-curl -fsS https://staging.token.place/
 ```
 
 ## Rollback

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -45,3 +45,12 @@ Host defaults:
 
 Cloudflare tunnels/routes are managed outside Helm. Use route mappings from hostname to Traefik
 (typically `http://traefik.kube-system.svc.cluster.local:80`) before deploy/upgrade steps.
+
+## 0.1.0 release alignment
+
+- Chart package version: `0.1.0`
+- Chart `appVersion`: `0.1.0`
+- token.place Git tag: `v0.1.0`
+- Release image tag: `v0.1.0` (`ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
+- Staging candidate image tag before final promotion: `main-<shortsha>`
+


### PR DESCRIPTION
### Motivation

- Ensure Sugarkube staging/prod overlays render Kubernetes Ingress `spec.tls` (secretName alone is not sufficient for charts that gate TLS blocks). 
- Preserve the token.place launch alignment with all identifiers pinned to `0.1.0` while keeping staging candidates as immutable `main-<shortsha>` tags. 
- Make runbooks explicit about Cloudflare Tunnel ownership of public host routing, the cert-manager/ClusterIssuer prerequisite, and strict single-pod relay rollout behavior (`strategy.type: Recreate`).

### Description

- Added `ingress.tls.enabled: true` to `docs/examples/tokenplace.values.staging.yaml` and `docs/examples/tokenplace.values.prod.yaml` while preserving `ingress.tls.secretName` values (`tokenplace-staging-tls` / `tokenplace-prod-tls`).
- Updated staging and production runbooks (`docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`) and app docs (`docs/apps/tokenplace.md`, `docs/apps/tokenplace-relay.md`, `docs/tokenplace_sugarkube_onboarding.md`) to add pre-flight guidance, render/contract checks, and to document that Cloudflare Tunnel handles hostname routing and that cert-manager/ClusterIssuer are assumed present.
- Added render/validation command snippets to runbooks including `helm show chart`, `helm template`, grep/yq checks for `spec.tls`, host, secretName, and `type: Recreate`, plus `kubectl -n tokenplace get ingress tokenplace -o yaml` and `curl -vI` checks for staging and prod.
- Added explicit “0.1.0 release alignment” text in token.place docs and kept `docs/apps/tokenplace.version` exactly `0.1.0`; this PR intentionally does not introduce any `0.1.1` identifiers.

### Testing

- Ran `cat docs/apps/tokenplace.version` which shows `0.1.0` as expected. 
- Ran `rg -n "0\.1\.1" .` which returned no `0.1.1` matches. 
- Ran targeted `rg` checks for TLS/secret/`Recreate`/`0.1.0`/`main-<shortsha>` across the edited docs and values and observed the expected matches. 
- Attempted `helm show chart` / `helm template` and `pre-commit run --all-files` in this execution environment but they could not be run because `helm` and `pre-commit` are not installed here (`helm: command not found`, `pre-commit: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1662e21320832faee674cc1b0eacf3)