### PR TITLE
Wait for DSPACE Prometheus target convergence

### DIFF
--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -94,7 +94,16 @@ The mutating recipes never use `--reuse-values`; the committed version and both 
 - Grafana URL: `http://sugarkube3.local:30300`; the same NodePort is available through the other staging nodes.
 - Prometheus, Alertmanager, and administrative services remain ClusterIP-only.
 - No public ingress, public DNS, Cloudflare route, router forwarding, or public observability endpoint is part of this lifecycle.
-- Verification waits up to the configured Helm timeout for each workload, requires every desired node-exporter pod to be ready, and fails unless every discovered DSPACE target reports healthy.
+- Verification waits up to the configured Helm timeout for each workload and requires every desired
+  node-exporter pod to be ready. After workload readiness, it also waits for DSPACE target discovery
+  and the first successful scrape. By default, it checks up to 20 times at 15-second intervals—a
+  maximum wait just under five minutes—and succeeds when one or more matching targets are present
+  and all are healthy. Override the positive-integer attempt count with
+  `SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS` and the interval with
+  `SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS` when a different bounded convergence
+  window is appropriate. Failures to query the service-proxy endpoint, malformed JSON, invalid
+  response structure, and unsuccessful Prometheus API status are immediate hard failures rather
+  than retryable convergence states.
 
 ## Troubleshooting signals
 

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -10,6 +10,8 @@ COMMON_VALUES="${ROOT}/platform/observability/helm/kube-prometheus-stack.values.
 STAGING_VALUES="${ROOT}/clusters/staging/observability/kube-prometheus-stack.values.yaml"
 TIMEOUT="${SUGARKUBE_OBSERVABILITY_HELM_TIMEOUT:-20m}"
 GRAFANA_URL="http://sugarkube3.local:30300"
+TARGET_HEALTH_ATTEMPTS="${SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS:-20}"
+TARGET_HEALTH_INTERVAL_SECONDS="${SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS:-15}"
 
 usage() { echo "Usage: $0 <render|install|upgrade|status|verify> env=staging" >&2; }
 normalize_env() {
@@ -76,6 +78,57 @@ render() { require_tools helm kubectl; print_resolved staging; tmp="$(mktemp -t 
 install_release() { require_tools helm kubectl python3; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --wait --timeout "${TIMEOUT}"; }
 upgrade_release() { require_tools helm kubectl python3; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --wait --timeout "${TIMEOUT}"; }
 status() { require_tools helm kubectl python3; print_resolved staging; assert_context; helm -n "${NAMESPACE}" status "${RELEASE}"; kubectl -n "${NAMESPACE}" get deploy,statefulset,daemonset -l "app.kubernetes.io/instance=${RELEASE}"; kubectl -n "${NAMESPACE}" get prometheus,alertmanager; kubectl -n "${NAMESPACE}" get svc,pvc; kubectl get crd prometheuses.monitoring.coreos.com alertmanagers.monitoring.coreos.com servicemonitors.monitoring.coreos.com probes.monitoring.coreos.com; }
+verify_dspace_targets() {
+  local attempts="${TARGET_HEALTH_ATTEMPTS}" interval="${TARGET_HEALTH_INTERVAL_SECONDS}"
+  local attempt targets_json result
+  [[ "${attempts}" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS must be a positive integer." >&2; return 8; }
+  [[ "${interval}" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS must be a positive integer." >&2; return 8; }
+
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if ! targets_json="$(kubectl get --raw "/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-prometheus:9090/proxy/api/v1/targets?state=active")"; then
+      echo "ERROR: Prometheus targets query transport failed." >&2
+      return 1
+    fi
+    result=0
+    python3 -c 'import json, sys
+try:
+    response = json.load(sys.stdin)
+    if not isinstance(response, dict):
+        raise TypeError("response is not an object")
+    if response.get("status") != "success":
+        raise RuntimeError("Prometheus API status was not success")
+    data = response.get("data")
+    if not isinstance(data, dict) or not isinstance(data.get("activeTargets"), list):
+        raise TypeError("activeTargets is not a list")
+    matches = []
+    for target in data["activeTargets"]:
+        if not isinstance(target, dict) or not isinstance(target.get("labels"), dict):
+            raise TypeError("target or labels is not an object")
+        if target["labels"].get("app") == "dspace" and target["labels"].get("namespace") == "dspace":
+            matches.append(target)
+    if matches and all(target.get("health") == "up" for target in matches):
+        raise SystemExit(0)
+    if sys.argv[1] == "final":
+        safe = [{key: target.get("labels", {}).get(key) for key in ("pod", "instance") if target.get("labels", {}).get(key) is not None} | {key: target.get(key) for key in ("health", "lastError", "lastScrape") if target.get(key) is not None} for target in matches]
+        print("ERROR: DSPACE Prometheus targets did not converge: " + json.dumps(safe, separators=(",", ":")), file=sys.stderr)
+    raise SystemExit(10)
+except (json.JSONDecodeError, TypeError, RuntimeError) as error:
+    print("ERROR: could not safely parse Prometheus targets response: " + str(error), file=sys.stderr)
+    raise SystemExit(11)' "$([[ "${attempt}" == "${attempts}" ]] && printf final || printf retry)" <<<"${targets_json}" || result=$?
+    case "${result}" in
+      0) return 0 ;;
+      10)
+        if ((attempt < attempts)); then
+          echo "Waiting for DSPACE Prometheus targets (${attempt}/${attempts})." >&2
+          sleep "${interval}"
+        fi
+        ;;
+      *) return 1 ;;
+    esac
+  done
+  echo "ERROR: every discovered DSPACE Prometheus target must be healthy." >&2
+  return 1
+}
 verify() {
   require_tools kubectl python3
   print_resolved staging
@@ -111,15 +164,7 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
   kubectl -n dspace get secret "${secret_name}" -o name >/dev/null
   echo "DSPACE ServiceMonitor secret reference exists (value intentionally not printed)."
 
-  targets_json="$(kubectl get --raw "/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-prometheus:9090/proxy/api/v1/targets?state=active")"
-  python3 -c 'import json, sys
-data = json.load(sys.stdin)
-if data.get("status") != "success":
-    raise SystemExit("ERROR: Prometheus targets query was unsuccessful.")
-targets = data.get("data", {}).get("activeTargets", [])
-dspace = [target for target in targets if target.get("labels", {}).get("app") == "dspace" and target.get("labels", {}).get("namespace") == "dspace"]
-if not dspace or not all(target.get("health") == "up" for target in dspace):
-    raise SystemExit("ERROR: every discovered DSPACE Prometheus target must be healthy.")' <<<"${targets_json}"
+  verify_dspace_targets
   echo "DSPACE Prometheus targets confirmed healthy without printing Secret values."
   echo "Grafana LAN URL: ${GRAFANA_URL} (same NodePort is available through the other staging nodes)"
 }

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -80,7 +80,9 @@ def test_grafana_alertmanager_k3s_monitor_values_are_guarded():
 
 def test_no_production_values_or_public_exposure_or_credentials_added():
     assert STAGING.exists()
-    assert not (ROOT / "clusters" / "prod" / "observability" / "kube-prometheus-stack.values.yaml").exists()
+    assert not (
+        ROOT / "clusters" / "prod" / "observability" / "kube-prometheus-stack.values.yaml"
+    ).exists()
     text = COMMON.read_text(encoding="utf-8") + STAGING.read_text(encoding="utf-8")
     forbidden = ["longhorn", "cloudflare", "IngressRoute", "kind: Ingress", "password:", "adminPassword"]
     for needle in forbidden:
@@ -97,9 +99,17 @@ def test_discovery_contract_uses_release_label():
 
 def test_lifecycle_uses_pinned_version_ordered_values_and_no_reuse_values():
     script = SCRIPT.read_text(encoding="utf-8")
-    assert 'VERSION_FILE="${ROOT}/platform/observability/helm/kube-prometheus-stack.version"' in script
-    assert 'COMMON_VALUES="${ROOT}/platform/observability/helm/kube-prometheus-stack.values.common.yaml"' in script
-    assert 'STAGING_VALUES="${ROOT}/clusters/staging/observability/kube-prometheus-stack.values.yaml"' in script
+    assert (
+        'VERSION_FILE="${ROOT}/platform/observability/helm/kube-prometheus-stack.version"' in script
+    )
+    assert (
+        'COMMON_VALUES="${ROOT}/platform/observability/helm/kube-prometheus-stack.values.common.yaml"'
+        in script
+    )
+    assert (
+        'STAGING_VALUES="${ROOT}/clusters/staging/observability/kube-prometheus-stack.values.yaml"'
+        in script
+    )
     assert 'CHART="prometheus-community/kube-prometheus-stack"' in script
     assert '--version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}"' in script
     assert "--reuse-values" not in script
@@ -126,7 +136,7 @@ def test_unsupported_env_and_context_mismatch_fail_before_mutation():
     script = SCRIPT.read_text(encoding="utf-8")
     assert "prod|production" in script
     assert "production observability is not yet codified" in script
-    assert 'expected \'sugar-staging\'' in script
+    assert "expected 'sugar-staging'" in script
     assert script.index("assert_context") < script.index("helm install")
     assert script.index("assert_context") < script.index("helm upgrade")
 
@@ -135,7 +145,14 @@ def test_status_and_verify_are_read_only():
     script = SCRIPT.read_text(encoding="utf-8")
     status = re.search(r"status\(\).*?\nverify\(", script, re.S).group(0)
     verify = re.search(r"verify\(\).*?\n\ncmd=", script, re.S).group(0)
-    mutating = [" helm install", " helm upgrade", "kubectl apply", "kubectl create", "kubectl patch", "kubectl delete"]
+    mutating = [
+        " helm install",
+        " helm upgrade",
+        "kubectl apply",
+        "kubectl create",
+        "kubectl patch",
+        "kubectl delete",
+    ]
     for body in (status, verify):
         for token in mutating:
             assert token not in body
@@ -145,7 +162,7 @@ def test_status_and_verify_are_read_only():
     assert '--timeout="${TIMEOUT}"' in verify
     assert "desiredNumberScheduled" in verify and "numberReady" in verify
     assert "|| true" not in verify
-    assert 'target.get("health") == "up" for target in dspace' in verify
+    assert "verify_dspace_targets" in verify
 
 
 def test_justfile_exposes_observability_recipes():
@@ -173,15 +190,9 @@ def test_legacy_flux_resources_are_absent_from_reconciliation_graph():
     platform = (ROOT / "platform" / "observability" / "kustomization.yaml").read_text(
         encoding="utf-8"
     )
-    staging = (ROOT / "clusters" / "staging" / "kustomization.yaml").read_text(
-        encoding="utf-8"
-    )
-    development = (ROOT / "clusters" / "dev" / "kustomization.yaml").read_text(
-        encoding="utf-8"
-    )
-    production = (ROOT / "clusters" / "prod" / "kustomization.yaml").read_text(
-        encoding="utf-8"
-    )
+    staging = (ROOT / "clusters" / "staging" / "kustomization.yaml").read_text(encoding="utf-8")
+    development = (ROOT / "clusters" / "dev" / "kustomization.yaml").read_text(encoding="utf-8")
+    production = (ROOT / "clusters" / "prod" / "kustomization.yaml").read_text(encoding="utf-8")
     assert "kube-prometheus-stack.yaml" not in platform
     assert "kube-prometheus-stack-values.yaml" not in platform
     assert "patches/kube-prometheus-stack-values.yaml" not in development
@@ -202,11 +213,30 @@ def test_flux_health_checks_exclude_manually_managed_observability():
     assert "just observability-verify" in text
 
 
-def run_helper(tmp_path: Path, command: str, *, helm_mode="absent", context="sugar-staging", kubectl_mode="healthy"):
+def run_helper(
+    tmp_path: Path,
+    command: str,
+    *,
+    helm_mode="absent",
+    context="sugar-staging",
+    kubectl_mode="healthy",
+    target_responses=None,
+    attempts=1,
+    interval=1,
+):
     """Run the lifecycle against deterministic command stubs and return its audit log."""
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(parents=True)
     audit = tmp_path / "audit"
+    responses = tmp_path / "target-responses"
+    if target_responses is not None:
+        responses.write_text(
+            "\n".join(
+                json.dumps(item) if not isinstance(item, str) else item for item in target_responses
+            )
+            + "\n",
+            encoding="utf-8",
+        )
     (bin_dir / "helm").write_text(
         """#!/bin/sh
 echo "helm $*" >> "$AUDIT"
@@ -236,7 +266,11 @@ case "$*" in
   *"get secret dspace-token -o name"*) [ "$KUBECTL_MODE" != missing-secret ] || exit 44; echo secret/dspace-token ;;
   *"get --raw "*)
     [ "$KUBECTL_MODE" != query-fail ] || exit 45
-    if [ "$KUBECTL_MODE" = mixed-targets ]; then
+    if [ -s "$TARGET_RESPONSES" ]; then
+      count_file="${TARGET_RESPONSES}.count"
+      count=$(cat "$count_file" 2>/dev/null || echo 0); count=$((count + 1)); echo "$count" > "$count_file"
+      sed -n "${count}p" "$TARGET_RESPONSES"
+    elif [ "$KUBECTL_MODE" = mixed-targets ]; then
       printf '%s\n' '{"status":"success","data":{"activeTargets":[{"labels":{"app":"dspace","namespace":"dspace"},"health":"up"},{"labels":{"app":"dspace","namespace":"dspace"},"health":"down"}]}}'
     else
       [ "$KUBECTL_MODE" = unhealthy ] && health=down || health=up
@@ -257,6 +291,13 @@ esac
         "CONTEXT": context,
         "KUBECTL_MODE": kubectl_mode,
         "KUBECONFIG": str(tmp_path / "kubeconfig"),
+    }
+    (bin_dir / "sleep").write_text('#!/bin/sh\necho "sleep $*" >> "$AUDIT"\n', encoding="utf-8")
+    (bin_dir / "sleep").chmod(0o755)
+    env |= {
+        "TARGET_RESPONSES": str(responses),
+        "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS": str(attempts),
+        "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS": str(interval),
     }
     result = subprocess.run(
         ["bash", str(SCRIPT), command, "env=staging"],
@@ -289,7 +330,9 @@ def test_fallback_secret_scanner_allows_only_complete_placeholders():
 
 
 def test_pre_mutation_guards_are_fail_closed(tmp_path):
-    unsupported = subprocess.run(["bash", str(SCRIPT), "install", "env=prod"], capture_output=True, text=True, check=False)
+    unsupported = subprocess.run(
+        ["bash", str(SCRIPT), "install", "env=prod"], capture_output=True, text=True, check=False
+    )
     assert unsupported.returncode != 0
     mismatch, audit = run_helper(tmp_path / "mismatch", "install", context="other")
     assert mismatch.returncode != 0 and "helm install" not in audit
@@ -317,7 +360,10 @@ def test_status_requires_staging_identity(tmp_path):
 
 def test_verify_exact_three_nodes_secret_reference_and_target_health(tmp_path):
     healthy, audit = run_helper(tmp_path / "healthy", "verify")
-    assert healthy.returncode == 0 and "get --raw /api/v1/namespaces/monitoring/services/http:" in audit
+    assert (
+        healthy.returncode == 0
+        and "get --raw /api/v1/namespaces/monitoring/services/http:" in audit
+    )
     for mode in (
         "two-nodes",
         "wrong-release",
@@ -329,3 +375,101 @@ def test_verify_exact_three_nodes_secret_reference_and_target_health(tmp_path):
     ):
         result, _ = run_helper(tmp_path / mode, "verify", kubectl_mode=mode)
         assert result.returncode != 0, mode
+
+
+def target(health="up", *, pod="dspace-0", instance="10.0.0.1:8080", error="", scrape="now"):
+    return {
+        "labels": {"app": "dspace", "namespace": "dspace", "pod": pod, "instance": instance},
+        "health": health,
+        "lastError": error,
+        "lastScrape": scrape,
+    }
+
+
+def response(*targets, status="success"):
+    return {"status": status, "data": {"activeTargets": list(targets)}}
+
+
+def test_target_health_accepts_one_or_multiple_healthy_targets_immediately(tmp_path):
+    for name, targets in (("one", [target()]), ("many", [target(), target(pod="dspace-1")])):
+        result, audit = run_helper(tmp_path / name, "verify", target_responses=[response(*targets)])
+        assert result.returncode == 0
+        assert audit.count("get --raw ") == 1
+        assert "sleep " not in audit
+
+
+def test_target_health_retries_empty_unknown_and_mixed_until_healthy(tmp_path):
+    sequences = {
+        "empty": [response(), response(target())],
+        "unknown": [response(target("unknown")), response(target())],
+        "mixed": [response(target(), target("down", pod="dspace-1")), response(target())],
+    }
+    for name, responses in sequences.items():
+        result, audit = run_helper(
+            tmp_path / name, "verify", target_responses=responses, attempts=2, interval=7
+        )
+        assert result.returncode == 0
+        assert audit.count("get --raw ") == 2
+        assert audit.count("sleep 7") == 1
+        assert "Waiting for DSPACE Prometheus targets (1/2)." in result.stderr
+
+
+def test_target_health_timeout_is_bounded_and_diagnostics_are_safe(tmp_path):
+    secret_value = "do-not-print-this-secret"
+    cases = {
+        "empty": [response(), response(), response()],
+        "mixed": [response(target(), target("down", error="connection refused"))] * 3,
+    }
+    for name, responses in cases.items():
+        result, audit = run_helper(
+            tmp_path / name, "verify", target_responses=responses, attempts=3, interval=4
+        )
+        assert result.returncode != 0
+        assert audit.count("get --raw ") == 3
+        assert audit.count("sleep 4") == 2
+        assert secret_value not in result.stdout + result.stderr
+        assert "activeTargets" not in result.stderr
+    mixed_result, _ = run_helper(
+        tmp_path / "safe-fields",
+        "verify",
+        target_responses=[
+            response(
+                target("down", error="connection refused", scrape="2026-07-25T12:00:00Z"),
+                {
+                    "labels": {"app": "other", "namespace": "other"},
+                    "health": "up",
+                    "token": secret_value,
+                },
+            )
+        ],
+    )
+    assert all(
+        value in mixed_result.stderr
+        for value in ("dspace-0", "down", "connection refused", "2026-07-25")
+    )
+    assert secret_value not in mixed_result.stderr
+
+
+def test_target_health_transport_and_payload_failures_are_immediate(tmp_path):
+    cases = {
+        "transport": {"kubectl_mode": "query-fail"},
+        "malformed": {"target_responses": ["not-json"]},
+        "api-status": {"target_responses": [response(status="error")]},
+        "structure": {"target_responses": [{"status": "success", "data": {}}]},
+    }
+    for name, kwargs in cases.items():
+        result, audit = run_helper(tmp_path / name, "verify", attempts=3, **kwargs)
+        assert result.returncode != 0
+        assert audit.count("get --raw ") == 1
+        assert "sleep " not in audit
+
+
+def test_invalid_target_retry_configuration_fails_before_polling(tmp_path):
+    for name, attempts, interval in (
+        ("zero-attempts", 0, 1),
+        ("bad-attempts", "x", 1),
+        ("zero-interval", 1, 0),
+    ):
+        result, audit = run_helper(tmp_path / name, "verify", attempts=attempts, interval=interval)
+        assert result.returncode != 0
+        assert "get --raw " not in audit


### PR DESCRIPTION
### Motivation
- Prometheus pod `Ready` can occur before service-discovery and the first scrape, producing a transient false failure in `observability-verify` for DSPACE targets.
- The verification must wait a bounded, testable convergence window for discovery/scrape while still failing immediately on transport/API/JSON errors and without printing secrets.

### Description
- Add configurable, validated retry bounds `SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS` (default `20`) and `SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS` (default `15`) to `scripts/observability_helm.sh`.
- Introduce `verify_dspace_targets()` in `scripts/observability_helm.sh` which polls the Prometheus service-proxy endpoint via `kubectl get --raw`, requires `status == "success"`, requires a nonempty set of targets matching `labels.app == "dspace"` and `labels.namespace == "dspace"`, and requires every matching target to have `health == "up"` in the same response.
- Treat absent matches, `unknown`, `down`, and partially healthy sets as transient and retry up to the configured attempts with sleeps only between attempts; fail immediately on transport errors, malformed JSON, non-`success` API status, or unexpected response structure.
- On final timeout emit privacy-safe diagnostics only (whitelisted `pod`/`instance`, `health`, `lastError`, `lastScrape`) and preserve the existing successful verification message; never log bearer tokens, raw Secrets, or full API payloads.
- Extend `tests/test_observability_helm.py` with deterministic command-stub coverage exercising: immediate healthy single/multiple targets, empty/unknown/mixed sequences that converge, permanent empty/mixed failures, one-target success, immediate transport/malformed/API-status failures, invalid retry configuration, and assertions that API calls and sleeps are correctly bounded; use a stubbed `sleep` so tests stay fast.
- Update `docs/observability-operations.md` to document the waiting behaviour, default just-under-five-minute window, and the two environment overrides and immediate hard-failure conditions.

### Testing
- Ran `bash -n scripts/observability_helm.sh` and it passed.
- Ran `pytest -q tests/test_observability_helm.py` and all tests passed (`22 passed`).
- Ran `python -m black --check tests/test_observability_helm.py` and `ruff check tests/test_observability_helm.py` and they passed.
- Ran repository checks `git diff --check`, `git diff | ./scripts/scan-secrets.py`, `git diff --stat`, and `git diff --name-only` against the change and they succeeded; only the three scope-locked files were modified.
- Unavailable checks in this environment: `shellcheck scripts/observability_helm.sh`, `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` were not run because those tools are not installed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a642274b374832f8be06b895357a3e7)