### PR TITLE
Fix staging PagerDuty synthetic Alertmanager submission

### DIFF
--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -269,24 +269,44 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
 )
 
 pagerduty_test() (
-  local action="${1:-}" ends_at endpoint response_file=""
+  local action="${1:-}" ends_at http_status="" line port="" remote_port
+  local pagerduty_pid="" pagerduty_tmp
+  local -a port_forward_lines=()
   action="${action#action=}"
   case "${action}" in
     fire|resolve) ;;
     "") echo "ERROR: PagerDuty test requires an explicit action: fire or resolve." >&2; return 17 ;;
     *) echo "ERROR: unsupported PagerDuty test action '${action}'; expected fire or resolve." >&2; return 17 ;;
   esac
-  require_tools kubectl python3
+  require_tools kubectl python3 curl sleep
   assert_context
+  pagerduty_tmp="$(mktemp -d -t sugarkube-alertmanager-test.XXXXXX)"
+  chmod 700 "${pagerduty_tmp}"
+  # The EXIT trap invokes this cleanup callback indirectly.
+  # shellcheck disable=SC2317
+  cleanup_pagerduty_test() {
+    if [[ -n "${pagerduty_pid}" && " $(jobs -pr) " == *" ${pagerduty_pid} "* ]]; then
+      kill "${pagerduty_pid}" 2>/dev/null || true
+    fi
+    [[ -z "${pagerduty_pid}" ]] || wait "${pagerduty_pid}" 2>/dev/null || true
+    rm -rf "${pagerduty_tmp}"
+  }
+  pagerduty_port_forward_stopped() {
+    wait "${pagerduty_pid}" 2>/dev/null || true
+    pagerduty_pid=""
+    echo "ERROR: Alertmanager port-forward stopped (diagnostics redacted)." >&2
+    return 19
+  }
+  trap cleanup_pagerduty_test EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
   ends_at="$(ACTION="${action}" python3 -c 'from datetime import datetime, timedelta, timezone
 import os
 now = datetime.now(timezone.utc)
 end = now + timedelta(minutes=15) if os.environ["ACTION"] == "fire" else now
 print(end.isoformat(timespec="seconds").replace("+00:00", "Z"))')"
-  endpoint="/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-alertmanager:9093/proxy/api/v2/alerts"
-  trap 'rm -f "${response_file:-}"' EXIT
-  response_file="$(mktemp -t sugarkube-alertmanager-response.XXXXXX)"
-  if ! ENDS_AT="${ends_at}" python3 -c 'import json, os, sys
+  ENDS_AT="${ends_at}" python3 -c 'import json, os, sys
 json.dump([{
   "labels": {
     "alertname": "SugarkubePagerDutyTest",
@@ -301,10 +321,47 @@ json.dump([{
   },
   "startsAt": "2020-01-01T00:00:00Z",
   "endsAt": os.environ["ENDS_AT"]
-}], sys.stdout)' | kubectl create --raw "${endpoint}" -f - >"${response_file}" 2>/dev/null; then
+}], sys.stdout)' >"${pagerduty_tmp}/payload.json"
+
+  : >"${pagerduty_tmp}/port-forward.log"
+  trap - EXIT
+  kubectl -n "${NAMESPACE}" port-forward --address=127.0.0.1 "service/${RELEASE}-alertmanager" :9093 >"${pagerduty_tmp}/port-forward.log" 2>&1 &
+  pagerduty_pid=$!
+  trap cleanup_pagerduty_test EXIT
+  for _ in {1..20}; do
+    kill -0 "${pagerduty_pid}" 2>/dev/null || pagerduty_port_forward_stopped
+    mapfile -t port_forward_lines <"${pagerduty_tmp}/port-forward.log"
+    for line in "${port_forward_lines[@]}"; do
+      if [[ "${line}" =~ ^Forwarding\ from\ 127\.0\.0\.1:([1-9][0-9]{0,4})\ -\>\ ([1-9][0-9]{0,4})$ ]]; then
+        port="${BASH_REMATCH[1]}"
+        remote_port="${BASH_REMATCH[2]}"
+        if ((10#${port} > 65535 || 10#${remote_port} > 65535)) || [[ "${remote_port}" != 9093 ]]; then
+          echo "ERROR: Alertmanager port-forward reported an unexpected listener (diagnostics redacted)." >&2
+          return 19
+        fi
+      elif [[ "${line}" == Forwarding\ from* ]]; then
+        echo "ERROR: Alertmanager port-forward reported an unexpected listener (diagnostics redacted)." >&2
+        return 19
+      fi
+    done
+    [[ -z "${port}" ]] || break
+    sleep 1
+  done
+  [[ -n "${port}" ]] || { echo "ERROR: Alertmanager port-forward did not establish an owned loopback listener (diagnostics redacted)." >&2; return 19; }
+  kill -0 "${pagerduty_pid}" 2>/dev/null || pagerduty_port_forward_stopped
+
+  if ! http_status="$(curl --silent --show-error --connect-timeout 3 --max-time 10 \
+    --header 'Content-Type: application/json' --data-binary "@${pagerduty_tmp}/payload.json" \
+    --output "${pagerduty_tmp}/response" --write-out '%{http_code}' \
+    "http://127.0.0.1:${port}/api/v2/alerts" 2>"${pagerduty_tmp}/curl.log")"; then
     echo "ERROR: Alertmanager v2 API rejected synthetic ${action} request (response redacted)." >&2
     return 18
   fi
+  kill -0 "${pagerduty_pid}" 2>/dev/null || pagerduty_port_forward_stopped
+  [[ "${http_status}" =~ ^[0-9]{3}$ && "${http_status}" == 200 ]] || {
+    echo "ERROR: Alertmanager v2 API rejected synthetic ${action} request (response redacted)." >&2
+    return 18
+  }
   echo "PagerDuty synthetic ${action} submitted; Alertmanager API status: accepted (response redacted)."
 )
 

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -479,6 +479,8 @@ def run_helper(
     retry_attempts="3",
     retry_interval="1",
     action=None,
+    pagerduty_mode="success",
+    pagerduty_forward_line="Forwarding from 127.0.0.1:43127 -> 9093",
 ):
     """Run the lifecycle against deterministic command stubs and return its audit log."""
     bin_dir = tmp_path / "bin"
@@ -521,7 +523,15 @@ case "$*" in
     [ "$KUBECTL_MODE" != malformed-alertmanager ] && sed 's/^/    /' "$ALERTMANAGER_CONFIG" || printf '%s\n' '    route: [unterminated'
     ;;
   *"get secret alertmanager-pagerduty -o go-template="*) [ "$KUBECTL_MODE" != missing-pagerduty ] || exit 44; [ "$KUBECTL_MODE" != empty-pagerduty ] && echo present ;;
-  *"create --raw "*"/api/v2/alerts -f -"*) cat > "$ALERT_PAYLOAD"; echo response-sentinel; [ "$KUBECTL_MODE" != api-fail ] ;;
+  *"port-forward"*"service/kube-prometheus-stack-alertmanager :9093"*)
+    echo $$ > "$FORWARD_PID"
+    trap 'echo reaped > "$FORWARD_REAPED"' EXIT
+    trap 'exit 0' TERM INT
+    [ "$PAGERDUTY_MODE" != forward-exit ] || { echo port-forward-sentinel >&2; exit 42; }
+    [ "$PAGERDUTY_MODE" = no-listener ] || echo "$PAGERDUTY_FORWARD_LINE"
+    [ "$PAGERDUTY_MODE" != no-listener ] || echo port-forward-sentinel >&2
+    while :; do /bin/sleep 1; done
+    ;;
   *"get ingress "*) exit 0 ;;
   *"get svc kube-prometheus-stack-grafana"*) echo 30300 ;;
   *"get servicemonitor dspace"*"metadata.labels.release"*) [ "$KUBECTL_MODE" = wrong-release ] && echo wrong || echo kube-prometheus-stack ;;
@@ -545,6 +555,29 @@ esac
 """,
         encoding="utf-8",
     )
+    (bin_dir / "curl").write_text(
+        """#!/bin/sh
+echo "curl $*" >> "$AUDIT"
+output=
+payload=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output=$2; shift 2 ;;
+    --data-binary) payload=${2#@}; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -z "$payload" ] || cp "$payload" "$ALERT_PAYLOAD"
+[ -z "$output" ] || printf response-sentinel > "$output"
+case "$PAGERDUTY_MODE" in
+  curl-transport) echo curl-sentinel >&2; exit 7 ;;
+  http-*) printf '%s' "${PAGERDUTY_MODE#http-}" ;;
+  malformed-status) printf malformed-sentinel ;;
+  *) printf 200 ;;
+esac
+""",
+        encoding="utf-8",
+    )
     (bin_dir / "sleep").write_text(
         '#!/bin/sh\necho "sleep $*" >> "$AUDIT"\n',
         encoding="utf-8",
@@ -563,6 +596,10 @@ esac
         "TARGET_COUNTER": str(tmp_path / "target-counter"),
         "TARGET_RESPONSE_DELAY": target_response_delay,
         "ALERT_PAYLOAD": str(tmp_path / "alert-payload"),
+        "PAGERDUTY_MODE": pagerduty_mode,
+        "PAGERDUTY_FORWARD_LINE": pagerduty_forward_line,
+        "FORWARD_PID": str(tmp_path / "port-forward.pid"),
+        "FORWARD_REAPED": str(tmp_path / "port-forward.reaped"),
         "ALERTMANAGER_CONFIG": str(tmp_path / "alertmanager-config.yaml"),
         "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS": retry_attempts,
         "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS": retry_interval,
@@ -719,7 +756,14 @@ def test_pagerduty_fire_and_resolve_share_labels_and_bound_end_times(tmp_path):
         tmp_path / "resolve", "pagerduty-test", action="action=resolve"
     )
     assert fired.returncode == resolved.returncode == 0
-    assert "create --raw" in fire_audit and "create --raw" in resolve_audit
+    for audit in (fire_audit, resolve_audit):
+        assert "create --raw" not in audit
+        assert (
+            "port-forward --address=127.0.0.1 " "service/kube-prometheus-stack-alertmanager :9093"
+        ) in audit
+        assert "--header Content-Type: application/json" in audit
+        assert "--data-binary @" in audit
+        assert "http://127.0.0.1:43127/api/v2/alerts" in audit
     fire = json.loads((tmp_path / "fire" / "alert-payload").read_text())[0]
     resolve = json.loads((tmp_path / "resolve" / "alert-payload").read_text())[0]
     expected = {
@@ -734,25 +778,70 @@ def test_pagerduty_fire_and_resolve_share_labels_and_bound_end_times(tmp_path):
     fire_end = datetime.fromisoformat(fire["endsAt"].replace("Z", "+00:00"))
     resolve_end = datetime.fromisoformat(resolve["endsAt"].replace("Z", "+00:00"))
     assert 14 * 60 <= (fire_end - resolve_end).total_seconds() <= 16 * 60
-    assert set(fire["annotations"]) == {"summary", "description", "runbook_url"}
+    expected_annotations = {
+        "summary": "Sugarkube staging PagerDuty delivery test",
+        "description": (
+            "Operator-triggered synthetic alert for the staging PagerDuty fire/resolve drill."
+        ),
+        "runbook_url": (
+            "https://github.com/futuroptimist/sugarkube/blob/main/"
+            "docs/observability-operations.md#pagerduty-staging-fire-and-resolve-runbook"
+        ),
+    }
+    assert fire["annotations"] == resolve["annotations"] == expected_annotations
+    assert fire["labels"] == resolve["labels"]  # Alertmanager derives the same fingerprint.
 
 
 @pytest.mark.parametrize("action", ["fire", "resolve"])
 def test_pagerduty_direct_bare_actions_remain_supported(tmp_path, action):
     result, audit = run_helper(tmp_path, "pagerduty-test", action=action)
-    assert result.returncode == 0 and "create --raw" in audit
+    assert result.returncode == 0 and "create --raw" not in audit
     assert "response-sentinel" not in result.stdout + result.stderr
-    assert not list(tmp_path.glob("sugarkube-alertmanager-response.*"))
+    assert not list(tmp_path.glob("sugarkube-alertmanager-test.*"))
+    assert (tmp_path / "port-forward.reaped").read_text().strip() == "reaped"
 
 
-def test_pagerduty_api_failure_is_redacted_and_cleans_response(tmp_path):
-    result, _ = run_helper(
-        tmp_path, "pagerduty-test", action="action=fire", kubectl_mode="api-fail"
+@pytest.mark.parametrize(
+    "mode", ["curl-transport", "http-000", "http-415", "http-400", "http-503", "malformed-status"]
+)
+def test_pagerduty_api_failure_is_redacted_and_cleans_response(tmp_path, mode):
+    result, audit = run_helper(
+        tmp_path, "pagerduty-test", action="action=fire", pagerduty_mode=mode
     )
     assert result.returncode == 18
     assert "response redacted" in result.stderr
-    assert "response-sentinel" not in result.stdout + result.stderr
-    assert not list(tmp_path.glob("sugarkube-alertmanager-response.*"))
+    for sentinel in ("response-sentinel", "curl-sentinel", "malformed-sentinel"):
+        assert sentinel not in result.stdout + result.stderr
+    assert "--header Content-Type: application/json" in audit
+    assert not list(tmp_path.glob("sugarkube-alertmanager-test.*"))
+    assert (tmp_path / "port-forward.reaped").read_text().strip() == "reaped"
+
+
+@pytest.mark.parametrize(
+    ("mode", "line"),
+    [
+        ("forward-exit", "Forwarding from 127.0.0.1:43127 -> 9093"),
+        ("no-listener", "Forwarding from 127.0.0.1:43127 -> 9093"),
+        ("success", "Forwarding from 0.0.0.0:43127 -> 9093"),
+        ("success", "Forwarding from 127.0.0.1:43127 -> 9094"),
+        ("success", "Forwarding from 127.0.0.1:not-a-port -> 9093"),
+    ],
+)
+def test_pagerduty_port_forward_failures_are_closed_redacted_and_cleaned(tmp_path, mode, line):
+    result, audit = run_helper(
+        tmp_path,
+        "pagerduty-test",
+        action="fire",
+        pagerduty_mode=mode,
+        pagerduty_forward_line=line,
+    )
+    assert result.returncode == 19
+    assert "diagnostics redacted" in result.stderr
+    assert "port-forward-sentinel" not in result.stdout + result.stderr
+    assert "curl " not in audit
+    assert not list(tmp_path.glob("sugarkube-alertmanager-test.*"))
+    if (tmp_path / "port-forward.pid").exists():
+        assert (tmp_path / "port-forward.reaped").read_text().strip() == "reaped"
 
 
 def test_status_requires_staging_identity(tmp_path):


### PR DESCRIPTION
### Motivation

- A live staging drill showed Alertmanager v2 rejected the synthetic fire/resolve request with `UnsupportedMediaType` when submitted via `kubectl create --raw`, indicating the proxy call did not supply the expected JSON media type. 
- The recipe must submit the same synthetic alert payload without exposing secrets, establish a local loopback-only connection to Alertmanager, and fail closed on transport, port-forward, or API errors.

### Description

- Replace the `kubectl create --raw .../api/v2/alerts` POST with an owned ephemeral loopback `kubectl port-forward` to `service/${RELEASE}-alertmanager` and a local `curl` POST to `http://127.0.0.1:<ephemeral>/api/v2/alerts` using `--header 'Content-Type: application/json'` and `--data-binary`.
- Implement robust port-forward readiness and ownership checks reusing the safety patterns from `dashboard_verify()` (private temp dir, parse only the expected `Forwarding from 127.0.0.1:<port> -> 9093` line, bounded startup wait, child liveness checks, and reliable kill/wait/cleanup on success/failure/INT/TERM).
- Keep existing semantics: `fire`/`resolve` interface, labels/annotations/fingerprint, 15-minute fire bound, redacted diagnostics, and preserve exit code `18` for Alertmanager/API submission failures while introducing an internal `19` for port-forward establishment failures.
- Extend deterministic stub tests to model `kubectl port-forward` and `curl`, assert explicit JSON content-type and `--data-binary`, cover successful fire/resolve behavior and regressions for port-forward readiness, malformed forwarding lines, transport failures, representative HTTP 4xx/5xx responses, response-status malformed cases, and cleanup/reaping of temp files and child processes.

### Testing

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_observability_helm.py -k 'pagerduty'` — 24 passed (pagerduty-focused tests).
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_observability_helm.py` — 89 passed (full test suite for observability helm tests).
- `bash -n scripts/observability_helm.sh` — syntax check passed.
- `black --check tests/test_observability_helm.py` — formatting check passed.

Note: environment tooling such as `shellcheck`, `pre-commit`, `pyspelling`, and `linkchecker` were not available in the runner; those checks were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68f7e83cc0832f8a88d24830676d33)