### PR TITLE
Fix staging Grafana port-forward parser

### DIFF
--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -148,13 +148,15 @@ is not rollout evidence.
   env=staging` checks the stable UID through Grafana's API. It validates context
   and cluster identity first, reads the existing Secret without printing it,
   uses a mode-`0600` temporary netrc, and asks this invocation's `kubectl` to
-  bind an ephemeral `127.0.0.1` port. Authentication begins only after that
-  child reports the exact owned forwarding endpoint. Success, failure, and
-  interruption all terminate and wait for the child and remove the netrc and
-  temporary directory. HTTP 401/403 responses fail immediately with redacted
-  diagnostics; only connection and readiness failures are retried. It performs
-  no Helm or Kubernetes mutation. A ConfigMap check alone is not acceptance
-  evidence.
+  bind an ephemeral `127.0.0.1` port. The right side of `kubectl`'s forwarding
+  message is the resolved pod/container port, so it may differ from the Grafana
+  Service port `80`. Authentication begins only after that child reports the
+  exact owned forwarding endpoint with valid local and resolved port numbers.
+  Success, failure, and interruption all terminate and wait for the child and
+  remove the netrc and temporary directory. HTTP 401/403 responses fail
+  immediately with redacted diagnostics; only connection and readiness
+  failures are retried. It performs no Helm or Kubernetes mutation. A ConfigMap
+  check alone is not acceptance evidence.
 - **Failed workloads:** use `just observability-status env=staging`, `kubectl -n monitoring describe`, and pod logs to identify image pulls, scheduling, resources, or PVC failures.
 
 ## Rollback

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -248,7 +248,7 @@ dashboard_verify() (
   require_tools kubectl python3 curl base64 sleep
   print_resolved staging
   assert_context
-  local response body http_status port="" line
+  local response body http_status port="" remote_port="" line
   local -a port_forward_lines=()
   local verify_pid="" verify_tmp
   verify_tmp="$(mktemp -d -t sugarkube-grafana-verify.XXXXXX)"
@@ -286,14 +286,16 @@ dashboard_verify() (
     kill -0 "${verify_pid}" 2>/dev/null || port_forward_stopped
     mapfile -t port_forward_lines <"${verify_tmp}/port-forward.log"
     for line in "${port_forward_lines[@]}"; do
-      if [[ "${line}" =~ ^Forwarding\ from\ 127\.0\.0\.1:([1-9][0-9]{0,4})\ -\>\ 80$ ]] && ((10#${BASH_REMATCH[1]} <= 65535)); then
+      if [[ "${line}" =~ ^Forwarding\ from\ 127\.0\.0\.1:([0-9]{1,5})\ -\>\ ([0-9]{1,5})$ ]] &&
+        ((10#${BASH_REMATCH[1]} >= 1 && 10#${BASH_REMATCH[1]} <= 65535 && 10#${BASH_REMATCH[2]} >= 1 && 10#${BASH_REMATCH[2]} <= 65535)); then
         port="${BASH_REMATCH[1]}"
+        remote_port="${BASH_REMATCH[2]}"
       fi
     done
     [[ -z "${port}" ]] || break
     sleep 1
   done
-  [[ -n "${port}" ]] || { echo "ERROR: Grafana port-forward did not establish an owned loopback listener (diagnostics redacted)." >&2; return 12; }
+  [[ -n "${port}" && -n "${remote_port}" ]] || { echo "ERROR: Grafana port-forward did not establish an owned loopback listener (diagnostics redacted)." >&2; return 12; }
   kill -0 "${verify_pid}" 2>/dev/null || port_forward_stopped
 
   # Keep decoded credentials out of argv, stdout, diagnostics, and persistent files.

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -613,7 +613,12 @@ def test_verify_deadline_uses_latest_safe_diagnostics_without_extra_request(tmp_
     assert "activeTargets" not in result.stderr and "Traceback" not in result.stderr
 
 
-def run_dashboard_verifier(tmp_path, mode="success", context="sugar-staging"):
+def run_dashboard_verifier(
+    tmp_path,
+    mode="success",
+    context="sugar-staging",
+    forwarding_line="Forwarding from 127.0.0.1:43127 -> 3000",
+):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(parents=True)
     audit = tmp_path / "audit"
@@ -632,7 +637,7 @@ case "$*" in
   *"get secret grafana-admin-credentials"*"admin-pass""word"*) printf placeholder | base64 ;;
   *"port-forward"*)
     [ "$MODE" != forward-fail ] || exit 42
-    echo 'Forwarding from 127.0.0.1:43127 -> 80'
+    echo "$FORWARDING_LINE"
     echo $$ > "$FORWARD_PID"
     trap 'echo terminated > "$PID_FILE"; exit 0' TERM INT
     if [ "$MODE" = forward-exits-after-ready ]; then
@@ -679,6 +684,7 @@ esac
         "CONTEXT": context,
         "PID_FILE": str(pid_file),
         "FORWARD_PID": str(tmp_path / "port-forward.pid"),
+        "FORWARDING_LINE": forwarding_line,
         "READY_SECRET": str(tmp_path / "secret-requested"),
         "TMPDIR": str(tmp_path),
         "KUBECONFIG": str(tmp_path / "kubeconfig"),
@@ -701,6 +707,47 @@ def test_dashboard_verifier_runtime_owns_port_and_cleans_up(tmp_path):
     assert "http://127.0.0.1:43127/" in audit
     assert not list(tmp_path.glob("sugarkube-grafana-verify.*"))
     assert pid_file.read_text(encoding="utf-8").strip() == "terminated"
+
+
+def test_dashboard_verifier_accepts_resolved_remote_ports(tmp_path):
+    for remote_port in (3000, 12345, 80):
+        result, audit, _ = run_dashboard_verifier(
+            tmp_path / str(remote_port),
+            forwarding_line=f"Forwarding from 127.0.0.1:43127 -> {remote_port}",
+        )
+        assert result.returncode == 0, result.stderr
+        assert "get secret" in audit
+
+
+def test_dashboard_verifier_rejects_invalid_ports_before_secret_access(tmp_path):
+    lines = (
+        "Forwarding from 127.0.0.1:0 -> 3000",
+        "Forwarding from 127.0.0.1:65536 -> 3000",
+        "Forwarding from 127.0.0.1:43127 -> 0",
+        "Forwarding from 127.0.0.1:43127 -> 65536",
+    )
+    for index, line in enumerate(lines):
+        result, audit, _ = run_dashboard_verifier(tmp_path / str(index), forwarding_line=line)
+        assert result.returncode != 0
+        assert "get secret" not in audit
+
+
+def test_dashboard_verifier_rejects_untrusted_or_malformed_lines_before_secret_access(tmp_path):
+    lines = (
+        "Forwarding from 0.0.0.0:43127 -> 3000",
+        "Forwarding from [::1]:43127 -> 3000",
+        "Forwarding from localhost:43127 -> 3000",
+        "Forwarding from 127.0.0.1: -> 3000",
+        "Forwarding from 127.0.0.1:43127 ->",
+        "Forwarding from 127.0.0.1:port -> 3000",
+        "Forwarding from 127.0.0.1:43127 -> port",
+        "noise Forwarding from 127.0.0.1:43127 -> 3000",
+        "Forwarding from 127.0.0.1:43127 -> 3000 noise",
+    )
+    for index, line in enumerate(lines):
+        result, audit, _ = run_dashboard_verifier(tmp_path / str(index), forwarding_line=line)
+        assert result.returncode != 0
+        assert "get secret" not in audit
 
 
 def test_dashboard_verifier_checks_context_before_secret_access(tmp_path):


### PR DESCRIPTION
### Motivation

- The staging dashboard verifier rejected a real `kubectl` readiness line like `Forwarding from 127.0.0.1:45553 -> 3000` because the parser assumed the right-hand port would always be the Service port `80`, while `kubectl` reports the resolved pod/container port there.  
- The change is a focused fix to accept kubectl's resolved remote target port while preserving existing security, cleanup, and fail-closed guarantees.

### Description

- Update `dashboard_verify()` in `scripts/observability_helm.sh` to parse exactly `Forwarding from 127.0.0.1:<local-port> -> <resolved-remote-port>` and capture both ports as decimal fields.  
- Validate both captured ports are integers in the inclusive range `1..65535` and require both to be present before accessing Secrets or credentials.  
- Preserve the existing behavior that the port-forward command still targets `service/${RELEASE}-grafana :80`, binds only to `--address=127.0.0.1`, maintains owned child PID/liveness checks, defers credential retrieval until readiness, and performs full cleanup and netrc redaction on every exit path.  
- Update the test harness in `tests/test_observability_helm.py` to emit the realistic `-> 3000` forwarding line by default and add regression tests that: accept `3000` and other valid resolved ports (including `80`), reject zero and out-of-range ports, reject non-loopback/IPv6/hostname/malformed lines before Secret access, and retain existing checks for child exit-after-ready, redaction, auth failure, malformed API, interruption, and cleanup.  
- Add a narrow docs clarification in `docs/observability-operations.md` explaining that the right-hand side of kubectl’s forwarding message is the resolved pod/container port and may differ from the Service port `80`.

### Testing

- Ran `bash -n scripts/observability_helm.sh` and static shell checks with no syntax errors.  
- Ran focused unit tests and linters: `pytest -q tests/test_observability_helm.py -k dashboard_verifier` (11 passed, 29 deselected), `pytest -q tests/test_observability_helm.py tests/test_observability_dashboard.py` (all selected tests passed), `ruff` and `black --check` against the modified tests passed, `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` passed.  
- `pre-commit run --all-files` was attempted; repository-wide pre-existing trailing-whitespace/EOF fixes were observed and reverted, and `check-yaml` flagged existing multi-document Kubernetes manifests (pre-existing, not caused by this change).  
- No live cluster was accessed or mutated during verification.  

Post-merge acceptance (run these exact commands; no Helm upgrade is required because the dashboard is already deployed):

```bash
cd ~/sugarkube
git status --short
git pull --ff-only
just kubeconfig-env env=staging

just observability-dashboard-verify env=staging

kubectl -n monitoring delete pod \
  -l 'app.kubernetes.io/name=grafana,app.kubernetes.io/instance=kube-prometheus-stack'

kubectl -n monitoring rollout status \
  deployment/kube-prometheus-stack-grafana \
  --timeout=20m

just observability-dashboard-verify env=staging
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66b6b26648832fb671f33f441a40b9)