### PR TITLE
Enable danielsmith GitHub metrics cache sidecar and document verification

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -210,4 +210,4 @@ Current values chains:
 | --- | --- | --- | --- | --- |
 | dspace | `docs/examples/dspace.values.dev.yaml` | `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml` | `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml` | `/config.json,/healthz,/livez` |
 | token.place | `docs/examples/tokenplace.values.dev.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml` | `/,/livez,/healthz,/relay/diagnostics` |
-| danielsmith.io | `docs/examples/danielsmith.values.dev.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml` | `/,/livez,/healthz` |
+| danielsmith.io | `docs/examples/danielsmith.values.dev.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml` | `/,/livez,/healthz,/runtime/github-metrics.json` |

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -17,7 +17,7 @@ This is the canonical runbook for deploying danielsmith.io from GHCR artifacts t
 | App config | `docs/examples/apps/danielsmith.env` |
 | Chart version pin | `docs/apps/danielsmith.version` |
 | Production tag pin | `docs/apps/danielsmith.prod.tag` |
-| Verify paths | `/`, `/livez`, `/healthz` |
+| Verify paths | `/`, `/livez`, `/healthz`, `/runtime/github-metrics.json` |
 
 ### Artifact links
 
@@ -41,6 +41,70 @@ Use these links before changing a deployment so the workflow runs, package versi
 - `env=staging`: staging host `staging.danielsmith.io` with values `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml`.
 - `env=prod`: production host `danielsmith.io` with values `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml`.
 - The app is a static Vite and Three.js site. Sugarkube runs the static web container only; no in-cluster API, queue, database, GPU, compute node, or stateful service is required.
+
+
+## Runtime GitHub metrics cache
+
+Staging and production enable the chart's `githubMetricsCache` sidecar so visitor browsers do not call GitHub directly for project star counts. The pod runs the normal nginx/static-site container plus a small sidecar container named `github-metrics-cache`. Both containers share an `emptyDir` volume: the sidecar refreshes a JSON cache atomically, and nginx serves the file to browsers at `/runtime/github-metrics.json`.
+
+The current portfolio star flow uses only public repository metadata from public GitHub repositories. The sidecar calls the unauthenticated public GitHub REST API and does **not** need a GitHub token, GitHub App credential, Kubernetes Secret, `envFrom` Secret, or any other authenticated API path. Do not add placeholder token values to Sugarkube for this flow; if the public unauthenticated rate limit is hit, treat it as an operations signal to inspect logs and staleness rather than a secret-management task.
+
+Sugarkube pins the sidecar-capable danielsmith chart in `docs/apps/danielsmith.version` and enables the cache from the staging and prod values overlays. The configured repository list intentionally includes public POI repositories only: `futuroptimist/danielsmith.io`, `futuroptimist/token.place`, `futuroptimist/gabriel`, `futuroptimist/flywheel`, `futuroptimist/jobbot3000`, `futuroptimist/gitshelves`, `futuroptimist/f2clipboard`, `futuroptimist/sigma`, `futuroptimist/wove`, `democratizedspace/dspace`, and `futuroptimist/pr-reaper`. Do not add private repositories unless they are publicly fetchable without credentials.
+
+The refresh interval is hourly (`refreshIntervalSeconds: 3600`). The cache TTL is longer than one interval so a single late refresh or brief GitHub outage does not cause visible churn; in normal operation displayed stars can be up to about an hour old. If GitHub is unavailable on startup or a refresh fails, the sidecar should keep or write a valid neutral JSON document so the app avoids presenting fake fallback star counts as facts.
+
+`just app-verify` includes the runtime cache path for danielsmith staging and production so deploy verification confirms nginx can serve the sidecar-backed file. The generic verifier only checks HTTP status and body preview; run the JSON checks below when validating schema details.
+
+### Verify the runtime cache
+
+Staging:
+
+```bash
+curl -fsS https://staging.danielsmith.io/runtime/github-metrics.json
+```
+
+```bash
+kubectl --context sugar-staging -n danielsmith logs deploy/danielsmith -c github-metrics-cache --tail=100
+```
+
+```bash
+curl -fsS https://staging.danielsmith.io/runtime/github-metrics.json \
+  | python3 -m json.tool
+```
+
+```bash
+python3 - <<'PY'
+import json
+import urllib.request
+
+url = 'https://staging.danielsmith.io/runtime/github-metrics.json'
+with urllib.request.urlopen(url, timeout=10) as response:
+    data = json.load(response)
+
+assert data.get('schemaVersion')
+assert data.get('generatedAt')
+repos = data.get('repos')
+assert isinstance(repos, dict)
+for key in (
+    'futuroptimist/danielsmith.io',
+    'futuroptimist/token.place',
+    'futuroptimist/flywheel',
+    'democratizedspace/dspace',
+):
+    assert key in repos, f'missing {key}'
+print(f"schemaVersion={data['schemaVersion']} generatedAt={data['generatedAt']} repos={len(repos)}")
+PY
+```
+
+Production uses the same checks with the production host and context:
+
+```bash
+curl -fsS https://danielsmith.io/runtime/github-metrics.json
+```
+
+```bash
+kubectl --context sugar-prod -n danielsmith logs deploy/danielsmith -c github-metrics-cache --tail=100
+```
 
 ## Find or publish GHCR image
 
@@ -119,6 +183,7 @@ Optional manual fallback when debugging DNS, TLS, or Cloudflare behavior:
 ```bash
 curl -fsS https://staging.danielsmith.io/healthz
 curl -fsS https://staging.danielsmith.io/livez
+curl -fsS https://staging.danielsmith.io/runtime/github-metrics.json
 curl -fsS https://staging.danielsmith.io/
 ```
 
@@ -158,6 +223,10 @@ curl -fsS https://danielsmith.io/healthz
 
 ```bash
 curl -fsS https://danielsmith.io/livez
+```
+
+```bash
+curl -fsS https://danielsmith.io/runtime/github-metrics.json
 ```
 
 ```bash
@@ -223,6 +292,19 @@ gh auth token | helm registry login ghcr.io \
   --username "$(gh api user --jq .login)" \
   "$HELM_STDIN_FLAG"
 ```
+
+
+### Runtime GitHub metrics cache
+
+If `/runtime/github-metrics.json` returns `404` or an empty response, confirm the deployed chart version includes the sidecar support, confirm the staging/prod values overlay has `githubMetricsCache.enabled: true`, then inspect the sidecar logs:
+
+```bash
+kubectl --context sugar-staging -n danielsmith logs deploy/danielsmith -c github-metrics-cache --tail=100
+```
+
+If logs mention GitHub rate limiting or transient GitHub failures, do not add a token by default. The current flow intentionally uses unauthenticated public metadata only. Check whether the existing cache remains within its TTL/grace window, retry after the public API limit resets, and only consider a future authenticated design in a separate secret-management change.
+
+If the cache is stale, compare the JSON `generatedAt` and `expiresAt` fields with the current UTC time. One late hourly refresh should not create visible churn because `cacheTtlSeconds` is longer than `refreshIntervalSeconds`; repeated stale values usually mean the sidecar cannot reach GitHub or cannot write the shared cache volume.
 
 Cloudflare Tunnel routes are external to Helm. Route public hosts to Traefik, typically `http://traefik.kube-system.svc.cluster.local:80`.
 

--- a/docs/apps/danielsmith.version
+++ b/docs/apps/danielsmith.version
@@ -1,2 +1,2 @@
 # Default danielsmith chart version. Update when new chart releases are published.
-0.1.0
+0.2.1

--- a/docs/examples/apps/danielsmith.env
+++ b/docs/examples/apps/danielsmith.env
@@ -13,5 +13,5 @@ SUGARKUBE_VALUES_DEV=docs/examples/danielsmith.values.dev.yaml
 SUGARKUBE_VALUES_STAGING=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml
 SUGARKUBE_VALUES_PROD=docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml
 SUGARKUBE_STATUS_HOST_KEY=ingress.host
-SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz
+SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz,/runtime/github-metrics.json
 SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=danielsmith

--- a/docs/examples/danielsmith.values.prod.yaml
+++ b/docs/examples/danielsmith.values.prod.yaml
@@ -10,3 +10,33 @@ ingress:
   tls:
     enabled: true
     secretName: danielsmith-prod-tls
+
+githubMetricsCache:
+  enabled: true
+  refreshIntervalSeconds: 3600
+  # Keep the browser cache useful if one hourly refresh is late or GitHub is
+  # briefly unavailable, without presenting day-old star counts as fresh.
+  cacheTtlSeconds: 9000
+  repos:
+    - owner: futuroptimist
+      repo: danielsmith.io
+    - owner: futuroptimist
+      repo: token.place
+    - owner: futuroptimist
+      repo: gabriel
+    - owner: futuroptimist
+      repo: flywheel
+    - owner: futuroptimist
+      repo: jobbot3000
+    - owner: futuroptimist
+      repo: gitshelves
+    - owner: futuroptimist
+      repo: f2clipboard
+    - owner: futuroptimist
+      repo: sigma
+    - owner: futuroptimist
+      repo: wove
+    - owner: democratizedspace
+      repo: dspace
+    - owner: futuroptimist
+      repo: pr-reaper

--- a/docs/examples/danielsmith.values.staging.yaml
+++ b/docs/examples/danielsmith.values.staging.yaml
@@ -10,3 +10,33 @@ ingress:
   tls:
     enabled: true
     secretName: danielsmith-staging-tls
+
+githubMetricsCache:
+  enabled: true
+  refreshIntervalSeconds: 3600
+  # Keep the browser cache useful if one hourly refresh is late or GitHub is
+  # briefly unavailable, without presenting day-old star counts as fresh.
+  cacheTtlSeconds: 9000
+  repos:
+    - owner: futuroptimist
+      repo: danielsmith.io
+    - owner: futuroptimist
+      repo: token.place
+    - owner: futuroptimist
+      repo: gabriel
+    - owner: futuroptimist
+      repo: flywheel
+    - owner: futuroptimist
+      repo: jobbot3000
+    - owner: futuroptimist
+      repo: gitshelves
+    - owner: futuroptimist
+      repo: f2clipboard
+    - owner: futuroptimist
+      repo: sigma
+    - owner: futuroptimist
+      repo: wove
+    - owner: democratizedspace
+      repo: dspace
+    - owner: futuroptimist
+      repo: pr-reaper

--- a/tests/test_danielsmith_github_metrics_cache.py
+++ b/tests/test_danielsmith_github_metrics_cache.py
@@ -1,0 +1,82 @@
+"""Regression tests for danielsmith.io GitHub metrics cache deployment docs."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+EXPECTED_REPOS = [
+    ("futuroptimist", "danielsmith.io"),
+    ("futuroptimist", "token.place"),
+    ("futuroptimist", "gabriel"),
+    ("futuroptimist", "flywheel"),
+    ("futuroptimist", "jobbot3000"),
+    ("futuroptimist", "gitshelves"),
+    ("futuroptimist", "f2clipboard"),
+    ("futuroptimist", "sigma"),
+    ("futuroptimist", "wove"),
+    ("democratizedspace", "dspace"),
+    ("futuroptimist", "pr-reaper"),
+]
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_staging_and_prod_enable_unauthenticated_github_metrics_cache() -> None:
+    for env in ("staging", "prod"):
+        text = _read(f"docs/examples/danielsmith.values.{env}.yaml")
+
+        assert "githubMetricsCache:\n  enabled: true" in text
+        assert "  refreshIntervalSeconds: 3600" in text
+        assert "  cacheTtlSeconds: 9000" in text
+        for owner, repo in EXPECTED_REPOS:
+            assert f"    - owner: {owner}\n      repo: {repo}" in text
+
+        cache_block = text.split("githubMetricsCache:", 1)[1].lower()
+        assert "github_token" not in cache_block
+        assert "githubtoken" not in cache_block
+        assert "authorization" not in cache_block
+        assert "secret" not in cache_block
+        assert "envfrom" not in cache_block
+
+
+def test_danielsmith_verify_paths_include_runtime_cache() -> None:
+    env_text = _read("docs/examples/apps/danielsmith.env")
+    assert "SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz,/runtime/github-metrics.json" in env_text
+
+
+def test_danielsmith_docs_explain_no_token_or_secret_needed() -> None:
+    text = _read("docs/apps/danielsmith.md")
+
+    assert "## Runtime GitHub metrics cache" in text
+    assert "/runtime/github-metrics.json" in text
+    assert "unauthenticated public GitHub REST API" in text
+    assert "does **not** need a GitHub token" in text
+    assert "Kubernetes Secret" in text
+    assert "stars can be up to about an hour old" in text
+    assert (
+        "kubectl --context sugar-staging -n danielsmith logs deploy/danielsmith "
+        "-c github-metrics-cache --tail=100"
+    ) in text
+
+
+def test_app_config_resolves_for_danielsmith_staging_and_prod() -> None:
+    for env in ("staging", "prod"):
+        result = subprocess.run(
+            ["python3", "scripts/app_config.py", "json", "--app", "danielsmith", "--env", env],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert '"SUGARKUBE_APP": "danielsmith"' in result.stdout
+        assert (
+            '"SUGARKUBE_VERIFY_PATHS": "/,/livez,/healthz,/runtime/github-metrics.json"'
+            in result.stdout
+        )

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -377,16 +377,18 @@ def test_app_verify_executes_curl_by_default_and_prints_summary(
     assert "https://example.test/" in curl_log
     assert "https://example.test/livez" in curl_log
     assert "https://example.test/healthz" in curl_log
+    assert "https://example.test/runtime/github-metrics.json" in curl_log
     assert result.stdout.startswith(
         "Verifying danielsmith env=staging\nHost: https://example.test\n\n"
     )
-    assert "\n[1/3] GET /\n" in result.stdout
-    assert "\n[2/3] GET /livez\n" in result.stdout
-    assert "\n[3/3] GET /healthz\n" in result.stdout
+    assert "\n[1/4] GET /\n" in result.stdout
+    assert "\n[2/4] GET /livez\n" in result.stdout
+    assert "\n[3/4] GET /healthz\n" in result.stdout
+    assert "\n[4/4] GET /runtime/github-metrics.json\n" in result.stdout
     assert "  URL: https://example.test/livez\n" in result.stdout
     assert "  Status: OK (HTTP 200)" in result.stdout
     assert '  Body:\n  {"status":"ok"}' in result.stdout
-    assert "Verification passed: 3/3 checks succeeded." in result.stdout
+    assert "Verification passed: 4/4 checks succeeded." in result.stdout
 
 
 def test_app_verify_adds_curl_timeouts(
@@ -440,11 +442,12 @@ def test_app_verify_failure_checks_all_paths_and_exits_nonzero(
     assert "https://example.test/" in curl_log
     assert "https://example.test/livez" in curl_log
     assert "https://example.test/healthz" in curl_log
-    assert "[2/3] GET /livez" in result.stdout
+    assert "https://example.test/runtime/github-metrics.json" in curl_log
+    assert "[2/4] GET /livez" in result.stdout
     assert "Status: FAILED (HTTP 503)" in result.stdout
     assert "curl exit status: 22" in result.stdout
     assert '{"status":"down"}' in result.stdout
-    assert "Verification failed: 1/3 checks failed." in result.stderr
+    assert "Verification failed: 1/4 checks failed." in result.stderr
     assert "/livez (https://example.test/livez)" in result.stderr
 
 
@@ -481,6 +484,7 @@ def test_app_verify_print_only_argument_overrides_false_environment_value(
         "curl -fsS https://example.test/",
         "curl -fsS https://example.test/livez",
         "curl -fsS https://example.test/healthz",
+        "curl -fsS https://example.test/runtime/github-metrics.json",
     ]
     assert not Path(env["CURL_LOG"]).exists()
 
@@ -498,6 +502,7 @@ def test_app_verify_print_only_environment_prints_commands_without_curl(
         "curl -fsS https://example.test/",
         "curl -fsS https://example.test/livez",
         "curl -fsS https://example.test/healthz",
+        "curl -fsS https://example.test/runtime/github-metrics.json",
     ]
     assert not Path(env["CURL_LOG"]).exists()
 
@@ -518,7 +523,7 @@ def test_app_verify_show_body_can_be_disabled(generic_app_stub_env: dict[str, st
 @pytest.mark.parametrize(
     ("app", "expected_paths"),
     [
-        ("danielsmith", "/,/livez,/healthz"),
+        ("danielsmith", "/,/livez,/healthz,/runtime/github-metrics.json"),
         ("tokenplace", "/,/livez,/healthz,/relay/diagnostics"),
         ("dspace", "/config.json,/healthz,/livez"),
     ],


### PR DESCRIPTION
### Motivation
- Serve public repository GitHub metrics to visitor browsers from a pod-local sidecar cache so client-side GitHub requests and visible churn are reduced. 
- Use the chart-provided unauthenticated sidecar flow (no tokens/secrets) to keep the initial deployment simple and auditable. 

### Description
- Enabled `githubMetricsCache` in `docs/examples/danielsmith.values.staging.yaml` and `docs/examples/danielsmith.values.prod.yaml` with `refreshIntervalSeconds: 3600`, `cacheTtlSeconds: 9000`, and the curated public POI repo list. 
- Updated `docs/examples/apps/danielsmith.env` and the generic deployment contract (`docs/app_deployment_contract.md`) to include `/runtime/github-metrics.json` in verification paths and bumped the chart pin in `docs/apps/danielsmith.version` to the sidecar-capable chart (`0.2.1`). 
- Extended the danielsmith runbook (`docs/apps/danielsmith.md`) with a “Runtime GitHub metrics cache” section describing the sidecar + shared `emptyDir` + nginx public path model, unauthenticated public GitHub API usage (explicitly stating no GitHub token/Secret is configured or required), expected staleness (~hourly), verification commands, and troubleshooting guidance. 
- Added a regression test `tests/test_danielsmith_github_metrics_cache.py` and adjusted `tests/test_generic_app_just_recipes.py` to validate the new verification path and behavior. 

### Testing
- Ran full test suite: `python3 -m pytest tests` — result: passed (1322 passed, 19 skipped). 
- Ran targeted tests: `python3 -m pytest tests/test_danielsmith_github_metrics_cache.py tests/test_generic_app_just_recipes.py -q` — result: passed (36 passed). 
- Verified resolved app configs: `just app-config app=danielsmith env=staging` and `just app-config app=danielsmith env=prod` — result: printed JSON with updated `SUGARKUBE_VERIFY_PATHS` and returned success. 
- Doc and examples checks: `rg "githubMetricsCache" -n docs docs/examples` and `rg "runtime/github-metrics.json" -n docs` — result: matches present in docs/examples and runbook. 
- Spelling and links: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` — result: spelling passed; linkchecker passed. 
- Security scan: `git diff --cached | ./scripts/scan-secrets.py` — result: no secrets detected in the staged changes. 
- Note: `pre-commit run --all-files` was attempted but failed due to existing, unrelated repository-wide YAML and flake8 issues outside the scope of this change; project linters and formatters were run where practical and the files touched by this PR pass the targeted checks listed above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a230a0d18a0832fac7cc36759818ec9)