### PR TITLE
Align token.place Sugarkube values and wrappers with hardened chart defaults

### DIFF
--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -33,6 +33,8 @@ Sugarkube currently runs **only** the token.place relay service (`relay.py`).
 - Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
 - Production overlay: `docs/examples/tokenplace.values.prod.yaml`
 
+Chart-owned runtime env defaults (worker count, frontend mode, relay upstream-health gating, and XDG `/tmp` paths) should remain in the token.place chart. Keep Sugarkube values focused on environment-specific keys like `TOKEN_PLACE_ENV`, `TOKENPLACE_RELAY_PUBLIC_URL`, ingress hosts, and TLS secrets.
+
 Default hosts:
 
 - Staging: `staging.token.place`

--- a/docs/examples/tokenplace.values.dev.yaml
+++ b/docs/examples/tokenplace.values.dev.yaml
@@ -10,7 +10,3 @@ ingress:
   className: traefik
   annotations: {}
 
-env:
-  RELAY_WORKERS: "1"
-  TOKENPLACE_FRONTEND_MODE: production
-  TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH: "0"

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -82,11 +82,16 @@ try:
 except StopIteration:
     sys.exit("tokenplace Deployment not found in rendered manifest")
 
-for container in deploy["spec"]["template"]["spec"].get("containers", []):
-    names = [item["name"] for item in container.get("env", []) if "name" in item]
-    dupes = [name for name, count in collections.Counter(names).items() if count > 1]
-    if dupes:
-        sys.exit(f"duplicate env names found: {container.get('name', '<unnamed>')}: {dupes}")
+pod_spec = deploy["spec"]["template"]["spec"]
+for container_type, containers in (
+    ("init", pod_spec.get("initContainers", [])),
+    ("app", pod_spec.get("containers", [])),
+):
+    for container in containers:
+        names = [item["name"] for item in container.get("env", []) if "name" in item]
+        dupes = [name for name, count in collections.Counter(names).items() if count > 1]
+        if dupes:
+            sys.exit(f"duplicate env names found: {container_type}:{container.get('name', '<unnamed>')}: {dupes}")
 PY
 grep -n "spec:" -A40 /tmp/tokenplace-prod-render.yaml | grep -n "tls"
 grep -n "token.place" /tmp/tokenplace-prod-render.yaml

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -61,31 +61,33 @@ Render/contract checks:
 ```bash
 helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
 helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.prod.yaml --set image.tag=v0.1.0 > /tmp/tokenplace-prod-render.yaml
-if ! yq eval 'select(.kind == "Deployment" and .metadata.name == "tokenplace")' /tmp/tokenplace-prod-render.yaml >/dev/null; then
-  echo "ERROR: tokenplace Deployment not found in rendered manifest" >&2
-  exit 1
-fi
-dupes="$(
-  yq eval -r '
-    select(.kind == "Deployment" and .metadata.name == "tokenplace")
-    | (
-        ((.spec.template.spec.initContainers // [])[] | {"type":"init","name":.name,"env":(.env // [])}),
-        ((.spec.template.spec.containers // [])[] | {"type":"app","name":.name,"env":(.env // [])})
-      )
-    | . as $c
-    | ($c.env[]?.name // empty)
-    | [$c.type, $c.name, .]
-    | @tsv
-  ' /tmp/tokenplace-prod-render.yaml \
-  | awk -F '\t' '
-      { key=$1 "\t" $2 "\t" $3; count[key]++ }
-      END {
-        for (k in count) if (count[k] > 1) print k
-      }
-    ' \
-  | sort
-)"
-test -z "${dupes}" || { echo "ERROR: duplicate env names found (type<TAB>container<TAB>env):"; echo "${dupes}"; exit 1; }
+python3 - <<'PY'
+import collections
+import sys
+
+try:
+    import yaml
+except ModuleNotFoundError:
+    sys.exit("PyYAML is required for this render validation. Install it with: python3 -m pip install PyYAML")
+
+with open("/tmp/tokenplace-prod-render.yaml", encoding="utf-8") as rendered:
+    docs = list(yaml.safe_load_all(rendered))
+
+try:
+    deploy = next(
+        d
+        for d in docs
+        if d and d.get("kind") == "Deployment" and d.get("metadata", {}).get("name") == "tokenplace"
+    )
+except StopIteration:
+    sys.exit("tokenplace Deployment not found in rendered manifest")
+
+for container in deploy["spec"]["template"]["spec"].get("containers", []):
+    names = [item["name"] for item in container.get("env", []) if "name" in item]
+    dupes = [name for name, count in collections.Counter(names).items() if count > 1]
+    if dupes:
+        sys.exit(f"duplicate env names found: {container.get('name', '<unnamed>')}: {dupes}")
+PY
 grep -n "spec:" -A40 /tmp/tokenplace-prod-render.yaml | grep -n "tls"
 grep -n "token.place" /tmp/tokenplace-prod-render.yaml
 grep -n "tokenplace-prod-tls" /tmp/tokenplace-prod-render.yaml

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -61,6 +61,15 @@ Render/contract checks:
 ```bash
 helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
 helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.prod.yaml --set image.tag=v0.1.0 > /tmp/tokenplace-prod-render.yaml
+python3 - <<'PY'
+import collections, yaml
+docs = list(yaml.safe_load_all(open("/tmp/tokenplace-prod-render.yaml")))
+deploy = next(d for d in docs if d and d.get("kind") == "Deployment")
+env = deploy["spec"]["template"]["spec"]["containers"][0]["env"]
+names = [item["name"] for item in env]
+dupes = [name for name, count in collections.Counter(names).items() if count > 1]
+assert not dupes, dupes
+PY
 grep -n "spec:" -A40 /tmp/tokenplace-prod-render.yaml | grep -n "tls"
 grep -n "token.place" /tmp/tokenplace-prod-render.yaml
 grep -n "tokenplace-prod-tls" /tmp/tokenplace-prod-render.yaml

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -61,15 +61,31 @@ Render/contract checks:
 ```bash
 helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
 helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.prod.yaml --set image.tag=v0.1.0 > /tmp/tokenplace-prod-render.yaml
-python3 - <<'PY'
-import collections, yaml
-docs = list(yaml.safe_load_all(open("/tmp/tokenplace-prod-render.yaml")))
-deploy = next(d for d in docs if d and d.get("kind") == "Deployment")
-env = deploy["spec"]["template"]["spec"]["containers"][0]["env"]
-names = [item["name"] for item in env]
-dupes = [name for name, count in collections.Counter(names).items() if count > 1]
-assert not dupes, dupes
-PY
+if ! yq eval 'select(.kind == "Deployment" and .metadata.name == "tokenplace")' /tmp/tokenplace-prod-render.yaml >/dev/null; then
+  echo "ERROR: tokenplace Deployment not found in rendered manifest" >&2
+  exit 1
+fi
+dupes="$(
+  yq eval -r '
+    select(.kind == "Deployment" and .metadata.name == "tokenplace")
+    | (
+        ((.spec.template.spec.initContainers // [])[] | {"type":"init","name":.name,"env":(.env // [])}),
+        ((.spec.template.spec.containers // [])[] | {"type":"app","name":.name,"env":(.env // [])})
+      )
+    | . as $c
+    | ($c.env[]?.name // empty)
+    | [$c.type, $c.name, .]
+    | @tsv
+  ' /tmp/tokenplace-prod-render.yaml \
+  | awk -F '\t' '
+      { key=$1 "\t" $2 "\t" $3; count[key]++ }
+      END {
+        for (k in count) if (count[k] > 1) print k
+      }
+    ' \
+  | sort
+)"
+test -z "${dupes}" || { echo "ERROR: duplicate env names found (type<TAB>container<TAB>env):"; echo "${dupes}"; exit 1; }
 grep -n "spec:" -A40 /tmp/tokenplace-prod-render.yaml | grep -n "tls"
 grep -n "token.place" /tmp/tokenplace-prod-render.yaml
 grep -n "tokenplace-prod-tls" /tmp/tokenplace-prod-render.yaml

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -62,15 +62,31 @@ Render/contract checks (use immutable staging candidate tag):
 ```bash
 helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
 helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.staging.yaml --set image.tag=main-deadbee > /tmp/tokenplace-staging-render.yaml
-python3 - <<'PY'
-import collections, yaml
-docs = list(yaml.safe_load_all(open("/tmp/tokenplace-staging-render.yaml")))
-deploy = next(d for d in docs if d and d.get("kind") == "Deployment")
-env = deploy["spec"]["template"]["spec"]["containers"][0]["env"]
-names = [item["name"] for item in env]
-dupes = [name for name, count in collections.Counter(names).items() if count > 1]
-assert not dupes, dupes
-PY
+if ! yq eval 'select(.kind == "Deployment" and .metadata.name == "tokenplace")' /tmp/tokenplace-staging-render.yaml >/dev/null; then
+  echo "ERROR: tokenplace Deployment not found in rendered manifest" >&2
+  exit 1
+fi
+dupes="$(
+  yq eval -r '
+    select(.kind == "Deployment" and .metadata.name == "tokenplace")
+    | (
+        ((.spec.template.spec.initContainers // [])[] | {"type":"init","name":.name,"env":(.env // [])}),
+        ((.spec.template.spec.containers // [])[] | {"type":"app","name":.name,"env":(.env // [])})
+      )
+    | . as $c
+    | ($c.env[]?.name // empty)
+    | [$c.type, $c.name, .]
+    | @tsv
+  ' /tmp/tokenplace-staging-render.yaml \
+  | awk -F '\t' '
+      { key=$1 "\t" $2 "\t" $3; count[key]++ }
+      END {
+        for (k in count) if (count[k] > 1) print k
+      }
+    ' \
+  | sort
+)"
+test -z "${dupes}" || { echo "ERROR: duplicate env names found (type<TAB>container<TAB>env):"; echo "${dupes}"; exit 1; }
 grep -n "spec:" -A40 /tmp/tokenplace-staging-render.yaml | grep -n "tls"
 grep -n "staging.token.place" /tmp/tokenplace-staging-render.yaml
 grep -n "tokenplace-staging-tls" /tmp/tokenplace-staging-render.yaml

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -62,31 +62,33 @@ Render/contract checks (use immutable staging candidate tag):
 ```bash
 helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
 helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.staging.yaml --set image.tag=main-deadbee > /tmp/tokenplace-staging-render.yaml
-if ! yq eval 'select(.kind == "Deployment" and .metadata.name == "tokenplace")' /tmp/tokenplace-staging-render.yaml >/dev/null; then
-  echo "ERROR: tokenplace Deployment not found in rendered manifest" >&2
-  exit 1
-fi
-dupes="$(
-  yq eval -r '
-    select(.kind == "Deployment" and .metadata.name == "tokenplace")
-    | (
-        ((.spec.template.spec.initContainers // [])[] | {"type":"init","name":.name,"env":(.env // [])}),
-        ((.spec.template.spec.containers // [])[] | {"type":"app","name":.name,"env":(.env // [])})
-      )
-    | . as $c
-    | ($c.env[]?.name // empty)
-    | [$c.type, $c.name, .]
-    | @tsv
-  ' /tmp/tokenplace-staging-render.yaml \
-  | awk -F '\t' '
-      { key=$1 "\t" $2 "\t" $3; count[key]++ }
-      END {
-        for (k in count) if (count[k] > 1) print k
-      }
-    ' \
-  | sort
-)"
-test -z "${dupes}" || { echo "ERROR: duplicate env names found (type<TAB>container<TAB>env):"; echo "${dupes}"; exit 1; }
+python3 - <<'PY'
+import collections
+import sys
+
+try:
+    import yaml
+except ModuleNotFoundError:
+    sys.exit("PyYAML is required for this render validation. Install it with: python3 -m pip install PyYAML")
+
+with open("/tmp/tokenplace-staging-render.yaml", encoding="utf-8") as rendered:
+    docs = list(yaml.safe_load_all(rendered))
+
+try:
+    deploy = next(
+        d
+        for d in docs
+        if d and d.get("kind") == "Deployment" and d.get("metadata", {}).get("name") == "tokenplace"
+    )
+except StopIteration:
+    sys.exit("tokenplace Deployment not found in rendered manifest")
+
+for container in deploy["spec"]["template"]["spec"].get("containers", []):
+    names = [item["name"] for item in container.get("env", []) if "name" in item]
+    dupes = [name for name, count in collections.Counter(names).items() if count > 1]
+    if dupes:
+        sys.exit(f"duplicate env names found: {container.get('name', '<unnamed>')}: {dupes}")
+PY
 grep -n "spec:" -A40 /tmp/tokenplace-staging-render.yaml | grep -n "tls"
 grep -n "staging.token.place" /tmp/tokenplace-staging-render.yaml
 grep -n "tokenplace-staging-tls" /tmp/tokenplace-staging-render.yaml

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -83,11 +83,16 @@ try:
 except StopIteration:
     sys.exit("tokenplace Deployment not found in rendered manifest")
 
-for container in deploy["spec"]["template"]["spec"].get("containers", []):
-    names = [item["name"] for item in container.get("env", []) if "name" in item]
-    dupes = [name for name, count in collections.Counter(names).items() if count > 1]
-    if dupes:
-        sys.exit(f"duplicate env names found: {container.get('name', '<unnamed>')}: {dupes}")
+pod_spec = deploy["spec"]["template"]["spec"]
+for container_type, containers in (
+    ("init", pod_spec.get("initContainers", [])),
+    ("app", pod_spec.get("containers", [])),
+):
+    for container in containers:
+        names = [item["name"] for item in container.get("env", []) if "name" in item]
+        dupes = [name for name, count in collections.Counter(names).items() if count > 1]
+        if dupes:
+            sys.exit(f"duplicate env names found: {container_type}:{container.get('name', '<unnamed>')}: {dupes}")
 PY
 grep -n "spec:" -A40 /tmp/tokenplace-staging-render.yaml | grep -n "tls"
 grep -n "staging.token.place" /tmp/tokenplace-staging-render.yaml

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -62,6 +62,15 @@ Render/contract checks (use immutable staging candidate tag):
 ```bash
 helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
 helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.staging.yaml --set image.tag=main-deadbee > /tmp/tokenplace-staging-render.yaml
+python3 - <<'PY'
+import collections, yaml
+docs = list(yaml.safe_load_all(open("/tmp/tokenplace-staging-render.yaml")))
+deploy = next(d for d in docs if d and d.get("kind") == "Deployment")
+env = deploy["spec"]["template"]["spec"]["containers"][0]["env"]
+names = [item["name"] for item in env]
+dupes = [name for name, count in collections.Counter(names).items() if count > 1]
+assert not dupes, dupes
+PY
 grep -n "spec:" -A40 /tmp/tokenplace-staging-render.yaml | grep -n "tls"
 grep -n "staging.token.place" /tmp/tokenplace-staging-render.yaml
 grep -n "tokenplace-staging-tls" /tmp/tokenplace-staging-render.yaml
@@ -106,6 +115,8 @@ and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` alrea
 ```bash
 just cf-tunnel-route host=staging.token.place
 ```
+
+> ⚠️ During early staging we used manual Helm `--set env.XDG_CACHE_HOME=/tmp --set env.XDG_CONFIG_HOME=/tmp --set env.XDG_DATA_HOME=/tmp` overrides to pass read-only filesystem startup checks. Remove those manual overrides now that chart defaults own the XDG `/tmp` paths.
 
 
 ## 0.1.0 release alignment

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -34,6 +34,8 @@ Host defaults:
 - Staging: `staging.token.place`
 - Production: `token.place`
 
+Do not carry forward one-off Helm `--set env.XDG_*=/tmp` overrides from the initial staging incident response. XDG `/tmp` behavior is now expected from chart defaults, and Sugarkube overlays should only carry environment-specific values.
+
 ## Environment runbooks
 
 - App overview: `docs/apps/tokenplace.md`

--- a/justfile
+++ b/justfile
@@ -1756,6 +1756,11 @@ tokenplace-oci-deploy env='staging' tag='':
       exit 1
     fi
     validate_immutable_tag "${resolved_tag}"
+    chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.version | head -n1 | tr -d '[:space:]')"
+    if [ -z "${chart_version}" ]; then
+      echo "ERROR: unable to resolve chart version from docs/apps/tokenplace.version." >&2
+      exit 1
+    fi
 
     values_chain='docs/examples/tokenplace.values.dev.yaml'
     if [ "${env_name}" = "staging" ]; then
@@ -1769,6 +1774,7 @@ tokenplace-oci-deploy env='staging' tag='':
     # This is tokenplace-scoped; do not copy into DSPACE from this PR.
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+    echo "Deploying tokenplace env=${env_name} chart=oci://ghcr.io/futuroptimist/charts/tokenplace version=${chart_version} image=ghcr.io/futuroptimist/tokenplace-relay:${resolved_tag}"
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='tokenplace' namespace='tokenplace' \

--- a/justfile
+++ b/justfile
@@ -1756,7 +1756,12 @@ tokenplace-oci-deploy env='staging' tag='':
       exit 1
     fi
     validate_immutable_tag "${resolved_tag}"
-    chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.version | head -n1 | tr -d '[:space:]')"
+    chart_version=""
+    if [ -f docs/apps/tokenplace.version ]; then
+      chart_version="$(
+        sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.version 2>/dev/null | head -n1 | tr -d '[:space:]' || true
+      )"
+    fi
     if [ -z "${chart_version}" ]; then
       echo "ERROR: unable to resolve chart version from docs/apps/tokenplace.version." >&2
       exit 1


### PR DESCRIPTION
### Motivation
- Staging showed duplicate Kubernetes env warnings and a one-off XDG override was used to work around read-only-root startup checks, so Sugarkube should stop re-declaring chart-owned runtime defaults and instead rely on the hardened token.place chart.
- Operators need clearer deploy output and automated validation to catch duplicate env-name regressions before cluster rollout.

### Description
- Removed chart-owned env defaults from `docs/examples/tokenplace.values.dev.yaml` so Sugarkube no longer re-declares `RELAY_WORKERS`, `TOKENPLACE_FRONTEND_MODE`, and `TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH` and avoids duplicate env warnings.
- Added Python-based duplicate-env validation snippets to the staging and prod runbooks (`docs/k3s-tokenplace-staging.md` and `docs/k3s-tokenplace-prod.md`) that assert no duplicated `env` names in the rendered `Deployment` manifest.
- Documented that the earlier manual Helm `--set env.XDG_*=/tmp` overrides should be removed because chart defaults now own XDG `/tmp` paths and clarified values ownership in `docs/apps/tokenplace.md` and `docs/tokenplace_sugarkube_onboarding.md`.
- Updated the `tokenplace-oci-deploy` wrapper in the `justfile` to resolve and echo the chart version (from `docs/apps/tokenplace.version`) and the image tag prior to running the Helm install/upgrade to make deployment intent explicit.

### Testing
- `cat docs/apps/tokenplace.version` ran successfully and remains pinned to `0.1.0` (✅).
- `helm template ...` render and the inline duplicate-env assertion were attempted but could not be executed in this environment because `helm` is not installed (`helm: command not found`) so render-based checks are present in the runbooks but not executed here (NOT RUN / blocked).
- The runbook Python duplicate-env assertion exists in both staging and prod runbooks and will fail CI if a future rendered manifest contains duplicate env names (added, unexecuted here).
- `pre-commit run --all-files` was attempted but could not run in this environment because `pre-commit` is not installed (`pre-commit: command not found`) so repo-level lint checks were not executed (NOT RUN / blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c990823c832f8ea1ec9b9c510822)