### PR TITLE
Gate DSPACE promotions on live runtime integrity

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -318,15 +318,22 @@ validates a public OCI chart and edits the repository pin.
 ```bash
 # Deploy or install a specific immutable candidate into an environment.
 just app-deploy app=dspace env=staging tag=main-REPLACE_SHORTSHA \
-  manifest=deployment-candidates/dspace/staging.json
+  manifest=deployment-candidates/dspace/staging.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER"
 
 # Redeploy an existing release with a specific immutable tag.
 just app-redeploy app=dspace env=staging tag=main-REPLACE_SHORTSHA \
-  manifest=deployment-candidates/dspace/staging.json evidence=deployment-evidence/dspace/staging/redeploy.json
+  manifest=deployment-candidates/dspace/staging.json \
+  evidence=deployment-evidence/dspace/staging/redeploy.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER"
 
 # Promote an approved immutable tag to production.
 just app-promote-prod app=dspace tag=main-REPLACE_SHORTSHA \
-  manifest=deployment-candidates/dspace/prod.json
+  manifest=deployment-candidates/dspace/prod.json \
+  staging_evidence=deployment-evidence/dspace/staging/REPLACE_FINALIZED.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER" \
+  staging_config=/etc/sugarkube/apps/dspace-staging.env \
+  staging_kubeconfig="$HOME/.kube/config-dspace-staging"
 
 # Inspect and intentionally bump the chart pin.
 just app-chart-status app=dspace

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -379,3 +379,20 @@ Current values chains:
 | token.place | `docs/examples/tokenplace.values.dev.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml` | `/,/livez,/healthz,/relay/diagnostics` |
 | danielsmith.io | `docs/examples/danielsmith.values.dev.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml` | `/,/livez,/healthz` |
 | jobbot3000 | `docs/examples/jobbot3000.values.dev.yaml` | `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml` | `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.prod.yaml` | `/,/healthz,/livez` |
+
+### DSPACE source-integrity gate
+
+DSPACE staging and production mutations require an approved manifest and an
+executable DSPACE remote-chat smoke runner. Verification uses argv execution and
+captures, but never records or prints, child output. It records only bounded
+identity, replica-agreement, provider, and public-journey success facts.
+Historical schema-version 1 finalized evidence remains valid: the added runtime
+gate does not rewrite candidate approvals or require historical records to gain
+new fields.
+
+A production DSPACE promotion additionally requires finalized staging evidence
+for the identical application version, full source revision, image tag/digest,
+chart version/digest, semantic tag, and expected default provider. The staging
+evidence and its live Helm revision are validated, and staging is reverified,
+before production preflight, evidence reservation, or mutation. Generic recipes
+for other applications retain their existing behavior.

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -477,3 +477,59 @@ just helm-oci-install release=dspace namespace=dspace chart=oci://ghcr.io/democr
 ```bash
 just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.staging.version tag="$APP_TAG" env=staging
 ```
+
+## Mandatory release identity and `/chat` gate
+
+A DSPACE checkout supplies the non-destructive browser harness. In that checkout,
+run `pnpm install` and `pnpm exec playwright install chromium`, then provide the
+executable itself—not a shell command or fragment:
+
+```bash
+DSPACE_SMOKE_RUNNER="$HOME/dspace/scripts/run-remote-chat-smoke.mjs"
+
+just dspace-release-verify \
+  env=staging \
+  manifest=deployment-evidence/dspace/staging/<finalized-record>.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER"
+```
+
+The verifier checks the public build identity and frontend marker, then checks
+all ready, release-owned replicas directly through the read-only Kubernetes API
+pod proxy. It proves the approved image digest, full source revision, replica
+agreement, public/direct agreement, and the isolated `/chat` journey. The
+harness mocks provider transport; real token.place or OpenAI credentials are
+neither required nor accepted. For a token.place-default manifest the origin and
+model come from the selected, ordered values chain. For an OpenAI-default
+manifest those token.place arguments are omitted, while OpenAI discoverability
+and missing-key gating remain part of the harness proof.
+
+Create staging evidence by deploying the approved staging candidate with the
+same executable:
+
+```bash
+just app-deploy app=dspace env=staging tag=main-REPLACE_SHORTSHA \
+  manifest=deployment-candidates/dspace/staging.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER"
+```
+
+Only after the post-rollout verifier succeeds is the non-overwriting finalized
+record written under `deployment-evidence/dspace/staging/`. Production requires
+that record as an additional gate:
+
+```bash
+just app-promote-prod \
+  app=dspace \
+  tag=main-REPLACE_SHORTSHA \
+  manifest=deployment-candidates/dspace/prod.json \
+  staging_evidence=deployment-evidence/dspace/staging/<finalized-record>.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER"
+```
+
+Before production rendering, reservation, or mutation, the command validates
+that staging evidence is finalized, compares all immutable release coordinates,
+rechecks the recorded live Helm revision, and reruns the full verifier against
+staging. It runs the same verifier after production rollout and before the final
+production evidence is written. A post-mutation failure leaves the reservation
+for the existing reconciliation procedure; it never writes successful evidence,
+retries, downgrades, or automatically rolls back. Use the reservation recovery
+instructions above after investigating the bounded failure category.

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -134,13 +134,31 @@ oras manifest fetch ghcr.io/democratizedspace/charts/dspace@"$CHART_DIGEST"
 # Fetch the chart config blob by digest and inspect its revision annotation.
 ```
 
-Pass the candidate to staging and preserve the generated final record:
+Prepare the upstream smoke runner once before any guarded deployment or
+verification. The upstream file is checked in with mode `100644`, so make it
+executable after installing its dependencies:
+
+```bash
+cd "$HOME/dspace"
+pnpm install
+pnpm exec playwright install chromium
+chmod +x "$HOME/dspace/scripts/run-remote-chat-smoke.mjs"
+export DSPACE_SMOKE_RUNNER="$HOME/dspace/scripts/run-remote-chat-smoke.mjs"
+```
+
+The smoke harness mocks provider transport. Real token.place or OpenAI
+credentials are neither required nor accepted.
+
+Pass the candidate and executable runner to staging, then preserve the generated
+final record:
 
 ```bash
 just app-deploy app=dspace env=staging tag="$APP_TAG" \
-  manifest=deployment-candidates/dspace/staging.json
+  manifest=deployment-candidates/dspace/staging.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER"
 EVIDENCE=$(python3 scripts/dspace_release_manifest.py evidence-path \
   --manifest deployment-candidates/dspace/staging.json)
+STAGING_EVIDENCE="$EVIDENCE"
 git add "$EVIDENCE"
 # Commit it after review, or attach that exact file to the external promotion record.
 ```
@@ -171,7 +189,11 @@ python3 scripts/dspace_release_manifest.py candidate \
   --environment prod --provider token-place \
   --approved-at 2026-07-26T13:00:00Z --approved-by '<operator-or-review-record>'
 just app-promote-prod app=dspace tag="$APP_TAG" \
-  manifest=deployment-candidates/dspace/prod.json
+  manifest=deployment-candidates/dspace/prod.json \
+  staging_evidence="$STAGING_EVIDENCE" \
+  smoke_runner="$DSPACE_SMOKE_RUNNER" \
+  staging_config=/etc/sugarkube/apps/dspace-staging.env \
+  staging_kubeconfig="$HOME/.kube/config-dspace-staging"
 EVIDENCE=$(python3 scripts/dspace_release_manifest.py evidence-path \
   --manifest deployment-candidates/dspace/prod.json)
 git add "$EVIDENCE"
@@ -180,16 +202,17 @@ git add "$EVIDENCE"
 The finalized JSON is sufficient to reconstruct the release using the recorded
 branch-SHA image tag and digest plus chart version and the exact digest-qualified
 chart deployment coordinate, without resolving
-`latest`, a branch, an environment tag, or the semantic tag. Until DSPACE #4732
-adds direct runtime identity, `runtimeSourceRevisionMethod` is strictly
-`podImageID+ociRevisionAnnotation`: every pod image ID must equal the approved
-digest and that exact OCI artifact's revision annotation must equal the full
-approved SHA. Finalization also reasserts the connected cluster environment,
-requires Helm to report the selected release and namespace as deployed with the
-exact approved DSPACE chart version, and accepts only Running, Ready pods owned
-through the selected Helm release's Deployment and ReplicaSet. Each DSPACE
-container must use the approved repository and immutable image tag before its
-resolved image ID is accepted. No HTTP build-identity check is claimed.
+`latest`, a branch, an environment tag, or the semantic tag. The runtime contract
+delivered by DSPACE [PR #4759](https://github.com/democratizedspace/dspace/pull/4759)
+and the remote smoke harness delivered by
+[PR #4763](https://github.com/democratizedspace/dspace/pull/4763) let Sugarkube
+verify the public build identity, frontend source marker, and isolated `/chat`
+journey. Verification also reasserts the connected cluster environment; the
+exact deployed Helm release, namespace, chart, and stable revision; complete
+rollout counts; and every Running, Ready replica linked by controller UIDs. Each
+DSPACE container must use the approved repository, immutable image tag, and
+resolved digest, and every direct pod response must agree with the bounded public
+identity response.
 
 Immediately before Helm changes the release, the guarded recipe atomically creates
 `<evidence-path>.reservation`. This sidecar binds the normalized destination,
@@ -211,13 +234,17 @@ This repository change only persists the staging configuration; it does not depl
 Preferred generic command:
 
 ```bash
-just app-deploy app=dspace env=staging tag="$APP_TAG" manifest=deployment-candidates/dspace/staging.json
+just app-deploy app=dspace env=staging tag="$APP_TAG" \
+  manifest=deployment-candidates/dspace/staging.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER"
 ```
 
 Compatibility shim while migration is in progress:
 
 ```bash
-just dspace-oci-deploy env=staging tag="$APP_TAG" manifest=deployment-candidates/dspace/staging.json
+just dspace-oci-deploy env=staging tag="$APP_TAG" \
+  manifest=deployment-candidates/dspace/staging.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER"
 ```
 
 ## Verify staging
@@ -283,13 +310,23 @@ For staging, the browser smoke must show DSPACE calling `https://staging.token.p
 This configuration change does not promote or mutate production. Promote only after staging sign-off. Prefer the generic command; it uses the prod values chain, resolves chart `3.0.1` from `docs/apps/dspace.prod.version`, and can read `docs/apps/dspace.prod.tag` (`main-1a31a56`) when `tag=` is omitted.
 
 ```bash
-just app-promote-prod app=dspace tag="$APP_TAG" manifest=deployment-candidates/dspace/prod.json
+just app-promote-prod app=dspace tag="$APP_TAG" \
+  manifest=deployment-candidates/dspace/prod.json \
+  staging_evidence="$STAGING_EVIDENCE" \
+  smoke_runner="$DSPACE_SMOKE_RUNNER" \
+  staging_config=/etc/sugarkube/apps/dspace-staging.env \
+  staging_kubeconfig="$HOME/.kube/config-dspace-staging"
 ```
 
 Compatibility shim:
 
 ```bash
-just dspace-oci-promote-prod tag="$APP_TAG" manifest=deployment-candidates/dspace/prod.json
+just dspace-oci-promote-prod tag="$APP_TAG" \
+  manifest=deployment-candidates/dspace/prod.json \
+  staging_evidence="$STAGING_EVIDENCE" \
+  smoke_runner="$DSPACE_SMOKE_RUNNER" \
+  staging_config=/etc/sugarkube/apps/dspace-staging.env \
+  staging_kubeconfig="$HOME/.kube/config-dspace-staging"
 ```
 
 ## Verify production
@@ -339,8 +376,7 @@ just dspace-manifest-rollback \
   env=staging \
   manifest=deployment-evidence/dspace/staging/previous-finalized-release.json \
   evidence=deployment-evidence/dspace/staging/rollback-20260727T120000Z.json \
-  smoke_runner="$DSPACE_SMOKE_RUNNER" \
-  verifier=/opt/dspace/bin/sugarkube-runtime-verifier
+  smoke_runner="$DSPACE_SMOKE_RUNNER"
 ```
 
 Production additionally requires a non-interactive confirmation bound to
@@ -354,7 +390,6 @@ just dspace-manifest-rollback \
   manifest=deployment-evidence/dspace/prod/previous-finalized-release.json \
   evidence=deployment-evidence/dspace/prod/rollback-20260727T120000Z.json \
   smoke_runner="$DSPACE_SMOKE_RUNNER" \
-  verifier=/opt/dspace/bin/sugarkube-runtime-verifier \
   confirm="dspace:prod:${TARGET_SHA}"
 ```
 
@@ -399,7 +434,11 @@ and the strict runtime/frontend/provider/public-journey result (including
 `/chat`). The successful non-overwritable record contains those proofs and
 values-file hashes; it does not alter the target release record.
 
-The verifier is an executable, not a shell fragment. It must support
+The standard operator path always uses the checked-in
+`scripts/dspace_runtime_verifier.py`; do not substitute an availability-only
+check. The separate rollback `verifier=` option exists only for exceptional
+compatibility with a legacy executable implementing the older verifier contract.
+Such a verifier is an executable, not a shell fragment, and must support
 `capabilities` and echo the selected environment, release, and namespace with
 schema version 1 and the exact ordered capabilities
 `applicationVersion`, `runtimeSourceRevision`, `frontendSourceRevision`,
@@ -409,11 +448,12 @@ those target coordinates and identity strings plus a non-empty list of
 including a passing `/chat`. Verifier output and response bodies are not echoed.
 Do not infer frontend identity from the semantic application version.
 
-Real production rollback remains unavailable until DSPACE
-[#4732](https://github.com/democratizedspace/dspace/issues/4732) supplies runtime
-and frontend identity and [#4733](https://github.com/democratizedspace/dspace/issues/4733)
-supplies the remote public-journey verifier contract. Tests use a stub; operators
-must not substitute an availability-only check.
+The checked-in verifier uses the runtime/frontend identity from DSPACE
+[PR #4759](https://github.com/democratizedspace/dspace/pull/4759) and the remote
+public-journey harness from
+[PR #4763](https://github.com/democratizedspace/dspace/pull/4763), so staging and
+production rollback use the same runtime, replica, provider, and `/chat` proof as
+normal deployment finalization.
 
 If anything fails after reservation, the command exits nonzero, leaves a
 redacted failed evidence record, and warns that cluster state may have changed.
@@ -482,17 +522,31 @@ just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democr
 
 ## Mandatory release identity and `/chat` gate
 
-A DSPACE checkout supplies the non-destructive browser harness. In that checkout,
-run `pnpm install` and `pnpm exec playwright install chromium`, then provide the
+A DSPACE checkout supplies the non-destructive browser harness. If the setup in
+the deployment section has not already been completed, install its dependencies
+and make the upstream mode-`100644` script executable. Always provide the
 executable itself—not a shell command or fragment:
 
 ```bash
-DSPACE_SMOKE_RUNNER="$HOME/dspace/scripts/run-remote-chat-smoke.mjs"
+cd "$HOME/dspace"
+pnpm install
+pnpm exec playwright install chromium
+chmod +x "$HOME/dspace/scripts/run-remote-chat-smoke.mjs"
+export DSPACE_SMOKE_RUNNER="$HOME/dspace/scripts/run-remote-chat-smoke.mjs"
 
 just dspace-release-verify \
   env=staging \
   manifest=deployment-evidence/dspace/staging/<finalized-record>.json \
-  smoke_runner="$DSPACE_SMOKE_RUNNER"
+  smoke_runner="$DSPACE_SMOKE_RUNNER" \
+  config=/etc/sugarkube/apps/dspace-staging.env \
+  kubeconfig="$HOME/.kube/config-dspace-staging"
+
+just dspace-release-verify \
+  env=prod \
+  manifest=deployment-evidence/dspace/prod/<finalized-record>.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER" \
+  config=/etc/sugarkube/apps/dspace-prod.env \
+  kubeconfig="$HOME/.kube/config-dspace-prod"
 ```
 
 The verifier checks the public build identity and frontend marker, then checks
@@ -514,16 +568,19 @@ just app-deploy app=dspace env=staging tag=main-REPLACE_SHORTSHA \
   smoke_runner="$DSPACE_SMOKE_RUNNER"
 ```
 
-Only after the post-rollout verifier succeeds is the non-overwriting finalized
-record written under `deployment-evidence/dspace/staging/`. Production requires
-that record as an additional gate:
+Only after the post-rollout verifier succeeds is the non-overwriting staging
+record written under `deployment-evidence/dspace/staging/`; production records
+are written under `deployment-evidence/dspace/prod/`. Production requires the
+finalized staging record as an additional gate. Assign its exact path, rather
+than a candidate or reservation path:
 
 ```bash
+STAGING_EVIDENCE=deployment-evidence/dspace/staging/<finalized-record>.json
 just app-promote-prod \
   app=dspace \
   tag=main-REPLACE_SHORTSHA \
   manifest=deployment-candidates/dspace/prod.json \
-  staging_evidence=deployment-evidence/dspace/staging/<finalized-record>.json \
+  staging_evidence="$STAGING_EVIDENCE" \
   staging_config=/etc/sugarkube/apps/dspace-staging.env \
   staging_kubeconfig="$HOME/.kube/config-dspace-staging" \
   smoke_runner="$DSPACE_SMOKE_RUNNER"
@@ -538,3 +595,9 @@ the final production evidence is written. A post-mutation failure leaves the res
 for the existing reconciliation procedure; it never writes successful evidence,
 retries, downgrades, or automatically rolls back. Use the reservation recovery
 instructions above after investigating the bounded failure category.
+
+For `provider=token-place`, verification derives the expected token.place URL
+and model from the selected ordered values chain. For `provider=openai`, it
+omits token.place arguments and verifies the OpenAI-default missing-key behavior.
+In both modes the isolated harness rejects real provider credentials; none are
+needed for staging, production, promotion, or rollback verification.

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -339,6 +339,7 @@ just dspace-manifest-rollback \
   env=staging \
   manifest=deployment-evidence/dspace/staging/previous-finalized-release.json \
   evidence=deployment-evidence/dspace/staging/rollback-20260727T120000Z.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER" \
   verifier=/opt/dspace/bin/sugarkube-runtime-verifier
 ```
 
@@ -352,6 +353,7 @@ just dspace-manifest-rollback \
   env=prod \
   manifest=deployment-evidence/dspace/prod/previous-finalized-release.json \
   evidence=deployment-evidence/dspace/prod/rollback-20260727T120000Z.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER" \
   verifier=/opt/dspace/bin/sugarkube-runtime-verifier \
   confirm="dspace:prod:${TARGET_SHA}"
 ```
@@ -522,14 +524,16 @@ just app-promote-prod \
   tag=main-REPLACE_SHORTSHA \
   manifest=deployment-candidates/dspace/prod.json \
   staging_evidence=deployment-evidence/dspace/staging/<finalized-record>.json \
+  staging_kubeconfig="$HOME/.kube/config-dspace-staging" \
   smoke_runner="$DSPACE_SMOKE_RUNNER"
 ```
 
 Before production rendering, reservation, or mutation, the command validates
 that staging evidence is finalized, compares all immutable release coordinates,
 rechecks the recorded live Helm revision, and reruns the full verifier against
-staging. It runs the same verifier after production rollout and before the final
-production evidence is written. A post-mutation failure leaves the reservation
+staging through the explicitly supplied `staging_kubeconfig` (and optional
+`staging_config`). It runs the same verifier after production rollout and before
+the final production evidence is written. A post-mutation failure leaves the reservation
 for the existing reconciliation procedure; it never writes successful evidence,
 retries, downgrades, or automatically rolls back. Use the reservation recovery
 instructions above after investigating the bounded failure category.

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -139,11 +139,14 @@ verification. The upstream file is checked in with mode `100644`, so make it
 executable after installing its dependencies:
 
 ```bash
-cd "$HOME/dspace"
-pnpm install
-pnpm exec playwright install chromium
-chmod +x "$HOME/dspace/scripts/run-remote-chat-smoke.mjs"
+(
+  cd "$HOME/dspace"
+  pnpm install
+  pnpm exec playwright install chromium
+  chmod +x scripts/run-remote-chat-smoke.mjs
+)
 export DSPACE_SMOKE_RUNNER="$HOME/dspace/scripts/run-remote-chat-smoke.mjs"
+test -x "$DSPACE_SMOKE_RUNNER"
 ```
 
 The smoke harness mocks provider transport. Real token.place or OpenAI
@@ -528,11 +531,14 @@ and make the upstream mode-`100644` script executable. Always provide the
 executable itself—not a shell command or fragment:
 
 ```bash
-cd "$HOME/dspace"
-pnpm install
-pnpm exec playwright install chromium
-chmod +x "$HOME/dspace/scripts/run-remote-chat-smoke.mjs"
+(
+  cd "$HOME/dspace"
+  pnpm install
+  pnpm exec playwright install chromium
+  chmod +x scripts/run-remote-chat-smoke.mjs
+)
 export DSPACE_SMOKE_RUNNER="$HOME/dspace/scripts/run-remote-chat-smoke.mjs"
+test -x "$DSPACE_SMOKE_RUNNER"
 
 just dspace-release-verify \
   env=staging \

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -524,6 +524,7 @@ just app-promote-prod \
   tag=main-REPLACE_SHORTSHA \
   manifest=deployment-candidates/dspace/prod.json \
   staging_evidence=deployment-evidence/dspace/staging/<finalized-record>.json \
+  staging_config=/etc/sugarkube/apps/dspace-staging.env \
   staging_kubeconfig="$HOME/.kube/config-dspace-staging" \
   smoke_runner="$DSPACE_SMOKE_RUNNER"
 ```
@@ -531,8 +532,8 @@ just app-promote-prod \
 Before production rendering, reservation, or mutation, the command validates
 that staging evidence is finalized, compares all immutable release coordinates,
 rechecks the recorded live Helm revision, and reruns the full verifier against
-staging through the explicitly supplied `staging_kubeconfig` (and optional
-`staging_config`). It runs the same verifier after production rollout and before
+staging through the explicitly supplied `staging_config` and
+`staging_kubeconfig`. It runs the same verifier after production rollout and before
 the final production evidence is written. A post-mutation failure leaves the reservation
 for the existing reconciliation procedure; it never writes successful evidence,
 retries, downgrades, or automatically rolls back. Use the reservation recovery

--- a/docs/examples/apps/dspace.env
+++ b/docs/examples/apps/dspace.env
@@ -18,5 +18,3 @@ SUGARKUBE_VALUES_PROD=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.
 SUGARKUBE_STATUS_HOST_KEY=ingress.host
 SUGARKUBE_VERIFY_PATHS=/config.json,/healthz,/livez
 SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=dspace
-# Runtime verification additionally requires smoke_runner=<executable DSPACE
-# checkout>/scripts/run-remote-chat-smoke.mjs; no provider credentials are used.

--- a/docs/examples/apps/dspace.env
+++ b/docs/examples/apps/dspace.env
@@ -18,3 +18,5 @@ SUGARKUBE_VALUES_PROD=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.
 SUGARKUBE_STATUS_HOST_KEY=ingress.host
 SUGARKUBE_VERIFY_PATHS=/config.json,/healthz,/livez
 SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=dspace
+# Runtime verification additionally requires smoke_runner=<executable DSPACE
+# checkout>/scripts/run-remote-chat-smoke.mjs; no provider credentials are used.

--- a/justfile
+++ b/justfile
@@ -1716,7 +1716,7 @@ dspace-release-verify env manifest smoke_runner config='' kubeconfig='':
     "${command[@]}"
 
 # Generic immutable-tag app deploy backed by docs/examples/apps/*.env or local app configs.
-app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='':
+app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' staging_config='' staging_kubeconfig='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1732,6 +1732,8 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_ev
     evidence_output={{ quote(evidence) }}
     staging_record={{ quote(staging_evidence) }}
     dspace_smoke_runner={{ quote(smoke_runner) }}
+    dspace_staging_config={{ quote(staging_config) }}
+    dspace_staging_kubeconfig={{ quote(staging_kubeconfig) }}
     while [ "${release_manifest#manifest=}" != "${release_manifest}" ]; do release_manifest="${release_manifest#manifest=}"; done
     while [ "${evidence_output#evidence=}" != "${evidence_output}" ]; do evidence_output="${evidence_output#evidence=}"; done
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
@@ -1748,11 +1750,16 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_ev
           echo "ERROR: staging_evidence=<finalized-staging.json> is required for DSPACE prod." >&2
           exit 2
         fi
+        if [ -z "${dspace_staging_kubeconfig}" ]; then
+          echo "ERROR: staging_kubeconfig=<path> is required for DSPACE prod verification." >&2
+          exit 2
+        fi
         recorded_revision="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" staging-gate \
           --manifest "${release_manifest}" --staging-evidence "${staging_record}")"
         just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify env=staging \
-          manifest="${staging_record}" smoke_runner="${dspace_smoke_runner}"
-        live_revision="$(helm --kubeconfig "${HOME}/.kube/config-sugarkube-staging" status dspace --namespace dspace -o json | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')"
+          manifest="${staging_record}" smoke_runner="${dspace_smoke_runner}" \
+          config="${dspace_staging_config}" kubeconfig="${dspace_staging_kubeconfig}"
+        live_revision="$(helm --kubeconfig "${dspace_staging_kubeconfig}" status dspace --namespace dspace -o json | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')"
         if [ "${live_revision}" != "${recorded_revision}" ]; then
           echo "ERROR: staging drift: Helm revision changed after evidence capture." >&2
           exit 2
@@ -1823,7 +1830,7 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_ev
     fi
 
 # Generic upgrade-only app redeploy backed by app config files.
-app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='':
+app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' staging_config='' staging_kubeconfig='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1839,6 +1846,8 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_
     evidence_output={{ quote(evidence) }}
     staging_record={{ quote(staging_evidence) }}
     dspace_smoke_runner={{ quote(smoke_runner) }}
+    dspace_staging_config={{ quote(staging_config) }}
+    dspace_staging_kubeconfig={{ quote(staging_kubeconfig) }}
     while [ "${release_manifest#manifest=}" != "${release_manifest}" ]; do release_manifest="${release_manifest#manifest=}"; done
     while [ "${evidence_output#evidence=}" != "${evidence_output}" ]; do evidence_output="${evidence_output#evidence=}"; done
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
@@ -1846,9 +1855,10 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_
       if [ -z "${dspace_smoke_runner}" ]; then echo "ERROR: smoke_runner=<executable> is required for DSPACE ${SUGARKUBE_ENV}." >&2; exit 2; fi
       if [ "${SUGARKUBE_ENV}" = prod ]; then
         if [ -z "${staging_record}" ]; then echo "ERROR: staging_evidence=<finalized-staging.json> is required for DSPACE prod." >&2; exit 2; fi
+        if [ -z "${dspace_staging_kubeconfig}" ]; then echo "ERROR: staging_kubeconfig=<path> is required for DSPACE prod verification." >&2; exit 2; fi
         recorded_revision="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" staging-gate --manifest "${release_manifest}" --staging-evidence "${staging_record}")"
-        just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify env=staging manifest="${staging_record}" smoke_runner="${dspace_smoke_runner}"
-        live_revision="$(helm --kubeconfig "${HOME}/.kube/config-sugarkube-staging" status dspace --namespace dspace -o json | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')"
+        just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify env=staging manifest="${staging_record}" smoke_runner="${dspace_smoke_runner}" config="${dspace_staging_config}" kubeconfig="${dspace_staging_kubeconfig}"
+        live_revision="$(helm --kubeconfig "${dspace_staging_kubeconfig}" status dspace --namespace dspace -o json | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')"
         if [ "${live_revision}" != "${recorded_revision}" ]; then echo "ERROR: staging drift: Helm revision changed after evidence capture." >&2; exit 2; fi
       fi
       chart_version="${SUGARKUBE_VERSION:-}"
@@ -1906,7 +1916,7 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_
     fi
 
 # Promote an app to prod with an explicit immutable tag, or the configured prod tag file.
-app-promote-prod app tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='':
+app-promote-prod app tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' staging_config='' staging_kubeconfig='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1924,6 +1934,8 @@ app-promote-prod app tag='' config='' manifest='' evidence='' staging_evidence='
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
     [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
     [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
+    [ -z {{ quote(staging_config) }} ] || delegate+=(staging_config={{ quote(staging_config) }})
+    [ -z {{ quote(staging_kubeconfig) }} ] || delegate+=(staging_kubeconfig={{ quote(staging_kubeconfig) }})
     "${delegate[@]}"
 
 # Show the pinned chart version and whether a newer semver chart appears published.
@@ -2049,7 +2061,7 @@ app-cors-verify app env='staging' config='' origin='https://cors-smoke.invalid' 
 #
 
 # Use this for steady-state release validation flows where explicit image pinning matters.
-dspace-oci-deploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='':
+dspace-oci-deploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' staging_config='' staging_kubeconfig='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -2058,10 +2070,12 @@ dspace-oci-deploy env='staging' tag='' manifest='' evidence='' staging_evidence=
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
     [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
     [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
+    [ -z {{ quote(staging_config) }} ] || delegate+=(staging_config={{ quote(staging_config) }})
+    [ -z {{ quote(staging_kubeconfig) }} ] || delegate+=(staging_kubeconfig={{ quote(staging_kubeconfig) }})
     "${delegate[@]}"
 
 # Use this for optional canary/smoke testing before or alongside apex promotion workflows.
-dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='' staging_evidence='' smoke_runner='':
+dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' staging_config='' staging_kubeconfig='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -2071,12 +2085,14 @@ dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='' staging_evidence
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
     [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
     [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
+    [ -z {{ quote(staging_config) }} ] || delegate+=(staging_config={{ quote(staging_config) }})
+    [ -z {{ quote(staging_kubeconfig) }} ] || delegate+=(staging_kubeconfig={{ quote(staging_kubeconfig) }})
     "${delegate[@]}"
 
 # Promote dspace to production apex (democratized.space) using immutable tags.
 
 # If tag is omitted, this reads the pinned value from docs/apps/dspace.prod.tag.
-dspace-oci-promote-prod tag='' manifest='' evidence='' staging_evidence='' smoke_runner='':
+dspace-oci-promote-prod tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' staging_config='' staging_kubeconfig='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -2092,10 +2108,12 @@ dspace-oci-promote-prod tag='' manifest='' evidence='' staging_evidence='' smoke
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
     [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
     [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
+    [ -z {{ quote(staging_config) }} ] || delegate+=(staging_config={{ quote(staging_config) }})
+    [ -z {{ quote(staging_kubeconfig) }} ] || delegate+=(staging_kubeconfig={{ quote(staging_kubeconfig) }})
     "${delegate[@]}"
 
 # Fast redeploy of dspace from GHCR (emergency mutable-tag refresh).
-dspace-oci-redeploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='':
+dspace-oci-redeploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' staging_config='' staging_kubeconfig='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -2104,6 +2122,8 @@ dspace-oci-redeploy env='staging' tag='' manifest='' evidence='' staging_evidenc
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
     [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
     [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
+    [ -z {{ quote(staging_config) }} ] || delegate+=(staging_config={{ quote(staging_config) }})
+    [ -z {{ quote(staging_kubeconfig) }} ] || delegate+=(staging_kubeconfig={{ quote(staging_kubeconfig) }})
     "${delegate[@]}"
 
 # Dump dspace and Traefik logs for debugging HTTP 500s.

--- a/justfile
+++ b/justfile
@@ -1670,7 +1670,7 @@ app-config app env='staging' config='':
       --config {{ quote(config) }}
 
 # DSPACE-only fail-closed recovery from previously finalized immutable evidence.
-dspace-manifest-rollback env manifest evidence smoke_runner verifier='' confirm='' config='' kubeconfig='':
+dspace-manifest-rollback env manifest evidence smoke_runner='' verifier='' confirm='' config='' kubeconfig='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
     kubeconfig_path={{ quote(kubeconfig) }}
@@ -1678,20 +1678,25 @@ dspace-manifest-rollback env manifest evidence smoke_runner verifier='' confirm=
       kubeconfig_path="${KUBECONFIG:-${HOME}/.kube/config}"
     fi
     verifier_path={{ quote(verifier) }}
-    python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py" \
+    command=(python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py" \
       --environment {{ quote(env) }} \
       --manifest {{ quote(manifest) }} \
       --evidence {{ quote(evidence) }} \
       --verifier "${verifier_path:-{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py}" \
-      --smoke-runner {{ quote(smoke_runner) }} \
       --confirm {{ quote(confirm) }} \
       --config {{ quote(config) }} \
-      --kubeconfig "${kubeconfig_path}"
+      --kubeconfig "${kubeconfig_path}")
+    [ -z {{ quote(smoke_runner) }} ] || command+=(--smoke-runner {{ quote(smoke_runner) }})
+    "${command[@]}"
 
 # Prove DSPACE public and per-replica identity plus the isolated /chat journey.
 dspace-release-verify env manifest smoke_runner config='' kubeconfig='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
+    manifest_path={{ quote(manifest) }}
+    while [ "${manifest_path#manifest=}" != "${manifest_path}" ]; do manifest_path="${manifest_path#manifest=}"; done
+    smoke_runner_path={{ quote(smoke_runner) }}
+    while [ "${smoke_runner_path#smoke_runner=}" != "${smoke_runner_path}" ]; do smoke_runner_path="${smoke_runner_path#smoke_runner=}"; done
     eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
       --app dspace --env {{ quote(env) }} --config {{ quote(config) }})"
     kubeconfig_path={{ quote(kubeconfig) }}
@@ -1703,13 +1708,20 @@ dspace-release-verify env manifest smoke_runner config='' kubeconfig='':
     just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "${SUGARKUBE_ENV}" "${kubeconfig_path}" >/dev/null
     resolved_host="$(python3 "{{ justfile_directory() }}/scripts/app_chart.py" resolve-host --values "${SUGARKUBE_VALUES}")"
     IFS=$'\t' read -r application_version source_revision image_tag image_digest provider approved_chart_version approved_helm_revision < <(
-      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" runtime-args --manifest {{ quote(manifest) }})
-    command=("{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" verify
+      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" runtime-args --manifest "${manifest_path}")
+    verifier_path="${SUGARKUBE_DSPACE_RUNTIME_VERIFIER:-{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py}"
+    if [ ! -f "${smoke_runner_path}" ] || [ ! -x "${smoke_runner_path}" ]; then
+      echo "ERROR: smoke_runner must be an existing executable file." >&2; exit 2
+    fi
+    if [ ! -f "${verifier_path}" ] || [ ! -x "${verifier_path}" ]; then
+      echo "ERROR: runtime verifier must be an existing executable file." >&2; exit 2
+    fi
+    command=("${verifier_path}" verify
       --environment "${SUGARKUBE_ENV}" --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}"
       --application-version "${application_version}" --source-revision "${source_revision}"
       --image-tag "${image_tag}" --image-digest "${image_digest}" --provider "${provider}"
       --chart-version "${approved_chart_version}"
-      --host "${resolved_host}" --smoke-runner {{ quote(smoke_runner) }} --kubeconfig "${kubeconfig_path}")
+      --host "${resolved_host}" --smoke-runner "${smoke_runner_path}" --kubeconfig "${kubeconfig_path}")
     [ -z "${approved_helm_revision}" ] || command+=(--helm-revision "${approved_helm_revision}")
     IFS=',' read -ra values_files <<< "${SUGARKUBE_VALUES}"
     for values_file in "${values_files[@]}"; do command+=(--values "${values_file}"); done
@@ -1741,8 +1753,8 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_ev
         echo "ERROR: manifest=<approved-candidate.json> is required for DSPACE ${SUGARKUBE_ENV}." >&2
         exit 2
       fi
-      if [ -z "${dspace_smoke_runner}" ]; then
-        echo "ERROR: smoke_runner=<executable> is required for DSPACE ${SUGARKUBE_ENV}." >&2
+      if [ ! -f "${dspace_smoke_runner}" ] || [ ! -x "${dspace_smoke_runner}" ]; then
+        echo "ERROR: smoke_runner=<executable> must be an existing executable for DSPACE ${SUGARKUBE_ENV}." >&2
         exit 2
       fi
       if [ "${SUGARKUBE_ENV}" = prod ]; then
@@ -1750,8 +1762,8 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_ev
           echo "ERROR: staging_evidence=<finalized-staging.json> is required for DSPACE prod." >&2
           exit 2
         fi
-        if [ -z "${dspace_staging_kubeconfig}" ]; then
-          echo "ERROR: staging_kubeconfig=<path> is required for DSPACE prod verification." >&2
+        if [ -z "${dspace_staging_config}" ] || [ -z "${dspace_staging_kubeconfig}" ]; then
+          echo "ERROR: staging_config=<path> and staging_kubeconfig=<path> are required for DSPACE prod verification." >&2
           exit 2
         fi
         recorded_revision="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" staging-gate \
@@ -1852,10 +1864,10 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_
     while [ "${evidence_output#evidence=}" != "${evidence_output}" ]; do evidence_output="${evidence_output#evidence=}"; done
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
       if [ -z "${release_manifest}" ]; then echo "ERROR: manifest=<approved-candidate.json> is required for DSPACE ${SUGARKUBE_ENV}." >&2; exit 2; fi
-      if [ -z "${dspace_smoke_runner}" ]; then echo "ERROR: smoke_runner=<executable> is required for DSPACE ${SUGARKUBE_ENV}." >&2; exit 2; fi
+      if [ ! -f "${dspace_smoke_runner}" ] || [ ! -x "${dspace_smoke_runner}" ]; then echo "ERROR: smoke_runner=<executable> must be an existing executable for DSPACE ${SUGARKUBE_ENV}." >&2; exit 2; fi
       if [ "${SUGARKUBE_ENV}" = prod ]; then
         if [ -z "${staging_record}" ]; then echo "ERROR: staging_evidence=<finalized-staging.json> is required for DSPACE prod." >&2; exit 2; fi
-        if [ -z "${dspace_staging_kubeconfig}" ]; then echo "ERROR: staging_kubeconfig=<path> is required for DSPACE prod verification." >&2; exit 2; fi
+        if [ -z "${dspace_staging_config}" ] || [ -z "${dspace_staging_kubeconfig}" ]; then echo "ERROR: staging_config=<path> and staging_kubeconfig=<path> are required for DSPACE prod verification." >&2; exit 2; fi
         recorded_revision="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" staging-gate --manifest "${release_manifest}" --staging-evidence "${staging_record}")"
         just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify env=staging manifest="${staging_record}" smoke_runner="${dspace_smoke_runner}" config="${dspace_staging_config}" kubeconfig="${dspace_staging_kubeconfig}"
         live_revision="$(helm --kubeconfig "${dspace_staging_kubeconfig}" status dspace --namespace dspace -o json | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')"

--- a/justfile
+++ b/justfile
@@ -1709,7 +1709,7 @@ dspace-release-verify env manifest smoke_runner config='' kubeconfig='':
     resolved_host="$(python3 "{{ justfile_directory() }}/scripts/app_chart.py" resolve-host --values "${SUGARKUBE_VALUES}")"
     IFS=$'\t' read -r application_version source_revision image_tag image_digest provider approved_chart_version approved_helm_revision < <(
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" runtime-args --manifest "${manifest_path}")
-    verifier_path="${SUGARKUBE_DSPACE_RUNTIME_VERIFIER:-{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py}"
+    verifier_path="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py"
     if [ ! -f "${smoke_runner_path}" ] || [ ! -x "${smoke_runner_path}" ]; then
       echo "ERROR: smoke_runner must be an existing executable file." >&2; exit 2
     fi

--- a/justfile
+++ b/justfile
@@ -1670,24 +1670,53 @@ app-config app env='staging' config='':
       --config {{ quote(config) }}
 
 # DSPACE-only fail-closed recovery from previously finalized immutable evidence.
-dspace-manifest-rollback env manifest evidence verifier confirm='' config='' kubeconfig='':
+dspace-manifest-rollback env manifest evidence smoke_runner verifier='' confirm='' config='' kubeconfig='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
     kubeconfig_path={{ quote(kubeconfig) }}
     if [ -z "${kubeconfig_path}" ]; then
       kubeconfig_path="${KUBECONFIG:-${HOME}/.kube/config}"
     fi
+    verifier_path={{ quote(verifier) }}
     python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py" \
       --environment {{ quote(env) }} \
       --manifest {{ quote(manifest) }} \
       --evidence {{ quote(evidence) }} \
-      --verifier {{ quote(verifier) }} \
+      --verifier "${verifier_path:-{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py}" \
+      --smoke-runner {{ quote(smoke_runner) }} \
       --confirm {{ quote(confirm) }} \
       --config {{ quote(config) }} \
       --kubeconfig "${kubeconfig_path}"
 
+# Prove DSPACE public and per-replica identity plus the isolated /chat journey.
+dspace-release-verify env manifest smoke_runner config='' kubeconfig='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell \
+      --app dspace --env {{ quote(env) }} --config {{ quote(config) }})"
+    kubeconfig_path={{ quote(kubeconfig) }}
+    if [ -z "${kubeconfig_path}" ]; then
+      export KUBECONFIG="${HOME}/.kube/config"
+      just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${SUGARKUBE_ENV}"
+      kubeconfig_path="${KUBECONFIG}"
+    fi
+    just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "${SUGARKUBE_ENV}" "${kubeconfig_path}" >/dev/null
+    resolved_host="$(python3 "{{ justfile_directory() }}/scripts/app_chart.py" resolve-host --values "${SUGARKUBE_VALUES}")"
+    IFS=$'\t' read -r application_version source_revision image_tag image_digest provider approved_chart_version approved_helm_revision < <(
+      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" runtime-args --manifest {{ quote(manifest) }})
+    command=("{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" verify
+      --environment "${SUGARKUBE_ENV}" --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}"
+      --application-version "${application_version}" --source-revision "${source_revision}"
+      --image-tag "${image_tag}" --image-digest "${image_digest}" --provider "${provider}"
+      --chart-version "${approved_chart_version}"
+      --host "${resolved_host}" --smoke-runner {{ quote(smoke_runner) }} --kubeconfig "${kubeconfig_path}")
+    [ -z "${approved_helm_revision}" ] || command+=(--helm-revision "${approved_helm_revision}")
+    IFS=',' read -ra values_files <<< "${SUGARKUBE_VALUES}"
+    for values_file in "${values_files[@]}"; do command+=(--values "${values_file}"); done
+    "${command[@]}"
+
 # Generic immutable-tag app deploy backed by docs/examples/apps/*.env or local app configs.
-app-deploy app env='staging' tag='' config='' manifest='' evidence='':
+app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1701,12 +1730,33 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
 
     release_manifest={{ quote(manifest) }}
     evidence_output={{ quote(evidence) }}
+    staging_record={{ quote(staging_evidence) }}
+    dspace_smoke_runner={{ quote(smoke_runner) }}
     while [ "${release_manifest#manifest=}" != "${release_manifest}" ]; do release_manifest="${release_manifest#manifest=}"; done
     while [ "${evidence_output#evidence=}" != "${evidence_output}" ]; do evidence_output="${evidence_output#evidence=}"; done
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
       if [ -z "${release_manifest}" ]; then
         echo "ERROR: manifest=<approved-candidate.json> is required for DSPACE ${SUGARKUBE_ENV}." >&2
         exit 2
+      fi
+      if [ -z "${dspace_smoke_runner}" ]; then
+        echo "ERROR: smoke_runner=<executable> is required for DSPACE ${SUGARKUBE_ENV}." >&2
+        exit 2
+      fi
+      if [ "${SUGARKUBE_ENV}" = prod ]; then
+        if [ -z "${staging_record}" ]; then
+          echo "ERROR: staging_evidence=<finalized-staging.json> is required for DSPACE prod." >&2
+          exit 2
+        fi
+        recorded_revision="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" staging-gate \
+          --manifest "${release_manifest}" --staging-evidence "${staging_record}")"
+        just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify env=staging \
+          manifest="${staging_record}" smoke_runner="${dspace_smoke_runner}"
+        live_revision="$(helm --kubeconfig "${HOME}/.kube/config-sugarkube-staging" status dspace --namespace dspace -o json | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')"
+        if [ "${live_revision}" != "${recorded_revision}" ]; then
+          echo "ERROR: staging drift: Helm revision changed after evidence capture." >&2
+          exit 2
+        fi
       fi
       chart_version="${SUGARKUBE_VERSION:-}"
       if [ -z "${chart_version}" ]; then
@@ -1757,16 +1807,23 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
     fi
     [ -z "${mutation_marker:-}" ] || rm -f "${mutation_marker}"
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
+      runtime_proof="$(mktemp)"
+      trap 'rm -f "${runtime_proof:-}"' EXIT
+      just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify env="${SUGARKUBE_ENV}" \
+        manifest="${release_manifest}" smoke_runner="${dspace_smoke_runner}" config="${SUGARKUBE_CONFIG_PATH}" kubeconfig="${KUBECONFIG}" >"${runtime_proof}"
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize \
         --manifest "${release_manifest}" --output "${evidence_output}" \
         --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" \
         --chart-version "${chart_version}" --kubeconfig "${KUBECONFIG}" \
         --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
-        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}"
+        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}" \
+        --runtime-verification "${runtime_proof}"
+      rm -f "${runtime_proof}"
+      trap - EXIT
     fi
 
 # Generic upgrade-only app redeploy backed by app config files.
-app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
+app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1780,10 +1837,20 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
 
     release_manifest={{ quote(manifest) }}
     evidence_output={{ quote(evidence) }}
+    staging_record={{ quote(staging_evidence) }}
+    dspace_smoke_runner={{ quote(smoke_runner) }}
     while [ "${release_manifest#manifest=}" != "${release_manifest}" ]; do release_manifest="${release_manifest#manifest=}"; done
     while [ "${evidence_output#evidence=}" != "${evidence_output}" ]; do evidence_output="${evidence_output#evidence=}"; done
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
       if [ -z "${release_manifest}" ]; then echo "ERROR: manifest=<approved-candidate.json> is required for DSPACE ${SUGARKUBE_ENV}." >&2; exit 2; fi
+      if [ -z "${dspace_smoke_runner}" ]; then echo "ERROR: smoke_runner=<executable> is required for DSPACE ${SUGARKUBE_ENV}." >&2; exit 2; fi
+      if [ "${SUGARKUBE_ENV}" = prod ]; then
+        if [ -z "${staging_record}" ]; then echo "ERROR: staging_evidence=<finalized-staging.json> is required for DSPACE prod." >&2; exit 2; fi
+        recorded_revision="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" staging-gate --manifest "${release_manifest}" --staging-evidence "${staging_record}")"
+        just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify env=staging manifest="${staging_record}" smoke_runner="${dspace_smoke_runner}"
+        live_revision="$(helm --kubeconfig "${HOME}/.kube/config-sugarkube-staging" status dspace --namespace dspace -o json | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')"
+        if [ "${live_revision}" != "${recorded_revision}" ]; then echo "ERROR: staging drift: Helm revision changed after evidence capture." >&2; exit 2; fi
+      fi
       chart_version="${SUGARKUBE_VERSION:-}"
       if [ -z "${chart_version}" ]; then chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -n1)"; fi
       chart_coordinate="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" preflight --manifest "${release_manifest}" --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" \
@@ -1827,14 +1894,19 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
     fi
     [ -z "${mutation_marker:-}" ] || rm -f "${mutation_marker}"
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
+      runtime_proof="$(mktemp)"
+      trap 'rm -f "${runtime_proof:-}"' EXIT
+      just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify env="${SUGARKUBE_ENV}" manifest="${release_manifest}" smoke_runner="${dspace_smoke_runner}" config="${SUGARKUBE_CONFIG_PATH}" kubeconfig="${KUBECONFIG}" >"${runtime_proof}"
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize --manifest "${release_manifest}" --output "${evidence_output}" \
         --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" --kubeconfig "${KUBECONFIG}" \
         --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
-        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}"
+        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}" --runtime-verification "${runtime_proof}"
+      rm -f "${runtime_proof}"
+      trap - EXIT
     fi
 
 # Promote an app to prod with an explicit immutable tag, or the configured prod tag file.
-app-promote-prod app tag='' config='' manifest='' evidence='':
+app-promote-prod app tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1850,6 +1922,8 @@ app-promote-prod app tag='' config='' manifest='' evidence='':
       app="${SUGARKUBE_APP}" env=prod tag="${SUGARKUBE_TAG}" config="${SUGARKUBE_CONFIG_PATH}")
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Show the pinned chart version and whether a newer semver chart appears published.
@@ -1975,17 +2049,19 @@ app-cors-verify app env='staging' config='' origin='https://cors-smoke.invalid' 
 #
 
 # Use this for steady-state release validation flows where explicit image pinning matters.
-dspace-oci-deploy env='staging' tag='' manifest='' evidence='':
+dspace-oci-deploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
     delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-deploy app=dspace env={{ quote(env) }} tag={{ quote(tag) }})
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Use this for optional canary/smoke testing before or alongside apex promotion workflows.
-dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='':
+dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1993,12 +2069,14 @@ dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='':
       "{{ justfile_directory() }}/docs/examples/apps/dspace-prod-subdomain.env")
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Promote dspace to production apex (democratized.space) using immutable tags.
 
 # If tag is omitted, this reads the pinned value from docs/apps/dspace.prod.tag.
-dspace-oci-promote-prod tag='' manifest='' evidence='':
+dspace-oci-promote-prod tag='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -2012,16 +2090,20 @@ dspace-oci-promote-prod tag='' manifest='' evidence='':
     delegate=(just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy env=prod tag="${SUGARKUBE_TAG}")
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Fast redeploy of dspace from GHCR (emergency mutable-tag refresh).
-dspace-oci-redeploy env='staging' tag='' manifest='' evidence='':
+dspace-oci-redeploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
     delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-redeploy app=dspace env={{ quote(env) }} tag={{ quote(tag) }})
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Dump dspace and Traefik logs for debugging HTTP 500s.

--- a/justfile
+++ b/justfile
@@ -1941,13 +1941,9 @@ app-promote-prod app tag='' config='' manifest='' evidence='' staging_evidence='
       --require-tag)"
     eval "${config_exports}"
     delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-deploy \
-      app="${SUGARKUBE_APP}" env=prod tag="${SUGARKUBE_TAG}" config="${SUGARKUBE_CONFIG_PATH}")
-    [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
-    [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
-    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
-    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
-    [ -z {{ quote(staging_config) }} ] || delegate+=(staging_config={{ quote(staging_config) }})
-    [ -z {{ quote(staging_kubeconfig) }} ] || delegate+=(staging_kubeconfig={{ quote(staging_kubeconfig) }})
+      "${SUGARKUBE_APP}" prod "${SUGARKUBE_TAG}" "${SUGARKUBE_CONFIG_PATH}" \
+      {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} \
+      {{ quote(smoke_runner) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }})
     "${delegate[@]}"
 
 # Show the pinned chart version and whether a newer semver chart appears published.
@@ -2077,13 +2073,7 @@ dspace-oci-deploy env='staging' tag='' manifest='' evidence='' staging_evidence=
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-deploy app=dspace env={{ quote(env) }} tag={{ quote(tag) }})
-    [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
-    [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
-    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
-    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
-    [ -z {{ quote(staging_config) }} ] || delegate+=(staging_config={{ quote(staging_config) }})
-    [ -z {{ quote(staging_kubeconfig) }} ] || delegate+=(staging_kubeconfig={{ quote(staging_kubeconfig) }})
+    delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-deploy dspace {{ quote(env) }} {{ quote(tag) }} '' {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }})
     "${delegate[@]}"
 
 # Use this for optional canary/smoke testing before or alongside apex promotion workflows.
@@ -2091,14 +2081,8 @@ dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='' staging_evidence
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-deploy app=dspace env=prod tag={{ quote(tag) }} \
-      "{{ justfile_directory() }}/docs/examples/apps/dspace-prod-subdomain.env")
-    [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
-    [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
-    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
-    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
-    [ -z {{ quote(staging_config) }} ] || delegate+=(staging_config={{ quote(staging_config) }})
-    [ -z {{ quote(staging_kubeconfig) }} ] || delegate+=(staging_kubeconfig={{ quote(staging_kubeconfig) }})
+    delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-deploy dspace prod {{ quote(tag) }} \
+      "{{ justfile_directory() }}/docs/examples/apps/dspace-prod-subdomain.env" {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }})
     "${delegate[@]}"
 
 # Promote dspace to production apex (democratized.space) using immutable tags.
@@ -2115,13 +2099,7 @@ dspace-oci-promote-prod tag='' manifest='' evidence='' staging_evidence='' smoke
       --prod-tag-fallback \
       --require-tag)"
     eval "${config_exports}"
-    delegate=(just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy env=prod tag="${SUGARKUBE_TAG}")
-    [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
-    [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
-    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
-    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
-    [ -z {{ quote(staging_config) }} ] || delegate+=(staging_config={{ quote(staging_config) }})
-    [ -z {{ quote(staging_kubeconfig) }} ] || delegate+=(staging_kubeconfig={{ quote(staging_kubeconfig) }})
+    delegate=(just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy prod "${SUGARKUBE_TAG}" {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }})
     "${delegate[@]}"
 
 # Fast redeploy of dspace from GHCR (emergency mutable-tag refresh).
@@ -2129,13 +2107,7 @@ dspace-oci-redeploy env='staging' tag='' manifest='' evidence='' staging_evidenc
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-redeploy app=dspace env={{ quote(env) }} tag={{ quote(tag) }})
-    [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
-    [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
-    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
-    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
-    [ -z {{ quote(staging_config) }} ] || delegate+=(staging_config={{ quote(staging_config) }})
-    [ -z {{ quote(staging_kubeconfig) }} ] || delegate+=(staging_kubeconfig={{ quote(staging_kubeconfig) }})
+    delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-redeploy dspace {{ quote(env) }} {{ quote(tag) }} '' {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }})
     "${delegate[@]}"
 
 # Dump dspace and Traefik logs for debugging HTTP 500s.

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -23,6 +23,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from scripts import app_config  # noqa: E402
+from scripts import app_chart  # noqa: E402
 from scripts import dspace_release_manifest as release  # noqa: E402
 
 SCHEMA_VERSION = 1
@@ -740,6 +741,27 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             "--provider",
             target["expectedDefaultChatProvider"],
         ]
+        if getattr(args, "smoke_runner", None) is not None:
+            verifier_command.extend(
+                (
+                    "--image-tag",
+                    target["imageTag"],
+                    "--image-digest",
+                    target["imageDigest"],
+                    "--chart-version",
+                    target["chartVersion"],
+                    "--helm-revision",
+                    str(after_revision),
+                    "--host",
+                    app_chart.expected_ingress_host(tuple(str(path) for path in values), ""),
+                    "--smoke-runner",
+                    str(args.smoke_runner),
+                    "--kubeconfig",
+                    args.kubeconfig,
+                )
+            )
+            for path in values:
+                verifier_command.extend(("--values", str(path)))
         failed_stage = "runtime-verification"
         verifier = validate_verifier_result(
             json_command(runner, verifier_command, "runtime verifier"), target, args.environment
@@ -790,8 +812,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "status": observed_info.get("status"),
                 "chartName": observed_chart.get("name"),
                 "chartVersion": chart_version(observed_helm),
-                "invocationDescriptionMatches": observed_info.get("description")
-                == description,
+                "invocationDescriptionMatches": observed_info.get("description") == description,
             }
         except Exception:
             diagnostics["helm"] = "unavailable"
@@ -822,7 +843,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--environment", choices=("staging", "prod"), required=True)
     parser.add_argument("--manifest", type=Path, required=True)
     parser.add_argument("--evidence", type=Path, required=True)
-    parser.add_argument("--verifier", type=Path, required=True)
+    parser.add_argument(
+        "--verifier",
+        type=Path,
+        default=Path(__file__).with_name("dspace_runtime_verifier.py"),
+    )
+    parser.add_argument("--smoke-runner", type=Path)
     parser.add_argument("--confirm", default="")
     parser.add_argument("--config", default="")
     parser.add_argument("--kubeconfig", default=str(Path.home() / ".kube" / "config-sugarkube"))

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -839,6 +839,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
 
 
 def main(argv: list[str] | None = None) -> int:
+    default_verifier = Path(__file__).with_name("dspace_runtime_verifier.py")
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--environment", choices=("staging", "prod"), required=True)
     parser.add_argument("--manifest", type=Path, required=True)
@@ -846,7 +847,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--verifier",
         type=Path,
-        default=Path(__file__).with_name("dspace_runtime_verifier.py"),
+        default=default_verifier,
     )
     parser.add_argument("--smoke-runner", type=Path)
     parser.add_argument("--confirm", default="")
@@ -855,6 +856,15 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--oras", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
     parser.add_argument("--timeout", default="10m")
     args = parser.parse_args(argv)
+    if (
+        args.verifier.expanduser().resolve() == default_verifier.resolve()
+        and args.smoke_runner is None
+    ):
+        print(
+            "error: --smoke-runner is required when using the default runtime verifier",
+            file=sys.stderr,
+        )
+        return 2
     try:
         rollback(args)
     except (RollbackError, app_config.AppConfigError) as exc:

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -708,23 +708,6 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             ],
             "DSPACE pods",
         )
-        finalizer_proof = release.finalize(
-            approved,
-            after_helm,
-            raw_pods,
-            workloads,
-            oci,
-            environment=args.environment,
-            image_tag=target["imageTag"],
-            chart_version=target["chartVersion"],
-            release="dspace",
-            namespace="dspace",
-            cluster_environment=args.environment,
-            invocation_description=description,
-            expected_image_coordinate=(
-                f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"
-            ),
-        )
         verifier_command = [
             str(args.verifier),
             "verify",
@@ -741,9 +724,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             "--provider",
             target["expectedDefaultChatProvider"],
         ]
-        if args.verifier.expanduser().resolve() == Path(__file__).with_name(
-            "dspace_runtime_verifier.py"
-        ).resolve():
+        if (
+            args.verifier.expanduser().resolve()
+            == Path(__file__).with_name("dspace_runtime_verifier.py").resolve()
+        ):
             verifier_command.extend(
                 (
                     "--image-tag",
@@ -767,6 +751,25 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         failed_stage = "runtime-verification"
         verifier = validate_verifier_result(
             json_command(runner, verifier_command, "runtime verifier"), target, args.environment
+        )
+        failed_stage = "ownership-and-finalization-proof"
+        finalizer_proof = release.finalize(
+            approved,
+            after_helm,
+            raw_pods,
+            workloads,
+            oci,
+            environment=args.environment,
+            image_tag=target["imageTag"],
+            chart_version=target["chartVersion"],
+            release="dspace",
+            namespace="dspace",
+            cluster_environment=args.environment,
+            invocation_description=description,
+            expected_image_coordinate=(
+                f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"
+            ),
+            runtime_verification=verifier,
         )
         failed_stage = "revision-stability-collection"
         stable = helm_status(runner, args.kubeconfig, "dspace", "dspace")
@@ -858,16 +861,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--oras", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
     parser.add_argument("--timeout", default="10m")
     args = parser.parse_args(argv)
-    if (
-        args.verifier.expanduser().resolve() == default_verifier.resolve()
-        and (
-            args.smoke_runner is None
-            or not args.smoke_runner.expanduser().is_file()
-            or not os.access(args.smoke_runner.expanduser(), os.X_OK)
-        )
+    if args.verifier.expanduser().resolve() == default_verifier.resolve() and (
+        args.smoke_runner is None
+        or not args.smoke_runner.expanduser().is_file()
+        or not os.access(args.smoke_runner.expanduser(), os.X_OK)
     ):
         print(
-            "error: --smoke-runner must be an existing executable when using the default runtime verifier",
+            "error: --smoke-runner must be an existing executable when using the "
+            "default runtime verifier",
             file=sys.stderr,
         )
         return 2

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -741,7 +741,9 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             "--provider",
             target["expectedDefaultChatProvider"],
         ]
-        if getattr(args, "smoke_runner", None) is not None:
+        if args.verifier.expanduser().resolve() == Path(__file__).with_name(
+            "dspace_runtime_verifier.py"
+        ).resolve():
             verifier_command.extend(
                 (
                     "--image-tag",
@@ -858,10 +860,14 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     if (
         args.verifier.expanduser().resolve() == default_verifier.resolve()
-        and args.smoke_runner is None
+        and (
+            args.smoke_runner is None
+            or not args.smoke_runner.expanduser().is_file()
+            or not os.access(args.smoke_runner.expanduser(), os.X_OK)
+        )
     ):
         print(
-            "error: --smoke-runner is required when using the default runtime verifier",
+            "error: --smoke-runner must be an existing executable when using the default runtime verifier",
             file=sys.stderr,
         )
         return 2

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -742,41 +742,17 @@ def finalize(
         },
     ]
     if runtime_verification is not None:
-        _exact_fields(
-            runtime_verification,
-            (
-                "schemaVersion",
-                "environment",
-                "release",
-                "namespace",
-                "applicationVersion",
-                "runtimeSourceRevision",
-                "frontendSourceRevision",
-                "defaultProvider",
-                "journeys",
-            ),
+        # Keep rollback and deployment evidence on one exact verifier contract.
+        from scripts.dspace_manifest_rollback import (  # pylint: disable=import-outside-toplevel
+            RollbackError,
+            validate_verifier_result,
         )
-        expected_runtime = {
-            "schemaVersion": 1,
-            "environment": environment,
-            "release": release,
-            "namespace": namespace,
-            "applicationVersion": value["applicationVersion"],
-            "runtimeSourceRevision": value["sourceRevision"],
-            "frontendSourceRevision": value["sourceRevision"],
-            "defaultProvider": value["expectedDefaultChatProvider"],
-        }
-        if any(
-            runtime_verification.get(key) != expected for key, expected in expected_runtime.items()
-        ):
-            raise ManifestError("runtime verification does not match approved release")
-        journeys = runtime_verification.get("journeys")
-        if (
-            not isinstance(journeys, list)
-            or not all(isinstance(item, dict) and item.get("passed") is True for item in journeys)
-            or not any(item.get("name") == "/chat" for item in journeys)
-        ):
-            raise ManifestError("runtime verification lacks successful public journeys")
+
+        try:
+            validate_verifier_result(runtime_verification, value, environment)
+        except RollbackError as exc:
+            raise ManifestError(f"invalid runtime verification: {exc}") from exc
+        journey_names = ",".join(item["name"] for item in runtime_verification["journeys"])
         results.extend(
             {"check": check, "passed": True, "details": details}
             for check, details in (
@@ -788,7 +764,10 @@ def finalize(
                     "defaultProvider",
                     f"approved default provider={value['expectedDefaultChatProvider']}",
                 ),
-                ("remoteChatSmoke", "isolated /chat journey and provider safety checks passed"),
+                (
+                    "remoteChatSmoke",
+                    f"successful public journeys={journey_names}; provider safety checks passed",
+                ),
             )
         )
     result = dict(value)

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -517,6 +517,13 @@ def staging_gate(candidate_record: dict[str, Any], staging_record: dict[str, Any
         raise ManifestError("manifest/evidence mismatch: candidate environment must be prod")
     if staging_record["environment"] != "staging":
         raise ManifestError("manifest/evidence mismatch: evidence environment must be staging")
+    checks = {result["check"] for result in staging_record["verificationResults"]}
+    missing_runtime = sorted(RUNTIME_EVIDENCE_CHECKS - checks)
+    if missing_runtime:
+        raise ManifestError(
+            "manifest/evidence mismatch: staging evidence lacks runtime verification: "
+            + ", ".join(missing_runtime)
+        )
     mismatched = [
         field
         for field in IMMUTABLE_PROMOTION_FIELDS
@@ -581,6 +588,8 @@ def finalize(
     runtime_verification: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     validate(value, False)
+    if runtime_verification is None:
+        raise ManifestError("finalization requires runtime verification")
     selected = {
         "environment": environment,
         "imageTag": image_tag,
@@ -741,35 +750,34 @@ def finalize(
             "details": "every running pod imageID matched approved image digest",
         },
     ]
-    if runtime_verification is not None:
-        # Keep rollback and deployment evidence on one exact verifier contract.
-        from scripts.dspace_manifest_rollback import (  # pylint: disable=import-outside-toplevel
-            RollbackError,
-            validate_verifier_result,
-        )
+    # Keep rollback and deployment evidence on one exact verifier contract.
+    from scripts.dspace_manifest_rollback import (  # pylint: disable=import-outside-toplevel
+        RollbackError,
+        validate_verifier_result,
+    )
 
-        try:
-            validate_verifier_result(runtime_verification, value, environment)
-        except RollbackError as exc:
-            raise ManifestError(f"invalid runtime verification: {exc}") from exc
-        journey_names = ",".join(item["name"] for item in runtime_verification["journeys"])
-        results.extend(
-            {"check": check, "passed": True, "details": details}
-            for check, details in (
-                ("runtimeIdentity", "approved application version and full source revision"),
-                ("frontendIdentity", "approved full frontend source revision marker"),
-                ("replicaAgreement", "all serving replicas reported the approved identity"),
-                ("publicDirectAgreement", "public and direct-origin identities agreed"),
-                (
-                    "defaultProvider",
-                    f"approved default provider={value['expectedDefaultChatProvider']}",
-                ),
-                (
-                    "remoteChatSmoke",
-                    f"successful public journeys={journey_names}; provider safety checks passed",
-                ),
-            )
+    try:
+        validate_verifier_result(runtime_verification, value, environment)
+    except RollbackError as exc:
+        raise ManifestError(f"invalid runtime verification: {exc}") from exc
+    journey_names = ",".join(item["name"] for item in runtime_verification["journeys"])
+    results.extend(
+        {"check": check, "passed": True, "details": details}
+        for check, details in (
+            ("runtimeIdentity", "approved application version and full source revision"),
+            ("frontendIdentity", "approved full frontend source revision marker"),
+            ("replicaAgreement", "all serving replicas reported the approved identity"),
+            ("publicDirectAgreement", "public and direct-origin identities agreed"),
+            (
+                "defaultProvider",
+                f"approved default provider={value['expectedDefaultChatProvider']}",
+            ),
+            (
+                "remoteChatSmoke",
+                f"successful public journeys={journey_names}; provider safety checks passed",
+            ),
         )
+    )
     result = dict(value)
     result.update(
         recordType="final",
@@ -817,7 +825,7 @@ def main(argv: list[str] | None = None) -> int:
     finish.add_argument("--chart-ref", default=CHART_REF)
     finish.add_argument("--reservation", required=True)
     finish.add_argument("--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
-    finish.add_argument("--runtime-verification", type=Path)
+    finish.add_argument("--runtime-verification", type=Path, required=True)
     available = sub.add_parser("check-output")
     available.add_argument("--output", type=Path, required=True)
     destination = sub.add_parser("evidence-path")
@@ -950,9 +958,7 @@ def main(argv: list[str] | None = None) -> int:
                 namespace=args.namespace,
                 cluster_environment=cluster_environment,
                 invocation_description=invocation_description,
-                runtime_verification=(
-                    _object(args.runtime_verification) if args.runtime_verification else None
-                ),
+                runtime_verification=_object(args.runtime_verification),
             )
             sidecar = verify_reservation(
                 args.output,

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -69,6 +69,24 @@ FINAL_FIXED_CHECKS = {
     "podImageCoordinates",
     "podImageDigests",
 }
+RUNTIME_EVIDENCE_CHECKS = {
+    "runtimeIdentity",
+    "frontendIdentity",
+    "replicaAgreement",
+    "publicDirectAgreement",
+    "defaultProvider",
+    "remoteChatSmoke",
+}
+IMMUTABLE_PROMOTION_FIELDS = (
+    "applicationVersion",
+    "sourceRevision",
+    "imageTag",
+    "imageDigest",
+    "chartVersion",
+    "chartDigest",
+    "semanticTag",
+    "expectedDefaultChatProvider",
+)
 PLATFORM_CHECK_RE = re.compile(r"^imagePlatformSourceRevision\[(0|[1-9][0-9]*)\]$")
 POD_SETTLE_TIMEOUT_SECONDS = 60.0
 POD_SETTLE_INTERVAL_SECONDS = 2.0
@@ -206,15 +224,13 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
             platform_match = PLATFORM_CHECK_RE.fullmatch(check)
             if platform_match:
                 platform_indices.append(int(platform_match.group(1)))
-            elif check not in FINAL_FIXED_CHECKS:
+            elif check not in FINAL_FIXED_CHECKS | RUNTIME_EVIDENCE_CHECKS:
                 raise ManifestError(f"unknown verification result: {check}")
         missing = sorted(FINAL_FIXED_CHECKS - checks)
         if missing:
             raise ManifestError("missing verification results: " + ", ".join(missing))
         if sorted(platform_indices) != list(range(len(platform_indices))):
-            raise ManifestError(
-                "image platform verification indices must be contiguous from zero"
-            )
+            raise ManifestError("image platform verification indices must be contiguous from zero")
         if not platform_indices:
             raise ManifestError("at least one image platform verification result is required")
     return value
@@ -235,9 +251,7 @@ def _write_new(path: Path, value: dict[str, Any]) -> None:
         try:
             os.link(temporary, path)
         except FileExistsError as exc:
-            raise ManifestError(
-                f"refusing to overwrite existing record: {path}"
-            ) from exc
+            raise ManifestError(f"refusing to overwrite existing record: {path}") from exc
         _sync_directory(path.parent)
     finally:
         Path(temporary).unlink(missing_ok=True)
@@ -290,9 +304,7 @@ def reserve(
     try:
         fd = os.open(sidecar, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     except FileExistsError as exc:
-        raise ManifestError(
-            f"evidence destination is already reserved: {sidecar}"
-        ) from exc
+        raise ManifestError(f"evidence destination is already reserved: {sidecar}") from exc
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as stream:
             stream.write(_canonical(metadata))
@@ -328,9 +340,7 @@ def verify_reservation(
     if not secrets.compare_digest(
         json.dumps(metadata, sort_keys=True), json.dumps(expected, sort_keys=True)
     ):
-        raise ManifestError(
-            "reservation ownership or deployment coordinates do not match"
-        )
+        raise ManifestError("reservation ownership or deployment coordinates do not match")
     if normalized.exists():
         raise ManifestError(f"refusing to overwrite existing record: {normalized}")
     return sidecar
@@ -499,6 +509,26 @@ def chart_coordinate(value: dict[str, Any]) -> str:
     return f"oci://{CHART_REF}@{value['chartDigest']}"
 
 
+def staging_gate(candidate_record: dict[str, Any], staging_record: dict[str, Any]) -> int:
+    """Validate finalized staging proof for the exact production artifact."""
+    candidate_record = validate(candidate_record, False)
+    staging_record = validate(staging_record, True)
+    if candidate_record["environment"] != "prod":
+        raise ManifestError("manifest/evidence mismatch: candidate environment must be prod")
+    if staging_record["environment"] != "staging":
+        raise ManifestError("manifest/evidence mismatch: evidence environment must be staging")
+    mismatched = [
+        field
+        for field in IMMUTABLE_PROMOTION_FIELDS
+        if candidate_record[field] != staging_record[field]
+    ]
+    if mismatched:
+        raise ManifestError(
+            "manifest/evidence mismatch: immutable coordinates differ: " + ", ".join(mismatched)
+        )
+    return staging_record["helmRevision"]
+
+
 def _image_id_digest(image_id: str) -> str:
     match = re.search(r"sha256:[0-9a-f]{64}$", image_id)
     if not match:
@@ -548,6 +578,7 @@ def finalize(
     cluster_environment: str,
     invocation_description: str,
     expected_image_coordinate: str | None = None,
+    runtime_verification: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     validate(value, False)
     selected = {
@@ -668,7 +699,9 @@ def finalize(
         {
             "check": "selectedCoordinates",
             "passed": True,
-            "details": f"environment={environment}; imageTag={image_tag}; chartVersion={chart_version}",
+            "details": (
+                f"environment={environment}; imageTag={image_tag}; chartVersion={chart_version}"
+            ),
         },
         {
             "check": "clusterEnvironment",
@@ -689,8 +722,7 @@ def finalize(
             # Helm metadata proves name/version, not immutable OCI content. The
             # guarded mutation therefore installs this approved digest directly.
             "details": (
-                f"chart=dspace; version={chart_version}; "
-                f"coordinate={chart_coordinate(value)}"
+                f"chart=dspace; version={chart_version}; " f"coordinate={chart_coordinate(value)}"
             ),
         },
         {
@@ -709,6 +741,56 @@ def finalize(
             "details": "every running pod imageID matched approved image digest",
         },
     ]
+    if runtime_verification is not None:
+        _exact_fields(
+            runtime_verification,
+            (
+                "schemaVersion",
+                "environment",
+                "release",
+                "namespace",
+                "applicationVersion",
+                "runtimeSourceRevision",
+                "frontendSourceRevision",
+                "defaultProvider",
+                "journeys",
+            ),
+        )
+        expected_runtime = {
+            "schemaVersion": 1,
+            "environment": environment,
+            "release": release,
+            "namespace": namespace,
+            "applicationVersion": value["applicationVersion"],
+            "runtimeSourceRevision": value["sourceRevision"],
+            "frontendSourceRevision": value["sourceRevision"],
+            "defaultProvider": value["expectedDefaultChatProvider"],
+        }
+        if any(
+            runtime_verification.get(key) != expected for key, expected in expected_runtime.items()
+        ):
+            raise ManifestError("runtime verification does not match approved release")
+        journeys = runtime_verification.get("journeys")
+        if (
+            not isinstance(journeys, list)
+            or not all(isinstance(item, dict) and item.get("passed") is True for item in journeys)
+            or not any(item.get("name") == "/chat" for item in journeys)
+        ):
+            raise ManifestError("runtime verification lacks successful public journeys")
+        results.extend(
+            {"check": check, "passed": True, "details": details}
+            for check, details in (
+                ("runtimeIdentity", "approved application version and full source revision"),
+                ("frontendIdentity", "approved full frontend source revision marker"),
+                ("replicaAgreement", "all serving replicas reported the approved identity"),
+                ("publicDirectAgreement", "public and direct-origin identities agreed"),
+                (
+                    "defaultProvider",
+                    f"approved default provider={value['expectedDefaultChatProvider']}",
+                ),
+                ("remoteChatSmoke", "isolated /chat journey and provider safety checks passed"),
+            )
+        )
     result = dict(value)
     result.update(
         recordType="final",
@@ -755,9 +837,8 @@ def main(argv: list[str] | None = None) -> int:
     finish.add_argument("--image-ref", default=IMAGE_REF)
     finish.add_argument("--chart-ref", default=CHART_REF)
     finish.add_argument("--reservation", required=True)
-    finish.add_argument(
-        "--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras")
-    )
+    finish.add_argument("--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
+    finish.add_argument("--runtime-verification", type=Path)
     available = sub.add_parser("check-output")
     available.add_argument("--output", type=Path, required=True)
     destination = sub.add_parser("evidence-path")
@@ -768,6 +849,11 @@ def main(argv: list[str] | None = None) -> int:
     claim.add_argument("--environment", required=True)
     claim.add_argument("--release", required=True)
     claim.add_argument("--namespace", required=True)
+    staging = sub.add_parser("staging-gate")
+    staging.add_argument("--manifest", type=Path, required=True)
+    staging.add_argument("--staging-evidence", type=Path, required=True)
+    inspect = sub.add_parser("runtime-args")
+    inspect.add_argument("--manifest", type=Path, required=True)
     args = parser.parse_args(argv)
     try:
         if args.command == "candidate":
@@ -885,6 +971,9 @@ def main(argv: list[str] | None = None) -> int:
                 namespace=args.namespace,
                 cluster_environment=cluster_environment,
                 invocation_description=invocation_description,
+                runtime_verification=(
+                    _object(args.runtime_verification) if args.runtime_verification else None
+                ),
             )
             sidecar = verify_reservation(
                 args.output,
@@ -909,19 +998,16 @@ def main(argv: list[str] | None = None) -> int:
                     metadata.get("version"),
                 )
 
-            if (
-                binding_fields(settled_helm) != binding_fields(helm)
-                or binding_fields(stable_helm) != binding_fields(helm)
-            ):
+            if binding_fields(settled_helm) != binding_fields(helm) or binding_fields(
+                stable_helm
+            ) != binding_fields(helm):
                 raise ManifestError("Helm release changed during evidence collection")
             _write_new(args.output, result)
             sidecar.unlink()
             _sync_directory(args.output.expanduser().resolve(strict=False).parent)
         elif args.command == "check-output":
             if args.output.exists():
-                raise ManifestError(
-                    f"refusing to overwrite existing record: {args.output}"
-                )
+                raise ManifestError(f"refusing to overwrite existing record: {args.output}")
         elif args.command == "reserve":
             sys.stdout.write(
                 reserve(
@@ -931,6 +1017,28 @@ def main(argv: list[str] | None = None) -> int:
                     args.release,
                     args.namespace,
                 )
+                + "\n"
+            )
+        elif args.command == "staging-gate":
+            sys.stdout.write(
+                str(staging_gate(_object(args.manifest), _object(args.staging_evidence))) + "\n"
+            )
+        elif args.command == "runtime-args":
+            record = validate(_object(args.manifest), None)
+            sys.stdout.write(
+                "\t".join(
+                    str(record[field])
+                    for field in (
+                        "applicationVersion",
+                        "sourceRevision",
+                        "imageTag",
+                        "imageDigest",
+                        "expectedDefaultChatProvider",
+                        "chartVersion",
+                    )
+                )
+                + "\t"
+                + str(record.get("helmRevision", ""))
                 + "\n"
             )
         else:

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -15,6 +15,13 @@ import urllib.request
 from pathlib import Path
 from typing import Any, Callable
 
+# Support the documented direct-script invocation from any working directory.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.dspace_release_manifest import ManifestError, _image_id_digest
+
 CAPABILITIES = (
     "applicationVersion",
     "runtimeSourceRevision",
@@ -152,6 +159,12 @@ def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -
     chart = (
         helm_before.get("chart", {}).get("metadata", {}) if isinstance(helm_before, dict) else {}
     )
+    if not isinstance(helm_before, dict) or (
+        helm_before.get("name") != args.release
+        or helm_before.get("namespace") != args.namespace
+        or helm_before.get("info", {}).get("status") != "deployed"
+    ):
+        raise VerificationError("cluster identity: Helm release is not the expected deployment")
     if args.helm_revision is not None and helm_before.get("version") != args.helm_revision:
         raise VerificationError("concurrent Helm change: revision differs from approved evidence")
     if chart.get("name") != "dspace" or chart.get("version") != args.chart_version:
@@ -184,6 +197,40 @@ def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -
     items = pods.get("items", []) if isinstance(pods, dict) else []
     if not items:
         raise VerificationError("pod/replica identity: no serving replicas")
+    workloads = json_run(
+        runner,
+        [
+            "kubectl",
+            "--kubeconfig",
+            args.kubeconfig,
+            "-n",
+            args.namespace,
+            "get",
+            "replicasets,deployments",
+            "-l",
+            f"app.kubernetes.io/name=dspace,app.kubernetes.io/instance={args.release}",
+            "-o",
+            "json",
+        ],
+        "pod/replica identity",
+    )
+    workload_items = workloads.get("items", []) if isinstance(workloads, dict) else []
+    deployments = {
+        item.get("metadata", {}).get("name")
+        for item in workload_items
+        if item.get("kind") == "Deployment"
+    }
+    owned_replicasets = {
+        item.get("metadata", {}).get("name")
+        for item in workload_items
+        if item.get("kind") == "ReplicaSet"
+        and any(
+            owner.get("kind") == "Deployment"
+            and owner.get("controller") is True
+            and owner.get("name") in deployments
+            for owner in item.get("metadata", {}).get("ownerReferences", [])
+        )
+    }
     pod_names: list[str] = []
     for pod in items:
         metadata, status = pod.get("metadata", {}), pod.get("status", {})
@@ -198,19 +245,33 @@ def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -
             )
         ):
             raise VerificationError("pod/replica identity: stale, terminating, or unready replica")
+        if not any(
+            owner.get("kind") == "ReplicaSet"
+            and owner.get("controller") is True
+            and owner.get("name") in owned_replicasets
+            for owner in metadata.get("ownerReferences", [])
+        ):
+            raise VerificationError("pod/replica identity: replica is not owned by the release")
         container, container_status = application_container(pod)
         expected_image = f"{IMAGE_REF}:{args.image_tag}"
         if container.get("image") not in {expected_image, f"{expected_image}@{args.image_digest}"}:
             raise VerificationError("pod/replica identity: image coordinate mismatch")
-        if not str(container_status.get("imageID", "")).endswith(args.image_digest):
+        try:
+            observed_digest = _image_id_digest(container_status.get("imageID", ""))
+        except (ManifestError, TypeError) as exc:
+            raise VerificationError("pod/replica identity: image digest mismatch") from exc
+        if observed_digest != args.image_digest:
             raise VerificationError("pod/replica identity: image digest mismatch")
         base = f"/api/v1/namespaces/{args.namespace}/pods/{name}:{args.pod_port}/proxy"
-        raw_info = runner(
-            ["kubectl", "--kubeconfig", args.kubeconfig, "get", "--raw", base + "/build-info.json"]
-        ).encode()
-        raw_html = runner(
-            ["kubectl", "--kubeconfig", args.kubeconfig, "get", "--raw", base + "/"]
-        ).encode()
+        try:
+            raw_info = runner(
+                ["kubectl", "--kubeconfig", args.kubeconfig, "get", "--raw", base + "/build-info.json"]
+            ).encode()
+            raw_html = runner(
+                ["kubectl", "--kubeconfig", args.kubeconfig, "get", "--raw", base + "/"]
+            ).encode()
+        except (OSError, VerificationError) as exc:
+            raise VerificationError("direct identity: endpoint was unreachable") from exc
         identity(
             raw_info,
             args.application_version,
@@ -290,7 +351,7 @@ def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -
     if smoke_result.returncode:
         raise VerificationError("provider/chat smoke: non-destructive /chat proof failed")
     helm_after = json_run(runner, helm_command, "concurrent Helm change")
-    if helm_after.get("version") != helm_before.get("version"):
+    if helm_after != helm_before:
         raise VerificationError("concurrent Helm change: revision changed during verification")
     return {
         "schemaVersion": 1,

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib
 import json
 import os
 import re
@@ -20,7 +21,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.dspace_release_manifest import ManifestError, _image_id_digest
+_manifest = importlib.import_module("scripts.dspace_release_manifest")
+ManifestError = _manifest.ManifestError
+_image_id_digest = _manifest._image_id_digest
 
 CAPABILITIES = (
     "applicationVersion",
@@ -139,6 +142,31 @@ def application_container(pod: dict[str, Any]) -> tuple[dict[str, Any], dict[str
     return containers[0], statuses[0]
 
 
+def release_owned(metadata: dict[str, Any], release: str, namespace: str) -> bool:
+    """Return whether metadata has the complete Helm release identity."""
+    labels = metadata.get("labels", {})
+    annotations = metadata.get("annotations", {})
+    return (
+        labels.get("app.kubernetes.io/name") == "dspace"
+        and labels.get("app.kubernetes.io/instance") == release
+        and labels.get("app.kubernetes.io/managed-by") == "Helm"
+        and annotations.get("meta.helm.sh/release-name") == release
+        and annotations.get("meta.helm.sh/release-namespace") == namespace
+    )
+
+
+def controller_owner(metadata: dict[str, Any], kind: str) -> tuple[str, str] | None:
+    owners = [
+        owner
+        for owner in metadata.get("ownerReferences", [])
+        if owner.get("kind") == kind and owner.get("controller") is True
+    ]
+    if len(owners) != 1:
+        return None
+    name, uid = owners[0].get("name"), owners[0].get("uid")
+    return (name, uid) if isinstance(name, str) and isinstance(uid, str) and uid else None
+
+
 def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -> dict[str, Any]:
     smoke = args.smoke_runner.expanduser()
     if not smoke.is_file() or not os.access(smoke, os.X_OK):
@@ -177,6 +205,65 @@ def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -
         "public identity",
     )
     marker(public_fetch(origin + "/", origin), args.source_revision, "public identity")
+    deployment = json_run(
+        runner,
+        [
+            "kubectl",
+            "--kubeconfig",
+            args.kubeconfig,
+            "-n",
+            args.namespace,
+            "get",
+            "deployment",
+            args.release,
+            "-o",
+            "json",
+        ],
+        "cluster identity",
+    )
+    deployment_metadata = deployment.get("metadata", {}) if isinstance(deployment, dict) else {}
+    deployment_uid = deployment_metadata.get("uid")
+    containers = (
+        deployment.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+        if isinstance(deployment, dict)
+        else []
+    )
+    deployed_containers = [item for item in containers if item.get("name") == "dspace"]
+    expected_image = f"{IMAGE_REF}:{args.image_tag}"
+    if len(deployed_containers) != 1 or deployed_containers[0].get("image") not in {
+        expected_image,
+        f"{expected_image}@{args.image_digest}",
+    }:
+        raise VerificationError("cluster identity: live Deployment image identity mismatch")
+    http_ports = [
+        port for port in deployed_containers[0].get("ports", []) if port.get("name") == "http"
+    ]
+    if (
+        len(http_ports) != 1
+        or http_ports[0].get("protocol", "TCP") != "TCP"
+        or not isinstance(http_ports[0].get("containerPort"), int)
+        or isinstance(http_ports[0].get("containerPort"), bool)
+        or not 1 <= http_ports[0]["containerPort"] <= 65535
+    ):
+        raise VerificationError("cluster identity: live Deployment has invalid named http port")
+    pod_port = http_ports[0]["containerPort"]
+    spec, status = deployment.get("spec", {}), deployment.get("status", {})
+    desired = spec.get("replicas")
+    generation = deployment_metadata.get("generation")
+    if (
+        not release_owned(deployment_metadata, args.release, args.namespace)
+        or not isinstance(deployment_uid, str)
+        or not deployment_uid
+        or not isinstance(desired, int)
+        or isinstance(desired, bool)
+        or desired <= 0
+        or status.get("observedGeneration") != generation
+        or status.get("updatedReplicas") != desired
+        or status.get("readyReplicas") != desired
+        or status.get("availableReplicas") != desired
+        or status.get("unavailableReplicas", 0) != 0
+    ):
+        raise VerificationError("cluster identity: Deployment rollout is incomplete or unowned")
     pods = json_run(
         runner,
         [
@@ -195,8 +282,8 @@ def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -
         "pod/replica identity",
     )
     items = pods.get("items", []) if isinstance(pods, dict) else []
-    if not items:
-        raise VerificationError("pod/replica identity: no serving replicas")
+    if len(items) != desired:
+        raise VerificationError("pod/replica identity: observed replica count is incomplete")
     workloads = json_run(
         runner,
         [
@@ -206,7 +293,7 @@ def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -
             "-n",
             args.namespace,
             "get",
-            "replicasets,deployments",
+            "replicasets",
             "-l",
             f"app.kubernetes.io/name=dspace,app.kubernetes.io/instance={args.release}",
             "-o",
@@ -215,21 +302,13 @@ def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -
         "pod/replica identity",
     )
     workload_items = workloads.get("items", []) if isinstance(workloads, dict) else []
-    deployments = {
-        item.get("metadata", {}).get("name")
-        for item in workload_items
-        if item.get("kind") == "Deployment"
-    }
     owned_replicasets = {
-        item.get("metadata", {}).get("name")
+        (item.get("metadata", {}).get("name"), item.get("metadata", {}).get("uid"))
         for item in workload_items
         if item.get("kind") == "ReplicaSet"
-        and any(
-            owner.get("kind") == "Deployment"
-            and owner.get("controller") is True
-            and owner.get("name") in deployments
-            for owner in item.get("metadata", {}).get("ownerReferences", [])
-        )
+        and release_owned(item.get("metadata", {}), args.release, args.namespace)
+        and controller_owner(item.get("metadata", {}), "Deployment")
+        == (args.release, deployment_uid)
     }
     pod_names: list[str] = []
     for pod in items:
@@ -245,15 +324,12 @@ def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -
             )
         ):
             raise VerificationError("pod/replica identity: stale, terminating, or unready replica")
-        if not any(
-            owner.get("kind") == "ReplicaSet"
-            and owner.get("controller") is True
-            and owner.get("name") in owned_replicasets
-            for owner in metadata.get("ownerReferences", [])
+        if (
+            not release_owned(metadata, args.release, args.namespace)
+            or controller_owner(metadata, "ReplicaSet") not in owned_replicasets
         ):
             raise VerificationError("pod/replica identity: replica is not owned by the release")
         container, container_status = application_container(pod)
-        expected_image = f"{IMAGE_REF}:{args.image_tag}"
         if container.get("image") not in {expected_image, f"{expected_image}@{args.image_digest}"}:
             raise VerificationError("pod/replica identity: image coordinate mismatch")
         try:
@@ -262,13 +338,29 @@ def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -
             raise VerificationError("pod/replica identity: image digest mismatch") from exc
         if observed_digest != args.image_digest:
             raise VerificationError("pod/replica identity: image digest mismatch")
-        base = f"/api/v1/namespaces/{args.namespace}/pods/{name}:{args.pod_port}/proxy"
+        base = f"/api/v1/namespaces/{args.namespace}/pods/{name}:{pod_port}/proxy"
         try:
             raw_info = runner(
-                ["kubectl", "--kubeconfig", args.kubeconfig, "get", "--raw", base + "/build-info.json"]
+                [
+                    "kubectl",
+                    "--kubeconfig",
+                    args.kubeconfig,
+                    "--request-timeout=15s",
+                    "get",
+                    "--raw",
+                    base + "/build-info.json",
+                ]
             ).encode()
             raw_html = runner(
-                ["kubectl", "--kubeconfig", args.kubeconfig, "get", "--raw", base + "/"]
+                [
+                    "kubectl",
+                    "--kubeconfig",
+                    args.kubeconfig,
+                    "--request-timeout=15s",
+                    "get",
+                    "--raw",
+                    base + "/",
+                ]
             ).encode()
         except (OSError, VerificationError) as exc:
             raise VerificationError("direct identity: endpoint was unreachable") from exc
@@ -282,32 +374,6 @@ def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -
         marker(raw_html, args.source_revision, "direct identity")
         pod_names.append(name)
     values = environment_values(args.values)
-    deployment = json_run(
-        runner,
-        [
-            "kubectl",
-            "--kubeconfig",
-            args.kubeconfig,
-            "-n",
-            args.namespace,
-            "get",
-            "deployment",
-            args.release,
-            "-o",
-            "json",
-        ],
-        "cluster identity",
-    )
-    deployed_containers = [
-        item
-        for item in deployment.get("spec", {})
-        .get("template", {})
-        .get("spec", {})
-        .get("containers", [])
-        if item.get("name") == "dspace"
-    ]
-    if len(deployed_containers) != 1:
-        raise VerificationError("cluster identity: live Deployment lacks named dspace container")
     deployed_env = {
         item.get("name"): item.get("value")
         for item in deployed_containers[0].get("env", [])
@@ -386,7 +452,6 @@ def parser() -> argparse.ArgumentParser:
             command.add_argument("--values", type=Path, action="append", default=[])
             command.add_argument("--smoke-runner", type=Path, required=True)
             command.add_argument("--kubeconfig", required=True)
-            command.add_argument("--pod-port", type=int, default=3000)
     return root
 
 

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -155,11 +155,25 @@ def release_owned(metadata: dict[str, Any], release: str, namespace: str) -> boo
     )
 
 
+def selector_owned(metadata: dict[str, Any], release: str) -> bool:
+    """Return whether workload metadata has the chart's selector labels."""
+    labels = metadata.get("labels", {})
+    return isinstance(labels, dict) and (
+        labels.get("app.kubernetes.io/name") == "dspace"
+        and labels.get("app.kubernetes.io/instance") == release
+    )
+
+
 def controller_owner(metadata: dict[str, Any], kind: str) -> tuple[str, str] | None:
+    references = metadata.get("ownerReferences", [])
+    if not isinstance(references, list):
+        return None
     owners = [
         owner
-        for owner in metadata.get("ownerReferences", [])
-        if owner.get("kind") == kind and owner.get("controller") is True
+        for owner in references
+        if isinstance(owner, dict)
+        and owner.get("kind") == kind
+        and owner.get("controller") is True
     ]
     if len(owners) != 1:
         return None
@@ -222,6 +236,7 @@ def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -
         "cluster identity",
     )
     deployment_metadata = deployment.get("metadata", {}) if isinstance(deployment, dict) else {}
+    deployment_name = deployment_metadata.get("name")
     deployment_uid = deployment_metadata.get("uid")
     containers = (
         deployment.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
@@ -252,6 +267,8 @@ def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -
     generation = deployment_metadata.get("generation")
     if (
         not release_owned(deployment_metadata, args.release, args.namespace)
+        or not isinstance(deployment_name, str)
+        or not deployment_name
         or not isinstance(deployment_uid, str)
         or not deployment_uid
         or not isinstance(desired, int)
@@ -302,14 +319,24 @@ def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -
         "pod/replica identity",
     )
     workload_items = workloads.get("items", []) if isinstance(workloads, dict) else []
-    owned_replicasets = {
-        (item.get("metadata", {}).get("name"), item.get("metadata", {}).get("uid"))
-        for item in workload_items
-        if item.get("kind") == "ReplicaSet"
-        and release_owned(item.get("metadata", {}), args.release, args.namespace)
-        and controller_owner(item.get("metadata", {}), "Deployment")
-        == (args.release, deployment_uid)
-    }
+    owned_replicasets: set[tuple[str, str]] = set()
+    for item in workload_items:
+        metadata = item.get("metadata", {}) if isinstance(item, dict) else {}
+        name, uid = metadata.get("name"), metadata.get("uid")
+        if (
+            not isinstance(item, dict)
+            or item.get("kind") != "ReplicaSet"
+            or not selector_owned(metadata, args.release)
+            or not isinstance(name, str)
+            or not name
+            or not isinstance(uid, str)
+            or not uid
+            or controller_owner(metadata, "Deployment") != (deployment_name, deployment_uid)
+        ):
+            raise VerificationError("pod/replica identity: ReplicaSet is not owned by Deployment")
+        if (name, uid) in owned_replicasets:
+            raise VerificationError("pod/replica identity: duplicate ReplicaSet identity")
+        owned_replicasets.add((name, uid))
     pod_names: list[str] = []
     for pod in items:
         metadata, status = pod.get("metadata", {}), pod.get("status", {})
@@ -325,7 +352,7 @@ def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -
         ):
             raise VerificationError("pod/replica identity: stale, terminating, or unready replica")
         if (
-            not release_owned(metadata, args.release, args.namespace)
+            not selector_owned(metadata, args.release)
             or controller_owner(metadata, "ReplicaSet") not in owned_replicasets
         ):
             raise VerificationError("pod/replica identity: replica is not owned by the release")

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -108,7 +108,12 @@ def environment_values(paths: list[Path]) -> dict[str, str]:
         for line in lines:
             found_name = re.match(r"^\s*-\s+name:\s*([A-Z0-9_]+)\s*$", line)
             if found_name:
-                name = found_name.group(1)
+                candidate = found_name.group(1)
+                name = (
+                    candidate
+                    if candidate in {"DSPACE_TOKEN_PLACE_URL", "DSPACE_TOKEN_PLACE_CHAT_MODEL"}
+                    else None
+                )
                 continue
             found_value = re.match(r"^\s+value:\s*[\"']?([^\"'#]+?)[\"']?\s*(?:#.*)?$", line)
             if found_value and name:
@@ -147,7 +152,7 @@ def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -
     chart = (
         helm_before.get("chart", {}).get("metadata", {}) if isinstance(helm_before, dict) else {}
     )
-    if helm_before.get("version") != args.helm_revision if args.helm_revision else False:
+    if args.helm_revision is not None and helm_before.get("version") != args.helm_revision:
         raise VerificationError("concurrent Helm change: revision differs from approved evidence")
     if chart.get("name") != "dspace" or chart.get("version") != args.chart_version:
         raise VerificationError("cluster identity: installed chart identity mismatch")

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -59,8 +59,8 @@ def run(command: list[str]) -> str:
 def json_run(runner: Runner, command: list[str], stage: str) -> Any:
     try:
         return json.loads(runner(command))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise VerificationError(f"{stage}: command did not return valid JSON") from exc
+    except (OSError, VerificationError, json.JSONDecodeError):
+        raise VerificationError(f"{stage}: command did not return valid JSON") from None
 
 
 def fetch(url: str, expected_origin: str, opener=urllib.request.urlopen) -> bytes:
@@ -171,14 +171,21 @@ def controller_owner(metadata: dict[str, Any], kind: str) -> tuple[str, str] | N
     owners = [
         owner
         for owner in references
-        if isinstance(owner, dict)
-        and owner.get("kind") == kind
-        and owner.get("controller") is True
+        if isinstance(owner, dict) and owner.get("controller") is True
     ]
     if len(owners) != 1:
         return None
-    name, uid = owners[0].get("name"), owners[0].get("uid")
-    return (name, uid) if isinstance(name, str) and isinstance(uid, str) and uid else None
+    owner = owners[0]
+    name, uid = owner.get("name"), owner.get("uid")
+    return (
+        (name, uid)
+        if owner.get("kind") == kind
+        and isinstance(name, str)
+        and name
+        and isinstance(uid, str)
+        and uid
+        else None
+    )
 
 
 def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -> dict[str, Any]:

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Prove DSPACE runtime identity and the non-destructive public /chat journey."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+
+CAPABILITIES = (
+    "applicationVersion",
+    "runtimeSourceRevision",
+    "frontendSourceRevision",
+    "defaultProvider",
+    "publicJourneys",
+)
+IMAGE_REF = "ghcr.io/democratizedspace/dspace"
+REVISION_META = re.compile(
+    rb'<meta\s+name=["\']dspace-build-revision["\']\s+content=["\']([^"\']+)["\']',
+    re.IGNORECASE,
+)
+
+
+class VerificationError(ValueError):
+    """A bounded, non-secret verification failure."""
+
+
+Runner = Callable[[list[str]], str]
+
+
+def run(command: list[str]) -> str:
+    try:
+        completed = subprocess.run(command, capture_output=True, check=False, text=True)
+    except OSError as exc:
+        raise VerificationError(f"cluster identity: could not execute {command[0]}") from exc
+    if completed.returncode:
+        raise VerificationError(f"cluster identity: {command[0]} command failed")
+    return completed.stdout
+
+
+def json_run(runner: Runner, command: list[str], stage: str) -> Any:
+    try:
+        return json.loads(runner(command))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise VerificationError(f"{stage}: command did not return valid JSON") from exc
+
+
+def fetch(url: str, expected_origin: str, opener=urllib.request.urlopen) -> bytes:
+    request = urllib.request.Request(url, headers={"Accept": "application/json,text/html"})
+    try:
+        with opener(request, timeout=15) as response:
+            final = urllib.parse.urlsplit(response.geturl())
+            expected = urllib.parse.urlsplit(expected_origin)
+            if (final.scheme, final.netloc) != (expected.scheme, expected.netloc):
+                raise VerificationError("public identity: redirect crossed the approved origin")
+            return response.read(1_048_577)
+    except VerificationError:
+        raise
+    except (OSError, urllib.error.URLError) as exc:
+        raise VerificationError("public identity: endpoint was unreachable") from exc
+
+
+def identity(raw: bytes, version: str, revision: str, image_tag: str, stage: str) -> None:
+    if len(raw) > 1_048_576:
+        raise VerificationError(f"{stage}: response exceeded the bounded limit")
+    try:
+        value = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise VerificationError(f"{stage}: build identity was malformed") from exc
+    if not isinstance(value, dict):
+        raise VerificationError(f"{stage}: build identity was malformed")
+    if value.get("version") != version or value.get("revision") != revision:
+        raise VerificationError(f"{stage}: version or revision mismatch")
+    if value.get("shortRevision") != revision[:7]:
+        raise VerificationError(f"{stage}: short revision mismatch")
+    coordinate = value.get("image") or value.get("imageCoordinate")
+    if coordinate is not None and coordinate not in {image_tag, f"{IMAGE_REF}:{image_tag}"}:
+        raise VerificationError(f"{stage}: runtime image coordinate mismatch")
+
+
+def marker(raw: bytes, revision: str, stage: str) -> None:
+    if len(raw) > 1_048_576:
+        raise VerificationError(f"{stage}: response exceeded the bounded limit")
+    match = REVISION_META.search(raw)
+    if match is None or match.group(1).decode("utf-8", "replace") != revision:
+        raise VerificationError(f"{stage}: frontend revision marker mismatch")
+
+
+def environment_values(paths: list[Path]) -> dict[str, str]:
+    """Read only the reviewed DSPACE env scalar pairs from the ordered values chain."""
+    result: dict[str, str] = {}
+    name: str | None = None
+    for path in paths:
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            raise VerificationError(
+                "manifest/evidence mismatch: values chain is unreadable"
+            ) from exc
+        for line in lines:
+            found_name = re.match(r"^\s*-\s+name:\s*([A-Z0-9_]+)\s*$", line)
+            if found_name:
+                name = found_name.group(1)
+                continue
+            found_value = re.match(r"^\s+value:\s*[\"']?([^\"'#]+?)[\"']?\s*(?:#.*)?$", line)
+            if found_value and name:
+                result[name] = found_value.group(1).strip()
+                name = None
+    return result
+
+
+def application_container(pod: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    containers = [x for x in pod.get("spec", {}).get("containers", []) if x.get("name") == "dspace"]
+    statuses = [
+        x for x in pod.get("status", {}).get("containerStatuses", []) if x.get("name") == "dspace"
+    ]
+    if len(containers) != 1 or len(statuses) != 1:
+        raise VerificationError("pod/replica identity: missing named dspace container")
+    return containers[0], statuses[0]
+
+
+def verify(args: argparse.Namespace, runner: Runner = run, public_fetch=fetch) -> dict[str, Any]:
+    smoke = args.smoke_runner.expanduser()
+    if not smoke.is_file() or not os.access(smoke, os.X_OK):
+        raise VerificationError("provider/chat smoke: runner must be an existing executable file")
+    origin = f"https://{args.host}"
+    helm_command = [
+        "helm",
+        "--kubeconfig",
+        args.kubeconfig,
+        "status",
+        args.release,
+        "--namespace",
+        args.namespace,
+        "-o",
+        "json",
+    ]
+    helm_before = json_run(runner, helm_command, "cluster identity")
+    chart = (
+        helm_before.get("chart", {}).get("metadata", {}) if isinstance(helm_before, dict) else {}
+    )
+    if helm_before.get("version") != args.helm_revision if args.helm_revision else False:
+        raise VerificationError("concurrent Helm change: revision differs from approved evidence")
+    if chart.get("name") != "dspace" or chart.get("version") != args.chart_version:
+        raise VerificationError("cluster identity: installed chart identity mismatch")
+    identity(
+        public_fetch(origin + "/build-info.json", origin),
+        args.application_version,
+        args.source_revision,
+        args.image_tag,
+        "public identity",
+    )
+    marker(public_fetch(origin + "/", origin), args.source_revision, "public identity")
+    pods = json_run(
+        runner,
+        [
+            "kubectl",
+            "--kubeconfig",
+            args.kubeconfig,
+            "-n",
+            args.namespace,
+            "get",
+            "pods",
+            "-l",
+            f"app.kubernetes.io/name=dspace,app.kubernetes.io/instance={args.release}",
+            "-o",
+            "json",
+        ],
+        "pod/replica identity",
+    )
+    items = pods.get("items", []) if isinstance(pods, dict) else []
+    if not items:
+        raise VerificationError("pod/replica identity: no serving replicas")
+    pod_names: list[str] = []
+    for pod in items:
+        metadata, status = pod.get("metadata", {}), pod.get("status", {})
+        name = metadata.get("name")
+        if (
+            not isinstance(name, str)
+            or metadata.get("deletionTimestamp") is not None
+            or status.get("phase") != "Running"
+            or not any(
+                x.get("type") == "Ready" and x.get("status") == "True"
+                for x in status.get("conditions", [])
+            )
+        ):
+            raise VerificationError("pod/replica identity: stale, terminating, or unready replica")
+        container, container_status = application_container(pod)
+        expected_image = f"{IMAGE_REF}:{args.image_tag}"
+        if container.get("image") not in {expected_image, f"{expected_image}@{args.image_digest}"}:
+            raise VerificationError("pod/replica identity: image coordinate mismatch")
+        if not str(container_status.get("imageID", "")).endswith(args.image_digest):
+            raise VerificationError("pod/replica identity: image digest mismatch")
+        base = f"/api/v1/namespaces/{args.namespace}/pods/{name}:{args.pod_port}/proxy"
+        raw_info = runner(
+            ["kubectl", "--kubeconfig", args.kubeconfig, "get", "--raw", base + "/build-info.json"]
+        ).encode()
+        raw_html = runner(
+            ["kubectl", "--kubeconfig", args.kubeconfig, "get", "--raw", base + "/"]
+        ).encode()
+        identity(
+            raw_info,
+            args.application_version,
+            args.source_revision,
+            args.image_tag,
+            "direct identity",
+        )
+        marker(raw_html, args.source_revision, "direct identity")
+        pod_names.append(name)
+    values = environment_values(args.values)
+    deployment = json_run(
+        runner,
+        [
+            "kubectl",
+            "--kubeconfig",
+            args.kubeconfig,
+            "-n",
+            args.namespace,
+            "get",
+            "deployment",
+            args.release,
+            "-o",
+            "json",
+        ],
+        "cluster identity",
+    )
+    deployed_containers = [
+        item
+        for item in deployment.get("spec", {})
+        .get("template", {})
+        .get("spec", {})
+        .get("containers", [])
+        if item.get("name") == "dspace"
+    ]
+    if len(deployed_containers) != 1:
+        raise VerificationError("cluster identity: live Deployment lacks named dspace container")
+    deployed_env = {
+        item.get("name"): item.get("value")
+        for item in deployed_containers[0].get("env", [])
+        if isinstance(item, dict) and isinstance(item.get("value"), str)
+    }
+    smoke_command = [
+        str(smoke),
+        "--base-url",
+        origin,
+        "--expected-version",
+        args.application_version,
+        "--expected-revision",
+        args.source_revision,
+        "--expected-provider",
+        args.provider,
+    ]
+    if args.provider == "token-place":
+        token_origin = values.get("DSPACE_TOKEN_PLACE_URL")
+        token_model = values.get("DSPACE_TOKEN_PLACE_CHAT_MODEL")
+        if not token_origin or not token_model:
+            raise VerificationError(
+                "provider/chat smoke: reviewed token.place expectations are missing"
+            )
+        if (
+            deployed_env.get("DSPACE_TOKEN_PLACE_URL") != token_origin
+            or deployed_env.get("DSPACE_TOKEN_PLACE_CHAT_MODEL") != token_model
+        ):
+            raise VerificationError(
+                "cluster identity: live Deployment routing differs from reviewed values"
+            )
+        smoke_command += [
+            "--expected-token-place-origin",
+            token_origin,
+            "--expected-token-place-model",
+            token_model,
+        ]
+    try:
+        smoke_result = subprocess.run(smoke_command, capture_output=True, check=False, text=True)
+    except OSError as exc:
+        raise VerificationError("provider/chat smoke: runner could not be executed") from exc
+    if smoke_result.returncode:
+        raise VerificationError("provider/chat smoke: non-destructive /chat proof failed")
+    helm_after = json_run(runner, helm_command, "concurrent Helm change")
+    if helm_after.get("version") != helm_before.get("version"):
+        raise VerificationError("concurrent Helm change: revision changed during verification")
+    return {
+        "schemaVersion": 1,
+        "environment": args.environment,
+        "release": args.release,
+        "namespace": args.namespace,
+        "applicationVersion": args.application_version,
+        "runtimeSourceRevision": args.source_revision,
+        "frontendSourceRevision": args.source_revision,
+        "defaultProvider": args.provider,
+        "journeys": [{"name": "/", "passed": True}, {"name": "/chat", "passed": True}],
+    }
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    commands = root.add_subparsers(dest="command", required=True)
+    for name in ("capabilities", "verify"):
+        command = commands.add_parser(name)
+        command.add_argument("--environment", choices=("staging", "prod"), required=True)
+        command.add_argument("--release", required=True)
+        command.add_argument("--namespace", required=True)
+        if name == "verify":
+            command.add_argument("--application-version", required=True)
+            command.add_argument("--source-revision", required=True)
+            command.add_argument("--provider", choices=("token-place", "openai"), required=True)
+            command.add_argument("--image-tag", required=True)
+            command.add_argument("--image-digest", required=True)
+            command.add_argument("--chart-version", required=True)
+            command.add_argument("--helm-revision", type=int)
+            command.add_argument("--host", required=True)
+            command.add_argument("--values", type=Path, action="append", default=[])
+            command.add_argument("--smoke-runner", type=Path, required=True)
+            command.add_argument("--kubeconfig", required=True)
+            command.add_argument("--pod-port", type=int, default=3000)
+    return root
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        if args.command == "capabilities":
+            result = {
+                "schemaVersion": 1,
+                "environment": args.environment,
+                "release": args.release,
+                "namespace": args.namespace,
+                "capabilities": list(CAPABILITIES),
+            }
+        else:
+            result = verify(args)
+        print(json.dumps(result, separators=(",", ":")))
+    except VerificationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -53,7 +53,8 @@ def test_values_chain_uses_last_reviewed_token_place_values(tmp_path: Path) -> N
     )
     overlay.write_text(
         "env:\n  - name: DSPACE_TOKEN_PLACE_URL\n    value: https://staging.token.place\n"
-        "  - name: DSPACE_TOKEN_PLACE_CHAT_MODEL\n    value: reviewed-model\n",
+        "  - name: DSPACE_TOKEN_PLACE_CHAT_MODEL\n    value: reviewed-model\n"
+        "  - name: UNRELATED_SETTING\n    value: ignored-value\n",
         encoding="utf-8",
     )
     assert verifier.environment_values([base, overlay]) == {

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -32,6 +32,16 @@ def helm_metadata(uid: str) -> dict:
     }
 
 
+def workload_metadata(uid: str) -> dict:
+    return {
+        "uid": uid,
+        "labels": {
+            "app.kubernetes.io/name": "dspace",
+            "app.kubernetes.io/instance": "dspace",
+        },
+    }
+
+
 def runtime_fixture(
     tmp_path: Path,
 ) -> tuple[Namespace, dict, list[list[str]], Callable[[list[str]], str]]:
@@ -65,7 +75,7 @@ def runtime_fixture(
             "unavailableReplicas": 0,
         },
     }
-    rs_metadata = helm_metadata("rs-uid")
+    rs_metadata = workload_metadata("rs-uid")
     rs_metadata.update(
         {
             "name": "dspace-rs",
@@ -79,7 +89,7 @@ def runtime_fixture(
             ],
         }
     )
-    pod_metadata = helm_metadata("pod-uid")
+    pod_metadata = workload_metadata("pod-uid")
     pod_metadata.update(
         {
             "name": "dspace-0",
@@ -230,7 +240,7 @@ def test_smoke_is_exact_argv_and_child_output_is_suppressed(
     html = f'<meta name="dspace-build-revision" content="{SHA}">'.encode()
     pod = {
         "metadata": {
-            **helm_metadata("pod-uid"),
+            **workload_metadata("pod-uid"),
             "name": "dspace-0",
             "ownerReferences": [
                 {
@@ -274,7 +284,7 @@ def test_smoke_is_exact_argv_and_child_output_is_suppressed(
                         {
                             "kind": "ReplicaSet",
                             "metadata": {
-                                **helm_metadata("rs-uid"),
+                                **workload_metadata("rs-uid"),
                                 "name": "dspace-rs",
                                 "ownerReferences": [
                                     {
@@ -449,6 +459,55 @@ def test_forged_owner_uids_fail_closed(tmp_path: Path, owner_level: str) -> None
     else:
         state["pods"][0]["metadata"]["ownerReferences"][0]["uid"] = "forged"
     with pytest.raises(verifier.VerificationError, match="unowned|not owned"):
+        verifier.verify(args, runner, lambda url, _origin: _public_body(url))
+
+
+@pytest.mark.parametrize("workload", ["replicaset", "pod"])
+def test_workload_selector_labels_fail_closed(tmp_path: Path, workload: str) -> None:
+    args, state, _calls, runner = runtime_fixture(tmp_path)
+    key = "replicasets" if workload == "replicaset" else "pods"
+    state[key][0]["metadata"]["labels"]["app.kubernetes.io/instance"] = "forged"
+    with pytest.raises(verifier.VerificationError, match="not owned"):
+        verifier.verify(args, runner, lambda url, _origin: _public_body(url))
+
+
+@pytest.mark.parametrize("workload", ["replicaset", "pod"])
+@pytest.mark.parametrize("owner_shape", [[], "malformed", None])
+def test_missing_or_malformed_controller_reference_is_bounded(
+    tmp_path: Path, workload: str, owner_shape
+) -> None:
+    args, state, _calls, runner = runtime_fixture(tmp_path)
+    key = "replicasets" if workload == "replicaset" else "pods"
+    state[key][0]["metadata"]["ownerReferences"] = owner_shape
+    with pytest.raises(verifier.VerificationError, match="not owned"):
+        verifier.verify(args, runner, lambda url, _origin: _public_body(url))
+
+
+@pytest.mark.parametrize("workload", ["replicaset", "pod"])
+def test_duplicate_controller_reference_fails_closed(tmp_path: Path, workload: str) -> None:
+    args, state, _calls, runner = runtime_fixture(tmp_path)
+    key = "replicasets" if workload == "replicaset" else "pods"
+    references = state[key][0]["metadata"]["ownerReferences"]
+    references.append(dict(references[0]))
+    with pytest.raises(verifier.VerificationError, match="not owned"):
+        verifier.verify(args, runner, lambda url, _origin: _public_body(url))
+
+
+@pytest.mark.parametrize("workload", ["replicaset", "pod"])
+def test_wrong_controller_name_fails_closed(tmp_path: Path, workload: str) -> None:
+    args, state, _calls, runner = runtime_fixture(tmp_path)
+    key = "replicasets" if workload == "replicaset" else "pods"
+    state[key][0]["metadata"]["ownerReferences"][0]["name"] = "forged"
+    with pytest.raises(verifier.VerificationError, match="not owned"):
+        verifier.verify(args, runner, lambda url, _origin: _public_body(url))
+
+
+def test_pod_owned_by_unknown_replicaset_fails_closed(tmp_path: Path) -> None:
+    args, state, _calls, runner = runtime_fixture(tmp_path)
+    state["pods"][0]["metadata"]["ownerReferences"][0].update(
+        {"name": "unknown", "uid": "unknown-uid"}
+    )
+    with pytest.raises(verifier.VerificationError, match="not owned"):
         verifier.verify(args, runner, lambda url, _origin: _public_body(url))
 
 

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -89,7 +89,12 @@ def test_smoke_is_exact_argv_and_child_output_is_suppressed(
     build = json.dumps({"version": "3.2.0", "revision": SHA, "shortRevision": SHA[:7]}).encode()
     html = f'<meta name="dspace-build-revision" content="{SHA}">'.encode()
     pod = {
-        "metadata": {"name": "dspace-0"},
+        "metadata": {
+            "name": "dspace-0",
+            "ownerReferences": [
+                {"kind": "ReplicaSet", "name": "dspace-rs", "controller": True}
+            ],
+        },
         "spec": {
             "containers": [
                 {"name": "dspace", "image": "ghcr.io/democratizedspace/dspace:main-abcdef0"}
@@ -105,10 +110,37 @@ def test_smoke_is_exact_argv_and_child_output_is_suppressed(
     def runner(command: list[str]) -> str:
         if command[0] == "helm":
             return json.dumps(
-                {"version": 7, "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}}}
+                {
+                    "name": "dspace",
+                    "namespace": "dspace",
+                    "version": 7,
+                    "info": {"status": "deployed"},
+                    "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}},
+                }
             )
         if "pods" in command:
             return json.dumps({"items": [pod]})
+        if "replicasets,deployments" in command:
+            return json.dumps(
+                {
+                    "items": [
+                        {"kind": "Deployment", "metadata": {"name": "dspace"}},
+                        {
+                            "kind": "ReplicaSet",
+                            "metadata": {
+                                "name": "dspace-rs",
+                                "ownerReferences": [
+                                    {
+                                        "kind": "Deployment",
+                                        "name": "dspace",
+                                        "controller": True,
+                                    }
+                                ],
+                            },
+                        },
+                    ]
+                }
+            )
         if "deployment" in command:
             return json.dumps(
                 {

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -493,6 +493,21 @@ def test_duplicate_controller_reference_fails_closed(tmp_path: Path, workload: s
         verifier.verify(args, runner, lambda url, _origin: _public_body(url))
 
 
+@pytest.mark.parametrize(
+    ("workload", "other_kind"), [("replicaset", "StatefulSet"), ("pod", "Deployment")]
+)
+def test_different_kind_duplicate_controller_fails_closed(
+    tmp_path: Path, workload: str, other_kind: str
+) -> None:
+    args, state, _calls, runner = runtime_fixture(tmp_path)
+    key = "replicasets" if workload == "replicaset" else "pods"
+    state[key][0]["metadata"]["ownerReferences"].append(
+        {"kind": other_kind, "name": "other", "uid": "other-uid", "controller": True}
+    )
+    with pytest.raises(verifier.VerificationError, match="not owned"):
+        verifier.verify(args, runner, lambda url, _origin: _public_body(url))
+
+
 @pytest.mark.parametrize("workload", ["replicaset", "pod"])
 def test_wrong_controller_name_fails_closed(tmp_path: Path, workload: str) -> None:
     args, state, _calls, runner = runtime_fixture(tmp_path)
@@ -555,6 +570,53 @@ def test_command_adapters_return_bounded_errors(monkeypatch: pytest.MonkeyPatch)
 
     with pytest.raises(verifier.VerificationError, match="valid JSON"):
         verifier.json_run(lambda _command: "not-json secret", ["helm"], "cluster identity")
+
+
+@pytest.mark.parametrize("resource", ["pods", "replicasets"])
+def test_discovery_adapter_failure_uses_pod_replica_stage(
+    tmp_path: Path, resource: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args, _state, _calls, base_runner = runtime_fixture(tmp_path)
+
+    def runner(command: list[str]) -> str:
+        if resource in command:
+            raise verifier.VerificationError("cluster identity: SENTINEL_SECRET")
+        return base_runner(command)
+
+    with pytest.raises(verifier.VerificationError, match="^pod/replica identity:") as caught:
+        verifier.verify(args, runner, lambda url, _origin: _public_body(url))
+    captured = capsys.readouterr()
+    assert "SENTINEL_SECRET" not in str(caught.value)
+    assert "SENTINEL_SECRET" not in captured.out + captured.err
+
+
+def test_final_helm_adapter_failure_uses_concurrent_change_stage(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args, _state, _calls, base_runner = runtime_fixture(tmp_path)
+    helm_reads = 0
+
+    def runner(command: list[str]) -> str:
+        nonlocal helm_reads
+        if command[0] == "helm":
+            helm_reads += 1
+            if helm_reads == 2:
+                raise verifier.VerificationError("cluster identity: SENTINEL_SECRET")
+        return base_runner(command)
+
+    with pytest.raises(verifier.VerificationError, match="^concurrent Helm change:") as caught:
+        verifier.verify(args, runner, lambda url, _origin: _public_body(url))
+    captured = capsys.readouterr()
+    assert "SENTINEL_SECRET" not in str(caught.value)
+    assert "SENTINEL_SECRET" not in captured.out + captured.err
+
+
+def test_json_run_malformed_json_retains_caller_stage() -> None:
+    with pytest.raises(
+        verifier.VerificationError,
+        match="^pod/replica identity: command did not return valid JSON$",
+    ):
+        verifier.json_run(lambda _command: "{SENTINEL_SECRET", ["kubectl"], "pod/replica identity")
 
 
 class _Response:

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -7,6 +7,7 @@ import subprocess
 import urllib.error
 from argparse import Namespace
 from pathlib import Path
+from typing import Callable
 
 import pytest
 
@@ -14,6 +15,142 @@ from scripts import dspace_runtime_verifier as verifier
 
 SHA = "abcdef0123456789abcdef0123456789abcdef01"
 DIGEST = "sha256:" + "1" * 64
+
+
+def helm_metadata(uid: str) -> dict:
+    return {
+        "uid": uid,
+        "labels": {
+            "app.kubernetes.io/name": "dspace",
+            "app.kubernetes.io/instance": "dspace",
+            "app.kubernetes.io/managed-by": "Helm",
+        },
+        "annotations": {
+            "meta.helm.sh/release-name": "dspace",
+            "meta.helm.sh/release-namespace": "dspace",
+        },
+    }
+
+
+def runtime_fixture(
+    tmp_path: Path,
+) -> tuple[Namespace, dict, list[list[str]], Callable[[list[str]], str]]:
+    smoke = tmp_path / "smoke"
+    smoke.write_text("#!/bin/sh\n", encoding="utf-8")
+    smoke.chmod(0o755)
+    metadata = helm_metadata("deployment-uid")
+    metadata.update({"name": "dspace", "generation": 4})
+    deployment = {
+        "metadata": metadata,
+        "spec": {
+            "replicas": 1,
+            "template": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "dspace",
+                            "image": f"{verifier.IMAGE_REF}:main-abcdef0",
+                            "ports": [{"name": "http", "containerPort": 8080, "protocol": "TCP"}],
+                            "env": [],
+                        }
+                    ]
+                }
+            },
+        },
+        "status": {
+            "observedGeneration": 4,
+            "updatedReplicas": 1,
+            "readyReplicas": 1,
+            "availableReplicas": 1,
+            "unavailableReplicas": 0,
+        },
+    }
+    rs_metadata = helm_metadata("rs-uid")
+    rs_metadata.update(
+        {
+            "name": "dspace-rs",
+            "ownerReferences": [
+                {
+                    "kind": "Deployment",
+                    "name": "dspace",
+                    "uid": "deployment-uid",
+                    "controller": True,
+                }
+            ],
+        }
+    )
+    pod_metadata = helm_metadata("pod-uid")
+    pod_metadata.update(
+        {
+            "name": "dspace-0",
+            "ownerReferences": [
+                {
+                    "kind": "ReplicaSet",
+                    "name": "dspace-rs",
+                    "uid": "rs-uid",
+                    "controller": True,
+                }
+            ],
+        }
+    )
+    pod = {
+        "metadata": pod_metadata,
+        "spec": {"containers": [{"name": "dspace", "image": f"{verifier.IMAGE_REF}:main-abcdef0"}]},
+        "status": {
+            "phase": "Running",
+            "conditions": [{"type": "Ready", "status": "True"}],
+            "containerStatuses": [{"name": "dspace", "imageID": "repo@" + DIGEST}],
+        },
+    }
+    state = {
+        "deployment": deployment,
+        "replicasets": [{"kind": "ReplicaSet", "metadata": rs_metadata}],
+        "pods": [pod],
+    }
+    calls: list[list[str]] = []
+    build = json.dumps({"version": "3.2.0", "revision": SHA, "shortRevision": SHA[:7]})
+
+    def runner(command: list[str]) -> str:
+        calls.append(command)
+        if command[0] == "helm":
+            return json.dumps(
+                {
+                    "name": "dspace",
+                    "namespace": "dspace",
+                    "version": 7,
+                    "info": {"status": "deployed"},
+                    "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}},
+                }
+            )
+        if "deployment" in command:
+            return json.dumps(state["deployment"])
+        if "pods" in command:
+            return json.dumps({"items": state["pods"]})
+        if "replicasets" in command:
+            return json.dumps({"items": state["replicasets"]})
+        return (
+            build
+            if command[-1].endswith("build-info.json")
+            else f'<meta name="dspace-build-revision" content="{SHA}">'
+        )
+
+    args = Namespace(
+        environment="staging",
+        release="dspace",
+        namespace="dspace",
+        application_version="3.2.0",
+        source_revision=SHA,
+        provider="openai",
+        image_tag="main-abcdef0",
+        image_digest=DIGEST,
+        host="example.test",
+        chart_version="3.2.0",
+        helm_revision=7,
+        values=[],
+        smoke_runner=smoke,
+        kubeconfig="fixture",
+    )
+    return args, state, calls, runner
 
 
 def test_capabilities_schema_and_order(capsys: pytest.CaptureFixture[str]) -> None:
@@ -79,6 +216,7 @@ def test_smoke_is_exact_argv_and_child_output_is_suppressed(
         encoding="utf-8",
     )
     calls: list[list[str]] = []
+    runner_calls: list[list[str]] = []
 
     class Completed:
         returncode = 0
@@ -92,8 +230,16 @@ def test_smoke_is_exact_argv_and_child_output_is_suppressed(
     html = f'<meta name="dspace-build-revision" content="{SHA}">'.encode()
     pod = {
         "metadata": {
+            **helm_metadata("pod-uid"),
             "name": "dspace-0",
-            "ownerReferences": [{"kind": "ReplicaSet", "name": "dspace-rs", "controller": True}],
+            "ownerReferences": [
+                {
+                    "kind": "ReplicaSet",
+                    "name": "dspace-rs",
+                    "uid": "rs-uid",
+                    "controller": True,
+                }
+            ],
         },
         "spec": {
             "containers": [
@@ -108,6 +254,7 @@ def test_smoke_is_exact_argv_and_child_output_is_suppressed(
     }
 
     def runner(command: list[str]) -> str:
+        runner_calls.append(command)
         if command[0] == "helm":
             return json.dumps(
                 {
@@ -120,19 +267,20 @@ def test_smoke_is_exact_argv_and_child_output_is_suppressed(
             )
         if "pods" in command:
             return json.dumps({"items": [pod]})
-        if "replicasets,deployments" in command:
+        if "replicasets" in command:
             return json.dumps(
                 {
                     "items": [
-                        {"kind": "Deployment", "metadata": {"name": "dspace"}},
                         {
                             "kind": "ReplicaSet",
                             "metadata": {
+                                **helm_metadata("rs-uid"),
                                 "name": "dspace-rs",
                                 "ownerReferences": [
                                     {
                                         "kind": "Deployment",
                                         "name": "dspace",
+                                        "uid": "deployment-uid",
                                         "controller": True,
                                     }
                                 ],
@@ -144,12 +292,20 @@ def test_smoke_is_exact_argv_and_child_output_is_suppressed(
         if "deployment" in command:
             return json.dumps(
                 {
+                    "metadata": {
+                        **helm_metadata("deployment-uid"),
+                        "name": "dspace",
+                        "generation": 4,
+                    },
                     "spec": {
+                        "replicas": 1,
                         "template": {
                             "spec": {
                                 "containers": [
                                     {
                                         "name": "dspace",
+                                        "image": "ghcr.io/democratizedspace/dspace:main-abcdef0",
+                                        "ports": [{"name": "http", "containerPort": 8080}],
                                         "env": [
                                             {
                                                 "name": "DSPACE_TOKEN_PLACE_URL",
@@ -163,8 +319,15 @@ def test_smoke_is_exact_argv_and_child_output_is_suppressed(
                                     }
                                 ]
                             }
-                        }
-                    }
+                        },
+                    },
+                    "status": {
+                        "observedGeneration": 4,
+                        "updatedReplicas": 1,
+                        "readyReplicas": 1,
+                        "availableReplicas": 1,
+                        "unavailableReplicas": 0,
+                    },
                 }
             )
         return (
@@ -188,7 +351,6 @@ def test_smoke_is_exact_argv_and_child_output_is_suppressed(
         values=[values],
         smoke_runner=smoke,
         kubeconfig="fixture",
-        pod_port=3000,
     )
     result = verifier.verify(
         args, runner, lambda url, _origin: build if url.endswith(".json") else html
@@ -196,6 +358,11 @@ def test_smoke_is_exact_argv_and_child_output_is_suppressed(
     assert result["journeys"][-1] == {"name": "/chat", "passed": True}
     smoke_call = calls[-1]
     assert smoke_call[0] == str(smoke)
+    proxy_calls = [call for call in runner_calls if "--raw" in call]
+    assert len(proxy_calls) == 2
+    assert all("--request-timeout=15s" in call for call in proxy_calls)
+    assert all(":8080/proxy" in call[-1] for call in proxy_calls)
+    assert all(":3000/proxy" not in call[-1] for call in proxy_calls)
     if provider == "token-place":
         assert smoke_call[-4:] == [
             "--expected-token-place-origin",
@@ -219,6 +386,97 @@ def test_identity_and_frontend_mismatches_are_bounded() -> None:
         )
     with pytest.raises(verifier.VerificationError, match="frontend revision marker mismatch"):
         verifier.marker(b"secret response without marker", SHA, "direct identity")
+
+
+@pytest.mark.parametrize(
+    "ports",
+    [
+        [],
+        [{"name": "other", "containerPort": 8080}],
+        [{"name": "http", "containerPort": "8080"}],
+        [{"name": "http", "containerPort": 8080, "protocol": "UDP"}],
+        [
+            {"name": "http", "containerPort": 8080},
+            {"name": "http", "containerPort": 8081},
+        ],
+    ],
+)
+def test_live_http_port_shapes_fail_closed(tmp_path: Path, monkeypatch, ports) -> None:
+    args, state, _calls, runner = runtime_fixture(tmp_path)
+    state["deployment"]["spec"]["template"]["spec"]["containers"][0]["ports"] = ports
+    monkeypatch.setattr(
+        verifier.subprocess, "run", lambda *_args, **_kwargs: pytest.fail("smoke executed")
+    )
+    with pytest.raises(verifier.VerificationError, match="invalid named http port"):
+        verifier.verify(args, runner, lambda url, _origin: _public_body(url))
+
+
+@pytest.mark.parametrize(
+    ("path", "value", "message"),
+    [
+        (("spec", "replicas"), 0, "rollout"),
+        (("status", "observedGeneration"), 3, "rollout"),
+        (("status", "updatedReplicas"), 0, "rollout"),
+        (("status", "readyReplicas"), 0, "rollout"),
+        (("status", "availableReplicas"), 0, "rollout"),
+        (("status", "unavailableReplicas"), 1, "rollout"),
+        (
+            ("spec", "template", "spec", "containers", 0, "image"),
+            f"{verifier.IMAGE_REF}:wrong",
+            "image identity",
+        ),
+    ],
+)
+def test_deployment_drift_and_incomplete_rollout_fail_closed(
+    tmp_path: Path, path, value, message
+) -> None:
+    args, state, _calls, runner = runtime_fixture(tmp_path)
+    target = state["deployment"]
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+    with pytest.raises(verifier.VerificationError, match=message):
+        verifier.verify(args, runner, lambda url, _origin: _public_body(url))
+
+
+@pytest.mark.parametrize("owner_level", ["deployment", "replicaset", "pod"])
+def test_forged_owner_uids_fail_closed(tmp_path: Path, owner_level: str) -> None:
+    args, state, _calls, runner = runtime_fixture(tmp_path)
+    if owner_level == "deployment":
+        state["deployment"]["metadata"]["annotations"]["meta.helm.sh/release-name"] = "forged"
+    elif owner_level == "replicaset":
+        state["replicasets"][0]["metadata"]["ownerReferences"][0]["uid"] = "forged"
+    else:
+        state["pods"][0]["metadata"]["ownerReferences"][0]["uid"] = "forged"
+    with pytest.raises(verifier.VerificationError, match="unowned|not owned"):
+        verifier.verify(args, runner, lambda url, _origin: _public_body(url))
+
+
+def test_missing_observed_replica_fails_closed(tmp_path: Path) -> None:
+    args, state, _calls, runner = runtime_fixture(tmp_path)
+    state["pods"] = []
+    with pytest.raises(verifier.VerificationError, match="replica count"):
+        verifier.verify(args, runner, lambda url, _origin: _public_body(url))
+
+
+def test_direct_proxy_failure_is_bounded_and_classified(tmp_path: Path) -> None:
+    args, _state, calls, base_runner = runtime_fixture(tmp_path)
+
+    def runner(command: list[str]) -> str:
+        if "--raw" in command:
+            raise OSError("SENTINEL_SECRET")
+        return base_runner(command)
+
+    with pytest.raises(verifier.VerificationError, match="^direct identity: endpoint") as caught:
+        verifier.verify(args, runner, lambda url, _origin: _public_body(url))
+    assert "SENTINEL_SECRET" not in str(caught.value)
+    assert not any(":3000/proxy" in part for call in calls for part in call)
+
+
+def _public_body(url: str) -> bytes:
+    if url.endswith(".json"):
+        return json.dumps({"version": "3.2.0", "revision": SHA, "shortRevision": SHA[:7]}).encode()
+    return f'<meta name="dspace-build-revision" content="{SHA}">'.encode()
 
 
 def test_command_adapters_return_bounded_errors(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -1,0 +1,188 @@
+"""Hermetic contract tests for the DSPACE runtime verifier."""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from scripts import dspace_runtime_verifier as verifier
+
+SHA = "abcdef0123456789abcdef0123456789abcdef01"
+DIGEST = "sha256:" + "1" * 64
+
+
+def test_capabilities_schema_and_order(capsys: pytest.CaptureFixture[str]) -> None:
+    assert (
+        verifier.main(
+            [
+                "capabilities",
+                "--environment",
+                "staging",
+                "--release",
+                "dspace",
+                "--namespace",
+                "dspace",
+            ]
+        )
+        == 0
+    )
+    value = json.loads(capsys.readouterr().out)
+    assert value == {
+        "schemaVersion": 1,
+        "environment": "staging",
+        "release": "dspace",
+        "namespace": "dspace",
+        "capabilities": [
+            "applicationVersion",
+            "runtimeSourceRevision",
+            "frontendSourceRevision",
+            "defaultProvider",
+            "publicJourneys",
+        ],
+    }
+
+
+def test_values_chain_uses_last_reviewed_token_place_values(tmp_path: Path) -> None:
+    base = tmp_path / "base.yaml"
+    overlay = tmp_path / "overlay.yaml"
+    base.write_text(
+        "env:\n  - name: DSPACE_TOKEN_PLACE_URL\n    value: https://old.invalid\n", encoding="utf-8"
+    )
+    overlay.write_text(
+        "env:\n  - name: DSPACE_TOKEN_PLACE_URL\n    value: https://staging.token.place\n"
+        "  - name: DSPACE_TOKEN_PLACE_CHAT_MODEL\n    value: reviewed-model\n",
+        encoding="utf-8",
+    )
+    assert verifier.environment_values([base, overlay]) == {
+        "DSPACE_TOKEN_PLACE_URL": "https://staging.token.place",
+        "DSPACE_TOKEN_PLACE_CHAT_MODEL": "reviewed-model",
+    }
+
+
+@pytest.mark.parametrize("provider", ["token-place", "openai"])
+def test_smoke_is_exact_argv_and_child_output_is_suppressed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, provider: str
+) -> None:
+    smoke = tmp_path / "smoke"
+    smoke.write_text("#!/bin/sh\n", encoding="utf-8")
+    smoke.chmod(0o755)
+    values = tmp_path / "values.yaml"
+    values.write_text(
+        "env:\n  - name: DSPACE_TOKEN_PLACE_URL\n    value: https://token.place\n"
+        "  - name: DSPACE_TOKEN_PLACE_CHAT_MODEL\n    value: model-from-values\n",
+        encoding="utf-8",
+    )
+    calls: list[list[str]] = []
+
+    class Completed:
+        returncode = 0
+        stdout = "SENTINEL_SECRET"
+        stderr = "SENTINEL_SECRET"
+
+    monkeypatch.setattr(
+        verifier.subprocess, "run", lambda command, **_kwargs: calls.append(command) or Completed()
+    )
+    build = json.dumps({"version": "3.2.0", "revision": SHA, "shortRevision": SHA[:7]}).encode()
+    html = f'<meta name="dspace-build-revision" content="{SHA}">'.encode()
+    pod = {
+        "metadata": {"name": "dspace-0"},
+        "spec": {
+            "containers": [
+                {"name": "dspace", "image": "ghcr.io/democratizedspace/dspace:main-abcdef0"}
+            ]
+        },
+        "status": {
+            "phase": "Running",
+            "conditions": [{"type": "Ready", "status": "True"}],
+            "containerStatuses": [{"name": "dspace", "imageID": "repo@" + DIGEST}],
+        },
+    }
+
+    def runner(command: list[str]) -> str:
+        if command[0] == "helm":
+            return json.dumps(
+                {"version": 7, "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}}}
+            )
+        if "pods" in command:
+            return json.dumps({"items": [pod]})
+        if "deployment" in command:
+            return json.dumps(
+                {
+                    "spec": {
+                        "template": {
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "dspace",
+                                        "env": [
+                                            {
+                                                "name": "DSPACE_TOKEN_PLACE_URL",
+                                                "value": "https://token.place",
+                                            },
+                                            {
+                                                "name": "DSPACE_TOKEN_PLACE_CHAT_MODEL",
+                                                "value": "model-from-values",
+                                            },
+                                        ],
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            )
+        return (
+            json.dumps(json.loads(build))
+            if command[-1].endswith("build-info.json")
+            else html.decode()
+        )
+
+    args = Namespace(
+        environment="staging",
+        release="dspace",
+        namespace="dspace",
+        application_version="3.2.0",
+        source_revision=SHA,
+        provider=provider,
+        image_tag="main-abcdef0",
+        image_digest=DIGEST,
+        host="example.test",
+        chart_version="3.2.0",
+        helm_revision=7,
+        values=[values],
+        smoke_runner=smoke,
+        kubeconfig="fixture",
+        pod_port=3000,
+    )
+    result = verifier.verify(
+        args, runner, lambda url, _origin: build if url.endswith(".json") else html
+    )
+    assert result["journeys"][-1] == {"name": "/chat", "passed": True}
+    smoke_call = calls[-1]
+    assert smoke_call[0] == str(smoke)
+    if provider == "token-place":
+        assert smoke_call[-4:] == [
+            "--expected-token-place-origin",
+            "https://token.place",
+            "--expected-token-place-model",
+            "model-from-values",
+        ]
+    else:
+        assert not any("token-place" in item for item in smoke_call)
+    assert "SENTINEL_SECRET" not in json.dumps(result)
+
+
+def test_identity_and_frontend_mismatches_are_bounded() -> None:
+    with pytest.raises(verifier.VerificationError, match="version or revision mismatch"):
+        verifier.identity(
+            b'{"version":"wrong","revision":"x","shortRevision":"x"}',
+            "3.2.0",
+            SHA,
+            "main-abcdef0",
+            "public identity",
+        )
+    with pytest.raises(verifier.VerificationError, match="frontend revision marker mismatch"):
+        verifier.marker(b"secret response without marker", SHA, "direct identity")

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import urllib.error
 from argparse import Namespace
 from pathlib import Path
 
@@ -91,9 +93,7 @@ def test_smoke_is_exact_argv_and_child_output_is_suppressed(
     pod = {
         "metadata": {
             "name": "dspace-0",
-            "ownerReferences": [
-                {"kind": "ReplicaSet", "name": "dspace-rs", "controller": True}
-            ],
+            "ownerReferences": [{"kind": "ReplicaSet", "name": "dspace-rs", "controller": True}],
         },
         "spec": {
             "containers": [
@@ -219,3 +219,137 @@ def test_identity_and_frontend_mismatches_are_bounded() -> None:
         )
     with pytest.raises(verifier.VerificationError, match="frontend revision marker mismatch"):
         verifier.marker(b"secret response without marker", SHA, "direct identity")
+
+
+def test_command_adapters_return_bounded_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        verifier.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 1, "secret", "secret"),
+    )
+    with pytest.raises(verifier.VerificationError, match="kubectl command failed"):
+        verifier.run(["kubectl", "secret"])
+
+    monkeypatch.setattr(
+        verifier.subprocess, "run", lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError())
+    )
+    with pytest.raises(verifier.VerificationError, match="could not execute"):
+        verifier.run(["kubectl"])
+
+    with pytest.raises(verifier.VerificationError, match="valid JSON"):
+        verifier.json_run(lambda _command: "not-json secret", ["helm"], "cluster identity")
+
+
+class _Response:
+    def __init__(self, url: str, body: bytes = b"ok") -> None:
+        self.url, self.body = url, body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def geturl(self) -> str:
+        return self.url
+
+    def read(self, _limit: int) -> bytes:
+        return self.body
+
+
+def test_public_fetch_is_bounded_and_same_origin() -> None:
+    assert (
+        verifier.fetch(
+            "https://dspace.test/build-info.json",
+            "https://dspace.test",
+            lambda *_args, **_kwargs: _Response("https://dspace.test/final"),
+        )
+        == b"ok"
+    )
+    with pytest.raises(verifier.VerificationError, match="crossed"):
+        verifier.fetch(
+            "https://dspace.test/",
+            "https://dspace.test",
+            lambda *_a, **_k: _Response("https://evil.test/"),
+        )
+    with pytest.raises(verifier.VerificationError, match="unreachable"):
+        verifier.fetch(
+            "https://dspace.test/",
+            "https://dspace.test",
+            lambda *_a, **_k: (_ for _ in ()).throw(urllib.error.URLError("secret")),
+        )
+
+
+@pytest.mark.parametrize(
+    ("raw", "message"),
+    [
+        (b"x" * 1_048_577, "bounded limit"),
+        (b"not-json", "malformed"),
+        (b"[]", "malformed"),
+        (
+            json.dumps({"version": "3.2.0", "revision": SHA, "shortRevision": "wrong"}).encode(),
+            "short revision",
+        ),
+        (
+            json.dumps(
+                {"version": "3.2.0", "revision": SHA, "shortRevision": SHA[:7], "image": "wrong"}
+            ).encode(),
+            "image coordinate",
+        ),
+    ],
+)
+def test_identity_rejects_each_untrusted_public_shape(raw: bytes, message: str) -> None:
+    with pytest.raises(verifier.VerificationError, match=message):
+        verifier.identity(raw, "3.2.0", SHA, "main-abcdef0", "public identity")
+
+
+def test_marker_and_values_failures_are_bounded(tmp_path: Path) -> None:
+    with pytest.raises(verifier.VerificationError, match="bounded limit"):
+        verifier.marker(b"x" * 1_048_577, SHA, "public identity")
+    with pytest.raises(verifier.VerificationError, match="values chain is unreadable"):
+        verifier.environment_values([tmp_path / "missing.yaml"])
+    with pytest.raises(verifier.VerificationError, match="missing named"):
+        verifier.application_container({})
+
+
+def test_verify_rejects_non_executable_runner_before_cluster_access(tmp_path: Path) -> None:
+    args = Namespace(smoke_runner=tmp_path / "missing")
+    with pytest.raises(verifier.VerificationError, match="existing executable"):
+        verifier.verify(args, lambda _command: pytest.fail("cluster command executed"))
+
+
+def test_verify_main_reports_bounded_failure(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    monkeypatch.setattr(
+        verifier, "verify", lambda _args: (_ for _ in ()).throw(verifier.VerificationError("safe"))
+    )
+    argv = [
+        "verify",
+        "--environment",
+        "staging",
+        "--release",
+        "dspace",
+        "--namespace",
+        "dspace",
+        "--application-version",
+        "3.2.0",
+        "--source-revision",
+        SHA,
+        "--provider",
+        "openai",
+        "--image-tag",
+        "main-abcdef0",
+        "--image-digest",
+        DIGEST,
+        "--chart-version",
+        "3.2.0",
+        "--host",
+        "dspace.test",
+        "--smoke-runner",
+        str(Path("runner")),
+        "--kubeconfig",
+        "fixture",
+    ]
+    assert verifier.main(argv) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "ERROR: safe\n"

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2886,6 +2886,7 @@ def test_dspace_production_orders_staging_gate_through_finalization(
         "manifest staging-gate",
         "verifier staging",
         "oras ",
+        "helm template ",
         "manifest reserve",
         "helm upgrade ",
         "verifier prod",
@@ -2896,6 +2897,7 @@ def test_dspace_production_orders_staging_gate_through_finalization(
         for stage in stages
     ]
     assert positions == sorted(positions)
+    assert sum(line.startswith("helm template ") for line in commands) == 1
     assert sum(line.startswith("helm upgrade ") for line in commands) == 1
     final = json.loads(evidence.read_text(encoding="utf-8"))
     runtime_checks = {
@@ -3005,7 +3007,7 @@ def test_dspace_production_entry_points_share_staging_evidence_guard(
     commands = commands_log.read_text(encoding="utf-8") if commands_log.exists() else ""
     assert "oras " not in commands
     assert "manifest reserve" not in commands
-    assert "helm upgrade " not in commands
+    assert not any(line.startswith("helm ") for line in commands.splitlines())
     assert "kubectl apply " not in commands
     assert "kubectl patch " not in commands
     assert "manifest finalize" not in commands

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -56,13 +56,24 @@ import json
 import os
 import sys
 verifier = {str(REPO_ROOT / "scripts/dspace_runtime_verifier.py")!r}
+manifest = {str(REPO_ROOT / "scripts/dspace_release_manifest.py")!r}
+commands_log = os.environ["SUGARKUBE_COMMANDS_LOG"]
+if len(sys.argv) >= 3 and sys.argv[1] == manifest:
+    with open(commands_log, "a", encoding="utf-8") as log:
+        log.write("manifest " + sys.argv[2] + "\\n")
+    os.execv(sys.executable, [sys.executable, *sys.argv[1:]])
 if len(sys.argv) < 2 or sys.argv[1] != verifier:
     os.execv(sys.executable, [sys.executable, *sys.argv[1:]])
-with open(os.environ["SUGARKUBE_RUNTIME_VERIFIER_LOG"], "a", encoding="utf-8") as log:
-    log.write(sys.argv[1] + "\\n")
 args = sys.argv[1:]
 def value(flag):
     return args[args.index(flag) + 1]
+environment = value("--environment")
+with open(os.environ["SUGARKUBE_RUNTIME_VERIFIER_LOG"], "a", encoding="utf-8") as log:
+    log.write(sys.argv[1] + " environment=" + environment + "\\n")
+with open(commands_log, "a", encoding="utf-8") as log:
+    log.write("verifier " + environment + "\\n")
+if environment == "prod" and os.environ.get("SUGARKUBE_STUB_FAIL_PROD_VERIFIER") == "1":
+    raise SystemExit("synthetic production runtime verification failure")
 print(json.dumps({{"schemaVersion": 1, "environment": value("--environment"),
   "release": value("--release"), "namespace": value("--namespace"),
   "applicationVersion": value("--application-version"),
@@ -120,6 +131,7 @@ if [[ "$*" == *"get replicasets,deployments"* && "$*" == *"-o json"* ]]; then
 fi
 if [[ "$*" == *"get nodes -o json"* ]]; then
   env_label="${{SUGARKUBE_STUB_NODE_ENV:-staging}}"
+  [[ "$*" != *"staging-kubeconfig"* ]] || env_label=staging
   cluster_label="${{SUGARKUBE_STUB_CLUSTER:-sugar}}"
   printf '{{"items":[{{"metadata":{{"name":"sugarkube3","labels":{{"sugarkube.env":"%s","sugarkube.cluster":"%s"}}}}}},{{"metadata":{{"name":"sugarkube4","labels":{{"sugarkube.env":"%s","sugarkube.cluster":"%s"}}}}}}]}}\n' "$env_label" "$cluster_label" "$env_label" "$cluster_label"
   exit 0
@@ -172,6 +184,7 @@ fi
 if [[ "$*" == *"status dspace --namespace dspace -o json" ]]; then
   chart_version=3.1.0
   [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" != prod ] || chart_version=3.0.1
+  [ -z "${{SUGARKUBE_STUB_CHART_VERSION:-}}" ] || chart_version="${{SUGARKUBE_STUB_CHART_VERSION}}"
   description="$(cat {str(tmp_path / "helm-description")!r} 2>/dev/null || true)"
   printf '{{"name":"dspace","namespace":"dspace","version":7,"info":{{"status":"deployed","description":"%s"}},"chart":{{"metadata":{{"name":"dspace","version":"%s"}}}}}}\n' "$description" "$chart_version"
   exit 0
@@ -190,6 +203,7 @@ if [[ "$*" == show\ chart* ]]; then
     if [[ "$version" == oci://*@sha256:* ]]; then
       version=3.1.0
       [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" != prod ] || version=3.0.1
+      [ -z "${{SUGARKUBE_STUB_CHART_VERSION:-}}" ] || version="${{SUGARKUBE_STUB_CHART_VERSION}}"
     fi
     printf 'apiVersion: v2\nname: dspace\nversion: %s\nappVersion: main-abcdef0\n' "$version"
     exit 0
@@ -479,6 +493,7 @@ print(json.dumps(value))
     env["CURL_LOG"] = str(tmp_path / "curl.log")
     env["DSPACE_SMOKE_RUNNER"] = str(smoke_runner)
     env["SUGARKUBE_RUNTIME_VERIFIER_LOG"] = str(verifier_log)
+    env["SUGARKUBE_COMMANDS_LOG"] = str(tmp_path / "commands.log")
     return env
 
 
@@ -2480,7 +2495,11 @@ def test_dspace_oci_deploy_wrapper_propagates_inline_chart_pin(
 
 
 def _write_dspace_candidate(
-    path: Path, environment: str, *, image_digest: str | None = None
+    path: Path,
+    environment: str,
+    *,
+    image_digest: str | None = None,
+    chart_version: str | None = None,
 ) -> None:
     path.write_text(
         json.dumps(
@@ -2491,7 +2510,8 @@ def _write_dspace_candidate(
                 "sourceRevision": "abcdef0123456789abcdef0123456789abcdef01",
                 "imageTag": "main-abcdef0",
                 "imageDigest": image_digest or "sha256:" + "1" * 64,
-                "chartVersion": "3.1.0" if environment == "staging" else "3.0.1",
+                "chartVersion": chart_version
+                or ("3.1.0" if environment == "staging" else "3.0.1"),
                 "chartDigest": "sha256:" + "2" * 64,
                 "semanticTag": "v3.2.0",
                 "recordType": "candidate",
@@ -2504,6 +2524,70 @@ def _write_dspace_candidate(
         + "\n",
         encoding="utf-8",
     )
+
+
+def _write_dspace_config(path: Path, version: str = "3.1.0") -> None:
+    path.write_text(
+        "\n".join(
+            (
+                "SUGARKUBE_APP=dspace",
+                "SUGARKUBE_RELEASE=dspace",
+                "SUGARKUBE_NAMESPACE=dspace",
+                "SUGARKUBE_CHART=oci://ghcr.io/democratizedspace/charts/dspace",
+                f"SUGARKUBE_VERSION={version}",
+                "SUGARKUBE_PROD_TAG_FILE=docs/apps/dspace.prod.tag",
+                "SUGARKUBE_VALUES_DEV=docs/examples/dspace.values.dev.yaml",
+                "SUGARKUBE_VALUES_STAGING=docs/examples/dspace.values.dev.yaml,"
+                "docs/examples/dspace.values.staging.yaml",
+                "SUGARKUBE_VALUES_PROD=docs/examples/dspace.values.dev.yaml,"
+                "docs/examples/dspace.values.prod.yaml",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _prepare_dspace_production(
+    tmp_path: Path, env: dict[str, str]
+) -> tuple[Path, Path, Path, Path, Path]:
+    staging_candidate = tmp_path / "staging-candidate.json"
+    staging_evidence = tmp_path / "staging-evidence.json"
+    production_candidate = tmp_path / "production-candidate.json"
+    production_evidence = tmp_path / "production-evidence.json"
+    config = tmp_path / "dspace.env"
+    staging_kubeconfig = tmp_path / "staging-kubeconfig"
+    _write_dspace_candidate(staging_candidate, "staging", chart_version="3.1.0")
+    _write_dspace_candidate(production_candidate, "prod", chart_version="3.1.0")
+    _write_dspace_config(config)
+    staging_kubeconfig.write_text("staging test kubeconfig\n", encoding="utf-8")
+
+    original_environment = env.get("SUGARKUBE_STUB_NODE_ENV")
+    env["SUGARKUBE_STUB_NODE_ENV"] = "staging"
+    result = _run_just(
+        [
+            "app-deploy",
+            "dspace",
+            "staging",
+            "main-abcdef0",
+            str(config),
+            str(staging_candidate),
+            str(staging_evidence),
+            "",
+            env["DSPACE_SMOKE_RUNNER"],
+        ],
+        env,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    if original_environment is None:
+        env.pop("SUGARKUBE_STUB_NODE_ENV", None)
+    else:
+        env["SUGARKUBE_STUB_NODE_ENV"] = original_environment
+    for log_name in ("commands.log", "helm.log", "kubectl.log", "runtime-verifier.log"):
+        log = tmp_path / log_name
+        if log.exists():
+            log.unlink()
+    return production_candidate, production_evidence, staging_evidence, config, staging_kubeconfig
 
 
 @pytest.mark.usefixtures("ensure_just_available")
@@ -2534,7 +2618,9 @@ def test_dspace_release_verify_ignores_forged_verifier_override(
     assert result.returncode == 0, result.stderr + result.stdout
     assert Path(env["SUGARKUBE_RUNTIME_VERIFIER_LOG"]).read_text(
         encoding="utf-8"
-    ).splitlines() == [str(REPO_ROOT / "scripts/dspace_runtime_verifier.py")]
+    ).splitlines() == [
+        f"{REPO_ROOT / 'scripts/dspace_runtime_verifier.py'} environment=staging"
+    ]
     assert not marker.exists()
 
 
@@ -2764,6 +2850,165 @@ def test_prod_subdomain_wrapper_reaches_guard_before_any_mutation(
     assert "smoke_runner=<executable>" in result.stderr
     helm_log = Path(env["HELM_LOG"])
     assert not helm_log.exists() or "upgrade " not in helm_log.read_text(encoding="utf-8")
+    assert not evidence.exists()
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_production_orders_staging_gate_through_finalization(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
+    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.1.0"
+    candidate, evidence, staging_evidence, config, staging_kubeconfig = (
+        _prepare_dspace_production(tmp_path, env)
+    )
+
+    result = _run_just(
+        [
+            "app-promote-prod",
+            "dspace",
+            "main-abcdef0",
+            str(config),
+            str(candidate),
+            str(evidence),
+            str(staging_evidence),
+            env["DSPACE_SMOKE_RUNNER"],
+            str(config),
+            str(staging_kubeconfig),
+        ],
+        env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    commands = (tmp_path / "commands.log").read_text(encoding="utf-8").splitlines()
+    stages = (
+        "manifest staging-gate",
+        "verifier staging",
+        "oras ",
+        "manifest reserve",
+        "helm upgrade ",
+        "verifier prod",
+        "manifest finalize",
+    )
+    positions = [
+        next(i for i, line in enumerate(commands) if line.startswith(stage))
+        for stage in stages
+    ]
+    assert positions == sorted(positions)
+    assert sum(line.startswith("helm upgrade ") for line in commands) == 1
+    final = json.loads(evidence.read_text(encoding="utf-8"))
+    runtime_checks = {
+        "runtimeIdentity",
+        "frontendIdentity",
+        "replicaAgreement",
+        "publicDirectAgreement",
+        "defaultProvider",
+        "remoteChatSmoke",
+    }
+    assert runtime_checks <= {
+        item["check"] for item in final["verificationResults"] if item["passed"] is True
+    }
+    assert final["recordType"] == "final"
+    assert not Path(str(evidence.resolve()) + ".reservation").exists()
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_production_verifier_failure_preserves_reservation(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
+    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.1.0"
+    candidate, evidence, staging_evidence, config, staging_kubeconfig = (
+        _prepare_dspace_production(tmp_path, env)
+    )
+    env["SUGARKUBE_STUB_FAIL_PROD_VERIFIER"] = "1"
+
+    result = _run_just(
+        [
+            "app-promote-prod",
+            "dspace",
+            "main-abcdef0",
+            str(config),
+            str(candidate),
+            str(evidence),
+            str(staging_evidence),
+            env["DSPACE_SMOKE_RUNNER"],
+            str(config),
+            str(staging_kubeconfig),
+        ],
+        env,
+    )
+
+    assert result.returncode != 0
+    commands = (tmp_path / "commands.log").read_text(encoding="utf-8").splitlines()
+    assert sum(line.startswith("helm upgrade ") for line in commands) == 1
+    assert "verifier prod" in commands
+    assert "manifest finalize" not in commands
+    assert not evidence.exists()
+    assert Path(str(evidence.resolve()) + ".reservation").exists()
+    assert not any("rollback" in line.lower() for line in commands)
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize(
+    ("recipe", "kind"),
+    [
+        ("app-deploy", "app-operation"),
+        ("app-redeploy", "app-operation"),
+        ("app-promote-prod", "app-promotion"),
+        ("dspace-oci-deploy", "dspace-operation"),
+        ("dspace-oci-redeploy", "dspace-operation"),
+        ("dspace-oci-promote-prod", "dspace-promotion"),
+        ("dspace-oci-deploy-prod-subdomain", "dspace-promotion"),
+    ],
+)
+def test_dspace_production_entry_points_share_staging_evidence_guard(
+    recipe: str,
+    kind: str,
+    tmp_path: Path,
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    candidate = tmp_path / "production-candidate.json"
+    evidence = tmp_path / "production-evidence.json"
+    config = tmp_path / "dspace.env"
+    staging_kubeconfig = tmp_path / "staging-kubeconfig"
+    _write_dspace_candidate(candidate, "prod", chart_version="3.1.0")
+    _write_dspace_config(config)
+    staging_kubeconfig.write_text("staging test kubeconfig\n", encoding="utf-8")
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
+    tail = [
+        "main-abcdef0",
+        str(candidate),
+        str(evidence),
+        "",
+        env["DSPACE_SMOKE_RUNNER"],
+        str(config),
+        str(staging_kubeconfig),
+    ]
+    if kind == "app-operation":
+        arguments = ["dspace", "prod", tail[0], str(config), *tail[1:]]
+    elif kind == "app-promotion":
+        arguments = ["dspace", tail[0], str(config), *tail[1:]]
+    elif kind == "dspace-operation":
+        arguments = ["prod", *tail]
+    else:
+        arguments = tail
+
+    result = _run_just([recipe, *arguments], env)
+
+    assert result.returncode != 0
+    assert "staging_evidence=<finalized-staging.json> is required" in result.stderr
+    commands_log = tmp_path / "commands.log"
+    commands = commands_log.read_text(encoding="utf-8") if commands_log.exists() else ""
+    assert "oras " not in commands
+    assert "manifest reserve" not in commands
+    assert "helm upgrade " not in commands
+    assert "kubectl apply " not in commands
+    assert "kubectl patch " not in commands
+    assert "manifest finalize" not in commands
     assert not evidence.exists()
 
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -46,6 +46,26 @@ def generic_app_stub_env(tmp_path: Path, ensure_just_available: Path) -> dict[st
     assert ensure_just_available.exists()
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
+    smoke_runner = tmp_path / "smoke-runner"
+    _write_executable(smoke_runner, "#!/usr/bin/env bash\nexit 0\n")
+    runtime_verifier = tmp_path / "runtime-verifier"
+    _write_executable(
+        runtime_verifier,
+        """#!/usr/bin/env python3
+import json
+import sys
+args = sys.argv[1:]
+def value(flag):
+    return args[args.index(flag) + 1]
+print(json.dumps({"schemaVersion": 1, "environment": value("--environment"),
+  "release": value("--release"), "namespace": value("--namespace"),
+  "applicationVersion": value("--application-version"),
+  "runtimeSourceRevision": value("--source-revision"),
+  "frontendSourceRevision": value("--source-revision"),
+  "defaultProvider": value("--provider"),
+  "journeys": [{"name": "/", "passed": True}, {"name": "/chat", "passed": True}]}))
+""",
+    )
     log_path = tmp_path / "helm.log"
     kubeconfig = """apiVersion: v1
 clusters:
@@ -451,6 +471,8 @@ print(json.dumps(value))
     env["HELM_LOG"] = str(log_path)
     env["KUBECTL_LOG"] = str(tmp_path / "kubectl.log")
     env["CURL_LOG"] = str(tmp_path / "curl.log")
+    env["DSPACE_SMOKE_RUNNER"] = str(smoke_runner)
+    env["SUGARKUBE_DSPACE_RUNTIME_VERIFIER"] = str(runtime_verifier)
     return env
 
 
@@ -2495,6 +2517,8 @@ def test_dspace_guarded_deploy_orders_preflight_mutation_and_finalization(
             "",
             str(manifest),
             str(evidence),
+            "",
+            generic_app_stub_env["DSPACE_SMOKE_RUNNER"],
         ],
         generic_app_stub_env,
     )
@@ -2557,6 +2581,8 @@ def test_dspace_render_failure_stops_before_evidence_reservation_or_mutation(
             "",
             str(manifest),
             str(evidence),
+            "",
+            env["DSPACE_SMOKE_RUNNER"],
         ],
         env,
     )
@@ -2593,6 +2619,8 @@ def test_dspace_guarded_redeploy_installs_approved_chart_digest(
             "",
             str(candidate_path),
             str(evidence),
+            "",
+            generic_app_stub_env["DSPACE_SMOKE_RUNNER"],
         ],
         generic_app_stub_env,
     )
@@ -2630,7 +2658,10 @@ def test_dspace_digest_mismatch_stops_before_helm(
     env.update(env_override)
 
     result = _run_just(
-        ["app-deploy", "dspace", "staging", "main-abcdef0", "", str(manifest)],
+        [
+            "app-deploy", "dspace", "staging", "main-abcdef0", "", str(manifest),
+            "", "", env["DSPACE_SMOKE_RUNNER"],
+        ],
         env,
     )
 
@@ -2659,6 +2690,8 @@ def test_dspace_reservation_collision_stops_before_helm(
             "",
             str(candidate_path),
             str(evidence),
+            "",
+            generic_app_stub_env["DSPACE_SMOKE_RUNNER"],
         ],
         generic_app_stub_env,
     )
@@ -2670,7 +2703,7 @@ def test_dspace_reservation_collision_stops_before_helm(
 
 
 @pytest.mark.usefixtures("ensure_just_available")
-def test_prod_subdomain_wrapper_preserves_canary_overlay_through_guarded_path(
+def test_prod_subdomain_wrapper_reaches_guard_before_any_mutation(
     tmp_path: Path, generic_app_stub_env: dict[str, str]
 ) -> None:
     manifest = tmp_path / "candidate.json"
@@ -2689,11 +2722,11 @@ def test_prod_subdomain_wrapper_preserves_canary_overlay_through_guarded_path(
         env,
     )
 
-    assert result.returncode == 0, result.stderr + result.stdout
-    helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
-    assert "-f docs/examples/dspace.values.prod-subdomain.yaml" in helm_log
-    assert "-f docs/examples/dspace.values.prod.yaml" not in helm_log
-    assert evidence.exists()
+    assert result.returncode != 0
+    assert "smoke_runner=<executable>" in result.stderr
+    helm_log = Path(env["HELM_LOG"])
+    assert not helm_log.exists() or "upgrade " not in helm_log.read_text(encoding="utf-8")
+    assert not evidence.exists()
 
 
 @pytest.mark.usefixtures("ensure_just_available")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -48,22 +48,28 @@ def generic_app_stub_env(tmp_path: Path, ensure_just_available: Path) -> dict[st
     bin_dir.mkdir()
     smoke_runner = tmp_path / "smoke-runner"
     _write_executable(smoke_runner, "#!/usr/bin/env bash\nexit 0\n")
-    runtime_verifier = tmp_path / "runtime-verifier"
+    verifier_log = tmp_path / "runtime-verifier.log"
     _write_executable(
-        runtime_verifier,
-        """#!/usr/bin/env python3
+        bin_dir / "python3",
+        f"""#!{sys.executable}
 import json
+import os
 import sys
+verifier = {str(REPO_ROOT / "scripts/dspace_runtime_verifier.py")!r}
+if len(sys.argv) < 2 or sys.argv[1] != verifier:
+    os.execv(sys.executable, [sys.executable, *sys.argv[1:]])
+with open(os.environ["SUGARKUBE_RUNTIME_VERIFIER_LOG"], "a", encoding="utf-8") as log:
+    log.write(sys.argv[1] + "\\n")
 args = sys.argv[1:]
 def value(flag):
     return args[args.index(flag) + 1]
-print(json.dumps({"schemaVersion": 1, "environment": value("--environment"),
+print(json.dumps({{"schemaVersion": 1, "environment": value("--environment"),
   "release": value("--release"), "namespace": value("--namespace"),
   "applicationVersion": value("--application-version"),
   "runtimeSourceRevision": value("--source-revision"),
   "frontendSourceRevision": value("--source-revision"),
   "defaultProvider": value("--provider"),
-  "journeys": [{"name": "/", "passed": True}, {"name": "/chat", "passed": True}]}))
+  "journeys": [{{"name": "/", "passed": True}}, {{"name": "/chat", "passed": True}}]}}))
 """,
     )
     log_path = tmp_path / "helm.log"
@@ -472,7 +478,7 @@ print(json.dumps(value))
     env["KUBECTL_LOG"] = str(tmp_path / "kubectl.log")
     env["CURL_LOG"] = str(tmp_path / "curl.log")
     env["DSPACE_SMOKE_RUNNER"] = str(smoke_runner)
-    env["SUGARKUBE_DSPACE_RUNTIME_VERIFIER"] = str(runtime_verifier)
+    env["SUGARKUBE_RUNTIME_VERIFIER_LOG"] = str(verifier_log)
     return env
 
 
@@ -2498,6 +2504,38 @@ def _write_dspace_candidate(
         + "\n",
         encoding="utf-8",
     )
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_release_verify_ignores_forged_verifier_override(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    manifest = tmp_path / "candidate.json"
+    marker = tmp_path / "forged-verifier-ran"
+    forged_verifier = tmp_path / "forged-verifier"
+    _write_dspace_candidate(manifest, "staging")
+    _write_executable(
+        forged_verifier,
+        f"#!/usr/bin/env bash\ntouch {str(marker)!r}\nexit 0\n",
+    )
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_DSPACE_RUNTIME_VERIFIER"] = str(forged_verifier)
+
+    result = _run_just(
+        [
+            "dspace-release-verify",
+            "env=staging",
+            f"manifest={manifest}",
+            f"smoke_runner={env['DSPACE_SMOKE_RUNNER']}",
+        ],
+        env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert Path(env["SUGARKUBE_RUNTIME_VERIFIER_LOG"]).read_text(
+        encoding="utf-8"
+    ).splitlines() == [str(REPO_ROOT / "scripts/dspace_runtime_verifier.py")]
+    assert not marker.exists()
 
 
 @pytest.mark.usefixtures("ensure_just_available")

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -185,6 +185,40 @@ def test_missing_or_candidate_target_fails_before_any_external_command(
     assert not (tmp_path / "rollback.json").exists()
 
 
+@pytest.mark.parametrize("runner_state", ["missing", "non-executable"])
+def test_default_verifier_requires_executable_smoke_runner_before_rollback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    runner_state: str,
+) -> None:
+    smoke_runner = tmp_path / "smoke-runner"
+    if runner_state == "non-executable":
+        smoke_runner.write_text("#!/bin/sh\n", encoding="utf-8")
+    called = False
+
+    def refuse_rollback(_args: Namespace) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(rollback, "rollback", refuse_rollback)
+    result = rollback.main(
+        [
+            "--environment",
+            "staging",
+            "--manifest",
+            str(tmp_path / "manifest.json"),
+            "--evidence",
+            str(tmp_path / "evidence.json"),
+            "--smoke-runner",
+            str(smoke_runner),
+        ]
+    )
+    assert result == 2
+    assert not called
+    assert "--smoke-runner must be an existing executable" in capsys.readouterr().err
+
+
 @pytest.mark.parametrize(
     "mismatch",
     ("image digest", "chart digest", "chart source revision", "image platform revision"),

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -532,21 +532,6 @@ def test_just_recipe_has_no_revision_rollback_or_reuse_values() -> None:
     assert "helm rollback" not in block
 
 
-def test_default_verifier_requires_smoke_runner(tmp_path: Path, capsys) -> None:
-    status = rollback.main(
-        [
-            "--environment",
-            "staging",
-            "--manifest",
-            str(tmp_path / "manifest.json"),
-            "--evidence",
-            str(tmp_path / "evidence.json"),
-        ]
-    )
-    assert status == 2
-    assert "--smoke-runner is required" in capsys.readouterr().err
-
-
 @pytest.mark.parametrize(
     ("failure", "failed_stage", "may_have_changed"),
     [

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -618,7 +618,13 @@ def test_orchestration_preserves_complete_success_and_failure_evidence(
         "preflight",
         lambda *_args, **_kwargs: [{"check": "imageDigest", "passed": True, "details": "observed"}],
     )
-    monkeypatch.setattr(rollback.release, "finalize", lambda *_args, **_kwargs: {})
+    finalizations: list[dict[str, object]] = []
+
+    def finalize_stub(*_args: object, **kwargs: object) -> dict[str, object]:
+        finalizations.append(kwargs)
+        return {}
+
+    monkeypatch.setattr(rollback.release, "finalize", finalize_stub)
     upgrade_attempted = [False]
     post_status_calls = [0]
 
@@ -720,9 +726,12 @@ def test_orchestration_preserves_complete_success_and_failure_evidence(
         assert observed["pods"][0]["images"]["dspace"]
         assert observed["pods"][0]["imageIDs"]["dspace"]
         assert "ownerReferences" in observed["pods"][0]
+        if failure == "verifier":
+            assert finalizations == []
         return
 
     result = rollback.rollback(args, runner)
+    assert finalizations[0]["runtime_verification"] == verifier_result()
     upgrade = next(command for command in commands if "upgrade" in command)
     assert f"oci://{manifest.CHART_REF}@{'sha256:' + '2' * 64}" in upgrade
     assert f"image.tag=main-abcdef0@{DIGEST}" in upgrade

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -532,6 +532,21 @@ def test_just_recipe_has_no_revision_rollback_or_reuse_values() -> None:
     assert "helm rollback" not in block
 
 
+def test_default_verifier_requires_smoke_runner(tmp_path: Path, capsys) -> None:
+    status = rollback.main(
+        [
+            "--environment",
+            "staging",
+            "--manifest",
+            str(tmp_path / "manifest.json"),
+            "--evidence",
+            str(tmp_path / "evidence.json"),
+        ]
+    )
+    assert status == 2
+    assert "--smoke-runner is required" in capsys.readouterr().err
+
+
 @pytest.mark.parametrize(
     ("failure", "failed_stage", "may_have_changed"),
     [

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -336,6 +336,25 @@ def finalize(**changes):
     return manifest.finalize(**arguments)
 
 
+def runtime_verification(**changes):
+    value = {
+        "schemaVersion": 1,
+        "environment": "staging",
+        "release": "dspace",
+        "namespace": "dspace",
+        "applicationVersion": "3.2.0",
+        "runtimeSourceRevision": SHA,
+        "frontendSourceRevision": SHA,
+        "defaultProvider": "token-place",
+        "journeys": [
+            {"name": "/", "passed": True},
+            {"name": "/chat", "passed": True},
+        ],
+    }
+    value.update(changes)
+    return value
+
+
 def test_finalize_collects_sorted_multi_pod_identity() -> None:
     final = finalize()
     assert final["helmRevision"] == 17
@@ -353,6 +372,26 @@ def test_finalize_collects_sorted_multi_pod_identity() -> None:
     }
 
 
+def test_finalize_records_validated_bounded_runtime_proof() -> None:
+    final = finalize(runtime_verification=runtime_verification())
+    results = {item["check"]: item["details"] for item in final["verificationResults"]}
+    assert {
+        "runtimeIdentity",
+        "frontendIdentity",
+        "replicaAgreement",
+        "publicDirectAgreement",
+        "defaultProvider",
+        "remoteChatSmoke",
+    } <= results.keys()
+    assert "successful public journeys=/,/chat" in results["remoteChatSmoke"]
+
+
+def test_finalize_rejects_runtime_proof_that_does_not_match_candidate() -> None:
+    proof = runtime_verification(runtimeSourceRevision="0" * 40)
+    with pytest.raises(manifest.ManifestError, match="invalid runtime verification"):
+        finalize(runtime_verification=proof)
+
+
 def test_finalize_optional_digest_coordinate_is_backward_compatible() -> None:
     assert finalize()["recordType"] == "final"
     coordinate = f"{manifest.IMAGE_REF}:main-abcdef0@{DIGEST}"
@@ -368,6 +407,37 @@ def test_generated_final_record_validates_through_cli(tmp_path: Path) -> None:
     output = tmp_path / "final.json"
     output.write_text(manifest._canonical(finalize()), encoding="utf-8")
     assert manifest.main(["validate", "--manifest", str(output), "--final"]) == 0
+
+
+def test_staging_gate_returns_revision_for_matching_promoted_artifact() -> None:
+    production = candidate()
+    production["environment"] = "prod"
+    staging = finalize()
+    assert manifest.staging_gate(production, staging) == 17
+
+
+@pytest.mark.parametrize(
+    ("candidate_environment", "evidence_environment", "changed_field", "message"),
+    [
+        ("staging", "staging", None, "candidate environment must be prod"),
+        ("prod", "prod", None, "evidence environment must be staging"),
+        ("prod", "staging", "imageDigest", "immutable coordinates differ: imageDigest"),
+    ],
+)
+def test_staging_gate_rejects_wrong_cluster_or_artifact(
+    candidate_environment: str,
+    evidence_environment: str,
+    changed_field: str | None,
+    message: str,
+) -> None:
+    production = candidate()
+    production["environment"] = candidate_environment
+    staging = finalize()
+    staging["environment"] = evidence_environment
+    if changed_field is not None:
+        production[changed_field] = "sha256:" + "9" * 64
+    with pytest.raises(manifest.ManifestError, match=message):
+        manifest.staging_gate(production, staging)
 
 
 def _replace_results(value, checks):
@@ -966,6 +1036,7 @@ def test_default_evidence_path_is_stable_and_approval_unique() -> None:
     assert str(manifest.evidence_path(candidate())) == (
         "deployment-evidence/dspace/staging/main-abcdef0-20260726T120000Z.json"
     )
+
 
 @pytest.mark.parametrize(
     ("change", "message"),

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -124,9 +124,12 @@ def test_accepts_strict_semver_prerelease_and_build(version: str) -> None:
     value = upstream()
     value["applicationVersion"] = version
     value["semanticTag"] = f"v{version}"
-    assert manifest.candidate(
-        value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator"
-    )["applicationVersion"] == version
+    assert (
+        manifest.candidate(value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator")[
+            "applicationVersion"
+        ]
+        == version
+    )
 
 
 @pytest.mark.parametrize(
@@ -331,6 +334,7 @@ def finalize(**changes):
         "namespace": "dspace",
         "cluster_environment": "staging",
         "invocation_description": "sugarkube-release-manifest:test-reservation",
+        "runtime_verification": runtime_verification(),
     }
     arguments.update(changes)
     return manifest.finalize(**arguments)
@@ -355,6 +359,12 @@ def runtime_verification(**changes):
     return value
 
 
+def write_runtime_verification(tmp_path: Path) -> Path:
+    path = tmp_path / "runtime-verification.json"
+    path.write_text(manifest._canonical(runtime_verification()), encoding="utf-8")
+    return path
+
+
 def test_finalize_collects_sorted_multi_pod_identity() -> None:
     final = finalize()
     assert final["helmRevision"] == 17
@@ -369,7 +379,44 @@ def test_finalize_collects_sorted_multi_pod_identity() -> None:
         "releaseOwnershipAndReadiness",
         "podImageCoordinates",
         "podImageDigests",
+        *manifest.RUNTIME_EVIDENCE_CHECKS,
     }
+
+
+def test_finalize_requires_runtime_proof_without_mutating_candidate() -> None:
+    approved = candidate()
+    original = json.loads(json.dumps(approved))
+    with pytest.raises(manifest.ManifestError, match="requires runtime verification"):
+        finalize(value=approved, runtime_verification=None)
+    assert approved == original
+
+
+def test_finalize_cli_requires_runtime_proof() -> None:
+    with pytest.raises(SystemExit) as exc:
+        manifest.main(
+            [
+                "finalize",
+                "--manifest",
+                "candidate.json",
+                "--output",
+                "evidence.json",
+                "--environment",
+                "staging",
+                "--image-tag",
+                "main-abcdef0",
+                "--chart-version",
+                "3.2.0",
+                "--kubeconfig",
+                "kubeconfig",
+                "--release",
+                "dspace",
+                "--namespace",
+                "dspace",
+                "--reservation",
+                "reservation",
+            ]
+        )
+    assert exc.value.code == 2
 
 
 def test_finalize_records_validated_bounded_runtime_proof() -> None:
@@ -414,6 +461,20 @@ def test_staging_gate_returns_revision_for_matching_promoted_artifact() -> None:
     production["environment"] = "prod"
     staging = finalize()
     assert manifest.staging_gate(production, staging) == 17
+
+
+def test_historical_proofless_record_validates_but_cannot_promote() -> None:
+    production = candidate()
+    production["environment"] = "prod"
+    historical = finalize()
+    historical["verificationResults"] = [
+        result
+        for result in historical["verificationResults"]
+        if result["check"] not in manifest.RUNTIME_EVIDENCE_CHECKS
+    ]
+    assert manifest.validate(historical, True)["recordType"] == "final"
+    with pytest.raises(manifest.ManifestError, match="lacks runtime verification"):
+        manifest.staging_gate(production, historical)
 
 
 @pytest.mark.parametrize(
@@ -465,9 +526,7 @@ def test_final_validation_requires_every_fixed_check(missing: str) -> None:
 @pytest.mark.parametrize("invalid", ["unknown", "imagePlatformSourceRevision[x]"])
 def test_final_validation_rejects_unknown_or_malformed_checks(invalid: str) -> None:
     value = finalize()
-    value["verificationResults"].append(
-        {"check": invalid, "passed": True, "details": "fabricated"}
-    )
+    value["verificationResults"].append({"check": invalid, "passed": True, "details": "fabricated"})
     with pytest.raises(manifest.ManifestError, match="unknown verification"):
         manifest.validate(value, True)
 
@@ -635,9 +694,7 @@ def test_reservation_is_atomic_and_bound_to_owner(tmp_path: Path) -> None:
     )
     metadata = json.loads(sidecar.read_text(encoding="utf-8"))
     assert metadata["output"] == str(output.resolve())
-    assert metadata["candidateFingerprint"] == manifest._candidate_fingerprint(
-        candidate()
-    )
+    assert metadata["candidateFingerprint"] == manifest._candidate_fingerprint(candidate())
 
 
 def test_reservation_rejects_existing_record_or_reservation(tmp_path: Path) -> None:
@@ -671,9 +728,7 @@ def test_reservation_binds_candidate_output_and_coordinates(tmp_path: Path) -> N
             )
 
 
-def test_post_reservation_failure_preserves_ownership(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_post_reservation_failure_preserves_ownership(tmp_path: Path, monkeypatch) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
     source.write_text(manifest._canonical(candidate()), encoding="utf-8")
@@ -681,9 +736,7 @@ def test_post_reservation_failure_preserves_ownership(
     monkeypatch.setattr(
         manifest,
         "preflight",
-        lambda *args, **kwargs: (_ for _ in ()).throw(
-            manifest.ManifestError("OCI failed")
-        ),
+        lambda *args, **kwargs: (_ for _ in ()).throw(manifest.ManifestError("OCI failed")),
     )
     assert (
         manifest.main(
@@ -707,6 +760,8 @@ def test_post_reservation_failure_preserves_ownership(
                 "dspace",
                 "--reservation",
                 owner,
+                "--runtime-verification",
+                str(write_runtime_verification(tmp_path)),
             ]
         )
         == 2
@@ -805,6 +860,8 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
                 "dspace",
                 "--reservation",
                 owner,
+                "--runtime-verification",
+                str(write_runtime_verification(tmp_path)),
             ]
         )
         == 0
@@ -860,10 +917,27 @@ def test_finalize_cli_settling_failure_preserves_reservation(
 
     monkeypatch.setattr(manifest, "_run", run)
     args = [
-        "finalize", "--manifest", str(source), "--output", str(output),
-        "--environment", "staging", "--image-tag", "main-abcdef0",
-        "--chart-version", "3.2.0", "--kubeconfig", "kubeconfig",
-        "--release", "dspace", "--namespace", "dspace", "--reservation", owner,
+        "finalize",
+        "--manifest",
+        str(source),
+        "--output",
+        str(output),
+        "--environment",
+        "staging",
+        "--image-tag",
+        "main-abcdef0",
+        "--chart-version",
+        "3.2.0",
+        "--kubeconfig",
+        "kubeconfig",
+        "--release",
+        "dspace",
+        "--namespace",
+        "dspace",
+        "--reservation",
+        owner,
+        "--runtime-verification",
+        str(write_runtime_verification(tmp_path)),
     ]
     assert manifest.main(args) == 2
     assert not output.exists()
@@ -905,25 +979,38 @@ def test_finalize_cli_rejects_changed_helm_binding_and_preserves_reservation(
                     status["info"]["description"] = "another invocation"
             return json.dumps(status)
         resource = command[command.index("get") + 1]
-        return json.dumps(
-            {"items": [pod("dspace-a")]} if resource == "pods" else workloads()
-        )
+        return json.dumps({"items": [pod("dspace-a")]} if resource == "pods" else workloads())
 
     monkeypatch.setattr(manifest, "_run", run)
     args = [
-        "finalize", "--manifest", str(source), "--output", str(output),
-        "--environment", "staging", "--image-tag", "main-abcdef0",
-        "--chart-version", "3.2.0", "--kubeconfig", "kubeconfig",
-        "--release", "dspace", "--namespace", "dspace", "--reservation", owner,
+        "finalize",
+        "--manifest",
+        str(source),
+        "--output",
+        str(output),
+        "--environment",
+        "staging",
+        "--image-tag",
+        "main-abcdef0",
+        "--chart-version",
+        "3.2.0",
+        "--kubeconfig",
+        "kubeconfig",
+        "--release",
+        "dspace",
+        "--namespace",
+        "dspace",
+        "--reservation",
+        owner,
+        "--runtime-verification",
+        str(write_runtime_verification(tmp_path)),
     ]
     assert manifest.main(args) == 2
     assert not output.exists()
     assert manifest.reservation_path(output).exists()
 
 
-def test_public_read_only_and_reservation_dispatch(
-    tmp_path: Path, monkeypatch, capsys
-) -> None:
+def test_public_read_only_and_reservation_dispatch(tmp_path: Path, monkeypatch, capsys) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
     source.write_text(manifest._canonical(candidate()), encoding="utf-8")
@@ -934,9 +1021,7 @@ def test_public_read_only_and_reservation_dispatch(
         preflight_calls.append(args)
         return real_preflight(*args, **kwargs, runner=oras_runner())
 
-    oci_results = checked_preflight(
-        candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras"
-    )
+    oci_results = checked_preflight(candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras")
     preflight_calls.clear()
     monkeypatch.setattr(manifest, "preflight", checked_preflight)
 
@@ -1017,16 +1102,9 @@ def test_preflight_chart_coordinate_is_not_printed_after_failed_validation(
     monkeypatch.setattr(
         manifest,
         "preflight",
-        lambda *args, **kwargs: real_preflight(
-            *args, **kwargs, runner=oras_runner()
-        ),
+        lambda *args, **kwargs: real_preflight(*args, **kwargs, runner=oras_runner()),
     )
-    assert (
-        manifest.main(
-            ["preflight", "--manifest", str(source), "--print-chart-coordinate"]
-        )
-        == 2
-    )
+    assert manifest.main(["preflight", "--manifest", str(source), "--print-chart-coordinate"]) == 2
     captured = capsys.readouterr()
     assert captured.out == ""
     assert "chartDigest" in captured.err


### PR DESCRIPTION
### Motivation

- Prevent production promotions from advancing when the approved DSPACE release artifact, live staging replicas, frontend identity, or the non-destructive `/chat` journey have drifted or become unsafe. 
- Make runtime identity and the isolated `/chat` smoke proof mandatory both before production reservation/mutation and after rollout, while preserving existing immutable-manifest, evidence reservation, and rollback contracts. 
- Preserve backward compatibility with existing finalized evidence (schema v1) and reuse the same verifier contract used by the rollback path.

### Description

- Add an argv-only DSPACE runtime verifier at `scripts/dspace_runtime_verifier.py` implementing the required `capabilities` and `verify` contract and preserving the ordered capability list `applicationVersion, runtimeSourceRevision, frontendSourceRevision, defaultProvider, publicJourneys`.
- Add focused just recipe `dspace-release-verify` (in `justfile`) which runs the verifier with explicit argv parameters and accepts a required `smoke_runner` executable path; wire that recipe into DSPACE deploy/redeploy/promote wrappers so the runtime gate is enforced consistently across staging and production flows.
- Add a `staging-gate` check and `runtime_args` inspector to `scripts/dspace_release_manifest.py`, a `staging_gate()` helper that compares immutable release coordinates between a prod candidate and finalized staging evidence, and extend `finalize()` to accept additive `--runtime-verification` evidence while validating its exact schema fields (keeps historical finalized records usable).
- Wire the new verifier into the existing rollback path (`scripts/dspace_manifest_rollback.py`) as the default verifier while retaining the ability to specify a custom verifier and preserving the prior rollback behavior and diagnostics.
- Enforce safety rules in the verifier: check public `/build-info.json` identity and `<meta name="dspace-build-revision">` frontend marker, enumerate and validate every running/Ready pod and container image/digest, probe each pod via read-only `kubectl --raw` proxy, reject redirects to other origins, derive `token.place` expectations from the reviewed values chain (omit token.place args when provider is `openai`), and execute the DSPACE remote-chat harness as argv (never via a shell fragment), capturing but not echoing child output.
- Keep diagnostics and evidence bounded: the verifier returns only the approved identity facts and journeys, and `finalize()` records additive runtime checks (e.g. `runtimeIdentity`, `frontendIdentity`, `replicaAgreement`, `publicDirectAgreement`, `defaultProvider`, `remoteChatSmoke`) without persisting response bodies, child output, or secrets.
- Documentation updates: add usage and guidance to `docs/apps/dspace.md`, `docs/app_deployment_contract.md` and note the `smoke_runner` requirement in `docs/examples/apps/dspace.env`.

### Testing

- Ran the focused verifier + manifest + rollback suites with: `python3 -m pytest -q tests/test_dspace_runtime_verifier.py tests/test_release_manifest.py tests/test_manifest_rollback.py tests/test_up_recipe_calls.py` and related targeted runs; overall result: `178 passed` for the exercised suites including the new hermetic verifier tests (`tests/test_dspace_runtime_verifier.py`).
- Static checks: `python3 -m flake8 scripts/dspace_runtime_verifier.py scripts/dspace_release_manifest.py scripts/dspace_manifest_rollback.py tests/test_dspace_runtime_verifier.py` passed for the modified files after formatting; `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` passed in this environment after installing required spellcheck tooling; `bash scripts/test-helm-oci-install.sh` was also exercised and passed.
- `just --unstable --fmt --check` and `pre-commit run --all-files` were exercised where possible; `pre-commit` surfaced unrelated repository baseline YAML/flake8 issues which are pre-existing and were not weakened or changed by this PR (no unrelated files were altered to silence hooks).

Closes #2328

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69b1eec998832f957e6ecf3ced31eb)