### PR TITLE
Add secret-safe staging node heartbeats

### DIFF
--- a/clusters/staging/nodes.txt
+++ b/clusters/staging/nodes.txt
@@ -1,0 +1,3 @@
+sugarkube3
+sugarkube4
+sugarkube5

--- a/docs/observability-alerting.md
+++ b/docs/observability-alerting.md
@@ -4,9 +4,10 @@ This is the canonical alerting strategy for Sugarkube. It defines the agreed tar
 routing policy, alert inventory, and rollout/drill plan for turning the staging observability stack
 described in [`docs/observability-design.md`](./observability-design.md) and
 [`docs/observability-operations.md`](./observability-operations.md) into something that actually pages
-a human. **Nothing in this document is deployed yet.** Alertmanager currently ships a no-op `"null"`
-receiver in staging (see [`docs/observability-operations.md`](./observability-operations.md)); this
-document records the plan for closing that gap, not evidence that it is closed.
+a human. The secret-file-backed synthetic Alertmanager → PagerDuty path has now been manually proven
+through fire, phone receipt, acknowledgement, and resolution. The host-heartbeat assets in this
+repository are ready for a separate post-merge install on each staging node; that install is not live
+deployment evidence. Real workload routes and the external observability watchdog remain deferred.
 
 ## 1. Goals and non-goals
 
@@ -99,9 +100,16 @@ CronJob only proves the k3s control plane can still schedule pods somewhere in t
 particular physical node is powered on and reachable. A `systemd` timer running on the node itself is
 the only check that actually proves that node is alive.
 
-Each Healthchecks.io check gets its own unique ping URL. These URLs must be stored outside Git — in
-root-readable local configuration on the node (e.g. an `EnvironmentFile` read by the timer's unit) or
-in a suitable secret store, never committed to this repository.
+Each Healthchecks.io check gets its own unique ping URL. The repository-owned service uses systemd's
+`LoadCredential=` support from the Debian Bookworm systemd baseline and a root-owned, mode-`0600`
+file. The delivery process reads the runtime credential and supplies it to curl through its config
+stdin, so the URL is absent from the unit command, process arguments, status, and normal journal
+output. Never commit or transcribe the value.
+
+The three existing **Sugarkube Staging** checks expect a ping every minute and allow two minutes of
+grace. A continuously missing node heartbeat should therefore page through the existing
+Healthchecks.io → PagerDuty integration after approximately the one-minute period plus two-minute
+grace (allowing modest scheduling and delivery jitter).
 
 What each check detects, and does not:
 
@@ -121,8 +129,8 @@ What each check detects, and does not:
   `routing-key` key from
   `/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key`; the credential is never inline.
   The only PagerDuty route is the exact `SugarkubePagerDutyTest` synthetic allowlist. This is
-  repository support, not evidence that it has been deployed or that phone delivery and resolution
-  have been manually proven.
+  repository support is deployed in staging, and its synthetic fire/acknowledge/resolve path has
+  been manually proven. No real workload alert is routed by that evidence.
 - Set `send_resolved: true` on the PagerDuty receiver so incidents auto-resolve when the underlying
   alert clears.
 - Define sensible `group_by`, `group_wait`, `group_interval`, and `repeat_interval` values so a single
@@ -156,9 +164,11 @@ A safe, phased sequence — each step depends on the previous one succeeding:
 1. Establish PagerDuty and Healthchecks.io accounts and integrations manually (outside this repo).
 2. Deploy and verify the repository's secret-safe receiver foundation (`routing_key_file`, no inline
    secrets); the root remains the null receiver and only the synthetic test is allowlisted.
-3. Manually send and resolve the synthetic PagerDuty test alert to prove receiver and phone delivery
-   work end-to-end, independent of any real Sugarkube rule.
-4. Add and verify the external node heartbeats and the observability watchdog against Healthchecks.io.
+3. **Proven:** manually fire the synthetic PagerDuty test alert, receive and acknowledge the phone
+   incident, resolve the alert, and observe resolution after Alertmanager's expected default
+   resolution delay (about five minutes).
+4. Install and verify the external node heartbeats against Healthchecks.io. Implement and verify the
+   observability watchdog only in a later slice.
    Confirm the watchdog's dedicated Alertmanager timing and the Healthchecks.io period/grace match
    the contract in §3; observe multiple repeat notifications before declaring the path healthy.
 5. Audit the existing `kube-prometheus-stack` bundled node rules (starting with `KubeNodeNotReady`).
@@ -216,5 +226,8 @@ it is deployed yet — see the rollout plan above for the actual sequencing.
 - Shallow public-endpoint blackbox monitoring (`PublicEndpointDown`, `PublicProbeMissing`,
   `TLSExpiringSoon`) is already live in staging today, independently of that dependency — see
   [`docs/observability-blackbox.md`](./observability-blackbox.md).
-- Alert delivery to a phone and node-power-off drills have not yet been performed. Everything in
-  [§6](#6-rollout-and-drill-plan) above is planned, not completed.
+- The synthetic Alertmanager → PagerDuty fire/acknowledge/resolve drill succeeded, including the
+  expected roughly five-minute Alertmanager resolution delay.
+- Per-node heartbeat assets are repository-ready but have not been installed on the Pis. The
+  node-power-off drill, watchdog, `KubeNodeNotReady` routing, and application alerts remain later
+  work.

--- a/docs/observability-design.md
+++ b/docs/observability-design.md
@@ -348,8 +348,13 @@ Do not page on symptoms without a response path, such as low traffic, GitHub sta
 3. **Blackbox monitoring**: *implemented in staging.* 16 public probes across all four apps plus TLS expiry are live and scripted-verified, per [`docs/observability-blackbox.md`](./observability-blackbox.md).
 4. **Application scrape integration**: app repos expose safe metrics and chart scrape hooks; Sugarkube enables discovery per environment. DSPACE's authenticated `ServiceMonitor` is live in staging (§7); token.place and danielsmith.io app metrics remain future work per each app's release gate.
 5. **Dashboards**: *implemented in staging* for the currently live signals — see §10. Additional per-app dashboard rows arrive as each app's metrics land.
-6. **Alerts**: enable only actionable alerts with runbook links and tested delivery. See [`docs/observability-alerting.md`](./observability-alerting.md) for the chosen architecture, routing policy, and rollout sequence — none of it is deployed yet.
-7. **Staging failure drills**: rehearse endpoint down, crash loop, scrape down, TLS warning, token.place no-compute-node, and Alertmanager delivery checks. See [`docs/observability-alerting.md`](./observability-alerting.md) §6 for the specific drill sequence, including node-power-off and monitoring-node-power-off drills — not yet performed.
+6. **Alerts**: the staging synthetic Alertmanager → PagerDuty route is deployed and delivery-tested;
+   enable real alerts only when actionable and linked to tested runbooks. See
+   [`docs/observability-alerting.md`](./observability-alerting.md) for the rollout sequence.
+7. **Staging failure drills**: the synthetic Alertmanager → PagerDuty fire, acknowledgement, and
+   resolution path is proven. Per-node Healthchecks.io installation and power-off drills are next;
+   the watchdog, `KubeNodeNotReady` route, and application drills remain later work. See
+   [`docs/observability-alerting.md`](./observability-alerting.md) §6.
 8. **Production rollout**: promote the monitoring stack and app scrape hooks after staging soak and drill evidence.
 9. **Post-release baseline review**: after at least one production week, adjust thresholds, retention, dashboard rows, and noisy alerts based on measured data.
 

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -305,8 +305,8 @@ not text to paste.
 1. Log in to the node, pull `main`, and review the checked-out commit.
 2. From an interactive terminal run `sudo just observability-node-heartbeat-install env=staging`.
    At the hidden prompt, paste that node's `<ROTATED-NODE-PING-URL>` and press Enter.
-3. Run `just observability-node-heartbeat-status env=staging`, then
-   `just observability-node-heartbeat-verify env=staging`. Verification explicitly starts one
+3. Run `sudo just observability-node-heartbeat-status env=staging`, then
+   `sudo just observability-node-heartbeat-verify env=staging`. Verification explicitly starts one
    oneshot, waits at most 25 seconds for a successful result, and leaves the recurring timer enabled.
 4. In the **Sugarkube Staging** Healthchecks.io project, confirm only the corresponding node check
    changes from **New** to **Up**. Repeat on the next physical node with its distinct URL.

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -11,7 +11,10 @@ Production observability is intentionally unsupported in this slice because no p
 - Staging overrides: `clusters/staging/observability/kube-prometheus-stack.values.yaml`.
 - Staging dashboard: `clusters/staging/observability/dashboards/sugarkube-staging-observability.json`.
 - Helper: `scripts/observability_helm.sh` through `just observability-*` recipes.
-- Alert delivery, routing, and drill strategy: [`docs/observability-alerting.md`](observability-alerting.md) — this runbook covers deploying and verifying the stack, not how (or whether) it pages anyone yet.
+- Alert delivery, routing, and drill strategy: [`docs/observability-alerting.md`](observability-alerting.md).
+- Canonical staging node inventory: `clusters/staging/nodes.txt`.
+- Host-heartbeat helper and assets: `scripts/observability_node_heartbeat.sh`,
+  `scripts/sugarkube-node-heartbeat`, and `scripts/systemd/sugarkube-node-heartbeat.*`.
 
 The dashboard is owned by Sugarkube and provisioned by the pinned Grafana
 subchart. Every render, install, and upgrade passes the same standalone JSON
@@ -127,7 +130,8 @@ is not rollout evidence.
 - Alertmanager: one replica with root/default no-op receiver named exactly `"null"`. Staging values
   define a secret-file-backed PagerDuty receiver, but route only the exact synthetic test labels to
   it; bundled and real workload alerts still fall through to `"null"`. Repository configuration is
-  not evidence of staging deployment or manually confirmed delivery.
+  is deployed, and its manual fire/acknowledge/resolve drill has been proven. Bundled and real
+  workload alerts still fall through to `"null"`.
 - Grafana: persistence disabled, no Ingress, LAN-only NodePort `30300`.
 - The provisioned dashboard defaults to six hours and a 30-second refresh. Its
   top-level public availability summary reports **Healthy endpoints**, **Failed
@@ -208,6 +212,10 @@ Do not use `--reuse-values` for the next forward upgrade; commit the full intend
 Repository support alone is not deployment or delivery evidence. This manual procedure is staging-only; no CI,
 render, install, upgrade, status, or verification command sends an alert.
 
+This drill has been successfully completed end to end: phone receipt and acknowledgement were
+confirmed, and resolution arrived after the expected default Alertmanager delay of approximately
+five minutes. Retain the procedure below for regression drills.
+
 1. Select and verify the staging context before creating or rotating anything:
 
    ```bash
@@ -280,6 +288,47 @@ render, install, upgrade, status, or verification command sends an alert.
 
    Repeat the explicit fire/acknowledge/resolve confirmations. Revoke the old integration key only
    after the new path is proven. Keep the Secret present throughout rollback safety windows.
+
+## Per-node Healthchecks.io heartbeat rollout
+
+The heartbeat is platform/node observability and does not inspect Kubernetes, Helm, DSPACE, or any
+other application. Debian Bookworm's systemd baseline supports `LoadCredential=`; the root-owned
+mode-`0600` source credential is exposed only to the service's private runtime credential directory.
+Installation refuses every environment except explicit `env=staging`, checks the local short
+hostname against `clusters/staging/nodes.txt`, and reads only from the controlling terminal with echo
+disabled. Do not pass a URL as an argument, environment variable, pipe, transcript, or command.
+
+After this change merges, perform these steps **separately on each of `sugarkube3`, `sugarkube4`, and
+`sugarkube5`**. Use that physical node's own rotated URL; `<ROTATED-NODE-PING-URL>` below is a label,
+not text to paste.
+
+1. Log in to the node, pull `main`, and review the checked-out commit.
+2. From an interactive terminal run `sudo just observability-node-heartbeat-install env=staging`.
+   At the hidden prompt, paste that node's `<ROTATED-NODE-PING-URL>` and press Enter.
+3. Run `just observability-node-heartbeat-status env=staging`, then
+   `just observability-node-heartbeat-verify env=staging`. Verification explicitly starts one
+   oneshot, waits at most 25 seconds for a successful result, and leaves the recurring timer enabled.
+4. In the **Sugarkube Staging** Healthchecks.io project, confirm only the corresponding node check
+   changes from **New** to **Up**. Repeat on the next physical node with its distinct URL.
+
+The timer runs 30 seconds after boot and every minute thereafter, with no more than five seconds of
+randomized delay. Each check has two minutes of grace, so a sustained outage should page PagerDuty
+after approximately one minute plus two minutes of grace.
+
+For the safe first drill, identify a node that does **not** host Prometheus or Alertmanager, power it
+down, confirm its Healthchecks.io check transitions late/down and the existing integration pages
+PagerDuty, acknowledge the incident, restore power, then confirm the next heartbeat returns the check
+to **Up** and the PagerDuty incident recovers/resolves. Do not start with the observability-hosting
+node.
+
+Rollback is destructive locally: run
+`sudo just observability-node-heartbeat-uninstall env=staging`, then type `uninstall` at the terminal
+confirmation. This disables the timer and removes only this feature's unit, executable, and local
+credential. It does **not** delete or change Healthchecks.io checks, integrations, or PagerDuty
+configuration. Deleting the credential means reinstall requires the node's rotated URL again.
+
+The Alertmanager-driven observability watchdog, in-cluster `KubeNodeNotReady` routing, and all
+application alert rules explicitly remain later tasks.
 
 ## Reprovisioning proof and post-merge checklist
 

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -302,12 +302,22 @@ After this change merges, perform these steps **separately on each of `sugarkube
 `sugarkube5`**. Use that physical node's own rotated URL; `<ROTATED-NODE-PING-URL>` below is a label,
 not text to paste.
 
-1. Log in to the node, pull `main`, and review the checked-out commit.
+1. Log in to the node, update `main`, and confirm that you are operating on the intended host:
+
+   ```bash
+   cd ~/sugarkube
+   git switch main
+   git pull --ff-only
+   hostname -s
+   ```
+
+   Confirm that the output is the node currently being installed before continuing.
 2. From an interactive terminal run `sudo just observability-node-heartbeat-install env=staging`.
    At the hidden prompt, paste that node's `<ROTATED-NODE-PING-URL>` and press Enter.
 3. Run `sudo just observability-node-heartbeat-status env=staging`, then
    `sudo just observability-node-heartbeat-verify env=staging`. Verification explicitly starts one
-   oneshot, waits at most 25 seconds for a successful result, and leaves the recurring timer enabled.
+   oneshot, waits for a successful result within its configured finite timeout, and leaves the
+   recurring timer enabled.
 4. In the **Sugarkube Staging** Healthchecks.io project, confirm only the corresponding node check
    changes from **New** to **Up**. Repeat on the next physical node with its distinct URL.
 

--- a/justfile
+++ b/justfile
@@ -3251,3 +3251,19 @@ observability-blackbox-status env='':
 # Verify exporter readiness, Probe discovery, and successful series (read-only).
 observability-blackbox-verify env='':
     @scripts/observability_blackbox.sh verify '{{ env }}'
+
+# Silently configure and enable this staging node's Healthchecks.io heartbeat.
+observability-node-heartbeat-install env='':
+    @scripts/observability_node_heartbeat.sh install '{{ env }}'
+
+# Show sanitized host heartbeat state without reading its credential.
+observability-node-heartbeat-status env='':
+    @scripts/observability_node_heartbeat.sh status '{{ env }}'
+
+# Trigger one heartbeat and prove success while leaving its timer enabled.
+observability-node-heartbeat-verify env='':
+    @scripts/observability_node_heartbeat.sh verify '{{ env }}'
+
+# Disable the heartbeat and destructively remove only its local owned assets.
+observability-node-heartbeat-uninstall env='':
+    @scripts/observability_node_heartbeat.sh uninstall '{{ env }}'

--- a/scripts/observability_node_heartbeat.sh
+++ b/scripts/observability_node_heartbeat.sh
@@ -27,7 +27,7 @@ hostname_checked() {
 }
 require_root() {
   if [[ -z "${ROOT}" && "${EUID}" -ne 0 ]]; then
-    die "this mutation must run as root (use sudo)."
+    die "this action must run as root (use sudo)."
   fi
 }
 require_tty() {
@@ -99,7 +99,7 @@ status_heartbeat() {
 }
 verify_heartbeat() {
   local host deadline state
-  require_tool "${SYSTEMCTL}"; host="$(hostname_checked)"
+  require_root; require_tool "${SYSTEMCTL}"; host="$(hostname_checked)"
   "${SYSTEMCTL}" is-enabled --quiet "${TIMER}" || die "timer is not enabled."
   "${SYSTEMCTL}" is-active --quiet "${TIMER}" || die "timer is not active."
   "${SYSTEMCTL}" start "${SERVICE}" || die "heartbeat trigger failed (credential and URL redacted)."

--- a/scripts/observability_node_heartbeat.sh
+++ b/scripts/observability_node_heartbeat.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="${SUGARKUBE_HEARTBEAT_ROOT:-}"
+SYSTEMD_DIR="${ROOT}/etc/systemd/system"
+CREDENTIAL_DIR="${ROOT}/etc/sugarkube/node-heartbeat"
+LIBEXEC_DIR="${ROOT}/usr/local/libexec"
+INVENTORY="${REPO_ROOT}/clusters/staging/nodes.txt"
+SYSTEMCTL="${SYSTEMCTL_BIN:-systemctl}"
+HOSTNAME_CMD="${HOSTNAME_BIN:-hostname}"
+TTY="${SUGARKUBE_HEARTBEAT_TTY:-/dev/tty}"
+SERVICE=sugarkube-node-heartbeat.service
+TIMER=sugarkube-node-heartbeat.timer
+
+die() { printf 'ERROR: %s\n' "$1" >&2; exit "${2:-1}"; }
+require_tool() { command -v "$1" >/dev/null 2>&1 || die "required tool is missing: $1"; }
+guard_env() {
+  [[ "${1:-}" == staging ]] || die "env=staging is required; production and unknown environments are unsupported."
+}
+hostname_checked() {
+  local host
+  [[ -r "${INVENTORY}" ]] || die "staging node inventory is unavailable."
+  host="$(${HOSTNAME_CMD} -s)" || die "could not resolve the local hostname."
+  grep -Fxq -- "${host}" "${INVENTORY}" || die "hostname is not a canonical staging node."
+  printf '%s' "${host}"
+}
+require_root() {
+  if [[ -z "${ROOT}" && "${EUID}" -ne 0 ]]; then
+    die "this mutation must run as root (use sudo)."
+  fi
+}
+require_tty() {
+  [[ -r "${TTY}" && -w "${TTY}" ]] || die "a readable controlling terminal is required."
+  if [[ "${SUGARKUBE_HEARTBEAT_TEST_NONTTY:-0}" != 1 && ! -t 3 ]]; then
+    die "a controlling terminal is required; piped stdin and environment secrets are refused."
+  fi
+}
+reject_secret_env() {
+  [[ -z "${HEALTHCHECKS_PING_URL:-}${HEALTHCHECK_PING_URL:-}${PING_URL:-}" ]] || \
+    die "ping URLs in environment variables are refused."
+}
+validate_url() {
+  local value="$1"
+  local uuid='[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89aAbB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}'
+  [[ "${value}" =~ ^https://hc-ping\.com/${uuid}$ ]]
+}
+install_file() {
+  local mode="$1" source="$2" destination="$3"
+  if [[ -n "${ROOT}" ]]; then
+    install -D -m "${mode}" "${source}" "${destination}"
+  else
+    install -D -o root -g root -m "${mode}" "${source}" "${destination}"
+  fi
+}
+install_heartbeat() {
+  local host secret tmp
+  require_root; require_tool install; require_tool curl; require_tool "${SYSTEMCTL}"; reject_secret_env
+  host="$(hostname_checked)"
+  exec 3<"${TTY}"; require_tty
+  printf 'Enter the rotated Healthchecks.io ping URL for %s (input hidden): ' "${host}" >&2
+  IFS= read -r -s secret <&3 || die "could not read the ping URL from the controlling terminal."
+  printf '\n' >&2
+  validate_url "${secret}" || die "ping URL is invalid (value redacted)."
+  if [[ -n "${ROOT}" ]]; then
+    install -d -m 0700 "${CREDENTIAL_DIR}"
+  else
+    install -d -o root -g root -m 0700 "${CREDENTIAL_DIR}"
+  fi
+  tmp="$(mktemp "${CREDENTIAL_DIR}/.ping-url.XXXXXX")"
+  trap 'rm -f "${tmp:-}"' RETURN
+  chmod 0600 "${tmp}"
+  [[ -n "${ROOT}" ]] || chown root:root "${tmp}"
+  printf '%s\n' "${secret}" >"${tmp}"
+  mv -f "${tmp}" "${CREDENTIAL_DIR}/ping-url"
+  trap - RETURN
+  install_file 0755 "${REPO_ROOT}/scripts/sugarkube-node-heartbeat" "${LIBEXEC_DIR}/sugarkube-node-heartbeat"
+  install_file 0644 "${REPO_ROOT}/scripts/systemd/${SERVICE}" "${SYSTEMD_DIR}/${SERVICE}"
+  install_file 0644 "${REPO_ROOT}/scripts/systemd/${TIMER}" "${SYSTEMD_DIR}/${TIMER}"
+  "${SYSTEMCTL}" daemon-reload
+  "${SYSTEMCTL}" enable "${TIMER}"
+  "${SYSTEMCTL}" start "${TIMER}"
+  printf 'Installed node heartbeat for %s; credential value remains redacted.\n' "${host}"
+}
+status_heartbeat() {
+  local host credential_state=missing service_state=missing timer_state=missing
+  require_tool "${SYSTEMCTL}"; require_tool stat; host="$(hostname_checked)"
+  if [[ -f "${CREDENTIAL_DIR}/ping-url" ]]; then
+    credential_state="present owner/mode=$(stat -c '%U:%G %a' "${CREDENTIAL_DIR}/ping-url") (content not inspected)"
+  fi
+  [[ -f "${SYSTEMD_DIR}/${SERVICE}" ]] && service_state="present mode=$(stat -c '%a' "${SYSTEMD_DIR}/${SERVICE}")"
+  [[ -f "${SYSTEMD_DIR}/${TIMER}" ]] && timer_state="present mode=$(stat -c '%a' "${SYSTEMD_DIR}/${TIMER}")"
+  printf 'Hostname: %s\nCredential: %s\nService asset: %s\nTimer asset: %s\n' \
+    "${host}" "${credential_state}" "${service_state}" "${timer_state}"
+  printf 'Timer enabled: %s\nTimer active: %s\nLast service result: %s\nCadence: boot + 30s, then every 1min (up to 5s randomized delay)\n' \
+    "$("${SYSTEMCTL}" is-enabled "${TIMER}" 2>/dev/null || echo no)" \
+    "$("${SYSTEMCTL}" is-active "${TIMER}" 2>/dev/null || echo no)" \
+    "$("${SYSTEMCTL}" show "${SERVICE}" --property=Result --value 2>/dev/null || echo unavailable)"
+}
+verify_heartbeat() {
+  local host deadline state
+  require_tool "${SYSTEMCTL}"; host="$(hostname_checked)"
+  "${SYSTEMCTL}" is-enabled --quiet "${TIMER}" || die "timer is not enabled."
+  "${SYSTEMCTL}" is-active --quiet "${TIMER}" || die "timer is not active."
+  "${SYSTEMCTL}" start "${SERVICE}" || die "heartbeat trigger failed (credential and URL redacted)."
+  deadline=$((SECONDS + ${SUGARKUBE_HEARTBEAT_VERIFY_TIMEOUT:-25}))
+  while ((SECONDS < deadline)); do
+    state="$("${SYSTEMCTL}" show "${SERVICE}" --property=Result --value 2>/dev/null || true)"
+    [[ "${state}" == success ]] && { printf 'Verified successful node heartbeat for %s; timer remains enabled.\n' "${host}"; return; }
+    [[ "${state}" == failed ]] && die "heartbeat failed (inspect sanitized unit diagnostics)."
+    sleep 1
+  done
+  die "heartbeat verification timed out after a bounded wait."
+}
+uninstall_heartbeat() {
+  local host answer
+  require_root; require_tool "${SYSTEMCTL}"; host="$(hostname_checked)"
+  exec 3<"${TTY}"; require_tty
+  printf 'Delete the local heartbeat credential and owned assets for %s? Type uninstall: ' "${host}" >&2
+  IFS= read -r answer <&3 || die "confirmation was not read."
+  [[ "${answer}" == uninstall ]] || die "uninstall cancelled."
+  "${SYSTEMCTL}" disable --now "${TIMER}" 2>/dev/null || true
+  rm -f "${SYSTEMD_DIR}/${SERVICE}" "${SYSTEMD_DIR}/${TIMER}" \
+    "${LIBEXEC_DIR}/sugarkube-node-heartbeat" "${CREDENTIAL_DIR}/ping-url"
+  rmdir "${CREDENTIAL_DIR}" 2>/dev/null || true
+  "${SYSTEMCTL}" daemon-reload
+  printf 'Removed node heartbeat assets for %s. Healthchecks.io and PagerDuty were not changed.\n' "${host}"
+}
+
+action="${1:-}"; env_name="${2:-}"
+[[ $# -eq 2 ]] || die "usage: $0 install|status|verify|uninstall staging"
+guard_env "${env_name}"
+case "${action}" in
+  install) install_heartbeat ;;
+  status) status_heartbeat ;;
+  verify) verify_heartbeat ;;
+  uninstall) uninstall_heartbeat ;;
+  *) die "unknown node heartbeat action." ;;
+esac

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -30,6 +30,17 @@ PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"password", re.IGNORECASE),
 )
 
+HEALTHCHECKS_URL = re.compile(
+    r"https://hc-ping\.com/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-"
+    r"[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+    re.IGNORECASE,
+)
+HEALTHCHECKS_UUID = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-"
+    r"[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+    re.IGNORECASE,
+)
+
 # Exact metadata placeholders are identifiers, not credential values. Keep this
 # deliberately narrow: trailing content must still be scanned.
 SAFE_PLACEHOLDERS = (
@@ -64,7 +75,10 @@ def run_ripsecrets(diff_text: str) -> bool | None:
             os.unlink(tmp_path)
     if result.returncode != 0:
         # ripsecrets prints findings to stdout; non-zero means potential secret
-        print(result.stdout or result.stderr, file=sys.stderr)
+        diagnostic = result.stdout or result.stderr
+        diagnostic = HEALTHCHECKS_URL.sub("[REDACTED HEALTHCHECKS URL]", diagnostic)
+        diagnostic = HEALTHCHECKS_UUID.sub("[REDACTED HEALTHCHECKS UUID]", diagnostic)
+        print(diagnostic, file=sys.stderr)
         return True
     return False
 
@@ -83,7 +97,11 @@ def regex_scan(lines: Iterable[str]) -> bool:
         if not any(pattern.fullmatch(line) for pattern in SAFE_PLACEHOLDERS):
             for pattern in PATTERNS:
                 if pattern.search(line):
-                    print(f"Possible secret: {line.rstrip()}", file=sys.stderr)
+                    print(
+                        f"Possible secret detected in {file_path or 'unknown path'} "
+                        "(value redacted).",
+                        file=sys.stderr,
+                    )
                     return True
     return False
 

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -19,6 +19,11 @@ from typing import Iterable
 SCAN_SCRIPT_PATH = "scripts/scan-secrets.py"
 
 PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"https://hc-ping\.com/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-"
+        r"[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+        re.IGNORECASE,
+    ),
     re.compile(r"aws(.{0,20})?(?:secret|access)_key", re.IGNORECASE),
     re.compile(r"api[_-]?key", re.IGNORECASE),
     re.compile(r"token\s*[:=]", re.IGNORECASE),

--- a/scripts/sugarkube-node-heartbeat
+++ b/scripts/sugarkube-node-heartbeat
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+fail() {
+  printf 'ERROR: node heartbeat %s (secret redacted).\n' "$1" >&2
+  exit 1
+}
+
+credential_dir="${CREDENTIALS_DIRECTORY:-}"
+[[ -n "${credential_dir}" ]] || fail "credential is unavailable"
+credential="${credential_dir}/ping-url"
+[[ -r "${credential}" && -f "${credential}" ]] || fail "credential is unavailable"
+
+# Read exactly one line without ever passing it in argv or emitting it. Healthchecks.io's
+# hosted ping endpoint uses a canonical UUID path; action suffixes and URL extras are forbidden.
+IFS= read -r ping_url <"${credential}" || fail "credential is empty"
+[[ -n "${ping_url}" ]] || fail "credential is empty"
+[[ "$(wc -l <"${credential}")" -eq 1 ]] || fail "credential format is invalid"
+uuid='[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89aAbB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}'
+[[ "${ping_url}" =~ ^https://hc-ping\.com/${uuid}$ ]] || fail "credential format is invalid"
+
+# --config - keeps the credential out of the process argument vector. Suppress curl's
+# potentially URL-bearing diagnostics and replace them with the fixed message below.
+if ! printf 'url = "%s"\n' "${ping_url}" | curl --config - --silent --fail \
+  --connect-timeout 5 --max-time 15 --retry 2 --retry-delay 1 --retry-max-time 20 \
+  --output /dev/null; then
+  fail "delivery failed"
+fi
+printf 'Node heartbeat delivered successfully.\n'

--- a/scripts/sugarkube-node-heartbeat
+++ b/scripts/sugarkube-node-heartbeat
@@ -13,9 +13,13 @@ credential="${credential_dir}/ping-url"
 
 # Read exactly one line without ever passing it in argv or emitting it. Healthchecks.io's
 # hosted ping endpoint uses a canonical UUID path; action suffixes and URL extras are forbidden.
-IFS= read -r ping_url <"${credential}" || fail "credential is empty"
+exec 3<"${credential}"
+IFS= read -r ping_url <&3 || [[ -n "${ping_url}" ]] || fail "credential is empty"
 [[ -n "${ping_url}" ]] || fail "credential is empty"
-[[ "$(wc -l <"${credential}")" -eq 1 ]] || fail "credential format is invalid"
+if IFS= read -r extra <&3 || [[ -n "${extra}" ]]; then
+  fail "credential format is invalid"
+fi
+exec 3<&-
 uuid='[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89aAbB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}'
 [[ "${ping_url}" =~ ^https://hc-ping\.com/${uuid}$ ]] || fail "credential format is invalid"
 

--- a/scripts/systemd/sugarkube-node-heartbeat.service
+++ b/scripts/systemd/sugarkube-node-heartbeat.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Sugarkube host heartbeat
+Documentation=https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-operations.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+LoadCredential=ping-url:/etc/sugarkube/node-heartbeat/ping-url
+ExecStart=/usr/local/libexec/sugarkube-node-heartbeat
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+RestrictAddressFamilies=AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+SystemCallArchitectures=native
+UMask=0077
+

--- a/scripts/systemd/sugarkube-node-heartbeat.timer
+++ b/scripts/systemd/sugarkube-node-heartbeat.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run the Sugarkube host heartbeat every minute
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=1min
+AccuracySec=5s
+RandomizedDelaySec=5s
+Persistent=true
+Unit=sugarkube-node-heartbeat.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/scan_secrets_test.py
+++ b/tests/scan_secrets_test.py
@@ -32,11 +32,22 @@ def test_regex_scan_detects_healthchecks_uuid_url(scan_secrets):
     assert scan_secrets.regex_scan(["+++ b/docs/example.md", line])
 
 
+def test_regex_scan_redacts_healthchecks_finding(scan_secrets, capsys):
+    uuid = "12345678" + "-1234-4123-8123-123456789abc"
+    url = "https://" + "hc-ping.com/" + uuid
+    assert scan_secrets.regex_scan(["+++ b/docs/example.md", "+" + url])
+    diagnostic = capsys.readouterr().err
+    assert "b/docs/example.md" in diagnostic
+    assert url not in diagnostic
+    assert uuid not in diagnostic
+
+
 def test_regex_scan_prints_warning(scan_secrets, capsys):
     diff = ["+++ b/file.txt", "+token" ": abc"]
     assert scan_secrets.regex_scan(diff)
     captured = capsys.readouterr()
-    assert "Possible secret: +tok" "en: abc" in captured.err
+    assert "Possible secret detected in b/file.txt (value redacted)." in captured.err
+    assert "abc" not in captured.err
 
 
 def test_regex_scan_ignores_self(scan_secrets):
@@ -152,6 +163,26 @@ def test_run_ripsecrets_logs_to_stderr(monkeypatch, scan_secrets, capsys):
     )
     assert scan_secrets.run_ripsecrets("diff") is True
     assert "leak" in capsys.readouterr().err
+
+
+def test_run_ripsecrets_redacts_healthchecks_diagnostics(
+    monkeypatch, scan_secrets, capsys
+):
+    monkeypatch.setattr(scan_secrets.shutil, "which", lambda _: "/bin/ripsecrets")
+    uuid = "12345678" + "-1234-4123-8123-123456789abc"
+    url = "https://" + "hc-ping.com/" + uuid
+
+    class Result:
+        returncode = 1
+        stdout = f"secret at b/file: +{url} ({uuid})"
+        stderr = ""
+
+    monkeypatch.setattr(scan_secrets.subprocess, "run", lambda *a, **k: Result)
+    assert scan_secrets.run_ripsecrets("diff") is True
+    diagnostic = capsys.readouterr().err
+    assert url not in diagnostic
+    assert uuid not in diagnostic
+    assert "b/file" in diagnostic
 
 
 def test_run_ripsecrets_clean(monkeypatch, scan_secrets):

--- a/tests/scan_secrets_test.py
+++ b/tests/scan_secrets_test.py
@@ -26,6 +26,12 @@ def test_regex_scan_detects_patterns(scan_secrets, line):
     assert scan_secrets.regex_scan(diff)
 
 
+def test_regex_scan_detects_healthchecks_uuid_url(scan_secrets):
+    uuid = "12345678" + "-1234-4123-8123-123456789abc"
+    line = "+https://" + "hc-ping.com/" + uuid
+    assert scan_secrets.regex_scan(["+++ b/docs/example.md", line])
+
+
 def test_regex_scan_prints_warning(scan_secrets, capsys):
     diff = ["+++ b/file.txt", "+token" ": abc"]
     assert scan_secrets.regex_scan(diff)

--- a/tests/test_observability_node_heartbeat.py
+++ b/tests/test_observability_node_heartbeat.py
@@ -202,6 +202,29 @@ def test_delivery_keeps_secret_out_of_argv_output_and_bounds_failure(tmp_path):
     assert "--retry 2" in args
 
 
+def test_delivery_accepts_single_line_credential_without_trailing_newline(tmp_path):
+    url, _ = canary()
+    credential_dir = tmp_path / "credentials"
+    credential_dir.mkdir()
+    (credential_dir / "ping-url").write_text(url)
+    curl = tmp_path / "curl"
+    curl.write_text("#!/bin/sh\ncat >/dev/null\n")
+    curl.chmod(0o755)
+    result = subprocess.run(
+        [str(DELIVERY)],
+        text=True,
+        capture_output=True,
+        env=os.environ
+        | {
+            "CREDENTIALS_DIRECTORY": str(credential_dir),
+            "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        },
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "delivered successfully" in result.stdout
+
+
 def test_delivery_rejects_multiline_credential_without_running_curl(tmp_path):
     url, uuid = canary()
     credential_dir = tmp_path / "credentials"
@@ -218,6 +241,22 @@ def test_delivery_rejects_multiline_credential_without_running_curl(tmp_path):
     assert "format is invalid" in result.stderr
     assert url not in result.stdout + result.stderr
     assert uuid not in result.stdout + result.stderr
+
+
+def test_delivery_rejects_second_line_without_trailing_newline(tmp_path):
+    url, _ = canary()
+    credential_dir = tmp_path / "credentials"
+    credential_dir.mkdir()
+    (credential_dir / "ping-url").write_text(url + "\nextra")
+    result = subprocess.run(
+        [str(DELIVERY)],
+        text=True,
+        capture_output=True,
+        env=os.environ | {"CREDENTIALS_DIRECTORY": str(credential_dir)},
+        check=False,
+    )
+    assert result.returncode
+    assert "format is invalid" in result.stderr
 
 
 def test_missing_systemctl_is_actionable(harness):

--- a/tests/test_observability_node_heartbeat.py
+++ b/tests/test_observability_node_heartbeat.py
@@ -202,11 +202,12 @@ def test_delivery_keeps_secret_out_of_argv_output_and_bounds_failure(tmp_path):
     assert "--retry 2" in args
 
 
-def test_delivery_accepts_single_line_credential_without_trailing_newline(tmp_path):
+@pytest.mark.parametrize("trailing_newline", [False, True])
+def test_delivery_accepts_single_line_credential(tmp_path, trailing_newline):
     url, _ = canary()
     credential_dir = tmp_path / "credentials"
     credential_dir.mkdir()
-    (credential_dir / "ping-url").write_text(url)
+    (credential_dir / "ping-url").write_text(url + ("\n" if trailing_newline else ""))
     curl = tmp_path / "curl"
     curl.write_text("#!/bin/sh\ncat >/dev/null\n")
     curl.chmod(0o755)
@@ -243,6 +244,23 @@ def test_delivery_rejects_multiline_credential_without_running_curl(tmp_path):
     assert uuid not in result.stdout + result.stderr
 
 
+def test_delivery_rejects_blank_extra_line_without_leaking_canary(tmp_path):
+    url, uuid = canary()
+    credential_dir = tmp_path / "credentials"
+    credential_dir.mkdir()
+    (credential_dir / "ping-url").write_text(url + "\n\n")
+    result = subprocess.run(
+        [str(DELIVERY)],
+        text=True,
+        capture_output=True,
+        env=os.environ | {"CREDENTIALS_DIRECTORY": str(credential_dir)},
+        check=False,
+    )
+    assert result.returncode
+    assert url not in result.stdout + result.stderr
+    assert uuid not in result.stdout + result.stderr
+
+
 def test_delivery_rejects_second_line_without_trailing_newline(tmp_path):
     url, _ = canary()
     credential_dir = tmp_path / "credentials"
@@ -259,6 +277,45 @@ def test_delivery_rejects_second_line_without_trailing_newline(tmp_path):
     assert "format is invalid" in result.stderr
 
 
+@pytest.mark.parametrize("content", ["", "\n", "\n\n"])
+def test_delivery_rejects_empty_or_blank_credentials(tmp_path, content):
+    credential_dir = tmp_path / "credentials"
+    credential_dir.mkdir()
+    (credential_dir / "ping-url").write_text(content)
+    result = subprocess.run(
+        [str(DELIVERY)],
+        text=True,
+        capture_output=True,
+        env=os.environ | {"CREDENTIALS_DIRECTORY": str(credential_dir)},
+        check=False,
+    )
+    assert result.returncode
+    assert "credential" in result.stderr
+
+
+def test_delivery_rejects_trailing_bytes_without_leaking_canary(tmp_path):
+    url, uuid = canary()
+    credential_dir = tmp_path / "credentials"
+    credential_dir.mkdir()
+    (credential_dir / "ping-url").write_text(url + " ")
+    result = subprocess.run(
+        [str(DELIVERY)],
+        text=True,
+        capture_output=True,
+        env=os.environ | {"CREDENTIALS_DIRECTORY": str(credential_dir)},
+        check=False,
+    )
+    assert result.returncode
+    assert url not in result.stdout + result.stderr
+    assert uuid not in result.stdout + result.stderr
+
+
+def test_verify_requires_root_before_systemctl_mutation():
+    script = LIFECYCLE.read_text()
+    verify_body = script.split("verify_heartbeat() {", 1)[1].split("\n}", 1)[0]
+    assert verify_body.index("require_root") < verify_body.index('"${SYSTEMCTL}" start')
+
+
 def test_missing_systemctl_is_actionable(harness):
     result = run_lifecycle(harness, "status", SYSTEMCTL_BIN="definitely-not-a-tool")
     assert result.returncode
@@ -269,3 +326,10 @@ def test_justfile_exposes_node_heartbeat_recipes():
     text = (ROOT / "justfile").read_text()
     for action in ("install", "status", "verify", "uninstall"):
         assert f"observability-node-heartbeat-{action} env=''" in text
+
+
+def test_operations_runbook_uses_privilege_for_all_lifecycle_commands():
+    operations = (ROOT / "docs/observability-operations.md").read_text()
+    for action in ("install", "status", "verify", "uninstall"):
+        command = f"sudo just observability-node-heartbeat-{action} env=staging"
+        assert command in operations

--- a/tests/test_observability_node_heartbeat.py
+++ b/tests/test_observability_node_heartbeat.py
@@ -1,0 +1,232 @@
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LIFECYCLE = ROOT / "scripts" / "observability_node_heartbeat.sh"
+DELIVERY = ROOT / "scripts" / "sugarkube-node-heartbeat"
+SERVICE = ROOT / "scripts/systemd/sugarkube-node-heartbeat.service"
+TIMER = ROOT / "scripts/systemd/sugarkube-node-heartbeat.timer"
+
+
+def canary():
+    uuid = "12345678" + "-1234-4123-8123-123456789abc"
+    return "https://" + "hc-ping.com/" + uuid, uuid
+
+
+@pytest.fixture
+def harness(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    calls = tmp_path / "calls"
+    systemctl = bin_dir / "systemctl"
+    systemctl.write_text(
+        """#!/bin/sh
+printf '%s\\n' "$*" >>"$CALLS"
+case "$1 $2" in
+  'is-enabled --quiet'|'is-active --quiet') exit 0 ;;
+  'is-enabled '*) echo enabled ;;
+  'is-active '*) echo active ;;
+  'show '*) echo success ;;
+esac
+"""
+    )
+    systemctl.chmod(0o755)
+    hostname = bin_dir / "hostname"
+    hostname.write_text("#!/bin/sh\nprintf '%s\\n' \"${TEST_HOST:-sugarkube3}\"\n")
+    hostname.chmod(0o755)
+    tty = tmp_path / "tty"
+    tty.write_text("")
+    env = os.environ | {
+        "SUGARKUBE_HEARTBEAT_ROOT": str(tmp_path / "root"),
+        "SUGARKUBE_HEARTBEAT_TTY": str(tty),
+        "SUGARKUBE_HEARTBEAT_TEST_NONTTY": "1",
+        "SYSTEMCTL_BIN": str(systemctl),
+        "HOSTNAME_BIN": str(hostname),
+        "CALLS": str(calls),
+    }
+    return tmp_path, tty, calls, env
+
+
+def run_lifecycle(harness, action, environment="staging", tty_text=None, **extra):
+    _, tty, _, env = harness
+    if tty_text is not None:
+        tty.write_text(tty_text)
+    return subprocess.run(
+        [str(LIFECYCLE), action, environment],
+        text=True,
+        capture_output=True,
+        env=env | {key: str(value) for key, value in extra.items()},
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("environment", ["", "dev", "prod", "production", "bogus"])
+def test_environment_guard_precedes_mutation(harness, environment):
+    result = run_lifecycle(harness, "install", environment)
+    assert result.returncode
+    assert "env=staging is required" in result.stderr
+    assert not harness[2].exists()
+
+
+def test_hostname_guard_uses_canonical_inventory(harness):
+    result = run_lifecycle(harness, "install", TEST_HOST="not-a-node")
+    assert result.returncode
+    assert "canonical staging node" in result.stderr
+
+
+def test_install_rotation_permissions_order_and_no_canary_leaks(harness):
+    url, uuid = canary()
+    result = run_lifecycle(harness, "install", tty_text=url + "\n")
+    assert result.returncode == 0, result.stderr
+    credential = harness[0] / "root/etc/sugarkube/node-heartbeat/ping-url"
+    assert credential.read_text() == url + "\n"
+    assert stat.S_IMODE(credential.stat().st_mode) == 0o600
+    calls = harness[2].read_text().splitlines()
+    assert calls == [
+        "daemon-reload",
+        "enable sugarkube-node-heartbeat.timer",
+        "start sugarkube-node-heartbeat.timer",
+    ]
+    result = run_lifecycle(harness, "install", tty_text=url + "\n")
+    assert result.returncode == 0
+    public = [result.stdout, result.stderr, harness[2].read_text()]
+    public += [
+        path.read_text()
+        for path in (harness[0] / "root").rglob("*")
+        if path.is_file() and path != credential
+    ]
+    assert all(url not in value and uuid not in value for value in public)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "http://hc-ping.com/not-secret",
+        "https://example.invalid/not-secret",
+        "https://hc-ping.com/not-a-uuid",
+    ],
+)
+def test_install_rejects_malformed_urls_without_echo(harness, value):
+    result = run_lifecycle(harness, "install", tty_text=value + "\n")
+    assert result.returncode
+    if value:
+        assert value not in result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("suffix", ["/fail", "/start", "?x=y", "#fragment"])
+def test_install_rejects_url_extras_and_multiline(harness, suffix):
+    url, _ = canary()
+    result = run_lifecycle(harness, "install", tty_text=url + suffix + "\n")
+    assert result.returncode
+    assert url not in result.stdout + result.stderr
+
+
+def test_install_refuses_environment_secret(harness):
+    url, _ = canary()
+    result = run_lifecycle(harness, "install", tty_text=url + "\n", PING_URL=url)
+    assert result.returncode
+    assert "environment variables are refused" in result.stderr
+    assert url not in result.stdout + result.stderr
+
+
+def test_status_and_verify_are_sanitized(harness):
+    url, uuid = canary()
+    assert run_lifecycle(harness, "install", tty_text=url + "\n").returncode == 0
+    for action in ("status", "verify"):
+        result = run_lifecycle(harness, action)
+        assert result.returncode == 0, result.stderr
+        assert url not in result.stdout + result.stderr
+        assert uuid not in result.stdout + result.stderr
+    assert "start sugarkube-node-heartbeat.service" in harness[2].read_text()
+
+
+def test_uninstall_confirmation_and_scope(harness):
+    url, _ = canary()
+    assert run_lifecycle(harness, "install", tty_text=url + "\n").returncode == 0
+    unrelated = harness[0] / "root/etc/systemd/system/unrelated.service"
+    unrelated.write_text("keep")
+    cancelled = run_lifecycle(harness, "uninstall", tty_text="no\n")
+    assert cancelled.returncode
+    result = run_lifecycle(harness, "uninstall", tty_text="uninstall\n")
+    assert result.returncode == 0
+    assert unrelated.read_text() == "keep"
+    assert not (harness[0] / "root/etc/sugarkube/node-heartbeat/ping-url").exists()
+    assert "disable --now sugarkube-node-heartbeat.timer" in harness[2].read_text()
+
+
+def test_unit_assets_cadence_credentials_and_hardening():
+    service = SERVICE.read_text()
+    timer = TIMER.read_text()
+    assert "LoadCredential=ping-url:/etc/sugarkube/node-heartbeat/ping-url" in service
+    assert "ExecStart=/usr/local/libexec/sugarkube-node-heartbeat" in service
+    assert "ProtectSystem=strict" in service
+    assert "OnBootSec=30s" in timer
+    assert "OnUnitActiveSec=1min" in timer
+    assert "Persistent=true" in timer
+
+
+def test_delivery_keeps_secret_out_of_argv_output_and_bounds_failure(tmp_path):
+    url, uuid = canary()
+    credential_dir = tmp_path / "credentials"
+    credential_dir.mkdir()
+    (credential_dir / "ping-url").write_text(url + "\n")
+    argv_log = tmp_path / "argv"
+    curl = tmp_path / "curl"
+    curl.write_text("#!/bin/sh\nprintf '%s\\n' \"$*\" >\"$ARGV_LOG\"\ncat >/dev/null\nexit 7\n")
+    curl.chmod(0o755)
+    result = subprocess.run(
+        [str(DELIVERY)],
+        text=True,
+        capture_output=True,
+        env=os.environ
+        | {
+            "CREDENTIALS_DIRECTORY": str(credential_dir),
+            "PATH": f"{tmp_path}:{os.environ['PATH']}",
+            "ARGV_LOG": str(argv_log),
+        },
+        check=False,
+    )
+    assert result.returncode
+    assert "delivery failed" in result.stderr
+    evidence = result.stdout + result.stderr + argv_log.read_text()
+    assert url not in evidence and uuid not in evidence
+    args = argv_log.read_text()
+    assert "--connect-timeout 5" in args
+    assert "--max-time 15" in args
+    assert "--retry 2" in args
+
+
+def test_delivery_rejects_multiline_credential_without_running_curl(tmp_path):
+    url, uuid = canary()
+    credential_dir = tmp_path / "credentials"
+    credential_dir.mkdir()
+    (credential_dir / "ping-url").write_text(url + "\nextra\n")
+    result = subprocess.run(
+        [str(DELIVERY)],
+        text=True,
+        capture_output=True,
+        env=os.environ | {"CREDENTIALS_DIRECTORY": str(credential_dir)},
+        check=False,
+    )
+    assert result.returncode
+    assert "format is invalid" in result.stderr
+    assert url not in result.stdout + result.stderr
+    assert uuid not in result.stdout + result.stderr
+
+
+def test_missing_systemctl_is_actionable(harness):
+    result = run_lifecycle(harness, "status", SYSTEMCTL_BIN="definitely-not-a-tool")
+    assert result.returncode
+    assert "required tool is missing" in result.stderr
+
+
+def test_justfile_exposes_node_heartbeat_recipes():
+    text = (ROOT / "justfile").read_text()
+    for action in ("install", "status", "verify", "uninstall"):
+        assert f"observability-node-heartbeat-{action} env=''" in text


### PR DESCRIPTION
### Motivation

Provide secret-safe, host-level Healthchecks.io heartbeats for the three staging Pis so node loss can page through the existing Healthchecks.io → PagerDuty integration without altering Kubernetes or Helm.

### Description

- Add the canonical staging-node inventory at `clusters/staging/nodes.txt`.
- Add guarded `observability-node-heartbeat-{install,status,verify,uninstall}` Just recipes backed by `scripts/observability_node_heartbeat.sh`.
- Require explicit `env=staging`, validate the current hostname against the inventory, and require root before mutation.
- Read each node’s unique ping URL silently from `/dev/tty`; environment variables, arguments, pipes, and ordinary stdin are not accepted as secret sources.
- Atomically install the credential as `root:root` mode `0600` under a protected directory.
- Add a hardened systemd oneshot and persistent timer that run 30 seconds after boot and approximately every minute.
- Add `scripts/sugarkube-node-heartbeat`, which reads the systemd credential, accepts one strict HTTPS Healthchecks UUID URL with or without a final newline, rejects extra content, and passes the URL to curl through config stdin rather than argv.
- Use bounded connection, transfer, and retry timing with sanitized success and failure diagnostics.
- Extend `scripts/scan-secrets.py` to detect realistic Healthchecks ping URLs while redacting URLs and UUIDs from both fallback and `ripsecrets` diagnostics.
- Add deterministic tests covering staging and hostname guards, hidden interactive input, validation, atomic rotation, permissions, systemd ordering and cadence, sanitized status/verification, delivery failures, uninstall scope, missing tools, scanner redaction, and canary non-disclosure.
- Update the observability runbooks and design documentation with the exact per-node rollout, expected paging timing, safe failure drill, destructive rollback warning, and deferred work.
- Record that the synthetic Alertmanager → PagerDuty fire/acknowledge/resolve drill has been proven, including the expected Alertmanager resolution delay.

No live node, cluster, Healthchecks.io, or PagerDuty mutation is performed by this PR.

### Testing

- `pytest -q tests/test_observability_node_heartbeat.py tests/scan_secrets_test.py tests/test_observability_helm.py tests/test_observability_blackbox.py tests/test_justfile_formatting.py tests/test_generic_app_just_recipes.py tests/test_helper_recipes.py` — 431 passed; one pre-existing `SyntaxWarning` in `tests/test_generic_app_just_recipes.py`.
- `pytest -q tests/test_observability_node_heartbeat.py tests/scan_secrets_test.py` — 53 passed.
- `bash -n scripts/observability_node_heartbeat.sh scripts/sugarkube-node-heartbeat` — passed.
- `shellcheck scripts/observability_node_heartbeat.sh scripts/sugarkube-node-heartbeat` — passed.
- `python3 -m flake8 scripts/scan-secrets.py tests/test_observability_node_heartbeat.py tests/scan_secrets_test.py` — passed.
- `just --unstable --fmt --check` — passed.
- `pyspelling -c .spellcheck.yaml` — passed.
- `linkchecker --no-warnings README.md docs/` — 204 URLs checked, 0 errors.
- `git diff --check` — passed.
- `git diff --cached | ./scripts/scan-secrets.py` — passed.
- Codecov reports all modified, coverable lines covered.
- `pre-commit run --all-files` was attempted but encountered existing repository-wide `check-yaml` failures on multi-document/Helm-template YAML and existing Flake8 failures beginning in `scripts/app_chart.py`. Automatic unrelated formatting changes were reverted.

### Post-merge staging rollout

Run separately on `sugarkube3`, `sugarkube4`, and `sugarkube5`, using that physical node’s distinct rotated URL:

~~~bash
cd ~/sugarkube
git switch main
git pull --ff-only
hostname -s

sudo just observability-node-heartbeat-install env=staging
sudo just observability-node-heartbeat-status env=staging
sudo just observability-node-heartbeat-verify env=staging
~~~

At the hidden installer prompt, enter only that node’s rotated URL. Confirm the corresponding check in the **Sugarkube Staging** Healthchecks.io project changes from **New** to **Up** before proceeding to the next node.

The expected failure timing is approximately the one-minute heartbeat period plus two minutes of grace before PagerDuty pages.

After all three checks are healthy, power down a node that does not host the observability stack, confirm the Healthchecks.io transition and PagerDuty incident, restore the node, and confirm recovery and resolution.

Rollback is locally destructive:

~~~bash
sudo just observability-node-heartbeat-uninstall env=staging
~~~

Type `uninstall` when prompted. This removes only the repository-owned local assets and credential; it does not alter Healthchecks.io or PagerDuty configuration.

### Intentionally deferred

- Prometheus/Alertmanager observability watchdog
- `KubeNodeNotReady` PagerDuty routing
- Application-specific alerts
- Production rollout
- Any live deployment or external-service mutation

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69683ed034832fb129f2153bb08293)