### PR TITLE
Make pi-image-release manual-only and robust (avoid hostedtoolcache removal, add Node guardrails)

### DIFF
--- a/.github/workflows/pi-image-release.yml
+++ b/.github/workflows/pi-image-release.yml
@@ -1,11 +1,35 @@
 name: pi-image-release
 
 on:
-  push:
-    branches:
-      - main
-  schedule:
-    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      release_channel:
+        description: "Release channel to encode in the manifest"
+        type: choice
+        options:
+          - stable
+          - nightly
+        default: stable
+      clone_sugarkube:
+        description: "Clone sugarkube repo into image"
+        type: boolean
+        default: true
+      clone_token_place:
+        description: "Clone token.place repo into image"
+        type: boolean
+        default: true
+      clone_dspace:
+        description: "Clone democratizedspace/dspace repo into image"
+        type: boolean
+        default: true
+      publish_release:
+        description: "Publish the signed artifacts to a GitHub Release"
+        type: boolean
+        default: false
+      run_qemu_smoke:
+        description: "Boot the image in QEMU before signing/publishing"
+        type: boolean
+        default: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -24,10 +48,10 @@ jobs:
       ARM64: 1
       DEBIAN_FRONTEND: noninteractive
       BUILD_TIMEOUT: 7200
-      RELEASE_CHANNEL: ${{ github.event_name == 'schedule' && 'nightly' || 'stable' }}
-      CLONE_SUGARKUBE: true
-      CLONE_TOKEN_PLACE: true
-      CLONE_DSPACE: true
+      RELEASE_CHANNEL: ${{ inputs.release_channel }}
+      CLONE_SUGARKUBE: ${{ inputs.clone_sugarkube && 'true' || 'false' }}
+      CLONE_TOKEN_PLACE: ${{ inputs.clone_token_place && 'true' || 'false' }}
+      CLONE_DSPACE: ${{ inputs.clone_dspace && 'true' || 'false' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -37,10 +61,17 @@ jobs:
         run: |
           sudo apt-get clean
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-            /opt/hostedtoolcache /usr/local/lib/node_modules \
-            /usr/local/share/boost
+            /usr/local/lib/node_modules /usr/local/share/boost
           docker system prune -af || true
           df -h
+
+      - name: Verify Node runtime availability
+        run: |
+          if ! command -v node >/dev/null 2>&1; then
+            echo "Node.js runtime missing after cleanup" >&2
+            exit 1
+          fi
+          node --version
 
       - name: Install pi-gen dependencies
         run: |
@@ -62,14 +93,16 @@ jobs:
 
       - name: Compute pi-gen cache key
         id: pigen-key
+        env:
+          PI_GEN_BRANCH: bookworm
+          PI_GEN_REMOTE: https://github.com/RPi-Distro/pi-gen.git
         run: |
-          branch=bookworm
-          ref=$(git ls-remote https://github.com/RPi-Distro/pi-gen.git "refs/heads/${branch}" | cut -f1)
-          echo "key=pigen-${RUNNER_OS}-${branch}-${ref}-$(date +'%Y-%m')" >> "$GITHUB_OUTPUT"
+          key=$(bash scripts/compute_pi_gen_cache_key.sh "${PI_GEN_BRANCH}" "${PI_GEN_REMOTE}")
+          echo "key=${key}" >> "$GITHUB_OUTPUT"
 
       - name: Restore pi-gen Docker image
         id: cache-pigen
-        uses: actions/cache@v4
+        uses: actions/cache@v4.3.0
         with:
           path: ~/cache/pi-gen.tar
           key: ${{ steps.pigen-key.outputs.key }}
@@ -102,7 +135,29 @@ jobs:
             CLONE_DSPACE="${CLONE_DSPACE}" \
             ./scripts/build_pi_image.sh
 
+      - name: Fix permissions on pi-image artifacts
+        run: |
+          sudo TARGET_UID="$(id -u)" TARGET_GID="$(id -g)" \
+            bash scripts/fix_pi_image_permissions.sh
+
+      - name: Verify image artifacts
+        run: |
+          set -euo pipefail
+          for path in \
+            ./sugarkube.img.xz \
+            ./sugarkube.img.xz.sha256 \
+            ./sugarkube.img.xz.metadata.json \
+            ./sugarkube.img.xz.stage-summary.json \
+            ./sugarkube.build.log; do
+            if [ ! -s "$path" ]; then
+              echo "Missing or empty artifact: $path" >&2
+              exit 1
+            fi
+          done
+          sha256sum -c ./sugarkube.img.xz.sha256
+
       - name: Boot image in QEMU smoke test
+        if: inputs.run_qemu_smoke
         run: |
           ./scripts/qemu_pi_smoke_test.py \
             --image sugarkube.img.xz \
@@ -128,6 +183,11 @@ jobs:
       - name: Generate release manifest and notes
         id: manifest
         run: |
+          set -euo pipefail
+          qemu_args=()
+          if [ -d qemu-smoke-artifacts ]; then
+            qemu_args=(--qemu-artifacts "qemu-smoke-artifacts")
+          fi
           python3 scripts/generate_release_manifest.py \
             --metadata "sugarkube.img.xz.metadata.json" \
             --manifest-output "sugarkube.img.xz.manifest.json" \
@@ -137,7 +197,7 @@ jobs:
             --run-id "${GITHUB_RUN_ID}" \
             --run-attempt "${GITHUB_RUN_ATTEMPT}" \
             --workflow "${GITHUB_WORKFLOW}" \
-            --qemu-artifacts "qemu-smoke-artifacts"
+            "${qemu_args[@]}"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.5.0
@@ -156,13 +216,14 @@ jobs:
             sugarkube.img.xz.manifest.json
 
       - name: Upload run artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
-          name: sugarkube-pi-image
+          name: sugarkube-pi-image-release
           path: |
             sugarkube.img.xz
             sugarkube.img.xz.sha256
             sugarkube.img.xz.metadata.json
+            sugarkube.img.xz.stage-summary.json
             sugarkube.img.xz.manifest.json
             sugarkube.img.xz.sig
             sugarkube.img.xz.pem
@@ -173,7 +234,7 @@ jobs:
 
       - name: Upload QEMU smoke artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: sugarkube-qemu-smoke
           path: qemu-smoke-artifacts
@@ -203,13 +264,14 @@ jobs:
 
       - name: Upload support bundle
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: sugarkube-support-bundle
           path: support-bundles
           if-no-files-found: ignore
 
       - name: Publish GitHub release
+        if: inputs.publish_release
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -225,6 +287,7 @@ jobs:
             sugarkube.img.xz
             sugarkube.img.xz.sha256
             sugarkube.img.xz.metadata.json
+            sugarkube.img.xz.stage-summary.json
             sugarkube.img.xz.manifest.json
             sugarkube.img.xz.sig
             sugarkube.img.xz.pem

--- a/README.md
+++ b/README.md
@@ -161,14 +161,24 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
 
 ## Pi image releases
 
-The `pi-image-release` workflow builds a fresh Raspberry Pi OS image on every
-push to `main` and once per day. Each run publishes a signed
-`sugarkube.img.xz`, its checksum, a provenance manifest, and the full
-`pi-gen` build log. Release notes summarize stage timings and link directly to
-the manifest so you can verify the build inputs and commit hashes before
- flashing. Run `./scripts/install_sugarkube_image.sh` (or fetch the same helper
- via `curl -fsSL https://raw.githubusercontent.com/futuroptimist/sugarkube/main/scripts/install_sugarkube_image.sh | bash`) to
- download, verify, and expand the latest release. When you prefer a task runner,
+Use **Actions → pi-image → Run workflow** when you need a fresh on-demand
+workflow artifact for reimaging Raspberry Pi 5 sugarkube nodes. That manual
+workflow keeps the clone toggles for `sugarkube`, `token.place`, and
+`democratizedspace/dspace`, and uploads the `sugarkube-img` run artifact for
+immediate flashing.
+
+Use **Actions → pi-image-release → Run workflow** only when you intend to build,
+sign, and optionally publish a GitHub Release asset. It is manual-only so
+unrelated `main` merges and nightly schedules do not start an expensive release
+publisher. Leave `publish_release` disabled for validate-only signed run
+artifacts; enable it when the release should become the latest downloadable
+release. Published runs attach `sugarkube.img.xz`, its checksum, a provenance
+manifest, signatures, certificates, and the full `pi-gen` build log. Release
+notes summarize stage timings and link directly to the manifest so you can
+verify the build inputs and commit hashes before flashing. Run
+`./scripts/install_sugarkube_image.sh` (or fetch the same helper via
+`curl -fsSL https://raw.githubusercontent.com/futuroptimist/sugarkube/main/scripts/install_sugarkube_image.sh | bash`) to
+download, verify, and expand the latest published release. When you prefer a task runner,
 use either `sudo make flash-pi FLASH_DEVICE=/dev/sdX` or `sudo FLASH_DEVICE=/dev/sdX just flash-pi` to
 chain download → verification → flashing with the streaming helper. Prefer go-task? Run
 `sudo task pi:flash FLASH_DEVICE=/dev/sdX` to reach the same helper via the Taskfile. Need to forward

--- a/docs/pi_image_builder_design.md
+++ b/docs/pi_image_builder_design.md
@@ -98,10 +98,15 @@ personas:
   packages. Override to build a full image. An empty value halts the script before
   running pi-gen.
 
-### Release automation
-- `pi-image-release.yml` rebuilds the image on every `main` push and on a nightly
-  schedule. The job reuses the cached `pi-gen` container when possible so daily runs
-  stay within GitHub's time limits.
+### Workflow roles
+- `pi-image.yml` is the canonical on-demand image workflow. It keeps the manual
+  `workflow_dispatch` clone toggles and uploads the `sugarkube-img` artifact that
+  operators use to reimage nodes.
+- `pi-image-release.yml` is a manual signed-release publisher. It no longer runs on
+  every `main` push or a nightly schedule; dispatch it only when validating signed
+  release artifacts or publishing a GitHub Release. Its inputs select the stable or
+  nightly channel, choose clone toggles, decide whether to run the QEMU smoke test,
+  and keep release publication explicit with `publish_release`.
 - `build_pi_image.sh` now writes `sugarkube.img.xz.metadata.json` with the pi-gen
   commit, stage durations parsed from `work/<img>/build.log`, the git ref used for
   the build, and all toggles passed to the script. The log itself is copied to

--- a/docs/pi_image_contributor_guide.md
+++ b/docs/pi_image_contributor_guide.md
@@ -46,10 +46,23 @@ sync.
     [Pi Image Builder Design](./pi_image_builder_design.md).
   - Related tooling: wrapped by `make download-pi-image`, `just download-pi-image`, and consumed by
     the installer script above.
+- `.github/workflows/pi-image.yml`
+  - Purpose: canonical on-demand workflow for fresh image artifacts used to reimage nodes.
+  - Primary docs: [Pi Image Quickstart](./pi_image_quickstart.md),
+    [Pi Image Builder Design](./pi_image_builder_design.md).
+  - Related tooling: keeps the manual clone toggles, uploads the `sugarkube-img` artifact, and
+    runs lightweight workflow guard tests on relevant pull requests.
+- `.github/workflows/pi-image-release.yml`
+  - Purpose: manual signed-release publisher for validate-only signed run artifacts or explicit
+    GitHub Release publication.
+  - Primary docs: [Pi Image Builder Design](./pi_image_builder_design.md).
+  - Related tooling: runs QEMU smoke testing by default, signs artifacts with cosign, and only
+    publishes when `publish_release` is enabled during manual dispatch.
 - `scripts/collect_pi_image.sh`
   - Purpose: normalize pi-gen output and compress it into the release artifact layout.
   - Primary docs: [Pi Image Builder Design](./pi_image_builder_design.md).
-  - Related tooling: invoked in the CI pipelines that publish release assets.
+  - Related tooling: invoked by the manual image and release workflows before artifacts are
+    uploaded or published.
 - `scripts/create_build_metadata.py` and `scripts/generate_release_manifest.py`
   - Purpose: capture build inputs, pi-gen SHAs, and stage timings, then export a signed manifest for
     releases.

--- a/docs/pi_image_quickstart.md
+++ b/docs/pi_image_quickstart.md
@@ -115,9 +115,12 @@ sync without modifying the host.
     `.run` marker pointing to the exact build that was flashed.
     Regression coverage: `tests/pi_cluster_bootstrap_test.py::test_run_bootstrap_invokes_workflow_and_join`
     verifies the workflow run ID flows into the installer so those markers stay accurate.
-   - **Manual:** open **Actions → pi-image → Run workflow**, tick **token.place** and **dspace** to
-     bake those repos into `/opt/projects`, then download `sugarkube.img.xz` once the run succeeds.
-     Need a guided path? Launch the [Sugarkube Flash Helper](./flash-helper/) and paste the workflow
+   - **Manual:** open **Actions → pi-image → Run workflow** for the normal fresh-artifact
+     path, tick **token.place** and **dspace** to bake those repos into `/opt/projects`, then
+     download `sugarkube.img.xz` from the `sugarkube-img` workflow artifact once the run succeeds.
+     Use **pi-image-release** only when you need to publish a signed GitHub Release instead of
+     collecting an on-demand workflow artifact. Need a guided path? Launch the
+     [Sugarkube Flash Helper](./flash-helper/) and paste the workflow
      URL to receive OS-specific download, verification, and flashing instructions. Prefer the
      terminal? Run `python scripts/workflow_flash_instructions.py --url <run-url> --os
      linux|mac|windows` from the repository root to print the same steps.

--- a/tests/test_pi_image_release_workflow.py
+++ b/tests/test_pi_image_release_workflow.py
@@ -1,6 +1,72 @@
 from pathlib import Path
 
 
-def test_release_workflow_clones_sugarkube() -> None:
-    workflow = Path(".github/workflows/pi-image-release.yml").read_text()
-    assert "CLONE_SUGARKUBE: true" in workflow
+WORKFLOW = Path(".github/workflows/pi-image-release.yml")
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_release_workflow_is_manual_only() -> None:
+    workflow = _workflow_text()
+
+    assert "workflow_dispatch:" in workflow
+    assert "\n  push:" not in workflow
+    assert "\n  schedule:" not in workflow
+    assert "cron:" not in workflow
+
+
+def test_release_workflow_exposes_intentional_inputs() -> None:
+    workflow = _workflow_text()
+
+    for snippet in [
+        "release_channel:",
+        "clone_sugarkube:",
+        "clone_token_place:",
+        "clone_dspace:",
+        "publish_release:",
+        "run_qemu_smoke:",
+        "default: stable",
+        "default: false",
+        "default: true",
+    ]:
+        assert snippet in workflow
+
+    assert "RELEASE_CHANNEL: ${{ inputs.release_channel }}" in workflow
+    assert "CLONE_SUGARKUBE: ${{ inputs.clone_sugarkube" in workflow
+    assert "CLONE_TOKEN_PLACE: ${{ inputs.clone_token_place" in workflow
+    assert "CLONE_DSPACE: ${{ inputs.clone_dspace" in workflow
+    assert "if: inputs.publish_release" in workflow
+    assert "if: inputs.run_qemu_smoke" in workflow
+
+
+def test_release_workflow_preserves_node_runtime_after_cleanup() -> None:
+    workflow = _workflow_text()
+
+    assert "/opt/hostedtoolcache" not in workflow
+    assert "Verify Node runtime availability" in workflow
+    assert "node --version" in workflow
+
+
+def test_release_workflow_uses_shared_cache_key_and_pinned_actions() -> None:
+    workflow = _workflow_text()
+
+    assert "scripts/compute_pi_gen_cache_key.sh" in workflow
+    assert "key=$(bash scripts/compute_pi_gen_cache_key.sh" in workflow
+    assert "actions/cache@v4.3.0" in workflow
+    assert "actions/upload-artifact@v4.6.2" in workflow
+
+
+def test_release_workflow_verifies_and_signs_artifacts_before_optional_publish() -> None:
+    workflow = _workflow_text()
+
+    assert "Fix permissions on pi-image artifacts" in workflow
+    assert "bash scripts/fix_pi_image_permissions.sh" in workflow
+    assert "Verify image artifacts" in workflow
+    assert "sha256sum -c ./sugarkube.img.xz.sha256" in workflow
+    assert "sigstore/cosign-installer@v3.5.0" in workflow
+    assert "cosign sign-blob --yes" in workflow
+    assert "sugarkube.img.xz.stage-summary.json" in workflow
+    assert "Upload QEMU smoke artifacts" in workflow
+    assert "if-no-files-found: warn" in workflow


### PR DESCRIPTION
### Motivation
- Public `pi-image-release` runs on `main` and nightly were repeatedly failing in the heavy `Build Raspberry Pi OS image` step and surfacing as red in dashboards, and run metadata suggested failures happened immediately after aggressive runner cleanup.  
- Investigation showed the release workflow removed `/opt/hostedtoolcache` (and other shared tool locations), which can remove Node/toolcache needed by later JS-based actions and cause subsequent action startup failures.  
- The intended UX is that `pi-image.yml` is the canonical on-demand image artifact builder and `pi-image-release.yml` should be an intentional signed-release publisher, not an automatic nightly/push job that repeatedly fails.  
- The change aims to stop unnecessary auto-triggering, preserve the manual build path, and make any release run reliable by copying the safer guardrails from the on-demand workflow.  

### Description
- Converted `.github/workflows/pi-image-release.yml` to manual-only `workflow_dispatch` with explicit inputs: `release_channel`, `clone_sugarkube`, `clone_token_place`, `clone_dspace`, `publish_release`, and `run_qemu_smoke`.  
- Removed `push` and `schedule` triggers and made release publication conditional on `publish_release`, while keeping QEMU smoke testing and cosign signing in the workflow.  
- Stopped deleting `/opt/hostedtoolcache` in the release cleanup step and added a `Verify Node runtime availability` step after cleanup; switched to the shared `scripts/compute_pi_gen_cache_key.sh` helper and pinned action versions (`actions/cache@v4.3.0`, `actions/upload-artifact@v4.6.2`).  
- Added artifact hardening: run `scripts/fix_pi_image_permissions.sh`, explicit artifact verification (`sha256sum -c` etc.), preserved QEMU/support bundle uploads on failure, and kept GitHub Release publishing gated behind the manual input.  
- Updated docs (`README.md`, `docs/pi_image_quickstart.md`, `docs/pi_image_builder_design.md`, `docs/pi_image_contributor_guide.md`) to clarify that `pi-image.yml` is the user-facing on-demand workflow and `pi-image-release.yml` is the intentional signed-publisher.  
- Added/updated tests: `tests/test_pi_image_release_workflow.py` asserts manual-only dispatch, required inputs, no `/opt/hostedtoolcache` deletion, shared cache-key usage, pinned actions, artifact verification, and signing/publish gating.  

### Testing
- Ran unit and integration checks that exercise the modified flows and guard tests: `python -m pytest tests/test_generate_release_manifest.py -q` (17 passed), and `python -m pytest tests/test_pi_image_release_workflow.py -q` (5 passed).  
- Ran shell guard and e2e checks: `bash tests/compute_pi_gen_cache_key_e2e.sh` (passed), `bash tests/workflow_verify_step_guard_test.sh` (passed), and `bash tests/oci_parity_smoke_guard_test.sh` (passed).  
- Executed combined test run: `python -m pytest tests/test_generate_release_manifest.py tests/test_pi_image_release_workflow.py -q` and observed all targeted tests passing (`22 passed`).  
- Could not download full workflow logs via `gh` in this environment because `gh` is not installed and the GitHub API returned 403 for full log download without repository admin rights, so investigation used public Actions run/job metadata instead.  
- Environment tooling not available here: `pre-commit`, `pyspelling`, and `linkchecker` are not installed so those checks were not executed locally; they should be run by the normal CI/doc-agent jobs and on maintainer machines via `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29f4351a28832f800dddeafab40fe1)