### PR TITLE
Enforce branch-SHA image tags for staging/production deployments

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -91,25 +91,28 @@ The current apps map to that model as examples:
 Deployment tags must identify application code and release intent, not mutable
 environments.
 
-Acceptable deployment tags:
+Acceptable staging and production deployment tags:
 
-- Immutable branch-SHA tags, such as `main-REPLACE_SHORTSHA`.
-- Semver or release tags, such as `v1.2.3`, `3.1.0`, or another documented
-  project-specific stable tag.
-- Mutable branch convenience tags, such as `main-latest`, only when an app
-  runbook explicitly documents that a non-prod bootstrap or iteration flow accepts
-  them. They are an app-specific exception, not a shared guarantee; for example,
-  token.place deploy/redeploy wrappers reject every tag containing `latest`,
-  including `main-latest`.
+- Lowercase branch-SHA tags with a 7-40 character lowercase hexadecimal suffix,
+  such as `main-1a31a56`, `main-5ca96df16f0f`, or `v3-deadbee`.
 
 Unacceptable deployment tags:
 
 - `latest`;
 - bare branch names such as `main`, `master`, `develop`, or `release`; and
 - environment names such as `dev`, `staging`, `prod`, or `production`.
+- semantic tags such as `v1.2.3`, including prerelease, build, and
+  semantic-looking branch variants; and
+- tags without a valid lowercase branch-SHA suffix.
+
+Semantic image tags are release/distribution aliases, not immutable deployment
+coordinates. For backward compatibility, an explicit `env=dev` local-development
+flow may validate a semantic image tag. That exception never applies when the
+environment is omitted, `int`/staging, or production. Semantic **chart versions**
+remain valid because chart coordinates and image tags are separate types.
 
 Production promotion must use an immutable tag. The production tag pin file is
-part of the standard app coordinates and must contain the single immutable image
+part of the standard app coordinates and must contain the single branch-SHA image
 tag approved for production. Generic production promotion flows should read that
 pin when `tag=` is omitted and should update it only as an explicit approval
 step.

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -71,7 +71,8 @@ The app repo's `ci-image.yml` should answer yes to each item before Sugarkube st
 - It logs in to GHCR with repository-scoped credentials.
 - It publishes `ghcr.io/OWNER/IMAGE`.
 - It emits immutable branch-SHA tags such as `main-REPLACE_SHORTSHA`.
-- It may emit convenience tags such as `main-latest`, but those are non-prod only unless an app runbook explicitly says otherwise.
+- It may emit convenience or semantic release aliases, but they are distribution
+  aliases rather than staging or production deployment coordinates.
 - It does not require local Docker builds for staging or production deploys.
 - It records enough workflow output for an operator to find the tag to deploy.
 
@@ -126,7 +127,7 @@ Do not invent real configs for future apps such as `wove` until their app repos 
 
 ### I have a successful image build; what tag do I deploy?
 
-- Use the immutable branch-SHA or release tag from the successful image workflow.
+- Use the lowercase branch-SHA tag from the successful image workflow.
 - Prefer tags shaped like `main-REPLACE_SHORTSHA` for staging validation.
 - Do not deploy `latest`, a bare branch name, or an environment name.
 - Deploy staging first.
@@ -166,7 +167,7 @@ git commit -m "Bump appslug chart pin to 0.1.3"
 
 ### Staging works; how do I promote prod?
 
-- Keep the same immutable image tag that passed staging.
+- Keep the same branch-SHA image tag that passed staging.
 - Record or review the approved tag in `docs/apps/APP.prod.tag` when the app uses a committed prod pin.
 - Use the generic production promotion command.
 

--- a/docs/apps/danielsmith.md
+++ b/docs/apps/danielsmith.md
@@ -80,7 +80,7 @@ For production sidecar sign-off, run `just app-verify app=danielsmith env=prod`,
 
 ## Find or publish GHCR image
 
-Find the successful image workflow in the danielsmith.io app repo and copy the immutable branch-SHA or release tag. The GitHub Actions workflow page is where recent builds are found; the GHCR package page is where published image tags are cross-checked. Do not deploy `latest`, a bare branch name, or an environment name.
+Find the successful image workflow in the danielsmith.io app repo and copy its lowercase branch-SHA tag. Semantic tags are distribution aliases, not staging or production coordinates. The GitHub Actions workflow page is where recent builds are found; the GHCR package page is where published image tags are cross-checked. Do not deploy `latest`, a bare branch name, or an environment name.
 
 Web UI shortcuts:
 

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -48,7 +48,7 @@ Use these links before changing a deployment so the workflow runs, package versi
 
 ## Find or publish GHCR image
 
-Find the successful image workflow in the DSPACE app repo and copy the immutable branch-SHA or release tag. The GitHub Actions workflow page is where recent builds are found; the GHCR package page is where published image tags are cross-checked. Do not deploy `latest`, a bare branch name, or an environment name.
+Find the successful image workflow in the DSPACE app repo and copy its lowercase branch-SHA tag. Semantic tags are distribution aliases, not staging or production coordinates. The GitHub Actions workflow page is where recent builds are found; the GHCR package page is where published image tags are cross-checked. Do not deploy `latest`, a bare branch name, or an environment name.
 
 Web UI shortcuts:
 

--- a/docs/apps/jobbot3000.md
+++ b/docs/apps/jobbot3000.md
@@ -60,7 +60,7 @@ The committed staging overlay is intentionally copy-paste-ready for the first re
 
 ## Find or publish GHCR image
 
-Find the successful image workflow in the jobbot3000 app repo and copy the immutable branch-SHA or release tag. Do not deploy `latest`, `main-latest`, a bare branch name, or an environment name.
+Find the successful image workflow in the jobbot3000 app repo and copy its lowercase branch-SHA tag. Semantic tags are distribution aliases, not staging or production coordinates. Do not deploy `latest`, `main-latest`, a bare branch name, or an environment name.
 
 Web UI shortcuts:
 

--- a/docs/apps/tokenplace-relay.md
+++ b/docs/apps/tokenplace-relay.md
@@ -67,11 +67,12 @@ curl -fsS https://staging.token.place/
 
 ## Production promotion, deploy, and rollback
 
-Promote approved staging image tag. Final production promotion after token.place Git tag push should use tag `v0.1.0` (tag only; repository is already set in chart values).
+Promote the approved staging branch-SHA image tag. Semantic release tags such as
+`v0.1.0` are distribution aliases, not production deployment coordinates.
 
 
 ```bash
-TOKENPLACE_TAG=v0.1.0 # use final release tag after token.place Git tag push
+TOKENPLACE_TAG=main-deadbee # replace with the approved staging branch-SHA tag
 just tokenplace-oci-promote-prod tag="$TOKENPLACE_TAG"
 ```
 
@@ -79,7 +80,7 @@ Generic production upgrade with prod overlay:
 
 ```bash
 just kubeconfig-env prod
-TOKENPLACE_TAG=v0.1.0 # use final release tag after token.place Git tag push
+TOKENPLACE_TAG=main-deadbee # replace with the approved staging branch-SHA tag
 just helm-oci-upgrade release=tokenplace namespace=tokenplace chart=oci://ghcr.io/futuroptimist/charts/tokenplace values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml version_file=docs/apps/tokenplace.version default_tag="$TOKENPLACE_TAG" env=prod
 ```
 

--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -44,7 +44,7 @@ Use these links before changing a deployment so the workflow runs, package versi
 
 ## Find or publish GHCR image
 
-Find the successful image workflow in the token.place app repo and copy the immutable branch-SHA or release tag. The GitHub Actions workflow page is where recent builds are found; the GHCR package page is where published image tags are cross-checked. Do not deploy `latest`, a bare branch name, or an environment name.
+Find the successful image workflow in the token.place app repo and copy its lowercase branch-SHA tag. Semantic tags are distribution aliases, not staging or production coordinates. The GitHub Actions workflow page is where recent builds are found; the GHCR package page is where published image tags are cross-checked. Do not deploy `latest`, a bare branch name, or an environment name.
 
 Web UI shortcuts:
 

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -460,7 +460,7 @@ Traefik is available per the section above.
    ```
 
 5. Iterate new builds using your app's upgrade instructions (e.g., the dspace
-   guide covers rolling new `main-<shortsha>` images).
+   guide covers rolling new `main-REPLACE_SHORTSHA` images).
 
 ## Step 1: Verify your 3-node control plane is healthy
 
@@ -780,7 +780,7 @@ just helm-oci-upgrade \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \
   values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
   version_file=docs/apps/dspace.version \
-  default_tag=main-<shortsha> env=staging
+  default_tag=main-REPLACE_SHORTSHA env=staging
 ```
 
 For production preview (optional canary), this guide intentionally switches from the generic
@@ -788,7 +788,7 @@ For production preview (optional canary), this guide intentionally switches from
 post-deploy checks are included by default:
 
 ```bash
-just dspace-oci-deploy-prod-subdomain tag=main-<shortsha>
+just dspace-oci-deploy-prod-subdomain tag=main-REPLACE_SHORTSHA
 ```
 
 For production apex promotion, use `dspace-oci-promote-prod` with a pinned tag (for example the
@@ -811,7 +811,7 @@ If you prefer a one-liner that bakes in those arguments for dspace, use the help
 recipe (defaults to staging):
 
 ```bash
-just dspace-oci-redeploy env=staging tag=main-<shortsha>
+just dspace-oci-redeploy env=staging tag=main-REPLACE_SHORTSHA
 # or explicitly select an environment:
 read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
 just dspace-oci-redeploy env=prod tag="$(read_prod_tag)"
@@ -826,7 +826,7 @@ For immutable RC/stable validation (recommended for staging and prod), use the d
 helper instead:
 
 ```bash
-just dspace-oci-deploy env=staging tag=main-<shortsha>
+just dspace-oci-deploy env=staging tag=main-REPLACE_SHORTSHA
 
 read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
 just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
@@ -981,7 +981,7 @@ As you continue operating your cluster, these recipes will be helpful:
   use `just wipe` to clean it up, then rerun `just ha3 env=dev` to rejoin correctly.
 
 - **Emergency dspace redeploy:** Run
-  `just dspace-oci-redeploy env=staging tag=main-<shortsha>` with the intended
+  `just dspace-oci-redeploy env=staging tag=main-REPLACE_SHORTSHA` with the intended
   branch-SHA image coordinate to force a rollout restart without retyping chart
   arguments.
 

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -780,7 +780,7 @@ just helm-oci-upgrade \
   chart=oci://ghcr.io/democratizedspace/charts/dspace \
   values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
   version_file=docs/apps/dspace.version \
-  default_tag=main-latest env=staging
+  default_tag=main-<shortsha> env=staging
 ```
 
 For production preview (optional canary), this guide intentionally switches from the generic
@@ -811,7 +811,7 @@ If you prefer a one-liner that bakes in those arguments for dspace, use the help
 recipe (defaults to staging):
 
 ```bash
-just dspace-oci-redeploy
+just dspace-oci-redeploy env=staging tag=main-<shortsha>
 # or explicitly select an environment:
 read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/dspace.prod.tag | head -n1 | tr -d '[:space:]'; }
 just dspace-oci-redeploy env=prod tag="$(read_prod_tag)"
@@ -819,8 +819,7 @@ just dspace-oci-redeploy env=prod tag="$(read_prod_tag)"
 
 Under the hood, both commands call the shared `_helm-oci-deploy` helper via
 `helm-oci-upgrade`, performing `helm upgrade --reuse-values` against the running release
-and then forcing a `kubectl rollout restart deploy/dspace` to ensure pods recycle even
-when `main-latest` is republished with the same tag. The helper waits for the rollout to
+and then forcing a `kubectl rollout restart deploy/dspace` to ensure pods recycle. The helper waits for the rollout to
 finish and exits non-zero if Kubernetes reports a failure.
 
 For immutable RC/stable validation (recommended for staging and prod), use the dedicated
@@ -839,10 +838,8 @@ just dspace-oci-deploy env=prod tag="$(read_prod_tag)"
 `kubectl rollout status`, and prints post-deploy verification commands for `config.json`,
 `/healthz`, and `/livez` using the live ingress host (or `<dspace-host>` when none is discoverable).
 
-When you pass an image tag (including the default `main-latest`), the helper sets
-`image.pullPolicy=Always` so the nodes re-check GHCR for the latest build of that tag on
-each redeploy. For production, prefer immutable tags (for example, `main-<shortsha>`) if you want
-to pin a specific image.
+When you pass the required branch-SHA image tag, the helper sets
+`image.pullPolicy=Always` so the nodes re-check GHCR for that build on each redeploy.
 
 **Emergency redeploy checklist:**
 
@@ -852,8 +849,8 @@ to pin a specific image.
     just cluster-status
     ```
 
-2. Ensure your new image is pushed and `main-latest` (or the tag you pass via `tag=`)
-   points at the desired build (see the dspace repo docs for image build/publish steps).
+2. Ensure your new image is pushed and copy its branch-SHA tag (see the dspace repo docs
+   for image build/publish steps).
 3. Run the redeploy command (`just helm-oci-upgrade ...` or `just dspace-oci-redeploy`).
 4. Verify pods and logs:
 
@@ -983,9 +980,10 @@ As you continue operating your cluster, these recipes will be helpful:
 - **Recover from misconfiguration:** If a node accidentally joins the wrong cluster,
   use `just wipe` to clean it up, then rerun `just ha3 env=dev` to rejoin correctly.
 
-- **Emergency dspace redeploy:** Run `just dspace-oci-redeploy` to pull the latest
-  dspace chart from GHCR and force a rollout restart so pods refresh to the newest
-  `main-latest` image digest without retyping chart arguments.
+- **Emergency dspace redeploy:** Run
+  `just dspace-oci-redeploy env=staging tag=main-<shortsha>` with the intended
+  branch-SHA image coordinate to force a rollout restart without retyping chart
+  arguments.
 
 ### Document outages and incidents
 

--- a/justfile
+++ b/justfile
@@ -1339,6 +1339,14 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     esac
     export SUGARKUBE_ENV="${requested_env}"
 
+    image_tag="${tag}"
+    if [ -z "${image_tag}" ] && [ -n "${default_tag}" ]; then
+        image_tag="${default_tag}"
+    fi
+    if [ -n "${image_tag}" ]; then
+      image_tag="$(python3 "{{ justfile_directory() }}/scripts/app_config.py" validate-tag "${image_tag}" --env "${requested_env}")"
+    fi
+
     allow_install="$(normalize_prefixed_value allow_install "{{ allow_install }}")"
     reuse_values="$(normalize_prefixed_value reuse_values "{{ reuse_values }}")"
 
@@ -1380,11 +1388,6 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     version_args=()
     if [ -n "${chart_version}" ] && [ "${digest_chart}" = false ]; then
         version_args+=(--version "${chart_version}")
-    fi
-
-    image_tag="${tag}"
-    if [ -z "${image_tag}" ] && [ -n "${default_tag}" ]; then
-        image_tag="${default_tag}"
     fi
 
     echo "app: ${release}"
@@ -1646,12 +1649,13 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+    config_exports="$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
       --app {{ quote(app) }} \
       --env {{ quote(env) }} \
       --config {{ quote(config) }} \
       --tag {{ quote(tag) }} \
       --require-tag)"
+    eval "${config_exports}"
 
     release_manifest={{ quote(manifest) }}
     evidence_output={{ quote(evidence) }}
@@ -1718,12 +1722,13 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+    config_exports="$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
       --app {{ quote(app) }} \
       --env {{ quote(env) }} \
       --config {{ quote(config) }} \
       --tag {{ quote(tag) }} \
       --require-tag)"
+    eval "${config_exports}"
 
     release_manifest={{ quote(manifest) }}
     evidence_output={{ quote(evidence) }}
@@ -1779,13 +1784,14 @@ app-promote-prod app tag='' config='' manifest='' evidence='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+    config_exports="$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
       --app {{ quote(app) }} \
       --env prod \
       --config {{ quote(config) }} \
       --tag {{ quote(tag) }} \
       --prod-tag-fallback \
       --require-tag)"
+    eval "${config_exports}"
     delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-deploy \
       app="${SUGARKUBE_APP}" env=prod tag="${SUGARKUBE_TAG}" config="${SUGARKUBE_CONFIG_PATH}")
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})

--- a/justfile
+++ b/justfile
@@ -1948,12 +1948,13 @@ dspace-oci-promote-prod tag='' manifest='' evidence='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+    config_exports="$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
       --app dspace \
       --env prod \
       --tag {{ quote(tag) }} \
       --prod-tag-fallback \
       --require-tag)"
+    eval "${config_exports}"
     delegate=(just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy env=prod tag="${SUGARKUBE_TAG}")
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
@@ -2057,20 +2058,6 @@ tokenplace-oci-deploy env='staging' tag='':
         ;;
     esac
 
-    # Shared immutable-tag guard for deploy/redeploy paths avoids moving-target tags.
-    validate_immutable_tag() {
-      local candidate="${1}"
-      local tag_lc
-      tag_lc="$(echo "${candidate}" | tr '[:upper:]' '[:lower:]')"
-      if [[ "${tag_lc}" == *latest* ]] \
-        || [[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || [[ "${tag_lc}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || ([[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] && [[ ! "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]); then
-        echo "ERROR: mutable tag '${candidate}' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
-        exit 1
-      fi
-    }
-
     resolved_tag="$(echo '{{ tag }}' | xargs)"
     while [ "${resolved_tag#tag=}" != "${resolved_tag}" ]; do
       resolved_tag="${resolved_tag#tag=}"
@@ -2079,7 +2066,7 @@ tokenplace-oci-deploy env='staging' tag='':
       echo "ERROR: tag is required for immutable deploys." >&2
       exit 1
     fi
-    validate_immutable_tag "${resolved_tag}"
+    python3 "{{ justfile_directory() }}/scripts/app_config.py" validate-tag "${resolved_tag}" --env "${env_name}" >/dev/null
     chart_version=""
     if [ -f docs/apps/tokenplace.version ]; then
       chart_version="$(
@@ -2143,12 +2130,13 @@ tokenplace-oci-promote-prod tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+    config_exports="$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
       --app tokenplace \
       --env prod \
       --tag {{ quote(tag) }} \
       --prod-tag-fallback \
       --require-tag)"
+    eval "${config_exports}"
     just --justfile "{{ justfile_directory() }}/justfile" tokenplace-oci-deploy env=prod tag="${SUGARKUBE_TAG}"
 
 # Upgrade-only token.place OCI redeploy path.
@@ -2169,19 +2157,6 @@ tokenplace-oci-redeploy env='staging' tag='':
         ;;
     esac
 
-    # Shared immutable-tag guard for deploy/redeploy paths avoids moving-target tags.
-    validate_immutable_tag() {
-      local candidate="${1}"
-      local tag_lc
-      tag_lc="$(echo "${candidate}" | tr '[:upper:]' '[:lower:]')"
-      if [[ "${tag_lc}" == *latest* ]] \
-        || [[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || [[ "${tag_lc}" =~ -(main|master|dev|develop|staging|prod|production|release)$ ]] \
-        || ([[ "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)- ]] && [[ ! "${tag_lc}" =~ ^(main|master|dev|develop|staging|prod|production|release)-[0-9a-f]{7,}$ ]]); then
-        echo "ERROR: mutable tag '${candidate}' is not allowed. Use an immutable branch-sha tag (example: main-deadbee)." >&2
-        exit 1
-      fi
-    }
     read_prod_tag() { sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' docs/apps/tokenplace.prod.tag | head -n1 | tr -d '[:space:]'; }
 
     resolved_tag="$(echo '{{ tag }}' | xargs)"
@@ -2197,7 +2172,7 @@ tokenplace-oci-redeploy env='staging' tag='':
       echo "Non-prod redeploy intentionally has no baked-in fallback tag so this path is reproducible and reviewable." >&2
       exit 1
     fi
-    [ -n "${resolved_tag}" ] && validate_immutable_tag "${resolved_tag}"
+    [ -z "${resolved_tag}" ] || python3 "{{ justfile_directory() }}/scripts/app_config.py" validate-tag "${resolved_tag}" --env "${env_name}" >/dev/null
 
     values_chain='docs/examples/tokenplace.values.dev.yaml'
     default_tag=''
@@ -2519,12 +2494,13 @@ danielsmith-oci-promote-prod tag='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+    config_exports="$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
       --app danielsmith \
       --env prod \
       --tag {{ quote(tag) }} \
       --prod-tag-fallback \
       --require-tag)"
+    eval "${config_exports}"
     just --justfile "{{ justfile_directory() }}/justfile" danielsmith-oci-deploy env=prod tag="${SUGARKUBE_TAG}"
 
 # Upgrade-only danielsmith OCI redeploy path.

--- a/scripts/app_config.py
+++ b/scripts/app_config.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Load Sugarkube app deployment config and validate immutable image tags."""
+"""Load Sugarkube app deployment config and validate deployment-safe image tags."""
 
 from __future__ import annotations
 
@@ -55,7 +55,7 @@ REQUIRED_KEYS = {
     "SUGARKUBE_CHART",
 }
 ASSIGNMENT_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
-BRANCH_SHA_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*-[0-9a-f]{7,}$", re.IGNORECASE)
+BRANCH_SHA_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*-[0-9a-f]{7,40}$")
 SEMVER_RE = re.compile(
     r"^v?[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$"
 )
@@ -91,29 +91,30 @@ def validate_app_name(app: str) -> str:
     return app
 
 
-def validate_tag(tag: str) -> str:
+def validate_tag(tag: str, env: str | None = None) -> str:
+    """Validate an image tag for an environment.
+
+    An omitted environment uses the strict deployment-safe policy.  Semantic
+    tags are retained only for explicit local-development flows.
+    """
     tag = normalize_named(tag, "tag")
     if not tag:
-        raise AppConfigError(
-            "tag must not be empty. Use an immutable tag such as main-deadbee or v0.1.0."
-        )
-    tag_lc = tag.lower()
-    if tag_lc in MOVING_TAGS or "latest" in tag_lc:
-        raise AppConfigError(
-            f"mutable tag '{tag}' is not allowed. Use an immutable branch-SHA tag "
-            "(example: main-deadbee) or a semver release tag (example: v0.1.0)."
-        )
-    if re.search(r"(^|[-_.])(dev|develop|staging|prod|production|release)([-_.]|$)", tag_lc):
-        if not BRANCH_SHA_RE.fullmatch(tag):
-            raise AppConfigError(
-                f"environment-like moving tag '{tag}' is not allowed. Use an immutable "
-                "branch-SHA tag ending in at least 7 hex characters."
-            )
-    if BRANCH_SHA_RE.fullmatch(tag) or SEMVER_RE.fullmatch(tag):
+        raise AppConfigError("tag must not be empty. Use a branch-SHA tag such as main-deadbee.")
+    normalized_env = normalize_env(env) if env is not None else None
+    if normalized_env == "dev" and SEMVER_RE.fullmatch(tag):
         return tag
+    if not SEMVER_RE.fullmatch(tag) and BRANCH_SHA_RE.fullmatch(tag):
+        return tag
+    tag_lc = tag.lower()
+    kind = (
+        "semantic or mutable"
+        if SEMVER_RE.fullmatch(tag) or tag_lc in MOVING_TAGS or "latest" in tag_lc
+        else "invalid"
+    )
     raise AppConfigError(
-        f"invalid tag '{tag}'. Use an immutable branch-SHA tag (main-deadbee) "
-        "or semver release tag."
+        f"{kind} tag '{tag}' is not a deployment-safe image tag. "
+        "Use a lowercase branch-SHA tag ending in 7-40 lowercase hex characters "
+        "(example: main-deadbee)."
     )
 
 
@@ -252,7 +253,7 @@ def resolve_tag(config: dict[str, str], raw_tag: str, *, prod_fallback: bool) ->
                     if line:
                         tag = line
                         break
-    return validate_tag(tag)
+    return validate_tag(tag, config.get("SUGARKUBE_ENV"))
 
 
 def shell_emit(config: dict[str, str]) -> str:
@@ -300,12 +301,13 @@ def main(argv: list[str] | None = None) -> int:
         cmd.add_argument("--prod-tag-fallback", action="store_true")
     validate = sub.add_parser("validate-tag")
     validate.add_argument("tag")
+    validate.add_argument("--env")
     host = sub.add_parser("host-value")
     host.add_argument("host_key")
     args = parser.parse_args(argv)
     try:
         if args.command == "validate-tag":
-            print(validate_tag(args.tag))
+            print(validate_tag(args.tag, args.env))
             return 0
         if args.command == "host-value":
             data = json.load(sys.stdin)

--- a/scripts/app_config.py
+++ b/scripts/app_config.py
@@ -103,9 +103,9 @@ def validate_tag(tag: str, env: str | None = None) -> str:
     normalized_env = normalize_env(env) if env is not None else None
     if normalized_env == "dev" and SEMVER_RE.fullmatch(tag):
         return tag
-    if not SEMVER_RE.fullmatch(tag) and BRANCH_SHA_RE.fullmatch(tag):
-        return tag
     tag_lc = tag.lower()
+    if "latest" not in tag_lc and not SEMVER_RE.fullmatch(tag) and BRANCH_SHA_RE.fullmatch(tag):
+        return tag
     kind = (
         "semantic or mutable"
         if SEMVER_RE.fullmatch(tag) or tag_lc in MOVING_TAGS or "latest" in tag_lc

--- a/scripts/test-helm-oci-install.sh
+++ b/scripts/test-helm-oci-install.sh
@@ -148,7 +148,7 @@ command_output="$(
         chart=oci://registry.test/charts/dspace \
         values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
         version_file=docs/apps/dspace.version \
-        default_tag=v3-latest env=staging
+        default_tag=v3-deadbee env=staging
 )"
 
 if ! grep -q "oci://registry.test/charts/dspace" <<<"${command_output}"; then

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -146,6 +146,7 @@ def test_validate_tag_allows_deployment_safe_tags(tag: str) -> None:
         "3.0.1+build.5",
         "v3.0.1-deadbee",
         "main-ABCDEF0",
+        "main-latest-deadbee",
         "main-deadbe",
         "main-" + "a" * 41,
     ],
@@ -349,7 +350,7 @@ def test_resolve_tag_rejects_semantic_prod_fallback(tmp_path: Path) -> None:
         )
 
 
-def test_committed_prod_pins_are_empty_or_branch_sha() -> None:
+def test_committed_prod_pins_are_empty_or_deployment_safe() -> None:
     for path in Path("docs/apps").glob("*.prod.tag"):
         pins = [
             line.split("#", 1)[0].strip()
@@ -358,7 +359,7 @@ def test_committed_prod_pins_are_empty_or_branch_sha() -> None:
         ]
         assert len(pins) <= 1
         for tag in pins:
-            assert app_config.BRANCH_SHA_RE.fullmatch(tag), f"invalid production pin: {path}"
+            assert app_config.validate_tag(tag, "prod") == tag, f"invalid production pin: {path}"
 
 
 def test_shell_emit_quotes_expected_exports(tmp_path: Path) -> None:

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -120,9 +120,9 @@ def test_explicit_config_path_precedes_config_dir_and_resolves_env_values(
 
 @pytest.mark.parametrize(
     "tag",
-    ["main-deadbee", "v3-deadbee", "feature-x-deadbee", "v0.1.0", "3.0.1", "3.1.0-rc.1"],
+    ["main-1a31a56", "main-5ca96df16f0f", "v3-deadbee", "feature-x-deadbee"],
 )
-def test_validate_tag_allows_immutable_tags(tag: str) -> None:
+def test_validate_tag_allows_deployment_safe_tags(tag: str) -> None:
     assert app_config.validate_tag(tag) == tag
 
 
@@ -140,11 +140,38 @@ def test_validate_tag_allows_immutable_tags(tag: str) -> None:
         "release",
         "staging-blue",
         "feature-x",
+        "v3.0.1",
+        "3.0.1",
+        "v3.0.1-rc.1",
+        "3.0.1+build.5",
+        "v3.0.1-deadbee",
+        "main-ABCDEF0",
+        "main-deadbe",
+        "main-" + "a" * 41,
     ],
 )
-def test_validate_tag_rejects_moving_tags(tag: str) -> None:
+def test_strict_validate_tag_rejects_semantic_movable_and_malformed_tags(tag: str) -> None:
     with pytest.raises(app_config.AppConfigError, match="tag"):
         app_config.validate_tag(tag)
+
+
+def test_validate_tag_semver_exception_requires_explicit_dev() -> None:
+    assert app_config.validate_tag("v3.0.1", "dev") == "v3.0.1"
+    with pytest.raises(app_config.AppConfigError, match="branch-SHA"):
+        app_config.validate_tag("v3.0.1", "int")
+    with pytest.raises(app_config.AppConfigError, match="branch-SHA"):
+        app_config.validate_tag("v3.0.1", "staging")
+    with pytest.raises(app_config.AppConfigError, match="branch-SHA"):
+        app_config.validate_tag("v3.0.1", "prod")
+
+
+def test_validate_tag_cli_defaults_strict_and_supports_explicit_dev(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert app_config.main(["validate-tag", "v3.0.1"]) == 2
+    assert "branch-SHA" in capsys.readouterr().err
+    assert app_config.main(["validate-tag", "v3.0.1", "--env", "dev"]) == 0
+    assert capsys.readouterr().out.strip() == "v3.0.1"
 
 
 def test_rejects_unknown_dotenv_keys(tmp_path: Path) -> None:
@@ -302,12 +329,36 @@ def test_resolve_tag_uses_prod_fallback_file(tmp_path: Path) -> None:
     tag_file.write_text("# promoted digest tag\nmain-deadbee\n", encoding="utf-8")
 
     tag = app_config.resolve_tag(
-        {"SUGARKUBE_PROD_TAG_FILE": str(tag_file)},
+        {"SUGARKUBE_PROD_TAG_FILE": str(tag_file), "SUGARKUBE_ENV": "prod"},
         "",
         prod_fallback=True,
     )
 
     assert tag == "main-deadbee"
+
+
+def test_resolve_tag_rejects_semantic_prod_fallback(tmp_path: Path) -> None:
+    tag_file = tmp_path / "prod-tag.txt"
+    tag_file.write_text("v3.0.1\n", encoding="utf-8")
+
+    with pytest.raises(app_config.AppConfigError, match="branch-SHA"):
+        app_config.resolve_tag(
+            {"SUGARKUBE_PROD_TAG_FILE": str(tag_file), "SUGARKUBE_ENV": "prod"},
+            "",
+            prod_fallback=True,
+        )
+
+
+def test_committed_prod_pins_are_empty_or_branch_sha() -> None:
+    for path in Path("docs/apps").glob("*.prod.tag"):
+        pins = [
+            line.split("#", 1)[0].strip()
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.split("#", 1)[0].strip()
+        ]
+        assert len(pins) <= 1
+        for tag in pins:
+            assert app_config.BRANCH_SHA_RE.fullmatch(tag), f"invalid production pin: {path}"
 
 
 def test_shell_emit_quotes_expected_exports(tmp_path: Path) -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1327,6 +1327,10 @@ def test_app_deploy_rejects_mutable_tag_before_helm(
         ("app-promote-prod", ["app=jobbot3000", "tag=v3.0.1"]),
         ("dspace-oci-deploy", ["env=staging", "tag=v3.0.1"]),
         ("dspace-oci-promote-prod", ["tag=v3.0.1"]),
+        ("tokenplace-oci-deploy", ["env=staging", "tag=v3.0.1"]),
+        ("tokenplace-oci-redeploy", ["env=staging", "tag=v3.0.1"]),
+        ("tokenplace-oci-promote-prod", ["tag=v3.0.1"]),
+        ("danielsmith-oci-promote-prod", ["tag=v3.0.1"]),
     ],
 )
 def test_deployment_entry_points_reject_semantic_tags_before_helm(
@@ -1338,6 +1342,45 @@ def test_deployment_entry_points_reject_semantic_tags_before_helm(
     assert "branch-SHA" in result.stderr
     helm_log_path = Path(generic_app_stub_env["HELM_LOG"])
     assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
+    command_log = helm_log_path.with_name("commands.log")
+    assert not command_log.exists() or command_log.read_text(encoding="utf-8") == ""
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_promote_prod_rejects_semantic_fallback_before_cluster_access(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    prod_tag = tmp_path / "jobbot3000.prod.tag"
+    prod_tag.write_text("v3.0.1\n", encoding="utf-8")
+    config = tmp_path / "jobbot3000.env"
+    config.write_text(
+        "\n".join(
+            [
+                "SUGARKUBE_APP=jobbot3000",
+                "SUGARKUBE_RELEASE=jobbot3000",
+                "SUGARKUBE_NAMESPACE=jobbot3000",
+                "SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/jobbot3000",
+                "SUGARKUBE_VERSION=1.0.0",
+                f"SUGARKUBE_PROD_TAG_FILE={prod_tag}",
+                "SUGARKUBE_VALUES_DEV=docs/examples/jobbot3000.values.dev.yaml",
+                "SUGARKUBE_VALUES_STAGING=docs/examples/jobbot3000.values.staging.yaml",
+                "SUGARKUBE_VALUES_PROD=docs/examples/jobbot3000.values.prod.yaml",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_just(
+        ["app-promote-prod", "app=jobbot3000", f"config={config}"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode != 0
+    assert "branch-SHA" in result.stderr
+    for name in ("helm.log", "kubectl.log", "commands.log"):
+        log = tmp_path / name
+        assert not log.exists() or log.read_text(encoding="utf-8") == ""
 
 
 @pytest.mark.usefixtures("ensure_just_available")
@@ -2824,8 +2867,9 @@ def test_direct_helm_oci_helper_accepts_inline_semver_with_prerelease_and_build(
 
 @pytest.mark.usefixtures("ensure_just_available")
 @pytest.mark.parametrize("recipe", ["helm-oci-install", "helm-oci-upgrade"])
+@pytest.mark.parametrize("image_arg", ["tag=v3.0.1", "default_tag=v3.0.1"])
 def test_direct_helm_oci_helpers_reject_semantic_image_tag_before_helm(
-    recipe: str, generic_app_stub_env: dict[str, str]
+    recipe: str, image_arg: str, generic_app_stub_env: dict[str, str]
 ) -> None:
     result = _run_just(
         [
@@ -2834,7 +2878,7 @@ def test_direct_helm_oci_helpers_reject_semantic_image_tag_before_helm(
             "namespace=tokenplace",
             "chart=oci://ghcr.io/futuroptimist/charts/tokenplace",
             "version=1.2.3",
-            "tag=v3.0.1",
+            image_arg,
             "env=staging",
         ],
         generic_app_stub_env,

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1319,6 +1319,28 @@ def test_app_deploy_rejects_mutable_tag_before_helm(
 
 
 @pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize(
+    ("recipe", "args"),
+    [
+        ("app-deploy", ["app=jobbot3000", "env=staging", "tag=v3.0.1"]),
+        ("app-redeploy", ["app=jobbot3000", "env=int", "tag=v3.0.1"]),
+        ("app-promote-prod", ["app=jobbot3000", "tag=v3.0.1"]),
+        ("dspace-oci-deploy", ["env=staging", "tag=v3.0.1"]),
+        ("dspace-oci-promote-prod", ["tag=v3.0.1"]),
+    ],
+)
+def test_deployment_entry_points_reject_semantic_tags_before_helm(
+    recipe: str, args: list[str], generic_app_stub_env: dict[str, str]
+) -> None:
+    result = _run_just([recipe, *args], generic_app_stub_env)
+
+    assert result.returncode != 0
+    assert "branch-SHA" in result.stderr
+    helm_log_path = Path(generic_app_stub_env["HELM_LOG"])
+    assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
+
+
+@pytest.mark.usefixtures("ensure_just_available")
 def test_dspace_oci_deploy_wrapper_propagates_inline_chart_pin(
     tmp_path: Path, generic_app_stub_env: dict[str, str]
 ) -> None:
@@ -2798,6 +2820,30 @@ def test_direct_helm_oci_helper_accepts_inline_semver_with_prerelease_and_build(
         "--version 1.2.3-rc.1+build.5"
     ) in helm_log
     assert "upgrade tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace" in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize("recipe", ["helm-oci-install", "helm-oci-upgrade"])
+def test_direct_helm_oci_helpers_reject_semantic_image_tag_before_helm(
+    recipe: str, generic_app_stub_env: dict[str, str]
+) -> None:
+    result = _run_just(
+        [
+            recipe,
+            "release=tokenplace",
+            "namespace=tokenplace",
+            "chart=oci://ghcr.io/futuroptimist/charts/tokenplace",
+            "version=1.2.3",
+            "tag=v3.0.1",
+            "env=staging",
+        ],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode != 0
+    assert "branch-SHA" in result.stderr
+    helm_log_path = Path(generic_app_stub_env["HELM_LOG"])
+    assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
 
 
 @pytest.mark.usefixtures("ensure_just_available")


### PR DESCRIPTION
### Motivation

- Prevent semantic and otherwise movable image tags such as `v3.0.1`, `latest`, `main`, `main-latest`, and `staging` from being used as staging or production deployment coordinates.
- Reject unsafe tags before Helm inspection, rendering, upgrades, cluster identity checks, or Kubernetes mutation.
- Preserve semantic tags only as an explicit `env=dev` local-development exception.

### What changed

- Centralized environment-aware image-tag validation in `scripts/app_config.py`.
  - Staging, `int`, production, and environment-free CLI validation require a lowercase branch-SHA tag with a 7–40 character lowercase hexadecimal suffix.
  - Examples accepted by the strict policy include `main-1a31a56`, longer branch-SHA tags, and `v3-deadbee`.
  - Semantic, movable, malformed, uppercase-SHA, and `latest`-containing tags are rejected.
  - `resolve_tag()` validates both explicit tags and production fallback-pin contents under the resolved environment.
- Updated `validate-tag` to accept an explicit environment while keeping omitted-environment validation strict.
- Closed deployment-path bypasses in `justfile`.
  - Generic deploy, redeploy, and production-promotion recipes fail closed on tag-resolution errors.
  - Direct `helm-oci-install` and `helm-oci-upgrade` helpers validate `tag` and `default_tag` before Helm or cluster access.
  - DSPACE, token.place, and danielsmith compatibility paths use the centralized policy before manifest, chart-preflight, Helm, or mutation handling.
- Added deterministic regression coverage for strict and development validation, `int` normalization, explicit and fallback production tags, committed production pins, direct Helm helpers, generic recipes, and compatibility wrappers.
- Updated the deployment contract, onboarding material, application runbooks, and Raspberry Pi operations examples to use shell-safe branch-SHA coordinates. Semantic tags remain documented as distribution aliases rather than immutable deployment coordinates.

### Safety and compatibility

- Chart-version SemVer validation remains unchanged.
- No image-digest support was added.
- DSPACE release-manifest schemas, OCI provenance, rollback behavior, chart pins, image pins, `--reuse-values`, and generic rendering behavior were not changed.
- No live cluster, Helm, Kubernetes, registry, release, or deployment operations were performed.

### Verification

- `python3 scripts/app_config.py validate-tag main-1a31a56`
- `python3 scripts/app_config.py validate-tag v3-deadbee`
- Verified that environment-free validation rejects `v3.0.1`.
- `python3 -m pytest -q tests/test_app_config.py tests/test_generic_app_just_recipes.py` — 213 passed.
- `bash scripts/test-helm-oci-install.sh`
- `just --unstable --fmt --check`
- Shell parsing checks for the branch-SHA runbook examples.
- `git diff --check`
- Secret scans for the working diff and complete PR diff.

Closes #2321

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66edc531e0832fb62f2a70bcc2e839)