### PR TITLE
Fix cf-tunnel-route normalization and clarify multi-host staging tunnel docs

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -28,6 +28,10 @@ Current/target topology:
   public host `democratized.space`.
 - **dev (planned, non-HA):** `env=dev` on `sugarkube6` (single-node future environment).
 
+Cloudflare Tunnel topology stays one tunnel per environment/cluster, with many hostnames routed to
+Traefik. For staging this means `staging.democratized.space` can share a tunnel with
+`staging.token.place`, and Traefik routes by HTTP `Host` header to the proper Ingress.
+
 ## Tagging model (evergreen releases)
 
 Use tags by purpose:

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -90,7 +90,9 @@ Cloudflare Tunnel/DNS configuration is external to Helm.
 - Configure routes explicitly:
 
 ```bash
+just cf-tunnel-route staging.token.place
 just cf-tunnel-route host=staging.token.place
+just cf-tunnel-route token.place
 just cf-tunnel-route host=token.place
 ```
 

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -80,8 +80,13 @@ Cloudflare Tunnel/DNS configuration is external to Helm.
 - Route hostnames to Traefik, typically
   `http://traefik.kube-system.svc.cluster.local:80`.
 - Helm chart deployment does **not** create Cloudflare routes.
+- One tunnel per environment can serve multiple app hostnames (for example
+  `staging.democratized.space` and `staging.token.place`) by routing both to Traefik.
+- Traefik chooses the correct Kubernetes Ingress by HTTP `Host` header.
 - Staging/prod overlays set `ingress.tls.enabled: true` so rendered Kubernetes Ingress includes `spec.tls`.
 - `cert-manager` and a compatible `ClusterIssuer` are assumed to already exist.
+- Cloudflare Tunnel routing (`cf-tunnel-route`) is separate from the Cloudflare DNS API token used
+  by cert-manager DNS-01.
 - Configure routes explicitly:
 
 ```bash

--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -27,9 +27,15 @@ runs inside the cluster.
 - On `sugarkube0`, export `CF_TUNNEL_TOKEN` and (optionally) `CF_TUNNEL_NAME`, then run:
   `just cf-tunnel-install env=dev token="$CF_TUNNEL_TOKEN"`.
 - In the tunnel UI, configure Public hostnames routing `staging.democratized.space`,
-  `prod.democratized.space` (optional legacy redirect host), and `democratized.space` →
+  `staging.token.place`, `prod.democratized.space` (optional legacy redirect host), and
+  `democratized.space` →
   `http://traefik.<namespace>.svc.cluster.local:80`.
 - Confirm readiness: use the port-forward + curl check shown below to hit `/ready` on port 2000.
+
+One tunnel per cluster/environment can serve many hostnames. For example, the staging tunnel
+`dspace-staging-v3` can serve both `staging.democratized.space` and `staging.token.place`, all
+routed to Traefik; Traefik then selects the right Kubernetes Ingress by HTTP `Host` header. You can
+optionally rename the tunnel later to `sugarkube-staging-v3`, but do not block launch on renaming.
 
 ## Prerequisites
 
@@ -55,7 +61,8 @@ and
    current UI).
 3. Click **Create a tunnel**.
 4. Choose **Cloudflared** as the connector type.
-5. Name the tunnel (for example, `dspace-staging-v3`). This can be any unique name.
+5. Name the tunnel (for example, `dspace-staging-v3`). This can be any unique name and can be reused
+   for multiple app hostnames in the same environment.
 6. Click **Save tunnel**. The dashboard opens **Install and run a connector** with OS-specific
    commands. **Ignore the OS install commands and do not run `curl | sudo bash` on your Pi.**
    Sugarkube will run `cloudflared` inside the cluster for you. Your only job here is to copy the
@@ -246,7 +253,7 @@ To fix:
 
 Once `cloudflared` runs with the correct token, Cloudflare links the named tunnel to the cluster so
 requests to your mapped hostnames (for example `staging.democratized.space`,
-optional `prod.democratized.space` redirect host, and `democratized.space`)
+`staging.token.place`, optional `prod.democratized.space` redirect host, and `democratized.space`)
 reach Traefik.
 
 ### Recovery and reset
@@ -259,6 +266,13 @@ return to a clean token-mode state:
   ```bash
   just cf-tunnel-debug
   ```
+
+  In `cf-tunnel-debug` logs, look for `Updated to new configuration` and confirm your target
+  hostname appears. If the tunnel is connected but the Kubernetes app ingress is not created yet,
+  a `404` is expected until that ingress exists.
+
+- If logs warn that the cloudflared image is outdated, treat that as a separate maintenance item.
+  Do not block app deployment when the tunnel is connected and hostname routes work.
 
 - Hard reset the deployment/configmap/pods while preserving the `tunnel-token` Secret:
 

--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -26,9 +26,8 @@ runs inside the cluster.
 - Copy the tunnel token (`eyJ...`) from the **Install and run a connector** panel.
 - On `sugarkube0`, export `CF_TUNNEL_TOKEN` and (optionally) `CF_TUNNEL_NAME`, then run:
   `just cf-tunnel-install env=dev token="$CF_TUNNEL_TOKEN"`.
-- In the tunnel UI, configure Public hostnames routing `staging.democratized.space`,
-  `staging.token.place`, `prod.democratized.space` (optional legacy redirect host), and
-  `democratized.space` →
+- In the tunnel UI, configure only the hostnames for **this environment's tunnel**. For example, a
+  staging tunnel can route `staging.democratized.space` and `staging.token.place` →
   `http://traefik.<namespace>.svc.cluster.local:80`.
 - Confirm readiness: use the port-forward + curl check shown below to hit `/ready` on port 2000.
 
@@ -40,8 +39,9 @@ optionally rename the tunnel later to `sugarkube-staging-v3`, but do not block l
 ## Prerequisites
 
 - A Cloudflare account.
-- A domain added as an active zone in Cloudflare and using Cloudflare nameservers (for example,
-  `democratized.space`).
+- Domains for every hostname you plan to publish must be active zones in Cloudflare and use
+  Cloudflare nameservers (for example, both `democratized.space` and `token.place` when publishing
+  `staging.token.place`).
 - `staging.democratized.space`, `prod.democratized.space` (optional legacy redirect host), and
   `democratized.space` (or your preferred rollout hostnames) are managed by Cloudflare DNS.
 - Access to the Cloudflare Zero Trust / Cloudflare One dashboard.
@@ -292,32 +292,34 @@ return to a clean token-mode state:
 The installer performs a teardown-and-retry if the first rollout fails, so rerunning the recipes is
 the canonical way to recover a wedged connector without losing the saved token.
 
-## Step 3 – Publish application routes (staging + optional prod redirect host + apex)
+## Step 3 – Publish application routes for one environment tunnel
 
-Now that the connector is running in the cluster, configure routes from your dspace hostnames to the
-internal Traefik Service.
+Now that the connector is running in the cluster, configure routes for the hostnames that belong to
+this tunnel/environment and point them to the internal Traefik Service.
 
 1. In the tunnel configuration, open the **Public hostnames**, **Application routes**, or
    **Published applications** section.
-2. Add routes/applications:
+2. Add routes/applications (example for staging tunnel):
    - **Hostname**: `staging.democratized.space`
-   - **Hostname**: `prod.democratized.space` *(optional legacy redirect host)*
-   - **Hostname**: `democratized.space`
+   - **Hostname**: `staging.token.place`
    - **Service type**: `HTTP`
    - **Service URL**: `http://traefik.<namespace>.svc.cluster.local:80`
 
    Replace `<namespace>` with the namespace used by your ingress controller inside the k3s cluster.
+   For production, use a separate production tunnel and publish production hostnames there (for
+   example, `democratized.space` and optional legacy `prod.democratized.space` redirect host).
 3. Save the routes. This sends HTTPS traffic for each hostname through the tunnel into the Traefik
    ClusterIP service in your k3s cluster.
 
 See Cloudflare’s docs for the latest UI steps:
 [Publish an application through Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/get-started/create-remote-tunnel/#publish-an-application).
 
-## Step 4 – Verify / create DNS records for rollout hostnames
+## Step 4 – Verify / create DNS records for published hostnames
 
-The `staging.democratized.space`, `prod.democratized.space`, and `democratized.space` hostnames are
-managed by Cloudflare DNS. When you publish hostnames through the tunnel UI, Cloudflare **usually**
-creates proxied CNAMEs automatically that point each hostname to your tunnel’s
+The hostnames you published (for example, `staging.democratized.space` and `staging.token.place` for
+staging) must be managed by Cloudflare DNS in their respective zones. When you publish hostnames
+through the tunnel UI, Cloudflare **usually** creates proxied CNAMEs automatically that point each
+hostname to your tunnel’s
 `*.cfargotunnel.com` address.
 
 If you see DNS records for the rollout hostnames pointing at `<UUID>.cfargotunnel.com`, you’re done.
@@ -326,11 +328,13 @@ If you see DNS records for the rollout hostnames pointing at `<UUID>.cfargotunne
 
 Only create this manually if the CNAME is missing:
 
-1. Go to **Cloudflare dashboard → DNS → Records** for `democratized.space`.
+1. Go to **Cloudflare dashboard → DNS → Records** for each relevant zone (for example,
+   `democratized.space` and `token.place`).
 2. Click **Add record**.
-3. Configure records as needed:
+3. Configure records as needed in each zone:
    - **Type**: `CNAME`
-   - **Name**: `staging`, `prod`, or `@` (for apex)
+   - **Name**: hostname label for that zone (for example, `staging` in either zone, `prod`, or `@`
+     for apex)
    - **Target**: `<UUID>.cfargotunnel.com` (the tunnel hostname shown in the dashboard)
    - **Proxy status**: **Proxied** (orange cloud)
 4. Save the record.
@@ -360,9 +364,11 @@ for temporary local development. See
 
 - A named Cloudflare Tunnel exists (for example, `dspace-staging`) with a saved token.
 - `cloudflared` runs inside the k3s cluster via `just cf-tunnel-install` using that token.
-- Routes map `staging.democratized.space`, `prod.democratized.space`, and `democratized.space` to
+- Routes for a given environment tunnel map that environment’s hostnames (for example,
+  `staging.democratized.space` and `staging.token.place`) to
   `http://traefik.<namespace>.svc.cluster.local:80` inside the cluster.
-- Cloudflare DNS has (or auto-created) proxied records pointing rollout hostnames to the tunnel’s
+- Cloudflare DNS has (or auto-created) proxied records in each required zone (for example,
+  `democratized.space` and `token.place`) pointing published hostnames to the tunnel’s
   `*.cfargotunnel.com` name.
 - After apex promotion, `prod.democratized.space` can be converted to a redirect to
   `https://democratized.space`.

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -108,6 +108,7 @@ Traefik selecting the target backend by `Host` header.
 cert-manager Cloudflare DNS token used for ACME DNS-01.
 
 ```bash
+just cf-tunnel-route token.place
 just cf-tunnel-route host=token.place
 ```
 

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -101,6 +101,11 @@ just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKE
 Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes. Route `token.place` to Traefik,
 typically `http://traefik.kube-system.svc.cluster.local:80`. Production overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
 and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
+One tunnel per environment can carry multiple app hostnames by routing them all to Traefik, with
+Traefik selecting the target backend by `Host` header.
+
+`cf-tunnel-route` configures Cloudflare Tunnel hostname routing. It does not configure the
+cert-manager Cloudflare DNS token used for ACME DNS-01.
 
 ```bash
 just cf-tunnel-route host=token.place

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -102,6 +102,12 @@ just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKE
 Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes. Route `staging.token.place` to Traefik,
 typically `http://traefik.kube-system.svc.cluster.local:80`. Staging overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
 and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
+One staging tunnel can serve multiple hostnames (for example `staging.democratized.space` and
+`staging.token.place`) by routing both to Traefik; Traefik dispatches by `Host` header to the
+correct Ingress.
+
+`cf-tunnel-route` is for Cloudflare Tunnel hostname routing only. It is separate from the
+Cloudflare DNS API token used by cert-manager DNS-01 challenges.
 
 ```bash
 just cf-tunnel-route host=staging.token.place

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -110,6 +110,7 @@ correct Ingress.
 Cloudflare DNS API token used by cert-manager DNS-01 challenges.
 
 ```bash
+just cf-tunnel-route staging.token.place
 just cf-tunnel-route host=staging.token.place
 ```
 

--- a/justfile
+++ b/justfile
@@ -1068,7 +1068,10 @@ cf-tunnel-route host='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    if [ -z "{{ host }}" ]; then
+    raw_host="{{ host }}"
+    normalized_host="${raw_host#host=}"
+
+    if [ -z "${normalized_host}" ]; then
         echo "Set host=<FQDN> (e.g., dspace-v3.example.com)." >&2
         exit 1
     fi
@@ -1077,7 +1080,7 @@ cf-tunnel-route host='':
 
     printf '%s\n' \
         'Use the Cloudflare dashboard to create a route for:' \
-        "  Hostname: {{ host }}" \
+        "  Hostname: ${normalized_host}" \
         "  Service URL: http://${svc_fqdn}" \
         '' \
         'Discover Traefik services:' \

--- a/tests/test_cloudflare_tunnel_token_mode.py
+++ b/tests/test_cloudflare_tunnel_token_mode.py
@@ -22,6 +22,12 @@ def _extract_cf_recipe_body() -> str:
     return _extract_recipe_body("cf-tunnel-install")
 
 
+def _extract_cf_tunnel_route_recipe_body() -> str:
+    """Return the full body of the cf-tunnel-route recipe."""
+
+    return _extract_recipe_body("cf-tunnel-route")
+
+
 @pytest.fixture(scope="module")
 def origin_cert_guidance_text() -> str:
     just_text = JUSTFILE.read_text(encoding="utf-8")
@@ -40,19 +46,22 @@ def _extract_recipe_body(name: str) -> str:
     heredoc_end: str | None = None
     for line in lines:
         if capture:
-            body.append(line)
             if heredoc_end:
+                body.append(line)
                 if line.strip() == heredoc_end:
                     heredoc_end = None
                 continue
             if "<<EOF" in line:
+                body.append(line)
                 heredoc_end = "EOF"
                 continue
             if "<<'PATCH'" in line:
+                body.append(line)
                 heredoc_end = "PATCH"
                 continue
             if line and not line[0].isspace() and line.strip() not in {')', 'EOF', 'PATCH'}:
                 break
+            body.append(line)
             continue
         if line.startswith(f"{name} ") or line.startswith(f"{name}:"):
             capture = True
@@ -64,6 +73,36 @@ def _extract_recipe_body(name: str) -> str:
 @pytest.fixture(scope="module")
 def cf_recipe_body() -> str:
     return _extract_cf_recipe_body()
+
+
+@pytest.fixture(scope="module")
+def cf_tunnel_route_recipe_body() -> str:
+    return _extract_cf_tunnel_route_recipe_body()
+
+
+def _run_cf_tunnel_route_recipe(host: str) -> subprocess.CompletedProcess[str]:
+    rendered_body = _extract_cf_tunnel_route_recipe_body().replace("{{ host }}", host)
+    script = textwrap.dedent(
+        """#!/usr/bin/env bash
+        set -euo pipefail
+        """
+    ) + rendered_body + "\n"
+
+    with tempfile.NamedTemporaryFile("w", delete=False) as f:
+        f.write(script)
+        path = f.name
+
+    try:
+        return subprocess.run(["bash", path], capture_output=True, text=True)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize("host_input", ["staging.token.place", "host=staging.token.place"])
+def test_cf_tunnel_route_normalizes_host_prefix(host_input: str) -> None:
+    result = _run_cf_tunnel_route_recipe(host_input)
+    assert result.returncode == 0, result.stderr
+    assert "Hostname: staging.token.place" in result.stdout
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### Motivation

- Users reported `just cf-tunnel-route host=staging.token.place` printed `Hostname: host=staging.token.place` instead of the normalized hostname, and staging operators needed clearer guidance for multi-app tunnels and debug expectations.
- The intent is to make the `cf-tunnel-route` helper accept both `just cf-tunnel-route staging.token.place` and `just cf-tunnel-route host=staging.token.place`, and to document the one-tunnel-per-env, many-hostnames model and cloudflared maintenance guidance.

### Description

- Normalize `host` input in the `justfile` `cf-tunnel-route` helper by stripping a leading `host=` prefix and printing the normalized hostname (so both `staging.token.place` and `host=staging.token.place` work). The change updates `justfile` around the `cf-tunnel-route` recipe.
- Updated `docs/cloudflare_tunnel.md` to include that one tunnel per cluster/env can serve many hostnames, to show the staging example (`dspace-staging-v3` serving both `staging.democratized.space` and `staging.token.place`), and to explain Traefik dispatch by HTTP `Host` header.
- Added `cf-tunnel-debug` guidance to check logs for `Updated to new configuration`, confirm the expected hostname appears, and note that a `404` is expected until the Kubernetes Ingress exists; also added a maintenance note that cloudflared image-age warnings are a separate task and should not block deployment if routes are healthy.
- Propagated clarifications to runbooks and app docs: `docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`, `docs/apps/tokenplace.md`, and `docs/apps/dspace.md` to distinguish Cloudflare Tunnel routes from cert-manager Cloudflare DNS token usage and to document the shared multi-host tunnel pattern.
- Before/after helper output: before: `Hostname: host=staging.token.place`; after: `Hostname: staging.token.place`.

### Testing

- Static search: ran `rg -n "staging.token.place|staging.democratized.space|one tunnel|Host header|cf-tunnel-route|cloudflared" docs justfile` and the updated references were found (success).
- Attempted runtime verification: tried `just cf-tunnel-route staging.token.place` and `just cf-tunnel-route host=staging.token.place` but `just` is not installed in this environment so runtime execution could not be performed (not run).
- Lint hooks: attempted `pre-commit run --all-files` but `pre-commit` is not available in this environment so the repository pre-commit checks were not run here (not run).
- Recommendations / follow-ups: verify the two `just` invocations on a machine with `just` installed and with appropriate kube/Cloudflare access, and run the repository `pre-commit` checks in CI or locally before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c9ba76b8832f85834e9e2fb178cc)