### PR TITLE
Add staging PagerDuty synthetic alert foundation (secret‑safe, fail‑closed, test workflow)

### DIFF
--- a/clusters/staging/observability/kube-prometheus-stack.values.yaml
+++ b/clusters/staging/observability/kube-prometheus-stack.values.yaml
@@ -4,3 +4,23 @@ prometheus:
   prometheusSpec:
     externalLabels:
       cluster: sugarkube-int
+alertmanager:
+  alertmanagerSpec:
+    secrets:
+      - alertmanager-pagerduty
+  config:
+    route:
+      receiver: "null"
+      routes:
+        - receiver: pagerduty-synthetic
+          matchers:
+            - alertname="SugarkubePagerDutyTest"
+            - environment="staging"
+            - cluster="sugarkube-int"
+            - severity="critical"
+    receivers:
+      - name: "null"
+      - name: pagerduty-synthetic
+        pagerduty_configs:
+          - routing_key_file: /etc/alertmanager/secrets/alertmanager-pagerduty/routing-key
+            send_resolved: true

--- a/docs/observability-alerting.md
+++ b/docs/observability-alerting.md
@@ -4,9 +4,11 @@ This is the canonical alerting strategy for Sugarkube. It defines the agreed tar
 routing policy, alert inventory, and rollout/drill plan for turning the staging observability stack
 described in [`docs/observability-design.md`](./observability-design.md) and
 [`docs/observability-operations.md`](./observability-operations.md) into something that actually pages
-a human. **Nothing in this document is deployed yet.** Alertmanager currently ships a no-op `"null"`
-receiver in staging (see [`docs/observability-operations.md`](./observability-operations.md)); this
-document records the plan for closing that gap, not evidence that it is closed.
+a human. The repository now supports a staging-only, file-backed PagerDuty receiver
+and an exact synthetic test route while retaining the root `"null"` receiver (see
+[`docs/observability-operations.md`](./observability-operations.md)). This is not
+evidence that the change is deployed or that PagerDuty phone delivery and resolution
+have been manually proven.
 
 ## 1. Goals and non-goals
 
@@ -117,9 +119,9 @@ What each check detects, and does not:
 - Route only explicitly named, reviewed, and tested Sugarkube alerts to PagerDuty — an allowlist, not
   the chart's entire default rule set. Do not forward `kube-prometheus-stack`'s bundled rules
   wholesale before auditing each one individually.
-- Use Alertmanager's PagerDuty integration with a secret file reference, for example
-  `routing_key_file: /etc/alertmanager/secrets/pagerduty-routing-key`, never an inline key committed to
-  Git.
+- Use Alertmanager's PagerDuty integration with the implemented Secret-backed file
+  reference `/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key`, never an
+  inline key committed to Git.
 - Set `send_resolved: true` on the PagerDuty receiver so incidents auto-resolve when the underlying
   alert clears.
 - Define sensible `group_by`, `group_wait`, `group_interval`, and `repeat_interval` values so a single
@@ -213,5 +215,6 @@ it is deployed yet — see the rollout plan above for the actual sequencing.
 - Shallow public-endpoint blackbox monitoring (`PublicEndpointDown`, `PublicProbeMissing`,
   `TLSExpiringSoon`) is already live in staging today, independently of that dependency — see
   [`docs/observability-blackbox.md`](./observability-blackbox.md).
-- Alert delivery to a phone and node-power-off drills have not yet been performed. Everything in
-  [§6](#6-rollout-and-drill-plan) above is planned, not completed.
+- The repository supports the synthetic PagerDuty fire/resolve drill. Its staging
+  deployment and phone-delivery/resolution observations have not been claimed or
+  performed by this repository change. Node-power-off drills remain future work.

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -11,7 +11,7 @@ Production observability is intentionally unsupported in this slice because no p
 - Staging overrides: `clusters/staging/observability/kube-prometheus-stack.values.yaml`.
 - Staging dashboard: `clusters/staging/observability/dashboards/sugarkube-staging-observability.json`.
 - Helper: `scripts/observability_helm.sh` through `just observability-*` recipes.
-- Alert delivery, routing, and drill strategy: [`docs/observability-alerting.md`](observability-alerting.md) — this runbook covers deploying and verifying the stack, not how (or whether) it pages anyone yet.
+- Alert delivery, routing, and drill strategy: [`docs/observability-alerting.md`](observability-alerting.md). Repository support does not prove that it has been deployed or that a phone notification was delivered.
 
 The dashboard is owned by Sugarkube and provisioned by the pinned Grafana
 subchart. Every render, install, and upgrade passes the same standalone JSON
@@ -46,6 +46,9 @@ The old Flux/Longhorn files under `platform/observability/*.yaml` and `clusters/
   - Secret name: `grafana-admin-credentials`.
   - Username key: `admin-user`.
   - Password key: `admin-password`.
+- Operator-managed PagerDuty Secret `alertmanager-pagerduty` exists in `monitoring`
+  with a nonempty `routing-key`. Install and upgrade fail before Helm state is
+  queried or mutated if this contract is absent; offline render does not require it.
 
 Never put example credentials or plaintext Secret data in commands, logs, docs, commits, or PRs.
 
@@ -120,11 +123,65 @@ is not rollout evidence.
    just observability-dashboard-verify env=staging
    ```
 
+## PagerDuty staging drill
+
+Repository support alone is not deployment or delivery evidence. Perform this
+operator-controlled sequence only after a PagerDuty Events API v2 integration has
+been created outside Git.
+
+1. Select `sugar-staging`, then create or rotate the Secret using a hidden read and
+   stdin. This keeps the value out of shell history, arguments, generated files,
+   and command output:
+
+   ```bash
+   just kubeconfig-env env=staging
+   read -r -s -p 'PagerDuty routing key: ' PAGERDUTY_ROUTING_KEY; printf '\n'
+   printf '%s' "$PAGERDUTY_ROUTING_KEY" | kubectl -n monitoring create secret generic \
+     alertmanager-pagerduty --from-file=routing-key=/dev/stdin \
+     --dry-run=client -o yaml | kubectl apply -f -
+   unset PAGERDUTY_ROUTING_KEY
+   ```
+
+2. Render to a protected temporary file and inspect the Alertmanager resource. The
+   render command structurally validates the decoded configuration and confirms
+   that only the documented file reference appears. Delete the temporary render when finished:
+
+   ```bash
+   umask 077
+   just observability-render env=staging > /tmp/sugarkube-observability-render.yaml
+   less /tmp/sugarkube-observability-render.yaml
+   rm -f /tmp/sugarkube-observability-render.yaml
+   ```
+
+3. Run `just observability-upgrade env=staging`, followed by
+   `just observability-verify env=staging`. Verification checks the Secret mount,
+   root null receiver, exact route, file reference, and resolved notifications
+   without displaying either credential or the complete live configuration.
+4. Explicitly run `just observability-pagerduty-test env=staging action=fire`.
+   Confirm receipt and acknowledge the incident manually in PagerDuty; the helper
+   does not claim that a phone received it. The test automatically expires after
+   15 minutes if abandoned.
+5. Run `just observability-pagerduty-test env=staging action=resolve`, then confirm
+   resolution manually in PagerDuty.
+6. If necessary, inspect `helm -n monitoring history kube-prometheus-stack`, roll
+   back with `helm -n monitoring rollback kube-prometheus-stack <prior-revision>
+   --wait --timeout 20m`, and run the standard verification appropriate to that
+   revision. Do **not** delete the credential Secret before rolling back the
+   configuration that mounts it: Alertmanager may otherwise fail to start.
+
+For rotation, replace the Secret through the same hidden-read/stdin pipeline,
+restart or upgrade Alertmanager so the mounted value is reloaded, run verification,
+and repeat both explicit fire and resolve observations. Retain the old PagerDuty
+integration until the post-rotation drill succeeds; then revoke it in PagerDuty.
+
 ## Runtime expectations
 
 - Helm release: `kube-prometheus-stack` in namespace `monitoring`.
 - Prometheus: one replica, `7d` retention, `15GB` retention size, `local-path` `ReadWriteOnce` PVC requesting `20Gi`, CPU request `200m`, memory request `512Mi`, memory limit `2Gi`, admin API disabled, and external label `cluster=sugarkube-int`.
-- Alertmanager: one replica and no-op receiver named exactly `"null"`. No real notification receiver (PagerDuty, Healthchecks.io, or otherwise) is configured yet; see [`docs/observability-alerting.md`](observability-alerting.md) for the planned rollout.
+- Alertmanager: one replica and root no-op receiver named exactly `"null"`. The
+  staging values mount `monitoring/alertmanager-pagerduty` and route only the exact
+  `SugarkubePagerDutyTest` critical staging label set to PagerDuty. All bundled and
+  other alerts continue to reach the no-op receiver.
 - Grafana: persistence disabled, no Ingress, LAN-only NodePort `30300`.
 - The provisioned dashboard defaults to six hours and a 30-second refresh. Its
   top-level public availability summary reports **Healthy endpoints**, **Failed

--- a/justfile
+++ b/justfile
@@ -3194,6 +3194,10 @@ observability-verify env='':
 observability-dashboard-verify env='':
     @scripts/observability_helm.sh dashboard-verify '{{ env }}'
 
+# Explicitly fire or resolve the staging PagerDuty synthetic alert (never run by CI).
+observability-pagerduty-test env='' action='':
+    @scripts/observability_helm.sh pagerduty-test '{{ env }}' '{{ action }}'
+
 # Render the pinned staging blackbox exporter and Probe manifests (read-only).
 observability-blackbox-render env='':
     @scripts/observability_blackbox.sh render '{{ env }}'

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -11,10 +11,12 @@ STAGING_VALUES="${ROOT}/clusters/staging/observability/kube-prometheus-stack.val
 DASHBOARD="${ROOT}/clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
 DASHBOARD_VALUE="grafana.dashboards.sugarkube.sugarkube-staging-observability.json"
 DASHBOARD_VALIDATOR="${ROOT}/scripts/validate_observability_dashboard.py"
+ALERTMANAGER_VALIDATOR="${ROOT}/scripts/validate_observability_alertmanager.py"
+PAGERDUTY_SECRET="alertmanager-pagerduty"
 TIMEOUT="${SUGARKUBE_OBSERVABILITY_HELM_TIMEOUT:-20m}"
 GRAFANA_URL="http://sugarkube3.local:30300"
 
-usage() { echo "Usage: $0 <render|install|upgrade|status|verify|dashboard-verify> env=staging" >&2; }
+usage() { echo "Usage: $0 <render|install|upgrade|status|verify|dashboard-verify> env=staging | $0 pagerduty-test env=staging <fire|resolve>" >&2; }
 normalize_env() {
   local raw="${1:-}"
   while [[ "${raw}" == env=* ]]; do raw="${raw#env=}"; done
@@ -61,6 +63,22 @@ render_to() {
   helm repo update prometheus-community >/dev/null
   helm template "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" >"${out}"
   validate_rendered_dashboard "${out}"
+  python3 "${ALERTMANAGER_VALIDATOR}" "${out}"
+}
+require_pagerduty_secret() {
+  if ! kubectl -n "${NAMESPACE}" get secret "${PAGERDUTY_SECRET}" -o json | python3 -c 'import json, sys
+try:
+    document = json.load(sys.stdin)
+    encoded = document.get("data", {}).get("routing-key")
+    # Kubernetes validates Secret data as base64. Its empty value is the empty
+    # string, so presence/nonemptiness can be checked without decoding it.
+    valid = isinstance(encoded, str) and encoded != ""
+except (ValueError, UnicodeError):
+    valid = False
+raise SystemExit(0 if valid else 1)' >/dev/null 2>&1; then
+    echo "ERROR: monitoring/${PAGERDUTY_SECRET} must exist with a nonempty routing-key before Helm mutation (value not printed)." >&2
+    return 15
+  fi
 }
 release_state() {
   local matches
@@ -80,8 +98,8 @@ release_state() {
   fi
 }
 render() { validate_dashboard; require_tools helm kubectl python3; print_resolved staging; tmp="$(mktemp -t sugarkube-observability-render.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; cat "${tmp}"; }
-install_release() { validate_dashboard; require_tools helm kubectl python3; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
-upgrade_release() { validate_dashboard; require_tools helm kubectl python3; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
+install_release() { validate_dashboard; require_tools helm kubectl python3; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; require_pagerduty_secret; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
+upgrade_release() { validate_dashboard; require_tools helm kubectl python3; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; require_pagerduty_secret; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
 status() { require_tools helm kubectl python3; print_resolved staging; assert_context; helm -n "${NAMESPACE}" status "${RELEASE}"; kubectl -n "${NAMESPACE}" get deploy,statefulset,daemonset -l "app.kubernetes.io/instance=${RELEASE}"; kubectl -n "${NAMESPACE}" get prometheus,alertmanager; kubectl -n "${NAMESPACE}" get svc,pvc; kubectl get crd prometheuses.monitoring.coreos.com alertmanagers.monitoring.coreos.com servicemonitors.monitoring.coreos.com probes.monitoring.coreos.com; }
 verify_dspace_targets() {
   require_tools kubectl python3 sleep
@@ -231,6 +249,19 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
     raise SystemExit("ERROR: expected one Bound local-path Prometheus PVC.")'
   [[ "$(kubectl -n "${NAMESPACE}" get prometheus kube-prometheus-stack-prometheus -o jsonpath='{.spec.replicas}')" == 1 ]]
   [[ "$(kubectl -n "${NAMESPACE}" get alertmanager kube-prometheus-stack-alertmanager -o jsonpath='{.spec.replicas}')" == 1 ]]
+  [[ "$(kubectl -n "${NAMESPACE}" get alertmanager kube-prometheus-stack-alertmanager -o jsonpath='{.spec.secrets[0]}')" == "${PAGERDUTY_SECRET}" ]] || {
+    echo "ERROR: Alertmanager does not reference the expected PagerDuty Secret." >&2; exit 16;
+  }
+  local alert_config
+  alert_config="$(mktemp -t sugarkube-alertmanager-config.XXXXXX.json)"
+  chmod 600 "${alert_config}"
+  if ! kubectl -n "${NAMESPACE}" get secret alertmanager-kube-prometheus-stack-alertmanager -o json >"${alert_config}"; then
+    rm -f "${alert_config}"; echo "ERROR: loaded Alertmanager configuration is unavailable." >&2; exit 16
+  fi
+  if ! python3 "${ALERTMANAGER_VALIDATOR}" --config-secret-json "${alert_config}"; then
+    rm -f "${alert_config}"; exit 16
+  fi
+  rm -f "${alert_config}"
   [[ -z "$(kubectl -n "${NAMESPACE}" get ingress -l app.kubernetes.io/name=grafana -o name 2>/dev/null)" ]]
   [[ "$(kubectl -n "${NAMESPACE}" get svc kube-prometheus-stack-grafana -o jsonpath='{.spec.ports[?(@.port==80)].nodePort}')" == 30300 ]]
   monitor_release="$(kubectl -n dspace get servicemonitor dspace -o jsonpath='{.metadata.labels.release}')"
@@ -339,7 +370,38 @@ if not isinstance(dashboard, dict) or dashboard.get("uid") != "sugarkube-staging
   return 13
 )
 
+pagerduty_test() {
+  require_tools kubectl python3
+  assert_context
+  local action="${1:-}" endpoint payload
+  case "${action}" in
+    fire|resolve) ;;
+    "") echo "ERROR: PagerDuty test requires explicit action: fire or resolve." >&2; return 2 ;;
+    *) echo "ERROR: unsupported PagerDuty test action '${action}'; use fire or resolve." >&2; return 2 ;;
+  esac
+  endpoint="/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-alertmanager:9093/proxy/api/v2/alerts"
+  payload="$(ACTION="${action}" python3 -c 'import datetime, json, os
+now = datetime.datetime.now(datetime.timezone.utc)
+end = now + datetime.timedelta(minutes=15) if os.environ["ACTION"] == "fire" else now
+stamp = lambda value: value.isoformat(timespec="seconds").replace("+00:00", "Z")
+print(json.dumps([{
+    "labels": {"alertname": "SugarkubePagerDutyTest", "environment": "staging", "cluster": "sugarkube-int", "severity": "critical"},
+    "annotations": {
+        "summary": "Sugarkube staging PagerDuty delivery test",
+        "description": "Operator-triggered Alertmanager-to-PagerDuty fire/resolve drill.",
+        "runbook_url": "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-operations.md#pagerduty-staging-drill"
+    },
+    "startsAt": stamp(now), "endsAt": stamp(end)
+}], separators=(",", ":")))')"
+  if kubectl create --raw "${endpoint}" -f - <<<"${payload}" >/dev/null 2>&1; then
+    echo "PagerDuty synthetic ${action} accepted (Alertmanager API status: success)."
+  else
+    echo "ERROR: PagerDuty synthetic ${action} rejected (Alertmanager API status: failure; response redacted)." >&2
+    return 17
+  fi
+}
+
 cmd="${1:-}"; shift || true; [[ -n "${cmd}" ]] || { usage; exit 2; }
 env_arg="${1:-}"; normalize_env "${env_arg}" >/dev/null
 validate_dashboard
-case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) dashboard_verify ;; *) usage; exit 2 ;; esac
+case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) dashboard_verify ;; pagerduty-test) pagerduty_test "${2:-}" ;; *) usage; exit 2 ;; esac

--- a/scripts/validate_observability_alertmanager.py
+++ b/scripts/validate_observability_alertmanager.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Validate the staging Alertmanager render without revealing secret material."""
+
+import base64
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SECRET = "alertmanager-pagerduty"
+RECEIVER = "pagerduty-synthetic"
+FILE = f"/etc/alertmanager/secrets/{SECRET}/routing-key"
+MATCHERS = {
+    'alertname="SugarkubePagerDutyTest"',
+    'environment="staging"',
+    'cluster="sugarkube-int"',
+    'severity="critical"',
+}
+
+
+def load_documents(path: Path) -> list[dict]:
+    ruby = subprocess.run(
+        [
+            "ruby",
+            "-ryaml",
+            "-rjson",
+            "-e",
+            "puts JSON.generate(YAML.load_stream(File.read(ARGV[0])))",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    documents = json.loads(ruby.stdout)
+    return [item for item in documents if isinstance(item, dict)]
+
+
+def validate_config(config: dict) -> None:
+    route = config.get("route", {})
+    if route.get("receiver") != "null":
+        raise ValueError('root receiver must remain "null"')
+    routes = route.get("routes", [])
+    pd_routes = [item for item in routes if item.get("receiver") == RECEIVER]
+    if len(pd_routes) != 1 or set(pd_routes[0].get("matchers", [])) != MATCHERS:
+        raise ValueError("PagerDuty must have exactly the narrow synthetic route")
+    receivers = [item for item in config.get("receivers", []) if item.get("name") == RECEIVER]
+    if len(receivers) != 1 or len(receivers[0].get("pagerduty_configs", [])) != 1:
+        raise ValueError("expected exactly one synthetic PagerDuty receiver")
+    pagerduty = receivers[0]["pagerduty_configs"][0]
+    if pagerduty.get("routing_key_file") != FILE or pagerduty.get("send_resolved") is not True:
+        raise ValueError("PagerDuty receiver requires the expected file and send_resolved")
+    if "routing_key" in pagerduty or "service_key" in pagerduty:
+        raise ValueError("inline PagerDuty credentials are forbidden")
+
+
+def validate_render(path: Path) -> None:
+    documents = load_documents(path)
+    alertmanagers = [doc for doc in documents if doc.get("kind") == "Alertmanager"]
+    if len(alertmanagers) != 1 or alertmanagers[0].get("spec", {}).get("secrets") != [SECRET]:
+        raise ValueError(f"Alertmanager must reference Secret {SECRET}")
+    configs = [
+        doc
+        for doc in documents
+        if doc.get("kind") == "Secret"
+        and doc.get("metadata", {}).get("name") == "alertmanager-kube-prometheus-stack-alertmanager"
+    ]
+    if len(configs) != 1:
+        raise ValueError("rendered Alertmanager configuration Secret is missing")
+    encoded = configs[0].get("data", {}).get("alertmanager.yaml")
+    if not isinstance(encoded, str):
+        raise ValueError("rendered Alertmanager configuration is missing")
+    raw = base64.b64decode(encoded, validate=True)
+    parsed = subprocess.run(
+        [
+            "ruby",
+            "-ryaml",
+            "-rjson",
+            "-e",
+            "puts JSON.generate(YAML.safe_load(STDIN.read, aliases: false))",
+        ],
+        input=raw,
+        check=True,
+        capture_output=True,
+    )
+    validate_config(json.loads(parsed.stdout))
+
+
+def validate_secret_json(path: Path) -> None:
+    secret = json.loads(path.read_text(encoding="utf-8"))
+    encoded = secret.get("data", {}).get("alertmanager.yaml")
+    if not isinstance(encoded, str):
+        raise ValueError("loaded Alertmanager configuration is missing")
+    raw = base64.b64decode(encoded, validate=True)
+    parsed = subprocess.run(
+        [
+            "ruby",
+            "-ryaml",
+            "-rjson",
+            "-e",
+            "puts JSON.generate(YAML.safe_load(STDIN.read, aliases: false))",
+        ],
+        input=raw,
+        check=True,
+        capture_output=True,
+    )
+    validate_config(json.loads(parsed.stdout))
+
+
+if __name__ == "__main__":
+    try:
+        if len(sys.argv) == 2:
+            validate_render(Path(sys.argv[1]))
+        elif len(sys.argv) == 3 and sys.argv[1] == "--config-secret-json":
+            validate_secret_json(Path(sys.argv[2]))
+        else:
+            raise ValueError(
+                "usage: validate_observability_alertmanager.py [--config-secret-json] FILE"
+            )
+    except (ValueError, OSError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
+        print(f"ERROR: invalid Alertmanager structure: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+    print("Alertmanager PagerDuty structure validated (file reference only).")

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -238,6 +239,7 @@ def run_helper(
     target_response_delay="0",
     retry_attempts="3",
     retry_interval="1",
+    action=None,
 ):
     """Run the lifecycle against deterministic command stubs and return its audit log."""
     bin_dir = tmp_path / "bin"
@@ -253,6 +255,23 @@ case "$*" in
     printf '%s\n' 'apiVersion: v1' 'kind: ConfigMap' 'metadata:' '  name: kube-prometheus-stack-grafana-dashboards-sugarkube' '  labels:' '    dashboard-provider: sugarkube' 'data:' '  sugarkube-staging-observability.json:' '    |-'
     sed 's/^/      /' "$DASHBOARD"
     printf '%s\n' '---' 'kind: ConfigMap' 'data:' '  dashboardproviders.yaml: |' '    providers:' '      - name: sugarkube' '        options:' '          path: /var/lib/grafana/dashboards/sugarkube' '---' 'kind: Deployment' 'spec:' '  template:' '    spec:' '      containers:' '        - volumeMounts:' '            - name: dashboards-sugarkube' '              mountPath: /var/lib/grafana/dashboards/sugarkube/sugarkube-staging-observability.json' '              subPath: sugarkube-staging-observability.json'
+    config='route:
+  receiver: "null"
+  routes:
+  - receiver: pagerduty-synthetic
+    matchers:
+    - alertname="SugarkubePagerDutyTest"
+    - environment="staging"
+    - cluster="sugarkube-int"
+    - severity="critical"
+receivers:
+- name: "null"
+- name: pagerduty-synthetic
+  pagerduty_configs:
+  - routing_key_file: /etc/alertmanager/secrets/alertmanager-pagerduty/routing-key
+    send_resolved: true'
+    encoded=$(printf '%s' "$config" | base64 | tr -d '\n')
+    printf '%s\n' '---' 'kind: Alertmanager' 'spec:' '  secrets:' '  - alertmanager-pagerduty' '---' 'kind: Secret' 'metadata:' '  name: alertmanager-kube-prometheus-stack-alertmanager' 'data:' "  alertmanager.yaml: $encoded"
     exit 0
     ;;
   *list*) [ "$HELM_MODE" != query-fail ] || exit 32; [ "$HELM_MODE" = present ] && echo kube-prometheus-stack; exit 0 ;;
@@ -270,12 +289,35 @@ case "$*" in
   *"get daemonset kube-prometheus-stack-prometheus-node-exporter"*) [ "$KUBECTL_MODE" = two-nodes ] && echo '2 2' || echo '3 3' ;;
   *"get pvc -o json"*) printf '%s\n' '{"items":[{"metadata":{"name":"generated-pvc","labels":{"app.kubernetes.io/name":"prometheus"}},"spec":{"storageClassName":"local-path"},"status":{"phase":"Bound"}}]}' ;;
   *"get prometheus kube-prometheus-stack-prometheus"*) echo 1 ;;
+  *"get alertmanager kube-prometheus-stack-alertmanager"*"spec.secrets[0]"*) echo alertmanager-pagerduty ;;
   *"get alertmanager kube-prometheus-stack-alertmanager"*) echo 1 ;;
   *"get ingress "*) exit 0 ;;
   *"get svc kube-prometheus-stack-grafana"*) echo 30300 ;;
   *"get servicemonitor dspace"*"metadata.labels.release"*) [ "$KUBECTL_MODE" = wrong-release ] && echo wrong || echo kube-prometheus-stack ;;
   *"get servicemonitor dspace"*"bearerTokenSecret.name"*) [ "$KUBECTL_MODE" != missing-secret-ref ] && echo dspace-token ;;
+  *"get secret alertmanager-pagerduty -o json"*)
+    [ "$KUBECTL_MODE" != missing-pagerduty-secret ] || exit 44
+    [ "$KUBECTL_MODE" = empty-pagerduty-key ] && echo '{"data":{"routing-key":""}}' || echo '{"data":{"routing-key":"c3R1Yg=="}}'
+    ;;
+  *"get secret alertmanager-kube-prometheus-stack-alertmanager -o json"*)
+    config='route:
+  receiver: "null"
+  routes:
+  - receiver: pagerduty-synthetic
+    matchers:
+    - alertname="SugarkubePagerDutyTest"
+    - environment="staging"
+    - cluster="sugarkube-int"
+    - severity="critical"
+receivers:
+- name: "null"
+- name: pagerduty-synthetic
+  pagerduty_configs:
+  - routing_key_file: /etc/alertmanager/secrets/alertmanager-pagerduty/routing-key
+    send_resolved: true'
+    encoded=$(printf '%s' "$config" | base64 | tr -d '\n'); printf '{"data":{"alertmanager.yaml":"%s"}}\n' "$encoded" ;;
   *"get secret dspace-token -o name"*) [ "$KUBECTL_MODE" != missing-secret ] || exit 44; echo secret/dspace-token ;;
+  *"create --raw "*"/api/v2/alerts"*) cat > "$PAYLOAD"; exit 0 ;;
   *"get --request-timeout="*" --raw "*)
     [ "$KUBECTL_MODE" != query-fail ] || exit 45
     [ "$TARGET_RESPONSE_DELAY" = 0 ] || /bin/sleep "$TARGET_RESPONSE_DELAY"
@@ -312,6 +354,7 @@ esac
         "TARGET_RESPONSE_DELAY": target_response_delay,
         "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS": retry_attempts,
         "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS": retry_interval,
+        "PAYLOAD": str(tmp_path / "payload"),
         "DASHBOARD": str(
             ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
         ),
@@ -330,7 +373,7 @@ esac
             responses.write_text("\n".join(target_responses) + "\n", encoding="utf-8")
         env["TARGET_RESPONSES"] = str(responses)
     result = subprocess.run(
-        ["bash", str(SCRIPT), command, "env=staging"],
+        ["bash", str(SCRIPT), command, "env=staging"] + ([action] if action is not None else []),
         text=True,
         capture_output=True,
         env=env,
@@ -800,3 +843,105 @@ def test_dashboard_verifier_cleans_up_when_interrupted(tmp_path):
     body = SCRIPT.read_text(encoding="utf-8").split("dashboard_verify()", 1)[1]
     assert "trap 'exit 130' INT" in body and "trap 'exit 143' TERM" in body
     assert not list(tmp_path.glob("sugarkube-grafana-verify.*"))
+
+
+def test_staging_pagerduty_contract_is_exact_and_file_backed():
+    staging = yaml_load(STAGING)["alertmanager"]
+    assert staging["alertmanagerSpec"]["secrets"] == ["alertmanager-pagerduty"]
+    config = staging["config"]
+    assert config["route"]["receiver"] == "null"
+    routes = config["route"]["routes"]
+    assert routes == [
+        {
+            "receiver": "pagerduty-synthetic",
+            "matchers": [
+                'alertname="SugarkubePagerDutyTest"',
+                'environment="staging"',
+                'cluster="sugarkube-int"',
+                'severity="critical"',
+            ],
+        }
+    ]
+    receiver = next(item for item in config["receivers"] if item["name"] == "pagerduty-synthetic")
+    pagerduty = receiver["pagerduty_configs"][0]
+    assert pagerduty == {
+        "routing_key_file": "/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key",
+        "send_resolved": True,
+    }
+    assert "routing_key" not in pagerduty and "service_key" not in pagerduty
+
+
+@pytest.mark.parametrize("mutation", ["root", "matcher", "path", "inline", "broad"])
+def test_alertmanager_validator_rejects_unsafe_routing(mutation):
+    sys.path.insert(0, str(ROOT / "scripts"))
+    try:
+        import validate_observability_alertmanager as validator
+    finally:
+        sys.path.pop(0)
+    config = yaml_load(STAGING)["alertmanager"]["config"]
+    if mutation == "root":
+        config["route"]["receiver"] = "pagerduty-synthetic"
+    elif mutation == "matcher":
+        config["route"]["routes"][0]["matchers"].pop()
+    elif mutation == "path":
+        config["receivers"][1]["pagerduty_configs"][0]["routing_key_file"] = "/wrong"
+    elif mutation == "inline":
+        config["receivers"][1]["pagerduty_configs"][0]["routing_key"] = "forbidden"
+    else:
+        config["route"]["routes"].append({"receiver": "pagerduty-synthetic", "matchers": []})
+    with pytest.raises(ValueError):
+        validator.validate_config(config)
+
+
+def test_pagerduty_secret_preflight_fails_before_helm_state_or_mutation(tmp_path):
+    for mode in ("missing-pagerduty-secret", "empty-pagerduty-key"):
+        result, audit = run_helper(
+            tmp_path / mode, "upgrade", helm_mode="present", kubectl_mode=mode
+        )
+        assert result.returncode != 0
+        assert "nonempty routing-key" in result.stderr
+        assert "helm list" not in audit and "helm upgrade" not in audit
+    result, audit = run_helper(tmp_path / "valid", "upgrade", helm_mode="present")
+    assert result.returncode == 0 and "helm upgrade" in audit
+
+
+def test_pagerduty_test_is_explicit_staging_only_and_fire_resolve_share_labels(tmp_path):
+    absent, audit = run_helper(tmp_path / "absent", "pagerduty-test")
+    assert absent.returncode != 0 and "create --raw" not in audit
+    invalid, audit = run_helper(tmp_path / "invalid", "pagerduty-test", action="oops")
+    assert invalid.returncode != 0 and "create --raw" not in audit
+    prod = subprocess.run(
+        ["bash", str(SCRIPT), "pagerduty-test", "env=prod", "fire"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert prod.returncode != 0
+    documents = {}
+    for action in ("fire", "resolve"):
+        path = tmp_path / action
+        result, audit = run_helper(path, "pagerduty-test", action=action)
+        assert result.returncode == 0 and "create --raw" in audit
+        documents[action] = json.loads((path / "payload").read_text())[0]
+    assert documents["fire"]["labels"] == documents["resolve"]["labels"]
+    assert documents["fire"]["annotations"] == documents["resolve"]["annotations"]
+    from datetime import datetime
+
+    def parse(value):
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+    assert (
+        14 * 60
+        <= (
+            parse(documents["fire"]["endsAt"]) - parse(documents["fire"]["startsAt"])
+        ).total_seconds()
+        <= 15 * 60
+    )
+    assert (
+        abs(
+            (
+                parse(documents["resolve"]["endsAt"]) - parse(documents["resolve"]["startsAt"])
+            ).total_seconds()
+        )
+        < 2
+    )


### PR DESCRIPTION
### Motivation
- Provide a minimal, secret-safe PagerDuty delivery path for staging without routing the chart's bundled alerts to PagerDuty. 
- Require an out-of-band Kubernetes Secret contract and fail-closed preflight so Helm mutations never proceed without an operator-managed routing key. 
- Offer an operator-invoked synthetic fire/resolve workflow and structural validators so delivery can be exercised and audited safely before wider rollout.

### Description
- Add a staging-only Alertmanager values entry that preserves the root receiver named exactly `"null"` and adds a single narrow synthetic route for `alertname="SugarkubePagerDutyTest"`, `environment="staging"`, `cluster="sugarkube-int"`, `severity="critical"` which targets a `pagerduty-synthetic` receiver that uses `routing_key_file: /etc/alertmanager/secrets/alertmanager-pagerduty/routing-key` with `send_resolved: true` (`clusters/staging/observability/kube-prometheus-stack.values.yaml`).
- Implement a fail-closed preflight in `scripts/observability_helm.sh` that verifies `monitoring/alertmanager-pagerduty` exists and contains a nonempty `routing-key` before doing `helm install`/`helm upgrade`, and extend `verify` to validate the loaded Alertmanager Secret reference and structure without exposing secret material.
- Add `scripts/validate_observability_alertmanager.py` to offline-validate rendered manifests and to validate the decoded `alertmanager.yaml` from the chart-rendered Secret, asserting the root `null` receiver, the exact synthetic matchers, the expected file path, `send_resolved: true`, and absence of inline keys.
- Add a guarded manual test flow: `just observability-pagerduty-test env=staging action=fire` and `just observability-pagerduty-test env=staging action=resolve`, which require explicit `fire|resolve`, the staging kubeconfig context, and submit identical-label alerts to Alertmanager via the service proxy (bounded `endsAt` for `fire`, immediate end for `resolve`).
- Update docs: `docs/observability-operations.md` with a staging runbook for hidden-read Secret creation, render/inspect/upgrade/verify steps, and the manual drill; `docs/observability-alerting.md` clarified the implemented Secret-backed file path. 
- Add focused tests and test harness changes in `tests/test_observability_helm.py` to cover render contract, secret preflight, pagerduty-test recipe behavior, validator rejections for unsafe mutations, and payload semantics; adjust test stubs to simulate clustered Secret responses and Alertmanager config secrets.

### Testing
- Ran the focused observability tests and helpers: `pytest -q tests/test_observability_helm.py -k 'pagerduty or install_and_upgrade or pre_mutation'` — passed (focused PagerDuty/install preflight tests succeeded).
- Ran the Alertmanager validator tests: `pytest -q tests/test_observability_helm.py -k alertmanager_validator` — passed.
- Ran the staging dashboard suite: `pytest -q tests/test_observability_dashboard.py` — passed (54 tests).
- Ran helper/recipe tests: `pytest -q tests/test_helper_recipes.py` — passed (10 tests); a formatting fixture attempted to install `just` but the upstream download returned 404 in this environment (not a repository failure).
- Performed offline Helm rendering and structural validation with `helm template ... -f <common> -f <staging> --set-file ...` and `python scripts/validate_observability_alertmanager.py /tmp/pure-render.yaml` — validator returned success and confirmed the Alertmanager secret reference and file-backed PagerDuty receiver.
- Documentation and link checks: `bash scripts/checks.sh --docs-only` and `linkchecker --no-warnings README.md docs/` — completed (link checks passed); `pyspelling` and `pre-commit` were not run due to missing local executables in this environment.
- Secret scan and diff checks: `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` — no accidental credentials or inline routing keys added.

No live PagerDuty requests, no credential material was printed, decoded, logged, hashed, or committed, and no cluster mutation or Helm install/upgrade was performed during testing; all cluster interactions in tests are stubbed or run offline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a682f218b14832fbbea977c84caf1eb)