### PR TITLE
Prepare jobbot3000 staging rollout for staging.jobbot3000.tech (immutable tag main-b3e6df1a4f68)

### DIFF
--- a/docs/apps/jobbot3000.md
+++ b/docs/apps/jobbot3000.md
@@ -53,10 +53,34 @@ Do not bake real user data into Docker images, Helm charts, Helm values, Kuberne
 ## Environment topology
 
 - `env=dev`: base values in `docs/examples/jobbot3000.values.dev.yaml`; ingress disabled by default and image tag shown as the immutable placeholder `main-REPLACE_SHORTSHA`.
-- `env=staging`: values chain `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml`; placeholder host `staging.jobbot3000.example.test`.
+- `env=staging`: values chain `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml`; real staging host `staging.jobbot3000.tech`.
 - `env=prod`: values chain `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.prod.yaml`; placeholder host `jobbot3000.example.test`.
 
-Replace placeholder hosts in a local operator config or overlay before using a real cluster. Keep Cloudflare DNS and Tunnel routing outside Helm.
+The committed staging overlay intentionally uses the real first rollout host, `staging.jobbot3000.tech`, because the existing Sugarkube app examples for dspace, token.place, and danielsmith.io use real staging hosts. Production remains placeholder-only until explicitly approved. Keep Cloudflare DNS and Tunnel routing outside Helm.
+
+## First staging deployment: `staging.jobbot3000.tech`
+
+The first real staging candidate has been verified as a published GHCR image tag:
+`ghcr.io/futuroptimist/jobbot3000:main-b3e6df1a4f68`. The committed staging values resolve
+the public ingress host to `staging.jobbot3000.tech`. Cloudflare is expected to route
+`staging.jobbot3000.tech` path `*` through the existing Tunnel/Connector to
+`http://traefik.kube-system.svc.cluster.local:80`; do not add Cloudflare tokens or Tunnel
+credentials to this repository.
+
+Use the generic Sugarkube app surface for the first staging deploy:
+
+```bash
+just app-config app=jobbot3000 env=staging
+just app-chart-status app=jobbot3000
+just app-deploy app=jobbot3000 env=staging tag=main-b3e6df1a4f68
+just app-status app=jobbot3000 env=staging
+just app-verify app=jobbot3000 env=staging
+```
+
+`app-verify` must continue to check exactly `/`, `/healthz`, and `/livez`. Production
+promotion is blocked until the staging URL above is manually verified and the exact
+passing immutable tag is approved for production; `docs/apps/jobbot3000.prod.tag` stays
+empty for this staging rollout.
 
 ## Find or publish GHCR image
 
@@ -69,12 +93,12 @@ Web UI shortcuts:
 - Copy the immutable tag from a successful workflow summary or package version.
 
 ```bash
-APP_TAG=main-REPLACE_SHORTSHA
+APP_TAG=main-b3e6df1a4f68
 ```
 
 ## Confirm/publish OCI chart
 
-Sugarkube deploys the chart version pinned in `docs/apps/jobbot3000.version`. Use [recent chart workflow runs](https://github.com/futuroptimist/jobbot3000/actions/workflows/ci-helm.yml), [GHCR chart package versions](https://github.com/futuroptimist/jobbot3000/pkgs/container/charts%2Fjobbot3000), and [the chart source](https://github.com/futuroptimist/jobbot3000/tree/main/charts/jobbot3000) to confirm the pinned immutable version.
+Sugarkube deploys the chart version pinned in `docs/apps/jobbot3000.version`; `0.1.0` was reachable in GHCR when this runbook was updated. Use [recent chart workflow runs](https://github.com/futuroptimist/jobbot3000/actions/workflows/ci-helm.yml), [GHCR chart package versions](https://github.com/futuroptimist/jobbot3000/pkgs/container/charts%2Fjobbot3000), and [the chart source](https://github.com/futuroptimist/jobbot3000/tree/main/charts/jobbot3000) to confirm the pinned immutable version.
 
 ```bash
 just app-chart-status app=jobbot3000
@@ -94,7 +118,7 @@ just app-chart-bump app=jobbot3000 version=0.1.1
 ## Deploy and verify staging
 
 ```bash
-just app-deploy app=jobbot3000 env=staging tag=main-REPLACE_SHORTSHA
+just app-deploy app=jobbot3000 env=staging tag=main-b3e6df1a4f68
 ```
 
 ```bash
@@ -111,15 +135,49 @@ Print the generated checks without executing them:
 just app-verify app=jobbot3000 env=staging print_only=1
 ```
 
+## Staging troubleshooting
+
+Use these commands to separate DNS, Tunnel, Ingress, registry, and certificate failures:
+
+```bash
+# DNS should resolve the public staging hostname through Cloudflare.
+dig +short staging.jobbot3000.tech
+
+# Confirm the public edge reaches the app paths after deploy.
+curl -fsS https://staging.jobbot3000.tech/
+curl -fsS https://staging.jobbot3000.tech/healthz
+curl -fsS https://staging.jobbot3000.tech/livez
+
+# Confirm Ingress, Service, EndpointSlice, and pod state in Kubernetes.
+kubectl -n jobbot3000 get ingress,svc,endpointslice,pods -o wide
+kubectl -n jobbot3000 describe ingress jobbot3000
+kubectl -n jobbot3000 logs -l app.kubernetes.io/name=jobbot3000 --tail=100
+
+# Confirm Traefik sees requests from the Cloudflare Tunnel target.
+kubectl -n kube-system logs deploy/traefik --tail=200
+
+# Confirm GHCR artifacts are pullable from the operator workstation.
+helm show chart oci://ghcr.io/futuroptimist/charts/jobbot3000 --version 0.1.0
+docker manifest inspect ghcr.io/futuroptimist/jobbot3000:main-b3e6df1a4f68
+
+# Inspect cert-manager if TLS remains pending or serves the wrong certificate.
+kubectl -n jobbot3000 get certificate,certificaterequest,order,challenge
+kubectl -n cert-manager logs deploy/cert-manager --tail=200
+```
+
+If DNS is correct but HTTPS fails, verify the Cloudflare Tunnel route still targets
+`http://traefik.kube-system.svc.cluster.local:80` for `staging.jobbot3000.tech` path `*`,
+then inspect the jobbot3000 Ingress and Traefik logs above.
+
 ## Redeploy, promote, and rollback
 
 Redeploy staging or production with a specific immutable tag:
 
 ```bash
-just app-redeploy app=jobbot3000 env=staging tag=main-REPLACE_SHORTSHA
+just app-redeploy app=jobbot3000 env=staging tag=main-b3e6df1a4f68
 ```
 
-Promote production only after staging sign-off, using the exact immutable image tag that passed staging:
+Production promotion is intentionally blocked for this first staging rollout. Promote production only after staging sign-off, using the exact immutable image tag that passed staging and an explicit production approval:
 
 ```bash
 just app-promote-prod app=jobbot3000 tag=main-REPLACE_SHORTSHA

--- a/docs/examples/jobbot3000.values.staging.yaml
+++ b/docs/examples/jobbot3000.values.staging.yaml
@@ -4,10 +4,10 @@ environment: staging
 ingress:
   enabled: true
   className: traefik
-  host: staging.jobbot3000.example.test
+  host: staging.jobbot3000.tech
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
   tls:
     - secretName: jobbot3000-staging-tls
       hosts:
-        - staging.jobbot3000.example.test
+        - staging.jobbot3000.tech

--- a/scripts/app_verify.py
+++ b/scripts/app_verify.py
@@ -57,9 +57,8 @@ def discover_host(kube_context: str) -> tuple[str, list[str]]:
             if host:
                 return host, errors
         else:
-            errors.append(
-                f"helm get values failed for context {kube_context}: {helm.stderr.replace(chr(10), ' ').strip()}"
-            )
+            stderr = helm.stderr.replace(chr(10), " ").strip()
+            errors.append(f"helm get values failed for context {kube_context}: {stderr}")
 
     if shutil_which("kubectl"):
         kubectl = run_capture(
@@ -78,9 +77,9 @@ def discover_host(kube_context: str) -> tuple[str, list[str]]:
         if kubectl.returncode == 0 and kubectl.stdout.strip():
             return kubectl.stdout.strip(), errors
         if kubectl.returncode != 0:
-            errors.append(
-                f"kubectl ingress lookup failed for context {kube_context}: {kubectl.stderr.replace(chr(10), ' ').strip()}"
-            )
+            stderr = kubectl.stderr.replace(chr(10), " ").strip()
+            errors.append(f"kubectl ingress lookup failed for context {kube_context}: {stderr}")
+
     return "", errors
 
 
@@ -102,6 +101,51 @@ def host_from_values(raw: str, host_key: str) -> str:
     return str(node) if node else ""
 
 
+def host_from_configured_values(values: str, host_key: str) -> str:
+    """Return a dotted host value from simple Helm values overlays.
+
+    This intentionally handles the small YAML subset used by Sugarkube example
+    values so print-only verification can be copy-paste-ready without requiring
+    cluster access or adding a YAML runtime dependency. Later files in the comma
+    separated Helm values chain override earlier files, matching Helm behavior.
+    """
+
+    host = ""
+    for raw_path in values.split(","):
+        path = Path(raw_path.strip())
+        if not path.is_absolute():
+            path = Path.cwd() / path
+        if not path.is_file():
+            continue
+        candidate = host_from_simple_yaml(path.read_text(encoding="utf-8"), host_key)
+        if candidate:
+            host = candidate
+    return host
+
+
+def host_from_simple_yaml(raw: str, host_key: str) -> str:
+    parts = host_key.split(".")
+    stack: list[tuple[int, str]] = []
+    for line in raw.splitlines():
+        content = line.split("#", 1)[0].rstrip()
+        if (
+            not content.strip()
+            or content.lstrip().startswith("-")
+            or ":" not in content
+        ):
+            continue
+        indent = len(content) - len(content.lstrip(" "))
+        key, value = content.strip().split(":", 1)
+        while stack and stack[-1][0] >= indent:
+            stack.pop()
+        current_path = [item[1] for item in stack] + [key.strip()]
+        if current_path == parts:
+            return value.strip().strip('"\'')
+        if not value.strip():
+            stack.append((indent, key.strip()))
+    return ""
+
+
 def base_url_from_host(host: str) -> str:
     host = host.strip().rstrip("/")
     if not host:
@@ -120,7 +164,8 @@ def print_placeholder_failure(
     for error in errors:
         print(error, file=sys.stderr)
     print(
-        f"Suggested next steps: just app-status app={app} env={env} or just app-config app={app} env={env}.",
+        f"Suggested next steps: just app-status app={app} env={env} "
+        f"or just app-config app={app} env={env}.",
         file=sys.stderr,
     )
     print("Generated verification commands with a placeholder host:", file=sys.stderr)
@@ -194,7 +239,10 @@ def tokenplace_meta_failure(env: str, raw: bytes) -> str:
     if version == "dev" or label.endswith(" dev"):
         if env == "prod":
             return "token.place prod metadata must not report version=dev."
-        return "token.place staging metadata must include the immutable image tag, not a dev label/version."
+        return (
+            "token.place staging metadata must include the immutable image tag, "
+            "not a dev label/version."
+        )
     return ""
 
 
@@ -207,11 +255,17 @@ def main(argv: list[str] | None = None) -> int:
     env = os.environ["SUGARKUBE_ENV"]
     kube_context = f"sugar-{env}"
     paths = [
-        normalize_path(path) for path in os.environ.get("SUGARKUBE_VERIFY_PATHS", "/").split(",")
+        normalize_path(path)
+        for path in os.environ.get("SUGARKUBE_VERIFY_PATHS", "/").split(",")
     ]
     print_only = args.print_only or env_flag("SUGARKUBE_APP_VERIFY_PRINT_ONLY")
 
     host, errors = discover_host(kube_context)
+    if print_only and not host:
+        host = host_from_configured_values(
+            os.environ.get("SUGARKUBE_VALUES", ""),
+            os.environ.get("SUGARKUBE_STATUS_HOST_KEY", "ingress.host"),
+        )
     base_url = base_url_from_host(host)
     if not base_url:
         print_placeholder_failure(app, env, kube_context, paths, errors)

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1235,9 +1235,12 @@ def test_app_promote_prod_delegates_to_prod_deploy_coordinates(
 
 
 @pytest.mark.usefixtures("ensure_just_available")
-def test_app_deploy_rejects_mutable_tag_before_helm(generic_app_stub_env: dict[str, str]) -> None:
+@pytest.mark.parametrize("mutable_tag", ["latest", "main-latest"])
+def test_app_deploy_rejects_mutable_tag_before_helm(
+    mutable_tag: str, generic_app_stub_env: dict[str, str]
+) -> None:
     result = _run_just(
-        ["app-deploy", "app=tokenplace", "env=staging", "tag=latest"],
+        ["app-deploy", "app=jobbot3000", "env=staging", f"tag={mutable_tag}"],
         generic_app_stub_env,
     )
 
@@ -1556,6 +1559,33 @@ def test_jobbot3000_example_config_resolves_all_env_values() -> None:
         assert f'"SUGARKUBE_VALUES": "{values}"' in result.stdout
 
 
+def test_jobbot3000_staging_values_use_real_first_rollout_host() -> None:
+    staging_values = (REPO_ROOT / "docs/examples/jobbot3000.values.staging.yaml").read_text(
+        encoding="utf-8"
+    )
+    runbook = (REPO_ROOT / "docs/apps/jobbot3000.md").read_text(encoding="utf-8")
+
+    assert "host: staging.jobbot3000.tech" in staging_values
+    assert "- staging.jobbot3000.tech" in staging_values
+    assert "staging.jobbot3000.example.test" not in staging_values
+    assert "staging.jobbot3000.tech" in runbook
+    assert "http://traefik.kube-system.svc.cluster.local:80" in runbook
+    assert "main-b3e6df1a4f68" in runbook
+
+
+def test_jobbot3000_print_only_verify_can_resolve_staging_host_without_cluster() -> None:
+    from scripts import app_verify
+
+    values = (
+        "docs/examples/jobbot3000.values.dev.yaml,"
+        "docs/examples/jobbot3000.values.staging.yaml"
+    )
+
+    assert app_verify.host_from_configured_values(values, "ingress.host") == (
+        "staging.jobbot3000.tech"
+    )
+
+
 def test_jobbot3000_values_are_static_only_and_use_immutable_image_example() -> None:
     values_paths = [
         REPO_ROOT / "docs/examples/jobbot3000.values.dev.yaml",
@@ -1567,8 +1597,8 @@ def test_jobbot3000_values_are_static_only_and_use_immutable_image_example() -> 
 
     assert "repository: ghcr.io/futuroptimist/jobbot3000" in dev_values
     assert "tag: main-REPLACE_SHORTSHA" in dev_values
-    assert "tag: latest" not in dev_values
-    assert "tag: main-latest" not in dev_values
+    assert "tag: latest" not in combined
+    assert "tag: main-latest" not in combined
     assert "containerPort: 8080" in dev_values
     assert "port: 80" in dev_values
     assert "persistentVolumeClaim" not in combined


### PR DESCRIPTION
### Motivation
- Prepare the Sugarkube repo for the first real jobbot3000 staging rollout on `staging.jobbot3000.tech` using a verified immutable image tag while keeping production promotion explicitly blocked. 
- Make the first staging deployment copy-paste-ready using the existing generic `just app-*` deployment surface and avoid introducing secrets, PVCs, or server-side persistence. 

### Description
- Update the runbook `docs/apps/jobbot3000.md` to document `staging.jobbot3000.tech`, the Cloudflare Tunnel target `http://traefik.kube-system.svc.cluster.local:80`, the immutable initial image tag `main-b3e6df1a4f68`, the exact `just` commands to run, and a staging troubleshooting snippet. 
- Change the committed staging Helm values in `docs/examples/jobbot3000.values.staging.yaml` to set the ingress host and TLS host to `staging.jobbot3000.tech`. 
- Enhance `scripts/app_verify.py` so print-only verification (`print_only=1`) can resolve the host from the configured Helm values chain (adds `host_from_configured_values`/`host_from_simple_yaml`) while preserving live discovery behavior. 
- Add and adjust tests in `tests/test_generic_app_just_recipes.py` to cover: the staging host resolution, `app-verify` print-only host resolution, immutable-tag rejection (reject `latest`/`main-latest`), and that jobbot3000 values remain static-only with no Secrets/PVCs/persistence. 

### Testing
- Ran targeted unit tests with `python -m pytest tests/test_generic_app_just_recipes.py tests/test_app_verify.py -q`, which passed. 
- Ran the full test suite with `python -m pytest`, which passed in this environment (`1426 passed, 19 skipped` in the run performed here). 
- Verified `just` helpers: `just app-config app=jobbot3000 env=staging` printed the resolved environment exports and `just app-verify app=jobbot3000 env=staging print_only=1` printed the expected curl checks for `https://staging.jobbot3000.tech/`, `/healthz`, and `/livez`. 
- Verified GHCR reachability for `ghcr.io/futuroptimist/jobbot3000:main-b3e6df1a4f68` and chart `oci://ghcr.io/futuroptimist/charts/jobbot3000:0.1.0` via registry manifest requests which returned OK. 
- Notes and environment limits: `just app-chart-status` could not run here because `helm` is not installed, so registry validation was done via direct manifest checks; `pre-commit`, `pyspelling`, and `linkchecker` were not available in this environment and were therefore not executed here, and `bash scripts/checks.sh` reported pre-existing lint/style items unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a485517fa5c832f80d85b1565d55603)