### PR TITLE
Enforce branch‑SHA image tags for staging/production and validate before Helm

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -91,25 +91,27 @@ The current apps map to that model as examples:
 Deployment tags must identify application code and release intent, not mutable
 environments.
 
-Acceptable deployment tags:
+Acceptable staging and production deployment tags are lowercase branch-SHA tags,
+such as `main-1a31a56`, with a 7–40 character lowercase hexadecimal suffix.
 
-- Immutable branch-SHA tags, such as `main-REPLACE_SHORTSHA`.
-- Semver or release tags, such as `v1.2.3`, `3.1.0`, or another documented
-  project-specific stable tag.
-- Mutable branch convenience tags, such as `main-latest`, only when an app
-  runbook explicitly documents that a non-prod bootstrap or iteration flow accepts
-  them. They are an app-specific exception, not a shared guarantee; for example,
-  token.place deploy/redeploy wrappers reject every tag containing `latest`,
-  including `main-latest`.
+Semantic image tags such as `v1.2.3` are release and distribution aliases, not
+immutable deployment coordinates. They are accepted only when `env=dev` is
+explicitly selected for local-development compatibility. An omitted environment,
+`int`/staging, and production all use the strict branch-SHA policy. This image-tag
+rule is separate from chart versions: pinned chart SemVer such as `3.1.0` remains
+valid.
 
 Unacceptable deployment tags:
 
 - `latest`;
 - bare branch names such as `main`, `master`, `develop`, or `release`; and
-- environment names such as `dev`, `staging`, `prod`, or `production`.
+- environment names such as `dev`, `staging`, `prod`, or `production`;
+- semantic and semantic-looking aliases, including `v3.0.1` and
+  `v3.0.1-deadbee`; and
+- malformed, uppercase, shorter-than-7, or longer-than-40 SHA suffixes.
 
-Production promotion must use an immutable tag. The production tag pin file is
-part of the standard app coordinates and must contain the single immutable image
+Production promotion must use a branch-SHA tag. The production tag pin file is
+part of the standard app coordinates and must contain the single branch-SHA image
 tag approved for production. Generic production promotion flows should read that
 pin when `tag=` is omitted and should update it only as an explicit approval
 step.

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -53,7 +53,7 @@ Check the resolved config before the first deploy.
 just app-config app=appslug env=staging config="$APP_CONFIG"
 ```
 
-Deploy staging with an immutable image tag.
+Deploy staging with a lowercase branch-SHA image tag.
 
 ```bash
 APP_TAG=main-REPLACE_SHORTSHA
@@ -126,7 +126,9 @@ Do not invent real configs for future apps such as `wove` until their app repos 
 
 ### I have a successful image build; what tag do I deploy?
 
-- Use the immutable branch-SHA or release tag from the successful image workflow.
+- Use the lowercase branch-SHA tag from the successful image workflow. Semantic
+  tags are release/distribution aliases, not staging or production coordinates;
+  only an explicit `env=dev` local flow retains compatibility for them.
 - Prefer tags shaped like `main-REPLACE_SHORTSHA` for staging validation.
 - Do not deploy `latest`, a bare branch name, or an environment name.
 - Deploy staging first.
@@ -166,7 +168,7 @@ git commit -m "Bump appslug chart pin to 0.1.3"
 
 ### Staging works; how do I promote prod?
 
-- Keep the same immutable image tag that passed staging.
+- Keep the same branch-SHA image tag that passed staging.
 - Record or review the approved tag in `docs/apps/APP.prod.tag` when the app uses a committed prod pin.
 - Use the generic production promotion command.
 

--- a/justfile
+++ b/justfile
@@ -1339,6 +1339,14 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     esac
     export SUGARKUBE_ENV="${requested_env}"
 
+    image_tag="${tag}"
+    if [ -z "${image_tag}" ] && [ -n "${default_tag}" ]; then
+        image_tag="${default_tag}"
+    fi
+    if [ -n "${image_tag}" ]; then
+      image_tag="$(python3 "{{ justfile_directory() }}/scripts/app_config.py" validate-tag "${image_tag}" --env "${requested_env}")"
+    fi
+
     allow_install="$(normalize_prefixed_value allow_install "{{ allow_install }}")"
     reuse_values="$(normalize_prefixed_value reuse_values "{{ reuse_values }}")"
 
@@ -1380,11 +1388,6 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     version_args=()
     if [ -n "${chart_version}" ] && [ "${digest_chart}" = false ]; then
         version_args+=(--version "${chart_version}")
-    fi
-
-    image_tag="${tag}"
-    if [ -z "${image_tag}" ] && [ -n "${default_tag}" ]; then
-        image_tag="${default_tag}"
     fi
 
     echo "app: ${release}"

--- a/scripts/app_config.py
+++ b/scripts/app_config.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Load Sugarkube app deployment config and validate immutable image tags."""
+"""Load Sugarkube app deployment config and validate image deployment tags."""
 
 from __future__ import annotations
 
@@ -55,7 +55,7 @@ REQUIRED_KEYS = {
     "SUGARKUBE_CHART",
 }
 ASSIGNMENT_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
-BRANCH_SHA_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*-[0-9a-f]{7,}$", re.IGNORECASE)
+BRANCH_SHA_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*-[0-9a-f]{7,40}$")
 SEMVER_RE = re.compile(
     r"^v?[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$"
 )
@@ -91,29 +91,35 @@ def validate_app_name(app: str) -> str:
     return app
 
 
-def validate_tag(tag: str) -> str:
+def validate_tag(tag: str, env: str | None = None) -> str:
+    """Validate an image tag for an environment.
+
+    An omitted environment deliberately uses the deployment-safe policy.  SemVer
+    image aliases are retained only for explicit local development compatibility.
+    """
     tag = normalize_named(tag, "tag")
+    resolved_env = normalize_env(env) if env is not None else None
     if not tag:
         raise AppConfigError(
-            "tag must not be empty. Use an immutable tag such as main-deadbee or v0.1.0."
+            "tag must not be empty. Use a branch-SHA tag such as main-deadbee."
         )
     tag_lc = tag.lower()
-    if tag_lc in MOVING_TAGS or "latest" in tag_lc:
+    if SEMVER_RE.fullmatch(tag):
+        if resolved_env == "dev":
+            return tag
         raise AppConfigError(
-            f"mutable tag '{tag}' is not allowed. Use an immutable branch-SHA tag "
-            "(example: main-deadbee) or a semver release tag (example: v0.1.0)."
+            f"semantic image tag '{tag}' is a movable release alias and is not allowed "
+            "for deployment. Use a branch-SHA tag (example: main-deadbee)."
         )
-    if re.search(r"(^|[-_.])(dev|develop|staging|prod|production|release)([-_.]|$)", tag_lc):
-        if not BRANCH_SHA_RE.fullmatch(tag):
-            raise AppConfigError(
-                f"environment-like moving tag '{tag}' is not allowed. Use an immutable "
-                "branch-SHA tag ending in at least 7 hex characters."
-            )
-    if BRANCH_SHA_RE.fullmatch(tag) or SEMVER_RE.fullmatch(tag):
+    if BRANCH_SHA_RE.fullmatch(tag):
         return tag
+    if tag_lc in MOVING_TAGS or "latest" in tag_lc:
+        kind = "mutable tag (movable image alias)"
+    else:
+        kind = "invalid or mutable tag"
     raise AppConfigError(
-        f"invalid tag '{tag}'. Use an immutable branch-SHA tag (main-deadbee) "
-        "or semver release tag."
+        f"{kind} '{tag}' is not allowed. Use a lowercase branch-SHA tag "
+        "ending in 7 to 40 lowercase hexadecimal characters (example: main-deadbee)."
     )
 
 
@@ -252,7 +258,7 @@ def resolve_tag(config: dict[str, str], raw_tag: str, *, prod_fallback: bool) ->
                     if line:
                         tag = line
                         break
-    return validate_tag(tag)
+    return validate_tag(tag, config.get("SUGARKUBE_ENV"))
 
 
 def shell_emit(config: dict[str, str]) -> str:
@@ -300,12 +306,13 @@ def main(argv: list[str] | None = None) -> int:
         cmd.add_argument("--prod-tag-fallback", action="store_true")
     validate = sub.add_parser("validate-tag")
     validate.add_argument("tag")
+    validate.add_argument("--env")
     host = sub.add_parser("host-value")
     host.add_argument("host_key")
     args = parser.parse_args(argv)
     try:
         if args.command == "validate-tag":
-            print(validate_tag(args.tag))
+            print(validate_tag(args.tag, args.env))
             return 0
         if args.command == "host-value":
             data = json.load(sys.stdin)

--- a/scripts/test-helm-oci-install.sh
+++ b/scripts/test-helm-oci-install.sh
@@ -148,7 +148,7 @@ command_output="$(
         chart=oci://registry.test/charts/dspace \
         values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
         version_file=docs/apps/dspace.version \
-        default_tag=v3-latest env=staging
+        default_tag=main-1a31a56 env=staging
 )"
 
 if ! grep -q "oci://registry.test/charts/dspace" <<<"${command_output}"; then

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -120,7 +121,7 @@ def test_explicit_config_path_precedes_config_dir_and_resolves_env_values(
 
 @pytest.mark.parametrize(
     "tag",
-    ["main-deadbee", "v3-deadbee", "feature-x-deadbee", "v0.1.0", "3.0.1", "3.1.0-rc.1"],
+    ["main-1a31a56", "main-5ca96df16f0f", "v3-deadbee", "feature-x-deadbee"],
 )
 def test_validate_tag_allows_immutable_tags(tag: str) -> None:
     assert app_config.validate_tag(tag) == tag
@@ -140,11 +141,37 @@ def test_validate_tag_allows_immutable_tags(tag: str) -> None:
         "release",
         "staging-blue",
         "feature-x",
+        "v3.0.1",
+        "3.0.1",
+        "3.1.0-rc.1",
+        "v3.0.1+build.2",
+        "v3.0.1-deadbee",
+        "main-ABCDEF0",
+        "main-abcdef",
+        f"main-{'a' * 41}",
     ],
 )
 def test_validate_tag_rejects_moving_tags(tag: str) -> None:
     with pytest.raises(app_config.AppConfigError, match="tag"):
         app_config.validate_tag(tag)
+
+
+def test_validate_tag_allows_semver_only_for_explicit_dev() -> None:
+    assert app_config.validate_tag("v3.0.1", "dev") == "v3.0.1"
+    with pytest.raises(app_config.AppConfigError, match="semantic image tag"):
+        app_config.validate_tag("v3.0.1", "int")
+
+
+def test_validate_tag_cli_defaults_to_strict_policy() -> None:
+    script = Path(app_config.__file__)
+    result = subprocess.run(
+        ["python3", str(script), "validate-tag", "v3.0.1"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "semantic image tag" in result.stderr
 
 
 def test_rejects_unknown_dotenv_keys(tmp_path: Path) -> None:
@@ -308,6 +335,30 @@ def test_resolve_tag_uses_prod_fallback_file(tmp_path: Path) -> None:
     )
 
     assert tag == "main-deadbee"
+
+
+def test_resolve_tag_rejects_semantic_prod_fallback_file(tmp_path: Path) -> None:
+    tag_file = tmp_path / "prod-tag.txt"
+    tag_file.write_text("v3.0.1\n", encoding="utf-8")
+    with pytest.raises(app_config.AppConfigError, match="semantic image tag"):
+        app_config.resolve_tag(
+            {"SUGARKUBE_ENV": "prod", "SUGARKUBE_PROD_TAG_FILE": str(tag_file)},
+            "",
+            prod_fallback=True,
+        )
+
+
+def test_committed_production_pins_use_strict_branch_sha_policy() -> None:
+    root = Path(app_config.__file__).resolve().parents[1]
+    for pin in (root / "docs" / "apps").glob("*.prod.tag"):
+        values = [
+            line.split("#", 1)[0].strip()
+            for line in pin.read_text(encoding="utf-8").splitlines()
+            if line.split("#", 1)[0].strip()
+        ]
+        assert len(values) <= 1, pin
+        if values:
+            assert app_config.validate_tag(values[0], "prod") == values[0]
 
 
 def test_shell_emit_quotes_expected_exports(tmp_path: Path) -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2801,6 +2801,29 @@ def test_direct_helm_oci_helper_accepts_inline_semver_with_prerelease_and_build(
 
 
 @pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize("recipe", ["helm-oci-install", "helm-oci-upgrade"])
+def test_direct_helm_oci_helper_rejects_semantic_image_tag_before_helm(
+    recipe: str, generic_app_stub_env: dict[str, str]
+) -> None:
+    result = _run_just(
+        [
+            recipe,
+            "release=tokenplace",
+            "namespace=tokenplace",
+            "chart=oci://ghcr.io/futuroptimist/charts/tokenplace",
+            "version=1.2.3",
+            "tag=v3.0.1",
+            "env=staging",
+        ],
+        generic_app_stub_env,
+    )
+    assert result.returncode != 0
+    assert "semantic image tag" in result.stderr
+    helm_log_path = Path(generic_app_stub_env["HELM_LOG"])
+    assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
+
+
+@pytest.mark.usefixtures("ensure_just_available")
 @pytest.mark.parametrize(
     ("filename", "contents", "message"),
     [


### PR DESCRIPTION
### Motivation
- Prevent movable image aliases (semantic tags, `latest`, bare branches, env names, `main-latest`, etc.) from being used on staging/int/production deploy paths because they can be retargeted after approval. 
- Centralize and environment‑aware tag policy so all deployment entry points reject unsafe tags before any Helm `show`/`template`/`upgrade` or Kubernetes mutation.
- Preserve chart SemVer semantics and allow a dev-only exception for semantic tags when `env=dev` is explicitly chosen.

### Description
- Centralized the image‑tag policy in `scripts/app_config.py` via `validate_tag(tag, env)` and `resolve_tag(...)`, requiring lowercase branch‑SHA tags with a 7–40 char lowercase hex suffix for the strict policy and accepting SemVer only when `env=dev` is explicit.
- Made the `validate-tag` CLI accept an optional `--env` and default to the strict deployment policy when `--env` is omitted.
- Adjusted `resolve_tag()` to validate tags read from `SUGARKUBE_PROD_TAG_FILE` under the resolved environment.
- Closed deployment-path bypasses by validating `tag`/`default_tag` in the shared Helm helper (the `_helm-oci-deploy` block in `justfile`) before cluster identity checks or any Helm invocation, and ensured retained DSPACE wrappers use the centralized validator via the shared paths.
- Added/updated tests to cover accepted branch‑SHA forms, rejected semantic/mutable/malformed tags, the `int`→`staging` normalization, dev-only SemVer allowance, production fallback pin validation, committed `docs/apps/*.prod.tag` pins, and direct `helm-oci-install`/`helm-oci-upgrade` rejection before Helm.
- Updated docs to declare branch‑SHA tags as staging/production deployment coordinates and semantic tags as release/distribution aliases (keeps chart SemVer policy unchanged).

### Testing
- `python3 scripts/app_config.py validate-tag main-1a31a56` — succeeded (printed `main-1a31a56`).
- `python3 scripts/app_config.py validate-tag v3-deadbee` — succeeded (printed `v3-deadbee`).
- `python3 scripts/app_config.py validate-tag v3.0.1` — rejected (exits non‑zero and prints a concise error instructing operators to use a branch‑SHA tag).
- `python3 -m pytest -q tests/test_app_config.py tests/test_generic_app_just_recipes.py` — all tests passed (200 passed).
- `bash scripts/test-helm-oci-install.sh` — passed; verified helpers do not invoke Helm when tag/env validation fails and that digest-qualified charts still pass through unchanged.
- `just --unstable --fmt --check`, `git diff --check`, and local secret scans (`git diff | python3 scripts/scan-secrets.py` and staged diff scan) were run and reported no issues for the change set; a remote diff secret scan against `origin` was not possible in this environment.
- Repository tooling not available in this execution environment: `pre-commit`, `pyspelling`, and `linkchecker` were not installed so those checks were not run here (they should be run in CI). 

Closes #2321

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66edc87064832f9fd4a2b9e9a390a3)