### PR TITLE
Align token.place Sugarkube values/wrappers with hardened chart defaults

### DIFF
--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -32,6 +32,8 @@ Sugarkube currently runs **only** the token.place relay service (`relay.py`).
 - Base: `docs/examples/tokenplace.values.dev.yaml`
 - Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
 - Production overlay: `docs/examples/tokenplace.values.prod.yaml`
+- Keep chart-owned runtime env defaults (for example worker/frontend/relay health and XDG `/tmp` paths) in the
+  token.place chart; Sugarkube values should only carry environment-specific overrides to avoid duplicate env warnings.
 
 Default hosts:
 

--- a/docs/examples/tokenplace.values.dev.yaml
+++ b/docs/examples/tokenplace.values.dev.yaml
@@ -11,6 +11,3 @@ ingress:
   annotations: {}
 
 env:
-  RELAY_WORKERS: "1"
-  TOKENPLACE_FRONTEND_MODE: production
-  TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH: "0"

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -61,11 +61,23 @@ Render/contract checks:
 ```bash
 helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
 helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.prod.yaml --set image.tag=v0.1.0 > /tmp/tokenplace-prod-render.yaml
+python3 - <<'PY'
+import collections, yaml
+docs = list(yaml.safe_load_all(open("/tmp/tokenplace-prod-render.yaml")))
+deploy = next(d for d in docs if d and d.get("kind") == "Deployment")
+env = deploy["spec"]["template"]["spec"]["containers"][0]["env"]
+names = [item["name"] for item in env]
+dupes = [name for name, count in collections.Counter(names).items() if count > 1]
+assert not dupes, dupes
+PY
 grep -n "spec:" -A40 /tmp/tokenplace-prod-render.yaml | grep -n "tls"
 grep -n "token.place" /tmp/tokenplace-prod-render.yaml
 grep -n "tokenplace-prod-tls" /tmp/tokenplace-prod-render.yaml
 yq eval '. | select(.kind == "Deployment" and .metadata.name == "tokenplace") | .spec.strategy.type' /tmp/tokenplace-prod-render.yaml
 ```
+
+Do **not** carry forward manual `--set env.XDG_CACHE_HOME=/tmp --set env.XDG_CONFIG_HOME=/tmp --set env.XDG_DATA_HOME=/tmp`
+overrides used during early staging debugging once Prompt 1 chart defaults are live; keep XDG runtime paths chart-owned.
 
 Cluster/runtime checks:
 

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -62,11 +62,24 @@ Render/contract checks (use immutable staging candidate tag):
 ```bash
 helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
 helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.staging.yaml --set image.tag=main-deadbee > /tmp/tokenplace-staging-render.yaml
+python3 - <<'PY'
+import collections, yaml
+docs = list(yaml.safe_load_all(open("/tmp/tokenplace-staging-render.yaml")))
+deploy = next(d for d in docs if d and d.get("kind") == "Deployment")
+env = deploy["spec"]["template"]["spec"]["containers"][0]["env"]
+names = [item["name"] for item in env]
+dupes = [name for name, count in collections.Counter(names).items() if count > 1]
+assert not dupes, dupes
+PY
 grep -n "spec:" -A40 /tmp/tokenplace-staging-render.yaml | grep -n "tls"
 grep -n "staging.token.place" /tmp/tokenplace-staging-render.yaml
 grep -n "tokenplace-staging-tls" /tmp/tokenplace-staging-render.yaml
 yq eval '. | select(.kind == "Deployment" and .metadata.name == "tokenplace") | .spec.strategy.type' /tmp/tokenplace-staging-render.yaml
 ```
+
+Do **not** keep manual `--set env.XDG_CACHE_HOME=/tmp --set env.XDG_CONFIG_HOME=/tmp --set env.XDG_DATA_HOME=/tmp`
+overrides from early staging bring-up once Prompt 1 chart defaults are published; these are now chart-managed
+runtime defaults and duplicate manual overrides can mask future chart drift.
 
 Cluster/runtime checks:
 

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -28,6 +28,8 @@ Current scope is **relay-only** on Sugarkube:
 - Base defaults: `docs/examples/tokenplace.values.dev.yaml`
 - Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
 - Production overlay: `docs/examples/tokenplace.values.prod.yaml`
+- The chart owns hardened runtime defaults (including XDG `/tmp` paths for read-only-root compatibility); avoid manual
+  Helm `--set env.XDG_*` overrides after Prompt 1 lands.
 
 Host defaults:
 

--- a/justfile
+++ b/justfile
@@ -1756,6 +1756,12 @@ tokenplace-oci-deploy env='staging' tag='':
       exit 1
     fi
     validate_immutable_tag "${resolved_tag}"
+    chart_ref='oci://ghcr.io/futuroptimist/charts/tokenplace'
+    chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.version | head -n1 | tr -d '[:space:]')"
+    if [ -z "${chart_version}" ]; then
+      echo "ERROR: docs/apps/tokenplace.version is empty." >&2
+      exit 1
+    fi
 
     values_chain='docs/examples/tokenplace.values.dev.yaml'
     if [ "${env_name}" = "staging" ]; then
@@ -1769,10 +1775,12 @@ tokenplace-oci-deploy env='staging' tag='':
     # This is tokenplace-scoped; do not copy into DSPACE from this PR.
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+    echo "Deploying tokenplace chart=${chart_ref} version=${chart_version} tag=${resolved_tag} env=${env_name}"
+    echo "Values files: ${values_chain}"
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='tokenplace' namespace='tokenplace' \
-      chart='oci://ghcr.io/futuroptimist/charts/tokenplace' \
+      chart="${chart_ref}" \
       values="${values_chain}" \
       version_file='docs/apps/tokenplace.version' \
       tag="${resolved_tag}"


### PR DESCRIPTION
### Motivation
- Staging showed duplicate environment-variable rendering warnings and required temporary manual `XDG_*=/tmp` Helm overrides before the chart provided hardened defaults, so Sugarkube should stop re-declaring chart-owned runtime envs and surface guidance to avoid masking chart drift.
- Keep Sugarkube overlays focused on environment-specific values (host, TLS, TOKEN_PLACE_ENV, public URL, image tag) while letting the token.place chart own runtime defaults such as read-only-root XDG paths and worker/frontend/relay health flags.

### Description
- Removed chart-owned env entries from `docs/examples/tokenplace.values.dev.yaml` (removed `RELAY_WORKERS`, `TOKENPLACE_FRONTEND_MODE`, and `TOKENPLACE_RELAY_REQUIRE_UPSTREAM_HEALTH`).
- Added an automated duplicate-env assertion (Python `collections.Counter` check against the `helm template` render) into the staging and prod runbook validation steps (`docs/k3s-tokenplace-staging.md` and `docs/k3s-tokenplace-prod.md`).
- Added explicit documentation warnings in runbooks/docs (`docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`, `docs/apps/tokenplace.md`, `docs/tokenplace_sugarkube_onboarding.md`) telling operators to remove historical manual `--set env.XDG_*=/tmp` overrides once the chart defaults land.
- Improved the tokenplace OCI deploy wrapper (`just tokenplace-oci-deploy` in `justfile`) to echo the resolved chart reference, chart version (read from `docs/apps/tokenplace.version`), image tag, environment and values chain before running the Helm helper, and to fail early if `docs/apps/tokenplace.version` is empty.

### Testing
- `cat docs/apps/tokenplace.version` — ran successfully and shows `0.1.0`.
- `helm template ... -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.staging.yaml --set image.tag=main-deadbee > /tmp/tokenplace-staging-render.yaml` — not run to completion here because `helm` is not installed in this environment (`/bin/bash: line 1: helm: command not found`).
- Duplicate-env manifest assertion (the added Python snippet that inspects `/tmp/tokenplace-*-render.yaml`) — not runnable here because the `helm template` render step could not be executed.
- `grep`/`yq` checks described in the runbooks (verify `spec.strategy.type: Recreate`, staging/prod hosts and TLS secrets) — blocked until `helm template` produces the render file in a HA environment with `helm` available.
- `pre-commit run --all-files` — not run because `pre-commit` is not installed in this environment (`/bin/bash: line 1: pre-commit: command not found`).

Follow-ups / notes: Run the verification commands in an environment with `helm` and `pre-commit` installed (example commands are included in the updated runbooks). After the token.place chart publishes the hardened defaults (Prompt 1), the manual `--set env.XDG_*` overrides used during early staging should be removed from local deploy wrappers or CI to avoid duplicate env names in rendered manifests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c990823c832f8ea1ec9b9c510822)