### PR TITLE
feat: add staging PagerDuty synthetic alert foundation

### DIFF
--- a/clusters/staging/observability/kube-prometheus-stack.values.yaml
+++ b/clusters/staging/observability/kube-prometheus-stack.values.yaml
@@ -4,3 +4,23 @@ prometheus:
   prometheusSpec:
     externalLabels:
       cluster: sugarkube-int
+alertmanager:
+  alertmanagerSpec:
+    secrets:
+      - alertmanager-pagerduty
+  config:
+    route:
+      receiver: "null"
+      routes:
+        - receiver: pagerduty-synthetic
+          matchers:
+            - alertname="SugarkubePagerDutyTest"
+            - environment="staging"
+            - cluster="sugarkube-int"
+            - severity="critical"
+    receivers:
+      - name: "null"
+      - name: pagerduty-synthetic
+        pagerduty_configs:
+          - routing_key_file: /etc/alertmanager/secrets/alertmanager-pagerduty/routing-key
+            send_resolved: true

--- a/docs/observability-alerting.md
+++ b/docs/observability-alerting.md
@@ -4,9 +4,10 @@ This is the canonical alerting strategy for Sugarkube. It defines the agreed tar
 routing policy, alert inventory, and rollout/drill plan for turning the staging observability stack
 described in [`docs/observability-design.md`](./observability-design.md) and
 [`docs/observability-operations.md`](./observability-operations.md) into something that actually pages
-a human. **Nothing in this document is deployed yet.** Alertmanager currently ships a no-op `"null"`
-receiver in staging (see [`docs/observability-operations.md`](./observability-operations.md)); this
-document records the plan for closing that gap, not evidence that it is closed.
+a human. Repository support now preserves the no-op `"null"` default while adding a staging-only,
+secret-file-backed PagerDuty receiver for one exact operator-triggered synthetic alert. That support
+is not evidence that it has been deployed or that PagerDuty phone delivery and resolution have been
+manually proven; see [`docs/observability-operations.md`](./observability-operations.md) for the drill.
 
 ## 1. Goals and non-goals
 
@@ -117,9 +118,8 @@ What each check detects, and does not:
 - Route only explicitly named, reviewed, and tested Sugarkube alerts to PagerDuty — an allowlist, not
   the chart's entire default rule set. Do not forward `kube-prometheus-stack`'s bundled rules
   wholesale before auditing each one individually.
-- Use Alertmanager's PagerDuty integration with a secret file reference, for example
-  `routing_key_file: /etc/alertmanager/secrets/pagerduty-routing-key`, never an inline key committed to
-  Git.
+- Use Alertmanager's PagerDuty integration with the staging Secret file reference
+  `/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key`, never an inline key committed to Git.
 - Set `send_resolved: true` on the PagerDuty receiver so incidents auto-resolve when the underlying
   alert clears.
 - Define sensible `group_by`, `group_wait`, `group_interval`, and `repeat_interval` values so a single
@@ -202,8 +202,8 @@ Rollback and noise control:
 
 PagerDuty plus an externally hosted Healthchecks.io is the preferred initial direction because it is
 the only combination here that gives both an acknowledgeable phone workflow *and* a dead-man path that
-survives the monitoring stack's own node going down. Nothing about this preference implies any part of
-it is deployed yet — see the rollout plan above for the actual sequencing.
+survives the monitoring stack's own node going down. Repository configuration alone does not imply
+deployment or delivery — see the rollout plan above for the actual sequencing.
 
 ## 8. Status and dependencies
 
@@ -213,5 +213,9 @@ it is deployed yet — see the rollout plan above for the actual sequencing.
 - Shallow public-endpoint blackbox monitoring (`PublicEndpointDown`, `PublicProbeMissing`,
   `TLSExpiringSoon`) is already live in staging today, independently of that dependency — see
   [`docs/observability-blackbox.md`](./observability-blackbox.md).
-- Alert delivery to a phone and node-power-off drills have not yet been performed. Everything in
-  [§6](#6-rollout-and-drill-plan) above is planned, not completed.
+- The repository implements rollout phases 2 and 3 as a secret-safe staging receiver foundation and
+  an explicitly invoked synthetic fire/resolve workflow. Actual staging deployment, PagerDuty phone
+  receipt, acknowledgement, and resolution are still manual post-merge evidence and are not claimed
+  here.
+- Node-power-off drills and all Healthchecks.io work have not been performed. The later phases in
+  [§6](#6-rollout-and-drill-plan) remain planned, not completed.

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -11,7 +11,7 @@ Production observability is intentionally unsupported in this slice because no p
 - Staging overrides: `clusters/staging/observability/kube-prometheus-stack.values.yaml`.
 - Staging dashboard: `clusters/staging/observability/dashboards/sugarkube-staging-observability.json`.
 - Helper: `scripts/observability_helm.sh` through `just observability-*` recipes.
-- Alert delivery, routing, and drill strategy: [`docs/observability-alerting.md`](observability-alerting.md) — this runbook covers deploying and verifying the stack, not how (or whether) it pages anyone yet.
+- Alert delivery, routing, and drill strategy: [`docs/observability-alerting.md`](observability-alerting.md). Repository support now includes the staging-only PagerDuty synthetic route and manual drill; deployment and phone delivery remain operator-proven steps.
 
 The dashboard is owned by Sugarkube and provisioned by the pinned Grafana
 subchart. Every render, install, and upgrade passes the same standalone JSON
@@ -46,6 +46,10 @@ The old Flux/Longhorn files under `platform/observability/*.yaml` and `clusters/
   - Secret name: `grafana-admin-credentials`.
   - Username key: `admin-user`.
   - Password key: `admin-password`.
+- Operator-managed PagerDuty Secret exists before an observability install or upgrade:
+  - Namespace: `monitoring`.
+  - Secret name: `alertmanager-pagerduty`.
+  - Key: `routing-key`.
 
 Never put example credentials or plaintext Secret data in commands, logs, docs, commits, or PRs.
 
@@ -120,11 +124,94 @@ is not rollout evidence.
    just observability-dashboard-verify env=staging
    ```
 
+## Staging PagerDuty synthetic drill
+
+Repository support is not evidence that this configuration has been deployed or that a phone has
+received anything. An operator performs this runbook after merge, with the PagerDuty Events API v2
+routing key supplied out of band. No command below displays the key, places it in an argument, or
+writes it to a persistent file.
+
+1. Select the `sugar-staging` context. Create the Secret for the first time with a hidden read and
+   stdin. The pipeline's manifest travels only between the two processes; do not add `tee`, shell
+   tracing, or a command that prints it:
+
+   ```bash
+   just kubeconfig-env env=staging
+   read -rsp 'PagerDuty routing key: ' PD_ROUTING_KEY; printf '\n'
+   printf '%s' "$PD_ROUTING_KEY" |
+     kubectl -n monitoring create secret generic alertmanager-pagerduty \
+       --from-file=routing-key=/dev/stdin --dry-run=client -o yaml |
+     kubectl apply -f - >/dev/null
+   unset PD_ROUTING_KEY
+   kubectl -n monitoring get secret alertmanager-pagerduty -o name
+   ```
+
+   Keep shell history expansion and command tracing disabled. The key is never committed. To rotate
+   it, repeat the same hidden-read pipeline with the replacement value; do not delete the existing
+   Secret first.
+
+2. Render and inspect the proposed resources offline. Confirm the Alertmanager custom resource lists
+   `alertmanager-pagerduty`, the root receiver is `"null"`, the only PagerDuty route has all four
+   synthetic matchers, and the receiver contains only the file path
+   `/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key` with resolved notifications enabled:
+
+   ```bash
+   just observability-render env=staging > /tmp/kube-prometheus-stack.rendered.yaml
+   less /tmp/kube-prometheus-stack.rendered.yaml
+   rm -f /tmp/kube-prometheus-stack.rendered.yaml
+   ```
+
+3. Upgrade and run both standard verifiers. The upgrade fails closed before any Helm command if the
+   Secret or its nonempty key is absent. Verification checks the live custom-resource Secret
+   reference and generated Alertmanager configuration without displaying it:
+
+   ```bash
+   just observability-upgrade env=staging
+   just observability-verify env=staging
+   just observability-dashboard-verify env=staging
+   ```
+
+4. Explicitly fire the synthetic alert. It expires after 30 minutes even if the drill is abandoned:
+
+   ```bash
+   just observability-pagerduty-test env=staging action=fire
+   ```
+
+5. In PagerDuty, manually confirm incident receipt on the expected service and phone, then acknowledge
+   it. The repository deliberately cannot automate or claim this observation.
+
+6. Resolve the same alert and manually confirm that PagerDuty resolves the same incident:
+
+   ```bash
+   just observability-pagerduty-test env=staging action=resolve
+   ```
+
+7. If necessary, roll back to the prior known-good Helm revision, then run the verifier appropriate
+   for that revision:
+
+   ```bash
+   helm -n monitoring history kube-prometheus-stack
+   helm -n monitoring rollback kube-prometheus-stack <prior-revision> --wait --timeout 20m
+   just observability-verify env=staging
+   ```
+
+   Keep `monitoring/alertmanager-pagerduty` until the rollback has completed. Deleting the credential
+   Secret while the current Alertmanager custom resource still mounts it can prevent Alertmanager
+   from starting, which can also make a rollback harder to diagnose.
+
+8. After credential rotation, run `just observability-upgrade env=staging` so the Alertmanager pods
+   reliably consume the replacement, then repeat verification and the explicit fire, manual receipt,
+   resolve, and manual resolution sequence. Retain the old integration until that post-rotation drill
+   succeeds; then revoke it in PagerDuty.
+
 ## Runtime expectations
 
 - Helm release: `kube-prometheus-stack` in namespace `monitoring`.
 - Prometheus: one replica, `7d` retention, `15GB` retention size, `local-path` `ReadWriteOnce` PVC requesting `20Gi`, CPU request `200m`, memory request `512Mi`, memory limit `2Gi`, admin API disabled, and external label `cluster=sugarkube-int`.
-- Alertmanager: one replica and no-op receiver named exactly `"null"`. No real notification receiver (PagerDuty, Healthchecks.io, or otherwise) is configured yet; see [`docs/observability-alerting.md`](observability-alerting.md) for the planned rollout.
+- Alertmanager: one replica with root no-op receiver named exactly `"null"`. Staging adds one
+  file-backed PagerDuty receiver, but only the exact `SugarkubePagerDutyTest` synthetic label set is
+  allowlisted. Bundled chart alerts and all real application, node, and blackbox alerts still fall
+  through to `"null"`.
 - Grafana: persistence disabled, no Ingress, LAN-only NodePort `30300`.
 - The provisioned dashboard defaults to six hours and a 30-second refresh. Its
   top-level public availability summary reports **Healthy endpoints**, **Failed

--- a/justfile
+++ b/justfile
@@ -3194,6 +3194,10 @@ observability-verify env='':
 observability-dashboard-verify env='':
     @scripts/observability_helm.sh dashboard-verify '{{ env }}'
 
+# Explicitly fire or resolve the staging PagerDuty synthetic alert (manual only).
+observability-pagerduty-test env action:
+    @scripts/observability_helm.sh pagerduty-test '{{ env }}' '{{ action }}'
+
 # Render the pinned staging blackbox exporter and Probe manifests (read-only).
 observability-blackbox-render env='':
     @scripts/observability_blackbox.sh render '{{ env }}'

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -11,10 +11,12 @@ STAGING_VALUES="${ROOT}/clusters/staging/observability/kube-prometheus-stack.val
 DASHBOARD="${ROOT}/clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
 DASHBOARD_VALUE="grafana.dashboards.sugarkube.sugarkube-staging-observability.json"
 DASHBOARD_VALIDATOR="${ROOT}/scripts/validate_observability_dashboard.py"
+ALERTMANAGER_VALIDATOR="${ROOT}/scripts/validate_observability_alertmanager.rb"
+PAGERDUTY_SECRET="alertmanager-pagerduty"
 TIMEOUT="${SUGARKUBE_OBSERVABILITY_HELM_TIMEOUT:-20m}"
 GRAFANA_URL="http://sugarkube3.local:30300"
 
-usage() { echo "Usage: $0 <render|install|upgrade|status|verify|dashboard-verify> env=staging" >&2; }
+usage() { echo "Usage: $0 <render|install|upgrade|status|verify|dashboard-verify|pagerduty-test> env=staging [fire|resolve]" >&2; }
 normalize_env() {
   local raw="${1:-}"
   while [[ "${raw}" == env=* ]]; do raw="${raw#env=}"; done
@@ -55,12 +57,26 @@ assert_context() {
 version() { tr -d '[:space:]' < "${VERSION_FILE}"; }
 validate_dashboard() { python3 "${DASHBOARD_VALIDATOR}" "${DASHBOARD}"; }
 validate_rendered_dashboard() { python3 "${DASHBOARD_VALIDATOR}" "${DASHBOARD}" --rendered "$1"; }
+validate_rendered_alertmanager() { ruby "${ALERTMANAGER_VALIDATOR}" "$1"; }
+require_pagerduty_secret() {
+  local present
+  if ! present="$(kubectl -n "${NAMESPACE}" get secret "${PAGERDUTY_SECRET}" -o go-template='{{if index .data "routing-key"}}present{{end}}' 2>/dev/null)"; then
+    echo "ERROR: required Secret ${NAMESPACE}/${PAGERDUTY_SECRET} is absent; create it with a nonempty routing-key before install or upgrade." >&2
+    return 15
+  fi
+  if [[ "${present}" != present ]]; then
+    echo "ERROR: required Secret ${NAMESPACE}/${PAGERDUTY_SECRET} has no nonempty routing-key; repair it before install or upgrade (value not read or printed)." >&2
+    return 15
+  fi
+  echo "PagerDuty Secret contract is present (value not read or printed)."
+}
 render_to() {
   local out="$1"
   helm repo add prometheus-community https://prometheus-community.github.io/helm-charts --force-update >/dev/null
   helm repo update prometheus-community >/dev/null
   helm template "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" >"${out}"
   validate_rendered_dashboard "${out}"
+  validate_rendered_alertmanager "${out}"
 }
 release_state() {
   local matches
@@ -79,9 +95,9 @@ release_state() {
     return 1
   fi
 }
-render() { validate_dashboard; require_tools helm kubectl python3; print_resolved staging; tmp="$(mktemp -t sugarkube-observability-render.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; cat "${tmp}"; }
-install_release() { validate_dashboard; require_tools helm kubectl python3; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
-upgrade_release() { validate_dashboard; require_tools helm kubectl python3; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
+render() { validate_dashboard; require_tools helm python3 ruby; print_resolved staging; tmp="$(mktemp -t sugarkube-observability-render.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; cat "${tmp}"; }
+install_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; require_pagerduty_secret; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
+upgrade_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; require_pagerduty_secret; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
 status() { require_tools helm kubectl python3; print_resolved staging; assert_context; helm -n "${NAMESPACE}" status "${RELEASE}"; kubectl -n "${NAMESPACE}" get deploy,statefulset,daemonset -l "app.kubernetes.io/instance=${RELEASE}"; kubectl -n "${NAMESPACE}" get prometheus,alertmanager; kubectl -n "${NAMESPACE}" get svc,pvc; kubectl get crd prometheuses.monitoring.coreos.com alertmanagers.monitoring.coreos.com servicemonitors.monitoring.coreos.com probes.monitoring.coreos.com; }
 verify_dspace_targets() {
   require_tools kubectl python3 sleep
@@ -205,8 +221,20 @@ raise SystemExit(10)' <<<"${targets_json}" || parser_status=$?
   done
   return 10
 }
+verify_alertmanager() {
+  local referenced
+  referenced="$(kubectl -n "${NAMESPACE}" get alertmanager "${RELEASE}-alertmanager" -o go-template='{{range .spec.secrets}}{{printf "%s\n" .}}{{end}}')"
+  [[ "${referenced}" == "${PAGERDUTY_SECRET}" ]] || {
+    echo "ERROR: Alertmanager does not reference exactly ${NAMESPACE}/${PAGERDUTY_SECRET}." >&2
+    return 16
+  }
+  kubectl -n "${NAMESPACE}" get secret "alertmanager-${RELEASE}-alertmanager" \
+    -o go-template='{{index .data "alertmanager.yaml"}}' |
+    ruby "${ALERTMANAGER_VALIDATOR}" --base64-config - >/dev/null
+  echo "Loaded Alertmanager configuration retains only the null default and narrow file-backed PagerDuty synthetic route."
+}
 verify() {
-  require_tools kubectl python3
+  require_tools kubectl python3 ruby
   print_resolved staging
   assert_context
   kubectl get crd prometheuses.monitoring.coreos.com alertmanagers.monitoring.coreos.com servicemonitors.monitoring.coreos.com probes.monitoring.coreos.com >/dev/null
@@ -240,6 +268,7 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
   kubectl -n dspace get secret "${secret_name}" -o name >/dev/null
   echo "DSPACE ServiceMonitor secret reference exists (value intentionally not printed)."
 
+  verify_alertmanager
   verify_dspace_targets
   echo "Grafana LAN URL: ${GRAFANA_URL} (same NodePort is available through the other staging nodes)"
 }
@@ -339,7 +368,43 @@ if not isinstance(dashboard, dict) or dashboard.get("uid") != "sugarkube-staging
   return 13
 )
 
+pagerduty_test() {
+  require_tools kubectl python3
+  print_resolved staging
+  assert_context
+  local action="${1:-}" ends_at payload endpoint
+  case "${action}" in
+    fire) ends_at="$(date -u -d '+30 minutes' '+%Y-%m-%dT%H:%M:%SZ')" ;;
+    resolve) ends_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" ;;
+    "") echo "ERROR: PagerDuty test action is required; pass action=fire or action=resolve explicitly." >&2; return 2 ;;
+    *) echo "ERROR: unsupported PagerDuty test action '${action}'; supported actions: fire, resolve." >&2; return 2 ;;
+  esac
+  payload="$(ENDS_AT="${ends_at}" python3 -c 'import json, os
+print(json.dumps([{
+    "labels": {
+        "alertname": "SugarkubePagerDutyTest",
+        "environment": "staging",
+        "cluster": "sugarkube-int",
+        "severity": "critical"
+    },
+    "annotations": {
+        "summary": "Sugarkube staging PagerDuty delivery test",
+        "description": "Operator-triggered synthetic alert for the staging PagerDuty fire/resolve drill.",
+        "runbook_url": "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-operations.md#staging-pagerduty-synthetic-drill"
+    },
+    "startsAt": "2026-01-01T00:00:00Z",
+    "endsAt": os.environ["ENDS_AT"]
+}]))')"
+  endpoint="/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-alertmanager:9093/proxy/api/v2/alerts"
+  if printf '%s' "${payload}" | kubectl create --raw "${endpoint}" -f - >/dev/null; then
+    echo "PagerDuty synthetic ${action} accepted by Alertmanager (HTTP 200)."
+  else
+    echo "ERROR: Alertmanager rejected PagerDuty synthetic ${action} (HTTP/API request failed; response redacted)." >&2
+    return 17
+  fi
+}
+
 cmd="${1:-}"; shift || true; [[ -n "${cmd}" ]] || { usage; exit 2; }
 env_arg="${1:-}"; normalize_env "${env_arg}" >/dev/null
 validate_dashboard
-case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) dashboard_verify ;; *) usage; exit 2 ;; esac
+case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) dashboard_verify ;; pagerduty-test) pagerduty_test "${2:-}" ;; *) usage; exit 2 ;; esac

--- a/scripts/validate_observability_alertmanager.rb
+++ b/scripts/validate_observability_alertmanager.rb
@@ -1,0 +1,85 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "yaml"
+require "base64"
+
+EXPECTED_SECRET = "alertmanager-pagerduty"
+EXPECTED_FILE = "/etc/alertmanager/secrets/#{EXPECTED_SECRET}/routing-key"
+EXPECTED_MATCHERS = [
+  'alertname="SugarkubePagerDutyTest"',
+  'environment="staging"',
+  'cluster="sugarkube-int"',
+  'severity="critical"'
+].freeze
+
+def fail_validation(message)
+  warn "ERROR: invalid staging Alertmanager configuration: #{message}"
+  exit 1
+end
+
+config_only = %w[--config --base64-config].include?(ARGV.first)
+base64_config = ARGV.first == "--base64-config"
+ARGV.shift if config_only
+path = ARGV.fetch(0) { fail_validation("manifest or configuration path is required") }
+input = path == "-" ? $stdin.read : File.read(path)
+if config_only
+  input = Base64.strict_decode64(input) if base64_config
+  config = YAML.safe_load(input, permitted_classes: [], aliases: false)
+else
+  documents = YAML.load_stream(input).compact
+  alertmanager = documents.find do |document|
+    document.is_a?(Hash) && document["kind"] == "Alertmanager" &&
+      document.dig("metadata", "name") == "kube-prometheus-stack-alertmanager"
+  end
+  fail_validation("expected Alertmanager custom resource is missing") unless alertmanager
+
+  secrets = alertmanager.dig("spec", "secrets")
+  fail_validation("Alertmanager must reference only #{EXPECTED_SECRET}") unless secrets == [EXPECTED_SECRET]
+
+  config_secret = documents.find do |document|
+    document.is_a?(Hash) && document["kind"] == "Secret" &&
+      document.dig("metadata", "name") == "alertmanager-kube-prometheus-stack-alertmanager"
+  end
+  fail_validation("chart-rendered Alertmanager configuration Secret is missing") unless config_secret
+
+  raw_config = config_secret.dig("stringData", "alertmanager.yaml")
+  raw_config ||= Base64.strict_decode64(config_secret.dig("data", "alertmanager.yaml").to_s)
+  fail_validation("Alertmanager configuration is missing") if raw_config.empty?
+  config = YAML.safe_load(raw_config, permitted_classes: [], aliases: false)
+end
+fail_validation('root receiver must remain "null"') unless config.dig("route", "receiver") == "null"
+
+routes = config.dig("route", "routes")
+pagerduty_routes = Array(routes).select { |route| route.is_a?(Hash) && route["receiver"] == "pagerduty-synthetic" }
+unless pagerduty_routes.length == 1 && pagerduty_routes.first["matchers"] == EXPECTED_MATCHERS
+  fail_validation("PagerDuty must have exactly the narrow synthetic route")
+end
+
+receivers = config["receivers"]
+null_receivers = Array(receivers).select { |receiver| receiver == {"name" => "null"} }
+pagerduty_receivers = Array(receivers).select do |receiver|
+  receiver.is_a?(Hash) && receiver["name"] == "pagerduty-synthetic"
+end
+unless null_receivers.length == 1 && pagerduty_receivers.length == 1 && receivers.length == 2
+  fail_validation("only the null and synthetic PagerDuty receivers are allowed")
+end
+
+pagerduty_configs = pagerduty_receivers.first["pagerduty_configs"]
+unless pagerduty_configs == [{"routing_key_file" => EXPECTED_FILE, "send_resolved" => true}]
+  fail_validation("PagerDuty must use the expected routing-key file with send_resolved enabled")
+end
+
+forbidden = %w[routing_key service_key]
+walk = lambda do |value|
+  case value
+  when Hash
+    fail_validation("inline PagerDuty credential fields are forbidden") unless (value.keys & forbidden).empty?
+    value.each_value { |child| walk.call(child) }
+  when Array
+    value.each { |child| walk.call(child) }
+  end
+end
+walk.call(config)
+
+puts "Rendered Alertmanager route, receiver, Secret mount contract, and file reference are valid."

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -11,6 +11,7 @@ VERSION = ROOT / "platform" / "observability" / "helm" / "kube-prometheus-stack.
 COMMON = ROOT / "platform" / "observability" / "helm" / "kube-prometheus-stack.values.common.yaml"
 STAGING = ROOT / "clusters" / "staging" / "observability" / "kube-prometheus-stack.values.yaml"
 SCRIPT = ROOT / "scripts" / "observability_helm.sh"
+ALERTMANAGER_VALIDATOR = ROOT / "scripts" / "validate_observability_alertmanager.rb"
 DASHBOARD = ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
 JUSTFILE = ROOT / "justfile"
 FLUX_SYNC = ROOT / "flux" / "gotk-sync.yaml"
@@ -59,6 +60,36 @@ def test_chart_version_and_values_match_live_staging_baseline():
     assert pvc["accessModes"] == ["ReadWriteOnce"]
     assert pvc["resources"]["requests"]["storage"] == "20Gi"
     assert staging["prometheus"]["prometheusSpec"]["externalLabels"] == {"cluster": "sugarkube-int"}
+    alertmanager = staging["alertmanager"]
+    assert alertmanager["alertmanagerSpec"]["secrets"] == ["alertmanager-pagerduty"]
+    assert alertmanager["config"]["route"] == {
+        "receiver": "null",
+        "routes": [
+            {
+                "receiver": "pagerduty-synthetic",
+                "matchers": [
+                    'alertname="SugarkubePagerDutyTest"',
+                    'environment="staging"',
+                    'cluster="sugarkube-int"',
+                    'severity="critical"',
+                ],
+            }
+        ],
+    }
+    assert alertmanager["config"]["receivers"] == [
+        {"name": "null"},
+        {
+            "name": "pagerduty-synthetic",
+            "pagerduty_configs": [
+                {
+                    "routing_key_file": (
+                        "/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key"
+                    ),
+                    "send_resolved": True,
+                }
+            ],
+        },
+    ]
 
 
 def test_grafana_alertmanager_k3s_monitor_values_are_guarded():
@@ -190,6 +221,8 @@ def test_justfile_exposes_observability_recipes():
     ):
         assert f"{recipe} env=''" in text
         assert f"scripts/observability_helm.sh {recipe.removeprefix('observability-')}" in text
+    assert "observability-pagerduty-test env action:" in text
+    assert "scripts/observability_helm.sh pagerduty-test" in text
 
 
 def test_legacy_flux_longhorn_files_are_clearly_marked_inactive():
@@ -238,6 +271,7 @@ def run_helper(
     target_response_delay="0",
     retry_attempts="3",
     retry_interval="1",
+    action=None,
 ):
     """Run the lifecycle against deterministic command stubs and return its audit log."""
     bin_dir = tmp_path / "bin"
@@ -253,6 +287,38 @@ case "$*" in
     printf '%s\n' 'apiVersion: v1' 'kind: ConfigMap' 'metadata:' '  name: kube-prometheus-stack-grafana-dashboards-sugarkube' '  labels:' '    dashboard-provider: sugarkube' 'data:' '  sugarkube-staging-observability.json:' '    |-'
     sed 's/^/      /' "$DASHBOARD"
     printf '%s\n' '---' 'kind: ConfigMap' 'data:' '  dashboardproviders.yaml: |' '    providers:' '      - name: sugarkube' '        options:' '          path: /var/lib/grafana/dashboards/sugarkube' '---' 'kind: Deployment' 'spec:' '  template:' '    spec:' '      containers:' '        - volumeMounts:' '            - name: dashboards-sugarkube' '              mountPath: /var/lib/grafana/dashboards/sugarkube/sugarkube-staging-observability.json' '              subPath: sugarkube-staging-observability.json'
+    cat <<'EOF'
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Alertmanager
+metadata:
+  name: kube-prometheus-stack-alertmanager
+spec:
+  secrets:
+    - alertmanager-pagerduty
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-kube-prometheus-stack-alertmanager
+stringData:
+  alertmanager.yaml: |
+    route:
+      receiver: "null"
+      routes:
+        - receiver: pagerduty-synthetic
+          matchers:
+            - alertname="SugarkubePagerDutyTest"
+            - environment="staging"
+            - cluster="sugarkube-int"
+            - severity="critical"
+    receivers:
+      - name: "null"
+      - name: pagerduty-synthetic
+        pagerduty_configs:
+          - routing_key_file: /etc/alertmanager/secrets/alertmanager-pagerduty/routing-key
+            send_resolved: true
+EOF
     exit 0
     ;;
   *list*) [ "$HELM_MODE" != query-fail ] || exit 32; [ "$HELM_MODE" = present ] && echo kube-prometheus-stack; exit 0 ;;
@@ -270,7 +336,32 @@ case "$*" in
   *"get daemonset kube-prometheus-stack-prometheus-node-exporter"*) [ "$KUBECTL_MODE" = two-nodes ] && echo '2 2' || echo '3 3' ;;
   *"get pvc -o json"*) printf '%s\n' '{"items":[{"metadata":{"name":"generated-pvc","labels":{"app.kubernetes.io/name":"prometheus"}},"spec":{"storageClassName":"local-path"},"status":{"phase":"Bound"}}]}' ;;
   *"get prometheus kube-prometheus-stack-prometheus"*) echo 1 ;;
+  *"get secret alertmanager-pagerduty -o go-template="*)
+    [ "$KUBECTL_MODE" != missing-pagerduty-secret ] || exit 46
+    [ "$KUBECTL_MODE" != empty-pagerduty-key ] && echo present
+    ;;
+  *"get alertmanager kube-prometheus-stack-alertmanager -o go-template="*) echo alertmanager-pagerduty ;;
+  *"get secret alertmanager-kube-prometheus-stack-alertmanager -o go-template="*)
+    base64 -w0 <<'EOF'
+route:
+  receiver: "null"
+  routes:
+    - receiver: pagerduty-synthetic
+      matchers:
+        - alertname="SugarkubePagerDutyTest"
+        - environment="staging"
+        - cluster="sugarkube-int"
+        - severity="critical"
+receivers:
+  - name: "null"
+  - name: pagerduty-synthetic
+    pagerduty_configs:
+      - routing_key_file: /etc/alertmanager/secrets/alertmanager-pagerduty/routing-key
+        send_resolved: true
+EOF
+    ;;
   *"get alertmanager kube-prometheus-stack-alertmanager"*) echo 1 ;;
+  *"create --raw "*) cat >/dev/null; [ "$KUBECTL_MODE" != alert-post-fail ] ;;
   *"get ingress "*) exit 0 ;;
   *"get svc kube-prometheus-stack-grafana"*) echo 30300 ;;
   *"get servicemonitor dspace"*"metadata.labels.release"*) [ "$KUBECTL_MODE" = wrong-release ] && echo wrong || echo kube-prometheus-stack ;;
@@ -329,8 +420,11 @@ esac
         else:
             responses.write_text("\n".join(target_responses) + "\n", encoding="utf-8")
         env["TARGET_RESPONSES"] = str(responses)
+    args = ["bash", str(SCRIPT), command, "env=staging"]
+    if action is not None:
+        args.append(action)
     result = subprocess.run(
-        ["bash", str(SCRIPT), command, "env=staging"],
+        args,
         text=True,
         capture_output=True,
         env=env,
@@ -370,6 +464,119 @@ def test_pre_mutation_guards_are_fail_closed(tmp_path):
     assert render_fail.returncode != 0 and "helm list" not in audit and "helm install" not in audit
     query_fail, audit = run_helper(tmp_path / "query", "install", helm_mode="query-fail")
     assert query_fail.returncode != 0 and " template " in audit and "helm install" not in audit
+
+
+@pytest.mark.parametrize("mode", ["missing-pagerduty-secret", "empty-pagerduty-key"])
+def test_pagerduty_secret_preflight_fails_before_helm_commands_without_value(tmp_path, mode):
+    marker = "PAGERDUTY_VALUE_MUST_NOT_APPEAR"
+    result, audit = run_helper(tmp_path, "upgrade", helm_mode="present", kubectl_mode=mode)
+    assert result.returncode != 0
+    assert "helm repo" not in audit and "helm template" not in audit and "helm upgrade" not in audit
+    assert "routing-key" in result.stderr and marker not in result.stdout + result.stderr + audit
+
+
+def test_valid_pagerduty_secret_permits_install_and_upgrade(tmp_path):
+    install, install_audit = run_helper(tmp_path / "install", "install", helm_mode="absent")
+    upgrade, upgrade_audit = run_helper(tmp_path / "upgrade", "upgrade", helm_mode="present")
+    assert install.returncode == 0 and "helm install" in install_audit
+    assert upgrade.returncode == 0 and "helm upgrade" in upgrade_audit
+
+
+def test_alertmanager_validator_rejects_mount_path_matcher_inline_and_broad_route_changes(tmp_path):
+    staging = yaml_load(STAGING)["alertmanager"]
+    config = staging["config"]
+    manifest = {
+        "apiVersion": "monitoring.coreos.com/v1",
+        "kind": "Alertmanager",
+        "metadata": {"name": "kube-prometheus-stack-alertmanager"},
+        "spec": {"secrets": staging["alertmanagerSpec"]["secrets"]},
+    }
+
+    def rendered(candidate_config, *, secrets=None):
+        config_yaml = subprocess.run(
+            ["ruby", "-ryaml", "-rjson", "-e", "print YAML.dump(JSON.parse(ARGF.read))"],
+            input=json.dumps(candidate_config),
+            text=True,
+            capture_output=True,
+            check=True,
+        ).stdout
+        first = manifest | {"spec": {"secrets": secrets or ["alertmanager-pagerduty"]}}
+        return (
+            "---\n"
+            + subprocess.run(
+                ["ruby", "-ryaml", "-rjson", "-e", "print YAML.dump(JSON.parse(ARGF.read))"],
+                input=json.dumps(first),
+                text=True,
+                capture_output=True,
+                check=True,
+            ).stdout
+            + "---\napiVersion: v1\nkind: Secret\nmetadata:\n"
+            "  name: alertmanager-kube-prometheus-stack-alertmanager\nstringData:\n"
+            "  alertmanager.yaml: |\n"
+            + "".join(f"    {line}\n" for line in config_yaml.splitlines())
+        )
+
+    valid = tmp_path / "valid.yaml"
+    valid.write_text(rendered(config), encoding="utf-8")
+    valid_result = subprocess.run(
+        ["ruby", str(ALERTMANAGER_VALIDATOR), str(valid)], check=False
+    )
+    assert valid_result.returncode == 0
+
+    variants = []
+    for old, new in (
+        ("/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key", "/wrong/path"),
+        ('environment="staging"', 'environment=~".*"'),
+        ("routing_key_file", "routing_key"),
+        ('alertname="SugarkubePagerDutyTest"', 'alertname=~".*"'),
+    ):
+        variants.append(rendered(config).replace(old, new))
+    variants.append(rendered(config, secrets=["wrong-secret"]))
+    for index, text in enumerate(variants):
+        path = tmp_path / f"invalid-{index}.yaml"
+        path.write_text(text, encoding="utf-8")
+        result = subprocess.run(
+            ["ruby", str(ALERTMANAGER_VALIDATOR), str(path)],
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=2,
+        )
+        assert result.returncode != 0, index
+
+
+def test_pagerduty_test_requires_action_and_staging_context(tmp_path):
+    missing, audit = run_helper(tmp_path / "missing", "pagerduty-test")
+    assert missing.returncode != 0 and "create --raw" not in audit
+    invalid, audit = run_helper(tmp_path / "invalid", "pagerduty-test", action="page")
+    assert invalid.returncode != 0 and "create --raw" not in audit
+    mismatch, audit = run_helper(
+        tmp_path / "context", "pagerduty-test", action="fire", context="other"
+    )
+    assert mismatch.returncode != 0 and "create --raw" not in audit
+    unsupported = subprocess.run(
+        ["bash", str(SCRIPT), "pagerduty-test", "env=prod", "fire"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert unsupported.returncode != 0
+
+
+def test_pagerduty_fire_and_resolve_submit_same_labels_with_bounded_end_times(tmp_path):
+    for action in ("fire", "resolve"):
+        result, audit = run_helper(tmp_path / action, "pagerduty-test", action=action)
+        assert result.returncode == 0 and f"synthetic {action} accepted" in result.stdout
+        assert "create --raw" in audit
+        # The kubectl stub consumes payloads without retaining or printing them; source inspection
+        # proves the shared immutable label object and distinct end-time branches.
+    script = SCRIPT.read_text(encoding="utf-8")
+    label_block = script.split('"labels": {', 1)[1].split("},", 1)[0]
+    for label in ("SugarkubePagerDutyTest", "staging", "sugarkube-int", "critical"):
+        assert label in label_block
+    assert "date -u -d '+30 minutes'" in script
+    assert "date -u '+%Y-%m-%dT%H:%M:%SZ'" in script
+    assert "pagerduty_test" not in re.search(r"verify\(\).*?\n\}", script, re.S).group(0)
 
 
 def test_install_and_upgrade_require_distinct_release_states(tmp_path):


### PR DESCRIPTION
### Motivation
- Establish a secret-safe, staging-only PagerDuty receiver foundation that preserves the existing root no-op `"null"` receiver and avoids routing the chart’s bundled alerts to PagerDuty by default.
- Provide an operator-triggered synthetic fire/resolve workflow so teams can validate PagerDuty delivery without committing credentials or creating permanent firing rules.

### Description
- Add a narrow Alertmanager route and receiver that only routes alerts matching the exact labels `alertname="SugarkubePagerDutyTest"`, `environment="staging"`, `cluster="sugarkube-int"`, `severity="critical"` to a `pagerduty-synthetic` receiver which uses `routing_key_file` and `send_resolved: true`, while keeping the root receiver `"null"` unchanged (file: `clusters/staging/observability/kube-prometheus-stack.values.yaml`).
- Require and validate one Kubernetes Secret contract (`monitoring/alertmanager-pagerduty` with key `routing-key`) and mount it via the chart’s Alertmanager secret mechanism referencing the path `/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key` without ever reading or printing the secret value (changes in `scripts/observability_helm.sh` and new validator `scripts/validate_observability_alertmanager.rb`).
- Add a guarded manual just recipe and helper invocation to explicitly `fire` or `resolve` the synthetic alert through Alertmanager’s v2 alerts API via the cluster service proxy: `just observability-pagerduty-test env=staging action=fire` and `just observability-pagerduty-test env=staging action=resolve` (changes in `justfile` and `scripts/observability_helm.sh`).
- Extend offline structural validation and stubbed lifecycle tests to verify the rendered and live Alertmanager config, the Secret reference and file-backed credential usage, preflight fail-closed behavior, and that no broad or inline PagerDuty credentials are present (tests in `tests/test_observability_helm.py`).

### Testing
- Ran focused observability tests: `pytest -q tests/test_observability_helm.py -k 'not dashboard'` (35 passed) and `-k dashboard` (21 passed), and final focused run `pytest -q tests/test_observability_helm.py` (all observability tests passed).
- Performed offline render+validation: `just observability-render env=staging` with the pinned chart and `ruby scripts/validate_observability_alertmanager.rb /tmp/rendered.yaml` succeeded and confirmed the exact route, receiver, Secret mount contract, and file reference appear without inline keys.
- Ran repository checks: `bash -n scripts/observability_helm.sh`, `ruby -c scripts/validate_observability_alertmanager.rb`, `bash scripts/checks.sh --docs-only`, `linkchecker --no-warnings README.md docs/`, `git diff --cached | ./scripts/scan-secrets.py`, and `git diff --check`; all relevant verifications for this change passed, while `pyspelling` and `pre-commit` were not executed due to missing local tools in the environment (not a change regressions).

Files changed (high level): `clusters/staging/observability/kube-prometheus-stack.values.yaml`, `scripts/observability_helm.sh`, `scripts/validate_observability_alertmanager.rb` (new), `justfile`, `docs/observability-operations.md`, `docs/observability-alerting.md`, and `tests/test_observability_helm.py` (tests extended).

Secret & routing contract summary: Namespace `monitoring`, Secret `alertmanager-pagerduty`, key `routing-key`, mounted at `/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key`, receiver `pagerduty-synthetic`, root receiver remains `"null"`, and only the exact synthetic matcher is routed to PagerDuty.

Manual post-merge steps: (1) create/rotate the Secret via the documented hidden-read stdin pipeline; (2) `just observability-render env=staging` and inspect; (3) `just observability-upgrade env=staging` then `just observability-verify env=staging` and `just observability-dashboard-verify env=staging`; (4) `just observability-pagerduty-test env=staging action=fire` and manually confirm PagerDuty receipt/acknowledgement; (5) `just observability-pagerduty-test env=staging action=resolve` and confirm resolution; (6) rollback via Helm if needed while retaining the Secret until rollback completes (details in `docs/observability-operations.md`).

Safety note: No credential material was committed, printed, decoded, or used; no live alert was sent; no cluster mutation, Helm deployment, PagerDuty API call, or secret value exposure occurred during this work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a682f2459c4832f853e7cb0e6ddd157)