### PR TITLE
Enforce DSPACE source-integrity and chat promotion gates

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -379,3 +379,19 @@ Current values chains:
 | token.place | `docs/examples/tokenplace.values.dev.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml` | `/,/livez,/healthz,/relay/diagnostics` |
 | danielsmith.io | `docs/examples/danielsmith.values.dev.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml` | `/,/livez,/healthz` |
 | jobbot3000 | `docs/examples/jobbot3000.values.dev.yaml` | `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml` | `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.prod.yaml` | `/,/healthz,/livez` |
+# DSPACE production verification
+
+Standard DSPACE deploy, redeploy, promotion, and compatibility recipes share a fail-closed
+guard. Production requires a finalized staging evidence record whose version, source SHA,
+immutable image and chart coordinates, semantic tag, and default provider match the production
+candidate. Live staging verification precedes production render, evidence reservation, and Helm
+mutation. After rollout, fresh OCI, Helm, replica, public/direct frontend identity, and isolated
+`/chat` proof precede evidence finalization. Historical finalized evidence without the newer
+bounded runtime checks remains valid for rollback; newly finalized records include the complete
+runtime check set. Candidate approvals are never rewritten.
+
+Use `just dspace-release-verify env=<staging|prod> manifest=<record.json>
+smoke_runner=<executable>` for a standalone read-only check. Verification uses Kubernetes API
+pod proxies and does not modify Services, Ingresses, Deployments, or pods. Failure diagnostics
+identify the failed stage without response bodies, headers, browser storage, credentials, or
+child-process output.

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -477,3 +477,39 @@ just helm-oci-install release=dspace namespace=dspace chart=oci://ghcr.io/democr
 ```bash
 just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.staging.version tag="$APP_TAG" env=staging
 ```
+# Release source-integrity gate
+
+DSPACE staging and production releases require the upstream, non-destructive remote chat
+runner. In a DSPACE checkout run `pnpm install` and `pnpm exec playwright install chromium`,
+then provide the executable itself (never a shell command):
+
+```bash
+DSPACE_SMOKE_RUNNER="$HOME/dspace/scripts/run-remote-chat-smoke.mjs"
+
+just dspace-release-verify \
+  env=staging \
+  manifest=deployment-evidence/dspace/staging/<finalized-record>.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER"
+```
+
+A staging deployment uses an approved staging candidate and creates finalized evidence under
+`deployment-evidence/dspace/staging/` only after public identity, every direct replica, and the
+isolated `/chat` journey pass. Production additionally requires that exact finalized staging
+artifact:
+
+```bash
+just app-promote-prod \
+  app=dspace \
+  tag=main-REPLACE_SHORTSHA \
+  manifest=deployment-candidates/dspace/prod.json \
+  staging_evidence=deployment-evidence/dspace/staging/<finalized-record>.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER"
+```
+
+The gate rechecks the recorded staging Helm revision before any production reservation or
+mutation, then verifies production before finalizing its record under
+`deployment-evidence/dspace/prod/`. A post-mutation failure leaves the reservation for explicit
+reconciliation and never triggers an automatic rollback. Token.place-default releases derive
+the expected origin and model from the ordered environment values; OpenAI-default releases omit
+those arguments. The runner mocks provider transport: real provider credentials are neither
+required nor accepted, and child output is never stored in evidence.

--- a/docs/examples/apps/dspace.env
+++ b/docs/examples/apps/dspace.env
@@ -2,6 +2,8 @@
 # Copy to apps/dspace.env or set SUGARKUBE_APP_CONFIG_DIR to a directory
 # containing dspace.env.
 # This is an example fallback for generic recipes; local app configs take precedence.
+# Pass the executable DSPACE remote chat harness as smoke_runner=... at invocation time;
+# never put provider credentials or a configurable command fragment in this file.
 
 SUGARKUBE_APP=dspace
 SUGARKUBE_RELEASE=dspace

--- a/justfile
+++ b/justfile
@@ -1670,7 +1670,7 @@ app-config app env='staging' config='':
       --config {{ quote(config) }}
 
 # DSPACE-only fail-closed recovery from previously finalized immutable evidence.
-dspace-manifest-rollback env manifest evidence verifier confirm='' config='' kubeconfig='':
+dspace-manifest-rollback env manifest evidence smoke_runner verifier='{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py' confirm='' config='' kubeconfig='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
     kubeconfig_path={{ quote(kubeconfig) }}
@@ -1682,12 +1682,24 @@ dspace-manifest-rollback env manifest evidence verifier confirm='' config='' kub
       --manifest {{ quote(manifest) }} \
       --evidence {{ quote(evidence) }} \
       --verifier {{ quote(verifier) }} \
+      --smoke-runner {{ quote(smoke_runner) }} \
       --confirm {{ quote(confirm) }} \
       --config {{ quote(config) }} \
       --kubeconfig "${kubeconfig_path}"
 
+# Read-only DSPACE runtime, replica, frontend, and isolated /chat proof.
+dspace-release-verify env manifest smoke_runner config='' kubeconfig='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    kubeconfig_path={{ quote(kubeconfig) }}
+    if [ -z "${kubeconfig_path}" ]; then kubeconfig_path="${KUBECONFIG:-${HOME}/.kube/config}"; fi
+    python3 "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" verify \
+      --environment {{ quote(env) }} --release dspace --namespace dspace \
+      --manifest {{ quote(manifest) }} --smoke-runner {{ quote(smoke_runner) }} \
+      --config {{ quote(config) }} --kubeconfig "${kubeconfig_path}"
+
 # Generic immutable-tag app deploy backed by docs/examples/apps/*.env or local app configs.
-app-deploy app env='staging' tag='' config='' manifest='' evidence='':
+app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1707,6 +1719,15 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
       if [ -z "${release_manifest}" ]; then
         echo "ERROR: manifest=<approved-candidate.json> is required for DSPACE ${SUGARKUBE_ENV}." >&2
         exit 2
+      fi
+      if [ -z {{ quote(smoke_runner) }} ]; then echo "ERROR: smoke_runner=<executable> is required for DSPACE verification." >&2; exit 2; fi
+      if [ "${SUGARKUBE_ENV}" = prod ]; then
+        if [ -z {{ quote(staging_evidence) }} ]; then echo "ERROR: staging_evidence=<finalized-staging.json> is required for DSPACE production." >&2; exit 2; fi
+        export KUBECONFIG="${HOME}/.kube/config"
+        just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env staging
+        python3 "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" staging-gate \
+          --manifest "${release_manifest}" --staging-evidence {{ quote(staging_evidence) }} \
+          --smoke-runner {{ quote(smoke_runner) }} --staging-config "${SUGARKUBE_CONFIG_PATH}" --kubeconfig "${KUBECONFIG}" >/dev/null
       fi
       chart_version="${SUGARKUBE_VERSION:-}"
       if [ -z "${chart_version}" ]; then
@@ -1757,16 +1778,26 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
     fi
     [ -z "${mutation_marker:-}" ] || rm -f "${mutation_marker}"
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
+      runtime_proof="$(mktemp)"
+      if ! python3 "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" verify \
+        --environment "${SUGARKUBE_ENV}" --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
+        --manifest "${release_manifest}" --smoke-runner {{ quote(smoke_runner) }} \
+        --config "${SUGARKUBE_CONFIG_PATH}" --kubeconfig "${KUBECONFIG}" >"${runtime_proof}"; then
+        rm -f "${runtime_proof}"
+        exit 1
+      fi
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize \
         --manifest "${release_manifest}" --output "${evidence_output}" \
         --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" \
         --chart-version "${chart_version}" --kubeconfig "${KUBECONFIG}" \
         --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
-        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}"
+        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}" \
+        --runtime-verification "${runtime_proof}"
+      rm -f "${runtime_proof}"
     fi
 
 # Generic upgrade-only app redeploy backed by app config files.
-app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
+app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1784,6 +1815,15 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
     while [ "${evidence_output#evidence=}" != "${evidence_output}" ]; do evidence_output="${evidence_output#evidence=}"; done
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
       if [ -z "${release_manifest}" ]; then echo "ERROR: manifest=<approved-candidate.json> is required for DSPACE ${SUGARKUBE_ENV}." >&2; exit 2; fi
+      if [ -z {{ quote(smoke_runner) }} ]; then echo "ERROR: smoke_runner=<executable> is required for DSPACE verification." >&2; exit 2; fi
+      if [ "${SUGARKUBE_ENV}" = prod ]; then
+        if [ -z {{ quote(staging_evidence) }} ]; then echo "ERROR: staging_evidence=<finalized-staging.json> is required for DSPACE production." >&2; exit 2; fi
+        export KUBECONFIG="${HOME}/.kube/config"
+        just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env staging
+        python3 "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" staging-gate \
+          --manifest "${release_manifest}" --staging-evidence {{ quote(staging_evidence) }} \
+          --smoke-runner {{ quote(smoke_runner) }} --staging-config "${SUGARKUBE_CONFIG_PATH}" --kubeconfig "${KUBECONFIG}" >/dev/null
+      fi
       chart_version="${SUGARKUBE_VERSION:-}"
       if [ -z "${chart_version}" ]; then chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -n1)"; fi
       chart_coordinate="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" preflight --manifest "${release_manifest}" --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" \
@@ -1827,14 +1867,23 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
     fi
     [ -z "${mutation_marker:-}" ] || rm -f "${mutation_marker}"
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
+      runtime_proof="$(mktemp)"
+      if ! python3 "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" verify \
+        --environment "${SUGARKUBE_ENV}" --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
+        --manifest "${release_manifest}" --smoke-runner {{ quote(smoke_runner) }} \
+        --config "${SUGARKUBE_CONFIG_PATH}" --kubeconfig "${KUBECONFIG}" >"${runtime_proof}"; then
+        rm -f "${runtime_proof}"
+        exit 1
+      fi
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize --manifest "${release_manifest}" --output "${evidence_output}" \
         --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" --kubeconfig "${KUBECONFIG}" \
         --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
-        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}"
+        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}" --runtime-verification "${runtime_proof}"
+      rm -f "${runtime_proof}"
     fi
 
 # Promote an app to prod with an explicit immutable tag, or the configured prod tag file.
-app-promote-prod app tag='' config='' manifest='' evidence='':
+app-promote-prod app tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1850,6 +1899,8 @@ app-promote-prod app tag='' config='' manifest='' evidence='':
       app="${SUGARKUBE_APP}" env=prod tag="${SUGARKUBE_TAG}" config="${SUGARKUBE_CONFIG_PATH}")
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Show the pinned chart version and whether a newer semver chart appears published.
@@ -1975,17 +2026,19 @@ app-cors-verify app env='staging' config='' origin='https://cors-smoke.invalid' 
 #
 
 # Use this for steady-state release validation flows where explicit image pinning matters.
-dspace-oci-deploy env='staging' tag='' manifest='' evidence='':
+dspace-oci-deploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
     delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-deploy app=dspace env={{ quote(env) }} tag={{ quote(tag) }})
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Use this for optional canary/smoke testing before or alongside apex promotion workflows.
-dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='':
+dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1993,12 +2046,14 @@ dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='':
       "{{ justfile_directory() }}/docs/examples/apps/dspace-prod-subdomain.env")
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Promote dspace to production apex (democratized.space) using immutable tags.
 
 # If tag is omitted, this reads the pinned value from docs/apps/dspace.prod.tag.
-dspace-oci-promote-prod tag='' manifest='' evidence='':
+dspace-oci-promote-prod tag='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -2012,16 +2067,20 @@ dspace-oci-promote-prod tag='' manifest='' evidence='':
     delegate=(just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy env=prod tag="${SUGARKUBE_TAG}")
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Fast redeploy of dspace from GHCR (emergency mutable-tag refresh).
-dspace-oci-redeploy env='staging' tag='' manifest='' evidence='':
+dspace-oci-redeploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
     delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-redeploy app=dspace env={{ quote(env) }} tag={{ quote(tag) }})
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Dump dspace and Traefik logs for debugging HTTP 500s.

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -739,6 +739,14 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             target["sourceRevision"],
             "--provider",
             target["expectedDefaultChatProvider"],
+            "--manifest",
+            str(args.manifest),
+            "--smoke-runner",
+            str(getattr(args, "smoke_runner", args.verifier)),
+            "--config",
+            args.config,
+            "--kubeconfig",
+            args.kubeconfig,
         ]
         failed_stage = "runtime-verification"
         verifier = validate_verifier_result(
@@ -790,8 +798,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "status": observed_info.get("status"),
                 "chartName": observed_chart.get("name"),
                 "chartVersion": chart_version(observed_helm),
-                "invocationDescriptionMatches": observed_info.get("description")
-                == description,
+                "invocationDescriptionMatches": observed_info.get("description") == description,
             }
         except Exception:
             diagnostics["helm"] = "unavailable"
@@ -822,13 +829,20 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--environment", choices=("staging", "prod"), required=True)
     parser.add_argument("--manifest", type=Path, required=True)
     parser.add_argument("--evidence", type=Path, required=True)
-    parser.add_argument("--verifier", type=Path, required=True)
+    parser.add_argument(
+        "--verifier", type=Path, default=Path(__file__).with_name("dspace_runtime_verifier.py")
+    )
+    parser.add_argument("--smoke-runner", type=Path)
     parser.add_argument("--confirm", default="")
     parser.add_argument("--config", default="")
     parser.add_argument("--kubeconfig", default=str(Path.home() / ".kube" / "config-sugarkube"))
     parser.add_argument("--oras", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
     parser.add_argument("--timeout", default="10m")
     args = parser.parse_args(argv)
+    if args.smoke_runner is None:
+        # Backward-compatible programmatic callers supplied one executable under
+        # the legacy verifier option. Public recipes always pass the smoke runner.
+        args.smoke_runner = args.verifier
     try:
         rollback(args)
     except (RollbackError, app_config.AppConfigError) as exc:

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -69,6 +69,15 @@ FINAL_FIXED_CHECKS = {
     "podImageCoordinates",
     "podImageDigests",
 }
+FINAL_RUNTIME_CHECKS = {
+    "runtimeIdentity",
+    "frontendIdentity",
+    "replicaAgreement",
+    "publicDirectAgreement",
+    "defaultProvider",
+    "remoteChatSmoke",
+    "publicJourneys",
+}
 PLATFORM_CHECK_RE = re.compile(r"^imagePlatformSourceRevision\[(0|[1-9][0-9]*)\]$")
 POD_SETTLE_TIMEOUT_SECONDS = 60.0
 POD_SETTLE_INTERVAL_SECONDS = 2.0
@@ -206,17 +215,18 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
             platform_match = PLATFORM_CHECK_RE.fullmatch(check)
             if platform_match:
                 platform_indices.append(int(platform_match.group(1)))
-            elif check not in FINAL_FIXED_CHECKS:
+            elif check not in FINAL_FIXED_CHECKS | FINAL_RUNTIME_CHECKS:
                 raise ManifestError(f"unknown verification result: {check}")
         missing = sorted(FINAL_FIXED_CHECKS - checks)
         if missing:
             raise ManifestError("missing verification results: " + ", ".join(missing))
         if sorted(platform_indices) != list(range(len(platform_indices))):
-            raise ManifestError(
-                "image platform verification indices must be contiguous from zero"
-            )
+            raise ManifestError("image platform verification indices must be contiguous from zero")
         if not platform_indices:
             raise ManifestError("at least one image platform verification result is required")
+        runtime_checks = checks & FINAL_RUNTIME_CHECKS
+        if runtime_checks and runtime_checks != FINAL_RUNTIME_CHECKS:
+            raise ManifestError("runtime verification results must be complete when present")
     return value
 
 
@@ -235,9 +245,7 @@ def _write_new(path: Path, value: dict[str, Any]) -> None:
         try:
             os.link(temporary, path)
         except FileExistsError as exc:
-            raise ManifestError(
-                f"refusing to overwrite existing record: {path}"
-            ) from exc
+            raise ManifestError(f"refusing to overwrite existing record: {path}") from exc
         _sync_directory(path.parent)
     finally:
         Path(temporary).unlink(missing_ok=True)
@@ -290,9 +298,7 @@ def reserve(
     try:
         fd = os.open(sidecar, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     except FileExistsError as exc:
-        raise ManifestError(
-            f"evidence destination is already reserved: {sidecar}"
-        ) from exc
+        raise ManifestError(f"evidence destination is already reserved: {sidecar}") from exc
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as stream:
             stream.write(_canonical(metadata))
@@ -328,9 +334,7 @@ def verify_reservation(
     if not secrets.compare_digest(
         json.dumps(metadata, sort_keys=True), json.dumps(expected, sort_keys=True)
     ):
-        raise ManifestError(
-            "reservation ownership or deployment coordinates do not match"
-        )
+        raise ManifestError("reservation ownership or deployment coordinates do not match")
     if normalized.exists():
         raise ManifestError(f"refusing to overwrite existing record: {normalized}")
     return sidecar
@@ -548,6 +552,7 @@ def finalize(
     cluster_environment: str,
     invocation_description: str,
     expected_image_coordinate: str | None = None,
+    runtime_verification: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     validate(value, False)
     selected = {
@@ -668,7 +673,10 @@ def finalize(
         {
             "check": "selectedCoordinates",
             "passed": True,
-            "details": f"environment={environment}; imageTag={image_tag}; chartVersion={chart_version}",
+            "details": (
+                f"environment={environment}; imageTag={image_tag}; "
+                f"chartVersion={chart_version}"
+            ),
         },
         {
             "check": "clusterEnvironment",
@@ -689,8 +697,7 @@ def finalize(
             # Helm metadata proves name/version, not immutable OCI content. The
             # guarded mutation therefore installs this approved digest directly.
             "details": (
-                f"chart=dspace; version={chart_version}; "
-                f"coordinate={chart_coordinate(value)}"
+                f"chart=dspace; version={chart_version}; " f"coordinate={chart_coordinate(value)}"
             ),
         },
         {
@@ -709,6 +716,40 @@ def finalize(
             "details": "every running pod imageID matched approved image digest",
         },
     ]
+    if runtime_verification is not None:
+        expected_runtime = {
+            "schemaVersion": 1,
+            "environment": environment,
+            "release": release,
+            "namespace": namespace,
+            "applicationVersion": value["applicationVersion"],
+            "runtimeSourceRevision": value["sourceRevision"],
+            "frontendSourceRevision": value["sourceRevision"],
+            "defaultProvider": value["expectedDefaultChatProvider"],
+        }
+        for field, expected in expected_runtime.items():
+            if runtime_verification.get(field) != expected:
+                raise ManifestError(f"runtime verification {field} mismatch")
+        journeys = runtime_verification.get("journeys")
+        if (
+            not isinstance(journeys, list)
+            or not all(isinstance(item, dict) and item.get("passed") is True for item in journeys)
+            or "/chat" not in {item.get("name") for item in journeys}
+        ):
+            raise ManifestError("runtime verification lacks successful public journeys")
+        bounded = {
+            "runtimeIdentity": f"version={value['applicationVersion']}; revision matched approval",
+            "frontendIdentity": "public and replica frontend revisions matched approval",
+            "replicaAgreement": f"all {len(pods)} serving replica(s) agreed",
+            "publicDirectAgreement": "public and direct-origin identity agreed",
+            "defaultProvider": f"approved default={value['expectedDefaultChatProvider']}",
+            "remoteChatSmoke": "isolated remote /chat smoke passed",
+            "publicJourneys": "successful journeys=/,/chat",
+        }
+        results.extend(
+            {"check": check, "passed": True, "details": details}
+            for check, details in bounded.items()
+        )
     result = dict(value)
     result.update(
         recordType="final",
@@ -755,9 +796,8 @@ def main(argv: list[str] | None = None) -> int:
     finish.add_argument("--image-ref", default=IMAGE_REF)
     finish.add_argument("--chart-ref", default=CHART_REF)
     finish.add_argument("--reservation", required=True)
-    finish.add_argument(
-        "--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras")
-    )
+    finish.add_argument("--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
+    finish.add_argument("--runtime-verification", type=Path)
     available = sub.add_parser("check-output")
     available.add_argument("--output", type=Path, required=True)
     destination = sub.add_parser("evidence-path")
@@ -885,6 +925,9 @@ def main(argv: list[str] | None = None) -> int:
                 namespace=args.namespace,
                 cluster_environment=cluster_environment,
                 invocation_description=invocation_description,
+                runtime_verification=(
+                    _object(args.runtime_verification) if args.runtime_verification else None
+                ),
             )
             sidecar = verify_reservation(
                 args.output,
@@ -909,19 +952,16 @@ def main(argv: list[str] | None = None) -> int:
                     metadata.get("version"),
                 )
 
-            if (
-                binding_fields(settled_helm) != binding_fields(helm)
-                or binding_fields(stable_helm) != binding_fields(helm)
-            ):
+            if binding_fields(settled_helm) != binding_fields(helm) or binding_fields(
+                stable_helm
+            ) != binding_fields(helm):
                 raise ManifestError("Helm release changed during evidence collection")
             _write_new(args.output, result)
             sidecar.unlink()
             _sync_directory(args.output.expanduser().resolve(strict=False).parent)
         elif args.command == "check-output":
             if args.output.exists():
-                raise ManifestError(
-                    f"refusing to overwrite existing record: {args.output}"
-                )
+                raise ManifestError(f"refusing to overwrite existing record: {args.output}")
         elif args.command == "reserve":
             sys.stdout.write(
                 reserve(

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Prove the identity and safe public chat journey of a DSPACE release."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import app_chart, app_config  # noqa: E402
+from scripts import dspace_release_manifest as release_manifest  # noqa: E402
+
+CAPABILITIES = [
+    "applicationVersion",
+    "runtimeSourceRevision",
+    "frontendSourceRevision",
+    "defaultProvider",
+    "publicJourneys",
+]
+META_RE = re.compile(
+    r'<meta\s+[^>]*name=["\']dspace-build-revision["\'][^>]*content=["\']([^"\']+)',
+    re.I,
+)
+SAFE_ENV_NAMES = {"DSPACE_TOKEN_PLACE_URL", "DSPACE_TOKEN_PLACE_CHAT_MODEL"}
+IMMUTABLE_FIELDS = (
+    "applicationVersion",
+    "sourceRevision",
+    "imageTag",
+    "imageDigest",
+    "chartVersion",
+    "chartDigest",
+    "semanticTag",
+    "expectedDefaultChatProvider",
+)
+
+
+class VerificationError(ValueError):
+    """A bounded, non-secret verification failure."""
+
+
+Runner = Callable[[list[str]], str]
+
+
+def run(command: list[str]) -> str:
+    completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    if completed.returncode:
+        raise VerificationError(f"provider/chat smoke: command failed ({command[0]})")
+    return completed.stdout
+
+
+def json_run(runner: Runner, command: list[str], label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(runner(command))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise VerificationError(f"{label}: command did not return valid JSON") from exc
+    if not isinstance(value, dict):
+        raise VerificationError(f"{label}: expected a JSON object")
+    return value
+
+
+class SameOriginRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        if urllib.parse.urlsplit(newurl)[:2] != urllib.parse.urlsplit(req.full_url)[:2]:
+            raise VerificationError("public identity: redirect changed origin")
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def fetch(url: str) -> str:
+    try:
+        with urllib.request.build_opener(SameOriginRedirect()).open(url, timeout=15) as response:
+            return response.read(1024 * 1024).decode("utf-8")
+    except VerificationError:
+        raise
+    except (OSError, UnicodeError, urllib.error.HTTPError) as exc:
+        raise VerificationError("public identity: endpoint unavailable") from exc
+
+
+def identity(build: str, html: str, expected: dict[str, str], label: str) -> None:
+    try:
+        info = json.loads(build)
+    except json.JSONDecodeError as exc:
+        raise VerificationError(f"{label}: invalid build identity") from exc
+    if not isinstance(info, dict):
+        raise VerificationError(f"{label}: invalid build identity")
+    if info.get("version") != expected["version"]:
+        raise VerificationError(f"{label}: application version mismatch")
+    if info.get("revision") != expected["revision"]:
+        raise VerificationError(f"{label}: source revision mismatch")
+    if info.get("shortRevision") != expected["revision"][:7]:
+        raise VerificationError(f"{label}: short revision mismatch")
+    image = info.get("image") or info.get("imageTag")
+    if image is not None and expected["tag"] not in str(image):
+        raise VerificationError(f"{label}: runtime image coordinate mismatch")
+    marker = META_RE.search(html)
+    if marker is None or marker.group(1) != expected["revision"]:
+        raise VerificationError(f"{label}: frontend revision marker mismatch")
+
+
+def values_expectations(paths: str) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for raw in paths.split(","):
+        path = Path(raw.strip())
+        path = path if path.is_absolute() else REPO_ROOT / path
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            raise VerificationError("manifest/evidence mismatch: values chain unavailable") from exc
+        for index, line in enumerate(lines):
+            match = re.match(r"^\s*-\s*name:\s*([^#\s]+)\s*$", line)
+            if not match or match.group(1) not in SAFE_ENV_NAMES:
+                continue
+            for following in lines[index + 1 :]:
+                if re.match(r"^\s*-\s*name:", following):
+                    break
+                value = re.match(r"^\s*value:\s*([^#]+?)\s*$", following)
+                if value:
+                    result[match.group(1)] = value.group(1).strip(" \"'")
+                    break
+    return result
+
+
+def deployment_env(deployment: dict[str, Any]) -> dict[str, str]:
+    containers = (
+        deployment.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+    )
+    dspace = [item for item in containers if item.get("name") == "dspace"]
+    if len(dspace) != 1:
+        raise VerificationError("cluster identity: Deployment lacks one dspace container")
+    return {
+        item.get("name"): item.get("value")
+        for item in dspace[0].get("env", [])
+        if item.get("name") in SAFE_ENV_NAMES and isinstance(item.get("value"), str)
+    }
+
+
+def verify(
+    args: argparse.Namespace, runner: Runner = run, http_fetch: Callable[[str], str] = fetch
+) -> dict[str, Any]:
+    if not args.smoke_runner.is_file() or not os.access(args.smoke_runner, os.X_OK):
+        raise VerificationError(
+            "provider/chat smoke: smoke runner must be an existing executable file"
+        )
+    manifest = release_manifest._object(args.manifest)
+    release_manifest.validate(manifest, manifest.get("recordType") == "final")
+    if manifest["environment"] != args.environment:
+        raise VerificationError("manifest/evidence mismatch: environment mismatch")
+    config = app_config.load_config("dspace", args.environment, args.config or None)
+    paths = tuple(item.strip() for item in config["SUGARKUBE_VALUES"].split(",") if item.strip())
+    host = app_chart.expected_ingress_host(paths, "")
+    base_url = f"https://{host}"
+    expected = {
+        "version": manifest["applicationVersion"],
+        "revision": manifest["sourceRevision"],
+        "tag": manifest["imageTag"],
+    }
+    identity(
+        http_fetch(f"{base_url}/build-info.json"),
+        http_fetch(base_url + "/"),
+        expected,
+        "public identity",
+    )
+
+    command = ["kubectl", "--kubeconfig", args.kubeconfig, "-n", args.namespace]
+    deployment = json_run(
+        runner, [*command, "get", f"deployment/{args.release}", "-o", "json"], "cluster identity"
+    )
+    configured = values_expectations(config["SUGARKUBE_VALUES"])
+    live_env = deployment_env(deployment)
+    provider = manifest["expectedDefaultChatProvider"]
+    if provider == "token-place":
+        if any(not configured.get(name) for name in SAFE_ENV_NAMES) or live_env != configured:
+            raise VerificationError(
+                "cluster identity: token.place rendered/live expectations differ"
+            )
+
+    pod_data = json_run(
+        runner,
+        [
+            *command,
+            "get",
+            "pods",
+            "-l",
+            f"app.kubernetes.io/name=dspace,app.kubernetes.io/instance={args.release}",
+            "-o",
+            "json",
+        ],
+        "pod/replica identity",
+    )
+    pods = pod_data.get("items")
+    if not isinstance(pods, list) or not pods:
+        raise VerificationError("pod/replica identity: no serving replicas")
+    names: list[str] = []
+    for pod in pods:
+        metadata, status = pod.get("metadata", {}), pod.get("status", {})
+        if (
+            metadata.get("deletionTimestamp")
+            or status.get("phase") != "Running"
+            or not any(
+                c.get("type") == "Ready" and c.get("status") == "True"
+                for c in status.get("conditions", [])
+            )
+        ):
+            raise VerificationError("pod/replica identity: stale, terminating, or unready replica")
+        containers = [
+            c for c in pod.get("spec", {}).get("containers", []) if c.get("name") == "dspace"
+        ]
+        statuses = [c for c in status.get("containerStatuses", []) if c.get("name") == "dspace"]
+        coordinate = f"{release_manifest.IMAGE_REF}:{manifest['imageTag']}"
+        if len(containers) != 1 or containers[0].get("image", "").split("@")[0] != coordinate:
+            raise VerificationError("pod/replica identity: image coordinate mismatch")
+        try:
+            digest = release_manifest._image_id_digest(statuses[0].get("imageID", ""))
+        except (IndexError, release_manifest.ManifestError) as exc:
+            raise VerificationError("pod/replica identity: image digest unavailable") from exc
+        if digest != manifest["imageDigest"]:
+            raise VerificationError("pod/replica identity: image digest mismatch")
+        name = metadata.get("name")
+        if not isinstance(name, str) or not name:
+            raise VerificationError("pod/replica identity: unnamed replica")
+        names.append(name)
+        proxy = f"/api/v1/namespaces/{args.namespace}/pods/{name}:3000/proxy"
+        try:
+            direct_build = runner(
+                [
+                    "kubectl",
+                    "--kubeconfig",
+                    args.kubeconfig,
+                    "get",
+                    "--raw",
+                    proxy + "/build-info.json",
+                ]
+            )
+            direct_html = runner(
+                ["kubectl", "--kubeconfig", args.kubeconfig, "get", "--raw", proxy + "/"]
+            )
+        except Exception as exc:
+            raise VerificationError("direct identity: replica endpoint unavailable") from exc
+        identity(direct_build, direct_html, expected, "direct identity")
+
+    smoke = [
+        str(args.smoke_runner),
+        "--base-url",
+        base_url,
+        "--expected-version",
+        expected["version"],
+        "--expected-revision",
+        expected["revision"],
+        "--expected-provider",
+        provider,
+    ]
+    if provider == "token-place":
+        smoke.extend(
+            [
+                "--expected-token-place-origin",
+                configured["DSPACE_TOKEN_PLACE_URL"],
+                "--expected-token-place-model",
+                configured["DSPACE_TOKEN_PLACE_CHAT_MODEL"],
+            ]
+        )
+    runner(smoke)
+    return {
+        "schemaVersion": 1,
+        "environment": args.environment,
+        "release": args.release,
+        "namespace": args.namespace,
+        "applicationVersion": expected["version"],
+        "runtimeSourceRevision": expected["revision"],
+        "frontendSourceRevision": expected["revision"],
+        "defaultProvider": provider,
+        "journeys": [{"name": "/", "passed": True}, {"name": "/chat", "passed": True}],
+    }
+
+
+def staging_gate(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
+    """Validate finalized staging proof, its artifact binding, and current live revision."""
+    candidate = release_manifest._object(args.manifest)
+    evidence = release_manifest._object(args.staging_evidence)
+    release_manifest.validate(candidate, False)
+    release_manifest.validate(evidence, True)
+    if candidate["environment"] != "prod" or evidence["environment"] != "staging":
+        raise VerificationError(
+            "manifest/evidence mismatch: prod candidate and staging final required"
+        )
+    mismatches = [field for field in IMMUTABLE_FIELDS if candidate[field] != evidence[field]]
+    if mismatches:
+        raise VerificationError("manifest/evidence mismatch: immutable release coordinates differ")
+    helm = json_run(
+        runner,
+        [
+            "helm",
+            "--kubeconfig",
+            args.kubeconfig,
+            "status",
+            "dspace",
+            "--namespace",
+            "dspace",
+            "-o",
+            "json",
+        ],
+        "staging drift",
+    )
+    if helm.get("version") != evidence["helmRevision"]:
+        raise VerificationError("staging drift: Helm revision differs from finalized evidence")
+    metadata = helm.get("chart", {}).get("metadata", {})
+    if (
+        helm.get("info", {}).get("status") != "deployed"
+        or metadata.get("name") != "dspace"
+        or metadata.get("version") != evidence["chartVersion"]
+    ):
+        raise VerificationError("staging drift: live Helm release/chart identity differs")
+    approved = {field: evidence[field] for field in release_manifest.CANDIDATE_FIELDS}
+    approved["recordType"] = "candidate"
+    try:
+        release_manifest.preflight(
+            approved,
+            release_manifest.IMAGE_REF,
+            release_manifest.CHART_REF,
+            args.oras,
+            environment="staging",
+            image_tag=evidence["imageTag"],
+            chart_version=evidence["chartVersion"],
+            runner=runner,
+        )
+    except release_manifest.ManifestError as exc:
+        raise VerificationError("OCI coordinate: staging artifact provenance differs") from exc
+    verify_args = argparse.Namespace(
+        environment="staging",
+        release="dspace",
+        namespace="dspace",
+        manifest=args.staging_evidence,
+        smoke_runner=args.smoke_runner,
+        config=args.staging_config,
+        kubeconfig=args.kubeconfig,
+    )
+    proof = verify(verify_args, runner)
+    return {
+        "schemaVersion": 1,
+        "stagingEvidence": "finalized",
+        "helmRevision": evidence["helmRevision"],
+        "verification": proof,
+    }
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    sub = result.add_subparsers(dest="command", required=True)
+    for name in ("capabilities", "verify"):
+        command = sub.add_parser(name)
+        command.add_argument("--environment", choices=("staging", "prod"), required=True)
+        command.add_argument("--release", default="dspace")
+        command.add_argument("--namespace", default="dspace")
+        if name == "verify":
+            command.add_argument("--manifest", type=Path, required=True)
+            command.add_argument("--smoke-runner", type=Path, required=True)
+            command.add_argument("--config", default="")
+            command.add_argument("--kubeconfig", required=True)
+            command.add_argument("--application-version")
+            command.add_argument("--source-revision")
+            command.add_argument("--provider")
+    gate = sub.add_parser("staging-gate")
+    gate.add_argument("--manifest", type=Path, required=True)
+    gate.add_argument("--staging-evidence", type=Path, required=True)
+    gate.add_argument("--smoke-runner", type=Path, required=True)
+    gate.add_argument("--staging-config", default="")
+    gate.add_argument("--kubeconfig", required=True)
+    gate.add_argument("--oras", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        if args.command == "capabilities":
+            value = {
+                "schemaVersion": 1,
+                "environment": args.environment,
+                "release": args.release,
+                "namespace": args.namespace,
+                "capabilities": CAPABILITIES,
+            }
+        elif args.command == "verify":
+            value = verify(args)
+        else:
+            value = staging_gate(args)
+        print(json.dumps(value, separators=(",", ":")))
+    except (VerificationError, release_manifest.ManifestError, app_config.AppConfigError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -1,0 +1,93 @@
+"""Hermetic contract tests for the DSPACE runtime verifier."""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from scripts import dspace_runtime_verifier as verifier
+
+
+def test_capabilities_are_ordered_and_exact(capsys: pytest.CaptureFixture[str]) -> None:
+    assert (
+        verifier.main(
+            [
+                "capabilities",
+                "--environment",
+                "staging",
+                "--release",
+                "dspace",
+                "--namespace",
+                "dspace",
+            ]
+        )
+        == 0
+    )
+    assert json.loads(capsys.readouterr().out) == {
+        "schemaVersion": 1,
+        "environment": "staging",
+        "release": "dspace",
+        "namespace": "dspace",
+        "capabilities": [
+            "applicationVersion",
+            "runtimeSourceRevision",
+            "frontendSourceRevision",
+            "defaultProvider",
+            "publicJourneys",
+        ],
+    }
+
+
+def test_values_expectations_follow_ordered_overlay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base = tmp_path / "base.yaml"
+    overlay = tmp_path / "overlay.yaml"
+    base.write_text(
+        "env:\n  - name: DSPACE_TOKEN_PLACE_URL\n    value: https://old.invalid\n",
+        encoding="utf-8",
+    )
+    overlay.write_text(
+        "env:\n"
+        "  - name: DSPACE_TOKEN_PLACE_URL\n    value: https://expected.invalid\n"
+        "  - name: DSPACE_TOKEN_PLACE_CHAT_MODEL\n    value: expected-model\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(verifier, "REPO_ROOT", tmp_path)
+    assert verifier.values_expectations(f"{base},{overlay}") == {
+        "DSPACE_TOKEN_PLACE_URL": "https://expected.invalid",
+        "DSPACE_TOKEN_PLACE_CHAT_MODEL": "expected-model",
+    }
+
+
+@pytest.mark.parametrize("mode", ("missing", "not-executable"))
+def test_smoke_runner_must_be_executable(tmp_path: Path, mode: str) -> None:
+    runner = tmp_path / "runner"
+    if mode == "not-executable":
+        runner.write_text("#!/bin/sh\n", encoding="utf-8")
+    args = Namespace(smoke_runner=runner)
+    with pytest.raises(verifier.VerificationError, match="existing executable"):
+        verifier.verify(args)
+
+
+def test_identity_rejects_version_revision_and_frontend_mismatch() -> None:
+    expected = {"version": "3.2.0", "revision": "a" * 40, "tag": "main-aaaaaaa"}
+    good = json.dumps({"version": "3.2.0", "revision": "a" * 40, "shortRevision": "aaaaaaa"})
+    html = f'<meta name="dspace-build-revision" content="{"a" * 40}">'
+    verifier.identity(good, html, expected, "public identity")
+    with pytest.raises(verifier.VerificationError, match="application version"):
+        verifier.identity(good.replace("3.2.0", "3.1.0"), html, expected, "public identity")
+    with pytest.raises(verifier.VerificationError, match="frontend revision"):
+        verifier.identity(good, html.replace("a" * 40, "b" * 40), expected, "public identity")
+
+
+def test_cross_origin_redirect_is_rejected() -> None:
+    handler = verifier.SameOriginRedirect()
+    request = type("Request", (), {"full_url": "https://expected.invalid/build-info.json"})()
+    with pytest.raises(verifier.VerificationError, match="changed origin"):
+        handler.redirect_request(
+            request, None, 302, "Found", {}, "https://attacker.invalid/build-info.json"
+        )


### PR DESCRIPTION
### Motivation

- Prevent DSPACE production version drift by making runtime/source identity and the `/chat` journey mandatory before and after production promotion. 
- Require verified, finalized staging evidence that is coordinate-matched and live before any production mutation. 
- Centralize a fail-closed guard so all DSPACE deploy/redeploy/promote flows cannot bypass runtime verification. 

### Description

- Add a new argv-only DSPACE runtime verifier `scripts/dspace_runtime_verifier.py` implementing the established capability/result contract and performing public/direct identity, per-replica image/digest checks, values-derived provider expectations, and isolated `/chat` smoke invocation executed as argv.  
- Wire the verifier into promotion and rollback paths by: recording/consuming a `--runtime-verification` artifact in `scripts/dspace_release_manifest.py`, invoking the verifier from `just` recipes before finalize, and replacing the previous rollback stub with the real verifier in `scripts/dspace_manifest_rollback.py` while preserving backward-compatible CLI defaults.  
- Add a focused public recipe `just dspace-release-verify env=... manifest=... smoke_runner=...` and extend `just` deploy/promote/redeploy recipes to require `smoke_runner=` and (for prod) a finalized `staging_evidence=` record; ensure the smoke runner is executed directly as argv and not via a shell fragment. 
- Add hermetic contract tests `tests/test_dspace_runtime_verifier.py`, update manifest finalization schema handling to accept a bounded runtime check set, and update docs with checkout/prerequisites, standalone verification examples, and the staging→prod flow.  

Closes #2328

### Testing

- Ran the narrow pytest suite used by the task: `python3 -m pytest -q tests/test_dspace_runtime_verifier.py tests/test_release_manifest.py tests/test_manifest_rollback.py tests/test_generic_app_just_recipes.py tests/test_up_recipe_calls.py`, and the tests covering the verifier and manifest/rollback passed (focused suite succeeded). 
- Ran focused linters and formatting: `python3 -m flake8 scripts/dspace_runtime_verifier.py scripts/dspace_release_manifest.py scripts/dspace_manifest_rollback.py tests/test_dspace_runtime_verifier.py` passed for the changed files, and `python3 -m black` reformatted the new/modified files as expected; `just --unstable --fmt --check` passed for the updated `justfile`. 
- Exercised repository checks: `bash scripts/test-helm-oci-install.sh`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` completed successfully in this environment after installing required local spell dependencies. 
- Notes and residuals: `pre-commit run --all-files` initially applied unrelated trailing-whitespace/EOL fixes and exposed pre-existing YAML/multi-document issues in unrelated files (these are pre-existing baseline failures and were not weakened), and a broad flake8 run across the entire test corpus surfaced unrelated long-line/style problems in existing tests; only the focused linters for changed files were required to pass for this PR.

Changed files (key): `scripts/dspace_runtime_verifier.py`, `scripts/dspace_release_manifest.py`, `scripts/dspace_manifest_rollback.py`, `justfile`, `tests/test_dspace_runtime_verifier.py`, `docs/apps/dspace.md`, `docs/app_deployment_contract.md`, `docs/examples/apps/dspace.env`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69b1eae808832f9b83dcbd95d02ec4)