### PR TITLE
Guard environment deploys with Kubernetes node identity

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -70,6 +70,37 @@ The current apps map to that model as examples:
 | danielsmith.io | `ghcr.io/futuroptimist/danielsmith.io` | `oci://ghcr.io/futuroptimist/charts/danielsmith` | `danielsmith` | `danielsmith` | `docs/apps/danielsmith.version` | `docs/apps/danielsmith.prod.tag` |
 | jobbot3000 | `ghcr.io/futuroptimist/jobbot3000` | `oci://ghcr.io/futuroptimist/charts/jobbot3000` | `jobbot3000` | `jobbot3000` | `docs/apps/jobbot3000.version` | `docs/apps/jobbot3000.prod.tag` |
 
+
+## Cluster environment identity guard
+
+Sugarkube treats Kubernetes node labels as the authoritative identity for a
+connected physical cluster. Every node returned by the Kubernetes API must carry
+a nonempty `sugarkube.env` label (`dev`, `staging`, or `prod`; legacy `int` is
+normalized to `staging`) and all nodes must agree on one normalized environment.
+The companion `sugarkube.cluster` labels are included in diagnostics so operators
+can confirm which cube they are touching.
+
+Kubeconfig context names such as `sugar-prod` are display and scoping
+conveniences only. They are never trusted as proof that the connected cluster is
+production, and hostname or ingress naming is not used for identity. Before
+`kubeconfig-env` persists a renamed kubeconfig, and immediately before shared
+Helm install/upgrade paths mutate an environment-scoped release, Sugarkube reads
+the node labels from the supplied kubeconfig and fails closed if the API cannot
+be queried, returns zero nodes, has missing or malformed labels, reports mixed
+environments, or reports an environment different from the requested `env=`.
+
+Operators can inspect the detected identity without mutating the cluster with:
+
+```bash
+just cluster-env-detect
+```
+
+The equivalent raw Kubernetes query is:
+
+```bash
+kubectl get nodes -o 'custom-columns=NAME:.metadata.name,CLUSTER:.metadata.labels.sugarkube\.cluster,ENV:.metadata.labels.sugarkube\.env'
+```
+
 ## Standard image tag model
 
 Deployment tags must identify application code and release intent, not mutable

--- a/justfile
+++ b/justfile
@@ -461,7 +461,20 @@ kubeconfig env='':
 kubeconfig-user:
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig
 
-# Copy k3s kubeconfig to ~/.kube/config and rename context for the specified environment.
+# Show the Kubernetes-reported Sugarkube environment identity from node labels.
+cluster-env-detect kubeconfig='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    kubeconfig_input={{ quote(kubeconfig) }}
+    while [ "${kubeconfig_input#kubeconfig=}" != "${kubeconfig_input}" ]; do
+      kubeconfig_input="${kubeconfig_input#kubeconfig=}"
+    done
+    if [ -z "${kubeconfig_input}" ]; then
+      kubeconfig_input="${KUBECONFIG:-${HOME}/.kube/config}"
+    fi
+    python3 "{{ justfile_directory() }}/scripts/cluster_identity.py" --kubeconfig "${kubeconfig_input}"
+
+# Copy k3s kubeconfig to ~/.kube/config and rename context for the verified environment.
 kubeconfig-env env='dev':
     #!/usr/bin/env bash
     set -euo pipefail
@@ -480,12 +493,23 @@ kubeconfig-env env='dev':
     fi
     user="${USER:-$(id -un)}"
     mkdir -p ~/.kube
-    sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-    sudo chown -R "$user":"$user" ~/.kube
+    tmp_config="$(mktemp "${HOME}/.kube/config.candidate.XXXXXX")"
+    cleanup() { rm -f "${tmp_config}"; }
+    trap cleanup EXIT
+    sudo cp /etc/rancher/k3s/k3s.yaml "${tmp_config}"
+    sudo chown "$user":"$user" "${tmp_config}" 2>/dev/null || true
     chmod 700 ~/.kube
-    chmod 600 ~/.kube/config
-    scope_name="sugar-${env_name}"
-    python3 scripts/update_kubeconfig_scope.py "${HOME}/.kube/config" "${scope_name}"
+    chmod 600 "${tmp_config}"
+    detect_output="$(python3 "{{ justfile_directory() }}/scripts/cluster_identity.py" --kubeconfig "${tmp_config}" --request-env "${env_name}" --assert-env)"
+    detected_env="$(echo "${detect_output}" | sed -n "s/^env=//p" | head -n 1)"
+    if [ -z "${detected_env}" ]; then
+      echo "ERROR: cluster identity detector did not return an environment." >&2
+      exit 1
+    fi
+    scope_name="sugar-${detected_env}"
+    python3 "{{ justfile_directory() }}/scripts/update_kubeconfig_scope.py" "${tmp_config}" "${scope_name}"
+    mv "${tmp_config}" "${HOME}/.kube/config"
+    trap - EXIT
 
 kubeconfig-dev:
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env env=dev
@@ -1321,6 +1345,10 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     echo 'NOTE: chart pins are explicit. `tag=...` changes only the image tag.'
     printf 'Run `just app-chart-status app=%s` before release deploys to check for newer published chart versions.\n' "${release}"
     printf 'Use `just app-chart-bump app=%s version=<version>` to intentionally update %s.\n' "${release}" "${version_file:-docs/apps/${release}.version}"
+    if [ -n "${SUGARKUBE_ENV:-}" ]; then
+      python3 "{{ justfile_directory() }}/scripts/cluster_identity.py" --kubeconfig "${KUBECONFIG}" --request-env "${SUGARKUBE_ENV}" --assert-env >/dev/null
+    fi
+
     if [ -n "${chart_version}" ]; then
       helm show chart "${chart}" --version "${chart_version}" >/dev/null
     fi
@@ -1806,6 +1834,7 @@ dspace-oci-deploy env='staging' tag='':
       export KUBECONFIG="${HOME}/.kube/config"
     fi
 
+    export SUGARKUBE_ENV="${env_name}"
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='dspace' namespace='dspace' \
       chart='oci://ghcr.io/democratizedspace/charts/dspace' \
@@ -2447,6 +2476,7 @@ danielsmith-oci-deploy env='staging' tag='':
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
 
+    export SUGARKUBE_ENV="${env_name}"
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release='danielsmith' namespace='danielsmith' \
       chart='oci://ghcr.io/futuroptimist/charts/danielsmith' \
@@ -2559,6 +2589,7 @@ danielsmith-oci-redeploy env='staging' tag='':
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${env_name}"
 
+    export SUGARKUBE_ENV="${env_name}"
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release='danielsmith' namespace='danielsmith' \
       chart='oci://ghcr.io/futuroptimist/charts/danielsmith' \

--- a/scripts/cluster_identity.py
+++ b/scripts/cluster_identity.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Detect and assert Sugarkube cluster identity from Kubernetes node labels."""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import Counter
+from typing import Any
+
+VALID_ENVS = {"dev", "staging", "prod", "int"}
+
+
+def normalize_env(value: str) -> str:
+    return "staging" if value == "int" else value
+
+
+def run_kubectl(kubeconfig: str | None) -> tuple[int, str, str, list[str]]:
+    cmd = ["kubectl"]
+    if kubeconfig:
+        cmd.extend(["--kubeconfig", kubeconfig])
+    cmd.extend(["get", "nodes", "-o", "json"])
+    proc = subprocess.run(cmd, text=True, capture_output=True, check=False)
+    return proc.returncode, proc.stdout, proc.stderr, cmd
+
+
+def kube_context(kubeconfig: str | None) -> str:
+    cmd = ["kubectl"]
+    if kubeconfig:
+        cmd.extend(["--kubeconfig", kubeconfig])
+    cmd.extend(["config", "current-context"])
+    proc = subprocess.run(cmd, text=True, capture_output=True, check=False)
+    return proc.stdout.strip() if proc.returncode == 0 else "unknown"
+
+
+def kube_server(kubeconfig: str | None) -> str:
+    cmd = ["kubectl"]
+    if kubeconfig:
+        cmd.extend(["--kubeconfig", kubeconfig])
+    cmd.extend(["config", "view", "--minify", "-o", "jsonpath={.clusters[0].cluster.server}"])
+    proc = subprocess.run(cmd, text=True, capture_output=True, check=False)
+    return proc.stdout.strip() if proc.returncode == 0 else "unknown"
+
+
+def fail(message: str) -> int:
+    print(message, file=sys.stderr)
+    return 1
+
+
+def load_nodes(kubeconfig: str | None) -> tuple[int, list[dict[str, Any]] | None, str]:
+    code, out, err, cmd = run_kubectl(kubeconfig)
+    if code != 0:
+        return code, None, f"kubectl failed ({' '.join(cmd)}): {err.strip() or out.strip()}"
+    try:
+        doc = json.loads(out)
+    except json.JSONDecodeError as exc:
+        return 1, None, f"kubectl returned malformed node JSON: {exc}"
+    items = doc.get("items")
+    if not isinstance(items, list):
+        return 1, None, "kubectl node JSON did not contain an items list"
+    return 0, items, ""
+
+
+def inspect(kubeconfig: str | None) -> tuple[int, dict[str, Any] | None, str]:
+    code, nodes, err = load_nodes(kubeconfig)
+    context = kube_context(kubeconfig)
+    server = kube_server(kubeconfig)
+    if code != 0 or nodes is None:
+        return 1, None, f"ERROR: unable to detect Sugarkube cluster identity.\nContext: {context}\nServer: {server}\n{err}"
+    if not nodes:
+        return 1, None, f"ERROR: unable to detect Sugarkube cluster identity: Kubernetes API returned zero nodes.\nContext: {context}\nServer: {server}"
+
+    names: list[str] = []
+    envs_raw: list[str] = []
+    clusters: list[str] = []
+    missing: list[str] = []
+    malformed: list[str] = []
+    for node in nodes:
+        meta = node.get("metadata", {}) if isinstance(node, dict) else {}
+        name = str(meta.get("name") or "<unnamed>")
+        labels = meta.get("labels", {}) if isinstance(meta, dict) else {}
+        env = str(labels.get("sugarkube.env") or "").strip()
+        cluster = str(labels.get("sugarkube.cluster") or "").strip()
+        names.append(name)
+        if cluster:
+            clusters.append(cluster)
+        if not env:
+            missing.append(name)
+            continue
+        envs_raw.append(env)
+        if env not in VALID_ENVS:
+            malformed.append(f"{name}={env}")
+
+    if missing:
+        return 1, None, f"ERROR: node(s) missing nonempty sugarkube.env label: {', '.join(missing)}.\nConnected nodes: {', '.join(names)}\nCluster labels: {', '.join(sorted(set(clusters))) or '<none>'}\nContext: {context}\nServer: {server}"
+    if malformed:
+        return 1, None, f"ERROR: malformed sugarkube.env label(s): {', '.join(malformed)}. Expected dev|staging|prod (legacy int normalizes to staging).\nConnected nodes: {', '.join(names)}\nContext: {context}\nServer: {server}"
+    envs = [normalize_env(v) for v in envs_raw]
+    unique_envs = sorted(set(envs))
+    if len(unique_envs) != 1:
+        counts = ", ".join(f"{env}={count}" for env, count in sorted(Counter(envs).items()))
+        return 1, None, f"ERROR: connected Kubernetes cluster has mixed sugarkube.env labels after normalization: {counts}.\nConnected nodes: {', '.join(names)}\nCluster labels: {', '.join(sorted(set(clusters))) or '<none>'}\nContext: {context}\nServer: {server}"
+    return 0, {"env": unique_envs[0], "raw_envs": sorted(set(envs_raw)), "clusters": sorted(set(clusters)), "nodes": names, "context": context, "server": server}, ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--kubeconfig", default=None)
+    parser.add_argument("--request-env", default=None)
+    parser.add_argument("--assert-env", action="store_true")
+    args = parser.parse_args()
+    requested = normalize_env((args.request_env or "").strip()) if args.request_env else ""
+    if requested and requested not in {"dev", "staging", "prod"}:
+        return fail("ERROR: requested env must be dev|staging|prod (legacy int is accepted as staging).")
+    code, info, err = inspect(args.kubeconfig)
+    if code != 0 or info is None:
+        return fail(err)
+    if args.assert_env and requested != info["env"]:
+        return fail(
+            f"ERROR: requested env={requested}, but the connected Kubernetes cluster identifies as env={info['env']}.\n"
+            "Refusing to run a mutating command.\n"
+            f"Detected raw env label(s): {', '.join(info['raw_envs'])}\n"
+            f"Cluster label(s): {', '.join(info['clusters']) or '<none>'}\n"
+            f"Context: {info['context']}\nServer: {info['server']}\n"
+            f"Connected nodes: {', '.join(info['nodes'])}"
+        )
+    print(f"env={info['env']}")
+    print(f"raw_envs={','.join(info['raw_envs'])}")
+    print(f"clusters={','.join(info['clusters']) or '<none>'}")
+    print(f"context={info['context']}")
+    print(f"server={info['server']}")
+    print(f"nodes={','.join(info['nodes'])}")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_danielsmith_oci_wrappers.py
+++ b/tests/test_danielsmith_oci_wrappers.py
@@ -40,6 +40,14 @@ exit 0
     _write_executable(
         bin_dir / "kubectl",
         """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"config current-context"* ]]; then printf 'sugar-staging\n'; exit 0; fi
+if [[ "$*" == *"config view"* ]]; then printf 'https://127.0.0.1:6443'; exit 0; fi
+if [[ "$*" == *"get nodes"* ]]; then
+  env_label="${SUGARKUBE_STUB_NODE_ENV:-staging}"
+  printf '{"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.cluster":"sugar","sugarkube.env":"%s"}}}]}\n' "$env_label"
+  exit 0
+fi
 exit 0
 """,
     )
@@ -124,13 +132,15 @@ def test_danielsmith_oci_redeploy_normalizes_named_tag(
 def test_danielsmith_oci_promote_prod_normalizes_repeated_named_tag(
     danielsmith_oci_stub_env: dict[str, str],
 ) -> None:
+    env = danielsmith_oci_stub_env.copy()
+    env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
     result = _run_just(
         ["danielsmith-oci-promote-prod", "tag=tag=main-deadbee"],
-        danielsmith_oci_stub_env,
+        env,
     )
 
     assert result.returncode == 0, result.stderr + result.stdout
-    helm_log = Path(danielsmith_oci_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
     assert "--set image.tag=main-deadbee" in helm_log
     assert "--set image.tag=tag=main-deadbee" not in helm_log
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -64,6 +64,30 @@ fi
         f"""#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> {str(tmp_path / "kubectl.log")!r}
+if [[ "$*" == *"config current-context"* ]]; then
+  printf '%s\n' "${{SUGARKUBE_STUB_CONTEXT:-sugar-staging}}"
+  exit 0
+fi
+if [[ "$*" == *"config view"* ]]; then
+  printf '%s' "${{SUGARKUBE_STUB_SERVER:-https://127.0.0.1:6443}}"
+  exit 0
+fi
+if [[ "$*" == *"get nodes"* ]]; then
+  case "${{SUGARKUBE_STUB_NODES_MODE:-staging}}" in
+    none) printf '{{"items":[]}}\n' ;;
+    fail) echo 'api unavailable' >&2; exit 42 ;;
+    missing) printf '{{"items":[{{"metadata":{{"name":"sugarkube3","labels":{{"sugarkube.cluster":"sugar"}}}}}}]}}\n' ;;
+    mixed) printf '{{"items":[{{"metadata":{{"name":"sugarkube3","labels":{{"sugarkube.cluster":"sugar","sugarkube.env":"staging"}}}}}},{{"metadata":{{"name":"sugarkube4","labels":{{"sugarkube.cluster":"sugar","sugarkube.env":"prod"}}}}}}]}}\n' ;;
+    int) env_label='int' ;;
+    prod) env_label='prod' ;;
+    dev) env_label='dev' ;;
+    *) env_label='staging' ;;
+  esac
+  if [ -n "${{env_label:-}}" ]; then
+    printf '{{"items":[{{"metadata":{{"name":"sugarkube3","labels":{{"sugarkube.cluster":"sugar","sugarkube.env":"%s"}}}}}},{{"metadata":{{"name":"sugarkube4","labels":{{"sugarkube.cluster":"sugar","sugarkube.env":"%s"}}}}}}]}}\n' "$env_label" "$env_label"
+  fi
+  exit 0
+fi
 if [[ "$*" == *"get deploy,statefulset,daemonset"* ]]; then
   printf 'Deployment/danielsmith\n'
   exit 0
@@ -1220,13 +1244,16 @@ def test_app_promote_prod_delegates_to_prod_deploy_coordinates(
     chart: str,
     generic_app_stub_env: dict[str, str],
 ) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODES_MODE"] = "prod"
+    env["SUGARKUBE_STUB_CONTEXT"] = "sugar-prod"
     result = _run_just(
         ["app-promote-prod", f"app={app}", "tag=main-deadbee"],
-        generic_app_stub_env,
+        env,
     )
 
     assert result.returncode == 0, result.stderr + result.stdout
-    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
     assert f"upgrade {release} {chart}" in helm_log
     assert f"--namespace {namespace}" in helm_log
     assert f"-f docs/examples/{app}.values.dev.yaml" in helm_log
@@ -1302,12 +1329,15 @@ def test_promote_wrappers_preserve_app_specific_output(
     check_heading: str,
     generic_app_stub_env: dict[str, str],
 ) -> None:
-    result = _run_just([recipe, "tag=main-deadbee"], generic_app_stub_env)
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODES_MODE"] = "prod"
+    env["SUGARKUBE_STUB_CONTEXT"] = "sugar-prod"
+    result = _run_just([recipe, "tag=main-deadbee"], env)
 
     assert result.returncode == 0, result.stderr + result.stdout
     assert image_heading in result.stdout
     assert check_heading in result.stdout
-    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
     assert "--set image.tag=main-deadbee" in helm_log
     assert "--set image.tag=tag=main-deadbee" not in helm_log
 
@@ -2433,3 +2463,90 @@ def test_app_cors_verify_run_curl_defaults_blank_status_and_missing_files(
     assert headers == {}
     assert body == b""
     assert stderr == ""
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize(
+    ("requested_env", "node_mode"),
+    [("prod", "staging"), ("staging", "prod")],
+)
+def test_app_deploy_cluster_identity_mismatch_fails_before_helm(
+    requested_env: str, node_mode: str, generic_app_stub_env: dict[str, str]
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODES_MODE"] = node_mode
+    env["SUGARKUBE_STUB_CONTEXT"] = f"sugar-{requested_env}"
+
+    result = _run_just(["app-deploy", "app=danielsmith", f"env={requested_env}", "tag=main-deadbee"], env)
+
+    assert result.returncode != 0
+    assert f"requested env={requested_env}" in result.stderr
+    helm_log = Path(env["HELM_LOG"])
+    assert not helm_log.exists() or "upgrade" not in helm_log.read_text(encoding="utf-8")
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize("node_mode", ["none", "fail", "missing", "mixed"])
+def test_app_deploy_cluster_identity_failures_are_fail_closed_before_helm(
+    node_mode: str, generic_app_stub_env: dict[str, str]
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODES_MODE"] = node_mode
+
+    result = _run_just(["app-deploy", "app=danielsmith", "env=staging", "tag=main-deadbee"], env)
+
+    assert result.returncode != 0
+    helm_log = Path(env["HELM_LOG"])
+    assert not helm_log.exists() or "upgrade" not in helm_log.read_text(encoding="utf-8")
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_deploy_legacy_int_node_env_normalizes_to_staging(
+    generic_app_stub_env: dict[str, str]
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODES_MODE"] = "int"
+
+    result = _run_just(["app-deploy", "app=danielsmith", "env=staging", "tag=main-deadbee"], env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "upgrade danielsmith" in Path(env["HELM_LOG"]).read_text(encoding="utf-8")
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_context_name_cannot_override_node_label_identity(generic_app_stub_env: dict[str, str]) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODES_MODE"] = "staging"
+    env["SUGARKUBE_STUB_CONTEXT"] = "sugar-prod"
+
+    result = _run_just(["app-deploy", "app=danielsmith", "env=prod", "tag=main-deadbee"], env)
+
+    assert result.returncode != 0
+    assert "identifies as env=staging" in result.stderr
+    helm_log = Path(env["HELM_LOG"])
+    assert not helm_log.exists() or "upgrade" not in helm_log.read_text(encoding="utf-8")
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_compatibility_wrapper_cannot_bypass_cluster_identity_guard(
+    generic_app_stub_env: dict[str, str]
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODES_MODE"] = "staging"
+
+    result = _run_just(["danielsmith-oci-promote-prod", "tag=main-deadbee"], env)
+
+    assert result.returncode != 0
+    assert "requested env=prod" in result.stderr
+    helm_log = Path(env["HELM_LOG"])
+    assert not helm_log.exists() or "upgrade" not in helm_log.read_text(encoding="utf-8")
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_chart_bump_remains_cluster_independent(generic_app_stub_env: dict[str, str]) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODES_MODE"] = "fail"
+
+    result = _run_just(["app-chart-bump", "app=tokenplace", "version=0.1.3"], env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.3" in Path(env["HELM_LOG"]).read_text(encoding="utf-8")

--- a/tests/test_kubeconfig_recipe.py
+++ b/tests/test_kubeconfig_recipe.py
@@ -78,6 +78,23 @@ users:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     _write_fake_sudo(bin_dir)
+    kubectl = bin_dir / "kubectl"
+    kubectl.write_text(
+        textwrap.dedent(
+            """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"config current-context"* ]]; then printf 'PLACEHOLDER-CONTEXT\n'; exit 0; fi
+if [[ "$*" == *"config view"* ]]; then printf 'https://127.0.0.1:6443'; exit 0; fi
+if [[ "$*" == *"get nodes"* ]]; then
+  printf '{"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.cluster":"sugar","sugarkube.env":"dev"}}}]}\n'
+  exit 0
+fi
+exit 1
+"""
+        ),
+        encoding="utf-8",
+    )
+    kubectl.chmod(0o755)
 
     env = os.environ.copy()
     env.update(
@@ -109,3 +126,35 @@ users:
     assert "sugar-dev" in contents
     assert "current-context: sugar-dev" in contents
     assert "PLACEHOLDER" not in contents
+
+@pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")
+def test_kubeconfig_env_mismatch_does_not_persist_false_context(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    (home / ".kube").mkdir(parents=True)
+    existing = home / ".kube" / "config"
+    existing.write_text("current-context: sugar-staging\n", encoding="utf-8")
+    source_config = tmp_path / "k3s.yaml"
+    source_config.write_text("apiVersion: v1\nclusters: []\ncontexts: []\nusers: []\n", encoding="utf-8")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_sudo(bin_dir)
+    kubectl = bin_dir / "kubectl"
+    kubectl.write_text("""#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"config current-context"* ]]; then printf 'sugar-prod\n'; exit 0; fi
+if [[ "$*" == *"config view"* ]]; then printf 'https://127.0.0.1:6443'; exit 0; fi
+if [[ "$*" == *"get nodes"* ]]; then
+  printf '{"items":[{"metadata":{"name":"sugarkube3","labels":{"sugarkube.cluster":"sugar","sugarkube.env":"staging"}}}]}\n'
+  exit 0
+fi
+exit 1
+""", encoding="utf-8")
+    kubectl.chmod(0o755)
+    env = os.environ.copy()
+    env.update({"HOME": str(home), "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}", "TEST_K3S_SOURCE": str(source_config), "TEST_SKIP_CHOWN": "1"})
+
+    result = subprocess.run(["just", "--justfile", str(JUSTFILE), "kubeconfig-env", "env=prod"], env=env, capture_output=True, text=True, check=False)
+
+    assert result.returncode != 0
+    assert "requested env=prod" in result.stderr
+    assert existing.read_text(encoding="utf-8") == "current-context: sugar-staging\n"


### PR DESCRIPTION
### Motivation
- Prevent accidental mutating operations against the wrong physical cluster when kubeconfig/context names (for example `sugar-prod`) are misleading by making Kubernetes-reported node labels the single source of truth for environment identity.
- Fail closed on any ambiguity (API failure, zero nodes, missing/malformed labels, mixed envs) so production mutations cannot be accidentally executed against staging/dev.

### Description
- Add `scripts/cluster_identity.py`, a reusable detector/assertion that queries `kubectl get nodes -o json`, reads `sugarkube.env` and `sugarkube.cluster`, normalizes legacy `int` to `staging`, and emits actionable diagnostics or fails nonzero on errors.
- Add a read-only `just` command `cluster-env-detect` that invokes the detector for operator inspection without mutation.
- Harden `kubeconfig-env` so it copies k3s kubeconfig to a temporary candidate, validates the candidate with the detector (using `--request-env`/`--assert-env`), and only persists/renames the context from the validated environment; this prevents persisting a falsely scoped kubeconfig on mismatch.
- Add defense-in-depth before Helm mutations by asserting cluster identity in the shared `_helm-oci-deploy` path so `app-deploy`, `app-redeploy`, `app-promote-prod`, and compatibility wrappers cannot bypass the guard.
- Update documentation (`docs/app_deployment_contract.md`) to record the invariant (node labels authoritative, context names non-authoritative, `just cluster-env-detect` example).
- Add regression tests to `tests/` exercising mismatches, legacy `int` normalization, no-nodes/API failure/missing/mixed label cases, kubeconfig persistence safety, wrapper coverage, and verifying `app-chart-bump` remains cluster-independent.

### Testing
- Ran the focused test set: `python3 -m pytest -q tests/test_kubeconfig_recipe.py tests/test_generic_app_just_recipes.py tests/test_danielsmith_oci_wrappers.py`, which completed successfully with all tests passing (`142 passed`).
- Ran repository checks: `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` (both passed for the staged changes).
- Repo tooling unavailable in this environment: `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` were not run because the corresponding binaries are not installed in the container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a617aaa0af4832fa04b01df1169d861)