### PR TITLE
fix(dspace): pin production to immutable v3.0.1 image

### DIFF
--- a/docs/apps/dspace.prod.tag
+++ b/docs/apps/dspace.prod.tag
@@ -1,3 +1,3 @@
 # Default immutable image tag for production dspace deploys.
-# Override with a newer pinned tag when promoting releases.
-v3.0.0
+# Override with a newer pinned tag only after staging validation and promotion approval.
+main-1a31a56


### PR DESCRIPTION
## Summary

- replace the stale DSPACE production image pin `v3.0.0`
- pin production to immutable image `main-1a31a56`
- align Git configuration with the production image restored during incident recovery

## Incident context

Production briefly served unintended DSPACE 3.1.0 frontend content.

User impact is over. Production is currently healthy on:

- chart: `dspace-3.0.1`
- image: `ghcr.io/democratizedspace/dspace:main-1a31a56`
- source commit: `1a31a569aff2dbeb238e8c2688b9e85140d2077d`

This PR makes the recovered image coordinate durable. It does not deploy or restart production.

## Verification

- production fallback resolves to `main-1a31a56`
- live production Deployment uses `ghcr.io/democratizedspace/dspace:main-1a31a56`
- `git diff --check` passes
- local pytest was unavailable on the production node; CI should run the repository test suite
