### PR TITLE
Stop inheriting historical Helm values on app upgrades

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -58,10 +58,20 @@ Standard app paths perform exactly one render. DSPACE orders manifest validation
 digest resolution, render and validation, evidence reservation, Helm mutation, and
 evidence finalization; no render occurs after reservation.
 
-Upgrade currently retains `--reuse-values`. Therefore this gate validates the
-repository-controlled proposed inputs but does not claim to reproduce Helm's
-historical value merge. Removing `--reuse-values` remains the explicit follow-up in
-issue #2324. This PR deliberately does not change or remove `--reuse-values`.
+Standard upgrades do not use `--reuse-values`. Ordinary `helm upgrade` starts with
+the proposed chart's defaults, then the helper overlays the complete ordered,
+Git-controlled environment values chain, configured host, immutable branch-SHA
+image tag, and current pull policy. Helm's documented default behavior already
+provides this reset-to-new-chart-defaults contract, so the helper intentionally
+does not add `--reset-values`. The successful preflight and mutation consequently
+have identical release-defining inputs; only mutation metadata and rollout handling
+differ.
+
+Helm release history is evidence and rollback metadata, not desired-state
+configuration. Before upgrading, operators must migrate every intentional inline
+or historical setting into reviewed values files or an established existing-Secret
+reference. Standard paths never read release values or history to reconstruct
+configuration and never silently retain historical values.
 
 ### DSPACE recovery exception
 

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -379,8 +379,12 @@ manifest validation and digest resolution, one exact-release render and structur
 validation, evidence reservation, Helm mutation, then evidence finalization. No
 render occurs after reservation. A render or validation failure is terminal and
 creates no reservation, Helm mutation, Kubernetes rollout call, or final evidence.
-Steady-state upgrade still uses `--reuse-values`; removing it is explicitly deferred
-to #2324 and is not part of this change.
+Steady-state upgrades do not use `--reuse-values`: the new chart defaults plus the
+complete ordered Git-controlled environment values chain, host override, immutable
+image tag, and pull policy are authoritative for both preflight and mutation. Helm
+history remains evidence and rollback metadata, not desired-state configuration.
+Move any intentional historical or inline configuration into reviewed values files
+or an established existing-Secret reference before upgrading.
 
 After atomically reserving the unique evidence destination, the operation uses
 `helm upgrade` with the approved chart digest, complete values chain, and an

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -818,8 +818,9 @@ just dspace-oci-redeploy env=prod tag="$(read_prod_tag)"
 ```
 
 Under the hood, both commands call the shared `_helm-oci-deploy` helper via
-`helm-oci-upgrade`, performing `helm upgrade --reuse-values` against the running release
-and then forcing a `kubectl rollout restart deploy/dspace` to ensure pods recycle. The helper waits for the rollout to
+`helm-oci-upgrade`, performing `helm upgrade` with the new chart defaults and complete
+ordered Git-controlled environment values chain against the running release, then forcing a
+`kubectl rollout restart deploy/dspace` to ensure pods recycle. The helper waits for the rollout to
 finish and exits non-zero if Kubernetes reports a failure.
 
 For immutable RC/stable validation (recommended for staging and prod), use the dedicated

--- a/docs/raspi_cluster_operations_manual.md
+++ b/docs/raspi_cluster_operations_manual.md
@@ -325,9 +325,11 @@ Kustomizations you referenced in `gotk-sync.yaml`.
 - **Scale workloads:** `sudo kubectl scale deployment <name> --replicas=3 -n <ns>`.
 - **Inspect logs:** `sudo kubectl logs <pod> -n <ns>` (use `-c` for multi-container
   pods).
-- **Override Helm values temporarily:** run `helm upgrade <release> <chart> \
-  --namespace <ns> --reuse-values --set key=value` and confirm the change with
-  `sudo kubectl get deployment -n <ns>`.
+- **Change application Helm values:** commit the intended setting to the complete
+  environment values chain (or use the chart's established existing-Secret
+  reference), review it, and run the app's standard upgrade recipe. Do not create
+  temporary release-history configuration with `--reuse-values`; the next standard
+  upgrade intentionally replaces it with Git-controlled desired state.
 - **Heal a bad join:** `just wipe` remains the fastest way to reset a node
   before re-running `just ha3 env=dev`, but you can also remove k3s manually by
   following the official uninstall script from `/usr/local/bin/k3s-uninstall.sh`.

--- a/justfile
+++ b/justfile
@@ -1218,7 +1218,7 @@ cf-tunnel-route host='':
         '' \
         'Dashboard steps are documented in docs/cloudflare_tunnel.md.'
 
-_helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='' description='' app='' allow_install='false' reuse_values='false' mutation_marker='' preflight_complete='false':
+_helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='' description='' app='' allow_install='false' mutation_marker='' preflight_complete='false':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1352,7 +1352,6 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     fi
 
     allow_install="$(normalize_prefixed_value allow_install "{{ allow_install }}")"
-    reuse_values="$(normalize_prefixed_value reuse_values "{{ reuse_values }}")"
 
     if [ -z "${release}" ] || [ -z "${namespace}" ] || [ -z "${chart}" ]; then
         echo "Set release, namespace, and chart to deploy." >&2
@@ -1634,10 +1633,6 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
         helm_args+=(--install --create-namespace)
     fi
 
-    if [ "${reuse_values}" = "true" ]; then
-        helm_args+=(--reuse-values)
-    fi
-
     if [ ${#value_args[@]} -gt 0 ]; then
         helm_args+=("${value_args[@]}")
     fi
@@ -1659,10 +1654,10 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     wait_for_rollouts
 
 helm-oci-install release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='' description='' app='':
-    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' '{{ env }}' '{{ description }}' '{{ app }}' allow_install='true' reuse_values='false'
+    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' '{{ env }}' '{{ description }}' '{{ app }}' allow_install='true'
 
 helm-oci-upgrade release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='' description='' app='':
-    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' '{{ env }}' '{{ description }}' '{{ app }}' allow_install='false' reuse_values='true'
+    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' '{{ env }}' '{{ description }}' '{{ app }}' allow_install='false'
 
 # Print resolved Sugarkube app deployment config for an app/environment.
 app-config app env='staging' config='':
@@ -1751,7 +1746,7 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
       "${SUGARKUBE_RELEASE}" "${SUGARKUBE_NAMESPACE}" "${chart_coordinate:-${SUGARKUBE_CHART}}" \
       "${SUGARKUBE_VALUES}" '' "${SUGARKUBE_VERSION:-}" "${SUGARKUBE_VERSION_FILE:-}" \
       "${SUGARKUBE_TAG}" '' "${SUGARKUBE_ENV}" "${helm_description:-}" "${SUGARKUBE_APP}" \
-      true false "${mutation_marker:-}" true; then
+      true "${mutation_marker:-}" true; then
       if [ -n "${evidence_reservation:-}" ] && [ ! -e "${mutation_marker}" ]; then
         rm -f "$(realpath -m "${evidence_output}").reservation"
       fi
@@ -1818,7 +1813,7 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
       "${SUGARKUBE_RELEASE}" "${SUGARKUBE_NAMESPACE}" "${chart_coordinate:-${SUGARKUBE_CHART}}" \
       "${SUGARKUBE_VALUES}" '' "${SUGARKUBE_VERSION:-}" "${SUGARKUBE_VERSION_FILE:-}" \
       "${SUGARKUBE_TAG}" '' "${SUGARKUBE_ENV}" "${helm_description:-}" "${SUGARKUBE_APP}" \
-      false true "${mutation_marker:-}" true; then
+      false "${mutation_marker:-}" true; then
       if [ -n "${evidence_reservation:-}" ] && [ ! -e "${mutation_marker}" ]; then
         rm -f "$(realpath -m "${evidence_output}").reservation"
       fi

--- a/scripts/test-helm-oci-install.sh
+++ b/scripts/test-helm-oci-install.sh
@@ -352,8 +352,12 @@ upgrade_output="$(
         version_file=version_file=docs/apps/dspace.version default_tag=v3-deadbee host=staging.democratized.space env=staging app=dspace
 )"
 
-if ! grep -q "helm upgrade dspace oci://registry.test/charts/dspace --namespace dspace --reuse-values" <<<"${upgrade_output}"; then
+if ! grep -q "helm upgrade dspace oci://registry.test/charts/dspace --namespace dspace" <<<"${upgrade_output}"; then
     printf 'Upgrade path did not preserve expected behavior and argument normalization.\nOutput:\n%s\n' "${upgrade_output}" >&2
+    exit 1
+fi
+if grep -q -- '--reuse-values' <<<"${upgrade_output}"; then
+    printf 'Standard upgrade unexpectedly inherited historical Helm values.\nOutput:\n%s\n' "${upgrade_output}" >&2
     exit 1
 fi
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2081,6 +2081,42 @@ def test_app_redeploy_prints_chart_pin_reminder_without_latest_lookup_or_pin_mut
 
 
 @pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize("app", ["tokenplace", "danielsmith", "jobbot3000"])
+def test_standard_app_redeploys_use_authoritative_ordered_values_without_history(
+    app: str, generic_app_stub_env: dict[str, str]
+) -> None:
+    result = _run_just(
+        ["app-redeploy", f"app={app}", "env=staging", "tag=main-deadbee"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    lines = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8").splitlines()
+    template = next(line for line in lines if line.startswith(f"template {app} "))
+    upgrade = next(line for line in lines if line.startswith(f"upgrade {app} "))
+    expected_values = [
+        f"docs/examples/{app}.values.dev.yaml",
+        f"docs/examples/{app}.values.staging.yaml",
+    ]
+    for command in (template, upgrade):
+        assert command.index(f"-f {expected_values[0]}") < command.index(
+            f"-f {expected_values[1]}"
+        )
+        assert "--set image.tag=main-deadbee" in command
+        assert "--set image.pullPolicy=Always" in command
+        assert "--reuse-values" not in command
+
+
+def test_standard_helm_helper_has_no_historical_value_inheritance_switch() -> None:
+    justfile = (REPO_ROOT / "justfile").read_text(encoding="utf-8")
+    helper = justfile.split("_helm-oci-deploy ", 1)[1].split("\nhelm-oci-install ", 1)[0]
+
+    assert "reuse_values" not in helper
+    assert "--reuse-values" not in helper
+    assert "--reset-then-reuse-values" not in helper
+
+
+@pytest.mark.usefixtures("ensure_just_available")
 @pytest.mark.parametrize(
     ("app", "release", "namespace", "chart"),
     [
@@ -3887,6 +3923,51 @@ def test_direct_helm_oci_helper_matching_env_succeeds(
 
 
 @pytest.mark.usefixtures("ensure_just_available")
+def test_semver_upgrade_render_and_mutation_have_identical_release_inputs(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    chart = "oci://ghcr.io/futuroptimist/charts/tokenplace"
+    values = (
+        "docs/examples/tokenplace.values.dev.yaml,"
+        "docs/examples/tokenplace.values.staging.yaml"
+    )
+    result = _run_just(
+        [
+            "helm-oci-upgrade",
+            "release=tokenplace",
+            "namespace=tokenplace",
+            f"chart={chart}",
+            f"values={values}",
+            "host=staging.token.place",
+            "version=0.1.3",
+            "tag=main-deadbee",
+            "env=staging",
+        ],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    lines = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8").splitlines()
+    render = next(line for line in lines if line.startswith("template tokenplace "))
+    mutation = next(line for line in lines if line.startswith("upgrade tokenplace "))
+    release_inputs = [
+        chart,
+        "--namespace tokenplace",
+        "-f docs/examples/tokenplace.values.dev.yaml",
+        "-f docs/examples/tokenplace.values.staging.yaml",
+        "--set ingress.host=staging.token.place",
+        "--set image.tag=main-deadbee",
+        "--set image.pullPolicy=Always",
+        "--version 0.1.3",
+    ]
+    for command in (render, mutation):
+        for value in release_inputs:
+            assert value in command
+        assert command.index(release_inputs[2]) < command.index(release_inputs[3])
+    assert "--reuse-values" not in mutation
+
+
+@pytest.mark.usefixtures("ensure_just_available")
 @pytest.mark.parametrize("recipe", ["helm-oci-install", "helm-oci-upgrade"])
 def test_public_helm_helper_rejects_mutation_marker_without_altering_file(
     recipe: str, tmp_path: Path, generic_app_stub_env: dict[str, str]
@@ -3940,9 +4021,14 @@ def test_direct_helm_oci_helper_uses_digest_coordinate_without_version(
     assert result.returncode == 0, result.stderr + result.stdout
     lines = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8").splitlines()
     assert f"show chart {coordinate}" in lines
+    render = next(line for line in lines if line.startswith("template "))
     mutation = next(line for line in lines if line.startswith("upgrade "))
-    assert coordinate in mutation
-    assert "--version" not in mutation
+    for command in (render, mutation):
+        assert coordinate in command
+        assert "--version" not in command
+        assert "--set image.tag=main-deadbee" in command
+        assert "--set image.pullPolicy=Always" in command
+    assert "--reuse-values" not in mutation
 
 
 @pytest.mark.usefixtures("ensure_just_available")


### PR DESCRIPTION
### Motivation

- Historical Helm value inheritance via `--reuse-values` made Helm release history an unintended desired-state input; standard upgrades must instead be driven by chart defaults plus the repository-controlled values chain and immutable image tags (Closes #2324). 
- Preserve DSPACE exact-release preflight/evidence ordering and avoid broad rollback redesign while removing the accidental historical-value merge from standard upgrade paths.

### Description

- Remove the `reuse_values` parameter and all `--reuse-values` branching from the shared `_helm-oci-deploy` helper and its callers so standard install/upgrade wrappers cannot add `--reuse-values` anymore (edited `justfile`).
- Make Helm inputs explicit for preflight and mutation: chart coordinate/version semantics, the ordered `-f` values chain, host override, immutable branch-SHA `image.tag`, and `image.pullPolicy` are passed to both `helm template` (preflight) and `helm upgrade` (mutation) unchanged, preserving render/mutation parity and DSPACE evidence ordering (no change to DSPACE manifest rollback behavior).
- Update docs to state the authoritative desired-state contract and to explain why `--reset-values` was intentionally omitted (ordinary Helm upgrade semantics already achieve the reset-to-new-chart-defaults contract when `--reuse-values` is absent): updated `docs/app_deployment_contract.md`, `docs/apps/dspace.md`, `docs/raspi_cluster_operations.md`, and `docs/raspi_cluster_operations_manual.md`.
- Add regression tests and assertions preventing accidental return of historical-value switches and proving the ordered values chain, absence of `--reuse-values`, and render/mutation parity for both semver and digest-qualified charts (tests in `tests/test_generic_app_just_recipes.py`); small test harness tweak in `scripts/test-helm-oci-install.sh` to assert `--reuse-values` is not emitted.

### Testing

- Ran the parametric Justfile checks and unit/integration tests: `just --unstable --fmt --check` — passed.
- Ran the Python test suite for the modified areas: `python3 -m pytest -q tests/test_generic_app_just_recipes.py tests/test_app_config.py tests/test_release_manifest.py tests/test_manifest_rollback.py` — all relevant tests passed (`418 passed` in the CI run performed here).
- Exercised the Helm OCI install/upgrade script tests: `bash scripts/test-helm-oci-install.sh` — passed and includes an assertion that `--reuse-values` is not emitted during standard upgrades.
- Ran docs verification: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` — passed; `pre-commit run --all-files` was executed but flagged unrelated repo-wide lint/YAML issues that pre-existed and whose unrelated whitespace changes were reverted.

No live cluster, secret rotation, artifact publication, or external deployment was performed as part of this change. Closes #2324.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a684c7f664c832f87fd363bd128ff2a)