### PR TITLE
Wire DSPACE token.place runtime origins

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -38,7 +38,7 @@ Use these links before changing a deployment so the workflow runs, package versi
 
 ## Environment topology
 
-- `env=dev`: future single-node/non-HA environment using `docs/examples/dspace.values.dev.yaml`.
+- `env=dev`: future single-node/non-HA environment using `docs/examples/dspace.values.dev.yaml`. The dev overlay intentionally leaves token.place runtime variables unset; developers who need a local token.place origin should copy the values file or local app config and set `DSPACE_TOKEN_PLACE_URL` plus `DSPACE_TOKEN_PLACE_CHAT_MODEL` in their private override.
 - `env=staging`: HA staging on the staging Sugarkube cluster with host `staging.democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
 - `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
 - Optional legacy/canary host `prod.democratized.space` still has `docs/examples/dspace.values.prod-subdomain.yaml`, but the generic app flow uses the production apex overlay unless a local app config intentionally overrides it.
@@ -88,6 +88,8 @@ gh workflow run ci-helm.yml --repo democratizedspace/dspace --ref main
 
 ## Deploy staging
 
+Deploy the new immutable, environment-neutral DSPACE image after the DSPACE runtime-configuration change has merged and the image has been published. The staging values overlay, not the image tag, selects `https://staging.token.place` at container runtime.
+
 Preferred generic command:
 
 ```bash
@@ -116,6 +118,16 @@ just app-verify app=dspace env=staging
 just app-verify app=dspace env=staging print_only=1
 ```
 
+The runtime config check must pass before opening `/chat`; otherwise the browser bundle may route chat traffic to the wrong token.place origin. Browser Network must show staging DSPACE calling staging token.place. A staging request to production token.place is a stop-ship routing failure. CORS is owned by token.place and verified separately in the generic CORS recipe.
+
+```bash
+curl -fsS https://staging.democratized.space/config.json \
+  | jq -e '
+      .tokenPlace.url == "https://staging.token.place"
+      and .tokenPlace.model == "gpt-5-chat-latest"
+    '
+```
+
 Manual public checks are optional fallbacks when Cloudflare or cert-manager are suspect.
 
 ```bash
@@ -132,7 +144,7 @@ curl -fsS https://staging.democratized.space/livez
 
 ## Promote production
 
-Promote only after staging sign-off. Prefer the generic command; it uses the prod values chain and can read `docs/apps/dspace.prod.tag` when `tag=` is omitted.
+Promote only after staging sign-off. Prefer the generic command; it uses the prod values chain and can read `docs/apps/dspace.prod.tag` when `tag=` is omitted. The same immutable DSPACE image moves forward; the production values overlay selects `https://token.place` at container runtime instead of using an environment-specific image name.
 
 ```bash
 just app-promote-prod app=dspace tag="$APP_TAG"
@@ -158,6 +170,16 @@ Print the generated curl commands without executing them when you need a manual 
 
 ```bash
 just app-verify app=dspace env=prod print_only=1
+```
+
+The runtime config check must pass before opening `/chat`; otherwise production chat may route to the wrong token.place origin. Browser Network must show production DSPACE calling production token.place. CORS is owned by token.place and verified separately in the generic CORS recipe.
+
+```bash
+curl -fsS https://democratized.space/config.json \
+  | jq -e '
+      .tokenPlace.url == "https://token.place"
+      and .tokenPlace.model == "gpt-5-chat-latest"
+    '
 ```
 
 Optional manual fallback:
@@ -246,8 +268,11 @@ just cf-tunnel-route host=democratized.space
 
 ## App-specific notes
 
-- DSPACE serves `/config.json`; verify it with `jq` before production promotion.
-- Keep release lineage separate from environment routing: image tags identify app code, values overlays identify `staging` or `prod` hostnames.
+- DSPACE serves `/config.json`; verify it with `jq` before opening `/chat` or promoting production.
+- The DSPACE image tag remains immutable and environment-neutral. Environment overlays, not image names, select the token.place origin.
+- Keep release lineage separate from environment routing: image tags identify app code, values overlays identify `staging` or `prod` hostnames and token.place origins.
+- Do not put `VITE_TOKEN_PLACE_URL` or `VITE_TOKEN_PLACE_CHAT_MODEL` in Kubernetes runtime values; those are build-time compatibility fallbacks and cannot repair an already-built browser bundle.
+- Do not add token.place API keys, credentials, `Authorization` headers, or proxy/CORS ingress logic to DSPACE overlays. CORS belongs to token.place and is verified separately.
 - The optional `prod.democratized.space` overlay is not the default production path in the generic config.
 
 ### Legacy Helm helper reference

--- a/docs/examples/dspace.values.prod.yaml
+++ b/docs/examples/dspace.values.prod.yaml
@@ -6,3 +6,10 @@ ingress:
   enabled: true
   className: traefik
   host: democratized.space
+
+# Runtime token.place routing for the immutable DSPACE image.
+env:
+  - name: DSPACE_TOKEN_PLACE_URL
+    value: https://token.place
+  - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
+    value: gpt-5-chat-latest

--- a/docs/examples/dspace.values.staging.yaml
+++ b/docs/examples/dspace.values.staging.yaml
@@ -5,3 +5,10 @@ ingress:
   enabled: true
   className: traefik
   host: staging.democratized.space
+
+# Runtime token.place routing for the immutable DSPACE image.
+env:
+  - name: DSPACE_TOKEN_PLACE_URL
+    value: https://staging.token.place
+  - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
+    value: gpt-5-chat-latest

--- a/tests/test_dspace_values_runtime_config.py
+++ b/tests/test_dspace_values_runtime_config.py
@@ -1,0 +1,55 @@
+"""Guardrails for DSPACE token.place runtime routing values."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+DSPACE_OVERLAYS = [
+    Path("docs/examples/dspace.values.staging.yaml"),
+    Path("docs/examples/dspace.values.prod.yaml"),
+]
+
+
+def _env_values(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    current_name: str | None = None
+    for line in path.read_text(encoding="utf-8").splitlines():
+        name_match = re.match(r"\s*-\s+name:\s+([^\s#]+)\s*$", line)
+        if name_match:
+            current_name = name_match.group(1)
+            continue
+        value_match = re.match(r"\s+value:\s+(.+?)\s*$", line)
+        if value_match and current_name is not None:
+            values[current_name] = value_match.group(1).strip('"\'')
+            current_name = None
+    return values
+
+
+def test_dspace_staging_routes_to_staging_token_place() -> None:
+    env = _env_values(Path("docs/examples/dspace.values.staging.yaml"))
+
+    assert env["DSPACE_TOKEN_PLACE_URL"] == "https://staging.token.place"
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == "gpt-5-chat-latest"
+
+
+def test_dspace_prod_routes_to_prod_token_place() -> None:
+    env = _env_values(Path("docs/examples/dspace.values.prod.yaml"))
+
+    assert env["DSPACE_TOKEN_PLACE_URL"] == "https://token.place"
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == "gpt-5-chat-latest"
+
+
+def test_dspace_runtime_overlays_do_not_use_vite_build_time_fallbacks() -> None:
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in DSPACE_OVERLAYS)
+
+    assert "VITE_TOKEN_PLACE_URL" not in combined
+    assert "VITE_TOKEN_PLACE_CHAT_MODEL" not in combined
+
+
+def test_dspace_runtime_overlays_do_not_include_token_place_credentials() -> None:
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in DSPACE_OVERLAYS)
+
+    assert "Authorization" not in combined
+    assert ("api" + "Key") not in combined
+    assert "credential" not in combined.lower()


### PR DESCRIPTION
### Motivation
- Ensure the immutable DSPACE image can be promoted between environments while the runtime overlay selects the correct token.place origin for staging and production. 
- Make `/config.json` the explicit runtime release check before opening `/chat` and document how developers can override runtime values locally.

### Description
- Injected runtime env entries into the existing DSPACE Helm values overlays: `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest` in `docs/examples/dspace.values.staging.yaml`, and `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest` in `docs/examples/dspace.values.prod.yaml` using the chart's `env` list format. 
- Added focused pytest guardrails `tests/test_dspace_values_runtime_config.py` that verify staging/prod overlays contain the exact URLs and model, that `VITE_*` build-time fallbacks are not used at runtime, and that credential-like values are not present in overlays. 
- Updated `docs/apps/dspace.md` to document the runtime verification curl checks for both staging and production, guidance that the DSPACE image tag remains immutable and environment-neutral, developer-local override advice for `dev`, and CORS ownership/verification notes.

### Testing
- Ran the targeted pytest selection including the new overlay tests with `pytest -q tests/test_dspace_values_runtime_config.py tests/test_app_config.py tests/test_generic_app_just_recipes.py::test_app_deploy_uses_app_release_namespace_chart_values` and the selected suite completed successfully (all selected pytest tests passed). 
- Verified resolved app config for staging and prod with `mise x just -- just app-config app=dspace env=staging` and `mise x just -- just app-config app=dspace env=prod`, both produced expected SUGARKUBE_VALUES chains. 
- Confirmed overlays and docs do not contain `VITE_TOKEN_PLACE*`, credential tokens, or Authorization strings using `rg` and ran `linkchecker --no-warnings README.md docs/`, which completed with no link errors. 
- Attempted to validate chart rendering with `helm template ... oci://ghcr.io/democratizedspace/charts/dspace --version 3.0.1`, but fetching the pinned chart failed due to GHCR returning 401 Unauthorized (chart access restricted), so full `helm template` validation could not be completed in this environment. 

Warnings / environmental notes: `pre-commit run --all-files` surfaced unrelated repository-wide hook failures and YAML/flake8 issues outside this scoped change; `pyspelling -c .spellcheck.yaml` could not complete because `aspell` is not installed in the execution environment. These are pre-existing repo concerns and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35b1942bbc832fa005c5731831006e)