### PR TITLE
Add app chart pin guardrails: status, bump, and deploy preflight

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -108,6 +108,27 @@ Helm charts are immutable once published to GHCR OCI:
 - Sugarkube pins the chart version with the app's version file and uses that pin
   for cluster deployment orchestration.
 
+
+## Chart pin workflow
+
+Chart version and image tag are separate deployment coordinates. `just app-deploy app=<app> env=<env> tag=<tag>` deploys the requested image tag with the chart version pinned by `docs/apps/<app>.version`; it does not bump chart versions, chase `latest`, or silently auto-upgrade charts.
+
+Before release operations, inspect the pin explicitly:
+
+```bash
+just app-chart-status app=tokenplace
+```
+
+When the app repository publishes a new chart, bump the pin intentionally and commit that file before or with the release operation:
+
+```bash
+just app-chart-bump app=tokenplace version=0.1.3
+git add docs/apps/tokenplace.version
+git commit -m "Bump tokenplace chart pin to 0.1.3"
+```
+
+Deploy preflight logs print the app, environment, image tag, chart ref, pinned chart version, and chart pin path before Helm runs. Production flows must remain pinned and reproducible; do not use `chart=latest` or silent auto-upgrade behavior for prod.
+
 ## App config file shape
 
 Generic recipes load a simple shell/dotenv-style config with

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -84,6 +84,35 @@ If the chart changed, bump the chart version in the token.place app repo and pub
 gh workflow run ci-helm.yml --repo futuroptimist/token.place --ref main
 ```
 
+
+## Explicit chart pin status and bump flow
+
+The token.place image tag and Helm chart version are separate release coordinates. `just app-deploy app=tokenplace env=staging tag="$APP_TAG"` updates the image tag only; it does not update the pinned chart in `docs/apps/tokenplace.version` and does not bump chart versions or silently select the newest chart.
+
+Check the current pin before deployment:
+
+```bash
+just app-chart-status app=tokenplace
+```
+
+If token.place has published a new chart that is required for the image tag, bump the Sugarkube pin explicitly and commit it before or with the release:
+
+```bash
+just app-chart-bump app=tokenplace version=0.1.3
+git add docs/apps/tokenplace.version
+git commit -m "Bump tokenplace chart pin to 0.1.3"
+```
+
+The deploy preflight renders the pinned chart with the selected image tag and fails before Helm upgrade if the token.place deployment is missing `TOKENPLACE_IMAGE_TAG`, `TOKENPLACE_RELEASE_VERSION`, `TOKENPLACE_CHART_VERSION`, or `TOKENPLACE_DEPLOY_ENV`. Prefer committed pin bumps over temporary overrides; never rely on `chart=latest` or silent chart auto-upgrades for production.
+
+After staging deploy, verify runtime metadata as part of sign-off:
+
+```bash
+curl -fsS https://staging.token.place/api/v1/meta | jq .
+```
+
+Staging metadata should include the deployed image tag, for example `staging main-00797df`; warn loudly if `.label` ends with ` dev` or `.version == "dev"`. Production metadata should report a finalized release label such as `prod 0.1.1` and must not report `.version == "dev"`.
+
 ## Deploy staging
 
 Preferred generic command:

--- a/justfile
+++ b/justfile
@@ -1528,6 +1528,14 @@ app-config app env='staging' config='':
       --env {{ quote(env) }} \
       --config {{ quote(config) }}
 
+# Inspect a pinned app chart version and warn when a newer semver chart is visible.
+app-chart-status app config='':
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" status --app {{ quote(app) }} --config {{ quote(config) }}
+
+# Explicitly bump the chart pin file after validating that the chart version exists.
+app-chart-bump app version='' config='':
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" bump --app {{ quote(app) }} --version {{ quote(version) }} --config {{ quote(config) }}
+
 # Generic immutable-tag app deploy backed by docs/examples/apps/*.env or local app configs.
 app-deploy app env='staging' tag='' config='':
     #!/usr/bin/env bash
@@ -1539,6 +1547,12 @@ app-deploy app env='staging' tag='' config='':
       --config {{ quote(config) }} \
       --tag {{ quote(tag) }} \
       --require-tag)"
+
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight \
+      --app "${SUGARKUBE_APP}" \
+      --env "${SUGARKUBE_ENV}" \
+      --config "${SUGARKUBE_CONFIG_PATH}" \
+      --tag "${SUGARKUBE_TAG}"
 
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
@@ -1562,6 +1576,12 @@ app-redeploy app env='staging' tag='' config='':
       --config {{ quote(config) }} \
       --tag {{ quote(tag) }} \
       --require-tag)"
+
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight \
+      --app "${SUGARKUBE_APP}" \
+      --env "${SUGARKUBE_ENV}" \
+      --config "${SUGARKUBE_CONFIG_PATH}" \
+      --tag "${SUGARKUBE_TAG}"
 
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
@@ -1960,6 +1980,11 @@ tokenplace-oci-deploy env='staging' tag='':
       exit 1
     fi
     validate_immutable_tag "${resolved_tag}"
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight \
+      --app tokenplace \
+      --env "${env_name}" \
+      --config "" \
+      --tag "${resolved_tag}"
     chart_version=""
     if [ -f docs/apps/tokenplace.version ]; then
       chart_version="$(
@@ -2064,6 +2089,11 @@ tokenplace-oci-redeploy env='staging' tag='':
       exit 1
     fi
     [ -n "${resolved_tag}" ] && validate_immutable_tag "${resolved_tag}"
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight \
+      --app tokenplace \
+      --env "${env_name}" \
+      --config "" \
+      --tag "${resolved_tag}"
 
     values_chain='docs/examples/tokenplace.values.dev.yaml'
     default_tag=''

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Inspect and bump pinned Sugarkube app Helm chart versions."""
+from __future__ import annotations
+import argparse, json, os, re, subprocess, sys, urllib.request
+from pathlib import Path
+import app_config
+
+SEMVER = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$")
+REQ_ENV = {"tokenplace":["TOKENPLACE_IMAGE_TAG","TOKENPLACE_RELEASE_VERSION","TOKENPLACE_CHART_VERSION","TOKENPLACE_DEPLOY_ENV"]}
+ROOT=Path(__file__).resolve().parents[1]
+
+def read_pin(path: str) -> str:
+    p=(ROOT/path) if not Path(path).is_absolute() else Path(path)
+    for line in p.read_text().splitlines():
+        v=line.split('#',1)[0].strip()
+        if v: return v
+    raise SystemExit(f"ERROR: chart pin file {path} did not contain a version")
+
+def run(args:list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args,capture_output=True,text=True,check=False)
+
+def chart_meta(ref:str, ver:str) -> tuple[dict[str,str], str]:
+    cp=run(["helm","show","chart",ref,"--version",ver])
+    if cp.returncode: raise SystemExit(cp.stderr or cp.stdout)
+    meta={}
+    for line in cp.stdout.splitlines():
+        if ':' in line and not line.startswith(' '):
+            k,v=line.split(':',1); meta[k.strip()]=v.strip().strip('"')
+    digest=meta.get('digest') or meta.get('Digest') or ''
+    return meta,digest
+
+def latest_ghcr(ref:str)->tuple[str,str]:
+    if os.environ.get("SUGARKUBE_APP_CHART_LATEST"):
+        return os.environ["SUGARKUBE_APP_CHART_LATEST"], ""
+    m=re.match(r"oci://ghcr\.io/([^/]+)/(.+)", ref)
+    if not m: return '', 'latest unknown: unsupported chart registry; inspect manually with helm/oras.'
+    owner, package=m.group(1), m.group(2)
+    pkg=package.replace('/','%2F')
+    url=f"https://api.github.com/users/{owner}/packages/container/{pkg}/versions?per_page=100"
+    token=os.environ.get('GITHUB_TOKEN') or os.environ.get('GH_TOKEN')
+    req=urllib.request.Request(url, headers={"Accept":"application/vnd.github+json", **({"Authorization":f"Bearer {token}"} if token else {})})
+    try:
+        with urllib.request.urlopen(req, timeout=8) as resp: data=json.load(resp)
+    except Exception as e:
+        return '', f"latest unknown: GHCR API lookup unavailable ({e}). Check https://github.com/{owner}?tab=packages or run: gh api {url}"
+    versions=[]
+    for item in data:
+        for tag in item.get('metadata',{}).get('container',{}).get('tags',[]) or []:
+            t=tag[10:] if tag.startswith('tokenplace-') else tag
+            if SEMVER.match(t): versions.append(t)
+    if not versions: return '', 'latest unknown: no semver tags found in GHCR API response.'
+    versions=sorted(set(versions), key=lambda s: tuple(map(int, SEMVER.match(s).groups()[:3])))
+    return versions[-1], ''
+
+def cmp(a,b):
+    ma,mb=SEMVER.match(a),SEMVER.match(b)
+    if not ma or not mb: return 0
+    return (tuple(map(int,ma.groups())) > tuple(map(int,mb.groups()))) - (tuple(map(int,ma.groups())) < tuple(map(int,mb.groups())))
+
+def status(args):
+    cfg=app_config.load_config(args.app,'staging',args.config or None)
+    pin_file=cfg.get('SUGARKUBE_VERSION_FILE','')
+    ver=cfg.get('SUGARKUBE_VERSION') or read_pin(pin_file)
+    meta,digest=chart_meta(cfg['SUGARKUBE_CHART'],ver)
+    print(f"app: {cfg['SUGARKUBE_APP']}")
+    print(f"chart ref: {cfg['SUGARKUBE_CHART']}")
+    print(f"pinned version: {ver}")
+    print(f"chart appVersion: {meta.get('appVersion','unknown')}")
+    print(f"chart digest: {digest or 'unknown'}")
+    print(f"pin file: {pin_file}")
+    latest,msg=latest_ghcr(cfg['SUGARKUBE_CHART'])
+    if latest:
+        print(f"latest version: {latest}")
+        if cmp(ver,latest)<0:
+            print(f"WARNING: Pinned chart appears stale: {ver} < {latest}")
+            print(f"Run: just app-chart-bump app={cfg['SUGARKUBE_APP']} version={latest}")
+    else: print(msg)
+
+def bump(args):
+    version=(args.version or '').strip()
+    while version.startswith("version="):
+        version = version[len("version="):].strip()
+    if not version: raise SystemExit('ERROR: version must not be empty. Use version=<semver>.')
+    cfg=app_config.load_config(args.app,'staging',args.config or None)
+    pin_file=cfg.get('SUGARKUBE_VERSION_FILE','')
+    if not pin_file: raise SystemExit('ERROR: app config must use SUGARKUBE_VERSION_FILE for bumping.')
+    chart_meta(cfg['SUGARKUBE_CHART'], version)
+    p=ROOT/pin_file
+    lines=p.read_text().splitlines()
+    replaced=False; out=[]
+    for line in lines:
+        if not replaced and line.split('#',1)[0].strip(): out.append(version); replaced=True
+        else: out.append(line)
+    if not replaced: out.append(version)
+    p.write_text('\n'.join(out)+'\n')
+    subprocess.run(['git','diff','--',pin_file], cwd=ROOT, check=False)
+    print('\nNext steps:')
+    print(f'git add {pin_file}')
+    print(f'git commit -m "Bump {cfg["SUGARKUBE_APP"]} chart pin to {version}"')
+    print('git push')
+    print(f'just app-deploy app={cfg["SUGARKUBE_APP"]} env=staging tag=<APP_TAG>')
+
+def preflight(args):
+    cfg=app_config.load_config(args.app,args.env,args.config or None); ver=cfg.get('SUGARKUBE_VERSION') or read_pin(cfg.get('SUGARKUBE_VERSION_FILE',''))
+    tag=app_config.resolve_tag(cfg,args.tag,prod_fallback=False)
+    print(f"app: {cfg['SUGARKUBE_APP']}\nenv: {cfg['SUGARKUBE_ENV']}\nimage tag: {tag}\nchart ref: {cfg['SUGARKUBE_CHART']}\nchart version: {ver}\nchart pin: {cfg.get('SUGARKUBE_VERSION_FILE','<inline>')}")
+    chart_meta(cfg['SUGARKUBE_CHART'],ver)
+    req=REQ_ENV.get(cfg['SUGARKUBE_APP'],[])
+    if req:
+        cmd=['helm','template',cfg['SUGARKUBE_RELEASE'],cfg['SUGARKUBE_CHART'],'--namespace',cfg['SUGARKUBE_NAMESPACE'],'--version',ver]
+        for vf in cfg['SUGARKUBE_VALUES'].split(','): cmd += ['-f', vf.strip()]
+        cmd += ['--set', f'image.tag={tag}']
+        cp=run(cmd)
+        if cp.returncode: raise SystemExit(cp.stderr or cp.stdout)
+        missing=[x for x in req if x not in cp.stdout]
+        if missing:
+            print(f"ERROR: rendered {cfg['SUGARKUBE_APP']} manifest is missing required env vars: {', '.join(missing)}", file=sys.stderr)
+            print(f"Pinned chart version: {ver} ({cfg.get('SUGARKUBE_VERSION_FILE','<inline>')})", file=sys.stderr)
+            print(f"Run: just app-chart-status app={cfg['SUGARKUBE_APP']}", file=sys.stderr)
+            print(f"Then bump explicitly: just app-chart-bump app={cfg['SUGARKUBE_APP']} version=<published-version>", file=sys.stderr)
+            return 1
+    return 0
+
+def main():
+    p=argparse.ArgumentParser(); sub=p.add_subparsers(dest='cmd',required=True)
+    for c in ('status','bump','preflight'):
+        s=sub.add_parser(c); s.add_argument('--app',required=True); s.add_argument('--config',default='')
+        if c in ('bump',): s.add_argument('--version',required=True)
+        if c in ('preflight',): s.add_argument('--env',required=True); s.add_argument('--tag',required=True)
+    a=p.parse_args(); return {'status':status,'bump':bump,'preflight':preflight}[a.cmd](a) or 0
+if __name__=='__main__': raise SystemExit(main())

--- a/scripts/app_verify.py
+++ b/scripts/app_verify.py
@@ -189,6 +189,8 @@ def main(argv: list[str] | None = None) -> int:
     paths = [
         normalize_path(path) for path in os.environ.get("SUGARKUBE_VERIFY_PATHS", "/").split(",")
     ]
+    if app == "tokenplace" and env in {"staging", "prod"} and "/api/v1/meta" not in paths:
+        paths.append("/api/v1/meta")
     print_only = args.print_only or env_flag("SUGARKUBE_APP_VERIFY_PRINT_ONLY")
 
     host, errors = discover_host(kube_context)
@@ -225,6 +227,16 @@ def main(argv: list[str] | None = None) -> int:
         )
         if curl_rc == 0:
             print(f"  Status: OK{http_suffix}")
+            if app == "tokenplace" and path == "/api/v1/meta":
+                try:
+                    meta = json.loads(body.decode("utf-8"))
+                except json.JSONDecodeError:
+                    meta = {}
+                label = str(meta.get("label", ""))
+                version = str(meta.get("version", ""))
+                if version == "dev" or label.endswith(" dev"):
+                    print("  token.place metadata warning: deployment still reports dev metadata.")
+                    print("  Expected staging labels to include the immutable image tag; prod should use a finalized release version.")
             passed += 1
         else:
             print(f"  Status: FAILED{http_suffix}")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -96,6 +96,18 @@ if [[ "$*" == *"get values"* ]]; then
   printf '{{"ingress":{{"host":"%s"}}}}\n' "${{SUGARKUBE_STUB_HELM_HOST:-example.test}}"
   exit 0
 fi
+if [[ "$*" == show\ chart* ]]; then
+  printf 'apiVersion: v2\nname: tokenplace\nversion: 0.1.3\nappVersion: main-deadbee\ndigest: sha256:stub\n'
+  exit 0
+fi
+if [[ "$*" == template* ]]; then
+  if [ "${{SUGARKUBE_STUB_HELM_TEMPLATE_MISSING_ENV:-}}" = "1" ]; then
+    printf 'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: tokenplace\n'
+  else
+    printf 'env:\n- name: TOKENPLACE_IMAGE_TAG\n- name: TOKENPLACE_RELEASE_VERSION\n- name: TOKENPLACE_CHART_VERSION\n- name: TOKENPLACE_DEPLOY_ENV\n'
+  fi
+  exit 0
+fi
 if [[ "$*" == *" status "* ]]; then
   printf 'STATUS: deployed\n'
 fi
@@ -465,6 +477,7 @@ def test_app_verify_print_only_prints_commands_without_curl(
         "curl -fsS https://example.test/livez",
         "curl -fsS https://example.test/healthz",
         "curl -fsS https://example.test/relay/diagnostics",
+        "curl -fsS https://example.test/api/v1/meta",
     ]
     assert not Path(generic_app_stub_env["CURL_LOG"]).exists()
 
@@ -564,3 +577,119 @@ def test_app_verify_fails_closed_when_context_host_discovery_fails(
     assert "kubectl ingress lookup failed for context sugar-staging" in result.stderr
     assert "Suggested next steps: just app-status app=tokenplace env=staging" in result.stderr
     assert "curl -fsS https://<host>/" in result.stdout
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_chart_recipes_are_listed(generic_app_stub_env: dict[str, str]) -> None:
+    result = _run_just(["--list"], generic_app_stub_env)
+    assert result.returncode == 0, result.stderr
+    assert "app-chart-status" in result.stdout
+    assert "app-chart-bump" in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_deploy_prints_and_uses_pinned_chart_without_latest_lookup(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_APP_CHART_LATEST"] = "9.9.9"
+    result = _run_just(["app-deploy", "app=tokenplace", "env=staging", "tag=main-deadbee"], env)
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "app: tokenplace" in result.stdout
+    assert "env: staging" in result.stdout
+    assert "image tag: main-deadbee" in result.stdout
+    assert "chart ref: oci://ghcr.io/futuroptimist/charts/tokenplace" in result.stdout
+    assert "chart version: 0.1.3" in result.stdout
+    assert "chart pin: docs/apps/tokenplace.version" in result.stdout
+    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "--version 0.1.3" in helm_log
+    assert "9.9.9" not in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_chart_status_reports_stale_pin_when_latest_is_newer(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_APP_CHART_LATEST"] = "0.1.4"
+    result = _run_just(["app-chart-status", "app=tokenplace"], env)
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "pinned version: 0.1.3" in result.stdout
+    assert "chart appVersion: main-deadbee" in result.stdout
+    assert "chart digest: sha256:stub" in result.stdout
+    assert "Pinned chart appears stale: 0.1.3 < 0.1.4" in result.stdout
+    assert "Run: just app-chart-bump app=tokenplace version=0.1.4" in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_chart_bump_refuses_empty_version(generic_app_stub_env: dict[str, str]) -> None:
+    result = _run_just(["app-chart-bump", "app=tokenplace", "version="], generic_app_stub_env)
+    assert result.returncode != 0
+    assert "version must not be empty" in result.stderr
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_chart_bump_validates_and_updates_only_pin_file(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    cfg_dir = tmp_path / "cfg"
+    cfg_dir.mkdir()
+    pin = tmp_path / "tokenplace.version"
+    pin.write_text("# keep comment\n0.1.0\n", encoding="utf-8")
+    (cfg_dir / "tokenplace.env").write_text(
+        "\n".join(
+            [
+                "SUGARKUBE_APP=tokenplace",
+                "SUGARKUBE_RELEASE=tokenplace",
+                "SUGARKUBE_NAMESPACE=tokenplace",
+                "SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/tokenplace",
+                f"SUGARKUBE_VERSION_FILE={pin}",
+                "SUGARKUBE_VALUES_STAGING=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml",
+                "SUGARKUBE_VALUES_DEV=docs/examples/tokenplace.values.dev.yaml",
+                "SUGARKUBE_VALUES_PROD=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_APP_CONFIG_DIR"] = str(cfg_dir)
+    result = _run_just(["app-chart-bump", "app=tokenplace", "version=0.1.3"], env)
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert pin.read_text(encoding="utf-8") == "# keep comment\n0.1.3\n"
+    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.3" in helm_log
+    assert "git add" in result.stdout
+    assert "just app-deploy app=tokenplace env=staging tag=<APP_TAG>" in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_tokenplace_preflight_fails_when_rendered_manifest_lacks_metadata_env(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_HELM_TEMPLATE_MISSING_ENV"] = "1"
+    result = _run_just(["app-deploy", "app=tokenplace", "env=staging", "tag=main-deadbee"], env)
+    assert result.returncode != 0
+    assert "missing required env vars" in result.stderr
+    assert "TOKENPLACE_IMAGE_TAG" in result.stderr
+    assert "app-chart-status app=tokenplace" in result.stderr
+    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "upgrade tokenplace" not in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_tokenplace_preflight_passes_when_rendered_manifest_has_metadata_env(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(["app-deploy", "app=tokenplace", "env=staging", "tag=main-deadbee"], generic_app_stub_env)
+    assert result.returncode == 0, result.stderr + result.stdout
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "template tokenplace" in helm_log
+    assert "upgrade tokenplace" in helm_log
+
+
+def test_docs_mention_chart_status_and_bump_flow() -> None:
+    docs = (REPO_ROOT / "docs/app_deployment_contract.md").read_text(encoding="utf-8") + (REPO_ROOT / "docs/apps/tokenplace.md").read_text(encoding="utf-8")
+    assert "app-chart-status" in docs
+    assert "app-chart-bump" in docs
+    assert "does not bump chart" in docs or "does not update the chart" in docs


### PR DESCRIPTION
### Motivation

- Prevent silent Helm chart upgrades during `app-deploy` and loudly detect stale chart pins after the token.place incident where an image tag advanced but the pinned chart did not. 
- Keep deploys reproducible by preserving chart pins in `docs/apps/<app>.version` while providing an explicit inspect-and-bump workflow. 
- Provide token.place-specific manifest guardrails so deploys fail early when a rendered release lacks required chart-injected metadata env vars.

### Description

- Added a new helper `scripts/app_chart.py` implementing `status`, `bump`, and `preflight` commands to read pin files, run `helm show chart` to surface chart metadata, perform best-effort latest-version detection for GHCR (fallbacks if API/tools unavailable), validate chart versions, and render/check manifests for app-specific required envs. 
- Added `just` recipes `app-chart-status` and `app-chart-bump`, and wired a `python3 scripts/app_chart.py preflight ...` call into the generic `app-deploy` and `app-redeploy` recipes plus the existing token.place OCI wrappers, ensuring the pinned chart and selected image tag are printed and validated before Helm runs. 
- Implemented token.place-specific guards: `preflight` renders the pinned chart with the selected image tag and fails if any of `TOKENPLACE_IMAGE_TAG`, `TOKENPLACE_RELEASE_VERSION`, `TOKENPLACE_CHART_VERSION`, or `TOKENPLACE_DEPLOY_ENV` are missing; `app-verify` now includes `/api/v1/meta` for staging/prod and prints a clear warning if metadata still reports `dev`. 
- Documentation updates: added an explicit chart pin workflow to `docs/app_deployment_contract.md` and `docs/apps/tokenplace.md` that documents `app-chart-status` / `app-chart-bump`, emphasizes that `app-deploy tag=...` does not bump charts, and recommends committing pin bumps before release. 
- Tests: added/updated tests in `tests/test_generic_app_just_recipes.py` to cover recipe listing, `app-deploy` pinned behavior, `app-chart-status` stale warnings, `app-chart-bump` validation and pin-file edits, token.place preflight fail/pass cases, and docs references; the tests use a test stubbed `helm` and allow `SUGARKUBE_APP_CHART_LATEST` as a test hook for latest-version stubbing.

### Testing

- Ran `python -m pytest tests/test_generic_app_just_recipes.py -v` and all tests passed: `40 passed`.
- Confirmed new recipes are discoverable via `just --list` and the new `app-chart-status` / `app-chart-bump` entries are present. 
- Verified helper scripts compile with `python -m py_compile scripts/app_chart.py scripts/app_verify.py` (ok). 
- Searched the tree for the new keywords with `rg -n "app-chart-status|app-chart-bump|TOKENPLACE_IMAGE_TAG|TOKENPLACE_CHART_VERSION|docs/apps/.+\.version|chart pin|pinned chart"` (ok). 
- Ran the repo secret scan step used in CI over diffs (`git diff ... | ./scripts/scan-secrets.py`) which produced no issues in this change. 
- Note: repo-level checks `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` were not executed in this environment because those commands are not installed; they should be run in CI or locally as part of final review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e6ad8a2ac832f9010998e58259e12)