### PR TITLE
Fix cf-tunnel-route arg normalization and clarify multi-app Cloudflare Tunnel docs

### DIFF
--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -77,11 +77,16 @@ For production validation, use the same checks against `https://token.place`.
 
 Cloudflare Tunnel/DNS configuration is external to Helm.
 
+- One tunnel per cluster/environment can serve multiple app hostnames.
 - Route hostnames to Traefik, typically
   `http://traefik.kube-system.svc.cluster.local:80`.
+- Traefik routes traffic to the right Kubernetes Ingress by Host header.
 - Helm chart deployment does **not** create Cloudflare routes.
 - Staging/prod overlays set `ingress.tls.enabled: true` so rendered Kubernetes Ingress includes `spec.tls`.
 - `cert-manager` and a compatible `ClusterIssuer` are assumed to already exist.
+- Keep credentials separate:
+  - Cloudflare Tunnel token (`CF_TUNNEL_TOKEN`) is for `cloudflared` connector auth.
+  - Cloudflare DNS API token (cert-manager) is for DNS-01/TLS and does not create tunnel routes.
 - Configure routes explicitly:
 
 ```bash

--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -260,6 +260,14 @@ return to a clean token-mode state:
   just cf-tunnel-debug
   ```
 
+  In the logs, look for `Updated to new configuration` and confirm your target hostname appears
+  shortly after route changes. A Cloudflare edge `404` before the app Ingress exists is expected:
+  it means the tunnel is connected but Traefik/Ingress/app routing is not ready yet.
+
+  You may also see `cloudflared` warnings that the deployed image is outdated. Treat image upgrades
+  as separate maintenance work; do not block app deployment if the tunnel is connected and routes are
+  functioning.
+
 - Hard reset the deployment/configmap/pods while preserving the `tunnel-token` Secret:
 
   ```bash
@@ -278,15 +286,21 @@ return to a clean token-mode state:
 The installer performs a teardown-and-retry if the first rollout fails, so rerunning the recipes is
 the canonical way to recover a wedged connector without losing the saved token.
 
-## Step 3 – Publish application routes (staging + optional prod redirect host + apex)
+## Step 3 – Publish application routes (one tunnel per env, many hostnames)
 
 Now that the connector is running in the cluster, configure routes from your dspace hostnames to the
 internal Traefik Service.
+
+One Cloudflare tunnel per cluster/environment is enough for multiple apps and hostnames. For example,
+the staging tunnel `dspace-staging-v3` can route both `staging.democratized.space` and
+`staging.token.place` to the same in-cluster Traefik Service. Traefik then forwards requests to the
+correct Kubernetes Ingress by **Host** header.
 
 1. In the tunnel configuration, open the **Public hostnames**, **Application routes**, or
    **Published applications** section.
 2. Add routes/applications:
    - **Hostname**: `staging.democratized.space`
+   - **Hostname**: `staging.token.place` *(token.place staging app on the same tunnel)*
    - **Hostname**: `prod.democratized.space` *(optional legacy redirect host)*
    - **Hostname**: `democratized.space`
    - **Service type**: `HTTP`
@@ -353,3 +367,12 @@ for temporary local development. See
 - After apex promotion, `prod.democratized.space` can be converted to a redirect to
   `https://democratized.space`.
 - The Sugarkube dspace app expects this persistent tunnel setup to be in place.
+
+## Tunnel vs DNS API token (important distinction)
+
+- **Cloudflare Tunnel token** (`CF_TUNNEL_TOKEN`): connector credential from the tunnel dashboard
+  ("Install and run a connector"). Used by `just cf-tunnel-install` to connect `cloudflared`.
+- **Cloudflare DNS API token** (used by cert-manager): separate token for DNS-01 challenges and TLS
+  cert issuance/renewal. This token does not create Cloudflare Tunnel routes.
+
+Keep these credentials separate and scoped to their jobs.

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -102,6 +102,9 @@ Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not m
 typically `http://traefik.kube-system.svc.cluster.local:80`. Production overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
 and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
 
+One tunnel per environment can serve many hostnames. Route each public hostname to Traefik, then
+Traefik dispatches by Host header to the matching Kubernetes Ingress.
+
 ```bash
 just cf-tunnel-route host=token.place
 ```

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -103,9 +103,18 @@ Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not m
 typically `http://traefik.kube-system.svc.cluster.local:80`. Staging overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
 and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
 
+One staging tunnel can serve multiple staging app hostnames. For example, `dspace-staging-v3` can
+route both `staging.democratized.space` and `staging.token.place` to Traefik; Traefik then routes to
+the correct Kubernetes Ingress by Host header. Renaming that tunnel to `sugarkube-staging-v3` is
+optional and can wait until after launch.
+
 ```bash
 just cf-tunnel-route host=staging.token.place
 ```
+
+`just cf-tunnel-route` is a helper for dashboard values; it does not automate route creation.
+Use either `just cf-tunnel-route staging.token.place` or
+`just cf-tunnel-route host=staging.token.place`.
 
 
 ## 0.1.0 release alignment

--- a/justfile
+++ b/justfile
@@ -1068,7 +1068,13 @@ cf-tunnel-route host='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    if [ -z "{{ host }}" ]; then
+    host_input="{{ host }}"
+    host_name="${host_input}"
+    while [ "${host_name#host=}" != "${host_name}" ]; do
+        host_name="${host_name#host=}"
+    done
+
+    if [ -z "${host_name}" ]; then
         echo "Set host=<FQDN> (e.g., dspace-v3.example.com)." >&2
         exit 1
     fi
@@ -1077,8 +1083,11 @@ cf-tunnel-route host='':
 
     printf '%s\n' \
         'Use the Cloudflare dashboard to create a route for:' \
-        "  Hostname: {{ host }}" \
+        "  Hostname: ${host_name}" \
         "  Service URL: http://${svc_fqdn}" \
+        '' \
+        'One tunnel per cluster/environment can serve multiple app hostnames.' \
+        'Route every public hostname to Traefik; Traefik dispatches to the right Ingress by Host header.' \
         '' \
         'Discover Traefik services:' \
         '  kubectl -n kube-system get svc -l app.kubernetes.io/name=traefik' \


### PR DESCRIPTION
### Motivation
- The `cf-tunnel-route` helper printed `host=...` literally when invoked with `host=...`, which is misleading when preparing Cloudflare dashboard routes. 
- Documentation needed clearer guidance that one Cloudflare tunnel per cluster/environment can host many app hostnames, and better `cf-tunnel-debug` triage plus a maintenance note about cloudflared image warnings.

### Description
- Normalize `cf-tunnel-route` inputs in the `justfile` so both `just cf-tunnel-route staging.token.place` and `just cf-tunnel-route host=staging.token.place` print the clean hostname (fixing the `Hostname: host=...` bug). 
- Add helper output text describing the one-tunnel-per-env, many-hostnames model and that Traefik dispatches by Host header. 
- Update `docs/cloudflare_tunnel.md` with a staging example showing `dspace-staging-v3` serving both `staging.democratized.space` and `staging.token.place`, add `cf-tunnel-debug` guidance to look for `Updated to new configuration` and confirm the hostname, and add a maintenance note about cloudflared image warnings. 
- Propagate clarifications into `docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`, and `docs/apps/tokenplace.md`, and add an explicit distinction between the Cloudflare Tunnel token (`CF_TUNNEL_TOKEN`) and the Cloudflare DNS API token (used by cert-manager).

### Testing
- Ran a repository search to verify changes landed with `rg -n "staging.token.place|staging.democratized.space|one tunnel|Host header|cf-tunnel-route|cloudflared" docs justfile`, which succeeded and shows updated references. 
- Attempted `just cf-tunnel-route staging.token.place` and `just cf-tunnel-route host=staging.token.place` but `just` is not available in this execution environment so those commands were not run here. 
- Attempted `pre-commit run --all-files` but `pre-commit` is not available in this execution environment so lint checks were not run here. 
- Recommended verification for reviewers or CI: run `just cf-tunnel-route staging.token.place` and `just cf-tunnel-route host=staging.token.place` to confirm output `Hostname: staging.token.place`, and run `pre-commit run --all-files` locally or in CI to validate formatting and hooks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c9ba76b8832f85834e9e2fb178cc)