### PR TITLE
Fix tests workflow Codecov token gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,11 +46,24 @@ jobs:
       - name: Run tests with coverage
         run: |
           pytest --cov=. --cov-report=xml --cov-report=term --maxfail=1 --disable-warnings -q
+      - name: Check Codecov token
+        id: codecov-token
+        if: github.event_name == 'push'
+        env:
+          CODECOV_CREDENTIAL: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          if [ -n "$CODECOV_CREDENTIAL" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Upload coverage
+        # Secrets cannot be referenced directly in step-level if expressions, so
+        # gate this push-only upload on the preceding token check instead.
         if: >-
           github.event_name == 'push' &&
           hashFiles('coverage.xml') != '' &&
-          secrets.CODECOV_TOKEN != ''
+          steps.codecov-token.outputs.available == 'true'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Motivation
- The Test Suite workflow was failing at parse time because a step-level `if` referenced the `secrets` context directly, which GitHub disallows and caused the workflow runs to fail.

### Description
- Add a push-only `Check Codecov token` step (`id: codecov-token`) that reads `secrets.CODECOV_TOKEN` into an env var and emits a boolean output indicating availability.
- Gate the existing Codecov upload step on `steps.codecov-token.outputs.available == 'true'` and `hashFiles('coverage.xml') != ''`, removing the direct `secrets` reference from a step-level `if` while preserving the token usage in the upload `with` block.
- No changes were made to the test commands or tokenized upload behavior beyond the gating logic.

### Testing
- Created a virtualenv and installed test deps with `python -m venv .venv` and `. .venv/bin/activate && python -m pip install --upgrade pip uv && uv pip install pytest pytest-cov coverage`; result: environment prepared.
- Ran the repository test suite with `pytest --cov=. --cov-report=xml --cov-report=term --maxfail=1 --disable-warnings -q`; result: `1300 passed, 43 skipped`, coverage XML written to `coverage.xml`.
- Validated workflow syntax with `actionlint` against `.github/workflows/tests.yml`; result: no actionlint errors.
- Ran the repository secret-scan on the staged workflow change with `git diff --cached | ./scripts/scan-secrets.py`; result: clean for committed change after edits.
- Attempted `pre-commit run --all-files` after installing `pre-commit`; result: failed due to pre-existing repository-wide issues (trailing whitespace, multi-document YAML files, and flake8 line-length violations) unrelated to this workflow fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27c75cd0e4832f8135241e9235a186)