### PR TITLE
Make pi-image-release an intentional manual publisher and harden release workflow

### DIFF
--- a/.github/workflows/pi-image-release.yml
+++ b/.github/workflows/pi-image-release.yml
@@ -1,11 +1,35 @@
 name: pi-image-release
 
 on:
-  push:
-    branches:
-      - main
-  schedule:
-    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      release_channel:
+        description: "Release channel to stamp into the manifest"
+        type: choice
+        options:
+          - stable
+          - nightly
+        default: stable
+      clone_sugarkube:
+        description: "Clone sugarkube repo into image"
+        type: boolean
+        default: true
+      clone_token_place:
+        description: "Clone token.place repo into image"
+        type: boolean
+        default: true
+      clone_dspace:
+        description: "Clone democratizedspace/dspace repo into image"
+        type: boolean
+        default: true
+      publish_release:
+        description: "Publish or update the GitHub Release after signing artifacts"
+        type: boolean
+        default: false
+      run_qemu_smoke:
+        description: "Boot the freshly built image in QEMU before signing/publishing"
+        type: boolean
+        default: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -24,10 +48,12 @@ jobs:
       ARM64: 1
       DEBIAN_FRONTEND: noninteractive
       BUILD_TIMEOUT: 7200
-      RELEASE_CHANNEL: ${{ github.event_name == 'schedule' && 'nightly' || 'stable' }}
-      CLONE_SUGARKUBE: true
-      CLONE_TOKEN_PLACE: true
-      CLONE_DSPACE: true
+      RELEASE_CHANNEL: ${{ github.event.inputs.release_channel }}
+      CLONE_SUGARKUBE: ${{ github.event.inputs.clone_sugarkube }}
+      CLONE_TOKEN_PLACE: ${{ github.event.inputs.clone_token_place }}
+      CLONE_DSPACE: ${{ github.event.inputs.clone_dspace }}
+      PUBLISH_RELEASE: ${{ github.event.inputs.publish_release }}
+      RUN_QEMU_SMOKE: ${{ github.event.inputs.run_qemu_smoke }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -37,10 +63,17 @@ jobs:
         run: |
           sudo apt-get clean
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-            /opt/hostedtoolcache /usr/local/lib/node_modules \
-            /usr/local/share/boost
+            /usr/local/lib/node_modules /usr/local/share/boost
           docker system prune -af || true
           df -h
+
+      - name: Verify Node runtime availability
+        run: |
+          if ! command -v node >/dev/null 2>&1; then
+            echo "Node.js runtime missing after cleanup" >&2
+            exit 1
+          fi
+          node --version
 
       - name: Install pi-gen dependencies
         run: |
@@ -62,14 +95,16 @@ jobs:
 
       - name: Compute pi-gen cache key
         id: pigen-key
+        env:
+          PI_GEN_BRANCH: bookworm
+          PI_GEN_REMOTE: https://github.com/RPi-Distro/pi-gen.git
         run: |
-          branch=bookworm
-          ref=$(git ls-remote https://github.com/RPi-Distro/pi-gen.git "refs/heads/${branch}" | cut -f1)
-          echo "key=pigen-${RUNNER_OS}-${branch}-${ref}-$(date +'%Y-%m')" >> "$GITHUB_OUTPUT"
+          key=$(bash scripts/compute_pi_gen_cache_key.sh "${PI_GEN_BRANCH}" "${PI_GEN_REMOTE}")
+          echo "key=${key}" >> "$GITHUB_OUTPUT"
 
       - name: Restore pi-gen Docker image
         id: cache-pigen
-        uses: actions/cache@v4
+        uses: actions/cache@v4.3.0
         with:
           path: ~/cache/pi-gen.tar
           key: ${{ steps.pigen-key.outputs.key }}
@@ -102,7 +137,28 @@ jobs:
             CLONE_DSPACE="${CLONE_DSPACE}" \
             ./scripts/build_pi_image.sh
 
+      - name: Fix permissions on pi-image artifacts
+        run: |
+          sudo TARGET_UID="$(id -u)" TARGET_GID="$(id -g)" \
+            bash scripts/fix_pi_image_permissions.sh
+
+      - name: Verify image artifacts
+        run: |
+          set -euo pipefail
+          for path in \
+            ./sugarkube.img.xz \
+            ./sugarkube.img.xz.sha256 \
+            ./sugarkube.img.xz.metadata.json \
+            ./sugarkube.img.xz.stage-summary.json; do
+            if [ ! -s "$path" ]; then
+              echo "Missing or empty artifact: $path" >&2
+              exit 1
+            fi
+          done
+          sha256sum -c ./sugarkube.img.xz.sha256
+
       - name: Boot image in QEMU smoke test
+        if: env.RUN_QEMU_SMOKE == 'true'
         run: |
           ./scripts/qemu_pi_smoke_test.py \
             --image sugarkube.img.xz \
@@ -128,16 +184,21 @@ jobs:
       - name: Generate release manifest and notes
         id: manifest
         run: |
-          python3 scripts/generate_release_manifest.py \
-            --metadata "sugarkube.img.xz.metadata.json" \
-            --manifest-output "sugarkube.img.xz.manifest.json" \
-            --notes-output "RELEASE_NOTES.md" \
-            --release-channel "${RELEASE_CHANNEL}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --run-id "${GITHUB_RUN_ID}" \
-            --run-attempt "${GITHUB_RUN_ATTEMPT}" \
-            --workflow "${GITHUB_WORKFLOW}" \
-            --qemu-artifacts "qemu-smoke-artifacts"
+          set -euo pipefail
+          manifest_args=(
+            --metadata "sugarkube.img.xz.metadata.json"
+            --manifest-output "sugarkube.img.xz.manifest.json"
+            --notes-output "RELEASE_NOTES.md"
+            --release-channel "${RELEASE_CHANNEL}"
+            --repo "${GITHUB_REPOSITORY}"
+            --run-id "${GITHUB_RUN_ID}"
+            --run-attempt "${GITHUB_RUN_ATTEMPT}"
+            --workflow "${GITHUB_WORKFLOW}"
+          )
+          if [ "${RUN_QEMU_SMOKE}" = "true" ]; then
+            manifest_args+=(--qemu-artifacts "qemu-smoke-artifacts")
+          fi
+          python3 scripts/generate_release_manifest.py "${manifest_args[@]}"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.5.0
@@ -156,7 +217,7 @@ jobs:
             sugarkube.img.xz.manifest.json
 
       - name: Upload run artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: sugarkube-pi-image
           path: |
@@ -173,7 +234,7 @@ jobs:
 
       - name: Upload QEMU smoke artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: sugarkube-qemu-smoke
           path: qemu-smoke-artifacts
@@ -203,13 +264,14 @@ jobs:
 
       - name: Upload support bundle
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: sugarkube-support-bundle
           path: support-bundles
           if-no-files-found: ignore
 
       - name: Publish GitHub release
+        if: env.PUBLISH_RELEASE == 'true'
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pi-image.yml
+++ b/.github/workflows/pi-image.yml
@@ -299,6 +299,9 @@ jobs:
       - name: Run OCI parity smoke workflow guard test
         run: bash tests/oci_parity_smoke_guard_test.sh
 
+      - name: Run pi-image release workflow guard test
+        run: bash tests/pi_image_release_workflow_guard_test.sh
+
       - name: Run fix permissions e2e test
         run: bash tests/fix_pi_image_permissions_e2e.sh
 

--- a/README.md
+++ b/README.md
@@ -159,16 +159,24 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
   [docs/outage_catalog.md](docs/outage_catalog.md))
 - `tests/` — quick checks for helper scripts and documentation
 
-## Pi image releases
+## Pi image workflows and releases
 
-The `pi-image-release` workflow builds a fresh Raspberry Pi OS image on every
-push to `main` and once per day. Each run publishes a signed
-`sugarkube.img.xz`, its checksum, a provenance manifest, and the full
-`pi-gen` build log. Release notes summarize stage timings and link directly to
-the manifest so you can verify the build inputs and commit hashes before
- flashing. Run `./scripts/install_sugarkube_image.sh` (or fetch the same helper
- via `curl -fsSL https://raw.githubusercontent.com/futuroptimist/sugarkube/main/scripts/install_sugarkube_image.sh | bash`) to
- download, verify, and expand the latest release. When you prefer a task runner,
+Use **Actions → pi-image → Run workflow** when you need a fresh on-demand
+workflow artifact for reimaging Raspberry Pi 5 sugarkube nodes. That manual
+workflow preserves the clone toggles for `sugarkube`, `token.place`, and
+`dspace`, then uploads the `sugarkube-img` run artifact for the exact build you
+requested.
+
+Use **Actions → pi-image-release → Run workflow** only when maintainers need to
+sign artifacts and optionally publish or update the latest downloadable GitHub
+Release. The release publisher is intentionally manual so unrelated `main`
+merges do not start an expensive image release attempt. It still produces signed
+artifacts, checksums, provenance manifests, QEMU smoke evidence when enabled,
+and the full `pi-gen` build log. Release notes summarize stage timings and link
+directly to the manifest so you can verify the build inputs and commit hashes
+before flashing. Run `./scripts/install_sugarkube_image.sh` (or fetch the same
+helper via `curl -fsSL https://raw.githubusercontent.com/futuroptimist/sugarkube/main/scripts/install_sugarkube_image.sh | bash`) to
+download, verify, and expand the latest published release. When you prefer a task runner,
 use either `sudo make flash-pi FLASH_DEVICE=/dev/sdX` or `sudo FLASH_DEVICE=/dev/sdX just flash-pi` to
 chain download → verification → flashing with the streaming helper. Prefer go-task? Run
 `sudo task pi:flash FLASH_DEVICE=/dev/sdX` to reach the same helper via the Taskfile. Need to forward

--- a/docs/pi_image_builder_design.md
+++ b/docs/pi_image_builder_design.md
@@ -98,10 +98,16 @@ personas:
   packages. Override to build a full image. An empty value halts the script before
   running pi-gen.
 
-### Release automation
-- `pi-image-release.yml` rebuilds the image on every `main` push and on a nightly
-  schedule. The job reuses the cached `pi-gen` container when possible so daily runs
-  stay within GitHub's time limits.
+### Workflow roles and release automation
+- `pi-image.yml` is the canonical on-demand image builder. Maintainers and
+  operators dispatch it manually when they need a fresh `sugarkube-img` workflow
+  artifact for reimaging nodes; pull requests only run the lightweight guard jobs.
+- `pi-image-release.yml` is the signed GitHub Release publisher. Maintainers
+  dispatch it manually when they need signed assets or a refreshed latest
+  downloadable release, which keeps unrelated `main` merges and routine nightly
+  windows from surfacing expensive release-build failures. The job reuses the
+  cached `pi-gen` container when possible so intentional release runs stay within
+  GitHub's time limits.
 - `build_pi_image.sh` now writes `sugarkube.img.xz.metadata.json` with the pi-gen
   commit, stage durations parsed from `work/<img>/build.log`, the git ref used for
   the build, and all toggles passed to the script. The log itself is copied to
@@ -114,8 +120,8 @@ personas:
   hashes) so releases document verification evidence inline.
 - Artifacts are signed via GitHub OIDC + cosign. Both the signature and certificate
   are attached to the release for offline verification.
-- After signing, the workflow launches `scripts/qemu_pi_smoke_test.py` to boot the
-  freshly built image inside `qemu-system-aarch64`. The helper swaps in a stub
+- Before signing, the workflow can launch `scripts/qemu_pi_smoke_test.py` to boot the
+  freshly built image inside `qemu-system-aarch64` when `run_qemu_smoke` is enabled. The helper swaps in a stub
   verifier, trims first-boot retry windows, waits for `[first-boot]` success markers
   on the serial console, and then copies `/boot/first-boot-report` plus
   `/var/log/sugarkube` into uploadable artifacts so every release ships with the

--- a/docs/pi_image_contributor_guide.md
+++ b/docs/pi_image_contributor_guide.md
@@ -49,7 +49,8 @@ sync.
 - `scripts/collect_pi_image.sh`
   - Purpose: normalize pi-gen output and compress it into the release artifact layout.
   - Primary docs: [Pi Image Builder Design](./pi_image_builder_design.md).
-  - Related tooling: invoked in the CI pipelines that publish release assets.
+  - Related tooling: invoked by the manual `pi-image` artifact workflow and the manual
+    `pi-image-release` publisher that signs and optionally publishes release assets.
 - `scripts/create_build_metadata.py` and `scripts/generate_release_manifest.py`
   - Purpose: capture build inputs, pi-gen SHAs, and stage timings, then export a signed manifest for
     releases.
@@ -196,7 +197,9 @@ trust the published status.
     image.
   - Primary docs: [Pi Image Quickstart](./pi_image_quickstart.md),
     [Pi Image Builder Design](./pi_image_builder_design.md).
-  - Related tooling: triggered manually via shell or by the GitHub Actions release workflow.
+  - Related tooling: triggered manually via shell, by **Actions → pi-image → Run workflow**
+    for fresh reimaging artifacts, or by **Actions → pi-image-release → Run workflow** when
+    maintainers need signed GitHub Release assets.
 - `scripts/checks.sh`
   - Purpose: unify linting, spellcheck, link-check, CAD, and KiCad validations in CI and local
     development.

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -117,6 +117,8 @@ sync without modifying the host.
     verifies the workflow run ID flows into the installer so those markers stay accurate.
    - **Manual:** open **Actions → pi-image → Run workflow**, tick **token.place** and **dspace** to
      bake those repos into `/opt/projects`, then download `sugarkube.img.xz` once the run succeeds.
+     This is the canonical fresh-artifact path for reimaging nodes; reserve
+     **pi-image-release** for maintainers who need signed GitHub Release assets.
      Need a guided path? Launch the [Sugarkube Flash Helper](./flash-helper/) and paste the workflow
      URL to receive OS-specific download, verification, and flashing instructions. Prefer the
      terminal? Run `python scripts/workflow_flash_instructions.py --url <run-url> --os

--- a/docs/pi_support_bundles.md
+++ b/docs/pi_support_bundles.md
@@ -82,7 +82,7 @@ point.
 
 ## CI integration
 
-The `pi-image-release.yml` workflow now uploads a support bundle after every build when the
+The manual `pi-image-release.yml` publisher uploads a support bundle after each release build when the
 following secrets are configured:
 
 - `SUPPORT_BUNDLE_HOST` — hostname or IP address of the validation Pi.

--- a/scripts/ci_commands.sh
+++ b/scripts/ci_commands.sh
@@ -57,6 +57,7 @@ run_image_e2e_scripts() {
     tests/verify_just_in_logs_test.sh
     tests/no_libraspberrypi_bin_test.sh
     tests/workflow_verify_step_guard_test.sh
+    tests/pi_image_release_workflow_guard_test.sh
   )
 
   local script

--- a/tests/pi_image_release_workflow_guard_test.sh
+++ b/tests/pi_image_release_workflow_guard_test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+wf=".github/workflows/pi-image-release.yml"
+
+# The release publisher must stay intentionally manual so unrelated main merges
+# and nightly windows do not run the expensive signed image build.
+grep -F "workflow_dispatch:" "$wf" >/dev/null
+if grep -Eq '^  (push|schedule):' "$wf"; then
+  echo "pi-image-release.yml must not run on push or schedule without an explicit guard update" >&2
+  exit 1
+fi
+
+# Disk cleanup must not remove the hosted toolcache because later JavaScript
+# actions need a working Node runtime.
+if grep -F "/opt/hostedtoolcache" "$wf" >/dev/null; then
+  echo "pi-image-release.yml must not delete /opt/hostedtoolcache" >&2
+  exit 1
+fi
+grep -F "Verify Node runtime availability" "$wf" >/dev/null
+
+# Keep the release workflow aligned with the canonical pi-gen cache helper and
+# make release publication an explicit dispatch choice.
+grep -F "scripts/compute_pi_gen_cache_key.sh" "$wf" >/dev/null
+grep -F "publish_release:" "$wf" >/dev/null
+grep -F "if: env.PUBLISH_RELEASE == 'true'" "$wf" >/dev/null
+grep -F "run_qemu_smoke:" "$wf" >/dev/null
+grep -F "if: env.RUN_QEMU_SMOKE == 'true'" "$wf" >/dev/null

--- a/tests/test_pi_image_tooling.py
+++ b/tests/test_pi_image_tooling.py
@@ -787,3 +787,33 @@ def test_collect_pi_image_scan_depth_configurable():
 
     assert 'MAX_SCAN_DEPTH="${MAX_SCAN_DEPTH:-6}"' in script_text
     assert 'find "${DEPLOY_ROOT}" -maxdepth "${MAX_SCAN_DEPTH}"' in script_text
+
+
+def test_pi_image_release_workflow_is_manual_only():
+    workflow_path = Path(".github/workflows/pi-image-release.yml")
+    content = workflow_path.read_text()
+
+    assert "workflow_dispatch:" in content
+    assert re.search(r"^  push:", content, re.MULTILINE) is None
+    assert re.search(r"^  schedule:", content, re.MULTILINE) is None
+
+
+def test_pi_image_release_workflow_preserves_node_and_cache_guardrails():
+    workflow_path = Path(".github/workflows/pi-image-release.yml")
+    content = workflow_path.read_text()
+
+    assert "/opt/hostedtoolcache" not in content
+    assert "Verify Node runtime availability" in content
+    assert "scripts/compute_pi_gen_cache_key.sh" in content
+    assert "key=$(bash scripts/compute_pi_gen_cache_key.sh" in content
+
+
+def test_pi_image_release_workflow_keeps_publish_and_qemu_explicit():
+    workflow_path = Path(".github/workflows/pi-image-release.yml")
+    content = workflow_path.read_text()
+
+    assert "publish_release:" in content
+    assert "default: false" in content
+    assert "if: env.PUBLISH_RELEASE == 'true'" in content
+    assert "run_qemu_smoke:" in content
+    assert "if: env.RUN_QEMU_SMOKE == 'true'" in content


### PR DESCRIPTION
### Motivation
- The recurring `pi-image-release` failures were caused by automatic `push`/`schedule` runs surfacing expensive image builds that then failed early in the `Build Raspberry Pi OS image` step.
- The intent is to keep `.github/workflows/pi-image.yml` as the canonical on-demand artifact builder while making `pi-image-release.yml` an intentional, maintainers-only publisher for signed GitHub Releases.
- Release workflow guardrails (Node/toolcache, cache-key helper, artifact verification, conditional publish) were missing or unsafe and needed to be ported to the release path to keep any manual run reliable.

### Description
- Converted `.github/workflows/pi-image-release.yml` to `workflow_dispatch` with inputs: `release_channel`, `clone_sugarkube`, `clone_token_place`, `clone_dspace`, `publish_release` (default false), and `run_qemu_smoke` (default true), and removed automatic `push`/`schedule` triggers.
- Ported reliability guardrails from `pi-image.yml` into the release job: removed deletion of `/opt/hostedtoolcache`, added a `Verify Node runtime availability` step after cleanup, use `scripts/compute_pi_gen_cache_key.sh` for cache keys, pinned `actions/cache` / `upload-artifact` versions, added permission fix/`Verify image artifacts` steps, and made GitHub Release publishing conditional on `PUBLISH_RELEASE`.
- Kept QEMU smoke testing but gated it via `RUN_QEMU_SMOKE`; ensured QEMU artifacts upload and support-bundle behavior remain non-fatal when secrets absent. Also preserved signing with `sigstore/cosign-installer` and kept signed artifact attachments.
- Documentation updates to clarify workflow roles: `README.md`, `docs/pi_image_quickstart.md`, `docs/pi_image_builder_design.md`, `docs/pi_image_contributor_guide.md`, and `docs/pi_support_bundles.md` now state `pi-image` is for fresh on-demand artifacts and `pi-image-release` is the manual signed-release publisher.
- Test and guard additions: added `tests/pi_image_release_workflow_guard_test.sh`, extended `tests/test_pi_image_tooling.py` with three tests validating manual-only release semantics, Node/cache guardrails, and explicit publish/QEMU toggles, and wired the new guard into `ci_commands.sh` and the `pi-image.yml` unit job so regression checks run automatically.

### Testing
- `python -m pytest tests/test_generate_release_manifest.py -q` — 17 passed (✅).
- `bash tests/compute_pi_gen_cache_key_e2e.sh` — `compute_pi_gen_cache_key e2e test passed` (✅).
- `bash tests/workflow_verify_step_guard_test.sh` — passed (✅).
- `bash tests/oci_parity_smoke_guard_test.sh` — passed (✅).
- `bash tests/pi_image_release_workflow_guard_test.sh` — passed (✅).
- `python -m pytest tests/test_pi_image_tooling.py -q` — 38 passed (✅).
- Workflow YAML sanity: `ruby -e 'require "yaml"; ...' .github/workflows/pi-image-release.yml .github/workflows/pi-image.yml` — both load as valid YAML (✅).
- Repository checks: `git diff --cached --check` and `git diff --cached | ./scripts/scan-secrets.py` — passed (✅).
- Not run in this environment due to missing tools: `pre-commit run --all-files` (pre-commit not installed), `pyspelling -c .spellcheck.yaml` (pyspelling not installed), and `linkchecker --no-warnings README.md docs/` (linkchecker not installed) (⚠️).
- Note: `gh` was not available inside this container so the live `gh run` inspection was done via the GitHub API metadata; the failing runs observed were schedule/push runs which motivated converting the release job to manual dispatch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29f4351a28832f800dddeafab40fe1)