### PR TITLE
Implement generic app deploy recipes backed by app config files

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -1,12 +1,14 @@
 # Sugarkube app deployment contract
 
-Sugarkube is moving toward a generic app deployment surface where each app is
+Sugarkube now exposes a generic app deployment surface where each app is
 identified by a small local config file and deployed with shared `just` recipes.
-This page is the contract future implementation work will target; it does not
-change current `justfile` deployment behavior.
+This page is the contract that app repositories and local operator configs should
+follow.
 
 The existing app-specific recipes for dspace, token.place, and danielsmith.io
-remain compatibility wrappers until the generic recipes are implemented.
+remain compatibility shims during migration. They are intentionally not removed
+in this phase and will be deprecated only after downstream runbooks have moved to
+the generic flow.
 
 ## Ownership boundary
 
@@ -93,10 +95,19 @@ Helm charts are immutable once published to GHCR OCI:
 
 ## App config file shape
 
-Future generic recipes will load a simple shell/dotenv-style config so they do
-not require `yq`. Example files live under [`docs/examples/apps/`](examples/apps/)
-and may be copied into a local config directory such as `apps/APP.env`. Operators
-may also set `SUGARKUBE_APP_CONFIG_DIR` to point at another directory.
+Generic recipes load a simple shell/dotenv-style config with
+[`scripts/app_config.py`](../scripts/app_config.py), using only Python stdlib so
+they do not require `yq`. Example files live under
+[`docs/examples/apps/`](examples/apps/) and may be copied into a local config
+directory such as `apps/APP.env`. Operators may also set
+`SUGARKUBE_APP_CONFIG_DIR` to point at another directory.
+
+Config lookup order is:
+
+1. an explicit `config=<path>` passed to a generic recipe;
+2. `${SUGARKUBE_APP_CONFIG_DIR}/${app}.env` when `SUGARKUBE_APP_CONFIG_DIR` is set;
+3. `apps/${app}.env` in the local clone; and
+4. `docs/examples/apps/${app}.env` for the current example apps.
 
 Rules for app config files:
 
@@ -106,7 +117,7 @@ Rules for app config files:
 - Keep verify paths comma-separated with leading slashes.
 - Do not store secrets in app config files.
 
-Required keys for the planned generic recipes:
+Required keys for the generic recipes:
 
 | Key | Purpose |
 | --- | --- |
@@ -131,10 +142,10 @@ cp docs/examples/apps/dspace.env apps/dspace.env
 export SUGARKUBE_APP_CONFIG_DIR=apps
 ```
 
-## Planned generic command surface
+## Generic command surface
 
-P5 will implement these command shapes. They are documented here so app repos can
-align their artifacts before Sugarkube changes behavior.
+These recipes are implemented in the root `justfile` and use the app config
+lookup order above.
 
 ```bash
 # Deploy or install a specific immutable candidate into an environment.
@@ -156,10 +167,11 @@ just app-verify app=dspace env=staging
 just app-config app=dspace env=staging
 ```
 
-The compatibility wrappers will remain during migration. For example,
+Migration note: app-specific commands such as
 `just dspace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA` and
-`just tokenplace-oci-promote-prod tag=main-REPLACE_SHORTSHA` continue to be the
-current operational commands until generic recipes replace their internals.
+`just tokenplace-oci-promote-prod tag=main-REPLACE_SHORTSHA` remain available as
+compatibility shims. Prefer the generic recipes for new runbooks and app
+onboarding, but do not delete the legacy wrapper commands yet.
 
 ## Current example configs
 

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -167,11 +167,15 @@ just app-verify app=dspace env=staging
 just app-config app=dspace env=staging
 ```
 
-Migration note: app-specific commands such as
-`just dspace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA` and
-`just tokenplace-oci-promote-prod tag=main-REPLACE_SHORTSHA` remain available as
-compatibility shims. Prefer the generic recipes for new runbooks and app
-onboarding, but do not delete the legacy wrapper commands yet.
+Migration/TODO note: the mature `dspace-oci-deploy`/`dspace-oci-redeploy`,
+`tokenplace-oci-deploy`/`tokenplace-oci-redeploy`, and
+`danielsmith-oci-deploy`/`danielsmith-oci-redeploy` compatibility paths
+intentionally remain in place for now. Generic `app-deploy` and `app-redeploy`
+support all three apps, so prefer the generic recipes for new runbooks and app
+onboarding, but thinning the remaining deploy/redeploy wrappers is deferred to a
+follow-up PR. Production promotion wrappers such as
+`just tokenplace-oci-promote-prod tag=main-REPLACE_SHORTSHA` remain documented as
+thin generic shims over the shared production promotion flow.
 
 ## Current example configs
 

--- a/docs/examples/apps/danielsmith.env
+++ b/docs/examples/apps/danielsmith.env
@@ -1,7 +1,7 @@
 # Example Sugarkube app config for danielsmith.io.
 # Copy to apps/danielsmith.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
-# containing danielsmith.env when the generic app recipes are implemented.
-# This is documentation scaffold only; it is not a platform default.
+# containing danielsmith.env.
+# This is an example fallback for generic recipes; local app configs take precedence.
 
 SUGARKUBE_APP=danielsmith
 SUGARKUBE_RELEASE=danielsmith

--- a/docs/examples/apps/dspace.env
+++ b/docs/examples/apps/dspace.env
@@ -1,7 +1,7 @@
 # Example Sugarkube app config for dspace.
 # Copy to apps/dspace.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
-# containing dspace.env when the generic app recipes are implemented.
-# This is documentation scaffold only; it is not a platform default.
+# containing dspace.env.
+# This is an example fallback for generic recipes; local app configs take precedence.
 
 SUGARKUBE_APP=dspace
 SUGARKUBE_RELEASE=dspace

--- a/docs/examples/apps/tokenplace.env
+++ b/docs/examples/apps/tokenplace.env
@@ -1,7 +1,7 @@
 # Example Sugarkube app config for token.place.
 # Copy to apps/tokenplace.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
-# containing tokenplace.env when the generic app recipes are implemented.
-# This is documentation scaffold only; it is not a platform default.
+# containing tokenplace.env.
+# This is an example fallback for generic recipes; local app configs take precedence.
 
 SUGARKUBE_APP=tokenplace
 SUGARKUBE_RELEASE=tokenplace

--- a/justfile
+++ b/justfile
@@ -1605,16 +1605,19 @@ app-verify app env='staging' config='':
     if [ -z "${KUBECONFIG:-}" ]; then
       export KUBECONFIG="${HOME}/.kube/config"
     fi
+    kube_context="sugar-${SUGARKUBE_ENV}"
+    kubectl_context_args=(--context "${kube_context}")
+    helm_context_args=(--kube-context "${kube_context}")
 
     host=""
     if command -v helm >/dev/null 2>&1; then
-      host="$(helm get values "${SUGARKUBE_RELEASE}" \
+      host="$(helm "${helm_context_args[@]}" get values "${SUGARKUBE_RELEASE}" \
         --namespace "${SUGARKUBE_NAMESPACE}" \
         --all --output json 2>/dev/null | \
         python3 "{{ justfile_directory() }}/scripts/app_config.py" host-value "${SUGARKUBE_STATUS_HOST_KEY:-ingress.host}" || true)"
     fi
     if [ -z "${host}" ] && command -v kubectl >/dev/null 2>&1; then
-      host="$(kubectl -n "${SUGARKUBE_NAMESPACE}" get ingress -o jsonpath='{.items[0].spec.rules[0].host}' 2>/dev/null || true)"
+      host="$(kubectl "${kubectl_context_args[@]}" -n "${SUGARKUBE_NAMESPACE}" get ingress -o jsonpath='{.items[0].spec.rules[0].host}' 2>/dev/null || true)"
     fi
 
     IFS=',' read -r -a paths <<< "${SUGARKUBE_VERIFY_PATHS:-/}"
@@ -2546,6 +2549,8 @@ app-status app='' env='staging' config='' namespace='' release='' host_key='ingr
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
+    kubectl_context_args=()
+    helm_context_args=()
     if [ -n {{ quote(app) }} ]; then
         eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
           --app {{ quote(app) }} \
@@ -2554,6 +2559,9 @@ app-status app='' env='staging' config='' namespace='' release='' host_key='ingr
         if [ -z "${KUBECONFIG:-}" ]; then
             export KUBECONFIG="${HOME}/.kube/config"
         fi
+        kube_context="sugar-${SUGARKUBE_ENV}"
+        kubectl_context_args=(--context "${kube_context}")
+        helm_context_args=(--kube-context "${kube_context}")
         namespace="${SUGARKUBE_NAMESPACE}"
         release="${SUGARKUBE_RELEASE}"
         host_key="${SUGARKUBE_STATUS_HOST_KEY:-ingress.host}"
@@ -2576,12 +2584,12 @@ app-status app='' env='staging' config='' namespace='' release='' host_key='ingr
         exit 1
     fi
 
-    kubectl -n "${namespace}" get pods
-    kubectl -n "${namespace}" get ingress
+    kubectl "${kubectl_context_args[@]}" -n "${namespace}" get pods
+    kubectl "${kubectl_context_args[@]}" -n "${namespace}" get ingress
 
     if [ -n "${release}" ] && command -v helm >/dev/null 2>&1; then
         host="$(
-            helm get values "${release}"                 --namespace "${namespace}"                 --all --output json 2>/dev/null |
+            helm "${helm_context_args[@]}" get values "${release}"                 --namespace "${namespace}"                 --all --output json 2>/dev/null |
                 python3 "{{ justfile_directory() }}/scripts/app_config.py" host-value "${host_key}" || true
         )"
     else

--- a/justfile
+++ b/justfile
@@ -1518,6 +1518,118 @@ helm-oci-install release='' namespace='' chart='' values='' host='' version='' v
 helm-oci-upgrade release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='':
     @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' allow_install='false' reuse_values='true'
 
+# Print resolved Sugarkube app deployment config for an app/environment.
+app-config app env='staging' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    python3 "{{ justfile_directory() }}/scripts/app_config.py" json \
+      --app {{ quote(app) }} \
+      --env {{ quote(env) }} \
+      --config {{ quote(config) }}
+
+# Generic immutable-tag app deploy backed by docs/examples/apps/*.env or local app configs.
+app-deploy app env='staging' tag='' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+      --app {{ quote(app) }} \
+      --env {{ quote(env) }} \
+      --config {{ quote(config) }} \
+      --tag {{ quote(tag) }} \
+      --require-tag)"
+
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
+      release="${SUGARKUBE_RELEASE}" \
+      namespace="${SUGARKUBE_NAMESPACE}" \
+      chart="${SUGARKUBE_CHART}" \
+      values="${SUGARKUBE_VALUES}" \
+      version="${SUGARKUBE_VERSION:-}" \
+      version_file="${SUGARKUBE_VERSION_FILE:-}" \
+      tag="${SUGARKUBE_TAG}"
+
+# Generic upgrade-only app redeploy backed by app config files.
+app-redeploy app env='staging' tag='' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+      --app {{ quote(app) }} \
+      --env {{ quote(env) }} \
+      --config {{ quote(config) }} \
+      --tag {{ quote(tag) }} \
+      --require-tag)"
+
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
+      release="${SUGARKUBE_RELEASE}" \
+      namespace="${SUGARKUBE_NAMESPACE}" \
+      chart="${SUGARKUBE_CHART}" \
+      values="${SUGARKUBE_VALUES}" \
+      version="${SUGARKUBE_VERSION:-}" \
+      version_file="${SUGARKUBE_VERSION_FILE:-}" \
+      tag="${SUGARKUBE_TAG}"
+
+# Promote an app to prod with an explicit immutable tag, or the configured prod tag file.
+app-promote-prod app tag='' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+      --app {{ quote(app) }} \
+      --env prod \
+      --config {{ quote(config) }} \
+      --tag {{ quote(tag) }} \
+      --prod-tag-fallback \
+      --require-tag)"
+    just --justfile "{{ justfile_directory() }}/justfile" app-deploy \
+      app="${SUGARKUBE_APP}" \
+      env=prod \
+      tag="${SUGARKUBE_TAG}" \
+      config="${SUGARKUBE_CONFIG_PATH}"
+
+# Verify configured HTTPS paths for a Sugarkube app.
+app-verify app env='staging' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+      --app {{ quote(app) }} \
+      --env {{ quote(env) }} \
+      --config {{ quote(config) }})"
+
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+
+    host=""
+    if command -v helm >/dev/null 2>&1; then
+      host="$(helm get values "${SUGARKUBE_RELEASE}" \
+        --namespace "${SUGARKUBE_NAMESPACE}" \
+        --all --output json 2>/dev/null | \
+        python3 "{{ justfile_directory() }}/scripts/app_config.py" host-value "${SUGARKUBE_STATUS_HOST_KEY:-ingress.host}" || true)"
+    fi
+    if [ -z "${host}" ] && command -v kubectl >/dev/null 2>&1; then
+      host="$(kubectl -n "${SUGARKUBE_NAMESPACE}" get ingress -o jsonpath='{.items[0].spec.rules[0].host}' 2>/dev/null || true)"
+    fi
+
+    IFS=',' read -r -a paths <<< "${SUGARKUBE_VERIFY_PATHS:-/}"
+    if [ -z "${host}" ]; then
+      echo "Could not derive a host for ${SUGARKUBE_APP}; run these commands after replacing <host>:" >&2
+      for path in "${paths[@]}"; do
+        printf '  curl -fsS https://<host>%s\n' "${path}"
+      done
+      exit 0
+    fi
+
+    for path in "${paths[@]}"; do
+      printf 'curl -fsS https://%s%s\n' "${host}" "${path}"
+      curl -fsS "https://${host}${path}" >/dev/null
+    done
+
 # Opinionated immutable-tag dspace deploy with rollout verification.
 #
 
@@ -1662,21 +1774,7 @@ dspace-oci-deploy-prod-subdomain tag='':
 
 # If tag is omitted, this reads the pinned value from docs/apps/dspace.prod.tag.
 dspace-oci-promote-prod tag='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
-
-    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
-
-    deploy_tag="$(echo "{{ tag }}" | xargs)"
-    if [ -z "${deploy_tag}" ]; then
-      deploy_tag="$(read_prod_tag)"
-    fi
-    if [ -z "${deploy_tag}" ]; then
-      echo "Set tag=<immutable-tag> or populate docs/apps/dspace.prod.tag." >&2
-      exit 1
-    fi
-
-    just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy env=prod tag="${deploy_tag}"
+    @just app-promote-prod app=dspace tag='{{ tag }}'
 
 # Fast redeploy of dspace from GHCR (emergency mutable-tag refresh).
 dspace-oci-redeploy env='staging' tag='':
@@ -1906,21 +2004,7 @@ tokenplace-oci-deploy env='staging' tag='':
     fi
 
 tokenplace-oci-promote-prod tag='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
-
-    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.prod.tag | head -n1 | tr -d '[:space:]'; }
-
-    resolved_tag="$(echo '{{ tag }}' | xargs)"
-    if [ -z "${resolved_tag}" ]; then
-      resolved_tag="$(read_prod_tag 2>/dev/null || true)"
-    fi
-    if [ -z "${resolved_tag}" ]; then
-      echo "ERROR: provide tag=<immutable-tag> or set docs/apps/tokenplace.prod.tag." >&2
-      exit 1
-    fi
-
-    just --justfile "{{ justfile_directory() }}/justfile" tokenplace-oci-deploy env=prod tag="${resolved_tag}"
+    @just app-promote-prod app=tokenplace tag='{{ tag }}'
 
 # Upgrade-only token.place OCI redeploy path.
 tokenplace-oci-redeploy env='staging' tag='':
@@ -2249,24 +2333,7 @@ danielsmith-oci-deploy env='staging' tag='':
     fi
 
 danielsmith-oci-promote-prod tag='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
-
-    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.prod.tag | head -n1 | tr -d '[:space:]'; }
-
-    resolved_tag="$(echo '{{ tag }}' | xargs)"
-    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
-      resolved_tag="${resolved_tag#tag=}"
-    done
-    if [ -z "${resolved_tag}" ]; then
-      resolved_tag="$(read_prod_tag 2>/dev/null || true)"
-    fi
-    if [ -z "${resolved_tag}" ]; then
-      echo "ERROR: provide tag=<immutable-tag> or set docs/apps/danielsmith.prod.tag." >&2
-      exit 1
-    fi
-
-    just --justfile "{{ justfile_directory() }}/justfile" danielsmith-oci-deploy env=prod tag="${resolved_tag}"
+    @just app-promote-prod app=danielsmith tag='{{ tag }}'
 
 # Upgrade-only danielsmith OCI redeploy path.
 danielsmith-oci-redeploy env='staging' tag='':
@@ -2447,14 +2514,29 @@ tokenplace-port-forward namespace='tokenplace' service='tokenplace' local_port='
     echo "Port-forwarding ${svc} to localhost:{{ local_port }} (Ctrl+C to stop)..."
     kubectl -n '{{ namespace }}' port-forward svc/${svc} {{ local_port }}:{{ remote_port }}
 
-app-status namespace='' release='' host_key='ingress.host':
+app-status app='' env='staging' config='' namespace='' release='' host_key='ingress.host':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    export KUBECONFIG="${HOME}/.kube/config"
+    if [ -n {{ quote(app) }} ]; then
+        eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+          --app {{ quote(app) }} \
+          --env {{ quote(env) }} \
+          --config {{ quote(config) }})"
+        export KUBECONFIG="${HOME}/.kube/config"
+        just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+        namespace="${SUGARKUBE_NAMESPACE}"
+        release="${SUGARKUBE_RELEASE}"
+        host_key="${SUGARKUBE_STATUS_HOST_KEY:-ingress.host}"
+    else
+        export KUBECONFIG="${HOME}/.kube/config"
+        namespace={{ quote(namespace) }}
+        release={{ quote(release) }}
+        host_key={{ quote(host_key) }}
+    fi
 
-    if [ -z "{{ namespace }}" ]; then
-        echo "Set namespace to inspect." >&2
+    if [ -z "${namespace}" ]; then
+        echo "Set app=<name> or namespace=<namespace> to inspect." >&2
         exit 1
     fi
 
@@ -2463,41 +2545,13 @@ app-status namespace='' release='' host_key='ingress.host':
         exit 1
     fi
 
-    kubectl -n "{{ namespace }}" get pods
-    kubectl -n "{{ namespace }}" get ingress
+    kubectl -n "${namespace}" get pods
+    kubectl -n "${namespace}" get ingress
 
-    if [ -n "{{ release }}" ] && command -v helm >/dev/null 2>&1; then
+    if [ -n "${release}" ] && command -v helm >/dev/null 2>&1; then
         host="$(
-            helm get values "{{ release }}" \
-                --namespace "{{ namespace }}" \
-                --all --output json 2>/dev/null |
-                python3 - "{{ host_key }}" <<'PY'
-                import json
-                import sys
-
-                try:
-                    host_key = sys.argv[1]
-                    data = json.load(sys.stdin)
-                except (json.JSONDecodeError, KeyError, IndexError) as e:
-                    sys.stderr.write(f"Error extracting host value: {e}\n")
-                    sys.exit(1)
-                except Exception as e:
-                    sys.stderr.write(f"Unexpected error: {e}\n")
-                    sys.exit(1)
-
-                def get_with_dots(payload, dotted_key):
-                    node = payload
-                    for part in dotted_key.split('.'):
-                        if not isinstance(node, dict):
-                            return None
-                        node = node.get(part)
-                    return node
-
-                if isinstance(data, dict):
-                    host_value = get_with_dots(data, host_key)
-                    if host_value:
-                        print(host_value)
-                PY
+            helm get values "${release}"                 --namespace "${namespace}"                 --all --output json 2>/dev/null |
+                python3 "{{ justfile_directory() }}/scripts/app_config.py" host-value "${host_key}" || true
         )"
     else
         host=""

--- a/justfile
+++ b/justfile
@@ -1610,18 +1610,36 @@ app-verify app env='staging' config='':
     helm_context_args=(--kube-context "${kube_context}")
 
     host=""
+    discovery_errors=()
     if command -v helm >/dev/null 2>&1; then
-      host="$(helm "${helm_context_args[@]}" get values "${SUGARKUBE_RELEASE}" \
+      helm_values=""
+      helm_error="$(mktemp)"
+      if helm_values="$(helm "${helm_context_args[@]}" get values "${SUGARKUBE_RELEASE}" \
         --namespace "${SUGARKUBE_NAMESPACE}" \
-        --all --output json 2>/dev/null | \
-        python3 "{{ justfile_directory() }}/scripts/app_config.py" host-value "${SUGARKUBE_STATUS_HOST_KEY:-ingress.host}" || true)"
+        --all --output json 2>"${helm_error}")"; then
+        host="$(printf '%s\n' "${helm_values}" | \
+          python3 "{{ justfile_directory() }}/scripts/app_config.py" host-value "${SUGARKUBE_STATUS_HOST_KEY:-ingress.host}")"
+      else
+        discovery_errors+=("helm get values failed for context ${kube_context}: $(tr '\n' ' ' < "${helm_error}")")
+      fi
+      rm -f "${helm_error}"
     fi
     if [ -z "${host}" ] && command -v kubectl >/dev/null 2>&1; then
-      host="$(kubectl "${kubectl_context_args[@]}" -n "${SUGARKUBE_NAMESPACE}" get ingress -o jsonpath='{.items[0].spec.rules[0].host}' 2>/dev/null || true)"
+      kubectl_error="$(mktemp)"
+      if ! host="$(kubectl "${kubectl_context_args[@]}" -n "${SUGARKUBE_NAMESPACE}" get ingress -o jsonpath='{.items[0].spec.rules[0].host}' 2>"${kubectl_error}")"; then
+        discovery_errors+=("kubectl ingress lookup failed for context ${kube_context}: $(tr '\n' ' ' < "${kubectl_error}")")
+        host=""
+      fi
+      rm -f "${kubectl_error}"
     fi
 
     IFS=',' read -r -a paths <<< "${SUGARKUBE_VERIFY_PATHS:-/}"
     if [ -z "${host}" ]; then
+      if [ "${#discovery_errors[@]}" -gt 0 ]; then
+        printf 'Could not derive a host for %s using context %s.\n' "${SUGARKUBE_APP}" "${kube_context}" >&2
+        printf '%s\n' "${discovery_errors[@]}" >&2
+        exit 1
+      fi
       echo "Could not derive a host for ${SUGARKUBE_APP}; run these commands after replacing <host>:" >&2
       for path in "${paths[@]}"; do
         printf '  curl -fsS https://<host>%s\n' "${path}"

--- a/justfile
+++ b/justfile
@@ -1602,8 +1602,9 @@ app-verify app env='staging' config='':
       --env {{ quote(env) }} \
       --config {{ quote(config) }})"
 
-    export KUBECONFIG="${HOME}/.kube/config"
-    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+    if [ -z "${KUBECONFIG:-}" ]; then
+      export KUBECONFIG="${HOME}/.kube/config"
+    fi
 
     host=""
     if command -v helm >/dev/null 2>&1; then
@@ -1774,7 +1775,16 @@ dspace-oci-deploy-prod-subdomain tag='':
 
 # If tag is omitted, this reads the pinned value from docs/apps/dspace.prod.tag.
 dspace-oci-promote-prod tag='':
-    @just app-promote-prod app=dspace tag='{{ tag }}'
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+      --app dspace \
+      --env prod \
+      --tag {{ quote(tag) }} \
+      --prod-tag-fallback \
+      --require-tag)"
+    just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy env=prod tag="${SUGARKUBE_TAG}"
 
 # Fast redeploy of dspace from GHCR (emergency mutable-tag refresh).
 dspace-oci-redeploy env='staging' tag='':
@@ -2004,7 +2014,16 @@ tokenplace-oci-deploy env='staging' tag='':
     fi
 
 tokenplace-oci-promote-prod tag='':
-    @just app-promote-prod app=tokenplace tag='{{ tag }}'
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+      --app tokenplace \
+      --env prod \
+      --tag {{ quote(tag) }} \
+      --prod-tag-fallback \
+      --require-tag)"
+    just --justfile "{{ justfile_directory() }}/justfile" tokenplace-oci-deploy env=prod tag="${SUGARKUBE_TAG}"
 
 # Upgrade-only token.place OCI redeploy path.
 tokenplace-oci-redeploy env='staging' tag='':
@@ -2333,7 +2352,16 @@ danielsmith-oci-deploy env='staging' tag='':
     fi
 
 danielsmith-oci-promote-prod tag='':
-    @just app-promote-prod app=danielsmith tag='{{ tag }}'
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+      --app danielsmith \
+      --env prod \
+      --tag {{ quote(tag) }} \
+      --prod-tag-fallback \
+      --require-tag)"
+    just --justfile "{{ justfile_directory() }}/justfile" danielsmith-oci-deploy env=prod tag="${SUGARKUBE_TAG}"
 
 # Upgrade-only danielsmith OCI redeploy path.
 danielsmith-oci-redeploy env='staging' tag='':
@@ -2523,13 +2551,16 @@ app-status app='' env='staging' config='' namespace='' release='' host_key='ingr
           --app {{ quote(app) }} \
           --env {{ quote(env) }} \
           --config {{ quote(config) }})"
-        export KUBECONFIG="${HOME}/.kube/config"
-        just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+        if [ -z "${KUBECONFIG:-}" ]; then
+            export KUBECONFIG="${HOME}/.kube/config"
+        fi
         namespace="${SUGARKUBE_NAMESPACE}"
         release="${SUGARKUBE_RELEASE}"
         host_key="${SUGARKUBE_STATUS_HOST_KEY:-ingress.host}"
     else
-        export KUBECONFIG="${HOME}/.kube/config"
+        if [ -z "${KUBECONFIG:-}" ]; then
+            export KUBECONFIG="${HOME}/.kube/config"
+        fi
         namespace={{ quote(namespace) }}
         release={{ quote(release) }}
         host_key={{ quote(host_key) }}

--- a/scripts/app_config.py
+++ b/scripts/app_config.py
@@ -132,7 +132,7 @@ def parse_dotenv(path: Path) -> dict[str, str]:
         if key not in ALLOWED_KEYS:
             raise AppConfigError(f"{path}:{lineno}: unknown app config key '{key}'.")
         try:
-            parts = shlex.split(raw_value, comments=False, posix=True)
+            parts = shlex.split(raw_value, comments=True, posix=True)
         except ValueError as exc:
             raise AppConfigError(f"{path}:{lineno}: invalid quoted value for {key}: {exc}.") from exc
         if len(parts) > 1:
@@ -160,6 +160,10 @@ def load_config(app: str, env: str, explicit: str | None = None) -> dict[str, st
     if data["SUGARKUBE_APP"] != app:
         raise AppConfigError(
             f"{config_path}: SUGARKUBE_APP={data['SUGARKUBE_APP']!r} does not match app={app!r}."
+        )
+    if not (data.get("SUGARKUBE_VERSION") or data.get("SUGARKUBE_VERSION_FILE")):
+        raise AppConfigError(
+            f"{config_path}: missing chart version pin; set SUGARKUBE_VERSION or SUGARKUBE_VERSION_FILE."
         )
     values_key = f"SUGARKUBE_VALUES_{env.upper()}"
     values = data.get(values_key, "")

--- a/scripts/app_config.py
+++ b/scripts/app_config.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Load Sugarkube app deployment config and validate immutable image tags."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import sys
+from pathlib import Path
+from typing import Iterable
+
+SUPPORTED_ENVS = {"dev", "staging", "prod"}
+EXAMPLE_FALLBACK_APPS = {"danielsmith", "dspace", "tokenplace"}
+MOVING_TAGS = {
+    "latest",
+    "main",
+    "master",
+    "dev",
+    "develop",
+    "staging",
+    "prod",
+    "production",
+    "release",
+}
+ALLOWED_KEYS = {
+    "SUGARKUBE_APP",
+    "SUGARKUBE_RELEASE",
+    "SUGARKUBE_NAMESPACE",
+    "SUGARKUBE_CHART",
+    "SUGARKUBE_VERSION",
+    "SUGARKUBE_VERSION_FILE",
+    "SUGARKUBE_PROD_TAG_FILE",
+    "SUGARKUBE_VALUES_DEV",
+    "SUGARKUBE_VALUES_STAGING",
+    "SUGARKUBE_VALUES_PROD",
+    "SUGARKUBE_STATUS_HOST_KEY",
+    "SUGARKUBE_VERIFY_PATHS",
+    "SUGARKUBE_DEBUG_SELECTOR",
+}
+REQUIRED_KEYS = {
+    "SUGARKUBE_APP",
+    "SUGARKUBE_RELEASE",
+    "SUGARKUBE_NAMESPACE",
+    "SUGARKUBE_CHART",
+}
+ASSIGNMENT_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
+BRANCH_SHA_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*-[0-9a-f]{7,}$", re.IGNORECASE)
+SEMVER_RE = re.compile(
+    r"^v?[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$"
+)
+
+
+class AppConfigError(ValueError):
+    """Raised when app config or tag validation fails."""
+
+
+def normalize_named(value: str, name: str) -> str:
+    value = (value or "").strip()
+    prefix = f"{name}="
+    while value.startswith(prefix):
+        value = value[len(prefix) :].strip()
+    return value
+
+
+def normalize_env(value: str) -> str:
+    env = normalize_named(value, "env")
+    if env == "int":
+        env = "staging"
+    if env not in SUPPORTED_ENVS:
+        raise AppConfigError("env must be one of dev|staging|prod.")
+    return env
+
+
+def validate_app_name(app: str) -> str:
+    app = normalize_named(app, "app")
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", app or ""):
+        raise AppConfigError("app must be a non-empty name using letters, numbers, dots, underscores, or dashes.")
+    return app
+
+
+def validate_tag(tag: str) -> str:
+    tag = normalize_named(tag, "tag")
+    if not tag:
+        raise AppConfigError(
+            "tag must not be empty. Use an immutable tag such as main-deadbee or v0.1.0."
+        )
+    tag_lc = tag.lower()
+    if tag_lc in MOVING_TAGS or "latest" in tag_lc:
+        raise AppConfigError(
+            f"mutable tag '{tag}' is not allowed. Use an immutable branch-SHA tag "
+            "(example: main-deadbee) or a semver release tag (example: v0.1.0)."
+        )
+    if re.search(r"(^|[-_.])(dev|develop|staging|prod|production|release)([-_.]|$)", tag_lc):
+        if not BRANCH_SHA_RE.fullmatch(tag):
+            raise AppConfigError(
+                f"environment-like moving tag '{tag}' is not allowed. Use an immutable "
+                "branch-SHA tag ending in at least 7 hex characters."
+            )
+    if BRANCH_SHA_RE.fullmatch(tag) or SEMVER_RE.fullmatch(tag):
+        return tag
+    raise AppConfigError(
+        f"invalid tag '{tag}'. Use an immutable branch-SHA tag (main-deadbee) or semver release tag."
+    )
+
+
+def iter_config_candidates(repo_root: Path, app: str, explicit: str | None) -> Iterable[Path]:
+    if explicit:
+        yield Path(explicit)
+    config_dir = os.environ.get("SUGARKUBE_APP_CONFIG_DIR")
+    if config_dir:
+        yield Path(config_dir) / f"{app}.env"
+    yield repo_root / "apps" / f"{app}.env"
+    if app in EXAMPLE_FALLBACK_APPS:
+        yield repo_root / "docs" / "examples" / "apps" / f"{app}.env"
+
+
+def parse_dotenv(path: Path) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for lineno, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        match = ASSIGNMENT_RE.fullmatch(line)
+        if not match:
+            raise AppConfigError(f"{path}:{lineno}: expected KEY=value dotenv assignment.")
+        key, raw_value = match.groups()
+        if key not in ALLOWED_KEYS:
+            raise AppConfigError(f"{path}:{lineno}: unknown app config key '{key}'.")
+        try:
+            parts = shlex.split(raw_value, comments=False, posix=True)
+        except ValueError as exc:
+            raise AppConfigError(f"{path}:{lineno}: invalid quoted value for {key}: {exc}.") from exc
+        if len(parts) > 1:
+            raise AppConfigError(f"{path}:{lineno}: {key} must be a single dotenv value.")
+        value = parts[0] if parts else ""
+        if any(token in raw_value for token in ("$(", "`", "$((", ";", "&&", "||")):
+            raise AppConfigError(f"{path}:{lineno}: shell syntax is not allowed in {key}.")
+        data[key] = value
+    return data
+
+
+def load_config(app: str, env: str, explicit: str | None = None) -> dict[str, str]:
+    app = validate_app_name(app)
+    env = normalize_env(env)
+    repo_root = Path(__file__).resolve().parents[1]
+    candidates = list(iter_config_candidates(repo_root, app, explicit))
+    config_path = next((path for path in candidates if path.is_file()), None)
+    if config_path is None:
+        searched = ", ".join(str(path) for path in candidates)
+        raise AppConfigError(f"no config found for app '{app}'. Searched: {searched}")
+    data = parse_dotenv(config_path)
+    missing = sorted(REQUIRED_KEYS - data.keys())
+    if missing:
+        raise AppConfigError(f"{config_path}: missing required keys: {', '.join(missing)}")
+    if data["SUGARKUBE_APP"] != app:
+        raise AppConfigError(
+            f"{config_path}: SUGARKUBE_APP={data['SUGARKUBE_APP']!r} does not match app={app!r}."
+        )
+    values_key = f"SUGARKUBE_VALUES_{env.upper()}"
+    values = data.get(values_key, "")
+    if not values:
+        raise AppConfigError(f"{config_path}: missing {values_key} for env={env}.")
+    resolved = dict(data)
+    resolved["SUGARKUBE_ENV"] = env
+    resolved["SUGARKUBE_VALUES"] = values
+    resolved["SUGARKUBE_CONFIG_PATH"] = str(config_path)
+    resolved.setdefault("SUGARKUBE_STATUS_HOST_KEY", "ingress.host")
+    resolved.setdefault("SUGARKUBE_VERIFY_PATHS", "/")
+    return resolved
+
+
+def resolve_tag(config: dict[str, str], raw_tag: str, *, prod_fallback: bool) -> str:
+    tag = normalize_named(raw_tag, "tag")
+    if not tag and prod_fallback:
+        tag_file = config.get("SUGARKUBE_PROD_TAG_FILE", "")
+        if tag_file:
+            path = Path(tag_file)
+            if not path.is_absolute():
+                path = Path(__file__).resolve().parents[1] / path
+            if path.is_file():
+                for line in path.read_text(encoding="utf-8").splitlines():
+                    line = line.split("#", 1)[0].strip()
+                    if line:
+                        tag = line
+                        break
+    return validate_tag(tag)
+
+
+def shell_emit(config: dict[str, str]) -> str:
+    keys = [
+        "SUGARKUBE_APP",
+        "SUGARKUBE_ENV",
+        "SUGARKUBE_RELEASE",
+        "SUGARKUBE_NAMESPACE",
+        "SUGARKUBE_CHART",
+        "SUGARKUBE_VALUES",
+        "SUGARKUBE_VERSION",
+        "SUGARKUBE_VERSION_FILE",
+        "SUGARKUBE_PROD_TAG_FILE",
+        "SUGARKUBE_STATUS_HOST_KEY",
+        "SUGARKUBE_VERIFY_PATHS",
+        "SUGARKUBE_DEBUG_SELECTOR",
+        "SUGARKUBE_CONFIG_PATH",
+        "SUGARKUBE_TAG",
+    ]
+    lines = []
+    for key in keys:
+        if key in config:
+            lines.append(f"export {key}={shlex.quote(config[key])}")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name in ("json", "shell"):
+        cmd = sub.add_parser(name)
+        cmd.add_argument("--app", required=True)
+        cmd.add_argument("--env", required=True)
+        cmd.add_argument("--config", default="")
+        cmd.add_argument("--tag", default="")
+        cmd.add_argument("--require-tag", action="store_true")
+        cmd.add_argument("--prod-tag-fallback", action="store_true")
+    validate = sub.add_parser("validate-tag")
+    validate.add_argument("tag")
+    host = sub.add_parser("host-value")
+    host.add_argument("host_key")
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "validate-tag":
+            print(validate_tag(args.tag))
+            return 0
+        if args.command == "host-value":
+            data = json.load(sys.stdin)
+            node = data
+            for part in args.host_key.split("."):
+                if not isinstance(node, dict):
+                    return 0
+                node = node.get(part)
+            if node:
+                print(node)
+            return 0
+        config = load_config(args.app, args.env, args.config or None)
+        if args.require_tag or args.tag or args.prod_tag_fallback:
+            config["SUGARKUBE_TAG"] = resolve_tag(
+                config, args.tag, prod_fallback=bool(args.prod_tag_fallback)
+            )
+        if args.command == "json":
+            print(json.dumps(config, indent=2, sort_keys=True))
+        else:
+            sys.stdout.write(shell_emit(config))
+        return 0
+    except AppConfigError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/app_config.py
+++ b/scripts/app_config.py
@@ -77,7 +77,10 @@ def normalize_env(value: str) -> str:
 def validate_app_name(app: str) -> str:
     app = normalize_named(app, "app")
     if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", app or ""):
-        raise AppConfigError("app must be a non-empty name using letters, numbers, dots, underscores, or dashes.")
+        raise AppConfigError(
+            "app must be a non-empty name using letters, numbers, dots, underscores, "
+            "or dashes."
+        )
     return app
 
 
@@ -102,7 +105,8 @@ def validate_tag(tag: str) -> str:
     if BRANCH_SHA_RE.fullmatch(tag) or SEMVER_RE.fullmatch(tag):
         return tag
     raise AppConfigError(
-        f"invalid tag '{tag}'. Use an immutable branch-SHA tag (main-deadbee) or semver release tag."
+        f"invalid tag '{tag}'. Use an immutable branch-SHA tag (main-deadbee) "
+        "or semver release tag."
     )
 
 
@@ -134,7 +138,9 @@ def parse_dotenv(path: Path) -> dict[str, str]:
         try:
             parts = shlex.split(raw_value, comments=True, posix=True)
         except ValueError as exc:
-            raise AppConfigError(f"{path}:{lineno}: invalid quoted value for {key}: {exc}.") from exc
+            raise AppConfigError(
+                f"{path}:{lineno}: invalid quoted value for {key}: {exc}."
+            ) from exc
         if len(parts) > 1:
             raise AppConfigError(f"{path}:{lineno}: {key} must be a single dotenv value.")
         value = parts[0] if parts else ""
@@ -163,7 +169,8 @@ def load_config(app: str, env: str, explicit: str | None = None) -> dict[str, st
         )
     if not (data.get("SUGARKUBE_VERSION") or data.get("SUGARKUBE_VERSION_FILE")):
         raise AppConfigError(
-            f"{config_path}: missing chart version pin; set SUGARKUBE_VERSION or SUGARKUBE_VERSION_FILE."
+            f"{config_path}: missing chart version pin; set SUGARKUBE_VERSION "
+            "or SUGARKUBE_VERSION_FILE."
         )
     values_key = f"SUGARKUBE_VALUES_{env.upper()}"
     values = data.get(values_key, "")

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -1,0 +1,80 @@
+"""Tests for generic Sugarkube app config loading and tag validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import app_config
+
+
+def test_example_config_fallback_resolves_staging_values() -> None:
+    cfg = app_config.load_config("tokenplace", "staging")
+
+    assert cfg["SUGARKUBE_CONFIG_PATH"].endswith("docs/examples/apps/tokenplace.env")
+    assert cfg["SUGARKUBE_RELEASE"] == "tokenplace"
+    assert cfg["SUGARKUBE_NAMESPACE"] == "tokenplace"
+    assert cfg["SUGARKUBE_VALUES"] == (
+        "docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml"
+    )
+
+
+def test_config_dir_precedes_example_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_dir = tmp_path / "configs"
+    config_dir.mkdir()
+    (config_dir / "custom.env").write_text(
+        "\n".join(
+            [
+                "SUGARKUBE_APP=custom",
+                "SUGARKUBE_RELEASE=custom-release",
+                "SUGARKUBE_NAMESPACE=custom-ns",
+                "SUGARKUBE_CHART=oci://example.invalid/charts/custom",
+                "SUGARKUBE_VALUES_DEV=dev.yaml",
+                "SUGARKUBE_VALUES_STAGING=dev.yaml,staging.yaml",
+                "SUGARKUBE_VALUES_PROD=dev.yaml,prod.yaml",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SUGARKUBE_APP_CONFIG_DIR", str(config_dir))
+
+    cfg = app_config.load_config("custom", "env=staging")
+
+    assert cfg["SUGARKUBE_CONFIG_PATH"] == str(config_dir / "custom.env")
+    assert cfg["SUGARKUBE_VALUES"] == "dev.yaml,staging.yaml"
+
+
+@pytest.mark.parametrize("tag", ["main-deadbee", "v3-deadbee", "feature-x-deadbee", "v0.1.0", "3.0.1", "3.1.0-rc.1"])
+def test_validate_tag_allows_immutable_tags(tag: str) -> None:
+    assert app_config.validate_tag(tag) == tag
+
+
+@pytest.mark.parametrize("tag", ["latest", "main", "master", "dev", "develop", "staging", "prod", "production", "release", "staging-blue", "feature-x"])
+def test_validate_tag_rejects_moving_tags(tag: str) -> None:
+    with pytest.raises(app_config.AppConfigError, match="tag"):
+        app_config.validate_tag(tag)
+
+
+def test_rejects_unknown_dotenv_keys(tmp_path: Path) -> None:
+    config = tmp_path / "bad.env"
+    config.write_text(
+        "\n".join(
+            [
+                "SUGARKUBE_APP=bad",
+                "SUGARKUBE_RELEASE=bad",
+                "SUGARKUBE_NAMESPACE=bad",
+                "SUGARKUBE_CHART=oci://example.invalid/charts/bad",
+                "SUGARKUBE_VALUES_DEV=dev.yaml",
+                "SUGARKUBE_VALUES_STAGING=staging.yaml",
+                "SUGARKUBE_VALUES_PROD=prod.yaml",
+                "BASH_ENV=/tmp/pwn",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(app_config.AppConfigError, match="unknown app config key"):
+        app_config.load_config("bad", "staging", str(config))

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -20,7 +20,9 @@ def test_example_config_fallback_resolves_staging_values() -> None:
     )
 
 
-def test_config_dir_precedes_example_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_config_dir_precedes_example_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     config_dir = tmp_path / "configs"
     config_dir.mkdir()
     (config_dir / "custom.env").write_text(
@@ -47,12 +49,30 @@ def test_config_dir_precedes_example_fallback(tmp_path: Path, monkeypatch: pytes
     assert cfg["SUGARKUBE_VALUES"] == "dev.yaml,staging.yaml"
 
 
-@pytest.mark.parametrize("tag", ["main-deadbee", "v3-deadbee", "feature-x-deadbee", "v0.1.0", "3.0.1", "3.1.0-rc.1"])
+@pytest.mark.parametrize(
+    "tag",
+    ["main-deadbee", "v3-deadbee", "feature-x-deadbee", "v0.1.0", "3.0.1", "3.1.0-rc.1"],
+)
 def test_validate_tag_allows_immutable_tags(tag: str) -> None:
     assert app_config.validate_tag(tag) == tag
 
 
-@pytest.mark.parametrize("tag", ["latest", "main", "master", "dev", "develop", "staging", "prod", "production", "release", "staging-blue", "feature-x"])
+@pytest.mark.parametrize(
+    "tag",
+    [
+        "latest",
+        "main",
+        "master",
+        "dev",
+        "develop",
+        "staging",
+        "prod",
+        "production",
+        "release",
+        "staging-blue",
+        "feature-x",
+    ],
+)
 def test_validate_tag_rejects_moving_tags(tag: str) -> None:
     with pytest.raises(app_config.AppConfigError, match="tag"):
         app_config.validate_tag(tag)

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -49,6 +49,54 @@ def test_config_dir_precedes_example_fallback(
     assert cfg["SUGARKUBE_VALUES"] == "dev.yaml,staging.yaml"
 
 
+def test_explicit_config_path_precedes_config_dir_and_resolves_env_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_dir = tmp_path / "configs"
+    config_dir.mkdir()
+    (config_dir / "custom.env").write_text(
+        "\n".join(
+            [
+                "SUGARKUBE_APP=custom",
+                "SUGARKUBE_RELEASE=from-dir",
+                "SUGARKUBE_NAMESPACE=from-dir",
+                "SUGARKUBE_CHART=oci://example.invalid/charts/from-dir",
+                "SUGARKUBE_VERSION=1.2.3",
+                "SUGARKUBE_VALUES_DEV=dir-dev.yaml",
+                "SUGARKUBE_VALUES_STAGING=dir-dev.yaml,dir-staging.yaml",
+                "SUGARKUBE_VALUES_PROD=dir-dev.yaml,dir-prod.yaml",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    explicit_config = tmp_path / "explicit.env"
+    explicit_config.write_text(
+        "\n".join(
+            [
+                "SUGARKUBE_APP=custom",
+                "SUGARKUBE_RELEASE=from-explicit",
+                "SUGARKUBE_NAMESPACE=from-explicit",
+                "SUGARKUBE_CHART=oci://example.invalid/charts/from-explicit",
+                "SUGARKUBE_VERSION=4.5.6",
+                "SUGARKUBE_VALUES_DEV=explicit-dev.yaml",
+                "SUGARKUBE_VALUES_STAGING=explicit-dev.yaml,explicit-staging.yaml",
+                "SUGARKUBE_VALUES_PROD=explicit-dev.yaml,explicit-prod.yaml",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SUGARKUBE_APP_CONFIG_DIR", str(config_dir))
+
+    cfg = app_config.load_config("custom", "env=staging", str(explicit_config))
+
+    assert cfg["SUGARKUBE_CONFIG_PATH"] == str(explicit_config)
+    assert cfg["SUGARKUBE_RELEASE"] == "from-explicit"
+    assert cfg["SUGARKUBE_NAMESPACE"] == "from-explicit"
+    assert cfg["SUGARKUBE_VALUES"] == "explicit-dev.yaml,explicit-staging.yaml"
+
+
 @pytest.mark.parametrize(
     "tag",
     ["main-deadbee", "v3-deadbee", "feature-x-deadbee", "v0.1.0", "3.0.1", "3.1.0-rc.1"],

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -30,6 +30,7 @@ def test_config_dir_precedes_example_fallback(tmp_path: Path, monkeypatch: pytes
                 "SUGARKUBE_RELEASE=custom-release",
                 "SUGARKUBE_NAMESPACE=custom-ns",
                 "SUGARKUBE_CHART=oci://example.invalid/charts/custom",
+                "SUGARKUBE_VERSION=1.2.3",
                 "SUGARKUBE_VALUES_DEV=dev.yaml",
                 "SUGARKUBE_VALUES_STAGING=dev.yaml,staging.yaml",
                 "SUGARKUBE_VALUES_PROD=dev.yaml,prod.yaml",
@@ -66,6 +67,7 @@ def test_rejects_unknown_dotenv_keys(tmp_path: Path) -> None:
                 "SUGARKUBE_RELEASE=bad",
                 "SUGARKUBE_NAMESPACE=bad",
                 "SUGARKUBE_CHART=oci://example.invalid/charts/bad",
+                "SUGARKUBE_VERSION=1.2.3",
                 "SUGARKUBE_VALUES_DEV=dev.yaml",
                 "SUGARKUBE_VALUES_STAGING=staging.yaml",
                 "SUGARKUBE_VALUES_PROD=prod.yaml",
@@ -78,3 +80,52 @@ def test_rejects_unknown_dotenv_keys(tmp_path: Path) -> None:
 
     with pytest.raises(app_config.AppConfigError, match="unknown app config key"):
         app_config.load_config("bad", "staging", str(config))
+
+
+def test_dotenv_parser_strips_inline_comments(tmp_path: Path) -> None:
+    config = tmp_path / "commented.env"
+    config.write_text(
+        "\n".join(
+            [
+                "SUGARKUBE_APP=commented",
+                "SUGARKUBE_RELEASE=commented",
+                "SUGARKUBE_NAMESPACE=commented",
+                "SUGARKUBE_CHART=oci://example.invalid/charts/commented",
+                "SUGARKUBE_VERSION_FILE=docs/apps/commented.version # approved chart pin",
+                "SUGARKUBE_VALUES_DEV=dev.yaml",
+                "SUGARKUBE_VALUES_STAGING=dev.yaml,staging.yaml # staging overlays",
+                "SUGARKUBE_VALUES_PROD=dev.yaml,prod.yaml",
+                "SUGARKUBE_VERIFY_PATHS=/,/healthz # prod checks",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    cfg = app_config.load_config("commented", "staging", str(config))
+
+    assert cfg["SUGARKUBE_VALUES"] == "dev.yaml,staging.yaml"
+    assert cfg["SUGARKUBE_VERIFY_PATHS"] == "/,/healthz"
+    assert cfg["SUGARKUBE_VERSION_FILE"] == "docs/apps/commented.version"
+
+
+def test_requires_chart_version_pin(tmp_path: Path) -> None:
+    config = tmp_path / "unpinned.env"
+    config.write_text(
+        "\n".join(
+            [
+                "SUGARKUBE_APP=unpinned",
+                "SUGARKUBE_RELEASE=unpinned",
+                "SUGARKUBE_NAMESPACE=unpinned",
+                "SUGARKUBE_CHART=oci://example.invalid/charts/unpinned",
+                "SUGARKUBE_VALUES_DEV=dev.yaml",
+                "SUGARKUBE_VALUES_STAGING=dev.yaml,staging.yaml",
+                "SUGARKUBE_VALUES_PROD=dev.yaml,prod.yaml",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(app_config.AppConfigError, match="missing chart version pin"):
+        app_config.load_config("unpinned", "staging", str(config))

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -2,11 +2,32 @@
 
 from __future__ import annotations
 
+import io
+import json
 from pathlib import Path
 
 import pytest
 
 from scripts import app_config
+
+
+def _write_config(path: Path, app: str = "custom", **overrides: str) -> Path:
+    data = {
+        "SUGARKUBE_APP": app,
+        "SUGARKUBE_RELEASE": f"{app}-release",
+        "SUGARKUBE_NAMESPACE": f"{app}-ns",
+        "SUGARKUBE_CHART": f"oci://example.invalid/charts/{app}",
+        "SUGARKUBE_VERSION": "1.2.3",
+        "SUGARKUBE_VALUES_DEV": "dev.yaml",
+        "SUGARKUBE_VALUES_STAGING": "dev.yaml,staging.yaml",
+        "SUGARKUBE_VALUES_PROD": "dev.yaml,prod.yaml",
+    }
+    data.update(overrides)
+    path.write_text(
+        "\n".join(f"{key}={value}" for key, value in data.items()) + "\n",
+        encoding="utf-8",
+    )
+    return path
 
 
 def test_example_config_fallback_resolves_staging_values() -> None:
@@ -197,3 +218,147 @@ def test_requires_chart_version_pin(tmp_path: Path) -> None:
 
     with pytest.raises(app_config.AppConfigError, match="missing chart version pin"):
         app_config.load_config("unpinned", "staging", str(config))
+
+
+def test_normalizes_int_env_and_rejects_invalid_names() -> None:
+    assert app_config.normalize_env("env=int") == "staging"
+
+    with pytest.raises(app_config.AppConfigError, match="env must be one of"):
+        app_config.normalize_env("qa")
+
+    with pytest.raises(app_config.AppConfigError, match="app must be"):
+        app_config.validate_app_name("bad app")
+
+
+def test_validate_tag_rejects_empty_tag() -> None:
+    with pytest.raises(app_config.AppConfigError, match="must not be empty"):
+        app_config.validate_tag("")
+
+
+def test_parse_dotenv_accepts_exported_values(tmp_path: Path) -> None:
+    config = tmp_path / "exported.env"
+    config.write_text(
+        "\n".join(
+            [
+                "# local operator notes",
+                "export SUGARKUBE_APP=exported",
+                "SUGARKUBE_RELEASE=exported",
+                "SUGARKUBE_NAMESPACE=exported",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    data = app_config.parse_dotenv(config)
+
+    assert data["SUGARKUBE_APP"] == "exported"
+    assert data["SUGARKUBE_RELEASE"] == "exported"
+
+
+@pytest.mark.parametrize(
+    ("line", "message"),
+    [
+        ("not dotenv", "expected KEY=value"),
+        ('SUGARKUBE_RELEASE="unterminated', "invalid quoted value"),
+        ("SUGARKUBE_RELEASE=two words", "must be a single dotenv value"),
+        ("SUGARKUBE_RELEASE=$(whoami)", "shell syntax is not allowed"),
+    ],
+)
+def test_parse_dotenv_rejects_unsafe_or_invalid_values(
+    tmp_path: Path, line: str, message: str
+) -> None:
+    config = tmp_path / "bad.env"
+    config.write_text(f"{line}\n", encoding="utf-8")
+
+    with pytest.raises(app_config.AppConfigError, match=message):
+        app_config.parse_dotenv(config)
+
+
+def test_load_config_reports_missing_config_required_keys_app_mismatch_and_values(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(app_config.AppConfigError, match="no config found"):
+        app_config.load_config("missing", "staging", str(tmp_path / "missing.env"))
+
+    missing_required = tmp_path / "missing-required.env"
+    missing_required.write_text("SUGARKUBE_APP=broken\n", encoding="utf-8")
+    with pytest.raises(app_config.AppConfigError, match="missing required keys"):
+        app_config.load_config("broken", "staging", str(missing_required))
+
+    mismatch = _write_config(tmp_path / "mismatch.env", app="other")
+    with pytest.raises(app_config.AppConfigError, match="does not match app"):
+        app_config.load_config("expected", "staging", str(mismatch))
+
+    missing_values = _write_config(tmp_path / "missing-values.env", SUGARKUBE_VALUES_PROD="")
+    with pytest.raises(app_config.AppConfigError, match="missing SUGARKUBE_VALUES_PROD"):
+        app_config.load_config("custom", "prod", str(missing_values))
+
+
+def test_resolve_tag_uses_prod_fallback_file(tmp_path: Path) -> None:
+    tag_file = tmp_path / "prod-tag.txt"
+    tag_file.write_text("# promoted digest tag\nmain-deadbee\n", encoding="utf-8")
+
+    tag = app_config.resolve_tag(
+        {"SUGARKUBE_PROD_TAG_FILE": str(tag_file)},
+        "",
+        prod_fallback=True,
+    )
+
+    assert tag == "main-deadbee"
+
+
+def test_shell_emit_quotes_expected_exports(tmp_path: Path) -> None:
+    config = app_config.load_config(
+        "custom",
+        "staging",
+        str(_write_config(tmp_path / "custom.env", SUGARKUBE_VERIFY_PATHS="/,/healthz")),
+    )
+    config["SUGARKUBE_TAG"] = "main-deadbee"
+
+    emitted = app_config.shell_emit(config)
+
+    assert "export SUGARKUBE_APP=custom" in emitted
+    assert "export SUGARKUBE_ENV=staging" in emitted
+    assert "export SUGARKUBE_VERIFY_PATHS=/,/healthz" in emitted
+    assert "export SUGARKUBE_TAG=main-deadbee" in emitted
+
+
+def test_main_supports_json_shell_validate_tag_and_host_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config = _write_config(tmp_path / "custom.env")
+
+    assert app_config.main(["validate-tag", "main-deadbee"]) == 0
+    assert capsys.readouterr().out.strip() == "main-deadbee"
+
+    monkeypatch.setattr("sys.stdin", io.StringIO('{"ingress":{"host":"example.test"}}'))
+    assert app_config.main(["host-value", "ingress.host"]) == 0
+    assert capsys.readouterr().out.strip() == "example.test"
+
+    assert app_config.main(
+        ["json", "--app", "custom", "--env", "staging", "--config", str(config)]
+    ) == 0
+    loaded = json.loads(capsys.readouterr().out)
+    assert loaded["SUGARKUBE_VALUES"] == "dev.yaml,staging.yaml"
+
+    assert app_config.main(
+        [
+            "shell",
+            "--app",
+            "custom",
+            "--env",
+            "staging",
+            "--config",
+            str(config),
+            "--tag",
+            "tag=main-deadbee",
+            "--require-tag",
+        ]
+    ) == 0
+    assert "export SUGARKUBE_TAG=main-deadbee" in capsys.readouterr().out
+
+
+def test_main_reports_config_errors(capsys: pytest.CaptureFixture[str]) -> None:
+    assert app_config.main(["json", "--app", "missing", "--env", "staging"]) == 2
+    assert "ERROR: no config found for app 'missing'" in capsys.readouterr().err

--- a/tests/test_danielsmith_oci_wrappers.py
+++ b/tests/test_danielsmith_oci_wrappers.py
@@ -38,12 +38,6 @@ exit 0
 """,
     )
     _write_executable(
-        bin_dir / "python3",
-        """#!/usr/bin/env bash
-exit 0
-""",
-    )
-    _write_executable(
         bin_dir / "kubectl",
         """#!/usr/bin/env bash
 exit 0

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -55,9 +55,19 @@ fi
     )
     _write_executable(
         bin_dir / "kubectl",
-        """#!/usr/bin/env bash
+        f"""#!/usr/bin/env bash
 set -euo pipefail
-if [ "${1:-}" = "-n" ] && [ "${3:-}" = "get" ]; then
+printf '%s\n' "$*" >> {str(tmp_path / "kubectl.log")!r}
+if [[ "$*" == *"get deploy,statefulset,daemonset"* ]]; then
+  printf 'Deployment/danielsmith\n'
+  exit 0
+fi
+if [[ "$*" == *"get ingress"* && "$*" == *"jsonpath"* ]]; then
+  printf 'example.test'
+  exit 0
+fi
+if [[ "$*" == *"get deploy/tokenplace"* || "$*" == *"get deploy dspace"* || "$*" == *"get Deployment/danielsmith"* ]]; then
+  printf 'app=ghcr.io/example/app:main-deadbee\n'
   exit 0
 fi
 exit 0
@@ -68,17 +78,30 @@ exit 0
         f"""#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> {str(log_path)!r}
+if [ "${{1:-}}" = "get" ] && [ "${{2:-}}" = "values" ]; then
+  printf '{{"ingress":{{"host":"example.test"}}}}\n'
+  exit 0
+fi
 if [ "${{1:-}}" = "-n" ] && [ "${{3:-}}" = "status" ]; then
   printf 'STATUS: deployed\n'
 fi
 exit 0
 """,
     )
+    _write_executable(
+        bin_dir / "curl",
+        """#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+""",
+    )
+
     env = os.environ.copy()
     env["HOME"] = str(tmp_path / "home")
     env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
     env["SUGARKUBE_HELM_ROLLOUT_TIMEOUT"] = "1s"
     env["HELM_LOG"] = str(log_path)
+    env["KUBECTL_LOG"] = str(tmp_path / "kubectl.log")
     return env
 
 
@@ -180,3 +203,45 @@ def test_existing_app_specific_deploy_wrappers_still_work(
     helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
     assert f"--namespace {app}" in helm_log
     assert "--set image.tag=main-deadbee" in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize(
+    ("recipe", "image_heading", "check_heading"),
+    [
+        ("dspace-oci-promote-prod", "Resolved deployment image(s):", "Post-deploy verification commands"),
+        ("tokenplace-oci-promote-prod", "Resolved images for deployment/tokenplace:", "Post-deploy checks:"),
+        ("danielsmith-oci-promote-prod", "Resolved images for danielsmith workloads:", "Post-deploy checks:"),
+    ],
+)
+def test_promote_wrappers_preserve_app_specific_output(
+    recipe: str,
+    image_heading: str,
+    check_heading: str,
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just([recipe, "tag=main-deadbee"], generic_app_stub_env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert image_heading in result.stdout
+    assert check_heading in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_status_does_not_rewrite_kubeconfig_for_read_only_checks(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(["app-status", "app=tokenplace", "env=staging"], generic_app_stub_env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert not (Path(generic_app_stub_env["HOME"]) / ".kube" / "config").exists()
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_does_not_rewrite_kubeconfig_for_read_only_checks(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(["app-verify", "app=tokenplace", "env=staging"], generic_app_stub_env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert not (Path(generic_app_stub_env["HOME"]) / ".kube" / "config").exists()

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -63,6 +63,10 @@ if [[ "$*" == *"get deploy,statefulset,daemonset"* ]]; then
   exit 0
 fi
 if [[ "$*" == *"get ingress"* && "$*" == *"jsonpath"* ]]; then
+  if [ "${{SUGARKUBE_STUB_KUBECTL_INGRESS_FAIL:-}}" = "1" ]; then
+    echo 'error: context sugar-staging does not exist' >&2
+    exit 1
+  fi
   printf 'example.test'
   exit 0
 fi
@@ -83,6 +87,10 @@ exit 0
 set -euo pipefail
 printf '%s\n' "$*" >> {str(log_path)!r}
 if [[ "$*" == *"get values"* ]]; then
+  if [ "${{SUGARKUBE_STUB_HELM_GET_VALUES_FAIL:-}}" = "1" ]; then
+    echo 'Error: Kubernetes cluster unreachable for context sugar-staging' >&2
+    exit 1
+  fi
   printf '{{"ingress":{{"host":"example.test"}}}}\n'
   exit 0
 fi
@@ -319,3 +327,20 @@ def test_app_verify_does_not_rewrite_kubeconfig_for_read_only_checks(
     assert not (Path(generic_app_stub_env["HOME"]) / ".kube" / "config").exists()
     helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
     assert "--kube-context sugar-staging" in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_fails_closed_when_context_host_discovery_fails(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_HELM_GET_VALUES_FAIL"] = "1"
+    env["SUGARKUBE_STUB_KUBECTL_INGRESS_FAIL"] = "1"
+
+    result = _run_just(["app-verify", "app=tokenplace", "env=staging"], env)
+
+    assert result.returncode != 0
+    assert "Could not derive a host for tokenplace using context sugar-staging" in result.stderr
+    assert "helm get values failed for context sugar-staging" in result.stderr
+    assert "kubectl ingress lookup failed for context sugar-staging" in result.stderr
+    assert "curl -fsS https://<host>" not in result.stdout

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -78,11 +78,11 @@ exit 0
         f"""#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> {str(log_path)!r}
-if [ "${{1:-}}" = "get" ] && [ "${{2:-}}" = "values" ]; then
+if [[ "$*" == *"get values"* ]]; then
   printf '{{"ingress":{{"host":"example.test"}}}}\n'
   exit 0
 fi
-if [ "${{1:-}}" = "-n" ] && [ "${{3:-}}" = "status" ]; then
+if [[ "$*" == *" status "* ]]; then
   printf 'STATUS: deployed\n'
 fi
 exit 0
@@ -235,6 +235,10 @@ def test_app_status_does_not_rewrite_kubeconfig_for_read_only_checks(
 
     assert result.returncode == 0, result.stderr + result.stdout
     assert not (Path(generic_app_stub_env["HOME"]) / ".kube" / "config").exists()
+    kubectl_log = Path(generic_app_stub_env["KUBECTL_LOG"]).read_text(encoding="utf-8")
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "--context sugar-staging" in kubectl_log
+    assert "--kube-context sugar-staging" in helm_log
 
 
 @pytest.mark.usefixtures("ensure_just_available")
@@ -245,3 +249,5 @@ def test_app_verify_does_not_rewrite_kubeconfig_for_read_only_checks(
 
     assert result.returncode == 0, result.stderr + result.stdout
     assert not (Path(generic_app_stub_env["HOME"]) / ".kube" / "config").exists()
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "--kube-context sugar-staging" in helm_log

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1,0 +1,182 @@
+"""Stubbed just tests for generic Sugarkube app recipes."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+@pytest.fixture()
+def generic_app_stub_env(tmp_path: Path, ensure_just_available: Path) -> dict[str, str]:
+    assert ensure_just_available.exists()
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_path = tmp_path / "helm.log"
+    kubeconfig = """apiVersion: v1
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: default
+contexts:
+- context:
+    cluster: default
+    user: default
+  name: default
+current-context: default
+users:
+- name: default
+  user: {}
+"""
+    _write_executable(
+        bin_dir / "sudo",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+if [ "${{1:-}}" = "cp" ]; then
+  mkdir -p "$(dirname "${{3}}")"
+  cat > "${{3}}" <<'KUBECONFIG'
+{kubeconfig}KUBECONFIG
+  exit 0
+fi
+if [ "${{1:-}}" = "chown" ]; then
+  exit 0
+fi
+"$@"
+""",
+    )
+    _write_executable(
+        bin_dir / "kubectl",
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "-n" ] && [ "${3:-}" = "get" ]; then
+  exit 0
+fi
+exit 0
+""",
+    )
+    _write_executable(
+        bin_dir / "helm",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> {str(log_path)!r}
+if [ "${{1:-}}" = "-n" ] && [ "${{3:-}}" = "status" ]; then
+  printf 'STATUS: deployed\n'
+fi
+exit 0
+""",
+    )
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "home")
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["SUGARKUBE_HELM_ROLLOUT_TIMEOUT"] = "1s"
+    env["HELM_LOG"] = str(log_path)
+    return env
+
+
+def _run_just(args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["just", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_deploy_danielsmith_passes_image_tag(generic_app_stub_env: dict[str, str]) -> None:
+    result = _run_just(
+        ["app-deploy", "app=danielsmith", "env=staging", "tag=main-deadbee"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "upgrade danielsmith oci://ghcr.io/futuroptimist/charts/danielsmith" in helm_log
+    assert "--namespace danielsmith" in helm_log
+    assert "-f docs/examples/danielsmith.values.dev.yaml" in helm_log
+    assert "-f docs/examples/danielsmith.values.staging.yaml" in helm_log
+    assert "--set image.tag=main-deadbee" in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize(
+    ("app", "chart", "namespace", "values"),
+    [
+        (
+            "tokenplace",
+            "oci://ghcr.io/futuroptimist/charts/tokenplace",
+            "tokenplace",
+            ["docs/examples/tokenplace.values.dev.yaml", "docs/examples/tokenplace.values.staging.yaml"],
+        ),
+        (
+            "dspace",
+            "oci://ghcr.io/democratizedspace/charts/dspace",
+            "dspace",
+            ["docs/examples/dspace.values.dev.yaml", "docs/examples/dspace.values.staging.yaml"],
+        ),
+    ],
+)
+def test_app_deploy_uses_app_release_namespace_chart_values(
+    app: str,
+    chart: str,
+    namespace: str,
+    values: list[str],
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        ["app-deploy", f"app={app}", "env=staging", "tag=main-deadbee"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert f"upgrade {app} {chart}" in helm_log
+    assert f"--namespace {namespace}" in helm_log
+    for value in values:
+        assert f"-f {value}" in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_deploy_rejects_mutable_tag_before_helm(generic_app_stub_env: dict[str, str]) -> None:
+    result = _run_just(
+        ["app-deploy", "app=tokenplace", "env=staging", "tag=latest"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode != 0
+    assert "mutable tag" in result.stderr
+    helm_log_path = Path(generic_app_stub_env["HELM_LOG"])
+    assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize(
+    ("recipe", "app"),
+    [
+        ("danielsmith-oci-deploy", "danielsmith"),
+        ("tokenplace-oci-deploy", "tokenplace"),
+        ("dspace-oci-deploy", "dspace"),
+    ],
+)
+def test_existing_app_specific_deploy_wrappers_still_work(
+    recipe: str,
+    app: str,
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just([recipe, "env=staging", "tag=main-deadbee"], generic_app_stub_env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert f"--namespace {app}" in helm_log
+    assert "--set image.tag=main-deadbee" in helm_log

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -66,7 +66,11 @@ if [[ "$*" == *"get ingress"* && "$*" == *"jsonpath"* ]]; then
   printf 'example.test'
   exit 0
 fi
-if [[ "$*" == *"get deploy/tokenplace"* || "$*" == *"get deploy dspace"* || "$*" == *"get Deployment/danielsmith"* ]]; then
+if [[ "$*" == *"get deploy/tokenplace"* || "$*" == *"get deploy dspace"* ]]; then
+  printf 'app=ghcr.io/example/app:main-deadbee\n'
+  exit 0
+fi
+if [[ "$*" == *"get Deployment/danielsmith"* ]]; then
   printf 'app=ghcr.io/example/app:main-deadbee\n'
   exit 0
 fi
@@ -119,7 +123,7 @@ def _run_just(args: list[str], env: dict[str, str]) -> subprocess.CompletedProce
 @pytest.mark.usefixtures("ensure_just_available")
 def test_app_deploy_danielsmith_passes_image_tag(generic_app_stub_env: dict[str, str]) -> None:
     result = _run_just(
-        ["app-deploy", "app=danielsmith", "env=staging", "tag=main-deadbee"],
+        ["app-deploy", "app=danielsmith", "env=env=staging", "tag=tag=main-deadbee"],
         generic_app_stub_env,
     )
 
@@ -130,6 +134,7 @@ def test_app_deploy_danielsmith_passes_image_tag(generic_app_stub_env: dict[str,
     assert "-f docs/examples/danielsmith.values.dev.yaml" in helm_log
     assert "-f docs/examples/danielsmith.values.staging.yaml" in helm_log
     assert "--set image.tag=main-deadbee" in helm_log
+    assert "--set image.tag=tag=main-deadbee" not in helm_log
 
 
 @pytest.mark.usefixtures("ensure_just_available")
@@ -140,7 +145,10 @@ def test_app_deploy_danielsmith_passes_image_tag(generic_app_stub_env: dict[str,
             "tokenplace",
             "oci://ghcr.io/futuroptimist/charts/tokenplace",
             "tokenplace",
-            ["docs/examples/tokenplace.values.dev.yaml", "docs/examples/tokenplace.values.staging.yaml"],
+            [
+                "docs/examples/tokenplace.values.dev.yaml",
+                "docs/examples/tokenplace.values.staging.yaml",
+            ],
         ),
         (
             "dspace",
@@ -168,6 +176,51 @@ def test_app_deploy_uses_app_release_namespace_chart_values(
     assert f"--namespace {namespace}" in helm_log
     for value in values:
         assert f"-f {value}" in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize(
+    ("app", "release", "namespace", "chart"),
+    [
+        (
+            "dspace",
+            "dspace",
+            "dspace",
+            "oci://ghcr.io/democratizedspace/charts/dspace",
+        ),
+        (
+            "tokenplace",
+            "tokenplace",
+            "tokenplace",
+            "oci://ghcr.io/futuroptimist/charts/tokenplace",
+        ),
+        (
+            "danielsmith",
+            "danielsmith",
+            "danielsmith",
+            "oci://ghcr.io/futuroptimist/charts/danielsmith",
+        ),
+    ],
+)
+def test_app_promote_prod_delegates_to_prod_deploy_coordinates(
+    app: str,
+    release: str,
+    namespace: str,
+    chart: str,
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        ["app-promote-prod", f"app={app}", "tag=main-deadbee"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert f"upgrade {release} {chart}" in helm_log
+    assert f"--namespace {namespace}" in helm_log
+    assert f"-f docs/examples/{app}.values.dev.yaml" in helm_log
+    assert f"-f docs/examples/{app}.values.prod.yaml" in helm_log
+    assert "--set image.tag=main-deadbee" in helm_log
 
 
 @pytest.mark.usefixtures("ensure_just_available")
@@ -209,9 +262,21 @@ def test_existing_app_specific_deploy_wrappers_still_work(
 @pytest.mark.parametrize(
     ("recipe", "image_heading", "check_heading"),
     [
-        ("dspace-oci-promote-prod", "Resolved deployment image(s):", "Post-deploy verification commands"),
-        ("tokenplace-oci-promote-prod", "Resolved images for deployment/tokenplace:", "Post-deploy checks:"),
-        ("danielsmith-oci-promote-prod", "Resolved images for danielsmith workloads:", "Post-deploy checks:"),
+        (
+            "dspace-oci-promote-prod",
+            "Resolved deployment image(s):",
+            "Post-deploy verification commands",
+        ),
+        (
+            "tokenplace-oci-promote-prod",
+            "Resolved images for deployment/tokenplace:",
+            "Post-deploy checks:",
+        ),
+        (
+            "danielsmith-oci-promote-prod",
+            "Resolved images for danielsmith workloads:",
+            "Post-deploy checks:",
+        ),
     ],
 )
 def test_promote_wrappers_preserve_app_specific_output(
@@ -225,6 +290,9 @@ def test_promote_wrappers_preserve_app_specific_output(
     assert result.returncode == 0, result.stderr + result.stdout
     assert image_heading in result.stdout
     assert check_heading in result.stdout
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "--set image.tag=main-deadbee" in helm_log
+    assert "--set image.tag=tag=main-deadbee" not in helm_log
 
 
 @pytest.mark.usefixtures("ensure_just_available")


### PR DESCRIPTION
### Motivation
- Provide a single generic façade for app deploy/redeploy/promote/status/verify flows so repeated env parsing, values-chain selection, tag validation, and kubeconfig selection are centralized.
- Preserve existing app-specific deploy wrappers as compatibility shims during migration to avoid breaking current runbooks.

### Description
- Added a stdlib-only app config loader `scripts/app_config.py` that reads dotenv-style app configs from the configured search order, whitelists expected keys, emits shell-safe exports, extracts env-scoped values chains, resolves optional prod tag pins, exposes a `host-value` extraction helper, and centralizes immutable tag validation.
- Implemented generic just recipes in `justfile`: `app-config`, `app-deploy`, `app-redeploy`, `app-promote-prod`, `app-status` (extended to accept `app=<name> env=<env>`), and `app-verify` which derives host and curls configured verify paths (or prints copy-paste curl commands when host cannot be resolved).
- Kept existing app-specific wrappers for `dspace`, `tokenplace`, and `danielsmith` and converted their `*-promote-prod` wrappers into thin delegations to the generic `app-promote-prod` recipe.
- Updated `docs/app_deployment_contract.md` and the example app envs under `docs/examples/apps/` to document the implemented generic flow, lookup order, and migration note that app-specific recipes are compatibility shims.
- Added unit tests: `tests/test_app_config.py` for config resolution and tag validation, `tests/test_generic_app_just_recipes.py` for stubbed just/Helm behavior, and small adjustments to existing wrapper tests to preserve behavior.

### Testing
- Ran full test suite: `python -m pytest tests -q` — result: 1229 passed, 19 skipped (local environment), all new/modified tests passed (36 passed for focused test runs; final run passed 1229 tests total).
- Validated just targets: `just --summary | grep -E 'app-(config|deploy|redeploy|promote-prod|status|verify)'` — present.
- Verified `just app-config` for example apps: `just app-config app=danielsmith env=staging`, `just app-config app=tokenplace env=staging`, `just app-config app=dspace env=staging` — successful and printed JSON config.
- Performed repo checks: `git diff --check`, `git diff | ./scripts/scan-secrets.py`, and `git diff --cached | ./scripts/scan-secrets.py` — no issues.

Notes and environment limits:
- Formatting check `just --unstable --fmt --check` and `just --unstable --fmt` were used during development to ensure the `justfile` formatting; `pre-commit`, `pyspelling`, and `linkchecker` could not be run in this environment because those tools are not installed here, and are noted in the PR body as not-run steps.
- No new runtime dependencies were introduced; `scripts/app_config.py` uses only Python stdlib.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e0c4d4a44832fae566689e78eebc0)