### PR TITLE
docs: define Sugarkube app deployment contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
 
 ## Application runbooks
 
+- **[Sugarkube app deployment contract](docs/app_deployment_contract.md)** — shared artifact,
+  tag, chart, app-config, and future generic `just app-*` command contract.
 - **[token.place onboarding contract](docs/tokenplace_sugarkube_onboarding.md)** — prerequisites,
   ownership boundaries, and environment mapping for first-class token.place operations.
 - **[token.place app operations](docs/apps/tokenplace.md)** — topology and deployment workflow

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -1,0 +1,179 @@
+# Sugarkube app deployment contract
+
+This page defines the target cross-app deployment contract that future generic
+Sugarkube recipes will implement. It is a **specification and scaffold only**:
+today's app-specific `just` recipes and Helm OCI helpers remain the live
+interfaces until the generic recipes are implemented.
+
+Sugarkube's role is cluster and environment orchestration. Each app repository
+continues to own its application source, Dockerfile, Helm chart, release process,
+and GHCR publishing workflow.
+
+## Standard artifact model
+
+Every Sugarkube app should publish and deploy the same set of artifacts and
+metadata:
+
+| Field | Contract |
+| --- | --- |
+| Image | `ghcr.io/<owner>/<image>` |
+| Chart | `oci://ghcr.io/<owner>/charts/<chart>` |
+| Release name | Stable Helm release name, normally the app slug. |
+| Namespace | Stable Kubernetes namespace, normally the app slug. |
+| Chart version pin file | A repo-local file such as `docs/apps/<app>.version` containing the immutable chart version Sugarkube should deploy. |
+| Prod-approved tag pin file | Optional repo-local file such as `docs/apps/<app>.prod.tag` containing the immutable image tag approved for production. |
+| Values chain per environment | Comma-separated Helm values files, ordered from base to environment overlay. |
+| Validation URLs/paths | Environment host plus one or more HTTP paths that prove the app is serving the expected workload. |
+
+The chart and image names are intentionally separate. A chart may deploy an
+image whose repository name is not identical to the chart name, but that mapping
+belongs in the app-owned chart or environment values, not in ad hoc deploy
+commands.
+
+## Standard image tag model
+
+Deployment tags must identify what is actually running. Use these tag classes:
+
+- **Immutable branch-SHA tag:** `main-REPLACE_SHORTSHA` or an equivalent
+  branch-plus-short-SHA tag. This is the preferred staging, promotion, rollback,
+  and incident-response tag shape.
+- **Mutable branch convenience tag:** `main-latest`. This is allowed only for
+  explicitly documented non-production bootstrap or fast iteration. Never use it
+  for production sign-off or promotion.
+- **Release or stable tag:** `v1.2.3`, `3.1.0`, or a project-specific stable tag
+  documented by the app repository.
+
+Do **not** use these as deployment tags:
+
+- `latest`
+- bare branch names such as `main`, `master`, `develop`, or `release`
+- environment names such as `dev`, `staging`, `prod`, or `production`
+
+Environment names select kubeconfig context and values overlays. Image tags
+select the released application build. Keep those concerns separate.
+
+## Standard chart publishing model
+
+- Chart versions are immutable after publishing to GHCR.
+- App repositories must bump the chart version whenever chart content changes,
+  including templates, default values, probes, labels, or chart metadata.
+- App repositories own their Dockerfile, image publishing, Helm chart, chart
+  versioning, and GHCR workflow.
+- Sugarkube owns cluster/environment deployment orchestration, local chart
+  version pins, production tag approvals, and runbooks.
+- Sugarkube deploys the chart version in the app's version pin file unless an
+  emergency runbook explicitly says otherwise.
+
+## App config shape
+
+Future generic recipes will load one shell/dotenv-style app config file per app.
+The examples in [`docs/examples/apps/`](examples/apps/) are documentation
+scaffolds only. Copy one into a local config directory such as `apps/<app>.env`,
+or set `SUGARKUBE_APP_CONFIG_DIR` to a directory that contains `<app>.env` files.
+
+The file format intentionally avoids YAML-only tooling so a POSIX shell or Bash
+recipe can parse it without `yq`:
+
+```dotenv
+SUGARKUBE_APP=example
+SUGARKUBE_RELEASE=example
+SUGARKUBE_NAMESPACE=example
+SUGARKUBE_CHART=oci://ghcr.io/example/charts/example
+SUGARKUBE_VERSION_FILE=docs/apps/example.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/example.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/example.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/example.values.dev.yaml,docs/examples/example.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/example.values.dev.yaml,docs/examples/example.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=example
+```
+
+Required keys for the first generic implementation:
+
+- `SUGARKUBE_APP`: config/app slug passed to `app=<app>`.
+- `SUGARKUBE_RELEASE`: Helm release name.
+- `SUGARKUBE_NAMESPACE`: Kubernetes namespace.
+- `SUGARKUBE_CHART`: OCI chart reference.
+- `SUGARKUBE_VERSION_FILE`: chart version pin file.
+- `SUGARKUBE_PROD_TAG_FILE`: production-approved image tag pin file, if the app
+  supports production promotion.
+- `SUGARKUBE_VALUES_DEV`: dev values chain.
+- `SUGARKUBE_VALUES_STAGING`: staging values chain.
+- `SUGARKUBE_VALUES_PROD`: production values chain.
+- `SUGARKUBE_STATUS_HOST_KEY`: Helm values key that stores the public host.
+- `SUGARKUBE_VERIFY_PATHS`: comma-separated HTTP paths for verification.
+- `SUGARKUBE_DEBUG_SELECTOR`: Kubernetes label selector for app logs and pod
+  inspection.
+
+Keep values chains relative to the Sugarkube repo root unless a runbook clearly
+states otherwise.
+
+## Future generic command surface
+
+P5 in the prompt sequence will implement these recipes. They are documented here
+now so app repositories and runbooks can align before Sugarkube behavior changes:
+
+```bash
+APP=dspace
+TAG=main-REPLACE_SHORTSHA
+just app-config app="$APP" env=staging
+just app-deploy app="$APP" env=staging tag="$TAG"
+just app-status app="$APP" env=staging
+just app-verify app="$APP" env=staging
+```
+
+```bash
+APP=dspace
+TAG=main-REPLACE_SHORTSHA
+just app-redeploy app="$APP" env=staging tag="$TAG"
+```
+
+```bash
+APP=dspace
+TAG=main-REPLACE_SHORTSHA
+just app-promote-prod app="$APP" tag="$TAG"
+```
+
+Intended semantics:
+
+- `just app-config app=<app> env=<dev|staging|prod>` prints the resolved config,
+  values chain, chart version, release, namespace, and verification paths.
+- `just app-deploy app=<app> env=<dev|staging|prod> tag=<immutable-tag>` performs
+  install-or-upgrade for the pinned chart version and explicit immutable image
+  tag.
+- `just app-redeploy app=<app> env=<dev|staging|prod> tag=<immutable-tag>` performs
+  an upgrade/restart path for an already deployed immutable tag.
+- `just app-promote-prod app=<app> tag=<immutable-tag>` deploys the approved tag
+  to production and may read the prod tag pin file when `tag=` is omitted.
+- `just app-status app=<app> env=<dev|staging|prod>` selects the environment and
+  prints Kubernetes/Helm status plus the public URL when available.
+- `just app-verify app=<app> env=<dev|staging|prod>` curls the configured
+  verification paths for the environment host.
+
+Until those recipes exist, use the existing app-specific wrappers documented in
+the app runbooks.
+
+## Current app examples
+
+The current first-class app configs are examples, not platform defaults:
+
+- [`docs/examples/apps/dspace.env`](examples/apps/dspace.env)
+- [`docs/examples/apps/tokenplace.env`](examples/apps/tokenplace.env)
+- [`docs/examples/apps/danielsmith.env`](examples/apps/danielsmith.env)
+
+These examples model today's known release names, namespaces, chart references,
+version pin files, prod tag pin files, values chains, status host keys,
+verification paths, and debug selectors.
+
+Future apps such as **wove** and **jobbot3000** should be onboarded by adding
+app-owned image/chart publishing first, then copying this config shape into a
+local app config. Do not add Sugarkube app configs for future apps until they
+have concrete chart and publishing contracts.
+
+## Non-goals for this spec PR
+
+- No `justfile` deployment behavior changes.
+- No removal of app-specific recipes.
+- No live values changes.
+- No secrets, kubeconfig assumptions, or cluster credentials.

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -1,5 +1,8 @@
 # danielsmith.io on Sugarkube
 
+For the cross-app contract that future generic `just app-*` recipes will implement, see
+[`docs/app_deployment_contract.md`](../app_deployment_contract.md).
+
 This is the canonical Sugarkube deployment model for `danielsmith.io`.
 
 ## Topology and scope (static-site only)

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -3,6 +3,9 @@
 This guide covers **steady-state dspace operations** on Sugarkube: repeatable deploys,
 upgrades, promotions, and rollbacks using immutable image tags.
 
+For the cross-app contract that future generic `just app-*` recipes will implement, see
+[`docs/app_deployment_contract.md`](../app_deployment_contract.md).
+
 The `justfile` exposes both:
 
 - generic Helm OCI helpers (`helm-oci-install`, `helm-oci-upgrade`) for any app; and

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -2,6 +2,9 @@
 
 This is the canonical Sugarkube deployment model for token.place.
 
+For the cross-app contract that future generic `just app-*` recipes will implement, see
+[`docs/app_deployment_contract.md`](../app_deployment_contract.md).
+
 For onboarding ownership and environment sequencing, see
 [`docs/tokenplace_sugarkube_onboarding.md`](../tokenplace_sugarkube_onboarding.md).
 

--- a/docs/examples/apps/danielsmith.env
+++ b/docs/examples/apps/danielsmith.env
@@ -1,0 +1,17 @@
+# Example Sugarkube app config for danielsmith.io.
+# Copy to apps/danielsmith.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
+# containing danielsmith.env when the generic app recipes are implemented.
+# This example is documentation only; it is not loaded by today's justfile.
+
+SUGARKUBE_APP=danielsmith
+SUGARKUBE_RELEASE=danielsmith
+SUGARKUBE_NAMESPACE=danielsmith
+SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/danielsmith
+SUGARKUBE_VERSION_FILE=docs/apps/danielsmith.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/danielsmith.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/danielsmith.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=danielsmith

--- a/docs/examples/apps/dspace.env
+++ b/docs/examples/apps/dspace.env
@@ -1,0 +1,17 @@
+# Example Sugarkube app config for dspace.
+# Copy to apps/dspace.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
+# containing dspace.env when the generic app recipes are implemented.
+# This example is documentation only; it is not loaded by today's justfile.
+
+SUGARKUBE_APP=dspace
+SUGARKUBE_RELEASE=dspace
+SUGARKUBE_NAMESPACE=dspace
+SUGARKUBE_CHART=oci://ghcr.io/democratizedspace/charts/dspace
+SUGARKUBE_VERSION_FILE=docs/apps/dspace.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/dspace.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/dspace.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/config.json,/healthz,/livez
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=dspace

--- a/docs/examples/apps/tokenplace.env
+++ b/docs/examples/apps/tokenplace.env
@@ -1,0 +1,17 @@
+# Example Sugarkube app config for token.place.
+# Copy to apps/tokenplace.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
+# containing tokenplace.env when the generic app recipes are implemented.
+# This example is documentation only; it is not loaded by today's justfile.
+
+SUGARKUBE_APP=tokenplace
+SUGARKUBE_RELEASE=tokenplace
+SUGARKUBE_NAMESPACE=tokenplace
+SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/tokenplace
+SUGARKUBE_VERSION_FILE=docs/apps/tokenplace.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/tokenplace.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/tokenplace.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz,/relay/diagnostics
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=tokenplace

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,8 @@ Review the safety notes before working with power components.
   and Helm OCI issues, including GHCR `401/403` chart pull failures
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
 - [projects-compose.md](projects-compose.md) — run token.place & dspace via docker compose
+- [app_deployment_contract.md](app_deployment_contract.md) — shared Sugarkube app artifact,
+  tag, chart, app-config, and future generic `just app-*` command contract
 - [tokenplace_sugarkube_onboarding.md](tokenplace_sugarkube_onboarding.md) — onboarding contract,
   ownership boundaries, and environment mapping for token.place on Sugarkube
 - [apps/tokenplace.md](apps/tokenplace.md) — token.place app topology and operations model on Sugarkube


### PR DESCRIPTION
### Motivation
- Make the intended Sugarkube cross-app deployment contract explicit so future generic `just app-*` recipes (P5) can be implemented against a stable spec. 
- Provide a small, shell-friendly app-config scaffold and example configs for first-class apps so runbooks and app repos can align without changing current deployment behavior. 
- Wire the contract into the docs index and existing app runbooks so readers discover the new contract from the existing app pages.

### Description
- Add `docs/app_deployment_contract.md` defining the standard artifact model, image tag rules, chart publishing expectations, app-config shape, and the future generic `just app-*` command surface. 
- Add dotenv-style example app configs at `docs/examples/apps/{dspace,tokenplace,danielsmith}.env` modeling current release/chart/version/value chains and verification paths. 
- Link the new contract from `README.md`, `docs/index.md`, and the dspace/token.place/danielsmith app runbooks without modifying any `justfile` deployment behavior. 
- This PR is documentation-only and does not change runtime behavior, remove app-specific recipes, or edit live deployment values.

### Testing
- Ran `git diff --check` which completed with no local diff-check errors. 
- Verified doc patterns with `rg "app-deploy app=" docs | head` and `rg "SUGARKUBE_CHART" docs/examples/apps` which returned the expected references. 
- Ran the repository test suite with `python -m pytest tests -q` which succeeded (1178 passed, 43 skipped). 
- Ran secret scans `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` which produced no findings. 
- The following repo checks could not be executed in this environment: `pre-commit run --all-files` (missing `pre-commit`), `pyspelling -c .spellcheck.yaml` (missing `pyspelling`), and `linkchecker --no-warnings README.md docs/` (missing `linkchecker`). 
- `bash scripts/checks.sh` was attempted and exited due to unrelated pre-existing pycodestyle/line-length warnings and missing KiCad in this environment, not due to the docs changes introduced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d47c8e244832f8ec112cedbc516f1)