### PR TITLE
Fix staging PagerDuty synthetic Alertmanager submission

### DIFF
--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -328,10 +328,8 @@ json.dump([{
 }], sys.stdout)' >"${test_tmp}/payload.json"
 
   : >"${test_tmp}/port-forward.log"
-  trap - EXIT
   kubectl -n "${NAMESPACE}" port-forward --address=127.0.0.1 "service/${RELEASE}-alertmanager" :9093 >"${test_tmp}/port-forward.log" 2>&1 &
   test_pid=$!
-  trap cleanup_pagerduty_test EXIT
   for _ in {1..20}; do
     port_forward_running || port_forward_stopped
     mapfile -t port_forward_lines <"${test_tmp}/port-forward.log"
@@ -347,7 +345,7 @@ json.dump([{
   [[ -n "${port}" ]] || { echo "ERROR: Alertmanager port-forward did not establish an owned loopback listener (diagnostics redacted)." >&2; return 19; }
   port_forward_running || port_forward_stopped
 
-  if ! curl --silent --show-error --connect-timeout 3 --max-time 10 \
+  if ! curl --silent --show-error --noproxy '*' --connect-timeout 3 --max-time 10 \
     --header 'Content-Type: application/json' --data-binary "@${test_tmp}/payload.json" \
     --output "${test_tmp}/response" --write-out '%{http_code}' \
     "http://127.0.0.1:${port}/api/v2/alerts" >"${test_tmp}/status" 2>"${test_tmp}/curl.log"; then

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -269,24 +269,48 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
 )
 
 pagerduty_test() (
-  local action="${1:-}" ends_at endpoint response_file=""
+  local action="${1:-}" ends_at port="" line http_status
+  local -a port_forward_lines=()
+  local test_pid="" test_tmp
   action="${action#action=}"
   case "${action}" in
     fire|resolve) ;;
     "") echo "ERROR: PagerDuty test requires an explicit action: fire or resolve." >&2; return 17 ;;
     *) echo "ERROR: unsupported PagerDuty test action '${action}'; expected fire or resolve." >&2; return 17 ;;
   esac
-  require_tools kubectl python3
+  require_tools kubectl python3 curl sleep
   assert_context
   ends_at="$(ACTION="${action}" python3 -c 'from datetime import datetime, timedelta, timezone
 import os
 now = datetime.now(timezone.utc)
 end = now + timedelta(minutes=15) if os.environ["ACTION"] == "fire" else now
 print(end.isoformat(timespec="seconds").replace("+00:00", "Z"))')"
-  endpoint="/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-alertmanager:9093/proxy/api/v2/alerts"
-  trap 'rm -f "${response_file:-}"' EXIT
-  response_file="$(mktemp -t sugarkube-alertmanager-response.XXXXXX)"
-  if ! ENDS_AT="${ends_at}" python3 -c 'import json, os, sys
+  test_tmp="$(mktemp -d -t sugarkube-alertmanager-test.XXXXXX)"
+  chmod 700 "${test_tmp}"
+  # Return 19 specifically when the owned port-forward cannot be established.
+  # shellcheck disable=SC2317
+  cleanup_pagerduty_test() {
+    if [[ -n "${test_pid}" && " $(jobs -pr) " == *" ${test_pid} "* ]]; then
+      kill "${test_pid}" 2>/dev/null || true
+    fi
+    [[ -z "${test_pid}" ]] || wait "${test_pid}" 2>/dev/null || true
+    rm -rf "${test_tmp}"
+  }
+  port_forward_stopped() {
+    wait "${test_pid}" 2>/dev/null || true
+    test_pid=""
+    echo "ERROR: Alertmanager port-forward stopped (diagnostics redacted)." >&2
+    return 19
+  }
+  port_forward_running() {
+    [[ " $(jobs -pr) " == *" ${test_pid} "* ]] && kill -0 "${test_pid}" 2>/dev/null
+  }
+  trap cleanup_pagerduty_test EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  umask 077
+  ENDS_AT="${ends_at}" python3 -c 'import json, os, sys
 json.dump([{
   "labels": {
     "alertname": "SugarkubePagerDutyTest",
@@ -301,10 +325,41 @@ json.dump([{
   },
   "startsAt": "2020-01-01T00:00:00Z",
   "endsAt": os.environ["ENDS_AT"]
-}], sys.stdout)' | kubectl create --raw "${endpoint}" -f - >"${response_file}" 2>/dev/null; then
+}], sys.stdout)' >"${test_tmp}/payload.json"
+
+  : >"${test_tmp}/port-forward.log"
+  trap - EXIT
+  kubectl -n "${NAMESPACE}" port-forward --address=127.0.0.1 "service/${RELEASE}-alertmanager" :9093 >"${test_tmp}/port-forward.log" 2>&1 &
+  test_pid=$!
+  trap cleanup_pagerduty_test EXIT
+  for _ in {1..20}; do
+    port_forward_running || port_forward_stopped
+    mapfile -t port_forward_lines <"${test_tmp}/port-forward.log"
+    for line in "${port_forward_lines[@]}"; do
+      if [[ "${line}" =~ ^Forwarding\ from\ 127\.0\.0\.1:([1-9][0-9]{0,4})\ -\>\ 9093$ ]]; then
+        port="${BASH_REMATCH[1]}"
+        ((10#${port} <= 65535)) || port=""
+      fi
+    done
+    [[ -z "${port}" ]] || break
+    sleep 1
+  done
+  [[ -n "${port}" ]] || { echo "ERROR: Alertmanager port-forward did not establish an owned loopback listener (diagnostics redacted)." >&2; return 19; }
+  port_forward_running || port_forward_stopped
+
+  if ! curl --silent --show-error --connect-timeout 3 --max-time 10 \
+    --header 'Content-Type: application/json' --data-binary "@${test_tmp}/payload.json" \
+    --output "${test_tmp}/response" --write-out '%{http_code}' \
+    "http://127.0.0.1:${port}/api/v2/alerts" >"${test_tmp}/status" 2>"${test_tmp}/curl.log"; then
     echo "ERROR: Alertmanager v2 API rejected synthetic ${action} request (response redacted)." >&2
     return 18
   fi
+  port_forward_running || port_forward_stopped
+  http_status="$(cat "${test_tmp}/status")"
+  [[ "${http_status}" =~ ^[0-9]{3}$ && "${http_status}" == 200 ]] || {
+    echo "ERROR: Alertmanager v2 API rejected synthetic ${action} request (response redacted)." >&2
+    return 18
+  }
   echo "PagerDuty synthetic ${action} submitted; Alertmanager API status: accepted (response redacted)."
 )
 

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -479,6 +479,8 @@ def run_helper(
     retry_attempts="3",
     retry_interval="1",
     action=None,
+    pagerduty_mode="success",
+    pagerduty_forward_line="Forwarding from 127.0.0.1:43128 -> 9093",
 ):
     """Run the lifecycle against deterministic command stubs and return its audit log."""
     bin_dir = tmp_path / "bin"
@@ -521,7 +523,13 @@ case "$*" in
     [ "$KUBECTL_MODE" != malformed-alertmanager ] && sed 's/^/    /' "$ALERTMANAGER_CONFIG" || printf '%s\n' '    route: [unterminated'
     ;;
   *"get secret alertmanager-pagerduty -o go-template="*) [ "$KUBECTL_MODE" != missing-pagerduty ] || exit 44; [ "$KUBECTL_MODE" != empty-pagerduty ] && echo present ;;
-  *"create --raw "*"/api/v2/alerts -f -"*) cat > "$ALERT_PAYLOAD"; echo response-sentinel; [ "$KUBECTL_MODE" != api-fail ] ;;
+  *"port-forward"*"service/kube-prometheus-stack-alertmanager"*":9093"*)
+    [ "$PAGERDUTY_MODE" != forward-exit ] || { echo PORT_FORWARD_SENTINEL; exit 42; }
+    echo "$PAGERDUTY_FORWARD_LINE"
+    echo $$ > "$PAGERDUTY_PID"
+    trap 'echo reaped > "$PAGERDUTY_REAPED"; exit 0' TERM INT
+    while :; do /bin/sleep 1; done
+    ;;
   *"get ingress "*) exit 0 ;;
   *"get svc kube-prometheus-stack-grafana"*) echo 30300 ;;
   *"get servicemonitor dspace"*"metadata.labels.release"*) [ "$KUBECTL_MODE" = wrong-release ] && echo wrong || echo kube-prometheus-stack ;;
@@ -545,6 +553,30 @@ esac
 """,
         encoding="utf-8",
     )
+    (bin_dir / "curl").write_text(
+        """#!/bin/sh
+echo "curl $*" >> "$AUDIT"
+data=""
+while [ "$#" -gt 0 ]; do
+  [ "$1" != --data-binary ] || { shift; data=${1#@}; }
+  shift
+done
+[ -z "$data" ] || cp "$data" "$ALERT_PAYLOAD"
+case "$PAGERDUTY_MODE" in
+  transport) echo CURL_RESPONSE_SENTINEL >&2; exit 7 ;;
+  forward-exit-during-curl) kill -9 "$(cat "$PAGERDUTY_PID")"; /bin/sleep 0.1; code=200 ;;
+  http000) code=000 ;;
+  http415) code=415 ;;
+  http400) code=400 ;;
+  http503) code=503 ;;
+  malformed) code=not-a-status ;;
+  *) code=200 ;;
+esac
+printf RESPONSE_SENTINEL > "$TMPDIR"/sugarkube-alertmanager-test.*/response
+printf '%s' "$code"
+""",
+        encoding="utf-8",
+    )
     (bin_dir / "sleep").write_text(
         '#!/bin/sh\necho "sleep $*" >> "$AUDIT"\n',
         encoding="utf-8",
@@ -563,6 +595,10 @@ esac
         "TARGET_COUNTER": str(tmp_path / "target-counter"),
         "TARGET_RESPONSE_DELAY": target_response_delay,
         "ALERT_PAYLOAD": str(tmp_path / "alert-payload"),
+        "PAGERDUTY_MODE": pagerduty_mode,
+        "PAGERDUTY_FORWARD_LINE": pagerduty_forward_line,
+        "PAGERDUTY_PID": str(tmp_path / "pagerduty.pid"),
+        "PAGERDUTY_REAPED": str(tmp_path / "pagerduty.reaped"),
         "ALERTMANAGER_CONFIG": str(tmp_path / "alertmanager-config.yaml"),
         "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS": retry_attempts,
         "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS": retry_interval,
@@ -719,7 +755,14 @@ def test_pagerduty_fire_and_resolve_share_labels_and_bound_end_times(tmp_path):
         tmp_path / "resolve", "pagerduty-test", action="action=resolve"
     )
     assert fired.returncode == resolved.returncode == 0
-    assert "create --raw" in fire_audit and "create --raw" in resolve_audit
+    for audit in (fire_audit, resolve_audit):
+        assert "create --raw" not in audit
+        assert (
+            "port-forward --address=127.0.0.1 " "service/kube-prometheus-stack-alertmanager :9093"
+        ) in audit
+        assert "--header Content-Type: application/json" in audit
+        assert "--data-binary @" in audit
+        assert "http://127.0.0.1:43128/api/v2/alerts" in audit
     fire = json.loads((tmp_path / "fire" / "alert-payload").read_text())[0]
     resolve = json.loads((tmp_path / "resolve" / "alert-payload").read_text())[0]
     expected = {
@@ -734,25 +777,85 @@ def test_pagerduty_fire_and_resolve_share_labels_and_bound_end_times(tmp_path):
     fire_end = datetime.fromisoformat(fire["endsAt"].replace("Z", "+00:00"))
     resolve_end = datetime.fromisoformat(resolve["endsAt"].replace("Z", "+00:00"))
     assert 14 * 60 <= (fire_end - resolve_end).total_seconds() <= 16 * 60
-    assert set(fire["annotations"]) == {"summary", "description", "runbook_url"}
+    expected_annotations = {
+        "summary": "Sugarkube staging PagerDuty delivery test",
+        "description": (
+            "Operator-triggered synthetic alert for the staging PagerDuty fire/resolve drill."
+        ),
+        "runbook_url": (
+            "https://github.com/futuroptimist/sugarkube/blob/main/docs/"
+            "observability-operations.md#pagerduty-staging-fire-and-resolve-runbook"
+        ),
+    }
+    assert fire["annotations"] == resolve["annotations"] == expected_annotations
+    assert fire["startsAt"] == resolve["startsAt"] == "2020-01-01T00:00:00Z"
+    for directory in (tmp_path / "fire", tmp_path / "resolve"):
+        assert (directory / "pagerduty.reaped").read_text().strip() == "reaped"
+        assert not list(directory.glob("sugarkube-alertmanager-test.*"))
 
 
 @pytest.mark.parametrize("action", ["fire", "resolve"])
 def test_pagerduty_direct_bare_actions_remain_supported(tmp_path, action):
     result, audit = run_helper(tmp_path, "pagerduty-test", action=action)
-    assert result.returncode == 0 and "create --raw" in audit
-    assert "response-sentinel" not in result.stdout + result.stderr
-    assert not list(tmp_path.glob("sugarkube-alertmanager-response.*"))
+    assert result.returncode == 0 and "curl " in audit and "create --raw" not in audit
+    assert "RESPONSE_SENTINEL" not in result.stdout + result.stderr
+    assert not list(tmp_path.glob("sugarkube-alertmanager-test.*"))
 
 
-def test_pagerduty_api_failure_is_redacted_and_cleans_response(tmp_path):
-    result, _ = run_helper(
-        tmp_path, "pagerduty-test", action="action=fire", kubectl_mode="api-fail"
-    )
+@pytest.mark.parametrize(
+    "mode", ["transport", "http000", "http415", "http400", "http503", "malformed"]
+)
+def test_pagerduty_api_failure_is_redacted_and_cleans_response(tmp_path, mode):
+    result, _ = run_helper(tmp_path, "pagerduty-test", action="action=fire", pagerduty_mode=mode)
     assert result.returncode == 18
     assert "response redacted" in result.stderr
-    assert "response-sentinel" not in result.stdout + result.stderr
-    assert not list(tmp_path.glob("sugarkube-alertmanager-response.*"))
+    assert "RESPONSE_SENTINEL" not in result.stdout + result.stderr
+    assert "CURL_RESPONSE_SENTINEL" not in result.stdout + result.stderr
+    forward_pid = (tmp_path / "pagerduty.pid").read_text().strip()
+    assert not Path(f"/proc/{forward_pid}").exists()
+    assert not list(tmp_path.glob("sugarkube-alertmanager-test.*"))
+
+
+def test_pagerduty_rejects_port_forward_exit_during_submission(tmp_path):
+    result, audit = run_helper(
+        tmp_path,
+        "pagerduty-test",
+        action="fire",
+        pagerduty_mode="forward-exit-during-curl",
+    )
+    assert result.returncode == 19 and "curl " in audit
+    assert "diagnostics redacted" in result.stderr
+    forward_pid = (tmp_path / "pagerduty.pid").read_text().strip()
+    assert not Path(f"/proc/{forward_pid}").exists()
+    assert not list(tmp_path.glob("sugarkube-alertmanager-test.*"))
+
+
+@pytest.mark.parametrize(
+    ("mode", "line"),
+    [
+        ("forward-exit", "Forwarding from 127.0.0.1:43128 -> 9093"),
+        ("success", ""),
+        ("success", "Forwarding from 127.0.0.1:43128 -> 9094"),
+        ("success", "Forwarding from 0.0.0.0:43128 -> 9093"),
+        ("success", "noise Forwarding from 127.0.0.1:43128 -> 9093"),
+    ],
+)
+def test_pagerduty_port_forward_failures_are_redacted_and_cleaned(tmp_path, mode, line):
+    result, audit = run_helper(
+        tmp_path,
+        "pagerduty-test",
+        action="fire",
+        pagerduty_mode=mode,
+        pagerduty_forward_line=line,
+    )
+    assert result.returncode == 19
+    assert "curl " not in audit
+    assert "PORT_FORWARD_SENTINEL" not in result.stdout + result.stderr
+    assert not line or line not in result.stdout + result.stderr
+    if (tmp_path / "pagerduty.pid").exists():
+        assert (tmp_path / "pagerduty.reaped").read_text().strip() == "reaped"
+        assert not Path(f"/proc/{(tmp_path / 'pagerduty.pid').read_text().strip()}").exists()
+    assert not list(tmp_path.glob("sugarkube-alertmanager-test.*"))
 
 
 def test_status_requires_staging_identity(tmp_path):

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -557,10 +557,13 @@ esac
         """#!/bin/sh
 echo "curl $*" >> "$AUDIT"
 data=""
+noproxy=""
 while [ "$#" -gt 0 ]; do
   [ "$1" != --data-binary ] || { shift; data=${1#@}; }
+  [ "$1" != --noproxy ] || { shift; noproxy=$1; }
   shift
 done
+[ "$noproxy" = '*' ] || exit 64
 [ -z "$data" ] || cp "$data" "$ALERT_PAYLOAD"
 case "$PAGERDUTY_MODE" in
   transport) echo CURL_RESPONSE_SENTINEL >&2; exit 7 ;;

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -760,6 +760,7 @@ def test_pagerduty_fire_and_resolve_share_labels_and_bound_end_times(tmp_path):
         assert (
             "port-forward --address=127.0.0.1 " "service/kube-prometheus-stack-alertmanager :9093"
         ) in audit
+        assert "--noproxy *" in audit
         assert "--header Content-Type: application/json" in audit
         assert "--data-binary @" in audit
         assert "http://127.0.0.1:43128/api/v2/alerts" in audit
@@ -792,6 +793,14 @@ def test_pagerduty_fire_and_resolve_share_labels_and_bound_end_times(tmp_path):
     for directory in (tmp_path / "fire", tmp_path / "resolve"):
         assert (directory / "pagerduty.reaped").read_text().strip() == "reaped"
         assert not list(directory.glob("sugarkube-alertmanager-test.*"))
+
+
+def test_pagerduty_cleanup_trap_remains_installed_before_port_forward_starts():
+    script = SCRIPT.read_text(encoding="utf-8")
+    pagerduty = script.split("pagerduty_test() (", 1)[1].split("\n)\n\ndashboard_verify()", 1)[0]
+    start = pagerduty.index('kubectl -n "${NAMESPACE}" port-forward')
+    assert "trap cleanup_pagerduty_test EXIT" in pagerduty[:start]
+    assert "trap - EXIT" not in pagerduty
 
 
 @pytest.mark.parametrize("action", ["fire", "resolve"])


### PR DESCRIPTION
### Motivation
- The live staging drill exposed Alertmanager 0.33.1 returning an HTTP 415 (Unsupported Media Type) for the previous `kubectl create --raw .../api/v2/alerts` submission, so the synthetic PagerDuty fire/resolve recipe must send JSON with an explicit media type over an owned loopback port-forward. 
- The change must be fail-closed, maintain existing alert identity/semantics, avoid exposing secrets, and be fully covered by deterministic local tests.

### Description
- Replaced the `kubectl create --raw .../api/v2/alerts` POST in `pagerduty_test()` with an owned loopback-only `kubectl port-forward` to `service/${RELEASE}-alertmanager` and a `curl` POST to `http://127.0.0.1:<ephemeral>/api/v2/alerts` using `--header 'Content-Type: application/json'` and `--data-binary` to submit the same JSON payload. (modified `scripts/observability_helm.sh`).
- Implemented robust, loopback-only port-forward ownership and readiness checks: private temporary dir, parse only the expected `Forwarding from 127.0.0.1:<port> -> 9093` line, verify child PID is owned and alive, bounded startup wait, and deterministic cleanup on success, failure, `INT`, and `TERM`; introduced a distinct internal return code `19` for port-forward establishment failures while preserving `18` for Alertmanager/API submission failure.
- Kept the existing synthetic alert content unchanged (four labels, annotations, `startsAt`, `endsAt` semantics, 15-minute fire bound) and preserved the `fire`/`resolve` and `action=` interfaces and exit behaviors.
- Extended the deterministic test harness to model a long-running `kubectl port-forward` child and deterministic `curl` responses and added tests covering: explicit JSON `Content-Type` submission, use of `--data-binary`, successful fire/resolve, media-type/HTTP 415 regression, representative 4xx/5xx/transport failures, malformed forwarding lines, premature port-forward exit (including exit during submission), redaction of diagnostics, and reliable cleanup/reaping of the child process. (modified `tests/test_observability_helm.py`).
- Only the two authorized files were changed: `scripts/observability_helm.sh` and `tests/test_observability_helm.py`.

### Testing
- Ran unit tests focused on the PagerDuty recipe: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_observability_helm.py -k pagerduty` — 25 passed (65 deselected).
- Ran full test matrix: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_observability_helm.py` — 90 passed.
- Syntax and basic checks: `bash -n scripts/observability_helm.sh` — OK, `black --check tests/test_observability_helm.py` — OK, `git diff --check` — OK, `git diff HEAD | ./scripts/scan-secrets.py` — OK, `git diff --cached | ./scripts/scan-secrets.py` — OK, and `git diff --stat` shows only the two intended files changed.
- Notes: `shellcheck scripts/observability_helm.sh` and `pre-commit run --all-files` were not run because those tools are not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68f7ed1db8832faafda5992b26b7bb)