### PR TITLE
Migrate staging HA verification to EndpointSlices

### DIFF
--- a/docs/drills/2026-07-29-staging-node-failure.md
+++ b/docs/drills/2026-07-29-staging-node-failure.md
@@ -1,0 +1,54 @@
+# 2026-07-29 staging node-failure drill
+
+## Context and change
+
+Before PR #2400, staging ran one CoreDNS replica, one Traefik replica, and two Cloudflare Tunnel
+replicas. Losing `sugarkube3` caused roughly six minutes of public token.place interruption. PR
+#2400 added node-spread CoreDNS coverage and two node-separated Traefik replicas.
+
+For the post-change drill, an operator manually powered off `sugarkube3` at approximately
+`2026-07-29T00:05:25-07:00`. No shutdown is required to use this record, and this report contains no
+credentials, Secret data, private certificate material, raw event dump, or unnecessary private IP.
+
+## Observations
+
+* `sugarkube3` became `NotReady`; `sugarkube4` and `sugarkube5` stayed `Ready`. Kubernetes API and
+  etcd readiness remained available.
+* Healthchecks detected the missing node heartbeat and created a PagerDuty incident. This evidence
+  does not establish PagerDuty auto-resolution timing, so none is claimed.
+* Sampled DSPACE, danielsmith.io, and Jobbot3000 endpoints remained HTTP 200.
+* token.place remained on `sugarkube4` with zero restarts. It showed the only visible transient: one
+  root request took about 4.7 seconds, one `/livez` request took about 10 seconds, and one `/healthz`
+  request returned HTTP 502 after about 10 seconds. Sampled endpoints were normal again by
+  approximately `00:06:14`, less than 49 seconds after shutdown. The compute client needed roughly
+  another 10–15 seconds to re-register before chat worked.
+* EndpointSlices eventually marked dead-node Traefik and CoreDNS endpoints `ready:false`,
+  `serving:false`, and `terminating:true`; surviving endpoints stayed ready and serving. A replacement
+  Traefik pod later scheduled on `sugarkube5`.
+* After restoration, all nodes became `Ready`. CoreDNS had ready endpoints on all three nodes;
+  Traefik was ready on `sugarkube4` and `sugarkube5`. Ingress HA, blackbox, Prometheus, Alertmanager,
+  and node-heartbeat verification passed, and Healthchecks returned green.
+
+## Conclusions and limitations
+
+> **Limitations:** The sampler was serial and cannot prove zero failures between samples. This drill
+> proved continuity of shared ingress and DNS, not fast rescheduling of every singleton workload.
+> token.place happened to remain on a surviving node. Platform continuity must not be presented as
+> evidence that every application is highly available.
+
+The results support the narrower conclusion that the post-PR #2400 shared DNS and ingress topology
+continued serving sampled traffic through this one-node loss. They also preserve evidence of a
+short token.place transient and slower compute-client recovery. Residual-transient investigation is
+tracked in [issue #2407](https://github.com/futuroptimist/sugarkube/issues/2407).
+
+The default control-plane readiness check is:
+
+```bash
+kubectl get --raw='/readyz?verbose' | rg 'etcd|readyz check passed'
+```
+
+It proves that the contacted API server is ready and that this API server's etcd dependency is
+ready. It is not a complete per-member etcd health, consistency, or latency report. Optional deeper
+inspection requires a separately installed compatible `etcdctl` configured with official
+K3s-managed endpoints and client-certificate paths; never print certificate, key, or Secret
+contents.

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -39,6 +39,9 @@ logs, preparing Helm, and rolling out real workloads like
 
 For the canonical staging CoreDNS, Traefik, and Cloudflare connector availability lifecycle and
 one-server power-off drill, see [Staging DNS and public-ingress high availability](staging-ingress-ha.md).
+The deployed staging topology has node-spread CoreDNS coverage, two node-separated Traefik replicas,
+and two Cloudflare Tunnel replicas. The [2026-07-29 staging node-failure drill](drills/2026-07-29-staging-node-failure.md)
+records the measured continuity and its important singleton-workload and sampling limitations.
 
 Follow this sequence after imaging and booting the Pis:
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -34,11 +34,17 @@ operator workstation with the `just`, `flux`, `kubectl`, and `sops` CLIs install
    sudo k3s kubectl get nodes -o wide
    ```
 
-4. Confirm the embedded etcd cluster is healthy:
+4. Confirm the contacted API server and its embedded-etcd dependency are ready:
 
    ```bash
-   sudo k3s etcdctl endpoint status --cluster --write-out=table
+   kubectl get --raw='/readyz?verbose' | rg 'etcd|readyz check passed'
    ```
+
+   This built-in check proves that the API server contacted by `kubectl` is ready and that this API
+   server's etcd dependency is ready. It is **not** a complete per-member etcd health, consistency,
+   or latency report. For deeper, optional inspection, separately install a compatible `etcdctl`
+   and configure it with the official endpoints and client-certificate paths managed by K3s. Do not
+   print certificate or key contents. K3s does not provide a `k3s etcdctl` subcommand.
 
 ## 2. Deploy kube-vip and verify the virtual IP
 

--- a/docs/staging-ingress-ha.md
+++ b/docs/staging-ingress-ha.md
@@ -2,11 +2,13 @@
 
 ## Incident and ownership
 
-When `sugarkube3` was powered off, the other two `control-plane,etcd` servers retained the
+Before PR #2400, staging had one CoreDNS replica, one Traefik replica, and two Cloudflare Tunnel
+replicas. When `sugarkube3` was powered off, the other two `control-plane,etcd` servers retained the
 two-member majority of the three-member etcd cluster, so etcd and the API remained available.
-Public service nevertheless failed for about six minutes: the sole packaged CoreDNS pod was on the
-lost node. Kubernetes waited its default roughly five-minute `NodeNotReady` eviction interval before
-`TaintManagerEviction` replaced it; the application itself remained running on `sugarkube4`.
+Public token.place service nevertheless failed for about six minutes: the sole packaged CoreDNS pod
+was on the lost node. Kubernetes waited its default roughly five-minute `NodeNotReady` eviction
+interval before `TaintManagerEviction` replaced it; the application itself remained running on
+`sugarkube4`.
 
 The active staging lifecycle is deliberately non-Flux:
 
@@ -34,6 +36,11 @@ must not be applied alongside it. The durable active sources are
 `scripts/staging_ingress_ha.sh`. Re-running apply is idempotent; K3s/server restarts retain the
 companion Deployment and reconcile the HelmChartConfig.
 
+PR #2400 deployed this node-spread CoreDNS coverage and two node-separated Traefik replicas. The
+current staging topology is therefore no longer singleton for either shared component. See the
+[dated 2026-07-29 drill record](drills/2026-07-29-staging-node-failure.md) for the resulting evidence,
+conclusions, and limitations.
+
 ## Post-merge rollout and rollback
 
 Use a kubeconfig whose context is exactly `sugar-staging`. Render/status are read-only. Apply,
@@ -53,8 +60,13 @@ configuration. Verification requires two ready CoreDNS and Traefik pods on disti
 discovers exactly one Cloudflare tunnel Deployment cluster-wide by the
 `app.kubernetes.io/name=cloudflare-tunnel` label, then checks only matching pods in its namespace;
 zero or multiple releases fail closed. It never queries tunnel Secrets or logs. Verification also
-checks ready `kube-dns` and Traefik Service backends and an in-cluster DNS lookup. Public HTTPS
-targets are discovered from live Probe resources labeled
+aggregates every `discovery.k8s.io/v1` EndpointSlice selected by
+`kubernetes.io/service-name` for `kube-dns` and Traefik, checks healthy Service backends, and runs an
+in-cluster DNS lookup. Exact duplicate endpoints are deterministically collapsed across slices.
+An endpoint is healthy only when ready and serving and not terminating. Per the EndpointSlice API
+compatibility contract, absent `ready` means ready, absent `serving` follows `ready`, and absent
+`terminating` means non-terminating. Unhealthy endpoints are diagnosed but never counted. Public
+HTTPS targets are discovered from live Probe resources labeled
 `environment=staging,criticality=critical`, and at least one is required. Curl timeouts are bounded,
 and failures redact the target and curl diagnostics. The temporary DNS pod is removed on success,
 error, or signal.
@@ -78,21 +90,24 @@ while true; do just staging-ingress-ha-verify env=staging; sleep 5; done
 ```
 
 In a second terminal, power off exactly one server, observe it, restore it, wait for readiness, and
-inspect three-member etcd health:
+check API/etcd readiness:
 
 ```bash
 ssh sugarkube3 'sudo systemctl poweroff'
 kubectl get nodes --watch
 # Restore power to sugarkube3 using the normal host power procedure.
 kubectl wait --for=condition=Ready node/sugarkube3 --timeout=10m
-ssh sugarkube4 'sudo k3s etcdctl endpoint status --cluster --write-out=table'
+kubectl get --raw='/readyz?verbose' | rg 'etcd|readyz check passed'
 ```
 
 Public endpoints should remain continuously available. Healthchecks.io and PagerDuty should still
 report the intentionally powered-off node; those alerts prove host monitoring works and are not a
 reason to suppress it. Do not test another node until `sugarkube3` is `Ready` **and** the command
-above confirms all three etcd members have recovered. Never remove a second server while etcd
-redundancy is reduced.
+above confirms the contacted API server and its etcd dependency are ready. This is not a complete
+per-member etcd health, consistency, or latency report. Deeper inspection is optional and requires
+a separately installed compatible `etcdctl`, configured with official K3s-managed endpoints and
+client-certificate paths without printing certificate or key contents. Never remove a second server
+while etcd redundancy is reduced.
 
 This baseline is platform/app agnostic. It does not alter eviction or node-monitor timing, scale
 applications, or change observability credentials. In particular, token.place relay registration

--- a/scripts/staging_ingress_ha.sh
+++ b/scripts/staging_ingress_ha.sh
@@ -23,7 +23,82 @@ for k in ("creationTimestamp","resourceVersion","uid","generation","managedField
 d.pop("status",None); print(json.dumps(d,sort_keys=True,indent=2))'
 }
 render() { normalize_env "$1"; need kubectl; need python3; cat "$TRAEFIK_CONFIG"; printf '%s\n' '---'; render_coredns; }
-status() { normalize_env "$1"; need kubectl; printf 'Context: %s (read-only)\n' "$(context)"; kubectl -n kube-system get deploy coredns traefik -o wide; kubectl -n kube-system get deploy coredns-ha -o wide --ignore-not-found=true; kubectl -n kube-system get endpoints kube-dns traefik; kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o wide; }
+endpoint_slices() {
+  local service="$1" mode="${2:-backend}"
+  kubectl -n kube-system get endpointslices.discovery.k8s.io \
+    -l "kubernetes.io/service-name=${service}" -o json | python3 -c '
+import json,sys
+
+service,mode=sys.argv[1:]
+try:
+    document=json.load(sys.stdin)
+except (ValueError, TypeError) as exc:
+    raise SystemExit(f"ERROR: malformed EndpointSlice JSON for {service}: {exc}")
+if not isinstance(document,dict) or not isinstance(document.get("items"),list):
+    raise SystemExit(f"ERROR: malformed EndpointSlice list for {service}")
+if not document["items"]:
+    raise SystemExit(f"ERROR: no EndpointSlices found for Service {service}")
+
+endpoints={}
+for slice_ in document["items"]:
+    if not isinstance(slice_,dict) or not isinstance(slice_.get("endpoints"),list):
+        raise SystemExit(f"ERROR: malformed EndpointSlice data for Service {service}")
+    for endpoint in slice_["endpoints"]:
+        if not isinstance(endpoint,dict):
+            raise SystemExit(f"ERROR: malformed endpoint data for Service {service}")
+        addresses=endpoint.get("addresses")
+        conditions=endpoint.get("conditions",{})
+        node=endpoint.get("nodeName")
+        target=endpoint.get("targetRef")
+        if (not isinstance(addresses,list) or not addresses or
+            any(not isinstance(address,str) or not address for address in addresses) or
+            not isinstance(conditions,dict) or
+            (node is not None and not isinstance(node,str)) or
+            (target is not None and not isinstance(target,dict))):
+            raise SystemExit(f"ERROR: malformed endpoint data for Service {service}")
+        for field in ("ready","serving","terminating"):
+            if field in conditions and not isinstance(conditions[field],bool):
+                raise SystemExit(f"ERROR: malformed endpoint condition {field} for Service {service}")
+        ready=conditions.get("ready",True)
+        serving=conditions.get("serving",ready)
+        terminating=conditions.get("terminating",False)
+        target_key=json.dumps(target,sort_keys=True,separators=(",",":")) if target is not None else ""
+        key=(node or "",tuple(sorted(set(addresses))),target_key)
+        if key in endpoints:
+            _,old_ready,old_serving,old_terminating=endpoints[key]
+            ready=ready and old_ready
+            serving=serving and old_serving
+            terminating=terminating or old_terminating
+        endpoints[key]=(node,ready,serving,terminating)
+
+healthy=[]
+unhealthy=[]
+for key,(node,ready,serving,terminating) in sorted(endpoints.items()):
+    addresses=",".join(key[1])
+    target=key[2] or "-"
+    node_text=node or "<none>"
+    description=f"node={node_text} addresses={addresses} targetRef={target} ready={str(ready).lower()} serving={str(serving).lower()} terminating={str(terminating).lower()}"
+    (healthy if ready and serving and not terminating else unhealthy).append((node,description))
+print(f"{service}: healthy endpoints={len(healthy)} nodes={sorted({node for node,_ in healthy if node})}")
+for _,description in unhealthy:
+    print(f"{service}: unhealthy endpoint: {description}",file=sys.stderr)
+if not healthy:
+    raise SystemExit(f"ERROR: Service {service} has no healthy EndpointSlice backend")
+if mode == "spread":
+    nodes={node for node,_ in healthy if node}
+    if len(healthy)<2 or len(nodes)<2:
+        raise SystemExit(f"ERROR: fewer than two healthy, hostname-spread {service} EndpointSlice endpoints")
+' "$service" "$mode"
+}
+status() {
+  normalize_env "$1"; need kubectl; need python3
+  printf 'Context: %s (read-only)\n' "$(context)"
+  kubectl -n kube-system get deploy coredns traefik -o wide
+  kubectl -n kube-system get deploy coredns-ha -o wide --ignore-not-found=true
+  endpoint_slices kube-dns spread
+  endpoint_slices traefik backend
+  kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o wide
+}
 assert_owned_or_absent() {
   local kind="$1" name="$2" value error_file resource_file
   error_file="$(mktemp -t sugarkube-ownership.XXXXXX)"
@@ -80,13 +155,7 @@ nodes={p.get("spec",{}).get("nodeName") for p in pods if ready(p)}-{None}
 print(f"{sys.argv[1]}: ready nodes={sorted(nodes)}")
 if len(nodes)<2: raise SystemExit(f"ERROR: fewer than two ready, hostname-spread {sys.argv[1]} pods")' "$name"
   }
-  kubectl -n kube-system get endpoints kube-dns -o json | python3 -c '
-import json,sys
-endpoint=json.load(sys.stdin)
-addresses=[a for subset in endpoint.get("subsets",[]) for a in subset.get("addresses",[])]
-nodes={a.get("nodeName") for a in addresses if a.get("nodeName")}
-print(f"CoreDNS: ready endpoint nodes={sorted(nodes)}")
-if len(addresses)<2 or len(nodes)<2: raise SystemExit("ERROR: fewer than two ready, hostname-spread CoreDNS endpoints")'
+  endpoint_slices kube-dns spread
   kubectl -n kube-system get pods -l app.kubernetes.io/name=traefik -o json | check_spread Traefik
   local tunnel_namespace
   tunnel_namespace="$(kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o json | python3 -c '
@@ -95,7 +164,7 @@ items=json.load(sys.stdin)["items"]
 if len(items) != 1: raise SystemExit(f"ERROR: expected exactly one Cloudflare tunnel Deployment; found {len(items)}")
 print(items[0]["metadata"]["namespace"])')"
   kubectl -n "$tunnel_namespace" get pods -l app.kubernetes.io/name=cloudflare-tunnel -o json | check_spread 'Cloudflare tunnel'
-  for svc in kube-dns traefik; do kubectl -n kube-system get endpoints "$svc" -o json | python3 -c 'import json,sys; e=json.load(sys.stdin); assert any(x.get("addresses") for x in e.get("subsets",[])), "ERROR: Service has no ready backend"'; done
+  endpoint_slices traefik backend
   kubectl -n default run "$probe" --image="${SUGARKUBE_DNS_TEST_IMAGE:-busybox:1.36}" --restart=Never --command -- nslookup kubernetes.default.svc.cluster.local >/dev/null
   kubectl -n default wait --for=jsonpath='{.status.phase}'=Succeeded "pod/$probe" --timeout="$TIMEOUT" || die "bounded in-cluster DNS probe failed"
   local targets url

--- a/tests/test_staging_ingress_ha.py
+++ b/tests/test_staging_ingress_ha.py
@@ -38,8 +38,31 @@ def _pod(node):
     }}
 
 
+def _slices(*endpoints):
+    return {"apiVersion": "discovery.k8s.io/v1", "kind": "EndpointSliceList", "items": [
+        {"metadata": {"name": "slice-a"}, "endpoints": list(endpoints)}
+    ]}
+
+
+def _endpoint(node, addresses, conditions=None, target_ref=None):
+    value = {"addresses": addresses}
+    if node is not None:
+        value["nodeName"] = node
+    if conditions is not None:
+        value["conditions"] = conditions
+    if target_ref is not None:
+        value["targetRef"] = target_ref
+    return value
+
+
+DEFAULT_SLICES = _slices(
+    _endpoint("node1", ["10.0.0.1"], {"ready": True, "serving": True, "terminating": False}),
+    _endpoint("node2", ["10.0.0.2"], {"ready": True, "serving": True, "terminating": False}),
+)
+
+
 def _stub(tmp_path, *, context="sugar-staging", nodes="node1,node2", workload_nodes=None, tunnels=1,
-          owner="staging-ingress-ha", probes=True, probe_mode="canonical", endpoint_nodes="node1,node2",
+          owner="staging-ingress-ha", probes=True, probe_mode="canonical", endpoint_slices=None,
           resource_absent=False, lookup_error=False, fail_wait="", fail_curl=False,
           fail_reconcile=False):
     calls = tmp_path / "calls"
@@ -67,9 +90,9 @@ elif joined == "get probes -A -l environment=staging,criticality=critical -o jso
     elif os.environ["PROBE_MODE"] == "legacy": items=[{{"spec":{{"url":"https://legacy.example/health"}}}}]
     else: items=[{{"spec":{{"targets":{{"staticConfig":{{"static":["https://private.example/health", "http://ignored.example", "https://private.example/health"]}}}}}}}}]
     print(json.dumps({{"items":items}}))
-elif "get endpoints" in joined and "-o json" in joined:
-    nodes=os.environ["ENDPOINT_NODES"].split(",") if "kube-dns" in joined else ["node1"]
-    print(json.dumps({{"subsets":[{{"addresses":[{{"ip":f"10.0.0.{{i+1}}","nodeName":n}} for i,n in enumerate(nodes) if n]}}]}}))
+elif "get endpointslices.discovery.k8s.io" in joined and "-o json" in joined:
+    service=next(value.split("=",1)[1] for value in args if value.startswith("kubernetes.io/service-name="))
+    print(json.loads(os.environ["ENDPOINT_SLICES"])[service] if isinstance(json.loads(os.environ["ENDPOINT_SLICES"])[service], str) else json.dumps(json.loads(os.environ["ENDPOINT_SLICES"])[service]))
 elif "wait" in args:
     if os.environ.get("FAIL_WAIT") and os.environ["FAIL_WAIT"] in joined: sys.exit(1)
     if "deployment/traefik" in joined and "jsonpath={{.spec.replicas}}" in joined:
@@ -92,7 +115,7 @@ elif "rollout status" in joined and os.environ.get("FAIL_WAIT") and os.environ["
         "TRAEFIK_NODES": (workload_nodes or {}).get("Traefik", nodes),
         "TUNNEL_NODES": (workload_nodes or {}).get("Cloudflare tunnel", nodes),
         "TUNNELS": str(tunnels), "OWNER": owner, "PROBES": "1" if probes else "0",
-        "PROBE_MODE": probe_mode, "ENDPOINT_NODES": endpoint_nodes,
+        "PROBE_MODE": probe_mode, "ENDPOINT_SLICES": json.dumps(endpoint_slices or {"kube-dns": DEFAULT_SLICES, "traefik": DEFAULT_SLICES}),
         "RESOURCE_ABSENT": "1" if resource_absent else "0", "LOOKUP_ERROR": "1" if lookup_error else "0",
         "FAIL_WAIT": fail_wait, "FAIL_CURL": "1" if fail_curl else "0",
         "FAIL_RECONCILE": "1" if fail_reconcile else "0",
@@ -154,6 +177,9 @@ def test_status_is_read_only_and_optional_companion_may_be_absent(tmp_path):
     text = calls.read_text()
     assert "get deploy coredns traefik -o wide" in text
     assert "get deploy coredns-ha -o wide --ignore-not-found=true" in text
+    assert text.count("get endpointslices.discovery.k8s.io") == 2
+    assert "kubernetes.io/service-name=kube-dns" in text
+    assert "kubernetes.io/service-name=traefik" in text
     assert all(word not in text for word in ("apply", "patch", "delete", " run "))
 
 
@@ -228,15 +254,66 @@ def test_each_pod_workload_rejects_singleton_and_same_node(tmp_path):
 
 
 def test_coredns_requires_two_ready_endpoints_on_distinct_nodes(tmp_path):
-    for i, nodes in enumerate(("node1", "node1,node1")):
+    for i, endpoints in enumerate((
+        [_endpoint("node1", ["10.0.0.1"], {"ready": True})],
+        [_endpoint("node1", ["10.0.0.1"], {"ready": True}), _endpoint("node1", ["10.0.0.2"], {"ready": True})],
+    )):
         case = tmp_path / str(i); case.mkdir()
-        env, calls = _stub(case, endpoint_nodes=nodes)
+        env, calls = _stub(case, endpoint_slices={"kube-dns": _slices(*endpoints), "traefik": DEFAULT_SLICES})
         result = _run(env, "verify")
-        assert result.returncode and "hostname-spread CoreDNS endpoints" in result.stderr
+        assert result.returncode and "hostname-spread kube-dns EndpointSlice endpoints" in result.stderr
         assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
     healthy = tmp_path / "healthy"; healthy.mkdir()
-    env, _ = _stub(healthy, endpoint_nodes="node1,node2")
+    env, _ = _stub(healthy)
     assert _run(env, "verify").returncode == 0
+
+
+def test_endpoint_slices_aggregate_deduplicate_and_sort_deterministically(tmp_path):
+    duplicate = _endpoint("node2", ["2001:db8::2", "10.0.0.2"],
+                          {"ready": True, "serving": True, "terminating": False},
+                          {"kind": "Pod", "name": "dns-b"})
+    data = {"items": [
+        {"metadata": {"name": "z"}, "endpoints": [duplicate, _endpoint(
+            "node1", ["10.0.0.1"], {"ready": True, "serving": True, "terminating": False})]},
+        {"metadata": {"name": "a"}, "endpoints": [duplicate]},
+    ]}
+    env, calls = _stub(tmp_path, endpoint_slices={"kube-dns": data, "traefik": data})
+    result = _run(env, "verify")
+    assert result.returncode == 0, result.stderr
+    assert "kube-dns: healthy endpoints=2 nodes=['node1', 'node2']" in result.stdout
+    assert "traefik: healthy endpoints=2 nodes=['node1', 'node2']" in result.stdout
+    assert calls.read_text().count("get endpointslices.discovery.k8s.io") == 2
+
+
+def test_endpoint_slice_conditions_and_missing_nodes_are_diagnostic(tmp_path):
+    # API-compatible defaults: absent ready means ready, absent serving follows
+    # ready, and absent terminating means non-terminating.
+    data = _slices(
+        _endpoint("node1", ["10.0.0.1"]),
+        _endpoint("node2", ["10.0.0.2"], {"ready": False, "serving": False}),
+        _endpoint(None, ["2001:db8::3"], {"ready": True, "serving": True, "terminating": True}),
+    )
+    env, _ = _stub(tmp_path, endpoint_slices={"kube-dns": data, "traefik": data})
+    result = _run(env, "status")
+    assert result.returncode
+    assert "ready=false serving=false terminating=false" in result.stderr
+    assert "node=<none> addresses=2001:db8::3" in result.stderr
+    assert "terminating=true" in result.stderr
+    assert "hostname-spread kube-dns" in result.stderr
+
+
+def test_no_slices_and_malformed_endpoint_data_fail_clearly(tmp_path):
+    cases = [
+        ({"items": []}, "no EndpointSlices"),
+        ("not-json", "malformed EndpointSlice JSON"),
+        ({"items": [{"endpoints": [{"nodeName": "node1", "addresses": []}]}]}, "malformed endpoint data"),
+        ({"items": [{"endpoints": [{"addresses": ["10.0.0.1"], "conditions": {"ready": "yes"}}]}]}, "malformed endpoint condition"),
+    ]
+    for index, (bad, message) in enumerate(cases):
+        case = tmp_path / str(index); case.mkdir()
+        env, _ = _stub(case, endpoint_slices={"kube-dns": bad, "traefik": DEFAULT_SLICES})
+        result = _run(env, "status")
+        assert result.returncode and message in result.stderr
 
 
 def test_healthy_verify_and_unique_tunnel_discovery(tmp_path):


### PR DESCRIPTION
### Motivation

- Preserve the July 29, 2026 staging node-failure drill as durable evidence and correct stale singleton topology statements. 
- Remove invalid `k3s etcdctl` runbook guidance and provide a safe, built-in readiness check as the default. 
- Replace deprecated `core/v1 Endpoints` reads with aggregated `discovery.k8s.io/v1` EndpointSlice-based verification to avoid Kubernetes 1.33+ deprecation warnings and to make HA checks comprehensive across slices. 

### Description

- Add a dated drill record at `docs/drills/2026-07-29-staging-node-failure.md` that records timeline, observed behavior, PagerDuty/Healthchecks observations, token.place transient, conclusions, and explicit sampling/singleton limitations. 
- Replace `k3s etcdctl` guidance with the built-in API readiness probe `kubectl get --raw='/readyz?verbose' | rg 'etcd|readyz check passed'` and document its scope and optional deeper inspection requirements without implying `k3s etcdctl` exists. 
- Implement `endpoint_slices()` in `scripts/staging_ingress_ha.sh` to select all EndpointSlices with `kubernetes.io/service-name=<service>`, aggregate every matching slice, flatten and deterministically deduplicate endpoints, and conservatively merge duplicate conditions (ready and serving require every duplicate to be true, any terminating marks it terminating). 
- Enforce the healthy contract (endpoint counted healthy only when `ready && serving && not terminating`), treat absent `ready/serving/terminating` according to the EndpointSlice API contract, print diagnostic unhealthy endpoint lines without counting them healthy, and fail clearly on no slices or malformed data; preserve staging/context guards, bounded waits, cleanup, and redaction. 
- Update `tests/test_staging_ingress_ha.py` with deterministic offline coverage for single and multiple slices, duplicates, duplicate node names, ready/not-ready, serving-but-terminating, absent condition fields, no slices, endpoints without `nodeName`, IPv4/IPv6 addresses, and malformed JSON/endpoint data, plus deterministic summary assertions. 

### Testing

- Ran `python3 -m pytest -q tests/test_staging_ingress_ha.py` and all added/modified tests passed (`15 passed`). 
- Ran static and CI checks: `bash -n scripts/staging_ingress_ha.sh` and `shellcheck scripts/staging_ingress_ha.sh` succeeded, `just --unstable --fmt --check` ran, `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` ran successfully with no link errors. 
- Verified repository scanning: `rg -n 'sudo k3s etcdctl|kubectl.*get endpoints?\b|\.subsets\b'` returned no remaining active usages in the edited scripts/tests/docs, and `git diff --cached | ./scripts/scan-secrets.py` returned no new secrets. 
- Ran commit-time checks (`git diff --check`, pre-commit hooks) and `bash scripts/checks.sh` (note: this full run surfaced pre-existing, out-of-scope Flake8/style warnings elsewhere in the repository which were not introduced by this focused change). 

Files changed (high level): `scripts/staging_ingress_ha.sh`, `tests/test_staging_ingress_ha.py`, `docs/staging-ingress-ha.md`, `docs/runbook.md`, `docs/raspi_cluster_operations.md`, and the new drill `docs/drills/2026-07-29-staging-node-failure.md`.

If you want, I can open a follow-up to adjust any wording in the drill or to further expand test coverage for additional EndpointSlice edge cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69bca0e998832fbbfe267ab3127df2)