### PR TITLE
Fix staging Grafana resolved port parsing

### DIFF
--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -149,12 +149,14 @@ is not rollout evidence.
   and cluster identity first, reads the existing Secret without printing it,
   uses a mode-`0600` temporary netrc, and asks this invocation's `kubectl` to
   bind an ephemeral `127.0.0.1` port. Authentication begins only after that
-  child reports the exact owned forwarding endpoint. Success, failure, and
-  interruption all terminate and wait for the child and remove the netrc and
-  temporary directory. HTTP 401/403 responses fail immediately with redacted
-  diagnostics; only connection and readiness failures are retried. It performs
-  no Helm or Kubernetes mutation. A ConfigMap check alone is not acceptance
-  evidence.
+  child reports the exact owned forwarding endpoint. The right side of that
+  message is the pod/container port resolved by kubectl and can differ from the
+  requested Grafana Service port `80`; both reported ports must be valid.
+  Success, failure, and interruption all terminate and wait for the child and
+  remove the netrc and temporary directory. HTTP 401/403 responses fail
+  immediately with redacted diagnostics; only connection and readiness
+  failures are retried. It performs no Helm or Kubernetes mutation. A ConfigMap
+  check alone is not acceptance evidence.
 - **Failed workloads:** use `just observability-status env=staging`, `kubectl -n monitoring describe`, and pod logs to identify image pulls, scheduling, resources, or PVC failures.
 
 ## Rollback

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -248,7 +248,7 @@ dashboard_verify() (
   require_tools kubectl python3 curl base64 sleep
   print_resolved staging
   assert_context
-  local response body http_status port="" line
+  local response body http_status port="" remote_port="" line
   local -a port_forward_lines=()
   local verify_pid="" verify_tmp
   verify_tmp="$(mktemp -d -t sugarkube-grafana-verify.XXXXXX)"
@@ -286,8 +286,12 @@ dashboard_verify() (
     kill -0 "${verify_pid}" 2>/dev/null || port_forward_stopped
     mapfile -t port_forward_lines <"${verify_tmp}/port-forward.log"
     for line in "${port_forward_lines[@]}"; do
-      if [[ "${line}" =~ ^Forwarding\ from\ 127\.0\.0\.1:([1-9][0-9]{0,4})\ -\>\ 80$ ]] && ((10#${BASH_REMATCH[1]} <= 65535)); then
+      if [[ "${line}" =~ ^Forwarding\ from\ 127\.0\.0\.1:([0-9]{1,5})\ -\>\ ([0-9]{1,5})$ ]]; then
         port="${BASH_REMATCH[1]}"
+        remote_port="${BASH_REMATCH[2]}"
+        if ((10#${port} < 1 || 10#${port} > 65535 || 10#${remote_port} < 1 || 10#${remote_port} > 65535)); then
+          port=""
+        fi
       fi
     done
     [[ -z "${port}" ]] || break

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -4,6 +4,8 @@ import re
 import subprocess
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 VERSION = ROOT / "platform" / "observability" / "helm" / "kube-prometheus-stack.version"
 COMMON = ROOT / "platform" / "observability" / "helm" / "kube-prometheus-stack.values.common.yaml"
@@ -613,7 +615,12 @@ def test_verify_deadline_uses_latest_safe_diagnostics_without_extra_request(tmp_
     assert "activeTargets" not in result.stderr and "Traceback" not in result.stderr
 
 
-def run_dashboard_verifier(tmp_path, mode="success", context="sugar-staging"):
+def run_dashboard_verifier(
+    tmp_path,
+    mode="success",
+    context="sugar-staging",
+    forwarding_line="Forwarding from 127.0.0.1:43127 -> 3000",
+):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(parents=True)
     audit = tmp_path / "audit"
@@ -632,7 +639,7 @@ case "$*" in
   *"get secret grafana-admin-credentials"*"admin-pass""word"*) printf placeholder | base64 ;;
   *"port-forward"*)
     [ "$MODE" != forward-fail ] || exit 42
-    echo 'Forwarding from 127.0.0.1:43127 -> 80'
+    printf '%s\n' "$FORWARDING_LINE"
     echo $$ > "$FORWARD_PID"
     trap 'echo terminated > "$PID_FILE"; exit 0' TERM INT
     if [ "$MODE" = forward-exits-after-ready ]; then
@@ -677,6 +684,7 @@ esac
         "AUDIT": str(audit),
         "MODE": mode,
         "CONTEXT": context,
+        "FORWARDING_LINE": forwarding_line,
         "PID_FILE": str(pid_file),
         "FORWARD_PID": str(tmp_path / "port-forward.pid"),
         "READY_SECRET": str(tmp_path / "secret-requested"),
@@ -701,6 +709,51 @@ def test_dashboard_verifier_runtime_owns_port_and_cleans_up(tmp_path):
     assert "http://127.0.0.1:43127/" in audit
     assert not list(tmp_path.glob("sugarkube-grafana-verify.*"))
     assert pid_file.read_text(encoding="utf-8").strip() == "terminated"
+
+
+@pytest.mark.parametrize("remote_port", ["3000", "8443", "80"])
+def test_dashboard_verifier_accepts_resolved_remote_port(tmp_path, remote_port):
+    result, audit, _ = run_dashboard_verifier(
+        tmp_path, forwarding_line=f"Forwarding from 127.0.0.1:43127 -> {remote_port}"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "get secret" in audit
+
+
+@pytest.mark.parametrize(
+    "forwarding_line",
+    [
+        "Forwarding from 127.0.0.1:0 -> 3000",
+        "Forwarding from 127.0.0.1:65536 -> 3000",
+        "Forwarding from 127.0.0.1:43127 -> 0",
+        "Forwarding from 127.0.0.1:43127 -> 65536",
+    ],
+)
+def test_dashboard_verifier_rejects_invalid_ports_before_secret_access(tmp_path, forwarding_line):
+    result, audit, _ = run_dashboard_verifier(tmp_path, forwarding_line=forwarding_line)
+    assert result.returncode != 0
+    assert "get secret" not in audit
+    assert forwarding_line not in result.stdout + result.stderr
+
+
+@pytest.mark.parametrize(
+    "forwarding_line",
+    [
+        "Forwarding from 0.0.0.0:43127 -> 3000",
+        "Forwarding from [::1]:43127 -> 3000",
+        "Forwarding from localhost:43127 -> 3000",
+        "Forwarding from 127.0.0.1:43127 ->",
+        "prefix Forwarding from 127.0.0.1:43127 -> 3000",
+        "Forwarding from 127.0.0.1:43127 -> 3000 suffix",
+    ],
+)
+def test_dashboard_verifier_rejects_non_loopback_and_malformed_lines_before_secret_access(
+    tmp_path, forwarding_line
+):
+    result, audit, _ = run_dashboard_verifier(tmp_path, forwarding_line=forwarding_line)
+    assert result.returncode != 0
+    assert "get secret" not in audit
+    assert forwarding_line not in result.stdout + result.stderr
 
 
 def test_dashboard_verifier_checks_context_before_secret_access(tmp_path):


### PR DESCRIPTION
### Motivation

- The dashboard verifier assumed kubectl always reports `-> 80` and failed when kubectl reported the Service's resolved pod/container port (e.g. `-> 3000`).
- The intent is to accept kubectl's informational resolved remote port while preserving the existing safety, cleanup, and redaction guarantees.

### Description

- Update the port-forward parser in `scripts/observability_helm.sh` to anchor exactly on `Forwarding from 127.0.0.1:<local> -> <remote>` and capture both decimal ports. 
- Validate both captured ports are integers in the inclusive range `1..65535` and reject out-of-range or zero values without proceeding to Secret access. 
- Keep all existing constraints: bind-only `--address=127.0.0.1`, anchored loopback line acceptance, owned child PID checks, liveness/cleanup, delayed credential retrieval, redaction, and read-only verification logic. 
- Update the kubectl test stub and add regression tests in `tests/test_observability_helm.py` exercising `3000`, another resolved port (`8443`), legacy `80`, invalid ports, non-loopback/IPv6/hostname/malformed lines, child that exits after reporting readiness, and ensure sensitive information is never printed. 
- Document the behaviour in `docs/observability-operations.md` explaining that the right-hand value is kubectl's resolved pod/container port and may differ from Service port `80`.

### Testing

- Ran `bash -n scripts/observability_helm.sh` and it reported no syntax errors.
- Ran `pytest -q tests/test_observability_helm.py -k dashboard_verifier` and observed `21 passed, 29 deselected` for the focused verifier suite.
- Ran `pytest -q tests/test_observability_helm.py tests/test_observability_dashboard.py` and observed `86 passed` across both Python test suites.
- Ran `ruff` and `black --check` against the changed tests and helper files and applied a formatting pass where black reported a reformat; final checks passed for the modified files.
- Ran `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` (spellcheck/linkcheck required installing system spell binaries in CI-like environment) and both checks completed successfully in this environment.
- Ran `git diff --check` and `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` with no introduced secrets or trailing errors from this focused change.
- Ran `pre-commit run --all-files`; repository-wide pre-existing hooks attempted unrelated trailing-whitespace and end-of-file fixes and `check-yaml` surfaced existing multi-document YAML in the repo (pre-existing); those are not introduced by this PR and were reverted during the focused workflow.

Post-merge acceptance (run these exact commands; no Helm upgrade is necessary because the dashboard is already deployed):

```bash
cd ~/sugarkube
git status --short
git pull --ff-only
just kubeconfig-env env=staging

just observability-dashboard-verify env=staging

kubectl -n monitoring delete pod \
  -l 'app.kubernetes.io/name=grafana,app.kubernetes.io/instance=kube-prometheus-stack'

kubectl -n monitoring rollout status \
  deployment/kube-prometheus-stack-grafana \
  --timeout=20m

just observability-dashboard-verify env=staging
```

Residual notes: this is a minimal, targeted fix to the port-forward parser and tests; it preserves the existing threat model, redaction behavior, and runtime cleanup guarantees while adding regression coverage for resolved remote ports.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66b6b4bc1c832fbc2016c2b3a3f029)