### PR TITLE
docs: make app runbooks artifact-discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
     [image workflow](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml),
     [image package](https://github.com/democratizedspace/dspace/pkgs/container/dspace),
     [chart workflow](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml),
-    [chart package](https://github.com/orgs/democratizedspace/packages/container/package/charts%2Fdspace).
+    [GHCR package listing](https://github.com/orgs/democratizedspace/packages?repo_name=dspace) (chart package page pending).
   - [token.place runbook](docs/apps/tokenplace.md) for `ghcr.io/futuroptimist/tokenplace-relay`:
     [image workflow](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml),
     [image package](https://github.com/futuroptimist/token.place/pkgs/container/tokenplace-relay),

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
     [image workflow](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml),
     [image package](https://github.com/democratizedspace/dspace/pkgs/container/dspace),
     [chart workflow](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml),
-    [GHCR package listing](https://github.com/orgs/democratizedspace/packages?repo_name=dspace) (chart package page pending).
+    [chart package listing](https://github.com/orgs/democratizedspace/packages?repo_name=dspace&q=charts%2Fdspace) (chart package page pending).
   - [token.place runbook](docs/apps/tokenplace.md) for `ghcr.io/futuroptimist/tokenplace-relay`:
     [image workflow](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml),
     [image package](https://github.com/futuroptimist/token.place/pkgs/container/tokenplace-relay),

--- a/README.md
+++ b/README.md
@@ -43,10 +43,23 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
   tag, chart, app-config, and `just app-*` command contract for all Sugarkube apps.
 - **[Future-app onboarding guide](docs/app_onboarding.md)** — checklist and decision tree for
   adding apps such as wove, jobbot3000, and later services.
-- **Current app runbooks:** [DSPACE](docs/apps/dspace.md),
-  [token.place](docs/apps/tokenplace.md), and
-  [danielsmith.io](docs/apps/danielsmith.md) use the same GHCR-first staging,
-  verification, promotion, rollback, and troubleshooting flow.
+- **Current app runbooks** use the same GHCR-first staging, verification,
+  promotion, rollback, and troubleshooting flow:
+  - [DSPACE runbook](docs/apps/dspace.md) for `ghcr.io/democratizedspace/dspace`:
+    [image workflow](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml),
+    [image package](https://github.com/democratizedspace/dspace/pkgs/container/dspace),
+    [chart workflow](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml),
+    [chart package](https://github.com/orgs/democratizedspace/packages/container/package/charts%2Fdspace).
+  - [token.place runbook](docs/apps/tokenplace.md) for `ghcr.io/futuroptimist/tokenplace-relay`:
+    [image workflow](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml),
+    [image package](https://github.com/futuroptimist/token.place/pkgs/container/tokenplace-relay),
+    [chart workflow](https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml),
+    [chart package](https://github.com/futuroptimist/token.place/pkgs/container/charts%2Ftokenplace).
+  - [danielsmith.io runbook](docs/apps/danielsmith.md) for `ghcr.io/futuroptimist/danielsmith.io`:
+    [image workflow](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml),
+    [image package](https://github.com/futuroptimist/danielsmith.io/pkgs/container/danielsmith.io),
+    [chart workflow](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-helm.yml),
+    [chart package](https://github.com/futuroptimist/danielsmith.io/pkgs/container/charts%2Fdanielsmith).
 - **Environment shortcuts:** token.place
   [dev](docs/k3s-tokenplace-dev.md), [staging](docs/k3s-tokenplace-staging.md), and
   [production](docs/k3s-tokenplace-prod.md); danielsmith.io

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -47,6 +47,20 @@ Each Sugarkube-managed app needs the following deployment coordinates:
 | Values chain per env | Comma-separated Helm values files, ordered from base to environment overlay. |
 | Validation URLs/paths | Host key plus one or more HTTP paths to check after rollout. |
 
+### Artifact discovery links
+
+Every app runbook must include required runbook links that make artifacts
+discoverable without manually searching GitHub Actions or GHCR:
+
+- the app repository;
+- the image workflow;
+- the GHCR image package;
+- the chart workflow;
+- the GHCR chart package;
+- the Dockerfile or source image path;
+- the chart source path; and
+- the app-repo Sugarkube release guide when one is present.
+
 The current apps map to that model as examples:
 
 | App | Image | Chart | Release | Namespace | Version pin | Prod tag pin |

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -16,8 +16,12 @@ Use this checklist when onboarding the next GHCR-first app to Sugarkube. The goa
 4. Add `ci-helm.yml` with immutable OCI chart publishing.
 5. Add or copy a Sugarkube app config.
 6. Add environment values overlays for `dev`, `staging`, and `prod`.
-7. Run the generic Sugarkube deploy.
-8. Add app-specific smoke checks when generic HTTP checks are not enough.
+7. Add a Sugarkube runbook with direct artifact discovery links for the app
+   repo, image workflow, GHCR image package, chart workflow, GHCR chart package,
+   Dockerfile/source image path, chart source path, and app-repo release guide
+   when present.
+8. Run the generic Sugarkube deploy.
+9. Add app-specific smoke checks when generic HTTP checks are not enough.
 
 ## Minimal app config template
 
@@ -98,9 +102,14 @@ Do not invent real configs for `wove` or `jobbot3000` until their app repos have
 
 | Question | Why Sugarkube needs it |
 | --- | --- |
+| App repo URL | Anchors the runbook, source links, and release-guide link. |
+| Image workflow URL | Lets operators find recent builds without searching GitHub Actions. |
+| GHCR image package URL | Lets operators cross-check published image tags. |
 | App image name | Sets `image.repository` and lets operators find GHCR image tags. |
 | Container port | Drives Service and probe wiring in the chart. |
 | Health endpoints | Sets `SUGARKUBE_VERIFY_PATHS` and Kubernetes probes. |
+| Chart workflow URL | Lets operators find recent chart publish attempts. |
+| GHCR chart package URL | Lets operators confirm immutable chart versions before pinning. |
 | Chart name | Sets the OCI chart reference. |
 | Namespace and release | Sets stable Helm/Kubernetes ownership. |
 | Staging and production hostnames | Drives values overlays, ingress, certs, and Cloudflare routes. |

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -110,6 +110,9 @@ Do not invent real configs for `wove` or `jobbot3000` until their app repos have
 | Health endpoints | Sets `SUGARKUBE_VERIFY_PATHS` and Kubernetes probes. |
 | Chart workflow URL | Lets operators find recent chart publish attempts. |
 | GHCR chart package URL | Lets operators confirm immutable chart versions before pinning. |
+| Dockerfile/source image path URL | Lets operators review the build context or source image before trusting published tags. |
+| Chart source URL | Lets operators compare the published chart version with the source chart. |
+| App-repo release guide URL, when present | Gives operators app-owned release notes and publish steps without searching the app repo. |
 | Chart name | Sets the OCI chart reference. |
 | Namespace and release | Sets stable Helm/Kubernetes ownership. |
 | Staging and production hostnames | Drives values overlays, ingress, certs, and Cloudflare routes. |

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -19,6 +19,22 @@ This is the canonical runbook for deploying danielsmith.io from GHCR artifacts t
 | Production tag pin | `docs/apps/danielsmith.prod.tag` |
 | Verify paths | `/`, `/livez`, `/healthz` |
 
+### Artifact links
+
+Use these links before changing a deployment so the workflow runs, package versions, and source paths all agree.
+
+| Artifact | Link |
+| --- | --- |
+| App repository | [danielsmith.io app repository](https://github.com/futuroptimist/danielsmith.io) |
+| Image workflow | [Recent image workflow runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml) |
+| Successful main image runs | [Successful main image workflow runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess) |
+| GHCR image package | [GHCR image package versions](https://github.com/futuroptimist/danielsmith.io/pkgs/container/danielsmith.io) |
+| Chart workflow | [Recent chart workflow runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-helm.yml) |
+| GHCR chart package | [GHCR chart package versions](https://github.com/futuroptimist/danielsmith.io/pkgs/container/charts%2Fdanielsmith) |
+| Dockerfile | [Application Dockerfile](https://github.com/futuroptimist/danielsmith.io/blob/main/Dockerfile) |
+| Chart source | [Helm chart source](https://github.com/futuroptimist/danielsmith.io/tree/main/charts/danielsmith) |
+| App release guide | [Sugarkube release guide in the app repo](https://github.com/futuroptimist/danielsmith.io/blob/main/docs/ops/sugarkube-release.md) |
+
 ## Environment topology
 
 - `env=dev`: local/dev defaults using `docs/examples/danielsmith.values.dev.yaml`.
@@ -28,7 +44,13 @@ This is the canonical runbook for deploying danielsmith.io from GHCR artifacts t
 
 ## Find or publish GHCR image
 
-Find the successful image workflow in the danielsmith.io app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, a bare branch name, or an environment name.
+Find the successful image workflow in the danielsmith.io app repo and copy the immutable branch-SHA or release tag. The GitHub Actions workflow page is where recent builds are found; the GHCR package page is where published image tags are cross-checked. Do not deploy `latest`, a bare branch name, or an environment name.
+
+Web UI shortcuts:
+
+- Open [recent image workflow runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml) or [successful main image runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess).
+- Open [GHCR image package versions](https://github.com/futuroptimist/danielsmith.io/pkgs/container/danielsmith.io).
+- Copy the immutable tag from a successful workflow summary or package version.
 
 ```bash
 APP_TAG=main-REPLACE_SHORTSHA
@@ -46,7 +68,7 @@ gh workflow run ci-image.yml --repo futuroptimist/danielsmith.io --ref main
 
 ## Confirm/publish OCI chart
 
-Sugarkube deploys the chart version pinned in `docs/apps/danielsmith.version`.
+Sugarkube deploys the chart version pinned in `docs/apps/danielsmith.version`. Use [recent chart workflow runs](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-helm.yml) to find chart publish attempts, [GHCR chart package versions](https://github.com/futuroptimist/danielsmith.io/pkgs/container/charts%2Fdanielsmith) to confirm available immutable chart versions, and [the chart source](https://github.com/futuroptimist/danielsmith.io/tree/main/charts/danielsmith) to review the chart content that should match the pinned version.
 
 ```bash
 CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.version | head -n 1)
@@ -56,7 +78,7 @@ CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/danielsmith.v
 helm show chart oci://ghcr.io/futuroptimist/charts/danielsmith --version "$CHART_VERSION"
 ```
 
-If the chart changed, bump the chart version in the danielsmith.io app repo and publish it there with `ci-helm.yml`; do not republish a different chart under an existing OCI version.
+If the chart changed, bump the chart version in the danielsmith.io app repo and publish it there with [the chart workflow](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-helm.yml); do not republish a different chart under an existing OCI version.
 
 ```bash
 gh workflow run ci-helm.yml --repo futuroptimist/danielsmith.io --ref main

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -31,7 +31,7 @@ Use these links before changing a deployment so the workflow runs, package versi
 | Successful v3 image runs | [Successful v3 image workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml?query=branch%3Av3+is%3Asuccess) |
 | GHCR image package | [GHCR image package versions](https://github.com/democratizedspace/dspace/pkgs/container/dspace) |
 | Chart workflow | [Recent chart workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml) |
-| GHCR chart package | [GHCR chart package versions](https://github.com/orgs/democratizedspace/packages/container/package/charts%2Fdspace) |
+| GHCR chart package | No public package page is associated yet; use the [DSPACE GHCR package listing](https://github.com/orgs/democratizedspace/packages?repo_name=dspace) and `helm show chart` below until the chart package appears. |
 | Dockerfile | [Application Dockerfile](https://github.com/democratizedspace/dspace/blob/main/Dockerfile) |
 | Chart source | [Helm chart source](https://github.com/democratizedspace/dspace/tree/main/charts/dspace) |
 | App release guide | [Sugarkube release guide in the app repo](https://github.com/democratizedspace/dspace/blob/main/docs/ops/sugarkube-release.md) |
@@ -69,7 +69,7 @@ gh workflow run ci-image.yml --repo democratizedspace/dspace --ref main
 
 ## Confirm/publish OCI chart
 
-Sugarkube deploys the chart version pinned in `docs/apps/dspace.version`. Use [recent chart workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml) to find chart publish attempts, [GHCR chart package versions](https://github.com/orgs/democratizedspace/packages/container/package/charts%2Fdspace) to confirm available immutable chart versions, and [the chart source](https://github.com/democratizedspace/dspace/tree/main/charts/dspace) to review the chart content that should match the pinned version.
+Sugarkube deploys the chart version pinned in `docs/apps/dspace.version`. Use [recent chart workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml) to find chart publish attempts, `helm show chart` below to confirm available immutable chart versions, and [the chart source](https://github.com/democratizedspace/dspace/tree/main/charts/dspace) to review the chart content that should match the pinned version. The DSPACE OCI chart does not currently have an associated public GHCR package page; check the [DSPACE GHCR package listing](https://github.com/orgs/democratizedspace/packages?repo_name=dspace) until that package page appears.
 
 ```bash
 CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.version | head -n 1)

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -31,7 +31,7 @@ Use these links before changing a deployment so the workflow runs, package versi
 | Successful v3 image runs | [Successful v3 image workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml?query=branch%3Av3+is%3Asuccess) |
 | GHCR image package | [GHCR image package versions](https://github.com/democratizedspace/dspace/pkgs/container/dspace) |
 | Chart workflow | [Recent chart workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml) |
-| GHCR chart package | No public package page is associated yet; use the [DSPACE GHCR package listing](https://github.com/orgs/democratizedspace/packages?repo_name=dspace) and `helm show chart` below until the chart package appears. |
+| GHCR chart package | No public package page is associated yet; use the [DSPACE chart package lookup](https://github.com/orgs/democratizedspace/packages?repo_name=dspace&q=charts%2Fdspace) and `helm show chart` below until the chart package appears. |
 | Dockerfile | [Application Dockerfile](https://github.com/democratizedspace/dspace/blob/main/Dockerfile) |
 | Chart source | [Helm chart source](https://github.com/democratizedspace/dspace/tree/main/charts/dspace) |
 | App release guide | [Sugarkube release guide in the app repo](https://github.com/democratizedspace/dspace/blob/main/docs/ops/sugarkube-release.md) |
@@ -50,6 +50,7 @@ Find the successful image workflow in the DSPACE app repo and copy the immutable
 Web UI shortcuts:
 
 - Open [recent image workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml), [successful main image runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess), or [successful v3 image runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml?query=branch%3Av3+is%3Asuccess).
+  Consult `v3` in addition to `main` because the Raspberry Pi bootstrap helper still defaults `DSPACE_BRANCH` to `v3` for current DSPACE clones.
 - Open [GHCR image package versions](https://github.com/democratizedspace/dspace/pkgs/container/dspace).
 - Copy the immutable tag from a successful workflow summary or package version.
 
@@ -69,7 +70,7 @@ gh workflow run ci-image.yml --repo democratizedspace/dspace --ref main
 
 ## Confirm/publish OCI chart
 
-Sugarkube deploys the chart version pinned in `docs/apps/dspace.version`. Use [recent chart workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml) to find chart publish attempts, `helm show chart` below to confirm available immutable chart versions, and [the chart source](https://github.com/democratizedspace/dspace/tree/main/charts/dspace) to review the chart content that should match the pinned version. The DSPACE OCI chart does not currently have an associated public GHCR package page; check the [DSPACE GHCR package listing](https://github.com/orgs/democratizedspace/packages?repo_name=dspace) until that package page appears.
+Sugarkube deploys the chart version pinned in `docs/apps/dspace.version`. Use [recent chart workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml) to find chart publish attempts, `helm show chart` below to confirm available immutable chart versions, and [the chart source](https://github.com/democratizedspace/dspace/tree/main/charts/dspace) to review the chart content that should match the pinned version. The DSPACE OCI chart does not currently have an associated public GHCR package page; check the [DSPACE chart package lookup](https://github.com/orgs/democratizedspace/packages?repo_name=dspace&q=charts%2Fdspace) until that package page appears.
 
 ```bash
 CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.version | head -n 1)

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -19,6 +19,23 @@ This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugark
 | Production tag pin | `docs/apps/dspace.prod.tag` |
 | Verify paths | `/config.json`, `/healthz`, `/livez` |
 
+### Artifact links
+
+Use these links before changing a deployment so the workflow runs, package versions, and source paths all agree.
+
+| Artifact | Link |
+| --- | --- |
+| App repository | [DSPACE app repository](https://github.com/democratizedspace/dspace) |
+| Image workflow | [Recent image workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml) |
+| Successful main image runs | [Successful main image workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess) |
+| Successful v3 image runs | [Successful v3 image workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml?query=branch%3Av3+is%3Asuccess) |
+| GHCR image package | [GHCR image package versions](https://github.com/democratizedspace/dspace/pkgs/container/dspace) |
+| Chart workflow | [Recent chart workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml) |
+| GHCR chart package | [GHCR chart package versions](https://github.com/orgs/democratizedspace/packages/container/package/charts%2Fdspace) |
+| Dockerfile | [Application Dockerfile](https://github.com/democratizedspace/dspace/blob/main/Dockerfile) |
+| Chart source | [Helm chart source](https://github.com/democratizedspace/dspace/tree/main/charts/dspace) |
+| App release guide | [Sugarkube release guide in the app repo](https://github.com/democratizedspace/dspace/blob/main/docs/ops/sugarkube-release.md) |
+
 ## Environment topology
 
 - `env=dev`: future single-node/non-HA environment using `docs/examples/dspace.values.dev.yaml`.
@@ -28,7 +45,13 @@ This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugark
 
 ## Find or publish GHCR image
 
-Find the successful image workflow in the DSPACE app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, a bare branch name, or an environment name.
+Find the successful image workflow in the DSPACE app repo and copy the immutable branch-SHA or release tag. The GitHub Actions workflow page is where recent builds are found; the GHCR package page is where published image tags are cross-checked. Do not deploy `latest`, a bare branch name, or an environment name.
+
+Web UI shortcuts:
+
+- Open [recent image workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml), [successful main image runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess), or [successful v3 image runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-image.yml?query=branch%3Av3+is%3Asuccess).
+- Open [GHCR image package versions](https://github.com/democratizedspace/dspace/pkgs/container/dspace).
+- Copy the immutable tag from a successful workflow summary or package version.
 
 ```bash
 APP_TAG=main-REPLACE_SHORTSHA
@@ -46,7 +69,7 @@ gh workflow run ci-image.yml --repo democratizedspace/dspace --ref main
 
 ## Confirm/publish OCI chart
 
-Sugarkube deploys the chart version pinned in `docs/apps/dspace.version`.
+Sugarkube deploys the chart version pinned in `docs/apps/dspace.version`. Use [recent chart workflow runs](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml) to find chart publish attempts, [GHCR chart package versions](https://github.com/orgs/democratizedspace/packages/container/package/charts%2Fdspace) to confirm available immutable chart versions, and [the chart source](https://github.com/democratizedspace/dspace/tree/main/charts/dspace) to review the chart content that should match the pinned version.
 
 ```bash
 CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.version | head -n 1)
@@ -56,7 +79,7 @@ CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.versio
 helm show chart oci://ghcr.io/democratizedspace/charts/dspace --version "$CHART_VERSION"
 ```
 
-If the chart changed, bump the chart version in the DSPACE app repo and publish it there with `ci-helm.yml`; do not republish a different chart under an existing OCI version.
+If the chart changed, bump the chart version in the DSPACE app repo and publish it there with [the chart workflow](https://github.com/democratizedspace/dspace/actions/workflows/ci-helm.yml); do not republish a different chart under an existing OCI version.
 
 ```bash
 gh workflow run ci-helm.yml --repo democratizedspace/dspace --ref main

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -19,6 +19,22 @@ This is the canonical runbook for deploying token.place from GHCR artifacts to S
 | Production tag pin | `docs/apps/tokenplace.prod.tag` |
 | Verify paths | `/`, `/livez`, `/healthz`, `/relay/diagnostics` |
 
+### Artifact links
+
+Use these links before changing a deployment so the workflow runs, package versions, and source paths all agree.
+
+| Artifact | Link |
+| --- | --- |
+| App repository | [token.place app repository](https://github.com/futuroptimist/token.place) |
+| Image workflow | [Recent image workflow runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml) |
+| Successful main image runs | [Successful main image workflow runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess) |
+| GHCR image package | [GHCR image package versions](https://github.com/futuroptimist/token.place/pkgs/container/tokenplace-relay) |
+| Chart workflow | [Recent chart workflow runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml) |
+| GHCR chart package | [GHCR chart package versions](https://github.com/futuroptimist/token.place/pkgs/container/charts%2Ftokenplace) |
+| Dockerfile | [Application Dockerfile](https://github.com/futuroptimist/token.place/blob/main/Dockerfile) |
+| Chart source | [Helm chart source](https://github.com/futuroptimist/token.place/tree/main/charts/tokenplace) |
+| App release guide | [Sugarkube release guide in the app repo](https://github.com/futuroptimist/token.place/blob/main/docs/ops/sugarkube-release.md) |
+
 ## Environment topology
 
 - `env=dev`: local/dev defaults using `docs/examples/tokenplace.values.dev.yaml`.
@@ -28,7 +44,13 @@ This is the canonical runbook for deploying token.place from GHCR artifacts to S
 
 ## Find or publish GHCR image
 
-Find the successful image workflow in the token.place app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, a bare branch name, or an environment name.
+Find the successful image workflow in the token.place app repo and copy the immutable branch-SHA or release tag. The GitHub Actions workflow page is where recent builds are found; the GHCR package page is where published image tags are cross-checked. Do not deploy `latest`, a bare branch name, or an environment name.
+
+Web UI shortcuts:
+
+- Open [recent image workflow runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml) or [successful main image runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess).
+- Open [GHCR image package versions](https://github.com/futuroptimist/token.place/pkgs/container/tokenplace-relay).
+- Copy the immutable tag from a successful workflow summary or package version.
 
 ```bash
 APP_TAG=main-REPLACE_SHORTSHA
@@ -46,7 +68,7 @@ gh workflow run ci-image.yml --repo futuroptimist/token.place --ref main
 
 ## Confirm/publish OCI chart
 
-Sugarkube deploys the chart version pinned in `docs/apps/tokenplace.version`.
+Sugarkube deploys the chart version pinned in `docs/apps/tokenplace.version`. Use [recent chart workflow runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml) to find chart publish attempts, [GHCR chart package versions](https://github.com/futuroptimist/token.place/pkgs/container/charts%2Ftokenplace) to confirm available immutable chart versions, and [the chart source](https://github.com/futuroptimist/token.place/tree/main/charts/tokenplace) to review the chart content that should match the pinned version.
 
 ```bash
 CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.version | head -n 1)
@@ -56,7 +78,7 @@ CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.ve
 helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$CHART_VERSION"
 ```
 
-If the chart changed, bump the chart version in the token.place app repo and publish it there with `ci-helm.yml`; do not republish a different chart under an existing OCI version.
+If the chart changed, bump the chart version in the token.place app repo and publish it there with [the chart workflow](https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml); do not republish a different chart under an existing OCI version.
 
 ```bash
 gh workflow run ci-helm.yml --repo futuroptimist/token.place --ref main

--- a/tests/test_app_runbook_links.py
+++ b/tests/test_app_runbook_links.py
@@ -1,0 +1,121 @@
+"""Offline checks for app runbook artifact-discovery links."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+DSPACE_REPO = "https://github.com/democratizedspace/dspace"
+TOKENPLACE_REPO = "https://github.com/futuroptimist/token.place"
+DANIELSMITH_REPO = "https://github.com/futuroptimist/danielsmith.io"
+
+APP_LINKS = {
+    "dspace": {
+        "runbook": "docs/apps/dspace.md",
+        "urls": [
+            DSPACE_REPO,
+            f"{DSPACE_REPO}/actions/workflows/ci-image.yml",
+            f"{DSPACE_REPO}/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess",
+            f"{DSPACE_REPO}/actions/workflows/ci-image.yml?query=branch%3Av3+is%3Asuccess",
+            f"{DSPACE_REPO}/pkgs/container/dspace",
+            f"{DSPACE_REPO}/actions/workflows/ci-helm.yml",
+            "https://github.com/orgs/democratizedspace/packages/container/package/charts%2Fdspace",
+            f"{DSPACE_REPO}/blob/main/Dockerfile",
+            f"{DSPACE_REPO}/tree/main/charts/dspace",
+            f"{DSPACE_REPO}/blob/main/docs/ops/sugarkube-release.md",
+        ],
+    },
+    "tokenplace": {
+        "runbook": "docs/apps/tokenplace.md",
+        "urls": [
+            TOKENPLACE_REPO,
+            f"{TOKENPLACE_REPO}/actions/workflows/ci-image.yml",
+            f"{TOKENPLACE_REPO}/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess",
+            f"{TOKENPLACE_REPO}/pkgs/container/tokenplace-relay",
+            f"{TOKENPLACE_REPO}/actions/workflows/ci-helm.yml",
+            f"{TOKENPLACE_REPO}/pkgs/container/charts%2Ftokenplace",
+            f"{TOKENPLACE_REPO}/blob/main/Dockerfile",
+            f"{TOKENPLACE_REPO}/tree/main/charts/tokenplace",
+            f"{TOKENPLACE_REPO}/blob/main/docs/ops/sugarkube-release.md",
+        ],
+    },
+    "danielsmith": {
+        "runbook": "docs/apps/danielsmith.md",
+        "urls": [
+            DANIELSMITH_REPO,
+            f"{DANIELSMITH_REPO}/actions/workflows/ci-image.yml",
+            f"{DANIELSMITH_REPO}/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess",
+            f"{DANIELSMITH_REPO}/pkgs/container/danielsmith.io",
+            f"{DANIELSMITH_REPO}/actions/workflows/ci-helm.yml",
+            f"{DANIELSMITH_REPO}/pkgs/container/charts%2Fdanielsmith",
+            f"{DANIELSMITH_REPO}/blob/main/Dockerfile",
+            f"{DANIELSMITH_REPO}/tree/main/charts/danielsmith",
+            f"{DANIELSMITH_REPO}/blob/main/docs/ops/sugarkube-release.md",
+        ],
+    },
+}
+
+README_QUICK_LINKS = {
+    "dspace": [
+        "docs/apps/dspace.md",
+        f"{DSPACE_REPO}/actions/workflows/ci-image.yml",
+        f"{DSPACE_REPO}/pkgs/container/dspace",
+        f"{DSPACE_REPO}/actions/workflows/ci-helm.yml",
+        "https://github.com/orgs/democratizedspace/packages/container/package/charts%2Fdspace",
+    ],
+    "tokenplace": [
+        "docs/apps/tokenplace.md",
+        f"{TOKENPLACE_REPO}/actions/workflows/ci-image.yml",
+        f"{TOKENPLACE_REPO}/pkgs/container/tokenplace-relay",
+        f"{TOKENPLACE_REPO}/actions/workflows/ci-helm.yml",
+        f"{TOKENPLACE_REPO}/pkgs/container/charts%2Ftokenplace",
+    ],
+    "danielsmith": [
+        "docs/apps/danielsmith.md",
+        f"{DANIELSMITH_REPO}/actions/workflows/ci-image.yml",
+        f"{DANIELSMITH_REPO}/pkgs/container/danielsmith.io",
+        f"{DANIELSMITH_REPO}/actions/workflows/ci-helm.yml",
+        f"{DANIELSMITH_REPO}/pkgs/container/charts%2Fdanielsmith",
+    ],
+}
+
+REQUIRED_DISCOVERY_TERMS = [
+    "app repository",
+    "image workflow",
+    "GHCR image package",
+    "chart workflow",
+    "GHCR chart package",
+    "Dockerfile",
+    "chart source path",
+    "release guide",
+]
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_app_runbooks_include_artifact_link_matrix() -> None:
+    for app, expected in APP_LINKS.items():
+        text = _read(expected["runbook"])
+        assert "### Artifact links" in text, f"{app} runbook needs an artifact links table"
+        assert "Web UI shortcuts:" in text, f"{app} runbook needs image shortcuts"
+        for url in expected["urls"]:
+            assert url in text, f"{url} missing from {expected['runbook']}"
+
+
+def test_readme_application_runbooks_include_quick_artifact_links() -> None:
+    readme = _read("README.md")
+    for app, urls in README_QUICK_LINKS.items():
+        for url in urls:
+            assert url in readme, f"README app runbooks section missing {app} link {url}"
+
+
+def test_contract_and_onboarding_require_artifact_discovery_links() -> None:
+    contract = _read("docs/app_deployment_contract.md")
+    onboarding = _read("docs/app_onboarding.md")
+    combined = f"{contract}\n{onboarding}"
+    assert "Artifact discovery links" in contract
+    for term in REQUIRED_DISCOVERY_TERMS:
+        assert term in combined, f"artifact discovery checklist missing {term!r}"

--- a/tests/test_app_runbook_links.py
+++ b/tests/test_app_runbook_links.py
@@ -9,9 +9,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DSPACE_REPO = "https://github.com/democratizedspace/dspace"
 TOKENPLACE_REPO = "https://github.com/futuroptimist/token.place"
 DANIELSMITH_REPO = "https://github.com/futuroptimist/danielsmith.io"
-DSPACE_GHCR_PACKAGE_LIST = (
+DSPACE_CHART_PACKAGE_LOOKUP = (
     "https://github.com/orgs/democratizedspace/"
-    "packages?repo_name=dspace"
+    "packages?repo_name=dspace&q=charts%2Fdspace"
 )
 BROKEN_DSPACE_CHART_PACKAGE_URL = (
     "https://github.com/orgs/democratizedspace/packages/"
@@ -28,7 +28,7 @@ APP_LINKS = {
             f"{DSPACE_REPO}/actions/workflows/ci-image.yml?query=branch%3Av3+is%3Asuccess",
             f"{DSPACE_REPO}/pkgs/container/dspace",
             f"{DSPACE_REPO}/actions/workflows/ci-helm.yml",
-            DSPACE_GHCR_PACKAGE_LIST,
+            DSPACE_CHART_PACKAGE_LOOKUP,
             f"{DSPACE_REPO}/blob/main/Dockerfile",
             f"{DSPACE_REPO}/tree/main/charts/dspace",
             f"{DSPACE_REPO}/blob/main/docs/ops/sugarkube-release.md",
@@ -70,7 +70,7 @@ README_QUICK_LINKS = {
         f"{DSPACE_REPO}/actions/workflows/ci-image.yml",
         f"{DSPACE_REPO}/pkgs/container/dspace",
         f"{DSPACE_REPO}/actions/workflows/ci-helm.yml",
-        DSPACE_GHCR_PACKAGE_LIST,
+        DSPACE_CHART_PACKAGE_LOOKUP,
     ],
     "tokenplace": [
         "docs/apps/tokenplace.md",
@@ -127,10 +127,26 @@ def test_dspace_docs_do_not_link_missing_chart_package_page() -> None:
         assert "chart package page pending" in text or "No public package page" in text
 
 
-def test_contract_and_onboarding_require_artifact_discovery_links() -> None:
+ONBOARDING_DISCOVERY_FIELDS = [
+    "App repo URL",
+    "Image workflow URL",
+    "GHCR image package URL",
+    "Chart workflow URL",
+    "GHCR chart package URL",
+    "Dockerfile/source image path URL",
+    "Chart source URL",
+    "App-repo release guide URL, when present",
+]
+
+
+def test_contract_requires_artifact_discovery_links() -> None:
     contract = _read("docs/app_deployment_contract.md")
-    onboarding = _read("docs/app_onboarding.md")
-    combined = f"{contract}\n{onboarding}"
     assert "Artifact discovery links" in contract
     for term in REQUIRED_DISCOVERY_TERMS:
-        assert term in combined, f"artifact discovery checklist missing {term!r}"
+        assert term in contract, f"contract artifact discovery list missing {term!r}"
+
+
+def test_onboarding_intake_asserts_artifact_fields_separately() -> None:
+    onboarding = _read("docs/app_onboarding.md")
+    for field in ONBOARDING_DISCOVERY_FIELDS:
+        assert field in onboarding, f"onboarding intake missing {field!r}"

--- a/tests/test_app_runbook_links.py
+++ b/tests/test_app_runbook_links.py
@@ -9,6 +9,14 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DSPACE_REPO = "https://github.com/democratizedspace/dspace"
 TOKENPLACE_REPO = "https://github.com/futuroptimist/token.place"
 DANIELSMITH_REPO = "https://github.com/futuroptimist/danielsmith.io"
+DSPACE_GHCR_PACKAGE_LIST = (
+    "https://github.com/orgs/democratizedspace/"
+    "packages?repo_name=dspace"
+)
+BROKEN_DSPACE_CHART_PACKAGE_URL = (
+    "https://github.com/orgs/democratizedspace/packages/"
+    "container/package/charts%2Fdspace"
+)
 
 APP_LINKS = {
     "dspace": {
@@ -20,7 +28,7 @@ APP_LINKS = {
             f"{DSPACE_REPO}/actions/workflows/ci-image.yml?query=branch%3Av3+is%3Asuccess",
             f"{DSPACE_REPO}/pkgs/container/dspace",
             f"{DSPACE_REPO}/actions/workflows/ci-helm.yml",
-            "https://github.com/orgs/democratizedspace/packages/container/package/charts%2Fdspace",
+            DSPACE_GHCR_PACKAGE_LIST,
             f"{DSPACE_REPO}/blob/main/Dockerfile",
             f"{DSPACE_REPO}/tree/main/charts/dspace",
             f"{DSPACE_REPO}/blob/main/docs/ops/sugarkube-release.md",
@@ -62,7 +70,7 @@ README_QUICK_LINKS = {
         f"{DSPACE_REPO}/actions/workflows/ci-image.yml",
         f"{DSPACE_REPO}/pkgs/container/dspace",
         f"{DSPACE_REPO}/actions/workflows/ci-helm.yml",
-        "https://github.com/orgs/democratizedspace/packages/container/package/charts%2Fdspace",
+        DSPACE_GHCR_PACKAGE_LIST,
     ],
     "tokenplace": [
         "docs/apps/tokenplace.md",
@@ -110,6 +118,13 @@ def test_readme_application_runbooks_include_quick_artifact_links() -> None:
     for app, urls in README_QUICK_LINKS.items():
         for url in urls:
             assert url in readme, f"README app runbooks section missing {app} link {url}"
+
+
+def test_dspace_docs_do_not_link_missing_chart_package_page() -> None:
+    for relative_path in ("docs/apps/dspace.md", "README.md"):
+        text = _read(relative_path)
+        assert BROKEN_DSPACE_CHART_PACKAGE_URL not in text
+        assert "chart package page pending" in text or "No public package page" in text
 
 
 def test_contract_and_onboarding_require_artifact_discovery_links() -> None:


### PR DESCRIPTION
### Motivation

- Operators should open exact app workflow runs and GHCR package pages directly from Sugarkube docs rather than manually searching GitHub. 
- The runbooks needed a compact, consistent artifact-discovery surface (image workflow, image package, chart workflow, chart package, Dockerfile/chart source, and release guide) so promotion and verification are faster and less error-prone.
- The onboarding/contract docs should require these links so future apps are immediately discoverable.

### Description

- Added an "Artifact links" table and Web UI shortcuts to each runbook: `docs/apps/dspace.md`, `docs/apps/tokenplace.md`, and `docs/apps/danielsmith.md`, linking to app repo, image workflow (and successful main/v3 runs for DSPACE), GHCR image package, chart workflow, GHCR chart package, Dockerfile, chart source, and app repo Sugarkube release guide when present.
- Improved the "Find or publish GHCR image" sections with explicit Web UI shortcuts and retained the existing `gh run list` and `gh workflow run` commands.
- Improved the "Confirm/publish OCI chart" sections with direct links to the chart workflow, GHCR chart package versions page, and chart source while keeping `helm show chart` and `gh workflow run ci-helm.yml` commands unchanged.
- Updated `README.md` application runbooks section with compact per-app quick links for image workflow, image package, chart workflow, and chart package.
- Added an "Artifact discovery links" subsection to `docs/app_deployment_contract.md` and required artifact discovery links and additional checklist fields in `docs/app_onboarding.md` so future apps must include these links.
- Added an offline-only regression test `tests/test_app_runbook_links.py` that verifies each app runbook, the README, and the contract/onboarding docs include the expected links and terms; the test is network-free and reads local files only.
- No deployment behavior or runtime code was changed; shell commands in docs remain copy-pasteable.

### Testing

- Ran `python -m pytest tests/test_app_runbook_links.py -q` and the new offline checks passed (`3 passed`).
- Ran full test suite `python -m pytest tests -q` and it passed on this branch (`1256 passed, 19 skipped` in local run reported).
- Ran docs checks: `bash scripts/checks.sh --docs-only`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/`, all succeeded for the modified docs.
- Verified presence of expected link patterns with ripgrep: `rg "actions/workflows/ci-image.yml"`, `rg "actions/workflows/ci-helm.yml"`, and `rg "pkgs/container"` across README and docs; results contain the new links.
- Ran `git diff --check` and secret-scan `git diff | ./scripts/scan-secrets.py` with no issues reported for the changed files.
- `pre-commit run --all-files` was attempted but fails on unrelated, pre-existing repository-wide issues (trailing-whitespace/end-of-file fixes, templated multi-document YAML flagged by `check-yaml`, and existing E501/E303 lint findings); these are outside the scope of this docs-only PR and were not changed as part of this change.

If reviewers want, follow-ups could (a) expand the onboarding checklist examples to include new apps, (b) add additional app runbooks using the same template, or (c) address the unrelated global `pre-commit` findings in a separate PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f94dcc39c832f914615a14b6b9c1d)