### PR TITLE
Correct staging blackbox NetworkPolicy direction

### DIFF
--- a/clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml
+++ b/clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml
@@ -6,15 +6,15 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      operator.prometheus.io/name: kube-prometheus-stack-prometheus
+      app.kubernetes.io/instance: prometheus-blackbox-exporter
+      app.kubernetes.io/name: prometheus-blackbox-exporter
   policyTypes:
-    - Egress
-  egress:
-    - to:
+    - Ingress
+  ingress:
+    - from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/instance: prometheus-blackbox-exporter
-              app.kubernetes.io/name: prometheus-blackbox-exporter
+              operator.prometheus.io/name: kube-prometheus-stack-prometheus
       ports:
         - protocol: TCP
           port: 9115

--- a/docs/observability-blackbox.md
+++ b/docs/observability-blackbox.md
@@ -6,8 +6,11 @@ only. The exporter is a `ClusterIP` service; this work adds no Ingress,
 NodePort, public DNS, router rule, credential, or persistence. The lifecycle
 owns one staging-only NetworkPolicy that permits only the canonical
 `kube-prometheus-stack` Prometheus pods to reach only the canonical exporter
-pods on TCP 9115. Existing monitoring DNS and external HTTPS permissions are
-unchanged.
+pods on TCP 9115. The policy selects the exporter and isolates only its ingress;
+it does not select Prometheus or affect Prometheus DNS or any other egress. The
+observed live baseline had no monitoring default-deny policy or
+`allow-monitoring-ingress` policy, so this lifecycle does not assume either one
+exists.
 
 ## Canonical sources
 
@@ -73,22 +76,30 @@ app/route target matrix, `probe_success == 1`, and the duration, HTTP status,
 DNS lookup, and earliest TLS certificate-expiry metric families. It never logs
 raw target payloads or URLs; terminal diagnostics contain bounded labels and
 health/series states only. Before polling Prometheus, verification fails closed
-unless the deployed policy has exactly the required source selector,
-destination selector, Egress policy type, single peer/rule, and TCP 9115 port;
-broad or additional behavior is rejected.
+unless the deployed policy selects exactly the exporter pods and has one
+ingress peer selecting exactly the Prometheus pods, one rule, the sole
+`Ingress` policy type, and exactly TCP 9115; broad or additional behavior is
+rejected.
+The exact policy has a single `Ingress` type and no `egress` field. The former
+policy selected Prometheus for egress, which caused Kubernetes to isolate all
+Prometheus egress on the observed baseline while allowing only exporter TCP
+9115. That blocked DNS and put every scrape path at risk. Selecting only the
+exporter for ingress avoids that failure mode: Prometheus DNS and all other
+egress remain unaffected, while the exporter remains ClusterIP-only.
 
 ## Post-merge rollout
 
 1. Select and independently confirm the staging kubeconfig and cluster identity.
 2. Review `just observability-blackbox-render env=staging` without applying it.
-3. If `helm -n monitoring list --all --filter '^prometheus-blackbox-exporter$'`
-   shows no release, run `just observability-blackbox-install env=staging`; if
-   it shows the release, run `just observability-blackbox-upgrade env=staging`.
+3. The staging exporter release already exists, so run
+   `just observability-blackbox-upgrade env=staging`. Install remains reserved
+   for a genuinely absent release on a fresh staging cluster.
 4. Run status, then verify. Preserve this output as separate live evidence.
 5. Stop and investigate rather than attempting production if any guard fails.
 
-No live deployment was performed as part of this repository change; repository
-state is not evidence of a live rollout.
+Repository tests perform no live mutation. No live deployment was performed as
+part of this repository change; repository state is not evidence of a live
+rollout.
 
 ## Rollback
 

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -15,6 +15,14 @@ The staging blackbox exporter and Probe lifecycle is documented separately in
 [Staging blackbox monitoring](observability-blackbox.md). That guarded lifecycle
 exclusively owns its narrowly scoped staging Prometheus-to-exporter
 NetworkPolicy; it is not part of an active Flux or cluster Kustomize graph.
+The observed live baseline had no monitoring default-deny or
+`allow-monitoring-ingress` policy. The blackbox policy therefore selects only
+the exporter and isolates only ingress to it, allowing the canonical Prometheus
+pods to reach TCP 9115. The former egress policy selected Prometheus and was
+unsafe because that selection isolated every Prometheus egress path, including
+DNS, while permitting only exporter traffic. The corrected policy leaves
+Prometheus DNS and all other egress unaffected. The exporter remains
+ClusterIP-only.
 
 The old Flux/Longhorn files under `platform/observability/*.yaml` and `clusters/*/patches/kube-prometheus-stack-values.yaml` are inactive, unvalidated future/legacy configuration. They are deliberately absent from the platform resources and cluster overlay patches, so Flux does not reconcile the manually managed release. They must not be applied to staging or production as currently written, and operators must not combine Flux and manual Helm lifecycle paths for the same `kube-prometheus-stack` release.
 
@@ -50,6 +58,10 @@ Each helper prints the resolved environment, current Kubernetes context, namespa
 - `just observability-upgrade env=staging` is for steady-state changes. It renders first, checks the staging context, and fails if the Helm release does not exist.
 
 The mutating recipes never use `--reuse-values`; the committed version and both values files are always supplied in order.
+The existing staging blackbox exporter release is upgraded after this change
+with `just observability-blackbox-upgrade env=staging`; it is not reinstalled.
+Repository tests do not perform any live cluster mutation, and repository state
+is not rollout evidence.
 
 ## Fresh install procedure
 

--- a/scripts/observability_blackbox.sh
+++ b/scripts/observability_blackbox.sh
@@ -103,7 +103,7 @@ for key in ("app.kubernetes.io/instance","app.kubernetes.io/name"):
     labels[key]=value
 # Helm renders the Prometheus CR; operator-created pods carry
 # operator.prometheus.io/name=<CR name>, so the render supplies this value.
-json.dump({"source":{"operator.prometheus.io/name":base[0]["metadata"]["name"]},"destination":labels},open(sys.argv[3],"w",encoding="utf-8"),sort_keys=True)
+json.dump({"prometheus":{"operator.prometheus.io/name":base[0]["metadata"]["name"]},"exporter":labels},open(sys.argv[3],"w",encoding="utf-8"),sort_keys=True)
 PY
   validate_policy_file "${policy_json}" "${selectors_out}"
   python3 "${ROOT}/scripts/verify_blackbox_prometheus.py" --probes <"${probes_json}"
@@ -117,14 +117,14 @@ if len(objects) != 1 or not isinstance(objects[0],dict):
     raise SystemExit("ERROR: lifecycle policy render must contain exactly one non-null Kubernetes object.")
 policy=objects[0]
 expected = {
-    "podSelector": {"matchLabels": selectors["source"]},
-    "policyTypes": ["Egress"],
-    "egress": [{"to": [{"podSelector": {"matchLabels": selectors["destination"]}}], "ports": [{"protocol": "TCP", "port": 9115}]}],
+    "podSelector": {"matchLabels": selectors["exporter"]},
+    "policyTypes": ["Ingress"],
+    "ingress": [{"from": [{"podSelector": {"matchLabels": selectors["prometheus"]}}], "ports": [{"protocol": "TCP", "port": 9115}]}],
 }
 required={"apiVersion": "networking.k8s.io/v1", "kind": "NetworkPolicy", "metadata": {"name": sys.argv[2], "namespace": sys.argv[3]}, "spec": expected}
 policy.get("metadata",{}).pop("creationTimestamp",None)
 if policy != required:
-    raise SystemExit("ERROR: lifecycle NetworkPolicy is not the required exact narrow policy.")
+    raise SystemExit("ERROR: lifecycle NetworkPolicy must isolate only exporter ingress; Prometheus-selecting egress policies are forbidden.")
 json.dump(required,open(sys.argv[5],"w",encoding="utf-8"),sort_keys=True)
 PY
 }
@@ -181,7 +181,7 @@ import json, sys
 live=json.load(sys.stdin); expected=json.load(open(sys.argv[1]))
 live={"apiVersion":live.get("apiVersion"),"kind":live.get("kind"),"metadata":{"name":live.get("metadata",{}).get("name"),"namespace":live.get("metadata",{}).get("namespace")},"spec":live.get("spec")}
 if live != expected:
- raise SystemExit("ERROR: deployed lifecycle NetworkPolicy differs from the required exact narrow policy.")
+ raise SystemExit("ERROR: deployed lifecycle NetworkPolicy must isolate only exporter ingress; Prometheus-selecting egress policies are forbidden.")
 ' "${EXPECTED_POLICY_JSON}" <<<"${policy}" || exit 7
 }
 validate_resources() {

--- a/tests/test_monitoring_blackbox.py
+++ b/tests/test_monitoring_blackbox.py
@@ -195,11 +195,11 @@ def test_lifecycle_network_policy_is_exact_and_chart_render_backed():
         and doc["metadata"]["name"] == "prometheus-blackbox-exporter"
     ]
     assert len(prometheus) == len(deployments) == 1
-    source = {
+    prometheus_selector = {
         "operator.prometheus.io/name": prometheus[0]["metadata"]["name"],
     }
     rendered_labels = deployments[0]["spec"]["template"]["metadata"]["labels"]
-    destination = {
+    exporter_selector = {
         key: rendered_labels[key]
         for key in ("app.kubernetes.io/instance", "app.kubernetes.io/name")
     }
@@ -211,16 +211,18 @@ def test_lifecycle_network_policy_is_exact_and_chart_render_backed():
             "namespace": "monitoring",
         },
         "spec": {
-            "podSelector": {"matchLabels": source},
-            "policyTypes": ["Egress"],
-            "egress": [
+            "podSelector": {"matchLabels": exporter_selector},
+            "policyTypes": ["Ingress"],
+            "ingress": [
                 {
-                    "to": [{"podSelector": {"matchLabels": destination}}],
+                    "from": [{"podSelector": {"matchLabels": prometheus_selector}}],
                     "ports": [{"protocol": "TCP", "port": 9115}],
                 }
             ],
         },
     }
+    assert "egress" not in policy["spec"]
+    assert "Egress" not in policy["spec"]["policyTypes"]
     assert (POLICY.parent / "kustomization.yaml").read_text().count(POLICY.name) == 1
     for graph in [
         ROOT / "platform/networking/kustomization.yaml",

--- a/tests/test_observability_blackbox.py
+++ b/tests/test_observability_blackbox.py
@@ -165,20 +165,23 @@ elif "get networkpolicy allow-kube-prometheus-stack-to-blackbox-exporter -o json
     if scenario == "missing_policy": sys.exit(1)
     policy = json.load(open(os.environ["POLICY_JSON"]))
     spec = policy["spec"]
-    if scenario == "malformed_policy": spec["policyTypes"] = ["Ingress"]
-    elif scenario == "broad_source": spec["podSelector"] = {}
-    elif scenario == "broad_destination": spec["egress"][0]["to"][0]["podSelector"] = {}
-    elif scenario == "wrong_protocol": spec["egress"][0]["ports"][0]["protocol"] = "UDP"
-    elif scenario == "wrong_port": spec["egress"][0]["ports"][0]["port"] = 9116
-    elif scenario == "additional_protocol": spec["egress"][0]["ports"].append({"protocol": "UDP", "port": 9115})
-    elif scenario == "additional_port": spec["egress"][0]["ports"].append({"protocol": "TCP", "port": 9116})
-    elif scenario == "additional_source_selector": spec["podSelector"]["matchLabels"]["extra"] = "forbidden"
-    elif scenario == "additional_destination_selector": spec["egress"][0]["to"][0]["podSelector"]["matchLabels"]["extra"] = "forbidden"
-    elif scenario == "additional_peer": spec["egress"][0]["to"].append({"ipBlock": {"cidr": "0.0.0.0/0"}})
-    elif scenario == "additional_rule": spec["egress"].append({"to": [{"podSelector": {}}]})
-    elif scenario == "namespace_selector": spec["egress"][0]["to"][0]["namespaceSelector"] = {}
-    elif scenario == "ingress_spec": spec["ingress"] = []
-    elif scenario == "additional_policy_type": spec["policyTypes"].append("Ingress")
+    if scenario == "old_egress_policy":
+        spec = policy["spec"] = {"podSelector": {"matchLabels": {"operator.prometheus.io/name": "kube-prometheus-stack-prometheus"}}, "policyTypes": ["Egress"], "egress": [{"to": [{"podSelector": {"matchLabels": {"app.kubernetes.io/instance": "prometheus-blackbox-exporter", "app.kubernetes.io/name": "prometheus-blackbox-exporter"}}}], "ports": [{"protocol": "TCP", "port": 9115}]}]}
+    elif scenario == "malformed_policy": spec["policyTypes"] = ["Egress"]
+    elif scenario == "broad_exporter": spec["podSelector"] = {}
+    elif scenario == "broad_prometheus": spec["ingress"][0]["from"][0]["podSelector"] = {}
+    elif scenario == "wrong_protocol": spec["ingress"][0]["ports"][0]["protocol"] = "UDP"
+    elif scenario == "wrong_port": spec["ingress"][0]["ports"][0]["port"] = 9116
+    elif scenario == "additional_protocol": spec["ingress"][0]["ports"].append({"protocol": "UDP", "port": 9115})
+    elif scenario == "additional_port": spec["ingress"][0]["ports"].append({"protocol": "TCP", "port": 9116})
+    elif scenario == "additional_exporter_selector": spec["podSelector"]["matchLabels"]["extra"] = "forbidden"
+    elif scenario == "additional_prometheus_selector": spec["ingress"][0]["from"][0]["podSelector"]["matchLabels"]["extra"] = "forbidden"
+    elif scenario == "additional_peer": spec["ingress"][0]["from"].append({"ipBlock": {"cidr": "0.0.0.0/0"}})
+    elif scenario == "additional_rule": spec["ingress"].append({"from": [{"podSelector": {}}]})
+    elif scenario == "namespace_selector": spec["ingress"][0]["from"][0]["namespaceSelector"] = {}
+    elif scenario == "ip_block": spec["ingress"][0]["from"][0] = {"ipBlock": {"cidr": "0.0.0.0/0"}}
+    elif scenario == "egress_spec": spec["egress"] = []
+    elif scenario == "additional_policy_type": spec["policyTypes"].append("Egress")
     print(json.dumps(policy))
 elif "get probe -l" in joined and "-o json" in joined:
     print(open(os.environ["PROBES_JSON"]).read())
@@ -348,6 +351,83 @@ def test_rendered_selector_drift_fails_before_cluster_access(scenario, failure):
     assert not mutations(scenario.log)
 
 
+@pytest.mark.parametrize(
+    "failure",
+    [
+        "old_egress_policy",
+        "broad_exporter",
+        "broad_prometheus",
+        "additional_exporter_selector",
+        "additional_prometheus_selector",
+        "additional_peer",
+        "additional_rule",
+        "additional_port",
+        "additional_protocol",
+        "ip_block",
+        "namespace_selector",
+        "egress_spec",
+        "additional_policy_type",
+    ],
+)
+def test_lifecycle_policy_drift_fails_before_cluster_access_or_mutation(scenario, failure):
+    policy = json.loads(Path(scenario.env["POLICY_JSON"]).read_text())
+    spec = policy["spec"]
+    if failure == "old_egress_policy":
+        spec = policy["spec"] = {
+            "podSelector": {
+                "matchLabels": {"operator.prometheus.io/name": "kube-prometheus-stack-prometheus"}
+            },
+            "policyTypes": ["Egress"],
+            "egress": [
+                {
+                    "to": [
+                        {
+                            "podSelector": {
+                                "matchLabels": {
+                                    "app.kubernetes.io/instance": "prometheus-blackbox-exporter",
+                                    "app.kubernetes.io/name": "prometheus-blackbox-exporter",
+                                }
+                            }
+                        }
+                    ],
+                    "ports": [{"protocol": "TCP", "port": 9115}],
+                }
+            ],
+        }
+    elif failure == "broad_exporter":
+        spec["podSelector"] = {}
+    elif failure == "broad_prometheus":
+        spec["ingress"][0]["from"][0]["podSelector"] = {}
+    elif failure == "additional_exporter_selector":
+        spec["podSelector"]["matchLabels"]["extra"] = "forbidden"
+    elif failure == "additional_prometheus_selector":
+        spec["ingress"][0]["from"][0]["podSelector"]["matchLabels"]["extra"] = "forbidden"
+    elif failure == "additional_peer":
+        spec["ingress"][0]["from"].append({"podSelector": {}})
+    elif failure == "additional_rule":
+        spec["ingress"].append({"from": [{"podSelector": {}}]})
+    elif failure == "additional_port":
+        spec["ingress"][0]["ports"].append({"protocol": "TCP", "port": 9116})
+    elif failure == "additional_protocol":
+        spec["ingress"][0]["ports"].append({"protocol": "UDP", "port": 9115})
+    elif failure == "ip_block":
+        spec["ingress"][0]["from"][0] = {"ipBlock": {"cidr": "0.0.0.0/0"}}
+    elif failure == "namespace_selector":
+        spec["ingress"][0]["from"][0]["namespaceSelector"] = {}
+    elif failure == "egress_spec":
+        spec["egress"] = []
+    else:
+        spec["policyTypes"].append("Egress")
+    invalid_policy = scenario.root / f"{failure}.yaml"
+    invalid_policy.write_text(json.dumps(policy))
+
+    result = scenario.run("upgrade", POLICY=invalid_policy)
+
+    assert result.returncode != 0
+    assert not any("config current-context" in line for line in scenario.log)
+    assert not mutations(scenario.log)
+
+
 def test_render_stdout_is_a_clean_separated_kubernetes_stream(scenario):
     result = scenario.run("render")
     assert result.returncode == 0
@@ -441,19 +521,21 @@ def test_failed_policy_apply_suppresses_probe_mutation(scenario):
     "failure",
     [
         "missing_policy",
+        "old_egress_policy",
         "malformed_policy",
-        "broad_source",
-        "broad_destination",
+        "broad_exporter",
+        "broad_prometheus",
         "wrong_protocol",
         "wrong_port",
         "additional_protocol",
         "additional_port",
-        "additional_source_selector",
-        "additional_destination_selector",
+        "additional_exporter_selector",
+        "additional_prometheus_selector",
         "additional_peer",
         "additional_rule",
         "namespace_selector",
-        "ingress_spec",
+        "ip_block",
+        "egress_spec",
         "additional_policy_type",
     ],
 )

--- a/tests/test_observability_blackbox.py
+++ b/tests/test_observability_blackbox.py
@@ -241,7 +241,7 @@ class Scenario:
         args = [str(SCRIPT), command]
         if environment is not None:
             args.append(f"env={environment}")
-        return subprocess.run(args, cwd=ROOT, env=env, text=True, capture_output=True)
+        return subprocess.run(args, cwd=ROOT, env=env, text=True, capture_output=True, check=False)
 
 
 @pytest.fixture


### PR DESCRIPTION
### Motivation
- A merged change created a Prometheus‑selecting Egress NetworkPolicy that in the observed live staging baseline isolated Prometheus egress (including DNS) and caused monitoring outages.  
- The lifecycle must instead isolate only the exporter ingress so Prometheus egress (DNS and other outbound traffic) is never isolated by this manifest.  
- The repository tooling must derive selectors from pinned chart renders and reject any manifest shape that could reintroduce a Prometheus‑selecting egress policy before touching the cluster.

### Description
- Replace the canonical manifest `clusters/staging/observability/network-policies/prometheus-to-blackbox-exporter.yaml` so the top-level `podSelector` selects the exporter, the policy uses exactly `policyTypes: ["Ingress"]`, permits only `from` the canonical Prometheus pod selector, and exposes exactly TCP `9115`.  
- Update `scripts/observability_blackbox.sh` to derive Prometheus/exporter selectors from pinned chart renders, validate the rendered lifecycle policy against the exact ingress-only structure, write the expected policy JSON, and explicitly reject any Prometheus-selecting Egress form or any egress field before cluster access or mutation.  
- Strengthen regression coverage in `tests/test_observability_blackbox.py` and `tests/test_monitoring_blackbox.py` to assert exporter-top-level selection, single ingress peer of Prometheus, sole Ingress/TCP/9115 semantics, rejection of former egress policy, and many additional malformed/broad-policy drift scenarios.  
- Update docs (`docs/observability-blackbox.md` and `docs/observability-operations.md`) to explain the observed baseline, why the egress form was unsafe, that the corrected policy isolates only exporter ingress, that Prometheus DNS/egress remain unaffected, and that staging uses an upgrade path for the existing release.

### Testing
- `bash -n scripts/observability_blackbox.sh` — syntax check succeeded.  
- `pytest -q tests/test_observability_blackbox.py` — 67 passed.  
- `pytest -q tests/test_monitoring_blackbox.py tests/test_observability_blackbox.py` — 71 passed in the combined run.  
- `ruff check tests/test_observability_blackbox.py tests/test_monitoring_blackbox.py` and `black --check tests/test_observability_blackbox.py tests/test_monitoring_blackbox.py` — checks passed (formatting fixed where required).  
- `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` — spelling and link checks passed.  
- `git diff --check` and `git diff | ./scripts/scan-secrets.py` — no new issues found.  
- `pre-commit run --all-files` was attempted but failed on unrelated, repository-wide legacy hooks and YAML multi-document checks; those unrelated fixes were not committed and were reverted before the final commit.  

All automated tests and targeted linters for the changed surfaces passed after the edits, and no live Helm or kubectl mutation was performed during this work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65a4a360c0832f9e226ea7fe62721c)