### PR TITLE
Guard Helm mutations by Kubernetes cluster identity

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -187,6 +187,17 @@ export SUGARKUBE_APP_CONFIG_DIR=apps
 These recipes are implemented in the root `justfile` and use the app config
 lookup order above.
 
+Environment-scoped mutating recipes (`app-deploy`, `app-redeploy`,
+`app-promote-prod`, and the compatibility deploy/redeploy/promote wrappers) guard
+Helm with the connected cluster's Kubernetes-reported identity. The source of
+truth is the `sugarkube.env` node label assigned during cluster formation, not
+the kubeconfig context name, hostname, or ingress hostname. Every node must have
+a nonempty environment label, all normalized labels must agree, and the detected
+environment must match the requested `env=` before Helm can install, upgrade, or
+roll back a release. Use `just cluster-env-detect` to inspect the current
+read-only identity. `app-chart-bump` remains cluster-independent because it only
+validates a public OCI chart and edits the repository pin.
+
 ```bash
 # Deploy or install a specific immutable candidate into an environment.
 just app-deploy app=dspace env=staging tag=main-REPLACE_SHORTSHA

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -198,7 +198,7 @@ just kubeconfig-env "$ROLLBACK_ENV"
 ```
 
 ```bash
-just tokenplace-rollback release=appslug namespace=appslug revision="$HELM_REVISION"
+just tokenplace-rollback release=appslug namespace=appslug revision="$HELM_REVISION" env="$ROLLBACK_ENV"
 ```
 
 ## First-run smoke check pattern

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -233,7 +233,7 @@ just kubeconfig-env "$ROLLBACK_ENV"
 ```
 
 ```bash
-just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$HELM_REVISION"
+just tokenplace-rollback release=danielsmith namespace=danielsmith revision="$HELM_REVISION" env="$ROLLBACK_ENV"
 ```
 
 ## Troubleshooting

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -292,9 +292,9 @@ just cf-tunnel-route host=democratized.space
 The generic app commands above should be the normal operator path. Keep these lower-level helpers available for compatibility with existing tests and older runbooks when debugging raw Helm parameters.
 
 ```bash
-just helm-oci-install release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.version tag="$APP_TAG"
+just helm-oci-install release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.version tag="$APP_TAG" env=staging
 ```
 
 ```bash
-just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.version tag="$APP_TAG"
+just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.version tag="$APP_TAG" env=staging
 ```

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -239,7 +239,7 @@ just kubeconfig-env "$ROLLBACK_ENV"
 ```
 
 ```bash
-just tokenplace-rollback release=dspace namespace=dspace revision="$HELM_REVISION"
+just tokenplace-rollback release=dspace namespace=dspace revision="$HELM_REVISION" env="$ROLLBACK_ENV"
 ```
 
 ## Troubleshooting

--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -96,7 +96,7 @@ Rollback to previous Helm revision:
 ```bash
 just kubeconfig-env prod
 TOKENPLACE_REVISION=12 # replace with the known-good Helm revision
-just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION"
+just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$TOKENPLACE_REVISION" env=prod
 ```
 
 Production validation:

--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -37,7 +37,7 @@ First install:
 ```bash
 just kubeconfig-env staging
 TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+just helm-oci-install release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG" env=staging
 ```
 
 Existing release upgrade:
@@ -45,7 +45,7 @@ Existing release upgrade:
 ```bash
 just kubeconfig-env staging
 TOKENPLACE_TAG=main-deadbee # replace with the immutable tag you want to deploy
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG" env=staging
 ```
 
 Preferred wrapper:
@@ -80,7 +80,7 @@ Generic production upgrade with prod overlay:
 ```bash
 just kubeconfig-env prod
 TOKENPLACE_TAG=v0.1.0 # use final release tag after token.place Git tag push
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG"
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG" env=prod
 ```
 
 Rollback using previous immutable tag:
@@ -88,7 +88,7 @@ Rollback using previous immutable tag:
 ```bash
 just kubeconfig-env prod
 TOKENPLACE_PREVIOUS_TAG=main-deadbee # replace with the prior immutable tag
-just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_PREVIOUS_TAG"
+just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_PREVIOUS_TAG" env=prod
 ```
 
 Rollback to previous Helm revision:

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -276,7 +276,7 @@ just kubeconfig-env "$ROLLBACK_ENV"
 ```
 
 ```bash
-just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$HELM_REVISION"
+just tokenplace-rollback release=tokenplace namespace=tokenplace revision="$HELM_REVISION" env="$ROLLBACK_ENV"
 ```
 
 ## Troubleshooting

--- a/docs/k3s-tokenplace-dev.md
+++ b/docs/k3s-tokenplace-dev.md
@@ -26,18 +26,18 @@ Use this runbook for `dev` token.place deployments on Sugarkube.
 just tokenplace-deploy \
   release=<release> namespace=<namespace> chart=<chart-ref> \
   values=<base-values>,<dev-values> version_file=<optional-version-file> \
-  tag=<tag>
+  tag=<tag> env=dev
 ```
 
 ```bash
 just tokenplace-upgrade \
   release=<release> namespace=<namespace> chart=<chart-ref> \
   values=<base-values>,<dev-values> version_file=<optional-version-file> \
-  tag=<tag>
+  tag=<tag> env=dev
 ```
 
 ```bash
-just tokenplace-rollback release=<release> namespace=<namespace> revision=<helm-revision>
+just tokenplace-rollback release=<release> namespace=<namespace> revision=<helm-revision> env=dev
 ```
 
 ## Validation

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -780,7 +780,7 @@ just helm-oci-upgrade \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \
   values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
   version_file=docs/apps/dspace.version \
-  default_tag=main-latest
+  default_tag=main-latest env=staging
 ```
 
 For production preview (optional canary), this guide intentionally switches from the generic

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -512,7 +512,25 @@ just kubeconfig-env env=dev
 ```
 
 **What you should see:** This creates `~/.kube/config` with the context renamed to
-`sugar-dev`, allowing you to run kubectl commands from your local machine.
+`sugar-dev`, allowing you to run kubectl commands from your local machine. The
+context name is only a display/scoping convenience: Sugarkube treats Kubernetes
+node labels as the authoritative environment identity. `just kubeconfig-env`
+queries the connected API for `sugarkube.env` and `sugarkube.cluster` labels on
+every node before persisting the copied kubeconfig, normalizes the legacy `int`
+environment to `staging`, and refuses to overwrite a working kubeconfig when the
+requested `env=` does not match the labels.
+
+Inspect the connected cluster identity without mutating anything:
+
+```bash
+just cluster-env-detect
+kubectl get nodes -o 'custom-columns=NAME:.metadata.name,CLUSTER:.metadata.labels.sugarkube\.cluster,ENV:.metadata.labels.sugarkube\.env'
+```
+
+Mutating app commands fail closed when the API cannot be queried, no nodes are
+returned, any node lacks `sugarkube.env`, node labels contain mixed environments,
+or the requested `env=` differs from the single normalized environment reported
+by the nodes.
 
 Verify workloads across all namespaces:
 
@@ -539,6 +557,7 @@ Quick reference for the most common recipes when operating your cluster:
 |--------|--------------|-------------|
 | `just status` | Display cluster nodes with `kubectl get nodes -o wide` | Check overall cluster health and node readiness. Guards against running before k3s is installed. |
 | `just kubeconfig-env env=dev` | Copy k3s kubeconfig to `~/.kube/config` with context renamed to `sugar-dev` | Set up kubectl access from your workstation or after re-imaging a node. |
+| `just cluster-env-detect` | Print the connected cluster environment from node labels | Confirm which physical cluster the current kubeconfig reaches before mutating workloads. |
 | `just save-logs env=dev` | Run cluster bring-up with `SAVE_DEBUG_LOGS=1` into `logs/up/` | Capture sanitized logs for troubleshooting, documenting cluster changes, or sharing with the community. |
 | `just cat-node-token` | Print the k3s node token for joining nodes | Retrieve the token when adding new nodes or switching to a different shell session. |
 | `just wipe` | Clean up k3s and mDNS state on a node | Recover from a failed bootstrap/join or remove a node that joined the wrong cluster. Re-run `just ha3 env=dev` afterward. |

--- a/justfile
+++ b/justfile
@@ -1316,16 +1316,19 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     if [ -z "${requested_env}" ] && [ -n "${SUGARKUBE_ENV:-}" ]; then
       requested_env="${SUGARKUBE_ENV}"
     fi
-    if [ -n "${requested_env}" ]; then
-      if [ "${requested_env}" = "int" ]; then
-        requested_env="staging"
-      fi
-      case "${requested_env}" in
-        dev|staging|prod) ;;
-        *) echo "ERROR: env must be one of dev|staging|prod." >&2; exit 1 ;;
-      esac
-      export SUGARKUBE_ENV="${requested_env}"
+    if [ -z "${requested_env}" ]; then
+      echo "ERROR: env is required for helm-oci-install/helm-oci-upgrade." >&2
+      echo "Pass env=<dev|staging|prod> or deliberately export SUGARKUBE_ENV before invoking this Helm helper." >&2
+      exit 1
     fi
+    if [ "${requested_env}" = "int" ]; then
+      requested_env="staging"
+    fi
+    case "${requested_env}" in
+      dev|staging|prod) ;;
+      *) echo "ERROR: env must be one of dev|staging|prod." >&2; exit 1 ;;
+    esac
+    export SUGARKUBE_ENV="${requested_env}"
 
     allow_install="$(normalize_prefixed_value allow_install "{{ allow_install }}")"
     reuse_values="$(normalize_prefixed_value reuse_values "{{ reuse_values }}")"
@@ -1334,6 +1337,8 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
         echo "Set release, namespace, and chart to deploy." >&2
         exit 1
     fi
+
+    python3 "{{ justfile_directory() }}/scripts/cluster_identity.py" assert --kubeconfig "${KUBECONFIG}" --env "${requested_env}" >/dev/null
 
     chart_version="${version}"
     if [ -z "${chart_version}" ] && [ -n "${version_file}" ] && [ -f "${version_file}" ]; then
@@ -1489,8 +1494,10 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
             install_hint_args+=("default_tag=${default_tag}")
             upgrade_hint_args+=("default_tag=${default_tag}")
         fi
+        install_hint_args+=("env=${requested_env}")
+        upgrade_hint_args+=("env=${requested_env}")
 
-        local install_hint_shape="just helm-oci-install release=${release} namespace=${namespace} chart=${chart} [values=...] [version=...] [version_file=...] [host=...] [tag=...] [default_tag=...]"
+        local install_hint_shape="just helm-oci-install release=${release} namespace=${namespace} chart=${chart} env=${requested_env} [values=...] [version=...] [version_file=...] [host=...] [tag=...] [default_tag=...]"
         local status_output=""
         if ! status_output="$(helm -n "${namespace}" status "${release}" 2>&1)"; then
             if grep -qiE '(release:[[:space:]]*not found|not[[:space:]-]*found)' <<< "${status_output}"; then
@@ -1565,9 +1572,6 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
         helm_args+=("${version_args[@]}")
     fi
 
-    if [ -n "${requested_env}" ]; then
-      python3 "{{ justfile_directory() }}/scripts/cluster_identity.py" assert --kubeconfig "${KUBECONFIG}" --env "${requested_env}" >/dev/null
-    fi
     helm "${helm_args[@]}"
     wait_for_rollouts
 

--- a/justfile
+++ b/justfile
@@ -484,7 +484,7 @@ kubeconfig-env env='dev':
     cleanup() { rm -f "${tmp_config}"; }
     trap cleanup EXIT
     sudo cp /etc/rancher/k3s/k3s.yaml "${tmp_config}"
-    sudo chown "$user":"$user" "${tmp_config}" || true
+    sudo chown "$user":"$user" "${tmp_config}"
     chmod 600 "${tmp_config}"
     export SUGARKUBE_REQUESTED_ENV="${env_name}"
     detected_env="$(python3 scripts/cluster_identity.py assert --kubeconfig "${tmp_config}" --env "${env_name}")"
@@ -1839,6 +1839,8 @@ dspace-oci-deploy env='staging' tag='':
     if [ -z "${KUBECONFIG:-}" ]; then
       export KUBECONFIG="${HOME}/.kube/config"
     fi
+    export SUGARKUBE_ENV="${env_name}"
+    just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "${env_name}" "${KUBECONFIG}" >/dev/null
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='dspace' namespace='dspace' \
@@ -1900,6 +1902,8 @@ dspace-oci-deploy-prod-subdomain tag='':
     if [ -z "${KUBECONFIG:-}" ]; then
       export KUBECONFIG="${HOME}/.kube/config"
     fi
+    export SUGARKUBE_ENV="prod"
+    just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "prod" "${KUBECONFIG}" >/dev/null
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='dspace' namespace='dspace' \
@@ -1964,8 +1968,15 @@ dspace-oci-redeploy env='staging' tag='':
       values_chain="${values_chain},${overlay}"
     fi
 
-    # NOTE: This tokenplace-scoped change intentionally leaves dspace kubeconfig behavior unchanged here.
-    # If dspace needs env-scoped kubeconfig selection before Helm, handle that in a separate DSPACE PR.
+    if [ -z "${KUBECONFIG:-}" ] && [ ! -r "${HOME}/.kube/config" ]; then
+      scripts/ensure_user_kubeconfig.sh || true
+    fi
+    if [ -z "${KUBECONFIG:-}" ]; then
+      export KUBECONFIG="${HOME}/.kube/config"
+    fi
+    export SUGARKUBE_ENV="${env_name}"
+    just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "${env_name}" "${KUBECONFIG}" >/dev/null
+
     deploy_tag="{{ tag }}"
     default_tag_value=""
     if [ "${env_name}" = "prod" ]; then
@@ -1986,11 +1997,6 @@ dspace-oci-redeploy env='staging' tag='':
       values="${values_chain}" \
       version_file='docs/apps/dspace.version' \
       tag="${deploy_tag}" default_tag="${default_tag_value}"
-
-    scripts/ensure_user_kubeconfig.sh || true
-    if [ -z "${KUBECONFIG:-}" ]; then
-      export KUBECONFIG="${HOME}/.kube/config"
-    fi
 
     echo "Forcing rollout restart for dspace deployment..."
     if ! kubectl -n dspace rollout restart deploy/dspace; then
@@ -2351,12 +2357,12 @@ tokenplace-upgrade release='tokenplace' namespace='tokenplace' chart='oci://ghcr
       release='{{ release }}' namespace='{{ namespace }}' chart='{{ chart }}' values='{{ values }}' \
       version_file='{{ version_file }}' version='{{ version }}' tag="${resolved_tag}" default_tag="${resolved_default_tag}"
 
-tokenplace-rollback release='tokenplace' namespace='tokenplace' revision='' env='staging':
+tokenplace-rollback release='tokenplace' namespace='tokenplace' revision='' env='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
     if [ -z '{{ release }}' ] || [ -z '{{ namespace }}' ] || [ -z '{{ revision }}' ]; then
-      echo "Usage: just tokenplace-rollback release=<name> namespace=<ns> revision=<helm_revision>" >&2
+      echo "Usage: just tokenplace-rollback release=<name> namespace=<ns> revision=<helm_revision> env=<dev|staging|prod>" >&2
       exit 1
     fi
     ns='{{ namespace }}'
@@ -2365,6 +2371,10 @@ tokenplace-rollback release='tokenplace' namespace='tokenplace' revision='' env=
     while [ "${env_name#env=}" != "${env_name}" ]; do
       env_name="${env_name#env=}"
     done
+    if [ -z "${env_name}" ]; then
+      echo "ERROR: env is required for tokenplace-rollback. Use env=dev|staging|prod." >&2
+      exit 1
+    fi
     if [ "${env_name}" = "int" ]; then
       env_name="staging"
     fi

--- a/justfile
+++ b/justfile
@@ -480,12 +480,41 @@ kubeconfig-env env='dev':
     fi
     user="${USER:-$(id -un)}"
     mkdir -p ~/.kube
-    sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-    sudo chown -R "$user":"$user" ~/.kube
+    tmp_config="$(mktemp "${HOME}/.kube/config.candidate.XXXXXX")"
+    cleanup() { rm -f "${tmp_config}"; }
+    trap cleanup EXIT
+    sudo cp /etc/rancher/k3s/k3s.yaml "${tmp_config}"
+    sudo chown "$user":"$user" "${tmp_config}" || true
+    chmod 600 "${tmp_config}"
+    export SUGARKUBE_REQUESTED_ENV="${env_name}"
+    detected_env="$(python3 scripts/cluster_identity.py assert --kubeconfig "${tmp_config}" --env "${env_name}")"
+    unset SUGARKUBE_REQUESTED_ENV
+    scope_name="sugar-${detected_env}"
+    python3 scripts/update_kubeconfig_scope.py "${tmp_config}" "${scope_name}"
+    mv "${tmp_config}" "${HOME}/.kube/config"
+    trap - EXIT
     chmod 700 ~/.kube
     chmod 600 ~/.kube/config
-    scope_name="sugar-${env_name}"
-    python3 scripts/update_kubeconfig_scope.py "${HOME}/.kube/config" "${scope_name}"
+
+# Read-only cluster identity detector based on Kubernetes node labels.
+cluster-env-detect kubeconfig='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    kubeconfig_path={{ quote(kubeconfig) }}
+    if [ -z "${kubeconfig_path}" ]; then
+      kubeconfig_path="${KUBECONFIG:-${HOME}/.kube/config}"
+    fi
+    python3 scripts/cluster_identity.py detect --kubeconfig "${kubeconfig_path}"
+
+# Fail closed unless the connected cluster's node labels match env.
+assert-cluster-env env kubeconfig='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    kubeconfig_path={{ quote(kubeconfig) }}
+    if [ -z "${kubeconfig_path}" ]; then
+      kubeconfig_path="${KUBECONFIG:-${HOME}/.kube/config}"
+    fi
+    python3 scripts/cluster_identity.py assert --kubeconfig "${kubeconfig_path}" --env {{ quote(env) }}
 
 kubeconfig-dev:
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env env=dev
@@ -1203,6 +1232,9 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     if [ -z "${KUBECONFIG:-}" ]; then
       export KUBECONFIG="${HOME}/.kube/config"
     fi
+    if [ -n "${SUGARKUBE_ENV:-}" ]; then
+      python3 "{{ justfile_directory() }}/scripts/cluster_identity.py" assert --kubeconfig "${KUBECONFIG}" --env "${SUGARKUBE_ENV}" >/dev/null
+    fi
 
     raw_args=(
         "{{ release }}" "{{ namespace }}" "{{ chart }}" "{{ values }}" "{{ host }}" "{{ version }}"
@@ -1555,6 +1587,7 @@ app-deploy app env='staging' tag='' config='':
 
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+    just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "${SUGARKUBE_ENV}" "${KUBECONFIG}" >/dev/null
     python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight \
       --app "${SUGARKUBE_APP}" \
       --env "${SUGARKUBE_ENV}" \
@@ -1588,6 +1621,7 @@ app-redeploy app env='staging' tag='' config='':
 
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+    just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "${SUGARKUBE_ENV}" "${KUBECONFIG}" >/dev/null
     python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight \
       --app "${SUGARKUBE_APP}" \
       --env "${SUGARKUBE_ENV}" \
@@ -2104,6 +2138,7 @@ tokenplace-oci-deploy env='staging' tag='':
     # This is tokenplace-scoped; do not copy into DSPACE from this PR.
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+    export SUGARKUBE_ENV="${env_name}"
     echo "Deploying tokenplace env=${env_name} chart=oci://ghcr.io/futuroptimist/charts/tokenplace version=${chart_version} image=ghcr.io/futuroptimist/tokenplace-relay:${resolved_tag}"
     python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight \
       --app tokenplace \
@@ -2211,6 +2246,7 @@ tokenplace-oci-redeploy env='staging' tag='':
     # This is tokenplace-scoped; do not copy into DSPACE from this PR.
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+    export SUGARKUBE_ENV="${env_name}"
     python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight \
       --app tokenplace \
       --env "${env_name}" \
@@ -2315,7 +2351,7 @@ tokenplace-upgrade release='tokenplace' namespace='tokenplace' chart='oci://ghcr
       release='{{ release }}' namespace='{{ namespace }}' chart='{{ chart }}' values='{{ values }}' \
       version_file='{{ version_file }}' version='{{ version }}' tag="${resolved_tag}" default_tag="${resolved_default_tag}"
 
-tokenplace-rollback release='tokenplace' namespace='tokenplace' revision='':
+tokenplace-rollback release='tokenplace' namespace='tokenplace' revision='' env='staging':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -2325,6 +2361,21 @@ tokenplace-rollback release='tokenplace' namespace='tokenplace' revision='':
     fi
     ns='{{ namespace }}'
     release='{{ release }}'
+    env_name='{{ env }}'
+    while [ "${env_name#env=}" != "${env_name}" ]; do
+      env_name="${env_name#env=}"
+    done
+    if [ "${env_name}" = "int" ]; then
+      env_name="staging"
+    fi
+    case "${env_name}" in
+      dev|staging|prod) ;;
+      *) echo "ERROR: env must be one of dev|staging|prod." >&2; exit 1 ;;
+    esac
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+    export SUGARKUBE_ENV="${env_name}"
+    just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "${env_name}" "${KUBECONFIG}" >/dev/null
 
     helm -n "${ns}" rollback "${release}" '{{ revision }}'
 
@@ -2446,6 +2497,7 @@ danielsmith-oci-deploy env='staging' tag='':
 
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+    export SUGARKUBE_ENV="${env_name}"
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='danielsmith' namespace='danielsmith' \
@@ -2558,6 +2610,7 @@ danielsmith-oci-redeploy env='staging' tag='':
 
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+    export SUGARKUBE_ENV="${env_name}"
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release='danielsmith' namespace='danielsmith' \

--- a/justfile
+++ b/justfile
@@ -486,9 +486,7 @@ kubeconfig-env env='dev':
     sudo cp /etc/rancher/k3s/k3s.yaml "${tmp_config}"
     sudo chown "$user":"$user" "${tmp_config}"
     chmod 600 "${tmp_config}"
-    export SUGARKUBE_REQUESTED_ENV="${env_name}"
     detected_env="$(python3 scripts/cluster_identity.py assert --kubeconfig "${tmp_config}" --env "${env_name}")"
-    unset SUGARKUBE_REQUESTED_ENV
     scope_name="sugar-${detected_env}"
     python3 scripts/update_kubeconfig_scope.py "${tmp_config}" "${scope_name}"
     mv "${tmp_config}" "${HOME}/.kube/config"
@@ -1215,7 +1213,7 @@ cf-tunnel-route host='':
         '' \
         'Dashboard steps are documented in docs/cloudflare_tunnel.md.'
 
-_helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' allow_install='false' reuse_values='false':
+_helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='' allow_install='false' reuse_values='false':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1232,13 +1230,9 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     if [ -z "${KUBECONFIG:-}" ]; then
       export KUBECONFIG="${HOME}/.kube/config"
     fi
-    if [ -n "${SUGARKUBE_ENV:-}" ]; then
-      python3 "{{ justfile_directory() }}/scripts/cluster_identity.py" assert --kubeconfig "${KUBECONFIG}" --env "${SUGARKUBE_ENV}" >/dev/null
-    fi
-
     raw_args=(
         "{{ release }}" "{{ namespace }}" "{{ chart }}" "{{ values }}" "{{ host }}" "{{ version }}"
-        "{{ version_file }}" "{{ tag }}" "{{ default_tag }}"
+        "{{ version_file }}" "{{ tag }}" "{{ default_tag }}" "{{ env }}"
     )
 
     release=""
@@ -1250,6 +1244,7 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     version_file=""
     tag=""
     default_tag=""
+    requested_env=""
 
     normalize_prefixed_value() {
         local key="${1}"
@@ -1290,6 +1285,7 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
             version_file=*) version_file="${raw_arg#version_file=}" ;;
             tag=*) tag="${raw_arg#tag=}" ;;
             default_tag=*) default_tag="${raw_arg#default_tag=}" ;;
+            env=*) requested_env="${raw_arg#env=}" ;;
             *)
                 case "${raw_index}" in
                     0) assign_if_empty release "${raw_arg}" ;;
@@ -1301,6 +1297,7 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
                     6) assign_if_empty version_file "${raw_arg}" ;;
                     7) assign_if_empty tag "${raw_arg}" ;;
                     8) assign_if_empty default_tag "${raw_arg}" ;;
+                    9) assign_if_empty requested_env "${raw_arg}" ;;
                 esac
                 ;;
         esac
@@ -1315,6 +1312,20 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     version_file="$(normalize_prefixed_value version_file "${version_file}")"
     tag="$(normalize_prefixed_value tag "${tag}")"
     default_tag="$(normalize_prefixed_value default_tag "${default_tag}")"
+    requested_env="$(normalize_prefixed_value env "${requested_env}")"
+    if [ -z "${requested_env}" ] && [ -n "${SUGARKUBE_ENV:-}" ]; then
+      requested_env="${SUGARKUBE_ENV}"
+    fi
+    if [ -n "${requested_env}" ]; then
+      if [ "${requested_env}" = "int" ]; then
+        requested_env="staging"
+      fi
+      case "${requested_env}" in
+        dev|staging|prod) ;;
+        *) echo "ERROR: env must be one of dev|staging|prod." >&2; exit 1 ;;
+      esac
+      export SUGARKUBE_ENV="${requested_env}"
+    fi
 
     allow_install="$(normalize_prefixed_value allow_install "{{ allow_install }}")"
     reuse_values="$(normalize_prefixed_value reuse_values "{{ reuse_values }}")"
@@ -1554,14 +1565,17 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
         helm_args+=("${version_args[@]}")
     fi
 
+    if [ -n "${requested_env}" ]; then
+      python3 "{{ justfile_directory() }}/scripts/cluster_identity.py" assert --kubeconfig "${KUBECONFIG}" --env "${requested_env}" >/dev/null
+    fi
     helm "${helm_args[@]}"
     wait_for_rollouts
 
-helm-oci-install release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='':
-    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' allow_install='true' reuse_values='false'
+helm-oci-install release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='':
+    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' '{{ env }}' allow_install='true' reuse_values='false'
 
-helm-oci-upgrade release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='':
-    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' allow_install='false' reuse_values='true'
+helm-oci-upgrade release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='':
+    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' '{{ env }}' allow_install='false' reuse_values='true'
 
 # Print resolved Sugarkube app deployment config for an app/environment.
 app-config app env='staging' config='':
@@ -1605,7 +1619,8 @@ app-deploy app env='staging' tag='' config='':
       values="${SUGARKUBE_VALUES}" \
       version="${SUGARKUBE_VERSION:-}" \
       version_file="${SUGARKUBE_VERSION_FILE:-}" \
-      tag="${SUGARKUBE_TAG}"
+      tag="${SUGARKUBE_TAG}" \
+      env="${SUGARKUBE_ENV}"
 
 # Generic upgrade-only app redeploy backed by app config files.
 app-redeploy app env='staging' tag='' config='':
@@ -1639,7 +1654,8 @@ app-redeploy app env='staging' tag='' config='':
       values="${SUGARKUBE_VALUES}" \
       version="${SUGARKUBE_VERSION:-}" \
       version_file="${SUGARKUBE_VERSION_FILE:-}" \
-      tag="${SUGARKUBE_TAG}"
+      tag="${SUGARKUBE_TAG}" \
+      env="${SUGARKUBE_ENV}"
 
 # Promote an app to prod with an explicit immutable tag, or the configured prod tag file.
 app-promote-prod app tag='' config='':
@@ -1847,7 +1863,8 @@ dspace-oci-deploy env='staging' tag='':
       chart='oci://ghcr.io/democratizedspace/charts/dspace' \
       values="${values_chain}" \
       version_file='docs/apps/dspace.version' \
-      tag="${deploy_tag}"
+      tag="${deploy_tag}" \
+      env="${env_name}"
 
     echo "Resolved deployment image(s):"
     kubectl -n dspace get deploy dspace \
@@ -1910,7 +1927,8 @@ dspace-oci-deploy-prod-subdomain tag='':
       chart='oci://ghcr.io/democratizedspace/charts/dspace' \
       values="${values_chain}" \
       version_file='docs/apps/dspace.version' \
-      tag="${deploy_tag}"
+      tag="${deploy_tag}" \
+      env="prod"
 
     echo "Resolved deployment image(s):"
     kubectl -n dspace get deploy dspace \
@@ -1996,7 +2014,8 @@ dspace-oci-redeploy env='staging' tag='':
       chart='oci://ghcr.io/democratizedspace/charts/dspace' \
       values="${values_chain}" \
       version_file='docs/apps/dspace.version' \
-      tag="${deploy_tag}" default_tag="${default_tag_value}"
+      tag="${deploy_tag}" \
+      env="${env_name}" default_tag="${default_tag_value}"
 
     echo "Forcing rollout restart for dspace deployment..."
     if ! kubectl -n dspace rollout restart deploy/dspace; then
@@ -2161,7 +2180,8 @@ tokenplace-oci-deploy env='staging' tag='':
       chart='oci://ghcr.io/futuroptimist/charts/tokenplace' \
       values="${values_chain}" \
       version_file='docs/apps/tokenplace.version' \
-      tag="${resolved_tag}"
+      tag="${resolved_tag}" \
+      env="${env_name}"
 
     scripts/ensure_user_kubeconfig.sh || true
     export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
@@ -2268,7 +2288,8 @@ tokenplace-oci-redeploy env='staging' tag='':
       chart='oci://ghcr.io/futuroptimist/charts/tokenplace' \
       values="${values_chain}" \
       version_file='docs/apps/tokenplace.version' \
-      tag="${resolved_tag}" default_tag="${default_tag}"
+      tag="${resolved_tag}" \
+      env="${env_name}" default_tag="${default_tag}"
 
     scripts/ensure_user_kubeconfig.sh || true
     export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
@@ -2319,7 +2340,7 @@ tokenplace-deploy release='tokenplace' namespace='tokenplace' chart='oci://ghcr.
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='{{ release }}' namespace='{{ namespace }}' chart='{{ chart }}' values='{{ values }}' \
-      version_file='{{ version_file }}' version='{{ version }}' tag="${resolved_tag}" default_tag="${resolved_default_tag}"
+      version_file='{{ version_file }}' version='{{ version }}' tag="${resolved_tag}" default_tag="${resolved_default_tag}" env="${SUGARKUBE_ENV:-}"
 
 # Upgrade-only path for existing token.place releases.
 tokenplace-upgrade release='tokenplace' namespace='tokenplace' chart='oci://ghcr.io/futuroptimist/charts/tokenplace' values='' version_file='docs/apps/tokenplace.version' version='' tag='' default_tag='':
@@ -2355,14 +2376,14 @@ tokenplace-upgrade release='tokenplace' namespace='tokenplace' chart='oci://ghcr
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release='{{ release }}' namespace='{{ namespace }}' chart='{{ chart }}' values='{{ values }}' \
-      version_file='{{ version_file }}' version='{{ version }}' tag="${resolved_tag}" default_tag="${resolved_default_tag}"
+      version_file='{{ version_file }}' version='{{ version }}' tag="${resolved_tag}" default_tag="${resolved_default_tag}" env="${SUGARKUBE_ENV:-}"
 
 tokenplace-rollback release='tokenplace' namespace='tokenplace' revision='' env='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
     if [ -z '{{ release }}' ] || [ -z '{{ namespace }}' ] || [ -z '{{ revision }}' ]; then
-      echo "Usage: just tokenplace-rollback release=<name> namespace=<ns> revision=<helm_revision> env=<dev|staging|prod>" >&2
+      echo "Usage: just tokenplace-rollback release=<name> namespace=<ns> revision=<helm_revision> [env=<dev|staging|prod>]" >&2
       exit 1
     fi
     ns='{{ namespace }}'
@@ -2371,21 +2392,29 @@ tokenplace-rollback release='tokenplace' namespace='tokenplace' revision='' env=
     while [ "${env_name#env=}" != "${env_name}" ]; do
       env_name="${env_name#env=}"
     done
-    if [ -z "${env_name}" ]; then
-      echo "ERROR: env is required for tokenplace-rollback. Use env=dev|staging|prod." >&2
-      exit 1
+    if [ -z "${env_name}" ] && [ -n "${SUGARKUBE_ENV:-}" ]; then
+      env_name="${SUGARKUBE_ENV}"
     fi
     if [ "${env_name}" = "int" ]; then
       env_name="staging"
     fi
-    case "${env_name}" in
-      dev|staging|prod) ;;
-      *) echo "ERROR: env must be one of dev|staging|prod." >&2; exit 1 ;;
-    esac
-    export KUBECONFIG="${HOME}/.kube/config"
-    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
+    export KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config}"
+    if [ -z "${env_name}" ]; then
+      detect_output="$(python3 "{{ justfile_directory() }}/scripts/cluster_identity.py" detect --kubeconfig "${KUBECONFIG}")"
+      env_name="$(awk -F': ' '/^Environment:/ {print $2; exit}' <<< "${detect_output}")"
+      if [ -z "${env_name}" ]; then
+        echo "ERROR: unable to determine connected cluster environment for rollback." >&2
+        echo "${detect_output}" >&2
+        exit 1
+      fi
+    else
+      case "${env_name}" in
+        dev|staging|prod) ;;
+        *) echo "ERROR: env must be one of dev|staging|prod." >&2; exit 1 ;;
+      esac
+      just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "${env_name}" "${KUBECONFIG}" >/dev/null
+    fi
     export SUGARKUBE_ENV="${env_name}"
-    just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "${env_name}" "${KUBECONFIG}" >/dev/null
 
     helm -n "${ns}" rollback "${release}" '{{ revision }}'
 
@@ -2514,7 +2543,8 @@ danielsmith-oci-deploy env='staging' tag='':
       chart='oci://ghcr.io/futuroptimist/charts/danielsmith' \
       values="${values_chain}" \
       version_file='docs/apps/danielsmith.version' \
-      tag="${resolved_tag}"
+      tag="${resolved_tag}" \
+      env="${env_name}"
 
     scripts/ensure_user_kubeconfig.sh || true
     export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
@@ -2627,7 +2657,8 @@ danielsmith-oci-redeploy env='staging' tag='':
       chart='oci://ghcr.io/futuroptimist/charts/danielsmith' \
       values="${values_chain}" \
       version_file='docs/apps/danielsmith.version' \
-      tag="${resolved_tag}" default_tag="${default_tag}"
+      tag="${resolved_tag}" \
+      env="${env_name}" default_tag="${default_tag}"
 
     scripts/ensure_user_kubeconfig.sh || true
     export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"

--- a/justfile
+++ b/justfile
@@ -486,7 +486,7 @@ kubeconfig-env env='dev':
     sudo cp /etc/rancher/k3s/k3s.yaml "${tmp_config}"
     sudo chown "$user":"$user" "${tmp_config}"
     chmod 600 "${tmp_config}"
-    detected_env="$(python3 scripts/cluster_identity.py assert --kubeconfig "${tmp_config}" --env "${env_name}" --cluster "${SUGARKUBE_CLUSTER}")"
+    detected_env="$(python3 scripts/cluster_identity.py assert --kubeconfig "${tmp_config}" --env "${env_name}")"
     scope_name="sugar-${detected_env}"
     python3 scripts/update_kubeconfig_scope.py "${tmp_config}" "${scope_name}"
     mv "${tmp_config}" "${HOME}/.kube/config"
@@ -512,7 +512,7 @@ assert-cluster-env env kubeconfig='':
     if [ -z "${kubeconfig_path}" ]; then
       kubeconfig_path="${KUBECONFIG:-${HOME}/.kube/config}"
     fi
-    python3 scripts/cluster_identity.py assert --kubeconfig "${kubeconfig_path}" --env {{ quote(env) }} --cluster "${SUGARKUBE_CLUSTER}"
+    python3 scripts/cluster_identity.py assert --kubeconfig "${kubeconfig_path}" --env {{ quote(env) }}
 
 kubeconfig-dev:
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env env=dev
@@ -1338,7 +1338,7 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
         exit 1
     fi
 
-    python3 "{{ justfile_directory() }}/scripts/cluster_identity.py" assert --kubeconfig "${KUBECONFIG}" --env "${requested_env}" --cluster "${SUGARKUBE_CLUSTER}" >/dev/null
+    python3 "{{ justfile_directory() }}/scripts/cluster_identity.py" assert --kubeconfig "${KUBECONFIG}" --env "${requested_env}" >/dev/null
 
     chart_version="${version}"
     if [ -z "${chart_version}" ] && [ -n "${version_file}" ] && [ -f "${version_file}" ]; then

--- a/justfile
+++ b/justfile
@@ -486,7 +486,7 @@ kubeconfig-env env='dev':
     sudo cp /etc/rancher/k3s/k3s.yaml "${tmp_config}"
     sudo chown "$user":"$user" "${tmp_config}"
     chmod 600 "${tmp_config}"
-    detected_env="$(python3 scripts/cluster_identity.py assert --kubeconfig "${tmp_config}" --env "${env_name}")"
+    detected_env="$(python3 scripts/cluster_identity.py assert --kubeconfig "${tmp_config}" --env "${env_name}" --cluster "${SUGARKUBE_CLUSTER}")"
     scope_name="sugar-${detected_env}"
     python3 scripts/update_kubeconfig_scope.py "${tmp_config}" "${scope_name}"
     mv "${tmp_config}" "${HOME}/.kube/config"
@@ -512,7 +512,7 @@ assert-cluster-env env kubeconfig='':
     if [ -z "${kubeconfig_path}" ]; then
       kubeconfig_path="${KUBECONFIG:-${HOME}/.kube/config}"
     fi
-    python3 scripts/cluster_identity.py assert --kubeconfig "${kubeconfig_path}" --env {{ quote(env) }}
+    python3 scripts/cluster_identity.py assert --kubeconfig "${kubeconfig_path}" --env {{ quote(env) }} --cluster "${SUGARKUBE_CLUSTER}"
 
 kubeconfig-dev:
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env env=dev
@@ -1338,7 +1338,7 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
         exit 1
     fi
 
-    python3 "{{ justfile_directory() }}/scripts/cluster_identity.py" assert --kubeconfig "${KUBECONFIG}" --env "${requested_env}" >/dev/null
+    python3 "{{ justfile_directory() }}/scripts/cluster_identity.py" assert --kubeconfig "${KUBECONFIG}" --env "${requested_env}" --cluster "${SUGARKUBE_CLUSTER}" >/dev/null
 
     chart_version="${version}"
     if [ -z "${chart_version}" ] && [ -n "${version_file}" ] && [ -f "${version_file}" ]; then

--- a/justfile
+++ b/justfile
@@ -2311,7 +2311,7 @@ tokenplace-status namespace='tokenplace' release='tokenplace' host_key='ingress.
 # selection; these generic helpers require explicit values + tag/default_tag to
 
 # avoid active-kubeconfig environment drift.
-tokenplace-deploy release='tokenplace' namespace='tokenplace' chart='oci://ghcr.io/futuroptimist/charts/tokenplace' values='' version_file='docs/apps/tokenplace.version' version='' tag='' default_tag='':
+tokenplace-deploy release='tokenplace' namespace='tokenplace' chart='oci://ghcr.io/futuroptimist/charts/tokenplace' values='' version_file='docs/apps/tokenplace.version' version='' tag='' default_tag='' env='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -2344,10 +2344,10 @@ tokenplace-deploy release='tokenplace' namespace='tokenplace' chart='oci://ghcr.
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='{{ release }}' namespace='{{ namespace }}' chart='{{ chart }}' values='{{ values }}' \
-      version_file='{{ version_file }}' version='{{ version }}' tag="${resolved_tag}" default_tag="${resolved_default_tag}" env="${SUGARKUBE_ENV:-}"
+      version_file='{{ version_file }}' version='{{ version }}' tag="${resolved_tag}" default_tag="${resolved_default_tag}" env='{{ env }}'
 
 # Upgrade-only path for existing token.place releases.
-tokenplace-upgrade release='tokenplace' namespace='tokenplace' chart='oci://ghcr.io/futuroptimist/charts/tokenplace' values='' version_file='docs/apps/tokenplace.version' version='' tag='' default_tag='':
+tokenplace-upgrade release='tokenplace' namespace='tokenplace' chart='oci://ghcr.io/futuroptimist/charts/tokenplace' values='' version_file='docs/apps/tokenplace.version' version='' tag='' default_tag='' env='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -2380,7 +2380,7 @@ tokenplace-upgrade release='tokenplace' namespace='tokenplace' chart='oci://ghcr
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release='{{ release }}' namespace='{{ namespace }}' chart='{{ chart }}' values='{{ values }}' \
-      version_file='{{ version_file }}' version='{{ version }}' tag="${resolved_tag}" default_tag="${resolved_default_tag}" env="${SUGARKUBE_ENV:-}"
+      version_file='{{ version_file }}' version='{{ version }}' tag="${resolved_tag}" default_tag="${resolved_default_tag}" env='{{ env }}'
 
 tokenplace-rollback release='tokenplace' namespace='tokenplace' revision='' env='':
     #!/usr/bin/env bash
@@ -2404,20 +2404,15 @@ tokenplace-rollback release='tokenplace' namespace='tokenplace' revision='' env=
     fi
     export KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config}"
     if [ -z "${env_name}" ]; then
-      detect_output="$(python3 "{{ justfile_directory() }}/scripts/cluster_identity.py" detect --kubeconfig "${KUBECONFIG}")"
-      env_name="$(awk -F': ' '/^Environment:/ {print $2; exit}' <<< "${detect_output}")"
-      if [ -z "${env_name}" ]; then
-        echo "ERROR: unable to determine connected cluster environment for rollback." >&2
-        echo "${detect_output}" >&2
-        exit 1
-      fi
-    else
-      case "${env_name}" in
-        dev|staging|prod) ;;
-        *) echo "ERROR: env must be one of dev|staging|prod." >&2; exit 1 ;;
-      esac
-      just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "${env_name}" "${KUBECONFIG}" >/dev/null
+      echo "ERROR: tokenplace-rollback requires a requested environment." >&2
+      echo "Pass env=<dev|staging|prod> or deliberately export SUGARKUBE_ENV before invoking rollback." >&2
+      exit 1
     fi
+    case "${env_name}" in
+      dev|staging|prod) ;;
+      *) echo "ERROR: env must be one of dev|staging|prod." >&2; exit 1 ;;
+    esac
+    just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "${env_name}" "${KUBECONFIG}" >/dev/null
     export SUGARKUBE_ENV="${env_name}"
 
     helm -n "${ns}" rollback "${release}" '{{ revision }}'

--- a/scripts/cluster_identity.py
+++ b/scripts/cluster_identity.py
@@ -21,7 +21,7 @@ def norm_env(value: str) -> str:
 def run_kubectl(kubeconfig: str, args: list[str]) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["KUBECONFIG"] = kubeconfig
-    return subprocess.run(["kubectl", *args], env=env, text=True, capture_output=True, check=False)
+    return subprocess.run(["kubectl", "--kubeconfig", kubeconfig, *args], env=env, text=True, capture_output=True, check=False)
 
 
 def safe_info(kubeconfig: str) -> tuple[str, str]:
@@ -71,6 +71,8 @@ def load_identity(kubeconfig: str, requested: str | None = None) -> tuple[int, s
         name = str(meta.get("name") or "<unnamed>")
         nodes.append(name)
         labels = meta.get("labels", {}) if isinstance(meta, dict) else {}
+        if not isinstance(labels, dict):
+            labels = {}
         raw_env = str(labels.get("sugarkube.env") or "").strip()
         raw_cluster = str(labels.get("sugarkube.cluster") or "").strip()
         if raw_cluster:
@@ -122,7 +124,17 @@ def main() -> int:
     assert detected is not None
     if args.command == "assert" and requested != detected:
         return fail(f"requested env={requested}, but the connected Kubernetes cluster identifies as env={detected}.\nRefusing to run a mutating command.", requested=requested, detected={detected}, clusters=LAST_DETAILS["clusters"], nodes=LAST_DETAILS["nodes"], kubeconfig=kubeconfig)
-    print(detected)
+    if args.command == "detect":
+        context, server = safe_info(kubeconfig)
+        clusters = sorted(LAST_DETAILS["clusters"])
+        nodes = LAST_DETAILS["nodes"]
+        print(f"Environment: {detected}")
+        print(f"Cluster: {clusters[0] if clusters else '<none>'}")
+        print(f"Nodes: {', '.join(nodes) if nodes else '<none>'}")
+        print(f"Context: {context}")
+        print(f"Server: {server}")
+    else:
+        print(detected)
     return 0
 
 if __name__ == "__main__":

--- a/scripts/cluster_identity.py
+++ b/scripts/cluster_identity.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Detect and assert Sugarkube cluster identity from Kubernetes node labels."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+VALID_ENVS = {"dev", "staging", "prod"}
+LAST_DETAILS = {"envs": set(), "clusters": set(), "nodes": []}
+
+
+def norm_env(value: str) -> str:
+    value = value.strip().lower()
+    return "staging" if value == "int" else value
+
+
+def run_kubectl(kubeconfig: str, args: list[str]) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["KUBECONFIG"] = kubeconfig
+    return subprocess.run(["kubectl", *args], env=env, text=True, capture_output=True, check=False)
+
+
+def safe_info(kubeconfig: str) -> tuple[str, str]:
+    ctx = run_kubectl(kubeconfig, ["config", "current-context"])
+    context = ctx.stdout.strip() if ctx.returncode == 0 else "unknown"
+    server = "unknown"
+    if context and context != "unknown":
+        view = run_kubectl(kubeconfig, ["config", "view", "--minify", "-o", "jsonpath={.clusters[0].cluster.server}"])
+        if view.returncode == 0 and view.stdout.strip():
+            server = view.stdout.strip()
+    return context, server
+
+
+def fail(message: str, *, requested: str | None, detected: set[str], clusters: set[str], nodes: list[str], kubeconfig: str) -> int:
+    context, server = safe_info(kubeconfig)
+    print(f"ERROR: {message}", file=sys.stderr)
+    if requested:
+        print(f"Requested env: {requested}", file=sys.stderr)
+    print(f"Detected env(s): {', '.join(sorted(detected)) if detected else '<none>'}", file=sys.stderr)
+    print(f"Cluster label(s): {', '.join(sorted(clusters)) if clusters else '<none>'}", file=sys.stderr)
+    print(f"Context: {context}", file=sys.stderr)
+    print(f"Server: {server}", file=sys.stderr)
+    print(f"Connected nodes: {', '.join(nodes) if nodes else '<none>'}", file=sys.stderr)
+    return 1
+
+
+def load_identity(kubeconfig: str, requested: str | None = None) -> tuple[int, str | None]:
+    proc = run_kubectl(kubeconfig, ["get", "nodes", "-o", "json"])
+    if proc.returncode != 0:
+        return fail("failed to query Kubernetes nodes; refusing to trust cluster identity.", requested=requested, detected=set(), clusters=set(), nodes=[], kubeconfig=kubeconfig), None
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return fail("kubectl returned malformed node JSON; refusing to trust cluster identity.", requested=requested, detected=set(), clusters=set(), nodes=[], kubeconfig=kubeconfig), None
+    items = data.get("items")
+    if not isinstance(items, list) or not items:
+        return fail("connected Kubernetes API returned zero nodes; refusing to run a mutating command.", requested=requested, detected=set(), clusters=set(), nodes=[], kubeconfig=kubeconfig), None
+
+    nodes: list[str] = []
+    envs: set[str] = set()
+    clusters: set[str] = set()
+    missing: list[str] = []
+    malformed: list[str] = []
+    for item in items:
+        meta = item.get("metadata", {}) if isinstance(item, dict) else {}
+        name = str(meta.get("name") or "<unnamed>")
+        nodes.append(name)
+        labels = meta.get("labels", {}) if isinstance(meta, dict) else {}
+        raw_env = str(labels.get("sugarkube.env") or "").strip()
+        raw_cluster = str(labels.get("sugarkube.cluster") or "").strip()
+        if raw_cluster:
+            clusters.add(raw_cluster)
+        if not raw_env:
+            missing.append(name)
+            continue
+        env = norm_env(raw_env)
+        if env not in VALID_ENVS:
+            malformed.append(f"{name}={raw_env}")
+        envs.add(env)
+
+    if missing:
+        return fail(f"one or more nodes are missing sugarkube.env labels: {', '.join(missing)}.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
+    if malformed:
+        return fail(f"one or more nodes have malformed sugarkube.env labels: {', '.join(malformed)}.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
+    LAST_DETAILS["envs"] = set(envs)
+    LAST_DETAILS["clusters"] = set(clusters)
+    LAST_DETAILS["nodes"] = list(nodes)
+    if len(envs) != 1:
+        return fail("mixed or ambiguous sugarkube.env labels detected; refusing to run a mutating command.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
+    detected = next(iter(envs))
+    return 0, detected
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=["detect", "assert"])
+    parser.add_argument("--kubeconfig", required=True)
+    parser.add_argument("--env", default="")
+    args = parser.parse_args()
+    kubeconfig = str(Path(args.kubeconfig).expanduser())
+    requested = norm_env(args.env) if args.env else None
+    if requested and requested not in VALID_ENVS:
+        print("ERROR: env must be one of dev|staging|prod (legacy int normalizes to staging).", file=sys.stderr)
+        return 1
+    code, detected = load_identity(kubeconfig, requested)
+    if code != 0:
+        return code
+    assert detected is not None
+    if args.command == "assert" and requested != detected:
+        return fail(f"requested env={requested}, but the connected Kubernetes cluster identifies as env={detected}.\nRefusing to run a mutating command.", requested=requested, detected={detected}, clusters=LAST_DETAILS["clusters"], nodes=LAST_DETAILS["nodes"], kubeconfig=kubeconfig)
+    print(detected)
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cluster_identity.py
+++ b/scripts/cluster_identity.py
@@ -35,11 +35,13 @@ def safe_info(kubeconfig: str) -> tuple[str, str]:
     return context, server
 
 
-def fail(message: str, *, requested: str | None, detected: set[str], clusters: set[str], nodes: list[str], kubeconfig: str) -> int:
+def fail(message: str, *, requested: str | None, expected_cluster: str | None = None, detected: set[str], clusters: set[str], nodes: list[str], kubeconfig: str) -> int:
     context, server = safe_info(kubeconfig)
     print(f"ERROR: {message}", file=sys.stderr)
     if requested:
         print(f"Requested env: {requested}", file=sys.stderr)
+    if expected_cluster:
+        print(f"Expected cluster: {expected_cluster}", file=sys.stderr)
     print(f"Detected env(s): {', '.join(sorted(detected)) if detected else '<none>'}", file=sys.stderr)
     print(f"Cluster label(s): {', '.join(sorted(clusters)) if clusters else '<none>'}", file=sys.stderr)
     print(f"Context: {context}", file=sys.stderr)
@@ -48,17 +50,17 @@ def fail(message: str, *, requested: str | None, detected: set[str], clusters: s
     return 1
 
 
-def load_identity(kubeconfig: str, requested: str | None = None) -> tuple[int, str | None]:
+def load_identity(kubeconfig: str, requested: str | None = None, expected_cluster: str | None = None) -> tuple[int, str | None]:
     proc = run_kubectl(kubeconfig, ["get", "nodes", "-o", "json"])
     if proc.returncode != 0:
-        return fail("failed to query Kubernetes nodes; refusing to trust cluster identity.", requested=requested, detected=set(), clusters=set(), nodes=[], kubeconfig=kubeconfig), None
+        return fail("failed to query Kubernetes nodes; refusing to trust cluster identity.", requested=requested, expected_cluster=expected_cluster, detected=set(), clusters=set(), nodes=[], kubeconfig=kubeconfig), None
     try:
         data = json.loads(proc.stdout)
     except json.JSONDecodeError:
-        return fail("kubectl returned malformed node JSON; refusing to trust cluster identity.", requested=requested, detected=set(), clusters=set(), nodes=[], kubeconfig=kubeconfig), None
+        return fail("kubectl returned malformed node JSON; refusing to trust cluster identity.", requested=requested, expected_cluster=expected_cluster, detected=set(), clusters=set(), nodes=[], kubeconfig=kubeconfig), None
     items = data.get("items")
     if not isinstance(items, list) or not items:
-        return fail("connected Kubernetes API returned zero nodes; refusing to run a mutating command.", requested=requested, detected=set(), clusters=set(), nodes=[], kubeconfig=kubeconfig), None
+        return fail("connected Kubernetes API returned zero nodes; refusing to run a mutating command.", requested=requested, expected_cluster=expected_cluster, detected=set(), clusters=set(), nodes=[], kubeconfig=kubeconfig), None
 
     nodes: list[str] = []
     envs: set[str] = set()
@@ -88,18 +90,21 @@ def load_identity(kubeconfig: str, requested: str | None = None) -> tuple[int, s
         envs.add(env)
 
     if missing_env:
-        return fail(f"one or more nodes are missing sugarkube.env labels: {', '.join(missing_env)}.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
+        return fail(f"one or more nodes are missing sugarkube.env labels: {', '.join(missing_env)}.", requested=requested, expected_cluster=expected_cluster, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
     if missing_cluster:
-        return fail(f"one or more nodes are missing sugarkube.cluster labels: {', '.join(missing_cluster)}.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
+        return fail(f"one or more nodes are missing sugarkube.cluster labels: {', '.join(missing_cluster)}.", requested=requested, expected_cluster=expected_cluster, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
     if malformed:
-        return fail(f"one or more nodes have malformed sugarkube.env labels: {', '.join(malformed)}.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
+        return fail(f"one or more nodes have malformed sugarkube.env labels: {', '.join(malformed)}.", requested=requested, expected_cluster=expected_cluster, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
     LAST_DETAILS["envs"] = set(envs)
     LAST_DETAILS["clusters"] = set(clusters)
     LAST_DETAILS["nodes"] = list(nodes)
     if len(clusters) != 1:
-        return fail("mixed or ambiguous sugarkube.cluster labels detected; refusing to run a mutating command.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
+        return fail("mixed or ambiguous sugarkube.cluster labels detected; refusing to run a mutating command.", requested=requested, expected_cluster=expected_cluster, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
     if len(envs) != 1:
-        return fail("mixed or ambiguous sugarkube.env labels detected; refusing to run a mutating command.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
+        return fail("mixed or ambiguous sugarkube.env labels detected; refusing to run a mutating command.", requested=requested, expected_cluster=expected_cluster, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
+    detected_cluster = next(iter(clusters))
+    if expected_cluster and detected_cluster != expected_cluster:
+        return fail(f"expected cluster={expected_cluster}, but the connected Kubernetes cluster identifies as cluster={detected_cluster}.\nRefusing to run a mutating command.", requested=requested, expected_cluster=expected_cluster, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
     detected = next(iter(envs))
     return 0, detected
 
@@ -109,21 +114,26 @@ def main() -> int:
     parser.add_argument("command", choices=["detect", "assert"])
     parser.add_argument("--kubeconfig", required=True)
     parser.add_argument("--env", default="")
+    parser.add_argument("--cluster", default="")
     args = parser.parse_args()
     kubeconfig = str(Path(args.kubeconfig).expanduser())
     requested = norm_env(args.env) if args.env else None
+    expected_cluster = args.cluster.strip() or None
     if args.command == "assert" and not requested:
         print("ERROR: assert requires --env dev|staging|prod (legacy int normalizes to staging).", file=sys.stderr)
+        return 1
+    if args.command == "assert" and not expected_cluster:
+        print("ERROR: assert requires --cluster <expected-cluster>.", file=sys.stderr)
         return 1
     if requested and requested not in VALID_ENVS:
         print("ERROR: env must be one of dev|staging|prod (legacy int normalizes to staging).", file=sys.stderr)
         return 1
-    code, detected = load_identity(kubeconfig, requested)
+    code, detected = load_identity(kubeconfig, requested, expected_cluster)
     if code != 0:
         return code
     assert detected is not None
     if args.command == "assert" and requested != detected:
-        return fail(f"requested env={requested}, but the connected Kubernetes cluster identifies as env={detected}.\nRefusing to run a mutating command.", requested=requested, detected={detected}, clusters=LAST_DETAILS["clusters"], nodes=LAST_DETAILS["nodes"], kubeconfig=kubeconfig)
+        return fail(f"requested env={requested}, but the connected Kubernetes cluster identifies as env={detected}.\nRefusing to run a mutating command.", requested=requested, expected_cluster=expected_cluster, detected={detected}, clusters=LAST_DETAILS["clusters"], nodes=LAST_DETAILS["nodes"], kubeconfig=kubeconfig)
     if args.command == "detect":
         context, server = safe_info(kubeconfig)
         clusters = sorted(LAST_DETAILS["clusters"])

--- a/scripts/cluster_identity.py
+++ b/scripts/cluster_identity.py
@@ -35,13 +35,11 @@ def safe_info(kubeconfig: str) -> tuple[str, str]:
     return context, server
 
 
-def fail(message: str, *, requested: str | None, expected_cluster: str | None = None, detected: set[str], clusters: set[str], nodes: list[str], kubeconfig: str) -> int:
+def fail(message: str, *, requested: str | None, detected: set[str], clusters: set[str], nodes: list[str], kubeconfig: str) -> int:
     context, server = safe_info(kubeconfig)
     print(f"ERROR: {message}", file=sys.stderr)
     if requested:
         print(f"Requested env: {requested}", file=sys.stderr)
-    if expected_cluster:
-        print(f"Expected cluster: {expected_cluster}", file=sys.stderr)
     print(f"Detected env(s): {', '.join(sorted(detected)) if detected else '<none>'}", file=sys.stderr)
     print(f"Cluster label(s): {', '.join(sorted(clusters)) if clusters else '<none>'}", file=sys.stderr)
     print(f"Context: {context}", file=sys.stderr)
@@ -50,17 +48,17 @@ def fail(message: str, *, requested: str | None, expected_cluster: str | None = 
     return 1
 
 
-def load_identity(kubeconfig: str, requested: str | None = None, expected_cluster: str | None = None) -> tuple[int, str | None]:
+def load_identity(kubeconfig: str, requested: str | None = None) -> tuple[int, str | None]:
     proc = run_kubectl(kubeconfig, ["get", "nodes", "-o", "json"])
     if proc.returncode != 0:
-        return fail("failed to query Kubernetes nodes; refusing to trust cluster identity.", requested=requested, expected_cluster=expected_cluster, detected=set(), clusters=set(), nodes=[], kubeconfig=kubeconfig), None
+        return fail("failed to query Kubernetes nodes; refusing to trust cluster identity.", requested=requested, detected=set(), clusters=set(), nodes=[], kubeconfig=kubeconfig), None
     try:
         data = json.loads(proc.stdout)
     except json.JSONDecodeError:
-        return fail("kubectl returned malformed node JSON; refusing to trust cluster identity.", requested=requested, expected_cluster=expected_cluster, detected=set(), clusters=set(), nodes=[], kubeconfig=kubeconfig), None
+        return fail("kubectl returned malformed node JSON; refusing to trust cluster identity.", requested=requested, detected=set(), clusters=set(), nodes=[], kubeconfig=kubeconfig), None
     items = data.get("items")
     if not isinstance(items, list) or not items:
-        return fail("connected Kubernetes API returned zero nodes; refusing to run a mutating command.", requested=requested, expected_cluster=expected_cluster, detected=set(), clusters=set(), nodes=[], kubeconfig=kubeconfig), None
+        return fail("connected Kubernetes API returned zero nodes; refusing to run a mutating command.", requested=requested, detected=set(), clusters=set(), nodes=[], kubeconfig=kubeconfig), None
 
     nodes: list[str] = []
     envs: set[str] = set()
@@ -90,21 +88,22 @@ def load_identity(kubeconfig: str, requested: str | None = None, expected_cluste
         envs.add(env)
 
     if missing_env:
-        return fail(f"one or more nodes are missing sugarkube.env labels: {', '.join(missing_env)}.", requested=requested, expected_cluster=expected_cluster, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
+        return fail(f"one or more nodes are missing sugarkube.env labels: {', '.join(missing_env)}.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
     if missing_cluster:
-        return fail(f"one or more nodes are missing sugarkube.cluster labels: {', '.join(missing_cluster)}.", requested=requested, expected_cluster=expected_cluster, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
+        return fail(f"one or more nodes are missing sugarkube.cluster labels: {', '.join(missing_cluster)}.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
     if malformed:
-        return fail(f"one or more nodes have malformed sugarkube.env labels: {', '.join(malformed)}.", requested=requested, expected_cluster=expected_cluster, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
+        return fail(f"one or more nodes have malformed sugarkube.env labels: {', '.join(malformed)}.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
     LAST_DETAILS["envs"] = set(envs)
     LAST_DETAILS["clusters"] = set(clusters)
     LAST_DETAILS["nodes"] = list(nodes)
     if len(clusters) != 1:
-        return fail("mixed or ambiguous sugarkube.cluster labels detected; refusing to run a mutating command.", requested=requested, expected_cluster=expected_cluster, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
+        return fail("mixed or ambiguous sugarkube.cluster labels detected; refusing to run a mutating command.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
     if len(envs) != 1:
-        return fail("mixed or ambiguous sugarkube.env labels detected; refusing to run a mutating command.", requested=requested, expected_cluster=expected_cluster, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
-    detected_cluster = next(iter(clusters))
-    if expected_cluster and detected_cluster != expected_cluster:
-        return fail(f"expected cluster={expected_cluster}, but the connected Kubernetes cluster identifies as cluster={detected_cluster}.\nRefusing to run a mutating command.", requested=requested, expected_cluster=expected_cluster, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
+        return fail("mixed or ambiguous sugarkube.env labels detected; refusing to run a mutating command.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
+    # The requested environment is this helper's authorization input. The
+    # cluster label is still required to be complete and unanimous for
+    # consistency checks and diagnostics; binding to a separately requested
+    # physical-cluster identity would require a distinct operator interface.
     detected = next(iter(envs))
     return 0, detected
 
@@ -114,26 +113,21 @@ def main() -> int:
     parser.add_argument("command", choices=["detect", "assert"])
     parser.add_argument("--kubeconfig", required=True)
     parser.add_argument("--env", default="")
-    parser.add_argument("--cluster", default="")
     args = parser.parse_args()
     kubeconfig = str(Path(args.kubeconfig).expanduser())
     requested = norm_env(args.env) if args.env else None
-    expected_cluster = args.cluster.strip() or None
     if args.command == "assert" and not requested:
         print("ERROR: assert requires --env dev|staging|prod (legacy int normalizes to staging).", file=sys.stderr)
-        return 1
-    if args.command == "assert" and not expected_cluster:
-        print("ERROR: assert requires --cluster <expected-cluster>.", file=sys.stderr)
         return 1
     if requested and requested not in VALID_ENVS:
         print("ERROR: env must be one of dev|staging|prod (legacy int normalizes to staging).", file=sys.stderr)
         return 1
-    code, detected = load_identity(kubeconfig, requested, expected_cluster)
+    code, detected = load_identity(kubeconfig, requested)
     if code != 0:
         return code
     assert detected is not None
     if args.command == "assert" and requested != detected:
-        return fail(f"requested env={requested}, but the connected Kubernetes cluster identifies as env={detected}.\nRefusing to run a mutating command.", requested=requested, expected_cluster=expected_cluster, detected={detected}, clusters=LAST_DETAILS["clusters"], nodes=LAST_DETAILS["nodes"], kubeconfig=kubeconfig)
+        return fail(f"requested env={requested}, but the connected Kubernetes cluster identifies as env={detected}.\nRefusing to run a mutating command.", requested=requested, detected={detected}, clusters=LAST_DETAILS["clusters"], nodes=LAST_DETAILS["nodes"], kubeconfig=kubeconfig)
     if args.command == "detect":
         context, server = safe_info(kubeconfig)
         clusters = sorted(LAST_DETAILS["clusters"])

--- a/scripts/cluster_identity.py
+++ b/scripts/cluster_identity.py
@@ -63,7 +63,8 @@ def load_identity(kubeconfig: str, requested: str | None = None) -> tuple[int, s
     nodes: list[str] = []
     envs: set[str] = set()
     clusters: set[str] = set()
-    missing: list[str] = []
+    missing_env: list[str] = []
+    missing_cluster: list[str] = []
     malformed: list[str] = []
     for item in items:
         meta = item.get("metadata", {}) if isinstance(item, dict) else {}
@@ -74,21 +75,27 @@ def load_identity(kubeconfig: str, requested: str | None = None) -> tuple[int, s
         raw_cluster = str(labels.get("sugarkube.cluster") or "").strip()
         if raw_cluster:
             clusters.add(raw_cluster)
+        else:
+            missing_cluster.append(name)
         if not raw_env:
-            missing.append(name)
+            missing_env.append(name)
             continue
         env = norm_env(raw_env)
         if env not in VALID_ENVS:
             malformed.append(f"{name}={raw_env}")
         envs.add(env)
 
-    if missing:
-        return fail(f"one or more nodes are missing sugarkube.env labels: {', '.join(missing)}.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
+    if missing_env:
+        return fail(f"one or more nodes are missing sugarkube.env labels: {', '.join(missing_env)}.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
+    if missing_cluster:
+        return fail(f"one or more nodes are missing sugarkube.cluster labels: {', '.join(missing_cluster)}.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
     if malformed:
         return fail(f"one or more nodes have malformed sugarkube.env labels: {', '.join(malformed)}.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
     LAST_DETAILS["envs"] = set(envs)
     LAST_DETAILS["clusters"] = set(clusters)
     LAST_DETAILS["nodes"] = list(nodes)
+    if len(clusters) != 1:
+        return fail("mixed or ambiguous sugarkube.cluster labels detected; refusing to run a mutating command.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
     if len(envs) != 1:
         return fail("mixed or ambiguous sugarkube.env labels detected; refusing to run a mutating command.", requested=requested, detected=envs, clusters=clusters, nodes=nodes, kubeconfig=kubeconfig), None
     detected = next(iter(envs))
@@ -103,6 +110,9 @@ def main() -> int:
     args = parser.parse_args()
     kubeconfig = str(Path(args.kubeconfig).expanduser())
     requested = norm_env(args.env) if args.env else None
+    if args.command == "assert" and not requested:
+        print("ERROR: assert requires --env dev|staging|prod (legacy int normalizes to staging).", file=sys.stderr)
+        return 1
     if requested and requested not in VALID_ENVS:
         print("ERROR: env must be one of dev|staging|prod (legacy int normalizes to staging).", file=sys.stderr)
         return 1

--- a/scripts/test-helm-oci-install.sh
+++ b/scripts/test-helm-oci-install.sh
@@ -103,7 +103,7 @@ set -euo pipefail
 echo "kubectl $*" >> "${KUBECTL_TEST_LOG:-/dev/null}"
 
 if [[ "$*" == *"get nodes -o json"* ]]; then
-    printf '{"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.env":"staging","sugarkube.cluster":"sugarkube"}}},{"metadata":{"name":"sugarkube4","labels":{"sugarkube.env":"staging","sugarkube.cluster":"sugarkube"}}}]}\n'
+    printf '{"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.env":"staging","sugarkube.cluster":"sugar"}}},{"metadata":{"name":"sugarkube4","labels":{"sugarkube.env":"staging","sugarkube.cluster":"sugar"}}}]}\n'
     exit 0
 fi
 

--- a/scripts/test-helm-oci-install.sh
+++ b/scripts/test-helm-oci-install.sh
@@ -102,6 +102,21 @@ set -euo pipefail
 
 echo "kubectl $*" >> "${KUBECTL_TEST_LOG:-/dev/null}"
 
+if [[ "$*" == *"get nodes -o json"* ]]; then
+    printf '{"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.env":"staging","sugarkube.cluster":"sugarkube"}}},{"metadata":{"name":"sugarkube4","labels":{"sugarkube.env":"staging","sugarkube.cluster":"sugarkube"}}}]}\n'
+    exit 0
+fi
+
+if [[ "$*" == *"config current-context"* ]]; then
+    printf 'sugar-staging\n'
+    exit 0
+fi
+
+if [[ "$*" == *"config view"* ]]; then
+    printf 'https://127.0.0.1:6443\n'
+    exit 0
+fi
+
 if [ "$1" = "-n" ] && [ "$2" = "dspace" ] && [ "$3" = "get" ] && [ "$4" = "deploy,statefulset,daemonset" ] && [ "$5" = "-l" ] && [ "$6" = "app.kubernetes.io/instance=dspace" ]; then
     exit 0
 fi
@@ -133,7 +148,7 @@ command_output="$(
         chart=oci://registry.test/charts/dspace \
         values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
         version_file=docs/apps/dspace.version \
-        default_tag=v3-latest
+        default_tag=v3-latest env=staging
 )"
 
 if ! grep -q "oci://registry.test/charts/dspace" <<<"${command_output}"; then
@@ -176,6 +191,71 @@ if ! grep -q "rollout status deployment.apps/dspace" "${kubectl_log}"; then
     exit 1
 fi
 
+rm -f "${helm_log}"
+if PATH="${tmp_bin}:${PATH}" HELM_TEST_LOG="${helm_log}" KUBECTL_TEST_LOG="${kubectl_log}" \
+    HELM_STATUS_MODE_FILE="${status_mode_file}" \
+    FAKE_HELM_REGISTRY_CHART="${fixture_registry}" KUBECONFIG="${tmp_bin}/kubeconfig" \
+    just helm-oci-install \
+    release=dspace namespace=dspace \
+    chart=oci://registry.test/charts/dspace \
+    values=docs/examples/dspace.values.dev.yaml \
+    version_file=docs/apps/dspace.version >"${tmp_bin}/install-missing-env.out" 2>&1; then
+    printf 'Expected direct install without env or SUGARKUBE_ENV to fail.\n' >&2
+    exit 1
+fi
+
+if [ -s "${helm_log}" ]; then
+    printf 'Direct install without env should not invoke helm.\nLog:\n%s\n' "$(cat "${helm_log}")" >&2
+    exit 1
+fi
+
+if ! grep -q "env is required for helm-oci-install/helm-oci-upgrade" "${tmp_bin}/install-missing-env.out"; then
+    printf 'Missing direct install env-required guidance.\nOutput:\n%s\n' "$(cat "${tmp_bin}/install-missing-env.out")" >&2
+    exit 1
+fi
+
+rm -f "${helm_log}"
+printf 'deployed' >"${status_mode_file}"
+if PATH="${tmp_bin}:${PATH}" HELM_TEST_LOG="${helm_log}" KUBECTL_TEST_LOG="${kubectl_log}" \
+    HELM_STATUS_MODE_FILE="${status_mode_file}" \
+    FAKE_HELM_REGISTRY_CHART="${fixture_registry}" KUBECONFIG="${tmp_bin}/kubeconfig" \
+    just helm-oci-upgrade \
+    release=dspace namespace=dspace \
+    chart=oci://registry.test/charts/dspace \
+    values=docs/examples/dspace.values.dev.yaml \
+    version_file=docs/apps/dspace.version >"${tmp_bin}/upgrade-missing-env.out" 2>&1; then
+    printf 'Expected direct upgrade without env or SUGARKUBE_ENV to fail.\n' >&2
+    exit 1
+fi
+
+if [ -s "${helm_log}" ]; then
+    printf 'Direct upgrade without env should not invoke helm.\nLog:\n%s\n' "$(cat "${helm_log}")" >&2
+    exit 1
+fi
+
+rm -f "${helm_log}"
+if PATH="${tmp_bin}:${PATH}" HELM_TEST_LOG="${helm_log}" KUBECTL_TEST_LOG="${kubectl_log}" \
+    HELM_STATUS_MODE_FILE="${status_mode_file}" \
+    FAKE_HELM_REGISTRY_CHART="${fixture_registry}" KUBECONFIG="${tmp_bin}/kubeconfig" \
+    just helm-oci-install \
+    release=dspace namespace=dspace \
+    chart=oci://registry.test/charts/dspace \
+    values=docs/examples/dspace.values.dev.yaml \
+    version_file=docs/apps/dspace.version env=prod >"${tmp_bin}/install-mismatch.out" 2>&1; then
+    printf 'Expected direct install with prod request against staging-labeled nodes to fail.\n' >&2
+    exit 1
+fi
+
+if [ -s "${helm_log}" ]; then
+    printf 'Direct install mismatch should not invoke helm.\nLog:\n%s\n' "$(cat "${helm_log}")" >&2
+    exit 1
+fi
+
+if ! grep -q "requested env=prod" "${tmp_bin}/install-mismatch.out"; then
+    printf 'Missing direct install mismatch diagnostic.\nOutput:\n%s\n' "$(cat "${tmp_bin}/install-mismatch.out")" >&2
+    exit 1
+fi
+
 printf 'deployed' >"${status_mode_file}"
 upgrade_output="$(
     PATH="${tmp_bin}:${PATH}" HELM_TEST_LOG="${helm_log}" KUBECTL_TEST_LOG="${kubectl_log}" \
@@ -185,7 +265,7 @@ upgrade_output="$(
         release=release=dspace namespace=namespace=dspace \
         chart=chart=oci://registry.test/charts/dspace \
         values=values=docs/examples/dspace.values.dev.yaml \
-        version_file=version_file=docs/apps/dspace.version
+        version_file=version_file=docs/apps/dspace.version env=staging
 )"
 
 if ! grep -q "helm upgrade dspace oci://registry.test/charts/dspace --namespace dspace --reuse-values" <<<"${upgrade_output}"; then
@@ -201,7 +281,7 @@ if PATH="${tmp_bin}:${PATH}" HELM_TEST_LOG="${helm_log}" KUBECTL_TEST_LOG="${kub
     release=dspace namespace=dspace \
     chart=oci://registry.test/charts/dspace \
     values=docs/examples/dspace.values.dev.yaml \
-    version_file=docs/apps/dspace.version >"${tmp_bin}/upgrade-missing.out" 2>&1; then
+    version_file=docs/apps/dspace.version env=staging >"${tmp_bin}/upgrade-missing.out" 2>&1; then
     printf 'Expected upgrade-only path to fail when release is missing.\n' >&2
     exit 1
 fi
@@ -211,7 +291,7 @@ if ! grep -q "helm-oci-upgrade requires an existing deployed release" "${tmp_bin
     exit 1
 fi
 
-if ! grep -q "just helm-oci-install release=dspace namespace=dspace chart=oci://registry.test/charts/dspace" "${tmp_bin}/upgrade-missing.out"; then
+if ! grep -q "just helm-oci-install release=dspace namespace=dspace chart=oci://registry.test/charts/dspace env=staging" "${tmp_bin}/upgrade-missing.out"; then
     printf 'Missing install guidance in upgrade-only failure output.\nOutput:\n%s\n' "$(cat "${tmp_bin}/upgrade-missing.out")" >&2
     exit 1
 fi
@@ -235,7 +315,7 @@ if PATH="${tmp_bin}:${PATH}" HELM_TEST_LOG="${helm_log}" KUBECTL_TEST_LOG="${kub
     release=dspace namespace=dspace \
     chart=oci://registry.test/charts/dspace \
     values=docs/examples/dspace.values.dev.yaml \
-    version_file=docs/apps/dspace.version >"${tmp_bin}/upgrade-failed-status.out" 2>&1; then
+    version_file=docs/apps/dspace.version env=staging >"${tmp_bin}/upgrade-failed-status.out" 2>&1; then
     printf 'Expected upgrade-only path to fail when release status is not deployed.\n' >&2
     exit 1
 fi
@@ -255,7 +335,7 @@ if grep -q "just helm-oci-install" "${tmp_bin}/upgrade-failed-status.out"; then
     exit 1
 fi
 
-if ! grep -q "just helm-oci-upgrade release=dspace namespace=dspace chart=oci://registry.test/charts/dspace values=docs/examples/dspace.values.dev.yaml version_file=docs/apps/dspace.version" "${tmp_bin}/upgrade-failed-status.out"; then
+if ! grep -q "just helm-oci-upgrade release=dspace namespace=dspace chart=oci://registry.test/charts/dspace values=docs/examples/dspace.values.dev.yaml version_file=docs/apps/dspace.version env=staging" "${tmp_bin}/upgrade-failed-status.out"; then
     printf 'Non-deployed status guidance should preserve retry arguments.\nOutput:\n%s\n' "$(cat "${tmp_bin}/upgrade-failed-status.out")" >&2
     exit 1
 fi
@@ -266,7 +346,7 @@ if PATH="${tmp_bin}:${PATH}" HELM_TEST_LOG="${helm_log}" KUBECTL_TEST_LOG="${kub
     FAKE_HELM_REGISTRY_CHART="${fixture_registry}" KUBECONFIG="${tmp_bin}/kubeconfig" \
     just helm-oci-upgrade \
     release=dspace namespace=dspace \
-    chart=oci://registry.test/charts/dspace >"${tmp_bin}/upgrade-status-error.out" 2>&1; then
+    chart=oci://registry.test/charts/dspace env=staging >"${tmp_bin}/upgrade-status-error.out" 2>&1; then
     printf 'Expected upgrade-only path to fail on generic helm status error.\n' >&2
     exit 1
 fi

--- a/tests/test_cluster_identity.py
+++ b/tests/test_cluster_identity.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "cluster_identity.py"
+
+
+def _kubectl(bin_dir: Path) -> Path:
+    path = bin_dir / "kubectl"
+    path.write_text(
+        textwrap.dedent(
+            """#!/usr/bin/env python3
+import json, os, sys
+args = sys.argv[1:]
+if args[:2] == ["config", "current-context"]:
+    print(os.environ.get("STUB_CONTEXT", "sugar-prod")); raise SystemExit(0)
+if args[:2] == ["config", "view"]:
+    print("https://127.0.0.1:6443", end=""); raise SystemExit(0)
+if args == ["get", "nodes", "-o", "json"]:
+    mode = os.environ.get("STUB_NODES", "staging")
+    if mode == "fail":
+        print("api down", file=sys.stderr); raise SystemExit(7)
+    if mode == "empty":
+        print('{"items": []}'); raise SystemExit(0)
+    if mode == "missing":
+        print(json.dumps({"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.cluster":"cube"}}}]})); raise SystemExit(0)
+    if mode == "mixed":
+        envs = ["staging", "prod"]
+    else:
+        envs = [mode, mode]
+    print(json.dumps({"items":[{"metadata":{"name":f"sugarkube{i+3}","labels":{"sugarkube.env":e,"sugarkube.cluster":"cube"}}} for i,e in enumerate(envs)]}))
+    raise SystemExit(0)
+raise SystemExit(1)
+"""
+        ),
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+    return path
+
+
+def _run(tmp_path: Path, requested: str, mode: str) -> subprocess.CompletedProcess[str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _kubectl(bin_dir)
+    kubeconfig = tmp_path / "config"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["STUB_NODES"] = mode
+    return subprocess.run(
+        ["python3", str(SCRIPT), "assert", "--kubeconfig", str(kubeconfig), "--env", requested],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_cluster_identity_matching_environment_succeeds(tmp_path: Path) -> None:
+    assert _run(tmp_path, "staging", "staging").returncode == 0
+
+
+def test_cluster_identity_legacy_int_normalizes_to_staging(tmp_path: Path) -> None:
+    result = _run(tmp_path, "staging", "int")
+    assert result.returncode == 0
+    assert result.stdout.strip() == "staging"
+
+
+def test_cluster_identity_requested_prod_detected_staging_fails_closed(tmp_path: Path) -> None:
+    result = _run(tmp_path, "prod", "staging")
+    assert result.returncode != 0
+    assert "requested env=prod" in result.stderr
+    assert "env=staging" in result.stderr
+    assert "Connected nodes: sugarkube3, sugarkube4" in result.stderr
+
+
+def test_cluster_identity_requested_staging_detected_prod_fails_closed(tmp_path: Path) -> None:
+    result = _run(tmp_path, "staging", "prod")
+    assert result.returncode != 0
+    assert "requested env=staging" in result.stderr
+    assert "env=prod" in result.stderr
+
+
+def test_cluster_identity_zero_nodes_fails_closed(tmp_path: Path) -> None:
+    assert "zero nodes" in _run(tmp_path, "prod", "empty").stderr
+
+
+def test_cluster_identity_kubectl_failure_fails_closed(tmp_path: Path) -> None:
+    assert "failed to query" in _run(tmp_path, "prod", "fail").stderr
+
+
+def test_cluster_identity_missing_env_label_fails_closed(tmp_path: Path) -> None:
+    assert "missing sugarkube.env" in _run(tmp_path, "prod", "missing").stderr
+
+
+def test_cluster_identity_mixed_env_labels_fail_closed(tmp_path: Path) -> None:
+    assert "mixed or ambiguous" in _run(tmp_path, "prod", "mixed").stderr

--- a/tests/test_cluster_identity.py
+++ b/tests/test_cluster_identity.py
@@ -29,6 +29,10 @@ if args == ["get", "nodes", "-o", "json"]:
         print('{"items": []}'); raise SystemExit(0)
     if mode == "missing":
         print(json.dumps({"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.cluster":"cube"}}}]})); raise SystemExit(0)
+    if mode == "missing-cluster":
+        print(json.dumps({"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.env":"staging"}}}]})); raise SystemExit(0)
+    if mode == "mixed-cluster":
+        print(json.dumps({"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.env":"staging","sugarkube.cluster":"cube-a"}}},{"metadata":{"name":"sugarkube4","labels":{"sugarkube.env":"staging","sugarkube.cluster":"cube-b"}}}]})); raise SystemExit(0)
     if mode == "mixed":
         envs = ["staging", "prod"]
     else:
@@ -102,3 +106,35 @@ def test_cluster_identity_missing_env_label_fails_closed(tmp_path: Path) -> None
 
 def test_cluster_identity_mixed_env_labels_fail_closed(tmp_path: Path) -> None:
     assert "mixed or ambiguous" in _run(tmp_path, "prod", "mixed").stderr
+
+
+def test_cluster_identity_missing_cluster_label_fails_closed(tmp_path: Path) -> None:
+    result = _run(tmp_path, "staging", "missing-cluster")
+    assert result.returncode != 0
+    assert "missing sugarkube.cluster" in result.stderr
+
+
+def test_cluster_identity_mixed_cluster_labels_fail_closed(tmp_path: Path) -> None:
+    result = _run(tmp_path, "staging", "mixed-cluster")
+    assert result.returncode != 0
+    assert "mixed or ambiguous sugarkube.cluster" in result.stderr
+
+
+def test_cluster_identity_assert_requires_env(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _kubectl(bin_dir)
+    kubeconfig = tmp_path / "config"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    result = subprocess.run(
+        ["python3", str(SCRIPT), "assert", "--kubeconfig", str(kubeconfig)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "assert requires --env" in result.stderr

--- a/tests/test_cluster_identity.py
+++ b/tests/test_cluster_identity.py
@@ -17,6 +17,8 @@ def _kubectl(bin_dir: Path) -> Path:
             """#!/usr/bin/env python3
 import json, os, sys
 args = sys.argv[1:]
+if len(args) >= 2 and args[0] == "--kubeconfig":
+    args = args[2:]
 if args[:2] == ["config", "current-context"]:
     print(os.environ.get("STUB_CONTEXT", "sugar-prod")); raise SystemExit(0)
 if args[:2] == ["config", "view"]:
@@ -33,6 +35,8 @@ if args == ["get", "nodes", "-o", "json"]:
         print(json.dumps({"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.env":"staging"}}}]})); raise SystemExit(0)
     if mode == "mixed-cluster":
         print(json.dumps({"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.env":"staging","sugarkube.cluster":"cube-a"}}},{"metadata":{"name":"sugarkube4","labels":{"sugarkube.env":"staging","sugarkube.cluster":"cube-b"}}}]})); raise SystemExit(0)
+    if mode == "malformed-labels":
+        print(json.dumps({"items":[{"metadata":{"name":"sugarkube3","labels":[]}}]})); raise SystemExit(0)
     if mode == "mixed":
         envs = ["staging", "prod"]
     else:
@@ -118,6 +122,39 @@ def test_cluster_identity_mixed_cluster_labels_fail_closed(tmp_path: Path) -> No
     result = _run(tmp_path, "staging", "mixed-cluster")
     assert result.returncode != 0
     assert "mixed or ambiguous sugarkube.cluster" in result.stderr
+
+
+def test_cluster_identity_malformed_label_structure_fails_without_traceback(tmp_path: Path) -> None:
+    result = _run(tmp_path, "staging", "malformed-labels")
+    assert result.returncode != 0
+    assert "missing sugarkube.env" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_cluster_identity_detect_prints_details(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _kubectl(bin_dir)
+    kubeconfig = tmp_path / "config"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["STUB_NODES"] = "prod"
+    env["STUB_CONTEXT"] = "sugar-prod"
+    result = subprocess.run(
+        ["python3", str(SCRIPT), "detect", "--kubeconfig", str(kubeconfig)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Environment: prod" in result.stdout
+    assert "Cluster: cube" in result.stdout
+    assert "Nodes: sugarkube3, sugarkube4" in result.stdout
+    assert "Context: sugar-prod" in result.stdout
+    assert "Server: https://127.0.0.1:6443" in result.stdout
 
 
 def test_cluster_identity_assert_requires_env(tmp_path: Path) -> None:

--- a/tests/test_cluster_identity.py
+++ b/tests/test_cluster_identity.py
@@ -13,8 +13,7 @@ SCRIPT = REPO_ROOT / "scripts" / "cluster_identity.py"
 def _kubectl(bin_dir: Path) -> Path:
     path = bin_dir / "kubectl"
     path.write_text(
-        textwrap.dedent(
-            """#!/usr/bin/env python3
+        textwrap.dedent("""#!/usr/bin/env python3
 import json, os, sys
 args = sys.argv[1:]
 if len(args) >= 2 and args[0] == "--kubeconfig":
@@ -44,8 +43,7 @@ if args == ["get", "nodes", "-o", "json"]:
     print(json.dumps({"items":[{"metadata":{"name":f"sugarkube{i+3}","labels":{"sugarkube.env":e,"sugarkube.cluster":"cube"}}} for i,e in enumerate(envs)]}))
     raise SystemExit(0)
 raise SystemExit(1)
-"""
-        ),
+"""),
         encoding="utf-8",
     )
     path.chmod(0o755)
@@ -175,3 +173,231 @@ def test_cluster_identity_assert_requires_env(tmp_path: Path) -> None:
     )
     assert result.returncode != 0
     assert "assert requires --env" in result.stderr
+
+
+# Direct in-process coverage for scripts/cluster_identity.py. The CLI-oriented
+# tests above execute the helper in a subprocess, which validates operator
+# behavior but does not contribute to pytest-cov patch coverage.
+def _completed(
+    stdout: str = "", returncode: int = 0, stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(["kubectl"], returncode, stdout, stderr)
+
+
+def _module():
+    import importlib
+    import scripts.cluster_identity as cluster_identity
+
+    return importlib.reload(cluster_identity)
+
+
+def _nodes(*entries: tuple[str, str, str]) -> str:
+    return json.dumps(
+        {
+            "items": [
+                {
+                    "metadata": {
+                        "name": name,
+                        "labels": {
+                            "sugarkube.env": env,
+                            "sugarkube.cluster": cluster,
+                        },
+                    }
+                }
+                for name, env, cluster in entries
+            ]
+        }
+    )
+
+
+def test_cluster_identity_in_process_run_kubectl_sets_explicit_kubeconfig(monkeypatch) -> None:
+    module = _module()
+    observed: dict[str, object] = {}
+
+    def fake_run(command, **kwargs):
+        observed["command"] = command
+        observed["env"] = kwargs["env"]
+        observed["text"] = kwargs["text"]
+        observed["capture_output"] = kwargs["capture_output"]
+        observed["check"] = kwargs["check"]
+        return _completed("ok")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module.run_kubectl("/tmp/kube", ["get", "nodes"])
+
+    assert result.stdout == "ok"
+    assert observed["command"] == ["kubectl", "--kubeconfig", "/tmp/kube", "get", "nodes"]
+    assert observed["env"]["KUBECONFIG"] == "/tmp/kube"
+    assert observed["text"] is True
+    assert observed["capture_output"] is True
+    assert observed["check"] is False
+
+
+def test_cluster_identity_in_process_assert_success_and_kubectl_flags(monkeypatch, capsys) -> None:
+    module = _module()
+    calls: list[tuple[str, list[str]]] = []
+
+    def fake_run_kubectl(kubeconfig: str, args: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append((kubeconfig, args))
+        if args == ["get", "nodes", "-o", "json"]:
+            return _completed(_nodes(("sugarkube3", "int", "cube"), ("sugarkube4", "int", "cube")))
+        raise AssertionError(args)
+
+    monkeypatch.setattr(module, "run_kubectl", fake_run_kubectl)
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        ["cluster_identity.py", "assert", "--kubeconfig", "~/kube", "--env", "staging"],
+    )
+
+    assert module.main() == 0
+    assert capsys.readouterr().out.strip() == "staging"
+    assert calls == [(str(Path("~/kube").expanduser()), ["get", "nodes", "-o", "json"])]
+    assert module.LAST_DETAILS["clusters"] == {"cube"}
+    assert module.LAST_DETAILS["nodes"] == ["sugarkube3", "sugarkube4"]
+
+
+def test_cluster_identity_in_process_detect_prints_safe_info(monkeypatch, capsys) -> None:
+    module = _module()
+
+    def fake_run_kubectl(kubeconfig: str, args: list[str]) -> subprocess.CompletedProcess[str]:
+        if args == ["get", "nodes", "-o", "json"]:
+            return _completed(_nodes(("sugarkube3", "prod", "cube")))
+        if args == ["config", "current-context"]:
+            return _completed("sugar-prod\n")
+        if args == ["config", "view", "--minify", "-o", "jsonpath={.clusters[0].cluster.server}"]:
+            return _completed("https://127.0.0.1:6443")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(module, "run_kubectl", fake_run_kubectl)
+    monkeypatch.setattr(
+        module.sys, "argv", ["cluster_identity.py", "detect", "--kubeconfig", "kube"]
+    )
+
+    assert module.main() == 0
+    out = capsys.readouterr().out
+    assert "Environment: prod" in out
+    assert "Cluster: cube" in out
+    assert "Context: sugar-prod" in out
+    assert "Server: https://127.0.0.1:6443" in out
+
+
+def test_cluster_identity_in_process_mismatch_reports_diagnostics(monkeypatch, capsys) -> None:
+    module = _module()
+
+    def fake_run_kubectl(kubeconfig: str, args: list[str]) -> subprocess.CompletedProcess[str]:
+        if args == ["get", "nodes", "-o", "json"]:
+            return _completed(
+                _nodes(("sugarkube3", "staging", "cube"), ("sugarkube4", "staging", "cube"))
+            )
+        if args == ["config", "current-context"]:
+            return _completed("misleading-sugar-prod\n")
+        if args == ["config", "view", "--minify", "-o", "jsonpath={.clusters[0].cluster.server}"]:
+            return _completed("https://10.0.0.5:6443")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(module, "run_kubectl", fake_run_kubectl)
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        ["cluster_identity.py", "assert", "--kubeconfig", "kube", "--env", "prod"],
+    )
+
+    assert module.main() == 1
+    err = capsys.readouterr().err
+    assert "requested env=prod" in err
+    assert "Detected env(s): staging" in err
+    assert "Cluster label(s): cube" in err
+    assert "Context: misleading-sugar-prod" in err
+    assert "Server: https://10.0.0.5:6443" in err
+    assert "Connected nodes: sugarkube3, sugarkube4" in err
+
+
+def test_cluster_identity_in_process_fail_closed_modes(monkeypatch, capsys) -> None:
+    module = _module()
+    scenarios = [
+        (_completed("", 7, "api down"), "failed to query Kubernetes nodes"),
+        (_completed("not-json"), "malformed node JSON"),
+        (_completed(json.dumps({"items": []})), "zero nodes"),
+        (
+            _completed(
+                json.dumps(
+                    {
+                        "items": [
+                            {"metadata": {"name": "node1", "labels": {"sugarkube.cluster": "cube"}}}
+                        ]
+                    }
+                )
+            ),
+            "missing sugarkube.env",
+        ),
+        (
+            _completed(
+                json.dumps(
+                    {
+                        "items": [
+                            {"metadata": {"name": "node1", "labels": {"sugarkube.env": "staging"}}}
+                        ]
+                    }
+                )
+            ),
+            "missing sugarkube.cluster",
+        ),
+        (_completed(_nodes(("node1", "qa", "cube"))), "malformed sugarkube.env"),
+        (
+            _completed(_nodes(("node1", "staging", "cube-a"), ("node2", "staging", "cube-b"))),
+            "mixed or ambiguous sugarkube.cluster",
+        ),
+        (
+            _completed(_nodes(("node1", "staging", "cube"), ("node2", "prod", "cube"))),
+            "mixed or ambiguous sugarkube.env",
+        ),
+        (
+            _completed(json.dumps({"items": [{"metadata": {"name": "node1", "labels": []}}]})),
+            "missing sugarkube.env",
+        ),
+    ]
+
+    for completed, expected in scenarios:
+
+        def fake_run_kubectl(
+            kubeconfig: str, args: list[str], completed=completed
+        ) -> subprocess.CompletedProcess[str]:
+            if args == ["get", "nodes", "-o", "json"]:
+                return completed
+            return (
+                _completed("unknown\n") if args == ["config", "current-context"] else _completed("")
+            )
+
+        monkeypatch.setattr(module, "run_kubectl", fake_run_kubectl)
+        code, detected = module.load_identity("kube", "prod")
+        assert (code, detected) == (1, None)
+        assert expected in capsys.readouterr().err
+
+
+def test_cluster_identity_in_process_main_returns_load_failure(monkeypatch) -> None:
+    module = _module()
+    monkeypatch.setattr(module, "load_identity", lambda kubeconfig, requested: (1, None))
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        ["cluster_identity.py", "detect", "--kubeconfig", "kube"],
+    )
+
+    assert module.main() == 1
+
+
+def test_cluster_identity_in_process_argument_validation(monkeypatch, capsys) -> None:
+    module = _module()
+    monkeypatch.setattr(
+        module.sys, "argv", ["cluster_identity.py", "assert", "--kubeconfig", "kube"]
+    )
+    assert module.main() == 1
+    assert "assert requires --env" in capsys.readouterr().err
+
+    monkeypatch.setattr(
+        module.sys, "argv", ["cluster_identity.py", "assert", "--kubeconfig", "kube", "--env", "qa"]
+    )
+    assert module.main() == 1
+    assert "env must be one of" in capsys.readouterr().err

--- a/tests/test_cluster_identity.py
+++ b/tests/test_cluster_identity.py
@@ -62,7 +62,7 @@ def _run(tmp_path: Path, requested: str, mode: str) -> subprocess.CompletedProce
     env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
     env["STUB_NODES"] = mode
     return subprocess.run(
-        ["python3", str(SCRIPT), "assert", "--kubeconfig", str(kubeconfig), "--env", requested],
+        ["python3", str(SCRIPT), "assert", "--kubeconfig", str(kubeconfig), "--env", requested, "--cluster", "cube"],
         cwd=REPO_ROOT,
         env=env,
         text=True,
@@ -124,6 +124,28 @@ def test_cluster_identity_mixed_cluster_labels_fail_closed(tmp_path: Path) -> No
     assert "mixed or ambiguous sugarkube.cluster" in result.stderr
 
 
+def test_cluster_identity_unexpected_cluster_label_fails_closed(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _kubectl(bin_dir)
+    kubeconfig = tmp_path / "config"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["STUB_NODES"] = "staging"
+    result = subprocess.run(
+        ["python3", str(SCRIPT), "assert", "--kubeconfig", str(kubeconfig), "--env", "staging", "--cluster", "other-cube"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "expected cluster=other-cube" in result.stderr
+    assert "cluster=cube" in result.stderr
+
+
 def test_cluster_identity_malformed_label_structure_fails_without_traceback(tmp_path: Path) -> None:
     result = _run(tmp_path, "staging", "malformed-labels")
     assert result.returncode != 0
@@ -155,6 +177,26 @@ def test_cluster_identity_detect_prints_details(tmp_path: Path) -> None:
     assert "Nodes: sugarkube3, sugarkube4" in result.stdout
     assert "Context: sugar-prod" in result.stdout
     assert "Server: https://127.0.0.1:6443" in result.stdout
+
+
+def test_cluster_identity_assert_requires_cluster(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _kubectl(bin_dir)
+    kubeconfig = tmp_path / "config"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    result = subprocess.run(
+        ["python3", str(SCRIPT), "assert", "--kubeconfig", str(kubeconfig), "--env", "staging"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "assert requires --cluster" in result.stderr
 
 
 def test_cluster_identity_assert_requires_env(tmp_path: Path) -> None:

--- a/tests/test_cluster_identity.py
+++ b/tests/test_cluster_identity.py
@@ -62,7 +62,7 @@ def _run(tmp_path: Path, requested: str, mode: str) -> subprocess.CompletedProce
     env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
     env["STUB_NODES"] = mode
     return subprocess.run(
-        ["python3", str(SCRIPT), "assert", "--kubeconfig", str(kubeconfig), "--env", requested, "--cluster", "cube"],
+        ["python3", str(SCRIPT), "assert", "--kubeconfig", str(kubeconfig), "--env", requested],
         cwd=REPO_ROOT,
         env=env,
         text=True,
@@ -124,28 +124,6 @@ def test_cluster_identity_mixed_cluster_labels_fail_closed(tmp_path: Path) -> No
     assert "mixed or ambiguous sugarkube.cluster" in result.stderr
 
 
-def test_cluster_identity_unexpected_cluster_label_fails_closed(tmp_path: Path) -> None:
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    _kubectl(bin_dir)
-    kubeconfig = tmp_path / "config"
-    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
-    env = os.environ.copy()
-    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
-    env["STUB_NODES"] = "staging"
-    result = subprocess.run(
-        ["python3", str(SCRIPT), "assert", "--kubeconfig", str(kubeconfig), "--env", "staging", "--cluster", "other-cube"],
-        cwd=REPO_ROOT,
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    assert result.returncode != 0
-    assert "expected cluster=other-cube" in result.stderr
-    assert "cluster=cube" in result.stderr
-
-
 def test_cluster_identity_malformed_label_structure_fails_without_traceback(tmp_path: Path) -> None:
     result = _run(tmp_path, "staging", "malformed-labels")
     assert result.returncode != 0
@@ -177,26 +155,6 @@ def test_cluster_identity_detect_prints_details(tmp_path: Path) -> None:
     assert "Nodes: sugarkube3, sugarkube4" in result.stdout
     assert "Context: sugar-prod" in result.stdout
     assert "Server: https://127.0.0.1:6443" in result.stdout
-
-
-def test_cluster_identity_assert_requires_cluster(tmp_path: Path) -> None:
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    _kubectl(bin_dir)
-    kubeconfig = tmp_path / "config"
-    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
-    env = os.environ.copy()
-    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
-    result = subprocess.run(
-        ["python3", str(SCRIPT), "assert", "--kubeconfig", str(kubeconfig), "--env", "staging"],
-        cwd=REPO_ROOT,
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    assert result.returncode != 0
-    assert "assert requires --cluster" in result.stderr
 
 
 def test_cluster_identity_assert_requires_env(tmp_path: Path) -> None:

--- a/tests/test_danielsmith_oci_wrappers.py
+++ b/tests/test_danielsmith_oci_wrappers.py
@@ -43,7 +43,7 @@ exit 0
 set -euo pipefail
 if [[ "$*" == *"get nodes -o json"* ]]; then
   env_label="${SUGARKUBE_STUB_NODE_ENV:-staging}"
-  printf '{"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.env":"%s","sugarkube.cluster":"sugarkube"}}}]}\n' "$env_label"
+  printf '{"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.env":"%s","sugarkube.cluster":"sugar"}}}]}\n' "$env_label"
   exit 0
 fi
 if [[ "$*" == *"config current-context"* ]]; then printf 'sugar-prod\n'; exit 0; fi

--- a/tests/test_danielsmith_oci_wrappers.py
+++ b/tests/test_danielsmith_oci_wrappers.py
@@ -40,6 +40,14 @@ exit 0
     _write_executable(
         bin_dir / "kubectl",
         """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"get nodes -o json"* ]]; then
+  env_label="${SUGARKUBE_STUB_NODE_ENV:-${SUGARKUBE_REQUESTED_ENV:-${SUGARKUBE_ENV:-staging}}}"
+  printf '{"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.env":"%s","sugarkube.cluster":"sugarkube"}}}]}\n' "$env_label"
+  exit 0
+fi
+if [[ "$*" == *"config current-context"* ]]; then printf 'sugar-prod\n'; exit 0; fi
+if [[ "$*" == *"config view"* ]]; then printf 'https://127.0.0.1:6443'; exit 0; fi
 exit 0
 """,
     )
@@ -149,4 +157,16 @@ def test_danielsmith_oci_deploy_rejects_mutable_named_tags(
     assert result.returncode != 0
     assert "mutable tag" in result.stderr
     helm_log_path = Path(danielsmith_oci_stub_env["HELM_LOG"])
+    assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_danielsmith_oci_promote_prod_guard_mismatch_fails_before_helm(
+    danielsmith_oci_stub_env: dict[str, str],
+) -> None:
+    env = danielsmith_oci_stub_env.copy()
+    env["SUGARKUBE_STUB_NODE_ENV"] = "staging"
+    result = _run_just(["danielsmith-oci-promote-prod", "tag=main-deadbee"], env)
+    assert result.returncode != 0
+    assert "requested env=prod" in result.stderr
+    helm_log_path = Path(env["HELM_LOG"])
     assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""

--- a/tests/test_danielsmith_oci_wrappers.py
+++ b/tests/test_danielsmith_oci_wrappers.py
@@ -42,7 +42,7 @@ exit 0
         """#!/usr/bin/env bash
 set -euo pipefail
 if [[ "$*" == *"get nodes -o json"* ]]; then
-  env_label="${SUGARKUBE_STUB_NODE_ENV:-${SUGARKUBE_REQUESTED_ENV:-${SUGARKUBE_ENV:-staging}}}"
+  env_label="${SUGARKUBE_STUB_NODE_ENV:-staging}"
   printf '{"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.env":"%s","sugarkube.cluster":"sugarkube"}}}]}\n' "$env_label"
   exit 0
 fi
@@ -132,6 +132,7 @@ def test_danielsmith_oci_redeploy_normalizes_named_tag(
 def test_danielsmith_oci_promote_prod_normalizes_repeated_named_tag(
     danielsmith_oci_stub_env: dict[str, str],
 ) -> None:
+    danielsmith_oci_stub_env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
     result = _run_just(
         ["danielsmith-oci-promote-prod", "tag=tag=main-deadbee"],
         danielsmith_oci_stub_env,

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2445,6 +2445,76 @@ def test_app_cors_verify_run_curl_defaults_blank_status_and_missing_files(
     assert stderr == ""
 
 @pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize("recipe", ["helm-oci-install", "helm-oci-upgrade"])
+def test_direct_helm_oci_helpers_require_requested_env_before_helm(
+    recipe: str, generic_app_stub_env: dict[str, str]
+) -> None:
+    env = generic_app_stub_env.copy()
+    env.pop("SUGARKUBE_ENV", None)
+    result = _run_just(
+        [
+            recipe,
+            "release=tokenplace",
+            "namespace=tokenplace",
+            "chart=oci://ghcr.io/futuroptimist/charts/tokenplace",
+            "version_file=docs/apps/tokenplace.version",
+        ],
+        env,
+    )
+
+    assert result.returncode != 0
+    assert "env is required for helm-oci-install/helm-oci-upgrade" in result.stderr
+    helm_log_path = Path(env["HELM_LOG"])
+    assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_direct_helm_oci_helper_mismatch_fails_before_any_helm(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODE_ENV"] = "staging"
+    result = _run_just(
+        [
+            "helm-oci-install",
+            "release=tokenplace",
+            "namespace=tokenplace",
+            "chart=oci://ghcr.io/futuroptimist/charts/tokenplace",
+            "version_file=docs/apps/tokenplace.version",
+            "env=prod",
+        ],
+        env,
+    )
+
+    assert result.returncode != 0
+    assert "requested env=prod" in result.stderr
+    helm_log_path = Path(env["HELM_LOG"])
+    assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_direct_helm_oci_helper_matching_env_succeeds(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        [
+            "helm-oci-install",
+            "release=tokenplace",
+            "namespace=tokenplace",
+            "chart=oci://ghcr.io/futuroptimist/charts/tokenplace",
+            "version_file=docs/apps/tokenplace.version",
+            "env=staging",
+        ],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.3" in helm_log
+    assert "upgrade tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace" in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
 def test_app_deploy_guard_mismatch_fails_before_helm(generic_app_stub_env: dict[str, str]) -> None:
     env = generic_app_stub_env.copy()
     env["SUGARKUBE_STUB_NODE_ENV"] = "staging"

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2497,32 +2497,6 @@ def test_direct_helm_oci_helper_mismatch_fails_before_any_helm(
 
 
 @pytest.mark.usefixtures("ensure_just_available")
-def test_direct_helm_oci_helper_cluster_mismatch_fails_before_any_helm(
-    generic_app_stub_env: dict[str, str],
-) -> None:
-    env = generic_app_stub_env.copy()
-    env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
-    env["SUGARKUBE_STUB_CLUSTER"] = "other-sugar"
-    result = _run_just(
-        [
-            "helm-oci-install",
-            "release=tokenplace",
-            "namespace=tokenplace",
-            "chart=oci://ghcr.io/futuroptimist/charts/tokenplace",
-            "version_file=docs/apps/tokenplace.version",
-            "env=prod",
-        ],
-        env,
-    )
-
-    assert result.returncode != 0
-    assert "expected cluster=sugar" in result.stderr
-    assert "cluster=other-sugar" in result.stderr
-    helm_log_path = Path(env["HELM_LOG"])
-    assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
-
-
-@pytest.mark.usefixtures("ensure_just_available")
 def test_direct_helm_oci_helper_matching_env_succeeds(
     generic_app_stub_env: dict[str, str],
 ) -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -64,6 +64,14 @@ fi
         f"""#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> {str(tmp_path / "kubectl.log")!r}
+if [[ "$*" == *"get nodes -o json"* ]]; then
+  env_label="${{SUGARKUBE_STUB_NODE_ENV:-${{SUGARKUBE_REQUESTED_ENV:-${{SUGARKUBE_ENV:-staging}}}}}}"
+  cluster_label="${{SUGARKUBE_STUB_CLUSTER:-sugarkube}}"
+  printf '{{"items":[{{"metadata":{{"name":"sugarkube3","labels":{{"sugarkube.env":"%s","sugarkube.cluster":"%s"}}}}}},{{"metadata":{{"name":"sugarkube4","labels":{{"sugarkube.env":"%s","sugarkube.cluster":"%s"}}}}}}]}}\n' "$env_label" "$cluster_label" "$env_label" "$cluster_label"
+  exit 0
+fi
+if [[ "$*" == *"config current-context"* ]]; then printf 'sugar-prod\n'; exit 0; fi
+if [[ "$*" == *"config view"* ]]; then printf 'https://127.0.0.1:6443'; exit 0; fi
 if [[ "$*" == *"get deploy,statefulset,daemonset"* ]]; then
   printf 'Deployment/danielsmith\n'
   exit 0
@@ -2433,3 +2441,34 @@ def test_app_cors_verify_run_curl_defaults_blank_status_and_missing_files(
     assert headers == {}
     assert body == b""
     assert stderr == ""
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_deploy_guard_mismatch_fails_before_helm(generic_app_stub_env: dict[str, str]) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODE_ENV"] = "staging"
+    result = _run_just(["app-deploy", "app=jobbot3000", "env=prod", "tag=main-deadbee"], env)
+    assert result.returncode != 0
+    assert "requested env=prod" in result.stderr
+    helm_log_path = Path(env["HELM_LOG"])
+    assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_redeploy_guard_staging_requested_prod_detected_fails_before_helm(generic_app_stub_env: dict[str, str]) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
+    result = _run_just(["app-redeploy", "app=jobbot3000", "env=staging", "tag=main-deadbee"], env)
+    assert result.returncode != 0
+    assert "requested env=staging" in result.stderr
+    helm_log_path = Path(env["HELM_LOG"])
+    assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_chart_bump_remains_cluster_independent(generic_app_stub_env: dict[str, str]) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
+    result = _run_just(["app-chart-bump", "app=tokenplace", "version=0.1.3"], env)
+    assert result.returncode == 0, result.stderr + result.stdout
+    kubectl_log = Path(env["HOME"]).parent / "kubectl.log"
+    assert not kubectl_log.exists() or "get nodes" not in kubectl_log.read_text(encoding="utf-8")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -76,6 +76,10 @@ if [[ "$*" == *"get deploy,statefulset,daemonset"* ]]; then
   printf 'Deployment/danielsmith\n'
   exit 0
 fi
+if [[ "$*" == *"get deploy,statefulset"* ]]; then
+  printf 'Deployment/tokenplace\n'
+  exit 0
+fi
 if [[ "$*" == *"get ingress"* && "$*" == *"jsonpath"* ]]; then
   if [ "${{SUGARKUBE_STUB_KUBECTL_INGRESS_FAIL:-}}" = "1" ]; then
     echo 'error: context sugar-staging does not exist' >&2
@@ -2513,6 +2517,110 @@ def test_direct_helm_oci_helper_matching_env_succeeds(
     assert "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.3" in helm_log
     assert "upgrade tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace" in helm_log
 
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize("recipe", ["tokenplace-deploy", "tokenplace-upgrade"])
+def test_tokenplace_compat_wrappers_propagate_explicit_matching_env(
+    recipe: str, generic_app_stub_env: dict[str, str]
+) -> None:
+    result = _run_just(
+        [
+            recipe,
+            "tokenplace",
+            "tokenplace",
+            "oci://ghcr.io/futuroptimist/charts/tokenplace",
+            "docs/examples/tokenplace.values.dev.yaml",
+            "docs/apps/tokenplace.version",
+            "",
+            "main-deadbee",
+            "",
+            "env=staging",
+        ],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "upgrade tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace" in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_tokenplace_rollback_without_requested_env_fails_before_helm(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env.pop("SUGARKUBE_ENV", None)
+    result = _run_just(
+        ["tokenplace-rollback", "tokenplace", "tokenplace", "12"],
+        env,
+    )
+
+    assert result.returncode != 0
+    assert "tokenplace-rollback requires a requested environment" in result.stderr
+    helm_log_path = Path(env["HELM_LOG"])
+    assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_tokenplace_rollback_mismatch_fails_before_helm(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODE_ENV"] = "staging"
+    result = _run_just(
+        [
+            "tokenplace-rollback",
+            "tokenplace",
+            "tokenplace",
+            "12",
+            "env=prod",
+        ],
+        env,
+    )
+
+    assert result.returncode != 0
+    assert "requested env=prod" in result.stderr
+    helm_log_path = Path(env["HELM_LOG"])
+    assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_tokenplace_rollback_matching_env_succeeds(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        [
+            "tokenplace-rollback",
+            "tokenplace",
+            "tokenplace",
+            "12",
+            "env=staging",
+        ],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "-n tokenplace rollback tokenplace 12" in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_tokenplace_rollback_sugarkube_env_invocation_remains_guarded(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_ENV"] = "prod"
+    env["SUGARKUBE_STUB_NODE_ENV"] = "staging"
+    result = _run_just(
+        ["tokenplace-rollback", "tokenplace", "tokenplace", "12"],
+        env,
+    )
+
+    assert result.returncode != 0
+    assert "requested env=prod" in result.stderr
+    helm_log_path = Path(env["HELM_LOG"])
+    assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
 
 @pytest.mark.usefixtures("ensure_just_available")
 def test_app_deploy_guard_mismatch_fails_before_helm(generic_app_stub_env: dict[str, str]) -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -66,7 +66,7 @@ set -euo pipefail
 printf '%s\n' "$*" >> {str(tmp_path / "kubectl.log")!r}
 if [[ "$*" == *"get nodes -o json"* ]]; then
   env_label="${{SUGARKUBE_STUB_NODE_ENV:-staging}}"
-  cluster_label="${{SUGARKUBE_STUB_CLUSTER:-sugarkube}}"
+  cluster_label="${{SUGARKUBE_STUB_CLUSTER:-sugar}}"
   printf '{{"items":[{{"metadata":{{"name":"sugarkube3","labels":{{"sugarkube.env":"%s","sugarkube.cluster":"%s"}}}}}},{{"metadata":{{"name":"sugarkube4","labels":{{"sugarkube.env":"%s","sugarkube.cluster":"%s"}}}}}}]}}\n' "$env_label" "$cluster_label" "$env_label" "$cluster_label"
   exit 0
 fi
@@ -2492,6 +2492,32 @@ def test_direct_helm_oci_helper_mismatch_fails_before_any_helm(
 
     assert result.returncode != 0
     assert "requested env=prod" in result.stderr
+    helm_log_path = Path(env["HELM_LOG"])
+    assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_direct_helm_oci_helper_cluster_mismatch_fails_before_any_helm(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
+    env["SUGARKUBE_STUB_CLUSTER"] = "other-sugar"
+    result = _run_just(
+        [
+            "helm-oci-install",
+            "release=tokenplace",
+            "namespace=tokenplace",
+            "chart=oci://ghcr.io/futuroptimist/charts/tokenplace",
+            "version_file=docs/apps/tokenplace.version",
+            "env=prod",
+        ],
+        env,
+    )
+
+    assert result.returncode != 0
+    assert "expected cluster=sugar" in result.stderr
+    assert "cluster=other-sugar" in result.stderr
     helm_log_path = Path(env["HELM_LOG"])
     assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2472,3 +2472,17 @@ def test_app_chart_bump_remains_cluster_independent(generic_app_stub_env: dict[s
     assert result.returncode == 0, result.stderr + result.stdout
     kubectl_log = Path(env["HOME"]).parent / "kubectl.log"
     assert not kubectl_log.exists() or "get nodes" not in kubectl_log.read_text(encoding="utf-8")
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_promote_prod_guard_mismatch_fails_before_helm(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODE_ENV"] = "staging"
+    result = _run_just(["dspace-oci-promote-prod", "tag=main-deadbee"], env)
+
+    assert result.returncode != 0
+    assert "requested env=prod" in result.stderr
+    helm_log_path = Path(env["HELM_LOG"])
+    assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -65,7 +65,7 @@ fi
 set -euo pipefail
 printf '%s\n' "$*" >> {str(tmp_path / "kubectl.log")!r}
 if [[ "$*" == *"get nodes -o json"* ]]; then
-  env_label="${{SUGARKUBE_STUB_NODE_ENV:-${{SUGARKUBE_REQUESTED_ENV:-${{SUGARKUBE_ENV:-staging}}}}}}"
+  env_label="${{SUGARKUBE_STUB_NODE_ENV:-staging}}"
   cluster_label="${{SUGARKUBE_STUB_CLUSTER:-sugarkube}}"
   printf '{{"items":[{{"metadata":{{"name":"sugarkube3","labels":{{"sugarkube.env":"%s","sugarkube.cluster":"%s"}}}}}},{{"metadata":{{"name":"sugarkube4","labels":{{"sugarkube.env":"%s","sugarkube.cluster":"%s"}}}}}}]}}\n' "$env_label" "$cluster_label" "$env_label" "$cluster_label"
   exit 0
@@ -1228,6 +1228,7 @@ def test_app_promote_prod_delegates_to_prod_deploy_coordinates(
     chart: str,
     generic_app_stub_env: dict[str, str],
 ) -> None:
+    generic_app_stub_env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
     result = _run_just(
         ["app-promote-prod", f"app={app}", "tag=main-deadbee"],
         generic_app_stub_env,
@@ -1310,6 +1311,7 @@ def test_promote_wrappers_preserve_app_specific_output(
     check_heading: str,
     generic_app_stub_env: dict[str, str],
 ) -> None:
+    generic_app_stub_env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
     result = _run_just([recipe, "tag=main-deadbee"], generic_app_stub_env)
 
     assert result.returncode == 0, result.stderr + result.stdout

--- a/tests/test_kubeconfig_recipe.py
+++ b/tests/test_kubeconfig_recipe.py
@@ -45,6 +45,27 @@ if __name__ == "__main__":
     script.chmod(0o755)
 
 
+def _write_fake_kubectl(bin_dir: Path) -> None:
+    script = bin_dir / "kubectl"
+    script.write_text(
+        textwrap.dedent(
+            """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"get nodes -o json"* ]]; then
+  env_label="${SUGARKUBE_STUB_NODE_ENV:-dev}"
+  printf '{"items":[{"metadata":{"name":"sugarkube1","labels":{"sugarkube.env":"%s","sugarkube.cluster":"sugarkube"}}}]}\n' "$env_label"
+  exit 0
+fi
+if [[ "$*" == *"config current-context"* ]]; then printf 'PLACEHOLDER-CONTEXT\n'; exit 0; fi
+if [[ "$*" == *"config view"* ]]; then printf 'https://127.0.0.1:6443'; exit 0; fi
+exit 1
+"""
+        ),
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+
+
 @pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")
 def test_kubeconfig_recipe_scopes_context(tmp_path: Path) -> None:
     home = tmp_path / "home"
@@ -78,6 +99,7 @@ users:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     _write_fake_sudo(bin_dir)
+    _write_fake_kubectl(bin_dir)
 
     env = os.environ.copy()
     env.update(
@@ -109,3 +131,22 @@ users:
     assert "sugar-dev" in contents
     assert "current-context: sugar-dev" in contents
     assert "PLACEHOLDER" not in contents
+
+@pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")
+def test_kubeconfig_env_mismatch_does_not_persist_false_context(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    (home / ".kube").mkdir(parents=True)
+    existing = home / ".kube" / "config"
+    existing.write_text("current-context: sugar-staging\n", encoding="utf-8")
+    source_config = tmp_path / "k3s.yaml"
+    source_config.write_text("apiVersion: v1\nclusters: []\ncontexts: []\nusers: []\n", encoding="utf-8")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_sudo(bin_dir)
+    _write_fake_kubectl(bin_dir)
+    env = os.environ.copy()
+    env.update({"HOME": str(home), "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}", "TEST_K3S_SOURCE": str(source_config), "TEST_SKIP_CHOWN": "1", "SUGARKUBE_STUB_NODE_ENV": "staging"})
+    result = subprocess.run(["just", "--justfile", str(JUSTFILE), "kubeconfig-env", "env=prod"], env=env, capture_output=True, text=True, check=False)
+    assert result.returncode != 0
+    assert "requested env=prod" in result.stderr
+    assert existing.read_text(encoding="utf-8") == "current-context: sugar-staging\n"

--- a/tests/test_kubeconfig_recipe.py
+++ b/tests/test_kubeconfig_recipe.py
@@ -53,7 +53,7 @@ def _write_fake_kubectl(bin_dir: Path) -> None:
 set -euo pipefail
 if [[ "$*" == *"get nodes -o json"* ]]; then
   env_label="${SUGARKUBE_STUB_NODE_ENV:-dev}"
-  printf '{"items":[{"metadata":{"name":"sugarkube1","labels":{"sugarkube.env":"%s","sugarkube.cluster":"sugarkube"}}}]}\n' "$env_label"
+  printf '{"items":[{"metadata":{"name":"sugarkube1","labels":{"sugarkube.env":"%s","sugarkube.cluster":"sugar"}}}]}\n' "$env_label"
   exit 0
 fi
 if [[ "$*" == *"config current-context"* ]]; then printf 'PLACEHOLDER-CONTEXT\n'; exit 0; fi


### PR DESCRIPTION
### Motivation

- Prevent environment-scoped Kubernetes mutations from trusting kubeconfig context names or hostnames and applying values to a cluster whose Kubernetes-reported environment differs from the requested target.
- Fail closed before Helm when cluster identity is unavailable, incomplete, inconsistent, or mismatched.

### What changed

- Added `scripts/cluster_identity.py` to query all nodes through an explicitly supplied kubeconfig, read `sugarkube.env` and `sugarkube.cluster`, normalize legacy `int` to `staging`, and reject API failures, zero nodes, malformed data, missing labels, mixed environments, or mixed cluster labels.
- Added the read-only `cluster-env-detect` recipe and the fail-closed `assert-cluster-env` guard.
- Hardened `kubeconfig-env` by validating a temporary candidate before atomically replacing `~/.kube/config`. Failed validation preserves the existing kubeconfig, and the final context is named from the validated environment.
- Required an explicit requested environment—or deliberately supplied `SUGARKUBE_ENV`—through the shared Helm OCI path and tokenplace deploy, upgrade, and rollback helpers.
- Routed generic app, DSPACE, tokenplace, and danielsmith deployment and promotion paths through the shared guard. Rollback now preserves the active kubeconfig and verifies independent environment intent before `helm rollback`.
- Added deterministic regression coverage and updated the affected deployment, rollback, onboarding, and operator documentation.
- Kept `app-chart-bump` cluster-independent.

### Safety contract and scope

- `sugarkube.env` is the authorization boundary for these environment-scoped commands: the detected environment must match requested `env=dev|staging|prod` before Helm runs.
- `sugarkube.cluster` must be present and unanimous across all nodes and is included in diagnostics. Supported mutation recipes do not accept an independently requested cluster identifier, so this PR does not attempt to distinguish separate physical clusters intentionally carrying the same environment label. That would require a new expected-cluster interface and separate design.
- Kubeconfig context names and hostnames remain display or routing conveniences and are never identity sources.
- Missing environment intent, Kubernetes/API failure, zero nodes, missing or malformed labels, mixed labels, and requested/detected environment mismatches all fail closed without invoking Helm.

### Compatibility

- `helm-oci-install`, `helm-oci-upgrade`, `tokenplace-deploy`, `tokenplace-upgrade`, and `tokenplace-rollback` now require `env=dev|staging|prod` or a deliberately exported `SUGARKUBE_ENV`.
- Legacy `int` continues to normalize to `staging`.
- Existing higher-level app and compatibility wrappers pass their requested environment explicitly.
- `app-chart-bump` remains unchanged and requires no cluster access.

### Verification

Passed focused verification:

- `python3 -m pytest -q tests/test_cluster_identity.py tests/test_kubeconfig_recipe.py tests/test_generic_app_just_recipes.py tests/test_danielsmith_oci_wrappers.py`
- `./scripts/test-helm-oci-install.sh`
- `just --unstable --fmt --check`
- `git diff --check`
- `git diff --cached | ./scripts/scan-secrets.py`

All latest-head GitHub Actions workflows completed successfully: `Verify Justfile formatting`, `Spellcheck`, `Docs`, `pi-image`, `Test Suite`, and `ci`.

The Codex task environment did not provide the standalone `pre-commit`, `pyspelling`, or `linkchecker` executables.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a617a9da0fc832f84ebf05f4e452b74)