### PR TITLE
Add non-Flux cert-manager recipes and Cloudflare DNS-01 runbooks

### DIFF
--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -353,3 +353,19 @@ for temporary local development. See
 - After apex promotion, `prod.democratized.space` can be converted to a redirect to
   `https://democratized.space`.
 - The Sugarkube dspace app expects this persistent tunnel setup to be in place.
+
+## Cloudflare Tunnel token vs Cloudflare DNS API token
+
+These are different credentials:
+
+- `CF_TUNNEL_TOKEN` is only for the `cloudflared` connector process. It comes from the tunnel dashboard “Install and run a connector” screen.
+- `CF_DNS_API_TOKEN` (stored in Kubernetes as `cert-manager/cloudflare-api-token`) is for cert-manager DNS-01 ACME challenges.
+
+For DNS-01, create a Cloudflare API token with:
+
+- **Zone → DNS → Edit**
+- **Zone → Zone → Read**
+- Zone resource: **Specific zone** (`token.place`)
+- If one token is shared for democratized.space certs, include **Specific zone** `democratized.space` too.
+
+If `Zone Read` is missing, issuance may succeed but challenge cleanup/zone lookups can fail.

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -102,6 +102,15 @@ Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not m
 typically `http://traefik.kube-system.svc.cluster.local:80`. Production overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
 and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
 
+For non-Flux clusters, install and apply issuers with:
+
+```bash
+just cert-manager-install
+just cert-manager-cloudflare-token-secret token="$CF_DNS_API_TOKEN"
+just cert-manager-issuers-apply email="ops@example.com"
+just cert-manager-status
+```
+
 ```bash
 just cf-tunnel-route host=token.place
 ```

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -103,6 +103,15 @@ Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not m
 typically `http://traefik.kube-system.svc.cluster.local:80`. Staging overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
 and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
 
+For non-Flux clusters, install and apply issuers with:
+
+```bash
+just cert-manager-install
+just cert-manager-cloudflare-token-secret token="$CF_DNS_API_TOKEN"
+just cert-manager-issuers-apply email="ops@example.com"
+just cert-manager-status
+```
+
 ```bash
 just cf-tunnel-route host=staging.token.place
 ```

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -317,3 +317,48 @@ provisioner becomes the default StorageClass.
 - Keep `scripts/flux-bootstrap.sh` executable and rerun `just flux-bootstrap env=<env>` after Flux
   upgrades.
 - If MetalLB is introduced, follow the comments in the k3s config examples to disable `servicelb`.
+
+
+## Non-Flux cert-manager + Cloudflare DNS-01 (token.place staging/prod)
+
+Use this path on clusters that do **not** run Flux. This avoids the `HelmRelease` dependency in `platform/cert-manager`.
+
+### Why this exists
+
+In staging, `kubectl apply -k platform/cert-manager` applied `ClusterIssuer` objects but then failed because Flux CRDs/controllers were absent (`HelmRelease` kind unknown). A second issue was an unresolved literal `$(CERT_MANAGER_EMAIL)` in the issuer manifest, which produced `invalidContact` from Let's Encrypt.
+
+### Install and configure
+
+```bash
+just cert-manager-install
+export CF_DNS_API_TOKEN="<cloudflare-dns-api-token>"
+just cert-manager-cloudflare-token-secret token="$CF_DNS_API_TOKEN"
+just cert-manager-issuers-apply email="ops@example.com"
+just cert-manager-status
+```
+
+The install recipe uses the successful manual Helm path:
+
+- chart: `jetstack/cert-manager`
+- version: `v1.14.4`
+- namespace: `cert-manager`
+- `installCRDs=true`
+- `global.leaderElection.namespace=cert-manager`
+
+### Validation
+
+```bash
+kubectl get crd | grep cert-manager.io
+kubectl get clusterissuer letsencrypt-staging letsencrypt-production
+kubectl get certificate -A
+kubectl -n cert-manager get secret cloudflare-api-token
+kubectl -n cert-manager logs deploy/cert-manager --tail=80
+```
+
+### Troubleshooting
+
+- **Missing cert-manager CRDs / `clusterissuers.cert-manager.io` not found**: run `just cert-manager-install` and re-check CRDs.
+- **`no matches for kind "ClusterIssuer"`**: cert-manager CRDs are not installed yet; install cert-manager first.
+- **`invalidContact` with literal `$(CERT_MANAGER_EMAIL)`**: re-apply issuers with `just cert-manager-issuers-apply email=...` so the real email is rendered.
+- **`cloudflare-api-token` secret missing**: run `just cert-manager-cloudflare-token-secret token=...`.
+- **Challenge cleanup errors after cert is issued**: confirm Cloudflare token includes both `Zone:Read` and `DNS:Edit` for the target zone(s).

--- a/justfile
+++ b/justfile
@@ -736,6 +736,63 @@ cf-tunnel-debug:
         echo "No Cloudflare Tunnel pods to show logs for."
     fi
 
+cert-manager-install version='v1.14.4':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+
+    helm repo add jetstack https://charts.jetstack.io --force-update
+    helm repo update jetstack
+
+    helm upgrade --install cert-manager jetstack/cert-manager \
+      --namespace cert-manager \
+      --create-namespace \
+      --version "{{ version }}" \
+      --set installCRDs=true \
+      --set global.leaderElection.namespace=cert-manager
+
+cert-manager-cloudflare-token-secret token='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+    : "${token:=${CF_DNS_API_TOKEN:-}}"
+    if [ -z "${token}" ]; then
+      echo "Set CF_DNS_API_TOKEN or pass token=<cloudflare-dns-api-token>." >&2
+      exit 1
+    fi
+
+    kubectl -n cert-manager create secret generic cloudflare-api-token \
+      --from-literal=api-token="${token}" \
+      --dry-run=client -o yaml | kubectl apply -f -
+
+cert-manager-issuers-apply email='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+    : "${email:=${CERT_MANAGER_EMAIL:-}}"
+    if [ -z "${email}" ]; then
+      echo "Set CERT_MANAGER_EMAIL or pass email=<ops@example.com>." >&2
+      exit 1
+    fi
+
+    sed "s|__CERT_MANAGER_EMAIL__|${email}|g" platform/cert-manager/clusterissuers.nonflux.yaml | kubectl apply -f -
+
+cert-manager-status:
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+
+    kubectl get crd | grep -E 'certificates\\.cert-manager\\.io|clusterissuers\\.cert-manager\\.io|certificaterequests\\.cert-manager\\.io'
+    kubectl -n cert-manager get deploy,pods
+    kubectl get clusterissuer letsencrypt-staging letsencrypt-production -o wide
+    kubectl -n cert-manager get secret cloudflare-api-token
+    kubectl get certificate -A
+    kubectl -n cert-manager logs deploy/cert-manager --tail=80
+
 # Install the Helm CLI on the current node (idempotent; safe to re-run).
 
 # Downloads a pinned release archive and verifies checksum before install.

--- a/platform/cert-manager/clusterissuers.nonflux.yaml
+++ b/platform/cert-manager/clusterissuers.nonflux.yaml
@@ -1,0 +1,33 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    email: __CERT_MANAGER_EMAIL__
+    privateKeySecretRef:
+      name: acme-account-key-staging
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    solvers:
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: cloudflare-api-token
+              key: api-token
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production
+spec:
+  acme:
+    email: __CERT_MANAGER_EMAIL__
+    privateKeySecretRef:
+      name: acme-account-key-production
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: cloudflare-api-token
+              key: api-token


### PR DESCRIPTION
### Motivation
- Staging revealed a gap when `platform/cert-manager` was applied to clusters without Flux: `HelmRelease` manifests and a `$(CERT_MANAGER_EMAIL)` literal caused partial applies and ACME `invalidContact` errors.
- Provide an explicit, non-Flux path to install cert-manager, create the Cloudflare DNS API secret, and apply ClusterIssuers so operators can recover or bootstrap clusters that do not run Flux.

### Description
- Added `just` recipes to manage cert-manager on non-Flux clusters: `cert-manager-install`, `cert-manager-status`, `cert-manager-issuers-apply email=<email>`, and `cert-manager-cloudflare-token-secret` in `justfile` which install a pinned `jetstack/cert-manager` chart (`v1.14.4`) with `installCRDs=true` and `global.leaderElection.namespace=cert-manager` and provide status/templating helpers.
- Added a non-Flux ClusterIssuer manifest template `platform/cert-manager/clusterissuers.nonflux.yaml` that uses an explicit `__CERT_MANAGER_EMAIL__` placeholder so issuers can be applied with simple shell templating (no deprecated Kustomize vars).
- Updated docs to document the new flow and clarify credentials: appended a section to `docs/runbook.md` describing the staging failure (Flux absent + literal email) and the non-Flux recovery path, added Cloudflare token vs DNS API token guidance to `docs/cloudflare_tunnel.md`, and added `just` invocation hints to `docs/k3s-tokenplace-staging.md` and `docs/k3s-tokenplace-prod.md`.
- Documentation includes Cloudflare DNS API token permission guidance (`Zone → DNS → Edit` and `Zone → Zone → Read`) and warns about sharing tokens across zones (e.g., `token.place` and `democratized.space`).
- No secrets were committed; the recipes create Kubernetes Secrets from operator-provided tokens only (operators must provide `CF_DNS_API_TOKEN` or pass `token=` to the `just` recipe).

### Testing
- Attempted `just --list | grep cert-manager` to validate new recipes were exposed; this environment lacks `just`, so the command failed with `just: command not found` (not-run in CI context).
- Attempted `pre-commit run --all-files` to run linters and hooks; this environment lacks `pre-commit`, so the command failed with `pre-commit: command not found` (not-run in CI context).
- Verified repository changes committed locally via `git status` and created a commit titled "Add non-Flux cert-manager + Cloudflare DNS-01 runbooks" (commit created successfully).

Notes and follow-ups: run `just cert-manager-install`, `just cert-manager-cloudflare-token-secret token="<token>"`, and `just cert-manager-issuers-apply email="ops@example.com"` on a target node to exercise the flow; run `pre-commit run --all-files` and `shellcheck` on the new `just` scripts in your CI or a local environment where `just` and `pre-commit` are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c9b17ae4832f85b5cb1d6a3cbe2a)