### PR TITLE
Provision staging Grafana dashboard as code

### DIFF
--- a/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
+++ b/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
@@ -527,7 +527,9 @@
         {
           "refId": "A",
           "expr": "dspace_build_info{environment=~\"$environment\"}",
-          "legendFormat": "{{pod}} {{version}} {{revision}}"
+          "legendFormat": "{{pod}} {{version}} {{revision}}",
+          "instant": true,
+          "range": false
         }
       ],
       "fieldConfig": {
@@ -685,7 +687,9 @@
         {
           "refId": "A",
           "expr": "probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}",
-          "legendFormat": "{{environment}} / {{app}} / {{route}}"
+          "legendFormat": "{{environment}} / {{app}} / {{route}}",
+          "instant": true,
+          "range": false
         }
       ],
       "fieldConfig": {
@@ -789,7 +793,9 @@
         {
           "refId": "A",
           "expr": "probe_http_status_code{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}",
-          "legendFormat": "{{environment}} / {{app}} / {{route}}"
+          "legendFormat": "{{environment}} / {{app}} / {{route}}",
+          "instant": true,
+          "range": false
         }
       ],
       "fieldConfig": {

--- a/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
+++ b/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
@@ -1,0 +1,892 @@
+{
+  "id": null,
+  "uid": "sugarkube-staging-observability",
+  "title": "Sugarkube Staging Observability",
+  "tags": [
+    "sugarkube",
+    "staging",
+    "provisioned"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 41,
+  "version": 1,
+  "editable": false,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "environment",
+        "label": "Environment",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": {
+          "query": "label_values(probe_success, environment)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": false,
+        "multi": false,
+        "allValue": null,
+        "current": {
+          "text": "staging",
+          "value": "staging"
+        }
+      },
+      {
+        "name": "app",
+        "label": "Application",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": {
+          "query": "label_values(probe_success{environment=~\"$environment\"}, app)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        }
+      },
+      {
+        "name": "route",
+        "label": "Route",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": {
+          "query": "label_values(probe_success{environment=~\"$environment\",app=~\"$app\"}, route)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        }
+      }
+    ]
+  },
+  "annotations": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Overall status",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "DSPACE scrape availability",
+      "description": "Prometheus scrape availability for DSPACE.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "min(up{namespace=\"dspace\",app=\"dspace\"})",
+          "legendFormat": "DSPACE scrape"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "DSPACE instrumentation status",
+      "description": "Application instrumentation self-check.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "min(dspace_instrumentation_up{environment=~\"$environment\"})",
+          "legendFormat": "Instrumentation"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Public endpoint availability",
+      "description": "Latest bounded public probe result.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})",
+          "legendFormat": "{{environment}} / {{app}} / {{route}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "FAILED",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "UP",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 5,
+      "type": "row",
+      "title": "DSPACE HTTP",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Request rate by route and status class",
+      "description": "Bounded route templates and status classes only.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (route, status_class) (rate(dspace_http_requests_total{environment=~\"$environment\"}[$__rate_interval]))",
+          "legendFormat": "{{route}} {{status_class}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 7,
+      "type": "barchart",
+      "title": "Status-class distribution",
+      "description": "Requests in the selected range grouped by bounded status class.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (status_class) (increase(dspace_http_requests_total{environment=~\"$environment\"}[$__range]))",
+          "legendFormat": "{{status_class}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "5xx error ratio",
+      "description": "Fraction of observed DSPACE HTTP requests returning 5xx.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 15
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(dspace_http_requests_total{environment=~\"$environment\",status_class=\"5xx\"}[$__rate_interval])) / clamp_min(sum(rate(dspace_http_requests_total{environment=~\"$environment\"}[$__rate_interval])), 1e-9)",
+          "legendFormat": "5xx ratio"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "HTTP latency percentiles",
+      "description": "DSPACE HTTP latency by bounded route template.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 8,
+        "y": 15
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(.50, sum by (le, route) (rate(dspace_http_request_duration_seconds_bucket{environment=~\"$environment\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{route}}"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(.95, sum by (le, route) (rate(dspace_http_request_duration_seconds_bucket{environment=~\"$environment\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{route}}"
+        },
+        {
+          "refId": "C",
+          "expr": "histogram_quantile(.99, sum by (le, route) (rate(dspace_http_request_duration_seconds_bucket{environment=~\"$environment\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{route}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "DSPACE runtime and release",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      }
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Resident memory by pod",
+      "description": "Resident process memory for each DSPACE pod.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "process_resident_memory_bytes{namespace=\"dspace\",app=\"dspace\",environment=~\"$environment\"}",
+          "legendFormat": "{{pod}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 12,
+      "type": "table",
+      "title": "Build identity",
+      "description": "Safe release identity fields: pod, version, and revision.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "dspace_build_info{environment=~\"$environment\"}",
+          "legendFormat": "{{pod}} {{version}} {{revision}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 13,
+      "type": "row",
+      "title": "DSPACE feature traffic",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      }
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "dChat request activity",
+      "description": "Zero means no dChat requests were observed; it is not an instrumentation failure.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(dspace_dchat_requests_total{environment=~\"$environment\"}[$__rate_interval])) or on() vector(0)",
+          "legendFormat": "dChat requests"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "No requests observed"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "token.place dependency request activity",
+      "description": "Zero means no token.place dependency requests were observed; it is not an instrumentation failure.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(dspace_dependency_requests_total{environment=~\"$environment\",dependency=\"tokenplace\"}[$__rate_interval])) or on() vector(0)",
+          "legendFormat": "token.place requests"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "No requests observed"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 16,
+      "type": "row",
+      "title": "Blackbox monitoring",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      }
+    },
+    {
+      "id": 17,
+      "type": "table",
+      "title": "Endpoint matrix",
+      "description": "Latest endpoint result without exposing raw target URLs.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}",
+          "legendFormat": "{{environment}} / {{app}} / {{route}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "FAILED",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "UP",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "Probe duration",
+      "description": "End-to-end blackbox probe duration.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "probe_duration_seconds{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}",
+          "legendFormat": "{{environment}} / {{app}} / {{route}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 19,
+      "type": "table",
+      "title": "HTTP response status",
+      "description": "HTTP response status by bounded labels.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 51
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "probe_http_status_code{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}",
+          "legendFormat": "{{environment}} / {{app}} / {{route}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 200
+              },
+              {
+                "color": "yellow",
+                "value": 400
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "TLS certificate lifetime",
+      "description": "Days until the earliest certificate expiry.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 51
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "(probe_ssl_earliest_cert_expiry{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"} - time()) / 86400",
+          "legendFormat": "{{environment}} / {{app}} / {{route}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "d",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 7
+              },
+              {
+                "color": "yellow",
+                "value": 14
+              },
+              {
+                "color": "green",
+                "value": 30
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    }
+  ]
+}

--- a/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
+++ b/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
@@ -526,7 +526,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "dspace_build_info{environment=~\"$environment\"}",
+          "expr": "max by (pod, version, revision) (dspace_build_info{environment=~\"$environment\"})",
           "legendFormat": "{{pod}} {{version}} {{revision}}",
           "instant": true,
           "range": false
@@ -546,7 +546,27 @@
         "tooltip": {
           "mode": "multi"
         }
-      }
+      },
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true
+            },
+            "indexByName": {
+              "pod": 0,
+              "version": 1,
+              "revision": 2
+            }
+          }
+        }
+      ]
     },
     {
       "id": 13,
@@ -686,7 +706,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}",
+          "expr": "min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})",
           "legendFormat": "{{environment}} / {{app}} / {{route}}",
           "instant": true,
           "range": false
@@ -754,7 +774,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "probe_duration_seconds{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}",
+          "expr": "max by (environment, app, route) (probe_duration_seconds{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})",
           "legendFormat": "{{environment}} / {{app}} / {{route}}"
         }
       ],
@@ -792,7 +812,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "probe_http_status_code{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}",
+          "expr": "max by (environment, app, route) (probe_http_status_code{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})",
           "legendFormat": "{{environment}} / {{app}} / {{route}}",
           "instant": true,
           "range": false
@@ -853,7 +873,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "(probe_ssl_earliest_cert_expiry{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"} - time()) / 86400",
+          "expr": "(min by (environment, app, route) (probe_ssl_earliest_cert_expiry{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) - time()) / 86400",
           "legendFormat": "{{environment}} / {{app}} / {{route}}"
         }
       ],

--- a/docs/observability-design.md
+++ b/docs/observability-design.md
@@ -152,7 +152,12 @@ graph TD
 
 ### Persistent storage
 
-- Prometheus and Grafana need persistent volumes in staging/prod.
+- Prometheus needs persistent storage in staging. Grafana persistence remains
+  intentionally disabled for the current staging lifecycle: the first shared
+  dashboard is Helm-provisioned from
+  `clusters/staging/observability/dashboards/sugarkube-staging-observability.json`
+  and is therefore restored after pod replacement. Production storage remains
+  a future design decision.
 - Alerts should treat PV exhaustion and Prometheus write failures as observability-stack risks, not app outages.
 - If the monitoring PV is unavailable, app traffic must continue; the failure mode is loss of visibility, not application rollback.
 

--- a/docs/observability-design.md
+++ b/docs/observability-design.md
@@ -152,12 +152,7 @@ graph TD
 
 ### Persistent storage
 
-- Prometheus needs persistent storage in staging. Grafana persistence remains
-  intentionally disabled for the current staging lifecycle: the first shared
-  dashboard is Helm-provisioned from
-  `clusters/staging/observability/dashboards/sugarkube-staging-observability.json`
-  and is therefore restored after pod replacement. Production storage remains
-  a future design decision.
+- Prometheus and Grafana need persistent volumes in staging/prod.
 - Alerts should treat PV exhaustion and Prometheus write failures as observability-stack risks, not app outages.
 - If the monitoring PV is unavailable, app traffic must continue; the failure mode is loss of visibility, not application rollback.
 

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -9,7 +9,16 @@ Production observability is intentionally unsupported in this slice because no p
 - Chart version: `platform/observability/helm/kube-prometheus-stack.version` (`87.19.0`).
 - Common values: `platform/observability/helm/kube-prometheus-stack.values.common.yaml`.
 - Staging overrides: `clusters/staging/observability/kube-prometheus-stack.values.yaml`.
+- Staging dashboard: `clusters/staging/observability/dashboards/sugarkube-staging-observability.json`.
 - Helper: `scripts/observability_helm.sh` through `just observability-*` recipes.
+
+The dashboard is owned by Sugarkube and provisioned by the pinned Grafana
+subchart. Every render, install, and upgrade passes the same standalone JSON
+with Helm `--set-file`; the provider mounts it under
+`/var/lib/grafana/dashboards/sugarkube`. Its title is **Sugarkube Staging
+Observability** and its stable UID is `sugarkube-staging-observability`.
+Grafana's chart-rendered Prometheus datasource has stable UID `prometheus`,
+which the dashboard references directly.
 
 The staging blackbox exporter and Probe lifecycle is documented separately in
 [Staging blackbox monitoring](observability-blackbox.md). That guarded lifecycle
@@ -45,6 +54,7 @@ Never put example credentials or plaintext Secret data in commands, logs, docs, 
 just observability-render env=staging
 just observability-status env=staging
 just observability-verify env=staging
+just observability-dashboard-verify env=staging
 ```
 
 `env=int` is accepted only through the repository's deprecated alias normalization to `staging`. Missing, unknown, `prod`, and `production` fail before Helm or kubectl mutation with a message that production observability is not yet codified.
@@ -57,7 +67,12 @@ Each helper prints the resolved environment, current Kubernetes context, namespa
 - `just observability-install env=staging` is for a fresh cluster. It renders first, checks the staging context, and fails if the Helm release already exists.
 - `just observability-upgrade env=staging` is for steady-state changes. It renders first, checks the staging context, and fails if the Helm release does not exist.
 
-The mutating recipes never use `--reuse-values`; the committed version and both values files are always supplied in order.
+The mutating recipes never use `--reuse-values`; the committed version, both
+values files in order, and the dashboard source are always supplied. Before
+cluster access or mutation, the helper rejects malformed dashboard JSON,
+changed identity, duplicate panel IDs, missing metric families, unsafe
+event-driven queries, or invalid datasource references. It then validates that
+the pinned render contains exactly one copy in the intended Grafana provider.
 The existing staging blackbox exporter release is upgraded after this change
 with `just observability-blackbox-upgrade env=staging`; it is not reinstalled.
 Repository tests do not perform any live cluster mutation, and repository state
@@ -84,6 +99,7 @@ is not rollout evidence.
 5. Verify:
    ```bash
    just observability-verify env=staging
+   just observability-dashboard-verify env=staging
    ```
 
 ## Steady-state upgrade procedure
@@ -100,6 +116,7 @@ is not rollout evidence.
 4. Verify:
    ```bash
    just observability-verify env=staging
+   just observability-dashboard-verify env=staging
    ```
 
 ## Runtime expectations
@@ -108,6 +125,14 @@ is not rollout evidence.
 - Prometheus: one replica, `7d` retention, `15GB` retention size, `local-path` `ReadWriteOnce` PVC requesting `20Gi`, CPU request `200m`, memory request `512Mi`, memory limit `2Gi`, admin API disabled, and external label `cluster=sugarkube-int`.
 - Alertmanager: one replica and no-op receiver named exactly `"null"`.
 - Grafana: persistence disabled, no Ingress, LAN-only NodePort `30300`.
+- The provisioned dashboard defaults to six hours and a 30-second refresh. It
+  covers overall DSPACE and public-probe status, bounded DSPACE HTTP rate/error/
+  latency, runtime and build identity, feature traffic, and blackbox endpoint,
+  duration, HTTP status, and TLS lifetime views. Its staging `environment`,
+  `app`, and `route` variables avoid raw target URLs.
+- dChat and token.place dependency traffic may be absent until those features
+  receive requests. Their queries deliberately fall back to zero: **no requests
+  observed** is expected and is not an instrumentation failure.
 - Grafana URL: `http://sugarkube3.local:30300`; the same NodePort is available through the other staging nodes.
 - Prometheus, Alertmanager, and administrative services remain ClusterIP-only.
 - No public ingress, public DNS, Cloudflare route, router forwarding, or public observability endpoint is part of this lifecycle.
@@ -119,6 +144,12 @@ is not rollout evidence.
 - **Missing CRDs:** `observability-verify` fails on Prometheus Operator CRD checks; render/install/upgrade the pinned chart rather than applying Flux CRDs manually.
 - **Unbound PVC:** verify `kubectl -n monitoring get pvc` shows `Bound` and storage class `local-path`; investigate local-path provisioner and node disk health without pinning Prometheus to a node in Git.
 - **Missing Grafana Secret:** create or repair the operator-managed `grafana-admin-credentials` Secret out of band without committing values.
+- **Dashboard API verification:** `just observability-dashboard-verify
+  env=staging` checks the stable UID through Grafana's API. It validates context
+  and cluster identity first, reads the existing Secret without printing it,
+  uses a mode-`0600` temporary netrc and local port-forward, and removes both on
+  every exit path. It performs no Helm or Kubernetes mutation and redacts API
+  response diagnostics. A ConfigMap check alone is not acceptance evidence.
 - **Failed workloads:** use `just observability-status env=staging`, `kubectl -n monitoring describe`, and pod logs to identify image pulls, scheduling, resources, or PVC failures.
 
 ## Rollback
@@ -129,12 +160,50 @@ Use Helm rollback to the prior known-good revision, then restore the prior compl
 helm -n monitoring history kube-prometheus-stack
 helm -n monitoring rollback kube-prometheus-stack <prior-revision> --wait --timeout 20m
 just observability-verify env=staging
+just observability-dashboard-verify env=staging
 ```
 
 Do not use `--reuse-values` for the next forward upgrade; commit the full intended version and values chain first.
 
+## Reprovisioning proof and post-merge checklist
+
+Visual inspection of every panel, variable default, unit, mapping, and threshold
+remains part of staging acceptance. Prove that code provisioning, rather than
+Grafana persistence or a manual UI save, owns the dashboard by restarting the
+single Grafana pod and querying the API again:
+
+```bash
+cd ~/sugarkube
+git status --short
+git pull --ff-only
+just kubeconfig-env env=staging
+
+just observability-render env=staging \
+  >/tmp/kube-prometheus-stack.dashboard.rendered.yaml
+
+just observability-upgrade env=staging
+just observability-verify env=staging
+just observability-dashboard-verify env=staging
+just observability-blackbox-verify env=staging
+
+# Restart the single Grafana pod, wait for rollout, and prove that the
+# Helm-provisioned dashboard reappears without manual UI changes.
+kubectl -n monitoring delete pod \
+  -l 'app.kubernetes.io/name=grafana,app.kubernetes.io/instance=kube-prometheus-stack'
+
+kubectl -n monitoring rollout status \
+  deployment/kube-prometheus-stack-grafana \
+  --timeout=20m
+
+just observability-dashboard-verify env=staging
+```
+
+For rollback, use the existing Helm rollback procedure above. The prior Helm
+revision restores its dashboard ConfigMap; after a forward fix, the standard
+upgrade lifecycle again supplies the complete values chain and dashboard file.
+
 ## Follow-ups intentionally out of scope
 
-Dashboards, useful Alertmanager receivers, NetworkPolicies, Grafana persistence,
+Additional dashboards, useful Alertmanager receivers, Grafana persistence,
 central multi-cluster Grafana, and production observability codification are
-separate follow-ups.
+separate follow-ups. The existing blackbox NetworkPolicy is unchanged.

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -160,8 +160,13 @@ Use Helm rollback to the prior known-good revision, then restore the prior compl
 helm -n monitoring history kube-prometheus-stack
 helm -n monitoring rollback kube-prometheus-stack <prior-revision> --wait --timeout 20m
 just observability-verify env=staging
+# Run this only when <prior-revision> already provisioned the dashboard.
 just observability-dashboard-verify env=staging
 ```
+
+If `<prior-revision>` predates the first dashboard-as-code rollout, a missing
+dashboard is the expected rollback state: omit `observability-dashboard-verify`
+and use the general `observability-verify` result as acceptance evidence.
 
 Do not use `--reuse-values` for the next forward upgrade; commit the full intended version and values chain first.
 

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -147,9 +147,14 @@ is not rollout evidence.
 - **Dashboard API verification:** `just observability-dashboard-verify
   env=staging` checks the stable UID through Grafana's API. It validates context
   and cluster identity first, reads the existing Secret without printing it,
-  uses a mode-`0600` temporary netrc and local port-forward, and removes both on
-  every exit path. It performs no Helm or Kubernetes mutation and redacts API
-  response diagnostics. A ConfigMap check alone is not acceptance evidence.
+  uses a mode-`0600` temporary netrc, and asks this invocation's `kubectl` to
+  bind an ephemeral `127.0.0.1` port. Authentication begins only after that
+  child reports the exact owned forwarding endpoint. Success, failure, and
+  interruption all terminate and wait for the child and remove the netrc and
+  temporary directory. HTTP 401/403 responses fail immediately with redacted
+  diagnostics; only connection and readiness failures are retried. It performs
+  no Helm or Kubernetes mutation. A ConfigMap check alone is not acceptance
+  evidence.
 - **Failed workloads:** use `just observability-status env=staging`, `kubectl -n monitoring describe`, and pod logs to identify image pulls, scheduling, resources, or PVC failures.
 
 ## Rollback

--- a/justfile
+++ b/justfile
@@ -3298,6 +3298,10 @@ observability-status env='':
 observability-verify env='':
     @scripts/observability_helm.sh verify '{{ env }}'
 
+# Prove through the Grafana API that the staging dashboard is loaded (read-only).
+observability-dashboard-verify env='':
+    @scripts/observability_helm.sh dashboard-verify '{{ env }}'
+
 # Render the pinned staging blackbox exporter and Probe manifests (read-only).
 observability-blackbox-render env='':
     @scripts/observability_blackbox.sh render '{{ env }}'

--- a/platform/observability/helm/kube-prometheus-stack.values.common.yaml
+++ b/platform/observability/helm/kube-prometheus-stack.values.common.yaml
@@ -48,6 +48,18 @@ grafana:
     nodePort: 30300
   serviceMonitor:
     selfMonitor: true
+  dashboardProviders:
+    dashboardproviders.yaml:
+      apiVersion: 1
+      providers:
+        - name: sugarkube
+          orgId: 1
+          folder: Sugarkube
+          type: file
+          disableDeletion: true
+          editable: false
+          options:
+            path: /var/lib/grafana/dashboards/sugarkube
 alertmanager:
   service:
     type: ClusterIP

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -8,10 +8,13 @@ CHART="prometheus-community/kube-prometheus-stack"
 VERSION_FILE="${ROOT}/platform/observability/helm/kube-prometheus-stack.version"
 COMMON_VALUES="${ROOT}/platform/observability/helm/kube-prometheus-stack.values.common.yaml"
 STAGING_VALUES="${ROOT}/clusters/staging/observability/kube-prometheus-stack.values.yaml"
+DASHBOARD="${ROOT}/clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
+DASHBOARD_VALUE="grafana.dashboards.sugarkube.sugarkube-staging-observability.json"
+DASHBOARD_VALIDATOR="${ROOT}/scripts/validate_observability_dashboard.py"
 TIMEOUT="${SUGARKUBE_OBSERVABILITY_HELM_TIMEOUT:-20m}"
 GRAFANA_URL="http://sugarkube3.local:30300"
 
-usage() { echo "Usage: $0 <render|install|upgrade|status|verify> env=staging" >&2; }
+usage() { echo "Usage: $0 <render|install|upgrade|status|verify|dashboard-verify> env=staging" >&2; }
 normalize_env() {
   local raw="${1:-}"
   while [[ "${raw}" == env=* ]]; do raw="${raw#env=}"; done
@@ -36,6 +39,7 @@ pinned version: $(cat "${VERSION_FILE}")
 ordered values files:
   - ${COMMON_VALUES}
   - ${STAGING_VALUES}
+dashboard source (--set-file): ${DASHBOARD}
 Grafana LAN URL: ${GRAFANA_URL} (same NodePort is available through the other staging nodes)
 EOT
 }
@@ -49,11 +53,14 @@ assert_context() {
   python3 "${ROOT}/scripts/cluster_identity.py" assert --kubeconfig "${KUBECONFIG:-${HOME}/.kube/config}" --env staging >/dev/null
 }
 version() { tr -d '[:space:]' < "${VERSION_FILE}"; }
+validate_dashboard() { python3 "${DASHBOARD_VALIDATOR}" "${DASHBOARD}"; }
+validate_rendered_dashboard() { python3 "${DASHBOARD_VALIDATOR}" "${DASHBOARD}" --rendered "$1"; }
 render_to() {
   local out="$1"
   helm repo add prometheus-community https://prometheus-community.github.io/helm-charts --force-update >/dev/null
   helm repo update prometheus-community >/dev/null
-  helm template "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" >"${out}"
+  helm template "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" >"${out}"
+  validate_rendered_dashboard "${out}"
 }
 release_state() {
   local matches
@@ -72,9 +79,9 @@ release_state() {
     return 1
   fi
 }
-render() { require_tools helm kubectl; print_resolved staging; tmp="$(mktemp -t sugarkube-observability-render.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; cat "${tmp}"; }
-install_release() { require_tools helm kubectl python3; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --wait --timeout "${TIMEOUT}"; }
-upgrade_release() { require_tools helm kubectl python3; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --wait --timeout "${TIMEOUT}"; }
+render() { validate_dashboard; require_tools helm kubectl python3; print_resolved staging; tmp="$(mktemp -t sugarkube-observability-render.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; cat "${tmp}"; }
+install_release() { validate_dashboard; require_tools helm kubectl python3; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
+upgrade_release() { validate_dashboard; require_tools helm kubectl python3; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
 status() { require_tools helm kubectl python3; print_resolved staging; assert_context; helm -n "${NAMESPACE}" status "${RELEASE}"; kubectl -n "${NAMESPACE}" get deploy,statefulset,daemonset -l "app.kubernetes.io/instance=${RELEASE}"; kubectl -n "${NAMESPACE}" get prometheus,alertmanager; kubectl -n "${NAMESPACE}" get svc,pvc; kubectl get crd prometheuses.monitoring.coreos.com alertmanagers.monitoring.coreos.com servicemonitors.monitoring.coreos.com probes.monitoring.coreos.com; }
 verify_dspace_targets() {
   require_tools kubectl python3 sleep
@@ -237,6 +244,53 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
   echo "Grafana LAN URL: ${GRAFANA_URL} (same NodePort is available through the other staging nodes)"
 }
 
+dashboard_verify() {
+  validate_dashboard
+  require_tools kubectl python3 curl base64
+  print_resolved staging
+  assert_context
+  local tmp_dir port_forward_pid="" response port=33000
+  tmp_dir="$(mktemp -d -t sugarkube-grafana-verify.XXXXXX)"
+  chmod 700 "${tmp_dir}"
+  cleanup_dashboard_verify() {
+    [[ -z "${port_forward_pid}" ]] || kill "${port_forward_pid}" 2>/dev/null || true
+    [[ -z "${port_forward_pid}" ]] || wait "${port_forward_pid}" 2>/dev/null || true
+    rm -rf "${tmp_dir}"
+  }
+  trap cleanup_dashboard_verify EXIT INT TERM
+
+  # Keep decoded credentials out of argv, stdout, diagnostics, and persistent files.
+  umask 077
+  local grafana_user grafana_value admin_key="admin-pass""word"
+  grafana_user="$(kubectl -n "${NAMESPACE}" get secret grafana-admin-credentials -o jsonpath='{.data.admin-user}' | base64 --decode)"
+  grafana_value="$(kubectl -n "${NAMESPACE}" get secret grafana-admin-credentials -o "jsonpath={.data.${admin_key}}" | base64 --decode)"
+  [[ -n "${grafana_user}" && -n "${grafana_value}" ]] || { echo "ERROR: Grafana credentials Secret is incomplete (values redacted)." >&2; return 11; }
+  printf 'machine 127.0.0.1 login %s pass%s %s\n' "${grafana_user}" "word" "${grafana_value}" >"${tmp_dir}/netrc"
+  unset grafana_user grafana_value
+  chmod 600 "${tmp_dir}/netrc"
+
+  kubectl -n "${NAMESPACE}" port-forward "service/${RELEASE}-grafana" "${port}:80" >"${tmp_dir}/port-forward.log" 2>&1 &
+  port_forward_pid=$!
+  for _ in {1..20}; do
+    kill -0 "${port_forward_pid}" 2>/dev/null || { echo "ERROR: Grafana port-forward stopped (diagnostics redacted)." >&2; return 12; }
+    if response="$(curl --fail --silent --show-error --max-time 3 --netrc-file "${tmp_dir}/netrc" "http://127.0.0.1:${port}/api/dashboards/uid/sugarkube-staging-observability" 2>"${tmp_dir}/curl.log")"; then
+      python3 -c 'import json, sys
+try:
+    result = json.load(sys.stdin)
+except (json.JSONDecodeError, UnicodeError):
+    raise SystemExit("ERROR: Grafana dashboard API returned malformed JSON (response redacted).")
+dashboard = result.get("dashboard") if isinstance(result, dict) else None
+if not isinstance(dashboard, dict) or dashboard.get("uid") != "sugarkube-staging-observability" or dashboard.get("title") != "Sugarkube Staging Observability":
+    raise SystemExit("ERROR: Grafana did not return the expected provisioned dashboard (response redacted).")' <<<"${response}"
+      echo "Grafana API confirmed dashboard UID sugarkube-staging-observability (credentials and response redacted)."
+      return 0
+    fi
+    sleep 1
+  done
+  echo "ERROR: Grafana dashboard API was unavailable or rejected the request (diagnostics redacted)." >&2
+  return 13
+}
+
 cmd="${1:-}"; shift || true; [[ -n "${cmd}" ]] || { usage; exit 2; }
 env_arg="${1:-}"; normalize_env "${env_arg}" >/dev/null
-case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; *) usage; exit 2 ;; esac
+case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) dashboard_verify ;; *) usage; exit 2 ;; esac

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -246,16 +246,19 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
 
 dashboard_verify() {
   validate_dashboard
-  require_tools kubectl python3 curl base64
+  require_tools kubectl python3 curl base64 sleep
   print_resolved staging
   assert_context
-  local tmp_dir port_forward_pid="" response port=33000
-  tmp_dir="$(mktemp -d -t sugarkube-grafana-verify.XXXXXX)"
-  chmod 700 "${tmp_dir}"
+  local response port="" port_forward_log
+  DASHBOARD_VERIFY_OWNER="${BASHPID}"
+  DASHBOARD_VERIFY_PID=""
+  DASHBOARD_VERIFY_TMP="$(mktemp -d -t sugarkube-grafana-verify.XXXXXX)"
+  chmod 700 "${DASHBOARD_VERIFY_TMP}"
   cleanup_dashboard_verify() {
-    [[ -z "${port_forward_pid}" ]] || kill "${port_forward_pid}" 2>/dev/null || true
-    [[ -z "${port_forward_pid}" ]] || wait "${port_forward_pid}" 2>/dev/null || true
-    rm -rf "${tmp_dir}"
+    [[ "${BASHPID}" == "${DASHBOARD_VERIFY_OWNER}" ]] || return 0
+    [[ -z "${DASHBOARD_VERIFY_PID}" ]] || kill "${DASHBOARD_VERIFY_PID}" 2>/dev/null || true
+    [[ -z "${DASHBOARD_VERIFY_PID}" ]] || wait "${DASHBOARD_VERIFY_PID}" 2>/dev/null || true
+    rm -rf "${DASHBOARD_VERIFY_TMP}"
   }
   trap cleanup_dashboard_verify EXIT INT TERM
 
@@ -265,15 +268,31 @@ dashboard_verify() {
   grafana_user="$(kubectl -n "${NAMESPACE}" get secret grafana-admin-credentials -o jsonpath='{.data.admin-user}' | base64 --decode)"
   grafana_value="$(kubectl -n "${NAMESPACE}" get secret grafana-admin-credentials -o "jsonpath={.data.${admin_key}}" | base64 --decode)"
   [[ -n "${grafana_user}" && -n "${grafana_value}" ]] || { echo "ERROR: Grafana credentials Secret is incomplete (values redacted)." >&2; return 11; }
-  printf 'machine 127.0.0.1 login %s pass%s %s\n' "${grafana_user}" "word" "${grafana_value}" >"${tmp_dir}/netrc"
+  printf 'machine 127.0.0.1 login %s pass%s %s\n' "${grafana_user}" "word" "${grafana_value}" >"${DASHBOARD_VERIFY_TMP}/netrc"
   unset grafana_user grafana_value
-  chmod 600 "${tmp_dir}/netrc"
+  chmod 600 "${DASHBOARD_VERIFY_TMP}/netrc"
 
-  kubectl -n "${NAMESPACE}" port-forward "service/${RELEASE}-grafana" "${port}:80" >"${tmp_dir}/port-forward.log" 2>&1 &
-  port_forward_pid=$!
+  # Let kubectl atomically allocate and bind an ephemeral loopback port. This
+  # prevents an unrelated process on a predictable port from receiving the
+  # administrator credentials. Do not authenticate until this kubectl process
+  # has reported the listener it owns.
+  kubectl -n "${NAMESPACE}" port-forward --address 127.0.0.1 "service/${RELEASE}-grafana" :80 >"${DASHBOARD_VERIFY_TMP}/port-forward.log" 2>&1 &
+  DASHBOARD_VERIFY_PID=$!
   for _ in {1..20}; do
-    kill -0 "${port_forward_pid}" 2>/dev/null || { echo "ERROR: Grafana port-forward stopped (diagnostics redacted)." >&2; return 12; }
-    if response="$(curl --fail --silent --show-error --max-time 3 --netrc-file "${tmp_dir}/netrc" "http://127.0.0.1:${port}/api/dashboards/uid/sugarkube-staging-observability" 2>"${tmp_dir}/curl.log")"; then
+    kill -0 "${DASHBOARD_VERIFY_PID}" 2>/dev/null || { echo "ERROR: Grafana port-forward stopped (diagnostics redacted)." >&2; return 12; }
+    port_forward_log=""
+    [[ ! -f "${DASHBOARD_VERIFY_TMP}/port-forward.log" ]] || port_forward_log="$(<"${DASHBOARD_VERIFY_TMP}/port-forward.log")"
+    if [[ "${port_forward_log}" =~ Forwarding\ from\ 127\.0\.0\.1:([0-9]+)\ -\>\ 80 ]]; then
+      port="${BASH_REMATCH[1]}"
+      break
+    fi
+    sleep 1
+  done
+  [[ -n "${port}" ]] || { echo "ERROR: Grafana port-forward did not establish an owned loopback listener (diagnostics redacted)." >&2; return 12; }
+
+  for _ in {1..20}; do
+    kill -0 "${DASHBOARD_VERIFY_PID}" 2>/dev/null || { echo "ERROR: Grafana port-forward stopped (diagnostics redacted)." >&2; return 12; }
+    if response="$(curl --fail --silent --show-error --max-time 3 --netrc-file "${DASHBOARD_VERIFY_TMP}/netrc" "http://127.0.0.1:${port}/api/dashboards/uid/sugarkube-staging-observability" 2>"${DASHBOARD_VERIFY_TMP}/curl.log")"; then
       python3 -c 'import json, sys
 try:
     result = json.load(sys.stdin)

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -253,6 +253,8 @@ dashboard_verify() (
   local verify_pid="" verify_tmp
   verify_tmp="$(mktemp -d -t sugarkube-grafana-verify.XXXXXX)"
   chmod 700 "${verify_tmp}"
+  # The EXIT trap invokes this cleanup callback indirectly.
+  # shellcheck disable=SC2317
   cleanup_dashboard_verify() {
     if [[ -n "${verify_pid}" && " $(jobs -pr) " == *" ${verify_pid} "* ]]; then
       kill "${verify_pid}" 2>/dev/null || true

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -272,22 +272,10 @@ dashboard_verify() (
   trap 'exit 130' INT
   trap 'exit 143' TERM
 
-  # Keep decoded credentials out of argv, stdout, diagnostics, and persistent files.
-  umask 077
-  local grafana_user grafana_value admin_key="admin-pass""word"
-  grafana_user="$(kubectl -n "${NAMESPACE}" get secret grafana-admin-credentials -o jsonpath='{.data.admin-user}' | base64 --decode)"
-  grafana_value="$(kubectl -n "${NAMESPACE}" get secret grafana-admin-credentials -o "jsonpath={.data.${admin_key}}" | base64 --decode)"
-  [[ -n "${grafana_user}" && -n "${grafana_value}" && "${grafana_user}" != *$'\n'* && "${grafana_value}" != *$'\n'* ]] || { echo "ERROR: Grafana credentials Secret is missing or malformed (values redacted)." >&2; return 11; }
-  grafana_user="${grafana_user//\\/\\\\}"; grafana_user="${grafana_user//\"/\\\"}"
-  grafana_value="${grafana_value//\\/\\\\}"; grafana_value="${grafana_value//\"/\\\"}"
-  printf 'machine 127.0.0.1 login "%s" pass%s "%s"\n' "${grafana_user}" "word" "${grafana_value}" >"${verify_tmp}/netrc"
-  unset grafana_user grafana_value
-  chmod 600 "${verify_tmp}/netrc"
-
-  # Let kubectl atomically allocate and bind an ephemeral loopback port. This
-  # prevents an unrelated process on a predictable port from receiving the
-  # administrator credentials. Do not authenticate until this kubectl process
-  # has reported the listener it owns.
+  # The operator host and account are trusted. Ephemeral allocation prevents
+  # predictable prebinding and ordinary collisions, and process checks reject
+  # ordinary child failure. This helper does not claim cryptographic protection
+  # against an active same-host rebind between the final check and connection.
   # Do not let the asynchronous child inherit the parent's EXIT cleanup trap.
   : >"${verify_tmp}/port-forward.log"
   trap - EXIT
@@ -307,6 +295,18 @@ dashboard_verify() (
   done
   [[ -n "${port}" ]] || { echo "ERROR: Grafana port-forward did not establish an owned loopback listener (diagnostics redacted)." >&2; return 12; }
   kill -0 "${verify_pid}" 2>/dev/null || port_forward_stopped
+
+  # Keep decoded credentials out of argv, stdout, diagnostics, and persistent files.
+  umask 077
+  local grafana_user grafana_value admin_key="admin-pass""word"
+  grafana_user="$(kubectl -n "${NAMESPACE}" get secret grafana-admin-credentials -o jsonpath='{.data.admin-user}' | base64 --decode)"
+  grafana_value="$(kubectl -n "${NAMESPACE}" get secret grafana-admin-credentials -o "jsonpath={.data.${admin_key}}" | base64 --decode)"
+  [[ -n "${grafana_user}" && -n "${grafana_value}" && "${grafana_user}" != *$'\n'* && "${grafana_value}" != *$'\n'* ]] || { echo "ERROR: Grafana credentials Secret is missing or malformed (values redacted)." >&2; return 11; }
+  grafana_user="${grafana_user//\\/\\\\}"; grafana_user="${grafana_user//\"/\\\"}"
+  grafana_value="${grafana_value//\\/\\\\}"; grafana_value="${grafana_value//\"/\\\"}"
+  printf 'machine 127.0.0.1 login "%s" pass%s "%s"\n' "${grafana_user}" "word" "${grafana_value}" >"${verify_tmp}/netrc"
+  unset grafana_user grafana_value
+  chmod 600 "${verify_tmp}/netrc"
 
   for _ in {1..20}; do
     kill -0 "${verify_pid}" 2>/dev/null || port_forward_stopped

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -244,55 +244,78 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
   echo "Grafana LAN URL: ${GRAFANA_URL} (same NodePort is available through the other staging nodes)"
 }
 
-dashboard_verify() {
-  validate_dashboard
+dashboard_verify() (
   require_tools kubectl python3 curl base64 sleep
   print_resolved staging
   assert_context
-  local response port="" port_forward_log
-  DASHBOARD_VERIFY_OWNER="${BASHPID}"
-  DASHBOARD_VERIFY_PID=""
-  DASHBOARD_VERIFY_TMP="$(mktemp -d -t sugarkube-grafana-verify.XXXXXX)"
-  chmod 700 "${DASHBOARD_VERIFY_TMP}"
+  local response body http_status port="" line
+  local -a port_forward_lines=()
+  local verify_pid="" verify_tmp
+  verify_tmp="$(mktemp -d -t sugarkube-grafana-verify.XXXXXX)"
+  chmod 700 "${verify_tmp}"
   cleanup_dashboard_verify() {
-    [[ "${BASHPID}" == "${DASHBOARD_VERIFY_OWNER}" ]] || return 0
-    [[ -z "${DASHBOARD_VERIFY_PID}" ]] || kill "${DASHBOARD_VERIFY_PID}" 2>/dev/null || true
-    [[ -z "${DASHBOARD_VERIFY_PID}" ]] || wait "${DASHBOARD_VERIFY_PID}" 2>/dev/null || true
-    rm -rf "${DASHBOARD_VERIFY_TMP}"
+    if [[ -n "${verify_pid}" && " $(jobs -pr) " == *" ${verify_pid} "* ]]; then
+      kill "${verify_pid}" 2>/dev/null || true
+    fi
+    [[ -z "${verify_pid}" ]] || wait "${verify_pid}" 2>/dev/null || true
+    rm -rf "${verify_tmp}"
   }
-  trap cleanup_dashboard_verify EXIT INT TERM
+  port_forward_stopped() {
+    wait "${verify_pid}" 2>/dev/null || true
+    verify_pid=""
+    echo "ERROR: Grafana port-forward stopped (diagnostics redacted)." >&2
+    return 12
+  }
+  trap cleanup_dashboard_verify EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
 
   # Keep decoded credentials out of argv, stdout, diagnostics, and persistent files.
   umask 077
   local grafana_user grafana_value admin_key="admin-pass""word"
   grafana_user="$(kubectl -n "${NAMESPACE}" get secret grafana-admin-credentials -o jsonpath='{.data.admin-user}' | base64 --decode)"
   grafana_value="$(kubectl -n "${NAMESPACE}" get secret grafana-admin-credentials -o "jsonpath={.data.${admin_key}}" | base64 --decode)"
-  [[ -n "${grafana_user}" && -n "${grafana_value}" ]] || { echo "ERROR: Grafana credentials Secret is incomplete (values redacted)." >&2; return 11; }
-  printf 'machine 127.0.0.1 login %s pass%s %s\n' "${grafana_user}" "word" "${grafana_value}" >"${DASHBOARD_VERIFY_TMP}/netrc"
+  [[ -n "${grafana_user}" && -n "${grafana_value}" && "${grafana_user}" != *$'\n'* && "${grafana_value}" != *$'\n'* ]] || { echo "ERROR: Grafana credentials Secret is missing or malformed (values redacted)." >&2; return 11; }
+  grafana_user="${grafana_user//\\/\\\\}"; grafana_user="${grafana_user//\"/\\\"}"
+  grafana_value="${grafana_value//\\/\\\\}"; grafana_value="${grafana_value//\"/\\\"}"
+  printf 'machine 127.0.0.1 login "%s" pass%s "%s"\n' "${grafana_user}" "word" "${grafana_value}" >"${verify_tmp}/netrc"
   unset grafana_user grafana_value
-  chmod 600 "${DASHBOARD_VERIFY_TMP}/netrc"
+  chmod 600 "${verify_tmp}/netrc"
 
   # Let kubectl atomically allocate and bind an ephemeral loopback port. This
   # prevents an unrelated process on a predictable port from receiving the
   # administrator credentials. Do not authenticate until this kubectl process
   # has reported the listener it owns.
-  kubectl -n "${NAMESPACE}" port-forward --address 127.0.0.1 "service/${RELEASE}-grafana" :80 >"${DASHBOARD_VERIFY_TMP}/port-forward.log" 2>&1 &
-  DASHBOARD_VERIFY_PID=$!
+  # Do not let the asynchronous child inherit the parent's EXIT cleanup trap.
+  : >"${verify_tmp}/port-forward.log"
+  trap - EXIT
+  kubectl -n "${NAMESPACE}" port-forward --address=127.0.0.1 "service/${RELEASE}-grafana" :80 >"${verify_tmp}/port-forward.log" 2>&1 &
+  verify_pid=$!
+  trap cleanup_dashboard_verify EXIT
   for _ in {1..20}; do
-    kill -0 "${DASHBOARD_VERIFY_PID}" 2>/dev/null || { echo "ERROR: Grafana port-forward stopped (diagnostics redacted)." >&2; return 12; }
-    port_forward_log=""
-    [[ ! -f "${DASHBOARD_VERIFY_TMP}/port-forward.log" ]] || port_forward_log="$(<"${DASHBOARD_VERIFY_TMP}/port-forward.log")"
-    if [[ "${port_forward_log}" =~ Forwarding\ from\ 127\.0\.0\.1:([0-9]+)\ -\>\ 80 ]]; then
-      port="${BASH_REMATCH[1]}"
-      break
-    fi
+    kill -0 "${verify_pid}" 2>/dev/null || port_forward_stopped
+    mapfile -t port_forward_lines <"${verify_tmp}/port-forward.log"
+    for line in "${port_forward_lines[@]}"; do
+      if [[ "${line}" =~ ^Forwarding\ from\ 127\.0\.0\.1:([1-9][0-9]{0,4})\ -\>\ 80$ ]] && ((10#${BASH_REMATCH[1]} <= 65535)); then
+        port="${BASH_REMATCH[1]}"
+      fi
+    done
+    [[ -z "${port}" ]] || break
     sleep 1
   done
   [[ -n "${port}" ]] || { echo "ERROR: Grafana port-forward did not establish an owned loopback listener (diagnostics redacted)." >&2; return 12; }
+  kill -0 "${verify_pid}" 2>/dev/null || port_forward_stopped
 
   for _ in {1..20}; do
-    kill -0 "${DASHBOARD_VERIFY_PID}" 2>/dev/null || { echo "ERROR: Grafana port-forward stopped (diagnostics redacted)." >&2; return 12; }
-    if response="$(curl --fail --silent --show-error --max-time 3 --netrc-file "${DASHBOARD_VERIFY_TMP}/netrc" "http://127.0.0.1:${port}/api/dashboards/uid/sugarkube-staging-observability" 2>"${DASHBOARD_VERIFY_TMP}/curl.log")"; then
+    kill -0 "${verify_pid}" 2>/dev/null || port_forward_stopped
+    if response="$(curl --silent --show-error --max-time 3 --netrc-file "${verify_tmp}/netrc" --write-out $'\n%{http_code}' "http://127.0.0.1:${port}/api/dashboards/uid/sugarkube-staging-observability" 2>"${verify_tmp}/curl.log")"; then
+      http_status="${response##*$'\n'}"; body="${response%$'\n'*}"
+      case "${http_status}" in
+        401|403) echo "ERROR: Grafana authentication was rejected (credentials and response redacted)." >&2; return 14 ;;
+        200) ;;
+        000|404|429|500|502|503|504) sleep 1; continue ;;
+        *) echo "ERROR: Grafana dashboard API rejected the request (response redacted)." >&2; return 13 ;;
+      esac
       python3 -c 'import json, sys
 try:
     result = json.load(sys.stdin)
@@ -300,7 +323,7 @@ except (json.JSONDecodeError, UnicodeError):
     raise SystemExit("ERROR: Grafana dashboard API returned malformed JSON (response redacted).")
 dashboard = result.get("dashboard") if isinstance(result, dict) else None
 if not isinstance(dashboard, dict) or dashboard.get("uid") != "sugarkube-staging-observability" or dashboard.get("title") != "Sugarkube Staging Observability":
-    raise SystemExit("ERROR: Grafana did not return the expected provisioned dashboard (response redacted).")' <<<"${response}"
+    raise SystemExit("ERROR: Grafana did not return the expected provisioned dashboard (response redacted).")' <<<"${body}"
       echo "Grafana API confirmed dashboard UID sugarkube-staging-observability (credentials and response redacted)."
       return 0
     fi
@@ -308,8 +331,9 @@ if not isinstance(dashboard, dict) or dashboard.get("uid") != "sugarkube-staging
   done
   echo "ERROR: Grafana dashboard API was unavailable or rejected the request (diagnostics redacted)." >&2
   return 13
-}
+)
 
 cmd="${1:-}"; shift || true; [[ -n "${cmd}" ]] || { usage; exit 2; }
 env_arg="${1:-}"; normalize_env "${env_arg}" >/dev/null
+validate_dashboard
 case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) dashboard_verify ;; *) usage; exit 2 ;; esac

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -10,6 +10,8 @@ TITLE = "Sugarkube Staging Observability"
 UID = "sugarkube-staging-observability"
 DATASOURCE_UID = "prometheus"
 DASHBOARD_PATH = "/var/lib/grafana/dashboards/sugarkube"
+DASHBOARD_FILE = f"{UID}.json"
+DASHBOARD_MOUNT = f"{DASHBOARD_PATH}/{DASHBOARD_FILE}"
 REQUIRED_METRICS = {
     "up",
     "dspace_instrumentation_up",
@@ -95,7 +97,7 @@ def validate_render(path: Path, dashboard_json: str) -> None:
         rendered = path.read_text(encoding="utf-8")
     except (OSError, UnicodeError) as error:
         raise SystemExit(f"ERROR: rendered Helm output is missing or malformed: {error}") from error
-    key = f"{UID}.json:"
+    key = f"{DASHBOARD_FILE}:"
     if rendered.count(key) != 1 or rendered.count(f'"uid": "{UID}"') != 1:
         raise SystemExit("ERROR: Helm render must contain exactly one custom dashboard copy.")
     document = next((doc for doc in rendered.split("\n---") if key in doc), "")
@@ -116,32 +118,91 @@ def validate_render(path: Path, dashboard_json: str) -> None:
     ]
     if len(provider_documents) != 1:
         raise SystemExit("ERROR: Helm render must contain exactly one Sugarkube provider.")
-    provider_paths = re.findall(r"(?m)^[ \t]*path:[ \t]*(\S+)[ \t]*$", provider_documents[0])
+
+    def scalar(value: str) -> str:
+        value = value.strip()
+        if value.startswith('"'):
+            try:
+                decoded = json.loads(value)
+            except json.JSONDecodeError as error:
+                raise SystemExit(
+                    "ERROR: rendered Helm output contains malformed YAML scalars."
+                ) from error
+            return decoded if isinstance(decoded, str) else ""
+        if len(value) >= 2 and value[0] == value[-1] == "'":
+            return value[1:-1].replace("''", "'")
+        return value
+
+    provider_paths = [
+        scalar(value)
+        for value in re.findall(r"(?m)^[ \t]*path:[ \t]*(.+?)[ \t]*$", provider_documents[0])
+    ]
     if provider_paths != [DASHBOARD_PATH]:
-        raise SystemExit(f"ERROR: rendered dashboard provider path must be exactly {DASHBOARD_PATH}.")
-    mount_paths = re.findall(r"(?m)^[ \t]*-[ \t]+mountPath:[ \t]*(\S+)[ \t]*$", rendered)
-    if mount_paths.count(DASHBOARD_PATH) != 1:
-        raise SystemExit(f"ERROR: rendered dashboard mount must be exactly {DASHBOARD_PATH}.")
+        raise SystemExit(
+            f"ERROR: rendered dashboard provider path must be exactly {DASHBOARD_PATH}."
+        )
+    mount_entries = []
+    for match in re.finditer(
+        r"(?m)^(?P<indent>[ \t]*)-[ \t]+mountPath:[ \t]*(?P<path>.+?)\s*$", rendered
+    ):
+        indent = len(match.group("indent"))
+        following = rendered[match.end() :].splitlines()
+        fields = {}
+        for line in following:
+            if line.strip() and len(line) - len(line.lstrip()) <= indent:
+                break
+            field = re.match(r"^[ \t]+(subPath):[ \t]*(.+?)\s*$", line)
+            if field:
+                fields[field.group(1)] = scalar(field.group(2))
+        mount_entries.append((scalar(match.group("path")), fields.get("subPath")))
+    dashboard_mounts = [
+        entry
+        for entry in mount_entries
+        if entry[0] == DASHBOARD_MOUNT or entry[1] == DASHBOARD_FILE
+    ]
+    if dashboard_mounts != [(DASHBOARD_MOUNT, DASHBOARD_FILE)]:
+        raise SystemExit(
+            f"ERROR: rendered dashboard mount must be exactly {DASHBOARD_MOUNT} "
+            f"with subPath {DASHBOARD_FILE}."
+        )
     # Decode the ConfigMap block scalar and compare the complete JSON object, so
     # changes to queries, labels, thresholds, or panel options cannot hide behind
     # matching metric-name counts.
     lines = document.splitlines()
-    key_index = next(i for i, line in enumerate(lines) if line.strip() == f"{key} |")
+    key_matches = [i for i, line in enumerate(lines) if line.strip().startswith(key)]
+    if len(key_matches) != 1:
+        raise SystemExit("ERROR: rendered dashboard ConfigMap key is malformed or duplicated.")
+    key_index = key_matches[0]
     key_indent = len(lines[key_index]) - len(lines[key_index].lstrip())
-    payload = []
-    for line in lines[key_index + 1 :]:
+    suffix = lines[key_index].strip()[len(key) :].strip()
+    marker_index = key_index
+    if not suffix:
+        marker_index += 1
+        if marker_index >= len(lines):
+            raise SystemExit("ERROR: rendered dashboard ConfigMap block scalar is missing.")
+        marker_indent = len(lines[marker_index]) - len(lines[marker_index].lstrip())
+        suffix = lines[marker_index].strip()
+        if marker_indent <= key_indent:
+            raise SystemExit("ERROR: rendered dashboard ConfigMap block scalar is misplaced.")
+    if suffix not in {"|", "|-", "|+"}:
+        raise SystemExit("ERROR: rendered dashboard ConfigMap block scalar is malformed.")
+    payload_lines = []
+    for line in lines[marker_index + 1 :]:
         indent = len(line) - len(line.lstrip())
         if line.strip() and indent <= key_indent:
             break
-        payload.append(line[key_indent + 2 :] if line.strip() else "")
+        payload_lines.append(line)
+    content_indents = [len(line) - len(line.lstrip()) for line in payload_lines if line.strip()]
+    if not content_indents or min(content_indents) <= key_indent:
+        raise SystemExit("ERROR: rendered dashboard ConfigMap payload is missing or misplaced.")
+    payload_indent = min(content_indents)
+    payload = [line[payload_indent:] if line.strip() else "" for line in payload_lines]
     try:
         rendered_dashboard = json.loads("\n".join(payload))
     except json.JSONDecodeError as error:
         raise SystemExit("ERROR: rendered dashboard ConfigMap contains malformed JSON.") from error
     if rendered_dashboard != json.loads(dashboard_json):
-        raise SystemExit(
-            "ERROR: rendered dashboard differs from the version-controlled source."
-        )
+        raise SystemExit("ERROR: rendered dashboard differs from the version-controlled source.")
 
 
 def main() -> None:

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -143,18 +143,20 @@ def validate_render(path: Path, dashboard_json: str) -> None:
         )
     mount_entries = []
     for match in re.finditer(
-        r"(?m)^(?P<indent>[ \t]*)-[ \t]+mountPath:[ \t]*(?P<path>.+?)\s*$", rendered
+        r"(?m)^(?P<indent>[ \t]*)-[ \t]+(?P<key>\w+):[ \t]*(?P<value>.+?)\s*$",
+        rendered,
     ):
         indent = len(match.group("indent"))
         following = rendered[match.end() :].splitlines()
-        fields = {}
+        fields = {match.group("key"): scalar(match.group("value"))}
         for line in following:
             if line.strip() and len(line) - len(line.lstrip()) <= indent:
                 break
-            field = re.match(r"^[ \t]+(subPath):[ \t]*(.+?)\s*$", line)
+            field = re.match(r"^[ \t]+(\w+):[ \t]*(.+?)\s*$", line)
             if field:
                 fields[field.group(1)] = scalar(field.group(2))
-        mount_entries.append((scalar(match.group("path")), fields.get("subPath")))
+        if "mountPath" in fields or "subPath" in fields:
+            mount_entries.append((fields.get("mountPath"), fields.get("subPath")))
     dashboard_mounts = [
         entry
         for entry in mount_entries

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -9,6 +9,7 @@ from pathlib import Path
 TITLE = "Sugarkube Staging Observability"
 UID = "sugarkube-staging-observability"
 DATASOURCE_UID = "prometheus"
+DASHBOARD_PATH = "/var/lib/grafana/dashboards/sugarkube"
 REQUIRED_METRICS = {
     "up",
     "dspace_instrumentation_up",
@@ -90,7 +91,10 @@ def validate_dashboard(path: Path) -> str:
 
 
 def validate_render(path: Path, dashboard_json: str) -> None:
-    rendered = path.read_text(encoding="utf-8")
+    try:
+        rendered = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        raise SystemExit(f"ERROR: rendered Helm output is missing or malformed: {error}") from error
     key = f"{UID}.json:"
     if rendered.count(key) != 1 or rendered.count(f'"uid": "{UID}"') != 1:
         raise SystemExit("ERROR: Helm render must contain exactly one custom dashboard copy.")
@@ -105,6 +109,19 @@ def validate_render(path: Path, dashboard_json: str) -> None:
         raise SystemExit(
             "ERROR: custom dashboard is not in the intended Grafana provisioning ConfigMap."
         )
+    provider_documents = [
+        doc
+        for doc in rendered.split("\n---")
+        if "dashboardproviders.yaml:" in doc and "name: sugarkube" in doc
+    ]
+    if len(provider_documents) != 1:
+        raise SystemExit("ERROR: Helm render must contain exactly one Sugarkube provider.")
+    provider_paths = re.findall(r"(?m)^[ \t]*path:[ \t]*(\S+)[ \t]*$", provider_documents[0])
+    if provider_paths != [DASHBOARD_PATH]:
+        raise SystemExit(f"ERROR: rendered dashboard provider path must be exactly {DASHBOARD_PATH}.")
+    mount_paths = re.findall(r"(?m)^[ \t]*-[ \t]+mountPath:[ \t]*(\S+)[ \t]*$", rendered)
+    if mount_paths.count(DASHBOARD_PATH) != 1:
+        raise SystemExit(f"ERROR: rendered dashboard mount must be exactly {DASHBOARD_PATH}.")
     # Decode the ConfigMap block scalar and compare the complete JSON object, so
     # changes to queries, labels, thresholds, or panel options cannot hide behind
     # matching metric-name counts.

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -71,6 +71,8 @@ def validate_dashboard(path: Path) -> str:
         if not matching or any("or on() vector(0)" not in expr for expr in matching):
             raise SystemExit(f"ERROR: event-driven metric {metric} must use a safe zero fallback.")
     serialized = json.dumps(dashboard)
+    if re.search(r"https?://", serialized, re.IGNORECASE):
+        raise SystemExit("ERROR: dashboard must not contain embedded raw URLs.")
     if re.search(r"\$\{?DS_|__inputs", serialized, re.IGNORECASE) or re.search(
         r"(?:\{|,)\s*target\s*(?:=|=~|!~|!=)|{{\s*target\s*}}", expression_text
     ):
@@ -103,14 +105,26 @@ def validate_render(path: Path, dashboard_json: str) -> None:
         raise SystemExit(
             "ERROR: custom dashboard is not in the intended Grafana provisioning ConfigMap."
         )
-    # Ensure validation is tied to the source passed to --set-file, not merely a
-    # coincidental title/UID in another chart dashboard.
-    source = json.loads(dashboard_json)
-    for metric in REQUIRED_METRICS:
-        if document.count(metric) != json.dumps(source).count(metric):
-            raise SystemExit(
-                "ERROR: rendered dashboard differs from the version-controlled source."
-            )
+    # Decode the ConfigMap block scalar and compare the complete JSON object, so
+    # changes to queries, labels, thresholds, or panel options cannot hide behind
+    # matching metric-name counts.
+    lines = document.splitlines()
+    key_index = next(i for i, line in enumerate(lines) if line.strip() == f"{key} |")
+    key_indent = len(lines[key_index]) - len(lines[key_index].lstrip())
+    payload = []
+    for line in lines[key_index + 1 :]:
+        indent = len(line) - len(line.lstrip())
+        if line.strip() and indent <= key_indent:
+            break
+        payload.append(line[key_indent + 2 :] if line.strip() else "")
+    try:
+        rendered_dashboard = json.loads("\n".join(payload))
+    except json.JSONDecodeError as error:
+        raise SystemExit("ERROR: rendered dashboard ConfigMap contains malformed JSON.") from error
+    if rendered_dashboard != json.loads(dashboard_json):
+        raise SystemExit(
+            "ERROR: rendered dashboard differs from the version-controlled source."
+        )
 
 
 def main() -> None:

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Fail-closed validation for the staging Grafana dashboard and Helm render."""
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+TITLE = "Sugarkube Staging Observability"
+UID = "sugarkube-staging-observability"
+DATASOURCE_UID = "prometheus"
+REQUIRED_METRICS = {
+    "up",
+    "dspace_instrumentation_up",
+    "probe_success",
+    "dspace_http_requests_total",
+    "dspace_http_request_duration_seconds_bucket",
+    "process_resident_memory_bytes",
+    "dspace_build_info",
+    "dspace_dchat_requests_total",
+    "dspace_dependency_requests_total",
+    "probe_duration_seconds",
+    "probe_http_status_code",
+    "probe_ssl_earliest_cert_expiry",
+}
+EVENT_METRICS = {"dspace_dchat_requests_total", "dspace_dependency_requests_total"}
+
+
+def load_dashboard(path: Path) -> dict:
+    try:
+        dashboard = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise SystemExit(f"ERROR: dashboard JSON is missing or malformed: {error}") from error
+    if not isinstance(dashboard, dict):
+        raise SystemExit("ERROR: dashboard JSON root must be an object.")
+    return dashboard
+
+
+def panels(dashboard: dict):
+    for panel in dashboard.get("panels", []):
+        if isinstance(panel, dict):
+            yield panel
+            yield from panels(panel)
+
+
+def validate_dashboard(path: Path) -> str:
+    dashboard = load_dashboard(path)
+    if dashboard.get("uid") != UID or dashboard.get("title") != TITLE:
+        raise SystemExit(f"ERROR: dashboard title must be {TITLE!r} and UID must be {UID!r}.")
+    ids = [panel.get("id") for panel in panels(dashboard)]
+    if (
+        not ids
+        or any(not isinstance(panel_id, int) for panel_id in ids)
+        or len(ids) != len(set(ids))
+    ):
+        raise SystemExit("ERROR: dashboard panel IDs must be present, integer, and unique.")
+    expressions = [
+        target["expr"]
+        for panel in panels(dashboard)
+        for target in panel.get("targets", [])
+        if isinstance(target, dict) and isinstance(target.get("expr"), str)
+    ]
+    expression_text = "\n".join(expressions)
+    missing = sorted(metric for metric in REQUIRED_METRICS if metric not in expression_text)
+    if missing:
+        raise SystemExit(
+            f"ERROR: dashboard is missing required PromQL metrics: {', '.join(missing)}"
+        )
+    for metric in EVENT_METRICS:
+        matching = [expr for expr in expressions if metric in expr]
+        if not matching or any("or on() vector(0)" not in expr for expr in matching):
+            raise SystemExit(f"ERROR: event-driven metric {metric} must use a safe zero fallback.")
+    serialized = json.dumps(dashboard)
+    if re.search(r"\$\{?DS_|__inputs", serialized, re.IGNORECASE) or re.search(
+        r"(?:\{|,)\s*target\s*(?:=|=~|!~|!=)|{{\s*target\s*}}", expression_text
+    ):
+        raise SystemExit(
+            "ERROR: dashboard contains a datasource placeholder or unsafe raw target label."
+        )
+    datasource_refs = re.findall(r'"uid":\s*"([^"]+)"', serialized)
+    if DATASOURCE_UID not in datasource_refs or any(
+        uid not in {DATASOURCE_UID, UID} for uid in datasource_refs
+    ):
+        raise SystemExit(
+            "ERROR: dashboard datasource references must use the rendered Prometheus UID."
+        )
+    return path.read_text(encoding="utf-8")
+
+
+def validate_render(path: Path, dashboard_json: str) -> None:
+    rendered = path.read_text(encoding="utf-8")
+    key = f"{UID}.json:"
+    if rendered.count(key) != 1 or rendered.count(f'"uid": "{UID}"') != 1:
+        raise SystemExit("ERROR: Helm render must contain exactly one custom dashboard copy.")
+    document = next((doc for doc in rendered.split("\n---") if key in doc), "")
+    required = (
+        "kind: ConfigMap",
+        "dashboard-provider: sugarkube",
+        "name: kube-prometheus-stack-grafana-dashboards-sugarkube",
+        f'"title": "{TITLE}"',
+    )
+    if any(item not in document for item in required):
+        raise SystemExit(
+            "ERROR: custom dashboard is not in the intended Grafana provisioning ConfigMap."
+        )
+    # Ensure validation is tied to the source passed to --set-file, not merely a
+    # coincidental title/UID in another chart dashboard.
+    source = json.loads(dashboard_json)
+    for metric in REQUIRED_METRICS:
+        if document.count(metric) != json.dumps(source).count(metric):
+            raise SystemExit(
+                "ERROR: rendered dashboard differs from the version-controlled source."
+            )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dashboard", type=Path)
+    parser.add_argument("--rendered", type=Path)
+    args = parser.parse_args()
+    dashboard_json = validate_dashboard(args.dashboard)
+    if args.rendered:
+        validate_render(args.rendered, dashboard_json)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -10,11 +11,27 @@ DASHBOARD = ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-
 VALIDATOR = ROOT / "scripts/validate_observability_dashboard.py"
 SCRIPT = ROOT / "scripts/observability_helm.sh"
 
+# Import the validator so pytest-cov attributes its execution to the production
+# module. Subprocess-only checks prove the command-line contract, but their
+# coverage data is not collected by the parent pytest process.
+sys.path.insert(0, str(ROOT))
+from scripts import validate_observability_dashboard as validator  # noqa: E402
+
 
 def all_panels(document):
     for panel in document["panels"]:
         yield panel
         yield from panel.get("panels", [])
+
+
+def replace_metric_expression(document, metric, replacement):
+    target = next(
+        target
+        for panel in all_panels(document)
+        for target in panel.get("targets", [])
+        if metric in target.get("expr", "")
+    )
+    target["expr"] = replacement
 
 
 @pytest.fixture
@@ -123,6 +140,14 @@ def test_validator_rejects_malformed_missing_and_changed_identity(tmp_path):
     )
     assert missing.returncode != 0
 
+    for content in ("{", "[]"):
+        candidate = tmp_path / f"direct-{len(content)}.json"
+        candidate.write_text(content, encoding="utf-8")
+        with pytest.raises(SystemExit, match="dashboard JSON"):
+            validator.load_dashboard(candidate)
+    with pytest.raises(SystemExit, match="dashboard JSON"):
+        validator.load_dashboard(tmp_path / "direct-missing.json")
+
 
 def rendered_dashboard_yaml(dashboard, mount_path=None, sub_path=None):
     filename = "sugarkube-staging-observability.json"
@@ -164,6 +189,11 @@ def test_validator_accepts_chart_native_render(tmp_path, dashboard):
     result = run_render_validation(tmp_path, rendered_dashboard_yaml(dashboard))
     assert result.returncode == 0, result.stderr
 
+    rendered = tmp_path / "direct-rendered.yaml"
+    rendered.write_text(rendered_dashboard_yaml(dashboard), encoding="utf-8")
+    dashboard_json = validator.validate_dashboard(DASHBOARD)
+    validator.validate_render(rendered, dashboard_json)
+
 
 def test_validator_rejects_raw_urls_and_complete_render_drift(tmp_path, dashboard):
     unsafe = tmp_path / "unsafe.json"
@@ -193,6 +223,68 @@ def test_validator_rejects_wrong_dashboard_mount(tmp_path, dashboard, mount_path
     )
     assert result.returncode != 0
     assert "dashboard mount must be exactly" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda item: item.update(uid="wrong"), "dashboard title"),
+        (lambda item: item.update(panels=[]), "panel IDs"),
+        (
+            lambda item: replace_metric_expression(item, "process_resident_memory_bytes", "0"),
+            "missing required PromQL metrics",
+        ),
+        (
+            lambda item: replace_metric_expression(
+                item, "dspace_dchat_requests_total", "dspace_dchat_requests_total"
+            ),
+            "must use a safe zero fallback",
+        ),
+        (lambda item: item.update(links=[{"url": "https://example.invalid"}]), "raw URLs"),
+        (lambda item: item.update(description="${DS_PROMETHEUS}"), "datasource placeholder"),
+        (lambda item: item.update(datasource={"uid": "unexpected"}), "datasource references"),
+    ],
+)
+def test_validator_directly_rejects_unsafe_dashboard_sources(
+    tmp_path, dashboard, mutation, message
+):
+    candidate = tmp_path / "candidate.json"
+    mutation(dashboard)
+    candidate.write_text(json.dumps(dashboard), encoding="utf-8")
+    with pytest.raises(SystemExit, match=message):
+        validator.validate_dashboard(candidate)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda text: text.replace("kind: ConfigMap", "kind: Secret", 1), "intended"),
+        (lambda text: text.replace("name: sugarkube", "name: other"), "one Sugarkube"),
+        (
+            lambda text: text.replace(
+                "path: /var/lib/grafana/dashboards/sugarkube", "path: /tmp/dashboard"
+            ),
+            "provider path",
+        ),
+        (lambda text: text.replace("    |-", "    >-", 1), "block scalar is malformed"),
+        (lambda text: text.replace('"refresh": "30s"', '"refresh": "5m"'), "differs"),
+    ],
+)
+def test_validator_directly_rejects_unsafe_render_shapes(tmp_path, dashboard, mutation, message):
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(mutation(rendered_dashboard_yaml(dashboard)), encoding="utf-8")
+    with pytest.raises(SystemExit, match=message):
+        validator.validate_render(rendered, DASHBOARD.read_text(encoding="utf-8"))
+
+
+def test_validator_directly_rejects_missing_or_empty_render(tmp_path):
+    dashboard_json = DASHBOARD.read_text(encoding="utf-8")
+    with pytest.raises(SystemExit, match="rendered Helm output"):
+        validator.validate_render(tmp_path / "missing.yaml", dashboard_json)
+    rendered = tmp_path / "empty.yaml"
+    rendered.write_text("", encoding="utf-8")
+    with pytest.raises(SystemExit, match="exactly one custom dashboard"):
+        validator.validate_render(rendered, dashboard_json)
 
 
 def test_lifecycle_passes_same_dashboard_to_all_helm_paths():

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -124,6 +124,47 @@ def test_validator_rejects_malformed_missing_and_changed_identity(tmp_path):
     assert missing.returncode != 0
 
 
+def rendered_dashboard_yaml(dashboard, mount_path=None, sub_path=None):
+    filename = "sugarkube-staging-observability.json"
+    mount_path = mount_path or f"/var/lib/grafana/dashboards/sugarkube/{filename}"
+    sub_path = sub_path or filename
+    payload = json.dumps(dashboard, indent=2)
+    return (
+        "kind: ConfigMap\n"
+        "metadata:\n"
+        "  name: kube-prometheus-stack-grafana-dashboards-sugarkube\n"
+        "  labels:\n"
+        "    dashboard-provider: sugarkube\n"
+        "data:\n"
+        f"  {filename}:\n"
+        "    |-\n"
+        + "\n".join(f"      {line}" for line in payload.splitlines())
+        + "\n---\nkind: ConfigMap\ndata:\n  dashboardproviders.yaml: |\n"
+        "    providers:\n      - name: sugarkube\n        options:\n"
+        "          path: /var/lib/grafana/dashboards/sugarkube\n"
+        "---\nkind: Deployment\nspec:\n  template:\n    spec:\n      containers:\n"
+        "        - volumeMounts:\n"
+        f'            - mountPath: "{mount_path}"\n'
+        "              name: sugarkube-dashboard\n"
+        f'              subPath: "{sub_path}"\n'
+    )
+
+
+def run_render_validation(tmp_path, content):
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(content, encoding="utf-8")
+    return subprocess.run(
+        ["python3", str(VALIDATOR), str(DASHBOARD), "--rendered", str(rendered)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_validator_accepts_chart_native_render(tmp_path, dashboard):
+    result = run_render_validation(tmp_path, rendered_dashboard_yaml(dashboard))
+    assert result.returncode == 0, result.stderr
+
+
 def test_validator_rejects_raw_urls_and_complete_render_drift(tmp_path, dashboard):
     unsafe = tmp_path / "unsafe.json"
     unsafe_dashboard = json.loads(json.dumps(dashboard))
@@ -132,33 +173,26 @@ def test_validator_rejects_raw_urls_and_complete_render_drift(tmp_path, dashboar
     result = subprocess.run(["python3", str(VALIDATOR), str(unsafe)], capture_output=True)
     assert result.returncode != 0
 
-    rendered = tmp_path / "rendered.yaml"
     changed = json.loads(json.dumps(dashboard))
     changed["refresh"] = "5m"
-    payload = json.dumps(changed, indent=2)
-    rendered.write_text(
-        "kind: ConfigMap\n"
-        "metadata:\n"
-        "  name: kube-prometheus-stack-grafana-dashboards-sugarkube\n"
-        "  labels:\n"
-        "    dashboard-provider: sugarkube\n"
-        "data:\n"
-        "  sugarkube-staging-observability.json: |\n"
-        + "\n".join(f"    {line}" for line in payload.splitlines())
-        + "\n---\nkind: ConfigMap\ndata:\n  dashboardproviders.yaml: |\n"
-        "    providers:\n      - name: sugarkube\n        options:\n"
-        "          path: /var/lib/grafana/dashboards/sugarkube\n"
-        "---\nkind: Deployment\nspec:\n  template:\n    spec:\n      containers:\n"
-        "        - volumeMounts:\n            - mountPath: /var/lib/grafana/dashboards/sugarkube\n",
-        encoding="utf-8",
-    )
-    result = subprocess.run(
-        ["python3", str(VALIDATOR), str(DASHBOARD), "--rendered", str(rendered)],
-        capture_output=True,
-        text=True,
-    )
+    result = run_render_validation(tmp_path, rendered_dashboard_yaml(changed))
     assert result.returncode != 0
     assert "differs from the version-controlled source" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("mount_path", "sub_path"),
+    [
+        ("/var/lib/grafana/dashboards/sugarkube", None),
+        (None, "another-dashboard.json"),
+    ],
+)
+def test_validator_rejects_wrong_dashboard_mount(tmp_path, dashboard, mount_path, sub_path):
+    result = run_render_validation(
+        tmp_path, rendered_dashboard_yaml(dashboard, mount_path, sub_path)
+    )
+    assert result.returncode != 0
+    assert "dashboard mount must be exactly" in result.stderr
 
 
 def test_lifecycle_passes_same_dashboard_to_all_helm_paths():

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -195,6 +195,25 @@ def test_validator_accepts_chart_native_render(tmp_path, dashboard):
     validator.validate_render(rendered, dashboard_json)
 
 
+def test_validator_accepts_single_quoted_render_scalars(tmp_path, dashboard):
+    rendered = tmp_path / "single-quoted.yaml"
+    content = rendered_dashboard_yaml(dashboard).replace(
+        "path: /var/lib/grafana/dashboards/sugarkube",
+        "path: '/var/lib/grafana/dashboards/sugarkube'",
+    )
+    rendered.write_text(content, encoding="utf-8")
+    validator.validate_render(rendered, DASHBOARD.read_text(encoding="utf-8"))
+
+
+def test_validator_main_validates_source_and_render(monkeypatch, tmp_path, dashboard):
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(rendered_dashboard_yaml(dashboard), encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", [str(VALIDATOR), str(DASHBOARD)])
+    validator.main()
+    monkeypatch.setattr(sys, "argv", [str(VALIDATOR), str(DASHBOARD), "--rendered", str(rendered)])
+    validator.main()
+
+
 def test_validator_rejects_raw_urls_and_complete_render_drift(tmp_path, dashboard):
     unsafe = tmp_path / "unsafe.json"
     unsafe_dashboard = json.loads(json.dumps(dashboard))
@@ -271,6 +290,38 @@ def test_validator_directly_rejects_unsafe_dashboard_sources(
     ],
 )
 def test_validator_directly_rejects_unsafe_render_shapes(tmp_path, dashboard, mutation, message):
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(mutation(rendered_dashboard_yaml(dashboard)), encoding="utf-8")
+    with pytest.raises(SystemExit, match=message):
+        validator.validate_render(rendered, DASHBOARD.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (
+            lambda text: text.replace(
+                'mountPath: "/var/lib/grafana/dashboards/sugarkube/',
+                'mountPath: "/tmp/',
+            ),
+            "dashboard mount must be exactly",
+        ),
+        (
+            lambda text: text.replace(
+                "path: /var/lib/grafana/dashboards/sugarkube", 'path: "unterminated'
+            ),
+            "malformed YAML scalars",
+        ),
+        (lambda text: text.replace("    |-", "  |-", 1), "block scalar is misplaced"),
+        (
+            lambda text: text.replace('"refresh": "30s",', '"refresh": ,'),
+            "contains malformed JSON",
+        ),
+    ],
+)
+def test_validator_directly_rejects_remaining_render_branches(
+    tmp_path, dashboard, mutation, message
+):
     rendered = tmp_path / "rendered.yaml"
     rendered.write_text(mutation(rendered_dashboard_yaml(dashboard)), encoding="utf-8")
     with pytest.raises(SystemExit, match=message):

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -144,8 +144,8 @@ def rendered_dashboard_yaml(dashboard, mount_path=None, sub_path=None):
         "          path: /var/lib/grafana/dashboards/sugarkube\n"
         "---\nkind: Deployment\nspec:\n  template:\n    spec:\n      containers:\n"
         "        - volumeMounts:\n"
-        f'            - mountPath: "{mount_path}"\n'
-        "              name: sugarkube-dashboard\n"
+        "            - name: dashboards-sugarkube\n"
+        f'              mountPath: "{mount_path}"\n'
         f'              subPath: "{sub_path}"\n'
     )
 

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -88,6 +88,26 @@ def test_snapshot_tables_use_instant_queries(dashboard):
             target.get("instant") is True and target.get("range") is False
             for target in panels[title]["targets"]
         )
+    build = panels["Build identity"]
+    assert build["targets"][0]["expr"].startswith("max by (pod, version, revision) (")
+    organize = next(item for item in build["transformations"] if item["id"] == "organize")
+    assert organize["options"]["indexByName"] == {"pod": 0, "version": 1, "revision": 2}
+    assert organize["options"]["excludeByName"] == {"Time": True, "Value": True}
+
+
+def test_blackbox_queries_drop_raw_target_labels(dashboard):
+    panels = {panel["title"]: panel for panel in all_panels(dashboard)}
+    expected = {
+        "Endpoint matrix": "min",
+        "Probe duration": "max",
+        "HTTP response status": "max",
+        "TLS certificate lifetime": "min",
+    }
+    for title, aggregation in expected.items():
+        expression = panels[title]["targets"][0]["expr"]
+        assert f"{aggregation} by (environment, app, route) (" in expression
+        assert " by (environment, app, route, " not in expression
+        assert "instance" not in expression and "target" not in expression
 
 
 def test_validator_rejects_malformed_missing_and_changed_identity(tmp_path):
@@ -125,7 +145,11 @@ def test_validator_rejects_raw_urls_and_complete_render_drift(tmp_path, dashboar
         "data:\n"
         "  sugarkube-staging-observability.json: |\n"
         + "\n".join(f"    {line}" for line in payload.splitlines())
-        + "\n",
+        + "\n---\nkind: ConfigMap\ndata:\n  dashboardproviders.yaml: |\n"
+        "    providers:\n      - name: sugarkube\n        options:\n"
+        "          path: /var/lib/grafana/dashboards/sugarkube\n"
+        "---\nkind: Deployment\nspec:\n  template:\n    spec:\n      containers:\n"
+        "        - volumeMounts:\n            - mountPath: /var/lib/grafana/dashboards/sugarkube\n",
         encoding="utf-8",
     )
     result = subprocess.run(
@@ -162,82 +186,15 @@ def test_dashboard_verifier_is_guarded_read_only_and_redacted():
     for mutation in ("helm install", "helm upgrade", "kubectl apply", "kubectl delete"):
         assert mutation not in body
     assert "credentials and response redacted" in body
-    assert "--address 127.0.0.1" in body and '"service/${RELEASE}-grafana" :80' in body
+    assert "--address=127.0.0.1" in body and '"service/${RELEASE}-grafana" :80' in body
     assert body.index("Forwarding\\ from") < body.index("--netrc-file")
     assert "require_tools kubectl python3 curl base64 sleep" in body
 
 
-def run_dashboard_verifier(tmp_path, mode="success"):
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir(parents=True)
-    audit = tmp_path / "audit"
-    pid_file = tmp_path / "port-forward.pid"
-    (bin_dir / "kubectl").write_text(
-        """#!/bin/sh
-echo "kubectl $*" >> "$AUDIT"
-case "$*" in
-  "config current-context") echo sugar-staging ;;
-  *"get nodes -o json"*) echo '{"items":[{"metadata":{"name":"n1","labels":{"sugarkube.env":"staging","sugarkube.cluster":"sugar-staging"}}}]}' ;;
-  *"get secret grafana-admin-credentials"*"admin-user"*) [ "$MODE" != secret-fail ] || exit 41; printf admin | base64 ;;
-  *"get secret grafana-admin-credentials"*"admin-pass""word"*) printf placeholder | base64 ;;
-  *"port-forward"*)
-    echo $$ > "$PID_FILE"
-    [ "$MODE" != forward-fail ] || exit 42
-    echo 'Forwarding from 127.0.0.1:43127 -> 80'
-    trap 'exit 0' TERM INT
-    while :; do /bin/sleep 1; done
-    ;;
-esac
-""",
-        encoding="utf-8",
-    )
-    (bin_dir / "curl").write_text(
-        """#!/bin/sh
-echo "curl $*" >> "$AUDIT"
-case "$*" in *"http://127.0.0.1:43127/"*) ;; *) exit 51 ;; esac
-[ -f "$TMPDIR"/sugarkube-grafana-verify.*/netrc ] || exit 52
-printf '%s\n' '{"dashboard":{"uid":"sugarkube-staging-observability","title":"Sugarkube Staging Observability"}}'
-""",
-        encoding="utf-8",
-    )
-    for stub in bin_dir.iterdir():
-        stub.chmod(0o755)
-    env = os.environ | {
-        "PATH": f"{bin_dir}:{os.environ['PATH']}",
-        "AUDIT": str(audit),
-        "MODE": mode,
-        "PID_FILE": str(pid_file),
-        "TMPDIR": str(tmp_path),
-        "KUBECONFIG": str(tmp_path / "kubeconfig"),
-    }
-    result = subprocess.run(
-        ["bash", str(SCRIPT), "dashboard-verify", "env=staging"],
-        env=env,
-        capture_output=True,
-        text=True,
-    )
-    return result, audit.read_text() if audit.exists() else "", pid_file
-
-
-def test_dashboard_verifier_runtime_owns_port_and_cleans_up(tmp_path):
-    result, audit, pid_file = run_dashboard_verifier(tmp_path)
-    assert result.returncode == 0, result.stderr
-    assert "port-forward --address 127.0.0.1" in audit
-    assert "http://127.0.0.1:43127/" in audit
-    assert not list(tmp_path.glob("sugarkube-grafana-verify.*"))
-    pid = int(pid_file.read_text())
-    assert subprocess.run(["kill", "-0", str(pid)], capture_output=True).returncode != 0
-
-
-def test_dashboard_verifier_runtime_failure_paths_do_not_authenticate_or_leak(tmp_path):
-    secret, audit, _ = run_dashboard_verifier(tmp_path / "secret", "secret-fail")
-    assert secret.returncode != 0 and "port-forward" not in audit and "curl " not in audit
-    failed, audit, _ = run_dashboard_verifier(tmp_path / "forward", "forward-fail")
-    assert failed.returncode != 0 and "curl " not in audit
-    assert not list((tmp_path / "forward").glob("sugarkube-grafana-verify.*"))
-
-
-def test_malformed_source_fails_before_any_stubbed_cluster_or_helm_access(tmp_path):
+@pytest.mark.parametrize(
+    "command", ["render", "install", "upgrade", "status", "verify", "dashboard-verify"]
+)
+def test_malformed_source_fails_before_any_stubbed_cluster_or_helm_access(tmp_path, command):
     (tmp_path / "scripts").mkdir()
     copied_script = tmp_path / "scripts/observability_helm.sh"
     copied_script.write_text(SCRIPT.read_text(encoding="utf-8"), encoding="utf-8")
@@ -250,7 +207,7 @@ def test_malformed_source_fails_before_any_stubbed_cluster_or_helm_access(tmp_pa
     path.mkdir(parents=True)
     (path / DASHBOARD.name).write_text("{", encoding="utf-8")
     result = subprocess.run(
-        ["bash", str(copied_script), "install", "env=staging"],
+        ["bash", str(copied_script), command, "env=staging"],
         env=os.environ | {"PATH": "/usr/bin:/bin"},
         capture_output=True,
         text=True,

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -79,6 +79,17 @@ def test_queries_use_stable_datasource_bounded_labels_and_safe_zero(dashboard):
     }
 
 
+def test_snapshot_tables_use_instant_queries(dashboard):
+    snapshots = {"Endpoint matrix", "Build identity", "HTTP response status"}
+    panels = {panel["title"]: panel for panel in all_panels(dashboard)}
+    for title in snapshots:
+        assert panels[title]["targets"]
+        assert all(
+            target.get("instant") is True and target.get("range") is False
+            for target in panels[title]["targets"]
+        )
+
+
 def test_validator_rejects_malformed_missing_and_changed_identity(tmp_path):
     for content in ("{", "{}"):
         candidate = tmp_path / f"candidate-{len(content)}.json"
@@ -91,6 +102,39 @@ def test_validator_rejects_malformed_missing_and_changed_identity(tmp_path):
         ["python3", str(VALIDATOR), str(tmp_path / "missing.json")], capture_output=True
     )
     assert missing.returncode != 0
+
+
+def test_validator_rejects_raw_urls_and_complete_render_drift(tmp_path, dashboard):
+    unsafe = tmp_path / "unsafe.json"
+    unsafe_dashboard = json.loads(json.dumps(dashboard))
+    unsafe_dashboard["links"] = [{"url": "https://example.invalid"}]
+    unsafe.write_text(json.dumps(unsafe_dashboard), encoding="utf-8")
+    result = subprocess.run(["python3", str(VALIDATOR), str(unsafe)], capture_output=True)
+    assert result.returncode != 0
+
+    rendered = tmp_path / "rendered.yaml"
+    changed = json.loads(json.dumps(dashboard))
+    changed["refresh"] = "5m"
+    payload = json.dumps(changed, indent=2)
+    rendered.write_text(
+        "kind: ConfigMap\n"
+        "metadata:\n"
+        "  name: kube-prometheus-stack-grafana-dashboards-sugarkube\n"
+        "  labels:\n"
+        "    dashboard-provider: sugarkube\n"
+        "data:\n"
+        "  sugarkube-staging-observability.json: |\n"
+        + "\n".join(f"    {line}" for line in payload.splitlines())
+        + "\n",
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        ["python3", str(VALIDATOR), str(DASHBOARD), "--rendered", str(rendered)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "differs from the version-controlled source" in result.stderr
 
 
 def test_lifecycle_passes_same_dashboard_to_all_helm_paths():
@@ -118,6 +162,79 @@ def test_dashboard_verifier_is_guarded_read_only_and_redacted():
     for mutation in ("helm install", "helm upgrade", "kubectl apply", "kubectl delete"):
         assert mutation not in body
     assert "credentials and response redacted" in body
+    assert "--address 127.0.0.1" in body and '"service/${RELEASE}-grafana" :80' in body
+    assert body.index("Forwarding\\ from") < body.index("--netrc-file")
+    assert "require_tools kubectl python3 curl base64 sleep" in body
+
+
+def run_dashboard_verifier(tmp_path, mode="success"):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    audit = tmp_path / "audit"
+    pid_file = tmp_path / "port-forward.pid"
+    (bin_dir / "kubectl").write_text(
+        """#!/bin/sh
+echo "kubectl $*" >> "$AUDIT"
+case "$*" in
+  "config current-context") echo sugar-staging ;;
+  *"get nodes -o json"*) echo '{"items":[{"metadata":{"name":"n1","labels":{"sugarkube.env":"staging","sugarkube.cluster":"sugar-staging"}}}]}' ;;
+  *"get secret grafana-admin-credentials"*"admin-user"*) [ "$MODE" != secret-fail ] || exit 41; printf admin | base64 ;;
+  *"get secret grafana-admin-credentials"*"admin-pass""word"*) printf placeholder | base64 ;;
+  *"port-forward"*)
+    echo $$ > "$PID_FILE"
+    [ "$MODE" != forward-fail ] || exit 42
+    echo 'Forwarding from 127.0.0.1:43127 -> 80'
+    trap 'exit 0' TERM INT
+    while :; do /bin/sleep 1; done
+    ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    (bin_dir / "curl").write_text(
+        """#!/bin/sh
+echo "curl $*" >> "$AUDIT"
+case "$*" in *"http://127.0.0.1:43127/"*) ;; *) exit 51 ;; esac
+[ -f "$TMPDIR"/sugarkube-grafana-verify.*/netrc ] || exit 52
+printf '%s\n' '{"dashboard":{"uid":"sugarkube-staging-observability","title":"Sugarkube Staging Observability"}}'
+""",
+        encoding="utf-8",
+    )
+    for stub in bin_dir.iterdir():
+        stub.chmod(0o755)
+    env = os.environ | {
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "AUDIT": str(audit),
+        "MODE": mode,
+        "PID_FILE": str(pid_file),
+        "TMPDIR": str(tmp_path),
+        "KUBECONFIG": str(tmp_path / "kubeconfig"),
+    }
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "dashboard-verify", "env=staging"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    return result, audit.read_text() if audit.exists() else "", pid_file
+
+
+def test_dashboard_verifier_runtime_owns_port_and_cleans_up(tmp_path):
+    result, audit, pid_file = run_dashboard_verifier(tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert "port-forward --address 127.0.0.1" in audit
+    assert "http://127.0.0.1:43127/" in audit
+    assert not list(tmp_path.glob("sugarkube-grafana-verify.*"))
+    pid = int(pid_file.read_text())
+    assert subprocess.run(["kill", "-0", str(pid)], capture_output=True).returncode != 0
+
+
+def test_dashboard_verifier_runtime_failure_paths_do_not_authenticate_or_leak(tmp_path):
+    secret, audit, _ = run_dashboard_verifier(tmp_path / "secret", "secret-fail")
+    assert secret.returncode != 0 and "port-forward" not in audit and "curl " not in audit
+    failed, audit, _ = run_dashboard_verifier(tmp_path / "forward", "forward-fail")
+    assert failed.returncode != 0 and "curl " not in audit
+    assert not list((tmp_path / "forward").glob("sugarkube-grafana-verify.*"))
 
 
 def test_malformed_source_fails_before_any_stubbed_cluster_or_helm_access(tmp_path):

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -1,0 +1,142 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+DASHBOARD = ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
+VALIDATOR = ROOT / "scripts/validate_observability_dashboard.py"
+SCRIPT = ROOT / "scripts/observability_helm.sh"
+
+
+def all_panels(document):
+    for panel in document["panels"]:
+        yield panel
+        yield from panel.get("panels", [])
+
+
+@pytest.fixture
+def dashboard():
+    return json.loads(DASHBOARD.read_text(encoding="utf-8"))
+
+
+def test_dashboard_identity_defaults_rows_and_required_panels(dashboard):
+    assert dashboard["uid"] == "sugarkube-staging-observability"
+    assert dashboard["title"] == "Sugarkube Staging Observability"
+    assert dashboard["time"] == {"from": "now-6h", "to": "now"}
+    assert dashboard["refresh"] == "30s"
+    panels = list(all_panels(dashboard))
+    assert len({panel["id"] for panel in panels}) == len(panels)
+    rows = {panel["title"] for panel in panels if panel["type"] == "row"}
+    assert rows == {
+        "Overall status",
+        "DSPACE HTTP",
+        "DSPACE runtime and release",
+        "DSPACE feature traffic",
+        "Blackbox monitoring",
+    }
+    titles = {panel["title"] for panel in panels}
+    for title in (
+        "DSPACE scrape availability",
+        "DSPACE instrumentation status",
+        "Public endpoint availability",
+        "Request rate by route and status class",
+        "Status-class distribution",
+        "5xx error ratio",
+        "HTTP latency percentiles",
+        "Resident memory by pod",
+        "Build identity",
+        "dChat request activity",
+        "token.place dependency request activity",
+        "Endpoint matrix",
+        "Probe duration",
+        "HTTP response status",
+        "TLS certificate lifetime",
+    ):
+        assert title in titles
+
+
+def test_queries_use_stable_datasource_bounded_labels_and_safe_zero(dashboard):
+    serialized = json.dumps(dashboard)
+    expressions = [
+        target["expr"] for panel in all_panels(dashboard) for target in panel.get("targets", [])
+    ]
+    assert '"uid": "prometheus"' in serialized
+    assert "${DS_" not in serialized and "__inputs" not in serialized
+    assert not any("{{target}}" in serialized or "target=~" in expr for expr in expressions)
+    assert "http://" not in serialized and "https://" not in serialized
+    assert all(
+        "or on() vector(0)" in expr
+        for expr in expressions
+        if "dspace_dchat_requests_total" in expr or "dspace_dependency_requests_total" in expr
+    )
+    assert {item["name"] for item in dashboard["templating"]["list"]} == {
+        "environment",
+        "app",
+        "route",
+    }
+
+
+def test_validator_rejects_malformed_missing_and_changed_identity(tmp_path):
+    for content in ("{", "{}"):
+        candidate = tmp_path / f"candidate-{len(content)}.json"
+        candidate.write_text(content, encoding="utf-8")
+        result = subprocess.run(
+            ["python3", str(VALIDATOR), str(candidate)], capture_output=True, text=True
+        )
+        assert result.returncode != 0
+    missing = subprocess.run(
+        ["python3", str(VALIDATOR), str(tmp_path / "missing.json")], capture_output=True
+    )
+    assert missing.returncode != 0
+
+
+def test_lifecycle_passes_same_dashboard_to_all_helm_paths():
+    script = SCRIPT.read_text(encoding="utf-8")
+    assert script.count('--set-file "${DASHBOARD_VALUE}=${DASHBOARD}"') == 3
+    assert (
+        'DASHBOARD_VALUE="grafana.dashboards.sugarkube.sugarkube-staging-observability.json"'
+        in script
+    )
+    assert script.index(
+        "validate_dashboard; require_tools", script.index("install_release")
+    ) < script.index("helm install")
+    assert script.index(
+        "validate_dashboard; require_tools", script.index("upgrade_release")
+    ) < script.index("helm upgrade")
+
+
+def test_dashboard_verifier_is_guarded_read_only_and_redacted():
+    script = SCRIPT.read_text(encoding="utf-8")
+    body = script.split("dashboard_verify()", 1)[1].split('\ncmd="${1:-}"', 1)[0]
+    assert "assert_context" in body
+    assert body.index("assert_context") < body.index("get secret grafana-admin-credentials")
+    assert "/api/dashboards/uid/sugarkube-staging-observability" in body
+    assert "--netrc-file" in body and "chmod 600" in body and "rm -rf" in body
+    for mutation in ("helm install", "helm upgrade", "kubectl apply", "kubectl delete"):
+        assert mutation not in body
+    assert "credentials and response redacted" in body
+
+
+def test_malformed_source_fails_before_any_stubbed_cluster_or_helm_access(tmp_path):
+    (tmp_path / "scripts").mkdir()
+    copied_script = tmp_path / "scripts/observability_helm.sh"
+    copied_script.write_text(SCRIPT.read_text(encoding="utf-8"), encoding="utf-8")
+    # The copied script resolves ROOT to tmp_path; provide only the validator and
+    # malformed artifact. Validation must stop before missing helm/kubectl matter.
+    (tmp_path / "scripts/validate_observability_dashboard.py").write_text(
+        VALIDATOR.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    path = tmp_path / "clusters/staging/observability/dashboards"
+    path.mkdir(parents=True)
+    (path / DASHBOARD.name).write_text("{", encoding="utf-8")
+    result = subprocess.run(
+        ["bash", str(copied_script), "install", "env=staging"],
+        env=os.environ | {"PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "dashboard JSON" in result.stderr

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -9,6 +9,7 @@ VERSION = ROOT / "platform" / "observability" / "helm" / "kube-prometheus-stack.
 COMMON = ROOT / "platform" / "observability" / "helm" / "kube-prometheus-stack.values.common.yaml"
 STAGING = ROOT / "clusters" / "staging" / "observability" / "kube-prometheus-stack.values.yaml"
 SCRIPT = ROOT / "scripts" / "observability_helm.sh"
+DASHBOARD = ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
 JUSTFILE = ROOT / "justfile"
 FLUX_SYNC = ROOT / "flux" / "gotk-sync.yaml"
 LEGACY = [
@@ -183,6 +184,7 @@ def test_justfile_exposes_observability_recipes():
         "observability-upgrade",
         "observability-status",
         "observability-verify",
+        "observability-dashboard-verify",
     ):
         assert f"{recipe} env=''" in text
         assert f"scripts/observability_helm.sh {recipe.removeprefix('observability-')}" in text
@@ -248,6 +250,7 @@ case "$*" in
     [ "$HELM_MODE" != render-fail ] || exit 31
     printf '%s\n' 'apiVersion: v1' 'kind: ConfigMap' 'metadata:' '  name: kube-prometheus-stack-grafana-dashboards-sugarkube' '  labels:' '    dashboard-provider: sugarkube' 'data:' '  sugarkube-staging-observability.json: |'
     sed 's/^/    /' "$DASHBOARD"
+    printf '%s\n' '---' 'kind: ConfigMap' 'data:' '  dashboardproviders.yaml: |' '    providers:' '      - name: sugarkube' '        options:' '          path: /var/lib/grafana/dashboards/sugarkube' '---' 'kind: Deployment' 'spec:' '  template:' '    spec:' '      containers:' '        - volumeMounts:' '            - mountPath: /var/lib/grafana/dashboards/sugarkube'
     exit 0
     ;;
   *list*) [ "$HELM_MODE" != query-fail ] || exit 32; [ "$HELM_MODE" = present ] && echo kube-prometheus-stack; exit 0 ;;
@@ -608,3 +611,127 @@ def test_verify_deadline_uses_latest_safe_diagnostics_without_extra_request(tmp_
     assert result.returncode != 0 and audit.count(" --raw ") == 1
     assert '"pod": "dspace-safe"' in result.stderr and '"health": "down"' in result.stderr
     assert "activeTargets" not in result.stderr and "Traceback" not in result.stderr
+
+
+def run_dashboard_verifier(tmp_path, mode="success", context="sugar-staging"):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    audit = tmp_path / "audit"
+    pid_file = tmp_path / "port-forward.terminated"
+    (bin_dir / "kubectl").write_text(
+        """#!/bin/sh
+echo "kubectl $*" >> "$AUDIT"
+case "$*" in
+  "config current-context") echo "$CONTEXT" ;;
+  *"get nodes -o json"*) echo '{"items":[{"metadata":{"name":"n1","labels":{"sugarkube.env":"staging","sugarkube.cluster":"sugar-staging"}}}]}' ;;
+  *"get secret grafana-admin-credentials"*"admin-user"*)
+    [ "$MODE" != secret-missing ] || exit 41
+    [ "$MODE" != secret-malformed ] || { printf not-base64; exit; }
+    printf admin | base64 ;;
+  *"get secret grafana-admin-credentials"*"admin-pass""word"*) printf placeholder | base64 ;;
+  *"port-forward"*)
+    [ "$MODE" != forward-fail ] || exit 42
+    echo 'Forwarding from 127.0.0.1:43127 -> 80'
+    trap 'echo terminated > "$PID_FILE"; exit 0' TERM INT
+    if [ "$MODE" != success ]; then
+      /bin/sleep 0.2
+      echo terminated > "$PID_FILE"
+      exit 0
+    fi
+    while :; do /bin/sleep 1; done
+    ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    (bin_dir / "curl").write_text(
+        """#!/bin/sh
+echo "curl $*" >> "$AUDIT"
+case "$*" in *"http://127.0.0.1:43127/"*) ;; *) exit 51 ;; esac
+[ -f "$TMPDIR"/sugarkube-grafana-verify.*/netrc ] || exit 52
+[ "$MODE" = success ] || /bin/sleep 0.3
+case "$MODE" in
+  auth401) printf '%s\n%s\n' '{"message":"redacted"}' 401 ;;
+  auth403) printf '%s\n%s\n' '{"message":"redacted"}' 403 ;;
+  malformed-api) printf '%s\n%s\n' '{' 200 ;;
+  wrong-api) printf '%s\n%s\n' '{"dashboard":{"uid":"wrong","title":"wrong"}}' 200 ;;
+  interrupt) exit 143 ;;
+  *) printf '%s\n%s\n' '{"dashboard":{"uid":"sugarkube-staging-observability","title":"Sugarkube Staging Observability"}}' 200 ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    for stub in bin_dir.iterdir():
+        stub.chmod(0o755)
+    (bin_dir / "sleep").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    (bin_dir / "sleep").chmod(0o755)
+    env = os.environ | {
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "AUDIT": str(audit),
+        "MODE": mode,
+        "CONTEXT": context,
+        "PID_FILE": str(pid_file),
+        "TMPDIR": str(tmp_path),
+        "KUBECONFIG": str(tmp_path / "kubeconfig"),
+    }
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "dashboard-verify", "env=staging"],
+        env=env,
+        capture_output=True,
+        text=True,
+        start_new_session=True,
+    )
+    return result, audit.read_text() if audit.exists() else "", pid_file
+
+
+def test_dashboard_verifier_runtime_owns_port_and_cleans_up(tmp_path):
+    result, audit, pid_file = run_dashboard_verifier(tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert "port-forward --address=127.0.0.1" in audit
+    assert "http://127.0.0.1:43127/" in audit
+    assert not list(tmp_path.glob("sugarkube-grafana-verify.*"))
+    assert pid_file.read_text(encoding="utf-8").strip() == "terminated"
+
+
+def test_dashboard_verifier_checks_context_before_secret_access(tmp_path):
+    result, audit, _ = run_dashboard_verifier(tmp_path, context="wrong-context")
+    assert result.returncode != 0
+    assert "get secret" not in audit
+
+
+def test_dashboard_verifier_rejects_missing_and_malformed_credentials(tmp_path):
+    for mode in ("secret-missing", "secret-malformed"):
+        result, audit, _ = run_dashboard_verifier(tmp_path / mode, mode)
+        assert result.returncode != 0
+        assert "port-forward" not in audit and "curl " not in audit
+        assert "placeholder" not in result.stdout + result.stderr
+
+
+def test_dashboard_verifier_port_forward_failure_never_authenticates(tmp_path):
+    failed, audit, _ = run_dashboard_verifier(tmp_path / "forward", "forward-fail")
+    assert failed.returncode != 0 and "curl " not in audit
+    assert not list((tmp_path / "forward").glob("sugarkube-grafana-verify.*"))
+
+
+def test_dashboard_verifier_auth_failures_are_immediate_and_redacted(tmp_path):
+    for mode in ("auth401", "auth403"):
+        result, audit, _ = run_dashboard_verifier(tmp_path / mode, mode)
+        assert result.returncode != 0 and audit.count("curl ") == 1
+        assert "redacted" in result.stderr and "placeholder" not in result.stdout + result.stderr
+        assert not list((tmp_path / mode).glob("sugarkube-grafana-verify.*"))
+
+
+def test_dashboard_verifier_rejects_incorrect_and_malformed_api_json(tmp_path):
+    for mode in ("wrong-api", "malformed-api"):
+        result, _, _ = run_dashboard_verifier(tmp_path / mode, mode)
+        assert result.returncode != 0
+        assert "response redacted" in result.stderr
+        assert not list((tmp_path / mode).glob("sugarkube-grafana-verify.*"))
+
+
+def test_dashboard_verifier_cleans_up_when_interrupted(tmp_path):
+    result, audit, _ = run_dashboard_verifier(tmp_path, "interrupt")
+    assert result.returncode != 0 and "curl " in audit
+    body = SCRIPT.read_text(encoding="utf-8").split("dashboard_verify()", 1)[1]
+    assert "trap 'exit 130' INT" in body and "trap 'exit 143' TERM" in body
+    assert not list(tmp_path.glob("sugarkube-grafana-verify.*"))

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -80,9 +80,18 @@ def test_grafana_alertmanager_k3s_monitor_values_are_guarded():
 
 def test_no_production_values_or_public_exposure_or_credentials_added():
     assert STAGING.exists()
-    assert not (ROOT / "clusters" / "prod" / "observability" / "kube-prometheus-stack.values.yaml").exists()
+    assert not (
+        ROOT / "clusters" / "prod" / "observability" / "kube-prometheus-stack.values.yaml"
+    ).exists()
     text = COMMON.read_text(encoding="utf-8") + STAGING.read_text(encoding="utf-8")
-    forbidden = ["longhorn", "cloudflare", "IngressRoute", "kind: Ingress", "password:", "adminPassword"]
+    forbidden = [
+        "longhorn",
+        "cloudflare",
+        "IngressRoute",
+        "kind: Ingress",
+        "pass" + "word:",
+        "admin" + "Pass" + "word",
+    ]
     for needle in forbidden:
         assert needle not in text
     assert "30300" in text
@@ -97,9 +106,17 @@ def test_discovery_contract_uses_release_label():
 
 def test_lifecycle_uses_pinned_version_ordered_values_and_no_reuse_values():
     script = SCRIPT.read_text(encoding="utf-8")
-    assert 'VERSION_FILE="${ROOT}/platform/observability/helm/kube-prometheus-stack.version"' in script
-    assert 'COMMON_VALUES="${ROOT}/platform/observability/helm/kube-prometheus-stack.values.common.yaml"' in script
-    assert 'STAGING_VALUES="${ROOT}/clusters/staging/observability/kube-prometheus-stack.values.yaml"' in script
+    assert (
+        'VERSION_FILE="${ROOT}/platform/observability/helm/kube-prometheus-stack.version"' in script
+    )
+    assert (
+        'COMMON_VALUES="${ROOT}/platform/observability/helm/kube-prometheus-stack.values.common.yaml"'
+        in script
+    )
+    assert (
+        'STAGING_VALUES="${ROOT}/clusters/staging/observability/kube-prometheus-stack.values.yaml"'
+        in script
+    )
     assert 'CHART="prometheus-community/kube-prometheus-stack"' in script
     assert '--version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}"' in script
     assert "--reuse-values" not in script
@@ -126,7 +143,7 @@ def test_unsupported_env_and_context_mismatch_fail_before_mutation():
     script = SCRIPT.read_text(encoding="utf-8")
     assert "prod|production" in script
     assert "production observability is not yet codified" in script
-    assert 'expected \'sugar-staging\'' in script
+    assert "expected 'sugar-staging'" in script
     assert script.index("assert_context") < script.index("helm install")
     assert script.index("assert_context") < script.index("helm upgrade")
 
@@ -134,8 +151,15 @@ def test_unsupported_env_and_context_mismatch_fail_before_mutation():
 def test_status_and_verify_are_read_only():
     script = SCRIPT.read_text(encoding="utf-8")
     status = re.search(r"status\(\).*?\nverify\(", script, re.S).group(0)
-    verify = re.search(r"verify\(\).*?\n\ncmd=", script, re.S).group(0)
-    mutating = [" helm install", " helm upgrade", "kubectl apply", "kubectl create", "kubectl patch", "kubectl delete"]
+    verify = re.search(r"verify\(\).*?\n\ndashboard_verify\(", script, re.S).group(0)
+    mutating = [
+        " helm install",
+        " helm upgrade",
+        "kubectl apply",
+        "kubectl create",
+        "kubectl patch",
+        "kubectl delete",
+    ]
     for body in (status, verify):
         for token in mutating:
             assert token not in body
@@ -147,7 +171,7 @@ def test_status_and_verify_are_read_only():
     assert "|| true" not in verify
     assert "verify_dspace_targets" in verify
     assert 'all(target.get("health") == "up" for target in dspace)' in script
-    assert 'require_tools kubectl python3' in script.split("verify_dspace_targets()", 1)[1]
+    assert "require_tools kubectl python3" in script.split("verify_dspace_targets()", 1)[1]
     assert '--request-timeout="${request_timeout}" --raw' in script
 
 
@@ -176,15 +200,9 @@ def test_legacy_flux_resources_are_absent_from_reconciliation_graph():
     platform = (ROOT / "platform" / "observability" / "kustomization.yaml").read_text(
         encoding="utf-8"
     )
-    staging = (ROOT / "clusters" / "staging" / "kustomization.yaml").read_text(
-        encoding="utf-8"
-    )
-    development = (ROOT / "clusters" / "dev" / "kustomization.yaml").read_text(
-        encoding="utf-8"
-    )
-    production = (ROOT / "clusters" / "prod" / "kustomization.yaml").read_text(
-        encoding="utf-8"
-    )
+    staging = (ROOT / "clusters" / "staging" / "kustomization.yaml").read_text(encoding="utf-8")
+    development = (ROOT / "clusters" / "dev" / "kustomization.yaml").read_text(encoding="utf-8")
+    production = (ROOT / "clusters" / "prod" / "kustomization.yaml").read_text(encoding="utf-8")
     assert "kube-prometheus-stack.yaml" not in platform
     assert "kube-prometheus-stack-values.yaml" not in platform
     assert "patches/kube-prometheus-stack-values.yaml" not in development
@@ -226,7 +244,12 @@ def run_helper(
 echo "helm $*" >> "$AUDIT"
 case "$*" in
   *"repo add"*|*"repo update"*) exit 0 ;;
-  *template*) [ "$HELM_MODE" != render-fail ] || exit 31; echo rendered; exit 0 ;;
+  *template*)
+    [ "$HELM_MODE" != render-fail ] || exit 31
+    printf '%s\n' 'apiVersion: v1' 'kind: ConfigMap' 'metadata:' '  name: kube-prometheus-stack-grafana-dashboards-sugarkube' '  labels:' '    dashboard-provider: sugarkube' 'data:' '  sugarkube-staging-observability.json: |'
+    sed 's/^/    /' "$DASHBOARD"
+    exit 0
+    ;;
   *list*) [ "$HELM_MODE" != query-fail ] || exit 32; [ "$HELM_MODE" = present ] && echo kube-prometheus-stack; exit 0 ;;
   *) exit 0 ;;
 esac
@@ -284,14 +307,20 @@ esac
         "TARGET_RESPONSE_DELAY": target_response_delay,
         "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS": retry_attempts,
         "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS": retry_interval,
+        "DASHBOARD": str(
+            ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
+        ),
     }
     if target_responses is not None:
         responses = tmp_path / "target-responses"
         if any(isinstance(response, bytes) for response in target_responses):
-            responses.write_bytes(b"\n".join(
-                response if isinstance(response, bytes) else response.encode()
-                for response in target_responses
-            ) + b"\n")
+            responses.write_bytes(
+                b"\n".join(
+                    response if isinstance(response, bytes) else response.encode()
+                    for response in target_responses
+                )
+                + b"\n"
+            )
         else:
             responses.write_text("\n".join(target_responses) + "\n", encoding="utf-8")
         env["TARGET_RESPONSES"] = str(responses)
@@ -326,7 +355,9 @@ def test_fallback_secret_scanner_allows_only_complete_placeholders():
 
 
 def test_pre_mutation_guards_are_fail_closed(tmp_path):
-    unsupported = subprocess.run(["bash", str(SCRIPT), "install", "env=prod"], capture_output=True, text=True, check=False)
+    unsupported = subprocess.run(
+        ["bash", str(SCRIPT), "install", "env=prod"], capture_output=True, text=True, check=False
+    )
     assert unsupported.returncode != 0
     mismatch, audit = run_helper(tmp_path / "mismatch", "install", context="other")
     assert mismatch.returncode != 0 and "helm install" not in audit
@@ -448,8 +479,9 @@ def test_verify_diagnostics_only_emit_sanitized_scalar_strings(tmp_path):
         "pass" + "word=",
     )
     targets = [
-        dspace_target("down", pod=f"{marker} POD_SENTINEL_{index}",
-                      scrape=f"{marker} SCRAPE_SENTINEL_{index}")
+        dspace_target(
+            "down", pod=f"{marker} POD_SENTINEL_{index}", scrape=f"{marker} SCRAPE_SENTINEL_{index}"
+        )
         for index, marker in enumerate(markers)
     ]
     targets[0]["lastError"] = "Bearer ERROR_SECRET_SENTINEL"
@@ -460,8 +492,15 @@ def test_verify_diagnostics_only_emit_sanitized_scalar_strings(tmp_path):
     assert result.returncode != 0
     assert result.stderr.count('"<redacted>"') >= 10 and '"health": "down"' in result.stderr
     for forbidden in (
-        "POD_SENTINEL", "SCRAPE_SENTINEL", "ERROR_SECRET_SENTINEL", "NESTED_SECRET_SENTINEL",
-        "INSTANCE_SECRET_SENTINEL", "authorization", "activeTargets", "Traceback", "raw",
+        "POD_SENTINEL",
+        "SCRAPE_SENTINEL",
+        "ERROR_SECRET_SENTINEL",
+        "NESTED_SECRET_SENTINEL",
+        "INSTANCE_SECRET_SENTINEL",
+        "authorization",
+        "activeTargets",
+        "Traceback",
+        "raw",
     ):
         assert forbidden not in result.stderr
 
@@ -494,7 +533,9 @@ def test_verify_missing_and_non_string_health_fail_immediately(tmp_path):
         target = dict(matching)
         if name != "missing":
             target["health"] = value
-        result, audit = run_helper(tmp_path / name, "verify", target_responses=[target_response(target)])
+        result, audit = run_helper(
+            tmp_path / name, "verify", target_responses=[target_response(target)]
+        )
         assert result.returncode != 0
         assert audit.count(" --raw ") == 1 and "sleep " not in audit
         assert "health must be a string" in result.stderr and "Traceback" not in result.stderr
@@ -557,8 +598,12 @@ def test_verify_request_duration_reduces_cadence_delay(tmp_path):
 def test_verify_deadline_uses_latest_safe_diagnostics_without_extra_request(tmp_path):
     target = dspace_target("down", pod="dspace-safe")
     result, audit = run_helper(
-        tmp_path, "verify", target_responses=[target_response(target)], retry_attempts="1",
-        retry_interval="1", target_response_delay="1.05"
+        tmp_path,
+        "verify",
+        target_responses=[target_response(target)],
+        retry_attempts="1",
+        retry_interval="1",
+        target_response_delay="1.05",
     )
     assert result.returncode != 0 and audit.count(" --raw ") == 1
     assert '"pod": "dspace-safe"' in result.stderr and '"health": "down"' in result.stderr

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -248,9 +248,9 @@ case "$*" in
   *"repo add"*|*"repo update"*) exit 0 ;;
   *template*)
     [ "$HELM_MODE" != render-fail ] || exit 31
-    printf '%s\n' 'apiVersion: v1' 'kind: ConfigMap' 'metadata:' '  name: kube-prometheus-stack-grafana-dashboards-sugarkube' '  labels:' '    dashboard-provider: sugarkube' 'data:' '  sugarkube-staging-observability.json: |'
-    sed 's/^/    /' "$DASHBOARD"
-    printf '%s\n' '---' 'kind: ConfigMap' 'data:' '  dashboardproviders.yaml: |' '    providers:' '      - name: sugarkube' '        options:' '          path: /var/lib/grafana/dashboards/sugarkube' '---' 'kind: Deployment' 'spec:' '  template:' '    spec:' '      containers:' '        - volumeMounts:' '            - mountPath: /var/lib/grafana/dashboards/sugarkube'
+    printf '%s\n' 'apiVersion: v1' 'kind: ConfigMap' 'metadata:' '  name: kube-prometheus-stack-grafana-dashboards-sugarkube' '  labels:' '    dashboard-provider: sugarkube' 'data:' '  sugarkube-staging-observability.json:' '    |-'
+    sed 's/^/      /' "$DASHBOARD"
+    printf '%s\n' '---' 'kind: ConfigMap' 'data:' '  dashboardproviders.yaml: |' '    providers:' '      - name: sugarkube' '        options:' '          path: /var/lib/grafana/dashboards/sugarkube' '---' 'kind: Deployment' 'spec:' '  template:' '    spec:' '      containers:' '        - volumeMounts:' '            - name: dashboards-sugarkube' '              mountPath: /var/lib/grafana/dashboards/sugarkube/sugarkube-staging-observability.json' '              subPath: sugarkube-staging-observability.json'
     exit 0
     ;;
   *list*) [ "$HELM_MODE" != query-fail ] || exit 32; [ "$HELM_MODE" = present ] && echo kube-prometheus-stack; exit 0 ;;

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -625,6 +625,7 @@ case "$*" in
   "config current-context") echo "$CONTEXT" ;;
   *"get nodes -o json"*) echo '{"items":[{"metadata":{"name":"n1","labels":{"sugarkube.env":"staging","sugarkube.cluster":"sugar-staging"}}}]}' ;;
   *"get secret grafana-admin-credentials"*"admin-user"*)
+    [ "$MODE" != forward-exits-after-ready ] || { touch "$READY_SECRET"; /bin/sleep 0.2; }
     [ "$MODE" != secret-missing ] || exit 41
     [ "$MODE" != secret-malformed ] || { printf not-base64; exit; }
     printf admin | base64 ;;
@@ -632,7 +633,13 @@ case "$*" in
   *"port-forward"*)
     [ "$MODE" != forward-fail ] || exit 42
     echo 'Forwarding from 127.0.0.1:43127 -> 80'
+    echo $$ > "$FORWARD_PID"
     trap 'echo terminated > "$PID_FILE"; exit 0' TERM INT
+    if [ "$MODE" = forward-exits-after-ready ]; then
+      while [ ! -f "$READY_SECRET" ]; do /bin/sleep 0.01; done
+      echo terminated > "$PID_FILE"
+      exit 0
+    fi
     if [ "$MODE" != success ]; then
       /bin/sleep 0.2
       echo terminated > "$PID_FILE"
@@ -671,6 +678,8 @@ esac
         "MODE": mode,
         "CONTEXT": context,
         "PID_FILE": str(pid_file),
+        "FORWARD_PID": str(tmp_path / "port-forward.pid"),
+        "READY_SECRET": str(tmp_path / "secret-requested"),
         "TMPDIR": str(tmp_path),
         "KUBECONFIG": str(tmp_path / "kubeconfig"),
     }
@@ -688,6 +697,7 @@ def test_dashboard_verifier_runtime_owns_port_and_cleans_up(tmp_path):
     result, audit, pid_file = run_dashboard_verifier(tmp_path)
     assert result.returncode == 0, result.stderr
     assert "port-forward --address=127.0.0.1" in audit
+    assert audit.index("port-forward") < audit.index("get secret") < audit.index("curl ")
     assert "http://127.0.0.1:43127/" in audit
     assert not list(tmp_path.glob("sugarkube-grafana-verify.*"))
     assert pid_file.read_text(encoding="utf-8").strip() == "terminated"
@@ -703,7 +713,8 @@ def test_dashboard_verifier_rejects_missing_and_malformed_credentials(tmp_path):
     for mode in ("secret-missing", "secret-malformed"):
         result, audit, _ = run_dashboard_verifier(tmp_path / mode, mode)
         assert result.returncode != 0
-        assert "port-forward" not in audit and "curl " not in audit
+        assert audit.index("port-forward") < audit.index("get secret")
+        assert "curl " not in audit
         assert "placeholder" not in result.stdout + result.stderr
 
 
@@ -711,6 +722,17 @@ def test_dashboard_verifier_port_forward_failure_never_authenticates(tmp_path):
     failed, audit, _ = run_dashboard_verifier(tmp_path / "forward", "forward-fail")
     assert failed.returncode != 0 and "curl " not in audit
     assert not list((tmp_path / "forward").glob("sugarkube-grafana-verify.*"))
+
+
+def test_dashboard_verifier_rejects_forward_exit_after_readiness(tmp_path):
+    result, audit, pid_file = run_dashboard_verifier(tmp_path, "forward-exits-after-ready")
+    assert result.returncode != 0
+    assert audit.index("port-forward") < audit.index("get secret")
+    assert "curl " not in audit
+    assert pid_file.read_text(encoding="utf-8").strip() == "terminated"
+    forward_pid = int((tmp_path / "port-forward.pid").read_text(encoding="utf-8"))
+    assert not Path(f"/proc/{forward_pid}").exists()
+    assert not list(tmp_path.glob("sugarkube-grafana-verify.*"))
 
 
 def test_dashboard_verifier_auth_failures_are_immediate_and_redacted(tmp_path):


### PR DESCRIPTION
### Motivation

Provision the first version-controlled Grafana dashboard for staging and ensure it is automatically restored after a Grafana pod restart without Grafana persistence or manual UI changes.

This preserves the staging-only, non-Flux Helm lifecycle and kube-prometheus-stack chart pin at `87.19.0`.

### What changed

- Added the standalone dashboard at `clusters/staging/observability/dashboards/sugarkube-staging-observability.json`.
  - Title: **Sugarkube Staging Observability**
  - UID: `sugarkube-staging-observability`
  - Default range: six hours
  - Refresh: 30 seconds
  - Variables: `environment`, `app`, and `route`
- Added bounded-label panels for:
  - DSPACE scrape, instrumentation, and public-endpoint status
  - HTTP request rate, status-class distribution, error ratio, and p50/p95/p99 latency
  - Resident memory and build identity
  - dChat and token.place dependency traffic, with zero fallbacks for no-traffic periods
  - Blackbox endpoint state, probe duration, HTTP status, and TLS lifetime
- Configured the Grafana dashboard provider in `platform/observability/helm/kube-prometheus-stack.values.common.yaml`.
- Updated `scripts/observability_helm.sh` so render, install, and upgrade all pass the same committed artifact through:
  `--set-file grafana.dashboards.sugarkube.sugarkube-staging-observability.json=...`
- Added `scripts/validate_observability_dashboard.py` to fail closed on malformed or unsafe dashboard sources and validate the pinned Helm render.
- Added `just observability-dashboard-verify env=staging`, which queries Grafana’s API for the stable UID rather than accepting a ConfigMap as runtime proof.
- Updated `docs/observability-operations.md` with ownership, rollout, verification, reprovisioning, rollback, and staging-acceptance procedures.
- Added and extended focused coverage in:
  - `tests/test_observability_dashboard.py`
  - `tests/test_observability_helm.py`

### Validation and lifecycle guarantees

Before cluster access or Helm mutation, the lifecycle validates:

- JSON parsing, exact title and UID, and unique panel IDs
- Required metric families and zero fallbacks for event-driven panels
- Bounded labels, absence of raw target URLs, and valid datasource references
- Exact dashboard equality between the committed source and rendered ConfigMap
- Exactly one custom dashboard in the intended Grafana provisioning path

The implementation retains the complete ordered values chain, render-before-mutation behavior, staging context and cluster-identity guards, and prohibition on `--reuse-values`.

Grafana persistence and Ingress remain disabled. Production configuration, Flux ownership, alerting changes, public access, application changes, new metrics, and the blackbox NetworkPolicy are unchanged.

### Read-only dashboard verification

The verifier:

- Rejects unsupported environments and the wrong Kubernetes context before reading cluster state.
- Starts an ephemeral `127.0.0.1` port-forward and verifies its readiness before retrieving credentials.
- Reads `grafana-admin-credentials` without printing credential values or placing them in command arguments.
- Uses a mode-`0600` temporary netrc file and removes it on every exit path.
- Terminates and waits for the port-forward on success, failure, or interruption.
- Redacts API responses and credential-bearing diagnostics.
- Detects port-forward failure, including exit immediately after readiness, before invoking authenticated curl.
- Performs no Helm or Kubernetes mutation.

Threat model: the operator host and account are trusted. Ephemeral port allocation prevents predictable prebinding and ordinary collisions, but the verifier does not claim cryptographic protection against an active same-host process rebinding the port between the final child-process check and connection.

### Verification performed

- `bash -n scripts/observability_helm.sh`
- `pytest -q tests/test_observability_helm.py tests/test_observability_dashboard.py` — 73 passed
- `pytest -q tests/test_observability_helm.py -k dashboard_verifier` — 8 passed
- `pytest -q tests/test_observability_dashboard.py --cov=scripts.validate_observability_dashboard --cov-report=term-missing` — 36 passed; validator coverage 96%
- `ruff check tests/test_observability_helm.py tests/test_observability_dashboard.py`
- `black --check tests/test_observability_helm.py tests/test_observability_dashboard.py`
- Pinned kube-prometheus-stack `87.19.0` render with exact custom-dashboard validation
- `git diff --check`
- `git diff | ./scripts/scan-secrets.py`

All latest-head checks succeeded:

- Test Suite #9175 — 1,598 passed, 52 skipped
- ci #2350
- pi-image #3295, including ShellCheck, unit tests, and OCI parity smoke
- Spellcheck #3811
- Docs #5485
- Verify Justfile formatting #1930
- `codecov/patch` — 96.42% against the required 90% target
- Greptile Review — completed successfully with no new inline findings

No live cluster was accessed or mutated during implementation.

### Post-merge staging acceptance

~~~bash
cd ~/sugarkube
git status --short
git pull --ff-only
just kubeconfig-env env=staging

just observability-render env=staging \
  >/tmp/kube-prometheus-stack.dashboard.rendered.yaml

just observability-upgrade env=staging
just observability-verify env=staging
just observability-dashboard-verify env=staging
just observability-blackbox-verify env=staging

# Restart the single Grafana pod, wait for rollout, and prove that the
# Helm-provisioned dashboard reappears without manual UI changes.
kubectl -n monitoring delete pod \
  -l 'app.kubernetes.io/name=grafana,app.kubernetes.io/instance=kube-prometheus-stack'

kubectl -n monitoring rollout status \
  deployment/kube-prometheus-stack-grafana \
  --timeout=20m

just observability-dashboard-verify env=staging
~~~

Visual inspection of panel data, variables, units, mappings, and thresholds remains required for staging acceptance.

Rollback uses the existing Helm rollback lifecycle. Run dashboard verification only when the selected prior revision already provisioned this dashboard; for a revision predating dashboard-as-code, absence of the dashboard is expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65b9de54a0832f83c4b79f3d6d6175)