### PR TITLE
Add staging PagerDuty synthetic receiver, preflight checks, validator and manual fire/resolve workflow

### DIFF
--- a/clusters/staging/observability/kube-prometheus-stack.values.yaml
+++ b/clusters/staging/observability/kube-prometheus-stack.values.yaml
@@ -4,3 +4,23 @@ prometheus:
   prometheusSpec:
     externalLabels:
       cluster: sugarkube-int
+alertmanager:
+  alertmanagerSpec:
+    secrets:
+      - alertmanager-pagerduty
+  config:
+    route:
+      receiver: "null"
+      routes:
+        - receiver: pagerduty-synthetic-test
+          matchers:
+            - alertname="SugarkubePagerDutyTest"
+            - environment="staging"
+            - cluster="sugarkube-int"
+            - severity="critical"
+    receivers:
+      - name: "null"
+      - name: pagerduty-synthetic-test
+        pagerduty_configs:
+          - routing_key_file: /etc/alertmanager/secrets/alertmanager-pagerduty/routing-key
+            send_resolved: true

--- a/docs/observability-alerting.md
+++ b/docs/observability-alerting.md
@@ -117,9 +117,12 @@ What each check detects, and does not:
 - Route only explicitly named, reviewed, and tested Sugarkube alerts to PagerDuty — an allowlist, not
   the chart's entire default rule set. Do not forward `kube-prometheus-stack`'s bundled rules
   wholesale before auditing each one individually.
-- Use Alertmanager's PagerDuty integration with a secret file reference, for example
-  `routing_key_file: /etc/alertmanager/secrets/pagerduty-routing-key`, never an inline key committed to
-  Git.
+- Staging repository support now mounts `monitoring/alertmanager-pagerduty` and reads its
+  `routing-key` key from
+  `/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key`; the credential is never inline.
+  The only PagerDuty route is the exact `SugarkubePagerDutyTest` synthetic allowlist. This is
+  repository support, not evidence that it has been deployed or that phone delivery and resolution
+  have been manually proven.
 - Set `send_resolved: true` on the PagerDuty receiver so incidents auto-resolve when the underlying
   alert clears.
 - Define sensible `group_by`, `group_wait`, `group_interval`, and `repeat_interval` values so a single
@@ -151,9 +154,9 @@ These are the current alert-design candidates, not proof the rules already exist
 A safe, phased sequence — each step depends on the previous one succeeding:
 
 1. Establish PagerDuty and Healthchecks.io accounts and integrations manually (outside this repo).
-2. Add secret-safe Alertmanager receiver configuration (`routing_key_file`, no inline secrets),
-   still routed to nothing by default.
-3. Send and resolve a synthetic PagerDuty test alert to prove the receiver config and phone delivery
+2. Deploy and verify the repository's secret-safe receiver foundation (`routing_key_file`, no inline
+   secrets); the root remains the null receiver and only the synthetic test is allowlisted.
+3. Manually send and resolve the synthetic PagerDuty test alert to prove receiver and phone delivery
    work end-to-end, independent of any real Sugarkube rule.
 4. Add and verify the external node heartbeats and the observability watchdog against Healthchecks.io.
    Confirm the watchdog's dedicated Alertmanager timing and the Healthchecks.io period/grace match

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -124,7 +124,10 @@ is not rollout evidence.
 
 - Helm release: `kube-prometheus-stack` in namespace `monitoring`.
 - Prometheus: one replica, `7d` retention, `15GB` retention size, `local-path` `ReadWriteOnce` PVC requesting `20Gi`, CPU request `200m`, memory request `512Mi`, memory limit `2Gi`, admin API disabled, and external label `cluster=sugarkube-int`.
-- Alertmanager: one replica and no-op receiver named exactly `"null"`. No real notification receiver (PagerDuty, Healthchecks.io, or otherwise) is configured yet; see [`docs/observability-alerting.md`](observability-alerting.md) for the planned rollout.
+- Alertmanager: one replica with root/default no-op receiver named exactly `"null"`. Staging values
+  define a secret-file-backed PagerDuty receiver, but route only the exact synthetic test labels to
+  it; bundled and real workload alerts still fall through to `"null"`. Repository configuration is
+  not evidence of staging deployment or manually confirmed delivery.
 - Grafana: persistence disabled, no Ingress, LAN-only NodePort `30300`.
 - The provisioned dashboard defaults to six hours and a 30-second refresh. Its
   top-level public availability summary reports **Healthy endpoints**, **Failed
@@ -191,6 +194,76 @@ dashboard is the expected rollback state: omit `observability-dashboard-verify`
 and use the general `observability-verify` result as acceptance evidence.
 
 Do not use `--reuse-values` for the next forward upgrade; commit the full intended version and values chain first.
+
+## PagerDuty staging fire and resolve runbook
+
+Repository support alone is not deployment or delivery evidence. This manual procedure is staging-only; no CI,
+render, install, upgrade, status, or verification command sends an alert.
+
+1. Create or rotate the `monitoring/alertmanager-pagerduty` Secret without putting the routing key in
+   history, arguments, files, or output. Run this from an interactive terminal (the hidden read is
+   intentionally not suitable for a pasted automation transcript):
+
+   ```bash
+   read -r -s -p 'PagerDuty routing key: ' PAGERDUTY_ROUTING_KEY; printf '\n'
+   printf %s "$PAGERDUTY_ROUTING_KEY" |
+     kubectl -n monitoring create secret generic alertmanager-pagerduty \
+       --from-file=routing-key=/dev/stdin --dry-run=client -o yaml |
+     kubectl apply -f -
+   unset PAGERDUTY_ROUTING_KEY
+   ```
+
+   The pipe keeps the value off the process list and disk. Neither command prints the Secret value.
+2. Render and inspect the pinned proposal offline:
+
+   ```bash
+   just observability-render env=staging >/tmp/kube-prometheus-stack.rendered.yaml
+   ruby scripts/verify_observability_alertmanager.rb rendered \
+     /tmp/kube-prometheus-stack.rendered.yaml
+   ```
+
+   Confirm the validator reports the exact synthetic route, file reference, and Secret mount contract;
+   remove the temporary render after review.
+3. Select the staging kubeconfig, upgrade, and verify:
+
+   ```bash
+   just kubeconfig-env env=staging
+   just observability-upgrade env=staging
+   just observability-verify env=staging
+   ```
+
+   Upgrade fails closed before Helm mutation when the credential Secret or its nonempty key is absent.
+4. Explicitly fire the bounded synthetic alert (it auto-ends after 15 minutes if abandoned):
+
+   ```bash
+   just observability-pagerduty-test env=staging action=fire
+   ```
+
+5. In PagerDuty, manually confirm phone receipt and acknowledge the incident. The repository cannot
+   assert this external observation.
+6. Resolve the same alert fingerprint, then manually confirm PagerDuty resolution:
+
+   ```bash
+   just observability-pagerduty-test env=staging action=resolve
+   ```
+
+7. If necessary, use `helm -n monitoring history kube-prometheus-stack`, roll back to the prior
+   known-good revision with the command in [Rollback](#rollback), and run the applicable verification.
+8. Do **not** delete the credential Secret before rolling back configuration that references its
+   mounted file. A missing mounted Secret can prevent Alertmanager from starting, including during a
+   rollback whose configuration still expects it.
+9. For rotation, repeat step 1 with the new value, then reload it deterministically and verify:
+
+   ```bash
+   kubectl -n monitoring rollout restart \
+     statefulset/alertmanager-kube-prometheus-stack-alertmanager
+   kubectl -n monitoring rollout status \
+     statefulset/alertmanager-kube-prometheus-stack-alertmanager --timeout=20m
+   just observability-verify env=staging
+   ```
+
+   Repeat the explicit fire/acknowledge/resolve confirmations. Revoke the old integration key only
+   after the new path is proven. Keep the Secret present throughout rollback safety windows.
 
 ## Reprovisioning proof and post-merge checklist
 

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -184,14 +184,22 @@ Use Helm rollback to the prior known-good revision, then restore the prior compl
 ```bash
 helm -n monitoring history kube-prometheus-stack
 helm -n monitoring rollback kube-prometheus-stack <prior-revision> --wait --timeout 20m
+# From a worktree checked out at the Git commit that produced <prior-revision>:
 just observability-verify env=staging
-# Run this only when <prior-revision> already provisioned the dashboard.
+# Run this only when that revision provisioned the dashboard.
 just observability-dashboard-verify env=staging
 ```
 
-If `<prior-revision>` predates the first dashboard-as-code rollout, a missing
-dashboard is the expected rollback state: omit `observability-dashboard-verify`
-and use the general `observability-verify` result as acceptance evidence.
+The verification helper validates the configuration contract from its own Git
+revision. Do not run the current helper against an older Helm revision: for
+example, a revision from before PagerDuty support correctly lacks the current
+Secret mount and synthetic route. If the matching repository revision is not
+available, use `kubectl -n monitoring rollout status` for each workload shown by
+`just observability-status env=staging`, inspect pod readiness and logs, and
+check the Prometheus and Alertmanager endpoints without treating the current
+configuration validator as rollback acceptance evidence. If `<prior-revision>`
+predates the first dashboard-as-code rollout, a missing dashboard is likewise
+the expected rollback state, so omit `observability-dashboard-verify`.
 
 Do not use `--reuse-values` for the next forward upgrade; commit the full intended version and values chain first.
 
@@ -248,7 +256,9 @@ render, install, upgrade, status, or verification command sends an alert.
    ```
 
 7. If necessary, use `helm -n monitoring history kube-prometheus-stack`, roll back to the prior
-   known-good revision with the command in [Rollback](#rollback), and run the applicable verification.
+   known-good revision with the command in [Rollback](#rollback), and run verification from the Git
+   revision that produced that Helm revision (or use the configuration-neutral health checks described
+   there).
 8. Do **not** delete the credential Secret before rolling back configuration that references its
    mounted file. A missing mounted Secret can prevent Alertmanager from starting, including during a
    rollback whose configuration still expects it.

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -208,7 +208,14 @@ Do not use `--reuse-values` for the next forward upgrade; commit the full intend
 Repository support alone is not deployment or delivery evidence. This manual procedure is staging-only; no CI,
 render, install, upgrade, status, or verification command sends an alert.
 
-1. Create or rotate the `monitoring/alertmanager-pagerduty` Secret without putting the routing key in
+1. Select and verify the staging context before creating or rotating anything:
+
+   ```bash
+   just kubeconfig-env env=staging
+   test "$(kubectl config current-context)" = sugar-staging
+   ```
+
+2. Create or rotate the `monitoring/alertmanager-pagerduty` Secret without putting the routing key in
    history, arguments, files, or output. Run this from an interactive terminal (the hidden read is
    intentionally not suitable for a pasted automation transcript):
 
@@ -222,7 +229,7 @@ render, install, upgrade, status, or verification command sends an alert.
    ```
 
    The pipe keeps the value off the process list and disk. Neither command prints the Secret value.
-2. Render and inspect the pinned proposal offline:
+3. Render and inspect the pinned proposal offline:
 
    ```bash
    just observability-render env=staging >/tmp/kube-prometheus-stack.rendered.yaml
@@ -232,37 +239,36 @@ render, install, upgrade, status, or verification command sends an alert.
 
    Confirm the validator reports the exact synthetic route, file reference, and Secret mount contract;
    remove the temporary render after review.
-3. Select the staging kubeconfig, upgrade, and verify:
+4. Upgrade and verify:
 
    ```bash
-   just kubeconfig-env env=staging
    just observability-upgrade env=staging
    just observability-verify env=staging
    ```
 
    Upgrade fails closed before Helm mutation when the credential Secret or its nonempty key is absent.
-4. Explicitly fire the bounded synthetic alert (it auto-ends after 15 minutes if abandoned):
+5. Explicitly fire the bounded synthetic alert (it auto-ends after 15 minutes if abandoned):
 
    ```bash
    just observability-pagerduty-test env=staging action=fire
    ```
 
-5. In PagerDuty, manually confirm phone receipt and acknowledge the incident. The repository cannot
+6. In PagerDuty, manually confirm phone receipt and acknowledge the incident. The repository cannot
    assert this external observation.
-6. Resolve the same alert fingerprint, then manually confirm PagerDuty resolution:
+7. Resolve the same alert fingerprint, then manually confirm PagerDuty resolution:
 
    ```bash
    just observability-pagerduty-test env=staging action=resolve
    ```
 
-7. If necessary, use `helm -n monitoring history kube-prometheus-stack`, roll back to the prior
+8. If necessary, use `helm -n monitoring history kube-prometheus-stack`, roll back to the prior
    known-good revision with the command in [Rollback](#rollback), and run verification from the Git
    revision that produced that Helm revision (or use the configuration-neutral health checks described
    there).
-8. Do **not** delete the credential Secret before rolling back configuration that references its
+9. Do **not** delete the credential Secret before rolling back configuration that references its
    mounted file. A missing mounted Secret can prevent Alertmanager from starting, including during a
    rollback whose configuration still expects it.
-9. For rotation, repeat step 1 with the new value, then reload it deterministically and verify:
+10. For rotation, repeat step 2 with the new value, then reload it deterministically and verify:
 
    ```bash
    kubectl -n monitoring rollout restart \

--- a/justfile
+++ b/justfile
@@ -3194,6 +3194,10 @@ observability-verify env='':
 observability-dashboard-verify env='':
     @scripts/observability_helm.sh dashboard-verify '{{ env }}'
 
+# Explicitly fire or resolve the staging-only synthetic PagerDuty alert (manual only).
+observability-pagerduty-test env='' action='':
+    @scripts/observability_helm.sh pagerduty-test '{{ env }}' '{{ action }}'
+
 # Render the pinned staging blackbox exporter and Probe manifests (read-only).
 observability-blackbox-render env='':
     @scripts/observability_blackbox.sh render '{{ env }}'

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -69,7 +69,7 @@ render_to() {
 assert_pagerduty_secret() {
   local present
   if ! present="$(kubectl -n "${NAMESPACE}" get secret "${PAGERDUTY_SECRET}" -o 'go-template={{if index .data "routing-key"}}present{{end}}' 2>/dev/null)"; then
-    echo "ERROR: required Secret monitoring/alertmanager-pagerduty is absent; create it with a nonempty routing-key before install or upgrade." >&2
+    echo "ERROR: required Secret monitoring/alertmanager-pagerduty is absent; create it with a nonempty routing-key before deployment or verification." >&2
     return 15
   fi
   if [[ "${present}" != present ]]; then
@@ -247,13 +247,17 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
     raise SystemExit("ERROR: expected one Bound local-path Prometheus PVC.")'
   [[ "$(kubectl -n "${NAMESPACE}" get prometheus kube-prometheus-stack-prometheus -o jsonpath='{.spec.replicas}')" == 1 ]]
   [[ "$(kubectl -n "${NAMESPACE}" get alertmanager kube-prometheus-stack-alertmanager -o jsonpath='{.spec.replicas}')" == 1 ]]
-  local alertmanager_yaml config_yaml
+  assert_pagerduty_secret
+  local alertmanager_yaml config_yaml cleanup_command
   alertmanager_yaml="$(mktemp -t sugarkube-alertmanager-cr.XXXXXX.yaml)"
   config_yaml="$(mktemp -t sugarkube-alertmanager-config.XXXXXX.yaml)"
-  trap 'rm -f "${alertmanager_yaml}" "${config_yaml}"' RETURN
+  printf -v cleanup_command 'rm -f %q %q' "${alertmanager_yaml}" "${config_yaml}"
+  trap "${cleanup_command}" EXIT
   kubectl -n "${NAMESPACE}" get alertmanager kube-prometheus-stack-alertmanager -o yaml >"${alertmanager_yaml}"
   kubectl -n "${NAMESPACE}" get secret alertmanager-kube-prometheus-stack-alertmanager -o yaml >"${config_yaml}"
   ruby "${ALERTMANAGER_VALIDATOR}" live "${alertmanager_yaml}" "${config_yaml}"
+  rm -f "${alertmanager_yaml}" "${config_yaml}"
+  trap - EXIT
   [[ -z "$(kubectl -n "${NAMESPACE}" get ingress -l app.kubernetes.io/name=grafana -o name 2>/dev/null)" ]]
   [[ "$(kubectl -n "${NAMESPACE}" get svc kube-prometheus-stack-grafana -o jsonpath='{.spec.ports[?(@.port==80)].nodePort}')" == 30300 ]]
   monitor_release="$(kubectl -n dspace get servicemonitor dspace -o jsonpath='{.metadata.labels.release}')"
@@ -268,7 +272,7 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
 }
 
 pagerduty_test() {
-  local action="${1:-}" ends_at endpoint response_file
+  local action="${1:-}" ends_at endpoint response_file cleanup_command
   case "${action}" in
     fire|resolve) ;;
     "") echo "ERROR: PagerDuty test requires an explicit action: fire or resolve." >&2; return 17 ;;
@@ -283,7 +287,8 @@ end = now + timedelta(minutes=15) if os.environ["ACTION"] == "fire" else now
 print(end.isoformat(timespec="seconds").replace("+00:00", "Z"))')"
   endpoint="/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-alertmanager:9093/proxy/api/v2/alerts"
   response_file="$(mktemp -t sugarkube-alertmanager-response.XXXXXX)"
-  trap 'rm -f "${response_file}"' RETURN
+  printf -v cleanup_command 'rm -f %q' "${response_file}"
+  trap "${cleanup_command}" EXIT
   if ! ENDS_AT="${ends_at}" python3 -c 'import json, os, sys
 json.dump([{
   "labels": {
@@ -303,6 +308,8 @@ json.dump([{
     echo "ERROR: Alertmanager v2 API rejected synthetic ${action} request (response redacted)." >&2
     return 18
   fi
+  rm -f "${response_file}"
+  trap - EXIT
   echo "PagerDuty synthetic ${action} submitted; Alertmanager API status: accepted (response redacted)."
 }
 

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -13,8 +13,10 @@ DASHBOARD_VALUE="grafana.dashboards.sugarkube.sugarkube-staging-observability.js
 DASHBOARD_VALIDATOR="${ROOT}/scripts/validate_observability_dashboard.py"
 TIMEOUT="${SUGARKUBE_OBSERVABILITY_HELM_TIMEOUT:-20m}"
 GRAFANA_URL="http://sugarkube3.local:30300"
+PAGERDUTY_SECRET="alertmanager-pagerduty"
+ALERTMANAGER_VALIDATOR="${ROOT}/scripts/verify_observability_alertmanager.rb"
 
-usage() { echo "Usage: $0 <render|install|upgrade|status|verify|dashboard-verify> env=staging" >&2; }
+usage() { echo "Usage: $0 <render|install|upgrade|status|verify|dashboard-verify|pagerduty-test> env=staging [fire|resolve]" >&2; }
 normalize_env() {
   local raw="${1:-}"
   while [[ "${raw}" == env=* ]]; do raw="${raw#env=}"; done
@@ -55,12 +57,26 @@ assert_context() {
 version() { tr -d '[:space:]' < "${VERSION_FILE}"; }
 validate_dashboard() { python3 "${DASHBOARD_VALIDATOR}" "${DASHBOARD}"; }
 validate_rendered_dashboard() { python3 "${DASHBOARD_VALIDATOR}" "${DASHBOARD}" --rendered "$1"; }
+validate_rendered_alertmanager() { ruby "${ALERTMANAGER_VALIDATOR}" rendered "$1"; }
 render_to() {
   local out="$1"
   helm repo add prometheus-community https://prometheus-community.github.io/helm-charts --force-update >/dev/null
   helm repo update prometheus-community >/dev/null
   helm template "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" >"${out}"
   validate_rendered_dashboard "${out}"
+  validate_rendered_alertmanager "${out}"
+}
+assert_pagerduty_secret() {
+  local present
+  if ! present="$(kubectl -n "${NAMESPACE}" get secret "${PAGERDUTY_SECRET}" -o 'go-template={{if index .data "routing-key"}}present{{end}}' 2>/dev/null)"; then
+    echo "ERROR: required Secret monitoring/alertmanager-pagerduty is absent; create it with a nonempty routing-key before install or upgrade." >&2
+    return 15
+  fi
+  if [[ "${present}" != present ]]; then
+    echo "ERROR: Secret monitoring/alertmanager-pagerduty must contain a nonempty routing-key (value intentionally not read or printed)." >&2
+    return 15
+  fi
+  echo "PagerDuty Secret contract exists (value intentionally not read or printed)."
 }
 release_state() {
   local matches
@@ -79,9 +95,9 @@ release_state() {
     return 1
   fi
 }
-render() { validate_dashboard; require_tools helm kubectl python3; print_resolved staging; tmp="$(mktemp -t sugarkube-observability-render.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; cat "${tmp}"; }
-install_release() { validate_dashboard; require_tools helm kubectl python3; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
-upgrade_release() { validate_dashboard; require_tools helm kubectl python3; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
+render() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; tmp="$(mktemp -t sugarkube-observability-render.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; cat "${tmp}"; }
+install_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; assert_pagerduty_secret; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
+upgrade_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; assert_pagerduty_secret; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
 status() { require_tools helm kubectl python3; print_resolved staging; assert_context; helm -n "${NAMESPACE}" status "${RELEASE}"; kubectl -n "${NAMESPACE}" get deploy,statefulset,daemonset -l "app.kubernetes.io/instance=${RELEASE}"; kubectl -n "${NAMESPACE}" get prometheus,alertmanager; kubectl -n "${NAMESPACE}" get svc,pvc; kubectl get crd prometheuses.monitoring.coreos.com alertmanagers.monitoring.coreos.com servicemonitors.monitoring.coreos.com probes.monitoring.coreos.com; }
 verify_dspace_targets() {
   require_tools kubectl python3 sleep
@@ -206,7 +222,7 @@ raise SystemExit(10)' <<<"${targets_json}" || parser_status=$?
   return 10
 }
 verify() {
-  require_tools kubectl python3
+  require_tools kubectl python3 ruby
   print_resolved staging
   assert_context
   kubectl get crd prometheuses.monitoring.coreos.com alertmanagers.monitoring.coreos.com servicemonitors.monitoring.coreos.com probes.monitoring.coreos.com >/dev/null
@@ -231,6 +247,13 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
     raise SystemExit("ERROR: expected one Bound local-path Prometheus PVC.")'
   [[ "$(kubectl -n "${NAMESPACE}" get prometheus kube-prometheus-stack-prometheus -o jsonpath='{.spec.replicas}')" == 1 ]]
   [[ "$(kubectl -n "${NAMESPACE}" get alertmanager kube-prometheus-stack-alertmanager -o jsonpath='{.spec.replicas}')" == 1 ]]
+  local alertmanager_yaml config_yaml
+  alertmanager_yaml="$(mktemp -t sugarkube-alertmanager-cr.XXXXXX.yaml)"
+  config_yaml="$(mktemp -t sugarkube-alertmanager-config.XXXXXX.yaml)"
+  trap 'rm -f "${alertmanager_yaml}" "${config_yaml}"' RETURN
+  kubectl -n "${NAMESPACE}" get alertmanager kube-prometheus-stack-alertmanager -o yaml >"${alertmanager_yaml}"
+  kubectl -n "${NAMESPACE}" get secret alertmanager-kube-prometheus-stack-alertmanager -o yaml >"${config_yaml}"
+  ruby "${ALERTMANAGER_VALIDATOR}" live "${alertmanager_yaml}" "${config_yaml}"
   [[ -z "$(kubectl -n "${NAMESPACE}" get ingress -l app.kubernetes.io/name=grafana -o name 2>/dev/null)" ]]
   [[ "$(kubectl -n "${NAMESPACE}" get svc kube-prometheus-stack-grafana -o jsonpath='{.spec.ports[?(@.port==80)].nodePort}')" == 30300 ]]
   monitor_release="$(kubectl -n dspace get servicemonitor dspace -o jsonpath='{.metadata.labels.release}')"
@@ -242,6 +265,45 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
 
   verify_dspace_targets
   echo "Grafana LAN URL: ${GRAFANA_URL} (same NodePort is available through the other staging nodes)"
+}
+
+pagerduty_test() {
+  local action="${1:-}" ends_at endpoint response_file
+  case "${action}" in
+    fire|resolve) ;;
+    "") echo "ERROR: PagerDuty test requires an explicit action: fire or resolve." >&2; return 17 ;;
+    *) echo "ERROR: unsupported PagerDuty test action '${action}'; expected fire or resolve." >&2; return 17 ;;
+  esac
+  require_tools kubectl python3
+  assert_context
+  ends_at="$(ACTION="${action}" python3 -c 'from datetime import datetime, timedelta, timezone
+import os
+now = datetime.now(timezone.utc)
+end = now + timedelta(minutes=15) if os.environ["ACTION"] == "fire" else now
+print(end.isoformat(timespec="seconds").replace("+00:00", "Z"))')"
+  endpoint="/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-alertmanager:9093/proxy/api/v2/alerts"
+  response_file="$(mktemp -t sugarkube-alertmanager-response.XXXXXX)"
+  trap 'rm -f "${response_file}"' RETURN
+  if ! ENDS_AT="${ends_at}" python3 -c 'import json, os, sys
+json.dump([{
+  "labels": {
+    "alertname": "SugarkubePagerDutyTest",
+    "environment": "staging",
+    "cluster": "sugarkube-int",
+    "severity": "critical"
+  },
+  "annotations": {
+    "summary": "Sugarkube staging PagerDuty delivery test",
+    "description": "Operator-triggered synthetic alert for the staging PagerDuty fire/resolve drill.",
+    "runbook_url": "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-operations.md#pagerduty-staging-fire-and-resolve-runbook"
+  },
+  "startsAt": "2020-01-01T00:00:00Z",
+  "endsAt": os.environ["ENDS_AT"]
+}], sys.stdout)' | kubectl create --raw "${endpoint}" -f - >"${response_file}" 2>/dev/null; then
+    echo "ERROR: Alertmanager v2 API rejected synthetic ${action} request (response redacted)." >&2
+    return 18
+  fi
+  echo "PagerDuty synthetic ${action} submitted; Alertmanager API status: accepted (response redacted)."
 }
 
 dashboard_verify() (
@@ -342,4 +404,4 @@ if not isinstance(dashboard, dict) or dashboard.get("uid") != "sugarkube-staging
 cmd="${1:-}"; shift || true; [[ -n "${cmd}" ]] || { usage; exit 2; }
 env_arg="${1:-}"; normalize_env "${env_arg}" >/dev/null
 validate_dashboard
-case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) dashboard_verify ;; *) usage; exit 2 ;; esac
+case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) dashboard_verify ;; pagerduty-test) pagerduty_test "${2:-${1:-}}" ;; *) usage; exit 2 ;; esac

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -96,8 +96,8 @@ release_state() {
   fi
 }
 render() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; tmp="$(mktemp -t sugarkube-observability-render.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; cat "${tmp}"; }
-install_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; assert_pagerduty_secret; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
-upgrade_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; assert_pagerduty_secret; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
+install_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; assert_pagerduty_secret; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
+upgrade_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; assert_pagerduty_secret; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
 status() { require_tools helm kubectl python3; print_resolved staging; assert_context; helm -n "${NAMESPACE}" status "${RELEASE}"; kubectl -n "${NAMESPACE}" get deploy,statefulset,daemonset -l "app.kubernetes.io/instance=${RELEASE}"; kubectl -n "${NAMESPACE}" get prometheus,alertmanager; kubectl -n "${NAMESPACE}" get svc,pvc; kubectl get crd prometheuses.monitoring.coreos.com alertmanagers.monitoring.coreos.com servicemonitors.monitoring.coreos.com probes.monitoring.coreos.com; }
 verify_dspace_targets() {
   require_tools kubectl python3 sleep
@@ -221,7 +221,7 @@ raise SystemExit(10)' <<<"${targets_json}" || parser_status=$?
   done
   return 10
 }
-verify() {
+verify() (
   require_tools kubectl python3 ruby
   print_resolved staging
   assert_context
@@ -248,16 +248,13 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
   [[ "$(kubectl -n "${NAMESPACE}" get prometheus kube-prometheus-stack-prometheus -o jsonpath='{.spec.replicas}')" == 1 ]]
   [[ "$(kubectl -n "${NAMESPACE}" get alertmanager kube-prometheus-stack-alertmanager -o jsonpath='{.spec.replicas}')" == 1 ]]
   assert_pagerduty_secret
-  local alertmanager_yaml config_yaml cleanup_command
+  local alertmanager_yaml="" config_yaml=""
+  trap 'rm -f "${alertmanager_yaml:-}" "${config_yaml:-}"' EXIT
   alertmanager_yaml="$(mktemp -t sugarkube-alertmanager-cr.XXXXXX.yaml)"
   config_yaml="$(mktemp -t sugarkube-alertmanager-config.XXXXXX.yaml)"
-  printf -v cleanup_command 'rm -f %q %q' "${alertmanager_yaml}" "${config_yaml}"
-  trap "${cleanup_command}" EXIT
   kubectl -n "${NAMESPACE}" get alertmanager kube-prometheus-stack-alertmanager -o yaml >"${alertmanager_yaml}"
   kubectl -n "${NAMESPACE}" get secret alertmanager-kube-prometheus-stack-alertmanager -o yaml >"${config_yaml}"
   ruby "${ALERTMANAGER_VALIDATOR}" live "${alertmanager_yaml}" "${config_yaml}"
-  rm -f "${alertmanager_yaml}" "${config_yaml}"
-  trap - EXIT
   [[ -z "$(kubectl -n "${NAMESPACE}" get ingress -l app.kubernetes.io/name=grafana -o name 2>/dev/null)" ]]
   [[ "$(kubectl -n "${NAMESPACE}" get svc kube-prometheus-stack-grafana -o jsonpath='{.spec.ports[?(@.port==80)].nodePort}')" == 30300 ]]
   monitor_release="$(kubectl -n dspace get servicemonitor dspace -o jsonpath='{.metadata.labels.release}')"
@@ -269,10 +266,11 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
 
   verify_dspace_targets
   echo "Grafana LAN URL: ${GRAFANA_URL} (same NodePort is available through the other staging nodes)"
-}
+)
 
-pagerduty_test() {
-  local action="${1:-}" ends_at endpoint response_file cleanup_command
+pagerduty_test() (
+  local action="${1:-}" ends_at endpoint response_file=""
+  action="${action#action=}"
   case "${action}" in
     fire|resolve) ;;
     "") echo "ERROR: PagerDuty test requires an explicit action: fire or resolve." >&2; return 17 ;;
@@ -286,9 +284,8 @@ now = datetime.now(timezone.utc)
 end = now + timedelta(minutes=15) if os.environ["ACTION"] == "fire" else now
 print(end.isoformat(timespec="seconds").replace("+00:00", "Z"))')"
   endpoint="/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-alertmanager:9093/proxy/api/v2/alerts"
+  trap 'rm -f "${response_file:-}"' EXIT
   response_file="$(mktemp -t sugarkube-alertmanager-response.XXXXXX)"
-  printf -v cleanup_command 'rm -f %q' "${response_file}"
-  trap "${cleanup_command}" EXIT
   if ! ENDS_AT="${ends_at}" python3 -c 'import json, os, sys
 json.dump([{
   "labels": {
@@ -308,10 +305,8 @@ json.dump([{
     echo "ERROR: Alertmanager v2 API rejected synthetic ${action} request (response redacted)." >&2
     return 18
   fi
-  rm -f "${response_file}"
-  trap - EXIT
   echo "PagerDuty synthetic ${action} submitted; Alertmanager API status: accepted (response redacted)."
-}
+)
 
 dashboard_verify() (
   require_tools kubectl python3 curl base64 sleep

--- a/scripts/verify_observability_alertmanager.rb
+++ b/scripts/verify_observability_alertmanager.rb
@@ -23,15 +23,19 @@ mode, *paths = ARGV
 fail_closed("expected rendered FILE or live ALERTMANAGER_YAML CONFIG_SECRET_YAML") unless
   (mode == "rendered" && paths.length == 1) || (mode == "live" && paths.length == 2)
 
-documents = paths.flat_map do |path|
-  content = File.read(path)
-  content = content[content.index("---\n")..] if mode == "rendered" && content.index("---\n")
-  content.split(/^---\s*$\n?/).filter_map do |document|
-    relevant = document.match?(/^kind: Alertmanager\s*$/) ||
-      (document.match?(/^kind: Secret\s*$/) &&
-       document.include?("name: alertmanager-kube-prometheus-stack-alertmanager"))
-    YAML.safe_load(document, permitted_classes: [], aliases: false) if relevant
+begin
+  documents = paths.flat_map do |path|
+    content = File.read(path)
+    content = content[content.index("---\n")..] if mode == "rendered" && content.index("---\n")
+    content.split(/^---\s*$\n?/).filter_map do |document|
+      relevant = document.match?(/^kind: Alertmanager\s*$/) ||
+        (document.match?(/^kind: Secret\s*$/) &&
+         document.include?("name: alertmanager-kube-prometheus-stack-alertmanager"))
+      YAML.safe_load(document, permitted_classes: [], aliases: false) if relevant
+    end
   end
+rescue StandardError
+  fail_closed("input manifests are missing or malformed")
 end
 alertmanager = documents.find { |doc| doc["kind"] == "Alertmanager" }
 fail_closed("expected Alertmanager custom resource is missing") unless alertmanager
@@ -44,9 +48,13 @@ end
 fail_closed("generated Alertmanager configuration Secret is missing") unless config_secret
 encoded = config_secret.dig("data", "alertmanager.yaml")
 plain = config_secret.dig("stringData", "alertmanager.yaml")
-config_text = plain || (Base64.strict_decode64(encoded) if encoded)
-fail_closed("generated Alertmanager configuration is missing or malformed") unless config_text
-config = YAML.safe_load(config_text, permitted_classes: [], aliases: false)
+begin
+  config_text = plain || (Base64.strict_decode64(encoded) if encoded)
+  fail_closed("generated Alertmanager configuration is missing or malformed") unless config_text
+  config = YAML.safe_load(config_text, permitted_classes: [], aliases: false)
+rescue StandardError
+  fail_closed("generated Alertmanager configuration is missing or malformed")
+end
 
 route = config["route"]
 fail_closed('root receiver must remain "null"') unless route.is_a?(Hash) && route["receiver"] == "null"

--- a/scripts/verify_observability_alertmanager.rb
+++ b/scripts/verify_observability_alertmanager.rb
@@ -37,8 +37,11 @@ begin
 rescue StandardError
   fail_closed("input manifests are missing or malformed")
 end
-alertmanager = documents.find { |doc| doc["kind"] == "Alertmanager" }
-fail_closed("expected Alertmanager custom resource is missing") unless alertmanager
+alertmanagers = documents.select do |doc|
+  doc["kind"] == "Alertmanager" && doc.dig("metadata", "name") == "kube-prometheus-stack-alertmanager"
+end
+fail_closed("expected exactly one kube-prometheus-stack Alertmanager custom resource") unless alertmanagers.length == 1
+alertmanager = alertmanagers.first
 secrets = alertmanager.dig("spec", "secrets")
 fail_closed("Alertmanager must reference only #{EXPECTED_SECRET}") unless secrets == [EXPECTED_SECRET]
 
@@ -56,26 +59,53 @@ rescue StandardError
   fail_closed("generated Alertmanager configuration is missing or malformed")
 end
 
+fail_closed("generated Alertmanager configuration is malformed") unless config.is_a?(Hash)
+
+inline_credential = lambda do |value|
+  case value
+  when Hash
+    value.key?("routing_key") || value.key?("service_key") || value.any? { |_key, child| inline_credential.call(child) }
+  when Array
+    value.any? { |child| inline_credential.call(child) }
+  else
+    false
+  end
+end
+fail_closed("inline PagerDuty credentials are forbidden") if inline_credential.call(config)
+
 route = config["route"]
 fail_closed('root receiver must remain "null"') unless route.is_a?(Hash) && route["receiver"] == "null"
-routes = route["routes"]
-fail_closed("there must be exactly one PagerDuty route") unless routes.is_a?(Array) && routes.length == 1
-synthetic_route = routes.first
-fail_closed("PagerDuty route receiver changed") unless synthetic_route["receiver"] == EXPECTED_RECEIVER
-fail_closed("PagerDuty route matchers are not the exact synthetic allowlist") unless
-  synthetic_route["matchers"].is_a?(Array) && synthetic_route["matchers"].sort == EXPECTED_MATCHERS.sort
-fail_closed("PagerDuty route must not continue into broader routing") if synthetic_route["continue"] == true
 
 receivers = config["receivers"]
 fail_closed("receiver list is malformed") unless receivers.is_a?(Array)
+fail_closed("receiver list is malformed") unless receivers.all? { |item| item.is_a?(Hash) }
 fail_closed('root "null" receiver is missing') unless receivers.count { |item| item == { "name" => "null" } } == 1
-pagerduty = receivers.select { |item| item["name"] == EXPECTED_RECEIVER }
-fail_closed("there must be exactly one synthetic PagerDuty receiver") unless pagerduty.length == 1
+pagerduty = receivers.select { |item| item.key?("pagerduty_configs") }
+fail_closed("there must be exactly one PagerDuty receiver") unless pagerduty.length == 1
+fail_closed("PagerDuty receiver name changed") unless pagerduty.first["name"] == EXPECTED_RECEIVER
 pd_configs = pagerduty.first["pagerduty_configs"]
 fail_closed("there must be exactly one PagerDuty configuration") unless pd_configs.is_a?(Array) && pd_configs.length == 1
 pd_config = pd_configs.first
+fail_closed("PagerDuty configuration is malformed") unless pd_config.is_a?(Hash)
 fail_closed("PagerDuty must use the exact mounted routing-key file") unless pd_config["routing_key_file"] == EXPECTED_PATH
 fail_closed("PagerDuty resolved notifications must be enabled") unless pd_config["send_resolved"] == true
-fail_closed("inline PagerDuty credentials are forbidden") if pd_config.key?("routing_key") || pd_config.key?("service_key")
+
+all_routes = []
+walk_routes = lambda do |candidate|
+  fail_closed("route tree is malformed") unless candidate.is_a?(Hash)
+  all_routes << candidate
+  children = candidate["routes"]
+  return if children.nil?
+
+  fail_closed("route tree is malformed") unless children.is_a?(Array)
+  children.each { |child| walk_routes.call(child) }
+end
+walk_routes.call(route)
+pagerduty_routes = all_routes.select { |candidate| candidate["receiver"] == EXPECTED_RECEIVER }
+fail_closed("there must be exactly one PagerDuty route") unless pagerduty_routes.length == 1
+synthetic_route = pagerduty_routes.first
+fail_closed("PagerDuty route matchers are not the exact synthetic allowlist") unless
+  synthetic_route["matchers"].is_a?(Array) && synthetic_route["matchers"].sort == EXPECTED_MATCHERS.sort
+fail_closed("PagerDuty route must not specify continuation") if synthetic_route.key?("continue")
 
 warn "Alertmanager PagerDuty structure verified (credential value not accessed)."

--- a/scripts/verify_observability_alertmanager.rb
+++ b/scripts/verify_observability_alertmanager.rb
@@ -104,8 +104,12 @@ walk_routes.call(route)
 pagerduty_routes = all_routes.select { |candidate| candidate["receiver"] == EXPECTED_RECEIVER }
 fail_closed("there must be exactly one PagerDuty route") unless pagerduty_routes.length == 1
 synthetic_route = pagerduty_routes.first
+root_children = route["routes"]
+fail_closed("PagerDuty route must be a direct child of the root route") unless
+  root_children.is_a?(Array) && root_children.include?(synthetic_route)
 fail_closed("PagerDuty route matchers are not the exact synthetic allowlist") unless
   synthetic_route["matchers"].is_a?(Array) && synthetic_route["matchers"].sort == EXPECTED_MATCHERS.sort
+fail_closed("PagerDuty route must not contain nested routes") if synthetic_route.key?("routes")
 fail_closed("PagerDuty route must not specify continuation") if synthetic_route.key?("continue")
 
 warn "Alertmanager PagerDuty structure verified (credential value not accessed)."

--- a/scripts/verify_observability_alertmanager.rb
+++ b/scripts/verify_observability_alertmanager.rb
@@ -1,0 +1,73 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "base64"
+require "yaml"
+
+EXPECTED_SECRET = "alertmanager-pagerduty"
+EXPECTED_PATH = "/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key"
+EXPECTED_RECEIVER = "pagerduty-synthetic-test"
+EXPECTED_MATCHERS = [
+  'alertname="SugarkubePagerDutyTest"',
+  'environment="staging"',
+  'cluster="sugarkube-int"',
+  'severity="critical"'
+].freeze
+
+def fail_closed(message)
+  warn "ERROR: Alertmanager PagerDuty structure invalid: #{message} (sensitive values not printed)."
+  exit 16
+end
+
+mode, *paths = ARGV
+fail_closed("expected rendered FILE or live ALERTMANAGER_YAML CONFIG_SECRET_YAML") unless
+  (mode == "rendered" && paths.length == 1) || (mode == "live" && paths.length == 2)
+
+documents = paths.flat_map do |path|
+  content = File.read(path)
+  content = content[content.index("---\n")..] if mode == "rendered" && content.index("---\n")
+  content.split(/^---\s*$\n?/).filter_map do |document|
+    relevant = document.match?(/^kind: Alertmanager\s*$/) ||
+      (document.match?(/^kind: Secret\s*$/) &&
+       document.include?("name: alertmanager-kube-prometheus-stack-alertmanager"))
+    YAML.safe_load(document, permitted_classes: [], aliases: false) if relevant
+  end
+end
+alertmanager = documents.find { |doc| doc["kind"] == "Alertmanager" }
+fail_closed("expected Alertmanager custom resource is missing") unless alertmanager
+secrets = alertmanager.dig("spec", "secrets")
+fail_closed("Alertmanager must reference only #{EXPECTED_SECRET}") unless secrets == [EXPECTED_SECRET]
+
+config_secret = documents.find do |doc|
+  doc["kind"] == "Secret" && doc.dig("metadata", "name") == "alertmanager-kube-prometheus-stack-alertmanager"
+end
+fail_closed("generated Alertmanager configuration Secret is missing") unless config_secret
+encoded = config_secret.dig("data", "alertmanager.yaml")
+plain = config_secret.dig("stringData", "alertmanager.yaml")
+config_text = plain || (Base64.strict_decode64(encoded) if encoded)
+fail_closed("generated Alertmanager configuration is missing or malformed") unless config_text
+config = YAML.safe_load(config_text, permitted_classes: [], aliases: false)
+
+route = config["route"]
+fail_closed('root receiver must remain "null"') unless route.is_a?(Hash) && route["receiver"] == "null"
+routes = route["routes"]
+fail_closed("there must be exactly one PagerDuty route") unless routes.is_a?(Array) && routes.length == 1
+synthetic_route = routes.first
+fail_closed("PagerDuty route receiver changed") unless synthetic_route["receiver"] == EXPECTED_RECEIVER
+fail_closed("PagerDuty route matchers are not the exact synthetic allowlist") unless
+  synthetic_route["matchers"].is_a?(Array) && synthetic_route["matchers"].sort == EXPECTED_MATCHERS.sort
+fail_closed("PagerDuty route must not continue into broader routing") if synthetic_route["continue"] == true
+
+receivers = config["receivers"]
+fail_closed("receiver list is malformed") unless receivers.is_a?(Array)
+fail_closed('root "null" receiver is missing') unless receivers.count { |item| item == { "name" => "null" } } == 1
+pagerduty = receivers.select { |item| item["name"] == EXPECTED_RECEIVER }
+fail_closed("there must be exactly one synthetic PagerDuty receiver") unless pagerduty.length == 1
+pd_configs = pagerduty.first["pagerduty_configs"]
+fail_closed("there must be exactly one PagerDuty configuration") unless pd_configs.is_a?(Array) && pd_configs.length == 1
+pd_config = pd_configs.first
+fail_closed("PagerDuty must use the exact mounted routing-key file") unless pd_config["routing_key_file"] == EXPECTED_PATH
+fail_closed("PagerDuty resolved notifications must be enabled") unless pd_config["send_resolved"] == true
+fail_closed("inline PagerDuty credentials are forbidden") if pd_config.key?("routing_key") || pd_config.key?("service_key")
+
+warn "Alertmanager PagerDuty structure verified (credential value not accessed)."

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -11,6 +11,7 @@ VERSION = ROOT / "platform" / "observability" / "helm" / "kube-prometheus-stack.
 COMMON = ROOT / "platform" / "observability" / "helm" / "kube-prometheus-stack.values.common.yaml"
 STAGING = ROOT / "clusters" / "staging" / "observability" / "kube-prometheus-stack.values.yaml"
 SCRIPT = ROOT / "scripts" / "observability_helm.sh"
+ALERTMANAGER_VALIDATOR = ROOT / "scripts" / "verify_observability_alertmanager.rb"
 DASHBOARD = ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
 JUSTFILE = ROOT / "justfile"
 FLUX_SYNC = ROOT / "flux" / "gotk-sync.yaml"
@@ -59,6 +60,24 @@ def test_chart_version_and_values_match_live_staging_baseline():
     assert pvc["accessModes"] == ["ReadWriteOnce"]
     assert pvc["resources"]["requests"]["storage"] == "20Gi"
     assert staging["prometheus"]["prometheusSpec"]["externalLabels"] == {"cluster": "sugarkube-int"}
+    alertmanager = staging["alertmanager"]
+    assert alertmanager["alertmanagerSpec"]["secrets"] == ["alertmanager-pagerduty"]
+    route = alertmanager["config"]["route"]
+    assert route["receiver"] == "null"
+    assert route["routes"] == [{
+        "receiver": "pagerduty-synthetic-test",
+        "matchers": [
+            'alertname="SugarkubePagerDutyTest"',
+            'environment="staging"',
+            'cluster="sugarkube-int"',
+            'severity="critical"',
+        ],
+    }]
+    pagerduty = alertmanager["config"]["receivers"][1]["pagerduty_configs"][0]
+    assert pagerduty == {
+        "routing_key_file": "/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key",
+        "send_resolved": True,
+    }
 
 
 def test_grafana_alertmanager_k3s_monitor_values_are_guarded():
@@ -99,6 +118,69 @@ def test_no_production_values_or_public_exposure_or_credentials_added():
         assert needle not in text
     assert "30300" in text
     assert "enableAdminAPI: false" in text
+
+
+def rendered_alertmanager_fixture(
+    *, secret="alertmanager-pagerduty", path=None, matchers=None, inline=False
+):
+    path = path or "/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key"
+    matchers = matchers or [
+        'alertname="SugarkubePagerDutyTest"',
+        'environment="staging"',
+        'cluster="sugarkube-int"',
+        'severity="critical"',
+    ]
+    inline_field = "\n            " + "routing_" + "key: forbidden-stub" if inline else ""
+    matcher_yaml = "\n".join(f"            - '{matcher}'" for matcher in matchers)
+    return f"""---
+apiVersion: monitoring.coreos.com/v1
+kind: Alertmanager
+spec:
+  secrets: [{secret}]
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-kube-prometheus-stack-alertmanager
+stringData:
+  alertmanager.yaml: |
+    route:
+      receiver: "null"
+      routes:
+        - receiver: pagerduty-synthetic-test
+          matchers:
+{matcher_yaml}
+    receivers:
+      - name: "null"
+      - name: pagerduty-synthetic-test
+        pagerduty_configs:
+          - routing_key_file: {path}
+            send_resolved: true{inline_field}
+"""
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"secret": "wrong-secret"},
+        {"path": "/wrong/path"},
+        {"matchers": ['severity="critical"']},
+        {"inline": True},
+    ],
+)
+def test_alertmanager_validator_rejects_missing_mount_wrong_path_inline_and_broad_route(
+    tmp_path, kwargs
+):
+    manifest = tmp_path / "rendered.yaml"
+    manifest.write_text(rendered_alertmanager_fixture(**kwargs), encoding="utf-8")
+    result = subprocess.run(
+        ["ruby", str(ALERTMANAGER_VALIDATOR), "rendered", str(manifest)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "forbidden-stub" not in result.stderr
 
 
 def test_discovery_contract_uses_release_label():
@@ -154,7 +236,7 @@ def test_unsupported_env_and_context_mismatch_fail_before_mutation():
 def test_status_and_verify_are_read_only():
     script = SCRIPT.read_text(encoding="utf-8")
     status = re.search(r"status\(\).*?\nverify\(", script, re.S).group(0)
-    verify = re.search(r"verify\(\).*?\n\ndashboard_verify\(", script, re.S).group(0)
+    verify = re.search(r"verify\(\).*?\n\npagerduty_test\(", script, re.S).group(0)
     mutating = [
         " helm install",
         " helm upgrade",
@@ -187,6 +269,7 @@ def test_justfile_exposes_observability_recipes():
         "observability-status",
         "observability-verify",
         "observability-dashboard-verify",
+        "observability-pagerduty-test",
     ):
         assert f"{recipe} env=''" in text
         assert f"scripts/observability_helm.sh {recipe.removeprefix('observability-')}" in text
@@ -238,6 +321,7 @@ def run_helper(
     target_response_delay="0",
     retry_attempts="3",
     retry_interval="1",
+    action=None,
 ):
     """Run the lifecycle against deterministic command stubs and return its audit log."""
     bin_dir = tmp_path / "bin"
@@ -253,6 +337,9 @@ case "$*" in
     printf '%s\n' 'apiVersion: v1' 'kind: ConfigMap' 'metadata:' '  name: kube-prometheus-stack-grafana-dashboards-sugarkube' '  labels:' '    dashboard-provider: sugarkube' 'data:' '  sugarkube-staging-observability.json:' '    |-'
     sed 's/^/      /' "$DASHBOARD"
     printf '%s\n' '---' 'kind: ConfigMap' 'data:' '  dashboardproviders.yaml: |' '    providers:' '      - name: sugarkube' '        options:' '          path: /var/lib/grafana/dashboards/sugarkube' '---' 'kind: Deployment' 'spec:' '  template:' '    spec:' '      containers:' '        - volumeMounts:' '            - name: dashboards-sugarkube' '              mountPath: /var/lib/grafana/dashboards/sugarkube/sugarkube-staging-observability.json' '              subPath: sugarkube-staging-observability.json'
+    printf '%s\n' '---' 'apiVersion: monitoring.coreos.com/v1' 'kind: Alertmanager' 'metadata:' '  name: kube-prometheus-stack-alertmanager' 'spec:' '  secrets:' '    - alertmanager-pagerduty'
+    printf '%s\n' '---' 'apiVersion: v1' 'kind: Secret' 'metadata:' '  name: alertmanager-kube-prometheus-stack-alertmanager' 'stringData:' '  alertmanager.yaml: |'
+    sed 's/^/    /' "$ALERTMANAGER_CONFIG"
     exit 0
     ;;
   *list*) [ "$HELM_MODE" != query-fail ] || exit 32; [ "$HELM_MODE" = present ] && echo kube-prometheus-stack; exit 0 ;;
@@ -270,7 +357,11 @@ case "$*" in
   *"get daemonset kube-prometheus-stack-prometheus-node-exporter"*) [ "$KUBECTL_MODE" = two-nodes ] && echo '2 2' || echo '3 3' ;;
   *"get pvc -o json"*) printf '%s\n' '{"items":[{"metadata":{"name":"generated-pvc","labels":{"app.kubernetes.io/name":"prometheus"}},"spec":{"storageClassName":"local-path"},"status":{"phase":"Bound"}}]}' ;;
   *"get prometheus kube-prometheus-stack-prometheus"*) echo 1 ;;
+  *"get alertmanager kube-prometheus-stack-alertmanager -o yaml"*) printf '%s\n' 'apiVersion: monitoring.coreos.com/v1' 'kind: Alertmanager' 'metadata:' '  name: kube-prometheus-stack-alertmanager' 'spec:' '  secrets:' '    - alertmanager-pagerduty' ;;
   *"get alertmanager kube-prometheus-stack-alertmanager"*) echo 1 ;;
+  *"get secret alertmanager-kube-prometheus-stack-alertmanager -o yaml"*) printf '%s\n' 'apiVersion: v1' 'kind: Secret' 'metadata:' '  name: alertmanager-kube-prometheus-stack-alertmanager' 'stringData:' '  alertmanager.yaml: |'; sed 's/^/    /' "$ALERTMANAGER_CONFIG" ;;
+  *"get secret alertmanager-pagerduty -o go-template="*) [ "$KUBECTL_MODE" != missing-pagerduty ] || exit 44; [ "$KUBECTL_MODE" != empty-pagerduty ] && echo present ;;
+  *"create --raw "*"/api/v2/alerts -f -"*) cat > "$ALERT_PAYLOAD"; [ "$KUBECTL_MODE" != api-fail ] ;;
   *"get ingress "*) exit 0 ;;
   *"get svc kube-prometheus-stack-grafana"*) echo 30300 ;;
   *"get servicemonitor dspace"*"metadata.labels.release"*) [ "$KUBECTL_MODE" = wrong-release ] && echo wrong || echo kube-prometheus-stack ;;
@@ -310,12 +401,33 @@ esac
         "TARGET_RESPONSES": "",
         "TARGET_COUNTER": str(tmp_path / "target-counter"),
         "TARGET_RESPONSE_DELAY": target_response_delay,
+        "ALERT_PAYLOAD": str(tmp_path / "alert-payload"),
+        "ALERTMANAGER_CONFIG": str(tmp_path / "alertmanager-config.yaml"),
         "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS": retry_attempts,
         "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS": retry_interval,
         "DASHBOARD": str(
             ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
         ),
     }
+    (tmp_path / "alertmanager-config.yaml").write_text(
+        """route:
+  receiver: "null"
+  routes:
+    - receiver: pagerduty-synthetic-test
+      matchers:
+        - alertname="SugarkubePagerDutyTest"
+        - environment="staging"
+        - cluster="sugarkube-int"
+        - severity="critical"
+receivers:
+  - name: "null"
+  - name: pagerduty-synthetic-test
+    pagerduty_configs:
+      - routing_key_file: /etc/alertmanager/secrets/alertmanager-pagerduty/routing-key
+        send_resolved: true
+""",
+        encoding="utf-8",
+    )
     if target_responses is not None:
         responses = tmp_path / "target-responses"
         if any(isinstance(response, bytes) for response in target_responses):
@@ -330,7 +442,7 @@ esac
             responses.write_text("\n".join(target_responses) + "\n", encoding="utf-8")
         env["TARGET_RESPONSES"] = str(responses)
     result = subprocess.run(
-        ["bash", str(SCRIPT), command, "env=staging"],
+        ["bash", str(SCRIPT), command, "env=staging", *([action] if action is not None else [])],
         text=True,
         capture_output=True,
         env=env,
@@ -381,6 +493,64 @@ def test_install_and_upgrade_require_distinct_release_states(tmp_path):
     assert upgraded.returncode == 0 and "helm upgrade" in audit
     rejected, audit = run_helper(tmp_path / "reject-upgrade", "upgrade", helm_mode="absent")
     assert rejected.returncode != 0 and "helm upgrade" not in audit
+
+
+@pytest.mark.parametrize("mode", ["missing-pagerduty", "empty-pagerduty"])
+@pytest.mark.parametrize(("command", "helm_mode"), [("install", "absent"), ("upgrade", "present")])
+def test_mutation_requires_nonempty_pagerduty_secret_without_exposure(
+    tmp_path, mode, command, helm_mode
+):
+    result, audit = run_helper(tmp_path, command, helm_mode=helm_mode, kubectl_mode=mode)
+    assert result.returncode != 0
+    assert f"helm {command}" not in audit
+    assert "routing-key" in result.stderr
+    assert (
+        "value intentionally not read or printed" in result.stderr
+        or "is absent" in result.stderr
+    )
+
+
+def test_valid_pagerduty_secret_permits_helm_mutation(tmp_path):
+    result, audit = run_helper(tmp_path, "upgrade", helm_mode="present")
+    assert result.returncode == 0
+    assert "helm upgrade" in audit
+    assert "value intentionally not read or printed" in result.stdout
+
+
+def test_pagerduty_test_requires_explicit_action_and_staging(tmp_path):
+    absent, audit = run_helper(tmp_path / "absent", "pagerduty-test")
+    assert absent.returncode != 0 and "create --raw" not in audit
+    invalid, audit = run_helper(tmp_path / "invalid", "pagerduty-test", action="page")
+    assert invalid.returncode != 0 and "create --raw" not in audit
+    production = subprocess.run(
+        ["bash", str(SCRIPT), "pagerduty-test", "env=prod", "fire"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert production.returncode != 0
+
+
+def test_pagerduty_fire_and_resolve_share_labels_and_bound_end_times(tmp_path):
+    fired, fire_audit = run_helper(tmp_path / "fire", "pagerduty-test", action="fire")
+    resolved, resolve_audit = run_helper(tmp_path / "resolve", "pagerduty-test", action="resolve")
+    assert fired.returncode == resolved.returncode == 0
+    assert "create --raw" in fire_audit and "create --raw" in resolve_audit
+    fire = json.loads((tmp_path / "fire" / "alert-payload").read_text())[0]
+    resolve = json.loads((tmp_path / "resolve" / "alert-payload").read_text())[0]
+    expected = {
+        "alertname": "SugarkubePagerDutyTest",
+        "environment": "staging",
+        "cluster": "sugarkube-int",
+        "severity": "critical",
+    }
+    assert fire["labels"] == resolve["labels"] == expected
+    from datetime import datetime
+
+    fire_end = datetime.fromisoformat(fire["endsAt"].replace("Z", "+00:00"))
+    resolve_end = datetime.fromisoformat(resolve["endsAt"].replace("Z", "+00:00"))
+    assert 14 * 60 <= (fire_end - resolve_end).total_seconds() <= 16 * 60
+    assert set(fire["annotations"]) == {"summary", "description", "runbook_url"}
 
 
 def test_status_requires_staging_identity(tmp_path):

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -142,6 +142,8 @@ def rendered_alertmanager_fixture(
     return f"""---
 apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
+metadata:
+  name: kube-prometheus-stack-alertmanager
 spec:
   secrets: [{secret}]
 ---
@@ -167,16 +169,16 @@ stringData:
 
 
 @pytest.mark.parametrize(
-    "kwargs",
+    ("kwargs", "diagnostic"),
     [
-        {"secret": "wrong-secret"},
-        {"path": "/wrong/path"},
-        {"matchers": ['severity="critical"']},
-        {"inline": True},
+        ({"secret": "wrong-secret"}, "must reference only"),
+        ({"path": "/wrong/path"}, "exact mounted routing-key file"),
+        ({"matchers": ['severity="critical"']}, "exact synthetic allowlist"),
+        ({"inline": True}, "inline PagerDuty credentials are forbidden"),
     ],
 )
 def test_alertmanager_validator_rejects_missing_mount_wrong_path_inline_and_broad_route(
-    tmp_path, kwargs
+    tmp_path, kwargs, diagnostic
 ):
     manifest = tmp_path / "rendered.yaml"
     manifest.write_text(rendered_alertmanager_fixture(**kwargs), encoding="utf-8")
@@ -186,8 +188,22 @@ def test_alertmanager_validator_rejects_missing_mount_wrong_path_inline_and_broa
         text=True,
         check=False,
     )
-    assert result.returncode != 0
+    assert result.returncode == 16
+    assert diagnostic in result.stderr
     assert "forbidden-stub" not in result.stderr
+
+
+def test_alertmanager_validator_accepts_valid_rendered_fixture(tmp_path):
+    manifest = tmp_path / "rendered.yaml"
+    manifest.write_text(rendered_alertmanager_fixture(), encoding="utf-8")
+    result = subprocess.run(
+        ["ruby", str(ALERTMANAGER_VALIDATOR), "rendered", str(manifest)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "structure verified" in result.stderr
 
 
 @pytest.mark.parametrize(
@@ -235,37 +251,64 @@ def test_alertmanager_validator_redacts_invalid_base64(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "mutation",
+    ("mutation", "diagnostic"),
     [
-        lambda text: text.replace("kind: Alertmanager", "kind: Alertmanager", 1)
-        + text.split("---\napiVersion: v1", 1)[0],
-        lambda text: text.replace(
-            "      routes:\n        - receiver: pagerduty-synthetic-test",
-            "      routes:\n        - receiver: nested\n          routes:\n            - receiver: pagerduty-synthetic-test",
+        (
+            lambda text: text + text.split("---\napiVersion: v1", 1)[0],
+            "expected exactly one kube-prometheus-stack Alertmanager",
         ),
-        lambda text: text.replace(
-            "    receivers:\n",
-            "    receivers:\n      - name: alternate\n        pagerduty_configs: []\n",
+        (
+            lambda text: text.replace(
+                "      routes:\n        - receiver: pagerduty-synthetic-test",
+                "      routes:\n        - receiver: nested\n          routes:\n            - receiver: pagerduty-synthetic-test",
+            ),
+            "direct child of the root route",
         ),
-        lambda text: text.replace(
-            "            send_resolved: true",
-            "            send_resolved: true\n          - routing_key_file: /another/file",
+        (
+            lambda text: text.replace(
+                "    receivers:\n",
+                "    receivers:\n      - name: alternate\n        pagerduty_configs: []\n",
+            ),
+            "exactly one PagerDuty receiver",
         ),
-        lambda text: text.replace(
-            "            send_resolved: true",
-            "            send_resolved: true\n        continue: false",
+        (
+            lambda text: text.replace(
+                "            send_resolved: true",
+                "            send_resolved: true\n          - routing_key_file: /another/file",
+            ),
+            "exactly one PagerDuty configuration",
         ),
-        lambda text: text.replace(
-            "    receivers:",
-            "    routing_" + "key: forbidden-stub\n    receivers:",
+        (
+            lambda text: text.replace(
+                "            - 'severity=\"critical\"'",
+                "            - 'severity=\"critical\"'\n          continue: false",
+            ),
+            "must not specify continuation",
         ),
-        lambda text: text.replace(
-            "      - name: pagerduty-synthetic-test",
-            "      - name: alternate\n        pagerduty_configs:\n          - service_"
-            + "key: forbidden-stub\n      - name: pagerduty-synthetic-test",
-        ).replace(
-            "      routes:",
-            "      routes:\n        - receiver: alternate\n          matchers: ['severity=~\".*\"']",
+        (
+            lambda text: text.replace(
+                "            - 'severity=\"critical\"'",
+                "            - 'severity=\"critical\"'\n          routes: []",
+            ),
+            "must not contain nested routes",
+        ),
+        (
+            lambda text: text.replace(
+                "    receivers:",
+                "    routing_" + "key: forbidden-stub\n    receivers:",
+            ),
+            "inline PagerDuty credentials are forbidden",
+        ),
+        (
+            lambda text: text.replace(
+                "      - name: pagerduty-synthetic-test",
+                "      - name: alternate\n        pagerduty_configs:\n          - service_"
+                + "key: forbidden-stub\n      - name: pagerduty-synthetic-test",
+            ).replace(
+                "      routes:",
+                "      routes:\n        - receiver: alternate\n          matchers: ['severity=~\".*\"']",
+            ),
+            "inline PagerDuty credentials are forbidden",
         ),
     ],
     ids=[
@@ -274,11 +317,14 @@ def test_alertmanager_validator_redacts_invalid_base64(tmp_path):
         "alternate-receiver",
         "additional-config",
         "continuation",
+        "nested-children",
         "recursive-inline-key",
         "broad-nested-alternate-inline",
     ],
 )
-def test_alertmanager_validator_rejects_deterministic_contract_mutations(tmp_path, mutation):
+def test_alertmanager_validator_rejects_deterministic_contract_mutations(
+    tmp_path, mutation, diagnostic
+):
     manifest = tmp_path / "mutation.yaml"
     manifest.write_text(mutation(rendered_alertmanager_fixture()), encoding="utf-8")
     result = subprocess.run(
@@ -288,6 +334,7 @@ def test_alertmanager_validator_rejects_deterministic_contract_mutations(tmp_pat
         check=False,
     )
     assert result.returncode == 16
+    assert diagnostic in result.stderr
     assert "forbidden-stub" not in result.stderr
 
 

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -73,7 +73,12 @@ def test_chart_version_and_values_match_live_staging_baseline():
             'severity="critical"',
         ],
     }]
-    pagerduty = alertmanager["config"]["receivers"][1]["pagerduty_configs"][0]
+    pagerduty_receiver = next(
+        receiver
+        for receiver in alertmanager["config"]["receivers"]
+        if receiver["name"] == "pagerduty-synthetic-test"
+    )
+    pagerduty = pagerduty_receiver["pagerduty_configs"][0]
     assert pagerduty == {
         "routing_key_file": "/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key",
         "send_resolved": True,
@@ -181,6 +186,30 @@ def test_alertmanager_validator_rejects_missing_mount_wrong_path_inline_and_broa
     )
     assert result.returncode != 0
     assert "forbidden-stub" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        "---\nkind: Alertmanager\nspec: [unterminated\n",
+        rendered_alertmanager_fixture().replace(
+            "alertmanager.yaml: |", "alertmanager.yaml: !!invalid"
+        ),
+    ],
+)
+def test_alertmanager_validator_redacts_malformed_yaml(tmp_path, manifest):
+    path = tmp_path / "malformed.yaml"
+    path.write_text(manifest, encoding="utf-8")
+    result = subprocess.run(
+        ["ruby", str(ALERTMANAGER_VALIDATOR), "rendered", str(path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 16
+    assert "sensitive values not printed" in result.stderr
+    assert "Traceback" not in result.stderr
+    assert "Psych::" not in result.stderr
 
 
 def test_discovery_contract_uses_release_label():
@@ -359,7 +388,10 @@ case "$*" in
   *"get prometheus kube-prometheus-stack-prometheus"*) echo 1 ;;
   *"get alertmanager kube-prometheus-stack-alertmanager -o yaml"*) printf '%s\n' 'apiVersion: monitoring.coreos.com/v1' 'kind: Alertmanager' 'metadata:' '  name: kube-prometheus-stack-alertmanager' 'spec:' '  secrets:' '    - alertmanager-pagerduty' ;;
   *"get alertmanager kube-prometheus-stack-alertmanager"*) echo 1 ;;
-  *"get secret alertmanager-kube-prometheus-stack-alertmanager -o yaml"*) printf '%s\n' 'apiVersion: v1' 'kind: Secret' 'metadata:' '  name: alertmanager-kube-prometheus-stack-alertmanager' 'stringData:' '  alertmanager.yaml: |'; sed 's/^/    /' "$ALERTMANAGER_CONFIG" ;;
+  *"get secret alertmanager-kube-prometheus-stack-alertmanager -o yaml"*)
+    printf '%s\n' 'apiVersion: v1' 'kind: Secret' 'metadata:' '  name: alertmanager-kube-prometheus-stack-alertmanager' 'stringData:' '  alertmanager.yaml: |'
+    [ "$KUBECTL_MODE" != malformed-alertmanager ] && sed 's/^/    /' "$ALERTMANAGER_CONFIG" || printf '%s\n' '    route: [unterminated'
+    ;;
   *"get secret alertmanager-pagerduty -o go-template="*) [ "$KUBECTL_MODE" != missing-pagerduty ] || exit 44; [ "$KUBECTL_MODE" != empty-pagerduty ] && echo present ;;
   *"create --raw "*"/api/v2/alerts -f -"*) cat > "$ALERT_PAYLOAD"; [ "$KUBECTL_MODE" != api-fail ] ;;
   *"get ingress "*) exit 0 ;;
@@ -398,6 +430,7 @@ esac
         "CONTEXT": context,
         "KUBECTL_MODE": kubectl_mode,
         "KUBECONFIG": str(tmp_path / "kubeconfig"),
+        "TMPDIR": str(tmp_path),
         "TARGET_RESPONSES": "",
         "TARGET_COUNTER": str(tmp_path / "target-counter"),
         "TARGET_RESPONSE_DELAY": target_response_delay,
@@ -515,6 +548,22 @@ def test_valid_pagerduty_secret_permits_helm_mutation(tmp_path):
     assert result.returncode == 0
     assert "helm upgrade" in audit
     assert "value intentionally not read or printed" in result.stdout
+
+
+@pytest.mark.parametrize("mode", ["missing-pagerduty", "empty-pagerduty"])
+def test_verify_requires_nonempty_pagerduty_secret_and_cleans_temp_files(tmp_path, mode):
+    result, audit = run_helper(tmp_path, "verify", kubectl_mode=mode)
+    assert result.returncode != 0
+    assert "get secret alertmanager-pagerduty" in audit
+    assert "routing-key" in result.stderr
+    assert not list(tmp_path.glob("sugarkube-alertmanager-*.yaml"))
+
+
+def test_verify_cleans_temp_files_when_live_validator_fails(tmp_path):
+    result, _ = run_helper(tmp_path, "verify", kubectl_mode="malformed-alertmanager")
+    assert result.returncode == 16
+    assert "sensitive values not printed" in result.stderr
+    assert not list(tmp_path.glob("sugarkube-alertmanager-*.yaml"))
 
 
 def test_pagerduty_test_requires_explicit_action_and_staging(tmp_path):

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -64,15 +64,17 @@ def test_chart_version_and_values_match_live_staging_baseline():
     assert alertmanager["alertmanagerSpec"]["secrets"] == ["alertmanager-pagerduty"]
     route = alertmanager["config"]["route"]
     assert route["receiver"] == "null"
-    assert route["routes"] == [{
-        "receiver": "pagerduty-synthetic-test",
-        "matchers": [
-            'alertname="SugarkubePagerDutyTest"',
-            'environment="staging"',
-            'cluster="sugarkube-int"',
-            'severity="critical"',
-        ],
-    }]
+    assert route["routes"] == [
+        {
+            "receiver": "pagerduty-synthetic-test",
+            "matchers": [
+                'alertname="SugarkubePagerDutyTest"',
+                'environment="staging"',
+                'cluster="sugarkube-int"',
+                'severity="critical"',
+            ],
+        }
+    ]
     pagerduty_receiver = next(
         receiver
         for receiver in alertmanager["config"]["receivers"]
@@ -212,6 +214,83 @@ def test_alertmanager_validator_redacts_malformed_yaml(tmp_path, manifest):
     assert "Psych::" not in result.stderr
 
 
+def test_alertmanager_validator_redacts_invalid_base64(tmp_path):
+    manifest = tmp_path / "invalid-base64.yaml"
+    manifest.write_text(
+        rendered_alertmanager_fixture().replace(
+            "stringData:\n  alertmanager.yaml: |\n" + "    route:",
+            "data:\n  alertmanager.yaml: 'not-base64!'\nunused:\n  value: |\n    route:",
+        ),
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        ["ruby", str(ALERTMANAGER_VALIDATOR), "rendered", str(manifest)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 16
+    assert "sensitive values not printed" in result.stderr
+    assert "not-base64" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda text: text.replace("kind: Alertmanager", "kind: Alertmanager", 1)
+        + text.split("---\napiVersion: v1", 1)[0],
+        lambda text: text.replace(
+            "      routes:\n        - receiver: pagerduty-synthetic-test",
+            "      routes:\n        - receiver: nested\n          routes:\n            - receiver: pagerduty-synthetic-test",
+        ),
+        lambda text: text.replace(
+            "    receivers:\n",
+            "    receivers:\n      - name: alternate\n        pagerduty_configs: []\n",
+        ),
+        lambda text: text.replace(
+            "            send_resolved: true",
+            "            send_resolved: true\n          - routing_key_file: /another/file",
+        ),
+        lambda text: text.replace(
+            "            send_resolved: true",
+            "            send_resolved: true\n        continue: false",
+        ),
+        lambda text: text.replace(
+            "    receivers:",
+            "    routing_" + "key: forbidden-stub\n    receivers:",
+        ),
+        lambda text: text.replace(
+            "      - name: pagerduty-synthetic-test",
+            "      - name: alternate\n        pagerduty_configs:\n          - service_"
+            + "key: forbidden-stub\n      - name: pagerduty-synthetic-test",
+        ).replace(
+            "      routes:",
+            "      routes:\n        - receiver: alternate\n          matchers: ['severity=~\".*\"']",
+        ),
+    ],
+    ids=[
+        "duplicate-resource",
+        "nested-route",
+        "alternate-receiver",
+        "additional-config",
+        "continuation",
+        "recursive-inline-key",
+        "broad-nested-alternate-inline",
+    ],
+)
+def test_alertmanager_validator_rejects_deterministic_contract_mutations(tmp_path, mutation):
+    manifest = tmp_path / "mutation.yaml"
+    manifest.write_text(mutation(rendered_alertmanager_fixture()), encoding="utf-8")
+    result = subprocess.run(
+        ["ruby", str(ALERTMANAGER_VALIDATOR), "rendered", str(manifest)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 16
+    assert "forbidden-stub" not in result.stderr
+
+
 def test_discovery_contract_uses_release_label():
     spec = yaml_load(COMMON)["prometheus"]["prometheusSpec"]
     for selector in ("serviceMonitorSelector", "podMonitorSelector", "probeSelector"):
@@ -244,10 +323,12 @@ def test_install_upgrade_are_distinct_and_render_before_mutation():
     install = re.search(r"install_release\(\).*?\nupgrade_release\(", script, re.S).group(0)
     upgrade = re.search(r"upgrade_release\(\).*?\nstatus\(", script, re.S).group(0)
     assert "render_to" in install and "helm install" in install
+    assert install.index("assert_pagerduty_secret") < install.index("render_to")
     assert install.index("render_to") < install.index("helm install")
     assert 'state="$(release_state)"' in install
     assert "already exists" in install
     assert "render_to" in upgrade and "helm upgrade" in upgrade
+    assert upgrade.index("assert_pagerduty_secret") < upgrade.index("render_to")
     assert upgrade.index("render_to") < upgrade.index("helm upgrade")
     assert 'state="$(release_state)"' in upgrade
     assert "requires an existing Helm release" in upgrade
@@ -393,7 +474,7 @@ case "$*" in
     [ "$KUBECTL_MODE" != malformed-alertmanager ] && sed 's/^/    /' "$ALERTMANAGER_CONFIG" || printf '%s\n' '    route: [unterminated'
     ;;
   *"get secret alertmanager-pagerduty -o go-template="*) [ "$KUBECTL_MODE" != missing-pagerduty ] || exit 44; [ "$KUBECTL_MODE" != empty-pagerduty ] && echo present ;;
-  *"create --raw "*"/api/v2/alerts -f -"*) cat > "$ALERT_PAYLOAD"; [ "$KUBECTL_MODE" != api-fail ] ;;
+  *"create --raw "*"/api/v2/alerts -f -"*) cat > "$ALERT_PAYLOAD"; echo response-sentinel; [ "$KUBECTL_MODE" != api-fail ] ;;
   *"get ingress "*) exit 0 ;;
   *"get svc kube-prometheus-stack-grafana"*) echo 30300 ;;
   *"get servicemonitor dspace"*"metadata.labels.release"*) [ "$KUBECTL_MODE" = wrong-release ] && echo wrong || echo kube-prometheus-stack ;;
@@ -536,10 +617,11 @@ def test_mutation_requires_nonempty_pagerduty_secret_without_exposure(
     result, audit = run_helper(tmp_path, command, helm_mode=helm_mode, kubectl_mode=mode)
     assert result.returncode != 0
     assert f"helm {command}" not in audit
+    assert "helm " not in audit
+    assert "forbidden-secret-sentinel" not in result.stdout + result.stderr + audit
     assert "routing-key" in result.stderr
     assert (
-        "value intentionally not read or printed" in result.stderr
-        or "is absent" in result.stderr
+        "value intentionally not read or printed" in result.stderr or "is absent" in result.stderr
     )
 
 
@@ -578,11 +660,17 @@ def test_pagerduty_test_requires_explicit_action_and_staging(tmp_path):
         check=False,
     )
     assert production.returncode != 0
+    mismatch, audit = run_helper(
+        tmp_path / "mismatch", "pagerduty-test", context="other", action="action=fire"
+    )
+    assert mismatch.returncode != 0 and "create --raw" not in audit
 
 
 def test_pagerduty_fire_and_resolve_share_labels_and_bound_end_times(tmp_path):
-    fired, fire_audit = run_helper(tmp_path / "fire", "pagerduty-test", action="fire")
-    resolved, resolve_audit = run_helper(tmp_path / "resolve", "pagerduty-test", action="resolve")
+    fired, fire_audit = run_helper(tmp_path / "fire", "pagerduty-test", action="action=fire")
+    resolved, resolve_audit = run_helper(
+        tmp_path / "resolve", "pagerduty-test", action="action=resolve"
+    )
     assert fired.returncode == resolved.returncode == 0
     assert "create --raw" in fire_audit and "create --raw" in resolve_audit
     fire = json.loads((tmp_path / "fire" / "alert-payload").read_text())[0]
@@ -600,6 +688,24 @@ def test_pagerduty_fire_and_resolve_share_labels_and_bound_end_times(tmp_path):
     resolve_end = datetime.fromisoformat(resolve["endsAt"].replace("Z", "+00:00"))
     assert 14 * 60 <= (fire_end - resolve_end).total_seconds() <= 16 * 60
     assert set(fire["annotations"]) == {"summary", "description", "runbook_url"}
+
+
+@pytest.mark.parametrize("action", ["fire", "resolve"])
+def test_pagerduty_direct_bare_actions_remain_supported(tmp_path, action):
+    result, audit = run_helper(tmp_path, "pagerduty-test", action=action)
+    assert result.returncode == 0 and "create --raw" in audit
+    assert "response-sentinel" not in result.stdout + result.stderr
+    assert not list(tmp_path.glob("sugarkube-alertmanager-response.*"))
+
+
+def test_pagerduty_api_failure_is_redacted_and_cleans_response(tmp_path):
+    result, _ = run_helper(
+        tmp_path, "pagerduty-test", action="action=fire", kubectl_mode="api-fail"
+    )
+    assert result.returncode == 18
+    assert "response redacted" in result.stderr
+    assert "response-sentinel" not in result.stdout + result.stderr
+    assert not list(tmp_path.glob("sugarkube-alertmanager-response.*"))
 
 
 def test_status_requires_staging_identity(tmp_path):


### PR DESCRIPTION
### Motivation
- Add a secret-safe, staging-only PagerDuty receiver foundation that preserves the root no-op `"null"` receiver and does not route the chart’s bundled alerts to PagerDuty. 
- Provide an operator-triggered synthetic `SugarkubePagerDutyTest` alert (bounded fire + explicit resolve) to prove routing and phone delivery without committing credentials. 
- Fail closed before any Helm mutation when the PagerDuty credential Secret/key is missing or empty, while keeping offline rendering and structural validation possible.

### Description
- Values: add staging-only Alertmanager contract in `clusters/staging/observability/kube-prometheus-stack.values.yaml` to reference `monitoring/alertmanager-pagerduty` and route exactly the synthetic matcher to a `pagerduty-synthetic-test` receiver that uses `routing_key_file: /etc/alertmanager/secrets/alertmanager-pagerduty/routing-key` with `send_resolved: true` and keep root `receiver: "null"`.
- Helpers/verification: extend `scripts/observability_helm.sh` to validate rendered Alertmanager structure, assert pre-mutation Secret presence (`assert_pagerduty_secret`), and add a guarded `pagerduty-test` action that submits `fire`/`resolve` to Alertmanager's v2 API via the cluster proxy; the helper requires the `sugar-staging` context before mutation.
- Structural validator: add `scripts/verify_observability_alertmanager.rb` to statically validate rendered or live Alertmanager+Secret bundles (root `null` receiver preserved, exactly one synthetic route, exact secret reference and file path, `send_resolved: true`, and no inline `routing_key`/`service_key`).
- CLI recipe & docs: add `just observability-pagerduty-test env=staging action=fire|resolve` and update `docs/observability-operations.md` and `docs/observability-alerting.md` with a staging runbook that prescribes stdin-based Secret creation/rotation, offline render+validate, upgrade+verify, explicit fire/acknowledge/resolve, rollback safety, and rotation guidance.
- Tests: extend `tests/test_observability_helm.py` with focused stubs that assert the rendered root `null` receiver remains, the exact synthetic matcher reaches PagerDuty, `routing_key_file` usage is present, Secret preflight fails closed when absent/empty, the validator rejects wrong mounts/paths/inline values, and the `pagerduty-test` recipe enforces explicit `fire`/`resolve`, identical labels, and bounded `endsAt` semantics.

Files changed (key items):
- `clusters/staging/observability/kube-prometheus-stack.values.yaml` (add Alertmanager secret mount + synthetic route)
- `scripts/observability_helm.sh` (preflight checks, render-time validator call, `pagerduty-test` action)
- `scripts/verify_observability_alertmanager.rb` (new validator)
- `justfile` (new `observability-pagerduty-test` recipe)
- `docs/observability-operations.md`, `docs/observability-alerting.md` (runbook + clarifications)
- `tests/test_observability_helm.py` (new/updated focused unit tests)

### Testing
- Focused observability tests: `pytest -q tests/test_observability_helm.py -k 'pagerduty or alertmanager_validator or install_and_upgrade'` — all focused tests passed (12 passed).
- PagerDuty recipe tests: `pytest -q tests/test_observability_helm.py::test_pagerduty_fire_and_resolve_share_labels_and_bound_end_times` and related `pagerduty`/`alertmanager_validator` cases — passed under the test harness that uses stubbed `helm`/`kubectl` binaries.
- Rendering/validator and helper checks: `PATH=/tmp/render-bin:$PATH just observability-render env=staging` and `ruby scripts/verify_observability_alertmanager.rb rendered /tmp/kps-rendered.yaml` — both succeeded against the offline rendered manifest.
- Docs & tooling: `bash scripts/checks.sh --docs-only`, `pyspelling -c .spellcheck.yaml`, `linkchecker --no-warnings README.md docs/`, `just --unstable --fmt --check`, `bash -n scripts/observability_helm.sh`, and `ruby -c scripts/verify_observability_alertmanager.rb` — passed for the changed content.
- Secret & scan checks: `git diff --cached --check` and `git diff --cached | ./scripts/scan-secrets.py` — no secrets found in the change set.
- Notes about full repo hooks and environment: a repository-wide `pre-commit run --all-files` indicated pre-existing YAML multi-document and unrelated Flake8 issues elsewhere in the repo (these are existing, unrelated failures and were not introduced by this change). A full `pytest -q` run at scale encountered environment limitations (missing `helm` on PATH) that caused an unrelated test to fail; rerunning the affected test(s) with `helm` available passed.

Manual post-merge operator steps (summary):
- Select staging kubeconfig: `just kubeconfig-env env=staging`.
- Create/rotate the Secret interactively (stdin-based, hidden read):
  ```bash
  read -r -s -p 'PagerDuty routing key: ' PAGERDUTY_ROUTING_KEY; printf '\n'
  printf %s "$PAGERDUTY_ROUTING_KEY" | \
    kubectl -n monitoring create secret generic alertmanager-pagerduty \
      --from-file=routing-key=/dev/stdin --dry-run=client -o yaml | kubectl apply -f -
  unset PAGERDUTY_ROUTING_KEY
  ```
- Offline render + validate: `just observability-render env=staging >/tmp/kps-rendered.yaml` then `ruby scripts/verify_observability_alertmanager.rb rendered /tmp/kps-rendered.yaml`.
- Upgrade and verify: `just observability-upgrade env=staging` then `just observability-verify env=staging`.
- Fire and resolve the synthetic alert (manual confirmation in PagerDuty required):
  - Fire: `just observability-pagerduty-test env=staging action=fire`
  - Resolve: `just observability-pagerduty-test env=staging action=resolve`
- If rollback is required, keep the Secret present while rolling back a Helm revision (deleting the Secret before rollback can prevent Alertmanager from starting).

Safety confirmation: no credential was committed, no credential value was read/printed/hashed/exposed by tests or helpers, no live PagerDuty alert was sent from this environment, and no Helm or Kubernetes mutation was performed by the automated runs in this workspace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a682f11a734832faeb662ef2325f5ee)