### PR TITLE
Add guarded staging NetworkPolicy prerequisite for blackbox lifecycle

### DIFF
--- a/clusters/staging/observability/network-policies/kustomization.yaml
+++ b/clusters/staging/observability/network-policies/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Lifecycle-owned staging resource; applied only by observability_blackbox.sh.
+resources:
+  - prometheus-to-blackbox-exporter.yaml

--- a/clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml
+++ b/clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-kube-prometheus-stack-to-blackbox-exporter
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+      operator.prometheus.io/name: kube-prometheus-stack-prometheus
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: prometheus-blackbox-exporter
+              app.kubernetes.io/name: prometheus-blackbox-exporter
+      ports:
+        - protocol: TCP
+          port: 9115

--- a/docs/observability-blackbox.md
+++ b/docs/observability-blackbox.md
@@ -3,11 +3,12 @@
 Public-route monitoring has a guarded, **staging-only, non-Flux** lifecycle. The
 exporter, Prometheus, and their administrative interfaces remain LAN/internal
 only. The exporter is a `ClusterIP` service; this work adds no Ingress,
-NodePort, public DNS, router rule, credential, persistence, or NetworkPolicy.
-The existing monitoring default-deny policy therefore requires a separately
-scoped egress-policy prerequisite allowing Prometheus to reach exporter TCP
-9115 before any fresh-cluster rollout can succeed; this lifecycle does not
-resolve that prerequisite.
+NodePort, public DNS, router rule, credential, or persistence. The only added
+network permission is the lifecycle-owned policy described below.
+The lifecycle now owns one narrowly scoped staging `NetworkPolicy` allowing
+only the canonical Prometheus pods to reach only the canonical exporter pods
+on TCP 9115. Existing monitoring DNS and external HTTPS permissions remain
+unchanged.
 
 ## Canonical sources
 
@@ -19,6 +20,9 @@ resolve that prerequisite.
   `clusters/staging/observability/prometheus-blackbox-exporter.values.yaml`.
 - Lifecycle-owned Probes and deterministic Kustomize entrypoint:
   `clusters/staging/observability/probes/`.
+- Lifecycle-owned NetworkPolicy and deterministic Kustomize entrypoint:
+  `clusters/staging/observability/network-policies/`. Its stable object name is
+  `allow-kube-prometheus-stack-to-blackbox-exporter`.
 - Helper: `scripts/observability_blackbox.sh`, exposed by
   `just observability-blackbox-*`.
 
@@ -43,12 +47,15 @@ just observability-blackbox-verify env=staging
 ```
 
 Render, status, and verify are read-only. Install is only for an absent exporter
-release; upgrade requires it to exist. Both render the pinned chart and Probes
-first, pass the complete committed values on every Helm operation, and wait up
-to the Pi-appropriate timeout. Only after Helm succeeds, they delete the eleven
-explicit legacy production Probe names formerly present in the shared matrix,
-using `--ignore-not-found`, then apply the rendered staging Probes. No selector
-pruning or staging Probe deletion is used. Neither uses
+release; upgrade requires it to exist. All commands render and validate the
+pinned chart, policy, and Probes before cluster access. Mutations pass the
+complete committed values on every Helm operation and wait up to the
+Pi-appropriate timeout. Only after Helm succeeds, they apply the policy, delete
+the eleven explicit legacy production Probe names formerly present in the
+shared matrix using `--ignore-not-found`, and apply the rendered staging
+Probes, in that order. A Helm failure changes neither policy nor Probes; a
+policy failure changes no Probe. No selector pruning or staging Probe deletion
+is used. Neither mutation uses
 `--reuse-values`. Missing environments and production are rejected;
 `env=int` remains a deprecated alias for staging.
 
@@ -68,25 +75,35 @@ app/route target matrix, `probe_success == 1`, and the duration, HTTP status,
 DNS lookup, and earliest TLS certificate-expiry metric families. It never logs
 raw target payloads or URLs; terminal diagnostics contain bounded labels and
 health/series states only.
+Before polling Prometheus, verification retrieves the policy by its exact name
+and compares its deployed JSON with the required source selector, destination
+selector, sole egress rule, TCP port 9115, and sole `Egress` policy type. It
+fails closed for an absent, broad, or additional selector, peer, rule, port,
+policy type, namespace selector, IP block, or ingress behavior. Status displays
+that exact policy.
 
 ## Post-merge rollout
 
 1. Select and independently confirm the staging kubeconfig and cluster identity.
 2. Review `just observability-blackbox-render env=staging` without applying it.
-3. Use install for a new release or upgrade for an existing release.
+3. Use `just observability-blackbox-install env=staging` when the exporter Helm
+   release is absent, or `just observability-blackbox-upgrade env=staging` when
+   it already exists.
 4. Run status, then verify. Preserve this output as separate live evidence.
 5. Stop and investigate rather than attempting production if any guard fails.
 
-No live-cluster operation is part of repository review or CI.
+No live deployment was performed as part of this repository change; repository
+state is not evidence of a live rollout.
 
 ## Rollback
 
-Inspect Helm history, roll back the exporter, then reapply the Probe render from
-the matching Git revision and verify:
+Inspect Helm history, roll back the exporter, then reapply the policy and Probe
+renders from the matching Git revision in lifecycle order and verify:
 
 ```bash
 helm -n monitoring history prometheus-blackbox-exporter
 helm -n monitoring rollback prometheus-blackbox-exporter <prior-revision> --wait --timeout 20m
+kubectl apply -k clusters/staging/observability/network-policies
 kubectl apply -k clusters/staging/observability/probes
 just observability-blackbox-verify env=staging
 ```
@@ -122,3 +139,5 @@ helper neither manages production nor supplies a replacement production
 lifecycle. Any future Flux adoption
 of the exporter or staging Probes must first retire the manual lifecycle and
 must never manage the same Helm release or Probe object names simultaneously.
+The lifecycle-owned policy directory is likewise absent from active Flux and
+cluster Kustomize graphs and must be mutated only through this guarded helper.

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -13,6 +13,9 @@ Production observability is intentionally unsupported in this slice because no p
 
 The staging blackbox exporter and Probe lifecycle is documented separately in
 [Staging blackbox monitoring](observability-blackbox.md).
+That non-Flux lifecycle exclusively owns its staging Prometheus-to-exporter
+NetworkPolicy; it is intentionally absent from active Flux and cluster
+Kustomize graphs.
 
 The old Flux/Longhorn files under `platform/observability/*.yaml` and `clusters/*/patches/kube-prometheus-stack-values.yaml` are inactive, unvalidated future/legacy configuration. They are deliberately absent from the platform resources and cluster overlay patches, so Flux does not reconcile the manually managed release. They must not be applied to staging or production as currently written, and operators must not combine Flux and manual Helm lifecycle paths for the same `kube-prometheus-stack` release.
 

--- a/scripts/observability_blackbox.sh
+++ b/scripts/observability_blackbox.sh
@@ -10,6 +10,8 @@ REPOSITORY="https://prometheus-community.github.io/helm-charts"
 VERSION_FILE="${ROOT}/platform/observability/helm/prometheus-blackbox-exporter.version"
 VALUES="${ROOT}/clusters/staging/observability/prometheus-blackbox-exporter.values.yaml"
 PROBES="${ROOT}/clusters/staging/observability/probes"
+POLICIES="${ROOT}/clusters/staging/observability/network-policies"
+POLICY_NAME="allow-kube-prometheus-stack-to-blackbox-exporter"
 TIMEOUT="${SUGARKUBE_OBSERVABILITY_HELM_TIMEOUT:-20m}"
 PROMETHEUS_SERVICE="kube-prometheus-stack-prometheus"
 LEGACY_PROBES=(
@@ -45,6 +47,7 @@ pinned version: $(version)
 ordered values files:
   - ${VALUES}
 Probe manifest path: ${PROBES}
+NetworkPolicy manifest path: ${POLICIES}
 EOT
 }
 assert_context() {
@@ -53,12 +56,14 @@ assert_context() {
   python3 "${ROOT}/scripts/cluster_identity.py" assert --kubeconfig "${KUBECONFIG:-${HOME}/.kube/config}" --env staging >/dev/null
 }
 render_to() {
-  local chart_out="$1" probe_out="$2"
+  local chart_out="$1" policy_out="$2" probe_out="$3"
   helm repo add prometheus-community "${REPOSITORY}" --force-update >/dev/null
   helm repo update prometheus-community >/dev/null
   helm template "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${VALUES}" >"${chart_out}"
+  kubectl kustomize "${POLICIES}" >"${policy_out}"
   kubectl kustomize "${PROBES}" >"${probe_out}"
-  [[ -s "${chart_out}" && -s "${probe_out}" ]] || { echo "ERROR: chart and Probe renders must both be non-empty." >&2; exit 4; }
+  [[ -s "${chart_out}" && -s "${policy_out}" && -s "${probe_out}" ]] || { echo "ERROR: chart, NetworkPolicy, and Probe renders must all be non-empty." >&2; exit 4; }
+  python3 "${ROOT}/scripts/verify_blackbox_network_policy.py" --rendered-yaml <"${policy_out}"
   python3 - "${chart_out}" <<'PY'
 import re, sys
 text = open(sys.argv[1], encoding="utf-8").read()
@@ -85,17 +90,19 @@ preflight() {
 }
 with_render() {
   CHART_RENDER="$(mktemp -t sugarkube-blackbox-chart.XXXXXX.yaml)"
+  POLICY_RENDER="$(mktemp -t sugarkube-blackbox-policy.XXXXXX.yaml)"
   PROBE_RENDER="$(mktemp -t sugarkube-blackbox-probes.XXXXXX.yaml)"
-  trap 'rm -f "${CHART_RENDER:-}" "${PROBE_RENDER:-}"' EXIT
-  render_to "${CHART_RENDER}" "${PROBE_RENDER}"
+  trap 'rm -f "${CHART_RENDER:-}" "${POLICY_RENDER:-}" "${PROBE_RENDER:-}"' EXIT
+  render_to "${CHART_RENDER}" "${POLICY_RENDER}" "${PROBE_RENDER}"
 }
-render() { require_tools helm kubectl; print_resolved; with_render; cat "${CHART_RENDER}" "${PROBE_RENDER}"; }
+render() { require_tools helm kubectl python3; print_resolved >&2; with_render; cat "${CHART_RENDER}" "${POLICY_RENDER}" "${PROBE_RENDER}"; }
 mutate() {
   local action="$1" state
   require_tools helm kubectl python3; print_resolved; with_render; assert_context; preflight; state="$(release_state)"
   if [[ "${action}" == install && "${state}" == present ]]; then echo "ERROR: install requires an absent ${RELEASE} release; use upgrade." >&2; exit 6; fi
   if [[ "${action}" == upgrade && "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing ${RELEASE} release; use install." >&2; exit 6; fi
   helm "${action}" "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${VALUES}" --wait --timeout "${TIMEOUT}"
+  kubectl apply -f "${POLICY_RENDER}"
   # Remove only the production Probes left by the former mixed staging matrix.
   kubectl -n "${NAMESPACE}" delete probe "${LEGACY_PROBES[@]}" --ignore-not-found
   kubectl apply -f "${PROBE_RENDER}"
@@ -103,8 +110,12 @@ mutate() {
 status() {
   require_tools helm kubectl python3; print_resolved; with_render; assert_context
   helm -n "${NAMESPACE}" status "${RELEASE}"
+  kubectl -n "${NAMESPACE}" get networkpolicy "${POLICY_NAME}" -o yaml
   kubectl -n "${NAMESPACE}" get deployment,pods,service,servicemonitor -l "app.kubernetes.io/instance=${RELEASE}"
   kubectl -n "${NAMESPACE}" get probe -l 'release=kube-prometheus-stack,environment=staging' -L app,route,criticality
+}
+validate_policy() {
+  kubectl -n "${NAMESPACE}" get networkpolicy "${POLICY_NAME}" -o json | python3 "${ROOT}/scripts/verify_blackbox_network_policy.py"
 }
 validate_resources() {
   kubectl -n "${NAMESPACE}" rollout status "deployment/${RELEASE}" --timeout="${TIMEOUT}"
@@ -159,7 +170,7 @@ verify_series() {
   done
   exit 10
 }
-verify() { require_tools helm kubectl python3 sleep; print_resolved; with_render; assert_context; preflight; [[ "$(release_state)" == present ]] || { echo "ERROR: exporter release is absent." >&2; exit 7; }; validate_resources; verify_series; }
+verify() { require_tools helm kubectl python3 sleep; print_resolved; with_render; assert_context; preflight; [[ "$(release_state)" == present ]] || { echo "ERROR: exporter release is absent." >&2; exit 7; }; validate_policy; validate_resources; verify_series; }
 
 cmd="${1:-}"; shift || true; [[ -n "${cmd}" ]] || { usage; exit 2; }; normalize_env "${1:-}" >/dev/null
 case "${cmd}" in render) render;; install|upgrade) mutate "${cmd}";; status) status;; verify) verify;; *) usage; exit 2;; esac

--- a/scripts/verify_blackbox_network_policy.py
+++ b/scripts/verify_blackbox_network_policy.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Fail closed unless stdin is the exact lifecycle-owned NetworkPolicy JSON."""
+
+import json
+import sys
+
+NAME = "allow-kube-prometheus-stack-to-blackbox-exporter"
+EXPECTED_SPEC = {
+    "podSelector": {
+        "matchLabels": {
+            "app.kubernetes.io/name": "prometheus",
+            "operator.prometheus.io/name": "kube-prometheus-stack-prometheus",
+        }
+    },
+    "policyTypes": ["Egress"],
+    "egress": [
+        {
+            "to": [
+                {
+                    "podSelector": {
+                        "matchLabels": {
+                            "app.kubernetes.io/instance": "prometheus-blackbox-exporter",
+                            "app.kubernetes.io/name": "prometheus-blackbox-exporter",
+                        }
+                    }
+                }
+            ],
+            "ports": [{"protocol": "TCP", "port": 9115}],
+        }
+    ],
+}
+EXPECTED_YAML_LINES = sorted(line.strip() for line in """
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+name: allow-kube-prometheus-stack-to-blackbox-exporter
+namespace: monitoring
+spec:
+egress:
+- ports:
+- port: 9115
+protocol: TCP
+to:
+- podSelector:
+matchLabels:
+app.kubernetes.io/instance: prometheus-blackbox-exporter
+app.kubernetes.io/name: prometheus-blackbox-exporter
+podSelector:
+matchLabels:
+app.kubernetes.io/name: prometheus
+operator.prometheus.io/name: kube-prometheus-stack-prometheus
+policyTypes:
+- Egress
+""".splitlines() if line.strip())
+
+
+def main() -> int:
+    if sys.argv[1:] == ["--rendered-yaml"]:
+        actual = sorted(
+            line.strip() for line in sys.stdin if line.strip() and not line.lstrip().startswith("#")
+        )
+        if actual != EXPECTED_YAML_LINES:
+            print(
+                "ERROR: rendered lifecycle NetworkPolicy differs from its required narrow semantics.",
+                file=sys.stderr,
+            )
+            return 7
+        return 0
+    try:
+        policy = json.load(sys.stdin)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        print("ERROR: lifecycle NetworkPolicy response is malformed JSON.", file=sys.stderr)
+        return 7
+    if (
+        policy.get("apiVersion") != "networking.k8s.io/v1"
+        or policy.get("kind") != "NetworkPolicy"
+        or policy.get("metadata", {}).get("name") != NAME
+        or policy.get("metadata", {}).get("namespace") != "monitoring"
+        or policy.get("spec") != EXPECTED_SPEC
+    ):
+        print(
+            "ERROR: lifecycle NetworkPolicy is absent or differs from its required narrow semantics.",
+            file=sys.stderr,
+        )
+        return 7
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_monitoring_blackbox.py
+++ b/tests/test_monitoring_blackbox.py
@@ -57,14 +57,17 @@ def test_pinned_chart_values_are_private_and_bounded():
     assert value["ingress"]["enabled"] is False and value["networkPolicy"]["enabled"] is False
     assert value["serviceMonitor"]["enabled"] is False
     assert value["serviceMonitor"]["selfMonitor"]["enabled"] is True
-    assert (
-        value["serviceMonitor"]["selfMonitor"]["labels"]["release"]
-        == "kube-prometheus-stack"
-    )
+    assert value["serviceMonitor"]["selfMonitor"]["labels"]["release"] == "kube-prometheus-stack"
     assert value["secretConfig"] is False
-    assert all(value[key] == [] for key in (
-        "extraConfigmapMounts", "extraSecretMounts", "extraVolumes", "extraVolumeMounts"
-    ))
+    assert all(
+        value[key] == []
+        for key in (
+            "extraConfigmapMounts",
+            "extraSecretMounts",
+            "extraVolumes",
+            "extraVolumeMounts",
+        )
+    )
     modules = value["config"]["modules"]
     assert set(modules) == {"https_2xx", "json_health_2xx", "static_content_2xx"}
     for module in modules.values():
@@ -112,7 +115,68 @@ def test_legacy_resources_are_outside_active_graphs():
     assert "LEGACY/FUTURE ONLY" in (ROOT / "monitoring/probes/public-apps.yaml").read_text()
 
 
-def test_network_policy_prerequisite_is_explicitly_deferred():
-    docs = (ROOT / "docs/observability-blackbox.md").read_text()
-    assert "separately\nscoped egress-policy prerequisite" in docs
-    assert "this lifecycle does not\nresolve that prerequisite" in docs
+def test_lifecycle_network_policy_is_exact_and_inactive():
+    policy_path = (
+        ROOT
+        / "clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml"
+    )
+    policy = yaml(policy_path)[0]
+    assert policy["metadata"] == {
+        "name": "allow-kube-prometheus-stack-to-blackbox-exporter",
+        "namespace": "monitoring",
+    }
+    assert policy["spec"] == {
+        "podSelector": {
+            "matchLabels": {
+                "app.kubernetes.io/name": "prometheus",
+                "operator.prometheus.io/name": "kube-prometheus-stack-prometheus",
+            }
+        },
+        "policyTypes": ["Egress"],
+        "egress": [
+            {
+                "to": [
+                    {
+                        "podSelector": {
+                            "matchLabels": {
+                                "app.kubernetes.io/instance": "prometheus-blackbox-exporter",
+                                "app.kubernetes.io/name": "prometheus-blackbox-exporter",
+                            }
+                        }
+                    }
+                ],
+                "ports": [{"protocol": "TCP", "port": 9115}],
+            }
+        ],
+    }
+    staging = (ROOT / "clusters/staging/kustomization.yaml").read_text()
+    assert "observability/network-policies" not in staging
+
+
+def test_policy_selectors_track_pinned_chart_render_contract():
+    assert (
+        ROOT / "platform/observability/helm/kube-prometheus-stack.version"
+    ).read_text().strip() == "87.19.0"
+    assert (
+        ROOT / "platform/observability/helm/prometheus-blackbox-exporter.version"
+    ).read_text().strip() == "11.15.1"
+    exporter = yaml(VALUES)[0]
+    assert exporter["fullnameOverride"] == "prometheus-blackbox-exporter"
+    # Chart 11.15.1 renders these two labels in the Deployment pod template and selector.
+    expected_exporter = {
+        "app.kubernetes.io/name": "prometheus-blackbox-exporter",
+        "app.kubernetes.io/instance": "prometheus-blackbox-exporter",
+    }
+    policy = yaml(
+        ROOT
+        / "clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml"
+    )[0]
+    assert policy["spec"]["egress"][0]["to"][0]["podSelector"]["matchLabels"] == expected_exporter
+    # Chart 87.19.0 renders the canonical Prometheus CR name; the operator's pod-label
+    # contract adds app.kubernetes.io/name=prometheus and operator.prometheus.io/name=<CR name>.
+    common = yaml(ROOT / "platform/observability/helm/kube-prometheus-stack.values.common.yaml")[0]
+    assert common["fullnameOverride"] == "kube-prometheus-stack"
+    assert policy["spec"]["podSelector"]["matchLabels"] == {
+        "app.kubernetes.io/name": "prometheus",
+        "operator.prometheus.io/name": "kube-prometheus-stack-prometheus",
+    }

--- a/tests/test_observability_blackbox.py
+++ b/tests/test_observability_blackbox.py
@@ -13,6 +13,9 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts/observability_blackbox.sh"
 VALUES = ROOT / "clusters/staging/observability/prometheus-blackbox-exporter.values.yaml"
+POLICY = (
+    ROOT / "clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml"
+)
 LEGACY = [
     "blackbox-dspace-prod-root",
     "blackbox-dspace-prod-config",
@@ -126,7 +129,29 @@ joined = " ".join(args)
 if args[:2] == ["config", "current-context"]:
     print("wrong-context" if scenario == "bad_context" else "sugar-staging")
 elif args[:1] == ["kustomize"]:
-    print("kind: Probe\nmetadata:\n  name: rendered-probe")
+    if "network-policies" in joined: print(open(os.environ["POLICY_RENDER_FIXTURE"]).read())
+    else: print("kind: Probe\nmetadata:\n  name: rendered-probe")
+elif args[:2] == ["create", "--dry-run=client"]:
+    print(open(os.environ["POLICY_JSON"]).read())
+elif "get networkpolicy" in joined:
+    if scenario == "missing_policy": sys.exit(1)
+    policy = json.load(open(os.environ["POLICY_JSON"]))
+    mutations = {
+        "broad_source": lambda p: p["spec"].update(podSelector={}),
+        "broad_destination": lambda p: p["spec"]["egress"][0]["to"][0].update(podSelector={}),
+        "wrong_protocol": lambda p: p["spec"]["egress"][0]["ports"][0].update(protocol="UDP"),
+        "additional_port": lambda p: p["spec"]["egress"][0]["ports"].append({"protocol":"TCP","port":9116}),
+        "additional_peer": lambda p: p["spec"]["egress"][0]["to"].append({"podSelector":{"matchLabels":{"x":"y"}}}),
+        "additional_rule": lambda p: p["spec"]["egress"].append({"to":[],"ports":[]}),
+        "additional_policy_type": lambda p: p["spec"]["policyTypes"].append("Ingress"),
+        "ipblock": lambda p: p["spec"]["egress"][0]["to"][0].update(ipBlock={"cidr":"0.0.0.0/0"}),
+        "namespace_selector": lambda p: p["spec"]["egress"][0]["to"][0].update(namespaceSelector={}),
+        "ingress": lambda p: p["spec"].update(ingress=[{}]),
+    }
+    if scenario == "malformed_policy": print("not-json"); sys.exit(0)
+    if scenario in mutations: mutations[scenario](policy)
+    if "-o yaml" in joined: print(open(os.environ["POLICY_YAML"]).read())
+    else: print(json.dumps(policy))
 elif "get crd" in joined and scenario == "missing_crds": sys.exit(1)
 elif "get service kube-prometheus-stack-prometheus" in joined and scenario == "missing_service": sys.exit(1)
 elif "rollout status" in joined and scenario == "not_ready": sys.exit(1)
@@ -215,6 +240,44 @@ def scenario(tmp_path):
         path.write_text(content)
         path.chmod(0o755)
     probes = tmp_path / "probes.json"
+    policy_json = tmp_path / "policy.json"
+    policy_docs = subprocess.run(
+        [
+            "ruby",
+            "-ryaml",
+            "-rjson",
+            "-e",
+            "puts JSON.generate(YAML.load_file(ARGV[0]))",
+            str(POLICY),
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    policy_json.write_text(policy_docs.stdout)
+    policy_render = tmp_path / "policy-render.yaml"
+    policy_render.write_text("""apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-kube-prometheus-stack-to-blackbox-exporter
+  namespace: monitoring
+spec:
+  egress:
+  - ports:
+    - port: 9115
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/instance: prometheus-blackbox-exporter
+          app.kubernetes.io/name: prometheus-blackbox-exporter
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+      operator.prometheus.io/name: kube-prometheus-stack-prometheus
+  policyTypes:
+  - Egress
+""")
     docs = subprocess.run(
         [
             "ruby",
@@ -236,6 +299,9 @@ def scenario(tmp_path):
         "PATH": f"{bindir}:{os.environ['PATH']}",
         "LOG": str(tmp_path / "operations.log"),
         "PROBES_JSON": str(probes),
+        "POLICY_YAML": str(POLICY),
+        "POLICY_RENDER_FIXTURE": str(policy_render),
+        "POLICY_JSON": str(policy_json),
         "PROM_JSON": str(prom),
         "RAW_COUNT": str(tmp_path / "raw-count"),
         "REAL_PYTHON": sys.executable,
@@ -294,8 +360,13 @@ def test_rendering_precedes_release_queries(scenario):
     kustomize = next(
         i for i, line in enumerate(scenario.log) if line.startswith("kubectl kustomize")
     )
+    policy = next(
+        i
+        for i, line in enumerate(scenario.log)
+        if "kustomize" in line and "network-policies" in line
+    )
     query = next(i for i, line in enumerate(scenario.log) if line.startswith("helm list"))
-    assert template < query and kustomize < query
+    assert template < query and policy < query and kustomize < query
 
 
 @pytest.mark.parametrize("command,state", [("install", "success"), ("upgrade", "upgrade_absent")])
@@ -314,9 +385,14 @@ def test_successful_mutation_uses_pinned_complete_values_and_order(scenario, com
     assert f"-f {VALUES}" in mutation
     assert "--wait --timeout 7m" in mutation
     assert "--reuse-values" not in mutation
+    policy_apply, probe_apply = [line for line in scenario.log if line.startswith("kubectl apply")]
     delete = next(line for line in scenario.log if " delete probe " in line)
-    apply = next(line for line in scenario.log if line.startswith("kubectl apply"))
-    assert scenario.log.index(mutation) < scenario.log.index(delete) < scenario.log.index(apply)
+    assert (
+        scenario.log.index(mutation)
+        < scenario.log.index(policy_apply)
+        < scenario.log.index(delete)
+        < scenario.log.index(probe_apply)
+    )
     assert delete.endswith("delete probe " + " ".join(LEGACY) + " --ignore-not-found")
 
 
@@ -328,11 +404,50 @@ def test_failed_helm_mutation_suppresses_cleanup_and_apply(scenario):
     )
 
 
+def test_failed_policy_apply_suppresses_probe_mutation(scenario):
+    # Replace kubectl with a wrapper that fails only the lifecycle policy apply.
+    kubectl = Path(scenario.env["PATH"].split(":", 1)[0]) / "kubectl"
+    original = kubectl.read_text()
+    kubectl.write_text(
+        original.replace(
+            'scenario = os.environ.get("SCENARIO", "success")',
+            'scenario = os.environ.get("SCENARIO", "success")\nif scenario == "policy_apply_failure" and args[:2] == ["apply", "-f"] and "policy" in args[2]: sys.exit(41)',
+        )
+    )
+    result = scenario.run("upgrade", SCENARIO="policy_apply_failure")
+    assert result.returncode == 41
+    assert not any(" delete probe " in line for line in scenario.log)
+    assert sum(line.startswith("kubectl apply") for line in scenario.log) == 1
+
+
 @pytest.mark.parametrize("command", ["status", "verify"])
 def test_read_only_commands_never_mutate(scenario, command):
     result = scenario.run(command)
     assert result.returncode == 0
     assert not mutations(scenario.log)
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        "missing_policy",
+        "malformed_policy",
+        "broad_source",
+        "broad_destination",
+        "wrong_protocol",
+        "additional_port",
+        "additional_peer",
+        "additional_rule",
+        "additional_policy_type",
+        "ipblock",
+        "namespace_selector",
+        "ingress",
+    ],
+)
+def test_policy_verification_fails_closed_before_prometheus(scenario, failure):
+    result = scenario.run("verify", SCENARIO=failure)
+    assert result.returncode != 0
+    assert not any("--raw" in line for line in scenario.log)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation

- The `monitoring` namespace is default-deny and the kube-prometheus-stack Prometheus pods need a narrowly scoped egress path to the prometheus-blackbox-exporter on TCP 9115 for the staged blackbox Probe lifecycle to converge. 
- The lifecycle-owned policy must be derived from the committed pinned chart renders (no guessing) and verified so future chart changes break tests instead of producing a broad policy. 
- The lifecycle's guarded install/upgrade must apply the policy only after a successful Helm operation and before legacy Probe deletion and staging Probe application, and verification must fail closed for any absent or semantically different policy. 

### Description

- Added a lifecycle-owned, staging-only Kustomize entrypoint at `clusters/staging/observability/network-policies/kustomization.yaml` and the NetworkPolicy manifest `prometheus-to-blackbox-exporter.yaml` named `allow-kube-prometheus-stack-to-blackbox-exporter` that selects Prometheus pods and allows only egress to exporter pods on TCP 9115. 
- Added `scripts/verify_blackbox_network_policy.py` which implements fail-closed semantic checks against the exact lifecycle source semantics and a `--rendered-yaml` check used during render validation. 
- Integrated policy rendering and validation into `scripts/observability_blackbox.sh`: `render` now renders chart, policy, and Probes deterministically and validates the policy before cluster access; `mutate` performs Helm → `kubectl apply` (policy) → legacy Probe delete → staging Probe apply ordering; `status` shows the exact lifecycle NetworkPolicy and `verify` validates the deployed policy before polling Prometheus. 
- Extended offline deterministic tests to cover chart-backed selectors, policy rendering-before-cluster-access, Helm→policy→Probe mutation ordering, Helm failure suppression, policy-apply failure suppression, malformed/broad policy regressions, and read-only command behavior; updated docs in `docs/observability-blackbox.md` and `docs/observability-operations.md` to describe ownership, ordering, verification, rollback, and rollout. 

### Testing

- `bash -n scripts/observability_blackbox.sh` succeeded and the script renders/validates offline without cluster access. 
- `pytest -q tests/test_observability_blackbox.py` passed: 45 passed. 
- `pytest -q tests/test_monitoring_blackbox.py tests/test_observability_blackbox.py` passed: 50 passed total. 
- `ruff check tests/test_observability_blackbox.py` passed. 
- `black --check tests/test_observability_blackbox.py scripts/verify_blackbox_network_policy.py` passed after formatting; `black` was used to reformat the new files where necessary. 
- Offline `helm`+`kubectl kustomize` render using pinned chart versions validated the selectors and produced a deterministic multi-document YAML stream (20 valid YAML documents during an offline render run). 
- `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` ran successfully (spelling passed; linkchecker found 0 errors). 
- `pre-commit run --all-files` was attempted but long-standing, unrelated repository-wide hooks (trailing-whitespace, multi-document YAML/helm-template checks, and flake8 style issues) triggered and required unrelated edits; those unrelated hook-created whitespace changes were reverted before committing this PR to keep scope limited. 

Change summary: lifecycle-owned, staging-only NetworkPolicy + deterministic Kustomize entrypoint; fail-closed rendered-policy validation; guarded render and mutate ordering (Helm → policy apply → legacy Probe deletion → staging Probe apply); status/verify integration; docs and tests updated. 

No live Helm or `kubectl` mutation was performed while preparing or testing these changes; all verification was performed offline or with test stubs. 

Post-merge staging rollout (documented and recommended):

- Render and review without applying: `just observability-blackbox-render env=staging` 
- If the exporter release is absent: `just observability-blackbox-install env=staging` then `just observability-blackbox-status env=staging` and `just observability-blackbox-verify env=staging` 
- If the exporter release already exists: `just observability-blackbox-upgrade env=staging` then `just observability-blackbox-status env=staging` and `just observability-blackbox-verify env=staging`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6473a3bda8832f86d404f639751e22)