### PR TITLE
Fix staging PagerDuty synthetic Alertmanager submission

### DIFF
--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -269,24 +269,44 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
 )
 
 pagerduty_test() (
-  local action="${1:-}" ends_at endpoint response_file=""
+  local action="${1:-}" ends_at http_status="" line port="" remote_port
+  local pagerduty_pid="" pagerduty_tmp
+  local -a port_forward_lines=()
   action="${action#action=}"
   case "${action}" in
     fire|resolve) ;;
     "") echo "ERROR: PagerDuty test requires an explicit action: fire or resolve." >&2; return 17 ;;
     *) echo "ERROR: unsupported PagerDuty test action '${action}'; expected fire or resolve." >&2; return 17 ;;
   esac
-  require_tools kubectl python3
+  require_tools kubectl python3 curl sleep
   assert_context
+  pagerduty_tmp="$(mktemp -d -t sugarkube-pagerduty-test.XXXXXX)"
+  chmod 700 "${pagerduty_tmp}"
+  # The EXIT trap invokes this cleanup callback indirectly.
+  # shellcheck disable=SC2317
+  cleanup_pagerduty_test() {
+    if [[ -n "${pagerduty_pid}" && " $(jobs -pr) " == *" ${pagerduty_pid} "* ]]; then
+      kill "${pagerduty_pid}" 2>/dev/null || true
+    fi
+    [[ -z "${pagerduty_pid}" ]] || wait "${pagerduty_pid}" 2>/dev/null || true
+    rm -rf "${pagerduty_tmp}"
+  }
+  pagerduty_port_forward_stopped() {
+    wait "${pagerduty_pid}" 2>/dev/null || true
+    pagerduty_pid=""
+    echo "ERROR: Alertmanager port-forward stopped (diagnostics redacted)." >&2
+    return 19
+  }
+  trap cleanup_pagerduty_test EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
   ends_at="$(ACTION="${action}" python3 -c 'from datetime import datetime, timedelta, timezone
 import os
 now = datetime.now(timezone.utc)
 end = now + timedelta(minutes=15) if os.environ["ACTION"] == "fire" else now
 print(end.isoformat(timespec="seconds").replace("+00:00", "Z"))')"
-  endpoint="/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-alertmanager:9093/proxy/api/v2/alerts"
-  trap 'rm -f "${response_file:-}"' EXIT
-  response_file="$(mktemp -t sugarkube-alertmanager-response.XXXXXX)"
-  if ! ENDS_AT="${ends_at}" python3 -c 'import json, os, sys
+  ENDS_AT="${ends_at}" python3 -c 'import json, os, sys
 json.dump([{
   "labels": {
     "alertname": "SugarkubePagerDutyTest",
@@ -301,10 +321,44 @@ json.dump([{
   },
   "startsAt": "2020-01-01T00:00:00Z",
   "endsAt": os.environ["ENDS_AT"]
-}], sys.stdout)' | kubectl create --raw "${endpoint}" -f - >"${response_file}" 2>/dev/null; then
+}], sys.stdout)' >"${pagerduty_tmp}/payload.json"
+
+  : >"${pagerduty_tmp}/port-forward.log"
+  trap - EXIT
+  kubectl -n "${NAMESPACE}" port-forward --address=127.0.0.1 "service/${RELEASE}-alertmanager" :9093 >"${pagerduty_tmp}/port-forward.log" 2>&1 &
+  pagerduty_pid=$!
+  trap cleanup_pagerduty_test EXIT
+  for _ in {1..20}; do
+    kill -0 "${pagerduty_pid}" 2>/dev/null || pagerduty_port_forward_stopped
+    mapfile -t port_forward_lines <"${pagerduty_tmp}/port-forward.log"
+    for line in "${port_forward_lines[@]}"; do
+      if [[ "${line}" =~ ^Forwarding\ from\ 127\.0\.0\.1:([1-9][0-9]{0,4})\ -\>\ ([1-9][0-9]{0,4})$ ]]; then
+        port="${BASH_REMATCH[1]}"
+        remote_port="${BASH_REMATCH[2]}"
+        if ((10#${port} > 65535 || 10#${remote_port} != 9093)); then
+          port=""
+        fi
+      fi
+    done
+    [[ -z "${port}" ]] || break
+    sleep 1
+  done
+  [[ -n "${port}" ]] || { echo "ERROR: Alertmanager port-forward did not establish an owned loopback listener (diagnostics redacted)." >&2; return 19; }
+  kill -0 "${pagerduty_pid}" 2>/dev/null || pagerduty_port_forward_stopped
+
+  if ! curl --silent --show-error --connect-timeout 3 --max-time 10 \
+    --header "Content-Type: application/json" --data-binary "@${pagerduty_tmp}/payload.json" \
+    --output "${pagerduty_tmp}/response" --write-out '%{http_code}' \
+    "http://127.0.0.1:${port}/api/v2/alerts" >"${pagerduty_tmp}/status" 2>"${pagerduty_tmp}/curl.log"; then
     echo "ERROR: Alertmanager v2 API rejected synthetic ${action} request (response redacted)." >&2
     return 18
   fi
+  kill -0 "${pagerduty_pid}" 2>/dev/null || pagerduty_port_forward_stopped
+  IFS= read -r http_status <"${pagerduty_tmp}/status" || true
+  [[ "${http_status}" =~ ^[0-9]{3}$ && "${http_status}" == 200 ]] || {
+    echo "ERROR: Alertmanager v2 API rejected synthetic ${action} request (response redacted)." >&2
+    return 18
+  }
   echo "PagerDuty synthetic ${action} submitted; Alertmanager API status: accepted (response redacted)."
 )
 

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -479,6 +479,8 @@ def run_helper(
     retry_attempts="3",
     retry_interval="1",
     action=None,
+    pagerduty_forward_mode="ready",
+    pagerduty_curl_mode="200",
 ):
     """Run the lifecycle against deterministic command stubs and return its audit log."""
     bin_dir = tmp_path / "bin"
@@ -521,7 +523,18 @@ case "$*" in
     [ "$KUBECTL_MODE" != malformed-alertmanager ] && sed 's/^/    /' "$ALERTMANAGER_CONFIG" || printf '%s\n' '    route: [unterminated'
     ;;
   *"get secret alertmanager-pagerduty -o go-template="*) [ "$KUBECTL_MODE" != missing-pagerduty ] || exit 44; [ "$KUBECTL_MODE" != empty-pagerduty ] && echo present ;;
-  *"create --raw "*"/api/v2/alerts -f -"*) cat > "$ALERT_PAYLOAD"; echo response-sentinel; [ "$KUBECTL_MODE" != api-fail ] ;;
+  *"port-forward --address=127.0.0.1 service/kube-prometheus-stack-alertmanager :9093"*)
+    echo $$ > "$FORWARD_PID"
+    trap 'echo terminated >> "$FORWARD_EVENTS"; exit 0' TERM INT
+    case "$PAGERDUTY_FORWARD_MODE" in
+      early-exit) echo port-forward-sentinel >&2; exit 51 ;;
+      no-listener) echo port-forward-sentinel >&2 ;;
+      malformed) echo 'Forwarding from 0.0.0.0:43123 -> 9093' >&2 ;;
+      wrong-remote) echo 'Forwarding from 127.0.0.1:43123 -> 9094' >&2 ;;
+      *) echo 'Forwarding from 127.0.0.1:43123 -> 9093' >&2 ;;
+    esac
+    while :; do /bin/sleep 1; done
+    ;;
   *"get ingress "*) exit 0 ;;
   *"get svc kube-prometheus-stack-grafana"*) echo 30300 ;;
   *"get servicemonitor dspace"*"metadata.labels.release"*) [ "$KUBECTL_MODE" = wrong-release ] && echo wrong || echo kube-prometheus-stack ;;
@@ -545,6 +558,29 @@ esac
 """,
         encoding="utf-8",
     )
+    (bin_dir / "curl").write_text(
+        """#!/bin/sh
+echo "curl $*" >> "$AUDIT"
+output= status= data=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output=$2; shift 2 ;;
+    --write-out) shift 2 ;;
+    --data-binary) data=${2#@}; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -z "$data" ] || cp "$data" "$ALERT_PAYLOAD"
+printf '%s' response-sentinel > "$output"
+case "$PAGERDUTY_CURL_MODE" in
+  transport) echo curl-diagnostic-sentinel >&2; exit 7 ;;
+  malformed) status=not-a-status ;;
+  *) status=$PAGERDUTY_CURL_MODE ;;
+esac
+printf '%s' "$status"
+""",
+        encoding="utf-8",
+    )
     (bin_dir / "sleep").write_text(
         '#!/bin/sh\necho "sleep $*" >> "$AUDIT"\n',
         encoding="utf-8",
@@ -563,6 +599,10 @@ esac
         "TARGET_COUNTER": str(tmp_path / "target-counter"),
         "TARGET_RESPONSE_DELAY": target_response_delay,
         "ALERT_PAYLOAD": str(tmp_path / "alert-payload"),
+        "FORWARD_PID": str(tmp_path / "port-forward.pid"),
+        "FORWARD_EVENTS": str(tmp_path / "port-forward.events"),
+        "PAGERDUTY_FORWARD_MODE": pagerduty_forward_mode,
+        "PAGERDUTY_CURL_MODE": pagerduty_curl_mode,
         "ALERTMANAGER_CONFIG": str(tmp_path / "alertmanager-config.yaml"),
         "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS": retry_attempts,
         "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS": retry_interval,
@@ -719,7 +759,14 @@ def test_pagerduty_fire_and_resolve_share_labels_and_bound_end_times(tmp_path):
         tmp_path / "resolve", "pagerduty-test", action="action=resolve"
     )
     assert fired.returncode == resolved.returncode == 0
-    assert "create --raw" in fire_audit and "create --raw" in resolve_audit
+    for audit in (fire_audit, resolve_audit):
+        assert "create --raw" not in audit
+        assert (
+            "port-forward --address=127.0.0.1 " "service/kube-prometheus-stack-alertmanager :9093"
+        ) in audit
+        assert "--header Content-Type: application/json" in audit
+        assert "--data-binary @" in audit
+        assert "http://127.0.0.1:43123/api/v2/alerts" in audit
     fire = json.loads((tmp_path / "fire" / "alert-payload").read_text())[0]
     resolve = json.loads((tmp_path / "resolve" / "alert-payload").read_text())[0]
     expected = {
@@ -734,25 +781,64 @@ def test_pagerduty_fire_and_resolve_share_labels_and_bound_end_times(tmp_path):
     fire_end = datetime.fromisoformat(fire["endsAt"].replace("Z", "+00:00"))
     resolve_end = datetime.fromisoformat(resolve["endsAt"].replace("Z", "+00:00"))
     assert 14 * 60 <= (fire_end - resolve_end).total_seconds() <= 16 * 60
-    assert set(fire["annotations"]) == {"summary", "description", "runbook_url"}
+    expected_annotations = {
+        "summary": "Sugarkube staging PagerDuty delivery test",
+        "description": (
+            "Operator-triggered synthetic alert for the staging PagerDuty fire/resolve drill."
+        ),
+        "runbook_url": (
+            "https://github.com/futuroptimist/sugarkube/blob/main/"
+            "docs/observability-operations.md#pagerduty-staging-fire-and-resolve-runbook"
+        ),
+    }
+    assert fire["annotations"] == resolve["annotations"] == expected_annotations
+    assert fire["startsAt"] == resolve["startsAt"] == "2020-01-01T00:00:00Z"
 
 
 @pytest.mark.parametrize("action", ["fire", "resolve"])
 def test_pagerduty_direct_bare_actions_remain_supported(tmp_path, action):
     result, audit = run_helper(tmp_path, "pagerduty-test", action=action)
-    assert result.returncode == 0 and "create --raw" in audit
+    assert result.returncode == 0 and "create --raw" not in audit
     assert "response-sentinel" not in result.stdout + result.stderr
-    assert not list(tmp_path.glob("sugarkube-alertmanager-response.*"))
+    assert not list(tmp_path.glob("sugarkube-pagerduty-test.*"))
+    assert (tmp_path / "port-forward.events").read_text().strip() == "terminated"
 
 
-def test_pagerduty_api_failure_is_redacted_and_cleans_response(tmp_path):
+@pytest.mark.parametrize("status", ["000", "415", "400", "500", "malformed"])
+def test_pagerduty_api_failure_is_redacted_and_cleans_response(tmp_path, status):
     result, _ = run_helper(
-        tmp_path, "pagerduty-test", action="action=fire", kubectl_mode="api-fail"
+        tmp_path, "pagerduty-test", action="action=fire", pagerduty_curl_mode=status
     )
     assert result.returncode == 18
     assert "response redacted" in result.stderr
     assert "response-sentinel" not in result.stdout + result.stderr
-    assert not list(tmp_path.glob("sugarkube-alertmanager-response.*"))
+    assert "port-forward-sentinel" not in result.stdout + result.stderr
+    assert not list(tmp_path.glob("sugarkube-pagerduty-test.*"))
+    assert (tmp_path / "port-forward.events").read_text().strip() == "terminated"
+
+
+def test_pagerduty_curl_transport_failure_is_redacted_and_cleaned(tmp_path):
+    result, _ = run_helper(
+        tmp_path, "pagerduty-test", action="resolve", pagerduty_curl_mode="transport"
+    )
+    assert result.returncode == 18
+    assert "curl-diagnostic-sentinel" not in result.stdout + result.stderr
+    assert "response-sentinel" not in result.stdout + result.stderr
+    assert not list(tmp_path.glob("sugarkube-pagerduty-test.*"))
+    assert (tmp_path / "port-forward.events").read_text().strip() == "terminated"
+
+
+@pytest.mark.parametrize("mode", ["early-exit", "no-listener", "malformed", "wrong-remote"])
+def test_pagerduty_port_forward_failures_are_closed_redacted_and_cleaned(tmp_path, mode):
+    result, audit = run_helper(
+        tmp_path, "pagerduty-test", action="fire", pagerduty_forward_mode=mode
+    )
+    assert result.returncode == 19
+    assert "curl " not in audit
+    assert "port-forward-sentinel" not in result.stdout + result.stderr
+    assert not list(tmp_path.glob("sugarkube-pagerduty-test.*"))
+    if mode != "early-exit":
+        assert (tmp_path / "port-forward.events").read_text().strip() == "terminated"
 
 
 def test_status_requires_staging_identity(tmp_path):


### PR DESCRIPTION
### Motivation
- The Kubernetes service proxy rejected the Alertmanager v2 alerts POST because `kubectl create --raw` did not supply the explicit JSON media type required by Alertmanager 0.33.1, causing the staging PagerDuty fire/resolve recipe to fail with an UnsupportedMediaType error.

### Description
- Replace the `kubectl create --raw .../api/v2/alerts` POST in `pagerduty_test()` with an owned, ephemeral loopback-only `kubectl port-forward` to `service/${RELEASE}-alertmanager` and submit the payload with `curl` using `--header "Content-Type: application/json"` and `--data-binary` to `http://127.0.0.1:<ephemeral>/api/v2/alerts` while capturing responses in a private tmpdir; only an HTTP 200 response is accepted and the existing API-failure exit code `18` is preserved for submission failures. (changes to `scripts/observability_helm.sh`)
- Implement robust port-forward ownership, readiness parsing (explicitly matching `Forwarding from 127.0.0.1:<port> -> 9093`), bounded startup retries, child-liveness checks, deterministic cleanup (kill/wait and tempdir removal), `INT`/`TERM` handling, and a distinct closed failure return code `19` for port-forward establishment failures. (changes to `scripts/observability_helm.sh`)
- Extend the deterministic local stub harness to model a long-running `kubectl port-forward` and deterministic `curl` behavior, and add tests to validate: ephemeral loopback forwarding, explicit JSON `Content-Type`, `--data-binary` usage, preserved alert labels/annotations/fingerprint/timing, removal of `create --raw`, and many failure modes including malformed forwarding lines, wrong remote ports, premature port-forward exit, curl transport failures, and representative HTTP 4xx/5xx responses. (changes to `tests/test_observability_helm.py`)
- Preserve all safety and secrecy requirements: the recipe never reads or exposes the PagerDuty secret, keeps diagnostics redacted, and retains the existing recipe interface and semantics for `fire`/`resolve` actions.

### Testing
- Ran the focused PagerDuty tests with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_observability_helm.py -k pagerduty` and observed `23 passed`.
- Ran the full unit suite with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_observability_helm.py` and observed `88 passed`.
- Performed static/script checks: `bash -n scripts/observability_helm.sh` succeeded, `black --check tests/test_observability_helm.py` succeeded after formatting, `git diff --check` and `git diff HEAD | ./scripts/scan-secrets.py` produced no secret regressions, and `git diff --stat` shows only the two authorized files changed.
- Notes about environment limits: `shellcheck scripts/observability_helm.sh` and `pre-commit run --all-files` were not available in the execution environment (not installed), so those checks could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68f7f614d0832fb930880582b95f25)