### PR TITLE
Align Sugarkube token.place values/wrappers with chart-owned env defaults

### DIFF
--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -61,6 +61,10 @@ TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
 just tokenplace-oci-deploy env=staging tag="$TOKENPLACE_TAG"
 ```
 
+> [!WARNING]
+> If you used one-off Helm `--set` overrides for XDG runtime paths during early staging recovery, remove them now.
+> The hardened chart defaults own those values, and duplicate manual overrides can reintroduce duplicate `env` warnings at render/deploy time.
+
 ## Validation commands
 
 ```bash

--- a/docs/examples/tokenplace.values.dev.yaml
+++ b/docs/examples/tokenplace.values.dev.yaml
@@ -10,7 +10,3 @@ ingress:
   className: traefik
   annotations: {}
 
-env:
-  RELAY_WORKERS: "1"
-  TOKENPLACE_FRONTEND_MODE: production
-  TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH: "0"

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -65,6 +65,45 @@ grep -n "spec:" -A40 /tmp/tokenplace-prod-render.yaml | grep -n "tls"
 grep -n "token.place" /tmp/tokenplace-prod-render.yaml
 grep -n "tokenplace-prod-tls" /tmp/tokenplace-prod-render.yaml
 yq eval '. | select(.kind == "Deployment" and .metadata.name == "tokenplace") | .spec.strategy.type' /tmp/tokenplace-prod-render.yaml
+python3 - <<'PY'
+import collections
+import sys
+
+render_path = "/tmp/tokenplace-prod-render.yaml"
+env_names = []
+in_deployment = False
+in_first_container = False
+in_env = False
+for raw_line in open(render_path, encoding="utf-8"):
+    line = raw_line.rstrip("\n")
+    stripped = line.strip()
+    if stripped.startswith("---"):
+        in_deployment = False
+        in_first_container = False
+        in_env = False
+        continue
+    if stripped == "kind: Deployment":
+        in_deployment = True
+        continue
+    if not in_deployment:
+        continue
+    if stripped == "containers:":
+        in_first_container = True
+        continue
+    if in_first_container and stripped == "env:":
+        in_env = True
+        continue
+    if in_env and stripped.startswith("- name: "):
+        env_names.append(stripped.split(": ", 1)[1])
+        continue
+    if in_env and stripped and not stripped.startswith("-") and not stripped.startswith("name:"):
+        in_env = False
+
+dupes = [name for name, count in collections.Counter(env_names).items() if count > 1]
+if dupes:
+    sys.exit(f"duplicate env names found: {dupes}")
+print("no duplicate env names")
+PY
 ```
 
 Cluster/runtime checks:

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -66,6 +66,45 @@ grep -n "spec:" -A40 /tmp/tokenplace-staging-render.yaml | grep -n "tls"
 grep -n "staging.token.place" /tmp/tokenplace-staging-render.yaml
 grep -n "tokenplace-staging-tls" /tmp/tokenplace-staging-render.yaml
 yq eval '. | select(.kind == "Deployment" and .metadata.name == "tokenplace") | .spec.strategy.type' /tmp/tokenplace-staging-render.yaml
+python3 - <<'PY'
+import collections
+import sys
+
+render_path = "/tmp/tokenplace-staging-render.yaml"
+env_names = []
+in_deployment = False
+in_first_container = False
+in_env = False
+for raw_line in open(render_path, encoding="utf-8"):
+    line = raw_line.rstrip("\n")
+    stripped = line.strip()
+    if stripped.startswith("---"):
+        in_deployment = False
+        in_first_container = False
+        in_env = False
+        continue
+    if stripped == "kind: Deployment":
+        in_deployment = True
+        continue
+    if not in_deployment:
+        continue
+    if stripped == "containers:":
+        in_first_container = True
+        continue
+    if in_first_container and stripped == "env:":
+        in_env = True
+        continue
+    if in_env and stripped.startswith("- name: "):
+        env_names.append(stripped.split(": ", 1)[1])
+        continue
+    if in_env and stripped and not stripped.startswith("-") and not stripped.startswith("name:"):
+        in_env = False
+
+dupes = [name for name, count in collections.Counter(env_names).items() if count > 1]
+if dupes:
+    sys.exit(f"duplicate env names found: {dupes}")
+print("no duplicate env names")
+PY
 ```
 
 Cluster/runtime checks:
@@ -78,6 +117,11 @@ curl -vI https://staging.token.place/
 curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
 ```
+
+## Staging override cleanup note
+
+During initial staging validation we used manual Helm `--set` overrides for XDG runtime paths under a read-only root filesystem.
+Now that chart defaults own those paths, remove any manual XDG `--set` overrides from local scripts/shell history and deploy with only the checked-in values overlays.
 
 ## Rollback
 

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -34,6 +34,11 @@ Host defaults:
 - Staging: `staging.token.place`
 - Production: `token.place`
 
+## Override hygiene
+
+Do not carry forward temporary/manual Helm `--set` overrides used during initial staging incident response (for example XDG path overrides for read-only root filesystems).
+Keep deployments values-driven via the checked-in overlays so render checks can catch accidental duplicate `env` names before rollout.
+
 ## Environment runbooks
 
 - App overview: `docs/apps/tokenplace.md`

--- a/justfile
+++ b/justfile
@@ -1770,6 +1770,9 @@ tokenplace-oci-deploy env='staging' tag='':
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
 
+    resolved_chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.version | head -n1 | tr -d '[:space:]')"
+    echo "Deploying token.place chart=oci://ghcr.io/futuroptimist/charts/tokenplace version=${resolved_chart_version} image=ghcr.io/futuroptimist/tokenplace-relay:${resolved_tag} env=${env_name} values=${values_chain}"
+
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='tokenplace' namespace='tokenplace' \
       chart='oci://ghcr.io/futuroptimist/charts/tokenplace' \


### PR DESCRIPTION
### Motivation
- Staging produced Kubernetes duplicate `env` warnings and required a temporary manual Helm `--set` XDG override to get the relay pod Ready under a read-only root filesystem. 
- The token.place chart now owns those runtime/XDG and worker/frontend defaults, so Sugarkube should stop re-defining chart-owned envs and instead rely on hardened chart defaults. 

### Description
- Removed chart-owned env overrides from the Sugarkube base values file by deleting the `env:` block (no more `RELAY_WORKERS`, `TOKENPLACE_FRONTEND_MODE`, `TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH`) in `docs/examples/tokenplace.values.dev.yaml`. 
- Added duplicate-`env` render-time validation snippets to both staging and prod runbooks (`docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`) so `helm template` + a quick Python check will fail-fast on duplicate env names. 
- Added cleanup/warning docs encouraging removal of temporary/manual Helm `--set` XDG overrides in `docs/apps/tokenplace.md` and `docs/tokenplace_sugarkube_onboarding.md` and a short staging note in `docs/k3s-tokenplace-staging.md`. 
- Improved the `tokenplace-oci-deploy` wrapper output in the `justfile` to echo resolved chart/version/image tag/env/values chain before running the OCI Helm install/upgrade so rendered provenance is clear. 

### Testing
- Verified `cat docs/apps/tokenplace.version` returned the pinned chart version (`0.1.0`).
- Attempted the required render/verification commands including `helm template ...` and the duplicate-env Python check, but `helm` is not installed in this environment so template renders could not be produced. 
- The repository-level checks `pre-commit run --all-files` was not runnable here because `pre-commit` is not installed in the execution container. 
- Changes were committed locally (`git commit`) with message "Align tokenplace values/docs with chart-owned env defaults" and include the edits described above; functional verification requiring `helm`/`yq`/`pre-commit` should be run in a CI or developer environment with those tools available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c990823c832f8ea1ec9b9c510822)