### PR TITLE
docs: add app artifact discovery links

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,19 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
   tag, chart, app-config, and `just app-*` command contract for all Sugarkube apps.
 - **[Future-app onboarding guide](docs/app_onboarding.md)** — checklist and decision tree for
   adding apps such as wove, jobbot3000, and later services.
-- **Current app runbooks:** [DSPACE](docs/apps/dspace.md),
-  [token.place](docs/apps/tokenplace.md), and
-  [danielsmith.io](docs/apps/danielsmith.md) use the same GHCR-first staging,
-  verification, promotion, rollback, and troubleshooting flow.
+- **Current app runbooks:**
+  - [DSPACE](docs/apps/dspace.md) — [image workflow](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml),
+    [image package](https://github.com/democratizedspace/dspace/pkgs/container/dspace),
+    [chart workflow](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml),
+    [chart package](https://github.com/orgs/democratizedspace/packages?repo_name=dspace&q=charts%2Fdspace).
+  - [token.place](docs/apps/tokenplace.md) — [image workflow](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml),
+    [image package](https://github.com/futuroptimist/token.place/pkgs/container/tokenplace-relay),
+    [chart workflow](https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml),
+    [chart package](https://github.com/futuroptimist/token.place/pkgs/container/charts%2Ftokenplace).
+  - [danielsmith.io](docs/apps/danielsmith.md) — [image workflow](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml),
+    [image package](https://github.com/futuroptimist/danielsmith.io/pkgs/container/danielsmith.io),
+    [chart workflow](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-helm.yml),
+    [chart package](https://github.com/futuroptimist/danielsmith.io/pkgs/container/charts%2Fdanielsmith).
 - **Environment shortcuts:** token.place
   [dev](docs/k3s-tokenplace-dev.md), [staging](docs/k3s-tokenplace-staging.md), and
   [production](docs/k3s-tokenplace-prod.md); danielsmith.io

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -47,6 +47,19 @@ Each Sugarkube-managed app needs the following deployment coordinates:
 | Values chain per env | Comma-separated Helm values files, ordered from base to environment overlay. |
 | Validation URLs/paths | Host key plus one or more HTTP paths to check after rollout. |
 
+### Required runbook links
+
+Every app runbook must include an artifact-discovery link set near the top so operators do not have to search GitHub Actions or GHCR manually. Include descriptive Markdown links for:
+
+- the app repository;
+- the image workflow for recent builds;
+- the GHCR image package for published tags;
+- the chart workflow for recent chart publish attempts;
+- the GHCR chart package for published immutable chart versions;
+- the Dockerfile or other source image path;
+- the chart source path; and
+- the app-repo Sugarkube release guide when one exists.
+
 The current apps map to that model as examples:
 
 | App | Image | Chart | Release | Namespace | Version pin | Prod tag pin |

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -16,8 +16,9 @@ Use this checklist when onboarding the next GHCR-first app to Sugarkube. The goa
 4. Add `ci-helm.yml` with immutable OCI chart publishing.
 5. Add or copy a Sugarkube app config.
 6. Add environment values overlays for `dev`, `staging`, and `prod`.
-7. Run the generic Sugarkube deploy.
-8. Add app-specific smoke checks when generic HTTP checks are not enough.
+7. Add a Sugarkube runbook with direct artifact-discovery links for the app repo, image workflow, GHCR image package, chart workflow, GHCR chart package, Dockerfile/source image path, chart source path, and app-repo release guide when present.
+8. Run the generic Sugarkube deploy.
+9. Add app-specific smoke checks when generic HTTP checks are not enough.
 
 ## Minimal app config template
 
@@ -98,10 +99,15 @@ Do not invent real configs for `wove` or `jobbot3000` until their app repos have
 
 | Question | Why Sugarkube needs it |
 | --- | --- |
+| App repo URL | Anchors the Sugarkube runbook and source-of-truth release docs. |
 | App image name | Sets `image.repository` and lets operators find GHCR image tags. |
+| Image workflow URL | Lets operators open recent app image builds without searching Actions. |
+| GHCR image package URL | Lets operators cross-check published image tags. |
 | Container port | Drives Service and probe wiring in the chart. |
 | Health endpoints | Sets `SUGARKUBE_VERIFY_PATHS` and Kubernetes probes. |
 | Chart name | Sets the OCI chart reference. |
+| Chart workflow URL | Lets operators open recent chart publish attempts without searching Actions. |
+| GHCR chart package URL | Lets operators confirm published immutable chart versions. |
 | Namespace and release | Sets stable Helm/Kubernetes ownership. |
 | Staging and production hostnames | Drives values overlays, ingress, certs, and Cloudflare routes. |
 | Runtime secrets/config | Determines Secret references and what must remain outside docs. |

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -19,6 +19,20 @@ This is the canonical runbook for deploying danielsmith.io from GHCR artifacts t
 | Production tag pin | `docs/apps/danielsmith.prod.tag` |
 | Verify paths | `/`, `/livez`, `/healthz` |
 
+### Artifact links
+
+| Artifact | Link |
+| --- | --- |
+| App repo | [futuroptimist/danielsmith.io app repository](https://github.com/futuroptimist/danielsmith.io) |
+| Image workflow | [recent image workflow runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml) |
+| Successful main image runs | [successful `main` image builds](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess) |
+| GHCR image package | [published image package versions](https://github.com/futuroptimist/danielsmith.io/pkgs/container/danielsmith.io) |
+| Chart workflow | [recent chart publish runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-helm.yml) |
+| GHCR chart package | [published chart package versions](https://github.com/futuroptimist/danielsmith.io/pkgs/container/charts%2Fdanielsmith) |
+| Dockerfile | [container build source](https://github.com/futuroptimist/danielsmith.io/blob/main/Dockerfile) |
+| Chart source | [Helm chart source](https://github.com/futuroptimist/danielsmith.io/tree/main/charts/danielsmith) |
+| App release guide | [Sugarkube release guide in the app repo](https://github.com/futuroptimist/danielsmith.io/blob/main/docs/ops/sugarkube-release.md) |
+
 ## Environment topology
 
 - `env=dev`: local/dev defaults using `docs/examples/danielsmith.values.dev.yaml`.
@@ -28,7 +42,13 @@ This is the canonical runbook for deploying danielsmith.io from GHCR artifacts t
 
 ## Find or publish GHCR image
 
-Find the successful image workflow in the danielsmith.io app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, a bare branch name, or an environment name.
+Find the successful image workflow in the danielsmith.io app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, a bare branch name, or an environment name. The GitHub Actions workflow page is where recent builds are found; GHCR is where published package tags are cross-checked.
+
+Web UI shortcuts:
+
+- Open the [recent image workflow runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml).
+- Open the [GHCR image package versions](https://github.com/futuroptimist/danielsmith.io/pkgs/container/danielsmith.io).
+- Copy the immutable tag from a successful workflow summary or package version.
 
 ```bash
 APP_TAG=main-REPLACE_SHORTSHA
@@ -46,7 +66,7 @@ gh workflow run ci-image.yml --repo futuroptimist/danielsmith.io --ref main
 
 ## Confirm/publish OCI chart
 
-Sugarkube deploys the chart version pinned in `docs/apps/danielsmith.version`.
+Sugarkube deploys the chart version pinned in `docs/apps/danielsmith.version`. The [chart workflow runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-helm.yml) show recent chart publish attempts; the [GHCR chart package versions](https://github.com/futuroptimist/danielsmith.io/pkgs/container/charts%2Fdanielsmith) confirm which immutable chart versions are available. Review the [chart source](https://github.com/futuroptimist/danielsmith.io/tree/main/charts/danielsmith) when validating chart changes.
 
 ```bash
 CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.version | head -n 1)

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -19,6 +19,20 @@ This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugark
 | Production tag pin | `docs/apps/dspace.prod.tag` |
 | Verify paths | `/config.json`, `/healthz`, `/livez` |
 
+### Artifact links
+
+| Artifact | Link |
+| --- | --- |
+| App repo | [democratizedspace/dspace app repository](https://github.com/democratizedspace/dspace) |
+| Image workflow | [recent image workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml) |
+| Successful main image runs | [successful `main` image builds](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess) |
+| GHCR image package | [published image package versions](https://github.com/democratizedspace/dspace/pkgs/container/dspace) |
+| Chart workflow | [recent chart publish runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml) |
+| GHCR chart package | [published chart package versions](https://github.com/orgs/democratizedspace/packages?repo_name=dspace&q=charts%2Fdspace) |
+| Dockerfile | [container build source](https://github.com/democratizedspace/dspace/blob/main/Dockerfile) |
+| Chart source | [Helm chart source](https://github.com/democratizedspace/dspace/tree/main/charts/dspace) |
+| App release guide | [Sugarkube release guide in the app repo](https://github.com/democratizedspace/dspace/blob/main/docs/ops/sugarkube-release.md) |
+
 ## Environment topology
 
 - `env=dev`: future single-node/non-HA environment using `docs/examples/dspace.values.dev.yaml`.
@@ -28,7 +42,13 @@ This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugark
 
 ## Find or publish GHCR image
 
-Find the successful image workflow in the DSPACE app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, a bare branch name, or an environment name.
+Find the successful image workflow in the DSPACE app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, a bare branch name, or an environment name. The GitHub Actions workflow page is where recent builds are found; GHCR is where published package tags are cross-checked.
+
+Web UI shortcuts:
+
+- Open the [recent image workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml).
+- Open the [GHCR image package versions](https://github.com/democratizedspace/dspace/pkgs/container/dspace).
+- Copy the immutable tag from a successful workflow summary or package version.
 
 ```bash
 APP_TAG=main-REPLACE_SHORTSHA
@@ -46,7 +66,7 @@ gh workflow run ci-image.yml --repo democratizedspace/dspace --ref main
 
 ## Confirm/publish OCI chart
 
-Sugarkube deploys the chart version pinned in `docs/apps/dspace.version`.
+Sugarkube deploys the chart version pinned in `docs/apps/dspace.version`. The [chart workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml) show recent chart publish attempts; the [GHCR chart package versions](https://github.com/orgs/democratizedspace/packages?repo_name=dspace&q=charts%2Fdspace) confirm which immutable chart versions are available. Review the [chart source](https://github.com/democratizedspace/dspace/tree/main/charts/dspace) when validating chart changes.
 
 ```bash
 CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.version | head -n 1)

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -19,6 +19,20 @@ This is the canonical runbook for deploying token.place from GHCR artifacts to S
 | Production tag pin | `docs/apps/tokenplace.prod.tag` |
 | Verify paths | `/`, `/livez`, `/healthz`, `/relay/diagnostics` |
 
+### Artifact links
+
+| Artifact | Link |
+| --- | --- |
+| App repo | [futuroptimist/token.place app repository](https://github.com/futuroptimist/token.place) |
+| Image workflow | [recent image workflow runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml) |
+| Successful main image runs | [successful `main` image builds](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess) |
+| GHCR image package | [published image package versions](https://github.com/futuroptimist/token.place/pkgs/container/tokenplace-relay) |
+| Chart workflow | [recent chart publish runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml) |
+| GHCR chart package | [published chart package versions](https://github.com/futuroptimist/token.place/pkgs/container/charts%2Ftokenplace) |
+| Dockerfile | [container build source](https://github.com/futuroptimist/token.place/blob/main/Dockerfile) |
+| Chart source | [Helm chart source](https://github.com/futuroptimist/token.place/tree/main/charts/tokenplace) |
+| App release guide | [Sugarkube release guide in the app repo](https://github.com/futuroptimist/token.place/blob/main/docs/ops/sugarkube-release.md) |
+
 ## Environment topology
 
 - `env=dev`: local/dev defaults using `docs/examples/tokenplace.values.dev.yaml`.
@@ -28,7 +42,13 @@ This is the canonical runbook for deploying token.place from GHCR artifacts to S
 
 ## Find or publish GHCR image
 
-Find the successful image workflow in the token.place app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, a bare branch name, or an environment name.
+Find the successful image workflow in the token.place app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, a bare branch name, or an environment name. The GitHub Actions workflow page is where recent builds are found; GHCR is where published package tags are cross-checked.
+
+Web UI shortcuts:
+
+- Open the [recent image workflow runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml).
+- Open the [GHCR image package versions](https://github.com/futuroptimist/token.place/pkgs/container/tokenplace-relay).
+- Copy the immutable tag from a successful workflow summary or package version.
 
 ```bash
 APP_TAG=main-REPLACE_SHORTSHA
@@ -46,7 +66,7 @@ gh workflow run ci-image.yml --repo futuroptimist/token.place --ref main
 
 ## Confirm/publish OCI chart
 
-Sugarkube deploys the chart version pinned in `docs/apps/tokenplace.version`.
+Sugarkube deploys the chart version pinned in `docs/apps/tokenplace.version`. The [chart workflow runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml) show recent chart publish attempts; the [GHCR chart package versions](https://github.com/futuroptimist/token.place/pkgs/container/charts%2Ftokenplace) confirm which immutable chart versions are available. Review the [chart source](https://github.com/futuroptimist/token.place/tree/main/charts/tokenplace) when validating chart changes.
 
 ```bash
 CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.version | head -n 1)

--- a/tests/test_app_runbook_links.py
+++ b/tests/test_app_runbook_links.py
@@ -1,0 +1,115 @@
+"""Offline checks for application runbook artifact-discovery links."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+APP_LINKS = {
+    "dspace": {
+        "runbook": "docs/apps/dspace.md",
+        "readme_label": "DSPACE",
+        "urls": (
+            "https://github.com/democratizedspace/dspace",
+            "https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml",
+            ("https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml"
+             "?query=branch%3Amain+is%3Asuccess"),
+            "https://github.com/democratizedspace/dspace/pkgs/container/dspace",
+            "https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml",
+            ("https://github.com/orgs/democratizedspace/packages"
+             "?repo_name=dspace&q=charts%2Fdspace"),
+            "https://github.com/democratizedspace/dspace/blob/main/Dockerfile",
+            "https://github.com/democratizedspace/dspace/tree/main/charts/dspace",
+            ("https://github.com/democratizedspace/dspace/blob/main/docs/ops"
+             "/sugarkube-release.md"),
+        ),
+    },
+    "tokenplace": {
+        "runbook": "docs/apps/tokenplace.md",
+        "readme_label": "token.place",
+        "urls": (
+            "https://github.com/futuroptimist/token.place",
+            "https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml",
+            ("https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml"
+             "?query=branch%3Amain+is%3Asuccess"),
+            "https://github.com/futuroptimist/token.place/pkgs/container/tokenplace-relay",
+            "https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml",
+            "https://github.com/futuroptimist/token.place/pkgs/container/charts%2Ftokenplace",
+            "https://github.com/futuroptimist/token.place/blob/main/Dockerfile",
+            "https://github.com/futuroptimist/token.place/tree/main/charts/tokenplace",
+            "https://github.com/futuroptimist/token.place/blob/main/docs/ops/sugarkube-release.md",
+        ),
+    },
+    "danielsmith": {
+        "runbook": "docs/apps/danielsmith.md",
+        "readme_label": "danielsmith.io",
+        "urls": (
+            "https://github.com/futuroptimist/danielsmith.io",
+            "https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml",
+            ("https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml"
+             "?query=branch%3Amain+is%3Asuccess"),
+            "https://github.com/futuroptimist/danielsmith.io/pkgs/container/danielsmith.io",
+            "https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-helm.yml",
+            "https://github.com/futuroptimist/danielsmith.io/pkgs/container/charts%2Fdanielsmith",
+            "https://github.com/futuroptimist/danielsmith.io/blob/main/Dockerfile",
+            "https://github.com/futuroptimist/danielsmith.io/tree/main/charts/danielsmith",
+            ("https://github.com/futuroptimist/danielsmith.io/blob/main/docs/ops"
+             "/sugarkube-release.md"),
+        ),
+    },
+}
+
+README_ARTIFACT_URLS = {
+    app: tuple(
+        url
+        for url in data["urls"]
+        if (
+            ("actions/workflows" in url and "?query=" not in url)
+            or "pkgs/container" in url
+            or "packages?" in url
+        )
+    )
+    for app, data in APP_LINKS.items()
+}
+
+REQUIRED_CHECKLIST_TERMS = (
+    "app repository",
+    "image workflow",
+    "GHCR image package",
+    "chart workflow",
+    "GHCR chart package",
+    "Dockerfile",
+    "chart source path",
+    "app-repo Sugarkube release guide",
+)
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_app_runbooks_include_artifact_discovery_urls() -> None:
+    for app, data in APP_LINKS.items():
+        text = _read(data["runbook"])
+        assert "### Artifact links" in text, f"{app} runbook should expose an artifact links table."
+        for url in data["urls"]:
+            assert url in text, f"{app} runbook is missing {url}."
+
+
+def test_readme_application_runbooks_include_quick_artifact_links() -> None:
+    readme = _read("README.md")
+    for app, data in APP_LINKS.items():
+        assert data["readme_label"] in readme, f"README should list {app}."
+        for url in README_ARTIFACT_URLS[app]:
+            assert url in readme, f"README app runbooks section is missing {url}."
+
+
+def test_shared_docs_require_artifact_discovery_link_checklist() -> None:
+    contract = _read("docs/app_deployment_contract.md")
+    onboarding = _read("docs/app_onboarding.md")
+    combined = contract + "\n" + onboarding
+
+    assert "Required runbook links" in contract
+    for term in REQUIRED_CHECKLIST_TERMS:
+        assert term in combined, f"Shared app docs should require {term}."


### PR DESCRIPTION
### Motivation

- Operators should be able to open the exact app repo, image workflow runs, GHCR image package pages, chart workflows, GHCR chart package pages, Dockerfile/chart source locations, and app release guides directly from Sugarkube docs without manual GitHub/GHCR searches. 
- The shared app contract and onboarding checklist must require these artifact-discovery links so future apps provide the same operator-friendly entry points.
- Add lightweight offline regression coverage to prevent accidental removal of the new link affordances.

### Description

- Added an `### Artifact links` table to each runbook: `docs/apps/dspace.md`, `docs/apps/tokenplace.md`, and `docs/apps/danielsmith.md`, linking the app repo, image workflow, successful main runs, GHCR image package, chart workflow, GHCR chart package page, Dockerfile, chart source, and app release guide when present. 
- Enhanced each runbook `Find or publish GHCR image` section with an explicit note that GitHub Actions shows recent builds and GHCR is used to cross-check published tags, plus a short `Web UI shortcuts` list linking the image workflow and GHCR package pages while preserving the existing `gh run list` and `gh workflow run` commands. 
- Enhanced each runbook `Confirm/publish OCI chart` section with direct links to the chart workflow, GHCR chart package versions page, and chart source while keeping `helm show chart ... --version "$CHART_VERSION"` and the existing `gh workflow run ci-helm.yml ...` guidance. 
- Updated `README.md` application runbooks section to a compact per-app bulleted list that includes image workflow/package and chart workflow/package quick links. 
- Added a `### Required runbook links` subsection to `docs/app_deployment_contract.md` and extended `docs/app_onboarding.md` to require artifact-discovery links and capture app repo/chart/image workflow/package URLs in the onboarding checklist/questions. 
- Added an offline-only regression test `tests/test_app_runbook_links.py` that verifies each runbook and the README include the expected workflow and GHCR package URLs and that the shared contract/onboarding text mentions the required checklist items.

### Testing

- Ran `python -m pytest tests/test_app_runbook_links.py -q` and the new test passed (1 file, focused assertions). 
- Ran the repository test sweep `python -m pytest tests -q`, which completed successfully (`1232 passed, 43 skipped, 9 warnings`) in this environment. 
- Verified presence of expected link patterns via ripgrep with the provided search commands (examples: `rg "actions/workflows/ci-image.yml" README.md docs/apps docs/app_deployment_contract.md docs/app_onboarding.md`, `rg "pkgs/container" README.md docs/apps`), all checks showed the new links present. 
- Ran `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` with no secrets flagged, and `git diff --check` produced no whitespace errors from these changes; note that `bash scripts/checks.sh` was executed but failed on pre-existing flake8 line-length issues outside this PR. 

Notes: `pre-commit`, `pyspelling`, and `linkchecker` were not available in the runtime used to verify the changes (`command not found`), so those optional doc/linters were not executed here; the change itself is docs-only and the added test is offline-only and passes without network or GitHub credentials.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f94dcc39c832f914615a14b6b9c1d)