### PR TITLE
Implement generic app deploy recipes backed by app config files

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -1,12 +1,14 @@
 # Sugarkube app deployment contract
 
-Sugarkube is moving toward a generic app deployment surface where each app is
+Sugarkube now exposes a generic app deployment surface where each app is
 identified by a small local config file and deployed with shared `just` recipes.
-This page is the contract future implementation work will target; it does not
-change current `justfile` deployment behavior.
+This page is the shared contract for the implemented generic deploy, redeploy,
+promotion, status, and verification commands.
 
 The existing app-specific recipes for dspace, token.place, and danielsmith.io
-remain compatibility wrappers until the generic recipes are implemented.
+remain compatibility shims for migration. They delegate to the generic recipes
+where practical and will be deprecated later, but they are not removed in this
+phase.
 
 ## Ownership boundary
 
@@ -93,7 +95,7 @@ Helm charts are immutable once published to GHCR OCI:
 
 ## App config file shape
 
-Future generic recipes will load a simple shell/dotenv-style config so they do
+Generic recipes load a simple shell/dotenv-style config so they do
 not require `yq`. Example files live under [`docs/examples/apps/`](examples/apps/)
 and may be copied into a local config directory such as `apps/APP.env`. Operators
 may also set `SUGARKUBE_APP_CONFIG_DIR` to point at another directory.
@@ -106,7 +108,7 @@ Rules for app config files:
 - Keep verify paths comma-separated with leading slashes.
 - Do not store secrets in app config files.
 
-Required keys for the planned generic recipes:
+Required keys for the generic recipes:
 
 | Key | Purpose |
 | --- | --- |
@@ -131,10 +133,10 @@ cp docs/examples/apps/dspace.env apps/dspace.env
 export SUGARKUBE_APP_CONFIG_DIR=apps
 ```
 
-## Planned generic command surface
+## Generic command surface
 
-P5 will implement these command shapes. They are documented here so app repos can
-align their artifacts before Sugarkube changes behavior.
+P5 implements these config-backed command shapes. App repositories can align their
+artifacts to this surface while operators migrate away from compatibility shims.
 
 ```bash
 # Deploy or install a specific immutable candidate into an environment.
@@ -156,15 +158,18 @@ just app-verify app=dspace env=staging
 just app-config app=dspace env=staging
 ```
 
-The compatibility wrappers will remain during migration. For example,
+The compatibility wrappers remain during migration. For example,
 `just dspace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA` and
-`just tokenplace-oci-promote-prod tag=main-REPLACE_SHORTSHA` continue to be the
-current operational commands until generic recipes replace their internals.
+`just tokenplace-oci-promote-prod tag=main-REPLACE_SHORTSHA` continue to work,
+but they are now shims over the generic flow and should be treated as deprecated
+operator conveniences rather than the long-term interface.
 
 ## Current example configs
 
 The example configs in `docs/examples/apps/` intentionally are not platform
-defaults. They are scaffolds for future local configs and tests:
+defaults. The generic loader uses them as a fallback for the three existing apps
+when no local `apps/APP.env` or `SUGARKUBE_APP_CONFIG_DIR` override exists, so
+they double as copyable scaffolds and test fixtures:
 
 - [`docs/examples/apps/dspace.env`](examples/apps/dspace.env)
 - [`docs/examples/apps/tokenplace.env`](examples/apps/tokenplace.env)

--- a/docs/examples/apps/danielsmith.env
+++ b/docs/examples/apps/danielsmith.env
@@ -1,7 +1,7 @@
 # Example Sugarkube app config for danielsmith.io.
 # Copy to apps/danielsmith.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
-# containing danielsmith.env when the generic app recipes are implemented.
-# This is documentation scaffold only; it is not a platform default.
+# containing danielsmith.env. Generic recipes use this example as a fallback.
+# This is a copyable scaffold, not a cluster-specific platform default.
 
 SUGARKUBE_APP=danielsmith
 SUGARKUBE_RELEASE=danielsmith

--- a/docs/examples/apps/dspace.env
+++ b/docs/examples/apps/dspace.env
@@ -1,7 +1,7 @@
 # Example Sugarkube app config for dspace.
 # Copy to apps/dspace.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
-# containing dspace.env when the generic app recipes are implemented.
-# This is documentation scaffold only; it is not a platform default.
+# containing dspace.env. Generic recipes use this example as a fallback.
+# This is a copyable scaffold, not a cluster-specific platform default.
 
 SUGARKUBE_APP=dspace
 SUGARKUBE_RELEASE=dspace

--- a/docs/examples/apps/tokenplace.env
+++ b/docs/examples/apps/tokenplace.env
@@ -1,7 +1,7 @@
 # Example Sugarkube app config for token.place.
 # Copy to apps/tokenplace.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
-# containing tokenplace.env when the generic app recipes are implemented.
-# This is documentation scaffold only; it is not a platform default.
+# containing tokenplace.env. Generic recipes use this example as a fallback.
+# This is a copyable scaffold, not a cluster-specific platform default.
 
 SUGARKUBE_APP=tokenplace
 SUGARKUBE_RELEASE=tokenplace

--- a/justfile
+++ b/justfile
@@ -1518,10 +1518,195 @@ helm-oci-install release='' namespace='' chart='' values='' host='' version='' v
 helm-oci-upgrade release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='':
     @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' allow_install='false' reuse_values='true'
 
+# Print the resolved generic app deployment config for review/debugging.
+app-config app='' env='staging' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    config_path={{ quote(config) }}
+    config_args=()
+    if [ -n "${config_path}" ]; then
+      config_args+=(--config "${config_path}")
+    fi
+    python3 "{{ justfile_directory() }}/scripts/app_config.py" config \
+      --app {{ quote(app) }} \
+      --env {{ quote(env) }} \
+      "${config_args[@]}"
+
+# Install or upgrade a Sugarkube-managed app from its config-backed OCI chart.
+app-deploy app='' env='staging' tag='' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    config_path={{ quote(config) }}
+    config_args=()
+    if [ -n "${config_path}" ]; then
+      config_args+=(--config "${config_path}")
+    fi
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" config \
+      --app {{ quote(app) }} \
+      --env {{ quote(env) }} \
+      "${config_args[@]}" \
+      --format shell)"
+    deploy_tag="$(python3 "{{ justfile_directory() }}/scripts/app_config.py" validate-tag {{ quote(tag) }})"
+
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
+      release="${SUGARKUBE_RELEASE}" namespace="${SUGARKUBE_NAMESPACE}" \
+      chart="${SUGARKUBE_CHART}" \
+      values="${SUGARKUBE_VALUES}" \
+      version_file="${SUGARKUBE_VERSION_FILE}" \
+      tag="${deploy_tag}"
+
+# Upgrade-only redeploy for a Sugarkube-managed app from its config-backed OCI chart.
+app-redeploy app='' env='staging' tag='' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    config_path={{ quote(config) }}
+    config_args=()
+    if [ -n "${config_path}" ]; then
+      config_args+=(--config "${config_path}")
+    fi
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" config \
+      --app {{ quote(app) }} \
+      --env {{ quote(env) }} \
+      "${config_args[@]}" \
+      --format shell)"
+    deploy_tag="$(python3 "{{ justfile_directory() }}/scripts/app_config.py" validate-tag {{ quote(tag) }})"
+
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
+      release="${SUGARKUBE_RELEASE}" namespace="${SUGARKUBE_NAMESPACE}" \
+      chart="${SUGARKUBE_CHART}" \
+      values="${SUGARKUBE_VALUES}" \
+      version_file="${SUGARKUBE_VERSION_FILE}" \
+      tag="${deploy_tag}"
+
+# Promote a Sugarkube-managed app to prod using an explicit tag or the app prod tag pin file.
+app-promote-prod app='' tag='' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    config_path={{ quote(config) }}
+    config_args=()
+    just_config_args=()
+    if [ -n "${config_path}" ]; then
+      config_args+=(--config "${config_path}")
+      just_config_args+=(config="${config_path}")
+    fi
+    resolved_tag="$(python3 "{{ justfile_directory() }}/scripts/app_config.py" prod-tag \
+      --app {{ quote(app) }} \
+      --env prod \
+      "${config_args[@]}" \
+      --tag {{ quote(tag) }})"
+    if [ -z "${resolved_tag}" ]; then
+      echo "ERROR: provide tag=<immutable-tag> or set the configured SUGARKUBE_PROD_TAG_FILE." >&2
+      exit 1
+    fi
+    just --justfile "{{ justfile_directory() }}/justfile" app-deploy \
+      app={{ quote(app) }} env=prod tag="${resolved_tag}" "${just_config_args[@]}"
+
+# Inspect a Sugarkube-managed app. Also accepts the legacy namespace=/release= form.
+app-status app='' env='staging' config='' namespace='' release='' host_key='ingress.host':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    app_arg={{ quote(app) }}
+    ns={{ quote(namespace) }}
+    rel={{ quote(release) }}
+    host_key_arg={{ quote(host_key) }}
+    if [ -n "${app_arg}" ]; then
+      config_path={{ quote(config) }}
+      config_args=()
+      if [ -n "${config_path}" ]; then
+        config_args+=(--config "${config_path}")
+      fi
+      eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" config \
+        --app "${app_arg}" \
+        --env {{ quote(env) }} \
+        "${config_args[@]}" \
+        --format shell)"
+      ns="${SUGARKUBE_NAMESPACE}"
+      rel="${SUGARKUBE_RELEASE}"
+      host_key_arg="${SUGARKUBE_STATUS_HOST_KEY}"
+      export KUBECONFIG="${HOME}/.kube/config"
+      just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+    else
+      export KUBECONFIG="${HOME}/.kube/config"
+    fi
+
+    if [ -z "${ns}" ]; then
+      echo "Set app=<app> env=<dev|staging|prod> or namespace=<namespace> to inspect." >&2
+      exit 1
+    fi
+    if ! command -v kubectl >/dev/null 2>&1; then
+      echo "kubectl is required to check the deployment." >&2
+      exit 1
+    fi
+
+    kubectl -n "${ns}" get pods
+    kubectl -n "${ns}" get ingress
+
+    host=""
+    if [ -n "${rel}" ] && command -v helm >/dev/null 2>&1; then
+      host="$(helm get values "${rel}" --namespace "${ns}" --all --output json 2>/dev/null \
+        | python3 "{{ justfile_directory() }}/scripts/app_config.py" extract-host --host-key "${host_key_arg}" || true)"
+    fi
+    if [ -n "${host}" ]; then
+      printf 'Public URL: https://%s\n' "${host}"
+    else
+      echo "Public URL host not recorded; check the Helm release values."
+    fi
+
+# Verify a Sugarkube-managed app by curling configured HTTP paths from its Helm values host.
+app-verify app='' env='staging' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    config_path={{ quote(config) }}
+    config_args=()
+    if [ -n "${config_path}" ]; then
+      config_args+=(--config "${config_path}")
+    fi
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" config \
+      --app {{ quote(app) }} \
+      --env {{ quote(env) }} \
+      "${config_args[@]}" \
+      --format shell)"
+
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+
+    host=""
+    if command -v helm >/dev/null 2>&1; then
+      host="$(helm get values "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" --all --output json 2>/dev/null \
+        | python3 "{{ justfile_directory() }}/scripts/app_config.py" extract-host --host-key "${SUGARKUBE_STATUS_HOST_KEY}" || true)"
+    fi
+    if [ -z "${host}" ]; then
+      host="<${SUGARKUBE_APP}-host>"
+      echo "Unable to discover host from Helm values; copy and edit these commands:" >&2
+    fi
+    IFS=',' read -r -a verify_paths <<< "${SUGARKUBE_VERIFY_PATHS}"
+    for path in "${verify_paths[@]}"; do
+      path="$(printf '%s' "${path}" | xargs)"
+      [ -n "${path}" ] || continue
+      case "${path}" in /*) ;; *) path="/${path}" ;; esac
+      url="https://${host}${path}"
+      printf 'curl -fsS %q\n' "${url}"
+      if [[ "${host}" == \<*\> ]] || ! command -v curl >/dev/null 2>&1; then
+        continue
+      fi
+      curl -fsS "${url}"
+      echo
+    done
+
 # Opinionated immutable-tag dspace deploy with rollout verification.
 #
 
-# Use this for steady-state release validation flows where explicit image pinning matters.
+# Compatibility shim for the generic app deploy recipe.
 dspace-oci-deploy env='staging' tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
@@ -1529,90 +1714,18 @@ dspace-oci-deploy env='staging' tag='':
     env_input={{ quote(env) }}
     env_name="${env_input}"
     while [ "${env_name#env=}" != "${env_name}" ]; do
-      env_name="${env_name#env=}"
+        env_name="${env_name#env=}"
     done
     if [ -z "${env_name}" ]; then
-      printf 'ERROR: env must not be empty. Use env=dev|staging|prod.\n' >&2
-      exit 1
+        printf 'ERROR: env must not be empty. Use env=dev|staging|prod.\n' >&2
+        exit 1
     fi
     if [ "${env_name}" = "int" ]; then
-      printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
-      env_name="staging"
+        printf 'WARNING: env name \"int\" is deprecated; using env=staging.\n' >&2
+        env_name="staging"
     fi
+    just --justfile "{{ justfile_directory() }}/justfile" app-deploy app=dspace env="${env_name}" tag={{ quote(tag) }}
 
-    case "${env_name}" in
-      dev|staging|prod) ;;
-      *)
-        echo "Unsupported env=${env_name}. Use env=dev|staging|prod." >&2
-        exit 1
-        ;;
-    esac
-
-    deploy_tag="$(echo "{{ tag }}" | xargs)"
-    if [ -z "${deploy_tag}" ]; then
-      echo "Set tag=<immutable-tag> (for example main-<shortsha> or 3.1.0) for dspace immutable deploys." >&2
-      exit 1
-    fi
-    tag_lc="$(echo "${deploy_tag}" | tr '[:upper:]' '[:lower:]')"
-    if [[ "${tag_lc}" == *"latest"* || "${tag_lc}" == "main" || "${tag_lc}" == *":main" ]]; then
-      echo "Refusing mutable tag '${deploy_tag}'. Use an immutable RC/stable image tag." >&2
-      exit 1
-    fi
-
-    overlay=""
-    if [ "${env_name}" != "dev" ]; then
-      overlay="docs/examples/dspace.values.${env_name}.yaml"
-      if [ ! -f "${overlay}" ]; then
-        echo "No dspace values overlay found for env=${env_name} (${overlay})." >&2
-        exit 1
-      fi
-    fi
-
-    values_chain="docs/examples/dspace.values.dev.yaml"
-    if [ -n "${overlay}" ]; then
-      values_chain="${values_chain},${overlay}"
-    fi
-
-    if [ -z "${KUBECONFIG:-}" ] && [ ! -r "${HOME}/.kube/config" ]; then
-      scripts/ensure_user_kubeconfig.sh || true
-    fi
-    if [ -z "${KUBECONFIG:-}" ]; then
-      export KUBECONFIG="${HOME}/.kube/config"
-    fi
-
-    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
-      release='dspace' namespace='dspace' \
-      chart='oci://ghcr.io/democratizedspace/charts/dspace' \
-      values="${values_chain}" \
-      version_file='docs/apps/dspace.version' \
-      tag="${deploy_tag}"
-
-    echo "Resolved deployment image(s):"
-    kubectl -n dspace get deploy dspace \
-      -o jsonpath='{range .spec.template.spec.containers[*]}{.name}={.image}{"\n"}{end}'
-
-    verify_host="$(kubectl -n dspace get ingress dspace -o jsonpath='{.spec.rules[0].host}' 2>/dev/null || true)"
-    if [ -z "${verify_host}" ]; then
-      verify_host="<dspace-host>"
-    fi
-
-    echo
-    echo "Post-deploy verification commands:"
-    if [[ "${verify_host}" == "<"*">" ]]; then
-      echo "  # Replace ${verify_host} with your ingress hostname."
-      echo "  curl -fsS https://${verify_host}/config.json | jq ."
-      echo "  curl -fsS https://${verify_host}/healthz | jq ."
-      echo "  curl -fsS https://${verify_host}/livez | jq ."
-    else
-      echo "  curl -fsS https://${verify_host}/config.json | jq ."
-      echo "  curl -fsS https://${verify_host}/healthz | jq ."
-      echo "  curl -fsS https://${verify_host}/livez | jq ."
-    fi
-
-# Deploy dspace to the optional production preview subdomain (prod.democratized.space).
-#
-
-# Use this for optional canary/smoke testing before or alongside apex promotion workflows.
 dspace-oci-deploy-prod-subdomain tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
@@ -1660,25 +1773,11 @@ dspace-oci-deploy-prod-subdomain tag='':
 
 # Promote dspace to production apex (democratized.space) using immutable tags.
 
-# If tag is omitted, this reads the pinned value from docs/apps/dspace.prod.tag.
+# Compatibility shim for the generic app prod promotion recipe.
 dspace-oci-promote-prod tag='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
+    @just app-promote-prod app=dspace tag='{{ tag }}'
 
-    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
-
-    deploy_tag="$(echo "{{ tag }}" | xargs)"
-    if [ -z "${deploy_tag}" ]; then
-      deploy_tag="$(read_prod_tag)"
-    fi
-    if [ -z "${deploy_tag}" ]; then
-      echo "Set tag=<immutable-tag> or populate docs/apps/dspace.prod.tag." >&2
-      exit 1
-    fi
-
-    just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy env=prod tag="${deploy_tag}"
-
-# Fast redeploy of dspace from GHCR (emergency mutable-tag refresh).
+# Compatibility shim for the generic app redeploy recipe.
 dspace-oci-redeploy env='staging' tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
@@ -1686,70 +1785,18 @@ dspace-oci-redeploy env='staging' tag='':
     env_input={{ quote(env) }}
     env_name="${env_input}"
     while [ "${env_name#env=}" != "${env_name}" ]; do
-      env_name="${env_name#env=}"
+        env_name="${env_name#env=}"
     done
     if [ -z "${env_name}" ]; then
-      printf 'ERROR: env must not be empty. Use env=dev|staging|prod.\n' >&2
-      exit 1
+        printf 'ERROR: env must not be empty. Use env=dev|staging|prod.\n' >&2
+        exit 1
     fi
     if [ "${env_name}" = "int" ]; then
-      printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
-      env_name="staging"
+        printf 'WARNING: env name \"int\" is deprecated; using env=staging.\n' >&2
+        env_name="staging"
     fi
+    just --justfile "{{ justfile_directory() }}/justfile" app-redeploy app=dspace env="${env_name}" tag={{ quote(tag) }}
 
-    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
-
-    overlay="docs/examples/dspace.values.${env_name}.yaml"
-    if [ ! -f "${overlay}" ]; then
-      echo "No dspace values overlay found for env=${env_name} (${overlay})." >&2
-      exit 1
-    fi
-    values_chain="docs/examples/dspace.values.dev.yaml"
-    if [ "${env_name}" != "dev" ]; then
-      values_chain="${values_chain},${overlay}"
-    fi
-
-    # NOTE: This tokenplace-scoped change intentionally leaves dspace kubeconfig behavior unchanged here.
-    # If dspace needs env-scoped kubeconfig selection before Helm, handle that in a separate DSPACE PR.
-    deploy_tag="{{ tag }}"
-    default_tag_value=""
-    if [ "${env_name}" = "prod" ]; then
-      if [ -z "${deploy_tag}" ] && [ -f "docs/apps/dspace.prod.tag" ]; then
-        deploy_tag="$(read_prod_tag)"
-      fi
-      if [ -z "${deploy_tag}" ]; then
-        echo "Set tag=<immutable-tag> for prod or populate docs/apps/dspace.prod.tag." >&2
-        exit 1
-      fi
-    else
-      default_tag_value="main-latest"
-    fi
-
-    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
-      release='dspace' namespace='dspace' \
-      chart='oci://ghcr.io/democratizedspace/charts/dspace' \
-      values="${values_chain}" \
-      version_file='docs/apps/dspace.version' \
-      tag="${deploy_tag}" default_tag="${default_tag_value}"
-
-    scripts/ensure_user_kubeconfig.sh || true
-    if [ -z "${KUBECONFIG:-}" ]; then
-      export KUBECONFIG="${HOME}/.kube/config"
-    fi
-
-    echo "Forcing rollout restart for dspace deployment..."
-    if ! kubectl -n dspace rollout restart deploy/dspace; then
-      echo "ERROR: Failed to trigger rollout restart for dspace." >&2
-      exit 1
-    fi
-
-    echo "Waiting for dspace rollout to complete (timeout: 120s)..."
-    if ! kubectl -n dspace rollout status deploy/dspace --timeout=120s; then
-      echo "ERROR: dspace rollout did not complete successfully." >&2
-      exit 1
-    fi
-
-# Dump dspace and Traefik logs for debugging HTTP 500s.
 dspace-debug-logs namespace='dspace':
     #!/usr/bin/env bash
     set -Eeuo pipefail
@@ -1819,183 +1866,18 @@ dspace-debug-logs-env env='staging' namespace='dspace':
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
     just --justfile "{{ justfile_directory() }}/justfile" dspace-debug-logs namespace="{{ namespace }}"
 
-# Install-or-upgrade token.place from OCI chart with immutable tag policy.
+# Compatibility shim for the generic app deploy recipe.
 tokenplace-oci-deploy env='staging' tag='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
+    @just app-deploy app=tokenplace env='{{ env }}' tag='{{ tag }}'
 
-    env_input={{ quote(env) }}
-    env_name="${env_input}"
-    while [ "${env_name#env=}" != "${env_name}" ]; do
-        env_name="${env_name#env=}"
-    done
-    case "${env_name}" in
-      dev|staging|prod) ;;
-      *)
-        echo "ERROR: env must be one of dev|staging|prod." >&2
-        exit 1
-        ;;
-    esac
-
-    # Shared immutable-tag guard for deploy/redeploy paths avoids moving-target tags.
-    validate_immutable_tag() {
-      local candidate="${1}"
-      local tag_lc
-      tag_lc="$(echo "${candidate}" | tr '[:upper:]' '[:lower:]')"
-      if [[ "${tag_lc}" == *latest* ]] \
-        || [[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || [[ "${tag_lc}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || ([[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] && [[ ! "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]); then
-        echo "ERROR: mutable tag '${candidate}' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
-        exit 1
-      fi
-    }
-
-    resolved_tag="$(echo '{{ tag }}' | xargs)"
-    if [ -z "${resolved_tag}" ]; then
-      echo "ERROR: tag is required for immutable deploys." >&2
-      exit 1
-    fi
-    validate_immutable_tag "${resolved_tag}"
-    chart_version=""
-    if [ -f docs/apps/tokenplace.version ]; then
-      chart_version="$(
-        sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.version 2>/dev/null | head -n1 | tr -d '[:space:]' || true
-      )"
-    fi
-    if [ -z "${chart_version}" ]; then
-      echo "ERROR: unable to resolve chart version from docs/apps/tokenplace.version." >&2
-      exit 1
-    fi
-
-    values_chain='docs/examples/tokenplace.values.dev.yaml'
-    if [ "${env_name}" = "staging" ]; then
-      values_chain='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml'
-    elif [ "${env_name}" = "prod" ]; then
-      values_chain='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml'
-    fi
-
-    # Intentional: tokenplace OCI wrappers select kubeconfig from env before Helm
-    # so prod/staging values cannot be applied to an unrelated active context.
-    # This is tokenplace-scoped; do not copy into DSPACE from this PR.
-    export KUBECONFIG="${HOME}/.kube/config"
-    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
-    echo "Deploying tokenplace env=${env_name} chart=oci://ghcr.io/futuroptimist/charts/tokenplace version=${chart_version} image=ghcr.io/futuroptimist/tokenplace-relay:${resolved_tag}"
-
-    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
-      release='tokenplace' namespace='tokenplace' \
-      chart='oci://ghcr.io/futuroptimist/charts/tokenplace' \
-      values="${values_chain}" \
-      version_file='docs/apps/tokenplace.version' \
-      tag="${resolved_tag}"
-
-    scripts/ensure_user_kubeconfig.sh || true
-    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-
-    echo
-    echo "Resolved images for deployment/tokenplace:"
-    kubectl -n tokenplace get deploy/tokenplace -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"="}{.image}{"\n"}{end}' || true
-
-    ingress_host="$(kubectl -n tokenplace get ingress -o jsonpath='{.items[0].spec.rules[0].host}' 2>/dev/null || true)"
-    if [ -n "${ingress_host}" ]; then
-      echo
-      echo "Post-deploy checks:"
-      echo "  curl -fsS https://${ingress_host}/"
-      echo "  curl -fsS https://${ingress_host}/livez"
-      echo "  curl -fsS https://${ingress_host}/healthz"
-    fi
-
+# Compatibility shim for the generic app prod promotion recipe.
 tokenplace-oci-promote-prod tag='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
+    @just app-promote-prod app=tokenplace tag='{{ tag }}'
 
-    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.prod.tag | head -n1 | tr -d '[:space:]'; }
-
-    resolved_tag="$(echo '{{ tag }}' | xargs)"
-    if [ -z "${resolved_tag}" ]; then
-      resolved_tag="$(read_prod_tag 2>/dev/null || true)"
-    fi
-    if [ -z "${resolved_tag}" ]; then
-      echo "ERROR: provide tag=<immutable-tag> or set docs/apps/tokenplace.prod.tag." >&2
-      exit 1
-    fi
-
-    just --justfile "{{ justfile_directory() }}/justfile" tokenplace-oci-deploy env=prod tag="${resolved_tag}"
-
-# Upgrade-only token.place OCI redeploy path.
+# Compatibility shim for the generic app redeploy recipe.
 tokenplace-oci-redeploy env='staging' tag='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
+    @just app-redeploy app=tokenplace env='{{ env }}' tag='{{ tag }}'
 
-    env_input={{ quote(env) }}
-    env_name="${env_input}"
-    while [ "${env_name#env=}" != "${env_name}" ]; do
-        env_name="${env_name#env=}"
-    done
-    case "${env_name}" in
-      dev|staging|prod) ;;
-      *)
-        echo "ERROR: env must be one of dev|staging|prod." >&2
-        exit 1
-        ;;
-    esac
-
-    # Shared immutable-tag guard for deploy/redeploy paths avoids moving-target tags.
-    validate_immutable_tag() {
-      local candidate="${1}"
-      local tag_lc
-      tag_lc="$(echo "${candidate}" | tr '[:upper:]' '[:lower:]')"
-      if [[ "${tag_lc}" == *latest* ]] \
-        || [[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || [[ "${tag_lc}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || ([[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] && [[ ! "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]); then
-        echo "ERROR: mutable tag '${candidate}' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
-        exit 1
-      fi
-    }
-    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.prod.tag | head -n1 | tr -d '[:space:]'; }
-
-    resolved_tag="$(echo '{{ tag }}' | xargs)"
-    if [ -z "${resolved_tag}" ] && [ "${env_name}" = "prod" ]; then
-      resolved_tag="$(read_prod_tag 2>/dev/null || true)"
-      [ -n "${resolved_tag}" ] || { echo "ERROR: prod requires tag=<immutable-tag> or docs/apps/tokenplace.prod.tag." >&2; exit 1; }
-    fi
-    if [ "${env_name}" != "prod" ] && [ -z "${resolved_tag}" ]; then
-      echo "ERROR: env=${env_name} redeploy requires explicit tag=<immutable-tag>." >&2
-      echo "Non-prod redeploy intentionally has no baked-in fallback tag so this path is reproducible and reviewable." >&2
-      exit 1
-    fi
-    [ -n "${resolved_tag}" ] && validate_immutable_tag "${resolved_tag}"
-
-    values_chain='docs/examples/tokenplace.values.dev.yaml'
-    default_tag=''
-    if [ "${env_name}" = "staging" ]; then
-      values_chain='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml'
-    elif [ "${env_name}" = "prod" ]; then
-      values_chain='docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml'
-    fi
-
-    # Intentional: tokenplace OCI wrappers select kubeconfig from env before Helm
-    # so prod/staging values cannot be applied to an unrelated active context.
-    # This is tokenplace-scoped; do not copy into DSPACE from this PR.
-    export KUBECONFIG="${HOME}/.kube/config"
-    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
-
-    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
-      release='tokenplace' namespace='tokenplace' \
-      chart='oci://ghcr.io/futuroptimist/charts/tokenplace' \
-      values="${values_chain}" \
-      version_file='docs/apps/tokenplace.version' \
-      tag="${resolved_tag}" default_tag="${default_tag}"
-
-    scripts/ensure_user_kubeconfig.sh || true
-    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-    kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
-
-# token.place app status helper (generic/parameterized defaults, not final release wiring).
-# Override namespace/release/host_key per environment until onboarding locks chart naming.
-
-# See docs/tokenplace_sugarkube_onboarding.md and docs/apps/tokenplace.md.
 tokenplace-status namespace='tokenplace' release='tokenplace' host_key='ingress.host':
     @just app-status namespace='{{ namespace }}' release='{{ release }}' host_key='{{ host_key }}'
 
@@ -2155,187 +2037,17 @@ tokenplace-debug-logs-env env='staging' namespace='tokenplace':
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
     just --justfile "{{ justfile_directory() }}/justfile" tokenplace-debug-logs namespace="{{ namespace }}"
 
-# Install-or-upgrade danielsmith from OCI chart with immutable tag policy.
+# Compatibility shim for the generic app deploy recipe.
 danielsmith-oci-deploy env='staging' tag='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
+    @just app-deploy app=danielsmith env='{{ env }}' tag='{{ tag }}'
 
-    env_input={{ quote(env) }}
-    env_name="${env_input}"
-    while [ "${env_name#env=}" != "${env_name}" ]; do
-        env_name="${env_name#env=}"
-    done
-    case "${env_name}" in
-      dev|staging|prod) ;;
-      *)
-        echo "ERROR: env must be one of dev|staging|prod." >&2
-        exit 1
-        ;;
-    esac
-
-    validate_immutable_tag() {
-      local candidate="${1}"
-      local tag_lc
-      tag_lc="$(echo "${candidate}" | tr '[:upper:]' '[:lower:]')"
-      if [[ "${tag_lc}" == *latest* ]] \
-        || [[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || [[ "${tag_lc}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || ([[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] && [[ ! "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]) \
-        || ([[ "${tag_lc}" =~ -[0-9a-f]{7,}$ ]] && [[ ! "${tag_lc}" =~ ^[a-z0-9][a-z0-9._-]*-[0-9a-f]{7,}$ ]]); then
-        echo "ERROR: mutable tag '${candidate}' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
-        exit 1
-      fi
-    }
-
-    resolved_tag="$(echo '{{ tag }}' | xargs)"
-    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
-      resolved_tag="${resolved_tag#tag=}"
-    done
-    if [ -z "${resolved_tag}" ]; then
-      echo "ERROR: tag is required for immutable deploys." >&2
-      exit 1
-    fi
-    validate_immutable_tag "${resolved_tag}"
-
-    values_chain='docs/examples/danielsmith.values.dev.yaml'
-    if [ "${env_name}" = "staging" ]; then
-      values_chain='docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml'
-    elif [ "${env_name}" = "prod" ]; then
-      values_chain='docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml'
-    fi
-
-    export KUBECONFIG="${HOME}/.kube/config"
-    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
-
-    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
-      release='danielsmith' namespace='danielsmith' \
-      chart='oci://ghcr.io/futuroptimist/charts/danielsmith' \
-      values="${values_chain}" \
-      version_file='docs/apps/danielsmith.version' \
-      tag="${resolved_tag}"
-
-    scripts/ensure_user_kubeconfig.sh || true
-    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-
-    echo
-    workloads="$(
-      {
-        kubectl -n danielsmith get deploy,statefulset,daemonset \
-          -l 'app.kubernetes.io/instance=danielsmith' \
-          -o jsonpath='{range .items[*]}{.kind}/{.metadata.name}{"\n"}{end}'
-        kubectl -n danielsmith get deploy,statefulset,daemonset \
-          -l 'release=danielsmith' \
-          -o jsonpath='{range .items[*]}{.kind}/{.metadata.name}{"\n"}{end}'
-      } 2>/dev/null | sed '/^$/d' | sort -u
-    )"
-    if [ -z "${workloads}" ]; then
-      echo "No rollout-capable workloads found for release danielsmith in namespace danielsmith" >&2
-    else
-      echo "Resolved images for danielsmith workloads:"
-      while IFS= read -r workload; do
-        [ -n "${workload}" ] || continue
-        echo "--- ${workload} ---"
-        kubectl -n danielsmith get "${workload}" -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"="}{.image}{"\n"}{end}' || true
-      done <<< "${workloads}"
-    fi
-
-    ingress_host="$(kubectl -n danielsmith get ingress -o jsonpath='{.items[0].spec.rules[0].host}' 2>/dev/null || true)"
-    if [ -n "${ingress_host}" ]; then
-      echo
-      echo "Post-deploy checks:"
-      echo "  curl -fsS https://${ingress_host}/"
-      echo "  curl -fsS https://${ingress_host}/livez"
-      echo "  curl -fsS https://${ingress_host}/healthz"
-    fi
-
+# Compatibility shim for the generic app prod promotion recipe.
 danielsmith-oci-promote-prod tag='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
+    @just app-promote-prod app=danielsmith tag='{{ tag }}'
 
-    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.prod.tag | head -n1 | tr -d '[:space:]'; }
-
-    resolved_tag="$(echo '{{ tag }}' | xargs)"
-    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
-      resolved_tag="${resolved_tag#tag=}"
-    done
-    if [ -z "${resolved_tag}" ]; then
-      resolved_tag="$(read_prod_tag 2>/dev/null || true)"
-    fi
-    if [ -z "${resolved_tag}" ]; then
-      echo "ERROR: provide tag=<immutable-tag> or set docs/apps/danielsmith.prod.tag." >&2
-      exit 1
-    fi
-
-    just --justfile "{{ justfile_directory() }}/justfile" danielsmith-oci-deploy env=prod tag="${resolved_tag}"
-
-# Upgrade-only danielsmith OCI redeploy path.
+# Compatibility shim for the generic app redeploy recipe.
 danielsmith-oci-redeploy env='staging' tag='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
-
-    env_input={{ quote(env) }}
-    env_name="${env_input}"
-    while [ "${env_name#env=}" != "${env_name}" ]; do
-        env_name="${env_name#env=}"
-    done
-    case "${env_name}" in
-      dev|staging|prod) ;;
-      *)
-        echo "ERROR: env must be one of dev|staging|prod." >&2
-        exit 1
-        ;;
-    esac
-
-    validate_immutable_tag() {
-      local candidate="${1}"
-      local tag_lc
-      tag_lc="$(echo "${candidate}" | tr '[:upper:]' '[:lower:]')"
-      if [[ "${tag_lc}" == *latest* ]] \
-        || [[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || [[ "${tag_lc}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || ([[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] && [[ ! "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]) \
-        || ([[ "${tag_lc}" =~ -[0-9a-f]{7,}$ ]] && [[ ! "${tag_lc}" =~ ^[a-z0-9][a-z0-9._-]*-[0-9a-f]{7,}$ ]]); then
-        echo "ERROR: mutable tag '${candidate}' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
-        exit 1
-      fi
-    }
-    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.prod.tag | head -n1 | tr -d '[:space:]'; }
-
-    resolved_tag="$(echo '{{ tag }}' | xargs)"
-    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
-      resolved_tag="${resolved_tag#tag=}"
-    done
-    if [ -z "${resolved_tag}" ] && [ "${env_name}" = "prod" ]; then
-      resolved_tag="$(read_prod_tag 2>/dev/null || true)"
-      [ -n "${resolved_tag}" ] || { echo "ERROR: prod requires tag=<immutable-tag> or docs/apps/danielsmith.prod.tag." >&2; exit 1; }
-    fi
-    if [ "${env_name}" != "prod" ] && [ -z "${resolved_tag}" ]; then
-      echo "ERROR: env=${env_name} redeploy requires explicit tag=<immutable-tag>." >&2
-      echo "Non-prod redeploy intentionally has no baked-in fallback tag so this path is reproducible and reviewable." >&2
-      exit 1
-    fi
-    [ -n "${resolved_tag}" ] && validate_immutable_tag "${resolved_tag}"
-
-    values_chain='docs/examples/danielsmith.values.dev.yaml'
-    default_tag=''
-    if [ "${env_name}" = "staging" ]; then
-      values_chain='docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml'
-    elif [ "${env_name}" = "prod" ]; then
-      values_chain='docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml'
-    fi
-
-    export KUBECONFIG="${HOME}/.kube/config"
-    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
-
-    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
-      release='danielsmith' namespace='danielsmith' \
-      chart='oci://ghcr.io/futuroptimist/charts/danielsmith' \
-      values="${values_chain}" \
-      version_file='docs/apps/danielsmith.version' \
-      tag="${resolved_tag}" default_tag="${default_tag}"
-
-    scripts/ensure_user_kubeconfig.sh || true
-    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+    @just app-redeploy app=danielsmith env='{{ env }}' tag='{{ tag }}'
 
 danielsmith-debug-logs namespace='danielsmith':
     #!/usr/bin/env bash
@@ -2446,68 +2158,6 @@ tokenplace-port-forward namespace='tokenplace' service='tokenplace' local_port='
 
     echo "Port-forwarding ${svc} to localhost:{{ local_port }} (Ctrl+C to stop)..."
     kubectl -n '{{ namespace }}' port-forward svc/${svc} {{ local_port }}:{{ remote_port }}
-
-app-status namespace='' release='' host_key='ingress.host':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
-
-    export KUBECONFIG="${HOME}/.kube/config"
-
-    if [ -z "{{ namespace }}" ]; then
-        echo "Set namespace to inspect." >&2
-        exit 1
-    fi
-
-    if ! command -v kubectl >/dev/null 2>&1; then
-        echo "kubectl is required to check the deployment." >&2
-        exit 1
-    fi
-
-    kubectl -n "{{ namespace }}" get pods
-    kubectl -n "{{ namespace }}" get ingress
-
-    if [ -n "{{ release }}" ] && command -v helm >/dev/null 2>&1; then
-        host="$(
-            helm get values "{{ release }}" \
-                --namespace "{{ namespace }}" \
-                --all --output json 2>/dev/null |
-                python3 - "{{ host_key }}" <<'PY'
-                import json
-                import sys
-
-                try:
-                    host_key = sys.argv[1]
-                    data = json.load(sys.stdin)
-                except (json.JSONDecodeError, KeyError, IndexError) as e:
-                    sys.stderr.write(f"Error extracting host value: {e}\n")
-                    sys.exit(1)
-                except Exception as e:
-                    sys.stderr.write(f"Unexpected error: {e}\n")
-                    sys.exit(1)
-
-                def get_with_dots(payload, dotted_key):
-                    node = payload
-                    for part in dotted_key.split('.'):
-                        if not isinstance(node, dict):
-                            return None
-                        node = node.get(part)
-                    return node
-
-                if isinstance(data, dict):
-                    host_value = get_with_dots(data, host_key)
-                    if host_value:
-                        print(host_value)
-                PY
-        )"
-    else
-        host=""
-    fi
-
-    if [ -n "${host}" ]; then
-        printf 'Public URL: https://%s\n' "${host}"
-    else
-        echo "Public URL host not recorded; check the Helm release values."
-    fi
 
 wipe:
     #!/usr/bin/env bash

--- a/scripts/app_config.py
+++ b/scripts/app_config.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Load Sugarkube app deployment config files for generic just recipes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import sys
+from pathlib import Path
+from typing import Iterable
+
+SUPPORTED_ENVS = {"dev", "staging", "prod"}
+DEFAULT_HOST_KEY = "ingress.host"
+
+ALLOWED_KEYS = {
+    "SUGARKUBE_APP",
+    "SUGARKUBE_RELEASE",
+    "SUGARKUBE_NAMESPACE",
+    "SUGARKUBE_CHART",
+    "SUGARKUBE_VERSION_FILE",
+    "SUGARKUBE_PROD_TAG_FILE",
+    "SUGARKUBE_VALUES_DEV",
+    "SUGARKUBE_VALUES_STAGING",
+    "SUGARKUBE_VALUES_PROD",
+    "SUGARKUBE_STATUS_HOST_KEY",
+    "SUGARKUBE_VERIFY_PATHS",
+    "SUGARKUBE_DEBUG_SELECTOR",
+}
+REQUIRED_KEYS = {
+    "SUGARKUBE_APP",
+    "SUGARKUBE_RELEASE",
+    "SUGARKUBE_NAMESPACE",
+    "SUGARKUBE_CHART",
+    "SUGARKUBE_VERSION_FILE",
+    "SUGARKUBE_PROD_TAG_FILE",
+    "SUGARKUBE_VALUES_DEV",
+    "SUGARKUBE_VALUES_STAGING",
+    "SUGARKUBE_VALUES_PROD",
+}
+
+MOVING_TAGS = {
+    "latest",
+    "main",
+    "master",
+    "dev",
+    "develop",
+    "development",
+    "staging",
+    "stage",
+    "prod",
+    "production",
+    "release",
+    "stable",
+}
+BRANCH_SHA_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*-[0-9a-fA-F]{7,}$")
+SEMVER_RE = re.compile(r"^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z][0-9A-Za-z._-]*)?$")
+APP_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+
+
+class AppConfigError(ValueError):
+    """Raised for config or argument validation errors."""
+
+
+def normalize_named(value: str, name: str) -> str:
+    value = (value or "").strip()
+    prefix = f"{name}="
+    while value.startswith(prefix):
+        value = value[len(prefix) :].strip()
+    return value
+
+
+def parse_env_name(raw: str) -> str:
+    env_name = normalize_named(raw, "env")
+    if env_name == "int":
+        env_name = "staging"
+    if env_name not in SUPPORTED_ENVS:
+        raise AppConfigError("env must be one of dev|staging|prod")
+    return env_name
+
+
+def parse_app_name(raw: str) -> str:
+    app = normalize_named(raw, "app")
+    if not app:
+        raise AppConfigError("app must not be empty")
+    if not APP_RE.match(app) or "/" in app or ".." in app:
+        raise AppConfigError(
+            "app must be a simple slug using letters, numbers, dot, underscore, or dash"
+        )
+    return app
+
+
+def _strip_inline_comment(value: str) -> str:
+    in_single = False
+    in_double = False
+    escaped = False
+    out: list[str] = []
+    for char in value:
+        if escaped:
+            out.append(char)
+            escaped = False
+            continue
+        if char == "\\" and not in_single:
+            out.append(char)
+            escaped = True
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        if char == "#" and not in_single and not in_double:
+            break
+        out.append(char)
+    if in_single or in_double:
+        raise AppConfigError("unterminated quoted value")
+    return "".join(out).strip()
+
+
+def _parse_value(raw: str, line_no: int) -> str:
+    raw = _strip_inline_comment(raw)
+    if not raw:
+        return ""
+    if any(token in raw for token in ("$(", "`", "${", ";", "&&", "||", "<", ">")):
+        raise AppConfigError(f"line {line_no}: shell syntax is not allowed in app configs")
+    if (raw.startswith("'") and raw.endswith("'")) or (raw.startswith('"') and raw.endswith('"')):
+        try:
+            parts = shlex.split(raw, posix=True)
+        except ValueError as exc:
+            raise AppConfigError(f"line {line_no}: invalid quoted value: {exc}") from exc
+        if len(parts) != 1:
+            raise AppConfigError(f"line {line_no}: expected a single value")
+        return parts[0]
+    return raw.strip()
+
+
+def parse_dotenv(path: Path) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for line_no, original in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = original.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        if "=" not in line:
+            raise AppConfigError(f"line {line_no}: expected KEY=value assignment")
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        if not KEY_RE.match(key):
+            raise AppConfigError(f"line {line_no}: invalid key {key!r}")
+        if key not in ALLOWED_KEYS:
+            raise AppConfigError(f"line {line_no}: unknown app config key {key!r}")
+        data[key] = _parse_value(raw_value, line_no)
+    missing = sorted(REQUIRED_KEYS - data.keys())
+    if missing:
+        raise AppConfigError(f"missing required app config keys: {', '.join(missing)}")
+    return data
+
+
+def candidate_paths(app: str, explicit_config: str | None = None) -> Iterable[Path]:
+    if explicit_config:
+        yield Path(explicit_config).expanduser()
+        return
+    config_dir = os.environ.get("SUGARKUBE_APP_CONFIG_DIR")
+    if config_dir:
+        yield Path(config_dir).expanduser() / f"{app}.env"
+    yield Path("apps") / f"{app}.env"
+    yield Path("docs/examples/apps") / f"{app}.env"
+
+
+def load_config(app_raw: str, env_raw: str, explicit_config: str | None = None) -> dict[str, str]:
+    app = parse_app_name(app_raw)
+    env_name = parse_env_name(env_raw)
+    checked: list[str] = []
+    config_path = None
+    for path in candidate_paths(app, explicit_config):
+        checked.append(str(path))
+        if path.is_file():
+            config_path = path
+            break
+    if config_path is None:
+        raise AppConfigError(f"no config found for app={app}; checked: {', '.join(checked)}")
+    data = parse_dotenv(config_path)
+    configured_app = data.get("SUGARKUBE_APP", "")
+    if configured_app != app:
+        raise AppConfigError(
+            f"config {config_path} declares SUGARKUBE_APP={configured_app!r}, expected {app!r}"
+        )
+    values_key = f"SUGARKUBE_VALUES_{env_name.upper()}"
+    data["SUGARKUBE_ENV"] = env_name
+    data["SUGARKUBE_CONFIG_PATH"] = str(config_path)
+    data["SUGARKUBE_VALUES"] = data[values_key]
+    data["SUGARKUBE_STATUS_HOST_KEY"] = data.get("SUGARKUBE_STATUS_HOST_KEY") or DEFAULT_HOST_KEY
+    data["SUGARKUBE_VERIFY_PATHS"] = data.get("SUGARKUBE_VERIFY_PATHS") or "/"
+    return data
+
+
+def validate_tag(tag_raw: str) -> str:
+    tag = normalize_named(tag_raw, "tag")
+    if not tag:
+        raise AppConfigError(
+            "tag must not be empty; use an immutable branch-SHA tag like "
+            "main-deadbee or a release tag like v1.2.3"
+        )
+    if any(ch.isspace() for ch in tag) or any(ch in tag for ch in "/:@"):
+        raise AppConfigError(
+            f"invalid tag {tag!r}; use an image tag only, for example main-deadbee or v1.2.3"
+        )
+    lower = tag.lower()
+    if "latest" in lower:
+        raise AppConfigError(
+            f"mutable tag {tag!r} is not allowed; use an immutable branch-SHA tag "
+            "like main-deadbee or a release tag like v1.2.3"
+        )
+    if lower in MOVING_TAGS:
+        raise AppConfigError(
+            f"mutable tag {tag!r} is not allowed; use an immutable branch-SHA tag "
+            f"like {lower}-deadbee or a release tag like v1.2.3"
+        )
+    if lower.endswith(tuple(f"-{name}" for name in MOVING_TAGS)):
+        raise AppConfigError(
+            f"environment-like moving tag {tag!r} is not allowed; use a tag "
+            "ending in a Git SHA, for example main-deadbee"
+        )
+    if SEMVER_RE.match(tag) or BRANCH_SHA_RE.match(tag):
+        return tag
+    if re.search(r"-[0-9a-fA-F]{1,6}$", tag):
+        raise AppConfigError(
+            f"tag {tag!r} looks like a branch-SHA tag but the hex suffix is "
+            "too short; use at least 7 hex characters"
+        )
+    raise AppConfigError(
+        f"tag {tag!r} is not recognized as immutable; use branch-SHA tags "
+        "like main-deadbee or semver tags like v1.2.3"
+    )
+
+
+def read_prod_tag(config: dict[str, str]) -> str:
+    tag_file = Path(config["SUGARKUBE_PROD_TAG_FILE"])
+    if not tag_file.is_file():
+        return ""
+    for line in tag_file.read_text(encoding="utf-8").splitlines():
+        stripped = line.split("#", 1)[0].strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def shell_quote_map(values: dict[str, str]) -> str:
+    return "\n".join(
+        f"export {key}={shlex.quote(str(value))}" for key, value in sorted(values.items())
+    )
+
+
+def get_dotted(data: object, dotted_key: str) -> object | None:
+    node = data
+    for part in dotted_key.split("."):
+        if not isinstance(node, dict):
+            return None
+        node = node.get(part)
+    return node
+
+
+def cmd_config(args: argparse.Namespace) -> int:
+    config = load_config(args.app, args.env, args.config)
+    if args.format == "shell":
+        print(shell_quote_map(config))
+    elif args.format == "json":
+        print(json.dumps(config, indent=2, sort_keys=True))
+    else:
+        for key in sorted(config):
+            print(f"{key}={config[key]}")
+    return 0
+
+
+def cmd_validate_tag(args: argparse.Namespace) -> int:
+    print(validate_tag(args.tag))
+    return 0
+
+
+def cmd_prod_tag(args: argparse.Namespace) -> int:
+    config = load_config(args.app, args.env, args.config)
+    tag = normalize_named(args.tag or "", "tag") or read_prod_tag(config)
+    print(validate_tag(tag))
+    return 0
+
+
+def cmd_extract_host(args: argparse.Namespace) -> int:
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        raise AppConfigError(f"invalid Helm values JSON: {exc}") from exc
+    host = get_dotted(data, args.host_key or DEFAULT_HOST_KEY)
+    if host:
+        print(host)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    config = sub.add_parser("config", help="load and print app config")
+    config.add_argument("--app", required=True)
+    config.add_argument("--env", required=True)
+    config.add_argument("--config")
+    config.add_argument("--format", choices=("env", "shell", "json"), default="env")
+    config.set_defaults(func=cmd_config)
+
+    validate = sub.add_parser("validate-tag", help="validate and normalize an immutable image tag")
+    validate.add_argument("tag")
+    validate.set_defaults(func=cmd_validate_tag)
+
+    prod = sub.add_parser("prod-tag", help="resolve explicit tag or app prod tag file")
+    prod.add_argument("--app", required=True)
+    prod.add_argument("--env", default="prod")
+    prod.add_argument("--config")
+    prod.add_argument("--tag", default="")
+    prod.set_defaults(func=cmd_prod_tag)
+
+    host = sub.add_parser(
+        "extract-host", help="extract dotted host key from Helm values JSON on stdin"
+    )
+    host.add_argument("--host-key", default=DEFAULT_HOST_KEY)
+    host.set_defaults(func=cmd_extract_host)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except AppConfigError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -1,0 +1,169 @@
+"""Tests for generic Sugarkube app config loading and tag validation."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import app_config
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_app_config_uses_example_fallback_for_existing_apps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    monkeypatch.delenv("SUGARKUBE_APP_CONFIG_DIR", raising=False)
+
+    config = app_config.load_config("tokenplace", "env=staging")
+
+    assert config["SUGARKUBE_CONFIG_PATH"] == "docs/examples/apps/tokenplace.env"
+    assert config["SUGARKUBE_RELEASE"] == "tokenplace"
+    assert config["SUGARKUBE_VALUES"] == (
+        "docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml"
+    )
+
+
+def test_app_config_dir_precedes_local_and_example_configs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir = tmp_path / "configs"
+    config_dir.mkdir()
+    override = config_dir / "danielsmith.env"
+    override.write_text(
+        "\n".join(
+            [
+                "SUGARKUBE_APP=danielsmith",
+                "SUGARKUBE_RELEASE=custom-danielsmith",
+                "SUGARKUBE_NAMESPACE=custom-ns",
+                "SUGARKUBE_CHART=oci://example.test/charts/danielsmith",
+                "SUGARKUBE_VERSION_FILE=docs/apps/danielsmith.version",
+                "SUGARKUBE_PROD_TAG_FILE=docs/apps/danielsmith.prod.tag",
+                "SUGARKUBE_VALUES_DEV=values-dev.yaml",
+                "SUGARKUBE_VALUES_STAGING=values-dev.yaml,values-staging.yaml",
+                "SUGARKUBE_VALUES_PROD=values-dev.yaml,values-prod.yaml",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(REPO_ROOT)
+    monkeypatch.setenv("SUGARKUBE_APP_CONFIG_DIR", str(config_dir))
+
+    config = app_config.load_config("danielsmith", "staging")
+
+    assert config["SUGARKUBE_CONFIG_PATH"] == str(override)
+    assert config["SUGARKUBE_RELEASE"] == "custom-danielsmith"
+    assert config["SUGARKUBE_VALUES"] == "values-dev.yaml,values-staging.yaml"
+
+
+def test_explicit_config_precedes_config_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_dir = tmp_path / "configs"
+    config_dir.mkdir()
+    (config_dir / "dspace.env").write_text("SUGARKUBE_APP=dspace\n", encoding="utf-8")
+    explicit = tmp_path / "explicit.env"
+    explicit.write_text(
+        "\n".join(
+            [
+                "SUGARKUBE_APP=dspace",
+                "SUGARKUBE_RELEASE=explicit-dspace",
+                "SUGARKUBE_NAMESPACE=dspace",
+                "SUGARKUBE_CHART=oci://example.test/charts/dspace",
+                "SUGARKUBE_VERSION_FILE=docs/apps/dspace.version",
+                "SUGARKUBE_PROD_TAG_FILE=docs/apps/dspace.prod.tag",
+                "SUGARKUBE_VALUES_DEV=dev.yaml",
+                "SUGARKUBE_VALUES_STAGING=dev.yaml,staging.yaml",
+                "SUGARKUBE_VALUES_PROD=dev.yaml,prod.yaml",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(REPO_ROOT)
+    monkeypatch.setenv("SUGARKUBE_APP_CONFIG_DIR", str(config_dir))
+
+    config = app_config.load_config("dspace", "staging", str(explicit))
+
+    assert config["SUGARKUBE_CONFIG_PATH"] == str(explicit)
+    assert config["SUGARKUBE_RELEASE"] == "explicit-dspace"
+
+
+@pytest.mark.parametrize(
+    "tag",
+    ["main-deadbee", "v3-deadbee", "feature-x-deadbee", "v0.1.0", "3.0.1", "3.1.0", "v1.2.3-rc.1"],
+)
+def test_validate_tag_accepts_immutable_tags(tag: str) -> None:
+    assert app_config.validate_tag(tag) == tag
+
+
+@pytest.mark.parametrize(
+    "tag",
+    [
+        "latest",
+        "main",
+        "master",
+        "dev",
+        "develop",
+        "staging",
+        "prod",
+        "production",
+        "release",
+        "main-latest",
+        "feature-prod",
+    ],
+)
+def test_validate_tag_rejects_moving_tags(tag: str) -> None:
+    with pytest.raises(app_config.AppConfigError, match="tag"):
+        app_config.validate_tag(tag)
+
+
+def test_parse_dotenv_rejects_unknown_keys_and_shell_syntax(tmp_path: Path) -> None:
+    config = tmp_path / "bad.env"
+    config.write_text(
+        "\n".join(
+            [
+                "SUGARKUBE_APP=dspace",
+                "SUGARKUBE_RELEASE=$(whoami)",
+                "SUGARKUBE_NAMESPACE=dspace",
+                "SUGARKUBE_CHART=oci://example.test/charts/dspace",
+                "SUGARKUBE_VERSION_FILE=docs/apps/dspace.version",
+                "SUGARKUBE_PROD_TAG_FILE=docs/apps/dspace.prod.tag",
+                "SUGARKUBE_VALUES_DEV=dev.yaml",
+                "SUGARKUBE_VALUES_STAGING=dev.yaml,staging.yaml",
+                "SUGARKUBE_VALUES_PROD=dev.yaml,prod.yaml",
+                "UNRELATED=value",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(app_config.AppConfigError, match="shell syntax"):
+        app_config.parse_dotenv(config)
+
+
+def test_app_config_cli_shell_output_is_export_safe() -> None:
+    result = subprocess.run(
+        [
+            "python3",
+            "scripts/app_config.py",
+            "config",
+            "--app",
+            "dspace",
+            "--env",
+            "staging",
+            "--format",
+            "shell",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "export SUGARKUBE_APP=dspace" in result.stdout
+    assert "export SUGARKUBE_VALUES=" in result.stdout

--- a/tests/test_app_just_recipes.py
+++ b/tests/test_app_just_recipes.py
@@ -1,0 +1,160 @@
+"""Stubbed just tests for generic app deploy recipes."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+@pytest.fixture()
+def app_just_stub_env(tmp_path: Path, ensure_just_available: Path) -> dict[str, str]:
+    assert ensure_just_available.exists()
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_path = tmp_path / "helm.log"
+
+    _write_executable(
+        bin_dir / "sudo",
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "cp" ]; then
+  mkdir -p "$(dirname "${3}")"
+  printf 'stub kubeconfig\n' > "${3}"
+fi
+exit 0
+""",
+    )
+    _write_executable(
+        bin_dir / "kubectl",
+        """#!/usr/bin/env bash
+exit 0
+""",
+    )
+    _write_executable(
+        bin_dir / "helm",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> {str(log_path)!r}
+if [ "${{1:-}}" = "-n" ] && [ "${{3:-}}" = "status" ]; then
+  printf 'STATUS: deployed\n'
+fi
+if [ "${{1:-}}" = "get" ] && [ "${{2:-}}" = "values" ]; then
+  printf '{{"ingress":{{"host":"staging.example.test"}}}}\n'
+fi
+exit 0
+""",
+    )
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "home")
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["SUGARKUBE_HELM_ROLLOUT_TIMEOUT"] = "1s"
+    env["HELM_LOG"] = str(log_path)
+    return env
+
+
+def _run_just(args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["just", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize(
+    ("app", "release", "namespace", "chart", "values"),
+    [
+        (
+            "danielsmith",
+            "danielsmith",
+            "danielsmith",
+            "oci://ghcr.io/futuroptimist/charts/danielsmith",
+            "docs/examples/danielsmith.values.dev.yaml,"
+            "docs/examples/danielsmith.values.staging.yaml",
+        ),
+        (
+            "tokenplace",
+            "tokenplace",
+            "tokenplace",
+            "oci://ghcr.io/futuroptimist/charts/tokenplace",
+            "docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml",
+        ),
+        (
+            "dspace",
+            "dspace",
+            "dspace",
+            "oci://ghcr.io/democratizedspace/charts/dspace",
+            "docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml",
+        ),
+    ],
+)
+def test_app_deploy_uses_configured_helm_coordinates(
+    app: str,
+    release: str,
+    namespace: str,
+    chart: str,
+    values: str,
+    app_just_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        ["app-deploy", f"app={app}", "env=staging", "tag=main-deadbee"],
+        app_just_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    helm_log = Path(app_just_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert f"upgrade {release} {chart}" in helm_log
+    assert f"--namespace {namespace}" in helm_log
+    for values_file in values.split(","):
+        assert f"-f {values_file}" in helm_log
+    assert "--set image.tag=main-deadbee" in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_deploy_rejects_mutable_tag_before_helm(app_just_stub_env: dict[str, str]) -> None:
+    result = _run_just(
+        ["app-deploy", "app=tokenplace", "env=staging", "tag=latest"],
+        app_just_stub_env,
+    )
+
+    assert result.returncode != 0
+    assert "mutable tag" in result.stderr
+    helm_log_path = Path(app_just_stub_env["HELM_LOG"])
+    assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize(
+    ("recipe", "app"),
+    [
+        ("dspace-oci-deploy", "dspace"),
+        ("tokenplace-oci-deploy", "tokenplace"),
+        ("danielsmith-oci-deploy", "danielsmith"),
+    ],
+)
+def test_app_specific_deploy_wrappers_delegate_to_generic_recipe(
+    recipe: str,
+    app: str,
+    app_just_stub_env: dict[str, str],
+) -> None:
+    result = _run_just([recipe, "env=staging", "tag=tag=main-deadbee"], app_just_stub_env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    helm_log = Path(app_just_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert f"upgrade {app}" in helm_log
+    assert "--set image.tag=main-deadbee" in helm_log
+    assert "--set image.tag=tag=main-deadbee" not in helm_log

--- a/tests/test_danielsmith_oci_wrappers.py
+++ b/tests/test_danielsmith_oci_wrappers.py
@@ -38,12 +38,6 @@ exit 0
 """,
     )
     _write_executable(
-        bin_dir / "python3",
-        """#!/usr/bin/env bash
-exit 0
-""",
-    )
-    _write_executable(
         bin_dir / "kubectl",
         """#!/usr/bin/env bash
 exit 0


### PR DESCRIPTION
### Motivation
- Centralize repeated app deployment logic (env parsing, values chain, tag validation, prod tag pinning, kubeconfig selection) behind a generic façade so future apps can reuse a single flow.
- Provide a small stdlib-only config loader for dotenv-style app configs with a clear precedence order and safe shell emission.
- Keep existing dspace/tokenplace/danielsmith recipes as compatibility shims while enabling migration to the generic interface.

### Description
- Add `scripts/app_config.py`, a stdlib-only loader exposing `config`, `validate-tag`, `prod-tag`, and `extract-host` subcommands that: resolves config files (`--config`, `SUGARKUBE_APP_CONFIG_DIR`, `apps/`, `docs/examples/apps/`), whitelists keys, rejects dangerous shell syntax, resolves env-scoped `SUGARKUBE_VALUES_*`, reads `SUGARKUBE_PROD_TAG_FILE`, and centralizes immutable-tag validation (branch-SHA and semver rules).
- Add generic `just` recipes: `app-config`, `app-deploy`, `app-redeploy`, `app-promote-prod`, `app-status`, and `app-verify` that load app config via `scripts/app_config.py`, call `just kubeconfig-env <env>` before Helm, and delegate to existing `helm-oci-install` / `helm-oci-upgrade` as appropriate.
- Convert existing app-specific deploy/redeploy/promote recipes into thin compatibility shims that call the generic `app-*` recipes where practical, preserving special-case behavior that must remain in-place.
- Update docs (`docs/app_deployment_contract.md`) and example config scaffolds (`docs/examples/apps/*.env`) to document the implemented generic surface and migration note.
- Add tests: `tests/test_app_config.py` for config resolution and tag validation, and `tests/test_app_just_recipes.py` for stubbed `just` behavior plus small updates to the existing `danielsmith` wrapper tests to verify compatibility.

### Testing
- Ran unit and integration test suite: `python -m pytest tests -q` — result: `1232 passed, 19 skipped` (all new and updated tests passed).
- Verified `just` surface is exposed: `just --summary | grep -E 'app-(config|deploy|redeploy|promote-prod|status|verify)'` — generic recipes listed.
- Exercised config loader and shell output: `just app-config app=danielsmith env=staging`, `just app-config app=tokenplace env=staging`, `just app-config app=dspace env=staging` — produced expected config exports.
- Docs/tools checks: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` — both completed with no errors in this run.
- Notes on pre-commit: `pre-commit run --all-files` was exercised during development and auto-fixed trailing-whitespace/EOF in unrelated legacy files; repo-wide YAML multi-document/Helm-template checks and pre-existing line-length issues are outside this PR's scope and were not introduced by these changes.

Files of interest: `scripts/app_config.py`, `justfile` (new `app-*` recipes + compatibility shims), `docs/app_deployment_contract.md`, `docs/examples/apps/*.env`, and tests under `tests/test_app_config.py` and `tests/test_app_just_recipes.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e0c4d4a44832fae566689e78eebc0)