### PR TITLE
Make Git-controlled Helm values authoritative on app upgrades (remove --reuse-values)

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -58,10 +58,19 @@ Standard app paths perform exactly one render. DSPACE orders manifest validation
 digest resolution, render and validation, evidence reservation, Helm mutation, and
 evidence finalization; no render occurs after reservation.
 
-Upgrade currently retains `--reuse-values`. Therefore this gate validates the
-repository-controlled proposed inputs but does not claim to reproduce Helm's
-historical value merge. Removing `--reuse-values` remains the explicit follow-up in
-issue #2324. This PR deliberately does not change or remove `--reuse-values`.
+Standard upgrades do not use `--reuse-values`. Both preflight and mutation start
+with the proposed chart's defaults, then apply only the complete ordered
+Git-controlled environment values chain and the explicit host, immutable image
+tag, and pull-policy overrides. Ordinary `helm upgrade` has these reset semantics
+when `--reuse-values` is absent, so the helpers intentionally do not add the
+redundant `--reset-values` flag. The render and mutation therefore have identical
+release-defining inputs.
+
+Helm release history is evidence and rollback metadata, not desired-state
+configuration. Before a standard upgrade, operators must migrate every intentional
+setting into reviewed values files or established Secret references. The helpers
+do not inspect `helm get values`, replay historical inline values, or copy secret
+material from release history.
 
 ### DSPACE recovery exception
 

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -379,8 +379,12 @@ manifest validation and digest resolution, one exact-release render and structur
 validation, evidence reservation, Helm mutation, then evidence finalization. No
 render occurs after reservation. A render or validation failure is terminal and
 creates no reservation, Helm mutation, Kubernetes rollout call, or final evidence.
-Steady-state upgrade still uses `--reuse-values`; removing it is explicitly deferred
-to #2324 and is not part of this change.
+Steady-state upgrades do not use `--reuse-values`: the approved digest-qualified
+chart defaults, complete ordered Git-controlled values chain, host, immutable image
+coordinates, and pull policy are identical for render and mutation. Treat Helm
+history as evidence and rollback metadata, not desired-state configuration; migrate
+intentional settings into reviewed values files or established Secret references
+before upgrading.
 
 After atomically reserving the unique evidence destination, the operation uses
 `helm upgrade` with the approved chart digest, complete values chain, and an

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -818,9 +818,14 @@ just dspace-oci-redeploy env=prod tag="$(read_prod_tag)"
 ```
 
 Under the hood, both commands call the shared `_helm-oci-deploy` helper via
-`helm-oci-upgrade`, performing `helm upgrade --reuse-values` against the running release
-and then forcing a `kubectl rollout restart deploy/dspace` to ensure pods recycle. The helper waits for the rollout to
-finish and exits non-zero if Kubernetes reports a failure.
+`helm-oci-upgrade`, performing `helm upgrade` against the running release without
+`--reuse-values` and then forcing a `kubectl rollout restart deploy/dspace` to ensure
+pods recycle. The proposed chart defaults plus the complete ordered Git-controlled
+values chain and explicit host/image overrides are authoritative. Move intentional
+configuration into reviewed values files or established Secret references before
+upgrading; Helm history is evidence and rollback metadata, not desired state. The
+helper waits for the rollout to finish and exits non-zero if Kubernetes reports a
+failure.
 
 For immutable RC/stable validation (recommended for staging and prod), use the dedicated
 helper instead:

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -819,10 +819,10 @@ just dspace-oci-redeploy env=prod tag="$(read_prod_tag)"
 
 Under the hood, both commands call the shared `_helm-oci-deploy` helper via
 `helm-oci-upgrade`, performing `helm upgrade` against the running release without
-`--reuse-values` and then forcing a `kubectl rollout restart deploy/dspace` to ensure
-pods recycle. The proposed chart defaults plus the complete ordered Git-controlled
-values chain and explicit host/image overrides are authoritative. Move intentional
-configuration into reviewed values files or established Secret references before
+`--reuse-values`. It discovers the release-associated, rollout-tracked workloads and
+waits for each one with `kubectl rollout status`; it does not force a rollout restart.
+The proposed chart defaults plus the complete ordered Git-controlled values chain and explicit
+host/image overrides are authoritative. Move intentional configuration into reviewed values files or established Secret references before
 upgrading; Helm history is evidence and rollback metadata, not desired state. The
 helper waits for the rollout to finish and exits non-zero if Kubernetes reports a
 failure.

--- a/docs/raspi_cluster_operations_manual.md
+++ b/docs/raspi_cluster_operations_manual.md
@@ -325,9 +325,10 @@ Kustomizations you referenced in `gotk-sync.yaml`.
 - **Scale workloads:** `sudo kubectl scale deployment <name> --replicas=3 -n <ns>`.
 - **Inspect logs:** `sudo kubectl logs <pod> -n <ns>` (use `-c` for multi-container
   pods).
-- **Override Helm values temporarily:** run `helm upgrade <release> <chart> \
-  --namespace <ns> --reuse-values --set key=value` and confirm the change with
-  `sudo kubectl get deployment -n <ns>`.
+- **Change Helm values:** do not replay release-history values or make temporary
+  inline overrides. Add the intended setting to the complete reviewed environment
+  values chain (or use an established Secret reference), then run the standard app
+  upgrade and confirm it with `sudo kubectl get deployment -n <ns>`.
 - **Heal a bad join:** `just wipe` remains the fastest way to reset a node
   before re-running `just ha3 env=dev`, but you can also remove k3s manually by
   following the official uninstall script from `/usr/local/bin/k3s-uninstall.sh`.

--- a/justfile
+++ b/justfile
@@ -1218,7 +1218,7 @@ cf-tunnel-route host='':
         '' \
         'Dashboard steps are documented in docs/cloudflare_tunnel.md.'
 
-_helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='' description='' app='' allow_install='false' reuse_values='false' mutation_marker='' preflight_complete='false':
+_helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='' description='' app='' allow_install='false' mutation_marker='' preflight_complete='false':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1352,7 +1352,6 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     fi
 
     allow_install="$(normalize_prefixed_value allow_install "{{ allow_install }}")"
-    reuse_values="$(normalize_prefixed_value reuse_values "{{ reuse_values }}")"
 
     if [ -z "${release}" ] || [ -z "${namespace}" ] || [ -z "${chart}" ]; then
         echo "Set release, namespace, and chart to deploy." >&2
@@ -1634,10 +1633,6 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
         helm_args+=(--install --create-namespace)
     fi
 
-    if [ "${reuse_values}" = "true" ]; then
-        helm_args+=(--reuse-values)
-    fi
-
     if [ ${#value_args[@]} -gt 0 ]; then
         helm_args+=("${value_args[@]}")
     fi
@@ -1659,10 +1654,10 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     wait_for_rollouts
 
 helm-oci-install release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='' description='' app='':
-    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' '{{ env }}' '{{ description }}' '{{ app }}' allow_install='true' reuse_values='false'
+    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' '{{ env }}' '{{ description }}' '{{ app }}' allow_install='true'
 
 helm-oci-upgrade release='' namespace='' chart='' values='' host='' version='' version_file='' tag='' default_tag='' env='' description='' app='':
-    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' '{{ env }}' '{{ description }}' '{{ app }}' allow_install='false' reuse_values='true'
+    @just _helm-oci-deploy '{{ release }}' '{{ namespace }}' '{{ chart }}' '{{ values }}' '{{ host }}' '{{ version }}' '{{ version_file }}' '{{ tag }}' '{{ default_tag }}' '{{ env }}' '{{ description }}' '{{ app }}' allow_install='false'
 
 # Print resolved Sugarkube app deployment config for an app/environment.
 app-config app env='staging' config='':
@@ -1729,6 +1724,7 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
     just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "${SUGARKUBE_ENV}" "${KUBECONFIG}" >/dev/null
+    resolved_host="$(python3 "{{ justfile_directory() }}/scripts/app_chart.py" resolve-host --values "${SUGARKUBE_VALUES}")"
     python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight \
       --app "${SUGARKUBE_APP}" \
       --env "${SUGARKUBE_ENV}" \
@@ -1738,7 +1734,9 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
       --version-file "${SUGARKUBE_VERSION_FILE:-}" \
       --values "${SUGARKUBE_VALUES}" \
       --release "${SUGARKUBE_RELEASE}" \
-      --namespace "${SUGARKUBE_NAMESPACE}"
+      --namespace "${SUGARKUBE_NAMESPACE}" \
+      --host "${resolved_host}" \
+      --pull-policy Always
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
       evidence_reservation="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" reserve \
         --manifest "${release_manifest}" --output "${evidence_output}" \
@@ -1749,9 +1747,9 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
     fi
     if ! just --justfile "{{ justfile_directory() }}/justfile" _helm-oci-deploy \
       "${SUGARKUBE_RELEASE}" "${SUGARKUBE_NAMESPACE}" "${chart_coordinate:-${SUGARKUBE_CHART}}" \
-      "${SUGARKUBE_VALUES}" '' "${SUGARKUBE_VERSION:-}" "${SUGARKUBE_VERSION_FILE:-}" \
+      "${SUGARKUBE_VALUES}" "${resolved_host}" "${SUGARKUBE_VERSION:-}" "${SUGARKUBE_VERSION_FILE:-}" \
       "${SUGARKUBE_TAG}" '' "${SUGARKUBE_ENV}" "${helm_description:-}" "${SUGARKUBE_APP}" \
-      true false "${mutation_marker:-}" true; then
+      true "${mutation_marker:-}" true; then
       if [ -n "${evidence_reservation:-}" ] && [ ! -e "${mutation_marker}" ]; then
         rm -f "$(realpath -m "${evidence_output}").reservation"
       fi
@@ -1796,6 +1794,7 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
     export KUBECONFIG="${HOME}/.kube/config"
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
     just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "${SUGARKUBE_ENV}" "${KUBECONFIG}" >/dev/null
+    resolved_host="$(python3 "{{ justfile_directory() }}/scripts/app_chart.py" resolve-host --values "${SUGARKUBE_VALUES}")"
     python3 "{{ justfile_directory() }}/scripts/app_chart.py" preflight \
       --app "${SUGARKUBE_APP}" \
       --env "${SUGARKUBE_ENV}" \
@@ -1805,7 +1804,9 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
       --version-file "${SUGARKUBE_VERSION_FILE:-}" \
       --values "${SUGARKUBE_VALUES}" \
       --release "${SUGARKUBE_RELEASE}" \
-      --namespace "${SUGARKUBE_NAMESPACE}"
+      --namespace "${SUGARKUBE_NAMESPACE}" \
+      --host "${resolved_host}" \
+      --pull-policy Always
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
       evidence_reservation="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" reserve \
         --manifest "${release_manifest}" --output "${evidence_output}" \
@@ -1816,9 +1817,9 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
     fi
     if ! just --justfile "{{ justfile_directory() }}/justfile" _helm-oci-deploy \
       "${SUGARKUBE_RELEASE}" "${SUGARKUBE_NAMESPACE}" "${chart_coordinate:-${SUGARKUBE_CHART}}" \
-      "${SUGARKUBE_VALUES}" '' "${SUGARKUBE_VERSION:-}" "${SUGARKUBE_VERSION_FILE:-}" \
+      "${SUGARKUBE_VALUES}" "${resolved_host}" "${SUGARKUBE_VERSION:-}" "${SUGARKUBE_VERSION_FILE:-}" \
       "${SUGARKUBE_TAG}" '' "${SUGARKUBE_ENV}" "${helm_description:-}" "${SUGARKUBE_APP}" \
-      false true "${mutation_marker:-}" true; then
+      false "${mutation_marker:-}" true; then
       if [ -n "${evidence_reservation:-}" ] && [ ! -e "${mutation_marker}" ]; then
         rm -f "$(realpath -m "${evidence_output}").reservation"
       fi

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -626,11 +626,22 @@ def cmd_preflight(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_resolve_host(args: argparse.Namespace) -> int:
+    """Print the effective ingress host used as an explicit Helm override."""
+    values = tuple(filter(None, (value.strip() for value in args.values.split(","))))
+    print(expected_ingress_host(values, args.host))
+    return 0
+
+
 def main() -> int:
     p = argparse.ArgumentParser()
     sub = p.add_subparsers(dest="cmd", required=True)
-    for name in ("status", "bump", "preflight"):
+    for name in ("status", "bump", "preflight", "resolve-host"):
         s = sub.add_parser(name)
+        if name == "resolve-host":
+            s.add_argument("--values", required=True)
+            s.add_argument("--host", default="")
+            continue
         s.add_argument("--app", required=True)
         s.add_argument("--chart", required=True)
         s.add_argument("--version-file", required=True)
@@ -646,7 +657,12 @@ def main() -> int:
             s.add_argument("--host", default="")
             s.add_argument("--pull-policy", default="Always")
     a = p.parse_args()
-    return {"status": cmd_status, "bump": cmd_bump, "preflight": cmd_preflight}[a.cmd](a)
+    return {
+        "status": cmd_status,
+        "bump": cmd_bump,
+        "preflight": cmd_preflight,
+        "resolve-host": cmd_resolve_host,
+    }[a.cmd](a)
 
 
 if __name__ == "__main__":

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -629,7 +629,12 @@ def cmd_preflight(args: argparse.Namespace) -> int:
 def cmd_resolve_host(args: argparse.Namespace) -> int:
     """Print the effective ingress host used as an explicit Helm override."""
     values = tuple(filter(None, (value.strip() for value in args.values.split(","))))
-    print(expected_ingress_host(values, args.host))
+    try:
+        host = expected_ingress_host(values, args.host)
+    except (ValueError, json.JSONDecodeError, SystemExit) as error:
+        print(f"ERROR: values parsing failed while resolving ingress host: {error}", file=sys.stderr)
+        return 1
+    print(host)
     return 0
 
 

--- a/scripts/test-helm-oci-install.sh
+++ b/scripts/test-helm-oci-install.sh
@@ -352,8 +352,12 @@ upgrade_output="$(
         version_file=version_file=docs/apps/dspace.version default_tag=v3-deadbee host=staging.democratized.space env=staging app=dspace
 )"
 
-if ! grep -q "helm upgrade dspace oci://registry.test/charts/dspace --namespace dspace --reuse-values" <<<"${upgrade_output}"; then
+if ! grep -q "helm upgrade dspace oci://registry.test/charts/dspace --namespace dspace -f docs/examples/dspace.values.dev.yaml" <<<"${upgrade_output}"; then
     printf 'Upgrade path did not preserve expected behavior and argument normalization.\nOutput:\n%s\n' "${upgrade_output}" >&2
+    exit 1
+fi
+if grep -q -- '--reuse-values' <<<"${upgrade_output}"; then
+    printf 'Standard upgrade path must not inherit historical Helm values.\nOutput:\n%s\n' "${upgrade_output}" >&2
     exit 1
 fi
 

--- a/scripts/test-helm-oci-install.sh
+++ b/scripts/test-helm-oci-install.sh
@@ -352,11 +352,11 @@ upgrade_output="$(
         version_file=version_file=docs/apps/dspace.version default_tag=v3-deadbee host=staging.democratized.space env=staging app=dspace
 )"
 
-if ! grep -q "helm upgrade dspace oci://registry.test/charts/dspace --namespace dspace -f docs/examples/dspace.values.dev.yaml" <<<"${upgrade_output}"; then
+if ! grep -Fq -- "helm upgrade dspace oci://registry.test/charts/dspace --namespace dspace -f docs/examples/dspace.values.dev.yaml" <<<"${upgrade_output}"; then
     printf 'Upgrade path did not preserve expected behavior and argument normalization.\nOutput:\n%s\n' "${upgrade_output}" >&2
     exit 1
 fi
-if grep -q -- '--reuse-values' <<<"${upgrade_output}"; then
+if grep -Fq -- '--reuse-values' <<<"${upgrade_output}"; then
     printf 'Standard upgrade path must not inherit historical Helm values.\nOutput:\n%s\n' "${upgrade_output}" >&2
     exit 1
 fi

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -953,6 +953,34 @@ def test_enabled_ingress_requires_resolved_host(tmp_path: Path) -> None:
         app_chart.expected_ingress_host((str(values),), "")
 
 
+def test_resolve_host_reports_values_parsing_failure(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    values = tmp_path / "values.yaml"
+    values.write_text("ingress: [invalid\n", encoding="utf-8")
+    args = argparse.Namespace(values=str(values), host="")
+
+    assert app_chart.cmd_resolve_host(args) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "ERROR: values parsing failed while resolving ingress host:" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_resolve_host_reports_missing_enabled_ingress_host(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    values = tmp_path / "values.yaml"
+    values.write_text("ingress:\n  enabled: true\n", encoding="utf-8")
+    args = argparse.Namespace(values=str(values), host="")
+
+    assert app_chart.cmd_resolve_host(args) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "no nonempty ingress.host was resolved" in captured.err
+    assert "Traceback" not in captured.err
+
+
 def test_dspace_render_contract_requires_resources_and_validates_metrics() -> None:
     inputs = app_chart.ReleaseInputs(
         "dspace",
@@ -2101,12 +2129,9 @@ def test_standard_app_redeploy_has_authoritative_values_and_render_mutation_pari
     def release_inputs(command: list[str]) -> list[str]:
         inputs: list[str] = []
         for flag in ("--namespace", "--version", "-f", "--set"):
-            inputs.extend(
-                argument
-                for index, argument in enumerate(command[:-1])
-                if argument == flag
-                for argument in command[index : index + 2]
-            )
+            for index, argument in enumerate(command[:-1]):
+                if argument == flag:
+                    inputs.extend(command[index : index + 2])
         return inputs
 
     assert release_inputs(rendered) == release_inputs(mutated)

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2081,6 +2081,52 @@ def test_app_redeploy_prints_chart_pin_reminder_without_latest_lookup_or_pin_mut
 
 
 @pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize("app", ["tokenplace", "danielsmith", "jobbot3000"])
+def test_standard_app_redeploy_has_authoritative_values_and_render_mutation_parity(
+    app: str, generic_app_stub_env: dict[str, str]
+) -> None:
+    result = _run_just(
+        ["app-redeploy", f"app={app}", "env=staging", "tag=main-deadbee"],
+        generic_app_stub_env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    lines = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8").splitlines()
+    rendered = next(line.split() for line in lines if line.startswith("template "))
+    mutated = next(line.split() for line in lines if line.startswith("upgrade "))
+    assert "--reuse-values" not in mutated
+    assert "--reset-values" not in mutated
+    assert rendered[1:4] == mutated[1:4]
+
+    def release_inputs(command: list[str]) -> list[str]:
+        inputs: list[str] = []
+        for flag in ("--namespace", "--version", "-f", "--set"):
+            inputs.extend(
+                argument
+                for index, argument in enumerate(command[:-1])
+                if argument == flag
+                for argument in command[index : index + 2]
+            )
+        return inputs
+
+    assert release_inputs(rendered) == release_inputs(mutated)
+    base = f"docs/examples/{app}.values.dev.yaml"
+    overlay = f"docs/examples/{app}.values.staging.yaml"
+    assert mutated.index(base) < mutated.index(overlay)
+    assert "image.tag=main-deadbee" in mutated
+    assert "image.pullPolicy=Always" in mutated
+
+
+def test_standard_helm_helper_source_cannot_reintroduce_historical_values() -> None:
+    justfile = (REPO_ROOT / "justfile").read_text(encoding="utf-8")
+    helper = justfile.split("_helm-oci-deploy ", 1)[1].split("\nhelm-oci-install ", 1)[0]
+
+    assert "reuse_values" not in helper
+    assert "--reuse-values" not in helper
+    assert "reset-then-reuse-values" not in helper
+
+
+@pytest.mark.usefixtures("ensure_just_available")
 @pytest.mark.parametrize(
     ("app", "release", "namespace", "chart"),
     [
@@ -2301,9 +2347,23 @@ def test_dspace_guarded_deploy_orders_preflight_mutation_and_finalization(
     )
     assert coordinate in installed["details"]
     helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
+    render_line = next(line for line in helm_log.splitlines() if line.startswith("template "))
     mutation_line = next(line for line in helm_log.splitlines() if line.startswith("upgrade "))
+    for expected in (
+        coordinate,
+        "--namespace dspace",
+        "-f docs/examples/dspace.values.dev.yaml",
+        "-f docs/examples/dspace.values.staging.yaml",
+        "--set ingress.host=staging.democratized.space",
+        "--set image.tag=main-abcdef0",
+        "--set image.pullPolicy=Always",
+    ):
+        assert expected in render_line
+        assert expected in mutation_line
     assert coordinate in mutation_line
+    assert "--reuse-values" not in mutation_line
     assert "--version" not in mutation_line
+    assert "--version" not in render_line
     assert "--description sugarkube-release-manifest:" in mutation_line
     commands = (tmp_path / "commands.log").read_text(encoding="utf-8").splitlines()
     preflight = next(i for i, line in enumerate(commands) if line.startswith("oras "))

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2109,9 +2109,16 @@ def test_app_redeploy_prints_chart_pin_reminder_without_latest_lookup_or_pin_mut
 
 
 @pytest.mark.usefixtures("ensure_just_available")
-@pytest.mark.parametrize("app", ["tokenplace", "danielsmith", "jobbot3000"])
+@pytest.mark.parametrize(
+    ("app", "staging_host"),
+    [
+        ("tokenplace", "staging.token.place"),
+        ("danielsmith", "staging.danielsmith.io"),
+        ("jobbot3000", "staging.jobbot3000.tech"),
+    ],
+)
 def test_standard_app_redeploy_has_authoritative_values_and_render_mutation_parity(
-    app: str, generic_app_stub_env: dict[str, str]
+    app: str, staging_host: str, generic_app_stub_env: dict[str, str]
 ) -> None:
     result = _run_just(
         ["app-redeploy", f"app={app}", "env=staging", "tag=main-deadbee"],
@@ -2135,11 +2142,130 @@ def test_standard_app_redeploy_has_authoritative_values_and_render_mutation_pari
         return inputs
 
     assert release_inputs(rendered) == release_inputs(mutated)
+    host_override = f"ingress.host={staging_host}"
+    assert host_override in rendered
+    assert host_override in mutated
     base = f"docs/examples/{app}.values.dev.yaml"
     overlay = f"docs/examples/{app}.values.staging.yaml"
     assert mutated.index(base) < mutated.index(overlay)
     assert "image.tag=main-deadbee" in mutated
     assert "image.pullPolicy=Always" in mutated
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize(
+    ("values_contents", "diagnostic"),
+    [
+        ("ingress: [invalid\n", "values parsing failed while resolving ingress host"),
+        ("ingress:\n  enabled: true\n", "no nonempty ingress.host was resolved"),
+    ],
+)
+def test_app_redeploy_host_resolution_failure_stops_before_release_activity(
+    tmp_path: Path,
+    values_contents: str,
+    diagnostic: str,
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    values = tmp_path / "values.yaml"
+    values.write_text(values_contents, encoding="utf-8")
+    config = tmp_path / "tokenplace.env"
+    config.write_text(
+        "\n".join(
+            [
+                "SUGARKUBE_APP=tokenplace",
+                "SUGARKUBE_RELEASE=tokenplace",
+                "SUGARKUBE_NAMESPACE=tokenplace",
+                "SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/tokenplace",
+                "SUGARKUBE_VERSION=0.1.3",
+                f"SUGARKUBE_VALUES_STAGING={values}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    evidence = tmp_path / "evidence.json"
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_APP_CONFIG_DIR"] = str(tmp_path)
+
+    result = _run_just(
+        [
+            "app-redeploy",
+            "app=tokenplace",
+            "env=staging",
+            "tag=main-deadbee",
+            f"evidence={evidence}",
+        ],
+        env,
+    )
+
+    assert result.returncode != 0
+    assert diagnostic in result.stderr
+    assert "Traceback" not in result.stderr
+    helm_log = Path(generic_app_stub_env["HELM_LOG"])
+    assert not helm_log.exists() or helm_log.read_text(encoding="utf-8") == ""
+    commands = (tmp_path / "commands.log").read_text(encoding="utf-8")
+    assert "helm template" not in commands
+    assert "helm upgrade" not in commands
+    assert "rollout" not in commands
+    assert not evidence.exists()
+    assert not Path(f"{evidence}.reservation").exists()
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_helm_oci_install_and_upgrade_keep_authoritative_inputs_identical(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    common_args = [
+        "release=tokenplace",
+        "namespace=tokenplace",
+        "chart=oci://ghcr.io/futuroptimist/charts/tokenplace",
+        "values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml",
+        "host=staging.token.place",
+        "version=0.1.3",
+        "tag=main-deadbee",
+        "env=staging",
+        "app=tokenplace",
+    ]
+    mutations: dict[str, list[str]] = {}
+    helm_log_path = Path(generic_app_stub_env["HELM_LOG"])
+    for recipe in ("helm-oci-install", "helm-oci-upgrade"):
+        helm_log_path.unlink(missing_ok=True)
+        result = _run_just([recipe, *common_args], generic_app_stub_env)
+        assert result.returncode == 0, result.stderr + result.stdout
+        lines = helm_log_path.read_text(encoding="utf-8").splitlines()
+        mutations[recipe] = next(line.split() for line in lines if line.startswith("upgrade "))
+
+    install = mutations["helm-oci-install"]
+    upgrade = mutations["helm-oci-upgrade"]
+    assert "--install" in install
+    assert "--create-namespace" in install
+    assert "--install" not in upgrade
+    assert "--create-namespace" not in upgrade
+    prohibited = {"--reuse-values", "--reset-values", "--reset-then-reuse-values"}
+    assert prohibited.isdisjoint(install)
+    assert prohibited.isdisjoint(upgrade)
+
+    def release_inputs(command: list[str]) -> list[str]:
+        inputs = command[1:3]
+        for flag in ("--namespace", "--version", "-f", "--set"):
+            for index, argument in enumerate(command[:-1]):
+                if argument == flag:
+                    inputs.extend(command[index : index + 2])
+        return inputs
+
+    assert release_inputs(install) == release_inputs(upgrade)
+    for expected in (
+        "docs/examples/tokenplace.values.dev.yaml",
+        "docs/examples/tokenplace.values.staging.yaml",
+        "ingress.host=staging.token.place",
+        "image.tag=main-deadbee",
+        "image.pullPolicy=Always",
+    ):
+        assert expected in install
+        assert expected in upgrade
+    assert install.index("docs/examples/tokenplace.values.dev.yaml") < install.index(
+        "docs/examples/tokenplace.values.staging.yaml"
+    )
 
 
 def test_standard_helm_helper_source_cannot_reintroduce_historical_values() -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -981,6 +981,19 @@ def test_resolve_host_reports_missing_enabled_ingress_host(
     assert "Traceback" not in captured.err
 
 
+def test_resolve_host_prints_effective_host(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    values = tmp_path / "values.yaml"
+    values.write_text("ingress:\n  host: values.example.test\n", encoding="utf-8")
+    args = argparse.Namespace(values=f" , {values}, ", host="override.example.test")
+
+    assert app_chart.cmd_resolve_host(args) == 0
+    captured = capsys.readouterr()
+    assert captured.out == "override.example.test\n"
+    assert captured.err == ""
+
+
 def test_dspace_render_contract_requires_resources_and_validates_metrics() -> None:
     inputs = app_chart.ReleaseInputs(
         "dspace",


### PR DESCRIPTION
### Motivation

- Remove historical Helm-value inheritance so chart defaults plus the complete ordered Git-controlled values chain and explicit immutable image coordinates are authoritative for standard upgrades (Closes #2324 and follows the incident postmortem at democratizedspace/dspace#4723). 
- Preserve existing DSPACE evidence reservation/finalization ordering, install-vs-upgrade guards, rollout handling, and digest-qualified chart behavior while improving preflight ↔ mutation parity. 

### Description

- Remove the `reuse_values` parameter and all `--reuse-values` branching from the shared `_helm-oci-deploy` helper and make `helm-oci-upgrade`/public wrappers incapable of adding `--reuse-values`.
- Resolve the effective ingress host before preflight and pass the same `-f` ordered values chain, host override, explicit `--set image.tag=<sha>` and `--set image.pullPolicy=Always` into both `helm template` (preflight) and `helm upgrade` (mutation) so render and mutation consume identical release-defining inputs; digest-qualified charts continue to omit `--version`.
- Do not add `--reset-values`; this was intentionally omitted because ordinary `helm upgrade` without `--reuse-values` already produces the required reset semantics for supported Helm versions, and adding it would be redundant and expand command surface.
- Update documentation (`docs/app_deployment_contract.md`, `docs/apps/dspace.md`, `docs/raspi_cluster_operations.md`, and relevant runbooks) to state that standard upgrades do not use `--reuse-values` and that Helm history is evidence/rollback metadata, not desired-state configuration.
- Add hermetic regression tests ensuring `helm-oci-upgrade` and `app-redeploy` never emit `--reuse-values`, that the exact ordered `-f` chain is preserved, and that `helm template` and `helm upgrade` use identical chart/version/values/host/tag/pull-policy inputs for token.place, danielsmith.io, jobbot3000, and the DSPACE guarded digest-qualified flow.

### Testing

- Ran targeted pytest: `python3 -m pytest -q tests/test_generic_app_just_recipes.py tests/test_app_config.py tests/test_release_manifest.py tests/test_manifest_rollback.py` and relevant subsets, resulting in all tests passing (417 tests passed in the active run).
- Ran `bash scripts/test-helm-oci-install.sh` which passed and added a focused assertion that `--reuse-values` is not present in standard upgrade logs.
- Ran `just --unstable --fmt --check`, `rg -n -- '--reuse-values|reuse_values|reset-then-reuse-values' justfile scripts tests docs`, `linkchecker --no-warnings README.md docs/`, `git diff --check`, and repository secret scans; all items were reviewed and remaining `rg` hits are either prohibitions or documentation notes.
- `pyspelling -c .spellcheck.yaml` could not complete due to a missing `aspell` binary in the runtime environment, and `pre-commit run --all-files` was attempted but the repository contains unrelated pre-existing hook baseline issues; unrelated automatic changes were reverted before committing.

No live cluster, deployment, artifact publication, secret rotation, or credential use occurred during verification.

Closes #2324

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a684c842478832fb07a0670ecb519b1)