### PR TITLE
docs: add token.place staging validation and Cloudflare 403 triage

### DIFF
--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -70,10 +70,17 @@ kubectl -n tokenplace get deploy,po,svc,ingress
 kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
 curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/relay/diagnostics
 curl -fsS https://staging.token.place/
 ```
 
-For production validation, use the same checks against `https://token.place`.
+For production validation, use the same checks against `https://token.place`. Do not use a
+long-running public `/healthz` watch as the primary readiness signal until health, liveness, metrics,
+diagnostics, and API v1 heartbeat routes are confirmed exempt from global API rate limits; prefer
+`kubectl -n tokenplace get endpoints`, `kubectl -n tokenplace get deploy,po`, relay logs, and
+low-frequency diagnostics curls. Staging signoff also includes synthetic API v1
+`/api/v1/servers/register` and `/api/v1/servers/poll` checks plus external desktop/server
+compute-node registration and an E2EE request/response.
 
 ## Cloudflare and ingress model
 

--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -294,6 +294,23 @@ return to a clean token-mode state:
 The installer performs a teardown-and-retry if the first rollout fails, so rerunning the recipes is
 the canonical way to recover a wedged connector without losing the saved token.
 
+### HTTP 403 before the app sees a request
+
+For token.place staging, synthetic API v1 register/poll curls succeeded while a desktop compute node
+reported HTTP 403 and relay logs showed no matching `POST /api/v1/servers/register` or
+`POST /api/v1/servers/poll`. Use that pattern to separate Cloudflare/pre-app rejection from relay
+application failures:
+
+1. Check the application logs first. If the relay logged the POST, debug the app response; if it did
+   not, debug Cloudflare/Tunnel/WAF/Access before changing relay code.
+2. Capture the `cf-ray` response header from the failing client and search **Cloudflare Security
+   Events** for that Ray ID, client IP, path, user agent, and rule action.
+3. Compare headers between a successful synthetic curl and the desktop request, especially `Host`,
+   `Origin`, `User-Agent`, `Content-Type`, auth/debug headers, and exact API v1 path.
+4. Keep credential types separate: the `CF_TUNNEL_TOKEN` connects `cloudflared` to the remotely
+   managed tunnel, while the Cloudflare DNS API token is only for cert-manager DNS-01. Neither value
+   should appear in desktop `knownServers` config, application headers, or logs.
+
 ## Step 3 – Publish application routes for one environment tunnel
 
 Now that the connector is running in the cluster, configure routes for the hostnames that belong to
@@ -374,4 +391,4 @@ for temporary local development. See
   `*.cfargotunnel.com` name.
 - After apex promotion, `prod.democratized.space` can be converted to a redirect to
   `https://democratized.space`.
-- The Sugarkube dspace app expects this persistent tunnel setup to be in place. 
+- The Sugarkube dspace app expects this persistent tunnel setup to be in place.

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -108,7 +108,14 @@ kubectl -n tokenplace get ingress tokenplace -o yaml
 curl -vI https://token.place/
 curl -fsS https://token.place/livez
 curl -fsS https://token.place/healthz
+curl -fsS https://token.place/relay/diagnostics
 ```
+
+Do not promote solely on web/TLS or synthetic checks. Production signoff requires an external
+compute node to register against `https://token.place` and complete an E2EE request/response through
+the relay. Avoid long-running public `/healthz` watches as readiness monitors until health endpoints
+and API v1 heartbeat routes are confirmed exempt from global API rate limits; prefer Kubernetes
+endpoints/deployment state, relay logs, and low-frequency diagnostics checks.
 
 ## Rollback options
 

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -109,7 +109,97 @@ kubectl -n tokenplace get ingress tokenplace -o yaml
 curl -vI https://staging.token.place/
 curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/relay/diagnostics
 ```
+
+### Staging signoff sequence
+
+Run these checks in order after every staging deploy. Basic web/TLS checks are necessary but not
+sufficient; real production signoff requires an external compute node to register through the
+desktop/server client and complete an end-to-end encrypted (E2EE) request/response through the
+relay.
+
+1. **Web/TLS smoke tests:**
+
+   ```bash
+   curl -vI https://staging.token.place/
+   curl -fsS https://staging.token.place/livez
+   curl -fsS https://staging.token.place/healthz
+   curl -fsS https://staging.token.place/relay/diagnostics
+   ```
+
+2. **Inspect readiness without hammering public health endpoints:**
+
+   ```bash
+   kubectl -n tokenplace get endpoints
+   kubectl -n tokenplace get deploy,po
+   kubectl -n tokenplace logs deploy/tokenplace --tail=200
+   curl -fsS https://staging.token.place/relay/diagnostics
+   ```
+
+   Avoid long-running public `/healthz` watches such as `watch curl .../healthz` as a primary
+   readiness monitor until `/healthz`, `/livez`, metrics, diagnostics, and API v1 relay heartbeat
+   routes are confirmed exempt from global API rate limits. During staging, a public `/healthz` watch
+   combined with Kubernetes probes consumed rate-limit budget, caused `429` responses, and made
+   readiness appear unstable even though web/TLS and synthetic API v1 checks were otherwise healthy.
+
+3. **Synthetic API v1 compute-node registration:**
+
+   ```bash
+   DEBUG_KEY="debug-$(date -u +%Y%m%dT%H%M%SZ)-$(openssl rand -hex 8)"
+   export DEBUG_KEY
+
+   curl -fsS -X POST https://staging.token.place/api/v1/servers/register \
+     -H 'content-type: application/json' \
+     --data "{\"serverId\":\"$DEBUG_KEY\",\"publicKey\":\"$DEBUG_KEY\",\"url\":\"debug://$DEBUG_KEY\",\"capacity\":1}"
+   ```
+
+   The debug server is intentionally synthetic and will age out by the relay lease/TTL. Do not reuse
+   the generated `DEBUG_KEY` as a credential.
+
+4. **Confirm registration appears in health output, then poll with a bounded wait:**
+
+   ```bash
+   curl -fsS https://staging.token.place/healthz | jq --arg key "$DEBUG_KEY" '.knownServers? // .servers? // . | tostring | contains($key)'
+
+   curl -fsS --max-time 20 -X POST https://staging.token.place/api/v1/servers/poll \
+     -H 'content-type: application/json' \
+     --data "{\"serverId\":\"$DEBUG_KEY\"}"
+   ```
+
+   A successful empty/no-work poll still validates that the API v1 registration/poll route reaches
+   the relay. Keep `--max-time 20` so a quiet queue cannot hang the runbook.
+
+5. **Desktop compute-node registration:** point the desktop client at
+   `https://staging.token.place`, verify its staging `knownServers`/relay configuration is not using
+   a production URL, and confirm relay logs show the corresponding API v1 `register` or
+   `servers/poll` POST.
+
+6. **E2EE request/response:** submit a real client request to the externally registered compute
+   node and verify the encrypted response returns through staging. The relay must remain blind to
+   plaintext; use only safe routing metadata and ciphertext-level diagnostics in logs.
+
+### Desktop HTTP 403 / pre-app rejection triage
+
+If the desktop client reports HTTP 403 while synthetic `curl` registration/poll succeeds, determine
+whether the request reached the relay before changing application code:
+
+1. Check relay logs for matching desktop POSTs around the failure time:
+
+   ```bash
+   kubectl -n tokenplace logs deploy/tokenplace --since=15m | grep -E 'api/v1|register|servers/poll|403|cf-ray'
+   ```
+
+2. If no matching POST appears, treat the 403 as a pre-app rejection. Capture the `cf-ray` response
+   header from the desktop failure, then inspect **Cloudflare Security Events** for that Ray ID, the
+   client IP, and the user agent.
+3. Compare a successful synthetic curl request and the desktop request headers: method, path
+   (`/api/v1/servers/register` or `/api/v1/servers/poll`), `Host`, `Origin`, `User-Agent`,
+   `Content-Type`, auth/debug headers, and any Cloudflare Access or WAF-triggering headers.
+4. Confirm Cloudflare Tunnel credentials are not being confused with DNS credentials.
+   `CF_TUNNEL_TOKEN` is the connector token for the tunnel route; `CF_DNS_API_TOKEN` is the separate
+   Cloudflare DNS API token used by cert-manager DNS-01. Neither token belongs in desktop client
+   configuration or logs.
 
 ## Rollback
 
@@ -177,6 +267,19 @@ kubectl get certificate --all-namespaces
 kubectl -n cert-manager get secret cloudflare-api-token
 kubectl -n cert-manager logs deploy/cert-manager --tail=100
 ```
+
+For release gating, require the relevant `Certificate` to report `Ready=True`:
+
+```bash
+kubectl -n tokenplace get certificate
+kubectl -n tokenplace describe certificate tokenplace-staging-tls
+```
+
+cert-manager may log DNS-01 challenge cleanup errors after successful issuance. Treat
+`Certificate Ready=True` and a valid served certificate as the staging release gate, but investigate
+cleanup errors before production promotion: they can indicate the Cloudflare DNS API token is missing
+`Zone -> Zone -> Read`, the token is scoped to the wrong zone, or cert-manager/Cloudflare had a
+resolver or zone-lookup mismatch while deleting the temporary `_acme-challenge` record.
 
 > ⚠️ During early staging we used manual Helm `--set env.XDG_CACHE_HOME=/tmp --set env.XDG_CONFIG_HOME=/tmp --set env.XDG_DATA_HOME=/tmp` overrides to pass read-only filesystem startup checks. Remove those manual overrides now that chart defaults own the XDG `/tmp` paths.
 


### PR DESCRIPTION
### Motivation
- Capture the concrete staging validation sequence and the failure modes observed during the token.place staging run (public `/healthz` rate-limits, desktop HTTP 403 pre-app rejections, and synthetic API v1 register/poll behavior). 
- Prevent accidental readiness/monitoring regressions by warning operators not to use long-running public `/healthz` watches until health/diagnostic endpoints are exempt from global API rate limits. 
- Ensure production promotion requires an external compute-node registration and end-to-end encrypted (E2EE) request/response verification, not just synthetic or TLS checks. 

### Description
- Added a staged signoff sequence to `docs/k3s-tokenplace-staging.md` with ordered checks and runnable commands including web/TLS smoke tests, `/livez`/`/healthz`/`/relay/diagnostics`, synthetic API v1 `servers/register` (using a generated `DEBUG_KEY`) and bounded `servers/poll` with `--max-time 20`, desktop compute-node registration, and E2EE request/response validation. 
- Documented the `/healthz` rate-limit trap and recommended lower-frequency, cluster-local readiness inspections such as `kubectl -n tokenplace get endpoints`, `kubectl -n tokenplace get deploy,po`, and tailing relay logs. 
- Added Cloudflare 403 triage guidance to `docs/cloudflare_tunnel.md` and the staging runbook explaining how to distinguish pre-app rejections from relay failures (check relay logs for POSTs, capture `cf-ray`, inspect Cloudflare Security Events, compare request headers between synthetic curl and desktop clients, and avoid confusing `CF_TUNNEL_TOKEN` with Cloudflare DNS API tokens). 
- Added cert-manager troubleshooting notes to `docs/k3s-tokenplace-staging.md` instructing that `Certificate Ready=True` is the staging release gate while investigating DNS-01 cleanup errors (token zone scope, `Zone -> Zone -> Read`, or resolver/zone lookup mismatches). 
- Mirrored the diagnostics and health-endpoint recommendations into `docs/apps/tokenplace.md` and `docs/k3s-tokenplace-prod.md` so staging/prod/app runbooks remain aligned. 

Files changed: `docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`, `docs/apps/tokenplace.md`, `docs/cloudflare_tunnel.md`.

### Testing
- Searched docs for keywords to verify coverage with `rg -n "synthetic|register|servers/poll|HTTP 403|cf-ray|rate limit|healthz|knownServers|relay/diagnostics|Cloudflare Security Events" docs` and found the new guidance across the expected files (PASS). 
- Ran the docs spellcheck with `pyspelling -c .spellcheck.yaml` which completed successfully (PASS). 
- Ran link validation with `linkchecker --no-warnings README.md docs/` which reported 0 errors (PASS). 
- Attempted repository checks via `python3 -m pre_commit run --all-files` and `bash scripts/checks.sh`; these surfaced pre-existing repository issues outside this docs patch (hooks auto-fixed trailing whitespace and end-of-file issues across many unrelated files, `check-yaml` failed on multi-document Helm/YAML templates, and flake8 reported E501/E303 style problems in scripts/tests), so the pre-commit run did not pass for the whole repo (EXPECTED/FAIL - unrelated to this docs-only change). 

Residual notes: the commit was created as `docs: add token.place staging validation runbook`; no secrets were added; follow-up work may include exempting health/diagnostic endpoints from global rate limits and addressing the unrelated repo lint/YAML issues flagged by the project pre-commit checks before a green CI run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1877619ee0832fb05af9f72c1cd201)