### PR TITLE
Enforce DSPACE source‑integrity and /chat promotion gates

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -379,3 +379,21 @@ Current values chains:
 | token.place | `docs/examples/tokenplace.values.dev.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml` | `/,/livez,/healthz,/relay/diagnostics` |
 | danielsmith.io | `docs/examples/danielsmith.values.dev.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml` | `/,/livez,/healthz` |
 | jobbot3000 | `docs/examples/jobbot3000.values.dev.yaml` | `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml` | `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.prod.yaml` | `/,/healthz,/livez` |
+
+### DSPACE runtime promotion gate
+
+DSPACE alone adds a mandatory source-integrity and remote `/chat` gate to the shared contract.
+`just dspace-release-verify` consumes an approved candidate or finalized record, an executable DSPACE
+`run-remote-chat-smoke.mjs`, the resolved app config, and kubeconfig. Standard staging operations run
+it after rollout and before final evidence is written. Production additionally requires finalized
+staging evidence for identical application/source/image/chart/semantic/provider coordinates and
+re-verifies live staging before any production reservation, render, Helm command, or Kubernetes
+mutation. The live Helm revision must still equal staging evidence, and production verification must
+finish before successful evidence finalization. Other applications retain the generic ordering.
+
+The DSPACE harness is argv-only, mocks provider transport, and requires no real provider credentials.
+Token.place defaults use origin/model expectations from the ordered environment values chain;
+OpenAI defaults omit both token.place arguments while still proving OpenAI discoverability and
+missing-key gating. Verification evidence is bounded identity/journey metadata, never response or
+child-process content. Existing finalized records without the additive runtime checks remain valid
+for historical audit and rollback.

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -477,3 +477,54 @@ just helm-oci-install release=dspace namespace=dspace chart=oci://ghcr.io/democr
 ```bash
 just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.staging.version tag="$APP_TAG" env=staging
 ```
+
+## Mandatory source-integrity and `/chat` proof
+
+Use a DSPACE checkout whose dependencies have been installed with `pnpm install`, then install the
+browser with `pnpm exec playwright install chromium`. The smoke runner must be the executable file
+from that checkout; Sugarkube invokes it directly as argv and captures, but never records or prints,
+its output. No token.place or OpenAI credential is required or accepted: the runner uses an isolated
+browser context and mocked provider transport.
+
+```bash
+DSPACE_SMOKE_RUNNER="$HOME/dspace/scripts/run-remote-chat-smoke.mjs"
+chmod +x "$DSPACE_SMOKE_RUNNER"
+
+just dspace-release-verify \
+  env=staging \
+  manifest=deployment-evidence/dspace/staging/<finalized-record>.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER"
+```
+
+The verifier derives the public host and token.place origin/model from the selected, ordered values
+chain, then cross-checks every Running, Ready release replica through the read-only Kubernetes API
+pod proxy. It verifies `/build-info.json`, the shared-layout revision marker, immutable pod image
+coordinates and digests, replica agreement, and the isolated `/chat` journey. For a token.place
+release, origin and model expectations are passed to the runner; for an OpenAI-default release they
+are omitted. Public redirects to another origin fail closed.
+
+Create finalized staging evidence through the standard manifest-backed staging deployment. A
+production promotion must use the matching production candidate and that finalized staging record:
+
+```bash
+just app-deploy app=dspace env=staging tag=main-REPLACE_SHORTSHA \
+  manifest=deployment-candidates/dspace/staging.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER"
+
+just app-promote-prod \
+  app=dspace \
+  tag=main-REPLACE_SHORTSHA \
+  manifest=deployment-candidates/dspace/prod.json \
+  staging_evidence=deployment-evidence/dspace/staging/<finalized-record>.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER"
+```
+
+Successful records remain under `deployment-evidence/dspace/<environment>/`. Runtime verification
+adds only bounded booleans and identity summaries; it never stores HTTP bodies, HTML, child output,
+browser artifacts, headers, cookies, payloads, keys, or provider ciphertext. Historical finalized
+schema-version 1 evidence remains valid because the newer runtime checks are additive.
+
+A failure before mutation removes an owned reservation. A failure after Helm mutation preserves the
+reservation for explicit reconciliation and never finalizes success, retries, downgrades, or rolls
+back automatically. Inspect the cluster and reserved destination, then either complete reconciliation
+or remove only the confirmed stale `.reservation` sidecar before a deliberate retry.

--- a/justfile
+++ b/justfile
@@ -1670,7 +1670,7 @@ app-config app env='staging' config='':
       --config {{ quote(config) }}
 
 # DSPACE-only fail-closed recovery from previously finalized immutable evidence.
-dspace-manifest-rollback env manifest evidence verifier confirm='' config='' kubeconfig='':
+dspace-manifest-rollback env manifest evidence verifier='scripts/dspace_runtime_verifier.py' smoke_runner='' confirm='' config='' kubeconfig='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
     kubeconfig_path={{ quote(kubeconfig) }}
@@ -1682,12 +1682,26 @@ dspace-manifest-rollback env manifest evidence verifier confirm='' config='' kub
       --manifest {{ quote(manifest) }} \
       --evidence {{ quote(evidence) }} \
       --verifier {{ quote(verifier) }} \
+      --smoke-runner {{ quote(smoke_runner) }} \
       --confirm {{ quote(confirm) }} \
       --config {{ quote(config) }} \
       --kubeconfig "${kubeconfig_path}"
 
+# Prove DSPACE public/direct runtime identity and the isolated /chat journey.
+dspace-release-verify env manifest smoke_runner config='' kubeconfig='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    kubeconfig_path={{ quote(kubeconfig) }}
+    if [ -z "${kubeconfig_path}" ]; then kubeconfig_path="${KUBECONFIG:-${HOME}/.kube/config}"; fi
+    eval "$(python3 "{{ justfile_directory() }}/scripts/app_config.py" shell --app dspace --env {{ quote(env) }} --config {{ quote(config) }})"
+    "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" verify \
+      --environment "${SUGARKUBE_ENV}" --release "${SUGARKUBE_RELEASE}" \
+      --namespace "${SUGARKUBE_NAMESPACE}" --manifest {{ quote(manifest) }} \
+      --smoke-runner {{ quote(smoke_runner) }} --config "${SUGARKUBE_CONFIG_PATH}" \
+      --kubeconfig "${kubeconfig_path}"
+
 # Generic immutable-tag app deploy backed by docs/examples/apps/*.env or local app configs.
-app-deploy app env='staging' tag='' config='' manifest='' evidence='':
+app-deploy app env='staging' tag='' config='' manifest='' evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1698,6 +1712,8 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
       --tag {{ quote(tag) }} \
       --require-tag)"
     eval "${config_exports}"
+    dspace_smoke_runner={{ quote(smoke_runner) }}
+    [ -n "${dspace_smoke_runner}" ] || dspace_smoke_runner="${DSPACE_SMOKE_RUNNER:-}"
 
     release_manifest={{ quote(manifest) }}
     evidence_output={{ quote(evidence) }}
@@ -1708,6 +1724,7 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
         echo "ERROR: manifest=<approved-candidate.json> is required for DSPACE ${SUGARKUBE_ENV}." >&2
         exit 2
       fi
+      if [ -z "${dspace_smoke_runner}" ]; then echo "ERROR: smoke_runner=<executable> is required for DSPACE verification." >&2; exit 2; fi
       chart_version="${SUGARKUBE_VERSION:-}"
       if [ -z "${chart_version}" ]; then
         chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -n1)"
@@ -1757,16 +1774,25 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
     fi
     [ -z "${mutation_marker:-}" ] || rm -f "${mutation_marker}"
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
+      runtime_proof="$(mktemp)"
+      if ! "${SUGARKUBE_DSPACE_RUNTIME_VERIFIER:-{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py}" verify \
+        --environment "${SUGARKUBE_ENV}" --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
+        --manifest "${release_manifest}" --smoke-runner "${dspace_smoke_runner}" \
+        --config "${SUGARKUBE_CONFIG_PATH}" --kubeconfig "${KUBECONFIG}" >"${runtime_proof}"; then
+        rm -f "${runtime_proof}"
+        exit 1
+      fi
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize \
         --manifest "${release_manifest}" --output "${evidence_output}" \
         --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" \
         --chart-version "${chart_version}" --kubeconfig "${KUBECONFIG}" \
         --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
-        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}"
+        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}" --runtime-proof "${runtime_proof}"
+      rm -f "${runtime_proof}"
     fi
 
 # Generic upgrade-only app redeploy backed by app config files.
-app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
+app-redeploy app env='staging' tag='' config='' manifest='' evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1777,6 +1803,8 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
       --tag {{ quote(tag) }} \
       --require-tag)"
     eval "${config_exports}"
+    dspace_smoke_runner={{ quote(smoke_runner) }}
+    [ -n "${dspace_smoke_runner}" ] || dspace_smoke_runner="${DSPACE_SMOKE_RUNNER:-}"
 
     release_manifest={{ quote(manifest) }}
     evidence_output={{ quote(evidence) }}
@@ -1784,6 +1812,7 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
     while [ "${evidence_output#evidence=}" != "${evidence_output}" ]; do evidence_output="${evidence_output#evidence=}"; done
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
       if [ -z "${release_manifest}" ]; then echo "ERROR: manifest=<approved-candidate.json> is required for DSPACE ${SUGARKUBE_ENV}." >&2; exit 2; fi
+      if [ -z "${dspace_smoke_runner}" ]; then echo "ERROR: smoke_runner=<executable> is required for DSPACE verification." >&2; exit 2; fi
       chart_version="${SUGARKUBE_VERSION:-}"
       if [ -z "${chart_version}" ]; then chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -n1)"; fi
       chart_coordinate="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" preflight --manifest "${release_manifest}" --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" \
@@ -1827,14 +1856,18 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
     fi
     [ -z "${mutation_marker:-}" ] || rm -f "${mutation_marker}"
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
+      runtime_proof="$(mktemp)"
+      if ! "${SUGARKUBE_DSPACE_RUNTIME_VERIFIER:-{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py}" verify --environment "${SUGARKUBE_ENV}" --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
+        --manifest "${release_manifest}" --smoke-runner "${dspace_smoke_runner}" --config "${SUGARKUBE_CONFIG_PATH}" --kubeconfig "${KUBECONFIG}" >"${runtime_proof}"; then rm -f "${runtime_proof}"; exit 1; fi
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize --manifest "${release_manifest}" --output "${evidence_output}" \
         --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" --kubeconfig "${KUBECONFIG}" \
         --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
-        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}"
+        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}" --runtime-proof "${runtime_proof}"
+      rm -f "${runtime_proof}"
     fi
 
 # Promote an app to prod with an explicit immutable tag, or the configured prod tag file.
-app-promote-prod app tag='' config='' manifest='' evidence='':
+app-promote-prod app tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1846,10 +1879,20 @@ app-promote-prod app tag='' config='' manifest='' evidence='':
       --prod-tag-fallback \
       --require-tag)"
     eval "${config_exports}"
+    if [ "${SUGARKUBE_APP}" = dspace ]; then
+      if [ -z {{ quote(staging_evidence) }} ] || [ -z {{ quote(smoke_runner) }} ]; then
+        echo "ERROR: staging_evidence=<finalized-staging.json> and smoke_runner=<executable> are required for DSPACE production." >&2; exit 2
+      fi
+      python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" validate-promotion --manifest {{ quote(manifest) }} --staging-evidence {{ quote(staging_evidence) }}
+      staging_kubeconfig="${HOME}/.kube/config"
+      just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env staging
+      just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify env=staging manifest={{ quote(staging_evidence) }} smoke_runner={{ quote(smoke_runner) }} config={{ quote(config) }} kubeconfig="${staging_kubeconfig}" >/dev/null
+    fi
     delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-deploy \
       app="${SUGARKUBE_APP}" env=prod tag="${SUGARKUBE_TAG}" config="${SUGARKUBE_CONFIG_PATH}")
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Show the pinned chart version and whether a newer semver chart appears published.
@@ -1975,17 +2018,18 @@ app-cors-verify app env='staging' config='' origin='https://cors-smoke.invalid' 
 #
 
 # Use this for steady-state release validation flows where explicit image pinning matters.
-dspace-oci-deploy env='staging' tag='' manifest='' evidence='':
+dspace-oci-deploy env='staging' tag='' manifest='' evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
     delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-deploy app=dspace env={{ quote(env) }} tag={{ quote(tag) }})
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Use this for optional canary/smoke testing before or alongside apex promotion workflows.
-dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='':
+dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1993,12 +2037,13 @@ dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='':
       "{{ justfile_directory() }}/docs/examples/apps/dspace-prod-subdomain.env")
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Promote dspace to production apex (democratized.space) using immutable tags.
 
 # If tag is omitted, this reads the pinned value from docs/apps/dspace.prod.tag.
-dspace-oci-promote-prod tag='' manifest='' evidence='':
+dspace-oci-promote-prod tag='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -2009,19 +2054,22 @@ dspace-oci-promote-prod tag='' manifest='' evidence='':
       --prod-tag-fallback \
       --require-tag)"
     eval "${config_exports}"
-    delegate=(just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy env=prod tag="${SUGARKUBE_TAG}")
+    delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-promote-prod app=dspace tag="${SUGARKUBE_TAG}" config="${SUGARKUBE_CONFIG_PATH}")
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Fast redeploy of dspace from GHCR (emergency mutable-tag refresh).
-dspace-oci-redeploy env='staging' tag='' manifest='' evidence='':
+dspace-oci-redeploy env='staging' tag='' manifest='' evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
     delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-redeploy app=dspace env={{ quote(env) }} tag={{ quote(tag) }})
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Dump dspace and Traefik logs for debugging HTTP 500s.

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -740,6 +740,20 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             "--provider",
             target["expectedDefaultChatProvider"],
         ]
+        if (
+            args.verifier.resolve()
+            == Path(__file__).with_name("dspace_runtime_verifier.py").resolve()
+        ):
+            verifier_command += [
+                "--manifest",
+                str(args.manifest),
+                "--smoke-runner",
+                str(args.smoke_runner),
+                "--config",
+                args.config,
+                "--kubeconfig",
+                args.kubeconfig,
+            ]
         failed_stage = "runtime-verification"
         verifier = validate_verifier_result(
             json_command(runner, verifier_command, "runtime verifier"), target, args.environment
@@ -790,8 +804,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "status": observed_info.get("status"),
                 "chartName": observed_chart.get("name"),
                 "chartVersion": chart_version(observed_helm),
-                "invocationDescriptionMatches": observed_info.get("description")
-                == description,
+                "invocationDescriptionMatches": observed_info.get("description") == description,
             }
         except Exception:
             diagnostics["helm"] = "unavailable"
@@ -823,6 +836,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--manifest", type=Path, required=True)
     parser.add_argument("--evidence", type=Path, required=True)
     parser.add_argument("--verifier", type=Path, required=True)
+    parser.add_argument("--smoke-runner", type=Path, default=Path(""))
     parser.add_argument("--confirm", default="")
     parser.add_argument("--config", default="")
     parser.add_argument("--kubeconfig", default=str(Path.home() / ".kube" / "config-sugarkube"))

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -69,6 +69,14 @@ FINAL_FIXED_CHECKS = {
     "podImageCoordinates",
     "podImageDigests",
 }
+RUNTIME_CHECKS = {
+    "runtimeIdentity",
+    "frontendIdentity",
+    "replicaAgreement",
+    "publicDirectOriginAgreement",
+    "defaultProvider",
+    "remoteChatSmoke",
+}
 PLATFORM_CHECK_RE = re.compile(r"^imagePlatformSourceRevision\[(0|[1-9][0-9]*)\]$")
 POD_SETTLE_TIMEOUT_SECONDS = 60.0
 POD_SETTLE_INTERVAL_SECONDS = 2.0
@@ -206,15 +214,13 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
             platform_match = PLATFORM_CHECK_RE.fullmatch(check)
             if platform_match:
                 platform_indices.append(int(platform_match.group(1)))
-            elif check not in FINAL_FIXED_CHECKS:
+            elif check not in FINAL_FIXED_CHECKS | RUNTIME_CHECKS:
                 raise ManifestError(f"unknown verification result: {check}")
         missing = sorted(FINAL_FIXED_CHECKS - checks)
         if missing:
             raise ManifestError("missing verification results: " + ", ".join(missing))
         if sorted(platform_indices) != list(range(len(platform_indices))):
-            raise ManifestError(
-                "image platform verification indices must be contiguous from zero"
-            )
+            raise ManifestError("image platform verification indices must be contiguous from zero")
         if not platform_indices:
             raise ManifestError("at least one image platform verification result is required")
     return value
@@ -235,9 +241,7 @@ def _write_new(path: Path, value: dict[str, Any]) -> None:
         try:
             os.link(temporary, path)
         except FileExistsError as exc:
-            raise ManifestError(
-                f"refusing to overwrite existing record: {path}"
-            ) from exc
+            raise ManifestError(f"refusing to overwrite existing record: {path}") from exc
         _sync_directory(path.parent)
     finally:
         Path(temporary).unlink(missing_ok=True)
@@ -290,9 +294,7 @@ def reserve(
     try:
         fd = os.open(sidecar, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     except FileExistsError as exc:
-        raise ManifestError(
-            f"evidence destination is already reserved: {sidecar}"
-        ) from exc
+        raise ManifestError(f"evidence destination is already reserved: {sidecar}") from exc
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as stream:
             stream.write(_canonical(metadata))
@@ -328,9 +330,7 @@ def verify_reservation(
     if not secrets.compare_digest(
         json.dumps(metadata, sort_keys=True), json.dumps(expected, sort_keys=True)
     ):
-        raise ManifestError(
-            "reservation ownership or deployment coordinates do not match"
-        )
+        raise ManifestError("reservation ownership or deployment coordinates do not match")
     if normalized.exists():
         raise ManifestError(f"refusing to overwrite existing record: {normalized}")
     return sidecar
@@ -366,6 +366,27 @@ def evidence_path(value: dict[str, Any]) -> Path:
         / value["environment"]
         / (f"{value['imageTag']}-{approved}.json")
     )
+
+
+def validate_promotion(candidate_value: dict[str, Any], staging_value: dict[str, Any]) -> None:
+    """Require finalized staging proof for exactly the production artifact."""
+    validate(candidate_value, False)
+    validate(staging_value, True)
+    if candidate_value["environment"] != "prod" or staging_value["environment"] != "staging":
+        raise ManifestError("promotion requires a prod candidate and finalized staging evidence")
+    coordinates = (
+        "applicationVersion",
+        "sourceRevision",
+        "imageTag",
+        "imageDigest",
+        "chartVersion",
+        "chartDigest",
+        "semanticTag",
+        "expectedDefaultChatProvider",
+    )
+    mismatches = [field for field in coordinates if candidate_value[field] != staging_value[field]]
+    if mismatches:
+        raise ManifestError("staging evidence artifact mismatch: " + ", ".join(mismatches))
 
 
 def _run(command: list[str]) -> str:
@@ -548,6 +569,7 @@ def finalize(
     cluster_environment: str,
     invocation_description: str,
     expected_image_coordinate: str | None = None,
+    runtime_proof: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     validate(value, False)
     selected = {
@@ -668,7 +690,10 @@ def finalize(
         {
             "check": "selectedCoordinates",
             "passed": True,
-            "details": f"environment={environment}; imageTag={image_tag}; chartVersion={chart_version}",
+            "details": (
+                f"environment={environment}; imageTag={image_tag}; "
+                f"chartVersion={chart_version}"
+            ),
         },
         {
             "check": "clusterEnvironment",
@@ -689,8 +714,7 @@ def finalize(
             # Helm metadata proves name/version, not immutable OCI content. The
             # guarded mutation therefore installs this approved digest directly.
             "details": (
-                f"chart=dspace; version={chart_version}; "
-                f"coordinate={chart_coordinate(value)}"
+                f"chart=dspace; version={chart_version}; " f"coordinate={chart_coordinate(value)}"
             ),
         },
         {
@@ -709,6 +733,24 @@ def finalize(
             "details": "every running pod imageID matched approved image digest",
         },
     ]
+    if runtime_proof is not None:
+        from scripts.dspace_manifest_rollback import validate_verifier_result
+
+        validate_verifier_result(runtime_proof, value, environment)
+        runtime_details = {
+            "runtimeIdentity": "approved application version and full source revision reported",
+            "frontendIdentity": "public and direct frontend revision markers matched approval",
+            "replicaAgreement": (
+                f"all {len(pods)} serving replica(s) reported one approved revision"
+            ),
+            "publicDirectOriginAgreement": "public and every direct-origin identity agreed",
+            "defaultProvider": f"approved default provider={value['expectedDefaultChatProvider']}",
+            "remoteChatSmoke": "isolated /chat public journey passed without provider traffic",
+        }
+        results.extend(
+            {"check": check, "passed": True, "details": details}
+            for check, details in runtime_details.items()
+        )
     result = dict(value)
     result.update(
         recordType="final",
@@ -755,9 +797,8 @@ def main(argv: list[str] | None = None) -> int:
     finish.add_argument("--image-ref", default=IMAGE_REF)
     finish.add_argument("--chart-ref", default=CHART_REF)
     finish.add_argument("--reservation", required=True)
-    finish.add_argument(
-        "--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras")
-    )
+    finish.add_argument("--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
+    finish.add_argument("--runtime-proof", type=Path)
     available = sub.add_parser("check-output")
     available.add_argument("--output", type=Path, required=True)
     destination = sub.add_parser("evidence-path")
@@ -768,6 +809,9 @@ def main(argv: list[str] | None = None) -> int:
     claim.add_argument("--environment", required=True)
     claim.add_argument("--release", required=True)
     claim.add_argument("--namespace", required=True)
+    promotion = sub.add_parser("validate-promotion")
+    promotion.add_argument("--manifest", type=Path, required=True)
+    promotion.add_argument("--staging-evidence", type=Path, required=True)
     args = parser.parse_args(argv)
     try:
         if args.command == "candidate":
@@ -885,6 +929,7 @@ def main(argv: list[str] | None = None) -> int:
                 namespace=args.namespace,
                 cluster_environment=cluster_environment,
                 invocation_description=invocation_description,
+                runtime_proof=_object(args.runtime_proof) if args.runtime_proof else None,
             )
             sidecar = verify_reservation(
                 args.output,
@@ -909,19 +954,16 @@ def main(argv: list[str] | None = None) -> int:
                     metadata.get("version"),
                 )
 
-            if (
-                binding_fields(settled_helm) != binding_fields(helm)
-                or binding_fields(stable_helm) != binding_fields(helm)
-            ):
+            if binding_fields(settled_helm) != binding_fields(helm) or binding_fields(
+                stable_helm
+            ) != binding_fields(helm):
                 raise ManifestError("Helm release changed during evidence collection")
             _write_new(args.output, result)
             sidecar.unlink()
             _sync_directory(args.output.expanduser().resolve(strict=False).parent)
         elif args.command == "check-output":
             if args.output.exists():
-                raise ManifestError(
-                    f"refusing to overwrite existing record: {args.output}"
-                )
+                raise ManifestError(f"refusing to overwrite existing record: {args.output}")
         elif args.command == "reserve":
             sys.stdout.write(
                 reserve(
@@ -933,6 +975,8 @@ def main(argv: list[str] | None = None) -> int:
                 )
                 + "\n"
             )
+        elif args.command == "validate-promotion":
+            validate_promotion(_object(args.manifest), _object(args.staging_evidence))
         else:
             sys.stdout.write(str(evidence_path(_object(args.manifest))) + "\n")
     except (ManifestError, json.JSONDecodeError) as exc:

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Fail-closed, non-destructive DSPACE runtime and chat verification."""
+
+from __future__ import annotations
+
+import argparse
+import html.parser
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import app_chart, app_config  # noqa: E402
+from scripts import dspace_release_manifest as release_manifest  # noqa: E402
+
+CAPABILITIES = (
+    "applicationVersion",
+    "runtimeSourceRevision",
+    "frontendSourceRevision",
+    "defaultProvider",
+    "publicJourneys",
+)
+IMAGE_REF = release_manifest.IMAGE_REF
+SAFE_STAGES = {
+    "manifest/evidence mismatch",
+    "cluster identity",
+    "pod/replica identity",
+    "public identity",
+    "direct identity",
+    "provider/chat smoke",
+}
+
+
+class VerificationError(ValueError):
+    """A bounded, non-secret verification failure."""
+
+    def __init__(self, stage: str, message: str):
+        if stage not in SAFE_STAGES:
+            stage = "cluster identity"
+        super().__init__(f"{stage}: {message}")
+
+
+Runner = Callable[[list[str]], str]
+
+
+def run(command: list[str]) -> str:
+    """Run argv without exposing child output."""
+    try:
+        completed = subprocess.run(command, capture_output=True, text=True, check=False)
+    except OSError as exc:
+        raise VerificationError(
+            "cluster identity", "required command could not be started"
+        ) from exc
+    if completed.returncode:
+        raise VerificationError("cluster identity", "required command failed")
+    return completed.stdout
+
+
+def exact_fields(value: dict[str, Any], expected: tuple[str, ...], label: str) -> None:
+    if set(value) != set(expected):
+        raise VerificationError("manifest/evidence mismatch", f"{label} schema is invalid")
+
+
+def read_manifest(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(value, dict):
+            raise ValueError
+        release_manifest.validate(value, value.get("recordType") == "final")
+        return value
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise VerificationError(
+            "manifest/evidence mismatch", "approved manifest is invalid"
+        ) from exc
+
+
+class RevisionParser(html.parser.HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.revision: str | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        values = dict(attrs)
+        if tag.lower() == "meta" and values.get("name") == "dspace-build-revision":
+            self.revision = values.get("content")
+
+
+def http_get(url: str, expected_origin: str, opener=urllib.request.urlopen) -> bytes:
+    try:
+        response = opener(
+            urllib.request.Request(url, headers={"Accept": "application/json,text/html"})
+        )
+        final = urllib.parse.urlsplit(response.geturl())
+        origin = f"{final.scheme}://{final.netloc}"
+        if origin != expected_origin:
+            raise VerificationError("public identity", "redirected to an unexpected origin")
+        return response.read(1024 * 1024 + 1)
+    except VerificationError:
+        raise
+    except (OSError, urllib.error.URLError) as exc:
+        raise VerificationError("public identity", "public endpoint is unreachable") from exc
+
+
+def identity(body: bytes, expected: dict[str, Any], stage: str) -> dict[str, str]:
+    try:
+        value = json.loads(body)
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise VerificationError(stage, "build identity is malformed") from exc
+    if not isinstance(value, dict):
+        raise VerificationError(stage, "build identity is malformed")
+    wanted = {
+        "applicationVersion": expected["applicationVersion"],
+        "revision": expected["sourceRevision"],
+        "shortRevision": expected["sourceRevision"][:7],
+    }
+    if any(value.get(key) != item for key, item in wanted.items()):
+        raise VerificationError(stage, "build version or revision does not match approval")
+    coordinate = value.get("image") or value.get("imageCoordinate")
+    if coordinate is not None and coordinate not in {
+        f"{IMAGE_REF}:{expected['imageTag']}",
+        f"{IMAGE_REF}:{expected['imageTag']}@{expected['imageDigest']}",
+    }:
+        raise VerificationError(stage, "runtime image coordinate does not match approval")
+    return wanted
+
+
+def frontend(body: bytes, revision: str, stage: str) -> None:
+    try:
+        parser = RevisionParser()
+        parser.feed(body.decode("utf-8"))
+    except (UnicodeError, ValueError) as exc:
+        raise VerificationError(stage, "frontend revision marker is malformed") from exc
+    if parser.revision != revision:
+        raise VerificationError(stage, "frontend revision marker does not match approval")
+
+
+def value_expectations(config: dict[str, str]) -> tuple[str, str, str]:
+    values = tuple(item.strip() for item in config["SUGARKUBE_VALUES"].split(",") if item.strip())
+    document = app_chart.merged_values_document(values)
+    host = app_chart.scalar(app_chart.nested_value(document, ("ingress", "host"))[1])
+    origin = model = ""
+    env = app_chart.nested_value(document, ("env",))[1]
+    if isinstance(env, list):
+        mapped = {
+            item.get("name"): item.get("value")
+            for item in env
+            if isinstance(item, dict) and isinstance(item.get("name"), str)
+        }
+        origin = app_chart.scalar(mapped.get("DSPACE_TOKEN_PLACE_URL"))
+        model = app_chart.scalar(mapped.get("DSPACE_TOKEN_PLACE_CHAT_MODEL"))
+    if not host:
+        raise VerificationError("manifest/evidence mismatch", "values do not resolve ingress host")
+    return host, origin, model
+
+
+def pod_items(raw: str, expected: dict[str, Any]) -> list[dict[str, str]]:
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise VerificationError("cluster identity", "pod inventory is malformed") from exc
+    items = value.get("items") if isinstance(value, dict) else None
+    if not isinstance(items, list) or not items:
+        raise VerificationError("pod/replica identity", "no serving DSPACE pods were found")
+    result = []
+    for item in items:
+        metadata = item.get("metadata", {})
+        status = item.get("status", {})
+        if metadata.get("deletionTimestamp") is not None:
+            raise VerificationError("pod/replica identity", "a stale terminating replica exists")
+        ready = any(
+            c.get("type") == "Ready" and c.get("status") == "True"
+            for c in status.get("conditions", [])
+            if isinstance(c, dict)
+        )
+        if status.get("phase") != "Running" or not ready:
+            raise VerificationError("pod/replica identity", "a replica is not Running and Ready")
+        containers = [
+            c for c in item.get("spec", {}).get("containers", []) if c.get("name") == "dspace"
+        ]
+        statuses = [c for c in status.get("containerStatuses", []) if c.get("name") == "dspace"]
+        if len(containers) != 1 or len(statuses) != 1:
+            raise VerificationError(
+                "pod/replica identity", "a replica lacks its named dspace container"
+            )
+        approved = f"{IMAGE_REF}:{expected['imageTag']}"
+        if containers[0].get("image") not in {approved, f"{approved}@{expected['imageDigest']}"}:
+            raise VerificationError(
+                "pod/replica identity", "a pod image coordinate does not match approval"
+            )
+        try:
+            digest = release_manifest._image_id_digest(statuses[0].get("imageID", ""))
+        except ValueError as exc:
+            raise VerificationError(
+                "pod/replica identity", "a pod image digest is malformed"
+            ) from exc
+        if digest != expected["imageDigest"]:
+            raise VerificationError(
+                "pod/replica identity", "a pod image digest does not match approval"
+            )
+        name = metadata.get("name")
+        if not isinstance(name, str) or not name:
+            raise VerificationError("pod/replica identity", "a pod name is invalid")
+        result.append({"name": name, "imageID": statuses[0]["imageID"]})
+    return sorted(result, key=lambda item: item["name"])
+
+
+def verify(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
+    expected = read_manifest(args.manifest)
+    if expected["environment"] != args.environment:
+        raise VerificationError("manifest/evidence mismatch", "manifest environment does not match")
+    for field, actual in (
+        ("applicationVersion", args.application_version),
+        ("sourceRevision", args.source_revision),
+        ("expectedDefaultChatProvider", args.provider),
+    ):
+        if actual and expected[field] != actual:
+            raise VerificationError(
+                "manifest/evidence mismatch", "argv expectations do not match manifest"
+            )
+    config = app_config.load_config("dspace", args.environment, args.config or None)
+    helm_command = [
+        "helm",
+        "--kubeconfig",
+        args.kubeconfig,
+        "status",
+        args.release,
+        "--namespace",
+        args.namespace,
+        "-o",
+        "json",
+    ]
+    starting_revision = None
+    if expected.get("recordType") == "final":
+        try:
+            starting_revision = json.loads(runner(helm_command)).get("version")
+        except (json.JSONDecodeError, AttributeError) as exc:
+            raise VerificationError("cluster identity", "live Helm identity is malformed") from exc
+        if starting_revision != expected["helmRevision"]:
+            raise VerificationError(
+                "cluster identity", "live Helm revision differs from finalized evidence"
+            )
+    host, token_origin, token_model = value_expectations(config)
+    base_url = f"https://{host}"
+    public_identity = identity(
+        http_get(f"{base_url}/build-info.json", base_url), expected, "public identity"
+    )
+    frontend(http_get(f"{base_url}/", base_url), expected["sourceRevision"], "public identity")
+    kubectl = ["kubectl", "--kubeconfig", args.kubeconfig, "-n", args.namespace]
+    selector = f"app.kubernetes.io/name=dspace,app.kubernetes.io/instance={args.release}"
+    pods = pod_items(runner([*kubectl, "get", "pods", "-l", selector, "-o", "json"]), expected)
+    for pod in pods:
+        prefix = f"/api/v1/namespaces/{args.namespace}/pods/{pod['name']}:3000/proxy"
+        direct = identity(
+            runner([*kubectl, "get", "--raw", f"{prefix}/build-info.json"]).encode(),
+            expected,
+            "direct identity",
+        )
+        frontend(
+            runner([*kubectl, "get", "--raw", f"{prefix}/"]).encode(),
+            expected["sourceRevision"],
+            "direct identity",
+        )
+        if direct != public_identity:
+            raise VerificationError("direct identity", "public and direct-origin identity differ")
+    smoke = args.smoke_runner
+    if not smoke.is_file() or not os.access(smoke, os.X_OK):
+        raise VerificationError(
+            "provider/chat smoke", "smoke runner must be an existing executable file"
+        )
+    command = [
+        str(smoke),
+        "--base-url",
+        base_url,
+        "--expected-version",
+        expected["applicationVersion"],
+        "--expected-revision",
+        expected["sourceRevision"],
+        "--expected-provider",
+        expected["expectedDefaultChatProvider"],
+    ]
+    if expected["expectedDefaultChatProvider"] == "token-place":
+        if not token_origin or not token_model:
+            raise VerificationError(
+                "manifest/evidence mismatch", "token.place expectations are absent from values"
+            )
+        command += [
+            "--expected-token-place-origin",
+            token_origin,
+            "--expected-token-place-model",
+            token_model,
+        ]
+    try:
+        completed = subprocess.run(command, capture_output=True, text=True, check=False)
+    except OSError as exc:
+        raise VerificationError("provider/chat smoke", "smoke runner could not be started") from exc
+    if completed.returncode:
+        raise VerificationError("provider/chat smoke", "remote chat verification failed")
+    if starting_revision is not None:
+        try:
+            stable_revision = json.loads(runner(helm_command)).get("version")
+        except (json.JSONDecodeError, AttributeError) as exc:
+            raise VerificationError("cluster identity", "live Helm identity is malformed") from exc
+        if stable_revision != starting_revision:
+            raise VerificationError("cluster identity", "Helm revision changed concurrently")
+    return {
+        "schemaVersion": 1,
+        "environment": args.environment,
+        "release": args.release,
+        "namespace": args.namespace,
+        "applicationVersion": expected["applicationVersion"],
+        "runtimeSourceRevision": expected["sourceRevision"],
+        "frontendSourceRevision": expected["sourceRevision"],
+        "defaultProvider": expected["expectedDefaultChatProvider"],
+        "journeys": [{"name": "/", "passed": True}, {"name": "/chat", "passed": True}],
+    }
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser()
+    subs = result.add_subparsers(dest="command", required=True)
+    for name in ("capabilities", "verify"):
+        command = subs.add_parser(name)
+        command.add_argument("--environment", choices=("staging", "prod"), required=True)
+        command.add_argument("--release", required=True)
+        command.add_argument("--namespace", required=True)
+        if name == "verify":
+            command.add_argument("--manifest", type=Path, required=True)
+            command.add_argument("--smoke-runner", type=Path, required=True)
+            command.add_argument("--config", default="")
+            command.add_argument("--kubeconfig", required=True)
+            command.add_argument("--application-version")
+            command.add_argument("--source-revision")
+            command.add_argument("--provider")
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        if args.command == "capabilities":
+            value = {
+                "schemaVersion": 1,
+                "environment": args.environment,
+                "release": args.release,
+                "namespace": args.namespace,
+                "capabilities": list(CAPABILITIES),
+            }
+        else:
+            value = verify(args)
+        sys.stdout.write(json.dumps(value, separators=(",", ":")) + "\n")
+        return 0
+    except (VerificationError, app_config.AppConfigError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -1,0 +1,137 @@
+"""Hermetic tests for the DSPACE runtime verifier contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import dspace_runtime_verifier as verifier
+
+SHA = "abcdef0123456789abcdef0123456789abcdef01"
+DIGEST = "sha256:" + "1" * 64
+
+
+def manifest() -> dict[str, object]:
+    return {
+        "schemaVersion": 1,
+        "app": "dspace",
+        "applicationVersion": "3.2.0",
+        "sourceRevision": SHA,
+        "imageTag": "main-abcdef0",
+        "imageDigest": DIGEST,
+        "chartVersion": "3.2.0",
+        "chartDigest": "sha256:" + "2" * 64,
+        "semanticTag": "v3.2.0",
+        "recordType": "candidate",
+        "environment": "staging",
+        "expectedDefaultChatProvider": "token-place",
+        "approvedAt": "2026-07-26T12:00:00Z",
+        "approvedBy": "test",
+    }
+
+
+def test_capabilities_are_exact_and_ordered(capsys: pytest.CaptureFixture[str]) -> None:
+    assert (
+        verifier.main(
+            [
+                "capabilities",
+                "--environment",
+                "staging",
+                "--release",
+                "dspace",
+                "--namespace",
+                "dspace",
+            ]
+        )
+        == 0
+    )
+    value = json.loads(capsys.readouterr().out)
+    assert list(value) == ["schemaVersion", "environment", "release", "namespace", "capabilities"]
+    assert value["capabilities"] == list(verifier.CAPABILITIES)
+
+
+@pytest.mark.parametrize(
+    "coordinate",
+    [None, f"{verifier.IMAGE_REF}:main-abcdef0", f"{verifier.IMAGE_REF}:main-abcdef0@{DIGEST}"],
+)
+def test_identity_accepts_exact_build_contract(coordinate: str | None) -> None:
+    body = {"applicationVersion": "3.2.0", "revision": SHA, "shortRevision": SHA[:7]}
+    if coordinate:
+        body["image"] = coordinate
+    assert (
+        verifier.identity(json.dumps(body).encode(), manifest(), "public identity")["revision"]
+        == SHA
+    )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [("applicationVersion", "3.2.1"), ("revision", "0" * 40), ("shortRevision", "deadbee")],
+)
+def test_public_identity_mismatch_is_bounded(field: str, value: str) -> None:
+    body = {"applicationVersion": "3.2.0", "revision": SHA, "shortRevision": SHA[:7]}
+    body[field] = value
+    with pytest.raises(verifier.VerificationError, match="public identity"):
+        verifier.identity(json.dumps(body).encode(), manifest(), "public identity")
+
+
+def test_frontend_marker_must_match() -> None:
+    verifier.frontend(
+        f'<meta name="dspace-build-revision" content="{SHA}">'.encode(), SHA, "public identity"
+    )
+    with pytest.raises(verifier.VerificationError, match="frontend revision marker"):
+        verifier.frontend(
+            b'<meta name="dspace-build-revision" content="wrong">', SHA, "public identity"
+        )
+
+
+def test_redirect_to_other_origin_is_rejected() -> None:
+    class Response:
+        def geturl(self) -> str:
+            return "https://evil.example/build-info.json"
+
+        def read(self, _size: int) -> bytes:
+            return b"secret"
+
+    with pytest.raises(verifier.VerificationError, match="unexpected origin"):
+        verifier.http_get(
+            "https://good.example/build-info.json",
+            "https://good.example",
+            lambda _request: Response(),
+        )
+
+
+def test_one_bad_pod_digest_fails_without_secret_content() -> None:
+    def pod(name: str, digest: str) -> dict[str, object]:
+        return {
+            "metadata": {"name": name},
+            "spec": {
+                "containers": [{"name": "dspace", "image": f"{verifier.IMAGE_REF}:main-abcdef0"}]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [{"type": "Ready", "status": "True"}],
+                "containerStatuses": [
+                    {"name": "dspace", "imageID": f"{verifier.IMAGE_REF}@{digest}"}
+                ],
+            },
+        }
+
+    with pytest.raises(verifier.VerificationError, match="pod image digest") as caught:
+        verifier.pod_items(
+            json.dumps({"items": [pod("good", DIGEST), pod("bad-SENTINEL", "sha256:" + "9" * 64)]}),
+            manifest(),
+        )
+    assert "SENTINEL" not in str(caught.value)
+
+
+def test_missing_and_non_executable_smoke_runner_are_rejected(tmp_path: Path) -> None:
+    missing = tmp_path / "missing"
+    assert not missing.exists()
+    # The path is checked before child execution by the public verifier workflow.
+    assert not (missing.is_file() and verifier.os.access(missing, verifier.os.X_OK))
+    runner = tmp_path / "runner"
+    runner.write_text("#!/bin/sh\n", encoding="utf-8")
+    assert not verifier.os.access(runner, verifier.os.X_OK)

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -444,6 +444,26 @@ print(json.dumps(value))
 """,
     )
 
+    smoke_runner = bin_dir / "dspace-smoke"
+    _write_executable(smoke_runner, "#!/usr/bin/env bash\nexit 0\n")
+    runtime_verifier = bin_dir / "dspace-runtime-verifier"
+    _write_executable(
+        runtime_verifier,
+        """#!/usr/bin/env python3
+import json, sys
+args = sys.argv[1:]
+def option(name): return args[args.index(name) + 1]
+manifest = json.load(open(option("--manifest"), encoding="utf-8"))
+print(json.dumps({"schemaVersion": 1, "environment": option("--environment"),
+ "release": option("--release"), "namespace": option("--namespace"),
+ "applicationVersion": manifest["applicationVersion"],
+ "runtimeSourceRevision": manifest["sourceRevision"],
+ "frontendSourceRevision": manifest["sourceRevision"],
+ "defaultProvider": manifest["expectedDefaultChatProvider"],
+ "journeys": [{"name": "/", "passed": True}, {"name": "/chat", "passed": True}]}))
+""",
+    )
+
     env = os.environ.copy()
     env["HOME"] = str(tmp_path / "home")
     env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
@@ -451,6 +471,8 @@ print(json.dumps(value))
     env["HELM_LOG"] = str(log_path)
     env["KUBECTL_LOG"] = str(tmp_path / "kubectl.log")
     env["CURL_LOG"] = str(tmp_path / "curl.log")
+    env["DSPACE_SMOKE_RUNNER"] = str(smoke_runner)
+    env["SUGARKUBE_DSPACE_RUNTIME_VERIFIER"] = str(runtime_verifier)
     return env
 
 
@@ -4344,6 +4366,6 @@ def test_dspace_promote_prod_guard_mismatch_fails_before_helm(
     result = _run_just(["dspace-oci-promote-prod", "tag=main-deadbee"], env)
 
     assert result.returncode != 0
-    assert "manifest=<approved-candidate.json> is required" in result.stderr
+    assert "staging_evidence=<finalized-staging.json>" in result.stderr
     helm_log_path = Path(env["HELM_LOG"])
     assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -44,6 +44,40 @@ def candidate() -> dict[str, object]:
     )
 
 
+def test_promotion_requires_matching_finalized_staging_evidence() -> None:
+    staging = candidate()
+    staging.update(
+        recordType="final",
+        helmRevision=7,
+        pods=[
+            {
+                "name": "dspace-0",
+                "startTime": "2026-07-26T12:01:00Z",
+                "imageID": f"repo@{DIGEST}",
+            }
+        ],
+        runtimeSourceRevision=SHA,
+        runtimeSourceRevisionMethod=manifest.RUNTIME_METHOD,
+        verificationResults=[
+            {"check": check, "passed": True, "details": "bounded"}
+            for check in sorted(manifest.FINAL_FIXED_CHECKS)
+        ]
+        + [
+            {
+                "check": "imagePlatformSourceRevision[0]",
+                "passed": True,
+                "details": "bounded",
+            }
+        ],
+    )
+    production = candidate()
+    production["environment"] = "prod"
+    manifest.validate_promotion(production, staging)
+    production["chartDigest"] = "sha256:" + "9" * 64
+    with pytest.raises(manifest.ManifestError, match="chartDigest"):
+        manifest.validate_promotion(production, staging)
+
+
 def test_upstream_import_is_canonical_and_round_trips(tmp_path: Path) -> None:
     source = tmp_path / "upstream.json"
     output = tmp_path / "candidate.json"
@@ -966,6 +1000,7 @@ def test_default_evidence_path_is_stable_and_approval_unique() -> None:
     assert str(manifest.evidence_path(candidate())) == (
         "deployment-evidence/dspace/staging/main-abcdef0-20260726T120000Z.json"
     )
+
 
 @pytest.mark.parametrize(
     ("change", "message"),


### PR DESCRIPTION
### Motivation

- Prevent DSPACE production version/source drift by proving the approved immutable artifact and its `/chat` behaviour before and after promotion.
- Make runtime, frontend and per-replica identity checks mandatory and centralize the DSPACE production guard into the standard promotion flow.
- Reuse the existing verifier contract (capabilities/verify) and preserve existing finalized evidence backward compatibility.

### Description

- Add a new argv-only runtime verifier executable `scripts/dspace_runtime_verifier.py` implementing the documented `capabilities` and `verify` contract and performing fail-closed checks for public `/build-info.json`, frontend revision meta, per-pod image coordinates/digests, public vs direct-origin agreement, redirect rejection, and invoking the isolated `/chat` smoke runner as argv (never via a shell).
- Wire the verifier into existing flows by updating `scripts/dspace_manifest_rollback.py` to call the real verifier when appropriate and by extending `scripts/dspace_release_manifest.py` to accept an optional `--runtime-proof` and to validate and persist additive, bounded runtime verification results into finalized evidence.
- Enforce a pre-production staging gate and post-rollout verification by updating `justfile` recipes: add `just dspace-release-verify`, require a `smoke_runner` for DSPACE guarded `app-deploy`/`app-redeploy`/`app-promote-prod` flows, and require a finalized staging evidence record that is re-verified before any production mutation.
- Add hermetic tests `tests/test_dspace_runtime_verifier.py`, extend manifest tests with `validate_promotion`, and update docs `docs/apps/dspace.md` and `docs/app_deployment_contract.md` describing smoke-runner checkout prerequisites, how to run `just dspace-release-verify`, promotion inputs, and evidence/reconciliation rules.

### Testing

- Ran the narrow pytest suite: `python3 -m pytest -q tests/test_dspace_runtime_verifier.py tests/test_release_manifest.py tests/test_manifest_rollback.py tests/test_generic_app_just_recipes.py tests/test_up_recipe_calls.py` and the focused DSPACE recipe tests; the verification and recipe tests passed in the hermetic CI-like environment (tests exercised the new runtime verifier stubs).  (See transcript: multiple focused runs completing successfully; earlier narrow run reported `169 passed`.)
- Ran style and repository checks: `python3 -m flake8` on the changed scripts/tests and `just --unstable --fmt --check`; the modified implementation files and added tests were formatted and lint-checked as part of the workflow; repository-wide `pre-commit run --all-files` initially flagged unrelated trailing-whitespace baseline files which were reverted rather than weakened.
- Doc/link checks executed: `linkchecker --no-warnings README.md docs/` succeeded; `pyspelling -c .spellcheck.yaml` was not run to completion because the environment lacks `aspell` (documented in the test summary).

Changed files (high level): `scripts/dspace_runtime_verifier.py`, `scripts/dspace_release_manifest.py`, `scripts/dspace_manifest_rollback.py`, `justfile`, `tests/test_dspace_runtime_verifier.py`, `docs/apps/dspace.md`, `docs/app_deployment_contract.md` and small guarded test additions.

Closes #2328

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69b1edd54c832fbe5416570213f518)