### PR TITLE
Update DSPACE token.place chat model to token.place API v1 model

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -41,9 +41,9 @@ Use these links before changing a deployment so the workflow runs, package versi
 - `env=dev`: future single-node/non-HA environment using `docs/examples/dspace.values.dev.yaml`.
   The dev overlay intentionally does not choose a token.place origin; developers who need local runtime routing can copy `docs/examples/apps/dspace.env` to a local app config and add chart-supported `env` entries to their private values file.
 - `env=staging`: HA staging on the staging Sugarkube cluster with host `staging.democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
-  The staging overlay injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest`.
+  The staging overlay injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3-8b-instruct`.
 - `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
-  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest`.
+  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3-8b-instruct`.
 - Optional legacy/canary host `prod.democratized.space` still has `docs/examples/dspace.values.prod-subdomain.yaml`, but the generic app flow uses the production apex overlay unless a local app config intentionally overrides it.
 
 ## Find or publish GHCR image
@@ -127,7 +127,7 @@ The runtime config check is a required routing gate, not an optional fallback: i
 curl -fsS https://staging.democratized.space/config.json \
   | jq -e '
       .tokenPlace.url == "https://staging.token.place"
-      and .tokenPlace.model == "gpt-5-chat-latest"
+      and .tokenPlace.model == "llama-3-8b-instruct"
     '
 ```
 
@@ -199,7 +199,7 @@ The runtime config check is a required production routing gate before opening `/
 curl -fsS https://democratized.space/config.json \
   | jq -e '
       .tokenPlace.url == "https://token.place"
-      and .tokenPlace.model == "gpt-5-chat-latest"
+      and .tokenPlace.model == "llama-3-8b-instruct"
     '
 ```
 

--- a/docs/examples/dspace.values.prod.yaml
+++ b/docs/examples/dspace.values.prod.yaml
@@ -11,4 +11,4 @@ env:
   - name: DSPACE_TOKEN_PLACE_URL
     value: https://token.place
   - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
-    value: gpt-5-chat-latest
+    value: llama-3-8b-instruct

--- a/docs/examples/dspace.values.staging.yaml
+++ b/docs/examples/dspace.values.staging.yaml
@@ -10,4 +10,4 @@ env:
   - name: DSPACE_TOKEN_PLACE_URL
     value: https://staging.token.place
   - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
-    value: gpt-5-chat-latest
+    value: llama-3-8b-instruct

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -60,14 +60,14 @@ def test_dspace_staging_overlay_points_to_staging_token_place() -> None:
     env = _runtime_env(OVERLAYS["staging"])
 
     assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://staging.token.place"]
-    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["gpt-5-chat-latest"]
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["llama-3-8b-instruct"]
 
 
 def test_dspace_prod_overlay_points_to_prod_token_place() -> None:
     env = _runtime_env(OVERLAYS["prod"])
 
     assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://token.place"]
-    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["gpt-5-chat-latest"]
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["llama-3-8b-instruct"]
 
 
 def test_dspace_deployment_overlays_have_no_vite_runtime_env() -> None:


### PR DESCRIPTION
### Motivation
- The DSPACE staging/production runtime overlays were using the OpenAI identifier `gpt-5-chat-latest` which is not appropriate for token.place API v1; the runtime must use the canonical token.place model chosen in the token.place rollout.
- Keep runtime routing and origins unchanged while aligning the model name with token.place API v1 semantics to avoid runtime routing / compatibility failures.

### Description
- Replaced `DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest` with `llama-3-8b-instruct` in the DSPACE staging and production example values (`docs/examples/dspace.values.staging.yaml` and `docs/examples/dspace.values.prod.yaml`).
- Updated the DSPACE runbook and `/config.json` verification snippets in `docs/apps/dspace.md` to assert the new token.place model while preserving `DSPACE_TOKEN_PLACE_URL` values (`https://staging.token.place` and `https://token.place`).
- Updated focused tests in `tests/test_dspace_runtime_values.py` to expect the token.place API v1 model and retained guards that prevent reintroducing Vite build-time envs.
- Ensured no `VITE_TOKEN_PLACE_CHAT_MODEL` or other build-time Vite env was introduced and the runtime URLs remain unchanged.

### Testing
- Ran `pytest -q tests/test_dspace_runtime_values.py`, which passed. 
- Ran `pytest -q tests/test_generic_app_just_recipes.py`, which passed. 
- Ran the repository test run used in the session (full pytest), resulting in `112 passed, 1 warning` in this environment. 
- Verified text replacements with `rg` to confirm no remaining `gpt-5-chat-latest` occurrences and no `VITE_TOKEN_PLACE_CHAT_MODEL` reintroduction, and ran `./scripts/scan-secrets.py` over the staged diff with no secrets flagged. 
- `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` were not run because those commands are not available in this execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35e946c75c832f8cbb39fe454d736a)