### PR TITLE
Wire DSPACE token.place runtime origins

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -39,8 +39,11 @@ Use these links before changing a deployment so the workflow runs, package versi
 ## Environment topology
 
 - `env=dev`: future single-node/non-HA environment using `docs/examples/dspace.values.dev.yaml`.
+  The dev overlay intentionally does not choose a token.place origin; developers who need local runtime routing can copy `docs/examples/apps/dspace.env` to a local app config and add chart-supported `env` entries to their private values file.
 - `env=staging`: HA staging on the staging Sugarkube cluster with host `staging.democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
+  The staging overlay injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest`.
 - `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
+  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest`.
 - Optional legacy/canary host `prod.democratized.space` still has `docs/examples/dspace.values.prod-subdomain.yaml`, but the generic app flow uses the production apex overlay unless a local app config intentionally overrides it.
 
 ## Find or publish GHCR image
@@ -88,6 +91,8 @@ gh workflow run ci-helm.yml --repo democratizedspace/dspace --ref main
 
 ## Deploy staging
 
+After this repository change is merged, deploy the new immutable, environment-neutral DSPACE image that contains runtime `/config.json` support. The image tag stays the same as it moves between staging and production; the Sugarkube values overlays, not image names, select the token.place origin.
+
 Preferred generic command:
 
 ```bash
@@ -116,10 +121,14 @@ just app-verify app=dspace env=staging
 just app-verify app=dspace env=staging print_only=1
 ```
 
-Manual public checks are optional fallbacks when Cloudflare or cert-manager are suspect.
+Manual public checks are optional fallbacks when Cloudflare or cert-manager are suspect. The runtime config check must pass before opening `/chat`; browser Network must show staging DSPACE calling staging token.place. A staging request to production token.place is a stop-ship routing failure. CORS is owned by token.place and verified separately in the generic CORS recipe.
 
 ```bash
-curl -fsS https://staging.democratized.space/config.json | jq .
+curl -fsS https://staging.democratized.space/config.json \
+  | jq -e '
+      .tokenPlace.url == "https://staging.token.place"
+      and .tokenPlace.model == "gpt-5-chat-latest"
+    '
 ```
 
 ```bash
@@ -160,10 +169,14 @@ Print the generated curl commands without executing them when you need a manual 
 just app-verify app=dspace env=prod print_only=1
 ```
 
-Optional manual fallback:
+Optional manual fallback. The runtime config check must pass before opening `/chat`; browser Network should show production DSPACE calling production token.place. The immutable DSPACE image remains environment-neutral, and this production overlay selects the production token.place origin without rebuilding the image. CORS is owned by token.place and verified separately in the generic CORS recipe.
 
 ```bash
-curl -fsS https://democratized.space/config.json | jq .
+curl -fsS https://democratized.space/config.json \
+  | jq -e '
+      .tokenPlace.url == "https://token.place"
+      and .tokenPlace.model == "gpt-5-chat-latest"
+    '
 ```
 
 ```bash
@@ -246,8 +259,8 @@ just cf-tunnel-route host=democratized.space
 
 ## App-specific notes
 
-- DSPACE serves `/config.json`; verify it with `jq` before production promotion.
-- Keep release lineage separate from environment routing: image tags identify app code, values overlays identify `staging` or `prod` hostnames.
+- DSPACE serves `/config.json`; verify it with `jq` before production promotion and before opening `/chat`.
+- Keep release lineage separate from environment routing: image tags identify app code, values overlays identify `staging` or `prod` hostnames and token.place origins.
 - The optional `prod.democratized.space` overlay is not the default production path in the generic config.
 
 ### Legacy Helm helper reference

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -107,7 +107,7 @@ just dspace-oci-deploy env=staging tag="$APP_TAG"
 
 ## Verify staging
 
-Generic verification discovers the host from Helm values or Ingress, executes the configured DSPACE paths, prints a per-path body preview, and exits non-zero if any check fails. Use `print_only=1` when you only want the curl commands for docs or troubleshooting.
+Generic verification discovers the host from Helm values or Ingress, executes the configured DSPACE paths, prints a per-path body preview, and exits non-zero if any HTTP check fails. It does not validate the `/config.json` body, so staging sign-off also requires the explicit `curl | jq` routing gate below. Use `print_only=1` when you only want the curl commands for docs or troubleshooting.
 
 ```bash
 just app-status app=dspace env=staging
@@ -121,7 +121,7 @@ just app-verify app=dspace env=staging
 just app-verify app=dspace env=staging print_only=1
 ```
 
-Manual public checks are optional fallbacks when Cloudflare or cert-manager are suspect. The runtime config check must pass before opening `/chat`; browser Network must show staging DSPACE calling staging token.place. A staging request to production token.place is a stop-ship routing failure. CORS is owned by token.place and verified separately in the generic CORS recipe.
+The runtime config check is a required routing gate, not an optional fallback: it must return the staging token.place origin before production promotion and before opening `/chat`. Browser Network must show staging DSPACE calling staging token.place; a staging request to production token.place is a stop-ship routing failure. If `/chat` fails after `/config.json` is correct, capture the browser CORS error plus the token.place response headers and escalate to the token.place operator; do not change DSPACE values to work around token.place CORS policy.
 
 ```bash
 curl -fsS https://staging.democratized.space/config.json \
@@ -169,7 +169,7 @@ Print the generated curl commands without executing them when you need a manual 
 just app-verify app=dspace env=prod print_only=1
 ```
 
-Optional manual fallback. The runtime config check must pass before opening `/chat`; browser Network should show production DSPACE calling production token.place. The immutable DSPACE image remains environment-neutral, and this production overlay selects the production token.place origin without rebuilding the image. CORS is owned by token.place and verified separately in the generic CORS recipe.
+The runtime config check is a required production routing gate before opening `/chat`; browser Network should show production DSPACE calling production token.place. The immutable DSPACE image remains environment-neutral, and this production overlay selects the production token.place origin without rebuilding the image. If `/chat` fails after `/config.json` is correct, capture the browser CORS error plus the token.place response headers and escalate to the token.place operator; do not change DSPACE values to work around token.place CORS policy.
 
 ```bash
 curl -fsS https://democratized.space/config.json \

--- a/docs/examples/dspace.values.prod.yaml
+++ b/docs/examples/dspace.values.prod.yaml
@@ -6,3 +6,9 @@ ingress:
   enabled: true
   className: traefik
   host: democratized.space
+
+env:
+  - name: DSPACE_TOKEN_PLACE_URL
+    value: https://token.place
+  - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
+    value: gpt-5-chat-latest

--- a/docs/examples/dspace.values.staging.yaml
+++ b/docs/examples/dspace.values.staging.yaml
@@ -5,3 +5,9 @@ ingress:
   enabled: true
   className: traefik
   host: staging.democratized.space
+
+env:
+  - name: DSPACE_TOKEN_PLACE_URL
+    value: https://staging.token.place
+  - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
+    value: gpt-5-chat-latest

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -1,0 +1,75 @@
+"""Focused tests for DSPACE token.place runtime Helm values."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OVERLAYS = {
+    "staging": REPO_ROOT / "docs/examples/dspace.values.staging.yaml",
+    "prod": REPO_ROOT / "docs/examples/dspace.values.prod.yaml",
+}
+TOKEN_PLACE_NAMES = {
+    "DSPACE_TOKEN_PLACE_URL",
+    "DSPACE_TOKEN_PLACE_CHAT_MODEL",
+}
+FORBIDDEN_RUNTIME_NAMES = {
+    "VITE_TOKEN_PLACE_URL",
+    "VITE_TOKEN_PLACE_CHAT_MODEL",
+}
+FORBIDDEN_SECRET_PATTERNS = (
+    re.compile(r"Authorization", re.IGNORECASE),
+    re.compile("api" + "Key", re.IGNORECASE),
+    re.compile(r"credential", re.IGNORECASE),
+)
+
+
+def _runtime_env(path: Path) -> dict[str, str]:
+    """Parse the simple chart env list used by the DSPACE example overlays."""
+    env: dict[str, str] = {}
+    in_env = False
+    current_name: str | None = None
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line == "env:":
+            in_env = True
+            continue
+        if not in_env:
+            continue
+        if line.startswith("- name: "):
+            current_name = line.removeprefix("- name: ").strip()
+            continue
+        if line.startswith("value: ") and current_name is not None:
+            env[current_name] = line.removeprefix("value: ").strip().strip('"')
+            current_name = None
+    return env
+
+
+def test_dspace_staging_overlay_points_to_staging_token_place() -> None:
+    env = _runtime_env(OVERLAYS["staging"])
+
+    assert env["DSPACE_TOKEN_PLACE_URL"] == "https://staging.token.place"
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == "gpt-5-chat-latest"
+
+
+def test_dspace_prod_overlay_points_to_prod_token_place() -> None:
+    env = _runtime_env(OVERLAYS["prod"])
+
+    assert env["DSPACE_TOKEN_PLACE_URL"] == "https://token.place"
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == "gpt-5-chat-latest"
+
+
+def test_dspace_deployment_overlays_have_no_vite_runtime_env() -> None:
+    for path in OVERLAYS.values():
+        env = _runtime_env(path)
+        assert TOKEN_PLACE_NAMES <= env.keys()
+        assert FORBIDDEN_RUNTIME_NAMES.isdisjoint(env.keys())
+
+
+def test_dspace_deployment_overlays_do_not_carry_token_place_credentials() -> None:
+    for path in OVERLAYS.values():
+        text = path.read_text(encoding="utf-8")
+        assert "token.place" in text
+        for pattern in FORBIDDEN_SECRET_PATTERNS:
+            assert pattern.search(text) is None, f"{pattern.pattern} found in {path}"

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -14,10 +14,6 @@ TOKEN_PLACE_NAMES = {
     "DSPACE_TOKEN_PLACE_URL",
     "DSPACE_TOKEN_PLACE_CHAT_MODEL",
 }
-FORBIDDEN_RUNTIME_NAMES = {
-    "VITE_TOKEN_PLACE_URL",
-    "VITE_TOKEN_PLACE_CHAT_MODEL",
-}
 FORBIDDEN_SECRET_PATTERNS = (
     re.compile(r"Authorization", re.IGNORECASE),
     re.compile("api" + "Key", re.IGNORECASE),
@@ -64,7 +60,8 @@ def test_dspace_deployment_overlays_have_no_vite_runtime_env() -> None:
     for path in OVERLAYS.values():
         env = _runtime_env(path)
         assert TOKEN_PLACE_NAMES <= env.keys()
-        assert FORBIDDEN_RUNTIME_NAMES.isdisjoint(env.keys())
+        vite_names = sorted(name for name in env if name.startswith("VITE_"))
+        assert vite_names == []
 
 
 def test_dspace_deployment_overlays_do_not_carry_token_place_credentials() -> None:

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -3,27 +3,39 @@
 from __future__ import annotations
 
 import re
+import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.app_config import load_config  # noqa: E402
+
 OVERLAYS = {
     "staging": REPO_ROOT / "docs/examples/dspace.values.staging.yaml",
     "prod": REPO_ROOT / "docs/examples/dspace.values.prod.yaml",
+}
+ALL_DSPACE_VALUES = sorted((REPO_ROOT / "docs/examples").glob("dspace.values.*.yaml"))
+EXPECTED_VALUES_CHAINS = {
+    "staging": "docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml",
+    "prod": "docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml",
 }
 TOKEN_PLACE_NAMES = {
     "DSPACE_TOKEN_PLACE_URL",
     "DSPACE_TOKEN_PLACE_CHAT_MODEL",
 }
-FORBIDDEN_SECRET_PATTERNS = (
+FORBIDDEN_RUNTIME_PATTERNS = (
+    re.compile(r"VITE_TOKEN_PLACE_URL", re.IGNORECASE),
+    re.compile(r"VITE_TOKEN_PLACE_CHAT_MODEL", re.IGNORECASE),
     re.compile(r"Authorization", re.IGNORECASE),
     re.compile("api" + "Key", re.IGNORECASE),
     re.compile(r"credential", re.IGNORECASE),
 )
 
 
-def _runtime_env(path: Path) -> dict[str, str]:
+def _runtime_env(path: Path) -> dict[str, list[str]]:
     """Parse the simple chart env list used by the DSPACE example overlays."""
-    env: dict[str, str] = {}
+    env: dict[str, list[str]] = {}
     in_env = False
     current_name: str | None = None
     for raw_line in path.read_text(encoding="utf-8").splitlines():
@@ -37,7 +49,9 @@ def _runtime_env(path: Path) -> dict[str, str]:
             current_name = line.removeprefix("- name: ").strip()
             continue
         if line.startswith("value: ") and current_name is not None:
-            env[current_name] = line.removeprefix("value: ").strip().strip('"')
+            env.setdefault(current_name, []).append(
+                line.removeprefix("value: ").strip().strip('"')
+            )
             current_name = None
     return env
 
@@ -45,15 +59,15 @@ def _runtime_env(path: Path) -> dict[str, str]:
 def test_dspace_staging_overlay_points_to_staging_token_place() -> None:
     env = _runtime_env(OVERLAYS["staging"])
 
-    assert env["DSPACE_TOKEN_PLACE_URL"] == "https://staging.token.place"
-    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == "gpt-5-chat-latest"
+    assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://staging.token.place"]
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["gpt-5-chat-latest"]
 
 
 def test_dspace_prod_overlay_points_to_prod_token_place() -> None:
     env = _runtime_env(OVERLAYS["prod"])
 
-    assert env["DSPACE_TOKEN_PLACE_URL"] == "https://token.place"
-    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == "gpt-5-chat-latest"
+    assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://token.place"]
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["gpt-5-chat-latest"]
 
 
 def test_dspace_deployment_overlays_have_no_vite_runtime_env() -> None:
@@ -64,9 +78,14 @@ def test_dspace_deployment_overlays_have_no_vite_runtime_env() -> None:
         assert vite_names == []
 
 
-def test_dspace_deployment_overlays_do_not_carry_token_place_credentials() -> None:
-    for path in OVERLAYS.values():
+def test_all_dspace_values_do_not_carry_forbidden_runtime_names_or_credentials() -> None:
+    for path in ALL_DSPACE_VALUES:
         text = path.read_text(encoding="utf-8")
-        assert "token.place" in text
-        for pattern in FORBIDDEN_SECRET_PATTERNS:
+        for pattern in FORBIDDEN_RUNTIME_PATTERNS:
             assert pattern.search(text) is None, f"{pattern.pattern} found in {path}"
+
+
+def test_dspace_values_chains_resolve_expected_deployment_overlays() -> None:
+    for env, expected_values in EXPECTED_VALUES_CHAINS.items():
+        config = load_config("dspace", env)
+        assert config["SUGARKUBE_VALUES"] == expected_values


### PR DESCRIPTION
### Motivation
- Ensure Sugarkube DSPACE staging routes to the staging `token.place` origin and production routes to the production `token.place` origin at container runtime. 
- Preserve the immutable, environment-neutral DSPACE image promotion model by selecting runtime origins in values overlays rather than rebuilding or tagging images. 
- Prevent build-time Vite fallbacks and avoid embedding credentials or Authorization headers in overlay values. 

### Description
- Add runtime `env` entries to `docs/examples/dspace.values.staging.yaml` to inject `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest`. 
- Add runtime `env` entries to `docs/examples/dspace.values.prod.yaml` to inject `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest`. 
- Add focused tests in `tests/test_dspace_runtime_values.py` that assert the staging/prod overlays contain the exact `DSPACE_TOKEN_PLACE_URL` and `DSPACE_TOKEN_PLACE_CHAT_MODEL`, that no `VITE_*` runtime variables are present, and that no credential-like patterns or Authorization values appear in the overlays. 
- Update `docs/apps/dspace.md` with developer guidance for local overrides, an explicit post-deploy `/config.json` runtime routing verification for staging and production, and stop-ship guidance if staging calls the wrong token.place origin. 

### Testing
- Ran `pytest -q tests/test_app_config.py tests/test_dspace_runtime_values.py tests/test_generic_app_just_recipes.py::test_app_deploy_uses_app_release_namespace_chart_values` and received `41 passed`. 
- Ran `just app-config app=dspace env=staging` and `just app-config app=dspace env=prod` to verify the resolved values chains include the updated overlays and observed expected `SUGARKUBE_VALUES` outputs. 
- Ran `rg -n "DSPACE_TOKEN_PLACE|VITE_TOKEN_PLACE|token.place|Authorization|apiKey|credential" docs/examples/dspace.values.*.yaml docs/apps/dspace.md` and confirmed the new `DSPACE_TOKEN_PLACE_*` entries and absence of forbidden runtime names/credentials. 
- Ran `linkchecker --no-warnings README.md docs/` which completed with 0 errors, and ran the repository secret scan via `git diff --cached | ./scripts/scan-secrets.py` which did not report leaked credentials for the changes. 
- Not run: `helm template` rendering could not be executed in this environment because `helm` was not installed. 
- Partial checks not completed: `pyspelling -c .spellcheck.yaml` could not complete because `aspell` is not present in the environment, and an initial `pre-commit run --all-files` attempt surfaced unrelated repo-wide hook auto-fixes that were reverted and are outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35b19d4220832fb187ad566eaa30fb)