### PR TITLE
Fix Danielsmith OCI named tag normalization

### DIFF
--- a/justfile
+++ b/justfile
@@ -2188,6 +2188,9 @@ danielsmith-oci-deploy env='staging' tag='':
     }
 
     resolved_tag="$(echo '{{ tag }}' | xargs)"
+    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
+      resolved_tag="${resolved_tag#tag=}"
+    done
     if [ -z "${resolved_tag}" ]; then
       echo "ERROR: tag is required for immutable deploys." >&2
       exit 1
@@ -2252,6 +2255,9 @@ danielsmith-oci-promote-prod tag='':
     read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.prod.tag | head -n1 | tr -d '[:space:]'; }
 
     resolved_tag="$(echo '{{ tag }}' | xargs)"
+    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
+      resolved_tag="${resolved_tag#tag=}"
+    done
     if [ -z "${resolved_tag}" ]; then
       resolved_tag="$(read_prod_tag 2>/dev/null || true)"
     fi
@@ -2296,6 +2302,9 @@ danielsmith-oci-redeploy env='staging' tag='':
     read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.prod.tag | head -n1 | tr -d '[:space:]'; }
 
     resolved_tag="$(echo '{{ tag }}' | xargs)"
+    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
+      resolved_tag="${resolved_tag#tag=}"
+    done
     if [ -z "${resolved_tag}" ] && [ "${env_name}" = "prod" ]; then
       resolved_tag="$(read_prod_tag 2>/dev/null || true)"
       [ -n "${resolved_tag}" ] || { echo "ERROR: prod requires tag=<immutable-tag> or docs/apps/danielsmith.prod.tag." >&2; exit 1; }

--- a/tests/test_danielsmith_oci_tag_normalization.py
+++ b/tests/test_danielsmith_oci_tag_normalization.py
@@ -1,0 +1,63 @@
+"""Regression tests for Danielsmith OCI just wrapper tag normalization."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+JUSTFILE = REPO_ROOT / "justfile"
+
+
+def _recipe_body(justfile_text: str, recipe_name: str) -> str:
+    pattern = rf"(?ms)^{re.escape(recipe_name)} .+?(?=^\S|\Z)"
+    match = re.search(pattern, justfile_text)
+    assert match is not None, f"could not find {recipe_name} recipe"
+    return match.group(0)
+
+
+def _normalize_with_wrapper_shell(value: str) -> str:
+    script = r'''
+set -Eeuo pipefail
+resolved_tag="$(echo "$1" | xargs)"
+while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
+  resolved_tag="${resolved_tag#tag=}"
+done
+printf '%s\n' "${resolved_tag}"
+'''
+    completed = subprocess.run(
+        ["bash", "-c", script, "bash", value],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return completed.stdout.rstrip("\n")
+
+
+def test_danielsmith_wrappers_strip_named_tag_prefixes_before_use() -> None:
+    """All Danielsmith user-facing tag wrappers strip one or more tag= prefixes."""
+    justfile_text = JUSTFILE.read_text(encoding="utf-8")
+
+    for recipe_name in (
+        "danielsmith-oci-deploy",
+        "danielsmith-oci-promote-prod",
+        "danielsmith-oci-redeploy",
+    ):
+        body = _recipe_body(justfile_text, recipe_name)
+        assert "while [ \"${resolved_tag#tag=}\" != \"${resolved_tag}\" ]; do" in body
+        assert "resolved_tag=\"${resolved_tag#tag=}\"" in body
+
+
+def test_danielsmith_tag_normalization_accepts_positional_and_named_forms() -> None:
+    """The shell normalization used by the wrappers preserves positional tags."""
+    assert _normalize_with_wrapper_shell("main-deadbee") == "main-deadbee"
+    assert _normalize_with_wrapper_shell("tag=main-deadbee") == "main-deadbee"
+    assert _normalize_with_wrapper_shell("tag=tag=main-deadbee") == "main-deadbee"
+
+
+def test_danielsmith_tag_normalization_keeps_mutable_tag_text_for_validation() -> None:
+    """Mutable named tags normalize to mutable values so existing validation rejects them."""
+    assert _normalize_with_wrapper_shell("tag=main") == "main"
+    assert _normalize_with_wrapper_shell("tag=main-latest") == "main-latest"
+    assert _normalize_with_wrapper_shell("tag=latest") == "latest"


### PR DESCRIPTION
### Motivation
- The Danielsmith `just` wrappers rejected named-style `tag=...` arguments because the wrapper validated the literal `tag=...` string instead of the normalized tag, making documented invocations like `just danielsmith-oci-deploy env=staging tag="$DANIELSMITH_TAG"` fail.

### Description
- Add a small normalization loop that strips repeated `tag=` prefixes before fallback, validation, and delegation in `danielsmith-oci-deploy`, `danielsmith-oci-promote-prod`, and `danielsmith-oci-redeploy` so both positional and named-style inputs are accepted.
- Preserve the existing immutable-tag validation semantics and the prod fallback behavior so empty-tag fallbacks remain unchanged.
- Add `tests/test_danielsmith_oci_tag_normalization.py` to assert the normalization block exists and to check positional, named, repeated-prefix normalization and that mutable tags still normalize to mutable values for rejection.

### Testing
- Ran `python -m pytest tests/test_danielsmith_oci_tag_normalization.py tests/test_helper_recipes.py -q` and observed all tests pass (`13 passed`).
- Ran `just --unstable --fmt --check` and it succeeded for the updated `justfile` formatting check.
- Verified recipe visibility with `just --list | grep -E 'danielsmith-oci-(deploy|redeploy|promote-prod)'` which listed the three recipes.
- Performed fake-`just`/fake-`kubectl` smoke checks simulating `just danielsmith-oci-deploy env=staging tag=main-deadbee`, positional invocations, repeated `tag=tag=...` inputs, and mutable-tag cases, and confirmed the Helm helper receives `tag=main-deadbee` for normalized inputs and mutable tags still fail validation (exit status 1).
- Ran `git diff --cached | ./scripts/scan-secrets.py` which produced no secrets warnings for the staged changes.
- Attempted `pre-commit run --all-files`, which failed due to existing unrelated repository-wide issues (YAML multi-document parsing and pre-existing flake8 findings); these unrelated failures are not caused by this focused change and were not altered by it.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1916bb04fc832fba0f77f2daf3e0ad)