### PR TITLE
Fix cf-tunnel-route host normalization and clarify multi-host staging tunnel docs

### DIFF
--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -85,7 +85,9 @@ Cloudflare Tunnel/DNS configuration is external to Helm.
 - Configure routes explicitly:
 
 ```bash
+just cf-tunnel-route staging.token.place
 just cf-tunnel-route host=staging.token.place
+just cf-tunnel-route token.place
 just cf-tunnel-route host=token.place
 ```
 

--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -15,6 +15,10 @@ The tunnel routes these hostnames to Traefik (or another ingress controller) run
 k3s cluster. You do **not** need to install or run `cloudflared` on your workstation; the connector
 runs inside the cluster.
 
+One tunnel per cluster/environment can serve multiple public app hostnames. For staging, for example,
+a single `dspace-staging-v3` tunnel can route both `staging.democratized.space` and `staging.token.place`
+to Traefik. Traefik then routes to the correct Kubernetes Ingress by HTTP Host header.
+
 > Cloudflare has two big modes for tunnels: **remotely-managed** (token-only, created in the
 > dashboard) and **locally-managed** (requires `cloudflared login` and a `cert.pem`). Sugarkube uses
 > the **remotely-managed, token-based connector mode** only. If you create the tunnel in the
@@ -172,6 +176,8 @@ Run these commands on `sugarkube0` (or whichever node has the Sugarkube checkout
    In normal operation the Kubernetes readiness probe and the Cloudflare dashboard “Connected” state
    are sufficient; this port-forward check is just an extra manual confirmation.
 
+Maintenance note: cloudflared may log warnings that a newer image exists. Treat image upgrades as a separate maintenance task; do not block app deployment when the tunnel is connected and routes resolve correctly.
+
 ### Worked example: dspace staging tunnel on the `dev` Sugarkube env
 
 Below is the full sequence for deploying the `dspace-staging-v3` tunnel on the primary control-plane
@@ -258,6 +264,8 @@ return to a clean token-mode state:
 
   ```bash
   just cf-tunnel-debug
+
+  In recent logs, look for `Updated to new configuration` and confirm the target hostname appears. If the route exists but the app Ingress is not deployed yet, a `404` response is expected until the Ingress/Service is created.
   ```
 
 - Hard reset the deployment/configmap/pods while preserving the `tunnel-token` Secret:
@@ -279,6 +287,8 @@ The installer performs a teardown-and-retry if the first rollout fails, so rerun
 the canonical way to recover a wedged connector without losing the saved token.
 
 ## Step 3 – Publish application routes (staging + optional prod redirect host + apex)
+
+This route configuration is a Cloudflare Tunnel setting (public hostname → service URL). It is separate from the Cloudflare DNS API token used by cert-manager for ACME DNS-01 challenges.
 
 Now that the connector is running in the cluster, configure routes from your dspace hostnames to the
 internal Traefik Service.

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -98,11 +98,12 @@ just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKE
 
 ## Cloudflare tunnel routing (external to Helm)
 
-Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes. Route `token.place` to Traefik,
+Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes. One tunnel per cluster/environment can serve many app hostnames. Route `token.place` to Traefik,
 typically `http://traefik.kube-system.svc.cluster.local:80`. Production overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
 and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
 
 ```bash
+just cf-tunnel-route token.place
 just cf-tunnel-route host=token.place
 ```
 

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -99,11 +99,12 @@ just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKE
 
 ## Cloudflare tunnel routing (external to Helm)
 
-Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes. Route `staging.token.place` to Traefik,
+Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes. One tunnel per cluster/environment can serve many app hostnames. Route `staging.token.place` to Traefik,
 typically `http://traefik.kube-system.svc.cluster.local:80`. Staging overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
 and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
 
 ```bash
+just cf-tunnel-route staging.token.place
 just cf-tunnel-route host=staging.token.place
 ```
 

--- a/justfile
+++ b/justfile
@@ -1068,7 +1068,10 @@ cf-tunnel-route host='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    if [ -z "{{ host }}" ]; then
+    raw_host="{{ host }}"
+    normalized_host="${raw_host#host=}"
+
+    if [ -z "${normalized_host}" ]; then
         echo "Set host=<FQDN> (e.g., dspace-v3.example.com)." >&2
         exit 1
     fi
@@ -1077,8 +1080,11 @@ cf-tunnel-route host='':
 
     printf '%s\n' \
         'Use the Cloudflare dashboard to create a route for:' \
-        "  Hostname: {{ host }}" \
+        "  Hostname: ${normalized_host}" \
         "  Service URL: http://${svc_fqdn}" \
+        '' \
+        'A single tunnel per cluster/environment can route multiple public hostnames to Traefik.' \
+        'Traefik then dispatches to the correct Kubernetes Ingress via the HTTP Host header.' \
         '' \
         'Discover Traefik services:' \
         '  kubectl -n kube-system get svc -l app.kubernetes.io/name=traefik' \


### PR DESCRIPTION
### Motivation
- Fix a usability bug where `just cf-tunnel-route host=staging.token.place` printed `Hostname: host=staging.token.place` instead of the literal hostname. 
- Clarify documentation and runbooks so operators understand a single Cloudflare Tunnel per cluster/environment can host many app hostnames and route them to Traefik.

### Description
- Normalize `host` input in the `cf-tunnel-route` helper (`justfile`) by stripping a leading `host=` prefix and printing the cleaned hostname. 
- Augment the helper output to explain that a single tunnel per cluster/env can route multiple public hostnames to Traefik and that Traefik dispatches by the HTTP Host header. 
- Update `docs/cloudflare_tunnel.md` with a multi-host staging example (`dspace-staging-v3` serving `staging.democratized.space` and `staging.token.place`), debug guidance to watch for `Updated to new configuration` and the fact that `404` is expected until an Ingress/Service exists, a maintenance note about cloudflared image warnings, and a clarification separating Cloudflare Tunnel route configuration from cert-manager’s Cloudflare DNS token. 
- Update staging/prod and app runbooks to show both invocation forms (`just cf-tunnel-route staging.token.place` and `just cf-tunnel-route host=staging.token.place`) and to reinforce the one-tunnel-many-hostnames model.

### Testing
- Searched and verified updated references with `rg -n "staging.token.place|staging.democratized.space|one tunnel|Host header|cf-tunnel-route|cloudflared" docs justfile`, which succeeded and shows the docs and helper references were updated. 
- Verified the `justfile` change by inspecting the helper block (for example `nl -ba justfile | sed -n '1067,1092p'`) which shows `raw_host` → `normalized_host` and the helper now prints `Hostname: ${normalized_host}` as expected. 
- Attempted to run `just cf-tunnel-route staging.token.place` and `just cf-tunnel-route host=staging.token.place`, but `just` is not installed in this environment (`just: command not found`), so execution could not be performed here. 
- Attempted `pre-commit run --all-files`, but `pre-commit` is not installed in this environment, so lint hooks were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c9ba76b8832f85834e9e2fb178cc)