### PR TITLE
Polish staging observability dashboard signals

### DIFF
--- a/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
+++ b/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
@@ -41,7 +41,7 @@
       },
       {
         "name": "app",
-        "label": "Application",
+        "label": "Probe application",
         "type": "query",
         "datasource": {
           "type": "prometheus",
@@ -62,7 +62,7 @@
       },
       {
         "name": "route",
-        "label": "Route",
+        "label": "Probe route",
         "type": "query",
         "datasource": {
           "type": "prometheus",
@@ -153,7 +153,7 @@
     {
       "id": 3,
       "type": "stat",
-      "title": "DSPACE instrumentation status",
+      "title": "Instrumentation health",
       "description": "Application instrumentation self-check.",
       "datasource": {
         "type": "prometheus",
@@ -204,8 +204,8 @@
     {
       "id": 4,
       "type": "stat",
-      "title": "Public endpoint availability",
-      "description": "Latest bounded public probe result.",
+      "title": "Public availability summary",
+      "description": "Aggregate latest probe results for the selected filters. Zero healthy and zero failed indicates missing probe data.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -219,52 +219,69 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})",
-          "legendFormat": "{{environment}} / {{app}} / {{route}}"
+          "expr": "count(probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"} == 1)",
+          "legendFormat": "Healthy endpoints",
+          "instant": true,
+          "range": false
+        },
+        {
+          "refId": "B",
+          "expr": "count(probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"} == 0)",
+          "legendFormat": "Failed endpoints",
+          "instant": true,
+          "range": false
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "percentunit",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Healthy endpoints"
+            },
+            "properties": [
               {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
               }
             ]
           },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": {
-                  "text": "FAILED",
-                  "color": "red"
-                },
-                "1": {
-                  "text": "UP",
-                  "color": "green"
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failed endpoints"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
                 }
               }
-            }
-          ]
-        },
-        "overrides": []
+            ]
+          }
+        ]
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom"
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
         },
-        "tooltip": {
-          "mode": "multi"
-        }
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
       }
     },
     {
@@ -282,22 +299,22 @@
     {
       "id": 6,
       "type": "timeseries",
-      "title": "Request rate by route and status class",
-      "description": "Bounded route templates and status classes only.",
+      "title": "User request rate by route and status class",
+      "description": "Application traffic only; operational health and metrics routes are shown separately.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 7
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by (route, status_class) (rate(dspace_http_requests_total{environment=~\"$environment\"}[$__rate_interval]))",
+          "expr": "sum by (route, status_class) (rate(dspace_http_requests_total{environment=~\"$environment\",route!~\"/healthz|/livez|/metrics\"}[$__rate_interval]))",
           "legendFormat": "{{route}} {{status_class}}"
         }
       ],
@@ -319,7 +336,7 @@
     },
     {
       "id": 7,
-      "type": "barchart",
+      "type": "piechart",
       "title": "Status-class distribution",
       "description": "Requests in the selected range grouped by bounded status class.",
       "datasource": {
@@ -328,20 +345,119 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 8,
         "y": 7
       },
       "targets": [
         {
           "refId": "A",
           "expr": "sum by (status_class) (increase(dspace_http_requests_total{environment=~\"$environment\"}[$__range]))",
-          "legendFormat": "{{status_class}}"
+          "legendFormat": "{{status_class}}",
+          "instant": true,
+          "range": false
         }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "2xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "pieType": "pie",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "values": [
+            "value",
+            "percent"
+          ]
+        }
+      }
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Operational request rate",
+      "description": "Traffic to bounded health and metrics routes, separated from user activity.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 7
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (route, status_class) (rate(dspace_http_requests_total{environment=~\"$environment\",route=~\"/healthz|/livez|/metrics\"}[$__rate_interval]))",
+          "legendFormat": "{{route}} {{status_class}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
         },
         "overrides": []
       },

--- a/docs/observability-design.md
+++ b/docs/observability-design.md
@@ -242,6 +242,14 @@ These are provisional until staging data establishes normal behavior. They are n
 
 DSPACE has `/healthz` and `/livez` support in Docker/Helm/runbooks, release workflows for GHCR image and chart publication, and an app-local `/metrics` implementation and monitoring scaffold in the public repo. Sugarkube currently verifies `/config.json`, `/healthz`, and `/livez` through app runbooks and the shared app contract.
 
+The staging dashboard treats DSPACE request traffic and public probes as separate operator signals.
+The primary request-rate chart excludes `/healthz`, `/livez`, and `/metrics`, while a compact chart
+retains those operational routes. Status classes are an instant categorical total over the selected
+window, not a rising range-query series. Public availability is summarized as aggregate healthy and
+failed endpoint counts for the selected probe filters; zero healthy and zero failed means probe data
+is missing, and the endpoint matrix remains the per-route diagnostic view. The visible probe controls
+are labeled **Probe application** and **Probe route** so they are not mistaken for DSPACE HTTP filters.
+
 ### Design requirements for DSPACE v3.1.0 release gate
 
 Minimum gate for DSPACE v3.1.0:

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -27,6 +27,7 @@ REQUIRED_METRICS = {
     "probe_ssl_earliest_cert_expiry",
 }
 EVENT_METRICS = {"dspace_dchat_requests_total", "dspace_dependency_requests_total"}
+PROBE_SELECTOR = 'probe_success{environment=~"$environment",app=~"$app",route=~"$route"}'
 
 
 def load_dashboard(path: Path) -> dict:
@@ -64,6 +65,7 @@ def validate_dashboard(path: Path) -> str:
         if isinstance(target, dict) and isinstance(target.get("expr"), str)
     ]
     expression_text = "\n".join(expressions)
+    panel_by_title = {panel.get("title"): panel for panel in panels(dashboard)}
     missing = sorted(metric for metric in REQUIRED_METRICS if metric not in expression_text)
     if missing:
         raise SystemExit(
@@ -73,6 +75,55 @@ def validate_dashboard(path: Path) -> str:
         matching = [expr for expr in expressions if metric in expr]
         if not matching or any("or on() vector(0)" not in expr for expr in matching):
             raise SystemExit(f"ERROR: event-driven metric {metric} must use a safe zero fallback.")
+    distribution = panel_by_title.get("Status-class distribution", {})
+    distribution_targets = distribution.get("targets", [])
+    if (
+        distribution.get("type") != "piechart"
+        or len(distribution_targets) != 1
+        or distribution_targets[0].get("instant") is not True
+        or distribution_targets[0].get("range") is not False
+        or "sum by (status_class)" not in distribution_targets[0].get("expr", "")
+        or "[$__range]" not in distribution_targets[0].get("expr", "")
+    ):
+        raise SystemExit(
+            "ERROR: status-class distribution must be an instant selected-window "
+            "categorical summary."
+        )
+    user_traffic = panel_by_title.get("User request rate by route and status class", {})
+    user_expressions = [target.get("expr", "") for target in user_traffic.get("targets", [])]
+    if len(user_expressions) != 1 or 'route!~"/healthz|/livez|/metrics"' not in user_expressions[0]:
+        raise SystemExit("ERROR: user request rate must exclude operational health routes.")
+    operational = panel_by_title.get("Operational request rate", {})
+    operational_expressions = [target.get("expr", "") for target in operational.get("targets", [])]
+    if (
+        len(operational_expressions) != 1
+        or 'route=~"/healthz|/livez|/metrics"' not in operational_expressions[0]
+    ):
+        raise SystemExit("ERROR: operational health-route traffic must remain visible separately.")
+    availability = panel_by_title.get("Public availability summary", {})
+    availability_targets = availability.get("targets", [])
+    if (
+        availability.get("type") != "stat"
+        or len(availability_targets) != 2
+        or any(
+            target.get("instant") is not True
+            or target.get("range") is not False
+            or PROBE_SELECTOR not in target.get("expr", "")
+            or " by (" in target.get("expr", "")
+            for target in availability_targets
+        )
+    ):
+        raise SystemExit(
+            "ERROR: public availability must be a two-value instant aggregate using probe filters."
+        )
+    endpoint_matrix = panel_by_title.get("Endpoint matrix", {})
+    if endpoint_matrix.get("type") != "table" or not endpoint_matrix.get("targets"):
+        raise SystemExit("ERROR: detailed endpoint matrix must remain available for diagnosis.")
+    variables = {item.get("name"): item for item in dashboard.get("templating", {}).get("list", [])}
+    if variables.get("app", {}).get("label") != "Probe application" or variables.get(
+        "route", {}
+    ).get("label") != "Probe route":
+        raise SystemExit("ERROR: blackbox variable labels must identify probe filters.")
     serialized = json.dumps(dashboard)
     if re.search(r"https?://", serialized, re.IGNORECASE):
         raise SystemExit("ERROR: dashboard must not contain embedded raw URLs.")
@@ -82,6 +133,12 @@ def validate_dashboard(path: Path) -> str:
         raise SystemExit(
             "ERROR: dashboard contains a datasource placeholder or unsafe raw target label."
         )
+    if re.search(
+        r"(?:\{|,)\s*(?:user|session|request_id|prompt|response|instance)\s*(?:=|=~|!~|!=)"
+        r"|\bby\s*\([^)]*\b(?:user|session|request_id|prompt|response|instance)\b",
+        expression_text,
+    ):
+        raise SystemExit("ERROR: dashboard query uses a privacy-sensitive or unbounded label.")
     datasource_refs = re.findall(r'"uid":\s*"([^"]+)"', serialized)
     if DATASOURCE_UID not in datasource_refs or any(
         uid not in {DATASOURCE_UID, UID} for uid in datasource_refs

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -57,9 +57,10 @@ def test_dashboard_identity_defaults_rows_and_required_panels(dashboard):
     titles = {panel["title"] for panel in panels}
     for title in (
         "DSPACE scrape availability",
-        "DSPACE instrumentation status",
-        "Public endpoint availability",
-        "Request rate by route and status class",
+        "Instrumentation health",
+        "Public availability summary",
+        "User request rate by route and status class",
+        "Operational request rate",
         "Status-class distribution",
         "5xx error ratio",
         "HTTP latency percentiles",
@@ -110,6 +111,41 @@ def test_snapshot_tables_use_instant_queries(dashboard):
     organize = next(item for item in build["transformations"] if item["id"] == "organize")
     assert organize["options"]["indexByName"] == {"pod": 0, "version": 1, "revision": 2}
     assert organize["options"]["excludeByName"] == {"Time": True, "Value": True}
+
+
+def test_dashboard_separates_traffic_and_uses_aggregate_window_summaries(dashboard):
+    panels = {panel["title"]: panel for panel in all_panels(dashboard)}
+    distribution = panels["Status-class distribution"]
+    assert distribution["type"] == "piechart"
+    assert distribution["targets"][0]["instant"] is True
+    assert distribution["targets"][0]["range"] is False
+    assert "sum by (status_class)" in distribution["targets"][0]["expr"]
+    assert "[$__range]" in distribution["targets"][0]["expr"]
+    colors = {
+        override["matcher"]["options"]: override["properties"][0]["value"]["fixedColor"]
+        for override in distribution["fieldConfig"]["overrides"]
+    }
+    assert colors == {"2xx": "green", "4xx": "orange", "5xx": "red"}
+
+    user_query = panels["User request rate by route and status class"]["targets"][0]["expr"]
+    operational_query = panels["Operational request rate"]["targets"][0]["expr"]
+    assert 'route!~"/healthz|/livez|/metrics"' in user_query
+    assert 'route=~"/healthz|/livez|/metrics"' in operational_query
+
+    summary = panels["Public availability summary"]
+    assert len(summary["targets"]) == 2
+    assert {target["legendFormat"] for target in summary["targets"]} == {
+        "Healthy endpoints",
+        "Failed endpoints",
+    }
+    assert all(
+        target["instant"] is True and target["range"] is False for target in summary["targets"]
+    )
+    assert all(" by (" not in target["expr"] for target in summary["targets"])
+    assert "Endpoint matrix" in panels
+    variables = {item["name"]: item for item in dashboard["templating"]["list"]}
+    assert variables["app"]["label"] == "Probe application"
+    assert variables["route"]["label"] == "Probe route"
 
 
 def test_blackbox_queries_drop_raw_target_labels(dashboard):
@@ -261,6 +297,12 @@ def test_validator_rejects_wrong_dashboard_mount(tmp_path, dashboard, mount_path
         ),
         (lambda item: item.update(links=[{"url": "https://example.invalid"}]), "raw URLs"),
         (lambda item: item.update(description="${DS_PROMETHEUS}"), "datasource placeholder"),
+        (
+            lambda item: replace_metric_expression(
+                item, "process_resident_memory_bytes", 'process_resident_memory_bytes{user=~".*"}'
+            ),
+            "privacy-sensitive or unbounded label",
+        ),
         (lambda item: item.update(datasource={"uid": "unexpected"}), "datasource references"),
     ],
 )


### PR DESCRIPTION
### Motivation

- Fix a misleading status-class chart that used a range-increase time series and produced rising totals instead of a selected-window categorical summary.
- Make user request traffic legible by separating operational probe traffic (health/metrics) from real application requests.
- Reduce top-level noise by replacing cramped per-endpoint mini-stats with a compact aggregate availability summary and clarify blackbox controls and instrumentation labeling.

### Description

- Dashboard JSON changes: convert the Status-class distribution into an instant selected-window categorical panel (pie chart) with explicit 2xx/4xx/5xx colors, change the main request-rate panel to exclude `/healthz`, `/livez`, and `/metrics`, and add a dedicated compact Operational request rate panel for those routes while preserving the detailed Endpoint matrix and other diagnostics.
- Replace the top-level one-stat-per-endpoint view with a two-value instant aggregate `Healthy endpoints` / `Failed endpoints` summary that cannot present missing data as healthy, and shorten `DSPACE instrumentation status` to `Instrumentation health` while renaming visible blackbox variables to `Probe application` and `Probe route`.
- Validation and privacy/cardinality guards: extend `scripts/validate_observability_dashboard.py` to enforce the instant categorical distribution semantics, traffic separation, two-value aggregate availability, retention of the endpoint matrix, probe-variable labels, and to reject queries using privacy-sensitive or unbounded labels.
- Tests and docs: update `tests/test_observability_dashboard.py` to cover the new panels/queries/labels and document the intended operator semantics in `docs/observability-design.md` so the intended dashboard behavior and privacy constraints are explicit.

### Testing

- Ran the dashboard validator: `python3 scripts/validate_observability_dashboard.py clusters/staging/observability/dashboards/sugarkube-staging-observability.json` (success).
- Ran the unit/acceptance tests: `python3 -m pytest -q tests/test_observability_dashboard.py tests/test_observability_helm.py` (tests passed; validator-covered dashboard expectations succeeded).
- Linting and content checks executed for the touched files: `python3 -m flake8 scripts/validate_observability_dashboard.py tests/test_observability_dashboard.py`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` (these checks passed for the updated files); `pre-commit run --all-files` was attempted but the repository-wide hook run failed on existing unrelated YAML/multi-document and lint issues; targeted pre-commit hooks for the changed files passed.
- Post-merge staging verification commands to run in order: `git pull --ff-only`, `just kubeconfig-env env=staging`, `just observability-render env=staging >/tmp/kube-prometheus-stack.dashboard.rendered.yaml`, `just observability-upgrade env=staging`, `just observability-verify env=staging`, `just observability-dashboard-verify env=staging`, `just observability-blackbox-verify env=staging`.
- Short visual-inspection checklist: confirm the Status-class distribution is a categorical pie (no time axis) that recomputes totals for the selected window with 2xx=green/4xx=orange/5xx=red; confirm the User request-rate panel omits `/healthz`, `/livez`, `/metrics` while Operational request rate shows them; confirm the top Public availability summary shows only Healthy and Failed counts and that zero/zero indicates missing probe data; confirm `Probe application`/`Probe route` labels and that the Endpoint matrix remains for per-route diagnosis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6700b30c1c832fbf339b11f1d53d1d)