### PR TITLE
Align DSPACE token.place runtime model to API v1 (llama-3.1-8b-instruct)

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -41,9 +41,9 @@ Use these links before changing a deployment so the workflow runs, package versi
 - `env=dev`: future single-node/non-HA environment using `docs/examples/dspace.values.dev.yaml`.
   The dev overlay intentionally does not choose a token.place origin; developers who need local runtime routing can copy `docs/examples/apps/dspace.env` to a local app config and add chart-supported `env` entries to their private values file.
 - `env=staging`: HA staging on the staging Sugarkube cluster with host `staging.democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
-  The staging overlay injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest`.
+  The staging overlay injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`.
 - `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
-  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest`.
+  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`.
 - Optional legacy/canary host `prod.democratized.space` still has `docs/examples/dspace.values.prod-subdomain.yaml`, but the generic app flow uses the production apex overlay unless a local app config intentionally overrides it.
 
 ## Find or publish GHCR image
@@ -127,7 +127,7 @@ The runtime config check is a required routing gate, not an optional fallback: i
 curl -fsS https://staging.democratized.space/config.json \
   | jq -e '
       .tokenPlace.url == "https://staging.token.place"
-      and .tokenPlace.model == "gpt-5-chat-latest"
+      and .tokenPlace.model == "llama-3.1-8b-instruct"
     '
 ```
 
@@ -199,7 +199,7 @@ The runtime config check is a required production routing gate before opening `/
 curl -fsS https://democratized.space/config.json \
   | jq -e '
       .tokenPlace.url == "https://token.place"
-      and .tokenPlace.model == "gpt-5-chat-latest"
+      and .tokenPlace.model == "llama-3.1-8b-instruct"
     '
 ```
 

--- a/docs/examples/dspace.values.prod.yaml
+++ b/docs/examples/dspace.values.prod.yaml
@@ -11,4 +11,4 @@ env:
   - name: DSPACE_TOKEN_PLACE_URL
     value: https://token.place
   - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
-    value: gpt-5-chat-latest
+    value: llama-3.1-8b-instruct

--- a/docs/examples/dspace.values.staging.yaml
+++ b/docs/examples/dspace.values.staging.yaml
@@ -10,4 +10,4 @@ env:
   - name: DSPACE_TOKEN_PLACE_URL
     value: https://staging.token.place
   - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
-    value: gpt-5-chat-latest
+    value: llama-3.1-8b-instruct

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -60,14 +60,14 @@ def test_dspace_staging_overlay_points_to_staging_token_place() -> None:
     env = _runtime_env(OVERLAYS["staging"])
 
     assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://staging.token.place"]
-    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["gpt-5-chat-latest"]
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["llama-3.1-8b-instruct"]
 
 
 def test_dspace_prod_overlay_points_to_prod_token_place() -> None:
     env = _runtime_env(OVERLAYS["prod"])
 
     assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://token.place"]
-    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["gpt-5-chat-latest"]
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["llama-3.1-8b-instruct"]
 
 
 def test_dspace_deployment_overlays_have_no_vite_runtime_env() -> None:


### PR DESCRIPTION
### Motivation
- DSPACE staging/prod runtime values were using the OpenAI identifier `gpt-5-chat-latest` instead of the token.place API v1 canonical model chosen in the DSPACE migration (P6a). 
- The change must be scoped to Sugarkube DSPACE runtime values, examples, docs, and focused tests while keeping routing URLs unchanged and avoiding any Vite/build-time token.place env injection.

### Description
- Replaced `gpt-5-chat-latest` with the token.place API v1 model `llama-3.1-8b-instruct` in staging and production runtime examples. 
- Updated `docs/apps/dspace.md` verification snippets and runbook text to expect `llama-3.1-8b-instruct`. 
- Updated `docs/examples/dspace.values.staging.yaml` and `docs/examples/dspace.values.prod.yaml` to set `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct` while leaving `DSPACE_TOKEN_PLACE_URL` unchanged. 
- Updated `tests/test_dspace_runtime_values.py` to assert the corrected model and preserved the guard against `VITE_`-prefixed token.place runtime envs.

### Testing
- Ran `pytest -q tests/test_dspace_runtime_values.py` and it passed: `5 passed`.
- Ran `pytest -q tests/test_generic_app_just_recipes.py` and it passed as part of the local smoke: overall repo tests ran locally showing the suite passing (`112 passed, 1 warning` observed while running focused checks).
- Searched the tree for stale/forbidden patterns with `rg -n "gpt-5-chat-latest|DSPACE_TOKEN_PLACE_CHAT_MODEL|VITE_TOKEN_PLACE_CHAT_MODEL|token.place.*model|tokenPlace.*model" .` to confirm no remaining references to the old model identifier.
- Ran the repo secret scanner: `git diff --cached | ./scripts/scan-secrets.py` which returned no findings for the staged changes.

Notes: `pre-commit`, `pyspelling`, and `linkchecker` were not available in the execution environment and therefore were not run locally (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3608d09b50832fafec24876482e424)