### PR TITLE
Add durable staging ingress HA baseline (CoreDNS & Traefik HelmChartConfig overlays)

### DIFF
--- a/clusters/staging/ingress-ha/README.md
+++ b/clusters/staging/ingress-ha/README.md
@@ -1,0 +1,10 @@
+# Staging ingress HA source of truth
+
+These two `HelmChartConfig` resources customize the K3s-packaged `coredns` and
+`traefik` charts. K3s owns their `HelmChart` resources and all generated manifests;
+this directory owns only the supported values overlay. Do not copy these resources
+into the legacy Flux kustomization or edit `/var/lib/rancher/k3s/server/manifests`.
+
+The checked-in rollback values deliberately restore the previous singleton
+configuration. Use only the guarded `just staging-ingress-ha-*` commands described
+in the operations runbook.

--- a/clusters/staging/ingress-ha/coredns-helmchartconfig.yaml
+++ b/clusters/staging/ingress-ha/coredns-helmchartconfig.yaml
@@ -1,0 +1,15 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: coredns
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    replicaCount: 2
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                k8s-app: kube-dns
+            topologyKey: kubernetes.io/hostname

--- a/clusters/staging/ingress-ha/rollback/coredns-helmchartconfig.yaml
+++ b/clusters/staging/ingress-ha/rollback/coredns-helmchartconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: coredns
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    replicaCount: 1
+    affinity: {}

--- a/clusters/staging/ingress-ha/rollback/traefik-helmchartconfig.yaml
+++ b/clusters/staging/ingress-ha/rollback/traefik-helmchartconfig.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    deployment:
+      replicas: 1
+    affinity: {}

--- a/clusters/staging/ingress-ha/traefik-helmchartconfig.yaml
+++ b/clusters/staging/ingress-ha/traefik-helmchartconfig.yaml
@@ -1,0 +1,17 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    deployment:
+      replicas: 2
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: traefik
+                app.kubernetes.io/instance: traefik-kube-system
+            topologyKey: kubernetes.io/hostname

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -401,3 +401,106 @@ observability codification are separate follow-ups. The existing blackbox Networ
 Alerting onboarding — real Alertmanager receivers, external heartbeats, and failure drills — is no
 longer undesigned scope creep; it is planned, designed work tracked in
 [`docs/observability-alerting.md`](observability-alerting.md), just not yet executed.
+
+## Staging public ingress high availability
+
+### Failure mode and ownership audit
+
+During a controlled shutdown of `sugarkube3`, the three-server embedded-etcd
+control plane retained quorum: `sugarkube4` and `sugarkube5` were still a
+majority, so etcd and the API remained available. The public path nevertheless
+failed for about six minutes. Its only CoreDNS pod was on the powered-off node;
+the default `NoExecute` toleration kept that unavailable pod bound for roughly
+five minutes. Only after `TaintManagerEviction` removed it did a replacement
+start on `sugarkube4`, immediately restoring the public service. The application
+itself had remained running on `sugarkube4`. This is a data-plane singleton
+failure, not slow quorum formation, and this baseline intentionally does not
+change cluster-wide node monitoring or eviction timers.
+
+The active ownership model is:
+
+- **CoreDNS and Traefik:** K3s owns the packaged `HelmChart` objects and rewrites
+  their generated server manifests at startup. Sugarkube's durable staging
+  customization is exactly the two `HelmChartConfig` overlays in
+  `clusters/staging/ingress-ha/`, applied with `scripts/staging_ingress_ha.sh`.
+  They request two replicas with required hostname anti-affinity, while leaving
+  the packaged charts to retain the existing Services, cluster IP, Corefile,
+  RBAC, service accounts, probes, ports, ingress classes, TLS, and ServiceLB
+  settings. Never edit `/var/lib/rancher/k3s/server/manifests` or use an
+  unrecorded scale/patch as the source of truth.
+- **Cloudflare tunnel:** the active, token-mode Helm deployment is discovered
+  cluster-wide by its stable `app.kubernetes.io/name` label. Its observed live
+  namespace is `cloudflare`, with two ready replicas already spread across
+  `sugarkube4` and `sugarkube5`; this lifecycle verifies it but does not install,
+  patch, render, log, or read its credentials.
+- **Inactive Flux tree:** `clusters/staging/kustomization.yaml` and
+  `platform/cloudflared/` describe a legacy/future Flux path (including the
+  historical `cloudflared` namespace). They are not in the active staging
+  lifecycle and do not own these HA fields. Do not add the ingress HA overlays
+  to that graph unless staging is deliberately migrated to Flux and the old
+  controller is retired first.
+
+### Post-merge apply, verify, and rollback
+
+Select the exact staging context, inspect without mutation, and then apply. The
+apply is staged: CoreDNS must finish its bounded rollout before Traefik is
+changed, preventing a DNS gap. Reapplication is idempotent.
+
+```bash
+just kubeconfig-env env=staging
+just staging-ingress-ha-render env=staging
+just staging-ingress-ha-plan env=staging
+just staging-ingress-ha-status env=staging
+just staging-ingress-ha-apply env=staging
+just staging-ingress-ha-verify env=staging
+```
+
+`apply`, `verify` (which creates and always removes a temporary DNS pod), and
+`rollback` fail closed unless the current context is exactly `sugar-staging`.
+`render`, `plan`, and `status` are read-only. Verification requires two ready
+CoreDNS pods, two ready Traefik pods, and two ready tunnel pods, with each pair
+on distinct hostnames; ready Service backends; in-cluster DNS; and every
+critical staging public health URL discovered from the active blackbox `Probe`
+resources. Diagnostics never print tunnel data or public target URLs.
+
+To restore the previous singleton packaged-chart settings without disabling
+either packaged component, run:
+
+```bash
+just kubeconfig-env env=staging
+just staging-ingress-ha-rollback env=staging
+just staging-ingress-ha-status env=staging
+```
+
+The checked-in rollback overlays set both components back to one replica and
+remove the added affinity. A subsequent forward apply restores the HA baseline.
+
+### One-node power-off drill
+
+Start continuous external observation in one terminal, then power off exactly
+one server in another. Substitute the selected server only after confirming it
+is currently Ready; the example deliberately uses `sugarkube3`.
+
+```bash
+# Terminal 1: external observation must remain successful throughout.
+while sleep 2; do just staging-ingress-ha-verify env=staging || break; done
+
+# Terminal 2: controlled loss of one server.
+ssh sugarkube3 'sudo systemctl poweroff'
+
+# After powering sugarkube3 back on, do not proceed until both checks pass.
+kubectl wait --for=condition=Ready node/sugarkube3 --timeout=10m
+kubectl get nodes -l node-role.kubernetes.io/etcd -o wide
+just staging-ingress-ha-verify env=staging
+```
+
+Healthchecks.io and PagerDuty should still report the intentionally powered-off
+node: this change does not suppress node-loss monitoring. Public endpoints
+should remain continuously available because DNS, ingress, and the tunnel each
+retain an endpoint on another node. **Do not test another node until the first
+node is Ready and etcd redundancy is restored.** Losing a second server before
+then removes the embedded-etcd majority.
+
+token.place application-level HA remains separate work. Relay registration and
+default rate-limit state are process-local, so this baseline neither scales nor
+changes any application chart.

--- a/justfile
+++ b/justfile
@@ -3267,3 +3267,27 @@ observability-node-heartbeat-verify env='':
 # Disable the heartbeat and destructively remove only its local owned assets.
 observability-node-heartbeat-uninstall env='':
     @scripts/observability_node_heartbeat.sh uninstall '{{ env }}'
+
+# Render the durable K3s packaged-component staging HA overlays (read-only).
+staging-ingress-ha-render env='':
+    @scripts/staging_ingress_ha.sh render '{{ env }}'
+
+# Show the changes the staging HA overlays would make (read-only).
+staging-ingress-ha-plan env='':
+    @scripts/staging_ingress_ha.sh plan '{{ env }}'
+
+# Summarize active packaged components and the discovered tunnel (read-only).
+staging-ingress-ha-status env='':
+    @scripts/staging_ingress_ha.sh status '{{ env }}'
+
+# Apply the staging-only CoreDNS and Traefik HA baseline.
+staging-ingress-ha-apply env='':
+    @scripts/staging_ingress_ha.sh apply '{{ env }}'
+
+# Verify DNS, ingress, tunnel node spread, Services, DNS, and public health.
+staging-ingress-ha-verify env='':
+    @scripts/staging_ingress_ha.sh verify '{{ env }}'
+
+# Restore the prior singleton packaged-component values in staging.
+staging-ingress-ha-rollback env='':
+    @scripts/staging_ingress_ha.sh rollback '{{ env }}'

--- a/scripts/staging_ingress_ha.sh
+++ b/scripts/staging_ingress_ha.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ACTIVE="${ROOT}/clusters/staging/ingress-ha"
+ROLLBACK="${ACTIVE}/rollback"
+TIMEOUT="${SUGARKUBE_INGRESS_HA_TIMEOUT:-180s}"
+DNS_POD="sugarkube-ingress-ha-dns-check"
+
+usage() { echo "Usage: $0 <render|plan|status|apply|verify|rollback> env=staging" >&2; }
+env_name() {
+  local value="${1:-}"; value="${value#env=}"
+  [[ "${value}" == staging ]] || { echo "ERROR: this lifecycle is staging-only; pass env=staging." >&2; exit 2; }
+}
+need() { for tool in "$@"; do command -v "${tool}" >/dev/null || { echo "ERROR: required tool missing: ${tool}" >&2; exit 127; }; done; }
+context() { kubectl config current-context 2>/dev/null || true; }
+guard_mutation() {
+  local current; current="$(context)"
+  [[ "${current}" == sugar-staging ]] || {
+    echo "ERROR: refusing staging mutation: expected context 'sugar-staging', got '${current:-<none>}'." >&2
+    exit 3
+  }
+}
+manifest() { cat "${ACTIVE}/coredns-helmchartconfig.yaml"; printf '\n---\n'; cat "${ACTIVE}/traefik-helmchartconfig.yaml"; }
+rollout() {
+  local expected="${1:-2}"
+  kubectl -n kube-system rollout status deployment/coredns --timeout="${TIMEOUT}" || {
+    echo "ERROR: CoreDNS did not converge within ${TIMEOUT}; inspect deployment events (sensitive values omitted)." >&2; return 10;
+  }
+  kubectl -n kube-system rollout status deployment/traefik --timeout="${TIMEOUT}" || {
+    echo "ERROR: Traefik did not converge within ${TIMEOUT}; inspect deployment events (sensitive values omitted)." >&2; return 10;
+  }
+  for deployment in coredns traefik; do
+    kubectl -n kube-system wait "deployment/${deployment}" \
+      --for="jsonpath={.status.readyReplicas}=${expected}" --timeout="${TIMEOUT}" || {
+      echo "ERROR: ${deployment} did not reach ${expected} ready replica(s) within ${TIMEOUT}." >&2
+      return 10
+    }
+  done
+}
+check_workload() {
+  local description="$1" selector="$2"
+  kubectl get pods -A -l "${selector}" -o json | DESCRIPTION="${description}" python3 -c '
+import json, os, sys
+d=json.load(sys.stdin); ready=[]
+for p in d.get("items", []):
+  statuses=p.get("status", {}).get("containerStatuses") or []
+  if p.get("status", {}).get("phase") == "Running" and statuses and all(c.get("ready") for c in statuses):
+    ready.append(p)
+nodes={p.get("spec", {}).get("nodeName") for p in ready if p.get("spec", {}).get("nodeName")}
+if len(ready) < 2 or len(nodes) < 2:
+  print(f"ERROR: {os.environ[\"DESCRIPTION\"]} requires >=2 ready pods on distinct nodes; found {len(ready)} ready on {len(nodes)} node(s).", file=sys.stderr)
+  raise SystemExit(11)
+print(f"OK: {os.environ[\"DESCRIPTION\"]}: {len(ready)} ready pods across {len(nodes)} nodes.")'
+}
+check_service() {
+  local service="$1"
+  kubectl -n kube-system get endpointslice -l "kubernetes.io/service-name=${service}" -o json | SERVICE="${service}" python3 -c '
+import json, os, sys
+d=json.load(sys.stdin); ready=sum(1 for s in d.get("items",[]) for e in s.get("endpoints",[]) if e.get("conditions",{}).get("ready") is not False)
+if ready < 1:
+  print(f"ERROR: Service {os.environ[\"SERVICE\"]} has no ready backends.", file=sys.stderr); raise SystemExit(12)
+print(f"OK: Service {os.environ[\"SERVICE\"]} has {ready} ready backend(s).")'
+}
+verify() {
+  need kubectl python3 curl
+  check_workload CoreDNS 'k8s-app=kube-dns'
+  check_workload Traefik 'app.kubernetes.io/name=traefik'
+  # Discover the live Helm deployment by stable application labels, across namespaces.
+  check_workload 'Cloudflare tunnel' 'app.kubernetes.io/name in (cloudflare-tunnel,cloudflared)'
+  check_service kube-dns
+  check_service traefik
+  kubectl delete pod "${DNS_POD}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  trap 'kubectl delete pod "${DNS_POD}" --ignore-not-found --wait=false >/dev/null 2>&1 || true' EXIT
+  kubectl run "${DNS_POD}" --image=busybox:1.36.1 --restart=Never --command -- nslookup kubernetes.default.svc.cluster.local >/dev/null
+  if ! kubectl wait --for=jsonpath='{.status.phase}'=Succeeded "pod/${DNS_POD}" --timeout="${TIMEOUT}" >/dev/null; then
+    echo "ERROR: bounded in-cluster DNS check failed; temporary pod output is intentionally not printed." >&2; return 13
+  fi
+  local urls
+  urls="$(kubectl get probes.monitoring.coreos.com -A -l environment=staging,criticality=critical -o json | python3 -c '
+import json,sys
+for p in json.load(sys.stdin).get("items",[]):
+  for u in p.get("spec",{}).get("targets",{}).get("staticConfig",{}).get("static",[]):
+    if isinstance(u,str) and u.startswith("https://"): print(u)' | sort -u)"
+  [[ -n "${urls}" ]] || { echo "ERROR: no critical public staging Probe targets were discovered." >&2; return 14; }
+  while IFS= read -r url; do
+    curl --fail --silent --show-error --location --max-time 15 --output /dev/null "${url}" || {
+      echo "ERROR: a public staging health target was unreachable (target redacted)." >&2; return 15;
+    }
+  done <<<"${urls}"
+  echo "OK: all discovered critical public staging health targets are reachable."
+}
+
+[[ $# -eq 2 ]] || { usage; exit 2; }
+action="$1"; env_name "$2"
+case "${action}" in
+  render) manifest ;;
+  plan) need kubectl; manifest | kubectl diff -f - || [[ $? -eq 1 ]] ;;
+  status)
+    need kubectl
+    kubectl -n kube-system get helmchart,helmchartconfig coredns traefik
+    kubectl get pods -A -l 'k8s-app=kube-dns' -o wide
+    kubectl get pods -A -l 'app.kubernetes.io/name=traefik' -o wide
+    kubectl get pods -A -l 'app.kubernetes.io/name in (cloudflare-tunnel,cloudflared)' -o wide
+    ;;
+  apply)
+    need kubectl; guard_mutation
+    kubectl apply -f "${ACTIVE}/coredns-helmchartconfig.yaml"
+    kubectl -n kube-system wait deployment/coredns --for=jsonpath='{.status.readyReplicas}'=2 --timeout="${TIMEOUT}" || {
+      echo "ERROR: CoreDNS HA did not converge within ${TIMEOUT}; Traefik was not changed." >&2; exit 10;
+    }
+    kubectl apply -f "${ACTIVE}/traefik-helmchartconfig.yaml"
+    rollout 2
+    ;;
+  verify) guard_mutation; verify ;;
+  rollback) need kubectl; guard_mutation; kubectl apply -f "${ROLLBACK}"; rollout 1 ;;
+  *) usage; exit 2 ;;
+esac

--- a/tests/test_staging_ingress_ha.py
+++ b/tests/test_staging_ingress_ha.py
@@ -1,0 +1,131 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/staging_ingress_ha.sh"
+ACTIVE = ROOT / "clusters/staging/ingress-ha"
+JUSTFILE = ROOT / "justfile"
+
+
+def load_yaml(path):
+    result = subprocess.run(
+        [
+            "ruby",
+            "-ryaml",
+            "-rjson",
+            "-e",
+            "puts JSON.generate(YAML.safe_load_file(ARGV[0]))",
+            path,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+@pytest.mark.parametrize("component", ["coredns", "traefik"])
+def test_active_config_has_two_replicas_and_required_hostname_anti_affinity(component):
+    document = load_yaml(ACTIVE / f"{component}-helmchartconfig.yaml")
+    values = document["spec"]["valuesContent"]
+    parsed = subprocess.run(
+        ["ruby", "-ryaml", "-rjson", "-e", "puts JSON.generate(YAML.safe_load(STDIN.read))"],
+        input=values,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    values = json.loads(parsed.stdout)
+    replicas = (
+        values["replicaCount"] if component == "coredns" else values["deployment"]["replicas"]
+    )
+    assert replicas == 2
+    terms = values["affinity"]["podAntiAffinity"]["requiredDuringSchedulingIgnoredDuringExecution"]
+    assert terms and all(term["topologyKey"] == "kubernetes.io/hostname" for term in terms)
+    assert document["kind"] == "HelmChartConfig"
+    assert document["metadata"] == {"name": component, "namespace": "kube-system"}
+
+
+@pytest.mark.parametrize("component", ["coredns", "traefik"])
+def test_rollback_explicitly_restores_singleton_without_anti_affinity(component):
+    document = load_yaml(ACTIVE / "rollback" / f"{component}-helmchartconfig.yaml")
+    values = subprocess.run(
+        ["ruby", "-ryaml", "-rjson", "-e", "puts JSON.generate(YAML.safe_load(STDIN.read))"],
+        input=document["spec"]["valuesContent"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    values = json.loads(values.stdout)
+    replicas = (
+        values["replicaCount"] if component == "coredns" else values["deployment"]["replicas"]
+    )
+    assert replicas == 1
+    assert values["affinity"] == {}
+
+
+def run(action, env="env=staging", *, path=None):
+    environment = os.environ.copy()
+    if path:
+        environment["PATH"] = f"{path}:{environment['PATH']}"
+    return subprocess.run(
+        [SCRIPT, action, env], capture_output=True, text=True, check=False, env=environment
+    )
+
+
+def fake_kubectl(tmp_path, context="wrong-context"):
+    executable = tmp_path / "kubectl"
+    executable.write_text(
+        f'#!/bin/sh\nif [ "$1 $2" = "config current-context" ]; then echo {context}; exit 0; fi\nexit 0\n',
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    return tmp_path
+
+
+@pytest.mark.parametrize("action", ["apply", "verify", "rollback"])
+def test_mutations_fail_closed_on_wrong_context(tmp_path, action):
+    result = run(action, path=fake_kubectl(tmp_path))
+    assert result.returncode == 3
+    assert "expected context 'sugar-staging'" in result.stderr
+
+
+@pytest.mark.parametrize("action", ["render", "plan", "status", "apply", "verify", "rollback"])
+def test_all_actions_reject_non_staging_environment(action):
+    result = run(action, "env=prod")
+    assert result.returncode == 2
+    assert "staging-only" in result.stderr
+
+
+def test_render_is_idempotent_and_contains_only_two_configs():
+    first = run("render")
+    second = run("render")
+    assert first.returncode == second.returncode == 0
+    assert first.stdout == second.stdout
+    assert first.stdout.count("kind: HelmChartConfig") == 2
+    assert "Secret" not in first.stdout
+
+
+def test_verify_logic_rejects_singleton_and_same_node_and_redacts_targets():
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "len(ready) < 2 or len(nodes) < 2" in text
+    assert "app.kubernetes.io/name in (cloudflare-tunnel,cloudflared)" in text
+    assert "target redacted" in text
+    assert "credentials" not in text.lower()
+    assert '--timeout="${TIMEOUT}"' in text
+    assert "trap 'kubectl delete pod" in text
+
+
+def test_justfile_exposes_complete_small_lifecycle():
+    text = JUSTFILE.read_text(encoding="utf-8")
+    for action in ("render", "plan", "status", "apply", "verify", "rollback"):
+        assert f"staging-ingress-ha-{action}" in text
+
+
+def test_flux_staging_path_does_not_own_active_ha_configs():
+    flux = (ROOT / "clusters/staging/kustomization.yaml").read_text(encoding="utf-8")
+    assert "ingress-ha" not in flux


### PR DESCRIPTION
### Motivation

- A controlled shutdown of one staging control-plane node left etcd/API quorum intact but removed the only CoreDNS pod and caused ~6 minutes of public ingress outage while Kubernetes evicted the pod; the goal is to ensure public ingress tolerates the loss of any one server without relying on transient `kubectl scale`/patch or editing k3s-generated manifests.
- Provide a minimal, durable, K3s-supported, app-agnostic HA baseline for CoreDNS and Traefik that survives k3s restarts, preserves packaged chart behavior, and verifies (but does not replace or duplicate) the live Cloudflare tunnel deployment.

### Description

- Add durable K3s `HelmChartConfig` overlays for staging that request two replicas and require hostname anti-affinity: `clusters/staging/ingress-ha/coredns-helmchartconfig.yaml` and `clusters/staging/ingress-ha/traefik-helmchartconfig.yaml` to ensure at-least-two ready endpoints on distinct `kubernetes.io/hostname` values while preserving the packaged charts' Services, Corefile, RBAC, probes, ports, ingress classes, TLS, and ServiceLB behavior.
- Add explicit rollback overlays that restore the prior singleton configuration (one replica, affinity cleared) at `clusters/staging/ingress-ha/rollback/*` so operators have a clear, reversible path.
- Implement a guarded staging operator lifecycle script `scripts/staging_ingress_ha.sh` exposing `render|plan|status|apply|verify|rollback` with the following safety/behavior rules: mutation-only when current Kubernetes context equals `sugar-staging`; staged apply assuring CoreDNS converges before changing Traefik; bounded rollout/wait timeouts; discovery-based Cloudflare tunnel verification (label-driven); in-cluster DNS probe via a temporary pod with guaranteed cleanup; Service backend checks; and redaction of credentials and public target details.
- Expose operator commands via `just` recipes (`staging-ingress-ha-{render,plan,status,apply,verify,rollback}`) and record the ownership, failure mode, staged apply/verify/rollback commands and a one-node power-off drill in `docs/observability-operations.md` and `clusters/staging/ingress-ha/README.md`.
- Add offline regression/unit tests `tests/test_staging_ingress_ha.py` to validate rendered values, replica counts, required hostname anti-affinity, rollback behavior, context guards, idempotent render, discovery selection for Cloudflare tunnel, bounded-timeout waits, cleanup behavior for the temporary DNS pod, and secret/credential redaction.

Files changed or added (key):
- `clusters/staging/ingress-ha/coredns-helmchartconfig.yaml`
- `clusters/staging/ingress-ha/traefik-helmchartconfig.yaml`
- `clusters/staging/ingress-ha/rollback/coredns-helmchartconfig.yaml`
- `clusters/staging/ingress-ha/rollback/traefik-helmchartconfig.yaml`
- `clusters/staging/ingress-ha/README.md`
- `scripts/staging_ingress_ha.sh`
- `tests/test_staging_ingress_ha.py`
- `justfile` (added `staging-ingress-ha-*` recipes)
- `docs/observability-operations.md` (documented failure, ownership, commands, drill)

Design notes / constraints preserved:
- Does not edit k3s-generated files under `/var/lib/rancher/k3s/server/manifests` or rely on transient `kubectl scale`/patch as source-of-truth.
- Does not install or duplicate Cloudflare tunnel credentials or create a second tunnel deployment; it discovers and verifies the existing deployment by stable labels.
- Preserves application charts, ServiceLB behavior, observability, and unrelated flows; does not change eviction or node-monitoring timers.

### Testing

- Static/script checks: ran `bash -n scripts/staging_ingress_ha.sh` which passed (syntax OK).
- Focused tests: ran `pytest -q tests/test_staging_ingress_ha.py tests/test_justfile_formatting.py tests/test_docs_guardrails.py` and received `21 passed` for the targeted test set.
- Formatting: ran `python -m black tests/test_staging_ingress_ha.py` to autoformat the new test file (reformatted then ran tests).
- Secrets and pre-checks: ran `git diff --cached | ./scripts/scan-secrets.py` and `git diff --cached --check` as part of pre-merge validation (no new secrets found, no diff-check issues reported).
- Wider CI-equivalent run: ran `pytest -q` across the repository; the run reached `1,156 passed, 5 skipped` before an unrelated test (`tests/test_monitoring_blackbox.py::test_lifecycle_network_policy_is_exact_and_chart_render_backed`) failed because `helm` is not available in this execution environment (FileNotFoundError for `helm`), so the full suite could not be completed here.

Commands executed (representative):
- `bash -n scripts/staging_ingress_ha.sh`
- `pytest -q tests/test_staging_ingress_ha.py tests/test_justfile_formatting.py tests/test_docs_guardrails.py`
- `python -m black tests/test_staging_ingress_ha.py`
- `git diff --cached | ./scripts/scan-secrets.py`
- `git diff --cached --check`
- `pytest -q` (full run reached 1,156 passed and 5 skipped before failing due to missing `helm` binary)

Environment notes and residual risks:
- `helm`, `pre-commit`, `pyspelling`, and `linkchecker` were not available in this execution environment so a small set of repository scripts and checks could not be executed here; CI will run those checks where available.
- The staged apply enforces CoreDNS convergence before Traefik changes to avoid creating a DNS gap; operators must run the provided `just staging-ingress-ha-*` recipes from the `sugar-staging` context to mutate staging.
- This change does not attempt application-level HA for `token.place` (that remains separate work).

If you want, I can open the PR with the branch and the message prepared, or split follow-ups (e.g., add CI/helm smoke-test job notes) into a focused follow-up PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6983b5fef0832fba3832d95e08b777)