### PR TITLE
Promote danielsmith 0.1.2 to production

### DIFF
--- a/docs/apps/danielsmith.prod.tag
+++ b/docs/apps/danielsmith.prod.tag
@@ -1,1 +1,1 @@
-main-5ca96df16f0f
+main-60ba52185442

--- a/docs/apps/danielsmith.version
+++ b/docs/apps/danielsmith.version
@@ -1,2 +1,2 @@
 # Default danielsmith chart version. Update when new chart releases are published.
-0.2.3
+0.2.4


### PR DESCRIPTION
## Summary

- run the explicit chart-bump workflow for danielsmith chart `0.2.4`
- approve immutable image `main-60ba52185442` for production
- promote the staging-tested danielsmith.io `appVersion: 0.1.2` release

## Promotion sequence

1. `just app-chart-bump app=danielsmith version=0.2.4`
2. commit the resulting `docs/apps/danielsmith.version` pin
3. update `docs/apps/danielsmith.prod.tag` to the staging-tested immutable image
4. after this PR merges, run `just app-promote-prod app=danielsmith tag=main-60ba52185442`
5. verify status and public production paths

The PR commit order preserves that sequence: the chart pin bump precedes the production image approval.

## Promotion evidence

- `just app-chart-bump app=danielsmith version=0.2.4` completed successfully against the published OCI chart
- staging serves `/assets/index-DNQX1fqy.js`
- the `main-60ba52185442` image layer contains the same asset
- published chart `0.2.4` declares `appVersion: 0.1.2`

## Validation

- `44 passed, 86 deselected` in the targeted Danielsmith/chart/promotion test selection
- file-scoped trailing-whitespace and end-of-file hooks pass
- `git diff --check` passes
- staged diff passes `scripts/scan-secrets.py`

The repository-wide pre-commit gate was also attempted. Its existing global YAML checks reject multi-document and Helm-template YAML files, and `run-checks` could not auto-install KiCad in this runner; neither failure involves the two promotion pin files changed here.