### PR TITLE
Onboard jobbot3000 to generic Sugarkube app deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
   design, ownership contract, privacy rules, dashboards, alerts, and release gates for Sugarkube,
   DSPACE, token.place, and danielsmith.io.
 - **[Future-app onboarding guide](docs/app_onboarding.md)** — checklist and decision tree for
-  adding apps such as wove, jobbot3000, and later services.
+  adding apps such as wove and later services.
 - **Current app runbooks** use the same GHCR-first staging, verification,
   promotion, rollback, and troubleshooting flow:
   - [DSPACE runbook](docs/apps/dspace.md) for `ghcr.io/democratizedspace/dspace`:
@@ -63,6 +63,11 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
     [image package](https://github.com/futuroptimist/danielsmith.io/pkgs/container/danielsmith.io),
     [chart workflow](https://github.com/futuroptimist/danielsmith.io/actions/workflows/ci-helm.yml),
     [chart package](https://github.com/futuroptimist/danielsmith.io/pkgs/container/charts%2Fdanielsmith).
+  - [jobbot3000 runbook](docs/apps/jobbot3000.md) for `ghcr.io/futuroptimist/jobbot3000`:
+    [image workflow](https://github.com/futuroptimist/jobbot3000/actions/workflows/ci-image.yml),
+    [image package](https://github.com/futuroptimist/jobbot3000/pkgs/container/jobbot3000),
+    [chart workflow](https://github.com/futuroptimist/jobbot3000/actions/workflows/ci-helm.yml),
+    [chart package](https://github.com/futuroptimist/jobbot3000/pkgs/container/charts%2Fjobbot3000).
 - **Environment shortcuts:** token.place
   [dev](docs/k3s-tokenplace-dev.md), [staging](docs/k3s-tokenplace-staging.md), and
   [production](docs/k3s-tokenplace-prod.md); danielsmith.io

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -27,9 +27,9 @@ Sugarkube owns cluster and environment orchestration:
 - applying the environment values chain; and
 - running status and verification checks against the cluster.
 
-Future onboarding examples include wove and jobbot3000, but they should only get
-Sugarkube app configs after their app repositories have published compatible
-images and charts.
+Future onboarding examples such as wove should only get Sugarkube app configs
+after their app repositories have published compatible images and charts.
+jobbot3000 now follows this contract through the generic app config and runbook.
 Use the [future-app onboarding guide](app_onboarding.md) for the checklist, minimal config template, and release decision tree.
 
 ## Standard artifact model
@@ -68,6 +68,7 @@ The current apps map to that model as examples:
 | dspace | `ghcr.io/democratizedspace/dspace` | `oci://ghcr.io/democratizedspace/charts/dspace` | `dspace` | `dspace` | `docs/apps/dspace.version` | `docs/apps/dspace.prod.tag` |
 | token.place | `ghcr.io/futuroptimist/tokenplace-relay` | `oci://ghcr.io/futuroptimist/charts/tokenplace` | `tokenplace` | `tokenplace` | `docs/apps/tokenplace.version` | `docs/apps/tokenplace.prod.tag` |
 | danielsmith.io | `ghcr.io/futuroptimist/danielsmith.io` | `oci://ghcr.io/futuroptimist/charts/danielsmith` | `danielsmith` | `danielsmith` | `docs/apps/danielsmith.version` | `docs/apps/danielsmith.prod.tag` |
+| jobbot3000 | `ghcr.io/futuroptimist/jobbot3000` | `oci://ghcr.io/futuroptimist/charts/jobbot3000` | `jobbot3000` | `jobbot3000` | `docs/apps/jobbot3000.version` | `docs/apps/jobbot3000.prod.tag` |
 
 ## Standard image tag model
 
@@ -237,6 +238,7 @@ shared `SUGARKUBE_VERIFY_PATHS` value:
 - [`docs/examples/apps/dspace.env`](examples/apps/dspace.env)
 - [`docs/examples/apps/tokenplace.env`](examples/apps/tokenplace.env)
 - [`docs/examples/apps/danielsmith.env`](examples/apps/danielsmith.env)
+- [`docs/examples/apps/jobbot3000.env`](examples/apps/jobbot3000.env)
 
 Current values chains:
 
@@ -245,3 +247,4 @@ Current values chains:
 | dspace | `docs/examples/dspace.values.dev.yaml` | `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml` | `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml` | `/config.json,/healthz,/livez` |
 | token.place | `docs/examples/tokenplace.values.dev.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml` | `/,/livez,/healthz,/relay/diagnostics` |
 | danielsmith.io | `docs/examples/danielsmith.values.dev.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml` | `/,/livez,/healthz` |
+| jobbot3000 | `docs/examples/jobbot3000.values.dev.yaml` | `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml` | `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.prod.yaml` | `/,/healthz,/livez` |

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -1,6 +1,6 @@
 # Sugarkube future-app onboarding guide
 
-Use this checklist when onboarding the next GHCR-first app to Sugarkube. The goal is that `wove`, `jobbot3000`, and later apps can reuse the same app repository release contract and the same Sugarkube `just app-*` operations without asking for bespoke deployment instructions.
+Use this checklist when onboarding the next GHCR-first app to Sugarkube. The goal is that `wove` and later apps can reuse the same app repository release contract and the same Sugarkube `just app-*` operations without asking for bespoke deployment instructions.
 
 ## Ownership boundaries
 
@@ -98,9 +98,9 @@ Create a base values file plus one overlay per environment.
 - `docs/examples/APP.values.prod.yaml`: production host, TLS secret, production env vars, and production-only settings.
 - Secrets must be referenced through Kubernetes Secret names or external secret tooling; never place secret values in docs or app configs.
 
-## Questions before onboarding wove or jobbot3000
+## Questions before onboarding future apps
 
-Do not invent real configs for `wove` or `jobbot3000` until their app repos have the required image and chart details. Capture these answers first:
+Do not invent real configs for future apps such as `wove` until their app repos have the required image and chart details. jobbot3000 is now onboarded because its image and chart details are known. Capture these answers first:
 
 | Question | Why Sugarkube needs it |
 | --- | --- |

--- a/docs/apps/jobbot3000.md
+++ b/docs/apps/jobbot3000.md
@@ -1,0 +1,142 @@
+# jobbot3000 on Sugarkube
+
+This is the canonical Sugarkube runbook for deploying jobbot3000 from app-owned GHCR artifacts. jobbot3000 is a static, offline-capable, browser-only job application tracker. Sugarkube serves the web app; private tracker data stays in each user's browser IndexedDB and is never stored in Kubernetes.
+
+## Artifact model
+
+- App repository responsibilities: build `ghcr.io/futuroptimist/jobbot3000`, publish immutable image tags, maintain the Helm chart, and publish immutable chart versions to `oci://ghcr.io/futuroptimist/charts/jobbot3000`.
+- Sugarkube responsibilities: select `dev`, `staging`, or `prod`; load `docs/examples/apps/jobbot3000.env` or a local override; pin chart and production tags; install or upgrade Helm; verify rollout status and public paths.
+- Cloudflare responsibilities: DNS and Tunnel routes to Traefik are outside Helm and must exist before public verification.
+
+| Coordinate | Value |
+| --- | --- |
+| Image | `ghcr.io/futuroptimist/jobbot3000` |
+| Chart | `oci://ghcr.io/futuroptimist/charts/jobbot3000` |
+| Release | `jobbot3000` |
+| Namespace | `jobbot3000` |
+| App config | `docs/examples/apps/jobbot3000.env` |
+| Chart version pin | `docs/apps/jobbot3000.version` |
+| Production tag pin | `docs/apps/jobbot3000.prod.tag` |
+| Verify paths | `/`, `/healthz`, `/livez` |
+| Container port | `8080` |
+
+### Artifact links
+
+Use these links before changing a deployment so the workflow runs, package versions, and source paths all agree.
+
+| Artifact | Link |
+| --- | --- |
+| App repository | [jobbot3000 app repository](https://github.com/futuroptimist/jobbot3000) |
+| Image workflow | [Recent image workflow runs](https://github.com/futuroptimist/jobbot3000/actions/workflows/ci-image.yml) |
+| Successful main image runs | [Successful main image workflow runs](https://github.com/futuroptimist/jobbot3000/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess) |
+| GHCR image package | [GHCR image package versions](https://github.com/futuroptimist/jobbot3000/pkgs/container/jobbot3000) |
+| Chart workflow | [Recent chart workflow runs](https://github.com/futuroptimist/jobbot3000/actions/workflows/ci-helm.yml) |
+| GHCR chart package | [GHCR chart package versions](https://github.com/futuroptimist/jobbot3000/pkgs/container/charts%2Fjobbot3000) |
+| Dockerfile | [Application Dockerfile](https://github.com/futuroptimist/jobbot3000/blob/main/Dockerfile) |
+| Chart source path | [Helm chart source](https://github.com/futuroptimist/jobbot3000/tree/main/charts/jobbot3000) |
+| Image release docs | [jobbot3000 GHCR image release docs](https://github.com/futuroptimist/jobbot3000/blob/main/docs/release-ghcr.md) |
+| Helm release docs | [jobbot3000 Helm release docs](https://github.com/futuroptimist/jobbot3000/blob/main/docs/release-helm.md) |
+| App release guide | [jobbot3000 release docs index](https://github.com/futuroptimist/jobbot3000/tree/main/docs) |
+
+## Data, backup, and seeding model
+
+jobbot3000's production deployment model is a static browser-local tracker. Kubernetes serves only the static web container. The application data model is IndexedDB-first: applications, outreach, interviews, offers, outcomes, notes, contacts, resume links, Drive links, private settings, and imported backups live in the user's browser storage.
+
+Backups and restores are user-driven through the browser UI:
+
+- CSV is the spreadsheet-compatible, human-editable backup format.
+- JSON and NDJSON are the full-fidelity backup and restore formats.
+- Dev, staging, and production seed data must be imported manually through the browser UI.
+
+Do not bake real user data into Docker images, Helm charts, Helm values, Kubernetes Secrets, ConfigMaps, PVCs, Sugarkube docs, or Sugarkube examples. The example values intentionally do not configure server-side persistence.
+
+## Environment topology
+
+- `env=dev`: base values in `docs/examples/jobbot3000.values.dev.yaml`; ingress disabled by default and image tag shown as the immutable placeholder `main-REPLACE_SHORTSHA`.
+- `env=staging`: values chain `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml`; placeholder host `staging.jobbot3000.example.test`.
+- `env=prod`: values chain `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.prod.yaml`; placeholder host `jobbot3000.example.test`.
+
+Replace placeholder hosts in a local operator config or overlay before using a real cluster. Keep Cloudflare DNS and Tunnel routing outside Helm.
+
+## Find or publish GHCR image
+
+Find the successful image workflow in the jobbot3000 app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, `main-latest`, a bare branch name, or an environment name.
+
+Web UI shortcuts:
+
+- Open [recent image workflow runs](https://github.com/futuroptimist/jobbot3000/actions/workflows/ci-image.yml) or [successful main image runs](https://github.com/futuroptimist/jobbot3000/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess).
+- Open [GHCR image package versions](https://github.com/futuroptimist/jobbot3000/pkgs/container/jobbot3000).
+- Copy the immutable tag from a successful workflow summary or package version.
+
+```bash
+APP_TAG=main-REPLACE_SHORTSHA
+```
+
+## Confirm/publish OCI chart
+
+Sugarkube deploys the chart version pinned in `docs/apps/jobbot3000.version`. Use [recent chart workflow runs](https://github.com/futuroptimist/jobbot3000/actions/workflows/ci-helm.yml), [GHCR chart package versions](https://github.com/futuroptimist/jobbot3000/pkgs/container/charts%2Fjobbot3000), and [the chart source](https://github.com/futuroptimist/jobbot3000/tree/main/charts/jobbot3000) to confirm the pinned immutable version.
+
+```bash
+just app-chart-status app=jobbot3000
+```
+
+```bash
+CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/jobbot3000.version | head -n 1)
+helm show chart oci://ghcr.io/futuroptimist/charts/jobbot3000 --version "$CHART_VERSION"
+```
+
+If registry validation was unavailable when this runbook was last edited, operators should run one of the commands above before the first deploy. If the app repo publishes a new chart, bump the Sugarkube pin explicitly:
+
+```bash
+just app-chart-bump app=jobbot3000 version=0.1.1
+```
+
+## Deploy and verify staging
+
+```bash
+just app-deploy app=jobbot3000 env=staging tag=main-REPLACE_SHORTSHA
+```
+
+```bash
+just app-status app=jobbot3000 env=staging
+```
+
+```bash
+just app-verify app=jobbot3000 env=staging
+```
+
+Print the generated checks without executing them:
+
+```bash
+just app-verify app=jobbot3000 env=staging print_only=1
+```
+
+## Redeploy, promote, and rollback
+
+Redeploy staging or production with a specific immutable tag:
+
+```bash
+just app-redeploy app=jobbot3000 env=staging tag=main-REPLACE_SHORTSHA
+```
+
+Promote production only after staging sign-off, using the exact immutable image tag that passed staging:
+
+```bash
+just app-promote-prod app=jobbot3000 tag=main-REPLACE_SHORTSHA
+```
+
+Rollback by redeploying the previous known-good immutable image tag:
+
+```bash
+just app-redeploy app=jobbot3000 env=prod tag=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+After any production deploy or rollback, run:
+
+```bash
+just app-status app=jobbot3000 env=prod
+```
+
+```bash
+just app-verify app=jobbot3000 env=prod
+```

--- a/docs/apps/jobbot3000.prod.tag
+++ b/docs/apps/jobbot3000.prod.tag
@@ -1,0 +1,4 @@
+# Approved production image tag for jobbot3000.
+#
+# Leave empty until an immutable image tag is explicitly approved for production.
+# Use the same immutable tag that passed staging, such as main-REPLACE_SHORTSHA.

--- a/docs/apps/jobbot3000.version
+++ b/docs/apps/jobbot3000.version
@@ -1,0 +1,6 @@
+# Default jobbot3000 chart version. Update when new chart releases are published.
+# Source chart version checked from futuroptimist/jobbot3000 charts/jobbot3000/Chart.yaml.
+# If registry validation is unavailable, run `just app-chart-status app=jobbot3000`
+# or `helm show chart oci://ghcr.io/futuroptimist/charts/jobbot3000 --version 0.1.0`
+# before the first deploy.
+0.1.0

--- a/docs/examples/apps/jobbot3000.env
+++ b/docs/examples/apps/jobbot3000.env
@@ -1,0 +1,17 @@
+# Example Sugarkube app config for jobbot3000.
+# Copy to apps/jobbot3000.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
+# containing jobbot3000.env.
+# This is an example fallback for generic recipes; local app configs take precedence.
+
+SUGARKUBE_APP=jobbot3000
+SUGARKUBE_RELEASE=jobbot3000
+SUGARKUBE_NAMESPACE=jobbot3000
+SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/jobbot3000
+SUGARKUBE_VERSION_FILE=docs/apps/jobbot3000.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/jobbot3000.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/jobbot3000.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/,/healthz,/livez
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=jobbot3000

--- a/docs/examples/jobbot3000.values.dev.yaml
+++ b/docs/examples/jobbot3000.values.dev.yaml
@@ -1,0 +1,40 @@
+# Base/shared jobbot3000 values consumed alongside environment overlays.
+# jobbot3000 is a static browser-local tracker: do not add PVCs, Secrets,
+# ConfigMaps, or fixtures containing real application data or backups here.
+replicaCount: 1
+
+environment: dev
+
+image:
+  repository: ghcr.io/futuroptimist/jobbot3000
+  # Replace with an immutable image tag from the jobbot3000 image workflow.
+  # Do not use latest, main-latest, a bare branch, or an environment name.
+  tag: main-REPLACE_SHORTSHA
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+containerPort: 8080
+
+ingress:
+  enabled: false
+  className: traefik
+  host: jobbot3000.dev.example.test
+  annotations: {}
+  tls: []
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi
+
+probes:
+  readiness:
+    path: /healthz
+  liveness:
+    path: /livez

--- a/docs/examples/jobbot3000.values.prod.yaml
+++ b/docs/examples/jobbot3000.values.prod.yaml
@@ -1,0 +1,13 @@
+# Production overlay values layered on top of jobbot3000.values.dev.yaml.
+environment: prod
+
+ingress:
+  enabled: true
+  className: traefik
+  host: jobbot3000.example.test
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  tls:
+    - secretName: jobbot3000-prod-tls
+      hosts:
+        - jobbot3000.example.test

--- a/docs/examples/jobbot3000.values.staging.yaml
+++ b/docs/examples/jobbot3000.values.staging.yaml
@@ -1,0 +1,13 @@
+# Staging overlay values layered on top of jobbot3000.values.dev.yaml.
+environment: staging
+
+ingress:
+  enabled: true
+  className: traefik
+  host: staging.jobbot3000.example.test
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  tls:
+    - secretName: jobbot3000-staging-tls
+      hosts:
+        - staging.jobbot3000.example.test

--- a/scripts/app_config.py
+++ b/scripts/app_config.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Iterable
 
 SUPPORTED_ENVS = {"dev", "staging", "prod"}
-EXAMPLE_FALLBACK_APPS = {"danielsmith", "dspace", "tokenplace"}
+EXAMPLE_FALLBACK_APPS = {"danielsmith", "dspace", "jobbot3000", "tokenplace"}
 MOVING_TAGS = {
     "latest",
     "main",

--- a/tests/test_app_runbook_links.py
+++ b/tests/test_app_runbook_links.py
@@ -76,6 +76,7 @@ APP_LINKS = {
             f"{JOBBOT3000_REPO}/tree/main/charts/jobbot3000",
             f"{JOBBOT3000_REPO}/blob/main/docs/release-ghcr.md",
             f"{JOBBOT3000_REPO}/blob/main/docs/release-helm.md",
+            f"{JOBBOT3000_REPO}/tree/main/docs",
         ],
     },
 }

--- a/tests/test_app_runbook_links.py
+++ b/tests/test_app_runbook_links.py
@@ -9,6 +9,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DSPACE_REPO = "https://github.com/democratizedspace/dspace"
 TOKENPLACE_REPO = "https://github.com/futuroptimist/token.place"
 DANIELSMITH_REPO = "https://github.com/futuroptimist/danielsmith.io"
+JOBBOT3000_REPO = "https://github.com/futuroptimist/jobbot3000"
 DSPACE_CHART_PACKAGE_LOOKUP = (
     "https://github.com/orgs/democratizedspace/"
     "packages?repo_name=dspace&q=charts%2Fdspace"
@@ -62,6 +63,21 @@ APP_LINKS = {
             f"{DANIELSMITH_REPO}/blob/main/docs/ops/sugarkube-release.md",
         ],
     },
+    "jobbot3000": {
+        "runbook": "docs/apps/jobbot3000.md",
+        "urls": [
+            JOBBOT3000_REPO,
+            f"{JOBBOT3000_REPO}/actions/workflows/ci-image.yml",
+            f"{JOBBOT3000_REPO}/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess",
+            f"{JOBBOT3000_REPO}/pkgs/container/jobbot3000",
+            f"{JOBBOT3000_REPO}/actions/workflows/ci-helm.yml",
+            f"{JOBBOT3000_REPO}/pkgs/container/charts%2Fjobbot3000",
+            f"{JOBBOT3000_REPO}/blob/main/Dockerfile",
+            f"{JOBBOT3000_REPO}/tree/main/charts/jobbot3000",
+            f"{JOBBOT3000_REPO}/blob/main/docs/release-ghcr.md",
+            f"{JOBBOT3000_REPO}/blob/main/docs/release-helm.md",
+        ],
+    },
 }
 
 README_QUICK_LINKS = {
@@ -85,6 +101,13 @@ README_QUICK_LINKS = {
         f"{DANIELSMITH_REPO}/pkgs/container/danielsmith.io",
         f"{DANIELSMITH_REPO}/actions/workflows/ci-helm.yml",
         f"{DANIELSMITH_REPO}/pkgs/container/charts%2Fdanielsmith",
+    ],
+    "jobbot3000": [
+        "docs/apps/jobbot3000.md",
+        f"{JOBBOT3000_REPO}/actions/workflows/ci-image.yml",
+        f"{JOBBOT3000_REPO}/pkgs/container/jobbot3000",
+        f"{JOBBOT3000_REPO}/actions/workflows/ci-helm.yml",
+        f"{JOBBOT3000_REPO}/pkgs/container/charts%2Fjobbot3000",
     ],
 }
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1075,6 +1075,15 @@ def test_app_deploy_danielsmith_passes_image_tag(generic_app_stub_env: dict[str,
             "dspace",
             ["docs/examples/dspace.values.dev.yaml", "docs/examples/dspace.values.staging.yaml"],
         ),
+        (
+            "jobbot3000",
+            "oci://ghcr.io/futuroptimist/charts/jobbot3000",
+            "jobbot3000",
+            [
+                "docs/examples/jobbot3000.values.dev.yaml",
+                "docs/examples/jobbot3000.values.staging.yaml",
+            ],
+        ),
     ],
 )
 def test_app_deploy_uses_app_release_namespace_chart_values(
@@ -1195,6 +1204,12 @@ def test_app_redeploy_prints_chart_pin_reminder_without_latest_lookup_or_pin_mut
             "danielsmith",
             "danielsmith",
             "oci://ghcr.io/futuroptimist/charts/danielsmith",
+        ),
+        (
+            "jobbot3000",
+            "jobbot3000",
+            "jobbot3000",
+            "oci://ghcr.io/futuroptimist/charts/jobbot3000",
         ),
     ],
 )
@@ -1478,6 +1493,7 @@ def test_app_verify_show_body_can_be_disabled(generic_app_stub_env: dict[str, st
         ("danielsmith", "/,/livez,/healthz"),
         ("tokenplace", "/,/livez,/healthz,/relay/diagnostics,/api/v1/meta"),
         ("dspace", "/config.json,/healthz,/livez"),
+        ("jobbot3000", "/,/healthz,/livez"),
     ],
 )
 def test_example_app_configs_preserve_verify_paths(app: str, expected_paths: str) -> None:
@@ -1501,6 +1517,88 @@ def test_example_app_configs_preserve_verify_paths(app: str, expected_paths: str
 
     assert result.returncode == 0, result.stderr
     assert f'"SUGARKUBE_VERIFY_PATHS": "{expected_paths}"' in result.stdout
+
+
+def test_jobbot3000_example_config_resolves_all_env_values() -> None:
+    expected_values = {
+        "dev": "docs/examples/jobbot3000.values.dev.yaml",
+        "staging": (
+            "docs/examples/jobbot3000.values.dev.yaml,"
+            "docs/examples/jobbot3000.values.staging.yaml"
+        ),
+        "prod": (
+            "docs/examples/jobbot3000.values.dev.yaml,"
+            "docs/examples/jobbot3000.values.prod.yaml"
+        ),
+    }
+
+    for env, values in expected_values.items():
+        result = subprocess.run(
+            [
+                "python3",
+                "scripts/app_config.py",
+                "json",
+                "--app",
+                "jobbot3000",
+                "--env",
+                env,
+                "--config",
+                "",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert '"SUGARKUBE_CHART": "oci://ghcr.io/futuroptimist/charts/jobbot3000"' in result.stdout
+        assert f'"SUGARKUBE_VALUES": "{values}"' in result.stdout
+
+
+def test_jobbot3000_values_are_static_only_and_use_immutable_image_example() -> None:
+    values_paths = [
+        REPO_ROOT / "docs/examples/jobbot3000.values.dev.yaml",
+        REPO_ROOT / "docs/examples/jobbot3000.values.staging.yaml",
+        REPO_ROOT / "docs/examples/jobbot3000.values.prod.yaml",
+    ]
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in values_paths)
+    dev_values = values_paths[0].read_text(encoding="utf-8")
+
+    assert "repository: ghcr.io/futuroptimist/jobbot3000" in dev_values
+    assert "tag: main-REPLACE_SHORTSHA" in dev_values
+    assert "tag: latest" not in dev_values
+    assert "tag: main-latest" not in dev_values
+    assert "containerPort: 8080" in dev_values
+    assert "port: 80" in dev_values
+    assert "persistentVolumeClaim" not in combined
+    assert "persistence:" not in combined
+    assert "kind: Secret" not in combined
+    assert "secretKeyRef" not in combined
+    assert "kind: ConfigMap" not in combined
+    assert "configMapKeyRef" not in combined
+    assert "applications:" not in combined
+    assert "outreach" not in combined
+    assert "interviews" not in combined
+    assert "offers" not in combined
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_print_only_jobbot3000_paths(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        ["app-verify", "app=jobbot3000", "env=staging", "print_only=1"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert result.stdout.splitlines() == [
+        "curl -fsS https://example.test/",
+        "curl -fsS https://example.test/healthz",
+        "curl -fsS https://example.test/livez",
+    ]
+    assert not Path(generic_app_stub_env["CURL_LOG"]).exists()
 
 
 @pytest.mark.usefixtures("ensure_just_available")


### PR DESCRIPTION
### Motivation
- Add jobbot3000 as a first-class example for Sugarkube's generic `just app-*` deployment flow now that the app repo publishes the image and Helm chart. 
- Provide operators with example values, chart/image pins, and a runbook so jobbot3000 can be deployed with the shared recipes without bespoke wrappers. 
- Keep the Sugarkube ownership boundary: app repo owns image/chart artifacts while Sugarkube owns orchestration, pins, and verify flows. 

### Description
- Added example app config `docs/examples/apps/jobbot3000.env` with release, namespace, chart, version/prod tag pin files, values chains, host key, verify paths, and debug selector. 
- Added values overlays `docs/examples/jobbot3000.values.dev.yaml`, `docs/examples/jobbot3000.values.staging.yaml`, and `docs/examples/jobbot3000.values.prod.yaml` that use `ghcr.io/futuroptimist/jobbot3000`, an immutable-shaped placeholder tag `main-REPLACE_SHORTSHA`, container port `8080`, Pi-friendly resources, placeholder ingress hosts, and no server-side persistence. 
- Added chart pin `docs/apps/jobbot3000.version`, prod-tag pin `docs/apps/jobbot3000.prod.tag`, and a canonical runbook `docs/apps/jobbot3000.md` with artifact discovery links and operator commands. 
- Registered jobbot3000 in shared docs and onboarding (updated `docs/app_deployment_contract.md`, `docs/app_onboarding.md`, and `README.md`) and made `jobbot3000` an example fallback in `scripts/app_config.py`. 
- Extended tests to cover jobbot3000: updated `tests/test_generic_app_just_recipes.py` and `tests/test_app_runbook_links.py` with config resolution, values chain checks, verify paths, static-only values assertions, immutable tag examples, and artifact-link expectations. 

### Testing
- Resolved app config for all environments with `just app-config app=jobbot3000 env=dev`, `just app-config app=jobbot3000 env=staging`, and `just app-config app=jobbot3000 env=prod` which completed and produced expected resolved values. 
- Verified print-only checks with `just app-verify app=jobbot3000 env=staging print_only=1` which emitted the expected curl commands for `/`, `/healthz`, and `/livez` (placeholder host when cluster host discovery is not available). 
- Ran unit/integration tests: `python -m pytest tests/test_generic_app_just_recipes.py tests/test_app_runbook_links.py` and the affected test suite passed (`118 passed`). 
- Notes and environment limits: `pre-commit`, `pyspelling`, and `linkchecker` were not run in this container because those tools are not installed, and `helm show chart ...` was not executed here because `helm` is not available (the chart version `0.1.0` was read from the app repo Chart.yaml earlier and guidance to run `just app-chart-status`/`helm show chart` is included in the runbook).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4604e08d2c832fb9d0a2cd96651d64)