### PR TITLE
Fix tests workflow Codecov token guard

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,11 +46,22 @@ jobs:
       - name: Run tests with coverage
         run: |
           pytest --cov=. --cov-report=xml --cov-report=term --maxfail=1 --disable-warnings -q
+      - name: Check Codecov token
+        id: codecov-token
+        if: github.event_name == 'push'
+        env:
+          CODECOV_AUTH: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          if [ -n "$CODECOV_AUTH" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Upload coverage
         if: >-
           github.event_name == 'push' &&
           hashFiles('coverage.xml') != '' &&
-          secrets.CODECOV_TOKEN != ''
+          steps.codecov-token.outputs.available == 'true'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           pytest --cov=. --cov-report=xml --cov-report=term --maxfail=1 --disable-warnings -q
       - name: Check Codecov token
-        id: codecov-token
+        id: codecov_token
         if: github.event_name == 'push'
         env:
           CODECOV_AUTH: ${{ secrets.CODECOV_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
         if: >-
           github.event_name == 'push' &&
           hashFiles('coverage.xml') != '' &&
-          steps.codecov-token.outputs.available == 'true'
+          steps.codecov_token.outputs.available == 'true'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Motivation
- The `Upload coverage` step in `.github/workflows/tests.yml` referenced the `secrets` context directly in its `if` expression which caused the workflow check to fail; a narrow guard was needed that does not use `secrets` in the `if` expression.

### Description
- Added a push-only step `Check Codecov token` which maps `secrets.CODECOV_TOKEN` into a step `env`, probes it in shell, and emits a boolean output to `$GITHUB_OUTPUT`.
- Updated the `Upload coverage` step condition to use `steps.codecov-token.outputs.available == 'true'` instead of referencing `secrets` directly, while preserving the existing push-only behavior and still passing the secret to the Codecov action's `token` input.
- Change is confined to `.github/workflows/tests.yml` and keeps the coverage upload behaviour, files, and `fail_ci_if_error: true` intact.

### Testing
- Ran the project test command `pytest --cov=. --cov-report=xml --cov-report=term --maxfail=1 --disable-warnings -q` which completed successfully: `1300 passed, 43 skipped, 9 warnings`.
- Validated the workflow YAML with `pre-commit run check-yaml --files .github/workflows/tests.yml` which passed, and ran `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/tests.yml` which also passed.
- Ran the repository secret scan `git diff --cached | ./scripts/scan-secrets.py` which returned clean for the staged changes, and committed the single-file workflow fix as `Fix tests workflow Codecov token guard`.
- Note: `pre-commit run --all-files` was attempted but failed on pre-existing repository-wide hooks and unrelated auto-format changes; those broader changes were reverted because they are outside the scope of this targeted fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27c75cd0e4832f8135241e9235a186)