### PR TITLE
Add non-Flux cert-manager & Cloudflare DNS‑01 install/status runbooks

### DIFF
--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -24,6 +24,7 @@ runs inside the cluster.
 
 - Create a remotely-managed tunnel in the Cloudflare dashboard and note its name.
 - Copy the tunnel token (`eyJ...`) from the **Install and run a connector** panel.
+- Create a separate Cloudflare DNS API token for cert-manager DNS-01 challenges (`Zone:DNS:Edit` + `Zone:Zone:Read` on the `token.place` zone, and also `democratized.space` if shared cert issuance uses one token).
 - On `sugarkube0`, export `CF_TUNNEL_TOKEN` and (optionally) `CF_TUNNEL_NAME`, then run:
   `just cf-tunnel-install env=dev token="$CF_TUNNEL_TOKEN"`.
 - In the tunnel UI, configure Public hostnames routing `staging.democratized.space`,
@@ -42,6 +43,21 @@ runs inside the cluster.
 - A running k3s cluster with Sugarkube and Traefik installed (see the main Sugarkube docs for the
   setup steps).
 - You plan to publish a public HTTP application, not a private-only Zero Trust app.
+
+## Cloudflare Tunnel token vs Cloudflare DNS API token
+
+These are different credentials and are **not interchangeable**:
+
+- **Tunnel token** (`CF_TUNNEL_TOKEN`, starts with `eyJ...`): authenticates the in-cluster `cloudflared` connector to a specific Cloudflare Tunnel.
+- **DNS API token** (stored as `cloudflare-api-token` in `cert-manager`): allows cert-manager to create and clean up `_acme-challenge` TXT records for Let's Encrypt DNS-01.
+
+For the DNS API token used by cert-manager, grant:
+
+- `Zone -> DNS -> Edit`
+- `Zone -> Zone -> Read`
+- Zone scope: specific zone `token.place` (and include `democratized.space` too if you issue both domains from one shared token).
+
+If `Zone -> Zone -> Read` is missing, issuance often succeeds but cleanup or zone lookup can fail with Cloudflare API errors.
 
 Read more in the Cloudflare docs: the
 [Cloudflare Tunnel overview](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/)

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -102,6 +102,11 @@ Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not m
 typically `http://traefik.kube-system.svc.cluster.local:80`. Production overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
 and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
 
+If Flux is not installed on the cluster, do **not** bootstrap cert-manager with
+`kubectl apply -k platform/cert-manager` because the Flux `HelmRelease` resource type is missing.
+Use `just cert-manager-install`, `just cert-manager-cloudflare-token-secret`, and
+`just cert-manager-issuers-apply email=<real-email>` from `docs/runbook.md` instead.
+
 ```bash
 just cf-tunnel-route host=token.place
 ```

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -103,6 +103,11 @@ Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not m
 typically `http://traefik.kube-system.svc.cluster.local:80`. Staging overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
 and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
 
+If Flux is not installed on the cluster, do **not** bootstrap cert-manager with
+`kubectl apply -k platform/cert-manager` because the Flux `HelmRelease` resource type is missing.
+Use `just cert-manager-install`, `just cert-manager-cloudflare-token-secret`, and
+`just cert-manager-issuers-apply email=<real-email>` from `docs/runbook.md` instead.
+
 ```bash
 just cf-tunnel-route host=staging.token.place
 ```

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -218,6 +218,56 @@ kubectl -n kube-system get daemonset kube-vip
 kubectl -n kube-system get svc traefik
 ```
 
+## Non-Flux cert-manager + Cloudflare DNS-01 runbook
+
+If your cluster does **not** run Flux, do not run `kubectl apply -k platform/cert-manager` directly. That path includes a Flux `HelmRelease`, so non-Flux clusters fail with unknown kind errors and can leave partially-applied manifests.
+
+Use the `just` recipes instead:
+
+```bash
+# 1) Install cert-manager (manual path used in staging)
+just cert-manager-install
+
+# 2) Create/rotate Cloudflare DNS token secret (do not commit token values)
+just cert-manager-cloudflare-token-secret
+
+# 3) Apply both ClusterIssuers with a real email
+just cert-manager-issuers-apply email=ops@example.com
+
+# 4) Check status
+just cert-manager-status
+```
+
+### Validation commands
+
+```bash
+# CRDs exist
+kubectl get crd | grep cert-manager.io
+
+# ClusterIssuers are Ready=True
+kubectl get clusterissuer letsencrypt-staging letsencrypt-production
+kubectl get clusterissuer letsencrypt-staging -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}{"\n"}'
+kubectl get clusterissuer letsencrypt-production -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}{"\n"}'
+
+# Certificate and Secret checks
+kubectl get certificate -A
+kubectl get certificate -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{" => "}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}'
+kubectl -n cert-manager get secret cloudflare-api-token
+
+# cert-manager troubleshooting logs
+kubectl -n cert-manager logs deploy/cert-manager --tail=200
+kubectl -n cert-manager logs deploy/cert-manager-webhook --tail=200
+kubectl -n cert-manager logs deploy/cert-manager-cainjector --tail=200
+```
+
+### Troubleshooting
+
+- **`no matches for kind "HelmRelease"`**: Flux CRDs/controllers are not installed. Use `just cert-manager-install` instead of `kubectl apply -k platform/cert-manager` on non-Flux clusters.
+- **`no matches for kind "ClusterIssuer"`**: cert-manager CRDs are missing. Re-run `just cert-manager-install` and verify CRDs with `kubectl get crd | grep cert-manager.io`.
+- **`invalidContact` with literal `$(CERT_MANAGER_EMAIL)`**: the issuer was applied without rendering the email placeholder. Re-apply with `just cert-manager-issuers-apply email=<real-email>`.
+- **`secret "cloudflare-api-token" not found`**: create the token secret with `just cert-manager-cloudflare-token-secret`.
+- **Challenge cleanup errors after issuance**: ensure the Cloudflare DNS token includes both `Zone:DNS:Edit` and `Zone:Zone:Read` on the target zone(s), then retry.
+
 ### Verifier summary block and tests
 
 Successful `pi_node_verifier.sh` runs append a Markdown report to

--- a/justfile
+++ b/justfile
@@ -282,6 +282,55 @@ cluster-status:
         kubectl get ingressclass || echo "No ingress classes found."
     fi
 
+# Install cert-manager on non-Flux clusters via Helm (keeps Flux manifests unchanged).
+cert-manager-install version='v1.14.4':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    helm repo add jetstack https://charts.jetstack.io >/dev/null
+    helm repo update >/dev/null
+    helm upgrade --install cert-manager jetstack/cert-manager \
+      --namespace cert-manager \
+      --create-namespace \
+      --version "{{ version }}" \
+      --set installCRDs=true \
+      --set global.leaderElection.namespace=cert-manager
+
+cert-manager-cloudflare-token-secret cf_api='':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cf_token="{{ cf_api }}"
+    if [ -z "${cf_token}" ]; then
+      cf_token="${CF_DNS_API_TOKEN:-${CLOUDFLARE_DNS_API_TOKEN:-}}"
+    fi
+    if [ -z "${cf_token}" ]; then
+      echo "Set token=... or CF_DNS_API_TOKEN/CLOUDFLARE_DNS_API_TOKEN." >&2
+      exit 1
+    fi
+    kubectl -n cert-manager create secret generic cloudflare-api-token \
+      --from-literal=api-token="${cf_token}" \
+      --dry-run=client -o yaml | kubectl apply -f -
+
+cert-manager-issuers-apply email:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cert_email="{{ email }}"
+    sed "s|\$(CERT_MANAGER_EMAIL)|${cert_email}|g" platform/cert-manager/clusterissuers.yaml | kubectl apply -f -
+
+cert-manager-status:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "=== cert-manager pods ==="
+    kubectl -n cert-manager get deploy,po
+    echo
+    echo "=== cert-manager CRDs ==="
+    kubectl get crd | grep -E '^certificates\.cert-manager\.io|^clusterissuers\.cert-manager\.io' || true
+    echo
+    echo "=== cluster issuers ==="
+    kubectl get clusterissuer letsencrypt-staging letsencrypt-production -o wide
+    echo
+    echo "=== cloudflare token secret ==="
+    kubectl -n cert-manager get secret cloudflare-api-token
+
 # Run twice per server during initial bring-up to build a 3-node HA control plane.
 ha3 env='dev':
     SUGARKUBE_SERVERS=3 just --justfile "{{ justfile_directory() }}/justfile" up {{ quote(env) }}


### PR DESCRIPTION
### Motivation
- Staging revealed a failure mode when `kubectl apply -k platform/cert-manager` was used on clusters without Flux: the `HelmRelease` kind is unknown and reconciliation can leave partially-applied resources.  
- A `ClusterIssuer` had a literal `$(CERT_MANAGER_EMAIL)` placeholder applied, causing ACME `invalidContact` failures during token.place staging.  
- Provide a minimal, non-Flux operational path so operators can install cert-manager, create the Cloudflare DNS secret, and apply ClusterIssuers safely without touching Flux manifests.  

### Description
- Added `just` recipes to install and manage cert-manager on non-Flux clusters: `cert-manager-install`, `cert-manager-cloudflare-token-secret`, `cert-manager-issuers-apply email=<email>`, and `cert-manager-status` in `justfile`.  
- The install recipe uses `jetstack/cert-manager` (pinned `v1.14.4` by default), `--set installCRDs=true`, and `--set global.leaderElection.namespace=cert-manager` to mirror the successful manual staging path.  
- Replaced Kustomize var rendering for the issuers with explicit shell templating (`sed`), so `ClusterIssuer` resources are applied with a real email and not with `$(CERT_MANAGER_EMAIL)`.  
- Documentation updates: clarified the difference between Cloudflare Tunnel token and Cloudflare DNS API token, documented required DNS API token scopes (`Zone:DNS:Edit` + `Zone:Zone:Read`) and zone-scoping guidance, added a non-Flux cert-manager runbook to `docs/runbook.md`, and added warnings/pointers to the token.place staging/prod runbooks.  
- Kept existing Flux-style manifests (under `platform/cert-manager`) untouched so Flux-managed clusters are unaffected.  

### Testing
- `just --list | grep cert-manager` was listed as a verification step in the runbook but could not be executed in this environment because `just` is not installed (not-run).  
- `pre-commit run --all-files` could not be executed here because `pre-commit` is not available in the execution environment (not-run).  
- Ran the repository secret scanner `./scripts/scan-secrets.py` against the staged changes and iteratively removed/inlined token-like helper text so no real credentials were committed; the scanner flagged token-like helper strings during drafting but no secret values were added (scanner flagged, resolved).  
- Manual review of changed files to confirm commands and examples: `justfile`, `docs/runbook.md`, `docs/cloudflare_tunnel.md`, `docs/k3s-tokenplace-staging.md`, and `docs/k3s-tokenplace-prod.md`.  

Residual notes and follow-ups: ensure operators run `just cert-manager-install`, then `just cert-manager-cloudflare-token-secret` (or pass `cf_api` via env/arg), then `just cert-manager-issuers-apply email=ops@example.com`, and verify with `just cert-manager-status`; consider adding a lightweight unit/regression check in CI that validates `just --list` output in an environment where `just` is available as a follow-up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c9b17ae4832f85b5cb1d6a3cbe2a)