### PR TITLE
Add guarded staging NetworkPolicy for Prometheus → blackbox-exporter and integrate into blackbox lifecycle

### DIFF
--- a/clusters/staging/observability/network-policies/kustomization.yaml
+++ b/clusters/staging/observability/network-policies/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - prometheus-to-blackbox-exporter.yaml

--- a/clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml
+++ b/clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-kube-prometheus-stack-to-blackbox-exporter
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: kube-prometheus-stack-prometheus
+      app.kubernetes.io/name: prometheus
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: prometheus-blackbox-exporter
+              app.kubernetes.io/name: prometheus-blackbox-exporter
+      ports:
+        - protocol: TCP
+          port: 9115

--- a/docs/observability-blackbox.md
+++ b/docs/observability-blackbox.md
@@ -3,11 +3,11 @@
 Public-route monitoring has a guarded, **staging-only, non-Flux** lifecycle. The
 exporter, Prometheus, and their administrative interfaces remain LAN/internal
 only. The exporter is a `ClusterIP` service; this work adds no Ingress,
-NodePort, public DNS, router rule, credential, persistence, or NetworkPolicy.
-The existing monitoring default-deny policy therefore requires a separately
-scoped egress-policy prerequisite allowing Prometheus to reach exporter TCP
-9115 before any fresh-cluster rollout can succeed; this lifecycle does not
-resolve that prerequisite.
+NodePort, public DNS, router rule, credential, or persistence. The lifecycle
+owns one staging-only NetworkPolicy that permits only the canonical Prometheus
+pods to reach the canonical exporter pods on TCP 9115. Existing DNS and
+external HTTPS permissions in `platform/networking/platform-allow.yaml` remain
+unchanged.
 
 ## Canonical sources
 
@@ -19,6 +19,10 @@ resolve that prerequisite.
   `clusters/staging/observability/prometheus-blackbox-exporter.values.yaml`.
 - Lifecycle-owned Probes and deterministic Kustomize entrypoint:
   `clusters/staging/observability/probes/`.
+- Lifecycle-owned NetworkPolicy and deterministic Kustomize entrypoint:
+  `clusters/staging/observability/network-policies/`. The canonical manifest is
+  `prometheus-to-blackbox-exporter.yaml`; it is not in an active Flux or cluster
+  Kustomize graph.
 - Helper: `scripts/observability_blackbox.sh`, exposed by
   `just observability-blackbox-*`.
 
@@ -45,10 +49,12 @@ just observability-blackbox-verify env=staging
 Render, status, and verify are read-only. Install is only for an absent exporter
 release; upgrade requires it to exist. Both render the pinned chart and Probes
 first, pass the complete committed values on every Helm operation, and wait up
-to the Pi-appropriate timeout. Only after Helm succeeds, they delete the eleven
-explicit legacy production Probe names formerly present in the shared matrix,
-using `--ignore-not-found`, then apply the rendered staging Probes. No selector
-pruning or staging Probe deletion is used. Neither uses
+to the Pi-appropriate timeout. The mutation order is Helm install/upgrade,
+NetworkPolicy apply, deletion of the eleven explicit legacy production Probe
+names formerly present in the shared matrix using `--ignore-not-found`, then
+staging Probe apply. Helm failure prevents every later mutation; policy failure
+prevents both Probe mutations. No selector pruning or staging Probe deletion is
+used. Neither uses
 `--reuse-values`. Missing environments and production are rejected;
 `env=int` remains a deprecated alias for staging.
 
@@ -67,7 +73,10 @@ Prometheus Kubernetes service proxy and bounded polling to prove the exact
 app/route target matrix, `probe_success == 1`, and the duration, HTTP status,
 DNS lookup, and earliest TLS certificate-expiry metric families. It never logs
 raw target payloads or URLs; terminal diagnostics contain bounded labels and
-health/series states only.
+health/series states only. Before polling Prometheus, verification fails closed
+unless the deployed policy has exactly the required source selector,
+destination selector, Egress type, single peer/rule, and TCP 9115 port. Status
+prints that exact named policy. Status and verify remain read-only.
 
 ## Post-merge rollout
 
@@ -77,16 +86,18 @@ health/series states only.
 4. Run status, then verify. Preserve this output as separate live evidence.
 5. Stop and investigate rather than attempting production if any guard fails.
 
-No live-cluster operation is part of repository review or CI.
+No live deployment was performed as part of this repository change. Repository
+state is not live-deployment evidence.
 
 ## Rollback
 
-Inspect Helm history, roll back the exporter, then reapply the Probe render from
-the matching Git revision and verify:
+Inspect Helm history, roll back the exporter, then reapply both lifecycle-owned
+renders from the matching Git revision and verify:
 
 ```bash
 helm -n monitoring history prometheus-blackbox-exporter
 helm -n monitoring rollback prometheus-blackbox-exporter <prior-revision> --wait --timeout 20m
+kubectl apply -k clusters/staging/observability/network-policies
 kubectl apply -k clusters/staging/observability/probes
 just observability-blackbox-verify env=staging
 ```

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -12,7 +12,15 @@ Production observability is intentionally unsupported in this slice because no p
 - Helper: `scripts/observability_helm.sh` through `just observability-*` recipes.
 
 The staging blackbox exporter and Probe lifecycle is documented separately in
-[Staging blackbox monitoring](observability-blackbox.md).
+[Staging blackbox monitoring](observability-blackbox.md). That guarded
+non-Flux lifecycle exclusively owns
+`clusters/staging/observability/network-policies/`, including the narrow
+Prometheus-to-exporter TCP 9115 policy; the directory is intentionally outside
+active Kustomize graphs. Its post-merge operator flow applies Helm, then the
+policy, then legacy Probe cleanup, then staging Probes, and verifies the exact
+deployed policy before Prometheus convergence. Existing monitoring DNS and
+external HTTPS permissions are unchanged. No live deployment was performed by
+the repository change.
 
 The old Flux/Longhorn files under `platform/observability/*.yaml` and `clusters/*/patches/kube-prometheus-stack-values.yaml` are inactive, unvalidated future/legacy configuration. They are deliberately absent from the platform resources and cluster overlay patches, so Flux does not reconcile the manually managed release. They must not be applied to staging or production as currently written, and operators must not combine Flux and manual Helm lifecycle paths for the same `kube-prometheus-stack` release.
 

--- a/scripts/observability_blackbox.sh
+++ b/scripts/observability_blackbox.sh
@@ -10,6 +10,8 @@ REPOSITORY="https://prometheus-community.github.io/helm-charts"
 VERSION_FILE="${ROOT}/platform/observability/helm/prometheus-blackbox-exporter.version"
 VALUES="${ROOT}/clusters/staging/observability/prometheus-blackbox-exporter.values.yaml"
 PROBES="${ROOT}/clusters/staging/observability/probes"
+POLICY_SOURCE="${ROOT}/clusters/staging/observability/network-policies"
+POLICY_NAME="allow-kube-prometheus-stack-to-blackbox-exporter"
 TIMEOUT="${SUGARKUBE_OBSERVABILITY_HELM_TIMEOUT:-20m}"
 PROMETHEUS_SERVICE="kube-prometheus-stack-prometheus"
 LEGACY_PROBES=(
@@ -45,6 +47,7 @@ pinned version: $(version)
 ordered values files:
   - ${VALUES}
 Probe manifest path: ${PROBES}
+NetworkPolicy manifest path: ${POLICY_SOURCE}
 EOT
 }
 assert_context() {
@@ -53,22 +56,39 @@ assert_context() {
   python3 "${ROOT}/scripts/cluster_identity.py" assert --kubeconfig "${KUBECONFIG:-${HOME}/.kube/config}" --env staging >/dev/null
 }
 render_to() {
-  local chart_out="$1" probe_out="$2"
+  local chart_out="$1" policy_out="$2" probe_out="$3"
   helm repo add prometheus-community "${REPOSITORY}" --force-update >/dev/null
   helm repo update prometheus-community >/dev/null
   helm template "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${VALUES}" >"${chart_out}"
+  kubectl kustomize "${POLICY_SOURCE}" >"${policy_out}"
   kubectl kustomize "${PROBES}" >"${probe_out}"
-  [[ -s "${chart_out}" && -s "${probe_out}" ]] || { echo "ERROR: chart and Probe renders must both be non-empty." >&2; exit 4; }
-  python3 - "${chart_out}" <<'PY'
+  [[ -s "${chart_out}" && -s "${policy_out}" && -s "${probe_out}" ]] || { echo "ERROR: chart, NetworkPolicy, and Probe renders must all be non-empty." >&2; exit 4; }
+  python3 - "${chart_out}" "${policy_out}" <<'PY'
 import re, sys
 text = open(sys.argv[1], encoding="utf-8").read()
+policy = open(sys.argv[2], encoding="utf-8").read()
 docs = text.split("\n---")
 deployments = [d for d in docs if re.search(r"(?m)^kind: Deployment$", d) and re.search(r"(?m)^  name: prometheus-blackbox-exporter$", d)]
 monitors = [d for d in docs if re.search(r"(?m)^kind: ServiceMonitor$", d) and re.search(r"(?m)^  name: prometheus-blackbox-exporter$", d)]
 if len(deployments) != 1 or not re.search(r"(?m)^  replicas: 1$", deployments[0]):
     raise SystemExit("ERROR: rendered exporter Deployment must have exactly one replica.")
+for label in (
+    "app.kubernetes.io/name: prometheus-blackbox-exporter",
+    "app.kubernetes.io/instance: prometheus-blackbox-exporter",
+):
+    if label not in deployments[0]:
+        raise SystemExit("ERROR: rendered exporter Deployment lacks its canonical pod labels.")
 if len(monitors) != 1 or not re.search(r"(?m)^    release: kube-prometheus-stack$", monitors[0]):
     raise SystemExit("ERROR: rendered exporter ServiceMonitor must carry the base release label.")
+required = (
+    "name: allow-kube-prometheus-stack-to-blackbox-exporter", "namespace: monitoring",
+    "app.kubernetes.io/instance: kube-prometheus-stack-prometheus",
+    "app.kubernetes.io/name: prometheus", "policyTypes:", "- Egress", "egress:",
+    "app.kubernetes.io/instance: prometheus-blackbox-exporter",
+    "app.kubernetes.io/name: prometheus-blackbox-exporter", "protocol: TCP", "port: 9115",
+)
+if any(value not in policy for value in required) or policy.count("kind: NetworkPolicy") != 1:
+    raise SystemExit("ERROR: rendered lifecycle NetworkPolicy is incomplete.")
 PY
 }
 release_state() {
@@ -85,17 +105,26 @@ preflight() {
 }
 with_render() {
   CHART_RENDER="$(mktemp -t sugarkube-blackbox-chart.XXXXXX.yaml)"
+  POLICY_RENDER="$(mktemp -t sugarkube-blackbox-policy.XXXXXX.yaml)"
   PROBE_RENDER="$(mktemp -t sugarkube-blackbox-probes.XXXXXX.yaml)"
-  trap 'rm -f "${CHART_RENDER:-}" "${PROBE_RENDER:-}"' EXIT
-  render_to "${CHART_RENDER}" "${PROBE_RENDER}"
+  trap 'rm -f "${CHART_RENDER:-}" "${POLICY_RENDER:-}" "${PROBE_RENDER:-}"' EXIT
+  render_to "${CHART_RENDER}" "${POLICY_RENDER}" "${PROBE_RENDER}"
 }
-render() { require_tools helm kubectl; print_resolved; with_render; cat "${CHART_RENDER}" "${PROBE_RENDER}"; }
+render() {
+  require_tools helm kubectl python3; print_resolved; with_render
+  cat "${CHART_RENDER}"
+  printf '\n---\n'
+  cat "${POLICY_RENDER}"
+  printf '\n---\n'
+  cat "${PROBE_RENDER}"
+}
 mutate() {
   local action="$1" state
   require_tools helm kubectl python3; print_resolved; with_render; assert_context; preflight; state="$(release_state)"
   if [[ "${action}" == install && "${state}" == present ]]; then echo "ERROR: install requires an absent ${RELEASE} release; use upgrade." >&2; exit 6; fi
   if [[ "${action}" == upgrade && "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing ${RELEASE} release; use install." >&2; exit 6; fi
   helm "${action}" "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${VALUES}" --wait --timeout "${TIMEOUT}"
+  kubectl apply -f "${POLICY_RENDER}"
   # Remove only the production Probes left by the former mixed staging matrix.
   kubectl -n "${NAMESPACE}" delete probe "${LEGACY_PROBES[@]}" --ignore-not-found
   kubectl apply -f "${PROBE_RENDER}"
@@ -104,7 +133,11 @@ status() {
   require_tools helm kubectl python3; print_resolved; with_render; assert_context
   helm -n "${NAMESPACE}" status "${RELEASE}"
   kubectl -n "${NAMESPACE}" get deployment,pods,service,servicemonitor -l "app.kubernetes.io/instance=${RELEASE}"
+  kubectl -n "${NAMESPACE}" get networkpolicy "${POLICY_NAME}" -o yaml
   kubectl -n "${NAMESPACE}" get probe -l 'release=kube-prometheus-stack,environment=staging' -L app,route,criticality
+}
+validate_policy() {
+  kubectl -n "${NAMESPACE}" get networkpolicy "${POLICY_NAME}" -o json | python3 "${ROOT}/scripts/verify_blackbox_network_policy.py"
 }
 validate_resources() {
   kubectl -n "${NAMESPACE}" rollout status "deployment/${RELEASE}" --timeout="${TIMEOUT}"
@@ -159,7 +192,7 @@ verify_series() {
   done
   exit 10
 }
-verify() { require_tools helm kubectl python3 sleep; print_resolved; with_render; assert_context; preflight; [[ "$(release_state)" == present ]] || { echo "ERROR: exporter release is absent." >&2; exit 7; }; validate_resources; verify_series; }
+verify() { require_tools helm kubectl python3 sleep; print_resolved; with_render; assert_context; preflight; [[ "$(release_state)" == present ]] || { echo "ERROR: exporter release is absent." >&2; exit 7; }; validate_policy; validate_resources; verify_series; }
 
 cmd="${1:-}"; shift || true; [[ -n "${cmd}" ]] || { usage; exit 2; }; normalize_env "${1:-}" >/dev/null
 case "${cmd}" in render) render;; install|upgrade) mutate "${cmd}";; status) status;; verify) verify;; *) usage; exit 2;; esac

--- a/scripts/verify_blackbox_network_policy.py
+++ b/scripts/verify_blackbox_network_policy.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Fail-closed validation for the blackbox lifecycle NetworkPolicy."""
+
+import json
+import sys
+
+EXPECTED_SPEC = {
+    "podSelector": {
+        "matchLabels": {
+            "app.kubernetes.io/instance": "kube-prometheus-stack-prometheus",
+            "app.kubernetes.io/name": "prometheus",
+        }
+    },
+    "policyTypes": ["Egress"],
+    "egress": [
+        {
+            "to": [
+                {
+                    "podSelector": {
+                        "matchLabels": {
+                            "app.kubernetes.io/instance": "prometheus-blackbox-exporter",
+                            "app.kubernetes.io/name": "prometheus-blackbox-exporter",
+                        }
+                    }
+                }
+            ],
+            "ports": [{"protocol": "TCP", "port": 9115}],
+        }
+    ],
+}
+
+
+def main() -> int:
+    try:
+        policy = json.load(sys.stdin)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        print("ERROR: lifecycle NetworkPolicy response is not valid JSON.", file=sys.stderr)
+        return 7
+    if not isinstance(policy, dict) or policy.get("spec") != EXPECTED_SPEC:
+        print("ERROR: lifecycle NetworkPolicy does not have the exact required egress policy.", file=sys.stderr)
+        return 7
+    metadata = policy.get("metadata")
+    if not isinstance(metadata, dict) or metadata.get("name") != (
+        "allow-kube-prometheus-stack-to-blackbox-exporter"
+    ) or metadata.get("namespace") != "monitoring":
+        print("ERROR: lifecycle NetworkPolicy identity is invalid.", file=sys.stderr)
+        return 7
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_monitoring_blackbox.py
+++ b/tests/test_monitoring_blackbox.py
@@ -5,6 +5,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 VALUES = ROOT / "clusters/staging/observability/prometheus-blackbox-exporter.values.yaml"
 PROBES = ROOT / "clusters/staging/observability/probes/public-apps.yaml"
+POLICY = ROOT / "clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml"
 EXPECTED = {
     ("dspace", "root", "https://staging.democratized.space/", "https_2xx"),
     ("dspace", "config", "https://staging.democratized.space/config.json", "static_content_2xx"),
@@ -112,7 +113,54 @@ def test_legacy_resources_are_outside_active_graphs():
     assert "LEGACY/FUTURE ONLY" in (ROOT / "monitoring/probes/public-apps.yaml").read_text()
 
 
-def test_network_policy_prerequisite_is_explicitly_deferred():
-    docs = (ROOT / "docs/observability-blackbox.md").read_text()
-    assert "separately\nscoped egress-policy prerequisite" in docs
-    assert "this lifecycle does not\nresolve that prerequisite" in docs
+def test_lifecycle_network_policy_is_exact_and_inactive():
+    policy = yaml(POLICY)[0]
+    assert policy == {
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "name": "allow-kube-prometheus-stack-to-blackbox-exporter",
+            "namespace": "monitoring",
+        },
+        "spec": {
+            "podSelector": {"matchLabels": {
+                "app.kubernetes.io/instance": "kube-prometheus-stack-prometheus",
+                "app.kubernetes.io/name": "prometheus",
+            }},
+            "policyTypes": ["Egress"],
+            "egress": [{
+                "to": [{"podSelector": {"matchLabels": {
+                    "app.kubernetes.io/instance": "prometheus-blackbox-exporter",
+                    "app.kubernetes.io/name": "prometheus-blackbox-exporter",
+                }}}],
+                "ports": [{"protocol": "TCP", "port": 9115}],
+            }],
+        },
+    }
+    entrypoint = yaml(POLICY.parent / "kustomization.yaml")[0]
+    assert entrypoint["resources"] == ["prometheus-to-blackbox-exporter.yaml"]
+    assert "network-policies" not in (
+        ROOT / "clusters/staging/kustomization.yaml"
+    ).read_text()
+
+
+def test_policy_selectors_match_pinned_chart_render_labels():
+    """Labels recorded from complete 87.19.0 and 11.15.1 staging renders."""
+    assert (
+        ROOT / "platform/observability/helm/kube-prometheus-stack.version"
+    ).read_text().strip() == "87.19.0"
+    source = yaml(POLICY)[0]["spec"]["podSelector"]["matchLabels"]
+    destination = yaml(POLICY)[0]["spec"]["egress"][0]["to"][0]["podSelector"][
+        "matchLabels"
+    ]
+    # The complete stack render's Prometheus affinity targets the operator-created
+    # pods with this canonical resource identity; the exporter Deployment render
+    # uses these exact selector/template labels.
+    assert source == {
+        "app.kubernetes.io/name": "prometheus",
+        "app.kubernetes.io/instance": "kube-prometheus-stack-prometheus",
+    }
+    assert destination == {
+        "app.kubernetes.io/name": "prometheus-blackbox-exporter",
+        "app.kubernetes.io/instance": "prometheus-blackbox-exporter",
+    }

--- a/tests/test_observability_blackbox.py
+++ b/tests/test_observability_blackbox.py
@@ -13,6 +13,10 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts/observability_blackbox.sh"
 VALUES = ROOT / "clusters/staging/observability/prometheus-blackbox-exporter.values.yaml"
+POLICY = (
+    ROOT / "clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml"
+)
+POLICY_NAME = "allow-kube-prometheus-stack-to-blackbox-exporter"
 LEGACY = [
     "blackbox-dspace-prod-root",
     "blackbox-dspace-prod-config",
@@ -100,6 +104,15 @@ metadata:
   name: prometheus-blackbox-exporter
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-blackbox-exporter
+      app.kubernetes.io/instance: prometheus-blackbox-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prometheus-blackbox-exporter
+        app.kubernetes.io/instance: prometheus-blackbox-exporter
 ---
 kind: ServiceMonitor
 metadata:
@@ -126,7 +139,31 @@ joined = " ".join(args)
 if args[:2] == ["config", "current-context"]:
     print("wrong-context" if scenario == "bad_context" else "sugar-staging")
 elif args[:1] == ["kustomize"]:
-    print("kind: Probe\nmetadata:\n  name: rendered-probe")
+    if "network-policies" in joined:
+        print(open(os.environ["POLICY_YAML"]).read())
+    else: print("kind: Probe\nmetadata:\n  name: rendered-probe")
+elif "get networkpolicy" in joined and "-o json" in joined:
+    if scenario == "missing_policy": sys.exit(1)
+    if scenario == "malformed_policy": print("not-json"); sys.exit(0)
+    policy = json.load(open(os.environ["POLICY_JSON"]))
+    if scenario.startswith("policy_"):
+        mutation = scenario.removeprefix("policy_")
+        spec = policy["spec"]
+        if mutation == "source_broad": spec["podSelector"] = {"matchLabels": {"app.kubernetes.io/name": "prometheus"}}
+        elif mutation == "source_empty": spec["podSelector"] = {}
+        elif mutation == "destination_broad": spec["egress"][0]["to"][0]["podSelector"] = {}
+        elif mutation == "protocol": spec["egress"][0]["ports"][0]["protocol"] = "UDP"
+        elif mutation == "port": spec["egress"][0]["ports"][0]["port"] = 9116
+        elif mutation == "peer": spec["egress"][0]["to"].append({"podSelector": {"matchLabels": {"x": "y"}}})
+        elif mutation == "rule": spec["egress"].append({"to": [{"ipBlock": {"cidr": "0.0.0.0/0"}}]})
+        elif mutation == "type": spec["policyTypes"].append("Ingress")
+        elif mutation == "ipblock": spec["egress"][0]["to"][0] = {"ipBlock": {"cidr": "10.0.0.0/8"}}
+        elif mutation == "namespace": spec["egress"][0]["to"][0]["namespaceSelector"] = {}
+        elif mutation == "ingress": spec["ingress"] = []
+        elif mutation == "additional_port": spec["egress"][0]["ports"].append({"protocol": "TCP", "port": 443})
+    print(json.dumps(policy))
+elif "get networkpolicy" in joined and "-o yaml" in joined:
+    print(open(os.environ["POLICY_YAML"]).read())
 elif "get crd" in joined and scenario == "missing_crds": sys.exit(1)
 elif "get service kube-prometheus-stack-prometheus" in joined and scenario == "missing_service": sys.exit(1)
 elif "rollout status" in joined and scenario == "not_ready": sys.exit(1)
@@ -165,6 +202,8 @@ elif "--raw" in joined:
         family = next(name for name in bundle["metrics"] if name in joined)
         payload = bundle["metrics"][family]
     print(json.dumps(payload))
+elif args[:2] == ["apply", "-f"] and scenario == "policy_apply_failure" and "policy" in joined:
+    sys.exit(31)
 """
 
 PYTHON_STUB = r"""#!/usr/bin/python3
@@ -229,6 +268,23 @@ def scenario(tmp_path):
         capture_output=True,
     )
     probes.write_text(json.dumps({"items": json.loads(docs.stdout)}))
+    policy_docs = json.loads(
+        subprocess.run(
+            [
+                "ruby",
+                "-ryaml",
+                "-rjson",
+                "-e",
+                "puts JSON.generate(YAML.load_file(ARGV[0]))",
+                str(POLICY),
+            ],
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout
+    )
+    policy_json = tmp_path / "policy.json"
+    policy_json.write_text(json.dumps(policy_docs))
     prom = tmp_path / "prom.json"
     prom.write_text(json.dumps(verifier_bundle()))
     env = {
@@ -236,6 +292,8 @@ def scenario(tmp_path):
         "PATH": f"{bindir}:{os.environ['PATH']}",
         "LOG": str(tmp_path / "operations.log"),
         "PROBES_JSON": str(probes),
+        "POLICY_YAML": str(POLICY),
+        "POLICY_JSON": str(policy_json),
         "PROM_JSON": str(prom),
         "RAW_COUNT": str(tmp_path / "raw-count"),
         "REAL_PYTHON": sys.executable,
@@ -291,11 +349,9 @@ def test_rendering_precedes_release_queries(scenario):
     result = scenario.run("install", SCENARIO="release_absent")
     assert result.returncode == 0
     template = next(i for i, line in enumerate(scenario.log) if line.startswith("helm template"))
-    kustomize = next(
-        i for i, line in enumerate(scenario.log) if line.startswith("kubectl kustomize")
-    )
+    kustomizes = [i for i, line in enumerate(scenario.log) if line.startswith("kubectl kustomize")]
     query = next(i for i, line in enumerate(scenario.log) if line.startswith("helm list"))
-    assert template < query and kustomize < query
+    assert template < query and len(kustomizes) == 2 and max(kustomizes) < query
 
 
 @pytest.mark.parametrize("command,state", [("install", "success"), ("upgrade", "upgrade_absent")])
@@ -315,8 +371,16 @@ def test_successful_mutation_uses_pinned_complete_values_and_order(scenario, com
     assert "--wait --timeout 7m" in mutation
     assert "--reuse-values" not in mutation
     delete = next(line for line in scenario.log if " delete probe " in line)
-    apply = next(line for line in scenario.log if line.startswith("kubectl apply"))
-    assert scenario.log.index(mutation) < scenario.log.index(delete) < scenario.log.index(apply)
+    applies = [line for line in scenario.log if line.startswith("kubectl apply")]
+    assert len(applies) == 2
+    assert "sugarkube-blackbox-policy" in applies[0]
+    assert "sugarkube-blackbox-probes" in applies[1]
+    assert (
+        scenario.log.index(mutation)
+        < scenario.log.index(applies[0])
+        < scenario.log.index(delete)
+        < scenario.log.index(applies[1])
+    )
     assert delete.endswith("delete probe " + " ".join(LEGACY) + " --ignore-not-found")
 
 
@@ -328,11 +392,52 @@ def test_failed_helm_mutation_suppresses_cleanup_and_apply(scenario):
     )
 
 
+def test_failed_policy_apply_suppresses_all_probe_mutation(scenario):
+    result = scenario.run("upgrade", SCENARIO="policy_apply_failure")
+    assert result.returncode == 31
+    assert not any(" delete probe " in line for line in scenario.log)
+    assert not any(
+        "sugarkube-blackbox-probes" in line and line.startswith("kubectl apply")
+        for line in scenario.log
+    )
+
+
 @pytest.mark.parametrize("command", ["status", "verify"])
 def test_read_only_commands_never_mutate(scenario, command):
     result = scenario.run(command)
     assert result.returncode == 0
     assert not mutations(scenario.log)
+
+
+def test_status_displays_exact_lifecycle_policy(scenario):
+    result = scenario.run("status")
+    assert result.returncode == 0
+    assert any(f"get networkpolicy {POLICY_NAME} -o yaml" in line for line in scenario.log)
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        "missing_policy",
+        "malformed_policy",
+        "policy_source_broad",
+        "policy_source_empty",
+        "policy_destination_broad",
+        "policy_protocol",
+        "policy_port",
+        "policy_peer",
+        "policy_rule",
+        "policy_type",
+        "policy_ipblock",
+        "policy_namespace",
+        "policy_ingress",
+        "policy_additional_port",
+    ],
+)
+def test_policy_verification_fails_closed_before_prometheus(scenario, failure):
+    result = scenario.run("verify", SCENARIO=failure)
+    assert result.returncode != 0
+    assert not any("--raw" in line for line in scenario.log)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation
- The `monitoring` namespace uses default-deny policies and the staging blackbox lifecycle needs a single narrow egress path from the kube-prometheus-stack Prometheus pods to the prometheus-blackbox-exporter pods on TCP 9115. 
- The lifecycle is guarded and non‑Flux so the policy must be lifecycle-owned, rendered from committed chart/values, and applied only by the lifecycle helper in a controlled ordering. 
- Verification must fail closed on absent/broadened/malformed policies so a staged rollout cannot proceed with an incorrect policy.

### Description
- Added a lifecycle-owned, staging-only NetworkPolicy manifest at `clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml` and a `kustomization.yaml` entrypoint; the policy is `monitoring`-scoped, `policyTypes: [Egress]`, selects only canonical Prometheus pods, permits only canonical exporter pods, and allows exactly `TCP 9115`. 
- Integrated rendering, validation, and application of the policy into the guarded lifecycle helper by updating `scripts/observability_blackbox.sh` to render `helm template` + policy + probes, then perform Helm → `kubectl apply` policy → legacy Probe deletion → `kubectl apply` probes, and to show and verify the exact policy in `status`/`verify`. 
- Added a fail-closed JSON verifier `scripts/verify_blackbox_network_policy.py` that rejects deployed policies which differ semantically from the exact required selectors, peers, ports, or policy type. 
- Extended offline regression tests in `tests/test_monitoring_blackbox.py` and `tests/test_observability_blackbox.py` to cover chart-backed selectors, policy rendering-before-cluster-access, Helm→policy→delete→probes ordering, Helm and policy failure suppression of later mutations, missing/malformed/broad policies, and `status`/`verify` read-only behavior, and updated docs in `docs/observability-blackbox.md` and `docs/observability-operations.md` to document ownership, ordering, verification, rollback, and post-merge rollout.

### Testing
- `bash -n scripts/observability_blackbox.sh` returned no syntax errors. 
- `pytest -q tests/test_observability_blackbox.py` — 48 passed. 
- `pytest -q tests/test_monitoring_blackbox.py tests/test_observability_blackbox.py` — 53 passed. 
- `ruff check tests/test_observability_blackbox.py` and `black --check tests/test_observability_blackbox.py` passed after formatting the test file. 
- `git diff --check` and `git diff | ./scripts/scan-secrets.py` produced no secret findings for the staged changes; `linkchecker --no-warnings README.md docs/` completed (201 links, 0 errors). 
- `pyspelling -c .spellcheck.yaml` could not be executed in this environment because the system `aspell` binary is unavailable, and `pre-commit run --all-files` surfaced unrelated, pre-existing repository-wide trailing-whitespace/YAML-hook issues which were not committed (hook edits were reverted). 
- No live Helm or `kubectl` mutation was performed; chart rendering used local `helm template`/`kubectl kustomize` stubs in tests and all cluster mutations are gated by the helper guards. 

Change summary: add lifecycle NetworkPolicy, render/validate it before cluster access, apply it in guarded mutation ordering, add strict verification and tests, and update docs. 

Post-merge staging rollout (manual operator steps):
- Render and inspect without mutation: `just observability-blackbox-render env=staging`.
- If exporter release is absent: `just observability-blackbox-install env=staging` then `just observability-blackbox-status env=staging` and `just observability-blackbox-verify env=staging`.
- If exporter release already exists: `just observability-blackbox-upgrade env=staging` then `just observability-blackbox-status env=staging` and `just observability-blackbox-verify env=staging`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6473970128832f99767287ffc5b8a6)