### PR TITLE
Define Sugarkube app deployment contract and add example app-config scaffolds

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
 
 ## Application runbooks
 
+- **[Sugarkube app deployment contract](docs/app_deployment_contract.md)** — cross-app
+  artifact, tag, chart, config, and future generic command contract.
 - **[token.place onboarding contract](docs/tokenplace_sugarkube_onboarding.md)** — prerequisites,
   ownership boundaries, and environment mapping for first-class token.place operations.
 - **[token.place app operations](docs/apps/tokenplace.md)** — topology and deployment workflow

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -1,0 +1,172 @@
+# Sugarkube app deployment contract
+
+This contract defines the target deployment shape for apps that run on a Sugarkube-managed
+Kubernetes environment. It is a **specification and docs scaffold only**: the current app-specific
+`just` recipes remain in place, and the generic commands below are reserved for the follow-up
+implementation.
+
+Sugarkube should be generic deployment sugar for many app repositories. App repositories own their
+build and release artifacts; Sugarkube owns cluster and environment orchestration.
+
+## Ownership boundary
+
+App repositories own:
+
+- the application source code;
+- the app `Dockerfile` and published image;
+- the app Helm chart and chart version bumps;
+- GHCR publishing workflows for images and charts; and
+- release notes or app-specific validation requirements.
+
+Sugarkube owns:
+
+- local app deployment config discovery;
+- environment-specific kubeconfig selection;
+- Helm install, upgrade, promote, status, and verify orchestration;
+- app runbooks that explain how to operate a release on the cluster; and
+- compatibility wrappers for existing app-specific workflows while the generic flow lands.
+
+Future apps such as `wove` and `jobbot3000` should onboard by publishing the same artifact set and
+adding a local app config. They should not require hard-coded Sugarkube recipes when the generic flow
+is available.
+
+## Standard artifact model
+
+Every Sugarkube app config describes these artifacts and deployment coordinates:
+
+| Field | Standard | Notes |
+| --- | --- | --- |
+| Image | `ghcr.io/OWNER/IMAGE` | Published by the app repository. |
+| Chart | `oci://ghcr.io/OWNER/charts/CHART` | Published by the app repository as an OCI Helm chart. |
+| Release name | Stable lowercase app release, for example `tokenplace` | Used for Helm release lookup and rollout selection. |
+| Namespace | Stable lowercase namespace, often matching the release | Sugarkube creates or targets this namespace during deploys. |
+| Chart version pin file | Repo-relative text file, for example `docs/apps/tokenplace.version` | Contains the immutable chart version Sugarkube should deploy. |
+| Production approved tag pin file | Optional repo-relative text file, for example `docs/apps/tokenplace.prod.tag` | Contains the image tag approved for production promotion. |
+| Values chain per env | Comma-separated repo-relative values files | Base values first, then the env overlay. |
+| Validation URLs and paths | Host value key plus comma-separated paths | Used by status and verify recipes to print and curl app endpoints. |
+
+The checked-in files under [`docs/examples/apps/`](examples/apps/) are examples only. Operators may
+copy one into a local config directory such as `apps/tokenplace.env`, or point
+`SUGARKUBE_APP_CONFIG_DIR` at another directory, once the generic recipes support config discovery.
+
+## Standard image tag model
+
+Deployment tags must identify exactly what was built:
+
+- **Immutable branch-SHA tag:** use this for normal deploys, staging sign-off, rollback, and most
+  production promotions. Example: `main-REPLACE_SHORTSHA`.
+- **Mutable branch convenience tag:** allowed only for explicitly documented non-production bootstrap
+  or rapid iteration. Example: `main-latest`.
+- **Semantic or release tag:** allowed when the app repository cuts a stable release. Examples:
+  `v1.2.3`, `3.1.0`, or another project-specific stable tag documented by that app.
+
+Do **not** deploy with ambiguous mutable tags:
+
+- `latest`
+- bare branch names such as `main`, `master`, or `develop`
+- environment names such as `dev`, `staging`, `prod`, or `production`
+
+Environment routing belongs in values files. Image tags describe released code and must not double as
+environment names.
+
+## Standard chart publishing model
+
+- Chart versions are immutable after publication.
+- Any chart content change requires a chart version bump before publishing.
+- The app repository owns its chart source and GHCR chart publishing workflow.
+- Sugarkube records the desired chart version in the app's chart version pin file and deploys that
+  exact version.
+- Image-only releases can reuse an existing chart version when the chart content did not change.
+- Chart changes and image changes may ship together, but both the chart version and image tag must be
+  explicit in the deployment review.
+
+## App config file shape
+
+Use simple shell-compatible `KEY=value` files so future `just` recipes can parse them without YAML
+helpers. Keep values unquoted unless a value truly needs shell quoting.
+
+```bash
+# Example only. Copy to apps/myapp.env or set SUGARKUBE_APP_CONFIG_DIR later.
+SUGARKUBE_APP=myapp
+SUGARKUBE_IMAGE=ghcr.io/yourorg/myapp
+SUGARKUBE_RELEASE=myapp
+SUGARKUBE_NAMESPACE=myapp
+SUGARKUBE_CHART=oci://ghcr.io/yourorg/charts/myapp
+SUGARKUBE_VERSION_FILE=docs/apps/myapp.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/myapp.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/myapp.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/myapp.values.dev.yaml,docs/examples/myapp.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/myapp.values.dev.yaml,docs/examples/myapp.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=myapp
+```
+
+Rules for config files:
+
+- `SUGARKUBE_APP` is the app identifier passed as `app=`.
+- `SUGARKUBE_IMAGE` is documented for humans and release review, even when deploy recipes only pass a
+  tag to the chart.
+- `SUGARKUBE_VALUES_DEV`, `SUGARKUBE_VALUES_STAGING`, and `SUGARKUBE_VALUES_PROD` are comma-separated
+  Helm values chains in apply order.
+- `SUGARKUBE_STATUS_HOST_KEY` is the dotted values key that resolves the public host from Helm
+  values, commonly `ingress.host`.
+- `SUGARKUBE_VERIFY_PATHS` is a comma-separated path list. Each path is checked against the resolved
+  host for the selected environment.
+- `SUGARKUBE_DEBUG_SELECTOR` selects app pods for log and rollout diagnostics.
+
+## Future generic command surface
+
+The follow-up implementation should expose this command shape while preserving existing app-specific
+recipes as compatibility wrappers:
+
+```bash
+just app-config app=tokenplace env=staging
+```
+
+```bash
+just app-deploy app=tokenplace env=staging tag=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-redeploy app=tokenplace env=staging tag=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-promote-prod app=tokenplace tag=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-status app=tokenplace env=staging
+```
+
+```bash
+just app-verify app=tokenplace env=staging
+```
+
+Expected behavior for the future recipes:
+
+- `app-config` prints the resolved config, selected values chain, release, namespace, chart, chart
+  version file, optional prod tag file, status host key, verify paths, and debug selector.
+- `app-deploy` performs an install-or-upgrade with an explicit immutable tag.
+- `app-redeploy` performs an upgrade-only refresh of an already deployed immutable tag.
+- `app-promote-prod` deploys `env=prod`, requiring either `tag=` or the app's prod-approved tag pin
+  file.
+- `app-status` selects the environment kubeconfig, prints pods and ingress, and reports the public
+  URL when available.
+- `app-verify` selects the environment kubeconfig, checks rollout status, and curls each configured
+  validation path.
+
+## Current app examples
+
+The current app configs are intentionally examples, not platform defaults:
+
+- [`docs/examples/apps/dspace.env`](examples/apps/dspace.env)
+- [`docs/examples/apps/tokenplace.env`](examples/apps/tokenplace.env)
+- [`docs/examples/apps/danielsmith.env`](examples/apps/danielsmith.env)
+
+Current app-specific runbooks remain authoritative until the generic recipes are implemented:
+
+- [`docs/apps/dspace.md`](apps/dspace.md)
+- [`docs/apps/tokenplace.md`](apps/tokenplace.md)
+- [`docs/apps/danielsmith.md`](apps/danielsmith.md)

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -2,6 +2,9 @@
 
 This is the canonical Sugarkube deployment model for `danielsmith.io`.
 
+For the cross-app artifact, tag, chart, config, and future generic command contract, see
+[`docs/app_deployment_contract.md`](../app_deployment_contract.md).
+
 ## Topology and scope (static-site only)
 
 `danielsmith.io` is a static Vite + Three.js site. Sugarkube runs only the static web container.

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -3,6 +3,9 @@
 This guide covers **steady-state dspace operations** on Sugarkube: repeatable deploys,
 upgrades, promotions, and rollbacks using immutable image tags.
 
+For the cross-app artifact, tag, chart, config, and future generic command contract, see
+[`docs/app_deployment_contract.md`](../app_deployment_contract.md).
+
 The `justfile` exposes both:
 
 - generic Helm OCI helpers (`helm-oci-install`, `helm-oci-upgrade`) for any app; and

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -2,6 +2,9 @@
 
 This is the canonical Sugarkube deployment model for token.place.
 
+For the cross-app artifact, tag, chart, config, and future generic command contract, see
+[`docs/app_deployment_contract.md`](../app_deployment_contract.md).
+
 For onboarding ownership and environment sequencing, see
 [`docs/tokenplace_sugarkube_onboarding.md`](../tokenplace_sugarkube_onboarding.md).
 

--- a/docs/examples/apps/danielsmith.env
+++ b/docs/examples/apps/danielsmith.env
@@ -1,0 +1,17 @@
+# Example Sugarkube app config for danielsmith.io static-site deployments.
+# Copy to apps/danielsmith.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
+# containing danielsmith.env once generic app recipes support config discovery.
+# This example is documentation-only and is not a required platform default.
+SUGARKUBE_APP=danielsmith
+SUGARKUBE_IMAGE=ghcr.io/futuroptimist/danielsmith.io
+SUGARKUBE_RELEASE=danielsmith
+SUGARKUBE_NAMESPACE=danielsmith
+SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/danielsmith
+SUGARKUBE_VERSION_FILE=docs/apps/danielsmith.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/danielsmith.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/danielsmith.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=danielsmith

--- a/docs/examples/apps/dspace.env
+++ b/docs/examples/apps/dspace.env
@@ -1,0 +1,17 @@
+# Example Sugarkube app config for democratized.space (dspace).
+# Copy to apps/dspace.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
+# containing dspace.env once generic app recipes support config discovery.
+# This example is documentation-only and is not a required platform default.
+SUGARKUBE_APP=dspace
+SUGARKUBE_IMAGE=ghcr.io/democratizedspace/dspace
+SUGARKUBE_RELEASE=dspace
+SUGARKUBE_NAMESPACE=dspace
+SUGARKUBE_CHART=oci://ghcr.io/democratizedspace/charts/dspace
+SUGARKUBE_VERSION_FILE=docs/apps/dspace.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/dspace.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/dspace.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/config.json,/healthz,/livez
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=dspace

--- a/docs/examples/apps/tokenplace.env
+++ b/docs/examples/apps/tokenplace.env
@@ -1,0 +1,17 @@
+# Example Sugarkube app config for token.place relay deployments.
+# Copy to apps/tokenplace.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
+# containing tokenplace.env once generic app recipes support config discovery.
+# This example is documentation-only and is not a required platform default.
+SUGARKUBE_APP=tokenplace
+SUGARKUBE_IMAGE=ghcr.io/futuroptimist/tokenplace-relay
+SUGARKUBE_RELEASE=tokenplace
+SUGARKUBE_NAMESPACE=tokenplace
+SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/tokenplace
+SUGARKUBE_VERSION_FILE=docs/apps/tokenplace.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/tokenplace.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/tokenplace.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz,/relay/diagnostics
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=tokenplace

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,8 @@ Review the safety notes before working with power components.
   and Helm OCI issues, including GHCR `401/403` chart pull failures
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
 - [projects-compose.md](projects-compose.md) — run token.place & dspace via docker compose
+- [app_deployment_contract.md](app_deployment_contract.md) — cross-app artifact, tag, chart,
+  config, and future generic command contract
 - [tokenplace_sugarkube_onboarding.md](tokenplace_sugarkube_onboarding.md) — onboarding contract,
   ownership boundaries, and environment mapping for token.place on Sugarkube
 - [apps/tokenplace.md](apps/tokenplace.md) — token.place app topology and operations model on Sugarkube


### PR DESCRIPTION
### Motivation
- Make the Sugarkube cross-app deployment expectations explicit before implementing generic `just` recipes, so apps can onboard to a single artifact/tag/chart contract. 
- Provide copy-paste example app configs for the three documented apps (dspace, token.place, danielsmith) and link the contract from existing app runbooks and docs index without changing any runtime behavior.

### Description
- Added `docs/app_deployment_contract.md` that documents ownership boundaries, the standard artifact model, accepted image tag patterns, chart publishing rules, the shell-style app-config shape, and the future generic command surface (`app-config`, `app-deploy`, `app-redeploy`, `app-promote-prod`, `app-status`, `app-verify`).
- Added documentation-only example app configs under `docs/examples/apps/` for `dspace.env`, `tokenplace.env`, and `danielsmith.env` containing the keys required by the future generic recipes (release, namespace, chart, version/prod tag files, values chains, status host key, verify paths, debug selector).
- Linked the new contract from `README.md`, `docs/index.md`, and the three existing app runbooks so readers can discover the contract from current docs; no `justfile` behavior was modified and existing app-specific recipes remain unchanged.

### Testing
- Ran `git diff --check` and found no whitespace or check errors for the staged docs changes (passed).
- Ran the test suite with `python -m pytest tests -q` which completed successfully (`1178 passed, 43 skipped`) (passed).
- Verified presence of the new generic command examples with `grep -R "app-deploy app=" docs | head` and example chart values with `grep -R "SUGARKUBE_CHART" docs/examples/apps` (found expected entries) (passed).
- Ran documentation checks: `pyspelling -c .spellcheck.yaml` (spelling passed) and `linkchecker --no-warnings README.md docs/` (link checker passed) after installing tooling (passed).
- Attempted `pre-commit run --all-files` but it failed due to existing repository-wide hook issues unrelated to this docs-only change (YAML multi-document templates and existing long-line/formatting lints were flagged); this is a pre-existing, repo-wide noise and not caused by these new docs (attempted / failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d47c8e244832f8ec112cedbc516f1)