### PR TITLE
Add app-chart-status/app-chart-bump, deploy preflight guardrails, and token.place manifest checks

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -163,7 +163,14 @@ These recipes are implemented in the root `justfile` and use the app config
 lookup order above.
 
 ```bash
-# Deploy or install a specific immutable candidate into an environment.
+# Inspect the committed chart pin and best-effort published chart freshness.
+just app-chart-status app=dspace
+
+# Explicitly bump the committed chart pin after the app repo publishes a chart.
+just app-chart-bump app=dspace version=0.1.3
+
+# Deploy or install a specific immutable image candidate into an environment.
+# This uses docs/apps/<app>.version and never auto-selects the latest chart.
 just app-deploy app=dspace env=staging tag=main-REPLACE_SHORTSHA
 
 # Redeploy an existing release with a specific immutable tag.
@@ -194,6 +201,30 @@ onboarding, but thinning the remaining deploy/redeploy wrappers is deferred to a
 follow-up PR. Production promotion wrappers such as
 `just tokenplace-oci-promote-prod tag=main-REPLACE_SHORTSHA` remain documented as
 thin generic shims over the shared production promotion flow.
+
+
+## Chart pin contract
+
+Every app deploy has two independent coordinates: the immutable image tag passed
+as `tag=...` and the Helm chart version pinned by `docs/apps/<app>.version` (or
+`SUGARKUBE_VERSION`). Deploy recipes print the app, environment, image tag, chart
+ref, chart version, and chart pin path before Helm runs. They intentionally do
+not discover or use the latest chart by default, because a committed chart pin is
+part of the reproducible deployment contract.
+
+Use `just app-chart-status app=<app>` before deployment to verify the pinned
+chart exists and to get a best-effort stale-pin warning for OCI/GHCR charts. If
+the app repository publishes a new chart, run `just app-chart-bump app=<app>
+version=<published-version>`, review the single-file diff to
+`docs/apps/<app>.version`, then commit and push that bump before or alongside the
+release operation. Do not use `chart=latest` or silent chart auto-upgrade
+behavior for production.
+
+The shared deploy preflight can also run app-specific rendered-manifest guards.
+For token.place, staging/prod manifests must include `TOKENPLACE_IMAGE_TAG`,
+`TOKENPLACE_RELEASE_VERSION`, `TOKENPLACE_CHART_VERSION`, and
+`TOKENPLACE_DEPLOY_ENV`; missing metadata env vars fail before Helm upgrade and
+point operators to `app-chart-status` and `app-chart-bump`.
 
 ## Current example configs
 

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -86,6 +86,8 @@ The app repo's chart and `ci-helm.yml` should answer yes to each item before Sug
 - `ci-helm.yml` publishes `oci://ghcr.io/OWNER/charts/CHART`.
 - Published chart versions are immutable; never republish different content under an existing version.
 - Sugarkube pins the deployed chart version in `docs/apps/APP.version`.
+- `just app-deploy tag=...` updates the image coordinate only; it must not silently select the newest chart.
+- Operators inspect chart freshness with `just app-chart-status app=APP` and bump intentionally with `just app-chart-bump app=APP version=X.Y.Z`.
 
 ## Environment overlay checklist
 
@@ -143,13 +145,14 @@ just app-deploy app=appslug env=staging tag="$APP_TAG" config="$APP_CONFIG"
 - Update `appVersion` when the human-facing app version changed.
 - Publish the new OCI chart once.
 - Update Sugarkube's `docs/apps/APP.version` to the new chart version after publication.
+- Commit the chart pin bump before or with release operations; do not rely on `chart=latest` or unreviewed production chart upgrades.
 
 ```bash
-CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/appslug.version | head -n 1)
+just app-chart-status app=appslug
 ```
 
 ```bash
-helm show chart oci://ghcr.io/OWNER/charts/CHART --version "$CHART_VERSION"
+just app-chart-bump app=appslug version=0.1.3
 ```
 
 ### Staging works; how do I promote prod?

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -68,15 +68,23 @@ gh workflow run ci-image.yml --repo futuroptimist/token.place --ref main
 
 ## Confirm/publish OCI chart
 
-Sugarkube deploys the chart version pinned in `docs/apps/tokenplace.version`. Use [recent chart workflow runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml) to find chart publish attempts, [GHCR chart package versions](https://github.com/futuroptimist/token.place/pkgs/container/charts%2Ftokenplace) to confirm available immutable chart versions, and [the chart source](https://github.com/futuroptimist/token.place/tree/main/charts/tokenplace) to review the chart content that should match the pinned version.
+Sugarkube deploys the chart version pinned in `docs/apps/tokenplace.version`. The image tag and chart version are separate release coordinates: `just app-deploy tag=...` changes the container image only and never silently bumps or chases the newest Helm chart. Use [recent chart workflow runs](https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml) to find chart publish attempts, [GHCR chart package versions](https://github.com/futuroptimist/token.place/pkgs/container/charts%2Ftokenplace) to confirm available immutable chart versions, and [the chart source](https://github.com/futuroptimist/token.place/tree/main/charts/tokenplace) to review the chart content that should match the pinned version.
+
+Before deploying, inspect the current pin and whether a newer semver chart appears to be published:
 
 ```bash
-CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.version | head -n 1)
+just app-chart-status app=tokenplace
 ```
 
+When token.place publishes a new chart that the next image requires, explicitly bump and commit the Sugarkube pin before or with release operations:
+
 ```bash
-helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version "$CHART_VERSION"
+just app-chart-bump app=tokenplace version=0.1.3
+git add docs/apps/tokenplace.version
+git commit -m "Bump tokenplace chart pin to 0.1.3"
 ```
+
+Do not use `chart=latest` or any silent auto-upgrade pattern for production; production deploys should use a reviewed, committed chart pin.
 
 If the chart changed, bump the chart version in the token.place app repo and publish it there with [the chart workflow](https://github.com/futuroptimist/token.place/actions/workflows/ci-helm.yml); do not republish a different chart under an existing OCI version.
 
@@ -112,6 +120,12 @@ just app-verify app=tokenplace env=staging
 
 ```bash
 just app-verify app=tokenplace env=staging print_only=1
+```
+
+Token.place also requires metadata verification after staging deploys. The label should include the deployed image tag, for example `staging main-00797df`; fail or warn loudly if `.label` ends with ` dev` or `.version == "dev"`.
+
+```bash
+curl -fsS https://staging.token.place/api/v1/meta | jq .
 ```
 
 Optional manual fallback:
@@ -160,6 +174,12 @@ just app-status app=tokenplace env=prod
 
 ```bash
 just app-verify app=tokenplace env=prod
+```
+
+Production metadata must report a finalized release label such as `prod 0.1.1`; fail or warn loudly if `.version == "dev"`.
+
+```bash
+curl -fsS https://token.place/api/v1/meta | jq .
 ```
 
 Print the generated curl commands without executing them when you need a manual fallback:

--- a/justfile
+++ b/justfile
@@ -1528,6 +1528,16 @@ app-config app env='staging' config='':
       --env {{ quote(env) }} \
       --config {{ quote(config) }}
 
+app-chart-status app:
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" status --app {{ quote(app) }}
+
+app-chart-bump app version='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" bump --app {{ quote(app) }} --version {{ quote(version) }}
+
 # Generic immutable-tag app deploy backed by docs/examples/apps/*.env or local app configs.
 app-deploy app env='staging' tag='' config='':
     #!/usr/bin/env bash
@@ -1542,6 +1552,10 @@ app-deploy app env='staging' tag='' config='':
 
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight \
+      --app "${SUGARKUBE_APP}" \
+      --env "${SUGARKUBE_ENV}" \
+      --tag "${SUGARKUBE_TAG}"
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release="${SUGARKUBE_RELEASE}" \
       namespace="${SUGARKUBE_NAMESPACE}" \
@@ -1565,6 +1579,10 @@ app-redeploy app env='staging' tag='' config='':
 
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight \
+      --app "${SUGARKUBE_APP}" \
+      --env "${SUGARKUBE_ENV}" \
+      --tag "${SUGARKUBE_TAG}"
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release="${SUGARKUBE_RELEASE}" \
       namespace="${SUGARKUBE_NAMESPACE}" \
@@ -1983,6 +2001,10 @@ tokenplace-oci-deploy env='staging' tag='':
     # This is tokenplace-scoped; do not copy into DSPACE from this PR.
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight \
+      --app tokenplace \
+      --env "${env_name}" \
+      --tag "${resolved_tag}"
     echo "Deploying tokenplace env=${env_name} chart=oci://ghcr.io/futuroptimist/charts/tokenplace version=${chart_version} image=ghcr.io/futuroptimist/tokenplace-relay:${resolved_tag}"
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
@@ -2078,6 +2100,10 @@ tokenplace-oci-redeploy env='staging' tag='':
     # This is tokenplace-scoped; do not copy into DSPACE from this PR.
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+    python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight \
+      --app tokenplace \
+      --env "${env_name}" \
+      --tag "${resolved_tag}"
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release='tokenplace' namespace='tokenplace' \

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Inspect and bump pinned Sugarkube app Helm chart versions."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.app_config import AppConfigError, load_config, normalize_env, normalize_named
+
+SEMVER = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$")
+REQUIRED = {
+    "tokenplace": [
+        "TOKENPLACE_IMAGE_TAG",
+        "TOKENPLACE_RELEASE_VERSION",
+        "TOKENPLACE_CHART_VERSION",
+        "TOKENPLACE_DEPLOY_ENV",
+    ]
+}
+
+
+def root():
+    return Path(os.environ.get("SUGARKUBE_REPO_ROOT", Path(__file__).resolve().parents[1]))
+
+
+def pin_version(path: Path):
+    for line in path.read_text().splitlines():
+        s = line.split("#", 1)[0].strip()
+        if s:
+            return s
+    raise SystemExit(f"ERROR: chart pin file {path} has no version")
+
+
+def cfg(app, env="staging"):
+    return load_config(app, env, None)
+
+
+def pin_path(c):
+    p = Path(c.get("SUGARKUBE_VERSION_FILE", ""))
+    return p if p.is_absolute() else root() / p
+
+
+def rel(p):
+    try:
+        return str(p.relative_to(root()))
+    except ValueError:
+        return str(p)
+
+
+def helm_show(chart, version):
+    r = subprocess.run(
+        ["helm", "show", "chart", chart, "--version", version],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if r.returncode:
+        raise RuntimeError(r.stderr or r.stdout)
+    return r.stdout
+
+
+def parse_show(out):
+    data = {}
+    for line in out.splitlines():
+        if ":" not in line or line[:1].isspace():
+            continue
+        key, value = line.split(":", 1)
+        data[key.strip()] = value.strip().strip("\"'")
+    return data
+
+
+def latest(chart):
+    env = os.environ.get("SUGARKUBE_APP_CHART_LATEST")
+    if env:
+        return env
+    if not chart.startswith("oci://ghcr.io/"):
+        return ""
+    pkg = chart.removeprefix("oci://ghcr.io/")
+    if "/charts/" in pkg:
+        owner, name = pkg.split("/charts/", 1)
+        package = f"charts%2F{name}"
+    else:
+        return ""
+    url = f"https://api.github.com/users/{owner}/packages/container/{package}/versions?per_page=100"
+    r = subprocess.run(["curl", "-fsS", url], text=True, capture_output=True, check=False)
+    if r.returncode:
+        return ""
+    import json
+
+    try:
+        arr = json.loads(r.stdout)
+    except Exception:
+        return ""
+    versions = []
+    for item in arr:
+        for tag in item.get("metadata", {}).get("container", {}).get("tags", []) or []:
+            if SEMVER.match(tag):
+                versions.append(tag.lstrip("v"))
+    return (
+        max(versions, key=lambda v: tuple(map(int, SEMVER.match(v).groups()))) if versions else ""
+    )
+
+
+def status(args):
+    args.app = normalize_named(args.app, "app")
+    c = cfg(args.app)
+    chart = c["SUGARKUBE_CHART"]
+    pp = pin_path(c)
+    ver = pin_version(pp)
+    out = helm_show(chart, ver)
+    data = parse_show(out)
+    lat = latest(chart)
+    print(
+        f"app: {args.app}\nchart ref: {chart}\npinned version: {ver}\nchart appVersion: {data.get('appVersion','unknown')}\nchart digest: {data.get('digest','unknown')}\npin file: {rel(pp)}"
+    )
+    if lat:
+        print(f"latest version: {lat}")
+        if tuple(map(int, SEMVER.match(ver).groups())) < tuple(
+            map(int, SEMVER.match(lat).groups())
+        ):
+            print(f"WARNING: Pinned chart appears stale: {ver} < {lat}")
+            print(f"Run: just app-chart-bump app={args.app} version={lat}")
+    else:
+        print("latest unknown: unable to query published chart versions automatically.")
+        print(f"Manual: helm show chart {chart} --version <version>")
+
+
+def bump(args):
+    args.app = normalize_named(args.app, "app")
+    version = normalize_named(args.version or "", "version")
+    if not version:
+        raise SystemExit("ERROR: version must not be empty")
+    c = cfg(args.app)
+    chart = c["SUGARKUBE_CHART"]
+    pp = pin_path(c)
+    helm_show(chart, version)
+    lines = pp.read_text().splitlines()
+    done = False
+    new = []
+    for line in lines:
+        if not done and line.split("#", 1)[0].strip():
+            suffix = (" #" + line.split("#", 1)[1]) if "#" in line else ""
+            new.append(version + suffix)
+            done = True
+        else:
+            new.append(line)
+    if not done:
+        new.append(version)
+    pp.write_text("\n".join(new) + "\n")
+    subprocess.run(["git", "diff", "--", rel(pp)], cwd=root(), check=False)
+    print("\nNext steps:")
+    print(f"git add {rel(pp)}")
+    print(f'git commit -m "Bump {args.app} chart pin to {version}"')
+    print("git push")
+    print(f"just app-deploy app={args.app} env=staging tag=<APP_TAG>")
+
+
+def preflight(args):
+    args.app = normalize_named(args.app, "app")
+    args.env = normalize_env(args.env)
+    args.tag = normalize_named(args.tag, "tag")
+    c = cfg(args.app, args.env)
+    chart = c["SUGARKUBE_CHART"]
+    pp = pin_path(c)
+    ver = pin_version(pp)
+    tag = args.tag
+    print(
+        f"app: {args.app}\nenv: {args.env}\nimage tag: {tag}\nchart ref: {chart}\nchart version: {ver}\nchart pin: {rel(pp)}"
+    )
+    helm_show(chart, ver)
+    req = REQUIRED.get(args.app, [])
+    if req and args.env in {"staging", "prod"}:
+        cmd = [
+            "helm",
+            "template",
+            c["SUGARKUBE_RELEASE"],
+            chart,
+            "--namespace",
+            c["SUGARKUBE_NAMESPACE"],
+            "--version",
+            ver,
+            "--set",
+            f"image.tag={tag}",
+        ]
+        for vf in c["SUGARKUBE_VALUES"].split(","):
+            cmd += ["-f", vf.strip()]
+        r = subprocess.run(cmd, text=True, capture_output=True, check=False)
+        if r.returncode:
+            raise RuntimeError(r.stderr or r.stdout)
+        missing = [x for x in req if x not in r.stdout]
+        if missing:
+            raise SystemExit(
+                "ERROR: rendered token.place manifest is missing required env vars: "
+                + ", ".join(missing)
+                + f"\nPinned chart version: {ver}\nRun: just app-chart-status app={args.app}\nRun: just app-chart-bump app={args.app} version=<published-version>"
+            )
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser()
+    sub = p.add_subparsers(dest="cmd", required=True)
+    for n in ("status", "bump", "preflight"):
+        s = sub.add_parser(n)
+        s.add_argument("--app", required=True)
+    sub.choices["bump"].add_argument("--version", required=True)
+    sub.choices["preflight"].add_argument("--env", required=True)
+    sub.choices["preflight"].add_argument("--tag", required=True)
+    a = p.parse_args(argv)
+    try:
+        globals()[a.cmd](a)
+        return 0
+    except (AppConfigError, RuntimeError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -88,6 +88,18 @@ exit 0
         f"""#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> {str(log_path)!r}
+if [[ "$*" == *"show chart"* ]]; then
+  printf 'apiVersion: v2\nname: tokenplace\nversion: %s\nappVersion: %s\ndigest: sha256:stub\n' "${{SUGARKUBE_STUB_HELM_CHART_VERSION:-0.1.0}}" "${{SUGARKUBE_STUB_HELM_APP_VERSION:-main-deadbee}}"
+  exit 0
+fi
+if [[ "$*" == *"template"* ]]; then
+  if [ "${{SUGARKUBE_STUB_HELM_TEMPLATE_MISSING_ENVS:-}}" = "1" ]; then
+    printf 'kind: Deployment\nmetadata:\n  name: tokenplace\n'
+  else
+    printf 'env:\n- name: TOKENPLACE_IMAGE_TAG\n- name: TOKENPLACE_RELEASE_VERSION\n- name: TOKENPLACE_CHART_VERSION\n- name: TOKENPLACE_DEPLOY_ENV\n'
+  fi
+  exit 0
+fi
 if [[ "$*" == *"get values"* ]]; then
   if [ "${{SUGARKUBE_STUB_HELM_GET_VALUES_FAIL:-}}" = "1" ]; then
     echo 'Error: Kubernetes cluster unreachable for context sugar-staging' >&2
@@ -564,3 +576,155 @@ def test_app_verify_fails_closed_when_context_host_discovery_fails(
     assert "kubectl ingress lookup failed for context sugar-staging" in result.stderr
     assert "Suggested next steps: just app-status app=tokenplace env=staging" in result.stderr
     assert "curl -fsS https://<host>/" in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_chart_recipes_are_listed(generic_app_stub_env: dict[str, str]) -> None:
+    result = _run_just(["--list"], generic_app_stub_env)
+    assert result.returncode == 0
+    assert "app-chart-status" in result.stdout
+    assert "app-chart-bump" in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_deploy_prints_and_uses_pinned_chart_without_latest(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_APP_CHART_LATEST"] = "9.9.9"
+    result = _run_just(["app-deploy", "app=tokenplace", "env=staging", "tag=main-deadbee"], env)
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "app: tokenplace" in result.stdout
+    assert "env: staging" in result.stdout
+    assert "image tag: main-deadbee" in result.stdout
+    assert "chart ref: oci://ghcr.io/futuroptimist/charts/tokenplace" in result.stdout
+    assert "chart pin: docs/apps/tokenplace.version" in result.stdout
+    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
+    pinned = "0.1.3"
+    assert f"--version {pinned}" in helm_log
+    assert "9.9.9" not in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_chart_status_reports_pin_and_stale_warning(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_APP_CHART_LATEST"] = "9.9.9"
+    result = _run_just(["app-chart-status", "app=tokenplace"], env)
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "app: tokenplace" in result.stdout
+    assert "chart ref: oci://ghcr.io/futuroptimist/charts/tokenplace" in result.stdout
+    assert "pinned version:" in result.stdout
+    assert "chart appVersion: main-deadbee" in result.stdout
+    assert "Pinned chart appears stale" in result.stdout
+    assert "Run: just app-chart-bump app=tokenplace version=9.9.9" in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_chart_bump_refuses_empty_version(generic_app_stub_env: dict[str, str]) -> None:
+    result = _run_just(["app-chart-bump", "app=tokenplace", "version="], generic_app_stub_env)
+    assert result.returncode != 0
+    assert "version must not be empty" in result.stderr
+
+
+def test_app_chart_bump_updates_only_pin_file_in_temp_fixture(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    fixture = tmp_path / "repo"
+    (fixture / "docs/apps").mkdir(parents=True)
+    (fixture / "docs/examples/apps").mkdir(parents=True)
+    (fixture / "docs/examples").mkdir(parents=True, exist_ok=True)
+    (fixture / "scripts").mkdir()
+    for rel in [
+        "scripts/app_chart.py",
+        "scripts/app_config.py",
+        "docs/examples/apps/tokenplace.env",
+    ]:
+        src = REPO_ROOT / rel
+        dst = fixture / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+    (fixture / "docs/apps/tokenplace.version").write_text(
+        "0.1.0 # keep comment\n", encoding="utf-8"
+    )
+    for rel in [
+        "docs/examples/tokenplace.values.dev.yaml",
+        "docs/examples/tokenplace.values.staging.yaml",
+    ]:
+        (fixture / rel).write_text("{}\n", encoding="utf-8")
+    subprocess.run(["git", "init"], cwd=fixture, check=True, capture_output=True)
+    subprocess.run(["git", "add", "."], cwd=fixture, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "init"],
+        cwd=fixture,
+        check=True,
+        capture_output=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@example.com",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@example.com",
+        },
+    )
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_REPO_ROOT"] = str(fixture)
+    env["PYTHONPATH"] = str(fixture)
+    result = subprocess.run(
+        ["python3", "scripts/app_chart.py", "bump", "--app", "tokenplace", "--version", "0.1.3"],
+        cwd=fixture,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert (fixture / "docs/apps/tokenplace.version").read_text(
+        encoding="utf-8"
+    ) == "0.1.3 # keep comment\n"
+    changed = subprocess.run(
+        ["git", "diff", "--name-only"], cwd=fixture, capture_output=True, text=True, check=True
+    ).stdout.splitlines()
+    assert changed == ["docs/apps/tokenplace.version"]
+    assert "show chart" in (Path(env["HELM_LOG"]).read_text(encoding="utf-8"))
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_tokenplace_deploy_preflight_fails_when_metadata_env_missing(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_HELM_TEMPLATE_MISSING_ENVS"] = "1"
+    result = _run_just(["app-deploy", "app=tokenplace", "env=staging", "tag=main-deadbee"], env)
+    assert result.returncode != 0
+    assert "missing required env vars" in result.stderr
+    assert "TOKENPLACE_IMAGE_TAG" in result.stderr
+    assert "TOKENPLACE_DEPLOY_ENV" in result.stderr
+    assert "just app-chart-status app=tokenplace" in result.stderr
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_tokenplace_deploy_preflight_passes_when_metadata_env_present(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        ["app-deploy", "app=tokenplace", "env=staging", "tag=main-deadbee"], generic_app_stub_env
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "template tokenplace" in helm_log
+    assert "upgrade tokenplace" in helm_log
+
+
+def test_docs_mention_chart_status_and_bump_flow() -> None:
+    combined = "\n".join(
+        (REPO_ROOT / path).read_text(encoding="utf-8")
+        for path in [
+            "docs/apps/tokenplace.md",
+            "docs/app_deployment_contract.md",
+            "docs/app_onboarding.md",
+        ]
+    )
+    assert "app-chart-status" in combined
+    assert "app-chart-bump" in combined
+    assert "does not" in combined and "bump" in combined and "chart" in combined


### PR DESCRIPTION
### Motivation

- Prevent silent mismatches where `just app-deploy tag=...` changes only the image but runs an old pinned Helm chart, causing runtime/manifest mismatches (the token.place incident). 
- Keep chart versions explicitly pinned and reproducible while making it easy to inspect and intentionally bump them. 

### Description

- Add a new helper `scripts/app_chart.py` that implements `status`, `bump`, and `preflight` operations for pinned OCI Helm charts and token.place-specific rendered-manifest checks. 
- Add `just` recipes `app-chart-status` and `app-chart-bump` and wire a preflight call into generic `app-deploy`/`app-redeploy` plus token.place compatibility wrappers so deploys print pin/chart/tag info and validate the pinned chart before Helm runs. 
- Implement token.place rendered-manifest guardrails that render the pinned chart with the chosen image tag and fail when required metadata env vars (`TOKENPLACE_IMAGE_TAG`, `TOKENPLACE_RELEASE_VERSION`, `TOKENPLACE_CHART_VERSION`, `TOKENPLACE_DEPLOY_ENV`) are missing. 
- Update docs (`docs/apps/tokenplace.md`, `docs/app_deployment_contract.md`, `docs/app_onboarding.md`) to document the separate coordinates (image tag vs chart version), the `app-chart-status`/`app-chart-bump` flow, and post-deploy token.place metadata checks. 
- Add and extend unit tests in `tests/test_generic_app_just_recipes.py` to cover recipe presence, pinned deploy behavior, status/bump flows, preflight guardrails, and docs coverage. 

### Testing

- Ran unit tests with `python -m pytest tests/test_generic_app_just_recipes.py -v`, all tests passed (`40 passed`).
- Verified helper script compiles with `python -m py_compile scripts/app_chart.py` and ran formatting/ordering checks (`isort`/`black`) as used in repo, which completed successfully. 
- Verified `just --list` shows `app-chart-status` and `app-chart-bump`, and used `rg` to confirm updated docs and code references. 
- Note: repo-level checks `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` were not run successfully in this environment because those tools are not installed; their absence is an environment limitation, not a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e6aec3244832fa2dac614803e5cd4)