### PR TITLE
docs: add token.place promotion blockers, emergency diagnostics, and rollback reminders

### DIFF
--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -75,6 +75,27 @@ curl -fsS https://staging.token.place/
 
 For production validation, use the same checks against `https://token.place`.
 
+## Promotion blockers
+
+Use the environment runbooks for copy-paste commands, but keep this release-blocker rule in every
+token.place promotion review: **web/TLS health is not relay validation**. A build can only move from
+staging to production after all of these are true:
+
+- [ ] OCI chart freshness and chart digest are captured for the exact version being promoted.
+- [ ] Rendered manifests contain no duplicate env vars.
+- [ ] XDG writable `/tmp` env defaults are present from the chart, not one-off CLI overrides.
+- [ ] `/healthz` is exempt from API rate limiting.
+- [ ] Synthetic API v1 compute-node register/poll passes.
+- [ ] A desktop compute node uses the intended `knownServers`/server entry and registers.
+- [ ] The registered compute node appears in `/healthz` and `/relay/diagnostics`.
+- [ ] An E2EE request/response succeeds through that compute node.
+- [ ] The production Cloudflare route exists and points to Traefik before prod cutover.
+
+Emergency diagnostics and rollback remain environment-specific:
+
+- Staging: [`docs/k3s-tokenplace-staging.md`](../k3s-tokenplace-staging.md)
+- Production: [`docs/k3s-tokenplace-prod.md`](../k3s-tokenplace-prod.md)
+
 ## Cloudflare and ingress model
 
 Cloudflare Tunnel/DNS configuration is external to Helm.

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -113,28 +113,38 @@ curl -fsS https://token.place/healthz
 ## Promotion blockers
 
 > **Release blocker:** production promotion is blocked until staging proves the actual
-> relay-compute path. Deployment Ready, TLS Ready, `/livez`, `/healthz`, `/`, `/metrics`, and
+> relay-compute path, and the promoted production deployment then proves its own prod
+> compute-node path. Deployment Ready, TLS Ready, `/livez`, `/healthz`, `/`, `/metrics`, and
 > synthetic register/poll are necessary but not sufficient by themselves.
 
-Before running the prod upgrade, confirm every item from staging evidence:
+Before running the prod upgrade, confirm every item from staging sign-off evidence:
 
 - [ ] OCI chart freshness is proven with `helm show chart` plus chart digest evidence for the
-  exact chart version used in staging and prod.
+  exact chart version being promoted from staging to prod.
 - [ ] Render validation finds no duplicate environment variables in any init/app container.
 - [ ] Rendered Deployment includes writable XDG `/tmp` defaults from the chart without one-off
   Sugarkube override drift.
-- [ ] `/healthz` is exempt from token.place global API rate limits.
-- [ ] Synthetic API v1 compute-node register/poll passes.
-- [ ] A desktop compute node has the intended hostname in `knownServers`/server config and
-  registers to staging first, not production.
-- [ ] That registered compute node appears in `/healthz` and `/relay/diagnostics`.
-- [ ] An E2EE request/response succeeds through the registered compute node.
+- [ ] Staging `/healthz` is exempt from token.place global API rate limits.
+- [ ] Synthetic API v1 compute-node register/poll passes against `https://staging.token.place`.
+- [ ] A desktop compute node has `staging.token.place` in `knownServers`/server config, registers
+  to staging, appears in staging `/healthz` and `/relay/diagnostics`, and completes an E2EE
+  request/response through the staging relay.
 - [ ] The prod Cloudflare route for `token.place` is configured to Traefik and checked outside
   Helm/cert-manager before promotion.
 
+After the prod upgrade, capture separate prod validation evidence before marking the promotion
+complete:
+
+- [ ] Synthetic API v1 compute-node register/poll passes against `https://token.place`.
+- [ ] A desktop compute node has `token.place` in `knownServers`/server config, registers to prod,
+  and does not silently fall back to staging.
+- [ ] That prod-registered compute node appears in prod `/healthz` and `/relay/diagnostics`.
+- [ ] An E2EE request/response succeeds through the prod-registered compute node.
+
 ### Release evidence capture
 
-Capture and attach this evidence for the prod promotion record:
+Capture and attach the staging sign-off artifacts plus this separate prod evidence for the prod
+promotion record:
 
 ```bash
 just kubeconfig-env prod
@@ -149,7 +159,7 @@ printf 'image tag: ghcr.io/futuroptimist/tokenplace-relay:%s\n' "$TOKENPLACE_TAG
 kubectl -n tokenplace get deploy tokenplace -o yaml > /tmp/tokenplace-prod-deployment.yaml
 curl -fsS "https://${TOKENPLACE_HOST}/healthz" | tee /tmp/tokenplace-prod-healthz.json
 curl -fsS "https://${TOKENPLACE_HOST}/relay/diagnostics" | tee /tmp/tokenplace-prod-diagnostics.json
-# After the desktop compute-node registration and E2EE flow finish:
+# After the prod desktop compute-node registration and E2EE flow finish:
 kubectl -n tokenplace logs deploy/tokenplace --since=30m --tail=500 | tee /tmp/tokenplace-prod-relay-after-compute.log
 ```
 

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -144,7 +144,10 @@ complete:
 ### Release evidence capture
 
 Capture and attach the staging sign-off artifacts plus this separate prod evidence for the prod
-promotion record:
+promotion record. For the prod evidence, run the prod synthetic register/poll, confirm prod
+desktop compute-node registration, and complete the prod E2EE request/response before saving
+`/healthz`, `/relay/diagnostics`, or relay logs so those artifacts prove the prod-registered
+desktop compute node is visible after the real prod relay-compute path passes:
 
 ```bash
 just kubeconfig-env prod
@@ -157,9 +160,10 @@ helm pull oci://ghcr.io/futuroptimist/charts/tokenplace --version "$TOKENPLACE_C
 sha256sum "/tmp/tokenplace-${TOKENPLACE_CHART_VERSION}.tgz" # chart digest evidence
 printf 'image tag: ghcr.io/futuroptimist/tokenplace-relay:%s\n' "$TOKENPLACE_TAG"
 kubectl -n tokenplace get deploy tokenplace -o yaml > /tmp/tokenplace-prod-deployment.yaml
+# First run synthetic register/poll, desktop compute-node registration, and the E2EE flow.
+# Then capture health, diagnostics, and relay logs as post-compute-path evidence:
 curl -fsS "https://${TOKENPLACE_HOST}/healthz" | tee /tmp/tokenplace-prod-healthz.json
 curl -fsS "https://${TOKENPLACE_HOST}/relay/diagnostics" | tee /tmp/tokenplace-prod-diagnostics.json
-# After the prod desktop compute-node registration and E2EE flow finish:
 kubectl -n tokenplace logs deploy/tokenplace --since=30m --tail=500 | tee /tmp/tokenplace-prod-relay-after-compute.log
 ```
 

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -110,7 +110,81 @@ curl -fsS https://token.place/livez
 curl -fsS https://token.place/healthz
 ```
 
+## Promotion blockers
+
+> **Release blocker:** production promotion is blocked until staging proves the actual
+> relay-compute path. Deployment Ready, TLS Ready, `/livez`, `/healthz`, `/`, `/metrics`, and
+> synthetic register/poll are necessary but not sufficient by themselves.
+
+Before running the prod upgrade, confirm every item from staging evidence:
+
+- [ ] OCI chart freshness is proven with `helm show chart` plus chart digest evidence for the
+  exact chart version used in staging and prod.
+- [ ] Render validation finds no duplicate environment variables in any init/app container.
+- [ ] Rendered Deployment includes writable XDG `/tmp` defaults from the chart without one-off
+  Sugarkube override drift.
+- [ ] `/healthz` is exempt from token.place global API rate limits.
+- [ ] Synthetic API v1 compute-node register/poll passes.
+- [ ] A desktop compute node has the intended hostname in `knownServers`/server config and
+  registers to staging first, not production.
+- [ ] That registered compute node appears in `/healthz` and `/relay/diagnostics`.
+- [ ] An E2EE request/response succeeds through the registered compute node.
+- [ ] The prod Cloudflare route for `token.place` is configured to Traefik and checked outside
+  Helm/cert-manager before promotion.
+
+### Release evidence capture
+
+Capture and attach this evidence for the prod promotion record:
+
+```bash
+just kubeconfig-env prod
+TOKENPLACE_TAG=v0.1.0 # replace with the immutable release tag
+TOKENPLACE_HOST=token.place
+TOKENPLACE_CHART_VERSION="$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
+
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$TOKENPLACE_CHART_VERSION"
+helm pull oci://ghcr.io/futuroptimist/charts/tokenplace --version "$TOKENPLACE_CHART_VERSION" --destination /tmp
+sha256sum "/tmp/tokenplace-${TOKENPLACE_CHART_VERSION}.tgz" # chart digest evidence
+printf 'image tag: ghcr.io/futuroptimist/tokenplace-relay:%s\n' "$TOKENPLACE_TAG"
+kubectl -n tokenplace get deploy tokenplace -o yaml > /tmp/tokenplace-prod-deployment.yaml
+curl -fsS "https://${TOKENPLACE_HOST}/healthz" | tee /tmp/tokenplace-prod-healthz.json
+curl -fsS "https://${TOKENPLACE_HOST}/relay/diagnostics" | tee /tmp/tokenplace-prod-diagnostics.json
+# After the desktop compute-node registration and E2EE flow finish:
+kubectl -n tokenplace logs deploy/tokenplace --since=30m --tail=500 | tee /tmp/tokenplace-prod-relay-after-compute.log
+```
+
+### Emergency diagnostics
+
+This emergency diagnostics command block is copy-pasteable. Run it when prod web/TLS health is green but compute registration or E2EE is blocked:
+
+```bash
+just kubeconfig-env prod
+TOKENPLACE_HOST=token.place
+
+kubectl -n tokenplace get deployments,replicasets,pods,services,ingress,certificates -o wide
+kubectl -n tokenplace describe deploy/tokenplace
+kubectl -n tokenplace describe ingress/tokenplace
+kubectl -n tokenplace get events --sort-by=.lastTimestamp | tail -n 80
+kubectl -n tokenplace logs deploy/tokenplace --since=30m --tail=500
+kubectl -n tokenplace logs deploy/tokenplace --previous --tail=500 || true
+curl -vI "https://${TOKENPLACE_HOST}/"
+curl -fsS "https://${TOKENPLACE_HOST}/healthz" || true
+curl -fsS "https://${TOKENPLACE_HOST}/relay/diagnostics" || true
+just cf-tunnel-debug
+just cert-manager-status
+```
+
+If Cloudflare returns HTTP 403 before the request reaches token.place, check Cloudflare Security
+Events for the hostname, ray ID, source IP, path, and rule that made the decision.
+
 ## Rollback options
+
+Rollback reminders:
+
+- Prefer immutable image tag rollback when the bad rollout is tied to a single image.
+- Use Helm revision rollback when you need to restore the entire rendered release state.
+- Expect a short outage during rollback because token.place is intentionally single-replica and
+  the Deployment strategy is `Recreate`; wait for the replacement pod before retesting relay E2EE.
 
 Rollback by immutable tag:
 

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -111,7 +111,81 @@ curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/healthz
 ```
 
+## Promotion blockers
+
+> **Release blocker:** staging is not validated by web/TLS health alone. Do not promote this
+> token.place build to production until the real relay-compute path below passes end-to-end.
+
+Check every item before approving prod promotion:
+
+- [ ] OCI chart freshness is proven with `helm show chart`; the chart digest/version was published
+  for this candidate and is not a stale `0.1.0` package.
+- [ ] Render validation finds no duplicate environment variables in any init/app container.
+- [ ] Rendered Deployment keeps XDG runtime/cache/config/data homes on writable `/tmp` chart
+  defaults, with no one-off Sugarkube `--set env.XDG_*=/tmp` drift.
+- [ ] `/healthz` is exempt from token.place global API rate limits; repeated probes return 200 and
+  do not mask Cloudflare 403/pre-app rejection behavior.
+- [ ] Synthetic API v1 compute-node register/poll passes against `https://staging.token.place`.
+- [ ] A real desktop compute node has `staging.token.place` in its `knownServers`/server list,
+  registers successfully, and does not silently fall back to production.
+- [ ] The registered desktop compute node appears in both `/healthz` and `/relay/diagnostics`.
+- [ ] An E2EE request/response succeeds through the registered staging compute node.
+- [ ] The production Cloudflare route for `token.place` is configured before prod cutover, but is
+  still treated as external to Helm/cert-manager.
+
+### Release evidence capture
+
+Capture this evidence with the staging candidate tag before promotion review:
+
+```bash
+just kubeconfig-env staging
+TOKENPLACE_TAG=main-deadbee # replace with the immutable candidate tag
+TOKENPLACE_HOST=staging.token.place
+TOKENPLACE_CHART_VERSION="$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
+
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$TOKENPLACE_CHART_VERSION"
+helm pull oci://ghcr.io/futuroptimist/charts/tokenplace --version "$TOKENPLACE_CHART_VERSION" --destination /tmp
+sha256sum "/tmp/tokenplace-${TOKENPLACE_CHART_VERSION}.tgz" # chart digest evidence
+printf 'image tag: ghcr.io/futuroptimist/tokenplace-relay:%s\n' "$TOKENPLACE_TAG"
+kubectl -n tokenplace get deploy tokenplace -o yaml > /tmp/tokenplace-staging-deployment.yaml
+curl -fsS "https://${TOKENPLACE_HOST}/healthz" | tee /tmp/tokenplace-staging-healthz.json
+curl -fsS "https://${TOKENPLACE_HOST}/relay/diagnostics" | tee /tmp/tokenplace-staging-diagnostics.json
+# After the desktop compute-node registration and E2EE flow finish:
+kubectl -n tokenplace logs deploy/tokenplace --since=30m --tail=500 | tee /tmp/tokenplace-staging-relay-after-compute.log
+```
+
+### Emergency diagnostics
+
+This emergency diagnostics command block is copy-pasteable. Run it when staging looks healthy at `/` or TLS but relay registration/E2EE fails:
+
+```bash
+just kubeconfig-env staging
+TOKENPLACE_HOST=staging.token.place
+
+kubectl -n tokenplace get deployments,replicasets,pods,services,ingress,certificates -o wide
+kubectl -n tokenplace describe deploy/tokenplace
+kubectl -n tokenplace describe ingress/tokenplace
+kubectl -n tokenplace get events --sort-by=.lastTimestamp | tail -n 80
+kubectl -n tokenplace logs deploy/tokenplace --since=30m --tail=500
+kubectl -n tokenplace logs deploy/tokenplace --previous --tail=500 || true
+curl -vI "https://${TOKENPLACE_HOST}/"
+curl -fsS "https://${TOKENPLACE_HOST}/healthz" || true
+curl -fsS "https://${TOKENPLACE_HOST}/relay/diagnostics" || true
+just cf-tunnel-debug
+just cert-manager-status
+```
+
+If Cloudflare returns HTTP 403 before the request reaches the app, check Cloudflare Security
+Events for the exact hostname, ray ID, source IP, path, and rule that blocked the request.
+
 ## Rollback
+
+Rollback reminders:
+
+- Prefer immutable image tag rollback when the bad rollout is tied to a single image.
+- Use Helm revision rollback when you need to restore the entire rendered release state.
+- Expect a short outage during rollback because token.place is intentionally single-replica and
+  the Deployment strategy is `Recreate`; wait for the replacement pod before retesting relay E2EE.
 
 Rollback by immutable tag:
 

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -135,7 +135,10 @@ Check every item before approving prod promotion:
 
 ### Release evidence capture
 
-Capture this evidence with the staging candidate tag before promotion review:
+Capture this evidence with the staging candidate tag before promotion review. Run the synthetic
+register/poll, confirm desktop compute-node registration, and complete the E2EE request/response
+before saving `/healthz`, `/relay/diagnostics`, or relay logs so those artifacts prove the
+registered desktop compute node is visible after the real relay-compute path passes:
 
 ```bash
 just kubeconfig-env staging
@@ -148,9 +151,10 @@ helm pull oci://ghcr.io/futuroptimist/charts/tokenplace --version "$TOKENPLACE_C
 sha256sum "/tmp/tokenplace-${TOKENPLACE_CHART_VERSION}.tgz" # chart digest evidence
 printf 'image tag: ghcr.io/futuroptimist/tokenplace-relay:%s\n' "$TOKENPLACE_TAG"
 kubectl -n tokenplace get deploy tokenplace -o yaml > /tmp/tokenplace-staging-deployment.yaml
+# First run synthetic register/poll, desktop compute-node registration, and the E2EE flow.
+# Then capture health, diagnostics, and relay logs as post-compute-path evidence:
 curl -fsS "https://${TOKENPLACE_HOST}/healthz" | tee /tmp/tokenplace-staging-healthz.json
 curl -fsS "https://${TOKENPLACE_HOST}/relay/diagnostics" | tee /tmp/tokenplace-staging-diagnostics.json
-# After the desktop compute-node registration and E2EE flow finish:
 kubectl -n tokenplace logs deploy/tokenplace --since=30m --tail=500 | tee /tmp/tokenplace-staging-relay-after-compute.log
 ```
 

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -36,6 +36,13 @@ Host defaults:
 
 Do not carry forward one-off Helm `--set env.XDG_*=/tmp` overrides from the initial staging incident response. XDG `/tmp` behavior is now expected from chart defaults, and Sugarkube overlays should only carry environment-specific values.
 
+## Promotion gate ownership
+
+Staging-to-prod promotion is blocked until the real relay-compute path passes. Web/TLS readiness,
+`/livez`, `/healthz`, `/`, `/metrics`, and synthetic register/poll checks do not replace desktop
+compute-node registration plus an E2EE request/response. Keep release evidence with chart digest,
+image tag, deployment YAML, health/diagnostics responses, and relay logs from after the compute test.
+
 ## Environment runbooks
 
 - App overview: `docs/apps/tokenplace.md`


### PR DESCRIPTION
### Motivation
- Harden token.place runbooks so staging web/TLS readiness cannot be mistaken for full relay validation and to prevent accidental staging→prod promotions when the relay-compute path is not validated. 
- Require explicit compute-node registration and an E2EE request/response as part of promotion evidence so reviewers can verify the real relay flow end-to-end.

### Description
- Added a `Promotion blockers` checklist and release-evidence capture steps to `docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`, and `docs/apps/tokenplace.md` covering OCI chart freshness/chart digest, duplicate env detection, XDG `/tmp` defaults, `/healthz` rate-limit exemption, synthetic register/poll, desktop compute-node registration, `/relay/diagnostics` visibility, E2EE success, and Cloudflare routing checks. 
- Added copy-pasteable emergency diagnostics command blocks (Kubernetes resources, recent events, relay logs including previous logs, `just cf-tunnel-debug`, and `just cert-manager-status`) and a Cloudflare Security Events investigation note to staging and prod runbooks. 
- Inserted rollback reminders recommending immutable image tag rollback and Helm revision rollback and noting expected short outage for single-replica `spec.strategy.type: Recreate` deployments. 
- Clarified onboarding note `Promotion gate ownership` in `docs/tokenplace_sugarkube_onboarding.md` so promotion reviewers do not conflate web/TLS checks with relay validation. 
- Adjusted diagnostic commands to list `deployments,replicasets,pods,services,ingress,certificates` for copy-pasteable output; made no runtime or application behavior changes.

### Testing
- Searched docs for key terms with `rg -n "Promotion blockers|E2EE|synthetic|knownServers|rollback|Recreate|chart digest|emergency diagnostics" docs` and verified the new sections are present (matches found). — passed. 
- Ran documentation checks with `bash scripts/checks.sh --docs-only` which executed spellcheck and linkcheck; `pyspelling`/linkchecker reports showed spelling and link checks passed. — passed. 
- Ran repository checks: `git diff --cached --check` and `git diff --cached | ./scripts/scan-secrets.py` to validate staged changes and secrets scan; both completed with no issues for these doc changes. — passed. 
- Attempted `pre-commit run --all-files` but `pre-commit` is not installed in this environment so it did not run: `/bin/bash: line 1: pre-commit: command not found`. — not run in this environment. 
- Attempted full `bash scripts/checks.sh` (non-docs checks) which failed on unrelated, pre-existing flake8 line-length/whitespace findings in Python tests/scripts outside this docs-only change; those lint issues are pre-existing and not introduced by this PR. — failed (unrelated existing findings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1877796de0832fb82e2bacaf093182)