### PR TITLE
Add DSPACE, Sugarkube, and Axel to danielsmith GitHub metrics sidecar config

### DIFF
--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -46,7 +46,7 @@ Use these links before changing a deployment so the workflow runs, package versi
 
 Staging and production enable the danielsmith.io Helm chart's `githubMetricsCache` sidecar. The main nginx container serves the static portfolio, while the sidecar wakes up about once an hour, calls the unauthenticated public GitHub repository API for the configured public POI repositories, and writes a shared cache file to the pod-local runtime volume. nginx exposes that file to visitors at `/runtime/github-metrics.json`, so browsers read same-origin JSON instead of each visitor spending their own GitHub API rate limit.
 
-The current public stars flow does **not** require a GitHub token, Kubernetes Secret, `envFrom` Secret, or authenticated API path. Keep the cache unauthenticated unless a future feature needs private repository metadata. The configured repo list mirrors only the public POI GitHub star sources from the app repo and intentionally omits private-only sources. The DSPACE POI is marked private in the app copy and stays on neutral fallback copy instead of being configured here.
+The current public stars flow does **not** require a GitHub token, Kubernetes Secret, `envFrom` Secret, or authenticated API path. Keep the cache unauthenticated unless a future feature needs private repository metadata. The configured repo list mirrors only the public POI GitHub star sources from the app repo and intentionally omits private-only sources. DSPACE star metrics are fetched from the public `democratizedspace/dspace` repository, while Sugarkube and Axel use the public `futuroptimist/sugarkube` and `futuroptimist/axel` repositories.
 
 The sidecar uses `refreshIntervalSeconds: 3600`. Its `cacheTtlSeconds: 7200` value gives the browser cache enough grace to avoid visible metric churn when one hourly refresh is late, so displayed stars can normally be up to about an hour old and may briefly remain older during GitHub outages or rate-limit windows.
 
@@ -69,7 +69,7 @@ curl -fsS https://staging.danielsmith.io/runtime/github-metrics.json | jq -e '.s
 ```
 
 ```bash
-curl -fsS https://staging.danielsmith.io/runtime/github-metrics.json | jq -e '.repos["futuroptimist/danielsmith.io"].stars | type == "number"'
+curl -fsS https://staging.danielsmith.io/runtime/github-metrics.json | jq -e '(.repos["futuroptimist/danielsmith.io"].stars | type == "number") and (.repos["democratizedspace/dspace"].stars | type == "number") and (.repos["futuroptimist/sugarkube"].stars | type == "number") and (.repos["futuroptimist/axel"].stars | type == "number")'
 ```
 
 ```bash

--- a/docs/examples/danielsmith.values.prod.yaml
+++ b/docs/examples/danielsmith.values.prod.yaml
@@ -37,3 +37,9 @@ githubMetricsCache:
       repo: wove
     - owner: futuroptimist
       repo: pr-reaper
+    - owner: democratizedspace
+      repo: dspace
+    - owner: futuroptimist
+      repo: sugarkube
+    - owner: futuroptimist
+      repo: axel

--- a/docs/examples/danielsmith.values.staging.yaml
+++ b/docs/examples/danielsmith.values.staging.yaml
@@ -37,3 +37,9 @@ githubMetricsCache:
       repo: wove
     - owner: futuroptimist
       repo: pr-reaper
+    - owner: democratizedspace
+      repo: dspace
+    - owner: futuroptimist
+      repo: sugarkube
+    - owner: futuroptimist
+      repo: axel

--- a/tests/test_danielsmith_github_metrics_cache.py
+++ b/tests/test_danielsmith_github_metrics_cache.py
@@ -19,6 +19,9 @@ EXPECTED_PUBLIC_REPOS = {
     "futuroptimist/sigma",
     "futuroptimist/wove",
     "futuroptimist/pr-reaper",
+    "democratizedspace/dspace",
+    "futuroptimist/sugarkube",
+    "futuroptimist/axel",
 }
 
 
@@ -53,12 +56,27 @@ def test_staging_and_prod_enable_unauthenticated_github_metrics_cache() -> None:
         assert "refreshIntervalSeconds: 3600" in block
         assert "cacheTtlSeconds: 7200" in block
         assert "publicPath: /runtime/github-metrics.json" in block
-        assert _repo_slugs(block) == EXPECTED_PUBLIC_REPOS
-        assert "democratizedspace/dspace" not in _repo_slugs(block)
+        repos = _repo_slugs(block)
+        assert repos == EXPECTED_PUBLIC_REPOS
+        assert "democratizedspace/dspace" in repos
+        assert "futuroptimist/sugarkube" in repos
+        assert "futuroptimist/axel" in repos
+        assert "futuroptimist/dspace" not in repos
         for forbidden in ("github_token", "github-token", "gh_token", "access_token"):
             assert forbidden not in block.lower()
         assert "secret" not in block.lower()
         assert "envFrom" not in block
+
+
+def test_danielsmith_docs_describe_public_dspace_metrics_repo() -> None:
+    docs = _read("docs/apps/danielsmith.md")
+
+    assert (
+        "DSPACE star metrics are fetched from the public "
+        "`democratizedspace/dspace` repository"
+    ) in docs
+    assert "futuroptimist/dspace" not in docs
+    assert "DSPACE POI is marked private" not in docs
 
 
 def test_danielsmith_docs_explain_no_github_token_or_secret() -> None:


### PR DESCRIPTION
### Motivation
- Ensure the danielsmith.io runtime GitHub metrics sidecar fetches public star counts for the remaining POI targets used by the app so UI shows correct metrics for DSPACE, Sugarkube, and Axel. 
- Replace the incorrect `futuroptimist/dspace` target and document the true public DSPACE source without introducing any secrets or authentication.

### Description
- Updated staging and production Helm values to add the three public repo targets under `githubMetricsCache.repos`: `democratizedspace/dspace`, `futuroptimist/sugarkube`, and `futuroptimist/axel` in `docs/examples/danielsmith.values.staging.yaml` and `docs/examples/danielsmith.values.prod.yaml`.
- Removed reliance on any `futuroptimist/dspace` stale target (no references remain in the updated docs/examples tree).
- Edited `docs/apps/danielsmith.md` to state that DSPACE stars come from `democratizedspace/dspace`, to keep the existing unauthenticated/no-token guidance, and to extend the manual `jq` verification example to check the three new repo keys.
- Extended `tests/test_danielsmith_github_metrics_cache.py` to include the three repo slugs in `EXPECTED_PUBLIC_REPOS`, assert the absence of `futuroptimist/dspace`, and add a test asserting the docs mention the public `democratizedspace/dspace` repo.
- No chart version pins, secrets, or authenticated GitHub API behavior were added or changed.

### Testing
- Ran unit tests: `python3 -m pytest tests` — full test-suite executed and completed successfully: `1300 passed, 43 skipped`.
- Verified resolved app config: `just app-config app=danielsmith env=staging` and `just app-config app=danielsmith env=prod` — both returned expected `SUGARKUBE_VALUES` and `SUGARKUBE_VERIFY_PATHS` values (commands succeeded).
- Grep checks: `rg` searches confirmed `democratizedspace/dspace`, `futuroptimist/sugarkube`, and `futuroptimist/axel` appear in `docs`/`docs/examples`, and there are no remaining `futuroptimist/dspace` references (commands succeeded).
- Secrets scan: `git diff --cached | ./scripts/scan-secrets.py` run on staged changes (succeeded, no secrets reported).
- Repository tooling unavailable in this environment: `pre-commit run --all-files` (not run: `pre-commit` not installed), `pyspelling -c .spellcheck.yaml` (not run: `pyspelling` not installed), and `linkchecker --no-warnings README.md docs/` (not run: `linkchecker` not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a237aedaa8c832fbc453c66d6f71055)