### PR TITLE
Fix staging Grafana port-forward parser

### DIFF
--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -149,7 +149,9 @@ is not rollout evidence.
   and cluster identity first, reads the existing Secret without printing it,
   uses a mode-`0600` temporary netrc, and asks this invocation's `kubectl` to
   bind an ephemeral `127.0.0.1` port. Authentication begins only after that
-  child reports the exact owned forwarding endpoint. Success, failure, and
+  child reports the exact owned forwarding endpoint. The right side of
+  kubectl's forwarding message is the resolved pod/container port, so it may
+  differ from the requested Service port `80`. Success, failure, and
   interruption all terminate and wait for the child and remove the netrc and
   temporary directory. HTTP 401/403 responses fail immediately with redacted
   diagnostics; only connection and readiness failures are retried. It performs

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -248,7 +248,7 @@ dashboard_verify() (
   require_tools kubectl python3 curl base64 sleep
   print_resolved staging
   assert_context
-  local response body http_status port="" line
+  local response body http_status port="" remote_port line
   local -a port_forward_lines=()
   local verify_pid="" verify_tmp
   verify_tmp="$(mktemp -d -t sugarkube-grafana-verify.XXXXXX)"
@@ -286,8 +286,12 @@ dashboard_verify() (
     kill -0 "${verify_pid}" 2>/dev/null || port_forward_stopped
     mapfile -t port_forward_lines <"${verify_tmp}/port-forward.log"
     for line in "${port_forward_lines[@]}"; do
-      if [[ "${line}" =~ ^Forwarding\ from\ 127\.0\.0\.1:([1-9][0-9]{0,4})\ -\>\ 80$ ]] && ((10#${BASH_REMATCH[1]} <= 65535)); then
+      if [[ "${line}" =~ ^Forwarding\ from\ 127\.0\.0\.1:([1-9][0-9]{0,4})\ -\>\ ([1-9][0-9]{0,4})$ ]]; then
         port="${BASH_REMATCH[1]}"
+        remote_port="${BASH_REMATCH[2]}"
+        if ((10#${port} > 65535 || 10#${remote_port} > 65535)); then
+          port=""
+        fi
       fi
     done
     [[ -z "${port}" ]] || break

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -4,6 +4,8 @@ import re
 import subprocess
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 VERSION = ROOT / "platform" / "observability" / "helm" / "kube-prometheus-stack.version"
 COMMON = ROOT / "platform" / "observability" / "helm" / "kube-prometheus-stack.values.common.yaml"
@@ -613,7 +615,12 @@ def test_verify_deadline_uses_latest_safe_diagnostics_without_extra_request(tmp_
     assert "activeTargets" not in result.stderr and "Traceback" not in result.stderr
 
 
-def run_dashboard_verifier(tmp_path, mode="success", context="sugar-staging"):
+def run_dashboard_verifier(
+    tmp_path,
+    mode="success",
+    context="sugar-staging",
+    forward_line="Forwarding from 127.0.0.1:43127 -> 3000",
+):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(parents=True)
     audit = tmp_path / "audit"
@@ -632,7 +639,7 @@ case "$*" in
   *"get secret grafana-admin-credentials"*"admin-pass""word"*) printf placeholder | base64 ;;
   *"port-forward"*)
     [ "$MODE" != forward-fail ] || exit 42
-    echo 'Forwarding from 127.0.0.1:43127 -> 80'
+    echo "$FORWARD_LINE"
     echo $$ > "$FORWARD_PID"
     trap 'echo terminated > "$PID_FILE"; exit 0' TERM INT
     if [ "$MODE" = forward-exits-after-ready ]; then
@@ -679,6 +686,7 @@ esac
         "CONTEXT": context,
         "PID_FILE": str(pid_file),
         "FORWARD_PID": str(tmp_path / "port-forward.pid"),
+        "FORWARD_LINE": forward_line,
         "READY_SECRET": str(tmp_path / "secret-requested"),
         "TMPDIR": str(tmp_path),
         "KUBECONFIG": str(tmp_path / "kubeconfig"),
@@ -701,6 +709,41 @@ def test_dashboard_verifier_runtime_owns_port_and_cleans_up(tmp_path):
     assert "http://127.0.0.1:43127/" in audit
     assert not list(tmp_path.glob("sugarkube-grafana-verify.*"))
     assert pid_file.read_text(encoding="utf-8").strip() == "terminated"
+
+
+@pytest.mark.parametrize("remote_port", ["3000", "12345", "80"])
+def test_dashboard_verifier_accepts_resolved_remote_port(tmp_path, remote_port):
+    result, audit, _ = run_dashboard_verifier(
+        tmp_path, forward_line=f"Forwarding from 127.0.0.1:43127 -> {remote_port}"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "get secret" in audit
+
+
+@pytest.mark.parametrize(
+    "forward_line",
+    [
+        "Forwarding from 127.0.0.1:0 -> 3000",
+        "Forwarding from 127.0.0.1:65536 -> 3000",
+        "Forwarding from 127.0.0.1:43127 -> 0",
+        "Forwarding from 127.0.0.1:43127 -> 65536",
+        "Forwarding from 0.0.0.0:43127 -> 3000",
+        "Forwarding from [::1]:43127 -> 3000",
+        "Forwarding from localhost:43127 -> 3000",
+        "Forwarding from 127.0.0.1:43127 ->",
+        "noise Forwarding from 127.0.0.1:43127 -> 3000",
+        "Forwarding from 127.0.0.1:43127 -> 3000 noise",
+    ],
+)
+def test_dashboard_verifier_rejects_invalid_forwarding_lines_before_secret_access(
+    tmp_path, forward_line
+):
+    result, audit, _ = run_dashboard_verifier(tmp_path, forward_line=forward_line)
+    assert result.returncode != 0
+    assert "get secret" not in audit
+    assert "curl " not in audit
+    assert forward_line not in result.stdout + result.stderr
+    assert not list(tmp_path.glob("sugarkube-grafana-verify.*"))
 
 
 def test_dashboard_verifier_checks_context_before_secret_access(tmp_path):


### PR DESCRIPTION
### Motivation

The staging dashboard verifier assumed `kubectl port-forward` would report the requested Grafana Service port `80` on the right-hand side of its readiness line. In practice, kubectl reports the resolved pod/container port:

~~~text
Forwarding from 127.0.0.1:45553 -> 3000
~~~

This caused `just observability-dashboard-verify env=staging` to reject a valid forwarding endpoint even though Grafana and the provisioned dashboard were healthy.

### Changes

- Parse the exactly anchored form `Forwarding from 127.0.0.1:<local> -> <resolved-remote>`.
- Validate both captured ports as decimal integers in the inclusive range `1..65535`.
- Treat the right-hand port as kubectl’s informational resolved target port without hard-coding either `80` or `3000`.
- Update the kubectl test stub’s normal output to use the observed `-> 3000` form.
- Add focused regression coverage for:
  - resolved remote ports `3000`, `12345`, and `80`;
  - zero and out-of-range local and remote ports;
  - non-loopback, IPv6, hostname, missing-port, prefixed, and suffixed output;
  - rejection before Secret or curl access;
  - diagnostic redaction and temporary-directory cleanup.
- Document why kubectl’s reported port may differ from Grafana Service port `80`.

### Safety guarantees preserved

- Port-forwarding remains bound only to `--address=127.0.0.1`.
- Only an exactly anchored IPv4 loopback forwarding line is accepted.
- Child ownership and liveness checks remain unchanged.
- Grafana credentials are not retrieved until an acceptable forwarding line is observed and the child is still running.
- Success, failure, interruption, and timeout paths still terminate and wait for the child and remove the mode-`0600` netrc and temporary directory.
- Credentials, API bodies, curl diagnostics, and raw port-forward diagnostics remain redacted.
- Verification remains read-only and preserves the staging-context and cluster-identity guards.
- No dashboard JSON, Helm values, release configuration, provisioning, production configuration, Flux ownership, Secrets, persistence, or exposure settings were changed.

### Verification

- ✅ `bash -n scripts/observability_helm.sh`
- ✅ `pytest -q tests/test_observability_helm.py -k dashboard_verifier` — 21 passed, 29 deselected
- ✅ `pytest -q tests/test_observability_helm.py tests/test_observability_dashboard.py` — 86 passed
- ✅ `ruff check tests/test_observability_helm.py tests/test_observability_dashboard.py`
- ✅ `black --check tests/test_observability_helm.py tests/test_observability_dashboard.py`
- ✅ `pyspelling -c .spellcheck.yaml`
- ✅ `linkchecker --no-warnings README.md docs/` — 202 links checked, 0 errors
- ✅ `git diff --check 1ab7f58d3526846ae8d2a5d70605f05a61543c59...HEAD`
- ✅ `git diff 1ab7f58d3526846ae8d2a5d70605f05a61543c59...HEAD | ./scripts/scan-secrets.py`
- ⚠️ `pre-commit run --all-files` encountered unrelated, pre-existing repository-wide trailing-whitespace, end-of-file, multi-document/templated YAML, and flake8 failures. Hook-generated edits outside this PR’s scope were discarded and the worktree remained clean.
- ✅ Latest-head GitHub Actions passed: `ci`, `Test Suite`, `Docs`, `Spellcheck`, and `pi-image`.
- No live cluster was accessed or mutated during implementation or verification.

### Post-merge acceptance

No Helm upgrade is necessary because the dashboard is already deployed.

~~~bash
cd ~/sugarkube
git status --short
git pull --ff-only
just kubeconfig-env env=staging

just observability-dashboard-verify env=staging

kubectl -n monitoring delete pod \
  -l 'app.kubernetes.io/name=grafana,app.kubernetes.io/instance=kube-prometheus-stack'

kubectl -n monitoring rollout status \
  deployment/kube-prometheus-stack-grafana \
  --timeout=20m

just observability-dashboard-verify env=staging
~~~

------

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66b6a56d3c832f8f2bc3c2b2aa30b8)