### PR TITLE
Staging: durable CoreDNS+Traefik HA baseline with guarded operator lifecycle

### DIFF
--- a/clusters/staging/ingress-ha/kustomization.yaml
+++ b/clusters/staging/ingress-ha/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - traefik-helmchartconfig.yaml

--- a/clusters/staging/ingress-ha/traefik-helmchartconfig.yaml
+++ b/clusters/staging/ingress-ha/traefik-helmchartconfig.yaml
@@ -1,0 +1,18 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: k3s-traefik
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/managed-by: sugarkube-staging-ingress-ha
+spec:
+  valuesContent: |-
+    deployment:
+      replicas: 2
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: traefik
+            topologyKey: kubernetes.io/hostname

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -1,5 +1,10 @@
 # Observability operations runbook
 
+The staging DNS/ingress dependency lifecycle and single-node failure drill are
+documented in [Staging DNS and ingress high availability](staging-ingress-ha.md).
+It complements this observability lifecycle without changing Prometheus,
+Alertmanager, PagerDuty, or Healthchecks.io configuration.
+
 This runbook covers the current live **staging-only** kube-prometheus-stack lifecycle. It is intentionally non-Flux: operators use guarded Helm commands from this repository, with the chart version and full values chain committed in Git.
 
 Production observability is intentionally unsupported in this slice because no production live baseline has been proven yet.

--- a/docs/staging-ingress-ha.md
+++ b/docs/staging-ingress-ha.md
@@ -1,0 +1,95 @@
+# Staging DNS and ingress high availability
+
+This is the canonical operations lifecycle for the staging public data path. It
+does not make any application highly available.
+
+## Incident and ownership audit
+
+During the controlled shutdown of `sugarkube3`, the remaining two etcd/server
+members retained quorum, so the Kubernetes API stayed available. The public path
+still failed for about six minutes because the sole CoreDNS pod was on the powered
+off node. Kubernetes' default `NoExecute` toleration delayed
+`TaintManagerEviction` for approximately five minutes. A replacement CoreDNS pod
+then started on `sugarkube4`, and public service recovered immediately. This was
+a singleton data-plane dependency failure, not slow etcd quorum formation.
+
+Staging has three distinct ownership paths:
+
+* K3s owns its packaged CoreDNS and Traefik `HelmChart` resources. K3s rewrites
+  the packaged manifests at server startup. Traefik uses the supported, version-controlled `HelmChartConfig` in
+  `clusters/staging/ingress-ha/`. CoreDNS is not a Helm chart in the active K3s
+  lifecycle, so apply clones the live packaged Deployment into a separately named
+  supplemental `coredns-ha` Deployment. The clone retains its image, arguments,
+  Corefile mount, RBAC, service account, probes, and `kube-dns` selector while
+  adding two replicas and required hostname anti-affinity. K3s continues owning
+  the original Deployment, so no controllers fight and there is no staged DNS
+  gap. Traefik retains LoadBalancer/ServiceLB, ports, classes, TLS, and defaults.
+* The active Cloudflare connector is the existing Helm-managed Deployment in
+  namespace `cloudflare`, discovered using the stable
+  `app.kubernetes.io/name=cloudflare-tunnel` label. Its two ready connectors on
+  different nodes are already HA; this lifecycle only verifies them and never
+  reads their Secret or installs another Deployment.
+* `platform/cloudflared/` and the broad `clusters/*` Flux overlays describe a
+  legacy/future `cloudflared` namespace path and are not the active staging
+  tunnel lifecycle. Do not apply that path to staging. Likewise, manual
+  `kubectl scale`, patches, and edits below
+  `/var/lib/rancher/k3s/server/manifests` are ephemeral and unsupported.
+
+Apply refuses to overwrite a pre-existing Traefik `HelmChartConfig` without Sugarkube's
+ownership label. This prevents two controllers from fighting and protects live
+custom values until they are reviewed and merged into the canonical files.
+
+## Apply and verify after merge
+
+```bash
+just kubeconfig-env env=staging
+test "$(kubectl config current-context)" = sugar-staging
+just staging-ingress-ha-render env=staging
+just staging-ingress-ha-status env=staging
+just staging-ingress-ha-apply env=staging
+just staging-ingress-ha-verify env=staging
+```
+
+Render is local and non-mutating. Status is read-only. Verify only creates a
+temporary `default/sugarkube-dns-check-*` pod and always deletes it, including
+after failure. Mutations require explicit `staging`, exact `sugar-staging`
+context, and the staging identity check. Waits default to five minutes. Errors
+redact endpoint URLs and never inspect or print tunnel credentials.
+
+Verification proves two ready, hostname-spread pods for each of CoreDNS, Traefik,
+and the existing tunnel; ready `kube-dns` and Traefik Service backends; DNS from
+a temporary pod; and all environment-labeled staging public Probe targets.
+
+## Rollback
+
+```bash
+just staging-ingress-ha-rollback env=staging
+just staging-ingress-ha-status env=staging
+```
+
+Rollback deletes only the owned supplemental `coredns-ha` Deployment and Traefik
+`HelmChartConfig`, then waits for the packaged workloads. It never deletes Services,
+RBAC, CoreDNS configuration, Traefik, or the tunnel. Rollback intentionally
+removes the HA guarantee.
+
+## One-node power-off drill
+
+After apply and verify, power off exactly one server using the normal hardware
+procedure. From an unaffected operator host, continuously exercise a public
+health endpoint and verify:
+
+```bash
+watch -n 2 'kubectl --context sugar-staging get nodes; curl --fail --silent --show-error --max-time 10 https://staging.token.place/healthz >/dev/null'
+just staging-ingress-ha-verify env=staging
+```
+
+The example URL is an operator drill target, not embedded platform configuration.
+Public endpoints should remain continuously available while Healthchecks.io and
+PagerDuty still report the powered-off node. Bring it back before another test.
+**Do not power off another node until the first is `Ready` and etcd has restored
+three-member redundancy.** Then rerun status and verify. Do not tune cluster-wide
+node-monitor or default eviction timing for this drill.
+
+The token.place process remains a singleton: relay registration and default
+rate-limit state are process-local. Application-level horizontal HA and state
+coordination are separate work; no application chart is changed here.

--- a/justfile
+++ b/justfile
@@ -3267,3 +3267,23 @@ observability-node-heartbeat-verify env='':
 # Disable the heartbeat and destructively remove only its local owned assets.
 observability-node-heartbeat-uninstall env='':
     @scripts/observability_node_heartbeat.sh uninstall '{{ env }}'
+
+# Render the durable K3s CoreDNS and Traefik staging HA customizations (local/read-only).
+staging-ingress-ha-render env='':
+    @scripts/staging_ingress_ha.sh render '{{ env }}'
+
+# Show active DNS, ingress, and tunnel resources without changing them.
+staging-ingress-ha-status env='':
+    @scripts/staging_ingress_ha.sh status '{{ env }}'
+
+# Apply the guarded staging-only K3s packaged-chart customizations.
+staging-ingress-ha-apply env='':
+    @scripts/staging_ingress_ha.sh apply '{{ env }}'
+
+# Verify replica spread, service backends, in-cluster DNS, and public health.
+staging-ingress-ha-verify env='':
+    @scripts/staging_ingress_ha.sh verify '{{ env }}'
+
+# Remove owned customizations and restore the K3s packaged chart defaults.
+staging-ingress-ha-rollback env='':
+    @scripts/staging_ingress_ha.sh rollback '{{ env }}'

--- a/scripts/render_coredns_ha.py
+++ b/scripts/render_coredns_ha.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Clone the live K3s-packaged CoreDNS Deployment into a supplemental HA Deployment."""
+
+import json
+import sys
+
+source = json.load(sys.stdin)
+if source.get("kind") != "Deployment" or source.get("metadata", {}).get("name") != "coredns":
+    raise SystemExit("ERROR: expected the kube-system/coredns Deployment")
+for key in (
+    "uid",
+    "resourceVersion",
+    "generation",
+    "creationTimestamp",
+    "managedFields",
+    "ownerReferences",
+):
+    source["metadata"].pop(key, None)
+source.pop("status", None)
+metadata = source["metadata"]
+metadata["name"] = "coredns-ha"
+metadata.setdefault("labels", {})["app.kubernetes.io/managed-by"] = "sugarkube-staging-ingress-ha"
+spec = source.setdefault("spec", {})
+spec["replicas"] = 2
+spec["revisionHistoryLimit"] = 2
+pod_spec = spec["template"]["spec"]
+affinity = pod_spec.setdefault("affinity", {})
+pod_affinity = affinity.setdefault("podAntiAffinity", {})
+pod_affinity["requiredDuringSchedulingIgnoredDuringExecution"] = [
+    {
+        "labelSelector": {"matchLabels": {"k8s-app": "kube-dns"}},
+        "topologyKey": "kubernetes.io/hostname",
+    }
+]
+print(json.dumps(source, sort_keys=True, indent=2))

--- a/scripts/staging_ingress_ha.sh
+++ b/scripts/staging_ingress_ha.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG_DIR="${ROOT}/clusters/staging/ingress-ha"
+TIMEOUT="${SUGARKUBE_STAGING_HA_TIMEOUT:-5m}"
+OWNER="sugarkube-staging-ingress-ha"
+
+usage() { echo "Usage: $0 <render|status|apply|verify|rollback> env=staging" >&2; }
+normalize_env() {
+  local value="${1:-}"
+  while [[ "${value}" == env=* ]]; do value="${value#env=}"; done
+  [[ "${value}" == staging ]] || { echo "ERROR: staging ingress HA only supports explicit env=staging." >&2; exit 2; }
+}
+require_tools() { for tool in "$@"; do command -v "${tool}" >/dev/null || { echo "ERROR: required tool missing: ${tool}" >&2; exit 127; }; done; }
+context() { kubectl config current-context 2>/dev/null || true; }
+guard() {
+  local current; current="$(context)"
+  [[ "${current}" == sugar-staging ]] || {
+    echo "ERROR: expected Kubernetes context 'sugar-staging', got '${current:-<none>}'; refusing cluster access." >&2
+    exit 3
+  }
+  python3 "${ROOT}/scripts/cluster_identity.py" assert --kubeconfig "${KUBECONFIG:-${HOME}/.kube/config}" --env staging >/dev/null
+}
+render() { require_tools kubectl; kubectl kustomize "${CONFIG_DIR}"; echo "---"; echo "# CoreDNS is rendered from the active packaged Deployment during apply; preview with status."; }
+assert_owned_or_absent() {
+  local name owner
+  name="$1"
+  owner="$(kubectl -n kube-system get helmchartconfig "${name}" -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}' 2>/dev/null || true)"
+  if kubectl -n kube-system get helmchartconfig "${name}" >/dev/null 2>&1 && [[ "${owner}" != "${OWNER}" ]]; then
+    echo "ERROR: kube-system/${name} already exists outside this lifecycle; refusing to overwrite current custom values." >&2
+    echo "Merge its redacted values into ${CONFIG_DIR} before retrying." >&2
+    exit 4
+  fi
+}
+status() {
+  require_tools kubectl python3; guard
+  kubectl -n kube-system get helmchartconfig k3s-traefik --ignore-not-found
+  kubectl -n kube-system get deployment coredns coredns-ha -o wide
+  kubectl -n kube-system get deploy,pod,svc,endpoints -l 'k8s-app=kube-dns' -o wide
+  kubectl -n kube-system get deploy,pod,svc,endpoints -l 'app.kubernetes.io/name=traefik' -o wide
+  discover_cloudflare get
+}
+discover_cloudflare() {
+  local verb="$1" inventory namespace name
+  inventory="$(kubectl get deployments --all-namespaces -l 'app.kubernetes.io/name=cloudflare-tunnel' -o json)"
+  read -r namespace name < <(python3 -c 'import json,sys
+d=json.load(sys.stdin); items=d.get("items",[])
+if len(items)!=1: raise SystemExit("ERROR: expected exactly one active Cloudflare tunnel Deployment discovered by stable label")
+print(items[0]["metadata"]["namespace"],items[0]["metadata"]["name"])' <<<"${inventory}")
+  if [[ "${verb}" == get ]]; then kubectl -n "${namespace}" get deploy "${name}"; kubectl -n "${namespace}" get pods -l 'app.kubernetes.io/name=cloudflare-tunnel' -o wide; else printf '%s %s\n' "${namespace}" "${name}"; fi
+}
+apply_config() {
+  require_tools kubectl python3; guard
+  assert_owned_or_absent k3s-traefik
+  render >/dev/null
+  kubectl -n kube-system get deployment coredns -o json | python3 "${ROOT}/scripts/render_coredns_ha.py" | kubectl apply -f -
+  kubectl apply -k "${CONFIG_DIR}"
+  kubectl -n kube-system rollout status deployment/coredns-ha --timeout="${TIMEOUT}" || { echo "ERROR: supplemental CoreDNS rollout timed out; packaged CoreDNS remains active." >&2; exit 5; }
+  kubectl -n kube-system rollout status deployment/traefik --timeout="${TIMEOUT}" || { echo "ERROR: Traefik rollout timed out; inspect deployment events (credentials are never printed)." >&2; exit 5; }
+}
+verify() {
+  require_tools kubectl python3; guard
+  local cf_namespace cf_name tmp pod rc=0
+  read -r cf_namespace cf_name < <(discover_cloudflare identify)
+  tmp="$(mktemp -d -t sugarkube-staging-ha.XXXXXX)"; pod="sugarkube-dns-check-$RANDOM"
+  trap 'kubectl -n default delete pod "${pod}" --ignore-not-found --wait=false >/dev/null 2>&1 || true; rm -rf "${tmp}"' EXIT
+  kubectl -n kube-system get pods -l k8s-app=kube-dns -o json >"${tmp}/coredns"
+  kubectl -n kube-system get pods -l app.kubernetes.io/name=traefik -o json >"${tmp}/traefik"
+  kubectl -n "${cf_namespace}" get pods -l app.kubernetes.io/name=cloudflare-tunnel -o json >"${tmp}/cloudflare"
+  kubectl -n kube-system get endpoints kube-dns -o json >"${tmp}/dns_endpoints"
+  kubectl -n kube-system get endpoints traefik -o json >"${tmp}/traefik_endpoints"
+  python3 - "${tmp}" <<'PY' | python3 "${ROOT}/scripts/staging_ingress_ha_verify.py"
+import json, pathlib, sys
+root=pathlib.Path(sys.argv[1]); print(json.dumps({p.name:json.loads(p.read_text()) for p in root.iterdir()}))
+PY
+  kubectl -n default run "${pod}" --image="${SUGARKUBE_DNS_TEST_IMAGE:-busybox:1.36}" --restart=Never --command -- nslookup kubernetes.default.svc.cluster.local
+  kubectl -n default wait --for=jsonpath='{.status.phase}'=Succeeded "pod/${pod}" --timeout="${TIMEOUT}" || { echo "ERROR: bounded in-cluster DNS check failed; test pod will be removed." >&2; rc=6; }
+  if ((rc == 0)); then
+    kubectl -n monitoring get probes -l environment=staging -o json | python3 -c 'import json,subprocess,sys
+items=json.load(sys.stdin).get("items",[])
+urls=[target for item in items for target in item.get("spec",{}).get("targets",{}).get("staticConfig",{}).get("static",[])]
+if not urls: raise SystemExit("ERROR: no labeled public staging health Probe targets discovered")
+for url in urls:
+ r=subprocess.run(["curl","--fail","--silent","--show-error","--max-time","10","--output","/dev/null",url])
+ if r.returncode: raise SystemExit("ERROR: a public staging health endpoint was unreachable (URL redacted)")
+print(f"public staging health: {len(urls)} endpoints reachable")' || rc=7
+  fi
+  return "${rc}"
+}
+rollback() {
+  require_tools kubectl python3; guard
+  assert_owned_or_absent k3s-traefik
+  kubectl -n kube-system delete deployment coredns-ha --ignore-not-found
+  kubectl -n kube-system delete helmchartconfig k3s-traefik --ignore-not-found
+  kubectl -n kube-system rollout status deployment/coredns --timeout="${TIMEOUT}"
+  kubectl -n kube-system rollout status deployment/traefik --timeout="${TIMEOUT}"
+  echo "Rollback complete: supplemental CoreDNS is removed and K3s packaged chart defaults are restored."
+}
+
+[[ $# -eq 2 ]] || { usage; exit 2; }
+normalize_env "$2"
+case "$1" in render) render;; status) status;; apply) apply_config;; verify) verify;; rollback) rollback;; *) usage; exit 2;; esac

--- a/scripts/staging_ingress_ha_verify.py
+++ b/scripts/staging_ingress_ha_verify.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Validate the redacted Kubernetes inventory emitted by staging_ingress_ha.sh."""
+
+import json
+import sys
+
+
+def fail(message):
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def ready_pod_nodes(items, name):
+    nodes = []
+    for pod in items:
+        statuses = pod.get("status", {}).get("containerStatuses", [])
+        ready = (
+            pod.get("status", {}).get("phase") == "Running"
+            and statuses
+            and all(status.get("ready") is True for status in statuses)
+        )
+        if ready and pod.get("spec", {}).get("nodeName"):
+            nodes.append(pod["spec"]["nodeName"])
+    if len(nodes) < 2:
+        fail(f"{name} has {len(nodes)} ready pods; at least 2 are required")
+    if len(set(nodes)) < 2:
+        fail(f"{name} ready pods are not spread across at least 2 nodes")
+    print(f"{name}: {len(nodes)} ready pods on {len(set(nodes))} nodes")
+
+
+def main():
+    try:
+        inventory = json.load(sys.stdin)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        fail(f"cluster inventory is not valid JSON ({error})")
+    for key in ("coredns", "traefik", "cloudflare"):
+        value = inventory.get(key)
+        if not isinstance(value, dict) or not isinstance(value.get("items"), list):
+            fail(f"cluster inventory is missing {key} pod data")
+        ready_pod_nodes(value["items"], key)
+    for key in ("dns_endpoints", "traefik_endpoints"):
+        addresses = inventory.get(key, {}).get("subsets", [])
+        ready = sum(len(subset.get("addresses", [])) for subset in addresses)
+        if ready < 1:
+            fail(f"{key.removesuffix('_endpoints')} Service has no ready backend")
+        print(f"{key.removesuffix('_endpoints')} Service: {ready} ready backends")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_staging_ingress_ha.py
+++ b/tests/test_staging_ingress_ha.py
@@ -1,0 +1,144 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/staging_ingress_ha.sh"
+VERIFY = ROOT / "scripts/staging_ingress_ha_verify.py"
+CONFIG = ROOT / "clusters/staging/ingress-ha"
+
+
+def pod(node, ready=True):
+    return {
+        "spec": {"nodeName": node},
+        "status": {"phase": "Running", "containerStatuses": [{"ready": ready}]},
+    }
+
+
+def inventory(nodes=("sugarkube4", "sugarkube5")):
+    pods = {"items": [pod(node) for node in nodes]}
+    endpoints = {"subsets": [{"addresses": [{"ip": "10.0.0.1"}]}]}
+    return {
+        "coredns": pods,
+        "traefik": pods,
+        "cloudflare": pods,
+        "dns_endpoints": endpoints,
+        "traefik_endpoints": endpoints,
+    }
+
+
+def run_verifier(value):
+    return subprocess.run([str(VERIFY)], input=json.dumps(value), text=True, capture_output=True)
+
+
+def test_canonical_configs_have_two_replicas_and_required_hostname_spread():
+    traefik = (CONFIG / "traefik-helmchartconfig.yaml").read_text()
+    renderer = (ROOT / "scripts/render_coredns_ha.py").read_text()
+    assert "replicas: 2" in traefik
+    assert "requiredDuringSchedulingIgnoredDuringExecution:" in traefik
+    assert "topologyKey: kubernetes.io/hostname" in traefik
+    assert 'spec["replicas"] = 2' in renderer
+    assert '"topologyKey": "kubernetes.io/hostname"' in renderer
+    assert "/var/lib/rancher/k3s/server/manifests" not in traefik + renderer
+
+
+def test_coredns_renderer_preserves_packaged_contract_and_is_idempotent():
+    source = {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+            "name": "coredns",
+            "namespace": "kube-system",
+            "resourceVersion": "9",
+            "labels": {"k8s-app": "kube-dns"},
+        },
+        "spec": {
+            "selector": {"matchLabels": {"k8s-app": "kube-dns"}},
+            "template": {
+                "metadata": {"labels": {"k8s-app": "kube-dns"}},
+                "spec": {
+                    "serviceAccountName": "coredns",
+                    "containers": [
+                        {
+                            "name": "coredns",
+                            "image": "example/coredns:pinned",
+                            "readinessProbe": {"httpGet": {"path": "/ready"}},
+                        }
+                    ],
+                },
+            },
+        },
+    }
+    command = [str(ROOT / "scripts/render_coredns_ha.py")]
+    first = subprocess.run(
+        command, input=json.dumps(source), text=True, capture_output=True, check=True
+    ).stdout
+    rendered = json.loads(first)
+    assert rendered["metadata"]["name"] == "coredns-ha"
+    assert "resourceVersion" not in rendered["metadata"]
+    assert rendered["spec"]["replicas"] == 2
+    assert rendered["spec"]["template"]["spec"]["serviceAccountName"] == "coredns"
+    assert (
+        rendered["spec"]["template"]["spec"]["containers"][0]["image"] == "example/coredns:pinned"
+    )
+    second = subprocess.run(
+        command, input=json.dumps(source), text=True, capture_output=True, check=True
+    ).stdout
+    assert first == second
+
+
+def test_verifier_accepts_healthy_node_spread_inventory():
+    result = run_verifier(inventory())
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("component", ["coredns", "traefik", "cloudflare"])
+def test_verifier_rejects_single_replica(component):
+    value = inventory()
+    value[component] = {"items": [pod("sugarkube4")]}
+    result = run_verifier(value)
+    assert result.returncode != 0
+    assert "at least 2" in result.stderr
+
+
+@pytest.mark.parametrize("component", ["coredns", "traefik", "cloudflare"])
+def test_verifier_rejects_same_node_replicas(component):
+    value = inventory()
+    value[component] = {"items": [pod("sugarkube4"), pod("sugarkube4")]}
+    result = run_verifier(value)
+    assert result.returncode != 0
+    assert "not spread" in result.stderr
+
+
+def test_environment_guard_runs_before_tools_or_cluster_access():
+    result = subprocess.run([str(SCRIPT), "apply", "env=prod"], text=True, capture_output=True)
+    assert result.returncode == 2
+    assert "only supports explicit env=staging" in result.stderr
+
+
+def test_context_guard_fails_closed_without_mutation(tmp_path):
+    kubectl = tmp_path / "kubectl"
+    kubectl.write_text("#!/bin/sh\n[ \"$1 $2\" = 'config current-context' ] && echo production\n")
+    kubectl.chmod(0o755)
+    env = os.environ | {"PATH": f"{tmp_path}:{os.environ['PATH']}"}
+    result = subprocess.run(
+        [str(SCRIPT), "apply", "env=staging"], env=env, text=True, capture_output=True
+    )
+    assert result.returncode == 3
+    assert "refusing cluster access" in result.stderr
+
+
+def test_script_has_bounded_cleanup_discovery_rollback_and_redaction():
+    text = SCRIPT.read_text()
+    assert '--timeout="${TIMEOUT}"' in text
+    assert "trap 'kubectl -n default delete pod" in text
+    assert "app.kubernetes.io/name=cloudflare-tunnel" in text
+    assert "--all-namespaces" in text
+    assert "delete helmchartconfig" in text
+    assert "delete deployment coredns-ha" in text
+    assert "URL redacted" in text
+    assert "get secret" not in text
+    assert "kubectl patch" not in text


### PR DESCRIPTION
### Motivation

- A controlled shutdown of one staging server left etcd/API quorum intact but public ingress failed for ~6 minutes because a singleton CoreDNS pod was evicted by the default 5m node eviction delay, so the staging public path needs an app-agnostic, durable HA baseline. 
- The solution must be durable across K3s restarts, must not edit K3s-generated files under `/var/lib/rancher/k3s/server/manifests`, must preserve existing Service/ServiceLB/TLS behavior, and must provide safe operator commands with explicit staging/context guards. 

### Description

- Add a supplemental, version-controlled CoreDNS renderer that clones the live K3s-packaged `kube-system/coredns` Deployment into a separately owned `coredns-ha` Deployment with `replicas: 2` and required hostname anti-affinity, preserving image, serviceAccount, probes, Corefile mounts, and `kube-dns` identity via `scripts/render_coredns_ha.py` and applying it during `apply` (so we do not edit packaged manifests). 
- Add a durable Traefik customization using a K3s `HelmChartConfig` at `clusters/staging/ingress-ha/traefik-helmchartconfig.yaml` that sets `deployment.replicas: 2` plus required hostname anti-affinity and leaves ServiceLB/ports/ingress classes/TLS and other chart defaults intact. 
- Implement a guarded operator lifecycle in `scripts/staging_ingress_ha.sh` (render/status/apply/verify/rollback) that requires `env=staging` and exact `kubectl` context `sugar-staging`, performs bounded rollout waits, discovers the active Cloudflare tunnel via the stable `app.kubernetes.io/name=cloudflare-tunnel` label, and refuses to overwrite externally owned `HelmChartConfig` resources. 
- Add a small verifier `scripts/staging_ingress_ha_verify.py` and offline regression tests `tests/test_staging_ingress_ha.py` that validate replica counts, node spread, renderer idempotence, guards, cleanup, discovery, rollback semantics, and that no secrets/tunnel credentials are read or emitted. 
- Add documentation `docs/staging-ingress-ha.md` and justfile recipes (`staging-ingress-ha-render/status/apply/verify/rollback`) that describe ownership, the observed 5m eviction failure mode, post-merge operator commands, rollback, and the one-node power-off drill. 

### Testing

- Ran static script check `bash -n scripts/staging_ingress_ha.sh` which succeeded. 
- Ran unit/regression tests with `python3 -m pytest -q tests/test_staging_ingress_ha.py` which passed `12` tests. 
- Linted the new Python files with `flake8` (targeted files) and reformatted with `black`, both passing for the added files. 
- Ran Just formatting check with `just --unstable --fmt --check` (passed for the added recipes). 
- Ran docs link checks with `linkchecker --no-warnings README.md docs/` (205 internal links checked, no errors). 
- Ran the repository secret scan with `git diff --cached | ./scripts/scan-secrets.py` (no secrets in the staged changes). 
- Ran the repository-wide preflight `bash scripts/checks.sh`; this surfaced pre-existing Flake8 failures in unrelated files in the repo (the newly added files were verified separately and are compliant). 
- Attempted `pyspelling -c .spellcheck.yaml` but it failed due to missing system `aspell` in the environment; this is an environment limitation (no secrets or live cluster access were used). 

Residual notes and safety

- No live cluster mutations were performed from the Codex environment; the change implements guarded operator commands that must be run from an operator host with `just kubeconfig-env env=staging` and `kubectl` context `sugar-staging` to mutate the cluster. 
- The implementation does not alter Prometheus/Alertmanager/PagerDuty secrets, does not change application charts or scaling, and does not tune cluster-wide node eviction timing. 
- Files added or modified: `clusters/staging/ingress-ha/*`, `scripts/render_coredns_ha.py`, `scripts/staging_ingress_ha.sh`, `scripts/staging_ingress_ha_verify.py`, `tests/test_staging_ingress_ha.py`, `docs/staging-ingress-ha.md`, and `justfile` updates for the new recipes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6983b3aedc832fab98accafa4c6f99)