### PR TITLE
Make `just app-verify` execute HTTP checks

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -175,8 +175,11 @@ just app-promote-prod app=dspace tag=main-REPLACE_SHORTSHA
 # Inspect Kubernetes and Helm status for an app environment.
 just app-status app=dspace env=staging
 
-# Run HTTP verification paths for an app environment.
+# Execute configured HTTP verification paths and fail if any path fails.
 just app-verify app=dspace env=staging
+
+# Print the curl commands without executing network requests, for docs/debugging.
+just app-verify app=dspace env=staging print_only=1
 
 # Print the resolved app config for review/debugging.
 just app-config app=dspace env=staging
@@ -191,6 +194,16 @@ onboarding, but thinning the remaining deploy/redeploy wrappers is deferred to a
 follow-up PR. Production promotion wrappers such as
 `just tokenplace-oci-promote-prod tag=main-REPLACE_SHORTSHA` remain documented as
 thin generic shims over the shared production promotion flow.
+
+`app-verify` prints the resolved host, one spaced result block per configured path,
+a bounded response-body preview, and a final pass/fail summary. Set
+`SUGARKUBE_APP_VERIFY_SHOW_BODY=0` to hide bodies,
+`SUGARKUBE_APP_VERIFY_BODY_PREVIEW_BYTES` to tune the preview limit, or
+`SUGARKUBE_APP_VERIFY_PRINT_ONLY=1` (equivalent to `print_only=1`) to preserve
+the old command-printing behavior without making HTTP requests. If host
+discovery fails, the recipe prints placeholder `curl -fsS https://<host>/...`
+commands and suggests `app-status`/`app-config`; that fallback exits non-zero
+unless print-only mode was requested.
 
 ## Current example configs
 

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -191,7 +191,9 @@ just tokenplace-rollback release=appslug namespace=appslug revision="$HELM_REVIS
 
 ## First-run smoke check pattern
 
-Start with generic checks.
+Start with generic checks. `app-verify` executes the configured
+`SUGARKUBE_VERIFY_PATHS` checks directly, prints a per-path report, and exits
+non-zero if any path fails.
 
 ```bash
 just app-status app=appslug env=staging config="$APP_CONFIG"
@@ -199,6 +201,13 @@ just app-status app=appslug env=staging config="$APP_CONFIG"
 
 ```bash
 just app-verify app=appslug env=staging config="$APP_CONFIG"
+```
+
+To print the generated `curl -fsS` commands without executing them while
+drafting docs or debugging host discovery, use print-only mode.
+
+```bash
+just app-verify app=appslug env=staging config="$APP_CONFIG" print_only=1
 ```
 
 Add app-specific checks only for behavior the generic URL checks cannot validate, such as a login-free API health endpoint, a static asset manifest, a queue worker heartbeat, or a safe diagnostics endpoint.

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -100,6 +100,9 @@ just danielsmith-oci-deploy env=staging tag="$APP_TAG"
 
 ## Verify staging
 
+Generic verification discovers the host from Helm values or Ingress, executes
+the configured HTTP checks, and exits non-zero if any path fails.
+
 ```bash
 just app-status app=danielsmith env=staging
 ```
@@ -107,6 +110,16 @@ just app-status app=danielsmith env=staging
 ```bash
 just app-verify app=danielsmith env=staging
 ```
+
+Print the generated curl commands without executing them when updating docs or
+troubleshooting host discovery.
+
+```bash
+just app-verify app=danielsmith env=staging print_only=1
+```
+
+Manual curl commands are optional fallbacks when Cloudflare, DNS, or
+cert-manager are suspect.
 
 ```bash
 curl -fsS https://staging.danielsmith.io/healthz

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -102,7 +102,9 @@ just dspace-oci-deploy env=staging tag="$APP_TAG"
 
 ## Verify staging
 
-Generic verification discovers the host from Helm values or Ingress and checks the configured DSPACE paths.
+Generic verification discovers the host from Helm values or Ingress and executes
+the configured DSPACE paths. The command prints one result block per path and
+exits non-zero if any path fails.
 
 ```bash
 just app-status app=dspace env=staging
@@ -110,6 +112,13 @@ just app-status app=dspace env=staging
 
 ```bash
 just app-verify app=dspace env=staging
+```
+
+Print the generated curl commands without executing them when updating docs or
+troubleshooting host discovery.
+
+```bash
+just app-verify app=dspace env=staging print_only=1
 ```
 
 Manual public checks are useful when Cloudflare or cert-manager are suspect.

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -100,6 +100,9 @@ just tokenplace-oci-deploy env=staging tag="$APP_TAG"
 
 ## Verify staging
 
+Generic verification discovers the host from Helm values or Ingress, executes
+the configured HTTP checks, and exits non-zero if any path fails.
+
 ```bash
 just app-status app=tokenplace env=staging
 ```
@@ -107,6 +110,16 @@ just app-status app=tokenplace env=staging
 ```bash
 just app-verify app=tokenplace env=staging
 ```
+
+Print the generated curl commands without executing them when updating docs or
+troubleshooting host discovery.
+
+```bash
+just app-verify app=tokenplace env=staging print_only=1
+```
+
+Manual curl commands are optional fallbacks when Cloudflare, DNS, or
+cert-manager are suspect.
 
 ```bash
 curl -fsS https://staging.token.place/healthz

--- a/justfile
+++ b/justfile
@@ -1593,14 +1593,21 @@ app-promote-prod app tag='' config='':
       config="${SUGARKUBE_CONFIG_PATH}"
 
 # Verify configured HTTPS paths for a Sugarkube app.
-app-verify app env='staging' config='':
+app-verify app env='staging' config='' print_only='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
+
+    config_input={{ quote(config) }}
+    print_only_input={{ quote(print_only) }}
+    if [ -z "${print_only_input}" ] && [[ "${config_input}" == print_only=* ]]; then
+      print_only_input="${config_input#print_only=}"
+      config_input=""
+    fi
 
     eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
       --app {{ quote(app) }} \
       --env {{ quote(env) }} \
-      --config {{ quote(config) }})"
+      --config "${config_input}")"
 
     if [ -z "${KUBECONFIG:-}" ]; then
       export KUBECONFIG="${HOME}/.kube/config"
@@ -1608,6 +1615,22 @@ app-verify app env='staging' config='':
     kube_context="sugar-${SUGARKUBE_ENV}"
     kubectl_context_args=(--context "${kube_context}")
     helm_context_args=(--kube-context "${kube_context}")
+
+    print_only_mode="${SUGARKUBE_APP_VERIFY_PRINT_ONLY:-${print_only_input}}"
+    while [ "${print_only_mode#print_only=}" != "${print_only_mode}" ]; do
+      print_only_mode="${print_only_mode#print_only=}"
+    done
+    case "${print_only_mode}" in
+      1|true|TRUE|yes|YES|on|ON) print_only_mode="1" ;;
+      *) print_only_mode="0" ;;
+    esac
+
+    show_body="${SUGARKUBE_APP_VERIFY_SHOW_BODY:-1}"
+    preview_bytes="${SUGARKUBE_APP_VERIFY_BODY_PREVIEW_BYTES:-4000}"
+    if ! [[ "${preview_bytes}" =~ ^[0-9]+$ ]] || [ "${preview_bytes}" -lt 1 ]; then
+      printf 'ERROR: SUGARKUBE_APP_VERIFY_BODY_PREVIEW_BYTES must be a positive integer.\n' >&2
+      exit 1
+    fi
 
     host=""
     discovery_errors=()
@@ -1633,24 +1656,128 @@ app-verify app env='staging' config='':
       rm -f "${kubectl_error}"
     fi
 
-    IFS=',' read -r -a paths <<< "${SUGARKUBE_VERIFY_PATHS:-/}"
-    if [ -z "${host}" ]; then
-      if [ "${#discovery_errors[@]}" -gt 0 ]; then
-        printf 'Could not derive a host for %s using context %s.\n' "${SUGARKUBE_APP}" "${kube_context}" >&2
-        printf '%s\n' "${discovery_errors[@]}" >&2
-        exit 1
+    IFS=',' read -r -a raw_paths <<< "${SUGARKUBE_VERIFY_PATHS:-/}"
+    paths=()
+    for raw_path in "${raw_paths[@]}"; do
+      path="${raw_path#${raw_path%%[![:space:]]*}}"
+      path="${path%${path##*[![:space:]]}}"
+      [ -n "${path}" ] || continue
+      if [[ "${path}" != /* ]]; then
+        path="/${path}"
       fi
-      echo "Could not derive a host for ${SUGARKUBE_APP}; run these commands after replacing <host>:" >&2
+      paths+=("${path}")
+    done
+    if [ "${#paths[@]}" -eq 0 ]; then
+      paths=("/")
+    fi
+
+    scheme="https"
+    host_display="${host}"
+    if [[ "${host}" == http://* ]]; then
+      scheme="http"
+      host_display="${host#http://}"
+    elif [[ "${host}" == https://* ]]; then
+      scheme="https"
+      host_display="${host#https://}"
+    fi
+    host_display="${host_display%/}"
+
+    print_curl_commands() {
+      local command_host="${host_display:-<host>}"
       for path in "${paths[@]}"; do
-        printf '  curl -fsS https://<host>%s\n' "${path}"
+        printf 'curl -fsS %s://%s%s\n' "${scheme}" "${command_host}" "${path}"
       done
+    }
+
+    if [ -z "${host_display}" ]; then
+      printf 'Could not derive a host for %s using context %s.\n' "${SUGARKUBE_APP}" "${kube_context}" >&2
+      if [ "${#discovery_errors[@]}" -gt 0 ]; then
+        printf '%s\n' "${discovery_errors[@]}" >&2
+      fi
+      printf 'Run `just app-status app=%s env=%s` or `just app-config app=%s env=%s` to inspect the deployment, or run these commands after replacing <host>:\n' \
+        "${SUGARKUBE_APP}" "${SUGARKUBE_ENV}" "${SUGARKUBE_APP}" "${SUGARKUBE_ENV}" >&2
+      print_curl_commands
+      if [ "${print_only_mode}" = "1" ]; then
+        exit 0
+      fi
+      exit 1
+    fi
+
+    if [ "${print_only_mode}" = "1" ]; then
+      print_curl_commands
       exit 0
     fi
 
+    total="${#paths[@]}"
+    passed=0
+    failed=0
+    failing_paths=()
+
+    printf 'Verifying %s env=%s\n' "${SUGARKUBE_APP}" "${SUGARKUBE_ENV}"
+    printf 'Host: %s://%s\n' "${scheme}" "${host_display}"
+
+    index=0
     for path in "${paths[@]}"; do
-      printf 'curl -fsS https://%s%s\n' "${host}" "${path}"
-      curl -fsS "https://${host}${path}" >/dev/null
+      index=$((index + 1))
+      url="${scheme}://${host_display}${path}"
+      body_file="$(mktemp)"
+      header_file="$(mktemp)"
+      curl_error="$(mktemp)"
+      http_status="000"
+      curl_status=0
+
+      set +e
+      http_status="$(curl -sS -L -o "${body_file}" -D "${header_file}" -w '%{http_code}' "${url}" 2>"${curl_error}")"
+      curl_status=$?
+      set -e
+      http_status="${http_status//$'\n'/}"
+      if [ -z "${http_status}" ]; then
+        http_status="000"
+      fi
+
+      printf '\n[%s/%s] GET %s\n' "${index}" "${total}" "${path}"
+      printf '  URL: %s\n' "${url}"
+
+      if [ "${curl_status}" -eq 0 ] && [[ "${http_status}" =~ ^[0-9][0-9][0-9]$ ]] && [ "${http_status}" -lt 400 ] && [ "${http_status}" -ge 200 ]; then
+        printf '  Status: OK (HTTP %s)\n' "${http_status}"
+        passed=$((passed + 1))
+      else
+        printf '  Status: FAIL (curl exit %s, HTTP %s)\n' "${curl_status}" "${http_status}"
+        if [ -s "${curl_error}" ]; then
+          printf '  curl error: %s\n' "$(tr '\n' ' ' < "${curl_error}")"
+        fi
+        failed=$((failed + 1))
+        failing_paths+=("${path}")
+      fi
+
+      if [ "${show_body}" != "0" ]; then
+        if [ -s "${body_file}" ]; then
+          body_size="$(wc -c < "${body_file}" | tr -d '[:space:]')"
+          if [ "${body_size}" -le "${preview_bytes}" ]; then
+            printf '  Body:\n'
+            sed 's/^/  /' "${body_file}"
+            printf '\n'
+          else
+            printf '  Body preview (%s of %s bytes):\n' "${preview_bytes}" "${body_size}"
+            head -c "${preview_bytes}" "${body_file}" | sed 's/^/  /'
+            printf '\n  ...\n'
+          fi
+        else
+          printf '  Body: <empty>\n'
+        fi
+      fi
+
+      rm -f "${body_file}" "${header_file}" "${curl_error}"
     done
+
+    if [ "${failed}" -eq 0 ]; then
+      printf '\nVerification passed: %s/%s checks succeeded.\n' "${passed}" "${total}"
+      exit 0
+    fi
+
+    printf '\nVerification failed: %s/%s checks succeeded; %s failed.\n' "${passed}" "${total}" "${failed}" >&2
+    printf 'Failing paths: %s\n' "${failing_paths[*]}" >&2
+    exit 1
 
 # Opinionated immutable-tag dspace deploy with rollout verification.
 #

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -362,3 +362,9 @@ def test_main_supports_json_shell_validate_tag_and_host_value(
 def test_main_reports_config_errors(capsys: pytest.CaptureFixture[str]) -> None:
     assert app_config.main(["json", "--app", "missing", "--env", "staging"]) == 2
     assert "ERROR: no config found for app 'missing'" in capsys.readouterr().err
+
+
+def test_example_app_verify_paths_remain_expected() -> None:
+    assert app_config.load_config("danielsmith", "staging")["SUGARKUBE_VERIFY_PATHS"] == "/,/livez,/healthz"
+    assert app_config.load_config("tokenplace", "staging")["SUGARKUBE_VERIFY_PATHS"] == "/,/livez,/healthz,/relay/diagnostics"
+    assert app_config.load_config("dspace", "staging")["SUGARKUBE_VERIFY_PATHS"] == "/config.json,/healthz,/livez"

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -102,8 +102,44 @@ exit 0
     )
     _write_executable(
         bin_dir / "curl",
-        """#!/usr/bin/env bash
+        f"""#!/usr/bin/env bash
 set -euo pipefail
+printf '%s\n' "$*" >> {str(tmp_path / "curl.log")!r}
+out=''
+write_out=''
+url=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -w) write_out="$2"; shift 2 ;;
+    -D) shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+status=200
+body='{{"status":"ok"}}'
+if [[ "${{url}}" == */ ]]; then
+  body=$'<!doctype html>\n<html lang="en">\n<body>ok</body>'
+fi
+if [ -n "${{SUGARKUBE_STUB_CURL_LARGE_BODY:-}}" ]; then
+  body="$(python3 - <<'BODY'
+print('x' * 5000)
+BODY
+)"
+fi
+if [ -n "${{SUGARKUBE_STUB_CURL_FAIL_PATH:-}}" ] && [[ "${{url}}" == *"${{SUGARKUBE_STUB_CURL_FAIL_PATH}}" ]]; then
+  status=500
+  body='{{"status":"bad"}}'
+fi
+if [ -n "${{out}}" ]; then
+  printf '%s\n' "${{body}}" > "${{out}}"
+else
+  printf '%s\n' "${{body}}"
+fi
+if [ -n "${{write_out}}" ]; then
+  printf '%s' "${{status}}"
+fi
 exit 0
 """,
     )
@@ -114,6 +150,7 @@ exit 0
     env["SUGARKUBE_HELM_ROLLOUT_TIMEOUT"] = "1s"
     env["HELM_LOG"] = str(log_path)
     env["KUBECTL_LOG"] = str(tmp_path / "kubectl.log")
+    env["CURL_LOG"] = str(tmp_path / "curl.log")
     return env
 
 
@@ -343,4 +380,89 @@ def test_app_verify_fails_closed_when_context_host_discovery_fails(
     assert "Could not derive a host for tokenplace using context sugar-staging" in result.stderr
     assert "helm get values failed for context sugar-staging" in result.stderr
     assert "kubectl ingress lookup failed for context sugar-staging" in result.stderr
-    assert "curl -fsS https://<host>" not in result.stdout
+    assert "just app-status app=tokenplace env=staging" in result.stderr
+    assert "curl -fsS https://<host>/livez" in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_executes_curl_by_default_and_prints_summary(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(["app-verify", "app=danielsmith", "env=staging"], generic_app_stub_env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    curl_log = Path(generic_app_stub_env["CURL_LOG"]).read_text(encoding="utf-8")
+    assert "https://example.test/" in curl_log
+    assert "https://example.test/livez" in curl_log
+    assert "https://example.test/healthz" in curl_log
+    assert result.stdout.startswith("Verifying danielsmith env=staging\nHost: https://example.test\n\n")
+    assert "\n[1/3] GET /\n  URL: https://example.test/\n  Status: OK" in result.stdout
+    assert "\n[2/3] GET /livez\n  URL: https://example.test/livez\n  Status: OK" in result.stdout
+    assert "\n[3/3] GET /healthz\n  URL: https://example.test/healthz\n  Status: OK" in result.stdout
+    assert "  Body:" in result.stdout
+    assert "Verification passed: 3/3 checks succeeded." in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_checks_all_paths_before_failing(generic_app_stub_env: dict[str, str]) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_CURL_FAIL_PATH"] = "/livez"
+
+    result = _run_just(["app-verify", "app=danielsmith", "env=staging"], env)
+
+    assert result.returncode != 0
+    curl_log = Path(env["CURL_LOG"]).read_text(encoding="utf-8")
+    assert "https://example.test/" in curl_log
+    assert "https://example.test/livez" in curl_log
+    assert "https://example.test/healthz" in curl_log
+    assert "[2/3] GET /livez" in result.stdout
+    assert "Status: FAIL (curl exit 0, HTTP 500)" in result.stdout
+    assert "[3/3] GET /healthz" in result.stdout
+    assert "Verification failed: 2/3 checks succeeded; 1 failed." in result.stderr
+    assert "Failing paths: /livez" in result.stderr
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_print_only_prints_commands_without_curl(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        ["app-verify", "app=tokenplace", "env=staging", "print_only=1"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert result.stdout.splitlines() == [
+        "curl -fsS https://example.test/",
+        "curl -fsS https://example.test/livez",
+        "curl -fsS https://example.test/healthz",
+        "curl -fsS https://example.test/relay/diagnostics",
+    ]
+    curl_log_path = Path(generic_app_stub_env["CURL_LOG"])
+    assert not curl_log_path.exists() or curl_log_path.read_text(encoding="utf-8") == ""
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_can_suppress_response_bodies(generic_app_stub_env: dict[str, str]) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_APP_VERIFY_SHOW_BODY"] = "0"
+
+    result = _run_just(["app-verify", "app=danielsmith", "env=staging"], env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "  URL: https://example.test/" in result.stdout
+    assert "  Status: OK" in result.stdout
+    assert "  Body" not in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_body_preview_is_bounded(generic_app_stub_env: dict[str, str]) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_CURL_LARGE_BODY"] = "1"
+    env["SUGARKUBE_APP_VERIFY_BODY_PREVIEW_BYTES"] = "25"
+
+    result = _run_just(["app-verify", "app=danielsmith", "env=staging"], env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "Body preview (25 of " in result.stdout
+    assert "  ..." in result.stdout


### PR DESCRIPTION
### Motivation
- `just app-verify` previously only printed `curl` hints instead of running verification checks, forcing manual copy/paste and producing cramped, hard-to-read output.
- Operators need a readable, per-path verification report that fails the recipe when any check is bad while still reporting all paths.
- Keep the old print-only behavior for docs/debugging and preserve host-discovery fallback guidance when the host cannot be derived.

### Description
- Implemented execution-mode verification in the root `justfile` so `app-verify` runs `curl` against the configured `SUGARKUBE_VERIFY_PATHS` by default and aggregates pass/fail results. (key changes in `justfile` recipe `app-verify`).
- Added print-only support via `print_only=1` or `SUGARKUBE_APP_VERIFY_PRINT_ONLY=1`, optional body suppression via `SUGARKUBE_APP_VERIFY_SHOW_BODY=0`, and a configurable preview size via `SUGARKUBE_APP_VERIFY_BODY_PREVIEW_BYTES`.
- Improved host discovery logic and added a helpful fallback that prints `curl -fsS https://<host>...` placeholders and suggests `just app-status` / `just app-config` when discovery fails (non-zero exit unless print-only requested).
- Tests updated/added in `tests/test_generic_app_just_recipes.py` and `tests/test_app_config.py` to cover execution, aggregated failures, print-only behavior, body suppression, and bounded preview; `curl`/`helm`/`kubectl` are stubbed in test fixtures to avoid live network/cluster.
- Documentation updated to reflect the change in behavior in `docs/app_deployment_contract.md`, `docs/app_onboarding.md`, and per-app docs in `docs/apps/danielsmith.md`, `docs/apps/dspace.md`, and `docs/apps/tokenplace.md` (describe executing checks and print-only usage).

### Testing
- Ran focused tests: `python -m pytest tests/test_generic_app_just_recipes.py tests/test_app_config.py -q` — all tests passed.
- Ran the full test suite: `python -m pytest tests -q` — `1264 passed, 19 skipped` (local environment), all test runs succeeded.
- Verified command output: `just app-config app=danielsmith env=staging` and stubbed runs of `just app-verify` for `danielsmith`, `tokenplace`, and `dspace` (using a temporary PATH with stubbed `curl`/`helm`/`kubectl`) produced the readable per-path summaries and print-only output as intended.
- Ran static checks: `git diff --check` and `git diff | ./scripts/scan-secrets.py` (passed); `pre-commit`, `pyspelling`, and `linkchecker` could not be executed in this container because those tools were not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20e7375f34832fbfc229fd216ec3c6)