### PR TITLE
Enable danielsmith GitHub metrics cache sidecar and add verification docs/tests

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -210,4 +210,4 @@ Current values chains:
 | --- | --- | --- | --- | --- |
 | dspace | `docs/examples/dspace.values.dev.yaml` | `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml` | `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml` | `/config.json,/healthz,/livez` |
 | token.place | `docs/examples/tokenplace.values.dev.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml` | `/,/livez,/healthz,/relay/diagnostics` |
-| danielsmith.io | `docs/examples/danielsmith.values.dev.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml` | `/,/livez,/healthz` |
+| danielsmith.io | `docs/examples/danielsmith.values.dev.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml` | `/,/livez,/healthz,/runtime/github-metrics.json` |

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -17,7 +17,7 @@ This is the canonical runbook for deploying danielsmith.io from GHCR artifacts t
 | App config | `docs/examples/apps/danielsmith.env` |
 | Chart version pin | `docs/apps/danielsmith.version` |
 | Production tag pin | `docs/apps/danielsmith.prod.tag` |
-| Verify paths | `/`, `/livez`, `/healthz` |
+| Verify paths | `/`, `/livez`, `/healthz`, `/runtime/github-metrics.json` |
 
 ### Artifact links
 
@@ -41,6 +41,39 @@ Use these links before changing a deployment so the workflow runs, package versi
 - `env=staging`: staging host `staging.danielsmith.io` with values `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml`.
 - `env=prod`: production host `danielsmith.io` with values `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml`.
 - The app is a static Vite and Three.js site. Sugarkube runs the static web container only; no in-cluster API, queue, database, GPU, compute node, or stateful service is required.
+
+## Runtime GitHub metrics cache
+
+Staging and production enable the chart's `githubMetricsCache` sidecar so public
+GitHub repository stars are cached in the pod instead of fetched directly by each
+visitor's browser.
+
+- The `github-metrics-cache` sidecar shares a runtime cache volume with the
+  nginx/static-site container.
+- The sidecar wakes about hourly (`refreshIntervalSeconds: 3600`), calls the
+  unauthenticated public GitHub API for the configured public repositories, and
+  writes `/cache/github-metrics.json` in the shared volume.
+- nginx serves that file to visitors at `/runtime/github-metrics.json`; the app
+  reads this endpoint before using neutral unavailable states.
+- The configured repositories are public POI repositories only. Do not add
+  private repositories unless they are publicly fetchable, and do not add a
+  GitHub token, Kubernetes Secret, `envFrom` Secret, or any authenticated GitHub
+  API path for the current public stars flow.
+- Stars can be up to about an hour old during normal operation. The values set a
+  two-hour cache TTL so one late refresh does not cause visible churn for
+  visitors.
+
+Current staging and production overlays enable the cache with:
+
+```yaml
+githubMetricsCache:
+  enabled: true
+  refreshIntervalSeconds: 3600
+  cacheTtlSeconds: 7200
+```
+
+Dev keeps the chart default (`enabled: false`) unless an operator explicitly
+wants to test the sidecar locally.
 
 ## Find or publish GHCR image
 
@@ -114,12 +147,28 @@ just app-verify app=danielsmith env=staging
 just app-verify app=danielsmith env=staging print_only=1
 ```
 
-Optional manual fallback when debugging DNS, TLS, or Cloudflare behavior:
+Optional manual fallback when debugging DNS, TLS, Cloudflare behavior, or the
+runtime metrics cache:
 
 ```bash
 curl -fsS https://staging.danielsmith.io/healthz
 curl -fsS https://staging.danielsmith.io/livez
 curl -fsS https://staging.danielsmith.io/
+curl -fsS https://staging.danielsmith.io/runtime/github-metrics.json
+```
+
+Inspect the sidecar logs if the runtime JSON file is missing or stale:
+
+```bash
+kubectl --context sugar-staging -n danielsmith logs deploy/danielsmith \
+  -c github-metrics-cache --tail=100
+```
+
+Check the cache shape with Python stdlib tools:
+
+```bash
+curl -fsS https://staging.danielsmith.io/runtime/github-metrics.json \
+  | python3 -c 'import json,sys; data=json.load(sys.stdin); assert data["schemaVersion"]; assert data["generatedAt"]; assert data["repos"]; print(data["schemaVersion"], data["generatedAt"], len(data["repos"]))'
 ```
 
 ## Promote production
@@ -162,6 +211,11 @@ curl -fsS https://danielsmith.io/livez
 
 ```bash
 curl -fsS https://danielsmith.io/
+```
+
+```bash
+curl -fsS https://danielsmith.io/runtime/github-metrics.json \
+  | python3 -c 'import json,sys; data=json.load(sys.stdin); assert data["schemaVersion"]; assert data["generatedAt"]; assert data["repos"]; print(data["schemaVersion"], data["generatedAt"], len(data["repos"]))'
 ```
 
 ## Rollback
@@ -214,6 +268,44 @@ Review logs with the compatibility debug helper.
 ```bash
 just danielsmith-debug-logs-env env=staging
 ```
+
+
+### Runtime GitHub metrics cache troubleshooting
+
+Cache file missing:
+
+- Confirm the deployed values include `githubMetricsCache.enabled=true` for
+  staging or production.
+- Check the sidecar logs:
+
+  ```bash
+  kubectl --context sugar-staging -n danielsmith logs deploy/danielsmith \
+    -c github-metrics-cache --tail=100
+  ```
+
+- Re-run the public path check:
+
+  ```bash
+  curl -fsS https://staging.danielsmith.io/runtime/github-metrics.json
+  ```
+
+GitHub rate limit or transient API failures:
+
+- The sidecar intentionally uses unauthenticated public GitHub API requests for
+  public repository metadata, so the lower unauthenticated rate limit applies.
+- The cache refresh interval is hourly, and `cacheTtlSeconds: 7200` gives the pod
+  a stale-cache grace window when one refresh is late.
+- Do not add a GitHub token or Secret for the current public stars flow. If the
+  public repo list grows enough to require authentication, design that as a
+  separate secret-management change.
+
+Stale cache behavior:
+
+- A normally healthy cache can be roughly one hour old.
+- If `generatedAt` is older than the two-hour TTL, inspect sidecar logs and
+  GitHub rate-limit messages before redeploying.
+- Browser-visible stars should fall back to neutral unavailable states rather
+  than fake numbers when the runtime JSON cannot be served.
 
 Validate GHCR auth if Helm reports `401`, `403`, or `denied`. Use a non-interactive login so recovery works in copy-paste shells; `gh auth token` must have package read access for private packages.
 

--- a/docs/apps/danielsmith.version
+++ b/docs/apps/danielsmith.version
@@ -1,2 +1,2 @@
 # Default danielsmith chart version. Update when new chart releases are published.
-0.1.0
+0.2.1

--- a/docs/examples/apps/danielsmith.env
+++ b/docs/examples/apps/danielsmith.env
@@ -13,5 +13,5 @@ SUGARKUBE_VALUES_DEV=docs/examples/danielsmith.values.dev.yaml
 SUGARKUBE_VALUES_STAGING=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml
 SUGARKUBE_VALUES_PROD=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml
 SUGARKUBE_STATUS_HOST_KEY=ingress.host
-SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz
+SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz,/runtime/github-metrics.json
 SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=danielsmith

--- a/docs/examples/danielsmith.values.prod.yaml
+++ b/docs/examples/danielsmith.values.prod.yaml
@@ -10,3 +10,31 @@ ingress:
   tls:
     enabled: true
     secretName: danielsmith-prod-tls
+
+githubMetricsCache:
+  enabled: true
+  refreshIntervalSeconds: 3600
+  cacheTtlSeconds: 7200
+  repos:
+    - owner: futuroptimist
+      repo: danielsmith.io
+    - owner: futuroptimist
+      repo: token.place
+    - owner: futuroptimist
+      repo: gabriel
+    - owner: futuroptimist
+      repo: flywheel
+    - owner: futuroptimist
+      repo: jobbot3000
+    - owner: futuroptimist
+      repo: gitshelves
+    - owner: futuroptimist
+      repo: f2clipboard
+    - owner: futuroptimist
+      repo: sigma
+    - owner: futuroptimist
+      repo: wove
+    - owner: democratizedspace
+      repo: dspace
+    - owner: futuroptimist
+      repo: pr-reaper

--- a/docs/examples/danielsmith.values.staging.yaml
+++ b/docs/examples/danielsmith.values.staging.yaml
@@ -10,3 +10,31 @@ ingress:
   tls:
     enabled: true
     secretName: danielsmith-staging-tls
+
+githubMetricsCache:
+  enabled: true
+  refreshIntervalSeconds: 3600
+  cacheTtlSeconds: 7200
+  repos:
+    - owner: futuroptimist
+      repo: danielsmith.io
+    - owner: futuroptimist
+      repo: token.place
+    - owner: futuroptimist
+      repo: gabriel
+    - owner: futuroptimist
+      repo: flywheel
+    - owner: futuroptimist
+      repo: jobbot3000
+    - owner: futuroptimist
+      repo: gitshelves
+    - owner: futuroptimist
+      repo: f2clipboard
+    - owner: futuroptimist
+      repo: sigma
+    - owner: futuroptimist
+      repo: wove
+    - owner: democratizedspace
+      repo: dspace
+    - owner: futuroptimist
+      repo: pr-reaper

--- a/tests/test_danielsmith_github_metrics_cache.py
+++ b/tests/test_danielsmith_github_metrics_cache.py
@@ -1,0 +1,90 @@
+"""Regression tests for the danielsmith.io runtime GitHub metrics cache config."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_REPOS = {
+    "futuroptimist/danielsmith.io",
+    "futuroptimist/token.place",
+    "futuroptimist/gabriel",
+    "futuroptimist/flywheel",
+    "futuroptimist/jobbot3000",
+    "futuroptimist/gitshelves",
+    "futuroptimist/f2clipboard",
+    "futuroptimist/sigma",
+    "futuroptimist/wove",
+    "democratizedspace/dspace",
+    "futuroptimist/pr-reaper",
+}
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _github_metrics_block(env: str) -> str:
+    text = _read(f"docs/examples/danielsmith.values.{env}.yaml")
+    match = re.search(r"(?ms)^githubMetricsCache:\n(?P<block>.*)$", text)
+    assert match, f"missing githubMetricsCache block in {env} values"
+    return match.group("block")
+
+
+def _configured_repos(block: str) -> set[str]:
+    repos: set[str] = set()
+    owner = ""
+    for line in block.splitlines():
+        owner_match = re.match(r"\s*- owner: (\S+)\s*$", line)
+        if owner_match:
+            owner = owner_match.group(1)
+            continue
+        repo_match = re.match(r"\s*repo: (\S+)\s*$", line)
+        if repo_match and owner:
+            repos.add(f"{owner}/{repo_match.group(1)}")
+            owner = ""
+    return repos
+
+
+def test_staging_and_prod_enable_public_github_metrics_cache() -> None:
+    for env in ("staging", "prod"):
+        block = _github_metrics_block(env)
+        assert re.search(r"(?m)^\s+enabled: true$", block)
+        assert re.search(r"(?m)^\s+refreshIntervalSeconds: 3600$", block)
+        assert re.search(r"(?m)^\s+cacheTtlSeconds: 7200$", block)
+        assert _configured_repos(block) == EXPECTED_REPOS
+        assert "DSPACE" not in block
+        for forbidden in ("githubToken", "github_token", "GITHUB_TOKEN", "secretName", "envFrom"):
+            assert forbidden not in block
+
+
+def test_dev_keeps_github_metrics_cache_disabled_by_default() -> None:
+    dev_values = _read("docs/examples/danielsmith.values.dev.yaml")
+    assert "githubMetricsCache:" not in dev_values
+
+
+def test_docs_explain_public_cache_without_github_secret() -> None:
+    runbook = _read("docs/apps/danielsmith.md")
+    assert "Runtime GitHub metrics cache" in runbook
+    assert "/runtime/github-metrics.json" in runbook
+    assert "unauthenticated public GitHub API" in runbook
+    assert "Do not add a GitHub token or Secret" in runbook
+    assert "envFrom" in runbook
+
+
+def test_app_config_resolves_danielsmith_staging_and_prod() -> None:
+    for env in ("staging", "prod"):
+        result = subprocess.run(
+            ["python3", "scripts/app_config.py", "json", "--app", "danielsmith", "--env", env],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        config = json.loads(result.stdout)
+        assert config["SUGARKUBE_ENV"] == env
+        assert "/runtime/github-metrics.json" in config["SUGARKUBE_VERIFY_PATHS"]

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -377,16 +377,18 @@ def test_app_verify_executes_curl_by_default_and_prints_summary(
     assert "https://example.test/" in curl_log
     assert "https://example.test/livez" in curl_log
     assert "https://example.test/healthz" in curl_log
+    assert "https://example.test/runtime/github-metrics.json" in curl_log
     assert result.stdout.startswith(
         "Verifying danielsmith env=staging\nHost: https://example.test\n\n"
     )
-    assert "\n[1/3] GET /\n" in result.stdout
-    assert "\n[2/3] GET /livez\n" in result.stdout
-    assert "\n[3/3] GET /healthz\n" in result.stdout
+    assert "\n[1/4] GET /\n" in result.stdout
+    assert "\n[2/4] GET /livez\n" in result.stdout
+    assert "\n[3/4] GET /healthz\n" in result.stdout
+    assert "\n[4/4] GET /runtime/github-metrics.json\n" in result.stdout
     assert "  URL: https://example.test/livez\n" in result.stdout
     assert "  Status: OK (HTTP 200)" in result.stdout
     assert '  Body:\n  {"status":"ok"}' in result.stdout
-    assert "Verification passed: 3/3 checks succeeded." in result.stdout
+    assert "Verification passed: 4/4 checks succeeded." in result.stdout
 
 
 def test_app_verify_adds_curl_timeouts(
@@ -440,11 +442,12 @@ def test_app_verify_failure_checks_all_paths_and_exits_nonzero(
     assert "https://example.test/" in curl_log
     assert "https://example.test/livez" in curl_log
     assert "https://example.test/healthz" in curl_log
-    assert "[2/3] GET /livez" in result.stdout
+    assert "https://example.test/runtime/github-metrics.json" in curl_log
+    assert "[2/4] GET /livez" in result.stdout
     assert "Status: FAILED (HTTP 503)" in result.stdout
     assert "curl exit status: 22" in result.stdout
     assert '{"status":"down"}' in result.stdout
-    assert "Verification failed: 1/3 checks failed." in result.stderr
+    assert "Verification failed: 1/4 checks failed." in result.stderr
     assert "/livez (https://example.test/livez)" in result.stderr
 
 
@@ -481,6 +484,7 @@ def test_app_verify_print_only_argument_overrides_false_environment_value(
         "curl -fsS https://example.test/",
         "curl -fsS https://example.test/livez",
         "curl -fsS https://example.test/healthz",
+        "curl -fsS https://example.test/runtime/github-metrics.json",
     ]
     assert not Path(env["CURL_LOG"]).exists()
 
@@ -498,6 +502,7 @@ def test_app_verify_print_only_environment_prints_commands_without_curl(
         "curl -fsS https://example.test/",
         "curl -fsS https://example.test/livez",
         "curl -fsS https://example.test/healthz",
+        "curl -fsS https://example.test/runtime/github-metrics.json",
     ]
     assert not Path(env["CURL_LOG"]).exists()
 
@@ -518,7 +523,7 @@ def test_app_verify_show_body_can_be_disabled(generic_app_stub_env: dict[str, st
 @pytest.mark.parametrize(
     ("app", "expected_paths"),
     [
-        ("danielsmith", "/,/livez,/healthz"),
+        ("danielsmith", "/,/livez,/healthz,/runtime/github-metrics.json"),
         ("tokenplace", "/,/livez,/healthz,/relay/diagnostics"),
         ("dspace", "/config.json,/healthz,/livez"),
     ],


### PR DESCRIPTION
### Motivation
- Provide an hourly, pod-local cache of public GitHub metrics so visitor browsers read a shared runtime JSON instead of hitting GitHub per-request. 
- Enable the sidecar for staging and production (dev remains off by default) and document how operators verify and troubleshoot it without introducing any secrets.

### Description
- Bumped the danielsmith chart pin in `docs/apps/danielsmith.version` to `0.2.1` to pick up the sidecar-capable chart. 
- Enabled `githubMetricsCache` in `docs/examples/danielsmith.values.staging.yaml` and `docs/examples/danielsmith.values.prod.yaml` with `refreshIntervalSeconds: 3600`, `cacheTtlSeconds: 7200`, and a curated list of public POI repositories only (no private repos, no tokens, no `envFrom` secrets).
- Added `/runtime/github-metrics.json` to the danielsmith verify paths in `docs/examples/apps/danielsmith.env` and the app deployment contract in `docs/app_deployment_contract.md` so `just app-verify`/runbooks exercise the runtime cache endpoint for staging/prod.
- Extended `docs/apps/danielsmith.md` with a “Runtime GitHub metrics cache” section explaining the pod sidecar/shared-volume model, unauthenticated public GitHub API usage (explicitly stating no GitHub token or Kubernetes Secret is configured), expected staleness, verification commands, and troubleshooting steps including sidecar log inspection and JSON-shape checks.
- Added `tests/test_danielsmith_github_metrics_cache.py` to validate the values overlays, repo list, TTLs, and runbook guidance; updated `tests/test_generic_app_just_recipes.py` expectations to include the new runtime path.

### Testing
- Ran the unit test suite: `python3 -m pytest tests` — result: all tests passed (1322 passed, 19 skipped). 
- Ran focused tests: `python3 -m pytest tests/test_danielsmith_github_metrics_cache.py tests/test_generic_app_just_recipes.py -q` — result: passed.
- Verified resolved app config: `just app-config app=danielsmith env=staging` and `just app-config app=danielsmith env=prod` — both returned JSON with `SUGARKUBE_VERIFY_PATHS` including `/runtime/github-metrics.json`.
- Searched docs: `rg "githubMetricsCache" -n docs docs/examples` and `rg "runtime/github-metrics.json" -n docs` — found updated overlays and runbook references.
- Docs link check: `linkchecker --no-warnings README.md docs/` — result: no errors.
- Secrets scan: `git diff --cached | ./scripts/scan-secrets.py` — result: no secrets detected in the changed files.
- Notes about other checks: `pyspelling -c .spellcheck.yaml` was attempted but failed in this environment because `aspell` is not installed; `pre-commit run --all-files` was attempted and flagged unrelated repo-wide YAML/flake8 issues outside this change (auto-fixes to unrelated files were reverted), so the full pre-commit suite was not used to gate this PR in this run.

Residual risks / follow-ups: add authenticated cache support only if and when the public repo list grows and requires it (this requires a separate secret-management change), and run the full `pre-commit`/spellcheck steps in CI where `aspell` and other tooling are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a230a0d18a0832fac7cc36759818ec9)