### PR TITLE
Make `just app-verify` execute HTTP checks with readable output

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -175,8 +175,11 @@ just app-promote-prod app=dspace tag=main-REPLACE_SHORTSHA
 # Inspect Kubernetes and Helm status for an app environment.
 just app-status app=dspace env=staging
 
-# Run HTTP verification paths for an app environment.
+# Execute HTTP verification paths for an app environment.
 just app-verify app=dspace env=staging
+
+# Print the equivalent curl commands without executing requests.
+just app-verify app=dspace env=staging print_only=1
 
 # Print the resolved app config for review/debugging.
 just app-config app=dspace env=staging

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -201,4 +201,10 @@ just app-status app=appslug env=staging config="$APP_CONFIG"
 just app-verify app=appslug env=staging config="$APP_CONFIG"
 ```
 
+`just app-verify` executes the configured HTTP checks and exits non-zero after reporting every failed path. To print the generated commands without making network requests, run:
+
+```bash
+just app-verify app=appslug env=staging config="$APP_CONFIG" print_only=1
+```
+
 Add app-specific checks only for behavior the generic URL checks cannot validate, such as a login-free API health endpoint, a static asset manifest, a queue worker heartbeat, or a safe diagnostics endpoint.

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -100,6 +100,8 @@ just danielsmith-oci-deploy env=staging tag="$APP_TAG"
 
 ## Verify staging
 
+`just app-verify` discovers the public host and executes the configured HTTP checks directly. Use `print_only=1` when you only want to print the equivalent `curl -fsS` commands for docs or debugging.
+
 ```bash
 just app-status app=danielsmith env=staging
 ```
@@ -107,6 +109,12 @@ just app-status app=danielsmith env=staging
 ```bash
 just app-verify app=danielsmith env=staging
 ```
+
+```bash
+just app-verify app=danielsmith env=staging print_only=1
+```
+
+Manual public checks are optional troubleshooting fallbacks when DNS, Cloudflare, or certificates are suspect.
 
 ```bash
 curl -fsS https://staging.danielsmith.io/healthz

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -102,7 +102,7 @@ just dspace-oci-deploy env=staging tag="$APP_TAG"
 
 ## Verify staging
 
-Generic verification discovers the host from Helm values or Ingress and checks the configured DSPACE paths.
+Generic verification discovers the host from Helm values or Ingress and executes the configured DSPACE HTTP checks directly. Use `print_only=1` when you only want to print the equivalent `curl -fsS` commands for docs or debugging.
 
 ```bash
 just app-status app=dspace env=staging
@@ -112,7 +112,11 @@ just app-status app=dspace env=staging
 just app-verify app=dspace env=staging
 ```
 
-Manual public checks are useful when Cloudflare or cert-manager are suspect.
+```bash
+just app-verify app=dspace env=staging print_only=1
+```
+
+Manual public checks are optional troubleshooting fallbacks when Cloudflare or cert-manager are suspect.
 
 ```bash
 curl -fsS https://staging.democratized.space/config.json | jq .

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -100,6 +100,8 @@ just tokenplace-oci-deploy env=staging tag="$APP_TAG"
 
 ## Verify staging
 
+`just app-verify` discovers the public host and executes the configured HTTP checks directly. Use `print_only=1` when you only want to print the equivalent `curl -fsS` commands for docs or debugging.
+
 ```bash
 just app-status app=tokenplace env=staging
 ```
@@ -107,6 +109,12 @@ just app-status app=tokenplace env=staging
 ```bash
 just app-verify app=tokenplace env=staging
 ```
+
+```bash
+just app-verify app=tokenplace env=staging print_only=1
+```
+
+Manual public checks are optional troubleshooting fallbacks when DNS, Cloudflare, or certificates are suspect.
 
 ```bash
 curl -fsS https://staging.token.place/healthz

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
-set export := true
+set export
 
 export SUGARKUBE_CLUSTER := env('SUGARKUBE_CLUSTER', 'sugar')
 export SUGARKUBE_SERVERS := env('SUGARKUBE_SERVERS', '1')
@@ -1593,64 +1593,28 @@ app-promote-prod app tag='' config='':
       config="${SUGARKUBE_CONFIG_PATH}"
 
 # Verify configured HTTPS paths for a Sugarkube app.
-app-verify app env='staging' config='':
+app-verify app env='staging' arg3='' arg4='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+    config=""
+    print_only=""
+    for raw_arg in {{ quote(arg3) }} {{ quote(arg4) }}; do
+      if [ -z "${raw_arg}" ]; then
+        continue
+      fi
+      case "${raw_arg}" in
+        config=*) config="${raw_arg#config=}" ;;
+        print_only=*) print_only="${raw_arg#print_only=}" ;;
+        *) config="${raw_arg}" ;;
+      esac
+    done
+
+    python3 "{{ justfile_directory() }}/scripts/app_verify.py" \
       --app {{ quote(app) }} \
       --env {{ quote(env) }} \
-      --config {{ quote(config) }})"
-
-    if [ -z "${KUBECONFIG:-}" ]; then
-      export KUBECONFIG="${HOME}/.kube/config"
-    fi
-    kube_context="sugar-${SUGARKUBE_ENV}"
-    kubectl_context_args=(--context "${kube_context}")
-    helm_context_args=(--kube-context "${kube_context}")
-
-    host=""
-    discovery_errors=()
-    if command -v helm >/dev/null 2>&1; then
-      helm_values=""
-      helm_error="$(mktemp)"
-      if helm_values="$(helm "${helm_context_args[@]}" get values "${SUGARKUBE_RELEASE}" \
-        --namespace "${SUGARKUBE_NAMESPACE}" \
-        --all --output json 2>"${helm_error}")"; then
-        host="$(printf '%s\n' "${helm_values}" | \
-          python3 "{{ justfile_directory() }}/scripts/app_config.py" host-value "${SUGARKUBE_STATUS_HOST_KEY:-ingress.host}")"
-      else
-        discovery_errors+=("helm get values failed for context ${kube_context}: $(tr '\n' ' ' < "${helm_error}")")
-      fi
-      rm -f "${helm_error}"
-    fi
-    if [ -z "${host}" ] && command -v kubectl >/dev/null 2>&1; then
-      kubectl_error="$(mktemp)"
-      if ! host="$(kubectl "${kubectl_context_args[@]}" -n "${SUGARKUBE_NAMESPACE}" get ingress -o jsonpath='{.items[0].spec.rules[0].host}' 2>"${kubectl_error}")"; then
-        discovery_errors+=("kubectl ingress lookup failed for context ${kube_context}: $(tr '\n' ' ' < "${kubectl_error}")")
-        host=""
-      fi
-      rm -f "${kubectl_error}"
-    fi
-
-    IFS=',' read -r -a paths <<< "${SUGARKUBE_VERIFY_PATHS:-/}"
-    if [ -z "${host}" ]; then
-      if [ "${#discovery_errors[@]}" -gt 0 ]; then
-        printf 'Could not derive a host for %s using context %s.\n' "${SUGARKUBE_APP}" "${kube_context}" >&2
-        printf '%s\n' "${discovery_errors[@]}" >&2
-        exit 1
-      fi
-      echo "Could not derive a host for ${SUGARKUBE_APP}; run these commands after replacing <host>:" >&2
-      for path in "${paths[@]}"; do
-        printf '  curl -fsS https://<host>%s\n' "${path}"
-      done
-      exit 0
-    fi
-
-    for path in "${paths[@]}"; do
-      printf 'curl -fsS https://%s%s\n' "${host}" "${path}"
-      curl -fsS "https://${host}${path}" >/dev/null
-    done
+      --config "${config}" \
+      --print-only "${print_only}"
 
 # Opinionated immutable-tag dspace deploy with rollout verification.
 #

--- a/scripts/app_verify.py
+++ b/scripts/app_verify.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Run public HTTP verification checks for a configured Sugarkube app."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from urllib.parse import urljoin
+
+from app_config import AppConfigError, load_config
+
+TRUE_VALUES = {"1", "true", "yes", "on"}
+FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+def _normalize_named(value: str, name: str) -> str:
+    value = (value or "").strip()
+    prefix = f"{name}="
+    while value.startswith(prefix):
+        value = value[len(prefix) :].strip()
+    return value
+
+
+def _is_truthy(value: str) -> bool:
+    return value.strip().lower() in TRUE_VALUES
+
+
+def _is_falsey(value: str) -> bool:
+    return value.strip().lower() in FALSE_VALUES
+
+
+def _parse_paths(raw: str) -> list[str]:
+    paths: list[str] = []
+    for part in (raw or "/").split(","):
+        path = re.sub(r"\s+", "", part)
+        if not path:
+            continue
+        if not path.startswith("/"):
+            path = f"/{path}"
+        paths.append(path)
+    return paths or ["/"]
+
+
+def _run_text(args: list[str]) -> tuple[int, str, str]:
+    try:
+        proc = subprocess.run(args, capture_output=True, text=True, check=False)
+    except FileNotFoundError as exc:
+        return 127, "", str(exc)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _discover_host(config: dict[str, str], kube_context: str) -> tuple[str, list[str]]:
+    errors: list[str] = []
+    host = ""
+
+    helm_rc, helm_out, helm_err = _run_text(
+        [
+            "helm",
+            "--kube-context",
+            kube_context,
+            "get",
+            "values",
+            config["SUGARKUBE_RELEASE"],
+            "--namespace",
+            config["SUGARKUBE_NAMESPACE"],
+            "--all",
+            "--output",
+            "json",
+        ]
+    )
+    if helm_rc == 0:
+        helper = Path(__file__).with_name("app_config.py")
+        try:
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(helper),
+                    "host-value",
+                    config.get("SUGARKUBE_STATUS_HOST_KEY", "ingress.host"),
+                ],
+                input=helm_out,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if proc.returncode == 0:
+                host = proc.stdout.strip()
+        except OSError as exc:
+            errors.append(f"helm host parsing failed for context {kube_context}: {exc}")
+    elif helm_rc != 127:
+        errors.append(
+            f"helm get values failed for context {kube_context}: "
+            f"{helm_err.replace(chr(10), ' ').strip()}"
+        )
+
+    if host:
+        return host, errors
+
+    kubectl_rc, kubectl_out, kubectl_err = _run_text(
+        [
+            "kubectl",
+            "--context",
+            kube_context,
+            "-n",
+            config["SUGARKUBE_NAMESPACE"],
+            "get",
+            "ingress",
+            "-o",
+            "jsonpath={.items[0].spec.rules[0].host}",
+        ]
+    )
+    if kubectl_rc == 0:
+        host = kubectl_out.strip()
+    elif kubectl_rc != 127:
+        errors.append(
+            f"kubectl ingress lookup failed for context {kube_context}: "
+            f"{kubectl_err.replace(chr(10), ' ').strip()}"
+        )
+
+    return host, errors
+
+
+def _print_commands(host: str, paths: list[str]) -> None:
+    target = host or "<host>"
+    for path in paths:
+        print(f"curl -fsS https://{target}{path}")
+
+
+def _body_preview(path: Path, limit: int) -> tuple[str, bool, bool]:
+    data = path.read_bytes() if path.exists() else b""
+    if not data:
+        return "", False, False
+    truncated = len(data) > limit
+    preview = data[:limit]
+    return preview.decode("utf-8", errors="replace"), truncated, True
+
+
+def _run_curl(url: str, body_path: Path) -> tuple[int, str, str]:
+    try:
+        proc = subprocess.run(
+            ["curl", "-sS", "-L", "-o", str(body_path), "-w", "%{http_code}", url],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return 127, "000", str(exc)
+    status = proc.stdout.strip() or "000"
+    return proc.returncode, status, proc.stderr.strip()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--app", required=True)
+    parser.add_argument("--env", required=True)
+    parser.add_argument("--config", default="")
+    parser.add_argument("--print-only", default="")
+    args = parser.parse_args(argv)
+
+    try:
+        config = load_config(args.app, args.env, args.config or None)
+    except AppConfigError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    os.environ.setdefault("KUBECONFIG", str(Path.home() / ".kube" / "config"))
+    kube_context = f"sugar-{config['SUGARKUBE_ENV']}"
+    paths = _parse_paths(config.get("SUGARKUBE_VERIFY_PATHS", "/"))
+
+    print_only_raw = os.environ.get("SUGARKUBE_APP_VERIFY_PRINT_ONLY", args.print_only)
+    print_only_raw = _normalize_named(print_only_raw, "print_only")
+    print_only = _is_truthy(print_only_raw)
+
+    show_body_raw = os.environ.get("SUGARKUBE_APP_VERIFY_SHOW_BODY", "1")
+    show_body = not _is_falsey(show_body_raw)
+    try:
+        preview_bytes = int(os.environ.get("SUGARKUBE_APP_VERIFY_BODY_PREVIEW_BYTES", "4000"))
+    except ValueError:
+        print(
+            "ERROR: SUGARKUBE_APP_VERIFY_BODY_PREVIEW_BYTES must be a non-negative integer.",
+            file=sys.stderr,
+        )
+        return 2
+    if preview_bytes < 0:
+        print(
+            "ERROR: SUGARKUBE_APP_VERIFY_BODY_PREVIEW_BYTES must be a non-negative integer.",
+            file=sys.stderr,
+        )
+        return 2
+
+    host, discovery_errors = _discover_host(config, kube_context)
+    if not host:
+        print(
+            f"Could not derive a host for {config['SUGARKUBE_APP']} using context {kube_context}.",
+            file=sys.stderr,
+        )
+        for error in discovery_errors:
+            print(error, file=sys.stderr)
+        print(
+            "Run `just app-status app={app} env={env}` or `just app-config app={app} env={env}` "
+            "to inspect deployment details.".format(
+                app=config["SUGARKUBE_APP"], env=config["SUGARKUBE_ENV"]
+            ),
+            file=sys.stderr,
+        )
+        print("Verification commands after replacing <host>:")
+        _print_commands("", paths)
+        return 0 if print_only else 1
+
+    if print_only:
+        _print_commands(host, paths)
+        return 0
+
+    print(f"Verifying {config['SUGARKUBE_APP']} env={config['SUGARKUBE_ENV']}")
+    print(f"Host: https://{host}")
+
+    failures: list[str] = []
+    passed = 0
+    for index, path in enumerate(paths, start=1):
+        url = urljoin(f"https://{host}/", path.lstrip("/"))
+        print()
+        print(f"[{index}/{len(paths)}] GET {path}")
+        print(f"  URL: {url}")
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            body_path = Path(tmp.name)
+        try:
+            curl_exit, http_status, curl_error = _run_curl(url, body_path)
+            http_ok = http_status.isdigit() and 200 <= int(http_status) < 400
+            if curl_exit == 0 and http_ok:
+                print(f"  Status: OK (HTTP {http_status})")
+                passed += 1
+            else:
+                print(f"  Status: FAIL (HTTP {http_status or 'unknown'}, curl exit {curl_exit})")
+                if curl_error:
+                    print(f"  Error: {curl_error.replace(chr(10), ' ')}")
+                failures.append(f"{path} ({url})")
+
+            if show_body:
+                preview, truncated, has_body = _body_preview(body_path, preview_bytes)
+                if not has_body:
+                    print("  Body: <empty>")
+                else:
+                    print(f"  {'Body preview' if truncated else 'Body'}:")
+                    for line in preview.splitlines() or [""]:
+                        print(f"  {line}")
+                    if truncated:
+                        print(f"  ... [truncated to {preview_bytes} bytes]")
+            else:
+                print("  Body: <suppressed by SUGARKUBE_APP_VERIFY_SHOW_BODY=0>")
+        finally:
+            body_path.unlink(missing_ok=True)
+
+    print()
+    if not failures:
+        print(f"Verification passed: {passed}/{len(paths)} checks succeeded.")
+        return 0
+
+    failed = len(failures)
+    print(
+        f"Verification failed: {passed}/{len(paths)} checks succeeded; {failed} failed.",
+        file=sys.stderr,
+    )
+    print("Failed paths:", file=sys.stderr)
+    for failure in failures:
+        print(f"  {failure}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -102,8 +103,45 @@ exit 0
     )
     _write_executable(
         bin_dir / "curl",
-        """#!/usr/bin/env bash
+        f"""#!/usr/bin/env bash
 set -euo pipefail
+printf '%s\n' "$*" >> {str(tmp_path / "curl.log")!r}
+out=''
+write_status=''
+url=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -w) write_status="$2"; shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+url_without_scheme="${{url#https://}}"
+path="/${{url_without_scheme#*/}}"
+if [[ "${{path}}" == "//" || "${{path}}" == "/${{url_without_scheme}}" ]]; then
+  path="/"
+fi
+case "${{path}}" in
+  /) body='<!doctype html>
+<html lang="en" data-app-mode="loading" data-app-loading>
+<body>ok</body>
+</html>' ;;
+  /config.json) body='{{"status":"configured"}}' ;;
+  /relay/diagnostics) body='{{"relay":"ok"}}' ;;
+  *) body='{{"status":"ok"}}' ;;
+esac
+status=200
+if [[ ",${{SUGARKUBE_STUB_CURL_FAIL_PATHS:-}}," == *",${{path}},"* ]]; then
+  status=500
+  body='{{"status":"error"}}'
+fi
+if [ -n "${{out}}" ]; then
+  printf '%b' "${{body}}" > "${{out}}"
+fi
+if [ -n "${{write_status}}" ]; then
+  printf '%s' "${{status}}"
+fi
 exit 0
 """,
     )
@@ -114,6 +152,7 @@ exit 0
     env["SUGARKUBE_HELM_ROLLOUT_TIMEOUT"] = "1s"
     env["HELM_LOG"] = str(log_path)
     env["KUBECTL_LOG"] = str(tmp_path / "kubectl.log")
+    env["CURL_LOG"] = str(tmp_path / "curl.log")
     return env
 
 
@@ -343,4 +382,101 @@ def test_app_verify_fails_closed_when_context_host_discovery_fails(
     assert "Could not derive a host for tokenplace using context sugar-staging" in result.stderr
     assert "helm get values failed for context sugar-staging" in result.stderr
     assert "kubectl ingress lookup failed for context sugar-staging" in result.stderr
-    assert "curl -fsS https://<host>" not in result.stdout
+    assert "Verification commands after replacing <host>:" in result.stdout
+    assert "curl -fsS https://<host>/livez" in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_executes_curl_by_default_and_checks_all_paths(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(["app-verify", "app=danielsmith", "env=staging"], generic_app_stub_env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "Verifying danielsmith env=staging" in result.stdout
+    assert "Host: https://example.test" in result.stdout
+    assert "\n[1/3] GET /\n" in result.stdout
+    assert "\n[2/3] GET /livez\n" in result.stdout
+    assert "\n[3/3] GET /healthz\n" in result.stdout
+    assert "  URL: https://example.test/" in result.stdout
+    assert "  Status: OK (HTTP 200)" in result.stdout
+    assert "  Body:" in result.stdout
+    assert "Verification passed: 3/3 checks succeeded." in result.stdout
+    curl_log = Path(generic_app_stub_env["CURL_LOG"]).read_text(encoding="utf-8")
+    assert "https://example.test/" in curl_log
+    assert "https://example.test/livez" in curl_log
+    assert "https://example.test/healthz" in curl_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_exits_nonzero_after_attempting_all_paths_on_failure(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_CURL_FAIL_PATHS"] = "/livez"
+
+    result = _run_just(["app-verify", "app=danielsmith", "env=staging"], env)
+
+    assert result.returncode != 0
+    assert "\n[1/3] GET /\n" in result.stdout
+    assert "\n[2/3] GET /livez\n" in result.stdout
+    assert "\n[3/3] GET /healthz\n" in result.stdout
+    assert "Status: FAIL (HTTP 500, curl exit 0)" in result.stdout
+    assert "Verification failed: 2/3 checks succeeded; 1 failed." in result.stderr
+    curl_log = Path(env["CURL_LOG"]).read_text(encoding="utf-8")
+    assert "https://example.test/" in curl_log
+    assert "https://example.test/livez" in curl_log
+    assert "https://example.test/healthz" in curl_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_print_only_prints_commands_without_calling_curl(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        ["app-verify", "app=tokenplace", "env=staging", "print_only=1"], generic_app_stub_env
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert result.stdout.splitlines() == [
+        "curl -fsS https://example.test/",
+        "curl -fsS https://example.test/livez",
+        "curl -fsS https://example.test/healthz",
+        "curl -fsS https://example.test/relay/diagnostics",
+    ]
+    curl_log_path = Path(generic_app_stub_env["CURL_LOG"])
+    assert not curl_log_path.exists() or curl_log_path.read_text(encoding="utf-8") == ""
+
+
+@pytest.mark.parametrize(
+    ("app", "expected_paths"),
+    [
+        ("danielsmith", ["/", "/livez", "/healthz"]),
+        ("tokenplace", ["/", "/livez", "/healthz", "/relay/diagnostics"]),
+        ("dspace", ["/config.json", "/healthz", "/livez"]),
+    ],
+)
+def test_example_app_configs_expose_expected_verification_paths(
+    app: str, expected_paths: list[str]
+) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "app_config.py"),
+            "json",
+            "--app",
+            app,
+            "--env",
+            "staging",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    import json
+
+    config = json.loads(result.stdout)
+    assert config["SUGARKUBE_VERIFY_PATHS"].split(",") == expected_paths


### PR DESCRIPTION
### Motivation
- Operators expect `just app-verify` to actually run the configured HTTP verification paths and present a readable per-path report instead of only printing curl hints.
- Existing behavior required manual copy/paste and produced cramped output; verification should be automated, informative, and fail the recipe when checks fail.

### Description
- Add `scripts/app_verify.py`, a Python helper that: resolves app config via `scripts/app_config.py`, discovers the public host from Helm values or Ingress, parses `SUGARKUBE_VERIFY_PATHS`, executes `curl -sS -L` for each path, prints a human-friendly per-path summary including URL, status and a bounded body preview, and exits non-zero if any check fails; it supports `SUGARKUBE_APP_VERIFY_BODY_PREVIEW_BYTES` and `SUGARKUBE_APP_VERIFY_SHOW_BODY` to control body previewing.  (new file)
- Update the `just app-verify` recipe in `justfile` to delegate to `scripts/app_verify.py` and accept `print_only=` (and `SUGARKUBE_APP_VERIFY_PRINT_ONLY`) to preserve the old print-only behavior without making network requests. (modified `justfile`)
- Add and extend unit tests in `tests/test_generic_app_just_recipes.py` to stub `curl`, `helm`, and `kubectl` and cover: executing curl by default, checking all configured paths, non-zero exit after attempting all paths on failure, print-only behavior that prints commands and does not call `curl`, host-discovery fallback output, and that example app configs expose expected verification paths. (modified tests)
- Update docs to reflect the new default executing behavior and document `print_only=1` as a troubleshooting fallback in `docs/app_deployment_contract.md`, `docs/app_onboarding.md`, and `docs/apps/{danielsmith,dspace,tokenplace}.md`. (modified docs)

### Testing
- Ran formatting and static checks where available: `git diff --check` (no issues reported).
- Ran unit test suite with stubbed tools: `PATH="/tmp/just-bin:$PATH" python -m pytest tests -q`, resulting in all tests passing (`1264 passed, 19 skipped` in the local run during development, focused tests completed successfully during iterative development).
- Verified `just` invocations with stubbed `helm`/`kubectl`/`curl`: `just app-config app=danielsmith env=staging` and `just app-verify` for `danielsmith`, `tokenplace`, and `dspace` in the test harness produced the readable reports and `print_only` output as intended.
- Notes: repo-local checks `pre-commit`, `pyspelling`, and `linkchecker` were not available in the container used for this run, so those were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20e7375f34832fbfc229fd216ec3c6)