### PR TITLE
Fix Danielsmith OCI tag argument normalization

### DIFF
--- a/justfile
+++ b/justfile
@@ -2188,6 +2188,9 @@ danielsmith-oci-deploy env='staging' tag='':
     }
 
     resolved_tag="$(echo '{{ tag }}' | xargs)"
+    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
+      resolved_tag="${resolved_tag#tag=}"
+    done
     if [ -z "${resolved_tag}" ]; then
       echo "ERROR: tag is required for immutable deploys." >&2
       exit 1
@@ -2252,6 +2255,9 @@ danielsmith-oci-promote-prod tag='':
     read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.prod.tag | head -n1 | tr -d '[:space:]'; }
 
     resolved_tag="$(echo '{{ tag }}' | xargs)"
+    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
+      resolved_tag="${resolved_tag#tag=}"
+    done
     if [ -z "${resolved_tag}" ]; then
       resolved_tag="$(read_prod_tag 2>/dev/null || true)"
     fi
@@ -2296,6 +2302,9 @@ danielsmith-oci-redeploy env='staging' tag='':
     read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.prod.tag | head -n1 | tr -d '[:space:]'; }
 
     resolved_tag="$(echo '{{ tag }}' | xargs)"
+    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
+      resolved_tag="${resolved_tag#tag=}"
+    done
     if [ -z "${resolved_tag}" ] && [ "${env_name}" = "prod" ]; then
       resolved_tag="$(read_prod_tag 2>/dev/null || true)"
       [ -n "${resolved_tag}" ] || { echo "ERROR: prod requires tag=<immutable-tag> or docs/apps/danielsmith.prod.tag." >&2; exit 1; }

--- a/tests/test_danielsmith_oci_wrappers.py
+++ b/tests/test_danielsmith_oci_wrappers.py
@@ -1,0 +1,107 @@
+"""Regression coverage for Danielsmith OCI just wrapper argument normalization."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_executable(path: Path, contents: str) -> None:
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(0o755)
+
+
+@pytest.fixture()
+def wrapper_stubs(tmp_path: Path) -> tuple[Path, Path]:
+    """Place harmless just/kubectl stubs before PATH for inner recipe calls."""
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    just_log = tmp_path / "inner-just.log"
+    _write_executable(
+        bin_dir / "just",
+        """#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$*" >> "${SUGARKUBE_JUST_LOG}"
+""",
+    )
+    _write_executable(
+        bin_dir / "kubectl",
+        """#!/usr/bin/env bash
+exit 0
+""",
+    )
+    return bin_dir, just_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize(
+    ("recipe", "args", "expected_helper"),
+    [
+        ("danielsmith-oci-deploy", ["env=staging", "tag=tag=main-deadbee"], "helm-oci-install"),
+        ("danielsmith-oci-deploy", ["staging", "main-deadbee"], "helm-oci-install"),
+        ("danielsmith-oci-redeploy", ["env=staging", "tag=tag=main-deadbee"], "helm-oci-upgrade"),
+    ],
+)
+def test_danielsmith_oci_wrappers_pass_immutable_tags_to_helm_helpers(
+    wrapper_stubs: tuple[Path, Path], recipe: str, args: list[str], expected_helper: str
+) -> None:
+    """Named-style and positional tags should reach the Helm wrapper as immutable tags."""
+
+    bin_dir, just_log = wrapper_stubs
+    just_bin = shutil.which("just")
+    assert just_bin, "just should be installed by the ensure_just_available fixture"
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["SUGARKUBE_JUST_LOG"] = str(just_log)
+
+    result = subprocess.run(
+        [just_bin, recipe, *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    log = just_log.read_text(encoding="utf-8")
+    assert expected_helper in log
+    assert "tag=main-deadbee" in log
+    assert "tag=tag=main-deadbee" not in log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize("mutable_tag", ["tag=main-latest", "tag=latest", "tag=main"])
+def test_danielsmith_oci_deploy_rejects_named_mutable_tags(
+    wrapper_stubs: tuple[Path, Path], mutable_tag: str
+) -> None:
+    """Mutable tag rejection should run after named-style tag normalization."""
+
+    bin_dir, just_log = wrapper_stubs
+    just_bin = shutil.which("just")
+    assert just_bin, "just should be installed by the ensure_just_available fixture"
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["SUGARKUBE_JUST_LOG"] = str(just_log)
+
+    result = subprocess.run(
+        [just_bin, "danielsmith-oci-deploy", "env=staging", mutable_tag],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "mutable tag" in result.stderr
+    assert not just_log.exists(), "invalid tags should fail before invoking helper recipes"


### PR DESCRIPTION
### Motivation
- Named-style `just` invocations like `just danielsmith-oci-deploy env=staging tag="$DANIELSMITH_TAG"` were passing the literal `tag=...` string into immutable-tag validation, causing valid immutable tags to be rejected. 
- The intent is to accept both positional and named-style `tag` inputs (including accidental repeated `tag=` prefixes) while preserving existing mutable-tag rejection rules.

### Description
- Normalize repeated `tag=` prefixes by adding a small loop that strips leading `tag=` occurrences in the Danielsmith wrappers using `while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do resolved_tag="${resolved_tag#tag=}"; done` in `justfile` for `danielsmith-oci-deploy`, `danielsmith-oci-promote-prod`, and `danielsmith-oci-redeploy`. 
- Leave the existing `validate_immutable_tag()` logic unchanged so mutable tags remain rejected. 
- Add `tests/test_danielsmith_oci_wrappers.py` which uses harmless `just`/`kubectl` stubs to assert that named and positional invocation forms reach the Helm helpers with normalized immutable tags and that named mutable tags are rejected before helper invocation. 

### Testing
- Ran `python3 -m pytest tests/test_danielsmith_oci_wrappers.py -q` and the new tests passed (`6 passed`).
- Ran `just --unstable --fmt --check` which passed for the changed justfile formatting. 
- Verified recipe visibility with `just --list | grep -E 'danielsmith-oci-(deploy|redeploy|promote-prod)'` and examples in docs with `grep -n "danielsmith-oci-deploy" -n justfile docs/apps/danielsmith.md docs/k3s-danielsmith-staging.md docs/k3s-danielsmith-prod.md` which returned the expected lines. 
- Attempted `pre-commit run --all-files` and `python3 -m pre_commit run --all-files` but these failed due to unrelated, pre-existing repository-wide checks (YAML/flake8 issues) outside the scope of this targeted change; targeted hooks for the modified files succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1916bb04fc832fba0f77f2daf3e0ad)