### PR TITLE
Polish staging observability dashboard signals

### DIFF
--- a/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
+++ b/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
@@ -41,7 +41,7 @@
       },
       {
         "name": "app",
-        "label": "Application",
+        "label": "Probe application",
         "type": "query",
         "datasource": {
           "type": "prometheus",
@@ -62,7 +62,7 @@
       },
       {
         "name": "route",
-        "label": "Route",
+        "label": "Probe route",
         "type": "query",
         "datasource": {
           "type": "prometheus",
@@ -153,7 +153,7 @@
     {
       "id": 3,
       "type": "stat",
-      "title": "DSPACE instrumentation status",
+      "title": "Instrumentation health",
       "description": "Application instrumentation self-check.",
       "datasource": {
         "type": "prometheus",
@@ -204,8 +204,8 @@
     {
       "id": 4,
       "type": "stat",
-      "title": "Public endpoint availability",
-      "description": "Latest bounded public probe result.",
+      "title": "Public availability summary",
+      "description": "Aggregate latest health for the selected public probe filters. No data remains unknown rather than healthy.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -219,52 +219,69 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})",
-          "legendFormat": "{{environment}} / {{app}} / {{route}}"
+          "expr": "count(min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) == 1)",
+          "legendFormat": "Healthy endpoints",
+          "instant": true,
+          "range": false
+        },
+        {
+          "refId": "B",
+          "expr": "count(min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) == 0)",
+          "legendFormat": "Failed endpoints",
+          "instant": true,
+          "range": false
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "percentunit",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Healthy endpoints"
+            },
+            "properties": [
               {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
               }
             ]
           },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": {
-                  "text": "FAILED",
-                  "color": "red"
-                },
-                "1": {
-                  "text": "UP",
-                  "color": "green"
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failed endpoints"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
                 }
               }
-            }
-          ]
-        },
-        "overrides": []
+            ]
+          }
+        ]
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom"
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
         },
-        "tooltip": {
-          "mode": "multi"
-        }
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
       }
     },
     {
@@ -282,22 +299,22 @@
     {
       "id": 6,
       "type": "timeseries",
-      "title": "Request rate by route and status class",
-      "description": "Bounded route templates and status classes only.",
+      "title": "User request rate by route and status class",
+      "description": "Application traffic only; health, liveness, and metrics routes are shown separately.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 10,
         "x": 0,
         "y": 7
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by (route, status_class) (rate(dspace_http_requests_total{environment=~\"$environment\"}[$__rate_interval]))",
+          "expr": "sum by (route, status_class) (rate(dspace_http_requests_total{environment=~\"$environment\",route!~\"/(healthz|livez|metrics)\"}[$__rate_interval]))",
           "legendFormat": "{{route}} {{status_class}}"
         }
       ],
@@ -318,41 +335,132 @@
       }
     },
     {
-      "id": 7,
-      "type": "barchart",
-      "title": "Status-class distribution",
-      "description": "Requests in the selected range grouped by bounded status class.",
+      "id": 21,
+      "type": "timeseries",
+      "title": "Operational request rate",
+      "description": "Health, liveness, and metrics traffic kept separate from user requests.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
+        "w": 4,
+        "x": 10,
+        "y": 7
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (route) (rate(dspace_http_requests_total{environment=~\"$environment\",route=~\"/(healthz|livez|metrics)\"}[$__rate_interval]))",
+          "legendFormat": "{{route}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 7,
+      "type": "bargauge",
+      "title": "Status-class distribution",
+      "description": "Selected-window request totals grouped by bounded status class.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 10,
+        "x": 14,
         "y": 7
       },
       "targets": [
         {
           "refId": "A",
           "expr": "sum by (status_class) (increase(dspace_http_requests_total{environment=~\"$environment\"}[$__range]))",
-          "legendFormat": "{{status_class}}"
+          "legendFormat": "{{status_class}}",
+          "instant": true,
+          "range": false
         }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^2xx$"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^4xx$"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "yellow"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^5xx$"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          }
+        ]
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom"
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
         },
-        "tooltip": {
-          "mode": "multi"
-        }
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true,
+        "minVizWidth": 0,
+        "minVizHeight": 10
       }
     },
     {

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -71,8 +71,10 @@ The mutating recipes never use `--reuse-values`; the committed version, both
 values files in order, and the dashboard source are always supplied. Before
 cluster access or mutation, the helper rejects malformed dashboard JSON,
 changed identity, duplicate panel IDs, missing metric families, unsafe
-event-driven queries, or invalid datasource references. It then validates that
-the pinned render contains exactly one copy in the intended Grafana provider.
+event-driven queries, invalid datasource references, or regressions in the
+dashboard's aggregate availability, traffic separation, selected-window status
+distribution, probe filters, and detailed endpoint matrix. It then validates
+that the pinned render contains exactly one copy in the intended Grafana provider.
 The existing staging blackbox exporter release is upgraded after this change
 with `just observability-blackbox-upgrade env=staging`; it is not reinstalled.
 Repository tests do not perform any live cluster mutation, and repository state
@@ -126,10 +128,15 @@ is not rollout evidence.
 - Alertmanager: one replica and no-op receiver named exactly `"null"`.
 - Grafana: persistence disabled, no Ingress, LAN-only NodePort `30300`.
 - The provisioned dashboard defaults to six hours and a 30-second refresh. It
-  covers overall DSPACE and public-probe status, bounded DSPACE HTTP rate/error/
-  latency, runtime and build identity, feature traffic, and blackbox endpoint,
-  duration, HTTP status, and TLS lifetime views. Its staging `environment`,
-  `app`, and `route` variables avoid raw target URLs.
+  covers overall DSPACE status and an instant aggregate of healthy and failed
+  public probes. DSPACE HTTP panels separate user request rates from `/healthz`,
+  `/livez`, and `/metrics` operational traffic, while status classes are an
+  instant categorical total for the selected window rather than a rising time
+  series. Runtime and build identity, feature traffic, and the detailed blackbox
+  endpoint matrix, duration, HTTP status, and TLS lifetime views remain
+  available. The visible **Probe application** and **Probe route** controls
+  affect blackbox panels; their bounded `app` and `route` labels avoid raw target
+  URLs. Missing probe data is not treated as healthy.
 - dChat and token.place dependency traffic may be absent until those features
   receive requests. Their queries deliberately fall back to zero: **no requests
   observed** is expected and is not an instrumentation failure.

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -27,6 +27,22 @@ REQUIRED_METRICS = {
     "probe_ssl_earliest_cert_expiry",
 }
 EVENT_METRICS = {"dspace_dchat_requests_total", "dspace_dependency_requests_total"}
+HEALTH_ROUTES = r"/(healthz|livez|metrics)"
+
+
+def panel_by_title(dashboard: dict, title: str) -> dict:
+    matching = [panel for panel in panels(dashboard) if panel.get("title") == title]
+    if len(matching) != 1:
+        raise SystemExit(f"ERROR: dashboard must contain exactly one {title!r} panel.")
+    return matching[0]
+
+
+def require_instant_targets(panel: dict) -> None:
+    targets = panel.get("targets", [])
+    if not targets or any(
+        target.get("instant") is not True or target.get("range") is not False for target in targets
+    ):
+        raise SystemExit(f"ERROR: {panel['title']} must use instant-only queries.")
 
 
 def load_dashboard(path: Path) -> dict:
@@ -73,6 +89,68 @@ def validate_dashboard(path: Path) -> str:
         matching = [expr for expr in expressions if metric in expr]
         if not matching or any("or on() vector(0)" not in expr for expr in matching):
             raise SystemExit(f"ERROR: event-driven metric {metric} must use a safe zero fallback.")
+
+    distribution = panel_by_title(dashboard, "Status-class distribution")
+    require_instant_targets(distribution)
+    if distribution.get("type") != "bargauge" or distribution["targets"][0].get("expr") != (
+        "sum by (status_class) (increase(dspace_http_requests_total"
+        '{environment=~"$environment"}[$__range]))'
+    ):
+        raise SystemExit(
+            "ERROR: Status-class distribution must be a bounded categorical "
+            "selected-window summary."
+        )
+
+    user_traffic = panel_by_title(dashboard, "User request rate by route and status class")
+    user_expressions = [target.get("expr", "") for target in user_traffic.get("targets", [])]
+    if len(user_expressions) != 1 or f'route!~"{HEALTH_ROUTES}"' not in user_expressions[0]:
+        raise SystemExit("ERROR: user request rate must exclude bounded operational health routes.")
+    operational = panel_by_title(dashboard, "Operational request rate")
+    operational_expressions = [target.get("expr", "") for target in operational.get("targets", [])]
+    if (
+        len(operational_expressions) != 1
+        or f'route=~"{HEALTH_ROUTES}"' not in operational_expressions[0]
+    ):
+        raise SystemExit(
+            "ERROR: operational request rate must retain bounded health-route traffic."
+        )
+
+    summary = panel_by_title(dashboard, "Public availability summary")
+    require_instant_targets(summary)
+    summary_targets = summary.get("targets", [])
+    if (
+        summary.get("type") != "stat"
+        or len(summary_targets) != 2
+        or {target.get("legendFormat") for target in summary_targets}
+        != {"Healthy endpoints", "Failed endpoints"}
+        or any(
+            "count(min by (environment, app, route) (probe_success{" not in target["expr"]
+            for target in summary_targets
+        )
+        or {target["expr"].rsplit(" == ", 1)[-1] for target in summary_targets} != {"0)", "1)"}
+    ):
+        raise SystemExit(
+            "ERROR: public availability must aggregate healthy and failed selected endpoints."
+        )
+
+    matrix = panel_by_title(dashboard, "Endpoint matrix")
+    require_instant_targets(matrix)
+    matrix_expression = matrix["targets"][0].get("expr", "")
+    if matrix.get("type") != "table" or not matrix_expression.startswith(
+        "min by (environment, app, route) (probe_success{"
+    ):
+        raise SystemExit("ERROR: detailed bounded endpoint matrix must be retained.")
+
+    variable_labels = {
+        item.get("name"): item.get("label")
+        for item in dashboard.get("templating", {}).get("list", [])
+    }
+    if (
+        variable_labels.get("app") != "Probe application"
+        or variable_labels.get("route") != "Probe route"
+    ):
+        raise SystemExit("ERROR: blackbox variables must use probe-specific visible labels.")
+    panel_by_title(dashboard, "Instrumentation health")
     serialized = json.dumps(dashboard)
     if re.search(r"https?://", serialized, re.IGNORECASE):
         raise SystemExit("ERROR: dashboard must not contain embedded raw URLs.")

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -34,6 +34,37 @@ def replace_metric_expression(document, metric, replacement):
     target["expr"] = replacement
 
 
+def named_panel(document, title):
+    return next(panel for panel in all_panels(document) if panel.get("title") == title)
+
+
+def make_distribution_range_query(document):
+    target = named_panel(document, "Status-class distribution")["targets"][0]
+    target.update(instant=False, range=True)
+
+
+def restore_health_routes_to_user_traffic(document):
+    target = named_panel(document, "User request rate by route and status class")["targets"][0]
+    target["expr"] = target["expr"].replace(',route!~"/(healthz|livez|metrics)"', "")
+
+
+def expand_public_summary_per_endpoint(document):
+    panel = named_panel(document, "Public availability summary")
+    panel["targets"] = [
+        {
+            "expr": 'min by (environment, app, route) (probe_success{environment=~"$environment"})',
+            "instant": True,
+            "range": False,
+        }
+    ]
+
+
+def remove_endpoint_matrix(document):
+    document["panels"] = [
+        panel for panel in document["panels"] if panel.get("title") != "Endpoint matrix"
+    ]
+
+
 @pytest.fixture
 def dashboard():
     return json.loads(DASHBOARD.read_text(encoding="utf-8"))
@@ -57,9 +88,10 @@ def test_dashboard_identity_defaults_rows_and_required_panels(dashboard):
     titles = {panel["title"] for panel in panels}
     for title in (
         "DSPACE scrape availability",
-        "DSPACE instrumentation status",
-        "Public endpoint availability",
-        "Request rate by route and status class",
+        "Instrumentation health",
+        "Public availability summary",
+        "User request rate by route and status class",
+        "Operational request rate",
         "Status-class distribution",
         "5xx error ratio",
         "HTTP latency percentiles",
@@ -97,7 +129,13 @@ def test_queries_use_stable_datasource_bounded_labels_and_safe_zero(dashboard):
 
 
 def test_snapshot_tables_use_instant_queries(dashboard):
-    snapshots = {"Endpoint matrix", "Build identity", "HTTP response status"}
+    snapshots = {
+        "Endpoint matrix",
+        "Build identity",
+        "HTTP response status",
+        "Public availability summary",
+        "Status-class distribution",
+    }
     panels = {panel["title"]: panel for panel in all_panels(dashboard)}
     for title in snapshots:
         assert panels[title]["targets"]
@@ -110,6 +148,41 @@ def test_snapshot_tables_use_instant_queries(dashboard):
     organize = next(item for item in build["transformations"] if item["id"] == "organize")
     assert organize["options"]["indexByName"] == {"pod": 0, "version": 1, "revision": 2}
     assert organize["options"]["excludeByName"] == {"Time": True, "Value": True}
+
+
+def test_dashboard_separates_traffic_and_uses_aggregate_snapshots(dashboard):
+    panels = {panel["title"]: panel for panel in all_panels(dashboard)}
+    user_expression = panels["User request rate by route and status class"]["targets"][0]["expr"]
+    operational_expression = panels["Operational request rate"]["targets"][0]["expr"]
+    assert 'route!~"/(healthz|livez|metrics)"' in user_expression
+    assert 'route=~"/(healthz|livez|metrics)"' in operational_expression
+
+    distribution = panels["Status-class distribution"]
+    assert distribution["type"] == "bargauge"
+    assert distribution["targets"][0]["expr"] == (
+        "sum by (status_class) (increase(dspace_http_requests_total"
+        '{environment=~"$environment"}[$__range]))'
+    )
+    colors = {
+        override["matcher"]["options"]: override["properties"][0]["value"]["fixedColor"]
+        for override in distribution["fieldConfig"]["overrides"]
+    }
+    assert colors == {"^2xx$": "green", "^4xx$": "yellow", "^5xx$": "red"}
+
+    summary = panels["Public availability summary"]
+    assert len(summary["targets"]) == 2
+    assert {target["legendFormat"] for target in summary["targets"]} == {
+        "Healthy endpoints",
+        "Failed endpoints",
+    }
+    assert all(
+        "count(min by (environment, app, route) (probe_success{" in target["expr"]
+        for target in summary["targets"]
+    )
+    assert panels["Endpoint matrix"]["type"] == "table"
+    labels = {item["name"]: item["label"] for item in dashboard["templating"]["list"]}
+    assert labels["app"] == "Probe application"
+    assert labels["route"] == "Probe route"
 
 
 def test_blackbox_queries_drop_raw_target_labels(dashboard):
@@ -262,6 +335,10 @@ def test_validator_rejects_wrong_dashboard_mount(tmp_path, dashboard, mount_path
         (lambda item: item.update(links=[{"url": "https://example.invalid"}]), "raw URLs"),
         (lambda item: item.update(description="${DS_PROMETHEUS}"), "datasource placeholder"),
         (lambda item: item.update(datasource={"uid": "unexpected"}), "datasource references"),
+        (make_distribution_range_query, "instant-only"),
+        (restore_health_routes_to_user_traffic, "exclude bounded operational"),
+        (expand_public_summary_per_endpoint, "aggregate healthy and failed"),
+        (remove_endpoint_matrix, "exactly one 'Endpoint matrix'"),
     ],
 )
 def test_validator_directly_rejects_unsafe_dashboard_sources(


### PR DESCRIPTION
### Motivation
- Prevent misleading time-series and reduce visual noise by converting the status-class distribution into a selected-window categorical summary and by separating application traffic from operational probe traffic.
- Make the top-level availability summary actionable and compact by aggregating healthy/failed counts while keeping the detailed endpoint matrix for diagnosis, and clarify visible blackbox controls and titles for operators.

### Description
- Dashboard JSON changes: render Status-class distribution as an instant selected-window bar/bargauge with explicit 2xx/4xx/5xx colors, add a compact "Operational request rate" panel, and change the primary request-rate panel to exclude `/healthz`, `/livez`, and `/metrics` routes while renaming the user panel to "User request rate by route and status class".
- Top summary replaced the many per-endpoint stats with instant aggregate `Healthy endpoints` and `Failed endpoints` counts (instant queries) and kept the lower detailed "Endpoint matrix" table unchanged.
- UX and variables: visible variable labels were renamed to `Probe application` and `Probe route` and the instrumentation panel title shortened to `Instrumentation health` while preserving internal variable names and bounded-label queries.
- Validation and tests: extended `scripts/validate_observability_dashboard.py` to enforce instant-distribution semantics, traffic separation, aggregate availability semantics, presence of the endpoint matrix, and probe-variable labels, and added/updated tests in `tests/test_observability_dashboard.py` to catch regressions; updated the operations runbook with the corrected behavior.

### Testing
- Dashboard validator: `python3 scripts/validate_observability_dashboard.py clusters/staging/observability/dashboards/sugarkube-staging-observability.json` — passed.
- Unit/regression tests: `python3 -m pytest -q tests/test_observability_dashboard.py tests/test_observability_helm.py` — all tests passed (91 passed).
- Formatting/lint/docs checks: `python3 -m black --check` and `python3 -m flake8` on the modified files passed; `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` also passed; `pre-commit run --all-files` was executed but failed due to unrelated, pre-existing repository-wide YAML/multi-document and broad flake8 issues (these are not caused by this PR and unrelated automatic whitespace edits were reverted before commit).
- Post-merge staging verification commands to run in order: `git pull --ff-only`; `just kubeconfig-env env=staging`; `just observability-render env=staging >/tmp/kube-prometheus-stack.dashboard.rendered.yaml`; `just observability-upgrade env=staging`; `just observability-verify env=staging`; `just observability-dashboard-verify env=staging`; `just observability-blackbox-verify env=staging`.
- Visual inspection checklist (quick): confirm the Status-class distribution is categorical and instant with 2xx=green/4xx=yellow/5xx=red and respects the chosen time window; confirm user request-rate excludes `/healthz`, `/livez`, `/metrics` while the operational panel shows those routes; confirm the top-level availability panel shows only aggregate healthy/failed counts and that missing probe data is not treated as healthy; confirm `Probe application` and `Probe route` labels are visible and the detailed "Endpoint matrix" remains present for diagnosis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6700a49738832fb535df8b5fbc350e)