### PR TITLE
Add secret-safe staging node heartbeats

### DIFF
--- a/config/staging-nodes.txt
+++ b/config/staging-nodes.txt
@@ -1,0 +1,4 @@
+# Canonical physical-node inventory for staging host operations.
+sugarkube3
+sugarkube4
+sugarkube5

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,8 @@ Review the safety notes before working with power components.
   design across Sugarkube, DSPACE, token.place, danielsmith.io, and jobbot3000
 - [observability-operations.md](observability-operations.md) — staging-only non-Flux kube-prometheus-stack operations runbook
 - [observability-blackbox.md](observability-blackbox.md) — staging blackbox exporter and public probe lifecycle runbook
-- [observability-alerting.md](observability-alerting.md) — canonical alerting strategy: PagerDuty/Healthchecks.io target architecture, routing policy, and rollout/drill plan
+- [observability-alerting.md](observability-alerting.md) — canonical PagerDuty/Healthchecks.io strategy, proven synthetic delivery, and deferred routing work
+- [observability-operations.md](observability-operations.md) — guarded staging stack operations and secret-safe per-node heartbeat lifecycle
 - [pi_image_team_notifications.md](pi_image_team_notifications.md) — optional Slack/Matrix progress
   notifications for first boot and SSD cloning
 - [pi_image_cloudflare.md](pi_image_cloudflare.md) — preconfigure Docker and Cloudflare tunnels

--- a/docs/observability-alerting.md
+++ b/docs/observability-alerting.md
@@ -156,11 +156,15 @@ A safe, phased sequence — each step depends on the previous one succeeding:
 1. Establish PagerDuty and Healthchecks.io accounts and integrations manually (outside this repo).
 2. Deploy and verify the repository's secret-safe receiver foundation (`routing_key_file`, no inline
    secrets); the root remains the null receiver and only the synthetic test is allowlisted.
-3. Manually send and resolve the synthetic PagerDuty test alert to prove receiver and phone delivery
-   work end-to-end, independent of any real Sugarkube rule.
-4. Add and verify the external node heartbeats and the observability watchdog against Healthchecks.io.
-   Confirm the watchdog's dedicated Alertmanager timing and the Healthchecks.io period/grace match
-   the contract in §3; observe multiple repeat notifications before declaring the path healthy.
+3. **Completed:** the synthetic Alertmanager → PagerDuty alert was fired, received and acknowledged
+   on the phone, then resolved. The resolved notification arrived after Alertmanager's expected
+   default resolution delay (approximately five minutes) rather than immediately.
+   This proves the receiver and phone workflow end-to-end, independent of any real Sugarkube rule.
+4. Install and verify the repository-owned one-minute external node heartbeat separately on each
+   staging Pi, following [`docs/observability-operations.md`](observability-operations.md). The checks
+   use two minutes of grace. The observability watchdog remains a separate later task; when added,
+   confirm its dedicated Alertmanager timing and Healthchecks.io period/grace match the contract in
+   §3 and observe multiple repeat notifications before declaring that path healthy.
 5. Audit the existing `kube-prometheus-stack` bundled node rules (starting with `KubeNodeNotReady`).
 6. Enable the node-down route in Alertmanager's allowlist.
 7. Identify which staging nodes currently host Prometheus and Alertmanager.
@@ -216,5 +220,7 @@ it is deployed yet — see the rollout plan above for the actual sequencing.
 - Shallow public-endpoint blackbox monitoring (`PublicEndpointDown`, `PublicProbeMissing`,
   `TLSExpiringSoon`) is already live in staging today, independently of that dependency — see
   [`docs/observability-blackbox.md`](./observability-blackbox.md).
-- Alert delivery to a phone and node-power-off drills have not yet been performed. Everything in
-  [§6](#6-rollout-and-drill-plan) above is planned, not completed.
+- The synthetic Alertmanager → PagerDuty fire/acknowledge/resolve drill has been successfully proven,
+  including the expected approximately five-minute Alertmanager resolution delay. Host heartbeat activation and the
+  node-power-off drill remain post-merge operator work; repository tests perform no live mutation.
+- The observability watchdog, `KubeNodeNotReady` routing, and application alerts remain later slices.

--- a/docs/observability-design.md
+++ b/docs/observability-design.md
@@ -374,6 +374,11 @@ Prometheus or Grafana should not be listed as production skills until evidence e
 
 - Which cluster names should distinguish staging and production if both run on Sugarkube-managed hardware?
 - Should app metrics endpoints use bearer tokens, network policy only, or both?
-- The Alertmanager receiver question is answered at the design level: PagerDuty plus Healthchecks.io, per [`docs/observability-alerting.md`](./observability-alerting.md). What remains open is execution — accounts, secret-safe config, and drills, none of which are done yet.
+- PagerDuty plus Healthchecks.io remains the alerting design. The synthetic Alertmanager → PagerDuty
+  fire/acknowledge/resolve path has been manually proven, and repository-owned secret-safe host
+  heartbeat assets now cover the three staging nodes. Per-node activation and the first power-off
+  drill remain operator work; the Alertmanager watchdog, `KubeNodeNotReady` route, and application
+  alerts remain later slices. See [`docs/observability-alerting.md`](./observability-alerting.md) and
+  [`docs/observability-operations.md`](./observability-operations.md).
 - What Prometheus PV size is realistic after a one-week staging soak on the target Pi hardware?
 - Should Loki remain entirely deferred, or should minimal log labels be designed now without deploying Loki?

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -1,6 +1,6 @@
 # Observability operations runbook
 
-This runbook covers the current live **staging-only** kube-prometheus-stack lifecycle. It is intentionally non-Flux: operators use guarded Helm commands from this repository, with the chart version and full values chain committed in Git.
+This runbook covers the current live **staging-only** kube-prometheus-stack lifecycle and the repository-owned, host-level Healthchecks.io node heartbeat lifecycle. The stack is intentionally non-Flux: operators use guarded commands from this repository.
 
 Production observability is intentionally unsupported in this slice because no production live baseline has been proven yet.
 
@@ -48,6 +48,66 @@ The old Flux/Longhorn files under `platform/observability/*.yaml` and `clusters/
   - Password key: `admin-password`.
 
 Never put example credentials or plaintext Secret data in commands, logs, docs, commits, or PRs.
+
+## Host-level staging node heartbeats
+
+Each of `sugarkube3`, `sugarkube4`, and `sugarkube5` runs one app-agnostic
+systemd timer. The service uses systemd's `LoadCredential=` support (available
+in Debian Bookworm's systemd baseline) to expose a root-owned mode-`0600` file
+only in the service credential directory. The delivery program passes the URL
+to curl through standard-input configuration, never in `ExecStart`, argv, or
+normal status output. It accepts only an HTTPS `hc-ping.com` UUID success URL;
+alternate hosts, suffixes, queries, fragments, and multiline values fail
+closed with redacted diagnostics.
+
+The four guarded commands are:
+
+```bash
+just observability-node-heartbeat-install env=staging
+just observability-node-heartbeat-status env=staging
+just observability-node-heartbeat-verify env=staging
+SUGARKUBE_HEARTBEAT_CONFIRM=REMOVE \
+  just observability-node-heartbeat-uninstall env=staging
+```
+
+Missing, production, and unknown environments fail before mutation, as does a
+hostname outside the canonical staging inventory. Installation requires a
+controlling terminal and reads the rotated URL silently; it deliberately does
+not accept the secret as an argument, environment variable, or piped stdin.
+Re-running it atomically rotates the credential, reloads systemd, and leaves
+the minute timer enabled across reboot. Status never reads the credential.
+Verify triggers a heartbeat, waits at most 15 seconds for a successful unit
+result, and confirms the recurring timer remains enabled.
+
+Uninstall is destructive: the explicit confirmation deletes the local
+credential and only this feature's executable and units. It does **not** delete
+or change Healthchecks.io checks, PagerDuty services, Kubernetes, or Helm.
+
+### Post-merge activation (run separately on every Pi)
+
+On `sugarkube3`, then `sugarkube4`, then `sugarkube5`:
+
+1. Run `cd ~/sugarkube && git pull --ff-only main`.
+2. Run `just observability-node-heartbeat-install env=staging` and paste only
+   that physical node's rotated URL at the hidden prompt. Use a value supplied
+   out of band; `<ROTATED-URL-FOR-THIS-NODE>` is a placeholder, not a command
+   argument.
+3. Run `just observability-node-heartbeat-status env=staging` and
+   `just observability-node-heartbeat-verify env=staging`.
+4. In the **Sugarkube Staging** Healthchecks.io project, confirm that this
+   node's corresponding check changes from **New** to **Up** before proceeding
+   to the next node.
+
+Each check expects a ping every minute with two minutes of grace. Consequently,
+a stopped node should transition late and page the connected Sugarkube Staging
+PagerDuty service after approximately the one-minute period plus two-minute
+grace (provider processing can add a small delay).
+
+For the first failure drill, identify a node that is not currently hosting
+Prometheus/Alertmanager, power down only that node, confirm its Healthchecks.io
+transition and PagerDuty page, then restore it and confirm the next heartbeat
+returns the check to **Up** and the incident resolves. The Alertmanager
+watchdog and in-cluster `KubeNodeNotReady` routing remain later tasks.
 
 ## Read-only preflight and status
 
@@ -339,6 +399,7 @@ lost, and distinct from the automated evidence above:
 
 Additional dashboards, Grafana persistence, central multi-cluster Grafana, and production
 observability codification are separate follow-ups. The existing blackbox NetworkPolicy is unchanged.
-Alerting onboarding — real Alertmanager receivers, external heartbeats, and failure drills — is no
-longer undesigned scope creep; it is planned, designed work tracked in
-[`docs/observability-alerting.md`](observability-alerting.md), just not yet executed.
+Per-node heartbeat activation and failure drills are post-merge operator work. The observability
+watchdog, in-cluster `KubeNodeNotReady` routing, and application alerts are designed follow-ups
+tracked in [`docs/observability-alerting.md`](observability-alerting.md); they are not implemented by
+this host-level slice.

--- a/justfile
+++ b/justfile
@@ -3232,6 +3232,22 @@ observability-dashboard-verify env='':
 observability-pagerduty-test env='' action='':
     @scripts/observability_helm.sh pagerduty-test '{{ env }}' '{{ action }}'
 
+# Silently configure/rotate this staging node's Healthchecks.io heartbeat.
+observability-node-heartbeat-install env='':
+    @scripts/observability_node_heartbeat.sh install '{{ env }}'
+
+# Show only sanitized local heartbeat state.
+observability-node-heartbeat-status env='':
+    @scripts/observability_node_heartbeat.sh status '{{ env }}'
+
+# Trigger one heartbeat and prove successful completion.
+observability-node-heartbeat-verify env='':
+    @scripts/observability_node_heartbeat.sh verify '{{ env }}'
+
+# Remove local heartbeat assets after explicit destructive confirmation.
+observability-node-heartbeat-uninstall env='':
+    @scripts/observability_node_heartbeat.sh uninstall '{{ env }}'
+
 # Render the pinned staging blackbox exporter and Probe manifests (read-only).
 observability-blackbox-render env='':
     @scripts/observability_blackbox.sh render '{{ env }}'

--- a/scripts/healthchecks-heartbeat.sh
+++ b/scripts/healthchecks-heartbeat.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+credential="${CREDENTIALS_DIRECTORY:?systemd credential directory is unavailable}/ping-url"
+
+fail() {
+  printf 'healthchecks heartbeat: %s\n' "$1" >&2
+  exit 1
+}
+
+[[ -r "${credential}" ]] || fail "credential is missing or unreadable"
+IFS= read -r url <"${credential}" || fail "credential is empty"
+[[ -n "${url}" ]] || fail "credential is empty"
+[[ "$(wc -l <"${credential}")" -eq 1 ]] || fail "credential must contain exactly one line"
+[[ "${url}" =~ ^https://hc-ping\.com/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]] ||
+  fail "credential is not an accepted Healthchecks.io ping URL"
+
+# Read curl configuration through its standard input so the credential never
+# becomes an argument. Suppress curl's potentially URL-bearing diagnostics.
+if ! printf 'url = "%s"\n' "${url}" | /usr/bin/curl \
+  --config - --silent --fail --output /dev/null \
+  --connect-timeout 3 --max-time 10 --retry 2 --retry-delay 1 \
+  --retry-max-time 25 2>/dev/null; then
+  fail "delivery failed (details redacted)"
+fi
+
+printf 'healthchecks heartbeat: delivered\n'

--- a/scripts/observability_node_heartbeat.sh
+++ b/scripts/observability_node_heartbeat.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST_ROOT="${SUGARKUBE_HEARTBEAT_ROOT:-}"
+SYSTEMCTL="${SUGARKUBE_SYSTEMCTL:-systemctl}"
+INVENTORY="${ROOT}/config/staging-nodes.txt"
+UNIT_DIR="${DEST_ROOT}/etc/systemd/system"
+LIBEXEC_DIR="${DEST_ROOT}/usr/local/libexec"
+CREDENTIAL_DIR="${DEST_ROOT}/etc/sugarkube"
+CREDENTIAL="${CREDENTIAL_DIR}/healthchecks-heartbeat.url"
+SERVICE=sugarkube-healthchecks-heartbeat.service
+TIMER=sugarkube-healthchecks-heartbeat.timer
+
+die() { printf 'ERROR: %s\n' "$1" >&2; exit "${2:-2}"; }
+validate_env() {
+  [[ "${1:-}" == staging ]] || die "pass env=staging explicitly; production and unknown environments are unsupported"
+}
+hostname_short() { "${SUGARKUBE_HOSTNAME_CMD:-hostname}" -s 2>/dev/null || "${SUGARKUBE_HOSTNAME_CMD:-hostname}"; }
+validate_host() {
+  HOST="$(hostname_short)" || die "could not resolve hostname"
+  grep -Fxq -- "${HOST}" "${INVENTORY}" || die "host is not a canonical staging node"
+}
+require_tool() { command -v "$1" >/dev/null 2>&1 || die "required tool is unavailable: $1"; }
+as_root() {
+  if [[ -n "${DEST_ROOT}" || "$(id -u)" -eq 0 ]]; then "$@"; else sudo "$@"; fi
+}
+validate_url() {
+  local value=$1
+  [[ "${value}" =~ ^https://hc-ping\.com/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]
+}
+install_heartbeat() {
+  [[ -t 0 && -t 1 && -r /dev/tty ]] || die "installation requires an interactive controlling terminal"
+  local url tmp extra=''
+  IFS= read -r -s -p 'Rotated Healthchecks.io ping URL: ' url </dev/tty
+  # Reject a pasted second line without ever displaying either line.
+  IFS= read -r -s -t 0.1 extra </dev/tty || true
+  printf '\n' >/dev/tty
+  [[ -z "${extra}" ]] || die "ping URL rejected (value redacted)"
+  validate_url "${url}" || die "ping URL rejected (value redacted)"
+  require_tool install; require_tool "${SYSTEMCTL}"
+  as_root install -d -m 0755 "${UNIT_DIR}" "${LIBEXEC_DIR}"
+  as_root install -d -m 0700 -o root -g root "${CREDENTIAL_DIR}"
+  as_root install -m 0755 "${ROOT}/scripts/healthchecks-heartbeat.sh" "${LIBEXEC_DIR}/sugarkube-healthchecks-heartbeat"
+  as_root install -m 0644 "${ROOT}/scripts/systemd/${SERVICE}" "${UNIT_DIR}/${SERVICE}"
+  as_root install -m 0644 "${ROOT}/scripts/systemd/${TIMER}" "${UNIT_DIR}/${TIMER}"
+  tmp="${CREDENTIAL}.new.$$"
+  trap '[[ -z "${tmp:-}" ]] || as_root rm -f "${tmp}"' EXIT
+  umask 077
+  printf '%s\n' "${url}" | as_root tee "${tmp}" >/dev/null
+  as_root chown root:root "${tmp}"
+  as_root chmod 0600 "${tmp}"
+  as_root mv -f "${tmp}" "${CREDENTIAL}"
+  tmp=''
+  trap - EXIT
+  unset url
+  as_root "${SYSTEMCTL}" daemon-reload
+  as_root "${SYSTEMCTL}" enable "${TIMER}"
+  as_root "${SYSTEMCTL}" start "${TIMER}"
+  printf 'Installed heartbeat for %s; credential value redacted.\n' "${HOST}"
+}
+status_heartbeat() {
+  printf 'hostname: %s\n' "${HOST}"
+  for path in "${CREDENTIAL}" "${UNIT_DIR}/${SERVICE}" "${UNIT_DIR}/${TIMER}" "${LIBEXEC_DIR}/sugarkube-healthchecks-heartbeat"; do
+    if [[ -e "${path}" ]]; then
+      printf 'asset: present %s owner=%s mode=%s\n' "${path}" \
+        "$(stat -c %U:%G "${path}")" "$(stat -c %a "${path}")"
+    else
+      printf 'asset: missing %s\n' "${path}"
+    fi
+  done
+  printf 'timer enabled: %s\n' "$("${SYSTEMCTL}" is-enabled "${TIMER}" 2>/dev/null || printf inactive)"
+  printf 'timer active: %s\n' "$("${SYSTEMCTL}" is-active "${TIMER}" 2>/dev/null || printf inactive)"
+  printf 'last service result: %s\n' "$("${SYSTEMCTL}" show "${SERVICE}" -p Result --value 2>/dev/null || printf unavailable)"
+  printf 'timing: boot=30s period=1min accuracy=5s\n'
+}
+verify_heartbeat() {
+  "${SYSTEMCTL}" is-enabled --quiet "${TIMER}" || die "timer is not enabled"
+  "${SYSTEMCTL}" is-active --quiet "${TIMER}" || die "timer is not active"
+  as_root "${SYSTEMCTL}" start "${SERVICE}" || die "heartbeat failed (diagnostics redacted)" 4
+  local result
+  for _ in {1..15}; do
+    result="$("${SYSTEMCTL}" show "${SERVICE}" -p Result --value 2>/dev/null || true)"
+    [[ "${result}" == success ]] && { printf 'Heartbeat verification succeeded for %s; timer remains enabled.\n' "${HOST}"; return; }
+    sleep 1
+  done
+  die "heartbeat did not complete successfully within 15 seconds (details redacted)" 4
+}
+uninstall_heartbeat() {
+  [[ "${SUGARKUBE_HEARTBEAT_CONFIRM:-}" == REMOVE ]] || die "set SUGARKUBE_HEARTBEAT_CONFIRM=REMOVE to confirm destructive credential deletion"
+  require_tool "${SYSTEMCTL}"
+  as_root "${SYSTEMCTL}" disable --now "${TIMER}" 2>/dev/null || true
+  as_root rm -f "${UNIT_DIR}/${SERVICE}" "${UNIT_DIR}/${TIMER}" "${LIBEXEC_DIR}/sugarkube-healthchecks-heartbeat" "${CREDENTIAL}"
+  as_root "${SYSTEMCTL}" daemon-reload
+  printf 'Removed repository-owned heartbeat assets for %s. Remote Healthchecks.io and PagerDuty configuration was not deleted.\n' "${HOST}"
+}
+
+action="${1:-}"; env="${2:-}"
+validate_env "${env}"; validate_host
+case "${action}" in
+  install) install_heartbeat ;;
+  status) require_tool "${SYSTEMCTL}"; status_heartbeat ;;
+  verify) require_tool "${SYSTEMCTL}"; verify_heartbeat ;;
+  uninstall) uninstall_heartbeat ;;
+  *) die "usage: $0 {install|status|verify|uninstall} staging" ;;
+esac

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -6,6 +6,7 @@ such as API keys or tokens. If `ripsecrets` is available it will be used for a
 more thorough scan; otherwise a lightweight regex-based fallback is used. Any
 findings are printed to stderr so they don't pollute stdout.
 """
+
 from __future__ import annotations
 
 import os
@@ -19,6 +20,10 @@ from typing import Iterable
 SCAN_SCRIPT_PATH = "scripts/scan-secrets.py"
 
 PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"https://hc-ping\.com/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-"
+        r"[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+    ),
     re.compile(r"aws(.{0,20})?(?:secret|access)_key", re.IGNORECASE),
     re.compile(r"api[_-]?key", re.IGNORECASE),
     re.compile(r"token\s*[:=]", re.IGNORECASE),

--- a/scripts/systemd/sugarkube-healthchecks-heartbeat.service
+++ b/scripts/systemd/sugarkube-healthchecks-heartbeat.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Sugarkube node availability heartbeat
+Documentation=https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-operations.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+LoadCredential=ping-url:/etc/sugarkube/healthchecks-heartbeat.url
+ExecStart=/usr/local/libexec/sugarkube-healthchecks-heartbeat
+DynamicUser=yes
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+RestrictAddressFamilies=AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+SystemCallArchitectures=native
+UMask=0077

--- a/scripts/systemd/sugarkube-healthchecks-heartbeat.timer
+++ b/scripts/systemd/sugarkube-healthchecks-heartbeat.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run the Sugarkube node availability heartbeat every minute
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=1min
+AccuracySec=5s
+Persistent=true
+Unit=sugarkube-healthchecks-heartbeat.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/observability_node_heartbeat_test.py
+++ b/tests/observability_node_heartbeat_test.py
@@ -1,0 +1,235 @@
+import fcntl
+import os
+import pty
+import select
+import stat
+import subprocess
+import termios
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+LIFECYCLE = ROOT / "scripts/observability_node_heartbeat.sh"
+DELIVERY = ROOT / "scripts/healthchecks-heartbeat.sh"
+UUID = "12345678-1234-" + "4234-8234-123456789abc"
+CANARY = "https://hc-ping.com/" + UUID
+
+
+def stub_tools(tmp_path, hostname="sugarkube4"):
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    audit = tmp_path / "audit"
+    (bindir / "hostname").write_text(f"#!/bin/sh\nprintf '%s\\n' {hostname}\n")
+    (bindir / "systemctl").write_text(
+        '#!/bin/sh\nprintf \'%s\\n\' "$*" >>"$AUDIT"\n'
+        'case "$1 $2" in\n'
+        " 'is-enabled --quiet'|'is-active --quiet') exit 0;;\n"
+        " 'is-enabled sugarkube-healthchecks-heartbeat.timer') echo enabled;;\n"
+        " 'is-active sugarkube-healthchecks-heartbeat.timer') echo active;;\n"
+        " 'show sugarkube-healthchecks-heartbeat.service') echo success;;\n"
+        "esac\n"
+    )
+    for item in bindir.iterdir():
+        item.chmod(0o755)
+    env = os.environ | {
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "AUDIT": str(audit),
+        "SUGARKUBE_HOSTNAME_CMD": str(bindir / "hostname"),
+        "SUGARKUBE_SYSTEMCTL": str(bindir / "systemctl"),
+        "SUGARKUBE_HEARTBEAT_ROOT": str(tmp_path / "root"),
+    }
+    return env, audit
+
+
+def run(action, env, environment="staging"):
+    return subprocess.run(
+        [str(LIFECYCLE), action, environment],
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=5,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("environment", ["", "prod", "production", "dev", "mystery"])
+def test_environment_guard_precedes_mutation(tmp_path, environment):
+    env, audit = stub_tools(tmp_path)
+    result = run("status", env, environment)
+    assert result.returncode == 2
+    assert "env=staging explicitly" in result.stderr
+    assert not audit.exists()
+
+
+def test_hostname_guard_uses_canonical_inventory(tmp_path):
+    env, audit = stub_tools(tmp_path, "not-a-staging-node")
+    result = run("uninstall", env)
+    assert result.returncode == 2
+    assert "not a canonical staging node" in result.stderr
+    assert not audit.exists()
+
+
+def test_missing_systemctl_has_actionable_error(tmp_path):
+    env, _ = stub_tools(tmp_path)
+    env["SUGARKUBE_SYSTEMCTL"] = str(tmp_path / "missing-systemctl")
+    result = run("status", env)
+    assert result.returncode == 2
+    assert "required tool is unavailable" in result.stderr
+
+
+def test_install_rejects_noninteractive_input(tmp_path):
+    env, _ = stub_tools(tmp_path)
+    result = subprocess.run(
+        [str(LIFECYCLE), "install", "staging"],
+        input=CANARY + "\n",
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "controlling terminal" in result.stderr
+    assert CANARY not in result.stdout + result.stderr
+
+
+def interactive_install(tmp_path, env, secret=CANARY):
+    master, slave = pty.openpty()
+
+    def make_controlling_terminal():
+        os.setsid()
+        fcntl.ioctl(0, termios.TIOCSCTTY, 0)
+
+    process = subprocess.Popen(
+        [str(LIFECYCLE), "install", "staging"],
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        env=env,
+        close_fds=True,
+        preexec_fn=make_controlling_terminal,
+    )
+    os.close(slave)
+    output = b""
+    deadline = time.monotonic() + 5
+    while b"Rotated Healthchecks.io ping URL:" not in output:
+        assert time.monotonic() < deadline
+        ready, _, _ = select.select([master], [], [], 0.2)
+        if ready:
+            try:
+                output += os.read(master, 4096)
+            except OSError:
+                break
+    os.write(master, secret.encode() + b"\n")
+    while process.poll() is None:
+        ready, _, _ = select.select([master], [], [], 0.2)
+        if ready:
+            try:
+                output += os.read(master, 4096)
+            except OSError:
+                break
+    try:
+        while True:
+            output += os.read(master, 4096)
+    except OSError:
+        pass
+    os.close(master)
+    return process.wait(timeout=5), output.decode(errors="replace")
+
+
+def test_atomic_install_rotation_order_and_secret_canary(tmp_path):
+    env, audit = stub_tools(tmp_path)
+    rc, output = interactive_install(tmp_path, env)
+    assert rc == 0
+    credential = tmp_path / "root/etc/sugarkube/healthchecks-heartbeat.url"
+    assert credential.read_text().strip() == CANARY
+    assert stat.S_IMODE(credential.stat().st_mode) == 0o600
+    assert CANARY not in output
+    commands = audit.read_text()
+    expected_order = (
+        "daemon-reload\n"
+        "enable sugarkube-healthchecks-heartbeat.timer\n"
+        "start sugarkube-healthchecks-heartbeat.timer"
+    )
+    assert expected_order in commands
+    assert CANARY not in commands and UUID not in commands
+    new = "https://hc-ping.com/" + "abcdefab-cdef-" + "4abc-8def-abcdefabcdef"
+    rc, output = interactive_install(tmp_path, env, new)
+    assert rc == 0 and credential.read_text().strip() == new
+    for path in (tmp_path / "root").rglob("*"):
+        if path.is_file() and path != credential:
+            content = path.read_text(errors="ignore")
+            assert CANARY not in content and UUID not in content
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "http://hc-ping.com/x",
+        "https://example.com/" + UUID,
+        CANARY + "/fail",
+        CANARY + "/start",
+        CANARY + "?x=1",
+        CANARY + "#x",
+        CANARY + "\nextra",
+    ],
+)
+def test_strict_url_validation_is_redacted(tmp_path, bad):
+    env, audit = stub_tools(tmp_path)
+    rc, output = interactive_install(tmp_path, env, bad)
+    assert rc != 0
+    if bad:
+        assert bad not in output
+    assert not audit.exists()
+
+
+def test_status_verify_and_uninstall_are_sanitized_and_scoped(tmp_path):
+    env, audit = stub_tools(tmp_path)
+    rc, _ = interactive_install(tmp_path, env)
+    assert rc == 0
+    unrelated = tmp_path / "root/etc/sugarkube/unrelated"
+    unrelated.write_text("keep")
+    for action in ("status", "verify"):
+        result = run(action, env)
+        assert result.returncode == 0
+        assert CANARY not in result.stdout + result.stderr
+        assert UUID not in result.stdout + result.stderr
+    denied = run("uninstall", env)
+    assert denied.returncode != 0
+    env["SUGARKUBE_HEARTBEAT_CONFIRM"] = "REMOVE"
+    removed = run("uninstall", env)
+    assert removed.returncode == 0 and unrelated.read_text() == "keep"
+    assert not (tmp_path / "root/etc/sugarkube/healthchecks-heartbeat.url").exists()
+
+
+def test_units_have_credentials_cadence_and_hardening():
+    service = (ROOT / "scripts/systemd/sugarkube-healthchecks-heartbeat.service").read_text()
+    timer = (ROOT / "scripts/systemd/sugarkube-healthchecks-heartbeat.timer").read_text()
+    assert "LoadCredential=ping-url:" in service
+    assert "ExecStart=/usr/local/libexec/sugarkube-healthchecks-heartbeat" in service
+    assert "hc-ping" not in service and "ProtectSystem=strict" in service
+    assert "OnBootSec=30s" in timer and "OnUnitActiveSec=1min" in timer
+    assert "Persistent=true" in timer
+
+
+def test_delivery_failure_is_bounded_and_redacted(tmp_path):
+    credential_dir = tmp_path / "credentials"
+    credential_dir.mkdir()
+    (credential_dir / "ping-url").write_text(CANARY + "\n")
+    # The production script fixes curl's absolute path; inspect its finite bounds
+    # and exercise rejection before network access deterministically.
+    source = DELIVERY.read_text()
+    assert "--connect-timeout 3" in source and "--max-time 10" in source
+    assert "--retry 2" in source and "--retry-max-time 25" in source
+    (credential_dir / "ping-url").write_text(CANARY + "/fail\n")
+    result = subprocess.run(
+        [str(DELIVERY)],
+        env=os.environ | {"CREDENTIALS_DIRECTORY": str(credential_dir)},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert CANARY not in result.stdout + result.stderr

--- a/tests/scan_secrets_test.py
+++ b/tests/scan_secrets_test.py
@@ -26,6 +26,12 @@ def test_regex_scan_detects_patterns(scan_secrets, line):
     assert scan_secrets.regex_scan(diff)
 
 
+def test_regex_scan_detects_healthchecks_uuid_url(scan_secrets):
+    # Assemble the credential-shaped canary so the repository itself stays clean.
+    canary = "https://hc-ping.com/" + "12345678-1234-4234-8234-123456789abc"
+    assert scan_secrets.regex_scan(["+++ b/docs/example.md", "+" + canary])
+
+
 def test_regex_scan_prints_warning(scan_secrets, capsys):
     diff = ["+++ b/file.txt", "+token" ": abc"]
     assert scan_secrets.regex_scan(diff)


### PR DESCRIPTION
### Motivation

- Provide a minimal, secret-safe, host-level dead-man path for the three staging Pis (`sugarkube3/4/5`) so a missing node can eventually page the existing Healthchecks.io → PagerDuty integration. 
- Keep credentials out of Git, process args, logs, status output, and test artifacts while using an operator-friendly, repository-owned workflow to install/verify/uninstall per-node systemd heartbeats. 
- Preserve Sugarkube's app-agnostic platform orientation and avoid any in-cluster/watchdog/prometheus routing or live deployments in this slice.

### Description

- Added a hardened oneshot service and recurring timer (`scripts/systemd/sugarkube-healthchecks-heartbeat.service` and `.timer`) that runs 30s after boot and then every minute, using `LoadCredential=` to expose a root-owned mode-`0600` credential file to the unit. 
- Implemented the heartbeat delivery program (`scripts/healthchecks-heartbeat.sh`) that strictly validates an HTTPS `hc-ping.com` UUID form, reads the credential from the systemd credential directory, passes the URL to `curl` via stdin (so the URL never appears in argv), uses finite timeouts and bounded retries, and fails the unit with sanitized diagnostics on delivery failure. 
- Added the guarded lifecycle script (`scripts/observability_node_heartbeat.sh`) that enforces `env=staging`, validates hostname against a canonical inventory (`config/staging-nodes.txt`), requires a silent controlling-terminal read for the rotated URL, installs/rotates the credential atomically as `root:root` mode `0600`, installs unit/libexec assets, reloads systemd, enables/starts the timer, verifies without printing secrets, and performs an explicit destructive `uninstall` requiring confirmation. 
- Exposed operator-facing Just recipes (`observability-node-heartbeat-install/status/verify/uninstall`) wired to the lifecycle script and kept names consistent with existing `observability-*` recipes. 
- Extended the repository secret scanner (`scripts/scan-secrets.py`) to detect Healthchecks UUID ping URLs and added a deterministic canary test to prove the URL/UUID never appears in outputs or committed files. 
- Added comprehensive unit tests (`tests/observability_node_heartbeat_test.py`) that run entirely in stubbed/temp roots without root, systemd, network, or external services; tests cover environment/hostname guards, interactive secret read, strict validation, atomic install & mode-`0600` rotation, idempotence, unit/timer content and cadence expectations, sanitized status/verify output, bounded delivery failure, scoped uninstall, and canary non-disclosure assertions. 
- Documented the per-node post-merge activation, the expected one-minute period plus two-minute grace before Healthchecks.io pages PagerDuty, a safe first power-off drill, and explicitly noted deferred items (Alertmanager watchdog, `KubeNodeNotReady` routing, application alerts) in `docs/observability-operations.md`, `docs/observability-alerting.md`, and related docs. 

### Testing

- Ran focused heartbeat and secret scanner tests with `python -m pytest -q tests/observability_node_heartbeat_test.py tests/scan_secrets_test.py` and observed: `38 passed`.
- Exercised a broader observability and justfile surface with `python -m pytest -q tests/observability_node_heartbeat_test.py tests/scan_secrets_test.py tests/test_observability_helm.py tests/test_observability_blackbox.py tests/test_justfile_formatting.py tests/test_generic_app_just_recipes.py` and observed: `408 passed, 1 warning` (pre-existing SyntaxWarning). 
- Static/shell/docs checks run and passed: `shellcheck scripts/healthchecks-heartbeat.sh scripts/observability_node_heartbeat.sh`, `bash -n scripts/healthchecks-heartbeat.sh scripts/observability_node_heartbeat.sh`, `just --unstable --fmt --check`, `python -m black --check tests/observability_node_heartbeat_test.py tests/scan_secrets_test.py scripts/scan-secrets.py`, `python -m isort --check-only ...`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` (204 links checked, 0 errors). 
- Verified repository secret scanning: `git diff --cached | ./scripts/scan-secrets.py` returned clean for the staged changes. 
- Per-repo `pre-commit run --all-files` could not be completed cleanly due to pre-existing repository-wide issues (legacy whitespace/EoF fixes, multi-document YAML rejected by a generic YAML hook, and existing flake8 failures); unrelated automatic edits were reverted and the focused checks above were used as the acceptance signal for this slice. 

Notes and intentionally deferred work: no live node, Kubernetes, Helm, Healthchecks.io, or PagerDuty mutations were performed by these changes; the Alertmanager → Healthchecks watchdog, `KubeNodeNotReady` routing, and application-specific alerts remain separate follow-ups to be implemented and drilled after per-node activation on each Pi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a696820f3e4832f8457fc5555653bad)