### PR TITLE
Polish staging observability dashboard signals

### DIFF
--- a/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
+++ b/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
@@ -41,7 +41,7 @@
       },
       {
         "name": "app",
-        "label": "Application",
+        "label": "Probe application",
         "type": "query",
         "datasource": {
           "type": "prometheus",
@@ -62,7 +62,7 @@
       },
       {
         "name": "route",
-        "label": "Route",
+        "label": "Probe route",
         "type": "query",
         "datasource": {
           "type": "prometheus",
@@ -153,7 +153,7 @@
     {
       "id": 3,
       "type": "stat",
-      "title": "DSPACE instrumentation status",
+      "title": "Instrumentation health",
       "description": "Application instrumentation self-check.",
       "datasource": {
         "type": "prometheus",
@@ -204,8 +204,8 @@
     {
       "id": 4,
       "type": "stat",
-      "title": "Public endpoint availability",
-      "description": "Latest bounded public probe result.",
+      "title": "Public availability summary",
+      "description": "Current healthy and failed endpoint counts for the selected probe filters; missing probe data is shown as no data, never healthy.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -219,52 +219,72 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})",
-          "legendFormat": "{{environment}} / {{app}} / {{route}}"
+          "expr": "count((min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})) == 1)",
+          "legendFormat": "Healthy endpoints",
+          "instant": true,
+          "range": false
+        },
+        {
+          "refId": "B",
+          "expr": "count((min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})) == 0)",
+          "legendFormat": "Failed endpoints",
+          "instant": true,
+          "range": false
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "percentunit",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Healthy endpoints"
+            },
+            "properties": [
               {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
               }
             ]
           },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": {
-                  "text": "FAILED",
-                  "color": "red"
-                },
-                "1": {
-                  "text": "UP",
-                  "color": "green"
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failed endpoints"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
                 }
               }
-            }
-          ]
-        },
-        "overrides": []
+            ]
+          }
+        ]
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom"
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
         },
-        "tooltip": {
-          "mode": "multi"
-        }
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "wideLayout": true,
+        "showPercentChange": false
       }
     },
     {
@@ -282,22 +302,22 @@
     {
       "id": 6,
       "type": "timeseries",
-      "title": "Request rate by route and status class",
-      "description": "Bounded route templates and status classes only.",
+      "title": "User request rate by route and status class",
+      "description": "Application request rate by bounded route templates and status classes; operational health and metrics routes are excluded.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 7
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by (route, status_class) (rate(dspace_http_requests_total{environment=~\"$environment\"}[$__rate_interval]))",
+          "expr": "sum by (route, status_class) (rate(dspace_http_requests_total{environment=~\"$environment\",route!~\"/(healthz|livez|metrics)\"}[$__rate_interval]))",
           "legendFormat": "{{route}} {{status_class}}"
         }
       ],
@@ -319,29 +339,133 @@
     },
     {
       "id": 7,
-      "type": "barchart",
+      "type": "piechart",
       "title": "Status-class distribution",
-      "description": "Requests in the selected range grouped by bounded status class.",
+      "description": "Selected-window request totals grouped by bounded status class.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 8,
         "y": 7
       },
       "targets": [
         {
           "refId": "A",
           "expr": "sum by (status_class) (increase(dspace_http_requests_total{environment=~\"$environment\"}[$__range]))",
-          "legendFormat": "{{status_class}}"
+          "legendFormat": "{{status_class}}",
+          "instant": true,
+          "range": false
         }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "2xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "pieType": "pie",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "displayLabels": [
+          "name",
+          "percent"
+        ]
+      }
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Operational request rate",
+      "description": "Health, liveness, and metrics request rate kept separate from user traffic.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 7
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (route, status_class) (rate(dspace_http_requests_total{environment=~\"$environment\",route=~\"/(healthz|livez|metrics)\"}[$__rate_interval]))",
+          "legendFormat": "{{route}} {{status_class}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
         },
         "overrides": []
       },

--- a/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
+++ b/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
@@ -205,7 +205,7 @@
       "id": 4,
       "type": "stat",
       "title": "Public availability summary",
-      "description": "Current healthy and failed endpoint counts for the selected probe filters; recently observed endpoints with missing probe data count as failed, while a complete absence of discovered probes is shown as no data.",
+      "description": "Current healthy, failed, and recently missing probe-data counts for the selected filters; complete absence of expected target data is shown as no data.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -219,15 +219,22 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) == bool 1)",
+          "expr": "sum(min by (environment, app, route) (probe_success{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) == bool 1)",
           "legendFormat": "Healthy endpoints",
           "instant": true,
           "range": false
         },
         {
           "refId": "B",
-          "expr": "sum(max by (environment, app, route) (max_over_time(up{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}[5m])) >= bool 0) - (sum(min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) == bool 1) or vector(0))",
+          "expr": "sum(min by (environment, app, route) (probe_success{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) == bool 0)",
           "legendFormat": "Failed endpoints",
+          "instant": true,
+          "range": false
+        },
+        {
+          "refId": "C",
+          "expr": "sum(max by (environment, app, route) (max_over_time(up{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}[5m])) >= bool 0) - (sum(min by (environment, app, route) (probe_success{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) >= bool 0) or vector(0))",
+          "legendFormat": "Missing probe data",
           "instant": true,
           "range": false
         }
@@ -264,6 +271,33 @@
                 "value": {
                   "mode": "fixed",
                   "fixedColor": "red"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Missing probe data"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "yellow"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "yellow",
+                      "value": null
+                    }
+                  ]
                 }
               }
             ]

--- a/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
+++ b/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
@@ -205,7 +205,7 @@
       "id": 4,
       "type": "stat",
       "title": "Public availability summary",
-      "description": "Current healthy and failed endpoint counts for the selected probe filters; missing probe data is shown as no data, never healthy.",
+      "description": "Current healthy and failed endpoint counts for the selected probe filters; recently observed endpoints with missing probe data count as failed, while a complete absence of discovered probes is shown as no data.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -219,14 +219,14 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "count((min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})) == 1)",
+          "expr": "sum(min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) == bool 1)",
           "legendFormat": "Healthy endpoints",
           "instant": true,
           "range": false
         },
         {
           "refId": "B",
-          "expr": "count((min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})) == 0)",
+          "expr": "sum(max by (environment, app, route) (max_over_time(up{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}[5m])) >= bool 0) - (sum(min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) == bool 1) or vector(0))",
           "legendFormat": "Failed endpoints",
           "instant": true,
           "range": false

--- a/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
+++ b/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
@@ -205,7 +205,7 @@
       "id": 4,
       "type": "stat",
       "title": "Public availability summary",
-      "description": "Current healthy, failed, and recently missing probe-data counts for the selected filters; complete absence of expected target data is shown as no data.",
+      "description": "Current healthy, failed, and retention-backed missing probe-data counts for the selected filters; complete absence of expected target data is shown as no data.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -233,7 +233,7 @@
         },
         {
           "refId": "C",
-          "expr": "sum(max by (environment, app, route) (max_over_time(up{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}[5m])) >= bool 0) - (sum(min by (environment, app, route) (probe_success{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) >= bool 0) or vector(0))",
+          "expr": "sum(max by (environment, app, route) (max_over_time(up{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}[7d])) >= bool 0) - (sum(min by (environment, app, route) (probe_success{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) >= bool 0) or vector(0))",
           "legendFormat": "Missing probe data",
           "instant": true,
           "range": false

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -125,11 +125,17 @@ is not rollout evidence.
 - Prometheus: one replica, `7d` retention, `15GB` retention size, `local-path` `ReadWriteOnce` PVC requesting `20Gi`, CPU request `200m`, memory request `512Mi`, memory limit `2Gi`, admin API disabled, and external label `cluster=sugarkube-int`.
 - Alertmanager: one replica and no-op receiver named exactly `"null"`.
 - Grafana: persistence disabled, no Ingress, LAN-only NodePort `30300`.
-- The provisioned dashboard defaults to six hours and a 30-second refresh. It
-  covers overall DSPACE and public-probe status, bounded DSPACE HTTP rate/error/
-  latency, runtime and build identity, feature traffic, and blackbox endpoint,
-  duration, HTTP status, and TLS lifetime views. Its staging `environment`,
-  `app`, and `route` variables avoid raw target URLs.
+- The provisioned dashboard defaults to six hours and a 30-second refresh. Its
+  top-level public availability summary reports current healthy and failed
+  endpoint counts for the selected probe filters; missing data remains visibly
+  absent rather than appearing healthy. The detailed endpoint matrix remains the
+  diagnostic view. DSPACE user request rate excludes `/healthz`, `/livez`, and
+  `/metrics`, whose traffic has a separate operational-rate panel. Status-class
+  distribution is an instant categorical summary over the selected time window.
+  The `Probe application` and `Probe route` controls filter blackbox panels while
+  preserving the internal bounded `app` and `route` labels and avoiding raw
+  target URLs. Runtime, build identity, feature traffic, latency, error ratio,
+  probe duration, HTTP status, and TLS lifetime views remain available.
 - dChat and token.place dependency traffic may be absent until those features
   receive requests. Their queries deliberately fall back to zero: **no requests
   observed** is expected and is not an instrumentation failure.

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -130,7 +130,9 @@ is not rollout evidence.
   endpoints**, and a yellow **Missing probe data** count for the selected probe
   filters. Healthy and failed are current `probe_success` results; missing compares
   current samples with lifecycle-owned targets discovered through `up` during the
-  last five minutes, so a briefly disappeared discovery target remains visible.
+  seven-day Prometheus retention horizon, so disappeared discovery targets remain
+  visible throughout retained history. Exact long-term target inventory remains
+  verified by `just observability-blackbox-verify env=staging`.
   `16/0/0` is fully healthy, `15/1/0` has one observed failure, and `15/0/1`
   identifies one expected target without current probe data. If no expected target
   data exists, all three values remain `NO DATA` rather than implying health. The

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -126,11 +126,15 @@ is not rollout evidence.
 - Alertmanager: one replica and no-op receiver named exactly `"null"`.
 - Grafana: persistence disabled, no Ingress, LAN-only NodePort `30300`.
 - The provisioned dashboard defaults to six hours and a 30-second refresh. Its
-  top-level public availability summary reports current healthy and failed
-  endpoint counts for the selected probe filters. An endpoint discovered in the
-  last five minutes but missing a current probe sample counts as failed; a complete
-  absence of discovered probes remains visibly absent rather than appearing
-  healthy. The detailed endpoint matrix remains the diagnostic view. DSPACE user
+  top-level public availability summary reports **Healthy endpoints**, **Failed
+  endpoints**, and a yellow **Missing probe data** count for the selected probe
+  filters. Healthy and failed are current `probe_success` results; missing compares
+  current samples with lifecycle-owned targets discovered through `up` during the
+  last five minutes, so a briefly disappeared discovery target remains visible.
+  `16/0/0` is fully healthy, `15/1/0` has one observed failure, and `15/0/1`
+  identifies one expected target without current probe data. If no expected target
+  data exists, all three values remain `NO DATA` rather than implying health. The
+  detailed endpoint matrix remains the diagnostic view. DSPACE user
   request rate excludes `/healthz`, `/livez`, and
   `/metrics`, whose traffic has a separate operational-rate panel. Status-class
   distribution is an instant categorical summary over the selected time window.

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -127,9 +127,11 @@ is not rollout evidence.
 - Grafana: persistence disabled, no Ingress, LAN-only NodePort `30300`.
 - The provisioned dashboard defaults to six hours and a 30-second refresh. Its
   top-level public availability summary reports current healthy and failed
-  endpoint counts for the selected probe filters; missing data remains visibly
-  absent rather than appearing healthy. The detailed endpoint matrix remains the
-  diagnostic view. DSPACE user request rate excludes `/healthz`, `/livez`, and
+  endpoint counts for the selected probe filters. An endpoint discovered in the
+  last five minutes but missing a current probe sample counts as failed; a complete
+  absence of discovered probes remains visibly absent rather than appearing
+  healthy. The detailed endpoint matrix remains the diagnostic view. DSPACE user
+  request rate excludes `/healthz`, `/livez`, and
   `/metrics`, whose traffic has a separate operational-rate panel. Status-class
   distribution is an instant categorical summary over the selected time window.
   The `Probe application` and `Probe route` controls filter blackbox panels while

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -113,7 +113,8 @@ def validate_dashboard_semantics(dashboard: dict) -> None:
     if len(summary_targets) != 2 or any(
         target.get("instant") is not True
         or target.get("range") is not False
-        or "count(" not in target.get("expr", "")
+        or "sum(" not in target.get("expr", "")
+        or "== bool 1" not in target.get("expr", "")
         or " by (environment, app, route) " not in target.get("expr", "")
         or any(
             selector not in target.get("expr", "")
@@ -127,6 +128,21 @@ def validate_dashboard_semantics(dashboard: dict) -> None:
     ):
         raise SystemExit(
             "ERROR: public availability must be a two-value instant aggregate summary."
+        )
+    summary_by_legend = {
+        target.get("legendFormat"): target.get("expr", "") for target in summary_targets
+    }
+    failed_expression = summary_by_legend.get("Failed endpoints", "")
+    if (
+        "max_over_time(up{" not in failed_expression
+        or "[5m]" not in failed_expression
+        or ">= bool 0" not in failed_expression
+        or " - (sum(" not in failed_expression
+        or "or vector(0)" not in failed_expression
+    ):
+        raise SystemExit(
+            "ERROR: failed availability must include recently discovered probes "
+            "with missing samples."
         )
     if {target.get("legendFormat") for target in summary_targets} != {
         "Healthy endpoints",

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -27,6 +27,7 @@ REQUIRED_METRICS = {
     "probe_ssl_earliest_cert_expiry",
 }
 EVENT_METRICS = {"dspace_dchat_requests_total", "dspace_dependency_requests_total"}
+OPERATIONAL_ROUTES = '"/(healthz|livez|metrics)"'
 
 
 def load_dashboard(path: Path) -> dict:
@@ -46,6 +47,100 @@ def panels(dashboard: dict):
             yield from panels(panel)
 
 
+def panel_named(dashboard: dict, title: str) -> dict:
+    matching = [panel for panel in panels(dashboard) if panel.get("title") == title]
+    if len(matching) != 1:
+        raise SystemExit(f"ERROR: dashboard must contain exactly one {title!r} panel.")
+    return matching[0]
+
+
+def validate_dashboard_semantics(dashboard: dict) -> None:
+    variables = {
+        variable.get("name"): variable
+        for variable in dashboard.get("templating", {}).get("list", [])
+        if isinstance(variable, dict)
+    }
+    expected_labels = {"app": "Probe application", "route": "Probe route"}
+    if any(
+        variables.get(name, {}).get("label") != label for name, label in expected_labels.items()
+    ):
+        raise SystemExit("ERROR: blackbox variables must use probe-specific visible labels.")
+
+    distribution = panel_named(dashboard, "Status-class distribution")
+    if distribution.get("type") not in {"piechart", "bargauge"}:
+        raise SystemExit("ERROR: status-class distribution must use a categorical visualization.")
+    distribution_targets = distribution.get("targets", [])
+    if not distribution_targets or any(
+        target.get("instant") is not True or target.get("range") is not False
+        for target in distribution_targets
+    ):
+        raise SystemExit(
+            "ERROR: status-class distribution must be an instant selected-window query."
+        )
+    if any(
+        "increase(" not in target.get("expr", "")
+        or "$__range" not in target.get("expr", "")
+        or "sum by (status_class)" not in target.get("expr", "")
+        or 'environment=~"$environment"' not in target.get("expr", "")
+        for target in distribution_targets
+    ):
+        raise SystemExit("ERROR: status-class distribution must summarize the selected window.")
+    distribution_colors = {
+        override.get("matcher", {})
+        .get("options"): override.get("properties", [{}])[0]
+        .get("value", {})
+        .get("fixedColor")
+        for override in distribution.get("fieldConfig", {}).get("overrides", [])
+    }
+    if distribution_colors != {"2xx": "green", "4xx": "orange", "5xx": "red"}:
+        raise SystemExit("ERROR: status-class distribution must use explicit status-class colors.")
+
+    user_rate = panel_named(dashboard, "User request rate by route and status class")
+    user_expressions = [target.get("expr", "") for target in user_rate.get("targets", [])]
+    if not user_expressions or any(
+        f"route!~{OPERATIONAL_ROUTES}" not in expression for expression in user_expressions
+    ):
+        raise SystemExit("ERROR: user request rate must exclude operational routes.")
+    operational_rate = panel_named(dashboard, "Operational request rate")
+    if not any(
+        f"route=~{OPERATIONAL_ROUTES}" in target.get("expr", "")
+        for target in operational_rate.get("targets", [])
+    ):
+        raise SystemExit("ERROR: operational request rate must retain health and metrics routes.")
+
+    summary = panel_named(dashboard, "Public availability summary")
+    summary_targets = summary.get("targets", [])
+    if len(summary_targets) != 2 or any(
+        target.get("instant") is not True
+        or target.get("range") is not False
+        or "count(" not in target.get("expr", "")
+        or " by (environment, app, route) " not in target.get("expr", "")
+        or any(
+            selector not in target.get("expr", "")
+            for selector in (
+                'environment=~"$environment"',
+                'app=~"$app"',
+                'route=~"$route"',
+            )
+        )
+        for target in summary_targets
+    ):
+        raise SystemExit(
+            "ERROR: public availability must be a two-value instant aggregate summary."
+        )
+    if {target.get("legendFormat") for target in summary_targets} != {
+        "Healthy endpoints",
+        "Failed endpoints",
+    } or summary.get("fieldConfig", {}).get("defaults", {}).get("noValue") != "NO DATA":
+        raise SystemExit(
+            "ERROR: public availability must distinguish healthy, failed, and no data."
+        )
+
+    matrix = panel_named(dashboard, "Endpoint matrix")
+    if matrix.get("type") != "table" or not matrix.get("targets"):
+        raise SystemExit("ERROR: dashboard must retain the detailed endpoint matrix.")
+
+
 def validate_dashboard(path: Path) -> str:
     dashboard = load_dashboard(path)
     if dashboard.get("uid") != UID or dashboard.get("title") != TITLE:
@@ -57,6 +152,7 @@ def validate_dashboard(path: Path) -> str:
         or len(ids) != len(set(ids))
     ):
         raise SystemExit("ERROR: dashboard panel IDs must be present, integer, and unique.")
+    validate_dashboard_semantics(dashboard)
     expressions = [
         target["expr"]
         for panel in panels(dashboard)

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -28,6 +28,9 @@ REQUIRED_METRICS = {
 }
 EVENT_METRICS = {"dspace_dchat_requests_total", "dspace_dependency_requests_total"}
 OPERATIONAL_ROUTES = '"/(healthz|livez|metrics)"'
+BLACKBOX_JOB_MATCHER = (
+    'job=~"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*"'
+)
 
 
 def load_dashboard(path: Path) -> dict:
@@ -110,47 +113,69 @@ def validate_dashboard_semantics(dashboard: dict) -> None:
 
     summary = panel_named(dashboard, "Public availability summary")
     summary_targets = summary.get("targets", [])
-    if len(summary_targets) != 2 or any(
-        target.get("instant") is not True
-        or target.get("range") is not False
-        or "sum(" not in target.get("expr", "")
-        or "== bool 1" not in target.get("expr", "")
-        or " by (environment, app, route) " not in target.get("expr", "")
+    if (
+        not isinstance(summary_targets, list)
+        or len(summary_targets) != 3
         or any(
-            selector not in target.get("expr", "")
-            for selector in (
-                'environment=~"$environment"',
-                'app=~"$app"',
-                'route=~"$route"',
+            not isinstance(target, dict)
+            or not isinstance(target.get("expr"), str)
+            or target.get("instant") is not True
+            or target.get("range") is not False
+            or "sum(" not in target.get("expr", "")
+            or " by (environment, app, route) " not in target.get("expr", "")
+            or BLACKBOX_JOB_MATCHER not in target.get("expr", "")
+            or any(
+                selector not in target.get("expr", "")
+                for selector in (
+                    'environment=~"$environment"',
+                    'app=~"$app"',
+                    'route=~"$route"',
+                )
             )
+            for target in summary_targets
         )
-        for target in summary_targets
     ):
         raise SystemExit(
-            "ERROR: public availability must be a two-value instant aggregate summary."
+            "ERROR: public availability must be a three-value instant aggregate summary."
         )
     summary_by_legend = {
         target.get("legendFormat"): target.get("expr", "") for target in summary_targets
     }
-    failed_expression = summary_by_legend.get("Failed endpoints", "")
+    healthy_expression = re.sub(r"\s+", " ", summary_by_legend.get("Healthy endpoints", ""))
+    failed_expression = re.sub(r"\s+", " ", summary_by_legend.get("Failed endpoints", ""))
+    missing_expression = re.sub(r"\s+", " ", summary_by_legend.get("Missing probe data", ""))
+    if "== bool 1" not in healthy_expression or "== bool 0" not in failed_expression:
+        raise SystemExit("ERROR: availability counts must use boolean healthy and failed sums.")
     if (
-        "max_over_time(up{" not in failed_expression
-        or "[5m]" not in failed_expression
-        or ">= bool 0" not in failed_expression
-        or " - (sum(" not in failed_expression
-        or "or vector(0)" not in failed_expression
+        "max_over_time(up{" not in missing_expression
+        or "[5m]" not in missing_expression
+        or ">= bool 0" not in missing_expression
+        or " - (sum(" not in missing_expression
+        or "probe_success{" not in missing_expression
+        or "or vector(0)" not in missing_expression
     ):
         raise SystemExit(
-            "ERROR: failed availability must include recently discovered probes "
-            "with missing samples."
+            "ERROR: missing probe data must compare recently discovered probes "
+            "with current samples."
         )
     if {target.get("legendFormat") for target in summary_targets} != {
         "Healthy endpoints",
         "Failed endpoints",
+        "Missing probe data",
     } or summary.get("fieldConfig", {}).get("defaults", {}).get("noValue") != "NO DATA":
         raise SystemExit(
             "ERROR: public availability must distinguish healthy, failed, and no data."
         )
+    missing_colors = [
+        prop.get("value", {}).get("fixedColor")
+        for override in summary.get("fieldConfig", {}).get("overrides", [])
+        if isinstance(override, dict)
+        and override.get("matcher", {}).get("options") == "Missing probe data"
+        for prop in override.get("properties", [])
+        if isinstance(prop, dict) and prop.get("id") == "color"
+    ]
+    if missing_colors != ["yellow"]:
+        raise SystemExit("ERROR: missing probe data must be a compact yellow summary value.")
 
     matrix = panel_named(dashboard, "Endpoint matrix")
     if matrix.get("type") != "table" or not matrix.get("targets"):

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -148,15 +148,15 @@ def validate_dashboard_semantics(dashboard: dict) -> None:
         raise SystemExit("ERROR: availability counts must use boolean healthy and failed sums.")
     if (
         "max_over_time(up{" not in missing_expression
-        or "[5m]" not in missing_expression
+        or "[7d]" not in missing_expression
         or ">= bool 0" not in missing_expression
         or " - (sum(" not in missing_expression
         or "probe_success{" not in missing_expression
         or "or vector(0)" not in missing_expression
     ):
         raise SystemExit(
-            "ERROR: missing probe data must compare recently discovered probes "
-            "with current samples."
+            "ERROR: missing probe data must compare retention-backed discovered "
+            "probes with current samples."
         )
     if {target.get("legendFormat") for target in summary_targets} != {
         "Healthy endpoints",

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -10,6 +10,7 @@ ROOT = Path(__file__).resolve().parents[1]
 DASHBOARD = ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
 VALIDATOR = ROOT / "scripts/validate_observability_dashboard.py"
 SCRIPT = ROOT / "scripts/observability_helm.sh"
+PROMETHEUS_VALUES = ROOT / "platform/observability/helm/kube-prometheus-stack.values.common.yaml"
 
 # Import the validator so pytest-cov attributes its execution to the production
 # module. Subprocess-only checks prove the command-line contract, but their
@@ -152,7 +153,12 @@ def test_selected_window_traffic_and_availability_semantics(dashboard):
     assert "sum(" in failed_expression and "== bool 0" in failed_expression
     missing_expression = summary_expressions["Missing probe data"]
     assert "max_over_time(up{" in missing_expression
-    assert "[5m]" in missing_expression
+    retention = next(
+        line.split(":", 1)[1].strip()
+        for line in PROMETHEUS_VALUES.read_text(encoding="utf-8").splitlines()
+        if line.strip().startswith("retention:")
+    )
+    assert f"[{retention}]" in missing_expression
     assert ">= bool 0" in missing_expression
     assert " - (sum(" in missing_expression
     assert "probe_success{" in missing_expression
@@ -326,6 +332,24 @@ def test_validator_rejects_wrong_dashboard_mount(tmp_path, dashboard, mount_path
         (lambda item: item.update(links=[{"url": "https://example.invalid"}]), "raw URLs"),
         (lambda item: item.update(description="${DS_PROMETHEUS}"), "datasource placeholder"),
         (lambda item: item.update(datasource={"uid": "unexpected"}), "datasource references"),
+        (
+            lambda item: next(
+                target
+                for panel in item["panels"]
+                if panel["title"] == "Public availability summary"
+                for target in panel["targets"]
+                if target["legendFormat"] == "Missing probe data"
+            ).update(
+                expr=next(
+                    target["expr"]
+                    for panel in item["panels"]
+                    if panel["title"] == "Public availability summary"
+                    for target in panel["targets"]
+                    if target["legendFormat"] == "Missing probe data"
+                ).replace("[7d]", "[5m]")
+            ),
+            "retention-backed discovered probes",
+        ),
         (
             lambda item: next(
                 panel for panel in item["panels"] if panel["title"] == "Status-class distribution"

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -136,27 +136,38 @@ def test_selected_window_traffic_and_availability_semantics(dashboard):
     assert 'route=~"/(healthz|livez|metrics)"' in operational_expression
 
     summary = panels["Public availability summary"]
-    assert len(summary["targets"]) == 2
+    assert len(summary["targets"]) == 3
     assert all(
         target["instant"] is True and target["range"] is False for target in summary["targets"]
     )
     assert {target["legendFormat"] for target in summary["targets"]} == {
         "Healthy endpoints",
         "Failed endpoints",
+        "Missing probe data",
     }
-    summary_expressions = {
-        target["legendFormat"]: target["expr"] for target in summary["targets"]
-    }
+    summary_expressions = {target["legendFormat"]: target["expr"] for target in summary["targets"]}
+    assert "sum(" in summary_expressions["Healthy endpoints"]
+    assert "== bool 1" in summary_expressions["Healthy endpoints"]
+    failed_expression = summary_expressions["Failed endpoints"]
+    assert "sum(" in failed_expression and "== bool 0" in failed_expression
+    missing_expression = summary_expressions["Missing probe data"]
+    assert "max_over_time(up{" in missing_expression
+    assert "[5m]" in missing_expression
+    assert ">= bool 0" in missing_expression
+    assert " - (sum(" in missing_expression
+    assert "probe_success{" in missing_expression
+    assert "or vector(0)" in missing_expression
     assert all(
-        "sum(" in expression and "== bool 1" in expression
+        'job=~"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*"'
+        in expression
         for expression in summary_expressions.values()
     )
-    failed_expression = summary_expressions["Failed endpoints"]
-    assert "max_over_time(up{" in failed_expression
-    assert "[5m]" in failed_expression
-    assert ">= bool 0" in failed_expression
-    assert " - (sum(" in failed_expression
-    assert "or vector(0)" in failed_expression
+    missing_override = next(
+        override
+        for override in summary["fieldConfig"]["overrides"]
+        if override["matcher"]["options"] == "Missing probe data"
+    )
+    assert missing_override["properties"][0]["value"]["fixedColor"] == "yellow"
     assert summary["fieldConfig"]["defaults"]["noValue"] == "NO DATA"
     assert panels["Endpoint matrix"]["type"] == "table"
 
@@ -335,7 +346,45 @@ def test_validator_rejects_wrong_dashboard_mount(tmp_path, dashboard, mount_path
             lambda item: next(
                 panel for panel in item["panels"] if panel["title"] == "Public availability summary"
             ).update(targets=[]),
-            "two-value instant aggregate summary",
+            "three-value instant aggregate summary",
+        ),
+        (
+            lambda item: next(
+                target
+                for panel in item["panels"]
+                if panel["title"] == "Public availability summary"
+                for target in panel["targets"]
+                if target["legendFormat"] == "Healthy endpoints"
+            ).update(expr='count(probe_success{environment=~"$environment"} == 1)'),
+            "three-value instant aggregate summary",
+        ),
+        (
+            lambda item: next(
+                target
+                for panel in item["panels"]
+                if panel["title"] == "Public availability summary"
+                for target in panel["targets"]
+                if target["legendFormat"] == "Missing probe data"
+            ).update(
+                expr=(
+                    "sum(min by (environment, app, route) (probe_success{"
+                    'job=~"probe/monitoring/blackbox-'
+                    '(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*",'
+                    'environment=~"$environment",app=~"$app",route=~"$route"'
+                    "}) == bool 1)"
+                )
+            ),
+            "missing probe data must compare",
+        ),
+        (
+            lambda item: next(
+                target
+                for panel in item["panels"]
+                if panel["title"] == "Public availability summary"
+                for target in panel["targets"]
+                if target["legendFormat"] == "Failed endpoints"
+            ).pop("expr"),
+            "three-value instant aggregate summary",
         ),
         (
             lambda item: next(

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -144,6 +144,19 @@ def test_selected_window_traffic_and_availability_semantics(dashboard):
         "Healthy endpoints",
         "Failed endpoints",
     }
+    summary_expressions = {
+        target["legendFormat"]: target["expr"] for target in summary["targets"]
+    }
+    assert all(
+        "sum(" in expression and "== bool 1" in expression
+        for expression in summary_expressions.values()
+    )
+    failed_expression = summary_expressions["Failed endpoints"]
+    assert "max_over_time(up{" in failed_expression
+    assert "[5m]" in failed_expression
+    assert ">= bool 0" in failed_expression
+    assert " - (sum(" in failed_expression
+    assert "or vector(0)" in failed_expression
     assert summary["fieldConfig"]["defaults"]["noValue"] == "NO DATA"
     assert panels["Endpoint matrix"]["type"] == "table"
 

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -320,6 +320,36 @@ def test_validator_rejects_wrong_dashboard_mount(tmp_path, dashboard, mount_path
         (lambda item: item.update(uid="wrong"), "dashboard title"),
         (lambda item: item.update(panels=[]), "panel IDs"),
         (
+            lambda item: next(
+                variable for variable in item["templating"]["list"] if variable["name"] == "app"
+            ).update(label="Application"),
+            "probe-specific visible labels",
+        ),
+        (
+            lambda item: next(
+                panel for panel in item["panels"] if panel["title"] == "Status-class distribution"
+            ).update(type="timeseries"),
+            "categorical visualization",
+        ),
+        (
+            lambda item: next(
+                panel for panel in item["panels"] if panel["title"] == "Status-class distribution"
+            )["targets"][0].update(expr="sum(dspace_http_requests_total)"),
+            "summarize the selected window",
+        ),
+        (
+            lambda item: next(
+                panel for panel in item["panels"] if panel["title"] == "Status-class distribution"
+            )["fieldConfig"].update(overrides=[]),
+            "explicit status-class colors",
+        ),
+        (
+            lambda item: next(
+                panel for panel in item["panels"] if panel["title"] == "Operational request rate"
+            )["targets"][0].update(expr="sum(dspace_http_requests_total)"),
+            "retain health and metrics routes",
+        ),
+        (
             lambda item: replace_metric_expression(item, "process_resident_memory_bytes", "0"),
             "missing required PromQL metrics",
         ),
@@ -379,8 +409,48 @@ def test_validator_rejects_wrong_dashboard_mount(tmp_path, dashboard, mount_path
                 if panel["title"] == "Public availability summary"
                 for target in panel["targets"]
                 if target["legendFormat"] == "Healthy endpoints"
+            ).update(
+                expr=next(
+                    target["expr"]
+                    for panel in item["panels"]
+                    if panel["title"] == "Public availability summary"
+                    for target in panel["targets"]
+                    if target["legendFormat"] == "Healthy endpoints"
+                ).replace("== bool 1", "== 1")
+            ),
+            "boolean healthy and failed sums",
+        ),
+        (
+            lambda item: next(
+                target
+                for panel in item["panels"]
+                if panel["title"] == "Public availability summary"
+                for target in panel["targets"]
+                if target["legendFormat"] == "Healthy endpoints"
             ).update(expr='count(probe_success{environment=~"$environment"} == 1)'),
             "three-value instant aggregate summary",
+        ),
+        (
+            lambda item: next(
+                panel for panel in item["panels"] if panel["title"] == "Public availability summary"
+            )["fieldConfig"]["defaults"].update(noValue="0"),
+            "distinguish healthy, failed, and no data",
+        ),
+        (
+            lambda item: next(
+                override
+                for panel in item["panels"]
+                if panel["title"] == "Public availability summary"
+                for override in panel["fieldConfig"]["overrides"]
+                if override["matcher"]["options"] == "Missing probe data"
+            )["properties"][0]["value"].update(fixedColor="green"),
+            "compact yellow summary value",
+        ),
+        (
+            lambda item: next(
+                panel for panel in item["panels"] if panel["title"] == "Endpoint matrix"
+            ).update(type="stat"),
+            "retain the detailed endpoint matrix",
         ),
         (
             lambda item: next(

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -57,9 +57,10 @@ def test_dashboard_identity_defaults_rows_and_required_panels(dashboard):
     titles = {panel["title"] for panel in panels}
     for title in (
         "DSPACE scrape availability",
-        "DSPACE instrumentation status",
-        "Public endpoint availability",
-        "Request rate by route and status class",
+        "Instrumentation health",
+        "Public availability summary",
+        "User request rate by route and status class",
+        "Operational request rate",
         "Status-class distribution",
         "5xx error ratio",
         "HTTP latency percentiles",
@@ -110,6 +111,45 @@ def test_snapshot_tables_use_instant_queries(dashboard):
     organize = next(item for item in build["transformations"] if item["id"] == "organize")
     assert organize["options"]["indexByName"] == {"pod": 0, "version": 1, "revision": 2}
     assert organize["options"]["excludeByName"] == {"Time": True, "Value": True}
+
+
+def test_selected_window_traffic_and_availability_semantics(dashboard):
+    panels = {panel["title"]: panel for panel in all_panels(dashboard)}
+
+    distribution = panels["Status-class distribution"]
+    assert distribution["type"] == "piechart"
+    assert all(
+        target.get("instant") is True and target.get("range") is False
+        for target in distribution["targets"]
+    )
+    assert "increase(" in distribution["targets"][0]["expr"]
+    assert "$__range" in distribution["targets"][0]["expr"]
+    colors = {
+        override["matcher"]["options"]: override["properties"][0]["value"]["fixedColor"]
+        for override in distribution["fieldConfig"]["overrides"]
+    }
+    assert colors == {"2xx": "green", "4xx": "orange", "5xx": "red"}
+
+    user_expression = panels["User request rate by route and status class"]["targets"][0]["expr"]
+    operational_expression = panels["Operational request rate"]["targets"][0]["expr"]
+    assert 'route!~"/(healthz|livez|metrics)"' in user_expression
+    assert 'route=~"/(healthz|livez|metrics)"' in operational_expression
+
+    summary = panels["Public availability summary"]
+    assert len(summary["targets"]) == 2
+    assert all(
+        target["instant"] is True and target["range"] is False for target in summary["targets"]
+    )
+    assert {target["legendFormat"] for target in summary["targets"]} == {
+        "Healthy endpoints",
+        "Failed endpoints",
+    }
+    assert summary["fieldConfig"]["defaults"]["noValue"] == "NO DATA"
+    assert panels["Endpoint matrix"]["type"] == "table"
+
+    variables = {item["name"]: item for item in dashboard["templating"]["list"]}
+    assert variables["app"]["label"] == "Probe application"
+    assert variables["route"]["label"] == "Probe route"
 
 
 def test_blackbox_queries_drop_raw_target_labels(dashboard):
@@ -262,6 +302,34 @@ def test_validator_rejects_wrong_dashboard_mount(tmp_path, dashboard, mount_path
         (lambda item: item.update(links=[{"url": "https://example.invalid"}]), "raw URLs"),
         (lambda item: item.update(description="${DS_PROMETHEUS}"), "datasource placeholder"),
         (lambda item: item.update(datasource={"uid": "unexpected"}), "datasource references"),
+        (
+            lambda item: next(
+                panel for panel in item["panels"] if panel["title"] == "Status-class distribution"
+            )["targets"][0].update(instant=False, range=True),
+            "instant selected-window query",
+        ),
+        (
+            lambda item: next(
+                panel
+                for panel in item["panels"]
+                if panel["title"] == "User request rate by route and status class"
+            )["targets"][0].update(
+                expr='sum(rate(dspace_http_requests_total{environment=~"$environment"}[5m]))'
+            ),
+            "exclude operational routes",
+        ),
+        (
+            lambda item: next(
+                panel for panel in item["panels"] if panel["title"] == "Public availability summary"
+            ).update(targets=[]),
+            "two-value instant aggregate summary",
+        ),
+        (
+            lambda item: next(
+                panel for panel in item["panels"] if panel["title"] == "Endpoint matrix"
+            ).update(title="Removed matrix"),
+            "exactly one 'Endpoint matrix' panel",
+        ),
     ],
 )
 def test_validator_directly_rejects_unsafe_dashboard_sources(


### PR DESCRIPTION
### Motivation

Improve the correctness and signal-to-noise ratio of the provisioned **Sugarkube Staging Observability** dashboard now that DSPACE metrics and all 16 blackbox probes are healthy.

### Changes

- Converted **Status-class distribution** into an instant selected-window pie chart using `increase(...[$__range])`, with explicit green `2xx`, orange `4xx`, and red `5xx` colors and no time axis.
- Split DSPACE HTTP traffic into:
  - **User request rate by route and status class**, excluding `/healthz`, `/livez`, and `/metrics`.
  - **Operational request rate**, containing only those routes.
- Replaced the 16 cramped top-level endpoint stats with a three-value **Public availability summary**:
  - **Healthy endpoints** uses a zero-preserving `sum(... == bool 1)`.
  - **Failed endpoints** uses a zero-preserving `sum(... == bool 0)`.
  - **Missing probe data** compares current grouped `probe_success` series with lifecycle-owned blackbox targets observed through `up` across the configured seven-day Prometheus retention horizon.
- The expected summary states are:
  - `16/0/0`: all endpoints healthy.
  - `15/1/0`: one observed probe failure.
  - `15/0/1`: one expected endpoint has no current probe data.
  - Complete absence of expected target data: all values remain `NO DATA`.
- Retained the detailed **Endpoint matrix** for per-endpoint diagnosis.
- Renamed visible controls to **Probe application** and **Probe route** while preserving the internal `app` and `route` variable names.
- Renamed **DSPACE instrumentation status** to **Instrumentation health**.
- Preserved bounded `environment`, `app`, and `route` labels without exposing instances, raw targets, or URLs.

### Validation and regression coverage

Updated:

- `scripts/validate_observability_dashboard.py`
- `tests/test_observability_dashboard.py`
- `docs/observability-operations.md`

The validator and tests now enforce:

- Instant-only selected-window status distribution with explicit status-class colors.
- User and operational traffic separation.
- Three-value availability semantics with reliable zero-versus-`NO DATA` behavior.
- Seven-day missing-target visibility aligned with configured Prometheus retention.
- Rejection of regressions to a five-minute target-discovery window.
- Preservation of the detailed endpoint matrix, bounded labels, datasource behavior, UID, and privacy constraints.
- Controlled validation failures for malformed targets and invalid panel, query, color, label, route-filtering, aggregation, and missing-data configurations.
- Direct test coverage for every modified and coverable validator branch.

### Testing

- `python3 scripts/validate_observability_dashboard.py clusters/staging/observability/dashboards/sugarkube-staging-observability.json` — passed.
- `python3 -m pytest -q tests/test_observability_dashboard.py tests/test_observability_helm.py` — 104 passed.
- `python3 -m black --check scripts/validate_observability_dashboard.py tests/test_observability_dashboard.py` — passed.
- Secret and whitespace checks — passed.
- `codecov/patch` — passed; all modified and coverable lines are covered by tests.
- Latest-head GitHub Actions on `fc45ea72f511753509457d2918bf18efeac9bb6c`:
  - `ci` — passed.
  - `Test Suite` — passed.
  - `Docs` — passed.
  - `Spellcheck` — passed.
  - `pi-image` path-aware checks — passed.

### Scope and compatibility

The diff is limited to the dashboard JSON, validator, focused regression tests, and operations documentation. It preserves the dashboard UID, title, folder, datasource behavior, Helm provisioning, existing diagnostic panels, and cluster configuration. No alerts, receivers, persistence, infrastructure, chart-version, or cluster changes are included.

### Post-merge staging verification

~~~bash
git pull --ff-only
just kubeconfig-env env=staging
just observability-render env=staging >/tmp/kube-prometheus-stack.dashboard.rendered.yaml
just observability-upgrade env=staging
just observability-verify env=staging
just observability-dashboard-verify env=staging
just observability-blackbox-verify env=staging
~~~

### Visual inspection checklist

- **Status-class distribution** is categorical, instant, and colored correctly without a time axis.
- User request rate excludes `/healthz`, `/livez`, and `/metrics`; operational traffic appears separately.
- Public availability shows healthy, failed, and yellow missing-data counts without treating absent data as healthy.
- Controls read **Probe application** and **Probe route**.
- **Endpoint matrix** remains available for detailed diagnosis.

---

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6700c13790832f8d568d8781061428)