### PR TITLE
DSPACE: Add fail-closed manifest-based rollback (dspace-manifest-rollback)

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -240,6 +240,15 @@ and retries.
 These recipes are implemented in the root `justfile` and use the app config
 lookup order above.
 
+DSPACE rollback is deliberately DSPACE-only rather than a new generic app
+primitive. `just dspace-manifest-rollback` accepts historical finalized
+evidence, derives every coordinate from it, and completes cluster, values-chain,
+render, OCI, current-state, verifier-capability, and production-confirmation
+preflight before reserving evidence. It then uses a digest-qualified `helm
+upgrade` and proves the resulting runtime; it never reuses values or invokes
+Helm revision rollback. The DSPACE runbook defines the strict verifier contract
+and its temporary runtime-identity and remote-smoke dependency.
+
 Environment-scoped mutating recipes (`app-deploy`, `app-redeploy`,
 `app-promote-prod`, and the compatibility deploy/redeploy/promote wrappers) guard
 Helm with the connected cluster's Kubernetes-reported identity. The source of

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -328,38 +328,51 @@ curl -fsS https://democratized.space/livez
 
 ## Rollback
 
-Rollback by deploying the previous known-good immutable image tag with the generic redeploy command and an approved environment-specific candidate for that release. Use a unique `evidence=` path if evidence for the tag already exists; occupied paths are rejected before Helm runs.
-Do not infer or generate a rollback manifest automatically; that future
-automation is tracked in #2327.
+The primary recovery procedure is a manifest rollback from a **previously
+finalized** DSPACE release-evidence record. Candidate approvals, independent
+image/chart overrides, mutable tags, and semantic tags are rejected. Staging is
+non-interactive:
 
 ```bash
-APP_TAG=main-REPLACE_PREVIOUS_SHORTSHA
-STAGING_ROLLBACK_MANIFEST=deployment-candidates/dspace/previous-release-staging.json
-PROD_ROLLBACK_MANIFEST=deployment-candidates/dspace/previous-release-prod.json
+just dspace-manifest-rollback env=staging \
+  manifest=deployment-evidence/dspace/staging/previous-final.json \
+  evidence=deployment-evidence/dspace/staging/rollback-20260727.json \
+  verifier=/absolute/path/to/dspace-runtime-verifier
 ```
 
 ```bash
-just app-redeploy app=dspace env=staging tag="$APP_TAG" manifest="$STAGING_ROLLBACK_MANIFEST" evidence=deployment-evidence/dspace/staging/"$APP_TAG"-rollback.json
+TARGET_SHA=$(jq -r .sourceRevision deployment-evidence/dspace/prod/previous-final.json)
+just dspace-manifest-rollback env=prod \
+  manifest=deployment-evidence/dspace/prod/previous-final.json \
+  evidence=deployment-evidence/dspace/prod/rollback-20260727.json \
+  verifier=/absolute/path/to/dspace-runtime-verifier \
+  confirm="dspace:prod:${TARGET_SHA}"
 ```
 
-```bash
-just app-redeploy app=dspace env=prod tag="$APP_TAG" manifest="$PROD_ROLLBACK_MANIFEST" evidence=deployment-evidence/dspace/prod/"$APP_TAG"-rollback.json
-```
+Production requires the literal `dspace:prod:<full-source-SHA>` token; generic
+confirmation is invalid. Before reserving evidence or mutating the cluster, the
+command verifies cluster identity, every ordered values file and hash,
+digest-qualified rendering, fresh OCI provenance, verifier capabilities, and
+current Helm/pod state. It prints a current-versus-target summary and rejects a
+no-op. Mutation is a digest-qualified `helm upgrade` with every explicit values
+file and the approved immutable tag—never `--reuse-values`, a semantic tag, or
+`helm rollback <revision>`.
 
-Rollback by Helm revision is still available through the existing parameterized helper. Set `ROLLBACK_ENV=staging` instead when intentionally rolling back staging.
+Success requires an advanced stable Helm revision, release ownership, replaced
+pod identities when artifacts differ, no terminating pods, Running/Ready pods,
+exact image IDs, and strict runtime/frontend/provider/public-journey proof
+(including `/chat`). Evidence is non-overwritable. A post-reservation failure
+leaves its sidecar for manual reconciliation and never automatically retries.
+`helm history dspace -n dspace` remains investigative; revision rollback is not
+the default. `tokenplace-rollback` is Tokenplace-only and must not target DSPACE.
 
-```bash
-HELM_REVISION=12
-```
-
-```bash
-ROLLBACK_ENV=prod
-just kubeconfig-env "$ROLLBACK_ENV"
-```
-
-```bash
-just tokenplace-rollback release=dspace namespace=dspace revision="$HELM_REVISION" env="$ROLLBACK_ENV"
-```
+The verifier's argv-only `capabilities` mode must advertise the exact typed
+contract; `verify` receives non-secret expectations on stdin and must return
+application version, full runtime and frontend SHAs, provider, and passing
+`home` and `chat` journeys. Real production rollback remains unavailable until
+DSPACE [#4732](https://github.com/democratizedspace/dspace/issues/4732) and
+[#4733](https://github.com/democratizedspace/dspace/issues/4733) supply that
+proof. Availability-only checks and inferred frontend identity fail closed.
 
 ## Troubleshooting
 

--- a/justfile
+++ b/justfile
@@ -1946,6 +1946,25 @@ dspace-oci-redeploy env='staging' tag='' manifest='' evidence='':
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
     "${delegate[@]}"
 
+# Restore DSPACE only from previously finalized immutable release evidence.
+dspace-manifest-rollback env='staging' manifest='' evidence='' verifier='' confirm='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    if [ -z {{ quote(manifest) }} ] || [ -z {{ quote(evidence) }} ] || [ -z {{ quote(verifier) }} ]; then
+      echo 'Usage: just dspace-manifest-rollback env=<staging|prod> manifest=<final.json> evidence=<rollback.json> verifier=<executable> [confirm=<exact-prod-token>]' >&2
+      exit 2
+    fi
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell --app dspace --env {{ quote(env) }})"
+    export KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config}"
+    cluster_environment="$(just --justfile "{{ justfile_directory() }}/justfile" cluster-env-detect kubeconfig="${KUBECONFIG}")"
+    python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py" \
+      --environment {{ quote(env) }} --manifest {{ quote(manifest) }} \
+      --evidence {{ quote(evidence) }} --verifier {{ quote(verifier) }} \
+      --confirm {{ quote(confirm) }} --values "${SUGARKUBE_VALUES}" \
+      --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
+      --cluster-environment "${cluster_environment}" --kubeconfig "${KUBECONFIG}"
+
 # Dump dspace and Traefik logs for debugging HTTP 500s.
 dspace-debug-logs namespace='dspace':
     #!/usr/bin/env bash

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Fail-closed DSPACE rollback from immutable finalized release evidence."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts import dspace_release_manifest as release  # noqa: E402
+
+SCHEMA_VERSION = 1
+VERIFIER_CAPABILITIES = {
+    "schemaVersion": 1,
+    "capabilities": [
+        "applicationVersion",
+        "runtimeSourceRevision",
+        "frontendSourceRevision",
+        "defaultProvider",
+        "publicJourneys",
+    ],
+}
+JOURNEYS = ("home", "chat")
+
+
+def canonical(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def run(command: list[str], *, input_text: str | None = None) -> str:
+    completed = subprocess.run(command, input=input_text, text=True, capture_output=True)
+    if completed.returncode:
+        # Verifier/command output can contain credentials.  Report only the
+        # executable and status, never stdout, stderr, headers, or bodies.
+        raise release.ManifestError(f"command failed ({command[0]}, exit {completed.returncode})")
+    return completed.stdout
+
+
+def json_command(command: list[str], *, input_text: str | None = None) -> dict[str, Any]:
+    try:
+        value = json.loads(run(command, input_text=input_text))
+    except json.JSONDecodeError as exc:
+        raise release.ManifestError(f"invalid JSON returned by {command[0]}") from exc
+    if not isinstance(value, dict):
+        raise release.ManifestError(f"{command[0]} returned non-object JSON")
+    return value
+
+
+def validate_capabilities(value: dict[str, Any]) -> None:
+    if value != VERIFIER_CAPABILITIES:
+        raise release.ManifestError("verifier does not implement the required exact capabilities")
+
+
+def validate_verifier_result(value: dict[str, Any], target: dict[str, Any]) -> dict[str, Any]:
+    expected_fields = {
+        "schemaVersion",
+        "applicationVersion",
+        "runtimeSourceRevision",
+        "frontendSourceRevision",
+        "defaultProvider",
+        "journeys",
+    }
+    if set(value) != expected_fields or value.get("schemaVersion") != 1:
+        raise release.ManifestError("verifier result has missing or unknown fields")
+    expected = {
+        "applicationVersion": target["applicationVersion"],
+        "runtimeSourceRevision": target["sourceRevision"],
+        "frontendSourceRevision": target["sourceRevision"],
+        "defaultProvider": target["expectedDefaultChatProvider"],
+    }
+    for field, wanted in expected.items():
+        if not isinstance(value.get(field), str) or value[field] != wanted:
+            raise release.ManifestError(f"verifier {field} mismatch")
+    journeys = value.get("journeys")
+    if not isinstance(journeys, list) or len(journeys) != len(JOURNEYS):
+        raise release.ManifestError("verifier journeys must contain the exact required journeys")
+    seen: set[str] = set()
+    for item in journeys:
+        if not isinstance(item, dict) or set(item) != {"name", "passed"}:
+            raise release.ManifestError("verifier journey result has invalid fields")
+        if (
+            item.get("name") not in JOURNEYS
+            or item["name"] in seen
+            or item.get("passed") is not True
+        ):
+            raise release.ManifestError("a required public journey failed or was duplicated")
+        seen.add(item["name"])
+    if seen != set(JOURNEYS):
+        raise release.ManifestError("verifier omitted a required public journey")
+    return value
+
+
+def values_evidence(raw: str, root: Path) -> tuple[list[Path], list[dict[str, str]]]:
+    if not raw:
+        raise release.ManifestError("the complete values-file chain is required")
+    paths: list[Path] = []
+    evidence = []
+    for entry in raw.split(","):
+        supplied = Path(entry)
+        path = supplied if supplied.is_absolute() else root / supplied
+        try:
+            content = path.read_bytes()
+        except OSError as exc:
+            raise release.ManifestError(f"values file is unavailable: {entry}") from exc
+        paths.append(path)
+        try:
+            portable = path.resolve().relative_to(root.resolve()).as_posix()
+        except ValueError:
+            portable = path.resolve().as_posix()
+        evidence.append({"path": portable, "sha256": hashlib.sha256(content).hexdigest()})
+    return paths, evidence
+
+
+def pods(value: dict[str, Any]) -> list[dict[str, Any]]:
+    result = []
+    for item in value.get("items", []):
+        meta, spec, status = item.get("metadata", {}), item.get("spec", {}), item.get("status", {})
+        result.append(
+            {
+                "name": meta.get("name"),
+                "uid": meta.get("uid"),
+                "startTime": status.get("startTime"),
+                "terminating": meta.get("deletionTimestamp") is not None,
+                "images": [c.get("image") for c in spec.get("containers", [])],
+                "imageIDs": [c.get("imageID") for c in status.get("containerStatuses", [])],
+            }
+        )
+    return sorted(result, key=lambda item: str(item["name"]))
+
+
+def fingerprint(value: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        (json.dumps(value, indent=2, ensure_ascii=True) + "\n").encode()
+    ).hexdigest()
+
+
+def reserve(path: Path, target_fingerprint: str, invocation: str) -> Path:
+    path = path.expanduser().resolve(strict=False)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        raise release.ManifestError(f"refusing to overwrite existing record: {path}")
+    sidecar = path.with_name(path.name + release.RESERVATION_SUFFIX)
+    payload = {
+        "schemaVersion": 1,
+        "operation": "dspaceManifestRollback",
+        "output": str(path),
+        "targetManifestFingerprint": target_fingerprint,
+        "invocationId": invocation,
+    }
+    try:
+        fd = os.open(sidecar, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError as exc:
+        raise release.ManifestError(f"evidence destination is already reserved: {sidecar}") from exc
+    with os.fdopen(fd, "w", encoding="utf-8") as stream:
+        stream.write(json.dumps(payload, indent=2) + "\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    return sidecar
+
+
+def write_evidence(path: Path, sidecar: Path, value: dict[str, Any]) -> None:
+    release._write_new(path.expanduser().resolve(strict=False), value)
+    sidecar.unlink()
+
+
+def helm_status(helm: str, release_name: str, namespace: str) -> dict[str, Any]:
+    return json_command([helm, "status", release_name, "--namespace", namespace, "-o", "json"])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--environment", required=True, choices=("staging", "prod"))
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--evidence", required=True, type=Path)
+    parser.add_argument("--verifier", required=True)
+    parser.add_argument("--confirm", default="")
+    parser.add_argument("--values", required=True)
+    parser.add_argument("--release", default="dspace")
+    parser.add_argument("--namespace", default="dspace")
+    parser.add_argument("--cluster-environment", required=True)
+    parser.add_argument("--kubeconfig", required=True)
+    parser.add_argument("--helm", default="helm")
+    parser.add_argument("--kubectl", default="kubectl")
+    parser.add_argument("--oras", default="oras")
+    args = parser.parse_args(argv)
+    reserved: Path | None = None
+    mutated = False
+    try:
+        target = release._object(args.manifest)
+        release.validate(target, True)
+        if target["environment"] != args.environment:
+            raise release.ManifestError("target manifest environment does not match selection")
+        if args.cluster_environment != args.environment:
+            raise release.ManifestError("connected cluster environment does not match selection")
+        candidate = release.candidate_from_final(target)
+        preflight = release.preflight(
+            candidate,
+            release.IMAGE_REF,
+            "oci://" + release.CHART_REF,
+            args.oras,
+            environment=args.environment,
+        )
+        root = Path(__file__).resolve().parents[1]
+        value_paths, value_records = values_evidence(args.values, root)
+        verifier = Path(args.verifier)
+        if not verifier.is_file() or not os.access(verifier, os.X_OK):
+            raise release.ManifestError("verifier must name an available executable file")
+        validate_capabilities(json_command([str(verifier), "capabilities"]))
+        chart = release.chart_coordinate(candidate)
+        template = [
+            args.helm,
+            "template",
+            args.release,
+            chart,
+            "--namespace",
+            args.namespace,
+            "--set-string",
+            f"image.tag={target['imageTag']}",
+        ]
+        for path in value_paths:
+            template.extend(["-f", str(path)])
+        run(template)
+        before_helm = helm_status(args.helm, args.release, args.namespace)
+        before_pods_json = json_command(
+            [
+                args.kubectl,
+                "--kubeconfig",
+                args.kubeconfig,
+                "-n",
+                args.namespace,
+                "get",
+                "pods",
+                "-l",
+                f"app.kubernetes.io/instance={args.release}",
+                "-o",
+                "json",
+            ]
+        )
+        before = pods(before_pods_json)
+        summary = {
+            "current": {
+                "helmRevision": before_helm.get("version"),
+                "chartName": before_helm.get("chart", {}).get("metadata", {}).get("name"),
+                "chartVersion": before_helm.get("chart", {}).get("metadata", {}).get("version"),
+                "pods": before,
+            },
+            "target": {
+                "chartVersion": target["chartVersion"],
+                "chartDigest": target["chartDigest"],
+                "imageTag": target["imageTag"],
+                "imageDigest": target["imageDigest"],
+                "sourceRevision": target["sourceRevision"],
+            },
+        }
+        print(json.dumps(summary, sort_keys=True))
+        current_images = {image for pod in before for image in pod["images"]}
+        if (
+            before_helm.get("chart", {}).get("metadata", {}).get("version")
+            == target["chartVersion"]
+            and current_images == {f"{release.IMAGE_REF}:{target['imageTag']}"}
+            and all(
+                release._image_id_digest(image_id) == target["imageDigest"]
+                for pod in before
+                for image_id in pod["imageIDs"]
+            )
+        ):
+            raise release.ManifestError("refusing exact no-op rollback")
+        confirmation = f"dspace:prod:{target['sourceRevision']}"
+        if args.environment == "prod" and args.confirm != confirmation:
+            raise release.ManifestError(
+                f"production confirmation must exactly equal {confirmation}"
+            )
+        started_at = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        invocation = str(uuid.uuid4())
+        target_fp = fingerprint(target)
+        reserved = reserve(args.evidence, target_fp, invocation)
+        description = f"sugarkube-dspace-manifest-rollback:{invocation}:{reserved}"
+        upgrade = [
+            args.helm,
+            "upgrade",
+            args.release,
+            chart,
+            "--namespace",
+            args.namespace,
+            "--description",
+            description,
+            "--set-string",
+            f"image.tag={target['imageTag']}",
+            "--wait",
+        ]
+        for path in value_paths:
+            upgrade.extend(["-f", str(path)])
+        mutated = True
+        run(upgrade)
+        run(
+            [
+                args.kubectl,
+                "--kubeconfig",
+                args.kubeconfig,
+                "-n",
+                args.namespace,
+                "rollout",
+                "status",
+                "deployment/dspace",
+                "--timeout=5m",
+            ]
+        )
+        post_pods_json = release._settle_release_pods(
+            [
+                args.kubectl,
+                "--kubeconfig",
+                args.kubeconfig,
+                "-n",
+                args.namespace,
+                "get",
+                "pods",
+                "-l",
+                f"app.kubernetes.io/instance={args.release}",
+                "-o",
+                "json",
+            ],
+            runner=run,
+        )
+        workloads = json_command(
+            [
+                args.kubectl,
+                "--kubeconfig",
+                args.kubeconfig,
+                "-n",
+                args.namespace,
+                "get",
+                "replicasets,deployments",
+                "-l",
+                f"app.kubernetes.io/instance={args.release}",
+                "-o",
+                "json",
+            ]
+        )
+        after_helm = helm_status(args.helm, args.release, args.namespace)
+        after = pods(post_pods_json)
+        if (
+            not isinstance(before_helm.get("version"), int)
+            or after_helm.get("version") <= before_helm["version"]
+        ):
+            raise release.ManifestError("Helm revision did not advance")
+        finalized = release.finalize(
+            candidate,
+            after_helm,
+            post_pods_json,
+            workloads,
+            preflight,
+            environment=args.environment,
+            image_tag=target["imageTag"],
+            chart_version=target["chartVersion"],
+            release=args.release,
+            namespace=args.namespace,
+            cluster_environment=args.cluster_environment,
+            invocation_description=description,
+        )
+        expected_changed = (
+            current_images != {f"{release.IMAGE_REF}:{target['imageTag']}"}
+            or before_helm.get("chart", {}).get("metadata", {}).get("version")
+            != target["chartVersion"]
+        )
+        old_ids = {(p["uid"], p["startTime"]) for p in before}
+        new_ids = {(p["uid"], p["startTime"]) for p in after}
+        if expected_changed and (old_ids & new_ids or old_ids == new_ids):
+            raise release.ManifestError(
+                "target artifact changed but serving pod identities were not replaced"
+            )
+        request = {
+            "schemaVersion": 1,
+            "applicationVersion": target["applicationVersion"],
+            "sourceRevision": target["sourceRevision"],
+            "defaultProvider": target["expectedDefaultChatProvider"],
+            "requiredJourneys": list(JOURNEYS),
+        }
+        verification = validate_verifier_result(
+            json_command([str(verifier), "verify"], input_text=canonical(request)), target
+        )
+        stable = helm_status(args.helm, args.release, args.namespace)
+        if (
+            stable.get("version") != after_helm.get("version")
+            or stable.get("info", {}).get("status") != "deployed"
+        ):
+            raise release.ManifestError("Helm revision changed during evidence collection")
+        completed_at = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        evidence = {
+            "schemaVersion": SCHEMA_VERSION,
+            "operation": "dspaceManifestRollback",
+            "targetManifestFingerprint": target_fp,
+            "environment": args.environment,
+            "release": args.release,
+            "namespace": args.namespace,
+            "invocationId": invocation,
+            "target": {
+                k: target[k]
+                for k in (
+                    "chartVersion",
+                    "chartDigest",
+                    "imageTag",
+                    "imageDigest",
+                    "sourceRevision",
+                    "applicationVersion",
+                    "expectedDefaultChatProvider",
+                )
+            },
+            "values": value_records,
+            "sugarkubeRevision": run(["git", "-C", str(root), "rev-parse", "HEAD"]).strip(),
+            "before": {"helmRevision": before_helm["version"], "pods": before},
+            "after": {"helmRevision": after_helm["version"], "pods": after},
+            "verification": {
+                "oci": preflight,
+                "cluster": finalized["verificationResults"],
+                "runtime": verification,
+            },
+            "startedAt": started_at,
+            "completedAt": completed_at,
+        }
+        write_evidence(args.evidence, reserved, evidence)
+        return 0
+    except (release.ManifestError, OSError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        if reserved is not None or mutated:
+            print(
+                "Cluster state may have changed; reservation and diagnostics are preserved "
+                "for reconciliation. Do not retry automatically.",
+                file=sys.stderr,
+            )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -220,6 +220,19 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
     return value
 
 
+def candidate_from_final(value: dict[str, Any]) -> dict[str, Any]:
+    """Project an immutable finalized record through the candidate validators.
+
+    Rollback deliberately accepts only historical final evidence.  The OCI
+    preflight operates on candidate coordinates, so keep one strict projection
+    here rather than teaching rollback a second, weaker manifest schema.
+    """
+    validate(value, True)
+    projected = {field: value[field] for field in CANDIDATE_FIELDS}
+    projected["recordType"] = "candidate"
+    return validate(projected, False)
+
+
 def _canonical(value: dict[str, Any]) -> str:
     return json.dumps(value, indent=2, ensure_ascii=True) + "\n"
 

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -1,0 +1,194 @@
+"""Focused unit tests for the DSPACE manifest rollback safety boundary."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import dspace_manifest_rollback as rollback
+from scripts import dspace_release_manifest as manifest
+
+SHA = "abcdef0123456789abcdef0123456789abcdef01"
+DIGEST = "sha256:" + "1" * 64
+
+
+def final(environment: str = "staging") -> dict[str, object]:
+    value = manifest.candidate(
+        {
+            "schemaVersion": 1,
+            "app": "dspace",
+            "applicationVersion": "3.2.0",
+            "sourceRevision": SHA,
+            "imageTag": "main-abcdef0",
+            "imageDigest": DIGEST,
+            "chartVersion": "3.2.0",
+            "chartDigest": "sha256:" + "2" * 64,
+            "semanticTag": "v3.2.0",
+        },
+        environment,
+        "token-place",
+        "2026-07-26T12:00:00Z",
+        "operator",
+    )
+    value.update(
+        recordType="final",
+        helmRevision=4,
+        pods=[
+            {"name": "dspace-a", "startTime": "2026-07-26T12:01:00Z", "imageID": "repo@" + DIGEST}
+        ],
+        runtimeSourceRevision=SHA,
+        runtimeSourceRevisionMethod=manifest.RUNTIME_METHOD,
+        verificationResults=[
+            {"check": check, "passed": True, "details": "verified"}
+            for check in sorted(manifest.FINAL_FIXED_CHECKS)
+        ]
+        + [{"check": "imagePlatformSourceRevision[0]", "passed": True, "details": "verified"}],
+    )
+    return manifest.validate(value, True)
+
+
+def verifier_result(**changes: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "schemaVersion": 1,
+        "applicationVersion": "3.2.0",
+        "runtimeSourceRevision": SHA,
+        "frontendSourceRevision": SHA,
+        "defaultProvider": "token-place",
+        "journeys": [{"name": "home", "passed": True}, {"name": "chat", "passed": True}],
+    }
+    value.update(changes)
+    return value
+
+
+def test_final_projection_rejects_candidate() -> None:
+    candidate = manifest.candidate_from_final(final())
+    with pytest.raises(manifest.ManifestError, match="missing fields"):
+        manifest.candidate_from_final(candidate)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("imageTag", "latest"),
+        ("imageTag", "v3.2.0"),
+        ("environment", "dev"),
+        ("sourceRevision", "f" * 40),
+    ],
+)
+def test_final_projection_rejects_mutable_or_inconsistent_coordinates(
+    field: str, value: str
+) -> None:
+    target = final()
+    target[field] = value
+    with pytest.raises(manifest.ManifestError):
+        manifest.candidate_from_final(target)
+
+
+def test_values_chain_is_ordered_portable_and_hashed(tmp_path: Path) -> None:
+    (tmp_path / "a.yaml").write_text("one\n")
+    (tmp_path / "b.yaml").write_text("two\n")
+    paths, records = rollback.values_evidence("a.yaml,b.yaml", tmp_path)
+    assert paths == [tmp_path / "a.yaml", tmp_path / "b.yaml"]
+    assert [item["path"] for item in records] == ["a.yaml", "b.yaml"]
+    assert all(len(item["sha256"]) == 64 for item in records)
+
+
+def test_missing_values_file_fails() -> None:
+    with pytest.raises(manifest.ManifestError, match="values file is unavailable"):
+        rollback.values_evidence("missing.yaml", Path("/"))
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"runtimeSourceRevision": "f" * 40},
+        {"frontendSourceRevision": "f" * 40},
+        {"defaultProvider": "openai"},
+        {"journeys": [{"name": "home", "passed": True}, {"name": "chat", "passed": False}]},
+        {"extra": True},
+    ],
+)
+def test_verifier_result_fails_closed(changes: dict[str, object]) -> None:
+    with pytest.raises(manifest.ManifestError):
+        rollback.validate_verifier_result(verifier_result(**changes), final())
+
+
+def test_verifier_result_accepts_exact_contract() -> None:
+    assert (
+        rollback.validate_verifier_result(verifier_result(), final())["frontendSourceRevision"]
+        == SHA
+    )
+
+
+def test_incompatible_capabilities_fail() -> None:
+    with pytest.raises(manifest.ManifestError, match="exact capabilities"):
+        rollback.validate_capabilities({"schemaVersion": 1, "capabilities": ["availability"]})
+
+
+def test_reservation_collision_and_immutable_write(tmp_path: Path) -> None:
+    output = tmp_path / "rollback.json"
+    sidecar = rollback.reserve(output, "a" * 64, "invocation")
+    assert sidecar.exists() and not output.exists()
+    with pytest.raises(manifest.ManifestError, match="already reserved"):
+        rollback.reserve(output, "a" * 64, "other")
+    rollback.write_evidence(output, sidecar, {"schemaVersion": 1})
+    assert json.loads(output.read_text()) == {"schemaVersion": 1}
+    assert not sidecar.exists()
+    with pytest.raises(manifest.ManifestError, match="overwrite"):
+        rollback.reserve(output, "a" * 64, "third")
+
+
+def test_missing_manifest_fails_before_reservation(tmp_path: Path) -> None:
+    output = tmp_path / "rollback.json"
+    assert (
+        rollback.main(
+            [
+                "--environment",
+                "staging",
+                "--manifest",
+                str(tmp_path / "missing.json"),
+                "--evidence",
+                str(output),
+                "--verifier",
+                str(tmp_path / "missing-verifier"),
+                "--values",
+                "missing.yaml",
+                "--cluster-environment",
+                "staging",
+                "--kubeconfig",
+                "unused",
+            ]
+        )
+        == 1
+    )
+    assert not output.exists()
+    assert not Path(str(output) + manifest.RESERVATION_SUFFIX).exists()
+
+
+def test_pod_summary_uses_uid_start_time_and_all_coordinates() -> None:
+    result = rollback.pods(
+        {
+            "items": [
+                {
+                    "metadata": {"name": "p", "uid": "u"},
+                    "spec": {"containers": [{"image": "repo:tag"}]},
+                    "status": {
+                        "startTime": "time",
+                        "containerStatuses": [{"imageID": "repo@" + DIGEST}],
+                    },
+                }
+            ]
+        }
+    )
+    assert result == [
+        {
+            "name": "p",
+            "uid": "u",
+            "startTime": "time",
+            "terminating": False,
+            "images": ["repo:tag"],
+            "imageIDs": ["repo@" + DIGEST],
+        }
+    ]


### PR DESCRIPTION
### Motivation

- Replace the brittle, revision-based DSPACE rollback path with a manifest-driven, fail-closed operation that only restores previously finalized immutable releases and proves what became active. (Refs #2327)
- Ensure rollbacks derive every deployment coordinate from approved evidence, re-run fresh OCI provenance, and refuse mutable/semantic overrides or implicit confirmations.
- Provide an operator-facing, DSPACE-only command that performs strict preflight, atomic evidence reservation, controlled mutation, and immutable post-rollback proofing.

### Description

- Add a new rollback orchestrator `scripts/dspace_manifest_rollback.py` and a `just` recipe `dspace-manifest-rollback` that accepts `env`, `manifest`, `evidence`, `verifier`, `confirm` and the resolved values chain and kubeconfig; the recipe selects the cluster identity and invokes the orchestrator. The orchestrator implements strict preflight → reserve → controlled `helm upgrade` → evidence flow with no `--reuse-values`, no semantic tag use, and no `helm rollback`.
- Reuse and extend the existing manifest validation by adding `candidate_from_final()` in `scripts/dspace_release_manifest.py` to project a finalized record through the candidate validator and exercise the same OCI preflight logic (no duplicated/weaker validation).
- Implement a small, exact JSON verifier contract (capabilities + verify modes) that runtime/verifier implementations must satisfy, run the verifier in a safe argv/stdin mode, and validate typed results (application version, runtime/frontend source SHAs, default provider, and required public journeys such as `/chat`) before mutation.
- Enforce a read-only preflight that: asserts cluster environment, resolves the ordered values-file chain and records portable paths + SHA256 hashes, re-runs OCI checks for the chart/image/revision, renders the digest-qualified chart with the values chain, captures current Helm release and pod state (names/UIDs/start times/imageIDs), prints concise current-vs-target summary, and rejects exact no-op rollbacks.
- Atomically reserve an evidence sidecar (`*.reservation`) before mutation, bind the Helm mutation via `--description`, perform `helm upgrade` with the digest-qualified chart and explicit values files, wait for rollout, then require and record post-rollback proofs (advanced Helm revision, chart identity, release ownership, pod replacement/readiness, exact image IDs, OCI revision metadata, and verifier journey results). On success write a non-overwritable evidence record; on failure preserve reservation and diagnostics and fail non-zero.
- Update documentation: `docs/apps/dspace.md` now makes manifest-based rollback the primary recovery procedure, gives staging and production examples, documents the exact production confirmation token shape, and explains the verifier dependency (DSPACE #4732/#4733); `docs/app_deployment_contract.md` explains the DSPACE-only scope and safety properties.
- Add focused unit tests in `tests/test_manifest_rollback.py` to cover finalized-record projection, mutable/inconsistent coordinate rejection, values-chain hashing and portability, strict verifier contract, reservation collision and immutable evidence write, and that missing manifest fails before reservation.

### Testing

- `python3 -m pytest -q tests/test_release_manifest.py tests/test_generic_app_just_recipes.py tests/test_manifest_rollback.py` — all tests passed (284 passed).
- `python3 -m pytest -q tests/test_manifest_rollback.py` — focused tests passed (17 passed).
- Formatting and static checks: `python3 -m black --check scripts/dspace_manifest_rollback.py tests/test_manifest_rollback.py`, `pycodestyle --max-line-length=100 ...`, and `python3 -m compileall scripts/dspace_manifest_rollback.py` were executed as part of the workflow and final formatting checks completed successfully in the run used to produce the changes.
- Repo-level checks: `just --unstable --fmt --check`, `just --list`, `git diff --check`, `git diff --cached | python3 scripts/scan-secrets.py`, and `linkchecker --no-warnings README.md docs/` were executed; `linkchecker` found 202 links and 0 errors.
- Environment caveats: `pyspelling -c .spellcheck.yaml` could not run here because the environment lacks the `aspell` binary, and `pre-commit run --all-files` was not run in this environment (tooling not available); these checks should be run in CI or a maintainer workstation before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66a501d8ac832f9cd337c9a95dde51)