### PR TITLE
Correct staging blackbox exporter NetworkPolicy to ingress-only

### DIFF
--- a/clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml
+++ b/clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml
@@ -6,15 +6,15 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      operator.prometheus.io/name: kube-prometheus-stack-prometheus
+      app.kubernetes.io/instance: prometheus-blackbox-exporter
+      app.kubernetes.io/name: prometheus-blackbox-exporter
   policyTypes:
-    - Egress
-  egress:
-    - to:
+    - Ingress
+  ingress:
+    - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/instance: prometheus-blackbox-exporter
-              app.kubernetes.io/name: prometheus-blackbox-exporter
+              operator.prometheus.io/name: kube-prometheus-stack-prometheus
       ports:
         - protocol: TCP
           port: 9115

--- a/docs/observability-blackbox.md
+++ b/docs/observability-blackbox.md
@@ -6,8 +6,12 @@ only. The exporter is a `ClusterIP` service; this work adds no Ingress,
 NodePort, public DNS, router rule, credential, or persistence. The lifecycle
 owns one staging-only NetworkPolicy that permits only the canonical
 `kube-prometheus-stack` Prometheus pods to reach only the canonical exporter
-pods on TCP 9115. Existing monitoring DNS and external HTTPS permissions are
-unchanged.
+pods on TCP 9115. The observed live baseline had no monitoring default-deny or
+general monitoring allow policy. The former egress policy selected Prometheus,
+so merely creating it isolated every Prometheus egress path; DNS to CoreDNS and
+all 16 blackbox targets failed. The corrected ingress-only policy selects and
+isolates only exporter ingress. It does not select Prometheus, so Prometheus DNS
+and every other egress path remain unaffected.
 
 ## Canonical sources
 
@@ -47,7 +51,8 @@ just observability-blackbox-verify env=staging
 
 Render, status, and verify are read-only. Status displays the exact owned
 NetworkPolicy. Install is only for an absent exporter release; upgrade requires
-it to exist. Both render the pinned chart, policy, and Probes first, pass the
+it to exist. The staging exporter release already exists, so the post-merge
+rollout uses upgrade, not install. Both render the pinned chart, policy, and Probes first, pass the
 complete committed values on every Helm operation, and wait up to the
 Pi-appropriate timeout. Only after Helm succeeds, they apply the policy, delete
 the eleven explicit legacy production Probe names using `--ignore-not-found`,
@@ -73,22 +78,23 @@ app/route target matrix, `probe_success == 1`, and the duration, HTTP status,
 DNS lookup, and earliest TLS certificate-expiry metric families. It never logs
 raw target payloads or URLs; terminal diagnostics contain bounded labels and
 health/series states only. Before polling Prometheus, verification fails closed
-unless the deployed policy has exactly the required source selector,
-destination selector, Egress policy type, single peer/rule, and TCP 9115 port;
-broad or additional behavior is rejected.
+unless the deployed policy selects exactly the exporter pods and contains one
+Ingress rule from exactly the canonical Prometheus pods on TCP 9115. An egress
+field or policy type—including the former Prometheus-selecting egress
+policy—and broad or additional behavior is rejected.
 
 ## Post-merge rollout
 
 1. Select and independently confirm the staging kubeconfig and cluster identity.
 2. Review `just observability-blackbox-render env=staging` without applying it.
-3. If `helm -n monitoring list --all --filter '^prometheus-blackbox-exporter$'`
-   shows no release, run `just observability-blackbox-install env=staging`; if
-   it shows the release, run `just observability-blackbox-upgrade env=staging`.
+3. Upgrade the already deployed exporter release with
+   `just observability-blackbox-upgrade env=staging`.
 4. Run status, then verify. Preserve this output as separate live evidence.
 5. Stop and investigate rather than attempting production if any guard fails.
 
-No live deployment was performed as part of this repository change; repository
-state is not evidence of a live rollout.
+Repository tests perform no live mutation. No live deployment was performed as
+part of this repository change; repository state is not evidence of a live
+rollout.
 
 ## Rollback
 

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -15,6 +15,15 @@ The staging blackbox exporter and Probe lifecycle is documented separately in
 [Staging blackbox monitoring](observability-blackbox.md). That guarded lifecycle
 exclusively owns its narrowly scoped staging Prometheus-to-exporter
 NetworkPolicy; it is not part of an active Flux or cluster Kustomize graph.
+The observed staging baseline has no monitoring default-deny policy. The
+blackbox lifecycle policy is ingress-only and selects only exporter pods,
+allowing canonical Prometheus pods to reach TCP 9115. The earlier egress form
+selected Prometheus and therefore isolated all of its egress, including DNS;
+the corrected policy leaves Prometheus DNS and every other egress path
+unaffected. The exporter remains a ClusterIP-only service. The exporter release
+already exists in staging, so its post-merge rollout uses
+`just observability-blackbox-upgrade env=staging`, not install. Repository tests
+do not mutate the live cluster.
 
 The old Flux/Longhorn files under `platform/observability/*.yaml` and `clusters/*/patches/kube-prometheus-stack-values.yaml` are inactive, unvalidated future/legacy configuration. They are deliberately absent from the platform resources and cluster overlay patches, so Flux does not reconcile the manually managed release. They must not be applied to staging or production as currently written, and operators must not combine Flux and manual Helm lifecycle paths for the same `kube-prometheus-stack` release.
 
@@ -123,6 +132,6 @@ Do not use `--reuse-values` for the next forward upgrade; commit the full intend
 
 ## Follow-ups intentionally out of scope
 
-Dashboards, useful Alertmanager receivers, NetworkPolicies, Grafana persistence,
+Dashboards, useful Alertmanager receivers, namespace-wide default-deny policies, Grafana persistence,
 central multi-cluster Grafana, and production observability codification are
 separate follow-ups.

--- a/scripts/observability_blackbox.sh
+++ b/scripts/observability_blackbox.sh
@@ -103,7 +103,7 @@ for key in ("app.kubernetes.io/instance","app.kubernetes.io/name"):
     labels[key]=value
 # Helm renders the Prometheus CR; operator-created pods carry
 # operator.prometheus.io/name=<CR name>, so the render supplies this value.
-json.dump({"source":{"operator.prometheus.io/name":base[0]["metadata"]["name"]},"destination":labels},open(sys.argv[3],"w",encoding="utf-8"),sort_keys=True)
+json.dump({"prometheus":{"operator.prometheus.io/name":base[0]["metadata"]["name"]},"exporter":labels},open(sys.argv[3],"w",encoding="utf-8"),sort_keys=True)
 PY
   validate_policy_file "${policy_json}" "${selectors_out}"
   python3 "${ROOT}/scripts/verify_blackbox_prometheus.py" --probes <"${probes_json}"
@@ -117,9 +117,9 @@ if len(objects) != 1 or not isinstance(objects[0],dict):
     raise SystemExit("ERROR: lifecycle policy render must contain exactly one non-null Kubernetes object.")
 policy=objects[0]
 expected = {
-    "podSelector": {"matchLabels": selectors["source"]},
-    "policyTypes": ["Egress"],
-    "egress": [{"to": [{"podSelector": {"matchLabels": selectors["destination"]}}], "ports": [{"protocol": "TCP", "port": 9115}]}],
+    "podSelector": {"matchLabels": selectors["exporter"]},
+    "policyTypes": ["Ingress"],
+    "ingress": [{"from": [{"podSelector": {"matchLabels": selectors["prometheus"]}}], "ports": [{"protocol": "TCP", "port": 9115}]}],
 }
 required={"apiVersion": "networking.k8s.io/v1", "kind": "NetworkPolicy", "metadata": {"name": sys.argv[2], "namespace": sys.argv[3]}, "spec": expected}
 policy.get("metadata",{}).pop("creationTimestamp",None)

--- a/tests/test_monitoring_blackbox.py
+++ b/tests/test_monitoring_blackbox.py
@@ -195,11 +195,11 @@ def test_lifecycle_network_policy_is_exact_and_chart_render_backed():
         and doc["metadata"]["name"] == "prometheus-blackbox-exporter"
     ]
     assert len(prometheus) == len(deployments) == 1
-    source = {
+    prometheus_selector = {
         "operator.prometheus.io/name": prometheus[0]["metadata"]["name"],
     }
     rendered_labels = deployments[0]["spec"]["template"]["metadata"]["labels"]
-    destination = {
+    exporter_selector = {
         key: rendered_labels[key]
         for key in ("app.kubernetes.io/instance", "app.kubernetes.io/name")
     }
@@ -211,11 +211,11 @@ def test_lifecycle_network_policy_is_exact_and_chart_render_backed():
             "namespace": "monitoring",
         },
         "spec": {
-            "podSelector": {"matchLabels": source},
-            "policyTypes": ["Egress"],
-            "egress": [
+            "podSelector": {"matchLabels": exporter_selector},
+            "policyTypes": ["Ingress"],
+            "ingress": [
                 {
-                    "to": [{"podSelector": {"matchLabels": destination}}],
+                    "from": [{"podSelector": {"matchLabels": prometheus_selector}}],
                     "ports": [{"protocol": "TCP", "port": 9115}],
                 }
             ],

--- a/tests/test_observability_blackbox.py
+++ b/tests/test_observability_blackbox.py
@@ -165,20 +165,30 @@ elif "get networkpolicy allow-kube-prometheus-stack-to-blackbox-exporter -o json
     if scenario == "missing_policy": sys.exit(1)
     policy = json.load(open(os.environ["POLICY_JSON"]))
     spec = policy["spec"]
-    if scenario == "malformed_policy": spec["policyTypes"] = ["Ingress"]
-    elif scenario == "broad_source": spec["podSelector"] = {}
-    elif scenario == "broad_destination": spec["egress"][0]["to"][0]["podSelector"] = {}
-    elif scenario == "wrong_protocol": spec["egress"][0]["ports"][0]["protocol"] = "UDP"
-    elif scenario == "wrong_port": spec["egress"][0]["ports"][0]["port"] = 9116
-    elif scenario == "additional_protocol": spec["egress"][0]["ports"].append({"protocol": "UDP", "port": 9115})
-    elif scenario == "additional_port": spec["egress"][0]["ports"].append({"protocol": "TCP", "port": 9116})
-    elif scenario == "additional_source_selector": spec["podSelector"]["matchLabels"]["extra"] = "forbidden"
-    elif scenario == "additional_destination_selector": spec["egress"][0]["to"][0]["podSelector"]["matchLabels"]["extra"] = "forbidden"
-    elif scenario == "additional_peer": spec["egress"][0]["to"].append({"ipBlock": {"cidr": "0.0.0.0/0"}})
-    elif scenario == "additional_rule": spec["egress"].append({"to": [{"podSelector": {}}]})
-    elif scenario == "namespace_selector": spec["egress"][0]["to"][0]["namespaceSelector"] = {}
-    elif scenario == "ingress_spec": spec["ingress"] = []
-    elif scenario == "additional_policy_type": spec["policyTypes"].append("Ingress")
+    if scenario == "old_egress_policy":
+        spec = policy["spec"] = {
+            "podSelector": {"matchLabels": {"operator.prometheus.io/name": "kube-prometheus-stack-prometheus"}},
+            "policyTypes": ["Egress"],
+            "egress": [{"to": [{"podSelector": {"matchLabels": {
+                "app.kubernetes.io/instance": "prometheus-blackbox-exporter",
+                "app.kubernetes.io/name": "prometheus-blackbox-exporter"}}}],
+                "ports": [{"protocol": "TCP", "port": 9115}]}],
+        }
+    elif scenario == "malformed_policy": spec["policyTypes"] = ["Egress"]
+    elif scenario == "broad_exporter": spec["podSelector"] = {}
+    elif scenario == "broad_prometheus": spec["ingress"][0]["from"][0]["podSelector"] = {}
+    elif scenario == "wrong_protocol": spec["ingress"][0]["ports"][0]["protocol"] = "UDP"
+    elif scenario == "wrong_port": spec["ingress"][0]["ports"][0]["port"] = 9116
+    elif scenario == "additional_protocol": spec["ingress"][0]["ports"].append({"protocol": "UDP", "port": 9115})
+    elif scenario == "additional_port": spec["ingress"][0]["ports"].append({"protocol": "TCP", "port": 9116})
+    elif scenario == "additional_exporter_selector": spec["podSelector"]["matchLabels"]["extra"] = "forbidden"
+    elif scenario == "additional_prometheus_selector": spec["ingress"][0]["from"][0]["podSelector"]["matchLabels"]["extra"] = "forbidden"
+    elif scenario == "additional_peer": spec["ingress"][0]["from"].append({"ipBlock": {"cidr": "0.0.0.0/0"}})
+    elif scenario == "additional_rule": spec["ingress"].append({"from": [{"podSelector": {}}]})
+    elif scenario == "ip_block": spec["ingress"][0]["from"][0]["ipBlock"] = {"cidr": "10.0.0.0/8"}
+    elif scenario == "namespace_selector": spec["ingress"][0]["from"][0]["namespaceSelector"] = {}
+    elif scenario == "egress_spec": spec["egress"] = []
+    elif scenario == "additional_policy_type": spec["policyTypes"].append("Egress")
     print(json.dumps(policy))
 elif "get probe -l" in joined and "-o json" in joined:
     print(open(os.environ["PROBES_JSON"]).read())
@@ -366,6 +376,52 @@ def test_render_stdout_is_a_clean_separated_kubernetes_stream(scenario):
     assert "blackbox environment: staging" in result.stderr
 
 
+def test_render_rejects_former_prometheus_selecting_egress_manifest_before_cluster_access(
+    scenario,
+):
+    old_policy = scenario.root / "old-egress-policy.yaml"
+    old_policy.write_text(
+        json.dumps(
+            {
+                "apiVersion": "networking.k8s.io/v1",
+                "kind": "NetworkPolicy",
+                "metadata": {
+                    "name": "allow-kube-prometheus-stack-to-blackbox-exporter",
+                    "namespace": "monitoring",
+                },
+                "spec": {
+                    "podSelector": {
+                        "matchLabels": {
+                            "operator.prometheus.io/name": "kube-prometheus-stack-prometheus"
+                        }
+                    },
+                    "policyTypes": ["Egress"],
+                    "egress": [
+                        {
+                            "to": [
+                                {
+                                    "podSelector": {
+                                        "matchLabels": {
+                                            "app.kubernetes.io/instance": "prometheus-blackbox-exporter",
+                                            "app.kubernetes.io/name": "prometheus-blackbox-exporter",
+                                        }
+                                    }
+                                }
+                            ],
+                            "ports": [{"protocol": "TCP", "port": 9115}],
+                        }
+                    ],
+                },
+            }
+        )
+    )
+    result = scenario.run("upgrade", POLICY=old_policy)
+    assert result.returncode != 0
+    assert "required exact narrow policy" in result.stderr
+    assert not any("config current-context" in line for line in scenario.log)
+    assert not mutations(scenario.log)
+
+
 @pytest.mark.parametrize("failure", ["bad_context", "bad_identity"])
 def test_identity_guards_precede_release_queries_and_mutation(scenario, failure):
     result = scenario.run("install", SCENARIO=failure)
@@ -442,18 +498,20 @@ def test_failed_policy_apply_suppresses_probe_mutation(scenario):
     [
         "missing_policy",
         "malformed_policy",
-        "broad_source",
-        "broad_destination",
+        "old_egress_policy",
+        "broad_exporter",
+        "broad_prometheus",
         "wrong_protocol",
         "wrong_port",
         "additional_protocol",
         "additional_port",
-        "additional_source_selector",
-        "additional_destination_selector",
+        "additional_exporter_selector",
+        "additional_prometheus_selector",
         "additional_peer",
         "additional_rule",
+        "ip_block",
         "namespace_selector",
-        "ingress_spec",
+        "egress_spec",
         "additional_policy_type",
     ],
 )


### PR DESCRIPTION
### Motivation
- The previously-committed lifecycle NetworkPolicy selected Prometheus pods and used an Egress rule, which on the observed staging baseline isolated Prometheus egress (including DNS) and caused the blackbox probes to fail, so the policy must be replaced with a minimal ingress-only policy that isolates only exporter ingress. 

### Description
- Replace the canonical manifest `clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml` so the top-level selector matches only the exporter pods and the policy uses `policyTypes: [Ingress]` with a single ingress peer selecting Prometheus pods and a single TCP port `9115` (no `egress`, `ipBlock`, `namespaceSelector`, empty selectors, extra peers, ports, or protocols). 
- Update `scripts/observability_blackbox.sh` to derive `prometheus` and `exporter` selectors from pinned chart renders, produce the selectors JSON accordingly, validate the rendered policy is the exact ingress-only shape above, and explicitly reject the former Prometheus-selecting egress form or any policy that could isolate Prometheus egress. 
- Strengthen regression coverage in `tests/test_monitoring_blackbox.py` and `tests/test_observability_blackbox.py` to assert the top-level exporter selector, single ingress peer from Prometheus, only TCP/9115, rejection of the old egress manifest, and rejection of broad/additional selectors, peers, ports, protocols, `ipBlock`, `namespaceSelector`, and empty selectors. 
- Update documentation (`docs/observability-blackbox.md`, `docs/observability-operations.md`) to explain the observed baseline, why the egress policy was unsafe, that the corrected policy isolates only exporter ingress, that Prometheus DNS and other egress paths remain unaffected, that the exporter stays ClusterIP-only, and that the staging rollout uses upgrade when the release already exists.

### Testing
- `bash -n scripts/observability_blackbox.sh` — succeeded (syntax/static checks).
- `pytest -q tests/test_observability_blackbox.py` — passed.
- `pytest -q tests/test_monitoring_blackbox.py tests/test_observability_blackbox.py` — passed (59 tests total).
- `ruff check` and `black --check` on the modified tests — passed for the touched test files.
- `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` — passed.
- `git diff --check` and `git diff | ./scripts/scan-secrets.py` — no new issues detected.
- `pre-commit run --all-files` reported unrelated, pre-existing repository-wide checks outside the six-file scope changed here; no live cluster mutations were performed and no Helm/kubectl operations were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65a493ab9c832fb02a8a6ef9009549)