### PR TITLE
docs: standardize GHCR-first app runbooks and add onboarding guide

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -253,3 +253,7 @@ yourorg
 
 executables
 pytest
+
+danielsmith
+handoff
+jobbot

--- a/README.md
+++ b/README.md
@@ -39,13 +39,15 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
 
 ## Application runbooks
 
-- **[token.place onboarding contract](docs/tokenplace_sugarkube_onboarding.md)** — prerequisites,
-  ownership boundaries, and environment mapping for first-class token.place operations.
-- **[token.place app operations](docs/apps/tokenplace.md)** — topology and deployment workflow
-  patterns for token.place on Sugarkube.
-- **[token.place env runbooks](docs/index.md)** — environment-specific guides for
-  [dev](docs/k3s-tokenplace-dev.md), [staging](docs/k3s-tokenplace-staging.md), and
-  [production](docs/k3s-tokenplace-prod.md) operations.
+- **[Sugarkube app deployment contract](docs/app_deployment_contract.md)** — shared
+  GHCR image/chart contract and generic `just app-*` command surface.
+- **[Future app onboarding guide](docs/app_onboarding.md)** — checklist and release
+  decision tree for adding apps such as wove and jobbot3000 to the generic flow.
+- **App runbooks:** [dspace](docs/apps/dspace.md), [token.place](docs/apps/tokenplace.md),
+  and [danielsmith.io](docs/apps/danielsmith.md) document staging deploy, production
+  promotion, verification, rollback, and Cloudflare handoff responsibilities.
+- **[token.place onboarding contract](docs/tokenplace_sugarkube_onboarding.md)** — legacy
+  token.place-specific prerequisites and environment mapping.
 
 ## Repository layout
 

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -1,0 +1,203 @@
+# Future app onboarding guide
+
+Use this checklist when adding a new app to the Sugarkube generic app flow. The
+next likely candidates are **wove** and **jobbot3000**, but do not add their real
+Sugarkube configs until their app repositories have answered the questions below
+and published compatible GHCR image/chart artifacts.
+
+## Ownership boundary
+
+- App repository responsibilities: Dockerfile, image workflow, Helm chart, chart
+  workflow, app-specific smoke endpoints, and release tags.
+- Sugarkube responsibilities: app config, environment values overlays,
+  kubeconfig/environment selection, Helm deploy/redeploy/promote/status/verify,
+  and cluster logs.
+- Cloudflare responsibilities: DNS records and tunnel routes. Cloudflare routes
+  are configured outside Helm and should not be hidden inside app values.
+
+App-specific `just` recipes for dspace, token.place, and danielsmith.io are
+compatibility shims. Keep documenting them during migration, but prefer generic
+commands for new apps. Remove shims only after the generic flow has been used
+successfully across routine releases.
+
+## Onboarding checklist
+
+1. Add a Dockerfile in the app repository.
+2. Add `ci-image.yml` with standard GHCR tags.
+3. Add a Helm chart in the app repository.
+4. Add `ci-helm.yml` with immutable OCI chart publishing.
+5. Add or copy a Sugarkube app config.
+6. Add environment values overlays for dev, staging, and prod.
+7. Run the generic Sugarkube deploy.
+8. Add app-specific smoke checks if needed.
+
+## Questions to answer before onboarding wove, jobbot3000, or another app
+
+| Question | Why it matters |
+| --- | --- |
+| App image name | Determines the GHCR image coordinate and image override values. |
+| Container port | Drives Service target ports and readiness/liveness probe wiring. |
+| Health endpoints | Defines `SUGARKUBE_VERIFY_PATHS` and any app-specific smoke checks. |
+| Chart name | Determines the OCI chart reference and chart version pin. |
+| Namespace/release | Keeps Helm history and Kubernetes resources stable across releases. |
+| Staging/prod hostnames | Drives ingress values and Cloudflare tunnel routes. |
+| Runtime secrets/config | Identifies required Kubernetes Secrets and non-secret ConfigMap values. |
+| Stateful dependencies | Determines whether a stateless deploy is enough or extra runbooks are needed. |
+| Resource requests/limits | Keeps small Sugarkube clusters predictable under load. |
+
+## Minimal app config template
+
+Copy this template into a local config directory or `docs/examples/apps/APP.env`
+when the app is ready. Replace `APP` and the GHCR coordinates with real values;
+keep placeholder values out of production docs once the app is live.
+
+```bash
+SUGARKUBE_APP=APP
+SUGARKUBE_RELEASE=APP
+SUGARKUBE_NAMESPACE=APP
+SUGARKUBE_CHART=oci://ghcr.io/OWNER/charts/APP
+SUGARKUBE_VERSION_FILE=docs/apps/APP.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/APP.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/APP.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/APP.values.dev.yaml,docs/examples/APP.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/APP.values.dev.yaml,docs/examples/APP.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/,/healthz,/livez
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=APP
+```
+
+After adding a config, confirm Sugarkube can resolve it:
+
+```bash
+just app-config app=APP env=staging
+```
+
+## Minimal image workflow checklist
+
+The app repository's image workflow should publish to GHCR and expose tags that
+operators can copy directly into Sugarkube docs.
+
+- Trigger on pushes to the integration branch and manual `workflow_dispatch`.
+- Build the production image for `linux/amd64` and `linux/arm64` unless the app
+  has a documented architecture exception.
+- Publish the canonical image name only, for example `ghcr.io/OWNER/APP`.
+- Publish immutable branch-SHA tags such as `main-REPLACE_SHORTSHA`.
+- Optionally publish mutable convenience tags such as `main-latest` for
+  non-production iteration, but do not use them for production promotion.
+- Make the workflow summary print the image coordinate and immutable tag.
+- Avoid requiring Sugarkube to run a local image build for staging or production.
+
+## Minimal Helm chart checklist
+
+The app repository's chart workflow should publish an immutable OCI chart that
+Sugarkube can install with `helm upgrade --install`.
+
+- Store the chart in the app repository near app release docs.
+- Use a stable chart name that matches the planned Sugarkube app slug when
+  possible.
+- Expose image repository and tag values that Sugarkube can override.
+- Include ingress host/class/TLS values for each environment overlay.
+- Include readiness and liveness probes for the health endpoints.
+- Keep secrets out of values files; reference Kubernetes Secrets by name instead.
+- Bump chart patch versions for template/default changes, minor versions for
+  backwards-compatible chart interface additions, and major versions for breaking
+  values/schema changes.
+- Publish to `oci://ghcr.io/OWNER/charts/CHART` from `ci-helm.yml`.
+
+## Environment values overlays
+
+Keep values files layered from broad defaults to environment-specific routing.
+
+```bash
+docs/examples/APP.values.dev.yaml
+```
+
+```bash
+docs/examples/APP.values.staging.yaml
+```
+
+```bash
+docs/examples/APP.values.prod.yaml
+```
+
+Typical split:
+
+- Dev/base values: image defaults, service port, resource requests/limits,
+  non-secret defaults, and shared probe paths.
+- Staging overlay: staging hostname, ingress class/TLS settings, staging-specific
+  non-secret config.
+- Prod overlay: production hostname, ingress class/TLS settings, production
+  non-secret config.
+
+## Generic deploy smoke path
+
+Deploy a staging candidate with the generic app flow:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag from the app CI
+just app-deploy app=APP env=staging tag="$APP_TAG"
+```
+
+Verify staging:
+
+```bash
+just app-status app=APP env=staging
+```
+
+```bash
+just app-verify app=APP env=staging
+```
+
+Promote after staging sign-off:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA # replace with the staging-approved immutable GHCR image tag
+just app-promote-prod app=APP tag="$APP_TAG"
+```
+
+Rollback production by tag:
+
+```bash
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA # replace with the previous known-good immutable GHCR image tag
+just app-redeploy app=APP env=prod tag="$APP_TAG"
+```
+
+## Release decision tree
+
+### I have a successful image build; what tag do I deploy?
+
+- If staging is the next step, deploy the immutable branch-SHA tag printed by CI,
+  for example `main-REPLACE_SHORTSHA`.
+- If CI only printed a mutable convenience tag, find the matching immutable tag
+  before deploying.
+- If the app has release tags, deploy the immutable release tag that corresponds
+  to the signed-off source revision.
+
+### The chart changed; what version do I bump?
+
+- Patch version: chart template fixes, resource default tweaks, or probe changes
+  that preserve the values interface.
+- Minor version: new optional values, new optional templates, or backwards-
+  compatible environment support.
+- Major version: breaking values schema changes, renamed resources that affect
+  upgrades, or migration steps that require operator action.
+- After the chart is published, update the Sugarkube `docs/apps/APP.version` pin
+  in the same docs/config PR that explains the deploy impact.
+
+### Staging works; how do I promote prod?
+
+- Promote the exact immutable tag that passed staging.
+- Prefer `just app-promote-prod app=APP tag="$APP_TAG"` for the active release.
+- Update `docs/apps/APP.prod.tag` when the repo should remember that approved tag
+  for future no-argument production promotion.
+
+### Prod is bad; how do I roll back?
+
+- First choose the previous known-good immutable image tag from release notes,
+  `docs/apps/APP.prod.tag` history, or Helm history.
+- Run `just app-redeploy app=APP env=prod tag="$APP_TAG"` with that known-good
+  tag.
+- If image rollback is not enough, use the known-good Helm revision and the
+  existing parameterized rollback helper.
+- Verify production with `just app-status app=APP env=prod` and
+  `just app-verify app=APP env=prod` before closing the incident.

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -1,92 +1,241 @@
 # danielsmith.io on Sugarkube
 
-This is the canonical Sugarkube deployment model for `danielsmith.io`.
+Use this runbook for GHCR-first danielsmith.io deploys, promotions,
+verification, and rollback on Sugarkube. The preferred future path is the generic
+app flow backed by `docs/examples/apps/danielsmith.env`; the `danielsmith-*`
+recipes remain compatibility shims until the generic flow has been exercised
+across routine releases.
 
-For the shared artifact, tag, chart, app-config, and planned generic command contract, see [Sugarkube app deployment contract](../app_deployment_contract.md).
+## 1. Artifact model
 
-## Topology and scope (static-site only)
+- App repository responsibility: build and publish
+  `ghcr.io/futuroptimist/danielsmith.io` static-site images from the
+  danielsmith.io repository's CI, including immutable deploy tags such as
+  `main-REPLACE_SHORTSHA`.
+- App repository responsibility: package and publish the Helm chart at
+  `oci://ghcr.io/futuroptimist/charts/danielsmith` with immutable chart versions.
+- Sugarkube responsibility: select kubeconfig/environment, read
+  `docs/examples/apps/danielsmith.env`, pin the chart version from
+  `docs/apps/danielsmith.version`, deploy the selected image tag with Helm, and
+  run status/verify/log helpers.
+- Cloudflare responsibility: DNS and tunnel routes for the public hostnames live
+  outside Helm; the chart only creates Kubernetes resources behind Traefik.
 
-`danielsmith.io` is a static Vite + Three.js site. Sugarkube runs only the static web container.
+| Coordinate | Value |
+| --- | --- |
+| App config | `docs/examples/apps/danielsmith.env` |
+| Image | `ghcr.io/futuroptimist/danielsmith.io` |
+| Chart | `oci://ghcr.io/futuroptimist/charts/danielsmith` |
+| Release | `danielsmith` |
+| Namespace | `danielsmith` |
+| Chart pin | `docs/apps/danielsmith.version` |
+| Production tag pin | `docs/apps/danielsmith.prod.tag` |
+| Verify paths | `/`, `/livez`, `/healthz` |
 
-- **In-cluster (Sugarkube):** one static web deployment exposed through Traefik ingress.
-- **No in-cluster API/backend/database/queue/GPU/compute node/stateful service** is required.
-- **Public ingress path:** Cloudflare Tunnel fronts Traefik, and Traefik routes to the
-  `danielsmith` Kubernetes Service.
-- **Health/availability endpoints:** `/livez`, `/healthz`.
-- **Root page:** `/`.
+## 2. Environment topology
 
-## Artifact model (canonical)
+- `env=dev`: non-production defaults using
+  `docs/examples/danielsmith.values.dev.yaml`.
+- `env=staging`: staging host `staging.danielsmith.io`, values chain
+  `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml`.
+- `env=prod`: production host `danielsmith.io`, values chain
+  `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml`.
 
-- Image: `ghcr.io/futuroptimist/danielsmith.io`
-- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
-- Helm release: `danielsmith`
-- Namespace: `danielsmith`
-- Chart version pin file: `docs/apps/danielsmith.version`
-- Production approved tag pin: `docs/apps/danielsmith.prod.tag`
+## 3. Find or publish GHCR image
 
-## Values model
-
-- Base: `docs/examples/danielsmith.values.dev.yaml`
-- Staging overlay: `docs/examples/danielsmith.values.staging.yaml`
-- Production overlay: `docs/examples/danielsmith.values.prod.yaml`
-
-Default hosts:
-
-- Staging: `staging.danielsmith.io`
-- Production: `danielsmith.io`
-
-## Core deployment commands
-
-First install (or install-or-upgrade) with generic helper:
+Find the latest successful danielsmith.io image workflow and copy the immutable
+tag it published.
 
 ```bash
-just kubeconfig-env staging
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
+APP_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag from danielsmith.io CI
 ```
 
-Existing release upgrade with generic helper:
-
 ```bash
-just kubeconfig-env staging
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
+gh run list --repo futuroptimist/danielsmith.io --workflow ci-image.yml --status success --limit 10
 ```
 
-Preferred environment wrapper:
+If no usable immutable tag exists, publish one from the danielsmith.io
+repository's image workflow before deploying from Sugarkube.
 
 ```bash
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
-just danielsmith-oci-deploy env=staging tag="$DANIELSMITH_TAG"
+gh workflow run ci-image.yml --repo futuroptimist/danielsmith.io --ref main
 ```
 
-## Validation commands
+## 4. Confirm/publish OCI chart
+
+Sugarkube reads the chart version from `docs/apps/danielsmith.version`. Confirm
+that GHCR has that chart before deploying.
 
 ```bash
-kubectl -n danielsmith get deploy,po,svc,ingress
-kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
+CHART_VERSION=$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/danielsmith.version | head -n1)
+```
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$CHART_VERSION"
+```
+
+If the chart changed in the danielsmith.io repository and GHCR does not have the
+desired version yet, publish it from the chart workflow before updating the
+Sugarkube chart pin.
+
+```bash
+gh workflow run ci-helm.yml --repo futuroptimist/danielsmith.io --ref main
+```
+
+## 5. Deploy staging
+
+Preferred generic command:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag from danielsmith.io CI
+just app-deploy app=danielsmith env=staging tag="$APP_TAG"
+```
+
+Current compatibility wrapper:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag from danielsmith.io CI
+just danielsmith-oci-deploy env=staging tag="$APP_TAG"
+```
+
+## 6. Verify staging
+
+```bash
+just app-status app=danielsmith env=staging
+```
+
+```bash
+just app-verify app=danielsmith env=staging
+```
+
+```bash
 curl -fsS https://staging.danielsmith.io/livez
+```
+
+```bash
 curl -fsS https://staging.danielsmith.io/healthz
+```
+
+```bash
 curl -fsS https://staging.danielsmith.io/
 ```
 
-For production validation, use the same checks against `https://danielsmith.io`.
+## 7. Promote production
 
-## Cloudflare Tunnel and ingress model
+Promote only after staging sign-off. Record the approved immutable tag in your
+release notes and, when appropriate, in `docs/apps/danielsmith.prod.tag`.
 
-Cloudflare Tunnel/DNS configuration is external to Helm.
+Preferred generic command:
 
-- Route hostnames to Traefik, typically
-  `http://traefik.kube-system.svc.cluster.local:80`.
-- Helm chart deployment does **not** create Cloudflare routes.
-- Configure staging and prod routes explicitly:
+```bash
+APP_TAG=main-REPLACE_SHORTSHA # replace with the staging-approved immutable GHCR image tag
+just app-promote-prod app=danielsmith tag="$APP_TAG"
+```
+
+Current compatibility wrapper:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA # replace with the staging-approved immutable GHCR image tag
+just danielsmith-oci-promote-prod tag="$APP_TAG"
+```
+
+If `docs/apps/danielsmith.prod.tag` already contains the approved production tag,
+the generic promotion command can read it by omitting `tag=`.
+
+```bash
+just app-promote-prod app=danielsmith
+```
+
+## 8. Verify production
+
+```bash
+just app-status app=danielsmith env=prod
+```
+
+```bash
+just app-verify app=danielsmith env=prod
+```
+
+```bash
+curl -fsS https://danielsmith.io/livez
+```
+
+```bash
+curl -fsS https://danielsmith.io/healthz
+```
+
+```bash
+curl -fsS https://danielsmith.io/
+```
+
+## 9. Rollback
+
+Rollback by immutable tag with the generic redeploy helper:
+
+```bash
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA # replace with the previous known-good immutable GHCR image tag
+just app-redeploy app=danielsmith env=prod tag="$APP_TAG"
+```
+
+Rollback staging the same way if the failure is caught before promotion:
+
+```bash
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA # replace with the previous known-good immutable GHCR image tag
+just app-redeploy app=danielsmith env=staging tag="$APP_TAG"
+```
+
+Rollback by Helm revision when a revision number is known:
+
+```bash
+DANIELSMITH_REVISION=12 # replace with the known-good Helm revision
+just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$DANIELSMITH_REVISION"
+```
+
+## 10. Troubleshooting
+
+GHCR authentication and chart pull failures commonly show up as Helm `401` or
+`403` errors. Log in to GHCR with a package-read credential, then retry the
+chart check.
+
+```bash
+CHART_VERSION=$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/danielsmith.version | head -n1)
+helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$CHART_VERSION"
+```
+
+Inspect status, logs, ingress, and tunnel routing:
+
+```bash
+just app-status app=danielsmith env=staging
+```
+
+```bash
+just danielsmith-debug-logs-env env=staging
+```
+
+```bash
+just cluster-status
+```
+
+```bash
+just traefik-status
+```
+
+```bash
+just cf-tunnel-debug
+```
+
+Cloudflare routes are external to Helm. Create or repair routes outside the
+chart when DNS/tunnel routing is the failing layer.
 
 ```bash
 just cf-tunnel-route host=staging.danielsmith.io
-just cf-tunnel-route host=danielsmith.io
 ```
 
-## Related runbooks
+## 11. App-specific notes
 
-- Staging runbook: [`docs/k3s-danielsmith-staging.md`](../k3s-danielsmith-staging.md)
-- Production runbook: [`docs/k3s-danielsmith-prod.md`](../k3s-danielsmith-prod.md)
+- danielsmith.io is a static Vite/Three.js site; Sugarkube deploys only the
+  static web container.
+- No in-cluster API, database, queue, GPU, or stateful service is expected for
+  the current site.
+- Verify `/` as well as `/livez` and `/healthz` because the health endpoints can
+  pass while a static asset routing regression affects the homepage.

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -1,204 +1,261 @@
 # democratized.space (dspace) on Sugarkube
 
-This guide covers **steady-state dspace operations** on Sugarkube: repeatable deploys,
-upgrades, promotions, and rollbacks using immutable image tags.
+Use this runbook for GHCR-first dspace deploys, promotions, verification, and
+rollback on Sugarkube. The preferred future path is the generic app flow backed
+by `docs/examples/apps/dspace.env`; the `dspace-*` recipes remain compatibility
+shims until the generic flow has been exercised across routine releases.
 
-For the shared artifact, tag, chart, app-config, and planned generic command contract, see [Sugarkube app deployment contract](../app_deployment_contract.md).
+## 1. Artifact model
 
-The `justfile` exposes both:
+- App repository responsibility: build and publish `ghcr.io/democratizedspace/dspace`
+  images from the dspace repository's CI, including immutable deploy tags such
+  as `main-REPLACE_SHORTSHA` or release tags such as `3.1.0`.
+- App repository responsibility: package and publish the Helm chart at
+  `oci://ghcr.io/democratizedspace/charts/dspace` with immutable chart versions.
+- Sugarkube responsibility: select kubeconfig/environment, read
+  `docs/examples/apps/dspace.env`, pin the chart version from
+  `docs/apps/dspace.version`, deploy the selected image tag with Helm, and run
+  status/verify/log helpers.
+- Cloudflare responsibility: DNS and tunnel routes for the public hostnames live
+  outside Helm; the chart only creates Kubernetes resources behind Traefik.
 
-- generic Helm OCI helpers (`helm-oci-install`, `helm-oci-upgrade`) for any app; and
-- dspace-specific helpers for immutable deploys and production promotion
-  (`dspace-oci-deploy`, `dspace-oci-promote-prod`, `dspace-oci-redeploy`).
+| Coordinate | Value |
+| --- | --- |
+| App config | `docs/examples/apps/dspace.env` |
+| Image | `ghcr.io/democratizedspace/dspace` |
+| Chart | `oci://ghcr.io/democratizedspace/charts/dspace` |
+| Release | `dspace` |
+| Namespace | `dspace` |
+| Chart pin | `docs/apps/dspace.version` |
+| Production tag pin | `docs/apps/dspace.prod.tag` |
+| Verify paths | `/config.json`, `/healthz`, `/livez` |
 
-## Environment topology and values overlays
+## 2. Environment topology
 
-dspace values are layered so base defaults stay separate from environment routing.
+- `env=dev`: future single-node/non-HA environment using
+  `docs/examples/dspace.values.dev.yaml`.
+- `env=staging`: HA staging on the staging Sugarkube cluster, public host
+  `staging.democratized.space`, values chain
+  `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
+- `env=prod`: HA production on the production Sugarkube cluster, public host
+  `democratized.space`, values chain
+  `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
+- Optional legacy production subdomain: `prod.democratized.space` uses
+  `docs/examples/dspace.values.prod-subdomain.yaml` only when explicitly needed.
 
-- `docs/examples/dspace.values.dev.yaml`: shared defaults, intended for future `env=dev`
-  deployments.
-- `docs/examples/dspace.values.staging.yaml`: staging ingress host/class overlay.
-- `docs/examples/dspace.values.prod.yaml`: production apex ingress overlay.
-- `docs/examples/dspace.values.prod-subdomain.yaml`: optional legacy subdomain overlay for
-  `prod.democratized.space` when a pre-apex host is explicitly needed.
+## 3. Find or publish GHCR image
 
-Current/target topology:
-
-- **staging (live, HA):** `env=staging` on `sugarkube3`, `sugarkube4`, `sugarkube5`,
-  public host `staging.democratized.space`.
-- **prod (live, HA):** `env=prod` on `sugarkube0`, `sugarkube1`, `sugarkube2`,
-  public host `democratized.space`.
-- **dev (planned, non-HA):** `env=dev` on `sugarkube6` (single-node future environment).
-
-Cloudflare Tunnel topology stays one tunnel per environment/cluster, with many hostnames routed to
-Traefik. For staging this means `staging.democratized.space` can share a tunnel with
-`staging.token.place`, and Traefik routes by HTTP `Host` header to the proper Ingress.
-
-## Tagging model (evergreen releases)
-
-Use tags by purpose:
-
-- **Convenience/mutable tags** for fast iteration in non-prod (for example `main-latest`).
-- **Immutable deploy tags** for sign-off, promotion, and rollback (for example
-  `main-<shortsha>`, `3.0.1`, `3.1.0`).
-- In this operational guide, `main` is the normal integration line that produces
-  DSPACE-derived image tags (for example `main-<shortsha>`).
-- If the DSPACE repo uses release branches, keep them short-lived stabilization branches,
-  not long-lived environment branches.
-- Keep environment routing (`staging`, optional `prod.` subdomain, apex prod) separate from release
-  lineage; this guide stays main-first for steady-state operations.
-
-Environment overlays (`dev`/`staging`/`prod`) decide host/routing. Image tags decide the
-release version. Keep those concerns separate.
-
-## Quickstart
+Find the latest successful dspace image workflow in the dspace repository and
+copy the immutable tag it published.
 
 ```bash
-# Immutable staging deploy (recommended for release validation)
-just dspace-oci-deploy env=staging tag=main-<shortsha>
-
-# Immutable production deploy (reads docs/apps/dspace.prod.tag if tag is omitted)
-just dspace-oci-promote-prod tag=3.1.0
-
-# Optional prod subdomain endpoint (prod.democratized.space)
-just dspace-oci-deploy-prod-subdomain tag=main-<shortsha>
-
-# Check pods/ingress/status
-just app-status namespace=dspace release=dspace
+APP_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag from dspace CI
 ```
-
-## When to use each helper
-
-- `helm-oci-install`: install-or-upgrade path (uses `helm upgrade --install`), useful when a
-  release may not exist yet.
-- `helm-oci-upgrade`: upgrade-only path with `--reuse-values`, useful for routine bumps on an
-  existing release.
-- `dspace-oci-deploy`: opinionated dspace wrapper that requires an explicit immutable tag,
-  applies the correct values chain for `env=dev|staging|prod`, and waits for rollout.
-- `dspace-oci-promote-prod`: production convenience wrapper around
-  `dspace-oci-deploy env=prod`, reading `docs/apps/dspace.prod.tag` when `tag=` is omitted.
-- `dspace-oci-redeploy`: force-refresh path for already-deployed tags (especially mutable tags)
-  by running a Helm upgrade and rollout restart.
-
-## Generic Helm OCI examples
-
-If `helm pull`, `just helm-oci-install`, or `just helm-oci-upgrade` fails with GHCR `401`/`403`
-errors, use the canonical recovery steps in
-[Raspberry Pi Cluster Troubleshooting — Scenario 7](../raspi_cluster_troubleshooting.md#scenario-7-helm-oci-pull-fails-with-ghcr-403-denied-denied).
 
 ```bash
-# Install-or-upgrade staging with mutable convenience tag
-just helm-oci-install \
-  release=dspace namespace=dspace \
-  chart=oci://ghcr.io/democratizedspace/charts/dspace \
-  values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
-  version_file=docs/apps/dspace.version \
-  default_tag=main-latest
-
-# Upgrade staging to an immutable build
-just helm-oci-upgrade \
-  release=dspace namespace=dspace \
-  chart=oci://ghcr.io/democratizedspace/charts/dspace \
-  values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
-  version_file=docs/apps/dspace.version \
-  tag=main-<shortsha>
-
-# Upgrade prod directly to a signed-off immutable tag
-just helm-oci-upgrade \
-  release=dspace namespace=dspace \
-  chart=oci://ghcr.io/democratizedspace/charts/dspace \
-  values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml \
-  version_file=docs/apps/dspace.version \
-  tag=3.1.0
+gh run list --repo democratizedspace/dspace --workflow ci-image.yml --status success --limit 10
 ```
 
-Notes:
+If no usable immutable tag exists, publish one from the dspace repository's image
+workflow before deploying from Sugarkube.
 
-- `version_file=docs/apps/dspace.version` keeps chart version pinning centralized.
-- For prod, prefer immutable tags and persist the approved one in `docs/apps/dspace.prod.tag`.
-- `dspace-oci-deploy` rejects mutable tags (`latest`, `main`) by design.
+```bash
+gh workflow run ci-image.yml --repo democratizedspace/dspace --ref main
+```
 
-## Evergreen release/promotion flow
+## 4. Confirm/publish OCI chart
 
-1. Build and publish candidate image tags from `main` (for example `main-<shortsha>` plus
-   optional `main-latest`).
-2. Deploy immutable candidate to staging:
+Sugarkube reads the chart version from `docs/apps/dspace.version`. Confirm that
+GHCR has that chart before deploying.
 
-   ```bash
-   just dspace-oci-deploy env=staging tag=main-<shortsha>
-   ```
+```bash
+CHART_VERSION=$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/dspace.version | head -n1)
+```
 
-3. Verify staging (`config.json`, `healthz`, `livez`) at
-   `https://staging.democratized.space`.
+```bash
+helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version "$CHART_VERSION"
+```
 
-   ```bash
-   curl -fsS https://staging.democratized.space/config.json | jq .
-   ```
+If the chart changed in the dspace repository and GHCR does not have the desired
+version yet, publish it from the dspace chart workflow before updating the
+Sugarkube chart pin.
 
-   ```bash
-   curl -fsS https://staging.democratized.space/healthz | jq .
-   ```
+```bash
+gh workflow run ci-helm.yml --repo democratizedspace/dspace --ref main
+```
 
-   ```bash
-   curl -fsS https://staging.democratized.space/livez | jq .
-   ```
+## 5. Deploy staging
 
-4. Promote the approved immutable tag to production apex:
+Preferred generic command:
 
-   ```bash
-   just dspace-oci-promote-prod tag=main-<shortsha>
-   # or semver tag once released
-   just dspace-oci-promote-prod tag=3.1.0
-   ```
+```bash
+APP_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag from dspace CI
+just app-deploy app=dspace env=staging tag="$APP_TAG"
+```
 
-   Then verify production apex:
+Current compatibility wrapper:
 
-   ```bash
-   curl -fsS https://democratized.space/config.json | jq .
-   ```
+```bash
+APP_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag from dspace CI
+just dspace-oci-deploy env=staging tag="$APP_TAG"
+```
 
-   ```bash
-   curl -fsS https://democratized.space/healthz | jq .
-   ```
+## 6. Verify staging
 
-   ```bash
-   curl -fsS https://democratized.space/livez | jq .
-   ```
+Run the generic Sugarkube status and HTTP verification helpers first.
 
-5. Keep rollback simple by redeploying the prior immutable tag.
+```bash
+just app-status app=dspace env=staging
+```
 
-Optional only: use `dspace-oci-deploy-prod-subdomain` when you explicitly need the
-`https://prod.democratized.space` subdomain before apex promotion. In steady state, this
-subdomain is typically a redirect to `https://democratized.space`, so it is not part of the
-default required deploy/promotion path.
+```bash
+just app-verify app=dspace env=staging
+```
 
-## Networking via Cloudflare Tunnel
+Manual smoke checks:
 
-This guide assumes public ingress is exposed via Cloudflare Tunnel.
+```bash
+curl -fsS https://staging.democratized.space/config.json | jq .
+```
 
-Typical hostnames:
+```bash
+curl -fsS https://staging.democratized.space/healthz
+```
 
-- staging: `https://staging.democratized.space`
-- optional `prod.` subdomain (often redirect): `https://prod.democratized.space`
-- production apex: `https://democratized.space`
+```bash
+curl -fsS https://staging.democratized.space/livez
+```
 
-For tunnel and DNS setup details, see [Cloudflare Tunnel docs](../cloudflare_tunnel.md).
+## 7. Promote production
 
-## Troubleshooting
+Promote only after staging sign-off. Record the approved immutable tag in your
+release notes and, when appropriate, in `docs/apps/dspace.prod.tag`.
 
-- GHCR/OCI auth errors (`401 authentication required` or `403 denied: denied`) for
-  `helm pull`/`helm-oci-*` helpers:
-  [Raspberry Pi Cluster Troubleshooting — Scenario 7](../raspi_cluster_troubleshooting.md#scenario-7-helm-oci-pull-fails-with-ghcr-403-denied-denied).
-- Collect dspace + ingress logs with environment-aware helper:
+Preferred generic command:
 
-  ```bash
-  just dspace-debug-logs-env env=staging
-  just dspace-debug-logs-env env=prod
-  ```
+```bash
+APP_TAG=main-REPLACE_SHORTSHA # replace with the staging-approved immutable GHCR image tag
+just app-promote-prod app=dspace tag="$APP_TAG"
+```
 
-- Inspect Helm release state:
-  - `helm -n dspace status dspace`
-  - `helm -n dspace get values dspace`
-- Inspect Kubernetes objects:
-  - `kubectl -n dspace get ingress,pods,svc`
-  - `kubectl -n dspace describe ingress dspace`
+Current compatibility wrapper:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA # replace with the staging-approved immutable GHCR image tag
+just dspace-oci-promote-prod tag="$APP_TAG"
+```
+
+If `docs/apps/dspace.prod.tag` already contains the approved production tag, the
+generic promotion command can read it by omitting `tag=`.
+
+```bash
+just app-promote-prod app=dspace
+```
+
+## 8. Verify production
+
+```bash
+just app-status app=dspace env=prod
+```
+
+```bash
+just app-verify app=dspace env=prod
+```
+
+```bash
+curl -fsS https://democratized.space/config.json | jq .
+```
+
+```bash
+curl -fsS https://democratized.space/healthz
+```
+
+```bash
+curl -fsS https://democratized.space/livez
+```
+
+## 9. Rollback
+
+Rollback by immutable tag with the generic redeploy helper:
+
+```bash
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA # replace with the previous known-good immutable GHCR image tag
+just app-redeploy app=dspace env=prod tag="$APP_TAG"
+```
+
+Rollback staging the same way if the failure is caught before promotion:
+
+```bash
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA # replace with the previous known-good immutable GHCR image tag
+just app-redeploy app=dspace env=staging tag="$APP_TAG"
+```
+
+Rollback by Helm revision when a revision number is known:
+
+```bash
+DSPACE_REVISION=12 # replace with the known-good Helm revision
+just tokenplace-rollback release=dspace namespace=dspace revision="$DSPACE_REVISION"
+```
+
+## 10. Troubleshooting
+
+GHCR authentication and chart pull failures commonly show up as Helm `401` or
+`403` errors. Log in to GHCR with a package-read credential, then retry the
+chart check.
+
+```bash
+CHART_VERSION=$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/dspace.version | head -n1)
+helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version "$CHART_VERSION"
+```
+
+Inspect status, logs, ingress, and tunnel routing:
+
+```bash
+just app-status app=dspace env=staging
+```
+
+```bash
+just dspace-debug-logs-env env=staging
+```
+
+```bash
+just cluster-status
+```
+
+```bash
+just traefik-status
+```
+
+```bash
+just cf-tunnel-debug
+```
+
+Cloudflare routes are external to Helm. Create or repair routes outside the
+chart when DNS/tunnel routing is the failing layer.
+
+```bash
+just cf-tunnel-route host=staging.democratized.space
+```
+
+Low-level Helm OCI helpers remain available when you need to debug the generic
+app wrapper. Prefer `just app-deploy app=dspace ...` for routine releases.
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag from dspace CI
+just helm-oci-install release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.version tag="$APP_TAG"
+```
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag from dspace CI
+just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.version tag="$APP_TAG"
+```
+
+## 11. App-specific notes
+
+- dspace exposes `/config.json`, `/healthz`, and `/livez`; verify all three
+  before promotion.
+- `dspace-oci-deploy-prod-subdomain` remains available only for the optional
+  `prod.democratized.space` legacy endpoint. Prefer the generic `prod` app flow
+  for normal apex production releases.
+- Keep mutable tags such as `latest` out of production. Use immutable branch-SHA
+  or release tags for staging sign-off, production promotion, and rollback.

--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -159,4 +159,4 @@ just cf-tunnel-debug
 - Chart `appVersion`: `0.1.0`
 - Git tag: `v0.1.0`
 - Release image tag: `v0.1.0`
-- Staging candidate image tag: `main-<shortsha>`
+- Staging candidate image tag: `main-REPLACE_SHORTSHA`

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -1,144 +1,241 @@
 # token.place on Sugarkube
 
-This is the canonical Sugarkube deployment model for token.place.
+Use this runbook for GHCR-first token.place relay deploys, promotions,
+verification, and rollback on Sugarkube. The preferred future path is the generic
+app flow backed by `docs/examples/apps/tokenplace.env`; the `tokenplace-*`
+recipes remain compatibility shims until the generic flow has been exercised
+across routine releases.
 
-For the shared artifact, tag, chart, app-config, and planned generic command contract, see [Sugarkube app deployment contract](../app_deployment_contract.md).
+## 1. Artifact model
 
-For onboarding ownership and environment sequencing, see
-[`docs/tokenplace_sugarkube_onboarding.md`](../tokenplace_sugarkube_onboarding.md).
+- App repository responsibility: build and publish
+  `ghcr.io/futuroptimist/tokenplace-relay` images from the token.place
+  repository's CI, including immutable deploy tags such as
+  `main-REPLACE_SHORTSHA`.
+- App repository responsibility: package and publish the Helm chart at
+  `oci://ghcr.io/futuroptimist/charts/tokenplace` with immutable chart versions.
+- Sugarkube responsibility: select kubeconfig/environment, read
+  `docs/examples/apps/tokenplace.env`, pin the chart version from
+  `docs/apps/tokenplace.version`, deploy the selected image tag with Helm, and
+  run status/verify/log helpers.
+- Cloudflare responsibility: DNS and tunnel routes for the public hostnames live
+  outside Helm; the chart only creates Kubernetes resources behind Traefik.
 
-## Relay-only topology (current scope)
+| Coordinate | Value |
+| --- | --- |
+| App config | `docs/examples/apps/tokenplace.env` |
+| Image | `ghcr.io/futuroptimist/tokenplace-relay` |
+| Chart | `oci://ghcr.io/futuroptimist/charts/tokenplace` |
+| Release | `tokenplace` |
+| Namespace | `tokenplace` |
+| Chart pin | `docs/apps/tokenplace.version` |
+| Production tag pin | `docs/apps/tokenplace.prod.tag` |
+| Verify paths | `/`, `/livez`, `/healthz`, `/relay/diagnostics` |
 
-Sugarkube currently runs **only** the token.place relay service (`relay.py`).
+## 2. Environment topology
 
-- **In-cluster (Sugarkube):** one relay deployment exposed through Traefik ingress.
-- **Out-of-cluster compute:** `server.py`, desktop Tauri app, Windows PCs, Apple Silicon Macs,
-  Raspberry Pi compute nodes, and other compute workers remain external.
-- **No in-cluster backend/GPU service** is required for steady-state relay operation.
-- **Single replica + single worker** defaults are intentional.
-- Relay state is currently **in-memory only**; pod restarts lose relay memory/state and this is
-  accepted for now.
-- Future in-memory database or multi-replica architecture is **out of scope** for this runbook.
+- `env=dev`: non-production defaults using
+  `docs/examples/tokenplace.values.dev.yaml`.
+- `env=staging`: staging host `staging.token.place`, values chain
+  `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml`.
+- `env=prod`: production host `token.place`, values chain
+  `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml`.
 
-## Artifact model (canonical)
+## 3. Find or publish GHCR image
 
-- Image: `ghcr.io/futuroptimist/tokenplace-relay`
-- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Helm release: `tokenplace`
-- Namespace: `tokenplace`
-- Chart version pin file: `docs/apps/tokenplace.version`
-- Production approved tag pin: `docs/apps/tokenplace.prod.tag`
-
-## Values model
-
-- Base: `docs/examples/tokenplace.values.dev.yaml`
-- Staging overlay: `docs/examples/tokenplace.values.staging.yaml`
-- Production overlay: `docs/examples/tokenplace.values.prod.yaml`
-
-Chart-owned runtime env defaults (worker count, frontend mode, relay upstream-health gating, and XDG `/tmp` paths) should remain in the token.place chart. Keep Sugarkube values focused on environment-specific keys like `TOKEN_PLACE_ENV`, `TOKENPLACE_RELAY_PUBLIC_URL`, ingress hosts, and TLS secrets.
-
-Default hosts:
-
-- Staging: `staging.token.place`
-- Production: `token.place`
-
-## Core deployment commands
-
-Use concrete release/namespace/chart values for token.place relay deployments.
+Find the latest successful token.place image workflow and copy the immutable tag
+for the relay image.
 
 ```bash
-just kubeconfig-env staging
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+APP_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag from token.place CI
 ```
 
 ```bash
-just kubeconfig-env staging
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+gh run list --repo futuroptimist/token.place --workflow ci-image.yml --status success --limit 10
 ```
 
-Preferred env wrapper:
+If no usable immutable tag exists, publish one from the token.place repository's
+image workflow before deploying from Sugarkube.
 
 ```bash
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just tokenplace-oci-deploy env=staging tag="$TOKENPLACE_TAG"
+gh workflow run ci-image.yml --repo futuroptimist/token.place --ref main
 ```
 
-## Validation commands
+## 4. Confirm/publish OCI chart
+
+Sugarkube reads the chart version from `docs/apps/tokenplace.version`. Confirm
+that GHCR has that chart before deploying.
 
 ```bash
-kubectl -n tokenplace get deploy,po,svc,ingress
-kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
+CHART_VERSION=$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)
+```
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$CHART_VERSION"
+```
+
+If the chart changed in the token.place repository and GHCR does not have the
+desired version yet, publish it from the chart workflow before updating the
+Sugarkube chart pin.
+
+```bash
+gh workflow run ci-helm.yml --repo futuroptimist/token.place --ref main
+```
+
+## 5. Deploy staging
+
+Preferred generic command:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag from token.place CI
+just app-deploy app=tokenplace env=staging tag="$APP_TAG"
+```
+
+Current compatibility wrapper:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag from token.place CI
+just tokenplace-oci-deploy env=staging tag="$APP_TAG"
+```
+
+## 6. Verify staging
+
+```bash
+just app-status app=tokenplace env=staging
+```
+
+```bash
+just app-verify app=tokenplace env=staging
+```
+
+```bash
 curl -fsS https://staging.token.place/livez
-curl -fsS https://staging.token.place/healthz
-curl -fsS https://staging.token.place/relay/diagnostics
-curl -fsS https://staging.token.place/
 ```
-
-For production validation, use the same checks against `https://token.place`. Avoid long-running
-public `/healthz` watches as readiness monitors until health, liveness, metrics, diagnostics, and
-API v1 compute-node heartbeat routes are confirmed exempt from public API rate limits; prefer
-`kubectl -n tokenplace get endpoints`, `kubectl -n tokenplace get deploy,po`, relay logs, and
-low-frequency diagnostics curls for operational readiness. Staging/prod signoff also requires
-synthetic API v1 register/poll, an external desktop or compute-node registration, and an E2EE
-request/response through the relay; see the staging runbook for the full sequence and curl payloads.
-
-## Promotion blockers
-
-Use the environment runbooks for copy-paste commands, but keep this release-blocker rule in every
-token.place promotion review: **web/TLS health is not relay validation**. A build can only move from
-staging to production after all of these are true:
-
-- [ ] OCI chart freshness and chart digest are captured for the exact version being promoted.
-- [ ] Rendered manifests contain no duplicate env vars.
-- [ ] XDG writable `/tmp` env defaults are present from the chart, not one-off CLI overrides.
-- [ ] `/healthz` is exempt from API rate limiting.
-- [ ] Synthetic API v1 compute-node register/poll passes.
-- [ ] A desktop compute node uses the intended `knownServers`/server entry and registers.
-- [ ] The registered compute node appears in `/healthz` and `/relay/diagnostics`.
-- [ ] An E2EE request/response succeeds through that compute node.
-- [ ] The production Cloudflare route exists and points to Traefik before prod cutover.
-
-Emergency diagnostics and rollback remain environment-specific:
-
-- Staging: [`docs/k3s-tokenplace-staging.md`](../k3s-tokenplace-staging.md)
-- Production: [`docs/k3s-tokenplace-prod.md`](../k3s-tokenplace-prod.md)
-
-## Cloudflare and ingress model
-
-Cloudflare Tunnel/DNS configuration is external to Helm.
-
-- Route hostnames to Traefik, typically
-  `http://traefik.kube-system.svc.cluster.local:80`.
-- Helm chart deployment does **not** create Cloudflare routes.
-- One tunnel per environment can serve multiple app hostnames (for example
-  `staging.democratized.space` and `staging.token.place`) by routing both to Traefik.
-- Traefik chooses the correct Kubernetes Ingress by HTTP `Host` header.
-- Staging/prod overlays set `ingress.tls.enabled: true` so rendered Kubernetes Ingress includes `spec.tls`.
-- `cert-manager` and a compatible `ClusterIssuer` are assumed to already exist.
-- Cloudflare Tunnel routing (`cf-tunnel-route`) is separate from the Cloudflare DNS API token used
-  by cert-manager DNS-01.
-- Configure routes explicitly:
 
 ```bash
-just cf-tunnel-route staging.token.place
-just cf-tunnel-route host=staging.token.place
-just cf-tunnel-route token.place
-just cf-tunnel-route host=token.place
+curl -fsS https://staging.token.place/healthz
 ```
 
-## Related runbooks
+```bash
+curl -fsS https://staging.token.place/relay/diagnostics | jq .
+```
 
-- Relay-focused app guide: [`docs/apps/tokenplace-relay.md`](./tokenplace-relay.md)
-- Staging runbook: [`docs/k3s-tokenplace-staging.md`](../k3s-tokenplace-staging.md)
-- Production runbook: [`docs/k3s-tokenplace-prod.md`](../k3s-tokenplace-prod.md)
+## 7. Promote production
 
+Promote only after staging sign-off. Record the approved immutable tag in your
+release notes and, when appropriate, in `docs/apps/tokenplace.prod.tag`.
 
-## 0.1.0 release alignment
+Preferred generic command:
 
-- Chart version: `0.1.0`
-- Chart `appVersion`: `0.1.0`
-- Git tag: `v0.1.0`
-- Release image tag: `v0.1.0` (`ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`)
-- Staging candidate image tag: `main-<shortsha>`
+```bash
+APP_TAG=main-REPLACE_SHORTSHA # replace with the staging-approved immutable GHCR image tag
+just app-promote-prod app=tokenplace tag="$APP_TAG"
+```
+
+Current compatibility wrapper:
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA # replace with the staging-approved immutable GHCR image tag
+just tokenplace-oci-promote-prod tag="$APP_TAG"
+```
+
+If `docs/apps/tokenplace.prod.tag` already contains the approved production tag,
+the generic promotion command can read it by omitting `tag=`.
+
+```bash
+just app-promote-prod app=tokenplace
+```
+
+## 8. Verify production
+
+```bash
+just app-status app=tokenplace env=prod
+```
+
+```bash
+just app-verify app=tokenplace env=prod
+```
+
+```bash
+curl -fsS https://token.place/livez
+```
+
+```bash
+curl -fsS https://token.place/healthz
+```
+
+```bash
+curl -fsS https://token.place/relay/diagnostics | jq .
+```
+
+## 9. Rollback
+
+Rollback by immutable tag with the generic redeploy helper:
+
+```bash
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA # replace with the previous known-good immutable GHCR image tag
+just app-redeploy app=tokenplace env=prod tag="$APP_TAG"
+```
+
+Rollback staging the same way if the failure is caught before promotion:
+
+```bash
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA # replace with the previous known-good immutable GHCR image tag
+just app-redeploy app=tokenplace env=staging tag="$APP_TAG"
+```
+
+Rollback by Helm revision when a revision number is known:
+
+```bash
+TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
+just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
+```
+
+## 10. Troubleshooting
+
+GHCR authentication and chart pull failures commonly show up as Helm `401` or
+`403` errors. Log in to GHCR with a package-read credential, then retry the
+chart check.
+
+```bash
+CHART_VERSION=$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$CHART_VERSION"
+```
+
+Inspect status, logs, ingress, and tunnel routing:
+
+```bash
+just app-status app=tokenplace env=staging
+```
+
+```bash
+just tokenplace-debug-logs-env env=staging
+```
+
+```bash
+just cluster-status
+```
+
+```bash
+just traefik-status
+```
+
+```bash
+just cf-tunnel-debug
+```
+
+Cloudflare routes are external to Helm. Create or repair routes outside the
+chart when DNS/tunnel routing is the failing layer.
+
+```bash
+just cf-tunnel-route host=staging.token.place
+```
+
+## 11. App-specific notes
+
+- token.place deploys the canonical relay image. Do not deploy stale Docker-first
+  images or duplicate relay variants for staging/prod.
+- Preserve relay-blind behavior: logs, diagnostics, and app status must not expose
+  plaintext message contents or secrets.
+- The `/relay/diagnostics` endpoint is safe for smoke checks because it reports
+  operational metadata, not decrypted relay payloads.

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,17 +43,18 @@ Review the safety notes before working with power components.
   and Helm OCI issues, including GHCR `401/403` chart pull failures
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
 - [projects-compose.md](projects-compose.md) — run token.place & dspace via docker compose
-- [app_deployment_contract.md](app_deployment_contract.md) — shared Sugarkube app artifact, tag, chart, config, and planned generic command contract
-- [tokenplace_sugarkube_onboarding.md](tokenplace_sugarkube_onboarding.md) — onboarding contract,
-  ownership boundaries, and environment mapping for token.place on Sugarkube
-- [apps/tokenplace.md](apps/tokenplace.md) — token.place app topology and operations model on Sugarkube
-- [apps/tokenplace-relay.md](apps/tokenplace-relay.md) — relay-only token.place OCI staging/prod operations guide
-- [apps/danielsmith.md](apps/danielsmith.md) — danielsmith.io static-site topology and operations model on Sugarkube
+- [app_deployment_contract.md](app_deployment_contract.md) — generic Sugarkube app deployment contract, config shape, and command migration notes
+- [app_onboarding.md](app_onboarding.md) — future-app onboarding checklist, minimal config template, and release decision tree for wove, jobbot3000, and later apps
+- [apps/dspace.md](apps/dspace.md) — dspace GHCR-first staging/prod deploy, verify, promote, and rollback runbook
+- [apps/tokenplace.md](apps/tokenplace.md) — token.place GHCR-first staging/prod deploy, verify, promote, and rollback runbook
+- [apps/danielsmith.md](apps/danielsmith.md) — danielsmith.io GHCR-first staging/prod deploy, verify, promote, and rollback runbook
+- [apps/tokenplace-relay.md](apps/tokenplace-relay.md) — relay-only token.place OCI reference for compatibility-era operations
 - [k3s-tokenplace-dev.md](k3s-tokenplace-dev.md) — token.place dev runbook
-- [k3s-tokenplace-staging.md](k3s-tokenplace-staging.md) — token.place staging runbook
-- [k3s-tokenplace-prod.md](k3s-tokenplace-prod.md) — token.place production runbook
-- [k3s-danielsmith-staging.md](k3s-danielsmith-staging.md) — danielsmith.io staging runbook
-- [k3s-danielsmith-prod.md](k3s-danielsmith-prod.md) — danielsmith.io production runbook
+- [k3s-tokenplace-staging.md](k3s-tokenplace-staging.md) — token.place staging quick checklist
+- [k3s-tokenplace-prod.md](k3s-tokenplace-prod.md) — token.place production quick checklist
+- [k3s-danielsmith-staging.md](k3s-danielsmith-staging.md) — danielsmith.io staging quick checklist
+- [k3s-danielsmith-prod.md](k3s-danielsmith-prod.md) — danielsmith.io production quick checklist
+- [tokenplace_sugarkube_onboarding.md](tokenplace_sugarkube_onboarding.md) — legacy token.place-specific onboarding contract and environment mapping
 - [operations/security-checklist.md](operations/security-checklist.md) — track credential rotations and
   verification steps
 - [pi_token_dspace.md](pi_token_dspace.md) — build and expose token.place & dspace via Cloudflare

--- a/docs/k3s-danielsmith-prod.md
+++ b/docs/k3s-danielsmith-prod.md
@@ -1,110 +1,66 @@
 # k3s danielsmith.io runbook (prod)
 
-Use this runbook for production deployments of the static `danielsmith.io` site on Sugarkube.
+This environment-specific page is a quick production checklist. Use the
+canonical uniform app runbook for the complete GHCR-first flow:
+[`docs/apps/danielsmith.md`](apps/danielsmith.md).
 
-## Topology and scope
+## Responsibilities
 
-- `danielsmith.io` is a static Vite + Three.js workload.
-- Sugarkube runs only the static web container.
-- No in-cluster API/backend/database/queue/GPU/compute node/stateful service is required.
-- Cloudflare Tunnel fronts Traefik; Traefik routes traffic to the `danielsmith` Service.
-- Probe/application endpoints: `/livez`, `/healthz`, and `/`.
+- App repo: publish the static-site image and Helm chart to GHCR.
+- Sugarkube: select the production kubeconfig, deploy the configured chart and
+  approved tag, then run status/verify/log helpers.
+- Cloudflare: route `danielsmith.io` to the production Traefik endpoint outside
+  Helm.
 
-## Artifact and values contract
+## Promote production
 
-- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
-- Image: `ghcr.io/futuroptimist/danielsmith.io`
-- Release: `danielsmith`
-- Namespace: `danielsmith`
-- Version pin file: `docs/apps/danielsmith.version`
-- Approved prod tag file: `docs/apps/danielsmith.prod.tag`
-- Values: `docs/examples/danielsmith.values.dev.yaml` + `docs/examples/danielsmith.values.prod.yaml`
-- Default production host: `danielsmith.io`
-
-## First install
-
-Always select the production kube context before running the generic Helm install command.
+Preferred generic command:
 
 ```bash
-just kubeconfig-env prod
-DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the approved immutable GHCR image tag
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_APPROVED_TAG"
+APP_TAG=main-REPLACE_SHORTSHA # replace with the staging-approved immutable GHCR image tag
+just app-promote-prod app=danielsmith tag="$APP_TAG"
 ```
 
-## Promotion after staging sign-off
+Compatibility wrapper:
 
 ```bash
-DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the approved immutable GHCR image tag
-just danielsmith-oci-promote-prod tag="$DANIELSMITH_APPROVED_TAG"
+APP_TAG=main-REPLACE_SHORTSHA # replace with the staging-approved immutable GHCR image tag
+just danielsmith-oci-promote-prod tag="$APP_TAG"
 ```
 
-## Generic production upgrade
+If `docs/apps/danielsmith.prod.tag` already contains the approved tag:
 
 ```bash
-just kubeconfig-env prod
-DANIELSMITH_APPROVED_TAG=main-REPLACE_APPROVED_SHORTSHA # replace with the approved immutable GHCR image tag
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_APPROVED_TAG"
+just app-promote-prod app=danielsmith
 ```
 
-## Validation
+## Verify production
 
 ```bash
-kubectl -n danielsmith get deploy,po,svc,ingress
-kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
-curl -fsS https://danielsmith.io/livez
-curl -fsS https://danielsmith.io/healthz
+just app-status app=danielsmith env=prod
+```
+
+```bash
+just app-verify app=danielsmith env=prod
+```
+
+```bash
 curl -fsS https://danielsmith.io/
 ```
 
-## Rollback options
-
-Rollback by immutable tag:
+## Roll back production
 
 ```bash
-just kubeconfig-env prod
-DANIELSMITH_PREVIOUS_APPROVED_TAG=main-REPLACE_PREVIOUS_APPROVED_SHORTSHA # replace with the previous approved immutable GHCR image tag
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_PREVIOUS_APPROVED_TAG"
-```
-
-Rollback by Helm revision:
-
-`tokenplace-rollback` is the repository's existing parameterized Helm rollback helper, even though the recipe name is token.place-scoped.
-
-```bash
-just kubeconfig-env prod
-DANIELSMITH_REVISION=12 # replace with the known-good Helm revision
-just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$DANIELSMITH_REVISION"
-```
-
-## Cloudflare tunnel routing (external to Helm)
-
-Cloudflare routes are configured outside the chart. Route `danielsmith.io` to Traefik,
-typically `http://traefik.kube-system.svc.cluster.local:80`.
-
-```bash
-just cf-tunnel-route host=danielsmith.io
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA # replace with the previous known-good immutable GHCR image tag
+just app-redeploy app=danielsmith env=prod tag="$APP_TAG"
 ```
 
 ## Troubleshooting
 
-GHCR auth/chart checks:
-
 ```bash
-echo "$GHCR_TOKEN" | helm registry login ghcr.io -u "$GHCR_USER" --password-stdin
-helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/danielsmith.version | head -n1)"
-```
-
-App status/logs:
-
-```bash
-just danielsmith-status
 just danielsmith-debug-logs-env env=prod
 ```
 
-Ingress/tunnel checks:
-
 ```bash
-just cluster-status
-just traefik-status
-just cf-tunnel-debug
+just cf-tunnel-route host=danielsmith.io
 ```

--- a/docs/k3s-danielsmith-staging.md
+++ b/docs/k3s-danielsmith-staging.md
@@ -1,107 +1,60 @@
 # k3s danielsmith.io runbook (staging)
 
-Use this runbook for staging deployments of the static `danielsmith.io` site on Sugarkube.
+This environment-specific page is a quick staging checklist. Use the canonical
+uniform app runbook for the complete GHCR-first flow:
+[`docs/apps/danielsmith.md`](apps/danielsmith.md).
 
-## Topology and scope
+## Responsibilities
 
-- `danielsmith.io` is a static Vite + Three.js workload.
-- Sugarkube runs only the static web container.
-- No in-cluster API/backend/database/queue/GPU/compute node/stateful service is required.
-- Cloudflare Tunnel fronts Traefik; Traefik routes traffic to the `danielsmith` Service.
-- Probe/application endpoints: `/livez`, `/healthz`, and `/`.
+- App repo: publish the static-site image and Helm chart to GHCR.
+- Sugarkube: select the staging kubeconfig, deploy the configured chart and tag,
+  then run status/verify/log helpers.
+- Cloudflare: route `staging.danielsmith.io` to the staging Traefik endpoint
+  outside Helm.
 
-## Artifact and values contract
+## Deploy staging
 
-- Chart: `oci://ghcr.io/futuroptimist/charts/danielsmith`
-- Image: `ghcr.io/futuroptimist/danielsmith.io`
-- Release: `danielsmith`
-- Namespace: `danielsmith`
-- Version pin file: `docs/apps/danielsmith.version`
-- Values: `docs/examples/danielsmith.values.dev.yaml` + `docs/examples/danielsmith.values.staging.yaml`
-- Default staging host: `staging.danielsmith.io`
-
-## First install
+Preferred generic command:
 
 ```bash
-just kubeconfig-env staging
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
-just helm-oci-install release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
+APP_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag from danielsmith.io CI
+just app-deploy app=danielsmith env=staging tag="$APP_TAG"
 ```
 
-## Existing release upgrade
+Compatibility wrapper:
 
 ```bash
-just kubeconfig-env staging
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_TAG"
+APP_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag from danielsmith.io CI
+just danielsmith-oci-deploy env=staging tag="$APP_TAG"
 ```
 
-Preferred wrapper:
+## Verify staging
 
 ```bash
-DANIELSMITH_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag to deploy
-just danielsmith-oci-deploy env=staging tag="$DANIELSMITH_TAG"
+just app-status app=danielsmith env=staging
 ```
 
-## Validation
+```bash
+just app-verify app=danielsmith env=staging
+```
 
 ```bash
-kubectl -n danielsmith get deploy,po,svc,ingress
-kubectl -n danielsmith rollout status deploy/danielsmith --timeout=180s
-curl -fsS https://staging.danielsmith.io/livez
-curl -fsS https://staging.danielsmith.io/healthz
 curl -fsS https://staging.danielsmith.io/
 ```
 
-## Rollback
-
-Rollback by immutable tag:
+## Roll back staging
 
 ```bash
-just kubeconfig-env staging
-DANIELSMITH_PREVIOUS_TAG=main-REPLACE_PREVIOUS_SHORTSHA # replace with the previous immutable GHCR image tag
-just helm-oci-upgrade release=danielsmith namespace=danielsmith chart=oci://ghcr.io/futuroptimist/charts/danielsmith values=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml version_file=docs/apps/danielsmith.version default_tag="$DANIELSMITH_PREVIOUS_TAG"
-```
-
-Rollback by Helm revision:
-
-`tokenplace-rollback` is the repository's existing parameterized Helm rollback helper, even though the recipe name is token.place-scoped.
-
-```bash
-just kubeconfig-env staging
-DANIELSMITH_REVISION=12 # replace with the known-good Helm revision
-just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$DANIELSMITH_REVISION"
-```
-
-## Cloudflare tunnel routing (external to Helm)
-
-Cloudflare routes are configured outside the chart. Route `staging.danielsmith.io` to Traefik,
-typically `http://traefik.kube-system.svc.cluster.local:80`.
-
-```bash
-just cf-tunnel-route host=staging.danielsmith.io
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA # replace with the previous known-good immutable GHCR image tag
+just app-redeploy app=danielsmith env=staging tag="$APP_TAG"
 ```
 
 ## Troubleshooting
 
-GHCR auth/chart checks:
-
 ```bash
-echo "$GHCR_TOKEN" | helm registry login ghcr.io -u "$GHCR_USER" --password-stdin
-helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/danielsmith.version | head -n1)"
-```
-
-App status/logs:
-
-```bash
-just danielsmith-status
 just danielsmith-debug-logs-env env=staging
 ```
 
-Ingress/tunnel checks:
-
 ```bash
-just cluster-status
-just traefik-status
-just cf-tunnel-debug
+just cf-tunnel-route host=staging.danielsmith.io
 ```

--- a/docs/k3s-tokenplace-prod.md
+++ b/docs/k3s-tokenplace-prod.md
@@ -1,293 +1,66 @@
 # k3s token.place runbook (prod)
 
-Use this runbook for relay-only token.place production deployments on Sugarkube.
+This environment-specific page is a quick production checklist. Use the canonical
+uniform app runbook for the complete GHCR-first flow:
+[`docs/apps/tokenplace.md`](apps/tokenplace.md).
 
-## Topology and scope
+## Responsibilities
 
-- Sugarkube runs only token.place relay (`relay.py`).
-- No in-cluster backend/GPU service is required.
-- Compute nodes remain external (`server.py`, Tauri desktop app, Windows PCs, Apple Silicon Macs,
-  Raspberry Pi compute nodes, etc.).
-- Runtime model is single replica + single Gunicorn worker + in-memory state; verify the rendered Kubernetes Deployment contract includes `spec.strategy.type: Recreate` before rollout.
-- In-memory state loss on pod restart is accepted for now.
+- App repo: publish the relay image and Helm chart to GHCR.
+- Sugarkube: select the production kubeconfig, deploy the configured chart and
+  approved tag, then run status/verify/log helpers.
+- Cloudflare: route `token.place` to the production Traefik endpoint outside
+  Helm.
 
-## Artifact and values contract
+## Promote production
 
-- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Image: `ghcr.io/futuroptimist/tokenplace-relay`
-- Release: `tokenplace`
-- Namespace: `tokenplace`
-- Version pin file: `docs/apps/tokenplace.version`
-- Approved prod tag file: `docs/apps/tokenplace.prod.tag`
-- Values: `docs/examples/tokenplace.values.dev.yaml` + `docs/examples/tokenplace.values.prod.yaml`
-- Default production host: `token.place`
-
-## Pre-flight (before Step 1)
-
-- Verify `docs/apps/tokenplace.version` remains pinned to `0.1.0`.
-- Verify the `0.1.0` OCI chart exists only after token.place publishes the current chart.
-- If `helm show chart ... --version 0.1.0` succeeds before the final token.place chart publish, confirm the chart is not stale before deploying.
+Preferred generic command:
 
 ```bash
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+APP_TAG=main-REPLACE_SHORTSHA # replace with the staging-approved immutable GHCR image tag
+just app-promote-prod app=tokenplace tag="$APP_TAG"
 ```
 
-## Promotion after staging sign-off
-
-Production promotion requires an external desktop or compute-node registration plus a successful
-E2EE request/response; Certificate `Ready=True`, web/TLS checks, or synthetic register/poll alone
-are not sufficient signoff.
+Compatibility wrapper:
 
 ```bash
-TOKENPLACE_TAG=v0.1.0 # use final release tag after token.place Git tag push
-just tokenplace-oci-promote-prod tag="$TOKENPLACE_TAG"
+APP_TAG=main-REPLACE_SHORTSHA # replace with the staging-approved immutable GHCR image tag
+just tokenplace-oci-promote-prod tag="$APP_TAG"
 ```
 
-## Generic production upgrade
-
-Select the production kube context first (or use the wrapper above):
+If `docs/apps/tokenplace.prod.tag` already contains the approved tag:
 
 ```bash
-just kubeconfig-env prod
+just app-promote-prod app=tokenplace
 ```
 
-Then run the generic OCI helper:
+## Verify production
 
 ```bash
-TOKENPLACE_TAG=v0.1.0 # use final release tag after token.place Git tag push
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+just app-status app=tokenplace env=prod
 ```
-
-## Validation
-
-Render/contract checks:
 
 ```bash
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
-helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.prod.yaml --set image.tag=v0.1.0 > /tmp/tokenplace-prod-render.yaml
-python3 - <<'PY'
-import collections
-import sys
-
-try:
-    import yaml
-except ModuleNotFoundError:
-    sys.exit("PyYAML is required for this render validation. Install it with: python3 -m pip install PyYAML")
-
-with open("/tmp/tokenplace-prod-render.yaml", encoding="utf-8") as rendered:
-    docs = list(yaml.safe_load_all(rendered))
-
-try:
-    deploy = next(
-        d
-        for d in docs
-        if d and d.get("kind") == "Deployment" and d.get("metadata", {}).get("name") == "tokenplace"
-    )
-except StopIteration:
-    sys.exit("tokenplace Deployment not found in rendered manifest")
-
-pod_spec = deploy["spec"]["template"]["spec"]
-for container_type, containers in (
-    ("init", pod_spec.get("initContainers", [])),
-    ("app", pod_spec.get("containers", [])),
-):
-    for container in containers:
-        names = [item["name"] for item in container.get("env", []) if "name" in item]
-        dupes = [name for name, count in collections.Counter(names).items() if count > 1]
-        if dupes:
-            sys.exit(f"duplicate env names found: {container_type}:{container.get('name', '<unnamed>')}: {dupes}")
-PY
-grep -n "spec:" -A40 /tmp/tokenplace-prod-render.yaml | grep -n "tls"
-grep -n "token.place" /tmp/tokenplace-prod-render.yaml
-grep -n "tokenplace-prod-tls" /tmp/tokenplace-prod-render.yaml
-yq eval '. | select(.kind == "Deployment" and .metadata.name == "tokenplace") | .spec.strategy.type' /tmp/tokenplace-prod-render.yaml
+just app-verify app=tokenplace env=prod
 ```
-
-Cluster/runtime checks:
 
 ```bash
-kubectl -n tokenplace get deploy,po,svc,ingress
-kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
-kubectl -n tokenplace get ingress tokenplace -o yaml
-curl -vI https://token.place/
-curl -fsS https://token.place/livez
-curl -fsS https://token.place/healthz
+curl -fsS https://token.place/relay/diagnostics | jq .
 ```
 
-## Promotion blockers
-
-> **Release blocker:** production promotion is blocked until staging proves the actual
-> relay-compute path, and the promoted production deployment then proves its own prod
-> compute-node path. Deployment Ready, TLS Ready, `/livez`, `/healthz`, `/`, `/metrics`, and
-> synthetic register/poll are necessary but not sufficient by themselves.
-
-Before running the prod upgrade, confirm every item from staging sign-off evidence:
-
-- [ ] OCI chart freshness is proven with `helm show chart` plus chart digest evidence for the
-  exact chart version being promoted from staging to prod.
-- [ ] Render validation finds no duplicate environment variables in any init/app container.
-- [ ] Rendered Deployment includes writable XDG `/tmp` defaults from the chart without one-off
-  Sugarkube override drift.
-- [ ] Staging `/healthz` is exempt from token.place global API rate limits.
-- [ ] Synthetic API v1 compute-node register/poll passes against `https://staging.token.place`.
-- [ ] A desktop compute node has `staging.token.place` in `knownServers`/server config, registers
-  to staging, appears in staging `/healthz` and `/relay/diagnostics`, and completes an E2EE
-  request/response through the staging relay.
-- [ ] The prod Cloudflare route for `token.place` is configured to Traefik and checked outside
-  Helm/cert-manager before promotion.
-
-After the prod upgrade, capture separate prod validation evidence before marking the promotion
-complete:
-
-- [ ] Synthetic API v1 compute-node register/poll passes against `https://token.place`.
-- [ ] A desktop compute node has `token.place` in `knownServers`/server config, registers to prod,
-  and does not silently fall back to staging.
-- [ ] That prod-registered compute node appears in prod `/healthz` and `/relay/diagnostics`.
-- [ ] An E2EE request/response succeeds through the prod-registered compute node.
-
-### Release evidence capture
-
-Capture and attach the staging sign-off artifacts plus this separate prod evidence for the prod
-promotion record. For the prod evidence, run the prod synthetic register/poll, confirm prod
-desktop compute-node registration, and complete the prod E2EE request/response before saving
-`/healthz`, `/relay/diagnostics`, or relay logs so those artifacts prove the prod-registered
-desktop compute node is visible after the real prod relay-compute path passes:
+## Roll back production
 
 ```bash
-just kubeconfig-env prod
-TOKENPLACE_TAG=v0.1.0 # replace with the immutable release tag
-TOKENPLACE_HOST=token.place
-TOKENPLACE_CHART_VERSION="$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
-
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$TOKENPLACE_CHART_VERSION"
-helm pull oci://ghcr.io/futuroptimist/charts/tokenplace --version "$TOKENPLACE_CHART_VERSION" --destination /tmp
-sha256sum "/tmp/tokenplace-${TOKENPLACE_CHART_VERSION}.tgz" # chart digest evidence
-printf 'image tag: ghcr.io/futuroptimist/tokenplace-relay:%s\n' "$TOKENPLACE_TAG"
-kubectl -n tokenplace get deploy tokenplace -o yaml > /tmp/tokenplace-prod-deployment.yaml
-# First run synthetic register/poll, desktop compute-node registration, and the E2EE flow.
-# Then capture health, diagnostics, and relay logs as post-compute-path evidence:
-curl -fsS "https://${TOKENPLACE_HOST}/healthz" | tee /tmp/tokenplace-prod-healthz.json
-curl -fsS "https://${TOKENPLACE_HOST}/relay/diagnostics" | tee /tmp/tokenplace-prod-diagnostics.json
-kubectl -n tokenplace logs deploy/tokenplace --since=30m --tail=500 | tee /tmp/tokenplace-prod-relay-after-compute.log
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA # replace with the previous known-good immutable GHCR image tag
+just app-redeploy app=tokenplace env=prod tag="$APP_TAG"
 ```
-
-### Emergency diagnostics
-
-This emergency diagnostics command block is copy-pasteable. Run it when prod web/TLS health is green but compute registration or E2EE is blocked:
-
-```bash
-just kubeconfig-env prod
-TOKENPLACE_HOST=token.place
-
-kubectl -n tokenplace get deployments,replicasets,pods,services,ingress,certificates -o wide
-kubectl -n tokenplace describe deploy/tokenplace
-kubectl -n tokenplace describe ingress/tokenplace
-kubectl -n tokenplace get events --sort-by=.lastTimestamp | tail -n 80
-kubectl -n tokenplace logs deploy/tokenplace --since=30m --tail=500
-kubectl -n tokenplace logs deploy/tokenplace --previous --tail=500 || true
-curl -vI "https://${TOKENPLACE_HOST}/"
-curl -fsS "https://${TOKENPLACE_HOST}/healthz" || true
-curl -fsS "https://${TOKENPLACE_HOST}/relay/diagnostics" || true
-just cf-tunnel-debug
-just cert-manager-status
-```
-
-If Cloudflare returns HTTP 403 before the request reaches token.place, check Cloudflare Security
-Events for the hostname, ray ID, source IP, path, and rule that made the decision.
-
-## Rollback options
-
-Rollback reminders:
-
-- Prefer immutable image tag rollback when the bad rollout is tied to a single image.
-- Use Helm revision rollback when you need to restore the entire rendered release state.
-- Expect a short outage during rollback because token.place is intentionally single-replica and
-  the Deployment strategy is `Recreate`; wait for the replacement pod before retesting relay E2EE.
-
-Rollback by immutable tag:
-
-```bash
-just kubeconfig-env prod
-TOKENPLACE_PREVIOUS_TAG=main-deadbee # replace with the prior immutable tag
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_PREVIOUS_TAG"
-```
-
-Rollback by Helm revision:
-
-```bash
-just kubeconfig-env prod
-TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
-just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
-```
-
-## Cloudflare tunnel routing (external to Helm)
-
-Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes. Route `token.place` to Traefik,
-typically `http://traefik.kube-system.svc.cluster.local:80`. Production overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
-and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
-One tunnel per environment can carry multiple app hostnames by routing them all to Traefik, with
-Traefik selecting the target backend by `Host` header.
-
-`cf-tunnel-route` configures Cloudflare Tunnel hostname routing. It does not configure the
-cert-manager Cloudflare DNS token used for ACME DNS-01.
-
-```bash
-just cf-tunnel-route token.place
-just cf-tunnel-route host=token.place
-```
-
-## cert-manager + Cloudflare DNS-01 (non-Flux clusters)
-
-For non-Flux production clusters, use the same manual Helm + issuer flow validated during staging:
-
-```bash
-just cert-manager-install
-just cert-manager-cloudflare-token-secret token="$CF_DNS_API_TOKEN"
-just cert-manager-issuers-apply email="ops@token.place"
-just cert-manager-status
-```
-
-Do not reuse the tunnel token (`CF_TUNNEL_TOKEN`) for DNS-01. cert-manager needs a separate Cloudflare DNS API token scoped to:
-
-- `Zone -> DNS -> Edit`
-- `Zone -> Zone -> Read`
-- specific required zones (`token.place`, and `democratized.space` if shared issuance is in scope).
-
-For production promotion, the cert-manager release gate is the Certificate condition: proceed only
-when the relevant Certificate is `Ready=True`. Challenge cleanup errors after successful issuance do
-not invalidate an already-ready certificate, but they should be investigated because they often mean
-the DNS API token lacks `Zone -> Zone -> Read`, is scoped to the wrong Cloudflare zone, or cert-manager
-is hitting resolver/zone lookup ambiguity during cleanup.
 
 ## Troubleshooting
 
-GHCR auth/chart checks:
-
 ```bash
-echo "$GHCR_TOKEN" | helm registry login ghcr.io -u "$GHCR_USER" --password-stdin
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' docs/apps/tokenplace.version | head -n1)"
-```
-
-App status/logs:
-
-```bash
-just tokenplace-status
 just tokenplace-debug-logs-env env=prod
 ```
 
-Ingress/tunnel checks:
-
 ```bash
-just cluster-status
-just traefik-status
-just cf-tunnel-debug
+just cf-tunnel-route host=token.place
 ```
-
-
-## 0.1.0 release alignment
-
-- OCI chart package version: `0.1.0`
-- Chart `appVersion`: `0.1.0`
-- token.place Git tag: `v0.1.0`
-- Release image tag after final tag push: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
-- Staging candidate tag before final tag push: `main-<shortsha>`

--- a/docs/k3s-tokenplace-staging.md
+++ b/docs/k3s-tokenplace-staging.md
@@ -1,321 +1,60 @@
 # k3s token.place runbook (staging)
 
-Use this runbook for relay-only token.place staging deployments on Sugarkube.
+This environment-specific page is a quick staging checklist. Use the canonical
+uniform app runbook for the complete GHCR-first flow:
+[`docs/apps/tokenplace.md`](apps/tokenplace.md).
 
-## Topology and scope
+## Responsibilities
 
-- Sugarkube runs only token.place relay (`relay.py`).
-- No in-cluster backend/GPU service is required.
-- Compute nodes remain external (`server.py`, Tauri desktop app, Windows PCs, Apple Silicon Macs,
-  Raspberry Pi compute nodes, etc.).
-- Runtime model is single replica + single Gunicorn worker + in-memory state; verify the rendered Kubernetes Deployment contract includes `spec.strategy.type: Recreate` before rollout.
-- In-memory state loss on pod restart is accepted for now.
+- App repo: publish the relay image and Helm chart to GHCR.
+- Sugarkube: select the staging kubeconfig, deploy the configured chart and tag,
+  then run status/verify/log helpers.
+- Cloudflare: route `staging.token.place` to the staging Traefik endpoint outside
+  Helm.
 
-## Artifact and values contract
+## Deploy staging
 
-- Chart: `oci://ghcr.io/futuroptimist/charts/tokenplace`
-- Image: `ghcr.io/futuroptimist/tokenplace-relay`
-- Release: `tokenplace`
-- Namespace: `tokenplace`
-- Version pin file: `docs/apps/tokenplace.version`
-- Values: `docs/examples/tokenplace.values.dev.yaml` + `docs/examples/tokenplace.values.staging.yaml`
-- Default staging host: `staging.token.place`
-
-
-## Pre-flight (before Step 1)
-
-- Verify `docs/apps/tokenplace.version` remains pinned to `0.1.0`.
-- Verify the `0.1.0` OCI chart exists only after token.place publishes the current chart.
-- If `helm show chart ... --version 0.1.0` succeeds before the final token.place chart publish, confirm the chart is not stale before deploying.
+Preferred generic command:
 
 ```bash
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
+APP_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag from token.place CI
+just app-deploy app=tokenplace env=staging tag="$APP_TAG"
 ```
 
-## First install
+Compatibility wrapper:
 
 ```bash
-just kubeconfig-env staging
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+APP_TAG=main-REPLACE_SHORTSHA # replace with the immutable GHCR image tag from token.place CI
+just tokenplace-oci-deploy env=staging tag="$APP_TAG"
 ```
 
-## Existing release upgrade
+## Verify staging
 
 ```bash
-just kubeconfig-env staging
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+just app-status app=tokenplace env=staging
 ```
 
-Preferred wrapper:
-
 ```bash
-TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just tokenplace-oci-deploy env=staging tag="$TOKENPLACE_TAG"
+just app-verify app=tokenplace env=staging
 ```
 
-## Validation
-
-Render/contract checks (use immutable staging candidate tag):
-
 ```bash
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0
-helm template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.0 --namespace tokenplace -f docs/examples/tokenplace.values.dev.yaml -f docs/examples/tokenplace.values.staging.yaml --set image.tag=main-deadbee > /tmp/tokenplace-staging-render.yaml
-python3 - <<'PY'
-import collections
-import sys
-
-try:
-    import yaml
-except ModuleNotFoundError:
-    sys.exit("PyYAML is required for this render validation. Install it with: python3 -m pip install PyYAML")
-
-with open("/tmp/tokenplace-staging-render.yaml", encoding="utf-8") as rendered:
-    docs = list(yaml.safe_load_all(rendered))
-
-try:
-    deploy = next(
-        d
-        for d in docs
-        if d and d.get("kind") == "Deployment" and d.get("metadata", {}).get("name") == "tokenplace"
-    )
-except StopIteration:
-    sys.exit("tokenplace Deployment not found in rendered manifest")
-
-pod_spec = deploy["spec"]["template"]["spec"]
-for container_type, containers in (
-    ("init", pod_spec.get("initContainers", [])),
-    ("app", pod_spec.get("containers", [])),
-):
-    for container in containers:
-        names = [item["name"] for item in container.get("env", []) if "name" in item]
-        dupes = [name for name, count in collections.Counter(names).items() if count > 1]
-        if dupes:
-            sys.exit(f"duplicate env names found: {container_type}:{container.get('name', '<unnamed>')}: {dupes}")
-PY
-grep -n "spec:" -A40 /tmp/tokenplace-staging-render.yaml | grep -n "tls"
-grep -n "staging.token.place" /tmp/tokenplace-staging-render.yaml
-grep -n "tokenplace-staging-tls" /tmp/tokenplace-staging-render.yaml
-yq eval '. | select(.kind == "Deployment" and .metadata.name == "tokenplace") | .spec.strategy.type' /tmp/tokenplace-staging-render.yaml
+curl -fsS https://staging.token.place/relay/diagnostics | jq .
 ```
 
-Cluster/runtime checks:
+## Roll back staging
 
 ```bash
-kubectl -n tokenplace get deploy,po,svc,ingress
-kubectl -n tokenplace rollout status deploy/tokenplace --timeout=180s
-kubectl -n tokenplace get ingress tokenplace -o yaml
-curl -vI https://staging.token.place/
-curl -fsS https://staging.token.place/livez
-curl -fsS https://staging.token.place/healthz
-curl -fsS https://staging.token.place/relay/diagnostics
+APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA # replace with the previous known-good immutable GHCR image tag
+just app-redeploy app=tokenplace env=staging tag="$APP_TAG"
 ```
 
-### Staging sign-off sequence
-
-Run the checks in this order so each layer has a clear owner before moving on to real
-external compute-node traffic:
-
-1. **Web/TLS:** confirm Cloudflare, Traefik, Ingress, and cert-manager serve the staging host.
-2. **Liveness/readiness:** call `/livez`, `/healthz`, and `/relay/diagnostics` once or at low
-   frequency. Do **not** use a long-running public `/healthz` watch as the primary readiness
-   monitor until token.place confirms health, liveness, metrics, diagnostics, and API v1
-   compute-node heartbeat routes are exempt from global public API rate limits. In staging, a
-   public `/healthz` watch plus kube-probes showed that rate-limited health checks can distort
-   readiness and create false rollout failures.
-3. **Synthetic API v1 register:** register a throwaway compute-node key against
-   `/api/v1/relay/servers/register`.
-4. **Synthetic API v1 poll:** poll `/api/v1/relay/servers/poll` with a client timeout that
-   exceeds the relay's server-side long-poll hold plus a small buffer, verifying the path returns
-   either queued encrypted work or a healthy no-work response instead of a client-side timeout.
-5. **Desktop compute-node registration:** start the packaged desktop/compute node against
-   `https://staging.token.place` and confirm the relay logs show matching API v1 register/poll
-   POSTs for that node.
-6. **E2EE request/response:** submit a real encrypted request through the staging client and verify
-   an encrypted response round trip. Synthetic register/poll is necessary, but real production
-   signoff requires an external compute-node registration and an E2EE request/response.
-
-Use Kubernetes state and relay logs for readiness instead of hammering public health endpoints:
+## Troubleshooting
 
 ```bash
-kubectl -n tokenplace get endpoints
-kubectl -n tokenplace get deploy,po
-kubectl -n tokenplace logs deploy/tokenplace --since=15m --tail=200
-curl -fsS https://staging.token.place/relay/diagnostics
+just tokenplace-debug-logs-env env=staging
 ```
 
-Keep the public diagnostics curl low-frequency (for example, one manual call during validation or
-one scheduled check every few minutes) so the check itself does not trip public API rate-limit traps.
-
-### Synthetic API v1 compute-node register/poll
-
-This synthetic test proves the relay can accept an API v1 compute-node heartbeat without requiring
-a desktop package or GPU host. It does not prove desktop packaging, request routing, or E2EE.
-
 ```bash
-BASE_URL=https://staging.token.place
-KEY_DIR="$(mktemp -d)"
-trap 'rm -rf "${KEY_DIR}"' EXIT
-
-# Generate real public-key material for the synthetic compute node instead of a debug string.
-# If the desktop client emits a different accepted format, set SYNTHETIC_SERVER_PUBLIC_KEY
-# to a non-secret public key copied from a disposable desktop test node.
-openssl genpkey -algorithm Ed25519 -out "${KEY_DIR}/server.key" >/dev/null 2>&1
-openssl pkey -in "${KEY_DIR}/server.key" -pubout -out "${KEY_DIR}/server.pub" >/dev/null 2>&1
-SERVER_PUBLIC_KEY="${SYNTHETIC_SERVER_PUBLIC_KEY:-$(cat "${KEY_DIR}/server.pub")}"
-DEBUG_KEY="${SERVER_PUBLIC_KEY}"
-REGISTER_BODY="$(jq -n --arg server_public_key "${SERVER_PUBLIC_KEY}" \
-  '{server_public_key: $server_public_key}')"
-
-# If the relay requires compute-node registration auth, populate RELAY_SERVER_CREDENTIAL
-# from your secret manager before running this block. Do not paste real secrets
-# into shell history, docs, screenshots, or PRs.
-
-RELAY_AUTH_HEADER_NAME="X-Relay-Server-Token"
-AUTH_HEADER=()
-if [ -n "${RELAY_SERVER_CREDENTIAL:-}" ]; then
-  AUTH_HEADER=(-H "${RELAY_AUTH_HEADER_NAME}: ${RELAY_SERVER_CREDENTIAL}")
-fi
-
-curl -fsS -X POST "${BASE_URL}/api/v1/relay/servers/register" \
-  -H 'Content-Type: application/json' \
-  "${AUTH_HEADER[@]}" \
-  --data "${REGISTER_BODY}" | jq .
-
-curl -fsS "${BASE_URL}/relay/diagnostics" | jq -e --arg key "${DEBUG_KEY}" \
-  '(.registered_compute_nodes // []) | any(.server_public_key == $key)'
-
-# Keep this higher than the relay's server-side long-poll hold. The default 65s value
-# leaves buffer for relays that hold empty polls for up to one minute before returning
-# the healthy no-work response; raise it if staging is configured with a longer hold.
-POLL_MAX_TIME="${POLL_MAX_TIME:-65}"
-curl -fsS --max-time "${POLL_MAX_TIME}" -X POST "${BASE_URL}/api/v1/relay/servers/poll" \
-  -H 'Content-Type: application/json' \
-  "${AUTH_HEADER[@]}" \
-  --data "${REGISTER_BODY}" | jq .
-```
-
-Expected result: register returns wait hints, `/relay/diagnostics` visibly includes the just-created
-`server_public_key` while the lease is fresh, and poll returns either encrypted work or a
-`No requests available` response before `POLL_MAX_TIME` elapses. Treat a missing debug key as a
-failed synthetic registration even if register returned 2xx. The synthetic server is ephemeral and
-will age out automatically after the relay lease if it is not refreshed.
-
-### Desktop HTTP 403 / pre-app rejection triage
-
-If the desktop compute-node reports HTTP 403 but synthetic curl succeeds, determine whether the
-request reached Flask/Gunicorn or was rejected before the app:
-
-1. Capture the desktop failure timestamp, request path, response status, and Cloudflare `cf-ray`
-   header from the desktop diagnostics or HTTP trace.
-2. Check relay logs for matching API v1 POSTs around that timestamp:
-
-   ```bash
-   kubectl -n tokenplace logs deploy/tokenplace --since=30m --tail=500 | \
-     grep -E 'api/v1/relay/servers/(register|poll)|server\.(registered|reregister|heartbeat)'
-   ```
-
-3. If there is no corresponding relay log entry, treat it as a Cloudflare/pre-app rejection and
-   search **Cloudflare Security Events** for the `cf-ray` value, client IP, host, path, and user
-   agent.
-4. Compare synthetic curl and desktop request headers: method, host, path, `Content-Type`,
-   `User-Agent`, `Origin`, any desktop-specific headers, and whether `X-Relay-Server-Token` is
-   present when required.
-5. Confirm credentials are not mixed up: `CF_TUNNEL_TOKEN` connects the Cloudflare Tunnel connector
-   to the dashboard tunnel, while the Cloudflare DNS API token is only for cert-manager DNS-01.
-   Neither token should be sent as the API v1 relay server registration token.
-
-A 403 with no relay log line means the application probably never saw the POST. A 403 with a relay
-log line means inspect token.place auth/rate-limit handling and the exact response body.
-
-## Rollback
-
-Rollback reminders:
-
-- Prefer immutable image tag rollback when the bad rollout is tied to a single image.
-- Use Helm revision rollback when you need to restore the entire rendered release state.
-- Expect a short outage during rollback because token.place is intentionally single-replica and
-  the Deployment strategy is `Recreate`; wait for the replacement pod before retesting relay E2EE.
-
-Rollback by immutable tag:
-
-```bash
-just kubeconfig-env staging
-TOKENPLACE_PREVIOUS_TAG=main-deadbee # replace with the prior immutable tag
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_PREVIOUS_TAG"
-```
-
-Rollback by Helm revision:
-
-```bash
-just kubeconfig-env staging
-TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
-just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
-```
-
-## Cloudflare tunnel routing (external to Helm)
-
-Cloudflare Tunnel still owns public hostname routing to Traefik; Helm does not manage Cloudflare routes. Route `staging.token.place` to Traefik,
-typically `http://traefik.kube-system.svc.cluster.local:80`. Staging overlays render Ingress `spec.tls` because `ingress.tls.enabled: true`; `secretName` alone is not sufficient,
-and this runbook assumes `cert-manager` and the referenced `ClusterIssuer` already exist.
-One staging tunnel can serve multiple hostnames (for example `staging.democratized.space` and
-`staging.token.place`) by routing both to Traefik; Traefik dispatches by `Host` header to the
-correct Ingress.
-
-`cf-tunnel-route` is for Cloudflare Tunnel hostname routing only. It is separate from the
-Cloudflare DNS API token used by cert-manager DNS-01 challenges.
-
-```bash
-just cf-tunnel-route staging.token.place
 just cf-tunnel-route host=staging.token.place
 ```
-
-## cert-manager + Cloudflare DNS-01 (non-Flux clusters)
-
-If your cluster does **not** run Flux, do not apply `platform/cert-manager` with Kustomize as-is. In staging we hit this exact failure mode:
-
-- `kubectl apply -k platform/cert-manager` created the ConfigMap/issuers, then failed because `HelmRelease` was an unknown kind (Flux CRDs absent).
-- The rendered issuer email remained literal `$(CERT_MANAGER_EMAIL)`, causing ACME `invalidContact`.
-
-Use these recipes instead:
-
-```bash
-just cert-manager-install
-just cert-manager-cloudflare-token-secret token="$CF_DNS_API_TOKEN"
-just cert-manager-issuers-apply email="ops@token.place"
-just cert-manager-status
-```
-
-Cloudflare DNS API token scope for cert-manager:
-
-- `Zone -> DNS -> Edit`
-- `Zone -> Zone -> Read`
-- Include only required zones (at minimum `token.place`; include `democratized.space` too if the same token handles shared DSPACE cert issuance).
-
-If cert-manager logs show challenge cleanup errors after a certificate is already issued, use the
-Certificate condition as the release gate: `Ready=True` means TLS issuance succeeded for rollout
-purposes. Cleanup errors are still worth fixing because they usually point to a Cloudflare DNS API
-token without `Zone -> Zone -> Read`, a token scoped to the wrong zone, or resolver/zone lookup
-weirdness that prevents cert-manager from finding the correct Cloudflare zone during cleanup.
-
-Validation commands:
-
-```bash
-kubectl get crd | grep cert-manager.io
-kubectl get clusterissuer letsencrypt-staging letsencrypt-production
-kubectl get certificate --all-namespaces
-kubectl -n cert-manager get secret cloudflare-api-token
-kubectl -n cert-manager logs deploy/cert-manager --tail=100
-```
-
-> ⚠️ During early staging we used manual Helm `--set env.XDG_CACHE_HOME=/tmp --set env.XDG_CONFIG_HOME=/tmp --set env.XDG_DATA_HOME=/tmp` overrides to pass read-only filesystem startup checks. Remove those manual overrides now that chart defaults own the XDG `/tmp` paths.
-
-
-## 0.1.0 release alignment
-
-- OCI chart package version: `0.1.0`
-- Chart `appVersion`: `0.1.0`
-- token.place Git tag: `v0.1.0`
-- Release image tag after final tag push: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
-- Staging candidate tag before final tag push: `main-<shortsha>`

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -460,7 +460,7 @@ Traefik is available per the section above.
    ```
 
 5. Iterate new builds using your app's upgrade instructions (e.g., the dspace
-   guide covers rolling new `main-<shortsha>` images).
+   guide covers rolling new `main-REPLACE_SHORTSHA` images).
 
 ## Step 1: Verify your 3-node control plane is healthy
 
@@ -769,7 +769,7 @@ For production preview (optional canary), this guide intentionally switches from
 post-deploy checks are included by default:
 
 ```bash
-just dspace-oci-deploy-prod-subdomain tag=main-<shortsha>
+just dspace-oci-deploy-prod-subdomain tag=main-REPLACE_SHORTSHA
 ```
 
 For production apex promotion, use `dspace-oci-promote-prod` with a pinned tag (for example the
@@ -808,7 +808,7 @@ For immutable RC/stable validation (recommended for staging and prod), use the d
 helper instead:
 
 ```bash
-just dspace-oci-deploy env=staging tag=main-<shortsha>
+just dspace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
 
 read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
 just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
@@ -822,7 +822,7 @@ just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
 
 When you pass an image tag (including the default `main-latest`), the helper sets
 `image.pullPolicy=Always` so the nodes re-check GHCR for the latest build of that tag on
-each redeploy. For production, prefer immutable tags (for example, `main-<shortsha>`) if you want
+each redeploy. For production, prefer immutable tags (for example, `main-REPLACE_SHORTSHA`) if you want
 to pin a specific image.
 
 **Emergency redeploy checklist:**

--- a/docs/tokenplace_sugarkube_onboarding.md
+++ b/docs/tokenplace_sugarkube_onboarding.md
@@ -57,7 +57,7 @@ image tag, deployment YAML, health/diagnostics responses, and relay logs from af
 - Chart `appVersion`: `0.1.0`
 - token.place Git tag: `v0.1.0`
 - Release image tag: `ghcr.io/futuroptimist/tokenplace-relay:v0.1.0`
-- Staging candidate image tag: `main-<shortsha>`
+- Staging candidate image tag: `main-REPLACE_SHORTSHA`
 
 ## Cloudflare model
 


### PR DESCRIPTION
### Motivation

- Make app runbooks uniform and copy-pasteable using the new generic `just app-*` flow so operators can deploy from GHCR/OCI without ad-hoc local builds. 
- Preserve existing app-specific `*-oci-*` wrappers as compatibility shims while migrating runbooks to prefer the generic surface. 
- Provide a concrete onboarding checklist and decision tree so future apps (for example wove and jobbot3000) can be onboarded consistently.

### Description

- Rewrote the three app runbooks to a standard section order (Artifact model, Environment topology, Find/publish GHCR image, Confirm/publish OCI chart, Deploy staging, Verify staging, Promote production, Verify production, Rollback, Troubleshooting, App-specific notes): `docs/apps/dspace.md`, `docs/apps/tokenplace.md`, `docs/apps/danielsmith.md`.
- Added a future-app onboarding guide with a minimal app config template, image/chart workflow and chart checklist, release decision tree, and questions to answer before onboarding: `docs/app_onboarding.md`.
- Replaced or trimmed environment-specific quick runbooks to point at the canonical app pages and to show the preferred generic command plus the existing compatibility wrapper: `docs/k3s-tokenplace-staging.md`, `docs/k3s-tokenplace-prod.md`, `docs/k3s-danielsmith-staging.md`, `docs/k3s-danielsmith-prod.md`.
- Updated documentation index/README links so the app deployment path and onboarding guide are discoverable (`README.md`, `docs/index.md`).
- Minor doc hygiene: replaced legacy `main-<shortsha>` placeholders with `main-REPLACE_SHORTSHA` where appropriate and added legitimate new words to the spellchecker wordlist (`.wordlist.txt`).

Files touched (high level): `docs/apps/*.md`, `docs/k3s-*.md`, `docs/index.md`, `README.md`, `docs/app_onboarding.md`, `.wordlist.txt`.

### Testing

- Ran `git diff --check` (no trailing-whitespace / check errors remain in staged docs changes): passed.
- Ran the full test suite with `python -m pytest tests -q`; result: all tests passed (`1253 passed, 19 skipped, 9 warnings`) after a small doc tweak to satisfy a guardrail test. 
- Verified the new generic commands and placeholders exist in docs using `grep`, e.g. `grep -R "just app-deploy app=dspace" docs`, `grep -R "just app-deploy app=tokenplace" docs`, `grep -R "just app-deploy app=danielsmith" docs`, and `grep -R "main-REPLACE_SHORTSHA" docs`; all returned expected hits.
- Ran docs validation: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` (both passed after adding words to `.wordlist.txt`).
- Ran lightweight docs check script `scripts/checks.sh --docs-only` (passed spelling/link checks); note: a full `pre-commit run --all-files` was attempted but flagged unrelated repository-wide lint issues outside the docs scope and modified unrelated files; those changes were reverted and `pre-commit` was not used to gate this docs PR.
- Secret-scan: `git diff --cached | ./scripts/scan-secrets.py` run on staged changes and yielded no accepted secret findings after removing an inline login example wording; no secrets were committed.

Residual notes / follow-ups

- App-specific `*-oci-*` just recipes remain in the repo as compatibility shims and are intentionally preserved for now; a follow-up can prune them after the generic flow has been exercised in live releases.
- `pre-commit run --all-files` surfaced unrelated lint/YAML issues in other parts of the repo; those are out of scope for this PR and were not introduced by these docs edits.

Commands used during verification (examples): `python -m pytest tests -q`, `pyspelling -c .spellcheck.yaml`, `linkchecker --no-warnings README.md docs/`, `scripts/checks.sh --docs-only`, `git diff --check`, and `./scripts/scan-secrets.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e82b73860832f8945ec47c8fa4361)