### PR TITLE
Prepare jobbot3000 staging deploy: real staging host and verified immutable tag

### DIFF
--- a/docs/apps/jobbot3000.md
+++ b/docs/apps/jobbot3000.md
@@ -53,14 +53,14 @@ Do not bake real user data into Docker images, Helm charts, Helm values, Kuberne
 ## Environment topology
 
 - `env=dev`: base values in `docs/examples/jobbot3000.values.dev.yaml`; ingress disabled by default and image tag shown as the immutable placeholder `main-REPLACE_SHORTSHA`.
-- `env=staging`: values chain `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml`; placeholder host `staging.jobbot3000.example.test`.
+- `env=staging`: values chain `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml`; real first-rollout host `staging.jobbot3000.tech`.
 - `env=prod`: values chain `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.prod.yaml`; placeholder host `jobbot3000.example.test`.
 
-Replace placeholder hosts in a local operator config or overlay before using a real cluster. Keep Cloudflare DNS and Tunnel routing outside Helm.
+The committed staging overlay follows the existing Sugarkube pattern used by the other onboarded apps and contains the real staging hostname. Production remains placeholder-only until explicitly approved. Keep Cloudflare DNS and Tunnel routing outside Helm.
 
 ## Find or publish GHCR image
 
-Find the successful image workflow in the jobbot3000 app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, `main-latest`, a bare branch name, or an environment name.
+Find the successful image workflow in the jobbot3000 app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, `main-latest`, a bare branch name, or an environment name. The initial staging candidate `main-b3e6df1a4f68` was verified as a published GHCR image tag when this runbook was updated.
 
 Web UI shortcuts:
 
@@ -69,7 +69,7 @@ Web UI shortcuts:
 - Copy the immutable tag from a successful workflow summary or package version.
 
 ```bash
-APP_TAG=main-REPLACE_SHORTSHA
+APP_TAG=main-b3e6df1a4f68
 ```
 
 ## Confirm/publish OCI chart
@@ -85,7 +85,7 @@ CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/jobbot3000.ve
 helm show chart oci://ghcr.io/futuroptimist/charts/jobbot3000 --version "$CHART_VERSION"
 ```
 
-If registry validation was unavailable when this runbook was last edited, operators should run one of the commands above before the first deploy. If the app repo publishes a new chart, bump the Sugarkube pin explicitly:
+This runbook was updated after confirming `0.1.0` is published at GHCR. If the app repo publishes a new chart, bump the Sugarkube pin explicitly:
 
 ```bash
 just app-chart-bump app=jobbot3000 version=0.1.1
@@ -93,8 +93,18 @@ just app-chart-bump app=jobbot3000 version=0.1.1
 
 ## Deploy and verify staging
 
+Before the first deployment, confirm the Cloudflare Tunnel public hostname route exists for `staging.jobbot3000.tech` with path `*` and service target `http://traefik.kube-system.svc.cluster.local:80`. Then use the generic Sugarkube app deployment surface with the verified immutable initial image candidate `main-b3e6df1a4f68`:
+
 ```bash
-just app-deploy app=jobbot3000 env=staging tag=main-REPLACE_SHORTSHA
+just app-chart-status app=jobbot3000
+```
+
+```bash
+just app-config app=jobbot3000 env=staging
+```
+
+```bash
+just app-deploy app=jobbot3000 env=staging tag=main-b3e6df1a4f68
 ```
 
 ```bash
@@ -111,18 +121,66 @@ Print the generated checks without executing them:
 just app-verify app=jobbot3000 env=staging print_only=1
 ```
 
+## Staging troubleshooting
+
+Use these read-only checks when staging fails before changing Helm values or application artifacts. Do not paste Cloudflare API tokens, GitHub PATs, cert-manager issuer tokens, private tracker exports, or browser backups into this repository.
+
+DNS and Cloudflare Tunnel routing:
+
+```bash
+dig +short staging.jobbot3000.tech
+```
+
+```bash
+kubectl -n cloudflare get pods,deploy,secret
+```
+
+```bash
+kubectl -n cloudflare logs deploy/cloudflared --tail=200
+```
+
+Ingress and Traefik:
+
+```bash
+kubectl -n jobbot3000 get ingress,svc,endpoints,pods -o wide
+```
+
+```bash
+kubectl -n kube-system logs deploy/traefik --tail=200
+```
+
+GHCR image or chart pull failures:
+
+```bash
+helm show chart oci://ghcr.io/futuroptimist/charts/jobbot3000 --version "$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/jobbot3000.version | head -n 1)"
+```
+
+```bash
+kubectl -n jobbot3000 describe pods
+```
+
+cert-manager and TLS issuance:
+
+```bash
+kubectl -n jobbot3000 get certificate,certificaterequest,order,challenge
+```
+
+```bash
+kubectl -n cert-manager logs deploy/cert-manager --tail=200
+```
+
 ## Redeploy, promote, and rollback
 
 Redeploy staging or production with a specific immutable tag:
 
 ```bash
-just app-redeploy app=jobbot3000 env=staging tag=main-REPLACE_SHORTSHA
+just app-redeploy app=jobbot3000 env=staging tag=main-b3e6df1a4f68
 ```
 
-Promote production only after staging sign-off, using the exact immutable image tag that passed staging:
+Production promotion is blocked for the first staging rollout. Leave `docs/apps/jobbot3000.prod.tag` empty and do not run production promotion until `staging.jobbot3000.tech` has been verified and an explicit production approval records the immutable tag to promote. After approval, promote production using the exact immutable image tag that passed staging:
 
 ```bash
-just app-promote-prod app=jobbot3000 tag=main-REPLACE_SHORTSHA
+just app-promote-prod app=jobbot3000 tag=<approved-immutable-tag>
 ```
 
 Rollback by redeploying the previous known-good immutable image tag:

--- a/docs/examples/jobbot3000.values.staging.yaml
+++ b/docs/examples/jobbot3000.values.staging.yaml
@@ -4,10 +4,10 @@ environment: staging
 ingress:
   enabled: true
   className: traefik
-  host: staging.jobbot3000.example.test
+  host: staging.jobbot3000.tech
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
   tls:
     - secretName: jobbot3000-staging-tls
       hosts:
-        - staging.jobbot3000.example.test
+        - staging.jobbot3000.tech

--- a/scripts/app_config.py
+++ b/scripts/app_config.py
@@ -185,6 +185,9 @@ def load_config(app: str, env: str, explicit: str | None = None) -> dict[str, st
     resolved["SUGARKUBE_VALUES"] = values
     resolved["SUGARKUBE_CONFIG_PATH"] = str(config_path)
     resolved.setdefault("SUGARKUBE_STATUS_HOST_KEY", "ingress.host")
+    host = resolve_values_host(repo_root, values, resolved["SUGARKUBE_STATUS_HOST_KEY"])
+    if host:
+        resolved["SUGARKUBE_HOST"] = host
     resolved.setdefault("SUGARKUBE_VERIFY_PATHS", "/")
     resolved.setdefault("SUGARKUBE_CORS_VERIFY_PATH", "/")
     resolved.setdefault("SUGARKUBE_CORS_VERIFY_METHOD", "POST")
@@ -192,6 +195,55 @@ def load_config(app: str, env: str, explicit: str | None = None) -> dict[str, st
     resolved.setdefault("SUGARKUBE_CORS_VERIFY_BODY", "{}")
     resolved.setdefault("SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES", "400,429")
     return resolved
+
+
+def resolve_values_host(repo_root: Path, values: str, host_key: str) -> str:
+    """Resolve a simple dotted scalar host from the layered values files."""
+
+    host = ""
+    for raw_path in values.split(","):
+        raw_path = raw_path.strip()
+        if not raw_path:
+            continue
+        path = Path(raw_path)
+        if not path.is_absolute():
+            path = repo_root / path
+        if path.is_file():
+            host = parse_dotted_yaml_scalar(path, host_key) or host
+    return host
+
+
+def parse_dotted_yaml_scalar(path: Path, dotted_key: str) -> str:
+    """Parse the repo's simple example values YAML enough to read dotted scalars.
+
+    This intentionally avoids adding a runtime dependency on PyYAML for the
+    generic app config path. It supports the plain nested mappings used by
+    docs/examples/*.values.*.yaml and ignores lists/comments.
+    """
+
+    parts = dotted_key.split(".")
+    stack: list[tuple[int, str]] = []
+    values: dict[tuple[str, ...], str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        if raw_line.startswith("-") or raw_line.lstrip().startswith("-"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        line = raw_line.strip()
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.split("#", 1)[0].strip().strip("'\"")
+        while stack and stack[-1][0] >= indent:
+            stack.pop()
+        current = tuple([item for _, item in stack] + [key])
+        if value:
+            values[current] = value
+        else:
+            stack.append((indent, key))
+    return values.get(tuple(parts), "")
 
 
 def resolve_tag(config: dict[str, str], raw_tag: str, *, prod_fallback: bool) -> str:
@@ -223,6 +275,7 @@ def shell_emit(config: dict[str, str]) -> str:
         "SUGARKUBE_VERSION_FILE",
         "SUGARKUBE_PROD_TAG_FILE",
         "SUGARKUBE_STATUS_HOST_KEY",
+        "SUGARKUBE_HOST",
         "SUGARKUBE_VERIFY_PATHS",
         "SUGARKUBE_DEBUG_SELECTOR",
         "SUGARKUBE_CORS_VERIFY_PATH",

--- a/scripts/app_verify.py
+++ b/scripts/app_verify.py
@@ -212,6 +212,8 @@ def main(argv: list[str] | None = None) -> int:
     print_only = args.print_only or env_flag("SUGARKUBE_APP_VERIFY_PRINT_ONLY")
 
     host, errors = discover_host(kube_context)
+    if not host:
+        host = os.environ.get("SUGARKUBE_HOST", "")
     base_url = base_url_from_host(host)
     if not base_url:
         print_placeholder_failure(app, env, kube_context, paths, errors)

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1554,6 +1554,31 @@ def test_jobbot3000_example_config_resolves_all_env_values() -> None:
         assert result.returncode == 0, result.stderr
         assert '"SUGARKUBE_CHART": "oci://ghcr.io/futuroptimist/charts/jobbot3000"' in result.stdout
         assert f'"SUGARKUBE_VALUES": "{values}"' in result.stdout
+        if env == "staging":
+            assert '"SUGARKUBE_HOST": "staging.jobbot3000.tech"' in result.stdout
+
+
+def test_jobbot3000_staging_overlay_uses_real_first_rollout_host() -> None:
+    staging = (REPO_ROOT / "docs/examples/jobbot3000.values.staging.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "host: staging.jobbot3000.tech" in staging
+    assert "- staging.jobbot3000.tech" in staging
+    assert "staging.jobbot3000.example.test" not in staging
+
+
+def test_jobbot3000_runbook_documents_copy_paste_ready_staging_deploy() -> None:
+    runbook = (REPO_ROOT / "docs/apps/jobbot3000.md").read_text(encoding="utf-8")
+
+    assert "staging.jobbot3000.tech" in runbook
+    assert "http://traefik.kube-system.svc.cluster.local:80" in runbook
+    assert "just app-chart-status app=jobbot3000" in runbook
+    assert "just app-config app=jobbot3000 env=staging" in runbook
+    assert "just app-deploy app=jobbot3000 env=staging tag=main-b3e6df1a4f68" in runbook
+    assert "just app-status app=jobbot3000 env=staging" in runbook
+    assert "just app-verify app=jobbot3000 env=staging" in runbook
+    assert "Production promotion is blocked" in runbook
 
 
 def test_jobbot3000_values_are_static_only_and_use_immutable_image_example() -> None:
@@ -1569,6 +1594,8 @@ def test_jobbot3000_values_are_static_only_and_use_immutable_image_example() -> 
     assert "tag: main-REPLACE_SHORTSHA" in dev_values
     assert "tag: latest" not in dev_values
     assert "tag: main-latest" not in dev_values
+    assert "tag: latest" not in combined
+    assert "tag: main-latest" not in combined
     assert "containerPort: 8080" in dev_values
     assert "port: 80" in dev_values
     assert "persistentVolumeClaim" not in combined


### PR DESCRIPTION
### Motivation

- Make Sugarkube ready for the first real jobbot3000 staging rollout at `staging.jobbot3000.tech` using a verified immutable image candidate and the existing generic app deploy surface. 
- Preserve the repository's example/placeholder boundaries and explicitly block production promotion until staging is verified. 

### Description

- Update the committed staging overlay to use the real host `staging.jobbot3000.tech` and include TLS host entries in `docs/examples/jobbot3000.values.staging.yaml`.
- Revise the runbook `docs/apps/jobbot3000.md` to document the Cloudflare Tunnel route target `http://traefik.kube-system.svc.cluster.local:80`, reference the verified initial immutable image tag `main-b3e6df1a4f68`, and provide copy-paste `just app-*` deploy/verify commands.
- Extend `scripts/app_config.py` to resolve a `SUGARKUBE_HOST` from layered values files (simple YAML scalar parsing without adding PyYAML) and export it via the existing `app-config` shell output.
- Make `scripts/app_verify.py` fall back to `SUGARKUBE_HOST` when cluster-based discovery cannot derive a host, and add/adjust tests in `tests/test_generic_app_just_recipes.py` to cover staging host resolution, runbook commands, verify paths, immutable-tag examples, and that example values remain static-only and contain no Secrets/PVCs.
- Files changed: `docs/apps/jobbot3000.md`, `docs/examples/jobbot3000.values.staging.yaml`, `scripts/app_config.py`, `scripts/app_verify.py`, `tests/test_generic_app_just_recipes.py`.
- Exact deploy commands to run after merge: `just app-chart-status app=jobbot3000`, `just app-config app=jobbot3000 env=staging`, `just app-deploy app=jobbot3000 env=staging tag=main-b3e6df1a4f68`, `just app-status app=jobbot3000 env=staging`, `just app-verify app=jobbot3000 env=staging`.

### Testing

- Ran the full test suite with `python -m pytest -q` which completed successfully (`1425 passed, 19 skipped` with warnings) and ran the focused module tests `tests/test_app_config.py` and `tests/test_generic_app_just_recipes.py` which also passed (`155` and targeted subsets shown as passing).
- Executed `just app-config app=jobbot3000 env=staging` which emits `SUGARKUBE_HOST` and `just app-verify app=jobbot3000 env=staging print_only=1` which produced the expected `curl` commands for `/`, `/healthz`, and `/livez`, both succeeding in this environment.
- Verified GHCR manifests for `futuroptimist/jobbot3000:main-b3e6df1a4f68` and `futuroptimist/charts/jobbot3000:0.1.0` via direct registry requests which returned HTTP 200 responses.
- Ran the repository secret scan `git diff --cached | ./scripts/scan-secrets.py` and it reported no secrets in the staged changes; note that `pre-commit`, `pyspelling`, and `linkchecker` were unavailable in this environment and `just app-chart-status` could not run locally because `helm` is not installed, while `bash scripts/checks.sh` surfaced pre-existing lint warnings unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4855329d34832f9dd372d9f5ad0056)