### PR TITLE
Fix staging PagerDuty synthetic Alertmanager submission

### DIFF
--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -269,24 +269,66 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
 )
 
 pagerduty_test() (
-  local action="${1:-}" ends_at endpoint response_file=""
+  local action="${1:-}" ends_at http_status="" line port="" remote_port=""
+  local -a port_forward_lines=()
+  local forward_pid="" test_tmp=""
   action="${action#action=}"
   case "${action}" in
     fire|resolve) ;;
     "") echo "ERROR: PagerDuty test requires an explicit action: fire or resolve." >&2; return 17 ;;
     *) echo "ERROR: unsupported PagerDuty test action '${action}'; expected fire or resolve." >&2; return 17 ;;
   esac
-  require_tools kubectl python3
+  require_tools kubectl python3 curl sleep
   assert_context
+  test_tmp="$(mktemp -d -t sugarkube-alertmanager-test.XXXXXX)"
+  chmod 700 "${test_tmp}"
+  # Port-forward establishment failures use 19; API/transport failures retain 18.
+  cleanup_pagerduty_test() {
+    if [[ -n "${forward_pid}" && " $(jobs -pr) " == *" ${forward_pid} "* ]]; then
+      kill "${forward_pid}" 2>/dev/null || true
+    fi
+    [[ -z "${forward_pid}" ]] || wait "${forward_pid}" 2>/dev/null || true
+    rm -rf "${test_tmp}"
+  }
+  port_forward_stopped() {
+    wait "${forward_pid}" 2>/dev/null || true
+    forward_pid=""
+    echo "ERROR: Alertmanager port-forward stopped (diagnostics redacted)." >&2
+    return 19
+  }
+  trap cleanup_pagerduty_test EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  : >"${test_tmp}/port-forward.log"
+  trap - EXIT
+  kubectl -n "${NAMESPACE}" port-forward --address=127.0.0.1 "service/${RELEASE}-alertmanager" :9093 >"${test_tmp}/port-forward.log" 2>&1 &
+  forward_pid=$!
+  trap cleanup_pagerduty_test EXIT
+  for _ in {1..20}; do
+    kill -0 "${forward_pid}" 2>/dev/null || port_forward_stopped
+    mapfile -t port_forward_lines <"${test_tmp}/port-forward.log"
+    for line in "${port_forward_lines[@]}"; do
+      if [[ "${line}" =~ ^Forwarding\ from\ 127\.0\.0\.1:([1-9][0-9]{0,4})\ -\>\ ([1-9][0-9]{0,4})$ ]]; then
+        port="${BASH_REMATCH[1]}"
+        remote_port="${BASH_REMATCH[2]}"
+        if ((10#${port} > 65535 || 10#${remote_port} > 65535)) || [[ "${remote_port}" != 9093 ]]; then
+          port=""
+        fi
+      fi
+    done
+    [[ -z "${port}" ]] || break
+    sleep 1
+  done
+  [[ -n "${port}" ]] || { echo "ERROR: Alertmanager port-forward did not establish an owned loopback listener on remote port 9093 (diagnostics redacted)." >&2; return 19; }
+  kill -0 "${forward_pid}" 2>/dev/null || port_forward_stopped
+
   ends_at="$(ACTION="${action}" python3 -c 'from datetime import datetime, timedelta, timezone
 import os
 now = datetime.now(timezone.utc)
 end = now + timedelta(minutes=15) if os.environ["ACTION"] == "fire" else now
 print(end.isoformat(timespec="seconds").replace("+00:00", "Z"))')"
-  endpoint="/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-alertmanager:9093/proxy/api/v2/alerts"
-  trap 'rm -f "${response_file:-}"' EXIT
-  response_file="$(mktemp -t sugarkube-alertmanager-response.XXXXXX)"
-  if ! ENDS_AT="${ends_at}" python3 -c 'import json, os, sys
+  ENDS_AT="${ends_at}" python3 -c 'import json, os, sys
 json.dump([{
   "labels": {
     "alertname": "SugarkubePagerDutyTest",
@@ -301,10 +343,20 @@ json.dump([{
   },
   "startsAt": "2020-01-01T00:00:00Z",
   "endsAt": os.environ["ENDS_AT"]
-}], sys.stdout)' | kubectl create --raw "${endpoint}" -f - >"${response_file}" 2>/dev/null; then
+}], sys.stdout)' >"${test_tmp}/payload.json"
+  if ! curl --silent --show-error --connect-timeout 3 --max-time 10 \
+    --header 'Content-Type: application/json' --data-binary "@${test_tmp}/payload.json" \
+    --output "${test_tmp}/response" --write-out '%{http_code}' \
+    "http://127.0.0.1:${port}/api/v2/alerts" >"${test_tmp}/status" 2>"${test_tmp}/curl.log"; then
     echo "ERROR: Alertmanager v2 API rejected synthetic ${action} request (response redacted)." >&2
     return 18
   fi
+  kill -0 "${forward_pid}" 2>/dev/null || port_forward_stopped
+  IFS= read -r http_status <"${test_tmp}/status" || true
+  [[ "${http_status}" == 200 ]] || {
+    echo "ERROR: Alertmanager v2 API rejected synthetic ${action} request (response redacted)." >&2
+    return 18
+  }
   echo "PagerDuty synthetic ${action} submitted; Alertmanager API status: accepted (response redacted)."
 )
 

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -479,6 +479,8 @@ def run_helper(
     retry_attempts="3",
     retry_interval="1",
     action=None,
+    curl_mode="success",
+    forward_line="Forwarding from 127.0.0.1:43127 -> 9093",
 ):
     """Run the lifecycle against deterministic command stubs and return its audit log."""
     bin_dir = tmp_path / "bin"
@@ -521,7 +523,13 @@ case "$*" in
     [ "$KUBECTL_MODE" != malformed-alertmanager ] && sed 's/^/    /' "$ALERTMANAGER_CONFIG" || printf '%s\n' '    route: [unterminated'
     ;;
   *"get secret alertmanager-pagerduty -o go-template="*) [ "$KUBECTL_MODE" != missing-pagerduty ] || exit 44; [ "$KUBECTL_MODE" != empty-pagerduty ] && echo present ;;
-  *"create --raw "*"/api/v2/alerts -f -"*) cat > "$ALERT_PAYLOAD"; echo response-sentinel; [ "$KUBECTL_MODE" != api-fail ] ;;
+  *"port-forward --address=127.0.0.1 service/kube-prometheus-stack-alertmanager :9093"*)
+    echo $$ > "$FORWARD_PID"
+    trap 'echo terminated > "$FORWARD_REAPED"; exit 0' TERM INT
+    [ "$KUBECTL_MODE" != forward-exit ] || { echo port-forward-sentinel >&2; exit 42; }
+    [ "$KUBECTL_MODE" = forward-timeout ] || echo "$FORWARD_LINE"
+    while :; do /bin/sleep 1; done
+    ;;
   *"get ingress "*) exit 0 ;;
   *"get svc kube-prometheus-stack-grafana"*) echo 30300 ;;
   *"get servicemonitor dspace"*"metadata.labels.release"*) [ "$KUBECTL_MODE" = wrong-release ] && echo wrong || echo kube-prometheus-stack ;;
@@ -545,6 +553,40 @@ esac
 """,
         encoding="utf-8",
     )
+    (bin_dir / "curl").write_text(
+        """#!/bin/sh
+echo "curl $*" >> "$AUDIT"
+header= data= output= status_output= url=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --header) header=$2; shift 2 ;;
+    --data-binary) data=$2; shift 2 ;;
+    --output) output=$2; shift 2 ;;
+    --write-out) status_output=$2; shift 2 ;;
+    http://*) url=$1; shift ;;
+    --connect-timeout|--max-time) shift 2 ;;
+    --silent|--show-error) shift ;;
+    *) exit 61 ;;
+  esac
+done
+[ "$header" = "Content-Type: application/json" ] || exit 62
+[ "$status_output" = "%{http_code}" ] || exit 63
+[ "$url" = "http://127.0.0.1:43127/api/v2/alerts" ] || exit 64
+case "$data" in @*) cp "${data#@}" "$ALERT_PAYLOAD" ;; *) exit 65 ;; esac
+printf response-sentinel > "$output"
+case "$CURL_MODE" in
+  premature) kill "$(cat "$FORWARD_PID")"; /bin/sleep 1; printf 200 ;;
+  transport) echo curl-sentinel >&2; exit 7 ;;
+  malformed) printf bad-status ;;
+  http415) printf 415 ;;
+  http404) printf 404 ;;
+  http503) printf 503 ;;
+  http000) printf 000 ;;
+  *) printf 200 ;;
+esac
+""",
+        encoding="utf-8",
+    )
     (bin_dir / "sleep").write_text(
         '#!/bin/sh\necho "sleep $*" >> "$AUDIT"\n',
         encoding="utf-8",
@@ -563,6 +605,10 @@ esac
         "TARGET_COUNTER": str(tmp_path / "target-counter"),
         "TARGET_RESPONSE_DELAY": target_response_delay,
         "ALERT_PAYLOAD": str(tmp_path / "alert-payload"),
+        "CURL_MODE": curl_mode,
+        "FORWARD_LINE": forward_line,
+        "FORWARD_PID": str(tmp_path / "port-forward.pid"),
+        "FORWARD_REAPED": str(tmp_path / "port-forward.reaped"),
         "ALERTMANAGER_CONFIG": str(tmp_path / "alertmanager-config.yaml"),
         "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS": retry_attempts,
         "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS": retry_interval,
@@ -719,7 +765,15 @@ def test_pagerduty_fire_and_resolve_share_labels_and_bound_end_times(tmp_path):
         tmp_path / "resolve", "pagerduty-test", action="action=resolve"
     )
     assert fired.returncode == resolved.returncode == 0
-    assert "create --raw" in fire_audit and "create --raw" in resolve_audit
+    for audit in (fire_audit, resolve_audit):
+        assert "create --raw" not in audit
+        assert (
+            "port-forward --address=127.0.0.1 "
+            "service/kube-prometheus-stack-alertmanager :9093" in audit
+        )
+        assert "--header Content-Type: application/json" in audit
+        assert "--data-binary @" in audit
+        assert "http://127.0.0.1:43127/api/v2/alerts" in audit
     fire = json.loads((tmp_path / "fire" / "alert-payload").read_text())[0]
     resolve = json.loads((tmp_path / "resolve" / "alert-payload").read_text())[0]
     expected = {
@@ -734,25 +788,85 @@ def test_pagerduty_fire_and_resolve_share_labels_and_bound_end_times(tmp_path):
     fire_end = datetime.fromisoformat(fire["endsAt"].replace("Z", "+00:00"))
     resolve_end = datetime.fromisoformat(resolve["endsAt"].replace("Z", "+00:00"))
     assert 14 * 60 <= (fire_end - resolve_end).total_seconds() <= 16 * 60
-    assert set(fire["annotations"]) == {"summary", "description", "runbook_url"}
+    assert (
+        fire["annotations"]
+        == resolve["annotations"]
+        == {
+            "summary": "Sugarkube staging PagerDuty delivery test",
+            "description": (
+                "Operator-triggered synthetic alert for the staging PagerDuty fire/resolve drill."
+            ),
+            "runbook_url": (
+                "https://github.com/futuroptimist/sugarkube/blob/main/"
+                "docs/observability-operations.md#pagerduty-staging-fire-and-resolve-runbook"
+            ),
+        }
+    )
+    assert fire["startsAt"] == resolve["startsAt"] == "2020-01-01T00:00:00Z"
 
 
 @pytest.mark.parametrize("action", ["fire", "resolve"])
 def test_pagerduty_direct_bare_actions_remain_supported(tmp_path, action):
     result, audit = run_helper(tmp_path, "pagerduty-test", action=action)
-    assert result.returncode == 0 and "create --raw" in audit
+    assert result.returncode == 0 and "create --raw" not in audit and "curl " in audit
     assert "response-sentinel" not in result.stdout + result.stderr
-    assert not list(tmp_path.glob("sugarkube-alertmanager-response.*"))
+    assert not list(tmp_path.glob("sugarkube-alertmanager-test.*"))
+    assert (tmp_path / "port-forward.reaped").read_text().strip() == "terminated"
+    assert not Path(f"/proc/{int((tmp_path / 'port-forward.pid').read_text())}").exists()
 
 
-def test_pagerduty_api_failure_is_redacted_and_cleans_response(tmp_path):
-    result, _ = run_helper(
-        tmp_path, "pagerduty-test", action="action=fire", kubectl_mode="api-fail"
-    )
+@pytest.mark.parametrize(
+    "curl_mode", ["transport", "http000", "malformed", "http415", "http404", "http503"]
+)
+def test_pagerduty_api_failure_is_redacted_and_cleans_response(tmp_path, curl_mode):
+    result, _ = run_helper(tmp_path, "pagerduty-test", action="action=fire", curl_mode=curl_mode)
     assert result.returncode == 18
     assert "response redacted" in result.stderr
     assert "response-sentinel" not in result.stdout + result.stderr
-    assert not list(tmp_path.glob("sugarkube-alertmanager-response.*"))
+    assert "curl-sentinel" not in result.stdout + result.stderr
+    assert not list(tmp_path.glob("sugarkube-alertmanager-test.*"))
+    assert (tmp_path / "port-forward.reaped").read_text().strip() == "terminated"
+    assert not Path(f"/proc/{int((tmp_path / 'port-forward.pid').read_text())}").exists()
+
+
+def test_pagerduty_rejects_port_forward_exit_during_submission(tmp_path):
+    result, _ = run_helper(tmp_path, "pagerduty-test", action="fire", curl_mode="premature")
+    assert result.returncode == 19
+    assert "diagnostics redacted" in result.stderr
+    assert "response-sentinel" not in result.stdout + result.stderr
+    assert not list(tmp_path.glob("sugarkube-alertmanager-test.*"))
+    assert (tmp_path / "port-forward.reaped").read_text().strip() == "terminated"
+    assert not Path(f"/proc/{int((tmp_path / 'port-forward.pid').read_text())}").exists()
+
+
+@pytest.mark.parametrize(
+    ("mode", "forward_line"),
+    [
+        ("forward-exit", "Forwarding from 127.0.0.1:43127 -> 9093"),
+        ("forward-timeout", "Forwarding from 127.0.0.1:43127 -> 9093"),
+        ("healthy", "Forwarding from 127.0.0.1:43127 -> 9094"),
+        ("healthy", "Forwarding from 0.0.0.0:43127 -> 9093"),
+        ("healthy", "noise Forwarding from 127.0.0.1:43127 -> 9093"),
+    ],
+)
+def test_pagerduty_port_forward_failures_are_closed_redacted_and_cleaned(
+    tmp_path, mode, forward_line
+):
+    result, audit = run_helper(
+        tmp_path,
+        "pagerduty-test",
+        action="fire",
+        kubectl_mode=mode,
+        forward_line=forward_line,
+    )
+    assert result.returncode == 19
+    assert "curl " not in audit
+    assert "port-forward-sentinel" not in result.stdout + result.stderr
+    assert forward_line not in result.stdout + result.stderr
+    assert "diagnostics redacted" in result.stderr
+    assert not list(tmp_path.glob("sugarkube-alertmanager-test.*"))
+    if (tmp_path / "port-forward.pid").exists():
+        assert not Path(f"/proc/{int((tmp_path / 'port-forward.pid').read_text())}").exists()
 
 
 def test_status_requires_staging_identity(tmp_path):


### PR DESCRIPTION
### Motivation
- The staging PagerDuty drill revealed Alertmanager 0.33.1 rejects the service-proxy POST because `kubectl create --raw` did not supply the JSON media type, causing HTTP 415 UnsupportedMediaType. 
- The recipe must submit the unchanged synthetic alert to Alertmanager over an owned loopback listener with deterministic port-forward ownership, readiness checks, and redacted diagnostics. 

### Description
- Replace the `kubectl create --raw .../api/v2/alerts` path in `pagerduty_test()` with an ephemeral, loopback-only `kubectl port-forward` to `service/${RELEASE}-alertmanager` that forwards remote port `9093` to an ephemeral local port and validates only a `Forwarding from 127.0.0.1:<port> -> 9093` line. 
- Submit the existing synthetic JSON array via `curl` with explicit `Content-Type: application/json`, `--data-binary`, bounded `--connect-timeout`/`--max-time`, capture response/status in private temp files, and accept only HTTP `200`; transport/API failures preserve exit code `18` while port-forward establishment failures use exit code `19`. 
- Preserve all alert identity, labels, annotations, fixed `startsAt` and 15‑minute fire semantics, resolve semantics, and recipe interface (supports both `fire|resolve` and `action=...`). 
- Reuse the safety properties of the existing `dashboard_verify()` pattern for private temp dir, child PID ownership/liveness checks, bounded readiness loop, reliable kill/wait on success/failure/`INT`/`TERM`, and redacted diagnostics. 
- Extend the deterministic local stub harness in `tests/test_observability_helm.py` with port-forward and `curl` stubs and add parametrized coverage for media-type regression, curl transport errors, malformed/HTTP error responses, invalid forwarding lines, premature port-forward exit, redaction, and process/temp cleanup. 

### Testing
- Ran the focused pagerduty tests: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_observability_helm.py -k 'pagerduty'` which returned `25 passed, 65 deselected`. 
- Ran the full test file: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_observability_helm.py` which returned `90 passed` (all tests in that file). 
- Syntax/lint/infra checks executed: `bash -n scripts/observability_helm.sh` (ok), `black --check tests/test_observability_helm.py` (ok), `git diff --check` (ok), `git diff HEAD | ./scripts/scan-secrets.py` (ok), and `git diff --stat` showing only the two authorized files changed; `shellcheck` and `pre-commit` were not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68f7f1c8fc832f93871de467044097)