### PR TITLE
docs: define Sugarkube app deployment contract and add app-config scaffolds

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,16 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
 
 ## Application runbooks
 
+- **[Sugarkube app deployment contract](docs/app_deployment_contract.md)** — shared artifact,
+  tag, chart, config, and future generic command contract for apps on Sugarkube.
 - **[token.place onboarding contract](docs/tokenplace_sugarkube_onboarding.md)** — prerequisites,
   ownership boundaries, and environment mapping for first-class token.place operations.
 - **[token.place app operations](docs/apps/tokenplace.md)** — topology and deployment workflow
   patterns for token.place on Sugarkube.
+- **[dspace app operations](docs/apps/dspace.md)** — topology and deployment workflow patterns for
+  democratized.space on Sugarkube.
+- **[danielsmith.io app operations](docs/apps/danielsmith.md)** — static-site deployment workflow
+  patterns for danielsmith.io on Sugarkube.
 - **[token.place env runbooks](docs/index.md)** — environment-specific guides for
   [dev](docs/k3s-tokenplace-dev.md), [staging](docs/k3s-tokenplace-staging.md), and
   [production](docs/k3s-tokenplace-prod.md) operations.

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -1,0 +1,160 @@
+# Sugarkube app deployment contract
+
+This contract defines the cross-app shape that future Sugarkube app automation will use. It is a
+specification and docs scaffold only: the existing `justfile` app-specific helpers remain the live
+entry points until the generic recipes are implemented.
+
+Sugarkube's app boundary is intentionally small:
+
+- **App repositories** own the application source, Dockerfile, Helm chart, and GHCR publishing.
+- **Sugarkube** owns cluster and environment deployment orchestration from local app config files.
+
+The current examples are dspace, token.place, and danielsmith.io. Future apps such as wove and
+jobbot3000 should use this same contract once their app repositories have charts and publishing
+workflows.
+
+## Standard artifact model
+
+Every app must identify these deployment artifacts and runtime checks:
+
+| Field | Required shape | Purpose |
+| --- | --- | --- |
+| Image | `ghcr.io/OWNER/IMAGE` | Container image repository published by the app repo. |
+| Chart | `oci://ghcr.io/OWNER/charts/CHART` | Immutable Helm OCI chart published by the app repo. |
+| Release name | Stable Helm release name, usually the app slug. | Selects the Helm release to install, upgrade, and inspect. |
+| Namespace | Stable Kubernetes namespace, usually the app slug. | Isolates app resources and status checks. |
+| Chart version pin file | Repo-local text file such as `docs/apps/APP.version`. | Records the chart version Sugarkube should deploy. |
+| Prod-approved tag pin file | Optional repo-local text file such as `docs/apps/APP.prod.tag`. | Records the image tag approved for production promotion. |
+| Values chain per environment | Comma-separated values files for `dev`, `staging`, and `prod`. | Keeps base settings separate from environment routing and sizing. |
+| Validation URLs and paths | Host resolved from Helm values plus a comma-separated path list. | Powers post-deploy smoke checks and runbook commands. |
+
+The values chain is ordered from shared base to environment-specific overlay. For example, staging
+usually looks like `docs/examples/APP.values.dev.yaml,docs/examples/APP.values.staging.yaml`, while
+production uses `docs/examples/APP.values.dev.yaml,docs/examples/APP.values.prod.yaml`.
+
+## Standard image tag model
+
+Deployment tags must identify what is running without depending on mutable names.
+
+Allowed deployment tags:
+
+- **Immutable branch-SHA tag:** `main-REPLACE_SHORTSHA`, where `REPLACE_SHORTSHA` is a real short
+  Git SHA from the app repository. This is the default shape for staging validation and most
+  non-prod deploys.
+- **Mutable branch convenience tag:** `main-latest`. This is allowed only for explicitly documented
+  non-prod bootstrap or rapid iteration. It is not acceptable for production promotion.
+- **Release or stable tag:** `v1.2.3`, `3.1.0`, or another app-specific stable tag documented by
+  the app repo.
+
+Disallowed deployment tags:
+
+- `latest`
+- bare branch names such as `main`, `master`, or `develop`
+- environment names such as `dev`, `staging`, `prod`, or `production`
+
+Environment selection belongs in Sugarkube values overlays and kubeconfig selection. Image tags
+belong to the app release lineage. Do not encode an environment as the deployment tag.
+
+## Standard chart publishing model
+
+- Chart versions are immutable once published to GHCR.
+- App repos must bump the chart version whenever chart content changes.
+- App repos own their Dockerfile, app chart, and GHCR image/chart publishing workflows.
+- Sugarkube owns deployment orchestration: choosing the environment, resolving the app config,
+  reading chart and prod tag pins, applying values chains, and running status/verification checks.
+
+A Sugarkube PR should update the chart version pin file only after the app repo has published that
+chart version.
+
+## App config file shape
+
+Future generic recipes will read a simple shell/dotenv-style config so they do not require `yq`.
+Each file must be safe to source in Bash: use `KEY=value` pairs, quote values only when needed, and
+keep comments on their own lines.
+
+Example configs live under `docs/examples/apps/` and are templates, not active platform defaults.
+Copy one into a local config directory before using the future generic recipes:
+
+```bash
+mkdir -p apps
+cp docs/examples/apps/tokenplace.env apps/tokenplace.env
+```
+
+Operators may also keep app configs outside the repository and point Sugarkube at them:
+
+```bash
+export SUGARKUBE_APP_CONFIG_DIR=/srv/sugarkube-apps
+just app-config app=tokenplace env=staging
+```
+
+Required keys for the P5 generic recipes:
+
+| Key | Description |
+| --- | --- |
+| `SUGARKUBE_APP` | Stable app slug used to find the config. |
+| `SUGARKUBE_RELEASE` | Helm release name. |
+| `SUGARKUBE_NAMESPACE` | Kubernetes namespace. |
+| `SUGARKUBE_CHART` | Helm OCI chart reference. |
+| `SUGARKUBE_VERSION_FILE` | File containing the pinned chart version. |
+| `SUGARKUBE_PROD_TAG_FILE` | File containing the prod-approved image tag, or an empty value when unused. |
+| `SUGARKUBE_VALUES_DEV` | Values chain for `env=dev`. |
+| `SUGARKUBE_VALUES_STAGING` | Values chain for `env=staging`. |
+| `SUGARKUBE_VALUES_PROD` | Values chain for `env=prod`. |
+| `SUGARKUBE_STATUS_HOST_KEY` | Dotted Helm values key used to find the public host, for example `ingress.host`. |
+| `SUGARKUBE_VERIFY_PATHS` | Comma-separated HTTP paths for smoke verification. |
+| `SUGARKUBE_DEBUG_SELECTOR` | Kubernetes label selector for app pod logs and debug output. |
+
+## Future generic command surface
+
+P5 will implement the commands below. They are documented here so app repos and Sugarkube docs can
+align before behavior changes land.
+
+```bash
+just app-config app=tokenplace env=staging
+```
+
+```bash
+just app-deploy app=tokenplace env=staging tag=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-redeploy app=tokenplace env=staging tag=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-promote-prod app=tokenplace tag=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-status app=tokenplace env=staging
+```
+
+```bash
+just app-verify app=tokenplace env=staging
+```
+
+Expected behavior once implemented:
+
+1. `app-config` resolves and prints the config file, selected values chain, chart version pin, prod
+   tag pin, status host key, verify paths, and debug selector.
+2. `app-deploy` installs or upgrades the app with the selected values chain and immutable image tag.
+3. `app-redeploy` performs an upgrade-only refresh for an existing release and waits for rollout.
+4. `app-promote-prod` deploys `env=prod`, using the explicit tag or the prod-approved tag pin file.
+5. `app-status` prints pods, ingress, Helm release status, and the resolved public URL when present.
+6. `app-verify` runs the app's configured HTTP path checks against the environment host.
+
+Until P5 lands, keep using the existing app-specific wrappers documented in each app runbook.
+
+## Current app examples
+
+| App | Image | Chart | Release / namespace | Version pin | Prod tag pin | Verify paths |
+| --- | --- | --- | --- | --- | --- | --- |
+| dspace | `ghcr.io/democratizedspace/dspace` | `oci://ghcr.io/democratizedspace/charts/dspace` | `dspace` / `dspace` | `docs/apps/dspace.version` | `docs/apps/dspace.prod.tag` | `/config.json,/healthz,/livez` |
+| token.place | `ghcr.io/futuroptimist/tokenplace-relay` | `oci://ghcr.io/futuroptimist/charts/tokenplace` | `tokenplace` / `tokenplace` | `docs/apps/tokenplace.version` | `docs/apps/tokenplace.prod.tag` | `/,/livez,/healthz,/relay/diagnostics` |
+| danielsmith.io | `ghcr.io/futuroptimist/danielsmith.io` | `oci://ghcr.io/futuroptimist/charts/danielsmith` | `danielsmith` / `danielsmith` | `docs/apps/danielsmith.version` | `docs/apps/danielsmith.prod.tag` | `/,/livez,/healthz` |
+
+See the template configs for the complete values chains:
+
+- [`docs/examples/apps/dspace.env`](examples/apps/dspace.env)
+- [`docs/examples/apps/tokenplace.env`](examples/apps/tokenplace.env)
+- [`docs/examples/apps/danielsmith.env`](examples/apps/danielsmith.env)

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -1,5 +1,8 @@
 # danielsmith.io on Sugarkube
 
+This app follows the shared [Sugarkube app deployment contract](../app_deployment_contract.md),
+including the artifact model, immutable tag policy, and future generic `just app-*` command shape.
+
 This is the canonical Sugarkube deployment model for `danielsmith.io`.
 
 ## Topology and scope (static-site only)

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -1,5 +1,8 @@
 # democratized.space (dspace) on Sugarkube
 
+This app follows the shared [Sugarkube app deployment contract](../app_deployment_contract.md),
+including the artifact model, immutable tag policy, and future generic `just app-*` command shape.
+
 This guide covers **steady-state dspace operations** on Sugarkube: repeatable deploys,
 upgrades, promotions, and rollbacks using immutable image tags.
 

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -1,5 +1,8 @@
 # token.place on Sugarkube
 
+This app follows the shared [Sugarkube app deployment contract](../app_deployment_contract.md),
+including the artifact model, immutable tag policy, and future generic `just app-*` command shape.
+
 This is the canonical Sugarkube deployment model for token.place.
 
 For onboarding ownership and environment sequencing, see

--- a/docs/examples/apps/danielsmith.env
+++ b/docs/examples/apps/danielsmith.env
@@ -1,0 +1,16 @@
+# Example Sugarkube app config for danielsmith.io.
+# Copy to apps/danielsmith.env or set SUGARKUBE_APP_CONFIG_DIR to a directory containing danielsmith.env.
+# This file is documentation scaffolding only; current deployments still use app-specific just recipes.
+
+SUGARKUBE_APP=danielsmith
+SUGARKUBE_RELEASE=danielsmith
+SUGARKUBE_NAMESPACE=danielsmith
+SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/danielsmith
+SUGARKUBE_VERSION_FILE=docs/apps/danielsmith.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/danielsmith.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/danielsmith.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=danielsmith

--- a/docs/examples/apps/dspace.env
+++ b/docs/examples/apps/dspace.env
@@ -1,0 +1,16 @@
+# Example Sugarkube app config for dspace.
+# Copy to apps/dspace.env or set SUGARKUBE_APP_CONFIG_DIR to a directory containing dspace.env.
+# This file is documentation scaffolding only; current deployments still use app-specific just recipes.
+
+SUGARKUBE_APP=dspace
+SUGARKUBE_RELEASE=dspace
+SUGARKUBE_NAMESPACE=dspace
+SUGARKUBE_CHART=oci://ghcr.io/democratizedspace/charts/dspace
+SUGARKUBE_VERSION_FILE=docs/apps/dspace.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/dspace.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/dspace.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/config.json,/healthz,/livez
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=dspace

--- a/docs/examples/apps/tokenplace.env
+++ b/docs/examples/apps/tokenplace.env
@@ -1,0 +1,16 @@
+# Example Sugarkube app config for token.place.
+# Copy to apps/tokenplace.env or set SUGARKUBE_APP_CONFIG_DIR to a directory containing tokenplace.env.
+# This file is documentation scaffolding only; current deployments still use app-specific just recipes.
+
+SUGARKUBE_APP=tokenplace
+SUGARKUBE_RELEASE=tokenplace
+SUGARKUBE_NAMESPACE=tokenplace
+SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/tokenplace
+SUGARKUBE_VERSION_FILE=docs/apps/tokenplace.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/tokenplace.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/tokenplace.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz,/relay/diagnostics
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=tokenplace

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,8 +43,11 @@ Review the safety notes before working with power components.
   and Helm OCI issues, including GHCR `401/403` chart pull failures
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
 - [projects-compose.md](projects-compose.md) — run token.place & dspace via docker compose
+- [app_deployment_contract.md](app_deployment_contract.md) — shared Sugarkube app artifact, tag,
+  chart, config, and future generic command contract
 - [tokenplace_sugarkube_onboarding.md](tokenplace_sugarkube_onboarding.md) — onboarding contract,
   ownership boundaries, and environment mapping for token.place on Sugarkube
+- [apps/dspace.md](apps/dspace.md) — democratized.space app topology and operations model on Sugarkube
 - [apps/tokenplace.md](apps/tokenplace.md) — token.place app topology and operations model on Sugarkube
 - [apps/tokenplace-relay.md](apps/tokenplace-relay.md) — relay-only token.place OCI staging/prod operations guide
 - [apps/danielsmith.md](apps/danielsmith.md) — danielsmith.io static-site topology and operations model on Sugarkube


### PR DESCRIPTION
### Motivation
- Establish a shared, explicit contract for how apps publish artifacts and how Sugarkube will consume app configs before implementing the generic `just app-*` workflows (P5).
- Provide copy-pasteable, dotenv-style example app config files so future generic recipes can parse them without introducing new tooling dependencies.
- Surface the allowed/forbidden image tag shapes, chart-publishing expectations, and the exact generic command surface that P5 will implement.

### Description
- Added `docs/app_deployment_contract.md` documenting the artifact model (image/chart/release/namespace/version and prod-tag pins), canonical tag model (immutable branch-SHA, limited mutable convenience tags, semver), chart publishing rules, dotenv-style app config shape, verification/host conventions, and the future generic command surface (`just app-config`, `just app-deploy`, `just app-redeploy`, `just app-promote-prod`, `just app-status`, `just app-verify`).
- Added example app config scaffolds under `docs/examples/apps/` for `dspace.env`, `tokenplace.env`, and `danielsmith.env` containing the required `SUGARKUBE_*` keys and values chains for `dev|staging|prod` (these are templates and not active platform defaults).
- Linked the new contract from `README.md` and `docs/index.md`, and added a short reference note into each existing app runbook (`docs/apps/dspace.md`, `docs/apps/tokenplace.md`, `docs/apps/danielsmith.md`) to point readers to the new contract without changing any runtime behavior or existing `justfile` recipes.

### Testing
- Ran `git diff --check` and it reported no check failures related to these changed files (OK).
- Ran `python -m pytest tests -q` which completed successfully: `1178 passed, 43 skipped` (OK).
- Verified doc grep checks: `rg "app-deploy app=" docs | head` and `rg "SUGARKUBE_CHART" docs/examples/apps` returned expected references (OK).
- Ran `git diff | ./scripts/scan-secrets.py` to scan for accidental secrets and it produced no findings (OK).
- Attempted repository checks that couldn't run in this environment: `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` were not executed because the corresponding commands are not installed in the execution environment (NOT RUN).
- Ran `bash scripts/checks.sh`; it reported pre-existing lint/flake8 line-length and whitespace warnings in unrelated files and skipped KiCad checks because KiCad is not installed (FAIL — issues are pre-existing and outside this PR's modified files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d47c8e244832f8ec112cedbc516f1)