### PR TITLE
Align DSPACE token.place runtime model

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -41,9 +41,9 @@ Use these links before changing a deployment so the workflow runs, package versi
 - `env=dev`: future single-node/non-HA environment using `docs/examples/dspace.values.dev.yaml`.
   The dev overlay intentionally does not choose a token.place origin; developers who need local runtime routing can copy `docs/examples/apps/dspace.env` to a local app config and add chart-supported `env` entries to their private values file.
 - `env=staging`: HA staging on the staging Sugarkube cluster with host `staging.democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
-  The staging overlay injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest`.
+  The staging overlay injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`.
 - `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
-  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest`.
+  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`.
 - Optional legacy/canary host `prod.democratized.space` still has `docs/examples/dspace.values.prod-subdomain.yaml`, but the generic app flow uses the production apex overlay unless a local app config intentionally overrides it.
 
 ## Find or publish GHCR image
@@ -127,7 +127,7 @@ The runtime config check is a required routing gate, not an optional fallback: i
 curl -fsS https://staging.democratized.space/config.json \
   | jq -e '
       .tokenPlace.url == "https://staging.token.place"
-      and .tokenPlace.model == "gpt-5-chat-latest"
+      and .tokenPlace.model == "llama-3.1-8b-instruct"
     '
 ```
 
@@ -199,7 +199,7 @@ The runtime config check is a required production routing gate before opening `/
 curl -fsS https://democratized.space/config.json \
   | jq -e '
       .tokenPlace.url == "https://token.place"
-      and .tokenPlace.model == "gpt-5-chat-latest"
+      and .tokenPlace.model == "llama-3.1-8b-instruct"
     '
 ```
 

--- a/docs/examples/dspace.values.prod.yaml
+++ b/docs/examples/dspace.values.prod.yaml
@@ -11,4 +11,4 @@ env:
   - name: DSPACE_TOKEN_PLACE_URL
     value: https://token.place
   - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
-    value: gpt-5-chat-latest
+    value: llama-3.1-8b-instruct

--- a/docs/examples/dspace.values.staging.yaml
+++ b/docs/examples/dspace.values.staging.yaml
@@ -10,4 +10,4 @@ env:
   - name: DSPACE_TOKEN_PLACE_URL
     value: https://staging.token.place
   - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
-    value: gpt-5-chat-latest
+    value: llama-3.1-8b-instruct

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -60,14 +60,14 @@ def test_dspace_staging_overlay_points_to_staging_token_place() -> None:
     env = _runtime_env(OVERLAYS["staging"])
 
     assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://staging.token.place"]
-    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["gpt-5-chat-latest"]
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["llama-3.1-8b-instruct"]
 
 
 def test_dspace_prod_overlay_points_to_prod_token_place() -> None:
     env = _runtime_env(OVERLAYS["prod"])
 
     assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://token.place"]
-    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["gpt-5-chat-latest"]
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["llama-3.1-8b-instruct"]
 
 
 def test_dspace_deployment_overlays_have_no_vite_runtime_env() -> None:


### PR DESCRIPTION
### Motivation
- DSPACE staging/prod runtime values used an OpenAI model identifier (`gpt-5-chat-latest`) that must be replaced with the canonical token.place API v1 model selected for API v1 runtime compatibility.
- Keep runtime routing (staging/prod token.place URLs) unchanged while making the model value accurate and consistent with token.place API v1.

### Description
- Replaced `DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest` with `llama-3.1-8b-instruct` in `docs/examples/dspace.values.staging.yaml` and `docs/examples/dspace.values.prod.yaml`.
- Updated `docs/apps/dspace.md` runtime `/config.json` verification snippets and environment topology text to assert `llama-3.1-8b-instruct` for staging and production.
- Updated `tests/test_dspace_runtime_values.py` to expect the `llama-3.1-8b-instruct` runtime model while preserving the checks that forbid `VITE_` runtime env names and credentials.
- Touched only the DSPACE runtime values, docs, and focused tests as scoped; staging/prod token.place URLs remain `https://staging.token.place` and `https://token.place`.

### Testing
- Ran `pytest -q tests/test_dspace_runtime_values.py` and it passed (5 passed in ~15s).
- Ran `pytest -q tests/test_generic_app_just_recipes.py` as a focused sanity check and the invoked test set passed (the run completed with the repository tests reporting success; overall test run showed 112 passed, 1 warning).
- Ran `rg -n "gpt-5-chat-latest|DSPACE_TOKEN_PLACE_CHAT_MODEL|VITE_TOKEN_PLACE_CHAT_MODEL|token.place.*model|tokenPlace.*model" .` and confirmed `gpt-5-chat-latest` was removed and no `VITE_TOKEN_PLACE_CHAT_MODEL` was introduced.
- Ran `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` with no secrets reported.
- Note: `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` were not executed because those commands are not installed in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35e923c28c832f84a078f600eb4d62)