### PR TITLE
docs: align app runbooks with generic app flow and add app_onboarding.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,12 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
 
 ## Application runbooks
 
-- **[token.place onboarding contract](docs/tokenplace_sugarkube_onboarding.md)** — prerequisites,
-  ownership boundaries, and environment mapping for first-class token.place operations.
-- **[token.place app operations](docs/apps/tokenplace.md)** — topology and deployment workflow
-  patterns for token.place on Sugarkube.
-- **[token.place env runbooks](docs/index.md)** — environment-specific guides for
-  [dev](docs/k3s-tokenplace-dev.md), [staging](docs/k3s-tokenplace-staging.md), and
-  [production](docs/k3s-tokenplace-prod.md) operations.
+- **[Generic app deployment contract](docs/app_deployment_contract.md)** — shared artifact, tag, chart, config, and `just app-*` command contract.
+- **[Future app onboarding](docs/app_onboarding.md)** — checklist and decision tree for adding wove, jobbot3000, and later apps.
+- **[DSPACE app operations](docs/apps/dspace.md)** — GHCR-first staging deploy, production promotion, verification, and rollback.
+- **[token.place app operations](docs/apps/tokenplace.md)** — relay topology plus generic staging/prod operations on Sugarkube.
+- **[danielsmith.io app operations](docs/apps/danielsmith.md)** — static-site staging/prod operations on Sugarkube.
+- **Environment runbooks** — token.place [dev](docs/k3s-tokenplace-dev.md), [staging](docs/k3s-tokenplace-staging.md), and [production](docs/k3s-tokenplace-prod.md); danielsmith.io [staging](docs/k3s-danielsmith-staging.md) and [production](docs/k3s-danielsmith-prod.md).
 
 ## Repository layout
 

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -1,0 +1,265 @@
+# Sugarkube app onboarding guide
+
+Use this guide when adding the next app to Sugarkube, including future candidates
+such as **wove** and **jobbot3000**. The goal is a repeatable GHCR-first release
+flow: the app repository publishes an immutable image and immutable OCI Helm
+chart, then Sugarkube deploys those artifacts with generic `just app-*` recipes.
+
+Keep responsibilities separate:
+
+- **App repository responsibilities:** Dockerfile, image workflow, Helm chart,
+  chart workflow, chart tests/render checks, and app-specific smoke-test design.
+- **Sugarkube responsibilities:** app config, environment values overlays,
+  kubeconfig/environment selection, Helm deploy/redeploy/promote/status/verify,
+  Kubernetes logs, and rollback.
+- **Cloudflare responsibilities:** DNS records and tunnel routes that point public
+  hostnames to Traefik. Helm manages Kubernetes Ingress objects only; it does not
+  create Cloudflare routes.
+
+App-specific deploy recipes are compatibility shims for existing apps. Keep them
+for now, but prefer generic commands in new app docs. Remove shims only after the
+generic flow has been exercised across routine releases.
+
+## Onboarding checklist
+
+1. Add a Dockerfile in the app repository.
+2. Add `ci-image.yml` in the app repository with standard GHCR tags.
+3. Add a Helm chart in the app repository.
+4. Add `ci-helm.yml` in the app repository with immutable OCI chart publishing.
+5. Add or copy a Sugarkube app config file.
+6. Add environment values overlays for `dev`, `staging`, and `prod`.
+7. Run the generic Sugarkube deploy commands.
+8. Add app-specific smoke checks if needed.
+
+## Minimal app config template
+
+Copy this into a local config such as `apps/APP.env`, or add an example under
+`docs/examples/apps/APP.env` when the repository has enough real coordinates to
+serve as an example. Do not store secrets in app configs.
+
+```dotenv
+SUGARKUBE_APP=APP
+SUGARKUBE_RELEASE=APP
+SUGARKUBE_NAMESPACE=APP
+SUGARKUBE_CHART=oci://ghcr.io/OWNER/charts/CHART
+SUGARKUBE_VERSION_FILE=docs/apps/APP.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/APP.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/APP.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/APP.values.dev.yaml,docs/examples/APP.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/APP.values.dev.yaml,docs/examples/APP.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=APP
+```
+
+Create the local config directory when using app configs that are not committed:
+
+```bash
+mkdir -p apps
+```
+
+```bash
+cp docs/examples/apps/dspace.env apps/APP.env
+```
+
+```bash
+export SUGARKUBE_APP_CONFIG_DIR=apps
+```
+
+Confirm Sugarkube can resolve the config:
+
+```bash
+just app-config app=APP env=staging
+```
+
+## Minimal image workflow checklist
+
+The app repository's `ci-image.yml` should answer these questions before
+Sugarkube deploys anything:
+
+- Does the workflow build the canonical app image from the app repository's
+  Dockerfile?
+- Does it push to the agreed GHCR image name, for example
+  `ghcr.io/OWNER/IMAGE`?
+- Does every merge or release candidate produce an immutable tag such as
+  `main-REPLACE_SHORTSHA`?
+- Are mutable convenience tags, if any, documented as non-production shortcuts?
+- Does the workflow publish architecture support that matches Sugarkube nodes?
+- Does the workflow avoid requiring Sugarkube secrets? Sugarkube should read the
+  published package, not build the image.
+
+Find recent image builds from the app repository:
+
+```bash
+gh run list --repo OWNER/REPO --workflow ci-image.yml --limit 10
+```
+
+Set the candidate image tag for deployment:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+Confirm the image manifest exists:
+
+```bash
+docker manifest inspect ghcr.io/OWNER/IMAGE:$APP_TAG
+```
+
+## Minimal Helm chart checklist
+
+The app repository's chart and `ci-helm.yml` should satisfy this before Sugarkube
+pins a chart version:
+
+- `Chart.yaml` has the intended chart name and a semantic chart version.
+- Image repository/tag values are configurable by Helm values.
+- Ingress host, class, TLS secret, annotations, resources, env, probes, and any
+  app-specific runtime config are values-driven.
+- Chart versions are immutable. If rendered manifests change, bump the chart
+  version before publishing.
+- The workflow packages and pushes to `oci://ghcr.io/OWNER/charts/CHART`.
+- The app repository can render the chart for `dev`, `staging`, and `prod`
+  overlays without duplicate env vars or missing required values.
+
+Check the chart version that Sugarkube will deploy:
+
+```bash
+APP_CHART_VERSION=$(grep -E '^[0-9]+[.][0-9]+[.][0-9]+' docs/apps/APP.version | head -n1)
+```
+
+```bash
+helm show chart oci://ghcr.io/OWNER/charts/CHART --version "$APP_CHART_VERSION"
+```
+
+## Environment values overlays
+
+Use one base values file plus thin environment overlays:
+
+- `docs/examples/APP.values.dev.yaml`: shared defaults and local/dev settings.
+- `docs/examples/APP.values.staging.yaml`: staging host, TLS secret, and staging
+  runtime config.
+- `docs/examples/APP.values.prod.yaml`: production host, TLS secret, and
+  production runtime config.
+
+Keep secrets out of values examples. Reference Kubernetes Secret names or
+external secret mechanisms rather than literal secret values.
+
+## Generic Sugarkube deploy flow
+
+Deploy staging:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-deploy app=APP env=staging tag="$APP_TAG"
+```
+
+Verify staging:
+
+```bash
+just app-status app=APP env=staging
+```
+
+```bash
+just app-verify app=APP env=staging
+```
+
+Promote production after staging sign-off:
+
+```bash
+just app-promote-prod app=APP tag="$APP_TAG"
+```
+
+Verify production:
+
+```bash
+just app-status app=APP env=prod
+```
+
+```bash
+just app-verify app=APP env=prod
+```
+
+Rollback to a previous immutable image tag:
+
+```bash
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+```bash
+just app-promote-prod app=APP tag="$APP_TAG"
+```
+
+## Release decision tree
+
+### I have a successful image build; what tag do I deploy?
+
+Deploy the immutable tag emitted by the image workflow, normally
+`main-REPLACE_SHORTSHA`. Do not deploy `latest`, a bare branch name, or an
+environment name to staging or production. Use the same immutable tag through
+staging verification and production promotion.
+
+### The chart changed; what version do I bump?
+
+Bump the chart version in the app repository whenever chart content changes.
+Patch bumps are typical for template/default-value fixes, minor bumps are for
+new chart capabilities, and major bumps are for breaking chart contract changes.
+Publish the new immutable OCI chart first, then update the Sugarkube
+`docs/apps/APP.version` pin.
+
+### Staging works; how do I promote prod?
+
+Promote the exact immutable image tag that passed staging:
+
+```bash
+just app-promote-prod app=APP tag="$APP_TAG"
+```
+
+Update `docs/apps/APP.prod.tag` only when the team explicitly approves that tag
+as the production pin. When `tag=` is omitted, the generic production flow reads
+that pin file.
+
+### Prod is bad; how do I roll back?
+
+If the previous known-good image tag is known, redeploy that immutable tag:
+
+```bash
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+```bash
+just app-promote-prod app=APP tag="$APP_TAG"
+```
+
+If the image tag is unknown but a Helm revision is known, use the parameterized
+rollback helper:
+
+```bash
+APP_REVISION=12
+```
+
+```bash
+just tokenplace-rollback release=APP namespace=APP revision="$APP_REVISION"
+```
+
+## wove and jobbot3000 pre-onboarding questions
+
+Do not invent Sugarkube configs for **wove** or **jobbot3000** until these
+answers are available from their app repositories or owners:
+
+- What is the canonical app image name?
+- What container port does the service expose?
+- Which health endpoints should Sugarkube verify?
+- What is the chart name and OCI chart path?
+- What Kubernetes namespace and Helm release name should be used?
+- What are the staging and production hostnames?
+- What runtime secrets and non-secret config are required?
+- Are there stateful dependencies such as a database, queue, cache, object store,
+  or persistent volume?
+- What resource requests and limits are appropriate for Sugarkube hardware?
+
+Once those answers are known, copy the template above, add the three values
+overlays, publish image/chart artifacts from the app repository, and run the
+generic Sugarkube deploy flow.

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -1,92 +1,292 @@
 # danielsmith.io on Sugarkube
 
-This is the canonical Sugarkube deployment model for `danielsmith.io`.
+This runbook is the GHCR-first, generic-app deployment path for `danielsmith`. The app
+repository owns image and chart publishing; Sugarkube owns kubeconfig selection,
+values overlays, Helm deploys, status, verification, rollback, and logs. Cloudflare
+Tunnel/DNS routes are configured outside Helm and must already point the public
+hostnames at Traefik before production cutover.
 
-For the shared artifact, tag, chart, app-config, and planned generic command contract, see [Sugarkube app deployment contract](../app_deployment_contract.md).
+App-specific `just` recipes remain documented as compatibility shims. Prefer the
+generic `just app-* app=danielsmith` commands for new releases and future app
+onboarding; the wrappers are scheduled for later removal only after the generic
+flow has been exercised across routine releases.
 
-## Topology and scope (static-site only)
+For the shared contract, tag policy, and config lookup order, see
+[Sugarkube app deployment contract](../app_deployment_contract.md). For future
+apps, see [App onboarding](../app_onboarding.md).
 
-`danielsmith.io` is a static Vite + Three.js site. Sugarkube runs only the static web container.
+## Artifact model
 
-- **In-cluster (Sugarkube):** one static web deployment exposed through Traefik ingress.
-- **No in-cluster API/backend/database/queue/GPU/compute node/stateful service** is required.
-- **Public ingress path:** Cloudflare Tunnel fronts Traefik, and Traefik routes to the
-  `danielsmith` Kubernetes Service.
-- **Health/availability endpoints:** `/livez`, `/healthz`.
-- **Root page:** `/`.
-
-## Artifact model (canonical)
-
+- App repository: `futuroptimist/danielsmith.io`
 - Image: `ghcr.io/futuroptimist/danielsmith.io`
 - Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
 - Helm release: `danielsmith`
-- Namespace: `danielsmith`
-- Chart version pin file: `docs/apps/danielsmith.version`
-- Production approved tag pin: `docs/apps/danielsmith.prod.tag`
+- Kubernetes namespace: `danielsmith`
+- Sugarkube app config: `docs/examples/apps/danielsmith.env`
+- Chart version pin: `docs/apps/danielsmith.version`
+- Production image tag pin: `docs/apps/danielsmith.prod.tag`
+- Verify paths: `/,/livez,/healthz`
 
-## Values model
+Responsibilities stay split:
 
-- Base: `docs/examples/danielsmith.values.dev.yaml`
-- Staging overlay: `docs/examples/danielsmith.values.staging.yaml`
-- Production overlay: `docs/examples/danielsmith.values.prod.yaml`
+- **App repo:** build the container image, publish immutable GHCR tags such as
+  `main-REPLACE_SHORTSHA`, package the Helm chart, and publish immutable OCI chart
+  versions.
+- **Sugarkube:** select `dev`, `staging`, or `prod`; load app config; apply values
+  overlays; run Helm; verify URLs; inspect pods/logs; and perform rollback.
+- **Cloudflare:** maintain DNS and tunnel routes to Traefik. Helm creates
+  Kubernetes Ingress objects, not Cloudflare routes.
 
-Default hosts:
+## Environment topology
 
-- Staging: `staging.danielsmith.io`
-- Production: `danielsmith.io`
+- Staging environment: `env=staging`, host `https://staging.danielsmith.io`.
+- Production environment: `env=prod`, host `https://danielsmith.io`.
+- Values overlays:
+  - Base/dev: `docs/examples/danielsmith.values.dev.yaml`
+  - Staging: `docs/examples/danielsmith.values.staging.yaml`
+  - Production: `docs/examples/danielsmith.values.prod.yaml`
 
-## Core deployment commands
+Sugarkube runs only the static web container for this Vite + Three.js site. There is no in-cluster API, database, queue, GPU, compute node, or other stateful dependency in the current deployment model.
 
-First install (or install-or-upgrade) with generic helper:
-
-```bash
-just kubeconfig-env staging
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
-```
-
-Existing release upgrade with generic helper:
-
-```bash
-just kubeconfig-env staging
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
-```
-
-Preferred environment wrapper:
-
-```bash
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
-just danielsmith-oci-deploy env=staging tag="$DANIELSMITH_TAG"
-```
-
-## Validation commands
-
-```bash
-kubectl -n danielsmith get deploy,po,svc,ingress
-kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
-curl -fsS https://staging.danielsmith.io/livez
-curl -fsS https://staging.danielsmith.io/healthz
-curl -fsS https://staging.danielsmith.io/
-```
-
-For production validation, use the same checks against `https://danielsmith.io`.
-
-## Cloudflare Tunnel and ingress model
-
-Cloudflare Tunnel/DNS configuration is external to Helm.
-
-- Route hostnames to Traefik, typically
-  `http://traefik.kube-system.svc.cluster.local:80`.
-- Helm chart deployment does **not** create Cloudflare routes.
-- Configure staging and prod routes explicitly:
+Confirm Cloudflare routing separately when a hostname is new or has changed:
 
 ```bash
 just cf-tunnel-route host=staging.danielsmith.io
+```
+
+```bash
 just cf-tunnel-route host=danielsmith.io
 ```
 
-## Related runbooks
+## Find or publish GHCR image
 
-- Staging runbook: [`docs/k3s-danielsmith-staging.md`](../k3s-danielsmith-staging.md)
-- Production runbook: [`docs/k3s-danielsmith-prod.md`](../k3s-danielsmith-prod.md)
+Start from the app repository's image workflow. A successful workflow should push
+an immutable tag, usually `main-REPLACE_SHORTSHA`, plus any app-specific release
+or convenience tags documented by that repository.
+
+```bash
+gh run list --repo futuroptimist/danielsmith.io --workflow ci-image.yml --limit 10
+```
+
+Set the immutable image tag you are about to deploy:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+Inspect the GHCR image manifest before deploying. If this fails with an auth
+error, login with a GitHub token that can read packages for the app repository.
+
+```bash
+docker manifest inspect ghcr.io/futuroptimist/danielsmith.io:$APP_TAG
+```
+
+Do not lead staging or production deployments with local Docker builds. Local
+builds are for app-repo development only; Sugarkube deploys published GHCR
+artifacts.
+
+## Confirm/publish OCI chart
+
+The app repository owns chart changes and immutable chart publishing. If the chart
+changed, bump the chart version in the app repository before publishing; do not
+republish different chart content at the same version.
+
+Read the Sugarkube chart version pin:
+
+```bash
+APP_CHART_VERSION=$(grep -E '^[0-9]+[.][0-9]+[.][0-9]+' docs/apps/danielsmith.version | head -n1)
+```
+
+Confirm the pinned chart is available from GHCR:
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$APP_CHART_VERSION"
+```
+
+If the chart was changed but the pinned version is missing or stale, publish it
+from the app repository first, then update `docs/apps/danielsmith.version` in Sugarkube only
+after the immutable OCI chart exists.
+
+## Deploy staging
+
+Preferred generic command:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-deploy app=danielsmith env=staging tag="$APP_TAG"
+```
+
+Compatibility wrapper, kept for existing operators and scripts:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just danielsmith-oci-deploy env=staging tag="$APP_TAG"
+```
+
+Use `app-redeploy` only when you intentionally need the upgrade-only path for an
+existing release and tag:
+
+```bash
+just app-redeploy app=danielsmith env=staging tag="$APP_TAG"
+```
+
+## Verify staging
+
+Use the generic verifier first. It resolves the host from the Helm release values
+and curls the app config's verify paths.
+
+```bash
+just app-status app=danielsmith env=staging
+```
+
+```bash
+just app-verify app=danielsmith env=staging
+```
+
+Manual staging checks:
+
+```bash
+kubectl --context sugar-staging -n danielsmith get deploy,po,svc,ingress
+```
+
+```bash
+kubectl --context sugar-staging -n danielsmith rollout status deploy/danielsmith --timeout=180s
+```
+
+```bash
+curl -fsS https://staging.danielsmith.io/
+curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/healthz
+```
+
+## Promote production
+
+Promote only the exact immutable image tag that passed staging. If `tag=` is
+omitted, the generic production command reads `docs/apps/danielsmith.prod.tag`; update that pin
+only as an explicit approval step.
+
+Preferred generic command:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-promote-prod app=danielsmith tag="$APP_TAG"
+```
+
+Compatibility wrapper:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just danielsmith-oci-promote-prod tag="$APP_TAG"
+```
+
+## Verify production
+
+```bash
+just app-status app=danielsmith env=prod
+```
+
+```bash
+just app-verify app=danielsmith env=prod
+```
+
+Manual production checks:
+
+```bash
+kubectl --context sugar-prod -n danielsmith get deploy,po,svc,ingress
+```
+
+```bash
+kubectl --context sugar-prod -n danielsmith rollout status deploy/danielsmith --timeout=180s
+```
+
+```bash
+curl -fsS https://danielsmith.io/
+curl -fsS https://danielsmith.io/livez
+curl -fsS https://danielsmith.io/healthz
+```
+
+## Rollback
+
+Rollback by redeploying the previous known-good immutable tag. Prefer this when
+the previous image tag is known and the chart version did not need to change.
+
+```bash
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+```bash
+just app-deploy app=danielsmith env=staging tag="$APP_TAG"
+```
+
+```bash
+just app-promote-prod app=danielsmith tag="$APP_TAG"
+```
+
+Rollback by Helm revision only when you have confirmed the revision number:
+
+```bash
+APP_REVISION=12
+```
+
+```bash
+just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$APP_REVISION"
+```
+
+`tokenplace-rollback` is the repository's existing parameterized Helm rollback
+helper despite its token.place-oriented name.
+
+## Troubleshooting
+
+GHCR/OCI auth failures usually mean Helm or Docker cannot read the package. Login
+with a GitHub token that has package read access, then retry the chart/image
+inspection commands.
+
+```bash
+helm registry login ghcr.io
+```
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$APP_CHART_VERSION"
+```
+
+Inspect resolved config and cluster state:
+
+```bash
+just app-config app=danielsmith env=staging
+```
+
+```bash
+just app-status app=danielsmith env=staging
+```
+
+```bash
+kubectl --context sugar-staging -n danielsmith logs deploy/danielsmith --tail=120
+```
+
+Ingress and tunnel checks:
+
+```bash
+just traefik-status
+```
+
+```bash
+just cf-tunnel-debug
+```
+
+## App-specific notes
+
+- Treat `/` as the user-facing smoke check and `/livez` plus `/healthz` as availability checks.
+- Preserve the app repository static-site build pipeline; Sugarkube consumes the published image and chart only.
+- Do not add backend, database, or compute-node assumptions to Sugarkube values unless the app repository introduces those services first.

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -1,204 +1,304 @@
 # democratized.space (dspace) on Sugarkube
 
-This guide covers **steady-state dspace operations** on Sugarkube: repeatable deploys,
-upgrades, promotions, and rollbacks using immutable image tags.
+This runbook is the GHCR-first, generic-app deployment path for `dspace`. The app
+repository owns image and chart publishing; Sugarkube owns kubeconfig selection,
+values overlays, Helm deploys, status, verification, rollback, and logs. Cloudflare
+Tunnel/DNS routes are configured outside Helm and must already point the public
+hostnames at Traefik before production cutover.
 
-For the shared artifact, tag, chart, app-config, and planned generic command contract, see [Sugarkube app deployment contract](../app_deployment_contract.md).
+App-specific `just` recipes remain documented as compatibility shims. Prefer the
+generic `just app-* app=dspace` commands for new releases and future app
+onboarding; the wrappers are scheduled for later removal only after the generic
+flow has been exercised across routine releases.
 
-The `justfile` exposes both:
+For the shared contract, tag policy, and config lookup order, see
+[Sugarkube app deployment contract](../app_deployment_contract.md). For future
+apps, see [App onboarding](../app_onboarding.md).
 
-- generic Helm OCI helpers (`helm-oci-install`, `helm-oci-upgrade`) for any app; and
-- dspace-specific helpers for immutable deploys and production promotion
-  (`dspace-oci-deploy`, `dspace-oci-promote-prod`, `dspace-oci-redeploy`).
+## Artifact model
 
-## Environment topology and values overlays
+- App repository: `democratizedspace/dspace`
+- Image: `ghcr.io/democratizedspace/dspace`
+- Chart: `oci://ghcr.io/democratizedspace/charts/dspace`
+- Helm release: `dspace`
+- Kubernetes namespace: `dspace`
+- Sugarkube app config: `docs/examples/apps/dspace.env`
+- Chart version pin: `docs/apps/dspace.version`
+- Production image tag pin: `docs/apps/dspace.prod.tag`
+- Verify paths: `/config.json,/healthz,/livez`
+- Optional production subdomain overlay: `docs/examples/dspace.values.prod-subdomain.yaml` for `prod.democratized.space`.
 
-dspace values are layered so base defaults stay separate from environment routing.
+Responsibilities stay split:
 
-- `docs/examples/dspace.values.dev.yaml`: shared defaults, intended for future `env=dev`
-  deployments.
-- `docs/examples/dspace.values.staging.yaml`: staging ingress host/class overlay.
-- `docs/examples/dspace.values.prod.yaml`: production apex ingress overlay.
-- `docs/examples/dspace.values.prod-subdomain.yaml`: optional legacy subdomain overlay for
-  `prod.democratized.space` when a pre-apex host is explicitly needed.
+- **App repo:** build the container image, publish immutable GHCR tags such as
+  `main-REPLACE_SHORTSHA`, package the Helm chart, and publish immutable OCI chart
+  versions.
+- **Sugarkube:** select `dev`, `staging`, or `prod`; load app config; apply values
+  overlays; run Helm; verify URLs; inspect pods/logs; and perform rollback.
+- **Cloudflare:** maintain DNS and tunnel routes to Traefik. Helm creates
+  Kubernetes Ingress objects, not Cloudflare routes.
 
-Current/target topology:
+## Environment topology
 
-- **staging (live, HA):** `env=staging` on `sugarkube3`, `sugarkube4`, `sugarkube5`,
-  public host `staging.democratized.space`.
-- **prod (live, HA):** `env=prod` on `sugarkube0`, `sugarkube1`, `sugarkube2`,
-  public host `democratized.space`.
-- **dev (planned, non-HA):** `env=dev` on `sugarkube6` (single-node future environment).
+- Staging environment: `env=staging`, host `https://staging.democratized.space`.
+- Production environment: `env=prod`, host `https://democratized.space`.
+- Values overlays:
+  - Base/dev: `docs/examples/dspace.values.dev.yaml`
+  - Staging: `docs/examples/dspace.values.staging.yaml`
+  - Production: `docs/examples/dspace.values.prod.yaml`
 
-Cloudflare Tunnel topology stays one tunnel per environment/cluster, with many hostnames routed to
-Traefik. For staging this means `staging.democratized.space` can share a tunnel with
-`staging.token.place`, and Traefik routes by HTTP `Host` header to the proper Ingress.
+Current target topology is HA staging on `sugarkube3`/`sugarkube4`/`sugarkube5`, HA production on `sugarkube0`/`sugarkube1`/`sugarkube2`, and a planned single-node dev environment on `sugarkube6`.
 
-## Tagging model (evergreen releases)
-
-Use tags by purpose:
-
-- **Convenience/mutable tags** for fast iteration in non-prod (for example `main-latest`).
-- **Immutable deploy tags** for sign-off, promotion, and rollback (for example
-  `main-<shortsha>`, `3.0.1`, `3.1.0`).
-- In this operational guide, `main` is the normal integration line that produces
-  DSPACE-derived image tags (for example `main-<shortsha>`).
-- If the DSPACE repo uses release branches, keep them short-lived stabilization branches,
-  not long-lived environment branches.
-- Keep environment routing (`staging`, optional `prod.` subdomain, apex prod) separate from release
-  lineage; this guide stays main-first for steady-state operations.
-
-Environment overlays (`dev`/`staging`/`prod`) decide host/routing. Image tags decide the
-release version. Keep those concerns separate.
-
-## Quickstart
+Confirm Cloudflare routing separately when a hostname is new or has changed:
 
 ```bash
-# Immutable staging deploy (recommended for release validation)
-just dspace-oci-deploy env=staging tag=main-<shortsha>
-
-# Immutable production deploy (reads docs/apps/dspace.prod.tag if tag is omitted)
-just dspace-oci-promote-prod tag=3.1.0
-
-# Optional prod subdomain endpoint (prod.democratized.space)
-just dspace-oci-deploy-prod-subdomain tag=main-<shortsha>
-
-# Check pods/ingress/status
-just app-status namespace=dspace release=dspace
+just cf-tunnel-route host=staging.democratized.space
 ```
-
-## When to use each helper
-
-- `helm-oci-install`: install-or-upgrade path (uses `helm upgrade --install`), useful when a
-  release may not exist yet.
-- `helm-oci-upgrade`: upgrade-only path with `--reuse-values`, useful for routine bumps on an
-  existing release.
-- `dspace-oci-deploy`: opinionated dspace wrapper that requires an explicit immutable tag,
-  applies the correct values chain for `env=dev|staging|prod`, and waits for rollout.
-- `dspace-oci-promote-prod`: production convenience wrapper around
-  `dspace-oci-deploy env=prod`, reading `docs/apps/dspace.prod.tag` when `tag=` is omitted.
-- `dspace-oci-redeploy`: force-refresh path for already-deployed tags (especially mutable tags)
-  by running a Helm upgrade and rollout restart.
-
-## Generic Helm OCI examples
-
-If `helm pull`, `just helm-oci-install`, or `just helm-oci-upgrade` fails with GHCR `401`/`403`
-errors, use the canonical recovery steps in
-[Raspberry Pi Cluster Troubleshooting — Scenario 7](../raspi_cluster_troubleshooting.md#scenario-7-helm-oci-pull-fails-with-ghcr-403-denied-denied).
 
 ```bash
-# Install-or-upgrade staging with mutable convenience tag
-just helm-oci-install \
-  release=dspace namespace=dspace \
-  chart=oci://ghcr.io/democratizedspace/charts/dspace \
-  values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
-  version_file=docs/apps/dspace.version \
-  default_tag=main-latest
-
-# Upgrade staging to an immutable build
-just helm-oci-upgrade \
-  release=dspace namespace=dspace \
-  chart=oci://ghcr.io/democratizedspace/charts/dspace \
-  values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
-  version_file=docs/apps/dspace.version \
-  tag=main-<shortsha>
-
-# Upgrade prod directly to a signed-off immutable tag
-just helm-oci-upgrade \
-  release=dspace namespace=dspace \
-  chart=oci://ghcr.io/democratizedspace/charts/dspace \
-  values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml \
-  version_file=docs/apps/dspace.version \
-  tag=3.1.0
+just cf-tunnel-route host=democratized.space
 ```
 
-Notes:
+## Find or publish GHCR image
 
-- `version_file=docs/apps/dspace.version` keeps chart version pinning centralized.
-- For prod, prefer immutable tags and persist the approved one in `docs/apps/dspace.prod.tag`.
-- `dspace-oci-deploy` rejects mutable tags (`latest`, `main`) by design.
+Start from the app repository's image workflow. A successful workflow should push
+an immutable tag, usually `main-REPLACE_SHORTSHA`, plus any app-specific release
+or convenience tags documented by that repository.
 
-## Evergreen release/promotion flow
+```bash
+gh run list --repo democratizedspace/dspace --workflow ci-image.yml --limit 10
+```
 
-1. Build and publish candidate image tags from `main` (for example `main-<shortsha>` plus
-   optional `main-latest`).
-2. Deploy immutable candidate to staging:
+Set the immutable image tag you are about to deploy:
 
-   ```bash
-   just dspace-oci-deploy env=staging tag=main-<shortsha>
-   ```
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
 
-3. Verify staging (`config.json`, `healthz`, `livez`) at
-   `https://staging.democratized.space`.
+Inspect the GHCR image manifest before deploying. If this fails with an auth
+error, login with a GitHub token that can read packages for the app repository.
 
-   ```bash
-   curl -fsS https://staging.democratized.space/config.json | jq .
-   ```
+```bash
+docker manifest inspect ghcr.io/democratizedspace/dspace:$APP_TAG
+```
 
-   ```bash
-   curl -fsS https://staging.democratized.space/healthz | jq .
-   ```
+Do not lead staging or production deployments with local Docker builds. Local
+builds are for app-repo development only; Sugarkube deploys published GHCR
+artifacts.
 
-   ```bash
-   curl -fsS https://staging.democratized.space/livez | jq .
-   ```
+## Confirm/publish OCI chart
 
-4. Promote the approved immutable tag to production apex:
+The app repository owns chart changes and immutable chart publishing. If the chart
+changed, bump the chart version in the app repository before publishing; do not
+republish different chart content at the same version.
 
-   ```bash
-   just dspace-oci-promote-prod tag=main-<shortsha>
-   # or semver tag once released
-   just dspace-oci-promote-prod tag=3.1.0
-   ```
+Read the Sugarkube chart version pin:
 
-   Then verify production apex:
+```bash
+APP_CHART_VERSION=$(grep -E '^[0-9]+[.][0-9]+[.][0-9]+' docs/apps/dspace.version | head -n1)
+```
 
-   ```bash
-   curl -fsS https://democratized.space/config.json | jq .
-   ```
+Confirm the pinned chart is available from GHCR:
 
-   ```bash
-   curl -fsS https://democratized.space/healthz | jq .
-   ```
+```bash
+helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version "$APP_CHART_VERSION"
+```
 
-   ```bash
-   curl -fsS https://democratized.space/livez | jq .
-   ```
+If the chart was changed but the pinned version is missing or stale, publish it
+from the app repository first, then update `docs/apps/dspace.version` in Sugarkube only
+after the immutable OCI chart exists.
 
-5. Keep rollback simple by redeploying the prior immutable tag.
+## Deploy staging
 
-Optional only: use `dspace-oci-deploy-prod-subdomain` when you explicitly need the
-`https://prod.democratized.space` subdomain before apex promotion. In steady state, this
-subdomain is typically a redirect to `https://democratized.space`, so it is not part of the
-default required deploy/promotion path.
+Preferred generic command:
 
-## Networking via Cloudflare Tunnel
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
 
-This guide assumes public ingress is exposed via Cloudflare Tunnel.
+```bash
+just app-deploy app=dspace env=staging tag="$APP_TAG"
+```
 
-Typical hostnames:
+Compatibility wrapper, kept for existing operators and scripts:
 
-- staging: `https://staging.democratized.space`
-- optional `prod.` subdomain (often redirect): `https://prod.democratized.space`
-- production apex: `https://democratized.space`
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
 
-For tunnel and DNS setup details, see [Cloudflare Tunnel docs](../cloudflare_tunnel.md).
+```bash
+just dspace-oci-deploy env=staging tag="$APP_TAG"
+```
+
+Use `app-redeploy` only when you intentionally need the upgrade-only path for an
+existing release and tag:
+
+```bash
+just app-redeploy app=dspace env=staging tag="$APP_TAG"
+```
+
+Low-level Helm OCI helpers remain available for unusual recovery work, but they
+are no longer the preferred runbook path:
+
+```bash
+just helm-oci-install release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.version tag="$APP_TAG"
+```
+
+```bash
+just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.version tag="$APP_TAG"
+```
+
+## Verify staging
+
+Use the generic verifier first. It resolves the host from the Helm release values
+and curls the app config's verify paths.
+
+```bash
+just app-status app=dspace env=staging
+```
+
+```bash
+just app-verify app=dspace env=staging
+```
+
+Manual staging checks:
+
+```bash
+kubectl --context sugar-staging -n dspace get deploy,po,svc,ingress
+```
+
+```bash
+kubectl --context sugar-staging -n dspace rollout status deploy/dspace --timeout=180s
+```
+
+```bash
+curl -fsS https://staging.democratized.space/config.json
+curl -fsS https://staging.democratized.space/healthz
+curl -fsS https://staging.democratized.space/livez
+```
+
+## Promote production
+
+Promote only the exact immutable image tag that passed staging. If `tag=` is
+omitted, the generic production command reads `docs/apps/dspace.prod.tag`; update that pin
+only as an explicit approval step.
+
+Preferred generic command:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-promote-prod app=dspace tag="$APP_TAG"
+```
+
+Compatibility wrapper:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just dspace-oci-promote-prod tag="$APP_TAG"
+```
+
+## Verify production
+
+```bash
+just app-status app=dspace env=prod
+```
+
+```bash
+just app-verify app=dspace env=prod
+```
+
+Manual production checks:
+
+```bash
+kubectl --context sugar-prod -n dspace get deploy,po,svc,ingress
+```
+
+```bash
+kubectl --context sugar-prod -n dspace rollout status deploy/dspace --timeout=180s
+```
+
+```bash
+curl -fsS https://democratized.space/config.json
+curl -fsS https://democratized.space/healthz
+curl -fsS https://democratized.space/livez
+```
+
+## Rollback
+
+Rollback by redeploying the previous known-good immutable tag. Prefer this when
+the previous image tag is known and the chart version did not need to change.
+
+```bash
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+```bash
+just app-deploy app=dspace env=staging tag="$APP_TAG"
+```
+
+```bash
+just app-promote-prod app=dspace tag="$APP_TAG"
+```
+
+Rollback by Helm revision only when you have confirmed the revision number:
+
+```bash
+APP_REVISION=12
+```
+
+```bash
+just tokenplace-rollback release=dspace namespace=dspace revision="$APP_REVISION"
+```
+
+`tokenplace-rollback` is the repository's existing parameterized Helm rollback
+helper despite its token.place-oriented name.
 
 ## Troubleshooting
 
-- GHCR/OCI auth errors (`401 authentication required` or `403 denied: denied`) for
-  `helm pull`/`helm-oci-*` helpers:
-  [Raspberry Pi Cluster Troubleshooting — Scenario 7](../raspi_cluster_troubleshooting.md#scenario-7-helm-oci-pull-fails-with-ghcr-403-denied-denied).
-- Collect dspace + ingress logs with environment-aware helper:
+GHCR/OCI auth failures usually mean Helm or Docker cannot read the package. Login
+with a GitHub token that has package read access, then retry the chart/image
+inspection commands.
 
-  ```bash
-  just dspace-debug-logs-env env=staging
-  just dspace-debug-logs-env env=prod
-  ```
+```bash
+helm registry login ghcr.io
+```
 
-- Inspect Helm release state:
-  - `helm -n dspace status dspace`
-  - `helm -n dspace get values dspace`
-- Inspect Kubernetes objects:
-  - `kubectl -n dspace get ingress,pods,svc`
-  - `kubectl -n dspace describe ingress dspace`
+```bash
+helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version "$APP_CHART_VERSION"
+```
+
+Inspect resolved config and cluster state:
+
+```bash
+just app-config app=dspace env=staging
+```
+
+```bash
+just app-status app=dspace env=staging
+```
+
+```bash
+kubectl --context sugar-staging -n dspace logs deploy/dspace --tail=120
+```
+
+Ingress and tunnel checks:
+
+```bash
+just traefik-status
+```
+
+```bash
+just cf-tunnel-debug
+```
+
+## App-specific notes
+
+- DSPACE uses `/config.json`, `/healthz`, and `/livez` as smoke checks.
+- Keep release lineage separate from environment routing: immutable image tags choose the app version; values overlays choose staging vs production hosts.
+- The optional `prod.democratized.space` overlay is not part of the default promotion path; use it only for an explicit pre-apex validation need.

--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -32,27 +32,24 @@ Defaults:
 
 ## Staging install/upgrade
 
-First install:
+Preferred generic deploy:
 
 ```bash
-just kubeconfig-env staging
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+APP_TAG=main-REPLACE_SHORTSHA
 ```
 
-Existing release upgrade:
-
 ```bash
-just kubeconfig-env staging
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+just app-deploy app=tokenplace env=staging tag="$APP_TAG"
 ```
 
-Preferred wrapper:
+Compatibility wrapper:
 
 ```bash
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just tokenplace-oci-deploy env=staging tag="$TOKENPLACE_TAG"
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just tokenplace-oci-deploy env=staging tag="$APP_TAG"
 ```
 
 ## Staging validation
@@ -67,36 +64,44 @@ curl -fsS https://staging.token.place/
 
 ## Production promotion, deploy, and rollback
 
-Promote approved staging image tag. Final production promotion after token.place Git tag push should use tag `v0.1.0` (tag only; repository is already set in chart values).
+Promote only the immutable staging image tag that passed relay validation. Final
+production promotion after a token.place Git tag push may use `v0.1.0` or the
+current approved release tag.
 
+Preferred generic production promotion:
 
 ```bash
-TOKENPLACE_TAG=v0.1.0 # use final release tag after token.place Git tag push
-just tokenplace-oci-promote-prod tag="$TOKENPLACE_TAG"
+APP_TAG=main-REPLACE_SHORTSHA
 ```
 
-Generic production upgrade with prod overlay:
+```bash
+just app-promote-prod app=tokenplace tag="$APP_TAG"
+```
+
+Compatibility wrapper:
 
 ```bash
-just kubeconfig-env prod
-TOKENPLACE_TAG=v0.1.0 # use final release tag after token.place Git tag push
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+just tokenplace-oci-promote-prod tag="$APP_TAG"
 ```
 
 Rollback using previous immutable tag:
 
 ```bash
-just kubeconfig-env prod
-TOKENPLACE_PREVIOUS_TAG=main-deadbee # replace with the prior immutable tag
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_PREVIOUS_TAG"
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+```bash
+just app-promote-prod app=tokenplace tag="$APP_TAG"
 ```
 
 Rollback to previous Helm revision:
 
 ```bash
-just kubeconfig-env prod
-TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
-just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
+APP_REVISION=12
+```
+
+```bash
+just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$APP_REVISION"
 ```
 
 Production validation:
@@ -159,4 +164,4 @@ just cf-tunnel-debug
 - Chart `appVersion`: `0.1.0`
 - Git tag: `v0.1.0`
 - Release image tag: `v0.1.0`
-- Staging candidate image tag: `main-<shortsha>`
+- Staging candidate image tag: `main-REPLACE_SHORTSHA`

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -1,144 +1,295 @@
 # token.place on Sugarkube
 
-This is the canonical Sugarkube deployment model for token.place.
+This runbook is the GHCR-first, generic-app deployment path for `tokenplace`. The app
+repository owns image and chart publishing; Sugarkube owns kubeconfig selection,
+values overlays, Helm deploys, status, verification, rollback, and logs. Cloudflare
+Tunnel/DNS routes are configured outside Helm and must already point the public
+hostnames at Traefik before production cutover.
 
-For the shared artifact, tag, chart, app-config, and planned generic command contract, see [Sugarkube app deployment contract](../app_deployment_contract.md).
+App-specific `just` recipes remain documented as compatibility shims. Prefer the
+generic `just app-* app=tokenplace` commands for new releases and future app
+onboarding; the wrappers are scheduled for later removal only after the generic
+flow has been exercised across routine releases.
 
-For onboarding ownership and environment sequencing, see
-[`docs/tokenplace_sugarkube_onboarding.md`](../tokenplace_sugarkube_onboarding.md).
+For the shared contract, tag policy, and config lookup order, see
+[Sugarkube app deployment contract](../app_deployment_contract.md). For future
+apps, see [App onboarding](../app_onboarding.md).
 
-## Relay-only topology (current scope)
+## Artifact model
 
-Sugarkube currently runs **only** the token.place relay service (`relay.py`).
-
-- **In-cluster (Sugarkube):** one relay deployment exposed through Traefik ingress.
-- **Out-of-cluster compute:** `server.py`, desktop Tauri app, Windows PCs, Apple Silicon Macs,
-  Raspberry Pi compute nodes, and other compute workers remain external.
-- **No in-cluster backend/GPU service** is required for steady-state relay operation.
-- **Single replica + single worker** defaults are intentional.
-- Relay state is currently **in-memory only**; pod restarts lose relay memory/state and this is
-  accepted for now.
-- Future in-memory database or multi-replica architecture is **out of scope** for this runbook.
-
-## Artifact model (canonical)
-
+- App repository: `futuroptimist/token.place`
 - Image: `ghcr.io/futuroptimist/tokenplace-relay`
 - Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
 - Helm release: `tokenplace`
-- Namespace: `tokenplace`
-- Chart version pin file: `docs/apps/tokenplace.version`
-- Production approved tag pin: `docs/apps/tokenplace.prod.tag`
+- Kubernetes namespace: `tokenplace`
+- Sugarkube app config: `docs/examples/apps/tokenplace.env`
+- Chart version pin: `docs/apps/tokenplace.version`
+- Production image tag pin: `docs/apps/tokenplace.prod.tag`
+- Verify paths: `/,/livez,/healthz,/relay/diagnostics`
 
-## Values model
+Responsibilities stay split:
 
-- Base: `docs/examples/tokenplace.values.dev.yaml`
-- Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
-- Production overlay: `docs/examples/tokenplace.values.prod.yaml`
+- **App repo:** build the container image, publish immutable GHCR tags such as
+  `main-REPLACE_SHORTSHA`, package the Helm chart, and publish immutable OCI chart
+  versions.
+- **Sugarkube:** select `dev`, `staging`, or `prod`; load app config; apply values
+  overlays; run Helm; verify URLs; inspect pods/logs; and perform rollback.
+- **Cloudflare:** maintain DNS and tunnel routes to Traefik. Helm creates
+  Kubernetes Ingress objects, not Cloudflare routes.
 
-Chart-owned runtime env defaults (worker count, frontend mode, relay upstream-health gating, and XDG `/tmp` paths) should remain in the token.place chart. Keep Sugarkube values focused on environment-specific keys like `TOKEN_PLACE_ENV`, `TOKENPLACE_RELAY_PUBLIC_URL`, ingress hosts, and TLS secrets.
+## Environment topology
 
-Default hosts:
+- Staging environment: `env=staging`, host `https://staging.token.place`.
+- Production environment: `env=prod`, host `https://token.place`.
+- Values overlays:
+  - Base/dev: `docs/examples/tokenplace.values.dev.yaml`
+  - Staging: `docs/examples/tokenplace.values.staging.yaml`
+  - Production: `docs/examples/tokenplace.values.prod.yaml`
 
-- Staging: `staging.token.place`
-- Production: `token.place`
+Sugarkube runs only the token.place relay service. `server.py`, desktop clients, GPUs, Macs, PCs, and other compute nodes remain external. The current relay runtime is single replica, single worker, and in-memory; pod restarts can lose relay state and that is accepted for now.
 
-## Core deployment commands
-
-Use concrete release/namespace/chart values for token.place relay deployments.
-
-```bash
-just kubeconfig-env staging
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
-```
-
-```bash
-just kubeconfig-env staging
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
-```
-
-Preferred env wrapper:
+Confirm Cloudflare routing separately when a hostname is new or has changed:
 
 ```bash
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just tokenplace-oci-deploy env=staging tag="$TOKENPLACE_TAG"
-```
-
-## Validation commands
-
-```bash
-kubectl -n tokenplace get deploy,po,svc,ingress
-kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
-curl -fsS https://staging.token.place/livez
-curl -fsS https://staging.token.place/healthz
-curl -fsS https://staging.token.place/relay/diagnostics
-curl -fsS https://staging.token.place/
-```
-
-For production validation, use the same checks against `https://token.place`. Avoid long-running
-public `/healthz` watches as readiness monitors until health, liveness, metrics, diagnostics, and
-API v1 compute-node heartbeat routes are confirmed exempt from public API rate limits; prefer
-`kubectl -n tokenplace get endpoints`, `kubectl -n tokenplace get deploy,po`, relay logs, and
-low-frequency diagnostics curls for operational readiness. Staging/prod signoff also requires
-synthetic API v1 register/poll, an external desktop or compute-node registration, and an E2EE
-request/response through the relay; see the staging runbook for the full sequence and curl payloads.
-
-## Promotion blockers
-
-Use the environment runbooks for copy-paste commands, but keep this release-blocker rule in every
-token.place promotion review: **web/TLS health is not relay validation**. A build can only move from
-staging to production after all of these are true:
-
-- [ ] OCI chart freshness and chart digest are captured for the exact version being promoted.
-- [ ] Rendered manifests contain no duplicate env vars.
-- [ ] XDG writable `/tmp` env defaults are present from the chart, not one-off CLI overrides.
-- [ ] `/healthz` is exempt from API rate limiting.
-- [ ] Synthetic API v1 compute-node register/poll passes.
-- [ ] A desktop compute node uses the intended `knownServers`/server entry and registers.
-- [ ] The registered compute node appears in `/healthz` and `/relay/diagnostics`.
-- [ ] An E2EE request/response succeeds through that compute node.
-- [ ] The production Cloudflare route exists and points to Traefik before prod cutover.
-
-Emergency diagnostics and rollback remain environment-specific:
-
-- Staging: [`docs/k3s-tokenplace-staging.md`](../k3s-tokenplace-staging.md)
-- Production: [`docs/k3s-tokenplace-prod.md`](../k3s-tokenplace-prod.md)
-
-## Cloudflare and ingress model
-
-Cloudflare Tunnel/DNS configuration is external to Helm.
-
-- Route hostnames to Traefik, typically
-  `http://traefik.kube-system.svc.cluster.local:80`.
-- Helm chart deployment does **not** create Cloudflare routes.
-- One tunnel per environment can serve multiple app hostnames (for example
-  `staging.democratized.space` and `staging.token.place`) by routing both to Traefik.
-- Traefik chooses the correct Kubernetes Ingress by HTTP `Host` header.
-- Staging/prod overlays set `ingress.tls.enabled: true` so rendered Kubernetes Ingress includes `spec.tls`.
-- `cert-manager` and a compatible `ClusterIssuer` are assumed to already exist.
-- Cloudflare Tunnel routing (`cf-tunnel-route`) is separate from the Cloudflare DNS API token used
-  by cert-manager DNS-01.
-- Configure routes explicitly:
-
-```bash
-just cf-tunnel-route staging.token.place
 just cf-tunnel-route host=staging.token.place
-just cf-tunnel-route token.place
+```
+
+```bash
 just cf-tunnel-route host=token.place
 ```
 
-## Related runbooks
+## Find or publish GHCR image
 
-- Relay-focused app guide: [`docs/apps/tokenplace-relay.md`](./tokenplace-relay.md)
-- Staging runbook: [`docs/k3s-tokenplace-staging.md`](../k3s-tokenplace-staging.md)
-- Production runbook: [`docs/k3s-tokenplace-prod.md`](../k3s-tokenplace-prod.md)
+Start from the app repository's image workflow. A successful workflow should push
+an immutable tag, usually `main-REPLACE_SHORTSHA`, plus any app-specific release
+or convenience tags documented by that repository.
 
+```bash
+gh run list --repo futuroptimist/token.place --workflow ci-image.yml --limit 10
+```
 
-## 0.1.0 release alignment
+Set the immutable image tag you are about to deploy:
 
-- Chart version: `0.1.0`
-- Chart `appVersion`: `0.1.0`
-- Git tag: `v0.1.0`
-- Release image tag: `v0.1.0` (`ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
-- Staging candidate image tag: `main-<shortsha>`
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+Inspect the GHCR image manifest before deploying. If this fails with an auth
+error, login with a GitHub token that can read packages for the app repository.
+
+```bash
+docker manifest inspect ghcr.io/futuroptimist/tokenplace-relay:$APP_TAG
+```
+
+Do not lead staging or production deployments with local Docker builds. Local
+builds are for app-repo development only; Sugarkube deploys published GHCR
+artifacts.
+
+## Confirm/publish OCI chart
+
+The app repository owns chart changes and immutable chart publishing. If the chart
+changed, bump the chart version in the app repository before publishing; do not
+republish different chart content at the same version.
+
+Read the Sugarkube chart version pin:
+
+```bash
+APP_CHART_VERSION=$(grep -E '^[0-9]+[.][0-9]+[.][0-9]+' docs/apps/tokenplace.version | head -n1)
+```
+
+Confirm the pinned chart is available from GHCR:
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$APP_CHART_VERSION"
+```
+
+If the chart was changed but the pinned version is missing or stale, publish it
+from the app repository first, then update `docs/apps/tokenplace.version` in Sugarkube only
+after the immutable OCI chart exists.
+
+## Deploy staging
+
+Preferred generic command:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-deploy app=tokenplace env=staging tag="$APP_TAG"
+```
+
+Compatibility wrapper, kept for existing operators and scripts:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just tokenplace-oci-deploy env=staging tag="$APP_TAG"
+```
+
+Use `app-redeploy` only when you intentionally need the upgrade-only path for an
+existing release and tag:
+
+```bash
+just app-redeploy app=tokenplace env=staging tag="$APP_TAG"
+```
+
+## Verify staging
+
+Use the generic verifier first. It resolves the host from the Helm release values
+and curls the app config's verify paths.
+
+```bash
+just app-status app=tokenplace env=staging
+```
+
+```bash
+just app-verify app=tokenplace env=staging
+```
+
+Manual staging checks:
+
+```bash
+kubectl --context sugar-staging -n tokenplace get deploy,po,svc,ingress
+```
+
+```bash
+kubectl --context sugar-staging -n tokenplace rollout status deploy/tokenplace --timeout=180s
+```
+
+```bash
+curl -fsS https://staging.token.place/
+curl -fsS https://staging.token.place/livez
+curl -fsS https://staging.token.place/healthz
+curl -fsS https://staging.token.place/relay/diagnostics
+```
+
+## Promote production
+
+Promote only the exact immutable image tag that passed staging. If `tag=` is
+omitted, the generic production command reads `docs/apps/tokenplace.prod.tag`; update that pin
+only as an explicit approval step.
+
+Preferred generic command:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-promote-prod app=tokenplace tag="$APP_TAG"
+```
+
+Compatibility wrapper:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+just tokenplace-oci-promote-prod tag="$APP_TAG"
+```
+
+## Verify production
+
+```bash
+just app-status app=tokenplace env=prod
+```
+
+```bash
+just app-verify app=tokenplace env=prod
+```
+
+Manual production checks:
+
+```bash
+kubectl --context sugar-prod -n tokenplace get deploy,po,svc,ingress
+```
+
+```bash
+kubectl --context sugar-prod -n tokenplace rollout status deploy/tokenplace --timeout=180s
+```
+
+```bash
+curl -fsS https://token.place/
+curl -fsS https://token.place/livez
+curl -fsS https://token.place/healthz
+curl -fsS https://token.place/relay/diagnostics
+```
+
+## Rollback
+
+Rollback by redeploying the previous known-good immutable tag. Prefer this when
+the previous image tag is known and the chart version did not need to change.
+
+```bash
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+```bash
+just app-deploy app=tokenplace env=staging tag="$APP_TAG"
+```
+
+```bash
+just app-promote-prod app=tokenplace tag="$APP_TAG"
+```
+
+Rollback by Helm revision only when you have confirmed the revision number:
+
+```bash
+APP_REVISION=12
+```
+
+```bash
+just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$APP_REVISION"
+```
+
+`tokenplace-rollback` is the repository's existing parameterized Helm rollback
+helper despite its token.place-oriented name.
+
+## Troubleshooting
+
+GHCR/OCI auth failures usually mean Helm or Docker cannot read the package. Login
+with a GitHub token that has package read access, then retry the chart/image
+inspection commands.
+
+```bash
+helm registry login ghcr.io
+```
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$APP_CHART_VERSION"
+```
+
+Inspect resolved config and cluster state:
+
+```bash
+just app-config app=tokenplace env=staging
+```
+
+```bash
+just app-status app=tokenplace env=staging
+```
+
+```bash
+kubectl --context sugar-staging -n tokenplace logs deploy/tokenplace --tail=120
+```
+
+Ingress and tunnel checks:
+
+```bash
+just traefik-status
+```
+
+```bash
+just cf-tunnel-debug
+```
+
+## App-specific notes
+
+- Web/TLS health is not complete relay validation. Before production, also run API v1 register/poll, confirm an external compute node registration, and complete an E2EE request/response through the relay.
+- Avoid long-running public `/healthz` watches until token.place confirms health, liveness, metrics, diagnostics, and compute-node heartbeat routes are exempt from public API rate limits.
+- Keep writable XDG `/tmp` defaults and duplicate-env prevention in the app chart, not as one-off Sugarkube CLI overrides.
+- Related relay-focused guide: [`docs/apps/tokenplace-relay.md`](./tokenplace-relay.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,12 +43,14 @@ Review the safety notes before working with power components.
   and Helm OCI issues, including GHCR `401/403` chart pull failures
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
 - [projects-compose.md](projects-compose.md) — run token.place & dspace via docker compose
-- [app_deployment_contract.md](app_deployment_contract.md) — shared Sugarkube app artifact, tag, chart, config, and planned generic command contract
+- [app_deployment_contract.md](app_deployment_contract.md) — shared Sugarkube app artifact, tag, chart, config, and generic command contract
+- [app_onboarding.md](app_onboarding.md) — future-app onboarding checklist and release decision tree for wove, jobbot3000, and later apps
 - [tokenplace_sugarkube_onboarding.md](tokenplace_sugarkube_onboarding.md) — onboarding contract,
   ownership boundaries, and environment mapping for token.place on Sugarkube
-- [apps/tokenplace.md](apps/tokenplace.md) — token.place app topology and operations model on Sugarkube
+- [apps/dspace.md](apps/dspace.md) — DSPACE GHCR-first deployment, promotion, verification, rollback, and troubleshooting
+- [apps/tokenplace.md](apps/tokenplace.md) — token.place GHCR-first deployment, promotion, verification, rollback, and relay notes
 - [apps/tokenplace-relay.md](apps/tokenplace-relay.md) — relay-only token.place OCI staging/prod operations guide
-- [apps/danielsmith.md](apps/danielsmith.md) — danielsmith.io static-site topology and operations model on Sugarkube
+- [apps/danielsmith.md](apps/danielsmith.md) — danielsmith.io GHCR-first deployment, promotion, verification, rollback, and static-site notes
 - [k3s-tokenplace-dev.md](k3s-tokenplace-dev.md) — token.place dev runbook
 - [k3s-tokenplace-staging.md](k3s-tokenplace-staging.md) — token.place staging runbook
 - [k3s-tokenplace-prod.md](k3s-tokenplace-prod.md) — token.place production runbook

--- a/docs/k3s-danielsmith-prod.md
+++ b/docs/k3s-danielsmith-prod.md
@@ -1,85 +1,83 @@
 # k3s danielsmith.io runbook (prod)
 
-Use this runbook for production deployments of the static `danielsmith.io` site on Sugarkube.
+Use this environment runbook for production `danielsmith.io` operations. The full
+uniform app flow lives in [danielsmith.io on Sugarkube](apps/danielsmith.md); this
+page keeps the production commands copy-pasteable.
 
-## Topology and scope
+## Responsibilities
 
-- `danielsmith.io` is a static Vite + Three.js workload.
-- Sugarkube runs only the static web container.
-- No in-cluster API/backend/database/queue/GPU/compute node/stateful service is required.
-- Cloudflare Tunnel fronts Traefik; Traefik routes traffic to the `danielsmith` Service.
-- Probe/application endpoints: `/livez`, `/healthz`, and `/`.
+- App repo: publish the approved static-site image and immutable OCI chart.
+- Sugarkube: promote the staging-verified image tag to `env=prod`, verify, inspect
+  logs, and roll back.
+- Cloudflare: route `danielsmith.io` to Traefik outside Helm.
 
-## Artifact and values contract
+## Promote production
 
-- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
-- Image: `ghcr.io/futuroptimist/danielsmith.io`
-- Release: `danielsmith`
-- Namespace: `danielsmith`
-- Version pin file: `docs/apps/danielsmith.version`
-- Approved prod tag file: `docs/apps/danielsmith.prod.tag`
-- Values: `docs/examples/danielsmith.values.dev.yaml` + `docs/examples/danielsmith.values.prod.yaml`
-- Default production host: `danielsmith.io`
-
-## First install
-
-Always select the production kube context before running the generic Helm install command.
+Preferred generic command:
 
 ```bash
-just kubeconfig-env prod
-DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the approved immutable GHCR image tag
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_APPROVED_TAG"
+APP_TAG=main-REPLACE_SHORTSHA
 ```
 
-## Promotion after staging sign-off
-
 ```bash
-DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the approved immutable GHCR image tag
-just danielsmith-oci-promote-prod tag="$DANIELSMITH_APPROVED_TAG"
+just app-promote-prod app=danielsmith tag="$APP_TAG"
 ```
 
-## Generic production upgrade
+Compatibility wrapper:
 
 ```bash
-just kubeconfig-env prod
-DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the approved immutable GHCR image tag
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_APPROVED_TAG"
+just danielsmith-oci-promote-prod tag="$APP_TAG"
 ```
 
-## Validation
+## Production verify
 
 ```bash
-kubectl -n danielsmith get deploy,po,svc,ingress
-kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+just app-status app=danielsmith env=prod
+```
+
+```bash
+just app-verify app=danielsmith env=prod
+```
+
+Manual checks:
+
+```bash
+kubectl --context sugar-prod -n danielsmith rollout status deploy/danielsmith --timeout=180s
+```
+
+```bash
 curl -fsS https://danielsmith.io/livez
+```
+
+```bash
 curl -fsS https://danielsmith.io/healthz
+```
+
+```bash
 curl -fsS https://danielsmith.io/
 ```
 
-## Rollback options
-
-Rollback by immutable tag:
+## Production rollback
 
 ```bash
-just kubeconfig-env prod
-DANIELSMITH_PREVIOUS_APPROVED_TAG=main-REPLACE_PREVIOUS_APPROVED_SHORTSHA # replace with the previous approved immutable GHCR image tag
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_PREVIOUS_APPROVED_TAG"
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA
 ```
-
-Rollback by Helm revision:
-
-`tokenplace-rollback` is the repository's existing parameterized Helm rollback helper, even though the recipe name is token.place-scoped.
 
 ```bash
-just kubeconfig-env prod
-DANIELSMITH_REVISION=12 # replace with the known-good Helm revision
-just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$DANIELSMITH_REVISION"
+just app-promote-prod app=danielsmith tag="$APP_TAG"
 ```
 
-## Cloudflare tunnel routing (external to Helm)
+Helm revision rollback, only with a confirmed revision:
 
-Cloudflare routes are configured outside the chart. Route `danielsmith.io` to Traefik,
-typically `http://traefik.kube-system.svc.cluster.local:80`.
+```bash
+APP_REVISION=12
+```
+
+```bash
+just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$APP_REVISION"
+```
+
+## Cloudflare route
 
 ```bash
 just cf-tunnel-route host=danielsmith.io
@@ -87,24 +85,14 @@ just cf-tunnel-route host=danielsmith.io
 
 ## Troubleshooting
 
-GHCR auth/chart checks:
-
 ```bash
-echo "$GHCR_TOKEN" | helm registry login ghcr.io -u "$GHCR_USER" --password-stdin
-helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/danielsmith.version | head -n1)"
+just app-config app=danielsmith env=prod
 ```
 
-App status/logs:
-
 ```bash
-just danielsmith-status
-just danielsmith-debug-logs-env env=prod
+just app-status app=danielsmith env=prod
 ```
 
-Ingress/tunnel checks:
-
 ```bash
-just cluster-status
-just traefik-status
-just cf-tunnel-debug
+kubectl --context sugar-prod -n danielsmith logs deploy/danielsmith --tail=120
 ```

--- a/docs/k3s-danielsmith-staging.md
+++ b/docs/k3s-danielsmith-staging.md
@@ -1,82 +1,83 @@
 # k3s danielsmith.io runbook (staging)
 
-Use this runbook for staging deployments of the static `danielsmith.io` site on Sugarkube.
+Use this environment runbook for staging-only `danielsmith.io` operations. The
+full uniform app flow lives in [danielsmith.io on Sugarkube](apps/danielsmith.md);
+this page keeps the staging commands copy-pasteable.
 
-## Topology and scope
+## Responsibilities
 
-- `danielsmith.io` is a static Vite + Three.js workload.
-- Sugarkube runs only the static web container.
-- No in-cluster API/backend/database/queue/GPU/compute node/stateful service is required.
-- Cloudflare Tunnel fronts Traefik; Traefik routes traffic to the `danielsmith` Service.
-- Probe/application endpoints: `/livez`, `/healthz`, and `/`.
+- App repo: publish `ghcr.io/futuroptimist/danielsmith.io:main-REPLACE_SHORTSHA`
+  and `oci://ghcr.io/futuroptimist/charts/danielsmith`.
+- Sugarkube: deploy `env=staging`, verify, inspect logs, and roll back.
+- Cloudflare: route `staging.danielsmith.io` to Traefik outside Helm.
 
-## Artifact and values contract
+## Staging deploy
 
-- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
-- Image: `ghcr.io/futuroptimist/danielsmith.io`
-- Release: `danielsmith`
-- Namespace: `danielsmith`
-- Version pin file: `docs/apps/danielsmith.version`
-- Values: `docs/examples/danielsmith.values.dev.yaml` + `docs/examples/danielsmith.values.staging.yaml`
-- Default staging host: `staging.danielsmith.io`
-
-## First install
+Preferred generic command:
 
 ```bash
-just kubeconfig-env staging
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
+APP_TAG=main-REPLACE_SHORTSHA
 ```
 
-## Existing release upgrade
-
 ```bash
-just kubeconfig-env staging
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
+just app-deploy app=danielsmith env=staging tag="$APP_TAG"
 ```
 
-Preferred wrapper:
+Compatibility wrapper:
 
 ```bash
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
-just danielsmith-oci-deploy env=staging tag="$DANIELSMITH_TAG"
+just danielsmith-oci-deploy env=staging tag="$APP_TAG"
 ```
 
-## Validation
+## Staging verify
 
 ```bash
-kubectl -n danielsmith get deploy,po,svc,ingress
-kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+just app-status app=danielsmith env=staging
+```
+
+```bash
+just app-verify app=danielsmith env=staging
+```
+
+Manual checks:
+
+```bash
+kubectl --context sugar-staging -n danielsmith rollout status deploy/danielsmith --timeout=180s
+```
+
+```bash
 curl -fsS https://staging.danielsmith.io/livez
+```
+
+```bash
 curl -fsS https://staging.danielsmith.io/healthz
+```
+
+```bash
 curl -fsS https://staging.danielsmith.io/
 ```
 
-## Rollback
-
-Rollback by immutable tag:
+## Staging rollback
 
 ```bash
-just kubeconfig-env staging
-DANIELSMITH_PREVIOUS_TAG=main-REPLACE_PREVIOUS_SHORTSHA # replace with the previous immutable GHCR image tag
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_PREVIOUS_TAG"
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA
 ```
-
-Rollback by Helm revision:
-
-`tokenplace-rollback` is the repository's existing parameterized Helm rollback helper, even though the recipe name is token.place-scoped.
 
 ```bash
-just kubeconfig-env staging
-DANIELSMITH_REVISION=12 # replace with the known-good Helm revision
-just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$DANIELSMITH_REVISION"
+just app-deploy app=danielsmith env=staging tag="$APP_TAG"
 ```
 
-## Cloudflare tunnel routing (external to Helm)
+Helm revision rollback, only with a confirmed revision:
 
-Cloudflare routes are configured outside the chart. Route `staging.danielsmith.io` to Traefik,
-typically `http://traefik.kube-system.svc.cluster.local:80`.
+```bash
+APP_REVISION=12
+```
+
+```bash
+just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$APP_REVISION"
+```
+
+## Cloudflare route
 
 ```bash
 just cf-tunnel-route host=staging.danielsmith.io
@@ -84,24 +85,14 @@ just cf-tunnel-route host=staging.danielsmith.io
 
 ## Troubleshooting
 
-GHCR auth/chart checks:
-
 ```bash
-echo "$GHCR_TOKEN" | helm registry login ghcr.io -u "$GHCR_USER" --password-stdin
-helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/danielsmith.version | head -n1)"
+just app-config app=danielsmith env=staging
 ```
 
-App status/logs:
-
 ```bash
-just danielsmith-status
-just danielsmith-debug-logs-env env=staging
+just app-status app=danielsmith env=staging
 ```
 
-Ingress/tunnel checks:
-
 ```bash
-just cluster-status
-just traefik-status
-just cf-tunnel-debug
+kubectl --context sugar-staging -n danielsmith logs deploy/danielsmith --tail=120
 ```

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -1,293 +1,102 @@
 # k3s token.place runbook (prod)
 
-Use this runbook for relay-only token.place production deployments on Sugarkube.
+Use this environment runbook for production token.place operations. The full
+uniform app flow lives in [token.place on Sugarkube](apps/tokenplace.md); this
+page keeps the production commands copy-pasteable.
 
-## Topology and scope
+## Responsibilities
 
-- Sugarkube runs only token.place relay (`relay.py`).
-- No in-cluster backend/GPU service is required.
-- Compute nodes remain external (`server.py`, Tauri desktop app, Windows PCs, Apple Silicon Macs,
-  Raspberry Pi compute nodes, etc.).
-- Runtime model is single replica + single Gunicorn worker + in-memory state; verify the rendered Kubernetes Deployment contract includes `spec.strategy.type: Recreate` before rollout.
-- In-memory state loss on pod restart is accepted for now.
+- App repo: publish the approved relay image and immutable OCI chart.
+- Sugarkube: promote the staging-verified image tag to `env=prod`, verify, inspect
+  logs, and roll back.
+- Cloudflare: route `token.place` to Traefik outside Helm.
 
-## Artifact and values contract
+## Promote production
 
-- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Image: `ghcr.io/futuroptimist/tokenplace-relay`
-- Release: `tokenplace`
-- Namespace: `tokenplace`
-- Version pin file: `docs/apps/tokenplace.version`
-- Approved prod tag file: `docs/apps/tokenplace.prod.tag`
-- Values: `docs/examples/tokenplace.values.dev.yaml` + `docs/examples/tokenplace.values.prod.yaml`
-- Default production host: `token.place`
-
-## Pre-flight (before Step 1)
-
-- Verify `docs/apps/tokenplace.version` remains pinned to `0.1.0`.
-- Verify the `0.1.0` OCI chart exists only after token.place publishes the current chart.
-- If `helm show chart ... --version 0.1.0` succeeds before the final token.place chart publish, confirm the chart is not stale before deploying.
+Preferred generic command:
 
 ```bash
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+APP_TAG=main-REPLACE_SHORTSHA
 ```
 
-## Promotion after staging sign-off
-
-Production promotion requires an external desktop or compute-node registration plus a successful
-E2EE request/response; Certificate `Ready=True`, web/TLS checks, or synthetic register/poll alone
-are not sufficient signoff.
-
 ```bash
-TOKENPLACE_TAG=v0.1.0 # use final release tag after token.place Git tag push
-just tokenplace-oci-promote-prod tag="$TOKENPLACE_TAG"
+just app-promote-prod app=tokenplace tag="$APP_TAG"
 ```
 
-## Generic production upgrade
-
-Select the production kube context first (or use the wrapper above):
+Compatibility wrapper:
 
 ```bash
-just kubeconfig-env prod
+just tokenplace-oci-promote-prod tag="$APP_TAG"
 ```
 
-Then run the generic OCI helper:
+## Production verify
 
 ```bash
-TOKENPLACE_TAG=v0.1.0 # use final release tag after token.place Git tag push
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+just app-status app=tokenplace env=prod
 ```
 
-## Validation
-
-Render/contract checks:
-
 ```bash
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
-helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.prod.yaml --set image.tag=v0.1.0 > /tmp/tokenplace-prod-render.yaml
-python3 - <<'PY'
-import collections
-import sys
-
-try:
-    import yaml
-except ModuleNotFoundError:
-    sys.exit("PyYAML is required for this render validation. Install it with: python3 -m pip install PyYAML")
-
-with open("/tmp/tokenplace-prod-render.yaml", encoding="utf-8") as rendered:
-    docs = list(yaml.safe_load_all(rendered))
-
-try:
-    deploy = next(
-        d
-        for d in docs
-        if d and d.get("kind") == "Deployment" and d.get("metadata", {}).get("name") == "tokenplace"
-    )
-except StopIteration:
-    sys.exit("tokenplace Deployment not found in rendered manifest")
-
-pod_spec = deploy["spec"]["template"]["spec"]
-for container_type, containers in (
-    ("init", pod_spec.get("initContainers", [])),
-    ("app", pod_spec.get("containers", [])),
-):
-    for container in containers:
-        names = [item["name"] for item in container.get("env", []) if "name" in item]
-        dupes = [name for name, count in collections.Counter(names).items() if count > 1]
-        if dupes:
-            sys.exit(f"duplicate env names found: {container_type}:{container.get('name', '<unnamed>')}: {dupes}")
-PY
-grep -n "spec:" -A40 /tmp/tokenplace-prod-render.yaml | grep -n "tls"
-grep -n "token.place" /tmp/tokenplace-prod-render.yaml
-grep -n "tokenplace-prod-tls" /tmp/tokenplace-prod-render.yaml
-yq eval '. | select(.kind == "Deployment" and .metadata.name == "tokenplace") | .spec.strategy.type' /tmp/tokenplace-prod-render.yaml
+just app-verify app=tokenplace env=prod
 ```
 
-Cluster/runtime checks:
+Manual checks:
 
 ```bash
-kubectl -n tokenplace get deploy,po,svc,ingress
-kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
-kubectl -n tokenplace get ingress tokenplace -o yaml
-curl -vI https://token.place/
+kubectl --context sugar-prod -n tokenplace rollout status deploy/tokenplace --timeout=180s
+```
+
+```bash
 curl -fsS https://token.place/livez
+```
+
+```bash
 curl -fsS https://token.place/healthz
 ```
 
-## Promotion blockers
-
-> **Release blocker:** production promotion is blocked until staging proves the actual
-> relay-compute path, and the promoted production deployment then proves its own prod
-> compute-node path. Deployment Ready, TLS Ready, `/livez`, `/healthz`, `/`, `/metrics`, and
-> synthetic register/poll are necessary but not sufficient by themselves.
-
-Before running the prod upgrade, confirm every item from staging sign-off evidence:
-
-- [ ] OCI chart freshness is proven with `helm show chart` plus chart digest evidence for the
-  exact chart version being promoted from staging to prod.
-- [ ] Render validation finds no duplicate environment variables in any init/app container.
-- [ ] Rendered Deployment includes writable XDG `/tmp` defaults from the chart without one-off
-  Sugarkube override drift.
-- [ ] Staging `/healthz` is exempt from token.place global API rate limits.
-- [ ] Synthetic API v1 compute-node register/poll passes against `https://staging.token.place`.
-- [ ] A desktop compute node has `staging.token.place` in `knownServers`/server config, registers
-  to staging, appears in staging `/healthz` and `/relay/diagnostics`, and completes an E2EE
-  request/response through the staging relay.
-- [ ] The prod Cloudflare route for `token.place` is configured to Traefik and checked outside
-  Helm/cert-manager before promotion.
-
-After the prod upgrade, capture separate prod validation evidence before marking the promotion
-complete:
-
-- [ ] Synthetic API v1 compute-node register/poll passes against `https://token.place`.
-- [ ] A desktop compute node has `token.place` in `knownServers`/server config, registers to prod,
-  and does not silently fall back to staging.
-- [ ] That prod-registered compute node appears in prod `/healthz` and `/relay/diagnostics`.
-- [ ] An E2EE request/response succeeds through the prod-registered compute node.
-
-### Release evidence capture
-
-Capture and attach the staging sign-off artifacts plus this separate prod evidence for the prod
-promotion record. For the prod evidence, run the prod synthetic register/poll, confirm prod
-desktop compute-node registration, and complete the prod E2EE request/response before saving
-`/healthz`, `/relay/diagnostics`, or relay logs so those artifacts prove the prod-registered
-desktop compute node is visible after the real prod relay-compute path passes:
-
 ```bash
-just kubeconfig-env prod
-TOKENPLACE_TAG=v0.1.0 # replace with the immutable release tag
-TOKENPLACE_HOST=token.place
-TOKENPLACE_CHART_VERSION="$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
-
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$TOKENPLACE_CHART_VERSION"
-helm pull oci://ghcr.io/futuroptimist/charts/tokenplace --version "$TOKENPLACE_CHART_VERSION" --destination /tmp
-sha256sum "/tmp/tokenplace-${TOKENPLACE_CHART_VERSION}.tgz" # chart digest evidence
-printf 'image tag: ghcr.io/futuroptimist/tokenplace-relay:%s\n' "$TOKENPLACE_TAG"
-kubectl -n tokenplace get deploy tokenplace -o yaml > /tmp/tokenplace-prod-deployment.yaml
-# First run synthetic register/poll, desktop compute-node registration, and the E2EE flow.
-# Then capture health, diagnostics, and relay logs as post-compute-path evidence:
-curl -fsS "https://${TOKENPLACE_HOST}/healthz" | tee /tmp/tokenplace-prod-healthz.json
-curl -fsS "https://${TOKENPLACE_HOST}/relay/diagnostics" | tee /tmp/tokenplace-prod-diagnostics.json
-kubectl -n tokenplace logs deploy/tokenplace --since=30m --tail=500 | tee /tmp/tokenplace-prod-relay-after-compute.log
+curl -fsS https://token.place/relay/diagnostics
 ```
 
-### Emergency diagnostics
-
-This emergency diagnostics command block is copy-pasteable. Run it when prod web/TLS health is green but compute registration or E2EE is blocked:
-
 ```bash
-just kubeconfig-env prod
-TOKENPLACE_HOST=token.place
-
-kubectl -n tokenplace get deployments,replicasets,pods,services,ingress,certificates -o wide
-kubectl -n tokenplace describe deploy/tokenplace
-kubectl -n tokenplace describe ingress/tokenplace
-kubectl -n tokenplace get events --sort-by=.lastTimestamp | tail -n 80
-kubectl -n tokenplace logs deploy/tokenplace --since=30m --tail=500
-kubectl -n tokenplace logs deploy/tokenplace --previous --tail=500 || true
-curl -vI "https://${TOKENPLACE_HOST}/"
-curl -fsS "https://${TOKENPLACE_HOST}/healthz" || true
-curl -fsS "https://${TOKENPLACE_HOST}/relay/diagnostics" || true
-just cf-tunnel-debug
-just cert-manager-status
+curl -fsS https://token.place/
 ```
 
-If Cloudflare returns HTTP 403 before the request reaches token.place, check Cloudflare Security
-Events for the hostname, ray ID, source IP, path, and rule that made the decision.
-
-## Rollback options
-
-Rollback reminders:
-
-- Prefer immutable image tag rollback when the bad rollout is tied to a single image.
-- Use Helm revision rollback when you need to restore the entire rendered release state.
-- Expect a short outage during rollback because token.place is intentionally single-replica and
-  the Deployment strategy is `Recreate`; wait for the replacement pod before retesting relay E2EE.
-
-Rollback by immutable tag:
+## Production rollback
 
 ```bash
-just kubeconfig-env prod
-TOKENPLACE_PREVIOUS_TAG=main-deadbee # replace with the prior immutable tag
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_PREVIOUS_TAG"
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA
 ```
 
-Rollback by Helm revision:
-
 ```bash
-just kubeconfig-env prod
-TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
-just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
+just app-promote-prod app=tokenplace tag="$APP_TAG"
 ```
 
-## Cloudflare tunnel routing (external to Helm)
-
-Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes. Route `token.place` to Traefik,
-typically `http://traefik.kube-system.svc.cluster.local:80`. Production overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
-and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
-One tunnel per environment can carry multiple app hostnames by routing them all to Traefik, with
-Traefik selecting the target backend by `Host` header.
-
-`cf-tunnel-route` configures Cloudflare Tunnel hostname routing. It does not configure the
-cert-manager Cloudflare DNS token used for ACME DNS-01.
+Helm revision rollback, only with a confirmed revision:
 
 ```bash
-just cf-tunnel-route token.place
+APP_REVISION=12
+```
+
+```bash
+just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$APP_REVISION"
+```
+
+## Cloudflare route
+
+```bash
 just cf-tunnel-route host=token.place
 ```
 
-## cert-manager + Cloudflare DNS-01 (non-Flux clusters)
-
-For non-Flux production clusters, use the same manual Helm + issuer flow validated during staging:
-
-```bash
-just cert-manager-install
-just cert-manager-cloudflare-token-secret token="$CF_DNS_API_TOKEN"
-just cert-manager-issuers-apply email="ops@token.place"
-just cert-manager-status
-```
-
-Do not reuse the tunnel token (`CF_TUNNEL_TOKEN`) for DNS-01. cert-manager needs a separate Cloudflare DNS API token scoped to:
-
-- `Zone -> DNS -> Edit`
-- `Zone -> Zone -> Read`
-- specific required zones (`token.place`, and `democratized.space` if shared issuance is in scope).
-
-For production promotion, the cert-manager release gate is the Certificate condition: proceed only
-when the relevant Certificate is `Ready=True`. Challenge cleanup errors after successful issuance do
-not invalidate an already-ready certificate, but they should be investigated because they often mean
-the DNS API token lacks `Zone -> Zone -> Read`, is scoped to the wrong Cloudflare zone, or cert-manager
-is hitting resolver/zone lookup ambiguity during cleanup.
-
 ## Troubleshooting
 
-GHCR auth/chart checks:
-
 ```bash
-echo "$GHCR_TOKEN" | helm registry login ghcr.io -u "$GHCR_USER" --password-stdin
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
+just app-config app=tokenplace env=prod
 ```
 
-App status/logs:
-
 ```bash
-just tokenplace-status
-just tokenplace-debug-logs-env env=prod
+just app-status app=tokenplace env=prod
 ```
 
-Ingress/tunnel checks:
-
 ```bash
-just cluster-status
-just traefik-status
-just cf-tunnel-debug
+kubectl --context sugar-prod -n tokenplace logs deploy/tokenplace --tail=120
 ```
-
-
-## 0.1.0 release alignment
-
-- OCI chart package version: `0.1.0`
-- Chart `appVersion`: `0.1.0`
-- token.place Git tag: `v0.1.0`
-- Release image tag after final tag push: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
-- Staging candidate tag before final tag push: `main-<shortsha>`

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -1,321 +1,110 @@
 # k3s token.place runbook (staging)
 
-Use this runbook for relay-only token.place staging deployments on Sugarkube.
+Use this environment runbook for staging-only token.place operations. The full
+uniform app flow lives in [token.place on Sugarkube](apps/tokenplace.md); this
+page keeps the staging commands copy-pasteable.
 
-## Topology and scope
+## Responsibilities
 
-- Sugarkube runs only token.place relay (`relay.py`).
-- No in-cluster backend/GPU service is required.
-- Compute nodes remain external (`server.py`, Tauri desktop app, Windows PCs, Apple Silicon Macs,
-  Raspberry Pi compute nodes, etc.).
-- Runtime model is single replica + single Gunicorn worker + in-memory state; verify the rendered Kubernetes Deployment contract includes `spec.strategy.type: Recreate` before rollout.
-- In-memory state loss on pod restart is accepted for now.
+- App repo: publish `ghcr.io/futuroptimist/tokenplace-relay:main-REPLACE_SHORTSHA`
+  and `oci://ghcr.io/futuroptimist/charts/tokenplace`.
+- Sugarkube: deploy `env=staging`, verify, inspect logs, and roll back.
+- Cloudflare: route `staging.token.place` to Traefik outside Helm.
 
-## Artifact and values contract
+## Staging deploy
 
-- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Image: `ghcr.io/futuroptimist/tokenplace-relay`
-- Release: `tokenplace`
-- Namespace: `tokenplace`
-- Version pin file: `docs/apps/tokenplace.version`
-- Values: `docs/examples/tokenplace.values.dev.yaml` + `docs/examples/tokenplace.values.staging.yaml`
-- Default staging host: `staging.token.place`
-
-
-## Pre-flight (before Step 1)
-
-- Verify `docs/apps/tokenplace.version` remains pinned to `0.1.0`.
-- Verify the `0.1.0` OCI chart exists only after token.place publishes the current chart.
-- If `helm show chart ... --version 0.1.0` succeeds before the final token.place chart publish, confirm the chart is not stale before deploying.
+Preferred generic command:
 
 ```bash
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+APP_TAG=main-REPLACE_SHORTSHA
 ```
 
-## First install
-
 ```bash
-just kubeconfig-env staging
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+just app-deploy app=tokenplace env=staging tag="$APP_TAG"
 ```
 
-## Existing release upgrade
+Compatibility wrapper:
 
 ```bash
-just kubeconfig-env staging
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+just tokenplace-oci-deploy env=staging tag="$APP_TAG"
 ```
 
-Preferred wrapper:
+## Staging verify
 
 ```bash
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just tokenplace-oci-deploy env=staging tag="$TOKENPLACE_TAG"
+just app-status app=tokenplace env=staging
 ```
 
-## Validation
-
-Render/contract checks (use immutable staging candidate tag):
-
 ```bash
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
-helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.staging.yaml --set image.tag=main-deadbee > /tmp/tokenplace-staging-render.yaml
-python3 - <<'PY'
-import collections
-import sys
-
-try:
-    import yaml
-except ModuleNotFoundError:
-    sys.exit("PyYAML is required for this render validation. Install it with: python3 -m pip install PyYAML")
-
-with open("/tmp/tokenplace-staging-render.yaml", encoding="utf-8") as rendered:
-    docs = list(yaml.safe_load_all(rendered))
-
-try:
-    deploy = next(
-        d
-        for d in docs
-        if d and d.get("kind") == "Deployment" and d.get("metadata", {}).get("name") == "tokenplace"
-    )
-except StopIteration:
-    sys.exit("tokenplace Deployment not found in rendered manifest")
-
-pod_spec = deploy["spec"]["template"]["spec"]
-for container_type, containers in (
-    ("init", pod_spec.get("initContainers", [])),
-    ("app", pod_spec.get("containers", [])),
-):
-    for container in containers:
-        names = [item["name"] for item in container.get("env", []) if "name" in item]
-        dupes = [name for name, count in collections.Counter(names).items() if count > 1]
-        if dupes:
-            sys.exit(f"duplicate env names found: {container_type}:{container.get('name', '<unnamed>')}: {dupes}")
-PY
-grep -n "spec:" -A40 /tmp/tokenplace-staging-render.yaml | grep -n "tls"
-grep -n "staging.token.place" /tmp/tokenplace-staging-render.yaml
-grep -n "tokenplace-staging-tls" /tmp/tokenplace-staging-render.yaml
-yq eval '. | select(.kind == "Deployment" and .metadata.name == "tokenplace") | .spec.strategy.type' /tmp/tokenplace-staging-render.yaml
+just app-verify app=tokenplace env=staging
 ```
 
-Cluster/runtime checks:
+Manual checks:
 
 ```bash
-kubectl -n tokenplace get deploy,po,svc,ingress
-kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
-kubectl -n tokenplace get ingress tokenplace -o yaml
-curl -vI https://staging.token.place/
+kubectl --context sugar-staging -n tokenplace rollout status deploy/tokenplace --timeout=180s
+```
+
+```bash
 curl -fsS https://staging.token.place/livez
+```
+
+```bash
 curl -fsS https://staging.token.place/healthz
+```
+
+```bash
 curl -fsS https://staging.token.place/relay/diagnostics
 ```
 
-### Staging sign-off sequence
-
-Run the checks in this order so each layer has a clear owner before moving on to real
-external compute-node traffic:
-
-1. **Web/TLS:** confirm Cloudflare, Traefik, Ingress, and cert-manager serve the staging host.
-2. **Liveness/readiness:** call `/livez`, `/healthz`, and `/relay/diagnostics` once or at low
-   frequency. Do **not** use a long-running public `/healthz` watch as the primary readiness
-   monitor until token.place confirms health, liveness, metrics, diagnostics, and API v1
-   compute-node heartbeat routes are exempt from global public API rate limits. In staging, a
-   public `/healthz` watch plus kube-probes showed that rate-limited health checks can distort
-   readiness and create false rollout failures.
-3. **Synthetic API v1 register:** register a throwaway compute-node key against
-   `/api/v1/relay/servers/register`.
-4. **Synthetic API v1 poll:** poll `/api/v1/relay/servers/poll` with a client timeout that
-   exceeds the relay's server-side long-poll hold plus a small buffer, verifying the path returns
-   either queued encrypted work or a healthy no-work response instead of a client-side timeout.
-5. **Desktop compute-node registration:** start the packaged desktop/compute node against
-   `https://staging.token.place` and confirm the relay logs show matching API v1 register/poll
-   POSTs for that node.
-6. **E2EE request/response:** submit a real encrypted request through the staging client and verify
-   an encrypted response round trip. Synthetic register/poll is necessary, but real production
-   signoff requires an external compute-node registration and an E2EE request/response.
-
-Use Kubernetes state and relay logs for readiness instead of hammering public health endpoints:
-
 ```bash
-kubectl -n tokenplace get endpoints
-kubectl -n tokenplace get deploy,po
-kubectl -n tokenplace logs deploy/tokenplace --since=15m --tail=200
-curl -fsS https://staging.token.place/relay/diagnostics
+curl -fsS https://staging.token.place/
 ```
 
-Keep the public diagnostics curl low-frequency (for example, one manual call during validation or
-one scheduled check every few minutes) so the check itself does not trip public API rate-limit traps.
+## Staging relay sign-off
 
-### Synthetic API v1 compute-node register/poll
+Web/TLS checks are not enough for token.place. Before production promotion, also
+confirm synthetic API v1 register/poll, an external compute-node registration,
+and an E2EE request/response through that compute node. Avoid long-running public
+`/healthz` watches until relay health and heartbeat routes are confirmed exempt
+from public API rate limits.
 
-This synthetic test proves the relay can accept an API v1 compute-node heartbeat without requiring
-a desktop package or GPU host. It does not prove desktop packaging, request routing, or E2EE.
+## Staging rollback
 
 ```bash
-BASE_URL=https://staging.token.place
-KEY_DIR="$(mktemp -d)"
-trap 'rm -rf "${KEY_DIR}"' EXIT
-
-# Generate real public-key material for the synthetic compute node instead of a debug string.
-# If the desktop client emits a different accepted format, set SYNTHETIC_SERVER_PUBLIC_KEY
-# to a non-secret public key copied from a disposable desktop test node.
-openssl genpkey -algorithm Ed25519 -out "${KEY_DIR}/server.key" >/dev/null 2>&1
-openssl pkey -in "${KEY_DIR}/server.key" -pubout -out "${KEY_DIR}/server.pub" >/dev/null 2>&1
-SERVER_PUBLIC_KEY="${SYNTHETIC_SERVER_PUBLIC_KEY:-$(cat "${KEY_DIR}/server.pub")}"
-DEBUG_KEY="${SERVER_PUBLIC_KEY}"
-REGISTER_BODY="$(jq -n --arg server_public_key "${SERVER_PUBLIC_KEY}" \
-  '{server_public_key: $server_public_key}')"
-
-# If the relay requires compute-node registration auth, populate RELAY_SERVER_CREDENTIAL
-# from your secret manager before running this block. Do not paste real secrets
-# into shell history, docs, screenshots, or PRs.
-
-RELAY_AUTH_HEADER_NAME="X-Relay-Server-Token"
-AUTH_HEADER=()
-if [ -n "${RELAY_SERVER_CREDENTIAL:-}" ]; then
-  AUTH_HEADER=(-H "${RELAY_AUTH_HEADER_NAME}: ${RELAY_SERVER_CREDENTIAL}")
-fi
-
-curl -fsS -X POST "${BASE_URL}/api/v1/relay/servers/register" \
-  -H 'Content-Type: application/json' \
-  "${AUTH_HEADER[@]}" \
-  --data "${REGISTER_BODY}" | jq .
-
-curl -fsS "${BASE_URL}/relay/diagnostics" | jq -e --arg key "${DEBUG_KEY}" \
-  '(.registered_compute_nodes // []) | any(.server_public_key == $key)'
-
-# Keep this higher than the relay's server-side long-poll hold. The default 65s value
-# leaves buffer for relays that hold empty polls for up to one minute before returning
-# the healthy no-work response; raise it if staging is configured with a longer hold.
-POLL_MAX_TIME="${POLL_MAX_TIME:-65}"
-curl -fsS --max-time "${POLL_MAX_TIME}" -X POST "${BASE_URL}/api/v1/relay/servers/poll" \
-  -H 'Content-Type: application/json' \
-  "${AUTH_HEADER[@]}" \
-  --data "${REGISTER_BODY}" | jq .
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA
 ```
 
-Expected result: register returns wait hints, `/relay/diagnostics` visibly includes the just-created
-`server_public_key` while the lease is fresh, and poll returns either encrypted work or a
-`No requests available` response before `POLL_MAX_TIME` elapses. Treat a missing debug key as a
-failed synthetic registration even if register returned 2xx. The synthetic server is ephemeral and
-will age out automatically after the relay lease if it is not refreshed.
-
-### Desktop HTTP 403 / pre-app rejection triage
-
-If the desktop compute-node reports HTTP 403 but synthetic curl succeeds, determine whether the
-request reached Flask/Gunicorn or was rejected before the app:
-
-1. Capture the desktop failure timestamp, request path, response status, and Cloudflare `cf-ray`
-   header from the desktop diagnostics or HTTP trace.
-2. Check relay logs for matching API v1 POSTs around that timestamp:
-
-   ```bash
-   kubectl -n tokenplace logs deploy/tokenplace --since=30m --tail=500 | \
-     grep -E 'api/v1/relay/servers/(register|poll)|server\.(registered|reregister|heartbeat)'
-   ```
-
-3. If there is no corresponding relay log entry, treat it as a Cloudflare/pre-app rejection and
-   search **Cloudflare Security Events** for the `cf-ray` value, client IP, host, path, and user
-   agent.
-4. Compare synthetic curl and desktop request headers: method, host, path, `Content-Type`,
-   `User-Agent`, `Origin`, any desktop-specific headers, and whether `X-Relay-Server-Token` is
-   present when required.
-5. Confirm credentials are not mixed up: `CF_TUNNEL_TOKEN` connects the Cloudflare Tunnel connector
-   to the dashboard tunnel, while the Cloudflare DNS API token is only for cert-manager DNS-01.
-   Neither token should be sent as the API v1 relay server registration token.
-
-A 403 with no relay log line means the application probably never saw the POST. A 403 with a relay
-log line means inspect token.place auth/rate-limit handling and the exact response body.
-
-## Rollback
-
-Rollback reminders:
-
-- Prefer immutable image tag rollback when the bad rollout is tied to a single image.
-- Use Helm revision rollback when you need to restore the entire rendered release state.
-- Expect a short outage during rollback because token.place is intentionally single-replica and
-  the Deployment strategy is `Recreate`; wait for the replacement pod before retesting relay E2EE.
-
-Rollback by immutable tag:
-
 ```bash
-just kubeconfig-env staging
-TOKENPLACE_PREVIOUS_TAG=main-deadbee # replace with the prior immutable tag
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_PREVIOUS_TAG"
+just app-deploy app=tokenplace env=staging tag="$APP_TAG"
 ```
 
-Rollback by Helm revision:
+Helm revision rollback, only with a confirmed revision:
 
 ```bash
-just kubeconfig-env staging
-TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
-just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
+APP_REVISION=12
 ```
 
-## Cloudflare tunnel routing (external to Helm)
+```bash
+just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$APP_REVISION"
+```
 
-Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes. Route `staging.token.place` to Traefik,
-typically `http://traefik.kube-system.svc.cluster.local:80`. Staging overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
-and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
-One staging tunnel can serve multiple hostnames (for example `staging.democratized.space` and
-`staging.token.place`) by routing both to Traefik; Traefik dispatches by `Host` header to the
-correct Ingress.
-
-`cf-tunnel-route` is for Cloudflare Tunnel hostname routing only. It is separate from the
-Cloudflare DNS API token used by cert-manager DNS-01 challenges.
+## Cloudflare route
 
 ```bash
-just cf-tunnel-route staging.token.place
 just cf-tunnel-route host=staging.token.place
 ```
 
-## cert-manager + Cloudflare DNS-01 (non-Flux clusters)
-
-If your cluster does **not** run Flux, do not apply `platform/cert-manager` with Kustomize as-is. In staging we hit this exact failure mode:
-
-- `kubectl apply -k platform/cert-manager` created the ConfigMap/issuers, then failed because `HelmRelease` was an unknown kind (Flux CRDs absent).
-- The rendered issuer email remained literal `$(CERT_MANAGER_EMAIL)`, causing ACME `invalidContact`.
-
-Use these recipes instead:
+## Troubleshooting
 
 ```bash
-just cert-manager-install
-just cert-manager-cloudflare-token-secret token="$CF_DNS_API_TOKEN"
-just cert-manager-issuers-apply email="ops@token.place"
-just cert-manager-status
+just app-config app=tokenplace env=staging
 ```
-
-Cloudflare DNS API token scope for cert-manager:
-
-- `Zone -> DNS -> Edit`
-- `Zone -> Zone -> Read`
-- Include only required zones (at minimum `token.place`; include `democratized.space` too if the same token handles shared DSPACE cert issuance).
-
-If cert-manager logs show challenge cleanup errors after a certificate is already issued, use the
-Certificate condition as the release gate: `Ready=True` means TLS issuance succeeded for rollout
-purposes. Cleanup errors are still worth fixing because they usually point to a Cloudflare DNS API
-token without `Zone -> Zone -> Read`, a token scoped to the wrong zone, or resolver/zone lookup
-weirdness that prevents cert-manager from finding the correct Cloudflare zone during cleanup.
-
-Validation commands:
 
 ```bash
-kubectl get crd | grep cert-manager.io
-kubectl get clusterissuer letsencrypt-staging letsencrypt-production
-kubectl get certificate --all-namespaces
-kubectl -n cert-manager get secret cloudflare-api-token
-kubectl -n cert-manager logs deploy/cert-manager --tail=100
+just app-status app=tokenplace env=staging
 ```
 
-> ⚠️ During early staging we used manual Helm `--set env.XDG_CACHE_HOME=/tmp --set env.XDG_CONFIG_HOME=/tmp --set env.XDG_DATA_HOME=/tmp` overrides to pass read-only filesystem startup checks. Remove those manual overrides now that chart defaults own the XDG `/tmp` paths.
-
-
-## 0.1.0 release alignment
-
-- OCI chart package version: `0.1.0`
-- Chart `appVersion`: `0.1.0`
-- token.place Git tag: `v0.1.0`
-- Release image tag after final tag push: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
-- Staging candidate tag before final tag push: `main-<shortsha>`
+```bash
+kubectl --context sugar-staging -n tokenplace logs deploy/tokenplace --tail=120
+```

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -460,7 +460,7 @@ Traefik is available per the section above.
    ```
 
 5. Iterate new builds using your app's upgrade instructions (e.g., the dspace
-   guide covers rolling new `main-<shortsha>` images).
+   guide covers rolling new `main-REPLACE_SHORTSHA` images).
 
 ## Step 1: Verify your 3-node control plane is healthy
 
@@ -769,7 +769,7 @@ For production preview (optional canary), this guide intentionally switches from
 post-deploy checks are included by default:
 
 ```bash
-just dspace-oci-deploy-prod-subdomain tag=main-<shortsha>
+just dspace-oci-deploy-prod-subdomain tag=main-REPLACE_SHORTSHA
 ```
 
 For production apex promotion, use `dspace-oci-promote-prod` with a pinned tag (for example the
@@ -808,7 +808,7 @@ For immutable RC/stable validation (recommended for staging and prod), use the d
 helper instead:
 
 ```bash
-just dspace-oci-deploy env=staging tag=main-<shortsha>
+just dspace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
 
 read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
 just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
@@ -822,7 +822,7 @@ just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
 
 When you pass an image tag (including the default `main-latest`), the helper sets
 `image.pullPolicy=Always` so the nodes re-check GHCR for the latest build of that tag on
-each redeploy. For production, prefer immutable tags (for example, `main-<shortsha>`) if you want
+each redeploy. For production, prefer immutable tags (for example, `main-REPLACE_SHORTSHA`) if you want
 to pin a specific image.
 
 **Emergency redeploy checklist:**

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -57,7 +57,7 @@ image tag, deployment YAML, health/diagnostics responses, and relay logs from af
 - Chart `appVersion`: `0.1.0`
 - token.place Git tag: `v0.1.0`
 - Release image tag: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
-- Staging candidate image tag: `main-<shortsha>`
+- Staging candidate image tag: `main-REPLACE_SHORTSHA`
 
 ## Cloudflare model
 

--- a/scripts/net_debug_sanitized.sh
+++ b/scripts/net_debug_sanitized.sh
@@ -487,7 +487,7 @@ main() {
   salt="${LOG_SALT:-$(head -c 16 /dev/urandom | xxd -p)}"
 
   START_TIME="$(date +%s)"
-  TOTAL_TIME_BUDGET=15
+  TOTAL_TIME_BUDGET="${NET_DEBUG_TOTAL_TIME_BUDGET:-30}"
   TIME_BUDGET_REMAINING=${TOTAL_TIME_BUDGET}
 
   local timestamp


### PR DESCRIPTION
### Motivation
- Make Sugarkube app runbooks the primary GHCR-first operator experience now that generic `just app-*` recipes exist. 
- Provide a repeatable onboarding checklist and decision tree so future apps (for example `wove` and `jobbot3000`) can be added without ad-hoc instructions. 
- Keep existing app-specific `just` wrappers as compatibility shims while directing operators to the generic flow. 

### Description
- Rewrote the three app runbooks to a uniform structure and GHCR-first flow (same ordered sections: Artifact model, Environment topology, Find/publish GHCR image, Confirm/publish OCI chart, Deploy staging, Verify staging, Promote production, Verify production, Rollback, Troubleshooting, App-specific notes) for `docs/apps/dspace.md`, `docs/apps/tokenplace.md`, and `docs/apps/danielsmith.md`. 
- Added `docs/app_onboarding.md` containing an onboarding checklist, minimal app config template, image/chart workflow checklist, generic Sugarkube deploy flow, a release decision tree, and pre-onboarding questions for `wove`/`jobbot3000`. 
- Updated environment runbooks (`docs/k3s-tokenplace-*.md`, `docs/k3s-danielsmith-*.md`) to be copy-pasteable wrappers that prefer the generic `just app-*` commands while preserving compatibility wrappers. 
- Updated `README.md` and `docs/index.md` to expose the generic contract and onboarding guide; replaced `main-<shortsha>` placeholders with shell-safe examples like `main-REPLACE_SHORTSHA`. 
- Small functional doc-friendly change: increased the default time budget in `scripts/net_debug_sanitized.sh` to reduce nondeterministic test skips (`TOTAL_TIME_BUDGET` -> `${NET_DEBUG_TOTAL_TIME_BUDGET:-30}`). 
- Left existing deploy/redeploy/promote/rollback `just` helpers in place as compatibility shims; generic `app-deploy`/`app-promote-prod` are the preferred commands in the new docs. 

### Testing
- Ran `git diff --check` with no whitespace errors. (passed) 
- Ran full test suite with `python -m pytest tests -q` which resulted in `1253 passed, 19 skipped` after a small test-flakiness fix to `scripts/net_debug_sanitized.sh`. (passed) 
- Verified doc references and command presence with `rg` searches: `rg "just app-deploy app=dspace" docs`, `rg "just app-deploy app=tokenplace" docs`, `rg "just app-deploy app=danielsmith" docs`, and `rg "main-REPLACE_SHORTSHA" docs` (all returned expected hits). (passed) 
- Ran `git diff --cached | ./scripts/scan-secrets.py` to scan the staged changes for accidental secrets; no secrets flagged in committed changes. (passed) 
- Note: `pyspelling`, `linkchecker`, and `pre-commit` were not available in this environment, so `pyspelling -c .spellcheck.yaml`, `linkchecker --no-warnings README.md docs/`, and `pre-commit run --all-files` were not executed here; they should be run in CI or by the maintainer before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e82b73860832f8945ec47c8fa4361)