### PR TITLE
Add fail-closed DSPACE release-manifest evidence gate

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -204,15 +204,21 @@ roll back a release. Use `just cluster-env-detect` to inspect the current
 read-only identity. `app-chart-bump` remains cluster-independent because it only
 validates a public OCI chart and edits the repository pin.
 
+DSPACE is additionally gated in `staging` and `prod` by its approved release manifest. Generic
+and retained `dspace-oci-*` mutation paths require `manifest=<approved-candidate.json>`, compare
+the requested coordinates and OCI source metadata before Helm, and atomically collect finalized
+Helm and pod evidence. Unrelated apps are not gated. See the
+[DSPACE operator flow](apps/dspace.md#approved-release-manifest-and-deployment-evidence).
+
 ```bash
 # Deploy or install a specific immutable candidate into an environment.
-just app-deploy app=dspace env=staging tag=main-REPLACE_SHORTSHA
+just app-deploy app=dspace env=staging tag=main-REPLACE_SHORTSHA manifest=candidates/dspace-staging.json
 
 # Redeploy an existing release with a specific immutable tag.
-just app-redeploy app=dspace env=staging tag=main-REPLACE_SHORTSHA
+just app-redeploy app=dspace env=staging tag=main-REPLACE_SHORTSHA manifest=candidates/dspace-staging.json
 
 # Promote an approved immutable tag to production.
-just app-promote-prod app=dspace tag=main-REPLACE_SHORTSHA
+just app-promote-prod app=dspace tag=main-REPLACE_SHORTSHA manifest=candidates/dspace-prod.json
 
 # Inspect and intentionally bump the chart pin.
 just app-chart-status app=dspace

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -2,6 +2,79 @@
 
 This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugarkube. The generic `just app-*` recipes are the preferred future path. The `dspace-oci-*` recipes remain compatibility shims and are scheduled for later removal only after the generic flow has been exercised across routine releases.
 
+## Approved release manifest and deployment evidence
+
+DSPACE staging and production mutations are fail closed: an operator must supply an approved
+Sugarkube candidate, and its immutable image tag, chart version, environment, digests, and source
+revision must pass an OCI-native preflight before Helm or Kubernetes can mutate the cluster.
+`semanticTag` is retained for human evidence only and is never passed to Helm. Other applications
+are not gated until they adopt an explicit compatible contract.
+
+1. Download the `dspace-release-manifest/dspace-release-manifest.json` artifact from the successful
+   upstream DSPACE release workflow. Keep the downloaded producer file unchanged.
+2. Generate, inspect, and validate a staging candidate. Use the existing DSPACE provider spelling
+   `openai`; approval timestamps are UTC RFC 3339 values and the approver must be attributable.
+
+   ```bash
+   python3 scripts/release_manifest.py candidate upstream.json \
+     --environment staging --provider openai \
+     --approved-at 2026-07-26T12:00:00Z --approved-by OPERATOR \
+     --output candidates/dspace-staging.json
+   python3 scripts/release_manifest.py validate candidates/dspace-staging.json
+   ```
+
+3. Deploy the exact candidate coordinates. Both generic and compatibility paths use the same
+   guard. `skopeo inspect` resolves the image-index digest and revision label, while `oras manifest
+   fetch --descriptor` resolves the chart OCI digest and revision annotation directly from GHCR.
+   This is the OCI-native fallback when the GitHub Packages REST API is unavailable; it needs no
+   ad hoc `read:packages` token for public artifacts.
+
+   ```bash
+   just app-deploy app=dspace env=staging tag=main-abcdef0 \
+     manifest=candidates/dspace-staging.json
+   # Compatibility equivalent:
+   just dspace-oci-deploy env=staging tag=main-abcdef0 \
+     manifest=candidates/dspace-staging.json
+   ```
+
+   After rollout waits succeed, the recipe reads Helm status and every running pod, proves each
+   resolved image ID equals the approved digest, and atomically creates
+   `deployment-evidence/dspace/staging/<full-source-sha>.json`. Existing records are never
+   overwritten. Runtime identity is recorded using
+   `oci-artifact-revision-and-all-pod-image-digests`: it means the exact OCI artifact's revision
+   metadata matched the approved full SHA and all pods resolved to its approved digest. It does
+   **not** claim an HTTP build-identity check.
+4. Inspect and preserve the finalized staging record. Add it to the reviewed promotion change or
+   attach it to the promotion record; the tool never commits automatically.
+
+   ```bash
+   python3 scripts/release_manifest.py validate --final \
+     deployment-evidence/dspace/staging/FULL_SOURCE_SHA.json
+   git add deployment-evidence/dspace/staging/FULL_SOURCE_SHA.json
+   ```
+
+5. Generate a new approved production candidate from the **same unchanged upstream manifest**,
+   changing only deployment environment and approval fields. Validate it, then promote:
+
+   ```bash
+   python3 scripts/release_manifest.py candidate upstream.json \
+     --environment prod --provider openai \
+     --approved-at 2026-07-26T13:00:00Z --approved-by OPERATOR \
+     --output candidates/dspace-prod.json
+   just app-promote-prod app=dspace tag=main-abcdef0 \
+     manifest=candidates/dspace-prod.json
+   python3 scripts/release_manifest.py validate --final \
+     deployment-evidence/dspace/prod/FULL_SOURCE_SHA.json
+   git add deployment-evidence/dspace/prod/FULL_SOURCE_SHA.json
+   ```
+
+To reconstruct a deployment during an incident, read its finalized JSON record and use
+`imageTag@imageDigest` plus chart `chartVersion@chartDigest`. Confirm the recorded full
+`sourceRevision`, pod image IDs, Helm revision, and approval; do not resolve `latest`, a branch,
+an environment tag, or the semantic evidence tag. Synthetic examples above are placeholders, not
+real approval evidence. Genuine staging and production records remain the operational follow-up
+tracked by issue #2326.
+
 ## Artifact model
 
 - App repository responsibilities: build `ghcr.io/democratizedspace/dspace`, publish immutable image tags, maintain the Helm chart, and publish immutable chart versions to `oci://ghcr.io/democratizedspace/charts/dspace`.

--- a/justfile
+++ b/justfile
@@ -1606,7 +1606,7 @@ app-config app env='staging' config='':
       --config {{ quote(config) }}
 
 # Generic immutable-tag app deploy backed by docs/examples/apps/*.env or local app configs.
-app-deploy app env='staging' tag='' config='':
+app-deploy app env='staging' tag='' config='' manifest='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1616,6 +1616,19 @@ app-deploy app env='staging' tag='' config='':
       --config {{ quote(config) }} \
       --tag {{ quote(tag) }} \
       --require-tag)"
+
+    if [ "${SUGARKUBE_APP}" = "dspace" ] && [ "${SUGARKUBE_ENV}" != "dev" ]; then
+      approved_manifest={{ quote(manifest) }}
+      : "${approved_manifest:=${SUGARKUBE_DSPACE_RELEASE_MANIFEST:-}}"
+      if [ -z "${approved_manifest}" ]; then
+        echo "ERROR: DSPACE ${SUGARKUBE_ENV} deployment requires manifest=<approved-candidate.json>." >&2
+        exit 1
+      fi
+      chart_version="${SUGARKUBE_VERSION:-}"
+      if [ -z "${chart_version}" ]; then chart_version="$(sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -n1 | xargs)"; fi
+      python3 "{{ justfile_directory() }}/scripts/release_manifest.py" preflight "${approved_manifest}" \
+        --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}"
+    fi
 
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
@@ -1639,9 +1652,15 @@ app-deploy app env='staging' tag='' config='':
       version_file="${SUGARKUBE_VERSION_FILE:-}" \
       tag="${SUGARKUBE_TAG}" \
       env="${SUGARKUBE_ENV}"
+    if [ "${SUGARKUBE_APP}" = "dspace" ] && [ "${SUGARKUBE_ENV}" != "dev" ]; then
+      source_revision="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["sourceRevision"])' "${approved_manifest}")"
+      record="${SUGARKUBE_DSPACE_EVIDENCE_OUTPUT:-deployment-evidence/dspace/${SUGARKUBE_ENV}/${source_revision}.json}"
+      python3 "{{ justfile_directory() }}/scripts/release_manifest.py" collect "${approved_manifest}" --output "${record}" --namespace "${SUGARKUBE_NAMESPACE}" --release "${SUGARKUBE_RELEASE}"
+      echo "Finalized deployment evidence: ${record}"
+    fi
 
 # Generic upgrade-only app redeploy backed by app config files.
-app-redeploy app env='staging' tag='' config='':
+app-redeploy app env='staging' tag='' config='' manifest='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1651,6 +1670,14 @@ app-redeploy app env='staging' tag='' config='':
       --config {{ quote(config) }} \
       --tag {{ quote(tag) }} \
       --require-tag)"
+
+    if [ "${SUGARKUBE_APP}" = "dspace" ] && [ "${SUGARKUBE_ENV}" != "dev" ]; then
+      approved_manifest={{ quote(manifest) }}
+      : "${approved_manifest:=${SUGARKUBE_DSPACE_RELEASE_MANIFEST:-}}"
+      if [ -z "${approved_manifest}" ]; then echo "ERROR: DSPACE ${SUGARKUBE_ENV} redeployment requires manifest=<approved-candidate.json>." >&2; exit 1; fi
+      chart_version="${SUGARKUBE_VERSION:-}"; if [ -z "${chart_version}" ]; then chart_version="$(sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -n1 | xargs)"; fi
+      python3 "{{ justfile_directory() }}/scripts/release_manifest.py" preflight "${approved_manifest}" --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}"
+    fi
 
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
@@ -1676,7 +1703,7 @@ app-redeploy app env='staging' tag='' config='':
       env="${SUGARKUBE_ENV}"
 
 # Promote an app to prod with an explicit immutable tag, or the configured prod tag file.
-app-promote-prod app tag='' config='':
+app-promote-prod app tag='' config='' manifest='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1687,6 +1714,8 @@ app-promote-prod app tag='' config='':
       --tag {{ quote(tag) }} \
       --prod-tag-fallback \
       --require-tag)"
+    promote_manifest={{ quote(manifest) }}
+    if [ -n "${promote_manifest}" ]; then export SUGARKUBE_DSPACE_RELEASE_MANIFEST="${promote_manifest}"; fi
     just --justfile "{{ justfile_directory() }}/justfile" app-deploy \
       app="${SUGARKUBE_APP}" \
       env=prod \
@@ -1816,7 +1845,7 @@ app-cors-verify app env='staging' config='' origin='https://cors-smoke.invalid' 
 #
 
 # Use this for steady-state release validation flows where explicit image pinning matters.
-dspace-oci-deploy env='staging' tag='':
+dspace-oci-deploy env='staging' tag='' manifest='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1875,6 +1904,12 @@ dspace-oci-deploy env='staging' tag='':
     fi
     export SUGARKUBE_ENV="${env_name}"
     eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell --app dspace --env "${env_name}")"
+    if [ "${env_name}" != "dev" ]; then
+      approved_manifest={{ quote(manifest) }}; : "${approved_manifest:=${SUGARKUBE_DSPACE_RELEASE_MANIFEST:-}}"
+      if [ -z "${approved_manifest}" ]; then echo "ERROR: DSPACE ${env_name} deployment requires manifest=<approved-candidate.json>." >&2; exit 1; fi
+      chart_version="${SUGARKUBE_VERSION:-}"; if [ -z "${chart_version}" ]; then chart_version="$(sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -n1 | xargs)"; fi
+      python3 "{{ justfile_directory() }}/scripts/release_manifest.py" preflight "${approved_manifest}" --environment "${env_name}" --image-tag "${deploy_tag}" --chart-version "${chart_version}"
+    fi
     just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "${env_name}" "${KUBECONFIG}" >/dev/null
 
     just --justfile "{{ justfile_directory() }}/justfile" helm-oci-install \
@@ -1885,6 +1920,12 @@ dspace-oci-deploy env='staging' tag='':
       version_file="${SUGARKUBE_VERSION_FILE:-}" \
       tag="${deploy_tag}" \
       env="${env_name}"
+    if [ "${env_name}" != "dev" ]; then
+      source_revision="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["sourceRevision"])' "${approved_manifest}")"
+      record="${SUGARKUBE_DSPACE_EVIDENCE_OUTPUT:-deployment-evidence/dspace/${env_name}/${source_revision}.json}"
+      python3 "{{ justfile_directory() }}/scripts/release_manifest.py" collect "${approved_manifest}" --output "${record}"
+      echo "Finalized deployment evidence: ${record}"
+    fi
 
     echo "Resolved deployment image(s):"
     kubectl -n dspace get deploy dspace \
@@ -1965,7 +2006,7 @@ dspace-oci-deploy-prod-subdomain tag='':
 # Promote dspace to production apex (democratized.space) using immutable tags.
 
 # If tag is omitted, this reads the pinned value from docs/apps/dspace.prod.tag.
-dspace-oci-promote-prod tag='':
+dspace-oci-promote-prod tag='' manifest='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1975,6 +2016,8 @@ dspace-oci-promote-prod tag='':
       --tag {{ quote(tag) }} \
       --prod-tag-fallback \
       --require-tag)"
+    promote_manifest={{ quote(manifest) }}
+    if [ -n "${promote_manifest}" ]; then export SUGARKUBE_DSPACE_RELEASE_MANIFEST="${promote_manifest}"; fi
     just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy env=prod tag="${SUGARKUBE_TAG}"
 
 # Fast redeploy of dspace from GHCR (emergency mutable-tag refresh).

--- a/scripts/release_manifest.py
+++ b/scripts/release_manifest.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""Validate and enrich DSPACE release manifests without third-party packages."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Callable
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+SEMVER_RE = re.compile(
+    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+TAG_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*-([0-9a-f]{7})$")
+TIME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
+
+UPSTREAM_FIELDS = (
+    "schemaVersion",
+    "app",
+    "applicationVersion",
+    "sourceRevision",
+    "imageTag",
+    "imageDigest",
+    "chartVersion",
+    "chartDigest",
+    "semanticTag",
+)
+CANDIDATE_FIELDS = UPSTREAM_FIELDS + (
+    "environment",
+    "expectedDefaultChatProvider",
+    "approvedAt",
+    "approvedBy",
+)
+FINAL_FIELDS = CANDIDATE_FIELDS + (
+    "helmRevision",
+    "pods",
+    "runtimeSourceRevision",
+    "runtimeSourceRevisionMethod",
+    "verificationResults",
+)
+PROVIDERS = {"openai"}  # Existing DSPACE configuration contract spelling.
+RUNTIME_METHOD = "oci-artifact-revision-and-all-pod-image-digests"
+
+
+class ManifestError(ValueError):
+    """A release record is absent, non-canonical, or internally inconsistent."""
+
+
+def _object(value: Any, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ManifestError(f"{name} must be a JSON object")
+    return value
+
+
+def _exact(data: dict[str, Any], fields: tuple[str, ...]) -> None:
+    missing = sorted(set(fields) - set(data))
+    unknown = sorted(set(data) - set(fields))
+    if missing or unknown:
+        parts = []
+        if missing:
+            parts.append("missing fields: " + ", ".join(missing))
+        if unknown:
+            parts.append("unknown fields: " + ", ".join(unknown))
+        raise ManifestError("; ".join(parts))
+
+
+def validate(data: dict[str, Any], finalized: bool | None = None) -> dict[str, Any]:
+    """Return *data* after strict schema and cross-field validation."""
+    data = _object(data, "manifest")
+    if finalized is None:
+        finalized = "helmRevision" in data
+    fields = FINAL_FIELDS if finalized else CANDIDATE_FIELDS
+    _exact(data, fields)
+    if data["schemaVersion"] != 1 or data["app"] != "dspace":
+        raise ManifestError("schemaVersion must be 1 and app must be 'dspace'")
+    for field in fields:
+        if field not in {
+            "schemaVersion",
+            "helmRevision",
+            "pods",
+            "verificationResults",
+        } and not isinstance(data[field], str):
+            raise ManifestError(f"{field} must be a string")
+    if not SEMVER_RE.fullmatch(data["applicationVersion"]):
+        raise ManifestError("applicationVersion must be strict SemVer")
+    if not SHA_RE.fullmatch(data["sourceRevision"]):
+        raise ManifestError("sourceRevision must be a full lowercase Git SHA")
+    tag = TAG_RE.fullmatch(data["imageTag"])
+    if not tag or tag.group(1) != data["sourceRevision"][:7]:
+        raise ManifestError("imageTag must be an immutable branch-SHA tag matching sourceRevision")
+    if data["imageTag"].startswith(("latest-", "staging-", "prod-", "production-")):
+        raise ManifestError("imageTag must not be a mutable or environment coordinate")
+    for field in ("imageDigest", "chartDigest"):
+        if not DIGEST_RE.fullmatch(data[field]):
+            raise ManifestError(f"{field} must be a lowercase sha256 digest")
+    if not SEMVER_RE.fullmatch(data["chartVersion"]):
+        raise ManifestError("chartVersion must be strict SemVer")
+    if data["semanticTag"] and not SEMVER_RE.fullmatch(data["semanticTag"].removeprefix("v")):
+        raise ManifestError("semanticTag must be empty or a semantic evidence tag")
+    if data["environment"] not in {"staging", "prod"}:
+        raise ManifestError("environment must be staging or prod")
+    if data["expectedDefaultChatProvider"] not in PROVIDERS:
+        raise ManifestError("expectedDefaultChatProvider must be openai")
+    if not TIME_RE.fullmatch(data["approvedAt"]):
+        raise ManifestError("approvedAt must be a UTC RFC3339 timestamp")
+    if not data["approvedBy"].strip():
+        raise ManifestError("approvedBy must identify the approving operator")
+    if finalized:
+        if (
+            not isinstance(data["helmRevision"], int)
+            or isinstance(data["helmRevision"], bool)
+            or data["helmRevision"] < 1
+        ):
+            raise ManifestError("helmRevision must be a positive integer")
+        pods = data["pods"]
+        if not isinstance(pods, list) or not pods:
+            raise ManifestError("pods must be a non-empty array")
+        names: set[str] = set()
+        for pod in pods:
+            pod = _object(pod, "pod")
+            _exact(pod, ("name", "startTime", "imageID"))
+            if not all(isinstance(pod[k], str) and pod[k] for k in pod):
+                raise ManifestError("pod evidence values must be non-empty strings")
+            if pod["name"] in names or not TIME_RE.fullmatch(pod["startTime"]):
+                raise ManifestError("pod names must be unique and startTime must be UTC RFC3339")
+            names.add(pod["name"])
+            digest = pod["imageID"].rsplit("@", 1)[-1]
+            if digest != data["imageDigest"]:
+                raise ManifestError("every pod imageID must equal the approved imageDigest")
+        if data["runtimeSourceRevision"] != data["sourceRevision"]:
+            raise ManifestError("runtimeSourceRevision must equal the approved sourceRevision")
+        if data["runtimeSourceRevisionMethod"] != RUNTIME_METHOD:
+            raise ManifestError("unsupported runtimeSourceRevisionMethod")
+        results = data["verificationResults"]
+        if not isinstance(results, list) or not results:
+            raise ManifestError("verificationResults must be a non-empty array")
+        for result in results:
+            result = _object(result, "verification result")
+            _exact(result, ("name", "passed", "details"))
+            if (
+                not isinstance(result["name"], str)
+                or not result["name"]
+                or not isinstance(result["passed"], bool)
+                or not isinstance(result["details"], str)
+            ):
+                raise ManifestError("invalid structured verification result")
+            if not result["passed"]:
+                raise ManifestError(f"verification failed: {result['name']}")
+    return data
+
+
+def load(path: str | Path) -> dict[str, Any]:
+    try:
+        return _object(json.loads(Path(path).read_text(encoding="utf-8")), "manifest")
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ManifestError(f"cannot read JSON manifest {path}: {exc}") from exc
+
+
+def canonical(data: dict[str, Any]) -> str:
+    return json.dumps(data, ensure_ascii=True, indent=2, separators=(",", ": ")) + "\n"
+
+
+def candidate(
+    upstream: dict[str, Any], environment: str, provider: str, approved_at: str, approved_by: str
+) -> dict[str, Any]:
+    _exact(upstream, UPSTREAM_FIELDS)
+    result = {field: upstream[field] for field in UPSTREAM_FIELDS}
+    result.update(
+        environment=environment,
+        expectedDefaultChatProvider=provider,
+        approvedAt=approved_at,
+        approvedBy=approved_by,
+    )
+    return validate(result, False)
+
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _run_json(command: list[str], runner: Runner = subprocess.run) -> dict[str, Any]:
+    completed = runner(command, capture_output=True, text=True, check=False)
+    if completed.returncode:
+        raise ManifestError(
+            f"read-only OCI command failed: {' '.join(command)}: {completed.stderr.strip()}"
+        )
+    try:
+        return _object(json.loads(completed.stdout), "OCI command output")
+    except json.JSONDecodeError as exc:
+        raise ManifestError("OCI command did not return JSON") from exc
+
+
+def preflight(
+    data: dict[str, Any],
+    image: str,
+    chart: str,
+    runner: Runner = subprocess.run,
+    environment: str = "",
+    image_tag: str = "",
+    chart_version: str = "",
+) -> None:
+    """Read OCI evidence with skopeo/oras and compare it before cluster mutation."""
+    validate(data, False)
+    for actual, expected, name in (
+        (data["environment"], environment, "environment"),
+        (data["imageTag"], image_tag, "image tag"),
+        (data["chartVersion"], chart_version, "chart version"),
+    ):
+        if expected and actual != expected:
+            raise ManifestError(f"approved {name} {actual!r} does not match requested {expected!r}")
+    image_info = _run_json(["skopeo", "inspect", f"docker://{image}:{data['imageTag']}"], runner)
+    if image_info.get("Digest") != data["imageDigest"]:
+        raise ManifestError("image digest mismatch")
+    labels = image_info.get("Labels") or {}
+    revision = labels.get("org.opencontainers.image.revision")
+    if revision != data["sourceRevision"]:
+        raise ManifestError("image source-revision metadata mismatch")
+    descriptor = _run_json(
+        ["oras", "manifest", "fetch", "--descriptor", f"{chart}:{data['chartVersion']}"], runner
+    )
+    if descriptor.get("digest") != data["chartDigest"]:
+        raise ManifestError("chart digest mismatch")
+    annotations = descriptor.get("annotations") or {}
+    revision = annotations.get("org.opencontainers.image.revision") or annotations.get(
+        "org.opencontainers.artifact.revision"
+    )
+    if revision != data["sourceRevision"]:
+        raise ManifestError("chart source-revision metadata mismatch")
+
+
+def finalize(
+    data: dict[str, Any],
+    helm: dict[str, Any],
+    pod_list: dict[str, Any],
+    results: list[dict[str, Any]],
+    oci_revision: str,
+) -> dict[str, Any]:
+    validate(data, False)
+    if oci_revision != data["sourceRevision"]:
+        raise ManifestError("OCI artifact revision does not equal approved sourceRevision")
+    pods = []
+    for item in pod_list.get("items", []):
+        statuses = item.get("status", {}).get("containerStatuses", [])
+        if not statuses:
+            raise ManifestError("running pod lacks resolved container image evidence")
+        for status in statuses:
+            pods.append(
+                {
+                    "name": item["metadata"]["name"],
+                    "startTime": item["status"]["startTime"],
+                    "imageID": status.get("imageID", ""),
+                }
+            )
+    out = dict(data)
+    out.update(
+        helmRevision=int(helm["version"]),
+        pods=pods,
+        runtimeSourceRevision=data["sourceRevision"],
+        runtimeSourceRevisionMethod=RUNTIME_METHOD,
+        verificationResults=results,
+    )
+    return validate(out, True)
+
+
+def write_atomic(path: str | Path, data: dict[str, Any]) -> None:
+    target = Path(path)
+    if target.exists():
+        raise ManifestError(f"refusing to overwrite existing record: {target}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent, text=True)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(canonical(data))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.link(temporary, target)
+    except FileExistsError as exc:
+        raise ManifestError(f"refusing to overwrite existing record: {target}") from exc
+    finally:
+        Path(temporary).unlink(missing_ok=True)
+
+
+def collect(
+    candidate_path: str,
+    output: str,
+    namespace: str = "dspace",
+    release: str = "dspace",
+    runner: Runner = subprocess.run,
+) -> dict[str, Any]:
+    """Collect read-only Helm/pod state and persist a finalized deployment record."""
+    data = load(candidate_path)
+    helm = _run_json(
+        ["helm", "status", release, "--namespace", namespace, "--output", "json"], runner
+    )
+    pods = _run_json(
+        [
+            "kubectl",
+            "--namespace",
+            namespace,
+            "get",
+            "pods",
+            "-l",
+            f"app.kubernetes.io/instance={release}",
+            "--output",
+            "json",
+        ],
+        runner,
+    )
+    result = finalize(
+        data,
+        helm,
+        pods,
+        [
+            {
+                "name": "ociPreflight",
+                "passed": True,
+                "details": (
+                    "approved image and chart digest/revision metadata matched before mutation"
+                ),
+            },
+            {
+                "name": "helmRollout",
+                "passed": True,
+                "details": "Helm deployment command and rollout waits completed",
+            },
+            {
+                "name": "podImageDigests",
+                "passed": True,
+                "details": "all resolved running pod image IDs match the approved digest",
+            },
+        ],
+        data["sourceRevision"],
+    )
+    write_atomic(output, result)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    make = sub.add_parser("candidate")
+    make.add_argument("upstream")
+    make.add_argument("--environment", required=True)
+    make.add_argument("--provider", default="openai")
+    make.add_argument("--approved-at", required=True)
+    make.add_argument("--approved-by", required=True)
+    make.add_argument("--output", required=True)
+    check = sub.add_parser("validate")
+    check.add_argument("manifest")
+    check.add_argument("--final", action="store_true")
+    pre = sub.add_parser("preflight")
+    pre.add_argument("manifest")
+    pre.add_argument("--image", default="ghcr.io/democratizedspace/dspace")
+    pre.add_argument("--chart", default="ghcr.io/democratizedspace/charts/dspace")
+    pre.add_argument("--environment", default="")
+    pre.add_argument("--image-tag", default="")
+    pre.add_argument("--chart-version", default="")
+    fin = sub.add_parser("finalize")
+    fin.add_argument("manifest")
+    fin.add_argument("--helm-json", required=True)
+    fin.add_argument("--pods-json", required=True)
+    fin.add_argument("--verification-json", required=True)
+    fin.add_argument("--oci-revision", required=True)
+    fin.add_argument("--output", required=True)
+    gather = sub.add_parser("collect")
+    gather.add_argument("manifest")
+    gather.add_argument("--output", required=True)
+    gather.add_argument("--namespace", default="dspace")
+    gather.add_argument("--release", default="dspace")
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "candidate":
+            write_atomic(
+                args.output,
+                candidate(
+                    load(args.upstream),
+                    args.environment,
+                    args.provider,
+                    args.approved_at,
+                    args.approved_by,
+                ),
+            )
+        elif args.command == "validate":
+            validate(load(args.manifest), args.final)
+        elif args.command == "preflight":
+            preflight(
+                load(args.manifest),
+                args.image,
+                args.chart,
+                environment=args.environment,
+                image_tag=args.image_tag,
+                chart_version=args.chart_version,
+            )
+        elif args.command == "finalize":
+            write_atomic(
+                args.output,
+                finalize(
+                    load(args.manifest),
+                    load(args.helm_json),
+                    load(args.pods_json),
+                    json.loads(Path(args.verification_json).read_text()),
+                    args.oci_revision,
+                ),
+            )
+        else:
+            collect(args.manifest, args.output, args.namespace, args.release)
+    except (ManifestError, KeyError, TypeError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1082,12 +1082,6 @@ def test_app_deploy_danielsmith_passes_image_tag(generic_app_stub_env: dict[str,
             ],
         ),
         (
-            "dspace",
-            "oci://ghcr.io/democratizedspace/charts/dspace",
-            "dspace",
-            ["docs/examples/dspace.values.dev.yaml", "docs/examples/dspace.values.staging.yaml"],
-        ),
-        (
             "jobbot3000",
             "oci://ghcr.io/futuroptimist/charts/jobbot3000",
             "jobbot3000",
@@ -1200,12 +1194,6 @@ def test_app_redeploy_prints_chart_pin_reminder_without_latest_lookup_or_pin_mut
     ("app", "release", "namespace", "chart"),
     [
         (
-            "dspace",
-            "dspace",
-            "dspace",
-            "oci://ghcr.io/democratizedspace/charts/dspace",
-        ),
-        (
             "tokenplace",
             "tokenplace",
             "tokenplace",
@@ -1292,13 +1280,9 @@ def test_dspace_oci_deploy_wrapper_propagates_inline_chart_pin(
 
     result = _run_just(["dspace-oci-deploy", "env=staging", "tag=main-deadbee"], env)
 
-    assert result.returncode == 0, result.stderr + result.stdout
-    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
-    assert (
-        "show chart oci://ghcr.io/democratizedspace/charts/dspace "
-        "--version 3.1.0-rc.1+build.5"
-    ) in helm_log
-    assert "--version ${SUGARKUBE_VERSION_FILE}" not in helm_log
+    assert result.returncode != 0
+    assert "requires manifest=" in result.stderr
+    assert not Path(env["HELM_LOG"]).exists()
 
 
 @pytest.mark.usefixtures("ensure_just_available")
@@ -1307,7 +1291,6 @@ def test_dspace_oci_deploy_wrapper_propagates_inline_chart_pin(
     [
         ("danielsmith-oci-deploy", "danielsmith"),
         ("tokenplace-oci-deploy", "tokenplace"),
-        ("dspace-oci-deploy", "dspace"),
     ],
 )
 def test_existing_app_specific_deploy_wrappers_still_work(
@@ -1330,11 +1313,6 @@ def test_existing_app_specific_deploy_wrappers_still_work(
 @pytest.mark.parametrize(
     ("recipe", "image_heading", "check_heading"),
     [
-        (
-            "dspace-oci-promote-prod",
-            "Resolved deployment image(s):",
-            "Post-deploy verification commands",
-        ),
         (
             "tokenplace-oci-promote-prod",
             "Resolved images for deployment/tokenplace:",
@@ -2632,12 +2610,9 @@ def test_dspace_oci_deploy_wrapper_propagates_env_specific_chart_pin(
 
     result = _run_just(["dspace-oci-deploy", "env=staging", "tag=main-deadbee"], env)
 
-    assert result.returncode == 0, result.stderr + result.stdout
-    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
-    assert (
-        "show chart oci://ghcr.io/democratizedspace/charts/dspace "
-        "--version 3.1.0-rc.1+build.5"
-    ) in helm_log
+    assert result.returncode != 0
+    assert "requires manifest=" in result.stderr
+    assert not Path(env["HELM_LOG"]).exists()
 
 
 def test_direct_helm_oci_helper_matching_env_succeeds(
@@ -2806,6 +2781,6 @@ def test_dspace_promote_prod_guard_mismatch_fails_before_helm(
     result = _run_just(["dspace-oci-promote-prod", "tag=main-deadbee"], env)
 
     assert result.returncode != 0
-    assert "requested env=prod" in result.stderr
+    assert "requires manifest=" in result.stderr
     helm_log_path = Path(env["HELM_LOG"])
     assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import release_manifest as manifest
+
+SHA = "abcdef0123456789abcdef0123456789abcdef01"
+DIGEST = "sha256:" + "1" * 64
+CHART_DIGEST = "sha256:" + "2" * 64
+
+
+def upstream() -> dict[str, object]:
+    return {
+        "schemaVersion": 1,
+        "app": "dspace",
+        "applicationVersion": "3.2.0",
+        "sourceRevision": SHA,
+        "imageTag": "main-abcdef0",
+        "imageDigest": DIGEST,
+        "chartVersion": "3.2.1",
+        "chartDigest": CHART_DIGEST,
+        "semanticTag": "v3.2.0",
+    }
+
+
+def approved() -> dict[str, object]:
+    return manifest.candidate(
+        upstream(), "staging", "openai", "2026-07-26T12:00:00Z", "operator@example.test"
+    )
+
+
+def test_valid_import_has_canonical_round_trip() -> None:
+    candidate = approved()
+    assert json.loads(manifest.canonical(candidate)) == candidate
+    assert manifest.canonical(candidate).endswith("\n")
+
+
+@pytest.mark.parametrize("change", [{"extra": True}, {"sourceRevision": None}])
+def test_unknown_and_missing_or_malformed_fields_fail(change: dict[str, object]) -> None:
+    value = approved()
+    if change["sourceRevision"] is None if "sourceRevision" in change else False:
+        value.pop("sourceRevision")
+    else:
+        value.update(change)
+    with pytest.raises(manifest.ManifestError):
+        manifest.validate(value)
+
+
+@pytest.mark.parametrize("tag", ["latest", "main", "v3.2.0", "staging-abcdef0", "main-deadbee"])
+def test_mutable_semantic_environment_and_mismatched_tags_fail(tag: str) -> None:
+    value = approved()
+    value["imageTag"] = tag
+    with pytest.raises(manifest.ManifestError, match="imageTag"):
+        manifest.validate(value)
+
+
+def test_wrong_environment_provider_and_approver_fail() -> None:
+    for key, value in (
+        ("environment", "dev"),
+        ("expectedDefaultChatProvider", "tokenplace"),
+        ("approvedBy", ""),
+    ):
+        candidate = approved()
+        candidate[key] = value
+        with pytest.raises(manifest.ManifestError):
+            manifest.validate(candidate)
+
+
+def runner_for(image_digest: str = DIGEST, revision: str = SHA, chart_digest: str = CHART_DIGEST):
+    calls: list[list[str]] = []
+
+    def run(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        payload = (
+            {"Digest": image_digest, "Labels": {"org.opencontainers.image.revision": revision}}
+            if command[0] == "skopeo"
+            else {
+                "digest": chart_digest,
+                "annotations": {"org.opencontainers.image.revision": revision},
+            }
+        )
+        return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+
+    return calls, run
+
+
+def test_preflight_success_order_and_mismatches() -> None:
+    calls, runner = runner_for()
+    manifest.preflight(approved(), "example/dspace", "example/charts/dspace", runner)
+    assert [call[0] for call in calls] == ["skopeo", "oras"]
+    for kwargs, message in (
+        ({"image_digest": "sha256:" + "9" * 64}, "image digest"),
+        ({"chart_digest": "sha256:" + "9" * 64}, "chart digest"),
+        ({"revision": "0" * 40}, "source-revision"),
+    ):
+        _, bad_runner = runner_for(**kwargs)
+        with pytest.raises(manifest.ManifestError, match=message):
+            manifest.preflight(approved(), "image", "chart", bad_runner)
+
+
+def test_multi_pod_finalize_and_image_mismatch() -> None:
+    pods = {
+        "items": [
+            {
+                "metadata": {"name": "dspace-a"},
+                "status": {
+                    "startTime": "2026-07-26T12:01:00Z",
+                    "containerStatuses": [{"imageID": "ghcr.io/example/dspace@" + DIGEST}],
+                },
+            },
+            {
+                "metadata": {"name": "dspace-b"},
+                "status": {
+                    "startTime": "2026-07-26T12:02:00Z",
+                    "containerStatuses": [{"imageID": "ghcr.io/example/dspace@" + DIGEST}],
+                },
+            },
+        ]
+    }
+    final = manifest.finalize(
+        approved(),
+        {"version": 7},
+        pods,
+        [{"name": "rollout", "passed": True, "details": "complete"}],
+        SHA,
+    )
+    assert [pod["name"] for pod in final["pods"]] == ["dspace-a", "dspace-b"]
+    pods["items"][1]["status"]["containerStatuses"][0]["imageID"] = "image@sha256:" + "9" * 64
+    with pytest.raises(manifest.ManifestError, match="pod imageID"):
+        manifest.finalize(
+            approved(),
+            {"version": 7},
+            pods,
+            [{"name": "rollout", "passed": True, "details": "complete"}],
+            SHA,
+        )
+
+
+def test_atomic_write_refuses_overwrite_and_contains_no_token(tmp_path: Path) -> None:
+    output = tmp_path / "record.json"
+    manifest.write_atomic(output, approved())
+    assert "token" not in output.read_text(encoding="utf-8").lower()
+    with pytest.raises(manifest.ManifestError, match="overwrite"):
+        manifest.write_atomic(output, approved())


### PR DESCRIPTION
### Motivation

- Prevent production promotion/version-drift regressions by requiring a validated, machine-readable upstream release manifest and fail-closed OCI preflight for DSPACE staging approval and production promotion.
- Preserve immutable release coordinates, approval data, and post-deploy evidence so responders can reconstruct a deployed release without resolving mutable tags or relying on ad hoc package API tokens. Refs #2326.

### Description

- Add a stdlib-only CLI `scripts/release_manifest.py` that imports upstream DSPACE manifests, generates canonical staging/production candidates, validates candidate and finalized-record schemas, performs injectable read-only OCI preflight checks (`skopeo inspect` and `oras manifest fetch --descriptor`), finalizes Helm/pod evidence, and atomically writes non-overwritable JSON evidence. Key validations include full 40-char lowercase `sourceRevision`, `sha256:` digests, strict SemVer for `applicationVersion`/`chartVersion`, immutable branch-SHA `imageTag` whose 7-char suffix matches `sourceRevision`, `environment` ∈ {`staging`,`prod`}, and `expectedDefaultChatProvider` == `openai`.
- Integrate the guard into shared DSPACE paths by requiring an `--manifest` candidate (or `SUGARKUBE_DSPACE_RELEASE_MANIFEST`) for `app-deploy`/`app-redeploy`/`app-promote-prod` and the retained `dspace-oci-*` wrappers, running `release_manifest.py preflight` before Helm/kubectl mutation and `release_manifest.py collect` after successful rollout to produce `deployment-evidence/dspace/<env>/<full-source-sha>.json` atomically (refuse overwrite).
- Add deterministic unit tests `tests/test_release_manifest.py` covering canonical round-trip, missing/unknown fields, malformed SHAs/tags/digests, mutable/semantic tag rejection, preflight mismatches (image/chart revision/digest), multi-pod evidence collection and pod image mismatches, atomic write/overwrite refusal, and token exclusion; adapt a few generic recipe tests to assert the new fail-closed requirement for DSPACE.
- Document the operator flow and examples in `docs/apps/dspace.md` and note the manifest contract in `docs/app_deployment_contract.md` so the generic and compatibility recipes present a single shared guard; preserve `semanticTag` as non-deployment evidence only.

### Testing

- Ran unit tests: `python3 -m pytest -q tests/test_release_manifest.py tests/test_generic_app_just_recipes.py` — all tests passed (150 tests; one pre-existing Python SyntaxWarning in the generic suite). ✅
- Ran docs/quality checks: `pyspelling -c .spellcheck.yaml` — passed, and `linkchecker --no-warnings README.md docs/` — passed (201 internal links). ✅
- Ran repository checks: `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` — passed. ✅
- Attempted `pre-commit run --all-files`; repository-wide unrelated YAML/flake8 issues exist outside this change, so full pre-commit across the repo did not complete cleanly, but focused new Python files and whitespace/EOF hooks for changed files passed. (Reported as a repo maintenance caution; new code passes the focused linters used in tests.) ⚠️

Remaining operational notes

- The changes do not publish artifacts, mutate a live cluster, or create real approval evidence; operators must supply and review the upstream manifest, run the candidate validation, and attach or commit the finalized `deployment-evidence` record after a live rollout as documented. Refs #2326

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a659e564d5c832f8f321345c3377cdc)