### PR TITLE
Make `just app-verify` execute HTTP checks

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -146,7 +146,7 @@ Required keys for the generic recipes:
 | `SUGARKUBE_VALUES_STAGING` | Values chain for `env=staging`. |
 | `SUGARKUBE_VALUES_PROD` | Values chain for `env=prod`. |
 | `SUGARKUBE_STATUS_HOST_KEY` | Dotted Helm values key used to discover the public host. |
-| `SUGARKUBE_VERIFY_PATHS` | Comma-separated HTTP paths for post-deploy verification. |
+| `SUGARKUBE_VERIFY_PATHS` | Comma-separated HTTP paths that `just app-verify` executes for post-deploy verification. |
 | `SUGARKUBE_DEBUG_SELECTOR` | Kubernetes label selector for app pod logs/debugging. |
 
 Example local setup:
@@ -175,8 +175,12 @@ just app-promote-prod app=dspace tag=main-REPLACE_SHORTSHA
 # Inspect Kubernetes and Helm status for an app environment.
 just app-status app=dspace env=staging
 
-# Run HTTP verification paths for an app environment.
+# Execute configured HTTP verification paths for an app environment.
+# This prints a per-path report and exits non-zero if any check fails.
 just app-verify app=dspace env=staging
+
+# Print the curl commands without executing them for docs/debugging.
+just app-verify app=dspace env=staging print_only=1
 
 # Print the resolved app config for review/debugging.
 just app-config app=dspace env=staging

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -191,7 +191,7 @@ just tokenplace-rollback release=appslug namespace=appslug revision="$HELM_REVIS
 
 ## First-run smoke check pattern
 
-Start with generic checks.
+Start with generic checks. `just app-verify` discovers the public host, executes configured HTTP checks, prints a per-path report, and exits non-zero if any path fails.
 
 ```bash
 just app-status app=appslug env=staging config="$APP_CONFIG"
@@ -199,6 +199,12 @@ just app-status app=appslug env=staging config="$APP_CONFIG"
 
 ```bash
 just app-verify app=appslug env=staging config="$APP_CONFIG"
+```
+
+For documentation or debugging without network execution, print the generated curl commands instead.
+
+```bash
+just app-verify app=appslug env=staging config="$APP_CONFIG" print_only=1
 ```
 
 Add app-specific checks only for behavior the generic URL checks cannot validate, such as a login-free API health endpoint, a static asset manifest, a queue worker heartbeat, or a safe diagnostics endpoint.

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -108,6 +108,10 @@ just app-status app=danielsmith env=staging
 just app-verify app=danielsmith env=staging
 ```
 
+`just app-verify` executes the configured public HTTP checks, prints a per-path URL/status/body preview report, and exits non-zero after attempting every path if any check fails. To print the generated curl commands without executing them, run `just app-verify app=danielsmith env=staging print_only=1`.
+
+Manual public checks are optional fallback/troubleshooting when host discovery, Cloudflare, or cert-manager are suspect.
+
 ```bash
 curl -fsS https://staging.danielsmith.io/healthz
 ```
@@ -143,6 +147,10 @@ just app-status app=danielsmith env=prod
 ```bash
 just app-verify app=danielsmith env=prod
 ```
+
+For command generation only, use `just app-verify app=danielsmith env=prod print_only=1`.
+
+Optional manual fallback:
 
 ```bash
 curl -fsS https://danielsmith.io/healthz

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -102,7 +102,7 @@ just dspace-oci-deploy env=staging tag="$APP_TAG"
 
 ## Verify staging
 
-Generic verification discovers the host from Helm values or Ingress and checks the configured DSPACE paths.
+Generic verification discovers the host from Helm values or Ingress, executes the configured DSPACE paths, prints a readable report, and fails if any path fails.
 
 ```bash
 just app-status app=dspace env=staging
@@ -112,7 +112,9 @@ just app-status app=dspace env=staging
 just app-verify app=dspace env=staging
 ```
 
-Manual public checks are useful when Cloudflare or cert-manager are suspect.
+`just app-verify` executes the configured public HTTP checks, prints a per-path URL/status/body preview report, and exits non-zero after attempting every path if any check fails. To print the generated curl commands without executing them, run `just app-verify app=dspace env=staging print_only=1`.
+
+Manual public checks are optional fallback/troubleshooting when host discovery, Cloudflare, or cert-manager are suspect.
 
 ```bash
 curl -fsS https://staging.democratized.space/config.json | jq .
@@ -149,6 +151,10 @@ just app-status app=dspace env=prod
 ```bash
 just app-verify app=dspace env=prod
 ```
+
+For command generation only, use `just app-verify app=dspace env=prod print_only=1`.
+
+Optional manual fallback:
 
 ```bash
 curl -fsS https://democratized.space/config.json | jq .

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -108,6 +108,10 @@ just app-status app=tokenplace env=staging
 just app-verify app=tokenplace env=staging
 ```
 
+`just app-verify` executes the configured public HTTP checks, prints a per-path URL/status/body preview report, and exits non-zero after attempting every path if any check fails. To print the generated curl commands without executing them, run `just app-verify app=tokenplace env=staging print_only=1`.
+
+Manual public checks are optional fallback/troubleshooting when host discovery, Cloudflare, or cert-manager are suspect.
+
 ```bash
 curl -fsS https://staging.token.place/healthz
 ```
@@ -153,6 +157,10 @@ just app-status app=tokenplace env=prod
 ```bash
 just app-verify app=tokenplace env=prod
 ```
+
+For command generation only, use `just app-verify app=tokenplace env=prod print_only=1`.
+
+Optional manual fallback:
 
 ```bash
 curl -fsS https://token.place/healthz

--- a/justfile
+++ b/justfile
@@ -1593,14 +1593,27 @@ app-promote-prod app tag='' config='':
       config="${SUGARKUBE_CONFIG_PATH}"
 
 # Verify configured HTTPS paths for a Sugarkube app.
-app-verify app env='staging' config='':
+app-verify app env='staging' config='' print_only='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
+
+    config_input={{ quote(config) }}
+    print_only_input={{ quote(print_only) }}
+    while [ "${config_input#config=}" != "${config_input}" ]; do
+      config_input="${config_input#config=}"
+    done
+    if [ "${config_input#print_only=}" != "${config_input}" ]; then
+      print_only_input="${config_input}"
+      config_input=""
+    fi
+    while [ "${print_only_input#print_only=}" != "${print_only_input}" ]; do
+      print_only_input="${print_only_input#print_only=}"
+    done
 
     eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
       --app {{ quote(app) }} \
       --env {{ quote(env) }} \
-      --config {{ quote(config) }})"
+      --config "${config_input}")"
 
     if [ -z "${KUBECONFIG:-}" ]; then
       export KUBECONFIG="${HOME}/.kube/config"
@@ -1608,6 +1621,10 @@ app-verify app env='staging' config='':
     kube_context="sugar-${SUGARKUBE_ENV}"
     kubectl_context_args=(--context "${kube_context}")
     helm_context_args=(--kube-context "${kube_context}")
+    print_only_mode=0
+    case "${print_only_input:-${SUGARKUBE_APP_VERIFY_PRINT_ONLY:-0}}" in
+      1|true|TRUE|yes|YES|on|ON) print_only_mode=1 ;;
+    esac
 
     host=""
     discovery_errors=()
@@ -1633,24 +1650,36 @@ app-verify app env='staging' config='':
       rm -f "${kubectl_error}"
     fi
 
-    IFS=',' read -r -a paths <<< "${SUGARKUBE_VERIFY_PATHS:-/}"
     if [ -z "${host}" ]; then
+      printf 'Could not derive a host for %s using context %s.\n' "${SUGARKUBE_APP}" "${kube_context}" >&2
       if [ "${#discovery_errors[@]}" -gt 0 ]; then
-        printf 'Could not derive a host for %s using context %s.\n' "${SUGARKUBE_APP}" "${kube_context}" >&2
         printf '%s\n' "${discovery_errors[@]}" >&2
-        exit 1
       fi
-      echo "Could not derive a host for ${SUGARKUBE_APP}; run these commands after replacing <host>:" >&2
-      for path in "${paths[@]}"; do
-        printf '  curl -fsS https://<host>%s\n' "${path}"
-      done
-      exit 0
+      printf 'Run just app-status app=%s env=%s or just app-config app=%s env=%s for discovery details.\n' \
+        "${SUGARKUBE_APP}" "${SUGARKUBE_ENV}" "${SUGARKUBE_APP}" "${SUGARKUBE_ENV}" >&2
+      printf 'Manual commands after replacing <host>:\n' >&2
+      python3 "{{ justfile_directory() }}/scripts/app_verify.py" \
+        --app "${SUGARKUBE_APP}" \
+        --env "${SUGARKUBE_ENV}" \
+        --host '<host>' \
+        --paths "${SUGARKUBE_VERIFY_PATHS:-/}" \
+        --print-only
+      if [ "${print_only_mode}" = "1" ]; then
+        exit 0
+      fi
+      exit 1
     fi
 
-    for path in "${paths[@]}"; do
-      printf 'curl -fsS https://%s%s\n' "${host}" "${path}"
-      curl -fsS "https://${host}${path}" >/dev/null
-    done
+    verify_args=(
+      --app "${SUGARKUBE_APP}"
+      --env "${SUGARKUBE_ENV}"
+      --host "${host}"
+      --paths "${SUGARKUBE_VERIFY_PATHS:-/}"
+    )
+    if [ "${print_only_mode}" = "1" ]; then
+      verify_args+=(--print-only)
+    fi
+    python3 "{{ justfile_directory() }}/scripts/app_verify.py" "${verify_args[@]}"
 
 # Opinionated immutable-tag dspace deploy with rollout verification.
 #

--- a/scripts/app_verify.py
+++ b/scripts/app_verify.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Run Sugarkube app HTTP verification checks with operator-friendly output."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+DEFAULT_PREVIEW_BYTES = 4000
+DEFAULT_PREVIEW_LINES = 40
+
+
+def truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def split_paths(raw_paths: str) -> list[str]:
+    paths = []
+    for raw in (raw_paths or "/").split(","):
+        path = raw.strip() or "/"
+        if not path.startswith("/"):
+            path = f"/{path}"
+        paths.append(path)
+    return paths or ["/"]
+
+
+def base_url(host: str) -> str:
+    host = host.strip().rstrip("/")
+    if host.startswith(("http://", "https://")):
+        return host
+    return f"https://{host}"
+
+
+def preview_body(body: bytes, byte_limit: int, line_limit: int) -> tuple[str, bool]:
+    limited = body[:byte_limit]
+    truncated = len(body) > byte_limit
+    text = limited.decode("utf-8", errors="replace")
+    lines = text.splitlines()
+    if len(lines) > line_limit:
+        text = "\n".join(lines[:line_limit])
+        truncated = True
+    return text, truncated
+
+
+def print_body(body: bytes, *, ok: bool) -> None:
+    if not truthy(os.environ.get("SUGARKUBE_APP_VERIFY_SHOW_BODY", "1")):
+        return
+    try:
+        byte_limit = int(
+            os.environ.get("SUGARKUBE_APP_VERIFY_BODY_PREVIEW_BYTES", DEFAULT_PREVIEW_BYTES)
+        )
+    except ValueError:
+        byte_limit = DEFAULT_PREVIEW_BYTES
+    try:
+        line_limit = int(
+            os.environ.get("SUGARKUBE_APP_VERIFY_BODY_PREVIEW_LINES", DEFAULT_PREVIEW_LINES)
+        )
+    except ValueError:
+        line_limit = DEFAULT_PREVIEW_LINES
+    byte_limit = max(0, byte_limit)
+    line_limit = max(0, line_limit)
+    text, truncated = preview_body(body, byte_limit, line_limit)
+    label = "Body preview:" if truncated else "Body:"
+    print(f"  {label}")
+    if text:
+        for line in text.splitlines() or [text]:
+            print(f"  {line}")
+    else:
+        print("  (empty)")
+    if truncated:
+        print("  ...")
+    # Keep a visual break after even empty failure bodies.
+    if not ok and not text and not truncated:
+        return
+
+
+def curl_check(url: str) -> tuple[int, str, bytes, str]:
+    with tempfile.NamedTemporaryFile(delete=False) as body_file:
+        body_path = Path(body_file.name)
+    try:
+        command = ["curl", "-sS", "-L", "-o", str(body_path), "-w", "%{http_code}", url]
+        completed = subprocess.run(command, capture_output=True, text=True, check=False)
+        body = body_path.read_bytes() if body_path.exists() else b""
+        return completed.returncode, completed.stdout.strip(), body, completed.stderr.strip()
+    finally:
+        try:
+            body_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def is_http_success(http_status: str) -> bool:
+    try:
+        code = int(http_status)
+    except ValueError:
+        return False
+    return 200 <= code < 400
+
+
+def shell_quote_url(url: str) -> str:
+    # Verification URLs come from public host/path config. Keep old readable output for normal URLs,
+    # but quote defensively if an unusual character appears.
+    safe_chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    safe_chars += "-._~:/?#[]@!$&'()*+,;=%<>"
+    safe = set(safe_chars)
+    if all(ch in safe for ch in url):
+        return url
+    return "'" + url.replace("'", "'\\''") + "'"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--app", required=True)
+    parser.add_argument("--env", required=True)
+    parser.add_argument("--host", required=True)
+    parser.add_argument("--paths", default="/")
+    parser.add_argument("--print-only", action="store_true")
+    args = parser.parse_args(argv)
+
+    paths = split_paths(args.paths)
+    root = base_url(args.host)
+    urls = [(path, f"{root}{path}") for path in paths]
+
+    if args.print_only:
+        for _, url in urls:
+            print(f"curl -fsS {shell_quote_url(url)}")
+        return 0
+
+    print(f"Verifying {args.app} env={args.env}")
+    print(f"Host: {root}")
+
+    failures: list[str] = []
+    total = len(urls)
+    for index, (path, url) in enumerate(urls, start=1):
+        print()
+        print(f"[{index}/{total}] GET {path}")
+        print(f"  URL: {url}")
+        curl_exit, http_status, body, stderr = curl_check(url)
+        ok = curl_exit == 0 and is_http_success(http_status)
+        print(f"  Status: {'OK' if ok else 'FAILED'}")
+        if http_status:
+            print(f"  HTTP status: {http_status}")
+        if not ok:
+            print(f"  curl exit status: {curl_exit}")
+            if stderr:
+                print("  curl stderr:")
+                for line in stderr.splitlines():
+                    print(f"  {line}")
+            failures.append(path)
+        print_body(body, ok=ok)
+
+    print()
+    passed = total - len(failures)
+    if failures:
+        print(f"Verification failed: {passed}/{total} checks succeeded.")
+        print("Failing paths: " + ", ".join(failures))
+        return 1
+    print(f"Verification passed: {total}/{total} checks succeeded.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -359,6 +359,18 @@ def test_main_supports_json_shell_validate_tag_and_host_value(
     assert "export SUGARKUBE_TAG=main-deadbee" in capsys.readouterr().out
 
 
+def test_example_app_configs_preserve_verification_paths() -> None:
+    expected = {
+        "danielsmith": "/,/livez,/healthz",
+        "tokenplace": "/,/livez,/healthz,/relay/diagnostics",
+        "dspace": "/config.json,/healthz,/livez",
+    }
+
+    for app, paths in expected.items():
+        config = app_config.load_config(app, "staging")
+        assert config["SUGARKUBE_VERIFY_PATHS"] == paths
+
+
 def test_main_reports_config_errors(capsys: pytest.CaptureFixture[str]) -> None:
     assert app_config.main(["json", "--app", "missing", "--env", "staging"]) == 2
     assert "ERROR: no config found for app 'missing'" in capsys.readouterr().err

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -102,8 +102,37 @@ exit 0
     )
     _write_executable(
         bin_dir / "curl",
-        """#!/usr/bin/env bash
+        f"""#!/usr/bin/env bash
 set -euo pipefail
+printf '%s\n' "$*" >> {str(tmp_path / "curl.log")!r}
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -w) shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+url_without_scheme="${{url#*://}}"
+if [ "${{url_without_scheme#*/}}" = "${{url_without_scheme}}" ]; then
+  path="/"
+else
+  path="/${{url_without_scheme#*/}}"
+fi
+if [ "${{SUGARKUBE_STUB_CURL_FAIL_PATH:-}}" = "${{path}}" ]; then
+  printf '{{"status":"fail"}}\n' > "${{out}}"
+  printf '503'
+  exit 0
+fi
+case "${{path}}" in
+  /) printf '<!doctype html>\n<html lang="en">\n<body>ok</body>\n</html>\n' > "${{out}}" ;;
+  /config.json) printf '{{"app":"dspace"}}\n' > "${{out}}" ;;
+  /relay/diagnostics) printf '{{"relay":"ok"}}\n' > "${{out}}" ;;
+  *) printf '{{"status":"ok"}}\n' > "${{out}}" ;;
+esac
+printf '200'
 exit 0
 """,
     )
@@ -114,6 +143,7 @@ exit 0
     env["SUGARKUBE_HELM_ROLLOUT_TIMEOUT"] = "1s"
     env["HELM_LOG"] = str(log_path)
     env["KUBECTL_LOG"] = str(tmp_path / "kubectl.log")
+    env["CURL_LOG"] = str(tmp_path / "curl.log")
     return env
 
 
@@ -318,7 +348,7 @@ def test_app_status_does_not_rewrite_kubeconfig_for_read_only_checks(
 
 
 @pytest.mark.usefixtures("ensure_just_available")
-def test_app_verify_does_not_rewrite_kubeconfig_for_read_only_checks(
+def test_app_verify_executes_checks_with_readable_output_and_preserves_kubeconfig(
     generic_app_stub_env: dict[str, str],
 ) -> None:
     result = _run_just(["app-verify", "app=tokenplace", "env=staging"], generic_app_stub_env)
@@ -327,6 +357,72 @@ def test_app_verify_does_not_rewrite_kubeconfig_for_read_only_checks(
     assert not (Path(generic_app_stub_env["HOME"]) / ".kube" / "config").exists()
     helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
     assert "--kube-context sugar-staging" in helm_log
+    curl_log = Path(generic_app_stub_env["CURL_LOG"]).read_text(encoding="utf-8")
+    assert "https://example.test/" in curl_log
+    assert "https://example.test/livez" in curl_log
+    assert "https://example.test/healthz" in curl_log
+    assert "https://example.test/relay/diagnostics" in curl_log
+    assert "Verifying tokenplace env=staging" in result.stdout
+    assert "Host: https://example.test" in result.stdout
+    assert "\n[1/4] GET /\n  URL: https://example.test/\n  Status: OK" in result.stdout
+    assert "\n[2/4] GET /livez" in result.stdout
+    assert "  Body:" in result.stdout
+    assert "Verification passed: 4/4 checks succeeded." in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_continues_all_paths_and_fails_at_end(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_CURL_FAIL_PATH"] = "/livez"
+
+    result = _run_just(["app-verify", "app=tokenplace", "env=staging"], env)
+
+    assert result.returncode != 0
+    curl_log = Path(env["CURL_LOG"]).read_text(encoding="utf-8")
+    assert "https://example.test/" in curl_log
+    assert "https://example.test/livez" in curl_log
+    assert "https://example.test/healthz" in curl_log
+    assert "https://example.test/relay/diagnostics" in curl_log
+    assert "[2/4] GET /livez" in result.stdout
+    assert "  Status: FAILED" in result.stdout
+    assert "  HTTP status: 503" in result.stdout
+    assert "Verification failed: 3/4 checks succeeded." in result.stdout
+    assert "Failing paths: /livez" in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_print_only_prints_curl_commands_without_calling_curl(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        ["app-verify", "app=danielsmith", "env=staging", "print_only=1"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert result.stdout.splitlines() == [
+        "curl -fsS https://example.test/",
+        "curl -fsS https://example.test/livez",
+        "curl -fsS https://example.test/healthz",
+    ]
+    curl_log_path = Path(generic_app_stub_env["CURL_LOG"])
+    assert not curl_log_path.exists() or curl_log_path.read_text(encoding="utf-8") == ""
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_can_suppress_response_bodies(generic_app_stub_env: dict[str, str]) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_APP_VERIFY_SHOW_BODY"] = "0"
+
+    result = _run_just(["app-verify", "app=dspace", "env=staging"], env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "Body:" not in result.stdout
+    assert "Body preview:" not in result.stdout
+    assert "URL: https://example.test/config.json" in result.stdout
+    assert "Verification passed: 3/3 checks succeeded." in result.stdout
 
 
 @pytest.mark.usefixtures("ensure_just_available")
@@ -343,4 +439,24 @@ def test_app_verify_fails_closed_when_context_host_discovery_fails(
     assert "Could not derive a host for tokenplace using context sugar-staging" in result.stderr
     assert "helm get values failed for context sugar-staging" in result.stderr
     assert "kubectl ingress lookup failed for context sugar-staging" in result.stderr
-    assert "curl -fsS https://<host>" not in result.stdout
+    assert "just app-status app=tokenplace env=staging" in result.stderr
+    assert "curl -fsS https://<host>/livez" in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_print_only_succeeds_with_placeholder_when_host_discovery_fails(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_HELM_GET_VALUES_FAIL"] = "1"
+    env["SUGARKUBE_STUB_KUBECTL_INGRESS_FAIL"] = "1"
+
+    result = _run_just(
+        ["app-verify", "app=tokenplace", "env=staging", "print_only=1"],
+        env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "curl -fsS https://<host>/relay/diagnostics" in result.stdout
+    curl_log_path = Path(env["CURL_LOG"])
+    assert not curl_log_path.exists() or curl_log_path.read_text(encoding="utf-8") == ""


### PR DESCRIPTION
### Motivation
- `just app-verify` previously printed curl commands instead of running them, forcing manual copy/paste and producing cramped operator output. 
- The recipe should execute configured public HTTP paths by default, present readable per-path diagnostics, and fail non-zero if any check fails while still attempting all paths.

### Description
- Add `scripts/app_verify.py`, a small Python helper that executes each `SUGARKUBE_VERIFY_PATHS` URL, captures HTTP status and response body, prints a spaced per-path summary, supports bounded body previews and body suppression via `SUGARKUBE_APP_VERIFY_BODY_PREVIEW_BYTES`/`SUGARKUBE_APP_VERIFY_BODY_PREVIEW_LINES` and `SUGARKUBE_APP_VERIFY_SHOW_BODY`, continues after failures, and returns non-zero if any path failed. 
- Update the `app-verify` `justfile` recipe to resolve app config the same as other app recipes, discover the host via Helm/kubectl as before, delegate execution to `scripts/app_verify.py`, and support a `print_only=1` argument or `SUGARKUBE_APP_VERIFY_PRINT_ONLY=1` to preserve the old command-generation behavior. 
- Add offline tests that stub `curl`, `helm`, and `kubectl` to cover default execution, continuation on failures, print-only mode, body suppression, host-discovery failure fallback, and preservation of example apps' `SUGARKUBE_VERIFY_PATHS`. 
- Update docs (`docs/app_deployment_contract.md`, `docs/app_onboarding.md`, and app runbooks for danielsmith/dspace/tokenplace) to describe the new executing behaviour and document `print_only` as a fallback for docs/debugging.

### Testing
- Ran unit test suite: `python -m pytest tests -q`, which completed successfully for the repo test set used during the rollout (targeted and full test runs during development passed). 
- Verified app config output with `just app-config app=danielsmith env=staging` and confirmed the expected `SUGARKUBE_VERIFY_PATHS` values. 
- Exercised `just app-verify` with stubbed `helm`/`kubectl`/`curl` in `PATH` for `danielsmith`, `tokenplace`, and `dspace`, and verified both execution and `print_only` behaviour (stubs logged expected curl calls and the verifier printed readable per-path summaries). 
- Attempted repo standard checks: `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` were not run in this environment because those tools are not installed; `bash scripts/checks.sh` was run and the new verifier file passed, but pre-existing unrelated lint findings remain in other files (these are unchanged by this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20e7375f34832fbfc229fd216ec3c6)