### PR TITLE
Add a durable staging DNS and ingress HA baseline

### DIFF
--- a/clusters/staging/platform-ha/coredns-patch.yaml
+++ b/clusters/staging/platform-ha/coredns-patch.yaml
@@ -1,0 +1,11 @@
+spec:
+  replicas: 2
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+              topologyKey: kubernetes.io/hostname

--- a/clusters/staging/platform-ha/coredns-rollback-patch.yaml
+++ b/clusters/staging/platform-ha/coredns-rollback-patch.yaml
@@ -1,0 +1,6 @@
+spec:
+  replicas: 1
+  template:
+    spec:
+      affinity:
+        podAntiAffinity: null

--- a/clusters/staging/platform-ha/traefik-helmchartconfig.yaml
+++ b/clusters/staging/platform-ha/traefik-helmchartconfig.yaml
@@ -1,0 +1,16 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    deployment:
+      replicas: 2
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: traefik
+            topologyKey: kubernetes.io/hostname

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -17,6 +17,68 @@ logs, preparing Helm, and rolling out real workloads like
 [token.place](https://github.com/futuroptimist/token.place) and
 [democratized.space (dspace)](https://github.com/democratizedspace/dspace).
 
+## Staging DNS and ingress high availability
+
+### Failure mode and active ownership
+
+Staging has three k3s servers (`sugarkube3`, `sugarkube4`, and `sugarkube5`). During a controlled loss of `sugarkube3`, embedded etcd and the API remained available because the other two voting members retained quorum. Public traffic nevertheless failed for about six minutes: the sole CoreDNS pod was on the stopped node, and Kubernetes did not evict it until the default approximately five-minute `NodeNotReady` toleration expired. The application on `sugarkube4` stayed healthy; service recovered when replacement DNS became ready. This baseline deliberately does **not** change cluster-wide monitoring or eviction timing.
+
+The active ownership model is:
+
+* K3s owns packaged CoreDNS (including its Service identity and ClusterIP, Corefile, RBAC, service account, and probes). Sugarkube owns only the staging replica/required hostname anti-affinity patch in `clusters/staging/platform-ha/coredns-patch.yaml`. K3s rewrites its manifest at startup, so a post-start systemd hook on every server reapplies this narrow idempotent patch. It does not replace CoreDNS or create a continuous controller.
+* K3s owns packaged Traefik. Sugarkube uses K3s's supported `HelmChartConfig` extension for two replicas with required hostname anti-affinity. ServiceLB, ports, ingress classes, TLS, and all unspecified chart values remain unchanged.
+* The active Cloudflare connector is the existing `cloudflare-tunnel` Helm release installed by `just cf-tunnel-install`, currently in namespace `cloudflare`. Its existing two node-spread replicas are already HA. Verification discovers pods across namespaces by stable application label; it neither duplicates the release nor reads credentials.
+
+The Flux resources under `platform/` and `clusters/staging/patches/` are an inactive legacy/future path, not live staging ownership. Do not apply them alongside this lifecycle. Never edit `/var/lib/rancher/k3s/server/manifests`, use a transient scale/patch as the source of truth, or add another reconciler for these fields.
+
+### Post-merge apply, verification, and rollback
+
+Render/plan is offline. Then select the exact context and apply with bounded rollouts:
+
+```bash
+just staging-ingress-ha-render
+kubectl config use-context sugar-staging
+just staging-ingress-ha-status
+just staging-ingress-ha-apply env=staging
+just staging-ingress-ha-verify env=staging
+```
+
+Install the restart hook once on **each** server (it fails closed unless the preserved kubeconfig context is exactly `sugar-staging`, and does not restart k3s):
+
+```bash
+for node in sugarkube3 sugarkube4 sugarkube5; do
+  ssh "$node" 'cd ~/sugarkube && sudo --preserve-env=KUBECONFIG just staging-ingress-ha-hook install staging'
+done
+```
+
+Verification requires two Ready, node-spread pods for each of CoreDNS, Traefik, and the existing Cloudflare tunnel; ready `kube-dns` and `traefik` Service backends; in-cluster DNS resolution from a temporary BusyBox pod; and all canonical staging public URLs declared by the blackbox Probe manifest. The temporary pod is cleaned up on failure. Errors identify resources and placement but never expose tunnel credentials.
+
+Remove the durable hook from every server first, then rollback. Rollback restores one packaged CoreDNS replica without required anti-affinity and deletes only the Traefik customization so K3s chart defaults resume:
+
+```bash
+for node in sugarkube3 sugarkube4 sugarkube5; do
+  ssh "$node" 'cd ~/sugarkube && sudo --preserve-env=KUBECONFIG just staging-ingress-ha-hook remove staging'
+done
+just staging-ingress-ha-rollback env=staging
+```
+
+### One-node power-off drill
+
+After apply succeeds, continuously verify in one terminal, then power off exactly one server and watch scheduling in another:
+
+```bash
+while sleep 2; do just staging-ingress-ha-verify env=staging || break; done
+```
+
+```bash
+ssh sugarkube3 sudo poweroff
+kubectl --context sugar-staging get nodes,pods -A -o wide --watch
+```
+
+Public health endpoints should remain continuously reachable. Healthchecks.io and PagerDuty should still report the powered-off node; that expected alert must not be disabled. **Do not test another node until the first is back `Ready`, etcd three-member redundancy is restored, and HA verification passes.**
+
+This is app agnostic. token.place application-level HA remains separate work because relay registration and default rate-limit state are process-local; this change does not scale any application.
+
 > **Note**
 > If you've copied the k3s kubeconfig to `/home/pi/.kube/config` and set
 > `KUBECONFIG=$HOME/.kube/config` for the `pi` user (see the setup guide), you can omit `sudo`

--- a/justfile
+++ b/justfile
@@ -14,6 +14,28 @@ export SUGARKUBE_MDNS_ABSENCE_DBUS := env('SUGARKUBE_MDNS_ABSENCE_DBUS', '1')
 default: up
     @true
 
+# Render the staging-only DNS/ingress HA desired state without cluster access.
+staging-ingress-ha-render:
+    python3 scripts/staging_ingress_ha.py render
+
+# Read-only staging DNS/ingress HA inventory.
+staging-ingress-ha-status:
+    python3 scripts/staging_ingress_ha.py status
+
+staging-ingress-ha-verify env='':
+    python3 scripts/staging_ingress_ha.py verify "{{ env }}"
+
+# Mutations fail closed unless env=staging and the context is exactly sugar-staging.
+staging-ingress-ha-apply env='':
+    python3 scripts/staging_ingress_ha.py apply "{{ env }}"
+
+staging-ingress-ha-rollback env='':
+    python3 scripts/staging_ingress_ha.py rollback "{{ env }}"
+
+# Run on every staging server so a K3s manifest rewrite is followed by reconciliation.
+staging-ingress-ha-hook action env='':
+    scripts/install_staging_ingress_ha_hook.sh "{{ action }}" "{{ env }}"
+
 up-dev:
     just --justfile "{{ justfile_directory() }}/justfile" up env=dev
 

--- a/scripts/install_staging_ingress_ha_hook.sh
+++ b/scripts/install_staging_ingress_ha_hook.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Install/remove the post-k3s-start reconciliation hook on a staging server.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ACTION=${1:-}
+ENVIRONMENT=${2:-}
+DEST=/usr/local/libexec/sugarkube-staging-ingress-ha
+CONFIG=/etc/sugarkube/staging-ingress-ha
+DROPIN=/etc/systemd/system/k3s.service.d/30-staging-ingress-ha.conf
+
+[[ ${ENVIRONMENT#env=} == staging ]] || { echo "ERROR: hook mutation requires env=staging" >&2; exit 2; }
+[[ $(kubectl config current-context) == sugar-staging ]] || { echo "ERROR: expected Kubernetes context sugar-staging" >&2; exit 3; }
+[[ $EUID -eq 0 ]] || { echo "ERROR: rerun hook installation with sudo while preserving KUBECONFIG" >&2; exit 4; }
+
+case "$ACTION" in
+  install)
+    install -d -m 0755 "$DEST" "$CONFIG" "$(dirname "$DROPIN")"
+    install -m 0755 "$ROOT/scripts/staging_ingress_ha.py" "$DEST/staging_ingress_ha.py"
+    install -m 0644 "$ROOT/clusters/staging/platform-ha/"*.yaml "$CONFIG/"
+    cat >"$DROPIN" <<EOF
+[Service]
+ExecStartPost=/usr/bin/env SUGARKUBE_HA_CONFIG=$CONFIG KUBECONFIG=${KUBECONFIG:-/etc/rancher/k3s/k3s.yaml} $DEST/staging_ingress_ha.py reconcile staging
+EOF
+    systemctl daemon-reload
+    echo "Installed post-start reconciliation hook; k3s was not restarted."
+    ;;
+  remove)
+    rm -f "$DROPIN"
+    rm -rf "$DEST" "$CONFIG"
+    systemctl daemon-reload
+    echo "Removed post-start reconciliation hook; k3s was not restarted."
+    ;;
+  *) echo "usage: $0 install|remove env=staging" >&2; exit 2 ;;
+esac

--- a/scripts/staging_ingress_ha.py
+++ b/scripts/staging_ingress_ha.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Guarded lifecycle for the active staging DNS/ingress HA baseline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = Path(os.environ.get("SUGARKUBE_HA_CONFIG", ROOT / "clusters/staging/platform-ha"))
+TRAEFIK = CONFIG / "traefik-helmchartconfig.yaml"
+COREDNS = CONFIG / "coredns-patch.yaml"
+COREDNS_ROLLBACK = CONFIG / "coredns-rollback-patch.yaml"
+TIMEOUT = os.environ.get("SUGARKUBE_HA_TIMEOUT", "180s")
+
+
+def run(*args: str, capture: bool = False, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, check=check, text=True, capture_output=capture)
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def guard(env: str) -> None:
+    if env != "staging":
+        fail("this mutation is staging-only; pass env=staging")
+    context = run("kubectl", "config", "current-context", capture=True).stdout.strip()
+    if context != "sugar-staging":
+        fail(f"expected Kubernetes context sugar-staging, got {context or '<none>'}")
+
+
+def objects(namespace: str, resource: str, selector: str = "") -> dict:
+    command = ["kubectl", "-n", namespace, "get", resource]
+    if selector:
+        command += ["-l", selector]
+    command += ["-o", "json"]
+    return json.loads(run(*command, capture=True).stdout)
+
+
+def ready_nodes(data: dict) -> set[str]:
+    nodes: set[str] = set()
+    for pod in data.get("items", []):
+        conditions = pod.get("status", {}).get("conditions", [])
+        ready = any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions)
+        node = pod.get("spec", {}).get("nodeName")
+        if ready and node:
+            nodes.add(node)
+    return nodes
+
+
+def require_spread(name: str, data: dict) -> None:
+    nodes = ready_nodes(data)
+    if len(nodes) < 2:
+        fail(
+            f"{name} needs at least two ready pods on distinct nodes; ready nodes: {sorted(nodes)}"
+        )
+    print(f"OK: {name} has ready pods on distinct nodes: {', '.join(sorted(nodes))}")
+
+
+def require_endpoints(namespace: str, service: str) -> None:
+    data = objects(namespace, "endpointslice", f"kubernetes.io/service-name={service}")
+    ready = sum(
+        endpoint.get("conditions", {}).get("ready") is not False
+        for item in data.get("items", [])
+        for endpoint in item.get("endpoints", [])
+    )
+    if ready < 1:
+        fail(f"Service {namespace}/{service} has no ready EndpointSlice backends")
+    print(f"OK: Service {namespace}/{service} has {ready} ready backend(s)")
+
+
+def cloudflare_pods() -> dict:
+    # Helm's standard app label is stable; discover the live namespace rather than guessing it.
+    data = json.loads(
+        run(
+            "kubectl",
+            "get",
+            "pods",
+            "-A",
+            "-l",
+            "app.kubernetes.io/name=cloudflare-tunnel",
+            "-o",
+            "json",
+            capture=True,
+        ).stdout
+    )
+    if not data.get("items"):
+        fail(
+            "no live Cloudflare tunnel pods found by label app.kubernetes.io/name=cloudflare-tunnel"
+        )
+    return data
+
+
+def verify(env: str = "") -> None:
+    guard(env)
+    require_spread("CoreDNS", objects("kube-system", "pods", "k8s-app=kube-dns"))
+    require_spread("Traefik", objects("kube-system", "pods", "app.kubernetes.io/name=traefik"))
+    require_spread("Cloudflare tunnel", cloudflare_pods())
+    require_endpoints("kube-system", "kube-dns")
+    require_endpoints("kube-system", "traefik")
+    name = f"sugarkube-dns-check-{os.getpid()}"
+    try:
+        run(
+            "kubectl",
+            "run",
+            name,
+            "-n",
+            "default",
+            "--restart=Never",
+            "--image=busybox:1.36.1",
+            "--command",
+            "--",
+            "nslookup",
+            "kubernetes.default.svc.cluster.local",
+        )
+        run(
+            "kubectl",
+            "wait",
+            "-n",
+            "default",
+            f"pod/{name}",
+            "--for=jsonpath={.status.phase}=Succeeded",
+            f"--timeout={TIMEOUT}",
+        )
+    finally:
+        run(
+            "kubectl",
+            "delete",
+            "pod",
+            name,
+            "-n",
+            "default",
+            "--ignore-not-found",
+            "--wait=false",
+            check=False,
+        )
+    probes = ROOT / "clusters/staging/observability/probes/public-apps.yaml"
+    urls = sorted(
+        {
+            line.strip()[2:]
+            for line in probes.read_text().splitlines()
+            if line.strip().startswith("- https://")
+        }
+    )
+    if not urls:
+        fail("no canonical staging public health URLs were discovered")
+    for url in urls:
+        run(
+            "curl",
+            "--fail",
+            "--silent",
+            "--show-error",
+            "--max-time",
+            "15",
+            "--output",
+            os.devnull,
+            url,
+        )
+    print(f"OK: {len(urls)} canonical public staging endpoints are reachable")
+
+
+def status() -> None:
+    for args in (
+        ("kubectl", "-n", "kube-system", "get", "deploy", "coredns", "-o", "wide"),
+        (
+            "kubectl",
+            "-n",
+            "kube-system",
+            "get",
+            "deploy,svc",
+            "-l",
+            "app.kubernetes.io/name=traefik",
+            "-o",
+            "wide",
+        ),
+        (
+            "kubectl",
+            "get",
+            "pods",
+            "-A",
+            "-l",
+            "app.kubernetes.io/name=cloudflare-tunnel",
+            "-o",
+            "wide",
+        ),
+    ):
+        run(*args)
+
+
+def reconcile(env: str) -> None:
+    guard(env)
+    run("kubectl", "apply", "-f", str(TRAEFIK))
+    run(
+        "kubectl",
+        "-n",
+        "kube-system",
+        "patch",
+        "deployment",
+        "coredns",
+        "--type=strategic",
+        "--patch-file",
+        str(COREDNS),
+    )
+    run(
+        "kubectl",
+        "-n",
+        "kube-system",
+        "rollout",
+        "status",
+        "deployment/coredns",
+        f"--timeout={TIMEOUT}",
+    )
+    for deployment in ("coredns", "traefik"):
+        run(
+            "kubectl",
+            "-n",
+            "kube-system",
+            "wait",
+            f"deployment/{deployment}",
+            "--for=jsonpath={.status.readyReplicas}=2",
+            f"--timeout={TIMEOUT}",
+        )
+    run(
+        "kubectl",
+        "-n",
+        "kube-system",
+        "rollout",
+        "status",
+        "deployment/traefik",
+        f"--timeout={TIMEOUT}",
+    )
+
+
+def apply(env: str) -> None:
+    reconcile(env)
+    verify(env)
+
+
+def rollback(env: str) -> None:
+    guard(env)
+    run("kubectl", "delete", "-f", str(TRAEFIK), "--ignore-not-found")
+    run(
+        "kubectl",
+        "-n",
+        "kube-system",
+        "patch",
+        "deployment",
+        "coredns",
+        "--type=strategic",
+        "--patch-file",
+        str(COREDNS_ROLLBACK),
+    )
+    run(
+        "kubectl",
+        "-n",
+        "kube-system",
+        "rollout",
+        "status",
+        "deployment/coredns",
+        f"--timeout={TIMEOUT}",
+    )
+    print("Rollback complete: packaged Traefik defaults and one CoreDNS replica restored.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "command", choices=("render", "status", "apply", "reconcile", "verify", "rollback")
+    )
+    parser.add_argument("environment", nargs="?", default="")
+    args = parser.parse_args()
+    if args.command == "render":
+        print("--- # Traefik HelmChartConfig\n" + TRAEFIK.read_text(), end="")
+        print("--- # CoreDNS strategic merge patch\n" + COREDNS.read_text(), end="")
+    elif args.command == "status":
+        status()
+    elif args.command == "verify":
+        verify(args.environment.removeprefix("env="))
+    elif args.command == "apply":
+        apply(args.environment.removeprefix("env="))
+    elif args.command == "reconcile":
+        reconcile(args.environment.removeprefix("env="))
+    else:
+        rollback(args.environment.removeprefix("env="))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_staging_ingress_ha.py
+++ b/tests/test_staging_ingress_ha.py
@@ -1,0 +1,103 @@
+"""Offline regression tests for the staging DNS/ingress HA lifecycle."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/staging_ingress_ha.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("staging_ingress_ha", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_desired_state_has_two_replicas_and_required_hostname_spread() -> None:
+    core = (ROOT / "clusters/staging/platform-ha/coredns-patch.yaml").read_text()
+    traefik = (ROOT / "clusters/staging/platform-ha/traefik-helmchartconfig.yaml").read_text()
+    for manifest in (core, traefik):
+        assert "replicas: 2" in manifest
+        assert "requiredDuringSchedulingIgnoredDuringExecution:" in manifest
+        assert "topologyKey: kubernetes.io/hostname" in manifest
+
+
+def test_render_is_offline_and_idempotent() -> None:
+    first = subprocess.run(
+        [sys.executable, str(SCRIPT), "render"], text=True, capture_output=True, check=True
+    )
+    second = subprocess.run(
+        [sys.executable, str(SCRIPT), "render"], text=True, capture_output=True, check=True
+    )
+    assert first.stdout == second.stdout
+    assert "replicas: 2" in first.stdout
+
+
+@pytest.mark.parametrize("component", ["CoreDNS", "Traefik", "Cloudflare tunnel"])
+def test_verifier_rejects_single_or_same_node_ready_pods(component: str) -> None:
+    module = load_module()
+    pod = {
+        "spec": {"nodeName": "sugarkube4"},
+        "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+    }
+    with pytest.raises(SystemExit):
+        module.require_spread(component, {"items": [pod, pod]})
+
+
+def test_verifier_accepts_two_distinct_ready_nodes() -> None:
+    module = load_module()
+    pods = {
+        "items": [
+            {
+                "spec": {"nodeName": node},
+                "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+            }
+            for node in ("sugarkube4", "sugarkube5")
+        ]
+    }
+    module.require_spread("CoreDNS", pods)
+
+
+def test_mutation_guards_environment_before_kubectl() -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "apply", "prod"], text=True, capture_output=True
+    )
+    assert result.returncode != 0
+    assert "staging-only" in result.stderr
+
+
+def test_rollback_removes_affinity_and_restores_one_replica() -> None:
+    rollback = (ROOT / "clusters/staging/platform-ha/coredns-rollback-patch.yaml").read_text()
+    assert "replicas: 1" in rollback
+    assert "podAntiAffinity: null" in rollback
+
+
+def test_cloudflare_discovery_uses_all_namespaces_and_stable_label(monkeypatch) -> None:
+    module = load_module()
+    seen = []
+
+    def fake_run(*args, **kwargs):
+        seen.append(args)
+        return subprocess.CompletedProcess(
+            args, 0, json.dumps({"items": [{"metadata": {"namespace": "cloudflare"}}]}), ""
+        )
+
+    monkeypatch.setattr(module, "run", fake_run)
+    module.cloudflare_pods()
+    assert seen[0][:4] == ("kubectl", "get", "pods", "-A")
+    assert "app.kubernetes.io/name=cloudflare-tunnel" in seen[0]
+
+
+def test_script_never_requests_tunnel_secrets_or_logs() -> None:
+    text = SCRIPT.read_text()
+    assert "secret" not in text.lower()
+    assert 'kubectl", "logs' not in text


### PR DESCRIPTION
### Motivation

- A controlled shutdown of one staging server left etcd/API quorate but removed the singleton CoreDNS endpoint and caused ~5–6 minute public outage due to default eviction timing; CoreDNS and Traefik need durable node-spread redundancy without changing cluster-wide eviction behavior.
- Provide a minimal, app-agnostic, idempotent, and durable staging baseline that survives k3s packaged manifest rewrites and gives operators a guarded apply/verify/rollback workflow.

### Description

- Add staging-only CoreDNS strategic-merge patch `clusters/staging/platform-ha/coredns-patch.yaml` to request `replicas: 2` and a required `podAntiAffinity` keyed to `kubernetes.io/hostname`, and add `clusters/staging/platform-ha/coredns-rollback-patch.yaml` to restore one replica and remove the anti-affinity.
- Add a K3s-supported `HelmChartConfig` `clusters/staging/platform-ha/traefik-helmchartconfig.yaml` to configure Traefik with `replicas: 2` and required hostname anti-affinity while inheriting all other packaged chart values.
- Provide guarded operator tooling in `scripts/staging_ingress_ha.py` and `justfile` recipes for `render`, `status`, `apply`, `reconcile`, `verify`, and `rollback`, where mutating actions fail closed unless `env=staging` and the current context is exactly `sugar-staging`.
- Add a small per-server installable hook `scripts/install_staging_ingress_ha_hook.sh` that installs a post-k3s-start reconciliation step so the narrow CoreDNS patch is reapplied after k3s rewrites packaged manifests.
- Add offline regression tests `tests/test_staging_ingress_ha.py` to assert rendered manifests, replica counts, hostname anti-affinity, idempotent render output, environment/context guards, rollback patch shape, cloudflare-tunnel discovery by stable label, and rejection of singleton/same-node states.
- Update operations docs `docs/raspi_cluster_operations.md` with failure-mode explanation, ownership model, exact post-merge operator commands, rollback steps, and one-node power-off drill instructions.
- The change deliberately does not modify node eviction/monitoring settings, ServiceLB behavior, application charts, probe behavior, or secrets; it discovers the existing Cloudflare tunnel by label and does not read or expose credentials.

### Testing

- Ran focused unit/regression tests: `pytest -q tests/test_staging_ingress_ha.py` — 10 passed.
- Ran repository test suite smoke and formatting checks: `pytest -q` — passed; `black --check` and `flake8` on the new files — passed after formatting; `just --unstable --fmt --check` — passed; `bash -n scripts/install_staging_ingress_ha_hook.sh` — syntax OK.
- Ran docs/link checks: `just staging-ingress-ha-render` (offline render) — produced expected manifest output, and `linkchecker --no-warnings README.md docs/` — 204 links checked, 0 errors.
- Ran the repository secret scanner on staged changes: `git diff --cached | ./scripts/scan-secrets.py` — no issues reported.
- Not run / blocked in this environment: `pre-commit run --all-files` (missing `pre-commit`), `pyspelling -c .spellcheck.yaml` (blocked because `aspell` is not installed), and `shellcheck` was not available (used `bash -n` as substitute).
- No live cluster mutations were performed from this environment; all mutating commands in `justfile` and `scripts/staging_ingress_ha.py` are guarded and require `env=staging` + `sugar-staging` context.

Changed files (high level): `clusters/staging/platform-ha/{coredns-patch.yaml,coredns-rollback-patch.yaml,traefik-helmchartconfig.yaml}`, `scripts/staging_ingress_ha.py`, `scripts/install_staging_ingress_ha_hook.sh`, `tests/test_staging_ingress_ha.py`, `docs/raspi_cluster_operations.md`, and `justfile` additions.

Operator apply/verify/rollback commands (documented and tested offline):

- Render/plan (no cluster access): `just staging-ingress-ha-render`
- Apply and verify (operator host with `sugar-staging` context):
  - `kubectl config use-context sugar-staging`
  - `just staging-ingress-ha-status`
  - `just staging-ingress-ha-apply env=staging`
  - `just staging-ingress-ha-verify env=staging`
- Install per-server reconciliation hook (run on each staging server):
  - `ssh <node> 'cd ~/sugarkube && sudo --preserve-env=KUBECONFIG just staging-ingress-ha-hook install staging'`
- Rollback (remove hook on servers first, then rollback from operator host):
  - `ssh <node> 'cd ~/sugarkube && sudo --preserve-env=KUBECONFIG just staging-ingress-ha-hook remove staging'`
  - `just staging-ingress-ha-rollback env=staging`

Residual notes and environment limits: `pyspelling` and `pre-commit` were not available here so those checks were not executed; `shellcheck` was not installed but `bash -n` was used and `bash -n` passed; no live k8s cluster changes were made from this environment. If accepted, follow the documented per-server hook install and operator apply/verify steps in the runbook before performing the one-node power-off drill.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6983a0af98832f8c7b931ef627e406)