### PR TITLE
Define Sugarkube app deployment contract and add app-config scaffolds

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
 
 ## Application runbooks
 
-- **[Sugarkube app deployment contract](docs/app_deployment_contract.md)** — shared artifact, tag, chart, config, and planned generic command model for app deployments.
 - **[token.place onboarding contract](docs/tokenplace_sugarkube_onboarding.md)** — prerequisites,
   ownership boundaries, and environment mapping for first-class token.place operations.
 - **[token.place app operations](docs/apps/tokenplace.md)** — topology and deployment workflow

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
 
 ## Application runbooks
 
+- **[Sugarkube app deployment contract](docs/app_deployment_contract.md)** — shared artifact, tag, chart, config, and planned generic command model for app deployments.
 - **[token.place onboarding contract](docs/tokenplace_sugarkube_onboarding.md)** — prerequisites,
   ownership boundaries, and environment mapping for first-class token.place operations.
 - **[token.place app operations](docs/apps/tokenplace.md)** — topology and deployment workflow

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -40,7 +40,7 @@ Each Sugarkube-managed app needs the following deployment coordinates:
 | Release name | Stable Helm release name, normally the app slug. |
 | Namespace | Stable Kubernetes namespace, normally the app slug. |
 | Chart version pin file | A repo file containing the chart version Sugarkube should install or upgrade. |
-| Production tag pin file | Optional repo file containing the production-approved image tag. |
+| Production tag pin file | Required repo file containing the production-approved immutable image tag for production promotion. |
 | Values chain per env | Comma-separated Helm values files, ordered from base to environment overlay. |
 | Validation URLs/paths | Host key plus one or more HTTP paths to check after rollout. |
 
@@ -62,8 +62,11 @@ Acceptable deployment tags:
 - Immutable branch-SHA tags, such as `main-REPLACE_SHORTSHA`.
 - Semver or release tags, such as `v1.2.3`, `3.1.0`, or another documented
   project-specific stable tag.
-- Mutable branch convenience tags, such as `main-latest`, only for explicitly
-  documented non-prod bootstrap or iteration flows.
+- Mutable branch convenience tags, such as `main-latest`, only when an app
+  runbook explicitly documents that a non-prod bootstrap or iteration flow accepts
+  them. They are an app-specific exception, not a shared guarantee; for example,
+  token.place deploy/redeploy wrappers reject every tag containing `latest`,
+  including `main-latest`.
 
 Unacceptable deployment tags:
 
@@ -71,8 +74,11 @@ Unacceptable deployment tags:
 - bare branch names such as `main`, `master`, `develop`, or `release`; and
 - environment names such as `dev`, `staging`, `prod`, or `production`.
 
-Production promotion must use an immutable tag. If a production tag pin file is
-present, it should contain the single immutable image tag approved for production.
+Production promotion must use an immutable tag. The production tag pin file is
+part of the standard app coordinates and must contain the single immutable image
+tag approved for production. Generic production promotion flows should read that
+pin when `tag=` is omitted and should update it only as an explicit approval
+step.
 
 ## Standard chart publishing model
 

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -144,7 +144,7 @@ just app-deploy app=dspace env=staging tag=main-REPLACE_SHORTSHA
 just app-redeploy app=dspace env=staging tag=main-REPLACE_SHORTSHA
 
 # Promote an approved immutable tag to production.
-just app-promote-prod app=dspace tag=v1.2.3
+just app-promote-prod app=dspace tag=main-REPLACE_SHORTSHA
 
 # Inspect Kubernetes and Helm status for an app environment.
 just app-status app=dspace env=staging

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -1,0 +1,173 @@
+# Sugarkube app deployment contract
+
+Sugarkube is moving toward a generic app deployment surface where each app is
+identified by a small local config file and deployed with shared `just` recipes.
+This page is the contract future implementation work will target; it does not
+change current `justfile` deployment behavior.
+
+The existing app-specific recipes for dspace, token.place, and danielsmith.io
+remain compatibility wrappers until the generic recipes are implemented.
+
+## Ownership boundary
+
+App repositories own build and release artifacts:
+
+- the application `Dockerfile`;
+- the application Helm chart;
+- GHCR image publishing; and
+- GHCR Helm OCI chart publishing.
+
+Sugarkube owns cluster and environment orchestration:
+
+- choosing the environment (`dev`, `staging`, or `prod`);
+- selecting the chart version pin;
+- selecting the approved image tag;
+- applying the environment values chain; and
+- running status and verification checks against the cluster.
+
+Future onboarding examples include wove and jobbot3000, but they should only get
+Sugarkube app configs after their app repositories have published compatible
+images and charts.
+
+## Standard artifact model
+
+Each Sugarkube-managed app needs the following deployment coordinates:
+
+| Coordinate | Contract |
+| --- | --- |
+| Image | `ghcr.io/OWNER/IMAGE` |
+| Chart | `oci://ghcr.io/OWNER/charts/CHART` |
+| Release name | Stable Helm release name, normally the app slug. |
+| Namespace | Stable Kubernetes namespace, normally the app slug. |
+| Chart version pin file | A repo file containing the chart version Sugarkube should install or upgrade. |
+| Production tag pin file | Optional repo file containing the production-approved image tag. |
+| Values chain per env | Comma-separated Helm values files, ordered from base to environment overlay. |
+| Validation URLs/paths | Host key plus one or more HTTP paths to check after rollout. |
+
+The current apps map to that model as examples:
+
+| App | Image | Chart | Release | Namespace | Version pin | Prod tag pin |
+| --- | --- | --- | --- | --- | --- | --- |
+| dspace | `ghcr.io/democratizedspace/dspace` | `oci://ghcr.io/democratizedspace/charts/dspace` | `dspace` | `dspace` | `docs/apps/dspace.version` | `docs/apps/dspace.prod.tag` |
+| token.place | `ghcr.io/futuroptimist/tokenplace-relay` | `oci://ghcr.io/futuroptimist/charts/tokenplace` | `tokenplace` | `tokenplace` | `docs/apps/tokenplace.version` | `docs/apps/tokenplace.prod.tag` |
+| danielsmith.io | `ghcr.io/futuroptimist/danielsmith.io` | `oci://ghcr.io/futuroptimist/charts/danielsmith` | `danielsmith` | `danielsmith` | `docs/apps/danielsmith.version` | `docs/apps/danielsmith.prod.tag` |
+
+## Standard image tag model
+
+Deployment tags must identify application code and release intent, not mutable
+environments.
+
+Acceptable deployment tags:
+
+- Immutable branch-SHA tags, such as `main-REPLACE_SHORTSHA`.
+- Semver or release tags, such as `v1.2.3`, `3.1.0`, or another documented
+  project-specific stable tag.
+- Mutable branch convenience tags, such as `main-latest`, only for explicitly
+  documented non-prod bootstrap or iteration flows.
+
+Unacceptable deployment tags:
+
+- `latest`;
+- bare branch names such as `main`, `master`, `develop`, or `release`; and
+- environment names such as `dev`, `staging`, `prod`, or `production`.
+
+Production promotion must use an immutable tag. If a production tag pin file is
+present, it should contain the single immutable image tag approved for production.
+
+## Standard chart publishing model
+
+Helm charts are immutable once published to GHCR OCI:
+
+- Chart versions are immutable and must not be republished with different
+  content.
+- Chart content changes require a chart version bump in the app repository.
+- App repositories publish their chart to `oci://ghcr.io/OWNER/charts/CHART`.
+- Sugarkube pins the chart version with the app's version file and uses that pin
+  for cluster deployment orchestration.
+
+## App config file shape
+
+Future generic recipes will load a simple shell/dotenv-style config so they do
+not require `yq`. Example files live under [`docs/examples/apps/`](examples/apps/)
+and may be copied into a local config directory such as `apps/APP.env`. Operators
+may also set `SUGARKUBE_APP_CONFIG_DIR` to point at another directory.
+
+Rules for app config files:
+
+- Use one `KEY=value` assignment per line.
+- Quote values only when the shell requires it.
+- Keep values chains comma-separated and ordered from base to overlay.
+- Keep verify paths comma-separated with leading slashes.
+- Do not store secrets in app config files.
+
+Required keys for the planned generic recipes:
+
+| Key | Purpose |
+| --- | --- |
+| `SUGARKUBE_APP` | Local Sugarkube app slug used by generic commands. |
+| `SUGARKUBE_RELEASE` | Helm release name. |
+| `SUGARKUBE_NAMESPACE` | Kubernetes namespace. |
+| `SUGARKUBE_CHART` | Helm OCI chart reference. |
+| `SUGARKUBE_VERSION_FILE` | Chart version pin file. |
+| `SUGARKUBE_PROD_TAG_FILE` | Production-approved tag pin file. |
+| `SUGARKUBE_VALUES_DEV` | Values chain for `env=dev`. |
+| `SUGARKUBE_VALUES_STAGING` | Values chain for `env=staging`. |
+| `SUGARKUBE_VALUES_PROD` | Values chain for `env=prod`. |
+| `SUGARKUBE_STATUS_HOST_KEY` | Dotted Helm values key used to discover the public host. |
+| `SUGARKUBE_VERIFY_PATHS` | Comma-separated HTTP paths for post-deploy verification. |
+| `SUGARKUBE_DEBUG_SELECTOR` | Kubernetes label selector for app pod logs/debugging. |
+
+Example local setup:
+
+```bash
+mkdir -p apps
+cp docs/examples/apps/dspace.env apps/dspace.env
+export SUGARKUBE_APP_CONFIG_DIR=apps
+```
+
+## Planned generic command surface
+
+P5 will implement these command shapes. They are documented here so app repos can
+align their artifacts before Sugarkube changes behavior.
+
+```bash
+# Deploy or install a specific immutable candidate into an environment.
+just app-deploy app=dspace env=staging tag=main-REPLACE_SHORTSHA
+
+# Redeploy an existing release with a specific immutable tag.
+just app-redeploy app=dspace env=staging tag=main-REPLACE_SHORTSHA
+
+# Promote an approved immutable tag to production.
+just app-promote-prod app=dspace tag=v1.2.3
+
+# Inspect Kubernetes and Helm status for an app environment.
+just app-status app=dspace env=staging
+
+# Run HTTP verification paths for an app environment.
+just app-verify app=dspace env=staging
+
+# Print the resolved app config for review/debugging.
+just app-config app=dspace env=staging
+```
+
+The compatibility wrappers will remain during migration. For example,
+`just dspace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA` and
+`just tokenplace-oci-promote-prod tag=main-REPLACE_SHORTSHA` continue to be the
+current operational commands until generic recipes replace their internals.
+
+## Current example configs
+
+The example configs in `docs/examples/apps/` intentionally are not platform
+defaults. They are scaffolds for future local configs and tests:
+
+- [`docs/examples/apps/dspace.env`](examples/apps/dspace.env)
+- [`docs/examples/apps/tokenplace.env`](examples/apps/tokenplace.env)
+- [`docs/examples/apps/danielsmith.env`](examples/apps/danielsmith.env)
+
+Current values chains:
+
+| App | dev | staging | prod | Verify paths |
+| --- | --- | --- | --- | --- |
+| dspace | `docs/examples/dspace.values.dev.yaml` | `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml` | `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml` | `/config.json,/healthz,/livez` |
+| token.place | `docs/examples/tokenplace.values.dev.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml` | `/,/livez,/healthz,/relay/diagnostics` |
+| danielsmith.io | `docs/examples/danielsmith.values.dev.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml` | `/,/livez,/healthz` |

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -2,6 +2,8 @@
 
 This is the canonical Sugarkube deployment model for `danielsmith.io`.
 
+For the shared artifact, tag, chart, app-config, and planned generic command contract, see [Sugarkube app deployment contract](../app_deployment_contract.md).
+
 ## Topology and scope (static-site only)
 
 `danielsmith.io` is a static Vite + Three.js site. Sugarkube runs only the static web container.

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -3,6 +3,8 @@
 This guide covers **steady-state dspace operations** on Sugarkube: repeatable deploys,
 upgrades, promotions, and rollbacks using immutable image tags.
 
+For the shared artifact, tag, chart, app-config, and planned generic command contract, see [Sugarkube app deployment contract](../app_deployment_contract.md).
+
 The `justfile` exposes both:
 
 - generic Helm OCI helpers (`helm-oci-install`, `helm-oci-upgrade`) for any app; and

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -2,6 +2,8 @@
 
 This is the canonical Sugarkube deployment model for token.place.
 
+For the shared artifact, tag, chart, app-config, and planned generic command contract, see [Sugarkube app deployment contract](../app_deployment_contract.md).
+
 For onboarding ownership and environment sequencing, see
 [`docs/tokenplace_sugarkube_onboarding.md`](../tokenplace_sugarkube_onboarding.md).
 

--- a/docs/examples/apps/danielsmith.env
+++ b/docs/examples/apps/danielsmith.env
@@ -1,0 +1,17 @@
+# Example Sugarkube app config for danielsmith.io.
+# Copy to apps/danielsmith.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
+# containing danielsmith.env when the generic app recipes are implemented.
+# This is documentation scaffold only; it is not a platform default.
+
+SUGARKUBE_APP=danielsmith
+SUGARKUBE_RELEASE=danielsmith
+SUGARKUBE_NAMESPACE=danielsmith
+SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/danielsmith
+SUGARKUBE_VERSION_FILE=docs/apps/danielsmith.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/danielsmith.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/danielsmith.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=danielsmith

--- a/docs/examples/apps/dspace.env
+++ b/docs/examples/apps/dspace.env
@@ -1,0 +1,17 @@
+# Example Sugarkube app config for dspace.
+# Copy to apps/dspace.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
+# containing dspace.env when the generic app recipes are implemented.
+# This is documentation scaffold only; it is not a platform default.
+
+SUGARKUBE_APP=dspace
+SUGARKUBE_RELEASE=dspace
+SUGARKUBE_NAMESPACE=dspace
+SUGARKUBE_CHART=oci://ghcr.io/democratizedspace/charts/dspace
+SUGARKUBE_VERSION_FILE=docs/apps/dspace.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/dspace.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/dspace.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/config.json,/healthz,/livez
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=dspace

--- a/docs/examples/apps/tokenplace.env
+++ b/docs/examples/apps/tokenplace.env
@@ -1,0 +1,17 @@
+# Example Sugarkube app config for token.place.
+# Copy to apps/tokenplace.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
+# containing tokenplace.env when the generic app recipes are implemented.
+# This is documentation scaffold only; it is not a platform default.
+
+SUGARKUBE_APP=tokenplace
+SUGARKUBE_RELEASE=tokenplace
+SUGARKUBE_NAMESPACE=tokenplace
+SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/tokenplace
+SUGARKUBE_VERSION_FILE=docs/apps/tokenplace.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/tokenplace.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/tokenplace.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz,/relay/diagnostics
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=tokenplace

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,7 @@ Review the safety notes before working with power components.
   and Helm OCI issues, including GHCR `401/403` chart pull failures
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
 - [projects-compose.md](projects-compose.md) — run token.place & dspace via docker compose
+- [app_deployment_contract.md](app_deployment_contract.md) — shared Sugarkube app artifact, tag, chart, config, and planned generic command contract
 - [tokenplace_sugarkube_onboarding.md](tokenplace_sugarkube_onboarding.md) — onboarding contract,
   ownership boundaries, and environment mapping for token.place on Sugarkube
 - [apps/tokenplace.md](apps/tokenplace.md) — token.place app topology and operations model on Sugarkube


### PR DESCRIPTION
### Motivation
- Make the intended Sugarkube cross-app deployment contract explicit so future generic `just` recipes can implement a single, predictable command surface without changing current deployment behavior yet. 
- Provide copy-pasteable example app-config scaffolds and document artifact/tag/chart expectations so existing apps (dspace, token.place, danielsmith.io) can align their repos and publishables to the contract.

### Description
- Add `docs/app_deployment_contract.md` describing the standard artifact model, image tag rules, chart publishing model, dotenv-style app-config shape, validation/verify paths, and the planned generic `just app-*` command surface (deploy/redeploy/promote/status/verify/config). 
- Add example app-config scaffolds under `docs/examples/apps/` for `dspace.env`, `tokenplace.env`, and `danielsmith.env` containing the keys required by the planned generic recipes (`SUGARKUBE_APP`, `SUGARKUBE_RELEASE`, `SUGARKUBE_NAMESPACE`, `SUGARKUBE_CHART`, `SUGARKUBE_VERSION_FILE`, `SUGARKUBE_PROD_TAG_FILE`, `SUGARKUBE_VALUES_*`, `SUGARKUBE_STATUS_HOST_KEY`, `SUGARKUBE_VERIFY_PATHS`, `SUGARKUBE_DEBUG_SELECTOR`).
- Wire the new contract into documentation index and app runbooks by adding links from `README.md`, `docs/index.md`, and the dspace/token.place/danielsmith app pages while explicitly leaving existing app-specific `justfile` wrappers unchanged.
- Keep this PR purely documentation/config scaffolding (no behavioral changes to `justfile` deploy recipes in this change).

### Testing
- Ran `git diff --check` with no issues reported. (passed)
- Ran `python -m pytest tests -q` and observed `1178 passed, 43 skipped` indicating the test suite completed successfully. (passed)
- Verified the new generic command examples and presence of the contract with `rg "app-deploy app=" docs | head` and found the documented `just app-deploy` example. (verified)
- Verified example app config chart references with `rg "SUGARKUBE_CHART" docs/examples/apps` and confirmed expected entries. (verified)
- Ran the repository secret scan via `git diff --cached | ./scripts/scan-secrets.py` and found no flagged secrets. (passed)
- Ran link checking with `uvx --from linkchecker linkchecker --no-warnings README.md docs/` which completed with no errors. (passed)
- Attempted spelling checks with `pyspelling -c .spellcheck.yaml` but the environment lacks the `aspell` binary, so the check could not run here. (not-run / env issue)
- Attempted `pre-commit` hooks (`uvx pre-commit run --all-files`) to mirror repo lint gates but the pre-commit run flagged existing, unrelated repository-wide issues (YAML multi-doc and flake8 line-length/blank-line findings); those repository-wide failures are outside the scope of this PR and were not used to block these documentation changes. (failed due to unrelated repo state)

If you want, I can split the contract into a shorter one-page summary or add an example `apps/` loader snippet for P5 to consume in the next implementation PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d47c8e244832f8ec112cedbc516f1)