### PR TITLE
Align token.place Sugarkube values and wrappers with hardened chart defaults

### DIFF
--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -33,6 +33,9 @@ Sugarkube currently runs **only** the token.place relay service (`relay.py`).
 - Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
 - Production overlay: `docs/examples/tokenplace.values.prod.yaml`
 
+
+Rely on hardened chart-owned runtime env defaults (`RELAY_WORKERS`, `TOKENPLACE_FRONTEND_MODE`, `TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH`, and XDG paths for read-only root filesystems) from the token.place chart instead of re-declaring them in Sugarkube values overlays. Keep only environment-specific overrides such as `TOKEN_PLACE_ENV` and `TOKENPLACE_RELAY_PUBLIC_URL`.
+
 Default hosts:
 
 - Staging: `staging.token.place`
@@ -53,6 +56,9 @@ just kubeconfig-env staging
 TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
 just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
+
+
+> ⚠️ If you used manual Helm `--set env.XDG_*=/tmp` overrides during initial staging troubleshooting, remove them after pulling these repo updates; chart defaults now own those values.
 
 Preferred env wrapper:
 

--- a/docs/examples/tokenplace.values.dev.yaml
+++ b/docs/examples/tokenplace.values.dev.yaml
@@ -10,7 +10,3 @@ ingress:
   className: traefik
   annotations: {}
 
-env:
-  RELAY_WORKERS: "1"
-  TOKENPLACE_FRONTEND_MODE: production
-  TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH: "0"

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -64,6 +64,15 @@ helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version
 grep -n "spec:" -A40 /tmp/tokenplace-prod-render.yaml | grep -n "tls"
 grep -n "token.place" /tmp/tokenplace-prod-render.yaml
 grep -n "tokenplace-prod-tls" /tmp/tokenplace-prod-render.yaml
+python3 - <<'PY'
+import collections, yaml
+docs = list(yaml.safe_load_all(open("/tmp/tokenplace-prod-render.yaml")))
+deploy = next(d for d in docs if d and d.get("kind") == "Deployment")
+env = deploy["spec"]["template"]["spec"]["containers"][0].get("env", [])
+names = [item["name"] for item in env]
+dupes = [name for name, count in collections.Counter(names).items() if count > 1]
+assert not dupes, dupes
+PY
 yq eval '. | select(.kind == "Deployment" and .metadata.name == "tokenplace") | .spec.strategy.type' /tmp/tokenplace-prod-render.yaml
 ```
 

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -48,6 +48,9 @@ TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
 just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
 ```
 
+
+> ⚠️ During initial staging bring-up we temporarily used manual Helm `--set env.XDG_CONFIG_HOME=/tmp --set env.XDG_CACHE_HOME=/tmp --set env.XDG_DATA_HOME=/tmp` overrides to get the pod Ready on read-only root filesystems. Remove those manual overrides now that chart defaults manage XDG paths and other runtime env defaults.
+
 Preferred wrapper:
 
 ```bash
@@ -65,6 +68,15 @@ helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version
 grep -n "spec:" -A40 /tmp/tokenplace-staging-render.yaml | grep -n "tls"
 grep -n "staging.token.place" /tmp/tokenplace-staging-render.yaml
 grep -n "tokenplace-staging-tls" /tmp/tokenplace-staging-render.yaml
+python3 - <<'PY'
+import collections, yaml
+docs = list(yaml.safe_load_all(open("/tmp/tokenplace-staging-render.yaml")))
+deploy = next(d for d in docs if d and d.get("kind") == "Deployment")
+env = deploy["spec"]["template"]["spec"]["containers"][0].get("env", [])
+names = [item["name"] for item in env]
+dupes = [name for name, count in collections.Counter(names).items() if count > 1]
+assert not dupes, dupes
+PY
 yq eval '. | select(.kind == "Deployment" and .metadata.name == "tokenplace") | .spec.strategy.type' /tmp/tokenplace-staging-render.yaml
 ```
 

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -29,6 +29,9 @@ Current scope is **relay-only** on Sugarkube:
 - Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
 - Production overlay: `docs/examples/tokenplace.values.prod.yaml`
 
+
+Chart-owned runtime env defaults (worker count, frontend mode, relay upstream-health behavior, and XDG temp paths for read-only-root compatibility) should stay in the token.place chart. Sugarkube values should only carry environment-specific overlays like hostname, TLS, `TOKEN_PLACE_ENV`, and `TOKENPLACE_RELAY_PUBLIC_URL`.
+
 Host defaults:
 
 - Staging: `staging.token.place`

--- a/justfile
+++ b/justfile
@@ -1770,9 +1770,15 @@ tokenplace-oci-deploy env='staging' tag='':
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
 
+    chart_ref='oci://ghcr.io/futuroptimist/charts/tokenplace'
+    chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.version | head -n1 | tr -d '[:space:]')"
+    image_repo="$(yq eval -r ' .image.repository ' docs/examples/tokenplace.values.dev.yaml)"
+
+    echo "Deploying token.place chart=${chart_ref} version=${chart_version} tag=${resolved_tag} values=${values_chain}"
+
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='tokenplace' namespace='tokenplace' \
-      chart='oci://ghcr.io/futuroptimist/charts/tokenplace' \
+      chart="${chart_ref}" \
       values="${values_chain}" \
       version_file='docs/apps/tokenplace.version' \
       tag="${resolved_tag}"
@@ -1781,7 +1787,7 @@ tokenplace-oci-deploy env='staging' tag='':
     export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
 
     echo
-    echo "Resolved images for deployment/tokenplace:"
+    echo "Resolved image(s) for deployment/tokenplace (expected ${image_repo}:${resolved_tag}):"
     kubectl -n tokenplace get deploy/tokenplace -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"="}{.image}{"\n"}{end}' || true
 
     ingress_host="$(kubectl -n tokenplace get ingress -o jsonpath='{.items[0].spec.rules[0].host}' 2>/dev/null || true)"


### PR DESCRIPTION
### Motivation
- Staging showed duplicate `env` warnings and required temporary manual `--set env.XDG_*=/tmp` overrides to get the relay pod Ready on read-only-root systems. 
- The token.place chart now owns hardened runtime defaults (worker count, frontend mode, upstream-health behavior, and XDG paths), so Sugarkube should stop re-declaring those values. 

### Description
- Removed chart-owned env keys from `docs/examples/tokenplace.values.dev.yaml`: `RELAY_WORKERS`, `TOKENPLACE_FRONTEND_MODE`, and `TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH`. 
- Preserved Sugarkube-owned, environment-specific overlays such as `TOKEN_PLACE_ENV`, `TOKENPLACE_RELAY_PUBLIC_URL`, ingress host, and TLS secret settings (`tokenplace-staging-tls`, `tokenplace-prod-tls`). 
- Added manifest validation snippets to staging and prod runbooks that assert no duplicate env names via a Python check, and added doc warnings instructing operators to remove the initial manual `env.XDG_*=/tmp` Helm overrides now that the chart owns XDG defaults. 
- Improved `tokenplace-oci-deploy` wrapper output in `justfile` to echo the chart ref, resolved chart version, image repository, values chain, and the expected image tag before/after deploy checks for clearer rollout visibility. 

### Testing
- `cat docs/apps/tokenplace.version` — succeeded and shows pinned `0.1.0`. 
- `helm template ... -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.staging.yaml --set image.tag=main-deadbee > /tmp/tokenplace-staging-render.yaml` — attempted but failed here because `helm` is not installed in this runner. 
- Python duplicate-env assertion against the rendered YAML (`python3 - <<'PY' ...`) — attempted but failed in this runner due to missing `PyYAML` (`ModuleNotFoundError: No module named 'yaml'`). 
- `pre-commit run --all-files` — attempted but not run in this environment because `pre-commit` is not installed. 

Notes: the repo now contains explicit duplicate-env validation steps and operator guidance in the runbooks; full verification (helm render + Python check + `pre-commit`) should be executed in a fully provisioned Sugarkube/dev environment to confirm the `helm template` render contains no duplicate env names and that staging/prod acceptance criteria hold.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c990823c832f8ea1ec9b9c510822)