### PR TITLE
Polish staging observability dashboard semantics

### DIFF
--- a/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
+++ b/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
@@ -41,7 +41,7 @@
       },
       {
         "name": "app",
-        "label": "Application",
+        "label": "Probe application",
         "type": "query",
         "datasource": {
           "type": "prometheus",
@@ -62,7 +62,7 @@
       },
       {
         "name": "route",
-        "label": "Route",
+        "label": "Probe route",
         "type": "query",
         "datasource": {
           "type": "prometheus",
@@ -153,7 +153,7 @@
     {
       "id": 3,
       "type": "stat",
-      "title": "DSPACE instrumentation status",
+      "title": "Instrumentation health",
       "description": "Application instrumentation self-check.",
       "datasource": {
         "type": "prometheus",
@@ -205,7 +205,7 @@
       "id": 4,
       "type": "stat",
       "title": "Public endpoint availability",
-      "description": "Latest bounded public probe result.",
+      "description": "Healthy and failed endpoint counts for the selected probe filters; missing probe data remains No data.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -219,52 +219,70 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})",
-          "legendFormat": "{{environment}} / {{app}} / {{route}}"
+          "expr": "count((min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})) == 1",
+          "legendFormat": "Healthy endpoints",
+          "instant": true,
+          "range": false
+        },
+        {
+          "refId": "B",
+          "expr": "count((min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})) == 0",
+          "legendFormat": "Failed endpoints",
+          "instant": true,
+          "range": false
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "percentunit",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Healthy endpoints"
+            },
+            "properties": [
               {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
               }
             ]
           },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": {
-                  "text": "FAILED",
-                  "color": "red"
-                },
-                "1": {
-                  "text": "UP",
-                  "color": "green"
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failed endpoints"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
                 }
               }
-            }
-          ]
-        },
-        "overrides": []
+            ]
+          }
+        ]
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom"
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
         },
-        "tooltip": {
-          "mode": "multi"
-        }
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "wideLayout": true
       }
     },
     {
@@ -282,22 +300,22 @@
     {
       "id": 6,
       "type": "timeseries",
-      "title": "Request rate by route and status class",
-      "description": "Bounded route templates and status classes only.",
+      "title": "User request rate by route and status class",
+      "description": "Application request rate excluding health and metrics routes; bounded route templates and status classes only.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 7
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by (route, status_class) (rate(dspace_http_requests_total{environment=~\"$environment\"}[$__rate_interval]))",
+          "expr": "sum by (route, status_class) (rate(dspace_http_requests_total{environment=~\"$environment\",route!~\"/(healthz|livez|metrics)\"}[$__rate_interval]))",
           "legendFormat": "{{route}} {{status_class}}"
         }
       ],
@@ -328,20 +346,117 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 8,
         "y": 7
       },
       "targets": [
         {
           "refId": "A",
           "expr": "sum by (status_class) (increase(dspace_http_requests_total{environment=~\"$environment\"}[$__range]))",
-          "legendFormat": "{{status_class}}"
+          "legendFormat": "{{status_class}}",
+          "instant": true,
+          "range": false
         }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^2xx$"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^4xx$"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "yellow"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^5xx$"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "orientation": "horizontal",
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0,
+        "showValue": "always",
+        "stacking": "none",
+        "groupWidth": 0.7,
+        "barWidth": 0.97,
+        "barRadius": 0,
+        "fullHighlight": false,
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        }
+      }
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Operational request rate",
+      "description": "Health and metrics request rate, kept separate from user traffic.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 7
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (route, status_class) (rate(dspace_http_requests_total{environment=~\"$environment\",route=~\"/(healthz|livez|metrics)\"}[$__rate_interval]))",
+          "legendFormat": "{{route}} {{status_class}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
         },
         "overrides": []
       },

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -125,11 +125,17 @@ is not rollout evidence.
 - Prometheus: one replica, `7d` retention, `15GB` retention size, `local-path` `ReadWriteOnce` PVC requesting `20Gi`, CPU request `200m`, memory request `512Mi`, memory limit `2Gi`, admin API disabled, and external label `cluster=sugarkube-int`.
 - Alertmanager: one replica and no-op receiver named exactly `"null"`.
 - Grafana: persistence disabled, no Ingress, LAN-only NodePort `30300`.
-- The provisioned dashboard defaults to six hours and a 30-second refresh. It
-  covers overall DSPACE and public-probe status, bounded DSPACE HTTP rate/error/
-  latency, runtime and build identity, feature traffic, and blackbox endpoint,
-  duration, HTTP status, and TLS lifetime views. Its staging `environment`,
-  `app`, and `route` variables avoid raw target URLs.
+- The provisioned dashboard defaults to six hours and a 30-second refresh. Its
+  top-level public availability stat reports aggregate healthy and failed
+  endpoint counts for the selected probe filters; absent probe data remains
+  **No data**, never healthy. The lower endpoint matrix retains per-endpoint
+  diagnosis. The selected-window status-class distribution is an instant
+  categorical summary, while DSPACE user request rate excludes `/healthz`,
+  `/livez`, and `/metrics` and a separate compact panel preserves those
+  operational request rates. The visible **Probe application** and **Probe
+  route** controls apply only to blackbox panels; the internal `app` and `route`
+  variable names remain stable. All queries retain bounded labels and omit raw
+  target URLs.
 - dChat and token.place dependency traffic may be absent until those features
   receive requests. Their queries deliberately fall back to zero: **no requests
   observed** is expected and is not an instrumentation failure.

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -27,6 +27,7 @@ REQUIRED_METRICS = {
     "probe_ssl_earliest_cert_expiry",
 }
 EVENT_METRICS = {"dspace_dchat_requests_total", "dspace_dependency_requests_total"}
+OPERATIONAL_ROUTES = r"/(healthz|livez|metrics)"
 
 
 def load_dashboard(path: Path) -> dict:
@@ -44,6 +45,13 @@ def panels(dashboard: dict):
         if isinstance(panel, dict):
             yield panel
             yield from panels(panel)
+
+
+def require_panel(panel_by_title: dict, title: str) -> dict:
+    panel = panel_by_title.get(title)
+    if not panel:
+        raise SystemExit(f"ERROR: dashboard is missing required panel {title!r}.")
+    return panel
 
 
 def validate_dashboard(path: Path) -> str:
@@ -73,6 +81,61 @@ def validate_dashboard(path: Path) -> str:
         matching = [expr for expr in expressions if metric in expr]
         if not matching or any("or on() vector(0)" not in expr for expr in matching):
             raise SystemExit(f"ERROR: event-driven metric {metric} must use a safe zero fallback.")
+    panel_by_title = {panel.get("title"): panel for panel in panels(dashboard)}
+    distribution = require_panel(panel_by_title, "Status-class distribution")
+    distribution_targets = distribution.get("targets", [])
+    if (
+        distribution.get("type") not in {"barchart", "piechart"}
+        or len(distribution_targets) != 1
+        or any(
+            target.get("instant") is not True or target.get("range") is not False
+            for target in distribution_targets
+        )
+        or not distribution_targets[0]
+        .get("expr", "")
+        .startswith("sum by (status_class) (increase(dspace_http_requests_total{")
+        or "[$__range]" not in distribution_targets[0].get("expr", "")
+    ):
+        raise SystemExit(
+            "ERROR: status-class distribution must be a categorical instant selected-window query."
+        )
+    user_rate = require_panel(panel_by_title, "User request rate by route and status class")
+    if not user_rate.get("targets") or any(
+        f'route!~"{OPERATIONAL_ROUTES}"' not in target.get("expr", "")
+        for target in user_rate["targets"]
+    ):
+        raise SystemExit("ERROR: user request rate must exclude health and metrics routes.")
+    operational_rate = require_panel(panel_by_title, "Operational request rate")
+    if not operational_rate.get("targets") or any(
+        f'route=~"{OPERATIONAL_ROUTES}"' not in target.get("expr", "")
+        for target in operational_rate["targets"]
+    ):
+        raise SystemExit("ERROR: operational request rate must contain health and metrics routes.")
+    availability = require_panel(panel_by_title, "Public endpoint availability")
+    availability_targets = availability.get("targets", [])
+    if (
+        availability.get("type") != "stat"
+        or len(availability_targets) != 2
+        or {target.get("legendFormat") for target in availability_targets}
+        != {"Healthy endpoints", "Failed endpoints"}
+        or any(
+            target.get("instant") is not True or target.get("range") is not False
+            for target in availability_targets
+        )
+        or any(
+            not target.get("expr", "").startswith(
+                "count((min by (environment, app, route) (probe_success{"
+            )
+            for target in availability_targets
+        )
+        or any("or on() vector" in target.get("expr", "") for target in availability_targets)
+    ):
+        raise SystemExit(
+            "ERROR: public endpoint availability must be an aggregate, fail-closed instant summary."
+        )
+    endpoint_matrix = require_panel(panel_by_title, "Endpoint matrix")
+    if endpoint_matrix.get("type") != "table" or not endpoint_matrix.get("targets"):
+        raise SystemExit("ERROR: detailed endpoint matrix must remain available for diagnosis.")
     serialized = json.dumps(dashboard)
     if re.search(r"https?://", serialized, re.IGNORECASE):
         raise SystemExit("ERROR: dashboard must not contain embedded raw URLs.")

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -34,6 +34,10 @@ def replace_metric_expression(document, metric, replacement):
     target["expr"] = replacement
 
 
+def panel_named(document, title):
+    return next(panel for panel in all_panels(document) if panel.get("title") == title)
+
+
 @pytest.fixture
 def dashboard():
     return json.loads(DASHBOARD.read_text(encoding="utf-8"))
@@ -57,9 +61,10 @@ def test_dashboard_identity_defaults_rows_and_required_panels(dashboard):
     titles = {panel["title"] for panel in panels}
     for title in (
         "DSPACE scrape availability",
-        "DSPACE instrumentation status",
+        "Instrumentation health",
         "Public endpoint availability",
-        "Request rate by route and status class",
+        "User request rate by route and status class",
+        "Operational request rate",
         "Status-class distribution",
         "5xx error ratio",
         "HTTP latency percentiles",
@@ -110,6 +115,46 @@ def test_snapshot_tables_use_instant_queries(dashboard):
     organize = next(item for item in build["transformations"] if item["id"] == "organize")
     assert organize["options"]["indexByName"] == {"pod": 0, "version": 1, "revision": 2}
     assert organize["options"]["excludeByName"] == {"Time": True, "Value": True}
+
+
+def test_selected_window_traffic_and_availability_semantics(dashboard):
+    panels = {panel["title"]: panel for panel in all_panels(dashboard)}
+    distribution = panels["Status-class distribution"]
+    assert distribution["type"] in {"barchart", "piechart"}
+    assert all(
+        target["instant"] is True and target["range"] is False for target in distribution["targets"]
+    )
+    assert "increase(dspace_http_requests_total" in distribution["targets"][0]["expr"]
+    assert {
+        override["matcher"]["options"] for override in distribution["fieldConfig"]["overrides"]
+    } == {
+        "^2xx$",
+        "^4xx$",
+        "^5xx$",
+    }
+
+    user_expression = panels["User request rate by route and status class"]["targets"][0]["expr"]
+    operational_expression = panels["Operational request rate"]["targets"][0]["expr"]
+    assert 'route!~"/(healthz|livez|metrics)"' in user_expression
+    assert 'route=~"/(healthz|livez|metrics)"' in operational_expression
+
+    availability = panels["Public endpoint availability"]
+    assert {target["legendFormat"] for target in availability["targets"]} == {
+        "Healthy endpoints",
+        "Failed endpoints",
+    }
+    assert len(availability["targets"]) == 2
+    assert all(
+        target["instant"] is True and target["range"] is False for target in availability["targets"]
+    )
+    assert all("vector" not in target["expr"] for target in availability["targets"])
+    assert panels["Endpoint matrix"]["type"] == "table"
+    labels = {item["name"]: item["label"] for item in dashboard["templating"]["list"]}
+    assert labels == {
+        "environment": "Environment",
+        "app": "Probe application",
+        "route": "Probe route",
+    }
 
 
 def test_blackbox_queries_drop_raw_target_labels(dashboard):
@@ -262,6 +307,30 @@ def test_validator_rejects_wrong_dashboard_mount(tmp_path, dashboard, mount_path
         (lambda item: item.update(links=[{"url": "https://example.invalid"}]), "raw URLs"),
         (lambda item: item.update(description="${DS_PROMETHEUS}"), "datasource placeholder"),
         (lambda item: item.update(datasource={"uid": "unexpected"}), "datasource references"),
+        (
+            lambda item: panel_named(item, "Status-class distribution")["targets"][0].update(
+                instant=False, range=True
+            ),
+            "categorical instant",
+        ),
+        (
+            lambda item: panel_named(item, "User request rate by route and status class")[
+                "targets"
+            ][0].update(
+                expr='sum(rate(dspace_http_requests_total{environment=~"$environment"}[5m]))'
+            ),
+            "exclude health",
+        ),
+        (
+            lambda item: panel_named(item, "Public endpoint availability").update(
+                targets=panel_named(item, "Endpoint matrix")["targets"]
+            ),
+            "aggregate, fail-closed",
+        ),
+        (
+            lambda item: item["panels"].remove(panel_named(item, "Endpoint matrix")),
+            "missing required panel 'Endpoint matrix'",
+        ),
     ],
 )
 def test_validator_directly_rejects_unsafe_dashboard_sources(


### PR DESCRIPTION
### Motivation
- Improve correctness and reduce misleading signal/noise in the Sugarkube Staging Observability Grafana dashboard now that DSPACE metrics and all blackbox probes are healthy. 
- Convert an accidental range time-series distribution and intermixed operational/user traffic into clear categorical and separated panels so operators can quickly see real user load and aggregate probe availability. 
- Make the dashboard provisioning and validator enforce the intended selected-window, instant-query, and privacy/cardinality semantics to prevent regressions.

### Description
- Converted the "Status-class distribution" into an instant categorical selected-window bar chart using `sum by (status_class) (increase(dspace_http_requests_total{...}[$__range]))` with explicit 2xx/4xx/5xx colors and no time axis (edited `clusters/staging/observability/dashboards/sugarkube-staging-observability.json`).
- Split DSPACE request-rate into a primary "User request rate by route and status class" that excludes `/healthz`, `/livez`, and `/metrics`, and added a compact "Operational request rate" panel that contains those probe routes (dashboard JSON update).
- Replaced the cramped per-endpoint top-level mini-stats with an aggregate, fail-closed instant summary (two stats: `Healthy endpoints` and `Failed endpoints`) while preserving the detailed endpoint matrix lower in the dashboard and avoiding zero-fallbacks that would mark missing data as healthy (dashboard JSON update).
- Clarified visible variable labels to `Probe application` and `Probe route` and shortened the instrumentation panel title to `Instrumentation health` (dashboard JSON update) while preserving internal variable names and UID.
- Extended the dashboard validator to assert the distribution is an instant selected-window categorical query, that user/operational traffic queries are separated by route filters, that the top-level availability is an aggregate fail-closed instant summary, and that the detailed endpoint matrix still exists (`scripts/validate_observability_dashboard.py`).
- Added regression tests covering the new semantics and negative mutations, and updated the operations doc to describe the new behavior (`tests/test_observability_dashboard.py`, `docs/observability-operations.md`).

### Testing
- Ran the dashboard validator: `python3 scripts/validate_observability_dashboard.py clusters/staging/observability/dashboards/sugarkube-staging-observability.json` and it passed. 
- Ran the requested pytest suites: `python3 -m pytest -q tests/test_observability_dashboard.py tests/test_observability_helm.py` (combined run reported **91 passed**) and `python3 -m pytest -q tests/test_observability_dashboard.py` (focused run reported **41 passed**); both runs passed for the modified tests. 
- Ran formatting and doc checks: `python3 -m black` was applied to the two modified Python files and `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` completed successfully. 
- Note: `pre-commit run --all-files` surfaced unrelated repository-wide YAML/flake8 issues in other files (existing pre-existing failures); those unrelated failures did not block the targeted validator, tests, spelling, link checking, or the focused changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6700ba3cd8832f812f0dfe405f47cb)