### PR TITLE
Enforce branch-SHA image deployment tags for staging and production

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -59,7 +59,7 @@ Each Sugarkube-managed app needs the following deployment coordinates:
 | Release name | Stable Helm release name, normally the app slug. |
 | Namespace | Stable Kubernetes namespace, normally the app slug. |
 | Chart version pin file | A repo file containing the chart version Sugarkube should install or upgrade. Apps may provide environment-specific pin files with shared-pin fallback. |
-| Production tag pin file | Required repo file containing the production-approved immutable image tag for production promotion. |
+| Production tag pin file | Required repo file containing the production-approved branch-SHA image tag for production promotion. |
 | Values chain per env | Comma-separated Helm values files, ordered from base to environment overlay. |
 | Validation URLs/paths | Host key plus one or more HTTP paths to check after rollout. |
 
@@ -88,28 +88,33 @@ The current apps map to that model as examples:
 
 ## Standard image tag model
 
-Deployment tags must identify application code and release intent, not mutable
-environments.
+Staging and production deployment tags must identify application code exactly,
+not a movable release or environment alias.
 
-Acceptable deployment tags:
+Acceptable staging and production deployment tags:
 
-- Immutable branch-SHA tags, such as `main-REPLACE_SHORTSHA`.
-- Semver or release tags, such as `v1.2.3`, `3.1.0`, or another documented
-  project-specific stable tag.
-- Mutable branch convenience tags, such as `main-latest`, only when an app
-  runbook explicitly documents that a non-prod bootstrap or iteration flow accepts
-  them. They are an app-specific exception, not a shared guarantee; for example,
-  token.place deploy/redeploy wrappers reject every tag containing `latest`,
-  including `main-latest`.
+- Lowercase branch-SHA tags, such as `main-1a31a56`, `v3-deadbee`, or a tag
+  ending in a longer lowercase commit SHA. The hexadecimal suffix must contain
+  7 through 40 characters.
 
 Unacceptable deployment tags:
 
 - `latest`;
-- bare branch names such as `main`, `master`, `develop`, or `release`; and
-- environment names such as `dev`, `staging`, `prod`, or `production`.
+- bare branch names such as `main`, `master`, `develop`, or `release`;
+- environment names such as `dev`, `staging`, `prod`, or `production`;
+- semantic tags and variants such as `v3.0.1`, `3.0.1-rc.1`, or
+  `v3.0.1-deadbee`; and
+- tags with an uppercase, malformed, shorter-than-7, or longer-than-40 SHA
+  suffix.
 
-Production promotion must use an immutable tag. The production tag pin file is
-part of the standard app coordinates and must contain the single immutable image
+Semantic image tags are release and distribution aliases, not immutable
+deployment coordinates. An explicit `env=dev` local-development flow may accept
+a semantic tag for backward compatibility; omitted environments, `int`
+(normalized to staging), staging, and production always use the strict policy.
+Chart versions remain separate coordinates and continue to use SemVer.
+
+Production promotion must use a branch-SHA tag. The production tag pin file is
+part of the standard app coordinates and must contain the single branch-SHA image
 tag approved for production. Generic production promotion flows should read that
 pin when `tag=` is omitted and should update it only as an explicit approval
 step.
@@ -272,11 +277,11 @@ validates a public OCI chart and edits the repository pin.
 just app-deploy app=dspace env=staging tag=main-REPLACE_SHORTSHA \
   manifest=deployment-candidates/dspace/staging.json
 
-# Redeploy an existing release with a specific immutable tag.
+# Redeploy an existing release with a specific branch-SHA tag.
 just app-redeploy app=dspace env=staging tag=main-REPLACE_SHORTSHA \
   manifest=deployment-candidates/dspace/staging.json evidence=deployment-evidence/dspace/staging/redeploy.json
 
-# Promote an approved immutable tag to production.
+# Promote an approved branch-SHA tag to production.
 just app-promote-prod app=dspace tag=main-REPLACE_SHORTSHA \
   manifest=deployment-candidates/dspace/prod.json
 

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -53,7 +53,7 @@ Check the resolved config before the first deploy.
 just app-config app=appslug env=staging config="$APP_CONFIG"
 ```
 
-Deploy staging with an immutable image tag.
+Deploy staging with a lowercase branch-SHA image tag.
 
 ```bash
 APP_TAG=main-REPLACE_SHORTSHA
@@ -71,7 +71,8 @@ The app repo's `ci-image.yml` should answer yes to each item before Sugarkube st
 - It logs in to GHCR with repository-scoped credentials.
 - It publishes `ghcr.io/OWNER/IMAGE`.
 - It emits immutable branch-SHA tags such as `main-REPLACE_SHORTSHA`.
-- It may emit convenience tags such as `main-latest`, but those are non-prod only unless an app runbook explicitly says otherwise.
+- It may emit convenience or semantic release aliases for distribution, but
+  staging and production never use them as deployment coordinates.
 - It does not require local Docker builds for staging or production deploys.
 - It records enough workflow output for an operator to find the tag to deploy.
 
@@ -126,9 +127,13 @@ Do not invent real configs for future apps such as `wove` until their app repos 
 
 ### I have a successful image build; what tag do I deploy?
 
-- Use the immutable branch-SHA or release tag from the successful image workflow.
-- Prefer tags shaped like `main-REPLACE_SHORTSHA` for staging validation.
+- Use the branch-SHA tag from the successful image workflow.
+- Tags must end in 7 through 40 lowercase hexadecimal characters, as in
+  `main-REPLACE_SHORTSHA` or `v3-deadbee`.
 - Do not deploy `latest`, a bare branch name, or an environment name.
+- Do not deploy a semantic image tag; semantic tags are movable release or
+  distribution aliases. Only explicit `env=dev` local-development flows retain
+  semantic-tag compatibility. Chart versions remain SemVer coordinates.
 - Deploy staging first.
 
 ```bash
@@ -166,7 +171,7 @@ git commit -m "Bump appslug chart pin to 0.1.3"
 
 ### Staging works; how do I promote prod?
 
-- Keep the same immutable image tag that passed staging.
+- Keep the same branch-SHA image tag that passed staging.
 - Record or review the approved tag in `docs/apps/APP.prod.tag` when the app uses a committed prod pin.
 - Use the generic production promotion command.
 

--- a/justfile
+++ b/justfile
@@ -1347,6 +1347,15 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
         exit 1
     fi
 
+    image_tag="${tag}"
+    if [ -z "${image_tag}" ] && [ -n "${default_tag}" ]; then
+        image_tag="${default_tag}"
+    fi
+    if [ -n "${image_tag}" ]; then
+        python3 "{{ justfile_directory() }}/scripts/app_config.py" validate-tag \
+          "${image_tag}" --env "${requested_env}" >/dev/null
+    fi
+
     python3 "{{ justfile_directory() }}/scripts/cluster_identity.py" assert --kubeconfig "${KUBECONFIG}" --env "${requested_env}" >/dev/null
 
     chart_version="${version}"
@@ -1380,11 +1389,6 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     version_args=()
     if [ -n "${chart_version}" ] && [ "${digest_chart}" = false ]; then
         version_args+=(--version "${chart_version}")
-    fi
-
-    image_tag="${tag}"
-    if [ -z "${image_tag}" ] && [ -n "${default_tag}" ]; then
-        image_tag="${default_tag}"
     fi
 
     echo "app: ${release}"

--- a/scripts/app_config.py
+++ b/scripts/app_config.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Load Sugarkube app deployment config and validate immutable image tags."""
+"""Load Sugarkube app deployment config and validate image deployment tags."""
 
 from __future__ import annotations
 
@@ -55,7 +55,7 @@ REQUIRED_KEYS = {
     "SUGARKUBE_CHART",
 }
 ASSIGNMENT_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
-BRANCH_SHA_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*-[0-9a-f]{7,}$", re.IGNORECASE)
+BRANCH_SHA_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*-[0-9a-f]{7,40}$")
 SEMVER_RE = re.compile(
     r"^v?[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$"
 )
@@ -91,29 +91,32 @@ def validate_app_name(app: str) -> str:
     return app
 
 
-def validate_tag(tag: str) -> str:
+def validate_tag(tag: str, env: str | None = None) -> str:
+    """Validate an image tag for an environment.
+
+    An omitted environment deliberately uses the strict deployment-safe policy.
+    Semantic tags are retained only for explicit local-development compatibility.
+    """
     tag = normalize_named(tag, "tag")
     if not tag:
         raise AppConfigError(
-            "tag must not be empty. Use an immutable tag such as main-deadbee or v0.1.0."
+            "tag must not be empty. Use a branch-SHA tag such as main-deadbee."
         )
-    tag_lc = tag.lower()
-    if tag_lc in MOVING_TAGS or "latest" in tag_lc:
-        raise AppConfigError(
-            f"mutable tag '{tag}' is not allowed. Use an immutable branch-SHA tag "
-            "(example: main-deadbee) or a semver release tag (example: v0.1.0)."
-        )
-    if re.search(r"(^|[-_.])(dev|develop|staging|prod|production|release)([-_.]|$)", tag_lc):
-        if not BRANCH_SHA_RE.fullmatch(tag):
-            raise AppConfigError(
-                f"environment-like moving tag '{tag}' is not allowed. Use an immutable "
-                "branch-SHA tag ending in at least 7 hex characters."
-            )
-    if BRANCH_SHA_RE.fullmatch(tag) or SEMVER_RE.fullmatch(tag):
+    resolved_env = normalize_env(env) if env is not None else None
+    if resolved_env == "dev" and SEMVER_RE.fullmatch(tag):
         return tag
+    if SEMVER_RE.fullmatch(tag):
+        raise AppConfigError(
+            f"semantic image tag '{tag}' is not deployment-safe. Use a branch-SHA tag "
+            "such as main-deadbee."
+        )
+    if BRANCH_SHA_RE.fullmatch(tag):
+        return tag
+    tag_lc = tag.lower()
+    kind = "movable" if tag_lc in MOVING_TAGS or "latest" in tag_lc else "invalid"
     raise AppConfigError(
-        f"invalid tag '{tag}'. Use an immutable branch-SHA tag (main-deadbee) "
-        "or semver release tag."
+        f"{kind} image tag '{tag}' is not deployment-safe. Use a branch-SHA tag "
+        "with a 7-40 character lowercase hexadecimal suffix (example: main-deadbee)."
     )
 
 
@@ -252,7 +255,7 @@ def resolve_tag(config: dict[str, str], raw_tag: str, *, prod_fallback: bool) ->
                     if line:
                         tag = line
                         break
-    return validate_tag(tag)
+    return validate_tag(tag, config.get("SUGARKUBE_ENV"))
 
 
 def shell_emit(config: dict[str, str]) -> str:
@@ -300,12 +303,13 @@ def main(argv: list[str] | None = None) -> int:
         cmd.add_argument("--prod-tag-fallback", action="store_true")
     validate = sub.add_parser("validate-tag")
     validate.add_argument("tag")
+    validate.add_argument("--env", default=None)
     host = sub.add_parser("host-value")
     host.add_argument("host_key")
     args = parser.parse_args(argv)
     try:
         if args.command == "validate-tag":
-            print(validate_tag(args.tag))
+            print(validate_tag(args.tag, args.env))
             return 0
         if args.command == "host-value":
             data = json.load(sys.stdin)

--- a/scripts/test-helm-oci-install.sh
+++ b/scripts/test-helm-oci-install.sh
@@ -148,7 +148,7 @@ command_output="$(
         chart=oci://registry.test/charts/dspace \
         values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
         version_file=docs/apps/dspace.version \
-        default_tag=v3-latest env=staging
+        default_tag=v3-deadbee env=staging
 )"
 
 if ! grep -q "oci://registry.test/charts/dspace" <<<"${command_output}"; then

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -120,9 +120,9 @@ def test_explicit_config_path_precedes_config_dir_and_resolves_env_values(
 
 @pytest.mark.parametrize(
     "tag",
-    ["main-deadbee", "v3-deadbee", "feature-x-deadbee", "v0.1.0", "3.0.1", "3.1.0-rc.1"],
+    ["main-1a31a56", "main-5ca96df16f0f", "v3-deadbee", "feature-x-deadbee"],
 )
-def test_validate_tag_allows_immutable_tags(tag: str) -> None:
+def test_validate_tag_allows_branch_sha_tags(tag: str) -> None:
     assert app_config.validate_tag(tag) == tag
 
 
@@ -140,11 +140,30 @@ def test_validate_tag_allows_immutable_tags(tag: str) -> None:
         "release",
         "staging-blue",
         "feature-x",
+        "v3.0.1",
+        "3.0.1",
+        "3.1.0-rc.1",
+        "v3.0.1+build.5",
+        "v3.0.1-deadbee",
+        "main-latest",
+        "main-DEADBEE",
+        "main-deadbe",
+        "main-" + "a" * 41,
     ],
 )
 def test_validate_tag_rejects_moving_tags(tag: str) -> None:
     with pytest.raises(app_config.AppConfigError, match="tag"):
         app_config.validate_tag(tag)
+
+
+@pytest.mark.parametrize("tag", ["v3.0.1", "3.1.0-rc.1", "v3.0.1+build.5"])
+def test_validate_tag_dev_allows_semantic_release_aliases(tag: str) -> None:
+    assert app_config.validate_tag(tag, "dev") == tag
+
+
+def test_validate_tag_int_uses_strict_staging_policy() -> None:
+    with pytest.raises(app_config.AppConfigError, match="semantic image tag"):
+        app_config.validate_tag("v3.0.1", "int")
 
 
 def test_rejects_unknown_dotenv_keys(tmp_path: Path) -> None:
@@ -302,12 +321,24 @@ def test_resolve_tag_uses_prod_fallback_file(tmp_path: Path) -> None:
     tag_file.write_text("# promoted digest tag\nmain-deadbee\n", encoding="utf-8")
 
     tag = app_config.resolve_tag(
-        {"SUGARKUBE_PROD_TAG_FILE": str(tag_file)},
+        {"SUGARKUBE_ENV": "prod", "SUGARKUBE_PROD_TAG_FILE": str(tag_file)},
         "",
         prod_fallback=True,
     )
 
     assert tag == "main-deadbee"
+
+
+def test_resolve_tag_rejects_semantic_prod_fallback_file(tmp_path: Path) -> None:
+    tag_file = tmp_path / "prod-tag.txt"
+    tag_file.write_text("v3.0.1\n", encoding="utf-8")
+
+    with pytest.raises(app_config.AppConfigError, match="semantic image tag"):
+        app_config.resolve_tag(
+            {"SUGARKUBE_ENV": "prod", "SUGARKUBE_PROD_TAG_FILE": str(tag_file)},
+            "",
+            prod_fallback=True,
+        )
 
 
 def test_shell_emit_quotes_expected_exports(tmp_path: Path) -> None:
@@ -333,6 +364,11 @@ def test_main_supports_json_shell_validate_tag_and_host_value(
 
     assert app_config.main(["validate-tag", "main-deadbee"]) == 0
     assert capsys.readouterr().out.strip() == "main-deadbee"
+
+    assert app_config.main(["validate-tag", "v3.0.1"]) == 2
+    assert "semantic image tag" in capsys.readouterr().err
+    assert app_config.main(["validate-tag", "v3.0.1", "--env", "dev"]) == 0
+    assert capsys.readouterr().out.strip() == "v3.0.1"
 
     monkeypatch.setattr("sys.stdin", io.StringIO('{"ingress":{"host":"example.test"}}'))
     assert app_config.main(["host-value", "ingress.host"]) == 0
@@ -465,3 +501,14 @@ def test_dspace_env_specific_chart_and_prod_tag_pins() -> None:
     assert staging["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.staging.version"
     assert prod["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.prod.version"
     assert app_config.resolve_tag(prod, "", prod_fallback=True) == "main-1a31a56"
+
+
+def test_committed_production_image_pins_are_empty_or_branch_sha_tags() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    for pin in (repo_root / "docs" / "apps").glob("*.prod.tag"):
+        values = [
+            line.split("#", 1)[0].strip()
+            for line in pin.read_text(encoding="utf-8").splitlines()
+        ]
+        for value in filter(None, values):
+            assert app_config.validate_tag(value, "prod") == value, pin

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1313,7 +1313,7 @@ def test_app_deploy_rejects_mutable_tag_before_helm(
     )
 
     assert result.returncode != 0
-    assert "mutable tag" in result.stderr
+    assert "movable image tag" in result.stderr
     helm_log_path = Path(generic_app_stub_env["HELM_LOG"])
     assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
 
@@ -2898,6 +2898,91 @@ def test_direct_helm_oci_helper_matching_env_succeeds(
     assert "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.3" in helm_log
     assert "upgrade tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace" in helm_log
     assert "--description" not in helm_log
+
+
+@pytest.mark.parametrize("recipe", ["helm-oci-install", "helm-oci-upgrade"])
+def test_direct_helm_oci_helpers_reject_semantic_tag_before_any_helm(
+    recipe: str, generic_app_stub_env: dict[str, str]
+) -> None:
+    result = _run_just(
+        [
+            recipe,
+            "release=tokenplace",
+            "namespace=tokenplace",
+            "chart=oci://ghcr.io/futuroptimist/charts/tokenplace",
+            "version=0.1.3",
+            "tag=v3.0.1",
+            "env=staging",
+        ],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode != 0
+    assert "semantic image tag" in result.stderr
+    assert not Path(generic_app_stub_env["HELM_LOG"]).exists()
+
+
+@pytest.mark.parametrize("recipe", ["app-deploy", "app-redeploy", "app-promote-prod"])
+def test_generic_mutation_paths_reject_semantic_tag_before_any_helm(
+    recipe: str, generic_app_stub_env: dict[str, str]
+) -> None:
+    args = [recipe, "app=jobbot3000"]
+    if recipe != "app-promote-prod":
+        args.append("env=staging")
+    args.append("tag=v3.0.1")
+    result = _run_just(args, generic_app_stub_env)
+
+    assert result.returncode != 0
+    assert "semantic image tag" in result.stderr
+    assert not Path(generic_app_stub_env["HELM_LOG"]).exists()
+
+
+def test_prod_fallback_semantic_tag_fails_before_any_helm(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    pin = tmp_path / "custom.prod.tag"
+    pin.write_text("v3.0.1\n", encoding="utf-8")
+    config = tmp_path / "custom.env"
+    config.write_text(
+        "\n".join(
+            [
+                "SUGARKUBE_APP=custom",
+                "SUGARKUBE_RELEASE=custom",
+                "SUGARKUBE_NAMESPACE=custom",
+                "SUGARKUBE_CHART=oci://example.invalid/charts/custom",
+                "SUGARKUBE_VERSION=1.2.3",
+                f"SUGARKUBE_PROD_TAG_FILE={pin}",
+                "SUGARKUBE_VALUES_DEV=dev.yaml",
+                "SUGARKUBE_VALUES_STAGING=staging.yaml",
+                "SUGARKUBE_VALUES_PROD=prod.yaml",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    generic_app_stub_env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
+
+    result = _run_just(
+        ["app-promote-prod", "custom", "", str(config)],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode != 0
+    assert "semantic image tag" in result.stderr
+    assert not Path(generic_app_stub_env["HELM_LOG"]).exists()
+
+
+def test_dspace_compat_deploy_rejects_semantic_tag_before_manifest_or_helm(
+    generic_app_stub_env: dict[str, str]
+) -> None:
+    result = _run_just(
+        ["dspace-oci-deploy", "env=staging", "tag=v3.0.1"], generic_app_stub_env
+    )
+
+    assert result.returncode != 0
+    assert "semantic image tag" in result.stderr
+    assert "manifest=<approved-candidate.json> is required" not in result.stderr
+    assert not Path(generic_app_stub_env["HELM_LOG"]).exists()
 
 
 @pytest.mark.usefixtures("ensure_just_available")


### PR DESCRIPTION
### Motivation

- Prevent movable or semantic image tags from being used as staging/production deployment coordinates and ensure such rejections happen before any Helm `show`, `template`, `upgrade` or Kubernetes mutation.
- Centralize and make environment-aware image-tag policy so every entry point (generic recipes, DSPACE wrappers, and direct Helm helpers) uses the same guard.
- Preserve SemVer chart validation and allow an explicit dev-only semantic-tag exception for local development.

### Description

- Centralized tag policy in `scripts/app_config.py` by adding `validate_tag(tag, env=None)`, tightening `BRANCH_SHA_RE` to require a lowercase 7–40 hex suffix, making the default/omitted environment strict (deployment-safe), and allowing semantic tags only when `env=dev` is explicitly requested. The production fallback pin file is validated under the resolved environment via `resolve_tag(...)`.
- Updated the `validate-tag` CLI to accept `--env` and to default to the strict deployment-safe policy when `--env` is omitted.
- Closed Helm-helper bypasses by validating the selected `tag`/`default_tag` in the shared `_helm-oci-deploy` implementation (in `justfile`) before cluster identity checks, `helm show`, and any Helm mutation.
- Ensured compatibility paths (DSPACE wrappers and direct `helm-oci-install`/`helm-oci-upgrade`) validate tags with the centralized Python validator before manifest/provenance checks or Helm invocation.
- Added and adjusted deterministic tests: updated `tests/test_app_config.py` and `tests/test_generic_app_just_recipes.py` to cover accepted branch-SHA shapes, rejected semantic/movable/malformed tags, `int` → staging normalization, dev-only exception, production fallback pin validation, absence of Helm invocation on rejection, and relevant compatibility wrappers.
- Documentation updates in `docs/app_deployment_contract.md` and `docs/app_onboarding.md` clarifying that branch-SHA tags are the staging/production deployment coordinates, semantic tags are distribution aliases, production pin files must contain branch-SHA tags, and chart SemVer remains an independent coordinate.
- Minor test helper tweak in `scripts/test-helm-oci-install.sh` to use a deterministic default tag in the test stub.

Closes #2321

### Testing

- `python3 scripts/app_config.py validate-tag main-1a31a56` — accepted (OK).
- `python3 scripts/app_config.py validate-tag v3-deadbee` — accepted (OK for branch-sha-like `v3-deadbee`).
- Semantic rejection assertion for `v3.0.1` (shell): rejected with concise remediation message (OK).
- `python3 -m pytest -q tests/test_app_config.py tests/test_generic_app_just_recipes.py` — test run passing for the modified suites (207 passed, 1 warning in this environment).
- Focused mutation/tag tests: `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k 'semantic_tag or semantic_prod or mutation_paths'` — passed (7 passed in focused run).
- `bash scripts/test-helm-oci-install.sh` — passed in the test environment.
- `just --unstable --fmt --check` — passed for the touched files in this environment.
- `linkchecker --no-warnings README.md docs/` — ran successfully (202 links checked, no errors).
- `pyspelling -c .spellcheck.yaml` — could not run in this environment due to missing `aspell` binary (noted); no docs content changed beyond the targeted onboarding/contract wording.
- `pre-commit run --all-files` — exposed unrelated, pre-existing repo-wide hooks and lint warnings; these were not altered as part of this focused change.

Residual notes and safety

- The implementation rejects movable/semantic tags early and emits concise operator-facing errors instructing use of a branch-SHA tag (7–40 lowercase hex suffix examples such as `main-1a31a56`).
- The dev-only semantic-tag exception remains available only when `env=dev` is explicitly requested and is never applied for omitted env, `int`, staging, or production flows.
- No live cluster, Helm, registry, or deployment operations were performed; tests rely on existing command stubs and assert the absence of any Helm invocation on rejection.
- This PR centralizes policy and test coverage; follow-ups may address any downstream runbook updates or extra CI formatting checks if desired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66edba5cec832f903516766df3ca8f)