### PR TITLE
docs: make app runbooks link-rich and add offline artifact-link tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,23 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
   tag, chart, app-config, and `just app-*` command contract for all Sugarkube apps.
 - **[Future-app onboarding guide](docs/app_onboarding.md)** — checklist and decision tree for
   adding apps such as wove, jobbot3000, and later services.
-- **Current app runbooks:** [DSPACE](docs/apps/dspace.md),
-  [token.place](docs/apps/tokenplace.md), and
-  [danielsmith.io](docs/apps/danielsmith.md) use the same GHCR-first staging,
-  verification, promotion, rollback, and troubleshooting flow.
+- **Current app runbooks:** each app uses the same GHCR-first staging,
+  verification, promotion, rollback, and troubleshooting flow, with direct artifact shortcuts:
+  - [DSPACE runbook](docs/apps/dspace.md):
+    [image workflow](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml),
+    [image package](https://github.com/democratizedspace/dspace/pkgs/container/dspace),
+    [chart workflow](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml),
+    [chart package listing](https://github.com/orgs/democratizedspace/packages?ecosystem=container&repo_name=dspace).
+  - [token.place runbook](docs/apps/tokenplace.md):
+    [image workflow](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml),
+    [image package](https://github.com/futuroptimist/token.place/pkgs/container/tokenplace-relay),
+    [chart workflow](https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml),
+    [chart package](https://github.com/futuroptimist/token.place/pkgs/container/charts%2Ftokenplace).
+  - [danielsmith.io runbook](docs/apps/danielsmith.md):
+    [image workflow](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml),
+    [image package](https://github.com/futuroptimist/danielsmith.io/pkgs/container/danielsmith.io),
+    [chart workflow](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-helm.yml),
+    [chart package](https://github.com/futuroptimist/danielsmith.io/pkgs/container/charts%2Fdanielsmith).
 - **Environment shortcuts:** token.place
   [dev](docs/k3s-tokenplace-dev.md), [staging](docs/k3s-tokenplace-staging.md), and
   [production](docs/k3s-tokenplace-prod.md); danielsmith.io

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -55,6 +55,23 @@ The current apps map to that model as examples:
 | token.place | `ghcr.io/futuroptimist/tokenplace-relay` | `oci://ghcr.io/futuroptimist/charts/tokenplace` | `tokenplace` | `tokenplace` | `docs/apps/tokenplace.version` | `docs/apps/tokenplace.prod.tag` |
 | danielsmith.io | `ghcr.io/futuroptimist/danielsmith.io` | `oci://ghcr.io/futuroptimist/charts/danielsmith` | `danielsmith` | `danielsmith` | `docs/apps/danielsmith.version` | `docs/apps/danielsmith.prod.tag` |
 
+### Required runbook artifact discovery links
+
+Every Sugarkube app runbook must include a compact artifact discovery section so
+operators can move from Sugarkube docs directly to the publishing system without
+searching GitHub Actions or GHCR manually. Link to all of the following before
+an app is considered fully documented:
+
+- the app repository;
+- the image workflow recent runs page, plus a successful default-branch filter
+  when useful;
+- the GHCR image package versions page;
+- the chart publish workflow recent runs page;
+- the GHCR chart package versions page;
+- the Dockerfile or source image build path;
+- the chart source path; and
+- the app-repo Sugarkube release guide when one exists.
+
 ## Standard image tag model
 
 Deployment tags must identify application code and release intent, not mutable

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -16,8 +16,12 @@ Use this checklist when onboarding the next GHCR-first app to Sugarkube. The goa
 4. Add `ci-helm.yml` with immutable OCI chart publishing.
 5. Add or copy a Sugarkube app config.
 6. Add environment values overlays for `dev`, `staging`, and `prod`.
-7. Run the generic Sugarkube deploy.
-8. Add app-specific smoke checks when generic HTTP checks are not enough.
+7. Add a Sugarkube app runbook with artifact discovery links for the app repo,
+   image workflow, GHCR image package, chart workflow, GHCR chart package,
+   Dockerfile/source image path, chart source path, and app-repo release guide
+   when present.
+8. Run the generic Sugarkube deploy.
+9. Add app-specific smoke checks when generic HTTP checks are not enough.
 
 ## Minimal app config template
 
@@ -98,6 +102,11 @@ Do not invent real configs for `wove` or `jobbot3000` until their app repos have
 
 | Question | Why Sugarkube needs it |
 | --- | --- |
+| App repo URL | Anchors the Sugarkube runbook and app-owned release guide links. |
+| Image workflow URL | Lets operators find recent image builds and successful immutable tags. |
+| GHCR image package URL | Lets operators cross-check published image package tags. |
+| Chart workflow URL | Lets operators find recent chart publish attempts and failures. |
+| GHCR chart package URL | Lets operators confirm available immutable chart versions. |
 | App image name | Sets `image.repository` and lets operators find GHCR image tags. |
 | Container port | Drives Service and probe wiring in the chart. |
 | Health endpoints | Sets `SUGARKUBE_VERIFY_PATHS` and Kubernetes probes. |

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -8,6 +8,19 @@ This is the canonical runbook for deploying danielsmith.io from GHCR artifacts t
 - Sugarkube responsibilities: select `dev`, `staging`, or `prod`; load `docs/examples/apps/danielsmith.env` or a local override; select kubeconfig/context; install or upgrade Helm; verify rollout status, logs, and public paths.
 - Cloudflare responsibilities: DNS and Tunnel routes to Traefik are outside Helm and must exist before public verification.
 
+### Artifact links
+
+| Artifact | Link |
+| --- | --- |
+| App repo | [danielsmith.io source repository](https://github.com/futuroptimist/danielsmith.io) |
+| Image workflow | [danielsmith.io image workflow recent runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml) and [successful `main` image runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess) |
+| GHCR image package | [danielsmith.io image package versions](https://github.com/futuroptimist/danielsmith.io/pkgs/container/danielsmith.io) |
+| Chart workflow | [danielsmith.io chart publish workflow runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-helm.yml) |
+| GHCR chart package | [danielsmith.io chart package versions](https://github.com/futuroptimist/danielsmith.io/pkgs/container/charts%2Fdanielsmith) |
+| Dockerfile | [danielsmith.io Dockerfile](https://github.com/futuroptimist/danielsmith.io/blob/main/Dockerfile) |
+| Chart source | [danielsmith.io Helm chart source](https://github.com/futuroptimist/danielsmith.io/tree/main/charts/danielsmith) |
+| App release guide | [danielsmith.io Sugarkube release guide](https://github.com/futuroptimist/danielsmith.io/blob/main/docs/ops/sugarkube-release.md) |
+
 | Coordinate | Value |
 | --- | --- |
 | Image | `ghcr.io/futuroptimist/danielsmith.io` |
@@ -29,6 +42,12 @@ This is the canonical runbook for deploying danielsmith.io from GHCR artifacts t
 ## Find or publish GHCR image
 
 Find the successful image workflow in the danielsmith.io app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, a bare branch name, or an environment name.
+
+Web UI shortcuts before using `gh`:
+
+- Open the [danielsmith.io image workflow recent runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml); GitHub Actions is where recent image builds and workflow summaries are found.
+- Open the [danielsmith.io GHCR image package versions](https://github.com/futuroptimist/danielsmith.io/pkgs/container/danielsmith.io); GHCR is where published package tags are cross-checked.
+- Copy the immutable tag from a successful workflow summary or package version.
 
 ```bash
 APP_TAG=main-REPLACE_SHORTSHA
@@ -55,6 +74,12 @@ CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.v
 ```bash
 helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$CHART_VERSION"
 ```
+
+Chart discovery shortcuts:
+
+- Open the [danielsmith.io chart publish workflow runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-helm.yml); GitHub Actions is where recent chart publish attempts and failures are found.
+- Open the [danielsmith.io GHCR chart package versions](https://github.com/futuroptimist/danielsmith.io/pkgs/container/charts%2Fdanielsmith); chart package pages confirm available immutable chart versions for `oci://ghcr.io/futuroptimist/charts/danielsmith`.
+- Review the [danielsmith.io Helm chart source](https://github.com/futuroptimist/danielsmith.io/tree/main/charts/danielsmith) before publishing a chart change.
 
 If the chart changed, bump the chart version in the danielsmith.io app repo and publish it there with `ci-helm.yml`; do not republish a different chart under an existing OCI version.
 

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -8,6 +8,21 @@ This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugark
 - Sugarkube responsibilities: select `dev`, `staging`, or `prod`; load `docs/examples/apps/dspace.env` or a local override; select kubeconfig/context; install or upgrade Helm; verify rollout status, logs, and public paths.
 - Cloudflare responsibilities: DNS and Tunnel routes to Traefik are outside Helm and must exist before public verification.
 
+### Artifact links
+
+| Artifact | Link |
+| --- | --- |
+| App repo | [DSPACE source repository](https://github.com/democratizedspace/dspace) |
+| Image workflow | [DSPACE image workflow recent runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml) and [successful `main` image runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess) and [successful `v3` image runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml?query=branch%3Av3+is%3Asuccess) remain useful while DSPACE release work still references the `v3` branch |
+| GHCR image package | [DSPACE image package versions](https://github.com/democratizedspace/dspace/pkgs/container/dspace) |
+| Chart workflow | [DSPACE chart publish workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml) |
+| GHCR chart package | [DSPACE chart package versions](https://github.com/orgs/democratizedspace/packages?ecosystem=container&repo_name=dspace) |
+| Dockerfile | [DSPACE Dockerfile](https://github.com/democratizedspace/dspace/blob/main/Dockerfile) |
+| Chart source | [DSPACE Helm chart source](https://github.com/democratizedspace/dspace/tree/main/charts/dspace) |
+| App release guide | [DSPACE Sugarkube release guide](https://github.com/democratizedspace/dspace/blob/main/docs/ops/sugarkube-release.md) |
+
+The DSPACE chart workflow publishes `oci://ghcr.io/democratizedspace/charts/dspace`; GitHub currently exposes the openable package discovery page as the democratizedspace container package listing filtered to the DSPACE repo.
+
 | Coordinate | Value |
 | --- | --- |
 | Image | `ghcr.io/democratizedspace/dspace` |
@@ -29,6 +44,12 @@ This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugark
 ## Find or publish GHCR image
 
 Find the successful image workflow in the DSPACE app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, a bare branch name, or an environment name.
+
+Web UI shortcuts before using `gh`:
+
+- Open the [DSPACE image workflow recent runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml); GitHub Actions is where recent image builds and workflow summaries are found.
+- Open the [DSPACE GHCR image package versions](https://github.com/democratizedspace/dspace/pkgs/container/dspace); GHCR is where published package tags are cross-checked.
+- Copy the immutable tag from a successful workflow summary or package version.
 
 ```bash
 APP_TAG=main-REPLACE_SHORTSHA
@@ -55,6 +76,12 @@ CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.versio
 ```bash
 helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version "$CHART_VERSION"
 ```
+
+Chart discovery shortcuts:
+
+- Open the [DSPACE chart publish workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml); GitHub Actions is where recent chart publish attempts and failures are found.
+- Open the [DSPACE GHCR chart package listing](https://github.com/orgs/democratizedspace/packages?ecosystem=container&repo_name=dspace); chart package pages confirm available immutable chart versions for `oci://ghcr.io/democratizedspace/charts/dspace` when GitHub exposes the chart package publicly.
+- Review the [DSPACE Helm chart source](https://github.com/democratizedspace/dspace/tree/main/charts/dspace) before publishing a chart change.
 
 If the chart changed, bump the chart version in the DSPACE app repo and publish it there with `ci-helm.yml`; do not republish a different chart under an existing OCI version.
 

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -8,6 +8,19 @@ This is the canonical runbook for deploying token.place from GHCR artifacts to S
 - Sugarkube responsibilities: select `dev`, `staging`, or `prod`; load `docs/examples/apps/tokenplace.env` or a local override; select kubeconfig/context; install or upgrade Helm; verify rollout status, logs, and public paths.
 - Cloudflare responsibilities: DNS and Tunnel routes to Traefik are outside Helm and must exist before public verification.
 
+### Artifact links
+
+| Artifact | Link |
+| --- | --- |
+| App repo | [token.place source repository](https://github.com/futuroptimist/token.place) |
+| Image workflow | [token.place image workflow recent runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml) and [successful `main` image runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess) |
+| GHCR image package | [token.place image package versions](https://github.com/futuroptimist/token.place/pkgs/container/tokenplace-relay) |
+| Chart workflow | [token.place chart publish workflow runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml) |
+| GHCR chart package | [token.place chart package versions](https://github.com/futuroptimist/token.place/pkgs/container/charts%2Ftokenplace) |
+| Dockerfile | [token.place Dockerfile](https://github.com/futuroptimist/token.place/blob/main/Dockerfile) |
+| Chart source | [token.place Helm chart source](https://github.com/futuroptimist/token.place/tree/main/charts/tokenplace) |
+| App release guide | [token.place Sugarkube release guide](https://github.com/futuroptimist/token.place/blob/main/docs/ops/sugarkube-release.md) |
+
 | Coordinate | Value |
 | --- | --- |
 | Image | `ghcr.io/futuroptimist/tokenplace-relay` |
@@ -29,6 +42,12 @@ This is the canonical runbook for deploying token.place from GHCR artifacts to S
 ## Find or publish GHCR image
 
 Find the successful image workflow in the token.place app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, a bare branch name, or an environment name.
+
+Web UI shortcuts before using `gh`:
+
+- Open the [token.place image workflow recent runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml); GitHub Actions is where recent image builds and workflow summaries are found.
+- Open the [token.place GHCR image package versions](https://github.com/futuroptimist/token.place/pkgs/container/tokenplace-relay); GHCR is where published package tags are cross-checked.
+- Copy the immutable tag from a successful workflow summary or package version.
 
 ```bash
 APP_TAG=main-REPLACE_SHORTSHA
@@ -55,6 +74,12 @@ CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.ve
 ```bash
 helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$CHART_VERSION"
 ```
+
+Chart discovery shortcuts:
+
+- Open the [token.place chart publish workflow runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml); GitHub Actions is where recent chart publish attempts and failures are found.
+- Open the [token.place GHCR chart package versions](https://github.com/futuroptimist/token.place/pkgs/container/charts%2Ftokenplace); chart package pages confirm available immutable chart versions for `oci://ghcr.io/futuroptimist/charts/tokenplace`.
+- Review the [token.place Helm chart source](https://github.com/futuroptimist/token.place/tree/main/charts/tokenplace) before publishing a chart change.
 
 If the chart changed, bump the chart version in the token.place app repo and publish it there with `ci-helm.yml`; do not republish a different chart under an existing OCI version.
 

--- a/tests/test_app_runbook_links.py
+++ b/tests/test_app_runbook_links.py
@@ -1,0 +1,102 @@
+"""Offline regression checks for app runbook artifact discovery links."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+APP_LINKS = {
+    "dspace": {
+        "runbook": REPO_ROOT / "docs" / "apps" / "dspace.md",
+        "readme_label": "DSPACE runbook",
+        "urls": [
+            "https://github.com/democratizedspace/dspace",
+            "https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml",
+            "https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess",
+            "https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml?query=branch%3Av3+is%3Asuccess",
+            "https://github.com/democratizedspace/dspace/pkgs/container/dspace",
+            "https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml",
+            "https://github.com/orgs/democratizedspace/packages?ecosystem=container&repo_name=dspace",
+            "https://github.com/democratizedspace/dspace/blob/main/Dockerfile",
+            "https://github.com/democratizedspace/dspace/tree/main/charts/dspace",
+            "https://github.com/democratizedspace/dspace/blob/main/docs/ops/sugarkube-release.md",
+        ],
+    },
+    "tokenplace": {
+        "runbook": REPO_ROOT / "docs" / "apps" / "tokenplace.md",
+        "readme_label": "token.place runbook",
+        "urls": [
+            "https://github.com/futuroptimist/token.place",
+            "https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml",
+            "https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess",
+            "https://github.com/futuroptimist/token.place/pkgs/container/tokenplace-relay",
+            "https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml",
+            "https://github.com/futuroptimist/token.place/pkgs/container/charts%2Ftokenplace",
+            "https://github.com/futuroptimist/token.place/blob/main/Dockerfile",
+            "https://github.com/futuroptimist/token.place/tree/main/charts/tokenplace",
+            "https://github.com/futuroptimist/token.place/blob/main/docs/ops/sugarkube-release.md",
+        ],
+    },
+    "danielsmith": {
+        "runbook": REPO_ROOT / "docs" / "apps" / "danielsmith.md",
+        "readme_label": "danielsmith.io runbook",
+        "urls": [
+            "https://github.com/futuroptimist/danielsmith.io",
+            "https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml",
+            "https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess",
+            "https://github.com/futuroptimist/danielsmith.io/pkgs/container/danielsmith.io",
+            "https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-helm.yml",
+            "https://github.com/futuroptimist/danielsmith.io/pkgs/container/charts%2Fdanielsmith",
+            "https://github.com/futuroptimist/danielsmith.io/blob/main/Dockerfile",
+            "https://github.com/futuroptimist/danielsmith.io/tree/main/charts/danielsmith",
+            "https://github.com/futuroptimist/danielsmith.io/blob/main/docs/ops/sugarkube-release.md",
+        ],
+    },
+}
+
+README_REQUIRED_URLS = {
+    app: [
+        url
+        for url in metadata["urls"]
+        if ("/actions/workflows/" in url and "?query=" not in url) or "/pkgs/container/" in url or "packages?" in url
+    ]
+    for app, metadata in APP_LINKS.items()
+}
+
+REQUIRED_CHECKLIST_TERMS = [
+    "app repository",
+    "image workflow",
+    "GHCR image package",
+    "chart publish workflow",
+    "GHCR chart package",
+    "Dockerfile or source image build path",
+    "chart source path",
+    "app-repo Sugarkube release guide",
+]
+
+
+def test_app_runbooks_include_artifact_discovery_links() -> None:
+    for app, metadata in APP_LINKS.items():
+        text = metadata["runbook"].read_text(encoding="utf-8")
+        assert "### Artifact links" in text, f"{app} runbook should expose artifact links"
+        for url in metadata["urls"]:
+            assert url in text, f"{app} runbook is missing {url}"
+
+
+def test_readme_application_runbooks_include_artifact_shortcuts() -> None:
+    text = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    for app, metadata in APP_LINKS.items():
+        assert metadata["readme_label"] in text, f"README should link the {app} runbook"
+        for url in README_REQUIRED_URLS[app]:
+            assert url in text, f"README is missing {app} artifact shortcut {url}"
+
+
+def test_shared_docs_require_future_artifact_discovery_links() -> None:
+    contract = (REPO_ROOT / "docs" / "app_deployment_contract.md").read_text(encoding="utf-8")
+    onboarding = (REPO_ROOT / "docs" / "app_onboarding.md").read_text(encoding="utf-8")
+    combined = f"{contract}\n{onboarding}"
+    for term in REQUIRED_CHECKLIST_TERMS:
+        assert term in combined, f"shared docs should require {term} links"
+    assert "Image workflow URL" in onboarding
+    assert "GHCR chart package URL" in onboarding


### PR DESCRIPTION
### Motivation

- Operators should be able to jump directly from Sugarkube docs to exact app repos, Actions workflows, GHCR package pages, Dockerfiles, chart sources and release guides without manual searching. 
- The shared app contract and onboarding guidance must require these artifact-discovery links for future apps. 

### Description

- Added a compact "Artifact links" section to each current runbook: `docs/apps/dspace.md`, `docs/apps/tokenplace.md`, and `docs/apps/danielsmith.md`, including descriptive links to app repo, image workflow, workflow success filters, GHCR image package, chart workflow, chart package/listing, Dockerfile, chart source, and app release guide when present. 
- Inserted Web UI shortcut guidance upstream of existing `gh run list` / `gh workflow run` commands explaining that GitHub Actions is for recent builds while GHCR is for published immutable tags. 
- Updated `README.md#Application runbooks` to include compact per-app artifact shortcuts (image workflow, image package, chart workflow, chart package). 
- Extended `docs/app_deployment_contract.md` with a "Required runbook artifact discovery links" subsection and updated `docs/app_onboarding.md` to require artifact-discovery links in onboarding checklists and question tables. 
- Added an offline-only regression test `tests/test_app_runbook_links.py` that verifies the three runbooks and README include the expected workflow and GHCR package URLs and that shared docs mention the artifact checklist. 

### Testing

- Ran the offline tests: `python -m pytest tests/test_app_runbook_links.py -q` and `python -m pytest tests -q`; all tests passed locally (`tests/test_app_runbook_links.py` passed and full `tests` run completed successfully). 
- Verified link text occurrences with ripgrep: `rg -n "actions/workflows/ci-image\.yml" README.md docs/apps docs/app_deployment_contract.md docs/app_onboarding.md`, `rg -n "actions/workflows/ci-helm\.yml" README.md docs/apps docs/app_deployment_contract.md docs/app_onboarding.md`, and `rg -n "pkgs/container" README.md docs/apps` all returned the expected matches. 
- Ran secret-scan hooks: `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` with no findings. 
- Notes on environment limits: `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` were not executed because those tools are not installed in the verification container; they are listed in the PR testing checklist for CI to run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f94dcc39c832f914615a14b6b9c1d)