### PR TITLE
docs: add token.place staging validation sequence and Cloudflare 403 triage

### DIFF
--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -68,12 +68,20 @@ just tokenplace-oci-deploy env=staging tag="$TOKENPLACE_TAG"
 ```bash
 kubectl -n tokenplace get deploy,po,svc,ingress
 kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+kubectl -n tokenplace get endpoints
 curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/relay/diagnostics | jq .
 curl -fsS https://staging.token.place/
 ```
 
-For production validation, use the same checks against `https://token.place`.
+For production validation, use the same checks against `https://token.place`. Do not use a
+long-running public `/healthz` watch as the primary readiness monitor until the deployed relay is
+known to exempt health and diagnostics endpoints from global API rate limits; prefer Kubernetes
+readiness state (`kubectl -n tokenplace get endpoints`, `kubectl -n tokenplace get deploy,po`) and
+relay logs for continuous monitoring. The staging runbook includes synthetic API v1
+`/api/v1/compute/servers/register` and `/api/v1/compute/servers/poll` commands, but production
+signoff still requires an external desktop/compute-node registration and an E2EE request/response.
 
 ## Cloudflare and ingress model
 

--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -316,6 +316,34 @@ this tunnel/environment and point them to the internal Traefik Service.
 See Cloudflare’s docs for the latest UI steps:
 [Publish an application through Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/get-started/create-remote-tunnel/#publish-an-application).
 
+
+## Cloudflare 403 triage for token.place API v1
+
+When token.place desktop compute-node registration returns HTTP 403 but synthetic `curl`
+register/poll works, first determine whether the request reached the relay. If relay logs do not show
+a matching API v1 `POST`, treat it as a Cloudflare/pre-app rejection rather than an application
+handler failure.
+
+```bash
+kubectl -n tokenplace logs deploy/tokenplace --since=30m | grep -E 'POST .*/api/v1/.*/(register|poll)'
+```
+
+Triage checklist:
+
+1. Capture the failing response headers from the desktop client and record the `cf-ray` value,
+   timestamp, hostname, path, method, and source network.
+2. Search **Cloudflare Security Events** for that `cf-ray` in the `token.place` zone to identify the
+   product/rule that produced the 403: WAF, bot management, security level, access policy, rate
+   limit, or a custom rule.
+3. Compare a passing synthetic request with the failing desktop request: method, path, `Host`,
+   `User-Agent`, `Origin`, `Referer`, `Content-Type`, `Accept`, auth/debug headers, body shape, and
+   whether the desktop sends an `OPTIONS` preflight.
+4. Keep credentials distinct: `CF_TUNNEL_TOKEN` joins the cluster to a remotely-managed Cloudflare
+   Tunnel; cert-manager DNS-01 uses a separate Cloudflare DNS API token with zone permissions. Do not
+   paste either token into desktop settings, docs, or logs.
+5. After changing Cloudflare policy, confirm relay logs now show desktop register/poll `POST` entries
+   and finish validation with a real E2EE request/response through staging.
+
 ## Step 4 – Verify / create DNS records for published hostnames
 
 The hostnames you published (for example, `staging.democratized.space` and `staging.token.place` for
@@ -374,4 +402,4 @@ for temporary local development. See
   `*.cfargotunnel.com` name.
 - After apex promotion, `prod.democratized.space` can be converted to a redirect to
   `https://democratized.space`.
-- The Sugarkube dspace app expects this persistent tunnel setup to be in place. 
+- The Sugarkube dspace app expects this persistent tunnel setup to be in place.

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -109,7 +109,126 @@ kubectl -n tokenplace get ingress tokenplace -o yaml
 curl -vI https://staging.token.place/
 curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/relay/diagnostics | jq .
 ```
+
+### Staging validation sequence
+
+Run the checks in this order after each staging candidate rollout. During the incident that prompted
+this runbook update, basic web/TLS checks and synthetic register/poll both passed, but a public
+`/healthz` watch plus Kubernetes probes exposed that `/healthz` was still covered by the public API
+rate limit and could make readiness look broken. Treat high-frequency public health checks as a
+load/rate-limit test, not as the primary readiness monitor, until the relay release under test is
+known to exempt `/livez`, `/healthz`, metrics, diagnostics, and API v1 compute-node heartbeat routes
+from global API rate limits.
+
+1. **Web/TLS smoke:** confirm Cloudflare, tunnel routing, Traefik, ingress, and certificate wiring.
+
+   ```bash
+   curl -vI https://staging.token.place/
+   curl -fsS https://staging.token.place/
+   ```
+
+2. **Low-frequency public health/diagnostics:** call each endpoint once or on a slow cadence. Do not
+   run a tight `watch curl https://staging.token.place/healthz` loop as the readiness source of truth.
+
+   ```bash
+   curl -fsS https://staging.token.place/livez
+   curl -fsS https://staging.token.place/healthz | jq .
+   curl -fsS https://staging.token.place/relay/diagnostics | jq .
+   ```
+
+3. **Readiness without abusing public health endpoints:** use Kubernetes state and relay logs first,
+   then use public diagnostics sparingly.
+
+   ```bash
+   kubectl -n tokenplace get endpoints
+   kubectl -n tokenplace get deploy,po
+   kubectl -n tokenplace logs deploy/tokenplace --tail=200
+   curl -fsS https://staging.token.place/relay/diagnostics | jq .
+   ```
+
+4. **Synthetic API v1 compute-node register/poll:** register a throwaway debug server and then poll
+   with a bounded long-poll timeout. The debug server is in relay memory only and will age out by its
+   normal lease/TTL; do not use production secrets or a real operator key for this synthetic check.
+
+   ```bash
+   DEBUG_KEY="debug-$(date -u +%Y%m%dT%H%M%SZ)-$(openssl rand -hex 6)"
+   DEBUG_SERVER_ID="sugarkube-staging-${DEBUG_KEY}"
+
+   curl -fsS -X POST https://staging.token.place/api/v1/compute/servers/register \
+     -H 'content-type: application/json' \
+     --data @- <<EOF | jq .
+   {
+     "serverId": "${DEBUG_SERVER_ID}",
+     "debugKey": "${DEBUG_KEY}",
+     "models": ["debug/sugarkube-smoke"],
+     "capacity": 1,
+     "metadata": {
+       "source": "sugarkube-staging-runbook",
+       "environment": "staging"
+     }
+   }
+   EOF
+
+   curl -fsS https://staging.token.place/healthz | jq '.knownServers // .servers // .'
+
+   curl -fsS --max-time 20 -X POST https://staging.token.place/api/v1/compute/servers/poll \
+     -H 'content-type: application/json' \
+     --data @- <<EOF | jq .
+   {
+     "serverId": "${DEBUG_SERVER_ID}",
+     "debugKey": "${DEBUG_KEY}"
+   }
+   EOF
+   ```
+
+   If token.place changes the exact debug payload schema, keep the same validation intent: generate a
+   unique `DEBUG_KEY`, register a synthetic server through the API v1 registration route, confirm
+   `knownServers`/server visibility through health or diagnostics, and poll
+   `/api/v1/compute/servers/poll` with `--max-time 20`.
+
+5. **Desktop compute-node registration:** start the desktop/Tauri compute-node client against
+   `https://staging.token.place`, confirm the desktop reports registered, and confirm relay logs show
+   matching API v1 register/poll `POST` requests.
+
+   ```bash
+   kubectl -n tokenplace logs deploy/tokenplace --tail=200 | grep -E 'POST .*/api/v1/.*/(register|poll)'
+   curl -fsS https://staging.token.place/relay/diagnostics | jq '.knownServers // .servers // .'
+   ```
+
+6. **End-to-end encrypted request/response:** before production promotion, send a real desktop or
+   external compute-node E2EE request through staging and verify the encrypted response returns to the
+   requesting client. Synthetic register/poll proves the relay API path works; production signoff
+   additionally requires an external compute-node registration plus a successful E2EE request/response.
+
+### Desktop HTTP 403 / pre-app rejection triage
+
+During staging, the desktop client saw HTTP 403 while synthetic `curl` register/poll succeeded, and
+relay logs did not contain corresponding desktop register/poll `POST` lines. That combination means
+Cloudflare or another pre-app layer likely rejected the request before it reached the relay. Triage in
+this order:
+
+1. Capture the desktop response headers and note the `cf-ray` value, timestamp, method, URL, and
+   source IP/network.
+2. Check relay logs for a matching `POST`. If the relay log entry is absent, debug Cloudflare before
+   changing the app.
+
+   ```bash
+   kubectl -n tokenplace logs deploy/tokenplace --since=30m | grep -E 'POST .*/api/v1/.*/(register|poll)'
+   ```
+
+3. Use the `cf-ray` value in **Cloudflare Security Events** for the `token.place` zone to identify the
+   blocking product/rule: WAF, bot management, security level, access policy, rate limit, or custom
+   rule.
+4. Compare a passing synthetic request with the failing desktop request: method, path, `Host`,
+   `User-Agent`, `Origin`, `Referer`, `Content-Type`, `Accept`, auth/debug headers, request body
+   shape, and whether the desktop performs an `OPTIONS` preflight.
+5. Confirm tunnel and DNS credentials are not mixed up. `CF_TUNNEL_TOKEN` is the token-only
+   Cloudflare Tunnel connector credential; cert-manager DNS-01 uses a separate Cloudflare DNS API
+   token. Neither token should be pasted into desktop settings or committed to Sugarkube docs.
+6. Once Cloudflare allows the desktop request, rerun the desktop registration and confirm relay logs
+   now show register/poll `POST` entries plus a successful E2EE request/response.
 
 ## Rollback
 
@@ -167,6 +286,12 @@ Cloudflare DNS API token scope for cert-manager:
 - `Zone -> DNS -> Edit`
 - `Zone -> Zone -> Read`
 - Include only required zones (at minimum `token.place`; include `democratized.space` too if the same token handles shared DSPACE cert issuance).
+
+If cert-manager logs cleanup errors after issuance, gate release on the Kubernetes Certificate state,
+not on noisy solver cleanup alone: `Ready=True` on the target Certificate means the usable TLS Secret
+was issued. Cleanup failures still deserve follow-up because they can indicate the DNS API token lacks
+`Zone -> Zone -> Read`, the token is scoped to the wrong zone, or Cloudflare zone/resolver lookup is
+behaving unexpectedly.
 
 Validation commands:
 


### PR DESCRIPTION
### Motivation
- Codify the actual staging validation steps discovered during testing so signoff covers web/TLS, public health/diagnostics, synthetic API v1 register/poll, desktop registration, and E2EE verification.
- Record observed failure modes from staging: public `/healthz` being subject to global API rate limits, desktop HTTP 403s that never reach the relay (Cloudflare/pre-app), and synthetic curl register/poll success masking pre-app rejections.

### Description
- Extended `docs/k3s-tokenplace-staging.md` with a new "Staging validation sequence" that enumerates: web/TLS smoke checks, low-frequency `/livez`/`/healthz`/`/relay/diagnostics` calls, Kubernetes readiness checks (`kubectl -n tokenplace get endpoints, deploy,po`), a synthetic API v1 compute-node registration (`/api/v1/compute/servers/register`) and bounded poll (`/api/v1/compute/servers/poll` with `--max-time 20`), desktop compute-node registration verification, and an E2EE request/response signoff requirement before production promotion.
- Warned against using long-running public `/healthz` watches as the primary readiness monitor until health/diagnostics routes are confirmed exempt from rate limits, and added recommended commands to inspect readiness without abusing public endpoints (for example `kubectl -n tokenplace get endpoints`, `kubectl -n tokenplace get deploy,po`, and relay logs).
- Added a Cloudflare 403 triage section to `docs/cloudflare_tunnel.md` describing how to correlate missing relay log entries, capture the desktop response `cf-ray`, inspect Cloudflare Security Events, compare request headers between synthetic and desktop requests, and remind operators to keep `CF_TUNNEL_TOKEN` (tunnel connector) distinct from the Cloudflare DNS API token used by cert-manager.
- Updated `docs/apps/tokenplace.md` validation block to include `kubectl -n tokenplace get endpoints`, `relay/diagnostics`, and the caution about public health watches.
- Added guidance about cert-manager challenge/cleanup noise: gate release on the Certificate `Ready=True` state and follow up on cleanup errors as they can indicate DNS token/zone permission or resolver issues.

### Testing
- Ran content searches to verify coverage: `rg -n "synthetic|register|servers/poll|HTTP 403|cf-ray|rate limit|healthz|knownServers|relay/diagnostics|Cloudflare Security Events" docs` (matches present in the updated docs).
- Verified diffs and local secret scan: `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` (no secrets detected and no diff-check errors from these changes).
- Link validation: `linkchecker --no-warnings README.md docs/` succeeded with 0 errors.
- Spelling check: `pyspelling -c .spellcheck.yaml` was attempted but blocked in the environment due to a missing `aspell` binary.
- Project checks: `bash scripts/checks.sh` and `python3 -m pre_commit run --all-files` were attempted and surfaced pre-existing unrelated lint/YAML/template issues in the repository (these are not caused by this PR and unrelated files were left unchanged by this PR).

Notes and residual risks: the changes are documentation-only and do not modify application code or add secrets; the environment used to run verification lacked `aspell` and the repo contains pre-existing lint/template issues that prevent a fully green `pre-commit` run here, but those failures are unrelated to the documentation edits in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1877619ee0832fb05af9f72c1cd201)