### PR TITLE
Fix staging blackbox exporter NetworkPolicy

### DIFF
--- a/clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml
+++ b/clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml
@@ -6,15 +6,15 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      operator.prometheus.io/name: kube-prometheus-stack-prometheus
+      app.kubernetes.io/instance: prometheus-blackbox-exporter
+      app.kubernetes.io/name: prometheus-blackbox-exporter
   policyTypes:
-    - Egress
-  egress:
-    - to:
+    - Ingress
+  ingress:
+    - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/instance: prometheus-blackbox-exporter
-              app.kubernetes.io/name: prometheus-blackbox-exporter
+              operator.prometheus.io/name: kube-prometheus-stack-prometheus
       ports:
         - protocol: TCP
           port: 9115

--- a/docs/observability-blackbox.md
+++ b/docs/observability-blackbox.md
@@ -6,8 +6,16 @@ only. The exporter is a `ClusterIP` service; this work adds no Ingress,
 NodePort, public DNS, router rule, credential, or persistence. The lifecycle
 owns one staging-only NetworkPolicy that permits only the canonical
 `kube-prometheus-stack` Prometheus pods to reach only the canonical exporter
-pods on TCP 9115. Existing monitoring DNS and external HTTPS permissions are
-unchanged.
+pods on TCP 9115. The policy selects only exporter pods and isolates only their
+ingress. It does not select Prometheus, so Prometheus DNS and every other egress
+path remain unaffected. No monitoring namespace default-deny policy is assumed
+or added.
+
+The former egress policy selected Prometheus itself. On the observed live
+baseline, where no monitoring default-deny/allow policy existed, that selection
+immediately isolated all Prometheus egress. DNS to CoreDNS failed, all 16
+blackbox targets went down, and unrelated scrape paths were put at risk. The
+corrected ingress-only policy cannot repeat that failure mode.
 
 ## Canonical sources
 
@@ -72,23 +80,25 @@ Prometheus Kubernetes service proxy and bounded polling to prove the exact
 app/route target matrix, `probe_success == 1`, and the duration, HTTP status,
 DNS lookup, and earliest TLS certificate-expiry metric families. It never logs
 raw target payloads or URLs; terminal diagnostics contain bounded labels and
-health/series states only. Before polling Prometheus, verification fails closed
-unless the deployed policy has exactly the required source selector,
-destination selector, Egress policy type, single peer/rule, and TCP 9115 port;
-broad or additional behavior is rejected.
+health/series states only. Before polling Prometheus, verification fails closed unless the deployed policy
+selects exactly the exporter pods and contains one Ingress rule whose sole peer
+is the canonical Prometheus selector and whose sole port is TCP 9115. Egress
+policy types and fields, including the former Prometheus-selecting policy, and
+all broad or additional behavior are rejected.
 
 ## Post-merge rollout
 
 1. Select and independently confirm the staging kubeconfig and cluster identity.
 2. Review `just observability-blackbox-render env=staging` without applying it.
-3. If `helm -n monitoring list --all --filter '^prometheus-blackbox-exporter$'`
-   shows no release, run `just observability-blackbox-install env=staging`; if
-   it shows the release, run `just observability-blackbox-upgrade env=staging`.
+3. The staging exporter release and all 16 Probe resources already exist. Run
+   `just observability-blackbox-upgrade env=staging`; do not use install for
+   this post-merge rollout.
 4. Run status, then verify. Preserve this output as separate live evidence.
 5. Stop and investigate rather than attempting production if any guard fails.
 
-No live deployment was performed as part of this repository change; repository
-state is not evidence of a live rollout.
+Repository tests perform no live mutation. No live deployment was performed as
+part of this repository change; repository state is not evidence of a live
+rollout.
 
 ## Rollback
 

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -14,7 +14,19 @@ Production observability is intentionally unsupported in this slice because no p
 The staging blackbox exporter and Probe lifecycle is documented separately in
 [Staging blackbox monitoring](observability-blackbox.md). That guarded lifecycle
 exclusively owns its narrowly scoped staging Prometheus-to-exporter
-NetworkPolicy; it is not part of an active Flux or cluster Kustomize graph.
+NetworkPolicy; it is not part of an active Flux or cluster Kustomize graph. The
+policy selects only exporter pods and permits ingress only from the canonical
+Prometheus pods on TCP 9115. It does not assume a monitoring default-deny
+baseline, select Prometheus, or alter Prometheus DNS or other egress. The
+exporter remains ClusterIP-only.
+
+The replaced egress form selected Prometheus and, on the observed live baseline
+without monitoring default-deny/allow policies, isolated all Prometheus egress.
+That broke DNS and all 16 blackbox targets and risked unrelated scrape paths.
+The corrected exporter-ingress policy avoids that outage mode. The current
+staging exporter release already exists, so its post-merge rollout uses
+`just observability-blackbox-upgrade env=staging`, never install. Repository
+tests perform no live mutation and are not evidence of rollout state.
 
 The old Flux/Longhorn files under `platform/observability/*.yaml` and `clusters/*/patches/kube-prometheus-stack-values.yaml` are inactive, unvalidated future/legacy configuration. They are deliberately absent from the platform resources and cluster overlay patches, so Flux does not reconcile the manually managed release. They must not be applied to staging or production as currently written, and operators must not combine Flux and manual Helm lifecycle paths for the same `kube-prometheus-stack` release.
 

--- a/scripts/observability_blackbox.sh
+++ b/scripts/observability_blackbox.sh
@@ -103,7 +103,7 @@ for key in ("app.kubernetes.io/instance","app.kubernetes.io/name"):
     labels[key]=value
 # Helm renders the Prometheus CR; operator-created pods carry
 # operator.prometheus.io/name=<CR name>, so the render supplies this value.
-json.dump({"source":{"operator.prometheus.io/name":base[0]["metadata"]["name"]},"destination":labels},open(sys.argv[3],"w",encoding="utf-8"),sort_keys=True)
+json.dump({"prometheus":{"operator.prometheus.io/name":base[0]["metadata"]["name"]},"exporter":labels},open(sys.argv[3],"w",encoding="utf-8"),sort_keys=True)
 PY
   validate_policy_file "${policy_json}" "${selectors_out}"
   python3 "${ROOT}/scripts/verify_blackbox_prometheus.py" --probes <"${probes_json}"
@@ -117,14 +117,14 @@ if len(objects) != 1 or not isinstance(objects[0],dict):
     raise SystemExit("ERROR: lifecycle policy render must contain exactly one non-null Kubernetes object.")
 policy=objects[0]
 expected = {
-    "podSelector": {"matchLabels": selectors["source"]},
-    "policyTypes": ["Egress"],
-    "egress": [{"to": [{"podSelector": {"matchLabels": selectors["destination"]}}], "ports": [{"protocol": "TCP", "port": 9115}]}],
+    "podSelector": {"matchLabels": selectors["exporter"]},
+    "policyTypes": ["Ingress"],
+    "ingress": [{"from": [{"podSelector": {"matchLabels": selectors["prometheus"]}}], "ports": [{"protocol": "TCP", "port": 9115}]}],
 }
 required={"apiVersion": "networking.k8s.io/v1", "kind": "NetworkPolicy", "metadata": {"name": sys.argv[2], "namespace": sys.argv[3]}, "spec": expected}
 policy.get("metadata",{}).pop("creationTimestamp",None)
 if policy != required:
-    raise SystemExit("ERROR: lifecycle NetworkPolicy is not the required exact narrow policy.")
+    raise SystemExit("ERROR: lifecycle NetworkPolicy must select only exporter ingress; Prometheus egress isolation and any broader policy are forbidden.")
 json.dump(required,open(sys.argv[5],"w",encoding="utf-8"),sort_keys=True)
 PY
 }
@@ -181,7 +181,7 @@ import json, sys
 live=json.load(sys.stdin); expected=json.load(open(sys.argv[1]))
 live={"apiVersion":live.get("apiVersion"),"kind":live.get("kind"),"metadata":{"name":live.get("metadata",{}).get("name"),"namespace":live.get("metadata",{}).get("namespace")},"spec":live.get("spec")}
 if live != expected:
- raise SystemExit("ERROR: deployed lifecycle NetworkPolicy differs from the required exact narrow policy.")
+ raise SystemExit("ERROR: deployed lifecycle NetworkPolicy must select only exporter ingress; Prometheus egress isolation and any broader policy are forbidden.")
 ' "${EXPECTED_POLICY_JSON}" <<<"${policy}" || exit 7
 }
 validate_resources() {

--- a/tests/test_monitoring_blackbox.py
+++ b/tests/test_monitoring_blackbox.py
@@ -195,11 +195,11 @@ def test_lifecycle_network_policy_is_exact_and_chart_render_backed():
         and doc["metadata"]["name"] == "prometheus-blackbox-exporter"
     ]
     assert len(prometheus) == len(deployments) == 1
-    source = {
+    prometheus_selector = {
         "operator.prometheus.io/name": prometheus[0]["metadata"]["name"],
     }
     rendered_labels = deployments[0]["spec"]["template"]["metadata"]["labels"]
-    destination = {
+    exporter_selector = {
         key: rendered_labels[key]
         for key in ("app.kubernetes.io/instance", "app.kubernetes.io/name")
     }
@@ -211,11 +211,11 @@ def test_lifecycle_network_policy_is_exact_and_chart_render_backed():
             "namespace": "monitoring",
         },
         "spec": {
-            "podSelector": {"matchLabels": source},
-            "policyTypes": ["Egress"],
-            "egress": [
+            "podSelector": {"matchLabels": exporter_selector},
+            "policyTypes": ["Ingress"],
+            "ingress": [
                 {
-                    "to": [{"podSelector": {"matchLabels": destination}}],
+                    "from": [{"podSelector": {"matchLabels": prometheus_selector}}],
                     "ports": [{"protocol": "TCP", "port": 9115}],
                 }
             ],

--- a/tests/test_observability_blackbox.py
+++ b/tests/test_observability_blackbox.py
@@ -165,20 +165,23 @@ elif "get networkpolicy allow-kube-prometheus-stack-to-blackbox-exporter -o json
     if scenario == "missing_policy": sys.exit(1)
     policy = json.load(open(os.environ["POLICY_JSON"]))
     spec = policy["spec"]
-    if scenario == "malformed_policy": spec["policyTypes"] = ["Ingress"]
-    elif scenario == "broad_source": spec["podSelector"] = {}
-    elif scenario == "broad_destination": spec["egress"][0]["to"][0]["podSelector"] = {}
-    elif scenario == "wrong_protocol": spec["egress"][0]["ports"][0]["protocol"] = "UDP"
-    elif scenario == "wrong_port": spec["egress"][0]["ports"][0]["port"] = 9116
-    elif scenario == "additional_protocol": spec["egress"][0]["ports"].append({"protocol": "UDP", "port": 9115})
-    elif scenario == "additional_port": spec["egress"][0]["ports"].append({"protocol": "TCP", "port": 9116})
-    elif scenario == "additional_source_selector": spec["podSelector"]["matchLabels"]["extra"] = "forbidden"
-    elif scenario == "additional_destination_selector": spec["egress"][0]["to"][0]["podSelector"]["matchLabels"]["extra"] = "forbidden"
-    elif scenario == "additional_peer": spec["egress"][0]["to"].append({"ipBlock": {"cidr": "0.0.0.0/0"}})
-    elif scenario == "additional_rule": spec["egress"].append({"to": [{"podSelector": {}}]})
-    elif scenario == "namespace_selector": spec["egress"][0]["to"][0]["namespaceSelector"] = {}
-    elif scenario == "ingress_spec": spec["ingress"] = []
-    elif scenario == "additional_policy_type": spec["policyTypes"].append("Ingress")
+    if scenario == "old_egress_policy":
+        spec = {"podSelector": {"matchLabels": {"operator.prometheus.io/name": "kube-prometheus-stack-prometheus"}}, "policyTypes": ["Egress"], "egress": [{"to": [{"podSelector": {"matchLabels": {"app.kubernetes.io/instance": "prometheus-blackbox-exporter", "app.kubernetes.io/name": "prometheus-blackbox-exporter"}}}], "ports": [{"protocol": "TCP", "port": 9115}]}]}
+        policy["spec"] = spec
+    elif scenario == "malformed_policy": spec["policyTypes"] = ["Egress"]
+    elif scenario == "broad_source": spec["ingress"][0]["from"][0]["podSelector"] = {}
+    elif scenario == "broad_destination": spec["podSelector"] = {}
+    elif scenario == "wrong_protocol": spec["ingress"][0]["ports"][0]["protocol"] = "UDP"
+    elif scenario == "wrong_port": spec["ingress"][0]["ports"][0]["port"] = 9116
+    elif scenario == "additional_protocol": spec["ingress"][0]["ports"].append({"protocol": "UDP", "port": 9115})
+    elif scenario == "additional_port": spec["ingress"][0]["ports"].append({"protocol": "TCP", "port": 9116})
+    elif scenario == "additional_source_selector": spec["ingress"][0]["from"][0]["podSelector"]["matchLabels"]["extra"] = "forbidden"
+    elif scenario == "additional_destination_selector": spec["podSelector"]["matchLabels"]["extra"] = "forbidden"
+    elif scenario == "additional_peer": spec["ingress"][0]["from"].append({"ipBlock": {"cidr": "0.0.0.0/0"}})
+    elif scenario == "additional_rule": spec["ingress"].append({"from": [{"podSelector": {}}]})
+    elif scenario == "namespace_selector": spec["ingress"][0]["from"][0]["namespaceSelector"] = {}
+    elif scenario == "egress_spec": spec["egress"] = []
+    elif scenario == "additional_policy_type": spec["policyTypes"].append("Egress")
     print(json.dumps(policy))
 elif "get probe -l" in joined and "-o json" in joined:
     print(open(os.environ["PROBES_JSON"]).read())
@@ -348,6 +351,67 @@ def test_rendered_selector_drift_fails_before_cluster_access(scenario, failure):
     assert not mutations(scenario.log)
 
 
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "old_egress",
+        "empty_exporter_selector",
+        "extra_exporter_label",
+        "empty_prometheus_selector",
+        "extra_prometheus_label",
+        "extra_peer",
+        "extra_rule",
+        "extra_port",
+        "extra_protocol",
+        "ip_block",
+        "namespace_selector",
+    ],
+)
+def test_unsafe_lifecycle_policy_fails_before_cluster_access(scenario, mutation, tmp_path):
+    policy = json.loads(Path(scenario.env["POLICY_JSON"]).read_text())
+    spec = policy["spec"]
+    peer = spec["ingress"][0]["from"][0]
+    if mutation == "old_egress":
+        spec.clear()
+        spec.update(
+            {
+                "podSelector": {
+                    "matchLabels": {
+                        "operator.prometheus.io/name": "kube-prometheus-stack-prometheus"
+                    }
+                },
+                "policyTypes": ["Egress"],
+                "egress": [],
+            }
+        )
+    elif mutation == "empty_exporter_selector":
+        spec["podSelector"] = {}
+    elif mutation == "extra_exporter_label":
+        spec["podSelector"]["matchLabels"]["extra"] = "forbidden"
+    elif mutation == "empty_prometheus_selector":
+        peer["podSelector"] = {}
+    elif mutation == "extra_prometheus_label":
+        peer["podSelector"]["matchLabels"]["extra"] = "forbidden"
+    elif mutation == "extra_peer":
+        spec["ingress"][0]["from"].append({"podSelector": {}})
+    elif mutation == "extra_rule":
+        spec["ingress"].append({"from": [{"podSelector": {}}]})
+    elif mutation == "extra_port":
+        spec["ingress"][0]["ports"].append({"protocol": "TCP", "port": 9116})
+    elif mutation == "extra_protocol":
+        spec["ingress"][0]["ports"].append({"protocol": "UDP", "port": 9115})
+    elif mutation == "ip_block":
+        peer["ipBlock"] = {"cidr": "0.0.0.0/0"}
+    elif mutation == "namespace_selector":
+        peer["namespaceSelector"] = {}
+    unsafe = tmp_path / "unsafe-policy.yaml"
+    unsafe.write_text(json.dumps(policy))
+    result = scenario.run("upgrade", POLICY=unsafe)
+    assert result.returncode != 0
+    assert not any("config current-context" in line for line in scenario.log)
+    assert not mutations(scenario.log)
+
+
 def test_render_stdout_is_a_clean_separated_kubernetes_stream(scenario):
     result = scenario.run("render")
     assert result.returncode == 0
@@ -441,6 +505,7 @@ def test_failed_policy_apply_suppresses_probe_mutation(scenario):
     "failure",
     [
         "missing_policy",
+        "old_egress_policy",
         "malformed_policy",
         "broad_source",
         "broad_destination",
@@ -453,7 +518,7 @@ def test_failed_policy_apply_suppresses_probe_mutation(scenario):
         "additional_peer",
         "additional_rule",
         "namespace_selector",
-        "ingress_spec",
+        "egress_spec",
         "additional_policy_type",
     ],
 )


### PR DESCRIPTION
### Motivation
- Correct the unsafe NetworkPolicy introduced by the previous change which selected Prometheus pods with an `Egress` rule and thereby risked isolating Prometheus egress (observed live outage: DNS failures and all blackbox targets going down). 

### Description
- Replace the canonical manifest `clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml` to select only the exporter pods at the top level and expose exactly one `Ingress` rule permitting only the canonical Prometheus selector to reach TCP port `9115` (no `egress`, `ipBlock`, `namespaceSelector`, empty selectors, extra peers, ports, or protocols). 
- Update `scripts/observability_blackbox.sh` to derive both selectors from pinned chart renders, render and validate the exact ingress-only structure, refuse the former Prometheus-selecting egress form, and preserve the existing mutation order and failure-suppression semantics. 
- Strengthen regression coverage in `tests/test_observability_blackbox.py` and `tests/test_monitoring_blackbox.py` to assert the exact exporter selector, the single Prometheus ingress peer, `policyTypes: ["Ingress"]`, only TCP/9115, and to reject the old egress form and any broad/additional selectors/peers/rules/ports/protocols before any cluster mutation. 
- Update docs (`docs/observability-blackbox.md`, `docs/observability-operations.md`) to remove the incorrect assumption about a monitoring default-deny baseline, explain the observed outage cause, and document that the policy isolates only exporter ingress and that post-merge rollout is an `upgrade` for the existing staging release. 

### Testing
- Ran `bash -n scripts/observability_blackbox.sh` and it reported syntactically valid shell (success). 
- Ran `pytest -q tests/test_observability_blackbox.py` with the updated tests which passed (`64 passed`). 
- Ran `pytest -q tests/test_monitoring_blackbox.py tests/test_observability_blackbox.py` which passed (`68 passed` total). 
- Ran lint/format checks: `ruff check` and `black --check` for the touched tests passed, `git diff --check` and `git diff | ./scripts/scan-secrets.py` returned no actionable issues, `pyspelling -c .spellcheck.yaml` passed, and `linkchecker --no-warnings README.md docs/` reported no link errors. 
- `pre-commit run --all-files` surfaced pre-existing repository-wide lint/yaml issues unrelated to this change; those are known, not introduced here, and no unrelated files were included in this commit. 

No live `helm` or `kubectl` mutation was performed as part of these edits. Post-merge, run the guarded staging sequence: `git pull --ff-only`, `just kubeconfig-env env=staging`, `just observability-blackbox-render env=staging`, `just observability-blackbox-upgrade env=staging`, `just observability-blackbox-status env=staging`, and `just observability-blackbox-verify env=staging`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65a4a6409c832fab592caebf0f5218)