### PR TITLE
Add app chart pin guardrails (status, bump, deploy preflight, token.place guards)

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -217,3 +217,23 @@ Current values chains:
 | dspace | `docs/examples/dspace.values.dev.yaml` | `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml` | `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml` | `/config.json,/healthz,/livez` |
 | token.place | `docs/examples/tokenplace.values.dev.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml` | `/,/livez,/healthz,/relay/diagnostics` |
 | danielsmith.io | `docs/examples/danielsmith.values.dev.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml` | `/,/livez,/healthz` |
+
+### Chart pins are explicit release coordinates
+
+Every generic app deploy uses the chart version pinned by `docs/apps/<app>.version` or the app config's `SUGARKUBE_VERSION`. Image tags and chart versions move independently: `just app-deploy app=<app> env=<env> tag=<tag>` deploys the requested image tag with the already-pinned chart and must not silently select the newest published chart.
+
+Use the chart status workflow before release operations:
+
+```bash
+just app-chart-status app=tokenplace
+```
+
+When the app repository publishes a new chart that should become part of Sugarkube's deployment contract, bump the pin intentionally:
+
+```bash
+just app-chart-bump app=tokenplace version=0.1.3
+```
+
+The bump validates `helm show chart <chart-ref> --version <version>`, updates only `docs/apps/<app>.version`, and prints the diff plus commit/deploy next steps. Commit chart pin changes before or with release operations. Do not use `chart=latest`, unpinned production overrides, or silent auto-upgrade behavior; reproducible deploys require a reviewed chart pin. Deploy and redeploy preflights print the app, environment, image tag, chart ref, chart version, and chart pin path before Helm upgrade.
+
+App-specific deploy guardrails may render the pinned chart before applying it. token.place requires `TOKENPLACE_IMAGE_TAG`, `TOKENPLACE_RELEASE_VERSION`, `TOKENPLACE_CHART_VERSION`, and `TOKENPLACE_DEPLOY_ENV` in staging/prod rendered manifests so old chart pins fail before rollout.

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -142,7 +142,8 @@ just app-deploy app=appslug env=staging tag="$APP_TAG" config="$APP_CONFIG"
 - Bump the app repo chart `version` for any chart content change.
 - Update `appVersion` when the human-facing app version changed.
 - Publish the new OCI chart once.
-- Update Sugarkube's `docs/apps/APP.version` to the new chart version after publication.
+- Check the current chart pin with `just app-chart-status app=APP` before deploying.
+- Update Sugarkube's `docs/apps/APP.version` to the new chart version after publication with `just app-chart-bump app=APP version=X.Y.Z`; image tags and chart versions are separate coordinates, and `app-deploy tag=...` does not bump the chart pin.
 
 ```bash
 CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/appslug.version | head -n 1)

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -84,6 +84,26 @@ If the chart changed, bump the chart version in the token.place app repo and pub
 gh workflow run ci-helm.yml --repo futuroptimist/token.place --ref main
 ```
 
+## Chart pin workflow
+
+Sugarkube treats the token.place image tag and Helm chart version as separate deployment coordinates. `just app-deploy app=tokenplace env=staging tag=<APP_TAG>` changes the relay image tag only; it does **not** chase the newest chart and does **not** edit `docs/apps/tokenplace.version`. The pinned chart is part of the reproducible deployment contract and must be bumped explicitly when token.place publishes chart wiring that new app code depends on.
+
+Before staging or production deploys, inspect the current pin:
+
+```bash
+just app-chart-status app=tokenplace
+```
+
+If GHCR/latest detection is available and the pin is stale, the command prints a warning such as `Pinned chart appears stale: 0.1.0 < 0.1.3` plus the exact bump command. To intentionally move the pin after a chart has been published, run:
+
+```bash
+just app-chart-bump app=tokenplace version=0.1.3
+```
+
+The bump command validates the chart with `helm show chart`, edits only `docs/apps/tokenplace.version`, prints the diff, and stops. Commit the pin bump before or with the release operation; do not rely on `chart=latest`, unpinned overrides, or silent auto-upgrade behavior for production.
+
+Deploy preflight renders the pinned token.place chart with the selected image tag before Helm upgrade. Staging and production deploys fail early if the rendered Deployment is missing `TOKENPLACE_IMAGE_TAG`, `TOKENPLACE_RELEASE_VERSION`, `TOKENPLACE_CHART_VERSION`, or `TOKENPLACE_DEPLOY_ENV`; this catches image/chart mismatches before the cluster is changed.
+
 ## Deploy staging
 
 Preferred generic command:
@@ -108,7 +128,10 @@ just app-status app=tokenplace env=staging
 
 ```bash
 just app-verify app=tokenplace env=staging
+curl -fsS https://staging.token.place/api/v1/meta | jq .
 ```
+
+For staging, the metadata label should include the deployed immutable image tag, for example `staging main-00797df`. Treat `.label` ending in ` dev` or `.version == "dev"` as a failed release verification because it usually means the chart did not inject release metadata.
 
 ```bash
 just app-verify app=tokenplace env=staging print_only=1
@@ -160,7 +183,10 @@ just app-status app=tokenplace env=prod
 
 ```bash
 just app-verify app=tokenplace env=prod
+curl -fsS https://token.place/api/v1/meta | jq .
 ```
+
+For production, metadata should show a finalized release label such as `prod 0.1.1`; `.version == "dev"` is a loud failure signal.
 
 Print the generated curl commands without executing them when you need a manual fallback:
 
@@ -197,6 +223,7 @@ kubectl --context sugar-prod -n tokenplace get deploy tokenplace -o yaml > /tmp/
 # First run production desktop or compute-node registration and the
 # production E2EE request/response. Then capture post-test evidence:
 curl -fsS "https://${TOKENPLACE_HOST}/healthz" | tee /tmp/tokenplace-prod-healthz.json
+curl -fsS "https://${TOKENPLACE_HOST}/api/v1/meta" | jq . | tee /tmp/tokenplace-prod-meta.json
 curl -fsS "https://${TOKENPLACE_HOST}/relay/diagnostics" | tee /tmp/tokenplace-prod-diagnostics.json
 kubectl --context sugar-prod -n tokenplace logs deploy/tokenplace --since=30m --tail=500 \
   | tee /tmp/tokenplace-prod-relay-after-compute.log

--- a/justfile
+++ b/justfile
@@ -1528,6 +1528,18 @@ app-config app env='staging' config='':
       --env {{ quote(env) }} \
       --config {{ quote(config) }}
 
+# Inspect the pinned Helm chart for a Sugarkube app and report stale pins when detectable.
+app-chart-status app config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" status --app {{ quote(app) }} --config {{ quote(config) }}
+
+# Explicitly bump a Sugarkube app chart pin after validating the chart exists.
+app-chart-bump app version='' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" bump --app {{ quote(app) }} --version {{ quote(version) }} --config {{ quote(config) }}
+
 # Generic immutable-tag app deploy backed by docs/examples/apps/*.env or local app configs.
 app-deploy app env='staging' tag='' config='':
     #!/usr/bin/env bash
@@ -1539,6 +1551,8 @@ app-deploy app env='staging' tag='' config='':
       --config {{ quote(config) }} \
       --tag {{ quote(tag) }} \
       --require-tag)"
+
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight --app "${SUGARKUBE_APP}" --env "${SUGARKUBE_ENV}" --tag "${SUGARKUBE_TAG}" --config "${SUGARKUBE_CONFIG_PATH}"
 
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
@@ -1562,6 +1576,8 @@ app-redeploy app env='staging' tag='' config='':
       --config {{ quote(config) }} \
       --tag {{ quote(tag) }} \
       --require-tag)"
+
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight --app "${SUGARKUBE_APP}" --env "${SUGARKUBE_ENV}" --tag "${SUGARKUBE_TAG}" --config "${SUGARKUBE_CONFIG_PATH}"
 
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
@@ -1955,6 +1971,9 @@ tokenplace-oci-deploy env='staging' tag='':
     }
 
     resolved_tag="$(echo '{{ tag }}' | xargs)"
+    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
+      resolved_tag="${resolved_tag#tag=}"
+    done
     if [ -z "${resolved_tag}" ]; then
       echo "ERROR: tag is required for immutable deploys." >&2
       exit 1
@@ -1983,6 +2002,7 @@ tokenplace-oci-deploy env='staging' tag='':
     # This is tokenplace-scoped; do not copy into DSPACE from this PR.
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight --app tokenplace --env "${env_name}" --tag "${resolved_tag}" --config docs/examples/apps/tokenplace.env
     echo "Deploying tokenplace env=${env_name} chart=oci://ghcr.io/futuroptimist/charts/tokenplace version=${chart_version} image=ghcr.io/futuroptimist/tokenplace-relay:${resolved_tag}"
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
@@ -2054,6 +2074,9 @@ tokenplace-oci-redeploy env='staging' tag='':
     read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.prod.tag | head -n1 | tr -d '[:space:]'; }
 
     resolved_tag="$(echo '{{ tag }}' | xargs)"
+    while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
+      resolved_tag="${resolved_tag#tag=}"
+    done
     if [ -z "${resolved_tag}" ] && [ "${env_name}" = "prod" ]; then
       resolved_tag="$(read_prod_tag 2>/dev/null || true)"
       [ -n "${resolved_tag}" ] || { echo "ERROR: prod requires tag=<immutable-tag> or docs/apps/tokenplace.prod.tag." >&2; exit 1; }
@@ -2078,6 +2101,8 @@ tokenplace-oci-redeploy env='staging' tag='':
     # This is tokenplace-scoped; do not copy into DSPACE from this PR.
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight --app tokenplace --env "${env_name}" --tag "${resolved_tag}" --config docs/examples/apps/tokenplace.env
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release='tokenplace' namespace='tokenplace' \

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Inspect, bump, and preflight pinned Sugarkube app Helm charts."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts import app_config
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SEMVER = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$")
+TOKENPLACE_REQUIRED_ENV = [
+    "TOKENPLACE_IMAGE_TAG",
+    "TOKENPLACE_RELEASE_VERSION",
+    "TOKENPLACE_CHART_VERSION",
+    "TOKENPLACE_DEPLOY_ENV",
+]
+
+
+def clean_pin(path: Path) -> str:
+    for line in path.read_text(encoding="utf-8").splitlines():
+        value = line.split("#", 1)[0].strip()
+        if value:
+            return value
+    return ""
+
+
+def resolve_pin(config: dict[str, str]) -> tuple[str, Path]:
+    if config.get("SUGARKUBE_VERSION"):
+        return config["SUGARKUBE_VERSION"], Path("<config:SUGARKUBE_VERSION>")
+    rel = config.get("SUGARKUBE_VERSION_FILE", "")
+    if not rel:
+        raise SystemExit(
+            "ERROR: app config does not define SUGARKUBE_VERSION_FILE or "
+            "SUGARKUBE_VERSION."
+        )
+    path = Path(rel)
+    abs_path = path if path.is_absolute() else REPO_ROOT / path
+    version = clean_pin(abs_path) if abs_path.is_file() else ""
+    if not version:
+        raise SystemExit(f"ERROR: unable to resolve chart version from {rel}.")
+    return version, path
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=REPO_ROOT, capture_output=True, text=True, check=False)
+
+
+def helm_show(chart: str, version: str) -> subprocess.CompletedProcess[str]:
+    return run(["helm", "show", "chart", chart, "--version", version])
+
+
+def parse_field(raw: str, name: str) -> str:
+    for line in raw.splitlines():
+        if line.lower().startswith(f"{name.lower()}:"):
+            return line.split(":", 1)[1].strip()
+    return ""
+
+
+def semver_key(value: str) -> tuple[int, int, int, int, str] | None:
+    match = SEMVER.match(value.strip())
+    if not match:
+        return None
+    major, minor, patch, prerelease, _build = match.groups()
+    return (int(major), int(minor), int(patch), 0 if prerelease else 1, prerelease or "")
+
+
+def detect_latest(chart: str) -> tuple[str, str]:
+    forced = os.environ.get("SUGARKUBE_APP_CHART_LATEST", "").strip()
+    if forced:
+        return forced, "SUGARKUBE_APP_CHART_LATEST"
+    if not chart.startswith("oci://ghcr.io/"):
+        return "", "latest unknown: only GHCR OCI best-effort detection is implemented"
+    package = chart.removeprefix("oci://ghcr.io/")
+    owner, _, name = package.partition("/")
+    if not owner or not name:
+        return "", "latest unknown: could not parse GHCR chart ref"
+    api_name = name.replace("/", "%2F")
+    gh = run([
+        "gh", "api", f"/users/{owner}/packages/container/{api_name}/versions",
+        "--jq", ".[].[.metadata.container.tags[]?] | .[]",
+    ])
+    if gh.returncode != 0:
+        return (
+            "",
+            "latest unknown: run gh api "
+            f"/users/{owner}/packages/container/{api_name}/versions "
+            f"or open https://github.com/{owner}?tab=packages",
+        )
+    versions = [line.strip() for line in gh.stdout.splitlines() if semver_key(line.strip())]
+    if not versions:
+        return "", "latest unknown: no semver chart tags found in GHCR response"
+    return sorted(versions, key=lambda item: semver_key(item) or (0, 0, 0, 0, ""))[-1], "GHCR"
+
+
+def load(app: str, env: str = "staging", config_path: str = "") -> dict[str, str]:
+    return app_config.load_config(
+        app_config.normalize_named(app, "app"),
+        app_config.normalize_named(env, "env"),
+        app_config.normalize_named(config_path or "", "config") or None,
+    )
+
+
+def print_preflight(config: dict[str, str], tag: str, version: str, pin: Path) -> None:
+    print(f"app: {config['SUGARKUBE_APP']}")
+    print(f"env: {config['SUGARKUBE_ENV']}")
+    print(f"image tag: {tag}")
+    print(f"chart ref: {config['SUGARKUBE_CHART']}")
+    print(f"chart version: {version}")
+    print(f"chart pin: {pin}")
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    config = load(args.app, "staging", args.config)
+    version, pin = resolve_pin(config)
+    shown = helm_show(config["SUGARKUBE_CHART"], version)
+    if shown.returncode != 0:
+        sys.stderr.write(shown.stderr)
+        return shown.returncode or 1
+    print(f"app: {config['SUGARKUBE_APP']}")
+    print(f"chart ref: {config['SUGARKUBE_CHART']}")
+    print(f"pinned version: {version}")
+    print(f"chart appVersion: {parse_field(shown.stdout, 'appVersion') or 'unknown'}")
+    print(f"chart digest: {parse_field(shown.stdout, 'digest') or 'unknown'}")
+    print(f"pin file: {pin}")
+    latest, source = detect_latest(config["SUGARKUBE_CHART"])
+    if not latest:
+        print(source)
+        return 0
+    print(f"latest version: {latest} ({source})")
+    if (
+        semver_key(version)
+        and semver_key(latest)
+        and semver_key(version) < semver_key(latest)
+    ):
+        print(f"WARNING: Pinned chart appears stale: {version} < {latest}")
+        print(f"Run: just app-chart-bump app={config['SUGARKUBE_APP']} version={latest}")
+    return 0
+
+
+def rewrite_pin(path: Path, version: str) -> None:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    changed = False
+    out = []
+    for line in lines:
+        if not changed and line.split("#", 1)[0].strip():
+            suffix = ""
+            if "#" in line:
+                suffix = "  #" + line.split("#", 1)[1]
+            out.append(f"{version}{suffix}")
+            changed = True
+        else:
+            out.append(line)
+    if not changed:
+        out.append(version)
+    path.write_text("\n".join(out) + "\n", encoding="utf-8")
+
+
+def cmd_bump(args: argparse.Namespace) -> int:
+    version = app_config.normalize_named(args.version or "", "version")
+    if not version:
+        print("ERROR: version must not be empty. Use version=<chart-version>.", file=sys.stderr)
+        return 2
+    config = load(args.app, "staging", args.config)
+    _old, pin = resolve_pin(config)
+    if str(pin).startswith("<"):
+        print("ERROR: app uses inline SUGARKUBE_VERSION; cannot bump a pin file.", file=sys.stderr)
+        return 2
+    shown = helm_show(config["SUGARKUBE_CHART"], version)
+    if shown.returncode != 0:
+        sys.stderr.write(shown.stderr)
+        return shown.returncode or 1
+    path = pin if pin.is_absolute() else REPO_ROOT / pin
+    rewrite_pin(path, version)
+    diff = run(["git", "diff", "--", str(pin)])
+    print(diff.stdout, end="")
+    print("Next steps:")
+    print(f"git add {pin}")
+    print(f"git commit -m \"Bump {config['SUGARKUBE_APP']} chart pin to {version}\"")
+    print("git push")
+    print(f"just app-deploy app={config['SUGARKUBE_APP']} env=staging tag=<APP_TAG>")
+    return 0
+
+
+def cmd_preflight(args: argparse.Namespace) -> int:
+    config = load(args.app, args.env, args.config)
+    version, pin = resolve_pin(config)
+    print_preflight(config, args.tag, version, pin)
+    shown = helm_show(config["SUGARKUBE_CHART"], version)
+    if shown.returncode != 0:
+        sys.stderr.write(shown.stderr)
+        return shown.returncode or 1
+    if (
+        config["SUGARKUBE_APP"] != "tokenplace"
+        or config["SUGARKUBE_ENV"] not in {"staging", "prod"}
+    ):
+        return 0
+    cmd = [
+        "helm",
+        "template",
+        config["SUGARKUBE_RELEASE"],
+        config["SUGARKUBE_CHART"],
+        "--namespace",
+        config["SUGARKUBE_NAMESPACE"],
+        "--version",
+        version,
+    ]
+    for value in config["SUGARKUBE_VALUES"].split(","):
+        if value.strip():
+            cmd.extend(["-f", value.strip()])
+    cmd.extend(["--set", f"image.tag={args.tag}"])
+    templated = run(cmd)
+    if templated.returncode != 0:
+        sys.stderr.write(templated.stderr)
+        return templated.returncode or 1
+    missing = [name for name in TOKENPLACE_REQUIRED_ENV if name not in templated.stdout]
+    if missing:
+        print(
+            "ERROR: token.place rendered manifest is missing required metadata env vars: "
+            + ", ".join(missing),
+            file=sys.stderr,
+        )
+        print(f"Pinned chart version: {version} ({pin})", file=sys.stderr)
+        print("Run: just app-chart-status app=tokenplace", file=sys.stderr)
+        print(
+            "Then bump intentionally, for example: "
+            "just app-chart-bump app=tokenplace version=<published-version>",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    status = sub.add_parser("status")
+    status.add_argument("--app", required=True)
+    status.add_argument("--config", default="")
+    bump = sub.add_parser("bump")
+    bump.add_argument("--app", required=True)
+    bump.add_argument("--version", required=True)
+    bump.add_argument("--config", default="")
+    pre = sub.add_parser("preflight")
+    pre.add_argument("--app", required=True)
+    pre.add_argument("--env", required=True)
+    pre.add_argument("--tag", required=True)
+    pre.add_argument("--config", default="")
+    args = parser.parse_args(argv)
+    funcs = {"status": cmd_status, "bump": cmd_bump, "preflight": cmd_preflight}
+    return funcs[args.command](args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -87,13 +87,38 @@ exit 0
         bin_dir / "helm",
         f"""#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\n' "$*" >> {str(log_path)!r}
+printf '%s
+' "$*" >> {str(log_path)!r}
+if [[ "$*" == *"show chart"* ]]; then
+  if [ "${{SUGARKUBE_STUB_HELM_SHOW_FAIL:-}}" = "1" ]; then
+    echo 'Error: chart not found' >&2
+    exit 1
+  fi
+  printf 'apiVersion: v2\n'
+  printf 'name: tokenplace\n'
+  printf 'version: 0.1.3\n'
+  printf 'appVersion: 0.1.3\n'
+  printf 'digest: sha256:abc123\n'
+  exit 0
+fi
+if [[ "$*" == *"template"* ]]; then
+  if [ "${{SUGARKUBE_STUB_HELM_TEMPLATE_MISSING_TOKENPLACE_ENV:-}}" = "1" ]; then
+    printf 'apiVersion: apps/v1\nkind: Deployment\n'
+  else
+    printf 'env:\n'
+    printf -- '- name: TOKENPLACE_IMAGE_TAG\n'
+    printf -- '- name: TOKENPLACE_RELEASE_VERSION\n'
+    printf -- '- name: TOKENPLACE_CHART_VERSION\n'
+    printf -- '- name: TOKENPLACE_DEPLOY_ENV\n'
+  fi
+  exit 0
+fi
 if [[ "$*" == *"get values"* ]]; then
   if [ "${{SUGARKUBE_STUB_HELM_GET_VALUES_FAIL:-}}" = "1" ]; then
     echo 'Error: Kubernetes cluster unreachable for context sugar-staging' >&2
     exit 1
   fi
-  printf '{{"ingress":{{"host":"%s"}}}}\n' "${{SUGARKUBE_STUB_HELM_HOST:-example.test}}"
+  printf '{{{{"ingress":{{{{"host":"%s"}}}}}}}}\n' "${{SUGARKUBE_STUB_HELM_HOST:-example.test}}"
   exit 0
 fi
 if [[ "$*" == *" status "* ]]; then
@@ -163,6 +188,148 @@ def _run_just(args: list[str], env: dict[str, str]) -> subprocess.CompletedProce
         text=True,
         check=False,
     )
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_chart_recipes_exist(generic_app_stub_env: dict[str, str]) -> None:
+    result = _run_just(["--list"], generic_app_stub_env)
+
+    assert result.returncode == 0, result.stderr
+    assert "app-chart-status" in result.stdout
+    assert "app-chart-bump" in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_deploy_prints_and_uses_pinned_chart_without_latest(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_APP_CHART_LATEST"] = "9.9.9"
+
+    result = _run_just(["app-deploy", "app=tokenplace", "env=staging", "tag=main-deadbee"], env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "app: tokenplace" in result.stdout
+    assert "image tag: main-deadbee" in result.stdout
+    assert "chart ref: oci://ghcr.io/futuroptimist/charts/tokenplace" in result.stdout
+    assert "chart version: 0.1.3" in result.stdout
+    assert "chart pin: docs/apps/tokenplace.version" in result.stdout
+    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "--version 0.1.3" in helm_log
+    assert "9.9.9" not in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_chart_status_reports_stale_pin(generic_app_stub_env: dict[str, str]) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_APP_CHART_LATEST"] = "0.1.4"
+
+    result = _run_just(["app-chart-status", "app=tokenplace"], env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "pinned version: 0.1.3" in result.stdout
+    assert "chart ref: oci://ghcr.io/futuroptimist/charts/tokenplace" in result.stdout
+    assert "chart appVersion: 0.1.3" in result.stdout
+    assert "WARNING: Pinned chart appears stale: 0.1.3 < 0.1.4" in result.stdout
+    assert "Run: just app-chart-bump app=tokenplace version=0.1.4" in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_chart_bump_refuses_empty_version(generic_app_stub_env: dict[str, str]) -> None:
+    result = _run_just(["app-chart-bump", "app=tokenplace", "version="], generic_app_stub_env)
+
+    assert result.returncode != 0
+    assert "version must not be empty" in result.stderr
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_chart_bump_validates_chart(generic_app_stub_env: dict[str, str]) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_HELM_SHOW_FAIL"] = "1"
+
+    result = _run_just(["app-chart-bump", "app=tokenplace", "version=0.1.3"], env)
+
+    assert result.returncode != 0
+    assert "chart not found" in result.stderr
+
+
+def test_app_chart_bump_updates_only_version_file_in_temp_fixture(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    pin = tmp_path / "tokenplace.version"
+    pin.write_text(
+        "# Default tokenplace chart version. Update when new chart releases are published.\n"
+        "0.1.0  # keep this comment\n",
+        encoding="utf-8",
+    )
+    config = tmp_path / "tokenplace.env"
+    staging_values = (
+        "docs/examples/tokenplace.values.dev.yaml,"
+        "docs/examples/tokenplace.values.staging.yaml"
+    )
+    prod_values = (
+        "docs/examples/tokenplace.values.dev.yaml,"
+        "docs/examples/tokenplace.values.prod.yaml"
+    )
+    config.write_text(
+        f"""SUGARKUBE_APP=tokenplace
+SUGARKUBE_RELEASE=tokenplace
+SUGARKUBE_NAMESPACE=tokenplace
+SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/tokenplace
+SUGARKUBE_VERSION_FILE={pin}
+SUGARKUBE_VALUES_DEV=docs/examples/tokenplace.values.dev.yaml
+SUGARKUBE_VALUES_STAGING={staging_values}
+SUGARKUBE_VALUES_PROD={prod_values}
+""",
+        encoding="utf-8",
+    )
+
+    before = {path: path.read_text(encoding="utf-8") for path in (pin, config)}
+    result = _run_just(
+        ["app-chart-bump", "app=tokenplace", "version=0.1.3", f"config={config}"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert pin.read_text(encoding="utf-8").splitlines() == [
+        "# Default tokenplace chart version. Update when new chart releases are published.",
+        "0.1.3  # keep this comment",
+    ]
+    assert config.read_text(encoding="utf-8") == before[config]
+    assert "git add" in result.stdout
+    assert "just app-deploy app=tokenplace env=staging tag=<APP_TAG>" in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_tokenplace_preflight_fails_when_metadata_env_missing(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_HELM_TEMPLATE_MISSING_TOKENPLACE_ENV"] = "1"
+
+    result = _run_just(["app-deploy", "app=tokenplace", "env=staging", "tag=main-deadbee"], env)
+
+    assert result.returncode != 0
+    assert "missing required metadata env vars" in result.stderr
+    assert "TOKENPLACE_IMAGE_TAG" in result.stderr
+    assert "TOKENPLACE_RELEASE_VERSION" in result.stderr
+    assert "TOKENPLACE_CHART_VERSION" in result.stderr
+    assert "TOKENPLACE_DEPLOY_ENV" in result.stderr
+    assert "just app-chart-status app=tokenplace" in result.stderr
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_tokenplace_preflight_passes_when_metadata_env_present(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        ["app-deploy", "app=tokenplace", "env=staging", "tag=main-deadbee"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace" in helm_log
 
 
 @pytest.mark.usefixtures("ensure_just_available")


### PR DESCRIPTION
### Motivation

- Prevent deploying a new image tag against an old pinned Helm chart (the token.place incident) by detecting stale chart pins and making bumps explicit. 
- Preserve reproducible, pinned chart coordinates so `just app-deploy` does not silently chase latest charts. 
- Provide actionable operator workflows (inspect -> validate -> bump -> commit -> deploy) and catch mismatched chart+image combinations before Helm upgrades.

### Description

- Add `scripts/app_chart.py` implementing `status`, `bump`, and `preflight` subcommands to inspect `docs/apps/<app>.version`, run `helm show chart`, detect a best-effort latest for GHCR OCI charts, validate a bump via `helm show chart`, and render token.place manifests for preflight checks. 
- Add `just` recipes `app-chart-status` and `app-chart-bump`, and wire a preflight call into `app-deploy`, `app-redeploy`, and token.place OCI compatibility wrappers so deploys print app/env/image/chart/chart-pin and fail early on missing token.place metadata. 
- Token.place-specific guardrails: render the pinned chart with the selected image tag and fail staging/prod deploys if any of `TOKENPLACE_IMAGE_TAG`, `TOKENPLACE_RELEASE_VERSION`, `TOKENPLACE_CHART_VERSION`, `TOKENPLACE_DEPLOY_ENV` are missing. 
- Docs updated: `docs/apps/tokenplace.md`, `docs/app_deployment_contract.md`, and `docs/app_onboarding.md` to document the explicit chart status/bump workflow and metadata checks. 
- Tests extended/added in `tests/test_generic_app_just_recipes.py` to cover recipe existence, pinned deploy behavior (no latest chasing), status stale warnings, bump validation and file update, and token.place preflight failure/pass cases.

### Testing

- Ran `python -m pytest tests/test_generic_app_just_recipes.py -v` and `-q`; result: all tests in that suite passed (`40 passed`).
- Verified new recipes appear in `just --list`; result: shows `app-chart-status` and `app-chart-bump` (pass).
- Byte-compile check `python -m py_compile scripts/app_chart.py scripts/app_config.py scripts/app_verify.py`; result: pass.
- Secrets scan and staged diff checks (`git diff -- ... | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py`); result: pass.
- Link check `linkchecker --no-warnings README.md docs/`; result: pass.
- Repo style check `bash scripts/checks.sh`; result: reported pre-existing pycodestyle line-length/whitespace issues outside this change (known repo-wide issues), changed files do not introduce new pycodestyle failures (warning noted). 
- Spelling check `pyspelling -c .spellcheck.yaml` could not run in this environment because `aspell` is not installed (environment limitation).

Residual notes and risks:
- `detect_latest` is best-effort and currently targets GHCR OCI via `gh api`; network connectivity and `gh` availability (or auth) affect latest-version detection and will print a clear "latest unknown" hint when unavailable. 
- `app-chart-bump` validates pins with `helm show chart` and `app-deploy`/`preflight` uses `helm template`/`helm show chart`, so a local `helm` binary (or CI stubs) is required for runtime checks; tests stub these commands.
- The change intentionally does not auto-upgrade pinned charts or commit bumps; operators must run `just app-chart-bump`, review the diff and commit the pin bump before deploying to production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e6ae3c54c832f86a111afc8ab5b35)