### PR TITLE
Add fail-closed DSPACE manifest-based rollback (`dspace-manifest-rollback`)

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -38,6 +38,10 @@ preflight precedes the unique evidence reservation and digest-qualified
 the strict runtime/frontend/provider/public-journey verifier described in the
 [DSPACE runbook](apps/dspace.md#rollback). `helm history` remains investigative,
 and `helm rollback <revision>` is not the default DSPACE recovery operation.
+PR #2350 final evidence has no historical values coordinates, so this operation
+byte-binds the selected environment's complete current values chain for render
+and upgrade. It restores manifest-approved artifacts with current configuration;
+historical-configuration replay is outside this recovery exception.
 
 Future onboarding examples such as wove should only get Sugarkube app configs
 after their app repositories have published compatible images and charts.

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -27,6 +27,18 @@ Sugarkube owns cluster and environment orchestration:
 - applying the environment values chain; and
 - running status and verification checks against the cluster.
 
+### DSPACE recovery exception
+
+DSPACE staging and production recovery uses `just dspace-manifest-rollback`,
+not the generic Tokenplace revision helper. It accepts a finalized DSPACE
+release-evidence record and derives every chart, image, source, application, and
+provider coordinate from that immutable approval. Its complete read-only
+preflight precedes the unique evidence reservation and digest-qualified
+`helm upgrade`; post-deployment proof requires stable Helm and pod identity plus
+the strict runtime/frontend/provider/public-journey verifier described in the
+[DSPACE runbook](apps/dspace.md#rollback). `helm history` remains investigative,
+and `helm rollback <revision>` is not the default DSPACE recovery operation.
+
 Future onboarding examples such as wove should only get Sugarkube app configs
 after their app repositories have published compatible images and charts.
 jobbot3000 now follows this contract through the generic app config and runbook.

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -358,13 +358,21 @@ just dspace-manifest-rollback \
 
 Before reserving evidence or changing Helm/Kubernetes state, the command checks
 cluster identity, validates the strict final manifest and fresh OCI provenance,
-loads and hashes every ordered values file, requires those hashes and paths to
-match the values chain recorded in the finalized target evidence, renders the
-digest-qualified chart,
+resolves the selected environment's complete current values chain, reads each
+file once, records its repository-relative path and SHA-256, and stages those
+exact bytes in a restricted temporary directory for both rendering and upgrade.
+Finalized records created by PR #2350 do not contain historical values
+coordinates. Consequently, rollback restores manifest-approved chart and image
+artifacts using the selected environment's current byte-bound values chain;
+historical-configuration replay is deliberately deferred. The command renders
+the digest-qualified chart,
 checks verifier capabilities, and captures current Helm and pod identity. It
 prints only non-secret current-versus-target coordinates; a current chart digest
-is reported as unknown because Helm status cannot prove it. Exact no-ops and all
-preflight or confirmation failures stop before mutation.
+is reported as unknown because Helm status cannot prove it. It rejects an exact
+no-op only when `helm get manifest` and the named `dspace` container identity
+prove equivalence to the digest-bound target render; matching version and image
+metadata alone still proceeds. All preflight or confirmation failures stop
+before mutation.
 
 After atomically reserving the unique evidence destination, the operation uses
 `helm upgrade` with the approved chart digest, complete values chain, and an
@@ -378,10 +386,12 @@ and the strict runtime/frontend/provider/public-journey result (including
 values-file hashes; it does not alter the target release record.
 
 The verifier is an executable, not a shell fragment. It must support
-`capabilities` and return schema version 1 with the exact ordered capabilities
+`capabilities` and echo the selected environment, release, and namespace with
+schema version 1 and the exact ordered capabilities
 `applicationVersion`, `runtimeSourceRevision`, `frontendSourceRevision`,
 `defaultProvider`, and `publicJourneys`. Its `verify` result must contain exactly
-those identity strings plus a non-empty list of `{name, passed}` journey objects,
+those target coordinates and identity strings plus a non-empty list of
+`{name, passed}` journey objects,
 including a passing `/chat`. Verifier output and response bodies are not echoed.
 Do not infer frontend identity from the semantic application version.
 

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -328,38 +328,73 @@ curl -fsS https://democratized.space/livez
 
 ## Rollback
 
-Rollback by deploying the previous known-good immutable image tag with the generic redeploy command and an approved environment-specific candidate for that release. Use a unique `evidence=` path if evidence for the tag already exists; occupied paths are rejected before Helm runs.
-Do not infer or generate a rollback manifest automatically; that future
-automation is tracked in #2327.
+Use the DSPACE-only manifest rollback command with a **previously finalized**
+release-evidence record. The historical record supplies the chart digest,
+chart version, immutable branch-SHA image tag, image digest, full source SHA,
+application version, and approved provider. There are deliberately no separate
+tag or chart-version arguments.
 
 ```bash
-APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA
-STAGING_ROLLBACK_MANIFEST=deployment-candidates/dspace/previous-release-staging.json
-PROD_ROLLBACK_MANIFEST=deployment-candidates/dspace/previous-release-prod.json
+just dspace-manifest-rollback \
+  env=staging \
+  manifest=deployment-evidence/dspace/staging/previous-finalized-release.json \
+  evidence=deployment-evidence/dspace/staging/rollback-20260727T120000Z.json \
+  verifier=/opt/dspace/bin/sugarkube-runtime-verifier
 ```
+
+Production additionally requires a non-interactive confirmation bound to
+DSPACE, `prod`, and the target record's full source revision. A generic `yes`
+is rejected:
 
 ```bash
-just app-redeploy app=dspace env=staging tag="$APP_TAG" manifest="$STAGING_ROLLBACK_MANIFEST" evidence=deployment-evidence/dspace/staging/"$APP_TAG"-rollback.json
+TARGET_SHA=REPLACE_WITH_THE_40_CHARACTER_TARGET_SOURCE_SHA
+just dspace-manifest-rollback \
+  env=prod \
+  manifest=deployment-evidence/dspace/prod/previous-finalized-release.json \
+  evidence=deployment-evidence/dspace/prod/rollback-20260727T120000Z.json \
+  verifier=/opt/dspace/bin/sugarkube-runtime-verifier \
+  confirm="dspace:prod:${TARGET_SHA}"
 ```
 
-```bash
-just app-redeploy app=dspace env=prod tag="$APP_TAG" manifest="$PROD_ROLLBACK_MANIFEST" evidence=deployment-evidence/dspace/prod/"$APP_TAG"-rollback.json
-```
+Before reserving evidence or changing Helm/Kubernetes state, the command checks
+cluster identity, validates the strict final manifest and fresh OCI provenance,
+loads and hashes every ordered values file, renders the digest-qualified chart,
+checks verifier capabilities, and captures current Helm and pod identity. It
+prints only non-secret current-versus-target coordinates; a current chart digest
+is reported as unknown because Helm status cannot prove it. Exact no-ops and all
+preflight or confirmation failures stop before mutation.
 
-Rollback by Helm revision is still available through the existing parameterized helper. Set `ROLLBACK_ENV=staging` instead when intentionally rolling back staging.
+After atomically reserving the unique evidence destination, the operation uses
+`helm upgrade` with the approved chart digest, complete values chain, and
+immutable image tag. It never uses `--reuse-values`, a semantic tag, or
+`helm rollback <revision>`. It then proves the advanced stable Helm revision,
+chart identity, Deployment/ReplicaSet ownership, replacement pod UIDs and start
+times, readiness, image coordinates and resolved digests, OCI source metadata,
+and the strict runtime/frontend/provider/public-journey result (including
+`/chat`). The successful non-overwritable record contains those proofs and
+values-file hashes; it does not alter the target release record.
 
-```bash
-HELM_REVISION=12
-```
+The verifier is an executable, not a shell fragment. It must support
+`capabilities` and return schema version 1 with the exact ordered capabilities
+`applicationVersion`, `runtimeSourceRevision`, `frontendSourceRevision`,
+`defaultProvider`, and `publicJourneys`. Its `verify` result must contain exactly
+those identity strings plus a non-empty list of `{name, passed}` journey objects,
+including a passing `/chat`. Verifier output and response bodies are not echoed.
+Do not infer frontend identity from the semantic application version.
 
-```bash
-ROLLBACK_ENV=prod
-just kubeconfig-env "$ROLLBACK_ENV"
-```
+Real production rollback remains unavailable until DSPACE
+[#4732](https://github.com/democratizedspace/dspace/issues/4732) supplies runtime
+and frontend identity and [#4733](https://github.com/democratizedspace/dspace/issues/4733)
+supplies the remote public-journey verifier contract. Tests use a stub; operators
+must not substitute an availability-only check.
 
-```bash
-just tokenplace-rollback release=dspace namespace=dspace revision="$HELM_REVISION" env="$ROLLBACK_ENV"
-```
+If anything fails after reservation, the command exits nonzero, leaves a
+redacted failed evidence record, and warns that cluster state may have changed.
+Inspect `helm history dspace --namespace dspace` and the preserved invocation ID,
+then reconcile manually. Never immediately invoke a second rollback. Helm
+history remains useful for investigation, but a Helm revision rollback is not
+the default DSPACE recovery mechanism. The `tokenplace-rollback` helper is for
+Tokenplace and must not be invoked against DSPACE.
 
 ## Troubleshooting
 

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -358,15 +358,18 @@ just dspace-manifest-rollback \
 
 Before reserving evidence or changing Helm/Kubernetes state, the command checks
 cluster identity, validates the strict final manifest and fresh OCI provenance,
-loads and hashes every ordered values file, renders the digest-qualified chart,
+loads and hashes every ordered values file, requires those hashes and paths to
+match the values chain recorded in the finalized target evidence, renders the
+digest-qualified chart,
 checks verifier capabilities, and captures current Helm and pod identity. It
 prints only non-secret current-versus-target coordinates; a current chart digest
 is reported as unknown because Helm status cannot prove it. Exact no-ops and all
 preflight or confirmation failures stop before mutation.
 
 After atomically reserving the unique evidence destination, the operation uses
-`helm upgrade` with the approved chart digest, complete values chain, and
-immutable image tag. It never uses `--reuse-values`, a semantic tag, or
+`helm upgrade` with the approved chart digest, complete values chain, and an
+application image reference pinned by both its immutable tag and approved digest.
+It never uses `--reuse-values`, a semantic tag, or
 `helm rollback <revision>`. It then proves the advanced stable Helm revision,
 chart identity, Deployment/ReplicaSet ownership, replacement pod UIDs and start
 times, readiness, image coordinates and resolved digests, OCI source metadata,

--- a/justfile
+++ b/justfile
@@ -1710,8 +1710,7 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
         --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" \
         --chart-version "${chart_version}" --kubeconfig "${KUBECONFIG}" \
         --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
-        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}" \
-        --values "${SUGARKUBE_VALUES}"
+        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}"
     fi
 
 # Generic upgrade-only app redeploy backed by app config files.
@@ -1772,8 +1771,7 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize --manifest "${release_manifest}" --output "${evidence_output}" \
         --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" --kubeconfig "${KUBECONFIG}" \
         --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
-        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}" \
-        --values "${SUGARKUBE_VALUES}"
+        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}"
     fi
 
 # Promote an app to prod with an explicit immutable tag, or the configured prod tag file.

--- a/justfile
+++ b/justfile
@@ -1710,7 +1710,8 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
         --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" \
         --chart-version "${chart_version}" --kubeconfig "${KUBECONFIG}" \
         --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
-        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}"
+        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}" \
+        --values "${SUGARKUBE_VALUES}"
     fi
 
 # Generic upgrade-only app redeploy backed by app config files.
@@ -1771,7 +1772,8 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize --manifest "${release_manifest}" --output "${evidence_output}" \
         --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" --kubeconfig "${KUBECONFIG}" \
         --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
-        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}"
+        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}" \
+        --values "${SUGARKUBE_VALUES}"
     fi
 
 # Promote an app to prod with an explicit immutable tag, or the configured prod tag file.

--- a/justfile
+++ b/justfile
@@ -1624,6 +1624,23 @@ app-config app env='staging' config='':
       --env {{ quote(env) }} \
       --config {{ quote(config) }}
 
+# DSPACE-only fail-closed recovery from previously finalized immutable evidence.
+dspace-manifest-rollback env manifest evidence verifier confirm='' config='' kubeconfig='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    kubeconfig_path={{ quote(kubeconfig) }}
+    if [ -z "${kubeconfig_path}" ]; then
+      kubeconfig_path="${KUBECONFIG:-${HOME}/.kube/config}"
+    fi
+    python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py" \
+      --environment {{ quote(env) }} \
+      --manifest {{ quote(manifest) }} \
+      --evidence {{ quote(evidence) }} \
+      --verifier {{ quote(verifier) }} \
+      --confirm {{ quote(confirm) }} \
+      --config {{ quote(config) }} \
+      --kubeconfig "${kubeconfig_path}"
+
 # Generic immutable-tag app deploy backed by docs/examples/apps/*.env or local app configs.
 app-deploy app env='staging' tag='' config='' manifest='' evidence='':
     #!/usr/bin/env bash

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -56,9 +56,8 @@ Runner = Callable[[list[str]], str]
 def run(command: list[str]) -> str:
     completed = subprocess.run(command, check=False, capture_output=True, text=True)
     if completed.returncode:
-        # Verifier output is deliberately never reflected: it may contain credentials.
-        detail = "" if command and Path(command[0]).name not in {"verify", "verifier"} else ""
-        raise RollbackError(f"command failed: {command[0]}{detail}")
+        # Command output is deliberately never reflected: verifier output may contain credentials.
+        raise RollbackError(f"command failed: {command[0]}")
     return completed.stdout
 
 
@@ -188,13 +187,15 @@ def cluster_environment(runner: Runner, kubeconfig: str) -> str:
         ["kubectl", "--kubeconfig", kubeconfig, "get", "nodes", "-o", "json"],
         "cluster nodes",
     )
+    items = nodes.get("items", [])
+    if not isinstance(items, list) or not items:
+        raise RollbackError("cluster nodes do not prove one Sugarkube environment")
     labels = {
         item.get("metadata", {}).get("labels", {}).get("sugarkube.env")
-        for item in nodes.get("items", [])
+        for item in items
         if isinstance(item, dict)
     }
-    labels.discard(None)
-    if len(labels) != 1:
+    if len(labels) != 1 or None in labels:
         raise RollbackError("cluster nodes do not prove one Sugarkube environment")
     return labels.pop()
 
@@ -225,9 +226,15 @@ def pods(
         metadata = item.get("metadata", {})
         status = item.get("status", {})
         declared = {
-            c.get("name"): c.get("image") for c in item.get("spec", {}).get("containers", [])
+            c.get("name"): c.get("image")
+            for c in item.get("spec", {}).get("containers", [])
+            if c.get("name") == "dspace"
         }
-        resolved = {c.get("name"): c.get("imageID") for c in status.get("containerStatuses", [])}
+        resolved = {
+            c.get("name"): c.get("imageID")
+            for c in status.get("containerStatuses", [])
+            if c.get("name") == "dspace"
+        }
         result.append(
             {
                 "name": metadata.get("name"),
@@ -334,10 +341,13 @@ def verify_post_pods(
     for pod in after:
         if not pod["images"] or any(image != expected_image for image in pod["images"].values()):
             raise RollbackError("DSPACE container image coordinate does not match target")
-        if not pod["imageIDs"] or any(
-            release._image_id_digest(image_id or "") != target["imageDigest"]
-            for image_id in pod["imageIDs"].values()
-        ):
+        try:
+            resolved = {
+                release._image_id_digest(image_id or "") for image_id in pod["imageIDs"].values()
+            }
+        except release.ManifestError as exc:
+            raise RollbackError("DSPACE resolved image ID is invalid") from exc
+        if resolved != {target["imageDigest"]}:
             raise RollbackError("DSPACE resolved image ID does not match target digest")
 
 
@@ -362,6 +372,8 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
     if config["SUGARKUBE_RELEASE"] != "dspace" or config["SUGARKUBE_NAMESPACE"] != "dspace":
         raise RollbackError("DSPACE release and namespace must both be dspace")
     values, values_proof = values_evidence(config, root)
+    if values_proof != target["values"]:
+        raise RollbackError("configured values chain does not match finalized target evidence")
     environment = cluster_environment(runner, args.kubeconfig)
     if environment != args.environment:
         raise RollbackError("connected cluster environment does not match selected environment")
@@ -383,6 +395,8 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
             f"image.repository={release.IMAGE_REF}",
             "--set-string",
             f"image.tag={target['imageTag']}",
+            "--set-string",
+            f"image.digest={target['imageDigest']}",
         ]
     )
     before_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
@@ -401,19 +415,17 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
     )
     print(summary(before_helm, before_pods, target))
     current_images = {image for pod in before_pods for image in pod["images"].values()}
-    current_ids = {
-        release._image_id_digest(image_id)
-        for pod in before_pods
-        for image_id in pod["imageIDs"].values()
-        if image_id
-    }
-    exact_noop = (
-        chart_version(before_helm) == target["chartVersion"]
-        and current_images == {f"{release.IMAGE_REF}:{target['imageTag']}"}
-        and current_ids == {target["imageDigest"]}
-    )
-    if exact_noop:
-        raise RollbackError("refusing exact no-op rollback")
+    try:
+        current_ids = {
+            release._image_id_digest(image_id)
+            for pod in before_pods
+            for image_id in pod["imageIDs"].values()
+            if image_id
+        }
+    except release.ManifestError as exc:
+        raise RollbackError("current DSPACE image ID is invalid") from exc
+    # Helm status cannot prove the installed OCI chart digest, so matching mutable
+    # metadata is insufficient to reject this recovery as an exact no-op.
     confirmation(args.environment, args.confirm, target)
 
     invocation = uuid.uuid4().hex
@@ -469,6 +481,8 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
             f"image.repository={release.IMAGE_REF}",
             "--set-string",
             f"image.tag={target['imageTag']}",
+            "--set-string",
+            f"image.digest={target['imageDigest']}",
             "--wait",
             "--timeout",
             args.timeout,
@@ -568,6 +582,7 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
             namespace="dspace",
             cluster_environment=args.environment,
             invocation_description=description,
+            values=target["values"],
         )
         verifier_command = [
             str(args.verifier),

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -566,6 +566,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         "release": "dspace",
         "namespace": "dspace",
         "startedAt": started,
+        "sugarkubeRevision": sugarkube_revision,
         "target": {
             key: target[key]
             for key in (
@@ -589,10 +590,11 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     }
     reserve(args.evidence, evidence)
     mutated = False
+    failed_stage = "pre-mutation-revalidation"
+    description = f"sugarkube-dspace-manifest-rollback:{invocation}"
     try:
         if runner(["git", "rev-parse", "HEAD"]).strip() != sugarkube_revision:
             raise RollbackError("Sugarkube revision changed before mutation")
-        description = f"sugarkube-dspace-manifest-rollback:{invocation}"
         command = [
             "helm",
             "--kubeconfig",
@@ -613,8 +615,12 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             "--timeout",
             args.timeout,
         ]
+        failed_stage = "helm-upgrade"
+        # From this point onward Helm may have accepted or partially applied the
+        # request even when the command reports failure.
         mutated = True
         runner(command)
+        failed_stage = "rollout-wait"
         runner(
             [
                 "kubectl",
@@ -629,6 +635,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 args.timeout,
             ]
         )
+        failed_stage = "pod-settling-and-proof"
         deadline = time.monotonic() + POD_TIMEOUT
         while True:
             after_pods = pods(runner, args.kubeconfig, "dspace", "dspace")
@@ -662,6 +669,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         )
         verify_post_pods(after_pods, before_pods, target, changed)
         # Reuse finalization's strict Deployment/ReplicaSet ownership validator.
+        failed_stage = "ownership-and-finalization-proof"
         workloads = json_command(
             runner,
             [
@@ -729,9 +737,11 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             "--provider",
             target["expectedDefaultChatProvider"],
         ]
+        failed_stage = "runtime-verification"
         verifier = validate_verifier_result(
             json_command(runner, verifier_command, "runtime verifier"), target, args.environment
         )
+        failed_stage = "revision-stability-collection"
         stable = helm_status(runner, args.kubeconfig, "dspace", "dspace")
         if revision(stable) != after_revision:
             raise RollbackError("Helm revision changed concurrently during evidence collection")
@@ -768,28 +778,31 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         diagnostics: dict[str, Any] = {}
         try:
             observed_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
+            observed_info = observed_helm.get("info", {})
+            observed_chart = observed_helm.get("chart", {}).get("metadata", {})
             diagnostics["helm"] = {
+                "release": observed_helm.get("name"),
+                "namespace": observed_helm.get("namespace"),
                 "revision": revision(observed_helm),
-                "status": observed_helm.get("info", {}).get("status"),
+                "status": observed_info.get("status"),
+                "chartName": observed_chart.get("name"),
+                "chartVersion": chart_version(observed_helm),
+                "invocationDescriptionMatches": observed_info.get("description")
+                == description,
             }
         except Exception:
             diagnostics["helm"] = "unavailable"
         try:
-            observed_pods = pods(runner, args.kubeconfig, "dspace", "dspace", require_any=False)
-            diagnostics["pods"] = [
-                {
-                    "name": item["name"],
-                    "phase": item["phase"],
-                    "ready": item["ready"],
-                    "terminating": item["terminating"],
-                }
-                for item in observed_pods
-            ]
+            diagnostics["pods"] = pods(
+                runner, args.kubeconfig, "dspace", "dspace", require_any=False
+            )
         except Exception:
             diagnostics["pods"] = "unavailable"
         evidence.update(
             state="failed",
-            failedStage="mutation-or-verification",
+            failedStage=failed_stage,
+            failureCode=f"{failed_stage}-failed",
+            failureType=("rollback" if isinstance(exc, RollbackError) else "dependency"),
             failedAt=timestamp(),
             clusterMayHaveChanged=mutated,
             diagnostics=diagnostics,

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -1,0 +1,648 @@
+#!/usr/bin/env python3
+"""Restore DSPACE from finalized immutable evidence and prove the result."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Callable
+
+# Support the documented direct-script invocation from any working directory.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import app_config  # noqa: E402
+from scripts import dspace_release_manifest as release  # noqa: E402
+
+SCHEMA_VERSION = 1
+OPERATION = "dspaceManifestRollback"
+REQUIRED_CAPABILITIES = (
+    "applicationVersion",
+    "runtimeSourceRevision",
+    "frontendSourceRevision",
+    "defaultProvider",
+    "publicJourneys",
+)
+VERIFIER_FIELDS = (
+    "schemaVersion",
+    "applicationVersion",
+    "runtimeSourceRevision",
+    "frontendSourceRevision",
+    "defaultProvider",
+    "journeys",
+)
+POD_TIMEOUT = 60.0
+POLL_INTERVAL = 2.0
+
+
+class RollbackError(ValueError):
+    """The rollback cannot safely proceed or could not be proved."""
+
+
+Runner = Callable[[list[str]], str]
+
+
+def run(command: list[str]) -> str:
+    completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    if completed.returncode:
+        # Verifier output is deliberately never reflected: it may contain credentials.
+        detail = "" if command and Path(command[0]).name not in {"verify", "verifier"} else ""
+        raise RollbackError(f"command failed: {command[0]}{detail}")
+    return completed.stdout
+
+
+def json_command(runner: Runner, command: list[str], label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(runner(command))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise RollbackError(f"{label} did not return valid JSON") from exc
+    if not isinstance(value, dict):
+        raise RollbackError(f"{label} must return a JSON object")
+    return value
+
+
+def exact_fields(value: dict[str, Any], fields: tuple[str, ...], label: str) -> None:
+    missing = sorted(set(fields) - value.keys())
+    unknown = sorted(value.keys() - set(fields))
+    if missing or unknown:
+        raise RollbackError(
+            f"{label} schema mismatch (missing={','.join(missing) or '-'}; "
+            f"unknown={','.join(unknown) or '-'})"
+        )
+
+
+def verifier_capabilities(executable: Path, runner: Runner = run) -> dict[str, Any]:
+    if not executable.is_file() or not os.access(executable, os.X_OK):
+        raise RollbackError("runtime verifier must be an existing executable file")
+    value = json_command(runner, [str(executable), "capabilities"], "runtime verifier")
+    exact_fields(value, ("schemaVersion", "capabilities"), "runtime verifier capabilities")
+    capabilities = value["capabilities"]
+    if value["schemaVersion"] != 1 or capabilities != list(REQUIRED_CAPABILITIES):
+        raise RollbackError("runtime verifier has an incompatible capability contract")
+    return value
+
+
+def validate_verifier_result(value: dict[str, Any], target: dict[str, Any]) -> dict[str, Any]:
+    """Validate reusable runtime/frontend/provider/journey proof from DSPACE tooling."""
+    exact_fields(value, VERIFIER_FIELDS, "runtime verifier result")
+    if value["schemaVersion"] != 1:
+        raise RollbackError("runtime verifier result schemaVersion must be 1")
+    expected = {
+        "applicationVersion": target["applicationVersion"],
+        "runtimeSourceRevision": target["sourceRevision"],
+        "frontendSourceRevision": target["sourceRevision"],
+        "defaultProvider": target["expectedDefaultChatProvider"],
+    }
+    for field, wanted in expected.items():
+        if not isinstance(value[field], str) or value[field] != wanted:
+            raise RollbackError(f"runtime verifier {field} mismatch")
+    journeys = value["journeys"]
+    if not isinstance(journeys, list) or not journeys:
+        raise RollbackError("runtime verifier must report public journeys")
+    names: set[str] = set()
+    for journey in journeys:
+        if not isinstance(journey, dict):
+            raise RollbackError("runtime verifier journeys must be objects")
+        exact_fields(journey, ("name", "passed"), "runtime verifier journey")
+        if (
+            not isinstance(journey["name"], str)
+            or not re.fullmatch(r"/[A-Za-z0-9._~!$&'()*+,;=:@%/-]*", journey["name"])
+            or not isinstance(journey["passed"], bool)
+            or journey["name"] in names
+        ):
+            raise RollbackError("runtime verifier journey has invalid fields")
+        names.add(journey["name"])
+        if not journey["passed"]:
+            raise RollbackError("runtime verifier reported a failed public journey")
+    if "/chat" not in names:
+        raise RollbackError("runtime verifier did not prove the required /chat journey")
+    return value
+
+
+def timestamp() -> str:
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def portable(path: Path, root: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return resolved.as_posix()
+
+
+def values_evidence(config: dict[str, str], root: Path) -> tuple[list[Path], list[dict[str, str]]]:
+    paths: list[Path] = []
+    evidence: list[dict[str, str]] = []
+    for raw in config["SUGARKUBE_VALUES"].split(","):
+        path = Path(raw.strip())
+        path = path if path.is_absolute() else root / path
+        if not path.is_file() or not os.access(path, os.R_OK):
+            raise RollbackError(f"values file is missing or unreadable: {raw.strip()}")
+        paths.append(path)
+        evidence.append(
+            {
+                "path": portable(path, root),
+                "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            }
+        )
+    if not paths:
+        raise RollbackError("DSPACE values chain is empty")
+    return paths, evidence
+
+
+def helm_status(
+    runner: Runner, kubeconfig: str, release_name: str, namespace: str
+) -> dict[str, Any]:
+    return json_command(
+        runner,
+        [
+            "helm",
+            "--kubeconfig",
+            kubeconfig,
+            "status",
+            release_name,
+            "--namespace",
+            namespace,
+            "-o",
+            "json",
+        ],
+        "Helm status",
+    )
+
+
+def cluster_environment(runner: Runner, kubeconfig: str) -> str:
+    nodes = json_command(
+        runner,
+        ["kubectl", "--kubeconfig", kubeconfig, "get", "nodes", "-o", "json"],
+        "cluster nodes",
+    )
+    labels = {
+        item.get("metadata", {}).get("labels", {}).get("sugarkube.env")
+        for item in nodes.get("items", [])
+        if isinstance(item, dict)
+    }
+    labels.discard(None)
+    if len(labels) != 1:
+        raise RollbackError("cluster nodes do not prove one Sugarkube environment")
+    return labels.pop()
+
+
+def pods(
+    runner: Runner, kubeconfig: str, namespace: str, release_name: str
+) -> list[dict[str, Any]]:
+    selector = f"app.kubernetes.io/name=dspace,app.kubernetes.io/instance={release_name}"
+    value = json_command(
+        runner,
+        [
+            "kubectl",
+            "--kubeconfig",
+            kubeconfig,
+            "get",
+            "pods",
+            "--namespace",
+            namespace,
+            "-l",
+            selector,
+            "-o",
+            "json",
+        ],
+        "DSPACE pods",
+    )
+    result = []
+    for item in value.get("items", []):
+        metadata = item.get("metadata", {})
+        status = item.get("status", {})
+        declared = {
+            c.get("name"): c.get("image") for c in item.get("spec", {}).get("containers", [])
+        }
+        resolved = {c.get("name"): c.get("imageID") for c in status.get("containerStatuses", [])}
+        result.append(
+            {
+                "name": metadata.get("name"),
+                "uid": metadata.get("uid"),
+                "startTime": status.get("startTime"),
+                "phase": status.get("phase"),
+                "ready": any(
+                    c.get("type") == "Ready" and c.get("status") == "True"
+                    for c in status.get("conditions", [])
+                ),
+                "terminating": metadata.get("deletionTimestamp") is not None,
+                "images": declared,
+                "imageIDs": resolved,
+                "ownerReferences": metadata.get("ownerReferences", []),
+            }
+        )
+    if not result:
+        raise RollbackError("no release-owned DSPACE pods were found")
+    return sorted(result, key=lambda item: str(item["name"]))
+
+
+def chart_version(status: dict[str, Any]) -> str | None:
+    value = status.get("chart", {}).get("metadata", {}).get("version")
+    return value if isinstance(value, str) else None
+
+
+def revision(status: dict[str, Any]) -> int:
+    value = status.get("version")
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise RollbackError("Helm status lacks a valid revision")
+    return value
+
+
+def summary(
+    current: dict[str, Any], current_pods: list[dict[str, Any]], target: dict[str, Any]
+) -> str:
+    images = sorted({image for pod in current_pods for image in pod["images"].values() if image})
+    image_ids = sorted(
+        {image for pod in current_pods for image in pod["imageIDs"].values() if image}
+    )
+    lines = [
+        "DSPACE manifest rollback preflight:",
+        (
+            f"  current: helmRevision={revision(current)} "
+            f"chartVersion={chart_version(current) or 'unknown'} chartDigest=unknown"
+        ),
+        (
+            f"           images={','.join(images) or 'unknown'} "
+            f"imageIDs={','.join(image_ids) or 'unknown'}"
+        ),
+        (
+            f"  target:  sourceRevision={target['sourceRevision']} "
+            f"applicationVersion={target['applicationVersion']}"
+        ),
+        f"           chartVersion={target['chartVersion']} chartDigest={target['chartDigest']}",
+        f"           imageTag={target['imageTag']} imageDigest={target['imageDigest']}",
+    ]
+    return "\n".join(lines)
+
+
+def confirmation(environment: str, supplied: str, target: dict[str, Any]) -> None:
+    expected = f"dspace:prod:{target['sourceRevision']}"
+    if environment == "prod" and supplied != expected:
+        raise RollbackError(f"production confirmation must exactly equal {expected}")
+
+
+def reserve(path: Path, metadata: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        raise RollbackError(f"refusing to overwrite rollback evidence: {path}")
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError as exc:
+        raise RollbackError(f"rollback evidence destination is already reserved: {path}") from exc
+    with os.fdopen(fd, "w", encoding="utf-8") as stream:
+        stream.write(release._canonical(metadata))
+        stream.flush()
+        os.fsync(stream.fileno())
+    release._sync_directory(path.parent)
+
+
+def replace_reserved(path: Path, value: dict[str, Any]) -> None:
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    with os.fdopen(fd, "w", encoding="utf-8") as stream:
+        stream.write(release._canonical(value))
+        stream.flush()
+        os.fsync(stream.fileno())
+    os.replace(temporary, path)
+    release._sync_directory(path.parent)
+
+
+def verify_post_pods(
+    after: list[dict[str, Any]], before: list[dict[str, Any]], target: dict[str, Any], changed: bool
+) -> None:
+    if any(p["terminating"] for p in after):
+        raise RollbackError("terminating old DSPACE pods remain")
+    if any(p["phase"] != "Running" or not p["ready"] for p in after):
+        raise RollbackError("all DSPACE pods must be Running and Ready")
+    old = {(p["uid"], p["startTime"]) for p in before}
+    new = {(p["uid"], p["startTime"]) for p in after}
+    if changed and (old & new or old == new):
+        raise RollbackError("DSPACE pod replacement was not proved")
+    expected_image = f"{release.IMAGE_REF}:{target['imageTag']}"
+    for pod in after:
+        if not pod["images"] or any(image != expected_image for image in pod["images"].values()):
+            raise RollbackError("DSPACE container image coordinate does not match target")
+        if not pod["imageIDs"] or any(
+            release._image_id_digest(image_id or "") != target["imageDigest"]
+            for image_id in pod["imageIDs"].values()
+        ):
+            raise RollbackError("DSPACE resolved image ID does not match target digest")
+
+
+def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
+    started = timestamp()
+    try:
+        target = release.validate(release._object(args.manifest), True)
+    except release.ManifestError as exc:
+        raise RollbackError(f"target must be finalized DSPACE release evidence: {exc}") from exc
+    if target["environment"] != args.environment:
+        raise RollbackError("target manifest environment does not match selected environment")
+    # The manifest module's OCI and cluster proof functions deliberately accept
+    # candidate records. Project the exact candidate portion of the validated
+    # final record rather than reimplementing or weakening those validators.
+    approved = {field: target[field] for field in release.CANDIDATE_FIELDS}
+    approved["recordType"] = "candidate"
+    release.validate(approved, False)
+    root = REPO_ROOT
+    config = app_config.load_config("dspace", args.environment, args.config or None)
+    if config["SUGARKUBE_CHART"] != f"oci://{release.CHART_REF}":
+        raise RollbackError("DSPACE config chart repository is not canonical")
+    if config["SUGARKUBE_RELEASE"] != "dspace" or config["SUGARKUBE_NAMESPACE"] != "dspace":
+        raise RollbackError("DSPACE release and namespace must both be dspace")
+    values, values_proof = values_evidence(config, root)
+    environment = cluster_environment(runner, args.kubeconfig)
+    if environment != args.environment:
+        raise RollbackError("connected cluster environment does not match selected environment")
+    capabilities = verifier_capabilities(args.verifier, runner)
+    coordinate = release.chart_coordinate(approved)
+    helm_values = [part for path in values for part in ("--values", str(path))]
+    runner(
+        [
+            "helm",
+            "--kubeconfig",
+            args.kubeconfig,
+            "template",
+            "dspace",
+            coordinate,
+            "--namespace",
+            "dspace",
+            *helm_values,
+            "--set-string",
+            f"image.repository={release.IMAGE_REF}",
+            "--set-string",
+            f"image.tag={target['imageTag']}",
+        ]
+    )
+    before_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
+    before_pods = pods(runner, args.kubeconfig, "dspace", "dspace")
+    # Keep the registry proof fresh: no tag resolution occurs between this
+    # exact-digest check and confirmation/reservation/mutation.
+    oci = release.preflight(
+        approved,
+        release.IMAGE_REF,
+        release.CHART_REF,
+        args.oras,
+        environment=args.environment,
+        image_tag=target["imageTag"],
+        chart_version=target["chartVersion"],
+        runner=runner,
+    )
+    print(summary(before_helm, before_pods, target))
+    current_images = {image for pod in before_pods for image in pod["images"].values()}
+    current_ids = {
+        release._image_id_digest(image_id)
+        for pod in before_pods
+        for image_id in pod["imageIDs"].values()
+        if image_id
+    }
+    exact_noop = (
+        chart_version(before_helm) == target["chartVersion"]
+        and current_images == {f"{release.IMAGE_REF}:{target['imageTag']}"}
+        and current_ids == {target["imageDigest"]}
+    )
+    if exact_noop:
+        raise RollbackError("refusing exact no-op rollback")
+    confirmation(args.environment, args.confirm, target)
+
+    invocation = uuid.uuid4().hex
+    target_fingerprint = hashlib.sha256(release._canonical(target).encode()).hexdigest()
+    evidence: dict[str, Any] = {
+        "schemaVersion": SCHEMA_VERSION,
+        "operation": OPERATION,
+        "state": "reserved",
+        "invocationId": invocation,
+        "targetManifestFingerprint": target_fingerprint,
+        "environment": args.environment,
+        "release": "dspace",
+        "namespace": "dspace",
+        "startedAt": started,
+        "target": {
+            key: target[key]
+            for key in (
+                "chartVersion",
+                "chartDigest",
+                "imageTag",
+                "imageDigest",
+                "sourceRevision",
+                "applicationVersion",
+                "expectedDefaultChatProvider",
+            )
+        },
+        "values": values_proof,
+        "before": {
+            "helmRevision": revision(before_helm),
+            "helmStatus": before_helm.get("info", {}).get("status"),
+            "chartVersion": chart_version(before_helm),
+            "pods": before_pods,
+        },
+        "ociPreflight": oci,
+    }
+    reserve(args.evidence, evidence)
+    mutated = False
+    try:
+        description = f"sugarkube-dspace-manifest-rollback:{invocation}"
+        command = [
+            "helm",
+            "--kubeconfig",
+            args.kubeconfig,
+            "upgrade",
+            "dspace",
+            coordinate,
+            "--namespace",
+            "dspace",
+            "--description",
+            description,
+            *helm_values,
+            "--set-string",
+            f"image.repository={release.IMAGE_REF}",
+            "--set-string",
+            f"image.tag={target['imageTag']}",
+            "--wait",
+            "--timeout",
+            args.timeout,
+        ]
+        mutated = True
+        runner(command)
+        runner(
+            [
+                "kubectl",
+                "--kubeconfig",
+                args.kubeconfig,
+                "rollout",
+                "status",
+                "deployment/dspace",
+                "--namespace",
+                "dspace",
+                "--timeout",
+                args.timeout,
+            ]
+        )
+        deadline = time.monotonic() + POD_TIMEOUT
+        while True:
+            after_pods = pods(runner, args.kubeconfig, "dspace", "dspace")
+            if not any(p["terminating"] for p in after_pods):
+                break
+            if time.monotonic() >= deadline:
+                raise RollbackError("timed out waiting for old terminating pods to disappear")
+            time.sleep(POLL_INTERVAL)
+        after_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
+        after_revision = revision(after_helm)
+        if (
+            after_helm.get("name") != "dspace"
+            or after_helm.get("namespace") != "dspace"
+            or after_helm.get("info", {}).get("status") != "deployed"
+        ):
+            raise RollbackError("Helm did not report the expected deployed release")
+        if after_helm.get("info", {}).get("description") != description:
+            raise RollbackError("Helm release description is not bound to this invocation")
+        if after_revision <= revision(before_helm):
+            raise RollbackError("Helm revision did not advance")
+        if (
+            after_helm.get("chart", {}).get("metadata", {}).get("name") != "dspace"
+            or chart_version(after_helm) != target["chartVersion"]
+        ):
+            raise RollbackError("installed chart name/version does not match target")
+        changed = (
+            chart_version(before_helm) != target["chartVersion"]
+            or current_ids != {target["imageDigest"]}
+            or current_images != {f"{release.IMAGE_REF}:{target['imageTag']}"}
+        )
+        verify_post_pods(after_pods, before_pods, target, changed)
+        # Reuse finalization's strict Deployment/ReplicaSet ownership validator.
+        workloads = json_command(
+            runner,
+            [
+                "kubectl",
+                "--kubeconfig",
+                args.kubeconfig,
+                "get",
+                "replicasets,deployments",
+                "--namespace",
+                "dspace",
+                "-l",
+                "app.kubernetes.io/name=dspace,app.kubernetes.io/instance=dspace",
+                "-o",
+                "json",
+            ],
+            "DSPACE workloads",
+        )
+        raw_pods = json_command(
+            runner,
+            [
+                "kubectl",
+                "--kubeconfig",
+                args.kubeconfig,
+                "get",
+                "pods",
+                "--namespace",
+                "dspace",
+                "-l",
+                "app.kubernetes.io/name=dspace,app.kubernetes.io/instance=dspace",
+                "-o",
+                "json",
+            ],
+            "DSPACE pods",
+        )
+        release.finalize(
+            approved,
+            after_helm,
+            raw_pods,
+            workloads,
+            oci,
+            environment=args.environment,
+            image_tag=target["imageTag"],
+            chart_version=target["chartVersion"],
+            release="dspace",
+            namespace="dspace",
+            cluster_environment=args.environment,
+            invocation_description=description,
+        )
+        verifier_command = [
+            str(args.verifier),
+            "verify",
+            "--environment",
+            args.environment,
+            "--application-version",
+            target["applicationVersion"],
+            "--source-revision",
+            target["sourceRevision"],
+            "--provider",
+            target["expectedDefaultChatProvider"],
+        ]
+        verifier = validate_verifier_result(
+            json_command(runner, verifier_command, "runtime verifier"), target
+        )
+        stable = helm_status(runner, args.kubeconfig, "dspace", "dspace")
+        if revision(stable) != after_revision:
+            raise RollbackError("Helm revision changed concurrently during evidence collection")
+        sugarkube_revision = runner(["git", "rev-parse", "HEAD"]).strip()
+        result = {
+            **evidence,
+            "state": "succeeded",
+            "completedAt": timestamp(),
+            "sugarkubeRevision": sugarkube_revision,
+            "helm": {
+                "beforeRevision": revision(before_helm),
+                "afterRevision": after_revision,
+                "status": "deployed",
+                "chartName": "dspace",
+                "chartVersion": chart_version(after_helm),
+            },
+            "pods": {"before": before_pods, "after": after_pods},
+            "verification": {
+                "oci": oci,
+                "clusterEnvironment": environment,
+                "verifierCapabilities": capabilities,
+                "runtime": verifier,
+            },
+        }
+        replace_reserved(args.evidence, result)
+        return result
+    except Exception as exc:
+        evidence.update(
+            state="failed",
+            failedAt=timestamp(),
+            clusterMayHaveChanged=mutated,
+            diagnostic={"type": type(exc).__name__, "message": str(exc)},
+        )
+        replace_reserved(args.evidence, evidence)
+        raise RollbackError(
+            "rollback failed; cluster state may have changed; reconcile with "
+            f"preserved evidence {args.evidence}"
+        ) from exc
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--environment", choices=("staging", "prod"), required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--verifier", type=Path, required=True)
+    parser.add_argument("--confirm", default="")
+    parser.add_argument("--config", default="")
+    parser.add_argument("--kubeconfig", default=str(Path.home() / ".kube" / "config-sugarkube"))
+    parser.add_argument("--oras", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
+    parser.add_argument("--timeout", default="10m")
+    args = parser.parse_args(argv)
+    try:
+        rollback(args)
+    except (RollbackError, app_config.AppConfigError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -498,16 +498,19 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     before_pods = pods(runner, args.kubeconfig, "dspace", "dspace", require_any=False)
     # Keep the registry proof fresh: no tag resolution occurs between this
     # exact-digest check and confirmation/reservation/mutation.
-    oci = release.preflight(
-        approved,
-        release.IMAGE_REF,
-        release.CHART_REF,
-        args.oras,
-        environment=args.environment,
-        image_tag=target["imageTag"],
-        chart_version=target["chartVersion"],
-        runner=runner,
-    )
+    try:
+        oci = release.preflight(
+            approved,
+            release.IMAGE_REF,
+            release.CHART_REF,
+            args.oras,
+            environment=args.environment,
+            image_tag=target["imageTag"],
+            chart_version=target["chartVersion"],
+            runner=runner,
+        )
+    except release.ManifestError as exc:
+        raise RollbackError("OCI preflight validation failed") from exc
     print(summary(before_helm, before_pods, target, values_proof))
     current_images = {application_image(pod) for pod in before_pods if application_image(pod)}
     current_ids: set[str] = set()

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -36,6 +36,9 @@ REQUIRED_CAPABILITIES = (
 )
 VERIFIER_FIELDS = (
     "schemaVersion",
+    "environment",
+    "release",
+    "namespace",
     "applicationVersion",
     "runtimeSourceRevision",
     "frontendSourceRevision",
@@ -81,23 +84,54 @@ def exact_fields(value: dict[str, Any], fields: tuple[str, ...], label: str) -> 
         )
 
 
-def verifier_capabilities(executable: Path, runner: Runner = run) -> dict[str, Any]:
+def verifier_capabilities(
+    executable: Path, environment: str, release_name: str, namespace: str, runner: Runner = run
+) -> dict[str, Any]:
     if not executable.is_file() or not os.access(executable, os.X_OK):
         raise RollbackError("runtime verifier must be an existing executable file")
-    value = json_command(runner, [str(executable), "capabilities"], "runtime verifier")
-    exact_fields(value, ("schemaVersion", "capabilities"), "runtime verifier capabilities")
+    value = json_command(
+        runner,
+        [
+            str(executable),
+            "capabilities",
+            "--environment",
+            environment,
+            "--release",
+            release_name,
+            "--namespace",
+            namespace,
+        ],
+        "runtime verifier",
+    )
+    exact_fields(
+        value,
+        ("schemaVersion", "environment", "release", "namespace", "capabilities"),
+        "runtime verifier capabilities",
+    )
     capabilities = value["capabilities"]
-    if value["schemaVersion"] != 1 or capabilities != list(REQUIRED_CAPABILITIES):
+    if (
+        type(value["schemaVersion"]) is not int
+        or value["schemaVersion"] != 1
+        or value["environment"] != environment
+        or value["release"] != release_name
+        or value["namespace"] != namespace
+        or capabilities != list(REQUIRED_CAPABILITIES)
+    ):
         raise RollbackError("runtime verifier has an incompatible capability contract")
     return value
 
 
-def validate_verifier_result(value: dict[str, Any], target: dict[str, Any]) -> dict[str, Any]:
+def validate_verifier_result(
+    value: dict[str, Any], target: dict[str, Any], environment: str
+) -> dict[str, Any]:
     """Validate reusable runtime/frontend/provider/journey proof from DSPACE tooling."""
     exact_fields(value, VERIFIER_FIELDS, "runtime verifier result")
-    if value["schemaVersion"] != 1:
+    if type(value["schemaVersion"]) is not int or value["schemaVersion"] != 1:
         raise RollbackError("runtime verifier result schemaVersion must be 1")
     expected = {
+        "environment": environment,
+        "release": "dspace",
+        "namespace": "dspace",
         "applicationVersion": target["applicationVersion"],
         "runtimeSourceRevision": target["sourceRevision"],
         "frontendSourceRevision": target["sourceRevision"],
@@ -137,11 +171,13 @@ def portable(path: Path, root: Path) -> str:
     resolved = path.resolve()
     try:
         return resolved.relative_to(root.resolve()).as_posix()
-    except ValueError:
-        return resolved.as_posix()
+    except ValueError as exc:
+        raise RollbackError("values files must be inside the Sugarkube repository") from exc
 
 
-def values_evidence(config: dict[str, str], root: Path) -> tuple[list[Path], list[dict[str, str]]]:
+def stage_values(
+    config: dict[str, str], root: Path, destination: Path
+) -> tuple[list[Path], list[dict[str, str]]]:
     paths: list[Path] = []
     evidence: list[dict[str, str]] = []
     for raw in config["SUGARKUBE_VALUES"].split(","):
@@ -149,12 +185,38 @@ def values_evidence(config: dict[str, str], root: Path) -> tuple[list[Path], lis
         path = path if path.is_absolute() else root / path
         if not path.is_file() or not os.access(path, os.R_OK):
             raise RollbackError(f"values file is missing or unreadable: {raw.strip()}")
-        paths.append(path)
+        content = path.read_bytes()
+        staged = destination / f"{len(paths):02d}.yaml"
+        fd = os.open(staged, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        paths.append(staged)
         evidence.append(
             {
                 "path": portable(path, root),
-                "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+                "sha256": hashlib.sha256(content).hexdigest(),
             }
+        )
+    if not paths:
+        raise RollbackError("DSPACE values chain is empty")
+    return paths, evidence
+
+
+def values_evidence(config: dict[str, str], root: Path) -> tuple[list[Path], list[dict[str, str]]]:
+    """Compatibility helper for callers that only need current values proof."""
+    paths: list[Path] = []
+    evidence: list[dict[str, str]] = []
+    for raw in config["SUGARKUBE_VALUES"].split(","):
+        path = Path(raw.strip()).expanduser()
+        path = path if path.is_absolute() else root / path
+        if not path.is_file() or not os.access(path, os.R_OK):
+            raise RollbackError(f"values file is missing or unreadable: {raw.strip()}")
+        content = path.read_bytes()
+        paths.append(path)
+        evidence.append(
+            {"path": portable(path, root), "sha256": hashlib.sha256(content).hexdigest()}
         )
     if not paths:
         raise RollbackError("DSPACE values chain is empty")
@@ -201,7 +263,12 @@ def cluster_environment(runner: Runner, kubeconfig: str) -> str:
 
 
 def pods(
-    runner: Runner, kubeconfig: str, namespace: str, release_name: str
+    runner: Runner,
+    kubeconfig: str,
+    namespace: str,
+    release_name: str,
+    *,
+    require_any: bool = True,
 ) -> list[dict[str, Any]]:
     selector = f"app.kubernetes.io/name=dspace,app.kubernetes.io/instance={release_name}"
     value = json_command(
@@ -228,12 +295,12 @@ def pods(
         declared = {
             c.get("name"): c.get("image")
             for c in item.get("spec", {}).get("containers", [])
-            if c.get("name") == "dspace"
+            if isinstance(c, dict)
         }
         resolved = {
             c.get("name"): c.get("imageID")
             for c in status.get("containerStatuses", [])
-            if c.get("name") == "dspace"
+            if isinstance(c, dict)
         }
         result.append(
             {
@@ -248,10 +315,12 @@ def pods(
                 "terminating": metadata.get("deletionTimestamp") is not None,
                 "images": declared,
                 "imageIDs": resolved,
+                "applicationImage": declared.get("dspace"),
+                "applicationImageID": resolved.get("dspace"),
                 "ownerReferences": metadata.get("ownerReferences", []),
             }
         )
-    if not result:
+    if require_any and not result:
         raise RollbackError("no release-owned DSPACE pods were found")
     return sorted(result, key=lambda item: str(item["name"]))
 
@@ -269,16 +338,23 @@ def revision(status: dict[str, Any]) -> int:
 
 
 def summary(
-    current: dict[str, Any], current_pods: list[dict[str, Any]], target: dict[str, Any]
+    current: dict[str, Any],
+    current_pods: list[dict[str, Any]],
+    target: dict[str, Any],
+    values: list[dict[str, str]],
 ) -> str:
-    images = sorted({image for pod in current_pods for image in pod["images"].values() if image})
+    images = sorted({application_image(pod) for pod in current_pods if application_image(pod)})
     image_ids = sorted(
-        {image for pod in current_pods for image in pod["imageIDs"].values() if image}
+        {application_image_id(pod) for pod in current_pods if application_image_id(pod)}
     )
+    info = current.get("info", {})
     lines = [
         "DSPACE manifest rollback preflight:",
         (
-            f"  current: helmRevision={revision(current)} "
+            "  current: release=dspace namespace=dspace "
+            f"helmStatus={info.get('status') or 'unknown'} "
+            f"helmRevision={revision(current)} chartName="
+            f"{current.get('chart', {}).get('metadata', {}).get('name') or 'unknown'} "
             f"chartVersion={chart_version(current) or 'unknown'} chartDigest=unknown"
         ),
         (
@@ -286,11 +362,17 @@ def summary(
             f"imageIDs={','.join(image_ids) or 'unknown'}"
         ),
         (
-            f"  target:  sourceRevision={target['sourceRevision']} "
+            f"  target:  release=dspace namespace=dspace sourceRevision={target['sourceRevision']} "
             f"applicationVersion={target['applicationVersion']}"
         ),
         f"           chartVersion={target['chartVersion']} chartDigest={target['chartDigest']}",
         f"           imageTag={target['imageTag']} imageDigest={target['imageDigest']}",
+        (
+            f"           imageCoordinate={release.IMAGE_REF}:"
+            f"{target['imageTag']}@{target['imageDigest']}"
+        ),
+        f"           provider={target['expectedDefaultChatProvider']}",
+        "  values:  " + ",".join(f"{item['path']}={item['sha256']}" for item in values),
     ]
     return "\n".join(lines)
 
@@ -337,22 +419,37 @@ def verify_post_pods(
     new = {(p["uid"], p["startTime"]) for p in after}
     if changed and (old & new or old == new):
         raise RollbackError("DSPACE pod replacement was not proved")
-    expected_image = f"{release.IMAGE_REF}:{target['imageTag']}"
+    expected_image = f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"
     for pod in after:
-        if not pod["images"] or any(image != expected_image for image in pod["images"].values()):
+        if application_image(pod) != expected_image:
             raise RollbackError("DSPACE container image coordinate does not match target")
         try:
-            resolved = {
-                release._image_id_digest(image_id or "") for image_id in pod["imageIDs"].values()
-            }
+            resolved = release._image_id_digest(application_image_id(pod) or "")
         except release.ManifestError as exc:
             raise RollbackError("DSPACE resolved image ID is invalid") from exc
-        if resolved != {target["imageDigest"]}:
+        if resolved != target["imageDigest"]:
             raise RollbackError("DSPACE resolved image ID does not match target digest")
 
 
+def application_image(pod: dict[str, Any]) -> str | None:
+    return pod.get("applicationImage", pod.get("images", {}).get("dspace"))
+
+
+def application_image_id(pod: dict[str, Any]) -> str | None:
+    return pod.get("applicationImageID", pod.get("imageIDs", {}).get("dspace"))
+
+
 def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="dspace-rollback-values-") as temporary:
+        os.chmod(temporary, 0o700)
+        return _rollback(args, runner, Path(temporary))
+
+
+def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) -> dict[str, Any]:
     started = timestamp()
+    args.manifest = args.manifest.expanduser()
+    args.evidence = args.evidence.expanduser()
+    args.verifier = args.verifier.expanduser()
     try:
         target = release.validate(release._object(args.manifest), True)
     except release.ManifestError as exc:
@@ -371,16 +468,16 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
         raise RollbackError("DSPACE config chart repository is not canonical")
     if config["SUGARKUBE_RELEASE"] != "dspace" or config["SUGARKUBE_NAMESPACE"] != "dspace":
         raise RollbackError("DSPACE release and namespace must both be dspace")
-    values, values_proof = values_evidence(config, root)
-    if values_proof != target["values"]:
-        raise RollbackError("configured values chain does not match finalized target evidence")
+    values, values_proof = stage_values(config, root, staged_directory)
     environment = cluster_environment(runner, args.kubeconfig)
     if environment != args.environment:
         raise RollbackError("connected cluster environment does not match selected environment")
-    capabilities = verifier_capabilities(args.verifier, runner)
+    capabilities = verifier_capabilities(
+        args.verifier, args.environment, "dspace", "dspace", runner
+    )
     coordinate = release.chart_coordinate(approved)
     helm_values = [part for path in values for part in ("--values", str(path))]
-    runner(
+    rendered_target = runner(
         [
             "helm",
             "--kubeconfig",
@@ -394,13 +491,11 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
             "--set-string",
             f"image.repository={release.IMAGE_REF}",
             "--set-string",
-            f"image.tag={target['imageTag']}",
-            "--set-string",
-            f"image.digest={target['imageDigest']}",
+            f"image.tag={target['imageTag']}@{target['imageDigest']}",
         ]
     )
     before_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
-    before_pods = pods(runner, args.kubeconfig, "dspace", "dspace")
+    before_pods = pods(runner, args.kubeconfig, "dspace", "dspace", require_any=False)
     # Keep the registry proof fresh: no tag resolution occurs between this
     # exact-digest check and confirmation/reservation/mutation.
     oci = release.preflight(
@@ -413,20 +508,51 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
         chart_version=target["chartVersion"],
         runner=runner,
     )
-    print(summary(before_helm, before_pods, target))
-    current_images = {image for pod in before_pods for image in pod["images"].values()}
+    print(summary(before_helm, before_pods, target, values_proof))
+    current_images = {application_image(pod) for pod in before_pods if application_image(pod)}
+    current_ids: set[str] = set()
+    for pod in before_pods:
+        image_id = application_image_id(pod)
+        if not image_id:
+            continue
+        try:
+            current_ids.add(release._image_id_digest(image_id))
+        except release.ManifestError:
+            # Old state is context, not a safety assertion. Preserve malformed
+            # identities in pod evidence and recover rather than crashing.
+            current_ids.clear()
+            break
     try:
-        current_ids = {
-            release._image_id_digest(image_id)
-            for pod in before_pods
-            for image_id in pod["imageIDs"].values()
-            if image_id
-        }
-    except release.ManifestError as exc:
-        raise RollbackError("current DSPACE image ID is invalid") from exc
-    # Helm status cannot prove the installed OCI chart digest, so matching mutable
-    # metadata is insufficient to reject this recovery as an exact no-op.
+        installed_render = runner(
+            [
+                "helm",
+                "--kubeconfig",
+                args.kubeconfig,
+                "get",
+                "manifest",
+                "dspace",
+                "--namespace",
+                "dspace",
+            ]
+        )
+    except RollbackError:
+        installed_render = None
+    expected_image = f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"
+    if (
+        installed_render is not None
+        and installed_render == rendered_target
+        and current_images == {expected_image}
+        and current_ids == {target["imageDigest"]}
+    ):
+        raise RollbackError("current rendered release is already the exact approved target")
+    # Matching chart version and image identity alone is not exact proof: Helm
+    # status cannot establish the installed OCI chart digest.
     confirmation(args.environment, args.confirm, target)
+    sugarkube_revision = runner(["git", "rev-parse", "HEAD"]).strip()
+    if not re.fullmatch(r"[0-9a-f]{40}", sugarkube_revision):
+        raise RollbackError("could not capture the Sugarkube revision")
+    if revision(helm_status(runner, args.kubeconfig, "dspace", "dspace")) != revision(before_helm):
+        raise RollbackError("Helm revision changed during preflight")
 
     invocation = uuid.uuid4().hex
     target_fingerprint = hashlib.sha256(release._canonical(target).encode()).hexdigest()
@@ -464,6 +590,8 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
     reserve(args.evidence, evidence)
     mutated = False
     try:
+        if runner(["git", "rev-parse", "HEAD"]).strip() != sugarkube_revision:
+            raise RollbackError("Sugarkube revision changed before mutation")
         description = f"sugarkube-dspace-manifest-rollback:{invocation}"
         command = [
             "helm",
@@ -480,9 +608,7 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
             "--set-string",
             f"image.repository={release.IMAGE_REF}",
             "--set-string",
-            f"image.tag={target['imageTag']}",
-            "--set-string",
-            f"image.digest={target['imageDigest']}",
+            f"image.tag={target['imageTag']}@{target['imageDigest']}",
             "--wait",
             "--timeout",
             args.timeout,
@@ -531,7 +657,8 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
         changed = (
             chart_version(before_helm) != target["chartVersion"]
             or current_ids != {target["imageDigest"]}
-            or current_images != {f"{release.IMAGE_REF}:{target['imageTag']}"}
+            or current_images
+            != {f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"}
         )
         verify_post_pods(after_pods, before_pods, target, changed)
         # Reuse finalization's strict Deployment/ReplicaSet ownership validator.
@@ -569,7 +696,7 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
             ],
             "DSPACE pods",
         )
-        release.finalize(
+        finalizer_proof = release.finalize(
             approved,
             after_helm,
             raw_pods,
@@ -582,13 +709,19 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
             namespace="dspace",
             cluster_environment=args.environment,
             invocation_description=description,
-            values=target["values"],
+            expected_image_coordinate=(
+                f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"
+            ),
         )
         verifier_command = [
             str(args.verifier),
             "verify",
             "--environment",
             args.environment,
+            "--release",
+            "dspace",
+            "--namespace",
+            "dspace",
             "--application-version",
             target["applicationVersion"],
             "--source-revision",
@@ -597,12 +730,11 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
             target["expectedDefaultChatProvider"],
         ]
         verifier = validate_verifier_result(
-            json_command(runner, verifier_command, "runtime verifier"), target
+            json_command(runner, verifier_command, "runtime verifier"), target, args.environment
         )
         stable = helm_status(runner, args.kubeconfig, "dspace", "dspace")
         if revision(stable) != after_revision:
             raise RollbackError("Helm revision changed concurrently during evidence collection")
-        sugarkube_revision = runner(["git", "rev-parse", "HEAD"]).strip()
         result = {
             **evidence,
             "state": "succeeded",
@@ -620,17 +752,47 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
                 "oci": oci,
                 "clusterEnvironment": environment,
                 "verifierCapabilities": capabilities,
-                "runtime": verifier,
+                "finalizerChecks": finalizer_proof.get("verificationResults", []),
+                "runtime": {
+                    "applicationVersion": verifier["applicationVersion"],
+                    "sourceRevision": verifier["runtimeSourceRevision"],
+                },
+                "frontend": {"sourceRevision": verifier["frontendSourceRevision"]},
+                "provider": {"default": verifier["defaultProvider"]},
+                "journeys": verifier["journeys"],
             },
         }
         replace_reserved(args.evidence, result)
         return result
     except Exception as exc:
+        diagnostics: dict[str, Any] = {}
+        try:
+            observed_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
+            diagnostics["helm"] = {
+                "revision": revision(observed_helm),
+                "status": observed_helm.get("info", {}).get("status"),
+            }
+        except Exception:
+            diagnostics["helm"] = "unavailable"
+        try:
+            observed_pods = pods(runner, args.kubeconfig, "dspace", "dspace", require_any=False)
+            diagnostics["pods"] = [
+                {
+                    "name": item["name"],
+                    "phase": item["phase"],
+                    "ready": item["ready"],
+                    "terminating": item["terminating"],
+                }
+                for item in observed_pods
+            ]
+        except Exception:
+            diagnostics["pods"] = "unavailable"
         evidence.update(
             state="failed",
+            failedStage="mutation-or-verification",
             failedAt=timestamp(),
             clusterMayHaveChanged=mutated,
-            diagnostic={"type": type(exc).__name__, "message": str(exc)},
+            diagnostics=diagnostics,
         )
         replace_reserved(args.evidence, evidence)
         raise RollbackError(

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -36,6 +36,7 @@ CANDIDATE_FIELDS = UPSTREAM_FIELDS + (
     "approvedBy",
 )
 FINAL_FIELDS = CANDIDATE_FIELDS + (
+    "values",
     "helmRevision",
     "pods",
     "runtimeSourceRevision",
@@ -153,6 +154,19 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
     except ValueError as exc:
         raise ManifestError("approvedAt is not a valid UTC timestamp") from exc
     if finalized:
+        values = value["values"]
+        if not isinstance(values, list) or not values:
+            raise ManifestError("values must be a non-empty ordered list")
+        for item in values:
+            if not isinstance(item, dict):
+                raise ManifestError("values entries must be objects")
+            _exact_fields(item, ("path", "sha256"))
+            if not isinstance(item["path"], str) or not item["path"]:
+                raise ManifestError("values path must be non-empty")
+            if not isinstance(item["sha256"], str) or not re.fullmatch(
+                r"[0-9a-f]{64}", item["sha256"]
+            ):
+                raise ManifestError("values sha256 must be a lowercase digest")
         if (
             not isinstance(value["helmRevision"], int)
             or isinstance(value["helmRevision"], bool)
@@ -212,9 +226,7 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
         if missing:
             raise ManifestError("missing verification results: " + ", ".join(missing))
         if sorted(platform_indices) != list(range(len(platform_indices))):
-            raise ManifestError(
-                "image platform verification indices must be contiguous from zero"
-            )
+            raise ManifestError("image platform verification indices must be contiguous from zero")
         if not platform_indices:
             raise ManifestError("at least one image platform verification result is required")
     return value
@@ -235,9 +247,7 @@ def _write_new(path: Path, value: dict[str, Any]) -> None:
         try:
             os.link(temporary, path)
         except FileExistsError as exc:
-            raise ManifestError(
-                f"refusing to overwrite existing record: {path}"
-            ) from exc
+            raise ManifestError(f"refusing to overwrite existing record: {path}") from exc
         _sync_directory(path.parent)
     finally:
         Path(temporary).unlink(missing_ok=True)
@@ -290,9 +300,7 @@ def reserve(
     try:
         fd = os.open(sidecar, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     except FileExistsError as exc:
-        raise ManifestError(
-            f"evidence destination is already reserved: {sidecar}"
-        ) from exc
+        raise ManifestError(f"evidence destination is already reserved: {sidecar}") from exc
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as stream:
             stream.write(_canonical(metadata))
@@ -328,9 +336,7 @@ def verify_reservation(
     if not secrets.compare_digest(
         json.dumps(metadata, sort_keys=True), json.dumps(expected, sort_keys=True)
     ):
-        raise ManifestError(
-            "reservation ownership or deployment coordinates do not match"
-        )
+        raise ManifestError("reservation ownership or deployment coordinates do not match")
     if normalized.exists():
         raise ManifestError(f"refusing to overwrite existing record: {normalized}")
     return sidecar
@@ -547,6 +553,7 @@ def finalize(
     namespace: str,
     cluster_environment: str,
     invocation_description: str,
+    values: list[dict[str, str]],
 ) -> dict[str, Any]:
     validate(value, False)
     selected = {
@@ -688,8 +695,7 @@ def finalize(
             # Helm metadata proves name/version, not immutable OCI content. The
             # guarded mutation therefore installs this approved digest directly.
             "details": (
-                f"chart=dspace; version={chart_version}; "
-                f"coordinate={chart_coordinate(value)}"
+                f"chart=dspace; version={chart_version}; " f"coordinate={chart_coordinate(value)}"
             ),
         },
         {
@@ -711,6 +717,7 @@ def finalize(
     result = dict(value)
     result.update(
         recordType="final",
+        values=values,
         helmRevision=revision,
         pods=pods,
         runtimeSourceRevision=value["sourceRevision"],
@@ -754,9 +761,8 @@ def main(argv: list[str] | None = None) -> int:
     finish.add_argument("--image-ref", default=IMAGE_REF)
     finish.add_argument("--chart-ref", default=CHART_REF)
     finish.add_argument("--reservation", required=True)
-    finish.add_argument(
-        "--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras")
-    )
+    finish.add_argument("--values", default="")
+    finish.add_argument("--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
     available = sub.add_parser("check-output")
     available.add_argument("--output", type=Path, required=True)
     destination = sub.add_parser("evidence-path")
@@ -884,6 +890,15 @@ def main(argv: list[str] | None = None) -> int:
                 namespace=args.namespace,
                 cluster_environment=cluster_environment,
                 invocation_description=invocation_description,
+                values=[
+                    {
+                        "path": str(path),
+                        "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+                    }
+                    for raw in args.values.split(",")
+                    for path in [Path(raw.strip())]
+                    if raw.strip()
+                ],
             )
             sidecar = verify_reservation(
                 args.output,
@@ -908,19 +923,16 @@ def main(argv: list[str] | None = None) -> int:
                     metadata.get("version"),
                 )
 
-            if (
-                binding_fields(settled_helm) != binding_fields(helm)
-                or binding_fields(stable_helm) != binding_fields(helm)
-            ):
+            if binding_fields(settled_helm) != binding_fields(helm) or binding_fields(
+                stable_helm
+            ) != binding_fields(helm):
                 raise ManifestError("Helm release changed during evidence collection")
             _write_new(args.output, result)
             sidecar.unlink()
             _sync_directory(args.output.expanduser().resolve(strict=False).parent)
         elif args.command == "check-output":
             if args.output.exists():
-                raise ManifestError(
-                    f"refusing to overwrite existing record: {args.output}"
-                )
+                raise ManifestError(f"refusing to overwrite existing record: {args.output}")
         elif args.command == "reserve":
             sys.stdout.write(
                 reserve(

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -36,7 +36,6 @@ CANDIDATE_FIELDS = UPSTREAM_FIELDS + (
     "approvedBy",
 )
 FINAL_FIELDS = CANDIDATE_FIELDS + (
-    "values",
     "helmRevision",
     "pods",
     "runtimeSourceRevision",
@@ -154,19 +153,6 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
     except ValueError as exc:
         raise ManifestError("approvedAt is not a valid UTC timestamp") from exc
     if finalized:
-        values = value["values"]
-        if not isinstance(values, list) or not values:
-            raise ManifestError("values must be a non-empty ordered list")
-        for item in values:
-            if not isinstance(item, dict):
-                raise ManifestError("values entries must be objects")
-            _exact_fields(item, ("path", "sha256"))
-            if not isinstance(item["path"], str) or not item["path"]:
-                raise ManifestError("values path must be non-empty")
-            if not isinstance(item["sha256"], str) or not re.fullmatch(
-                r"[0-9a-f]{64}", item["sha256"]
-            ):
-                raise ManifestError("values sha256 must be a lowercase digest")
         if (
             not isinstance(value["helmRevision"], int)
             or isinstance(value["helmRevision"], bool)
@@ -226,7 +212,9 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
         if missing:
             raise ManifestError("missing verification results: " + ", ".join(missing))
         if sorted(platform_indices) != list(range(len(platform_indices))):
-            raise ManifestError("image platform verification indices must be contiguous from zero")
+            raise ManifestError(
+                "image platform verification indices must be contiguous from zero"
+            )
         if not platform_indices:
             raise ManifestError("at least one image platform verification result is required")
     return value
@@ -247,7 +235,9 @@ def _write_new(path: Path, value: dict[str, Any]) -> None:
         try:
             os.link(temporary, path)
         except FileExistsError as exc:
-            raise ManifestError(f"refusing to overwrite existing record: {path}") from exc
+            raise ManifestError(
+                f"refusing to overwrite existing record: {path}"
+            ) from exc
         _sync_directory(path.parent)
     finally:
         Path(temporary).unlink(missing_ok=True)
@@ -300,7 +290,9 @@ def reserve(
     try:
         fd = os.open(sidecar, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     except FileExistsError as exc:
-        raise ManifestError(f"evidence destination is already reserved: {sidecar}") from exc
+        raise ManifestError(
+            f"evidence destination is already reserved: {sidecar}"
+        ) from exc
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as stream:
             stream.write(_canonical(metadata))
@@ -336,7 +328,9 @@ def verify_reservation(
     if not secrets.compare_digest(
         json.dumps(metadata, sort_keys=True), json.dumps(expected, sort_keys=True)
     ):
-        raise ManifestError("reservation ownership or deployment coordinates do not match")
+        raise ManifestError(
+            "reservation ownership or deployment coordinates do not match"
+        )
     if normalized.exists():
         raise ManifestError(f"refusing to overwrite existing record: {normalized}")
     return sidecar
@@ -553,7 +547,7 @@ def finalize(
     namespace: str,
     cluster_environment: str,
     invocation_description: str,
-    values: list[dict[str, str]],
+    expected_image_coordinate: str | None = None,
 ) -> dict[str, Any]:
     validate(value, False)
     selected = {
@@ -639,7 +633,7 @@ def finalize(
         application = [container for container in containers if container.get("name") == "dspace"]
         if len(application) != 1:
             raise ManifestError("pod must contain exactly one dspace application container")
-        expected_image = f"{IMAGE_REF}:{image_tag}"
+        expected_image = expected_image_coordinate or f"{IMAGE_REF}:{image_tag}"
         if application[0].get("image") != expected_image:
             raise ManifestError(
                 "pod application image does not match approved repository and imageTag"
@@ -695,7 +689,8 @@ def finalize(
             # Helm metadata proves name/version, not immutable OCI content. The
             # guarded mutation therefore installs this approved digest directly.
             "details": (
-                f"chart=dspace; version={chart_version}; " f"coordinate={chart_coordinate(value)}"
+                f"chart=dspace; version={chart_version}; "
+                f"coordinate={chart_coordinate(value)}"
             ),
         },
         {
@@ -717,7 +712,6 @@ def finalize(
     result = dict(value)
     result.update(
         recordType="final",
-        values=values,
         helmRevision=revision,
         pods=pods,
         runtimeSourceRevision=value["sourceRevision"],
@@ -761,8 +755,9 @@ def main(argv: list[str] | None = None) -> int:
     finish.add_argument("--image-ref", default=IMAGE_REF)
     finish.add_argument("--chart-ref", default=CHART_REF)
     finish.add_argument("--reservation", required=True)
-    finish.add_argument("--values", default="")
-    finish.add_argument("--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
+    finish.add_argument(
+        "--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras")
+    )
     available = sub.add_parser("check-output")
     available.add_argument("--output", type=Path, required=True)
     destination = sub.add_parser("evidence-path")
@@ -890,15 +885,6 @@ def main(argv: list[str] | None = None) -> int:
                 namespace=args.namespace,
                 cluster_environment=cluster_environment,
                 invocation_description=invocation_description,
-                values=[
-                    {
-                        "path": str(path),
-                        "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
-                    }
-                    for raw in args.values.split(",")
-                    for path in [Path(raw.strip())]
-                    if raw.strip()
-                ],
             )
             sidecar = verify_reservation(
                 args.output,
@@ -923,16 +909,19 @@ def main(argv: list[str] | None = None) -> int:
                     metadata.get("version"),
                 )
 
-            if binding_fields(settled_helm) != binding_fields(helm) or binding_fields(
-                stable_helm
-            ) != binding_fields(helm):
+            if (
+                binding_fields(settled_helm) != binding_fields(helm)
+                or binding_fields(stable_helm) != binding_fields(helm)
+            ):
                 raise ManifestError("Helm release changed during evidence collection")
             _write_new(args.output, result)
             sidecar.unlink()
             _sync_directory(args.output.expanduser().resolve(strict=False).parent)
         elif args.command == "check-output":
             if args.output.exists():
-                raise ManifestError(f"refusing to overwrite existing record: {args.output}")
+                raise ManifestError(
+                    f"refusing to overwrite existing record: {args.output}"
+                )
         elif args.command == "reserve":
             sys.stdout.write(
                 reserve(

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -185,6 +185,86 @@ def test_missing_or_candidate_target_fails_before_any_external_command(
     assert not (tmp_path / "rollback.json").exists()
 
 
+@pytest.mark.parametrize(
+    "mismatch",
+    ("image digest", "chart digest", "chart source revision", "image platform revision"),
+)
+def test_oci_preflight_mismatch_is_controlled_before_reservation_or_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    mismatch: str,
+) -> None:
+    manifest_path = tmp_path / "target.json"
+    evidence_path = tmp_path / "rollback.json"
+    verifier = tmp_path / "verifier"
+    values = tmp_path / "values.yaml"
+    manifest_path.write_text(manifest._canonical(target()), encoding="utf-8")
+    verifier.write_text("#!/bin/sh\n", encoding="utf-8")
+    verifier.chmod(0o755)
+    values.write_text("staging: true\n", encoding="utf-8")
+    monkeypatch.setattr(
+        rollback.app_config,
+        "load_config",
+        lambda *_args: {
+            "SUGARKUBE_CHART": f"oci://{manifest.CHART_REF}",
+            "SUGARKUBE_RELEASE": "dspace",
+            "SUGARKUBE_NAMESPACE": "dspace",
+            "SUGARKUBE_VALUES": str(values),
+        },
+    )
+    monkeypatch.setattr(rollback, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(rollback, "cluster_environment", lambda *_args: "staging")
+    monkeypatch.setattr(rollback, "verifier_capabilities", lambda *_args: {})
+    monkeypatch.setattr(
+        rollback,
+        "helm_status",
+        lambda *_args: {
+            "name": "dspace",
+            "namespace": "dspace",
+            "version": 7,
+            "info": {"status": "deployed"},
+            "chart": {"metadata": {"name": "dspace", "version": "3.1.0"}},
+        },
+    )
+    monkeypatch.setattr(rollback, "pods", lambda *_args, **_kwargs: [])
+    sentinel = "TOP-SECRET-oci-output"
+    monkeypatch.setattr(
+        rollback.release,
+        "preflight",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            manifest.ManifestError(f"{mismatch}: {sentinel}")
+        ),
+    )
+    commands: list[list[str]] = []
+
+    def runner(command: list[str]) -> str:
+        commands.append(command)
+        return "rendered"
+
+    original_rollback = rollback.rollback
+    monkeypatch.setattr(rollback, "rollback", lambda args: original_rollback(args, runner))
+    status = rollback.main(
+        [
+            "--environment",
+            "staging",
+            "--manifest",
+            str(manifest_path),
+            "--evidence",
+            str(evidence_path),
+            "--verifier",
+            str(verifier),
+        ]
+    )
+
+    assert status == 2
+    stderr = capsys.readouterr().err
+    assert stderr == "error: OCI preflight validation failed\n"
+    assert sentinel not in stderr
+    assert not evidence_path.exists()
+    assert not any("upgrade" in command or "rollout" in command for command in commands)
+
+
 def test_values_chain_is_ordered_hashed_and_never_contains_contents(tmp_path: Path) -> None:
     first = tmp_path / "base.yaml"
     second = tmp_path / "prod.yaml"

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -1,0 +1,335 @@
+"""Focused fail-closed tests for DSPACE manifest rollback."""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from scripts import dspace_manifest_rollback as rollback
+from scripts import dspace_release_manifest as manifest
+
+SHA = "abcdef0123456789abcdef0123456789abcdef01"
+DIGEST = "sha256:" + "1" * 64
+
+
+def target(environment: str = "staging") -> dict[str, object]:
+    value = {
+        "schemaVersion": 1,
+        "app": "dspace",
+        "applicationVersion": "3.2.0",
+        "sourceRevision": SHA,
+        "imageTag": "main-abcdef0",
+        "imageDigest": DIGEST,
+        "chartVersion": "3.2.0",
+        "chartDigest": "sha256:" + "2" * 64,
+        "semanticTag": "v3.2.0",
+        "recordType": "final",
+        "environment": environment,
+        "expectedDefaultChatProvider": "token-place",
+        "approvedAt": "2026-07-26T12:00:00Z",
+        "approvedBy": "test-approver",
+        "helmRevision": 7,
+        "pods": [
+            {
+                "name": "dspace-old",
+                "startTime": "2026-07-26T12:01:00Z",
+                "imageID": f"{manifest.IMAGE_REF}@{DIGEST}",
+            }
+        ],
+        "runtimeSourceRevision": SHA,
+        "runtimeSourceRevisionMethod": manifest.RUNTIME_METHOD,
+        "verificationResults": [],
+    }
+    checks = sorted(manifest.FINAL_FIXED_CHECKS) + ["imagePlatformSourceRevision[0]"]
+    value["verificationResults"] = [
+        {"check": check, "passed": True, "details": "observed"} for check in checks
+    ]
+    return manifest.validate(value, True)
+
+
+def verifier_result(**changes: object) -> dict[str, object]:
+    value = {
+        "schemaVersion": 1,
+        "applicationVersion": "3.2.0",
+        "runtimeSourceRevision": SHA,
+        "frontendSourceRevision": SHA,
+        "defaultProvider": "token-place",
+        "journeys": [{"name": "/"}, {"name": "/chat"}],
+    }
+    value["journeys"] = [{"name": item["name"], "passed": True} for item in value["journeys"]]
+    value.update(changes)
+    return value
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"runtimeSourceRevision": "0" * 40}, "runtimeSourceRevision"),
+        ({"frontendSourceRevision": "0" * 40}, "frontendSourceRevision"),
+        ({"defaultProvider": "openai"}, "defaultProvider"),
+        ({"journeys": [{"name": "/chat", "passed": False}]}, "failed public journey"),
+        ({"journeys": [{"name": "/", "passed": True}]}, "required /chat"),
+        ({"secret": "must-not-be-accepted"}, "schema mismatch"),
+    ],
+)
+def test_verifier_result_fails_closed(changes: dict[str, object], message: str) -> None:
+    with pytest.raises(rollback.RollbackError, match=message):
+        rollback.validate_verifier_result(verifier_result(**changes), target())
+
+
+def test_verifier_result_accepts_exact_identity_and_journeys() -> None:
+    assert rollback.validate_verifier_result(verifier_result(), target())["journeys"][1] == {
+        "name": "/chat",
+        "passed": True,
+    }
+
+
+def test_capability_probe_is_argv_only_and_exact(tmp_path: Path) -> None:
+    executable = tmp_path / "verifier"
+    executable.write_text("#!/bin/sh\n", encoding="utf-8")
+    executable.chmod(0o755)
+    calls = []
+
+    def runner(command: list[str]) -> str:
+        calls.append(command)
+        return json.dumps(
+            {"schemaVersion": 1, "capabilities": list(rollback.REQUIRED_CAPABILITIES)}
+        )
+
+    rollback.verifier_capabilities(executable, runner)
+    assert calls == [[str(executable), "capabilities"]]
+
+
+def test_missing_or_incompatible_verifier_fails(tmp_path: Path) -> None:
+    with pytest.raises(rollback.RollbackError, match="existing executable"):
+        rollback.verifier_capabilities(tmp_path / "missing")
+    executable = tmp_path / "verifier"
+    executable.write_text("#!/bin/sh\n", encoding="utf-8")
+    executable.chmod(0o755)
+    with pytest.raises(rollback.RollbackError, match="incompatible"):
+        rollback.verifier_capabilities(
+            executable,
+            lambda _command: json.dumps({"schemaVersion": 1, "capabilities": ["health"]}),
+        )
+
+
+def test_production_confirmation_is_bound_to_full_target_sha() -> None:
+    for invalid in ("", "yes", "dspace:prod:deadbee", f"dspace:staging:{SHA}"):
+        with pytest.raises(rollback.RollbackError, match="exactly equal"):
+            rollback.confirmation("prod", invalid, target("prod"))
+    rollback.confirmation("prod", f"dspace:prod:{SHA}", target("prod"))
+    rollback.confirmation("staging", "", target())
+
+
+def test_missing_or_candidate_target_fails_before_any_external_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    called = []
+    monkeypatch.setattr(rollback, "run", lambda command: called.append(command) or "")
+    common = [
+        "--environment",
+        "staging",
+        "--evidence",
+        str(tmp_path / "rollback.json"),
+        "--verifier",
+        str(tmp_path / "verifier"),
+    ]
+    assert rollback.main(["--manifest", str(tmp_path / "missing.json"), *common]) == 2
+    candidate = {field: target()[field] for field in manifest.CANDIDATE_FIELDS}
+    candidate["recordType"] = "candidate"
+    source = tmp_path / "candidate.json"
+    source.write_text(manifest._canonical(candidate), encoding="utf-8")
+    assert rollback.main(["--manifest", str(source), *common]) == 2
+    assert called == []
+    assert not (tmp_path / "rollback.json").exists()
+
+
+def test_values_chain_is_ordered_hashed_and_never_contains_contents(tmp_path: Path) -> None:
+    first = tmp_path / "base.yaml"
+    second = tmp_path / "prod.yaml"
+    first.write_text("privateSetting: do-not-log\n", encoding="utf-8")
+    second.write_text("provider: token-place\n", encoding="utf-8")
+    paths, proof = rollback.values_evidence({"SUGARKUBE_VALUES": "base.yaml,prod.yaml"}, tmp_path)
+    assert paths == [first, second]
+    assert [item["path"] for item in proof] == ["base.yaml", "prod.yaml"]
+    assert "do-not-log" not in json.dumps(proof)
+    with pytest.raises(rollback.RollbackError, match="missing or unreadable"):
+        rollback.values_evidence({"SUGARKUBE_VALUES": "missing.yaml"}, tmp_path)
+
+
+def pod(uid: str, *, digest: str = DIGEST, terminating: bool = False) -> dict[str, object]:
+    return {
+        "name": f"dspace-{uid}",
+        "uid": uid,
+        "startTime": f"2026-07-27T12:00:0{uid[-1]}Z",
+        "phase": "Running",
+        "ready": True,
+        "terminating": terminating,
+        "images": {"dspace": f"{manifest.IMAGE_REF}:main-abcdef0"},
+        "imageIDs": {"dspace": f"{manifest.IMAGE_REF}@{digest}"},
+        "ownerReferences": [],
+    }
+
+
+def test_post_pod_proof_rejects_unchanged_lingering_and_digest_mismatch() -> None:
+    before = [pod("1")]
+    with pytest.raises(rollback.RollbackError, match="replacement"):
+        rollback.verify_post_pods(before, before, target(), True)
+    with pytest.raises(rollback.RollbackError, match="terminating"):
+        rollback.verify_post_pods([pod("2", terminating=True)], before, target(), True)
+    with pytest.raises(rollback.RollbackError, match="resolved image ID"):
+        rollback.verify_post_pods([pod("2", digest="sha256:" + "9" * 64)], before, target(), True)
+    rollback.verify_post_pods([pod("2")], before, target(), True)
+
+
+def test_summary_never_invents_current_chart_digest() -> None:
+    current = {
+        "version": 8,
+        "chart": {"metadata": {"name": "dspace", "version": "3.1.0"}},
+    }
+    text = rollback.summary(current, [pod("1")], target())
+    assert "current: helmRevision=8 chartVersion=3.1.0 chartDigest=unknown" in text
+    assert f"chartDigest={target()['chartDigest']}" in text
+
+
+def test_reservation_collision_and_failure_record_are_non_secret(tmp_path: Path) -> None:
+    evidence = tmp_path / "rollback.json"
+    reservation = {"schemaVersion": 1, "state": "reserved", "invocationId": "safe"}
+    rollback.reserve(evidence, reservation)
+    with pytest.raises(rollback.RollbackError, match="overwrite"):
+        rollback.reserve(evidence, reservation)
+    failed = {**reservation, "state": "failed", "diagnostic": "RollbackError"}
+    rollback.replace_reserved(evidence, failed)
+    assert json.loads(evidence.read_text(encoding="utf-8")) == failed
+    assert "token" not in evidence.read_text(encoding="utf-8").lower()
+
+
+def test_just_recipe_has_no_revision_rollback_or_reuse_values() -> None:
+    recipe = (Path(__file__).parents[1] / "justfile").read_text(encoding="utf-8")
+    block = recipe.split("dspace-manifest-rollback", 1)[1].split("\n# Generic", 1)[0]
+    assert "dspace_manifest_rollback.py" in block
+    assert "--reuse-values" not in block
+    assert "helm rollback" not in block
+
+
+def test_success_uses_digest_chart_complete_values_and_writes_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_path = tmp_path / "target.json"
+    evidence_path = tmp_path / "rollback.json"
+    manifest_path.write_text(manifest._canonical(target()), encoding="utf-8")
+    verifier = tmp_path / "verifier"
+    verifier.write_text("#!/bin/sh\n", encoding="utf-8")
+    verifier.chmod(0o755)
+    base = tmp_path / "base.yaml"
+    overlay = tmp_path / "staging.yaml"
+    base.write_text("base: true\n", encoding="utf-8")
+    overlay.write_text("staging: true\n", encoding="utf-8")
+    config = {
+        "SUGARKUBE_CHART": f"oci://{manifest.CHART_REF}",
+        "SUGARKUBE_RELEASE": "dspace",
+        "SUGARKUBE_NAMESPACE": "dspace",
+        "SUGARKUBE_VALUES": f"{base},{overlay}",
+    }
+    monkeypatch.setattr(rollback.app_config, "load_config", lambda *_args: config)
+    monkeypatch.setattr(rollback, "cluster_environment", lambda *_args: "staging")
+    monkeypatch.setattr(
+        rollback,
+        "verifier_capabilities",
+        lambda *_args: {
+            "schemaVersion": 1,
+            "capabilities": list(rollback.REQUIRED_CAPABILITIES),
+        },
+    )
+    monkeypatch.setattr(
+        rollback.release,
+        "preflight",
+        lambda *_args, **_kwargs: [{"check": "imageDigest", "passed": True, "details": "observed"}],
+    )
+    monkeypatch.setattr(rollback.release, "finalize", lambda *_args, **_kwargs: {})
+    statuses = iter(
+        [
+            {
+                "name": "dspace",
+                "namespace": "dspace",
+                "version": 7,
+                "info": {"status": "deployed", "description": "old"},
+                "chart": {"metadata": {"name": "dspace", "version": "3.1.0"}},
+            },
+            {
+                "name": "dspace",
+                "namespace": "dspace",
+                "version": 8,
+                "info": {"status": "deployed", "description": "placeholder"},
+                "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}},
+            },
+            {
+                "name": "dspace",
+                "namespace": "dspace",
+                "version": 8,
+                "info": {"status": "deployed", "description": "placeholder"},
+                "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}},
+            },
+        ]
+    )
+
+    def status(*_args: object) -> dict[str, object]:
+        value = next(statuses)
+        if value["version"] == 8:
+            value["info"]["description"] = description[0]
+        return value
+
+    description = [""]
+    monkeypatch.setattr(rollback, "helm_status", status)
+    pod_states = iter([[pod("1", digest="sha256:" + "9" * 64)], [pod("2")]])
+    latest = [pod("2")]
+
+    def pods_stub(*_args: object) -> list[dict[str, object]]:
+        try:
+            latest[:] = next(pod_states)
+        except StopIteration:
+            pass
+        return json.loads(json.dumps(latest))
+
+    monkeypatch.setattr(rollback, "pods", pods_stub)
+    commands: list[list[str]] = []
+
+    def runner(command: list[str]) -> str:
+        commands.append(command)
+        if command[0] == "helm" and "upgrade" in command:
+            description[0] = command[command.index("--description") + 1]
+        if command[:2] == [str(verifier), "verify"]:
+            return json.dumps(verifier_result())
+        if command[:2] == ["git", "rev-parse"]:
+            return "f" * 40 + "\n"
+        if command[0] == "kubectl" and "replicasets,deployments" in command:
+            return '{"items": []}'
+        if command[0] == "kubectl" and "pods" in command:
+            return '{"items": []}'
+        return "rendered"
+
+    args = Namespace(
+        environment="staging",
+        manifest=manifest_path,
+        evidence=evidence_path,
+        verifier=verifier,
+        confirm="",
+        config="",
+        kubeconfig="kubeconfig",
+        oras="oras",
+        timeout="10m",
+    )
+    result = rollback.rollback(args, runner)
+    upgrade = next(command for command in commands if "upgrade" in command)
+    assert f"oci://{manifest.CHART_REF}@{'sha256:' + '2' * 64}" in upgrade
+    assert upgrade.count("--values") == 2
+    assert str(base) in upgrade and str(overlay) in upgrade
+    assert "--reuse-values" not in upgrade
+    assert result["state"] == "succeeded"
+    written = json.loads(evidence_path.read_text(encoding="utf-8"))
+    assert written["targetManifestFingerprint"] == result["targetManifestFingerprint"]
+    assert written["helm"]["beforeRevision"] == 7
+    assert written["helm"]["afterRevision"] == 8

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -344,8 +344,172 @@ def test_summary_never_invents_current_chart_digest() -> None:
     text = rollback.summary(
         current, [pod("1")], target(), [{"path": "values.yaml", "sha256": "3" * 64}]
     )
-    assert "helmRevision=8 chartName=dspace chartVersion=3.1.0 chartDigest=unknown" in text
-    assert f"chartDigest={target()['chartDigest']}" in text
+    assert text == "\n".join(
+        [
+            "DSPACE manifest rollback preflight:",
+            "  current: release=dspace namespace=dspace helmStatus=unknown "
+            "helmRevision=8 chartName=dspace chartVersion=3.1.0 chartDigest=unknown",
+            f"           images={manifest.IMAGE_REF}:main-abcdef0@{DIGEST} "
+            f"imageIDs={manifest.IMAGE_REF}@{DIGEST}",
+            f"  target:  release=dspace namespace=dspace sourceRevision={SHA} "
+            "applicationVersion=3.2.0",
+            f"           chartVersion=3.2.0 chartDigest={'sha256:' + '2' * 64}",
+            f"           imageTag=main-abcdef0 imageDigest={DIGEST}",
+            f"           imageCoordinate={manifest.IMAGE_REF}:main-abcdef0@{DIGEST}",
+            "           provider=token-place",
+            f"  values:  values.yaml={'3' * 64}",
+        ]
+    )
+
+
+def pre_reservation_case(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    environment: str = "staging",
+) -> tuple[Namespace, list[list[str]], Path, Path]:
+    manifest_path = tmp_path / "target.json"
+    evidence_path = tmp_path / "rollback.json"
+    verifier = tmp_path / "verifier"
+    values = tmp_path / "values.yaml"
+    manifest_path.write_text(manifest._canonical(target(environment)), encoding="utf-8")
+    verifier.write_text("#!/bin/sh\n", encoding="utf-8")
+    verifier.chmod(0o755)
+    values.write_text("environment: test\n", encoding="utf-8")
+    monkeypatch.setattr(
+        rollback.app_config,
+        "load_config",
+        lambda *_args: {
+            "SUGARKUBE_CHART": f"oci://{manifest.CHART_REF}",
+            "SUGARKUBE_RELEASE": "dspace",
+            "SUGARKUBE_NAMESPACE": "dspace",
+            "SUGARKUBE_VALUES": str(values),
+        },
+    )
+    monkeypatch.setattr(rollback, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(rollback, "cluster_environment", lambda *_args: environment)
+    monkeypatch.setattr(rollback, "verifier_capabilities", lambda *_args: {})
+    monkeypatch.setattr(
+        rollback.release,
+        "preflight",
+        lambda *_args, **_kwargs: [{"check": "oci", "passed": True}],
+    )
+    monkeypatch.setattr(
+        rollback,
+        "helm_status",
+        lambda *_args: {
+            "name": "dspace",
+            "namespace": "dspace",
+            "version": 7,
+            "info": {"status": "deployed"},
+            "chart": {"metadata": {"name": "dspace", "version": "3.1.0"}},
+        },
+    )
+    monkeypatch.setattr(rollback, "pods", lambda *_args, **_kwargs: [])
+    commands: list[list[str]] = []
+
+    args = Namespace(
+        environment=environment,
+        manifest=manifest_path,
+        evidence=evidence_path,
+        verifier=verifier,
+        confirm="",
+        config="",
+        kubeconfig="kubeconfig",
+        oras="oras",
+        timeout="10m",
+    )
+    return args, commands, evidence_path, verifier
+
+
+def assert_no_mutation(commands: list[list[str]]) -> None:
+    assert not any("upgrade" in command or "rollout" in command for command in commands)
+
+
+def test_render_failure_precedes_reservation_and_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    args, commands, evidence, _verifier = pre_reservation_case(tmp_path, monkeypatch)
+
+    def runner(command: list[str]) -> str:
+        commands.append(command)
+        if "template" in command:
+            raise rollback.RollbackError("render failed")
+        return ""
+
+    with pytest.raises(rollback.RollbackError, match="render failed"):
+        rollback.rollback(args, runner)
+    assert not evidence.exists()
+    assert_no_mutation(commands)
+
+
+def test_exact_no_op_is_rejected_before_reservation_and_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    args, commands, evidence, _verifier = pre_reservation_case(tmp_path, monkeypatch)
+    monkeypatch.setattr(rollback, "pods", lambda *_args, **_kwargs: [pod("1")])
+
+    def runner(command: list[str]) -> str:
+        commands.append(command)
+        if "template" in command or ("get" in command and "manifest" in command):
+            return "exact rendered manifest"
+        return ""
+
+    with pytest.raises(rollback.RollbackError, match="already the exact approved target"):
+        rollback.rollback(args, runner)
+    assert not evidence.exists()
+    assert_no_mutation(commands)
+
+
+@pytest.mark.parametrize("gate", ("confirmation", "verifier"))
+def test_confirmation_and_verifier_gates_precede_reservation_and_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, gate: str
+) -> None:
+    environment = "prod" if gate == "confirmation" else "staging"
+    args, commands, evidence, _verifier = pre_reservation_case(
+        tmp_path, monkeypatch, environment=environment
+    )
+    if gate == "verifier":
+        monkeypatch.setattr(
+            rollback,
+            "verifier_capabilities",
+            lambda *_args: (_ for _ in ()).throw(
+                rollback.RollbackError("verifier capabilities are incompatible")
+            ),
+        )
+
+    def runner(command: list[str]) -> str:
+        commands.append(command)
+        return "target render" if "template" in command else "installed render"
+
+    message = "confirmation" if gate == "confirmation" else "incompatible"
+    with pytest.raises(rollback.RollbackError, match=message):
+        rollback.rollback(args, runner)
+    assert not evidence.exists()
+    assert_no_mutation(commands)
+    if gate == "verifier":
+        assert not any("template" in command for command in commands)
+
+
+def test_staging_is_non_interactive_and_reservation_collision_is_immutable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    args, commands, evidence, _verifier = pre_reservation_case(tmp_path, monkeypatch)
+    original = b"pre-existing immutable evidence\n"
+    evidence.write_bytes(original)
+
+    def runner(command: list[str]) -> str:
+        commands.append(command)
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return "f" * 40 + "\n"
+        return "target render" if "template" in command else "installed render"
+
+    with pytest.raises(rollback.RollbackError, match="refusing to overwrite"):
+        rollback.rollback(args, runner)
+    assert evidence.read_bytes() == original
+    assert any("template" in command for command in commands)
+    assert any("get" in command and "manifest" in command for command in commands)
+    assert_no_mutation(commands)
 
 
 def test_reservation_collision_and_failure_record_are_non_secret(tmp_path: Path) -> None:

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -288,8 +288,24 @@ def test_just_recipe_has_no_revision_rollback_or_reuse_values() -> None:
     assert "helm rollback" not in block
 
 
-def test_success_uses_digest_chart_complete_values_and_writes_evidence(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    ("failure", "failed_stage", "may_have_changed"),
+    [
+        (None, None, None),
+        ("pre-mutation", "pre-mutation-revalidation", False),
+        ("helm", "helm-upgrade", True),
+        ("rollout", "rollout-wait", True),
+        ("verifier", "runtime-verification", True),
+        ("revision", "revision-stability-collection", True),
+    ],
+)
+def test_orchestration_preserves_complete_success_and_failure_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str | None,
+    failed_stage: str | None,
+    may_have_changed: bool | None,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     manifest_path = tmp_path / "target.json"
     evidence_path = tmp_path / "rollback.json"
@@ -325,44 +341,27 @@ def test_success_uses_digest_chart_complete_values_and_writes_evidence(
         lambda *_args, **_kwargs: [{"check": "imageDigest", "passed": True, "details": "observed"}],
     )
     monkeypatch.setattr(rollback.release, "finalize", lambda *_args, **_kwargs: {})
-    statuses = iter(
-        [
-            {
-                "name": "dspace",
-                "namespace": "dspace",
-                "version": 7,
-                "info": {"status": "deployed", "description": "old"},
-                "chart": {"metadata": {"name": "dspace", "version": "3.1.0"}},
-            },
-            {
-                "name": "dspace",
-                "namespace": "dspace",
-                "version": 7,
-                "info": {"status": "deployed", "description": "old"},
-                "chart": {"metadata": {"name": "dspace", "version": "3.1.0"}},
-            },
-            {
-                "name": "dspace",
-                "namespace": "dspace",
-                "version": 8,
-                "info": {"status": "deployed", "description": "placeholder"},
-                "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}},
-            },
-            {
-                "name": "dspace",
-                "namespace": "dspace",
-                "version": 8,
-                "info": {"status": "deployed", "description": "placeholder"},
-                "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}},
-            },
-        ]
-    )
+    upgrade_attempted = [False]
+    post_status_calls = [0]
 
     def status(*_args: object) -> dict[str, object]:
-        value = next(statuses)
-        if value["version"] == 8:
-            value["info"]["description"] = description[0]
-        return value
+        if not upgrade_attempted[0]:
+            return {
+                "name": "dspace",
+                "namespace": "dspace",
+                "version": 7,
+                "info": {"status": "deployed", "description": "old"},
+                "chart": {"metadata": {"name": "dspace", "version": "3.1.0"}},
+            }
+        post_status_calls[0] += 1
+        revision = 9 if failure == "revision" and post_status_calls[0] >= 2 else 8
+        return {
+            "name": "dspace",
+            "namespace": "dspace",
+            "version": revision,
+            "info": {"status": "deployed", "description": description[0]},
+            "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}},
+        }
 
     description = [""]
     monkeypatch.setattr(rollback, "helm_status", status)
@@ -378,14 +377,26 @@ def test_success_uses_digest_chart_complete_values_and_writes_evidence(
 
     monkeypatch.setattr(rollback, "pods", pods_stub)
     commands: list[list[str]] = []
+    git_calls = [0]
+    sentinel = "TOP-SECRET-verifier-output"
 
     def runner(command: list[str]) -> str:
         commands.append(command)
         if command[0] == "helm" and "upgrade" in command:
+            upgrade_attempted[0] = True
             description[0] = command[command.index("--description") + 1]
+            if failure == "helm":
+                raise rollback.RollbackError(sentinel)
+        if command[0] == "kubectl" and "rollout" in command and failure == "rollout":
+            raise rollback.RollbackError(sentinel)
         if command[:2] == [str(verifier), "verify"]:
+            if failure == "verifier":
+                raise rollback.RollbackError(sentinel)
             return json.dumps(verifier_result())
         if command[:2] == ["git", "rev-parse"]:
+            git_calls[0] += 1
+            if failure == "pre-mutation" and git_calls[0] == 2:
+                return "e" * 40 + "\n"
             return "f" * 40 + "\n"
         if command[0] == "kubectl" and "replicasets,deployments" in command:
             return '{"items": []}'
@@ -404,6 +415,35 @@ def test_success_uses_digest_chart_complete_values_and_writes_evidence(
         oras="oras",
         timeout="10m",
     )
+    if failure is not None:
+        with pytest.raises(rollback.RollbackError, match="preserved evidence"):
+            rollback.rollback(args, runner)
+        written = json.loads(evidence_path.read_text(encoding="utf-8"))
+        assert written["state"] == "failed"
+        assert written["failedStage"] == failed_stage
+        assert written["failureCode"] == f"{failed_stage}-failed"
+        assert written["failureType"] == "rollback"
+        assert written["clusterMayHaveChanged"] is may_have_changed
+        assert written["sugarkubeRevision"] == "f" * 40
+        assert sentinel not in evidence_path.read_text(encoding="utf-8")
+        assert sentinel not in capsys.readouterr().err
+        observed = written["diagnostics"]
+        assert observed["helm"] == {
+            "release": "dspace",
+            "namespace": "dspace",
+            "revision": 7 if failure == "pre-mutation" else (9 if failure == "revision" else 8),
+            "status": "deployed",
+            "chartName": "dspace",
+            "chartVersion": "3.1.0" if failure == "pre-mutation" else "3.2.0",
+            "invocationDescriptionMatches": failure != "pre-mutation",
+        }
+        assert observed["pods"][0]["uid"] == "2"
+        assert observed["pods"][0]["startTime"]
+        assert observed["pods"][0]["images"]["dspace"]
+        assert observed["pods"][0]["imageIDs"]["dspace"]
+        assert "ownerReferences" in observed["pods"][0]
+        return
+
     result = rollback.rollback(args, runner)
     upgrade = next(command for command in commands if "upgrade" in command)
     assert f"oci://{manifest.CHART_REF}@{'sha256:' + '2' * 64}" in upgrade

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -27,6 +27,7 @@ def target(environment: str = "staging") -> dict[str, object]:
         "chartDigest": "sha256:" + "2" * 64,
         "semanticTag": "v3.2.0",
         "recordType": "final",
+        "values": [{"path": "values.yaml", "sha256": "3" * 64}],
         "environment": environment,
         "expectedDefaultChatProvider": "token-place",
         "approvedAt": "2026-07-26T12:00:00Z",
@@ -185,6 +186,27 @@ def test_post_pod_proof_rejects_unchanged_lingering_and_digest_mismatch() -> Non
     rollback.verify_post_pods([pod("2")], before, target(), True)
 
 
+def test_post_pod_proof_ignores_regular_sidecars() -> None:
+    after = pod("2")
+    after["images"]["metrics"] = "example.invalid/metrics:1"
+    after["imageIDs"]["metrics"] = "example.invalid/metrics@sha256:" + "9" * 64
+    # pods() filters these before proof, mirroring release finalization's named container contract.
+    after["images"] = {"dspace": after["images"]["dspace"]}
+    after["imageIDs"] = {"dspace": after["imageIDs"]["dspace"]}
+    rollback.verify_post_pods([after], [pod("1")], target(), True)
+
+
+def test_cluster_environment_rejects_partially_labeled_nodes() -> None:
+    nodes = {
+        "items": [
+            {"metadata": {"labels": {"sugarkube.env": "staging"}}},
+            {"metadata": {"labels": {}}},
+        ]
+    }
+    with pytest.raises(rollback.RollbackError, match="do not prove"):
+        rollback.cluster_environment(lambda _command: json.dumps(nodes), "kubeconfig")
+
+
 def test_summary_never_invents_current_chart_digest() -> None:
     current = {
         "version": 8,
@@ -220,7 +242,6 @@ def test_success_uses_digest_chart_complete_values_and_writes_evidence(
 ) -> None:
     manifest_path = tmp_path / "target.json"
     evidence_path = tmp_path / "rollback.json"
-    manifest_path.write_text(manifest._canonical(target()), encoding="utf-8")
     verifier = tmp_path / "verifier"
     verifier.write_text("#!/bin/sh\n", encoding="utf-8")
     verifier.chmod(0o755)
@@ -228,6 +249,12 @@ def test_success_uses_digest_chart_complete_values_and_writes_evidence(
     overlay = tmp_path / "staging.yaml"
     base.write_text("base: true\n", encoding="utf-8")
     overlay.write_text("staging: true\n", encoding="utf-8")
+    selected_target = target()
+    selected_target["values"] = [
+        {"path": str(path), "sha256": rollback.hashlib.sha256(path.read_bytes()).hexdigest()}
+        for path in (base, overlay)
+    ]
+    manifest_path.write_text(manifest._canonical(selected_target), encoding="utf-8")
     config = {
         "SUGARKUBE_CHART": f"oci://{manifest.CHART_REF}",
         "SUGARKUBE_RELEASE": "dspace",
@@ -325,6 +352,7 @@ def test_success_uses_digest_chart_complete_values_and_writes_evidence(
     result = rollback.rollback(args, runner)
     upgrade = next(command for command in commands if "upgrade" in command)
     assert f"oci://{manifest.CHART_REF}@{'sha256:' + '2' * 64}" in upgrade
+    assert f"image.digest={DIGEST}" in upgrade
     assert upgrade.count("--values") == 2
     assert str(base) in upgrade and str(overlay) in upgrade
     assert "--reuse-values" not in upgrade

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -27,7 +27,6 @@ def target(environment: str = "staging") -> dict[str, object]:
         "chartDigest": "sha256:" + "2" * 64,
         "semanticTag": "v3.2.0",
         "recordType": "final",
-        "values": [{"path": "values.yaml", "sha256": "3" * 64}],
         "environment": environment,
         "expectedDefaultChatProvider": "token-place",
         "approvedAt": "2026-07-26T12:00:00Z",
@@ -54,6 +53,9 @@ def target(environment: str = "staging") -> dict[str, object]:
 def verifier_result(**changes: object) -> dict[str, object]:
     value = {
         "schemaVersion": 1,
+        "environment": "staging",
+        "release": "dspace",
+        "namespace": "dspace",
         "applicationVersion": "3.2.0",
         "runtimeSourceRevision": SHA,
         "frontendSourceRevision": SHA,
@@ -78,14 +80,21 @@ def verifier_result(**changes: object) -> dict[str, object]:
 )
 def test_verifier_result_fails_closed(changes: dict[str, object], message: str) -> None:
     with pytest.raises(rollback.RollbackError, match=message):
-        rollback.validate_verifier_result(verifier_result(**changes), target())
+        rollback.validate_verifier_result(verifier_result(**changes), target(), "staging")
 
 
 def test_verifier_result_accepts_exact_identity_and_journeys() -> None:
-    assert rollback.validate_verifier_result(verifier_result(), target())["journeys"][1] == {
+    assert rollback.validate_verifier_result(verifier_result(), target(), "staging")["journeys"][
+        1
+    ] == {
         "name": "/chat",
         "passed": True,
     }
+
+
+def test_verifier_schema_version_rejects_boolean() -> None:
+    with pytest.raises(rollback.RollbackError, match="schemaVersion"):
+        rollback.validate_verifier_result(verifier_result(schemaVersion=True), target(), "staging")
 
 
 def test_capability_probe_is_argv_only_and_exact(tmp_path: Path) -> None:
@@ -97,23 +106,51 @@ def test_capability_probe_is_argv_only_and_exact(tmp_path: Path) -> None:
     def runner(command: list[str]) -> str:
         calls.append(command)
         return json.dumps(
-            {"schemaVersion": 1, "capabilities": list(rollback.REQUIRED_CAPABILITIES)}
+            {
+                "schemaVersion": 1,
+                "environment": "staging",
+                "release": "dspace",
+                "namespace": "dspace",
+                "capabilities": list(rollback.REQUIRED_CAPABILITIES),
+            }
         )
 
-    rollback.verifier_capabilities(executable, runner)
-    assert calls == [[str(executable), "capabilities"]]
+    rollback.verifier_capabilities(executable, "staging", "dspace", "dspace", runner)
+    assert calls == [
+        [
+            str(executable),
+            "capabilities",
+            "--environment",
+            "staging",
+            "--release",
+            "dspace",
+            "--namespace",
+            "dspace",
+        ]
+    ]
 
 
 def test_missing_or_incompatible_verifier_fails(tmp_path: Path) -> None:
     with pytest.raises(rollback.RollbackError, match="existing executable"):
-        rollback.verifier_capabilities(tmp_path / "missing")
+        rollback.verifier_capabilities(tmp_path / "missing", "staging", "dspace", "dspace")
     executable = tmp_path / "verifier"
     executable.write_text("#!/bin/sh\n", encoding="utf-8")
     executable.chmod(0o755)
     with pytest.raises(rollback.RollbackError, match="incompatible"):
         rollback.verifier_capabilities(
             executable,
-            lambda _command: json.dumps({"schemaVersion": 1, "capabilities": ["health"]}),
+            "staging",
+            "dspace",
+            "dspace",
+            lambda _command: json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "environment": "staging",
+                    "release": "dspace",
+                    "namespace": "dspace",
+                    "capabilities": ["health"],
+                }
+            ),
         )
 
 
@@ -169,7 +206,7 @@ def pod(uid: str, *, digest: str = DIGEST, terminating: bool = False) -> dict[st
         "phase": "Running",
         "ready": True,
         "terminating": terminating,
-        "images": {"dspace": f"{manifest.IMAGE_REF}:main-abcdef0"},
+        "images": {"dspace": f"{manifest.IMAGE_REF}:main-abcdef0@{DIGEST}"},
         "imageIDs": {"dspace": f"{manifest.IMAGE_REF}@{digest}"},
         "ownerReferences": [],
     }
@@ -207,13 +244,27 @@ def test_cluster_environment_rejects_partially_labeled_nodes() -> None:
         rollback.cluster_environment(lambda _command: json.dumps(nodes), "kubeconfig")
 
 
+def test_pre_state_pods_may_be_empty() -> None:
+    response = json.dumps({"items": []})
+    assert (
+        rollback.pods(
+            lambda _command: response, "kubeconfig", "dspace", "dspace", require_any=False
+        )
+        == []
+    )
+    with pytest.raises(rollback.RollbackError, match="no release-owned"):
+        rollback.pods(lambda _command: response, "kubeconfig", "dspace", "dspace")
+
+
 def test_summary_never_invents_current_chart_digest() -> None:
     current = {
         "version": 8,
         "chart": {"metadata": {"name": "dspace", "version": "3.1.0"}},
     }
-    text = rollback.summary(current, [pod("1")], target())
-    assert "current: helmRevision=8 chartVersion=3.1.0 chartDigest=unknown" in text
+    text = rollback.summary(
+        current, [pod("1")], target(), [{"path": "values.yaml", "sha256": "3" * 64}]
+    )
+    assert "helmRevision=8 chartName=dspace chartVersion=3.1.0 chartDigest=unknown" in text
     assert f"chartDigest={target()['chartDigest']}" in text
 
 
@@ -250,10 +301,6 @@ def test_success_uses_digest_chart_complete_values_and_writes_evidence(
     base.write_text("base: true\n", encoding="utf-8")
     overlay.write_text("staging: true\n", encoding="utf-8")
     selected_target = target()
-    selected_target["values"] = [
-        {"path": str(path), "sha256": rollback.hashlib.sha256(path.read_bytes()).hexdigest()}
-        for path in (base, overlay)
-    ]
     manifest_path.write_text(manifest._canonical(selected_target), encoding="utf-8")
     config = {
         "SUGARKUBE_CHART": f"oci://{manifest.CHART_REF}",
@@ -262,6 +309,7 @@ def test_success_uses_digest_chart_complete_values_and_writes_evidence(
         "SUGARKUBE_VALUES": f"{base},{overlay}",
     }
     monkeypatch.setattr(rollback.app_config, "load_config", lambda *_args: config)
+    monkeypatch.setattr(rollback, "REPO_ROOT", tmp_path)
     monkeypatch.setattr(rollback, "cluster_environment", lambda *_args: "staging")
     monkeypatch.setattr(
         rollback,
@@ -279,6 +327,13 @@ def test_success_uses_digest_chart_complete_values_and_writes_evidence(
     monkeypatch.setattr(rollback.release, "finalize", lambda *_args, **_kwargs: {})
     statuses = iter(
         [
+            {
+                "name": "dspace",
+                "namespace": "dspace",
+                "version": 7,
+                "info": {"status": "deployed", "description": "old"},
+                "chart": {"metadata": {"name": "dspace", "version": "3.1.0"}},
+            },
             {
                 "name": "dspace",
                 "namespace": "dspace",
@@ -314,7 +369,7 @@ def test_success_uses_digest_chart_complete_values_and_writes_evidence(
     pod_states = iter([[pod("1", digest="sha256:" + "9" * 64)], [pod("2")]])
     latest = [pod("2")]
 
-    def pods_stub(*_args: object) -> list[dict[str, object]]:
+    def pods_stub(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
         try:
             latest[:] = next(pod_states)
         except StopIteration:
@@ -352,9 +407,12 @@ def test_success_uses_digest_chart_complete_values_and_writes_evidence(
     result = rollback.rollback(args, runner)
     upgrade = next(command for command in commands if "upgrade" in command)
     assert f"oci://{manifest.CHART_REF}@{'sha256:' + '2' * 64}" in upgrade
-    assert f"image.digest={DIGEST}" in upgrade
+    assert f"image.tag=main-abcdef0@{DIGEST}" in upgrade
     assert upgrade.count("--values") == 2
-    assert str(base) in upgrade and str(overlay) in upgrade
+    template = next(command for command in commands if "template" in command)
+    assert [upgrade[i + 1] for i, item in enumerate(upgrade) if item == "--values"] == [
+        template[i + 1] for i, item in enumerate(template) if item == "--values"
+    ]
     assert "--reuse-values" not in upgrade
     assert result["state"] == "succeeded"
     written = json.loads(evidence_path.read_text(encoding="utf-8"))

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -124,9 +124,12 @@ def test_accepts_strict_semver_prerelease_and_build(version: str) -> None:
     value = upstream()
     value["applicationVersion"] = version
     value["semanticTag"] = f"v{version}"
-    assert manifest.candidate(
-        value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator"
-    )["applicationVersion"] == version
+    assert (
+        manifest.candidate(value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator")[
+            "applicationVersion"
+        ]
+        == version
+    )
 
 
 @pytest.mark.parametrize(
@@ -331,6 +334,7 @@ def finalize(**changes):
         "namespace": "dspace",
         "cluster_environment": "staging",
         "invocation_description": "sugarkube-release-manifest:test-reservation",
+        "values": [{"path": "values.yaml", "sha256": "3" * 64}],
     }
     arguments.update(changes)
     return manifest.finalize(**arguments)
@@ -384,9 +388,7 @@ def test_final_validation_requires_every_fixed_check(missing: str) -> None:
 @pytest.mark.parametrize("invalid", ["unknown", "imagePlatformSourceRevision[x]"])
 def test_final_validation_rejects_unknown_or_malformed_checks(invalid: str) -> None:
     value = finalize()
-    value["verificationResults"].append(
-        {"check": invalid, "passed": True, "details": "fabricated"}
-    )
+    value["verificationResults"].append({"check": invalid, "passed": True, "details": "fabricated"})
     with pytest.raises(manifest.ManifestError, match="unknown verification"):
         manifest.validate(value, True)
 
@@ -554,9 +556,7 @@ def test_reservation_is_atomic_and_bound_to_owner(tmp_path: Path) -> None:
     )
     metadata = json.loads(sidecar.read_text(encoding="utf-8"))
     assert metadata["output"] == str(output.resolve())
-    assert metadata["candidateFingerprint"] == manifest._candidate_fingerprint(
-        candidate()
-    )
+    assert metadata["candidateFingerprint"] == manifest._candidate_fingerprint(candidate())
 
 
 def test_reservation_rejects_existing_record_or_reservation(tmp_path: Path) -> None:
@@ -590,9 +590,7 @@ def test_reservation_binds_candidate_output_and_coordinates(tmp_path: Path) -> N
             )
 
 
-def test_post_reservation_failure_preserves_ownership(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_post_reservation_failure_preserves_ownership(tmp_path: Path, monkeypatch) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
     source.write_text(manifest._canonical(candidate()), encoding="utf-8")
@@ -600,9 +598,7 @@ def test_post_reservation_failure_preserves_ownership(
     monkeypatch.setattr(
         manifest,
         "preflight",
-        lambda *args, **kwargs: (_ for _ in ()).throw(
-            manifest.ManifestError("OCI failed")
-        ),
+        lambda *args, **kwargs: (_ for _ in ()).throw(manifest.ManifestError("OCI failed")),
     )
     assert (
         manifest.main(
@@ -640,6 +636,8 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
     source.write_text(manifest._canonical(candidate()), encoding="utf-8")
+    values = tmp_path / "values.yaml"
+    values.write_text("environment: staging\n", encoding="utf-8")
     owner = manifest.reserve(output, candidate(), "staging", "dspace", "dspace")
     sidecar = manifest.reservation_path(output)
     oci_results = manifest.preflight(
@@ -724,6 +722,8 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
                 "dspace",
                 "--reservation",
                 owner,
+                "--values",
+                str(values),
             ]
         )
         == 0
@@ -779,10 +779,25 @@ def test_finalize_cli_settling_failure_preserves_reservation(
 
     monkeypatch.setattr(manifest, "_run", run)
     args = [
-        "finalize", "--manifest", str(source), "--output", str(output),
-        "--environment", "staging", "--image-tag", "main-abcdef0",
-        "--chart-version", "3.2.0", "--kubeconfig", "kubeconfig",
-        "--release", "dspace", "--namespace", "dspace", "--reservation", owner,
+        "finalize",
+        "--manifest",
+        str(source),
+        "--output",
+        str(output),
+        "--environment",
+        "staging",
+        "--image-tag",
+        "main-abcdef0",
+        "--chart-version",
+        "3.2.0",
+        "--kubeconfig",
+        "kubeconfig",
+        "--release",
+        "dspace",
+        "--namespace",
+        "dspace",
+        "--reservation",
+        owner,
     ]
     assert manifest.main(args) == 2
     assert not output.exists()
@@ -824,25 +839,36 @@ def test_finalize_cli_rejects_changed_helm_binding_and_preserves_reservation(
                     status["info"]["description"] = "another invocation"
             return json.dumps(status)
         resource = command[command.index("get") + 1]
-        return json.dumps(
-            {"items": [pod("dspace-a")]} if resource == "pods" else workloads()
-        )
+        return json.dumps({"items": [pod("dspace-a")]} if resource == "pods" else workloads())
 
     monkeypatch.setattr(manifest, "_run", run)
     args = [
-        "finalize", "--manifest", str(source), "--output", str(output),
-        "--environment", "staging", "--image-tag", "main-abcdef0",
-        "--chart-version", "3.2.0", "--kubeconfig", "kubeconfig",
-        "--release", "dspace", "--namespace", "dspace", "--reservation", owner,
+        "finalize",
+        "--manifest",
+        str(source),
+        "--output",
+        str(output),
+        "--environment",
+        "staging",
+        "--image-tag",
+        "main-abcdef0",
+        "--chart-version",
+        "3.2.0",
+        "--kubeconfig",
+        "kubeconfig",
+        "--release",
+        "dspace",
+        "--namespace",
+        "dspace",
+        "--reservation",
+        owner,
     ]
     assert manifest.main(args) == 2
     assert not output.exists()
     assert manifest.reservation_path(output).exists()
 
 
-def test_public_read_only_and_reservation_dispatch(
-    tmp_path: Path, monkeypatch, capsys
-) -> None:
+def test_public_read_only_and_reservation_dispatch(tmp_path: Path, monkeypatch, capsys) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
     source.write_text(manifest._canonical(candidate()), encoding="utf-8")
@@ -853,9 +879,7 @@ def test_public_read_only_and_reservation_dispatch(
         preflight_calls.append(args)
         return real_preflight(*args, **kwargs, runner=oras_runner())
 
-    oci_results = checked_preflight(
-        candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras"
-    )
+    oci_results = checked_preflight(candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras")
     preflight_calls.clear()
     monkeypatch.setattr(manifest, "preflight", checked_preflight)
 
@@ -936,16 +960,9 @@ def test_preflight_chart_coordinate_is_not_printed_after_failed_validation(
     monkeypatch.setattr(
         manifest,
         "preflight",
-        lambda *args, **kwargs: real_preflight(
-            *args, **kwargs, runner=oras_runner()
-        ),
+        lambda *args, **kwargs: real_preflight(*args, **kwargs, runner=oras_runner()),
     )
-    assert (
-        manifest.main(
-            ["preflight", "--manifest", str(source), "--print-chart-coordinate"]
-        )
-        == 2
-    )
+    assert manifest.main(["preflight", "--manifest", str(source), "--print-chart-coordinate"]) == 2
     captured = capsys.readouterr()
     assert captured.out == ""
     assert "chartDigest" in captured.err
@@ -955,6 +972,7 @@ def test_default_evidence_path_is_stable_and_approval_unique() -> None:
     assert str(manifest.evidence_path(candidate())) == (
         "deployment-evidence/dspace/staging/main-abcdef0-20260726T120000Z.json"
     )
+
 
 @pytest.mark.parametrize(
     ("change", "message"),

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -124,12 +124,9 @@ def test_accepts_strict_semver_prerelease_and_build(version: str) -> None:
     value = upstream()
     value["applicationVersion"] = version
     value["semanticTag"] = f"v{version}"
-    assert (
-        manifest.candidate(value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator")[
-            "applicationVersion"
-        ]
-        == version
-    )
+    assert manifest.candidate(
+        value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator"
+    )["applicationVersion"] == version
 
 
 @pytest.mark.parametrize(
@@ -334,7 +331,6 @@ def finalize(**changes):
         "namespace": "dspace",
         "cluster_environment": "staging",
         "invocation_description": "sugarkube-release-manifest:test-reservation",
-        "values": [{"path": "values.yaml", "sha256": "3" * 64}],
     }
     arguments.update(changes)
     return manifest.finalize(**arguments)
@@ -355,6 +351,17 @@ def test_finalize_collects_sorted_multi_pod_identity() -> None:
         "podImageCoordinates",
         "podImageDigests",
     }
+
+
+def test_finalize_optional_digest_coordinate_is_backward_compatible() -> None:
+    assert finalize()["recordType"] == "final"
+    coordinate = f"{manifest.IMAGE_REF}:main-abcdef0@{DIGEST}"
+    selected_pods = {"items": [pod("dspace-a")]}
+    selected_pods["items"][0]["spec"]["containers"][0]["image"] = coordinate
+    assert (
+        finalize(pods_json=selected_pods, expected_image_coordinate=coordinate)["recordType"]
+        == "final"
+    )
 
 
 def test_generated_final_record_validates_through_cli(tmp_path: Path) -> None:
@@ -388,7 +395,9 @@ def test_final_validation_requires_every_fixed_check(missing: str) -> None:
 @pytest.mark.parametrize("invalid", ["unknown", "imagePlatformSourceRevision[x]"])
 def test_final_validation_rejects_unknown_or_malformed_checks(invalid: str) -> None:
     value = finalize()
-    value["verificationResults"].append({"check": invalid, "passed": True, "details": "fabricated"})
+    value["verificationResults"].append(
+        {"check": invalid, "passed": True, "details": "fabricated"}
+    )
     with pytest.raises(manifest.ManifestError, match="unknown verification"):
         manifest.validate(value, True)
 
@@ -556,7 +565,9 @@ def test_reservation_is_atomic_and_bound_to_owner(tmp_path: Path) -> None:
     )
     metadata = json.loads(sidecar.read_text(encoding="utf-8"))
     assert metadata["output"] == str(output.resolve())
-    assert metadata["candidateFingerprint"] == manifest._candidate_fingerprint(candidate())
+    assert metadata["candidateFingerprint"] == manifest._candidate_fingerprint(
+        candidate()
+    )
 
 
 def test_reservation_rejects_existing_record_or_reservation(tmp_path: Path) -> None:
@@ -590,7 +601,9 @@ def test_reservation_binds_candidate_output_and_coordinates(tmp_path: Path) -> N
             )
 
 
-def test_post_reservation_failure_preserves_ownership(tmp_path: Path, monkeypatch) -> None:
+def test_post_reservation_failure_preserves_ownership(
+    tmp_path: Path, monkeypatch
+) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
     source.write_text(manifest._canonical(candidate()), encoding="utf-8")
@@ -598,7 +611,9 @@ def test_post_reservation_failure_preserves_ownership(tmp_path: Path, monkeypatc
     monkeypatch.setattr(
         manifest,
         "preflight",
-        lambda *args, **kwargs: (_ for _ in ()).throw(manifest.ManifestError("OCI failed")),
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            manifest.ManifestError("OCI failed")
+        ),
     )
     assert (
         manifest.main(
@@ -636,8 +651,6 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
     source.write_text(manifest._canonical(candidate()), encoding="utf-8")
-    values = tmp_path / "values.yaml"
-    values.write_text("environment: staging\n", encoding="utf-8")
     owner = manifest.reserve(output, candidate(), "staging", "dspace", "dspace")
     sidecar = manifest.reservation_path(output)
     oci_results = manifest.preflight(
@@ -722,8 +735,6 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
                 "dspace",
                 "--reservation",
                 owner,
-                "--values",
-                str(values),
             ]
         )
         == 0
@@ -779,25 +790,10 @@ def test_finalize_cli_settling_failure_preserves_reservation(
 
     monkeypatch.setattr(manifest, "_run", run)
     args = [
-        "finalize",
-        "--manifest",
-        str(source),
-        "--output",
-        str(output),
-        "--environment",
-        "staging",
-        "--image-tag",
-        "main-abcdef0",
-        "--chart-version",
-        "3.2.0",
-        "--kubeconfig",
-        "kubeconfig",
-        "--release",
-        "dspace",
-        "--namespace",
-        "dspace",
-        "--reservation",
-        owner,
+        "finalize", "--manifest", str(source), "--output", str(output),
+        "--environment", "staging", "--image-tag", "main-abcdef0",
+        "--chart-version", "3.2.0", "--kubeconfig", "kubeconfig",
+        "--release", "dspace", "--namespace", "dspace", "--reservation", owner,
     ]
     assert manifest.main(args) == 2
     assert not output.exists()
@@ -839,36 +835,25 @@ def test_finalize_cli_rejects_changed_helm_binding_and_preserves_reservation(
                     status["info"]["description"] = "another invocation"
             return json.dumps(status)
         resource = command[command.index("get") + 1]
-        return json.dumps({"items": [pod("dspace-a")]} if resource == "pods" else workloads())
+        return json.dumps(
+            {"items": [pod("dspace-a")]} if resource == "pods" else workloads()
+        )
 
     monkeypatch.setattr(manifest, "_run", run)
     args = [
-        "finalize",
-        "--manifest",
-        str(source),
-        "--output",
-        str(output),
-        "--environment",
-        "staging",
-        "--image-tag",
-        "main-abcdef0",
-        "--chart-version",
-        "3.2.0",
-        "--kubeconfig",
-        "kubeconfig",
-        "--release",
-        "dspace",
-        "--namespace",
-        "dspace",
-        "--reservation",
-        owner,
+        "finalize", "--manifest", str(source), "--output", str(output),
+        "--environment", "staging", "--image-tag", "main-abcdef0",
+        "--chart-version", "3.2.0", "--kubeconfig", "kubeconfig",
+        "--release", "dspace", "--namespace", "dspace", "--reservation", owner,
     ]
     assert manifest.main(args) == 2
     assert not output.exists()
     assert manifest.reservation_path(output).exists()
 
 
-def test_public_read_only_and_reservation_dispatch(tmp_path: Path, monkeypatch, capsys) -> None:
+def test_public_read_only_and_reservation_dispatch(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
     source.write_text(manifest._canonical(candidate()), encoding="utf-8")
@@ -879,7 +864,9 @@ def test_public_read_only_and_reservation_dispatch(tmp_path: Path, monkeypatch, 
         preflight_calls.append(args)
         return real_preflight(*args, **kwargs, runner=oras_runner())
 
-    oci_results = checked_preflight(candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras")
+    oci_results = checked_preflight(
+        candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras"
+    )
     preflight_calls.clear()
     monkeypatch.setattr(manifest, "preflight", checked_preflight)
 
@@ -960,9 +947,16 @@ def test_preflight_chart_coordinate_is_not_printed_after_failed_validation(
     monkeypatch.setattr(
         manifest,
         "preflight",
-        lambda *args, **kwargs: real_preflight(*args, **kwargs, runner=oras_runner()),
+        lambda *args, **kwargs: real_preflight(
+            *args, **kwargs, runner=oras_runner()
+        ),
     )
-    assert manifest.main(["preflight", "--manifest", str(source), "--print-chart-coordinate"]) == 2
+    assert (
+        manifest.main(
+            ["preflight", "--manifest", str(source), "--print-chart-coordinate"]
+        )
+        == 2
+    )
     captured = capsys.readouterr()
     assert captured.out == ""
     assert "chartDigest" in captured.err
@@ -972,7 +966,6 @@ def test_default_evidence_path_is_stable_and_approval_unique() -> None:
     assert str(manifest.evidence_path(candidate())) == (
         "deployment-evidence/dspace/staging/main-abcdef0-20260726T120000Z.json"
     )
-
 
 @pytest.mark.parametrize(
     ("change", "message"),


### PR DESCRIPTION
### Motivation

The DSPACE incident demonstrated that `helm rollback <revision>` can report success while retaining mutable image references or unintended frontend artifacts. Recovery must instead deploy previously approved immutable chart and image coordinates and prove what became active.

This PR adds a DSPACE-only, fail-closed manifest rollback operation. Refs #2327.

### Summary

- Add `just dspace-manifest-rollback` and `scripts/dspace_manifest_rollback.py` with explicit `env`, finalized `manifest`, new `evidence`, `verifier`, and production `confirm` inputs.
- Accept only strict finalized DSPACE release evidence; reject candidate records, unknown fields, wrong environments, mutable/semantic deployment tags, inconsistent coordinates, and OCI provenance mismatches.
- Resolve the complete environment values chain, read each file once, record portable paths and SHA-256 hashes, and stage those exact bytes for both Helm rendering and upgrade.
- Complete all read-only checks before evidence reservation or mutation:
  - selected cluster environment;
  - verifier capabilities;
  - digest-qualified Helm render;
  - current Helm and pod state;
  - fresh image/chart digest and source-revision OCI checks;
  - deterministic current-versus-target summary;
  - exact rendered no-op rejection.
- Require production confirmation exactly matching `dspace:prod:<target-full-source-sha>`; staging remains non-interactive.
- Atomically reserve a unique evidence destination, bind the invocation through Helm’s description, and perform `helm upgrade` with:
  - the approved digest-qualified OCI chart;
  - the complete staged values chain;
  - the application image pinned by immutable tag and digest;
  - no `--reuse-values`, semantic deployment tag, or `helm rollback`.
- Prove the resulting release through stable advanced Helm revision, chart identity, Deployment/ReplicaSet ownership, pod replacement/readiness, named `dspace` container coordinates and resolved digest, OCI revision metadata, and strict runtime/frontend/provider/journey verification.
- Preserve immutable success evidence or secret-safe failed evidence with the precise failure stage, mutation risk, Sugarkube revision, and reconciliation-oriented Helm and pod diagnostics.
- Add a narrow backward-compatible finalizer hook for validating the digest-qualified application image coordinate.
- Update the DSPACE runbook and deployment contract so manifest rollback is the primary recovery path while `helm history` remains investigative and Tokenplace’s helper remains Tokenplace-only.

### Values boundary

Finalized records produced by PR #2350 do not contain historical values coordinates. This operation therefore restores the manifest-approved chart and image artifacts using the selected environment’s current byte-staged and hashed values chain. Historical configuration replay is deliberately deferred and documented; the target historical manifest is never modified.

### Verifier dependency

The verifier contract is argv-only and strictly validates exact JSON fields and types for:

- application version;
- full runtime source revision;
- frontend source revision;
- approved default provider;
- passing public journeys, including `/chat`.

Verifier output, response bodies, credentials, headers, and secrets are never logged.

Real production rollback remains unavailable until [DSPACE #4732](https://github.com/democratizedspace/dspace/issues/4732) supplies runtime/frontend identity and [DSPACE #4733](https://github.com/democratizedspace/dspace/issues/4733) supplies the remote public-journey implementation. Both dependencies remain open, so this PR uses `Refs #2327`, not `Closes #2327`.

### Scope and compatibility

- Limited to the new DSPACE rollback path.
- No production pins, artifacts, release tags, promotion gates, or live systems are changed.
- No behavior change to unrelated applications.
- Existing release-manifest and Tokenplace rollback callers remain compatible.

### Verification

- `python3 -m pytest -q tests/test_release_manifest.py tests/test_generic_app_just_recipes.py tests/test_manifest_rollback.py` — 303 passed.
- Targeted rollback safety subset — 22 passed, 13 deselected.
- Latest-head Test Suite 9224 — 1,759 passed, 53 skipped.
- Latest-head `ci` 2365 — Bash tests passed; Python tests reported 1,791 passed and 21 skipped; Codecov upload succeeded.
- Latest-head Docs 5523, Spellcheck 3837, Verify Justfile formatting 1956, and pi-image 3321 — passed.
- `python3 -m flake8 scripts/dspace_manifest_rollback.py tests/test_manifest_rollback.py` — passed.
- `just --unstable --fmt --check` — passed.
- `linkchecker --no-warnings README.md docs/` — 202 links checked successfully.
- `git diff --check` and task-level repository secret scans — passed.
- Codecov reports 84.59% patch coverage with 55 changed lines uncovered; the prompt-required fail-closed rollback matrix is directly covered by deterministic stubbed tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66a4fec9c0832fabf9cb8dd9b9a5d9)