### PR TITLE
docs(tokenplace): align staging/prod TLS rendering and v0.1.0 promotion docs

### DIFF
--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -5,7 +5,7 @@ This guide documents the **relay-only** token.place deployment on Sugarkube.
 - Sugarkube runs only `relay.py`.
 - No in-cluster backend/GPU service is required.
 - Compute nodes remain external (`server.py`, Tauri desktop app, Windows/Apple Silicon/Raspberry Pi nodes, etc.).
-- Runtime is intentionally single replica, single worker, with in-memory state.
+- Runtime is intentionally one replica, one Gunicorn worker, in-memory state, and strict `strategy.type: Recreate`.
 - In-memory state loss on pod restart is accepted at this stage.
 
 For the broader app overview, see [`docs/apps/tokenplace.md`](./tokenplace.md).
@@ -67,7 +67,8 @@ curl -fsS https://staging.token.place/
 
 ## Production promotion, deploy, and rollback
 
-Promote approved staging image tag:
+Promote approved staging image tag. Final production promotion after token.place Git tag push should use `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`.
+
 
 ```bash
 TOKENPLACE_TAG=main-deadbee # replace with the approved immutable tag
@@ -116,6 +117,8 @@ Use the same DSPACE-style tunnel model:
   `http://traefik.kube-system.svc.cluster.local:80`.
 - Staging/prod tunnel and DNS routes are configured outside Helm.
 - The chart deploy does not create Cloudflare routes.
+- Staging/prod overlays set `ingress.tls.enabled: true` so rendered Kubernetes Ingress includes `spec.tls` (with `tokenplace-staging-tls` and `tokenplace-prod-tls`).
+- `cert-manager` and the referenced `ClusterIssuer` are assumed to already exist.
 
 Helpful commands:
 
@@ -148,3 +151,12 @@ just cluster-status
 just traefik-status
 just cf-tunnel-debug
 ```
+
+
+## 0.1.0 release alignment
+
+- Chart version: `0.1.0`
+- Chart `appVersion`: `0.1.0`
+- Git tag: `v0.1.0`
+- Release image tag: `v0.1.0`
+- Staging candidate image tag: `main-<shortsha>`

--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -5,7 +5,7 @@ This guide documents the **relay-only** token.place deployment on Sugarkube.
 - Sugarkube runs only `relay.py`.
 - No in-cluster backend/GPU service is required.
 - Compute nodes remain external (`server.py`, Tauri desktop app, Windows/Apple Silicon/Raspberry Pi nodes, etc.).
-- Runtime is intentionally one replica, one Gunicorn worker, in-memory state, and strict `strategy.type: Recreate`.
+- Runtime is intentionally one replica, one Gunicorn worker, and in-memory state; verify the rendered Kubernetes Deployment contract includes `spec.strategy.type: Recreate` before rollout.
 - In-memory state loss on pod restart is accepted at this stage.
 
 For the broader app overview, see [`docs/apps/tokenplace.md`](./tokenplace.md).
@@ -67,11 +67,11 @@ curl -fsS https://staging.token.place/
 
 ## Production promotion, deploy, and rollback
 
-Promote approved staging image tag. Final production promotion after token.place Git tag push should use `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`.
+Promote approved staging image tag. Final production promotion after token.place Git tag push should use tag `v0.1.0` (tag only; repository is already set in chart values).
 
 
 ```bash
-TOKENPLACE_TAG=main-deadbee # replace with the approved immutable tag
+TOKENPLACE_TAG=v0.1.0 # use final release tag after token.place Git tag push
 just tokenplace-oci-promote-prod tag="$TOKENPLACE_TAG"
 ```
 
@@ -79,7 +79,7 @@ Generic production upgrade with prod overlay:
 
 ```bash
 just kubeconfig-env prod
-TOKENPLACE_TAG=main-deadbee # replace with the approved immutable tag
+TOKENPLACE_TAG=v0.1.0 # use final release tag after token.place Git tag push
 just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
 

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -101,5 +101,5 @@ just cf-tunnel-route host=token.place
 - Chart version: `0.1.0`
 - Chart `appVersion`: `0.1.0`
 - Git tag: `v0.1.0`
-- Release image tag: `v0.1.0`
+- Release image tag: `v0.1.0` (`ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
 - Staging candidate image tag: `main-<shortsha>`

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -80,6 +80,8 @@ Cloudflare Tunnel/DNS configuration is external to Helm.
 - Route hostnames to Traefik, typically
   `http://traefik.kube-system.svc.cluster.local:80`.
 - Helm chart deployment does **not** create Cloudflare routes.
+- Staging/prod overlays set `ingress.tls.enabled: true` so rendered Kubernetes Ingress includes `spec.tls`.
+- `cert-manager` and a compatible `ClusterIssuer` are assumed to already exist.
 - Configure routes explicitly:
 
 ```bash
@@ -92,3 +94,12 @@ just cf-tunnel-route host=token.place
 - Relay-focused app guide: [`docs/apps/tokenplace-relay.md`](./tokenplace-relay.md)
 - Staging runbook: [`docs/k3s-tokenplace-staging.md`](../k3s-tokenplace-staging.md)
 - Production runbook: [`docs/k3s-tokenplace-prod.md`](../k3s-tokenplace-prod.md)
+
+
+## 0.1.0 release alignment
+
+- Chart version: `0.1.0`
+- Chart `appVersion`: `0.1.0`
+- Git tag: `v0.1.0`
+- Release image tag: `v0.1.0`
+- Staging candidate image tag: `main-<shortsha>`

--- a/docs/examples/tokenplace.values.prod.yaml
+++ b/docs/examples/tokenplace.values.prod.yaml
@@ -8,6 +8,7 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
   tls:
+    enabled: true
     secretName: tokenplace-prod-tls
 
 env:

--- a/docs/examples/tokenplace.values.staging.yaml
+++ b/docs/examples/tokenplace.values.staging.yaml
@@ -8,6 +8,7 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
   tls:
+    enabled: true
     secretName: tokenplace-staging-tls
 
 env:

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -8,7 +8,7 @@ Use this runbook for relay-only token.place production deployments on Sugarkube.
 - No in-cluster backend/GPU service is required.
 - Compute nodes remain external (`server.py`, Tauri desktop app, Windows PCs, Apple Silicon Macs,
   Raspberry Pi compute nodes, etc.).
-- Runtime model is single replica + single Gunicorn worker + in-memory state, deployed with strict `strategy.type: Recreate`.
+- Runtime model is single replica + single Gunicorn worker + in-memory state; verify the rendered Kubernetes Deployment contract includes `spec.strategy.type: Recreate` before rollout.
 - In-memory state loss on pod restart is accepted for now.
 
 ## Artifact and values contract
@@ -64,7 +64,7 @@ helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version
 grep -n "spec:" -A40 /tmp/tokenplace-prod-render.yaml | grep -n "tls"
 grep -n "token.place" /tmp/tokenplace-prod-render.yaml
 grep -n "tokenplace-prod-tls" /tmp/tokenplace-prod-render.yaml
-grep -n "type: Recreate" /tmp/tokenplace-prod-render.yaml
+yq eval '. | select(.kind == "Deployment" and .metadata.name == "tokenplace") | .spec.strategy.type' /tmp/tokenplace-prod-render.yaml
 ```
 
 Cluster/runtime checks:

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -8,7 +8,7 @@ Use this runbook for relay-only token.place production deployments on Sugarkube.
 - No in-cluster backend/GPU service is required.
 - Compute nodes remain external (`server.py`, Tauri desktop app, Windows PCs, Apple Silicon Macs,
   Raspberry Pi compute nodes, etc.).
-- Runtime model is single replica + single worker + in-memory state.
+- Runtime model is single replica + single Gunicorn worker + in-memory state, deployed with strict `strategy.type: Recreate`.
 - In-memory state loss on pod restart is accepted for now.
 
 ## Artifact and values contract
@@ -22,10 +22,20 @@ Use this runbook for relay-only token.place production deployments on Sugarkube.
 - Values: `docs/examples/tokenplace.values.dev.yaml` + `docs/examples/tokenplace.values.prod.yaml`
 - Default production host: `token.place`
 
+## Pre-flight (before Step 1)
+
+- Verify `docs/apps/tokenplace.version` remains pinned to `0.1.0`.
+- Verify the `0.1.0` OCI chart exists only after token.place publishes the current chart.
+- If `helm show chart ... --version 0.1.0` succeeds before the final token.place chart publish, confirm the chart is not stale before deploying.
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+```
+
 ## Promotion after staging sign-off
 
 ```bash
-TOKENPLACE_TAG=main-deadbee # replace with the approved immutable tag
+TOKENPLACE_TAG=v0.1.0 # use final release tag after token.place Git tag push
 just tokenplace-oci-promote-prod tag="$TOKENPLACE_TAG"
 ```
 
@@ -40,18 +50,32 @@ just kubeconfig-env prod
 Then run the generic OCI helper:
 
 ```bash
-TOKENPLACE_TAG=main-deadbee # replace with the approved immutable tag
+TOKENPLACE_TAG=v0.1.0 # use final release tag after token.place Git tag push
 just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
 
 ## Validation
 
+Render/contract checks:
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.prod.yaml --set image.tag=v0.1.0 > /tmp/tokenplace-prod-render.yaml
+grep -n "spec:" -A40 /tmp/tokenplace-prod-render.yaml | grep -n "tls"
+grep -n "token.place" /tmp/tokenplace-prod-render.yaml
+grep -n "tokenplace-prod-tls" /tmp/tokenplace-prod-render.yaml
+grep -n "type: Recreate" /tmp/tokenplace-prod-render.yaml
+```
+
+Cluster/runtime checks:
+
 ```bash
 kubectl -n tokenplace get deploy,po,svc,ingress
 kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+kubectl -n tokenplace get ingress tokenplace -o yaml
+curl -vI https://token.place/
 curl -fsS https://token.place/livez
 curl -fsS https://token.place/healthz
-curl -fsS https://token.place/
 ```
 
 ## Rollback options
@@ -74,7 +98,7 @@ just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKE
 
 ## Cloudflare tunnel routing (external to Helm)
 
-Cloudflare routes are configured outside the chart. Route `token.place` to Traefik,
+Cloudflare routes are configured outside the chart. Helm does not manage Cloudflare routes. Route `token.place` to Traefik,
 typically `http://traefik.kube-system.svc.cluster.local:80`.
 
 ```bash
@@ -104,3 +128,12 @@ just cluster-status
 just traefik-status
 just cf-tunnel-debug
 ```
+
+
+## 0.1.0 release alignment
+
+- OCI chart package version: `0.1.0`
+- Chart `appVersion`: `0.1.0`
+- token.place Git tag: `v0.1.0`
+- Release image tag after final tag push: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Staging candidate tag before final tag push: `main-<shortsha>`

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -98,8 +98,9 @@ just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKE
 
 ## Cloudflare tunnel routing (external to Helm)
 
-Cloudflare routes are configured outside the chart. Helm does not manage Cloudflare routes. Route `token.place` to Traefik,
-typically `http://traefik.kube-system.svc.cluster.local:80`.
+Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes. Route `token.place` to Traefik,
+typically `http://traefik.kube-system.svc.cluster.local:80`. Production overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
+and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
 
 ```bash
 just cf-tunnel-route host=token.place

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -99,8 +99,9 @@ just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKE
 
 ## Cloudflare tunnel routing (external to Helm)
 
-Cloudflare routes are configured outside the chart. Helm does not manage Cloudflare routes. Route `staging.token.place` to Traefik,
-typically `http://traefik.kube-system.svc.cluster.local:80`.
+Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes. Route `staging.token.place` to Traefik,
+typically `http://traefik.kube-system.svc.cluster.local:80`. Staging overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
+and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
 
 ```bash
 just cf-tunnel-route host=staging.token.place

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -8,7 +8,7 @@ Use this runbook for relay-only token.place staging deployments on Sugarkube.
 - No in-cluster backend/GPU service is required.
 - Compute nodes remain external (`server.py`, Tauri desktop app, Windows PCs, Apple Silicon Macs,
   Raspberry Pi compute nodes, etc.).
-- Runtime model is single replica + single Gunicorn worker + in-memory state, deployed with strict `strategy.type: Recreate`.
+- Runtime model is single replica + single Gunicorn worker + in-memory state; verify the rendered Kubernetes Deployment contract includes `spec.strategy.type: Recreate` before rollout.
 - In-memory state loss on pod restart is accepted for now.
 
 ## Artifact and values contract
@@ -65,7 +65,7 @@ helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version
 grep -n "spec:" -A40 /tmp/tokenplace-staging-render.yaml | grep -n "tls"
 grep -n "staging.token.place" /tmp/tokenplace-staging-render.yaml
 grep -n "tokenplace-staging-tls" /tmp/tokenplace-staging-render.yaml
-grep -n "type: Recreate" /tmp/tokenplace-staging-render.yaml
+yq eval '. | select(.kind == "Deployment" and .metadata.name == "tokenplace") | .spec.strategy.type' /tmp/tokenplace-staging-render.yaml
 ```
 
 Cluster/runtime checks:

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -8,7 +8,7 @@ Use this runbook for relay-only token.place staging deployments on Sugarkube.
 - No in-cluster backend/GPU service is required.
 - Compute nodes remain external (`server.py`, Tauri desktop app, Windows PCs, Apple Silicon Macs,
   Raspberry Pi compute nodes, etc.).
-- Runtime model is single replica + single worker + in-memory state.
+- Runtime model is single replica + single Gunicorn worker + in-memory state, deployed with strict `strategy.type: Recreate`.
 - In-memory state loss on pod restart is accepted for now.
 
 ## Artifact and values contract
@@ -20,6 +20,17 @@ Use this runbook for relay-only token.place staging deployments on Sugarkube.
 - Version pin file: `docs/apps/tokenplace.version`
 - Values: `docs/examples/tokenplace.values.dev.yaml` + `docs/examples/tokenplace.values.staging.yaml`
 - Default staging host: `staging.token.place`
+
+
+## Pre-flight (before Step 1)
+
+- Verify `docs/apps/tokenplace.version` remains pinned to `0.1.0`.
+- Verify the `0.1.0` OCI chart exists only after token.place publishes the current chart.
+- If `helm show chart ... --version 0.1.0` succeeds before the final token.place chart publish, confirm the chart is not stale before deploying.
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+```
 
 ## First install
 
@@ -46,12 +57,26 @@ just tokenplace-oci-deploy env=staging tag="$TOKENPLACE_TAG"
 
 ## Validation
 
+Render/contract checks (use immutable staging candidate tag):
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.staging.yaml --set image.tag=main-deadbee > /tmp/tokenplace-staging-render.yaml
+grep -n "spec:" -A40 /tmp/tokenplace-staging-render.yaml | grep -n "tls"
+grep -n "staging.token.place" /tmp/tokenplace-staging-render.yaml
+grep -n "tokenplace-staging-tls" /tmp/tokenplace-staging-render.yaml
+grep -n "type: Recreate" /tmp/tokenplace-staging-render.yaml
+```
+
+Cluster/runtime checks:
+
 ```bash
 kubectl -n tokenplace get deploy,po,svc,ingress
 kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+kubectl -n tokenplace get ingress tokenplace -o yaml
+curl -vI https://staging.token.place/
 curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
-curl -fsS https://staging.token.place/
 ```
 
 ## Rollback
@@ -74,9 +99,18 @@ just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKE
 
 ## Cloudflare tunnel routing (external to Helm)
 
-Cloudflare routes are configured outside the chart. Route `staging.token.place` to Traefik,
+Cloudflare routes are configured outside the chart. Helm does not manage Cloudflare routes. Route `staging.token.place` to Traefik,
 typically `http://traefik.kube-system.svc.cluster.local:80`.
 
 ```bash
 just cf-tunnel-route host=staging.token.place
 ```
+
+
+## 0.1.0 release alignment
+
+- OCI chart package version: `0.1.0`
+- Chart `appVersion`: `0.1.0`
+- token.place Git tag: `v0.1.0`
+- Release image tag after final tag push: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Staging candidate tag before final tag push: `main-<shortsha>`

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -10,7 +10,7 @@ Current scope is **relay-only** on Sugarkube:
 - No in-cluster backend/GPU service is required.
 - Compute nodes remain external (`server.py`, desktop Tauri app, Windows PCs, Apple Silicon Macs,
   Raspberry Pi compute nodes, and other remote workers).
-- Runtime defaults are one replica, one Gunicorn worker, in-memory state, and strict `strategy.type: Recreate`.
+- Runtime defaults are one replica, one Gunicorn worker, and in-memory state; validate the rendered Kubernetes Deployment contract for `spec.strategy.type: Recreate` before rollout.
 - State loss on pod restart is currently accepted.
 - Future multi-replica / in-memory database architecture is out of scope for this runbook.
 

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -41,6 +41,16 @@ Host defaults:
 - Staging runbook: `docs/k3s-tokenplace-staging.md`
 - Production runbook: `docs/k3s-tokenplace-prod.md`
 
+
+## 0.1.0 release alignment
+
+- Chart version: `0.1.0`
+- Chart `appVersion`: `0.1.0`
+- token.place Git tag: `v0.1.0`
+- Release image tag: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
+- Staging candidate image tag: `main-<shortsha>`
+- This PR intentionally does not introduce `0.1.1`.
+
 ## Cloudflare model
 
 Cloudflare tunnels/routes are managed outside Helm, and Helm does not manage Cloudflare hostname routing. Use route mappings from hostname to Traefik

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -10,7 +10,7 @@ Current scope is **relay-only** on Sugarkube:
 - No in-cluster backend/GPU service is required.
 - Compute nodes remain external (`server.py`, desktop Tauri app, Windows PCs, Apple Silicon Macs,
   Raspberry Pi compute nodes, and other remote workers).
-- Runtime defaults are one replica and one worker with in-memory state.
+- Runtime defaults are one replica, one Gunicorn worker, in-memory state, and strict `strategy.type: Recreate`.
 - State loss on pod restart is currently accepted.
 - Future multi-replica / in-memory database architecture is out of scope for this runbook.
 
@@ -43,5 +43,5 @@ Host defaults:
 
 ## Cloudflare model
 
-Cloudflare tunnels/routes are managed outside Helm. Use route mappings from hostname to Traefik
+Cloudflare tunnels/routes are managed outside Helm, and Helm does not manage Cloudflare hostname routing. Use route mappings from hostname to Traefik
 (typically `http://traefik.kube-system.svc.cluster.local:80`) before deploy/upgrade steps.


### PR DESCRIPTION
### Motivation
- Ensure staging/prod overlays render a Kubernetes Ingress `spec.tls` (a `secretName` alone is insufficient when the chart requires `ingress.tls.enabled: true`).
- Make runbooks explicit about the relay runtime remaining single-pod, single-worker, in-memory state with strict `strategy.type: Recreate` so operators do not attempt multi-replica changes prematurely.
- Document the v0.1.0 launch alignment (chart version, `appVersion`, Git tag and image tag) and add pre-flight/validation guidance while intentionally avoiding any `0.1.1` introduction.

### Description
- Added `ingress.tls.enabled: true` to `docs/examples/tokenplace.values.staging.yaml` and `docs/examples/tokenplace.values.prod.yaml` while keeping `secretName` values as `tokenplace-staging-tls` and `tokenplace-prod-tls` respectively.
- Updated staging and production runbooks and token.place docs (`docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`, `docs/apps/tokenplace.md`, `docs/apps/tokenplace-relay.md`, `docs/tokenplace_sugarkube_onboarding.md`) to state that Cloudflare Tunnel/DNS routing is external to Helm, cert-manager/ClusterIssuer are assumed present, and rendered overlays will include `spec.tls`.
- Added pre-flight steps and render/contract validation commands including `helm show chart`, `helm template`, and grep/yq-style checks for `spec.tls`, host, `secretName`, and `type: Recreate`, plus `kubectl -n tokenplace get ingress tokenplace -o yaml` and `curl -vI` checks for the hostnames.
- Inserted a compact “0.1.0 release alignment” section documenting chart version `0.1.0`, `appVersion` `0.1.0`, Git tag `v0.1.0`, release image tag `v0.1.0`, and staging candidate tag pattern `main-<shortsha>`, and left `docs/apps/tokenplace.version` pinned at `0.1.0` (no `0.1.1` added).

### Testing
- Verified `docs/apps/tokenplace.version` content with `cat docs/apps/tokenplace.version` and confirmed it remains `0.1.0`.
- Scanned the repo for accidental `0.1.1` introductions with `rg -n "0\.1\.1" .` and confirmed none were added, and validated presence of TLS/Recreate/version strings via `rg` checks against the updated docs files.
- Attempted Helm-based render checks (`helm show chart` / `helm template`) but they were not executed because `helm` is not available in this environment (`helm: command not found`), so template/render validation should be run by operators in an environment with `helm` installed.
- Attempted repository-wide checks with `pre-commit run --all-files` but the tool is not installed in this environment (`pre-commit: command not found`), so CI or a local pre-commit run is recommended prior to merge.

All launch versions remain `0.1.0` in this PR and this change intentionally does not introduce `0.1.1`.

Files touched: `docs/examples/tokenplace.values.staging.yaml`, `docs/examples/tokenplace.values.prod.yaml`, `docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`, `docs/apps/tokenplace.md`, `docs/apps/tokenplace-relay.md`, `docs/tokenplace_sugarkube_onboarding.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1662e21320832faee674cc1b0eacf3)