### PR TITLE
Allow env=<value> syntax for assert-cluster-env (normalize before assert)

### DIFF
--- a/justfile
+++ b/justfile
@@ -508,11 +508,24 @@ cluster-env-detect kubeconfig='':
 assert-cluster-env env kubeconfig='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
+    env_input={{ quote(env) }}
+    env_name="${env_input}"
+    while [ "${env_name#env=}" != "${env_name}" ]; do
+        env_name="${env_name#env=}"
+    done
+    if [ -z "${env_name}" ]; then
+        printf 'ERROR: env must not be empty. Use env=dev|staging|prod.\n' >&2
+        exit 1
+    fi
+    if [ "${env_name}" = "int" ]; then
+        printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
+        env_name="staging"
+    fi
     kubeconfig_path={{ quote(kubeconfig) }}
     if [ -z "${kubeconfig_path}" ]; then
       kubeconfig_path="${KUBECONFIG:-${HOME}/.kube/config}"
     fi
-    python3 scripts/cluster_identity.py assert --kubeconfig "${kubeconfig_path}" --env {{ quote(env) }}
+    python3 scripts/cluster_identity.py assert --kubeconfig "${kubeconfig_path}" --env "${env_name}"
 
 kubeconfig-dev:
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env env=dev

--- a/tests/test_kubeconfig_recipe.py
+++ b/tests/test_kubeconfig_recipe.py
@@ -150,3 +150,122 @@ def test_kubeconfig_env_mismatch_does_not_persist_false_context(tmp_path: Path) 
     assert result.returncode != 0
     assert "requested env=prod" in result.stderr
     assert existing.read_text(encoding="utf-8") == "current-context: sugar-staging\n"
+
+
+@pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")
+@pytest.mark.parametrize("requested", ["prod", "env=prod", "staging", "env=staging"])
+def test_assert_cluster_env_accepts_positional_and_env_prefix(
+    tmp_path: Path, requested: str
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_kubectl(bin_dir)
+    kubeconfig = tmp_path / "config"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    expected_env = requested.removeprefix("env=")
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            "KUBECONFIG": str(kubeconfig),
+            "SUGARKUBE_STUB_NODE_ENV": expected_env,
+        }
+    )
+
+    result = subprocess.run(
+        ["just", "--justfile", str(JUSTFILE), "assert-cluster-env", requested],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == expected_env
+
+
+@pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")
+def test_assert_cluster_env_prefixed_mismatch_fails_closed(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_kubectl(bin_dir)
+    kubeconfig = tmp_path / "config"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            "KUBECONFIG": str(kubeconfig),
+            "SUGARKUBE_STUB_NODE_ENV": "staging",
+        }
+    )
+
+    result = subprocess.run(
+        ["just", "--justfile", str(JUSTFILE), "assert-cluster-env", "env=prod"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "requested env=prod" in result.stderr
+    assert "env=staging" in result.stderr
+
+
+@pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")
+@pytest.mark.parametrize("requested", ["qa", "env=qa", "env="])
+def test_assert_cluster_env_invalid_values_remain_rejected(
+    tmp_path: Path, requested: str
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_kubectl(bin_dir)
+    kubeconfig = tmp_path / "config"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    env = os.environ.copy()
+    env.update(
+        {"PATH": f"{bin_dir}{os.pathsep}{env['PATH']}", "KUBECONFIG": str(kubeconfig)}
+    )
+
+    result = subprocess.run(
+        ["just", "--justfile", str(JUSTFILE), "assert-cluster-env", requested],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "env must" in result.stderr
+
+
+@pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")
+def test_assert_cluster_env_legacy_int_normalization_remains_supported(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_kubectl(bin_dir)
+    kubeconfig = tmp_path / "config"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            "KUBECONFIG": str(kubeconfig),
+            "SUGARKUBE_STUB_NODE_ENV": "staging",
+        }
+    )
+
+    result = subprocess.run(
+        ["just", "--justfile", str(JUSTFILE), "assert-cluster-env", "int"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "staging"
+    assert 'env name "int" is deprecated' in result.stderr


### PR DESCRIPTION
### Motivation
- Make the `assert-cluster-env` Just recipe accept the repository’s conventional `env=<value>` form as well as the existing positional form to avoid passing the literal `env=...` string to `scripts/cluster_identity.py`.
- Follow the established normalization pattern used by nearby recipes so behavior is consistent across recipes and legacy `int` normalization remains supported.

### Description
- Updated the `assert-cluster-env` recipe in `justfile` to copy the same `env=` prefix-stripping loop used elsewhere, validate the normalized value is non-empty, map legacy `int` → `staging`, and pass the stripped `env_name` to `scripts/cluster_identity.py`.
- Added focused regression tests in `tests/test_kubeconfig_recipe.py` that exercise positional and `env=` forms, a prefixed mismatch failing closed, invalid-value rejection, and legacy `int` normalization.
- Change surface is minimal and scoped to `justfile` and the new/extended tests; no changes to cluster identity semantics, node labels, Helm behavior, kubeconfig handling, or other recipes.

### Testing
- Ran `python3 -m pytest -q tests/test_cluster_identity.py tests/test_kubeconfig_recipe.py` and the targeted test set passed (`31 passed`).
- Ran `just --unstable --fmt --check` and the justfile formatting/check passed for the modified Justfile.
- Ran `git diff --check` and found no whitespace or patch issues related to the change.
- Ran `pre-commit run --all-files` which failed due to pre-existing repository-wide lint/YAML issues unrelated to this change; those failures are pre-existing and not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a628bdc0cc8832f89d2d8ab3021f3e3)