### PR TITLE
Prepare jobbot3000 staging deployment

### DIFF
--- a/docs/apps/jobbot3000.md
+++ b/docs/apps/jobbot3000.md
@@ -174,24 +174,24 @@ cloudflared tunnel ingress validate
 
 ```bash
 # Confirm Traefik sees the jobbot3000 Ingress and routes to the service.
-kubectl get ingress -n jobbot3000 jobbot3000 -o wide
-kubectl describe ingress -n jobbot3000 jobbot3000
-kubectl get svc,endpoints -n jobbot3000
-kubectl logs -n kube-system -l app.kubernetes.io/name=traefik --tail=200
+kubectl --context sugar-staging get ingress -n jobbot3000 jobbot3000 -o wide
+kubectl --context sugar-staging describe ingress -n jobbot3000 jobbot3000
+kubectl --context sugar-staging get svc,endpoints -n jobbot3000
+kubectl --context sugar-staging logs -n kube-system -l app.kubernetes.io/name=traefik --tail=200
 ```
 
 ```bash
 # Confirm cert-manager issued the staging certificate.
-kubectl get certificate,challenge,order -n jobbot3000
-kubectl describe certificate -n jobbot3000 jobbot3000-staging-tls
-kubectl logs -n cert-manager deploy/cert-manager --tail=200
+kubectl --context sugar-staging get certificate,challenge,order -n jobbot3000
+kubectl --context sugar-staging describe certificate -n jobbot3000 jobbot3000-staging-tls
+kubectl --context sugar-staging logs -n cert-manager deploy/cert-manager --tail=200
 ```
 
 ```bash
 # Confirm GHCR image/chart access and the immutable deployment coordinates.
 helm show chart oci://ghcr.io/futuroptimist/charts/jobbot3000 --version 0.1.0
-helm get values -n jobbot3000 jobbot3000
-kubectl get deploy -n jobbot3000 jobbot3000 -o jsonpath='{.spec.template.spec.containers[*].image}{"\n"}'
+helm --kube-context sugar-staging get values -n jobbot3000 jobbot3000
+kubectl --context sugar-staging get deploy -n jobbot3000 jobbot3000 -o jsonpath='{.spec.template.spec.containers[*].image}{"\n"}'
 ```
 
 ```bash

--- a/docs/apps/jobbot3000.md
+++ b/docs/apps/jobbot3000.md
@@ -53,10 +53,10 @@ Do not bake real user data into Docker images, Helm charts, Helm values, Kuberne
 ## Environment topology
 
 - `env=dev`: base values in `docs/examples/jobbot3000.values.dev.yaml`; ingress disabled by default and image tag shown as the immutable placeholder `main-REPLACE_SHORTSHA`.
-- `env=staging`: values chain `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml`; placeholder host `staging.jobbot3000.example.test`.
+- `env=staging`: values chain `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml`; real host `staging.jobbot3000.tech`.
 - `env=prod`: values chain `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.prod.yaml`; placeholder host `jobbot3000.example.test`.
 
-Replace placeholder hosts in a local operator config or overlay before using a real cluster. Keep Cloudflare DNS and Tunnel routing outside Helm.
+The committed staging overlay is intentionally copy-paste-ready for the first real staging rollout at `staging.jobbot3000.tech`, matching the existing Sugarkube pattern used by dspace, token.place, and danielsmith.io staging overlays. Keep Cloudflare credentials outside Helm; DNS and Tunnel routing remain Cloudflare-owned and are only referenced here for operator verification.
 
 ## Find or publish GHCR image
 
@@ -69,7 +69,7 @@ Web UI shortcuts:
 - Copy the immutable tag from a successful workflow summary or package version.
 
 ```bash
-APP_TAG=main-REPLACE_SHORTSHA
+APP_TAG=main-b3e6df1a4f68
 ```
 
 ## Confirm/publish OCI chart
@@ -91,10 +91,26 @@ If registry validation was unavailable when this runbook was last edited, operat
 just app-chart-bump app=jobbot3000 version=0.1.1
 ```
 
-## Deploy and verify staging
+## First staging deploy
+
+The initial staging candidate is `main-b3e6df1a4f68`. Before committing this runbook, that tag was verified as a published GHCR manifest for `ghcr.io/futuroptimist/jobbot3000`, and chart version `0.1.0` was verified as published for `oci://ghcr.io/futuroptimist/charts/jobbot3000`.
+
+The Cloudflare zone for `jobbot3000.tech` is active, and the Cloudflare Tunnel route for `staging.jobbot3000.tech` path `*` must point to Traefik at `http://traefik.kube-system.svc.cluster.local:80`. The Helm chart only creates the Kubernetes Service and Ingress; do not put Cloudflare tokens in Sugarkube values.
+
+Confirm the resolved generic app config and chart pin:
 
 ```bash
-just app-deploy app=jobbot3000 env=staging tag=main-REPLACE_SHORTSHA
+just app-config app=jobbot3000 env=staging
+```
+
+```bash
+just app-chart-status app=jobbot3000
+```
+
+Deploy the immutable candidate to staging:
+
+```bash
+just app-deploy app=jobbot3000 env=staging tag=main-b3e6df1a4f68
 ```
 
 ```bash
@@ -116,13 +132,13 @@ just app-verify app=jobbot3000 env=staging print_only=1
 Redeploy staging or production with a specific immutable tag:
 
 ```bash
-just app-redeploy app=jobbot3000 env=staging tag=main-REPLACE_SHORTSHA
+just app-redeploy app=jobbot3000 env=staging tag=main-b3e6df1a4f68
 ```
 
-Promote production only after staging sign-off, using the exact immutable image tag that passed staging:
+Production promotion is explicitly blocked until staging is verified and approved. Leave `docs/apps/jobbot3000.prod.tag` empty for this staging-only rollout. After a later production approval, promote using the exact immutable image tag that passed staging:
 
 ```bash
-just app-promote-prod app=jobbot3000 tag=main-REPLACE_SHORTSHA
+just app-promote-prod app=jobbot3000 tag=<APPROVED_IMMUTABLE_TAG>
 ```
 
 Rollback by redeploying the previous known-good immutable image tag:
@@ -139,4 +155,48 @@ just app-status app=jobbot3000 env=prod
 
 ```bash
 just app-verify app=jobbot3000 env=prod
+```
+
+## Staging troubleshooting
+
+Use these focused checks when the first staging rollout fails:
+
+```bash
+# DNS should resolve through Cloudflare for the public hostname.
+dig +short staging.jobbot3000.tech
+```
+
+```bash
+# The Cloudflare Tunnel route should send staging.jobbot3000.tech/* to Traefik.
+cloudflared tunnel route dns --help
+cloudflared tunnel ingress validate
+```
+
+```bash
+# Confirm Traefik sees the jobbot3000 Ingress and routes to the service.
+kubectl get ingress -n jobbot3000 jobbot3000 -o wide
+kubectl describe ingress -n jobbot3000 jobbot3000
+kubectl get svc,endpoints -n jobbot3000
+kubectl logs -n kube-system -l app.kubernetes.io/name=traefik --tail=200
+```
+
+```bash
+# Confirm cert-manager issued the staging certificate.
+kubectl get certificate,challenge,order -n jobbot3000
+kubectl describe certificate -n jobbot3000 jobbot3000-staging-tls
+kubectl logs -n cert-manager deploy/cert-manager --tail=200
+```
+
+```bash
+# Confirm GHCR image/chart access and the immutable deployment coordinates.
+helm show chart oci://ghcr.io/futuroptimist/charts/jobbot3000 --version 0.1.0
+helm get values -n jobbot3000 jobbot3000
+kubectl get deploy -n jobbot3000 jobbot3000 -o jsonpath='{.spec.template.spec.containers[*].image}{"\n"}'
+```
+
+```bash
+# Re-run the public path checks expected by the Sugarkube contract.
+curl -fsS https://staging.jobbot3000.tech/
+curl -fsS https://staging.jobbot3000.tech/healthz
+curl -fsS https://staging.jobbot3000.tech/livez
 ```

--- a/docs/apps/jobbot3000.md
+++ b/docs/apps/jobbot3000.md
@@ -190,7 +190,8 @@ kubectl --context sugar-staging logs -n cert-manager deploy/cert-manager --tail=
 ```bash
 # Confirm GHCR image/chart access and the immutable deployment coordinates.
 helm show chart oci://ghcr.io/futuroptimist/charts/jobbot3000 --version 0.1.0
-helm --kube-context sugar-staging get values -n jobbot3000 jobbot3000
+helm --kube-context sugar-staging -n jobbot3000 get values jobbot3000
+helm --kube-context sugar-staging -n jobbot3000 status jobbot3000
 kubectl --context sugar-staging get deploy -n jobbot3000 jobbot3000 -o jsonpath='{.spec.template.spec.containers[*].image}{"\n"}'
 ```
 

--- a/docs/examples/jobbot3000.values.staging.yaml
+++ b/docs/examples/jobbot3000.values.staging.yaml
@@ -4,10 +4,10 @@ environment: staging
 ingress:
   enabled: true
   className: traefik
-  host: staging.jobbot3000.example.test
+  host: staging.jobbot3000.tech
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
   tls:
     - secretName: jobbot3000-staging-tls
       hosts:
-        - staging.jobbot3000.example.test
+        - staging.jobbot3000.tech

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1589,6 +1589,22 @@ def test_jobbot3000_runbook_first_staging_deploy_is_concrete_and_blocks_prod() -
     assert "Production promotion is explicitly blocked until staging is verified" in runbook
 
 
+def test_jobbot3000_runbook_troubleshooting_pins_staging_context() -> None:
+    runbook = (REPO_ROOT / "docs/apps/jobbot3000.md").read_text(encoding="utf-8")
+
+    assert "kubectl --context sugar-staging get ingress" in runbook
+    assert "kubectl --context sugar-staging describe ingress" in runbook
+    assert "kubectl --context sugar-staging get svc,endpoints" in runbook
+    assert "kubectl --context sugar-staging logs -n kube-system" in runbook
+    assert "kubectl --context sugar-staging get certificate,challenge,order" in runbook
+    assert "kubectl --context sugar-staging describe certificate" in runbook
+    assert "kubectl --context sugar-staging logs -n cert-manager" in runbook
+    assert "helm --kube-context sugar-staging get values" in runbook
+    assert "kubectl --context sugar-staging get deploy" in runbook
+    assert "kubectl get ingress -n jobbot3000" not in runbook
+    assert "helm get values -n jobbot3000" not in runbook
+
+
 def test_jobbot3000_values_are_static_only_and_use_immutable_image_example() -> None:
     values_paths = [
         REPO_ROOT / "docs/examples/jobbot3000.values.dev.yaml",

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1599,9 +1599,13 @@ def test_jobbot3000_runbook_troubleshooting_pins_staging_context() -> None:
     assert "kubectl --context sugar-staging get certificate,challenge,order" in runbook
     assert "kubectl --context sugar-staging describe certificate" in runbook
     assert "kubectl --context sugar-staging logs -n cert-manager" in runbook
-    assert "helm --kube-context sugar-staging get values" in runbook
+    assert "helm --kube-context sugar-staging -n jobbot3000 get values jobbot3000" in runbook
+    assert "helm --kube-context sugar-staging -n jobbot3000 status jobbot3000" in runbook
     assert "kubectl --context sugar-staging get deploy" in runbook
     assert "kubectl get ingress -n jobbot3000" not in runbook
+    assert "kubectl describe ingress -n jobbot3000 jobbot3000" not in runbook
+    assert "kubectl logs -n cert-manager deploy/cert-manager" not in runbook
+    assert "helm get values -n jobbot3000 jobbot3000" not in runbook
     assert "helm get values -n jobbot3000" not in runbook
 
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1235,9 +1235,12 @@ def test_app_promote_prod_delegates_to_prod_deploy_coordinates(
 
 
 @pytest.mark.usefixtures("ensure_just_available")
-def test_app_deploy_rejects_mutable_tag_before_helm(generic_app_stub_env: dict[str, str]) -> None:
+@pytest.mark.parametrize("mutable_tag", ["latest", "main-latest"])
+def test_app_deploy_rejects_mutable_tag_before_helm(
+    mutable_tag: str, generic_app_stub_env: dict[str, str]
+) -> None:
     result = _run_just(
-        ["app-deploy", "app=tokenplace", "env=staging", "tag=latest"],
+        ["app-deploy", "app=jobbot3000", "env=staging", f"tag={mutable_tag}"],
         generic_app_stub_env,
     )
 
@@ -1554,6 +1557,36 @@ def test_jobbot3000_example_config_resolves_all_env_values() -> None:
         assert result.returncode == 0, result.stderr
         assert '"SUGARKUBE_CHART": "oci://ghcr.io/futuroptimist/charts/jobbot3000"' in result.stdout
         assert f'"SUGARKUBE_VALUES": "{values}"' in result.stdout
+
+
+def test_jobbot3000_staging_values_resolve_real_staging_host() -> None:
+    staging_values = (REPO_ROOT / "docs/examples/jobbot3000.values.staging.yaml").read_text(
+        encoding="utf-8"
+    )
+    app_env = (REPO_ROOT / "docs/examples/apps/jobbot3000.env").read_text(encoding="utf-8")
+
+    assert (
+        "SUGARKUBE_VALUES_STAGING="
+        "docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml"
+    ) in app_env
+    assert "host: staging.jobbot3000.tech" in staging_values
+    assert "- staging.jobbot3000.tech" in staging_values
+    assert "staging.jobbot3000.example.test" not in staging_values
+
+
+def test_jobbot3000_runbook_first_staging_deploy_is_concrete_and_blocks_prod() -> None:
+    runbook = (REPO_ROOT / "docs/apps/jobbot3000.md").read_text(encoding="utf-8")
+
+    assert "staging.jobbot3000.tech" in runbook
+    assert "http://traefik.kube-system.svc.cluster.local:80" in runbook
+    assert "just app-config app=jobbot3000 env=staging" in runbook
+    assert "just app-chart-status app=jobbot3000" in runbook
+    assert (
+        "just app-deploy app=jobbot3000 env=staging tag=main-b3e6df1a4f68" in runbook
+    )
+    assert "just app-status app=jobbot3000 env=staging" in runbook
+    assert "just app-verify app=jobbot3000 env=staging" in runbook
+    assert "Production promotion is explicitly blocked until staging is verified" in runbook
 
 
 def test_jobbot3000_values_are_static_only_and_use_immutable_image_example() -> None:


### PR DESCRIPTION
### Motivation
- Make Sugarkube ready to run the first real jobbot3000 staging rollout at `staging.jobbot3000.tech` using an immutable image tag while preserving the existing generic `just app-*` deployment contract. 
- Ensure the initial staging candidate is explicit and verifiable (`main-b3e6df1a4f68`) and that production promotion remains blocked until manual approval. 
- Add guardrails and tests to prevent mutable tags, secrets, PVCs, or server-side persistence from being introduced in the committed examples or runbook.

### Description
- Updated the staging values file `docs/examples/jobbot3000.values.staging.yaml` to use the real host `staging.jobbot3000.tech` and TLS host list entries. 
- Expanded the runbook `docs/apps/jobbot3000.md` to include a concrete first-staging path that uses the immutable tag `main-b3e6df1a4f68`, documents the Cloudflare Tunnel target `http://traefik.kube-system.svc.cluster.local:80`, preserves the generic `just` command surface, blocks automatic production promotion, and adds focused staging troubleshooting commands. 
- Added and extended tests in `tests/test_generic_app_just_recipes.py` to assert rejection of mutable tags (`latest`, `main-latest`), that `env=staging` resolves the committed staging host `staging.jobbot3000.tech`, that the runbook contains the concrete first-deploy commands and explicit production-block language, and that no Secrets/PVC/persistence are present in the example values. 
- Files changed: `docs/examples/jobbot3000.values.staging.yaml`, `docs/apps/jobbot3000.md`, and `tests/test_generic_app_just_recipes.py`; the change keeps all other app config behavior and the `just app-*` recipes unchanged so operators can run the documented commands after merge: `just app-config app=jobbot3000 env=staging`, `just app-chart-status app=jobbot3000`, `just app-deploy app=jobbot3000 env=staging tag=main-b3e6df1a4f68`, `just app-status app=jobbot3000 env=staging`, and `just app-verify app=jobbot3000 env=staging`.

### Testing
- Ran the full test suite with `python -m pytest -q`, which completed successfully with `1426 passed, 19 skipped`. 
- Ran the focused generic app tests in `tests/test_generic_app_just_recipes.py` and the newly added assertions, all of which passed (`121` tests in that file as observed and the selected three tests passed). 
- Verified `just app-config app=jobbot3000 env=staging` succeeded in this environment and validated the GHCR image tag and chart version via direct registry API calls because `helm` was not available here, so `just app-chart-status` could not run locally due to missing `helm`. 
- Performed a secrets scan via `git diff --cached | ./scripts/scan-secrets.py` which passed, and noted that `pre-commit`, `pyspelling`, and `linkchecker` were not available in this execution environment so those hooks were not run here (they should be invoked by CI or an operator locally).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4855269494832fb88a05e4b137428c)