### PR TITLE
Fix assert-cluster-env to accept env=<value> and positional forms

### DIFF
--- a/justfile
+++ b/justfile
@@ -508,11 +508,16 @@ cluster-env-detect kubeconfig='':
 assert-cluster-env env kubeconfig='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
+    env_input={{ quote(env) }}
+    env_name="${env_input}"
+    while [ "${env_name#env=}" != "${env_name}" ]; do
+      env_name="${env_name#env=}"
+    done
     kubeconfig_path={{ quote(kubeconfig) }}
     if [ -z "${kubeconfig_path}" ]; then
       kubeconfig_path="${KUBECONFIG:-${HOME}/.kube/config}"
     fi
-    python3 scripts/cluster_identity.py assert --kubeconfig "${kubeconfig_path}" --env {{ quote(env) }}
+    python3 scripts/cluster_identity.py assert --kubeconfig "${kubeconfig_path}" --env "${env_name}"
 
 kubeconfig-dev:
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env env=dev

--- a/tests/test_kubeconfig_recipe.py
+++ b/tests/test_kubeconfig_recipe.py
@@ -214,11 +214,20 @@ def test_assert_cluster_env_prefixed_mismatch_fails_closed(tmp_path: Path) -> No
 
 
 @pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")
-def test_assert_cluster_env_prefixed_invalid_value_remains_rejected(tmp_path: Path) -> None:
-    result = _run_assert_cluster_env_recipe(tmp_path, "env=qa", "prod")
+@pytest.mark.parametrize(
+    ("requested", "expected_error"),
+    [
+        ("env=qa", "env must be one of dev|staging|prod"),
+        ("env=", "assert requires --env dev|staging|prod"),
+    ],
+)
+def test_assert_cluster_env_prefixed_invalid_value_remains_rejected(
+    tmp_path: Path, requested: str, expected_error: str
+) -> None:
+    result = _run_assert_cluster_env_recipe(tmp_path, requested, "prod")
 
     assert result.returncode != 0
-    assert "env must be one of dev|staging|prod" in result.stderr
+    assert expected_error in result.stderr
     assert result.stdout == ""
 
 

--- a/tests/test_kubeconfig_recipe.py
+++ b/tests/test_kubeconfig_recipe.py
@@ -150,3 +150,83 @@ def test_kubeconfig_env_mismatch_does_not_persist_false_context(tmp_path: Path) 
     assert result.returncode != 0
     assert "requested env=prod" in result.stderr
     assert existing.read_text(encoding="utf-8") == "current-context: sugar-staging\n"
+
+
+def _run_assert_cluster_env_recipe(
+    tmp_path: Path, requested: str, detected: str
+) -> subprocess.CompletedProcess[str]:
+    home = tmp_path / "home-assert"
+    home.mkdir(exist_ok=True)
+    kubeconfig = tmp_path / "assert-kubeconfig.yaml"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    bin_dir = tmp_path / "bin-assert"
+    bin_dir.mkdir(exist_ok=True)
+    _write_fake_kubectl(bin_dir)
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "KUBECONFIG": str(kubeconfig),
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+            "SUGARKUBE_STUB_NODE_ENV": detected,
+        }
+    )
+    return subprocess.run(
+        [
+            "just",
+            "--justfile",
+            str(JUSTFILE),
+            "assert-cluster-env",
+            requested,
+            str(kubeconfig),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")
+@pytest.mark.parametrize(
+    ("positional", "keyed", "detected"),
+    [("prod", "env=prod", "prod"), ("staging", "env=staging", "staging")],
+)
+def test_assert_cluster_env_normalizes_positional_and_env_prefix_forms(
+    tmp_path: Path, positional: str, keyed: str, detected: str
+) -> None:
+    positional_result = _run_assert_cluster_env_recipe(tmp_path, positional, detected)
+    keyed_result = _run_assert_cluster_env_recipe(tmp_path, keyed, detected)
+
+    assert positional_result.returncode == 0, positional_result.stderr
+    assert keyed_result.returncode == 0, keyed_result.stderr
+    assert positional_result.stdout == keyed_result.stdout == f"{detected}\n"
+
+
+@pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")
+def test_assert_cluster_env_prefixed_mismatch_fails_closed(tmp_path: Path) -> None:
+    result = _run_assert_cluster_env_recipe(tmp_path, "env=prod", "staging")
+
+    assert result.returncode != 0
+    assert "requested env=prod" in result.stderr
+    assert "env=staging" in result.stderr
+    assert result.stdout == ""
+
+
+@pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")
+def test_assert_cluster_env_prefixed_invalid_value_remains_rejected(tmp_path: Path) -> None:
+    result = _run_assert_cluster_env_recipe(tmp_path, "env=qa", "prod")
+
+    assert result.returncode != 0
+    assert "env must be one of dev|staging|prod" in result.stderr
+    assert result.stdout == ""
+
+
+@pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")
+def test_assert_cluster_env_legacy_int_prefix_still_normalizes_to_staging(
+    tmp_path: Path,
+) -> None:
+    result = _run_assert_cluster_env_recipe(tmp_path, "env=int", "staging")
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "staging\n"


### PR DESCRIPTION
### Motivation
- The `assert-cluster-env` recipe passed a literal `env=<value>` argument through to `scripts/cluster_identity.py`, causing the helper to receive `env=prod` (invalid) instead of `prod`; nearby recipes normalize the conventional `env=` prefix and this recipe should match that pattern to avoid operator errors.

### Description
- Updated the `assert-cluster-env` Just recipe to strip leading `env=` prefixes (using the same `env_input`/`env_name` loop pattern used elsewhere) and pass the normalized `env_name` to `scripts/cluster_identity.py`.
- Added focused regression tests to `tests/test_kubeconfig_recipe.py` that exercise positional and `env=` forms, ensure matching environments succeed, cross-environment mismatches fail closed, invalid values are rejected, and the legacy `int` → `staging` normalization remains supported.
- The change is minimal and local to the Just recipe and tests, and it does not alter cluster identity semantics, node labels, Helm behavior, kubeconfig handling, or unrelated recipes.

### Testing
- Ran `python3 -m pytest -q tests/test_cluster_identity.py tests/test_kubeconfig_recipe.py` and received a successful run (`27 passed`).
- Ran `just --unstable --fmt --check` which reported a formatting difference between the installed `just` formatter and the repository's checked-in `justfile` (the change itself is intentionally minimal; the broader `just` formatting mismatch is unrelated to the recipe change).
- Ran `git diff --check` with no new whitespace/errors reported from the change (no problems found).
- Ran `git diff --cached | ./scripts/scan-secrets.py` which produced no findings.
- Attempted `pre-commit run --all-files`; this surfaced pre-existing repository-wide issues (YAML multi-document/template cases and many long-line flake8 findings) unrelated to this change and therefore not modified here.

Notes: the patch preserves the repository's established argument-normalization pattern and keeps the diff intentionally small to reduce risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a628bebaf30832f92b7438a80f65f80)