### PR TITLE
Guard Helm mutations by cluster node identity

### DIFF
--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -512,7 +512,22 @@ just kubeconfig-env env=dev
 ```
 
 **What you should see:** This creates `~/.kube/config` with the context renamed to
-`sugar-dev`, allowing you to run kubectl commands from your local machine.
+`sugar-dev`, allowing you to run kubectl commands from your local machine. The
+context name is only a display/scoping convenience: Sugarkube treats the
+`sugarkube.env` labels on Kubernetes nodes as the authoritative environment
+identity, not the requested `env=`, kubeconfig context, hostname, or ingress
+hostname. `just kubeconfig-env` validates the copied kubeconfig against those
+node labels before replacing an existing `~/.kube/config`, and mutating Helm
+deployment, promotion, redeploy, and environment-scoped rollback commands fail
+closed when node labels are missing, mixed, malformed, or do not match the
+requested environment.
+
+Inspect the connected cluster identity without mutating anything:
+
+```bash
+just cluster-env-detect
+kubectl get nodes -o 'custom-columns=NAME:.metadata.name,CLUSTER:.metadata.labels.sugarkube\.cluster,ENV:.metadata.labels.sugarkube\.env'
+```
 
 Verify workloads across all namespaces:
 

--- a/justfile
+++ b/justfile
@@ -480,12 +480,19 @@ kubeconfig-env env='dev':
     fi
     user="${USER:-$(id -un)}"
     mkdir -p ~/.kube
-    sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-    sudo chown -R "$user":"$user" ~/.kube
+    tmp_config="$(mktemp "${HOME}/.kube/config.candidate.XXXXXX")"
+    cleanup() { rm -f "${tmp_config}" 2>/dev/null || true; }
+    trap cleanup EXIT
+    sudo cp /etc/rancher/k3s/k3s.yaml "${tmp_config}"
+    sudo chown "$user":"$user" "${tmp_config}" 2>/dev/null || true
     chmod 700 ~/.kube
-    chmod 600 ~/.kube/config
-    scope_name="sugar-${env_name}"
-    python3 scripts/update_kubeconfig_scope.py "${HOME}/.kube/config" "${scope_name}"
+    chmod 600 "${tmp_config}"
+    detected_env="$(python3 scripts/cluster_identity.py --kubeconfig "${tmp_config}" --requested-env "${env_name}" --assert-match --mutating)"
+    scope_name="sugar-${detected_env}"
+    python3 scripts/update_kubeconfig_scope.py "${tmp_config}" "${scope_name}"
+    mv "${tmp_config}" "${HOME}/.kube/config"
+    trap - EXIT
+    cleanup
 
 kubeconfig-dev:
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env env=dev
@@ -495,6 +502,16 @@ kubeconfig-staging:
 
 kubeconfig-prod:
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env env=prod
+
+# Read-only: detect authoritative cluster identity from Kubernetes node labels.
+cluster-env-detect kubeconfig='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    kubeconfig_path={{ quote(kubeconfig) }}
+    if [ -z "${kubeconfig_path}" ]; then
+      kubeconfig_path="${KUBECONFIG:-${HOME}/.kube/config}"
+    fi
+    python3 scripts/cluster_identity.py --kubeconfig "${kubeconfig_path}"
 
 origin_cert_guidance := """
   NOTE: cloudflared is still behaving like a locally-managed tunnel (looking for cert.pem / credentials.json).
@@ -1290,6 +1307,14 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     if [ -z "${release}" ] || [ -z "${namespace}" ] || [ -z "${chart}" ]; then
         echo "Set release, namespace, and chart to deploy." >&2
         exit 1
+    fi
+
+    if [ -n "${SUGARKUBE_ENV:-}" ]; then
+        python3 "{{ justfile_directory() }}/scripts/cluster_identity.py" \
+          --kubeconfig "${KUBECONFIG}" \
+          --requested-env "${SUGARKUBE_ENV}" \
+          --assert-match \
+          --mutating >/dev/null
     fi
 
     chart_version="${version}"
@@ -2315,7 +2340,7 @@ tokenplace-upgrade release='tokenplace' namespace='tokenplace' chart='oci://ghcr
       release='{{ release }}' namespace='{{ namespace }}' chart='{{ chart }}' values='{{ values }}' \
       version_file='{{ version_file }}' version='{{ version }}' tag="${resolved_tag}" default_tag="${resolved_default_tag}"
 
-tokenplace-rollback release='tokenplace' namespace='tokenplace' revision='':
+tokenplace-rollback release='tokenplace' namespace='tokenplace' revision='' env='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -2325,6 +2350,19 @@ tokenplace-rollback release='tokenplace' namespace='tokenplace' revision='':
     fi
     ns='{{ namespace }}'
     release='{{ release }}'
+    env_name='{{ env }}'
+    while [ "${env_name#env=}" != "${env_name}" ]; do
+      env_name="${env_name#env=}"
+    done
+    if [ -n "${env_name}" ]; then
+      [ "${env_name}" = "int" ] && env_name="staging"
+      export KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config}"
+      python3 "{{ justfile_directory() }}/scripts/cluster_identity.py" \
+        --kubeconfig "${KUBECONFIG}" \
+        --requested-env "${env_name}" \
+        --assert-match \
+        --mutating >/dev/null
+    fi
 
     helm -n "${ns}" rollback "${release}" '{{ revision }}'
 

--- a/scripts/cluster_identity.py
+++ b/scripts/cluster_identity.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Detect and assert Sugarkube cluster identity from Kubernetes node labels."""
+from __future__ import annotations
+
+import argparse, json, subprocess, sys
+from typing import Any
+
+VALID_ENVS = {"dev", "staging", "prod"}
+
+
+def norm_env(value: str) -> str:
+    return "staging" if value == "int" else value
+
+
+def run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, text=True, capture_output=True, check=False)
+
+
+def kube(kubeconfig: str, *args: str) -> subprocess.CompletedProcess[str]:
+    return run(["kubectl", "--kubeconfig", kubeconfig, *args])
+
+
+def context_server(kubeconfig: str) -> tuple[str, str]:
+    cp = kube(kubeconfig, "config", "view", "--minify", "-o", "json")
+    if cp.returncode != 0:
+        return ("unknown", "unknown")
+    try:
+        data = json.loads(cp.stdout or "{}")
+        ctx = data.get("current-context") or "unknown"
+        clusters = data.get("clusters") or []
+        server = "unknown"
+        if clusters:
+            server = ((clusters[0] or {}).get("cluster") or {}).get("server") or "unknown"
+        return (ctx, server)
+    except Exception:
+        return ("unknown", "unknown")
+
+
+def fail(msg: str, *, kubeconfig: str, requested: str | None, nodes: list[dict[str, Any]] | None = None, detected: list[str] | None = None, clusters: list[str] | None = None, mutating: bool = False) -> int:
+    ctx, server = context_server(kubeconfig)
+    if requested:
+        print(f"ERROR: requested env={requested}, but {msg}", file=sys.stderr)
+    else:
+        print(f"ERROR: {msg}", file=sys.stderr)
+    if mutating:
+        print("Refusing to run a mutating command.", file=sys.stderr)
+    if detected is not None:
+        print(f"Detected env(s): {', '.join(detected) if detected else '<none>'}", file=sys.stderr)
+    if clusters is not None:
+        print(f"Cluster label(s): {', '.join(clusters) if clusters else '<none>'}", file=sys.stderr)
+    print(f"Kubeconfig: {kubeconfig}", file=sys.stderr)
+    print(f"Context: {ctx}", file=sys.stderr)
+    print(f"Server: {server}", file=sys.stderr)
+    if nodes is not None:
+        names = [str(n.get("metadata", {}).get("name") or "<unnamed>") for n in nodes]
+        print(f"Connected nodes: {', '.join(names) if names else '<none>'}", file=sys.stderr)
+    return 1
+
+
+def detect(kubeconfig: str, requested: str | None, assert_match: bool, mutating: bool) -> int:
+    cp = kube(kubeconfig, "get", "nodes", "-o", "json")
+    if cp.returncode != 0:
+        return fail(f"the Kubernetes API/node query failed: {(cp.stderr or cp.stdout).strip() or 'kubectl failed'}.", kubeconfig=kubeconfig, requested=requested, mutating=mutating)
+    try:
+        nodes = json.loads(cp.stdout).get("items", [])
+    except Exception as exc:
+        return fail(f"kubectl returned malformed node JSON: {exc}.", kubeconfig=kubeconfig, requested=requested, mutating=mutating)
+    if not nodes:
+        return fail("the connected Kubernetes cluster returned zero nodes.", kubeconfig=kubeconfig, requested=requested, nodes=[], mutating=mutating, detected=[], clusters=[])
+    envs: list[str] = []
+    clusters: list[str] = []
+    missing: list[str] = []
+    malformed: list[str] = []
+    for n in nodes:
+        md = n.get("metadata") or {}; labels = md.get("labels") or {}; name = md.get("name") or "<unnamed>"
+        raw = str(labels.get("sugarkube.env") or "").strip()
+        cl = str(labels.get("sugarkube.cluster") or "").strip()
+        if cl and cl not in clusters: clusters.append(cl)
+        if not raw:
+            missing.append(name); continue
+        normal = norm_env(raw)
+        if normal not in VALID_ENVS:
+            malformed.append(f"{name}={raw}"); continue
+        if normal not in envs: envs.append(normal)
+    if missing:
+        return fail(f"node(s) are missing required sugarkube.env labels: {', '.join(missing)}.", kubeconfig=kubeconfig, requested=requested, nodes=nodes, detected=envs, clusters=clusters, mutating=mutating)
+    if malformed:
+        return fail(f"node(s) have malformed sugarkube.env labels: {', '.join(malformed)}.", kubeconfig=kubeconfig, requested=requested, nodes=nodes, detected=envs, clusters=clusters, mutating=mutating)
+    if len(envs) != 1:
+        return fail("the connected Kubernetes cluster has mixed environment labels.", kubeconfig=kubeconfig, requested=requested, nodes=nodes, detected=envs, clusters=clusters, mutating=mutating)
+    detected = envs[0]
+    if assert_match and requested and detected != requested:
+        return fail(f"the connected Kubernetes cluster identifies as env={detected}.", kubeconfig=kubeconfig, requested=requested, nodes=nodes, detected=envs, clusters=clusters, mutating=mutating)
+    print(detected)
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--kubeconfig", required=True)
+    p.add_argument("--requested-env")
+    p.add_argument("--assert-match", action="store_true")
+    p.add_argument("--mutating", action="store_true")
+    a = p.parse_args()
+    req = norm_env(a.requested_env) if a.requested_env else None
+    return detect(a.kubeconfig, req, a.assert_match, a.mutating)
+
+if __name__ == "__main__": sys.exit(main())

--- a/tests/test_danielsmith_oci_wrappers.py
+++ b/tests/test_danielsmith_oci_wrappers.py
@@ -40,6 +40,16 @@ exit 0
     _write_executable(
         bin_dir / "kubectl",
         """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"config view"* ]]; then
+  printf '{"current-context":"sugar-staging","clusters":[{"cluster":{"server":"https://127.0.0.1:6443"}}]}\n'
+  exit 0
+fi
+if [[ "$*" == *"get nodes"* ]]; then
+  node_env="${SUGARKUBE_STUB_NODE_ENV:-${SUGARKUBE_ENV:-staging}}"
+  printf '{"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.cluster":"sugar","sugarkube.env":"%s"}}}]}\n' "$node_env"
+  exit 0
+fi
 exit 0
 """,
     )

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -68,6 +68,31 @@ if [[ "$*" == *"get deploy,statefulset,daemonset"* ]]; then
   printf 'Deployment/danielsmith\n'
   exit 0
 fi
+if [[ "$*" == *"config view"* ]]; then
+  printf '{{"current-context":"sugar-${{SUGARKUBE_CONTEXT_ENV:-staging}}","clusters":[{{"cluster":{{"server":"https://127.0.0.1:6443"}}}}]}}\n'
+  exit 0
+fi
+if [[ "$*" == *"get nodes"* ]]; then
+  if [ "${{SUGARKUBE_STUB_KUBECTL_NODE_FAIL:-}}" = "1" ]; then
+    echo 'api down' >&2
+    exit 1
+  fi
+  if [ "${{SUGARKUBE_STUB_ZERO_NODES:-}}" = "1" ]; then
+    printf '{{"items":[]}}\n'
+    exit 0
+  fi
+  if [ "${{SUGARKUBE_STUB_MISSING_ENV:-}}" = "1" ]; then
+    printf '{{"items":[{{"metadata":{{"name":"sugarkube3","labels":{{"sugarkube.cluster":"sugar"}}}}}}]}}\n'
+    exit 0
+  fi
+  if [ "${{SUGARKUBE_STUB_MIXED_ENV:-}}" = "1" ]; then
+    printf '{{"items":[{{"metadata":{{"name":"sugarkube3","labels":{{"sugarkube.cluster":"sugar","sugarkube.env":"staging"}}}}}},{{"metadata":{{"name":"sugarkube4","labels":{{"sugarkube.cluster":"sugar","sugarkube.env":"prod"}}}}}}]}}\n'
+    exit 0
+  fi
+  node_env="${{SUGARKUBE_STUB_NODE_ENV:-${{SUGARKUBE_ENV:-staging}}}}"
+  printf '{{"items":[{{"metadata":{{"name":"sugarkube3","labels":{{"sugarkube.cluster":"sugar","sugarkube.env":"%s"}}}}}},{{"metadata":{{"name":"sugarkube4","labels":{{"sugarkube.cluster":"sugar","sugarkube.env":"%s"}}}}}}]}}\n' "$node_env" "$node_env"
+  exit 0
+fi
 if [[ "$*" == *"get ingress"* && "$*" == *"jsonpath"* ]]; then
   if [ "${{SUGARKUBE_STUB_KUBECTL_INGRESS_FAIL:-}}" = "1" ]; then
     echo 'error: context sugar-staging does not exist' >&2
@@ -1030,6 +1055,10 @@ def test_app_chart_bump_updates_only_pin_file_in_temp_config(
     assert "git add" in result.stdout
     helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
     assert "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.3" in helm_log
+    kubectl_log_path = Path(env["KUBECTL_LOG"])
+    assert not kubectl_log_path.exists() or "get nodes" not in kubectl_log_path.read_text(
+        encoding="utf-8"
+    )
 
 
 def test_app_chart_bump_refuses_empty_version(generic_app_stub_env: dict[str, str]) -> None:
@@ -1054,6 +1083,81 @@ def test_app_deploy_danielsmith_passes_image_tag(generic_app_stub_env: dict[str,
     assert "-f docs/examples/danielsmith.values.staging.yaml" in helm_log
     assert "--set image.tag=main-deadbee" in helm_log
     assert "--set image.tag=tag=main-deadbee" not in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize(
+    ("requested", "detected"),
+    [("prod", "staging"), ("staging", "prod")],
+)
+def test_app_deploy_cluster_env_mismatch_fails_before_helm(
+    requested: str, detected: str, generic_app_stub_env: dict[str, str]
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODE_ENV"] = detected
+    env["SUGARKUBE_CONTEXT_ENV"] = requested
+
+    result = _run_just(["app-deploy", "app=danielsmith", f"env={requested}", "tag=main-deadbee"], env)
+
+    assert result.returncode != 0
+    assert f"requested env={requested}" in result.stderr
+    assert f"env={detected}" in result.stderr
+    assert "Refusing to run a mutating command" in result.stderr
+    assert "sugarkube3, sugarkube4" in result.stderr
+    assert not Path(env["HELM_LOG"]).exists()
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize(
+    ("flag", "expected"),
+    [
+        ("SUGARKUBE_STUB_ZERO_NODES", "zero nodes"),
+        ("SUGARKUBE_STUB_KUBECTL_NODE_FAIL", "query failed"),
+        ("SUGARKUBE_STUB_MISSING_ENV", "missing required sugarkube.env"),
+        ("SUGARKUBE_STUB_MIXED_ENV", "mixed environment"),
+    ],
+)
+def test_app_deploy_cluster_identity_fail_closed_cases(
+    flag: str, expected: str, generic_app_stub_env: dict[str, str]
+) -> None:
+    env = generic_app_stub_env.copy()
+    env[flag] = "1"
+
+    result = _run_just(["app-deploy", "app=danielsmith", "env=staging", "tag=main-deadbee"], env)
+
+    assert result.returncode != 0
+    assert expected in result.stderr
+    assert not Path(env["HELM_LOG"]).exists()
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_deploy_context_name_cannot_override_node_identity(
+    generic_app_stub_env: dict[str, str]
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_CONTEXT_ENV"] = "prod"
+    env["SUGARKUBE_STUB_NODE_ENV"] = "staging"
+
+    result = _run_just(["app-deploy", "app=danielsmith", "env=prod", "tag=main-deadbee"], env)
+
+    assert result.returncode != 0
+    assert "Context:" in result.stderr
+    assert "env=staging" in result.stderr
+    assert not Path(env["HELM_LOG"]).exists()
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_deploy_legacy_int_node_env_normalizes_to_staging(
+    generic_app_stub_env: dict[str, str]
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODE_ENV"] = "int"
+
+    result = _run_just(["app-deploy", "app=danielsmith", "env=staging", "tag=main-deadbee"], env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "upgrade danielsmith" in helm_log
 
 
 @pytest.mark.usefixtures("ensure_just_available")

--- a/tests/test_kubeconfig_recipe.py
+++ b/tests/test_kubeconfig_recipe.py
@@ -45,6 +45,36 @@ if __name__ == "__main__":
     script.chmod(0o755)
 
 
+def _write_fake_kubectl(bin_dir: Path) -> None:
+    script = bin_dir / "kubectl"
+    script.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"config view"* ]]; then
+  printf '{"current-context":"PLACEHOLDER-CONTEXT","clusters":[{"cluster":{"server":"https://127.0.0.1:6443"}}]}\n'
+  exit 0
+fi
+if [[ "$*" == *"get nodes"* ]]; then
+  env_label="${TEST_NODE_ENV:-dev}"
+  cluster_label="${TEST_NODE_CLUSTER:-sugar}"
+  if [ "${TEST_ZERO_NODES:-0}" = "1" ]; then
+    printf '{"items":[]}\n'
+  elif [ "${TEST_MISSING_NODE_ENV:-0}" = "1" ]; then
+    printf '{"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.cluster":"%s"}}}]}\n' "${cluster_label}"
+  elif [ "${TEST_MIXED_NODE_ENV:-0}" = "1" ]; then
+    printf '{"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.cluster":"%s","sugarkube.env":"staging"}}},{"metadata":{"name":"sugarkube4","labels":{"sugarkube.cluster":"%s","sugarkube.env":"prod"}}}]}\n' "${cluster_label}" "${cluster_label}"
+  else
+    printf '{"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.cluster":"%s","sugarkube.env":"%s"}}},{"metadata":{"name":"sugarkube4","labels":{"sugarkube.cluster":"%s","sugarkube.env":"%s"}}}]}\n' "${cluster_label}" "${env_label}" "${cluster_label}" "${env_label}"
+  fi
+  exit 0
+fi
+exit 0
+""",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+
+
 @pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")
 def test_kubeconfig_recipe_scopes_context(tmp_path: Path) -> None:
     home = tmp_path / "home"
@@ -78,6 +108,7 @@ users:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     _write_fake_sudo(bin_dir)
+    _write_fake_kubectl(bin_dir)
 
     env = os.environ.copy()
     env.update(
@@ -109,3 +140,40 @@ users:
     assert "sugar-dev" in contents
     assert "current-context: sugar-dev" in contents
     assert "PLACEHOLDER" not in contents
+
+
+@pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")
+def test_kubeconfig_env_mismatch_does_not_persist_false_context(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    kube_dir = home / ".kube"
+    kube_dir.mkdir(parents=True)
+    existing = kube_dir / "config"
+    existing.write_text("current-context: sugar-staging\n", encoding="utf-8")
+    source_config = tmp_path / "k3s.yaml"
+    source_config.write_text("apiVersion: v1\nclusters: []\ncontexts: []\nusers: []\n", encoding="utf-8")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_sudo(bin_dir)
+    _write_fake_kubectl(bin_dir)
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            "TEST_K3S_SOURCE": str(source_config),
+            "TEST_SKIP_CHOWN": "1",
+            "TEST_NODE_ENV": "staging",
+        }
+    )
+
+    result = subprocess.run(
+        ["just", "--justfile", str(JUSTFILE), "kubeconfig-env", "env=prod"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "requested env=prod" in result.stderr
+    assert existing.read_text(encoding="utf-8") == "current-context: sugar-staging\n"


### PR DESCRIPTION
### Motivation
- Prevent environment-scoped Kubernetes mutations from being driven by kubeconfig context names or requested `env=` arguments by making node labels the authoritative identity.
- Fail closed on mismatches so production mutations cannot be applied to a staging cluster due to a renamed context or kubeconfig forgery.
- Provide a read-only operator command to inspect the connected cluster identity without mutating state.

### Description
- Add `scripts/cluster_identity.py` to query nodes using an explicit `--kubeconfig`, read `sugarkube.env`/`sugarkube.cluster`, normalize legacy `int` to `staging`, and fail closed on API errors, zero nodes, missing/malformed labels, or mixed environments while emitting actionable diagnostics (requested/detected envs, cluster labels, context/server, and node names).
- Update `kubeconfig-env` to copy the cluster kubeconfig to a temporary candidate file, validate it with `scripts/cluster_identity.py`, rename the context using the detected environment, and atomically move the candidate into `~/.kube/config` only after validation.
- Add a shared guard call into the Helm OCI deploy path to assert requested vs detected environment before any mutating Helm command runs, and add the same guard to environment-scoped rollback wrappers; also add a read-only `just cluster-env-detect` recipe.
- Update docs (`docs/raspi_cluster_operations.md`) to state the invariant (node labels are authoritative) and how to inspect identity, and extend tests/stubs to cover mismatch, missing/mixed/no nodes, API failure, `int` normalization, kubeconfig persistence, wrapper coverage, and absence of Helm logs on guard failures.

### Testing
- Ran the focused regression suite: `python3 -m pytest -q tests/test_kubeconfig_recipe.py tests/test_generic_app_just_recipes.py tests/test_danielsmith_oci_wrappers.py`, which completed with `140 passed, 0 failed` in this environment.
- Ran repository checks: `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` (both succeeded); `pre-commit`, `pyspelling`, and `linkchecker` were not run because the tools are not installed in this execution environment.
- Tests assert guard behavior for mismatches and that Helm logs are absent on guard failures, and the new `kubeconfig-env` test ensures a mismatched candidate kubeconfig does not overwrite an existing valid `~/.kube/config`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a617aa3949c832f80e9d946794fbd64)