### PR TITLE
Normalize named `tag=` arguments in Danielsmith just wrappers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
         run: |
           ./scripts/test-helm-oci-install.sh
 
+      - name: Verify Danielsmith OCI tag normalization
+        run: |
+          ./scripts/test-danielsmith-oci-tag-normalization.sh
+
       - name: Ensure Avahi services are running
         run: |
           sudo systemctl start dbus

--- a/justfile
+++ b/justfile
@@ -2188,6 +2188,9 @@ danielsmith-oci-deploy env='staging' tag='':
     }
 
     resolved_tag="$(echo '{{ tag }}' | xargs)"
+    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
+      resolved_tag="${resolved_tag#tag=}"
+    done
     if [ -z "${resolved_tag}" ]; then
       echo "ERROR: tag is required for immutable deploys." >&2
       exit 1
@@ -2252,6 +2255,9 @@ danielsmith-oci-promote-prod tag='':
     read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.prod.tag | head -n1 | tr -d '[:space:]'; }
 
     resolved_tag="$(echo '{{ tag }}' | xargs)"
+    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
+      resolved_tag="${resolved_tag#tag=}"
+    done
     if [ -z "${resolved_tag}" ]; then
       resolved_tag="$(read_prod_tag 2>/dev/null || true)"
     fi
@@ -2296,6 +2302,9 @@ danielsmith-oci-redeploy env='staging' tag='':
     read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.prod.tag | head -n1 | tr -d '[:space:]'; }
 
     resolved_tag="$(echo '{{ tag }}' | xargs)"
+    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
+      resolved_tag="${resolved_tag#tag=}"
+    done
     if [ -z "${resolved_tag}" ] && [ "${env_name}" = "prod" ]; then
       resolved_tag="$(read_prod_tag 2>/dev/null || true)"
       [ -n "${resolved_tag}" ] || { echo "ERROR: prod requires tag=<immutable-tag> or docs/apps/danielsmith.prod.tag." >&2; exit 1; }

--- a/scripts/test-danielsmith-oci-tag-normalization.sh
+++ b/scripts/test-danielsmith-oci-tag-normalization.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+if ! command -v just >/dev/null 2>&1; then
+    echo "The 'just' command is required to run this test." >&2
+    exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+tmp_bin="${tmp_dir}/bin"
+mkdir -p "${tmp_bin}"
+helm_log="${tmp_dir}/helm.log"
+kubectl_log="${tmp_dir}/kubectl.log"
+home_dir="${tmp_dir}/home"
+mkdir -p "${home_dir}"
+
+cat >"${tmp_bin}/sudo" <<'SH_STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+    exit 0
+fi
+
+case "$1" in
+    cp)
+        dest="${3:-}"
+        if [ -z "${dest}" ]; then
+            exit 1
+        fi
+        mkdir -p "$(dirname "${dest}")"
+        cat >"${dest}" <<'KUBECONFIG'
+apiVersion: v1
+kind: Config
+clusters:
+- name: default
+  cluster:
+    server: https://127.0.0.1:6443
+contexts:
+- name: default
+  context:
+    cluster: default
+    user: default
+current-context: default
+users:
+- name: default
+  user: {}
+KUBECONFIG
+        ;;
+    chown|chmod)
+        ;;
+    test)
+        shift
+        test "$@"
+        ;;
+    *)
+        "$@"
+        ;;
+esac
+SH_STUB
+chmod +x "${tmp_bin}/sudo"
+
+cat >"${tmp_bin}/helm" <<'SH_STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$1" = "-n" ] && [ "$3" = "status" ]; then
+    echo "STATUS: deployed"
+    exit 0
+fi
+
+echo "helm $*" >> "${HELM_TEST_LOG:-/dev/null}"
+SH_STUB
+chmod +x "${tmp_bin}/helm"
+
+cat >"${tmp_bin}/kubectl" <<'SH_STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "kubectl $*" >> "${KUBECTL_TEST_LOG:-/dev/null}"
+
+if [ "$1" = "-n" ] && [ "$3" = "get" ] && [ "$4" = "deploy,statefulset,daemonset" ]; then
+    if [ "${*: -1}" = "name" ]; then
+        echo "deployment.apps/danielsmith"
+    elif [[ "$*" == *"jsonpath"* ]]; then
+        echo "Deployment/danielsmith"
+    fi
+    exit 0
+fi
+
+if [ "$1" = "-n" ] && [ "$3" = "rollout" ] && [ "$4" = "status" ]; then
+    echo "deployment \"danielsmith\" successfully rolled out"
+    exit 0
+fi
+
+if [ "$1" = "-n" ] && [ "$3" = "get" ] && [ "$4" = "deployment.apps/danielsmith" ]; then
+    echo "danielsmith=ghcr.io/futuroptimist/danielsmith.io:main-deadbee"
+    exit 0
+fi
+
+if [ "$1" = "-n" ] && [ "$3" = "get" ] && [ "$4" = "ingress" ]; then
+    exit 0
+fi
+
+exit 0
+SH_STUB
+chmod +x "${tmp_bin}/kubectl"
+
+run_with_stubs() {
+    PATH="${tmp_bin}:${PATH}" \
+    HOME="${home_dir}" \
+    USER="${USER:-sugarkube}" \
+    HELM_TEST_LOG="${helm_log}" \
+    KUBECTL_TEST_LOG="${kubectl_log}" \
+    KUBECONFIG="${home_dir}/.kube/config" \
+        just "$@"
+}
+
+assert_helm_tag() {
+    local expected_tag="$1"
+    local latest_line
+    latest_line="$(tail -n1 "${helm_log}")"
+    if [[ "${latest_line}" != *"--set image.tag=${expected_tag}"* ]]; then
+        printf 'Expected latest helm call to set image.tag=%s.\nLatest helm call:\n%s\n' \
+            "${expected_tag}" "${latest_line}" >&2
+        exit 1
+    fi
+    if [[ "${latest_line}" == *"image.tag=tag="* ]]; then
+        printf 'Helm call still contained a tag= prefix.\nLatest helm call:\n%s\n' \
+            "${latest_line}" >&2
+        exit 1
+    fi
+}
+
+run_with_stubs danielsmith-oci-deploy env=staging tag=main-deadbee >"${tmp_dir}/deploy-named.out"
+assert_helm_tag "main-deadbee"
+
+run_with_stubs danielsmith-oci-deploy staging main-deadbee >"${tmp_dir}/deploy-positional.out"
+assert_helm_tag "main-deadbee"
+
+run_with_stubs danielsmith-oci-redeploy env=staging tag=tag=main-deadbee >"${tmp_dir}/redeploy-named.out"
+assert_helm_tag "main-deadbee"
+
+run_with_stubs danielsmith-oci-promote-prod tag=tag=main-deadbee >"${tmp_dir}/promote-named.out"
+assert_helm_tag "main-deadbee"
+
+for mutable_tag in tag=main-latest tag=latest tag=main; do
+    if run_with_stubs danielsmith-oci-deploy env=staging "${mutable_tag}" \
+        >"${tmp_dir}/mutable.out" 2>"${tmp_dir}/mutable.err"; then
+        printf 'Expected mutable Danielsmith tag to be rejected: %s\n' "${mutable_tag}" >&2
+        exit 1
+    fi
+    if ! grep -q "mutable tag" "${tmp_dir}/mutable.err"; then
+        printf 'Mutable tag rejection did not explain the immutable-tag policy for %s.\nOutput:\n%s\n' \
+            "${mutable_tag}" "$(cat "${tmp_dir}/mutable.err")" >&2
+        exit 1
+    fi
+done
+
+printf 'Danielsmith OCI wrappers normalize named tag arguments and still reject mutable tags.\n'


### PR DESCRIPTION
### Motivation
- The Danielsmith `just` wrappers passed named-style tag arguments like `tag=main-5804a0...` verbatim into immutable-tag validation, causing valid immutable tags to be rejected. The wrappers must accept both positional and named forms and still reject mutable tags.

### Description
- Strip repeated `tag=` prefixes from the `tag` parameter before any empty-tag fallback or `validate_immutable_tag` checks in `danielsmith-oci-deploy`, `danielsmith-oci-redeploy`, and `danielsmith-oci-promote-prod` using a small `while` loop.
- Add a dry-run-safe verification script `scripts/test-danielsmith-oci-tag-normalization.sh` that stubs `sudo`, `helm`, and `kubectl` and asserts that named `tag=...`, repeated `tag=tag=...`, and positional forms normalize to the expected immutable tag and that mutable tags are rejected.
- Invoke the new verification script in CI next to the existing Helm OCI helper test in `.github/workflows/ci.yml`.
- Preserve existing immutable-tag validation semantics; only normalize the `tag=` prefix before validation and fallback logic.

### Testing
- Ran `just --unstable --fmt --check` to validate justfile formatting; status: passed for changed files.
- Executed the new unit-like test: `bash -n scripts/test-danielsmith-oci-tag-normalization.sh` (syntax check) and `./scripts/test-danielsmith-oci-tag-normalization.sh`; status: test passed and confirmed named, positional, repeated-prefix normalization and mutable-tag rejection.
- Ran the existing Helm helper verification: `./scripts/test-helm-oci-install.sh`; status: passed.
- Ran repository checks: `pre-commit run --all-files` (and `pre-commit run --files .github/workflows/ci.yml justfile scripts/test-danielsmith-oci-tag-normalization.sh`); status: failed due to pre-existing repo-wide formatting/YAML/flake8 issues unrelated to this change (local file-level hooks passed for the modified files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1916bb04fc832fba0f77f2daf3e0ad)