### PR TITLE
Align DSPACE token.place runtime model to token.place API v1

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -41,9 +41,9 @@ Use these links before changing a deployment so the workflow runs, package versi
 - `env=dev`: future single-node/non-HA environment using `docs/examples/dspace.values.dev.yaml`.
   The dev overlay intentionally does not choose a token.place origin; developers who need local runtime routing can copy `docs/examples/apps/dspace.env` to a local app config and add chart-supported `env` entries to their private values file.
 - `env=staging`: HA staging on the staging Sugarkube cluster with host `staging.democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
-  The staging overlay injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest`.
+  The staging overlay injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3-8b-instruct`.
 - `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
-  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest`.
+  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3-8b-instruct`.
 - Optional legacy/canary host `prod.democratized.space` still has `docs/examples/dspace.values.prod-subdomain.yaml`, but the generic app flow uses the production apex overlay unless a local app config intentionally overrides it.
 
 ## Find or publish GHCR image
@@ -127,7 +127,7 @@ The runtime config check is a required routing gate, not an optional fallback: i
 curl -fsS https://staging.democratized.space/config.json \
   | jq -e '
       .tokenPlace.url == "https://staging.token.place"
-      and .tokenPlace.model == "gpt-5-chat-latest"
+      and .tokenPlace.model == "llama-3-8b-instruct"
     '
 ```
 
@@ -199,7 +199,7 @@ The runtime config check is a required production routing gate before opening `/
 curl -fsS https://democratized.space/config.json \
   | jq -e '
       .tokenPlace.url == "https://token.place"
-      and .tokenPlace.model == "gpt-5-chat-latest"
+      and .tokenPlace.model == "llama-3-8b-instruct"
     '
 ```
 

--- a/docs/examples/dspace.values.prod.yaml
+++ b/docs/examples/dspace.values.prod.yaml
@@ -11,4 +11,4 @@ env:
   - name: DSPACE_TOKEN_PLACE_URL
     value: https://token.place
   - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
-    value: gpt-5-chat-latest
+    value: llama-3-8b-instruct

--- a/docs/examples/dspace.values.staging.yaml
+++ b/docs/examples/dspace.values.staging.yaml
@@ -10,4 +10,4 @@ env:
   - name: DSPACE_TOKEN_PLACE_URL
     value: https://staging.token.place
   - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
-    value: gpt-5-chat-latest
+    value: llama-3-8b-instruct

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -60,14 +60,14 @@ def test_dspace_staging_overlay_points_to_staging_token_place() -> None:
     env = _runtime_env(OVERLAYS["staging"])
 
     assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://staging.token.place"]
-    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["gpt-5-chat-latest"]
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["llama-3-8b-instruct"]
 
 
 def test_dspace_prod_overlay_points_to_prod_token_place() -> None:
     env = _runtime_env(OVERLAYS["prod"])
 
     assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://token.place"]
-    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["gpt-5-chat-latest"]
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["llama-3-8b-instruct"]
 
 
 def test_dspace_deployment_overlays_have_no_vite_runtime_env() -> None:


### PR DESCRIPTION
### Motivation
- DSPACE staging and production runtime values were using the OpenAI identifier `gpt-5-chat-latest` but the deployment should reference the token.place API v1 model selected in the token.place/DSPACE migration (P6a), so the runtime model must be updated to the canonical token.place model `llama-3-8b-instruct`.
- The change must preserve the existing token.place runtime URLs for staging and prod and must not introduce any build-time Vite token.place envs.

### Description
- Replace `DSPACE_TOKEN_PLACE_CHAT_MODEL=gpt-5-chat-latest` with `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3-8b-instruct` in `docs/examples/dspace.values.staging.yaml` and `docs/examples/dspace.values.prod.yaml`.
- Update the runtime verification examples and narrative in `docs/apps/dspace.md` to assert the token.place API v1 model `llama-3-8b-instruct` for staging and production.
- Update `tests/test_dspace_runtime_values.py` to expect `llama-3-8b-instruct` while keeping the checks that ensure `DSPACE_TOKEN_PLACE_URL` values remain the staging/prod URLs and that no `VITE_` runtime env names are present.

### Testing
- Ran `pytest -q tests/test_dspace_runtime_values.py` and it passed (`5 passed`).
- Ran `pytest -q tests/test_generic_app_just_recipes.py` as part of a broader test run and overall tests reported `112 passed, 1 warning`.
- Searched the tree with `rg -n "gpt-5-chat-latest|DSPACE_TOKEN_PLACE_CHAT_MODEL|VITE_TOKEN_PLACE_CHAT_MODEL|token.place.*model|tokenPlace.*model" .` and confirmed occurrences were updated to reference `llama-3-8b-instruct` and the token.place URLs remain unchanged.
- `pyspelling -c .spellcheck.yaml`, `linkchecker --no-warnings README.md docs/`, and `pre-commit run --all-files` were attempted but could not run in this environment because those commands were not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3608d85b20832f874ae695683e8062)