### PR TITLE
Wait for DSPACE target scrape convergence

### DIFF
--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -94,7 +94,7 @@ The mutating recipes never use `--reuse-values`; the committed version and both 
 - Grafana URL: `http://sugarkube3.local:30300`; the same NodePort is available through the other staging nodes.
 - Prometheus, Alertmanager, and administrative services remain ClusterIP-only.
 - No public ingress, public DNS, Cloudflare route, router forwarding, or public observability endpoint is part of this lifecycle.
-- Verification waits up to the configured Helm timeout for each workload, requires every desired node-exporter pod to be ready, and fails unless every discovered DSPACE target reports healthy.
+- Verification waits up to the configured Helm timeout for each workload and requires every desired node-exporter pod to be ready. It also waits for a nonempty set of DSPACE targets to be discovered and complete a successful scrape. By default it checks up to 20 times at 15-second intervals (a maximum wait just under five minutes), allowing Prometheus readiness to precede scrape convergence. Override these positive-integer settings with `SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS` and `SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS`. Missing, unknown, down, or partially healthy target sets are retried; kubectl transport errors, malformed JSON, invalid response structure, and a Prometheus API status other than `success` fail immediately.
 
 ## Troubleshooting signals
 

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -10,6 +10,8 @@ COMMON_VALUES="${ROOT}/platform/observability/helm/kube-prometheus-stack.values.
 STAGING_VALUES="${ROOT}/clusters/staging/observability/kube-prometheus-stack.values.yaml"
 TIMEOUT="${SUGARKUBE_OBSERVABILITY_HELM_TIMEOUT:-20m}"
 GRAFANA_URL="http://sugarkube3.local:30300"
+TARGET_HEALTH_ATTEMPTS="${SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS:-20}"
+TARGET_HEALTH_INTERVAL_SECONDS="${SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS:-15}"
 
 usage() { echo "Usage: $0 <render|install|upgrade|status|verify> env=staging" >&2; }
 normalize_env() {
@@ -72,6 +74,69 @@ release_state() {
     return 1
   fi
 }
+verify_dspace_targets() {
+  local attempts="${TARGET_HEALTH_ATTEMPTS}" interval="${TARGET_HEALTH_INTERVAL_SECONDS}"
+  local attempt targets_json observation rc
+  [[ "${attempts}" =~ ^[0-9]+$ && "${attempts}" -gt 0 ]] || {
+    echo "ERROR: SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS must be a positive integer." >&2
+    return 8
+  }
+  [[ "${interval}" =~ ^[0-9]+$ && "${interval}" -gt 0 ]] || {
+    echo "ERROR: SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS must be a positive integer." >&2
+    return 8
+  }
+
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if ! targets_json="$(kubectl get --raw "/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-prometheus:9090/proxy/api/v1/targets?state=active" 2>/dev/null)"; then
+      echo "ERROR: Prometheus targets query transport failed." >&2
+      return 9
+    fi
+    set +e
+    observation="$(python3 -c 'import json, sys
+try:
+    response = json.load(sys.stdin)
+    if not isinstance(response, dict) or response.get("status") != "success":
+        raise ValueError("Prometheus API status was not success")
+    data = response.get("data")
+    if not isinstance(data, dict) or not isinstance(data.get("activeTargets"), list):
+        raise TypeError("required Prometheus target structure is missing")
+    matches = []
+    for target in data["activeTargets"]:
+        if not isinstance(target, dict) or not isinstance(target.get("labels"), dict):
+            raise TypeError("target labels cannot be parsed safely")
+        labels = target["labels"]
+        if labels.get("app") == "dspace" and labels.get("namespace") == "dspace":
+            if not isinstance(target.get("health"), str):
+                raise TypeError("target health cannot be parsed safely")
+            matches.append(target)
+    if matches and all(target["health"] == "up" for target in matches):
+        raise SystemExit(0)
+    safe = [{key: target.get(key) for key in ("health", "lastError", "lastScrape")}
+            | {key: target["labels"].get(key) for key in ("pod", "instance")}
+            for target in matches]
+    print(json.dumps(safe, separators=(",", ":")))
+    raise SystemExit(10)
+except (json.JSONDecodeError, TypeError, ValueError) as error:
+    print("ERROR: invalid Prometheus targets response: " + str(error), file=sys.stderr)
+    raise SystemExit(2)' <<<"${targets_json}")"
+    rc=$?
+    set -e
+    case "${rc}" in
+      0) echo "DSPACE Prometheus targets confirmed healthy without printing Secret values."; return 0 ;;
+      10)
+        if (( attempt < attempts )); then
+          echo "DSPACE Prometheus targets not yet healthy (attempt ${attempt}/${attempts}); retrying." >&2
+          sleep "${interval}"
+        else
+          echo "ERROR: DSPACE Prometheus targets did not become healthy after ${attempts} attempts." >&2
+          echo "Safe target diagnostics: ${observation}" >&2
+          return 10
+        fi
+        ;;
+      *) return "${rc}" ;;
+    esac
+  done
+}
 render() { require_tools helm kubectl; print_resolved staging; tmp="$(mktemp -t sugarkube-observability-render.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; cat "${tmp}"; }
 install_release() { require_tools helm kubectl python3; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --wait --timeout "${TIMEOUT}"; }
 upgrade_release() { require_tools helm kubectl python3; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --wait --timeout "${TIMEOUT}"; }
@@ -111,16 +176,7 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
   kubectl -n dspace get secret "${secret_name}" -o name >/dev/null
   echo "DSPACE ServiceMonitor secret reference exists (value intentionally not printed)."
 
-  targets_json="$(kubectl get --raw "/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-prometheus:9090/proxy/api/v1/targets?state=active")"
-  python3 -c 'import json, sys
-data = json.load(sys.stdin)
-if data.get("status") != "success":
-    raise SystemExit("ERROR: Prometheus targets query was unsuccessful.")
-targets = data.get("data", {}).get("activeTargets", [])
-dspace = [target for target in targets if target.get("labels", {}).get("app") == "dspace" and target.get("labels", {}).get("namespace") == "dspace"]
-if not dspace or not all(target.get("health") == "up" for target in dspace):
-    raise SystemExit("ERROR: every discovered DSPACE Prometheus target must be healthy.")' <<<"${targets_json}"
-  echo "DSPACE Prometheus targets confirmed healthy without printing Secret values."
+  verify_dspace_targets
   echo "Grafana LAN URL: ${GRAFANA_URL} (same NodePort is available through the other staging nodes)"
 }
 

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -145,7 +145,7 @@ def test_status_and_verify_are_read_only():
     assert '--timeout="${TIMEOUT}"' in verify
     assert "desiredNumberScheduled" in verify and "numberReady" in verify
     assert "|| true" not in verify
-    assert 'target.get("health") == "up" for target in dspace' in verify
+    assert 'all(target["health"] == "up" for target in matches)' in script
 
 
 def test_justfile_exposes_observability_recipes():
@@ -202,7 +202,16 @@ def test_flux_health_checks_exclude_manually_managed_observability():
     assert "just observability-verify" in text
 
 
-def run_helper(tmp_path: Path, command: str, *, helm_mode="absent", context="sugar-staging", kubectl_mode="healthy"):
+def run_helper(
+    tmp_path: Path,
+    command: str,
+    *,
+    helm_mode="absent",
+    context="sugar-staging",
+    kubectl_mode="healthy",
+    attempts="3",
+    interval="1",
+):
     """Run the lifecycle against deterministic command stubs and return its audit log."""
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(parents=True)
@@ -235,19 +244,30 @@ case "$*" in
   *"get servicemonitor dspace"*"bearerTokenSecret.name"*) [ "$KUBECTL_MODE" != missing-secret-ref ] && echo dspace-token ;;
   *"get secret dspace-token -o name"*) [ "$KUBECTL_MODE" != missing-secret ] || exit 44; echo secret/dspace-token ;;
   *"get --raw "*)
+    count_file="$AUDIT.target-count"
+    count=0; [ ! -f "$count_file" ] || count=$(cat "$count_file")
+    count=$((count + 1)); echo "$count" > "$count_file"
     [ "$KUBECTL_MODE" != query-fail ] || exit 45
-    if [ "$KUBECTL_MODE" = mixed-targets ]; then
-      printf '%s\n' '{"status":"success","data":{"activeTargets":[{"labels":{"app":"dspace","namespace":"dspace"},"health":"up"},{"labels":{"app":"dspace","namespace":"dspace"},"health":"down"}]}}'
-    else
-      [ "$KUBECTL_MODE" = unhealthy ] && health=down || health=up
-      printf '{"status":"success","data":{"activeTargets":[{"labels":{"app":"dspace","namespace":"dspace"},"health":"%s"}]}}\n' "$health"
-    fi
+    case "$KUBECTL_MODE" in
+      malformed) echo 'not-json' ;;
+      api-fail) echo '{"status":"error","data":{"activeTargets":[]}}' ;;
+      bad-structure) echo '{"status":"success","data":{"activeTargets":{}}}' ;;
+      absent) echo '{"status":"success","data":{"activeTargets":[]}}' ;;
+      absent-then-healthy) [ "$count" -lt 2 ] && echo '{"status":"success","data":{"activeTargets":[]}}' || echo "$ONE_HEALTHY" ;;
+      mixed-then-healthy) [ "$count" -lt 3 ] && echo "$MIXED" || echo "$TWO_HEALTHY" ;;
+      unknown-then-healthy) [ "$count" -lt 2 ] && echo "$UNKNOWN" || echo "$ONE_HEALTHY" ;;
+      mixed-targets) echo "$MIXED" ;;
+      unhealthy) echo "$DOWN" ;;
+      two-healthy) echo "$TWO_HEALTHY" ;;
+      *) echo "$ONE_HEALTHY" ;;
+    esac
     ;;
   *) exit 0 ;;
 esac
 """,
         encoding="utf-8",
     )
+    (bin_dir / "sleep").write_text('#!/bin/sh\necho "sleep $*" >> "$AUDIT"\n', encoding="utf-8")
     for stub in bin_dir.iterdir():
         stub.chmod(0o755)
     env = os.environ | {
@@ -257,6 +277,13 @@ esac
         "CONTEXT": context,
         "KUBECTL_MODE": kubectl_mode,
         "KUBECONFIG": str(tmp_path / "kubeconfig"),
+        "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS": attempts,
+        "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS": interval,
+        "ONE_HEALTHY": '{"status":"success","data":{"activeTargets":[{"labels":{"app":"dspace","namespace":"dspace","pod":"safe-pod","instance":"safe-instance"},"health":"up","lastError":"","lastScrape":"2026-07-25T00:00:00Z"}]}}',
+        "TWO_HEALTHY": '{"status":"success","data":{"activeTargets":[{"labels":{"app":"dspace","namespace":"dspace"},"health":"up"},{"labels":{"app":"dspace","namespace":"dspace"},"health":"up"}]}}',
+        "MIXED": '{"status":"success","data":{"activeTargets":[{"labels":{"app":"dspace","namespace":"dspace","pod":"safe-pod"},"health":"up","lastError":""},{"labels":{"app":"dspace","namespace":"dspace","instance":"safe-instance"},"health":"down","lastError":"safe diagnostic","lastScrape":"2026-07-25T00:00:00Z"}]}}',
+        "DOWN": '{"status":"success","data":{"activeTargets":[{"labels":{"app":"dspace","namespace":"dspace","pod":"safe-pod"},"health":"down","lastError":"safe diagnostic","lastScrape":"2026-07-25T00:00:00Z","authorization":"Bearer TOP-SECRET","secret":"TOP-SECRET"}]}}',
+        "UNKNOWN": '{"status":"success","data":{"activeTargets":[{"labels":{"app":"dspace","namespace":"dspace"},"health":"unknown"}]}}',
     }
     result = subprocess.run(
         ["bash", str(SCRIPT), command, "env=staging"],
@@ -323,9 +350,59 @@ def test_verify_exact_three_nodes_secret_reference_and_target_health(tmp_path):
         "wrong-release",
         "missing-secret-ref",
         "missing-secret",
-        "query-fail",
-        "unhealthy",
-        "mixed-targets",
     ):
         result, _ = run_helper(tmp_path / mode, "verify", kubectl_mode=mode)
         assert result.returncode != 0, mode
+
+
+def test_target_health_convergence_is_bounded_and_accepts_any_positive_count(tmp_path):
+    for mode in ("healthy", "two-healthy"):
+        result, audit = run_helper(tmp_path / mode, "verify", kubectl_mode=mode)
+        assert result.returncode == 0
+        assert audit.count("get --raw") == 1
+        assert "sleep " not in audit
+
+    absent, audit = run_helper(tmp_path / "absent-then", "verify", kubectl_mode="absent-then-healthy")
+    assert absent.returncode == 0
+    assert audit.count("get --raw") == 2 and audit.count("sleep 1") == 1
+
+    mixed, audit = run_helper(tmp_path / "mixed-then", "verify", kubectl_mode="mixed-then-healthy")
+    assert mixed.returncode == 0
+    assert audit.count("get --raw") == 3 and audit.count("sleep 1") == 2
+
+    unknown, audit = run_helper(
+        tmp_path / "unknown-then", "verify", kubectl_mode="unknown-then-healthy"
+    )
+    assert unknown.returncode == 0
+    assert audit.count("get --raw") == 2 and audit.count("sleep 1") == 1
+
+
+def test_target_health_timeout_rejects_empty_down_and_mixed_sets_safely(tmp_path):
+    for mode in ("absent", "unhealthy", "mixed-targets"):
+        result, audit = run_helper(tmp_path / mode, "verify", kubectl_mode=mode)
+        assert result.returncode != 0
+        assert audit.count("get --raw") == 3 and audit.count("sleep 1") == 2
+        assert "Safe target diagnostics:" in result.stderr
+        assert "TOP-SECRET" not in result.stderr
+    assert "safe-pod" in result.stderr
+    assert "safe diagnostic" in result.stderr
+
+
+def test_target_query_and_parsing_failures_are_immediate(tmp_path):
+    for mode in ("query-fail", "malformed", "api-fail", "bad-structure"):
+        result, audit = run_helper(tmp_path / mode, "verify", kubectl_mode=mode)
+        assert result.returncode != 0
+        assert audit.count("get --raw") == 1
+        assert "sleep " not in audit
+
+
+def test_invalid_target_retry_configuration_fails_before_polling(tmp_path):
+    for attempts, interval in (("0", "1"), ("no", "1"), ("1", "0"), ("1", "1.5")):
+        result, audit = run_helper(
+            tmp_path / f"{attempts}-{interval}",
+            "verify",
+            attempts=attempts,
+            interval=interval,
+        )
+        assert result.returncode != 0
+        assert "get --raw" not in audit


### PR DESCRIPTION
### Motivation

- Prometheus pod readiness can precede the first post-restart DSPACE target discovery/scrape, causing a transient false failure in `just observability-verify env=staging`.

### Description

- Add a focused helper `verify_dspace_targets()` in `scripts/observability_helm.sh` that polls the existing Prometheus service-proxy `/api/v1/.../targets?state=active` endpoint and enforces that the API `status` is `success`, the matching `labels.app=="dspace" && labels.namespace=="dspace"` set is nonempty, and every matching target reports `health == "up"` in the same response.
- Make retries bounded and configurable via positive-integer environment variables `SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS` (default `20`) and `SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS` (default `15`), validate both before polling, and sleep only between attempts (not after the final attempt).
- Treat transport failures, malformed JSON, Prometheus API `status != "success"`, or missing/invalid response structure as immediate hard failures; treat empty, `unknown`, `down`, or partially healthy target sets as transient and retryable until the bounded attempts are exhausted.
- Emit concise retry progress lines during polling and, on final timeout, print only safe, whitelisted diagnostic fields (`pod`, `instance`, `health`, `lastError`, `lastScrape`) while avoiding any Secrets or bearer tokens in diagnostics.
- Preserve existing runtime checks and messages; replace the one-shot Python target-check snippet with the new helper; document the behavior and environment overrides in `docs/observability-operations.md`.
- Add deterministic, offline unit tests in `tests/test_observability_helm.py` to cover convergence, timeouts, varied target counts (one or more), immediate hard failures (transport/JSON/API structure), invalid retry configuration, call/sleep bounding, and diagnostic privacy; use stubbed `kubectl`/`helm` and a fake `sleep` so tests run fast and deterministically.

### Testing

- `bash -n scripts/observability_helm.sh` — syntax check succeeded.
- `pytest -q tests/test_observability_helm.py` — all tests passed (`21 passed`).
- `git diff --check` — no whitespace/git-diff issues.
- `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` — secret scan reported no issues.
- `git diff --stat` / `git diff --name-only` — changes are limited to `scripts/observability_helm.sh`, `tests/test_observability_helm.py`, and `docs/observability-operations.md` as scoped.
- Not run in this environment: `shellcheck scripts/observability_helm.sh` (ShellCheck not installed), `pre-commit run --all-files` (pre-commit not installed), `pyspelling -c .spellcheck.yaml` (pyspelling not installed), and `linkchecker --no-warnings README.md docs/` (linkchecker not installed).

Implementation summary: the new polling helper waits up to the configured (default ≈ 285s) convergence window for a nonempty set of DSPACE targets to be discovered and for all to be healthy, fails immediately on transport/JSON/API errors, logs only safe diagnostic fields on timeout, and is fully covered by deterministic offline tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a642260cc3c832fb1bcfbc6fdb632d9)