### PR TITLE
danielsmith: add democratizedspace/dspace, futuroptimist/sugarkube, and futuroptimist/axel to GitHub metrics sidecar

### DIFF
--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -46,7 +46,7 @@ Use these links before changing a deployment so the workflow runs, package versi
 
 Staging and production enable the danielsmith.io Helm chart's `githubMetricsCache` sidecar. The main nginx container serves the static portfolio, while the sidecar wakes up about once an hour, calls the unauthenticated public GitHub repository API for the configured public POI repositories, and writes a shared cache file to the pod-local runtime volume. nginx exposes that file to visitors at `/runtime/github-metrics.json`, so browsers read same-origin JSON instead of each visitor spending their own GitHub API rate limit.
 
-The current public stars flow does **not** require a GitHub token, Kubernetes Secret, `envFrom` Secret, or authenticated API path. Keep the cache unauthenticated unless a future feature needs private repository metadata. The configured repo list mirrors only the public POI GitHub star sources from the app repo and intentionally omits private-only sources. The DSPACE POI is marked private in the app copy and stays on neutral fallback copy instead of being configured here.
+The current public stars flow does **not** require a GitHub token, Kubernetes Secret, `envFrom` Secret, or authenticated API path. Keep the cache unauthenticated unless a future feature needs private repository metadata. The configured repo list mirrors only the public POI GitHub star sources from the app repo and intentionally omits private-only sources. DSPACE star metrics are public and come from `democratizedspace/dspace`. The same sidecar target list also includes `futuroptimist/sugarkube` and `futuroptimist/axel` so the Sugarkube and Axel POIs read from the runtime cache.
 
 The sidecar uses `refreshIntervalSeconds: 3600`. Its `cacheTtlSeconds: 7200` value gives the browser cache enough grace to avoid visible metric churn when one hourly refresh is late, so displayed stars can normally be up to about an hour old and may briefly remain older during GitHub outages or rate-limit windows.
 
@@ -69,7 +69,7 @@ curl -fsS https://staging.danielsmith.io/runtime/github-metrics.json | jq -e '.s
 ```
 
 ```bash
-curl -fsS https://staging.danielsmith.io/runtime/github-metrics.json | jq -e '.repos["futuroptimist/danielsmith.io"].stars | type == "number"'
+curl -fsS https://staging.danielsmith.io/runtime/github-metrics.json | jq -e '(.repos["futuroptimist/danielsmith.io"].stars | type == "number") and (.repos["democratizedspace/dspace"].stars | type == "number")'
 ```
 
 ```bash

--- a/docs/examples/danielsmith.values.prod.yaml
+++ b/docs/examples/danielsmith.values.prod.yaml
@@ -37,3 +37,9 @@ githubMetricsCache:
       repo: wove
     - owner: futuroptimist
       repo: pr-reaper
+    - owner: democratizedspace
+      repo: dspace
+    - owner: futuroptimist
+      repo: sugarkube
+    - owner: futuroptimist
+      repo: axel

--- a/docs/examples/danielsmith.values.staging.yaml
+++ b/docs/examples/danielsmith.values.staging.yaml
@@ -37,3 +37,9 @@ githubMetricsCache:
       repo: wove
     - owner: futuroptimist
       repo: pr-reaper
+    - owner: democratizedspace
+      repo: dspace
+    - owner: futuroptimist
+      repo: sugarkube
+    - owner: futuroptimist
+      repo: axel

--- a/tests/test_danielsmith_github_metrics_cache.py
+++ b/tests/test_danielsmith_github_metrics_cache.py
@@ -19,6 +19,9 @@ EXPECTED_PUBLIC_REPOS = {
     "futuroptimist/sigma",
     "futuroptimist/wove",
     "futuroptimist/pr-reaper",
+    "democratizedspace/dspace",
+    "futuroptimist/sugarkube",
+    "futuroptimist/axel",
 }
 
 
@@ -53,8 +56,12 @@ def test_staging_and_prod_enable_unauthenticated_github_metrics_cache() -> None:
         assert "refreshIntervalSeconds: 3600" in block
         assert "cacheTtlSeconds: 7200" in block
         assert "publicPath: /runtime/github-metrics.json" in block
-        assert _repo_slugs(block) == EXPECTED_PUBLIC_REPOS
-        assert "democratizedspace/dspace" not in _repo_slugs(block)
+        repo_slugs = _repo_slugs(block)
+        assert repo_slugs == EXPECTED_PUBLIC_REPOS
+        assert "democratizedspace/dspace" in repo_slugs
+        assert "futuroptimist/sugarkube" in repo_slugs
+        assert "futuroptimist/axel" in repo_slugs
+        assert "futuroptimist/dspace" not in repo_slugs
         for forbidden in ("github_token", "github-token", "gh_token", "access_token"):
             assert forbidden not in block.lower()
         assert "secret" not in block.lower()
@@ -68,6 +75,16 @@ def test_danielsmith_docs_explain_no_github_token_or_secret() -> None:
     assert "does **not** require a GitHub token" in docs
     assert "Kubernetes Secret" in docs
     assert "Do not configure a GitHub token" in docs
+
+
+def test_danielsmith_docs_name_correct_dspace_metrics_repo() -> None:
+    docs = _read("docs/apps/danielsmith.md")
+
+    assert "DSPACE star metrics" in docs
+    assert "`democratizedspace/dspace`" in docs
+    assert "`futuroptimist/sugarkube`" in docs
+    assert "`futuroptimist/axel`" in docs
+    assert "futuroptimist/dspace" not in docs
 
 
 def test_danielsmith_docs_use_sidecar_container_name_for_logs() -> None:


### PR DESCRIPTION
### Motivation
- Ensure the danielsmith.io staging/prod GitHub-metrics sidecar collects public star metrics for DSPACE, Sugarkube, and Axel so the app displays accurate POI counts.
- Correct a stale DSPACE target that pointed at `futuroptimist/dspace` and document the real source `democratizedspace/dspace`.
- Preserve the unauthenticated public-stars design and avoid introducing any secrets or tokens.

### Description
- Updated `docs/examples/danielsmith.values.staging.yaml` and `docs/examples/danielsmith.values.prod.yaml` to add the sidecar repo targets `democratizedspace/dspace`, `futuroptimist/sugarkube`, and `futuroptimist/axel` under `githubMetricsCache.repos`.
- Updated `docs/apps/danielsmith.md` to state that DSPACE stars come from `democratizedspace/dspace`, and to note that Sugarkube and Axel read from the same runtime cache; also adjusted the example `jq` verification to include the DSPACE entry.
- Extended `tests/test_danielsmith_github_metrics_cache.py` to expect the three new repo slugs, to assert the stale `futuroptimist/dspace` is not present, and to verify the docs mention the correct repo names.
- No chart versions, secrets, or authenticated GitHub API behavior were added or changed.

### Testing
- Ran `python3 -m pytest tests/test_danielsmith_github_metrics_cache.py` which passed: `6 passed`.
- Ran the full test suite `python3 -m pytest tests` which passed: `1324 passed, 19 skipped, 9 warnings` (local environment, ~4m 10s).
- Executed `just app-config app=danielsmith env=staging` and `just app-config app=danielsmith env=prod` to validate resolved `SUGARKUBE_VALUES` and `SUGARKUBE_VERIFY_PATHS`; both commands completed successfully.
- Confirmed docs/values presence with ripgrep: `rg "democratizedspace/dspace"`, `rg "futuroptimist/sugarkube"`, and `rg "futuroptimist/axel"` all found the expected references, and `rg "futuroptimist/dspace"` returned no hits in the updated docs/examples (command checks succeeded).
- Ran `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` which reported no secrets.
- Repo-standard checks `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` were not run because those tools are not installed in this environment (not-run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a237aedaa8c832fbc453c66d6f71055)