### PR TITLE
Make pi-image-release manual, harden release workflow, update docs and guards

### DIFF
--- a/.github/workflows/pi-image-release.yml
+++ b/.github/workflows/pi-image-release.yml
@@ -1,11 +1,35 @@
 name: pi-image-release
 
 on:
-  push:
-    branches:
-      - main
-  schedule:
-    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      release_channel:
+        description: "Release channel to publish"
+        type: choice
+        options:
+          - stable
+          - nightly
+        default: stable
+      clone_sugarkube:
+        description: "Clone sugarkube repo into image"
+        type: boolean
+        default: true
+      clone_token_place:
+        description: "Clone token.place repo into image"
+        type: boolean
+        default: true
+      clone_dspace:
+        description: "Clone democratizedspace/dspace into image"
+        type: boolean
+        default: true
+      publish_release:
+        description: "Publish or update the signed GitHub Release"
+        type: boolean
+        default: false
+      run_qemu_smoke:
+        description: "Boot the image in QEMU before signing/publishing"
+        type: boolean
+        default: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -24,10 +48,12 @@ jobs:
       ARM64: 1
       DEBIAN_FRONTEND: noninteractive
       BUILD_TIMEOUT: 7200
-      RELEASE_CHANNEL: ${{ github.event_name == 'schedule' && 'nightly' || 'stable' }}
-      CLONE_SUGARKUBE: true
-      CLONE_TOKEN_PLACE: true
-      CLONE_DSPACE: true
+      RELEASE_CHANNEL: ${{ inputs.release_channel }}
+      CLONE_SUGARKUBE: ${{ inputs.clone_sugarkube }}
+      CLONE_TOKEN_PLACE: ${{ inputs.clone_token_place }}
+      CLONE_DSPACE: ${{ inputs.clone_dspace }}
+      PUBLISH_RELEASE: ${{ inputs.publish_release }}
+      RUN_QEMU_SMOKE: ${{ inputs.run_qemu_smoke }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -37,10 +63,17 @@ jobs:
         run: |
           sudo apt-get clean
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-            /opt/hostedtoolcache /usr/local/lib/node_modules \
-            /usr/local/share/boost
+            /usr/local/lib/node_modules /usr/local/share/boost
           docker system prune -af || true
           df -h
+
+      - name: Verify Node runtime availability
+        run: |
+          if ! command -v node >/dev/null 2>&1; then
+            echo "Node.js runtime missing after cleanup" >&2
+            exit 1
+          fi
+          node --version
 
       - name: Install pi-gen dependencies
         run: |
@@ -62,14 +95,16 @@ jobs:
 
       - name: Compute pi-gen cache key
         id: pigen-key
+        env:
+          PI_GEN_BRANCH: bookworm
+          PI_GEN_REMOTE: https://github.com/RPi-Distro/pi-gen.git
         run: |
-          branch=bookworm
-          ref=$(git ls-remote https://github.com/RPi-Distro/pi-gen.git "refs/heads/${branch}" | cut -f1)
-          echo "key=pigen-${RUNNER_OS}-${branch}-${ref}-$(date +'%Y-%m')" >> "$GITHUB_OUTPUT"
+          key=$(bash scripts/compute_pi_gen_cache_key.sh "${PI_GEN_BRANCH}" "${PI_GEN_REMOTE}")
+          echo "key=${key}" >> "$GITHUB_OUTPUT"
 
       - name: Restore pi-gen Docker image
         id: cache-pigen
-        uses: actions/cache@v4
+        uses: actions/cache@v4.3.0
         with:
           path: ~/cache/pi-gen.tar
           key: ${{ steps.pigen-key.outputs.key }}
@@ -78,7 +113,7 @@ jobs:
         if: steps.cache-pigen.outputs.cache-hit == 'true'
         run: docker load -i ~/cache/pi-gen.tar
 
-      - name: Build pi-gen image
+      - name: Build pi-gen Docker image
         if: steps.cache-pigen.outputs.cache-hit != 'true'
         run: |
           git clone --depth=1 --branch bookworm https://github.com/RPi-Distro/pi-gen.git ~/pi-gen
@@ -97,17 +132,51 @@ jobs:
         run: |
           sudo env \
             BUILD_TIMEOUT="${BUILD_TIMEOUT}" \
+            ARM64="${ARM64}" \
             CLONE_SUGARKUBE="${CLONE_SUGARKUBE}" \
             CLONE_TOKEN_PLACE="${CLONE_TOKEN_PLACE}" \
             CLONE_DSPACE="${CLONE_DSPACE}" \
             ./scripts/build_pi_image.sh
 
+      - name: Fix permissions on pi-image artifacts
+        run: |
+          sudo TARGET_UID="$(id -u)" TARGET_GID="$(id -g)" \
+            bash scripts/fix_pi_image_permissions.sh
+
+      - name: Collect image artifact
+        run: |
+          bash scripts/collect_pi_image.sh deploy ./sugarkube.img.xz
+
+      - name: Verify image artifacts
+        run: |
+          set -euo pipefail
+          for path in \
+            ./sugarkube.img.xz \
+            ./sugarkube.img.xz.sha256 \
+            ./sugarkube.img.xz.metadata.json \
+            ./sugarkube.img.xz.stage-summary.json; do
+            if [ ! -s "$path" ]; then
+              echo "Missing or empty artifact: $path" >&2
+              exit 1
+            fi
+          done
+          sha256sum -c ./sugarkube.img.xz.sha256
+
       - name: Boot image in QEMU smoke test
+        if: env.RUN_QEMU_SMOKE == 'true'
         run: |
           ./scripts/qemu_pi_smoke_test.py \
             --image sugarkube.img.xz \
             --artifacts-dir qemu-smoke-artifacts \
             --timeout 480
+
+      - name: Record skipped QEMU smoke test
+        if: env.RUN_QEMU_SMOKE != 'true'
+        run: |
+          mkdir -p qemu-smoke-artifacts
+          cat > qemu-smoke-artifacts/smoke-success.json <<'JSON'
+          {"status":"skipped","reason":"run_qemu_smoke input was false"}
+          JSON
 
       - name: Collect deploy directory listing
         if: always()
@@ -156,13 +225,14 @@ jobs:
             sugarkube.img.xz.manifest.json
 
       - name: Upload run artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: sugarkube-pi-image
           path: |
             sugarkube.img.xz
             sugarkube.img.xz.sha256
             sugarkube.img.xz.metadata.json
+            sugarkube.img.xz.stage-summary.json
             sugarkube.img.xz.manifest.json
             sugarkube.img.xz.sig
             sugarkube.img.xz.pem
@@ -173,7 +243,7 @@ jobs:
 
       - name: Upload QEMU smoke artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: sugarkube-qemu-smoke
           path: qemu-smoke-artifacts
@@ -203,13 +273,14 @@ jobs:
 
       - name: Upload support bundle
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: sugarkube-support-bundle
           path: support-bundles
           if-no-files-found: ignore
 
       - name: Publish GitHub release
+        if: env.PUBLISH_RELEASE == 'true'
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -225,6 +296,7 @@ jobs:
             sugarkube.img.xz
             sugarkube.img.xz.sha256
             sugarkube.img.xz.metadata.json
+            sugarkube.img.xz.stage-summary.json
             sugarkube.img.xz.manifest.json
             sugarkube.img.xz.sig
             sugarkube.img.xz.pem

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -255,3 +255,6 @@ danielsmith
 executables
 jobbot
 pytest
+
+QEMU
+reimaging

--- a/README.md
+++ b/README.md
@@ -161,14 +161,22 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
 
 ## Pi image releases
 
-The `pi-image-release` workflow builds a fresh Raspberry Pi OS image on every
-push to `main` and once per day. Each run publishes a signed
-`sugarkube.img.xz`, its checksum, a provenance manifest, and the full
-`pi-gen` build log. Release notes summarize stage timings and link directly to
-the manifest so you can verify the build inputs and commit hashes before
- flashing. Run `./scripts/install_sugarkube_image.sh` (or fetch the same helper
- via `curl -fsSL https://raw.githubusercontent.com/futuroptimist/sugarkube/main/scripts/install_sugarkube_image.sh | bash`) to
- download, verify, and expand the latest release. When you prefer a task runner,
+Use **Actions → pi-image → Run workflow** when you need a fresh on-demand
+workflow artifact for reimaging Raspberry Pi nodes. That manual workflow keeps
+the clone toggles for `sugarkube`, `token.place`, and `dspace`, then uploads the
+`sugarkube-img` artifact for the exact run you dispatched. Use
+**Actions → pi-image-release → Run workflow** only when you intentionally need to
+sign artifacts and, with `publish_release` enabled, publish or update the latest
+downloadable GitHub Release. The release workflow is manual-only so unrelated
+`main` merges and nightly schedules do not trigger expensive Pi image release
+attempts. Published releases include `sugarkube.img.xz`, its checksum, a
+provenance manifest, cosign signatures/certificates, QEMU smoke-test evidence,
+and the full `pi-gen` build log. Release notes summarize stage timings and link
+directly to the manifest so you can verify the build inputs and commit hashes
+before flashing. Run `./scripts/install_sugarkube_image.sh` (or fetch the same
+helper via `curl -fsSL https://raw.githubusercontent.com/futuroptimist/sugarkube/main/scripts/install_sugarkube_image.sh | bash`) to
+download, verify, and expand the latest published release. When you prefer a
+task runner,
 use either `sudo make flash-pi FLASH_DEVICE=/dev/sdX` or `sudo FLASH_DEVICE=/dev/sdX just flash-pi` to
 chain download → verification → flashing with the streaming helper. Prefer go-task? Run
 `sudo task pi:flash FLASH_DEVICE=/dev/sdX` to reach the same helper via the Taskfile. Need to forward

--- a/docs/pi_image_builder_design.md
+++ b/docs/pi_image_builder_design.md
@@ -99,9 +99,15 @@ personas:
   running pi-gen.
 
 ### Release automation
-- `pi-image-release.yml` rebuilds the image on every `main` push and on a nightly
-  schedule. The job reuses the cached `pi-gen` container when possible so daily runs
-  stay within GitHub's time limits.
+- `pi-image.yml` is the canonical on-demand image builder. Operators dispatch it
+  manually when they need a fresh workflow artifact for reimaging nodes, and the
+  pull-request jobs stay lightweight by running only guard/unit checks.
+- `pi-image-release.yml` is a manual signed-release publisher. Dispatch it only
+  when validating or publishing release assets; set `publish_release=true` to update
+  GitHub Releases after the build, artifact verification, QEMU smoke test, manifest
+  generation, and cosign signing pass. The workflow intentionally does not run on
+  every `main` push or on a daily schedule, so unrelated merges cannot fail the
+  expensive release path.
 - `build_pi_image.sh` now writes `sugarkube.img.xz.metadata.json` with the pi-gen
   commit, stage durations parsed from `work/<img>/build.log`, the git ref used for
   the build, and all toggles passed to the script. The log itself is copied to

--- a/docs/pi_image_contributor_guide.md
+++ b/docs/pi_image_contributor_guide.md
@@ -31,6 +31,22 @@ sync.
 
 ## Automation map
 
+### GitHub Actions workflows
+
+- `.github/workflows/pi-image.yml`
+  - Purpose: canonical on-demand workflow for fresh Raspberry Pi image artifacts used to reimage
+    nodes. It keeps the manual clone toggles for `sugarkube`, `token.place`, and `dspace`, and its
+    pull-request triggers run lightweight guards instead of the expensive image build.
+  - Primary docs: [Pi Image Quickstart](./pi_image_quickstart.md),
+    [Pi Image Builder Design](./pi_image_builder_design.md).
+- `.github/workflows/pi-image-release.yml`
+  - Purpose: manual signed-release publisher for maintainers who need provenance manifests, cosign
+    signatures, QEMU smoke evidence, and optional GitHub Release publication. Leave
+    `publish_release=false` for validate-only runs; set it to `true` only when publishing release
+    assets intentionally.
+  - Primary docs: [README](../README.md),
+    [Pi Image Builder Design](./pi_image_builder_design.md).
+
 ### Download and release helpers
 
 - `scripts/install_sugarkube_image.sh`
@@ -47,9 +63,10 @@ sync.
   - Related tooling: wrapped by `make download-pi-image`, `just download-pi-image`, and consumed by
     the installer script above.
 - `scripts/collect_pi_image.sh`
-  - Purpose: normalize pi-gen output and compress it into the release artifact layout.
+  - Purpose: normalize pi-gen output and compress it into the image artifact layout.
   - Primary docs: [Pi Image Builder Design](./pi_image_builder_design.md).
-  - Related tooling: invoked in the CI pipelines that publish release assets.
+  - Related tooling: invoked by the manual `pi-image.yml` artifact workflow and the manual
+    `pi-image-release.yml` signed-release workflow.
 - `scripts/create_build_metadata.py` and `scripts/generate_release_manifest.py`
   - Purpose: capture build inputs, pi-gen SHAs, and stage timings, then export a signed manifest for
     releases.
@@ -137,8 +154,8 @@ sync.
   - Primary docs: [Pi Support Bundles](./pi_support_bundles.md),
     [Pi Image Quickstart](./pi_image_quickstart.md).
   - Related tooling: invoked via `make support-bundle` / `just support-bundle`, supports
-    `SUPPORT_BUNDLE_ARGS` overrides, and publishes artifacts from `pi-image-release.yml` when
-    bundle secrets are configured.
+    `SUPPORT_BUNDLE_ARGS` overrides, and publishes artifacts from manually dispatched
+    `pi-image-release.yml` runs when bundle secrets are configured.
 - `scripts/update_hardware_boot_badge.py`
   - Purpose: generate shields.io endpoint JSON so the README hardware boot badge reflects the
     latest physical verification run.
@@ -196,7 +213,8 @@ trust the published status.
     image.
   - Primary docs: [Pi Image Quickstart](./pi_image_quickstart.md),
     [Pi Image Builder Design](./pi_image_builder_design.md).
-  - Related tooling: triggered manually via shell or by the GitHub Actions release workflow.
+  - Related tooling: triggered manually via shell, by `pi-image.yml` for fresh workflow artifacts,
+    and by `pi-image-release.yml` when validating or publishing signed GitHub Release assets.
 - `scripts/checks.sh`
   - Purpose: unify linting, spellcheck, link-check, CAD, and KiCad validations in CI and local
     development.

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -116,11 +116,14 @@ sync without modifying the host.
     Regression coverage: `tests/pi_cluster_bootstrap_test.py::test_run_bootstrap_invokes_workflow_and_join`
     verifies the workflow run ID flows into the installer so those markers stay accurate.
    - **Manual:** open **Actions → pi-image → Run workflow**, tick **token.place** and **dspace** to
-     bake those repos into `/opt/projects`, then download `sugarkube.img.xz` once the run succeeds.
-     Need a guided path? Launch the [Sugarkube Flash Helper](./flash-helper/) and paste the workflow
-     URL to receive OS-specific download, verification, and flashing instructions. Prefer the
-     terminal? Run `python scripts/workflow_flash_instructions.py --url <run-url> --os
-     linux|mac|windows` from the repository root to print the same steps.
+     bake those repos into `/opt/projects`, then download the `sugarkube-img` workflow artifact once
+     the run succeeds. This is the normal path for fresh OS images used to reimage nodes. Use
+     **pi-image-release** only when you intentionally need signed GitHub Release assets for the
+     latest downloadable release. Need a guided path? Launch the
+     [Sugarkube Flash Helper](./flash-helper/) and paste the workflow URL to receive OS-specific
+     download, verification, and flashing instructions. Prefer the terminal? Run
+     `python scripts/workflow_flash_instructions.py --url <run-url> --os linux|mac|windows` from the
+     repository root to print the same steps.
    - `./scripts/download_pi_image.sh --output /your/path.img.xz` still resumes partial downloads and
      verifies checksums automatically.
    - Prefer a unified entry point? Run `python -m sugarkube_toolkit pi download --dry-run` from the

--- a/tests/pi_image_release_workflow_guard_test.sh
+++ b/tests/pi_image_release_workflow_guard_test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+wf=".github/workflows/pi-image-release.yml"
+
+# The signed release publisher is intentionally manual so unrelated main merges
+# and scheduled runs do not repeatedly execute the expensive image release path.
+grep -F "workflow_dispatch:" "$wf" >/dev/null
+if grep -Eq '^  (push|schedule):' "$wf"; then
+  echo "pi-image-release.yml must remain manual-only unless path gating is added intentionally" >&2
+  exit 1
+fi
+
+# Cleanup must not remove the runner toolcache; later JavaScript actions need Node.
+if grep -F "/opt/hostedtoolcache" "$wf" >/dev/null; then
+  echo "pi-image-release.yml must not delete /opt/hostedtoolcache" >&2
+  exit 1
+fi
+grep -F "Verify Node runtime availability" "$wf" >/dev/null
+grep -F "node --version" "$wf" >/dev/null
+
+# Release runs should share the maintained pi-gen cache-key helper and keep publish explicit.
+grep -F "scripts/compute_pi_gen_cache_key.sh" "$wf" >/dev/null
+grep -F "publish_release:" "$wf" >/dev/null
+grep -F "if: env.PUBLISH_RELEASE == 'true'" "$wf" >/dev/null

--- a/tests/test_pi_image_tooling.py
+++ b/tests/test_pi_image_tooling.py
@@ -774,6 +774,36 @@ def test_pi_image_workflow_uses_cache_key_script():
     assert "key=$(bash scripts/compute_pi_gen_cache_key.sh" in content
 
 
+def test_pi_image_release_workflow_is_manual_only():
+    workflow_path = Path(".github/workflows/pi-image-release.yml")
+    content = workflow_path.read_text()
+    assert "workflow_dispatch:" in content
+    assert "release_channel:" in content
+    assert "publish_release:" in content
+    assert "run_qemu_smoke:" in content
+    assert "\n  push:" not in content
+    assert "\n  schedule:" not in content
+
+
+def test_pi_image_release_workflow_preserves_node_runtime():
+    workflow_path = Path(".github/workflows/pi-image-release.yml")
+    content = workflow_path.read_text()
+    assert "/opt/hostedtoolcache" not in content
+    assert "Verify Node runtime availability" in content
+    assert "node --version" in content
+
+
+def test_pi_image_release_workflow_uses_safe_image_artifact_path():
+    workflow_path = Path(".github/workflows/pi-image-release.yml")
+    content = workflow_path.read_text()
+    assert "scripts/compute_pi_gen_cache_key.sh" in content
+    assert "key=$(bash scripts/compute_pi_gen_cache_key.sh" in content
+    assert "fix_pi_image_permissions.sh" in content
+    assert "bash scripts/collect_pi_image.sh deploy ./sugarkube.img.xz" in content
+    assert "sha256sum -c ./sugarkube.img.xz.sha256" in content
+    assert "if: env.PUBLISH_RELEASE == 'true'" in content
+
+
 def test_compute_pi_gen_cache_key_script_has_fallback():
     script_path = Path("scripts/compute_pi_gen_cache_key.sh")
     script_text = script_path.read_text()


### PR DESCRIPTION
### Motivation
- The public `pi-image-release` runs were repeatedly failing on `main` and surfacing as unrelated dashboard failures, and the release path removed `/opt/hostedtoolcache` which broke later JS-based actions.  
- Operators need a clear separation: `pi-image.yml` for manual on-demand artifacts and `pi-image-release.yml` only for intentional signed-release publishing.  
- Make the signed-release path reliable and explicit so nightly/push noise does not cause expensive builds or false red status.

### Description
- Converted `.github/workflows/pi-image-release.yml` to `workflow_dispatch` with inputs (`release_channel`, `clone_sugarkube`, `clone_token_place`, `clone_dspace`, `publish_release`, `run_qemu_smoke`) and removed automatic `push`/`schedule` triggers.  
- Hardened the release job: stopped deleting `/opt/hostedtoolcache`, added a `Verify Node runtime availability` step, switched to the shared `scripts/compute_pi_gen_cache_key.sh` helper, improved pi-gen cache handling, added artifact permission fix/collect/verify steps, and gated GitHub Release publication behind `publish_release` (`PUBLISH_RELEASE`).  
- Preserved `pi-image.yml` as the canonical manual on-demand artifact workflow and updated docs (`README.md`, `docs/pi_image_quickstart.md`, `docs/pi_image_builder_design.md`, `docs/pi_image_contributor_guide.md`) to explain the roles of both workflows.  
- Added automated guards and tests: new shell guard `tests/pi_image_release_workflow_guard_test.sh` and pytest assertions in `tests/test_pi_image_tooling.py` to prevent reintroduction of automatic triggers or removal of the hosted toolcache; updated wordlist with a couple of terms used by docs.

### Testing
- Ran `python -m pytest tests/test_generate_release_manifest.py -q` and it passed (17 tests).  
- Ran `bash tests/compute_pi_gen_cache_key_e2e.sh` and it passed.  
- Ran guard scripts `bash tests/workflow_verify_step_guard_test.sh`, `bash tests/oci_parity_smoke_guard_test.sh`, and `bash tests/pi_image_release_workflow_guard_test.sh` and they all passed.  
- Ran `python -m pytest tests/test_pi_image_tooling.py -q` and it passed (38 tests).  
- Documentation checks: `python -m pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` were run and passed after adding the requested dictionary entries.  
- Ran `git diff --cached | ./scripts/scan-secrets.py` with the staged changes and it found no secrets.  
- Attempted `pre-commit run --all-files` but it failed due to unrelated repository-wide hooks and pre-existing lint/format issues; those unrelated hook-driven edits were not included in this change (they were reverted), and `pre-commit` failure is documented as a residual repo-level cleanup task.  

If you'd like, I can split the doc updates or the test additions into a focused follow-up PR, or add an explicit README note describing the recommended `pi-image` vs `pi-image-release` dispatch sequence for maintainers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29f4351a28832f800dddeafab40fe1)