### PR TITLE
Make `just app-verify` execute HTTP checks and print readable summaries

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -146,7 +146,7 @@ Required keys for the generic recipes:
 | `SUGARKUBE_VALUES_STAGING` | Values chain for `env=staging`. |
 | `SUGARKUBE_VALUES_PROD` | Values chain for `env=prod`. |
 | `SUGARKUBE_STATUS_HOST_KEY` | Dotted Helm values key used to discover the public host. |
-| `SUGARKUBE_VERIFY_PATHS` | Comma-separated HTTP paths for post-deploy verification. |
+| `SUGARKUBE_VERIFY_PATHS` | Comma-separated HTTP paths that `just app-verify` executes after deploy. |
 | `SUGARKUBE_DEBUG_SELECTOR` | Kubernetes label selector for app pod logs/debugging. |
 
 Example local setup:
@@ -175,8 +175,11 @@ just app-promote-prod app=dspace tag=main-REPLACE_SHORTSHA
 # Inspect Kubernetes and Helm status for an app environment.
 just app-status app=dspace env=staging
 
-# Run HTTP verification paths for an app environment.
+# Execute HTTP verification paths for an app environment. Fails non-zero if any path fails.
 just app-verify app=dspace env=staging
+
+# Print generated curl commands without executing them.
+just app-verify app=dspace env=staging print_only=1
 
 # Print the resolved app config for review/debugging.
 just app-config app=dspace env=staging

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -191,7 +191,7 @@ just tokenplace-rollback release=appslug namespace=appslug revision="$HELM_REVIS
 
 ## First-run smoke check pattern
 
-Start with generic checks.
+Start with generic checks. `just app-verify` executes the configured paths, prints readable per-path output with body previews, and exits non-zero if any path fails.
 
 ```bash
 just app-status app=appslug env=staging config="$APP_CONFIG"
@@ -199,6 +199,12 @@ just app-status app=appslug env=staging config="$APP_CONFIG"
 
 ```bash
 just app-verify app=appslug env=staging config="$APP_CONFIG"
+```
+
+Use print-only mode when you need the generated curl commands without making requests:
+
+```bash
+just app-verify app=appslug env=staging config="$APP_CONFIG" print_only=1
 ```
 
 Add app-specific checks only for behavior the generic URL checks cannot validate, such as a login-free API health endpoint, a static asset manifest, a queue worker heartbeat, or a safe diagnostics endpoint.

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -100,6 +100,8 @@ just danielsmith-oci-deploy env=staging tag="$APP_TAG"
 
 ## Verify staging
 
+`just app-verify` discovers the public host, executes the configured HTTP paths, prints a per-path body preview, and exits non-zero if any check fails. Use `print_only=1` when you only want the curl commands for docs or troubleshooting.
+
 ```bash
 just app-status app=danielsmith env=staging
 ```
@@ -109,14 +111,14 @@ just app-verify app=danielsmith env=staging
 ```
 
 ```bash
+just app-verify app=danielsmith env=staging print_only=1
+```
+
+Optional manual fallback when debugging DNS, TLS, or Cloudflare behavior:
+
+```bash
 curl -fsS https://staging.danielsmith.io/healthz
-```
-
-```bash
 curl -fsS https://staging.danielsmith.io/livez
-```
-
-```bash
 curl -fsS https://staging.danielsmith.io/
 ```
 
@@ -142,6 +144,12 @@ just app-status app=danielsmith env=prod
 
 ```bash
 just app-verify app=danielsmith env=prod
+```
+
+Print the generated curl commands without executing them when you need a manual fallback:
+
+```bash
+just app-verify app=danielsmith env=prod print_only=1
 ```
 
 ```bash

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -102,7 +102,7 @@ just dspace-oci-deploy env=staging tag="$APP_TAG"
 
 ## Verify staging
 
-Generic verification discovers the host from Helm values or Ingress and checks the configured DSPACE paths.
+Generic verification discovers the host from Helm values or Ingress, executes the configured DSPACE paths, prints a per-path body preview, and exits non-zero if any check fails. Use `print_only=1` when you only want the curl commands for docs or troubleshooting.
 
 ```bash
 just app-status app=dspace env=staging
@@ -112,7 +112,11 @@ just app-status app=dspace env=staging
 just app-verify app=dspace env=staging
 ```
 
-Manual public checks are useful when Cloudflare or cert-manager are suspect.
+```bash
+just app-verify app=dspace env=staging print_only=1
+```
+
+Manual public checks are optional fallbacks when Cloudflare or cert-manager are suspect.
 
 ```bash
 curl -fsS https://staging.democratized.space/config.json | jq .
@@ -149,6 +153,14 @@ just app-status app=dspace env=prod
 ```bash
 just app-verify app=dspace env=prod
 ```
+
+Print the generated curl commands without executing them when you need a manual fallback:
+
+```bash
+just app-verify app=dspace env=prod print_only=1
+```
+
+Optional manual fallback:
 
 ```bash
 curl -fsS https://democratized.space/config.json | jq .

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -100,6 +100,8 @@ just tokenplace-oci-deploy env=staging tag="$APP_TAG"
 
 ## Verify staging
 
+`just app-verify` discovers the public host, executes the configured HTTP paths, prints a per-path body preview, and exits non-zero if any check fails. Use `print_only=1` when you only want the curl commands for docs or troubleshooting.
+
 ```bash
 just app-status app=tokenplace env=staging
 ```
@@ -107,6 +109,12 @@ just app-status app=tokenplace env=staging
 ```bash
 just app-verify app=tokenplace env=staging
 ```
+
+```bash
+just app-verify app=tokenplace env=staging print_only=1
+```
+
+Optional manual fallback:
 
 ```bash
 curl -fsS https://staging.token.place/healthz
@@ -153,6 +161,14 @@ just app-status app=tokenplace env=prod
 ```bash
 just app-verify app=tokenplace env=prod
 ```
+
+Print the generated curl commands without executing them when you need a manual fallback:
+
+```bash
+just app-verify app=tokenplace env=prod print_only=1
+```
+
+Optional manual fallback:
 
 ```bash
 curl -fsS https://token.place/healthz

--- a/justfile
+++ b/justfile
@@ -1593,64 +1593,38 @@ app-promote-prod app tag='' config='':
       config="${SUGARKUBE_CONFIG_PATH}"
 
 # Verify configured HTTPS paths for a Sugarkube app.
-app-verify app env='staging' config='':
+app-verify app env='staging' config='' print_only='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
+
+    config_input={{ quote(config) }}
+    print_only_input={{ quote(print_only) }}
+    if [ "${config_input#print_only=}" != "${config_input}" ]; then
+      print_only_input="${config_input}"
+      config_input=""
+    fi
+    while [ "${config_input#config=}" != "${config_input}" ]; do
+      config_input="${config_input#config=}"
+    done
 
     eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
       --app {{ quote(app) }} \
       --env {{ quote(env) }} \
-      --config {{ quote(config) }})"
+      --config "${config_input}")"
 
     if [ -z "${KUBECONFIG:-}" ]; then
       export KUBECONFIG="${HOME}/.kube/config"
     fi
-    kube_context="sugar-${SUGARKUBE_ENV}"
-    kubectl_context_args=(--context "${kube_context}")
-    helm_context_args=(--kube-context "${kube_context}")
 
-    host=""
-    discovery_errors=()
-    if command -v helm >/dev/null 2>&1; then
-      helm_values=""
-      helm_error="$(mktemp)"
-      if helm_values="$(helm "${helm_context_args[@]}" get values "${SUGARKUBE_RELEASE}" \
-        --namespace "${SUGARKUBE_NAMESPACE}" \
-        --all --output json 2>"${helm_error}")"; then
-        host="$(printf '%s\n' "${helm_values}" | \
-          python3 "{{ justfile_directory() }}/scripts/app_config.py" host-value "${SUGARKUBE_STATUS_HOST_KEY:-ingress.host}")"
-      else
-        discovery_errors+=("helm get values failed for context ${kube_context}: $(tr '\n' ' ' < "${helm_error}")")
-      fi
-      rm -f "${helm_error}"
-    fi
-    if [ -z "${host}" ] && command -v kubectl >/dev/null 2>&1; then
-      kubectl_error="$(mktemp)"
-      if ! host="$(kubectl "${kubectl_context_args[@]}" -n "${SUGARKUBE_NAMESPACE}" get ingress -o jsonpath='{.items[0].spec.rules[0].host}' 2>"${kubectl_error}")"; then
-        discovery_errors+=("kubectl ingress lookup failed for context ${kube_context}: $(tr '\n' ' ' < "${kubectl_error}")")
-        host=""
-      fi
-      rm -f "${kubectl_error}"
-    fi
-
-    IFS=',' read -r -a paths <<< "${SUGARKUBE_VERIFY_PATHS:-/}"
-    if [ -z "${host}" ]; then
-      if [ "${#discovery_errors[@]}" -gt 0 ]; then
-        printf 'Could not derive a host for %s using context %s.\n' "${SUGARKUBE_APP}" "${kube_context}" >&2
-        printf '%s\n' "${discovery_errors[@]}" >&2
-        exit 1
-      fi
-      echo "Could not derive a host for ${SUGARKUBE_APP}; run these commands after replacing <host>:" >&2
-      for path in "${paths[@]}"; do
-        printf '  curl -fsS https://<host>%s\n' "${path}"
-      done
-      exit 0
-    fi
-
-    for path in "${paths[@]}"; do
-      printf 'curl -fsS https://%s%s\n' "${host}" "${path}"
-      curl -fsS "https://${host}${path}" >/dev/null
+    while [ "${print_only_input#print_only=}" != "${print_only_input}" ]; do
+      print_only_input="${print_only_input#print_only=}"
     done
+    print_only_args=()
+    if [ "${SUGARKUBE_APP_VERIFY_PRINT_ONLY:-${print_only_input}}" = "1" ]; then
+      print_only_args+=(--print-only)
+    fi
+
+    python3 "{{ justfile_directory() }}/scripts/app_verify.py" "${print_only_args[@]}"
 
 # Opinionated immutable-tag dspace deploy with rollout verification.
 #

--- a/justfile
+++ b/justfile
@@ -1620,7 +1620,7 @@ app-verify app env='staging' config='' print_only='':
       print_only_input="${print_only_input#print_only=}"
     done
     print_only_args=()
-    if [ "${SUGARKUBE_APP_VERIFY_PRINT_ONLY:-${print_only_input}}" = "1" ]; then
+    if [ "${print_only_input:-${SUGARKUBE_APP_VERIFY_PRINT_ONLY:-}}" = "1" ]; then
       print_only_args+=(--print-only)
     fi
 

--- a/scripts/app_verify.py
+++ b/scripts/app_verify.py
@@ -11,8 +11,6 @@ import sys
 import tempfile
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-
 
 def env_flag(name: str, default: bool = False) -> bool:
     value = os.environ.get(name)
@@ -108,8 +106,10 @@ def base_url_from_host(host: str) -> str:
     host = host.strip().rstrip("/")
     if not host:
         return ""
-    if host.startswith(("http://", "https://")):
+    if host.startswith("https://"):
         return host
+    if host.startswith("http://"):
+        host = host[len("http://") :]
     return f"https://{host}"
 
 
@@ -149,11 +149,25 @@ def int_env(name: str, default: int) -> int:
 
 
 def run_curl(url: str) -> tuple[int, str, bytes, str]:
+    connect_timeout = int_env("SUGARKUBE_APP_VERIFY_CURL_CONNECT_TIMEOUT", 10)
+    max_time = int_env("SUGARKUBE_APP_VERIFY_CURL_MAX_TIME", 30)
     with tempfile.NamedTemporaryFile(delete=False) as body_tmp:
         body_path = Path(body_tmp.name)
     try:
         curl = subprocess.run(
-            ["curl", "-sS", "-o", str(body_path), "-w", "%{http_code}", url],
+            [
+                "curl",
+                "-sS",
+                "--connect-timeout",
+                str(connect_timeout),
+                "--max-time",
+                str(max_time),
+                "-o",
+                str(body_path),
+                "-w",
+                "%{http_code}",
+                url,
+            ],
             capture_output=True,
             text=True,
             check=False,

--- a/scripts/app_verify.py
+++ b/scripts/app_verify.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Run generic Sugarkube app HTTP verification checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def env_flag(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return default
+    return value.lower() not in {"0", "false", "no", "off"}
+
+
+def normalize_path(path: str) -> str:
+    path = "".join(path.split()) or "/"
+    if not path.startswith("/"):
+        path = f"/{path}"
+    return path
+
+
+def run_capture(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, capture_output=True, text=True, check=False)
+
+
+def discover_host(kube_context: str) -> tuple[str, list[str]]:
+    errors: list[str] = []
+    release = os.environ["SUGARKUBE_RELEASE"]
+    namespace = os.environ["SUGARKUBE_NAMESPACE"]
+    host_key = os.environ.get("SUGARKUBE_STATUS_HOST_KEY", "ingress.host")
+
+    if shutil_which("helm"):
+        helm = run_capture(
+            [
+                "helm",
+                "--kube-context",
+                kube_context,
+                "get",
+                "values",
+                release,
+                "--namespace",
+                namespace,
+                "--all",
+                "--output",
+                "json",
+            ]
+        )
+        if helm.returncode == 0:
+            host = host_from_values(helm.stdout, host_key)
+            if host:
+                return host, errors
+        else:
+            errors.append(
+                f"helm get values failed for context {kube_context}: {helm.stderr.replace(chr(10), ' ').strip()}"
+            )
+
+    if shutil_which("kubectl"):
+        kubectl = run_capture(
+            [
+                "kubectl",
+                "--context",
+                kube_context,
+                "-n",
+                namespace,
+                "get",
+                "ingress",
+                "-o",
+                "jsonpath={.items[0].spec.rules[0].host}",
+            ]
+        )
+        if kubectl.returncode == 0 and kubectl.stdout.strip():
+            return kubectl.stdout.strip(), errors
+        if kubectl.returncode != 0:
+            errors.append(
+                f"kubectl ingress lookup failed for context {kube_context}: {kubectl.stderr.replace(chr(10), ' ').strip()}"
+            )
+    return "", errors
+
+
+def shutil_which(name: str) -> str | None:
+    from shutil import which
+
+    return which(name)
+
+
+def host_from_values(raw: str, host_key: str) -> str:
+    try:
+        node: object = json.loads(raw)
+    except json.JSONDecodeError:
+        return ""
+    for part in host_key.split("."):
+        if not isinstance(node, dict):
+            return ""
+        node = node.get(part)
+    return str(node) if node else ""
+
+
+def base_url_from_host(host: str) -> str:
+    host = host.strip().rstrip("/")
+    if not host:
+        return ""
+    if host.startswith(("http://", "https://")):
+        return host
+    return f"https://{host}"
+
+
+def print_placeholder_failure(
+    app: str, env: str, kube_context: str, paths: list[str], errors: list[str]
+) -> None:
+    print(f"Could not derive a host for {app} using context {kube_context}.", file=sys.stderr)
+    for error in errors:
+        print(error, file=sys.stderr)
+    print(
+        f"Suggested next steps: just app-status app={app} env={env} or just app-config app={app} env={env}.",
+        file=sys.stderr,
+    )
+    print("Generated verification commands with a placeholder host:", file=sys.stderr)
+    for path in paths:
+        print(f"  curl -fsS https://<host>{path}")
+
+
+def preview_text(body: bytes, byte_limit: int, line_limit: int) -> tuple[list[str], bool]:
+    truncated = False
+    if byte_limit > 0 and len(body) > byte_limit:
+        body = body[:byte_limit]
+        truncated = True
+    text = body.decode("utf-8", errors="replace")
+    lines = text.splitlines() or ([text] if text else [])
+    if line_limit > 0 and len(lines) > line_limit:
+        lines = lines[:line_limit]
+        truncated = True
+    return lines, truncated
+
+
+def int_env(name: str, default: int) -> int:
+    try:
+        return max(0, int(os.environ.get(name, str(default))))
+    except ValueError:
+        return default
+
+
+def run_curl(url: str) -> tuple[int, str, bytes, str]:
+    with tempfile.NamedTemporaryFile(delete=False) as body_tmp:
+        body_path = Path(body_tmp.name)
+    try:
+        curl = subprocess.run(
+            ["curl", "-sS", "-o", str(body_path), "-w", "%{http_code}", url],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        body = body_path.read_bytes() if body_path.exists() else b""
+        return curl.returncode, curl.stdout.strip() or "000", body, curl.stderr.strip()
+    finally:
+        body_path.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--print-only", action="store_true")
+    args = parser.parse_args(argv)
+
+    app = os.environ["SUGARKUBE_APP"]
+    env = os.environ["SUGARKUBE_ENV"]
+    kube_context = f"sugar-{env}"
+    paths = [
+        normalize_path(path) for path in os.environ.get("SUGARKUBE_VERIFY_PATHS", "/").split(",")
+    ]
+    print_only = args.print_only or env_flag("SUGARKUBE_APP_VERIFY_PRINT_ONLY")
+
+    host, errors = discover_host(kube_context)
+    base_url = base_url_from_host(host)
+    if not base_url:
+        print_placeholder_failure(app, env, kube_context, paths, errors)
+        return 0 if print_only else 1
+
+    if print_only:
+        for path in paths:
+            print(f"curl -fsS {base_url}{path}")
+        return 0
+
+    print(f"Verifying {app} env={env}")
+    print(f"Host: {base_url}")
+
+    show_body = env_flag("SUGARKUBE_APP_VERIFY_SHOW_BODY", default=True)
+    byte_limit = int_env("SUGARKUBE_APP_VERIFY_BODY_PREVIEW_BYTES", 4000)
+    line_limit = int_env("SUGARKUBE_APP_VERIFY_BODY_PREVIEW_LINES", 40)
+    passed = 0
+    failures: list[tuple[str, str]] = []
+    total = len(paths)
+
+    for index, path in enumerate(paths, start=1):
+        url = f"{base_url}{path}"
+        curl_rc, http_status, body, curl_stderr = run_curl(url)
+        if curl_rc == 0 and http_status.isdigit() and int(http_status) >= 400:
+            curl_rc = 22
+
+        print(f"\n[{index}/{total}] GET {path}")
+        print(f"  URL: {url}")
+        http_suffix = (
+            f" (HTTP {http_status})" if http_status.isdigit() and http_status != "000" else ""
+        )
+        if curl_rc == 0:
+            print(f"  Status: OK{http_suffix}")
+            passed += 1
+        else:
+            print(f"  Status: FAILED{http_suffix}")
+            print(f"  curl exit status: {curl_rc}")
+            if curl_stderr:
+                print("  curl stderr:")
+                for line in curl_stderr.splitlines():
+                    print(f"  {line}")
+            failures.append((path, url))
+
+        if show_body:
+            if body:
+                lines, truncated = preview_text(body, byte_limit, line_limit)
+                print("  Body preview:" if truncated else "  Body:")
+                for line in lines:
+                    print(f"  {line}")
+                if truncated:
+                    print("  ...")
+            else:
+                print("  Body: <empty>")
+
+    if not failures:
+        print(f"\nVerification passed: {passed}/{total} checks succeeded.")
+        return 0
+
+    print(f"\nVerification failed: {len(failures)}/{total} checks failed.", file=sys.stderr)
+    print("Failed paths:", file=sys.stderr)
+    for path, url in failures:
+        print(f"  {path} ({url})", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_app_verify.py
+++ b/tests/test_app_verify.py
@@ -1,0 +1,393 @@
+"""Unit tests for scripts.app_verify."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import app_verify
+
+
+def _set_main_env(monkeypatch: pytest.MonkeyPatch, *, paths: str = "/,/livez") -> None:
+    monkeypatch.setenv("SUGARKUBE_APP", "demo")
+    monkeypatch.setenv("SUGARKUBE_ENV", "staging")
+    monkeypatch.setenv("SUGARKUBE_VERIFY_PATHS", paths)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, True),
+        ("", True),
+        ("0", False),
+        ("false", False),
+        ("no", False),
+        ("off", False),
+        ("1", True),
+        ("true", True),
+    ],
+)
+def test_env_flag_parses_common_boolean_values(
+    monkeypatch: pytest.MonkeyPatch, value: str | None, expected: bool
+) -> None:
+    if value is None:
+        monkeypatch.delenv("SUGARKUBE_TEST_FLAG", raising=False)
+    else:
+        monkeypatch.setenv("SUGARKUBE_TEST_FLAG", value)
+
+    assert app_verify.env_flag("SUGARKUBE_TEST_FLAG", default=True) is expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("", "/"),
+        ("livez", "/livez"),
+        (" /healthz \n", "/healthz"),
+        (" nested / path ", "/nested/path"),
+    ],
+)
+def test_normalize_path_removes_whitespace_and_adds_leading_slash(raw: str, expected: str) -> None:
+    assert app_verify.normalize_path(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "host_key", "expected"),
+    [
+        ('{"ingress":{"host":"example.test"}}', "ingress.host", "example.test"),
+        ('{"status":{"url":"https://example.test"}}', "status.url", "https://example.test"),
+        ('{"ingress":{}}', "ingress.host", ""),
+        ('{"ingress":"not-a-dict"}', "ingress.host", ""),
+        ("not json", "ingress.host", ""),
+    ],
+)
+def test_host_from_values_follows_configured_key(raw: str, host_key: str, expected: str) -> None:
+    assert app_verify.host_from_values(raw, host_key) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "default", "expected"),
+    [
+        (None, 7, 7),
+        ("12", 7, 12),
+        ("-5", 7, 0),
+        ("not-an-int", 7, 7),
+    ],
+)
+def test_int_env_parses_nonnegative_integers(
+    monkeypatch: pytest.MonkeyPatch, raw: str | None, default: int, expected: int
+) -> None:
+    if raw is None:
+        monkeypatch.delenv("SUGARKUBE_TEST_INT", raising=False)
+    else:
+        monkeypatch.setenv("SUGARKUBE_TEST_INT", raw)
+
+    assert app_verify.int_env("SUGARKUBE_TEST_INT", default) == expected
+
+
+@pytest.mark.parametrize(
+    ("body", "byte_limit", "line_limit", "expected_lines", "expected_truncated"),
+    [
+        (b"", 10, 2, [], False),
+        (b"one\ntwo\nthree", 20, 2, ["one", "two"], True),
+        (b"abcdef", 3, 5, ["abc"], True),
+        ("caf\xe9".encode(), 10, 5, ["café"], False),
+    ],
+)
+def test_preview_text_applies_byte_and_line_limits(
+    body: bytes,
+    byte_limit: int,
+    line_limit: int,
+    expected_lines: list[str],
+    expected_truncated: bool,
+) -> None:
+    assert app_verify.preview_text(body, byte_limit, line_limit) == (
+        expected_lines,
+        expected_truncated,
+    )
+
+
+def test_discover_host_prefers_helm_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SUGARKUBE_RELEASE", "demo")
+    monkeypatch.setenv("SUGARKUBE_NAMESPACE", "demo-ns")
+    monkeypatch.setattr(app_verify, "shutil_which", lambda name: f"/bin/{name}")
+
+    calls: list[list[str]] = []
+
+    def fake_run_capture(args: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        return subprocess.CompletedProcess(args, 0, '{"ingress":{"host":"helm.example"}}', "")
+
+    monkeypatch.setattr(app_verify, "run_capture", fake_run_capture)
+
+    assert app_verify.discover_host("sugar-staging") == ("helm.example", [])
+    assert calls == [
+        [
+            "helm",
+            "--kube-context",
+            "sugar-staging",
+            "get",
+            "values",
+            "demo",
+            "--namespace",
+            "demo-ns",
+            "--all",
+            "--output",
+            "json",
+        ]
+    ]
+
+
+def test_discover_host_falls_back_to_kubectl_and_reports_helm_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SUGARKUBE_RELEASE", "demo")
+    monkeypatch.setenv("SUGARKUBE_NAMESPACE", "demo-ns")
+    monkeypatch.setattr(app_verify, "shutil_which", lambda name: f"/bin/{name}")
+
+    def fake_run_capture(args: list[str]) -> subprocess.CompletedProcess[str]:
+        if args[0] == "helm":
+            return subprocess.CompletedProcess(args, 1, "", "helm boom\nwith newline")
+        return subprocess.CompletedProcess(args, 0, "kubectl.example\n", "")
+
+    monkeypatch.setattr(app_verify, "run_capture", fake_run_capture)
+
+    host, errors = app_verify.discover_host("sugar-staging")
+
+    assert host == "kubectl.example"
+    assert errors == ["helm get values failed for context sugar-staging: helm boom with newline"]
+
+
+def test_discover_host_returns_errors_when_tools_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SUGARKUBE_RELEASE", "demo")
+    monkeypatch.setenv("SUGARKUBE_NAMESPACE", "demo-ns")
+    monkeypatch.setattr(app_verify, "shutil_which", lambda name: f"/bin/{name}")
+
+    def fake_run_capture(args: list[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args, 1, "", f"{args[0]} failed\n")
+
+    monkeypatch.setattr(app_verify, "run_capture", fake_run_capture)
+
+    host, errors = app_verify.discover_host("sugar-staging")
+
+    assert host == ""
+    assert errors == [
+        "helm get values failed for context sugar-staging: helm failed",
+        "kubectl ingress lookup failed for context sugar-staging: kubectl failed",
+    ]
+
+
+def test_discover_host_skips_missing_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SUGARKUBE_RELEASE", "demo")
+    monkeypatch.setenv("SUGARKUBE_NAMESPACE", "demo-ns")
+    monkeypatch.setattr(app_verify, "shutil_which", lambda name: None)
+
+    assert app_verify.discover_host("sugar-staging") == ("", [])
+
+
+def test_run_curl_passes_timeouts_and_reads_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SUGARKUBE_APP_VERIFY_CURL_CONNECT_TIMEOUT", "2")
+    monkeypatch.setenv("SUGARKUBE_APP_VERIFY_CURL_MAX_TIME", "5")
+    calls: list[list[str]] = []
+
+    def fake_run(
+        args: list[str], *, capture_output: bool, text: bool, check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        body_path = Path(args[args.index("-o") + 1])
+        body_path.write_bytes(b'{"status":"ok"}')
+        return subprocess.CompletedProcess(args, 0, "200", "")
+
+    monkeypatch.setattr(app_verify.subprocess, "run", fake_run)
+
+    rc, status, body, stderr = app_verify.run_curl("https://example.test/livez")
+
+    assert (rc, status, body, stderr) == (0, "200", b'{"status":"ok"}', "")
+    assert calls == [
+        [
+            "curl",
+            "-sS",
+            "--connect-timeout",
+            "2",
+            "--max-time",
+            "5",
+            "-o",
+            calls[0][7],
+            "-w",
+            "%{http_code}",
+            "https://example.test/livez",
+        ]
+    ]
+    assert not Path(calls[0][7]).exists()
+
+
+def test_run_curl_defaults_blank_status_to_000(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(
+        args: list[str], *, capture_output: bool, text: bool, check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args, 7, "", "connect failed\n")
+
+    monkeypatch.setattr(app_verify.subprocess, "run", fake_run)
+
+    assert app_verify.run_curl("https://example.test/") == (7, "000", b"", "connect failed")
+
+
+def test_print_placeholder_failure_lists_errors_and_commands(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    app_verify.print_placeholder_failure(
+        "demo", "staging", "sugar-staging", ["/", "/livez"], ["helm failed"]
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out.splitlines() == [
+        "  curl -fsS https://<host>/",
+        "  curl -fsS https://<host>/livez",
+    ]
+    assert "Could not derive a host for demo using context sugar-staging." in captured.err
+    assert "helm failed" in captured.err
+    assert "Suggested next steps: just app-status app=demo env=staging" in captured.err
+
+
+def test_main_print_only_uses_discovered_host_without_curl(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _set_main_env(monkeypatch, paths="/, livez")
+    monkeypatch.setattr(app_verify, "discover_host", lambda kube_context: ("example.test", []))
+    monkeypatch.setattr(app_verify, "run_curl", lambda url: pytest.fail("curl should not run"))
+
+    assert app_verify.main(["--print-only"]) == 0
+
+    captured = capsys.readouterr()
+    assert captured.out.splitlines() == [
+        "curl -fsS https://example.test/",
+        "curl -fsS https://example.test/livez",
+    ]
+    assert captured.err == ""
+
+
+def test_main_print_only_returns_zero_with_placeholder_host(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _set_main_env(monkeypatch)
+    monkeypatch.setattr(app_verify, "discover_host", lambda kube_context: ("", ["lookup failed"]))
+
+    assert app_verify.main(["--print-only"]) == 0
+
+    captured = capsys.readouterr()
+    assert "curl -fsS https://<host>/livez" in captured.out
+    assert "lookup failed" in captured.err
+
+
+def test_main_returns_one_when_host_discovery_fails_outside_print_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_main_env(monkeypatch)
+    monkeypatch.setattr(app_verify, "discover_host", lambda kube_context: ("", []))
+
+    assert app_verify.main([]) == 1
+
+
+def test_main_runs_all_checks_and_reports_failures(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _set_main_env(monkeypatch, paths="/,/livez,/large")
+    monkeypatch.setenv("SUGARKUBE_APP_VERIFY_BODY_PREVIEW_BYTES", "4")
+    monkeypatch.setenv("SUGARKUBE_APP_VERIFY_BODY_PREVIEW_LINES", "1")
+    monkeypatch.setattr(
+        app_verify, "discover_host", lambda kube_context: ("https://example.test", [])
+    )
+    calls: list[str] = []
+
+    def fake_run_curl(url: str) -> tuple[int, str, bytes, str]:
+        calls.append(url)
+        if url.endswith("/livez"):
+            return 0, "503", b"down", ""
+        if url.endswith("/large"):
+            return 0, "200", b"line1\nline2", ""
+        return 0, "200", b"ok", ""
+
+    monkeypatch.setattr(app_verify, "run_curl", fake_run_curl)
+
+    assert app_verify.main([]) == 1
+
+    captured = capsys.readouterr()
+    assert calls == [
+        "https://example.test/",
+        "https://example.test/livez",
+        "https://example.test/large",
+    ]
+    assert "Status: OK (HTTP 200)" in captured.out
+    assert "Status: FAILED (HTTP 503)" in captured.out
+    assert "curl exit status: 22" in captured.out
+    assert "Body preview:" in captured.out
+    assert "Verification failed: 1/3 checks failed." in captured.err
+    assert "/livez (https://example.test/livez)" in captured.err
+
+
+def test_main_reports_curl_stderr_and_can_hide_bodies(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _set_main_env(monkeypatch, paths="/")
+    monkeypatch.setenv("SUGARKUBE_APP_VERIFY_SHOW_BODY", "0")
+    monkeypatch.setattr(app_verify, "discover_host", lambda kube_context: ("example.test", []))
+    monkeypatch.setattr(
+        app_verify,
+        "run_curl",
+        lambda url: (7, "000", b"secret body", "first stderr line\nsecond stderr line"),
+    )
+
+    assert app_verify.main([]) == 1
+
+    captured = capsys.readouterr()
+    assert "curl stderr:" in captured.out
+    assert "first stderr line" in captured.out
+    assert "second stderr line" in captured.out
+    assert "Body:" not in captured.out
+
+
+def test_main_success_reports_empty_body(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _set_main_env(monkeypatch, paths="/")
+    monkeypatch.setattr(app_verify, "discover_host", lambda kube_context: ("example.test", []))
+    monkeypatch.setattr(app_verify, "run_curl", lambda url: (0, "200", b"", ""))
+
+    assert app_verify.main([]) == 0
+
+    captured = capsys.readouterr()
+    assert "Body: <empty>" in captured.out
+    assert "Verification passed: 1/1 checks succeeded." in captured.out
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        ("", ""),
+        (" example.test/ ", "https://example.test"),
+        ("http://example.test", "https://example.test"),
+        ("https://example.test", "https://example.test"),
+    ],
+)
+def test_base_url_from_host_preserves_https_contract(host: str, expected: str) -> None:
+    assert app_verify.base_url_from_host(host) == expected
+
+
+def test_run_capture_uses_text_capture_without_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(
+        args: list[str], *, capture_output: bool, text: bool, check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        assert capture_output is True
+        assert text is True
+        assert check is False
+        return subprocess.CompletedProcess(args, 0, "out", "err")
+
+    monkeypatch.setattr(app_verify.subprocess, "run", fake_run)
+
+    assert app_verify.run_capture(["demo"]).stdout == "out"
+
+
+def test_shutil_which_returns_matching_executable_path() -> None:
+    assert app_verify.shutil_which("python3")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+from scripts.app_verify import base_url_from_host
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -397,6 +399,18 @@ def test_app_verify_adds_curl_timeouts(
     assert "--connect-timeout 10 --max-time 30" in curl_log
 
 
+@pytest.mark.parametrize(
+    ("host", "expected_base_url"),
+    [
+        ("example.test", "https://example.test"),
+        ("http://example.test", "https://example.test"),
+        ("https://example.test", "https://example.test"),
+    ],
+)
+def test_app_verify_normalizes_hosts_to_https(host: str, expected_base_url: str) -> None:
+    assert base_url_from_host(host) == expected_base_url
+
+
 def test_app_verify_normalizes_http_host_values_to_https(
     generic_app_stub_env: dict[str, str],
 ) -> None:
@@ -453,16 +467,38 @@ def test_app_verify_print_only_prints_commands_without_curl(
     assert not Path(generic_app_stub_env["CURL_LOG"]).exists()
 
 
+@pytest.mark.parametrize("false_env_value", ["0", "false", ""])
 def test_app_verify_print_only_argument_overrides_false_environment_value(
+    generic_app_stub_env: dict[str, str], false_env_value: str
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_APP_VERIFY_PRINT_ONLY"] = false_env_value
+
+    result = _run_just(["app-verify", "app=danielsmith", "env=staging", "print_only=1"], env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert result.stdout.splitlines() == [
+        "curl -fsS https://example.test/",
+        "curl -fsS https://example.test/livez",
+        "curl -fsS https://example.test/healthz",
+    ]
+    assert not Path(env["CURL_LOG"]).exists()
+
+
+def test_app_verify_print_only_environment_prints_commands_without_curl(
     generic_app_stub_env: dict[str, str],
 ) -> None:
     env = generic_app_stub_env.copy()
-    env["SUGARKUBE_APP_VERIFY_PRINT_ONLY"] = "0"
+    env["SUGARKUBE_APP_VERIFY_PRINT_ONLY"] = "1"
 
-    result = _run_just(["app-verify", "app=tokenplace", "env=staging", "print_only=1"], env)
+    result = _run_just(["app-verify", "app=danielsmith", "env=staging"], env)
 
     assert result.returncode == 0, result.stderr + result.stdout
-    assert result.stdout.splitlines()[0] == "curl -fsS https://example.test/"
+    assert result.stdout.splitlines() == [
+        "curl -fsS https://example.test/",
+        "curl -fsS https://example.test/livez",
+        "curl -fsS https://example.test/healthz",
+    ]
     assert not Path(env["CURL_LOG"]).exists()
 
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -91,7 +91,7 @@ if [[ "$*" == *"get values"* ]]; then
     echo 'Error: Kubernetes cluster unreachable for context sugar-staging' >&2
     exit 1
   fi
-  printf '{{"ingress":{{"host":"example.test"}}}}\n'
+  printf '{{"ingress":{{"host":"%s"}}}}\n' "${{SUGARKUBE_STUB_HELM_HOST:-example.test}}"
   exit 0
 fi
 if [[ "$*" == *" status "* ]]; then
@@ -109,15 +109,14 @@ body_file=""
 url=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
+    --connect-timeout|--max-time|-w) shift 2 ;;
     -o) body_file="$2"; shift 2 ;;
-    -w) shift 2 ;;
     -*) shift ;;
     *) url="$1"; shift ;;
   esac
 done
-path="/${{url#https://example.test/}}
-"
-path="${{path//$'\n'/}}"
+path="${{url#https://example.test}}"
+path="${{path:-/}}"
 status=200
 body='{{"status":"ok"}}'
 case "${{path}}" in
@@ -388,6 +387,31 @@ def test_app_verify_executes_curl_by_default_and_prints_summary(
     assert "Verification passed: 3/3 checks succeeded." in result.stdout
 
 
+def test_app_verify_adds_curl_timeouts(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(["app-verify", "app=danielsmith", "env=staging"], generic_app_stub_env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    curl_log = Path(generic_app_stub_env["CURL_LOG"]).read_text(encoding="utf-8")
+    assert "--connect-timeout 10 --max-time 30" in curl_log
+
+
+def test_app_verify_normalizes_http_host_values_to_https(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_HELM_HOST"] = "http://example.test"
+
+    result = _run_just(["app-verify", "app=danielsmith", "env=staging"], env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "Host: https://example.test" in result.stdout
+    curl_log = Path(env["CURL_LOG"]).read_text(encoding="utf-8")
+    assert "https://example.test/livez" in curl_log
+    assert "http://example.test" not in curl_log
+
+
 @pytest.mark.usefixtures("ensure_just_available")
 def test_app_verify_failure_checks_all_paths_and_exits_nonzero(
     generic_app_stub_env: dict[str, str],
@@ -427,6 +451,19 @@ def test_app_verify_print_only_prints_commands_without_curl(
         "curl -fsS https://example.test/relay/diagnostics",
     ]
     assert not Path(generic_app_stub_env["CURL_LOG"]).exists()
+
+
+def test_app_verify_print_only_argument_overrides_false_environment_value(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_APP_VERIFY_PRINT_ONLY"] = "0"
+
+    result = _run_just(["app-verify", "app=tokenplace", "env=staging", "print_only=1"], env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert result.stdout.splitlines()[0] == "curl -fsS https://example.test/"
+    assert not Path(env["CURL_LOG"]).exists()
 
 
 @pytest.mark.usefixtures("ensure_just_available")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -102,8 +102,43 @@ exit 0
     )
     _write_executable(
         bin_dir / "curl",
-        """#!/usr/bin/env bash
+        f"""#!/usr/bin/env bash
 set -euo pipefail
+printf '%s\n' "$*" >> {str(tmp_path / "curl.log")!r}
+body_file=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) body_file="$2"; shift 2 ;;
+    -w) shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+path="/${{url#https://example.test/}}
+"
+path="${{path//$'\n'/}}"
+status=200
+body='{{"status":"ok"}}'
+case "${{path}}" in
+  /) body=$'<!doctype html>\n<html lang="en">\n<body>ok</body>\n</html>' ;;
+  /config.json) body='{{"publicConfig":true}}' ;;
+  /relay/diagnostics) body='{{"relay":"ok"}}' ;;
+esac
+if [ "${{SUGARKUBE_STUB_CURL_FAIL_PATH:-}}" = "${{path}}" ]; then
+  status=503
+  body='{{"status":"down"}}'
+  echo 'curl: (22) The requested URL returned error: 503' >&2
+fi
+if [ -n "${{body_file}}" ]; then
+  printf '%s\n' "${{body}}" > "${{body_file}}"
+else
+  printf '%s\n' "${{body}}"
+fi
+printf '%s' "${{status}}"
+if [ "${{status}}" -ge 400 ]; then
+  exit 22
+fi
 exit 0
 """,
     )
@@ -114,6 +149,7 @@ exit 0
     env["SUGARKUBE_HELM_ROLLOUT_TIMEOUT"] = "1s"
     env["HELM_LOG"] = str(log_path)
     env["KUBECTL_LOG"] = str(tmp_path / "kubectl.log")
+    env["CURL_LOG"] = str(tmp_path / "curl.log")
     return env
 
 
@@ -330,6 +366,114 @@ def test_app_verify_does_not_rewrite_kubeconfig_for_read_only_checks(
 
 
 @pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_executes_curl_by_default_and_prints_summary(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(["app-verify", "app=danielsmith", "env=staging"], generic_app_stub_env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    curl_log = Path(generic_app_stub_env["CURL_LOG"]).read_text(encoding="utf-8")
+    assert "https://example.test/" in curl_log
+    assert "https://example.test/livez" in curl_log
+    assert "https://example.test/healthz" in curl_log
+    assert result.stdout.startswith(
+        "Verifying danielsmith env=staging\nHost: https://example.test\n\n"
+    )
+    assert "\n[1/3] GET /\n" in result.stdout
+    assert "\n[2/3] GET /livez\n" in result.stdout
+    assert "\n[3/3] GET /healthz\n" in result.stdout
+    assert "  URL: https://example.test/livez\n" in result.stdout
+    assert "  Status: OK (HTTP 200)" in result.stdout
+    assert '  Body:\n  {"status":"ok"}' in result.stdout
+    assert "Verification passed: 3/3 checks succeeded." in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_failure_checks_all_paths_and_exits_nonzero(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_CURL_FAIL_PATH"] = "/livez"
+
+    result = _run_just(["app-verify", "app=danielsmith", "env=staging"], env)
+
+    assert result.returncode != 0
+    curl_log = Path(env["CURL_LOG"]).read_text(encoding="utf-8")
+    assert "https://example.test/" in curl_log
+    assert "https://example.test/livez" in curl_log
+    assert "https://example.test/healthz" in curl_log
+    assert "[2/3] GET /livez" in result.stdout
+    assert "Status: FAILED (HTTP 503)" in result.stdout
+    assert "curl exit status: 22" in result.stdout
+    assert '{"status":"down"}' in result.stdout
+    assert "Verification failed: 1/3 checks failed." in result.stderr
+    assert "/livez (https://example.test/livez)" in result.stderr
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_print_only_prints_commands_without_curl(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        ["app-verify", "app=tokenplace", "env=staging", "print_only=1"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert result.stdout.splitlines() == [
+        "curl -fsS https://example.test/",
+        "curl -fsS https://example.test/livez",
+        "curl -fsS https://example.test/healthz",
+        "curl -fsS https://example.test/relay/diagnostics",
+    ]
+    assert not Path(generic_app_stub_env["CURL_LOG"]).exists()
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_show_body_can_be_disabled(generic_app_stub_env: dict[str, str]) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_APP_VERIFY_SHOW_BODY"] = "0"
+
+    result = _run_just(["app-verify", "app=dspace", "env=staging"], env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "Body:" not in result.stdout
+    assert "https://example.test/config.json" in result.stdout
+    assert "Verification passed: 3/3 checks succeeded." in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("app", "expected_paths"),
+    [
+        ("danielsmith", "/,/livez,/healthz"),
+        ("tokenplace", "/,/livez,/healthz,/relay/diagnostics"),
+        ("dspace", "/config.json,/healthz,/livez"),
+    ],
+)
+def test_example_app_configs_preserve_verify_paths(app: str, expected_paths: str) -> None:
+    result = subprocess.run(
+        [
+            "python3",
+            "scripts/app_config.py",
+            "json",
+            "--app",
+            app,
+            "--env",
+            "staging",
+            "--config",
+            "",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f'"SUGARKUBE_VERIFY_PATHS": "{expected_paths}"' in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
 def test_app_verify_fails_closed_when_context_host_discovery_fails(
     generic_app_stub_env: dict[str, str],
 ) -> None:
@@ -343,4 +487,5 @@ def test_app_verify_fails_closed_when_context_host_discovery_fails(
     assert "Could not derive a host for tokenplace using context sugar-staging" in result.stderr
     assert "helm get values failed for context sugar-staging" in result.stderr
     assert "kubectl ingress lookup failed for context sugar-staging" in result.stderr
-    assert "curl -fsS https://<host>" not in result.stdout
+    assert "Suggested next steps: just app-status app=tokenplace env=staging" in result.stderr
+    assert "curl -fsS https://<host>/" in result.stdout


### PR DESCRIPTION
### Motivation
- `just app-verify` previously only printed `curl` commands which required manual copy/paste and produced cramped output when run; operators expect the recipe to run checks and fail on bad responses. 
- The change should run all configured verify paths by default, continue across failures to report a full summary, and preserve a print-only mode for docs/debugging.

### Description
- Add a dedicated helper `scripts/app_verify.py` that discovers the app host (Helm values or Ingress), runs each `SUGARKUBE_VERIFY_PATHS` URL, captures HTTP status/body/stderr, prints a readable per-path summary with configurable body previews (`SUGARKUBE_APP_VERIFY_BODY_PREVIEW_BYTES` / `_LINES`) and supports suppressing bodies via `SUGARKUBE_APP_VERIFY_SHOW_BODY`.
- Update the `app-verify` recipe in the `justfile` to invoke `scripts/app_verify.py`, preserve read-only kubeconfig behavior, accept `print_only=1` (and `SUGARKUBE_APP_VERIFY_PRINT_ONLY=1`) and preserve the old placeholder command output when host discovery fails.
- Extend `tests/test_generic_app_just_recipes.py` to stub `helm`/`kubectl`/`curl`, log curl invocations, and add tests for default execution, failure reporting, print-only output, body suppression, and verifying example app configs still expose the expected verify path lists.
- Update docs (`docs/app_deployment_contract.md`, `docs/app_onboarding.md`, and runbooks under `docs/apps/`) to document that `just app-verify` executes checks by default and to show `print_only=1` as the manual fallback.

### Testing
- Ran unit/recipe tests with stubs: `python -m pytest tests/test_generic_app_just_recipes.py -q` and the new/updated tests passed. 
- Ran full test suite: `python -m pytest tests -q` (all tests passed: test run completed successfully in CI-like environment).
- Exercised `just` helpers offline with stubs: `just app-config app=danielsmith env=staging` and stubbed `just app-verify` runs for `danielsmith`, `tokenplace`, and `dspace` and `print_only=1` to confirm behavior and output formatting (all succeeded under the test stubs).
- Could not run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, or `linkchecker --no-warnings README.md docs/` in this environment because those tools are not installed, but `git diff --check` and the project's secret-scan script were run and reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20e7375f34832fbfc229fd216ec3c6)