### PR TITLE
Add fail-closed DSPACE release-manifest evidence flow and guard (Refs #2326)

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -1,5 +1,14 @@
 # Sugarkube app deployment contract
 
+
+## DSPACE release-manifest exception
+
+DSPACE staging and production deployments have an additional fail-closed contract. They require
+an approved candidate passed as `manifest=<path>`; other applications are deliberately not gated
+until they publish a compatible manifest. Both the generic `app-deploy`/`app-promote-prod` path and
+the retained `dspace-oci-*` wrappers validate that candidate and perform the same read-only OCI
+preflight before Helm. See the [DSPACE release evidence flow](apps/dspace.md#release-manifest-and-deployment-evidence).
+
 Sugarkube now exposes a generic app deployment surface where each app is
 identified by a small local config file and deployed with shared `just` recipes.
 This page is the contract that app repositories and local operator configs should

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -2,6 +2,88 @@
 
 This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugarkube. The generic `just app-*` recipes are the preferred future path. The `dspace-oci-*` recipes remain compatibility shims and are scheduled for later removal only after the generic flow has been exercised across routine releases.
 
+
+## Release manifest and deployment evidence
+
+DSPACE promotion enriches the upstream `dspace-release-manifest` artifact with approval and observed
+cluster evidence. A semantic tag remains evidence only. Helm receives the immutable branch-SHA
+`imageTag`, whose seven-character suffix must match the full `sourceRevision`.
+
+Download the artifact from the successful DSPACE release workflow, validate it, and create an
+explicitly approved staging candidate. Provider values use DSPACE's exact `openai` and
+`token-place` spellings. The tool never invents an approver or timestamp.
+
+```bash
+gh run download <run-id> --repo democratizedspace/dspace \
+  --name dspace-release-manifest --dir dspace-release-manifest
+python3 scripts/release_manifest.py import \
+  dspace-release-manifest/dspace-release-manifest.json
+python3 scripts/release_manifest.py candidate \
+  dspace-release-manifest/dspace-release-manifest.json \
+  --environment staging --expected-default-chat-provider token-place \
+  --approved-at 2026-07-26T12:00:00Z --approved-by '<reviewer identity>' \
+  --output staging-candidate.json
+python3 scripts/release_manifest.py validate staging-candidate.json
+```
+
+Inspect the canonical JSON before deploying. The guard compares its environment, image tag, and
+chart version with the command, then resolves both OCI descriptors and checks both
+`org.opencontainers.image.revision` annotations before Helm can mutate the cluster.
+
+```bash
+just app-deploy app=dspace env=staging tag=main-abcdef0 manifest=staging-candidate.json
+# Retained compatibility path, protected by the same guard:
+just dspace-oci-deploy env=staging tag=main-abcdef0 manifest=staging-candidate.json
+```
+
+After Helm succeeds, the recipe captures the Helm revision and every DSPACE pod's name, start time,
+and resolved image ID. It verifies every image ID against the approved index digest and atomically
+creates `deployment-evidence/dspace/staging-<imageTag>.json`; it refuses overwrite. Until DSPACE
+issue 4732 exposes direct runtime identity, `pod-image-id-and-oci-revision` is the only accepted
+method: all pod digests and that exact OCI artifact's revision annotation must agree with approval.
+This does **not** claim an HTTP runtime identity check.
+
+Create production approval from the same upstream JSON, without resolving any tag again:
+
+```bash
+python3 scripts/release_manifest.py candidate \
+  dspace-release-manifest/dspace-release-manifest.json \
+  --environment prod --expected-default-chat-provider token-place \
+  --approved-at 2026-07-26T14:00:00Z --approved-by '<reviewer identity>' \
+  --output prod-candidate.json
+python3 scripts/release_manifest.py validate prod-candidate.json
+just app-promote-prod app=dspace tag=main-abcdef0 manifest=prod-candidate.json
+# Or: just dspace-oci-promote-prod tag=main-abcdef0 manifest=prod-candidate.json
+```
+
+Preserve each finalized file by committing it on the promotion change (`git add
+deployment-evidence/dspace/<record>.json && git commit`) or attaching that exact file to the
+promotion record. Deployment does not auto-commit. Genuine staging and production evidence remains
+an operational action tracked by Sugarkube issue 2326.
+
+### OCI-native fallback without package API access
+
+No GitHub Packages REST access or ad hoc `read:packages` token is required. ORAS talks directly to
+the OCI registry and exposes the same descriptors and annotations used by preflight:
+
+```bash
+oras manifest fetch --descriptor ghcr.io/democratizedspace/dspace:main-abcdef0
+oras manifest fetch ghcr.io/democratizedspace/dspace:main-abcdef0
+oras manifest fetch --descriptor ghcr.io/democratizedspace/charts/dspace:3.2.1
+oras manifest fetch ghcr.io/democratizedspace/charts/dspace:3.2.1
+```
+
+Set `SUGARKUBE_RELEASE_MANIFEST_ORAS` when ORAS has a nonstandard executable path. Never put
+credentials in a manifest or command line; a normal OCI credential store can authenticate where
+registry policy requires it. The tool does not read, log, or write tokens.
+
+### Reconstructing without mutable tags
+
+The finalized record supplies the full source SHA, image tag and digest, independently versioned
+chart and digest, approval, Helm revision, and pod identities. Pull the image by recorded digest and
+fetch the chart manifest by recorded digest. Never consult `latest`, a semantic tag, a bare branch,
+or an environment tag during reconstruction.
+
 ## Artifact model
 
 - App repository responsibilities: build `ghcr.io/democratizedspace/dspace`, publish immutable image tags, maintain the Helm chart, and publish immutable chart versions to `oci://ghcr.io/democratizedspace/charts/dspace`.

--- a/justfile
+++ b/justfile
@@ -1606,7 +1606,7 @@ app-config app env='staging' config='':
       --config {{ quote(config) }}
 
 # Generic immutable-tag app deploy backed by docs/examples/apps/*.env or local app configs.
-app-deploy app env='staging' tag='' config='':
+app-deploy app env='staging' tag='' config='' manifest='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1616,6 +1616,22 @@ app-deploy app env='staging' tag='' config='':
       --config {{ quote(config) }} \
       --tag {{ quote(tag) }} \
       --require-tag)"
+
+    manifest_path={{ quote(manifest) }}
+    while [ "${manifest_path#manifest=}" != "${manifest_path}" ]; do manifest_path="${manifest_path#manifest=}"; done
+    if [ "${SUGARKUBE_APP}" = dspace ]; then
+      if [ -z "${manifest_path}" ]; then echo "ERROR: DSPACE deployments require manifest=<approved-candidate.json>." >&2; exit 2; fi
+      python3 "{{ justfile_directory() }}/scripts/release_manifest.py" validate "${manifest_path}"
+      python3 - "${manifest_path}" "${SUGARKUBE_ENV}" "${SUGARKUBE_TAG}" "${SUGARKUBE_VERSION:-$(sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -1)}" <<'PY'
+    import json, sys
+    m=json.load(open(sys.argv[1], encoding="utf-8"))
+    if (m["environment"], m["imageTag"], m["chartVersion"]) != tuple(sys.argv[2:5]):
+        raise SystemExit("ERROR: approved manifest coordinates do not match requested deployment")
+    PY
+      python3 "{{ justfile_directory() }}/scripts/release_manifest.py" preflight "${manifest_path}" \
+        --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" \
+        --chart-version "${SUGARKUBE_VERSION:-$(sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -1)}"
+    fi
 
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
@@ -1639,6 +1655,12 @@ app-deploy app env='staging' tag='' config='':
       version_file="${SUGARKUBE_VERSION_FILE:-}" \
       tag="${SUGARKUBE_TAG}" \
       env="${SUGARKUBE_ENV}"
+    if [ "${SUGARKUBE_APP}" = dspace ]; then
+      evidence_dir="${SUGARKUBE_DEPLOYMENT_EVIDENCE_DIR:-deployment-evidence/dspace}"
+      output="${evidence_dir}/${SUGARKUBE_ENV}-${SUGARKUBE_TAG}.json"
+      python3 "{{ justfile_directory() }}/scripts/release_manifest.py" finalize "${manifest_path}" --output "${output}"
+      echo "Final deployment evidence: ${output}"
+    fi
 
 # Generic upgrade-only app redeploy backed by app config files.
 app-redeploy app env='staging' tag='' config='':
@@ -1676,7 +1698,7 @@ app-redeploy app env='staging' tag='' config='':
       env="${SUGARKUBE_ENV}"
 
 # Promote an app to prod with an explicit immutable tag, or the configured prod tag file.
-app-promote-prod app tag='' config='':
+app-promote-prod app tag='' config='' manifest='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1691,7 +1713,8 @@ app-promote-prod app tag='' config='':
       app="${SUGARKUBE_APP}" \
       env=prod \
       tag="${SUGARKUBE_TAG}" \
-      config="${SUGARKUBE_CONFIG_PATH}"
+      config="${SUGARKUBE_CONFIG_PATH}" \
+      manifest={{ quote(manifest) }}
 
 # Show the pinned chart version and whether a newer semver chart appears published.
 app-chart-status app env='staging' config='':
@@ -1816,9 +1839,13 @@ app-cors-verify app env='staging' config='' origin='https://cors-smoke.invalid' 
 #
 
 # Use this for steady-state release validation flows where explicit image pinning matters.
-dspace-oci-deploy env='staging' tag='':
+dspace-oci-deploy env='staging' tag='' manifest='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
+
+    manifest_path={{ quote(manifest) }}
+    while [ "${manifest_path#manifest=}" != "${manifest_path}" ]; do manifest_path="${manifest_path#manifest=}"; done
+    if [ -z "${manifest_path}" ]; then echo "ERROR: DSPACE deployments require manifest=<approved-candidate.json>." >&2; exit 2; fi
 
     env_input={{ quote(env) }}
     env_name="${env_input}"
@@ -1875,6 +1902,10 @@ dspace-oci-deploy env='staging' tag='':
     fi
     export SUGARKUBE_ENV="${env_name}"
     eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell --app dspace --env "${env_name}")"
+    python3 "{{ justfile_directory() }}/scripts/release_manifest.py" validate "${manifest_path}"
+    python3 "{{ justfile_directory() }}/scripts/release_manifest.py" preflight "${manifest_path}" \
+      --environment "${env_name}" --image-tag "${deploy_tag}" \
+      --chart-version "${SUGARKUBE_VERSION:-$(sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -1)}"
     just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "${env_name}" "${KUBECONFIG}" >/dev/null
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
@@ -1885,6 +1916,9 @@ dspace-oci-deploy env='staging' tag='':
       version_file="${SUGARKUBE_VERSION_FILE:-}" \
       tag="${deploy_tag}" \
       env="${env_name}"
+
+    evidence_dir="${SUGARKUBE_DEPLOYMENT_EVIDENCE_DIR:-deployment-evidence/dspace}"
+    python3 "{{ justfile_directory() }}/scripts/release_manifest.py" finalize "${manifest_path}" --output "${evidence_dir}/${env_name}-${deploy_tag}.json"
 
     echo "Resolved deployment image(s):"
     kubectl -n dspace get deploy dspace \
@@ -1965,7 +1999,7 @@ dspace-oci-deploy-prod-subdomain tag='':
 # Promote dspace to production apex (democratized.space) using immutable tags.
 
 # If tag is omitted, this reads the pinned value from docs/apps/dspace.prod.tag.
-dspace-oci-promote-prod tag='':
+dspace-oci-promote-prod tag='' manifest='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1975,7 +2009,7 @@ dspace-oci-promote-prod tag='':
       --tag {{ quote(tag) }} \
       --prod-tag-fallback \
       --require-tag)"
-    just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy env=prod tag="${SUGARKUBE_TAG}"
+    just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy env=prod tag="${SUGARKUBE_TAG}" manifest={{ quote(manifest) }}
 
 # Fast redeploy of dspace from GHCR (emergency mutable-tag refresh).
 dspace-oci-redeploy env='staging' tag='':

--- a/scripts/release_manifest.py
+++ b/scripts/release_manifest.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Validate DSPACE release coordinates and capture deployment evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Callable
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+SEMVER_RE = re.compile(
+    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+TAG_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*-([0-9a-f]{7})$")
+TIME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
+PROVIDERS = {"openai", "token-place"}
+UPSTREAM_REQUIRED = {
+    "schemaVersion",
+    "app",
+    "applicationVersion",
+    "sourceRevision",
+    "imageTag",
+    "imageDigest",
+    "chartVersion",
+    "chartDigest",
+}
+UPSTREAM_OPTIONAL = {"semanticTag"}
+CANDIDATE_FIELDS = (
+    UPSTREAM_REQUIRED
+    | UPSTREAM_OPTIONAL
+    | {"recordType", "environment", "expectedDefaultChatProvider", "approvedAt", "approvedBy"}
+)
+FINAL_FIELDS = CANDIDATE_FIELDS | {
+    "helmRevision",
+    "pods",
+    "runtimeSourceRevision",
+    "runtimeSourceRevisionMethod",
+    "verificationResults",
+}
+
+
+class ManifestError(ValueError):
+    pass
+
+
+def load(path: str | Path) -> dict[str, Any]:
+    try:
+        value = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ManifestError(f"cannot read manifest: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ManifestError("manifest must be a JSON object")
+    return value
+
+
+def _exact_fields(value: dict[str, Any], allowed: set[str], required: set[str]) -> None:
+    unknown, missing = set(value) - allowed, required - set(value)
+    if unknown:
+        raise ManifestError(f"unknown fields: {', '.join(sorted(unknown))}")
+    if missing:
+        raise ManifestError(f"missing fields: {', '.join(sorted(missing))}")
+
+
+def validate_upstream(value: dict[str, Any]) -> dict[str, Any]:
+    _exact_fields(value, UPSTREAM_REQUIRED | UPSTREAM_OPTIONAL, UPSTREAM_REQUIRED)
+    if value["schemaVersion"] != 1 or value["app"] != "dspace":
+        raise ManifestError("schemaVersion must be 1 and app must be 'dspace'")
+    sha = value["sourceRevision"]
+    if not isinstance(sha, str) or not SHA_RE.fullmatch(sha):
+        raise ManifestError("sourceRevision must be a full 40-character lowercase Git SHA")
+    for name in ("imageDigest", "chartDigest"):
+        if not isinstance(value[name], str) or not DIGEST_RE.fullmatch(value[name]):
+            raise ManifestError(f"{name} must be a lowercase sha256 digest")
+    if not isinstance(value["chartVersion"], str) or not SEMVER_RE.fullmatch(value["chartVersion"]):
+        raise ManifestError("chartVersion must be strict SemVer without a leading v")
+    tag = value["imageTag"]
+    match = TAG_RE.fullmatch(tag) if isinstance(tag, str) else None
+    if not match or match.group(1) != sha[:7]:
+        raise ManifestError("imageTag must be an immutable branch-SHA tag matching sourceRevision")
+    if "semanticTag" in value and (
+        not isinstance(value["semanticTag"], str)
+        or not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", value["semanticTag"])
+    ):
+        raise ManifestError("semanticTag must be a release semantic tag and is evidence only")
+    if not isinstance(value["applicationVersion"], str) or not value["applicationVersion"]:
+        raise ManifestError("applicationVersion must be a non-empty string")
+    return value
+
+
+def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, Any]:
+    record_type = value.get("recordType")
+    if finalized is None:
+        finalized = record_type == "deployment"
+    expected = FINAL_FIELDS if finalized else CANDIDATE_FIELDS
+    required = expected - UPSTREAM_OPTIONAL
+    _exact_fields(value, expected, required)
+    validate_upstream({k: value[k] for k in value if k in UPSTREAM_REQUIRED | UPSTREAM_OPTIONAL})
+    if record_type != ("deployment" if finalized else "candidate"):
+        raise ManifestError("recordType does not match the requested validation mode")
+    if value["environment"] not in {"staging", "prod"}:
+        raise ManifestError("environment must be staging or prod")
+    if value["expectedDefaultChatProvider"] not in PROVIDERS:
+        raise ManifestError("expectedDefaultChatProvider must be openai or token-place")
+    if not isinstance(value["approvedBy"], str) or not value["approvedBy"].strip():
+        raise ManifestError("approvedBy must be non-empty")
+    if not isinstance(value["approvedAt"], str) or not TIME_RE.fullmatch(value["approvedAt"]):
+        raise ManifestError("approvedAt must be an RFC 3339 UTC timestamp")
+    if finalized:
+        if not isinstance(value["helmRevision"], int) or value["helmRevision"] < 1:
+            raise ManifestError("helmRevision must be a positive integer")
+        if value["runtimeSourceRevision"] != value["sourceRevision"]:
+            raise ManifestError("runtimeSourceRevision must equal the approved sourceRevision")
+        if value["runtimeSourceRevisionMethod"] != "pod-image-id-and-oci-revision":
+            raise ManifestError("unsupported runtime source revision evidence method")
+        pods = value["pods"]
+        if not isinstance(pods, list) or not pods:
+            raise ManifestError("pods must be a non-empty list")
+        for pod in pods:
+            _exact_fields(pod, {"name", "startedAt", "imageID"}, {"name", "startedAt", "imageID"})
+            if not all(isinstance(pod[k], str) and pod[k] for k in pod):
+                raise ManifestError("pod evidence values must be non-empty strings")
+            if not TIME_RE.fullmatch(pod["startedAt"]):
+                raise ManifestError("pod startedAt must be an RFC 3339 UTC timestamp")
+            if pod["imageID"].rsplit("@", 1)[-1] != value["imageDigest"]:
+                raise ManifestError("pod image ID does not match approved imageDigest")
+        results = value["verificationResults"]
+        if not isinstance(results, list) or not results:
+            raise ManifestError("verificationResults must be a non-empty list")
+        for result in results:
+            _exact_fields(result, {"name", "passed", "details"}, {"name", "passed", "details"})
+            if not isinstance(result["passed"], bool):
+                raise ManifestError("verification result passed must be boolean")
+    return value
+
+
+def canonical(value: dict[str, Any]) -> str:
+    return json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+
+
+def write_new(path: str | Path, value: dict[str, Any]) -> None:
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists():
+        raise ManifestError(f"refusing to overwrite existing record: {destination}")
+    fd, temporary = tempfile.mkstemp(prefix=f".{destination.name}.", dir=destination.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(canonical(value))
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.link(temporary, destination)
+        os.unlink(temporary)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def command_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, text=True, capture_output=True, check=False)
+
+
+def _run_json(
+    command: list[str], runner: Callable[[list[str]], subprocess.CompletedProcess[str]]
+) -> dict[str, Any]:
+    result = runner(command)
+    if result.returncode:
+        raise ManifestError(
+            "read-only command failed: "
+            f"{' '.join(command)}: {(result.stderr or result.stdout).strip()}"
+        )
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise ManifestError(f"command returned invalid JSON: {' '.join(command)}") from exc
+
+
+def oci_preflight(
+    value: dict[str, Any],
+    runner: Callable[[list[str]], subprocess.CompletedProcess[str]] = command_runner,
+) -> list[dict[str, Any]]:
+    validate(value, finalized=False)
+    oras = os.environ.get("SUGARKUBE_RELEASE_MANIFEST_ORAS", "oras")
+    refs = [
+        (f"ghcr.io/democratizedspace/dspace:{value['imageTag']}", value["imageDigest"], "image"),
+        (
+            f"ghcr.io/democratizedspace/charts/dspace:{value['chartVersion']}",
+            value["chartDigest"],
+            "chart",
+        ),
+    ]
+    results = []
+    for ref, digest, kind in refs:
+        descriptor = _run_json([oras, "manifest", "fetch", "--descriptor", ref], runner)
+        if descriptor.get("digest") != digest:
+            raise ManifestError(f"{kind} digest mismatch")
+        manifest = _run_json([oras, "manifest", "fetch", ref], runner)
+        annotations = manifest.get("annotations", {})
+        revision = annotations.get("org.opencontainers.image.revision")
+        if revision != value["sourceRevision"]:
+            raise ManifestError(f"{kind} source-revision metadata mismatch")
+        results.append(
+            {"name": f"{kind}OciPreflight", "passed": True, "details": f"{ref}@{digest}"}
+        )
+    return results
+
+
+def collect(
+    candidate: dict[str, Any],
+    runner: Callable[[list[str]], subprocess.CompletedProcess[str]] = command_runner,
+    preflight_results: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    validate(candidate, finalized=False)
+    helm = _run_json(["helm", "-n", "dspace", "status", "dspace", "-o", "json"], runner)
+    pod_data = _run_json(
+        [
+            "kubectl",
+            "-n",
+            "dspace",
+            "get",
+            "pods",
+            "-l",
+            "app.kubernetes.io/name=dspace",
+            "-o",
+            "json",
+        ],
+        runner,
+    )
+    pods = []
+    for item in pod_data.get("items", []):
+        statuses = item.get("status", {}).get("containerStatuses", [])
+        starts = [s.get("state", {}).get("running", {}).get("startedAt") for s in statuses]
+        for status, started in zip(statuses, starts):
+            if status.get("imageID") and started:
+                pods.append(
+                    {
+                        "name": item["metadata"]["name"],
+                        "startedAt": started,
+                        "imageID": status["imageID"],
+                    }
+                )
+    record = dict(candidate)
+    record.update(
+        {
+            "recordType": "deployment",
+            "helmRevision": int(helm.get("version", 0)),
+            "pods": sorted(pods, key=lambda p: (p["name"], p["imageID"])),
+            "runtimeSourceRevision": candidate["sourceRevision"],
+            "runtimeSourceRevisionMethod": "pod-image-id-and-oci-revision",
+            "verificationResults": preflight_results
+            or [
+                {
+                    "name": "ociPreflight",
+                    "passed": True,
+                    "details": "approved OCI digests and revision metadata matched",
+                }
+            ],
+        }
+    )
+    return validate(record, finalized=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    imp = sub.add_parser("import")
+    imp.add_argument("upstream")
+    imp.add_argument("--output")
+    cand = sub.add_parser("candidate")
+    cand.add_argument("upstream")
+    cand.add_argument("--environment", required=True)
+    cand.add_argument("--expected-default-chat-provider", required=True)
+    cand.add_argument("--approved-at", required=True)
+    cand.add_argument("--approved-by", required=True)
+    cand.add_argument("--output")
+    val = sub.add_parser("validate")
+    val.add_argument("manifest")
+    val.add_argument("--final", action="store_true")
+    pre = sub.add_parser("preflight")
+    pre.add_argument("manifest")
+    pre.add_argument("--environment")
+    pre.add_argument("--image-tag")
+    pre.add_argument("--chart-version")
+    fin = sub.add_parser("finalize")
+    fin.add_argument("manifest")
+    fin.add_argument("--output", required=True)
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "import":
+            value = validate_upstream(load(args.upstream))
+        elif args.command == "candidate":
+            value = dict(validate_upstream(load(args.upstream)))
+            value.update(
+                recordType="candidate",
+                environment=args.environment,
+                expectedDefaultChatProvider=args.expected_default_chat_provider,
+                approvedAt=args.approved_at,
+                approvedBy=args.approved_by,
+            )
+            validate(value, False)
+        elif args.command == "validate":
+            value = validate(load(args.manifest), args.final or None)
+        elif args.command == "preflight":
+            candidate_value = load(args.manifest)
+            expected = {
+                "environment": args.environment,
+                "imageTag": args.image_tag,
+                "chartVersion": args.chart_version,
+            }
+            for field, expected_value in expected.items():
+                if expected_value is not None and candidate_value.get(field) != expected_value:
+                    raise ManifestError(
+                        f"approved {field} does not match requested deployment"
+                    )
+            value = oci_preflight(candidate_value)
+        else:
+            candidate = load(args.manifest)
+            checks = oci_preflight(candidate)
+            value = collect(candidate, preflight_results=checks)
+            write_new(args.output, value)
+            print(args.output)
+            return 0
+        output = getattr(args, "output", None)
+        if output:
+            write_new(output, value)
+        else:
+            sys.stdout.write(canonical(value))
+        return 0
+    except (ManifestError, OSError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1082,12 +1082,6 @@ def test_app_deploy_danielsmith_passes_image_tag(generic_app_stub_env: dict[str,
             ],
         ),
         (
-            "dspace",
-            "oci://ghcr.io/democratizedspace/charts/dspace",
-            "dspace",
-            ["docs/examples/dspace.values.dev.yaml", "docs/examples/dspace.values.staging.yaml"],
-        ),
-        (
             "jobbot3000",
             "oci://ghcr.io/futuroptimist/charts/jobbot3000",
             "jobbot3000",
@@ -1200,12 +1194,6 @@ def test_app_redeploy_prints_chart_pin_reminder_without_latest_lookup_or_pin_mut
     ("app", "release", "namespace", "chart"),
     [
         (
-            "dspace",
-            "dspace",
-            "dspace",
-            "oci://ghcr.io/democratizedspace/charts/dspace",
-        ),
-        (
             "tokenplace",
             "tokenplace",
             "tokenplace",
@@ -1292,13 +1280,9 @@ def test_dspace_oci_deploy_wrapper_propagates_inline_chart_pin(
 
     result = _run_just(["dspace-oci-deploy", "env=staging", "tag=main-deadbee"], env)
 
-    assert result.returncode == 0, result.stderr + result.stdout
-    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
-    assert (
-        "show chart oci://ghcr.io/democratizedspace/charts/dspace "
-        "--version 3.1.0-rc.1+build.5"
-    ) in helm_log
-    assert "--version ${SUGARKUBE_VERSION_FILE}" not in helm_log
+    assert result.returncode != 0
+    assert "require manifest=" in result.stderr
+    assert not Path(env["HELM_LOG"]).exists()
 
 
 @pytest.mark.usefixtures("ensure_just_available")
@@ -1307,7 +1291,6 @@ def test_dspace_oci_deploy_wrapper_propagates_inline_chart_pin(
     [
         ("danielsmith-oci-deploy", "danielsmith"),
         ("tokenplace-oci-deploy", "tokenplace"),
-        ("dspace-oci-deploy", "dspace"),
     ],
 )
 def test_existing_app_specific_deploy_wrappers_still_work(
@@ -1330,11 +1313,6 @@ def test_existing_app_specific_deploy_wrappers_still_work(
 @pytest.mark.parametrize(
     ("recipe", "image_heading", "check_heading"),
     [
-        (
-            "dspace-oci-promote-prod",
-            "Resolved deployment image(s):",
-            "Post-deploy verification commands",
-        ),
         (
             "tokenplace-oci-promote-prod",
             "Resolved images for deployment/tokenplace:",
@@ -2632,12 +2610,9 @@ def test_dspace_oci_deploy_wrapper_propagates_env_specific_chart_pin(
 
     result = _run_just(["dspace-oci-deploy", "env=staging", "tag=main-deadbee"], env)
 
-    assert result.returncode == 0, result.stderr + result.stdout
-    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
-    assert (
-        "show chart oci://ghcr.io/democratizedspace/charts/dspace "
-        "--version 3.1.0-rc.1+build.5"
-    ) in helm_log
+    assert result.returncode != 0
+    assert "require manifest=" in result.stderr
+    assert not Path(env["HELM_LOG"]).exists()
 
 
 def test_direct_helm_oci_helper_matching_env_succeeds(
@@ -2806,6 +2781,6 @@ def test_dspace_promote_prod_guard_mismatch_fails_before_helm(
     result = _run_just(["dspace-oci-promote-prod", "tag=main-deadbee"], env)
 
     assert result.returncode != 0
-    assert "requested env=prod" in result.stderr
+    assert "require manifest=" in result.stderr
     helm_log_path = Path(env["HELM_LOG"])
     assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -1,0 +1,187 @@
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "release_manifest", ROOT / "scripts/release_manifest.py"
+)
+rm = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(rm)
+
+SHA = "abcdef0123456789abcdef0123456789abcdef01"
+DIGEST = "sha256:" + "1" * 64
+CHART_DIGEST = "sha256:" + "2" * 64
+
+
+def upstream():
+    return {
+        "schemaVersion": 1,
+        "app": "dspace",
+        "applicationVersion": "3.1.0",
+        "sourceRevision": SHA,
+        "imageTag": "main-abcdef0",
+        "imageDigest": DIGEST,
+        "chartVersion": "3.2.1",
+        "chartDigest": CHART_DIGEST,
+        "semanticTag": "v3.1.0",
+    }
+
+
+def candidate():
+    return {
+        **upstream(),
+        "recordType": "candidate",
+        "environment": "staging",
+        "expectedDefaultChatProvider": "token-place",
+        "approvedAt": "2026-07-26T12:00:00Z",
+        "approvedBy": "synthetic-test-operator",
+    }
+
+
+def completed(args, stdout):
+    return subprocess.CompletedProcess(args, 0, json.dumps(stdout), "")
+
+
+def test_upstream_import_and_canonical_round_trip():
+    value = rm.validate_upstream(upstream())
+    assert json.loads(rm.canonical(value)) == value
+    assert rm.canonical(value) == rm.canonical(value)
+
+
+@pytest.mark.parametrize("change", [lambda x: x.pop("chartDigest"), lambda x: x.update(extra=True)])
+def test_missing_and_unknown_fields(change):
+    value = upstream()
+    change(value)
+    with pytest.raises(rm.ManifestError):
+        rm.validate_upstream(value)
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("sourceRevision", "abcdef0"),
+        ("sourceRevision", SHA.upper()),
+        ("imageTag", "latest"),
+        ("imageTag", "v3.1.0"),
+        ("imageTag", "main-deadbee"),
+        ("imageDigest", "sha256:no"),
+        ("chartDigest", DIGEST.upper()),
+        ("chartVersion", "v3.1.0"),
+    ],
+)
+def test_invalid_release_coordinates(key, value):
+    data = upstream()
+    data[key] = value
+    with pytest.raises(rm.ManifestError):
+        rm.validate_upstream(data)
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("environment", "production"),
+        ("expectedDefaultChatProvider", "tokenplace"),
+        ("approvedBy", ""),
+    ],
+)
+def test_invalid_approval(key, value):
+    data = candidate()
+    data[key] = value
+    with pytest.raises(rm.ManifestError):
+        rm.validate(data)
+
+
+def test_preflight_order_and_mismatches():
+    calls = []
+
+    def runner(args):
+        calls.append(args)
+        ref = args[-1]
+        digest = DIGEST if "/dspace:main-" in ref else CHART_DIGEST
+        value = (
+            {"digest": digest}
+            if "--descriptor" in args
+            else {"annotations": {"org.opencontainers.image.revision": SHA}}
+        )
+        return completed(args, value)
+
+    results = rm.oci_preflight(candidate(), runner)
+    assert [x[3] for x in calls] == [
+        "--descriptor",
+        "ghcr.io/democratizedspace/dspace:main-abcdef0",
+        "--descriptor",
+        "ghcr.io/democratizedspace/charts/dspace:3.2.1",
+    ]
+    assert len(results) == 2
+
+    def bad(args):
+        return completed(args, {"digest": "sha256:" + "9" * 64})
+
+    with pytest.raises(rm.ManifestError, match="digest mismatch"):
+        rm.oci_preflight(candidate(), bad)
+
+
+def test_source_metadata_mismatch():
+    def runner(args):
+        if "--descriptor" in args:
+            return completed(args, {"digest": DIGEST if "charts" not in args[-1] else CHART_DIGEST})
+        return completed(args, {"annotations": {"org.opencontainers.image.revision": "0" * 40}})
+
+    with pytest.raises(rm.ManifestError, match="source-revision"):
+        rm.oci_preflight(candidate(), runner)
+
+
+def test_multi_pod_collection_and_image_mismatch():
+    def runner(args):
+        if args[0] == "helm":
+            return completed(args, {"version": 17})
+        return completed(
+            args,
+            {
+                "items": [
+                    {
+                        "metadata": {"name": name},
+                        "status": {
+                            "containerStatuses": [
+                                {
+                                    "imageID": "ghcr.io/democratizedspace/dspace@" + DIGEST,
+                                    "state": {"running": {"startedAt": f"2026-07-26T12:00:0{i}Z"}},
+                                }
+                            ]
+                        },
+                    }
+                    for i, name in enumerate(["dspace-a", "dspace-b"])
+                ]
+            },
+        )
+
+    record = rm.collect(candidate(), runner)
+    assert record["helmRevision"] == 17
+    assert [p["name"] for p in record["pods"]] == ["dspace-a", "dspace-b"]
+    record["pods"][0]["imageID"] = "image@sha256:" + "9" * 64
+    with pytest.raises(rm.ManifestError, match="pod image ID"):
+        rm.validate(record, True)
+
+
+def test_atomic_output_and_overwrite_refusal(tmp_path):
+    path = tmp_path / "evidence" / "record.json"
+    rm.write_new(path, candidate())
+    assert json.loads(path.read_text()) == candidate()
+    assert not list(path.parent.glob(".*.json.*"))
+    with pytest.raises(rm.ManifestError, match="overwrite"):
+        rm.write_new(path, candidate())
+
+
+def test_records_exclude_tokens_and_secrets():
+    serialized = rm.canonical(candidate()).lower()
+    assert "token-place" in serialized
+    assert (
+        "password" not in serialized
+        and "credential" not in serialized
+        and "api_key" not in serialized
+    )


### PR DESCRIPTION
### Motivation

- The DSPACE production drift incident showed release coordinates (source SHA, immutable image, chart digests, approval, and runtime evidence) were not captured together as a durable, machine-readable record.  
- Operators must be able to approve an immutable candidate, preflight the exact OCI artifacts, and produce atomic post-deploy evidence so responders can reconstruct a deployment without relying on mutable tags.  
- Implement a minimal, stdlib-only consumer guard that validates and enriches the upstream DSPACE manifest and prevents Helm/Kubernetes mutations when evidence is absent or inconsistent.

### Description

- Add a canonical, deterministic CLI `scripts/release_manifest.py` with pure-stdlib Python subcommands: `import`, `candidate`, `validate`, `preflight`, and `finalize`; the tool strictly validates upstream manifests and emits atomic JSON records.  
- Enforce strict schema rules: full lowercase 40-char Git `sourceRevision`, `sha256:` digests for images/charts, strict SemVer for `chartVersion`, immutable branch-SHA `imageTag` whose 7-char suffix matches `sourceRevision`, `environment` ∈ {`staging`,`prod`}, exact provider spellings (`openai`, `token-place`), and approval metadata.  
- Add injectable, read-only OCI preflight (uses `oras` by default but executable is configurable) that verifies index descriptors, index digest equality, and `org.opencontainers.image.revision` annotations against the approved full SHA.  
- Integrate the guard into deployment flows: require `manifest=<approved-candidate.json>` for DSPACE in the generic `app-deploy`/`app-promote-prod` paths and the `dspace-oci-*` compatibility wrappers, run manifest validation + OCI preflight before Helm, and on success collect Helm revision, pod names/start times/imageIDs, verification results, and write an atomic finalized record under `deployment-evidence/dspace/` refusing overwrites and not auto-committing.

### Testing

- Unit and integration tests: `python3 -m pytest -q tests/test_release_manifest.py tests/test_generic_app_just_recipes.py` — 157 passed (includes new focused tests covering upstream import, malformed/missing fields, mutable-tag rejection, tag/SHA mismatch, OCI digest/revision mismatch, preflight failure, multi-pod evidence collection, pod image mismatch, atomic output and overwrite refusal, and secret exclusion).  
- Lint/docs checks performed where possible: `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` passed for the committed changes; `linkchecker --no-warnings README.md docs/` succeeded (201 links checked).  
- Repository-level pre-commit run attempted but environment lacked system dependencies (existing repository hooks reported unrelated YAML/flake8 issues outside this change and hooks auto-fixed whitespace in other files which were reverted); `pyspelling -c .spellcheck.yaml` could not complete due to missing `aspell` in the environment (documented limitation).  

Notes and operational limits

- No live cluster or production pins were changed and no approvals were fabricated; the tool only validates and records evidence locally (operators must generate/commit or attach the finalized record as part of promotion).  
- ORAS is used as an OCI-native fallback to avoid requiring GitHub Packages REST `read:packages` tokens; `SUGARKUBE_RELEASE_MANIFEST_ORAS` may be set to substitute the executable name.  

Files of interest (high level)

- Added: `scripts/release_manifest.py`, `tests/test_release_manifest.py`.  
- Modified: `justfile` (DSPACE deploy/promote paths now require `manifest=` and run validation/preflight/finalize), `docs/apps/dspace.md`, `docs/app_deployment_contract.md`, `tests/test_generic_app_just_recipes.py` (adjusted expectations for DSPACE deploy wrappers).  

Refs #2326

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a659e537de4832fbd7ae0bfad5e3a0f)