### PR TITLE
Fix tests workflow Codecov secret guard

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  CODECOV_SECRET: ${{ secrets.CODECOV_TOKEN }}
 
 jobs:
   test:
@@ -50,7 +51,7 @@ jobs:
         if: >-
           github.event_name == 'push' &&
           hashFiles('coverage.xml') != '' &&
-          secrets.CODECOV_TOKEN != ''
+          env.CODECOV_SECRET != ''
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Motivation
- The workflow validation failed because the `Upload coverage` step used `secrets.CODECOV_TOKEN` directly inside an `if:` expression, which is not allowed; the change makes the condition check an environment variable instead.

### Description
- Add a workflow-level `env` entry exposing the secret as `CODECOV_SECRET: ${{ secrets.CODECOV_TOKEN }}` and change the upload step guard to check `env.CODECOV_SECRET != ''`, while leaving the `with: token: ${{ secrets.CODECOV_TOKEN }}` usage and test commands unchanged.

### Testing
- Ran the project test command and checks locally: `python -m venv .venv` then `. .venv/bin/activate && uv pip install pytest pytest-cov coverage` and `pytest --cov=. --cov-report=xml --cov-report=term --maxfail=1 --disable-warnings -q` (result: `1300 passed, 43 skipped`, coverage XML written), validated the workflow with `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/tests.yml` (success), ran `git diff --cached | ./scripts/scan-secrets.py` (no secrets found), and attempted `pre-commit run --all-files` which surfaced pre-existing repo-wide lint/YAML multi-doc failures unrelated to this workflow change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27c75cd0e4832f8135241e9235a186)