### PR TITLE
Add fail-closed DSPACE manifest-based rollback (`dspace-manifest-rollback`)

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -237,6 +237,20 @@ requires inspecting and reconciling the cluster, Helm release, candidate, and
 existing evidence before an operator explicitly removes the exact stranded sidecar
 and retries.
 
+### DSPACE manifest rollback
+
+`just dspace-manifest-rollback` is the DSPACE-only recovery surface. It accepts a
+previously finalized release-evidence record and a new evidence destination, and
+derives every deployment coordinate from the finalized record. It performs all
+cluster, values-chain, OCI, chart-render, current-state, no-op, production
+confirmation, and verifier-capability checks before reserving evidence. The
+mutation is a digest-qualified `helm upgrade` with the complete values chain and
+without reused values; Helm revision rollback is not the default DSPACE recovery
+path. Post-rollout evidence requires stable Helm state, replacement pod identities,
+exact image IDs, OCI revision metadata, and strict runtime, frontend, provider, and
+public-journey proof. The verifier dependency is fail-closed pending DSPACE #4732
+and #4733; it is not replaced with inferred identity or an availability check.
+
 These recipes are implemented in the root `justfile` and use the app config
 lookup order above.
 

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -328,38 +328,71 @@ curl -fsS https://democratized.space/livez
 
 ## Rollback
 
-Rollback by deploying the previous known-good immutable image tag with the generic redeploy command and an approved environment-specific candidate for that release. Use a unique `evidence=` path if evidence for the tag already exists; occupied paths are rejected before Helm runs.
-Do not infer or generate a rollback manifest automatically; that future
-automation is tracked in #2327.
+The primary DSPACE recovery operation restores a previously approved **finalized
+release-evidence** record. It derives the image tag, image digest, chart version,
+chart digest, source revision, application version, and provider from that record;
+there are no independent image or chart overrides. Candidate records and semantic
+or mutable tags are rejected. `semanticTag` is corroborating evidence only.
 
 ```bash
-APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA
-STAGING_ROLLBACK_MANIFEST=deployment-candidates/dspace/previous-release-staging.json
-PROD_ROLLBACK_MANIFEST=deployment-candidates/dspace/previous-release-prod.json
+just dspace-manifest-rollback \
+  env=staging \
+  manifest=deployment-evidence/dspace/staging/previous-final.json \
+  evidence=deployment-evidence/dspace/staging/rollback-20260727T120000Z.json \
+  verifier=/absolute/path/to/dspace-runtime-journey-verifier
 ```
+
+Staging is non-interactive. Production additionally requires the exact confirmation
+`dspace:prod:<full-target-source-SHA>`. A generic `yes`, a short SHA, or a value for
+another release fails before reservation or mutation:
 
 ```bash
-just app-redeploy app=dspace env=staging tag="$APP_TAG" manifest="$STAGING_ROLLBACK_MANIFEST" evidence=deployment-evidence/dspace/staging/"$APP_TAG"-rollback.json
+TARGET_SHA=REPLACE_WITH_40_CHARACTER_SHA_FROM_FINAL_EVIDENCE
+just dspace-manifest-rollback \
+  env=prod \
+  manifest=deployment-evidence/dspace/prod/previous-final.json \
+  evidence=deployment-evidence/dspace/prod/rollback-20260727T120000Z.json \
+  verifier=/absolute/path/to/dspace-runtime-journey-verifier \
+  confirm="dspace:prod:${TARGET_SHA}"
 ```
+
+Before reserving evidence or changing the cluster, the command asserts cluster
+identity, resolves and hashes the complete ordered values chain, checks file
+readability, reruns digest and OCI-revision checks, renders the digest-qualified
+chart, establishes verifier capabilities, captures current Helm and pod identity,
+prints a current-versus-target summary, and rejects a no-op. It never prints values
+contents or verifier response bodies.
+
+Only then does it atomically reserve the new evidence path and run `helm upgrade`
+with the digest-qualified chart, every explicit values file, and the immutable
+target image tag. It does not use `--reuse-values`, a semantic tag, or `helm
+rollback <revision>`. After rollout it proves the Helm revision advanced and stayed
+stable, validates chart and release ownership, requires replacement Running/Ready
+pods with the exact image digest, reruns OCI provenance, and invokes the strict
+runtime/frontend/provider/public-journey verifier (including `/chat`). Success
+creates a non-overwritable rollback-evidence JSON record and removes its reservation.
+
+If anything fails after reservation, stop: cluster state may have changed. The
+reservation remains deliberately. Inspect the release, pods, target evidence, and
+reserved destination, then reconcile manually; the command never attempts a second
+automatic rollback. `helm history` remains useful for investigation, but `helm
+rollback <revision>` is not the default DSPACE recovery mechanism. The
+`tokenplace-rollback` helper is only for Tokenplace and must not be invoked for
+DSPACE.
 
 ```bash
-just app-redeploy app=dspace env=prod tag="$APP_TAG" manifest="$PROD_ROLLBACK_MANIFEST" evidence=deployment-evidence/dspace/prod/"$APP_TAG"-rollback.json
+helm history dspace --namespace dspace
 ```
 
-Rollback by Helm revision is still available through the existing parameterized helper. Set `ROLLBACK_ENV=staging` instead when intentionally rolling back staging.
-
-```bash
-HELM_REVISION=12
-```
-
-```bash
-ROLLBACK_ENV=prod
-just kubeconfig-env "$ROLLBACK_ENV"
-```
-
-```bash
-just tokenplace-rollback release=dspace namespace=dspace revision="$HELM_REVISION" env="$ROLLBACK_ENV"
-```
+The executable verifier contract is intentionally a dependency boundary. Its
+`capabilities` JSON must declare application version, full runtime SHA, frontend
+SHA, provider, and public journeys. Its `verify` result must contain exact typed
+fields and successful named journeys including `/chat`. Real production rollback
+therefore remains unavailable until DSPACE
+[#4732](https://github.com/democratizedspace/dspace/issues/4732) and
+[#4733](https://github.com/democratizedspace/dspace/issues/4733) provide commands
+that satisfy this contract. Sugarkube does not fabricate HTTP build identity,
+derive frontend identity from SemVer, or substitute an availability-only smoke.
 
 ## Troubleshooting
 

--- a/justfile
+++ b/justfile
@@ -1946,6 +1946,22 @@ dspace-oci-redeploy env='staging' tag='' manifest='' evidence='':
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
     "${delegate[@]}"
 
+# Restore DSPACE from immutable finalized evidence; this is intentionally not a Helm revision rollback.
+dspace-manifest-rollback env='staging' manifest='' evidence='' verifier='' confirm='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    if [ -z {{ quote(manifest) }} ] || [ -z {{ quote(evidence) }} ] || [ -z {{ quote(verifier) }} ]; then
+      echo "Usage: just dspace-manifest-rollback env=<staging|prod> manifest=<final.json> evidence=<new.json> verifier=<executable> [confirm=<dspace:prod:FULL_SHA>]" >&2
+      exit 2
+    fi
+    export KUBECONFIG="${HOME}/.kube/config"
+    just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env {{ quote(env) }}
+    python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py" \
+      --environment {{ quote(env) }} --manifest {{ quote(manifest) }} \
+      --evidence {{ quote(evidence) }} --verifier {{ quote(verifier) }} \
+      --confirm {{ quote(confirm) }}
+
 # Dump dspace and Traefik logs for debugging HTTP 500s.
 dspace-debug-logs namespace='dspace':
     #!/usr/bin/env bash

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+"""Fail-closed rollback of DSPACE to an approved, finalized release record."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import secrets
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Callable
+
+from scripts import dspace_release_manifest as release
+
+SCHEMA_VERSION = 1
+OPERATION = "dspaceManifestRollback"
+VERIFY_CAPABILITIES = (
+    "applicationVersion",
+    "runtimeSourceRevision",
+    "frontendSourceRevision",
+    "defaultProvider",
+    "publicJourneys",
+)
+RESULT_FIELDS = (
+    "schemaVersion",
+    "applicationVersion",
+    "runtimeSourceRevision",
+    "frontendSourceRevision",
+    "defaultProvider",
+    "journeys",
+)
+
+
+class RollbackError(ValueError):
+    """A rollback safety invariant was not satisfied."""
+
+
+def canonical(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def run(command: list[str]) -> str:
+    completed = subprocess.run(command, text=True, capture_output=True, check=False)
+    if completed.returncode:
+        # Tool output can contain credentials or response bodies. Deliberately report
+        # only the executable and exit status.
+        raise RollbackError(
+            f"{Path(command[0]).name} failed with exit status {completed.returncode}"
+        )
+    return completed.stdout
+
+
+def json_run(runner: Callable[[list[str]], str], command: list[str]) -> dict[str, Any]:
+    try:
+        result = json.loads(runner(command))
+    except json.JSONDecodeError as exc:
+        raise RollbackError(f"{Path(command[0]).name} returned invalid JSON") from exc
+    if not isinstance(result, dict):
+        raise RollbackError(f"{Path(command[0]).name} returned non-object JSON")
+    return result
+
+
+def exact_fields(value: dict[str, Any], fields: tuple[str, ...], what: str) -> None:
+    if set(value) != set(fields):
+        raise RollbackError(f"{what} has missing or unknown fields")
+
+
+def target_candidate(final: dict[str, Any]) -> dict[str, Any]:
+    """Strictly validate final evidence and project its approved immutable candidate."""
+    release.validate(final, True)
+    candidate = {field: final[field] for field in release.CANDIDATE_FIELDS}
+    candidate["recordType"] = "candidate"
+    return release.validate(candidate, False)
+
+
+def manifest_fingerprint(final: dict[str, Any]) -> str:
+    release.validate(final, True)
+    return "sha256:" + hashlib.sha256(canonical(final).encode()).hexdigest()
+
+
+def validate_capabilities(value: dict[str, Any]) -> None:
+    exact_fields(value, ("schemaVersion", "capabilities"), "verifier capabilities")
+    if value["schemaVersion"] != 1 or not isinstance(value["capabilities"], dict):
+        raise RollbackError("verifier capabilities use an incompatible schema")
+    exact_fields(value["capabilities"], VERIFY_CAPABILITIES, "verifier capabilities")
+    if any(value["capabilities"][name] is not True for name in VERIFY_CAPABILITIES):
+        raise RollbackError("verifier cannot establish every required capability")
+
+
+def validate_verifier_result(value: dict[str, Any], target: dict[str, Any]) -> dict[str, Any]:
+    """Validate the reusable DSPACE runtime/frontend/journey proof contract."""
+    exact_fields(value, RESULT_FIELDS, "verifier result")
+    expected = {
+        "schemaVersion": 1,
+        "applicationVersion": target["applicationVersion"],
+        "runtimeSourceRevision": target["sourceRevision"],
+        "frontendSourceRevision": target["sourceRevision"],
+        "defaultProvider": target["expectedDefaultChatProvider"],
+    }
+    for field, wanted in expected.items():
+        if value[field] != wanted or isinstance(value[field], bool):
+            raise RollbackError(f"verifier {field} does not match approved target")
+    journeys = value["journeys"]
+    if not isinstance(journeys, list) or not journeys:
+        raise RollbackError("verifier must report public journeys")
+    names: set[str] = set()
+    for journey in journeys:
+        if not isinstance(journey, dict):
+            raise RollbackError("verifier journey must be an object")
+        exact_fields(journey, ("name", "passed"), "verifier journey")
+        if not isinstance(journey["name"], str) or not journey["name"] or journey["name"] in names:
+            raise RollbackError("verifier journey names must be unique non-empty strings")
+        if journey["passed"] is not True:
+            raise RollbackError(f"public journey failed: {journey['name']}")
+        names.add(journey["name"])
+    if "/chat" not in names:
+        raise RollbackError("verifier result must include release-appropriate /chat journey")
+    return value
+
+
+def values_evidence(raw: str, root: Path) -> tuple[list[Path], list[dict[str, str]]]:
+    paths: list[Path] = []
+    evidence: list[dict[str, str]] = []
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        path = Path(item)
+        if not path.is_absolute():
+            path = root / path
+        try:
+            data = path.read_bytes()
+        except OSError as exc:
+            raise RollbackError(f"values file is not readable: {item}") from exc
+        paths.append(path)
+        try:
+            portable = path.resolve().relative_to(root.resolve()).as_posix()
+        except ValueError:
+            portable = path.resolve().as_posix()
+        evidence.append({"path": portable, "sha256": hashlib.sha256(data).hexdigest()})
+    if not paths:
+        raise RollbackError("DSPACE values chain is empty")
+    return paths, evidence
+
+
+def pod_identities(
+    pods: dict[str, Any], target: dict[str, Any] | None = None
+) -> list[dict[str, Any]]:
+    result = []
+    for pod in pods.get("items", []):
+        metadata = pod.get("metadata", {})
+        status = pod.get("status", {})
+        containers = pod.get("spec", {}).get("containers", [])
+        statuses = {item.get("name"): item for item in status.get("containerStatuses", [])}
+        if metadata.get("deletionTimestamp") is not None:
+            raise RollbackError("terminating old DSPACE pod remains")
+        if target is not None:
+            if status.get("phase") != "Running" or not any(
+                c.get("type") == "Ready" and c.get("status") == "True"
+                for c in status.get("conditions", [])
+            ):
+                raise RollbackError("all DSPACE pods must be Running and Ready")
+        for container in containers:
+            state = statuses.get(container.get("name"), {})
+            identity = {
+                "name": metadata.get("name"),
+                "uid": metadata.get("uid"),
+                "startTime": status.get("startTime"),
+                "container": container.get("name"),
+                "image": container.get("image"),
+                "imageID": state.get("imageID"),
+            }
+            if not all(isinstance(identity[k], str) and identity[k] for k in identity):
+                raise RollbackError("pod identity evidence is incomplete")
+            if target is not None:
+                wanted = f"{release.IMAGE_REF}:{target['imageTag']}"
+                if identity["image"] != wanted:
+                    raise RollbackError(
+                        "DSPACE container does not declare the target immutable image"
+                    )
+                try:
+                    digest = release._image_id_digest(identity["imageID"])
+                except release.ManifestError as exc:
+                    raise RollbackError(str(exc)) from exc
+                if digest != target["imageDigest"]:
+                    raise RollbackError("DSPACE container imageID does not match target digest")
+            result.append(identity)
+    if not result:
+        raise RollbackError("no release-owned DSPACE pod containers found")
+    return sorted(result, key=lambda item: (item["name"], item["container"]))
+
+
+def helm_identity(value: dict[str, Any], release_name: str, namespace: str) -> dict[str, Any]:
+    metadata = value.get("chart", {}).get("metadata", {})
+    info = value.get("info", {})
+    result = {
+        "release": value.get("name"),
+        "namespace": value.get("namespace"),
+        "revision": value.get("version"),
+        "status": info.get("status"),
+        "chartName": metadata.get("name"),
+        "chartVersion": metadata.get("version"),
+    }
+    if result["release"] != release_name or result["namespace"] != namespace:
+        raise RollbackError("Helm status identifies the wrong release or namespace")
+    if not isinstance(result["revision"], int) or isinstance(result["revision"], bool):
+        raise RollbackError("Helm status lacks a numeric revision")
+    return result
+
+
+def reserve(
+    path: Path, fingerprint: str, environment: str, release_name: str, namespace: str
+) -> tuple[str, Path]:
+    output = path.resolve(strict=False)
+    sidecar = release.reservation_path(output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if output.exists():
+        raise RollbackError(f"refusing to overwrite rollback evidence: {output}")
+    invocation = secrets.token_hex(32)
+    record = {
+        "schemaVersion": 1,
+        "operation": OPERATION,
+        "output": str(output),
+        "targetManifestFingerprint": fingerprint,
+        "environment": environment,
+        "release": release_name,
+        "namespace": namespace,
+        "invocationId": invocation,
+    }
+    try:
+        fd = os.open(sidecar, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError as exc:
+        raise RollbackError(f"rollback evidence is already reserved: {sidecar}") from exc
+    with os.fdopen(fd, "w", encoding="utf-8") as stream:
+        stream.write(json.dumps(record, indent=2) + "\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    return invocation, sidecar
+
+
+def write_new(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(value, stream, indent=2, ensure_ascii=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        try:
+            os.link(temporary, path)
+        except FileExistsError as exc:
+            raise RollbackError(f"refusing to overwrite rollback evidence: {path}") from exc
+    finally:
+        Path(temporary).unlink(missing_ok=True)
+
+
+def execute(args: argparse.Namespace, runner: Callable[[list[str]], str] = run) -> dict[str, Any]:
+    started = dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
+    if not args.manifest.is_file():
+        raise RollbackError(f"finalized target manifest does not exist: {args.manifest}")
+    try:
+        final = json.loads(args.manifest.read_text(encoding="utf-8"))
+        target = target_candidate(final)
+    except (OSError, json.JSONDecodeError, release.ManifestError) as exc:
+        raise RollbackError(f"invalid finalized target manifest: {exc}") from exc
+    if target["environment"] != args.environment:
+        raise RollbackError("target manifest environment does not match selected environment")
+
+    config = json_run(
+        runner,
+        [
+            args.python,
+            str(args.root / "scripts/app_config.py"),
+            "json",
+            "--app",
+            "dspace",
+            "--env",
+            args.environment,
+        ],
+    )
+    required = (
+        "SUGARKUBE_APP",
+        "SUGARKUBE_ENV",
+        "SUGARKUBE_CHART",
+        "SUGARKUBE_RELEASE",
+        "SUGARKUBE_NAMESPACE",
+        "SUGARKUBE_VALUES",
+    )
+    if any(not isinstance(config.get(key), str) or not config[key] for key in required):
+        raise RollbackError("resolved DSPACE environment configuration is incomplete")
+    if config["SUGARKUBE_CHART"].removeprefix("oci://") != release.CHART_REF:
+        raise RollbackError("resolved DSPACE chart is not the canonical chart")
+    values, value_records = values_evidence(config["SUGARKUBE_VALUES"], args.root)
+    release_name, namespace = config["SUGARKUBE_RELEASE"], config["SUGARKUBE_NAMESPACE"]
+
+    runner(
+        [
+            args.just,
+            "--justfile",
+            str(args.root / "justfile"),
+            "assert-cluster-env",
+            args.environment,
+            os.environ.get("KUBECONFIG", str(Path.home() / ".kube/config")),
+        ]
+    )
+    oci = release.preflight(
+        target,
+        release.IMAGE_REF,
+        config["SUGARKUBE_CHART"],
+        args.oras,
+        environment=args.environment,
+        runner=runner,
+    )
+    chart = release.chart_coordinate(target)
+    value_args = [part for path in values for part in ("-f", str(path))]
+    runner(
+        [
+            args.helm,
+            "template",
+            release_name,
+            chart,
+            "--namespace",
+            namespace,
+            *value_args,
+            "--set",
+            f"image.tag={target['imageTag']}",
+        ]
+    )
+
+    validate_capabilities(json_run(runner, [str(args.verifier), "capabilities"]))
+    before_helm = helm_identity(
+        json_run(
+            runner, [args.helm, "status", release_name, "--namespace", namespace, "-o", "json"]
+        ),
+        release_name,
+        namespace,
+    )
+    pod_command = [
+        args.kubectl,
+        "-n",
+        namespace,
+        "get",
+        "pods",
+        "-l",
+        f"app.kubernetes.io/name=dspace,app.kubernetes.io/instance={release_name}",
+        "-o",
+        "json",
+    ]
+    before_pods_json = json_run(runner, pod_command)
+    before_pods = pod_identities(before_pods_json)
+    workload_command = [
+        args.kubectl,
+        "-n",
+        namespace,
+        "get",
+        "replicasets,deployments",
+        "-l",
+        f"app.kubernetes.io/name=dspace,app.kubernetes.io/instance={release_name}",
+        "-o",
+        "json",
+    ]
+    # Capture the ownership objects during read-only preflight as well as after rollout.
+    json_run(runner, workload_command)
+    current_digest = sorted({p["imageID"].rsplit("@", 1)[-1] for p in before_pods})
+    summary = {
+        "current": {
+            **before_helm,
+            "imageCoordinates": sorted({p["image"] for p in before_pods}),
+            "imageDigests": current_digest,
+        },
+        "target": {
+            "chartName": "dspace",
+            "chartVersion": target["chartVersion"],
+            "chartDigest": target["chartDigest"],
+            "imageTag": target["imageTag"],
+            "imageDigest": target["imageDigest"],
+            "sourceRevision": target["sourceRevision"],
+        },
+    }
+    print(json.dumps(summary, sort_keys=True))
+    expected_image = f"{release.IMAGE_REF}:{target['imageTag']}"
+    if (
+        before_helm["chartName"] == "dspace"
+        and before_helm["chartVersion"] == target["chartVersion"]
+        and {p["image"] for p in before_pods} == {expected_image}
+        and set(current_digest) == {target["imageDigest"]}
+    ):
+        raise RollbackError("rollback target is already active; refusing exact no-op")
+    if args.environment == "prod":
+        wanted = f"dspace:prod:{target['sourceRevision']}"
+        if args.confirm != wanted:
+            raise RollbackError(f"production confirmation must exactly equal {wanted}")
+
+    fingerprint = manifest_fingerprint(final)
+    invocation, sidecar = reserve(
+        args.evidence, fingerprint, args.environment, release_name, namespace
+    )
+    description = f"sugarkube-dspace-manifest-rollback:{invocation}"
+    mutated = False
+    try:
+        runner(
+            [
+                args.helm,
+                "upgrade",
+                release_name,
+                chart,
+                "--namespace",
+                namespace,
+                "--description",
+                description,
+                *value_args,
+                "--set",
+                f"image.tag={target['imageTag']}",
+            ]
+        )
+        mutated = True
+        runner(
+            [
+                args.kubectl,
+                "-n",
+                namespace,
+                "rollout",
+                "status",
+                f"deployment/{release_name}",
+                f"--timeout={args.timeout}",
+            ]
+        )
+        after_raw = json_run(
+            runner, [args.helm, "status", release_name, "--namespace", namespace, "-o", "json"]
+        )
+        after_helm = helm_identity(after_raw, release_name, namespace)
+        if after_helm["status"] != "deployed" or after_helm["revision"] <= before_helm["revision"]:
+            raise RollbackError("Helm revision did not advance to a deployed release")
+        if (
+            after_helm["chartName"] != "dspace"
+            or after_helm["chartVersion"] != target["chartVersion"]
+        ):
+            raise RollbackError("installed chart identity/version does not match target")
+        settled_pods_json = release._settle_release_pods(pod_command, runner=runner)
+        workloads_json = json_run(runner, workload_command)
+        # Reuse the release-manifest workflow's strict Helm, Deployment/ReplicaSet,
+        # readiness, declared-image, image-ID, and OCI-result validation.
+        try:
+            release.finalize(
+                target,
+                after_raw,
+                settled_pods_json,
+                workloads_json,
+                oci,
+                environment=args.environment,
+                image_tag=target["imageTag"],
+                chart_version=target["chartVersion"],
+                release=release_name,
+                namespace=namespace,
+                cluster_environment=args.environment,
+                invocation_description=description,
+            )
+        except release.ManifestError as exc:
+            raise RollbackError(str(exc)) from exc
+        after_pods = pod_identities(settled_pods_json, target)
+        old = {(p["uid"], p["startTime"]) for p in before_pods}
+        new = {(p["uid"], p["startTime"]) for p in after_pods}
+        if old & new or new == old:
+            raise RollbackError(
+                "target artifact differed but serving pod replacement was not proven"
+            )
+        verifier = validate_verifier_result(
+            json_run(
+                runner,
+                [
+                    str(args.verifier),
+                    "verify",
+                    "--application-version",
+                    target["applicationVersion"],
+                    "--source-revision",
+                    target["sourceRevision"],
+                    "--provider",
+                    target["expectedDefaultChatProvider"],
+                ],
+            ),
+            target,
+        )
+        stable = helm_identity(
+            json_run(
+                runner, [args.helm, "status", release_name, "--namespace", namespace, "-o", "json"]
+            ),
+            release_name,
+            namespace,
+        )
+        if stable != after_helm:
+            raise RollbackError("Helm release changed concurrently during evidence collection")
+        finished = dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
+        evidence = {
+            "schemaVersion": SCHEMA_VERSION,
+            "operation": OPERATION,
+            "targetManifestFingerprint": fingerprint,
+            "environment": args.environment,
+            "release": release_name,
+            "namespace": namespace,
+            "invocationId": invocation,
+            "target": {
+                key: target[key]
+                for key in (
+                    "chartVersion",
+                    "chartDigest",
+                    "imageTag",
+                    "imageDigest",
+                    "sourceRevision",
+                    "applicationVersion",
+                    "expectedDefaultChatProvider",
+                )
+            },
+            "values": value_records,
+            "sugarkubeRevision": runner(["git", "-C", str(args.root), "rev-parse", "HEAD"]).strip(),
+            "before": {"helm": before_helm, "pods": before_pods},
+            "after": {"helm": after_helm, "pods": after_pods},
+            "verification": {
+                "oci": oci,
+                "clusterEnvironment": args.environment,
+                "runtime": verifier,
+            },
+            "startedAt": started.isoformat().replace("+00:00", "Z"),
+            "finishedAt": finished.isoformat().replace("+00:00", "Z"),
+        }
+        write_new(args.evidence.resolve(strict=False), evidence)
+        sidecar.unlink()
+        return evidence
+    except Exception as exc:
+        state = (
+            "cluster state may have changed; reservation preserved for reconciliation"
+            if mutated
+            else "reservation preserved for reconciliation"
+        )
+        raise RollbackError(f"rollback failed after evidence reservation; {state}: {exc}") from exc
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser()
+    result.add_argument("--environment", choices=("staging", "prod"), required=True)
+    result.add_argument("--manifest", type=Path, required=True)
+    result.add_argument("--evidence", type=Path, required=True)
+    result.add_argument("--verifier", type=Path, required=True)
+    result.add_argument("--confirm", default="")
+    result.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    result.add_argument("--python", default=sys.executable)
+    result.add_argument("--just", default="just")
+    result.add_argument("--helm", default="helm")
+    result.add_argument("--kubectl", default="kubectl")
+    result.add_argument("--oras", default="oras")
+    result.add_argument("--timeout", default="180s")
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        if not args.verifier.is_file() or not os.access(args.verifier, os.X_OK):
+            raise RollbackError("runtime-and-journey verifier is absent or not executable")
+        execute(args)
+    except RollbackError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -1,0 +1,206 @@
+"""Focused safety tests for the DSPACE manifest rollback operation."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from scripts import dspace_manifest_rollback as rollback
+from scripts import dspace_release_manifest as release
+
+SHA = "abcdef0123456789abcdef0123456789abcdef01"
+DIGEST = "sha256:" + "1" * 64
+CHART_DIGEST = "sha256:" + "2" * 64
+
+
+def final() -> dict[str, object]:
+    value: dict[str, object] = {
+        "schemaVersion": 1,
+        "app": "dspace",
+        "applicationVersion": "3.2.0",
+        "sourceRevision": SHA,
+        "imageTag": "main-abcdef0",
+        "imageDigest": DIGEST,
+        "chartVersion": "3.2.0",
+        "chartDigest": CHART_DIGEST,
+        "semanticTag": "v3.2.0",
+        "recordType": "final",
+        "environment": "staging",
+        "expectedDefaultChatProvider": "token-place",
+        "approvedAt": "2026-07-26T12:00:00Z",
+        "approvedBy": "operator",
+        "helmRevision": 4,
+        "pods": [
+            {
+                "name": "dspace-old",
+                "startTime": "2026-07-26T12:00:00Z",
+                "imageID": "ghcr.io/democratizedspace/dspace@" + DIGEST,
+            }
+        ],
+        "runtimeSourceRevision": SHA,
+        "runtimeSourceRevisionMethod": release.RUNTIME_METHOD,
+        "verificationResults": [],
+    }
+    checks = sorted(release.FINAL_FIXED_CHECKS) + ["imagePlatformSourceRevision[0]"]
+    value["verificationResults"] = [
+        {"check": check, "passed": True, "details": "verified"} for check in checks
+    ]
+    return release.validate(value, True)
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        lambda x: x.update(recordType="candidate"),
+        lambda x: x.update(imageTag="latest"),
+        lambda x: x.update(imageTag="v3.2.0"),
+        lambda x: x.update(imageTag="main-deadbee"),
+        lambda x: x.update(unknown=True),
+    ],
+)
+def test_target_requires_strict_finalized_evidence(change) -> None:
+    value = final()
+    change(value)
+    with pytest.raises(release.ManifestError):
+        rollback.target_candidate(value)
+
+
+def test_target_projection_preserves_immutable_coordinates() -> None:
+    target = rollback.target_candidate(final())
+    assert target["recordType"] == "candidate"
+    assert target["imageTag"] == "main-abcdef0"
+    assert target["chartDigest"] == CHART_DIGEST
+
+
+def test_values_chain_is_ordered_hashed_and_missing_fails(tmp_path: Path) -> None:
+    (tmp_path / "one.yaml").write_text("one: 1\n")
+    (tmp_path / "two.yaml").write_text("two: 2\n")
+    paths, evidence = rollback.values_evidence("one.yaml,two.yaml", tmp_path)
+    assert [path.name for path in paths] == ["one.yaml", "two.yaml"]
+    assert [item["path"] for item in evidence] == ["one.yaml", "two.yaml"]
+    assert all(len(item["sha256"]) == 64 for item in evidence)
+    with pytest.raises(rollback.RollbackError, match="not readable"):
+        rollback.values_evidence("one.yaml,missing.yaml", tmp_path)
+
+
+@pytest.mark.parametrize(
+    "change, message",
+    [
+        (lambda x: x["capabilities"].update(frontendSourceRevision=False), "every required"),
+        (lambda x: x.update(extra=True), "missing or unknown"),
+        (lambda x: x.update(schemaVersion=2), "incompatible"),
+    ],
+)
+def test_verifier_capabilities_fail_closed(change, message: str) -> None:
+    value = {
+        "schemaVersion": 1,
+        "capabilities": {name: True for name in rollback.VERIFY_CAPABILITIES},
+    }
+    change(value)
+    with pytest.raises(rollback.RollbackError, match=message):
+        rollback.validate_capabilities(value)
+
+
+def verifier_result() -> dict[str, object]:
+    return {
+        "schemaVersion": 1,
+        "applicationVersion": "3.2.0",
+        "runtimeSourceRevision": SHA,
+        "frontendSourceRevision": SHA,
+        "defaultProvider": "token-place",
+        "journeys": [{"name": "/healthz", "passed": True}, {"name": "/chat", "passed": True}],
+    }
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("runtimeSourceRevision", "0" * 40),
+        ("frontendSourceRevision", "0" * 40),
+        ("defaultProvider", "openai"),
+    ],
+)
+def test_verifier_rejects_identity_mismatch(field: str, value: str) -> None:
+    result = verifier_result()
+    result[field] = value
+    with pytest.raises(rollback.RollbackError, match=field):
+        rollback.validate_verifier_result(result, rollback.target_candidate(final()))
+
+
+def test_verifier_rejects_failed_or_missing_chat_journey() -> None:
+    result = verifier_result()
+    result["journeys"][1]["passed"] = False
+    with pytest.raises(rollback.RollbackError, match="journey failed"):
+        rollback.validate_verifier_result(result, rollback.target_candidate(final()))
+    result = verifier_result()
+    result["journeys"] = result["journeys"][:1]
+    with pytest.raises(rollback.RollbackError, match="/chat"):
+        rollback.validate_verifier_result(result, rollback.target_candidate(final()))
+
+
+def pod(uid: str = "new-uid", image_id: str = DIGEST, terminating: bool = False) -> dict:
+    metadata = {"name": "dspace-new", "uid": uid}
+    if terminating:
+        metadata["deletionTimestamp"] = "2026-07-27T00:00:00Z"
+    return {
+        "items": [
+            {
+                "metadata": metadata,
+                "spec": {
+                    "containers": [
+                        {"name": "dspace", "image": "ghcr.io/democratizedspace/dspace:main-abcdef0"}
+                    ]
+                },
+                "status": {
+                    "phase": "Running",
+                    "startTime": "2026-07-27T00:00:00Z",
+                    "conditions": [{"type": "Ready", "status": "True"}],
+                    "containerStatuses": [{"name": "dspace", "imageID": "repo@" + image_id}],
+                },
+            }
+        ]
+    }
+
+
+def test_post_pods_reject_lingering_and_image_id_mismatch() -> None:
+    target = rollback.target_candidate(final())
+    with pytest.raises(rollback.RollbackError, match="terminating"):
+        rollback.pod_identities(pod(terminating=True), target)
+    with pytest.raises(rollback.RollbackError, match="imageID"):
+        rollback.pod_identities(pod(image_id="sha256:" + "9" * 64), target)
+
+
+def test_reservation_collision_and_non_overwrite(tmp_path: Path) -> None:
+    output = tmp_path / "evidence.json"
+    _, sidecar = rollback.reserve(
+        output, rollback.manifest_fingerprint(final()), "staging", "dspace", "dspace"
+    )
+    assert sidecar.exists()
+    with pytest.raises(rollback.RollbackError, match="already reserved"):
+        rollback.reserve(
+            output, rollback.manifest_fingerprint(final()), "staging", "dspace", "dspace"
+        )
+
+
+def test_just_recipe_uses_upgrade_without_rollback_or_reuse_values() -> None:
+    source = (Path(__file__).parents[1] / "scripts/dspace_manifest_rollback.py").read_text()
+    assert '"upgrade",' in source
+    assert '"--reuse-values"' not in source
+    assert 'args.helm, "rollback"' not in source
+    justfile = (Path(__file__).parents[1] / "justfile").read_text()
+    assert "dspace-manifest-rollback env='staging'" in justfile
+
+
+def test_preflight_missing_manifest_creates_no_reservation_or_mutation(tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+    args = argparse.Namespace(
+        manifest=tmp_path / "missing.json",
+        environment="staging",
+        evidence=tmp_path / "evidence.json",
+    )
+    with pytest.raises(rollback.RollbackError, match="does not exist"):
+        rollback.execute(args, lambda command: calls.append(command) or "")
+    assert calls == []
+    assert not release.reservation_path(args.evidence).exists()


### PR DESCRIPTION
### Motivation

- Replace the fragile Helm-revision rollback path for DSPACE with a manifest-driven, fail-closed recovery operation that strictly replays an approved finalized release-evidence record and proves what actually became active. Refs #2327. 
- Prevent operators from supplying independent image-tag or chart-version overrides and ensure every preflight and verification step happens before any Helm/Kubernetes mutation. 

### Description

- Add a new rollback implementation `scripts/dspace_manifest_rollback.py` that: strictly validates a finalized DSPACE evidence record (reusing `dspace_release_manifest` validation), re-runs OCI preflight, resolves and hashes the ordered values chain, asserts cluster identity, captures current Helm/pod/workload state, atomically reserves an evidence destination, drives a digest-qualified `helm upgrade` (no `--reuse-values`, no semantic tags, no `helm rollback`), waits for rollout, reuses `finalize` checks to prove ownership/readiness/image digests/OCI revision, invokes a strict executable verifier contract, and writes an immutable rollback evidence JSON record only on success. 
- Add a user-facing `just` shim `dspace-manifest-rollback` to the `justfile` that calls the script and enforces required inputs (`env`, `manifest`, `evidence`, `verifier`, plus exact production confirmation for `prod`). 
- Introduce a small, strictly validated JSON verifier contract (capabilities + verify result) and wire the rollback to call that executable rather than an arbitrary shell string. 
- Update docs to promote manifest-based rollback as the primary DSPACE recovery path and document staging/production examples, confirmation semantics, reservation/finalization, and the remaining verifier dependency; add recovery notes to `docs/apps/dspace.md` and `docs/app_deployment_contract.md`. 
- Add focused tests in `tests/test_manifest_rollback.py` covering finalized-manifest strictness, mutable/semantic-tag rejection, values-chain hashing and missing-file failures, verifier capability/result validation, preflight non-mutation behavior, reservation collisions, Pod identity checks, and that the code uses `helm upgrade` (not `helm rollback`) and avoids `--reuse-values`. 

### Testing

- Ran the requested pytest matrix: `python3 -m pytest -q tests/test_release_manifest.py tests/test_generic_app_just_recipes.py tests/test_manifest_rollback.py` and `python3 -m pytest -q tests/test_manifest_rollback.py`; all tests in those suites passed (285 passed total; the new manifest rollback tests passed). 
- Code style and hygiene checks executed: `python3 -m flake8 scripts/dspace_manifest_rollback.py tests/test_manifest_rollback.py`, `python3 -m black --check scripts/dspace_manifest_rollback.py tests/test_manifest_rollback.py`, and `just --unstable --fmt --check` all passed for the changed files; `git diff --check` and `git diff --cached | python3 scripts/scan-secrets.py` were run with no new issues introduced by this patch. 
- Docs/tooling checks: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` completed (linkcheck reported no errors); `pre-commit run --all-files` and the repository-wide `scripts/checks.sh` were invoked and reported existing, unrelated repository-wide lint/YAML/flake8 items outside the focused changes (these are pre-existing and were not introduced by this PR). 

Notes and residual risk: production rollback remains fail-closed pending a verifier that satisfies DSPACE #4732 and #4733; the rollback command deliberately refuses to proceed without the executable verifier or without an exact production confirmation value. Evidence reservations are preserved on failure to enable safe manual reconciliation; the command never logs values content or verifier response bodies to avoid leaking secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66a4f56718832f90af2b33e4384345)