### PR TITLE
Onboard jobbot3000 generic app deployment

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -68,6 +68,7 @@ The current apps map to that model as examples:
 | dspace | `ghcr.io/democratizedspace/dspace` | `oci://ghcr.io/democratizedspace/charts/dspace` | `dspace` | `dspace` | `docs/apps/dspace.version` | `docs/apps/dspace.prod.tag` |
 | token.place | `ghcr.io/futuroptimist/tokenplace-relay` | `oci://ghcr.io/futuroptimist/charts/tokenplace` | `tokenplace` | `tokenplace` | `docs/apps/tokenplace.version` | `docs/apps/tokenplace.prod.tag` |
 | danielsmith.io | `ghcr.io/futuroptimist/danielsmith.io` | `oci://ghcr.io/futuroptimist/charts/danielsmith` | `danielsmith` | `danielsmith` | `docs/apps/danielsmith.version` | `docs/apps/danielsmith.prod.tag` |
+| jobbot3000 | `ghcr.io/futuroptimist/jobbot3000` | `oci://ghcr.io/futuroptimist/charts/jobbot3000` | `jobbot3000` | `jobbot3000` | `docs/apps/jobbot3000.version` | `docs/apps/jobbot3000.prod.tag` |
 
 ## Standard image tag model
 
@@ -237,6 +238,7 @@ shared `SUGARKUBE_VERIFY_PATHS` value:
 - [`docs/examples/apps/dspace.env`](examples/apps/dspace.env)
 - [`docs/examples/apps/tokenplace.env`](examples/apps/tokenplace.env)
 - [`docs/examples/apps/danielsmith.env`](examples/apps/danielsmith.env)
+- [`docs/examples/apps/jobbot3000.env`](examples/apps/jobbot3000.env)
 
 Current values chains:
 
@@ -245,3 +247,4 @@ Current values chains:
 | dspace | `docs/examples/dspace.values.dev.yaml` | `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml` | `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml` | `/config.json,/healthz,/livez` |
 | token.place | `docs/examples/tokenplace.values.dev.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml` | `/,/livez,/healthz,/relay/diagnostics` |
 | danielsmith.io | `docs/examples/danielsmith.values.dev.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml` | `/,/livez,/healthz` |
+| jobbot3000 | `docs/examples/jobbot3000.values.dev.yaml` | `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml` | `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.prod.yaml` | `/,/healthz,/livez` |

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -98,9 +98,9 @@ Create a base values file plus one overlay per environment.
 - `docs/examples/APP.values.prod.yaml`: production host, TLS secret, production env vars, and production-only settings.
 - Secrets must be referenced through Kubernetes Secret names or external secret tooling; never place secret values in docs or app configs.
 
-## Questions before onboarding wove or jobbot3000
+## Questions before onboarding future apps
 
-Do not invent real configs for `wove` or `jobbot3000` until their app repos have the required image and chart details. Capture these answers first:
+Do not invent real configs for future apps until their app repos have the required image and chart details. Capture these answers first:
 
 | Question | Why Sugarkube needs it |
 | --- | --- |

--- a/docs/apps/jobbot3000.md
+++ b/docs/apps/jobbot3000.md
@@ -1,0 +1,132 @@
+# jobbot3000 Sugarkube runbook
+
+jobbot3000 is deployed through Sugarkube's generic app recipes. The
+jobbot3000 repository owns the Dockerfile, static image, Helm chart, chart
+publication, app defaults, and release docs. Sugarkube owns the cluster-facing
+configuration: sanitized example app config, values overlays, chart pins,
+production tag pins, deploy/status/verify commands, and this runbook.
+
+## Artifact discovery
+
+- App repository: <https://github.com/futuroptimist/jobbot3000>
+- Image workflow: <https://github.com/futuroptimist/jobbot3000/blob/main/.github/workflows/ci-image.yml>
+- GHCR image package: <https://github.com/futuroptimist/jobbot3000/pkgs/container/jobbot3000>
+- Chart workflow: <https://github.com/futuroptimist/jobbot3000/blob/main/.github/workflows/ci-helm.yml>
+- GHCR chart package: <https://github.com/futuroptimist/jobbot3000/pkgs/container/charts%2Fjobbot3000>
+- Dockerfile source: <https://github.com/futuroptimist/jobbot3000/blob/main/Dockerfile>
+- Helm chart source: <https://github.com/futuroptimist/jobbot3000/tree/main/charts/jobbot3000>
+- Image release docs: <https://github.com/futuroptimist/jobbot3000/blob/main/docs/release-ghcr.md>
+- Helm release docs: <https://github.com/futuroptimist/jobbot3000/blob/main/docs/release-helm.md>
+
+Sugarkube consumes:
+
+- Image: `ghcr.io/futuroptimist/jobbot3000`
+- Chart: `oci://ghcr.io/futuroptimist/charts/jobbot3000`
+- Chart pin: [`jobbot3000.version`](jobbot3000.version)
+- Production tag pin: [`jobbot3000.prod.tag`](jobbot3000.prod.tag)
+- Example app config: [`../examples/apps/jobbot3000.env`](../examples/apps/jobbot3000.env)
+
+## Data, backup, and seeding model
+
+jobbot3000 is a static browser-only application. Kubernetes serves the web app;
+it does not store job applications, outreach messages, interview notes, offers,
+outcomes, imported files, contacts, resume links, Drive links, or private user
+settings.
+
+Private user data lives in the user's browser IndexedDB. Seed and restore data
+manually through the browser UI after opening the deployed app:
+
+- CSV is the spreadsheet-compatible, human-editable backup format.
+- JSON and NDJSON are full-fidelity backup and restore formats.
+- Dev, staging, and production are seeded only by browser import.
+
+Do not bake real user data into images, charts, Helm values, Kubernetes
+Secrets, ConfigMaps, PVCs, Sugarkube docs, or Sugarkube examples. The example
+values intentionally avoid PVCs and server-side persistence.
+
+## Staging deploy
+
+Pick an immutable image tag from the jobbot3000 image workflow or GHCR package,
+then deploy it to staging:
+
+```bash
+just app-deploy app=jobbot3000 env=staging tag=main-REPLACE_SHORTSHA
+```
+
+Redeploy the same or another immutable tag when re-running a rollout:
+
+```bash
+just app-redeploy app=jobbot3000 env=staging tag=main-REPLACE_SHORTSHA
+```
+
+## Status and verification
+
+Inspect the Helm release and resolved ingress host:
+
+```bash
+just app-status app=jobbot3000 env=staging
+```
+
+Run the generic HTTP smoke checks. The configured paths are `/`, `/healthz`, and
+`/livez`:
+
+```bash
+just app-verify app=jobbot3000 env=staging
+```
+
+Preview the verification curls without making network requests:
+
+```bash
+just app-verify app=jobbot3000 env=staging print_only=1
+```
+
+## Chart pin operations
+
+Before the first deploy, and before release deploys, confirm the committed chart
+pin exists in GHCR. This is especially important when the operator environment
+cannot run `helm show chart` during review:
+
+```bash
+just app-chart-status app=jobbot3000
+helm show chart oci://ghcr.io/futuroptimist/charts/jobbot3000 --version 0.1.0
+```
+
+When jobbot3000 publishes a new chart version that Sugarkube should consume,
+bump the committed pin intentionally:
+
+```bash
+just app-chart-bump app=jobbot3000 version=0.1.1
+```
+
+Do not use mutable chart selectors. Chart bumps are separate from image tag
+promotion and should be committed as explicit pin changes.
+
+## Production promotion
+
+Promote only an immutable image tag that already passed staging, such as a
+branch-SHA tag from the image workflow:
+
+```bash
+just app-promote-prod app=jobbot3000 tag=main-REPLACE_SHORTSHA
+```
+
+Do not use `latest`, `main-latest`, bare branch names, or environment names as
+production tags. Update [`jobbot3000.prod.tag`](jobbot3000.prod.tag) only when an
+immutable image tag is approved as the production pin.
+
+## Rollback
+
+Rollback by redeploying a previously known-good immutable image tag. If the
+chart pin also changed, revert or bump [`jobbot3000.version`](jobbot3000.version)
+first, then redeploy:
+
+```bash
+just app-redeploy app=jobbot3000 env=prod tag=main-PREVIOUSSHA
+```
+
+After rollback, run:
+
+```bash
+just app-status app=jobbot3000 env=prod
+just app-verify app=jobbot3000 env=prod
+```

--- a/docs/apps/jobbot3000.prod.tag
+++ b/docs/apps/jobbot3000.prod.tag
@@ -1,0 +1,4 @@
+# Approved production image tag for jobbot3000.
+#
+# Leave empty until an immutable image tag is explicitly approved for production.
+# Use the same tag that passed staging, for example main-REPLACE_SHORTSHA.

--- a/docs/apps/jobbot3000.version
+++ b/docs/apps/jobbot3000.version
@@ -1,0 +1,2 @@
+# Default jobbot3000 chart version. Update when new chart releases are published.
+0.1.0

--- a/docs/examples/apps/jobbot3000.env
+++ b/docs/examples/apps/jobbot3000.env
@@ -1,0 +1,17 @@
+# Example Sugarkube app config for jobbot3000.
+# Copy to apps/jobbot3000.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
+# containing jobbot3000.env.
+# This is an example fallback for generic recipes; local app configs take precedence.
+
+SUGARKUBE_APP=jobbot3000
+SUGARKUBE_RELEASE=jobbot3000
+SUGARKUBE_NAMESPACE=jobbot3000
+SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/jobbot3000
+SUGARKUBE_VERSION_FILE=docs/apps/jobbot3000.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/jobbot3000.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/jobbot3000.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/,/healthz,/livez
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=jobbot3000

--- a/docs/examples/jobbot3000.values.dev.yaml
+++ b/docs/examples/jobbot3000.values.dev.yaml
@@ -1,0 +1,28 @@
+# Base/shared jobbot3000 values consumed alongside environment overlays.
+# jobbot3000 is a static browser-local tracker: do not add PVCs, Secrets,
+# runtime fixtures containing real application data to these examples.
+environment: dev
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/jobbot3000
+  # Replace with an immutable image tag that passed CI, for example main-deadbee.
+  tag: main-REPLACE_SHORTSHA
+
+service:
+  port: 8080
+
+containerPort: 8080
+
+ingress:
+  enabled: false
+  className: traefik
+  annotations: {}
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi

--- a/docs/examples/jobbot3000.values.prod.yaml
+++ b/docs/examples/jobbot3000.values.prod.yaml
@@ -1,0 +1,12 @@
+# Production overlay values layered on top of jobbot3000.values.dev.yaml.
+environment: prod
+
+ingress:
+  enabled: true
+  className: traefik
+  host: jobbot3000.example.com
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  tls:
+    enabled: true
+    secretName: jobbot3000-prod-tls

--- a/docs/examples/jobbot3000.values.staging.yaml
+++ b/docs/examples/jobbot3000.values.staging.yaml
@@ -1,0 +1,12 @@
+# Staging overlay values layered on top of jobbot3000.values.dev.yaml.
+environment: staging
+
+ingress:
+  enabled: true
+  className: traefik
+  host: staging.jobbot3000.example.com
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  tls:
+    enabled: true
+    secretName: jobbot3000-staging-tls

--- a/scripts/app_config.py
+++ b/scripts/app_config.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Iterable
 
 SUPPORTED_ENVS = {"dev", "staging", "prod"}
-EXAMPLE_FALLBACK_APPS = {"danielsmith", "dspace", "tokenplace"}
+EXAMPLE_FALLBACK_APPS = {"danielsmith", "dspace", "jobbot3000", "tokenplace"}
 MOVING_TAGS = {
     "latest",
     "main",

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2282,3 +2282,94 @@ def test_app_cors_verify_run_curl_defaults_blank_status_and_missing_files(
     assert headers == {}
     assert body == b""
     assert stderr == ""
+
+
+def _read_simple_yaml(path: Path) -> dict[str, object]:
+    loaded: dict[str, object] = {}
+    parents: list[tuple[int, dict[str, object]]] = [(-1, loaded)]
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        key, separator, raw_value = raw_line.strip().partition(":")
+        assert separator, f"{path}: expected key/value line: {raw_line!r}"
+        while parents and indent <= parents[-1][0]:
+            parents.pop()
+        current = parents[-1][1]
+        value = raw_value.strip()
+        if not value:
+            nested: dict[str, object] = {}
+            current[key] = nested
+            parents.append((indent, nested))
+        elif value in {"true", "false"}:
+            current[key] = value == "true"
+        elif value.isdigit():
+            current[key] = int(value)
+        else:
+            current[key] = value
+    return loaded
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_jobbot3000_example_config_resolves_for_all_envs(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    for env_name in ("dev", "staging", "prod"):
+        result = _run_just(
+            ["app-config", "app=jobbot3000", f"env={env_name}"], generic_app_stub_env
+        )
+
+        assert result.returncode == 0, result.stderr + result.stdout
+        import json
+
+        resolved = json.loads(result.stdout)
+        assert resolved["SUGARKUBE_APP"] == "jobbot3000"
+        assert resolved["SUGARKUBE_CHART"] == "oci://ghcr.io/futuroptimist/charts/jobbot3000"
+        assert resolved["SUGARKUBE_VERIFY_PATHS"] == "/,/healthz,/livez"
+
+
+def test_jobbot3000_values_are_loadable_static_and_persistence_free() -> None:
+    values_paths = [
+        REPO_ROOT / "docs/examples/jobbot3000.values.dev.yaml",
+        REPO_ROOT / "docs/examples/jobbot3000.values.staging.yaml",
+        REPO_ROOT / "docs/examples/jobbot3000.values.prod.yaml",
+    ]
+    for path in values_paths:
+        values = _read_simple_yaml(path)
+        serialized = path.read_text(encoding="utf-8").lower()
+        assert "persistentvolumeclaim" not in serialized
+        assert "persistence:" not in serialized
+        assert "secret:" not in serialized
+        assert "configmap" not in serialized
+        assert "applications" not in serialized
+        assert "outreach" not in serialized
+        assert "interviews" not in serialized
+        assert "offers" not in serialized
+        assert "csv" not in serialized
+        assert "ndjson" not in serialized
+        assert isinstance(values, dict)
+
+    dev_values = _read_simple_yaml(values_paths[0])
+    assert dev_values["image"]["repository"] == "ghcr.io/futuroptimist/jobbot3000"
+    assert dev_values["image"]["tag"] == "main-REPLACE_SHORTSHA"
+    assert dev_values["image"]["tag"] not in {"latest", "main-latest"}
+    assert dev_values["service"]["port"] == 8080
+    assert dev_values["containerPort"] == 8080
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_jobbot3000_verify_print_only_includes_public_static_paths(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        ["app-verify", "app=jobbot3000", "env=staging", "print_only=1"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert result.stdout.splitlines() == [
+        "curl -fsS https://example.test/",
+        "curl -fsS https://example.test/healthz",
+        "curl -fsS https://example.test/livez",
+    ]
+    assert not Path(generic_app_stub_env["CURL_LOG"]).exists()


### PR DESCRIPTION
### Motivation

- Add jobbot3000 to Sugarkube's generic GHCR-first app onboarding so the app can be deployed with the shared `just app-*` recipes and example configs. 
- Provide sanitized example values and runbook guidance that enforce the browser-local IndexedDB data model and prevent baking user data into cluster resources.

### Description

- Added example app config `docs/examples/apps/jobbot3000.env`, dev/staging/prod values overlays in `docs/examples/jobbot3000.values.*.yaml`, chart pin `docs/apps/jobbot3000.version`, empty production tag pin `docs/apps/jobbot3000.prod.tag`, and the Sugarkube runbook `docs/apps/jobbot3000.md` with artifact discovery links and operator commands. 
- Registered jobbot3000 in shared docs by updating `docs/app_deployment_contract.md` and `docs/app_onboarding.md`. 
- Extended `tests/test_generic_app_just_recipes.py` with tests covering config resolution, values loadability, absence of persistence/user-data patterns, expected image repo and immutable placeholder tag shape, service/container port, and `app-verify print_only` paths. 
- Updated `scripts/app_config.py` to include `jobbot3000` in the example fallback apps so `just app-config app=jobbot3000 ...` resolves from the checked-in example config.

### Testing

- Ran `just app-config app=jobbot3000 env=dev`, `just app-config app=jobbot3000 env=staging`, and `just app-config app=jobbot3000 env=prod`, all of which succeeded and printed resolved JSON config. 
- Ran `python -m pytest tests/test_generic_app_just_recipes.py -q` and received all tests passing (`115 passed, 1 warning`). 
- Ran `just app-verify app=jobbot3000 env=staging print_only=1` in the test harness (stubbed env) which produced the expected print-only curl commands for `/`, `/healthz`, and `/livez`; a manual invocation in this environment printed placeholder host guidance because Helm/cluster host resolution is unavailable. 
- Ran `git diff --check` and `git diff | ./scripts/scan-secrets.py` and observed no new issues; `helm`, `pre-commit`, `pyspelling`, and `linkchecker` were not available in the execution environment so chart validation and full repo checks are noted in the runbook as operator steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4604f2aac8832f9b3428036cb8a671)