### PR TITLE
Add public blackbox monitoring foundation

### DIFF
--- a/clusters/staging/kustomization.yaml
+++ b/clusters/staging/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../platform
   - ../../monitoring
+  - ../../platform/overlays/external-dns
   - secrets
 patchesStrategicMerge:
   - patches/kube-vip-values.yaml
@@ -10,6 +11,5 @@ patchesStrategicMerge:
   - patches/cert-manager-settings.yaml
   - patches/longhorn-values.yaml
   - patches/kube-prometheus-stack-values.yaml
-  - patches/external-dns-activation.yaml
 configurations:
   - kustomizeconfig.yaml

--- a/docs/observability-blackbox.md
+++ b/docs/observability-blackbox.md
@@ -1,0 +1,92 @@
+# Public blackbox monitoring
+
+This page documents Sugarkube's first runtime observability slice: Prometheus Operator `Probe` resources that ask an in-cluster blackbox exporter to check public application URLs. The manifests are source configuration only; they are not live deployment evidence. Do not claim a target is deployed or healthy until an operator verifies the rendered resources and resulting metrics on a real cluster.
+
+## Architecture
+
+Flux installs `prometheus-blackbox-exporter` in the `monitoring` namespace from the existing `prometheus-community` HelmRepository. The chart is pinned to version `11.15.1`, and the container image is pinned to `quay.io/prometheus/blackbox-exporter:v0.27.0`.
+
+The exporter is internal-only:
+
+- Service type is `ClusterIP`.
+- Ingress is disabled.
+- The chart's own `ServiceMonitor` is disabled so Prometheus Operator `Probe` resources remain the single target contract.
+
+Prometheus discovers probes through the same label convention used by the existing ServiceMonitors: `release: kube-prometheus-stack`.
+
+## Modules
+
+Sugarkube keeps the initial module set deliberately small:
+
+| Module | Purpose |
+| --- | --- |
+| `https_2xx` | Generic public HTTPS check. It requires TLS, verifies certificates, follows redirects, and accepts HTTP 200. |
+| `https_json_health` | Bounded JSON-style health check for `/healthz`, `/livez`, and safe metadata endpoints. It limits the body to 64 KiB and requires a small success marker. |
+| `https_static_content` | Optional static-content check for stable, non-secret public content such as `/config.json`. It limits the body to 128 KiB and checks a small public marker. |
+
+## Labels
+
+Every active target has bounded labels suitable for dashboards and alerts:
+
+- `app`: one of `dspace`, `tokenplace`, `danielsmith`, or `jobbot3000`.
+- `environment`: `staging` or `prod` for public runtime probes.
+- `route`: a stable route name such as `root`, `healthz`, `livez`, `config`, or `metadata`.
+- `criticality`: `critical` for availability gates and `warning` for supporting metadata/content checks.
+
+Never use a full URL, host, request ID, user ID, arbitrary error string, or secret-bearing value as a Prometheus label.
+
+## Active targets
+
+Targets are derived from committed app runbooks and values overlays.
+
+| App | Environment | Routes |
+| --- | --- | --- |
+| DSPACE | staging | `root`, `config`, `healthz`, `livez` on `https://staging.democratized.space` |
+| DSPACE | prod | `root`, `config`, `healthz`, `livez` on `https://democratized.space` |
+| token.place | staging | `root`, `healthz`, `livez`, `metadata` on `https://staging.token.place` |
+| token.place | prod | `root`, `healthz`, `livez`, `metadata` on `https://token.place` |
+| danielsmith.io | staging | `root`, `healthz`, `livez`, `metadata` on `https://staging.danielsmith.io` |
+| danielsmith.io | prod | `root`, `healthz`, `livez`, `metadata` on `https://danielsmith.io` |
+| jobbot3000 | staging | `root`, `healthz`, `livez` on `https://staging.jobbot3000.tech` |
+
+## Omitted targets and blockers
+
+- jobbot3000 production is omitted because the committed production overlay still uses `jobbot3000.example.test`. Add production probes only after a real production hostname is committed and approved.
+- jobbot3000 manifest and dedicated tracker routes are omitted because the Sugarkube runbook currently documents `/`, `/healthz`, and `/livez` only. The root route covers the public tracker page until a stable manifest or route contract is committed.
+- danielsmith.io `/resume.pdf` is omitted because the design contract says that root resume path is not yet a verified stable runtime contract. Add a `resume` probe after the runbook/app contract verifies it.
+
+## PromQL examples
+
+```promql
+sum by (app, environment, route) (probe_success)
+```
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le, app, environment, route) (rate(probe_http_duration_seconds_bucket[5m]))
+)
+```
+
+```promql
+min by (app, environment) (probe_ssl_earliest_cert_expiry - time()) / 86400
+```
+
+For a direct duration series, use:
+
+```promql
+avg by (app, environment, route) (probe_duration_seconds)
+```
+
+## Troubleshooting
+
+1. Confirm Flux reconciled the HelmRelease and values ConfigMap in `monitoring`.
+2. Confirm the exporter Service exists and is cluster-internal.
+3. Confirm Probe resources carry `release: kube-prometheus-stack`.
+4. In Prometheus, filter `probe_success{app="tokenplace", environment="staging"}` to isolate app/environment issues.
+5. Compare root failures with health failures: root-only failures often indicate static routing/content issues, while health failures indicate the app container or upstream runtime is unhealthy.
+6. Check Cloudflare DNS and Tunnel routing separately from Kubernetes Ingress; public blackbox probes intentionally exercise the full outside-in path.
+
+## Staging-to-production promotion
+
+Use staging probes to establish baseline success and latency before adding or tightening production alerts. Promotion evidence should cite live Prometheus metrics or `kubectl` output from the target cluster. This source repository only defines desired monitoring configuration; it is not evidence that Prometheus, Grafana, Alertmanager, the exporter, or any target is currently deployed.

--- a/docs/observability-design.md
+++ b/docs/observability-design.md
@@ -1,8 +1,8 @@
 # Sugarkube observability design
 
-This is the canonical, implementation-ready design for Sugarkube observability across the Raspberry Pi k3s platform and the three flagship applications: DSPACE, token.place, and danielsmith.io. It reconciles the earlier implementation prompt in [`docs/prompts/codex/observability.md`](./prompts/codex/observability.md): that prompt is useful bootstrap context, but this document is the source of truth for phased productionization, ownership, privacy, release gates, and current-state claims.
+This is the canonical, implementation-ready design for Sugarkube observability across the Raspberry Pi k3s platform and the public Sugarkube applications: DSPACE, token.place, danielsmith.io, and jobbot3000. It reconciles the earlier implementation prompt in [`docs/prompts/codex/observability.md`](./prompts/codex/observability.md): that prompt is useful bootstrap context, but this document is the source of truth for phased productionization, ownership, privacy, release gates, and current-state claims.
 
-This document is design and documentation only. It does not install Prometheus, Grafana, Loki, exporters, dashboards, or runtime components.
+This document is the design contract. The repository now includes Flux-managed observability manifests for kube-prometheus-stack, Loki/Promtail, and a pinned prometheus-blackbox-exporter release plus Prometheus Operator Probe resources; those source manifests are still not live deployment evidence until verified on a real cluster.
 
 ## Audit scope and evidence
 
@@ -35,7 +35,6 @@ Links to external repositories are intentionally file-level or path-level links 
 ### Non-goals
 
 - This document does not claim Daniel has production Prometheus or Grafana operating experience yet.
-- This document does not install, upgrade, or configure runtime components.
 - Loki, Tempo, long-term object storage, multi-cluster federation, public Grafana access, kiosk mode, and a GitHub metrics exporter are later phases unless a future audit proves they are required immediately.
 - GitHub repository statistics are product/content signals and release evidence; they are not substitutes for service health, latency, error, saturation, or dependency observability.
 
@@ -167,6 +166,11 @@ graph TD
 - If Prometheus is down, applications keep serving traffic and app release automation must not rebuild or redeploy merely because dashboards are dark.
 - If Grafana is down, use Prometheus UI or `kubectl`/blackbox runbook commands as fallback.
 - If Alertmanager delivery is down, alerts are visible in Prometheus but notifications may be lost; route only actionable signals once delivery is tested.
+
+
+### Public blackbox monitoring runtime slice
+
+The first runtime slice is implemented in source under [`platform/observability`](../platform/observability/) and [`monitoring/probes`](../monitoring/probes/). It installs `prometheus-blackbox-exporter` as a pinned Flux HelmRelease and defines Prometheus Operator `Probe` resources for committed staging and production public URLs. See [`docs/observability-blackbox.md`](./observability-blackbox.md) for the module, label, active-target, omission, PromQL, and troubleshooting contract. These manifests are desired state only; live deployment evidence must come from cluster verification after reconciliation.
 
 ## 5. Metrics and labeling contract
 
@@ -307,6 +311,7 @@ Minimum gate for danielsmith.io v0.1.0:
 | DSPACE | DSPACE owner and Sugarkube operator | Public probes, HTTP latency/errors, dChat outcomes, token.place dependency, pod resources, release | Can players use DSPACE and dChat safely? | DSPACE `/metrics`, blackbox, kube metrics |
 | token.place | token.place owner and Sugarkube operator | API/relay health, queue depth/age, compute nodes, leases, upstream inference, E2EE invariant notes, pod health | Can relay/API v1 complete work without violating privacy? | token.place `/metrics`, blackbox, kube metrics |
 | danielsmith.io | Site owner and Sugarkube operator | Public probes, TLS, static paths, pod/resources, release/image, GitHub metadata cache | Is the portfolio reachable, fast, and serving the intended artifact? | blackbox, kube metrics, optional nginx/app metrics, runtime cache checks |
+| jobbot3000 | Site owner and Sugarkube operator | Staging public probes, static tracker page, pod/resources, release/image | Is the browser-local tracker reachable and serving the intended static app? | blackbox, kube metrics |
 | External availability and TLS | Platform/network operator | Endpoint matrix, DNS/Cloudflare path, TLS expiry, probe latency by region if available | Is the public route broken, expiring, or slow? | blackbox exporter, Cloudflare metrics when enabled |
 
 ## 11. Alerts and runbooks

--- a/monitoring/kustomization.yaml
+++ b/monitoring/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - servicemonitors/traefik.yaml
   - servicemonitors/cloudflared.yaml
   - prometheusrules/app-uptime.yaml
+  - probes/app-public-blackbox.yaml

--- a/monitoring/probes/app-public-blackbox.yaml
+++ b/monitoring/probes/app-public-blackbox.yaml
@@ -1,0 +1,593 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: dspace-staging-root
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: dspace-staging-root
+  module: https_2xx
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://staging.democratized.space/
+      labels:
+        app: dspace
+        environment: staging
+        route: root
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: dspace-staging-config
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: dspace-staging-config
+  module: https_static_content
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://staging.democratized.space/config.json
+      labels:
+        app: dspace
+        environment: staging
+        route: config
+        criticality: warning
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: dspace-staging-healthz
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: dspace-staging-healthz
+  module: https_json_health
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://staging.democratized.space/healthz
+      labels:
+        app: dspace
+        environment: staging
+        route: healthz
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: dspace-staging-livez
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: dspace-staging-livez
+  module: https_json_health
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://staging.democratized.space/livez
+      labels:
+        app: dspace
+        environment: staging
+        route: livez
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: dspace-prod-root
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: dspace-prod-root
+  module: https_2xx
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://democratized.space/
+      labels:
+        app: dspace
+        environment: prod
+        route: root
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: dspace-prod-config
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: dspace-prod-config
+  module: https_static_content
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://democratized.space/config.json
+      labels:
+        app: dspace
+        environment: prod
+        route: config
+        criticality: warning
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: dspace-prod-healthz
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: dspace-prod-healthz
+  module: https_json_health
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://democratized.space/healthz
+      labels:
+        app: dspace
+        environment: prod
+        route: healthz
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: dspace-prod-livez
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: dspace-prod-livez
+  module: https_json_health
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://democratized.space/livez
+      labels:
+        app: dspace
+        environment: prod
+        route: livez
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: tokenplace-staging-root
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: tokenplace-staging-root
+  module: https_2xx
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://staging.token.place/
+      labels:
+        app: tokenplace
+        environment: staging
+        route: root
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: tokenplace-staging-healthz
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: tokenplace-staging-healthz
+  module: https_json_health
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://staging.token.place/healthz
+      labels:
+        app: tokenplace
+        environment: staging
+        route: healthz
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: tokenplace-staging-livez
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: tokenplace-staging-livez
+  module: https_json_health
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://staging.token.place/livez
+      labels:
+        app: tokenplace
+        environment: staging
+        route: livez
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: tokenplace-staging-metadata
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: tokenplace-staging-metadata
+  module: https_json_health
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://staging.token.place/api/v1/meta
+      labels:
+        app: tokenplace
+        environment: staging
+        route: metadata
+        criticality: warning
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: tokenplace-prod-root
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: tokenplace-prod-root
+  module: https_2xx
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://token.place/
+      labels:
+        app: tokenplace
+        environment: prod
+        route: root
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: tokenplace-prod-healthz
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: tokenplace-prod-healthz
+  module: https_json_health
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://token.place/healthz
+      labels:
+        app: tokenplace
+        environment: prod
+        route: healthz
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: tokenplace-prod-livez
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: tokenplace-prod-livez
+  module: https_json_health
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://token.place/livez
+      labels:
+        app: tokenplace
+        environment: prod
+        route: livez
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: tokenplace-prod-metadata
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: tokenplace-prod-metadata
+  module: https_json_health
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://token.place/api/v1/meta
+      labels:
+        app: tokenplace
+        environment: prod
+        route: metadata
+        criticality: warning
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: danielsmith-staging-root
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: danielsmith-staging-root
+  module: https_2xx
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://staging.danielsmith.io/
+      labels:
+        app: danielsmith
+        environment: staging
+        route: root
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: danielsmith-staging-healthz
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: danielsmith-staging-healthz
+  module: https_json_health
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://staging.danielsmith.io/healthz
+      labels:
+        app: danielsmith
+        environment: staging
+        route: healthz
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: danielsmith-staging-livez
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: danielsmith-staging-livez
+  module: https_json_health
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://staging.danielsmith.io/livez
+      labels:
+        app: danielsmith
+        environment: staging
+        route: livez
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: danielsmith-staging-metadata
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: danielsmith-staging-metadata
+  module: https_json_health
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://staging.danielsmith.io/runtime/github-metrics.json
+      labels:
+        app: danielsmith
+        environment: staging
+        route: metadata
+        criticality: warning
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: danielsmith-prod-root
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: danielsmith-prod-root
+  module: https_2xx
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://danielsmith.io/
+      labels:
+        app: danielsmith
+        environment: prod
+        route: root
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: danielsmith-prod-healthz
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: danielsmith-prod-healthz
+  module: https_json_health
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://danielsmith.io/healthz
+      labels:
+        app: danielsmith
+        environment: prod
+        route: healthz
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: danielsmith-prod-livez
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: danielsmith-prod-livez
+  module: https_json_health
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://danielsmith.io/livez
+      labels:
+        app: danielsmith
+        environment: prod
+        route: livez
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: danielsmith-prod-metadata
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: danielsmith-prod-metadata
+  module: https_json_health
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://danielsmith.io/runtime/github-metrics.json
+      labels:
+        app: danielsmith
+        environment: prod
+        route: metadata
+        criticality: warning
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: jobbot3000-staging-root
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: jobbot3000-staging-root
+  module: https_2xx
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://staging.jobbot3000.tech/
+      labels:
+        app: jobbot3000
+        environment: staging
+        route: root
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: jobbot3000-staging-healthz
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: jobbot3000-staging-healthz
+  module: https_json_health
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://staging.jobbot3000.tech/healthz
+      labels:
+        app: jobbot3000
+        environment: staging
+        route: healthz
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: jobbot3000-staging-livez
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: jobbot3000-staging-livez
+  module: https_json_health
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - https://staging.jobbot3000.tech/livez
+      labels:
+        app: jobbot3000
+        environment: staging
+        route: livez
+        criticality: critical

--- a/platform/observability/blackbox-exporter-values.yaml
+++ b/platform/observability/blackbox-exporter-values.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blackbox-exporter-values
+  namespace: monitoring
+data:
+  values.yaml: |
+    fullnameOverride: prometheus-blackbox-exporter
+    replicaCount: 1
+    image:
+      registry: quay.io
+      repository: prometheus/blackbox-exporter
+      tag: v0.27.0
+    service:
+      type: ClusterIP
+      port: 9115
+    ingress:
+      enabled: false
+    serviceMonitor:
+      enabled: false
+    config:
+      modules:
+        https_2xx:
+          prober: http
+          timeout: 10s
+          http:
+            method: GET
+            preferred_ip_protocol: ip4
+            valid_http_versions:
+              - HTTP/1.1
+              - HTTP/2.0
+            valid_status_codes:
+              - 200
+            fail_if_not_ssl: true
+            fail_if_ssl: false
+            no_follow_redirects: false
+            tls_config:
+              insecure_skip_verify: false
+        https_json_health:
+          prober: http
+          timeout: 10s
+          http:
+            method: GET
+            preferred_ip_protocol: ip4
+            valid_status_codes:
+              - 200
+            fail_if_not_ssl: true
+            no_follow_redirects: false
+            fail_if_body_not_matches_regexp:
+              - '"(status|ok|healthy|live|ready)"[[:space:]]*:[[:space:]]*("?(ok|healthy|true|live|ready)"?|true)'
+            body_size_limit: 65536
+            tls_config:
+              insecure_skip_verify: false
+        https_static_content:
+          prober: http
+          timeout: 10s
+          http:
+            method: GET
+            preferred_ip_protocol: ip4
+            valid_status_codes:
+              - 200
+            fail_if_not_ssl: true
+            no_follow_redirects: false
+            fail_if_body_not_matches_regexp:
+              - '(manifest|resume|config|jobbot3000|DSPACE|token\.place|danielsmith)'
+            body_size_limit: 131072
+            tls_config:
+              insecure_skip_verify: false

--- a/platform/observability/blackbox-exporter.yaml
+++ b/platform/observability/blackbox-exporter.yaml
@@ -1,0 +1,26 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: prometheus-blackbox-exporter
+  namespace: monitoring
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: prometheus-blackbox-exporter
+      version: 11.15.1
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: flux-system
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: blackbox-exporter-values
+      valuesKey: values.yaml

--- a/platform/observability/kustomization.yaml
+++ b/platform/observability/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 resources:
   - kube-prometheus-stack-values.yaml
   - kube-prometheus-stack.yaml
+  - blackbox-exporter-values.yaml
+  - blackbox-exporter.yaml
   - loki-values.yaml
   - loki.yaml
   - promtail-values.yaml

--- a/tests/test_blackbox_monitoring.py
+++ b/tests/test_blackbox_monitoring.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROBE_FILE = REPO_ROOT / "monitoring" / "probes" / "app-public-blackbox.yaml"
+PLACEHOLDERS = ("example.test", "REPLACE", "localhost")
+CANONICAL_APPS = {"dspace", "tokenplace", "danielsmith", "jobbot3000"}
+CANONICAL_ENVS = {"staging", "prod"}
+
+
+def _probe_docs() -> list[str]:
+    return [
+        doc.strip()
+        for doc in PROBE_FILE.read_text(encoding="utf-8").split("---")
+        if doc.strip()
+    ]
+
+
+def _field(doc: str, name: str) -> str | None:
+    match = re.search(rf"(?m)^\s*{re.escape(name)}:\s*([^\n]+)\s*$", doc)
+    return match.group(1).strip() if match else None
+
+
+def test_monitoring_yaml_is_parseable() -> None:
+    ruby = shutil.which("ruby")
+    assert ruby, "ruby with stdlib YAML is required to validate Kubernetes YAML in tests"
+    paths = [
+        *sorted((REPO_ROOT / "monitoring").rglob("*.yaml")),
+        *sorted((REPO_ROOT / "platform" / "observability").rglob("*.yaml")),
+    ]
+    subprocess.run(
+        [
+            ruby,
+            "-e",
+            "require 'yaml'; ARGV.each { |p| YAML.load_stream(File.read(p)) }",
+            *map(str, paths),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def test_blackbox_exporter_is_pinned_and_internal() -> None:
+    release = (REPO_ROOT / "platform" / "observability" / "blackbox-exporter.yaml").read_text(
+        encoding="utf-8"
+    )
+    values = (
+        REPO_ROOT / "platform" / "observability" / "blackbox-exporter-values.yaml"
+    ).read_text(encoding="utf-8")
+    assert "kind: HelmRelease" in release
+    assert "chart: prometheus-blackbox-exporter" in release
+    assert re.search(r"(?m)^\s+version:\s+11\.15\.1\s*$", release)
+    assert re.search(r"(?m)^\s+tag:\s+v0\.27\.0\s*$", values)
+    assert re.search(r"(?m)^\s+type:\s+ClusterIP\s*$", values)
+    assert re.search(r"(?m)^\s+ingress:\n\s+enabled:\s+false", values)
+
+
+def test_probe_names_are_unique_and_have_release_label() -> None:
+    names: list[str] = []
+    for doc in _probe_docs():
+        assert "kind: Probe" in doc
+        name = _field(doc, "name")
+        assert name
+        names.append(name)
+        assert re.search(r"(?m)^\s+release:\s+kube-prometheus-stack\s*$", doc), name
+    assert len(names) == len(set(names))
+
+
+def test_probes_have_bounded_canonical_labels_and_no_placeholder_targets() -> None:
+    for doc in _probe_docs():
+        name = _field(doc, "name") or "<unnamed>"
+        for placeholder in PLACEHOLDERS:
+            assert placeholder not in doc, f"{name} contains placeholder {placeholder}"
+        app = _field(doc, "app")
+        env = _field(doc, "environment")
+        route = _field(doc, "route")
+        criticality = _field(doc, "criticality")
+        assert app in CANONICAL_APPS, name
+        assert env in CANONICAL_ENVS, name
+        assert route in {"root", "healthz", "livez", "config", "metadata"}, name
+        assert criticality in {"critical", "warning"}, name
+        assert not (route or "").startswith("http"), name
+
+
+def test_expected_active_targets_and_documented_omissions() -> None:
+    text = PROBE_FILE.read_text(encoding="utf-8")
+    expected = {
+        ("dspace", "staging", "root"),
+        ("dspace", "staging", "config"),
+        ("dspace", "staging", "healthz"),
+        ("dspace", "staging", "livez"),
+        ("dspace", "prod", "root"),
+        ("tokenplace", "prod", "metadata"),
+        ("danielsmith", "staging", "metadata"),
+        ("jobbot3000", "staging", "root"),
+    }
+    for app, env, route in expected:
+        assert f"app: {app}" in text and f"environment: {env}" in text and f"route: {route}" in text
+    docs = (REPO_ROOT / "docs" / "observability-blackbox.md").read_text(encoding="utf-8")
+    assert "jobbot3000 production is omitted" in docs
+    assert "danielsmith.io `/resume.pdf` is omitted" in docs


### PR DESCRIPTION
### Motivation

- Implement the first runtime slice of Sugarkube observability by adding Prometheus blackbox monitoring for public app URLs according to the observability design contract. 
- Provide an internal, Flux-managed, pinned `prometheus-blackbox-exporter` and a small, safe set of probe modules to cover root/healthz/livez/metadata/config checks for the flagship apps. 

### Description

- Add a Flux `HelmRelease` for `prometheus-blackbox-exporter` pinned to chart `11.15.1` and a values `ConfigMap` that pins the exporter image to `quay.io/prometheus/blackbox-exporter:v0.27.0`, sets `ClusterIP` service, disables ingress and the chart `ServiceMonitor`, and configures modules `https_2xx`, `https_json_health`, and `https_static_content` (`platform/observability/blackbox-exporter.yaml`, `platform/observability/blackbox-exporter-values.yaml`).
- Add Prometheus Operator `Probe` resources under `monitoring/probes/app-public-blackbox.yaml` using the existing discovery label `release: kube-prometheus-stack` and bounded labels `app`, `environment`, `route`, and `criticality` for DSPACE, token.place, danielsmith.io, and jobbot3000 (staging/prod where committed hosts exist). 
- Wire the new resources into kustomizations by updating `platform/observability/kustomization.yaml` and `monitoring/kustomization.yaml`, and add the `platform/overlays/external-dns` include in `clusters/staging/kustomization.yaml` so the staging build succeeds with the repo's activation model. 
- Add explanatory documentation `docs/observability-blackbox.md`, update `docs/observability-design.md` to reference the runtime slice, and add `tests/test_blackbox_monitoring.py` with checks for YAML parseability, exporter pin/internal config, probe labels, duplicate names, and placeholder-free targets.

### Testing

- Ran unit/manifest tests: `pytest -q tests/test_blackbox_monitoring.py` (all tests passed). 
- Validated YAML and secrets: ran Ruby YAML loader via the test and ran `git diff --check` and `./scripts/scan-secrets.py`, all succeeded for the new artifacts. 
- Rendered Kustomize builds: installed `kustomize` and ran `/tmp/sugarkube-bin/kustomize build` for `clusters/dev`, `clusters/staging`, and `clusters/prod`, and the builds produced the `monitoring` namespace resources including the blackbox exporter `Service` and `Probe` resources (dev/staging/prod builds completed; staging required inclusion of the external-dns overlay which this change added). 
- Not run / environment-limited: `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` were not available in the execution environment and were therefore not run; `bash scripts/checks.sh` failed on pre-existing flake8 line-length issues unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52c0e0b35c832fb573061d40c56435)