### PR TITLE
Add staging DNS and ingress HA baseline (CoreDNS companion + Traefik HelmChartConfig)

### DIFF
--- a/clusters/staging/ingress-ha/traefik-helmchartconfig.yaml
+++ b/clusters/staging/ingress-ha/traefik-helmchartconfig.yaml
@@ -1,0 +1,16 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    deployment:
+      replicas: 2
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: traefik
+            topologyKey: kubernetes.io/hostname

--- a/clusters/staging/ingress-ha/traefik-helmchartconfig.yaml
+++ b/clusters/staging/ingress-ha/traefik-helmchartconfig.yaml
@@ -3,6 +3,8 @@ kind: HelmChartConfig
 metadata:
   name: traefik
   namespace: kube-system
+  labels:
+    sugarkube.dev/managed-by: staging-ingress-ha
 spec:
   valuesContent: |-
     deployment:

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -37,6 +37,9 @@ logs, preparing Helm, and rolling out real workloads like
 
 ## Golden path: HA dev cluster → Helm → Traefik → workloads
 
+For the canonical staging CoreDNS, Traefik, and Cloudflare connector availability lifecycle and
+one-server power-off drill, see [Staging DNS and public-ingress high availability](staging-ingress-ha.md).
+
 Follow this sequence after imaging and booting the Pis:
 
 1. **Form or re-run the HA cluster:** From each node, use the quick-start flow in

--- a/docs/staging-ingress-ha.md
+++ b/docs/staging-ingress-ha.md
@@ -33,8 +33,9 @@ companion Deployment and reconcile the HelmChartConfig.
 ## Post-merge rollout and rollback
 
 Use a kubeconfig whose context is exactly `sugar-staging`. Render/status are read-only. Apply,
-upgrade, and rollback additionally fail closed for every environment except staging and for every
-other context. Rollout waits are bounded at 180 seconds by default.
+upgrade, verify, and rollback fail closed for every environment except staging and for every other
+context. Verification creates a temporary DNS probe pod, so it receives the same exact-context
+guard as the other mutating commands. Rollout waits are bounded at 180 seconds by default.
 
 ```bash
 just staging-ingress-ha-render env=staging

--- a/docs/staging-ingress-ha.md
+++ b/docs/staging-ingress-ha.md
@@ -18,6 +18,10 @@ The active staging lifecycle is deliberately non-Flux:
 * K3s owns packaged Traefik. The committed `HelmChartConfig` is K3s's supported merge point and adds
   two replicas with required hostname anti-affinity without replacing existing chart values,
   ServiceLB, ports, ingress classes, or TLS configuration.
+  Both lifecycle resources carry `sugarkube.dev/managed-by: staging-ingress-ha`. Apply and rollback
+  inspect only that ownership label and refuse to overwrite or delete a resource with another owner.
+  If a `kube-system/traefik` HelmChartConfig already exists, first review and redact its values,
+  merge them into this file, and arrange ownership; this lifecycle never replaces unknown values.
 * The active token-mode Cloudflare release is discovered cluster-wide by stable
   `app.kubernetes.io/name=cloudflare-tunnel` labels. Its observed namespace is `cloudflare`, and its
   two ready, node-spread pods are already HA. This lifecycle verifies but neither installs nor reads
@@ -45,11 +49,15 @@ just staging-ingress-ha-verify env=staging
 ```
 
 Apply first creates two ready CoreDNS companion endpoints and only then applies Traefik's supported
-configuration. Verification requires two ready CoreDNS, Traefik, and Cloudflare connector pods on
-distinct hostnames; ready `kube-dns` and Traefik Service backends; an in-cluster DNS lookup; and the
-public staging token.place and Democratized Space health endpoints. Override
-`SUGARKUBE_STAGING_HEALTH_URLS` only to supply a space-separated, app-agnostic staging endpoint set.
-The temporary DNS pod is removed on success, error, or signal.
+configuration. Verification requires two ready CoreDNS and Traefik pods on distinct hostnames. It
+discovers exactly one Cloudflare tunnel Deployment cluster-wide by the
+`app.kubernetes.io/name=cloudflare-tunnel` label, then checks only matching pods in its namespace;
+zero or multiple releases fail closed. It never queries tunnel Secrets or logs. Verification also
+checks ready `kube-dns` and Traefik Service backends and an in-cluster DNS lookup. Public HTTPS
+targets are discovered from live Probe resources labeled
+`environment=staging,criticality=critical`, and at least one is required. Curl timeouts are bounded,
+and failures redact the target and curl diagnostics. The temporary DNS pod is removed on success,
+error, or signal.
 
 Rollback removes only the two resources owned here and waits for the packaged defaults:
 
@@ -63,19 +71,23 @@ one-node availability guarantee. It does not disable or replace K3s components.
 
 ## One-node power-off drill
 
-After apply and verify, power off exactly one server (for example `sugarkube3`) using the normal
-host power procedure, then continuously verify from a different server:
+After apply and verify, run verification continuously from a different server, power off exactly
+one server, observe it, restore it, wait for readiness, and inspect three-member etcd health:
 
 ```bash
-just staging-ingress-ha-verify env=staging
-watch -n 5 'curl -fsS https://staging.token.place/healthz >/dev/null && echo reachable'
+while true; do just staging-ingress-ha-verify env=staging; sleep 5; done
+ssh sugarkube3 'sudo systemctl poweroff'
+kubectl get nodes --watch
+# Restore power to sugarkube3 using the normal host power procedure.
+kubectl wait --for=condition=Ready node/sugarkube3 --timeout=10m
+ssh sugarkube4 'sudo k3s etcdctl endpoint status --cluster --write-out=table'
 ```
 
 Public endpoints should remain continuously available. Healthchecks.io and PagerDuty should still
 report the intentionally powered-off node; those alerts prove host monitoring works and are not a
-reason to suppress it. Restore that node, wait for `kubectl get node sugarkube3` to report `Ready`,
-and confirm all three etcd members are healthy **before testing another node**. Never remove a
-second server while etcd redundancy is reduced.
+reason to suppress it. Do not test another node until `sugarkube3` is `Ready` **and** the command
+above confirms all three etcd members have recovered. Never remove a second server while etcd
+redundancy is reduced.
 
 This baseline is platform/app agnostic. It does not alter eviction or node-monitor timing, scale
 applications, or change observability credentials. In particular, token.place relay registration

--- a/docs/staging-ingress-ha.md
+++ b/docs/staging-ingress-ha.md
@@ -1,0 +1,82 @@
+# Staging DNS and public-ingress high availability
+
+## Incident and ownership
+
+When `sugarkube3` was powered off, the other two `control-plane,etcd` servers retained the
+two-member majority of the three-member etcd cluster, so etcd and the API remained available.
+Public service nevertheless failed for about six minutes: the sole packaged CoreDNS pod was on the
+lost node. Kubernetes waited its default roughly five-minute `NodeNotReady` eviction interval before
+`TaintManagerEviction` replaced it; the application itself remained running on `sugarkube4`.
+
+The active staging lifecycle is deliberately non-Flux:
+
+* K3s owns the packaged `coredns` Deployment, `kube-dns` Service, Corefile, RBAC, service account,
+  probes, and image. This lifecycle clones that live pod template into the narrowly owned,
+  two-replica `coredns-ha` companion. Required hostname anti-affinity includes all `kube-dns` pods.
+  Thus it preserves the exact installed K3s compatibility surface, adds endpoints before any other
+  change, and never edits `/var/lib/rancher/k3s/server/manifests` or fights the packaged Deployment.
+* K3s owns packaged Traefik. The committed `HelmChartConfig` is K3s's supported merge point and adds
+  two replicas with required hostname anti-affinity without replacing existing chart values,
+  ServiceLB, ports, ingress classes, or TLS configuration.
+* The active token-mode Cloudflare release is discovered cluster-wide by stable
+  `app.kubernetes.io/name=cloudflare-tunnel` labels. Its observed namespace is `cloudflare`, and its
+  two ready, node-spread pods are already HA. This lifecycle verifies but neither installs nor reads
+  its Secret.
+
+The `platform/cloudflared` HelmRelease and `clusters/staging/patches/cloudflared-values.yaml` belong
+to the inactive future/legacy Flux graph; they are not the source of truth for this live release and
+must not be applied alongside it. The durable active sources are
+`clusters/staging/ingress-ha/traefik-helmchartconfig.yaml` and
+`scripts/staging_ingress_ha.sh`. Re-running apply is idempotent; K3s/server restarts retain the
+companion Deployment and reconcile the HelmChartConfig.
+
+## Post-merge rollout and rollback
+
+Use a kubeconfig whose context is exactly `sugar-staging`. Render/status are read-only. Apply,
+upgrade, and rollback additionally fail closed for every environment except staging and for every
+other context. Rollout waits are bounded at 180 seconds by default.
+
+```bash
+just staging-ingress-ha-render env=staging
+just staging-ingress-ha-status env=staging
+just staging-ingress-ha-apply env=staging
+just staging-ingress-ha-verify env=staging
+```
+
+Apply first creates two ready CoreDNS companion endpoints and only then applies Traefik's supported
+configuration. Verification requires two ready CoreDNS, Traefik, and Cloudflare connector pods on
+distinct hostnames; ready `kube-dns` and Traefik Service backends; an in-cluster DNS lookup; and the
+public staging token.place and Democratized Space health endpoints. Override
+`SUGARKUBE_STAGING_HEALTH_URLS` only to supply a space-separated, app-agnostic staging endpoint set.
+The temporary DNS pod is removed on success, error, or signal.
+
+Rollback removes only the two resources owned here and waits for the packaged defaults:
+
+```bash
+just staging-ingress-ha-rollback env=staging
+just staging-ingress-ha-status env=staging
+```
+
+Rollback intentionally returns DNS/ingress to the K3s singleton defaults and therefore removes the
+one-node availability guarantee. It does not disable or replace K3s components.
+
+## One-node power-off drill
+
+After apply and verify, power off exactly one server (for example `sugarkube3`) using the normal
+host power procedure, then continuously verify from a different server:
+
+```bash
+just staging-ingress-ha-verify env=staging
+watch -n 5 'curl -fsS https://staging.token.place/healthz >/dev/null && echo reachable'
+```
+
+Public endpoints should remain continuously available. Healthchecks.io and PagerDuty should still
+report the intentionally powered-off node; those alerts prove host monitoring works and are not a
+reason to suppress it. Restore that node, wait for `kubectl get node sugarkube3` to report `Ready`,
+and confirm all three etcd members are healthy **before testing another node**. Never remove a
+second server while etcd redundancy is reduced.
+
+This baseline is platform/app agnostic. It does not alter eviction or node-monitor timing, scale
+applications, or change observability credentials. In particular, token.place relay registration
+and default rate-limit state are process-local; token.place application-level HA remains separate
+design work.

--- a/docs/staging-ingress-ha.md
+++ b/docs/staging-ingress-ha.md
@@ -71,11 +71,16 @@ one-node availability guarantee. It does not disable or replace K3s components.
 
 ## One-node power-off drill
 
-After apply and verify, run verification continuously from a different server, power off exactly
-one server, observe it, restore it, wait for readiness, and inspect three-member etcd health:
+After apply and verify, run verification continuously from a different server in its own terminal:
 
 ```bash
 while true; do just staging-ingress-ha-verify env=staging; sleep 5; done
+```
+
+In a second terminal, power off exactly one server, observe it, restore it, wait for readiness, and
+inspect three-member etcd health:
+
+```bash
 ssh sugarkube3 'sudo systemctl poweroff'
 kubectl get nodes --watch
 # Restore power to sugarkube3 using the normal host power procedure.

--- a/justfile
+++ b/justfile
@@ -3267,3 +3267,22 @@ observability-node-heartbeat-verify env='':
 # Disable the heartbeat and destructively remove only its local owned assets.
 observability-node-heartbeat-uninstall env='':
     @scripts/observability_node_heartbeat.sh uninstall '{{ env }}'
+
+# Render the staging-only DNS/ingress HA resources without applying them.
+staging-ingress-ha-render env='staging':
+    scripts/staging_ingress_ha.sh render "{{ env }}"
+
+staging-ingress-ha-status env='staging':
+    scripts/staging_ingress_ha.sh status "{{ env }}"
+
+staging-ingress-ha-apply env='staging':
+    scripts/staging_ingress_ha.sh apply "{{ env }}"
+
+staging-ingress-ha-upgrade env='staging':
+    scripts/staging_ingress_ha.sh upgrade "{{ env }}"
+
+staging-ingress-ha-verify env='staging':
+    scripts/staging_ingress_ha.sh verify "{{ env }}"
+
+staging-ingress-ha-rollback env='staging':
+    scripts/staging_ingress_ha.sh rollback "{{ env }}"

--- a/scripts/staging_ingress_ha.sh
+++ b/scripts/staging_ingress_ha.sh
@@ -52,6 +52,7 @@ apply() {
   kubectl apply -f "$tmp"
   kubectl -n kube-system rollout status deployment/coredns-ha --timeout="$TIMEOUT" || die "CoreDNS HA rollout timed out; run staging-ingress-ha-status (no credentials are logged)"
   kubectl apply -f "$TRAEFIK_CONFIG"
+  kubectl -n kube-system wait --for=jsonpath='{.spec.replicas}'=2 deployment/traefik --timeout="$TIMEOUT" || die "Traefik did not reconcile to the expected two-replica specification before timeout (resource details redacted)"
   kubectl -n kube-system rollout status deployment/traefik --timeout="$TIMEOUT" || die "Traefik rollout timed out; run staging-ingress-ha-status"
 }
 rollback() {
@@ -59,6 +60,7 @@ rollback() {
   assert_owned_or_absent deployment coredns-ha
   assert_owned_or_absent helmchartconfig traefik
   kubectl delete -f "$TRAEFIK_CONFIG" --ignore-not-found=true
+  kubectl -n kube-system wait --for=jsonpath='{.spec.replicas}'=1 deployment/traefik --timeout="$TIMEOUT" || die "packaged Traefik did not reconcile to the expected one-replica specification before timeout (resource details redacted)"
   kubectl -n kube-system delete deployment coredns-ha --ignore-not-found=true
   kubectl -n kube-system rollout status deployment/coredns --timeout="$TIMEOUT" || die "packaged CoreDNS did not become ready during rollback"
   kubectl -n kube-system rollout status deployment/traefik --timeout="$TIMEOUT" || die "packaged Traefik did not become ready during rollback"

--- a/scripts/staging_ingress_ha.sh
+++ b/scripts/staging_ingress_ha.sh
@@ -21,7 +21,7 @@ for k in ("creationTimestamp","resourceVersion","uid","generation","managedField
 d.pop("status",None); print(json.dumps(d,sort_keys=True,indent=2))'
 }
 render() { normalize_env "$1"; need kubectl; need python3; cat "$TRAEFIK_CONFIG"; printf '%s\n' '---'; render_coredns; }
-status() { normalize_env "$1"; need kubectl; printf 'Context: %s (read-only)\n' "$(context)"; kubectl -n kube-system get deploy coredns coredns-ha traefik -o wide; kubectl -n kube-system get endpoints kube-dns traefik; kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o wide; }
+status() { normalize_env "$1"; need kubectl; printf 'Context: %s (read-only)\n' "$(context)"; kubectl -n kube-system get deploy coredns traefik -o wide; kubectl -n kube-system get deploy coredns-ha -o wide --ignore-not-found=true; kubectl -n kube-system get endpoints kube-dns traefik; kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o wide; }
 apply() {
   guard "$1"; need kubectl; need python3
   local tmp; tmp="$(mktemp -t sugarkube-coredns-ha.XXXXXX.json)"; trap 'rm -f "${tmp:-}"' EXIT
@@ -39,7 +39,7 @@ rollback() {
   kubectl -n kube-system rollout status deployment/traefik --timeout="$TIMEOUT" || die "packaged Traefik did not become ready during rollback"
 }
 verify() {
-  normalize_env "$1"; need kubectl; need python3; need curl
+  guard "$1"; need kubectl; need python3; need curl
   probe="sugarkube-ingress-ha-verify-$$"
   cleanup() { kubectl -n default delete pod "$probe" --ignore-not-found=true --wait=false >/dev/null 2>&1 || true; }
   trap cleanup EXIT INT TERM

--- a/scripts/staging_ingress_ha.sh
+++ b/scripts/staging_ingress_ha.sh
@@ -4,6 +4,8 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TRAEFIK_CONFIG="${ROOT}/clusters/staging/ingress-ha/traefik-helmchartconfig.yaml"
 TIMEOUT="${SUGARKUBE_INGRESS_HA_TIMEOUT:-180s}"
 EXPECTED_CONTEXT=sugar-staging
+OWNER_LABEL='sugarkube.dev/managed-by'
+OWNER_VALUE='staging-ingress-ha'
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 2; }
 need() { command -v "$1" >/dev/null 2>&1 || die "required command '$1' was not found"; }
 normalize_env() { local value="${1#env=}"; [[ "$value" == staging ]] || die "this lifecycle is staging-only; use env=staging"; }
@@ -22,8 +24,24 @@ d.pop("status",None); print(json.dumps(d,sort_keys=True,indent=2))'
 }
 render() { normalize_env "$1"; need kubectl; need python3; cat "$TRAEFIK_CONFIG"; printf '%s\n' '---'; render_coredns; }
 status() { normalize_env "$1"; need kubectl; printf 'Context: %s (read-only)\n' "$(context)"; kubectl -n kube-system get deploy coredns traefik -o wide; kubectl -n kube-system get deploy coredns-ha -o wide --ignore-not-found=true; kubectl -n kube-system get endpoints kube-dns traefik; kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o wide; }
+assert_owned_or_absent() {
+  local kind="$1" name="$2" value error_file
+  error_file="$(mktemp -t sugarkube-ownership.XXXXXX)"
+  if ! value="$(kubectl -n kube-system get "${kind}/${name}" -o "jsonpath={.metadata.labels['${OWNER_LABEL}']}" 2>"$error_file")"; then
+    if grep -q '(NotFound)' "$error_file"; then
+      rm -f "$error_file"
+      return 0
+    fi
+    rm -f "$error_file"
+    die "unable to inspect ownership of ${kind}/${name}"
+  fi
+  rm -f "$error_file"
+  [[ "$value" == "$OWNER_VALUE" ]] || die "refusing to modify existing ${kind}/${name}: resource is not owned by this lifecycle"
+}
 apply() {
   guard "$1"; need kubectl; need python3
+  assert_owned_or_absent deployment coredns-ha
+  assert_owned_or_absent helmchartconfig traefik
   local tmp; tmp="$(mktemp -t sugarkube-coredns-ha.XXXXXX.json)"; trap 'rm -f "${tmp:-}"' EXIT
   render_coredns >"$tmp"
   kubectl apply -f "$tmp"
@@ -33,6 +51,8 @@ apply() {
 }
 rollback() {
   guard "$1"; need kubectl
+  assert_owned_or_absent deployment coredns-ha
+  assert_owned_or_absent helmchartconfig traefik
   kubectl delete -f "$TRAEFIK_CONFIG" --ignore-not-found=true
   kubectl -n kube-system delete deployment coredns-ha --ignore-not-found=true
   kubectl -n kube-system rollout status deployment/coredns --timeout="$TIMEOUT" || die "packaged CoreDNS did not become ready during rollback"
@@ -43,20 +63,39 @@ verify() {
   probe="sugarkube-ingress-ha-verify-$$"
   cleanup() { kubectl -n default delete pod "$probe" --ignore-not-found=true --wait=false >/dev/null 2>&1 || true; }
   trap cleanup EXIT INT TERM
-  kubectl get pods -A -o json | python3 -c '
+  check_spread() {
+    local name="$1"
+    python3 -c '
 import json,sys
 pods=json.load(sys.stdin)["items"]
 def ready(p): return p.get("status",{}).get("phase")=="Running" and bool(p.get("status",{}).get("containerStatuses")) and all(c.get("ready") for c in p["status"]["containerStatuses"])
-def nodes(pred): return {p.get("spec",{}).get("nodeName") for p in pods if pred(p) and ready(p)}-{None}
-checks={"CoreDNS":nodes(lambda p:p["metadata"].get("labels",{}).get("k8s-app")=="kube-dns"),"Traefik":nodes(lambda p:p["metadata"].get("labels",{}).get("app.kubernetes.io/name")=="traefik"),"Cloudflare tunnel":nodes(lambda p:p["metadata"].get("labels",{}).get("app.kubernetes.io/name")=="cloudflare-tunnel")}
-bad=[]
-for name,ns in checks.items(): print(f"{name}: ready nodes={sorted(ns)}"); bad += [name] if len(ns)<2 else []
-if bad: raise SystemExit("ERROR: fewer than two ready, hostname-spread pods: "+", ".join(bad))'
+nodes={p.get("spec",{}).get("nodeName") for p in pods if ready(p)}-{None}
+print(f"{sys.argv[1]}: ready nodes={sorted(nodes)}")
+if len(nodes)<2: raise SystemExit(f"ERROR: fewer than two ready, hostname-spread {sys.argv[1]} pods")' "$name"
+  }
+  kubectl -n kube-system get pods -l k8s-app=kube-dns -o json | check_spread CoreDNS
+  kubectl -n kube-system get pods -l app.kubernetes.io/name=traefik -o json | check_spread Traefik
+  local tunnel_namespace
+  tunnel_namespace="$(kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o json | python3 -c '
+import json,sys
+items=json.load(sys.stdin)["items"]
+if len(items) != 1: raise SystemExit(f"ERROR: expected exactly one Cloudflare tunnel Deployment; found {len(items)}")
+print(items[0]["metadata"]["namespace"])')"
+  kubectl -n "$tunnel_namespace" get pods -l app.kubernetes.io/name=cloudflare-tunnel -o json | check_spread 'Cloudflare tunnel'
   for svc in kube-dns traefik; do kubectl -n kube-system get endpoints "$svc" -o json | python3 -c 'import json,sys; e=json.load(sys.stdin); assert any(x.get("addresses") for x in e.get("subsets",[])), "ERROR: Service has no ready backend"'; done
   kubectl -n default run "$probe" --image="${SUGARKUBE_DNS_TEST_IMAGE:-busybox:1.36}" --restart=Never --command -- nslookup kubernetes.default.svc.cluster.local >/dev/null
   kubectl -n default wait --for=jsonpath='{.status.phase}'=Succeeded "pod/$probe" --timeout="$TIMEOUT" || die "bounded in-cluster DNS probe failed"
-  local urls="${SUGARKUBE_STAGING_HEALTH_URLS:-https://staging.token.place/healthz https://staging.democratized.space/healthz}"
-  local url; for url in $urls; do curl --fail --silent --show-error --max-time 15 --retry 2 --output /dev/null "$url" || die "public staging health check failed for ${url}"; done
+  local targets url
+  targets="$(kubectl get probes -A -l environment=staging,criticality=critical -o json | python3 -c '
+import json,sys
+items=json.load(sys.stdin)["items"]
+urls=[item.get("spec",{}).get("url","") for item in items]
+urls=[url for url in urls if url.startswith("https://")]
+if not urls: raise SystemExit("ERROR: no critical staging HTTPS Probe targets found")
+print("\n".join(urls))')"
+  while IFS= read -r url; do
+    curl --fail --silent --max-time 15 --retry 2 --output /dev/null "$url" 2>/dev/null || die "critical staging HTTPS Probe target failed (target redacted)"
+  done <<<"$targets"
   printf 'PASS: staging DNS/ingress HA baseline is healthy.\n'
 }
 cmd="${1:-}"; env_name="${2:-}"

--- a/scripts/staging_ingress_ha.sh
+++ b/scripts/staging_ingress_ha.sh
@@ -25,17 +25,22 @@ d.pop("status",None); print(json.dumps(d,sort_keys=True,indent=2))'
 render() { normalize_env "$1"; need kubectl; need python3; cat "$TRAEFIK_CONFIG"; printf '%s\n' '---'; render_coredns; }
 status() { normalize_env "$1"; need kubectl; printf 'Context: %s (read-only)\n' "$(context)"; kubectl -n kube-system get deploy coredns traefik -o wide; kubectl -n kube-system get deploy coredns-ha -o wide --ignore-not-found=true; kubectl -n kube-system get endpoints kube-dns traefik; kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o wide; }
 assert_owned_or_absent() {
-  local kind="$1" name="$2" value error_file
+  local kind="$1" name="$2" value error_file resource_file
   error_file="$(mktemp -t sugarkube-ownership.XXXXXX)"
-  if ! value="$(kubectl -n kube-system get "${kind}/${name}" -o "jsonpath={.metadata.labels['${OWNER_LABEL}']}" 2>"$error_file")"; then
+  resource_file="$(mktemp -t sugarkube-resource.XXXXXX.json)"
+  if ! kubectl -n kube-system get "${kind}/${name}" -o json >"$resource_file" 2>"$error_file"; then
     if grep -q '(NotFound)' "$error_file"; then
-      rm -f "$error_file"
+      rm -f "$error_file" "$resource_file"
       return 0
     fi
-    rm -f "$error_file"
+    rm -f "$error_file" "$resource_file"
     die "unable to inspect ownership of ${kind}/${name}"
   fi
-  rm -f "$error_file"
+  if ! value="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("metadata",{}).get("labels",{}).get(sys.argv[1], ""), end="")' "$OWNER_LABEL" <"$resource_file" 2>/dev/null)"; then
+    rm -f "$error_file" "$resource_file"
+    die "unable to inspect ownership of ${kind}/${name}"
+  fi
+  rm -f "$error_file" "$resource_file"
   [[ "$value" == "$OWNER_VALUE" ]] || die "refusing to modify existing ${kind}/${name}: resource is not owned by this lifecycle"
 }
 apply() {
@@ -73,7 +78,13 @@ nodes={p.get("spec",{}).get("nodeName") for p in pods if ready(p)}-{None}
 print(f"{sys.argv[1]}: ready nodes={sorted(nodes)}")
 if len(nodes)<2: raise SystemExit(f"ERROR: fewer than two ready, hostname-spread {sys.argv[1]} pods")' "$name"
   }
-  kubectl -n kube-system get pods -l k8s-app=kube-dns -o json | check_spread CoreDNS
+  kubectl -n kube-system get endpoints kube-dns -o json | python3 -c '
+import json,sys
+endpoint=json.load(sys.stdin)
+addresses=[a for subset in endpoint.get("subsets",[]) for a in subset.get("addresses",[])]
+nodes={a.get("nodeName") for a in addresses if a.get("nodeName")}
+print(f"CoreDNS: ready endpoint nodes={sorted(nodes)}")
+if len(addresses)<2 or len(nodes)<2: raise SystemExit("ERROR: fewer than two ready, hostname-spread CoreDNS endpoints")'
   kubectl -n kube-system get pods -l app.kubernetes.io/name=traefik -o json | check_spread Traefik
   local tunnel_namespace
   tunnel_namespace="$(kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o json | python3 -c '
@@ -89,10 +100,9 @@ print(items[0]["metadata"]["namespace"])')"
   targets="$(kubectl get probes -A -l environment=staging,criticality=critical -o json | python3 -c '
 import json,sys
 items=json.load(sys.stdin)["items"]
-urls=[item.get("spec",{}).get("url","") for item in items]
-urls=[url for url in urls if url.startswith("https://")]
+urls={url for item in items for url in item.get("spec",{}).get("targets",{}).get("staticConfig",{}).get("static",[]) if isinstance(url,str) and url.startswith("https://")}
 if not urls: raise SystemExit("ERROR: no critical staging HTTPS Probe targets found")
-print("\n".join(urls))')"
+print("\n".join(sorted(urls)))')"
   while IFS= read -r url; do
     curl --fail --silent --max-time 15 --retry 2 --output /dev/null "$url" 2>/dev/null || die "critical staging HTTPS Probe target failed (target redacted)"
   done <<<"$targets"

--- a/scripts/staging_ingress_ha.sh
+++ b/scripts/staging_ingress_ha.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TRAEFIK_CONFIG="${ROOT}/clusters/staging/ingress-ha/traefik-helmchartconfig.yaml"
+TIMEOUT="${SUGARKUBE_INGRESS_HA_TIMEOUT:-180s}"
+EXPECTED_CONTEXT=sugar-staging
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 2; }
+need() { command -v "$1" >/dev/null 2>&1 || die "required command '$1' was not found"; }
+normalize_env() { local value="${1#env=}"; [[ "$value" == staging ]] || die "this lifecycle is staging-only; use env=staging"; }
+context() { kubectl config current-context 2>/dev/null || true; }
+guard() { normalize_env "$1"; [[ "$(context)" == "$EXPECTED_CONTEXT" ]] || die "refusing mutation: current context must be exactly ${EXPECTED_CONTEXT}"; }
+render_coredns() {
+  kubectl -n kube-system get deployment coredns -o json | python3 -c '
+import json,sys
+d=json.load(sys.stdin); d["metadata"]={"name":"coredns-ha","namespace":"kube-system","labels":{"sugarkube.dev/managed-by":"staging-ingress-ha"}}
+d["spec"]["replicas"]=2
+d["spec"]["selector"]["matchLabels"]["sugarkube.dev/component"]="coredns-ha"
+t=d["spec"]["template"]; t["metadata"].setdefault("labels",{})["sugarkube.dev/component"]="coredns-ha"
+t["spec"]["affinity"]={"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"kube-dns"}},"topologyKey":"kubernetes.io/hostname"}]}}
+for k in ("creationTimestamp","resourceVersion","uid","generation","managedFields","annotations"): d["metadata"].pop(k,None)
+d.pop("status",None); print(json.dumps(d,sort_keys=True,indent=2))'
+}
+render() { normalize_env "$1"; need kubectl; need python3; cat "$TRAEFIK_CONFIG"; printf '%s\n' '---'; render_coredns; }
+status() { normalize_env "$1"; need kubectl; printf 'Context: %s (read-only)\n' "$(context)"; kubectl -n kube-system get deploy coredns coredns-ha traefik -o wide; kubectl -n kube-system get endpoints kube-dns traefik; kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o wide; }
+apply() {
+  guard "$1"; need kubectl; need python3
+  local tmp; tmp="$(mktemp -t sugarkube-coredns-ha.XXXXXX.json)"; trap 'rm -f "${tmp:-}"' EXIT
+  render_coredns >"$tmp"
+  kubectl apply -f "$tmp"
+  kubectl -n kube-system rollout status deployment/coredns-ha --timeout="$TIMEOUT" || die "CoreDNS HA rollout timed out; run staging-ingress-ha-status (no credentials are logged)"
+  kubectl apply -f "$TRAEFIK_CONFIG"
+  kubectl -n kube-system rollout status deployment/traefik --timeout="$TIMEOUT" || die "Traefik rollout timed out; run staging-ingress-ha-status"
+}
+rollback() {
+  guard "$1"; need kubectl
+  kubectl delete -f "$TRAEFIK_CONFIG" --ignore-not-found=true
+  kubectl -n kube-system delete deployment coredns-ha --ignore-not-found=true
+  kubectl -n kube-system rollout status deployment/coredns --timeout="$TIMEOUT" || die "packaged CoreDNS did not become ready during rollback"
+  kubectl -n kube-system rollout status deployment/traefik --timeout="$TIMEOUT" || die "packaged Traefik did not become ready during rollback"
+}
+verify() {
+  normalize_env "$1"; need kubectl; need python3; need curl
+  probe="sugarkube-ingress-ha-verify-$$"
+  cleanup() { kubectl -n default delete pod "$probe" --ignore-not-found=true --wait=false >/dev/null 2>&1 || true; }
+  trap cleanup EXIT INT TERM
+  kubectl get pods -A -o json | python3 -c '
+import json,sys
+pods=json.load(sys.stdin)["items"]
+def ready(p): return p.get("status",{}).get("phase")=="Running" and bool(p.get("status",{}).get("containerStatuses")) and all(c.get("ready") for c in p["status"]["containerStatuses"])
+def nodes(pred): return {p.get("spec",{}).get("nodeName") for p in pods if pred(p) and ready(p)}-{None}
+checks={"CoreDNS":nodes(lambda p:p["metadata"].get("labels",{}).get("k8s-app")=="kube-dns"),"Traefik":nodes(lambda p:p["metadata"].get("labels",{}).get("app.kubernetes.io/name")=="traefik"),"Cloudflare tunnel":nodes(lambda p:p["metadata"].get("labels",{}).get("app.kubernetes.io/name")=="cloudflare-tunnel")}
+bad=[]
+for name,ns in checks.items(): print(f"{name}: ready nodes={sorted(ns)}"); bad += [name] if len(ns)<2 else []
+if bad: raise SystemExit("ERROR: fewer than two ready, hostname-spread pods: "+", ".join(bad))'
+  for svc in kube-dns traefik; do kubectl -n kube-system get endpoints "$svc" -o json | python3 -c 'import json,sys; e=json.load(sys.stdin); assert any(x.get("addresses") for x in e.get("subsets",[])), "ERROR: Service has no ready backend"'; done
+  kubectl -n default run "$probe" --image="${SUGARKUBE_DNS_TEST_IMAGE:-busybox:1.36}" --restart=Never --command -- nslookup kubernetes.default.svc.cluster.local >/dev/null
+  kubectl -n default wait --for=jsonpath='{.status.phase}'=Succeeded "pod/$probe" --timeout="$TIMEOUT" || die "bounded in-cluster DNS probe failed"
+  local urls="${SUGARKUBE_STAGING_HEALTH_URLS:-https://staging.token.place/healthz https://staging.democratized.space/healthz}"
+  local url; for url in $urls; do curl --fail --silent --show-error --max-time 15 --retry 2 --output /dev/null "$url" || die "public staging health check failed for ${url}"; done
+  printf 'PASS: staging DNS/ingress HA baseline is healthy.\n'
+}
+cmd="${1:-}"; env_name="${2:-}"
+case "$cmd" in render) render "$env_name";; status) status "$env_name";; apply|upgrade) apply "$env_name";; verify) verify "$env_name";; rollback) rollback "$env_name";; *) die "usage: $0 render|status|apply|upgrade|verify|rollback staging";; esac

--- a/tests/test_staging_ingress_ha.py
+++ b/tests/test_staging_ingress_ha.py
@@ -39,7 +39,8 @@ def _pod(node):
 
 
 def _stub(tmp_path, *, context="sugar-staging", nodes="node1,node2", workload_nodes=None, tunnels=1,
-          owner="staging-ingress-ha", probes=True, fail_wait="", fail_curl=False):
+          owner="staging-ingress-ha", probes=True, probe_mode="canonical", endpoint_nodes="node1,node2",
+          resource_absent=False, lookup_error=False, fail_wait="", fail_curl=False):
     calls = tmp_path / "calls"
     kubectl = tmp_path / "kubectl"
     kubectl.write_text(f'''#!/usr/bin/env python3
@@ -49,18 +50,25 @@ with open({str(calls)!r}, "a") as f: f.write(" ".join(args)+"\\n")
 joined=" ".join(args)
 if args == ["config", "current-context"]: print(os.environ["FAKE_CONTEXT"])
 elif joined == "-n kube-system get deployment coredns -o json": print(os.environ["DEPLOYMENT"])
-elif " get " in f" {{joined}} " and "jsonpath=" in joined:
-    if os.environ.get("RESOURCE_ABSENT") == "1": sys.exit(1)
-    print(os.environ.get("OWNER", ""), end="")
+elif joined.endswith("get deployment/coredns-ha -o json") or joined.endswith("get helmchartconfig/traefik -o json"):
+    if os.environ["RESOURCE_ABSENT"] == "1":
+        print('Error from server (NotFound): resource not found', file=sys.stderr); sys.exit(1)
+    if os.environ["LOOKUP_ERROR"] == "1":
+        print('forbidden live-value-secret', file=sys.stderr); sys.exit(1)
+    print(json.dumps({{"metadata":{{"labels":{{"sugarkube.dev/managed-by":os.environ.get("OWNER", "")}}}}}}))
 elif "get pods" in joined and "-o json" in joined:
     key = "TUNNEL_NODES" if "cloudflare-tunnel" in joined else ("TRAEFIK_NODES" if "traefik" in joined else "COREDNS_NODES")
     print(json.dumps({{"items":[{{"metadata":{{}},"spec":{{"nodeName":n}},"status":{{"phase":"Running","containerStatuses":[{{"ready":True}}]}}}} for n in os.environ[key].split(",") if n]}}))
 elif joined == "get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o json":
     print(json.dumps({{"items":[{{"metadata":{{"namespace":f"tunnel-{{i}}"}}}} for i in range(int(os.environ["TUNNELS"]))]}}))
 elif joined == "get probes -A -l environment=staging,criticality=critical -o json":
-    items=[{{"spec":{{"url":"https://private.example/health"}}}}] if os.environ["PROBES"] == "1" else []
+    if os.environ["PROBES"] != "1": items=[]
+    elif os.environ["PROBE_MODE"] == "legacy": items=[{{"spec":{{"url":"https://legacy.example/health"}}}}]
+    else: items=[{{"spec":{{"targets":{{"staticConfig":{{"static":["https://private.example/health", "http://ignored.example", "https://private.example/health"]}}}}}}}}]
     print(json.dumps({{"items":items}}))
-elif "get endpoints" in joined and "-o json" in joined: print('{{"subsets":[{{"addresses":[{{"ip":"10.0.0.1"}}]}}]}}')
+elif "get endpoints" in joined and "-o json" in joined:
+    nodes=os.environ["ENDPOINT_NODES"].split(",") if "kube-dns" in joined else ["node1"]
+    print(json.dumps({{"subsets":[{{"addresses":[{{"ip":f"10.0.0.{{i+1}}","nodeName":n}} for i,n in enumerate(nodes) if n]}}]}}))
 elif os.environ.get("FAIL_WAIT") and os.environ["FAIL_WAIT"] in joined and ("wait" in args or "rollout status" in joined): sys.exit(1)
 ''')
     kubectl.chmod(0o755)
@@ -74,6 +82,8 @@ elif os.environ.get("FAIL_WAIT") and os.environ["FAIL_WAIT"] in joined and ("wai
         "TRAEFIK_NODES": (workload_nodes or {}).get("Traefik", nodes),
         "TUNNEL_NODES": (workload_nodes or {}).get("Cloudflare tunnel", nodes),
         "TUNNELS": str(tunnels), "OWNER": owner, "PROBES": "1" if probes else "0",
+        "PROBE_MODE": probe_mode, "ENDPOINT_NODES": endpoint_nodes,
+        "RESOURCE_ABSENT": "1" if resource_absent else "0", "LOOKUP_ERROR": "1" if lookup_error else "0",
         "FAIL_WAIT": fail_wait, "FAIL_CURL": "1" if fail_curl else "0",
     }, calls
 
@@ -147,6 +157,10 @@ def test_apply_idempotent_ordered_and_owned_rollback(tmp_path):
     assert "delete deployment coredns-ha" in text
     assert "delete deployment coredns " not in text
 
+    absent = tmp_path / "absent"; absent.mkdir()
+    env, _ = _stub(absent, resource_absent=True)
+    assert _run(env, "apply").returncode == 0
+
 
 def test_unowned_resources_are_never_modified_or_disclosed(tmp_path):
     for action in ("apply", "rollback"):
@@ -156,17 +170,35 @@ def test_unowned_resources_are_never_modified_or_disclosed(tmp_path):
         assert result.returncode and "not owned" in result.stderr
         assert "someone-else" not in result.stdout + result.stderr
         assert all(word not in calls.read_text() for word in ("apply -f", "delete"))
+    failed = tmp_path / "lookup"; failed.mkdir()
+    env, calls = _stub(failed, lookup_error=True)
+    result = _run(env, "apply")
+    assert result.returncode and "unable to inspect ownership" in result.stderr
+    assert "live-value-secret" not in result.stdout + result.stderr
+    assert "apply -f" not in calls.read_text()
 
 
-def test_each_workload_rejects_singleton_and_same_node_and_healthy_spread_passes(tmp_path):
+def test_each_pod_workload_rejects_singleton_and_same_node(tmp_path):
     for nodes in ("node1", "node1,node1"):
-        for expected in ("CoreDNS", "Traefik", "Cloudflare tunnel"):
+        for expected in ("Traefik", "Cloudflare tunnel"):
             case = tmp_path / f"{nodes.replace(',', '-')}-{expected.split()[0]}"; case.mkdir()
             env, calls = _stub(case, workload_nodes={expected: nodes})
             result = _run(env, "verify")
             assert result.returncode
             assert f"hostname-spread {expected} pods" in result.stderr
             assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
+
+
+def test_coredns_requires_two_ready_endpoints_on_distinct_nodes(tmp_path):
+    for i, nodes in enumerate(("node1", "node1,node1")):
+        case = tmp_path / str(i); case.mkdir()
+        env, calls = _stub(case, endpoint_nodes=nodes)
+        result = _run(env, "verify")
+        assert result.returncode and "hostname-spread CoreDNS endpoints" in result.stderr
+        assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
+    healthy = tmp_path / "healthy"; healthy.mkdir()
+    env, _ = _stub(healthy, endpoint_nodes="node1,node2")
+    assert _run(env, "verify").returncode == 0
 
 
 def test_healthy_verify_and_unique_tunnel_discovery(tmp_path):
@@ -198,6 +230,11 @@ def test_probe_discovery_required_and_curl_failure_redacted(tmp_path):
     assert result.returncode and "target redacted" in result.stderr
     assert "private.example" not in result.stdout + result.stderr
     assert "sensitive-url-output" not in result.stdout + result.stderr
+    legacy = tmp_path / "legacy"; legacy.mkdir(); env, calls = _stub(legacy, probe_mode="legacy")
+    result = _run(env, "verify")
+    assert result.returncode and "no critical staging HTTPS Probe targets" in result.stderr
+    assert "legacy.example" not in calls.read_text()
+    assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
 
 
 def test_rollout_and_dns_probe_timeouts_cleanup(tmp_path):

--- a/tests/test_staging_ingress_ha.py
+++ b/tests/test_staging_ingress_ha.py
@@ -5,122 +5,205 @@ import subprocess
 
 ROOT = pathlib.Path(__file__).parents[1]
 SCRIPT = ROOT / "scripts/staging_ingress_ha.sh"
+OWNER = "sugarkube.dev/managed-by"
 
-
-def test_sources_encode_two_replicas_and_required_hostname_spread():
-    manifest = (ROOT / "clusters/staging/ingress-ha/traefik-helmchartconfig.yaml").read_text()
-    script = SCRIPT.read_text()
-    assert "replicas: 2" in manifest
-    assert "requiredDuringSchedulingIgnoredDuringExecution" in manifest
-    assert "topologyKey: kubernetes.io/hostname" in manifest
-    assert 'd["spec"]["replicas"]=2' in script
-    assert '"k8s-app":"kube-dns"' in script
-    assert '"topologyKey":"kubernetes.io/hostname"' in script
-
-
-def _stub(tmp_path, pods=None, context="sugar-staging"):
-    calls = tmp_path / "calls"
-    kubectl = tmp_path / "kubectl"
-    pods = pods or []
-    deployment = {
-        "apiVersion": "apps/v1",
-        "kind": "Deployment",
-        "metadata": {"name": "coredns"},
-        "spec": {
-            "replicas": 1,
-            "selector": {"matchLabels": {"k8s-app": "kube-dns"}},
-            "template": {
-                "metadata": {"labels": {"k8s-app": "kube-dns"}},
-                "spec": {
-                    "serviceAccountName": "coredns",
-                    "containers": [{"name": "coredns", "image": "example.invalid/coredns"}],
-                },
+DEPLOYMENT = {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {"name": "coredns"},
+    "spec": {
+        "replicas": 1,
+        "selector": {"matchLabels": {"k8s-app": "kube-dns"}},
+        "template": {
+            "metadata": {"labels": {"k8s-app": "kube-dns"}},
+            "spec": {
+                "serviceAccountName": "coredns",
+                "containers": [{
+                    "name": "coredns", "image": "registry.invalid/coredns:v1",
+                    "args": ["-conf", "/etc/coredns/Corefile"],
+                    "readinessProbe": {"httpGet": {"path": "/ready", "port": 8181}},
+                    "livenessProbe": {"httpGet": {"path": "/health", "port": 8080}},
+                    "volumeMounts": [{"name": "config-volume", "mountPath": "/etc/coredns"}],
+                }],
+                "volumes": [{"name": "config-volume", "configMap": {"name": "coredns"}}],
             },
         },
-    }
-    kubectl.write_text(f"""#!/bin/sh
-echo "$*" >>"{calls}"
-case "$*" in
-"config current-context") echo "{context}";;
-"-n kube-system get deployment coredns -o json") cat <<'JSON'
-{json.dumps(deployment)}
-JSON
-;;
-"get pods -A -o json") cat <<'JSON'
-{json.dumps({'items': pods})}
-JSON
-;;
-*"get endpoints "*" -o json") echo '{{"subsets":[{{"addresses":[{{"ip":"10.0.0.1"}}]}}]}}';;
-*) :;;
-esac
-""")
+    },
+}
+
+
+def _pod(node):
+    return {"metadata": {}, "spec": {"nodeName": node}, "status": {
+        "phase": "Running", "containerStatuses": [{"ready": True}]
+    }}
+
+
+def _stub(tmp_path, *, context="sugar-staging", nodes="node1,node2", workload_nodes=None, tunnels=1,
+          owner="staging-ingress-ha", probes=True, fail_wait="", fail_curl=False):
+    calls = tmp_path / "calls"
+    kubectl = tmp_path / "kubectl"
+    kubectl.write_text(f'''#!/usr/bin/env python3
+import json, os, sys
+args=sys.argv[1:]
+with open({str(calls)!r}, "a") as f: f.write(" ".join(args)+"\\n")
+joined=" ".join(args)
+if args == ["config", "current-context"]: print(os.environ["FAKE_CONTEXT"])
+elif joined == "-n kube-system get deployment coredns -o json": print(os.environ["DEPLOYMENT"])
+elif " get " in f" {{joined}} " and "jsonpath=" in joined:
+    if os.environ.get("RESOURCE_ABSENT") == "1": sys.exit(1)
+    print(os.environ.get("OWNER", ""), end="")
+elif "get pods" in joined and "-o json" in joined:
+    key = "TUNNEL_NODES" if "cloudflare-tunnel" in joined else ("TRAEFIK_NODES" if "traefik" in joined else "COREDNS_NODES")
+    print(json.dumps({{"items":[{{"metadata":{{}},"spec":{{"nodeName":n}},"status":{{"phase":"Running","containerStatuses":[{{"ready":True}}]}}}} for n in os.environ[key].split(",") if n]}}))
+elif joined == "get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o json":
+    print(json.dumps({{"items":[{{"metadata":{{"namespace":f"tunnel-{{i}}"}}}} for i in range(int(os.environ["TUNNELS"]))]}}))
+elif joined == "get probes -A -l environment=staging,criticality=critical -o json":
+    items=[{{"spec":{{"url":"https://private.example/health"}}}}] if os.environ["PROBES"] == "1" else []
+    print(json.dumps({{"items":items}}))
+elif "get endpoints" in joined and "-o json" in joined: print('{{"subsets":[{{"addresses":[{{"ip":"10.0.0.1"}}]}}]}}')
+elif os.environ.get("FAIL_WAIT") and os.environ["FAIL_WAIT"] in joined and ("wait" in args or "rollout status" in joined): sys.exit(1)
+''')
     kubectl.chmod(0o755)
     curl = tmp_path / "curl"
-    curl.write_text("#!/bin/sh\nexit 0\n")
+    curl.write_text('#!/bin/sh\necho "$*" >>"$CALLS"\necho "sensitive-url-output" >&2\nexit "${FAIL_CURL:-0}"\n')
     curl.chmod(0o755)
     return {
-        **os.environ,
-        "PATH": f"{tmp_path}:{os.environ['PATH']}",
-        "SUGARKUBE_STAGING_HEALTH_URLS": "https://example.invalid/healthz",
+        **os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}", "CALLS": str(calls),
+        "FAKE_CONTEXT": context, "DEPLOYMENT": json.dumps(DEPLOYMENT),
+        "COREDNS_NODES": (workload_nodes or {}).get("CoreDNS", nodes),
+        "TRAEFIK_NODES": (workload_nodes or {}).get("Traefik", nodes),
+        "TUNNEL_NODES": (workload_nodes or {}).get("Cloudflare tunnel", nodes),
+        "TUNNELS": str(tunnels), "OWNER": owner, "PROBES": "1" if probes else "0",
+        "FAIL_WAIT": fail_wait, "FAIL_CURL": "1" if fail_curl else "0",
     }, calls
 
 
-def _pod(label, node):
-    return {
-        "metadata": {"labels": label},
-        "spec": {"nodeName": node},
-        "status": {"phase": "Running", "containerStatuses": [{"ready": True}]},
-    }
+def _run(env, action, stage="staging"):
+    return subprocess.run([SCRIPT, action, stage], env=env, text=True, capture_output=True)
 
 
-def test_mutation_guards_wrong_environment_and_context(tmp_path):
-    env, calls = _stub(tmp_path, context="not-staging")
-    result = subprocess.run([SCRIPT, "apply", "prod"], env=env, text=True, capture_output=True)
-    assert result.returncode and "staging-only" in result.stderr
-    assert not calls.exists()
-    result = subprocess.run([SCRIPT, "apply", "staging"], env=env, text=True, capture_output=True)
-    assert result.returncode and "exactly sugar-staging" in result.stderr
-    assert "apply -f" not in calls.read_text()
-    calls.unlink()
-    result = subprocess.run([SCRIPT, "verify", "staging"], env=env, text=True, capture_output=True)
-    assert result.returncode and "exactly sugar-staging" in result.stderr
-    assert "get pods" not in calls.read_text()
-    assert "run sugarkube-ingress-ha-verify-" not in calls.read_text()
+def test_rendered_contracts_and_coredns_clone(tmp_path):
+    env, _ = _stub(tmp_path)
+    result = _run(env, "render")
+    assert result.returncode == 0, result.stderr
+    traefik_text, coredns_text = result.stdout.split("\n---\n")
+    # Parse the small manifest into its semantically relevant key/value records
+    # rather than merely searching the complete source for disconnected strings.
+    records = {}
+    path = []
+    for raw in traefik_text.splitlines():
+        if not raw.strip() or raw.lstrip().startswith("-") or raw.strip().endswith("|-"):
+            continue
+        indent = len(raw) - len(raw.lstrip())
+        key, _, value = raw.strip().partition(":")
+        while path and path[-1][0] >= indent:
+            path.pop()
+        if value.strip():
+            records[tuple(x[1] for x in path) + (key,)] = value.strip()
+        else:
+            path.append((indent, key))
+    assert records[("metadata", "name")] == "traefik"
+    assert records[("metadata", "labels", OWNER)] == "staging-ingress-ha"
+    assert records[("spec", "deployment", "replicas")] == "2"
+    assert records[("spec", "affinity", "podAntiAffinity", "requiredDuringSchedulingIgnoredDuringExecution", "topologyKey")] == "kubernetes.io/hostname"
+    coredns = json.loads(coredns_text)
+    assert coredns["spec"]["replicas"] == 2
+    assert coredns["metadata"]["labels"][OWNER] == "staging-ingress-ha"
+    assert coredns["spec"]["template"]["spec"] == DEPLOYMENT["spec"]["template"]["spec"] | {"affinity": coredns["spec"]["template"]["spec"]["affinity"]}
+    term = coredns["spec"]["template"]["spec"]["affinity"]["podAntiAffinity"]["requiredDuringSchedulingIgnoredDuringExecution"][0]
+    assert term["topologyKey"] == "kubernetes.io/hostname"
+    assert term["labelSelector"]["matchLabels"] == {"k8s-app": "kube-dns"}
 
 
-def test_apply_is_idempotent_ordered_and_rollback_owned_only(tmp_path):
+def test_every_mutation_guard_precedes_cluster_operations(tmp_path):
+    for action in ("apply", "upgrade", "verify", "rollback"):
+        case = tmp_path / action; case.mkdir()
+        env, calls = _stub(case, context="production")
+        assert "staging-only" in _run(env, action, "prod").stderr
+        assert not calls.exists()
+        result = _run(env, action)
+        assert result.returncode and "exactly sugar-staging" in result.stderr
+        text = calls.read_text()
+        assert all(word not in text for word in ("apply", " run ", "delete"))
+
+
+def test_status_is_read_only_and_optional_companion_may_be_absent(tmp_path):
     env, calls = _stub(tmp_path)
-    for _ in range(2):
-        assert subprocess.run([SCRIPT, "apply", "staging"], env=env).returncode == 0
-    text = calls.read_text()
-    assert text.count("apply -f") == 4
-    assert text.index("deployment/coredns-ha") < text.index("traefik-helmchartconfig.yaml")
-    assert subprocess.run([SCRIPT, "rollback", "staging"], env=env).returncode == 0
-    text = calls.read_text()
-    assert "delete deployment coredns-ha --ignore-not-found=true" in text
-    assert "delete deployment coredns --ignore-not-found" not in text
-
-
-def test_verify_rejects_singleton_and_same_node_and_cleans_up(tmp_path):
-    labels = [
-        {"k8s-app": "kube-dns"},
-        {"app.kubernetes.io/name": "traefik"},
-        {"app.kubernetes.io/name": "cloudflare-tunnel"},
-    ]
-    pods = [_pod(label, "sugarkube4") for label in labels for _ in range(2)]
-    env, calls = _stub(tmp_path, pods)
-    result = subprocess.run([SCRIPT, "verify", "staging"], env=env, text=True, capture_output=True)
-    assert result.returncode and "fewer than two" in result.stderr
-    assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
-
-
-def test_status_is_read_only_and_errors_do_not_expose_credentials(tmp_path):
-    env, calls = _stub(tmp_path)
-    assert subprocess.run([SCRIPT, "status", "staging"], env=env).returncode == 0
+    assert _run(env, "status").returncode == 0
     text = calls.read_text()
     assert "get deploy coredns traefik -o wide" in text
     assert "get deploy coredns-ha -o wide --ignore-not-found=true" in text
-    assert "get deploy coredns coredns-ha traefik" not in text
-    assert all(word not in text for word in ("apply", "patch", "delete", "secret"))
-    source = SCRIPT.read_text().lower()
-    assert "get secret" not in source and "logs" not in source
+    assert all(word not in text for word in ("apply", "patch", "delete", " run "))
+
+
+def test_apply_idempotent_ordered_and_owned_rollback(tmp_path):
+    env, calls = _stub(tmp_path)
+    for _ in range(2): assert _run(env, "apply").returncode == 0
+    text = calls.read_text()
+    assert text.count("apply -f") == 4
+    assert text.index("deployment/coredns-ha") < text.index("traefik-helmchartconfig.yaml")
+    assert _run(env, "rollback").returncode == 0
+    text = calls.read_text()
+    assert "delete deployment coredns-ha" in text
+    assert "delete deployment coredns " not in text
+
+
+def test_unowned_resources_are_never_modified_or_disclosed(tmp_path):
+    for action in ("apply", "rollback"):
+        case = tmp_path / action; case.mkdir()
+        env, calls = _stub(case, owner="someone-else")
+        result = _run(env, action)
+        assert result.returncode and "not owned" in result.stderr
+        assert "someone-else" not in result.stdout + result.stderr
+        assert all(word not in calls.read_text() for word in ("apply -f", "delete"))
+
+
+def test_each_workload_rejects_singleton_and_same_node_and_healthy_spread_passes(tmp_path):
+    for nodes in ("node1", "node1,node1"):
+        for expected in ("CoreDNS", "Traefik", "Cloudflare tunnel"):
+            case = tmp_path / f"{nodes.replace(',', '-')}-{expected.split()[0]}"; case.mkdir()
+            env, calls = _stub(case, workload_nodes={expected: nodes})
+            result = _run(env, "verify")
+            assert result.returncode
+            assert f"hostname-spread {expected} pods" in result.stderr
+            assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
+
+
+def test_healthy_verify_and_unique_tunnel_discovery(tmp_path):
+    env, calls = _stub(tmp_path)
+    result = _run(env, "verify")
+    assert result.returncode == 0, result.stderr
+    text = calls.read_text()
+    assert "get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o json" in text
+    assert "-n tunnel-0 get pods -l app.kubernetes.io/name=cloudflare-tunnel" in text
+    assert "delete pod sugarkube-ingress-ha-verify-" in text
+
+
+def test_zero_or_multiple_tunnel_deployments_fail_and_cleanup(tmp_path):
+    for count in (0, 2):
+        case = tmp_path / str(count); case.mkdir()
+        env, calls = _stub(case, tunnels=count)
+        result = _run(env, "verify")
+        assert result.returncode and f"found {count}" in result.stderr
+        assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
+
+
+def test_probe_discovery_required_and_curl_failure_redacted(tmp_path):
+    none = tmp_path / "none"; none.mkdir(); env, calls = _stub(none, probes=False)
+    result = _run(env, "verify")
+    assert result.returncode and "no critical staging HTTPS Probe targets" in result.stderr
+    assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
+    failed = tmp_path / "failed"; failed.mkdir(); env, calls = _stub(failed, fail_curl=True)
+    result = _run(env, "verify")
+    assert result.returncode and "target redacted" in result.stderr
+    assert "private.example" not in result.stdout + result.stderr
+    assert "sensitive-url-output" not in result.stdout + result.stderr
+
+
+def test_rollout_and_dns_probe_timeouts_cleanup(tmp_path):
+    rollout = tmp_path / "rollout"; rollout.mkdir(); env, _ = _stub(rollout, fail_wait="deployment/coredns-ha")
+    assert "rollout timed out" in _run(env, "apply").stderr
+    dns = tmp_path / "dns"; dns.mkdir(); env, calls = _stub(dns, fail_wait="pod/sugarkube")
+    result = _run(env, "verify")
+    assert result.returncode and "DNS probe failed" in result.stderr
+    assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()

--- a/tests/test_staging_ingress_ha.py
+++ b/tests/test_staging_ingress_ha.py
@@ -1,0 +1,118 @@
+import json
+import os
+import pathlib
+import subprocess
+
+ROOT = pathlib.Path(__file__).parents[1]
+SCRIPT = ROOT / "scripts/staging_ingress_ha.sh"
+
+
+def test_sources_encode_two_replicas_and_required_hostname_spread():
+    manifest = (ROOT / "clusters/staging/ingress-ha/traefik-helmchartconfig.yaml").read_text()
+    script = SCRIPT.read_text()
+    assert "replicas: 2" in manifest
+    assert "requiredDuringSchedulingIgnoredDuringExecution" in manifest
+    assert "topologyKey: kubernetes.io/hostname" in manifest
+    assert 'd["spec"]["replicas"]=2' in script
+    assert '"k8s-app":"kube-dns"' in script
+    assert '"topologyKey":"kubernetes.io/hostname"' in script
+
+
+def _stub(tmp_path, pods=None, context="sugar-staging"):
+    calls = tmp_path / "calls"
+    kubectl = tmp_path / "kubectl"
+    pods = pods or []
+    deployment = {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {"name": "coredns"},
+        "spec": {
+            "replicas": 1,
+            "selector": {"matchLabels": {"k8s-app": "kube-dns"}},
+            "template": {
+                "metadata": {"labels": {"k8s-app": "kube-dns"}},
+                "spec": {
+                    "serviceAccountName": "coredns",
+                    "containers": [{"name": "coredns", "image": "example.invalid/coredns"}],
+                },
+            },
+        },
+    }
+    kubectl.write_text(f"""#!/bin/sh
+echo "$*" >>"{calls}"
+case "$*" in
+"config current-context") echo "{context}";;
+"-n kube-system get deployment coredns -o json") cat <<'JSON'
+{json.dumps(deployment)}
+JSON
+;;
+"get pods -A -o json") cat <<'JSON'
+{json.dumps({'items': pods})}
+JSON
+;;
+*"get endpoints "*" -o json") echo '{{"subsets":[{{"addresses":[{{"ip":"10.0.0.1"}}]}}]}}';;
+*) :;;
+esac
+""")
+    kubectl.chmod(0o755)
+    curl = tmp_path / "curl"
+    curl.write_text("#!/bin/sh\nexit 0\n")
+    curl.chmod(0o755)
+    return {
+        **os.environ,
+        "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        "SUGARKUBE_STAGING_HEALTH_URLS": "https://example.invalid/healthz",
+    }, calls
+
+
+def _pod(label, node):
+    return {
+        "metadata": {"labels": label},
+        "spec": {"nodeName": node},
+        "status": {"phase": "Running", "containerStatuses": [{"ready": True}]},
+    }
+
+
+def test_mutation_guards_wrong_environment_and_context(tmp_path):
+    env, calls = _stub(tmp_path, context="not-staging")
+    result = subprocess.run([SCRIPT, "apply", "prod"], env=env, text=True, capture_output=True)
+    assert result.returncode and "staging-only" in result.stderr
+    assert not calls.exists()
+    result = subprocess.run([SCRIPT, "apply", "staging"], env=env, text=True, capture_output=True)
+    assert result.returncode and "exactly sugar-staging" in result.stderr
+    assert "apply -f" not in calls.read_text()
+
+
+def test_apply_is_idempotent_ordered_and_rollback_owned_only(tmp_path):
+    env, calls = _stub(tmp_path)
+    for _ in range(2):
+        assert subprocess.run([SCRIPT, "apply", "staging"], env=env).returncode == 0
+    text = calls.read_text()
+    assert text.count("apply -f") == 4
+    assert text.index("deployment/coredns-ha") < text.index("traefik-helmchartconfig.yaml")
+    assert subprocess.run([SCRIPT, "rollback", "staging"], env=env).returncode == 0
+    text = calls.read_text()
+    assert "delete deployment coredns-ha --ignore-not-found=true" in text
+    assert "delete deployment coredns --ignore-not-found" not in text
+
+
+def test_verify_rejects_singleton_and_same_node_and_cleans_up(tmp_path):
+    labels = [
+        {"k8s-app": "kube-dns"},
+        {"app.kubernetes.io/name": "traefik"},
+        {"app.kubernetes.io/name": "cloudflare-tunnel"},
+    ]
+    pods = [_pod(label, "sugarkube4") for label in labels for _ in range(2)]
+    env, calls = _stub(tmp_path, pods)
+    result = subprocess.run([SCRIPT, "verify", "staging"], env=env, text=True, capture_output=True)
+    assert result.returncode and "fewer than two" in result.stderr
+    assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
+
+
+def test_status_is_read_only_and_errors_do_not_expose_credentials(tmp_path):
+    env, calls = _stub(tmp_path)
+    assert subprocess.run([SCRIPT, "status", "staging"], env=env).returncode == 0
+    text = calls.read_text()
+    assert all(word not in text for word in ("apply", "patch", "delete", "secret"))
+    source = SCRIPT.read_text().lower()
+    assert "get secret" not in source and "logs" not in source

--- a/tests/test_staging_ingress_ha.py
+++ b/tests/test_staging_ingress_ha.py
@@ -81,6 +81,11 @@ def test_mutation_guards_wrong_environment_and_context(tmp_path):
     result = subprocess.run([SCRIPT, "apply", "staging"], env=env, text=True, capture_output=True)
     assert result.returncode and "exactly sugar-staging" in result.stderr
     assert "apply -f" not in calls.read_text()
+    calls.unlink()
+    result = subprocess.run([SCRIPT, "verify", "staging"], env=env, text=True, capture_output=True)
+    assert result.returncode and "exactly sugar-staging" in result.stderr
+    assert "get pods" not in calls.read_text()
+    assert "run sugarkube-ingress-ha-verify-" not in calls.read_text()
 
 
 def test_apply_is_idempotent_ordered_and_rollback_owned_only(tmp_path):
@@ -113,6 +118,9 @@ def test_status_is_read_only_and_errors_do_not_expose_credentials(tmp_path):
     env, calls = _stub(tmp_path)
     assert subprocess.run([SCRIPT, "status", "staging"], env=env).returncode == 0
     text = calls.read_text()
+    assert "get deploy coredns traefik -o wide" in text
+    assert "get deploy coredns-ha -o wide --ignore-not-found=true" in text
+    assert "get deploy coredns coredns-ha traefik" not in text
     assert all(word not in text for word in ("apply", "patch", "delete", "secret"))
     source = SCRIPT.read_text().lower()
     assert "get secret" not in source and "logs" not in source

--- a/tests/test_staging_ingress_ha.py
+++ b/tests/test_staging_ingress_ha.py
@@ -40,7 +40,8 @@ def _pod(node):
 
 def _stub(tmp_path, *, context="sugar-staging", nodes="node1,node2", workload_nodes=None, tunnels=1,
           owner="staging-ingress-ha", probes=True, probe_mode="canonical", endpoint_nodes="node1,node2",
-          resource_absent=False, lookup_error=False, fail_wait="", fail_curl=False):
+          resource_absent=False, lookup_error=False, fail_wait="", fail_curl=False,
+          fail_reconcile=False):
     calls = tmp_path / "calls"
     kubectl = tmp_path / "kubectl"
     kubectl.write_text(f'''#!/usr/bin/env python3
@@ -69,7 +70,16 @@ elif joined == "get probes -A -l environment=staging,criticality=critical -o jso
 elif "get endpoints" in joined and "-o json" in joined:
     nodes=os.environ["ENDPOINT_NODES"].split(",") if "kube-dns" in joined else ["node1"]
     print(json.dumps({{"subsets":[{{"addresses":[{{"ip":f"10.0.0.{{i+1}}","nodeName":n}} for i,n in enumerate(nodes) if n]}}]}}))
-elif os.environ.get("FAIL_WAIT") and os.environ["FAIL_WAIT"] in joined and ("wait" in args or "rollout status" in joined): sys.exit(1)
+elif "wait" in args:
+    if os.environ.get("FAIL_WAIT") and os.environ["FAIL_WAIT"] in joined: sys.exit(1)
+    if "deployment/traefik" in joined and "jsonpath={{.spec.replicas}}" in joined:
+        if os.environ["FAIL_RECONCILE"] == "1": sys.exit(1)
+        calls=open({str(calls)!r}).read()
+        expected = "=2" if "=2" in joined else "=1"
+        prerequisite = "apply -f" if expected == "=2" else "delete -f"
+        if prerequisite not in calls: sys.exit(1)
+    elif "pod/sugarkube" not in joined: sys.exit(1)
+elif "rollout status" in joined and os.environ.get("FAIL_WAIT") and os.environ["FAIL_WAIT"] in joined: sys.exit(1)
 ''')
     kubectl.chmod(0o755)
     curl = tmp_path / "curl"
@@ -85,6 +95,7 @@ elif os.environ.get("FAIL_WAIT") and os.environ["FAIL_WAIT"] in joined and ("wai
         "PROBE_MODE": probe_mode, "ENDPOINT_NODES": endpoint_nodes,
         "RESOURCE_ABSENT": "1" if resource_absent else "0", "LOOKUP_ERROR": "1" if lookup_error else "0",
         "FAIL_WAIT": fail_wait, "FAIL_CURL": "1" if fail_curl else "0",
+        "FAIL_RECONCILE": "1" if fail_reconcile else "0",
     }, calls
 
 
@@ -160,6 +171,33 @@ def test_apply_idempotent_ordered_and_owned_rollback(tmp_path):
     absent = tmp_path / "absent"; absent.mkdir()
     env, _ = _stub(absent, resource_absent=True)
     assert _run(env, "apply").returncode == 0
+
+
+def test_traefik_reconciliation_precedes_rollout_and_fails_closed(tmp_path):
+    env, calls = _stub(tmp_path)
+    assert _run(env, "apply").returncode == 0
+    text = calls.read_text()
+    apply_pos = text.rindex("apply -f", 0, text.index("traefik-helmchartconfig.yaml") + 1)
+    apply_wait = text.index("jsonpath={.spec.replicas}=2")
+    apply_rollout = text.index("rollout status deployment/traefik")
+    assert apply_pos < apply_wait < apply_rollout
+
+    calls.write_text("")
+    assert _run(env, "rollback").returncode == 0
+    text = calls.read_text()
+    delete_pos = text.index("delete -f")
+    rollback_wait = text.index("jsonpath={.spec.replicas}=1")
+    rollback_rollout = text.index("rollout status deployment/traefik")
+    assert delete_pos < rollback_wait < rollback_rollout
+
+    for action in ("apply", "rollback"):
+        case = tmp_path / f"never-{action}"; case.mkdir()
+        failed_env, failed_calls = _stub(case, fail_reconcile=True)
+        result = _run(failed_env, action)
+        assert result.returncode and "reconcile" in result.stderr
+        assert "resource details redacted" in result.stderr
+        text = failed_calls.read_text()
+        assert "rollout status deployment/traefik" not in text
 
 
 def test_unowned_resources_are_never_modified_or_disclosed(tmp_path):


### PR DESCRIPTION
### Motivation

During a controlled shutdown of `sugarkube3`, the remaining two control-plane/etcd nodes retained quorum, but staging public endpoints were unavailable for roughly six minutes. The application remained running; the outage lasted until Kubernetes’ default five-minute eviction interval replaced the sole CoreDNS pod.

This PR adds a minimal, app-agnostic staging DNS/ingress HA baseline without changing cluster-wide eviction timing, application replicas, or K3s-generated manifests.

### Implementation

- Add `clusters/staging/ingress-ha/traefik-helmchartconfig.yaml`, using K3s’s supported `HelmChartConfig` extension point to configure two Traefik replicas with required hostname anti-affinity.
- Add a durable `coredns-ha` companion lifecycle in `scripts/staging_ingress_ha.sh`:
  - clones the live packaged CoreDNS pod template;
  - preserves its image, arguments, probes, service account, Corefile mounts, RBAC compatibility, and `kube-dns` Service identity;
  - creates two companion replicas with required hostname anti-affinity;
  - never edits or scales the packaged CoreDNS Deployment.
- Preserve existing Traefik values by refusing to overwrite an unowned pre-existing `kube-system/traefik` `HelmChartConfig`.
- Discover the active Cloudflare tunnel cluster-wide through `app.kubernetes.io/name=cloudflare-tunnel`; require exactly one Deployment and verify its ready pods in the discovered namespace. The tunnel remains verification-only.
- Add staging-only `just` commands for render, status, apply, upgrade, verify, and rollback.
- Require `env=staging` and Kubernetes context `sugar-staging` before every mutating operation. Verification is mutating because it creates a temporary DNS test pod, and it uses the same guard.
- Add bounded Traefik reconciliation waits so apply cannot succeed before the Deployment reaches two desired replicas and rollback cannot succeed before it returns to the packaged one-replica specification.
- Verify:
  - at least two ready CoreDNS endpoints on distinct nodes;
  - at least two ready Traefik pods on distinct nodes;
  - at least two ready Cloudflare tunnel pods on distinct nodes;
  - ready `kube-dns` and Traefik Service backends;
  - in-cluster DNS resolution;
  - HTTPS targets discovered from critical staging `Probe.spec.targets.staticConfig.static[]` entries.
- Clean up the temporary DNS pod on success, error, or signal, and redact public-target, ownership-inspection, and curl failure details.
- Document active ownership, rollback, and an executable two-terminal one-node power-off drill.

The inactive `platform/cloudflared` HelmRelease and `clusters/staging/patches/cloudflared-values.yaml` remain unchanged and are not the active staging tunnel source of truth.

### Changed files

- `clusters/staging/ingress-ha/traefik-helmchartconfig.yaml`
- `scripts/staging_ingress_ha.sh`
- `tests/test_staging_ingress_ha.py`
- `docs/staging-ingress-ha.md`
- `docs/raspi_cluster_operations.md`
- `justfile`

### Operator commands

Use a kubeconfig whose current context is exactly `sugar-staging`.

~~~bash
just staging-ingress-ha-render env=staging
just staging-ingress-ha-status env=staging
just staging-ingress-ha-apply env=staging
just staging-ingress-ha-verify env=staging
~~~

For subsequent reconciliation:

~~~bash
just staging-ingress-ha-upgrade env=staging
just staging-ingress-ha-verify env=staging
~~~

Rollback removes only the lifecycle-owned CoreDNS companion and Traefik `HelmChartConfig`, waits for the packaged singleton specifications, and leaves packaged K3s components intact:

~~~bash
just staging-ingress-ha-rollback env=staging
just staging-ingress-ha-status env=staging
~~~

Rollback intentionally removes the one-node DNS/ingress availability guarantee.

### One-node power-off drill

After apply and verify, run continuous verification from another server in terminal 1:

~~~bash
while true; do just staging-ingress-ha-verify env=staging; sleep 5; done
~~~

In terminal 2:

~~~bash
ssh sugarkube3 'sudo systemctl poweroff'
kubectl get nodes --watch
# Restore power to sugarkube3 using the normal host power procedure.
kubectl wait --for=condition=Ready node/sugarkube3 --timeout=10m
ssh sugarkube4 'sudo k3s etcdctl endpoint status --cluster --write-out=table'
~~~

Public endpoints should remain continuously available. Healthchecks.io and PagerDuty should still report the intentionally powered-off node. Do not test another node until `sugarkube3` is Ready and all three etcd members have recovered.

### Testing

- `python3 -m pytest -q tests/test_staging_ingress_ha.py` — 12 passed.
- `python3 -m pytest -q tests/test_staging_ingress_ha.py -k 'apply or rollback or traefik'` — 2 passed, 10 deselected.
- `bash -n scripts/staging_ingress_ha.sh` — passed.
- `just --unstable --fmt --check` — passed.
- `linkchecker --no-warnings README.md docs/` — 205 links checked, 0 errors.
- `git diff --check` — passed.
- `git diff | ./scripts/scan-secrets.py` — passed.
- All six latest-head GitHub workflows passed: `ci`, `Test Suite`, `Docs`, `Spellcheck`, `Verify Justfile formatting`, and `pi-image` (including ShellCheck/unit coverage).
- The final scoped local `bash scripts/checks.sh` attempt encountered existing repository-wide pycodestyle findings outside this PR’s remediation scope; no unrelated files were changed.
- No live cluster mutations were performed from the implementation environment.

### Scope

This PR does not:

- tune node-monitor or eviction timing;
- scale token.place or modify application charts;
- install another Cloudflare tunnel;
- read, render, log, or commit tunnel credentials;
- modify Prometheus, Alertmanager, PagerDuty, or Healthchecks.io secrets;
- edit K3s-generated manifests.

Token.place application-level HA remains separate work because relay registration and default rate-limit state are process-local.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6983a9d404832fb6073a73931e8d4c)