### PR TITLE
Add fail-closed DSPACE release manifest evidence gate

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -210,6 +210,8 @@ release tag remains evidence and is never passed to Helm.
 The guarded mutation binds its evidence reservation to Helm's release
 description. Finalization verifies that description and the revision before
 and after runtime evidence collection, and fails closed if either changes.
+It boundedly waits for old release pods in graceful termination to disappear,
+but never ignores a non-terminating release pod with inconsistent coordinates.
 
 After rollout the command writes a new record beneath
 `deployment-evidence/dspace/<environment>/<image-tag>-<approval-time>.json`

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -217,6 +217,16 @@ Helm-owned Deployment, and rejects terminating, non-Running, non-Ready, or
 non-running DSPACE containers. Both the pod-spec image coordinate and resolved
 image ID must match the approval. Existing files are never overwritten.
 
+Immediately before Helm mutation, the guard exclusively creates
+`<evidence-path>.reservation`. It binds the normalized destination, canonical
+candidate fingerprint, environment, release, namespace, and an opaque invocation
+identifier. Finalization requires matching ownership and removes the sidecar only
+after its no-overwrite evidence write succeeds. A post-reservation failure preserves
+the sidecar; reservations never expire or get stolen automatically. Recovery
+requires inspecting and reconciling the cluster, Helm release, candidate, and
+existing evidence before an operator explicitly removes the exact stranded sidecar
+and retries.
+
 These recipes are implemented in the root `justfile` and use the app config
 lookup order above.
 

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -201,7 +201,12 @@ then reads the digest-qualified image index, every platform manifest/config,
 and the exact chart artifact/config. Every `org.opencontainers.image.revision`
 value must match the approved full source SHA. The configured DSPACE chart must
 be the canonical `oci://ghcr.io/democratizedspace/charts/dspace` reference, so
-the artifact checked is the artifact Helm deploys. A semantic release tag remains evidence and is never passed to Helm.
+the artifact checked is the artifact Helm deploys. After preflight, the guarded
+mutation passes Helm that chart as
+`oci://ghcr.io/democratizedspace/charts/dspace@<chartDigest>` without
+`--version`; the approved `chartVersion` remains separate display metadata and
+is checked against Helm's installed-chart metadata after rollout. A semantic
+release tag remains evidence and is never passed to Helm.
 
 After rollout the command writes a new record beneath
 `deployment-evidence/dspace/<environment>/<image-tag>-<approval-time>.json`

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -207,6 +207,9 @@ mutation passes Helm that chart as
 `--version`; the approved `chartVersion` remains separate display metadata and
 is checked against Helm's installed-chart metadata after rollout. A semantic
 release tag remains evidence and is never passed to Helm.
+The guarded mutation binds its evidence reservation to Helm's release
+description. Finalization verifies that description and the revision before
+and after runtime evidence collection, and fails closed if either changes.
 
 After rollout the command writes a new record beneath
 `deployment-evidence/dspace/<environment>/<image-tag>-<approval-time>.json`

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -197,12 +197,17 @@ DSPACE is the first application with a compatible producer manifest. Its
 therefore require `manifest=<approved-candidate.json>`. Other applications are
 not gated. Before any Helm or Kubernetes mutation, Sugarkube validates the
 candidate and uses `oras manifest fetch` to compare both OCI descriptor digests
-and both `org.opencontainers.image.revision` annotations with the approved full
-source SHA. A semantic release tag remains evidence and is never passed to Helm.
+then reads the digest-qualified image index, every platform manifest/config,
+and the exact chart artifact/config. Every `org.opencontainers.image.revision`
+value must match the approved full source SHA. The configured DSPACE chart must
+be the canonical `oci://ghcr.io/democratizedspace/charts/dspace` reference, so
+the artifact checked is the artifact Helm deploys. A semantic release tag remains evidence and is never passed to Helm.
 
 After rollout the command writes a new record beneath
-`deployment-evidence/dspace/<environment>/<image-tag>.json` (or the explicit
-`evidence=` path). It records the Helm revision and every DSPACE pod's name,
+`deployment-evidence/dspace/<environment>/<image-tag>-<approval-time>.json`
+(or the explicit `evidence=` path). The approval-qualified default is stable and
+deployment-unique; an occupied destination is rejected before mutation, so a
+repeat operation must supply a new explicit `evidence=` path. It records the Helm revision and every DSPACE pod's name,
 start time, and resolved image ID. Existing files are never overwritten.
 
 These recipes are implemented in the root `justfile` and use the app config
@@ -221,13 +226,16 @@ validates a public OCI chart and edits the repository pin.
 
 ```bash
 # Deploy or install a specific immutable candidate into an environment.
-just app-deploy app=dspace env=staging tag=main-REPLACE_SHORTSHA
+just app-deploy app=dspace env=staging tag=main-REPLACE_SHORTSHA \
+  manifest=deployment-candidates/dspace/staging.json
 
 # Redeploy an existing release with a specific immutable tag.
-just app-redeploy app=dspace env=staging tag=main-REPLACE_SHORTSHA
+just app-redeploy app=dspace env=staging tag=main-REPLACE_SHORTSHA \
+  manifest=deployment-candidates/dspace/staging.json evidence=deployment-evidence/dspace/staging/redeploy.json
 
 # Promote an approved immutable tag to production.
-just app-promote-prod app=dspace tag=main-REPLACE_SHORTSHA
+just app-promote-prod app=dspace tag=main-REPLACE_SHORTSHA \
+  manifest=deployment-candidates/dspace/prod.json
 
 # Inspect and intentionally bump the chart pin.
 just app-chart-status app=dspace

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -190,6 +190,21 @@ export SUGARKUBE_APP_CONFIG_DIR=apps
 
 ## Generic command surface
 
+### DSPACE release evidence gate
+
+DSPACE is the first application with a compatible producer manifest. Its
+`staging` and `prod` deploy, redeploy, promotion, and compatibility commands
+therefore require `manifest=<approved-candidate.json>`. Other applications are
+not gated. Before any Helm or Kubernetes mutation, Sugarkube validates the
+candidate and uses `oras manifest fetch` to compare both OCI descriptor digests
+and both `org.opencontainers.image.revision` annotations with the approved full
+source SHA. A semantic release tag remains evidence and is never passed to Helm.
+
+After rollout the command writes a new record beneath
+`deployment-evidence/dspace/<environment>/<image-tag>.json` (or the explicit
+`evidence=` path). It records the Helm revision and every DSPACE pod's name,
+start time, and resolved image ID. Existing files are never overwritten.
+
 These recipes are implemented in the root `justfile` and use the app config
 lookup order above.
 

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -208,7 +208,14 @@ After rollout the command writes a new record beneath
 (or the explicit `evidence=` path). The approval-qualified default is stable and
 deployment-unique; an occupied destination is rejected before mutation, so a
 repeat operation must supply a new explicit `evidence=` path. It records the Helm revision and every DSPACE pod's name,
-start time, and resolved image ID. Existing files are never overwritten.
+start time, and resolved image ID. Finalization requires the selected
+environment, image tag, chart version, kubeconfig, release, namespace, and chart
+reference; reruns exact-digest OCI provenance and cluster-identity checks; and
+verifies Helm reports that exact release as deployed with the approved DSPACE
+chart. Pod discovery is release-scoped, follows controller references to a
+Helm-owned Deployment, and rejects terminating, non-Running, non-Ready, or
+non-running DSPACE containers. Both the pod-spec image coordinate and resolved
+image ID must match the approval. Existing files are never overwritten.
 
 These recipes are implemented in the root `justfile` and use the app config
 lookup order above.

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -145,6 +145,12 @@ git add "$EVIDENCE"
 # Commit it after review, or attach that exact file to the external promotion record.
 ```
 
+The approved `chartVersion` remains the human-readable pin and the Helm metadata
+checked after rollout. The guarded deploy itself passes Helm the immutable
+`oci://ghcr.io/democratizedspace/charts/dspace@<chartDigest>` coordinate emitted
+by the successful preflight, without `--version`, so a tag cannot be resolved
+again between approval and installation.
+
 After staging sign-off, generate a separate `prod` candidate from the **same
 upstream manifest**, approve it independently, and promote it. The image tag,
 image digest, chart version, chart digest, and full source SHA must remain the
@@ -164,7 +170,8 @@ git add "$EVIDENCE"
 ```
 
 The finalized JSON is sufficient to reconstruct the release using the recorded
-branch-SHA image tag and digest plus chart version and digest, without resolving
+branch-SHA image tag and digest plus chart version and the exact digest-qualified
+chart deployment coordinate, without resolving
 `latest`, a branch, an environment tag, or the semantic tag. Until DSPACE #4732
 adds direct runtime identity, `runtimeSourceRevisionMethod` is strictly
 `podImageID+ociRevisionAnnotation`: every pod image ID must equal the approved

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -150,6 +150,10 @@ checked after rollout. The guarded deploy itself passes Helm the immutable
 `oci://ghcr.io/democratizedspace/charts/dspace@<chartDigest>` coordinate emitted
 by the successful preflight, without `--version`, so a tag cannot be resolved
 again between approval and installation.
+The mutation also carries an opaque description derived from the evidence
+reservation. Finalization requires that description and the Helm revision to
+remain stable across runtime evidence collection, failing closed if another
+upgrade or rollback becomes current.
 
 After staging sign-off, generate a separate `prod` candidate from the **same
 upstream manifest**, approve it independently, and promote it. The image tag,

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -96,7 +96,7 @@ gh workflow run ci-helm.yml --repo democratizedspace/dspace --ref main
 
 ## Deploy staging
 
-## Release-manifest approval and evidence flow
+### Release-manifest approval and evidence flow
 
 Download the `dspace-release-manifest` artifact from the successful upstream
 image workflow and extract `dspace-release-manifest/dspace-release-manifest.json`.
@@ -285,18 +285,20 @@ curl -fsS https://democratized.space/livez
 
 ## Rollback
 
-Rollback by deploying the previous known-good immutable image tag with the generic redeploy command.
+Rollback by deploying the previous known-good immutable image tag with the generic redeploy command and an approved environment-specific candidate for that release. Use a unique `evidence=` path if evidence for the tag already exists; occupied paths are rejected before Helm runs.
 
 ```bash
 APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA
+STAGING_ROLLBACK_MANIFEST=deployment-candidates/dspace/previous-release-staging.json
+PROD_ROLLBACK_MANIFEST=deployment-candidates/dspace/previous-release-prod.json
 ```
 
 ```bash
-just app-redeploy app=dspace env=staging tag="$APP_TAG"
+just app-redeploy app=dspace env=staging tag="$APP_TAG" manifest="$STAGING_ROLLBACK_MANIFEST" evidence=deployment-evidence/dspace/staging/"$APP_TAG"-rollback.json
 ```
 
 ```bash
-just app-redeploy app=dspace env=prod tag="$APP_TAG"
+just app-redeploy app=dspace env=prod tag="$APP_TAG" manifest="$PROD_ROLLBACK_MANIFEST" evidence=deployment-evidence/dspace/prod/"$APP_TAG"-rollback.json
 ```
 
 Rollback by Helm revision is still available through the existing parameterized helper. Set `ROLLBACK_ENV=staging` instead when intentionally rolling back staging.

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -169,7 +169,12 @@ branch-SHA image tag and digest plus chart version and digest, without resolving
 adds direct runtime identity, `runtimeSourceRevisionMethod` is strictly
 `podImageID+ociRevisionAnnotation`: every pod image ID must equal the approved
 digest and that exact OCI artifact's revision annotation must equal the full
-approved SHA. No HTTP build-identity check is claimed.
+approved SHA. Finalization also reasserts the connected cluster environment,
+requires Helm to report the selected release and namespace as deployed with the
+exact approved DSPACE chart version, and accepts only Running, Ready pods owned
+through the selected Helm release's Deployment and ReplicaSet. Each DSPACE
+container must use the approved repository and immutable image tag before its
+resolved image ID is accepted. No HTTP build-identity check is claimed.
 
 This repository change only persists the staging configuration; it does not deploy anything to a cluster. After it is merged, deploy the new immutable, environment-neutral DSPACE image that contains runtime `/config.json` support. The image tag stays the same as it moves between staging and production; the Sugarkube values overlays, not image names, select the token.place origin.
 

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -154,6 +154,10 @@ The mutation also carries an opaque description derived from the evidence
 reservation. Finalization requires that description and the Helm revision to
 remain stable across runtime evidence collection, failing closed if another
 upgrade or rollback becomes current.
+Finalization also waits for a bounded period for old release pods undergoing
+graceful rollout termination to disappear. It never filters out a still-running
+release pod: every remaining pod must satisfy the approved image and readiness
+checks.
 
 After staging sign-off, generate a separate `prod` candidate from the **same
 upstream manifest**, approve it independently, and promote it. The image tag,

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -44,7 +44,7 @@ Use these links before changing a deployment so the workflow runs, package versi
   The staging overlay injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`, uses chart `3.1.0`, and persists the authenticated metrics ServiceMonitor configuration discovered by kube-prometheus-stack. The metrics bearer value is not committed; operators manage the existing `dspace-staging-metrics-token` Secret out of band.
 - `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
   The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`. Production remains intentionally pinned to the recovered chart `3.0.1` deployment and image `ghcr.io/democratizedspace/dspace:main-1a31a56`; it does not enable metrics or ServiceMonitor settings.
-- Optional legacy/canary host `prod.democratized.space` still has `docs/examples/dspace.values.prod-subdomain.yaml`, but the generic app flow uses the production apex overlay unless a local app config intentionally overrides it.
+- Optional legacy/canary host `prod.democratized.space` uses `docs/examples/dspace.values.prod-subdomain.yaml`. The `dspace-oci-deploy-prod-subdomain` compatibility command selects the secret-free `docs/examples/apps/dspace-prod-subdomain.env` config, preserving that overlay while routing through the same manifest validation, OCI preflight, Helm deployment, and evidence finalization as the generic production path.
 
 ## Find or publish GHCR image
 

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -96,18 +96,85 @@ gh workflow run ci-helm.yml --repo democratizedspace/dspace --ref main
 
 ## Deploy staging
 
+## Release-manifest approval and evidence flow
+
+Download the `dspace-release-manifest` artifact from the successful upstream
+image workflow and extract `dspace-release-manifest/dspace-release-manifest.json`.
+Do not copy coordinates from mutable package tags. Create a canonical staging
+candidate with an explicit UTC approval time, approver identity, and one of the
+configuration contract's exact provider values (`token-place` or `openai`):
+
+```bash
+python3 scripts/dspace_release_manifest.py candidate \
+  --upstream dspace-release-manifest/dspace-release-manifest.json \
+  --output deployment-candidates/dspace/staging.json \
+  --environment staging --provider token-place \
+  --approved-at 2026-07-26T12:00:00Z --approved-by '<operator-or-review-record>'
+python3 scripts/dspace_release_manifest.py validate \
+  --manifest deployment-candidates/dspace/staging.json
+```
+
+Inspect and review that file before approval. Deploying performs a read-only OCI
+preflight first. It uses the OCI Distribution API through `oras`, not GitHub's
+Packages REST API, and does not need an ad hoc `read:packages` token for public
+artifacts. If a package is private, use the registry's normal OCI login flow;
+never put credentials in a manifest or command argument. The OCI-native manual
+fallback is:
+
+```bash
+oras manifest fetch --descriptor \
+  ghcr.io/democratizedspace/dspace:"$APP_TAG"
+oras manifest fetch ghcr.io/democratizedspace/dspace:"$APP_TAG"
+oras manifest fetch --descriptor \
+  ghcr.io/democratizedspace/charts/dspace:"$CHART_VERSION"
+oras manifest fetch ghcr.io/democratizedspace/charts/dspace:"$CHART_VERSION"
+```
+
+Pass the candidate to staging and preserve the generated final record:
+
+```bash
+just app-deploy app=dspace env=staging tag="$APP_TAG" \
+  manifest=deployment-candidates/dspace/staging.json
+git add deployment-evidence/dspace/staging/"$APP_TAG".json
+# Commit it after review, or attach that exact file to the external promotion record.
+```
+
+After staging sign-off, generate a separate `prod` candidate from the **same
+upstream manifest**, approve it independently, and promote it. The image tag,
+image digest, chart version, chart digest, and full source SHA must remain the
+same; `semanticTag` is only corroborating evidence.
+
+```bash
+python3 scripts/dspace_release_manifest.py candidate \
+  --upstream dspace-release-manifest/dspace-release-manifest.json \
+  --output deployment-candidates/dspace/prod.json \
+  --environment prod --provider token-place \
+  --approved-at 2026-07-26T13:00:00Z --approved-by '<operator-or-review-record>'
+just app-promote-prod app=dspace tag="$APP_TAG" \
+  manifest=deployment-candidates/dspace/prod.json
+git add deployment-evidence/dspace/prod/"$APP_TAG".json
+```
+
+The finalized JSON is sufficient to reconstruct the release using the recorded
+branch-SHA image tag and digest plus chart version and digest, without resolving
+`latest`, a branch, an environment tag, or the semantic tag. Until DSPACE #4732
+adds direct runtime identity, `runtimeSourceRevisionMethod` is strictly
+`podImageID+ociRevisionAnnotation`: every pod image ID must equal the approved
+digest and that exact OCI artifact's revision annotation must equal the full
+approved SHA. No HTTP build-identity check is claimed.
+
 This repository change only persists the staging configuration; it does not deploy anything to a cluster. After it is merged, deploy the new immutable, environment-neutral DSPACE image that contains runtime `/config.json` support. The image tag stays the same as it moves between staging and production; the Sugarkube values overlays, not image names, select the token.place origin.
 
 Preferred generic command:
 
 ```bash
-just app-deploy app=dspace env=staging tag="$APP_TAG"
+just app-deploy app=dspace env=staging tag="$APP_TAG" manifest=deployment-candidates/dspace/staging.json
 ```
 
 Compatibility shim while migration is in progress:
 
 ```bash
-just dspace-oci-deploy env=staging tag="$APP_TAG"
+just dspace-oci-deploy env=staging tag="$APP_TAG" manifest=deployment-candidates/dspace/staging.json
 ```
 
 ## Verify staging
@@ -173,13 +240,13 @@ For staging, the browser smoke must show DSPACE calling `https://staging.token.p
 This configuration change does not promote or mutate production. Promote only after staging sign-off. Prefer the generic command; it uses the prod values chain, resolves chart `3.0.1` from `docs/apps/dspace.prod.version`, and can read `docs/apps/dspace.prod.tag` (`main-1a31a56`) when `tag=` is omitted.
 
 ```bash
-just app-promote-prod app=dspace tag="$APP_TAG"
+just app-promote-prod app=dspace tag="$APP_TAG" manifest=deployment-candidates/dspace/prod.json
 ```
 
 Compatibility shim:
 
 ```bash
-just dspace-oci-promote-prod tag="$APP_TAG"
+just dspace-oci-promote-prod tag="$APP_TAG" manifest=deployment-candidates/dspace/prod.json
 ```
 
 ## Verify production

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -124,10 +124,14 @@ fallback is:
 ```bash
 oras manifest fetch --descriptor \
   ghcr.io/democratizedspace/dspace:"$APP_TAG"
-oras manifest fetch ghcr.io/democratizedspace/dspace:"$APP_TAG"
+IMAGE_DIGEST=$(oras manifest fetch --descriptor ghcr.io/democratizedspace/dspace:"$APP_TAG" | jq -r .digest)
+oras manifest fetch ghcr.io/democratizedspace/dspace@"$IMAGE_DIGEST"
+# Fetch each index manifest and its config blob by digest; inspect every config label.
 oras manifest fetch --descriptor \
   ghcr.io/democratizedspace/charts/dspace:"$CHART_VERSION"
-oras manifest fetch ghcr.io/democratizedspace/charts/dspace:"$CHART_VERSION"
+CHART_DIGEST=$(oras manifest fetch --descriptor ghcr.io/democratizedspace/charts/dspace:"$CHART_VERSION" | jq -r .digest)
+oras manifest fetch ghcr.io/democratizedspace/charts/dspace@"$CHART_DIGEST"
+# Fetch the chart config blob by digest and inspect its revision annotation.
 ```
 
 Pass the candidate to staging and preserve the generated final record:
@@ -135,14 +139,16 @@ Pass the candidate to staging and preserve the generated final record:
 ```bash
 just app-deploy app=dspace env=staging tag="$APP_TAG" \
   manifest=deployment-candidates/dspace/staging.json
-git add deployment-evidence/dspace/staging/"$APP_TAG".json
+EVIDENCE=$(python3 scripts/dspace_release_manifest.py evidence-path \
+  --manifest deployment-candidates/dspace/staging.json)
+git add "$EVIDENCE"
 # Commit it after review, or attach that exact file to the external promotion record.
 ```
 
 After staging sign-off, generate a separate `prod` candidate from the **same
 upstream manifest**, approve it independently, and promote it. The image tag,
 image digest, chart version, chart digest, and full source SHA must remain the
-same; `semanticTag` is only corroborating evidence.
+same; `semanticTag` must equal `v<applicationVersion>` and is only corroborating evidence.
 
 ```bash
 python3 scripts/dspace_release_manifest.py candidate \
@@ -152,7 +158,9 @@ python3 scripts/dspace_release_manifest.py candidate \
   --approved-at 2026-07-26T13:00:00Z --approved-by '<operator-or-review-record>'
 just app-promote-prod app=dspace tag="$APP_TAG" \
   manifest=deployment-candidates/dspace/prod.json
-git add deployment-evidence/dspace/prod/"$APP_TAG".json
+EVIDENCE=$(python3 scripts/dspace_release_manifest.py evidence-path \
+  --manifest deployment-candidates/dspace/prod.json)
+git add "$EVIDENCE"
 ```
 
 The finalized JSON is sufficient to reconstruct the release using the recorded
@@ -286,6 +294,8 @@ curl -fsS https://democratized.space/livez
 ## Rollback
 
 Rollback by deploying the previous known-good immutable image tag with the generic redeploy command and an approved environment-specific candidate for that release. Use a unique `evidence=` path if evidence for the tag already exists; occupied paths are rejected before Helm runs.
+Do not infer or generate a rollback manifest automatically; that future
+automation is tracked in #2327.
 
 ```bash
 APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -176,6 +176,21 @@ through the selected Helm release's Deployment and ReplicaSet. Each DSPACE
 container must use the approved repository and immutable image tag before its
 resolved image ID is accepted. No HTTP build-identity check is claimed.
 
+Immediately before Helm changes the release, the guarded recipe atomically creates
+`<evidence-path>.reservation`. This sidecar binds the normalized destination,
+approved-candidate fingerprint, environment, Helm release, and namespace to one
+opaque invocation identifier. A competitor stops before Helm or Kubernetes
+mutation. Only the owner can finalize; success atomically creates the JSON and
+removes the sidecar.
+
+Failures after reservation deliberately leave the sidecar. There is no timeout or
+automatic stale-lock takeover. For recovery, first inspect and reconcile the
+selected cluster, Helm release, pods, intended candidate, and existing evidence. If
+that proves the original invocation cannot resume and its destination must be
+abandoned, explicitly remove that exact sidecar (for example,
+`rm -- deployment-evidence/dspace/staging/<file>.json.reservation`) and rerun the
+guarded command. Never remove a reservation merely because it is old.
+
 This repository change only persists the staging configuration; it does not deploy anything to a cluster. After it is merged, deploy the new immutable, environment-neutral DSPACE image that contains runtime `/config.json` support. The image tag stays the same as it moves between staging and production; the Sugarkube values overlays, not image names, select the token.place origin.
 
 Preferred generic command:

--- a/docs/examples/apps/dspace-prod-subdomain.env
+++ b/docs/examples/apps/dspace-prod-subdomain.env
@@ -1,0 +1,16 @@
+# Secret-free compatibility config for the legacy DSPACE production canary host.
+SUGARKUBE_APP=dspace
+SUGARKUBE_RELEASE=dspace
+SUGARKUBE_NAMESPACE=dspace
+SUGARKUBE_CHART=oci://ghcr.io/democratizedspace/charts/dspace
+SUGARKUBE_VERSION_FILE=docs/apps/dspace.version
+SUGARKUBE_VERSION_FILE_DEV=docs/apps/dspace.version
+SUGARKUBE_VERSION_FILE_STAGING=docs/apps/dspace.staging.version
+SUGARKUBE_VERSION_FILE_PROD=docs/apps/dspace.prod.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/dspace.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/dspace.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod-subdomain.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/config.json,/healthz,/livez
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=dspace

--- a/justfile
+++ b/justfile
@@ -1364,8 +1364,17 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
         fi
     fi
 
+    digest_chart=false
+    if [[ "${chart}" == *@* ]]; then
+      if ! [[ "${chart}" =~ ^oci://[^@[:space:]]+@sha256:[0-9a-f]{64}$ ]]; then
+        echo "ERROR: digest-qualified OCI chart must match oci://...@sha256:<64 lowercase hex>." >&2
+        exit 2
+      fi
+      digest_chart=true
+    fi
+
     version_args=()
-    if [ -n "${chart_version}" ]; then
+    if [ -n "${chart_version}" ] && [ "${digest_chart}" = false ]; then
         version_args+=(--version "${chart_version}")
     fi
 
@@ -1383,7 +1392,9 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     echo 'NOTE: chart pins are explicit. `tag=...` changes only the image tag.'
     printf 'Run `just app-chart-status app=%s` before release deploys to check for newer published chart versions.\n' "${release}"
     printf 'Use `just app-chart-bump app=%s version=<version>` to intentionally update %s.\n' "${release}" "${version_file:-docs/apps/${release}.version}"
-    if [ -n "${chart_version}" ]; then
+    if [ "${digest_chart}" = true ]; then
+      helm show chart "${chart}" >/dev/null
+    elif [ -n "${chart_version}" ]; then
       helm show chart "${chart}" --version "${chart_version}" >/dev/null
     fi
 
@@ -1630,10 +1641,10 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
       if [ -z "${chart_version}" ]; then
         chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -n1)"
       fi
-      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" preflight \
+      chart_coordinate="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" preflight \
         --manifest "${release_manifest}" --environment "${SUGARKUBE_ENV}" \
         --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" \
-        --chart-ref "${SUGARKUBE_CHART}"
+        --chart-ref "${SUGARKUBE_CHART}" --print-chart-coordinate)"
       if [ -z "${evidence_output}" ]; then
         evidence_output="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" evidence-path --manifest "${release_manifest}")"
       fi
@@ -1660,7 +1671,7 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release="${SUGARKUBE_RELEASE}" \
       namespace="${SUGARKUBE_NAMESPACE}" \
-      chart="${SUGARKUBE_CHART}" \
+      chart="${chart_coordinate:-${SUGARKUBE_CHART}}" \
       values="${SUGARKUBE_VALUES}" \
       version="${SUGARKUBE_VERSION:-}" \
       version_file="${SUGARKUBE_VERSION_FILE:-}" \
@@ -1695,8 +1706,8 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
       if [ -z "${release_manifest}" ]; then echo "ERROR: manifest=<approved-candidate.json> is required for DSPACE ${SUGARKUBE_ENV}." >&2; exit 2; fi
       chart_version="${SUGARKUBE_VERSION:-}"
       if [ -z "${chart_version}" ]; then chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -n1)"; fi
-      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" preflight --manifest "${release_manifest}" --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" \
-        --chart-ref "${SUGARKUBE_CHART}"
+      chart_coordinate="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" preflight --manifest "${release_manifest}" --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" \
+        --chart-ref "${SUGARKUBE_CHART}" --print-chart-coordinate)"
       if [ -z "${evidence_output}" ]; then evidence_output="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" evidence-path --manifest "${release_manifest}")"; fi
     fi
 
@@ -1721,7 +1732,7 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release="${SUGARKUBE_RELEASE}" \
       namespace="${SUGARKUBE_NAMESPACE}" \
-      chart="${SUGARKUBE_CHART}" \
+      chart="${chart_coordinate:-${SUGARKUBE_CHART}}" \
       values="${SUGARKUBE_VALUES}" \
       version="${SUGARKUBE_VERSION:-}" \
       version_file="${SUGARKUBE_VERSION_FILE:-}" \

--- a/justfile
+++ b/justfile
@@ -1632,9 +1632,10 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
       fi
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" preflight \
         --manifest "${release_manifest}" --environment "${SUGARKUBE_ENV}" \
-        --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}"
+        --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" \
+        --chart-ref "${SUGARKUBE_CHART}"
       if [ -z "${evidence_output}" ]; then
-        evidence_output="deployment-evidence/dspace/${SUGARKUBE_ENV}/${SUGARKUBE_TAG}.json"
+        evidence_output="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" evidence-path --manifest "${release_manifest}")"
       fi
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" check-output --output "${evidence_output}"
     fi
@@ -1664,7 +1665,8 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize \
         --manifest "${release_manifest}" --output "${evidence_output}" \
-        --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}"
+        --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
+        --chart-ref "${SUGARKUBE_CHART}"
     fi
 
 # Generic upgrade-only app redeploy backed by app config files.
@@ -1687,8 +1689,9 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
       if [ -z "${release_manifest}" ]; then echo "ERROR: manifest=<approved-candidate.json> is required for DSPACE ${SUGARKUBE_ENV}." >&2; exit 2; fi
       chart_version="${SUGARKUBE_VERSION:-}"
       if [ -z "${chart_version}" ]; then chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -n1)"; fi
-      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" preflight --manifest "${release_manifest}" --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}"
-      if [ -z "${evidence_output}" ]; then evidence_output="deployment-evidence/dspace/${SUGARKUBE_ENV}/${SUGARKUBE_TAG}.json"; fi
+      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" preflight --manifest "${release_manifest}" --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" \
+        --chart-ref "${SUGARKUBE_CHART}"
+      if [ -z "${evidence_output}" ]; then evidence_output="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" evidence-path --manifest "${release_manifest}")"; fi
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" check-output --output "${evidence_output}"
     fi
 
@@ -1715,7 +1718,8 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
       tag="${SUGARKUBE_TAG}" \
       env="${SUGARKUBE_ENV}"
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
-      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize --manifest "${release_manifest}" --output "${evidence_output}" --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}"
+      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize --manifest "${release_manifest}" --output "${evidence_output}" --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
+        --chart-ref "${SUGARKUBE_CHART}"
     fi
 
 # Promote an app to prod with an explicit immutable tag, or the configured prod tag file.

--- a/justfile
+++ b/justfile
@@ -1218,7 +1218,7 @@ cf-tunnel-route host='':
         '' \
         'Dashboard steps are documented in docs/cloudflare_tunnel.md.'
 
-_helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='' allow_install='false' reuse_values='false':
+_helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='' description='' allow_install='false' reuse_values='false':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1237,7 +1237,7 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     fi
     raw_args=(
         "{{ release }}" "{{ namespace }}" "{{ chart }}" "{{ values }}" "{{ host }}" "{{ version }}"
-        "{{ version_file }}" "{{ tag }}" "{{ default_tag }}" "{{ env }}"
+        "{{ version_file }}" "{{ tag }}" "{{ default_tag }}" "{{ env }}" "{{ description }}"
     )
 
     release=""
@@ -1250,6 +1250,7 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     tag=""
     default_tag=""
     requested_env=""
+    description=""
 
     normalize_prefixed_value() {
         local key="${1}"
@@ -1291,6 +1292,7 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
             tag=*) tag="${raw_arg#tag=}" ;;
             default_tag=*) default_tag="${raw_arg#default_tag=}" ;;
             env=*) requested_env="${raw_arg#env=}" ;;
+            description=*) description="${raw_arg#description=}" ;;
             *)
                 case "${raw_index}" in
                     0) assign_if_empty release "${raw_arg}" ;;
@@ -1303,6 +1305,7 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
                     7) assign_if_empty tag "${raw_arg}" ;;
                     8) assign_if_empty default_tag "${raw_arg}" ;;
                     9) assign_if_empty requested_env "${raw_arg}" ;;
+                    10) assign_if_empty description "${raw_arg}" ;;
                 esac
                 ;;
         esac
@@ -1318,6 +1321,7 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     tag="$(normalize_prefixed_value tag "${tag}")"
     default_tag="$(normalize_prefixed_value default_tag "${default_tag}")"
     requested_env="$(normalize_prefixed_value env "${requested_env}")"
+    description="$(normalize_prefixed_value description "${description}")"
     if [ -z "${requested_env}" ] && [ -n "${SUGARKUBE_ENV:-}" ]; then
       requested_env="${SUGARKUBE_ENV}"
     fi
@@ -1577,6 +1581,10 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
 
     helm_args=(upgrade "${release}" "${chart}" --namespace "${namespace}")
 
+    if [ -n "${description}" ]; then
+        helm_args+=(--description "${description}")
+    fi
+
     if [ "${allow_install}" = "true" ]; then
         helm_args+=(--install --create-namespace)
     fi
@@ -1600,11 +1608,11 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     helm "${helm_args[@]}"
     wait_for_rollouts
 
-helm-oci-install release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='':
-    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' '{{ env }}' allow_install='true' reuse_values='false'
+helm-oci-install release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='' description='':
+    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' '{{ env }}' '{{ description }}' allow_install='true' reuse_values='false'
 
-helm-oci-upgrade release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='':
-    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' '{{ env }}' allow_install='false' reuse_values='true'
+helm-oci-upgrade release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='' description='':
+    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' '{{ env }}' '{{ description }}' allow_install='false' reuse_values='true'
 
 # Print resolved Sugarkube app deployment config for an app/environment.
 app-config app env='staging' config='':
@@ -1667,6 +1675,7 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
       evidence_reservation="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" reserve \
         --manifest "${release_manifest}" --output "${evidence_output}" \
         --environment "${SUGARKUBE_ENV}" --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}")"
+      helm_description="sugarkube-release-manifest:${evidence_reservation}"
     fi
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release="${SUGARKUBE_RELEASE}" \
@@ -1676,7 +1685,8 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
       version="${SUGARKUBE_VERSION:-}" \
       version_file="${SUGARKUBE_VERSION_FILE:-}" \
       tag="${SUGARKUBE_TAG}" \
-      env="${SUGARKUBE_ENV}"
+      env="${SUGARKUBE_ENV}" \
+      description="${helm_description:-}"
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize \
         --manifest "${release_manifest}" --output "${evidence_output}" \
@@ -1728,6 +1738,7 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
       evidence_reservation="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" reserve \
         --manifest "${release_manifest}" --output "${evidence_output}" \
         --environment "${SUGARKUBE_ENV}" --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}")"
+      helm_description="sugarkube-release-manifest:${evidence_reservation}"
     fi
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release="${SUGARKUBE_RELEASE}" \
@@ -1737,7 +1748,8 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
       version="${SUGARKUBE_VERSION:-}" \
       version_file="${SUGARKUBE_VERSION_FILE:-}" \
       tag="${SUGARKUBE_TAG}" \
-      env="${SUGARKUBE_ENV}"
+      env="${SUGARKUBE_ENV}" \
+      description="${helm_description:-}"
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize --manifest "${release_manifest}" --output "${evidence_output}" \
         --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" --kubeconfig "${KUBECONFIG}" \

--- a/justfile
+++ b/justfile
@@ -1637,7 +1637,6 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
       if [ -z "${evidence_output}" ]; then
         evidence_output="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" evidence-path --manifest "${release_manifest}")"
       fi
-      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" check-output --output "${evidence_output}"
     fi
 
     export KUBECONFIG="${HOME}/.kube/config"
@@ -1653,6 +1652,11 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
       --values "${SUGARKUBE_VALUES}" \
       --release "${SUGARKUBE_RELEASE}" \
       --namespace "${SUGARKUBE_NAMESPACE}"
+    if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
+      evidence_reservation="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" reserve \
+        --manifest "${release_manifest}" --output "${evidence_output}" \
+        --environment "${SUGARKUBE_ENV}" --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}")"
+    fi
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
       release="${SUGARKUBE_RELEASE}" \
       namespace="${SUGARKUBE_NAMESPACE}" \
@@ -1668,7 +1672,7 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
         --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" \
         --chart-version "${chart_version}" --kubeconfig "${KUBECONFIG}" \
         --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
-        --chart-ref "${SUGARKUBE_CHART}"
+        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}"
     fi
 
 # Generic upgrade-only app redeploy backed by app config files.
@@ -1694,7 +1698,6 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" preflight --manifest "${release_manifest}" --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" \
         --chart-ref "${SUGARKUBE_CHART}"
       if [ -z "${evidence_output}" ]; then evidence_output="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" evidence-path --manifest "${release_manifest}")"; fi
-      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" check-output --output "${evidence_output}"
     fi
 
     export KUBECONFIG="${HOME}/.kube/config"
@@ -1710,6 +1713,11 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
       --values "${SUGARKUBE_VALUES}" \
       --release "${SUGARKUBE_RELEASE}" \
       --namespace "${SUGARKUBE_NAMESPACE}"
+    if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
+      evidence_reservation="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" reserve \
+        --manifest "${release_manifest}" --output "${evidence_output}" \
+        --environment "${SUGARKUBE_ENV}" --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}")"
+    fi
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
       release="${SUGARKUBE_RELEASE}" \
       namespace="${SUGARKUBE_NAMESPACE}" \
@@ -1723,7 +1731,7 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize --manifest "${release_manifest}" --output "${evidence_output}" \
         --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" --kubeconfig "${KUBECONFIG}" \
         --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
-        --chart-ref "${SUGARKUBE_CHART}"
+        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}"
     fi
 
 # Promote an app to prod with an explicit immutable tag, or the configured prod tag file.

--- a/justfile
+++ b/justfile
@@ -1665,6 +1665,8 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize \
         --manifest "${release_manifest}" --output "${evidence_output}" \
+        --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" \
+        --chart-version "${chart_version}" --kubeconfig "${KUBECONFIG}" \
         --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
         --chart-ref "${SUGARKUBE_CHART}"
     fi
@@ -1718,7 +1720,9 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
       tag="${SUGARKUBE_TAG}" \
       env="${SUGARKUBE_ENV}"
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
-      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize --manifest "${release_manifest}" --output "${evidence_output}" --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
+      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize --manifest "${release_manifest}" --output "${evidence_output}" \
+        --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" --kubeconfig "${KUBECONFIG}" \
+        --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
         --chart-ref "${SUGARKUBE_CHART}"
     fi
 

--- a/justfile
+++ b/justfile
@@ -1636,6 +1636,7 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
       if [ -z "${evidence_output}" ]; then
         evidence_output="deployment-evidence/dspace/${SUGARKUBE_ENV}/${SUGARKUBE_TAG}.json"
       fi
+      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" check-output --output "${evidence_output}"
     fi
 
     export KUBECONFIG="${HOME}/.kube/config"
@@ -1660,7 +1661,7 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
       version_file="${SUGARKUBE_VERSION_FILE:-}" \
       tag="${SUGARKUBE_TAG}" \
       env="${SUGARKUBE_ENV}"
-    if [ "${SUGARKUBE_APP}" = dspace ] && [ -n "${release_manifest}" ]; then
+    if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize \
         --manifest "${release_manifest}" --output "${evidence_output}" \
         --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}"
@@ -1688,6 +1689,7 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
       if [ -z "${chart_version}" ]; then chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -n1)"; fi
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" preflight --manifest "${release_manifest}" --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}"
       if [ -z "${evidence_output}" ]; then evidence_output="deployment-evidence/dspace/${SUGARKUBE_ENV}/${SUGARKUBE_TAG}.json"; fi
+      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" check-output --output "${evidence_output}"
     fi
 
     export KUBECONFIG="${HOME}/.kube/config"
@@ -1712,7 +1714,7 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
       version_file="${SUGARKUBE_VERSION_FILE:-}" \
       tag="${SUGARKUBE_TAG}" \
       env="${SUGARKUBE_ENV}"
-    if [ "${SUGARKUBE_APP}" = dspace ] && [ -n "${release_manifest}" ]; then
+    if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize --manifest "${release_manifest}" --output "${evidence_output}" --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}"
     fi
 
@@ -1865,149 +1867,17 @@ dspace-oci-deploy env='staging' tag='' manifest='' evidence='':
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
     "${delegate[@]}"
-    exit
-
-    env_input={{ quote(env) }}
-    env_name="${env_input}"
-    while [ "${env_name#env=}" != "${env_name}" ]; do
-      env_name="${env_name#env=}"
-    done
-    if [ -z "${env_name}" ]; then
-      printf 'ERROR: env must not be empty. Use env=dev|staging|prod.\n' >&2
-      exit 1
-    fi
-    if [ "${env_name}" = "int" ]; then
-      printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
-      env_name="staging"
-    fi
-
-    case "${env_name}" in
-      dev|staging|prod) ;;
-      *)
-        echo "Unsupported env=${env_name}. Use env=dev|staging|prod." >&2
-        exit 1
-        ;;
-    esac
-
-    deploy_tag="$(echo "{{ tag }}" | xargs)"
-    if [ -z "${deploy_tag}" ]; then
-      echo "Set tag=<immutable-tag> (for example main-<shortsha> or 3.1.0) for dspace immutable deploys." >&2
-      exit 1
-    fi
-    tag_lc="$(echo "${deploy_tag}" | tr '[:upper:]' '[:lower:]')"
-    if [[ "${tag_lc}" == *"latest"* || "${tag_lc}" == "main" || "${tag_lc}" == *":main" ]]; then
-      echo "Refusing mutable tag '${deploy_tag}'. Use an immutable RC/stable image tag." >&2
-      exit 1
-    fi
-
-    overlay=""
-    if [ "${env_name}" != "dev" ]; then
-      overlay="docs/examples/dspace.values.${env_name}.yaml"
-      if [ ! -f "${overlay}" ]; then
-        echo "No dspace values overlay found for env=${env_name} (${overlay})." >&2
-        exit 1
-      fi
-    fi
-
-    values_chain="docs/examples/dspace.values.dev.yaml"
-    if [ -n "${overlay}" ]; then
-      values_chain="${values_chain},${overlay}"
-    fi
-
-    if [ -z "${KUBECONFIG:-}" ] && [ ! -r "${HOME}/.kube/config" ]; then
-      scripts/ensure_user_kubeconfig.sh || true
-    fi
-    if [ -z "${KUBECONFIG:-}" ]; then
-      export KUBECONFIG="${HOME}/.kube/config"
-    fi
-    export SUGARKUBE_ENV="${env_name}"
-    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell --app dspace --env "${env_name}")"
-    just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "${env_name}" "${KUBECONFIG}" >/dev/null
-
-    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
-      release='dspace' namespace='dspace' \
-      chart='oci://ghcr.io/democratizedspace/charts/dspace' \
-      values="${values_chain}" \
-      version="${SUGARKUBE_VERSION:-}" \
-      version_file="${SUGARKUBE_VERSION_FILE:-}" \
-      tag="${deploy_tag}" \
-      env="${env_name}"
-
-    echo "Resolved deployment image(s):"
-    kubectl -n dspace get deploy dspace \
-      -o jsonpath='{range .spec.template.spec.containers[*]}{.name}={.image}{"\n"}{end}'
-
-    verify_host="$(kubectl -n dspace get ingress dspace -o jsonpath='{.spec.rules[0].host}' 2>/dev/null || true)"
-    if [ -z "${verify_host}" ]; then
-      verify_host="<dspace-host>"
-    fi
-
-    echo
-    echo "Post-deploy verification commands:"
-    if [[ "${verify_host}" == "<"*">" ]]; then
-      echo "  # Replace ${verify_host} with your ingress hostname."
-      echo "  curl -fsS https://${verify_host}/config.json | jq ."
-      echo "  curl -fsS https://${verify_host}/healthz | jq ."
-      echo "  curl -fsS https://${verify_host}/livez | jq ."
-    else
-      echo "  curl -fsS https://${verify_host}/config.json | jq ."
-      echo "  curl -fsS https://${verify_host}/healthz | jq ."
-      echo "  curl -fsS https://${verify_host}/livez | jq ."
-    fi
-
-# Deploy dspace to the optional production preview subdomain (prod.democratized.space).
-#
 
 # Use this for optional canary/smoke testing before or alongside apex promotion workflows.
-dspace-oci-deploy-prod-subdomain tag='':
+dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    deploy_tag="$(echo "{{ tag }}" | xargs)"
-    if [ -z "${deploy_tag}" ]; then
-      echo "Set tag=<immutable-tag> (for example main-<shortsha> or 3.1.0) for prod subdomain deploys." >&2
-      exit 1
-    fi
-    tag_lc="$(echo "${deploy_tag}" | tr '[:upper:]' '[:lower:]')"
-    if [[ "${tag_lc}" == *"latest"* || "${tag_lc}" == "main" || "${tag_lc}" == *":main" ]]; then
-      echo "Refusing mutable tag '${deploy_tag}'. Use an immutable RC/stable image tag." >&2
-      exit 1
-    fi
-
-    values_chain="docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod-subdomain.yaml"
-    if [ ! -f "docs/examples/dspace.values.prod-subdomain.yaml" ]; then
-      echo "Missing values overlay: docs/examples/dspace.values.prod-subdomain.yaml" >&2
-      exit 1
-    fi
-
-    if [ -z "${KUBECONFIG:-}" ] && [ ! -r "${HOME}/.kube/config" ]; then
-      scripts/ensure_user_kubeconfig.sh || true
-    fi
-    if [ -z "${KUBECONFIG:-}" ]; then
-      export KUBECONFIG="${HOME}/.kube/config"
-    fi
-    export SUGARKUBE_ENV="prod"
-    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell --app dspace --env prod)"
-    just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "prod" "${KUBECONFIG}" >/dev/null
-
-    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
-      release='dspace' namespace='dspace' \
-      chart='oci://ghcr.io/democratizedspace/charts/dspace' \
-      values="${values_chain}" \
-      version="${SUGARKUBE_VERSION:-}" \
-      version_file="${SUGARKUBE_VERSION_FILE:-}" \
-      tag="${deploy_tag}" \
-      env="prod"
-
-    echo "Resolved deployment image(s):"
-    kubectl -n dspace get deploy dspace \
-      -o jsonpath='{range .spec.template.spec.containers[*]}{.name}={.image}{"\n"}{end}'
-
-    echo
-    echo "Post-deploy verification commands for the production preview endpoint:"
-    echo "  curl -fsS https://prod.democratized.space/config.json | jq ."
-    echo "  curl -fsS https://prod.democratized.space/healthz | jq ."
-    echo "  curl -fsS https://prod.democratized.space/livez | jq ."
+    echo "WARNING: the prod-subdomain compatibility command now uses the gated production deployment path." >&2
+    delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-deploy app=dspace env=prod tag={{ quote(tag) }})
+    [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
+    [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    "${delegate[@]}"
 
 # Promote dspace to production apex (democratized.space) using immutable tags.
 
@@ -2028,80 +1898,14 @@ dspace-oci-promote-prod tag='' manifest='' evidence='':
     "${delegate[@]}"
 
 # Fast redeploy of dspace from GHCR (emergency mutable-tag refresh).
-dspace-oci-redeploy env='staging' tag='':
+dspace-oci-redeploy env='staging' tag='' manifest='' evidence='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    env_input={{ quote(env) }}
-    env_name="${env_input}"
-    while [ "${env_name#env=}" != "${env_name}" ]; do
-      env_name="${env_name#env=}"
-    done
-    if [ -z "${env_name}" ]; then
-      printf 'ERROR: env must not be empty. Use env=dev|staging|prod.\n' >&2
-      exit 1
-    fi
-    if [ "${env_name}" = "int" ]; then
-      printf 'WARNING: env name "int" is deprecated; using env=staging.\n' >&2
-      env_name="staging"
-    fi
-
-    read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
-
-    overlay="docs/examples/dspace.values.${env_name}.yaml"
-    if [ ! -f "${overlay}" ]; then
-      echo "No dspace values overlay found for env=${env_name} (${overlay})." >&2
-      exit 1
-    fi
-    values_chain="docs/examples/dspace.values.dev.yaml"
-    if [ "${env_name}" != "dev" ]; then
-      values_chain="${values_chain},${overlay}"
-    fi
-
-    if [ -z "${KUBECONFIG:-}" ] && [ ! -r "${HOME}/.kube/config" ]; then
-      scripts/ensure_user_kubeconfig.sh || true
-    fi
-    if [ -z "${KUBECONFIG:-}" ]; then
-      export KUBECONFIG="${HOME}/.kube/config"
-    fi
-    export SUGARKUBE_ENV="${env_name}"
-    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell --app dspace --env "${env_name}")"
-    just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "${env_name}" "${KUBECONFIG}" >/dev/null
-
-    deploy_tag="{{ tag }}"
-    default_tag_value=""
-    if [ "${env_name}" = "prod" ]; then
-      if [ -z "${deploy_tag}" ] && [ -f "docs/apps/dspace.prod.tag" ]; then
-        deploy_tag="$(read_prod_tag)"
-      fi
-      if [ -z "${deploy_tag}" ]; then
-        echo "Set tag=<immutable-tag> for prod or populate docs/apps/dspace.prod.tag." >&2
-        exit 1
-      fi
-    else
-      default_tag_value="main-latest"
-    fi
-
-    just --justfile "{{ justfile_directory() }}/justfile" helm-oci-upgrade \
-      release='dspace' namespace='dspace' \
-      chart='oci://ghcr.io/democratizedspace/charts/dspace' \
-      values="${values_chain}" \
-      version="${SUGARKUBE_VERSION:-}" \
-      version_file="${SUGARKUBE_VERSION_FILE:-}" \
-      tag="${deploy_tag}" \
-      env="${env_name}" default_tag="${default_tag_value}"
-
-    echo "Forcing rollout restart for dspace deployment..."
-    if ! kubectl -n dspace rollout restart deploy/dspace; then
-      echo "ERROR: Failed to trigger rollout restart for dspace." >&2
-      exit 1
-    fi
-
-    echo "Waiting for dspace rollout to complete (timeout: 120s)..."
-    if ! kubectl -n dspace rollout status deploy/dspace --timeout=120s; then
-      echo "ERROR: dspace rollout did not complete successfully." >&2
-      exit 1
-    fi
+    delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-redeploy app=dspace env={{ quote(env) }} tag={{ quote(tag) }})
+    [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
+    [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    "${delegate[@]}"
 
 # Dump dspace and Traefik logs for debugging HTTP 500s.
 dspace-debug-logs namespace='dspace':

--- a/justfile
+++ b/justfile
@@ -1877,8 +1877,8 @@ dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    echo "WARNING: the prod-subdomain compatibility command now uses the gated production deployment path." >&2
-    delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-deploy app=dspace env=prod tag={{ quote(tag) }})
+    delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-deploy app=dspace env=prod tag={{ quote(tag) }} \
+      "{{ justfile_directory() }}/docs/examples/apps/dspace-prod-subdomain.env")
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
     "${delegate[@]}"

--- a/justfile
+++ b/justfile
@@ -1606,7 +1606,7 @@ app-config app env='staging' config='':
       --config {{ quote(config) }}
 
 # Generic immutable-tag app deploy backed by docs/examples/apps/*.env or local app configs.
-app-deploy app env='staging' tag='' config='':
+app-deploy app env='staging' tag='' config='' manifest='' evidence='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1616,6 +1616,27 @@ app-deploy app env='staging' tag='' config='':
       --config {{ quote(config) }} \
       --tag {{ quote(tag) }} \
       --require-tag)"
+
+    release_manifest={{ quote(manifest) }}
+    evidence_output={{ quote(evidence) }}
+    while [ "${release_manifest#manifest=}" != "${release_manifest}" ]; do release_manifest="${release_manifest#manifest=}"; done
+    while [ "${evidence_output#evidence=}" != "${evidence_output}" ]; do evidence_output="${evidence_output#evidence=}"; done
+    if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
+      if [ -z "${release_manifest}" ]; then
+        echo "ERROR: manifest=<approved-candidate.json> is required for DSPACE ${SUGARKUBE_ENV}." >&2
+        exit 2
+      fi
+      chart_version="${SUGARKUBE_VERSION:-}"
+      if [ -z "${chart_version}" ]; then
+        chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -n1)"
+      fi
+      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" preflight \
+        --manifest "${release_manifest}" --environment "${SUGARKUBE_ENV}" \
+        --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}"
+      if [ -z "${evidence_output}" ]; then
+        evidence_output="deployment-evidence/dspace/${SUGARKUBE_ENV}/${SUGARKUBE_TAG}.json"
+      fi
+    fi
 
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
@@ -1639,9 +1660,14 @@ app-deploy app env='staging' tag='' config='':
       version_file="${SUGARKUBE_VERSION_FILE:-}" \
       tag="${SUGARKUBE_TAG}" \
       env="${SUGARKUBE_ENV}"
+    if [ "${SUGARKUBE_APP}" = dspace ] && [ -n "${release_manifest}" ]; then
+      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize \
+        --manifest "${release_manifest}" --output "${evidence_output}" \
+        --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}"
+    fi
 
 # Generic upgrade-only app redeploy backed by app config files.
-app-redeploy app env='staging' tag='' config='':
+app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1651,6 +1677,18 @@ app-redeploy app env='staging' tag='' config='':
       --config {{ quote(config) }} \
       --tag {{ quote(tag) }} \
       --require-tag)"
+
+    release_manifest={{ quote(manifest) }}
+    evidence_output={{ quote(evidence) }}
+    while [ "${release_manifest#manifest=}" != "${release_manifest}" ]; do release_manifest="${release_manifest#manifest=}"; done
+    while [ "${evidence_output#evidence=}" != "${evidence_output}" ]; do evidence_output="${evidence_output#evidence=}"; done
+    if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
+      if [ -z "${release_manifest}" ]; then echo "ERROR: manifest=<approved-candidate.json> is required for DSPACE ${SUGARKUBE_ENV}." >&2; exit 2; fi
+      chart_version="${SUGARKUBE_VERSION:-}"
+      if [ -z "${chart_version}" ]; then chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -n1)"; fi
+      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" preflight --manifest "${release_manifest}" --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}"
+      if [ -z "${evidence_output}" ]; then evidence_output="deployment-evidence/dspace/${SUGARKUBE_ENV}/${SUGARKUBE_TAG}.json"; fi
+    fi
 
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
@@ -1674,9 +1712,12 @@ app-redeploy app env='staging' tag='' config='':
       version_file="${SUGARKUBE_VERSION_FILE:-}" \
       tag="${SUGARKUBE_TAG}" \
       env="${SUGARKUBE_ENV}"
+    if [ "${SUGARKUBE_APP}" = dspace ] && [ -n "${release_manifest}" ]; then
+      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize --manifest "${release_manifest}" --output "${evidence_output}" --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}"
+    fi
 
 # Promote an app to prod with an explicit immutable tag, or the configured prod tag file.
-app-promote-prod app tag='' config='':
+app-promote-prod app tag='' config='' manifest='' evidence='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1687,11 +1728,11 @@ app-promote-prod app tag='' config='':
       --tag {{ quote(tag) }} \
       --prod-tag-fallback \
       --require-tag)"
-    just --justfile "{{ justfile_directory() }}/justfile" app-deploy \
-      app="${SUGARKUBE_APP}" \
-      env=prod \
-      tag="${SUGARKUBE_TAG}" \
-      config="${SUGARKUBE_CONFIG_PATH}"
+    delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-deploy \
+      app="${SUGARKUBE_APP}" env=prod tag="${SUGARKUBE_TAG}" config="${SUGARKUBE_CONFIG_PATH}")
+    [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
+    [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    "${delegate[@]}"
 
 # Show the pinned chart version and whether a newer semver chart appears published.
 app-chart-status app env='staging' config='':
@@ -1816,9 +1857,15 @@ app-cors-verify app env='staging' config='' origin='https://cors-smoke.invalid' 
 #
 
 # Use this for steady-state release validation flows where explicit image pinning matters.
-dspace-oci-deploy env='staging' tag='':
+dspace-oci-deploy env='staging' tag='' manifest='' evidence='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
+
+    delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-deploy app=dspace env={{ quote(env) }} tag={{ quote(tag) }})
+    [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
+    [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    "${delegate[@]}"
+    exit
 
     env_input={{ quote(env) }}
     env_name="${env_input}"
@@ -1965,7 +2012,7 @@ dspace-oci-deploy-prod-subdomain tag='':
 # Promote dspace to production apex (democratized.space) using immutable tags.
 
 # If tag is omitted, this reads the pinned value from docs/apps/dspace.prod.tag.
-dspace-oci-promote-prod tag='':
+dspace-oci-promote-prod tag='' manifest='' evidence='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1975,7 +2022,10 @@ dspace-oci-promote-prod tag='':
       --tag {{ quote(tag) }} \
       --prod-tag-fallback \
       --require-tag)"
-    just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy env=prod tag="${SUGARKUBE_TAG}"
+    delegate=(just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy env=prod tag="${SUGARKUBE_TAG}")
+    [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
+    [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    "${delegate[@]}"
 
 # Fast redeploy of dspace from GHCR (emergency mutable-tag refresh).
 dspace-oci-redeploy env='staging' tag='':

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -45,10 +45,12 @@ SEMVER_RE = re.compile(
     r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
     r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
 )
-IMAGE_TAG_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*-([0-9a-f]{7})$")
+IMAGE_TAG_RE = re.compile(r"^(?:main|v[0-9]+)-([0-9a-f]{7})$")
 PROVIDERS = {"token-place", "openai"}
 REVISION_ANNOTATION = "org.opencontainers.image.revision"
 RUNTIME_METHOD = "podImageID+ociRevisionAnnotation"
+IMAGE_REF = "ghcr.io/democratizedspace/dspace"
+CHART_REF = "ghcr.io/democratizedspace/charts/dspace"
 
 
 class ManifestError(ValueError):
@@ -86,9 +88,7 @@ def _validate_upstream(value: dict[str, Any]) -> None:
         raise ManifestError("applicationVersion must be strict SemVer")
     sha = value["sourceRevision"]
     if not isinstance(sha, str) or not SHA_RE.fullmatch(sha):
-        raise ManifestError(
-            "sourceRevision must be a full 40-character lowercase Git SHA"
-        )
+        raise ManifestError("sourceRevision must be a full 40-character lowercase Git SHA")
     tag = value["imageTag"]
     match = IMAGE_TAG_RE.fullmatch(tag) if isinstance(tag, str) else None
     if not match:
@@ -100,17 +100,11 @@ def _validate_upstream(value: dict[str, Any]) -> None:
     for field in ("imageDigest", "chartDigest"):
         if not isinstance(value[field], str) or not DIGEST_RE.fullmatch(value[field]):
             raise ManifestError(f"{field} must be a lowercase sha256 digest")
-    if not isinstance(value["chartVersion"], str) or not SEMVER_RE.fullmatch(
-        value["chartVersion"]
-    ):
+    if not isinstance(value["chartVersion"], str) or not SEMVER_RE.fullmatch(value["chartVersion"]):
         raise ManifestError("chartVersion must be strict SemVer")
     semantic = value["semanticTag"]
-    if semantic is not None and (
-        not isinstance(semantic, str) or semantic != f"v{value['applicationVersion']}"
-    ):
-        raise ManifestError(
-            "semanticTag must be null or v<applicationVersion> evidence"
-        )
+    if not isinstance(semantic, str) or semantic != f"v{value['applicationVersion']}":
+        raise ManifestError("semanticTag must equal v<applicationVersion>")
 
 
 def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, Any]:
@@ -198,9 +192,7 @@ def _write_new(path: Path, value: dict[str, Any]) -> None:
         try:
             os.link(temporary, path)
         except FileExistsError as exc:
-            raise ManifestError(
-                f"refusing to overwrite existing record: {path}"
-            ) from exc
+            raise ManifestError(f"refusing to overwrite existing record: {path}") from exc
         # Persist the new directory entry as well as the file contents. Some
         # filesystems otherwise permit a successful return followed by losing
         # the link during a power failure.
@@ -237,6 +229,18 @@ def candidate(
     return validate(result, False)
 
 
+def evidence_path(value: dict[str, Any]) -> Path:
+    """Return the stable, approval-unique default evidence destination."""
+    validate(value, False)
+    approved = value["approvedAt"].replace("-", "").replace(":", "")
+    return (
+        Path("deployment-evidence")
+        / "dspace"
+        / value["environment"]
+        / (f"{value['imageTag']}-{approved}.json")
+    )
+
+
 def _run(command: list[str]) -> str:
     completed = subprocess.run(command, check=False, capture_output=True, text=True)
     if completed.returncode:
@@ -246,20 +250,65 @@ def _run(command: list[str]) -> str:
     return completed.stdout
 
 
-def _oras_evidence(oras: str, reference: str) -> tuple[str, str]:
-    descriptor = json.loads(
-        _run([oras, "manifest", "fetch", "--descriptor", reference])
-    )
-    manifest = json.loads(_run([oras, "manifest", "fetch", reference]))
-    digest = descriptor.get("digest")
-    annotations = manifest.get("annotations", {})
-    revision = annotations.get(REVISION_ANNOTATION) or descriptor.get(
-        "annotations", {}
-    ).get(REVISION_ANNOTATION)
-    if not isinstance(digest, str) or not isinstance(revision, str):
-        raise ManifestError(
-            f"OCI descriptor for {reference} lacks digest or revision annotation"
+def _json_run(runner, command: list[str]) -> dict[str, Any]:
+    try:
+        value = json.loads(runner(command))
+    except json.JSONDecodeError as exc:
+        raise ManifestError(f"invalid JSON returned by {command[0]}") from exc
+    if not isinstance(value, dict):
+        raise ManifestError(f"{command[0]} returned a non-object JSON value")
+    return value
+
+
+def _revision(config: dict[str, Any]) -> str | None:
+    labels = config.get("config", {}).get("Labels", {})
+    annotations = config.get("annotations", {})
+    return labels.get(REVISION_ANNOTATION) or annotations.get(REVISION_ANNOTATION)
+
+
+def _descriptor(oras: str, tagged_ref: str, runner) -> str:
+    value = _json_run(runner, [oras, "manifest", "fetch", "--descriptor", tagged_ref])
+    digest = value.get("digest")
+    if not isinstance(digest, str) or not DIGEST_RE.fullmatch(digest):
+        raise ManifestError(f"OCI descriptor for {tagged_ref} lacks a canonical digest")
+    return digest
+
+
+def _image_evidence(oras: str, repository: str, tag: str, runner) -> tuple[str, list[str]]:
+    digest = _descriptor(oras, f"{repository}:{tag}", runner)
+    index = _json_run(runner, [oras, "manifest", "fetch", f"{repository}@{digest}"])
+    manifests = index.get("manifests")
+    if not isinstance(manifests, list) or not manifests:
+        raise ManifestError("image artifact must be an OCI image index with platform manifests")
+    revisions = []
+    for platform in manifests:
+        platform_digest = platform.get("digest") if isinstance(platform, dict) else None
+        if not isinstance(platform_digest, str) or not DIGEST_RE.fullmatch(platform_digest):
+            raise ManifestError("image index contains a non-canonical platform digest")
+        image_manifest = _json_run(
+            runner, [oras, "manifest", "fetch", f"{repository}@{platform_digest}"]
         )
+        config_digest = image_manifest.get("config", {}).get("digest")
+        if not isinstance(config_digest, str) or not DIGEST_RE.fullmatch(config_digest):
+            raise ManifestError("image manifest lacks a canonical config digest")
+        config = _json_run(runner, [oras, "blob", "fetch", f"{repository}@{config_digest}"])
+        revision = _revision(config)
+        if not isinstance(revision, str):
+            raise ManifestError("image config lacks OCI revision label")
+        revisions.append(revision)
+    return digest, revisions
+
+
+def _chart_evidence(oras: str, repository: str, version: str, runner) -> tuple[str, str]:
+    digest = _descriptor(oras, f"{repository}:{version}", runner)
+    artifact = _json_run(runner, [oras, "manifest", "fetch", f"{repository}@{digest}"])
+    config_digest = artifact.get("config", {}).get("digest")
+    if not isinstance(config_digest, str) or not DIGEST_RE.fullmatch(config_digest):
+        raise ManifestError("chart artifact lacks a canonical config digest")
+    config = _json_run(runner, [oras, "blob", "fetch", f"{repository}@{config_digest}"])
+    revision = _revision(config)
+    if not isinstance(revision, str):
+        raise ManifestError("chart config lacks OCI revision metadata")
     return digest, revision
 
 
@@ -271,6 +320,7 @@ def preflight(
     environment: str | None = None,
     image_tag: str | None = None,
     chart_version: str | None = None,
+    runner=_run,
 ) -> list[dict[str, Any]]:
     validate(value, False)
     selected = (
@@ -281,16 +331,17 @@ def preflight(
     for field, expected in selected:
         if expected is not None and value[field] != expected:
             raise ManifestError(f"selected {field} does not match approved manifest")
-    image_digest, image_revision = _oras_evidence(
-        oras, f"{image_ref}:{value['imageTag']}"
-    )
-    chart_digest, chart_revision = _oras_evidence(
-        oras, f"{chart_ref}:{value['chartVersion']}"
-    )
+    image_ref = image_ref.removeprefix("oci://")
+    chart_ref = chart_ref.removeprefix("oci://")
+    if image_ref != IMAGE_REF:
+        raise ManifestError(f"image reference must be {IMAGE_REF}")
+    if chart_ref != CHART_REF:
+        raise ManifestError(f"chart reference must be oci://{CHART_REF}")
+    image_digest, image_revisions = _image_evidence(oras, image_ref, value["imageTag"], runner)
+    chart_digest, chart_revision = _chart_evidence(oras, chart_ref, value["chartVersion"], runner)
     checks = (
         ("imageDigest", image_digest, value["imageDigest"]),
         ("chartDigest", chart_digest, value["chartDigest"]),
-        ("imageSourceRevision", image_revision, value["sourceRevision"]),
         ("chartSourceRevision", chart_revision, value["sourceRevision"]),
     )
     results = [
@@ -301,6 +352,14 @@ def preflight(
         }
         for name, actual, expected in checks
     ]
+    results.extend(
+        {
+            "check": f"imagePlatformSourceRevision[{index}]",
+            "passed": revision == value["sourceRevision"],
+            "details": f"expected {value['sourceRevision']}; resolved {revision}",
+        }
+        for index, revision in enumerate(image_revisions)
+    )
     failed = [item["check"] for item in results if not item["passed"]]
     if failed:
         raise ManifestError("OCI preflight mismatch: " + ", ".join(failed))
@@ -326,9 +385,7 @@ def finalize(
     for item in pods_json.get("items", []):
         statuses = item.get("status", {}).get("containerStatuses", [])
         if len(statuses) != 1:
-            raise ManifestError(
-                "DSPACE pods must expose exactly one application container imageID"
-            )
+            raise ManifestError("DSPACE pods must expose exactly one application container imageID")
         pods.append(
             {
                 "name": item.get("metadata", {}).get("name"),
@@ -337,8 +394,16 @@ def finalize(
             }
         )
     pods.sort(key=lambda item: str(item["name"]))
-    if not preflight_results:
-        raise ManifestError("finalization requires fresh OCI preflight results")
+    checks = {
+        item.get("check")
+        for item in preflight_results
+        if isinstance(item, dict) and item.get("passed") is True
+    }
+    required = {"imageDigest", "chartDigest", "chartSourceRevision"}
+    if not required <= checks or not any(
+        str(check).startswith("imagePlatformSourceRevision[") for check in checks
+    ):
+        raise ManifestError("finalization requires complete fresh OCI preflight results")
     results = [
         *preflight_results,
         {
@@ -374,13 +439,9 @@ def main(argv: list[str] | None = None) -> int:
     check.add_argument("--final", action="store_true")
     flight = sub.add_parser("preflight")
     flight.add_argument("--manifest", type=Path, required=True)
-    flight.add_argument("--image-ref", default="ghcr.io/democratizedspace/dspace")
-    flight.add_argument(
-        "--chart-ref", default="ghcr.io/democratizedspace/charts/dspace"
-    )
-    flight.add_argument(
-        "--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras")
-    )
+    flight.add_argument("--image-ref", default=IMAGE_REF)
+    flight.add_argument("--chart-ref", default=CHART_REF)
+    flight.add_argument("--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
     flight.add_argument("--environment")
     flight.add_argument("--image-tag")
     flight.add_argument("--chart-version")
@@ -389,15 +450,13 @@ def main(argv: list[str] | None = None) -> int:
     finish.add_argument("--output", type=Path, required=True)
     finish.add_argument("--release", default="dspace")
     finish.add_argument("--namespace", default="dspace")
-    finish.add_argument("--image-ref", default="ghcr.io/democratizedspace/dspace")
-    finish.add_argument(
-        "--chart-ref", default="ghcr.io/democratizedspace/charts/dspace"
-    )
-    finish.add_argument(
-        "--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras")
-    )
+    finish.add_argument("--image-ref", default=IMAGE_REF)
+    finish.add_argument("--chart-ref", default=CHART_REF)
+    finish.add_argument("--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
     available = sub.add_parser("check-output")
     available.add_argument("--output", type=Path, required=True)
+    destination = sub.add_parser("evidence-path")
+    destination.add_argument("--manifest", type=Path, required=True)
     args = parser.parse_args(argv)
     try:
         if args.command == "candidate":
@@ -425,9 +484,7 @@ def main(argv: list[str] | None = None) -> int:
             sys.stdout.write(_canonical(result))
         elif args.command == "finalize":
             source = _object(args.manifest)
-            results = preflight(
-                source, args.image_ref, args.chart_ref, args.oras_command
-            )
+            results = preflight(source, args.image_ref, args.chart_ref, args.oras_command)
             helm = json.loads(
                 _run(
                     [
@@ -458,11 +515,11 @@ def main(argv: list[str] | None = None) -> int:
             )
             result = finalize(source, helm, pods, results)
             _write_new(args.output, result)
-        else:
+        elif args.command == "check-output":
             if args.output.exists():
-                raise ManifestError(
-                    f"refusing to overwrite existing record: {args.output}"
-                )
+                raise ManifestError(f"refusing to overwrite existing record: {args.output}")
+        else:
+            sys.stdout.write(str(evidence_path(_object(args.manifest))) + "\n")
     except (ManifestError, json.JSONDecodeError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -490,6 +490,12 @@ def preflight(
     return results
 
 
+def chart_coordinate(value: dict[str, Any]) -> str:
+    """Return the immutable Helm coordinate approved by a validated candidate."""
+    validate(value, False)
+    return f"oci://{CHART_REF}@{value['chartDigest']}"
+
+
 def _image_id_digest(image_id: str) -> str:
     match = re.search(r"sha256:[0-9a-f]{64}$", image_id)
     if not match:
@@ -642,7 +648,12 @@ def finalize(
         {
             "check": "installedChart",
             "passed": True,
-            "details": f"chart=dspace; version={chart_version}",
+            # Helm metadata proves name/version, not immutable OCI content. The
+            # guarded mutation therefore installs this approved digest directly.
+            "details": (
+                f"chart=dspace; version={chart_version}; "
+                f"coordinate={chart_coordinate(value)}"
+            ),
         },
         {
             "check": "releaseOwnershipAndReadiness",
@@ -693,6 +704,7 @@ def main(argv: list[str] | None = None) -> int:
     flight.add_argument("--environment")
     flight.add_argument("--image-tag")
     flight.add_argument("--chart-version")
+    flight.add_argument("--print-chart-coordinate", action="store_true")
     finish = sub.add_parser("finalize")
     finish.add_argument("--manifest", type=Path, required=True)
     finish.add_argument("--output", type=Path, required=True)
@@ -733,8 +745,9 @@ def main(argv: list[str] | None = None) -> int:
             result = validate(_object(args.manifest), args.final)
             sys.stdout.write(_canonical(result))
         elif args.command == "preflight":
+            source = _object(args.manifest)
             result = preflight(
-                _object(args.manifest),
+                source,
                 args.image_ref,
                 args.chart_ref,
                 args.oras_command,
@@ -742,7 +755,10 @@ def main(argv: list[str] | None = None) -> int:
                 args.image_tag,
                 args.chart_version,
             )
-            sys.stdout.write(_canonical(result))
+            if args.print_chart_coordinate:
+                sys.stdout.write(chart_coordinate(source) + "\n")
+            else:
+                sys.stdout.write(_canonical(result))
         elif args.command == "finalize":
             source = _object(args.manifest)
             sidecar = verify_reservation(

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import hashlib
 import json
 import os
 import re
+import secrets
 import subprocess
 import sys
 import tempfile
@@ -51,6 +53,7 @@ REVISION_ANNOTATION = "org.opencontainers.image.revision"
 RUNTIME_METHOD = "podImageID+ociRevisionAnnotation"
 IMAGE_REF = "ghcr.io/democratizedspace/dspace"
 CHART_REF = "ghcr.io/democratizedspace/charts/dspace"
+RESERVATION_SUFFIX = ".reservation"
 
 
 class ManifestError(ValueError):
@@ -192,21 +195,105 @@ def _write_new(path: Path, value: dict[str, Any]) -> None:
         try:
             os.link(temporary, path)
         except FileExistsError as exc:
-            raise ManifestError(f"refusing to overwrite existing record: {path}") from exc
-        # Persist the new directory entry as well as the file contents. Some
-        # filesystems otherwise permit a successful return followed by losing
-        # the link during a power failure.
-        try:
-            directory_fd = os.open(path.parent, os.O_RDONLY)
-            try:
-                os.fsync(directory_fd)
-            finally:
-                os.close(directory_fd)
-        except OSError:
-            # Directory fsync is not supported on every platform/filesystem.
-            pass
+            raise ManifestError(
+                f"refusing to overwrite existing record: {path}"
+            ) from exc
+        _sync_directory(path.parent)
     finally:
         Path(temporary).unlink(missing_ok=True)
+
+
+def _sync_directory(path: Path) -> None:
+    try:
+        directory_fd = os.open(path, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except OSError:
+        pass
+
+
+def reservation_path(output: Path) -> Path:
+    """Return the non-secret sidecar used to reserve an evidence destination."""
+    normalized = output.expanduser().resolve(strict=False)
+    return normalized.with_name(normalized.name + RESERVATION_SUFFIX)
+
+
+def _candidate_fingerprint(value: dict[str, Any]) -> str:
+    validate(value, False)
+    return hashlib.sha256(_canonical(value).encode()).hexdigest()
+
+
+def reserve(
+    output: Path, value: dict[str, Any], environment: str, release: str, namespace: str
+) -> str:
+    """Atomically reserve output for one invocation and return its opaque ID."""
+    validate(value, False)
+    if value["environment"] != environment:
+        raise ManifestError("reservation environment does not match candidate")
+    normalized = output.expanduser().resolve(strict=False)
+    sidecar = reservation_path(normalized)
+    normalized.parent.mkdir(parents=True, exist_ok=True)
+    if normalized.exists():
+        raise ManifestError(f"refusing to overwrite existing record: {normalized}")
+    identifier = secrets.token_hex(32)
+    metadata = {
+        "schemaVersion": 1,
+        "output": str(normalized),
+        "candidateFingerprint": _candidate_fingerprint(value),
+        "environment": environment,
+        "release": release,
+        "namespace": namespace,
+        "reservationId": identifier,
+    }
+    try:
+        fd = os.open(sidecar, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError as exc:
+        raise ManifestError(
+            f"evidence destination is already reserved: {sidecar}"
+        ) from exc
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(_canonical(metadata))
+            stream.flush()
+            os.fsync(stream.fileno())
+        _sync_directory(normalized.parent)
+    except BaseException:
+        sidecar.unlink(missing_ok=True)
+        raise
+    return identifier
+
+
+def verify_reservation(
+    output: Path,
+    value: dict[str, Any],
+    environment: str,
+    release: str,
+    namespace: str,
+    identifier: str,
+) -> Path:
+    normalized = output.expanduser().resolve(strict=False)
+    sidecar = reservation_path(normalized)
+    metadata = _object(sidecar)
+    expected = {
+        "schemaVersion": 1,
+        "output": str(normalized),
+        "candidateFingerprint": _candidate_fingerprint(value),
+        "environment": environment,
+        "release": release,
+        "namespace": namespace,
+        "reservationId": identifier,
+    }
+    if not secrets.compare_digest(
+        json.dumps(metadata, sort_keys=True), json.dumps(expected, sort_keys=True)
+    ):
+        raise ManifestError(
+            "reservation ownership or deployment coordinates do not match"
+        )
+    if normalized.exists():
+        raise ManifestError(f"refusing to overwrite existing record: {normalized}")
+    return sidecar
 
 
 def candidate(
@@ -580,11 +667,20 @@ def main(argv: list[str] | None = None) -> int:
     finish.add_argument("--namespace", required=True)
     finish.add_argument("--image-ref", default=IMAGE_REF)
     finish.add_argument("--chart-ref", default=CHART_REF)
-    finish.add_argument("--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
+    finish.add_argument("--reservation", required=True)
+    finish.add_argument(
+        "--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras")
+    )
     available = sub.add_parser("check-output")
     available.add_argument("--output", type=Path, required=True)
     destination = sub.add_parser("evidence-path")
     destination.add_argument("--manifest", type=Path, required=True)
+    claim = sub.add_parser("reserve")
+    claim.add_argument("--manifest", type=Path, required=True)
+    claim.add_argument("--output", type=Path, required=True)
+    claim.add_argument("--environment", required=True)
+    claim.add_argument("--release", required=True)
+    claim.add_argument("--namespace", required=True)
     args = parser.parse_args(argv)
     try:
         if args.command == "candidate":
@@ -612,6 +708,14 @@ def main(argv: list[str] | None = None) -> int:
             sys.stdout.write(_canonical(result))
         elif args.command == "finalize":
             source = _object(args.manifest)
+            sidecar = verify_reservation(
+                args.output,
+                source,
+                args.environment,
+                args.release,
+                args.namespace,
+                args.reservation,
+            )
             results = preflight(
                 source,
                 args.image_ref,
@@ -694,10 +798,33 @@ def main(argv: list[str] | None = None) -> int:
                 namespace=args.namespace,
                 cluster_environment=cluster_environment,
             )
+            sidecar = verify_reservation(
+                args.output,
+                source,
+                args.environment,
+                args.release,
+                args.namespace,
+                args.reservation,
+            )
             _write_new(args.output, result)
+            sidecar.unlink()
+            _sync_directory(args.output.expanduser().resolve(strict=False).parent)
         elif args.command == "check-output":
             if args.output.exists():
-                raise ManifestError(f"refusing to overwrite existing record: {args.output}")
+                raise ManifestError(
+                    f"refusing to overwrite existing record: {args.output}"
+                )
+        elif args.command == "reserve":
+            sys.stdout.write(
+                reserve(
+                    args.output,
+                    _object(args.manifest),
+                    args.environment,
+                    args.release,
+                    args.namespace,
+                )
+                + "\n"
+            )
         else:
             sys.stdout.write(str(evidence_path(_object(args.manifest))) + "\n")
     except (ManifestError, json.JSONDecodeError) as exc:

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -86,7 +86,9 @@ def _validate_upstream(value: dict[str, Any]) -> None:
         raise ManifestError("applicationVersion must be strict SemVer")
     sha = value["sourceRevision"]
     if not isinstance(sha, str) or not SHA_RE.fullmatch(sha):
-        raise ManifestError("sourceRevision must be a full 40-character lowercase Git SHA")
+        raise ManifestError(
+            "sourceRevision must be a full 40-character lowercase Git SHA"
+        )
     tag = value["imageTag"]
     match = IMAGE_TAG_RE.fullmatch(tag) if isinstance(tag, str) else None
     if not match:
@@ -98,13 +100,17 @@ def _validate_upstream(value: dict[str, Any]) -> None:
     for field in ("imageDigest", "chartDigest"):
         if not isinstance(value[field], str) or not DIGEST_RE.fullmatch(value[field]):
             raise ManifestError(f"{field} must be a lowercase sha256 digest")
-    if not isinstance(value["chartVersion"], str) or not SEMVER_RE.fullmatch(value["chartVersion"]):
+    if not isinstance(value["chartVersion"], str) or not SEMVER_RE.fullmatch(
+        value["chartVersion"]
+    ):
         raise ManifestError("chartVersion must be strict SemVer")
     semantic = value["semanticTag"]
     if semantic is not None and (
         not isinstance(semantic, str) or semantic != f"v{value['applicationVersion']}"
     ):
-        raise ManifestError("semanticTag must be null or v<applicationVersion> evidence")
+        raise ManifestError(
+            "semanticTag must be null or v<applicationVersion> evidence"
+        )
 
 
 def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, Any]:
@@ -192,13 +198,31 @@ def _write_new(path: Path, value: dict[str, Any]) -> None:
         try:
             os.link(temporary, path)
         except FileExistsError as exc:
-            raise ManifestError(f"refusing to overwrite existing record: {path}") from exc
+            raise ManifestError(
+                f"refusing to overwrite existing record: {path}"
+            ) from exc
+        # Persist the new directory entry as well as the file contents. Some
+        # filesystems otherwise permit a successful return followed by losing
+        # the link during a power failure.
+        try:
+            directory_fd = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except OSError:
+            # Directory fsync is not supported on every platform/filesystem.
+            pass
     finally:
         Path(temporary).unlink(missing_ok=True)
 
 
 def candidate(
-    upstream: dict[str, Any], environment: str, provider: str, approved_at: str, approved_by: str
+    upstream: dict[str, Any],
+    environment: str,
+    provider: str,
+    approved_at: str,
+    approved_by: str,
 ) -> dict[str, Any]:
     _exact_fields(upstream, UPSTREAM_FIELDS)
     _validate_upstream(upstream)
@@ -223,15 +247,19 @@ def _run(command: list[str]) -> str:
 
 
 def _oras_evidence(oras: str, reference: str) -> tuple[str, str]:
-    descriptor = json.loads(_run([oras, "manifest", "fetch", "--descriptor", reference]))
+    descriptor = json.loads(
+        _run([oras, "manifest", "fetch", "--descriptor", reference])
+    )
     manifest = json.loads(_run([oras, "manifest", "fetch", reference]))
     digest = descriptor.get("digest")
     annotations = manifest.get("annotations", {})
-    revision = annotations.get(REVISION_ANNOTATION) or descriptor.get("annotations", {}).get(
-        REVISION_ANNOTATION
-    )
+    revision = annotations.get(REVISION_ANNOTATION) or descriptor.get(
+        "annotations", {}
+    ).get(REVISION_ANNOTATION)
     if not isinstance(digest, str) or not isinstance(revision, str):
-        raise ManifestError(f"OCI descriptor for {reference} lacks digest or revision annotation")
+        raise ManifestError(
+            f"OCI descriptor for {reference} lacks digest or revision annotation"
+        )
     return digest, revision
 
 
@@ -253,8 +281,12 @@ def preflight(
     for field, expected in selected:
         if expected is not None and value[field] != expected:
             raise ManifestError(f"selected {field} does not match approved manifest")
-    image_digest, image_revision = _oras_evidence(oras, f"{image_ref}:{value['imageTag']}")
-    chart_digest, chart_revision = _oras_evidence(oras, f"{chart_ref}:{value['chartVersion']}")
+    image_digest, image_revision = _oras_evidence(
+        oras, f"{image_ref}:{value['imageTag']}"
+    )
+    chart_digest, chart_revision = _oras_evidence(
+        oras, f"{chart_ref}:{value['chartVersion']}"
+    )
     checks = (
         ("imageDigest", image_digest, value["imageDigest"]),
         ("chartDigest", chart_digest, value["chartDigest"]),
@@ -283,7 +315,10 @@ def _image_id_digest(image_id: str) -> str:
 
 
 def finalize(
-    value: dict[str, Any], helm_json: dict[str, Any], pods_json: dict[str, Any]
+    value: dict[str, Any],
+    helm_json: dict[str, Any],
+    pods_json: dict[str, Any],
+    preflight_results: list[dict[str, Any]],
 ) -> dict[str, Any]:
     validate(value, False)
     revision = helm_json.get("version")
@@ -291,7 +326,9 @@ def finalize(
     for item in pods_json.get("items", []):
         statuses = item.get("status", {}).get("containerStatuses", [])
         if len(statuses) != 1:
-            raise ManifestError("DSPACE pods must expose exactly one application container imageID")
+            raise ManifestError(
+                "DSPACE pods must expose exactly one application container imageID"
+            )
         pods.append(
             {
                 "name": item.get("metadata", {}).get("name"),
@@ -300,12 +337,10 @@ def finalize(
             }
         )
     pods.sort(key=lambda item: str(item["name"]))
+    if not preflight_results:
+        raise ManifestError("finalization requires fresh OCI preflight results")
     results = [
-        {
-            "check": "ociPreflight",
-            "passed": True,
-            "details": "image and chart digests and revision annotations matched candidate",
-        },
+        *preflight_results,
         {
             "check": "podImageDigests",
             "passed": True,
@@ -340,8 +375,12 @@ def main(argv: list[str] | None = None) -> int:
     flight = sub.add_parser("preflight")
     flight.add_argument("--manifest", type=Path, required=True)
     flight.add_argument("--image-ref", default="ghcr.io/democratizedspace/dspace")
-    flight.add_argument("--chart-ref", default="ghcr.io/democratizedspace/charts/dspace")
-    flight.add_argument("--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
+    flight.add_argument(
+        "--chart-ref", default="ghcr.io/democratizedspace/charts/dspace"
+    )
+    flight.add_argument(
+        "--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras")
+    )
     flight.add_argument("--environment")
     flight.add_argument("--image-tag")
     flight.add_argument("--chart-version")
@@ -350,6 +389,15 @@ def main(argv: list[str] | None = None) -> int:
     finish.add_argument("--output", type=Path, required=True)
     finish.add_argument("--release", default="dspace")
     finish.add_argument("--namespace", default="dspace")
+    finish.add_argument("--image-ref", default="ghcr.io/democratizedspace/dspace")
+    finish.add_argument(
+        "--chart-ref", default="ghcr.io/democratizedspace/charts/dspace"
+    )
+    finish.add_argument(
+        "--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras")
+    )
+    available = sub.add_parser("check-output")
+    available.add_argument("--output", type=Path, required=True)
     args = parser.parse_args(argv)
     try:
         if args.command == "candidate":
@@ -375,10 +423,23 @@ def main(argv: list[str] | None = None) -> int:
                 args.chart_version,
             )
             sys.stdout.write(_canonical(result))
-        else:
+        elif args.command == "finalize":
             source = _object(args.manifest)
+            results = preflight(
+                source, args.image_ref, args.chart_ref, args.oras_command
+            )
             helm = json.loads(
-                _run(["helm", "status", args.release, "--namespace", args.namespace, "-o", "json"])
+                _run(
+                    [
+                        "helm",
+                        "status",
+                        args.release,
+                        "--namespace",
+                        args.namespace,
+                        "-o",
+                        "json",
+                    ]
+                )
             )
             pods = json.loads(
                 _run(
@@ -395,8 +456,13 @@ def main(argv: list[str] | None = None) -> int:
                     ]
                 )
             )
-            result = finalize(source, helm, pods)
+            result = finalize(source, helm, pods, results)
             _write_new(args.output, result)
+        else:
+            if args.output.exists():
+                raise ManifestError(
+                    f"refusing to overwrite existing record: {args.output}"
+                )
     except (ManifestError, json.JSONDecodeError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -13,6 +13,7 @@ import secrets
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
@@ -69,6 +70,8 @@ FINAL_FIXED_CHECKS = {
     "podImageDigests",
 }
 PLATFORM_CHECK_RE = re.compile(r"^imagePlatformSourceRevision\[(0|[1-9][0-9]*)\]$")
+POD_SETTLE_TIMEOUT_SECONDS = 60.0
+POD_SETTLE_INTERVAL_SECONDS = 2.0
 
 
 class ManifestError(ValueError):
@@ -503,6 +506,33 @@ def _image_id_digest(image_id: str) -> str:
     return match.group(0)
 
 
+def _settle_release_pods(
+    command: list[str],
+    *,
+    runner: Any = None,
+    monotonic: Any = None,
+    sleeper: Any = None,
+) -> dict[str, Any]:
+    """Wait boundedly for release pods undergoing graceful deletion to disappear."""
+    runner = _run if runner is None else runner
+    monotonic = time.monotonic if monotonic is None else monotonic
+    sleeper = time.sleep if sleeper is None else sleeper
+    deadline = monotonic() + POD_SETTLE_TIMEOUT_SECONDS
+    while True:
+        pods = json.loads(runner(command))
+        terminating = [
+            item
+            for item in pods.get("items", [])
+            if isinstance(item, dict)
+            and item.get("metadata", {}).get("deletionTimestamp") is not None
+        ]
+        if not terminating:
+            return pods
+        if monotonic() >= deadline:
+            raise ManifestError("timed out waiting for terminating release pods")
+        sleeper(POD_SETTLE_INTERVAL_SECONDS)
+
+
 def finalize(
     value: dict[str, Any],
     helm_json: dict[str, Any],
@@ -797,38 +827,33 @@ def main(argv: list[str] | None = None) -> int:
                     args.environment,
                 ]
             ).strip()
-            helm = json.loads(
-                _run(
-                    [
-                        "helm",
-                        "--kubeconfig",
-                        args.kubeconfig,
-                        "status",
-                        args.release,
-                        "--namespace",
-                        args.namespace,
-                        "-o",
-                        "json",
-                    ]
-                )
-            )
-            pods = json.loads(
-                _run(
-                    [
-                        "kubectl",
-                        "--kubeconfig",
-                        args.kubeconfig,
-                        "-n",
-                        args.namespace,
-                        "get",
-                        "pods",
-                        "-l",
-                        f"app.kubernetes.io/name=dspace,app.kubernetes.io/instance={args.release}",
-                        "-o",
-                        "json",
-                    ]
-                )
-            )
+            helm_command = [
+                "helm",
+                "--kubeconfig",
+                args.kubeconfig,
+                "status",
+                args.release,
+                "--namespace",
+                args.namespace,
+                "-o",
+                "json",
+            ]
+            helm = json.loads(_run(helm_command))
+            pod_command = [
+                "kubectl",
+                "--kubeconfig",
+                args.kubeconfig,
+                "-n",
+                args.namespace,
+                "get",
+                "pods",
+                "-l",
+                f"app.kubernetes.io/name=dspace,app.kubernetes.io/instance={args.release}",
+                "-o",
+                "json",
+            ]
+            pods = _settle_release_pods(pod_command)
+            settled_helm = json.loads(_run(helm_command))
             workloads = json.loads(
                 _run(
                     [
@@ -868,21 +893,7 @@ def main(argv: list[str] | None = None) -> int:
                 args.namespace,
                 args.reservation,
             )
-            stable_helm = json.loads(
-                _run(
-                    [
-                        "helm",
-                        "--kubeconfig",
-                        args.kubeconfig,
-                        "status",
-                        args.release,
-                        "--namespace",
-                        args.namespace,
-                        "-o",
-                        "json",
-                    ]
-                )
-            )
+            stable_helm = json.loads(_run(helm_command))
 
             def binding_fields(status: dict[str, Any]) -> tuple[Any, ...]:
                 metadata = status.get("chart", {}).get("metadata", {})
@@ -897,7 +908,10 @@ def main(argv: list[str] | None = None) -> int:
                     metadata.get("version"),
                 )
 
-            if binding_fields(stable_helm) != binding_fields(helm):
+            if (
+                binding_fields(settled_helm) != binding_fields(helm)
+                or binding_fields(stable_helm) != binding_fields(helm)
+            ):
                 raise ManifestError("Helm release changed during evidence collection")
             _write_new(args.output, result)
             sidecar.unlink()

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -377,19 +377,113 @@ def finalize(
     value: dict[str, Any],
     helm_json: dict[str, Any],
     pods_json: dict[str, Any],
+    workloads_json: dict[str, Any],
     preflight_results: list[dict[str, Any]],
+    *,
+    environment: str,
+    image_tag: str,
+    chart_version: str,
+    release: str,
+    namespace: str,
+    cluster_environment: str,
 ) -> dict[str, Any]:
     validate(value, False)
+    selected = {
+        "environment": environment,
+        "imageTag": image_tag,
+        "chartVersion": chart_version,
+    }
+    for field, actual in selected.items():
+        if value[field] != actual:
+            raise ManifestError(f"selected {field} does not match approved manifest")
+    if cluster_environment != environment:
+        raise ManifestError("connected cluster environment does not match selected environment")
+
+    if helm_json.get("name") != release or helm_json.get("namespace") != namespace:
+        raise ManifestError("Helm status does not match selected release and namespace")
+    if helm_json.get("info", {}).get("status") != "deployed":
+        raise ManifestError("Helm release status must be deployed")
     revision = helm_json.get("version")
+    chart_metadata = helm_json.get("chart", {}).get("metadata", {})
+    if chart_metadata.get("name") != "dspace" or chart_metadata.get("version") != chart_version:
+        raise ManifestError("installed Helm chart identity or version does not match approval")
+
+    selector_labels = {
+        "app.kubernetes.io/name": "dspace",
+        "app.kubernetes.io/instance": release,
+    }
+    workloads: dict[tuple[str, str], dict[str, Any]] = {}
+    for item in workloads_json.get("items", []):
+        metadata = item.get("metadata", {}) if isinstance(item, dict) else {}
+        kind = item.get("kind") if isinstance(item, dict) else None
+        name = metadata.get("name")
+        if kind not in {"ReplicaSet", "Deployment"} or not isinstance(name, str):
+            raise ManifestError("release workload discovery returned an unexpected object")
+        if any(
+            metadata.get("labels", {}).get(key) != expected
+            for key, expected in selector_labels.items()
+        ):
+            raise ManifestError("release workload labels do not match selected release")
+        if kind == "Deployment":
+            annotations = metadata.get("annotations", {})
+            if (
+                metadata.get("labels", {}).get("app.kubernetes.io/managed-by") != "Helm"
+                or annotations.get("meta.helm.sh/release-name") != release
+                or annotations.get("meta.helm.sh/release-namespace") != namespace
+            ):
+                raise ManifestError("Deployment is not owned by the selected Helm release")
+        workloads[(kind, name)] = item
+
+    def controller(item: dict[str, Any], expected_kind: str) -> dict[str, Any]:
+        references = item.get("metadata", {}).get("ownerReferences", [])
+        owners = [
+            ref for ref in references if isinstance(ref, dict) and ref.get("controller") is True
+        ]
+        if len(owners) != 1 or owners[0].get("kind") != expected_kind:
+            raise ManifestError(f"broken {expected_kind} controller owner-reference chain")
+        owner = workloads.get((expected_kind, owners[0].get("name")))
+        if owner is None or owner.get("metadata", {}).get("uid") != owners[0].get("uid"):
+            raise ManifestError(f"broken {expected_kind} controller owner-reference chain")
+        return owner
+
     pods = []
     for item in pods_json.get("items", []):
-        statuses = item.get("status", {}).get("containerStatuses", [])
-        if len(statuses) != 1:
-            raise ManifestError("DSPACE pods must expose exactly one application container imageID")
+        metadata = item.get("metadata", {}) if isinstance(item, dict) else {}
+        if any(
+            metadata.get("labels", {}).get(key) != expected
+            for key, expected in selector_labels.items()
+        ):
+            raise ManifestError("pod labels do not match selected release")
+        if metadata.get("deletionTimestamp") is not None:
+            raise ManifestError("terminating pods cannot provide serving evidence")
+        replica_set = controller(item, "ReplicaSet")
+        controller(replica_set, "Deployment")
+        status = item.get("status", {})
+        if status.get("phase") != "Running":
+            raise ManifestError("all release pods must be Running")
+        conditions = status.get("conditions", [])
+        if not any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions):
+            raise ManifestError("all release pods must be Ready")
+        containers = item.get("spec", {}).get("containers", [])
+        application = [container for container in containers if container.get("name") == "dspace"]
+        if len(application) != 1:
+            raise ManifestError("pod must contain exactly one dspace application container")
+        expected_image = f"{IMAGE_REF}:{image_tag}"
+        if application[0].get("image") != expected_image:
+            raise ManifestError(
+                "pod application image does not match approved repository and imageTag"
+            )
+        statuses = [
+            container
+            for container in status.get("containerStatuses", [])
+            if container.get("name") == "dspace"
+        ]
+        if len(statuses) != 1 or statuses[0].get("state", {}).get("running") is None:
+            raise ManifestError("dspace application container must be running")
         pods.append(
             {
-                "name": item.get("metadata", {}).get("name"),
-                "startTime": item.get("status", {}).get("startTime"),
+                "name": metadata.get("name"),
+                "startTime": status.get("startTime"),
                 "imageID": statuses[0].get("imageID"),
             }
         )
@@ -406,6 +500,36 @@ def finalize(
         raise ManifestError("finalization requires complete fresh OCI preflight results")
     results = [
         *preflight_results,
+        {
+            "check": "selectedCoordinates",
+            "passed": True,
+            "details": f"environment={environment}; imageTag={image_tag}; chartVersion={chart_version}",
+        },
+        {
+            "check": "clusterEnvironment",
+            "passed": True,
+            "details": f"connected cluster environment={cluster_environment}",
+        },
+        {
+            "check": "helmRelease",
+            "passed": True,
+            "details": f"release={release}; namespace={namespace}; revision={revision}; status=deployed",
+        },
+        {
+            "check": "installedChart",
+            "passed": True,
+            "details": f"chart=dspace; version={chart_version}",
+        },
+        {
+            "check": "releaseOwnershipAndReadiness",
+            "passed": True,
+            "details": f"{len(pods)} pod(s) owned by release workloads and serving",
+        },
+        {
+            "check": "podImageCoordinates",
+            "passed": True,
+            "details": f"all dspace containers use {IMAGE_REF}:{image_tag}",
+        },
         {
             "check": "podImageDigests",
             "passed": True,
@@ -448,8 +572,12 @@ def main(argv: list[str] | None = None) -> int:
     finish = sub.add_parser("finalize")
     finish.add_argument("--manifest", type=Path, required=True)
     finish.add_argument("--output", type=Path, required=True)
-    finish.add_argument("--release", default="dspace")
-    finish.add_argument("--namespace", default="dspace")
+    finish.add_argument("--environment", required=True)
+    finish.add_argument("--image-tag", required=True)
+    finish.add_argument("--chart-version", required=True)
+    finish.add_argument("--kubeconfig", required=True)
+    finish.add_argument("--release", required=True)
+    finish.add_argument("--namespace", required=True)
     finish.add_argument("--image-ref", default=IMAGE_REF)
     finish.add_argument("--chart-ref", default=CHART_REF)
     finish.add_argument("--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
@@ -484,11 +612,32 @@ def main(argv: list[str] | None = None) -> int:
             sys.stdout.write(_canonical(result))
         elif args.command == "finalize":
             source = _object(args.manifest)
-            results = preflight(source, args.image_ref, args.chart_ref, args.oras_command)
+            results = preflight(
+                source,
+                args.image_ref,
+                args.chart_ref,
+                args.oras_command,
+                args.environment,
+                args.image_tag,
+                args.chart_version,
+            )
+            cluster_environment = _run(
+                [
+                    sys.executable,
+                    str(Path(__file__).with_name("cluster_identity.py")),
+                    "assert",
+                    "--kubeconfig",
+                    args.kubeconfig,
+                    "--env",
+                    args.environment,
+                ]
+            ).strip()
             helm = json.loads(
                 _run(
                     [
                         "helm",
+                        "--kubeconfig",
+                        args.kubeconfig,
                         "status",
                         args.release,
                         "--namespace",
@@ -502,18 +651,49 @@ def main(argv: list[str] | None = None) -> int:
                 _run(
                     [
                         "kubectl",
+                        "--kubeconfig",
+                        args.kubeconfig,
                         "-n",
                         args.namespace,
                         "get",
                         "pods",
                         "-l",
-                        "app.kubernetes.io/name=dspace",
+                        f"app.kubernetes.io/name=dspace,app.kubernetes.io/instance={args.release}",
                         "-o",
                         "json",
                     ]
                 )
             )
-            result = finalize(source, helm, pods, results)
+            workloads = json.loads(
+                _run(
+                    [
+                        "kubectl",
+                        "--kubeconfig",
+                        args.kubeconfig,
+                        "-n",
+                        args.namespace,
+                        "get",
+                        "replicasets,deployments",
+                        "-l",
+                        f"app.kubernetes.io/name=dspace,app.kubernetes.io/instance={args.release}",
+                        "-o",
+                        "json",
+                    ]
+                )
+            )
+            result = finalize(
+                source,
+                helm,
+                pods,
+                workloads,
+                results,
+                environment=args.environment,
+                image_tag=args.image_tag,
+                chart_version=args.chart_version,
+                release=args.release,
+                namespace=args.namespace,
+                cluster_environment=cluster_environment,
+            )
             _write_new(args.output, result)
         elif args.command == "check-output":
             if args.output.exists():

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Validate DSPACE release manifests and record deployment evidence."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+UPSTREAM_FIELDS = (
+    "schemaVersion",
+    "app",
+    "applicationVersion",
+    "sourceRevision",
+    "imageTag",
+    "imageDigest",
+    "chartVersion",
+    "chartDigest",
+    "semanticTag",
+)
+CANDIDATE_FIELDS = UPSTREAM_FIELDS + (
+    "recordType",
+    "environment",
+    "expectedDefaultChatProvider",
+    "approvedAt",
+    "approvedBy",
+)
+FINAL_FIELDS = CANDIDATE_FIELDS + (
+    "helmRevision",
+    "pods",
+    "runtimeSourceRevision",
+    "runtimeSourceRevisionMethod",
+    "verificationResults",
+)
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+SEMVER_RE = re.compile(
+    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+IMAGE_TAG_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*-([0-9a-f]{7})$")
+PROVIDERS = {"token-place", "openai"}
+REVISION_ANNOTATION = "org.opencontainers.image.revision"
+RUNTIME_METHOD = "podImageID+ociRevisionAnnotation"
+
+
+class ManifestError(ValueError):
+    """A release record is missing or inconsistent."""
+
+
+def _object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ManifestError(f"cannot read JSON from {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ManifestError("manifest must be a JSON object")
+    return value
+
+
+def _exact_fields(value: dict[str, Any], expected: tuple[str, ...]) -> None:
+    missing = sorted(set(expected) - value.keys())
+    unknown = sorted(value.keys() - set(expected))
+    if missing or unknown:
+        parts = []
+        if missing:
+            parts.append("missing fields: " + ", ".join(missing))
+        if unknown:
+            parts.append("unknown fields: " + ", ".join(unknown))
+        raise ManifestError("; ".join(parts))
+
+
+def _validate_upstream(value: dict[str, Any]) -> None:
+    if value["schemaVersion"] != 1 or value["app"] != "dspace":
+        raise ManifestError("schemaVersion must be 1 and app must be 'dspace'")
+    if not isinstance(value["applicationVersion"], str) or not SEMVER_RE.fullmatch(
+        value["applicationVersion"]
+    ):
+        raise ManifestError("applicationVersion must be strict SemVer")
+    sha = value["sourceRevision"]
+    if not isinstance(sha, str) or not SHA_RE.fullmatch(sha):
+        raise ManifestError("sourceRevision must be a full 40-character lowercase Git SHA")
+    tag = value["imageTag"]
+    match = IMAGE_TAG_RE.fullmatch(tag) if isinstance(tag, str) else None
+    if not match:
+        raise ManifestError(
+            "imageTag must be an immutable lowercase branch-SHA tag with a seven-character suffix"
+        )
+    if match.group(1) != sha[:7]:
+        raise ManifestError("imageTag suffix does not match sourceRevision")
+    for field in ("imageDigest", "chartDigest"):
+        if not isinstance(value[field], str) or not DIGEST_RE.fullmatch(value[field]):
+            raise ManifestError(f"{field} must be a lowercase sha256 digest")
+    if not isinstance(value["chartVersion"], str) or not SEMVER_RE.fullmatch(value["chartVersion"]):
+        raise ManifestError("chartVersion must be strict SemVer")
+    semantic = value["semanticTag"]
+    if semantic is not None and (
+        not isinstance(semantic, str) or semantic != f"v{value['applicationVersion']}"
+    ):
+        raise ManifestError("semanticTag must be null or v<applicationVersion> evidence")
+
+
+def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, Any]:
+    record_type = value.get("recordType")
+    if finalized is None:
+        finalized = record_type == "final"
+    expected = FINAL_FIELDS if finalized else CANDIDATE_FIELDS
+    _exact_fields(value, expected)
+    _validate_upstream(value)
+    if record_type != ("final" if finalized else "candidate"):
+        raise ManifestError("recordType does not match the requested record kind")
+    if value["environment"] not in {"staging", "prod"}:
+        raise ManifestError("environment must be staging or prod")
+    if value["expectedDefaultChatProvider"] not in PROVIDERS:
+        raise ManifestError("expectedDefaultChatProvider must be token-place or openai")
+    if not isinstance(value["approvedBy"], str) or not value["approvedBy"].strip():
+        raise ManifestError("approvedBy must be non-empty")
+    approved = value["approvedAt"]
+    if not isinstance(approved, str) or not re.fullmatch(
+        r"\d{4}-\d\d-\d\dT\d\d:\d\d:\d\dZ", approved
+    ):
+        raise ManifestError("approvedAt must be canonical UTC YYYY-MM-DDTHH:MM:SSZ")
+    try:
+        dt.datetime.strptime(approved, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError as exc:
+        raise ManifestError("approvedAt is not a valid UTC timestamp") from exc
+    if finalized:
+        if (
+            not isinstance(value["helmRevision"], int)
+            or isinstance(value["helmRevision"], bool)
+            or value["helmRevision"] < 1
+        ):
+            raise ManifestError("helmRevision must be a positive integer")
+        pods = value["pods"]
+        if not isinstance(pods, list) or not pods:
+            raise ManifestError("pods must be a non-empty list")
+        names: set[str] = set()
+        for pod in pods:
+            if not isinstance(pod, dict):
+                raise ManifestError("each pod must be an object")
+            _exact_fields(pod, ("name", "startTime", "imageID"))
+            if not all(isinstance(pod[k], str) and pod[k] for k in pod):
+                raise ManifestError("pod evidence values must be non-empty strings")
+            if pod["name"] in names:
+                raise ManifestError("pod names must be unique")
+            names.add(pod["name"])
+            if _image_id_digest(pod["imageID"]) != value["imageDigest"]:
+                raise ManifestError(
+                    f"pod {pod['name']} imageID does not match approved imageDigest"
+                )
+        if value["runtimeSourceRevision"] != value["sourceRevision"]:
+            raise ManifestError("runtimeSourceRevision must match sourceRevision")
+        if value["runtimeSourceRevisionMethod"] != RUNTIME_METHOD:
+            raise ManifestError(f"runtimeSourceRevisionMethod must be {RUNTIME_METHOD}")
+        results = value["verificationResults"]
+        if not isinstance(results, list) or not results:
+            raise ManifestError("verificationResults must be a non-empty list")
+        for result in results:
+            if not isinstance(result, dict):
+                raise ManifestError("verification results must be objects")
+            _exact_fields(result, ("check", "passed", "details"))
+            if (
+                not isinstance(result["check"], str)
+                or not isinstance(result["passed"], bool)
+                or not isinstance(result["details"], str)
+            ):
+                raise ManifestError("verification result fields have invalid types")
+            if not result["passed"]:
+                raise ManifestError(f"verification failed: {result['check']}")
+    return value
+
+
+def _canonical(value: dict[str, Any]) -> str:
+    return json.dumps(value, indent=2, ensure_ascii=True) + "\n"
+
+
+def _write_new(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(_canonical(value))
+            stream.flush()
+            os.fsync(stream.fileno())
+        try:
+            os.link(temporary, path)
+        except FileExistsError as exc:
+            raise ManifestError(f"refusing to overwrite existing record: {path}") from exc
+    finally:
+        Path(temporary).unlink(missing_ok=True)
+
+
+def candidate(
+    upstream: dict[str, Any], environment: str, provider: str, approved_at: str, approved_by: str
+) -> dict[str, Any]:
+    _exact_fields(upstream, UPSTREAM_FIELDS)
+    _validate_upstream(upstream)
+    result = {field: upstream[field] for field in UPSTREAM_FIELDS}
+    result.update(
+        recordType="candidate",
+        environment=environment,
+        expectedDefaultChatProvider=provider,
+        approvedAt=approved_at,
+        approvedBy=approved_by,
+    )
+    return validate(result, False)
+
+
+def _run(command: list[str]) -> str:
+    completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    if completed.returncode:
+        raise ManifestError(
+            f"command failed ({command[0]}): {completed.stderr.strip() or completed.stdout.strip()}"
+        )
+    return completed.stdout
+
+
+def _oras_evidence(oras: str, reference: str) -> tuple[str, str]:
+    descriptor = json.loads(_run([oras, "manifest", "fetch", "--descriptor", reference]))
+    manifest = json.loads(_run([oras, "manifest", "fetch", reference]))
+    digest = descriptor.get("digest")
+    annotations = manifest.get("annotations", {})
+    revision = annotations.get(REVISION_ANNOTATION) or descriptor.get("annotations", {}).get(
+        REVISION_ANNOTATION
+    )
+    if not isinstance(digest, str) or not isinstance(revision, str):
+        raise ManifestError(f"OCI descriptor for {reference} lacks digest or revision annotation")
+    return digest, revision
+
+
+def preflight(
+    value: dict[str, Any],
+    image_ref: str,
+    chart_ref: str,
+    oras: str,
+    environment: str | None = None,
+    image_tag: str | None = None,
+    chart_version: str | None = None,
+) -> list[dict[str, Any]]:
+    validate(value, False)
+    selected = (
+        ("environment", environment),
+        ("imageTag", image_tag),
+        ("chartVersion", chart_version),
+    )
+    for field, expected in selected:
+        if expected is not None and value[field] != expected:
+            raise ManifestError(f"selected {field} does not match approved manifest")
+    image_digest, image_revision = _oras_evidence(oras, f"{image_ref}:{value['imageTag']}")
+    chart_digest, chart_revision = _oras_evidence(oras, f"{chart_ref}:{value['chartVersion']}")
+    checks = (
+        ("imageDigest", image_digest, value["imageDigest"]),
+        ("chartDigest", chart_digest, value["chartDigest"]),
+        ("imageSourceRevision", image_revision, value["sourceRevision"]),
+        ("chartSourceRevision", chart_revision, value["sourceRevision"]),
+    )
+    results = [
+        {
+            "check": name,
+            "passed": actual == expected,
+            "details": f"expected {expected}; resolved {actual}",
+        }
+        for name, actual, expected in checks
+    ]
+    failed = [item["check"] for item in results if not item["passed"]]
+    if failed:
+        raise ManifestError("OCI preflight mismatch: " + ", ".join(failed))
+    return results
+
+
+def _image_id_digest(image_id: str) -> str:
+    match = re.search(r"sha256:[0-9a-f]{64}$", image_id)
+    if not match:
+        raise ManifestError(f"non-canonical pod imageID: {image_id}")
+    return match.group(0)
+
+
+def finalize(
+    value: dict[str, Any], helm_json: dict[str, Any], pods_json: dict[str, Any]
+) -> dict[str, Any]:
+    validate(value, False)
+    revision = helm_json.get("version")
+    pods = []
+    for item in pods_json.get("items", []):
+        statuses = item.get("status", {}).get("containerStatuses", [])
+        if len(statuses) != 1:
+            raise ManifestError("DSPACE pods must expose exactly one application container imageID")
+        pods.append(
+            {
+                "name": item.get("metadata", {}).get("name"),
+                "startTime": item.get("status", {}).get("startTime"),
+                "imageID": statuses[0].get("imageID"),
+            }
+        )
+    pods.sort(key=lambda item: str(item["name"]))
+    results = [
+        {
+            "check": "ociPreflight",
+            "passed": True,
+            "details": "image and chart digests and revision annotations matched candidate",
+        },
+        {
+            "check": "podImageDigests",
+            "passed": True,
+            "details": "every running pod imageID matched approved image digest",
+        },
+    ]
+    result = dict(value)
+    result.update(
+        recordType="final",
+        helmRevision=revision,
+        pods=pods,
+        runtimeSourceRevision=value["sourceRevision"],
+        runtimeSourceRevisionMethod=RUNTIME_METHOD,
+        verificationResults=results,
+    )
+    return validate(result, True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    make = sub.add_parser("candidate")
+    make.add_argument("--upstream", type=Path, required=True)
+    make.add_argument("--output", type=Path, required=True)
+    make.add_argument("--environment", required=True)
+    make.add_argument("--provider", required=True)
+    make.add_argument("--approved-at", required=True)
+    make.add_argument("--approved-by", required=True)
+    check = sub.add_parser("validate")
+    check.add_argument("--manifest", type=Path, required=True)
+    check.add_argument("--final", action="store_true")
+    flight = sub.add_parser("preflight")
+    flight.add_argument("--manifest", type=Path, required=True)
+    flight.add_argument("--image-ref", default="ghcr.io/democratizedspace/dspace")
+    flight.add_argument("--chart-ref", default="ghcr.io/democratizedspace/charts/dspace")
+    flight.add_argument("--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
+    flight.add_argument("--environment")
+    flight.add_argument("--image-tag")
+    flight.add_argument("--chart-version")
+    finish = sub.add_parser("finalize")
+    finish.add_argument("--manifest", type=Path, required=True)
+    finish.add_argument("--output", type=Path, required=True)
+    finish.add_argument("--release", default="dspace")
+    finish.add_argument("--namespace", default="dspace")
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "candidate":
+            result = candidate(
+                _object(args.upstream),
+                args.environment,
+                args.provider,
+                args.approved_at,
+                args.approved_by,
+            )
+            _write_new(args.output, result)
+        elif args.command == "validate":
+            result = validate(_object(args.manifest), args.final)
+            sys.stdout.write(_canonical(result))
+        elif args.command == "preflight":
+            result = preflight(
+                _object(args.manifest),
+                args.image_ref,
+                args.chart_ref,
+                args.oras_command,
+                args.environment,
+                args.image_tag,
+                args.chart_version,
+            )
+            sys.stdout.write(_canonical(result))
+        else:
+            source = _object(args.manifest)
+            helm = json.loads(
+                _run(["helm", "status", args.release, "--namespace", args.namespace, "-o", "json"])
+            )
+            pods = json.loads(
+                _run(
+                    [
+                        "kubectl",
+                        "-n",
+                        args.namespace,
+                        "get",
+                        "pods",
+                        "-l",
+                        "app.kubernetes.io/name=dspace",
+                        "-o",
+                        "json",
+                    ]
+                )
+            )
+            result = finalize(source, helm, pods)
+            _write_new(args.output, result)
+    except (ManifestError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -45,7 +45,9 @@ SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 SEMVER_RE = re.compile(
     r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
-    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+    r"(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)"
+    r"(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
 )
 IMAGE_TAG_RE = re.compile(r"^(?:main|v[0-9]+)-([0-9a-f]{7})$")
 PROVIDERS = {"token-place", "openai"}
@@ -54,6 +56,19 @@ RUNTIME_METHOD = "podImageID+ociRevisionAnnotation"
 IMAGE_REF = "ghcr.io/democratizedspace/dspace"
 CHART_REF = "ghcr.io/democratizedspace/charts/dspace"
 RESERVATION_SUFFIX = ".reservation"
+FINAL_FIXED_CHECKS = {
+    "imageDigest",
+    "chartDigest",
+    "chartSourceRevision",
+    "selectedCoordinates",
+    "clusterEnvironment",
+    "helmRelease",
+    "installedChart",
+    "releaseOwnershipAndReadiness",
+    "podImageCoordinates",
+    "podImageDigests",
+}
+PLATFORM_CHECK_RE = re.compile(r"^imagePlatformSourceRevision\[(0|[1-9][0-9]*)\]$")
 
 
 class ManifestError(ValueError):
@@ -165,6 +180,8 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
         results = value["verificationResults"]
         if not isinstance(results, list) or not results:
             raise ManifestError("verificationResults must be a non-empty list")
+        checks: set[str] = set()
+        platform_indices: list[int] = []
         for result in results:
             if not isinstance(result, dict):
                 raise ManifestError("verification results must be objects")
@@ -173,10 +190,30 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
                 not isinstance(result["check"], str)
                 or not isinstance(result["passed"], bool)
                 or not isinstance(result["details"], str)
+                or not result["check"]
+                or not result["details"]
             ):
                 raise ManifestError("verification result fields have invalid types")
             if not result["passed"]:
                 raise ManifestError(f"verification failed: {result['check']}")
+            check = result["check"]
+            if check in checks:
+                raise ManifestError(f"duplicate verification result: {check}")
+            checks.add(check)
+            platform_match = PLATFORM_CHECK_RE.fullmatch(check)
+            if platform_match:
+                platform_indices.append(int(platform_match.group(1)))
+            elif check not in FINAL_FIXED_CHECKS:
+                raise ManifestError(f"unknown verification result: {check}")
+        missing = sorted(FINAL_FIXED_CHECKS - checks)
+        if missing:
+            raise ManifestError("missing verification results: " + ", ".join(missing))
+        if sorted(platform_indices) != list(range(len(platform_indices))):
+            raise ManifestError(
+                "image platform verification indices must be contiguous from zero"
+            )
+        if not platform_indices:
+            raise ManifestError("at least one image platform verification result is required")
     return value
 
 

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -516,6 +516,7 @@ def finalize(
     release: str,
     namespace: str,
     cluster_environment: str,
+    invocation_description: str,
 ) -> dict[str, Any]:
     validate(value, False)
     selected = {
@@ -531,8 +532,11 @@ def finalize(
 
     if helm_json.get("name") != release or helm_json.get("namespace") != namespace:
         raise ManifestError("Helm status does not match selected release and namespace")
-    if helm_json.get("info", {}).get("status") != "deployed":
+    helm_info = helm_json.get("info", {})
+    if helm_info.get("status") != "deployed":
         raise ManifestError("Helm release status must be deployed")
+    if helm_info.get("description") != invocation_description:
+        raise ManifestError("Helm release description does not match this invocation")
     revision = helm_json.get("version")
     chart_metadata = helm_json.get("chart", {}).get("metadata", {})
     if chart_metadata.get("name") != "dspace" or chart_metadata.get("version") != chart_version:
@@ -643,7 +647,10 @@ def finalize(
         {
             "check": "helmRelease",
             "passed": True,
-            "details": f"release={release}; namespace={namespace}; revision={revision}; status=deployed",
+            "details": (
+                f"release={release}; namespace={namespace}; revision={revision}; "
+                "status=deployed; binding=Helm mutation description"
+            ),
         },
         {
             "check": "installedChart",
@@ -769,6 +776,7 @@ def main(argv: list[str] | None = None) -> int:
                 args.namespace,
                 args.reservation,
             )
+            invocation_description = f"sugarkube-release-manifest:{args.reservation}"
             results = preflight(
                 source,
                 args.image_ref,
@@ -850,6 +858,7 @@ def main(argv: list[str] | None = None) -> int:
                 release=args.release,
                 namespace=args.namespace,
                 cluster_environment=cluster_environment,
+                invocation_description=invocation_description,
             )
             sidecar = verify_reservation(
                 args.output,
@@ -859,6 +868,37 @@ def main(argv: list[str] | None = None) -> int:
                 args.namespace,
                 args.reservation,
             )
+            stable_helm = json.loads(
+                _run(
+                    [
+                        "helm",
+                        "--kubeconfig",
+                        args.kubeconfig,
+                        "status",
+                        args.release,
+                        "--namespace",
+                        args.namespace,
+                        "-o",
+                        "json",
+                    ]
+                )
+            )
+
+            def binding_fields(status: dict[str, Any]) -> tuple[Any, ...]:
+                metadata = status.get("chart", {}).get("metadata", {})
+                info = status.get("info", {})
+                return (
+                    status.get("name"),
+                    status.get("namespace"),
+                    info.get("status"),
+                    status.get("version"),
+                    info.get("description"),
+                    metadata.get("name"),
+                    metadata.get("version"),
+                )
+
+            if binding_fields(stable_helm) != binding_fields(helm):
+                raise ManifestError("Helm release changed during evidence collection")
             _write_new(args.output, result)
             sidecar.unlink()
             _sync_directory(args.output.expanduser().resolve(strict=False).parent)

--- a/scripts/test-helm-oci-install.sh
+++ b/scripts/test-helm-oci-install.sh
@@ -192,6 +192,24 @@ if ! grep -q "rollout status deployment.apps/dspace" "${kubectl_log}"; then
 fi
 
 rm -f "${helm_log}"
+digest_chart="oci://registry.test/charts/dspace@sha256:$(printf 'a%.0s' {1..64})"
+PATH="${tmp_bin}:${PATH}" HELM_TEST_LOG="${helm_log}" KUBECTL_TEST_LOG="${kubectl_log}" \
+    HELM_STATUS_MODE_FILE="${status_mode_file}" \
+    FAKE_HELM_REGISTRY_CHART="${fixture_registry}" KUBECONFIG="${tmp_bin}/kubeconfig" \
+    just helm-oci-install \
+    release=dspace namespace=dspace chart="${digest_chart}" version=3.1.0 env=staging >/dev/null
+
+if ! grep -Fq "show chart ${digest_chart}" "${helm_log}" || \
+    ! grep -Fq "upgrade dspace ${digest_chart}" "${helm_log}"; then
+    printf 'Digest-qualified chart was not passed unchanged to Helm.\nLog:\n%s\n' "$(cat "${helm_log}")" >&2
+    exit 1
+fi
+if grep -F -- '--version' "${helm_log}" >/dev/null; then
+    printf 'Digest-qualified chart unexpectedly received --version.\nLog:\n%s\n' "$(cat "${helm_log}")" >&2
+    exit 1
+fi
+
+rm -f "${helm_log}"
 if PATH="${tmp_bin}:${PATH}" HELM_TEST_LOG="${helm_log}" KUBECTL_TEST_LOG="${kubectl_log}" \
     HELM_STATUS_MODE_FILE="${status_mode_file}" \
     FAKE_HELM_REGISTRY_CHART="${fixture_registry}" KUBECONFIG="${tmp_bin}/kubeconfig" \

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -116,10 +116,21 @@ exit 0
 set -euo pipefail
 printf '%s\n' "$*" >> {str(log_path)!r}
 printf 'helm %s\n' "$*" >> {str(tmp_path / "commands.log")!r}
+if [ "${{1:-}}" = upgrade ]; then
+  previous=""
+  for argument in "$@"; do
+    if [ "$previous" = --description ]; then
+      printf '%s' "$argument" > {str(tmp_path / "helm-description")!r}
+      break
+    fi
+    previous="$argument"
+  done
+fi
 if [[ "$*" == *"status dspace --namespace dspace -o json" ]]; then
   chart_version=3.1.0
   [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" != prod ] || chart_version=3.0.1
-  printf '{{"name":"dspace","namespace":"dspace","version":7,"info":{{"status":"deployed"}},"chart":{{"metadata":{{"name":"dspace","version":"%s"}}}}}}\n' "$chart_version"
+  description="$(cat {str(tmp_path / "helm-description")!r} 2>/dev/null || true)"
+  printf '{{"name":"dspace","namespace":"dspace","version":7,"info":{{"status":"deployed","description":"%s"}},"chart":{{"metadata":{{"name":"dspace","version":"%s"}}}}}}\n' "$description" "$chart_version"
   exit 0
 fi
 if [[ "$*" == *"get values"* ]]; then
@@ -1402,6 +1413,7 @@ def test_dspace_guarded_deploy_orders_preflight_mutation_and_finalization(
     mutation_line = next(line for line in helm_log.splitlines() if line.startswith("upgrade "))
     assert coordinate in mutation_line
     assert "--version" not in mutation_line
+    assert "--description sugarkube-release-manifest:" in mutation_line
     commands = (tmp_path / "commands.log").read_text(encoding="utf-8").splitlines()
     preflight = next(i for i, line in enumerate(commands) if line.startswith("oras "))
     mutation = next(
@@ -1444,6 +1456,7 @@ def test_dspace_guarded_redeploy_installs_approved_chart_digest(
     )
     assert coordinate in mutation_line
     assert "--version" not in mutation_line
+    assert "--description sugarkube-release-manifest:" in mutation_line
 
 
 @pytest.mark.usefixtures("ensure_just_available")
@@ -2884,6 +2897,7 @@ def test_direct_helm_oci_helper_matching_env_succeeds(
     helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
     assert "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.3" in helm_log
     assert "upgrade tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace" in helm_log
+    assert "--description" not in helm_log
 
 
 @pytest.mark.usefixtures("ensure_just_available")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1393,6 +1393,15 @@ def test_dspace_guarded_deploy_orders_preflight_mutation_and_finalization(
     assert final["helmRevision"] == 7
     assert "reservation" not in json.dumps(final).lower()
     assert not Path(str(evidence.resolve()) + ".reservation").exists()
+    coordinate = "oci://ghcr.io/democratizedspace/charts/dspace@sha256:" + "2" * 64
+    installed = next(
+        item for item in final["verificationResults"] if item["check"] == "installedChart"
+    )
+    assert coordinate in installed["details"]
+    helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    mutation_line = next(line for line in helm_log.splitlines() if line.startswith("upgrade "))
+    assert coordinate in mutation_line
+    assert "--version" not in mutation_line
     commands = (tmp_path / "commands.log").read_text(encoding="utf-8").splitlines()
     preflight = next(i for i, line in enumerate(commands) if line.startswith("oras "))
     mutation = next(
@@ -1401,6 +1410,40 @@ def test_dspace_guarded_deploy_orders_preflight_mutation_and_finalization(
     collection = next(i for i, line in enumerate(commands) if " status dspace" in line)
     pods = next(i for i, line in enumerate(commands) if " -n dspace get pods" in line)
     assert preflight < mutation < collection < pods
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_guarded_redeploy_installs_approved_chart_digest(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    candidate_path = tmp_path / "candidate.json"
+    evidence = tmp_path / "evidence.json"
+    _write_dspace_candidate(candidate_path, "staging")
+
+    result = _run_just(
+        [
+            "app-redeploy",
+            "dspace",
+            "staging",
+            "main-abcdef0",
+            "",
+            str(candidate_path),
+            str(evidence),
+        ],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    coordinate = "oci://ghcr.io/democratizedspace/charts/dspace@sha256:" + "2" * 64
+    mutation_line = next(
+        line
+        for line in Path(generic_app_stub_env["HELM_LOG"])
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line.startswith("upgrade ")
+    )
+    assert coordinate in mutation_line
+    assert "--version" not in mutation_line
 
 
 @pytest.mark.usefixtures("ensure_just_available")
@@ -2841,6 +2884,31 @@ def test_direct_helm_oci_helper_matching_env_succeeds(
     helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
     assert "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.3" in helm_log
     assert "upgrade tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace" in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_direct_helm_oci_helper_uses_digest_coordinate_without_version(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    coordinate = "oci://ghcr.io/futuroptimist/charts/tokenplace@sha256:" + "a" * 64
+    result = _run_just(
+        [
+            "helm-oci-install",
+            "release=tokenplace",
+            "namespace=tokenplace",
+            f"chart={coordinate}",
+            "version=0.1.3",
+            "env=staging",
+        ],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    lines = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8").splitlines()
+    assert f"show chart {coordinate}" in lines
+    mutation = next(line for line in lines if line.startswith("upgrade "))
+    assert coordinate in mutation
+    assert "--version" not in mutation
 
 
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1082,12 +1082,6 @@ def test_app_deploy_danielsmith_passes_image_tag(generic_app_stub_env: dict[str,
             ],
         ),
         (
-            "dspace",
-            "oci://ghcr.io/democratizedspace/charts/dspace",
-            "dspace",
-            ["docs/examples/dspace.values.dev.yaml", "docs/examples/dspace.values.staging.yaml"],
-        ),
-        (
             "jobbot3000",
             "oci://ghcr.io/futuroptimist/charts/jobbot3000",
             "jobbot3000",
@@ -1200,12 +1194,6 @@ def test_app_redeploy_prints_chart_pin_reminder_without_latest_lookup_or_pin_mut
     ("app", "release", "namespace", "chart"),
     [
         (
-            "dspace",
-            "dspace",
-            "dspace",
-            "oci://ghcr.io/democratizedspace/charts/dspace",
-        ),
-        (
             "tokenplace",
             "tokenplace",
             "tokenplace",
@@ -1292,13 +1280,9 @@ def test_dspace_oci_deploy_wrapper_propagates_inline_chart_pin(
 
     result = _run_just(["dspace-oci-deploy", "env=staging", "tag=main-deadbee"], env)
 
-    assert result.returncode == 0, result.stderr + result.stdout
-    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
-    assert (
-        "show chart oci://ghcr.io/democratizedspace/charts/dspace "
-        "--version 3.1.0-rc.1+build.5"
-    ) in helm_log
-    assert "--version ${SUGARKUBE_VERSION_FILE}" not in helm_log
+    assert result.returncode != 0
+    assert "manifest=<approved-candidate.json> is required" in result.stderr
+    assert not Path(env["HELM_LOG"]).exists()
 
 
 @pytest.mark.usefixtures("ensure_just_available")
@@ -1307,7 +1291,6 @@ def test_dspace_oci_deploy_wrapper_propagates_inline_chart_pin(
     [
         ("danielsmith-oci-deploy", "danielsmith"),
         ("tokenplace-oci-deploy", "tokenplace"),
-        ("dspace-oci-deploy", "dspace"),
     ],
 )
 def test_existing_app_specific_deploy_wrappers_still_work(
@@ -1330,11 +1313,6 @@ def test_existing_app_specific_deploy_wrappers_still_work(
 @pytest.mark.parametrize(
     ("recipe", "image_heading", "check_heading"),
     [
-        (
-            "dspace-oci-promote-prod",
-            "Resolved deployment image(s):",
-            "Post-deploy verification commands",
-        ),
         (
             "tokenplace-oci-promote-prod",
             "Resolved images for deployment/tokenplace:",
@@ -2632,12 +2610,9 @@ def test_dspace_oci_deploy_wrapper_propagates_env_specific_chart_pin(
 
     result = _run_just(["dspace-oci-deploy", "env=staging", "tag=main-deadbee"], env)
 
-    assert result.returncode == 0, result.stderr + result.stdout
-    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
-    assert (
-        "show chart oci://ghcr.io/democratizedspace/charts/dspace "
-        "--version 3.1.0-rc.1+build.5"
-    ) in helm_log
+    assert result.returncode != 0
+    assert "manifest=<approved-candidate.json> is required" in result.stderr
+    assert not Path(env["HELM_LOG"]).exists()
 
 
 def test_direct_helm_oci_helper_matching_env_succeeds(
@@ -2806,6 +2781,6 @@ def test_dspace_promote_prod_guard_mismatch_fails_before_helm(
     result = _run_just(["dspace-oci-promote-prod", "tag=main-deadbee"], env)
 
     assert result.returncode != 0
-    assert "requested env=prod" in result.stderr
+    assert "manifest=<approved-candidate.json> is required" in result.stderr
     helm_log_path = Path(env["HELM_LOG"])
     assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -13,6 +13,7 @@ import pytest
 
 from scripts import app_chart
 from scripts import app_verify
+from scripts import dspace_release_manifest as release_manifest
 from scripts.app_verify import base_url_from_host, tokenplace_meta_failure
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -1390,9 +1391,13 @@ def test_dspace_guarded_deploy_orders_preflight_mutation_and_finalization(
     final = json.loads(evidence.read_text(encoding="utf-8"))
     assert final["recordType"] == "final"
     assert final["helmRevision"] == 7
+    assert "reservation" not in json.dumps(final).lower()
+    assert not Path(str(evidence.resolve()) + ".reservation").exists()
     commands = (tmp_path / "commands.log").read_text(encoding="utf-8").splitlines()
     preflight = next(i for i, line in enumerate(commands) if line.startswith("oras "))
-    mutation = next(i for i, line in enumerate(commands) if line.startswith("helm upgrade "))
+    mutation = next(
+        i for i, line in enumerate(commands) if line.startswith("helm upgrade ")
+    )
     collection = next(i for i, line in enumerate(commands) if " status dspace" in line)
     pods = next(i for i, line in enumerate(commands) if " -n dspace get pods" in line)
     assert preflight < mutation < collection < pods
@@ -1427,6 +1432,37 @@ def test_dspace_digest_mismatch_stops_before_helm(
     assert expected_check in result.stderr
     helm_log = Path(env["HELM_LOG"])
     assert not helm_log.exists() or "upgrade " not in helm_log.read_text(encoding="utf-8")
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_reservation_collision_stops_before_helm(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    candidate_path = tmp_path / "candidate.json"
+    evidence = tmp_path / "evidence.json"
+    _write_dspace_candidate(candidate_path, "staging")
+    candidate_record = json.loads(candidate_path.read_text(encoding="utf-8"))
+    release_manifest.reserve(evidence, candidate_record, "staging", "dspace", "dspace")
+
+    result = _run_just(
+        [
+            "app-deploy",
+            "dspace",
+            "staging",
+            "main-abcdef0",
+            "",
+            str(candidate_path),
+            str(evidence),
+        ],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode != 0
+    assert "already reserved" in result.stderr
+    helm_log = Path(generic_app_stub_env["HELM_LOG"])
+    assert not helm_log.exists() or "upgrade " not in helm_log.read_text(
+        encoding="utf-8"
+    )
 
 
 @pytest.mark.usefixtures("ensure_just_available")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import subprocess
 import sys
@@ -64,6 +65,11 @@ fi
         f"""#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> {str(tmp_path / "kubectl.log")!r}
+printf 'kubectl %s\n' "$*" >> {str(tmp_path / "commands.log")!r}
+if [[ "$*" == *"get pods"* && "$*" == *"-o json"* ]]; then
+  printf '{{"items":[{{"metadata":{{"name":"dspace-0"}},"status":{{"startTime":"2026-07-26T12:10:00Z","containerStatuses":[{{"imageID":"ghcr.io/democratizedspace/dspace@sha256:%s"}}]}}}}]}}\n' "${{SUGARKUBE_STUB_IMAGE_DIGEST_HEX:-1111111111111111111111111111111111111111111111111111111111111111}}"
+  exit 0
+fi
 if [[ "$*" == *"get nodes -o json"* ]]; then
   env_label="${{SUGARKUBE_STUB_NODE_ENV:-staging}}"
   cluster_label="${{SUGARKUBE_STUB_CLUSTER:-sugar}}"
@@ -104,6 +110,11 @@ exit 0
         f"""#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> {str(log_path)!r}
+printf 'helm %s\n' "$*" >> {str(tmp_path / "commands.log")!r}
+if [[ "$*" == "status dspace --namespace dspace -o json" ]]; then
+  printf '{{"version":7}}\n'
+  exit 0
+fi
 if [[ "$*" == *"get values"* ]]; then
   if [ "${{SUGARKUBE_STUB_HELM_GET_VALUES_FAIL:-}}" = "1" ]; then
     echo 'Error: Kubernetes cluster unreachable for context sugar-staging' >&2
@@ -113,6 +124,11 @@ if [[ "$*" == *"get values"* ]]; then
   exit 0
 fi
 if [[ "$*" == show\ chart* ]]; then
+  if [[ "$*" == *"charts/dspace"* ]]; then
+    version="${{*: -1}}"
+    printf 'apiVersion: v2\nname: dspace\nversion: %s\nappVersion: main-abcdef0\n' "$version"
+    exit 0
+  fi
   printf 'apiVersion: v2\nname: tokenplace\nversion: 0.1.3\nappVersion: main-deadbee\ndigest: sha256:abc123\n'
   exit 0
 fi
@@ -271,6 +287,39 @@ fi
 printf '%s' "${{status}}"
 exit "${{curl_exit}}"
 """,
+    )
+    _write_executable(
+        bin_dir / "oras",
+        f'''#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+image = "sha256:" + os.environ.get("SUGARKUBE_STUB_RESOLVED_IMAGE", "1" * 64)
+chart = "sha256:" + os.environ.get("SUGARKUBE_STUB_RESOLVED_CHART", "2" * 64)
+platform = "sha256:" + "3" * 64
+image_config = "sha256:" + "4" * 64
+chart_config = "sha256:" + "5" * 64
+sha = "abcdef0123456789abcdef0123456789abcdef01"
+args = sys.argv[1:]
+with Path({str(tmp_path / "commands.log")!r}).open("a", encoding="utf-8") as log:
+    log.write("oras " + " ".join(args) + "\\n")
+ref = args[-1]
+if "--descriptor" in args:
+    value = {{"digest": chart if "charts/dspace" in ref else image}}
+elif args[:2] == ["manifest", "fetch"] and ref.endswith("@" + image):
+    value = {{"manifests": [{{"digest": platform}}]}}
+elif args[:2] == ["manifest", "fetch"] and ref.endswith("@" + platform):
+    value = {{"config": {{"digest": image_config}}}}
+elif args[:2] == ["manifest", "fetch"] and ref.endswith("@" + chart):
+    value = {{"config": {{"digest": chart_config}}}}
+elif args[:2] == ["blob", "fetch"]:
+    value = {{"config": {{"Labels": {{"org.opencontainers.image.revision": sha}}}}}}
+else:
+    raise SystemExit("unexpected oras command: " + " ".join(args))
+print(json.dumps(value))
+''',
     )
 
     env = os.environ.copy()
@@ -1283,6 +1332,122 @@ def test_dspace_oci_deploy_wrapper_propagates_inline_chart_pin(
     assert result.returncode != 0
     assert "manifest=<approved-candidate.json> is required" in result.stderr
     assert not Path(env["HELM_LOG"]).exists()
+
+
+def _write_dspace_candidate(path: Path, environment: str, *, image_digest: str | None = None) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "app": "dspace",
+                "applicationVersion": "3.2.0",
+                "sourceRevision": "abcdef0123456789abcdef0123456789abcdef01",
+                "imageTag": "main-abcdef0",
+                "imageDigest": image_digest or "sha256:" + "1" * 64,
+                "chartVersion": "3.1.0" if environment == "staging" else "3.0.1",
+                "chartDigest": "sha256:" + "2" * 64,
+                "semanticTag": "v3.2.0",
+                "recordType": "candidate",
+                "environment": environment,
+                "expectedDefaultChatProvider": "token-place",
+                "approvedAt": "2026-07-26T12:00:00Z",
+                "approvedBy": "synthetic-test-approver",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_guarded_deploy_orders_preflight_mutation_and_finalization(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    manifest = tmp_path / "candidate.json"
+    evidence = tmp_path / "evidence.json"
+    _write_dspace_candidate(manifest, "staging")
+
+    result = _run_just(
+        [
+            "app-deploy",
+            "dspace",
+            "staging",
+            "main-abcdef0",
+            "",
+            str(manifest),
+            str(evidence),
+        ],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    final = json.loads(evidence.read_text(encoding="utf-8"))
+    assert final["recordType"] == "final"
+    assert final["helmRevision"] == 7
+    commands = (tmp_path / "commands.log").read_text(encoding="utf-8").splitlines()
+    preflight = next(i for i, line in enumerate(commands) if line.startswith("oras "))
+    mutation = next(i for i, line in enumerate(commands) if line.startswith("helm upgrade "))
+    collection = next(i for i, line in enumerate(commands) if line.startswith("helm status dspace"))
+    pods = next(i for i, line in enumerate(commands) if "kubectl -n dspace get pods" in line)
+    assert preflight < mutation < collection < pods
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize(
+    ("env_override", "manifest_digest", "expected_check"),
+    [
+        ({"SUGARKUBE_STUB_RESOLVED_IMAGE": "9" * 64}, None, "imageDigest"),
+        ({"SUGARKUBE_STUB_RESOLVED_CHART": "9" * 64}, None, "chartDigest"),
+    ],
+)
+def test_dspace_digest_mismatch_stops_before_helm(
+    tmp_path: Path,
+    generic_app_stub_env: dict[str, str],
+    env_override: dict[str, str],
+    manifest_digest: str | None,
+    expected_check: str,
+) -> None:
+    manifest = tmp_path / "candidate.json"
+    _write_dspace_candidate(manifest, "staging", image_digest=manifest_digest)
+    env = generic_app_stub_env.copy()
+    env.update(env_override)
+
+    result = _run_just(
+        ["app-deploy", "dspace", "staging", "main-abcdef0", "", str(manifest)],
+        env,
+    )
+
+    assert result.returncode != 0
+    assert expected_check in result.stderr
+    helm_log = Path(env["HELM_LOG"])
+    assert not helm_log.exists() or "upgrade " not in helm_log.read_text(encoding="utf-8")
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_prod_subdomain_wrapper_preserves_canary_overlay_through_guarded_path(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    manifest = tmp_path / "candidate.json"
+    evidence = tmp_path / "evidence.json"
+    _write_dspace_candidate(manifest, "prod")
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
+
+    result = _run_just(
+        [
+            "dspace-oci-deploy-prod-subdomain",
+            "main-abcdef0",
+            str(manifest),
+            str(evidence),
+        ],
+        env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert "-f docs/examples/dspace.values.prod-subdomain.yaml" in helm_log
+    assert "-f docs/examples/dspace.values.prod.yaml" not in helm_log
+    assert evidence.exists()
 
 
 @pytest.mark.usefixtures("ensure_just_available")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -67,7 +67,11 @@ set -euo pipefail
 printf '%s\n' "$*" >> {str(tmp_path / "kubectl.log")!r}
 printf 'kubectl %s\n' "$*" >> {str(tmp_path / "commands.log")!r}
 if [[ "$*" == *"get pods"* && "$*" == *"-o json"* ]]; then
-  printf '{{"items":[{{"metadata":{{"name":"dspace-0"}},"status":{{"startTime":"2026-07-26T12:10:00Z","containerStatuses":[{{"imageID":"ghcr.io/democratizedspace/dspace@sha256:%s"}}]}}}}]}}\n' "${{SUGARKUBE_STUB_IMAGE_DIGEST_HEX:-1111111111111111111111111111111111111111111111111111111111111111}}"
+  printf '{{"items":[{{"metadata":{{"name":"dspace-0","labels":{{"app.kubernetes.io/name":"dspace","app.kubernetes.io/instance":"dspace"}},"ownerReferences":[{{"kind":"ReplicaSet","name":"dspace-rs","uid":"rs-uid","controller":true}}]}},"spec":{{"containers":[{{"name":"dspace","image":"ghcr.io/democratizedspace/dspace:main-abcdef0"}}]}},"status":{{"phase":"Running","startTime":"2026-07-26T12:10:00Z","conditions":[{{"type":"Ready","status":"True"}}],"containerStatuses":[{{"name":"dspace","imageID":"ghcr.io/democratizedspace/dspace@sha256:%s","state":{{"running":{{}}}}}}]}}}}]}}\n' "${{SUGARKUBE_STUB_IMAGE_DIGEST_HEX:-1111111111111111111111111111111111111111111111111111111111111111}}"
+  exit 0
+fi
+if [[ "$*" == *"get replicasets,deployments"* && "$*" == *"-o json"* ]]; then
+  printf '{{"items":[{{"kind":"ReplicaSet","metadata":{{"name":"dspace-rs","uid":"rs-uid","labels":{{"app.kubernetes.io/name":"dspace","app.kubernetes.io/instance":"dspace"}},"ownerReferences":[{{"kind":"Deployment","name":"dspace","uid":"deploy-uid","controller":true}}]}}}},{{"kind":"Deployment","metadata":{{"name":"dspace","uid":"deploy-uid","labels":{{"app.kubernetes.io/name":"dspace","app.kubernetes.io/instance":"dspace","app.kubernetes.io/managed-by":"Helm"}},"annotations":{{"meta.helm.sh/release-name":"dspace","meta.helm.sh/release-namespace":"dspace"}}}}}}]}}\n'
   exit 0
 fi
 if [[ "$*" == *"get nodes -o json"* ]]; then
@@ -111,8 +115,10 @@ exit 0
 set -euo pipefail
 printf '%s\n' "$*" >> {str(log_path)!r}
 printf 'helm %s\n' "$*" >> {str(tmp_path / "commands.log")!r}
-if [[ "$*" == "status dspace --namespace dspace -o json" ]]; then
-  printf '{{"version":7}}\n'
+if [[ "$*" == *"status dspace --namespace dspace -o json" ]]; then
+  chart_version=3.1.0
+  [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" != prod ] || chart_version=3.0.1
+  printf '{{"name":"dspace","namespace":"dspace","version":7,"info":{{"status":"deployed"}},"chart":{{"metadata":{{"name":"dspace","version":"%s"}}}}}}\n' "$chart_version"
   exit 0
 fi
 if [[ "$*" == *"get values"* ]]; then
@@ -1387,8 +1393,8 @@ def test_dspace_guarded_deploy_orders_preflight_mutation_and_finalization(
     commands = (tmp_path / "commands.log").read_text(encoding="utf-8").splitlines()
     preflight = next(i for i, line in enumerate(commands) if line.startswith("oras "))
     mutation = next(i for i, line in enumerate(commands) if line.startswith("helm upgrade "))
-    collection = next(i for i, line in enumerate(commands) if line.startswith("helm status dspace"))
-    pods = next(i for i, line in enumerate(commands) if "kubectl -n dspace get pods" in line)
+    collection = next(i for i, line in enumerate(commands) if " status dspace" in line)
+    pods = next(i for i, line in enumerate(commands) if " -n dspace get pods" in line)
     assert preflight < mutation < collection < pods
 
 

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -105,6 +105,30 @@ def test_rejects_invalid_upstream(change) -> None:
 
 
 @pytest.mark.parametrize(
+    "version",
+    ["3.2.0-01", "3.2.0-alpha.01", "03.2.0", "3.02.0", "3.2.00"],
+)
+def test_rejects_non_strict_semver(version: str) -> None:
+    value = upstream()
+    value["applicationVersion"] = version
+    value["semanticTag"] = f"v{version}"
+    with pytest.raises(manifest.ManifestError, match="strict SemVer"):
+        manifest.candidate(value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator")
+
+
+@pytest.mark.parametrize(
+    "version", ["3.2.0-alpha", "3.2.0-alpha.1", "3.2.0-0", "3.2.0-0A.01a+build.01"]
+)
+def test_accepts_strict_semver_prerelease_and_build(version: str) -> None:
+    value = upstream()
+    value["applicationVersion"] = version
+    value["semanticTag"] = f"v{version}"
+    assert manifest.candidate(
+        value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator"
+    )["applicationVersion"] == version
+
+
+@pytest.mark.parametrize(
     ("environment", "provider", "approver"),
     [
         ("dev", "token-place", "operator"),
@@ -322,6 +346,88 @@ def test_finalize_collects_sorted_multi_pod_identity() -> None:
         "podImageCoordinates",
         "podImageDigests",
     }
+
+
+def test_generated_final_record_validates_through_cli(tmp_path: Path) -> None:
+    output = tmp_path / "final.json"
+    output.write_text(manifest._canonical(finalize()), encoding="utf-8")
+    assert manifest.main(["validate", "--manifest", str(output), "--final"]) == 0
+
+
+def _replace_results(value, checks):
+    value["verificationResults"] = [
+        {"check": check, "passed": True, "details": "observed"} for check in checks
+    ]
+    return value
+
+
+def test_final_validation_rejects_arbitrary_only_result() -> None:
+    with pytest.raises(manifest.ManifestError, match="unknown verification"):
+        manifest.validate(_replace_results(finalize(), ["inventedCheck"]), True)
+
+
+@pytest.mark.parametrize("missing", sorted(manifest.FINAL_FIXED_CHECKS))
+def test_final_validation_requires_every_fixed_check(missing: str) -> None:
+    value = finalize()
+    value["verificationResults"] = [
+        result for result in value["verificationResults"] if result["check"] != missing
+    ]
+    with pytest.raises(manifest.ManifestError, match="missing verification"):
+        manifest.validate(value, True)
+
+
+@pytest.mark.parametrize("invalid", ["unknown", "imagePlatformSourceRevision[x]"])
+def test_final_validation_rejects_unknown_or_malformed_checks(invalid: str) -> None:
+    value = finalize()
+    value["verificationResults"].append(
+        {"check": invalid, "passed": True, "details": "fabricated"}
+    )
+    with pytest.raises(manifest.ManifestError, match="unknown verification"):
+        manifest.validate(value, True)
+
+
+def test_final_validation_rejects_duplicate_and_gapped_platform_checks() -> None:
+    value = finalize()
+    value["verificationResults"].append(dict(value["verificationResults"][0]))
+    with pytest.raises(manifest.ManifestError, match="duplicate verification"):
+        manifest.validate(value, True)
+
+    value = finalize()
+    platform = next(
+        result
+        for result in value["verificationResults"]
+        if result["check"].startswith("imagePlatformSourceRevision")
+    )
+    platform["check"] = "imagePlatformSourceRevision[1]"
+    with pytest.raises(manifest.ManifestError, match="contiguous from zero"):
+        manifest.validate(value, True)
+
+
+def test_final_validation_requires_platform_check() -> None:
+    value = finalize()
+    value["verificationResults"] = [
+        result
+        for result in value["verificationResults"]
+        if not result["check"].startswith("imagePlatformSourceRevision")
+    ]
+    with pytest.raises(manifest.ManifestError, match="at least one image platform"):
+        manifest.validate(value, True)
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        lambda result: result.update(passed=False),
+        lambda result: result.update(details=""),
+        lambda result: result.update(check=1),
+        lambda result: result.update(extra="field"),
+    ],
+)
+def test_final_validation_rejects_non_passing_or_malformed_results(change) -> None:
+    value = finalize()
+    change(value["verificationResults"][0])
+    with pytest.raises(manifest.ManifestError):
+        manifest.validate(value, True)
 
 
 def test_finalize_rejects_pod_image_mismatch() -> None:

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -658,7 +658,10 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
         )
         return oci_results
 
+    pod_reads = 0
+
     def run(command):
+        nonlocal pod_reads
         if "cluster_identity.py" in " ".join(command):
             events.append("cluster-identity")
             return "staging\n"
@@ -675,6 +678,11 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
         resource = command[command.index("get") + 1]
         if resource == "pods":
             events.append("pod-discovery")
+            pod_reads += 1
+            if pod_reads == 1:
+                old = pod("dspace-old")
+                old["metadata"]["deletionTimestamp"] = "2026-07-26T12:02:00Z"
+                return json.dumps({"items": [pod("dspace-b"), old]})
             return json.dumps({"items": [pod("dspace-b"), pod("dspace-a")]})
         assert resource == "replicasets,deployments"
         events.append("workload-discovery")
@@ -691,6 +699,7 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
     monkeypatch.setattr(manifest, "preflight", preflight)
     monkeypatch.setattr(manifest, "_run", run)
     monkeypatch.setattr(manifest, "_write_new", atomic_write)
+    monkeypatch.setattr(manifest.time, "sleep", lambda seconds: None)
 
     assert (
         manifest.main(
@@ -723,6 +732,8 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
         "cluster-identity",
         "helm-status",
         "pod-discovery",
+        "pod-discovery",
+        "helm-status",
         "workload-discovery",
         "helm-status",
         "atomic-final-write",
@@ -731,6 +742,50 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
     assert final["helmRevision"] == 17
     assert [item["name"] for item in final["pods"]] == ["dspace-a", "dspace-b"]
     assert not sidecar.exists()
+
+
+@pytest.mark.parametrize("failure", ["timeout", "command"])
+def test_finalize_cli_settling_failure_preserves_reservation(
+    tmp_path: Path, monkeypatch, failure: str
+) -> None:
+    source = tmp_path / "candidate.json"
+    output = tmp_path / "evidence.json"
+    source.write_text(manifest._canonical(candidate()), encoding="utf-8")
+    owner = manifest.reserve(output, candidate(), "staging", "dspace", "dspace")
+    old = pod("dspace-old")
+    old["metadata"]["deletionTimestamp"] = "2026-07-26T12:02:00Z"
+    clock = iter([0.0, 0.0, 61.0])
+
+    monkeypatch.setattr(manifest, "preflight", lambda *args, **kwargs: [])
+    monkeypatch.setattr(manifest.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(manifest.time, "sleep", lambda seconds: None)
+
+    def run(command):
+        if "cluster_identity.py" in " ".join(command):
+            return "staging\n"
+        if command[0] == "helm":
+            return json.dumps(
+                helm_status(
+                    info={
+                        "status": "deployed",
+                        "description": f"sugarkube-release-manifest:{owner}",
+                    }
+                )
+            )
+        if failure == "command":
+            raise manifest.ManifestError("pod discovery failed")
+        return json.dumps({"items": [old]})
+
+    monkeypatch.setattr(manifest, "_run", run)
+    args = [
+        "finalize", "--manifest", str(source), "--output", str(output),
+        "--environment", "staging", "--image-tag", "main-abcdef0",
+        "--chart-version", "3.2.0", "--kubeconfig", "kubeconfig",
+        "--release", "dspace", "--namespace", "dspace", "--reservation", owner,
+    ]
+    assert manifest.main(args) == 2
+    assert not output.exists()
+    assert manifest.reservation_path(output).exists()
 
 
 @pytest.mark.parametrize("changed_field", ["version", "description"])

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -719,10 +719,18 @@ def test_public_read_only_and_reservation_dispatch(
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
     source.write_text(manifest._canonical(candidate()), encoding="utf-8")
-    oci_results = manifest.preflight(
-        candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras", runner=oras_runner()
+    real_preflight = manifest.preflight
+    preflight_calls = []
+
+    def checked_preflight(*args, **kwargs):
+        preflight_calls.append(args)
+        return real_preflight(*args, **kwargs, runner=oras_runner())
+
+    oci_results = checked_preflight(
+        candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras"
     )
-    monkeypatch.setattr(manifest, "preflight", lambda *args, **kwargs: oci_results)
+    preflight_calls.clear()
+    monkeypatch.setattr(manifest, "preflight", checked_preflight)
 
     assert (
         manifest.main(
@@ -741,6 +749,26 @@ def test_public_read_only_and_reservation_dispatch(
         == 0
     )
     assert json.loads(capsys.readouterr().out) == oci_results
+
+    assert (
+        manifest.main(
+            [
+                "preflight",
+                "--manifest",
+                str(source),
+                "--environment",
+                "staging",
+                "--image-tag",
+                "main-abcdef0",
+                "--chart-version",
+                "3.2.0",
+                "--print-chart-coordinate",
+            ]
+        )
+        == 0
+    )
+    assert capsys.readouterr().out == f"oci://{manifest.CHART_REF}@{CHART_DIGEST}\n"
+    assert len(preflight_calls) == 2
 
     assert manifest.main(["evidence-path", "--manifest", str(source)]) == 0
     assert capsys.readouterr().out.strip() == str(manifest.evidence_path(candidate()))
@@ -768,6 +796,32 @@ def test_public_read_only_and_reservation_dispatch(
     assert manifest.verify_reservation(
         output, candidate(), "staging", "dspace", "dspace", owner
     ) == manifest.reservation_path(output)
+
+
+def test_preflight_chart_coordinate_is_not_printed_after_failed_validation(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    source = tmp_path / "candidate.json"
+    invalid = candidate()
+    invalid["chartDigest"] = "sha256:" + "9" * 64
+    source.write_text(manifest._canonical(invalid), encoding="utf-8")
+    real_preflight = manifest.preflight
+    monkeypatch.setattr(
+        manifest,
+        "preflight",
+        lambda *args, **kwargs: real_preflight(
+            *args, **kwargs, runner=oras_runner()
+        ),
+    )
+    assert (
+        manifest.main(
+            ["preflight", "--manifest", str(source), "--print-chart-coordinate"]
+        )
+        == 2
+    )
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "chartDigest" in captured.err
 
 
 def test_default_evidence_path_is_stable_and_approval_unique() -> None:

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -621,6 +621,155 @@ def test_post_reservation_failure_preserves_ownership(
     assert manifest.reservation_path(output).exists()
 
 
+def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source = tmp_path / "candidate.json"
+    output = tmp_path / "evidence.json"
+    source.write_text(manifest._canonical(candidate()), encoding="utf-8")
+    owner = manifest.reserve(output, candidate(), "staging", "dspace", "dspace")
+    sidecar = manifest.reservation_path(output)
+    oci_results = manifest.preflight(
+        candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras", runner=oras_runner()
+    )
+    events = []
+
+    def preflight(*args, **kwargs):
+        events.append("oci-preflight")
+        assert args[1:] == (
+            manifest.IMAGE_REF,
+            manifest.CHART_REF,
+            "oras",
+            "staging",
+            "main-abcdef0",
+            "3.2.0",
+        )
+        return oci_results
+
+    def run(command):
+        if "cluster_identity.py" in " ".join(command):
+            events.append("cluster-identity")
+            return "staging\n"
+        if command[0] == "helm":
+            events.append("helm-status")
+            return json.dumps(helm_status())
+        resource = command[command.index("get") + 1]
+        if resource == "pods":
+            events.append("pod-discovery")
+            return json.dumps({"items": [pod("dspace-b"), pod("dspace-a")]})
+        assert resource == "replicasets,deployments"
+        events.append("workload-discovery")
+        return json.dumps(workloads())
+
+    write_new = manifest._write_new
+
+    def atomic_write(path, value):
+        events.append("atomic-final-write")
+        assert sidecar.exists()
+        write_new(path, value)
+        assert sidecar.exists()
+
+    monkeypatch.setattr(manifest, "preflight", preflight)
+    monkeypatch.setattr(manifest, "_run", run)
+    monkeypatch.setattr(manifest, "_write_new", atomic_write)
+
+    assert (
+        manifest.main(
+            [
+                "finalize",
+                "--manifest",
+                str(source),
+                "--output",
+                str(output),
+                "--environment",
+                "staging",
+                "--image-tag",
+                "main-abcdef0",
+                "--chart-version",
+                "3.2.0",
+                "--kubeconfig",
+                "kubeconfig",
+                "--release",
+                "dspace",
+                "--namespace",
+                "dspace",
+                "--reservation",
+                owner,
+            ]
+        )
+        == 0
+    )
+    assert events == [
+        "oci-preflight",
+        "cluster-identity",
+        "helm-status",
+        "pod-discovery",
+        "workload-discovery",
+        "atomic-final-write",
+    ]
+    final = manifest.validate(json.loads(output.read_text(encoding="utf-8")), True)
+    assert final["helmRevision"] == 17
+    assert [item["name"] for item in final["pods"]] == ["dspace-a", "dspace-b"]
+    assert not sidecar.exists()
+
+
+def test_public_read_only_and_reservation_dispatch(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    source = tmp_path / "candidate.json"
+    output = tmp_path / "evidence.json"
+    source.write_text(manifest._canonical(candidate()), encoding="utf-8")
+    oci_results = manifest.preflight(
+        candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras", runner=oras_runner()
+    )
+    monkeypatch.setattr(manifest, "preflight", lambda *args, **kwargs: oci_results)
+
+    assert (
+        manifest.main(
+            [
+                "preflight",
+                "--manifest",
+                str(source),
+                "--environment",
+                "staging",
+                "--image-tag",
+                "main-abcdef0",
+                "--chart-version",
+                "3.2.0",
+            ]
+        )
+        == 0
+    )
+    assert json.loads(capsys.readouterr().out) == oci_results
+
+    assert manifest.main(["evidence-path", "--manifest", str(source)]) == 0
+    assert capsys.readouterr().out.strip() == str(manifest.evidence_path(candidate()))
+
+    assert (
+        manifest.main(
+            [
+                "reserve",
+                "--manifest",
+                str(source),
+                "--output",
+                str(output),
+                "--environment",
+                "staging",
+                "--release",
+                "dspace",
+                "--namespace",
+                "dspace",
+            ]
+        )
+        == 0
+    )
+    owner = capsys.readouterr().out.strip()
+    assert owner
+    assert manifest.verify_reservation(
+        output, candidate(), "staging", "dspace", "dspace", owner
+    ) == manifest.reservation_path(output)
+
+
 def test_default_evidence_path_is_stable_and_approval_unique() -> None:
     assert str(manifest.evidence_path(candidate())) == (
         "deployment-evidence/dspace/staging/main-abcdef0-20260726T120000Z.json"

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -30,7 +30,11 @@ def upstream() -> dict[str, object]:
 
 def candidate() -> dict[str, object]:
     return manifest.candidate(
-        upstream(), "staging", "token-place", "2026-07-26T12:00:00Z", "synthetic-test-approver"
+        upstream(),
+        "staging",
+        "token-place",
+        "2026-07-26T12:00:00Z",
+        "synthetic-test-approver",
     )
 
 
@@ -83,7 +87,9 @@ def test_rejects_invalid_upstream(change) -> None:
     value = upstream()
     change(value)
     with pytest.raises(manifest.ManifestError):
-        manifest.candidate(value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator")
+        manifest.candidate(
+            value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator"
+        )
 
 
 @pytest.mark.parametrize(
@@ -95,9 +101,13 @@ def test_rejects_invalid_upstream(change) -> None:
         ("prod", "openai", ""),
     ],
 )
-def test_rejects_wrong_enrichment(environment: str, provider: str, approver: str) -> None:
+def test_rejects_wrong_enrichment(
+    environment: str, provider: str, approver: str
+) -> None:
     with pytest.raises(manifest.ManifestError):
-        manifest.candidate(upstream(), environment, provider, "2026-07-26T12:00:00Z", approver)
+        manifest.candidate(
+            upstream(), environment, provider, "2026-07-26T12:00:00Z", approver
+        )
 
 
 def test_preflight_checks_digests_and_both_revision_metadata(monkeypatch) -> None:
@@ -132,14 +142,19 @@ def pod(name: str, digest: str = DIGEST) -> dict[str, object]:
         "metadata": {"name": name},
         "status": {
             "startTime": "2026-07-26T12:01:00Z",
-            "containerStatuses": [{"imageID": "ghcr.io/democratizedspace/dspace@" + digest}],
+            "containerStatuses": [
+                {"imageID": "ghcr.io/democratizedspace/dspace@" + digest}
+            ],
         },
     }
 
 
 def test_finalize_collects_sorted_multi_pod_identity() -> None:
     final = manifest.finalize(
-        candidate(), {"version": 17}, {"items": [pod("dspace-b"), pod("dspace-a")]}
+        candidate(),
+        {"version": 17},
+        {"items": [pod("dspace-b"), pod("dspace-a")]},
+        [{"check": "imageDigest", "passed": True, "details": "fresh OCI result"}],
     )
     assert final["helmRevision"] == 17
     assert [item["name"] for item in final["pods"]] == ["dspace-a", "dspace-b"]
@@ -150,11 +165,16 @@ def test_finalize_collects_sorted_multi_pod_identity() -> None:
 def test_finalize_rejects_pod_image_mismatch() -> None:
     with pytest.raises(manifest.ManifestError, match="does not match"):
         manifest.finalize(
-            candidate(), {"version": 1}, {"items": [pod("dspace-a", "sha256:" + "9" * 64)]}
+            candidate(),
+            {"version": 1},
+            {"items": [pod("dspace-a", "sha256:" + "9" * 64)]},
+            [{"check": "imageDigest", "passed": True, "details": "fresh OCI result"}],
         )
 
 
-def test_atomic_write_refuses_overwrite_and_leaves_no_temporary_file(tmp_path: Path) -> None:
+def test_atomic_write_refuses_overwrite_and_leaves_no_temporary_file(
+    tmp_path: Path,
+) -> None:
     output = tmp_path / "record.json"
     manifest._write_new(output, candidate())
     original = output.read_bytes()
@@ -168,3 +188,17 @@ def test_record_excludes_tokens_and_secrets() -> None:
     encoded = json.dumps(candidate()).lower()
     assert "token" not in encoded.replace("token-place", "")
     assert "secret" not in encoded and "credential" not in encoded
+
+
+def test_finalize_requires_preflight_results() -> None:
+    with pytest.raises(manifest.ManifestError, match="fresh OCI preflight"):
+        manifest.finalize(candidate(), {"version": 1}, {"items": [pod("dspace-a")]}, [])
+
+
+def test_check_output_rejects_collision_before_deployment(
+    tmp_path: Path, capsys
+) -> None:
+    output = tmp_path / "existing.json"
+    output.write_text("already recorded", encoding="utf-8")
+    assert manifest.main(["check-output", "--output", str(output)]) == 2
+    assert "refusing to overwrite" in capsys.readouterr().err

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -206,39 +206,176 @@ def test_preflight_rejects_noncanonical_deployed_chart() -> None:
 
 def pod(name: str, digest: str = DIGEST) -> dict[str, object]:
     return {
-        "metadata": {"name": name},
+        "metadata": {
+            "name": name,
+            "uid": f"{name}-uid",
+            "labels": {
+                "app.kubernetes.io/name": "dspace",
+                "app.kubernetes.io/instance": "dspace",
+            },
+            "ownerReferences": [
+                {"kind": "ReplicaSet", "name": "dspace-rs", "uid": "rs-uid", "controller": True}
+            ],
+        },
+        "spec": {"containers": [{"name": "dspace", "image": f"{manifest.IMAGE_REF}:main-abcdef0"}]},
         "status": {
+            "phase": "Running",
             "startTime": "2026-07-26T12:01:00Z",
-            "containerStatuses": [{"imageID": "ghcr.io/democratizedspace/dspace@" + digest}],
+            "conditions": [{"type": "Ready", "status": "True"}],
+            "containerStatuses": [
+                {
+                    "name": "dspace",
+                    "imageID": "ghcr.io/democratizedspace/dspace@" + digest,
+                    "state": {"running": {"startedAt": "2026-07-26T12:01:00Z"}},
+                }
+            ],
         },
     }
 
 
-def test_finalize_collects_sorted_multi_pod_identity() -> None:
-    final = manifest.finalize(
-        candidate(),
-        {"version": 17},
-        {"items": [pod("dspace-b"), pod("dspace-a")]},
-        manifest.preflight(
+def helm_status(**changes) -> dict[str, object]:
+    value = {
+        "name": "dspace",
+        "namespace": "dspace",
+        "version": 17,
+        "info": {"status": "deployed"},
+        "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}},
+    }
+    value.update(changes)
+    return value
+
+
+def workloads() -> dict[str, object]:
+    labels = {
+        "app.kubernetes.io/name": "dspace",
+        "app.kubernetes.io/instance": "dspace",
+    }
+    helm_labels = {**labels, "app.kubernetes.io/managed-by": "Helm"}
+    return {
+        "items": [
+            {
+                "kind": "ReplicaSet",
+                "metadata": {
+                    "name": "dspace-rs",
+                    "uid": "rs-uid",
+                    "labels": labels,
+                    "ownerReferences": [
+                        {
+                            "kind": "Deployment",
+                            "name": "dspace",
+                            "uid": "deploy-uid",
+                            "controller": True,
+                        }
+                    ],
+                },
+            },
+            {
+                "kind": "Deployment",
+                "metadata": {
+                    "name": "dspace",
+                    "uid": "deploy-uid",
+                    "labels": helm_labels,
+                    "annotations": {
+                        "meta.helm.sh/release-name": "dspace",
+                        "meta.helm.sh/release-namespace": "dspace",
+                    },
+                },
+            },
+        ]
+    }
+
+
+def finalize(**changes):
+    arguments = {
+        "value": candidate(),
+        "helm_json": helm_status(),
+        "pods_json": {"items": [pod("dspace-b"), pod("dspace-a")]},
+        "workloads_json": workloads(),
+        "preflight_results": manifest.preflight(
             candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras", runner=oras_runner()
         ),
-    )
+        "environment": "staging",
+        "image_tag": "main-abcdef0",
+        "chart_version": "3.2.0",
+        "release": "dspace",
+        "namespace": "dspace",
+        "cluster_environment": "staging",
+    }
+    arguments.update(changes)
+    return manifest.finalize(**arguments)
+
+
+def test_finalize_collects_sorted_multi_pod_identity() -> None:
+    final = finalize()
     assert final["helmRevision"] == 17
     assert [item["name"] for item in final["pods"]] == ["dspace-a", "dspace-b"]
     assert final["runtimeSourceRevision"] == SHA
     assert final["runtimeSourceRevisionMethod"] == "podImageID+ociRevisionAnnotation"
+    assert {item["check"] for item in final["verificationResults"]} >= {
+        "selectedCoordinates",
+        "clusterEnvironment",
+        "helmRelease",
+        "installedChart",
+        "releaseOwnershipAndReadiness",
+        "podImageCoordinates",
+        "podImageDigests",
+    }
 
 
 def test_finalize_rejects_pod_image_mismatch() -> None:
     with pytest.raises(manifest.ManifestError, match="does not match"):
-        manifest.finalize(
-            candidate(),
-            {"version": 1},
-            {"items": [pod("dspace-a", "sha256:" + "9" * 64)]},
-            manifest.preflight(
-                candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras", runner=oras_runner()
-            ),
-        )
+        finalize(pods_json={"items": [pod("dspace-a", "sha256:" + "9" * 64)]})
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"environment": "prod"}, "selected environment"),
+        ({"image_tag": "main-deadbee"}, "selected imageTag"),
+        ({"chart_version": "3.2.1"}, "selected chartVersion"),
+        ({"cluster_environment": "prod"}, "cluster environment"),
+        ({"helm_json": helm_status(name="other")}, "release and namespace"),
+        ({"helm_json": helm_status(info={"status": "failed"})}, "must be deployed"),
+        (
+            {"helm_json": helm_status(chart={"metadata": {"name": "other", "version": "3.2.0"}})},
+            "chart identity",
+        ),
+        ({"helm_json": helm_status(chart={})}, "chart identity"),
+    ],
+)
+def test_finalize_rejects_unbound_coordinates_and_helm_state(changes, message) -> None:
+    with pytest.raises(manifest.ManifestError, match=message):
+        finalize(**changes)
+
+
+@pytest.mark.parametrize(
+    "failure", ["wrong-instance", "owner", "terminating", "phase", "ready", "image", "container"]
+)
+def test_finalize_rejects_unowned_or_non_serving_pods(failure: str) -> None:
+    item = pod("dspace-a")
+    if failure == "wrong-instance":
+        item["metadata"]["labels"]["app.kubernetes.io/instance"] = "other"
+    elif failure == "owner":
+        item["metadata"]["ownerReferences"][0]["uid"] = "wrong"
+    elif failure == "terminating":
+        item["metadata"]["deletionTimestamp"] = "2026-07-26T12:02:00Z"
+    elif failure == "phase":
+        item["status"]["phase"] = "Pending"
+    elif failure == "ready":
+        item["status"]["conditions"][0]["status"] = "False"
+    elif failure == "image":
+        item["spec"]["containers"][0]["image"] = f"{manifest.IMAGE_REF}:main-deadbee"
+    else:
+        item["status"]["containerStatuses"][0]["state"] = {"waiting": {}}
+    with pytest.raises(manifest.ManifestError):
+        finalize(pods_json={"items": [item]})
+
+
+def test_finalize_rejects_workload_not_owned_by_helm() -> None:
+    discovered = workloads()
+    discovered["items"][1]["metadata"]["annotations"]["meta.helm.sh/release-name"] = "other"
+    with pytest.raises(manifest.ManifestError, match="not owned"):
+        finalize(workloads_json=discovered)
 
 
 def test_atomic_write_refuses_overwrite_and_leaves_no_temporary_file(
@@ -261,7 +398,7 @@ def test_record_excludes_tokens_and_secrets() -> None:
 
 def test_finalize_requires_preflight_results() -> None:
     with pytest.raises(manifest.ManifestError, match="fresh OCI preflight"):
-        manifest.finalize(candidate(), {"version": 1}, {"items": [pod("dspace-a")]}, [])
+        finalize(preflight_results=[])
 
 
 def test_check_output_rejects_collision_before_deployment(tmp_path: Path, capsys) -> None:

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -406,6 +408,111 @@ def test_check_output_rejects_collision_before_deployment(tmp_path: Path, capsys
     output.write_text("already recorded", encoding="utf-8")
     assert manifest.main(["check-output", "--output", str(output)]) == 2
     assert "refusing to overwrite" in capsys.readouterr().err
+
+
+def test_reservation_is_atomic_and_bound_to_owner(tmp_path: Path) -> None:
+    output = tmp_path / "evidence.json"
+    barrier = threading.Barrier(2)
+
+    def acquire() -> tuple[str, str]:
+        barrier.wait()
+        try:
+            return (
+                "owner",
+                manifest.reserve(output, candidate(), "staging", "dspace", "dspace"),
+            )
+        except manifest.ManifestError as exc:
+            return ("loser", str(exc))
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda _: acquire(), range(2)))
+
+    owners = [value for status, value in results if status == "owner"]
+    assert len(owners) == 1
+    assert [status for status, _ in results].count("loser") == 1
+    sidecar = manifest.verify_reservation(
+        output, candidate(), "staging", "dspace", "dspace", owners[0]
+    )
+    metadata = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert metadata["output"] == str(output.resolve())
+    assert metadata["candidateFingerprint"] == manifest._candidate_fingerprint(
+        candidate()
+    )
+
+
+def test_reservation_rejects_existing_record_or_reservation(tmp_path: Path) -> None:
+    output = tmp_path / "evidence.json"
+    owner = manifest.reserve(output, candidate(), "staging", "dspace", "dspace")
+    with pytest.raises(manifest.ManifestError, match="already reserved"):
+        manifest.reserve(output, candidate(), "staging", "dspace", "dspace")
+    with pytest.raises(manifest.ManifestError, match="ownership"):
+        manifest.verify_reservation(
+            output, candidate(), "staging", "dspace", "dspace", owner + "wrong"
+        )
+    manifest.reservation_path(output).unlink()
+    output.write_text("final", encoding="utf-8")
+    with pytest.raises(manifest.ManifestError, match="overwrite"):
+        manifest.reserve(output, candidate(), "staging", "dspace", "dspace")
+
+
+def test_reservation_binds_candidate_output_and_coordinates(tmp_path: Path) -> None:
+    output = tmp_path / "evidence.json"
+    owner = manifest.reserve(output, candidate(), "staging", "dspace", "dspace")
+    changed = candidate()
+    changed["approvedBy"] = "another-approver"
+    for selected_output, selected, release in (
+        (tmp_path / "other.json", candidate(), "dspace"),
+        (output, changed, "dspace"),
+        (output, candidate(), "other"),
+    ):
+        with pytest.raises(manifest.ManifestError):
+            manifest.verify_reservation(
+                selected_output, selected, "staging", release, "dspace", owner
+            )
+
+
+def test_post_reservation_failure_preserves_ownership(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source = tmp_path / "candidate.json"
+    output = tmp_path / "evidence.json"
+    source.write_text(manifest._canonical(candidate()), encoding="utf-8")
+    owner = manifest.reserve(output, candidate(), "staging", "dspace", "dspace")
+    monkeypatch.setattr(
+        manifest,
+        "preflight",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            manifest.ManifestError("OCI failed")
+        ),
+    )
+    assert (
+        manifest.main(
+            [
+                "finalize",
+                "--manifest",
+                str(source),
+                "--output",
+                str(output),
+                "--environment",
+                "staging",
+                "--image-tag",
+                "main-abcdef0",
+                "--chart-version",
+                "3.2.0",
+                "--kubeconfig",
+                "kubeconfig",
+                "--release",
+                "dspace",
+                "--namespace",
+                "dspace",
+                "--reservation",
+                owner,
+            ]
+        )
+        == 2
+    )
+    assert not output.exists()
+    assert manifest.reservation_path(output).exists()
 
 
 def test_default_evidence_path_is_stable_and_approval_unique() -> None:

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -1,0 +1,170 @@
+"""Focused tests for fail-closed DSPACE release evidence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import dspace_release_manifest as manifest
+
+SHA = "abcdef0123456789abcdef0123456789abcdef01"
+DIGEST = "sha256:" + "1" * 64
+CHART_DIGEST = "sha256:" + "2" * 64
+
+
+def upstream() -> dict[str, object]:
+    return {
+        "schemaVersion": 1,
+        "app": "dspace",
+        "applicationVersion": "3.2.0",
+        "sourceRevision": SHA,
+        "imageTag": "main-abcdef0",
+        "imageDigest": DIGEST,
+        "chartVersion": "3.2.0",
+        "chartDigest": CHART_DIGEST,
+        "semanticTag": "v3.2.0",
+    }
+
+
+def candidate() -> dict[str, object]:
+    return manifest.candidate(
+        upstream(), "staging", "token-place", "2026-07-26T12:00:00Z", "synthetic-test-approver"
+    )
+
+
+def test_upstream_import_is_canonical_and_round_trips(tmp_path: Path) -> None:
+    source = tmp_path / "upstream.json"
+    output = tmp_path / "candidate.json"
+    source.write_text(json.dumps(upstream()), encoding="utf-8")
+    assert (
+        manifest.main(
+            [
+                "candidate",
+                "--upstream",
+                str(source),
+                "--output",
+                str(output),
+                "--environment",
+                "staging",
+                "--provider",
+                "token-place",
+                "--approved-at",
+                "2026-07-26T12:00:00Z",
+                "--approved-by",
+                "operator",
+            ]
+        )
+        == 0
+    )
+    loaded = json.loads(output.read_text())
+    assert manifest.validate(loaded) == loaded
+    assert output.read_text().endswith("\n")
+    assert list(loaded) == list(manifest.CANDIDATE_FIELDS)
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        lambda x: x.pop("chartDigest"),
+        lambda x: x.update(extra="no"),
+        lambda x: x.update(sourceRevision="abc1234"),
+        lambda x: x.update(sourceRevision=SHA.upper()),
+        lambda x: x.update(imageTag="latest"),
+        lambda x: x.update(imageTag="v3.2.0"),
+        lambda x: x.update(imageTag="main-deadbee"),
+        lambda x: x.update(imageDigest="sha256:abc"),
+        lambda x: x.update(chartDigest="2" * 64),
+        lambda x: x.update(chartVersion="v3.2.0"),
+    ],
+)
+def test_rejects_invalid_upstream(change) -> None:
+    value = upstream()
+    change(value)
+    with pytest.raises(manifest.ManifestError):
+        manifest.candidate(value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator")
+
+
+@pytest.mark.parametrize(
+    ("environment", "provider", "approver"),
+    [
+        ("dev", "token-place", "operator"),
+        ("staging", "tokenplace", "operator"),
+        ("prod", "open-ai", "operator"),
+        ("prod", "openai", ""),
+    ],
+)
+def test_rejects_wrong_enrichment(environment: str, provider: str, approver: str) -> None:
+    with pytest.raises(manifest.ManifestError):
+        manifest.candidate(upstream(), environment, provider, "2026-07-26T12:00:00Z", approver)
+
+
+def test_preflight_checks_digests_and_both_revision_metadata(monkeypatch) -> None:
+    responses = iter([(DIGEST, SHA), (CHART_DIGEST, SHA)])
+    monkeypatch.setattr(manifest, "_oras_evidence", lambda *_: next(responses))
+    results = manifest.preflight(candidate(), "image", "chart", "oras-stub")
+    assert [item["check"] for item in results] == [
+        "imageDigest",
+        "chartDigest",
+        "imageSourceRevision",
+        "chartSourceRevision",
+    ]
+
+
+@pytest.mark.parametrize(
+    "responses",
+    [
+        [("sha256:" + "9" * 64, SHA), (CHART_DIGEST, SHA)],
+        [(DIGEST, SHA), ("sha256:" + "9" * 64, SHA)],
+        [(DIGEST, "0" * 40), (CHART_DIGEST, SHA)],
+    ],
+)
+def test_preflight_mismatch_fails(monkeypatch, responses) -> None:
+    values = iter(responses)
+    monkeypatch.setattr(manifest, "_oras_evidence", lambda *_: next(values))
+    with pytest.raises(manifest.ManifestError, match="mismatch"):
+        manifest.preflight(candidate(), "image", "chart", "oras")
+
+
+def pod(name: str, digest: str = DIGEST) -> dict[str, object]:
+    return {
+        "metadata": {"name": name},
+        "status": {
+            "startTime": "2026-07-26T12:01:00Z",
+            "containerStatuses": [{"imageID": "ghcr.io/democratizedspace/dspace@" + digest}],
+        },
+    }
+
+
+def test_finalize_collects_sorted_multi_pod_identity() -> None:
+    final = manifest.finalize(
+        candidate(), {"version": 17}, {"items": [pod("dspace-b"), pod("dspace-a")]}
+    )
+    assert final["helmRevision"] == 17
+    assert [item["name"] for item in final["pods"]] == ["dspace-a", "dspace-b"]
+    assert final["runtimeSourceRevision"] == SHA
+    assert final["runtimeSourceRevisionMethod"] == "podImageID+ociRevisionAnnotation"
+
+
+def test_finalize_rejects_pod_image_mismatch() -> None:
+    with pytest.raises(manifest.ManifestError, match="does not match"):
+        manifest.finalize(
+            candidate(), {"version": 1}, {"items": [pod("dspace-a", "sha256:" + "9" * 64)]}
+        )
+
+
+def test_atomic_write_refuses_overwrite_and_leaves_no_temporary_file(tmp_path: Path) -> None:
+    output = tmp_path / "record.json"
+    manifest._write_new(output, candidate())
+    original = output.read_bytes()
+    with pytest.raises(manifest.ManifestError, match="overwrite"):
+        manifest._write_new(output, candidate())
+    assert output.read_bytes() == original
+    assert list(tmp_path.iterdir()) == [output]
+
+
+def test_record_excludes_tokens_and_secrets() -> None:
+    encoded = json.dumps(candidate()).lower()
+    assert "token" not in encoded.replace("token-place", "")
+    assert "secret" not in encoded and "credential" not in encoded

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -264,7 +264,10 @@ def helm_status(**changes) -> dict[str, object]:
         "name": "dspace",
         "namespace": "dspace",
         "version": 17,
-        "info": {"status": "deployed"},
+        "info": {
+            "status": "deployed",
+            "description": "sugarkube-release-manifest:test-reservation",
+        },
         "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}},
     }
     value.update(changes)
@@ -326,6 +329,7 @@ def finalize(**changes):
         "release": "dspace",
         "namespace": "dspace",
         "cluster_environment": "staging",
+        "invocation_description": "sugarkube-release-manifest:test-reservation",
     }
     arguments.update(changes)
     return manifest.finalize(**arguments)
@@ -444,6 +448,14 @@ def test_finalize_rejects_pod_image_mismatch() -> None:
         ({"cluster_environment": "prod"}, "cluster environment"),
         ({"helm_json": helm_status(name="other")}, "release and namespace"),
         ({"helm_json": helm_status(info={"status": "failed"})}, "must be deployed"),
+        (
+            {
+                "helm_json": helm_status(
+                    info={"status": "deployed", "description": "another invocation"}
+                )
+            },
+            "description",
+        ),
         (
             {"helm_json": helm_status(chart={"metadata": {"name": "other", "version": "3.2.0"}})},
             "chart identity",
@@ -652,7 +664,14 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
             return "staging\n"
         if command[0] == "helm":
             events.append("helm-status")
-            return json.dumps(helm_status())
+            return json.dumps(
+                helm_status(
+                    info={
+                        "status": "deployed",
+                        "description": f"sugarkube-release-manifest:{owner}",
+                    }
+                )
+            )
         resource = command[command.index("get") + 1]
         if resource == "pods":
             events.append("pod-discovery")
@@ -705,12 +724,64 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
         "helm-status",
         "pod-discovery",
         "workload-discovery",
+        "helm-status",
         "atomic-final-write",
     ]
     final = manifest.validate(json.loads(output.read_text(encoding="utf-8")), True)
     assert final["helmRevision"] == 17
     assert [item["name"] for item in final["pods"]] == ["dspace-a", "dspace-b"]
     assert not sidecar.exists()
+
+
+@pytest.mark.parametrize("changed_field", ["version", "description"])
+def test_finalize_cli_rejects_changed_helm_binding_and_preserves_reservation(
+    tmp_path: Path, monkeypatch, changed_field: str
+) -> None:
+    source = tmp_path / "candidate.json"
+    output = tmp_path / "evidence.json"
+    source.write_text(manifest._canonical(candidate()), encoding="utf-8")
+    owner = manifest.reserve(output, candidate(), "staging", "dspace", "dspace")
+    description = f"sugarkube-release-manifest:{owner}"
+    status_reads = 0
+
+    oci_results = manifest.preflight(
+        candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras", runner=oras_runner()
+    )
+    monkeypatch.setattr(
+        manifest,
+        "preflight",
+        lambda *args, **kwargs: oci_results,
+    )
+
+    def run(command):
+        nonlocal status_reads
+        if "cluster_identity.py" in " ".join(command):
+            return "staging\n"
+        if command[0] == "helm":
+            status_reads += 1
+            info = {"status": "deployed", "description": description}
+            status = helm_status(info=info)
+            if status_reads == 2:
+                if changed_field == "version":
+                    status["version"] = 18
+                else:
+                    status["info"]["description"] = "another invocation"
+            return json.dumps(status)
+        resource = command[command.index("get") + 1]
+        return json.dumps(
+            {"items": [pod("dspace-a")]} if resource == "pods" else workloads()
+        )
+
+    monkeypatch.setattr(manifest, "_run", run)
+    args = [
+        "finalize", "--manifest", str(source), "--output", str(output),
+        "--environment", "staging", "--image-tag", "main-abcdef0",
+        "--chart-version", "3.2.0", "--kubeconfig", "kubeconfig",
+        "--release", "dspace", "--namespace", "dspace", "--reservation", owner,
+    ]
+    assert manifest.main(args) == 2
+    assert not output.exists()
+    assert manifest.reservation_path(output).exists()
 
 
 def test_public_read_only_and_reservation_dispatch(

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -12,6 +12,9 @@ from scripts import dspace_release_manifest as manifest
 SHA = "abcdef0123456789abcdef0123456789abcdef01"
 DIGEST = "sha256:" + "1" * 64
 CHART_DIGEST = "sha256:" + "2" * 64
+PLATFORM_DIGEST = "sha256:" + "3" * 64
+IMAGE_CONFIG_DIGEST = "sha256:" + "4" * 64
+CHART_CONFIG_DIGEST = "sha256:" + "5" * 64
 
 
 def upstream() -> dict[str, object]:
@@ -76,20 +79,27 @@ def test_upstream_import_is_canonical_and_round_trips(tmp_path: Path) -> None:
         lambda x: x.update(sourceRevision="abc1234"),
         lambda x: x.update(sourceRevision=SHA.upper()),
         lambda x: x.update(imageTag="latest"),
+        lambda x: x.update(imageTag="staging-abcdef0"),
+        lambda x: x.update(imageTag="prod-abcdef0"),
+        lambda x: x.update(imageTag="production-abcdef0"),
+        lambda x: x.update(imageTag="latest-abcdef0"),
         lambda x: x.update(imageTag="v3.2.0"),
+        lambda x: x.update(imageTag="main"),
+        lambda x: x.update(imageTag="v3"),
         lambda x: x.update(imageTag="main-deadbee"),
         lambda x: x.update(imageDigest="sha256:abc"),
         lambda x: x.update(chartDigest="2" * 64),
         lambda x: x.update(chartVersion="v3.2.0"),
+        lambda x: x.pop("semanticTag"),
+        lambda x: x.update(semanticTag=None),
+        lambda x: x.update(semanticTag="v3.2.1"),
     ],
 )
 def test_rejects_invalid_upstream(change) -> None:
     value = upstream()
     change(value)
     with pytest.raises(manifest.ManifestError):
-        manifest.candidate(
-            value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator"
-        )
+        manifest.candidate(value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator")
 
 
 @pytest.mark.parametrize(
@@ -101,40 +111,97 @@ def test_rejects_invalid_upstream(change) -> None:
         ("prod", "openai", ""),
     ],
 )
-def test_rejects_wrong_enrichment(
-    environment: str, provider: str, approver: str
-) -> None:
+def test_rejects_wrong_enrichment(environment: str, provider: str, approver: str) -> None:
     with pytest.raises(manifest.ManifestError):
-        manifest.candidate(
-            upstream(), environment, provider, "2026-07-26T12:00:00Z", approver
-        )
+        manifest.candidate(upstream(), environment, provider, "2026-07-26T12:00:00Z", approver)
 
 
-def test_preflight_checks_digests_and_both_revision_metadata(monkeypatch) -> None:
-    responses = iter([(DIGEST, SHA), (CHART_DIGEST, SHA)])
-    monkeypatch.setattr(manifest, "_oras_evidence", lambda *_: next(responses))
-    results = manifest.preflight(candidate(), "image", "chart", "oras-stub")
+def oras_runner(*, image_revision: str = SHA, chart_revision: str = SHA):
+    responses = {
+        ("manifest", "fetch", "--descriptor", f"{manifest.IMAGE_REF}:main-abcdef0"): {
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "digest": DIGEST,
+        },
+        ("manifest", "fetch", f"{manifest.IMAGE_REF}@{DIGEST}"): {
+            "schemaVersion": 2,
+            "manifests": [
+                {"digest": PLATFORM_DIGEST, "platform": {"os": "linux", "architecture": "amd64"}}
+            ],
+        },
+        ("manifest", "fetch", f"{manifest.IMAGE_REF}@{PLATFORM_DIGEST}"): {
+            "schemaVersion": 2,
+            "config": {"digest": IMAGE_CONFIG_DIGEST},
+            "layers": [],
+        },
+        ("blob", "fetch", f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}"): {
+            "config": {"Labels": {manifest.REVISION_ANNOTATION: image_revision}}
+        },
+        ("manifest", "fetch", "--descriptor", f"{manifest.CHART_REF}:3.2.0"): {
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "digest": CHART_DIGEST,
+        },
+        ("manifest", "fetch", f"{manifest.CHART_REF}@{CHART_DIGEST}"): {
+            "schemaVersion": 2,
+            "config": {"digest": CHART_CONFIG_DIGEST},
+            "layers": [],
+        },
+        ("blob", "fetch", f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}"): {
+            "annotations": {manifest.REVISION_ANNOTATION: chart_revision}
+        },
+    }
+    calls = []
+
+    def run(command):
+        calls.append(command)
+        return json.dumps(responses[tuple(command[1:])])
+
+    run.calls = calls
+    return run
+
+
+def test_preflight_checks_exact_descriptors_and_digest_qualified_metadata() -> None:
+    runner = oras_runner()
+    results = manifest.preflight(
+        candidate(), manifest.IMAGE_REF, "oci://" + manifest.CHART_REF, "oras-stub", runner=runner
+    )
     assert [item["check"] for item in results] == [
         "imageDigest",
         "chartDigest",
-        "imageSourceRevision",
         "chartSourceRevision",
+        "imagePlatformSourceRevision[0]",
     ]
+    assert runner.calls[0][-1].endswith(":main-abcdef0")
+    assert runner.calls[1][-1] == f"{manifest.IMAGE_REF}@{DIGEST}"
+    assert all(":main-abcdef0" not in call[-1] for call in runner.calls[1:])
 
 
 @pytest.mark.parametrize(
-    "responses",
+    ("image_revision", "chart_revision"),
     [
-        [("sha256:" + "9" * 64, SHA), (CHART_DIGEST, SHA)],
-        [(DIGEST, SHA), ("sha256:" + "9" * 64, SHA)],
-        [(DIGEST, "0" * 40), (CHART_DIGEST, SHA)],
+        ("0" * 40, SHA),
+        (SHA, "0" * 40),
     ],
 )
-def test_preflight_mismatch_fails(monkeypatch, responses) -> None:
-    values = iter(responses)
-    monkeypatch.setattr(manifest, "_oras_evidence", lambda *_: next(values))
+def test_preflight_mismatch_fails(image_revision, chart_revision) -> None:
     with pytest.raises(manifest.ManifestError, match="mismatch"):
-        manifest.preflight(candidate(), "image", "chart", "oras")
+        manifest.preflight(
+            candidate(),
+            manifest.IMAGE_REF,
+            manifest.CHART_REF,
+            "oras",
+            runner=oras_runner(image_revision=image_revision, chart_revision=chart_revision),
+        )
+
+
+def test_preflight_rejects_noncanonical_deployed_chart() -> None:
+    with pytest.raises(manifest.ManifestError, match="chart reference"):
+        manifest.preflight(
+            candidate(),
+            manifest.IMAGE_REF,
+            "oci://example.invalid/dspace",
+            "oras",
+            runner=oras_runner(),
+        )
 
 
 def pod(name: str, digest: str = DIGEST) -> dict[str, object]:
@@ -142,9 +209,7 @@ def pod(name: str, digest: str = DIGEST) -> dict[str, object]:
         "metadata": {"name": name},
         "status": {
             "startTime": "2026-07-26T12:01:00Z",
-            "containerStatuses": [
-                {"imageID": "ghcr.io/democratizedspace/dspace@" + digest}
-            ],
+            "containerStatuses": [{"imageID": "ghcr.io/democratizedspace/dspace@" + digest}],
         },
     }
 
@@ -154,7 +219,9 @@ def test_finalize_collects_sorted_multi_pod_identity() -> None:
         candidate(),
         {"version": 17},
         {"items": [pod("dspace-b"), pod("dspace-a")]},
-        [{"check": "imageDigest", "passed": True, "details": "fresh OCI result"}],
+        manifest.preflight(
+            candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras", runner=oras_runner()
+        ),
     )
     assert final["helmRevision"] == 17
     assert [item["name"] for item in final["pods"]] == ["dspace-a", "dspace-b"]
@@ -168,7 +235,9 @@ def test_finalize_rejects_pod_image_mismatch() -> None:
             candidate(),
             {"version": 1},
             {"items": [pod("dspace-a", "sha256:" + "9" * 64)]},
-            [{"check": "imageDigest", "passed": True, "details": "fresh OCI result"}],
+            manifest.preflight(
+                candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras", runner=oras_runner()
+            ),
         )
 
 
@@ -195,10 +264,14 @@ def test_finalize_requires_preflight_results() -> None:
         manifest.finalize(candidate(), {"version": 1}, {"items": [pod("dspace-a")]}, [])
 
 
-def test_check_output_rejects_collision_before_deployment(
-    tmp_path: Path, capsys
-) -> None:
+def test_check_output_rejects_collision_before_deployment(tmp_path: Path, capsys) -> None:
     output = tmp_path / "existing.json"
     output.write_text("already recorded", encoding="utf-8")
     assert manifest.main(["check-output", "--output", str(output)]) == 2
     assert "refusing to overwrite" in capsys.readouterr().err
+
+
+def test_default_evidence_path_is_stable_and_approval_unique() -> None:
+    assert str(manifest.evidence_path(candidate())) == (
+        "deployment-evidence/dspace/staging/main-abcdef0-20260726T120000Z.json"
+    )

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -954,3 +955,154 @@ def test_default_evidence_path_is_stable_and_approval_unique() -> None:
     assert str(manifest.evidence_path(candidate())) == (
         "deployment-evidence/dspace/staging/main-abcdef0-20260726T120000Z.json"
     )
+
+@pytest.mark.parametrize(
+    ("change", "message"),
+    [
+        (lambda value: value.update(schemaVersion=2), "schemaVersion"),
+        (lambda value: value.update(recordType="final"), "recordType"),
+        (lambda value: value.update(approvedAt=1), "approvedAt"),
+        (lambda value: value.update(approvedAt="2026-02-30T12:00:00Z"), "valid UTC"),
+    ],
+)
+def test_candidate_validation_rejects_malformed_schema(change, message) -> None:
+    value = candidate()
+    change(value)
+    with pytest.raises(manifest.ManifestError, match=message):
+        manifest.validate(value, False)
+
+
+@pytest.mark.parametrize(
+    ("change", "message"),
+    [
+        (lambda value: value.update(helmRevision=True), "positive integer"),
+        (lambda value: value.update(pods=[]), "non-empty list"),
+        (lambda value: value.update(pods=["pod"]), "pod must be an object"),
+        (lambda value: value["pods"][0].update(name=""), "non-empty strings"),
+        (lambda value: value["pods"].append(dict(value["pods"][0])), "unique"),
+        (lambda value: value.update(runtimeSourceRevision="0" * 40), "must match"),
+        (lambda value: value.update(runtimeSourceRevisionMethod="invented"), "must be"),
+        (lambda value: value.update(verificationResults=[]), "non-empty list"),
+        (lambda value: value.update(verificationResults=["result"]), "must be objects"),
+    ],
+)
+def test_final_validation_rejects_malformed_runtime_schema(change, message) -> None:
+    value = finalize()
+    change(value)
+    with pytest.raises(manifest.ManifestError, match=message):
+        manifest.validate(value, True)
+
+
+def test_reservation_failure_cleanup_and_directory_sync_fallback(
+    tmp_path: Path, monkeypatch
+) -> None:
+    output = tmp_path / "evidence.json"
+    monkeypatch.setattr(manifest.os, "fsync", lambda _fd: (_ for _ in ()).throw(OSError("disk")))
+    with pytest.raises(OSError, match="disk"):
+        manifest.reserve(output, candidate(), "staging", "dspace", "dspace")
+    assert not manifest.reservation_path(output).exists()
+
+    monkeypatch.setattr(
+        manifest.os, "open", lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError())
+    )
+    manifest._sync_directory(tmp_path)
+
+
+def test_reservation_rejects_environment_and_late_output_collision(tmp_path: Path) -> None:
+    output = tmp_path / "evidence.json"
+    with pytest.raises(manifest.ManifestError, match="environment"):
+        manifest.reserve(output, candidate(), "prod", "dspace", "dspace")
+    owner = manifest.reserve(output, candidate(), "staging", "dspace", "dspace")
+    output.write_text("collision", encoding="utf-8")
+    with pytest.raises(manifest.ManifestError, match="overwrite"):
+        manifest.verify_reservation(output, candidate(), "staging", "dspace", "dspace", owner)
+
+
+def test_command_and_oci_json_failures(monkeypatch) -> None:
+    monkeypatch.setattr(
+        manifest.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 1, "", "failed"),
+    )
+    with pytest.raises(manifest.ManifestError, match="command failed.*failed"):
+        manifest._run(["oras"])
+    for response, message in (("not-json", "invalid JSON"), ("[]", "non-object")):
+        with pytest.raises(manifest.ManifestError, match=message):
+            manifest._json_run(lambda _command, result=response: result, ["oras"])
+
+
+@pytest.mark.parametrize(
+    ("command_key", "replacement", "message"),
+    [
+        (
+            ("manifest", "fetch", "--descriptor", f"{manifest.IMAGE_REF}:main-abcdef0"),
+            {},
+            "descriptor",
+        ),
+        (("manifest", "fetch", f"{manifest.IMAGE_REF}@{DIGEST}"), {"manifests": []}, "image index"),
+        (
+            ("manifest", "fetch", f"{manifest.IMAGE_REF}@{DIGEST}"),
+            {"manifests": [{}]},
+            "platform digest",
+        ),
+        (("manifest", "fetch", f"{manifest.IMAGE_REF}@{PLATFORM_DIGEST}"), {}, "config digest"),
+        (("blob", "fetch", f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}"), {}, "revision label"),
+        (("manifest", "fetch", f"{manifest.CHART_REF}@{CHART_DIGEST}"), {}, "config digest"),
+        (("blob", "fetch", f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}"), {}, "revision metadata"),
+    ],
+)
+def test_preflight_rejects_malformed_oci_evidence(command_key, replacement, message) -> None:
+    runner = oras_runner()
+
+    def malformed(command):
+        if tuple(command[1:]) == command_key:
+            return json.dumps(replacement)
+        return runner(command)
+
+    with pytest.raises(manifest.ManifestError, match=message):
+        manifest.preflight(
+            candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras", runner=malformed
+        )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"image_ref": "example.invalid/dspace"}, "image reference"),
+        ({"environment": "prod"}, "selected environment"),
+    ],
+)
+def test_preflight_rejects_unapproved_selected_coordinates(kwargs, message) -> None:
+    arguments = {
+        "value": candidate(),
+        "image_ref": manifest.IMAGE_REF,
+        "chart_ref": manifest.CHART_REF,
+        "oras": "oras",
+        "runner": oras_runner(),
+    }
+    arguments.update(kwargs)
+    with pytest.raises(manifest.ManifestError, match=message):
+        manifest.preflight(**arguments)
+
+
+@pytest.mark.parametrize("failure", ["object", "labels", "owner", "container"])
+def test_finalize_rejects_malformed_release_objects(failure: str) -> None:
+    discovered = workloads()
+    pods_json = {"items": [pod("dspace-a")]}
+    if failure == "object":
+        discovered["items"][0] = "replicaset"
+    elif failure == "labels":
+        discovered["items"][0]["metadata"]["labels"] = {}
+    elif failure == "owner":
+        pods_json["items"][0]["metadata"]["ownerReferences"] = []
+    else:
+        pods_json["items"][0]["spec"]["containers"] = []
+    with pytest.raises(manifest.ManifestError):
+        finalize(workloads_json=discovered, pods_json=pods_json)
+
+
+def test_finalize_rejects_noncanonical_image_id() -> None:
+    item = pod("dspace-a")
+    item["status"]["containerStatuses"][0]["imageID"] = "not-a-digest"
+    with pytest.raises(manifest.ManifestError, match="non-canonical pod imageID"):
+        finalize(pods_json={"items": [item]})

--- a/tests/test_up_recipe_calls.py
+++ b/tests/test_up_recipe_calls.py
@@ -167,6 +167,12 @@ def test_env_recipes_quote_and_normalize_named_arguments():
     forwarding_recipes = {
         "ha3 env='dev':": "up {{ quote(env) }}",
         "save-logs env='dev':": "up {{ quote(env) }}",
+        "dspace-oci-deploy env='staging' tag='' manifest='' evidence='':": (
+            "app-deploy app=dspace env={{ quote(env) }}"
+        ),
+        "dspace-oci-redeploy env='staging' tag='' manifest='' evidence='':": (
+            "app-redeploy app=dspace env={{ quote(env) }}"
+        ),
     }
     for header, expected_call in forwarding_recipes.items():
         body = _extract_recipe(lines, header)
@@ -179,8 +185,6 @@ def test_env_recipes_quote_and_normalize_named_arguments():
         "kubeconfig env='':",
         "kubeconfig-env env='dev':",
         cloudflare_tunnel_recipe,
-        "dspace-oci-deploy env='staging' tag='':",
-        "dspace-oci-redeploy env='staging' tag='':",
         "dspace-debug-logs-env env='staging' namespace='dspace':",
         "flux-bootstrap env='dev':",
         "platform-apply env='dev':",

--- a/tests/test_up_recipe_calls.py
+++ b/tests/test_up_recipe_calls.py
@@ -167,12 +167,6 @@ def test_env_recipes_quote_and_normalize_named_arguments():
     forwarding_recipes = {
         "ha3 env='dev':": "up {{ quote(env) }}",
         "save-logs env='dev':": "up {{ quote(env) }}",
-        "dspace-oci-deploy env='staging' tag='' manifest='' evidence='':": (
-            "app-deploy app=dspace env={{ quote(env) }}"
-        ),
-        "dspace-oci-redeploy env='staging' tag='' manifest='' evidence='':": (
-            "app-redeploy app=dspace env={{ quote(env) }}"
-        ),
     }
     for header, expected_call in forwarding_recipes.items():
         body = _extract_recipe(lines, header)
@@ -185,6 +179,8 @@ def test_env_recipes_quote_and_normalize_named_arguments():
         "kubeconfig env='':",
         "kubeconfig-env env='dev':",
         cloudflare_tunnel_recipe,
+        "dspace-oci-deploy env='staging' tag='':",
+        "dspace-oci-redeploy env='staging' tag='':",
         "dspace-debug-logs-env env='staging' namespace='dspace':",
         "flux-bootstrap env='dev':",
         "platform-apply env='dev':",

--- a/tests/test_up_recipe_calls.py
+++ b/tests/test_up_recipe_calls.py
@@ -179,8 +179,6 @@ def test_env_recipes_quote_and_normalize_named_arguments():
         "kubeconfig env='':",
         "kubeconfig-env env='dev':",
         cloudflare_tunnel_recipe,
-        "dspace-oci-deploy env='staging' tag='':",
-        "dspace-oci-redeploy env='staging' tag='':",
         "dspace-debug-logs-env env='staging' namespace='dspace':",
         "flux-bootstrap env='dev':",
         "platform-apply env='dev':",
@@ -193,6 +191,20 @@ def test_env_recipes_quote_and_normalize_named_arguments():
         assert "env_input={{ quote(env) }}" in joined, header
         assert 'while [ "${env_name#env=}" != "${env_name}" ]; do' in joined, header
         assert 'if [ -z "${env_name}" ]; then' in joined, header
+
+
+@pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")
+def test_dspace_wrapper_normalizes_repeated_named_env_argument() -> None:
+    result = subprocess.run(
+        ["just", "dspace-oci-deploy", "env=env=staging", "tag=main-deadbee"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "required for DSPACE staging" in result.stderr
+    assert "DSPACE env=staging" not in result.stderr
 
 
 @pytest.mark.skipif(shutil.which("just") is None, reason="just is required for this test")


### PR DESCRIPTION
### Motivation

- Prevent DSPACE staging approval or production promotion from reaching Helm with missing, mutable, or internally inconsistent release coordinates after the production version-drift incident.
- Consume the strict release artifact produced by DSPACE #4753 and enrich it with approval, environment, deployment, and runtime evidence.
- Provide deterministic records that let responders reconstruct a deployment without resolving mutable tags or using GitHub Packages REST credentials.

### What changed

- Added the stdlib-only `scripts/dspace_release_manifest.py` CLI to:
  - import upstream manifests;
  - generate canonical staging and production candidates;
  - validate candidate and finalized schemas with no missing or unknown fields;
  - perform injectable OCI preflight checks;
  - reserve evidence destinations before mutation;
  - collect and atomically finalize deployment evidence without overwriting records.
- Enforced full lowercase Git SHAs, strict `sha256:` digests, strict SemVer, `staging` or `prod`, existing provider spellings (`token-place` and `openai`), and immutable `main-SHA7` or `vN-SHA7` image tags matching the full source revision.
- Retained `semanticTag` only as evidence and never as a deployment coordinate.
- Added an OCI-native `oras` preflight that:
  - compares the resolved image-index and chart-artifact digests with the approval;
  - reads image platform configs and chart config through digest-qualified references;
  - verifies every relevant source-revision annotation against the approved full SHA;
  - does not depend on GitHub Packages REST access or an ad hoc `read:packages` token.
- Integrated the guard into DSPACE staging and production deploy, redeploy, promotion, and retained compatibility commands. Unrelated applications remain ungated.
- Helm now receives the approved digest-qualified DSPACE chart coordinate without re-resolving its version tag.
- Added an exclusive `.reservation` sidecar before Helm mutation. It binds the candidate fingerprint, environment, release, namespace, destination, and invocation identifier. Failed operations preserve the reservation for explicit operator reconciliation; successful finalization removes it only after the evidence write is durable.
- Bound deployment evidence to the guarded Helm invocation through the release description and stable revision checks before and after evidence collection.
- Finalization now:
  - re-runs OCI provenance checks;
  - verifies cluster environment and Helm release/chart identity;
  - boundedly waits for terminating rollout pods to disappear;
  - validates every remaining release-owned pod is Running and Ready;
  - verifies the pod image coordinate and resolved image ID;
  - records Helm revision, pod names, start times, image IDs, structured verification results, and runtime source identity.
- `runtimeSourceRevisionMethod` is strictly `podImageID+ociRevisionAnnotation`. No HTTP runtime identity check is claimed.
- Preserved the production-subdomain compatibility overlay through `docs/examples/apps/dspace-prod-subdomain.env` while routing it through the shared guard.
- Documented staging approval, production promotion, rollback preparation, OCI fallback inspection, evidence preservation, and stranded-reservation recovery in `docs/apps/dspace.md` and `docs/app_deployment_contract.md`.

The default final record is stored under `deployment-evidence/dspace/`, partitioned by environment and named from the immutable image tag plus canonical approval time. Existing evidence files are never overwritten. Operators must review and commit the record or attach that exact file to the external promotion record; the workflow does not auto-commit evidence.

### Testing

- `python3 -m pytest -q tests/test_release_manifest.py` — 122 passed.
- `python3 -m pytest -q tests/test_release_manifest.py tests/test_generic_app_just_recipes.py tests/test_up_recipe_calls.py` — 282 passed.
- Focused module coverage reached 99.39%, with three executable statements uncovered; the latest-head `codecov/patch` check succeeded.
- `bash scripts/test-helm-oci-install.sh` passed.
- `git diff --check origin/main...HEAD` passed.
- `git diff origin/main...HEAD | ./scripts/scan-secrets.py` passed.
- Latest-head `ci`, Test Suite, Docs, Spellcheck, Verify Justfile formatting, pi-image, Greptile Review, and Codecov checks all completed successfully.
- `pre-commit run --all-files` was attempted during development and still reports broad repository-wide formatting, lint, and YAML-template findings. This PR does not weaken hook configuration or coverage thresholds.

### Scope and operational follow-up

- No live cluster or registry was queried or mutated while implementing this PR.
- No real approval or production evidence was fabricated.
- No production pins, upstream DSPACE files, release tags, or published artifacts were changed.
- This does not implement #2327 rollback automation or #2328 runtime build-identity/chat smoke gates.
- Genuine staging and production evidence must still be captured during real promotions, so this references rather than closes the tracking issue.

Refs #2326

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a659e44abe0832f9fd53032ec553989)