### PR TITLE
Implement generic app deploy recipes and dotenv-backed app config loader

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -2,11 +2,14 @@
 
 Sugarkube is moving toward a generic app deployment surface where each app is
 identified by a small local config file and deployed with shared `just` recipes.
-This page is the contract future implementation work will target; it does not
-change current `justfile` deployment behavior.
+This page is the implemented P5 contract for the generic `just app-*` deployment
+surface and the app config files that back it.
 
 The existing app-specific recipes for dspace, token.place, and danielsmith.io
-remain compatibility wrappers until the generic recipes are implemented.
+now remain as compatibility shims over the generic flow. They are retained for
+current runbooks and muscle memory, but operators should prefer the generic
+commands for new docs and future apps. The shims will be deprecated in a later
+release, not removed in this PR.
 
 ## Ownership boundary
 
@@ -93,7 +96,7 @@ Helm charts are immutable once published to GHCR OCI:
 
 ## App config file shape
 
-Future generic recipes will load a simple shell/dotenv-style config so they do
+Generic recipes load a simple shell/dotenv-style config so they do
 not require `yq`. Example files live under [`docs/examples/apps/`](examples/apps/)
 and may be copied into a local config directory such as `apps/APP.env`. Operators
 may also set `SUGARKUBE_APP_CONFIG_DIR` to point at another directory.
@@ -131,10 +134,11 @@ cp docs/examples/apps/dspace.env apps/dspace.env
 export SUGARKUBE_APP_CONFIG_DIR=apps
 ```
 
-## Planned generic command surface
+## Generic command surface
 
-P5 will implement these command shapes. They are documented here so app repos can
-align their artifacts before Sugarkube changes behavior.
+P5 implements these command shapes. They are backed by `scripts/app_config.py`,
+which searches explicit `config=`, `SUGARKUBE_APP_CONFIG_DIR`, local `apps/`, and
+then `docs/examples/apps/` fallback configs.
 
 ```bash
 # Deploy or install a specific immutable candidate into an environment.
@@ -156,15 +160,16 @@ just app-verify app=dspace env=staging
 just app-config app=dspace env=staging
 ```
 
-The compatibility wrappers will remain during migration. For example,
+The compatibility wrappers remain during migration. For example,
 `just dspace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA` and
-`just tokenplace-oci-promote-prod tag=main-REPLACE_SHORTSHA` continue to be the
-current operational commands until generic recipes replace their internals.
+`just tokenplace-oci-promote-prod tag=main-REPLACE_SHORTSHA` continue to work,
+but they are thin shims over `app-deploy`, `app-redeploy`, or `app-promote-prod`.
+Prefer `just app-deploy app=<app> env=<env> tag=<immutable-tag>` in new runbooks.
 
 ## Current example configs
 
 The example configs in `docs/examples/apps/` intentionally are not platform
-defaults. They are scaffolds for future local configs and tests:
+defaults. They are fallback scaffolds for the current apps, local configs, and tests:
 
 - [`docs/examples/apps/dspace.env`](examples/apps/dspace.env)
 - [`docs/examples/apps/tokenplace.env`](examples/apps/tokenplace.env)

--- a/docs/examples/apps/danielsmith.env
+++ b/docs/examples/apps/danielsmith.env
@@ -1,7 +1,7 @@
 # Example Sugarkube app config for danielsmith.io.
 # Copy to apps/danielsmith.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
-# containing danielsmith.env when the generic app recipes are implemented.
-# This is documentation scaffold only; it is not a platform default.
+# containing danielsmith.env for generic app recipes.
+# This is an example scaffold; local configs and SUGARKUBE_APP_CONFIG_DIR take precedence.
 
 SUGARKUBE_APP=danielsmith
 SUGARKUBE_RELEASE=danielsmith

--- a/docs/examples/apps/dspace.env
+++ b/docs/examples/apps/dspace.env
@@ -1,7 +1,7 @@
 # Example Sugarkube app config for dspace.
 # Copy to apps/dspace.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
-# containing dspace.env when the generic app recipes are implemented.
-# This is documentation scaffold only; it is not a platform default.
+# containing dspace.env for generic app recipes.
+# This is an example scaffold; local configs and SUGARKUBE_APP_CONFIG_DIR take precedence.
 
 SUGARKUBE_APP=dspace
 SUGARKUBE_RELEASE=dspace

--- a/docs/examples/apps/tokenplace.env
+++ b/docs/examples/apps/tokenplace.env
@@ -1,7 +1,7 @@
 # Example Sugarkube app config for token.place.
 # Copy to apps/tokenplace.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
-# containing tokenplace.env when the generic app recipes are implemented.
-# This is documentation scaffold only; it is not a platform default.
+# containing tokenplace.env for generic app recipes.
+# This is an example scaffold; local configs and SUGARKUBE_APP_CONFIG_DIR take precedence.
 
 SUGARKUBE_APP=tokenplace
 SUGARKUBE_RELEASE=tokenplace

--- a/justfile
+++ b/justfile
@@ -1518,6 +1518,90 @@ helm-oci-install release='' namespace='' chart='' values='' host='' version='' v
 helm-oci-upgrade release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='':
     @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' allow_install='false' reuse_values='true'
 
+# Resolve a Sugarkube app dotenv config for an environment.
+app-config app='' env='staging' config='':
+    @python3 "{{ justfile_directory() }}/scripts/app_config.py" config --app '{{ app }}' --env '{{ env }}' --config '{{ config }}'
+
+# Install an app Helm OCI chart using the generic Sugarkube app config contract.
+app-deploy app='' env='staging' tag='' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" config --app '{{ app }}' --env '{{ env }}' --config '{{ config }}' --format shell)"
+    resolved_tag="$(python3 "{{ justfile_directory() }}/scripts/app_config.py" validate-tag '{{ tag }}')"
+
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
+      release="${SUGARKUBE_RELEASE}" namespace="${SUGARKUBE_NAMESPACE}" \
+      chart="${SUGARKUBE_CHART}" \
+      values="${SUGARKUBE_VALUES}" \
+      version_file="${SUGARKUBE_VERSION_FILE}" \
+      tag="${resolved_tag}"
+
+# Upgrade an existing app Helm OCI release using the generic Sugarkube app config contract.
+app-redeploy app='' env='staging' tag='' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" config --app '{{ app }}' --env '{{ env }}' --config '{{ config }}' --format shell)"
+    resolved_tag="$(python3 "{{ justfile_directory() }}/scripts/app_config.py" validate-tag '{{ tag }}')"
+
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
+      release="${SUGARKUBE_RELEASE}" namespace="${SUGARKUBE_NAMESPACE}" \
+      chart="${SUGARKUBE_CHART}" \
+      values="${SUGARKUBE_VALUES}" \
+      version_file="${SUGARKUBE_VERSION_FILE}" \
+      tag="${resolved_tag}"
+
+# Promote an app to prod with an explicit immutable tag or its configured prod tag pin.
+app-promote-prod app='' tag='' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    resolved_tag="$(python3 "{{ justfile_directory() }}/scripts/app_config.py" prod-tag --app '{{ app }}' --config '{{ config }}' --tag '{{ tag }}')"
+    just --justfile "{{ justfile_directory() }}/justfile" app-deploy app='{{ app }}' env=prod tag="${resolved_tag}" config='{{ config }}'
+
+# Run HTTP verification paths from the generic app config.
+app-verify app='' env='staging' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" config --app '{{ app }}' --env '{{ env }}' --config '{{ config }}' --format shell)"
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+
+    host=""
+    if command -v helm >/dev/null 2>&1; then
+      host="$(helm get values "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" --all --output json 2>/dev/null | python3 "{{ justfile_directory() }}/scripts/app_config.py" host --host-key "${SUGARKUBE_STATUS_HOST_KEY}" 2>/dev/null || true)"
+    fi
+    if [ -z "${host}" ]; then
+      host="$(kubectl -n "${SUGARKUBE_NAMESPACE}" get ingress -o jsonpath='{.items[0].spec.rules[0].host}' 2>/dev/null || true)"
+    fi
+    if [ -z "${host}" ]; then
+      echo "Unable to derive a host for ${SUGARKUBE_APP} from Helm values key ${SUGARKUBE_STATUS_HOST_KEY} or ingress." >&2
+      echo "Copy/paste after replacing <host>:" >&2
+      IFS=',' read -r -a paths <<< "${SUGARKUBE_VERIFY_PATHS}"
+      for path in "${paths[@]}"; do
+        [ -n "${path}" ] || continue
+        echo "  curl -fsS https://<host>${path}" >&2
+      done
+      exit 1
+    fi
+
+    IFS=',' read -r -a paths <<< "${SUGARKUBE_VERIFY_PATHS}"
+    for path in "${paths[@]}"; do
+      path="$(printf '%s' "${path}" | xargs)"
+      [ -n "${path}" ] || continue
+      case "${path}" in /*) ;; *) path="/${path}" ;; esac
+      echo "curl -fsS https://${host}${path}"
+      curl -fsS "https://${host}${path}" >/dev/null
+    done
+
 # Opinionated immutable-tag dspace deploy with rollout verification.
 #
 
@@ -1529,85 +1613,13 @@ dspace-oci-deploy env='staging' tag='':
     env_input={{ quote(env) }}
     env_name="${env_input}"
     while [ "${env_name#env=}" != "${env_name}" ]; do
-      env_name="${env_name#env=}"
+        env_name="${env_name#env=}"
     done
     if [ -z "${env_name}" ]; then
-      printf 'ERROR: env must not be empty. Use env=dev|staging|prod.\n' >&2
-      exit 1
-    fi
-    if [ "${env_name}" = "int" ]; then
-      printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
-      env_name="staging"
-    fi
-
-    case "${env_name}" in
-      dev|staging|prod) ;;
-      *)
-        echo "Unsupported env=${env_name}. Use env=dev|staging|prod." >&2
+        printf 'ERROR: env must not be empty. Use env=dev|staging|prod.\n' >&2
         exit 1
-        ;;
-    esac
-
-    deploy_tag="$(echo "{{ tag }}" | xargs)"
-    if [ -z "${deploy_tag}" ]; then
-      echo "Set tag=<immutable-tag> (for example main-<shortsha> or 3.1.0) for dspace immutable deploys." >&2
-      exit 1
     fi
-    tag_lc="$(echo "${deploy_tag}" | tr '[:upper:]' '[:lower:]')"
-    if [[ "${tag_lc}" == *"latest"* || "${tag_lc}" == "main" || "${tag_lc}" == *":main" ]]; then
-      echo "Refusing mutable tag '${deploy_tag}'. Use an immutable RC/stable image tag." >&2
-      exit 1
-    fi
-
-    overlay=""
-    if [ "${env_name}" != "dev" ]; then
-      overlay="docs/examples/dspace.values.${env_name}.yaml"
-      if [ ! -f "${overlay}" ]; then
-        echo "No dspace values overlay found for env=${env_name} (${overlay})." >&2
-        exit 1
-      fi
-    fi
-
-    values_chain="docs/examples/dspace.values.dev.yaml"
-    if [ -n "${overlay}" ]; then
-      values_chain="${values_chain},${overlay}"
-    fi
-
-    if [ -z "${KUBECONFIG:-}" ] && [ ! -r "${HOME}/.kube/config" ]; then
-      scripts/ensure_user_kubeconfig.sh || true
-    fi
-    if [ -z "${KUBECONFIG:-}" ]; then
-      export KUBECONFIG="${HOME}/.kube/config"
-    fi
-
-    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
-      release='dspace' namespace='dspace' \
-      chart='oci://ghcr.io/democratizedspace/charts/dspace' \
-      values="${values_chain}" \
-      version_file='docs/apps/dspace.version' \
-      tag="${deploy_tag}"
-
-    echo "Resolved deployment image(s):"
-    kubectl -n dspace get deploy dspace \
-      -o jsonpath='{range .spec.template.spec.containers[*]}{.name}={.image}{"\n"}{end}'
-
-    verify_host="$(kubectl -n dspace get ingress dspace -o jsonpath='{.spec.rules[0].host}' 2>/dev/null || true)"
-    if [ -z "${verify_host}" ]; then
-      verify_host="<dspace-host>"
-    fi
-
-    echo
-    echo "Post-deploy verification commands:"
-    if [[ "${verify_host}" == "<"*">" ]]; then
-      echo "  # Replace ${verify_host} with your ingress hostname."
-      echo "  curl -fsS https://${verify_host}/config.json | jq ."
-      echo "  curl -fsS https://${verify_host}/healthz | jq ."
-      echo "  curl -fsS https://${verify_host}/livez | jq ."
-    else
-      echo "  curl -fsS https://${verify_host}/config.json | jq ."
-      echo "  curl -fsS https://${verify_host}/healthz | jq ."
-      echo "  curl -fsS https://${verify_host}/livez | jq ."
-    fi
+    just --justfile "{{ justfile_directory() }}/justfile" app-deploy app=dspace env="${env_name}" tag='{{ tag }}'
 
 # Deploy dspace to the optional production preview subdomain (prod.democratized.space).
 #
@@ -1662,21 +1674,7 @@ dspace-oci-deploy-prod-subdomain tag='':
 
 # If tag is omitted, this reads the pinned value from docs/apps/dspace.prod.tag.
 dspace-oci-promote-prod tag='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
-
-    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
-
-    deploy_tag="$(echo "{{ tag }}" | xargs)"
-    if [ -z "${deploy_tag}" ]; then
-      deploy_tag="$(read_prod_tag)"
-    fi
-    if [ -z "${deploy_tag}" ]; then
-      echo "Set tag=<immutable-tag> or populate docs/apps/dspace.prod.tag." >&2
-      exit 1
-    fi
-
-    just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy env=prod tag="${deploy_tag}"
+    @just --justfile "{{ justfile_directory() }}/justfile" app-promote-prod app=dspace tag='{{ tag }}'
 
 # Fast redeploy of dspace from GHCR (emergency mutable-tag refresh).
 dspace-oci-redeploy env='staging' tag='':
@@ -1686,68 +1684,13 @@ dspace-oci-redeploy env='staging' tag='':
     env_input={{ quote(env) }}
     env_name="${env_input}"
     while [ "${env_name#env=}" != "${env_name}" ]; do
-      env_name="${env_name#env=}"
+        env_name="${env_name#env=}"
     done
     if [ -z "${env_name}" ]; then
-      printf 'ERROR: env must not be empty. Use env=dev|staging|prod.\n' >&2
-      exit 1
-    fi
-    if [ "${env_name}" = "int" ]; then
-      printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
-      env_name="staging"
-    fi
-
-    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
-
-    overlay="docs/examples/dspace.values.${env_name}.yaml"
-    if [ ! -f "${overlay}" ]; then
-      echo "No dspace values overlay found for env=${env_name} (${overlay})." >&2
-      exit 1
-    fi
-    values_chain="docs/examples/dspace.values.dev.yaml"
-    if [ "${env_name}" != "dev" ]; then
-      values_chain="${values_chain},${overlay}"
-    fi
-
-    # NOTE: This tokenplace-scoped change intentionally leaves dspace kubeconfig behavior unchanged here.
-    # If dspace needs env-scoped kubeconfig selection before Helm, handle that in a separate DSPACE PR.
-    deploy_tag="{{ tag }}"
-    default_tag_value=""
-    if [ "${env_name}" = "prod" ]; then
-      if [ -z "${deploy_tag}" ] && [ -f "docs/apps/dspace.prod.tag" ]; then
-        deploy_tag="$(read_prod_tag)"
-      fi
-      if [ -z "${deploy_tag}" ]; then
-        echo "Set tag=<immutable-tag> for prod or populate docs/apps/dspace.prod.tag." >&2
+        printf 'ERROR: env must not be empty. Use env=dev|staging|prod.\n' >&2
         exit 1
-      fi
-    else
-      default_tag_value="main-latest"
     fi
-
-    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
-      release='dspace' namespace='dspace' \
-      chart='oci://ghcr.io/democratizedspace/charts/dspace' \
-      values="${values_chain}" \
-      version_file='docs/apps/dspace.version' \
-      tag="${deploy_tag}" default_tag="${default_tag_value}"
-
-    scripts/ensure_user_kubeconfig.sh || true
-    if [ -z "${KUBECONFIG:-}" ]; then
-      export KUBECONFIG="${HOME}/.kube/config"
-    fi
-
-    echo "Forcing rollout restart for dspace deployment..."
-    if ! kubectl -n dspace rollout restart deploy/dspace; then
-      echo "ERROR: Failed to trigger rollout restart for dspace." >&2
-      exit 1
-    fi
-
-    echo "Waiting for dspace rollout to complete (timeout: 120s)..."
-    if ! kubectl -n dspace rollout status deploy/dspace --timeout=120s; then
-      echo "ERROR: dspace rollout did not complete successfully." >&2
-      exit 1
-    fi
+    just --justfile "{{ justfile_directory() }}/justfile" app-redeploy app=dspace env="${env_name}" tag='{{ tag }}'
 
 # Dump dspace and Traefik logs for debugging HTTP 500s.
 dspace-debug-logs namespace='dspace':
@@ -1821,176 +1764,14 @@ dspace-debug-logs-env env='staging' namespace='dspace':
 
 # Install-or-upgrade token.place from OCI chart with immutable tag policy.
 tokenplace-oci-deploy env='staging' tag='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
-
-    env_input={{ quote(env) }}
-    env_name="${env_input}"
-    while [ "${env_name#env=}" != "${env_name}" ]; do
-        env_name="${env_name#env=}"
-    done
-    case "${env_name}" in
-      dev|staging|prod) ;;
-      *)
-        echo "ERROR: env must be one of dev|staging|prod." >&2
-        exit 1
-        ;;
-    esac
-
-    # Shared immutable-tag guard for deploy/redeploy paths avoids moving-target tags.
-    validate_immutable_tag() {
-      local candidate="${1}"
-      local tag_lc
-      tag_lc="$(echo "${candidate}" | tr '[:upper:]' '[:lower:]')"
-      if [[ "${tag_lc}" == *latest* ]] \
-        || [[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || [[ "${tag_lc}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || ([[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] && [[ ! "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]); then
-        echo "ERROR: mutable tag '${candidate}' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
-        exit 1
-      fi
-    }
-
-    resolved_tag="$(echo '{{ tag }}' | xargs)"
-    if [ -z "${resolved_tag}" ]; then
-      echo "ERROR: tag is required for immutable deploys." >&2
-      exit 1
-    fi
-    validate_immutable_tag "${resolved_tag}"
-    chart_version=""
-    if [ -f docs/apps/tokenplace.version ]; then
-      chart_version="$(
-        sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.version 2>/dev/null | head -n1 | tr -d '[:space:]' || true
-      )"
-    fi
-    if [ -z "${chart_version}" ]; then
-      echo "ERROR: unable to resolve chart version from docs/apps/tokenplace.version." >&2
-      exit 1
-    fi
-
-    values_chain='docs/examples/tokenplace.values.dev.yaml'
-    if [ "${env_name}" = "staging" ]; then
-      values_chain='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml'
-    elif [ "${env_name}" = "prod" ]; then
-      values_chain='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml'
-    fi
-
-    # Intentional: tokenplace OCI wrappers select kubeconfig from env before Helm
-    # so prod/staging values cannot be applied to an unrelated active context.
-    # This is tokenplace-scoped; do not copy into DSPACE from this PR.
-    export KUBECONFIG="${HOME}/.kube/config"
-    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
-    echo "Deploying tokenplace env=${env_name} chart=oci://ghcr.io/futuroptimist/charts/tokenplace version=${chart_version} image=ghcr.io/futuroptimist/tokenplace-relay:${resolved_tag}"
-
-    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
-      release='tokenplace' namespace='tokenplace' \
-      chart='oci://ghcr.io/futuroptimist/charts/tokenplace' \
-      values="${values_chain}" \
-      version_file='docs/apps/tokenplace.version' \
-      tag="${resolved_tag}"
-
-    scripts/ensure_user_kubeconfig.sh || true
-    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-
-    echo
-    echo "Resolved images for deployment/tokenplace:"
-    kubectl -n tokenplace get deploy/tokenplace -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"="}{.image}{"\n"}{end}' || true
-
-    ingress_host="$(kubectl -n tokenplace get ingress -o jsonpath='{.items[0].spec.rules[0].host}' 2>/dev/null || true)"
-    if [ -n "${ingress_host}" ]; then
-      echo
-      echo "Post-deploy checks:"
-      echo "  curl -fsS https://${ingress_host}/"
-      echo "  curl -fsS https://${ingress_host}/livez"
-      echo "  curl -fsS https://${ingress_host}/healthz"
-    fi
+    @just --justfile "{{ justfile_directory() }}/justfile" app-deploy app=tokenplace env='{{ env }}' tag='{{ tag }}'
 
 tokenplace-oci-promote-prod tag='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
-
-    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.prod.tag | head -n1 | tr -d '[:space:]'; }
-
-    resolved_tag="$(echo '{{ tag }}' | xargs)"
-    if [ -z "${resolved_tag}" ]; then
-      resolved_tag="$(read_prod_tag 2>/dev/null || true)"
-    fi
-    if [ -z "${resolved_tag}" ]; then
-      echo "ERROR: provide tag=<immutable-tag> or set docs/apps/tokenplace.prod.tag." >&2
-      exit 1
-    fi
-
-    just --justfile "{{ justfile_directory() }}/justfile" tokenplace-oci-deploy env=prod tag="${resolved_tag}"
+    @just --justfile "{{ justfile_directory() }}/justfile" app-promote-prod app=tokenplace tag='{{ tag }}'
 
 # Upgrade-only token.place OCI redeploy path.
 tokenplace-oci-redeploy env='staging' tag='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
-
-    env_input={{ quote(env) }}
-    env_name="${env_input}"
-    while [ "${env_name#env=}" != "${env_name}" ]; do
-        env_name="${env_name#env=}"
-    done
-    case "${env_name}" in
-      dev|staging|prod) ;;
-      *)
-        echo "ERROR: env must be one of dev|staging|prod." >&2
-        exit 1
-        ;;
-    esac
-
-    # Shared immutable-tag guard for deploy/redeploy paths avoids moving-target tags.
-    validate_immutable_tag() {
-      local candidate="${1}"
-      local tag_lc
-      tag_lc="$(echo "${candidate}" | tr '[:upper:]' '[:lower:]')"
-      if [[ "${tag_lc}" == *latest* ]] \
-        || [[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || [[ "${tag_lc}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || ([[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] && [[ ! "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]); then
-        echo "ERROR: mutable tag '${candidate}' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
-        exit 1
-      fi
-    }
-    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.prod.tag | head -n1 | tr -d '[:space:]'; }
-
-    resolved_tag="$(echo '{{ tag }}' | xargs)"
-    if [ -z "${resolved_tag}" ] && [ "${env_name}" = "prod" ]; then
-      resolved_tag="$(read_prod_tag 2>/dev/null || true)"
-      [ -n "${resolved_tag}" ] || { echo "ERROR: prod requires tag=<immutable-tag> or docs/apps/tokenplace.prod.tag." >&2; exit 1; }
-    fi
-    if [ "${env_name}" != "prod" ] && [ -z "${resolved_tag}" ]; then
-      echo "ERROR: env=${env_name} redeploy requires explicit tag=<immutable-tag>." >&2
-      echo "Non-prod redeploy intentionally has no baked-in fallback tag so this path is reproducible and reviewable." >&2
-      exit 1
-    fi
-    [ -n "${resolved_tag}" ] && validate_immutable_tag "${resolved_tag}"
-
-    values_chain='docs/examples/tokenplace.values.dev.yaml'
-    default_tag=''
-    if [ "${env_name}" = "staging" ]; then
-      values_chain='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml'
-    elif [ "${env_name}" = "prod" ]; then
-      values_chain='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml'
-    fi
-
-    # Intentional: tokenplace OCI wrappers select kubeconfig from env before Helm
-    # so prod/staging values cannot be applied to an unrelated active context.
-    # This is tokenplace-scoped; do not copy into DSPACE from this PR.
-    export KUBECONFIG="${HOME}/.kube/config"
-    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
-
-    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
-      release='tokenplace' namespace='tokenplace' \
-      chart='oci://ghcr.io/futuroptimist/charts/tokenplace' \
-      values="${values_chain}" \
-      version_file='docs/apps/tokenplace.version' \
-      tag="${resolved_tag}" default_tag="${default_tag}"
-
-    scripts/ensure_user_kubeconfig.sh || true
-    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-    kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+    @just --justfile "{{ justfile_directory() }}/justfile" app-redeploy app=tokenplace env='{{ env }}' tag='{{ tag }}'
 
 # token.place app status helper (generic/parameterized defaults, not final release wiring).
 # Override namespace/release/host_key per environment until onboarding locks chart naming.
@@ -2157,185 +1938,14 @@ tokenplace-debug-logs-env env='staging' namespace='tokenplace':
 
 # Install-or-upgrade danielsmith from OCI chart with immutable tag policy.
 danielsmith-oci-deploy env='staging' tag='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
-
-    env_input={{ quote(env) }}
-    env_name="${env_input}"
-    while [ "${env_name#env=}" != "${env_name}" ]; do
-        env_name="${env_name#env=}"
-    done
-    case "${env_name}" in
-      dev|staging|prod) ;;
-      *)
-        echo "ERROR: env must be one of dev|staging|prod." >&2
-        exit 1
-        ;;
-    esac
-
-    validate_immutable_tag() {
-      local candidate="${1}"
-      local tag_lc
-      tag_lc="$(echo "${candidate}" | tr '[:upper:]' '[:lower:]')"
-      if [[ "${tag_lc}" == *latest* ]] \
-        || [[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || [[ "${tag_lc}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || ([[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] && [[ ! "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]) \
-        || ([[ "${tag_lc}" =~ -[0-9a-f]{7,}$ ]] && [[ ! "${tag_lc}" =~ ^[a-z0-9][a-z0-9._-]*-[0-9a-f]{7,}$ ]]); then
-        echo "ERROR: mutable tag '${candidate}' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
-        exit 1
-      fi
-    }
-
-    resolved_tag="$(echo '{{ tag }}' | xargs)"
-    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
-      resolved_tag="${resolved_tag#tag=}"
-    done
-    if [ -z "${resolved_tag}" ]; then
-      echo "ERROR: tag is required for immutable deploys." >&2
-      exit 1
-    fi
-    validate_immutable_tag "${resolved_tag}"
-
-    values_chain='docs/examples/danielsmith.values.dev.yaml'
-    if [ "${env_name}" = "staging" ]; then
-      values_chain='docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml'
-    elif [ "${env_name}" = "prod" ]; then
-      values_chain='docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml'
-    fi
-
-    export KUBECONFIG="${HOME}/.kube/config"
-    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
-
-    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
-      release='danielsmith' namespace='danielsmith' \
-      chart='oci://ghcr.io/futuroptimist/charts/danielsmith' \
-      values="${values_chain}" \
-      version_file='docs/apps/danielsmith.version' \
-      tag="${resolved_tag}"
-
-    scripts/ensure_user_kubeconfig.sh || true
-    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-
-    echo
-    workloads="$(
-      {
-        kubectl -n danielsmith get deploy,statefulset,daemonset \
-          -l 'app.kubernetes.io/instance=danielsmith' \
-          -o jsonpath='{range .items[*]}{.kind}/{.metadata.name}{"\n"}{end}'
-        kubectl -n danielsmith get deploy,statefulset,daemonset \
-          -l 'release=danielsmith' \
-          -o jsonpath='{range .items[*]}{.kind}/{.metadata.name}{"\n"}{end}'
-      } 2>/dev/null | sed '/^$/d' | sort -u
-    )"
-    if [ -z "${workloads}" ]; then
-      echo "No rollout-capable workloads found for release danielsmith in namespace danielsmith" >&2
-    else
-      echo "Resolved images for danielsmith workloads:"
-      while IFS= read -r workload; do
-        [ -n "${workload}" ] || continue
-        echo "--- ${workload} ---"
-        kubectl -n danielsmith get "${workload}" -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"="}{.image}{"\n"}{end}' || true
-      done <<< "${workloads}"
-    fi
-
-    ingress_host="$(kubectl -n danielsmith get ingress -o jsonpath='{.items[0].spec.rules[0].host}' 2>/dev/null || true)"
-    if [ -n "${ingress_host}" ]; then
-      echo
-      echo "Post-deploy checks:"
-      echo "  curl -fsS https://${ingress_host}/"
-      echo "  curl -fsS https://${ingress_host}/livez"
-      echo "  curl -fsS https://${ingress_host}/healthz"
-    fi
+    @just --justfile "{{ justfile_directory() }}/justfile" app-deploy app=danielsmith env='{{ env }}' tag='{{ tag }}'
 
 danielsmith-oci-promote-prod tag='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
-
-    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.prod.tag | head -n1 | tr -d '[:space:]'; }
-
-    resolved_tag="$(echo '{{ tag }}' | xargs)"
-    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
-      resolved_tag="${resolved_tag#tag=}"
-    done
-    if [ -z "${resolved_tag}" ]; then
-      resolved_tag="$(read_prod_tag 2>/dev/null || true)"
-    fi
-    if [ -z "${resolved_tag}" ]; then
-      echo "ERROR: provide tag=<immutable-tag> or set docs/apps/danielsmith.prod.tag." >&2
-      exit 1
-    fi
-
-    just --justfile "{{ justfile_directory() }}/justfile" danielsmith-oci-deploy env=prod tag="${resolved_tag}"
+    @just --justfile "{{ justfile_directory() }}/justfile" app-promote-prod app=danielsmith tag='{{ tag }}'
 
 # Upgrade-only danielsmith OCI redeploy path.
 danielsmith-oci-redeploy env='staging' tag='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
-
-    env_input={{ quote(env) }}
-    env_name="${env_input}"
-    while [ "${env_name#env=}" != "${env_name}" ]; do
-        env_name="${env_name#env=}"
-    done
-    case "${env_name}" in
-      dev|staging|prod) ;;
-      *)
-        echo "ERROR: env must be one of dev|staging|prod." >&2
-        exit 1
-        ;;
-    esac
-
-    validate_immutable_tag() {
-      local candidate="${1}"
-      local tag_lc
-      tag_lc="$(echo "${candidate}" | tr '[:upper:]' '[:lower:]')"
-      if [[ "${tag_lc}" == *latest* ]] \
-        || [[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || [[ "${tag_lc}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || ([[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] && [[ ! "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]) \
-        || ([[ "${tag_lc}" =~ -[0-9a-f]{7,}$ ]] && [[ ! "${tag_lc}" =~ ^[a-z0-9][a-z0-9._-]*-[0-9a-f]{7,}$ ]]); then
-        echo "ERROR: mutable tag '${candidate}' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
-        exit 1
-      fi
-    }
-    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.prod.tag | head -n1 | tr -d '[:space:]'; }
-
-    resolved_tag="$(echo '{{ tag }}' | xargs)"
-    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
-      resolved_tag="${resolved_tag#tag=}"
-    done
-    if [ -z "${resolved_tag}" ] && [ "${env_name}" = "prod" ]; then
-      resolved_tag="$(read_prod_tag 2>/dev/null || true)"
-      [ -n "${resolved_tag}" ] || { echo "ERROR: prod requires tag=<immutable-tag> or docs/apps/danielsmith.prod.tag." >&2; exit 1; }
-    fi
-    if [ "${env_name}" != "prod" ] && [ -z "${resolved_tag}" ]; then
-      echo "ERROR: env=${env_name} redeploy requires explicit tag=<immutable-tag>." >&2
-      echo "Non-prod redeploy intentionally has no baked-in fallback tag so this path is reproducible and reviewable." >&2
-      exit 1
-    fi
-    [ -n "${resolved_tag}" ] && validate_immutable_tag "${resolved_tag}"
-
-    values_chain='docs/examples/danielsmith.values.dev.yaml'
-    default_tag=''
-    if [ "${env_name}" = "staging" ]; then
-      values_chain='docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml'
-    elif [ "${env_name}" = "prod" ]; then
-      values_chain='docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml'
-    fi
-
-    export KUBECONFIG="${HOME}/.kube/config"
-    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
-
-    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
-      release='danielsmith' namespace='danielsmith' \
-      chart='oci://ghcr.io/futuroptimist/charts/danielsmith' \
-      values="${values_chain}" \
-      version_file='docs/apps/danielsmith.version' \
-      tag="${resolved_tag}" default_tag="${default_tag}"
-
-    scripts/ensure_user_kubeconfig.sh || true
-    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+    @just --justfile "{{ justfile_directory() }}/justfile" app-redeploy app=danielsmith env='{{ env }}' tag='{{ tag }}'
 
 danielsmith-debug-logs namespace='danielsmith':
     #!/usr/bin/env bash
@@ -2447,14 +2057,25 @@ tokenplace-port-forward namespace='tokenplace' service='tokenplace' local_port='
     echo "Port-forwarding ${svc} to localhost:{{ local_port }} (Ctrl+C to stop)..."
     kubectl -n '{{ namespace }}' port-forward svc/${svc} {{ local_port }}:{{ remote_port }}
 
-app-status namespace='' release='' host_key='ingress.host':
+app-status app='' env='staging' config='' namespace='' release='' host_key='ingress.host':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
     export KUBECONFIG="${HOME}/.kube/config"
 
-    if [ -z "{{ namespace }}" ]; then
-        echo "Set namespace to inspect." >&2
+    ns='{{ namespace }}'
+    rel='{{ release }}'
+    host_key='{{ host_key }}'
+    if [ -n '{{ app }}' ]; then
+        eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" config --app '{{ app }}' --env '{{ env }}' --config '{{ config }}' --format shell)"
+        ns="${SUGARKUBE_NAMESPACE}"
+        rel="${SUGARKUBE_RELEASE}"
+        host_key="${SUGARKUBE_STATUS_HOST_KEY}"
+        just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+    fi
+
+    if [ -z "${ns}" ]; then
+        echo "Set app=<app> env=<dev|staging|prod> or namespace=<namespace> to inspect." >&2
         exit 1
     fi
 
@@ -2463,41 +2084,15 @@ app-status namespace='' release='' host_key='ingress.host':
         exit 1
     fi
 
-    kubectl -n "{{ namespace }}" get pods
-    kubectl -n "{{ namespace }}" get ingress
+    kubectl -n "${ns}" get pods
+    kubectl -n "${ns}" get ingress
 
-    if [ -n "{{ release }}" ] && command -v helm >/dev/null 2>&1; then
+    if [ -n "${rel}" ] && command -v helm >/dev/null 2>&1; then
         host="$(
-            helm get values "{{ release }}" \
-                --namespace "{{ namespace }}" \
+            helm get values "${rel}" \
+                --namespace "${ns}" \
                 --all --output json 2>/dev/null |
-                python3 - "{{ host_key }}" <<'PY'
-                import json
-                import sys
-
-                try:
-                    host_key = sys.argv[1]
-                    data = json.load(sys.stdin)
-                except (json.JSONDecodeError, KeyError, IndexError) as e:
-                    sys.stderr.write(f"Error extracting host value: {e}\n")
-                    sys.exit(1)
-                except Exception as e:
-                    sys.stderr.write(f"Unexpected error: {e}\n")
-                    sys.exit(1)
-
-                def get_with_dots(payload, dotted_key):
-                    node = payload
-                    for part in dotted_key.split('.'):
-                        if not isinstance(node, dict):
-                            return None
-                        node = node.get(part)
-                    return node
-
-                if isinstance(data, dict):
-                    host_value = get_with_dots(data, host_key)
-                    if host_value:
-                        print(host_value)
-                PY
+                python3 "{{ justfile_directory() }}/scripts/app_config.py" host --host-key "${host_key}" 2>/dev/null || true
         )"
     else
         host=""

--- a/scripts/app_config.py
+++ b/scripts/app_config.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Load Sugarkube dotenv app configs and validate immutable app tags."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import sys
+from pathlib import Path
+from typing import Mapping
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SUPPORTED_ENVS = {"dev", "staging", "prod"}
+MOVING_TAGS = {
+    "latest",
+    "main",
+    "master",
+    "dev",
+    "develop",
+    "staging",
+    "prod",
+    "production",
+    "release",
+}
+KNOWN_KEYS = {
+    "SUGARKUBE_APP",
+    "SUGARKUBE_RELEASE",
+    "SUGARKUBE_NAMESPACE",
+    "SUGARKUBE_CHART",
+    "SUGARKUBE_VERSION_FILE",
+    "SUGARKUBE_PROD_TAG_FILE",
+    "SUGARKUBE_VALUES_DEV",
+    "SUGARKUBE_VALUES_STAGING",
+    "SUGARKUBE_VALUES_PROD",
+    "SUGARKUBE_STATUS_HOST_KEY",
+    "SUGARKUBE_VERIFY_PATHS",
+    "SUGARKUBE_DEBUG_SELECTOR",
+}
+REQUIRED_KEYS = {
+    "SUGARKUBE_APP",
+    "SUGARKUBE_RELEASE",
+    "SUGARKUBE_NAMESPACE",
+    "SUGARKUBE_CHART",
+    "SUGARKUBE_VERSION_FILE",
+    "SUGARKUBE_PROD_TAG_FILE",
+    "SUGARKUBE_VALUES_DEV",
+    "SUGARKUBE_VALUES_STAGING",
+    "SUGARKUBE_VALUES_PROD",
+}
+DANGEROUS_VALUE_PATTERNS = ("`", "$(", ";", "&&", "||", "|", "<", ">")
+KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+APP_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+BRANCH_SHA_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*-[0-9a-fA-F]{7,}$")
+SEMVER_RE = re.compile(
+    r"^v?[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$"
+)
+
+
+class ConfigError(ValueError):
+    """Raised when app config cannot be safely loaded."""
+
+
+def normalize_named_arg(value: str, name: str) -> str:
+    """Strip repeated just named-arg prefixes, e.g. tag=tag=main-deadbee."""
+
+    normalized = str(value or "").strip()
+    prefix = f"{name}="
+    while normalized.startswith(prefix):
+        normalized = normalized[len(prefix) :]
+    return normalized.strip()
+
+
+def normalize_env(value: str) -> str:
+    env = normalize_named_arg(value, "env") or "staging"
+    if env == "int":
+        env = "staging"
+    if env not in SUPPORTED_ENVS:
+        raise ConfigError(f"env must be one of dev|staging|prod, got {env!r}.")
+    return env
+
+
+def validate_app_slug(app: str) -> str:
+    slug = normalize_named_arg(app, "app")
+    if not slug or not APP_RE.match(slug):
+        raise ConfigError("app must be a non-empty slug using letters, numbers, dots, underscores, or hyphens.")
+    return slug
+
+
+def candidate_paths(app: str, explicit_config: str = "") -> list[Path]:
+    paths: list[Path] = []
+    if explicit_config:
+        paths.append(Path(explicit_config).expanduser())
+    config_dir = os.environ.get("SUGARKUBE_APP_CONFIG_DIR", "").strip()
+    if config_dir:
+        paths.append(Path(config_dir).expanduser() / f"{app}.env")
+    paths.append(REPO_ROOT / "apps" / f"{app}.env")
+    paths.append(REPO_ROOT / "docs" / "examples" / "apps" / f"{app}.env")
+    return paths
+
+
+def resolve_config_path(app: str, explicit_config: str = "") -> Path:
+    checked = candidate_paths(app, explicit_config)
+    for path in checked:
+        candidate = path if path.is_absolute() else REPO_ROOT / path
+        if candidate.is_file():
+            return candidate
+    rendered = "\n  - ".join(str(p) for p in checked)
+    raise ConfigError(f"No app config found for app={app}. Checked:\n  - {rendered}")
+
+
+def strip_inline_comment(value: str) -> str:
+    in_single = False
+    in_double = False
+    for index, char in enumerate(value):
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        elif char == "#" and not in_single and not in_double:
+            if index == 0 or value[index - 1].isspace():
+                return value[:index].rstrip()
+    return value.strip()
+
+
+def parse_value(raw_value: str, line_number: int) -> str:
+    value = strip_inline_comment(raw_value.strip())
+    if not value:
+        return ""
+    if (value[0], value[-1:]) in {("'", "'"), ('"', '"')}:
+        try:
+            parts = shlex.split(value, posix=True)
+        except ValueError as exc:
+            raise ConfigError(f"line {line_number}: invalid quoted value: {exc}") from exc
+        if len(parts) != 1:
+            raise ConfigError(f"line {line_number}: quoted values must contain one token.")
+        value = parts[0]
+    elif any(ch.isspace() for ch in value):
+        raise ConfigError(f"line {line_number}: unquoted values may not contain whitespace.")
+    for pattern in DANGEROUS_VALUE_PATTERNS:
+        if pattern in value:
+            raise ConfigError(
+                f"line {line_number}: value contains unsupported shell syntax {pattern!r}; "
+                "app configs must be static dotenv assignments."
+            )
+    return value
+
+
+def load_dotenv(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        if "=" not in line:
+            raise ConfigError(f"line {line_number}: expected KEY=value assignment.")
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        if not KEY_RE.match(key):
+            raise ConfigError(f"line {line_number}: invalid key {key!r}.")
+        if key not in KNOWN_KEYS:
+            raise ConfigError(f"line {line_number}: unsupported app config key {key!r}.")
+        values[key] = parse_value(raw_value, line_number)
+    missing = sorted(REQUIRED_KEYS - values.keys())
+    if missing:
+        raise ConfigError(f"missing required app config keys: {', '.join(missing)}")
+    return values
+
+
+def load_app_config(app: str, env: str, explicit_config: str = "") -> dict[str, str]:
+    app_slug = validate_app_slug(app)
+    env_name = normalize_env(env)
+    path = resolve_config_path(app_slug, explicit_config)
+    values = load_dotenv(path)
+    configured_app = values.get("SUGARKUBE_APP", "")
+    if configured_app != app_slug:
+        raise ConfigError(
+            f"config {path} declares SUGARKUBE_APP={configured_app!r}, expected {app_slug!r}."
+        )
+    values_key = f"SUGARKUBE_VALUES_{env_name.upper()}"
+    values_chain = values.get(values_key, "")
+    if not values_chain:
+        raise ConfigError(f"config {path} does not define {values_key}.")
+    resolved = dict(values)
+    resolved["SUGARKUBE_ENV"] = env_name
+    resolved["SUGARKUBE_CONFIG_PATH"] = str(path)
+    resolved["SUGARKUBE_VALUES"] = values_chain
+    resolved.setdefault("SUGARKUBE_STATUS_HOST_KEY", "ingress.host")
+    resolved.setdefault("SUGARKUBE_VERIFY_PATHS", "/")
+    resolved.setdefault("SUGARKUBE_DEBUG_SELECTOR", f"app.kubernetes.io/name={app_slug}")
+    return resolved
+
+
+def validate_immutable_tag(tag: str) -> str:
+    candidate = normalize_named_arg(tag, "tag")
+    if not candidate:
+        raise ConfigError(
+            "tag is required. Use an immutable branch-SHA tag like main-deadbee or a semver release tag like v1.2.3."
+        )
+    lowered = candidate.lower()
+    if "latest" in lowered:
+        raise ConfigError(
+            f"mutable tag {candidate!r} is not allowed. Use an immutable branch-SHA tag like main-deadbee or a semver release tag."
+        )
+    if lowered in MOVING_TAGS:
+        raise ConfigError(
+            f"mutable tag {candidate!r} is not allowed. Bare branch/environment tags move; use branch-SHA (main-deadbee) or semver."
+        )
+    for moving in MOVING_TAGS - {"latest"}:
+        if lowered.endswith(f"-{moving}"):
+            raise ConfigError(
+                f"environment-like moving tag {candidate!r} is not allowed. Use branch-SHA (main-deadbee) or semver."
+            )
+    if BRANCH_SHA_RE.match(candidate) or SEMVER_RE.match(candidate):
+        return candidate
+    raise ConfigError(
+        f"tag {candidate!r} is not recognized as immutable. Use branch-SHA with a 7+ hex suffix (main-deadbee) or semver (v1.2.3)."
+    )
+
+
+def read_prod_tag(path_value: str) -> str:
+    path = Path(path_value).expanduser()
+    if not path.is_absolute():
+        path = REPO_ROOT / path
+    if not path.is_file():
+        return ""
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if line:
+            return line
+    return ""
+
+
+def dotted_get(payload: object, dotted_key: str) -> object | None:
+    node = payload
+    for part in dotted_key.split("."):
+        if not isinstance(node, dict):
+            return None
+        node = node.get(part)
+    return node
+
+
+def emit_shell(config: Mapping[str, str]) -> None:
+    ordered_keys = [
+        "SUGARKUBE_CONFIG_PATH",
+        "SUGARKUBE_APP",
+        "SUGARKUBE_ENV",
+        "SUGARKUBE_RELEASE",
+        "SUGARKUBE_NAMESPACE",
+        "SUGARKUBE_CHART",
+        "SUGARKUBE_VERSION_FILE",
+        "SUGARKUBE_PROD_TAG_FILE",
+        "SUGARKUBE_VALUES",
+        "SUGARKUBE_STATUS_HOST_KEY",
+        "SUGARKUBE_VERIFY_PATHS",
+        "SUGARKUBE_DEBUG_SELECTOR",
+    ]
+    for key in ordered_keys:
+        print(f"export {key}={shlex.quote(config.get(key, ''))}")
+
+
+def emit_human(config: Mapping[str, str]) -> None:
+    for key in sorted(config):
+        print(f"{key}={config[key]}")
+
+
+def command_config(args: argparse.Namespace) -> int:
+    config = load_app_config(args.app, args.env, args.config)
+    if args.format == "shell":
+        emit_shell(config)
+    elif args.format == "json":
+        print(json.dumps(config, indent=2, sort_keys=True))
+    else:
+        emit_human(config)
+    return 0
+
+
+def command_validate_tag(args: argparse.Namespace) -> int:
+    print(validate_immutable_tag(args.tag))
+    return 0
+
+
+def command_prod_tag(args: argparse.Namespace) -> int:
+    config = load_app_config(args.app, "prod", args.config)
+    tag = normalize_named_arg(args.tag or "", "tag") or read_prod_tag(config["SUGARKUBE_PROD_TAG_FILE"])
+    print(validate_immutable_tag(tag))
+    return 0
+
+
+def command_host(args: argparse.Namespace) -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"unable to parse Helm values JSON: {exc}") from exc
+    host = dotted_get(payload, args.host_key or "ingress.host")
+    if host:
+        print(host)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    config_parser = subparsers.add_parser("config", help="resolve app config")
+    config_parser.add_argument("--app", required=True)
+    config_parser.add_argument("--env", default="staging")
+    config_parser.add_argument("--config", default="")
+    config_parser.add_argument("--format", choices=("human", "shell", "json"), default="human")
+    config_parser.set_defaults(func=command_config)
+
+    tag_parser = subparsers.add_parser("validate-tag", help="validate and normalize immutable tag")
+    tag_parser.add_argument("tag")
+    tag_parser.set_defaults(func=command_validate_tag)
+
+    prod_tag_parser = subparsers.add_parser("prod-tag", help="resolve explicit or configured prod tag")
+    prod_tag_parser.add_argument("--app", required=True)
+    prod_tag_parser.add_argument("--config", default="")
+    prod_tag_parser.add_argument("--tag", default="")
+    prod_tag_parser.set_defaults(func=command_prod_tag)
+
+    host_parser = subparsers.add_parser("host", help="extract a dotted host key from Helm values JSON")
+    host_parser.add_argument("--host-key", default="ingress.host")
+    host_parser.set_defaults(func=command_host)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except ConfigError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -1,0 +1,95 @@
+"""Tests for the generic Sugarkube app config loader."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import app_config
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_example_config_resolves_staging_values() -> None:
+    config = app_config.load_app_config("danielsmith", "env=staging")
+
+    assert config["SUGARKUBE_CONFIG_PATH"].endswith("docs/examples/apps/danielsmith.env")
+    assert config["SUGARKUBE_RELEASE"] == "danielsmith"
+    assert (
+        config["SUGARKUBE_VALUES"]
+        == "docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml"
+    )
+
+
+def test_config_resolution_prefers_explicit_then_env_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    env_dir = tmp_path / "env-dir"
+    env_dir.mkdir()
+    explicit = tmp_path / "explicit.env"
+    env_config = env_dir / "demo.env"
+    base = """
+SUGARKUBE_APP=demo
+SUGARKUBE_RELEASE={release}
+SUGARKUBE_NAMESPACE=demo
+SUGARKUBE_CHART=oci://example.invalid/charts/demo
+SUGARKUBE_VERSION_FILE=docs/apps/demo.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/demo.prod.tag
+SUGARKUBE_VALUES_DEV=dev.yaml
+SUGARKUBE_VALUES_STAGING=dev.yaml,staging.yaml
+SUGARKUBE_VALUES_PROD=dev.yaml,prod.yaml
+""".lstrip()
+    explicit.write_text(base.format(release="explicit"), encoding="utf-8")
+    env_config.write_text(base.format(release="envdir"), encoding="utf-8")
+    monkeypatch.setenv("SUGARKUBE_APP_CONFIG_DIR", str(env_dir))
+
+    assert app_config.load_app_config("demo", "staging", str(explicit))["SUGARKUBE_RELEASE"] == "explicit"
+    assert app_config.load_app_config("demo", "staging")["SUGARKUBE_RELEASE"] == "envdir"
+
+
+@pytest.mark.parametrize(
+    "tag",
+    ["main-deadbee", "v3-deadbee", "feature-x-deadbee", "v0.1.0", "3.0.1", "3.1.0", "v1.2.3-rc.1"],
+)
+def test_validate_immutable_tag_accepts_supported_shapes(tag: str) -> None:
+    assert app_config.validate_immutable_tag(f"tag={tag}") == tag
+
+
+@pytest.mark.parametrize(
+    "tag",
+    ["latest", "main", "master", "dev", "develop", "staging", "prod", "production", "release", "main-latest", "foo-prod", "feature-x"],
+)
+def test_validate_immutable_tag_rejects_moving_tags(tag: str) -> None:
+    with pytest.raises(app_config.ConfigError) as excinfo:
+        app_config.validate_immutable_tag(tag)
+
+    assert "mutable" in str(excinfo.value) or "immutable" in str(excinfo.value) or "moving" in str(excinfo.value)
+
+
+def test_rejects_unknown_config_keys_when_emitting_shell(tmp_path: Path) -> None:
+    config = tmp_path / "bad.env"
+    config.write_text("SUGARKUBE_APP=bad\nDANGEROUS=$(echo nope)\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            os.environ.get("PYTHON", "python3"),
+            str(REPO_ROOT / "scripts" / "app_config.py"),
+            "config",
+            "--app",
+            "bad",
+            "--env",
+            "staging",
+            "--config",
+            str(config),
+            "--format",
+            "shell",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "unsupported app config key" in result.stderr

--- a/tests/test_danielsmith_oci_wrappers.py
+++ b/tests/test_danielsmith_oci_wrappers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -40,7 +41,16 @@ exit 0
     _write_executable(
         bin_dir / "python3",
         """#!/usr/bin/env bash
-exit 0
+set -euo pipefail
+case \"${1:-}\" in
+  */scripts/app_config.py|scripts/app_config.py)
+    exec '/root/.pyenv/versions/3.12.13/bin/python3' \"$@\"
+    ;;
+  *update_kubeconfig_scope.py)
+    exit 0
+    ;;
+esac
+exec '/root/.pyenv/versions/3.12.13/bin/python3' \"$@\"
 """,
     )
     _write_executable(

--- a/tests/test_generic_app_recipes.py
+++ b/tests/test_generic_app_recipes.py
@@ -1,0 +1,182 @@
+"""Stubbed tests for generic app deployment recipes and compatibility wrappers."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+@pytest.fixture()
+def generic_app_stub_env(tmp_path: Path, ensure_just_available: Path) -> dict[str, str]:
+    assert ensure_just_available.exists()
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    helm_log = tmp_path / "helm.log"
+    kubectl_log = tmp_path / "kubectl.log"
+
+    _write_executable(
+        bin_dir / "sudo",
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "cp" ]; then
+  mkdir -p "$(dirname "${3}")"
+  printf 'stub kubeconfig\n' > "${3}"
+fi
+exit 0
+""",
+    )
+    _write_executable(
+        bin_dir / "python3",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+case "${{1:-}}" in
+  */scripts/app_config.py|scripts/app_config.py)
+    exec {sys.executable!r} "$@"
+    ;;
+  *update_kubeconfig_scope.py)
+    exit 0
+    ;;
+esac
+exec {sys.executable!r} "$@"
+""",
+    )
+    _write_executable(
+        bin_dir / "kubectl",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> {str(kubectl_log)!r}
+if [ "${{3:-}}" = "get" ] && [ "${{4:-}}" = "deploy,statefulset,daemonset" ]; then
+  exit 0
+fi
+if [ "${{3:-}}" = "get" ] && [ "${{4:-}}" = "deploy" ]; then
+  exit 1
+fi
+exit 0
+""",
+    )
+    _write_executable(
+        bin_dir / "helm",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> {str(helm_log)!r}
+if [ "${{1:-}}" = "-n" ] && [ "${{3:-}}" = "status" ]; then
+  printf 'STATUS: deployed\n'
+fi
+exit 0
+""",
+    )
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "home")
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["SUGARKUBE_HELM_ROLLOUT_TIMEOUT"] = "1s"
+    env["HELM_LOG"] = str(helm_log)
+    env["KUBECTL_LOG"] = str(kubectl_log)
+    return env
+
+
+def _run_just(args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["just", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_generic_danielsmith_deploy_passes_image_tag(generic_app_stub_env: dict[str, str]) -> None:
+    result = _run_just(
+        ["app-deploy", "app=danielsmith", "env=staging", "tag=main-deadbee"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "--set image.tag=main-deadbee" in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize(
+    ("app", "chart", "namespace", "values"),
+    [
+        (
+            "tokenplace",
+            "oci://ghcr.io/futuroptimist/charts/tokenplace",
+            "tokenplace",
+            "-f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.staging.yaml",
+        ),
+        (
+            "dspace",
+            "oci://ghcr.io/democratizedspace/charts/dspace",
+            "dspace",
+            "-f docs/examples/dspace.values.dev.yaml -f docs/examples/dspace.values.staging.yaml",
+        ),
+    ],
+)
+def test_generic_deploy_uses_app_config_coordinates(
+    app: str,
+    chart: str,
+    namespace: str,
+    values: str,
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        ["app-deploy", f"app={app}", "env=staging", "tag=main-deadbee"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert f"upgrade {namespace} {chart} --namespace {namespace}" in helm_log
+    assert values in helm_log
+    assert "--set image.tag=main-deadbee" in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_mutable_tag_rejected_before_helm(generic_app_stub_env: dict[str, str]) -> None:
+    result = _run_just(
+        ["app-deploy", "app=tokenplace", "env=staging", "tag=latest"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode != 0
+    assert "mutable tag" in result.stderr
+    helm_log_path = Path(generic_app_stub_env["HELM_LOG"])
+    assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize(
+    ("recipe", "app"),
+    [
+        ("danielsmith-oci-deploy", "danielsmith"),
+        ("tokenplace-oci-deploy", "tokenplace"),
+        ("dspace-oci-deploy", "dspace"),
+    ],
+)
+def test_compatibility_deploy_wrappers_call_generic_flow(
+    recipe: str,
+    app: str,
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just([recipe, "env=staging", "tag=tag=main-deadbee"], generic_app_stub_env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert f"upgrade {app if app != 'danielsmith' else 'danielsmith'}" in helm_log
+    assert "--set image.tag=main-deadbee" in helm_log
+    assert "--set image.tag=tag=main-deadbee" not in helm_log


### PR DESCRIPTION
### Motivation
- Remove duplicated app-specific deploy logic by introducing a generic, config-driven deployment façade.
- Centralize immutable image tag validation to prevent mutable/moving tags from reaching Helm.
- Provide a small, stdlib-only app config loader to resolve dotenv-style app configs from multiple locations safely.
- Preserve existing dspace/token.place/danielsmith wrappers as compatibility shims to avoid breaking current runbooks.

### Description
- Add `scripts/app_config.py` which parses dotenv-style app configs, searches config paths in order (`config=`, `SUGARKUBE_APP_CONFIG_DIR`, `apps/`, `docs/examples/apps/`), whitelists keys, guards against dangerous shell syntax, normalizes named args, resolves env-specific values chains, reads optional prod tag pins, extracts dotted Helm host keys, and implements `validate_immutable_tag` (branch-SHA and semver acceptance plus human-readable rejection messages).
- Add generic `just` recipes: `app-config`, `app-deploy`, `app-redeploy`, `app-promote-prod`, `app-status`, and `app-verify` that load/emit the app config (shell/json/human), select env-scoped kubeconfig via `just kubeconfig-env`, validate tags before calling existing `helm-oci-install`/`helm-oci-upgrade`, and run/call verification curl checks or print copy-paste commands when a host cannot be derived.
- Convert existing app-specific OCI recipes (`dspace-oci-*`, `tokenplace-oci-*`, `danielsmith-oci-*`) into thin compatibility shims that delegate to the generic recipes where practical while preserving mature special-case behavior and TODO hints.
- Update documentation (`docs/app_deployment_contract.md`) and example app configs to mark the generic flow implemented and document that app-specific recipes are retained as compatibility shims.
- Add tests covering app config resolution, tag validation, stubbed generic deploy behavior, mutable-tag rejection, and compatibility wrapper integration (`tests/test_app_config.py`, `tests/test_generic_app_recipes.py`) and adjust minor test stubs to invoke the new loader.

### Testing
- Ran the repository test suite with `python -m pytest tests -q`, resulting in success with `1231 passed, 19 skipped` for the environment used here.
- Ran focused test invocations for the changes with `python -m pytest tests/test_up_recipe_calls.py tests/test_justfile_formatting.py tests/test_app_config.py tests/test_generic_app_recipes.py tests/test_danielsmith_oci_wrappers.py` which all passed under the test harness.
- Verified `just` visibility and quick checks with `just --summary | grep -E 'app-(config|deploy|redeploy|promote-prod|status|verify)'` and exercised `just app-config app=danielsmith env=staging`, `just app-config app=tokenplace env=staging`, and `just app-config app=dspace env=staging` under the test stubs, producing expected outputs.
- Not run in this environment due to missing tooling: `pre-commit run --all-files` (no `pre-commit`), `pyspelling -c .spellcheck.yaml` (no `pyspelling`), and `linkchecker --no-warnings README.md docs/` (no `linkchecker`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e0c4d4a44832fae566689e78eebc0)