### PR TITLE
Add generic app CORS verification (just app-cors-verify) and token.place runbook updates

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -174,6 +174,29 @@ curl -fsS https://democratized.space/healthz
 curl -fsS https://democratized.space/livez
 ```
 
+
+## Cross-app token.place browser smoke
+
+DSPACE browser chat depends on token.place API v1 CORS being owned by the token.place application image, not by Sugarkube ingress or Cloudflare header rules. Use this order for staging and production releases that change either side of the integration:
+
+1. Deploy the token.place image containing wildcard API v1 CORS.
+2. Run `just app-verify app=tokenplace env=<staging|prod>`.
+3. Run `just app-cors-verify app=tokenplace env=<staging|prod>`.
+4. Deploy DSPACE with the runtime origin overlay for the same environment.
+5. Confirm DSPACE `/config.json` exposes the expected token.place API v1 URL.
+6. Open `/chat`, send a message, and inspect the browser Network panel.
+
+The browser smoke must verify:
+
+- Staging DSPACE calls `https://staging.token.place/api/v1/chat/completions`.
+- Production DSPACE calls `https://token.place/api/v1/chat/completions`.
+- The browser OPTIONS preflight succeeds.
+- The browser POST succeeds or returns a readable API-owned error.
+- No `Authorization` header is sent.
+- No token.place credentials or cookies are sent.
+- Fetch credentials are omitted.
+- The request body does not include `stream: true`.
+
 ## Rollback
 
 Rollback by deploying the previous known-good immutable image tag with the generic redeploy command.

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -152,6 +152,18 @@ curl -fsS https://staging.token.place/api/v1/meta | jq .
 
 Staging metadata must not report `.version == "dev"` or a `.label` ending in ` dev`; the expected label includes the deployed image tag, for example `staging main-00797df`.
 
+### Browser CORS verification
+
+Verify the public API v1 browser contract after staging HTTP verification:
+
+```bash
+just app-cors-verify app=tokenplace env=staging
+```
+
+The check sends an unrelated `Origin` and expects token.place itself to return a literal `Access-Control-Allow-Origin: *` on both the API v1 preflight and the deliberately invalid API v1 response. Credentialed CORS must remain disabled (`Access-Control-Allow-Credentials` absent or not `true`). API v1 remains zero-auth and non-streaming; this CORS contract applies to public API v1, not API v2.
+
+This check is separate from relay-compute E2EE sign-off and does not replace it. If it fails, deploy a token.place image containing the API-owned CORS fix rather than adding ingress, Traefik, or Cloudflare response-header mutations.
+
 ### Staging relay-compute sign-off
 
 `just app-status`, `just app-verify`, `/livez`, `/healthz`, `/`, and `/relay/diagnostics` are necessary but not sufficient for token.place promotion. Staging-to-prod promotion is blocked until the real relay-compute path passes, as defined in [the token.place Sugarkube onboarding contract](../tokenplace_sugarkube_onboarding.md#promotion-gate-ownership). Before production promotion, capture staging evidence for the real relay path:
@@ -165,6 +177,12 @@ Do not replace this sign-off with synthetic register/poll, web/TLS readiness, he
 ## Promote production
 
 Promote only after staging sign-off proves that a real external desktop or compute node registered with staging and completed a real E2EE request/response through the relay. Prefer the generic command; it uses the prod values chain and can read `docs/apps/tokenplace.prod.tag` when `tag=` is omitted.
+
+Before promotion, confirm the production target will satisfy the same API-owned browser contract once deployed:
+
+```bash
+just app-cors-verify app=tokenplace env=prod print_only=1
+```
 
 ```bash
 just app-promote-prod app=tokenplace tag="$APP_TAG"
@@ -184,6 +202,10 @@ just app-status app=tokenplace env=prod
 
 ```bash
 just app-verify app=tokenplace env=prod
+```
+
+```bash
+just app-cors-verify app=tokenplace env=prod
 ```
 
 Print the generated curl commands without executing them when you need a manual fallback:

--- a/docs/examples/apps/tokenplace.env
+++ b/docs/examples/apps/tokenplace.env
@@ -15,3 +15,8 @@ SUGARKUBE_VALUES_PROD=docs/examples/tokenplace.values.dev.yaml,docs/examples/tok
 SUGARKUBE_STATUS_HOST_KEY=ingress.host
 SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz,/relay/diagnostics,/api/v1/meta
 SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=tokenplace
+SUGARKUBE_CORS_VERIFY_PATH=/api/v1/chat/completions
+SUGARKUBE_CORS_VERIFY_METHOD=POST
+SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS=content-type
+SUGARKUBE_CORS_VERIFY_BODY={}
+SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES=400,429

--- a/justfile
+++ b/justfile
@@ -1692,6 +1692,54 @@ app-verify app env='staging' config='' print_only='':
 
     python3 "{{ justfile_directory() }}/scripts/app_verify.py" "${print_only_args[@]}"
 
+# Verify an app-owned public CORS contract without mutating ingress or edge resources.
+app-cors-verify app env='staging' config='' origin='https://cors-smoke.invalid' print_only='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    config_input={{ quote(config) }}
+    origin_input={{ quote(origin) }}
+    print_only_input={{ quote(print_only) }}
+    if [ "${origin_input#print_only=}" != "${origin_input}" ]; then
+      print_only_input="${origin_input}"
+      origin_input="https://cors-smoke.invalid"
+    fi
+    if [ "${print_only_input#origin=}" != "${print_only_input}" ]; then
+      origin_input="${print_only_input}"
+      print_only_input=""
+    fi
+    if [ "${config_input#print_only=}" != "${config_input}" ]; then
+      print_only_input="${config_input}"
+      config_input=""
+    fi
+    if [ "${config_input#origin=}" != "${config_input}" ]; then
+      origin_input="${config_input}"
+      config_input=""
+    fi
+    while [ "${config_input#config=}" != "${config_input}" ]; do
+      config_input="${config_input#config=}"
+    done
+    while [ "${origin_input#origin=}" != "${origin_input}" ]; do
+      origin_input="${origin_input#origin=}"
+    done
+    while [ "${print_only_input#print_only=}" != "${print_only_input}" ]; do
+      print_only_input="${print_only_input#print_only=}"
+    done
+
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+      --app {{ quote(app) }} \
+      --env {{ quote(env) }} \
+      --config "${config_input}")"
+
+    print_only_args=()
+    if [ "${print_only_input:-${SUGARKUBE_APP_CORS_VERIFY_PRINT_ONLY:-}}" = "1" ]; then
+      print_only_args+=(--print-only)
+    fi
+
+    python3 "{{ justfile_directory() }}/scripts/app_cors_verify.py" \
+      --origin "${origin_input}" \
+      "${print_only_args[@]}"
+
 # Opinionated immutable-tag dspace deploy with rollout verification.
 #
 

--- a/scripts/app_config.py
+++ b/scripts/app_config.py
@@ -39,6 +39,11 @@ ALLOWED_KEYS = {
     "SUGARKUBE_STATUS_HOST_KEY",
     "SUGARKUBE_VERIFY_PATHS",
     "SUGARKUBE_DEBUG_SELECTOR",
+    "SUGARKUBE_CORS_VERIFY_PATH",
+    "SUGARKUBE_CORS_VERIFY_METHOD",
+    "SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS",
+    "SUGARKUBE_CORS_VERIFY_BODY",
+    "SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES",
 }
 REQUIRED_KEYS = {
     "SUGARKUBE_APP",
@@ -78,8 +83,7 @@ def validate_app_name(app: str) -> str:
     app = normalize_named(app, "app")
     if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", app or ""):
         raise AppConfigError(
-            "app must be a non-empty name using letters, numbers, dots, underscores, "
-            "or dashes."
+            "app must be a non-empty name using letters, numbers, dots, underscores, " "or dashes."
         )
     return app
 
@@ -216,6 +220,11 @@ def shell_emit(config: dict[str, str]) -> str:
         "SUGARKUBE_STATUS_HOST_KEY",
         "SUGARKUBE_VERIFY_PATHS",
         "SUGARKUBE_DEBUG_SELECTOR",
+        "SUGARKUBE_CORS_VERIFY_PATH",
+        "SUGARKUBE_CORS_VERIFY_METHOD",
+        "SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS",
+        "SUGARKUBE_CORS_VERIFY_BODY",
+        "SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES",
         "SUGARKUBE_CONFIG_PATH",
         "SUGARKUBE_TAG",
     ]

--- a/scripts/app_cors_verify.py
+++ b/scripts/app_cors_verify.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Verify an app-owned public CORS contract for a Sugarkube app."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    from app_verify import base_url_from_host, discover_host, env_flag, int_env, normalize_path
+except ModuleNotFoundError:  # pragma: no cover - package import path used by pytest
+    from scripts.app_verify import (
+        base_url_from_host,
+        discover_host,
+        env_flag,
+        int_env,
+        normalize_path,
+    )
+
+DEFAULT_ORIGIN = "https://cors-smoke.invalid"
+
+
+def csv(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def parse_headers(raw: bytes) -> dict[str, list[str]]:
+    blocks = [
+        block
+        for block in raw.decode("iso-8859-1", errors="replace").replace("\r\n", "\n").split("\n\n")
+        if block.strip()
+    ]
+    lines = [
+        line.strip("\r") for line in (blocks[-1] if blocks else "").split("\n") if line.strip("\r")
+    ]
+    headers: dict[str, list[str]] = {}
+    for line in lines[1:]:
+        if ":" not in line:
+            continue
+        name, value = line.split(":", 1)
+        headers.setdefault(name.strip().lower(), []).append(value.strip())
+    return headers
+
+
+def single_header(headers: dict[str, list[str]], name: str) -> str | None:
+    values = headers.get(name.lower(), [])
+    if len(values) != 1:
+        return None
+    return values[0]
+
+
+def tokens(value: str) -> set[str]:
+    return {part.strip().lower() for part in value.split(",") if part.strip()}
+
+
+def require_wildcard(headers: dict[str, list[str]], origin: str) -> str:
+    values = headers.get("access-control-allow-origin", [])
+    if len(values) != 1:
+        return "Access-Control-Allow-Origin must be present exactly once with literal '*'."
+    value = values[0].strip()
+    if value == origin:
+        return "Access-Control-Allow-Origin echoes the supplied Origin instead of literal '*'."
+    if value != "*":
+        return "Access-Control-Allow-Origin must be literal '*'."
+    return ""
+
+
+def require_no_credentials(headers: dict[str, list[str]]) -> str:
+    value = single_header(headers, "Access-Control-Allow-Credentials")
+    if value is not None and value.strip().lower() == "true":
+        return "Access-Control-Allow-Credentials must be absent or not true."
+    return ""
+
+
+def run_curl(args: list[str]) -> tuple[int, str, bytes, bytes, str]:
+    with tempfile.NamedTemporaryFile(delete=False) as body_tmp, tempfile.NamedTemporaryFile(
+        delete=False
+    ) as header_tmp:
+        body_path = Path(body_tmp.name)
+        header_path = Path(header_tmp.name)
+    try:
+        proc = subprocess.run(
+            [
+                "curl",
+                "-sS",
+                "--connect-timeout",
+                str(int_env("SUGARKUBE_APP_VERIFY_CURL_CONNECT_TIMEOUT", 10)),
+                "--max-time",
+                str(int_env("SUGARKUBE_APP_VERIFY_CURL_MAX_TIME", 30)),
+                "-D",
+                str(header_path),
+                "-o",
+                str(body_path),
+                "-w",
+                "%{http_code}",
+                *args,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return (
+            proc.returncode,
+            proc.stdout.strip() or "000",
+            header_path.read_bytes() if header_path.exists() else b"",
+            body_path.read_bytes() if body_path.exists() else b"",
+            proc.stderr.strip(),
+        )
+    finally:
+        body_path.unlink(missing_ok=True)
+        header_path.unlink(missing_ok=True)
+
+
+def shell_cmd(args: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in ["curl", *args])
+
+
+def fail(msg: str, *, app: str, env: str, host: str, path: str, origin: str, status: str) -> int:
+    print(f"CORS verification failed for app={app} env={env}", file=sys.stderr)
+    print(f"Host: {host or '<unresolved>'}", file=sys.stderr)
+    print(f"Path: {path}", file=sys.stderr)
+    print(f"Origin: {origin}", file=sys.stderr)
+    print(f"HTTP status: {status}", file=sys.stderr)
+    print(msg, file=sys.stderr)
+    print("Suggested next steps:", file=sys.stderr)
+    print(f"  just app-status app={app} env={env}", file=sys.stderr)
+    print(f"  just app-verify app={app} env={env}", file=sys.stderr)
+    print(
+        "  Check that the intended immutable image tag containing the API CORS fix was deployed.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--origin", default=DEFAULT_ORIGIN)
+    parser.add_argument("--print-only", action="store_true")
+    args = parser.parse_args(argv)
+
+    app = os.environ["SUGARKUBE_APP"]
+    env = os.environ["SUGARKUBE_ENV"]
+    path = normalize_path(os.environ.get("SUGARKUBE_CORS_VERIFY_PATH", "/"))
+    method = os.environ.get("SUGARKUBE_CORS_VERIFY_METHOD", "POST").upper()
+    req_headers = os.environ.get("SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS", "content-type")
+    body = os.environ.get("SUGARKUBE_CORS_VERIFY_BODY", "{}")
+    expected = {
+        int(item)
+        for item in csv(os.environ.get("SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES", "400,429"))
+    }
+    print_only = args.print_only or env_flag("SUGARKUBE_APP_CORS_VERIFY_PRINT_ONLY")
+    kube_context = f"sugar-{env}"
+
+    host, errors = discover_host(kube_context)
+    base = base_url_from_host(host)
+    if not base:
+        if print_only:
+            placeholder = "https://<host>"
+            path_url = f"{placeholder}{path}"
+            preflight_args = [
+                "-X",
+                "OPTIONS",
+                "-H",
+                f"Origin: {args.origin}",
+                "-H",
+                f"Access-Control-Request-Method: {method}",
+                "-H",
+                f"Access-Control-Request-Headers: {req_headers}",
+                path_url,
+            ]
+            actual_args = [
+                "-X",
+                method,
+                "-H",
+                f"Origin: {args.origin}",
+                "-H",
+                "Content-Type: application/json",
+                "--data",
+                body,
+                path_url,
+            ]
+            for error in errors:
+                print(error, file=sys.stderr)
+            print(
+                "Could not derive a public host; generated placeholder CORS commands.",
+                file=sys.stderr,
+            )
+            print(shell_cmd(preflight_args))
+            print(shell_cmd(actual_args))
+            return 0
+        for error in errors:
+            print(error, file=sys.stderr)
+        return fail(
+            "Could not derive a public host.",
+            app=app,
+            env=env,
+            host=host,
+            path=path,
+            origin=args.origin,
+            status="000",
+        )
+    url = f"{base}{path}"
+
+    preflight_args = [
+        "-X",
+        "OPTIONS",
+        "-H",
+        f"Origin: {args.origin}",
+        "-H",
+        f"Access-Control-Request-Method: {method}",
+        "-H",
+        f"Access-Control-Request-Headers: {req_headers}",
+        url,
+    ]
+    actual_args = [
+        "-X",
+        method,
+        "-H",
+        f"Origin: {args.origin}",
+        "-H",
+        "Content-Type: application/json",
+        "--data",
+        body,
+        url,
+    ]
+    if print_only:
+        print(shell_cmd(preflight_args))
+        print(shell_cmd(actual_args))
+        return 0
+
+    print(f"Verifying CORS for {app} env={env}")
+    print(f"Host: {base}")
+    print(f"Path: {path}")
+    print(f"Origin: {args.origin}")
+
+    rc, status, raw_headers, _body, stderr = run_curl(preflight_args)
+    if rc != 0 or not status.isdigit() or not (200 <= int(status) < 300):
+        return fail(
+            f"Preflight OPTIONS must return a successful HTTP status. {stderr}".strip(),
+            app=app,
+            env=env,
+            host=base,
+            path=path,
+            origin=args.origin,
+            status=status,
+        )
+    headers = parse_headers(raw_headers)
+    for msg in [require_wildcard(headers, args.origin), require_no_credentials(headers)]:
+        if msg:
+            return fail(
+                msg, app=app, env=env, host=base, path=path, origin=args.origin, status=status
+            )
+    methods = single_header(headers, "Access-Control-Allow-Methods")
+    if not methods or method.lower() not in tokens(methods):
+        return fail(
+            f"Access-Control-Allow-Methods must contain {method}.",
+            app=app,
+            env=env,
+            host=base,
+            path=path,
+            origin=args.origin,
+            status=status,
+        )
+    allowed_headers = single_header(headers, "Access-Control-Allow-Headers")
+    for required in csv(req_headers):
+        if not allowed_headers or required.lower() not in tokens(allowed_headers):
+            return fail(
+                f"Access-Control-Allow-Headers must contain {required.lower()}.",
+                app=app,
+                env=env,
+                host=base,
+                path=path,
+                origin=args.origin,
+                status=status,
+            )
+
+    rc, status, raw_headers, body_bytes, stderr = run_curl(actual_args)
+    if not status.isdigit() or int(status) not in expected:
+        return fail(
+            f"Actual response must be one of {sorted(expected)} and not redirects, 403, 404, 405, or 5xx. {stderr}".strip(),
+            app=app,
+            env=env,
+            host=base,
+            path=path,
+            origin=args.origin,
+            status=status,
+        )
+    headers = parse_headers(raw_headers)
+    for msg in [require_wildcard(headers, args.origin), require_no_credentials(headers)]:
+        if msg:
+            return fail(
+                msg, app=app, env=env, host=base, path=path, origin=args.origin, status=status
+            )
+    if app == "tokenplace":
+        try:
+            data = json.loads(body_bytes.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return fail(
+                "token.place actual response must be JSON.",
+                app=app,
+                env=env,
+                host=base,
+                path=path,
+                origin=args.origin,
+                status=status,
+            )
+        if not isinstance(data, dict) or not isinstance(data.get("error"), dict):
+            return fail(
+                "token.place actual response must include a top-level API error object.",
+                app=app,
+                env=env,
+                host=base,
+                path=path,
+                origin=args.origin,
+                status=status,
+            )
+    print(
+        "CORS verification passed: preflight and actual response use literal wildcard CORS without credentials."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from scripts import app_chart
+from scripts import app_cors_verify
 from scripts import app_verify
 from scripts.app_verify import base_url_from_host, tokenplace_meta_failure
 
@@ -167,11 +168,16 @@ exit 0
 set -euo pipefail
 printf '%s\n' "$*" >> {str(tmp_path / "curl.log")!r}
 body_file=""
+header_file=""
 url=""
+method="GET"
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --connect-timeout|--max-time|-w) shift 2 ;;
+    --connect-timeout|--max-time|-w|--data) shift 2 ;;
     -o) body_file="$2"; shift 2 ;;
+    -D) header_file="$2"; shift 2 ;;
+    -X) method="$2"; shift 2 ;;
+    -H) shift 2 ;;
     -*) shift ;;
     *) url="$1"; shift ;;
   esac
@@ -195,7 +201,15 @@ case "${{path}}" in
   /config.json) body='{{"publicConfig":true}}' ;;
   /relay/diagnostics) body='{{"relay":"ok"}}' ;;
   /api/v1/meta) body='{{"label":"staging main-deadbee","version":"main-deadbee"}}' ;;
+  /api/v1/chat/completions) status=400; body='{{"error":{{"message":"invalid request"}}}}' ;;
 esac
+if [ "${{method}}" = "OPTIONS" ]; then
+  status=204
+  body=""
+fi
+if [ -n "${{header_file}}" ]; then
+  printf 'HTTP/2 %s\r\nAccess-Control-Allow-Origin: %s\r\nAccess-Control-Allow-Methods: OPTIONS, POST\r\nAccess-Control-Allow-Headers: content-type\r\n\r\n' "${{status}}" "${{SUGARKUBE_STUB_ACAO:-*}}" > "${{header_file}}"
+fi
 if [ "${{SUGARKUBE_STUB_CURL_FAIL_PATH:-}}" = "${{path}}" ]; then
   status=503
   body='{{"status":"down"}}'
@@ -1472,3 +1486,136 @@ def test_app_verify_fails_closed_when_context_host_discovery_fails(
     assert "kubectl ingress lookup failed for context sugar-staging" in result.stderr
     assert "Suggested next steps: just app-status app=tokenplace env=staging" in result.stderr
     assert "curl -fsS https://<host>/" in result.stdout
+
+
+def _headers(raw: str) -> dict[str, list[str]]:
+    return app_cors_verify.parse_headers(raw.encode("iso-8859-1"))
+
+
+def test_app_cors_header_assertions_cover_failures() -> None:
+    ok = _headers(
+        "HTTP/2 204\r\nAccess-Control-Allow-Origin: *\r\n"
+        "Access-Control-Allow-Methods: GET, POST\r\n"
+        "Access-Control-Allow-Headers: Content-Type\r\n\r\n"
+    )
+    assert app_cors_verify.require_wildcard(ok, "https://cors-smoke.invalid") == ""
+    assert app_cors_verify.require_no_credentials(ok) == ""
+    assert "post" in app_cors_verify.tokens(ok["access-control-allow-methods"][0])
+    assert "content-type" in app_cors_verify.tokens(ok["access-control-allow-headers"][0])
+
+    assert "present exactly once" in app_cors_verify.require_wildcard({}, "https://o.example")
+    echoed = _headers("HTTP/1.1 204\nAccess-Control-Allow-Origin: https://o.example\n\n")
+    assert "echoes" in app_cors_verify.require_wildcard(echoed, "https://o.example")
+    creds = _headers("HTTP/1.1 204\nAccess-Control-Allow-Credentials: true\n\n")
+    assert "must be absent" in app_cors_verify.require_no_credentials(creds)
+
+
+@pytest.mark.parametrize("actual_status", ["403", "404", "405", "500"])
+def test_app_cors_actual_rejects_disallowed_statuses(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], actual_status: str
+) -> None:
+    monkeypatch.setenv("SUGARKUBE_APP", "tokenplace")
+    monkeypatch.setenv("SUGARKUBE_ENV", "staging")
+    monkeypatch.setenv("SUGARKUBE_CORS_VERIFY_PATH", "/api/v1/chat/completions")
+    monkeypatch.setenv("SUGARKUBE_CORS_VERIFY_METHOD", "POST")
+    monkeypatch.setenv("SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS", "content-type")
+    monkeypatch.setenv("SUGARKUBE_CORS_VERIFY_BODY", "{}")
+    monkeypatch.setenv("SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES", "400,429")
+    monkeypatch.setattr(app_cors_verify, "discover_host", lambda context: ("example.test", []))
+    calls = {"n": 0}
+
+    def fake_run_curl(args: list[str]) -> tuple[int, str, bytes, bytes, str]:
+        calls["n"] += 1
+        headers = b"HTTP/2 204\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: POST\r\nAccess-Control-Allow-Headers: content-type\r\n\r\n"
+        if calls["n"] == 1:
+            return 0, "204", headers, b"", ""
+        return 0, actual_status, headers, b'{"error":{"message":"no"}}', ""
+
+    monkeypatch.setattr(app_cors_verify, "run_curl", fake_run_curl)
+    assert app_cors_verify.main([]) == 1
+    assert f"HTTP status: {actual_status}" in capsys.readouterr().err
+
+
+def test_app_cors_actual_400_with_wildcard_succeeds(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("SUGARKUBE_APP", "tokenplace")
+    monkeypatch.setenv("SUGARKUBE_ENV", "staging")
+    monkeypatch.setenv("SUGARKUBE_CORS_VERIFY_PATH", "/api/v1/chat/completions")
+    monkeypatch.setattr(app_cors_verify, "discover_host", lambda context: ("example.test", []))
+    headers = b"HTTP/2 204\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: POST\r\nAccess-Control-Allow-Headers: content-type\r\n\r\n"
+    calls = {"n": 0}
+
+    def fake_run_curl(args: list[str]) -> tuple[int, str, bytes, bytes, str]:
+        calls["n"] += 1
+        return (
+            (0, "204", headers, b"", "")
+            if calls["n"] == 1
+            else (0, "400", headers, b'{"error":{}}', "")
+        )
+
+    monkeypatch.setattr(app_cors_verify, "run_curl", fake_run_curl)
+    assert app_cors_verify.main([]) == 0
+    assert "CORS verification passed" in capsys.readouterr().out
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_cors_verify_print_only_prints_commands_without_curl(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        [
+            "app-cors-verify",
+            "app=tokenplace",
+            "env=staging",
+            "origin=https://unrelated-client.example",
+            "print_only=1",
+        ],
+        generic_app_stub_env,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "-X OPTIONS" in result.stdout
+    assert "Origin: https://unrelated-client.example" in result.stdout
+    assert "Access-Control-Request-Headers: content-type" in result.stdout
+    assert "--data '{}'" in result.stdout
+    assert "https://example.test/api/v1/chat/completions" in result.stdout
+    assert not Path(generic_app_stub_env["CURL_LOG"]).exists()
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_cors_verify_uses_staging_host_and_curl_args(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(["app-cors-verify", "app=tokenplace", "env=staging"], generic_app_stub_env)
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "CORS verification passed" in result.stdout
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    curl_log = Path(generic_app_stub_env["CURL_LOG"]).read_text(encoding="utf-8")
+    assert "--kube-context sugar-staging" in helm_log
+    assert "-X OPTIONS" in curl_log
+    assert "Origin: https://cors-smoke.invalid" in curl_log
+    assert "Access-Control-Request-Method: POST" in curl_log
+    assert "Access-Control-Request-Headers: content-type" in curl_log
+
+
+def test_app_config_emits_generic_cors_fields() -> None:
+    result = subprocess.run(
+        [
+            "python3",
+            "scripts/app_config.py",
+            "shell",
+            "--app",
+            "tokenplace",
+            "--env",
+            "staging",
+            "--config",
+            "",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "export SUGARKUBE_CORS_VERIFY_PATH=/api/v1/chat/completions" in result.stdout
+    assert "export SUGARKUBE_CORS_VERIFY_BODY='{}'" in result.stdout


### PR DESCRIPTION
### Motivation
- Operators need a single, read-only recipe to verify that an app’s public API implements literal wildcard CORS (owned by the app) without mutating ingress or edge layers.
- token.place must be the first consumer for this smoke check (API v1 chat/completions) and DSPACE’s runbook must include the cross-app verification sequence.

### Description
- Add a new read-only recipe `app-cors-verify` to the `justfile` that reuses `scripts/app_config.py` for app/env resolution and calls `scripts/app_cors_verify.py`. The recipe supports `app`, `env`, `origin`, `config`, and `print_only` and defaults to `https://cors-smoke.invalid` as the unrelated origin. 
- Implement `scripts/app_cors_verify.py` which: resolves the public host via existing helpers (`discover_host`, `base_url_from_host`), emits `curl` commands in `--print-only` mode, performs an OPTIONS preflight probe and an actual POST probe, enforces literal `Access-Control-Allow-Origin: *`, rejects credentialed CORS, checks allowed methods/headers case-insensitively, validates expected actual-statuses, and prints actionable failure guidance without changing cluster resources. 
- Extend `scripts/app_config.py` to allow and emit minimal generic CORS configuration keys (`SUGARKUBE_CORS_VERIFY_*`) and add example token.place defaults in `docs/examples/apps/tokenplace.env` for path, method, headers, body and expected statuses. 
- Update docs: add a “Browser CORS verification” section to `docs/apps/tokenplace.md` and a cross-app browser smoke sequence to `docs/apps/dspace.md` describing how to run `app-cors-verify` during staging→prod flows and the expectations (literal wildcard, no credentials, API v1 scope). 
- Add focused tests and wiring in `tests/test_generic_app_just_recipes.py` to cover header parsing, wildcard/credential checks, expected-status handling, print-only output, staging host discovery and that the new config fields are emitted by `app_config`. 

### Testing
- Ran unit/integration-style tests: `pytest -q tests/test_generic_app_just_recipes.py -k "cors or app_verify or app_config"` — result: all tests passed (`33 passed, 51 deselected`).
- Verified recipe listing and placeholder behavior: `just --list | rg "app-cors-verify"` succeeded and `just app-cors-verify app=tokenplace env=staging print_only=1` produced placeholder curl commands when host discovery is unresolved.
- Verified run-mode: executed `just app-cors-verify app=tokenplace env=staging print_only=1` (produced placeholder curl commands) and exercised the full recipe in tests where the stubbed `curl` simulated OPTIONS + POST probes.
- Static checks and formatting: `python -m py_compile scripts/app_cors_verify.py scripts/app_config.py scripts/app_verify.py` and `python -m black ...` ran successfully in the environment; repository `scan-secrets` was executed on the staged diff.
- Not run in this environment due to missing tools: `pre-commit run --all-files` (pre-commit not installed), `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` (tools not present).

All changes are focused to the allowed paths and the recipe is explicitly read-only and does not mutate Kubernetes ingress, Traefik middleware, or Cloudflare rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35a737f960832fbf2d38f172928265)