### PR TITLE
Add app-chart-status/app-chart-bump, deploy preflight, and token.place guardrails

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -108,6 +108,30 @@ Helm charts are immutable once published to GHCR OCI:
 - Sugarkube pins the chart version with the app's version file and uses that pin
   for cluster deployment orchestration.
 
+
+## Chart pin status and explicit bump workflow
+
+Image tags and chart versions are separate deployment coordinates. `just app-deploy tag=...` changes only the image tag passed to Helm; it does **not** discover, select, or bump a newer chart. Default deploys stay pinned and reproducible through `docs/apps/<app>.version`.
+
+Before release operations, inspect the committed chart pin:
+
+```bash
+just app-chart-status app=dspace
+```
+
+The status command prints the app name, chart ref, pinned version, chart `appVersion`, best-effort digest, and pin file. When registry metadata is available and the pin is older than the newest published semver chart, it warns loudly and prints the exact `just app-chart-bump` command to run. If registry/latest detection is unavailable because of network, auth, or missing tooling, deploys still use the committed pin and the status command prints a manual inspection hint.
+
+When an app repository publishes a new chart that Sugarkube should consume, bump the pin explicitly:
+
+```bash
+just app-chart-bump app=dspace version=0.1.3
+git add docs/apps/dspace.version
+git commit -m "Bump dspace chart pin to 0.1.3"
+git push
+```
+
+`app-chart-bump` validates the requested chart with `helm show chart <chart-ref> --version <version>`, edits only `docs/apps/<app>.version`, and prints the resulting diff. Do not use `chart=latest` or silent auto-upgrade behavior for production; commit chart pin bumps before or with release operations.
+
 ## App config file shape
 
 Generic recipes load a simple shell/dotenv-style config with
@@ -171,6 +195,10 @@ just app-redeploy app=dspace env=staging tag=main-REPLACE_SHORTSHA
 
 # Promote an approved immutable tag to production.
 just app-promote-prod app=dspace tag=main-REPLACE_SHORTSHA
+
+# Inspect and intentionally bump the chart pin.
+just app-chart-status app=dspace
+just app-chart-bump app=dspace version=0.1.3
 
 # Inspect Kubernetes and Helm status for an app environment.
 just app-status app=dspace env=staging

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -86,8 +86,8 @@ The app repo's chart and `ci-helm.yml` should answer yes to each item before Sug
 - `ci-helm.yml` publishes `oci://ghcr.io/OWNER/charts/CHART`.
 - Published chart versions are immutable; never republish different content under an existing version.
 - Sugarkube pins the deployed chart version in `docs/apps/APP.version`.
-  Image tags and chart versions are separate coordinates: `just app-deploy
-  tag=...` does not bump or auto-select charts.
+  Image tags and chart versions are separate coordinates: `just app-deploy tag=...`
+  does not bump or auto-select charts.
 
 ## Environment overlay checklist
 

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -86,6 +86,8 @@ The app repo's chart and `ci-helm.yml` should answer yes to each item before Sug
 - `ci-helm.yml` publishes `oci://ghcr.io/OWNER/charts/CHART`.
 - Published chart versions are immutable; never republish different content under an existing version.
 - Sugarkube pins the deployed chart version in `docs/apps/APP.version`.
+  Image tags and chart versions are separate coordinates: `just app-deploy
+  tag=...` does not bump or auto-select charts.
 
 ## Environment overlay checklist
 
@@ -137,19 +139,29 @@ APP_TAG=main-REPLACE_SHORTSHA
 just app-deploy app=appslug env=staging tag="$APP_TAG" config="$APP_CONFIG"
 ```
 
+Before deploying, inspect the current chart pin:
+
+```bash
+just app-chart-status app=appslug config="$APP_CONFIG"
+```
+
 ### The chart changed; what version do I bump?
 
 - Bump the app repo chart `version` for any chart content change.
 - Update `appVersion` when the human-facing app version changed.
 - Publish the new OCI chart once.
-- Update Sugarkube's `docs/apps/APP.version` to the new chart version after publication.
+- Update Sugarkube's `docs/apps/APP.version` to the new chart version after
+  publication with the explicit bump workflow, then commit that pin before or
+  with release operations. Do not use `chart=latest` or silent chart
+  auto-upgrades for production.
 
 ```bash
-CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/appslug.version | head -n 1)
+just app-chart-bump app=appslug version=0.1.3 config="$APP_CONFIG"
 ```
 
 ```bash
-helm show chart oci://ghcr.io/OWNER/charts/CHART --version "$CHART_VERSION"
+git add docs/apps/appslug.version
+git commit -m "Bump appslug chart pin to 0.1.3"
 ```
 
 ### Staging works; how do I promote prod?

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -17,7 +17,7 @@ This is the canonical runbook for deploying token.place from GHCR artifacts to S
 | App config | `docs/examples/apps/tokenplace.env` |
 | Chart version pin | `docs/apps/tokenplace.version` |
 | Production tag pin | `docs/apps/tokenplace.prod.tag` |
-| Verify paths | `/`, `/livez`, `/healthz`, `/relay/diagnostics` |
+| Verify paths | `/`, `/livez`, `/healthz`, `/relay/diagnostics`, `/api/v1/meta` |
 
 ### Artifact links
 
@@ -67,6 +67,24 @@ gh workflow run ci-image.yml --repo futuroptimist/token.place --ref main
 ```
 
 ## Confirm/publish OCI chart
+
+The token.place image tag and Helm chart version are independent coordinates. `just app-deploy app=tokenplace tag=...` deploys the requested image tag with the chart version already pinned in `docs/apps/tokenplace.version`; it never silently selects the newest chart. Run the status command before deployment and commit intentional pin bumps when the app repo publishes chart wiring changes.
+
+```bash
+just app-chart-status app=tokenplace
+```
+
+If status reports a stale pin after a new chart is published, bump it explicitly:
+
+```bash
+just app-chart-bump app=tokenplace version=0.1.3
+git add docs/apps/tokenplace.version
+git commit -m "Bump tokenplace chart pin to 0.1.3"
+git push
+```
+
+Prefer this committed pin workflow over unpinned chart overrides, and never use `chart=latest` for production.
+
 
 Sugarkube deploys the chart version pinned in `docs/apps/tokenplace.version`. Use [recent chart workflow runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml) to find chart publish attempts, [GHCR chart package versions](https://github.com/futuroptimist/token.place/pkgs/container/charts%2Ftokenplace) to confirm available immutable chart versions, and [the chart source](https://github.com/futuroptimist/token.place/tree/main/charts/tokenplace) to review the chart content that should match the pinned version.
 
@@ -128,6 +146,12 @@ curl -fsS https://staging.token.place/livez
 curl -fsS https://staging.token.place/relay/diagnostics | jq .
 ```
 
+```bash
+curl -fsS https://staging.token.place/api/v1/meta | jq .
+```
+
+Staging metadata must not report `.version == "dev"` or a `.label` ending in ` dev`; the expected label includes the deployed image tag, for example `staging main-00797df`.
+
 ### Staging relay-compute sign-off
 
 `just app-status`, `just app-verify`, `/livez`, `/healthz`, `/`, and `/relay/diagnostics` are necessary but not sufficient for token.place promotion. Staging-to-prod promotion is blocked until the real relay-compute path passes, as defined in [the token.place Sugarkube onboarding contract](../tokenplace_sugarkube_onboarding.md#promotion-gate-ownership). Before production promotion, capture staging evidence for the real relay path:
@@ -177,6 +201,12 @@ curl -fsS https://token.place/healthz
 ```bash
 curl -fsS https://token.place/livez
 ```
+
+```bash
+curl -fsS https://token.place/api/v1/meta | jq .
+```
+
+Production metadata must not report `.version == "dev"`; the expected label is a finalized release such as `prod 0.1.1`.
 
 ```bash
 curl -fsS https://token.place/relay/diagnostics | jq .

--- a/docs/examples/apps/tokenplace.env
+++ b/docs/examples/apps/tokenplace.env
@@ -13,5 +13,5 @@ SUGARKUBE_VALUES_DEV=docs/examples/tokenplace.values.dev.yaml
 SUGARKUBE_VALUES_STAGING=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml
 SUGARKUBE_VALUES_PROD=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml
 SUGARKUBE_STATUS_HOST_KEY=ingress.host
-SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz,/relay/diagnostics
+SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz,/relay/diagnostics,/api/v1/meta
 SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=tokenplace

--- a/justfile
+++ b/justfile
@@ -1307,6 +1307,16 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
         version_args+=(--version "${chart_version}")
     fi
 
+    echo "app: ${release}"
+    echo "env: ${SUGARKUBE_ENV:-unknown}"
+    echo "image tag: ${image_tag:-<none>}"
+    echo "chart ref: ${chart}"
+    echo "chart version: ${chart_version:-<unversioned>}"
+    echo "chart pin: ${version_file:-<inline version>}"
+    if [ -n "${chart_version}" ]; then
+      helm show chart "${chart}" --version "${chart_version}" >/dev/null
+    fi
+
     value_args=()
     if [ -n "${values}" ]; then
         IFS=',' read -ra value_files <<< "${values}"
@@ -1542,6 +1552,16 @@ app-deploy app env='staging' tag='' config='':
 
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight \
+      --app "${SUGARKUBE_APP}" \
+      --env "${SUGARKUBE_ENV}" \
+      --tag "${SUGARKUBE_TAG}" \
+      --chart "${SUGARKUBE_CHART}" \
+      --version "${SUGARKUBE_VERSION:-}" \
+      --version-file "${SUGARKUBE_VERSION_FILE:-}" \
+      --values "${SUGARKUBE_VALUES}" \
+      --release "${SUGARKUBE_RELEASE}" \
+      --namespace "${SUGARKUBE_NAMESPACE}"
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release="${SUGARKUBE_RELEASE}" \
       namespace="${SUGARKUBE_NAMESPACE}" \
@@ -1565,6 +1585,16 @@ app-redeploy app env='staging' tag='' config='':
 
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight \
+      --app "${SUGARKUBE_APP}" \
+      --env "${SUGARKUBE_ENV}" \
+      --tag "${SUGARKUBE_TAG}" \
+      --chart "${SUGARKUBE_CHART}" \
+      --version "${SUGARKUBE_VERSION:-}" \
+      --version-file "${SUGARKUBE_VERSION_FILE:-}" \
+      --values "${SUGARKUBE_VALUES}" \
+      --release "${SUGARKUBE_RELEASE}" \
+      --namespace "${SUGARKUBE_NAMESPACE}"
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release="${SUGARKUBE_RELEASE}" \
       namespace="${SUGARKUBE_NAMESPACE}" \
@@ -1591,6 +1621,39 @@ app-promote-prod app tag='' config='':
       env=prod \
       tag="${SUGARKUBE_TAG}" \
       config="${SUGARKUBE_CONFIG_PATH}"
+
+# Show the pinned chart version and whether a newer semver chart appears published.
+app-chart-status app env='staging' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+      --app {{ quote(app) }} \
+      --env {{ quote(env) }} \
+      --config {{ quote(config) }})"
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" status \
+      --app "${SUGARKUBE_APP}" \
+      --chart "${SUGARKUBE_CHART}" \
+      --version-file "${SUGARKUBE_VERSION_FILE:-}"
+
+# Explicitly bump a Sugarkube app chart pin after validating the chart exists.
+app-chart-bump app version env='staging' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+      --app {{ quote(app) }} \
+      --env {{ quote(env) }} \
+      --config {{ quote(config) }})"
+    bump_version={{ quote(version) }}
+    while [ "${bump_version#version=}" != "${bump_version}" ]; do
+      bump_version="${bump_version#version=}"
+    done
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" bump \
+      --app "${SUGARKUBE_APP}" \
+      --chart "${SUGARKUBE_CHART}" \
+      --version-file "${SUGARKUBE_VERSION_FILE:-}" \
+      --version "${bump_version}"
 
 # Verify configured HTTPS paths for a Sugarkube app.
 app-verify app env='staging' config='' print_only='':
@@ -1955,6 +2018,9 @@ tokenplace-oci-deploy env='staging' tag='':
     }
 
     resolved_tag="$(echo '{{ tag }}' | xargs)"
+    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
+      resolved_tag="${resolved_tag#tag=}"
+    done
     if [ -z "${resolved_tag}" ]; then
       echo "ERROR: tag is required for immutable deploys." >&2
       exit 1
@@ -1984,6 +2050,15 @@ tokenplace-oci-deploy env='staging' tag='':
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
     echo "Deploying tokenplace env=${env_name} chart=oci://ghcr.io/futuroptimist/charts/tokenplace version=${chart_version} image=ghcr.io/futuroptimist/tokenplace-relay:${resolved_tag}"
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight \
+      --app tokenplace \
+      --env "${env_name}" \
+      --tag "${resolved_tag}" \
+      --chart 'oci://ghcr.io/futuroptimist/charts/tokenplace' \
+      --version-file 'docs/apps/tokenplace.version' \
+      --values "${values_chain}" \
+      --release tokenplace \
+      --namespace tokenplace
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='tokenplace' namespace='tokenplace' \
@@ -2054,6 +2129,9 @@ tokenplace-oci-redeploy env='staging' tag='':
     read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.prod.tag | head -n1 | tr -d '[:space:]'; }
 
     resolved_tag="$(echo '{{ tag }}' | xargs)"
+    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
+      resolved_tag="${resolved_tag#tag=}"
+    done
     if [ -z "${resolved_tag}" ] && [ "${env_name}" = "prod" ]; then
       resolved_tag="$(read_prod_tag 2>/dev/null || true)"
       [ -n "${resolved_tag}" ] || { echo "ERROR: prod requires tag=<immutable-tag> or docs/apps/tokenplace.prod.tag." >&2; exit 1; }
@@ -2078,6 +2156,15 @@ tokenplace-oci-redeploy env='staging' tag='':
     # This is tokenplace-scoped; do not copy into DSPACE from this PR.
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight \
+      --app tokenplace \
+      --env "${env_name}" \
+      --tag "${resolved_tag}" \
+      --chart 'oci://ghcr.io/futuroptimist/charts/tokenplace' \
+      --version-file 'docs/apps/tokenplace.version' \
+      --values "${values_chain}" \
+      --release tokenplace \
+      --namespace tokenplace
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release='tokenplace' namespace='tokenplace' \

--- a/justfile
+++ b/justfile
@@ -1307,6 +1307,11 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
         version_args+=(--version "${chart_version}")
     fi
 
+    image_tag="${tag}"
+    if [ -z "${image_tag}" ] && [ -n "${default_tag}" ]; then
+        image_tag="${default_tag}"
+    fi
+
     echo "app: ${release}"
     echo "env: ${SUGARKUBE_ENV:-unknown}"
     echo "image tag: ${image_tag:-<none>}"
@@ -1326,11 +1331,6 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
                 value_args+=(-f "${value_file}")
             fi
         done
-    fi
-
-    image_tag="${tag}"
-    if [ -z "${image_tag}" ] && [ -n "${default_tag}" ]; then
-        image_tag="${default_tag}"
     fi
 
     set_args=()

--- a/justfile
+++ b/justfile
@@ -1318,6 +1318,9 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     echo "chart ref: ${chart}"
     echo "chart version: ${chart_version:-<unversioned>}"
     echo "chart pin: ${version_file:-<inline version>}"
+    echo 'NOTE: chart pins are explicit. `tag=...` changes only the image tag.'
+    printf 'Run `just app-chart-status app=%s` before release deploys to check for newer published chart versions.\n' "${release}"
+    printf 'Use `just app-chart-bump app=%s version=<version>` to intentionally update %s.\n' "${release}" "${version_file:-docs/apps/${release}.version}"
     if [ -n "${chart_version}" ]; then
       helm show chart "${chart}" --version "${chart_version}" >/dev/null
     fi

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -103,48 +103,21 @@ def deployment_app_container_env_sets(
     """Return env var names for each candidate Deployment application container."""
     candidates = {app, release, *APP_CONTAINER_NAMES.get(app, set())}
     found: list[tuple[str, set[str]]] = []
-    for doc in re.split(r"(?m)^---\s*$", manifest):
-        if not re.search(r"(?m)^kind:\s*Deployment\s*$", doc):
-            continue
-        lines = doc.splitlines()
-        in_containers = False
-        containers_indent = -1
-        current_name = ""
-        current_envs: set[str] = set()
-        container_item_indent = -1
+
+    def scalar_value(value: str) -> str:
+        return value.split("#", 1)[0].strip().strip('"\'')
+
+    def parse_container_block(block: list[str]) -> tuple[str, set[str]]:
+        container_name = ""
+        envs: set[str] = set()
         in_env = False
         env_indent = -1
-
-        def flush_current() -> None:
-            if current_name in candidates:
-                found.append((current_name, set(current_envs)))
-
-        for line in lines:
+        for line in block:
             stripped = line.strip()
             indent = len(line) - len(line.lstrip(" "))
-            if not in_containers:
-                if stripped == "containers:":
-                    in_containers = True
-                    containers_indent = indent
-                continue
-            if indent <= containers_indent and stripped:
-                flush_current()
-                break
-            container_match = re.match(r"^\s*-\s*name:\s*([^#\s]+)", line)
-            if (
-                container_match
-                and indent > containers_indent
-                and (container_item_indent == -1 or indent == container_item_indent)
-            ):
-                if container_item_indent == -1:
-                    container_item_indent = indent
-                flush_current()
-                current_name = container_match.group(1).strip("\"'")
-                current_envs = set()
-                in_env = False
-                env_indent = -1
-                continue
-            if not current_name:
+            name_match = re.match(r"^\s*(?:-\s*)?name:\s*(.+)$", line)
+            if name_match and not in_env and not container_name:
+                container_name = scalar_value(name_match.group(1))
                 continue
             if stripped == "env:":
                 in_env = True
@@ -153,12 +126,49 @@ def deployment_app_container_env_sets(
             if in_env and indent <= env_indent and stripped:
                 in_env = False
             if in_env:
-                env_match = re.match(r"^\s*-\s*name:\s*([^#\s]+)", line)
+                env_match = re.match(r"^\s*-\s*name:\s*(.+)$", line)
                 if env_match:
-                    current_envs.add(env_match.group(1).strip("\"'"))
+                    envs.add(scalar_value(env_match.group(1)))
+        return container_name, envs
+
+    def flush_block(block: list[str]) -> None:
+        container_name, envs = parse_container_block(block)
+        if container_name in candidates:
+            found.append((container_name, envs))
+
+    for doc in re.split(r"(?m)^---\s*$", manifest):
+        if not re.search(r"(?m)^kind:\s*Deployment\s*$", doc):
+            continue
+        in_containers = False
+        containers_indent = -1
+        container_item_indent = -1
+        current_block: list[str] = []
+        for line in doc.splitlines():
+            stripped = line.strip()
+            indent = len(line) - len(line.lstrip(" "))
+            if not in_containers:
+                if stripped == "containers:":
+                    in_containers = True
+                    containers_indent = indent
+                continue
+            if indent <= containers_indent and stripped:
+                if current_block:
+                    flush_block(current_block)
+                break
+            item_match = re.match(r"^\s*-\s+", line)
+            if item_match and indent > containers_indent:
+                if container_item_indent == -1:
+                    container_item_indent = indent
+                if indent == container_item_indent:
+                    if current_block:
+                        flush_block(current_block)
+                    current_block = [line]
+                    continue
+            if current_block:
+                current_block.append(line)
         else:
-            if in_containers:
-                flush_current()
+            if current_block:
+                flush_block(current_block)
     return found
 
 

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -105,29 +105,36 @@ def deployment_app_container_env_sets(
     found: list[tuple[str, set[str]]] = []
 
     def scalar_value(value: str) -> str:
-        return value.split("#", 1)[0].strip().strip('"\'')
+        return value.split("#", 1)[0].strip().strip("\"'")
 
     def parse_container_block(block: list[str]) -> tuple[str, set[str]]:
         container_name = ""
         envs: set[str] = set()
         in_env = False
         env_indent = -1
+        item_indent = len(block[0]) - len(block[0].lstrip(" ")) if block else -1
+        field_indent = item_indent + 2
         for line in block:
             stripped = line.strip()
             indent = len(line) - len(line.lstrip(" "))
-            name_match = re.match(r"^\s*(?:-\s*)?name:\s*(.+)$", line)
-            if name_match and not in_env and not container_name:
-                container_name = scalar_value(name_match.group(1))
-                continue
-            if stripped == "env:":
+            if in_env and indent <= env_indent and stripped:
+                in_env = False
+            item_name_match = re.match(r"^\s*-\s*name:\s*(.+)$", line)
+            field_name_match = re.match(r"^\s*name:\s*(.+)$", line)
+            if not in_env and not container_name:
+                if item_name_match and indent == item_indent:
+                    container_name = scalar_value(item_name_match.group(1))
+                    continue
+                if field_name_match and indent == field_indent:
+                    container_name = scalar_value(field_name_match.group(1))
+                    continue
+            if stripped == "env:" and indent == field_indent:
                 in_env = True
                 env_indent = indent
                 continue
-            if in_env and indent <= env_indent and stripped:
-                in_env = False
             if in_env:
                 env_match = re.match(r"^\s*-\s*name:\s*(.+)$", line)
-                if env_match:
+                if env_match and indent > env_indent:
                     envs.add(scalar_value(env_match.group(1)))
         return container_name, envs
 

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -97,10 +97,12 @@ def is_prerelease(v: str) -> bool:
     return bool(m and m.group(4))
 
 
-def deployment_app_container_envs(manifest: str, app: str, release: str) -> set[str]:
-    """Return env var names rendered on the Deployment application container."""
+def deployment_app_container_env_sets(
+    manifest: str, app: str, release: str
+) -> list[tuple[str, set[str]]]:
+    """Return env var names for each candidate Deployment application container."""
     candidates = {app, release, *APP_CONTAINER_NAMES.get(app, set())}
-    found: set[str] = set()
+    found: list[tuple[str, set[str]]] = []
     for doc in re.split(r"(?m)^---\s*$", manifest):
         if not re.search(r"(?m)^kind:\s*Deployment\s*$", doc):
             continue
@@ -115,7 +117,7 @@ def deployment_app_container_envs(manifest: str, app: str, release: str) -> set[
 
         def flush_current() -> None:
             if current_name in candidates:
-                found.update(current_envs)
+                found.append((current_name, set(current_envs)))
 
         for line in lines:
             stripped = line.strip()
@@ -129,13 +131,15 @@ def deployment_app_container_envs(manifest: str, app: str, release: str) -> set[
                 flush_current()
                 break
             container_match = re.match(r"^\s*-\s*name:\s*([^#\s]+)", line)
-            if container_match and indent > containers_indent and (
-                container_item_indent == -1 or indent == container_item_indent
+            if (
+                container_match
+                and indent > containers_indent
+                and (container_item_indent == -1 or indent == container_item_indent)
             ):
                 if container_item_indent == -1:
                     container_item_indent = indent
                 flush_current()
-                current_name = container_match.group(1).strip('"\'')
+                current_name = container_match.group(1).strip("\"'")
                 current_envs = set()
                 in_env = False
                 env_indent = -1
@@ -151,11 +155,19 @@ def deployment_app_container_envs(manifest: str, app: str, release: str) -> set[
             if in_env:
                 env_match = re.match(r"^\s*-\s*name:\s*([^#\s]+)", line)
                 if env_match:
-                    current_envs.add(env_match.group(1).strip('"\''))
+                    current_envs.add(env_match.group(1).strip("\"'"))
         else:
             if in_containers:
                 flush_current()
     return found
+
+
+def deployment_app_container_envs(manifest: str, app: str, release: str) -> set[str]:
+    """Return the union of env var names rendered on candidate app containers."""
+    merged: set[str] = set()
+    for _container_name, envs in deployment_app_container_env_sets(manifest, app, release):
+        merged.update(envs)
+    return merged
 
 
 def latest_version(chart: str) -> tuple[str, str]:
@@ -280,12 +292,23 @@ def cmd_preflight(args: argparse.Namespace) -> int:
     if tmpl.returncode != 0:
         print(tmpl.stderr or tmpl.stdout, file=sys.stderr)
         return tmpl.returncode or 1
-    app_container_envs = deployment_app_container_envs(tmpl.stdout, args.app, args.release)
-    missing = [name for name in req if name not in app_container_envs]
-    if missing:
+    app_container_env_sets = deployment_app_container_env_sets(tmpl.stdout, args.app, args.release)
+    complete_envs = next(
+        (
+            envs
+            for _container_name, envs in app_container_env_sets
+            if all(name in envs for name in req)
+        ),
+        None,
+    )
+    merged_envs: set[str] = set()
+    for _container_name, envs in app_container_env_sets:
+        merged_envs.update(envs)
+    missing = [name for name in req if name not in (complete_envs or merged_envs)]
+    if complete_envs is None:
         print(
             "ERROR: rendered token.place manifest is missing required metadata env vars: "
-            + ", ".join(missing),
+            + ", ".join(missing or req),
             file=sys.stderr,
         )
         print(f"Pinned chart version: {version} ({args.version_file})", file=sys.stderr)

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -91,6 +91,72 @@ def ghcr_versions_from_api(owner: str, name: str, owner_type: str) -> tuple[list
     return versions, ""
 
 
+def is_prerelease(v: str) -> bool:
+    m = SEMVER_RE.match(v)
+    return bool(m and m.group(4))
+
+
+def deployment_app_container_envs(manifest: str, app: str, release: str) -> set[str]:
+    """Return env var names rendered on the Deployment application container."""
+    candidates = {app, release}
+    found: set[str] = set()
+    for doc in re.split(r"(?m)^---\s*$", manifest):
+        if not re.search(r"(?m)^kind:\s*Deployment\s*$", doc):
+            continue
+        lines = doc.splitlines()
+        in_containers = False
+        containers_indent = -1
+        current_name = ""
+        current_envs: set[str] = set()
+        container_item_indent = -1
+        in_env = False
+        env_indent = -1
+
+        def flush_current() -> None:
+            if current_name in candidates:
+                found.update(current_envs)
+
+        for line in lines:
+            stripped = line.strip()
+            indent = len(line) - len(line.lstrip(" "))
+            if not in_containers:
+                if stripped == "containers:":
+                    in_containers = True
+                    containers_indent = indent
+                continue
+            if indent <= containers_indent and stripped:
+                flush_current()
+                break
+            container_match = re.match(r"^\s*-\s*name:\s*([^#\s]+)", line)
+            if container_match and indent > containers_indent and (
+                container_item_indent == -1 or indent == container_item_indent
+            ):
+                if container_item_indent == -1:
+                    container_item_indent = indent
+                flush_current()
+                current_name = container_match.group(1).strip('"\'')
+                current_envs = set()
+                in_env = False
+                env_indent = -1
+                continue
+            if not current_name:
+                continue
+            if stripped == "env:":
+                in_env = True
+                env_indent = indent
+                continue
+            if in_env and indent <= env_indent and stripped:
+                in_env = False
+            if in_env:
+                env_match = re.match(r"^\s*-\s*name:\s*([^#\s]+)", line)
+                if env_match:
+                    current_envs.add(env_match.group(1).strip('"\''))
+        else:
+            if in_containers:
+                flush_current()
+    return found
+
+
 def latest_version(chart: str) -> tuple[str, str]:
     forced = os.environ.get("SUGARKUBE_APP_CHART_LATEST_STUB", "").strip()
     if forced:
@@ -106,10 +172,12 @@ def latest_version(chart: str) -> tuple[str, str]:
         versions.extend(found)
         if found:
             break
-    versions = sorted(set(versions), key=semver_key)
+    unique_versions = sorted(set(versions), key=semver_key)
+    stable_versions = [version for version in unique_versions if not is_prerelease(version)]
+    production_safe_versions = stable_versions or unique_versions
     return (
-        (versions[-1], "GitHub/GHCR API")
-        if versions
+        (production_safe_versions[-1], "GitHub/GHCR API")
+        if production_safe_versions
         else (
             "",
             f"latest unknown: no semver tags found; run: helm show chart {chart} --version <version>",
@@ -211,11 +279,8 @@ def cmd_preflight(args: argparse.Namespace) -> int:
     if tmpl.returncode != 0:
         print(tmpl.stderr or tmpl.stdout, file=sys.stderr)
         return tmpl.returncode or 1
-    missing = [
-        name
-        for name in req
-        if not re.search(rf"(?m)^\s*-\s*name:\s*{re.escape(name)}\s*$", tmpl.stdout)
-    ]
+    app_container_envs = deployment_app_container_envs(tmpl.stdout, args.app, args.release)
+    missing = [name for name in req if name not in app_container_envs]
     if missing:
         print(
             "ERROR: rendered token.place manifest is missing required metadata env vars: "

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -3,7 +3,12 @@
 
 from __future__ import annotations
 
-import argparse, json, os, re, subprocess, sys
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -15,11 +20,18 @@ REQUIRED_ENVS = {
         "TOKENPLACE_DEPLOY_ENV",
     ]
 }
-SEMVER_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$")
+SEMVER_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:-([^+]+))?(?:\+.*)?$")
+
+
+def version_file_path(path: str) -> Path:
+    if not path or not path.strip():
+        raise SystemExit("ERROR: --version-file must not be empty.")
+    p = Path(path)
+    return p if p.is_absolute() else REPO_ROOT / p
 
 
 def read_pin(path: str) -> str:
-    p = REPO_ROOT / path if not Path(path).is_absolute() else Path(path)
+    p = version_file_path(path)
     for line in p.read_text(encoding="utf-8").splitlines():
         value = line.split("#", 1)[0].strip()
         if value:
@@ -45,11 +57,38 @@ def parse_chart_yaml(text: str) -> dict[str, str]:
     return out
 
 
-def semver_key(v: str) -> tuple[int, int, int, str]:
+def semver_key(v: str) -> tuple[int, int, int, int, tuple[object, ...]]:
+    """Return a SemVer precedence key where prereleases sort below final releases."""
     m = SEMVER_RE.match(v)
     if not m:
-        return (-1, -1, -1, v)
-    return (int(m.group(1)), int(m.group(2)), int(m.group(3)), v)
+        return (-1, -1, -1, 0, (v,))
+    prerelease = m.group(4)
+    if not prerelease:
+        return (int(m.group(1)), int(m.group(2)), int(m.group(3)), 1, ())
+    parts: list[object] = []
+    for part in prerelease.split("."):
+        parts.append((0, int(part)) if part.isdigit() else (1, part))
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)), 0, tuple(parts))
+
+
+def ghcr_versions_from_api(owner: str, name: str, owner_type: str) -> tuple[list[str], str]:
+    url = (
+        f"https://api.github.com/{owner_type}/{owner}/packages/container/"
+        f"charts%2F{name}/versions?per_page=100"
+    )
+    curl = run(["curl", "-fsS", url])
+    if curl.returncode != 0:
+        return [], curl.stderr or curl.stdout
+    try:
+        payload = json.loads(curl.stdout)
+    except json.JSONDecodeError:
+        return [], "could not parse GitHub/GHCR API response"
+    versions: list[str] = []
+    for item in payload if isinstance(payload, list) else []:
+        meta = item.get("metadata", {}) if isinstance(item, dict) else {}
+        tags = meta.get("container", {}).get("tags", []) if isinstance(meta, dict) else []
+        versions.extend(t for t in tags if SEMVER_RE.match(str(t)))
+    return versions, ""
 
 
 def latest_version(chart: str) -> tuple[str, str]:
@@ -61,22 +100,12 @@ def latest_version(chart: str) -> tuple[str, str]:
     if not m:
         return "", "latest unknown: unsupported chart registry; inspect the chart registry manually"
     owner, name = m.groups()
-    url = f"https://api.github.com/orgs/{owner}/packages/container/charts%2F{name}/versions?per_page=100"
-    curl = run(["curl", "-fsS", url])
-    if curl.returncode != 0:
-        return (
-            "",
-            f"latest unknown: GitHub/GHCR API unavailable; open https://github.com/{owner}?tab=packages and inspect charts/{name}",
-        )
-    try:
-        payload = json.loads(curl.stdout)
-    except json.JSONDecodeError:
-        return "", "latest unknown: could not parse GitHub/GHCR API response"
     versions: list[str] = []
-    for item in payload if isinstance(payload, list) else []:
-        meta = item.get("metadata", {}) if isinstance(item, dict) else {}
-        tags = meta.get("container", {}).get("tags", []) if isinstance(meta, dict) else []
-        versions.extend(t for t in tags if SEMVER_RE.match(str(t)))
+    for owner_type in ("orgs", "users"):
+        found, error = ghcr_versions_from_api(owner, name, owner_type)
+        versions.extend(found)
+        if found:
+            break
     versions = sorted(set(versions), key=semver_key)
     return (
         (versions[-1], "GitHub/GHCR API")
@@ -129,7 +158,7 @@ def cmd_bump(args: argparse.Namespace) -> int:
     if show.returncode != 0:
         print(show.stderr or show.stdout, file=sys.stderr)
         return show.returncode or 1
-    path = REPO_ROOT / args.version_file
+    path = version_file_path(args.version_file)
     lines = path.read_text(encoding="utf-8").splitlines()
     replaced = False
     new = []
@@ -145,7 +174,7 @@ def cmd_bump(args: argparse.Namespace) -> int:
     if not replaced:
         new.append(args.version)
     path.write_text("\n".join(new) + "\n", encoding="utf-8")
-    subprocess.run(["git", "diff", "--", args.version_file], cwd=REPO_ROOT, check=False)
+    subprocess.run(["git", "diff", "--", str(path)], cwd=REPO_ROOT, check=False)
     print("Next steps:")
     print(f"git add {args.version_file}")
     print(f'git commit -m "Bump {args.app} chart pin to {args.version}"')
@@ -182,7 +211,11 @@ def cmd_preflight(args: argparse.Namespace) -> int:
     if tmpl.returncode != 0:
         print(tmpl.stderr or tmpl.stdout, file=sys.stderr)
         return tmpl.returncode or 1
-    missing = [name for name in req if name not in tmpl.stdout]
+    missing = [
+        name
+        for name in req
+        if not re.search(rf"(?m)^\s*-\s*name:\s*{re.escape(name)}\s*$", tmpl.stdout)
+    ]
     if missing:
         print(
             "ERROR: rendered token.place manifest is missing required metadata env vars: "

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Manage Sugarkube app Helm chart pins and deploy guardrails."""
+
+from __future__ import annotations
+
+import argparse, json, os, re, subprocess, sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REQUIRED_ENVS = {
+    "tokenplace": [
+        "TOKENPLACE_IMAGE_TAG",
+        "TOKENPLACE_RELEASE_VERSION",
+        "TOKENPLACE_CHART_VERSION",
+        "TOKENPLACE_DEPLOY_ENV",
+    ]
+}
+SEMVER_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$")
+
+
+def read_pin(path: str) -> str:
+    p = REPO_ROOT / path if not Path(path).is_absolute() else Path(path)
+    for line in p.read_text(encoding="utf-8").splitlines():
+        value = line.split("#", 1)[0].strip()
+        if value:
+            return value
+    raise SystemExit(f"ERROR: chart pin file {path} does not contain a version.")
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=REPO_ROOT, capture_output=True, text=True, check=False)
+
+
+def helm_show(chart: str, version: str) -> subprocess.CompletedProcess[str]:
+    return run(["helm", "show", "chart", chart, "--version", version])
+
+
+def parse_chart_yaml(text: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for line in text.splitlines():
+        if ":" not in line or line.startswith(" "):
+            continue
+        k, v = line.split(":", 1)
+        out[k.strip()] = v.strip().strip("\"'")
+    return out
+
+
+def semver_key(v: str) -> tuple[int, int, int, str]:
+    m = SEMVER_RE.match(v)
+    if not m:
+        return (-1, -1, -1, v)
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)), v)
+
+
+def latest_version(chart: str) -> tuple[str, str]:
+    forced = os.environ.get("SUGARKUBE_APP_CHART_LATEST_STUB", "").strip()
+    if forced:
+        return forced, "SUGARKUBE_APP_CHART_LATEST_STUB"
+    # Best-effort GHCR OCI discovery via GitHub API for oci://ghcr.io/owner/charts/name.
+    m = re.match(r"^oci://ghcr\.io/([^/]+)/charts/([^/]+)$", chart)
+    if not m:
+        return "", "latest unknown: unsupported chart registry; inspect the chart registry manually"
+    owner, name = m.groups()
+    url = f"https://api.github.com/orgs/{owner}/packages/container/charts%2F{name}/versions?per_page=100"
+    curl = run(["curl", "-fsS", url])
+    if curl.returncode != 0:
+        return (
+            "",
+            f"latest unknown: GitHub/GHCR API unavailable; open https://github.com/{owner}?tab=packages and inspect charts/{name}",
+        )
+    try:
+        payload = json.loads(curl.stdout)
+    except json.JSONDecodeError:
+        return "", "latest unknown: could not parse GitHub/GHCR API response"
+    versions: list[str] = []
+    for item in payload if isinstance(payload, list) else []:
+        meta = item.get("metadata", {}) if isinstance(item, dict) else {}
+        tags = meta.get("container", {}).get("tags", []) if isinstance(meta, dict) else []
+        versions.extend(t for t in tags if SEMVER_RE.match(str(t)))
+    versions = sorted(set(versions), key=semver_key)
+    return (
+        (versions[-1], "GitHub/GHCR API")
+        if versions
+        else (
+            "",
+            f"latest unknown: no semver tags found; run: helm show chart {chart} --version <version>",
+        )
+    )
+
+
+def print_summary(app: str, env: str, tag: str, chart: str, version: str, pin: str) -> None:
+    print(f"app: {app}")
+    print(f"env: {env}")
+    print(f"image tag: {tag}")
+    print(f"chart ref: {chart}")
+    print(f"chart version: {version}")
+    print(f"chart pin: {pin}")
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    version = read_pin(args.version_file)
+    show = helm_show(args.chart, version)
+    if show.returncode != 0:
+        print(show.stderr or show.stdout, file=sys.stderr)
+        return show.returncode or 1
+    meta = parse_chart_yaml(show.stdout)
+    print(f"app: {args.app}")
+    print(f"chart ref: {args.chart}")
+    print(f"pinned version: {version}")
+    print(f"chart appVersion: {meta.get('appVersion', 'unknown')}")
+    print(f"chart digest: {meta.get('digest', 'unknown')}")
+    print(f"pin file: {args.version_file}")
+    latest, source = latest_version(args.chart)
+    if latest:
+        print(f"latest version: {latest} ({source})")
+        if semver_key(version) < semver_key(latest):
+            print(f"WARNING: Pinned chart appears stale: {version} < {latest}")
+            print(f"Run: just app-chart-bump app={args.app} version={latest}")
+    else:
+        print(source)
+    return 0
+
+
+def cmd_bump(args: argparse.Namespace) -> int:
+    if not args.version.strip():
+        print("ERROR: version must not be empty.", file=sys.stderr)
+        return 2
+    show = helm_show(args.chart, args.version)
+    if show.returncode != 0:
+        print(show.stderr or show.stdout, file=sys.stderr)
+        return show.returncode or 1
+    path = REPO_ROOT / args.version_file
+    lines = path.read_text(encoding="utf-8").splitlines()
+    replaced = False
+    new = []
+    for line in lines:
+        if not replaced and line.split("#", 1)[0].strip():
+            suffix = ""
+            if "#" in line:
+                suffix = "  #" + line.split("#", 1)[1]
+            new.append(args.version + suffix)
+            replaced = True
+        else:
+            new.append(line)
+    if not replaced:
+        new.append(args.version)
+    path.write_text("\n".join(new) + "\n", encoding="utf-8")
+    subprocess.run(["git", "diff", "--", args.version_file], cwd=REPO_ROOT, check=False)
+    print("Next steps:")
+    print(f"git add {args.version_file}")
+    print(f'git commit -m "Bump {args.app} chart pin to {args.version}"')
+    print("git push")
+    print(f"just app-deploy app={args.app} env=staging tag=<APP_TAG>")
+    return 0
+
+
+def cmd_preflight(args: argparse.Namespace) -> int:
+    version = args.version or read_pin(args.version_file)
+    print_summary(args.app, args.env, args.tag, args.chart, version, args.version_file)
+    show = helm_show(args.chart, version)
+    if show.returncode != 0:
+        print(show.stderr or show.stdout, file=sys.stderr)
+        return show.returncode or 1
+    req = REQUIRED_ENVS.get(args.app, [])
+    if not req:
+        return 0
+    cmd = [
+        "helm",
+        "template",
+        args.release,
+        args.chart,
+        "--namespace",
+        args.namespace,
+        "--version",
+        version,
+    ]
+    for vf in filter(None, (v.strip() for v in args.values.split(","))):
+        cmd += ["-f", vf]
+    if args.tag:
+        cmd += ["--set", f"image.tag={args.tag}", "--set", "image.pullPolicy=Always"]
+    tmpl = run(cmd)
+    if tmpl.returncode != 0:
+        print(tmpl.stderr or tmpl.stdout, file=sys.stderr)
+        return tmpl.returncode or 1
+    missing = [name for name in req if name not in tmpl.stdout]
+    if missing:
+        print(
+            "ERROR: rendered token.place manifest is missing required metadata env vars: "
+            + ", ".join(missing),
+            file=sys.stderr,
+        )
+        print(f"Pinned chart version: {version} ({args.version_file})", file=sys.stderr)
+        print(f"Run: just app-chart-status app={args.app}", file=sys.stderr)
+        print(
+            f"Run: just app-chart-bump app={args.app} version=<published-version>", file=sys.stderr
+        )
+        return 1
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    sub = p.add_subparsers(dest="cmd", required=True)
+    for name in ("status", "bump", "preflight"):
+        s = sub.add_parser(name)
+        s.add_argument("--app", required=True)
+        s.add_argument("--chart", required=True)
+        s.add_argument("--version-file", required=True)
+        if name == "bump":
+            s.add_argument("--version", required=True)
+        if name == "preflight":
+            s.add_argument("--env", required=True)
+            s.add_argument("--tag", required=True)
+            s.add_argument("--values", required=True)
+            s.add_argument("--release", required=True)
+            s.add_argument("--namespace", required=True)
+            s.add_argument("--version", default="")
+    a = p.parse_args()
+    return {"status": cmd_status, "bump": cmd_bump, "preflight": cmd_preflight}[a.cmd](a)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -12,6 +12,7 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_CONTAINER_NAMES = {"tokenplace": {"tokenplace", "relay"}}
 REQUIRED_ENVS = {
     "tokenplace": [
         "TOKENPLACE_IMAGE_TAG",
@@ -98,7 +99,7 @@ def is_prerelease(v: str) -> bool:
 
 def deployment_app_container_envs(manifest: str, app: str, release: str) -> set[str]:
     """Return env var names rendered on the Deployment application container."""
-    candidates = {app, release}
+    candidates = {app, release, *APP_CONTAINER_NAMES.get(app, set())}
     found: set[str] = set()
     for doc in re.split(r"(?m)^---\s*$", manifest):
         if not re.search(r"(?m)^kind:\s*Deployment\s*$", doc):

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -119,6 +119,8 @@ def deployment_app_container_env_sets(
             indent = len(line) - len(line.lstrip(" "))
             if in_env and indent <= env_indent and stripped:
                 in_env = False
+            if in_env and indent == field_indent and re.match(r"^[A-Za-z0-9_.-]+:\s*", stripped):
+                in_env = False
             item_name_match = re.match(r"^\s*-\s*name:\s*(.+)$", line)
             field_name_match = re.match(r"^\s*name:\s*(.+)$", line)
             if not in_env and not container_name:
@@ -128,7 +130,9 @@ def deployment_app_container_env_sets(
                 if field_name_match and indent == field_indent:
                     container_name = scalar_value(field_name_match.group(1))
                     continue
-            if stripped == "env:" and indent == field_indent:
+            if (stripped == "env:" and indent == field_indent) or (
+                stripped == "- env:" and indent == item_indent
+            ):
                 in_env = True
                 env_indent = indent
                 continue

--- a/scripts/app_verify.py
+++ b/scripts/app_verify.py
@@ -182,9 +182,15 @@ def tokenplace_meta_failure(env: str, raw: bytes) -> str:
     try:
         data = json.loads(raw.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError):
-        return ""
-    label = str(data.get("label", ""))
-    version = str(data.get("version", ""))
+        return "token.place metadata endpoint must return valid JSON."
+    if not isinstance(data, dict):
+        return "token.place metadata endpoint must return a JSON object."
+    label = data.get("label")
+    version = data.get("version")
+    if not isinstance(label, str) or not label.strip():
+        return "token.place metadata endpoint must include a non-empty label."
+    if not isinstance(version, str) or not version.strip():
+        return "token.place metadata endpoint must include a non-empty version."
     if version == "dev" or label.endswith(" dev"):
         if env == "prod":
             return "token.place prod metadata must not report version=dev."

--- a/scripts/app_verify.py
+++ b/scripts/app_verify.py
@@ -178,6 +178,20 @@ def run_curl(url: str) -> tuple[int, str, bytes, str]:
         body_path.unlink(missing_ok=True)
 
 
+def tokenplace_meta_failure(env: str, raw: bytes) -> str:
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return ""
+    label = str(data.get("label", ""))
+    version = str(data.get("version", ""))
+    if version == "dev" or label.endswith(" dev"):
+        if env == "prod":
+            return "token.place prod metadata must not report version=dev."
+        return "token.place staging metadata must include the immutable image tag, not a dev label/version."
+    return ""
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--print-only", action="store_true")
@@ -223,11 +237,19 @@ def main(argv: list[str] | None = None) -> int:
         http_suffix = (
             f" (HTTP {http_status})" if http_status.isdigit() and http_status != "000" else ""
         )
+        meta_error = ""
+        if curl_rc == 0 and app == "tokenplace" and path == "/api/v1/meta":
+            meta_error = tokenplace_meta_failure(env, body)
+            if meta_error:
+                curl_rc = 1
+
         if curl_rc == 0:
             print(f"  Status: OK{http_suffix}")
             passed += 1
         else:
             print(f"  Status: FAILED{http_suffix}")
+            if meta_error:
+                print(f"  metadata error: {meta_error}")
             print(f"  curl exit status: {curl_rc}")
             if curl_stderr:
                 print("  curl stderr:")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from scripts import app_chart
+from scripts import app_verify
 from scripts.app_verify import base_url_from_host, tokenplace_meta_failure
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -488,6 +489,267 @@ def test_app_chart_cmd_preflight_reports_template_failure(
 
     assert app_chart.cmd_preflight(args) == 2
     assert "render failed" in capsys.readouterr().err
+
+
+def test_app_chart_cmd_preflight_reports_helm_show_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = argparse.Namespace(
+        app="tokenplace",
+        env="staging",
+        tag="main-deadbee",
+        chart="oci://ghcr.io/futuroptimist/charts/tokenplace",
+        version_file="docs/apps/tokenplace.version",
+        version="0.1.3",
+        release="tokenplace",
+        namespace="tokenplace",
+        values="",
+    )
+    monkeypatch.setattr(
+        app_chart,
+        "helm_show",
+        lambda chart, version: subprocess.CompletedProcess([], 3, "", "chart missing"),
+    )
+
+    assert app_chart.cmd_preflight(args) == 3
+    assert "chart missing" in capsys.readouterr().err
+
+
+def test_app_chart_cmd_preflight_reports_missing_app_container_envs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = argparse.Namespace(
+        app="tokenplace",
+        env="staging",
+        tag="main-deadbee",
+        chart="oci://ghcr.io/futuroptimist/charts/tokenplace",
+        version_file="docs/apps/tokenplace.version",
+        version="0.1.3",
+        release="tokenplace",
+        namespace="tokenplace",
+        values="values-a.yaml, values-b.yaml",
+    )
+    monkeypatch.setattr(
+        app_chart,
+        "helm_show",
+        lambda chart, version: subprocess.CompletedProcess([], 0, "apiVersion: v2\n", ""),
+    )
+    monkeypatch.setattr(
+        app_chart,
+        "run",
+        lambda cmd: subprocess.CompletedProcess(
+            cmd,
+            0,
+            "apiVersion: apps/v1\nkind: Deployment\nspec:\n  template:\n    spec:\n      containers:\n        - name: relay\n          env:\n            - name: TOKENPLACE_IMAGE_TAG\n",
+            "",
+        ),
+    )
+
+    assert app_chart.cmd_preflight(args) == 1
+    err = capsys.readouterr().err
+    assert "missing required metadata env vars" in err
+    assert "TOKENPLACE_RELEASE_VERSION" in err
+    assert "just app-chart-bump app=tokenplace" in err
+
+
+def test_app_chart_cmd_preflight_passes_when_relay_envs_present(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = argparse.Namespace(
+        app="tokenplace",
+        env="staging",
+        tag="main-deadbee",
+        chart="oci://ghcr.io/futuroptimist/charts/tokenplace",
+        version_file="docs/apps/tokenplace.version",
+        version="0.1.3",
+        release="tokenplace",
+        namespace="tokenplace",
+        values="",
+    )
+    monkeypatch.setattr(
+        app_chart,
+        "helm_show",
+        lambda chart, version: subprocess.CompletedProcess([], 0, "apiVersion: v2\n", ""),
+    )
+    monkeypatch.setattr(
+        app_chart,
+        "run",
+        lambda cmd: subprocess.CompletedProcess(
+            cmd,
+            0,
+            "apiVersion: apps/v1\nkind: Deployment\nspec:\n  template:\n    spec:\n      containers:\n        - name: relay\n          env:\n            - name: TOKENPLACE_IMAGE_TAG\n            - name: TOKENPLACE_RELEASE_VERSION\n            - name: TOKENPLACE_CHART_VERSION\n            - name: TOKENPLACE_DEPLOY_ENV\n",
+            "",
+        ),
+    )
+
+    assert app_chart.cmd_preflight(args) == 0
+    assert "chart version: 0.1.3" in capsys.readouterr().out
+
+
+def test_app_chart_cmd_bump_reports_empty_version_and_show_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = argparse.Namespace(
+        app="tokenplace",
+        chart="oci://ghcr.io/futuroptimist/charts/tokenplace",
+        version_file="docs/apps/tokenplace.version",
+        version=" ",
+    )
+    assert app_chart.cmd_bump(args) == 2
+    assert "version must not be empty" in capsys.readouterr().err
+
+    args.version = "0.2.0"
+    monkeypatch.setattr(
+        app_chart,
+        "helm_show",
+        lambda chart, version: subprocess.CompletedProcess([], 4, "", "no such chart"),
+    )
+    assert app_chart.cmd_bump(args) == 4
+    assert "no such chart" in capsys.readouterr().err
+
+
+def test_app_chart_main_dispatches_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, str] = {}
+
+    def fake_status(args: argparse.Namespace) -> int:
+        seen["app"] = args.app
+        return 7
+
+    monkeypatch.setattr(app_chart, "cmd_status", fake_status)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "app_chart.py",
+            "status",
+            "--app",
+            "tokenplace",
+            "--chart",
+            "oci://example",
+            "--version-file",
+            "docs/apps/tokenplace.version",
+        ],
+    )
+
+    assert app_chart.main() == 7
+    assert seen == {"app": "tokenplace"}
+
+
+def test_app_verify_helpers_cover_edge_cases(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert app_verify.env_flag("MISSING_FLAG", default=True) is True
+    monkeypatch.setenv("BOOL_FLAG", "off")
+    assert app_verify.env_flag("BOOL_FLAG", default=True) is False
+    assert app_verify.normalize_path(" livez ") == "/livez"
+    assert app_verify.normalize_path("   ") == "/"
+    assert app_verify.host_from_values("not json", "ingress.host") == ""
+    assert app_verify.host_from_values('{"ingress":"bad"}', "ingress.host") == ""
+    assert (
+        app_verify.host_from_values('{"ingress":{"host":"example.test"}}', "ingress.host")
+        == "example.test"
+    )
+    assert app_verify.base_url_from_host("") == ""
+    assert app_verify.preview_text(b"one\ntwo\nthree", 7, 1) == (["one"], True)
+    monkeypatch.setenv("INT_FLAG", "not-int")
+    assert app_verify.int_env("INT_FLAG", 12) == 12
+    monkeypatch.setenv("INT_FLAG", "-5")
+    assert app_verify.int_env("INT_FLAG", 12) == 0
+
+
+def test_app_verify_discover_host_uses_kubectl_after_helm_without_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SUGARKUBE_RELEASE", "tokenplace")
+    monkeypatch.setenv("SUGARKUBE_NAMESPACE", "tokenplace")
+    monkeypatch.setattr(app_verify, "shutil_which", lambda name: f"/bin/{name}")
+
+    def fake_run_capture(args: list[str]) -> subprocess.CompletedProcess[str]:
+        if args[0] == "helm":
+            return subprocess.CompletedProcess(args, 0, '{"ingress":{}}', "")
+        return subprocess.CompletedProcess(args, 0, "kubectl.example.test", "")
+
+    monkeypatch.setattr(app_verify, "run_capture", fake_run_capture)
+
+    assert app_verify.discover_host("sugar-staging") == ("kubectl.example.test", [])
+
+
+def test_app_verify_run_curl_captures_body_and_stderr(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fake_run(
+        args: list[str], capture_output: bool, text: bool, check: bool
+    ) -> subprocess.CompletedProcess[str]:
+        body_path = Path(args[args.index("-o") + 1])
+        body_path.write_text("payload", encoding="utf-8")
+        return subprocess.CompletedProcess(args, 22, "503", "curl failed")
+
+    monkeypatch.setattr(app_verify.subprocess, "run", fake_run)
+
+    assert app_verify.run_curl("https://example.test/") == (22, "503", b"payload", "curl failed")
+
+
+def test_app_verify_main_print_only_and_placeholder_paths(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("SUGARKUBE_APP", "tokenplace")
+    monkeypatch.setenv("SUGARKUBE_ENV", "staging")
+    monkeypatch.setenv("SUGARKUBE_VERIFY_PATHS", " , livez")
+    monkeypatch.setattr(app_verify, "discover_host", lambda context: ("", ["no ingress"]))
+
+    assert app_verify.main(["--print-only"]) == 0
+    captured = capsys.readouterr()
+    assert "Could not derive a host for tokenplace" in captured.err
+    assert "curl -fsS https://<host>/livez" in captured.out
+
+    monkeypatch.setattr(app_verify, "discover_host", lambda context: ("example.test", []))
+    assert app_verify.main(["--print-only"]) == 0
+    assert "curl -fsS https://example.test/livez" in capsys.readouterr().out
+
+
+def test_app_verify_main_reports_meta_and_http_failures(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("SUGARKUBE_APP", "tokenplace")
+    monkeypatch.setenv("SUGARKUBE_ENV", "staging")
+    monkeypatch.setenv("SUGARKUBE_VERIFY_PATHS", "/api/v1/meta,/down,/empty")
+    monkeypatch.setenv("SUGARKUBE_APP_VERIFY_BODY_PREVIEW_BYTES", "12")
+    monkeypatch.setenv("SUGARKUBE_APP_VERIFY_BODY_PREVIEW_LINES", "1")
+    monkeypatch.setattr(app_verify, "discover_host", lambda context: ("example.test", []))
+
+    def fake_run_curl(url: str) -> tuple[int, str, bytes, str]:
+        if url.endswith("/api/v1/meta"):
+            return 0, "200", b"{}", ""
+        if url.endswith("/down"):
+            return 0, "503", b"line1\nline2", "server said no"
+        return 0, "200", b"", ""
+
+    monkeypatch.setattr(app_verify, "run_curl", fake_run_curl)
+
+    assert app_verify.main([]) == 1
+    captured = capsys.readouterr()
+    assert (
+        "metadata error: token.place metadata endpoint must include a non-empty label"
+        in captured.out
+    )
+    assert "Status: FAILED (HTTP 503)" in captured.out
+    assert "Body preview:" in captured.out
+    assert "Body: <empty>" in captured.out
+    assert "Verification failed: 2/3 checks failed." in captured.err
+
+
+def test_app_verify_main_success_without_body(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("SUGARKUBE_APP", "danielsmith")
+    monkeypatch.setenv("SUGARKUBE_ENV", "staging")
+    monkeypatch.setenv("SUGARKUBE_VERIFY_PATHS", "/")
+    monkeypatch.setenv("SUGARKUBE_APP_VERIFY_SHOW_BODY", "false")
+    monkeypatch.setattr(app_verify, "discover_host", lambda context: ("https://example.test", []))
+    monkeypatch.setattr(app_verify, "run_curl", lambda url: (0, "200", b"ok", ""))
+
+    assert app_verify.main([]) == 0
+    out = capsys.readouterr().out
+    assert "Status: OK (HTTP 200)" in out
+    assert "Body:" not in out
+    assert "Verification passed: 1/1 checks succeeded." in out
 
 
 def test_chart_recipes_are_listed(generic_app_stub_env: dict[str, str]) -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -233,6 +233,12 @@ def _run_just(args: list[str], env: dict[str, str]) -> subprocess.CompletedProce
     )
 
 
+def _assert_chart_pin_reminder(output: str, app: str) -> None:
+    assert "NOTE: chart pins are explicit. `tag=...` changes only the image tag." in output
+    assert f"Run `just app-chart-status app={app}`" in output
+    assert f"Use `just app-chart-bump app={app} version=<version>`" in output
+
+
 def test_app_chart_semver_prefers_final_release_over_matching_prerelease() -> None:
     assert sorted(["1.2.3", "1.2.3-rc.1"], key=app_chart.semver_key)[-1] == "1.2.3"
 
@@ -480,12 +486,45 @@ def test_app_deploy_fails_tokenplace_when_metadata_names_only_in_comments(
 def test_app_deploy_passes_tokenplace_when_manifest_metadata_env_present(
     generic_app_stub_env: dict[str, str],
 ) -> None:
+    pin_path = REPO_ROOT / "docs/apps/tokenplace.version"
+    before_pin = pin_path.read_text(encoding="utf-8")
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_APP_CHART_LATEST_STUB"] = "9.9.9"
+
     result = _run_just(
-        ["app-deploy", "app=tokenplace", "env=staging", "tag=main-deadbee"], generic_app_stub_env
+        ["app-deploy", "app=tokenplace", "env=staging", "tag=main-deadbee"], env
     )
 
     assert result.returncode == 0, result.stderr + result.stdout
     assert "chart pin: docs/apps/tokenplace.version" in result.stdout
+    _assert_chart_pin_reminder(result.stdout, "tokenplace")
+    assert "9.9.9" not in result.stdout
+    assert pin_path.read_text(encoding="utf-8") == before_pin
+    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "--version 0.1.3" in helm_log
+    assert "--version 9.9.9" not in helm_log
+
+
+def test_app_redeploy_prints_chart_pin_reminder_without_latest_lookup_or_pin_mutation(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    pin_path = REPO_ROOT / "docs/apps/tokenplace.version"
+    before_pin = pin_path.read_text(encoding="utf-8")
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_APP_CHART_LATEST_STUB"] = "9.9.9"
+
+    result = _run_just(
+        ["app-redeploy", "app=tokenplace", "env=staging", "tag=main-deadbee"], env
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    _assert_chart_pin_reminder(result.stdout, "tokenplace")
+    assert "9.9.9" not in result.stdout
+    assert pin_path.read_text(encoding="utf-8") == before_pin
+    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "upgrade tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace" in helm_log
+    assert "--version 0.1.3" in helm_log
+    assert "--version 9.9.9" not in helm_log
 
 
 @pytest.mark.usefixtures("ensure_just_available")
@@ -566,6 +605,9 @@ def test_existing_app_specific_deploy_wrappers_still_work(
     helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
     assert f"--namespace {app}" in helm_log
     assert "--set image.tag=main-deadbee" in helm_log
+    if recipe == "tokenplace-oci-deploy":
+        _assert_chart_pin_reminder(result.stdout, "tokenplace")
+        assert result.stdout.count("NOTE: chart pins are explicit") == 1
 
 
 @pytest.mark.usefixtures("ensure_just_available")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -103,11 +103,53 @@ if [[ "$*" == show\ chart* ]]; then
 fi
 if [[ "$*" == template* ]]; then
   if [ "${{SUGARKUBE_STUB_HELM_TEMPLATE_MISSING_META:-}}" = "1" ]; then
-    printf 'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: tokenplace\n'
+    printf 'apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tokenplace
+'
   elif [ "${{SUGARKUBE_STUB_HELM_TEMPLATE_COMMENT_META:-}}" = "1" ]; then
-    printf '# TOKENPLACE_IMAGE_TAG TOKENPLACE_RELEASE_VERSION TOKENPLACE_CHART_VERSION TOKENPLACE_DEPLOY_ENV\nkind: ConfigMap\ndata:\n  TOKENPLACE_IMAGE_TAG: main-deadbee\n'
+    printf '# TOKENPLACE_IMAGE_TAG TOKENPLACE_RELEASE_VERSION TOKENPLACE_CHART_VERSION TOKENPLACE_DEPLOY_ENV
+kind: ConfigMap
+data:
+  TOKENPLACE_IMAGE_TAG: main-deadbee
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tokenplace
+spec:
+  template:
+    spec:
+      containers:
+        - name: tokenplace
+          image: ghcr.io/example/tokenplace:main-deadbee
+        - name: metrics-sidecar
+          env:
+            - name: TOKENPLACE_IMAGE_TAG
+            - name: TOKENPLACE_RELEASE_VERSION
+            - name: TOKENPLACE_CHART_VERSION
+            - name: TOKENPLACE_DEPLOY_ENV
+'
   else
-    printf 'env:\n- name: TOKENPLACE_IMAGE_TAG\n- name: TOKENPLACE_RELEASE_VERSION\n- name: TOKENPLACE_CHART_VERSION\n- name: TOKENPLACE_DEPLOY_ENV\n'
+    printf 'apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tokenplace
+spec:
+  template:
+    spec:
+      containers:
+        - name: tokenplace
+          env:
+            - name: TOKENPLACE_IMAGE_TAG
+            - name: TOKENPLACE_RELEASE_VERSION
+            - name: TOKENPLACE_CHART_VERSION
+            - name: TOKENPLACE_DEPLOY_ENV
+        - name: metrics-sidecar
+          env:
+            - name: SIDECAR_ONLY
+'
   fi
   exit 0
 fi
@@ -191,11 +233,28 @@ def _run_just(args: list[str], env: dict[str, str]) -> subprocess.CompletedProce
     )
 
 
-def test_app_chart_semver_prefers_final_release_over_prerelease() -> None:
-    versions = ["1.2.3-rc.1", "1.2.3", "1.2.4-alpha.1"]
-
-    assert sorted(versions, key=app_chart.semver_key)[-1] == "1.2.4-alpha.1"
+def test_app_chart_semver_prefers_final_release_over_matching_prerelease() -> None:
     assert sorted(["1.2.3", "1.2.3-rc.1"], key=app_chart.semver_key)[-1] == "1.2.3"
+
+
+def test_app_chart_latest_version_prefers_production_safe_stable_over_prerelease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(args: list[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            '[{"metadata":{"container":{"tags":["1.0.0","1.0.1-alpha"]}}}]',
+            "",
+        )
+
+    monkeypatch.delenv("SUGARKUBE_APP_CHART_LATEST_STUB", raising=False)
+    monkeypatch.setattr(app_chart, "run", fake_run)
+
+    latest, source = app_chart.latest_version("oci://ghcr.io/futuroptimist/charts/tokenplace")
+
+    assert latest == "1.0.0"
+    assert source == "GitHub/GHCR API"
 
 
 def test_app_chart_read_pin_rejects_empty_version_file_path() -> None:
@@ -203,10 +262,27 @@ def test_app_chart_read_pin_rejects_empty_version_file_path() -> None:
         app_chart.read_pin("")
 
 
-def test_tokenplace_meta_failure_rejects_invalid_or_missing_metadata() -> None:
-    assert "valid JSON" in tokenplace_meta_failure("staging", b"<html>ok</html>")
-    assert "non-empty label" in tokenplace_meta_failure("staging", b"{}")
-    assert "non-empty version" in tokenplace_meta_failure("staging", b'{"label":"main-deadbee"}')
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        (b"{}", "non-empty label"),
+        (b"<html>ok</html>", "valid JSON"),
+        (b'{"version":"dev"}', "non-empty label"),
+        (b'{"label":"staging dev"}', "non-empty version"),
+        (
+            b'{"label":"staging main-deadbee","version":"dev"}',
+            "staging metadata must include the immutable image tag",
+        ),
+        (
+            b'{"label":"staging dev","version":"main-deadbee"}',
+            "staging metadata must include the immutable image tag",
+        ),
+    ],
+)
+def test_tokenplace_meta_failure_rejects_invalid_or_missing_metadata(
+    body: bytes, expected: str
+) -> None:
+    assert expected in tokenplace_meta_failure("staging", body)
 
 
 def test_chart_recipes_are_listed(generic_app_stub_env: dict[str, str]) -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -140,7 +140,7 @@ spec:
   template:
     spec:
       containers:
-        - name: tokenplace
+        - name: relay
           env:
             - name: TOKENPLACE_IMAGE_TAG
             - name: TOKENPLACE_RELEASE_VERSION

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -631,6 +631,41 @@ spec:
     ]
 
 
+def test_deployment_app_container_env_sets_ignores_nested_names_before_container_name() -> None:
+    manifest = """apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - image: ghcr.io/example/tokenplace:main-deadbee
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: TOKENPLACE_IMAGE_TAG
+            - name: TOKENPLACE_RELEASE_VERSION
+            - name: TOKENPLACE_CHART_VERSION
+            - name: TOKENPLACE_DEPLOY_ENV
+          name: relay
+"""
+
+    assert app_chart.deployment_app_container_env_sets(manifest, "tokenplace", "tokenplace") == [
+        (
+            "relay",
+            {
+                "TOKENPLACE_IMAGE_TAG",
+                "TOKENPLACE_RELEASE_VERSION",
+                "TOKENPLACE_CHART_VERSION",
+                "TOKENPLACE_DEPLOY_ENV",
+            },
+        )
+    ]
+
+
 def test_app_chart_cmd_preflight_passes_when_relay_envs_present(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import os
 import subprocess
 from pathlib import Path
@@ -291,6 +292,204 @@ def test_tokenplace_meta_failure_rejects_invalid_or_missing_metadata(
     assert expected in tokenplace_meta_failure("staging", body)
 
 
+def test_app_chart_parse_chart_yaml_strips_quotes_and_ignores_nested_lines() -> None:
+    assert app_chart.parse_chart_yaml(
+        "apiVersion: v2\nname: \"tokenplace\"\n  nested: ignored\ndigest: 'sha256:abc'\n"
+    ) == {
+        "apiVersion": "v2",
+        "name": "tokenplace",
+        "digest": "sha256:abc",
+    }
+
+
+def test_app_chart_latest_version_reports_unsupported_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SUGARKUBE_APP_CHART_LATEST_STUB", raising=False)
+
+    latest, source = app_chart.latest_version("https://charts.example.test/tokenplace")
+
+    assert latest == ""
+    assert "unsupported chart registry" in source
+
+
+def test_app_chart_latest_version_handles_bad_api_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(args: list[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args, 0, "not json", "")
+
+    monkeypatch.delenv("SUGARKUBE_APP_CHART_LATEST_STUB", raising=False)
+    monkeypatch.setattr(app_chart, "run", fake_run)
+
+    latest, source = app_chart.latest_version("oci://ghcr.io/futuroptimist/charts/tokenplace")
+
+    assert latest == ""
+    assert "no semver tags found" in source
+
+
+def test_app_chart_latest_version_uses_stub_without_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SUGARKUBE_APP_CHART_LATEST_STUB", "2.0.0")
+
+    latest, source = app_chart.latest_version("oci://ghcr.io/futuroptimist/charts/tokenplace")
+
+    assert latest == "2.0.0"
+    assert source == "SUGARKUBE_APP_CHART_LATEST_STUB"
+
+
+def test_app_chart_deployment_env_parser_accepts_quoted_release_container() -> None:
+    manifest = """apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: custom-release
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: tokenplace
+          env:
+            - name: INIT_ONLY
+      containers:
+        - name: "custom-release"
+          env:
+            - name: "TOKENPLACE_IMAGE_TAG"
+            - name: 'TOKENPLACE_RELEASE_VERSION'
+        - name: metrics-sidecar
+          env:
+            - name: TOKENPLACE_CHART_VERSION
+"""
+
+    envs = app_chart.deployment_app_container_envs(manifest, "tokenplace", "custom-release")
+
+    assert envs == {"TOKENPLACE_IMAGE_TAG", "TOKENPLACE_RELEASE_VERSION"}
+
+
+def test_app_chart_cmd_status_reports_helm_show_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = argparse.Namespace(
+        app="tokenplace",
+        chart="oci://ghcr.io/futuroptimist/charts/tokenplace",
+        version_file="docs/apps/tokenplace.version",
+    )
+    monkeypatch.setattr(app_chart, "read_pin", lambda path: "0.1.3")
+    monkeypatch.setattr(
+        app_chart,
+        "helm_show",
+        lambda chart, version: subprocess.CompletedProcess([], 1, "", "missing chart"),
+    )
+
+    assert app_chart.cmd_status(args) == 1
+    assert "missing chart" in capsys.readouterr().err
+
+
+def test_app_chart_cmd_status_prints_metadata_without_stale_warning(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = argparse.Namespace(
+        app="tokenplace",
+        chart="oci://ghcr.io/futuroptimist/charts/tokenplace",
+        version_file="docs/apps/tokenplace.version",
+    )
+    monkeypatch.setattr(app_chart, "read_pin", lambda path: "0.1.3")
+    monkeypatch.setattr(
+        app_chart,
+        "helm_show",
+        lambda chart, version: subprocess.CompletedProcess(
+            [], 0, "apiVersion: v2\nappVersion: main-deadbee\ndigest: sha256:abc\n", ""
+        ),
+    )
+    monkeypatch.setattr(app_chart, "latest_version", lambda chart: ("0.1.3", "test"))
+
+    assert app_chart.cmd_status(args) == 0
+    out = capsys.readouterr().out
+    assert "chart appVersion: main-deadbee" in out
+    assert "latest version: 0.1.3 (test)" in out
+    assert "Pinned chart appears stale" not in out
+
+
+def test_app_chart_cmd_bump_adds_pin_when_file_has_only_comments(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pin = tmp_path / "empty.version"
+    pin.write_text("# comment only\n", encoding="utf-8")
+    args = argparse.Namespace(
+        app="tokenplace",
+        chart="oci://ghcr.io/futuroptimist/charts/tokenplace",
+        version_file=str(pin),
+        version="0.2.0",
+    )
+    monkeypatch.setattr(
+        app_chart,
+        "helm_show",
+        lambda chart, version: subprocess.CompletedProcess([], 0, "apiVersion: v2\n", ""),
+    )
+
+    assert app_chart.cmd_bump(args) == 0
+    assert pin.read_text(encoding="utf-8") == "# comment only\n0.2.0\n"
+    assert "just app-deploy app=tokenplace env=staging tag=<APP_TAG>" in capsys.readouterr().out
+
+
+def test_app_chart_cmd_preflight_skips_manifest_render_for_apps_without_required_envs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = argparse.Namespace(
+        app="danielsmith",
+        env="staging",
+        tag="main-deadbee",
+        chart="oci://ghcr.io/futuroptimist/charts/danielsmith",
+        version_file="docs/apps/danielsmith.version",
+        version="1.0.0",
+        release="danielsmith",
+        namespace="danielsmith",
+        values="",
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(
+        app_chart,
+        "helm_show",
+        lambda chart, version: subprocess.CompletedProcess([], 0, "apiVersion: v2\n", ""),
+    )
+    monkeypatch.setattr(
+        app_chart,
+        "run",
+        lambda cmd: calls.append(cmd[0]) or subprocess.CompletedProcess(cmd, 0, "", ""),
+    )
+
+    assert app_chart.cmd_preflight(args) == 0
+    assert calls == []
+    assert "app: danielsmith" in capsys.readouterr().out
+
+
+def test_app_chart_cmd_preflight_reports_template_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = argparse.Namespace(
+        app="tokenplace",
+        env="staging",
+        tag="main-deadbee",
+        chart="oci://ghcr.io/futuroptimist/charts/tokenplace",
+        version_file="docs/apps/tokenplace.version",
+        version="0.1.3",
+        release="tokenplace",
+        namespace="tokenplace",
+        values="values-a.yaml, values-b.yaml",
+    )
+    monkeypatch.setattr(
+        app_chart,
+        "helm_show",
+        lambda chart, version: subprocess.CompletedProcess([], 0, "", ""),
+    )
+    monkeypatch.setattr(
+        app_chart,
+        "run",
+        lambda cmd: subprocess.CompletedProcess(cmd, 2, "", "render failed"),
+    )
+
+    assert app_chart.cmd_preflight(args) == 2
+    assert "render failed" in capsys.readouterr().err
+
+
 def test_chart_recipes_are_listed(generic_app_stub_env: dict[str, str]) -> None:
     result = _run_just(["--list"], generic_app_stub_env)
 
@@ -491,9 +690,7 @@ def test_app_deploy_passes_tokenplace_when_manifest_metadata_env_present(
     env = generic_app_stub_env.copy()
     env["SUGARKUBE_APP_CHART_LATEST_STUB"] = "9.9.9"
 
-    result = _run_just(
-        ["app-deploy", "app=tokenplace", "env=staging", "tag=main-deadbee"], env
-    )
+    result = _run_just(["app-deploy", "app=tokenplace", "env=staging", "tag=main-deadbee"], env)
 
     assert result.returncode == 0, result.stderr + result.stdout
     assert "chart pin: docs/apps/tokenplace.version" in result.stdout
@@ -513,9 +710,7 @@ def test_app_redeploy_prints_chart_pin_reminder_without_latest_lookup_or_pin_mut
     env = generic_app_stub_env.copy()
     env["SUGARKUBE_APP_CHART_LATEST_STUB"] = "9.9.9"
 
-    result = _run_just(
-        ["app-redeploy", "app=tokenplace", "env=staging", "tag=main-deadbee"], env
-    )
+    result = _run_just(["app-redeploy", "app=tokenplace", "env=staging", "tag=main-deadbee"], env)
 
     assert result.returncode == 0, result.stderr + result.stdout
     _assert_chart_pin_reminder(result.stdout, "tokenplace")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -552,6 +552,56 @@ def test_app_chart_cmd_preflight_reports_missing_app_container_envs(
     assert "just app-chart-bump app=tokenplace" in err
 
 
+def test_app_chart_cmd_preflight_rejects_envs_split_across_candidate_containers(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = argparse.Namespace(
+        app="tokenplace",
+        env="staging",
+        tag="main-deadbee",
+        chart="oci://ghcr.io/futuroptimist/charts/tokenplace",
+        version_file="docs/apps/tokenplace.version",
+        version="0.1.3",
+        release="tokenplace",
+        namespace="tokenplace",
+        values="",
+    )
+    monkeypatch.setattr(
+        app_chart,
+        "helm_show",
+        lambda chart, version: subprocess.CompletedProcess([], 0, "apiVersion: v2\n", ""),
+    )
+    monkeypatch.setattr(
+        app_chart,
+        "run",
+        lambda cmd: subprocess.CompletedProcess(
+            cmd,
+            0,
+            "apiVersion: apps/v1\n"
+            "kind: Deployment\n"
+            "spec:\n"
+            "  template:\n"
+            "    spec:\n"
+            "      containers:\n"
+            "        - name: relay\n"
+            "          env:\n"
+            "            - name: TOKENPLACE_IMAGE_TAG\n"
+            "            - name: TOKENPLACE_RELEASE_VERSION\n"
+            "        - name: tokenplace\n"
+            "          env:\n"
+            "            - name: TOKENPLACE_CHART_VERSION\n"
+            "            - name: TOKENPLACE_DEPLOY_ENV\n",
+            "",
+        ),
+    )
+
+    assert app_chart.cmd_preflight(args) == 1
+    err = capsys.readouterr().err
+    assert "missing required metadata env vars" in err
+    assert "TOKENPLACE_IMAGE_TAG" in err
+    assert "TOKENPLACE_DEPLOY_ENV" in err
+
+
 def test_app_chart_cmd_preflight_passes_when_relay_envs_present(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -666,6 +666,35 @@ spec:
     ]
 
 
+def test_deployment_app_container_env_sets_handles_env_before_container_name() -> None:
+    manifest = """apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - env:
+            - name: TOKENPLACE_IMAGE_TAG
+            - name: TOKENPLACE_RELEASE_VERSION
+            - name: TOKENPLACE_CHART_VERSION
+            - name: TOKENPLACE_DEPLOY_ENV
+          image: ghcr.io/example/tokenplace:main-deadbee
+          name: relay
+"""
+
+    assert app_chart.deployment_app_container_env_sets(manifest, "tokenplace", "tokenplace") == [
+        (
+            "relay",
+            {
+                "TOKENPLACE_IMAGE_TAG",
+                "TOKENPLACE_RELEASE_VERSION",
+                "TOKENPLACE_CHART_VERSION",
+                "TOKENPLACE_DEPLOY_ENV",
+            },
+        )
+    ]
+
+
 def test_app_chart_cmd_preflight_passes_when_relay_envs_present(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -8,7 +8,8 @@ from pathlib import Path
 
 import pytest
 
-from scripts.app_verify import base_url_from_host
+from scripts import app_chart
+from scripts.app_verify import base_url_from_host, tokenplace_meta_failure
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -103,6 +104,8 @@ fi
 if [[ "$*" == template* ]]; then
   if [ "${{SUGARKUBE_STUB_HELM_TEMPLATE_MISSING_META:-}}" = "1" ]; then
     printf 'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: tokenplace\n'
+  elif [ "${{SUGARKUBE_STUB_HELM_TEMPLATE_COMMENT_META:-}}" = "1" ]; then
+    printf '# TOKENPLACE_IMAGE_TAG TOKENPLACE_RELEASE_VERSION TOKENPLACE_CHART_VERSION TOKENPLACE_DEPLOY_ENV\nkind: ConfigMap\ndata:\n  TOKENPLACE_IMAGE_TAG: main-deadbee\n'
   else
     printf 'env:\n- name: TOKENPLACE_IMAGE_TAG\n- name: TOKENPLACE_RELEASE_VERSION\n- name: TOKENPLACE_CHART_VERSION\n- name: TOKENPLACE_DEPLOY_ENV\n'
   fi
@@ -133,6 +136,16 @@ path="${{url#https://example.test}}"
 path="${{path:-/}}"
 status=200
 body='{{"status":"ok"}}'
+case "${{url}}" in
+  https://api.github.com/orgs/futuroptimist/packages/container/charts%2Ftokenplace/versions*)
+    status=404
+    body='{{"message":"Not Found"}}'
+    ;;
+  https://api.github.com/users/futuroptimist/packages/container/charts%2Ftokenplace/versions*)
+    status=200
+    body='[{{"metadata":{{"container":{{"tags":["0.1.3","0.1.4-rc.1","0.1.4"]}}}}}}]'
+    ;;
+esac
 case "${{path}}" in
   /) body=$'<!doctype html>\n<html lang="en">\n<body>ok</body>\n</html>' ;;
   /config.json) body='{{"publicConfig":true}}' ;;
@@ -178,6 +191,24 @@ def _run_just(args: list[str], env: dict[str, str]) -> subprocess.CompletedProce
     )
 
 
+def test_app_chart_semver_prefers_final_release_over_prerelease() -> None:
+    versions = ["1.2.3-rc.1", "1.2.3", "1.2.4-alpha.1"]
+
+    assert sorted(versions, key=app_chart.semver_key)[-1] == "1.2.4-alpha.1"
+    assert sorted(["1.2.3", "1.2.3-rc.1"], key=app_chart.semver_key)[-1] == "1.2.3"
+
+
+def test_app_chart_read_pin_rejects_empty_version_file_path() -> None:
+    with pytest.raises(SystemExit, match="--version-file must not be empty"):
+        app_chart.read_pin("")
+
+
+def test_tokenplace_meta_failure_rejects_invalid_or_missing_metadata() -> None:
+    assert "valid JSON" in tokenplace_meta_failure("staging", b"<html>ok</html>")
+    assert "non-empty label" in tokenplace_meta_failure("staging", b"{}")
+    assert "non-empty version" in tokenplace_meta_failure("staging", b'{"label":"main-deadbee"}')
+
+
 def test_chart_recipes_are_listed(generic_app_stub_env: dict[str, str]) -> None:
     result = _run_just(["--list"], generic_app_stub_env)
 
@@ -201,6 +232,33 @@ def test_app_chart_status_reports_pin_and_stale_latest(
     assert "chart appVersion: main-deadbee" in result.stdout
     assert "Pinned chart appears stale: 0.1.3 < 9.9.9" in result.stdout
     assert "Run: just app-chart-bump app=tokenplace version=9.9.9" in result.stdout
+
+
+def test_app_chart_latest_version_falls_back_to_user_owned_ghcr_packages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_run(args: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(args[-1])
+        if "/orgs/" in args[-1]:
+            return subprocess.CompletedProcess(args, 22, "", "not found")
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            '[{"metadata":{"container":{"tags":["0.1.3","0.1.4-rc.1","0.1.4"]}}}]',
+            "",
+        )
+
+    monkeypatch.delenv("SUGARKUBE_APP_CHART_LATEST_STUB", raising=False)
+    monkeypatch.setattr(app_chart, "run", fake_run)
+
+    latest, source = app_chart.latest_version("oci://ghcr.io/futuroptimist/charts/tokenplace")
+
+    assert latest == "0.1.4"
+    assert source == "GitHub/GHCR API"
+    assert "/orgs/futuroptimist/packages/container/charts%2Ftokenplace/versions" in calls[0]
+    assert "/users/futuroptimist/packages/container/charts%2Ftokenplace/versions" in calls[1]
 
 
 def test_app_chart_bump_updates_only_pin_file_in_temp_config(
@@ -325,6 +383,20 @@ def test_app_deploy_fails_tokenplace_when_manifest_metadata_env_missing(
     assert "missing required metadata env vars" in result.stderr
     assert "TOKENPLACE_IMAGE_TAG" in result.stderr
     assert "just app-chart-status app=tokenplace" in result.stderr
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "upgrade tokenplace" not in helm_log
+
+
+def test_app_deploy_fails_tokenplace_when_metadata_names_only_in_comments(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_HELM_TEMPLATE_COMMENT_META"] = "1"
+
+    result = _run_just(["app-deploy", "app=tokenplace", "env=staging", "tag=main-deadbee"], env)
+
+    assert result.returncode != 0
+    assert "missing required metadata env vars" in result.stderr
     helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
     assert "upgrade tokenplace" not in helm_log
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -96,6 +96,18 @@ if [[ "$*" == *"get values"* ]]; then
   printf '{{"ingress":{{"host":"%s"}}}}\n' "${{SUGARKUBE_STUB_HELM_HOST:-example.test}}"
   exit 0
 fi
+if [[ "$*" == show\ chart* ]]; then
+  printf 'apiVersion: v2\nname: tokenplace\nversion: 0.1.3\nappVersion: main-deadbee\ndigest: sha256:abc123\n'
+  exit 0
+fi
+if [[ "$*" == template* ]]; then
+  if [ "${{SUGARKUBE_STUB_HELM_TEMPLATE_MISSING_META:-}}" = "1" ]; then
+    printf 'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: tokenplace\n'
+  else
+    printf 'env:\n- name: TOKENPLACE_IMAGE_TAG\n- name: TOKENPLACE_RELEASE_VERSION\n- name: TOKENPLACE_CHART_VERSION\n- name: TOKENPLACE_DEPLOY_ENV\n'
+  fi
+  exit 0
+fi
 if [[ "$*" == *" status "* ]]; then
   printf 'STATUS: deployed\n'
 fi
@@ -125,6 +137,7 @@ case "${{path}}" in
   /) body=$'<!doctype html>\n<html lang="en">\n<body>ok</body>\n</html>' ;;
   /config.json) body='{{"publicConfig":true}}' ;;
   /relay/diagnostics) body='{{"relay":"ok"}}' ;;
+  /api/v1/meta) body='{{"label":"staging main-deadbee","version":"main-deadbee"}}' ;;
 esac
 if [ "${{SUGARKUBE_STUB_CURL_FAIL_PATH:-}}" = "${{path}}" ]; then
   status=503
@@ -163,6 +176,76 @@ def _run_just(args: list[str], env: dict[str, str]) -> subprocess.CompletedProce
         text=True,
         check=False,
     )
+
+
+def test_chart_recipes_are_listed(generic_app_stub_env: dict[str, str]) -> None:
+    result = _run_just(["--list"], generic_app_stub_env)
+
+    assert result.returncode == 0
+    assert "app-chart-status" in result.stdout
+    assert "app-chart-bump" in result.stdout
+
+
+def test_app_chart_status_reports_pin_and_stale_latest(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_APP_CHART_LATEST_STUB"] = "9.9.9"
+
+    result = _run_just(["app-chart-status", "app=tokenplace"], env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "app: tokenplace" in result.stdout
+    assert "chart ref: oci://ghcr.io/futuroptimist/charts/tokenplace" in result.stdout
+    assert "pinned version: 0.1.3" in result.stdout
+    assert "chart appVersion: main-deadbee" in result.stdout
+    assert "Pinned chart appears stale: 0.1.3 < 9.9.9" in result.stdout
+    assert "Run: just app-chart-bump app=tokenplace version=9.9.9" in result.stdout
+
+
+def test_app_chart_bump_updates_only_pin_file_in_temp_config(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    pin = tmp_path / "tokenplace.version"
+    pin.write_text("# Default tokenplace chart version.\n0.1.0\n", encoding="utf-8")
+    config = tmp_path / "tokenplace.env"
+    config.write_text(
+        "\n".join(
+            [
+                "SUGARKUBE_APP=tokenplace",
+                "SUGARKUBE_RELEASE=tokenplace",
+                "SUGARKUBE_NAMESPACE=tokenplace",
+                "SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/tokenplace",
+                f"SUGARKUBE_VERSION_FILE={pin}",
+                "SUGARKUBE_PROD_TAG_FILE=docs/apps/tokenplace.prod.tag",
+                "SUGARKUBE_VALUES_DEV=docs/examples/tokenplace.values.dev.yaml",
+                "SUGARKUBE_VALUES_STAGING=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml",
+                "SUGARKUBE_VALUES_PROD=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_APP_CONFIG_DIR"] = str(tmp_path)
+    result = _run_just(
+        ["app-chart-bump", "app=tokenplace", "version=0.1.3"],
+        env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert pin.read_text(encoding="utf-8") == "# Default tokenplace chart version.\n0.1.3\n"
+    assert "git add" in result.stdout
+    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.3" in helm_log
+
+
+def test_app_chart_bump_refuses_empty_version(generic_app_stub_env: dict[str, str]) -> None:
+    result = _run_just(["app-chart-bump", "app=tokenplace", "version="], generic_app_stub_env)
+
+    assert result.returncode != 0
+    assert "version must not be empty" in result.stderr
 
 
 @pytest.mark.usefixtures("ensure_just_available")
@@ -221,6 +304,40 @@ def test_app_deploy_uses_app_release_namespace_chart_values(
     assert f"--namespace {namespace}" in helm_log
     for value in values:
         assert f"-f {value}" in helm_log
+    if app == "tokenplace":
+        assert (
+            "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.3" in helm_log
+        )
+        assert "template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace" in helm_log
+        assert "--version 0.1.3" in helm_log
+        assert "--version 9.9.9" not in helm_log
+
+
+def test_app_deploy_fails_tokenplace_when_manifest_metadata_env_missing(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_HELM_TEMPLATE_MISSING_META"] = "1"
+
+    result = _run_just(["app-deploy", "app=tokenplace", "env=staging", "tag=main-deadbee"], env)
+
+    assert result.returncode != 0
+    assert "missing required metadata env vars" in result.stderr
+    assert "TOKENPLACE_IMAGE_TAG" in result.stderr
+    assert "just app-chart-status app=tokenplace" in result.stderr
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "upgrade tokenplace" not in helm_log
+
+
+def test_app_deploy_passes_tokenplace_when_manifest_metadata_env_present(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        ["app-deploy", "app=tokenplace", "env=staging", "tag=main-deadbee"], generic_app_stub_env
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "chart pin: docs/apps/tokenplace.version" in result.stdout
 
 
 @pytest.mark.usefixtures("ensure_just_available")
@@ -465,6 +582,7 @@ def test_app_verify_print_only_prints_commands_without_curl(
         "curl -fsS https://example.test/livez",
         "curl -fsS https://example.test/healthz",
         "curl -fsS https://example.test/relay/diagnostics",
+        "curl -fsS https://example.test/api/v1/meta",
     ]
     assert not Path(generic_app_stub_env["CURL_LOG"]).exists()
 
@@ -521,7 +639,7 @@ def test_app_verify_show_body_can_be_disabled(generic_app_stub_env: dict[str, st
     ("app", "expected_paths"),
     [
         ("danielsmith", "/,/livez,/healthz"),
-        ("tokenplace", "/,/livez,/healthz,/relay/diagnostics"),
+        ("tokenplace", "/,/livez,/healthz,/relay/diagnostics,/api/v1/meta"),
         ("dspace", "/config.json,/healthz,/livez"),
     ],
 )

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -602,6 +602,35 @@ def test_app_chart_cmd_preflight_rejects_envs_split_across_candidate_containers(
     assert "TOKENPLACE_DEPLOY_ENV" in err
 
 
+def test_deployment_app_container_env_sets_handles_container_name_after_image() -> None:
+    manifest = """apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - image: ghcr.io/example/tokenplace:main-deadbee
+          name: relay
+          env:
+            - name: "TOKENPLACE_IMAGE_TAG"
+            - name: TOKENPLACE_RELEASE_VERSION
+            - name: TOKENPLACE_CHART_VERSION
+            - name: TOKENPLACE_DEPLOY_ENV
+"""
+
+    assert app_chart.deployment_app_container_env_sets(manifest, "tokenplace", "tokenplace") == [
+        (
+            "relay",
+            {
+                "TOKENPLACE_IMAGE_TAG",
+                "TOKENPLACE_RELEASE_VERSION",
+                "TOKENPLACE_CHART_VERSION",
+                "TOKENPLACE_DEPLOY_ENV",
+            },
+        )
+    ]
+
+
 def test_app_chart_cmd_preflight_passes_when_relay_envs_present(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
### Motivation

- Prevent silent chart drift that caused token.place staging to run new image code with an old pinned chart; chart pins must remain explicit and reproducible.  
- Provide a first-class inspect-and-bump workflow so operators can detect stale chart pins and intentionally update `docs/apps/<app>.version`.  
- Fail dangerous deploys early by validating pinned charts and rendering token.place manifests to ensure required metadata env vars are present before Helm runs.

### Description

- Add `scripts/app_chart.py` implementing `status`, `bump`, and `preflight` commands that read/validate chart pins, run `helm show chart`, best-effort latest detection (GHCR API fallback), edit only the pin file on bump, and render manifests for deploy-time checks (tokenplace-required envs).  
- Wire `justfile` to 1) print the resolved app/env/image/chart/pin before Helm, 2) run `scripts/app_chart.py preflight` from `app-deploy`, `app-redeploy`, and token.place compatibility wrappers, and 3) add recipes `app-chart-status` and `app-chart-bump`.  
- Extend `scripts/app_verify.py` to include token.place `/api/v1/meta` in verification and to fail/warn if metadata reports `version == "dev"` or a `.label` ending in ` dev`.  
- Update docs (`docs/app_deployment_contract.md`, `docs/app_onboarding.md`, `docs/apps/tokenplace.md`) to document that image tag and chart version are independent coordinates and to describe the explicit `app-chart-status` / `app-chart-bump` workflow.  
- Add tests and test stubs in `tests/test_generic_app_just_recipes.py` to cover recipe presence, status/bump behavior, bump validation and file editing, deploy preflight failures/success for token.place, and extended verify paths.

### Testing

- Ran formatting and linting: `python -m black scripts/app_chart.py scripts/app_verify.py tests/test_generic_app_just_recipes.py` (completed).  
- Unit/recipe tests: `python -m pytest tests/test_generic_app_just_recipes.py -q` — all tests passed: `38 passed, 1 warning`.  
- Additional checks executed: `rg -n "app-chart-status|app-chart-bump|TOKENPLACE_IMAGE_TAG|TOKENPLACE_CHART_VERSION|docs/apps/.+\.version|chart pin|pinned chart" justfile scripts docs tests` (verified entries present), `just --list` (new recipes listed), and `python -m py_compile scripts/app_chart.py scripts/app_verify.py` (compile OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e6ab5b474832fa89307a7530d9637)