### PR TITLE
Fix staging blackbox exporter ingress policy

### DIFF
--- a/clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml
+++ b/clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml
@@ -6,15 +6,15 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      operator.prometheus.io/name: kube-prometheus-stack-prometheus
+      app.kubernetes.io/instance: prometheus-blackbox-exporter
+      app.kubernetes.io/name: prometheus-blackbox-exporter
   policyTypes:
-    - Egress
-  egress:
-    - to:
+    - Ingress
+  ingress:
+    - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/instance: prometheus-blackbox-exporter
-              app.kubernetes.io/name: prometheus-blackbox-exporter
+              operator.prometheus.io/name: kube-prometheus-stack-prometheus
       ports:
         - protocol: TCP
           port: 9115

--- a/docs/observability-blackbox.md
+++ b/docs/observability-blackbox.md
@@ -6,8 +6,16 @@ only. The exporter is a `ClusterIP` service; this work adds no Ingress,
 NodePort, public DNS, router rule, credential, or persistence. The lifecycle
 owns one staging-only NetworkPolicy that permits only the canonical
 `kube-prometheus-stack` Prometheus pods to reach only the canonical exporter
-pods on TCP 9115. Existing monitoring DNS and external HTTPS permissions are
-unchanged.
+pods on TCP 9115. The policy selects the exporter at the top level and isolates
+only exporter ingress. It does not select Prometheus, so Prometheus DNS and all
+other egress remain unaffected.
+
+The observed staging baseline has no monitoring default-deny policy and no
+`allow-monitoring-ingress` policy. The former egress policy selected Prometheus;
+on that baseline, creating it isolated all Prometheus egress, including DNS,
+and took all 16 blackbox targets down. This lifecycle therefore must never use
+an `Egress` policy type or select Prometheus at the top level. It does not add a
+namespace-wide default deny, DNS policy, or exporter egress restriction.
 
 ## Canonical sources
 
@@ -73,22 +81,24 @@ app/route target matrix, `probe_success == 1`, and the duration, HTTP status,
 DNS lookup, and earliest TLS certificate-expiry metric families. It never logs
 raw target payloads or URLs; terminal diagnostics contain bounded labels and
 health/series states only. Before polling Prometheus, verification fails closed
-unless the deployed policy has exactly the required source selector,
-destination selector, Egress policy type, single peer/rule, and TCP 9115 port;
-broad or additional behavior is rejected.
+unless the deployed policy has exactly the exporter top-level selector,
+Prometheus ingress peer, Ingress-only policy type, single peer/rule, and TCP
+9115 port; the former Prometheus-selecting egress policy and any broad or
+additional behavior are rejected.
 
 ## Post-merge rollout
 
 1. Select and independently confirm the staging kubeconfig and cluster identity.
 2. Review `just observability-blackbox-render env=staging` without applying it.
-3. If `helm -n monitoring list --all --filter '^prometheus-blackbox-exporter$'`
-   shows no release, run `just observability-blackbox-install env=staging`; if
-   it shows the release, run `just observability-blackbox-upgrade env=staging`.
+3. The staging `prometheus-blackbox-exporter` release already exists. Run
+   `just observability-blackbox-upgrade env=staging`; do not use install for
+   this post-merge correction.
 4. Run status, then verify. Preserve this output as separate live evidence.
 5. Stop and investigate rather than attempting production if any guard fails.
 
-No live deployment was performed as part of this repository change; repository
-state is not evidence of a live rollout.
+Repository tests perform no live mutation. No live deployment was performed as
+part of this repository change; repository state is not evidence of a live
+rollout.
 
 ## Rollback
 

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -15,6 +15,13 @@ The staging blackbox exporter and Probe lifecycle is documented separately in
 [Staging blackbox monitoring](observability-blackbox.md). That guarded lifecycle
 exclusively owns its narrowly scoped staging Prometheus-to-exporter
 NetworkPolicy; it is not part of an active Flux or cluster Kustomize graph.
+That ingress-only policy selects the ClusterIP-only exporter pods and allows
+TCP 9115 solely from canonical Prometheus pods. The observed live baseline has
+no monitoring default-deny or `allow-monitoring-ingress` policy. An egress
+policy selecting Prometheus was therefore unsafe: creating it isolated all
+Prometheus egress, including DNS. The corrected policy never selects
+Prometheus at the top level, so Prometheus DNS and every other egress path stay
+unaffected. It does not introduce a namespace-wide default deny or DNS policy.
 
 The old Flux/Longhorn files under `platform/observability/*.yaml` and `clusters/*/patches/kube-prometheus-stack-values.yaml` are inactive, unvalidated future/legacy configuration. They are deliberately absent from the platform resources and cluster overlay patches, so Flux does not reconcile the manually managed release. They must not be applied to staging or production as currently written, and operators must not combine Flux and manual Helm lifecycle paths for the same `kube-prometheus-stack` release.
 
@@ -90,6 +97,12 @@ The mutating recipes never use `--reuse-values`; the committed version and both 
    just observability-verify env=staging
    ```
 
+The staging blackbox exporter release already exists. For the post-merge
+blackbox NetworkPolicy correction, use `observability-blackbox-render`, then
+`observability-blackbox-upgrade`, status, and verify; do not use the blackbox
+install recipe. Repository tests are offline/stubbed and perform no live
+cluster mutation, so their results are not rollout evidence.
+
 ## Runtime expectations
 
 - Helm release: `kube-prometheus-stack` in namespace `monitoring`.
@@ -123,6 +136,6 @@ Do not use `--reuse-values` for the next forward upgrade; commit the full intend
 
 ## Follow-ups intentionally out of scope
 
-Dashboards, useful Alertmanager receivers, NetworkPolicies, Grafana persistence,
-central multi-cluster Grafana, and production observability codification are
-separate follow-ups.
+Dashboards, useful Alertmanager receivers, namespace-wide default-deny
+policies, Grafana persistence, central multi-cluster Grafana, and production
+observability codification are separate follow-ups.

--- a/scripts/observability_blackbox.sh
+++ b/scripts/observability_blackbox.sh
@@ -116,10 +116,13 @@ objects=[document for document in documents if document is not None]
 if len(objects) != 1 or not isinstance(objects[0],dict):
     raise SystemExit("ERROR: lifecycle policy render must contain exactly one non-null Kubernetes object.")
 policy=objects[0]
+spec=policy.get("spec",{})
+if "Egress" in spec.get("policyTypes",[]) or "egress" in spec or spec.get("podSelector") == {"matchLabels": selectors["source"]}:
+    raise SystemExit("ERROR: unsafe lifecycle NetworkPolicy must not select or isolate Prometheus egress.")
 expected = {
-    "podSelector": {"matchLabels": selectors["source"]},
-    "policyTypes": ["Egress"],
-    "egress": [{"to": [{"podSelector": {"matchLabels": selectors["destination"]}}], "ports": [{"protocol": "TCP", "port": 9115}]}],
+    "podSelector": {"matchLabels": selectors["destination"]},
+    "policyTypes": ["Ingress"],
+    "ingress": [{"from": [{"podSelector": {"matchLabels": selectors["source"]}}], "ports": [{"protocol": "TCP", "port": 9115}]}],
 }
 required={"apiVersion": "networking.k8s.io/v1", "kind": "NetworkPolicy", "metadata": {"name": sys.argv[2], "namespace": sys.argv[3]}, "spec": expected}
 policy.get("metadata",{}).pop("creationTimestamp",None)
@@ -180,6 +183,9 @@ validate_policy_live() {
 import json, sys
 live=json.load(sys.stdin); expected=json.load(open(sys.argv[1]))
 live={"apiVersion":live.get("apiVersion"),"kind":live.get("kind"),"metadata":{"name":live.get("metadata",{}).get("name"),"namespace":live.get("metadata",{}).get("namespace")},"spec":live.get("spec")}
+spec=live.get("spec") or {}; prometheus=expected["spec"]["ingress"][0]["from"][0]["podSelector"]
+if "Egress" in spec.get("policyTypes",[]) or "egress" in spec or spec.get("podSelector") == prometheus:
+ raise SystemExit("ERROR: unsafe deployed NetworkPolicy selects or isolates Prometheus egress.")
 if live != expected:
  raise SystemExit("ERROR: deployed lifecycle NetworkPolicy differs from the required exact narrow policy.")
 ' "${EXPECTED_POLICY_JSON}" <<<"${policy}" || exit 7

--- a/tests/test_monitoring_blackbox.py
+++ b/tests/test_monitoring_blackbox.py
@@ -195,11 +195,11 @@ def test_lifecycle_network_policy_is_exact_and_chart_render_backed():
         and doc["metadata"]["name"] == "prometheus-blackbox-exporter"
     ]
     assert len(prometheus) == len(deployments) == 1
-    source = {
+    prometheus_selector = {
         "operator.prometheus.io/name": prometheus[0]["metadata"]["name"],
     }
     rendered_labels = deployments[0]["spec"]["template"]["metadata"]["labels"]
-    destination = {
+    exporter_selector = {
         key: rendered_labels[key]
         for key in ("app.kubernetes.io/instance", "app.kubernetes.io/name")
     }
@@ -211,11 +211,11 @@ def test_lifecycle_network_policy_is_exact_and_chart_render_backed():
             "namespace": "monitoring",
         },
         "spec": {
-            "podSelector": {"matchLabels": source},
-            "policyTypes": ["Egress"],
-            "egress": [
+            "podSelector": {"matchLabels": exporter_selector},
+            "policyTypes": ["Ingress"],
+            "ingress": [
                 {
-                    "to": [{"podSelector": {"matchLabels": destination}}],
+                    "from": [{"podSelector": {"matchLabels": prometheus_selector}}],
                     "ports": [{"protocol": "TCP", "port": 9115}],
                 }
             ],

--- a/tests/test_observability_blackbox.py
+++ b/tests/test_observability_blackbox.py
@@ -165,20 +165,28 @@ elif "get networkpolicy allow-kube-prometheus-stack-to-blackbox-exporter -o json
     if scenario == "missing_policy": sys.exit(1)
     policy = json.load(open(os.environ["POLICY_JSON"]))
     spec = policy["spec"]
-    if scenario == "malformed_policy": spec["policyTypes"] = ["Ingress"]
-    elif scenario == "broad_source": spec["podSelector"] = {}
-    elif scenario == "broad_destination": spec["egress"][0]["to"][0]["podSelector"] = {}
-    elif scenario == "wrong_protocol": spec["egress"][0]["ports"][0]["protocol"] = "UDP"
-    elif scenario == "wrong_port": spec["egress"][0]["ports"][0]["port"] = 9116
-    elif scenario == "additional_protocol": spec["egress"][0]["ports"].append({"protocol": "UDP", "port": 9115})
-    elif scenario == "additional_port": spec["egress"][0]["ports"].append({"protocol": "TCP", "port": 9116})
-    elif scenario == "additional_source_selector": spec["podSelector"]["matchLabels"]["extra"] = "forbidden"
-    elif scenario == "additional_destination_selector": spec["egress"][0]["to"][0]["podSelector"]["matchLabels"]["extra"] = "forbidden"
-    elif scenario == "additional_peer": spec["egress"][0]["to"].append({"ipBlock": {"cidr": "0.0.0.0/0"}})
-    elif scenario == "additional_rule": spec["egress"].append({"to": [{"podSelector": {}}]})
-    elif scenario == "namespace_selector": spec["egress"][0]["to"][0]["namespaceSelector"] = {}
-    elif scenario == "ingress_spec": spec["ingress"] = []
-    elif scenario == "additional_policy_type": spec["policyTypes"].append("Ingress")
+    if scenario == "old_egress_policy":
+        spec = {
+            "podSelector": {"matchLabels": {"operator.prometheus.io/name": "kube-prometheus-stack-prometheus"}},
+            "policyTypes": ["Egress"],
+            "egress": [{"to": [{"podSelector": {"matchLabels": {"app.kubernetes.io/instance": "prometheus-blackbox-exporter", "app.kubernetes.io/name": "prometheus-blackbox-exporter"}}}], "ports": [{"protocol": "TCP", "port": 9115}]}],
+        }
+    elif scenario == "egress_field": spec["egress"] = []
+    elif scenario == "egress_policy_type": spec["policyTypes"] = ["Egress"]
+    elif scenario == "broad_top_level_selector": spec["podSelector"] = {}
+    elif scenario == "broad_peer_selector": spec["ingress"][0]["from"][0]["podSelector"] = {}
+    elif scenario == "wrong_protocol": spec["ingress"][0]["ports"][0]["protocol"] = "UDP"
+    elif scenario == "wrong_port": spec["ingress"][0]["ports"][0]["port"] = 9116
+    elif scenario == "additional_protocol": spec["ingress"][0]["ports"].append({"protocol": "UDP", "port": 9115})
+    elif scenario == "additional_port": spec["ingress"][0]["ports"].append({"protocol": "TCP", "port": 9116})
+    elif scenario == "additional_top_level_selector": spec["podSelector"]["matchLabels"]["extra"] = "forbidden"
+    elif scenario == "additional_peer_selector": spec["ingress"][0]["from"][0]["podSelector"]["matchLabels"]["extra"] = "forbidden"
+    elif scenario == "additional_peer": spec["ingress"][0]["from"].append({"ipBlock": {"cidr": "0.0.0.0/0"}})
+    elif scenario == "additional_rule": spec["ingress"].append({"from": [{"podSelector": {}}]})
+    elif scenario == "ip_block": spec["ingress"][0]["from"][0]["ipBlock"] = {"cidr": "0.0.0.0/0"}
+    elif scenario == "namespace_selector": spec["ingress"][0]["from"][0]["namespaceSelector"] = {}
+    elif scenario == "additional_policy_type": spec["policyTypes"].append("Egress")
+    policy["spec"] = spec
     print(json.dumps(policy))
 elif "get probe -l" in joined and "-o json" in joined:
     print(open(os.environ["PROBES_JSON"]).read())
@@ -366,6 +374,35 @@ def test_render_stdout_is_a_clean_separated_kubernetes_stream(scenario):
     assert "blackbox environment: staging" in result.stderr
 
 
+def test_render_rejects_former_prometheus_selecting_egress_policy(scenario):
+    unsafe = scenario.root / "unsafe-egress-policy.yaml"
+    unsafe.write_text("""apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-kube-prometheus-stack-to-blackbox-exporter
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      operator.prometheus.io/name: kube-prometheus-stack-prometheus
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: prometheus-blackbox-exporter
+              app.kubernetes.io/name: prometheus-blackbox-exporter
+      ports:
+        - protocol: TCP
+          port: 9115
+""")
+    result = scenario.run("upgrade", POLICY=unsafe)
+    assert result.returncode == 1
+    assert "must not select or isolate Prometheus egress" in result.stderr
+    assert not any("config current-context" in line for line in scenario.log)
+    assert not mutations(scenario.log)
+
+
 @pytest.mark.parametrize("failure", ["bad_context", "bad_identity"])
 def test_identity_guards_precede_release_queries_and_mutation(scenario, failure):
     result = scenario.run("install", SCENARIO=failure)
@@ -441,19 +478,21 @@ def test_failed_policy_apply_suppresses_probe_mutation(scenario):
     "failure",
     [
         "missing_policy",
-        "malformed_policy",
-        "broad_source",
-        "broad_destination",
+        "old_egress_policy",
+        "egress_field",
+        "egress_policy_type",
+        "broad_top_level_selector",
+        "broad_peer_selector",
         "wrong_protocol",
         "wrong_port",
         "additional_protocol",
         "additional_port",
-        "additional_source_selector",
-        "additional_destination_selector",
+        "additional_top_level_selector",
+        "additional_peer_selector",
         "additional_peer",
         "additional_rule",
+        "ip_block",
         "namespace_selector",
-        "ingress_spec",
         "additional_policy_type",
     ],
 )


### PR DESCRIPTION
### Motivation
- Correct a faulty NetworkPolicy that previously selected Prometheus for `Egress` and could (and did) isolate Prometheus egress on the observed staging baseline. 
- Narrow the lifecycle policy to select only the exporter and permit only ingress from the canonical kube-prometheus-stack Prometheus pods on TCP 9115.

### Description
- Replace the Prometheus-selecting `Egress` policy with an exporter-selecting, `Ingress`-only policy at `clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml` so the top-level selector is the exporter and the sole peer is Prometheus on TCP 9115. 
- Update `scripts/observability_blackbox.sh` to derive selectors from pinned chart renders, validate that the rendered lifecycle policy is exactly the ingress-only structure, and explicitly reject any lifecycle render that would select or isolate Prometheus egress or include `egress`/`Egress` semantics. 
- Add and adjust tests in `tests/test_observability_blackbox.py` and `tests/test_monitoring_blackbox.py` to cover the former unsafe egress form, the new ingress-only semantics, selector drift, extra/broad selectors/peers/ports/protocols, render cleanliness, and mutation ordering/guard behavior. 
- Update runbooks `docs/observability-blackbox.md` and `docs/observability-operations.md` to explain the observed live baseline, why the egress form was unsafe, that Prometheus egress and DNS remain unaffected by the corrected policy, and to advise using `observability-blackbox-upgrade` (not install) for the post-merge correction.

### Testing
- Ran `bash -n scripts/observability_blackbox.sh` (syntax check) — passed. 
- Ran `pytest -q tests/test_observability_blackbox.py` — passed. 
- Ran `pytest -q tests/test_monitoring_blackbox.py tests/test_observability_blackbox.py` — passed. 
- Ran `ruff check tests/test_observability_blackbox.py tests/test_monitoring_blackbox.py` — passed. 
- Ran `black --check tests/test_observability_blackbox.py tests/test_monitoring_blackbox.py` — passed. 
- Ran `git diff --check` — passed (no diff-check issues). 
- Ran `git diff | ./scripts/scan-secrets.py` — passed (no secrets detected). 
- Additional repository checks run: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` — both passed. 
- Note: a full `pre-commit run --all-files` encountered unrelated, pre-existing repository-wide lint/format issues outside the narrow scope of this change (these are unrelated codebase debt and were not introduced by this PR); targeted hooks for the changed files passed. 

No live Helm or `kubectl` mutation was performed during these edits or tests; all verification and tests were executed offline or against stubbed helpers per the repository conventions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65a4a8c260832f8f53d07581a0d850)