### PR TITLE
Wait for DSPACE Prometheus target convergence

### DIFF
--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -94,7 +94,7 @@ The mutating recipes never use `--reuse-values`; the committed version and both 
 - Grafana URL: `http://sugarkube3.local:30300`; the same NodePort is available through the other staging nodes.
 - Prometheus, Alertmanager, and administrative services remain ClusterIP-only.
 - No public ingress, public DNS, Cloudflare route, router forwarding, or public observability endpoint is part of this lifecycle.
-- Verification waits up to the configured Helm timeout for each workload, requires every desired node-exporter pod to be ready, and fails unless every discovered DSPACE target reports healthy.
+- Verification waits up to the configured Helm timeout for each workload and requires every desired node-exporter pod to be ready. Because Prometheus readiness can precede target discovery and the first completed scrape, verification polls until one or more discovered DSPACE targets all report healthy. By default it makes 20 observations 15 seconds apart, for a maximum wait just under five minutes. Override these positive-integer settings with `SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS` and `SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS`. Missing, unknown, down, and partially healthy target sets are retried; kubectl transport errors, malformed JSON, invalid response structure, and unsuccessful Prometheus API status remain immediate hard failures.
 
 ## Troubleshooting signals
 

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -10,6 +10,8 @@ COMMON_VALUES="${ROOT}/platform/observability/helm/kube-prometheus-stack.values.
 STAGING_VALUES="${ROOT}/clusters/staging/observability/kube-prometheus-stack.values.yaml"
 TIMEOUT="${SUGARKUBE_OBSERVABILITY_HELM_TIMEOUT:-20m}"
 GRAFANA_URL="http://sugarkube3.local:30300"
+TARGET_HEALTH_ATTEMPTS="${SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS:-20}"
+TARGET_HEALTH_INTERVAL_SECONDS="${SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS:-15}"
 
 usage() { echo "Usage: $0 <render|install|upgrade|status|verify> env=staging" >&2; }
 normalize_env() {
@@ -76,6 +78,83 @@ render() { require_tools helm kubectl; print_resolved staging; tmp="$(mktemp -t 
 install_release() { require_tools helm kubectl python3; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --wait --timeout "${TIMEOUT}"; }
 upgrade_release() { require_tools helm kubectl python3; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --wait --timeout "${TIMEOUT}"; }
 status() { require_tools helm kubectl python3; print_resolved staging; assert_context; helm -n "${NAMESPACE}" status "${RELEASE}"; kubectl -n "${NAMESPACE}" get deploy,statefulset,daemonset -l "app.kubernetes.io/instance=${RELEASE}"; kubectl -n "${NAMESPACE}" get prometheus,alertmanager; kubectl -n "${NAMESPACE}" get svc,pvc; kubectl get crd prometheuses.monitoring.coreos.com alertmanagers.monitoring.coreos.com servicemonitors.monitoring.coreos.com probes.monitoring.coreos.com; }
+verify_dspace_targets() {
+  local attempt response_file result status
+  for value_name in TARGET_HEALTH_ATTEMPTS TARGET_HEALTH_INTERVAL_SECONDS; do
+    [[ "${!value_name}" =~ ^[0-9]+$ && "${!value_name}" -gt 0 ]] || {
+      echo "ERROR: ${value_name} must be a positive integer." >&2
+      return 8
+    }
+  done
+
+  response_file="$(mktemp -t sugarkube-prometheus-targets.XXXXXX.json)"
+  for ((attempt = 1; attempt <= TARGET_HEALTH_ATTEMPTS; attempt++)); do
+    if ! kubectl get --raw "/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-prometheus:9090/proxy/api/v1/targets?state=active" >"${response_file}"; then
+      rm -f "${response_file}"
+      echo "ERROR: Prometheus targets query transport failed." >&2
+      return 8
+    fi
+    set +e
+    result="$(python3 - "${response_file}" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as stream:
+        response = json.load(stream)
+except (OSError, UnicodeError, json.JSONDecodeError):
+    raise SystemExit("ERROR: Prometheus targets response was not valid JSON.")
+
+if not isinstance(response, dict):
+    raise SystemExit("ERROR: Prometheus targets response has an invalid structure.")
+if response.get("status") != "success":
+    raise SystemExit("ERROR: Prometheus targets query was unsuccessful.")
+data = response.get("data")
+if not isinstance(data, dict) or not isinstance(data.get("activeTargets"), list):
+    raise SystemExit("ERROR: Prometheus targets response has an invalid structure.")
+
+dspace = []
+for target in data["activeTargets"]:
+    if not isinstance(target, dict) or not isinstance(target.get("labels"), dict):
+        raise SystemExit("ERROR: Prometheus targets response has an invalid structure.")
+    if target["labels"].get("app") == "dspace" and target["labels"].get("namespace") == "dspace":
+        if not isinstance(target.get("health"), str):
+            raise SystemExit("ERROR: Prometheus targets response has an invalid structure.")
+        dspace.append(target)
+
+if dspace and all(target["health"] == "up" for target in dspace):
+    raise SystemExit(0)
+
+diagnostics = []
+for target in dspace:
+    labels = target["labels"]
+    item = {key: labels[key] for key in ("pod", "instance") if isinstance(labels.get(key), str)}
+    for key in ("health", "lastError", "lastScrape"):
+        if isinstance(target.get(key), str):
+            item[key] = target[key]
+    diagnostics.append(item)
+print(json.dumps(diagnostics, separators=(",", ":"), ensure_ascii=True))
+raise SystemExit(10)
+PY
+)"
+    status=$?
+    set -e
+    case "${status}" in
+      0) rm -f "${response_file}"; return 0 ;;
+      10)
+        if ((attempt == TARGET_HEALTH_ATTEMPTS)); then
+          rm -f "${response_file}"
+          echo "ERROR: DSPACE Prometheus targets did not become healthy after ${TARGET_HEALTH_ATTEMPTS} attempts." >&2
+          echo "DSPACE target diagnostics (whitelisted fields only): ${result}" >&2
+          return 8
+        fi
+        echo "Waiting for DSPACE Prometheus target convergence (attempt ${attempt}/${TARGET_HEALTH_ATTEMPTS})." >&2
+        sleep "${TARGET_HEALTH_INTERVAL_SECONDS}"
+        ;;
+      *) rm -f "${response_file}"; return "${status}" ;;
+    esac
+  done
+}
 verify() {
   require_tools kubectl python3
   print_resolved staging
@@ -111,15 +190,7 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
   kubectl -n dspace get secret "${secret_name}" -o name >/dev/null
   echo "DSPACE ServiceMonitor secret reference exists (value intentionally not printed)."
 
-  targets_json="$(kubectl get --raw "/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-prometheus:9090/proxy/api/v1/targets?state=active")"
-  python3 -c 'import json, sys
-data = json.load(sys.stdin)
-if data.get("status") != "success":
-    raise SystemExit("ERROR: Prometheus targets query was unsuccessful.")
-targets = data.get("data", {}).get("activeTargets", [])
-dspace = [target for target in targets if target.get("labels", {}).get("app") == "dspace" and target.get("labels", {}).get("namespace") == "dspace"]
-if not dspace or not all(target.get("health") == "up" for target in dspace):
-    raise SystemExit("ERROR: every discovered DSPACE Prometheus target must be healthy.")' <<<"${targets_json}"
+  verify_dspace_targets
   echo "DSPACE Prometheus targets confirmed healthy without printing Secret values."
   echo "Grafana LAN URL: ${GRAFANA_URL} (same NodePort is available through the other staging nodes)"
 }

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -145,7 +145,7 @@ def test_status_and_verify_are_read_only():
     assert '--timeout="${TIMEOUT}"' in verify
     assert "desiredNumberScheduled" in verify and "numberReady" in verify
     assert "|| true" not in verify
-    assert 'target.get("health") == "up" for target in dspace' in verify
+    assert "verify_dspace_targets" in verify
 
 
 def test_justfile_exposes_observability_recipes():
@@ -202,11 +202,24 @@ def test_flux_health_checks_exclude_manually_managed_observability():
     assert "just observability-verify" in text
 
 
-def run_helper(tmp_path: Path, command: str, *, helm_mode="absent", context="sugar-staging", kubectl_mode="healthy"):
+def run_helper(
+    tmp_path: Path,
+    command: str,
+    *,
+    helm_mode="absent",
+    context="sugar-staging",
+    kubectl_mode="healthy",
+    target_responses=None,
+    attempts="1",
+    interval="1",
+):
     """Run the lifecycle against deterministic command stubs and return its audit log."""
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(parents=True)
     audit = tmp_path / "audit"
+    responses = tmp_path / "target-responses"
+    if target_responses is not None:
+        responses.write_text("\n".join(target_responses) + "\n", encoding="utf-8")
     (bin_dir / "helm").write_text(
         """#!/bin/sh
 echo "helm $*" >> "$AUDIT"
@@ -236,7 +249,12 @@ case "$*" in
   *"get secret dspace-token -o name"*) [ "$KUBECTL_MODE" != missing-secret ] || exit 44; echo secret/dspace-token ;;
   *"get --raw "*)
     [ "$KUBECTL_MODE" != query-fail ] || exit 45
-    if [ "$KUBECTL_MODE" = mixed-targets ]; then
+    if [ -f "$TARGET_RESPONSES" ]; then
+      count=0
+      [ ! -f "$TARGET_COUNT" ] || count=$(cat "$TARGET_COUNT")
+      count=$((count + 1)); echo "$count" > "$TARGET_COUNT"
+      sed -n "${count}p" "$TARGET_RESPONSES"
+    elif [ "$KUBECTL_MODE" = mixed-targets ]; then
       printf '%s\n' '{"status":"success","data":{"activeTargets":[{"labels":{"app":"dspace","namespace":"dspace"},"health":"up"},{"labels":{"app":"dspace","namespace":"dspace"},"health":"down"}]}}'
     else
       [ "$KUBECTL_MODE" = unhealthy ] && health=down || health=up
@@ -248,6 +266,9 @@ esac
 """,
         encoding="utf-8",
     )
+    (bin_dir / "sleep").write_text(
+        '#!/bin/sh\necho "sleep $*" >> "$AUDIT"\n', encoding="utf-8"
+    )
     for stub in bin_dir.iterdir():
         stub.chmod(0o755)
     env = os.environ | {
@@ -257,6 +278,10 @@ esac
         "CONTEXT": context,
         "KUBECTL_MODE": kubectl_mode,
         "KUBECONFIG": str(tmp_path / "kubeconfig"),
+        "TARGET_RESPONSES": str(responses),
+        "TARGET_COUNT": str(tmp_path / "target-count"),
+        "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS": attempts,
+        "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS": interval,
     }
     result = subprocess.run(
         ["bash", str(SCRIPT), command, "env=staging"],
@@ -329,3 +354,130 @@ def test_verify_exact_three_nodes_secret_reference_and_target_health(tmp_path):
     ):
         result, _ = run_helper(tmp_path / mode, "verify", kubectl_mode=mode)
         assert result.returncode != 0, mode
+
+
+def target_payload(*targets, status="success"):
+    return json.dumps({"status": status, "data": {"activeTargets": list(targets)}})
+
+
+def dspace_target(health, *, pod="dspace-0", instance="10.0.0.1:8080", marker=None):
+    target = {
+        "labels": {
+            "app": "dspace",
+            "namespace": "dspace",
+            "pod": pod,
+            "instance": instance,
+        },
+        "health": health,
+        "lastError": "connection refused",
+        "lastScrape": "2026-07-25T12:00:00Z",
+    }
+    if marker is not None:
+        target["authorization"] = marker
+        target["labels"]["secretValue"] = marker
+    return target
+
+
+def api_calls(audit):
+    return audit.count("kubectl get --raw ")
+
+
+def test_target_health_succeeds_on_first_observation_for_one_or_many_targets(tmp_path):
+    one, audit = run_helper(
+        tmp_path / "one", "verify", target_responses=[target_payload(dspace_target("up"))]
+    )
+    assert one.returncode == 0
+    assert api_calls(audit) == 1 and "sleep " not in audit
+
+    many, audit = run_helper(
+        tmp_path / "many",
+        "verify",
+        target_responses=[target_payload(dspace_target("up"), dspace_target("up", pod="dspace-1"))],
+    )
+    assert many.returncode == 0
+    assert api_calls(audit) == 1 and "sleep " not in audit
+
+
+def test_target_health_retries_empty_unknown_and_mixed_then_succeeds(tmp_path):
+    healthy = target_payload(dspace_target("up"), dspace_target("up", pod="dspace-1"))
+    cases = {
+        "empty": [target_payload(), healthy],
+        "unknown": [target_payload(dspace_target("unknown")), healthy],
+        "mixed": [
+            target_payload(dspace_target("up"), dspace_target("down", pod="dspace-1")),
+            healthy,
+        ],
+    }
+    for name, responses in cases.items():
+        result, audit = run_helper(
+            tmp_path / name, "verify", target_responses=responses, attempts="2", interval="7"
+        )
+        assert result.returncode == 0, name
+        assert api_calls(audit) == 2
+        assert audit.count("sleep 7") == 1
+        assert "attempt 1/2" in result.stderr
+
+
+def test_target_health_timeout_is_bounded_and_empty_never_passes(tmp_path):
+    for name, response in {
+        "empty": target_payload(),
+        "down": target_payload(dspace_target("down")),
+        "mixed": target_payload(dspace_target("up"), dspace_target("down", pod="dspace-1")),
+    }.items():
+        result, audit = run_helper(
+            tmp_path / name,
+            "verify",
+            target_responses=[response, response, response],
+            attempts="3",
+            interval="4",
+        )
+        assert result.returncode != 0, name
+        assert api_calls(audit) == 3
+        assert audit.count("sleep 4") == 2
+        assert "after 3 attempts" in result.stderr
+
+
+def test_target_health_hard_failures_do_not_retry(tmp_path):
+    cases = {
+        "malformed": ["not-json"],
+        "api-error": [target_payload(status="error")],
+        "bad-structure": [json.dumps({"status": "success", "data": {}})],
+    }
+    for name, responses in cases.items():
+        result, audit = run_helper(
+            tmp_path / name, "verify", target_responses=responses, attempts="3"
+        )
+        assert result.returncode != 0, name
+        assert api_calls(audit) == 1
+        assert "sleep " not in audit
+
+    result, audit = run_helper(
+        tmp_path / "transport", "verify", kubectl_mode="query-fail", attempts="3"
+    )
+    assert result.returncode != 0
+    assert api_calls(audit) == 1 and "sleep " not in audit
+
+
+def test_invalid_target_retry_configuration_fails_before_polling(tmp_path):
+    for attempts, interval in (("0", "1"), ("two", "1"), ("1", "0"), ("1", "1.5")):
+        result, audit = run_helper(
+            tmp_path / f"case-{attempts}-{interval}",
+            "verify",
+            attempts=attempts,
+            interval=interval,
+        )
+        assert result.returncode != 0
+        assert api_calls(audit) == 0
+
+
+def test_final_target_diagnostics_are_useful_and_privacy_safe(tmp_path):
+    sensitive = "do-not-print-this-secret"
+    response = target_payload(dspace_target("down", marker=sensitive))
+    result, audit = run_helper(
+        tmp_path, "verify", target_responses=[response, response], attempts="2"
+    )
+    assert result.returncode != 0 and api_calls(audit) == 2
+    for expected in ("dspace-0", "10.0.0.1:8080", "down", "connection refused", "lastScrape"):
+        assert expected in result.stderr
+    assert sensitive not in result.stdout + result.stderr
+    assert "authorization" not in result.stdout + result.stderr


### PR DESCRIPTION
### Motivation
- After a Prometheus restart readiness can precede the first discovery/scrape cycle, causing a transient false failure in `just observability-verify env=staging` when the script performed a one-shot DSPACE target health check.
- The goal is to wait deterministically (but bounded) for Prometheus target discovery and the first successful scrape instead of hard-failing immediately on transient states.

### Description
- Add two validated, overridable retry controls `SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS` (default `20`) and `SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS` (default `15`) and expose them in `scripts/observability_helm.sh`.
- Replace the one-shot Prometheus target check with a new helper `verify_dspace_targets()` that polls the Prometheus service-proxy endpoint via `kubectl get --raw`, parses JSON with Python stdlib, and accepts any positive number of healthy matching targets (labels `app=="dspace"` and `namespace=="dspace"`).
- Treat absent/mixed/`unknown`/`down` target sets as transient and retry up to the bounded attempts, sleeping only between attempts; fail immediately (no retry) on transport errors, malformed JSON, `status != "success"`, or unexpected/missing response structure.
- Preserve privacy-safe diagnostics by printing a concise attempt indicator during retries and, on final timeout, emitting only whitelisted target fields (`pod`, `instance`, `health`, `lastError`, `lastScrape`) while never logging bearer tokens, raw Secrets, Authorization headers, or the full API response; integrate the helper into the existing `verify` flow without changing other guards.
- Update deterministic, stub-based tests in `tests/test_observability_helm.py` to cover first-observation success, retry convergence cases, timeout and bounded sleep counts, hard failures (transport, malformed JSON, API status), one-or-many healthy targets, invalid configuration validation, and privacy-safe diagnostics; update documentation in `docs/observability-operations.md` to describe the wait window and overrides.

### Testing
- Ran `bash -n scripts/observability_helm.sh` which reported no syntax errors.
- Ran `pytest -q tests/test_observability_helm.py` and observed `23 passed` covering the new helper and all requested scenarios.
- Ran `ruff check tests/test_observability_helm.py`, `git diff --check`, and `git diff | ./scripts/scan-secrets.py` which passed with no new secret findings, and verified only the three scoped files were modified (`scripts/observability_helm.sh`, `tests/test_observability_helm.py`, `docs/observability-operations.md`).
- Unavailable in the environment: `shellcheck scripts/observability_helm.sh`, `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` (these tools are not installed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6422686258832fb7a974a696c3113f)