### PR TITLE
Add staging blackbox NetworkPolicy lifecycle

### DIFF
--- a/clusters/staging/observability/network-policies/kustomization.yaml
+++ b/clusters/staging/observability/network-policies/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - prometheus-to-blackbox-exporter.yaml

--- a/clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml
+++ b/clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-kube-prometheus-stack-to-blackbox-exporter
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: kube-prometheus-stack
+      app.kubernetes.io/name: prometheus
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: prometheus-blackbox-exporter
+              app.kubernetes.io/name: prometheus-blackbox-exporter
+      ports:
+        - protocol: TCP
+          port: 9115

--- a/docs/observability-blackbox.md
+++ b/docs/observability-blackbox.md
@@ -3,11 +3,11 @@
 Public-route monitoring has a guarded, **staging-only, non-Flux** lifecycle. The
 exporter, Prometheus, and their administrative interfaces remain LAN/internal
 only. The exporter is a `ClusterIP` service; this work adds no Ingress,
-NodePort, public DNS, router rule, credential, persistence, or NetworkPolicy.
-The existing monitoring default-deny policy therefore requires a separately
-scoped egress-policy prerequisite allowing Prometheus to reach exporter TCP
-9115 before any fresh-cluster rollout can succeed; this lifecycle does not
-resolve that prerequisite.
+NodePort, public DNS, router rule, credential, or persistence. The lifecycle
+supplies one narrowly scoped staging NetworkPolicy allowing only the canonical
+Prometheus pods to reach only the canonical exporter pods on TCP 9115. Existing
+same-namespace ingress, DNS, and external HTTPS permissions in
+`platform/networking/platform-allow.yaml` remain unchanged.
 
 ## Canonical sources
 
@@ -19,6 +19,10 @@ resolve that prerequisite.
   `clusters/staging/observability/prometheus-blackbox-exporter.values.yaml`.
 - Lifecycle-owned Probes and deterministic Kustomize entrypoint:
   `clusters/staging/observability/probes/`.
+- Lifecycle-owned NetworkPolicy and deterministic Kustomize entrypoint:
+  `clusters/staging/observability/network-policies/`. The canonical manifest is
+  `prometheus-to-blackbox-exporter.yaml`; it is intentionally absent from every
+  Flux and cluster Kustomize graph.
 - Helper: `scripts/observability_blackbox.sh`, exposed by
   `just observability-blackbox-*`.
 
@@ -45,7 +49,8 @@ just observability-blackbox-verify env=staging
 Render, status, and verify are read-only. Install is only for an absent exporter
 release; upgrade requires it to exist. Both render the pinned chart and Probes
 first, pass the complete committed values on every Helm operation, and wait up
-to the Pi-appropriate timeout. Only after Helm succeeds, they delete the eleven
+to the Pi-appropriate timeout. Only after Helm succeeds, they apply the rendered NetworkPolicy. Only after
+that apply succeeds do they delete the eleven
 explicit legacy production Probe names formerly present in the shared matrix,
 using `--ignore-not-found`, then apply the rendered staging Probes. No selector
 pruning or staging Probe deletion is used. Neither uses
@@ -67,26 +72,37 @@ Prometheus Kubernetes service proxy and bounded polling to prove the exact
 app/route target matrix, `probe_success == 1`, and the duration, HTTP status,
 DNS lookup, and earliest TLS certificate-expiry metric families. It never logs
 raw target payloads or URLs; terminal diagnostics contain bounded labels and
-health/series states only.
+health/series states only. Before polling Prometheus, verification reads the
+exact lifecycle-owned policy and fails closed unless its source selector,
+destination selector, sole egress rule, TCP 9115 port, and `Egress` policy type
+match the committed contract semantically. Extra or broad selectors, peers,
+rules, ports, policy types, ingress, `ipBlock`, and `namespaceSelector` behavior
+are rejected. Status shows that exact named policy. Both commands remain
+read-only.
 
 ## Post-merge rollout
 
 1. Select and independently confirm the staging kubeconfig and cluster identity.
 2. Review `just observability-blackbox-render env=staging` without applying it.
-3. Use install for a new release or upgrade for an existing release.
+3. If `helm -n monitoring list --all --filter
+   '^prometheus-blackbox-exporter$' --short` is empty, use
+   `just observability-blackbox-install env=staging`; otherwise use
+   `just observability-blackbox-upgrade env=staging`.
 4. Run status, then verify. Preserve this output as separate live evidence.
 5. Stop and investigate rather than attempting production if any guard fails.
 
-No live-cluster operation is part of repository review or CI.
+No live deployment was performed as part of this repository change; repository
+state is not evidence of deployment.
 
 ## Rollback
 
-Inspect Helm history, roll back the exporter, then reapply the Probe render from
-the matching Git revision and verify:
+Inspect Helm history, roll back the exporter, then reapply the policy and Probe
+renders from the matching Git revision and verify:
 
 ```bash
 helm -n monitoring history prometheus-blackbox-exporter
 helm -n monitoring rollback prometheus-blackbox-exporter <prior-revision> --wait --timeout 20m
+kubectl apply -k clusters/staging/observability/network-policies
 kubectl apply -k clusters/staging/observability/probes
 just observability-blackbox-verify env=staging
 ```
@@ -122,3 +138,5 @@ helper neither manages production nor supplies a replacement production
 lifecycle. Any future Flux adoption
 of the exporter or staging Probes must first retire the manual lifecycle and
 must never manage the same Helm release or Probe object names simultaneously.
+The same exclusive ownership boundary applies to
+`allow-kube-prometheus-stack-to-blackbox-exporter`.

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -12,7 +12,10 @@ Production observability is intentionally unsupported in this slice because no p
 - Helper: `scripts/observability_helm.sh` through `just observability-*` recipes.
 
 The staging blackbox exporter and Probe lifecycle is documented separately in
-[Staging blackbox monitoring](observability-blackbox.md).
+[Staging blackbox monitoring](observability-blackbox.md). That lifecycle also
+exclusively owns its staging-only Prometheus-to-exporter NetworkPolicy; the
+policy is not part of this base-stack or Flux lifecycle, and the existing DNS
+and external HTTPS permissions remain unchanged.
 
 The old Flux/Longhorn files under `platform/observability/*.yaml` and `clusters/*/patches/kube-prometheus-stack-values.yaml` are inactive, unvalidated future/legacy configuration. They are deliberately absent from the platform resources and cluster overlay patches, so Flux does not reconcile the manually managed release. They must not be applied to staging or production as currently written, and operators must not combine Flux and manual Helm lifecycle paths for the same `kube-prometheus-stack` release.
 
@@ -121,6 +124,6 @@ Do not use `--reuse-values` for the next forward upgrade; commit the full intend
 
 ## Follow-ups intentionally out of scope
 
-Dashboards, useful Alertmanager receivers, NetworkPolicies, Grafana persistence,
+Dashboards, useful Alertmanager receivers, additional NetworkPolicies, Grafana persistence,
 central multi-cluster Grafana, and production observability codification are
 separate follow-ups.

--- a/platform/observability/helm/kube-prometheus-stack.values.common.yaml
+++ b/platform/observability/helm/kube-prometheus-stack.values.common.yaml
@@ -6,6 +6,11 @@ prometheus:
   service:
     type: ClusterIP
   prometheusSpec:
+    # Stable, lifecycle-consumed identity for the staging blackbox egress policy.
+    podMetadata:
+      labels:
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/instance: kube-prometheus-stack
     replicas: 1
     retention: 7d
     retentionSize: 15GB

--- a/scripts/observability_blackbox.sh
+++ b/scripts/observability_blackbox.sh
@@ -10,6 +10,9 @@ REPOSITORY="https://prometheus-community.github.io/helm-charts"
 VERSION_FILE="${ROOT}/platform/observability/helm/prometheus-blackbox-exporter.version"
 VALUES="${ROOT}/clusters/staging/observability/prometheus-blackbox-exporter.values.yaml"
 PROBES="${ROOT}/clusters/staging/observability/probes"
+POLICY_KUSTOMIZATION="${ROOT}/clusters/staging/observability/network-policies"
+POLICY_SOURCE="${POLICY_KUSTOMIZATION}/prometheus-to-blackbox-exporter.yaml"
+POLICY_NAME="allow-kube-prometheus-stack-to-blackbox-exporter"
 TIMEOUT="${SUGARKUBE_OBSERVABILITY_HELM_TIMEOUT:-20m}"
 PROMETHEUS_SERVICE="kube-prometheus-stack-prometheus"
 LEGACY_PROBES=(
@@ -45,6 +48,7 @@ pinned version: $(version)
 ordered values files:
   - ${VALUES}
 Probe manifest path: ${PROBES}
+NetworkPolicy manifest path: ${POLICY_SOURCE}
 EOT
 }
 assert_context() {
@@ -53,13 +57,14 @@ assert_context() {
   python3 "${ROOT}/scripts/cluster_identity.py" assert --kubeconfig "${KUBECONFIG:-${HOME}/.kube/config}" --env staging >/dev/null
 }
 render_to() {
-  local chart_out="$1" probe_out="$2"
+  local chart_out="$1" policy_out="$2" probe_out="$3"
   helm repo add prometheus-community "${REPOSITORY}" --force-update >/dev/null
   helm repo update prometheus-community >/dev/null
   helm template "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${VALUES}" >"${chart_out}"
+  kubectl kustomize "${POLICY_KUSTOMIZATION}" >"${policy_out}"
   kubectl kustomize "${PROBES}" >"${probe_out}"
-  [[ -s "${chart_out}" && -s "${probe_out}" ]] || { echo "ERROR: chart and Probe renders must both be non-empty." >&2; exit 4; }
-  python3 - "${chart_out}" <<'PY'
+  [[ -s "${chart_out}" && -s "${policy_out}" && -s "${probe_out}" ]] || { echo "ERROR: chart, NetworkPolicy, and Probe renders must all be non-empty." >&2; exit 4; }
+  python3 - "${chart_out}" "${policy_out}" <<'PY'
 import re, sys
 text = open(sys.argv[1], encoding="utf-8").read()
 docs = text.split("\n---")
@@ -67,8 +72,32 @@ deployments = [d for d in docs if re.search(r"(?m)^kind: Deployment$", d) and re
 monitors = [d for d in docs if re.search(r"(?m)^kind: ServiceMonitor$", d) and re.search(r"(?m)^  name: prometheus-blackbox-exporter$", d)]
 if len(deployments) != 1 or not re.search(r"(?m)^  replicas: 1$", deployments[0]):
     raise SystemExit("ERROR: rendered exporter Deployment must have exactly one replica.")
+for label in (
+    r"(?m)^        app\.kubernetes\.io/instance: prometheus-blackbox-exporter$",
+    r"(?m)^        app\.kubernetes\.io/name: prometheus-blackbox-exporter$",
+):
+    if not re.search(label, deployments[0]):
+        raise SystemExit("ERROR: rendered exporter pod labels do not match the NetworkPolicy selector.")
 if len(monitors) != 1 or not re.search(r"(?m)^    release: kube-prometheus-stack$", monitors[0]):
     raise SystemExit("ERROR: rendered exporter ServiceMonitor must carry the base release label.")
+policy = open(sys.argv[2], encoding="utf-8").read()
+required = [
+    r"(?m)^kind: NetworkPolicy$",
+    r"(?m)^  name: allow-kube-prometheus-stack-to-blackbox-exporter$",
+    r"(?m)^  namespace: monitoring$",
+    r"(?m)^\s+- Egress$",
+    r"(?m)^      app\.kubernetes\.io/instance: kube-prometheus-stack$",
+    r"(?m)^      app\.kubernetes\.io/name: prometheus$",
+    r"(?m)^              app\.kubernetes\.io/instance: prometheus-blackbox-exporter$",
+    r"(?m)^              app\.kubernetes\.io/name: prometheus-blackbox-exporter$",
+    r"(?m)^\s+-?\s*port: 9115$",
+    r"(?m)^\s+-?\s*protocol: TCP$",
+]
+if any(not re.search(pattern, policy) for pattern in required) or policy.count("kind: NetworkPolicy") != 1:
+    raise SystemExit("ERROR: rendered NetworkPolicy does not match the lifecycle contract.")
+for forbidden in ("namespaceSelector:", "ipBlock:", "ingress:", "podSelector: {}"):
+    if forbidden in policy:
+        raise SystemExit("ERROR: rendered NetworkPolicy contains forbidden broad behavior.")
 PY
 }
 release_state() {
@@ -85,17 +114,28 @@ preflight() {
 }
 with_render() {
   CHART_RENDER="$(mktemp -t sugarkube-blackbox-chart.XXXXXX.yaml)"
+  POLICY_RENDER="$(mktemp -t sugarkube-blackbox-policy.XXXXXX.yaml)"
   PROBE_RENDER="$(mktemp -t sugarkube-blackbox-probes.XXXXXX.yaml)"
-  trap 'rm -f "${CHART_RENDER:-}" "${PROBE_RENDER:-}"' EXIT
-  render_to "${CHART_RENDER}" "${PROBE_RENDER}"
+  trap 'rm -f "${CHART_RENDER:-}" "${POLICY_RENDER:-}" "${PROBE_RENDER:-}"' EXIT
+  render_to "${CHART_RENDER}" "${POLICY_RENDER}" "${PROBE_RENDER}"
 }
-render() { require_tools helm kubectl; print_resolved; with_render; cat "${CHART_RENDER}" "${PROBE_RENDER}"; }
+render() {
+  require_tools helm kubectl python3
+  print_resolved
+  with_render
+  cat "${CHART_RENDER}"
+  printf '\n---\n'
+  cat "${POLICY_RENDER}"
+  printf '\n---\n'
+  cat "${PROBE_RENDER}"
+}
 mutate() {
   local action="$1" state
   require_tools helm kubectl python3; print_resolved; with_render; assert_context; preflight; state="$(release_state)"
   if [[ "${action}" == install && "${state}" == present ]]; then echo "ERROR: install requires an absent ${RELEASE} release; use upgrade." >&2; exit 6; fi
   if [[ "${action}" == upgrade && "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing ${RELEASE} release; use install." >&2; exit 6; fi
   helm "${action}" "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${VALUES}" --wait --timeout "${TIMEOUT}"
+  kubectl apply -f "${POLICY_RENDER}"
   # Remove only the production Probes left by the former mixed staging matrix.
   kubectl -n "${NAMESPACE}" delete probe "${LEGACY_PROBES[@]}" --ignore-not-found
   kubectl apply -f "${PROBE_RENDER}"
@@ -104,7 +144,39 @@ status() {
   require_tools helm kubectl python3; print_resolved; with_render; assert_context
   helm -n "${NAMESPACE}" status "${RELEASE}"
   kubectl -n "${NAMESPACE}" get deployment,pods,service,servicemonitor -l "app.kubernetes.io/instance=${RELEASE}"
+  kubectl -n "${NAMESPACE}" get networkpolicy "${POLICY_NAME}" -o yaml
   kubectl -n "${NAMESPACE}" get probe -l 'release=kube-prometheus-stack,environment=staging' -L app,route,criticality
+}
+validate_policy() {
+  local deployed
+  deployed="$(mktemp -t sugarkube-blackbox-deployed-policy.XXXXXX.json)"
+  kubectl -n "${NAMESPACE}" get networkpolicy "${POLICY_NAME}" -o json >"${deployed}" || { rm -f "${deployed}"; echo "ERROR: lifecycle NetworkPolicy is absent." >&2; return 7; }
+  python3 - "${deployed}" <<'PY' || { local rc=$?; rm -f "${deployed}"; return "${rc}"; }
+import json, sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as stream:
+        actual = json.load(stream)
+except (json.JSONDecodeError, UnicodeDecodeError):
+    raise SystemExit("ERROR: lifecycle NetworkPolicy response is malformed JSON.")
+expected = {
+    "podSelector": {"matchLabels": {
+        "app.kubernetes.io/instance": "kube-prometheus-stack",
+        "app.kubernetes.io/name": "prometheus",
+    }},
+    "policyTypes": ["Egress"],
+    "egress": [{
+        "to": [{"podSelector": {"matchLabels": {
+            "app.kubernetes.io/instance": "prometheus-blackbox-exporter",
+            "app.kubernetes.io/name": "prometheus-blackbox-exporter",
+        }}}],
+        "ports": [{"protocol": "TCP", "port": 9115}],
+    }],
+}
+if not isinstance(actual, dict) or actual.get("spec") != expected:
+    raise SystemExit("ERROR: deployed lifecycle NetworkPolicy is absent, broad, or differs from the required contract.")
+PY
+  rm -f "${deployed}"
 }
 validate_resources() {
   kubectl -n "${NAMESPACE}" rollout status "deployment/${RELEASE}" --timeout="${TIMEOUT}"
@@ -159,7 +231,7 @@ verify_series() {
   done
   exit 10
 }
-verify() { require_tools helm kubectl python3 sleep; print_resolved; with_render; assert_context; preflight; [[ "$(release_state)" == present ]] || { echo "ERROR: exporter release is absent." >&2; exit 7; }; validate_resources; verify_series; }
+verify() { require_tools helm kubectl python3 sleep; print_resolved; with_render; assert_context; preflight; [[ "$(release_state)" == present ]] || { echo "ERROR: exporter release is absent." >&2; exit 7; }; validate_policy || exit 7; validate_resources; verify_series; }
 
 cmd="${1:-}"; shift || true; [[ -n "${cmd}" ]] || { usage; exit 2; }; normalize_env "${1:-}" >/dev/null
 case "${cmd}" in render) render;; install|upgrade) mutate "${cmd}";; status) status;; verify) verify;; *) usage; exit 2;; esac

--- a/tests/test_monitoring_blackbox.py
+++ b/tests/test_monitoring_blackbox.py
@@ -5,6 +5,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 VALUES = ROOT / "clusters/staging/observability/prometheus-blackbox-exporter.values.yaml"
 PROBES = ROOT / "clusters/staging/observability/probes/public-apps.yaml"
+POLICY = (
+    ROOT / "clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml"
+)
 EXPECTED = {
     ("dspace", "root", "https://staging.democratized.space/", "https_2xx"),
     ("dspace", "config", "https://staging.democratized.space/config.json", "static_content_2xx"),
@@ -57,14 +60,17 @@ def test_pinned_chart_values_are_private_and_bounded():
     assert value["ingress"]["enabled"] is False and value["networkPolicy"]["enabled"] is False
     assert value["serviceMonitor"]["enabled"] is False
     assert value["serviceMonitor"]["selfMonitor"]["enabled"] is True
-    assert (
-        value["serviceMonitor"]["selfMonitor"]["labels"]["release"]
-        == "kube-prometheus-stack"
-    )
+    assert value["serviceMonitor"]["selfMonitor"]["labels"]["release"] == "kube-prometheus-stack"
     assert value["secretConfig"] is False
-    assert all(value[key] == [] for key in (
-        "extraConfigmapMounts", "extraSecretMounts", "extraVolumes", "extraVolumeMounts"
-    ))
+    assert all(
+        value[key] == []
+        for key in (
+            "extraConfigmapMounts",
+            "extraSecretMounts",
+            "extraVolumes",
+            "extraVolumeMounts",
+        )
+    )
     modules = value["config"]["modules"]
     assert set(modules) == {"https_2xx", "json_health_2xx", "static_content_2xx"}
     for module in modules.values():
@@ -112,7 +118,55 @@ def test_legacy_resources_are_outside_active_graphs():
     assert "LEGACY/FUTURE ONLY" in (ROOT / "monitoring/probes/public-apps.yaml").read_text()
 
 
-def test_network_policy_prerequisite_is_explicitly_deferred():
-    docs = (ROOT / "docs/observability-blackbox.md").read_text()
-    assert "separately\nscoped egress-policy prerequisite" in docs
-    assert "this lifecycle does not\nresolve that prerequisite" in docs
+def test_network_policy_is_exact_and_selectors_are_chart_render_backed():
+    policy = yaml(POLICY)[0]
+    assert policy == {
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "name": "allow-kube-prometheus-stack-to-blackbox-exporter",
+            "namespace": "monitoring",
+        },
+        "spec": {
+            "podSelector": {
+                "matchLabels": {
+                    "app.kubernetes.io/instance": "kube-prometheus-stack",
+                    "app.kubernetes.io/name": "prometheus",
+                }
+            },
+            "policyTypes": ["Egress"],
+            "egress": [
+                {
+                    "to": [
+                        {
+                            "podSelector": {
+                                "matchLabels": {
+                                    "app.kubernetes.io/instance": "prometheus-blackbox-exporter",
+                                    "app.kubernetes.io/name": "prometheus-blackbox-exporter",
+                                }
+                            }
+                        }
+                    ],
+                    "ports": [{"protocol": "TCP", "port": 9115}],
+                }
+            ],
+        },
+    }
+    common = yaml(ROOT / "platform/observability/helm/kube-prometheus-stack.values.common.yaml")[0]
+    assert (
+        common["prometheus"]["prometheusSpec"]["podMetadata"]["labels"]
+        == policy["spec"]["podSelector"]["matchLabels"]
+    )
+    exporter = yaml(VALUES)[0]
+    assert exporter["fullnameOverride"] == "prometheus-blackbox-exporter"
+    destination = policy["spec"]["egress"][0]["to"][0]["podSelector"]["matchLabels"]
+    assert destination == {
+        "app.kubernetes.io/instance": "prometheus-blackbox-exporter",
+        "app.kubernetes.io/name": "prometheus-blackbox-exporter",
+    }
+    kustomization = yaml(POLICY.parent / "kustomization.yaml")[0]
+    assert kustomization["resources"] == [POLICY.name]
+    assert (
+        "observability/network-policies"
+        not in (ROOT / "clusters/staging/kustomization.yaml").read_text()
+    )

--- a/tests/test_observability_blackbox.py
+++ b/tests/test_observability_blackbox.py
@@ -13,6 +13,9 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts/observability_blackbox.sh"
 VALUES = ROOT / "clusters/staging/observability/prometheus-blackbox-exporter.values.yaml"
+POLICY = (
+    ROOT / "clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml"
+)
 LEGACY = [
     "blackbox-dspace-prod-root",
     "blackbox-dspace-prod-config",
@@ -100,6 +103,11 @@ metadata:
   name: prometheus-blackbox-exporter
 spec:
   replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: prometheus-blackbox-exporter
+        app.kubernetes.io/name: prometheus-blackbox-exporter
 ---
 kind: ServiceMonitor
 metadata:
@@ -126,7 +134,12 @@ joined = " ".join(args)
 if args[:2] == ["config", "current-context"]:
     print("wrong-context" if scenario == "bad_context" else "sugar-staging")
 elif args[:1] == ["kustomize"]:
-    print("kind: Probe\nmetadata:\n  name: rendered-probe")
+    if "network-policies" in joined:
+        print(open(os.environ["POLICY_SOURCE"]).read())
+    else:
+        print("kind: Probe\nmetadata:\n  name: rendered-probe")
+elif joined.startswith("apply -f") and "blackbox-policy" in joined and scenario == "policy_apply_failure":
+    sys.exit(44)
 elif "get crd" in joined and scenario == "missing_crds": sys.exit(1)
 elif "get service kube-prometheus-stack-prometheus" in joined and scenario == "missing_service": sys.exit(1)
 elif "rollout status" in joined and scenario == "not_ready": sys.exit(1)
@@ -140,6 +153,23 @@ elif "get service -l" in joined and "nodePort" in joined:
     if scenario == "nodeport": print("30115")
 elif "get servicemonitor" in joined:
     if scenario != "missing_monitor": print("kube-prometheus-stack", end="")
+elif "get networkpolicy allow-kube-prometheus-stack-to-blackbox-exporter -o json" in joined:
+    if scenario == "missing_policy": sys.exit(1)
+    policy = json.load(open(os.environ["POLICY_JSON"]))
+    spec = policy["spec"]
+    if scenario == "malformed_policy": print("not-json"); sys.exit(0)
+    if scenario == "broad_source": spec["podSelector"] = {}
+    if scenario == "broad_destination": spec["egress"][0]["to"][0]["podSelector"] = {}
+    if scenario == "wrong_port": spec["egress"][0]["ports"][0]["port"] = 9116
+    if scenario == "additional_port": spec["egress"][0]["ports"].append({"protocol": "TCP", "port": 80})
+    if scenario == "wrong_protocol": spec["egress"][0]["ports"][0]["protocol"] = "UDP"
+    if scenario == "additional_peer": spec["egress"][0]["to"].append({"podSelector": {"matchLabels": {"x": "y"}}})
+    if scenario == "additional_rule": spec["egress"].append({"to": [{"ipBlock": {"cidr": "0.0.0.0/0"}}]})
+    if scenario == "additional_type": spec["policyTypes"].append("Ingress")
+    if scenario == "namespace_selector": spec["egress"][0]["to"][0]["namespaceSelector"] = {}
+    if scenario == "ip_block": spec["egress"][0]["to"][0] = {"ipBlock": {"cidr": "10.0.0.0/8"}}
+    if scenario == "ingress": spec["ingress"] = []
+    print(json.dumps(policy))
 elif "get probe -l" in joined and "-o json" in joined:
     print(open(os.environ["PROBES_JSON"]).read())
 elif "--raw" in joined:
@@ -229,6 +259,21 @@ def scenario(tmp_path):
         capture_output=True,
     )
     probes.write_text(json.dumps({"items": json.loads(docs.stdout)}))
+    policy_docs = subprocess.run(
+        [
+            "ruby",
+            "-ryaml",
+            "-rjson",
+            "-e",
+            "puts JSON.generate(YAML.load_file(ARGV[0]))",
+            str(POLICY),
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    policy_json = tmp_path / "policy.json"
+    policy_json.write_text(policy_docs.stdout)
     prom = tmp_path / "prom.json"
     prom.write_text(json.dumps(verifier_bundle()))
     env = {
@@ -236,6 +281,8 @@ def scenario(tmp_path):
         "PATH": f"{bindir}:{os.environ['PATH']}",
         "LOG": str(tmp_path / "operations.log"),
         "PROBES_JSON": str(probes),
+        "POLICY_SOURCE": str(POLICY),
+        "POLICY_JSON": str(policy_json),
         "PROM_JSON": str(prom),
         "RAW_COUNT": str(tmp_path / "raw-count"),
         "REAL_PYTHON": sys.executable,
@@ -291,11 +338,9 @@ def test_rendering_precedes_release_queries(scenario):
     result = scenario.run("install", SCENARIO="release_absent")
     assert result.returncode == 0
     template = next(i for i, line in enumerate(scenario.log) if line.startswith("helm template"))
-    kustomize = next(
-        i for i, line in enumerate(scenario.log) if line.startswith("kubectl kustomize")
-    )
+    kustomizes = [i for i, line in enumerate(scenario.log) if line.startswith("kubectl kustomize")]
     query = next(i for i, line in enumerate(scenario.log) if line.startswith("helm list"))
-    assert template < query and kustomize < query
+    assert template < query and len(kustomizes) == 2 and all(index < query for index in kustomizes)
 
 
 @pytest.mark.parametrize("command,state", [("install", "success"), ("upgrade", "upgrade_absent")])
@@ -315,8 +360,14 @@ def test_successful_mutation_uses_pinned_complete_values_and_order(scenario, com
     assert "--wait --timeout 7m" in mutation
     assert "--reuse-values" not in mutation
     delete = next(line for line in scenario.log if " delete probe " in line)
-    apply = next(line for line in scenario.log if line.startswith("kubectl apply"))
-    assert scenario.log.index(mutation) < scenario.log.index(delete) < scenario.log.index(apply)
+    applies = [line for line in scenario.log if line.startswith("kubectl apply")]
+    assert len(applies) == 2
+    assert (
+        scenario.log.index(mutation)
+        < scenario.log.index(applies[0])
+        < scenario.log.index(delete)
+        < scenario.log.index(applies[1])
+    )
     assert delete.endswith("delete probe " + " ".join(LEGACY) + " --ignore-not-found")
 
 
@@ -326,6 +377,13 @@ def test_failed_helm_mutation_suppresses_cleanup_and_apply(scenario):
     assert not any(
         " delete " in f" {line} " or line.startswith("kubectl apply") for line in scenario.log
     )
+
+
+def test_failed_policy_apply_suppresses_all_probe_mutation(scenario):
+    result = scenario.run("upgrade", SCENARIO="policy_apply_failure")
+    assert result.returncode == 44
+    assert not any(" delete probe " in line for line in scenario.log)
+    assert sum(line.startswith("kubectl apply") for line in scenario.log) == 1
 
 
 @pytest.mark.parametrize("command", ["status", "verify"])
@@ -341,6 +399,30 @@ def test_read_only_commands_never_mutate(scenario, command):
 def test_resource_guards_fail_before_prometheus_queries(scenario, failure):
     result = scenario.run("verify", SCENARIO=failure)
     assert result.returncode == 1 if failure == "not_ready" else result.returncode == 7
+    assert not any("--raw" in line for line in scenario.log)
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        "missing_policy",
+        "malformed_policy",
+        "broad_source",
+        "broad_destination",
+        "wrong_port",
+        "additional_port",
+        "wrong_protocol",
+        "additional_peer",
+        "additional_rule",
+        "additional_type",
+        "namespace_selector",
+        "ip_block",
+        "ingress",
+    ],
+)
+def test_policy_verification_fails_closed_before_prometheus(scenario, failure):
+    result = scenario.run("verify", SCENARIO=failure)
+    assert result.returncode != 0
     assert not any("--raw" in line for line in scenario.log)
 
 


### PR DESCRIPTION
### Motivation

- Ensure kube-prometheus-stack Prometheus pods in `monitoring` can egress to the staging `prometheus-blackbox-exporter` on TCP 9115 under the cluster default-deny policy. 
- Derive selectors deterministically from the committed pinned charts and values rather than guessing selectors. 
- Keep the NetworkPolicy lifecycle-owned, staging-only, and explicitly out of any Flux/cluster Kustomize graphs. 
- Fail closed and surface loud regressions if chart labels or policy semantics drift in future changes.

### Description

- Add a lifecycle-owned policy and Kustomize entrypoint at `clusters/staging/observability/network-policies/` with the stable name `allow-kube-prometheus-stack-to-blackbox-exporter` that selects Prometheus pods and allows egress only to exporter pods on TCP 9115. (`clusters/staging/observability/network-policies/*.yaml`)
- Pin Prometheus source labels in the committed kube-prometheus-stack common values by adding `prometheus.prometheusSpec.podMetadata.labels` to match the policy source selector. (`platform/observability/helm/kube-prometheus-stack.values.common.yaml`)
- Integrate rendering, apply, status, and fail-closed verification into the guarded helper `scripts/observability_blackbox.sh`: render chart, policy, and Probes offline; apply the policy only after Helm succeeds; show the exact policy in `status`; validate deployed policy semantically before Prometheus queries; preserve Helm → policy apply → legacy Probe deletion → staging Probe apply ordering; do not use selector pruning. (`scripts/observability_blackbox.sh`)
- Add deterministic offline tests that assert exact manifest semantics, render-backed selectors, mutation ordering and failure-suppression behavior, and many malformed/broad deployed-policy failure cases. (`tests/test_observability_blackbox.py`, `tests/test_monitoring_blackbox.py`)
- Update docs to record the canonical policy path, ownership boundary, unchanged DNS/HTTPS permissions, mutation order, verification behavior, rollback guidance, and that no live deployment occurred. (`docs/observability-blackbox.md`, `docs/observability-operations.md`)

### Testing

- `bash -n scripts/observability_blackbox.sh` — syntax check passed.
- `pytest -q tests/test_observability_blackbox.py` — 46 passed.
- `pytest -q tests/test_monitoring_blackbox.py tests/test_observability_blackbox.py` — 50 passed (combined suite).
- `ruff check tests/test_observability_blackbox.py tests/test_monitoring_blackbox.py` — focused checks passed for the modified tests.
- `black --check tests/test_observability_blackbox.py` — focused check passed after formatting the modified test files.
- `git diff --check` and `git diff | ./scripts/scan-secrets.py` — no diffs-with-errors or secrets detected in the committed changes.

Notes and limits:
- I performed an offline Helm render-and-verify for pinned charts (`kube-prometheus-stack` v`87.19.0`, `prometheus-blackbox-exporter` v`11.15.1`) to derive selectors and confirmed the selectors match rendered labels.
- Repository-wide `bash scripts/checks.sh` could not be fully green due to pre-existing pycodestyle/line-length issues outside this change; focused linters and formatting for the modified files passed.
- `pre-commit`, `pyspelling`, and `linkchecker` were unavailable in the execution environment and were not run here.

Change summary: added lifecycle-owned staging NetworkPolicy, wired rendering/apply/verify into the guarded lifecycle, added chart-render-backed selector regression tests, and updated docs; no live cluster mutation was performed.

Post-merge staging rollout (pick one):

- When exporter release is absent (fresh install):

```bash
just observability-blackbox-render env=staging
just observability-blackbox-install env=staging
just observability-blackbox-status env=staging
just observability-blackbox-verify env=staging
```

- When exporter release already exists (upgrade):

```bash
just observability-blackbox-render env=staging
just observability-blackbox-upgrade env=staging
just observability-blackbox-status env=staging
just observability-blackbox-verify env=staging
```

All rollout commands preserve the existing environment/context/identity guards and will apply the lifecycle-owned NetworkPolicy only after a successful Helm install/upgrade.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64739fb4b4832f96e40985cb1d53ac)