### PR TITLE
Add secret-safe staging node heartbeats

### DIFF
--- a/clusters/staging/nodes.txt
+++ b/clusters/staging/nodes.txt
@@ -1,0 +1,4 @@
+# Canonical physical-node inventory for staging-only host operations.
+sugarkube3
+sugarkube4
+sugarkube5

--- a/docs/observability-alerting.md
+++ b/docs/observability-alerting.md
@@ -72,10 +72,12 @@ flowchart LR
 
 ## 3. External heartbeats
 
-Planned checks:
+Current node-heartbeat slice and planned watchdog:
 
-- One host-level heartbeat per staging node — `sugarkube3`, `sugarkube4`, `sugarkube5` — each a
-  `systemd` timer running directly on that node, pinging its own dedicated Healthchecks.io check.
+- Repository-owned installation, verification, status, and rollback support now exists for one
+  host-level heartbeat per staging node — `sugarkube3`, `sugarkube4`, `sugarkube5`. Each uses a
+  one-minute `systemd` timer and its own systemd credential. Post-merge installation on the Pis is
+  still required; repository support is not a claim that a check has received its first ping.
 - One observability watchdog heartbeat whose successful path traverses Prometheus and Alertmanager
   before reaching Healthchecks.io (for example, a Prometheus rule that is always true, routed through
   Alertmanager to a webhook receiver that pings Healthchecks.io for each Alertmanager notification).
@@ -99,9 +101,14 @@ CronJob only proves the k3s control plane can still schedule pods somewhere in t
 particular physical node is powered on and reachable. A `systemd` timer running on the node itself is
 the only check that actually proves that node is alive.
 
-Each Healthchecks.io check gets its own unique ping URL. These URLs must be stored outside Git — in
-root-readable local configuration on the node (e.g. an `EnvironmentFile` read by the timer's unit) or
-in a suitable secret store, never committed to this repository.
+Each Healthchecks.io check gets its own unique ping URL. The installer stores it only in a root-owned,
+mode-`0600` node-local file and systemd exposes it to the oneshot with `LoadCredential=`. Debian
+Bookworm's systemd baseline supports this mechanism, so an environment file is neither needed nor
+permitted. The URL never belongs in Git, shell arguments, exported variables, logs, or documentation.
+
+The checks expect a ping every minute and allow two minutes of grace. A sustained node failure should
+therefore page through Healthchecks.io to PagerDuty after approximately three minutes (one period plus
+grace), subject to external delivery latency.
 
 What each check detects, and does not:
 
@@ -120,9 +127,10 @@ What each check detects, and does not:
 - Staging repository support now mounts `monitoring/alertmanager-pagerduty` and reads its
   `routing-key` key from
   `/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key`; the credential is never inline.
-  The only PagerDuty route is the exact `SugarkubePagerDutyTest` synthetic allowlist. This is
-  repository support, not evidence that it has been deployed or that phone delivery and resolution
-  have been manually proven.
+  The only PagerDuty route is the exact `SugarkubePagerDutyTest` synthetic allowlist. Its staging
+  fire, phone receipt, acknowledgement, resolve submission, and eventual PagerDuty resolution have
+  been manually proven. Alertmanager's default `resolve_timeout: 5m` can make the final resolved
+  transition take approximately five minutes after the explicit resolve submission.
 - Set `send_resolved: true` on the PagerDuty receiver so incidents auto-resolve when the underlying
   alert clears.
 - Define sensible `group_by`, `group_wait`, `group_interval`, and `repeat_interval` values so a single

--- a/docs/observability-design.md
+++ b/docs/observability-design.md
@@ -348,7 +348,11 @@ Do not page on symptoms without a response path, such as low traffic, GitHub sta
 3. **Blackbox monitoring**: *implemented in staging.* 16 public probes across all four apps plus TLS expiry are live and scripted-verified, per [`docs/observability-blackbox.md`](./observability-blackbox.md).
 4. **Application scrape integration**: app repos expose safe metrics and chart scrape hooks; Sugarkube enables discovery per environment. DSPACE's authenticated `ServiceMonitor` is live in staging (§7); token.place and danielsmith.io app metrics remain future work per each app's release gate.
 5. **Dashboards**: *implemented in staging* for the currently live signals — see §10. Additional per-app dashboard rows arrive as each app's metrics land.
-6. **Alerts**: enable only actionable alerts with runbook links and tested delivery. See [`docs/observability-alerting.md`](./observability-alerting.md) for the chosen architecture, routing policy, and rollout sequence — none of it is deployed yet.
+6. **Alerts**: the synthetic Alertmanager-to-PagerDuty fire/acknowledge/resolve drill is proven, and
+   repository support for secret-safe per-node staging Healthchecks.io heartbeats is implemented but
+   awaits post-merge installation. The observability watchdog, `KubeNodeNotReady` routing, application
+   alerts, production rollout, and all live mutation remain later work. See
+   [`docs/observability-alerting.md`](./observability-alerting.md) for the rollout sequence.
 7. **Staging failure drills**: rehearse endpoint down, crash loop, scrape down, TLS warning, token.place no-compute-node, and Alertmanager delivery checks. See [`docs/observability-alerting.md`](./observability-alerting.md) §6 for the specific drill sequence, including node-power-off and monitoring-node-power-off drills — not yet performed.
 8. **Production rollout**: promote the monitoring stack and app scrape hooks after staging soak and drill evidence.
 9. **Post-release baseline review**: after at least one production week, adjust thresholds, retention, dashboard rows, and noisy alerts based on measured data.
@@ -374,6 +378,8 @@ Prometheus or Grafana should not be listed as production skills until evidence e
 
 - Which cluster names should distinguish staging and production if both run on Sugarkube-managed hardware?
 - Should app metrics endpoints use bearer tokens, network policy only, or both?
-- The Alertmanager receiver question is answered at the design level: PagerDuty plus Healthchecks.io, per [`docs/observability-alerting.md`](./observability-alerting.md). What remains open is execution — accounts, secret-safe config, and drills, none of which are done yet.
+- PagerDuty plus Healthchecks.io remains the receiver architecture. The synthetic PagerDuty drill is
+  proven and repository support for node heartbeats exists; node installation, failure drills, the
+  watchdog, audited node routing, and application alerts remain execution work.
 - What Prometheus PV size is realistic after a one-week staging soak on the target Pi hardware?
 - Should Loki remain entirely deferred, or should minimal log labels be designed now without deploying Loki?

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -208,6 +208,10 @@ Do not use `--reuse-values` for the next forward upgrade; commit the full intend
 Repository support alone is not deployment or delivery evidence. This manual procedure is staging-only; no CI,
 render, install, upgrade, status, or verification command sends an alert.
 
+The synthetic drill has now been successfully proven in staging: fire, phone receipt,
+acknowledgement, explicit resolve, and PagerDuty resolution all completed. The last transition may
+take about five minutes because of Alertmanager's default `resolve_timeout: 5m`.
+
 1. Select and verify the staging context before creating or rotating anything:
 
    ```bash
@@ -280,6 +284,46 @@ render, install, upgrade, status, or verification command sends an alert.
 
    Repeat the explicit fire/acknowledge/resolve confirmations. Revoke the old integration key only
    after the new path is proven. Keep the Secret present throughout rollback safety windows.
+
+## Per-node Healthchecks.io heartbeats
+
+This is host/platform observability only; it does not mutate Kubernetes or Helm and has no
+application-specific behavior. Debian Bookworm provides the systemd credentials support used to
+keep the node-local URL out of the unit command line, environment, journal, and normal status.
+
+After this change is merged, perform these steps **separately** on `sugarkube3`, `sugarkube4`, and
+`sugarkube5`:
+
+1. SSH to the node, run `git checkout main && git pull --ff-only`, and confirm `hostname -s` is
+   that node's canonical name.
+2. Run `just observability-node-heartbeat-install env=staging`. At the controlling-terminal prompt,
+   paste only that physical node's rotated `<HEALTHCHECKS_IO_PING_URL>`; input is hidden. Never pass
+   it as an argument, environment variable, pipe, or redirected stdin.
+3. Run `just observability-node-heartbeat-status env=staging`, then
+   `just observability-node-heartbeat-verify env=staging`. Verification deliberately sends one ping,
+   waits at most 40 seconds for success, and leaves the minute timer enabled.
+4. In the `Sugarkube Staging` Healthchecks.io project, confirm only the corresponding check changes
+   from **New** to **Up**. Do not paste its URL into an issue, log, transcript, or PR.
+
+Re-running install silently accepts a newly rotated URL and atomically replaces the mode-`0600`,
+`root:root` credential. Status never reads it. For rollback, type the canonical hostname explicitly:
+
+```bash
+just observability-node-heartbeat-uninstall env=staging confirm="$(hostname -s)"
+```
+
+Uninstall disables the timer and deletes only this feature's units, executable, and local credential.
+Deleting the credential is destructive; it does **not** delete or disable any Healthchecks.io check,
+project, integration, or PagerDuty service.
+
+Once all three checks are Up, perform the first safe failure drill on a node that is not hosting the
+observability stack: power it down, confirm the check becomes late/down after approximately the
+one-minute period plus two-minute grace and that PagerDuty pages, then restore power and confirm the
+next ping recovers the check and resolves the incident. Do not power down the observability node for
+this first drill.
+
+The Prometheus/Alertmanager watchdog and in-cluster `KubeNodeNotReady` PagerDuty route remain later
+tasks, as do application alerts. This slice implements none of them.
 
 ## Reprovisioning proof and post-merge checklist
 

--- a/justfile
+++ b/justfile
@@ -3232,6 +3232,22 @@ observability-dashboard-verify env='':
 observability-pagerduty-test env='' action='':
     @scripts/observability_helm.sh pagerduty-test '{{ env }}' '{{ action }}'
 
+# Install or rotate this staging Pi's secret host-level heartbeat.
+observability-node-heartbeat-install env='':
+    sudo python3 scripts/observability_node_heartbeat.py install --env {{ quote(env) }}
+
+# Show sanitized heartbeat state without reading its credential.
+observability-node-heartbeat-status env='':
+    python3 scripts/observability_node_heartbeat.py status --env {{ quote(env) }}
+
+# Trigger one bounded heartbeat and leave the recurring timer enabled.
+observability-node-heartbeat-verify env='':
+    sudo python3 scripts/observability_node_heartbeat.py verify --env {{ quote(env) }}
+
+# Remove only this feature's local assets; confirmation must equal the hostname.
+observability-node-heartbeat-uninstall env='' confirm='':
+    sudo python3 scripts/observability_node_heartbeat.py uninstall --env {{ quote(env) }} --confirm {{ quote(confirm) }}
+
 # Render the pinned staging blackbox exporter and Probe manifests (read-only).
 observability-blackbox-render env='':
     @scripts/observability_blackbox.sh render '{{ env }}'

--- a/scripts/observability_node_heartbeat.py
+++ b/scripts/observability_node_heartbeat.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Guarded lifecycle for the staging host-level Healthchecks.io heartbeat."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import os
+import re
+import socket
+import stat
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+INVENTORY = REPO / "clusters/staging/nodes.txt"
+SERVICE = "sugarkube-healthcheck-heartbeat.service"
+TIMER = "sugarkube-healthcheck-heartbeat.timer"
+URL_RE = re.compile(
+    r"https://hc-ping\.com/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"
+)
+
+
+def root_path(path: str) -> Path:
+    root = os.environ.get("SUGARKUBE_HEARTBEAT_TEST_ROOT")
+    return Path(root) / path.lstrip("/") if root else Path(path)
+
+
+def run(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(args, check=check, text=True, capture_output=True)
+    except FileNotFoundError as exc:
+        raise SystemExit(f"ERROR: required tool {args[0]!r} is unavailable") from exc
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(f"ERROR: sanitized command failed: {args[0]}") from exc
+
+
+def guard(environment: str) -> str:
+    if environment != "staging":
+        raise SystemExit(
+            "ERROR: this operation requires explicit env=staging; production and unknown environments are refused"
+        )
+    hostname = (
+        os.environ.get("SUGARKUBE_HEARTBEAT_TEST_HOSTNAME")
+        or socket.gethostname().split(".")[0].lower()
+    )
+    allowed = {
+        line.strip()
+        for line in INVENTORY.read_text().splitlines()
+        if line.strip() and not line.startswith("#")
+    }
+    if hostname not in allowed:
+        raise SystemExit(
+            f"ERROR: hostname {hostname!r} is not in the canonical staging node inventory"
+        )
+    return hostname
+
+
+def require_root() -> None:
+    if not os.environ.get("SUGARKUBE_HEARTBEAT_TEST_ROOT") and os.geteuid() != 0:
+        raise SystemExit(
+            "ERROR: lifecycle mutations must run as root (use the Just recipe)"
+        )
+
+
+def read_secret() -> bytes:
+    if os.environ.get("SUGARKUBE_HEALTHCHECK_PING_URL"):
+        raise SystemExit(
+            "ERROR: exported credentials are refused; use the silent controlling-terminal prompt"
+        )
+    tty_name = (
+        os.environ.get("SUGARKUBE_HEARTBEAT_TEST_TTY")
+        if os.environ.get("SUGARKUBE_HEARTBEAT_TEST_ROOT")
+        else "/dev/tty"
+    )
+    if not tty_name:
+        raise SystemExit("ERROR: a controlling terminal is required")
+    try:
+        with open(tty_name, "r+", encoding="ascii") as tty:
+            value = getpass.getpass("Healthchecks.io ping URL (hidden): ", stream=tty)
+    except (OSError, EOFError) as exc:
+        raise SystemExit(
+            "ERROR: unable to read a hidden credential from the controlling terminal"
+        ) from exc
+    if URL_RE.fullmatch(value) is None:
+        raise SystemExit(
+            "ERROR: credential must be one canonical HTTPS hc-ping.com UUID ping URL (no suffix, query, or fragment)"
+        )
+    return value.encode("ascii") + b"\n"
+
+
+def atomic_write(path: Path, data: bytes, mode: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, candidate = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        os.fchmod(fd, mode)
+        os.write(fd, data)
+        os.fsync(fd)
+        os.close(fd)
+        fd = -1
+        os.replace(candidate, path)
+        if not os.environ.get("SUGARKUBE_HEARTBEAT_TEST_ROOT"):
+            os.chown(path, 0, 0)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            os.unlink(candidate)
+        except FileNotFoundError:
+            pass
+
+
+def install(environment: str) -> None:
+    host = guard(environment)
+    require_root()
+    secret = read_secret()
+    atomic_write(root_path("/etc/sugarkube/healthcheck-ping-url"), secret, 0o600)
+    secret = b""
+    assets = (
+        (
+            "/usr/local/libexec/sugarkube-healthcheck-heartbeat",
+            "scripts/sugarkube_healthcheck_heartbeat.py",
+            0o755,
+        ),
+        (f"/etc/systemd/system/{SERVICE}", f"scripts/systemd/{SERVICE}", 0o644),
+        (f"/etc/systemd/system/{TIMER}", f"scripts/systemd/{TIMER}", 0o644),
+    )
+    for target, source, mode in assets:
+        atomic_write(root_path(target), (REPO / source).read_bytes(), mode)
+    run("systemctl", "daemon-reload")
+    run("systemctl", "enable", TIMER)
+    run("systemctl", "start", TIMER)
+    print(
+        f"Installed staging node heartbeat on {host}; credential stored with mode 0600"
+    )
+
+
+def file_fact(path: Path, mode: int) -> str:
+    try:
+        info = path.stat()
+        correct = stat.S_IMODE(info.st_mode) == mode and (
+            bool(os.environ.get("SUGARKUBE_HEARTBEAT_TEST_ROOT"))
+            or (info.st_uid, info.st_gid) == (0, 0)
+        )
+        return (
+            "present, owner/permissions ok"
+            if correct
+            else "present, owner/permissions WRONG"
+        )
+    except FileNotFoundError:
+        return "missing"
+
+
+def status(environment: str) -> None:
+    host = guard(environment)
+    print(f"Hostname: {host}")
+    for label, path, mode in (
+        ("Credential", "/etc/sugarkube/healthcheck-ping-url", 0o600),
+        ("Service", f"/etc/systemd/system/{SERVICE}", 0o644),
+        ("Timer", f"/etc/systemd/system/{TIMER}", 0o644),
+        ("Executable", "/usr/local/libexec/sugarkube-healthcheck-heartbeat", 0o755),
+    ):
+        print(f"{label}: {file_fact(root_path(path), mode)}")
+    for label, command in (
+        ("Timer enabled", "is-enabled"),
+        ("Timer active", "is-active"),
+    ):
+        result = run("systemctl", command, TIMER, check=False)
+        print(f"{label}: {result.stdout.strip() or 'unknown'}")
+    result = run(
+        "systemctl", "show", SERVICE, "--property=Result", "--value", check=False
+    )
+    print(f"Last service result: {result.stdout.strip() or 'unknown'}")
+    print("Timing: 30 seconds after boot, then every minute (5-second accuracy)")
+
+
+def verify(environment: str) -> None:
+    host = guard(environment)
+    require_root()
+    if run("systemctl", "is-enabled", TIMER, check=False).returncode != 0:
+        raise SystemExit("ERROR: recurring heartbeat timer is not enabled")
+    run("systemctl", "start", SERVICE)
+    deadline = time.monotonic() + 40
+    while (
+        time.monotonic() < deadline
+        and run("systemctl", "is-active", SERVICE, check=False).stdout.strip()
+        == "activating"
+    ):
+        time.sleep(1)
+    result = run(
+        "systemctl", "show", SERVICE, "--property=Result", "--value", check=False
+    ).stdout.strip()
+    if result != "success":
+        raise SystemExit(
+            "ERROR: heartbeat did not complete successfully within 40 seconds; inspect sanitized unit diagnostics"
+        )
+    run("systemctl", "start", TIMER)
+    print(
+        f"Verified one successful heartbeat on {host}; recurring timer remains enabled"
+    )
+
+
+def uninstall(environment: str, confirmation: str) -> None:
+    host = guard(environment)
+    require_root()
+    if confirmation != host:
+        raise SystemExit(f"ERROR: destructive uninstall requires --confirm {host}")
+    run("systemctl", "disable", "--now", TIMER, check=False)
+    for path in (
+        f"/etc/systemd/system/{SERVICE}",
+        f"/etc/systemd/system/{TIMER}",
+        "/usr/local/libexec/sugarkube-healthcheck-heartbeat",
+        "/etc/sugarkube/healthcheck-ping-url",
+    ):
+        root_path(path).unlink(missing_ok=True)
+    run("systemctl", "daemon-reload")
+    print(
+        f"Removed host heartbeat assets and local credential from {host}; remote Healthchecks.io and PagerDuty configuration was not changed"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("action", choices=("install", "status", "verify", "uninstall"))
+    parser.add_argument("--env", required=True)
+    parser.add_argument("--confirm", default="")
+    args = parser.parse_args()
+    {"install": install, "status": status, "verify": verify}.get(
+        args.action, lambda env: uninstall(env, args.confirm)
+    )(args.env)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -19,6 +19,7 @@ from typing import Iterable
 SCAN_SCRIPT_PATH = "scripts/scan-secrets.py"
 
 PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"https://hc-ping\.com/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"),
     re.compile(r"aws(.{0,20})?(?:secret|access)_key", re.IGNORECASE),
     re.compile(r"api[_-]?key", re.IGNORECASE),
     re.compile(r"token\s*[:=]", re.IGNORECASE),

--- a/scripts/sugarkube_healthcheck_heartbeat.py
+++ b/scripts/sugarkube_healthcheck_heartbeat.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Send one secret-safe Healthchecks.io node heartbeat."""
+
+from __future__ import annotations
+
+import os
+import re
+import signal
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+URL_RE = re.compile(
+    r"https://hc-ping\.com/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"
+)
+ATTEMPTS = 3
+REQUEST_TIMEOUT_SECONDS = 7
+OVERALL_TIMEOUT_SECONDS = 25
+
+
+def load_url() -> str:
+    directory = os.environ.get("CREDENTIALS_DIRECTORY", "")
+    if not directory:
+        raise ValueError("systemd credential directory is unavailable")
+    raw = (Path(directory) / "ping-url").read_bytes()
+    try:
+        url = raw.decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise ValueError("credential is not ASCII") from exc
+    if raw.endswith(b"\n"):
+        url = url[:-1]
+    if not url or "\n" in url or "\r" in url or URL_RE.fullmatch(url) is None:
+        raise ValueError("credential is not an allowed Healthchecks.io ping URL")
+    return url
+
+
+def deliver(url: str) -> None:
+    request = urllib.request.Request(
+        url, method="GET", headers={"User-Agent": "sugarkube-node-heartbeat/1"}
+    )
+    last_error: Exception | None = None
+    for attempt in range(ATTEMPTS):
+        try:
+            with urllib.request.urlopen(
+                request, timeout=REQUEST_TIMEOUT_SECONDS
+            ) as response:
+                if 200 <= response.status < 300:
+                    return
+                raise RuntimeError("remote endpoint returned a non-success response")
+        except (OSError, RuntimeError, urllib.error.URLError) as exc:
+            last_error = exc
+            if attempt + 1 < ATTEMPTS:
+                time.sleep(1)
+    raise RuntimeError(
+        "heartbeat delivery failed after bounded retries"
+    ) from last_error
+
+
+def main() -> int:
+    signal.alarm(OVERALL_TIMEOUT_SECONDS)
+    try:
+        deliver(load_url())
+    except (OSError, ValueError, RuntimeError, TimeoutError):
+        print(
+            "ERROR: node heartbeat failed; inspect network, credential format, and unit configuration",
+            file=sys.stderr,
+        )
+        return 1
+    finally:
+        signal.alarm(0)
+    print("Node heartbeat delivered successfully")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/systemd/sugarkube-healthcheck-heartbeat.service
+++ b/scripts/systemd/sugarkube-healthcheck-heartbeat.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=Sugarkube node availability heartbeat
+Documentation=https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-operations.md
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+LoadCredential=ping-url:/etc/sugarkube/healthcheck-ping-url
+ExecStart=/usr/local/libexec/sugarkube-healthcheck-heartbeat
+TimeoutStartSec=35s
+User=nobody
+Group=nogroup
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+RestrictAddressFamilies=AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+SystemCallArchitectures=native
+UMask=0077

--- a/scripts/systemd/sugarkube-healthcheck-heartbeat.timer
+++ b/scripts/systemd/sugarkube-healthcheck-heartbeat.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run the Sugarkube node availability heartbeat every minute
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=1min
+AccuracySec=5s
+Persistent=true
+Unit=sugarkube-healthcheck-heartbeat.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/test_observability_node_heartbeat.py
+++ b/tests/test_observability_node_heartbeat.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import importlib.util
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+LIFECYCLE_PATH = ROOT / "scripts/observability_node_heartbeat.py"
+DELIVERY_PATH = ROOT / "scripts/sugarkube_healthcheck_heartbeat.py"
+SERVICE_PATH = ROOT / "scripts/systemd/sugarkube-healthcheck-heartbeat.service"
+TIMER_PATH = ROOT / "scripts/systemd/sugarkube-healthcheck-heartbeat.timer"
+
+
+def load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def canary_url() -> str:
+    # Deliberately assembled so no credential-shaped URL is committed to a fixture.
+    uuid = "12345678" + "-1234-4234-a234-" + "123456789abc"
+    return "https://" + "hc-ping.com/" + uuid
+
+
+@pytest.fixture
+def lifecycle(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    module = load(LIFECYCLE_PATH, "heartbeat_lifecycle")
+    monkeypatch.setenv("SUGARKUBE_HEARTBEAT_TEST_ROOT", str(tmp_path / "root"))
+    monkeypatch.setenv("SUGARKUBE_HEARTBEAT_TEST_HOSTNAME", "sugarkube3")
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(*args: str, check: bool = True):
+        calls.append(args)
+        output = (
+            "success\n"
+            if "show" in args
+            else "enabled\n"
+            if "is-enabled" in args
+            else "active\n"
+        )
+        return subprocess.CompletedProcess(args, 0, output, "")
+
+    monkeypatch.setattr(module, "run", fake_run)
+    return module, tmp_path / "root", calls
+
+
+@pytest.mark.parametrize("environment", ["", "dev", "prod", "production", "STAGING"])
+def test_environment_guard_fails_closed(lifecycle, environment: str):
+    module, _, _ = lifecycle
+    with pytest.raises(SystemExit, match="explicit env=staging"):
+        module.guard(environment)
+
+
+def test_hostname_comes_from_canonical_inventory(
+    lifecycle, monkeypatch: pytest.MonkeyPatch
+):
+    module, _, _ = lifecycle
+    assert module.guard("staging") == "sugarkube3"
+    monkeypatch.setenv("SUGARKUBE_HEARTBEAT_TEST_HOSTNAME", "other-node")
+    with pytest.raises(SystemExit, match="canonical staging node inventory"):
+        module.guard("staging")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "http://hc-ping.com/x",
+        "https://example.com/x",
+        "https://hc-ping.com/not-a-uuid",
+        "/fail",
+        "?x=1",
+        "#x",
+        "\nextra",
+    ],
+)
+def test_strict_url_validation(
+    lifecycle, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, value: str
+):
+    module, _, _ = lifecycle
+    tty = tmp_path / "tty"
+    tty.write_text(
+        (canary_url() + value) if value.startswith(("/", "?", "#", "\n")) else value
+    )
+    monkeypatch.setenv("SUGARKUBE_HEARTBEAT_TEST_TTY", str(tty))
+    monkeypatch.setattr(
+        module.getpass,
+        "getpass",
+        lambda prompt, stream: stream.read().removesuffix("\n"),
+    )
+    with pytest.raises(SystemExit, match="canonical HTTPS"):
+        module.read_secret()
+
+
+def test_install_rotation_permissions_order_and_no_secret_leak(
+    lifecycle, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+):
+    module, root, calls = lifecycle
+    tty = tmp_path / "tty"
+    tty.write_text(canary_url() + "\n")
+    monkeypatch.setenv("SUGARKUBE_HEARTBEAT_TEST_TTY", str(tty))
+    monkeypatch.setattr(
+        module.getpass, "getpass", lambda prompt, stream: stream.readline().rstrip("\n")
+    )
+    module.install("staging")
+    credential = root / "etc/sugarkube/healthcheck-ping-url"
+    assert stat.S_IMODE(credential.stat().st_mode) == 0o600
+    assert calls == [
+        ("systemctl", "daemon-reload"),
+        ("systemctl", "enable", module.TIMER),
+        ("systemctl", "start", module.TIMER),
+    ]
+    first_inode = credential.stat().st_ino
+    tty.write_text(canary_url() + "\n")
+    module.install("staging")
+    assert credential.stat().st_ino != first_inode
+    visible = capsys.readouterr().out + capsys.readouterr().err + repr(calls)
+    assert canary_url() not in visible
+    assert canary_url().rsplit("/", 1)[1] not in visible
+    for path in (root / "etc/systemd/system", root / "usr/local/libexec"):
+        assert canary_url() not in "".join(p.read_text() for p in path.iterdir())
+
+
+def test_exported_secret_and_missing_tty_are_refused(
+    lifecycle, monkeypatch: pytest.MonkeyPatch
+):
+    module, _, _ = lifecycle
+    monkeypatch.setenv("SUGARKUBE_HEALTHCHECK_PING_URL", canary_url())
+    with pytest.raises(SystemExit, match="exported credentials are refused"):
+        module.read_secret()
+    monkeypatch.delenv("SUGARKUBE_HEALTHCHECK_PING_URL")
+    monkeypatch.delenv("SUGARKUBE_HEARTBEAT_TEST_TTY", raising=False)
+    with pytest.raises(SystemExit, match="controlling terminal"):
+        module.read_secret()
+
+
+def test_status_verify_and_uninstall_are_sanitized_and_scoped(lifecycle, capsys):
+    module, root, calls = lifecycle
+    credential = root / "etc/sugarkube/healthcheck-ping-url"
+    credential.parent.mkdir(parents=True)
+    credential.write_text(canary_url())
+    credential.chmod(0o600)
+    unrelated = root / "etc/keep-me"
+    unrelated.write_text("untouched")
+    module.status("staging")
+    module.verify("staging")
+    with pytest.raises(SystemExit, match="requires --confirm"):
+        module.uninstall("staging", "wrong")
+    module.uninstall("staging", "sugarkube3")
+    output = capsys.readouterr().out
+    assert canary_url() not in output
+    assert canary_url().rsplit("/", 1)[1] not in output
+    assert unrelated.exists() and not credential.exists()
+    assert ("systemctl", "disable", "--now", module.TIMER) in calls
+    assert ("systemctl", "start", module.SERVICE) in calls
+
+
+def test_unit_hardening_credential_and_minute_cadence():
+    service = SERVICE_PATH.read_text()
+    timer = TIMER_PATH.read_text()
+    assert "LoadCredential=ping-url:/etc/sugarkube/healthcheck-ping-url" in service
+    assert "ExecStart=/usr/local/libexec/sugarkube-healthcheck-heartbeat" in service
+    assert "hc-ping.com" not in service
+    for setting in (
+        "NoNewPrivileges=yes",
+        "ProtectSystem=strict",
+        "PrivateTmp=yes",
+        "RestrictAddressFamilies=AF_INET AF_INET6",
+    ):
+        assert setting in service
+    assert "OnBootSec=30s" in timer
+    assert "OnUnitActiveSec=1min" in timer
+    assert "Persistent=true" in timer
+
+
+def test_missing_systemctl_is_a_sanitized_error(monkeypatch: pytest.MonkeyPatch):
+    module = load(LIFECYCLE_PATH, "heartbeat_missing_tool")
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+    with pytest.raises(SystemExit, match="required tool 'systemctl' is unavailable"):
+        module.run("systemctl", "is-active", module.TIMER)
+
+
+def test_delivery_rejects_malformed_and_sanitizes_bounded_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+):
+    module = load(DELIVERY_PATH, "heartbeat_delivery")
+    (tmp_path / "ping-url").write_text(canary_url() + "/fail")
+    monkeypatch.setenv("CREDENTIALS_DIRECTORY", str(tmp_path))
+    assert module.main() == 1
+    assert canary_url() not in capsys.readouterr().err
+    (tmp_path / "ping-url").write_text(canary_url())
+    attempts = []
+    monkeypatch.setattr(module.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        module.urllib.request,
+        "urlopen",
+        lambda *a, **k: (
+            attempts.append((a, k))
+            or (_ for _ in ()).throw(OSError("secret-safe failure"))
+        ),
+    )
+    assert module.main() == 1
+    assert len(attempts) == module.ATTEMPTS
+    assert all(
+        call[1]["timeout"] == module.REQUEST_TIMEOUT_SECONDS for call in attempts
+    )
+    output = capsys.readouterr().err
+    assert canary_url() not in output and canary_url().rsplit("/", 1)[1] not in output
+
+
+def test_secret_scanner_rejects_realistic_healthchecks_url():
+    diff = "+++ b/file\n+" + canary_url() + "\n"
+    result = subprocess.run(
+        [sys.executable, "scripts/scan-secrets.py"],
+        input=diff,
+        text=True,
+        capture_output=True,
+        cwd=ROOT,
+    )
+    assert result.returncode != 0


### PR DESCRIPTION
### Motivation
- Implement a secret-safe, host-level heartbeat for each staging Pi so physical-node loss pages via the existing Healthchecks.io → PagerDuty integration without leaking per-node secrets. 
- Prefer a systemd-local, oneshot+timer approach (not a cluster CronJob) because the check must prove the specific physical node is booted and network-capable. 
- Follow the repository conventions for guarded operator workflows, atomic mode-`0600` credentials, and non-disclosive status/verify tooling.

### Description
- Add a hardened oneshot service and timer suitable for Debian Bookworm / Raspberry Pi OS that runs 30s after boot and then every minute, using `LoadCredential=` to keep the ping URL out of `ExecStart` and the journal (`scripts/systemd/sugarkube-healthcheck-heartbeat.service`, `scripts/systemd/sugarkube-healthcheck-heartbeat.timer`).
- Add a small delivery helper that strictly validates the Healthchecks.io UUID ping URL form, uses bounded per-request and overall timeouts, and performs bounded retries while sanitizing diagnostics (`scripts/sugarkube_healthcheck_heartbeat.py`).
- Add a guarded lifecycle script implementing `install`, `status`, `verify`, and `uninstall` operations that require `env=staging`, resolve the canonical hostname from a repository-owned inventory, read the ping URL only from the controlling terminal (hidden), atomically install a `root:root` mode-`0600` credential, install units/executables, `daemon-reload`, enable/start the timer, and provide sanitized outputs (`scripts/observability_node_heartbeat.py`).
- Expose safe Just recipes (`observability-node-heartbeat-{install,status,verify,uninstall}`) wired to the lifecycle script and add the canonical staging inventory (`clusters/staging/nodes.txt`) so installs only run against `sugarkube3|4|5` (`justfile`).
- Add deterministic unit/timer and lifecycle tests that operate in a temp root (no root/systemd/network required) and a canary-style secret fixture proving the real URL/UUID never appears in stdout/stderr/files/argv; also teach the repository secret scanner to detect realistic Healthchecks.io UUID ping URLs (`tests/test_observability_node_heartbeat.py`, `scripts/scan-secrets.py`).
- Update observability docs to describe the post-merge per-node installer procedure, expected failure timing (one-minute period plus two-minute grace ≈ ~3 minutes to page), safe first drill, rollback guidance, and to mark the Prometheus/Alertmanager watchdog, `KubeNodeNotReady` routing, and application alerts as deferred work (`docs/observability-alerting.md`, `docs/observability-operations.md`, `docs/observability-design.md`).

### Testing
- Ran the focused and related test suites and checks; results are shown verbatim below:
  - `pytest -q tests/test_observability_node_heartbeat.py` — 21 passed in repository test run.
  - `pytest -q tests/test_observability_helm.py tests/test_observability_blackbox.py tests/test_generic_app_just_recipes.py tests/test_helper_recipes.py` — passed in the run that exercised related observability checks.
  - `ruff check scripts/observability_node_heartbeat.py scripts/sugarkube_healthcheck_heartbeat.py tests/test_observability_node_heartbeat.py` — passed.
  - `python -m py_compile scripts/observability_node_heartbeat.py scripts/sugarkube_healthcheck_heartbeat.py` — passed (both helpers compile).
  - `git diff --cached --check` and `git diff --cached | python scripts/scan-secrets.py` — passed; the secret scanner flags realistic `hc-ping` URL patterns locally so no ping URLs were committed.
  - `linkchecker --no-warnings README.md docs/` — ran successfully (204 URLs checked, 0 errors).
  - Warnings / environment notes: `pre-commit run --all-files` could not fully complete in this environment because the repository's Just installer attempt returned HTTP 404 and some repository-wide YAML checks surfaced unrelated multi-document YAML issues; these hooks were not relaxed and unrelated broad whitespace edits were reverted during the work. `pyspelling -c .spellcheck.yaml` could not run here because the test environment lacked the `aspell` binary; the change does not relax repository doc checks.

Intentional deferrals (not implemented in this slice): Prometheus/Alertmanager watchdog submission, `KubeNodeNotReady` routing to PagerDuty, any application-level alerts, and any live cluster/Helm/Healthchecks.io/PagerDuty mutations; post-merge installation of each node's rotated ping URL must still be executed manually on `sugarkube3`, `sugarkube4`, and `sugarkube5` following the documented procedure.

Commands used during verification (representative):
- `pytest -q tests/test_observability_node_heartbeat.py`
- `pytest -q tests/test_observability_helm.py tests/test_observability_blackbox.py tests/test_generic_app_just_recipes.py tests/test_helper_recipes.py`
- `ruff check scripts/observability_node_heartbeat.py scripts/sugarkube_healthcheck_heartbeat.py tests/test_observability_node_heartbeat.py`
- `python -m py_compile scripts/observability_node_heartbeat.py scripts/sugarkube_healthcheck_heartbeat.py`
- `git diff --cached | python scripts/scan-secrets.py`
- `linkchecker --no-warnings README.md docs/`

Follow-ups / residual risks:
- Operators must run `just observability-node-heartbeat-install env=staging` on each staging Pi and paste the node's rotated ping URL at the hidden prompt; failing to do so leaves the checks `New` until the first ping.
- The environment used for CI here lacked `aspell` and the repository's pre-commit Just installer, so `pyspelling` and `pre-commit --all-files` could not fully complete in this run; these are environment/tooling gaps rather than regressions in this change.

Files of interest: `scripts/systemd/sugarkube-healthcheck-heartbeat.{service,timer}`, `scripts/sugarkube_healthcheck_heartbeat.py`, `scripts/observability_node_heartbeat.py`, `justfile` additions, `clusters/staging/nodes.txt`, `tests/test_observability_node_heartbeat.py`, and updates to `scripts/scan-secrets.py` and observability docs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6968375e6c832fabc463742b0883b5)