### PR TITLE
docs: token.place promotion gate checklist and emergency diagnostics

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -253,3 +253,12 @@ yourorg
 
 executables
 pytest
+E2EE
+XDG
+diagnostics
+healthz
+knownServers
+liveness
+livez
+rate-limit
+rate-limited

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -75,6 +75,25 @@ curl -fsS https://staging.token.place/
 
 For production validation, use the same checks against `https://token.place`.
 
+## Promotion blockers
+
+Web and certificate checks are only the start of validation. Do not promote staging to production
+until the release evidence proves the relay-compute path works end to end:
+
+- [ ] OCI chart freshness is confirmed with chart metadata and a chart digest.
+- [ ] Rendered manifests have no duplicate env vars and include chart-owned XDG `/tmp` env.
+- [ ] `/healthz` is exempt from global API rate limits.
+- [ ] Synthetic API v1 compute-node register/poll passes.
+- [ ] A desktop compute node whose `knownServers` points at staging registers successfully.
+- [ ] The registered compute node appears in `/healthz` and `/relay/diagnostics`.
+- [ ] E2EE request/response succeeds through that registered compute node.
+- [ ] The production Cloudflare route for `token.place` is configured to Traefik.
+
+See the staging and production runbooks for copy-pasteable release evidence, emergency diagnostics,
+and rollback commands. Rollbacks use either a Helm revision or a prior immutable image tag; because
+the relay Deployment uses `Recreate`, expect downtime and in-memory registration loss during pod
+replacement.
+
 ## Cloudflare and ingress model
 
 Cloudflare Tunnel/DNS configuration is external to Helm.

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -34,6 +34,31 @@ helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
 
 ## Promotion after staging sign-off
 
+Production promotion is blocked until staging proves the actual relay-compute path, not just web
+health or TLS readiness. Deployment Ready `1/1`, certificate Ready, `/livez`, `/healthz`, `/`,
+`/metrics`, and synthetic register/poll checks are necessary but not sufficient.
+
+### Promotion blockers
+
+- [ ] **OCI chart freshness:** chart metadata and the captured chart digest match the intended
+  token.place release candidate.
+- [ ] **No duplicate env vars:** prod render validation exits cleanly with no duplicate env names.
+- [ ] **XDG env present:** prod Deployment env includes chart-owned XDG `/tmp` paths; do not depend
+  on one-off Helm `--set env.XDG_*=/tmp` overrides.
+- [ ] **`/healthz` exempt from rate limit:** repeated `/healthz` probes succeed without consuming or
+  tripping global API rate limits.
+- [ ] **Synthetic register/poll passes:** API v1 synthetic compute-node register/poll succeeds
+  against staging.
+- [ ] **Desktop compute node registers:** a real desktop compute node whose `knownServers` targets
+  staging registers through `https://staging.token.place`.
+- [ ] **Registered compute node is visible:** the node appears in staging `/healthz` and
+  `/relay/diagnostics`.
+- [ ] **E2EE request/response passes:** staging completes an end-to-end encrypted request/response
+  through the registered compute node.
+- [ ] **Prod Cloudflare route configured:** `token.place` routes to Traefik before promotion.
+
+Only after every blocker is checked may production be promoted:
+
 ```bash
 TOKENPLACE_TAG=v0.1.0 # use final release tag after token.place Git tag push
 just tokenplace-oci-promote-prod tag="$TOKENPLACE_TAG"
@@ -110,9 +135,50 @@ curl -fsS https://token.place/livez
 curl -fsS https://token.place/healthz
 ```
 
+## Release evidence capture
+
+Capture evidence during the promotion window and attach it to the release notes or incident channel:
+
+```bash
+CHART_VERSION="$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
+TOKENPLACE_TAG=v0.1.0 # replace with the immutable production tag
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$CHART_VERSION"
+helm pull oci://ghcr.io/futuroptimist/charts/tokenplace --version "$CHART_VERSION" \
+  --destination /tmp/tokenplace-chart-evidence
+sha256sum /tmp/tokenplace-chart-evidence/tokenplace-"$CHART_VERSION".tgz # chart digest
+printf 'image tag: ghcr.io/futuroptimist/tokenplace-relay:%s\n' "$TOKENPLACE_TAG"
+kubectl -n tokenplace get deploy tokenplace -o yaml > /tmp/tokenplace-prod-deployment.yaml
+curl -fsS https://token.place/healthz | tee /tmp/tokenplace-prod-healthz.json
+curl -fsS https://token.place/relay/diagnostics | tee /tmp/tokenplace-prod-diagnostics.json
+# Run the desktop compute-node registration and E2EE request/response test now.
+kubectl -n tokenplace logs deploy/tokenplace --tail=200 > /tmp/tokenplace-prod-relay-after-compute.log
+```
+
+## Emergency diagnostics
+
+Copy/paste this block if production web health passes but compute-node registration, diagnostics, or
+E2EE relay traffic fails:
+
+```bash
+just kubeconfig-env prod
+kubectl -n tokenplace get deployments,replicasets,pods,services,ingress,certificates -o wide
+kubectl -n tokenplace describe deploy tokenplace
+kubectl -n tokenplace describe ingress tokenplace
+kubectl -n tokenplace get events --sort-by=.lastTimestamp | tail -n 80
+kubectl -n tokenplace logs deploy/tokenplace --tail=300
+kubectl -n tokenplace logs deploy/tokenplace --previous --tail=300 || true
+just tokenplace-debug-logs-env env=prod
+just cf-tunnel-debug
+just cert-manager-status
+```
+
+Also check Cloudflare Security Events for `token.place` around the failed registration time. A
+Cloudflare WAF/rate-limit/challenge event can reject requests before the relay application logs
+anything.
+
 ## Rollback options
 
-Rollback by immutable tag:
+Rollback by immutable image tag when the prior good container image is known:
 
 ```bash
 just kubeconfig-env prod
@@ -120,13 +186,17 @@ TOKENPLACE_PREVIOUS_TAG=main-deadbee # replace with the prior immutable tag
 just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_PREVIOUS_TAG"
 ```
 
-Rollback by Helm revision:
+Rollback by Helm revision when the prior good release revision is known:
 
 ```bash
 just kubeconfig-env prod
 TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
 just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
 ```
+
+Both rollback paths restart the only relay pod because the Deployment strategy is `Recreate`. Expect
+a short downtime window and loss of in-memory relay registrations while the single replacement pod
+starts.
 
 ## Cloudflare tunnel routing (external to Helm)
 

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -111,9 +111,75 @@ curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
 ```
 
+## Promotion blockers
+
+Treat these checks as release blockers before any staging candidate can be promoted to production.
+Passing web, TLS, `/livez`, `/healthz`, `/`, `/metrics`, or synthetic register/poll probes alone
+does **not** validate the relay release; the actual desktop compute path must pass too.
+
+- [ ] **OCI chart freshness:** `helm show chart` and the captured chart digest match the current
+  token.place release candidate, not an earlier `0.1.0` publish.
+- [ ] **No duplicate env vars:** the render validation above exits cleanly with no duplicate env names.
+- [ ] **XDG env present:** rendered Deployment env includes chart-owned XDG `/tmp` paths without
+  one-off manual Helm overrides.
+- [ ] **`/healthz` exempt from rate limit:** repeated unauthenticated health probes return success
+  and do not consume or trip the global API rate limit.
+- [ ] **Synthetic register/poll passes:** the API v1 synthetic compute-node register/poll smoke test
+  succeeds against `https://staging.token.place`.
+- [ ] **Desktop compute node registers:** a real desktop compute node whose `knownServers` targets
+  staging successfully registers through the public relay path.
+- [ ] **Registered compute node is visible:** the node appears in both `/healthz` and
+  `/relay/diagnostics` after registration.
+- [ ] **E2EE request/response passes:** an end-to-end encrypted request submitted through staging is
+  accepted by the registered compute node and returns an encrypted response to the requester.
+- [ ] **Production Cloudflare route is ready before promotion:** `token.place` is explicitly routed
+  to Traefik with `just cf-tunnel-route host=token.place` before the production upgrade window.
+
+## Release evidence capture
+
+Capture these artifacts in the staging sign-off notes so reviewers can distinguish web health from
+relay-path validation:
+
+```bash
+CHART_VERSION="$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
+TOKENPLACE_TAG=main-deadbee # replace with the immutable candidate tag
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$CHART_VERSION"
+helm pull oci://ghcr.io/futuroptimist/charts/tokenplace --version "$CHART_VERSION" \
+  --destination /tmp/tokenplace-chart-evidence
+sha256sum /tmp/tokenplace-chart-evidence/tokenplace-"$CHART_VERSION".tgz # chart digest
+printf 'image tag: ghcr.io/futuroptimist/tokenplace-relay:%s\n' "$TOKENPLACE_TAG"
+kubectl -n tokenplace get deploy tokenplace -o yaml > /tmp/tokenplace-staging-deployment.yaml
+curl -fsS https://staging.token.place/healthz | tee /tmp/tokenplace-staging-healthz.json
+curl -fsS https://staging.token.place/relay/diagnostics | tee /tmp/tokenplace-staging-diagnostics.json
+# Run the desktop compute-node registration and E2EE request/response test now.
+kubectl -n tokenplace logs deploy/tokenplace --tail=200 > /tmp/tokenplace-staging-relay-after-compute.log
+```
+
+## Emergency diagnostics
+
+Copy/paste this block when staging web health passes but compute-node registration, diagnostics, or
+E2EE relay traffic fails:
+
+```bash
+just kubeconfig-env staging
+kubectl -n tokenplace get deployments,replicasets,pods,services,ingress,certificates -o wide
+kubectl -n tokenplace describe deploy tokenplace
+kubectl -n tokenplace describe ingress tokenplace
+kubectl -n tokenplace get events --sort-by=.lastTimestamp | tail -n 80
+kubectl -n tokenplace logs deploy/tokenplace --tail=300
+kubectl -n tokenplace logs deploy/tokenplace --previous --tail=300 || true
+just tokenplace-debug-logs-env env=staging
+just cf-tunnel-debug
+just cert-manager-status
+```
+
+Also check Cloudflare Security Events for `staging.token.place` and `token.place` around the failed
+registration time. A Cloudflare WAF/rate-limit/challenge event can reject requests before the relay
+application logs anything.
+
 ## Rollback
 
-Rollback by immutable tag:
+Rollback by immutable image tag when the prior good container image is known:
 
 ```bash
 just kubeconfig-env staging
@@ -121,13 +187,17 @@ TOKENPLACE_PREVIOUS_TAG=main-deadbee # replace with the prior immutable tag
 just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_PREVIOUS_TAG"
 ```
 
-Rollback by Helm revision:
+Rollback by Helm revision when the prior good release revision is known:
 
 ```bash
 just kubeconfig-env staging
 TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
 just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
 ```
+
+Both rollback paths restart the only relay pod because the Deployment strategy is `Recreate`. Expect
+a short downtime window and loss of in-memory relay registrations while the single replacement pod
+starts.
 
 ## Cloudflare tunnel routing (external to Helm)
 

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -36,6 +36,16 @@ Host defaults:
 
 Do not carry forward one-off Helm `--set env.XDG_*=/tmp` overrides from the initial staging incident response. XDG `/tmp` behavior is now expected from chart defaults, and Sugarkube overlays should only carry environment-specific values.
 
+## Promotion gate contract
+
+Staging sign-off must validate the actual relay-compute path before production promotion. Web/TLS
+health alone is not enough: `/livez`, `/healthz`, `/`, `/metrics`, and synthetic register/poll may
+all pass while desktop compute-node registration or E2EE relay traffic is still blocked. The
+promotion gate therefore requires chart freshness, no duplicate env vars, XDG env defaults,
+rate-limit-exempt health checks, synthetic register/poll, desktop compute-node registration,
+visibility in `/healthz` and `/relay/diagnostics`, an E2EE request/response, and the production
+Cloudflare route.
+
 ## Environment runbooks
 
 - App overview: `docs/apps/tokenplace.md`


### PR DESCRIPTION
### Motivation
- Prevent accidental promotion of a staging token.place release when web/TLS probes pass but the relay→compute path is still broken. 
- Capture copy-pasteable emergency diagnostics and release-evidence steps so reviewers can distinguish web health from a validated relay release. 
- Remind operators of rollback semantics and expected downtime for the single-replica `Recreate` relay deployment.

### Description
- Add a “Promotion blockers” checklist to staging and production runbooks requiring chart freshness, no duplicate env vars, XDG env defaults, `/healthz` rate-limit exemption, synthetic register/poll, desktop compute-node registration, visibility in `/healthz` + `/relay/diagnostics`, E2EE request/response, and prod Cloudflare routing. 
- Add release evidence capture commands (chart digest, image tag, deployment YAML, `/healthz`, `/relay/diagnostics`, and relay logs) and copy/pasteable emergency diagnostics (deployments/replicasets/pods/services/ingress/certificates, recent events, current/previous relay logs, `just cf-tunnel-debug`, `just cert-manager-status`, and Cloudflare Security Events note). 
- Clarify rollback reminders for both immutable image-tag rollback and Helm revision rollback and call out expected downtime/loss-of-in-memory-registrations because `spec.strategy.type: Recreate`.
- Update canonical app/onboarding docs and the spellcheck wordlist with new terms used by the runbooks.

### Testing
- Searched docs for key markers with `rg -n "Promotion blockers|E2EE|synthetic|knownServers|rollback|Recreate|chart digest|emergency diagnostics" docs` and verified the new phrases are present (passed). 
- Ran documentation guardrails with `python -m pytest tests/test_docs_guardrails.py -q` and the test suite passed (`3 passed`). 
- Ran spelling check with `pyspelling -c .spellcheck.yaml` and it passed after installing `aspell` (passed). 
- Ran link validation with `linkchecker --no-warnings README.md docs/` and it returned no errors (passed). 
- Ran secret scan commands `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` which produced no findings (passed). 
- Attempted full `pre-commit run --all-files` and `bash scripts/checks.sh` but these surfaced pre-existing repository issues (YAML multi-document/Helm template checks and unrelated flake8 line-length / blank-line problems); these are unrelated to the docs changes and remain present in the repo (pre-commit/checks: not green). 

If you want I can follow up with a small separate PR to fix any repository-wide linting failures, but this change is intentionally limited to runbook/docs hardening and copy-pasteable diagnostics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1877796de0832fb82e2bacaf093182)