### PR TITLE
Add generic app CORS verification

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -130,6 +130,30 @@ curl -fsS https://staging.democratized.space/healthz
 curl -fsS https://staging.democratized.space/livez
 ```
 
+
+## Cross-app token.place browser API release sequence
+
+When a DSPACE release depends on browser calls to token.place API v1, keep the producer and consumer rollout ordered so Sugarkube verifies token.place behavior but never becomes the source of CORS response headers:
+
+1. Deploy the token.place image containing wildcard API v1 CORS.
+2. Run token.place public HTTP verification:
+
+   ```bash
+   just app-verify app=tokenplace env=staging
+   ```
+
+3. Run token.place browser CORS verification:
+
+   ```bash
+   just app-cors-verify app=tokenplace env=staging
+   ```
+
+4. Deploy DSPACE with the runtime origin settings from the current environment overlay.
+5. Confirm DSPACE `/config.json` exposes the expected token.place runtime URL for the target environment.
+6. Open `/chat`, send a message, and inspect Browser Network.
+
+For staging, the browser smoke must show DSPACE calling `https://staging.token.place/api/v1/chat/completions`; for production it must show `https://token.place/api/v1/chat/completions`. Confirm the `OPTIONS` preflight succeeds, the `POST` succeeds or returns a readable API-owned error, no `Authorization` header is sent, no token.place credentials are sent, fetch `credentials` are omitted, and the request does not set `stream: true`.
+
 ## Promote production
 
 Promote only after staging sign-off. Prefer the generic command; it uses the prod values chain and can read `docs/apps/dspace.prod.tag` when `tag=` is omitted.

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -152,6 +152,16 @@ curl -fsS https://staging.token.place/api/v1/meta | jq .
 
 Staging metadata must not report `.version == "dev"` or a `.label` ending in ` dev`; the expected label includes the deployed image tag, for example `staging main-00797df`.
 
+### Browser CORS verification
+
+After staging HTTP verification, confirm the application-owned public API v1 CORS contract from an unrelated origin:
+
+```bash
+just app-cors-verify app=tokenplace env=staging
+```
+
+The check sends an `OPTIONS` preflight and an intentionally invalid API v1 `POST` to `/api/v1/chat/completions`. It expects token.place itself to return a literal `Access-Control-Allow-Origin: *`, to keep credentialed CORS disabled, and to expose a readable API-owned JSON error such as validation or rate-limit status. API v1 remains zero-auth and non-streaming for this browser path; the CORS contract applies to public API v1, not API v2. This is separate from relay-compute E2EE sign-off and does not replace it.
+
 ### Staging relay-compute sign-off
 
 `just app-status`, `just app-verify`, `/livez`, `/healthz`, `/`, and `/relay/diagnostics` are necessary but not sufficient for token.place promotion. Staging-to-prod promotion is blocked until the real relay-compute path passes, as defined in [the token.place Sugarkube onboarding contract](../tokenplace_sugarkube_onboarding.md#promotion-gate-ownership). Before production promotion, capture staging evidence for the real relay path:
@@ -184,6 +194,12 @@ just app-status app=tokenplace env=prod
 
 ```bash
 just app-verify app=tokenplace env=prod
+```
+
+Before and after production promotion, verify the same browser CORS contract against production:
+
+```bash
+just app-cors-verify app=tokenplace env=prod
 ```
 
 Print the generated curl commands without executing them when you need a manual fallback:

--- a/docs/examples/apps/tokenplace.env
+++ b/docs/examples/apps/tokenplace.env
@@ -15,3 +15,8 @@ SUGARKUBE_VALUES_PROD=docs/examples/tokenplace.values.dev.yaml,docs/examples/tok
 SUGARKUBE_STATUS_HOST_KEY=ingress.host
 SUGARKUBE_VERIFY_PATHS=/,/livez,/healthz,/relay/diagnostics,/api/v1/meta
 SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=tokenplace
+SUGARKUBE_CORS_VERIFY_PATH=/api/v1/chat/completions
+SUGARKUBE_CORS_VERIFY_METHOD=POST
+SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS=content-type
+SUGARKUBE_CORS_VERIFY_BODY={}
+SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES=400,429

--- a/justfile
+++ b/justfile
@@ -1692,6 +1692,50 @@ app-verify app env='staging' config='' print_only='':
 
     python3 "{{ justfile_directory() }}/scripts/app_verify.py" "${print_only_args[@]}"
 
+# Verify app-owned public CORS headers for a Sugarkube app without mutating ingress or edge resources.
+app-cors-verify app env='staging' origin='https://cors-smoke.invalid' config='' print_only='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    config_input={{ quote(config) }}
+    origin_input={{ quote(origin) }}
+    print_only_input={{ quote(print_only) }}
+    if [ "${config_input#print_only=}" != "${config_input}" ]; then
+      print_only_input="${config_input}"
+      config_input=""
+    fi
+    if [ "${origin_input#print_only=}" != "${origin_input}" ]; then
+      print_only_input="${origin_input}"
+      origin_input="https://cors-smoke.invalid"
+    fi
+    while [ "${config_input#config=}" != "${config_input}" ]; do
+      config_input="${config_input#config=}"
+    done
+    while [ "${origin_input#origin=}" != "${origin_input}" ]; do
+      origin_input="${origin_input#origin=}"
+    done
+    while [ "${print_only_input#print_only=}" != "${print_only_input}" ]; do
+      print_only_input="${print_only_input#print_only=}"
+    done
+
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+      --app {{ quote(app) }} \
+      --env {{ quote(env) }} \
+      --config "${config_input}")"
+
+    if [ -z "${KUBECONFIG:-}" ]; then
+      export KUBECONFIG="${HOME}/.kube/config"
+    fi
+
+    print_only_args=()
+    if [ "${print_only_input:-${SUGARKUBE_CORS_VERIFY_PRINT_ONLY:-}}" = "1" ]; then
+      print_only_args+=(--print-only)
+    fi
+
+    python3 "{{ justfile_directory() }}/scripts/app_cors_verify.py" \
+      --origin "${origin_input}" \
+      "${print_only_args[@]}"
+
 # Opinionated immutable-tag dspace deploy with rollout verification.
 #
 

--- a/justfile
+++ b/justfile
@@ -1693,7 +1693,7 @@ app-verify app env='staging' config='' print_only='':
     python3 "{{ justfile_directory() }}/scripts/app_verify.py" "${print_only_args[@]}"
 
 # Verify app-owned public CORS headers for a Sugarkube app without mutating ingress or edge resources.
-app-cors-verify app env='staging' origin='https://cors-smoke.invalid' config='' print_only='':
+app-cors-verify app env='staging' config='' origin='https://cors-smoke.invalid' print_only='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1707,6 +1707,14 @@ app-cors-verify app env='staging' origin='https://cors-smoke.invalid' config='' 
     if [ "${origin_input#print_only=}" != "${origin_input}" ]; then
       print_only_input="${origin_input}"
       origin_input="https://cors-smoke.invalid"
+    fi
+    if [ "${origin_input#config=}" != "${origin_input}" ]; then
+      config_input="${origin_input}"
+      origin_input="https://cors-smoke.invalid"
+    fi
+    if [ "${config_input#origin=}" != "${config_input}" ]; then
+      origin_input="${config_input}"
+      config_input=""
     fi
     while [ "${config_input#config=}" != "${config_input}" ]; do
       config_input="${config_input#config=}"

--- a/scripts/app_config.py
+++ b/scripts/app_config.py
@@ -39,6 +39,11 @@ ALLOWED_KEYS = {
     "SUGARKUBE_STATUS_HOST_KEY",
     "SUGARKUBE_VERIFY_PATHS",
     "SUGARKUBE_DEBUG_SELECTOR",
+    "SUGARKUBE_CORS_VERIFY_PATH",
+    "SUGARKUBE_CORS_VERIFY_METHOD",
+    "SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS",
+    "SUGARKUBE_CORS_VERIFY_BODY",
+    "SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES",
 }
 REQUIRED_KEYS = {
     "SUGARKUBE_APP",
@@ -78,8 +83,7 @@ def validate_app_name(app: str) -> str:
     app = normalize_named(app, "app")
     if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", app or ""):
         raise AppConfigError(
-            "app must be a non-empty name using letters, numbers, dots, underscores, "
-            "or dashes."
+            "app must be a non-empty name using letters, numbers, dots, underscores, " "or dashes."
         )
     return app
 
@@ -182,6 +186,11 @@ def load_config(app: str, env: str, explicit: str | None = None) -> dict[str, st
     resolved["SUGARKUBE_CONFIG_PATH"] = str(config_path)
     resolved.setdefault("SUGARKUBE_STATUS_HOST_KEY", "ingress.host")
     resolved.setdefault("SUGARKUBE_VERIFY_PATHS", "/")
+    resolved.setdefault("SUGARKUBE_CORS_VERIFY_PATH", "/")
+    resolved.setdefault("SUGARKUBE_CORS_VERIFY_METHOD", "POST")
+    resolved.setdefault("SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS", "content-type")
+    resolved.setdefault("SUGARKUBE_CORS_VERIFY_BODY", "{}")
+    resolved.setdefault("SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES", "400,429")
     return resolved
 
 
@@ -216,6 +225,11 @@ def shell_emit(config: dict[str, str]) -> str:
         "SUGARKUBE_STATUS_HOST_KEY",
         "SUGARKUBE_VERIFY_PATHS",
         "SUGARKUBE_DEBUG_SELECTOR",
+        "SUGARKUBE_CORS_VERIFY_PATH",
+        "SUGARKUBE_CORS_VERIFY_METHOD",
+        "SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS",
+        "SUGARKUBE_CORS_VERIFY_BODY",
+        "SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES",
         "SUGARKUBE_CONFIG_PATH",
         "SUGARKUBE_TAG",
     ]

--- a/scripts/app_cors_verify.py
+++ b/scripts/app_cors_verify.py
@@ -117,6 +117,10 @@ def print_failure_context(
     )
 
 
+def curl_failure_detail(stderr: str) -> str:
+    return stderr or "network request failed"
+
+
 def assert_wildcard(headers: dict[str, list[str]], origin: str) -> str:
     acao, error = single_header(headers, "Access-Control-Allow-Origin")
     if error:
@@ -227,7 +231,7 @@ def main(argv: list[str] | None = None) -> int:
     rc, status, headers, _body, stderr = run_curl(preflight_args)
     if rc != 0:
         print_failure_context(
-            app, env, base_url, path, args.origin, status, stderr or "network request failed"
+            app, env, base_url, path, args.origin, status, curl_failure_detail(stderr)
         )
         return 1
     if not status.isdigit() or not (200 <= int(status) < 300):
@@ -254,7 +258,7 @@ def main(argv: list[str] | None = None) -> int:
     rc, status, headers, actual_body, stderr = run_curl(actual_args)
     if rc != 0:
         print_failure_context(
-            app, env, base_url, path, args.origin, status, stderr or "network request failed"
+            app, env, base_url, path, args.origin, status, curl_failure_detail(stderr)
         )
         return 1
     status_int = int(status) if status.isdigit() else 0

--- a/scripts/app_cors_verify.py
+++ b/scripts/app_cors_verify.py
@@ -52,7 +52,8 @@ def single_header(headers: dict[str, list[str]], name: str) -> tuple[str, str]:
 def contains_header_value(headers: dict[str, list[str]], name: str, expected: str) -> bool:
     wanted = expected.lower()
     for value in headers.get(name.lower(), []):
-        if any(part.strip().lower() in {wanted, "*"} for part in value.split(",")):
+        allowed = {part.strip().lower() for part in value.split(",")}
+        if wanted in allowed or (wanted != "authorization" and "*" in allowed):
             return True
     return False
 

--- a/scripts/app_cors_verify.py
+++ b/scripts/app_cors_verify.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Verify an app-owned public CORS contract for a Sugarkube app."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from app_verify import base_url_from_host, discover_host, env_flag, int_env, normalize_path
+
+DEFAULT_ORIGIN = "https://cors-smoke.invalid"
+
+
+def csv(value: str) -> list[str]:
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def curl_quote(value: str) -> str:
+    import shlex
+
+    return shlex.quote(value)
+
+
+def headers_from_bytes(raw: bytes) -> dict[str, list[str]]:
+    headers: dict[str, list[str]] = {}
+    text = raw.decode("iso-8859-1", errors="replace").replace("\r\n", "\n")
+    blocks = [block for block in text.split("\n\n") if block.strip()]
+    block = blocks[-1] if blocks else text
+    for line in block.split("\n"):
+        if not line or line.lower().startswith("http/") or ":" not in line:
+            continue
+        name, value = line.split(":", 1)
+        headers.setdefault(name.strip().lower(), []).append(value.strip())
+    return headers
+
+
+def single_header(headers: dict[str, list[str]], name: str) -> tuple[str, str]:
+    values = headers.get(name.lower(), [])
+    if not values:
+        return "", f"missing {name}"
+    normalized = {value.strip() for value in values}
+    if len(values) != 1 or len(normalized) != 1:
+        return "", f"duplicated/conflicting {name}: {values}"
+    return values[0].strip(), ""
+
+
+def contains_header_value(headers: dict[str, list[str]], name: str, expected: str) -> bool:
+    wanted = expected.lower()
+    for value in headers.get(name.lower(), []):
+        if any(part.strip().lower() == wanted for part in value.split(",")):
+            return True
+    return False
+
+
+def credentials_enabled(headers: dict[str, list[str]]) -> bool:
+    return any(
+        v.strip().lower() == "true" for v in headers.get("access-control-allow-credentials", [])
+    )
+
+
+def run_curl(args: list[str]) -> tuple[int, str, dict[str, list[str]], bytes, str]:
+    connect_timeout = int_env("SUGARKUBE_APP_VERIFY_CURL_CONNECT_TIMEOUT", 10)
+    max_time = int_env("SUGARKUBE_APP_VERIFY_CURL_MAX_TIME", 30)
+    with tempfile.NamedTemporaryFile(delete=False) as body_tmp, tempfile.NamedTemporaryFile(
+        delete=False
+    ) as header_tmp:
+        body_path = Path(body_tmp.name)
+        header_path = Path(header_tmp.name)
+    try:
+        proc = subprocess.run(
+            [
+                "curl",
+                "-sS",
+                "--connect-timeout",
+                str(connect_timeout),
+                "--max-time",
+                str(max_time),
+                "-D",
+                str(header_path),
+                "-o",
+                str(body_path),
+                "-w",
+                "%{http_code}",
+                *args,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        body = body_path.read_bytes() if body_path.exists() else b""
+        headers = headers_from_bytes(header_path.read_bytes() if header_path.exists() else b"")
+        return proc.returncode, proc.stdout.strip() or "000", headers, body, proc.stderr.strip()
+    finally:
+        body_path.unlink(missing_ok=True)
+        header_path.unlink(missing_ok=True)
+
+
+def print_failure_context(
+    app: str, env: str, host: str, path: str, origin: str, status: str, detail: str
+) -> None:
+    print("CORS verification failed.", file=sys.stderr)
+    print(
+        f"app={app} env={env} host={host or '<unknown>'} path={path} origin={origin} status={status}",
+        file=sys.stderr,
+    )
+    print(f"incorrect header/status: {detail}", file=sys.stderr)
+    print(f"Suggested next steps: just app-status app={app} env={env}", file=sys.stderr)
+    print(f"Suggested next steps: just app-verify app={app} env={env}", file=sys.stderr)
+    print(
+        "Check that the intended immutable image tag containing the app-owned CORS fix was deployed.",
+        file=sys.stderr,
+    )
+
+
+def assert_wildcard(headers: dict[str, list[str]], origin: str) -> str:
+    acao, error = single_header(headers, "Access-Control-Allow-Origin")
+    if error:
+        return error
+    if acao != "*":
+        if acao == origin:
+            return "Access-Control-Allow-Origin echoed the test Origin instead of literal *"
+        return f"Access-Control-Allow-Origin must be literal *, got {acao!r}"
+    if credentials_enabled(headers):
+        return "Access-Control-Allow-Credentials must be absent or not true"
+    return ""
+
+
+def tokenplace_api_error(raw: bytes) -> str:
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return "token.place API error response must be JSON"
+    if not isinstance(data, dict) or not isinstance(data.get("error"), dict):
+        return "token.place API error response must include a top-level error object"
+    return ""
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--origin", default=os.environ.get("SUGARKUBE_CORS_VERIFY_ORIGIN", DEFAULT_ORIGIN)
+    )
+    parser.add_argument("--print-only", action="store_true")
+    args = parser.parse_args(argv)
+
+    app = os.environ["SUGARKUBE_APP"]
+    env = os.environ["SUGARKUBE_ENV"]
+    kube_context = f"sugar-{env}"
+    path = normalize_path(os.environ.get("SUGARKUBE_CORS_VERIFY_PATH", "/"))
+    method = os.environ.get("SUGARKUBE_CORS_VERIFY_METHOD", "POST").upper()
+    request_headers = os.environ.get("SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS", "content-type")
+    body = os.environ.get("SUGARKUBE_CORS_VERIFY_BODY", "{}")
+    expected_statuses = {
+        int(v) for v in csv(os.environ.get("SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES", "400,429"))
+    }
+    print_only = args.print_only or env_flag("SUGARKUBE_CORS_VERIFY_PRINT_ONLY")
+
+    host, errors = discover_host(kube_context)
+    base_url = base_url_from_host(host)
+    url = f"{base_url or 'https://<host>'}{path}"
+
+    preflight_args = [
+        "-X",
+        "OPTIONS",
+        "-H",
+        f"Origin: {args.origin}",
+        "-H",
+        f"Access-Control-Request-Method: {method}",
+        "-H",
+        f"Access-Control-Request-Headers: {request_headers}",
+        url,
+    ]
+    actual_args = [
+        "-X",
+        method,
+        "-H",
+        f"Origin: {args.origin}",
+        "-H",
+        "Content-Type: application/json",
+        "--data",
+        body,
+        url,
+    ]
+
+    if print_only:
+        if not base_url:
+            for error in errors:
+                print(error, file=sys.stderr)
+            print(
+                "Could not derive a host; generated commands use https://<host>.", file=sys.stderr
+            )
+        print("curl -i -sS " + " ".join(curl_quote(v) for v in preflight_args))
+        print("curl -i -sS " + " ".join(curl_quote(v) for v in actual_args))
+        return 0
+
+    if not base_url:
+        for error in errors:
+            print(error, file=sys.stderr)
+        print_failure_context(
+            app, env, host, path, args.origin, "000", "could not derive public host"
+        )
+        return 1
+
+    print(f"Verifying CORS for {app} env={env}")
+    print(f"Host: {base_url}")
+    print(f"Path: {path}")
+    print(f"Origin: {args.origin}")
+
+    rc, status, headers, _body, stderr = run_curl(preflight_args)
+    if rc != 0 and status == "000":
+        print_failure_context(
+            app, env, base_url, path, args.origin, status, stderr or "network request failed"
+        )
+        return 1
+    if not status.isdigit() or not (200 <= int(status) < 300):
+        print_failure_context(
+            app,
+            env,
+            base_url,
+            path,
+            args.origin,
+            status,
+            "preflight HTTP status must be successful",
+        )
+        return 1
+    error = assert_wildcard(headers, args.origin)
+    if not error and not contains_header_value(headers, "Access-Control-Allow-Methods", method):
+        error = f"Access-Control-Allow-Methods must contain {method}"
+    for header in csv(request_headers):
+        if not error and not contains_header_value(headers, "Access-Control-Allow-Headers", header):
+            error = f"Access-Control-Allow-Headers must contain {header}"
+    if error:
+        print_failure_context(app, env, base_url, path, args.origin, status, error)
+        return 1
+
+    rc, status, headers, actual_body, stderr = run_curl(actual_args)
+    if rc != 0 and status == "000":
+        print_failure_context(
+            app, env, base_url, path, args.origin, status, stderr or "network request failed"
+        )
+        return 1
+    status_int = int(status) if status.isdigit() else 0
+    if status_int not in expected_statuses:
+        print_failure_context(
+            app,
+            env,
+            base_url,
+            path,
+            args.origin,
+            status,
+            f"actual status must be one of {sorted(expected_statuses)}",
+        )
+        return 1
+    error = assert_wildcard(headers, args.origin)
+    if not error and app == "tokenplace":
+        error = tokenplace_api_error(actual_body)
+    if error:
+        print_failure_context(app, env, base_url, path, args.origin, status, error)
+        return 1
+
+    print(
+        "CORS verification passed: preflight and actual API error response expose literal wildcard CORS without credentials."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/app_cors_verify.py
+++ b/scripts/app_cors_verify.py
@@ -52,7 +52,7 @@ def single_header(headers: dict[str, list[str]], name: str) -> tuple[str, str]:
 def contains_header_value(headers: dict[str, list[str]], name: str, expected: str) -> bool:
     wanted = expected.lower()
     for value in headers.get(name.lower(), []):
-        if any(part.strip().lower() == wanted for part in value.split(",")):
+        if any(part.strip().lower() in {wanted, "*"} for part in value.split(",")):
             return True
     return False
 
@@ -155,9 +155,18 @@ def main(argv: list[str] | None = None) -> int:
     method = os.environ.get("SUGARKUBE_CORS_VERIFY_METHOD", "POST").upper()
     request_headers = os.environ.get("SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS", "content-type")
     body = os.environ.get("SUGARKUBE_CORS_VERIFY_BODY", "{}")
-    expected_statuses = {
-        int(v) for v in csv(os.environ.get("SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES", "400,429"))
-    }
+    try:
+        expected_statuses = {
+            int(v)
+            for v in csv(os.environ.get("SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES", "400,429"))
+        }
+    except ValueError as exc:
+        parser.error(
+            "SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES must be comma-separated integers: "
+            f"{exc}"
+        )
+    if not expected_statuses:
+        parser.error("SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES must include at least one integer")
     print_only = args.print_only or env_flag("SUGARKUBE_CORS_VERIFY_PRINT_ONLY")
 
     host, errors = discover_host(kube_context)
@@ -180,12 +189,16 @@ def main(argv: list[str] | None = None) -> int:
         method,
         "-H",
         f"Origin: {args.origin}",
-        "-H",
-        "Content-Type: application/json",
-        "--data",
-        body,
-        url,
     ]
+    actual_header_names = {header.lower() for header in csv(request_headers)}
+    if "content-type" not in actual_header_names:
+        actual_args.extend(["-H", "Content-Type: application/json"])
+    for header in csv(request_headers):
+        if header.lower() == "content-type":
+            actual_args.extend(["-H", "Content-Type: application/json"])
+        else:
+            actual_args.extend(["-H", f"{header}: cors-smoke"])
+    actual_args.extend(["--data-raw", body, url])
 
     if print_only:
         if not base_url:
@@ -212,7 +225,7 @@ def main(argv: list[str] | None = None) -> int:
     print(f"Origin: {args.origin}")
 
     rc, status, headers, _body, stderr = run_curl(preflight_args)
-    if rc != 0 and status == "000":
+    if rc != 0:
         print_failure_context(
             app, env, base_url, path, args.origin, status, stderr or "network request failed"
         )
@@ -239,7 +252,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     rc, status, headers, actual_body, stderr = run_curl(actual_args)
-    if rc != 0 and status == "000":
+    if rc != 0:
         print_failure_context(
             app, env, base_url, path, args.origin, status, stderr or "network request failed"
         )

--- a/scripts/app_cors_verify.py
+++ b/scripts/app_cors_verify.py
@@ -165,7 +165,13 @@ def main(argv: list[str] | None = None) -> int:
     kube_context = f"sugar-{env}"
     path = normalize_path(os.environ.get("SUGARKUBE_CORS_VERIFY_PATH", "/"))
     method = os.environ.get("SUGARKUBE_CORS_VERIFY_METHOD", "POST").upper()
-    request_headers = os.environ.get("SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS", "content-type")
+    configured_request_headers = csv(
+        os.environ.get("SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS", "content-type")
+    )
+    effective_request_headers = [*configured_request_headers]
+    if "content-type" not in {header.lower() for header in effective_request_headers}:
+        effective_request_headers.append("content-type")
+    request_headers = ",".join(effective_request_headers)
     body = os.environ.get("SUGARKUBE_CORS_VERIFY_BODY", "{}")
     try:
         expected_statuses = {
@@ -202,10 +208,7 @@ def main(argv: list[str] | None = None) -> int:
         "-H",
         f"Origin: {args.origin}",
     ]
-    actual_header_names = {header.lower() for header in csv(request_headers)}
-    if "content-type" not in actual_header_names:
-        actual_args.extend(["-H", "Content-Type: application/json"])
-    for header in csv(request_headers):
+    for header in effective_request_headers:
         if header.lower() == "content-type":
             actual_args.extend(["-H", "Content-Type: application/json"])
         else:
@@ -256,7 +259,7 @@ def main(argv: list[str] | None = None) -> int:
     error = assert_wildcard(headers, args.origin)
     if not error and not contains_header_value(headers, "Access-Control-Allow-Methods", method):
         error = f"Access-Control-Allow-Methods must contain {method}"
-    for header in csv(request_headers):
+    for header in effective_request_headers:
         if not error and not contains_header_value(headers, "Access-Control-Allow-Headers", header):
             error = f"Access-Control-Allow-Headers must contain {header}"
     if error:

--- a/scripts/app_cors_verify.py
+++ b/scripts/app_cors_verify.py
@@ -51,9 +51,16 @@ def single_header(headers: dict[str, list[str]], name: str) -> tuple[str, str]:
 
 def contains_header_value(headers: dict[str, list[str]], name: str, expected: str) -> bool:
     wanted = expected.lower()
-    for value in headers.get(name.lower(), []):
+    header_name = name.lower()
+    for value in headers.get(header_name, []):
         allowed = {part.strip().lower() for part in value.split(",")}
-        if wanted in allowed or (wanted != "authorization" and "*" in allowed):
+        if wanted in allowed:
+            return True
+        if (
+            header_name == "access-control-allow-headers"
+            and wanted != "authorization"
+            and "*" in allowed
+        ):
             return True
     return False
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -241,6 +241,12 @@ if [ "${{SUGARKUBE_STUB_CURL_FAIL_PATH:-}}" = "${{path}}" ]; then
   body='{{"status":"down"}}'
   echo 'curl: (22) The requested URL returned error: 503' >&2
 fi
+if [ "${{method}}" != "OPTIONS" ] && [ -n "${{SUGARKUBE_STUB_CORS_ACTUAL_CURL_EXIT:-}}" ]; then
+  echo 'curl: (18) transfer closed with outstanding read data remaining' >&2
+  curl_exit="${{SUGARKUBE_STUB_CORS_ACTUAL_CURL_EXIT}}"
+else
+  curl_exit="${{SUGARKUBE_STUB_CURL_EXIT:-0}}"
+fi
 if [ -n "${{header_file}}" ]; then
   printf '%s\r\n' "${{headers}}" > "${{header_file}}"
 fi
@@ -250,10 +256,7 @@ else
   printf '%s\n' "${{body}}"
 fi
 printf '%s' "${{status}}"
-if [ -n "${{SUGARKUBE_STUB_CURL_EXIT:-}}" ]; then
-  exit "${{SUGARKUBE_STUB_CURL_EXIT}}"
-fi
-exit 0
+exit "${{curl_exit}}"
 """,
     )
 
@@ -1670,6 +1673,24 @@ def test_app_cors_verify_rejects_any_curl_error(
 
     assert result.returncode != 0
     assert "CORS verification failed" in result.stderr
+
+
+def test_app_cors_verify_actual_rejects_nonzero_curl_with_expected_response(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_CORS_ACTUAL_STATUS"] = "400"
+    env["SUGARKUBE_STUB_CORS_ACTUAL_ACAO"] = "*"
+    env["SUGARKUBE_STUB_CORS_ACTUAL_CURL_EXIT"] = "18"
+
+    result = _run_just(["app-cors-verify", "app=tokenplace", "env=staging"], env)
+
+    assert result.returncode != 0
+    assert "CORS verification failed" in result.stderr
+    assert "app=tokenplace env=staging host=https://example.test" in result.stderr
+    assert "path=/api/v1/chat/completions" in result.stderr
+    assert "origin=https://cors-smoke.invalid status=400" in result.stderr
+    assert "transfer closed with outstanding read data remaining" in result.stderr
 
 
 def test_app_cors_verify_bad_expected_statuses_is_operator_error(

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -1825,3 +1826,171 @@ def test_app_config_rejects_unknown_app_config_keys(tmp_path: Path) -> None:
 
     assert result.returncode == 2
     assert "unknown app config key 'SUGARKUBE_UNKNOWN'" in result.stderr
+
+
+def _cors_env(overrides: dict[str, str] | None = None) -> dict[str, str]:
+    env = {
+        "SUGARKUBE_APP": "tokenplace",
+        "SUGARKUBE_ENV": "staging",
+        "SUGARKUBE_CORS_VERIFY_PATH": "/api/v1/chat/completions",
+        "SUGARKUBE_CORS_VERIFY_METHOD": "POST",
+        "SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS": "content-type",
+        "SUGARKUBE_CORS_VERIFY_BODY": "{}",
+        "SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES": "400,429",
+    }
+    if overrides:
+        env.update(overrides)
+    return env
+
+
+def _cors_headers(extra: dict[str, list[str]] | None = None) -> dict[str, list[str]]:
+    headers = {
+        "access-control-allow-origin": ["*"],
+        "access-control-allow-methods": ["POST, OPTIONS"],
+        "access-control-allow-headers": ["content-type"],
+    }
+    if extra:
+        headers.update(extra)
+    return headers
+
+
+def _run_app_cors_main(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    *,
+    env: dict[str, str] | None = None,
+    responses: list[tuple[int, str, dict[str, list[str]], bytes, str]] | None = None,
+    host: str = "example.test",
+    errors: list[str] | None = None,
+    argv: list[str] | None = None,
+) -> tuple[int, str, str, list[list[str]]]:
+    if str(REPO_ROOT / "scripts") not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    from scripts import app_cors_verify
+
+    for key in [
+        "SUGARKUBE_APP",
+        "SUGARKUBE_ENV",
+        "SUGARKUBE_CORS_VERIFY_PATH",
+        "SUGARKUBE_CORS_VERIFY_METHOD",
+        "SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS",
+        "SUGARKUBE_CORS_VERIFY_BODY",
+        "SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES",
+        "SUGARKUBE_CORS_VERIFY_PRINT_ONLY",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+    for key, value in _cors_env(env).items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(app_cors_verify, "discover_host", lambda kube_context: (host, errors or []))
+    calls: list[list[str]] = []
+    pending = list(
+        responses
+        or [
+            (0, "204", _cors_headers(), b"", ""),
+            (0, "400", _cors_headers(), b'{"error":{"message":"invalid request"}}', ""),
+        ]
+    )
+
+    def fake_run_curl(args: list[str]) -> tuple[int, str, dict[str, list[str]], bytes, str]:
+        calls.append(args)
+        return pending.pop(0)
+
+    monkeypatch.setattr(app_cors_verify, "run_curl", fake_run_curl)
+
+    rc = app_cors_verify.main(argv or [])
+    captured = capsys.readouterr()
+    return rc, captured.out, captured.err, calls
+
+
+def test_app_cors_verify_main_success_exercises_preflight_and_actual(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc, out, err, calls = _run_app_cors_main(monkeypatch, capsys)
+
+    assert rc == 0, err + out
+    assert "Verifying CORS for tokenplace env=staging" in out
+    assert "CORS verification passed" in out
+    assert len(calls) == 2
+    assert calls[0][:2] == ["-X", "OPTIONS"]
+    assert calls[1][:2] == ["-X", "POST"]
+    assert "--data-raw" in calls[1]
+
+
+def test_app_cors_verify_main_rejects_authorization_wildcard(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc, _out, err, _calls = _run_app_cors_main(
+        monkeypatch,
+        capsys,
+        env={"SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS": "authorization"},
+        responses=[
+            (
+                0,
+                "204",
+                _cors_headers({"access-control-allow-headers": ["*"]}),
+                b"",
+                "",
+            ),
+        ],
+    )
+
+    assert rc == 1
+    assert "Access-Control-Allow-Headers must contain authorization" in err
+    assert "app=tokenplace env=staging host=https://example.test" in err
+
+
+def test_app_cors_verify_main_accepts_non_authorization_wildcard(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc, out, err, _calls = _run_app_cors_main(
+        monkeypatch,
+        capsys,
+        env={"SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS": "x-custom-token"},
+        responses=[
+            (
+                0,
+                "204",
+                _cors_headers({"access-control-allow-headers": ["*"]}),
+                b"",
+                "",
+            ),
+            (0, "400", _cors_headers(), b'{"error":{"message":"invalid request"}}', ""),
+        ],
+    )
+
+    assert rc == 0, err + out
+
+
+def test_app_cors_verify_main_reports_bad_actual_status(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc, _out, err, _calls = _run_app_cors_main(
+        monkeypatch,
+        capsys,
+        responses=[
+            (0, "204", _cors_headers(), b"", ""),
+            (0, "503", _cors_headers(), b'{"error":{"message":"unavailable"}}', ""),
+        ],
+    )
+
+    assert rc == 1
+    assert "status=503" in err
+    assert "actual status must be one of [400, 429]" in err
+
+
+def test_app_cors_verify_main_print_only_uses_placeholder_when_host_missing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc, out, err, calls = _run_app_cors_main(
+        monkeypatch,
+        capsys,
+        host="",
+        errors=["helm get values failed"],
+        argv=["--print-only"],
+    )
+
+    assert rc == 0
+    assert calls == []
+    assert "helm get values failed" in err
+    assert "https://<host>/api/v1/chat/completions" in out
+    assert "curl -i -sS" in out

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -250,8 +250,8 @@ else
   printf '%s\n' "${{body}}"
 fi
 printf '%s' "${{status}}"
-if [ "${{status}}" -ge 400 ]; then
-  exit 22
+if [ -n "${{SUGARKUBE_STUB_CURL_EXIT:-}}" ]; then
+  exit "${{SUGARKUBE_STUB_CURL_EXIT}}"
 fi
 exit 0
 """,
@@ -1533,7 +1533,7 @@ def test_app_cors_verify_tokenplace_staging_options_and_actual_curl(
     assert "Access-Control-Request-Method: POST" in curl_log
     assert "Access-Control-Request-Headers: content-type" in curl_log
     assert "https://example.test/api/v1/chat/completions" in curl_log
-    assert "--data {}" in curl_log
+    assert "--data-raw {}" in curl_log
 
 
 def test_app_cors_verify_arbitrary_origin_propagates(generic_app_stub_env: dict[str, str]) -> None:
@@ -1610,6 +1610,132 @@ def test_app_cors_verify_actual_400_with_wildcard_succeeds(
     assert result.returncode == 0, result.stderr + result.stdout
 
 
+def test_app_cors_verify_accepts_wildcard_methods_and_headers(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_CORS_METHODS"] = "*"
+    env["SUGARKUBE_STUB_CORS_HEADERS"] = "*"
+
+    result = _run_just(["app-cors-verify", "app=tokenplace", "env=staging"], env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_app_cors_verify_actual_sends_configured_request_headers(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    config = tmp_path / "tokenplace.env"
+    config.write_text(
+        "\n".join(
+            [
+                "SUGARKUBE_APP=tokenplace",
+                "SUGARKUBE_RELEASE=tokenplace",
+                "SUGARKUBE_NAMESPACE=tokenplace",
+                "SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/tokenplace",
+                "SUGARKUBE_VERSION=0.1.3",
+                "SUGARKUBE_VALUES_STAGING=deploy/helm/tokenplace/values.staging.yaml",
+                "SUGARKUBE_CORS_VERIFY_PATH=/api/v1/chat/completions",
+                "SUGARKUBE_CORS_VERIFY_METHOD=POST",
+                "SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS=x-custom-one,x-custom-two",
+                "SUGARKUBE_CORS_VERIFY_BODY={}",
+                "SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES=400,429",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_CORS_HEADERS"] = "x-custom-one,x-custom-two"
+
+    result = _run_just(
+        ["app-cors-verify", "app=tokenplace", "env=staging", f"config={config}"], env
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    curl_log = Path(generic_app_stub_env["CURL_LOG"]).read_text(encoding="utf-8")
+    assert "Access-Control-Request-Headers: x-custom-one,x-custom-two" in curl_log
+    assert "x-custom-one: cors-smoke" in curl_log
+    assert "x-custom-two: cors-smoke" in curl_log
+    assert "Content-Type: application/json" in curl_log
+
+
+def test_app_cors_verify_rejects_any_curl_error(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_CURL_EXIT"] = "18"
+
+    result = _run_just(["app-cors-verify", "app=tokenplace", "env=staging"], env)
+
+    assert result.returncode != 0
+    assert "CORS verification failed" in result.stderr
+
+
+def test_app_cors_verify_bad_expected_statuses_is_operator_error(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    config = tmp_path / "tokenplace.env"
+    config.write_text(
+        "\n".join(
+            [
+                "SUGARKUBE_APP=tokenplace",
+                "SUGARKUBE_RELEASE=tokenplace",
+                "SUGARKUBE_NAMESPACE=tokenplace",
+                "SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/tokenplace",
+                "SUGARKUBE_VERSION=0.1.3",
+                "SUGARKUBE_VALUES_STAGING=deploy/helm/tokenplace/values.staging.yaml",
+                "SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES=400,abc",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_just(
+        ["app-cors-verify", "app=tokenplace", "env=staging", f"config={config}"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode != 0
+    assert "must be comma-separated integers" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_app_cors_verify_config_third_argument_remains_config(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    config = tmp_path / "tokenplace.env"
+    config.write_text(
+        "\n".join(
+            [
+                "SUGARKUBE_APP=tokenplace",
+                "SUGARKUBE_RELEASE=tokenplace",
+                "SUGARKUBE_NAMESPACE=tokenplace",
+                "SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/tokenplace",
+                "SUGARKUBE_VERSION=0.1.3",
+                "SUGARKUBE_VALUES_STAGING=deploy/helm/tokenplace/values.staging.yaml",
+                "SUGARKUBE_CORS_VERIFY_PATH=/custom-cors",
+                "SUGARKUBE_CORS_VERIFY_METHOD=POST",
+                "SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS=content-type",
+                "SUGARKUBE_CORS_VERIFY_BODY={}",
+                "SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES=200",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_just(
+        ["app-cors-verify", "app=tokenplace", "env=staging", f"config={config}", "print_only=1"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "https://example.test/custom-cors" in result.stdout
+    assert "Origin: https://cors-smoke.invalid" in result.stdout
+
+
 def test_app_cors_verify_print_only_performs_no_network_calls(
     generic_app_stub_env: dict[str, str],
 ) -> None:
@@ -1622,7 +1748,7 @@ def test_app_cors_verify_print_only_performs_no_network_calls(
     assert "curl -i -sS -X OPTIONS" in result.stdout
     assert "Access-Control-Request-Headers: content-type" in result.stdout
     assert "curl -i -sS -X POST" in result.stdout
-    assert "--data '{}'" in result.stdout
+    assert "--data-raw '{}'" in result.stdout
     assert not Path(generic_app_stub_env["CURL_LOG"]).exists()
 
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1614,7 +1614,7 @@ def test_app_cors_verify_actual_400_with_wildcard_succeeds(
     assert result.returncode == 0, result.stderr + result.stdout
 
 
-def test_app_cors_verify_accepts_wildcard_methods_and_headers(
+def test_app_cors_verify_rejects_wildcard_methods_but_accepts_wildcard_headers(
     generic_app_stub_env: dict[str, str],
 ) -> None:
     env = generic_app_stub_env.copy()
@@ -1623,7 +1623,8 @@ def test_app_cors_verify_accepts_wildcard_methods_and_headers(
 
     result = _run_just(["app-cors-verify", "app=tokenplace", "env=staging"], env)
 
-    assert result.returncode == 0, result.stderr + result.stdout
+    assert result.returncode != 0
+    assert "Access-Control-Allow-Methods must contain POST" in result.stderr
 
 
 def test_app_cors_verify_actual_sends_configured_request_headers(
@@ -1915,6 +1916,26 @@ def test_app_cors_verify_main_success_exercises_preflight_and_actual(
     assert calls[1][:2] == ["-X", "POST"]
     assert "--data-raw" in calls[1]
 
+
+def test_app_cors_verify_main_rejects_wildcard_methods(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc, _out, err, _calls = _run_app_cors_main(
+        monkeypatch,
+        capsys,
+        responses=[
+            (
+                0,
+                "204",
+                _cors_headers({"access-control-allow-methods": ["*"]}),
+                b"",
+                "",
+            ),
+        ],
+    )
+
+    assert rc == 1
+    assert "Access-Control-Allow-Methods must contain POST" in err
 
 def test_app_cors_verify_main_rejects_authorization_wildcard(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2015,3 +2015,158 @@ def test_app_cors_verify_main_print_only_uses_placeholder_when_host_missing(
     assert "helm get values failed" in err
     assert "https://<host>/api/v1/chat/completions" in out
     assert "curl -i -sS" in out
+
+
+def test_app_cors_verify_main_reports_preflight_status_and_header_failures(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc, _out, err, _calls = _run_app_cors_main(
+        monkeypatch,
+        capsys,
+        responses=[(0, "503", _cors_headers(), b"", "")],
+    )
+
+    assert rc == 1
+    assert "status=503" in err
+    assert "preflight HTTP status must be successful" in err
+
+    rc, _out, err, _calls = _run_app_cors_main(
+        monkeypatch,
+        capsys,
+        responses=[(0, "204", {"access-control-allow-origin": ["https://cors-smoke.invalid"]}, b"", "")],
+    )
+
+    assert rc == 1
+    assert "Access-Control-Allow-Origin echoed the test Origin" in err
+
+
+def test_app_cors_verify_main_reports_missing_host_and_preflight_curl_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc, _out, err, calls = _run_app_cors_main(
+        monkeypatch,
+        capsys,
+        host="",
+        errors=["ingress lookup failed"],
+    )
+
+    assert rc == 1
+    assert calls == []
+    assert "ingress lookup failed" in err
+    assert "status=000" in err
+    assert "could not derive public host" in err
+
+    rc, _out, err, _calls = _run_app_cors_main(
+        monkeypatch,
+        capsys,
+        responses=[(28, "000", {}, b"", "curl: timed out")],
+    )
+
+    assert rc == 1
+    assert "status=000" in err
+    assert "curl: timed out" in err
+
+
+def test_app_cors_verify_main_reports_actual_cors_and_body_failures(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc, _out, err, _calls = _run_app_cors_main(
+        monkeypatch,
+        capsys,
+        responses=[
+            (0, "204", _cors_headers(), b"", ""),
+            (0, "400", _cors_headers({"access-control-allow-origin": ["https://evil.test"]}), b'{"error":{}}', ""),
+        ],
+    )
+
+    assert rc == 1
+    assert "Access-Control-Allow-Origin must be literal *" in err
+
+    rc, _out, err, _calls = _run_app_cors_main(
+        monkeypatch,
+        capsys,
+        responses=[
+            (0, "204", _cors_headers(), b"", ""),
+            (0, "400", _cors_headers(), b"not json", ""),
+        ],
+    )
+
+    assert rc == 1
+    assert "token.place API error response must be JSON" in err
+
+    rc, _out, err, _calls = _run_app_cors_main(
+        monkeypatch,
+        capsys,
+        responses=[
+            (0, "204", _cors_headers(), b"", ""),
+            (0, "400", _cors_headers(), b'{"message":"missing top-level error"}', ""),
+        ],
+    )
+
+    assert rc == 1
+    assert "top-level error object" in err
+
+
+def test_app_cors_verify_main_allows_non_tokenplace_non_json_actual_body(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc, out, err, _calls = _run_app_cors_main(
+        monkeypatch,
+        capsys,
+        env={"SUGARKUBE_APP": "otherapp"},
+        responses=[
+            (0, "204", _cors_headers(), b"", ""),
+            (0, "400", _cors_headers(), b"plain text error", ""),
+        ],
+    )
+
+    assert rc == 0, err + out
+
+
+def test_app_cors_verify_main_rejects_bad_expected_status_config(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        _run_app_cors_main(
+            monkeypatch,
+            capsys,
+            env={"SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES": "400,nope"},
+        )
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES must be comma-separated integers" in captured.err
+
+    with pytest.raises(SystemExit) as excinfo:
+        _run_app_cors_main(
+            monkeypatch,
+            capsys,
+            env={"SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES": " , "},
+        )
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES must include at least one integer" in captured.err
+
+
+def test_app_cors_verify_header_parsing_helpers() -> None:
+    from scripts import app_cors_verify
+
+    headers = app_cors_verify.headers_from_bytes(
+        b"HTTP/1.1 100 Continue\r\nIgnored: yes\r\n\r\n"
+        b"HTTP/2 204\r\nAccess-Control-Allow-Origin: *\r\n"
+        b"Access-Control-Allow-Headers: content-type, x-custom\r\n"
+        b"Access-Control-Allow-Credentials: true\r\n\r\n"
+    )
+
+    assert headers["access-control-allow-origin"] == ["*"]
+    assert app_cors_verify.single_header(headers, "Access-Control-Allow-Origin") == ("*", "")
+    assert app_cors_verify.contains_header_value(
+        headers, "Access-Control-Allow-Headers", "X-Custom"
+    )
+    assert app_cors_verify.credentials_enabled(headers)
+    assert app_cors_verify.assert_wildcard(headers, "https://cors-smoke.invalid") == (
+        "Access-Control-Allow-Credentials must be absent or not true"
+    )
+    assert app_cors_verify.curl_quote("two words") == "'two words'"
+    assert app_cors_verify.csv(" a, ,b ") == ["a", "b"]

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1651,7 +1651,7 @@ def test_app_cors_verify_actual_sends_configured_request_headers(
         encoding="utf-8",
     )
     env = generic_app_stub_env.copy()
-    env["SUGARKUBE_STUB_CORS_HEADERS"] = "x-custom-one,x-custom-two"
+    env["SUGARKUBE_STUB_CORS_HEADERS"] = "x-custom-one,x-custom-two,content-type"
 
     result = _run_just(
         ["app-cors-verify", "app=tokenplace", "env=staging", f"config={config}"], env
@@ -1659,7 +1659,7 @@ def test_app_cors_verify_actual_sends_configured_request_headers(
 
     assert result.returncode == 0, result.stderr + result.stdout
     curl_log = Path(generic_app_stub_env["CURL_LOG"]).read_text(encoding="utf-8")
-    assert "Access-Control-Request-Headers: x-custom-one,x-custom-two" in curl_log
+    assert "Access-Control-Request-Headers: x-custom-one,x-custom-two,content-type" in curl_log
     assert "x-custom-one: cors-smoke" in curl_log
     assert "x-custom-two: cors-smoke" in curl_log
     assert "Content-Type: application/json" in curl_log
@@ -1936,6 +1936,30 @@ def test_app_cors_verify_main_rejects_wildcard_methods(
 
     assert rc == 1
     assert "Access-Control-Allow-Methods must contain POST" in err
+
+
+def test_app_cors_verify_main_requires_content_type_with_configured_headers(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc, _out, err, calls = _run_app_cors_main(
+        monkeypatch,
+        capsys,
+        env={"SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS": "x-custom-token"},
+        responses=[
+            (
+                0,
+                "204",
+                _cors_headers({"access-control-allow-headers": ["x-custom-token"]}),
+                b"",
+                "",
+            ),
+        ],
+    )
+
+    assert rc == 1
+    assert "Access-Control-Allow-Headers must contain content-type" in err
+    assert "Access-Control-Request-Headers: x-custom-token,content-type" in calls[0]
+
 
 def test_app_cors_verify_main_rejects_authorization_wildcard(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -167,11 +167,23 @@ exit 0
 set -euo pipefail
 printf '%s\n' "$*" >> {str(tmp_path / "curl.log")!r}
 body_file=""
+header_file=""
 url=""
+method="GET"
+origin=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --connect-timeout|--max-time|-w) shift 2 ;;
     -o) body_file="$2"; shift 2 ;;
+    -D) header_file="$2"; shift 2 ;;
+    -X) method="$2"; shift 2 ;;
+    -H)
+      case "$2" in
+        Origin:*) origin="${{2#Origin: }}" ;;
+      esac
+      shift 2
+      ;;
+    --data|--data-raw) shift 2 ;;
     -*) shift ;;
     *) url="$1"; shift ;;
   esac
@@ -180,6 +192,7 @@ path="${{url#https://example.test}}"
 path="${{path:-/}}"
 status=200
 body='{{"status":"ok"}}'
+headers=$'HTTP/2 200\r\ncontent-type: application/json\r\n'
 case "${{url}}" in
   https://api.github.com/orgs/futuroptimist/packages/container/charts%2Ftokenplace/versions*)
     status=404
@@ -190,16 +203,46 @@ case "${{url}}" in
     body='[{{"metadata":{{"container":{{"tags":["0.1.3","0.1.4-rc.1","0.1.4"]}}}}}}]'
     ;;
 esac
+if [ "${{method}}" = "OPTIONS" ]; then
+  status="${{SUGARKUBE_STUB_CORS_PREFLIGHT_STATUS:-204}}"
+  acao="${{SUGARKUBE_STUB_CORS_ACAO-*}}"
+  methods="${{SUGARKUBE_STUB_CORS_METHODS:-POST, OPTIONS}}"
+  allow_headers="${{SUGARKUBE_STUB_CORS_HEADERS:-content-type}}"
+  credentials="${{SUGARKUBE_STUB_CORS_CREDENTIALS:-}}"
+  if [ "${{acao}}" = "__origin__" ]; then acao="${{origin}}"; fi
+  headers="HTTP/2 ${{status}}"$'\r\n'
+  if [ "${{acao}}" != "__missing__" ]; then headers+="Access-Control-Allow-Origin: ${{acao}}"$'\r\n'; fi
+  headers+="Access-Control-Allow-Methods: ${{methods}}"$'\r\n'
+  headers+="Access-Control-Allow-Headers: ${{allow_headers}}"$'\r\n'
+  if [ -n "${{credentials}}" ]; then headers+="Access-Control-Allow-Credentials: ${{credentials}}"$'\r\n'; fi
+  body=''
+fi
 case "${{path}}" in
   /) body=$'<!doctype html>\n<html lang="en">\n<body>ok</body>\n</html>' ;;
   /config.json) body='{{"publicConfig":true}}' ;;
   /relay/diagnostics) body='{{"relay":"ok"}}' ;;
   /api/v1/meta) body='{{"label":"staging main-deadbee","version":"main-deadbee"}}' ;;
+  /api/v1/chat/completions)
+    if [ "${{method}}" != "OPTIONS" ]; then
+      status="${{SUGARKUBE_STUB_CORS_ACTUAL_STATUS:-400}}"
+      body='{{"error":{{"message":"invalid request"}}}}'
+      acao="${{SUGARKUBE_STUB_CORS_ACTUAL_ACAO-${{SUGARKUBE_STUB_CORS_ACAO-*}}}}"
+      credentials="${{SUGARKUBE_STUB_CORS_CREDENTIALS:-}}"
+      if [ "${{acao}}" = "__origin__" ]; then acao="${{origin}}"; fi
+      headers="HTTP/2 ${{status}}"$'\r\n'
+      if [ "${{acao}}" != "__missing__" ]; then headers+="Access-Control-Allow-Origin: ${{acao}}"$'\r\n'; fi
+      headers+=$'content-type: application/json\r\n'
+      if [ -n "${{credentials}}" ]; then headers+="Access-Control-Allow-Credentials: ${{credentials}}"$'\r\n'; fi
+    fi
+    ;;
 esac
 if [ "${{SUGARKUBE_STUB_CURL_FAIL_PATH:-}}" = "${{path}}" ]; then
   status=503
   body='{{"status":"down"}}'
   echo 'curl: (22) The requested URL returned error: 503' >&2
+fi
+if [ -n "${{header_file}}" ]; then
+  printf '%s\r\n' "${{headers}}" > "${{header_file}}"
 fi
 if [ -n "${{body_file}}" ]; then
   printf '%s\n' "${{body}}" > "${{body_file}}"
@@ -1472,3 +1515,166 @@ def test_app_verify_fails_closed_when_context_host_discovery_fails(
     assert "kubectl ingress lookup failed for context sugar-staging" in result.stderr
     assert "Suggested next steps: just app-status app=tokenplace env=staging" in result.stderr
     assert "curl -fsS https://<host>/" in result.stdout
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_cors_verify_tokenplace_staging_options_and_actual_curl(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(["app-cors-verify", "app=tokenplace", "env=staging"], generic_app_stub_env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "CORS verification passed" in result.stdout
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "--kube-context sugar-staging" in helm_log
+    curl_log = Path(generic_app_stub_env["CURL_LOG"]).read_text(encoding="utf-8")
+    assert "-X OPTIONS" in curl_log
+    assert "Origin: https://cors-smoke.invalid" in curl_log
+    assert "Access-Control-Request-Method: POST" in curl_log
+    assert "Access-Control-Request-Headers: content-type" in curl_log
+    assert "https://example.test/api/v1/chat/completions" in curl_log
+    assert "--data {}" in curl_log
+
+
+def test_app_cors_verify_arbitrary_origin_propagates(generic_app_stub_env: dict[str, str]) -> None:
+    result = _run_just(
+        [
+            "app-cors-verify",
+            "app=tokenplace",
+            "env=staging",
+            "origin=https://unrelated-client.example",
+        ],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    curl_log = Path(generic_app_stub_env["CURL_LOG"]).read_text(encoding="utf-8")
+    assert "Origin: https://unrelated-client.example" in curl_log
+
+
+@pytest.mark.parametrize(
+    ("env_key", "env_value", "message"),
+    [
+        ("SUGARKUBE_STUB_CORS_ACAO", "__missing__", "missing Access-Control-Allow-Origin"),
+        ("SUGARKUBE_STUB_CORS_ACAO", "__origin__", "echoed the test Origin"),
+        ("SUGARKUBE_STUB_CORS_CREDENTIALS", "true", "Access-Control-Allow-Credentials"),
+        (
+            "SUGARKUBE_STUB_CORS_METHODS",
+            "GET, OPTIONS",
+            "Access-Control-Allow-Methods must contain POST",
+        ),
+        (
+            "SUGARKUBE_STUB_CORS_HEADERS",
+            "authorization",
+            "Access-Control-Allow-Headers must contain content-type",
+        ),
+    ],
+)
+def test_app_cors_verify_preflight_failures(
+    generic_app_stub_env: dict[str, str], env_key: str, env_value: str, message: str
+) -> None:
+    env = generic_app_stub_env.copy()
+    env[env_key] = env_value
+
+    result = _run_just(["app-cors-verify", "app=tokenplace", "env=staging"], env)
+
+    assert result.returncode != 0
+    assert message in result.stderr
+    assert "just app-status app=tokenplace env=staging" in result.stderr
+    assert "intended immutable image tag" in result.stderr
+
+
+@pytest.mark.parametrize("status", ["403", "404", "405", "500", "503"])
+def test_app_cors_verify_actual_rejects_forbidden_missing_method_and_5xx(
+    generic_app_stub_env: dict[str, str], status: str
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_CORS_ACTUAL_STATUS"] = status
+
+    result = _run_just(["app-cors-verify", "app=tokenplace", "env=staging"], env)
+
+    assert result.returncode != 0
+    assert f"status={status}" in result.stderr
+    assert "actual status must be one of [400, 429]" in result.stderr
+
+
+def test_app_cors_verify_actual_400_with_wildcard_succeeds(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_CORS_ACTUAL_STATUS"] = "400"
+    env["SUGARKUBE_STUB_CORS_ACAO"] = "*"
+
+    result = _run_just(["app-cors-verify", "app=tokenplace", "env=staging"], env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_app_cors_verify_print_only_performs_no_network_calls(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        ["app-cors-verify", "app=tokenplace", "env=staging", "print_only=1"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "curl -i -sS -X OPTIONS" in result.stdout
+    assert "Access-Control-Request-Headers: content-type" in result.stdout
+    assert "curl -i -sS -X POST" in result.stdout
+    assert "--data '{}'" in result.stdout
+    assert not Path(generic_app_stub_env["CURL_LOG"]).exists()
+
+
+def test_app_config_emits_generic_cors_fields_safely() -> None:
+    result = subprocess.run(
+        [
+            "python3",
+            "scripts/app_config.py",
+            "shell",
+            "--app",
+            "tokenplace",
+            "--env",
+            "staging",
+            "--config",
+            "",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "export SUGARKUBE_CORS_VERIFY_PATH=/api/v1/chat/completions" in result.stdout
+    assert "export SUGARKUBE_CORS_VERIFY_BODY='{}'" in result.stdout
+    assert "export SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES=400,429" in result.stdout
+
+
+def test_app_config_rejects_unknown_app_config_keys(tmp_path: Path) -> None:
+    config = tmp_path / "bad.env"
+    config.write_text(
+        "SUGARKUBE_APP=bad\nSUGARKUBE_RELEASE=bad\nSUGARKUBE_NAMESPACE=bad\nSUGARKUBE_CHART=oci://example/bad\nSUGARKUBE_VERSION=0.1.0\nSUGARKUBE_VALUES_STAGING=values.yaml\nSUGARKUBE_UNKNOWN=1\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            "python3",
+            "scripts/app_config.py",
+            "json",
+            "--app",
+            "bad",
+            "--env",
+            "staging",
+            "--config",
+            str(config),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "unknown app config key 'SUGARKUBE_UNKNOWN'" in result.stderr

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2194,3 +2194,91 @@ def test_app_cors_verify_header_parsing_helpers() -> None:
     )
     assert app_cors_verify.curl_quote("two words") == "'two words'"
     assert app_cors_verify.csv(" a, ,b ") == ["a", "b"]
+
+
+def test_app_cors_verify_run_curl_collects_status_headers_body_and_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts import app_cors_verify
+
+    monkeypatch.setenv("SUGARKUBE_APP_VERIFY_CURL_CONNECT_TIMEOUT", "3")
+    monkeypatch.setenv("SUGARKUBE_APP_VERIFY_CURL_MAX_TIME", "7")
+    seen: dict[str, object] = {}
+
+    class Completed:
+        returncode = 18
+        stdout = "400"
+        stderr = "curl: transfer closed"
+
+    def fake_run(
+        cmd: list[str],
+        *,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+    ) -> Completed:
+        seen["cmd"] = cmd
+        seen["capture_output"] = capture_output
+        seen["text"] = text
+        seen["check"] = check
+        header_path = Path(cmd[cmd.index("-D") + 1])
+        body_path = Path(cmd[cmd.index("-o") + 1])
+        header_path.write_bytes(
+            b"HTTP/1.1 100 Continue\r\nIgnored: yes\r\n\r\n"
+            b"HTTP/2 400\r\nAccess-Control-Allow-Origin: *\r\n"
+            b"Access-Control-Allow-Headers: content-type\r\n\r\n"
+        )
+        body_path.write_bytes(b'{"error":{}}')
+        return Completed()
+
+    monkeypatch.setattr(app_cors_verify.subprocess, "run", fake_run)
+
+    rc, status, headers, body, stderr = app_cors_verify.run_curl(
+        ["-X", "POST", "https://example.test"]
+    )
+
+    assert rc == 18
+    assert status == "400"
+    assert headers["access-control-allow-origin"] == ["*"]
+    assert headers["access-control-allow-headers"] == ["content-type"]
+    assert body == b'{"error":{}}'
+    assert stderr == "curl: transfer closed"
+    cmd = seen["cmd"]
+    assert isinstance(cmd, list)
+    assert cmd[:6] == ["curl", "-sS", "--connect-timeout", "3", "--max-time", "7"]
+    assert cmd[-3:] == ["-X", "POST", "https://example.test"]
+    assert seen == {**seen, "capture_output": True, "text": True, "check": False}
+    assert not Path(cmd[cmd.index("-D") + 1]).exists()
+    assert not Path(cmd[cmd.index("-o") + 1]).exists()
+
+
+def test_app_cors_verify_run_curl_defaults_blank_status_and_missing_files(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts import app_cors_verify
+
+    class Completed:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(
+        cmd: list[str],
+        *,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+    ) -> Completed:
+        Path(cmd[cmd.index("-D") + 1]).unlink()
+        Path(cmd[cmd.index("-o") + 1]).unlink()
+        return Completed()
+
+    monkeypatch.setattr(app_cors_verify.subprocess, "run", fake_run)
+
+    rc, status, headers, body, stderr = app_cors_verify.run_curl(["https://example.test"])
+
+    assert rc == 0
+    assert status == "000"
+    assert headers == {}
+    assert body == b""
+    assert stderr == ""


### PR DESCRIPTION
### Motivation
- Provide a generic, read-only operator workflow to verify an app-owned public CORS contract per environment without mutating ingress or edge rules. 
- Make token.place the first configured consumer of the check and document the required cross-app release ordering for DSPACE. 
- Reuse existing app config and host-discovery logic so the recipe fits into the established Sugarkube verification flows.

### Description
- Add a new helper `scripts/app_cors_verify.py` that performs an `OPTIONS` preflight and an actual invalid-POST probe, parses response headers case-insensitively, enforces literal `Access-Control-Allow-Origin: *`, rejects credentialed CORS, validates allowed methods/headers and token.place JSON error shape, and prints helpful failure context. 
- Add a `just app-cors-verify` recipe to `justfile` that reuses `scripts/app_config.py` and the kube-context naming used by existing verification recipes and supports `app=`, `env=`, `origin=`, and `print_only=1`. 
- Extend `scripts/app_config.py` to accept and default generic CORS fields (`SUGARKUBE_CORS_VERIFY_PATH`, `SUGARKUBE_CORS_VERIFY_METHOD`, `SUGARKUBE_CORS_VERIFY_REQUEST_HEADERS`, `SUGARKUBE_CORS_VERIFY_BODY`, `SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES`) and emit them via the `shell` output. 
- Add focused tests in `tests/test_generic_app_just_recipes.py` to cover preflight/actual probes, origin propagation, wildcard success, multiple failure modes, `print_only` behavior, and app-config key validation. 
- Document the browser CORS verification steps in `docs/apps/tokenplace.md` and add a cross-app token.place-first release sequence to `docs/apps/dspace.md`. 

### Testing
- Ran unit/recipe tests with `pytest -q tests/test_generic_app_just_recipes.py -k "cors or app_verify or app_config"` which completed successfully (`40 passed, 51 deselected`).
- Verified the recipe is discoverable with `just --list | rg "app-cors-verify"` and confirmed print-only output with `just app-cors-verify app=tokenplace env=staging print_only=1` (printed copy/paste curl commands). 
- Searched the tree for new symbols with `rg -n "app-cors-verify|SUGARKUBE_CORS_VERIFY|Access-Control-Allow-Origin|cors-smoke" justfile scripts tests docs` and ran the repository secret scan on staged changes with `git diff --cached | ./scripts/scan-secrets.py` (no secrets reported). 
- Not run in this environment: `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` due to missing tools in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35a741acf0832f95b5e91082460e00)