### PR TITLE
docs: link app runbooks to release artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,20 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
   tag, chart, app-config, and `just app-*` command contract for all Sugarkube apps.
 - **[Future-app onboarding guide](docs/app_onboarding.md)** — checklist and decision tree for
   adding apps such as wove, jobbot3000, and later services.
-- **Current app runbooks:** [DSPACE](docs/apps/dspace.md),
-  [token.place](docs/apps/tokenplace.md), and
-  [danielsmith.io](docs/apps/danielsmith.md) use the same GHCR-first staging,
-  verification, promotion, rollback, and troubleshooting flow.
+- **Current app runbooks** use the same GHCR-first staging, verification, promotion,
+  rollback, and troubleshooting flow:
+  - **[DSPACE](docs/apps/dspace.md):** [image workflow](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml),
+    [image package](https://github.com/democratizedspace/dspace/pkgs/container/dspace),
+    [chart workflow](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml),
+    [chart package lookup](https://github.com/orgs/democratizedspace/packages?repo_name=dspace&ecosystem=container).
+  - **[token.place](docs/apps/tokenplace.md):** [image workflow](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml),
+    [image package](https://github.com/futuroptimist/token.place/pkgs/container/tokenplace-relay),
+    [chart workflow](https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml),
+    [chart package](https://github.com/futuroptimist/token.place/pkgs/container/charts%2Ftokenplace).
+  - **[danielsmith.io](docs/apps/danielsmith.md):** [image workflow](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml),
+    [image package](https://github.com/futuroptimist/danielsmith.io/pkgs/container/danielsmith.io),
+    [chart workflow](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-helm.yml),
+    [chart package](https://github.com/futuroptimist/danielsmith.io/pkgs/container/charts%2Fdanielsmith).
 - **Environment shortcuts:** token.place
   [dev](docs/k3s-tokenplace-dev.md), [staging](docs/k3s-tokenplace-staging.md), and
   [production](docs/k3s-tokenplace-prod.md); danielsmith.io

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -55,6 +55,22 @@ The current apps map to that model as examples:
 | token.place | `ghcr.io/futuroptimist/tokenplace-relay` | `oci://ghcr.io/futuroptimist/charts/tokenplace` | `tokenplace` | `tokenplace` | `docs/apps/tokenplace.version` | `docs/apps/tokenplace.prod.tag` |
 | danielsmith.io | `ghcr.io/futuroptimist/danielsmith.io` | `oci://ghcr.io/futuroptimist/charts/danielsmith` | `danielsmith` | `danielsmith` | `docs/apps/danielsmith.version` | `docs/apps/danielsmith.prod.tag` |
 
+
+## Artifact discovery links
+
+Every app runbook must make artifacts discoverable without asking operators to
+search GitHub Actions or GHCR manually. Near the top of each runbook, include
+links to:
+
+- the app repo;
+- the image workflow for recent build runs;
+- the GHCR image package for published image tags;
+- the chart workflow for recent chart publish attempts;
+- the GHCR chart package for published immutable chart versions;
+- the Dockerfile or other source image path used by the workflow;
+- the chart source path; and
+- the app-repo release guide when one is present.
+
 ## Standard image tag model
 
 Deployment tags must identify application code and release intent, not mutable

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -16,8 +16,11 @@ Use this checklist when onboarding the next GHCR-first app to Sugarkube. The goa
 4. Add `ci-helm.yml` with immutable OCI chart publishing.
 5. Add or copy a Sugarkube app config.
 6. Add environment values overlays for `dev`, `staging`, and `prod`.
-7. Run the generic Sugarkube deploy.
-8. Add app-specific smoke checks when generic HTTP checks are not enough.
+7. Add the Sugarkube runbook artifact discovery links: app repo, image workflow,
+   GHCR image package, chart workflow, GHCR chart package, Dockerfile/source image
+   path, chart source path, and app-repo release guide when present.
+8. Run the generic Sugarkube deploy.
+9. Add app-specific smoke checks when generic HTTP checks are not enough.
 
 ## Minimal app config template
 
@@ -98,9 +101,14 @@ Do not invent real configs for `wove` or `jobbot3000` until their app repos have
 
 | Question | Why Sugarkube needs it |
 | --- | --- |
+| App repo URL | Gives operators the source-of-truth repository and ownership boundary. |
+| Image workflow URL | Lets operators open recent `ci-image.yml` build runs directly. |
+| GHCR image package URL | Lets operators confirm published immutable image tags. |
 | App image name | Sets `image.repository` and lets operators find GHCR image tags. |
 | Container port | Drives Service and probe wiring in the chart. |
 | Health endpoints | Sets `SUGARKUBE_VERIFY_PATHS` and Kubernetes probes. |
+| Chart workflow URL | Lets operators open recent `ci-helm.yml` chart publish attempts directly. |
+| GHCR chart package URL | Lets operators confirm published immutable OCI chart versions. |
 | Chart name | Sets the OCI chart reference. |
 | Namespace and release | Sets stable Helm/Kubernetes ownership. |
 | Staging and production hostnames | Drives values overlays, ingress, certs, and Cloudflare routes. |

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -19,6 +19,19 @@ This is the canonical runbook for deploying danielsmith.io from GHCR artifacts t
 | Production tag pin | `docs/apps/danielsmith.prod.tag` |
 | Verify paths | `/`, `/livez`, `/healthz` |
 
+### Artifact links
+
+| Artifact | Link |
+| --- | --- |
+| App repo | [danielsmith.io source repository](https://github.com/futuroptimist/danielsmith.io) |
+| Image workflow | [recent image builds](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml) and [successful main image runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess) |
+| GHCR image package | [published image versions](https://github.com/futuroptimist/danielsmith.io/pkgs/container/danielsmith.io) |
+| Chart workflow | [recent chart publish runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-helm.yml) |
+| GHCR chart package versions | [published chart versions](https://github.com/futuroptimist/danielsmith.io/pkgs/container/charts%2Fdanielsmith) |
+| Dockerfile | [container source Dockerfile](https://github.com/futuroptimist/danielsmith.io/blob/main/Dockerfile) |
+| Chart source | [Helm chart directory](https://github.com/futuroptimist/danielsmith.io/tree/main/charts/danielsmith) |
+| Release guide | [app repo Sugarkube release guide](https://github.com/futuroptimist/danielsmith.io/blob/main/docs/ops/sugarkube-release.md) |
+
 ## Environment topology
 
 - `env=dev`: local/dev defaults using `docs/examples/danielsmith.values.dev.yaml`.
@@ -28,7 +41,13 @@ This is the canonical runbook for deploying danielsmith.io from GHCR artifacts t
 
 ## Find or publish GHCR image
 
-Find the successful image workflow in the danielsmith.io app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, a bare branch name, or an environment name.
+Find the successful image workflow in the danielsmith.io app repo and copy the immutable branch-SHA or release tag. The GitHub Actions workflow page shows recent builds; GHCR is where operators cross-check published package tags. Do not deploy `latest`, a bare branch name, or an environment name.
+
+Web UI shortcuts:
+
+- Open the [image workflow recent runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml).
+- Open the [GHCR image package versions page](https://github.com/futuroptimist/danielsmith.io/pkgs/container/danielsmith.io).
+- Copy the immutable tag from a successful workflow summary or package version.
 
 ```bash
 APP_TAG=main-REPLACE_SHORTSHA
@@ -46,7 +65,13 @@ gh workflow run ci-image.yml --repo futuroptimist/danielsmith.io --ref main
 
 ## Confirm/publish OCI chart
 
-Sugarkube deploys the chart version pinned in `docs/apps/danielsmith.version`.
+Sugarkube deploys the chart version pinned in `docs/apps/danielsmith.version`. The chart workflow page shows recent publish attempts; the GHCR chart package page confirms available immutable chart versions, and the chart source shows what changed before publication.
+
+Web UI shortcuts:
+
+- Open the [chart workflow recent runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-helm.yml).
+- Open the [GHCR chart package versions](https://github.com/futuroptimist/danielsmith.io/pkgs/container/charts%2Fdanielsmith).
+- Review the [chart source directory](https://github.com/futuroptimist/danielsmith.io/tree/main/charts/danielsmith).
 
 ```bash
 CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.version | head -n 1)

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -19,6 +19,19 @@ This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugark
 | Production tag pin | `docs/apps/dspace.prod.tag` |
 | Verify paths | `/config.json`, `/healthz`, `/livez` |
 
+### Artifact links
+
+| Artifact | Link |
+| --- | --- |
+| App repo | [DSPACE source repository](https://github.com/democratizedspace/dspace) |
+| Image workflow | [recent image builds](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml) and [successful main image runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess); [Successful v3 image runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml?query=branch%3Av3+is%3Asuccess) |
+| GHCR image package | [published image versions](https://github.com/democratizedspace/dspace/pkgs/container/dspace) |
+| Chart workflow | [recent chart publish runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml) |
+| GHCR chart package lookup | [published chart versions](https://github.com/orgs/democratizedspace/packages?repo_name=dspace&ecosystem=container) |
+| Dockerfile | [container source Dockerfile](https://github.com/democratizedspace/dspace/blob/main/Dockerfile) |
+| Chart source | [Helm chart directory](https://github.com/democratizedspace/dspace/tree/main/charts/dspace) |
+| Release guide | [app repo Sugarkube release guide](https://github.com/democratizedspace/dspace/blob/main/docs/ops/sugarkube-release.md) |
+
 ## Environment topology
 
 - `env=dev`: future single-node/non-HA environment using `docs/examples/dspace.values.dev.yaml`.
@@ -28,7 +41,13 @@ This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugark
 
 ## Find or publish GHCR image
 
-Find the successful image workflow in the DSPACE app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, a bare branch name, or an environment name.
+Find the successful image workflow in the DSPACE app repo and copy the immutable branch-SHA or release tag. The GitHub Actions workflow page shows recent builds; GHCR is where operators cross-check published package tags. Do not deploy `latest`, a bare branch name, or an environment name.
+
+Web UI shortcuts:
+
+- Open the [image workflow recent runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml).
+- Open the [GHCR image package versions page](https://github.com/democratizedspace/dspace/pkgs/container/dspace).
+- Copy the immutable tag from a successful workflow summary or package version.
 
 ```bash
 APP_TAG=main-REPLACE_SHORTSHA
@@ -46,7 +65,13 @@ gh workflow run ci-image.yml --repo democratizedspace/dspace --ref main
 
 ## Confirm/publish OCI chart
 
-Sugarkube deploys the chart version pinned in `docs/apps/dspace.version`.
+Sugarkube deploys the chart version pinned in `docs/apps/dspace.version`. The chart workflow page shows recent publish attempts; the GHCR chart package page confirms available immutable chart versions, and the chart source shows what changed before publication.
+
+Web UI shortcuts:
+
+- Open the [chart workflow recent runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml).
+- Open the [GHCR chart package lookup](https://github.com/orgs/democratizedspace/packages?repo_name=dspace&ecosystem=container).
+- Review the [chart source directory](https://github.com/democratizedspace/dspace/tree/main/charts/dspace).
 
 ```bash
 CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.version | head -n 1)

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -19,6 +19,19 @@ This is the canonical runbook for deploying token.place from GHCR artifacts to S
 | Production tag pin | `docs/apps/tokenplace.prod.tag` |
 | Verify paths | `/`, `/livez`, `/healthz`, `/relay/diagnostics` |
 
+### Artifact links
+
+| Artifact | Link |
+| --- | --- |
+| App repo | [token.place source repository](https://github.com/futuroptimist/token.place) |
+| Image workflow | [recent image builds](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml) and [successful main image runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess) |
+| GHCR image package | [published image versions](https://github.com/futuroptimist/token.place/pkgs/container/tokenplace-relay) |
+| Chart workflow | [recent chart publish runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml) |
+| GHCR chart package versions | [published chart versions](https://github.com/futuroptimist/token.place/pkgs/container/charts%2Ftokenplace) |
+| Dockerfile | [container source Dockerfile](https://github.com/futuroptimist/token.place/blob/main/Dockerfile) |
+| Chart source | [Helm chart directory](https://github.com/futuroptimist/token.place/tree/main/charts/tokenplace) |
+| Release guide | [app repo Sugarkube release guide](https://github.com/futuroptimist/token.place/blob/main/docs/ops/sugarkube-release.md) |
+
 ## Environment topology
 
 - `env=dev`: local/dev defaults using `docs/examples/tokenplace.values.dev.yaml`.
@@ -28,7 +41,13 @@ This is the canonical runbook for deploying token.place from GHCR artifacts to S
 
 ## Find or publish GHCR image
 
-Find the successful image workflow in the token.place app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, a bare branch name, or an environment name.
+Find the successful image workflow in the token.place app repo and copy the immutable branch-SHA or release tag. The GitHub Actions workflow page shows recent builds; GHCR is where operators cross-check published package tags. Do not deploy `latest`, a bare branch name, or an environment name.
+
+Web UI shortcuts:
+
+- Open the [image workflow recent runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml).
+- Open the [GHCR image package versions page](https://github.com/futuroptimist/token.place/pkgs/container/tokenplace-relay).
+- Copy the immutable tag from a successful workflow summary or package version.
 
 ```bash
 APP_TAG=main-REPLACE_SHORTSHA
@@ -46,7 +65,13 @@ gh workflow run ci-image.yml --repo futuroptimist/token.place --ref main
 
 ## Confirm/publish OCI chart
 
-Sugarkube deploys the chart version pinned in `docs/apps/tokenplace.version`.
+Sugarkube deploys the chart version pinned in `docs/apps/tokenplace.version`. The chart workflow page shows recent publish attempts; the GHCR chart package page confirms available immutable chart versions, and the chart source shows what changed before publication.
+
+Web UI shortcuts:
+
+- Open the [chart workflow recent runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml).
+- Open the [GHCR chart package versions](https://github.com/futuroptimist/token.place/pkgs/container/charts%2Ftokenplace).
+- Review the [chart source directory](https://github.com/futuroptimist/token.place/tree/main/charts/tokenplace).
 
 ```bash
 CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.version | head -n 1)

--- a/tests/test_app_runbook_links.py
+++ b/tests/test_app_runbook_links.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+DSPACE_REPO = "https://github.com/democratizedspace/dspace"
+TOKENPLACE_REPO = "https://github.com/futuroptimist/token.place"
+DANIELSMITH_REPO = "https://github.com/futuroptimist/danielsmith.io"
+
+APP_LINKS = {
+    "dspace": {
+        "runbook": "docs/apps/dspace.md",
+        "readme_label": "DSPACE",
+        "urls": {
+            "app_repo": DSPACE_REPO,
+            "image_workflow": f"{DSPACE_REPO}/actions/workflows/ci-image.yml",
+            "successful_main_images": (
+                f"{DSPACE_REPO}/actions/workflows/ci-image.yml"
+                "?query=branch%3Amain+is%3Asuccess"
+            ),
+            "successful_v3_images": (
+                f"{DSPACE_REPO}/actions/workflows/ci-image.yml"
+                "?query=branch%3Av3+is%3Asuccess"
+            ),
+            "image_package": f"{DSPACE_REPO}/pkgs/container/dspace",
+            "chart_workflow": f"{DSPACE_REPO}/actions/workflows/ci-helm.yml",
+            "chart_package": (
+                "https://github.com/orgs/democratizedspace/packages"
+                "?repo_name=dspace&ecosystem=container"
+            ),
+            "dockerfile": f"{DSPACE_REPO}/blob/main/Dockerfile",
+            "chart_source": f"{DSPACE_REPO}/tree/main/charts/dspace",
+            "release_guide": f"{DSPACE_REPO}/blob/main/docs/ops/sugarkube-release.md",
+        },
+    },
+    "tokenplace": {
+        "runbook": "docs/apps/tokenplace.md",
+        "readme_label": "token.place",
+        "urls": {
+            "app_repo": TOKENPLACE_REPO,
+            "image_workflow": f"{TOKENPLACE_REPO}/actions/workflows/ci-image.yml",
+            "successful_main_images": (
+                f"{TOKENPLACE_REPO}/actions/workflows/ci-image.yml"
+                "?query=branch%3Amain+is%3Asuccess"
+            ),
+            "image_package": f"{TOKENPLACE_REPO}/pkgs/container/tokenplace-relay",
+            "chart_workflow": f"{TOKENPLACE_REPO}/actions/workflows/ci-helm.yml",
+            "chart_package": f"{TOKENPLACE_REPO}/pkgs/container/charts%2Ftokenplace",
+            "dockerfile": f"{TOKENPLACE_REPO}/blob/main/Dockerfile",
+            "chart_source": f"{TOKENPLACE_REPO}/tree/main/charts/tokenplace",
+            "release_guide": f"{TOKENPLACE_REPO}/blob/main/docs/ops/sugarkube-release.md",
+        },
+    },
+    "danielsmith": {
+        "runbook": "docs/apps/danielsmith.md",
+        "readme_label": "danielsmith.io",
+        "urls": {
+            "app_repo": DANIELSMITH_REPO,
+            "image_workflow": f"{DANIELSMITH_REPO}/actions/workflows/ci-image.yml",
+            "successful_main_images": (
+                f"{DANIELSMITH_REPO}/actions/workflows/ci-image.yml"
+                "?query=branch%3Amain+is%3Asuccess"
+            ),
+            "image_package": f"{DANIELSMITH_REPO}/pkgs/container/danielsmith.io",
+            "chart_workflow": f"{DANIELSMITH_REPO}/actions/workflows/ci-helm.yml",
+            "chart_package": f"{DANIELSMITH_REPO}/pkgs/container/charts%2Fdanielsmith",
+            "dockerfile": f"{DANIELSMITH_REPO}/blob/main/Dockerfile",
+            "chart_source": f"{DANIELSMITH_REPO}/tree/main/charts/danielsmith",
+            "release_guide": f"{DANIELSMITH_REPO}/blob/main/docs/ops/sugarkube-release.md",
+        },
+    },
+}
+
+README_LINK_KEYS = {"image_workflow", "image_package", "chart_workflow", "chart_package"}
+
+
+def read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text()
+
+
+def test_app_runbooks_expose_artifact_discovery_links() -> None:
+    for app in APP_LINKS.values():
+        runbook = read(app["runbook"])
+        assert "### Artifact links" in runbook
+        assert "Web UI shortcuts" in runbook
+        for name, url in app["urls"].items():
+            assert url in runbook, f"{app['runbook']} is missing {name}: {url}"
+
+
+def test_readme_exposes_quick_artifact_links_for_each_app() -> None:
+    readme = read("README.md")
+    for app in APP_LINKS.values():
+        assert app["readme_label"] in readme
+        for key in README_LINK_KEYS:
+            assert app["urls"][key] in readme, (
+                f"README.md is missing {key} for {app['readme_label']}"
+            )
+
+
+def test_shared_docs_require_artifact_discovery_checklist() -> None:
+    contract = read("docs/app_deployment_contract.md")
+    onboarding = read("docs/app_onboarding.md")
+    required_phrases = [
+        "Artifact discovery links",
+        "app repo",
+        "image workflow",
+        "GHCR image package",
+        "chart workflow",
+        "GHCR chart package",
+        "Dockerfile",
+        "chart source path",
+        "release guide",
+    ]
+    for phrase in required_phrases:
+        assert phrase in contract or phrase in onboarding


### PR DESCRIPTION
### Motivation
- Operators should be able to jump directly from Sugarkube runbooks to the exact app repo, image/chart workflows, GHCR package pages, Dockerfile and chart source locations without manual searching. 
- The existing runbooks had the right structure but lacked per-app artifact-discovery links and quick Web UI shortcuts. 
- The shared onboarding/contract docs should require these links so future apps are consistently discoverable.

### Description
- Added an "Artifact links" table and short "Web UI shortcuts" guidance to each current app runbook (`docs/apps/dspace.md`, `docs/apps/tokenplace.md`, `docs/apps/danielsmith.md`) with descriptive links to app repo, image workflow(s), GHCR image package, chart workflow, GHCR chart package lookup, Dockerfile, chart source, and release guide where present. 
- Expanded the image and chart sections to explicitly say the Actions workflow page shows recent builds while GHCR pages confirm published immutable tags/versions, and preserved existing `gh`/`helm` copy-paste commands. 
- Updated `README.md` application runbooks area to include compact per-app quick links to image workflow, image package, chart workflow, and chart package. 
- Extended `docs/app_deployment_contract.md` with an "Artifact discovery links" subsection and updated `docs/app_onboarding.md` to require runbook artifact links and to add onboarding checklist/question fields for those URLs. 
- Added an offline-only test `tests/test_app_runbook_links.py` that verifies the three runbooks, README, and shared docs contain the expected artifact discovery links without making network calls.

### Testing
- Ran the new offline test: `python -m pytest tests/test_app_runbook_links.py -q` and it passed (`3 passed`).
- Ran the repository test suite: `python -m pytest tests -q` and it completed successfully (`1256 passed, 19 skipped, 9 warnings` in this environment). 
- Verified presence of link tokens with ripgrep: `rg -n "actions/workflows/ci-image.yml" README.md docs/apps docs/app_deployment_contract.md docs/app_onboarding.md` and `rg -n "actions/workflows/ci-helm.yml" README.md docs/apps docs/app_deployment_contract.md docs/app_onboarding.md` (matches present). 
- Checked GHCR/package URL tokens with `rg -n "pkgs/container" README.md docs/apps` (matches present) and ran `linkchecker --no-warnings README.md docs/` which returned no errors. 
- Attempted `python -m pre_commit run --all-files` and `pyspelling -c .spellcheck.yaml`; `pre-commit` surfaced unrelated, repo-wide lint/YAML issues outside this PR's scope and `pyspelling` failed due to a missing `aspell` binary in the environment; these are notes only and did not block the docs changes or the added test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f94dcc39c832f914615a14b6b9c1d)