### PR TITLE
Fix cf-tunnel-route host normalization and document multi-app staging tunnel

### DIFF
--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -77,14 +77,19 @@ For production validation, use the same checks against `https://token.place`.
 
 Cloudflare Tunnel/DNS configuration is external to Helm.
 
+- One tunnel per environment can publish multiple app hostnames (for example `dspace-staging-v3`
+  for both `staging.democratized.space` and `staging.token.place`).
 - Route hostnames to Traefik, typically
   `http://traefik.kube-system.svc.cluster.local:80`.
+- Traefik dispatches traffic by `Host` header to the correct Kubernetes Ingress.
 - Helm chart deployment does **not** create Cloudflare routes.
 - Staging/prod overlays set `ingress.tls.enabled: true` so rendered Kubernetes Ingress includes `spec.tls`.
 - `cert-manager` and a compatible `ClusterIssuer` are assumed to already exist.
+- Cloudflare Tunnel route config and cert-manager Cloudflare DNS tokens are different credentials.
 - Configure routes explicitly:
 
 ```bash
+just cf-tunnel-route staging.token.place
 just cf-tunnel-route host=staging.token.place
 just cf-tunnel-route host=token.place
 ```

--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -15,6 +15,10 @@ The tunnel routes these hostnames to Traefik (or another ingress controller) run
 k3s cluster. You do **not** need to install or run `cloudflared` on your workstation; the connector
 runs inside the cluster.
 
+One tunnel per cluster/environment can publish many app hostnames. For example, a single
+`dspace-staging-v3` tunnel can serve both `staging.democratized.space` and
+`staging.token.place`.
+
 > Cloudflare has two big modes for tunnels: **remotely-managed** (token-only, created in the
 > dashboard) and **locally-managed** (requires `cloudflared login` and a `cert.pem`). Sugarkube uses
 > the **remotely-managed, token-based connector mode** only. If you create the tunnel in the
@@ -27,7 +31,8 @@ runs inside the cluster.
 - On `sugarkube0`, export `CF_TUNNEL_TOKEN` and (optionally) `CF_TUNNEL_NAME`, then run:
   `just cf-tunnel-install env=dev token="$CF_TUNNEL_TOKEN"`.
 - In the tunnel UI, configure Public hostnames routing `staging.democratized.space`,
-  `prod.democratized.space` (optional legacy redirect host), and `democratized.space` →
+  `staging.token.place`, `prod.democratized.space` (optional legacy redirect host), and
+  `democratized.space` →
   `http://traefik.<namespace>.svc.cluster.local:80`.
 - Confirm readiness: use the port-forward + curl check shown below to hit `/ready` on port 2000.
 
@@ -260,6 +265,10 @@ return to a clean token-mode state:
   just cf-tunnel-debug
   ```
 
+  Look for `Updated to new configuration` and confirm expected hostnames appear in logs. A `404`
+  before the app Ingress exists is expected and indicates the tunnel is live but app routing is not
+  created yet.
+
 - Hard reset the deployment/configmap/pods while preserving the `tunnel-token` Secret:
 
   ```bash
@@ -278,6 +287,12 @@ return to a clean token-mode state:
 The installer performs a teardown-and-retry if the first rollout fails, so rerunning the recipes is
 the canonical way to recover a wedged connector without losing the saved token.
 
+### Maintenance note: outdated `cloudflared` image warnings
+
+`cloudflared` can log warnings when a newer connector image exists. Treat this as a separate
+maintenance update task. Do not block app deploys on this warning alone when the tunnel is connected
+and route checks succeed.
+
 ## Step 3 – Publish application routes (staging + optional prod redirect host + apex)
 
 Now that the connector is running in the cluster, configure routes from your dspace hostnames to the
@@ -295,6 +310,7 @@ internal Traefik Service.
    Replace `<namespace>` with the namespace used by your ingress controller inside the k3s cluster.
 3. Save the routes. This sends HTTPS traffic for each hostname through the tunnel into the Traefik
    ClusterIP service in your k3s cluster.
+4. Traefik then routes by HTTP `Host` header to the matching Kubernetes Ingress for each app.
 
 See Cloudflare’s docs for the latest UI steps:
 [Publish an application through Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/get-started/create-remote-tunnel/#publish-an-application).

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -101,6 +101,7 @@ just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKE
 Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes. Route `token.place` to Traefik,
 typically `http://traefik.kube-system.svc.cluster.local:80`. Production overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
 and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
+Keep cert-manager Cloudflare DNS credentials separate from the Cloudflare Tunnel token.
 
 ```bash
 just cf-tunnel-route host=token.place

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -99,11 +99,16 @@ just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKE
 
 ## Cloudflare tunnel routing (external to Helm)
 
-Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes. Route `staging.token.place` to Traefik,
-typically `http://traefik.kube-system.svc.cluster.local:80`. Staging overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
-and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
+Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes.
+One staging tunnel can front multiple app hosts (for example, `dspace-staging-v3` serving both
+`staging.democratized.space` and `staging.token.place`) while Traefik routes by `Host` header.
+Route `staging.token.place` to Traefik, typically `http://traefik.kube-system.svc.cluster.local:80`.
+Staging overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone
+is not sufficient, and this runbook assumes `cert-manager` and the referenced `ClusterIssuer`
+already exist. Keep cert-manager Cloudflare DNS credentials separate from the Cloudflare Tunnel token.
 
 ```bash
+just cf-tunnel-route staging.token.place
 just cf-tunnel-route host=staging.token.place
 ```
 

--- a/justfile
+++ b/justfile
@@ -1068,7 +1068,16 @@ cf-tunnel-route host='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    if [ -z "{{ host }}" ]; then
+    host_input='{{ host }}'
+    host_name="${host_input}"
+    while [ "${host_name#host=}" != "${host_name}" ]; do
+        host_name="${host_name#host=}"
+    done
+    while [ "${host_name#HOST=}" != "${host_name}" ]; do
+        host_name="${host_name#HOST=}"
+    done
+
+    if [ -z "${host_name}" ]; then
         echo "Set host=<FQDN> (e.g., dspace-v3.example.com)." >&2
         exit 1
     fi
@@ -1077,7 +1086,7 @@ cf-tunnel-route host='':
 
     printf '%s\n' \
         'Use the Cloudflare dashboard to create a route for:' \
-        "  Hostname: {{ host }}" \
+        "  Hostname: ${host_name}" \
         "  Service URL: http://${svc_fqdn}" \
         '' \
         'Discover Traefik services:' \


### PR DESCRIPTION
### Motivation
- The `cf-tunnel-route` helper could echo the literal `host=…` token instead of a normalized FQDN which confused staging edits. 
- Docs did not clearly explain that one Cloudflare Tunnel per cluster/env can host multiple app hostnames and that Traefik routes by `Host` header. 
- Cloudflared runtime warnings and `cf-tunnel-debug` signals needed clearer operational guidance so engineers don’t block deployments on benign warnings. 

### Description
- Normalize `host` argument in `justfile` `cf-tunnel-route` so `host=staging.token.place`, `HOST=…`, and positional `staging.token.place` all normalize to the FQDN before printing. 
- Update `docs/cloudflare_tunnel.md` to state the multi-app tunnel model, add `cf-tunnel-debug` log interpretation guidance (look for `Updated to new configuration` and expected `404` before an Ingress exists), and add a maintenance note about outdated `cloudflared` image warnings. 
- Update token.place runbooks and app docs (`docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`, `docs/apps/tokenplace.md`) to document that a single staging tunnel (e.g. `dspace-staging-v3`) can serve both `staging.democratized.space` and `staging.token.place`, that Traefik dispatches by `Host` header, and that Cloudflare Tunnel route tokens are separate from cert-manager Cloudflare DNS credentials. 
- Before/after helper behavior: before reported output included `Hostname: host=staging.token.place`, and after the helper prints `Hostname: staging.token.place` for both positional and `host=` invocation forms. 

### Testing
- Ran repository search to verify edits and references with `rg -n "staging.token.place|staging.democratized.space|one tunnel|Host header|cf-tunnel-route|cloudflared" docs justfile`, which succeeded and showed updated files. 
- Attempted `just cf-tunnel-route staging.token.place` and `just cf-tunnel-route host=staging.token.place` in this execution environment but they could not run because `just` is not installed (error: `just: command not found`). 
- Attempted `pre-commit run --all-files` but it could not run in this environment because `pre-commit` is not installed (error: `pre-commit: command not found`). 
- Recommendation for maintainer verification: run `just cf-tunnel-route staging.token.place` and `just cf-tunnel-route host=staging.token.place` on a machine with `just` installed to confirm the helper now prints `Hostname: staging.token.place`, and run `pre-commit run --all-files` locally or in CI to validate formatting and hooks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c9ba76b8832f85834e9e2fb178cc)