### PR TITLE
docs: unify app runbooks around generic app flow and add future-app onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,21 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
 
 ## Application runbooks
 
-- **[token.place onboarding contract](docs/tokenplace_sugarkube_onboarding.md)** — prerequisites,
-  ownership boundaries, and environment mapping for first-class token.place operations.
-- **[token.place app operations](docs/apps/tokenplace.md)** — topology and deployment workflow
-  patterns for token.place on Sugarkube.
-- **[token.place env runbooks](docs/index.md)** — environment-specific guides for
+- **[Future-app onboarding](docs/app_onboarding.md)** — checklist, config template, workflow
+  requirements, and release decision tree for wove, jobbot3000, and later apps.
+- **[Sugarkube app deployment contract](docs/app_deployment_contract.md)** — shared artifact, tag,
+  chart, app-config, and generic command contract.
+- **[DSPACE app operations](docs/apps/dspace.md)** — uniform GHCR-first staging/prod deploy,
+  verify, promote, rollback, and troubleshooting flow.
+- **[token.place app operations](docs/apps/tokenplace.md)** — uniform GHCR-first staging/prod
+  deploy, verify, promote, rollback, and troubleshooting flow.
+- **[danielsmith.io app operations](docs/apps/danielsmith.md)** — uniform GHCR-first staging/prod
+  deploy, verify, promote, rollback, and troubleshooting flow.
+- **Environment quick checks** — token.place
   [dev](docs/k3s-tokenplace-dev.md), [staging](docs/k3s-tokenplace-staging.md), and
-  [production](docs/k3s-tokenplace-prod.md) operations.
+  [production](docs/k3s-tokenplace-prod.md); danielsmith.io
+  [staging](docs/k3s-danielsmith-staging.md) and
+  [production](docs/k3s-danielsmith-prod.md).
 
 ## Repository layout
 

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -1,0 +1,258 @@
+# Sugarkube future-app onboarding
+
+Use this checklist to onboard the next apps, including **wove** and **jobbot3000**, without
+inventing live hostnames, secrets, or production tags before their app repositories publish the
+required details.
+
+## Responsibility split
+
+App repository responsibilities:
+
+- Build and publish a container image to GHCR.
+- Build and publish a Helm chart to GHCR as an immutable OCI artifact.
+- Own app-specific tests, smoke checks, runtime config, and release notes.
+
+Sugarkube responsibilities:
+
+- Store app config and environment values overlays.
+- Select kubeconfig and environment.
+- Run generic Helm deploy, status, verify, logs, promotion, and rollback recipes.
+
+Cloudflare responsibilities:
+
+- DNS records and Cloudflare Tunnel routes are outside Helm.
+- Route each staging/prod hostname to Traefik before public HTTPS verification.
+
+## Onboarding checklist
+
+1. Add a `Dockerfile` in the app repo.
+2. Add `ci-image.yml` in the app repo with standard GHCR tags.
+3. Add a Helm chart in the app repo.
+4. Add `ci-helm.yml` in the app repo with immutable OCI chart publishing.
+5. Add or copy a Sugarkube app config.
+6. Add environment values overlays for `dev`, `staging`, and `prod`.
+7. Run the generic Sugarkube deploy.
+8. Add app-specific smoke checks if needed.
+
+## Minimal app config template
+
+Copy this to `apps/APP_SLUG.env` for private/local configs or to `docs/examples/apps/APP_SLUG.env`
+when the example is safe to publish. Replace placeholder values with real app details after the app
+repo has confirmed them.
+
+```dotenv
+SUGARKUBE_APP=APP_SLUG
+SUGARKUBE_RELEASE=APP_SLUG
+SUGARKUBE_NAMESPACE=APP_SLUG
+SUGARKUBE_CHART=oci://ghcr.io/OWNER/charts/CHART_NAME
+SUGARKUBE_VERSION_FILE=docs/apps/APP_SLUG.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/APP_SLUG.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/APP_SLUG.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/APP_SLUG.values.dev.yaml,docs/examples/APP_SLUG.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/APP_SLUG.values.dev.yaml,docs/examples/APP_SLUG.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/,/healthz,/livez
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=APP_SLUG
+```
+
+Create the chart version pin:
+
+```bash
+printf '0.1.0\n' > docs/apps/APP_SLUG.version
+```
+
+Create the production tag pin and leave it empty until a production tag is approved:
+
+```bash
+printf '# Approved production image tag for APP_SLUG.\n' > docs/apps/APP_SLUG.prod.tag
+```
+
+## Minimal image workflow checklist
+
+The app repo image workflow should:
+
+- Run on pushes to the default branch and release tags.
+- Authenticate with `GITHUB_TOKEN` or an explicitly scoped GHCR token.
+- Publish to `ghcr.io/OWNER/IMAGE_NAME`.
+- Emit immutable branch-SHA tags such as `main-REPLACE_SHORTSHA`.
+- Emit semver tags when building release tags such as `v0.1.0`.
+- Avoid relying on `latest`, `main`, `staging`, or `prod` for Sugarkube deploys.
+- Record the image digest in workflow output or release notes.
+
+## Minimal Helm chart checklist
+
+The app repo chart should:
+
+- Include a stable `Chart.yaml` name and semver `version`.
+- Set `appVersion` to the app release where practical.
+- Expose values for image repository, image tag, ingress host, service port, probes, resources, and
+  runtime config.
+- Avoid hard-coding Sugarkube staging/prod hostnames in templates; put hostnames in values overlays.
+- Publish to `oci://ghcr.io/OWNER/charts/CHART_NAME`.
+- Require a chart version bump whenever templates, default values, or CRD assumptions change.
+
+## Environment values overlays
+
+Create one base/dev values file and one overlay per routable environment:
+
+```bash
+APP_SLUG=wove
+```
+
+```bash
+cat > "docs/examples/${APP_SLUG}.values.dev.yaml" <<'YAML'
+environment: dev
+image:
+  repository: ghcr.io/OWNER/IMAGE_NAME
+ingress:
+  enabled: true
+  className: traefik
+YAML
+```
+
+```bash
+cat > "docs/examples/${APP_SLUG}.values.staging.yaml" <<'YAML'
+environment: staging
+ingress:
+  enabled: true
+  className: traefik
+  host: staging.example.com
+YAML
+```
+
+```bash
+cat > "docs/examples/${APP_SLUG}.values.prod.yaml" <<'YAML'
+environment: prod
+ingress:
+  enabled: true
+  className: traefik
+  host: example.com
+YAML
+```
+
+The hostnames above are illustrative. Do not commit invented wove or jobbot3000 hostnames; replace
+them only after the app owner confirms real staging and production routes.
+
+## Generic deploy flow for a newly onboarded app
+
+Inspect the resolved config:
+
+```bash
+just app-config app=APP_SLUG env=staging
+```
+
+Deploy the immutable image tag that the app repo published:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-deploy app=APP_SLUG env=staging tag="$APP_TAG"
+```
+
+Verify public HTTPS paths from `SUGARKUBE_VERIFY_PATHS`:
+
+```bash
+just app-verify app=APP_SLUG env=staging
+```
+
+Promote the exact staging-approved tag:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-promote-prod app=APP_SLUG tag="$APP_TAG"
+```
+
+Rollback by redeploying the previous immutable tag:
+
+```bash
+PREVIOUS_TAG=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+```bash
+just app-deploy app=APP_SLUG env=prod tag="$PREVIOUS_TAG"
+```
+
+## Questions to answer for wove, jobbot3000, and later apps
+
+Answer these before adding real Sugarkube configs:
+
+- App image name: what exact `ghcr.io/OWNER/IMAGE_NAME` should Sugarkube deploy?
+- Container port: which port does the Kubernetes Service target?
+- Health endpoints: which paths should `just app-verify` call?
+- Chart name: what exact `oci://ghcr.io/OWNER/charts/CHART_NAME` is published?
+- Namespace/release: should the Kubernetes namespace and Helm release match the app slug?
+- Staging/prod hostnames: which public hosts should Cloudflare route to Traefik?
+- Runtime secrets/config: which settings are values, which are Kubernetes Secrets, and which are
+  managed outside Sugarkube?
+- Stateful dependencies: does the app need a database, queue, object store, persistent volume, or
+  external service?
+- Resource requests/limits: what CPU and memory are safe for the Pi cluster and production HA?
+
+## Release decision tree
+
+### I have a successful image build; what tag do I deploy?
+
+Use the immutable branch-SHA tag from the app repo workflow, for example:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+If the workflow also produced a semver release tag and that release is the intended artifact, use
+that semver tag. Never use `latest`, `main`, `staging`, or `prod` for generic Sugarkube deploys.
+
+### The chart changed; what version do I bump?
+
+Bump the chart `version` in the app repo whenever templates, default values, chart metadata, probe
+configuration, or resource defaults changed. Publish the new OCI chart, then update the matching
+Sugarkube pin file:
+
+```bash
+printf '0.1.1\n' > docs/apps/APP_SLUG.version
+```
+
+If only the application image changed, do not bump the chart version.
+
+### Staging works; how do I promote prod?
+
+Promote the exact immutable tag that passed staging:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-promote-prod app=APP_SLUG tag="$APP_TAG"
+```
+
+Optionally record the approved tag in `docs/apps/APP_SLUG.prod.tag` after review so future
+production deploys can use the pinned fallback.
+
+### Prod is bad; how do I roll back?
+
+If the chart is still good and only the image is bad, redeploy the previous immutable image tag:
+
+```bash
+PREVIOUS_TAG=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+```bash
+just app-deploy app=APP_SLUG env=prod tag="$PREVIOUS_TAG"
+```
+
+If rendered manifests, values, or chart behavior are bad, roll back the Helm revision:
+
+```bash
+HELM_REVISION=12
+```
+
+```bash
+just tokenplace-rollback release=APP_SLUG namespace=APP_SLUG revision="$HELM_REVISION"
+```
+
+`tokenplace-rollback` is a generic parameterized Helm rollback helper despite its legacy name.

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -1,92 +1,278 @@
 # danielsmith.io on Sugarkube
 
-This is the canonical Sugarkube deployment model for `danielsmith.io`.
+Use this runbook for GHCR-first `danielsmith.io` deploys from published GitHub Actions artifacts to
+Sugarkube. The generic app recipes are the preferred future path; the `danielsmith-*` recipes are
+compatibility shims that stay documented until the generic flow has been exercised across routine
+releases.
 
-For the shared artifact, tag, chart, app-config, and planned generic command contract, see [Sugarkube app deployment contract](../app_deployment_contract.md).
+## 1. Artifact model
 
-## Topology and scope (static-site only)
+App repo responsibilities:
 
-`danielsmith.io` is a static Vite + Three.js site. Sugarkube runs only the static web container.
+- Build and publish the static-site image to GHCR.
+- Build and publish the Helm chart as an immutable OCI artifact.
+- Keep static-site build and chart release notes in the app repository.
 
-- **In-cluster (Sugarkube):** one static web deployment exposed through Traefik ingress.
-- **No in-cluster API/backend/database/queue/GPU/compute node/stateful service** is required.
-- **Public ingress path:** Cloudflare Tunnel fronts Traefik, and Traefik routes to the
-  `danielsmith` Kubernetes Service.
-- **Health/availability endpoints:** `/livez`, `/healthz`.
-- **Root page:** `/`.
+Sugarkube responsibilities:
 
-## Artifact model (canonical)
+- Select kubeconfig and environment.
+- Read `docs/examples/apps/danielsmith.env` or a copied local `apps/danielsmith.env`.
+- Run Helm deploys with the configured values overlays and chart version pin.
+- Verify Kubernetes status, public HTTPS paths, and logs.
 
-- Image: `ghcr.io/futuroptimist/danielsmith.io`
-- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
-- Helm release: `danielsmith`
-- Namespace: `danielsmith`
-- Chart version pin file: `docs/apps/danielsmith.version`
-- Production approved tag pin: `docs/apps/danielsmith.prod.tag`
+Cloudflare responsibilities:
 
-## Values model
+- DNS and Cloudflare Tunnel routes are configured outside Helm.
+- Route `staging.danielsmith.io` and `danielsmith.io` to Traefik before public HTTPS checks can
+  pass.
 
-- Base: `docs/examples/danielsmith.values.dev.yaml`
-- Staging overlay: `docs/examples/danielsmith.values.staging.yaml`
-- Production overlay: `docs/examples/danielsmith.values.prod.yaml`
+Current artifact contract:
 
-Default hosts:
+| Field | Value |
+| --- | --- |
+| Image | `ghcr.io/futuroptimist/danielsmith.io` |
+| Chart | `oci://ghcr.io/futuroptimist/charts/danielsmith` |
+| Release | `danielsmith` |
+| Namespace | `danielsmith` |
+| App config | `docs/examples/apps/danielsmith.env` |
+| Chart version pin | `docs/apps/danielsmith.version` |
+| Production tag pin | `docs/apps/danielsmith.prod.tag` |
+| Verify paths | `/`, `/livez`, `/healthz` |
 
-- Staging: `staging.danielsmith.io`
-- Production: `danielsmith.io`
+## 2. Environment topology
 
-## Core deployment commands
+Values overlays decide routing; image tags decide the static-site build.
 
-First install (or install-or-upgrade) with generic helper:
+| Environment | Sugarkube values chain | Public host |
+| --- | --- | --- |
+| `dev` | `docs/examples/danielsmith.values.dev.yaml` | Local/dev only unless overridden |
+| `staging` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml` | `staging.danielsmith.io` |
+| `prod` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml` | `danielsmith.io` |
+
+`danielsmith.io` is a static Vite and Three.js site. Sugarkube runs only the static web container;
+there is no in-cluster API, database, queue, GPU worker, or stateful service for this app.
+
+## 3. Find or publish GHCR image
+
+Find the successful image workflow run in the `danielsmith.io` app repo, then copy its immutable
+image tag. Prefer branch-SHA tags such as `main-REPLACE_SHORTSHA` or semver release tags. Do not
+deploy mutable tags such as `latest`, `main`, `staging`, or `prod` through the generic recipes.
 
 ```bash
-just kubeconfig-env staging
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
+APP_TAG=main-REPLACE_SHORTSHA
 ```
 
-Existing release upgrade with generic helper:
+Validate the tag shape locally before deploying:
 
 ```bash
-just kubeconfig-env staging
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
+python3 scripts/app_config.py validate-tag "$APP_TAG"
 ```
 
-Preferred environment wrapper:
+If no immutable image exists yet, publish one from the app repo's image workflow, then return here
+with the resulting GHCR tag. Local `docker build` commands are for app-repo development only, not
+Sugarkube staging or production deploys.
+
+## 4. Confirm/publish OCI chart
+
+Confirm Sugarkube can read the pinned chart version:
 
 ```bash
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
-just danielsmith-oci-deploy env=staging tag="$DANIELSMITH_TAG"
+CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.version | head -n1)
 ```
 
-## Validation commands
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$CHART_VERSION"
+```
+
+If the chart changed in the `danielsmith.io` app repo, publish a new immutable OCI chart there
+first and then update `docs/apps/danielsmith.version` in Sugarkube. If only the image changed, keep
+the chart version pin unchanged.
+
+## 5. Deploy staging
+
+Preferred generic deploy:
 
 ```bash
-kubectl -n danielsmith get deploy,po,svc,ingress
-kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
-curl -fsS https://staging.danielsmith.io/livez
-curl -fsS https://staging.danielsmith.io/healthz
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-deploy app=danielsmith env=staging tag="$APP_TAG"
+```
+
+Compatibility wrapper while the generic flow bakes in:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just danielsmith-oci-deploy env=staging tag="$APP_TAG"
+```
+
+## 6. Verify staging
+
+Generic HTTPS smoke checks from the app config:
+
+```bash
+just app-verify app=danielsmith env=staging
+```
+
+Kubernetes status with the generic app config:
+
+```bash
+just app-status app=danielsmith env=staging
+```
+
+Compatibility status/log helpers:
+
+```bash
+just danielsmith-status
+```
+
+```bash
+just danielsmith-debug-logs-env env=staging
+```
+
+Manual public checks when you need the exact commands:
+
+```bash
 curl -fsS https://staging.danielsmith.io/
 ```
 
-For production validation, use the same checks against `https://danielsmith.io`.
+```bash
+curl -fsS https://staging.danielsmith.io/livez
+```
 
-## Cloudflare Tunnel and ingress model
+```bash
+curl -fsS https://staging.danielsmith.io/healthz
+```
 
-Cloudflare Tunnel/DNS configuration is external to Helm.
+## 7. Promote production
 
-- Route hostnames to Traefik, typically
-  `http://traefik.kube-system.svc.cluster.local:80`.
-- Helm chart deployment does **not** create Cloudflare routes.
-- Configure staging and prod routes explicitly:
+Promote only the exact immutable tag that passed staging.
+
+Preferred generic production promotion:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-promote-prod app=danielsmith tag="$APP_TAG"
+```
+
+Compatibility wrapper:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just danielsmith-oci-promote-prod tag="$APP_TAG"
+```
+
+If `docs/apps/danielsmith.prod.tag` has already been reviewed and pinned to the approved tag, both
+production promotion recipes can read it when `tag=` is omitted. Passing `tag=` is still clearer for
+copy-pasteable release notes.
+
+## 8. Verify production
+
+Generic HTTPS smoke checks:
+
+```bash
+just app-verify app=danielsmith env=prod
+```
+
+Generic status:
+
+```bash
+just app-status app=danielsmith env=prod
+```
+
+Manual public checks:
+
+```bash
+curl -fsS https://danielsmith.io/
+```
+
+```bash
+curl -fsS https://danielsmith.io/livez
+```
+
+```bash
+curl -fsS https://danielsmith.io/healthz
+```
+
+## 9. Rollback
+
+Prefer immutable-tag rollback when the bad release maps to a single image tag:
+
+```bash
+PREVIOUS_TAG=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+```bash
+just app-deploy app=danielsmith env=prod tag="$PREVIOUS_TAG"
+```
+
+Use Helm revision rollback when you must restore the full rendered release state:
+
+```bash
+HELM_REVISION=12
+```
+
+```bash
+just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$HELM_REVISION"
+```
+
+`tokenplace-rollback` is a generic parameterized Helm rollback helper despite its legacy name.
+
+## 10. Troubleshooting
+
+GHCR auth failures usually look like `401`, `403`, or `denied`. Log in and retry the chart check:
+
+```bash
+helm registry login ghcr.io -u "$GHCR_USER"
+```
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$CHART_VERSION"
+```
+
+Check rendered app config before deploying:
+
+```bash
+just app-config app=danielsmith env=staging
+```
+
+Inspect cluster state and ingress routing:
+
+```bash
+just cluster-status
+```
+
+```bash
+just traefik-status
+```
+
+```bash
+just cf-tunnel-debug
+```
+
+Create or refresh Cloudflare Tunnel routes outside Helm when DNS is the blocker:
 
 ```bash
 just cf-tunnel-route host=staging.danielsmith.io
+```
+
+```bash
 just cf-tunnel-route host=danielsmith.io
 ```
 
-## Related runbooks
+## 11. App-specific notes
 
-- Staging runbook: [`docs/k3s-danielsmith-staging.md`](../k3s-danielsmith-staging.md)
-- Production runbook: [`docs/k3s-danielsmith-prod.md`](../k3s-danielsmith-prod.md)
+- `danielsmith.io` has no runtime secrets in the Sugarkube example overlays.
+- The primary app smoke checks are static page availability plus `/livez` and `/healthz`.
+- If the static-site chart changes without an image rebuild, bump only the chart version and keep
+  the last approved image tag.

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -1,204 +1,295 @@
-# democratized.space (dspace) on Sugarkube
+# democratized.space (DSPACE) on Sugarkube
 
-This guide covers **steady-state dspace operations** on Sugarkube: repeatable deploys,
-upgrades, promotions, and rollbacks using immutable image tags.
+Use this runbook for GHCR-first DSPACE deploys from published GitHub Actions artifacts to
+Sugarkube. The generic app recipes are the preferred future path; the `dspace-*` recipes are
+compatibility shims that stay documented until the generic flow has been exercised across routine
+releases.
 
-For the shared artifact, tag, chart, app-config, and planned generic command contract, see [Sugarkube app deployment contract](../app_deployment_contract.md).
+## 1. Artifact model
 
-The `justfile` exposes both:
+App repo responsibilities:
 
-- generic Helm OCI helpers (`helm-oci-install`, `helm-oci-upgrade`) for any app; and
-- dspace-specific helpers for immutable deploys and production promotion
-  (`dspace-oci-deploy`, `dspace-oci-promote-prod`, `dspace-oci-redeploy`).
+- Build and publish the application image to GHCR from the DSPACE repository.
+- Build and publish the Helm chart as an OCI artifact from the DSPACE repository.
+- Keep image tags immutable for release validation, promotion, and rollback.
 
-## Environment topology and values overlays
+Sugarkube responsibilities:
 
-dspace values are layered so base defaults stay separate from environment routing.
+- Select the kubeconfig/environment.
+- Read the app config from `docs/examples/apps/dspace.env` or a copied local `apps/dspace.env`.
+- Run Helm deploys with the configured values overlays and chart version pin.
+- Verify Kubernetes rollout state, public HTTPS paths, status, and logs.
 
-- `docs/examples/dspace.values.dev.yaml`: shared defaults, intended for future `env=dev`
-  deployments.
-- `docs/examples/dspace.values.staging.yaml`: staging ingress host/class overlay.
-- `docs/examples/dspace.values.prod.yaml`: production apex ingress overlay.
-- `docs/examples/dspace.values.prod-subdomain.yaml`: optional legacy subdomain overlay for
-  `prod.democratized.space` when a pre-apex host is explicitly needed.
+Cloudflare responsibilities:
 
-Current/target topology:
+- DNS and Cloudflare Tunnel routes are configured outside Helm.
+- Route DSPACE hostnames to Traefik before expecting public HTTPS verification to pass.
 
-- **staging (live, HA):** `env=staging` on `sugarkube3`, `sugarkube4`, `sugarkube5`,
-  public host `staging.democratized.space`.
-- **prod (live, HA):** `env=prod` on `sugarkube0`, `sugarkube1`, `sugarkube2`,
-  public host `democratized.space`.
-- **dev (planned, non-HA):** `env=dev` on `sugarkube6` (single-node future environment).
+Current artifact contract:
 
-Cloudflare Tunnel topology stays one tunnel per environment/cluster, with many hostnames routed to
-Traefik. For staging this means `staging.democratized.space` can share a tunnel with
-`staging.token.place`, and Traefik routes by HTTP `Host` header to the proper Ingress.
+| Field | Value |
+| --- | --- |
+| Image | `ghcr.io/democratizedspace/dspace` |
+| Chart | `oci://ghcr.io/democratizedspace/charts/dspace` |
+| Release | `dspace` |
+| Namespace | `dspace` |
+| App config | `docs/examples/apps/dspace.env` |
+| Chart version pin | `docs/apps/dspace.version` |
+| Production tag pin | `docs/apps/dspace.prod.tag` |
+| Verify paths | `/config.json`, `/healthz`, `/livez` |
 
-## Tagging model (evergreen releases)
+## 2. Environment topology
 
-Use tags by purpose:
+Values overlays decide routing; image tags decide the app build. Keep those concerns separate.
 
-- **Convenience/mutable tags** for fast iteration in non-prod (for example `main-latest`).
-- **Immutable deploy tags** for sign-off, promotion, and rollback (for example
-  `main-<shortsha>`, `3.0.1`, `3.1.0`).
-- In this operational guide, `main` is the normal integration line that produces
-  DSPACE-derived image tags (for example `main-<shortsha>`).
-- If the DSPACE repo uses release branches, keep them short-lived stabilization branches,
-  not long-lived environment branches.
-- Keep environment routing (`staging`, optional `prod.` subdomain, apex prod) separate from release
-  lineage; this guide stays main-first for steady-state operations.
+| Environment | Sugarkube values chain | Public host |
+| --- | --- | --- |
+| `dev` | `docs/examples/dspace.values.dev.yaml` | Local/dev only unless overridden |
+| `staging` | `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml` | `staging.democratized.space` |
+| `prod` | `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml` | `democratized.space` |
 
-Environment overlays (`dev`/`staging`/`prod`) decide host/routing. Image tags decide the
-release version. Keep those concerns separate.
+Optional production-preview routing exists at `prod.democratized.space` via
+`docs/examples/dspace.values.prod-subdomain.yaml`, but it is not part of the generic app config.
+Use it only when intentionally validating that legacy preview endpoint.
 
-## Quickstart
+## 3. Find or publish GHCR image
+
+Find the successful image workflow run in the DSPACE app repo, then copy its immutable tag. Prefer
+branch-SHA tags such as `main-REPLACE_SHORTSHA` or semver release tags. Do not deploy mutable tags
+such as `latest`, `main`, `staging`, or `prod` through the generic recipes.
 
 ```bash
-# Immutable staging deploy (recommended for release validation)
-just dspace-oci-deploy env=staging tag=main-<shortsha>
+APP_TAG=main-REPLACE_SHORTSHA
+```
 
-# Immutable production deploy (reads docs/apps/dspace.prod.tag if tag is omitted)
-just dspace-oci-promote-prod tag=3.1.0
+Validate the tag shape locally before deploying:
 
-# Optional prod subdomain endpoint (prod.democratized.space)
-just dspace-oci-deploy-prod-subdomain tag=main-<shortsha>
+```bash
+python3 scripts/app_config.py validate-tag "$APP_TAG"
+```
 
-# Check pods/ingress/status
+If no immutable image exists yet, publish one from the app repo's image workflow, then return here
+with the resulting GHCR tag. Local `docker build` commands are for app-repo development only, not
+Sugarkube staging or production deploys.
+
+## 4. Confirm/publish OCI chart
+
+Confirm Sugarkube can read the pinned chart version:
+
+```bash
+CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.version | head -n1)
+```
+
+```bash
+helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version "$CHART_VERSION"
+```
+
+If the chart changed in the DSPACE app repo, publish a new immutable OCI chart there first and then
+update `docs/apps/dspace.version` in Sugarkube. If only the image changed, keep the chart version
+pin unchanged.
+
+## 5. Deploy staging
+
+Preferred generic deploy:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-deploy app=dspace env=staging tag="$APP_TAG"
+```
+
+Compatibility wrapper while the generic flow bakes in:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just dspace-oci-deploy env=staging tag="$APP_TAG"
+```
+
+Lowest-level Helm helper examples remain available for debugging the wrappers, but they are not the
+preferred operator path:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just helm-oci-install release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.version tag="$APP_TAG"
+```
+
+```bash
+just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.version tag="$APP_TAG"
+```
+
+## 6. Verify staging
+
+Generic HTTPS smoke checks from the app config:
+
+```bash
+just app-verify app=dspace env=staging
+```
+
+Kubernetes status with the generic app config:
+
+```bash
+just app-status app=dspace env=staging
+```
+
+Compatibility status/log helpers:
+
+```bash
 just app-status namespace=dspace release=dspace
 ```
 
-## When to use each helper
-
-- `helm-oci-install`: install-or-upgrade path (uses `helm upgrade --install`), useful when a
-  release may not exist yet.
-- `helm-oci-upgrade`: upgrade-only path with `--reuse-values`, useful for routine bumps on an
-  existing release.
-- `dspace-oci-deploy`: opinionated dspace wrapper that requires an explicit immutable tag,
-  applies the correct values chain for `env=dev|staging|prod`, and waits for rollout.
-- `dspace-oci-promote-prod`: production convenience wrapper around
-  `dspace-oci-deploy env=prod`, reading `docs/apps/dspace.prod.tag` when `tag=` is omitted.
-- `dspace-oci-redeploy`: force-refresh path for already-deployed tags (especially mutable tags)
-  by running a Helm upgrade and rollout restart.
-
-## Generic Helm OCI examples
-
-If `helm pull`, `just helm-oci-install`, or `just helm-oci-upgrade` fails with GHCR `401`/`403`
-errors, use the canonical recovery steps in
-[Raspberry Pi Cluster Troubleshooting — Scenario 7](../raspi_cluster_troubleshooting.md#scenario-7-helm-oci-pull-fails-with-ghcr-403-denied-denied).
-
 ```bash
-# Install-or-upgrade staging with mutable convenience tag
-just helm-oci-install \
-  release=dspace namespace=dspace \
-  chart=oci://ghcr.io/democratizedspace/charts/dspace \
-  values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
-  version_file=docs/apps/dspace.version \
-  default_tag=main-latest
-
-# Upgrade staging to an immutable build
-just helm-oci-upgrade \
-  release=dspace namespace=dspace \
-  chart=oci://ghcr.io/democratizedspace/charts/dspace \
-  values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
-  version_file=docs/apps/dspace.version \
-  tag=main-<shortsha>
-
-# Upgrade prod directly to a signed-off immutable tag
-just helm-oci-upgrade \
-  release=dspace namespace=dspace \
-  chart=oci://ghcr.io/democratizedspace/charts/dspace \
-  values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml \
-  version_file=docs/apps/dspace.version \
-  tag=3.1.0
+just dspace-debug-logs-env env=staging
 ```
 
-Notes:
+Manual public checks when you need the exact commands:
 
-- `version_file=docs/apps/dspace.version` keeps chart version pinning centralized.
-- For prod, prefer immutable tags and persist the approved one in `docs/apps/dspace.prod.tag`.
-- `dspace-oci-deploy` rejects mutable tags (`latest`, `main`) by design.
+```bash
+curl -fsS https://staging.democratized.space/config.json | jq .
+```
 
-## Evergreen release/promotion flow
+```bash
+curl -fsS https://staging.democratized.space/healthz | jq .
+```
 
-1. Build and publish candidate image tags from `main` (for example `main-<shortsha>` plus
-   optional `main-latest`).
-2. Deploy immutable candidate to staging:
+```bash
+curl -fsS https://staging.democratized.space/livez | jq .
+```
 
-   ```bash
-   just dspace-oci-deploy env=staging tag=main-<shortsha>
-   ```
+## 7. Promote production
 
-3. Verify staging (`config.json`, `healthz`, `livez`) at
-   `https://staging.democratized.space`.
+Promote only the exact immutable tag that passed staging.
 
-   ```bash
-   curl -fsS https://staging.democratized.space/config.json | jq .
-   ```
+Preferred generic production promotion:
 
-   ```bash
-   curl -fsS https://staging.democratized.space/healthz | jq .
-   ```
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
 
-   ```bash
-   curl -fsS https://staging.democratized.space/livez | jq .
-   ```
+```bash
+just app-promote-prod app=dspace tag="$APP_TAG"
+```
 
-4. Promote the approved immutable tag to production apex:
+Compatibility wrapper:
 
-   ```bash
-   just dspace-oci-promote-prod tag=main-<shortsha>
-   # or semver tag once released
-   just dspace-oci-promote-prod tag=3.1.0
-   ```
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
 
-   Then verify production apex:
+```bash
+just dspace-oci-promote-prod tag="$APP_TAG"
+```
 
-   ```bash
-   curl -fsS https://democratized.space/config.json | jq .
-   ```
+If `docs/apps/dspace.prod.tag` has already been reviewed and pinned to the approved tag, both
+production promotion recipes can read it when `tag=` is omitted. Passing `tag=` is still clearer for
+copy-pasteable release notes.
 
-   ```bash
-   curl -fsS https://democratized.space/healthz | jq .
-   ```
+## 8. Verify production
 
-   ```bash
-   curl -fsS https://democratized.space/livez | jq .
-   ```
+Generic HTTPS smoke checks:
 
-5. Keep rollback simple by redeploying the prior immutable tag.
+```bash
+just app-verify app=dspace env=prod
+```
 
-Optional only: use `dspace-oci-deploy-prod-subdomain` when you explicitly need the
-`https://prod.democratized.space` subdomain before apex promotion. In steady state, this
-subdomain is typically a redirect to `https://democratized.space`, so it is not part of the
-default required deploy/promotion path.
+Generic status:
 
-## Networking via Cloudflare Tunnel
+```bash
+just app-status app=dspace env=prod
+```
 
-This guide assumes public ingress is exposed via Cloudflare Tunnel.
+Manual public checks:
 
-Typical hostnames:
+```bash
+curl -fsS https://democratized.space/config.json | jq .
+```
 
-- staging: `https://staging.democratized.space`
-- optional `prod.` subdomain (often redirect): `https://prod.democratized.space`
-- production apex: `https://democratized.space`
+```bash
+curl -fsS https://democratized.space/healthz | jq .
+```
 
-For tunnel and DNS setup details, see [Cloudflare Tunnel docs](../cloudflare_tunnel.md).
+```bash
+curl -fsS https://democratized.space/livez | jq .
+```
 
-## Troubleshooting
+## 9. Rollback
 
-- GHCR/OCI auth errors (`401 authentication required` or `403 denied: denied`) for
-  `helm pull`/`helm-oci-*` helpers:
-  [Raspberry Pi Cluster Troubleshooting — Scenario 7](../raspi_cluster_troubleshooting.md#scenario-7-helm-oci-pull-fails-with-ghcr-403-denied-denied).
-- Collect dspace + ingress logs with environment-aware helper:
+Prefer immutable-tag rollback when the bad release maps to a single image tag:
 
-  ```bash
-  just dspace-debug-logs-env env=staging
-  just dspace-debug-logs-env env=prod
-  ```
+```bash
+PREVIOUS_TAG=main-REPLACE_PREVIOUS_SHORTSHA
+```
 
-- Inspect Helm release state:
-  - `helm -n dspace status dspace`
-  - `helm -n dspace get values dspace`
-- Inspect Kubernetes objects:
-  - `kubectl -n dspace get ingress,pods,svc`
-  - `kubectl -n dspace describe ingress dspace`
+```bash
+just app-deploy app=dspace env=prod tag="$PREVIOUS_TAG"
+```
+
+Use Helm revision rollback when you must restore the full rendered release state:
+
+```bash
+HELM_REVISION=12
+```
+
+```bash
+just tokenplace-rollback release=dspace namespace=dspace revision="$HELM_REVISION"
+```
+
+`tokenplace-rollback` is a generic parameterized Helm rollback helper despite its legacy name.
+
+## 10. Troubleshooting
+
+GHCR auth failures usually look like `401`, `403`, or `denied`. Log in and retry the chart check:
+
+```bash
+helm registry login ghcr.io -u "$GHCR_USER"
+```
+
+```bash
+helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version "$CHART_VERSION"
+```
+
+Check rendered app config before deploying:
+
+```bash
+just app-config app=dspace env=staging
+```
+
+Inspect cluster state and ingress routing:
+
+```bash
+just cluster-status
+```
+
+```bash
+just traefik-status
+```
+
+```bash
+just cf-tunnel-debug
+```
+
+Create or refresh Cloudflare Tunnel routes outside Helm when DNS is the blocker:
+
+```bash
+just cf-tunnel-route host=staging.democratized.space
+```
+
+```bash
+just cf-tunnel-route host=democratized.space
+```
+
+## 11. App-specific notes
+
+- DSPACE keeps a mature release flow in its own repository; Sugarkube consumes the published image
+  and chart instead of rebuilding locally.
+- `dspace-oci-deploy-prod-subdomain` remains available for the optional
+  `prod.democratized.space` preview endpoint and is intentionally separate from the generic
+  `env=prod` apex promotion path.
+- Staging is the required sign-off environment before promoting `democratized.space`.

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -1,144 +1,285 @@
 # token.place on Sugarkube
 
-This is the canonical Sugarkube deployment model for token.place.
+Use this runbook for GHCR-first token.place deploys from published GitHub Actions artifacts to
+Sugarkube. The generic app recipes are the preferred future path; the `tokenplace-*` recipes are
+compatibility shims that stay documented until the generic flow has been exercised across routine
+releases.
 
-For the shared artifact, tag, chart, app-config, and planned generic command contract, see [Sugarkube app deployment contract](../app_deployment_contract.md).
+## 1. Artifact model
 
-For onboarding ownership and environment sequencing, see
-[`docs/tokenplace_sugarkube_onboarding.md`](../tokenplace_sugarkube_onboarding.md).
+App repo responsibilities:
 
-## Relay-only topology (current scope)
+- Build and publish the canonical relay image to GHCR.
+- Build and publish the token.place Helm chart as an immutable OCI artifact.
+- Preserve relay-blind E2EE behavior; relay diagnostics must expose safe routing metadata only.
 
-Sugarkube currently runs **only** the token.place relay service (`relay.py`).
+Sugarkube responsibilities:
 
-- **In-cluster (Sugarkube):** one relay deployment exposed through Traefik ingress.
-- **Out-of-cluster compute:** `server.py`, desktop Tauri app, Windows PCs, Apple Silicon Macs,
-  Raspberry Pi compute nodes, and other compute workers remain external.
-- **No in-cluster backend/GPU service** is required for steady-state relay operation.
-- **Single replica + single worker** defaults are intentional.
-- Relay state is currently **in-memory only**; pod restarts lose relay memory/state and this is
-  accepted for now.
-- Future in-memory database or multi-replica architecture is **out of scope** for this runbook.
+- Select kubeconfig and environment.
+- Read `docs/examples/apps/tokenplace.env` or a copied local `apps/tokenplace.env`.
+- Run Helm deploys with the configured values overlays and chart version pin.
+- Verify Kubernetes status, public HTTPS paths, and logs.
 
-## Artifact model (canonical)
+Cloudflare responsibilities:
 
-- Image: `ghcr.io/futuroptimist/tokenplace-relay`
-- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Helm release: `tokenplace`
-- Namespace: `tokenplace`
-- Chart version pin file: `docs/apps/tokenplace.version`
-- Production approved tag pin: `docs/apps/tokenplace.prod.tag`
+- DNS and Cloudflare Tunnel routes are configured outside Helm.
+- Route `staging.token.place` and `token.place` to Traefik before public HTTPS checks can pass.
 
-## Values model
+Current artifact contract:
 
-- Base: `docs/examples/tokenplace.values.dev.yaml`
-- Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
-- Production overlay: `docs/examples/tokenplace.values.prod.yaml`
+| Field | Value |
+| --- | --- |
+| Image | `ghcr.io/futuroptimist/tokenplace-relay` |
+| Chart | `oci://ghcr.io/futuroptimist/charts/tokenplace` |
+| Release | `tokenplace` |
+| Namespace | `tokenplace` |
+| App config | `docs/examples/apps/tokenplace.env` |
+| Chart version pin | `docs/apps/tokenplace.version` |
+| Production tag pin | `docs/apps/tokenplace.prod.tag` |
+| Verify paths | `/`, `/livez`, `/healthz`, `/relay/diagnostics` |
 
-Chart-owned runtime env defaults (worker count, frontend mode, relay upstream-health gating, and XDG `/tmp` paths) should remain in the token.place chart. Keep Sugarkube values focused on environment-specific keys like `TOKEN_PLACE_ENV`, `TOKENPLACE_RELAY_PUBLIC_URL`, ingress hosts, and TLS secrets.
+## 2. Environment topology
 
-Default hosts:
+Values overlays decide routing; image tags decide the relay build.
 
-- Staging: `staging.token.place`
-- Production: `token.place`
+| Environment | Sugarkube values chain | Public host |
+| --- | --- | --- |
+| `dev` | `docs/examples/tokenplace.values.dev.yaml` | Local/dev only unless overridden |
+| `staging` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml` | `staging.token.place` |
+| `prod` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml` | `token.place` |
 
-## Core deployment commands
+Cloudflare Tunnel routing is external to Helm. One environment tunnel can serve multiple app
+hostnames by routing all of them to Traefik and letting Kubernetes Ingress match on `Host`.
 
-Use concrete release/namespace/chart values for token.place relay deployments.
+## 3. Find or publish GHCR image
+
+Find the successful image workflow run in the token.place app repo, then copy its immutable relay
+image tag. Prefer branch-SHA tags such as `main-REPLACE_SHORTSHA` or semver release tags. Do not
+deploy mutable tags such as `latest`, `main`, `staging`, or `prod` through the generic recipes.
 
 ```bash
-just kubeconfig-env staging
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+Validate the tag shape locally before deploying:
+
+```bash
+python3 scripts/app_config.py validate-tag "$APP_TAG"
+```
+
+If no immutable image exists yet, publish one from the app repo's image workflow, then return here
+with the resulting GHCR tag. Local `docker build` commands are for app-repo development only, not
+Sugarkube staging or production deploys.
+
+## 4. Confirm/publish OCI chart
+
+Confirm Sugarkube can read the pinned chart version:
+
+```bash
+CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.version | head -n1)
 ```
 
 ```bash
-just kubeconfig-env staging
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$CHART_VERSION"
 ```
 
-Preferred env wrapper:
+If the chart changed in the token.place app repo, publish a new immutable OCI chart there first and
+then update `docs/apps/tokenplace.version` in Sugarkube. If only the image changed, keep the chart
+version pin unchanged.
+
+## 5. Deploy staging
+
+Preferred generic deploy:
 
 ```bash
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just tokenplace-oci-deploy env=staging tag="$TOKENPLACE_TAG"
+APP_TAG=main-REPLACE_SHORTSHA
 ```
 
-## Validation commands
+```bash
+just app-deploy app=tokenplace env=staging tag="$APP_TAG"
+```
+
+Compatibility wrapper while the generic flow bakes in:
 
 ```bash
-kubectl -n tokenplace get deploy,po,svc,ingress
-kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
-curl -fsS https://staging.token.place/livez
-curl -fsS https://staging.token.place/healthz
-curl -fsS https://staging.token.place/relay/diagnostics
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just tokenplace-oci-deploy env=staging tag="$APP_TAG"
+```
+
+## 6. Verify staging
+
+Generic HTTPS smoke checks from the app config:
+
+```bash
+just app-verify app=tokenplace env=staging
+```
+
+Kubernetes status with the generic app config:
+
+```bash
+just app-status app=tokenplace env=staging
+```
+
+Compatibility status/log helpers:
+
+```bash
+just tokenplace-status
+```
+
+```bash
+just tokenplace-debug-logs-env env=staging
+```
+
+Manual public checks when you need the exact commands:
+
+```bash
 curl -fsS https://staging.token.place/
 ```
 
-For production validation, use the same checks against `https://token.place`. Avoid long-running
-public `/healthz` watches as readiness monitors until health, liveness, metrics, diagnostics, and
-API v1 compute-node heartbeat routes are confirmed exempt from public API rate limits; prefer
-`kubectl -n tokenplace get endpoints`, `kubectl -n tokenplace get deploy,po`, relay logs, and
-low-frequency diagnostics curls for operational readiness. Staging/prod signoff also requires
-synthetic API v1 register/poll, an external desktop or compute-node registration, and an E2EE
-request/response through the relay; see the staging runbook for the full sequence and curl payloads.
-
-## Promotion blockers
-
-Use the environment runbooks for copy-paste commands, but keep this release-blocker rule in every
-token.place promotion review: **web/TLS health is not relay validation**. A build can only move from
-staging to production after all of these are true:
-
-- [ ] OCI chart freshness and chart digest are captured for the exact version being promoted.
-- [ ] Rendered manifests contain no duplicate env vars.
-- [ ] XDG writable `/tmp` env defaults are present from the chart, not one-off CLI overrides.
-- [ ] `/healthz` is exempt from API rate limiting.
-- [ ] Synthetic API v1 compute-node register/poll passes.
-- [ ] A desktop compute node uses the intended `knownServers`/server entry and registers.
-- [ ] The registered compute node appears in `/healthz` and `/relay/diagnostics`.
-- [ ] An E2EE request/response succeeds through that compute node.
-- [ ] The production Cloudflare route exists and points to Traefik before prod cutover.
-
-Emergency diagnostics and rollback remain environment-specific:
-
-- Staging: [`docs/k3s-tokenplace-staging.md`](../k3s-tokenplace-staging.md)
-- Production: [`docs/k3s-tokenplace-prod.md`](../k3s-tokenplace-prod.md)
-
-## Cloudflare and ingress model
-
-Cloudflare Tunnel/DNS configuration is external to Helm.
-
-- Route hostnames to Traefik, typically
-  `http://traefik.kube-system.svc.cluster.local:80`.
-- Helm chart deployment does **not** create Cloudflare routes.
-- One tunnel per environment can serve multiple app hostnames (for example
-  `staging.democratized.space` and `staging.token.place`) by routing both to Traefik.
-- Traefik chooses the correct Kubernetes Ingress by HTTP `Host` header.
-- Staging/prod overlays set `ingress.tls.enabled: true` so rendered Kubernetes Ingress includes `spec.tls`.
-- `cert-manager` and a compatible `ClusterIssuer` are assumed to already exist.
-- Cloudflare Tunnel routing (`cf-tunnel-route`) is separate from the Cloudflare DNS API token used
-  by cert-manager DNS-01.
-- Configure routes explicitly:
+```bash
+curl -fsS https://staging.token.place/livez
+```
 
 ```bash
-just cf-tunnel-route staging.token.place
+curl -fsS https://staging.token.place/healthz
+```
+
+```bash
+curl -fsS https://staging.token.place/relay/diagnostics | jq .
+```
+
+## 7. Promote production
+
+Promote only the exact immutable tag that passed staging.
+
+Preferred generic production promotion:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-promote-prod app=tokenplace tag="$APP_TAG"
+```
+
+Compatibility wrapper:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just tokenplace-oci-promote-prod tag="$APP_TAG"
+```
+
+If `docs/apps/tokenplace.prod.tag` has already been reviewed and pinned to the approved tag, both
+production promotion recipes can read it when `tag=` is omitted. Passing `tag=` is still clearer for
+copy-pasteable release notes.
+
+## 8. Verify production
+
+Generic HTTPS smoke checks:
+
+```bash
+just app-verify app=tokenplace env=prod
+```
+
+Generic status:
+
+```bash
+just app-status app=tokenplace env=prod
+```
+
+Manual public checks:
+
+```bash
+curl -fsS https://token.place/
+```
+
+```bash
+curl -fsS https://token.place/livez
+```
+
+```bash
+curl -fsS https://token.place/healthz
+```
+
+```bash
+curl -fsS https://token.place/relay/diagnostics | jq .
+```
+
+## 9. Rollback
+
+Prefer immutable-tag rollback when the bad release maps to a single image tag:
+
+```bash
+PREVIOUS_TAG=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+```bash
+just app-deploy app=tokenplace env=prod tag="$PREVIOUS_TAG"
+```
+
+Use Helm revision rollback when you must restore the full rendered release state:
+
+```bash
+HELM_REVISION=12
+```
+
+```bash
+just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$HELM_REVISION"
+```
+
+## 10. Troubleshooting
+
+GHCR auth failures usually look like `401`, `403`, or `denied`. Log in and retry the chart check:
+
+```bash
+helm registry login ghcr.io -u "$GHCR_USER"
+```
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$CHART_VERSION"
+```
+
+Check rendered app config before deploying:
+
+```bash
+just app-config app=tokenplace env=staging
+```
+
+Inspect cluster state and ingress routing:
+
+```bash
+just cluster-status
+```
+
+```bash
+just traefik-status
+```
+
+```bash
+just cf-tunnel-debug
+```
+
+Create or refresh Cloudflare Tunnel routes outside Helm when DNS is the blocker:
+
+```bash
 just cf-tunnel-route host=staging.token.place
-just cf-tunnel-route token.place
+```
+
+```bash
 just cf-tunnel-route host=token.place
 ```
 
-## Related runbooks
+## 11. App-specific notes
 
-- Relay-focused app guide: [`docs/apps/tokenplace-relay.md`](./tokenplace-relay.md)
-- Staging runbook: [`docs/k3s-tokenplace-staging.md`](../k3s-tokenplace-staging.md)
-- Production runbook: [`docs/k3s-tokenplace-prod.md`](../k3s-tokenplace-prod.md)
-
-
-## 0.1.0 release alignment
-
-- Chart version: `0.1.0`
-- Chart `appVersion`: `0.1.0`
-- Git tag: `v0.1.0`
-- Release image tag: `v0.1.0` (`ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
-- Staging candidate image tag: `main-<shortsha>`
+- token.place currently deploys the canonical relay image through the tokenplace chart.
+- Relay state, logs, and diagnostics must remain ciphertext-only plus safe routing metadata.
+- App-specific API v1 and relay smoke checks belong in the token.place app repo when they require
+  app fixtures; Sugarkube keeps generic HTTPS checks plus `/relay/diagnostics`.
+- The relay-focused legacy guide remains at `docs/apps/tokenplace-relay.md` for historical context,
+  but this page is the primary generic deployment runbook.

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,12 +43,14 @@ Review the safety notes before working with power components.
   and Helm OCI issues, including GHCR `401/403` chart pull failures
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
 - [projects-compose.md](projects-compose.md) — run token.place & dspace via docker compose
-- [app_deployment_contract.md](app_deployment_contract.md) — shared Sugarkube app artifact, tag, chart, config, and planned generic command contract
+- [app_deployment_contract.md](app_deployment_contract.md) — shared Sugarkube app artifact, tag, chart, config, and generic command contract
+- [app_onboarding.md](app_onboarding.md) — future-app onboarding checklist, app config template, and release decision tree
 - [tokenplace_sugarkube_onboarding.md](tokenplace_sugarkube_onboarding.md) — onboarding contract,
   ownership boundaries, and environment mapping for token.place on Sugarkube
-- [apps/tokenplace.md](apps/tokenplace.md) — token.place app topology and operations model on Sugarkube
-- [apps/tokenplace-relay.md](apps/tokenplace-relay.md) — relay-only token.place OCI staging/prod operations guide
-- [apps/danielsmith.md](apps/danielsmith.md) — danielsmith.io static-site topology and operations model on Sugarkube
+- [apps/dspace.md](apps/dspace.md) — DSPACE generic app deploy, verify, promote, rollback, and troubleshooting runbook
+- [apps/tokenplace.md](apps/tokenplace.md) — token.place generic app deploy, verify, promote, rollback, and troubleshooting runbook
+- [apps/tokenplace-relay.md](apps/tokenplace-relay.md) — relay-only token.place historical OCI staging/prod operations guide
+- [apps/danielsmith.md](apps/danielsmith.md) — danielsmith.io generic app deploy, verify, promote, rollback, and troubleshooting runbook
 - [k3s-tokenplace-dev.md](k3s-tokenplace-dev.md) — token.place dev runbook
 - [k3s-tokenplace-staging.md](k3s-tokenplace-staging.md) — token.place staging runbook
 - [k3s-tokenplace-prod.md](k3s-tokenplace-prod.md) — token.place production runbook

--- a/docs/k3s-danielsmith-prod.md
+++ b/docs/k3s-danielsmith-prod.md
@@ -1,110 +1,68 @@
-# k3s danielsmith.io runbook (prod)
+# k3s danielsmith.io runbook (production)
 
-Use this runbook for production deployments of the static `danielsmith.io` site on Sugarkube.
+This environment-specific page is a thin production checklist. Use the canonical generic flow in
+[`docs/apps/danielsmith.md`](apps/danielsmith.md) for the full artifact model, chart checks,
+verification, rollback, and troubleshooting details.
 
-## Topology and scope
+## Production promotion
 
-- `danielsmith.io` is a static Vite + Three.js workload.
-- Sugarkube runs only the static web container.
-- No in-cluster API/backend/database/queue/GPU/compute node/stateful service is required.
-- Cloudflare Tunnel fronts Traefik; Traefik routes traffic to the `danielsmith` Service.
-- Probe/application endpoints: `/livez`, `/healthz`, and `/`.
-
-## Artifact and values contract
-
-- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
-- Image: `ghcr.io/futuroptimist/danielsmith.io`
-- Release: `danielsmith`
-- Namespace: `danielsmith`
-- Version pin file: `docs/apps/danielsmith.version`
-- Approved prod tag file: `docs/apps/danielsmith.prod.tag`
-- Values: `docs/examples/danielsmith.values.dev.yaml` + `docs/examples/danielsmith.values.prod.yaml`
-- Default production host: `danielsmith.io`
-
-## First install
-
-Always select the production kube context before running the generic Helm install command.
+Promote only the immutable tag that passed staging.
 
 ```bash
-just kubeconfig-env prod
-DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the approved immutable GHCR image tag
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_APPROVED_TAG"
+APP_TAG=main-REPLACE_SHORTSHA
 ```
 
-## Promotion after staging sign-off
-
 ```bash
-DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the approved immutable GHCR image tag
-just danielsmith-oci-promote-prod tag="$DANIELSMITH_APPROVED_TAG"
+just app-promote-prod app=danielsmith tag="$APP_TAG"
 ```
 
-## Generic production upgrade
+Compatibility shim while generic app recipes are exercised across routine releases:
 
 ```bash
-just kubeconfig-env prod
-DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the approved immutable GHCR image tag
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_APPROVED_TAG"
+APP_TAG=main-REPLACE_SHORTSHA
 ```
 
-## Validation
+```bash
+just danielsmith-oci-promote-prod tag="$APP_TAG"
+```
+
+## Production verify
 
 ```bash
-kubectl -n danielsmith get deploy,po,svc,ingress
-kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
-curl -fsS https://danielsmith.io/livez
+just app-verify app=danielsmith env=prod
+```
+
+```bash
+just app-status app=danielsmith env=prod
+```
+
+```bash
 curl -fsS https://danielsmith.io/healthz
-curl -fsS https://danielsmith.io/
 ```
 
-## Rollback options
-
-Rollback by immutable tag:
+## Production rollback
 
 ```bash
-just kubeconfig-env prod
-DANIELSMITH_PREVIOUS_APPROVED_TAG=main-REPLACE_PREVIOUS_APPROVED_SHORTSHA # replace with the previous approved immutable GHCR image tag
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_PREVIOUS_APPROVED_TAG"
+PREVIOUS_TAG=main-REPLACE_PREVIOUS_SHORTSHA
 ```
-
-Rollback by Helm revision:
-
-`tokenplace-rollback` is the repository's existing parameterized Helm rollback helper, even though the recipe name is token.place-scoped.
 
 ```bash
-just kubeconfig-env prod
-DANIELSMITH_REVISION=12 # replace with the known-good Helm revision
-just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$DANIELSMITH_REVISION"
+just app-deploy app=danielsmith env=prod tag="$PREVIOUS_TAG"
 ```
 
-## Cloudflare tunnel routing (external to Helm)
+```bash
+HELM_REVISION=12
+```
 
-Cloudflare routes are configured outside the chart. Route `danielsmith.io` to Traefik,
-typically `http://traefik.kube-system.svc.cluster.local:80`.
+```bash
+just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$HELM_REVISION"
+```
+
+## Cloudflare route
+
+Cloudflare Tunnel routing is outside Helm. Route production traffic to Traefik before expecting
+public HTTPS checks to pass.
 
 ```bash
 just cf-tunnel-route host=danielsmith.io
-```
-
-## Troubleshooting
-
-GHCR auth/chart checks:
-
-```bash
-echo "$GHCR_TOKEN" | helm registry login ghcr.io -u "$GHCR_USER" --password-stdin
-helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/danielsmith.version | head -n1)"
-```
-
-App status/logs:
-
-```bash
-just danielsmith-status
-just danielsmith-debug-logs-env env=prod
-```
-
-Ingress/tunnel checks:
-
-```bash
-just cluster-status
-just traefik-status
-just cf-tunnel-debug
 ```

--- a/docs/k3s-danielsmith-staging.md
+++ b/docs/k3s-danielsmith-staging.md
@@ -1,107 +1,68 @@
 # k3s danielsmith.io runbook (staging)
 
-Use this runbook for staging deployments of the static `danielsmith.io` site on Sugarkube.
+This environment-specific page is a thin staging checklist. Use the canonical generic flow in
+[`docs/apps/danielsmith.md`](apps/danielsmith.md) for the full artifact model, chart checks,
+verification, rollback, and troubleshooting details.
 
-## Topology and scope
+## Staging deploy
 
-- `danielsmith.io` is a static Vite + Three.js workload.
-- Sugarkube runs only the static web container.
-- No in-cluster API/backend/database/queue/GPU/compute node/stateful service is required.
-- Cloudflare Tunnel fronts Traefik; Traefik routes traffic to the `danielsmith` Service.
-- Probe/application endpoints: `/livez`, `/healthz`, and `/`.
-
-## Artifact and values contract
-
-- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
-- Image: `ghcr.io/futuroptimist/danielsmith.io`
-- Release: `danielsmith`
-- Namespace: `danielsmith`
-- Version pin file: `docs/apps/danielsmith.version`
-- Values: `docs/examples/danielsmith.values.dev.yaml` + `docs/examples/danielsmith.values.staging.yaml`
-- Default staging host: `staging.danielsmith.io`
-
-## First install
+Preferred generic deploy:
 
 ```bash
-just kubeconfig-env staging
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
+APP_TAG=main-REPLACE_SHORTSHA
 ```
 
-## Existing release upgrade
-
 ```bash
-just kubeconfig-env staging
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
+just app-deploy app=danielsmith env=staging tag="$APP_TAG"
 ```
 
-Preferred wrapper:
+Compatibility shim while generic app recipes are exercised across routine releases:
 
 ```bash
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
-just danielsmith-oci-deploy env=staging tag="$DANIELSMITH_TAG"
+APP_TAG=main-REPLACE_SHORTSHA
 ```
 
-## Validation
+```bash
+just danielsmith-oci-deploy env=staging tag="$APP_TAG"
+```
+
+## Staging verify
 
 ```bash
-kubectl -n danielsmith get deploy,po,svc,ingress
-kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
-curl -fsS https://staging.danielsmith.io/livez
+just app-verify app=danielsmith env=staging
+```
+
+```bash
+just app-status app=danielsmith env=staging
+```
+
+```bash
 curl -fsS https://staging.danielsmith.io/healthz
-curl -fsS https://staging.danielsmith.io/
 ```
 
-## Rollback
-
-Rollback by immutable tag:
+## Staging rollback
 
 ```bash
-just kubeconfig-env staging
-DANIELSMITH_PREVIOUS_TAG=main-REPLACE_PREVIOUS_SHORTSHA # replace with the previous immutable GHCR image tag
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_PREVIOUS_TAG"
+PREVIOUS_TAG=main-REPLACE_PREVIOUS_SHORTSHA
 ```
-
-Rollback by Helm revision:
-
-`tokenplace-rollback` is the repository's existing parameterized Helm rollback helper, even though the recipe name is token.place-scoped.
 
 ```bash
-just kubeconfig-env staging
-DANIELSMITH_REVISION=12 # replace with the known-good Helm revision
-just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$DANIELSMITH_REVISION"
+just app-deploy app=danielsmith env=staging tag="$PREVIOUS_TAG"
 ```
 
-## Cloudflare tunnel routing (external to Helm)
+```bash
+HELM_REVISION=12
+```
 
-Cloudflare routes are configured outside the chart. Route `staging.danielsmith.io` to Traefik,
-typically `http://traefik.kube-system.svc.cluster.local:80`.
+```bash
+just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$HELM_REVISION"
+```
+
+## Cloudflare route
+
+Cloudflare Tunnel routing is outside Helm. Route staging traffic to Traefik before expecting public
+HTTPS checks to pass.
 
 ```bash
 just cf-tunnel-route host=staging.danielsmith.io
-```
-
-## Troubleshooting
-
-GHCR auth/chart checks:
-
-```bash
-echo "$GHCR_TOKEN" | helm registry login ghcr.io -u "$GHCR_USER" --password-stdin
-helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/danielsmith.version | head -n1)"
-```
-
-App status/logs:
-
-```bash
-just danielsmith-status
-just danielsmith-debug-logs-env env=staging
-```
-
-Ingress/tunnel checks:
-
-```bash
-just cluster-status
-just traefik-status
-just cf-tunnel-debug
 ```

--- a/docs/k3s-tokenplace-dev.md
+++ b/docs/k3s-tokenplace-dev.md
@@ -1,70 +1,44 @@
 # k3s token.place runbook (dev)
 
-Use this runbook for `dev` token.place deployments on Sugarkube.
+Use dev for local cluster experiments only. Staging and production releases should follow the
+GHCR-first generic flow in [`docs/apps/tokenplace.md`](apps/tokenplace.md).
 
-## Purpose
-
-- Fast feedback for onboarding and integration changes.
-- Validate chart wiring and values layering before staging.
-
-## Topology intent (dev)
-
-- Sugarkube hosts ingress/API-facing token.place components.
-- External compute handles heavy runtime jobs.
-- Routing and upstream credentials are dev-scoped.
-
-## Prerequisites
-
-- `kubectl`, `helm`, and `just` installed.
-- Kubeconfig points to the dev environment cluster/context.
-- token.place chart + image tag available.
-- Dev values files prepared.
-
-## Deploy / upgrade / rollback
+## Dev deploy
 
 ```bash
-just tokenplace-deploy \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<dev-values> version_file=<optional-version-file> \
-  tag=<tag>
+APP_TAG=main-REPLACE_SHORTSHA
 ```
 
 ```bash
-just tokenplace-upgrade \
-  release=<release> namespace=<namespace> chart=<chart-ref> \
-  values=<base-values>,<dev-values> version_file=<optional-version-file> \
-  tag=<tag>
+just app-deploy app=tokenplace env=dev tag="$APP_TAG"
+```
+
+Compatibility shim:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
 ```
 
 ```bash
-just tokenplace-rollback release=<release> namespace=<namespace> revision=<helm-revision>
+just tokenplace-oci-deploy env=dev tag="$APP_TAG"
 ```
 
-## Validation
+## Dev verify
 
 ```bash
-just tokenplace-status namespace=<namespace> release=<release>
-just tokenplace-validate namespace=<namespace> release=<release> health_url=https://<dev-host>/<health>
+just app-verify app=tokenplace env=dev
 ```
 
 ```bash
-just tokenplace-logs namespace=<namespace> selector=<label-selector>
+just app-status app=tokenplace env=dev
 ```
 
-## Local verification helper
+## Dev rollback
 
 ```bash
-just tokenplace-port-forward namespace=<namespace> service=<service> local_port=8080 remote_port=80
-curl -fsS http://127.0.0.1:8080/<health>
+PREVIOUS_TAG=main-REPLACE_PREVIOUS_SHORTSHA
 ```
 
-## Ingress / Cloudflare expectations
-
-- Dev hostname should be isolated from staging/prod.
-- Cloudflare tunnel/DNS should target Traefik for dev hostnames.
-- TLS secrets should not be shared across environments.
-
-## Notes
-
-- Dev may tolerate mutable convenience tags, but staging/prod should prefer immutable tags.
-- Keep compute-node endpoint and auth config explicitly dev-scoped.
+```bash
+just app-deploy app=tokenplace env=dev tag="$PREVIOUS_TAG"
+```

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -1,293 +1,68 @@
-# k3s token.place runbook (prod)
+# k3s token.place runbook (production)
 
-Use this runbook for relay-only token.place production deployments on Sugarkube.
+This environment-specific page is a thin production checklist. Use the canonical generic flow in
+[`docs/apps/tokenplace.md`](apps/tokenplace.md) for the full artifact model, chart checks,
+verification, rollback, and troubleshooting details.
 
-## Topology and scope
+## Production promotion
 
-- Sugarkube runs only token.place relay (`relay.py`).
-- No in-cluster backend/GPU service is required.
-- Compute nodes remain external (`server.py`, Tauri desktop app, Windows PCs, Apple Silicon Macs,
-  Raspberry Pi compute nodes, etc.).
-- Runtime model is single replica + single Gunicorn worker + in-memory state; verify the rendered Kubernetes Deployment contract includes `spec.strategy.type: Recreate` before rollout.
-- In-memory state loss on pod restart is accepted for now.
-
-## Artifact and values contract
-
-- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Image: `ghcr.io/futuroptimist/tokenplace-relay`
-- Release: `tokenplace`
-- Namespace: `tokenplace`
-- Version pin file: `docs/apps/tokenplace.version`
-- Approved prod tag file: `docs/apps/tokenplace.prod.tag`
-- Values: `docs/examples/tokenplace.values.dev.yaml` + `docs/examples/tokenplace.values.prod.yaml`
-- Default production host: `token.place`
-
-## Pre-flight (before Step 1)
-
-- Verify `docs/apps/tokenplace.version` remains pinned to `0.1.0`.
-- Verify the `0.1.0` OCI chart exists only after token.place publishes the current chart.
-- If `helm show chart ... --version 0.1.0` succeeds before the final token.place chart publish, confirm the chart is not stale before deploying.
+Promote only the immutable tag that passed staging.
 
 ```bash
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+APP_TAG=main-REPLACE_SHORTSHA
 ```
 
-## Promotion after staging sign-off
-
-Production promotion requires an external desktop or compute-node registration plus a successful
-E2EE request/response; Certificate `Ready=True`, web/TLS checks, or synthetic register/poll alone
-are not sufficient signoff.
-
 ```bash
-TOKENPLACE_TAG=v0.1.0 # use final release tag after token.place Git tag push
-just tokenplace-oci-promote-prod tag="$TOKENPLACE_TAG"
+just app-promote-prod app=tokenplace tag="$APP_TAG"
 ```
 
-## Generic production upgrade
-
-Select the production kube context first (or use the wrapper above):
+Compatibility shim while generic app recipes are exercised across routine releases:
 
 ```bash
-just kubeconfig-env prod
+APP_TAG=main-REPLACE_SHORTSHA
 ```
 
-Then run the generic OCI helper:
-
 ```bash
-TOKENPLACE_TAG=v0.1.0 # use final release tag after token.place Git tag push
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+just tokenplace-oci-promote-prod tag="$APP_TAG"
 ```
 
-## Validation
-
-Render/contract checks:
+## Production verify
 
 ```bash
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
-helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.prod.yaml --set image.tag=v0.1.0 > /tmp/tokenplace-prod-render.yaml
-python3 - <<'PY'
-import collections
-import sys
-
-try:
-    import yaml
-except ModuleNotFoundError:
-    sys.exit("PyYAML is required for this render validation. Install it with: python3 -m pip install PyYAML")
-
-with open("/tmp/tokenplace-prod-render.yaml", encoding="utf-8") as rendered:
-    docs = list(yaml.safe_load_all(rendered))
-
-try:
-    deploy = next(
-        d
-        for d in docs
-        if d and d.get("kind") == "Deployment" and d.get("metadata", {}).get("name") == "tokenplace"
-    )
-except StopIteration:
-    sys.exit("tokenplace Deployment not found in rendered manifest")
-
-pod_spec = deploy["spec"]["template"]["spec"]
-for container_type, containers in (
-    ("init", pod_spec.get("initContainers", [])),
-    ("app", pod_spec.get("containers", [])),
-):
-    for container in containers:
-        names = [item["name"] for item in container.get("env", []) if "name" in item]
-        dupes = [name for name, count in collections.Counter(names).items() if count > 1]
-        if dupes:
-            sys.exit(f"duplicate env names found: {container_type}:{container.get('name', '<unnamed>')}: {dupes}")
-PY
-grep -n "spec:" -A40 /tmp/tokenplace-prod-render.yaml | grep -n "tls"
-grep -n "token.place" /tmp/tokenplace-prod-render.yaml
-grep -n "tokenplace-prod-tls" /tmp/tokenplace-prod-render.yaml
-yq eval '. | select(.kind == "Deployment" and .metadata.name == "tokenplace") | .spec.strategy.type' /tmp/tokenplace-prod-render.yaml
+just app-verify app=tokenplace env=prod
 ```
 
-Cluster/runtime checks:
-
 ```bash
-kubectl -n tokenplace get deploy,po,svc,ingress
-kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
-kubectl -n tokenplace get ingress tokenplace -o yaml
-curl -vI https://token.place/
-curl -fsS https://token.place/livez
-curl -fsS https://token.place/healthz
+just app-status app=tokenplace env=prod
 ```
 
-## Promotion blockers
-
-> **Release blocker:** production promotion is blocked until staging proves the actual
-> relay-compute path, and the promoted production deployment then proves its own prod
-> compute-node path. Deployment Ready, TLS Ready, `/livez`, `/healthz`, `/`, `/metrics`, and
-> synthetic register/poll are necessary but not sufficient by themselves.
-
-Before running the prod upgrade, confirm every item from staging sign-off evidence:
-
-- [ ] OCI chart freshness is proven with `helm show chart` plus chart digest evidence for the
-  exact chart version being promoted from staging to prod.
-- [ ] Render validation finds no duplicate environment variables in any init/app container.
-- [ ] Rendered Deployment includes writable XDG `/tmp` defaults from the chart without one-off
-  Sugarkube override drift.
-- [ ] Staging `/healthz` is exempt from token.place global API rate limits.
-- [ ] Synthetic API v1 compute-node register/poll passes against `https://staging.token.place`.
-- [ ] A desktop compute node has `staging.token.place` in `knownServers`/server config, registers
-  to staging, appears in staging `/healthz` and `/relay/diagnostics`, and completes an E2EE
-  request/response through the staging relay.
-- [ ] The prod Cloudflare route for `token.place` is configured to Traefik and checked outside
-  Helm/cert-manager before promotion.
-
-After the prod upgrade, capture separate prod validation evidence before marking the promotion
-complete:
-
-- [ ] Synthetic API v1 compute-node register/poll passes against `https://token.place`.
-- [ ] A desktop compute node has `token.place` in `knownServers`/server config, registers to prod,
-  and does not silently fall back to staging.
-- [ ] That prod-registered compute node appears in prod `/healthz` and `/relay/diagnostics`.
-- [ ] An E2EE request/response succeeds through the prod-registered compute node.
-
-### Release evidence capture
-
-Capture and attach the staging sign-off artifacts plus this separate prod evidence for the prod
-promotion record. For the prod evidence, run the prod synthetic register/poll, confirm prod
-desktop compute-node registration, and complete the prod E2EE request/response before saving
-`/healthz`, `/relay/diagnostics`, or relay logs so those artifacts prove the prod-registered
-desktop compute node is visible after the real prod relay-compute path passes:
-
 ```bash
-just kubeconfig-env prod
-TOKENPLACE_TAG=v0.1.0 # replace with the immutable release tag
-TOKENPLACE_HOST=token.place
-TOKENPLACE_CHART_VERSION="$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
-
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$TOKENPLACE_CHART_VERSION"
-helm pull oci://ghcr.io/futuroptimist/charts/tokenplace --version "$TOKENPLACE_CHART_VERSION" --destination /tmp
-sha256sum "/tmp/tokenplace-${TOKENPLACE_CHART_VERSION}.tgz" # chart digest evidence
-printf 'image tag: ghcr.io/futuroptimist/tokenplace-relay:%s\n' "$TOKENPLACE_TAG"
-kubectl -n tokenplace get deploy tokenplace -o yaml > /tmp/tokenplace-prod-deployment.yaml
-# First run synthetic register/poll, desktop compute-node registration, and the E2EE flow.
-# Then capture health, diagnostics, and relay logs as post-compute-path evidence:
-curl -fsS "https://${TOKENPLACE_HOST}/healthz" | tee /tmp/tokenplace-prod-healthz.json
-curl -fsS "https://${TOKENPLACE_HOST}/relay/diagnostics" | tee /tmp/tokenplace-prod-diagnostics.json
-kubectl -n tokenplace logs deploy/tokenplace --since=30m --tail=500 | tee /tmp/tokenplace-prod-relay-after-compute.log
+curl -fsS https://token.place/relay/diagnostics | jq .
 ```
 
-### Emergency diagnostics
-
-This emergency diagnostics command block is copy-pasteable. Run it when prod web/TLS health is green but compute registration or E2EE is blocked:
+## Production rollback
 
 ```bash
-just kubeconfig-env prod
-TOKENPLACE_HOST=token.place
-
-kubectl -n tokenplace get deployments,replicasets,pods,services,ingress,certificates -o wide
-kubectl -n tokenplace describe deploy/tokenplace
-kubectl -n tokenplace describe ingress/tokenplace
-kubectl -n tokenplace get events --sort-by=.lastTimestamp | tail -n 80
-kubectl -n tokenplace logs deploy/tokenplace --since=30m --tail=500
-kubectl -n tokenplace logs deploy/tokenplace --previous --tail=500 || true
-curl -vI "https://${TOKENPLACE_HOST}/"
-curl -fsS "https://${TOKENPLACE_HOST}/healthz" || true
-curl -fsS "https://${TOKENPLACE_HOST}/relay/diagnostics" || true
-just cf-tunnel-debug
-just cert-manager-status
+PREVIOUS_TAG=main-REPLACE_PREVIOUS_SHORTSHA
 ```
 
-If Cloudflare returns HTTP 403 before the request reaches token.place, check Cloudflare Security
-Events for the hostname, ray ID, source IP, path, and rule that made the decision.
-
-## Rollback options
-
-Rollback reminders:
-
-- Prefer immutable image tag rollback when the bad rollout is tied to a single image.
-- Use Helm revision rollback when you need to restore the entire rendered release state.
-- Expect a short outage during rollback because token.place is intentionally single-replica and
-  the Deployment strategy is `Recreate`; wait for the replacement pod before retesting relay E2EE.
-
-Rollback by immutable tag:
-
 ```bash
-just kubeconfig-env prod
-TOKENPLACE_PREVIOUS_TAG=main-deadbee # replace with the prior immutable tag
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_PREVIOUS_TAG"
+just app-deploy app=tokenplace env=prod tag="$PREVIOUS_TAG"
 ```
 
-Rollback by Helm revision:
-
 ```bash
-just kubeconfig-env prod
-TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
-just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
+HELM_REVISION=12
 ```
 
-## Cloudflare tunnel routing (external to Helm)
+```bash
+just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$HELM_REVISION"
+```
 
-Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes. Route `token.place` to Traefik,
-typically `http://traefik.kube-system.svc.cluster.local:80`. Production overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
-and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
-One tunnel per environment can carry multiple app hostnames by routing them all to Traefik, with
-Traefik selecting the target backend by `Host` header.
+## Cloudflare route
 
-`cf-tunnel-route` configures Cloudflare Tunnel hostname routing. It does not configure the
-cert-manager Cloudflare DNS token used for ACME DNS-01.
+Cloudflare Tunnel routing is outside Helm. Route production traffic to Traefik before expecting
+public HTTPS checks to pass.
 
 ```bash
-just cf-tunnel-route token.place
 just cf-tunnel-route host=token.place
 ```
-
-## cert-manager + Cloudflare DNS-01 (non-Flux clusters)
-
-For non-Flux production clusters, use the same manual Helm + issuer flow validated during staging:
-
-```bash
-just cert-manager-install
-just cert-manager-cloudflare-token-secret token="$CF_DNS_API_TOKEN"
-just cert-manager-issuers-apply email="ops@token.place"
-just cert-manager-status
-```
-
-Do not reuse the tunnel token (`CF_TUNNEL_TOKEN`) for DNS-01. cert-manager needs a separate Cloudflare DNS API token scoped to:
-
-- `Zone -> DNS -> Edit`
-- `Zone -> Zone -> Read`
-- specific required zones (`token.place`, and `democratized.space` if shared issuance is in scope).
-
-For production promotion, the cert-manager release gate is the Certificate condition: proceed only
-when the relevant Certificate is `Ready=True`. Challenge cleanup errors after successful issuance do
-not invalidate an already-ready certificate, but they should be investigated because they often mean
-the DNS API token lacks `Zone -> Zone -> Read`, is scoped to the wrong Cloudflare zone, or cert-manager
-is hitting resolver/zone lookup ambiguity during cleanup.
-
-## Troubleshooting
-
-GHCR auth/chart checks:
-
-```bash
-echo "$GHCR_TOKEN" | helm registry login ghcr.io -u "$GHCR_USER" --password-stdin
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
-```
-
-App status/logs:
-
-```bash
-just tokenplace-status
-just tokenplace-debug-logs-env env=prod
-```
-
-Ingress/tunnel checks:
-
-```bash
-just cluster-status
-just traefik-status
-just cf-tunnel-debug
-```
-
-
-## 0.1.0 release alignment
-
-- OCI chart package version: `0.1.0`
-- Chart `appVersion`: `0.1.0`
-- token.place Git tag: `v0.1.0`
-- Release image tag after final tag push: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
-- Staging candidate tag before final tag push: `main-<shortsha>`

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -1,321 +1,68 @@
 # k3s token.place runbook (staging)
 
-Use this runbook for relay-only token.place staging deployments on Sugarkube.
+This environment-specific page is a thin staging checklist. Use the canonical generic flow in
+[`docs/apps/tokenplace.md`](apps/tokenplace.md) for the full artifact model, chart checks,
+verification, rollback, and troubleshooting details.
 
-## Topology and scope
+## Staging deploy
 
-- Sugarkube runs only token.place relay (`relay.py`).
-- No in-cluster backend/GPU service is required.
-- Compute nodes remain external (`server.py`, Tauri desktop app, Windows PCs, Apple Silicon Macs,
-  Raspberry Pi compute nodes, etc.).
-- Runtime model is single replica + single Gunicorn worker + in-memory state; verify the rendered Kubernetes Deployment contract includes `spec.strategy.type: Recreate` before rollout.
-- In-memory state loss on pod restart is accepted for now.
-
-## Artifact and values contract
-
-- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Image: `ghcr.io/futuroptimist/tokenplace-relay`
-- Release: `tokenplace`
-- Namespace: `tokenplace`
-- Version pin file: `docs/apps/tokenplace.version`
-- Values: `docs/examples/tokenplace.values.dev.yaml` + `docs/examples/tokenplace.values.staging.yaml`
-- Default staging host: `staging.token.place`
-
-
-## Pre-flight (before Step 1)
-
-- Verify `docs/apps/tokenplace.version` remains pinned to `0.1.0`.
-- Verify the `0.1.0` OCI chart exists only after token.place publishes the current chart.
-- If `helm show chart ... --version 0.1.0` succeeds before the final token.place chart publish, confirm the chart is not stale before deploying.
+Preferred generic deploy:
 
 ```bash
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+APP_TAG=main-REPLACE_SHORTSHA
 ```
 
-## First install
-
 ```bash
-just kubeconfig-env staging
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+just app-deploy app=tokenplace env=staging tag="$APP_TAG"
 ```
 
-## Existing release upgrade
+Compatibility shim while generic app recipes are exercised across routine releases:
 
 ```bash
-just kubeconfig-env staging
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+APP_TAG=main-REPLACE_SHORTSHA
 ```
 
-Preferred wrapper:
-
 ```bash
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just tokenplace-oci-deploy env=staging tag="$TOKENPLACE_TAG"
+just tokenplace-oci-deploy env=staging tag="$APP_TAG"
 ```
 
-## Validation
-
-Render/contract checks (use immutable staging candidate tag):
+## Staging verify
 
 ```bash
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
-helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.staging.yaml --set image.tag=main-deadbee > /tmp/tokenplace-staging-render.yaml
-python3 - <<'PY'
-import collections
-import sys
-
-try:
-    import yaml
-except ModuleNotFoundError:
-    sys.exit("PyYAML is required for this render validation. Install it with: python3 -m pip install PyYAML")
-
-with open("/tmp/tokenplace-staging-render.yaml", encoding="utf-8") as rendered:
-    docs = list(yaml.safe_load_all(rendered))
-
-try:
-    deploy = next(
-        d
-        for d in docs
-        if d and d.get("kind") == "Deployment" and d.get("metadata", {}).get("name") == "tokenplace"
-    )
-except StopIteration:
-    sys.exit("tokenplace Deployment not found in rendered manifest")
-
-pod_spec = deploy["spec"]["template"]["spec"]
-for container_type, containers in (
-    ("init", pod_spec.get("initContainers", [])),
-    ("app", pod_spec.get("containers", [])),
-):
-    for container in containers:
-        names = [item["name"] for item in container.get("env", []) if "name" in item]
-        dupes = [name for name, count in collections.Counter(names).items() if count > 1]
-        if dupes:
-            sys.exit(f"duplicate env names found: {container_type}:{container.get('name', '<unnamed>')}: {dupes}")
-PY
-grep -n "spec:" -A40 /tmp/tokenplace-staging-render.yaml | grep -n "tls"
-grep -n "staging.token.place" /tmp/tokenplace-staging-render.yaml
-grep -n "tokenplace-staging-tls" /tmp/tokenplace-staging-render.yaml
-yq eval '. | select(.kind == "Deployment" and .metadata.name == "tokenplace") | .spec.strategy.type' /tmp/tokenplace-staging-render.yaml
+just app-verify app=tokenplace env=staging
 ```
 
-Cluster/runtime checks:
-
 ```bash
-kubectl -n tokenplace get deploy,po,svc,ingress
-kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
-kubectl -n tokenplace get ingress tokenplace -o yaml
-curl -vI https://staging.token.place/
-curl -fsS https://staging.token.place/livez
-curl -fsS https://staging.token.place/healthz
-curl -fsS https://staging.token.place/relay/diagnostics
+just app-status app=tokenplace env=staging
 ```
 
-### Staging sign-off sequence
-
-Run the checks in this order so each layer has a clear owner before moving on to real
-external compute-node traffic:
-
-1. **Web/TLS:** confirm Cloudflare, Traefik, Ingress, and cert-manager serve the staging host.
-2. **Liveness/readiness:** call `/livez`, `/healthz`, and `/relay/diagnostics` once or at low
-   frequency. Do **not** use a long-running public `/healthz` watch as the primary readiness
-   monitor until token.place confirms health, liveness, metrics, diagnostics, and API v1
-   compute-node heartbeat routes are exempt from global public API rate limits. In staging, a
-   public `/healthz` watch plus kube-probes showed that rate-limited health checks can distort
-   readiness and create false rollout failures.
-3. **Synthetic API v1 register:** register a throwaway compute-node key against
-   `/api/v1/relay/servers/register`.
-4. **Synthetic API v1 poll:** poll `/api/v1/relay/servers/poll` with a client timeout that
-   exceeds the relay's server-side long-poll hold plus a small buffer, verifying the path returns
-   either queued encrypted work or a healthy no-work response instead of a client-side timeout.
-5. **Desktop compute-node registration:** start the packaged desktop/compute node against
-   `https://staging.token.place` and confirm the relay logs show matching API v1 register/poll
-   POSTs for that node.
-6. **E2EE request/response:** submit a real encrypted request through the staging client and verify
-   an encrypted response round trip. Synthetic register/poll is necessary, but real production
-   signoff requires an external compute-node registration and an E2EE request/response.
-
-Use Kubernetes state and relay logs for readiness instead of hammering public health endpoints:
-
 ```bash
-kubectl -n tokenplace get endpoints
-kubectl -n tokenplace get deploy,po
-kubectl -n tokenplace logs deploy/tokenplace --since=15m --tail=200
-curl -fsS https://staging.token.place/relay/diagnostics
+curl -fsS https://staging.token.place/relay/diagnostics | jq .
 ```
 
-Keep the public diagnostics curl low-frequency (for example, one manual call during validation or
-one scheduled check every few minutes) so the check itself does not trip public API rate-limit traps.
-
-### Synthetic API v1 compute-node register/poll
-
-This synthetic test proves the relay can accept an API v1 compute-node heartbeat without requiring
-a desktop package or GPU host. It does not prove desktop packaging, request routing, or E2EE.
+## Staging rollback
 
 ```bash
-BASE_URL=https://staging.token.place
-KEY_DIR="$(mktemp -d)"
-trap 'rm -rf "${KEY_DIR}"' EXIT
-
-# Generate real public-key material for the synthetic compute node instead of a debug string.
-# If the desktop client emits a different accepted format, set SYNTHETIC_SERVER_PUBLIC_KEY
-# to a non-secret public key copied from a disposable desktop test node.
-openssl genpkey -algorithm Ed25519 -out "${KEY_DIR}/server.key" >/dev/null 2>&1
-openssl pkey -in "${KEY_DIR}/server.key" -pubout -out "${KEY_DIR}/server.pub" >/dev/null 2>&1
-SERVER_PUBLIC_KEY="${SYNTHETIC_SERVER_PUBLIC_KEY:-$(cat "${KEY_DIR}/server.pub")}"
-DEBUG_KEY="${SERVER_PUBLIC_KEY}"
-REGISTER_BODY="$(jq -n --arg server_public_key "${SERVER_PUBLIC_KEY}" \
-  '{server_public_key: $server_public_key}')"
-
-# If the relay requires compute-node registration auth, populate RELAY_SERVER_CREDENTIAL
-# from your secret manager before running this block. Do not paste real secrets
-# into shell history, docs, screenshots, or PRs.
-
-RELAY_AUTH_HEADER_NAME="X-Relay-Server-Token"
-AUTH_HEADER=()
-if [ -n "${RELAY_SERVER_CREDENTIAL:-}" ]; then
-  AUTH_HEADER=(-H "${RELAY_AUTH_HEADER_NAME}: ${RELAY_SERVER_CREDENTIAL}")
-fi
-
-curl -fsS -X POST "${BASE_URL}/api/v1/relay/servers/register" \
-  -H 'Content-Type: application/json' \
-  "${AUTH_HEADER[@]}" \
-  --data "${REGISTER_BODY}" | jq .
-
-curl -fsS "${BASE_URL}/relay/diagnostics" | jq -e --arg key "${DEBUG_KEY}" \
-  '(.registered_compute_nodes // []) | any(.server_public_key == $key)'
-
-# Keep this higher than the relay's server-side long-poll hold. The default 65s value
-# leaves buffer for relays that hold empty polls for up to one minute before returning
-# the healthy no-work response; raise it if staging is configured with a longer hold.
-POLL_MAX_TIME="${POLL_MAX_TIME:-65}"
-curl -fsS --max-time "${POLL_MAX_TIME}" -X POST "${BASE_URL}/api/v1/relay/servers/poll" \
-  -H 'Content-Type: application/json' \
-  "${AUTH_HEADER[@]}" \
-  --data "${REGISTER_BODY}" | jq .
+PREVIOUS_TAG=main-REPLACE_PREVIOUS_SHORTSHA
 ```
 
-Expected result: register returns wait hints, `/relay/diagnostics` visibly includes the just-created
-`server_public_key` while the lease is fresh, and poll returns either encrypted work or a
-`No requests available` response before `POLL_MAX_TIME` elapses. Treat a missing debug key as a
-failed synthetic registration even if register returned 2xx. The synthetic server is ephemeral and
-will age out automatically after the relay lease if it is not refreshed.
-
-### Desktop HTTP 403 / pre-app rejection triage
-
-If the desktop compute-node reports HTTP 403 but synthetic curl succeeds, determine whether the
-request reached Flask/Gunicorn or was rejected before the app:
-
-1. Capture the desktop failure timestamp, request path, response status, and Cloudflare `cf-ray`
-   header from the desktop diagnostics or HTTP trace.
-2. Check relay logs for matching API v1 POSTs around that timestamp:
-
-   ```bash
-   kubectl -n tokenplace logs deploy/tokenplace --since=30m --tail=500 | \
-     grep -E 'api/v1/relay/servers/(register|poll)|server\.(registered|reregister|heartbeat)'
-   ```
-
-3. If there is no corresponding relay log entry, treat it as a Cloudflare/pre-app rejection and
-   search **Cloudflare Security Events** for the `cf-ray` value, client IP, host, path, and user
-   agent.
-4. Compare synthetic curl and desktop request headers: method, host, path, `Content-Type`,
-   `User-Agent`, `Origin`, any desktop-specific headers, and whether `X-Relay-Server-Token` is
-   present when required.
-5. Confirm credentials are not mixed up: `CF_TUNNEL_TOKEN` connects the Cloudflare Tunnel connector
-   to the dashboard tunnel, while the Cloudflare DNS API token is only for cert-manager DNS-01.
-   Neither token should be sent as the API v1 relay server registration token.
-
-A 403 with no relay log line means the application probably never saw the POST. A 403 with a relay
-log line means inspect token.place auth/rate-limit handling and the exact response body.
-
-## Rollback
-
-Rollback reminders:
-
-- Prefer immutable image tag rollback when the bad rollout is tied to a single image.
-- Use Helm revision rollback when you need to restore the entire rendered release state.
-- Expect a short outage during rollback because token.place is intentionally single-replica and
-  the Deployment strategy is `Recreate`; wait for the replacement pod before retesting relay E2EE.
-
-Rollback by immutable tag:
-
 ```bash
-just kubeconfig-env staging
-TOKENPLACE_PREVIOUS_TAG=main-deadbee # replace with the prior immutable tag
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_PREVIOUS_TAG"
+just app-deploy app=tokenplace env=staging tag="$PREVIOUS_TAG"
 ```
 
-Rollback by Helm revision:
-
 ```bash
-just kubeconfig-env staging
-TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
-just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
+HELM_REVISION=12
 ```
 
-## Cloudflare tunnel routing (external to Helm)
+```bash
+just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$HELM_REVISION"
+```
 
-Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes. Route `staging.token.place` to Traefik,
-typically `http://traefik.kube-system.svc.cluster.local:80`. Staging overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
-and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
-One staging tunnel can serve multiple hostnames (for example `staging.democratized.space` and
-`staging.token.place`) by routing both to Traefik; Traefik dispatches by `Host` header to the
-correct Ingress.
+## Cloudflare route
 
-`cf-tunnel-route` is for Cloudflare Tunnel hostname routing only. It is separate from the
-Cloudflare DNS API token used by cert-manager DNS-01 challenges.
+Cloudflare Tunnel routing is outside Helm. Route staging traffic to Traefik before expecting public
+HTTPS checks to pass.
 
 ```bash
-just cf-tunnel-route staging.token.place
 just cf-tunnel-route host=staging.token.place
 ```
-
-## cert-manager + Cloudflare DNS-01 (non-Flux clusters)
-
-If your cluster does **not** run Flux, do not apply `platform/cert-manager` with Kustomize as-is. In staging we hit this exact failure mode:
-
-- `kubectl apply -k platform/cert-manager` created the ConfigMap/issuers, then failed because `HelmRelease` was an unknown kind (Flux CRDs absent).
-- The rendered issuer email remained literal `$(CERT_MANAGER_EMAIL)`, causing ACME `invalidContact`.
-
-Use these recipes instead:
-
-```bash
-just cert-manager-install
-just cert-manager-cloudflare-token-secret token="$CF_DNS_API_TOKEN"
-just cert-manager-issuers-apply email="ops@token.place"
-just cert-manager-status
-```
-
-Cloudflare DNS API token scope for cert-manager:
-
-- `Zone -> DNS -> Edit`
-- `Zone -> Zone -> Read`
-- Include only required zones (at minimum `token.place`; include `democratized.space` too if the same token handles shared DSPACE cert issuance).
-
-If cert-manager logs show challenge cleanup errors after a certificate is already issued, use the
-Certificate condition as the release gate: `Ready=True` means TLS issuance succeeded for rollout
-purposes. Cleanup errors are still worth fixing because they usually point to a Cloudflare DNS API
-token without `Zone -> Zone -> Read`, a token scoped to the wrong zone, or resolver/zone lookup
-weirdness that prevents cert-manager from finding the correct Cloudflare zone during cleanup.
-
-Validation commands:
-
-```bash
-kubectl get crd | grep cert-manager.io
-kubectl get clusterissuer letsencrypt-staging letsencrypt-production
-kubectl get certificate --all-namespaces
-kubectl -n cert-manager get secret cloudflare-api-token
-kubectl -n cert-manager logs deploy/cert-manager --tail=100
-```
-
-> ⚠️ During early staging we used manual Helm `--set env.XDG_CACHE_HOME=/tmp --set env.XDG_CONFIG_HOME=/tmp --set env.XDG_DATA_HOME=/tmp` overrides to pass read-only filesystem startup checks. Remove those manual overrides now that chart defaults own the XDG `/tmp` paths.
-
-
-## 0.1.0 release alignment
-
-- OCI chart package version: `0.1.0`
-- Chart `appVersion`: `0.1.0`
-- token.place Git tag: `v0.1.0`
-- Release image tag after final tag push: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
-- Staging candidate tag before final tag push: `main-<shortsha>`


### PR DESCRIPTION
### Motivation
- Provide uniform, copy-pasteable operator runbooks that prefer the new generic `just` app recipes and make GHCR-first deployment the primary path.  
- Replace duplicated environment runbooks with thin env-specific checklists that point to the canonical app runbooks.  
- Add concrete onboarding guidance so future apps (for example `wove` and `jobbot3000`) can be onboarded without inventing hostnames or secrets prematurely.

### Description
- Rewrote the three primary app runbooks to the same section order and GHCR-first flow: `docs/apps/dspace.md`, `docs/apps/tokenplace.md`, and `docs/apps/danielsmith.md`; each doc now documents the artifact model, environment topology, find/publish image, confirm/publish chart, deploy staging, verify staging, promote production, verify production, rollback, troubleshooting, and app-specific notes.  
- Added a new onboarding guide `docs/app_onboarding.md` including responsibility split, a one-file app config template, minimal image/chart checklists, env overlay examples, the generic deploy/promote/rollback flow, FAQs for onboarding, and a release decision tree.  
- Slimmed environment-specific runbooks into thin checklists that point at the generic commands while preserving compatibility shims: updated `docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`, `docs/k3s-tokenplace-dev.md`, `docs/k3s-danielsmith-staging.md`, and `docs/k3s-danielsmith-prod.md`.  
- Updated discoverability links in `README.md` and `docs/index.md` to expose the onboarding guide and the unified app runbooks.  
- Ensured commands are copy-pasteable in rendered Markdown by using shell assignments such as `APP_TAG=main-REPLACE_SHORTSHA` (no angle-bracket redirections), preferring the generic commands (for example `just app-deploy app=dspace env=staging tag="$APP_TAG"`) and still showing the existing compatibility wrappers (for example `just dspace-oci-deploy env=staging tag="$APP_TAG"`).  
- Fixed a docs secret-scan false positive by removing `echo "$GHCR_TOKEN" | helm registry login ... --password-stdin` snippets and replacing with `helm registry login ghcr.io -u "$GHCR_USER"` where appropriate so `./scripts/scan-secrets.py` passes.

### Testing
- Ran `git diff --check` and addressed any issues; result: no whitespace or diff-check failures.  
- Ran unit test suite: `python -m pytest tests -q` and all tests passed (`1253 passed, 19 skipped` in CI run here).  
- Searched docs for the new generic commands and placeholders: `grep -R "just app-deploy app=dspace" docs`, `grep -R "just app-deploy app=tokenplace" docs`, `grep -R "just app-deploy app=danielsmith" docs`, and `grep -R "main-REPLACE_SHORTSHA" docs` — all returned the expected updated entries.  
- Reviewed `grep -R "docker build" docs` hits and confirmed remaining `docker build` references are explicitly marked as local/app-repo development only (not for staging/prod deploys).  
- Ran the docs secret checker: `git diff --cached | ./scripts/scan-secrets.py` which initially flagged an `echo "$GHCR_TOKEN"` snippet and the snippet was removed; subsequent run returned clean.  
- Note: repository doc verification tools were not available in this environment, so these checks were not run: `pre-commit run --all-files` (not found), `pyspelling -c .spellcheck.yaml` (not found), and `linkchecker --no-warnings README.md docs/` (not found).  These should be run in CI or by reviewers with those tools installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e82b73860832f8945ec47c8fa4361)