### PR TITLE
Wire DSPACE token.place runtime origins

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -39,9 +39,33 @@ Use these links before changing a deployment so the workflow runs, package versi
 ## Environment topology
 
 - `env=dev`: future single-node/non-HA environment using `docs/examples/dspace.values.dev.yaml`.
-- `env=staging`: HA staging on the staging Sugarkube cluster with host `staging.democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
-- `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
+  The dev base intentionally does not choose a token.place origin; developers who need one should
+  copy the app config outside the repo or pass a local values overlay that sets
+  `DSPACE_TOKEN_PLACE_URL` and `DSPACE_TOKEN_PLACE_CHAT_MODEL`.
+- `env=staging`: HA staging on the staging Sugarkube cluster with host
+  `staging.democratized.space` and values
+  `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`; the overlay
+  routes DSPACE to `https://staging.token.place`.
+- `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space`
+  and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`; the
+  overlay routes DSPACE to `https://token.place`.
 - Optional legacy/canary host `prod.democratized.space` still has `docs/examples/dspace.values.prod-subdomain.yaml`, but the generic app flow uses the production apex overlay unless a local app config intentionally overrides it.
+
+
+## Runtime token.place routing
+
+Sugarkube keeps the DSPACE image tag immutable and environment-neutral. Deploy the new immutable
+DSPACE image after this change merges, then promote that same image tag through staging and
+production; environment overlays, not image names or rebuilds, select the token.place origin. The
+staging overlay injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and the production
+overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place`; both set
+`DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest`.
+
+Do not add `VITE_TOKEN_PLACE_URL` or `VITE_TOKEN_PLACE_CHAT_MODEL` to Kubernetes runtime values.
+Those names are build-time compatibility fallbacks for the browser bundle and cannot fix an
+already-built image. Do not add token.place API keys, credentials, Authorization headers, proxy
+settings, or ingress CORS logic to DSPACE values. CORS is owned by token.place and is verified
+separately in the generic CORS recipe.
 
 ## Find or publish GHCR image
 
@@ -121,6 +145,20 @@ Manual public checks are optional fallbacks when Cloudflare or cert-manager are 
 ```bash
 curl -fsS https://staging.democratized.space/config.json | jq .
 ```
+The runtime routing check must pass before opening `/chat`:
+
+```bash
+curl -fsS https://staging.democratized.space/config.json \
+  | jq -e '
+      .tokenPlace.url == "https://staging.token.place"
+      and .tokenPlace.model == "gpt-5-chat-latest"
+    '
+```
+
+After the JSON check passes, open `/chat` and use Browser Network to confirm staging DSPACE calls
+staging token.place. A staging request to production token.place is a stop-ship routing failure;
+stop the rollout and inspect the values chain before continuing.
+
 
 ```bash
 curl -fsS https://staging.democratized.space/healthz
@@ -165,6 +203,20 @@ Optional manual fallback:
 ```bash
 curl -fsS https://democratized.space/config.json | jq .
 ```
+The runtime routing check must pass before opening `/chat`:
+
+```bash
+curl -fsS https://democratized.space/config.json \
+  | jq -e '
+      .tokenPlace.url == "https://token.place"
+      and .tokenPlace.model == "gpt-5-chat-latest"
+    '
+```
+
+After the JSON check passes, open `/chat` and use Browser Network to confirm production DSPACE
+calls production token.place. If a production rollout unexpectedly calls the staging origin, stop
+and correct the production overlay before sign-off.
+
 
 ```bash
 curl -fsS https://democratized.space/healthz

--- a/docs/examples/dspace.values.prod.yaml
+++ b/docs/examples/dspace.values.prod.yaml
@@ -6,3 +6,9 @@ ingress:
   enabled: true
   className: traefik
   host: democratized.space
+
+env:
+  - name: DSPACE_TOKEN_PLACE_URL
+    value: https://token.place
+  - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
+    value: gpt-5-chat-latest

--- a/docs/examples/dspace.values.staging.yaml
+++ b/docs/examples/dspace.values.staging.yaml
@@ -5,3 +5,9 @@ ingress:
   enabled: true
   className: traefik
   host: staging.democratized.space
+
+env:
+  - name: DSPACE_TOKEN_PLACE_URL
+    value: https://staging.token.place
+  - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
+    value: gpt-5-chat-latest

--- a/tests/test_dspace_token_place_runtime.py
+++ b/tests/test_dspace_token_place_runtime.py
@@ -1,0 +1,77 @@
+"""Regression tests for DSPACE token.place runtime routing overlays."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OVERLAYS = {
+    "staging": REPO_ROOT / "docs/examples/dspace.values.staging.yaml",
+    "prod": REPO_ROOT / "docs/examples/dspace.values.prod.yaml",
+}
+EXPECTED_URLS = {
+    "staging": "https://staging.token.place",
+    "prod": "https://token.place",
+}
+EXPECTED_MODEL = "gpt-5-chat-latest"
+FORBIDDEN_RUNTIME_NAMES = {"VITE_TOKEN_PLACE_URL", "VITE_TOKEN_PLACE_CHAT_MODEL"}
+FORBIDDEN_SECRET_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"Author" r"ization\s*:",
+        r"api" r"Key\s*:",
+        r"cred" r"ential\s*:",
+        r"token\.place.*(key|secret|token)",
+    )
+]
+
+
+def _env_entries(path: Path) -> dict[str, list[str]]:
+    entries: dict[str, list[str]] = {}
+    current_name: str | None = None
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line.startswith("- name: "):
+            current_name = line.removeprefix("- name: ").strip().strip('"\'')
+            entries.setdefault(current_name, [])
+        elif current_name and line.startswith("value: "):
+            value = line.removeprefix("value: ").strip().strip('"\'')
+            entries[current_name].append(value)
+            current_name = None
+    return entries
+
+
+def test_dspace_overlays_select_expected_token_place_runtime_origin_and_model() -> None:
+    for env, path in OVERLAYS.items():
+        entries = _env_entries(path)
+        assert entries.get("DSPACE_TOKEN_PLACE_URL") == [EXPECTED_URLS[env]]
+        assert entries.get("DSPACE_TOKEN_PLACE_CHAT_MODEL") == [EXPECTED_MODEL]
+
+
+def test_dspace_overlays_do_not_use_vite_runtime_fallbacks_or_credentials() -> None:
+    for path in OVERLAYS.values():
+        text = path.read_text(encoding="utf-8")
+        entries = _env_entries(path)
+        assert FORBIDDEN_RUNTIME_NAMES.isdisjoint(entries)
+        for forbidden in FORBIDDEN_RUNTIME_NAMES:
+            assert forbidden not in text
+        for pattern in FORBIDDEN_SECRET_PATTERNS:
+            assert not pattern.search(text), f"forbidden pattern {pattern.pattern!r} in {path}"
+
+
+def test_dspace_app_config_preserves_dev_plus_environment_overlay_chain() -> None:
+    expected_values = {
+        "staging": "docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml",
+        "prod": "docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml",
+    }
+    for env, values in expected_values.items():
+        result = subprocess.run(
+            ["python3", "scripts/app_config.py", "shell", "--app", "dspace", "--env", env],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        assert f"SUGARKUBE_VALUES={values}" in result.stdout


### PR DESCRIPTION
### Motivation
- Ensure Sugarkube DSPACE staging routes to the staging token.place origin and production routes to the production token.place origin at container runtime while keeping the DSPACE image immutable and promotable across environments.
- Prevent accidental use of build-time Vite fallbacks or embedding credentials in runtime values, and preserve the existing values-chain model (dev base + staging/prod overlays).

### Description
- Add `env` runtime entries to `docs/examples/dspace.values.staging.yaml` and `docs/examples/dspace.values.prod.yaml` to inject `DSPACE_TOKEN_PLACE_URL` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest` into the DSPACE container. 
- Update `docs/apps/dspace.md` with developer-local override guidance, explicit runtime routing checks for `/config.json`, the requirement that the runtime check pass before opening `/chat`, and clarification that overlays (not image tags) select the token.place origin. 
- Add focused regression tests in `tests/test_dspace_token_place_runtime.py` that assert the staging and production overlays set the expected `DSPACE_TOKEN_PLACE_URL` and `DSPACE_TOKEN_PLACE_CHAT_MODEL`, that `VITE_*` runtime names and credential-like patterns do not appear in overlays, and that the dev+environment values-chain contract is preserved. 
- Leave the dev base unchanged and do not add any token.place credentials, `VITE_*` runtime variables, proxying, or ingress/CORS logic.

### Testing
- Ran `python3 -m pytest tests/test_dspace_token_place_runtime.py tests/test_app_config.py tests/test_generic_app_just_recipes.py -q` and the tests passed (113 passed). 
- Ran `just app-config app=dspace env=staging` and `just app-config app=dspace env=prod` and both returned the expected resolved `SUGARKUBE_VALUES` chains. 
- Attempted to render the pinned DSPACE chart with `helm template` but fetching the OCI chart anonymously from GHCR failed with `401 Unauthorized` in this environment so chart-template validation could not be completed; `pre-commit`, `pyspelling`, and `linkchecker` are not installed in this container so those repo checks were not run locally. 
- Ran `rg -n "DSPACE_TOKEN_PLACE|VITE_TOKEN_PLACE|token.place|Authorization|apiKey|credential" docs/examples/dspace.values.*.yaml docs/apps/dspace.md` and `git diff --cached | ./scripts/scan-secrets.py` against the staged changes and found no credential leaks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35b1a3bbac832fac6cd79b576d5afb)