### PR TITLE
Fix staging Grafana port-forward parser

### DIFF
--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -149,7 +149,9 @@ is not rollout evidence.
   and cluster identity first, reads the existing Secret without printing it,
   uses a mode-`0600` temporary netrc, and asks this invocation's `kubectl` to
   bind an ephemeral `127.0.0.1` port. Authentication begins only after that
-  child reports the exact owned forwarding endpoint. Success, failure, and
+  child reports the exact owned forwarding endpoint. The right side of kubectl's
+  forwarding message is the resolved pod or container port, so it may differ
+  from the requested Grafana Service port `80`. Success, failure, and
   interruption all terminate and wait for the child and remove the netrc and
   temporary directory. HTTP 401/403 responses fail immediately with redacted
   diagnostics; only connection and readiness failures are retried. It performs

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -248,7 +248,7 @@ dashboard_verify() (
   require_tools kubectl python3 curl base64 sleep
   print_resolved staging
   assert_context
-  local response body http_status port="" line
+  local response body http_status port="" remote_port="" line
   local -a port_forward_lines=()
   local verify_pid="" verify_tmp
   verify_tmp="$(mktemp -d -t sugarkube-grafana-verify.XXXXXX)"
@@ -286,14 +286,16 @@ dashboard_verify() (
     kill -0 "${verify_pid}" 2>/dev/null || port_forward_stopped
     mapfile -t port_forward_lines <"${verify_tmp}/port-forward.log"
     for line in "${port_forward_lines[@]}"; do
-      if [[ "${line}" =~ ^Forwarding\ from\ 127\.0\.0\.1:([1-9][0-9]{0,4})\ -\>\ 80$ ]] && ((10#${BASH_REMATCH[1]} <= 65535)); then
+      if [[ "${line}" =~ ^Forwarding\ from\ 127\.0\.0\.1:([1-9][0-9]{0,4})\ -\>\ ([1-9][0-9]{0,4})$ ]] &&
+        ((10#${BASH_REMATCH[1]} <= 65535 && 10#${BASH_REMATCH[2]} <= 65535)); then
         port="${BASH_REMATCH[1]}"
+        remote_port="${BASH_REMATCH[2]}"
       fi
     done
     [[ -z "${port}" ]] || break
     sleep 1
   done
-  [[ -n "${port}" ]] || { echo "ERROR: Grafana port-forward did not establish an owned loopback listener (diagnostics redacted)." >&2; return 12; }
+  [[ -n "${port}" && -n "${remote_port}" ]] || { echo "ERROR: Grafana port-forward did not establish an owned loopback listener (diagnostics redacted)." >&2; return 12; }
   kill -0 "${verify_pid}" 2>/dev/null || port_forward_stopped
 
   # Keep decoded credentials out of argv, stdout, diagnostics, and persistent files.

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -613,7 +613,12 @@ def test_verify_deadline_uses_latest_safe_diagnostics_without_extra_request(tmp_
     assert "activeTargets" not in result.stderr and "Traceback" not in result.stderr
 
 
-def run_dashboard_verifier(tmp_path, mode="success", context="sugar-staging"):
+def run_dashboard_verifier(
+    tmp_path,
+    mode="success",
+    context="sugar-staging",
+    forwarding_line="Forwarding from 127.0.0.1:43127 -> 3000",
+):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(parents=True)
     audit = tmp_path / "audit"
@@ -632,7 +637,7 @@ case "$*" in
   *"get secret grafana-admin-credentials"*"admin-pass""word"*) printf placeholder | base64 ;;
   *"port-forward"*)
     [ "$MODE" != forward-fail ] || exit 42
-    echo 'Forwarding from 127.0.0.1:43127 -> 80'
+    echo "$FORWARDING_LINE"
     echo $$ > "$FORWARD_PID"
     trap 'echo terminated > "$PID_FILE"; exit 0' TERM INT
     if [ "$MODE" = forward-exits-after-ready ]; then
@@ -680,6 +685,7 @@ esac
         "PID_FILE": str(pid_file),
         "FORWARD_PID": str(tmp_path / "port-forward.pid"),
         "READY_SECRET": str(tmp_path / "secret-requested"),
+        "FORWARDING_LINE": forwarding_line,
         "TMPDIR": str(tmp_path),
         "KUBECONFIG": str(tmp_path / "kubeconfig"),
     }
@@ -701,6 +707,52 @@ def test_dashboard_verifier_runtime_owns_port_and_cleans_up(tmp_path):
     assert "http://127.0.0.1:43127/" in audit
     assert not list(tmp_path.glob("sugarkube-grafana-verify.*"))
     assert pid_file.read_text(encoding="utf-8").strip() == "terminated"
+
+
+def test_dashboard_verifier_accepts_valid_resolved_remote_ports(tmp_path):
+    for remote_port in (3000, 8443, 80):
+        result, audit, _ = run_dashboard_verifier(
+            tmp_path / str(remote_port),
+            forwarding_line=f"Forwarding from 127.0.0.1:43127 -> {remote_port}",
+        )
+        assert result.returncode == 0, result.stderr
+        assert "get secret" in audit
+
+
+def test_dashboard_verifier_rejects_invalid_ports_before_secret_access(tmp_path):
+    invalid_lines = (
+        "Forwarding from 127.0.0.1:0 -> 3000",
+        "Forwarding from 127.0.0.1:65536 -> 3000",
+        "Forwarding from 127.0.0.1:43127 -> 0",
+        "Forwarding from 127.0.0.1:43127 -> 65536",
+        "Forwarding from 127.0.0.1:port -> 3000",
+        "Forwarding from 127.0.0.1:43127 -> port",
+    )
+    for index, forwarding_line in enumerate(invalid_lines):
+        result, audit, _ = run_dashboard_verifier(
+            tmp_path / str(index), forwarding_line=forwarding_line
+        )
+        assert result.returncode != 0
+        assert "get secret" not in audit
+
+
+def test_dashboard_verifier_rejects_non_loopback_and_malformed_lines_before_secret_access(
+    tmp_path,
+):
+    invalid_lines = (
+        "Forwarding from 0.0.0.0:43127 -> 3000",
+        "Forwarding from [::1]:43127 -> 3000",
+        "Forwarding from localhost:43127 -> 3000",
+        "Forwarding from 127.0.0.1:43127 -> 3000 trailing",
+        "noise Forwarding from 127.0.0.1:43127 -> 3000",
+        "Forwarding from 127.0.0.1:43127",
+    )
+    for index, forwarding_line in enumerate(invalid_lines):
+        result, audit, _ = run_dashboard_verifier(
+            tmp_path / str(index), forwarding_line=forwarding_line
+        )
+        assert result.returncode != 0
+        assert "get secret" not in audit
 
 
 def test_dashboard_verifier_checks_context_before_secret_access(tmp_path):


### PR DESCRIPTION
### Motivation

- The dashboard verifier assumed kubectl would report `-> 80` and rejected the real `Forwarding from 127.0.0.1:<local> -> 3000` form, causing `just observability-dashboard-verify env=staging` to fail despite Grafana being reachable. 

### Description

- Update the port-forward parser in `scripts/observability_helm.sh` to anchor exactly on `127.0.0.1` and capture both local and remote ports with a single regex. 
- Validate both captured ports as decimal integers in the inclusive range `1..65535` and treat the right-hand port as kubectl’s informational resolved target rather than hard-coding `80` or `3000`. 
- Update the kubectl test stub and add focused regression tests in `tests/test_observability_helm.py` to exercise valid resolved ports (`3000`, `8443`, and `80`), invalid ports, non-loopback/IPv6/hostname/malformed lines, and pre-Secret rejection behaviors. 
- Add a short docs note in `docs/observability-operations.md` explaining that kubectl reports the resolved pod/container port on the right side of the forwarding message and may differ from Service port `80` while preserving the existing redaction/cleanup threat model.

### Testing

- Ran `bash -n scripts/observability_helm.sh` and the syntax check passed. 
- Ran `pytest -q tests/test_observability_helm.py -k dashboard_verifier` and observed `11 passed, 29 deselected`. 
- Ran `pytest -q tests/test_observability_helm.py tests/test_observability_dashboard.py` and observed `76 passed` in the workspace. 
- Ran `ruff` and `black --check` on the touched tests and they passed; ran `pyspelling` and `linkchecker` successfully in this environment. 
- Attempted `pre-commit run --all-files` but it reported unrelated, pre-existing repository-wide YAML/flake8 issues and the whitespace hooks modified unrelated tracked files (those unrelated edits were not included in this PR). 

Post-merge acceptance (run exactly):

```bash
cd ~/sugarkube
git status --short
git pull --ff-only
just kubeconfig-env env=staging

just observability-dashboard-verify env=staging

kubectl -n monitoring delete pod \
  -l 'app.kubernetes.io/name=grafana,app.kubernetes.io/instance=kube-prometheus-stack'

kubectl -n monitoring rollout status \
  deployment/kube-prometheus-stack-grafana \
  --timeout=20m

just observability-dashboard-verify env=staging
```

Notes: this is a minimal, focused fix that preserves all existing security, cleanup, liveness, and credential-redaction guarantees and does not mutate cluster state during verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66b6af2aac832fb77b677af0674f42)