### PR TITLE
docs(token.place): add staging validation checklist, synthetic API v1 register/poll, and Cloudflare 403 triage

### DIFF
--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -70,10 +70,17 @@ kubectl -n tokenplace get deploy,po,svc,ingress
 kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
 curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/relay/diagnostics
 curl -fsS https://staging.token.place/
 ```
 
-For production validation, use the same checks against `https://token.place`.
+For production validation, use the same checks against `https://token.place`. Avoid long-running
+public `/healthz` watches as readiness monitors until health, liveness, metrics, diagnostics, and
+API v1 compute-node heartbeat routes are confirmed exempt from public API rate limits; prefer
+`kubectl -n tokenplace get endpoints`, `kubectl -n tokenplace get deploy,po`, relay logs, and
+low-frequency diagnostics curls for operational readiness. Staging/prod signoff also requires
+synthetic API v1 register/poll, an external desktop or compute-node registration, and an E2EE
+request/response through the relay; see the staging runbook for the full sequence and curl payloads.
 
 ## Cloudflare and ingress model
 

--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -258,6 +258,38 @@ requests to your mapped hostnames (for example `staging.democratized.space`,
 `staging.token.place`, optional `prod.democratized.space` redirect host, and `democratized.space`)
 reach Traefik.
 
+### If an app client sees HTTP 403 before the app logs it
+
+For token.place desktop compute-node registration, staging showed a useful split-brain symptom:
+synthetic curl against `/api/v1/relay/servers/register` and `/api/v1/relay/servers/poll` succeeded,
+but the desktop client received HTTP 403 and relay logs did not show matching POSTs. Treat that as
+a Cloudflare/pre-app rejection until proven otherwise.
+
+Triage sequence:
+
+1. Capture the failing client timestamp, hostname, path, response status, and `cf-ray` response
+   header.
+2. Check the application logs for a matching POST. For token.place:
+
+   ```bash
+   kubectl -n tokenplace logs deploy/tokenplace --since=30m --tail=500 | \
+     grep -E 'api/v1/relay/servers/(register|poll)|server\.(registered|reregister|heartbeat)'
+   ```
+
+3. If the app logs are silent, open **Cloudflare Security Events** and search by `cf-ray`, client IP,
+   hostname, path, and user agent to find the WAF, bot, access, or firewall rule that generated the
+   403.
+4. Compare a successful synthetic curl with the failing desktop request: method, URL path, host,
+   `Content-Type`, `User-Agent`, `Origin`, auth headers, and whether the desktop is sending extra
+   headers that match a Cloudflare rule.
+5. Keep Cloudflare credentials distinct: `CF_TUNNEL_TOKEN` is the connector token for the tunnel
+   pod, while the Cloudflare DNS API token is used by cert-manager DNS-01. Neither one is the
+   token.place relay server registration token.
+
+If a matching app log exists, debug the application response. If no app log exists and Cloudflare
+has a Security Event for the same `cf-ray`, fix the Cloudflare rule or client headers before
+changing Kubernetes or token.place code.
+
 ### Recovery and reset
 
 If rollout gets stuck (CrashLoopBackOff, old ReplicaSets, etc.), use the built-in teardown helpers to
@@ -374,4 +406,4 @@ for temporary local development. See
   `*.cfargotunnel.com` name.
 - After apex promotion, `prod.democratized.space` can be converted to a redirect to
   `https://democratized.space`.
-- The Sugarkube dspace app expects this persistent tunnel setup to be in place. 
+- The Sugarkube dspace app expects this persistent tunnel setup to be in place.

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -161,6 +161,12 @@ Do not reuse the tunnel token (`CF_TUNNEL_TOKEN`) for DNS-01. cert-manager needs
 - `Zone -> Zone -> Read`
 - specific required zones (`token.place`, and `democratized.space` if shared issuance is in scope).
 
+For production promotion, the cert-manager release gate is the Certificate condition: proceed only
+when the relevant Certificate is `Ready=True`. Challenge cleanup errors after successful issuance do
+not invalidate an already-ready certificate, but they should be investigated because they often mean
+the DNS API token lacks `Zone -> Zone -> Read`, is scoped to the wrong Cloudflare zone, or cert-manager
+is hitting resolver/zone lookup ambiguity during cleanup.
+
 ## Troubleshooting
 
 GHCR auth/chart checks:

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -34,6 +34,10 @@ helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
 
 ## Promotion after staging sign-off
 
+Production promotion requires an external desktop or compute-node registration plus a successful
+E2EE request/response; Certificate `Ready=True`, web/TLS checks, or synthetic register/poll alone
+are not sufficient signoff.
+
 ```bash
 TOKENPLACE_TAG=v0.1.0 # use final release tag after token.place Git tag push
 just tokenplace-oci-promote-prod tag="$TOKENPLACE_TAG"

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -109,7 +109,107 @@ kubectl -n tokenplace get ingress tokenplace -o yaml
 curl -vI https://staging.token.place/
 curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/relay/diagnostics
 ```
+
+### Staging sign-off sequence
+
+Run the checks in this order so each layer has a clear owner before moving on to real
+external compute-node traffic:
+
+1. **Web/TLS:** confirm Cloudflare, Traefik, Ingress, and cert-manager serve the staging host.
+2. **Liveness/readiness:** call `/livez`, `/healthz`, and `/relay/diagnostics` once or at low
+   frequency. Do **not** use a long-running public `/healthz` watch as the primary readiness
+   monitor until token.place confirms health, liveness, metrics, diagnostics, and API v1
+   compute-node heartbeat routes are exempt from global public API rate limits. In staging, a
+   public `/healthz` watch plus kube-probes showed that rate-limited health checks can distort
+   readiness and create false rollout failures.
+3. **Synthetic API v1 register:** register a throwaway compute-node key against
+   `/api/v1/relay/servers/register`.
+4. **Synthetic API v1 poll:** poll `/api/v1/relay/servers/poll` with `--max-time 20` to verify the
+   long-poll path returns either queued encrypted work or a healthy no-work response.
+5. **Desktop compute-node registration:** start the packaged desktop/compute node against
+   `https://staging.token.place` and confirm the relay logs show matching API v1 register/poll
+   POSTs for that node.
+6. **E2EE request/response:** submit a real encrypted request through the staging client and verify
+   an encrypted response round trip. Synthetic register/poll is necessary, but real production
+   signoff requires an external compute-node registration and an E2EE request/response.
+
+Use Kubernetes state and relay logs for readiness instead of hammering public health endpoints:
+
+```bash
+kubectl -n tokenplace get endpoints
+kubectl -n tokenplace get deploy,po
+kubectl -n tokenplace logs deploy/tokenplace --since=15m --tail=200
+curl -fsS https://staging.token.place/relay/diagnostics
+```
+
+Keep the public diagnostics curl low-frequency (for example, one manual call during validation or
+one scheduled check every few minutes) so the check itself does not trip public API rate-limit traps.
+
+### Synthetic API v1 compute-node register/poll
+
+This synthetic test proves the relay can accept an API v1 compute-node heartbeat without requiring
+a desktop package or GPU host. It does not prove desktop packaging, request routing, or E2EE.
+
+```bash
+BASE_URL=https://staging.token.place
+DEBUG_KEY="debug-$(date -u +%Y%m%dT%H%M%SZ)-$(openssl rand -hex 8)"
+
+# If the relay requires compute-node registration auth, populate RELAY_SERVER_CREDENTIAL
+# from your secret manager before running this block. Do not paste real secrets
+# into shell history, docs, screenshots, or PRs.
+
+RELAY_AUTH_HEADER_NAME="X-Relay-Server-Token"
+AUTH_HEADER=()
+if [ -n "${RELAY_SERVER_CREDENTIAL:-}" ]; then
+  AUTH_HEADER=(-H "${RELAY_AUTH_HEADER_NAME}: ${RELAY_SERVER_CREDENTIAL}")
+fi
+
+curl -fsS -X POST "${BASE_URL}/api/v1/relay/servers/register" \
+  -H 'Content-Type: application/json' \
+  "${AUTH_HEADER[@]}" \
+  --data "{\"server_public_key\":\"${DEBUG_KEY}\"}" | jq .
+
+curl -fsS "${BASE_URL}/healthz" | jq '{status, knownServers, registeredServers}'
+
+curl -fsS --max-time 20 -X POST "${BASE_URL}/api/v1/relay/servers/poll" \
+  -H 'Content-Type: application/json' \
+  "${AUTH_HEADER[@]}" \
+  --data "{\"server_public_key\":\"${DEBUG_KEY}\"}" | jq .
+```
+
+Expected result: register returns wait hints, `/healthz` reports `knownServers` increased while the
+lease is fresh, and poll returns either encrypted work or a `No requests available` response. The
+debug server is ephemeral and will age out automatically after the relay lease if it is not
+refreshed.
+
+### Desktop HTTP 403 / pre-app rejection triage
+
+If the desktop compute-node reports HTTP 403 but synthetic curl succeeds, determine whether the
+request reached Flask/Gunicorn or was rejected before the app:
+
+1. Capture the desktop failure timestamp, request path, response status, and Cloudflare `cf-ray`
+   header from the desktop diagnostics or HTTP trace.
+2. Check relay logs for matching API v1 POSTs around that timestamp:
+
+   ```bash
+   kubectl -n tokenplace logs deploy/tokenplace --since=30m --tail=500 | \
+     grep -E 'api/v1/relay/servers/(register|poll)|server\.(registered|reregister|heartbeat)'
+   ```
+
+3. If there is no corresponding relay log entry, treat it as a Cloudflare/pre-app rejection and
+   search **Cloudflare Security Events** for the `cf-ray` value, client IP, host, path, and user
+   agent.
+4. Compare synthetic curl and desktop request headers: method, host, path, `Content-Type`,
+   `User-Agent`, `Origin`, any desktop-specific headers, and whether `X-Relay-Server-Token` is
+   present when required.
+5. Confirm credentials are not mixed up: `CF_TUNNEL_TOKEN` connects the Cloudflare Tunnel connector
+   to the dashboard tunnel, while the Cloudflare DNS API token is only for cert-manager DNS-01.
+   Neither token should be sent as the API v1 relay server registration token.
+
+A 403 with no relay log line means the application probably never saw the POST. A 403 with a relay
+log line means inspect token.place auth/rate-limit handling and the exact response body.
 
 ## Rollback
 
@@ -167,6 +267,12 @@ Cloudflare DNS API token scope for cert-manager:
 - `Zone -> DNS -> Edit`
 - `Zone -> Zone -> Read`
 - Include only required zones (at minimum `token.place`; include `democratized.space` too if the same token handles shared DSPACE cert issuance).
+
+If cert-manager logs show challenge cleanup errors after a certificate is already issued, use the
+Certificate condition as the release gate: `Ready=True` means TLS issuance succeeded for rollout
+purposes. Cleanup errors are still worth fixing because they usually point to a Cloudflare DNS API
+token without `Zone -> Zone -> Read`, a token scoped to the wrong zone, or resolver/zone lookup
+weirdness that prevents cert-manager from finding the correct Cloudflare zone during cleanup.
 
 Validation commands:
 

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -164,6 +164,7 @@ trap 'rm -rf "${KEY_DIR}"' EXIT
 openssl genpkey -algorithm Ed25519 -out "${KEY_DIR}/server.key" >/dev/null 2>&1
 openssl pkey -in "${KEY_DIR}/server.key" -pubout -out "${KEY_DIR}/server.pub" >/dev/null 2>&1
 SERVER_PUBLIC_KEY="${SYNTHETIC_SERVER_PUBLIC_KEY:-$(cat "${KEY_DIR}/server.pub")}"
+DEBUG_KEY="${SERVER_PUBLIC_KEY}"
 REGISTER_BODY="$(jq -n --arg server_public_key "${SERVER_PUBLIC_KEY}" \
   '{server_public_key: $server_public_key}')"
 
@@ -182,7 +183,8 @@ curl -fsS -X POST "${BASE_URL}/api/v1/relay/servers/register" \
   "${AUTH_HEADER[@]}" \
   --data "${REGISTER_BODY}" | jq .
 
-curl -fsS "${BASE_URL}/healthz" | jq '{status, knownServers, registeredServers}'
+curl -fsS "${BASE_URL}/relay/diagnostics" | jq -e --arg key "${DEBUG_KEY}" \
+  '(.registered_compute_nodes // []) | any(.server_public_key == $key)'
 
 # Keep this higher than the relay's server-side long-poll hold. The default 65s value
 # leaves buffer for relays that hold empty polls for up to one minute before returning
@@ -194,10 +196,11 @@ curl -fsS --max-time "${POLL_MAX_TIME}" -X POST "${BASE_URL}/api/v1/relay/server
   --data "${REGISTER_BODY}" | jq .
 ```
 
-Expected result: register returns wait hints, `/healthz` reports `knownServers` increased while the
-lease is fresh, and poll returns either encrypted work or a `No requests available` response before
-`POLL_MAX_TIME` elapses. The synthetic server is ephemeral and will age out automatically after the
-relay lease if it is not refreshed.
+Expected result: register returns wait hints, `/relay/diagnostics` visibly includes the just-created
+`server_public_key` while the lease is fresh, and poll returns either encrypted work or a
+`No requests available` response before `POLL_MAX_TIME` elapses. Treat a missing debug key as a
+failed synthetic registration even if register returned 2xx. The synthetic server is ephemeral and
+will age out automatically after the relay lease if it is not refreshed.
 
 ### Desktop HTTP 403 / pre-app rejection triage
 

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -126,8 +126,9 @@ external compute-node traffic:
    readiness and create false rollout failures.
 3. **Synthetic API v1 register:** register a throwaway compute-node key against
    `/api/v1/relay/servers/register`.
-4. **Synthetic API v1 poll:** poll `/api/v1/relay/servers/poll` with `--max-time 20` to verify the
-   long-poll path returns either queued encrypted work or a healthy no-work response.
+4. **Synthetic API v1 poll:** poll `/api/v1/relay/servers/poll` with a client timeout that
+   exceeds the relay's server-side long-poll hold plus a small buffer, verifying the path returns
+   either queued encrypted work or a healthy no-work response instead of a client-side timeout.
 5. **Desktop compute-node registration:** start the packaged desktop/compute node against
    `https://staging.token.place` and confirm the relay logs show matching API v1 register/poll
    POSTs for that node.
@@ -154,7 +155,17 @@ a desktop package or GPU host. It does not prove desktop packaging, request rout
 
 ```bash
 BASE_URL=https://staging.token.place
-DEBUG_KEY="debug-$(date -u +%Y%m%dT%H%M%SZ)-$(openssl rand -hex 8)"
+KEY_DIR="$(mktemp -d)"
+trap 'rm -rf "${KEY_DIR}"' EXIT
+
+# Generate real public-key material for the synthetic compute node instead of a debug string.
+# If the desktop client emits a different accepted format, set SYNTHETIC_SERVER_PUBLIC_KEY
+# to a non-secret public key copied from a disposable desktop test node.
+openssl genpkey -algorithm Ed25519 -out "${KEY_DIR}/server.key" >/dev/null 2>&1
+openssl pkey -in "${KEY_DIR}/server.key" -pubout -out "${KEY_DIR}/server.pub" >/dev/null 2>&1
+SERVER_PUBLIC_KEY="${SYNTHETIC_SERVER_PUBLIC_KEY:-$(cat "${KEY_DIR}/server.pub")}"
+REGISTER_BODY="$(jq -n --arg server_public_key "${SERVER_PUBLIC_KEY}" \
+  '{server_public_key: $server_public_key}')"
 
 # If the relay requires compute-node registration auth, populate RELAY_SERVER_CREDENTIAL
 # from your secret manager before running this block. Do not paste real secrets
@@ -169,20 +180,24 @@ fi
 curl -fsS -X POST "${BASE_URL}/api/v1/relay/servers/register" \
   -H 'Content-Type: application/json' \
   "${AUTH_HEADER[@]}" \
-  --data "{\"server_public_key\":\"${DEBUG_KEY}\"}" | jq .
+  --data "${REGISTER_BODY}" | jq .
 
 curl -fsS "${BASE_URL}/healthz" | jq '{status, knownServers, registeredServers}'
 
-curl -fsS --max-time 20 -X POST "${BASE_URL}/api/v1/relay/servers/poll" \
+# Keep this higher than the relay's server-side long-poll hold. The default 65s value
+# leaves buffer for relays that hold empty polls for up to one minute before returning
+# the healthy no-work response; raise it if staging is configured with a longer hold.
+POLL_MAX_TIME="${POLL_MAX_TIME:-65}"
+curl -fsS --max-time "${POLL_MAX_TIME}" -X POST "${BASE_URL}/api/v1/relay/servers/poll" \
   -H 'Content-Type: application/json' \
   "${AUTH_HEADER[@]}" \
-  --data "{\"server_public_key\":\"${DEBUG_KEY}\"}" | jq .
+  --data "${REGISTER_BODY}" | jq .
 ```
 
 Expected result: register returns wait hints, `/healthz` reports `knownServers` increased while the
-lease is fresh, and poll returns either encrypted work or a `No requests available` response. The
-debug server is ephemeral and will age out automatically after the relay lease if it is not
-refreshed.
+lease is fresh, and poll returns either encrypted work or a `No requests available` response before
+`POLL_MAX_TIME` elapses. The synthetic server is ephemeral and will age out automatically after the
+relay lease if it is not refreshed.
 
 ### Desktop HTTP 403 / pre-app rejection triage
 


### PR DESCRIPTION
### Motivation
- Capture the actual staging validation sequence and failure modes observed while testing token.place (public `/healthz` rate-limit/readiness distortion, desktop HTTP 403 with no relay POSTs, and a successful synthetic register/poll). 
- Provide an operator-friendly sign-off sequence that proves the relay accepts API v1 compute-node heartbeats before promoting to production. 
- Give clear triage steps for Cloudflare / pre-app 403s and guidance for cert-manager challenge cleanup errors so teams can diagnose without exposing secrets.

### Description
- Inserted a staged sign-off checklist into `docs/k3s-tokenplace-staging.md` that sequences: web/TLS checks, `/livez` + `/healthz` + `/relay/diagnostics`, synthetic API v1 register, synthetic API v1 poll (with `--max-time 20`), desktop compute-node registration, and E2EE request/response verification. 
- Added concrete curl examples and a short ephemeral `DEBUG_KEY` workflow (with safe handling notes and an opt-in `RELAY_SERVER_CREDENTIAL` environment variable) to validate `/api/v1/relay/servers/register` and `/api/v1/relay/servers/poll`. 
- Added Cloudflare pre-app HTTP 403 triage to `docs/cloudflare_tunnel.md` and staging runbook guidance that instructs operators to check relay logs for `api/v1/relay/servers/(register|poll)`, capture `cf-ray`, inspect Cloudflare Security Events, and compare headers between synthetic curl and the failing desktop request. 
- Updated `docs/apps/tokenplace.md` and `docs/k3s-tokenplace-prod.md` to include `/relay/diagnostics`, low-frequency diagnostics guidance, a warning against long-running public `/healthz` watches while rate limits are unresolved, and cert-manager challenge-cleanup guidance that treats `Certificate Ready=True` as the release gate while still investigating cleanup failures for `Zone:Read` or zone-scope issues.

### Testing
- Ran a repo search to confirm the new guidance appears where expected with `rg -n "synthetic|register|servers/poll|HTTP 403|cf-ray|rate limit|healthz|knownServers|relay/diagnostics|Cloudflare Security Events" docs`, and the new phrases were found in the intended files (pass). 
- Validated Markdown/YAML sanity with `git diff --check` (no blocking diffs introduced by these docs edits). 
- Ran docs linters: `pyspelling -c .spellcheck.yaml` (passed) and `linkchecker --no-warnings README.md docs/` (passed). 
- Ran targeted pre-commit hooks for the changed files: `pre-commit run trailing-whitespace --files <files>` and `pre-commit run end-of-file-fixer --files <files>` (both passed), and ran `./scripts/scan-secrets.py` against the staged diff to ensure no secrets were added (passed). 
- Attempted to run the full `pre-commit run --all-files`; after installing pre-commit it failed due to unrelated, pre-existing repository-wide checks (YAML/Helm template parsing and flake8 E501/E303 issues) that are outside the scope of this docs-only change (not caused by these edits).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1877619ee0832fb05af9f72c1cd201)