### PR TITLE
docs: Add token.place promotion blockers, emergency diagnostics, rollback & evidence capture

### DIFF
--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -40,6 +40,17 @@ Default hosts:
 - Staging: `staging.token.place`
 - Production: `token.place`
 
+## Promotion gate summary
+
+Web/TLS checks (`/livez`, `/healthz`, `/`, and certificate readiness) only prove the public shell is
+reachable. Treat production promotion as blocked until the staging runbook's **Promotion blockers**
+checklist proves the actual relay path: fresh OCI chart digest, no duplicate env vars, XDG `/tmp`
+defaults, rate-limit-exempt `/healthz`, synthetic API v1 register/poll, desktop compute-node
+registration through staging `knownServers`, compute-node visibility in `/healthz` and
+`/relay/diagnostics`, and an E2EE request/response. The production runbook then captures prod
+Cloudflare route readiness, deployment YAML, healthz, diagnostics, and relay logs after smoke
+validation.
+
 ## Core deployment commands
 
 Use concrete release/namespace/chart values for token.place relay deployments.

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -32,6 +32,65 @@ Use this runbook for relay-only token.place production deployments on Sugarkube.
 helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
 ```
 
+## Promotion blockers
+
+> Release blocker: web/TLS health is necessary but **not sufficient**. Production promotion is
+> blocked until the staging relay-compute path has passed with an external desktop compute node
+> and an end-to-end encrypted request/response.
+
+Confirm every item before running `just tokenplace-oci-promote-prod`:
+
+- [ ] **OCI chart freshness:** `helm show chart` and the recorded chart digest match the freshly
+  published token.place chart for the approved release.
+- [ ] **No duplicate env vars:** rendered production Deployment env validation passes for init and
+  app containers. Duplicate env names are a release blocker.
+- [ ] **XDG env present:** rendered Deployment includes chart-owned `XDG_CACHE_HOME`,
+  `XDG_CONFIG_HOME`, and `XDG_DATA_HOME` values pointing at writable `/tmp` paths.
+- [ ] **`/healthz` exempt from rate limit:** unauthenticated health checks stay below neither app
+  nor edge rate limits and do not return HTTP 429/403.
+- [ ] **Synthetic register/poll passes in staging:** API v1 synthetic registration and poll passed
+  against the exact staging candidate image.
+- [ ] **Desktop compute node registers in staging:** a real desktop compute node configured with
+  staging `knownServers` / relay URL registered through the public staging hostname.
+- [ ] **Registered compute node visible in staging:** the node appeared in `/healthz` and
+  `/relay/diagnostics` safe routing metadata.
+- [ ] **E2EE request/response passes in staging:** a client request completed through the relay and
+  returned a decryptable response from the registered compute node.
+- [ ] **Prod Cloudflare route configured:** `token.place` routes through Cloudflare Tunnel to
+  production Traefik before cutover.
+
+## Release evidence capture
+
+Capture these commands during production promotion. They complement, but do not replace, the
+staging evidence proving desktop compute registration and E2EE flow.
+
+```bash
+export TOKENPLACE_TAG=v0.1.0 # replace with the approved immutable release tag
+export TOKENPLACE_CHART_VERSION="$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
+export TOKENPLACE_HOST=token.place
+
+# chart digest / chart metadata
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$TOKENPLACE_CHART_VERSION"
+helm pull oci://ghcr.io/futuroptimist/charts/tokenplace --version "$TOKENPLACE_CHART_VERSION" --destination /tmp/tokenplace-chart
+sha256sum "/tmp/tokenplace-chart/tokenplace-${TOKENPLACE_CHART_VERSION}.tgz"
+
+# image tag and deployed image
+printf 'approved image tag=%s\n' "$TOKENPLACE_TAG"
+kubectl -n tokenplace get deploy/tokenplace -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"="}{.image}{"\n"}{end}'
+
+# deployment YAML, including strategy.type: Recreate and env/XDG checks
+kubectl -n tokenplace get deploy/tokenplace -o yaml > /tmp/tokenplace-prod-deployment.yaml
+yq eval '.spec.strategy.type' /tmp/tokenplace-prod-deployment.yaml
+yq eval '.spec.template.spec.containers[].env[] | select(.name | test("^XDG_"))' /tmp/tokenplace-prod-deployment.yaml
+
+# production healthz and diagnostics evidence after smoke validation
+curl -fsS "https://${TOKENPLACE_HOST}/healthz" | tee /tmp/tokenplace-prod-healthz.json
+curl -fsS "https://${TOKENPLACE_HOST}/relay/diagnostics" | tee /tmp/tokenplace-prod-diagnostics.json
+
+# relay logs after production smoke test
+kubectl -n tokenplace logs deploy/tokenplace --tail=300 > /tmp/tokenplace-prod-relay-after-smoke.log
+```
+
 ## Promotion after staging sign-off
 
 ```bash
@@ -112,6 +171,14 @@ curl -fsS https://token.place/healthz
 
 ## Rollback options
 
+Rollback reminders for the single-replica relay:
+
+- Prefer rollback by immutable image tag when the chart is healthy but the relay image is bad.
+- Use Helm revision rollback when the chart/rendered values are the suspected regression.
+- Expect brief relay downtime and in-memory state loss during rollback because the Deployment
+  intentionally uses `strategy.type: Recreate`. Existing compute-node registrations may need to
+  reconnect and clients may need to retry.
+
 Rollback by immutable tag:
 
 ```bash
@@ -126,6 +193,40 @@ Rollback by Helm revision:
 just kubeconfig-env prod
 TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
 just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
+```
+
+## Emergency diagnostics
+
+Use this emergency diagnostics copy-paste block when web health, compute-node registration,
+diagnostics, TLS, or Cloudflare routing looks wrong. Check Cloudflare Security Events separately
+for WAF, bot, rate-limit, or access-rule blocks if the relay logs do not show the rejected request.
+
+```bash
+just kubeconfig-env prod
+export TOKENPLACE_HOST=token.place
+
+# Kubernetes objects and rollout shape
+kubectl -n tokenplace get deploy,rs,po,svc,ingress -o wide
+kubectl -n tokenplace get certificates -o wide
+kubectl -n tokenplace describe deploy/tokenplace
+kubectl -n tokenplace describe ingress/tokenplace
+kubectl -n tokenplace describe certificate --all
+
+# Recent events, newest last
+kubectl -n tokenplace get events --sort-by=.lastTimestamp | tail -n 80
+
+# Relay logs: current and previous container, if a pod restarted
+kubectl -n tokenplace logs deploy/tokenplace --tail=300
+kubectl -n tokenplace logs deploy/tokenplace --previous --tail=300 || true
+
+# Public edge/app probes
+curl -vI "https://${TOKENPLACE_HOST}/"
+curl -fsS "https://${TOKENPLACE_HOST}/healthz" || true
+curl -fsS "https://${TOKENPLACE_HOST}/relay/diagnostics" || true
+
+# Tunnel/certificate helpers
+just cf-tunnel-debug
+just cert-manager-status
 ```
 
 ## Cloudflare tunnel routing (external to Helm)

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -32,6 +32,67 @@ Use this runbook for relay-only token.place staging deployments on Sugarkube.
 helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
 ```
 
+## Promotion blockers
+
+> Release blocker: web/TLS health is necessary but **not sufficient**. Do not promote a
+> staging candidate to production until the real relay-compute path passes with an external
+> desktop compute node and an end-to-end encrypted request/response.
+
+Before production promotion, capture each item in the release notes or incident channel:
+
+- [ ] **OCI chart freshness:** `helm show chart` reports the expected chart version and the
+  registry digest matches the freshly published token.place chart, not a stale package.
+- [ ] **No duplicate env vars:** rendered Deployment env validation passes for init and app
+  containers. Duplicate env names are a release blocker.
+- [ ] **XDG env present:** rendered Deployment includes chart-owned `XDG_CACHE_HOME`,
+  `XDG_CONFIG_HOME`, and `XDG_DATA_HOME` values pointing at writable `/tmp` paths; do not rely
+  on one-off manual Helm overrides.
+- [ ] **`/healthz` exempt from rate limit:** repeated unauthenticated `GET /healthz` checks do
+  not return HTTP 429/403 and remain usable for Kubernetes, Cloudflare, and operator probes.
+- [ ] **Synthetic register/poll passes:** the API v1 synthetic registration and poll smoke test
+  succeeds against `https://staging.token.place`.
+- [ ] **Desktop compute node registers:** a real desktop compute node configured with staging
+  `knownServers` / relay URL registers through the public staging hostname without HTTP 403 or
+  pre-app rejection.
+- [ ] **Registered compute node is visible:** the desktop node appears in both `/healthz` and
+  `/relay/diagnostics` safe routing metadata.
+- [ ] **E2EE request/response passes:** an end-to-end encrypted client request reaches the
+  registered compute node and returns a decryptable response through the relay.
+- [ ] **Prod Cloudflare route configured:** `token.place` is routed to the production Traefik
+  service before the production deploy.
+
+## Release evidence capture
+
+Run these commands for the staging candidate and attach the output to the release record. Keep the
+artifacts separate from basic web/TLS checks so reviewers can see the relay path was validated.
+
+```bash
+export TOKENPLACE_TAG=main-deadbee # replace with the immutable staging candidate tag
+export TOKENPLACE_CHART_VERSION="$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
+export TOKENPLACE_HOST=staging.token.place
+
+# chart digest / chart metadata
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$TOKENPLACE_CHART_VERSION"
+helm pull oci://ghcr.io/futuroptimist/charts/tokenplace --version "$TOKENPLACE_CHART_VERSION" --destination /tmp/tokenplace-chart
+sha256sum "/tmp/tokenplace-chart/tokenplace-${TOKENPLACE_CHART_VERSION}.tgz"
+
+# image tag and deployed image
+printf 'candidate image tag=%s\n' "$TOKENPLACE_TAG"
+kubectl -n tokenplace get deploy/tokenplace -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"="}{.image}{"\n"}{end}'
+
+# deployment YAML, including strategy.type: Recreate and env/XDG checks
+kubectl -n tokenplace get deploy/tokenplace -o yaml > /tmp/tokenplace-staging-deployment.yaml
+yq eval '.spec.strategy.type' /tmp/tokenplace-staging-deployment.yaml
+yq eval '.spec.template.spec.containers[].env[] | select(.name | test("^XDG_"))' /tmp/tokenplace-staging-deployment.yaml
+
+# healthz and diagnostics evidence after synthetic + desktop compute tests
+curl -fsS "https://${TOKENPLACE_HOST}/healthz" | tee /tmp/tokenplace-staging-healthz.json
+curl -fsS "https://${TOKENPLACE_HOST}/relay/diagnostics" | tee /tmp/tokenplace-staging-diagnostics.json
+
+# relay logs after compute-node registration and E2EE request/response
+kubectl -n tokenplace logs deploy/tokenplace --tail=300 > /tmp/tokenplace-staging-relay-after-compute.log
+```
+
 ## First install
 
 ```bash
@@ -113,6 +174,14 @@ curl -fsS https://staging.token.place/healthz
 
 ## Rollback
 
+Rollback reminders for the single-replica relay:
+
+- Prefer rollback by immutable image tag when the chart is healthy but the relay image is bad.
+- Use Helm revision rollback when the chart/rendered values are the suspected regression.
+- Expect brief relay downtime and in-memory state loss during rollback because the Deployment
+  intentionally uses `strategy.type: Recreate`. Existing compute-node registrations may need to
+  reconnect and clients may need to retry.
+
 Rollback by immutable tag:
 
 ```bash
@@ -127,6 +196,40 @@ Rollback by Helm revision:
 just kubeconfig-env staging
 TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
 just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
+```
+
+## Emergency diagnostics
+
+Use this emergency diagnostics copy-paste block when web health, compute-node registration,
+diagnostics, TLS, or Cloudflare routing looks wrong. Check Cloudflare Security Events separately
+for WAF, bot, rate-limit, or access-rule blocks if the relay logs do not show the rejected request.
+
+```bash
+just kubeconfig-env staging
+export TOKENPLACE_HOST=staging.token.place
+
+# Kubernetes objects and rollout shape
+kubectl -n tokenplace get deploy,rs,po,svc,ingress -o wide
+kubectl -n tokenplace get certificates -o wide
+kubectl -n tokenplace describe deploy/tokenplace
+kubectl -n tokenplace describe ingress/tokenplace
+kubectl -n tokenplace describe certificate --all
+
+# Recent events, newest last
+kubectl -n tokenplace get events --sort-by=.lastTimestamp | tail -n 80
+
+# Relay logs: current and previous container, if a pod restarted
+kubectl -n tokenplace logs deploy/tokenplace --tail=300
+kubectl -n tokenplace logs deploy/tokenplace --previous --tail=300 || true
+
+# Public edge/app probes
+curl -vI "https://${TOKENPLACE_HOST}/"
+curl -fsS "https://${TOKENPLACE_HOST}/healthz" || true
+curl -fsS "https://${TOKENPLACE_HOST}/relay/diagnostics" || true
+
+# Tunnel/certificate helpers
+just cf-tunnel-debug
+just cert-manager-status
 ```
 
 ## Cloudflare tunnel routing (external to Helm)

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -36,6 +36,15 @@ Host defaults:
 
 Do not carry forward one-off Helm `--set env.XDG_*=/tmp` overrides from the initial staging incident response. XDG `/tmp` behavior is now expected from chart defaults, and Sugarkube overlays should only carry environment-specific values.
 
+
+## Promotion gate ownership
+
+Staging sign-off must validate the real relay-compute path, not only web/TLS health. Production is
+blocked until the token.place runbooks record the Promotion blockers checklist: fresh chart digest,
+rendered env/XDG sanity, `/healthz` rate-limit exemption, synthetic API v1 register/poll, desktop
+compute-node registration through staging `knownServers`, `/healthz` and `/relay/diagnostics`
+visibility, E2EE request/response, and the production Cloudflare route.
+
 ## Environment runbooks
 
 - App overview: `docs/apps/tokenplace.md`


### PR DESCRIPTION
### Motivation
- Prevent confusing “web/TLS health passed” with a validated relay-compute release by making the promotion gate explicitly require a real compute-node registration and E2EE flow. 
- Provide copy-paste emergency diagnostics and release evidence capture so on-call engineers can quickly gather proof the relay path works before promoting to prod.

### Description
- Added a `Promotion blockers` checklist and staging evidence capture block to `docs/k3s-tokenplace-staging.md` that requires chart freshness, duplicate-env/XDG validation, `/healthz` rate-limit exemption, synthetic API v1 register/poll, desktop compute-node registration, `/relay/diagnostics` visibility, and an E2EE end-to-end request/response. 
- Added the same `Promotion blockers` checklist plus production `Release evidence capture` commands to `docs/k3s-tokenplace-prod.md`. 
- Added copy-paste `Emergency diagnostics` blocks (k8s objects, events, relay logs, previous logs, public probes, `just cf-tunnel-debug`, `just cert-manager-status`, and a Cloudflare Security Events note) and explicit rollback reminders mentioning `strategy.type: Recreate` to both staging and prod runbooks. 
- Added a short `Promotion gate summary` to `docs/apps/tokenplace.md` and `Promotion gate ownership` note to `docs/tokenplace_sugarkube_onboarding.md` to make ownership and intent explicit. 
- Files changed: `docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`, `docs/apps/tokenplace.md`, `docs/tokenplace_sugarkube_onboarding.md`.

### Testing
- Ran `rg -n "Promotion blockers|E2EE|synthetic|knownServers|rollback|Recreate|chart digest|emergency diagnostics" docs` to verify inserted text was present (succeeded). 
- Ran `linkchecker --no-warnings README.md docs/` to validate internal links (succeeded; 0 warnings/errors). 
- Ran `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` as part of vetting (succeeded; no secrets flagged). 
- Attempted `pre-commit run --all-files` but it could not run because `pre-commit` is not installed in the environment (not-run). 
- Executed `bash scripts/checks.sh` which started but failed on pre-existing unrelated `flake8` E501 line-length issues in scripts/tests (fail: unrelated code-style issues present). 
- Attempted `pyspelling -c .spellcheck.yaml` which failed because `aspell` was not available in the environment (not-run). 

Residual risks and follow-ups: update CI or contributors to run `pre-commit`/`pyspelling` in their environment, and address existing unrelated `flake8` issues if you want a clean `scripts/checks.sh` run; the runbook additions are docs-only and make no behavioral changes to the app.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1877796de0832fb82e2bacaf093182)