### PR TITLE
Onboard jobbot3000 to generic Sugarkube app deployment

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -27,9 +27,8 @@ Sugarkube owns cluster and environment orchestration:
 - applying the environment values chain; and
 - running status and verification checks against the cluster.
 
-Future onboarding examples include wove and jobbot3000, but they should only get
-Sugarkube app configs after their app repositories have published compatible
-images and charts.
+Future onboarding examples should only get Sugarkube app configs after their
+app repositories have published compatible images and charts.
 Use the [future-app onboarding guide](app_onboarding.md) for the checklist, minimal config template, and release decision tree.
 
 ## Standard artifact model
@@ -68,6 +67,7 @@ The current apps map to that model as examples:
 | dspace | `ghcr.io/democratizedspace/dspace` | `oci://ghcr.io/democratizedspace/charts/dspace` | `dspace` | `dspace` | `docs/apps/dspace.version` | `docs/apps/dspace.prod.tag` |
 | token.place | `ghcr.io/futuroptimist/tokenplace-relay` | `oci://ghcr.io/futuroptimist/charts/tokenplace` | `tokenplace` | `tokenplace` | `docs/apps/tokenplace.version` | `docs/apps/tokenplace.prod.tag` |
 | danielsmith.io | `ghcr.io/futuroptimist/danielsmith.io` | `oci://ghcr.io/futuroptimist/charts/danielsmith` | `danielsmith` | `danielsmith` | `docs/apps/danielsmith.version` | `docs/apps/danielsmith.prod.tag` |
+| jobbot3000 | `ghcr.io/futuroptimist/jobbot3000` | `oci://ghcr.io/futuroptimist/charts/jobbot3000` | `jobbot3000` | `jobbot3000` | `docs/apps/jobbot3000.version` | `docs/apps/jobbot3000.prod.tag` |
 
 ## Standard image tag model
 
@@ -237,6 +237,7 @@ shared `SUGARKUBE_VERIFY_PATHS` value:
 - [`docs/examples/apps/dspace.env`](examples/apps/dspace.env)
 - [`docs/examples/apps/tokenplace.env`](examples/apps/tokenplace.env)
 - [`docs/examples/apps/danielsmith.env`](examples/apps/danielsmith.env)
+- [`docs/examples/apps/jobbot3000.env`](examples/apps/jobbot3000.env)
 
 Current values chains:
 
@@ -245,3 +246,4 @@ Current values chains:
 | dspace | `docs/examples/dspace.values.dev.yaml` | `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml` | `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml` | `/config.json,/healthz,/livez` |
 | token.place | `docs/examples/tokenplace.values.dev.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml` | `/,/livez,/healthz,/relay/diagnostics` |
 | danielsmith.io | `docs/examples/danielsmith.values.dev.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml` | `/,/livez,/healthz` |
+| jobbot3000 | `docs/examples/jobbot3000.values.dev.yaml` | `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml` | `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.prod.yaml` | `/,/healthz,/livez` |

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -1,6 +1,6 @@
 # Sugarkube future-app onboarding guide
 
-Use this checklist when onboarding the next GHCR-first app to Sugarkube. The goal is that `wove`, `jobbot3000`, and later apps can reuse the same app repository release contract and the same Sugarkube `just app-*` operations without asking for bespoke deployment instructions.
+Use this checklist when onboarding the next GHCR-first app to Sugarkube. The goal is that `wove` and later apps can reuse the same app repository release contract and the same Sugarkube `just app-*` operations without asking for bespoke deployment instructions.
 
 ## Ownership boundaries
 
@@ -98,9 +98,9 @@ Create a base values file plus one overlay per environment.
 - `docs/examples/APP.values.prod.yaml`: production host, TLS secret, production env vars, and production-only settings.
 - Secrets must be referenced through Kubernetes Secret names or external secret tooling; never place secret values in docs or app configs.
 
-## Questions before onboarding wove or jobbot3000
+## Questions before onboarding future apps
 
-Do not invent real configs for `wove` or `jobbot3000` until their app repos have the required image and chart details. Capture these answers first:
+Do not invent real configs for future apps until their app repos have the required image and chart details. Capture these answers first:
 
 | Question | Why Sugarkube needs it |
 | --- | --- |

--- a/docs/apps/jobbot3000.md
+++ b/docs/apps/jobbot3000.md
@@ -1,0 +1,139 @@
+# jobbot3000 Sugarkube runbook
+
+jobbot3000 is a static, browser-only job application tracker. Sugarkube only
+orchestrates the Kubernetes deployment of the published static image and OCI Helm
+chart; the jobbot3000 repository owns the Dockerfile, image workflow, chart,
+chart publishing, and app release documentation.
+
+### Artifact links
+
+| Artifact | Link |
+| --- | --- |
+| app repository | <https://github.com/futuroptimist/jobbot3000> |
+| image workflow | <https://github.com/futuroptimist/jobbot3000/actions/workflows/ci-image.yml> |
+| GHCR image package | <https://github.com/futuroptimist/jobbot3000/pkgs/container/jobbot3000> |
+| chart workflow | <https://github.com/futuroptimist/jobbot3000/actions/workflows/ci-helm.yml> |
+| GHCR chart package | <https://github.com/futuroptimist/jobbot3000/pkgs/container/charts%2Fjobbot3000> |
+| Dockerfile | <https://github.com/futuroptimist/jobbot3000/blob/main/Dockerfile> |
+| chart source path | <https://github.com/futuroptimist/jobbot3000/tree/main/charts/jobbot3000> |
+| image release guide | <https://github.com/futuroptimist/jobbot3000/blob/main/docs/release-ghcr.md> |
+| Helm release guide | <https://github.com/futuroptimist/jobbot3000/blob/main/docs/release-helm.md> |
+
+Web UI shortcuts: open the image workflow, the GHCR image package, the chart
+workflow, and the GHCR chart package before deploying so the image tag and chart
+version are copied from successful app-repo artifacts instead of guessed.
+
+## Deployment coordinates
+
+- App config: `docs/examples/apps/jobbot3000.env`
+- Release/namespace: `jobbot3000` / `jobbot3000`
+- Image: `ghcr.io/futuroptimist/jobbot3000`
+- Chart: `oci://ghcr.io/futuroptimist/charts/jobbot3000`
+- Chart pin: `docs/apps/jobbot3000.version`
+- Production tag pin placeholder: `docs/apps/jobbot3000.prod.tag`
+- Container/service port: `8080`
+- Generic verify paths: `/`, `/healthz`, `/livez`
+
+If this Codex environment could not run `helm show chart`, operators should
+confirm the pinned chart exists before the first deploy:
+
+```bash
+just app-chart-status app=jobbot3000
+```
+
+or:
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/jobbot3000 --version 0.1.0
+```
+
+## Staging deploy
+
+Pick an immutable image tag from a successful jobbot3000 image workflow, such as
+`main-REPLACE_SHORTSHA`. Do not deploy `latest`, `main-latest`, a bare branch
+name, or an environment name.
+
+```bash
+just app-deploy app=jobbot3000 env=staging tag=main-REPLACE_SHORTSHA
+```
+
+Redeploy the same immutable tag after values, ingress, TLS, or cluster recovery:
+
+```bash
+just app-redeploy app=jobbot3000 env=staging tag=main-REPLACE_SHORTSHA
+```
+
+Check rollout state:
+
+```bash
+just app-status app=jobbot3000 env=staging
+```
+
+Run generic HTTP smoke checks:
+
+```bash
+just app-verify app=jobbot3000 env=staging
+```
+
+Print the generated checks without curling the host:
+
+```bash
+just app-verify app=jobbot3000 env=staging print_only=1
+```
+
+## Chart operations
+
+Inspect the currently pinned chart and the latest published GHCR chart metadata:
+
+```bash
+just app-chart-status app=jobbot3000
+```
+
+After the jobbot3000 repository publishes a new immutable chart version, bump the
+Sugarkube chart pin explicitly:
+
+```bash
+just app-chart-bump app=jobbot3000 version=0.1.0
+```
+
+Commit the resulting `docs/apps/jobbot3000.version` change with the rest of the
+release coordination. Never use a mutable chart selector for staging or
+production.
+
+## Production promotion and rollback
+
+Promote production only with the same immutable image tag that passed staging:
+
+```bash
+just app-promote-prod app=jobbot3000 tag=main-REPLACE_SHORTSHA
+```
+
+Rollback by redeploying a previous known-good immutable image tag:
+
+```bash
+just app-redeploy app=jobbot3000 env=prod tag=main-REPLACE_PREVIOUS_SHORTSHA
+```
+
+Use Helm revision rollback only when you intentionally want the entire rendered
+release state from a previous revision, not just the previous image.
+
+## Browser-local data model
+
+jobbot3000 stores private user data in the browser's IndexedDB. The Kubernetes
+workload serves static files only; it does not own job applications, outreach
+messages, interviews, offers, outcomes, notes, contacts, resume links, Drive
+links, imported spreadsheets, backups, or private settings.
+
+Backup and restore expectations:
+
+- CSV is the spreadsheet-compatible, human-editable backup format.
+- JSON and NDJSON are full-fidelity backup/restore formats.
+- Dev, staging, and production seeding happens manually through the browser
+  import UI after the static app is deployed.
+- Do not bake real user data into Docker images, Helm charts, Helm values,
+  Kubernetes Secrets, ConfigMaps, PVCs, repo fixtures, or Sugarkube docs/examples.
+
+The example values intentionally configure no PVCs and no Secret- or
+ConfigMap-backed user-data persistence. If a future jobbot3000 feature needs
+server-side state, update the app repository contract first, then add a focused
+Sugarkube follow-up instead of changing these static-app examples in place.

--- a/docs/apps/jobbot3000.prod.tag
+++ b/docs/apps/jobbot3000.prod.tag
@@ -1,0 +1,6 @@
+# Approved production image tag for jobbot3000.
+#
+# Leave empty until an image tag is explicitly approved for production.
+# Later deployment wrappers should require tag=<value> when this file has no
+# non-comment content. Use an immutable tag that passed staging, such as
+# main-REPLACE_SHORTSHA; never use latest, main-latest, or a bare branch name.

--- a/docs/apps/jobbot3000.version
+++ b/docs/apps/jobbot3000.version
@@ -1,0 +1,6 @@
+# Default jobbot3000 chart version. Update when new chart releases are published.
+# Source chart version observed in futuroptimist/jobbot3000 charts/jobbot3000/Chart.yaml.
+# If GHCR validation is unavailable, run `just app-chart-status app=jobbot3000`
+# or `helm show chart oci://ghcr.io/futuroptimist/charts/jobbot3000 --version 0.1.0`
+# before first deploy.
+0.1.0

--- a/docs/examples/apps/jobbot3000.env
+++ b/docs/examples/apps/jobbot3000.env
@@ -1,0 +1,17 @@
+# Example Sugarkube app config for jobbot3000.
+# Copy to apps/jobbot3000.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
+# containing jobbot3000.env.
+# This is an example fallback for generic recipes; local app configs take precedence.
+
+SUGARKUBE_APP=jobbot3000
+SUGARKUBE_RELEASE=jobbot3000
+SUGARKUBE_NAMESPACE=jobbot3000
+SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/jobbot3000
+SUGARKUBE_VERSION_FILE=docs/apps/jobbot3000.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/jobbot3000.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/jobbot3000.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/,/healthz,/livez
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=jobbot3000

--- a/docs/examples/jobbot3000.values.dev.yaml
+++ b/docs/examples/jobbot3000.values.dev.yaml
@@ -1,0 +1,27 @@
+# Base/shared jobbot3000 values consumed alongside environment overlays.
+# jobbot3000 is a static browser-local tracker: user data lives in IndexedDB
+# and is imported/exported through the browser, never Kubernetes persistence.
+environment: dev
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/jobbot3000
+  tag: main-REPLACE_SHORTSHA
+
+service:
+  port: 8080
+
+containerPort: 8080
+
+ingress:
+  enabled: false
+  className: traefik
+  annotations: {}
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi

--- a/docs/examples/jobbot3000.values.prod.yaml
+++ b/docs/examples/jobbot3000.values.prod.yaml
@@ -1,0 +1,12 @@
+# Production overlay values layered on top of jobbot3000.values.dev.yaml.
+environment: prod
+
+ingress:
+  enabled: true
+  className: traefik
+  host: jobbot3000.example.com
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  tls:
+    enabled: true
+    secretName: jobbot3000-prod-tls

--- a/docs/examples/jobbot3000.values.staging.yaml
+++ b/docs/examples/jobbot3000.values.staging.yaml
@@ -1,0 +1,12 @@
+# Staging overlay values layered on top of jobbot3000.values.dev.yaml.
+environment: staging
+
+ingress:
+  enabled: true
+  className: traefik
+  host: staging.jobbot3000.example.com
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  tls:
+    enabled: true
+    secretName: jobbot3000-staging-tls

--- a/scripts/app_config.py
+++ b/scripts/app_config.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Iterable
 
 SUPPORTED_ENVS = {"dev", "staging", "prod"}
-EXAMPLE_FALLBACK_APPS = {"danielsmith", "dspace", "tokenplace"}
+EXAMPLE_FALLBACK_APPS = {"danielsmith", "dspace", "jobbot3000", "tokenplace"}
 MOVING_TAGS = {
     "latest",
     "main",

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -30,15 +30,39 @@ def _write_config(path: Path, app: str = "custom", **overrides: str) -> Path:
     return path
 
 
-def test_example_config_fallback_resolves_staging_values() -> None:
-    cfg = app_config.load_config("tokenplace", "staging")
+@pytest.mark.parametrize(
+    ("app", "env", "values"),
+    [
+        (
+            "tokenplace",
+            "staging",
+            "docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml",
+        ),
+        ("jobbot3000", "dev", "docs/examples/jobbot3000.values.dev.yaml"),
+        (
+            "jobbot3000",
+            "staging",
+            "docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml",
+        ),
+        (
+            "jobbot3000",
+            "prod",
+            "docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.prod.yaml",
+        ),
+    ],
+)
+def test_example_config_fallback_resolves_env_values(
+    app: str, env: str, values: str
+) -> None:
+    cfg = app_config.load_config(app, env)
 
-    assert cfg["SUGARKUBE_CONFIG_PATH"].endswith("docs/examples/apps/tokenplace.env")
-    assert cfg["SUGARKUBE_RELEASE"] == "tokenplace"
-    assert cfg["SUGARKUBE_NAMESPACE"] == "tokenplace"
-    assert cfg["SUGARKUBE_VALUES"] == (
-        "docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml"
-    )
+    assert cfg["SUGARKUBE_CONFIG_PATH"].endswith(f"docs/examples/apps/{app}.env")
+    assert cfg["SUGARKUBE_RELEASE"] == app
+    assert cfg["SUGARKUBE_NAMESPACE"] == app
+    assert cfg["SUGARKUBE_VALUES"] == values
+    if app == "jobbot3000":
+        assert cfg["SUGARKUBE_CHART"] == "oci://ghcr.io/futuroptimist/charts/jobbot3000"
+        assert cfg["SUGARKUBE_VERIFY_PATHS"] == "/,/healthz,/livez"
 
 
 def test_config_dir_precedes_example_fallback(

--- a/tests/test_app_runbook_links.py
+++ b/tests/test_app_runbook_links.py
@@ -9,6 +9,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DSPACE_REPO = "https://github.com/democratizedspace/dspace"
 TOKENPLACE_REPO = "https://github.com/futuroptimist/token.place"
 DANIELSMITH_REPO = "https://github.com/futuroptimist/danielsmith.io"
+JOBBOT3000_REPO = "https://github.com/futuroptimist/jobbot3000"
 DSPACE_CHART_PACKAGE_LOOKUP = (
     "https://github.com/orgs/democratizedspace/"
     "packages?repo_name=dspace&q=charts%2Fdspace"
@@ -60,6 +61,20 @@ APP_LINKS = {
             f"{DANIELSMITH_REPO}/blob/main/Dockerfile",
             f"{DANIELSMITH_REPO}/tree/main/charts/danielsmith",
             f"{DANIELSMITH_REPO}/blob/main/docs/ops/sugarkube-release.md",
+        ],
+    },
+    "jobbot3000": {
+        "runbook": "docs/apps/jobbot3000.md",
+        "urls": [
+            JOBBOT3000_REPO,
+            f"{JOBBOT3000_REPO}/actions/workflows/ci-image.yml",
+            f"{JOBBOT3000_REPO}/pkgs/container/jobbot3000",
+            f"{JOBBOT3000_REPO}/actions/workflows/ci-helm.yml",
+            f"{JOBBOT3000_REPO}/pkgs/container/charts%2Fjobbot3000",
+            f"{JOBBOT3000_REPO}/blob/main/Dockerfile",
+            f"{JOBBOT3000_REPO}/tree/main/charts/jobbot3000",
+            f"{JOBBOT3000_REPO}/blob/main/docs/release-ghcr.md",
+            f"{JOBBOT3000_REPO}/blob/main/docs/release-helm.md",
         ],
     },
 }

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2282,3 +2282,74 @@ def test_app_cors_verify_run_curl_defaults_blank_status_and_missing_files(
     assert headers == {}
     assert body == b""
     assert stderr == ""
+
+
+def _jobbot3000_values_text(env: str) -> str:
+    return (REPO_ROOT / f"docs/examples/jobbot3000.values.{env}.yaml").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_jobbot3000_example_values_are_static_app_safe() -> None:
+    combined = "\n".join(
+        _jobbot3000_values_text(env) for env in ("dev", "staging", "prod")
+    )
+
+    assert "repository: ghcr.io/futuroptimist/jobbot3000" in combined
+    assert "tag: main-REPLACE_SHORTSHA" in combined
+    assert "latest" not in combined.lower()
+    assert "main-latest" not in combined.lower()
+    assert "port: 8080" in combined
+    assert "containerPort: 8080" in combined
+    assert "host: staging.jobbot3000.example.com" in combined
+    assert "host: jobbot3000.example.com" in combined
+    assert "resources:" in combined
+    for forbidden in (
+        "persistentVolumeClaim",
+        "persistence:",
+        "volumeClaimTemplates",
+        "existingSecret",
+        "secretKeyRef",
+        "configMapKeyRef",
+        "kind: Secret",
+        "kind: ConfigMap",
+    ):
+        assert forbidden not in combined
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_jobbot3000_app_deploy_uses_generic_coordinates(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        ["app-deploy", "app=jobbot3000", "env=staging", "tag=main-deadbee"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert (
+        "upgrade jobbot3000 oci://ghcr.io/futuroptimist/charts/jobbot3000" in helm_log
+    )
+    assert "--namespace jobbot3000" in helm_log
+    assert "-f docs/examples/jobbot3000.values.dev.yaml" in helm_log
+    assert "-f docs/examples/jobbot3000.values.staging.yaml" in helm_log
+    assert "--set image.tag=main-deadbee" in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_jobbot3000_app_verify_print_only_includes_static_paths(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        ["app-verify", "app=jobbot3000", "env=staging", "print_only=1"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert result.stdout.splitlines() == [
+        "curl -fsS https://example.test/",
+        "curl -fsS https://example.test/healthz",
+        "curl -fsS https://example.test/livez",
+    ]
+    assert not Path(generic_app_stub_env["CURL_LOG"]).exists()


### PR DESCRIPTION
### Motivation
- Provide a Sugarkube example config and runbook so `jobbot3000` can be deployed with the generic `just app-*` recipes and follow the existing GHCR+OCI chart contract. 
- Ensure example values are static-app-safe (browser-local IndexedDB model) and do not introduce server-side persistence, secrets, or mutable production tags. 
- Make the app discoverable in runbooks and tests so operators can find image/chart artifacts before deploying.

### Description
- Added example app config `docs/examples/apps/jobbot3000.env` with `SUGARKUBE_*` keys, `SUGARKUBE_VERIFY_PATHS` set to `/,/healthz,/livez`, and `SUGARKUBE_STATUS_HOST_KEY=ingress.host`.
- Added values overlays `docs/examples/jobbot3000.values.dev.yaml`, `docs/examples/jobbot3000.values.staging.yaml`, and `docs/examples/jobbot3000.values.prod.yaml` pointing to `ghcr.io/futuroptimist/jobbot3000`, using an immutable-shaped placeholder `main-REPLACE_SHORTSHA`, container/service port `8080`, Raspberry Pi-friendly resources, placeholder ingress hosts, and no PVCs/Secrets storing user data.
- Added chart pin `docs/apps/jobbot3000.version` (pinned to `0.1.0` with guidance to run `just app-chart-status` / `helm show chart` before first deploy) and production tag placeholder `docs/apps/jobbot3000.prod.tag` (comment-only until approved).
- Added a Sugarkube runbook `docs/apps/jobbot3000.md` with artifact discovery links (repo, image/chart workflows, GHCR packages, Dockerfile, chart source, release docs), deploy/redeploy/status/verify/chart/promote/rollback commands, and a Browser-local IndexedDB backup/import note that CSV/JSON/NDJSON are the supported backup formats.
- Registered `jobbot3000` as an example fallback app by updating `scripts/app_config.py`, `docs/app_deployment_contract.md`, and `docs/app_onboarding.md` and extended tests in `tests/test_app_config.py`, `tests/test_app_runbook_links.py`, and `tests/test_generic_app_just_recipes.py` to cover config resolution, runbook links, values safety, deploy coordinates, and print-only verify output.

### Testing
- Ran `just app-config app=jobbot3000 env=dev`, `just app-config app=jobbot3000 env=staging`, and `just app-config app=jobbot3000 env=prod` and confirmed the resolved JSON shell output contained the expected keys and values (success).
- Ran `just app-verify app=jobbot3000 env=staging print_only=1` and confirmed the printed curl checks include `/, /healthz, /livez` with placeholder host (success).
- Ran targeted pytest for modified tests: `python -m pytest tests/test_generic_app_just_recipes.py tests/test_app_config.py tests/test_app_runbook_links.py` and the tests covering `jobbot3000` passed (all relevant assertions succeeded).
- Ran repository checks: `git diff --check` and `./scripts/scan-secrets.py` on the diff passed; `pre-commit`, `pyspelling`, and `linkchecker` were attempted but unavailable in this container; `bash scripts/checks.sh` ran but reported pre-existing lint issues elsewhere in the repo unrelated to these changes (not introduced by this PR).

Residual risks / follow-ups: run `just app-chart-status app=jobbot3000` or `helm show chart oci://ghcr.io/futuroptimist/charts/jobbot3000 --version 0.1.0` from an operator environment with network/helm credentials to validate the chart publish before the first deploy, and populate `docs/apps/jobbot3000.prod.tag` with an approved immutable image tag when promoting to production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4604f582cc832f9d3d91fbf277fef7)