### PR TITLE
Onboard jobbot3000 generic app deployment

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -27,8 +27,8 @@ Sugarkube owns cluster and environment orchestration:
 - applying the environment values chain; and
 - running status and verification checks against the cluster.
 
-Future onboarding examples include wove and jobbot3000, but they should only get
-Sugarkube app configs after their app repositories have published compatible
+Future onboarding examples include wove, but it should only get
+Sugarkube app configs after its app repository has published compatible
 images and charts.
 Use the [future-app onboarding guide](app_onboarding.md) for the checklist, minimal config template, and release decision tree.
 
@@ -68,6 +68,7 @@ The current apps map to that model as examples:
 | dspace | `ghcr.io/democratizedspace/dspace` | `oci://ghcr.io/democratizedspace/charts/dspace` | `dspace` | `dspace` | `docs/apps/dspace.version` | `docs/apps/dspace.prod.tag` |
 | token.place | `ghcr.io/futuroptimist/tokenplace-relay` | `oci://ghcr.io/futuroptimist/charts/tokenplace` | `tokenplace` | `tokenplace` | `docs/apps/tokenplace.version` | `docs/apps/tokenplace.prod.tag` |
 | danielsmith.io | `ghcr.io/futuroptimist/danielsmith.io` | `oci://ghcr.io/futuroptimist/charts/danielsmith` | `danielsmith` | `danielsmith` | `docs/apps/danielsmith.version` | `docs/apps/danielsmith.prod.tag` |
+| jobbot3000 | `ghcr.io/futuroptimist/jobbot3000` | `oci://ghcr.io/futuroptimist/charts/jobbot3000` | `jobbot3000` | `jobbot3000` | `docs/apps/jobbot3000.version` | `docs/apps/jobbot3000.prod.tag` |
 
 ## Standard image tag model
 

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -1,6 +1,6 @@
 # Sugarkube future-app onboarding guide
 
-Use this checklist when onboarding the next GHCR-first app to Sugarkube. The goal is that `wove`, `jobbot3000`, and later apps can reuse the same app repository release contract and the same Sugarkube `just app-*` operations without asking for bespoke deployment instructions.
+Use this checklist when onboarding the next GHCR-first app to Sugarkube. The goal is that `wove` and later apps can reuse the same app repository release contract and the same Sugarkube `just app-*` operations without asking for bespoke deployment instructions.
 
 ## Ownership boundaries
 
@@ -98,9 +98,9 @@ Create a base values file plus one overlay per environment.
 - `docs/examples/APP.values.prod.yaml`: production host, TLS secret, production env vars, and production-only settings.
 - Secrets must be referenced through Kubernetes Secret names or external secret tooling; never place secret values in docs or app configs.
 
-## Questions before onboarding wove or jobbot3000
+## Questions before onboarding wove or another future app
 
-Do not invent real configs for `wove` or `jobbot3000` until their app repos have the required image and chart details. Capture these answers first:
+Do not invent real configs for `wove` or another future app until its app repo has the required image and chart details. Capture these answers first:
 
 | Question | Why Sugarkube needs it |
 | --- | --- |

--- a/docs/apps/jobbot3000.md
+++ b/docs/apps/jobbot3000.md
@@ -1,0 +1,142 @@
+# jobbot3000 on Sugarkube
+
+This is the Sugarkube runbook for deploying jobbot3000 from app-owned GHCR artifacts with the generic `just app-*` recipes. jobbot3000 is a static, browser-only job application tracker: Kubernetes serves the web app, while private tracker data lives in each user's browser IndexedDB.
+
+## Artifact model
+
+- App repository responsibilities: build `ghcr.io/futuroptimist/jobbot3000`, publish immutable image tags, maintain the Helm chart, publish immutable chart versions to `oci://ghcr.io/futuroptimist/charts/jobbot3000`, and document app release details.
+- Sugarkube responsibilities: select `dev`, `staging`, or `prod`; load `docs/examples/apps/jobbot3000.env` or a local override; pin chart versions and production image tags; apply values overlays; and run deploy, status, verification, promotion, and rollback commands.
+- Cloudflare responsibilities: DNS and Tunnel routes to Traefik are outside Helm and must exist before public verification.
+
+| Coordinate | Value |
+| --- | --- |
+| Image | `ghcr.io/futuroptimist/jobbot3000` |
+| Chart | `oci://ghcr.io/futuroptimist/charts/jobbot3000` |
+| Release | `jobbot3000` |
+| Namespace | `jobbot3000` |
+| App config | `docs/examples/apps/jobbot3000.env` |
+| Chart version pin | `docs/apps/jobbot3000.version` |
+| Production tag pin | `docs/apps/jobbot3000.prod.tag` |
+| Verify paths | `/`, `/healthz`, `/livez` |
+
+## Artifact links
+
+Use these links before changing a deployment so workflow runs, package versions, and source paths all agree.
+
+| Artifact | Link |
+| --- | --- |
+| App repository | [jobbot3000 app repository](https://github.com/futuroptimist/jobbot3000) |
+| Image workflow | [Recent image workflow runs](https://github.com/futuroptimist/jobbot3000/actions/workflows/ci-image.yml) |
+| Successful main image runs | [Successful main image workflow runs](https://github.com/futuroptimist/jobbot3000/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess) |
+| GHCR image package | [GHCR image package versions](https://github.com/futuroptimist/jobbot3000/pkgs/container/jobbot3000) |
+| Chart workflow | [Recent chart workflow runs](https://github.com/futuroptimist/jobbot3000/actions/workflows/ci-helm.yml) |
+| GHCR chart package | [GHCR chart package versions](https://github.com/futuroptimist/jobbot3000/pkgs/container/charts%2Fjobbot3000) |
+| Dockerfile | [Application Dockerfile](https://github.com/futuroptimist/jobbot3000/blob/main/Dockerfile) |
+| Chart source | [Helm chart source](https://github.com/futuroptimist/jobbot3000/tree/main/charts/jobbot3000) |
+| Image release docs | [jobbot3000 image release docs](https://github.com/futuroptimist/jobbot3000/blob/main/docs/ops/image-release.md) |
+| Helm release docs | [jobbot3000 Helm release docs](https://github.com/futuroptimist/jobbot3000/blob/main/docs/ops/helm-release.md) |
+
+## Data, backup, and seeding model
+
+jobbot3000 stores private user data in browser IndexedDB. The cluster should only serve the static app and health endpoints; it must not own job applications, outreach messages, interviews, offers, notes, contacts, resume links, Drive links, imported CSV rows, JSON/NDJSON backups, or private user settings.
+
+- CSV is the spreadsheet-compatible, human-editable backup format.
+- JSON and NDJSON are full-fidelity backup/restore formats.
+- Seed dev, staging, and prod only by manually importing CSV, JSON, or NDJSON through the browser UI.
+- Do not bake real user data into images, charts, Helm values, Kubernetes Secrets, ConfigMaps, PVCs, repo fixtures, or Sugarkube docs/examples.
+- Do not add server-side persistence for this app; no PVC is expected for jobbot3000.
+
+## Find or publish a GHCR image
+
+Find the successful image workflow in the jobbot3000 app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, `main-latest`, a bare branch name, or an environment name.
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+```bash
+gh run list --repo futuroptimist/jobbot3000 --workflow ci-image.yml --branch main --status success --limit 5
+```
+
+If no suitable image exists, publish it from the app repo workflow, then return here with the immutable tag it produced.
+
+```bash
+gh workflow run ci-image.yml --repo futuroptimist/jobbot3000 --ref main
+```
+
+## Confirm or bump the OCI chart
+
+Sugarkube deploys the chart version pinned in `docs/apps/jobbot3000.version`. The initial pin is sourced from the app repo chart; before the first deploy, validate that GHCR has published the same immutable version.
+
+```bash
+just app-chart-status app=jobbot3000
+```
+
+```bash
+CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/jobbot3000.version | head -n 1)
+helm show chart oci://ghcr.io/futuroptimist/charts/jobbot3000 --version "$CHART_VERSION"
+```
+
+If the chart changed, bump the chart version in the jobbot3000 app repo and publish it there with the chart workflow; do not republish a different chart under an existing OCI version. After the app repo publishes the new chart, update Sugarkube's chart pin:
+
+```bash
+just app-chart-bump app=jobbot3000 version=<version>
+```
+
+## Deploy and verify staging
+
+Deploy staging with an immutable image tag that came from the jobbot3000 image workflow.
+
+```bash
+just app-deploy app=jobbot3000 env=staging tag=main-REPLACE_SHORTSHA
+```
+
+Redeploy the same or another approved immutable tag when you need to reapply values or retry a rollout:
+
+```bash
+just app-redeploy app=jobbot3000 env=staging tag=main-REPLACE_SHORTSHA
+```
+
+Check status and public paths:
+
+```bash
+just app-status app=jobbot3000 env=staging
+```
+
+```bash
+just app-verify app=jobbot3000 env=staging
+```
+
+Print the generated curl commands without executing them when debugging host routing:
+
+```bash
+just app-verify app=jobbot3000 env=staging print_only=1
+```
+
+## Promote production
+
+Promote only after staging sign-off, using the exact immutable image tag that passed staging. Keep `docs/apps/jobbot3000.prod.tag` empty until an operator explicitly approves a production tag.
+
+```bash
+just app-promote-prod app=jobbot3000 tag=main-REPLACE_SHORTSHA
+```
+
+Verify production after promotion:
+
+```bash
+just app-status app=jobbot3000 env=prod
+```
+
+```bash
+just app-verify app=jobbot3000 env=prod
+```
+
+## Rollback
+
+Rollback by redeploying a previous immutable image tag that is still present in GHCR and compatible with the pinned chart.
+
+```bash
+just app-redeploy app=jobbot3000 env=prod tag=main-PREVIOUSSHA
+```
+
+If the chart pin itself must roll back, first confirm the old chart still exists in GHCR, then update `docs/apps/jobbot3000.version` through the same review process used for chart bumps.

--- a/docs/apps/jobbot3000.prod.tag
+++ b/docs/apps/jobbot3000.prod.tag
@@ -1,0 +1,5 @@
+# Approved production image tag for jobbot3000.
+#
+# Leave empty until an immutable image tag is explicitly approved for production,
+# such as main-REPLACE_SHORTSHA after staging verification passes.
+# Deployment wrappers may consume this file to enforce release policy.

--- a/docs/apps/jobbot3000.version
+++ b/docs/apps/jobbot3000.version
@@ -1,0 +1,4 @@
+# Default jobbot3000 chart version from the app repository chart.
+# Validate before first deploy with `just app-chart-status app=jobbot3000`
+# or `helm show chart oci://ghcr.io/futuroptimist/charts/jobbot3000 --version 0.1.0`.
+0.1.0

--- a/docs/examples/apps/jobbot3000.env
+++ b/docs/examples/apps/jobbot3000.env
@@ -1,0 +1,17 @@
+# Example Sugarkube app config for jobbot3000.
+# Copy to apps/jobbot3000.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
+# containing jobbot3000.env.
+# Values files are sanitized examples only; seed/restore private tracker data
+# through the browser import UI, never through Kubernetes resources.
+SUGARKUBE_APP=jobbot3000
+SUGARKUBE_RELEASE=jobbot3000
+SUGARKUBE_NAMESPACE=jobbot3000
+SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/jobbot3000
+SUGARKUBE_VERSION_FILE=docs/apps/jobbot3000.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/jobbot3000.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/jobbot3000.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/,/healthz,/livez
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=jobbot3000

--- a/docs/examples/jobbot3000.values.dev.yaml
+++ b/docs/examples/jobbot3000.values.dev.yaml
@@ -1,0 +1,30 @@
+# Base/shared jobbot3000 values consumed alongside environment overlays.
+# jobbot3000 is a static browser-local tracker: private application data lives
+# in browser IndexedDB and is imported/exported through the app UI, not Kubernetes.
+environment: dev
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/jobbot3000
+  tag: main-REPLACE_SHORTSHA
+
+service:
+  port: 8080
+
+containerPort: 8080
+
+ingress:
+  enabled: false
+  className: traefik
+  host: jobbot3000.localhost
+  annotations: {}
+  tls:
+    enabled: false
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 48Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi

--- a/docs/examples/jobbot3000.values.prod.yaml
+++ b/docs/examples/jobbot3000.values.prod.yaml
@@ -1,0 +1,13 @@
+# Production overlay values layered on top of jobbot3000.values.dev.yaml.
+# Replace the placeholder host and TLS secret only during an explicit production cutover.
+environment: prod
+
+ingress:
+  enabled: true
+  className: traefik
+  host: jobbot3000.example.com
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  tls:
+    enabled: true
+    secretName: jobbot3000-prod-tls

--- a/docs/examples/jobbot3000.values.staging.yaml
+++ b/docs/examples/jobbot3000.values.staging.yaml
@@ -1,0 +1,13 @@
+# Staging overlay values layered on top of jobbot3000.values.dev.yaml.
+# Use placeholder-safe hosts until DNS/Cloudflare routes are explicitly created.
+environment: staging
+
+ingress:
+  enabled: true
+  className: traefik
+  host: staging.jobbot3000.example.com
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  tls:
+    enabled: true
+    secretName: jobbot3000-staging-tls

--- a/scripts/app_config.py
+++ b/scripts/app_config.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Iterable
 
 SUPPORTED_ENVS = {"dev", "staging", "prod"}
-EXAMPLE_FALLBACK_APPS = {"danielsmith", "dspace", "tokenplace"}
+EXAMPLE_FALLBACK_APPS = {"danielsmith", "dspace", "jobbot3000", "tokenplace"}
 MOVING_TAGS = {
     "latest",
     "main",

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import subprocess
 import sys
@@ -1344,6 +1345,86 @@ def test_app_verify_executes_curl_by_default_and_prints_summary(
     assert "Verification passed: 3/3 checks succeeded." in result.stdout
 
 
+def _app_config_json(app: str, env: str = "staging") -> dict[str, str]:
+    result = subprocess.run(
+        [
+            "python3",
+            "scripts/app_config.py",
+            "json",
+            "--app",
+            app,
+            "--env",
+            env,
+            "--config",
+            "",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def _read_values(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_jobbot3000_example_config_resolves_all_envs_and_values() -> None:
+    for env in ("dev", "staging", "prod"):
+        config = _app_config_json("jobbot3000", env)
+        assert config["SUGARKUBE_APP"] == "jobbot3000"
+        assert config["SUGARKUBE_CHART"] == "oci://ghcr.io/futuroptimist/charts/jobbot3000"
+        assert config["SUGARKUBE_VERIFY_PATHS"] == "/,/healthz,/livez"
+        for values_path in config["SUGARKUBE_VALUES"].split(","):
+            values = _read_values(values_path)
+            assert values.strip(), values_path
+            assert "environment:" in values
+
+
+def test_jobbot3000_values_use_static_image_and_no_server_persistence() -> None:
+    config = _app_config_json("jobbot3000", "prod")
+    values_text = "\n---\n".join(
+        _read_values(path) for path in config["SUGARKUBE_VALUES"].split(",")
+    )
+
+    assert "repository: ghcr.io/futuroptimist/jobbot3000" in values_text
+    assert "tag: main-REPLACE_SHORTSHA" in values_text
+    assert "latest" not in values_text.lower()
+    assert "main-latest" not in values_text.lower()
+    assert "containerPort: 8080" in values_text
+    assert "port: 8080" in values_text
+    forbidden = (
+        "persistentVolume",
+        "persistence:",
+        "PersistentVolumeClaim",
+        "claimName",
+        "secretKeyRef",
+        "configMapKeyRef",
+    )
+    for token in forbidden:
+        assert token not in values_text
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_jobbot3000_print_only_includes_expected_paths(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        ["app-verify", "app=jobbot3000", "env=staging", "print_only=1"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert result.stdout.splitlines() == [
+        "curl -fsS https://example.test/",
+        "curl -fsS https://example.test/healthz",
+        "curl -fsS https://example.test/livez",
+    ]
+    assert not Path(generic_app_stub_env["CURL_LOG"]).exists()
+
+
 def test_app_verify_adds_curl_timeouts(
     generic_app_stub_env: dict[str, str],
 ) -> None:
@@ -1478,6 +1559,7 @@ def test_app_verify_show_body_can_be_disabled(generic_app_stub_env: dict[str, st
         ("danielsmith", "/,/livez,/healthz"),
         ("tokenplace", "/,/livez,/healthz,/relay/diagnostics,/api/v1/meta"),
         ("dspace", "/config.json,/healthz,/livez"),
+        ("jobbot3000", "/,/healthz,/livez"),
     ],
 )
 def test_example_app_configs_preserve_verify_paths(app: str, expected_paths: str) -> None:
@@ -2057,7 +2139,9 @@ def test_app_cors_verify_main_reports_preflight_status_and_header_failures(
     rc, _out, err, _calls = _run_app_cors_main(
         monkeypatch,
         capsys,
-        responses=[(0, "204", {"access-control-allow-origin": ["https://cors-smoke.invalid"]}, b"", "")],
+        responses=[
+            (0, "204", {"access-control-allow-origin": ["https://cors-smoke.invalid"]}, b"", "")
+        ],
     )
 
     assert rc == 1
@@ -2099,7 +2183,13 @@ def test_app_cors_verify_main_reports_actual_cors_and_body_failures(
         capsys,
         responses=[
             (0, "204", _cors_headers(), b"", ""),
-            (0, "400", _cors_headers({"access-control-allow-origin": ["https://evil.test"]}), b'{"error":{}}', ""),
+            (
+                0,
+                "400",
+                _cors_headers({"access-control-allow-origin": ["https://evil.test"]}),
+                b'{"error":{}}',
+                "",
+            ),
         ],
     )
 
@@ -2159,7 +2249,9 @@ def test_app_cors_verify_main_rejects_bad_expected_status_config(
 
     assert excinfo.value.code == 2
     captured = capsys.readouterr()
-    assert "SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES must be comma-separated integers" in captured.err
+    assert (
+        "SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES must be comma-separated integers" in captured.err
+    )
 
     with pytest.raises(SystemExit) as excinfo:
         _run_app_cors_main(
@@ -2170,7 +2262,9 @@ def test_app_cors_verify_main_rejects_bad_expected_status_config(
 
     assert excinfo.value.code == 2
     captured = capsys.readouterr()
-    assert "SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES must include at least one integer" in captured.err
+    assert (
+        "SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES must include at least one integer" in captured.err
+    )
 
 
 def test_app_cors_verify_header_parsing_helpers() -> None:


### PR DESCRIPTION
### Motivation
- Add jobbot3000 to Sugarkube's generic GHCR/OCI Helm app deployment surface now that the app repo owns image and chart artifacts so `just app-*` workflows can operate without bespoke recipes. 

### Description
- Add sanitized example app config `docs/examples/apps/jobbot3000.env`, values overlays `docs/examples/jobbot3000.values.{dev,staging,prod}.yaml`, chart pin `docs/apps/jobbot3000.version`, and prod tag pin `docs/apps/jobbot3000.prod.tag` so generic recipes can resolve jobbot3000 coordinates. 
- Add the Sugarkube runbook `docs/apps/jobbot3000.md` documenting artifact discovery links, `just` deploy/status/verify/promote/rollback commands, and the browser-local IndexedDB data/backup/import model (CSV/JSON/NDJSON). 
- Register jobbot3000 as an example fallback app in `scripts/app_config.py` and update shared docs `docs/app_deployment_contract.md` and `docs/app_onboarding.md` to include jobbot3000 in the contract examples. 
- Extend `tests/test_generic_app_just_recipes.py` with tests that assert config resolution across `dev|staging|prod`, that values files contain expected image/chart/port entries and no server-side persistence, and that `app-verify print_only` includes the expected verify paths for jobbot3000. 
- Formatting: ran `black` on the updated test file and committed the changes. 

### Testing
- Ran `python -m pytest tests/test_generic_app_just_recipes.py -q` and all tests passed (`116 passed, 1 warning`).
- Executed `just app-config app=jobbot3000 env=dev`, `just app-config app=jobbot3000 env=staging`, and `just app-config app=jobbot3000 env=prod` and they resolved the config JSON successfully. 
- Ran `just app-verify app=jobbot3000 env=staging print_only=1` and it generated the expected verification curl commands for `/`, `/healthz`, and `/livez` (placeholder host output is shown when ingress host cannot be derived in this environment). 
- Ran `git diff --check` and `git diff | ./scripts/scan-secrets.py` with no issues found. 
- Not run / unavailable in this environment: `helm show chart ...` (no `helm` binary), `pre-commit run --all-files` (no `pre-commit`), `pyspelling` and `linkchecker` (not installed); the runbook and version pin include operator guidance to validate the chart with `helm show chart` before first deploy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4604cb8408832fb56503b90636697d)