### PR TITLE
Stop standard upgrades from inheriting historical Helm values

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -58,10 +58,17 @@ Standard app paths perform exactly one render. DSPACE orders manifest validation
 digest resolution, render and validation, evidence reservation, Helm mutation, and
 evidence finalization; no render occurs after reservation.
 
-Upgrade currently retains `--reuse-values`. Therefore this gate validates the
-repository-controlled proposed inputs but does not claim to reproduce Helm's
-historical value merge. Removing `--reuse-values` remains the explicit follow-up in
-issue #2324. This PR deliberately does not change or remove `--reuse-values`.
+Standard upgrades do not use `--reuse-values`. Helm therefore starts with the new
+chart's defaults and overlays only the complete, ordered Git-controlled values-file
+chain plus the configured host, immutable branch-SHA image tag, and current image
+pull policy. With the repository's supported Helm 3.18 tooling, ordinary
+`helm upgrade` resets to the new chart defaults when new `-f`/`--set` values are
+supplied. Every standard helper supplies those explicit inputs, so adding
+`--reset-values` would be redundant. Preflight and mutation now have identical
+release-defining inputs. Helm release history is evidence and rollback metadata, not
+desired-state configuration. Before upgrading, migrate every intentional setting
+into reviewed values files or an established existing-Secret reference rather than
+relying on a historical inline value.
 
 ### DSPACE recovery exception
 

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -379,8 +379,12 @@ manifest validation and digest resolution, one exact-release render and structur
 validation, evidence reservation, Helm mutation, then evidence finalization. No
 render occurs after reservation. A render or validation failure is terminal and
 creates no reservation, Helm mutation, Kubernetes rollout call, or final evidence.
-Steady-state upgrade still uses `--reuse-values`; removing it is explicitly deferred
-to #2324 and is not part of this change.
+Steady-state upgrades do not use `--reuse-values`: the new chart defaults, complete
+ordered Git-controlled environment values chain, configured host, immutable image
+tag, and pull policy are authoritative for both preflight and mutation. Helm history
+remains evidence and rollback metadata, not desired-state configuration. Move any
+intentional historical or inline setting into reviewed values files or an established
+existing-Secret reference before upgrading.
 
 After atomically reserving the unique evidence destination, the operation uses
 `helm upgrade` with the approved chart digest, complete values chain, and an

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -818,8 +818,9 @@ just dspace-oci-redeploy env=prod tag="$(read_prod_tag)"
 ```
 
 Under the hood, both commands call the shared `_helm-oci-deploy` helper via
-`helm-oci-upgrade`, performing `helm upgrade --reuse-values` against the running release
-and then forcing a `kubectl rollout restart deploy/dspace` to ensure pods recycle. The helper waits for the rollout to
+`helm-oci-upgrade`, performing `helm upgrade` with the new chart defaults and complete
+ordered environment values chain rather than historical release values, and then
+forcing a `kubectl rollout restart deploy/dspace` to ensure pods recycle. The helper waits for the rollout to
 finish and exits non-zero if Kubernetes reports a failure.
 
 For immutable RC/stable validation (recommended for staging and prod), use the dedicated

--- a/docs/raspi_cluster_operations_manual.md
+++ b/docs/raspi_cluster_operations_manual.md
@@ -325,9 +325,9 @@ Kustomizations you referenced in `gotk-sync.yaml`.
 - **Scale workloads:** `sudo kubectl scale deployment <name> --replicas=3 -n <ns>`.
 - **Inspect logs:** `sudo kubectl logs <pod> -n <ns>` (use `-c` for multi-container
   pods).
-- **Override Helm values temporarily:** run `helm upgrade <release> <chart> \
-  --namespace <ns> --reuse-values --set key=value` and confirm the change with
-  `sudo kubectl get deployment -n <ns>`.
+- **Change Helm values:** commit the intended setting to the app's complete
+  environment values chain, review it, and use the standard app upgrade recipe.
+  Do not preserve an unreviewed inline override through release history.
 - **Heal a bad join:** `just wipe` remains the fastest way to reset a node
   before re-running `just ha3 env=dev`, but you can also remove k3s manually by
   following the official uninstall script from `/usr/local/bin/k3s-uninstall.sh`.

--- a/justfile
+++ b/justfile
@@ -1218,7 +1218,7 @@ cf-tunnel-route host='':
         '' \
         'Dashboard steps are documented in docs/cloudflare_tunnel.md.'
 
-_helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='' description='' app='' allow_install='false' reuse_values='false' mutation_marker='' preflight_complete='false':
+_helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='' description='' app='' allow_install='false' mutation_marker='' preflight_complete='false':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1352,7 +1352,6 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     fi
 
     allow_install="$(normalize_prefixed_value allow_install "{{ allow_install }}")"
-    reuse_values="$(normalize_prefixed_value reuse_values "{{ reuse_values }}")"
 
     if [ -z "${release}" ] || [ -z "${namespace}" ] || [ -z "${chart}" ]; then
         echo "Set release, namespace, and chart to deploy." >&2
@@ -1634,10 +1633,6 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
         helm_args+=(--install --create-namespace)
     fi
 
-    if [ "${reuse_values}" = "true" ]; then
-        helm_args+=(--reuse-values)
-    fi
-
     if [ ${#value_args[@]} -gt 0 ]; then
         helm_args+=("${value_args[@]}")
     fi
@@ -1659,10 +1654,10 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     wait_for_rollouts
 
 helm-oci-install release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='' description='' app='':
-    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' '{{ env }}' '{{ description }}' '{{ app }}' allow_install='true' reuse_values='false'
+    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' '{{ env }}' '{{ description }}' '{{ app }}' allow_install='true'
 
 helm-oci-upgrade release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='' description='' app='':
-    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' '{{ env }}' '{{ description }}' '{{ app }}' allow_install='false' reuse_values='true'
+    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' '{{ env }}' '{{ description }}' '{{ app }}' allow_install='false'
 
 # Print resolved Sugarkube app deployment config for an app/environment.
 app-config app env='staging' config='':
@@ -1751,7 +1746,7 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
       "${SUGARKUBE_RELEASE}" "${SUGARKUBE_NAMESPACE}" "${chart_coordinate:-${SUGARKUBE_CHART}}" \
       "${SUGARKUBE_VALUES}" '' "${SUGARKUBE_VERSION:-}" "${SUGARKUBE_VERSION_FILE:-}" \
       "${SUGARKUBE_TAG}" '' "${SUGARKUBE_ENV}" "${helm_description:-}" "${SUGARKUBE_APP}" \
-      true false "${mutation_marker:-}" true; then
+      true "${mutation_marker:-}" true; then
       if [ -n "${evidence_reservation:-}" ] && [ ! -e "${mutation_marker}" ]; then
         rm -f "$(realpath -m "${evidence_output}").reservation"
       fi
@@ -1818,7 +1813,7 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
       "${SUGARKUBE_RELEASE}" "${SUGARKUBE_NAMESPACE}" "${chart_coordinate:-${SUGARKUBE_CHART}}" \
       "${SUGARKUBE_VALUES}" '' "${SUGARKUBE_VERSION:-}" "${SUGARKUBE_VERSION_FILE:-}" \
       "${SUGARKUBE_TAG}" '' "${SUGARKUBE_ENV}" "${helm_description:-}" "${SUGARKUBE_APP}" \
-      false true "${mutation_marker:-}" true; then
+      false "${mutation_marker:-}" true; then
       if [ -n "${evidence_reservation:-}" ] && [ ! -e "${mutation_marker}" ]; then
         rm -f "$(realpath -m "${evidence_output}").reservation"
       fi

--- a/scripts/test-helm-oci-install.sh
+++ b/scripts/test-helm-oci-install.sh
@@ -352,7 +352,8 @@ upgrade_output="$(
         version_file=version_file=docs/apps/dspace.version default_tag=v3-deadbee host=staging.democratized.space env=staging app=dspace
 )"
 
-if ! grep -q "helm upgrade dspace oci://registry.test/charts/dspace --namespace dspace --reuse-values" <<<"${upgrade_output}"; then
+if ! grep -q "helm upgrade dspace oci://registry.test/charts/dspace --namespace dspace" <<<"${upgrade_output}" || \
+    grep -q -- "--reuse-values" <<<"${upgrade_output}"; then
     printf 'Upgrade path did not preserve expected behavior and argument normalization.\nOutput:\n%s\n' "${upgrade_output}" >&2
     exit 1
 fi

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1981,6 +1981,15 @@ def test_app_deploy_danielsmith_passes_image_tag(generic_app_stub_env: dict[str,
                 "docs/examples/jobbot3000.values.staging.yaml",
             ],
         ),
+        (
+            "danielsmith",
+            "oci://ghcr.io/futuroptimist/charts/danielsmith",
+            "danielsmith",
+            [
+                "docs/examples/danielsmith.values.dev.yaml",
+                "docs/examples/danielsmith.values.staging.yaml",
+            ],
+        ),
     ],
 )
 def test_app_deploy_uses_app_release_namespace_chart_values(
@@ -1999,8 +2008,11 @@ def test_app_deploy_uses_app_release_namespace_chart_values(
     helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
     assert f"upgrade {app} {chart}" in helm_log
     assert f"--namespace {namespace}" in helm_log
-    for value in values:
-        assert f"-f {value}" in helm_log
+    mutation = next(line for line in helm_log.splitlines() if line.startswith("upgrade "))
+    assert [mutation.index(f"-f {value}") for value in values] == sorted(
+        mutation.index(f"-f {value}") for value in values
+    )
+    assert "--reuse-values" not in mutation
     if app == "tokenplace":
         assert (
             "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.3" in helm_log
@@ -2078,6 +2090,7 @@ def test_app_redeploy_prints_chart_pin_reminder_without_latest_lookup_or_pin_mut
     assert "upgrade tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace" in helm_log
     assert "--version 0.1.3" in helm_log
     assert "--version 9.9.9" not in helm_log
+    assert "--reuse-values" not in helm_log
 
 
 @pytest.mark.usefixtures("ensure_just_available")
@@ -2302,8 +2315,26 @@ def test_dspace_guarded_deploy_orders_preflight_mutation_and_finalization(
     assert coordinate in installed["details"]
     helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
     mutation_line = next(line for line in helm_log.splitlines() if line.startswith("upgrade "))
+    template_line = next(line for line in helm_log.splitlines() if line.startswith("template "))
     assert coordinate in mutation_line
     assert "--version" not in mutation_line
+    assert "--reuse-values" not in mutation_line
+    for defining_input in (
+        coordinate,
+        "--namespace dspace",
+        "-f docs/examples/dspace.values.dev.yaml",
+        "-f docs/examples/dspace.values.staging.yaml",
+        "--set image.tag=main-abcdef0",
+        "--set image.pullPolicy=Always",
+    ):
+        assert defining_input in template_line
+        assert defining_input in mutation_line
+    assert template_line.index("dspace.values.dev.yaml") < template_line.index(
+        "dspace.values.staging.yaml"
+    )
+    assert mutation_line.index("dspace.values.dev.yaml") < mutation_line.index(
+        "dspace.values.staging.yaml"
+    )
     assert "--description sugarkube-release-manifest:" in mutation_line
     commands = (tmp_path / "commands.log").read_text(encoding="utf-8").splitlines()
     preflight = next(i for i, line in enumerate(commands) if line.startswith("oras "))
@@ -2382,7 +2413,17 @@ def test_dspace_guarded_redeploy_installs_approved_chart_digest(
     )
     assert coordinate in mutation_line
     assert "--version" not in mutation_line
+    assert "--reuse-values" not in mutation_line
     assert "--description sugarkube-release-manifest:" in mutation_line
+
+
+def test_standard_helm_helper_cannot_restore_historical_value_inheritance() -> None:
+    justfile = (REPO_ROOT / "justfile").read_text(encoding="utf-8")
+    helper = justfile.split("_helm-oci-deploy ", 1)[1].split("\nhelm-oci-install ", 1)[0]
+
+    assert "reuse_values" not in helper
+    assert "--reuse-values" not in helper
+    assert "--reset-then-reuse-values" not in helper
 
 
 @pytest.mark.usefixtures("ensure_just_available")
@@ -3884,6 +3925,54 @@ def test_direct_helm_oci_helper_matching_env_succeeds(
     assert "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.3" in helm_log
     assert "upgrade tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace" in helm_log
     assert "--description" not in helm_log
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize("recipe", ["helm-oci-install", "helm-oci-upgrade"])
+def test_semver_helm_helpers_render_and_mutate_with_identical_release_inputs(
+    recipe: str, generic_app_stub_env: dict[str, str]
+) -> None:
+    result = _run_just(
+        [
+            recipe,
+            "release=tokenplace",
+            "namespace=tokenplace",
+            "chart=oci://ghcr.io/futuroptimist/charts/tokenplace",
+            "values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml",
+            "host=staging.token.place",
+            "version=0.1.3",
+            "tag=main-deadbee",
+            "env=staging",
+            "app=tokenplace",
+        ],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    lines = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8").splitlines()
+    template = next(line for line in lines if line.startswith("template "))
+    mutation = next(line for line in lines if line.startswith("upgrade "))
+    defining_inputs = (
+        "tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace",
+        "--namespace tokenplace",
+        "--version 0.1.3",
+        "-f docs/examples/tokenplace.values.dev.yaml",
+        "-f docs/examples/tokenplace.values.staging.yaml",
+        "--set ingress.host=staging.token.place",
+        "--set image.tag=main-deadbee",
+        "--set image.pullPolicy=Always",
+    )
+    for defining_input in defining_inputs:
+        assert defining_input in template
+        assert defining_input in mutation
+    assert template.index("tokenplace.values.dev.yaml") < template.index(
+        "tokenplace.values.staging.yaml"
+    )
+    assert mutation.index("tokenplace.values.dev.yaml") < mutation.index(
+        "tokenplace.values.staging.yaml"
+    )
+    assert "--reuse-values" not in mutation
+    assert ("--install" in mutation) is (recipe == "helm-oci-install")
 
 
 @pytest.mark.usefixtures("ensure_just_available")


### PR DESCRIPTION
### Motivation

- Close #2324 and address the incident described in https://github.com/democratizedspace/dspace/pull/4723 by preventing historical release values from quietly surviving standard upgrades. 
- Make the chart defaults plus the complete, ordered Git-controlled values-file chain and explicit immutable image coordinates authoritative for every standard upgrade path.

### Description

- Remove the `reuse_values` parameter and all conditional `--reuse-values` logic from the shared helper `_helm-oci-deploy` and make `helm-oci-upgrade`, `app-redeploy`, `app-deploy`, DSPACE/token.place/danielsmith.io/jobbot3000 wrappers incapable of adding `--reuse-values` (changes primarily in `justfile`).
- Ensure Helm receives the chart defaults, the ordered `-f` values chain, host overrides, the explicit branch-SHA image tag, the image pull policy, and either the exact semver version or a digest-qualified chart coordinate without `--version` (preserve install-vs-upgrade checks, DSPACE evidence ordering, rollout handling, and digest semantics).
- Add/adjust hermetic tests to assert: `--reuse-values` is never emitted by standard helpers, the ordered `-f` chain is preserved, `helm template` and `helm upgrade` use identical release-defining inputs (semantic and digest-qualified cases), and cover DSPACE, token.place, danielsmith.io, and jobbot3000 paths (changes in `tests/test_generic_app_just_recipes.py` and related test harnesses).
- Update deployment documentation to state the new authoritative-value contract and explicitly document that `--reuse-values` is not used by standard upgrades and that `--reset-values` was intentionally omitted because Helm 3.18 semantics plus explicit `-f`/`--set` inputs already provide the desired reset-to-default behavior (docs changed in `docs/app_deployment_contract.md`, `docs/apps/dspace.md`, `docs/raspi_cluster_operations*.md`).
- Small test harness tweak to `scripts/test-helm-oci-install.sh` to assert absence of `--reuse-values` in upgrade logs.

### Testing

- Ran unit/integration tests with `python3 -m pytest -q tests/test_generic_app_just_recipes.py tests/test_app_config.py tests/test_release_manifest.py tests/test_manifest_rollback.py`, resulting in all targeted tests passing (417 passed).
- Ran the Helm helper smoke script with `bash scripts/test-helm-oci-install.sh`, which passed for the adjusted assertions.
- Ran formatting/recipe checks with `just --unstable --fmt --check` and verified the `justfile` changes are well-formed for the new helper signature.
- Verified docs and link/spelling checks with `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` (both completed successfully in this environment) and scanned the tree with `rg` to ensure no remaining standard helper reintroduces `--reuse-values` (`rg -n -- '--reuse-values|reuse_values|reset-then-reuse-values' justfile scripts tests docs` returned only negative-assertion/documentation occurrences).
- Ran repository checks: `git diff --check`, `git diff | ./scripts/scan-secrets.py`, and `git diff --cached | ./scripts/scan-secrets.py` with no focused-change secrets detected.
- Note: `pre-commit run --all-files` was attempted but the repo contains unrelated, pre-existing linter/YAML check failures outside the narrow scope of this change; these are not introduced by this PR and do not block the focused behavior change implemented here.

This change contains no live deployments, no registry/login/credential changes, and does not move or commit any secret material; it implements the authoritative-value contract and closes #2324.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a684c74f210832fb676c4dc221b125f)