### PR TITLE
Align token.place TLS rendering and keep all launch versions at v0.1.0

### DIFF
--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -6,6 +6,7 @@ This guide documents the **relay-only** token.place deployment on Sugarkube.
 - No in-cluster backend/GPU service is required.
 - Compute nodes remain external (`server.py`, Tauri desktop app, Windows/Apple Silicon/Raspberry Pi nodes, etc.).
 - Runtime is intentionally single replica, single worker, with in-memory state.
+- Rollout behavior is strict `strategy.type: Recreate`.
 - In-memory state loss on pod restart is accepted at this stage.
 
 For the broader app overview, see [`docs/apps/tokenplace.md`](./tokenplace.md).
@@ -58,11 +59,14 @@ just tokenplace-oci-deploy env=staging tag="$TOKENPLACE_TAG"
 ## Staging validation
 
 ```bash
-kubectl -n tokenplace get deploy,po,svc,ingress
-kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
-curl -fsS https://staging.token.place/livez
-curl -fsS https://staging.token.place/healthz
-curl -fsS https://staging.token.place/
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.staging.yaml --set image.tag=main-<shortsha> > /tmp/tokenplace-staging-render.yaml
+grep -n "tls:" -A8 /tmp/tokenplace-staging-render.yaml
+grep -n "staging.token.place" /tmp/tokenplace-staging-render.yaml
+grep -n "tokenplace-staging-tls" /tmp/tokenplace-staging-render.yaml
+grep -n "type: Recreate" /tmp/tokenplace-staging-render.yaml
+kubectl -n tokenplace get ingress tokenplace -o yaml
+curl -vI https://staging.token.place/
 ```
 
 ## Production promotion, deploy, and rollback
@@ -70,7 +74,7 @@ curl -fsS https://staging.token.place/
 Promote approved staging image tag:
 
 ```bash
-TOKENPLACE_TAG=main-deadbee # replace with the approved immutable tag
+TOKENPLACE_TAG=v0.1.0
 just tokenplace-oci-promote-prod tag="$TOKENPLACE_TAG"
 ```
 
@@ -101,11 +105,14 @@ just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKE
 Production validation:
 
 ```bash
-kubectl -n tokenplace get deploy,po,svc,ingress
-kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
-curl -fsS https://token.place/livez
-curl -fsS https://token.place/healthz
-curl -fsS https://token.place/
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.prod.yaml --set image.tag=v0.1.0 > /tmp/tokenplace-prod-render.yaml
+grep -n "tls:" -A8 /tmp/tokenplace-prod-render.yaml
+grep -n "token.place" /tmp/tokenplace-prod-render.yaml
+grep -n "tokenplace-prod-tls" /tmp/tokenplace-prod-render.yaml
+grep -n "type: Recreate" /tmp/tokenplace-prod-render.yaml
+kubectl -n tokenplace get ingress tokenplace -o yaml
+curl -vI https://token.place/
 ```
 
 ## Cloudflare tunnel guidance
@@ -116,6 +123,8 @@ Use the same DSPACE-style tunnel model:
   `http://traefik.kube-system.svc.cluster.local:80`.
 - Staging/prod tunnel and DNS routes are configured outside Helm.
 - The chart deploy does not create Cloudflare routes.
+- Staging/prod overlays render Ingress `spec.tls`; `ingress.tls.secretName` alone is not sufficient without `ingress.tls.enabled: true`.
+- cert-manager and the referenced ClusterIssuer are assumed to already exist.
 
 Helpful commands:
 

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -38,6 +38,16 @@ Default hosts:
 - Staging: `staging.token.place`
 - Production: `token.place`
 
+## 0.1.0 release alignment
+
+- Chart package version: `0.1.0`
+- Chart `appVersion`: `0.1.0`
+- token.place Git tag: `v0.1.0`
+- Release image tag: `v0.1.0` (`ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
+- Staging candidate image tag before final tagging: `main-<shortsha>`
+
+All launch versions remain aligned on `0.1.0`.
+
 ## Core deployment commands
 
 Use concrete release/namespace/chart values for token.place relay deployments.

--- a/docs/examples/tokenplace.values.prod.yaml
+++ b/docs/examples/tokenplace.values.prod.yaml
@@ -8,6 +8,7 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
   tls:
+    enabled: true
     secretName: tokenplace-prod-tls
 
 env:

--- a/docs/examples/tokenplace.values.staging.yaml
+++ b/docs/examples/tokenplace.values.staging.yaml
@@ -8,6 +8,7 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
   tls:
+    enabled: true
     secretName: tokenplace-staging-tls
 
 env:

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -8,7 +8,8 @@ Use this runbook for relay-only token.place production deployments on Sugarkube.
 - No in-cluster backend/GPU service is required.
 - Compute nodes remain external (`server.py`, Tauri desktop app, Windows PCs, Apple Silicon Macs,
   Raspberry Pi compute nodes, etc.).
-- Runtime model is single replica + single worker + in-memory state.
+- Runtime model is strict single replica + single Gunicorn worker + in-memory state.
+- Rollout strategy remains strict `strategy.type: Recreate`.
 - In-memory state loss on pod restart is accepted for now.
 
 ## Artifact and values contract
@@ -24,8 +25,10 @@ Use this runbook for relay-only token.place production deployments on Sugarkube.
 
 ## Promotion after staging sign-off
 
+After final token.place Git tag push, promote the release image tag `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`.
+
 ```bash
-TOKENPLACE_TAG=main-deadbee # replace with the approved immutable tag
+TOKENPLACE_TAG=v0.1.0
 just tokenplace-oci-promote-prod tag="$TOKENPLACE_TAG"
 ```
 
@@ -47,11 +50,15 @@ just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.i
 ## Validation
 
 ```bash
-kubectl -n tokenplace get deploy,po,svc,ingress
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.prod.yaml --set image.tag=v0.1.0 > /tmp/tokenplace-prod-render.yaml
+grep -n "tls:" -A8 /tmp/tokenplace-prod-render.yaml
+grep -n "token.place" /tmp/tokenplace-prod-render.yaml
+grep -n "tokenplace-prod-tls" /tmp/tokenplace-prod-render.yaml
+grep -n "type: Recreate" /tmp/tokenplace-prod-render.yaml
+kubectl -n tokenplace get ingress tokenplace -o yaml
 kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
-curl -fsS https://token.place/livez
-curl -fsS https://token.place/healthz
-curl -fsS https://token.place/
+curl -vI https://token.place/
 ```
 
 ## Rollback options
@@ -74,8 +81,7 @@ just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKE
 
 ## Cloudflare tunnel routing (external to Helm)
 
-Cloudflare routes are configured outside the chart. Route `token.place` to Traefik,
-typically `http://traefik.kube-system.svc.cluster.local:80`.
+Cloudflare Tunnel still owns public hostname routing. Helm does not manage Cloudflare routes. Route `token.place` to Traefik, typically `http://traefik.kube-system.svc.cluster.local:80`. Production values now render Kubernetes Ingress `spec.tls`, assuming cert-manager and a compatible ClusterIssuer already exist.
 
 ```bash
 just cf-tunnel-route host=token.place

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -8,7 +8,8 @@ Use this runbook for relay-only token.place staging deployments on Sugarkube.
 - No in-cluster backend/GPU service is required.
 - Compute nodes remain external (`server.py`, Tauri desktop app, Windows PCs, Apple Silicon Macs,
   Raspberry Pi compute nodes, etc.).
-- Runtime model is single replica + single worker + in-memory state.
+- Runtime model is strict single replica + single Gunicorn worker + in-memory state.
+- Rollout strategy remains strict `strategy.type: Recreate`.
 - In-memory state loss on pod restart is accepted for now.
 
 ## Artifact and values contract
@@ -21,11 +22,20 @@ Use this runbook for relay-only token.place staging deployments on Sugarkube.
 - Values: `docs/examples/tokenplace.values.dev.yaml` + `docs/examples/tokenplace.values.staging.yaml`
 - Default staging host: `staging.token.place`
 
+## Pre-flight checks (before Step 1)
+
+- Verify chart `0.1.0` exists only after token.place publishes the current chart release.
+- If `helm show chart ... --version 0.1.0` succeeds before final chart publish, treat it as potentially stale and confirm provenance before deploying.
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+```
+
 ## First install
 
 ```bash
 just kubeconfig-env staging
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
+TOKENPLACE_TAG=main-<shortsha> # use immutable staging candidate tag
 just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
 
@@ -47,11 +57,15 @@ just tokenplace-oci-deploy env=staging tag="$TOKENPLACE_TAG"
 ## Validation
 
 ```bash
-kubectl -n tokenplace get deploy,po,svc,ingress
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.staging.yaml --set image.tag=main-<shortsha> > /tmp/tokenplace-staging-render.yaml
+grep -n "tls:" -A8 /tmp/tokenplace-staging-render.yaml
+grep -n "staging.token.place" /tmp/tokenplace-staging-render.yaml
+grep -n "tokenplace-staging-tls" /tmp/tokenplace-staging-render.yaml
+grep -n "type: Recreate" /tmp/tokenplace-staging-render.yaml
+kubectl -n tokenplace get ingress tokenplace -o yaml
 kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
-curl -fsS https://staging.token.place/livez
-curl -fsS https://staging.token.place/healthz
-curl -fsS https://staging.token.place/
+curl -vI https://staging.token.place/
 ```
 
 ## Rollback
@@ -74,8 +88,7 @@ just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKE
 
 ## Cloudflare tunnel routing (external to Helm)
 
-Cloudflare routes are configured outside the chart. Route `staging.token.place` to Traefik,
-typically `http://traefik.kube-system.svc.cluster.local:80`.
+Cloudflare Tunnel still owns public hostname routing. Helm does not manage Cloudflare routes. Route `staging.token.place` to Traefik, typically `http://traefik.kube-system.svc.cluster.local:80`. Staging values now render Kubernetes Ingress `spec.tls`, assuming cert-manager and a compatible ClusterIssuer already exist.
 
 ```bash
 just cf-tunnel-route host=staging.token.place

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -34,6 +34,14 @@ Host defaults:
 - Staging: `staging.token.place`
 - Production: `token.place`
 
+## 0.1.0 release alignment
+
+- Helm chart package version: `0.1.0`
+- Helm chart `appVersion`: `0.1.0`
+- token.place Git tag: `v0.1.0`
+- Release image tag after tag push: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Staging candidate tag before final tagging: `main-<shortsha>`
+
 ## Environment runbooks
 
 - App overview: `docs/apps/tokenplace.md`
@@ -43,5 +51,4 @@ Host defaults:
 
 ## Cloudflare model
 
-Cloudflare tunnels/routes are managed outside Helm. Use route mappings from hostname to Traefik
-(typically `http://traefik.kube-system.svc.cluster.local:80`) before deploy/upgrade steps.
+Cloudflare Tunnel/DNS routes are managed outside Helm. Helm deploy/upgrade does not configure Cloudflare hostnames; map each hostname to Traefik (typically `http://traefik.kube-system.svc.cluster.local:80`) before deploy/upgrade steps. Staging/prod overlays now explicitly enable `ingress.tls.enabled: true` so Kubernetes Ingress `spec.tls` renders correctly with cert-manager and an existing ClusterIssuer.


### PR DESCRIPTION
### Motivation

- Ensure Sugarkube token.place staging/prod overlays actually render Kubernetes Ingress `spec.tls` (a `secretName` alone is insufficient) so TLS works when cert-manager/ClusterIssuer are present.
- Keep all launch identifiers pinned to `0.1.0` (chart, appVersion, Git tag, release image) and document the immutable staging candidate workflow (`main-<shortsha>`), without introducing `0.1.1` anywhere.
- Make runbooks explicit about Cloudflare Tunnel ownership (Cloudflare routes are external to Helm) and the intentional strict single-pod relay rollout behavior (`strategy.type: Recreate`, one replica, one Gunicorn worker, in-memory state).

### Description

- Enabled Ingress TLS rendering by adding `ingress.tls.enabled: true` to `docs/examples/tokenplace.values.staging.yaml` and `docs/examples/tokenplace.values.prod.yaml` while preserving `host`, `className`, cert-manager issuer annotation, and `secretName` (`tokenplace-staging-tls` / `tokenplace-prod-tls`).
- Updated staging and production runbooks (`docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`, `docs/apps/tokenplace-relay.md`, `docs/tokenplace_sugarkube_onboarding.md`, `docs/apps/tokenplace.md`) to add:
  - a pre-flight `helm show chart ... --version 0.1.0` freshness check, and `helm template` + grep/yq style render validation steps for `tls:`, host, secretName and `type: Recreate`; and `kubectl -n tokenplace get ingress tokenplace -o yaml` + `curl -vI` checks.
  - explicit wording that Cloudflare Tunnel/DNS routing is external to Helm and that cert-manager + ClusterIssuer are assumed.
  - explicit promotion guidance for the final release image `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0` and that staging candidates should use immutable `main-<shortsha>` tags.
  - clear statement that rollout behavior remains strict `strategy.type: Recreate` (single replica, single worker, in-memory state).
- Added a concise “0.1.0 release alignment” section to `docs/apps/tokenplace.md` and onboarding docs documenting chart version, `appVersion`, Git tag, release image tag, and staging candidate tag, and explicitly noting this change does not introduce `0.1.1`.
- Commit created with message: `Align token.place staging/prod TLS render and v0.1.0 runbooks` and updated files: `docs/examples/tokenplace.values.staging.yaml`, `docs/examples/tokenplace.values.prod.yaml`, `docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`, `docs/apps/tokenplace-relay.md`, `docs/apps/tokenplace.md`, `docs/tokenplace_sugarkube_onboarding.md`.

### Testing

- Verified the version pin file: `cat docs/apps/tokenplace.version` printed `0.1.0` (pass).
- Searched repo to confirm `0.1.1` was not introduced: `rg -n "0\.1\.1" . && exit 1 || true` (pass).
- Confirmed presence of required strings and TLS changes with ripgrep: `rg -n "tokenplace-(staging|prod)-tls|tls:|enabled: true|cert-manager.io/cluster-issuer|v0\.1\.0|0\.1\.0|main-<shortsha>|Recreate" docs/...` (pass).
- Attempted Helm chart visibility and template checks but could not run them in this environment because `helm` is not installed: `helm: command not found`; as a result `helm show chart` and `helm template` steps were not executed here (not-run due to environment limitation).
- Attempted to run repository linting hooks but `pre-commit` is not installed in this environment: `pre-commit: command not found` (not-run due to environment limitation).

Residual notes and verification guidance

- This PR intentionally does not introduce `0.1.1` and keeps all launch identifiers aligned at `0.1.0`.
- Before deploying, operators should run the added pre-flight and validation commands in an environment with `helm` and `pre-commit` available, specifically:
  - `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0`
  - `helm template ... --set image.tag=main-<shortsha> > /tmp/tokenplace-staging-render.yaml` and `grep -n "tls:" -A8 /tmp/tokenplace-staging-render.yaml` (staging)
  - `helm template ... --set image.tag=v0.1.0 > /tmp/tokenplace-prod-render.yaml` and `grep -n "tls:" -A8 /tmp/tokenplace-prod-render.yaml` (prod)
- All changes are scoped to token.place onboarding/runbooks/values and do not modify other apps or runtime behavior (no Redis/shared-state/multi-replica changes, no cert-manager installation steps, no Cloudflare connector changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1662e21320832faee674cc1b0eacf3)