### PR TITLE
Add non-Flux cert-manager + Cloudflare DNS-01 recipes and runbook guidance

### DIFF
--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -353,3 +353,65 @@ for temporary local development. See
 - After apex promotion, `prod.democratized.space` can be converted to a redirect to
   `https://democratized.space`.
 - The Sugarkube dspace app expects this persistent tunnel setup to be in place.
+
+## cert-manager DNS-01 (non-Flux clusters)
+
+If your cluster does **not** run Flux, `kubectl apply -k platform/cert-manager` will create some
+resources and then fail on `HelmRelease` because the `helm.toolkit.fluxcd.io` API is absent.
+Use Sugarkube Just recipes instead:
+
+```bash
+just cert-manager-install
+just cert-manager-cloudflare-token-secret token="$CF_DNS_API_TOKEN"
+just cert-manager-issuers-apply email="ops@example.com"
+just cert-manager-status
+```
+
+### Important token distinction
+
+- `CF_TUNNEL_TOKEN` is for the Cloudflare Tunnel connector (`cloudflared`).
+- `CF_DNS_API_TOKEN` is for cert-manager DNS-01 validation against Cloudflare DNS.
+
+Do **not** swap them. The tunnel token cannot solve ACME DNS challenges.
+
+### Required Cloudflare DNS API token permissions
+
+For DNS-01 to work reliably (including cleanup), create a token with:
+
+- **Zone → DNS → Edit**
+- **Zone → Zone → Read**
+- Zone resources: include the specific zone for `token.place`
+- If you issue certificates for `democratized.space` from the same cluster, include that zone too
+
+Without `Zone:Read`, cert-manager may create challenge records but fail zone lookup/cleanup.
+
+### Troubleshooting quick checks
+
+```bash
+# CRDs exist
+kubectl get crd | grep cert-manager.io
+
+# ClusterIssuer type available
+kubectl api-resources | grep -i clusterissuer
+
+# Issuers Ready=True
+kubectl get clusterissuer letsencrypt-staging letsencrypt-production
+
+# cert-manager certificates and secrets
+kubectl get certificate -A
+kubectl -n cert-manager get secret cloudflare-api-token
+
+# cert-manager logs
+kubectl -n cert-manager logs deploy/cert-manager --tail=200
+```
+
+Common failure modes:
+
+- `no matches for kind "HelmRelease"` when applying `platform/cert-manager`: Flux is not installed.
+  Use `just cert-manager-install` instead.
+- `no matches for kind "ClusterIssuer"`: cert-manager CRDs were not installed (`installCRDs=true` missing).
+- ACME `invalidContact` with literal `$(CERT_MANAGER_EMAIL)`: placeholders were applied literally.
+  Reapply with `just cert-manager-issuers-apply email="you@example.com"`.
+- `secret "cloudflare-api-token" not found`: create it with
+  `just cert-manager-cloudflare-token-secret token="$CF_DNS_API_TOKEN"`.
+- Challenge cleanup errors after issuance: usually missing `Zone:Read` permission on the DNS API token.

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -24,6 +24,15 @@ Use this runbook for relay-only token.place production deployments on Sugarkube.
 
 ## Pre-flight (before Step 1)
 
+- For non-Flux clusters, install cert-manager/issuers first:
+
+```bash
+just cert-manager-install
+just cert-manager-cloudflare-token-secret token="$CF_DNS_API_TOKEN"
+just cert-manager-issuers-apply email="ops@example.com"
+just cert-manager-status
+```
+
 - Verify `docs/apps/tokenplace.version` remains pinned to `0.1.0`.
 - Verify the `0.1.0` OCI chart exists only after token.place publishes the current chart.
 - If `helm show chart ... --version 0.1.0` succeeds before the final token.place chart publish, confirm the chart is not stale before deploying.

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -24,6 +24,15 @@ Use this runbook for relay-only token.place staging deployments on Sugarkube.
 
 ## Pre-flight (before Step 1)
 
+- For non-Flux clusters, install cert-manager/issuers first:
+
+```bash
+just cert-manager-install
+just cert-manager-cloudflare-token-secret token="$CF_DNS_API_TOKEN"
+just cert-manager-issuers-apply email="ops@example.com"
+just cert-manager-status
+```
+
 - Verify `docs/apps/tokenplace.version` remains pinned to `0.1.0`.
 - Verify the `0.1.0` OCI chart exists only after token.place publishes the current chart.
 - If `helm show chart ... --version 0.1.0` succeeds before the final token.place chart publish, confirm the chart is not stale before deploying.

--- a/justfile
+++ b/justfile
@@ -736,6 +736,87 @@ cf-tunnel-debug:
         echo "No Cloudflare Tunnel pods to show logs for."
     fi
 
+
+
+# Install cert-manager directly with Helm for non-Flux clusters.
+cert-manager-install version='v1.14.4':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+
+    helm repo add jetstack https://charts.jetstack.io --force-update
+    helm repo update jetstack
+
+    kubectl get namespace cert-manager >/dev/null 2>&1 || kubectl create namespace cert-manager
+
+    helm upgrade --install cert-manager jetstack/cert-manager       --namespace cert-manager       --create-namespace       --version "{{ version }}"       --set installCRDs=true       --set global.leaderElection.namespace=cert-manager
+
+    kubectl -n cert-manager rollout status deploy/cert-manager --timeout=180s
+    kubectl -n cert-manager rollout status deploy/cert-manager-cainjector --timeout=180s
+    kubectl -n cert-manager rollout status deploy/cert-manager-webhook --timeout=180s
+
+# Show cert-manager and ClusterIssuer readiness for non-Flux clusters.
+cert-manager-status:
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+
+    echo "=== cert-manager components ==="
+    kubectl -n cert-manager get deploy,po
+
+    echo
+    echo "=== cert-manager CRDs ==="
+    kubectl get crd | grep 'cert-manager.io' || true
+
+    echo
+    echo "=== ClusterIssuers ==="
+    kubectl get clusterissuer || true
+
+    echo
+    echo "=== Certificates (all namespaces) ==="
+    kubectl get certificate -A || true
+
+    echo
+    echo "=== cloudflare-api-token Secret (cert-manager namespace) ==="
+    kubectl -n cert-manager get secret cloudflare-api-token || true
+
+# Create or rotate the Cloudflare DNS API token Secret used by ClusterIssuers.
+cert-manager-cloudflare-token-secret token='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+
+    : "${token:=${CF_DNS_API_TOKEN:-}}"
+    if [ -z "${token}" ]; then
+      echo "Set CF_DNS_API_TOKEN or pass token=<cloudflare-dns-api-token>." >&2
+      exit 1
+    fi
+
+    kubectl get namespace cert-manager >/dev/null 2>&1 || kubectl create namespace cert-manager
+
+    kubectl -n cert-manager create secret generic cloudflare-api-token       --from-literal=api-token="${token}"       --dry-run=client -o yaml | kubectl apply -f -
+
+    echo "Updated secret cert-manager/cloudflare-api-token (key: api-token)."
+
+# Apply letsencrypt staging+production ClusterIssuers for non-Flux clusters.
+cert-manager-issuers-apply email='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+
+    : "${email:=${CERT_MANAGER_EMAIL:-}}"
+    if [ -z "${email}" ]; then
+      echo "Set CERT_MANAGER_EMAIL or pass email=<ops@example.com>." >&2
+      exit 1
+    fi
+
+    CERT_MANAGER_EMAIL="${email}" envsubst < platform/cert-manager/clusterissuers.nonflux.yaml | kubectl apply -f -
+    kubectl get clusterissuer letsencrypt-staging letsencrypt-production
+
 # Install the Helm CLI on the current node (idempotent; safe to re-run).
 
 # Downloads a pinned release archive and verifies checksum before install.

--- a/platform/cert-manager/clusterissuers.nonflux.yaml
+++ b/platform/cert-manager/clusterissuers.nonflux.yaml
@@ -1,0 +1,33 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    email: ${CERT_MANAGER_EMAIL}
+    privateKeySecretRef:
+      name: acme-account-key-staging
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    solvers:
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: cloudflare-api-token
+              key: api-token
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production
+spec:
+  acme:
+    email: ${CERT_MANAGER_EMAIL}
+    privateKeySecretRef:
+      name: acme-account-key-production
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: cloudflare-api-token
+              key: api-token


### PR DESCRIPTION
### Motivation
- Staging exposed a failure mode where `kubectl apply -k platform/cert-manager` created resources then failed on `HelmRelease` because Flux was not installed. 
- A literal `$(CERT_MANAGER_EMAIL)` placeholder ended up in ClusterIssuer CRs causing ACME `invalidContact` errors. 
- Provide a safe, documented path to install cert-manager and ClusterIssuers on clusters that do not run Flux so rollouts do not require Flux to be present. 

### Description
- Added Just recipes to install and manage cert-manager for non-Flux clusters: `cert-manager-install`, `cert-manager-status`, `cert-manager-cloudflare-token-secret`, and `cert-manager-issuers-apply email=<email>`. 
- Added `platform/cert-manager/clusterissuers.nonflux.yaml` as an envsubst-friendly issuer template that uses `${CERT_MANAGER_EMAIL}` to avoid deprecated Kustomize vars and literal placeholders. 
- Updated `docs/cloudflare_tunnel.md` with a new “cert-manager DNS-01 (non-Flux clusters)” section that documents the `CF_TUNNEL_TOKEN` vs `CF_DNS_API_TOKEN` distinction, required Cloudflare token permissions (`Zone → DNS → Edit` and `Zone → Zone → Read`), validation commands, and common failure modes. 
- Inserted pre-flight guidance into `docs/k3s-tokenplace-staging.md` and `docs/k3s-tokenplace-prod.md` recommending the non-Flux cert-manager install steps before deploying token.place. 

### Testing
- Ran `python -m py_compile scripts/scan-secrets.py` to sanity-check the repo secret scanner and it succeeded. 
- Attempted `just --list | grep cert-manager` and `just --fmt` but both failed because `just` is not installed in this execution environment. 
- Attempted `pre-commit run --all-files` but it could not be run here because `pre-commit` is not installed in this environment. 
- Files created/modified locally and verified syntactic placement: `platform/cert-manager/clusterissuers.nonflux.yaml` plus updates to `justfile`, `docs/cloudflare_tunnel.md`, `docs/k3s-tokenplace-staging.md`, and `docs/k3s-tokenplace-prod.md` (no secrets committed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c9b17ae4832f85b5cb1d6a3cbe2a)