### PR TITLE
docs(tokenplace): finalize v0.1.0 staging/prod TLS rendering and runbook alignment

### DIFF
--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -5,7 +5,7 @@ This guide documents the **relay-only** token.place deployment on Sugarkube.
 - Sugarkube runs only `relay.py`.
 - No in-cluster backend/GPU service is required.
 - Compute nodes remain external (`server.py`, Tauri desktop app, Windows/Apple Silicon/Raspberry Pi nodes, etc.).
-- Runtime is intentionally single replica, single worker, with in-memory state.
+- Runtime is intentionally single replica, single worker, with in-memory state and strict `strategy.type: Recreate`.
 - In-memory state loss on pod restart is accepted at this stage.
 
 For the broader app overview, see [`docs/apps/tokenplace.md`](./tokenplace.md).
@@ -57,6 +57,9 @@ just tokenplace-oci-deploy env=staging tag="$TOKENPLACE_TAG"
 
 ## Staging validation
 
+Use immutable staging tags (`main-<shortsha>`) for candidate validation before release tagging.
+
+
 ```bash
 kubectl -n tokenplace get deploy,po,svc,ingress
 kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
@@ -67,10 +70,10 @@ curl -fsS https://staging.token.place/
 
 ## Production promotion, deploy, and rollback
 
-Promote approved staging image tag:
+Promote approved staging image tag. For v0.1.0 final promotion after tag push, use `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0` (`TOKENPLACE_TAG=v0.1.0`):
 
 ```bash
-TOKENPLACE_TAG=main-deadbee # replace with the approved immutable tag
+TOKENPLACE_TAG=v0.1.0
 just tokenplace-oci-promote-prod tag="$TOKENPLACE_TAG"
 ```
 
@@ -78,7 +81,7 @@ Generic production upgrade with prod overlay:
 
 ```bash
 just kubeconfig-env prod
-TOKENPLACE_TAG=main-deadbee # replace with the approved immutable tag
+TOKENPLACE_TAG=v0.1.0
 just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
 
@@ -109,6 +112,8 @@ curl -fsS https://token.place/
 ```
 
 ## Cloudflare tunnel guidance
+
+Staging/prod overlays now render Kubernetes Ingress `spec.tls` and assume cert-manager plus a ClusterIssuer are pre-installed. TLS secret names alone are not sufficient without `ingress.tls.enabled: true`.
 
 Use the same DSPACE-style tunnel model:
 

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -13,7 +13,7 @@ Sugarkube currently runs **only** the token.place relay service (`relay.py`).
 - **Out-of-cluster compute:** `server.py`, desktop Tauri app, Windows PCs, Apple Silicon Macs,
   Raspberry Pi compute nodes, and other compute workers remain external.
 - **No in-cluster backend/GPU service** is required for steady-state relay operation.
-- **Single replica + single worker** defaults are intentional.
+- **Single replica + single worker** defaults are intentional, with strict `strategy.type: Recreate`.
 - Relay state is currently **in-memory only**; pod restarts lose relay memory/state and this is
   accepted for now.
 - Future in-memory database or multi-replica architecture is **out of scope** for this runbook.
@@ -26,6 +26,14 @@ Sugarkube currently runs **only** the token.place relay service (`relay.py`).
 - Namespace: `tokenplace`
 - Chart version pin file: `docs/apps/tokenplace.version`
 - Production approved tag pin: `docs/apps/tokenplace.prod.tag`
+
+## 0.1.0 release alignment
+
+- Chart package version: `0.1.0`
+- Chart `appVersion`: `0.1.0`
+- token.place Git tag: `v0.1.0`
+- Release image tag: `v0.1.0` (`ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
+- Staging candidate image tag before final tagging: `main-<shortsha>`
 
 ## Values model
 
@@ -74,6 +82,8 @@ curl -fsS https://staging.token.place/
 For production validation, use the same checks against `https://token.place`.
 
 ## Cloudflare and ingress model
+
+Staging/prod overlays render Kubernetes Ingress `spec.tls` (`ingress.tls.enabled: true`) and assume cert-manager plus a ClusterIssuer already exist. Helm manages Kubernetes resources only; Cloudflare public hostname routing remains external.
 
 Cloudflare Tunnel/DNS configuration is external to Helm.
 

--- a/docs/examples/tokenplace.values.prod.yaml
+++ b/docs/examples/tokenplace.values.prod.yaml
@@ -8,6 +8,7 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
   tls:
+    enabled: true
     secretName: tokenplace-prod-tls
 
 env:

--- a/docs/examples/tokenplace.values.staging.yaml
+++ b/docs/examples/tokenplace.values.staging.yaml
@@ -8,6 +8,7 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
   tls:
+    enabled: true
     secretName: tokenplace-staging-tls
 
 env:

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -8,7 +8,8 @@ Use this runbook for relay-only token.place production deployments on Sugarkube.
 - No in-cluster backend/GPU service is required.
 - Compute nodes remain external (`server.py`, Tauri desktop app, Windows PCs, Apple Silicon Macs,
   Raspberry Pi compute nodes, etc.).
-- Runtime model is single replica + single worker + in-memory state.
+- Runtime model is single replica + single Gunicorn worker + in-memory state.
+- Deployment strategy is strict `strategy.type: Recreate` (no overlapping old/new pods).
 - In-memory state loss on pod restart is accepted for now.
 
 ## Artifact and values contract
@@ -24,8 +25,14 @@ Use this runbook for relay-only token.place production deployments on Sugarkube.
 
 ## Promotion after staging sign-off
 
+Final production release promotion for v0.1.0 uses the semver image tag after Git tag push:
+
+```text
+ghcr.io/futuroptimist/tokenplace-relay:v0.1.0
+```
+
 ```bash
-TOKENPLACE_TAG=main-deadbee # replace with the approved immutable tag
+TOKENPLACE_TAG=v0.1.0
 just tokenplace-oci-promote-prod tag="$TOKENPLACE_TAG"
 ```
 
@@ -47,11 +54,16 @@ just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.i
 ## Validation
 
 ```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.prod.yaml --set image.tag=v0.1.0 > /tmp/tokenplace-prod-render.yaml
+grep -n "spec:" -A40 /tmp/tokenplace-prod-render.yaml | grep -n "tls"
+grep -n "token.place" /tmp/tokenplace-prod-render.yaml
+grep -n "tokenplace-prod-tls" /tmp/tokenplace-prod-render.yaml
+grep -n "type: Recreate" /tmp/tokenplace-prod-render.yaml
 kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace get ingress tokenplace -o yaml
 kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
-curl -fsS https://token.place/livez
-curl -fsS https://token.place/healthz
-curl -fsS https://token.place/
+curl -vI https://token.place/
 ```
 
 ## Rollback options
@@ -74,7 +86,7 @@ just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKE
 
 ## Cloudflare tunnel routing (external to Helm)
 
-Cloudflare routes are configured outside the chart. Route `token.place` to Traefik,
+Cloudflare routes are configured outside the chart. Helm does not manage Cloudflare hostname routes. Route `token.place` to Traefik,
 typically `http://traefik.kube-system.svc.cluster.local:80`.
 
 ```bash

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -8,7 +8,8 @@ Use this runbook for relay-only token.place staging deployments on Sugarkube.
 - No in-cluster backend/GPU service is required.
 - Compute nodes remain external (`server.py`, Tauri desktop app, Windows PCs, Apple Silicon Macs,
   Raspberry Pi compute nodes, etc.).
-- Runtime model is single replica + single worker + in-memory state.
+- Runtime model is single replica + single Gunicorn worker + in-memory state.
+- Deployment strategy is strict `strategy.type: Recreate` (no overlapping old/new pods).
 - In-memory state loss on pod restart is accepted for now.
 
 ## Artifact and values contract
@@ -20,6 +21,18 @@ Use this runbook for relay-only token.place staging deployments on Sugarkube.
 - Version pin file: `docs/apps/tokenplace.version`
 - Values: `docs/examples/tokenplace.values.dev.yaml` + `docs/examples/tokenplace.values.staging.yaml`
 - Default staging host: `staging.token.place`
+
+## Pre-flight (before Step 1)
+
+- `docs/apps/tokenplace.version` stays pinned to `0.1.0`.
+- Verify the OCI chart you intend to deploy is present and current:
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+```
+
+- Only proceed once token.place has published the current `0.1.0` chart artifact.
+- If the command above succeeds before final token.place chart publication, treat it as potentially stale and confirm provenance before deploying.
 
 ## First install
 
@@ -47,11 +60,16 @@ just tokenplace-oci-deploy env=staging tag="$TOKENPLACE_TAG"
 ## Validation
 
 ```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.staging.yaml --set image.tag=main-deadbee > /tmp/tokenplace-staging-render.yaml
+grep -n "spec:" -A40 /tmp/tokenplace-staging-render.yaml | grep -n "tls"
+grep -n "staging.token.place" /tmp/tokenplace-staging-render.yaml
+grep -n "tokenplace-staging-tls" /tmp/tokenplace-staging-render.yaml
+grep -n "type: Recreate" /tmp/tokenplace-staging-render.yaml
 kubectl -n tokenplace get deploy,po,svc,ingress
+kubectl -n tokenplace get ingress tokenplace -o yaml
 kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
-curl -fsS https://staging.token.place/livez
-curl -fsS https://staging.token.place/healthz
-curl -fsS https://staging.token.place/
+curl -vI https://staging.token.place/
 ```
 
 ## Rollback
@@ -74,7 +92,7 @@ just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKE
 
 ## Cloudflare tunnel routing (external to Helm)
 
-Cloudflare routes are configured outside the chart. Route `staging.token.place` to Traefik,
+Cloudflare routes are configured outside the chart. Helm does not manage Cloudflare hostname routes. Route `staging.token.place` to Traefik,
 typically `http://traefik.kube-system.svc.cluster.local:80`.
 
 ```bash

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -10,7 +10,7 @@ Current scope is **relay-only** on Sugarkube:
 - No in-cluster backend/GPU service is required.
 - Compute nodes remain external (`server.py`, desktop Tauri app, Windows PCs, Apple Silicon Macs,
   Raspberry Pi compute nodes, and other remote workers).
-- Runtime defaults are one replica and one worker with in-memory state.
+- Runtime defaults are one replica and one worker with in-memory state, using strict `strategy.type: Recreate`.
 - State loss on pod restart is currently accepted.
 - Future multi-replica / in-memory database architecture is out of scope for this runbook.
 
@@ -45,3 +45,12 @@ Host defaults:
 
 Cloudflare tunnels/routes are managed outside Helm. Use route mappings from hostname to Traefik
 (typically `http://traefik.kube-system.svc.cluster.local:80`) before deploy/upgrade steps.
+
+
+## 0.1.0 release alignment
+
+- Chart version: `0.1.0`
+- Chart appVersion: `0.1.0`
+- Git tag: `v0.1.0`
+- Release image tag: `v0.1.0`
+- Staging candidate tag: `main-<shortsha>`


### PR DESCRIPTION
### Motivation
- Ensure Sugarkube token.place overlays actually render Kubernetes Ingress `spec.tls` so TLS secret names are effective when the chart requires `ingress.tls.enabled: true`.
- Align runbooks and onboarding docs to the relay runtime that is strictly single-pod (one replica, one Gunicorn worker, in-memory state) and uses `strategy.type: Recreate` to match token.place behavior.
- Record the v0.1.0 release/promote story and staging candidate workflow while intentionally avoiding any introduction of `0.1.1` in the docs.

### Description
- Add `ingress.tls.enabled: true` to `docs/examples/tokenplace.values.staging.yaml` and `docs/examples/tokenplace.values.prod.yaml` while preserving `secretName` and `cert-manager.io/cluster-issuer` annotations so overlays render `spec.tls` (`tokenplace-staging-tls`, `tokenplace-prod-tls`).
- Update staging and production runbooks (`docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`, `docs/apps/tokenplace.md`, `docs/apps/tokenplace-relay.md`, `docs/tokenplace_sugarkube_onboarding.md`) to clarify that Cloudflare Tunnel/DNS routing is external to Helm, that Helm does not manage Cloudflare hostname routes, that cert-manager + ClusterIssuer are assumed present, and that TLS secretName alone is not sufficient without `ingress.tls.enabled: true`.
- Add pre-flight guidance and validation commands for staging/prod including `helm show chart ... --version 0.1.0`, `helm template` render checks, grep/yq checks for `spec.tls`, host, secretName and `type: Recreate`, `kubectl -n tokenplace get ingress tokenplace -o yaml`, and `curl -vI` checks for the public hosts.
- Add a compact “0.1.0 release alignment” section documenting chart version = `0.1.0`, chart `appVersion` = `0.1.0`, Git tag = `v0.1.0`, release image tag = `v0.1.0`, and staging candidate image tag = `main-<shortsha>`, and reinforce that no `0.1.1` was introduced.

### Testing
- `cat docs/apps/tokenplace.version` succeeded and shows `0.1.0`, confirming the version pin remains exactly `0.1.0`.
- Repository greps to confirm no `0.1.1` were found and that `tokenplace-(staging|prod)-tls`, `tls:`, `enabled: true`, `cert-manager.io/cluster-issuer`, `v0.1.0`, `main-<shortsha>`, and `Recreate` appear in the updated docs succeeded.
- Attempted `helm show chart` / `helm template` checks were included in the runbook text, but could not be executed here because `helm` is not installed in this execution environment (commands returned `helm: command not found`).
- `pre-commit run --all-files` could not be executed here because `pre-commit` is not installed in this container (returned `pre-commit: command not found`).

All launch versions remain `0.1.0` (this PR intentionally does not introduce `0.1.1`).

Before TLS values summary: staging/prod overlays set `ingress.tls.secretName` but did not enable TLS rendering (no `ingress.tls.enabled: true`).
After TLS values summary: staging/prod overlays include `ingress.tls.enabled: true` and preserve `secretName` as `tokenplace-staging-tls` / `tokenplace-prod-tls` and the `letsencrypt-production` issuer annotation.

Notes: `helm template` could not be run successfully in this environment due to missing `helm`; the runbooks include those commands for operator validation in a properly provisioned environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1662e21320832faee674cc1b0eacf3)