### PR TITLE
Migrate staging HA verification to EndpointSlices

### DIFF
--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -38,7 +38,11 @@ logs, preparing Helm, and rolling out real workloads like
 ## Golden path: HA dev cluster → Helm → Traefik → workloads
 
 For the canonical staging CoreDNS, Traefik, and Cloudflare connector availability lifecycle and
-one-server power-off drill, see [Staging DNS and public-ingress high availability](staging-ingress-ha.md).
+the dated July 29, 2026 evidence from its one-server power-off drill, see
+[Staging DNS and public-ingress high availability](staging-ingress-ha.md). The deployed staging
+topology now has node-spread CoreDNS coverage, two node-separated Traefik replicas, and two
+Cloudflare Tunnel replicas. That evidence demonstrates shared DNS/ingress continuity; it does not
+promise fast rescheduling for singleton applications.
 
 Follow this sequence after imaging and booting the Pis:
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -2,7 +2,7 @@
 
 This runbook documents the expected flow for bringing a three-node Raspberry Pi 5 k3s cluster
 online, keeping it healthy, and restoring service after failures. All commands assume an
-operator workstation with the `just`, `flux`, `kubectl`, and `sops` CLIs installed.
+operator workstation with the `just`, `flux`, `kubectl`, `rg` (ripgrep), and `sops` CLIs installed.
 
 ## 1. Bootstrap the first server
 
@@ -37,7 +37,7 @@ operator workstation with the `just`, `flux`, `kubectl`, and `sops` CLIs install
 4. Confirm the contacted API server and its etcd dependency are ready:
 
    ```bash
-   kubectl get --raw='/readyz?verbose' | grep -E 'etcd|readyz check passed'
+   kubectl get --raw='/readyz?verbose' | rg 'etcd|readyz check passed'
    ```
 
    This proves readiness only for the contacted API server and that server's etcd dependency. It

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -34,11 +34,17 @@ operator workstation with the `just`, `flux`, `kubectl`, and `sops` CLIs install
    sudo k3s kubectl get nodes -o wide
    ```
 
-4. Confirm the embedded etcd cluster is healthy:
+4. Confirm the contacted API server and its etcd dependency are ready:
 
    ```bash
-   sudo k3s etcdctl endpoint status --cluster --write-out=table
+   kubectl get --raw='/readyz?verbose' | rg 'etcd|readyz check passed'
    ```
+
+   This proves readiness only for the contacted API server and that server's etcd dependency. It
+   is not a complete per-member etcd health, consistency, or latency report. Optional deeper
+   inspection requires a separately installed compatible `etcdctl` using the official K3s-managed
+   endpoints and client-certificate paths. Never print certificate, private-key, or Secret
+   contents.
 
 ## 2. Deploy kube-vip and verify the virtual IP
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -37,7 +37,7 @@ operator workstation with the `just`, `flux`, `kubectl`, and `sops` CLIs install
 4. Confirm the contacted API server and its etcd dependency are ready:
 
    ```bash
-   kubectl get --raw='/readyz?verbose' | rg 'etcd|readyz check passed'
+   kubectl get --raw='/readyz?verbose' | grep -E 'etcd|readyz check passed'
    ```
 
    This proves readiness only for the contacted API server and that server's etcd dependency. It

--- a/docs/staging-ingress-ha.md
+++ b/docs/staging-ingress-ha.md
@@ -1,12 +1,39 @@
 # Staging DNS and public-ingress high availability
 
-## Incident and ownership
+## 2026-07-29 node-failure drill record
 
-When `sugarkube3` was powered off, the other two `control-plane,etcd` servers retained the
-two-member majority of the three-member etcd cluster, so etcd and the API remained available.
-Public service nevertheless failed for about six minutes: the sole packaged CoreDNS pod was on the
-lost node. Kubernetes waited its default roughly five-minute `NodeNotReady` eviction interval before
-`TaintManagerEviction` replaced it; the application itself remained running on `sugarkube4`.
+Before [PR #2400](https://github.com/futuroptimist/sugarkube/pull/2400), staging had one CoreDNS
+replica, one Traefik replica, and two Cloudflare Tunnel replicas. A loss of `sugarkube3` caused
+roughly six minutes of public token.place interruption. PR #2400 added node-spread CoreDNS coverage
+and two node-separated Traefik replicas.
+
+For the post-change drill, an operator manually powered off `sugarkube3` at approximately
+`2026-07-29T00:05:25-07:00`. The node became `NotReady`; `sugarkube4` and `sugarkube5` stayed
+`Ready`, and Kubernetes API/etcd readiness remained available. Healthchecks detected the missing
+node heartbeat and created a PagerDuty incident. Sampled DSPACE, danielsmith.io, and Jobbot3000
+endpoints continued to return HTTP 200.
+
+token.place remained on `sugarkube4` with zero restarts. It had the only visible transient: one root
+request took about 4.7 seconds, one `/livez` request took about 10 seconds, and one `/healthz`
+request returned HTTP 502 after about 10 seconds. Sampled endpoints were normal again by
+approximately `00:06:14`, less than 49 seconds after shutdown. The compute client needed roughly
+another 10–15 seconds to re-register before chat worked.
+
+EndpointSlices eventually marked dead-node Traefik and CoreDNS endpoints `ready: false`,
+`serving: false`, and `terminating: true`; surviving endpoints remained ready and serving. A
+replacement Traefik pod later scheduled on `sugarkube5`. After restoration, every node was `Ready`,
+CoreDNS had ready endpoints on all three nodes, and Traefik was ready on `sugarkube4` and
+`sugarkube5`. Ingress HA, blackbox, Prometheus, Alertmanager, and node-heartbeat verification all
+passed, and Healthchecks returned green. The evidence does **not** establish when PagerDuty
+auto-resolved, so this record makes no claim about its resolution timing.
+
+> **Evidence limitations:** the sampler was serial and cannot prove zero failures between samples.
+> This drill proved continuity of shared ingress and DNS, not fast rescheduling of every singleton
+> workload. token.place happened to remain on a surviving node. Treat the observed residual delay
+> as an open follow-up in [issue #2407](https://github.com/futuroptimist/sugarkube/issues/2407), not
+> as proof of failure-free application HA.
+
+## Current implementation and ownership
 
 The active staging lifecycle is deliberately non-Flux:
 
@@ -49,15 +76,23 @@ just staging-ingress-ha-verify env=staging
 ```
 
 Apply first creates two ready CoreDNS companion endpoints and only then applies Traefik's supported
-configuration. Verification requires two ready CoreDNS and Traefik pods on distinct hostnames. It
-discovers exactly one Cloudflare tunnel Deployment cluster-wide by the
+configuration. Verification requires two healthy CoreDNS endpoints and Traefik pods on distinct
+hostnames. It discovers exactly one Cloudflare Tunnel Deployment cluster-wide by the
 `app.kubernetes.io/name=cloudflare-tunnel` label, then checks only matching pods in its namespace;
-zero or multiple releases fail closed. It never queries tunnel Secrets or logs. Verification also
-checks ready `kube-dns` and Traefik Service backends and an in-cluster DNS lookup. Public HTTPS
-targets are discovered from live Probe resources labeled
-`environment=staging,criticality=critical`, and at least one is required. Curl timeouts are bounded,
-and failures redact the target and curl diagnostics. The temporary DNS pod is removed on success,
-error, or signal.
+zero or multiple releases fail closed. It never queries tunnel Secrets or logs.
+
+Status and verification aggregate every `discovery.k8s.io/v1` EndpointSlice selected by
+`kubernetes.io/service-name=<service>` for `kube-dns` and Traefik. Endpoints are deduplicated by node
+name, sorted addresses, and target reference. An endpoint is healthy only when effective `ready`
+and `serving` are true and `terminating` is false. Per the EndpointSlice compatibility contract, an
+absent `ready` is treated as true, absent `serving` follows effective readiness, and absent
+`terminating` is false. Unhealthy endpoints remain in redacted diagnostics but never count as
+healthy; summaries are sorted and do not print addresses.
+
+Verification also performs an in-cluster DNS lookup. Public HTTPS targets are discovered from live
+Probe resources labeled `environment=staging,criticality=critical`, and at least one is required.
+Curl timeouts are bounded, and failures redact the target and curl diagnostics. The temporary DNS
+pod is removed on success, error, or signal.
 
 Rollback removes only the two resources owned here and waits for the packaged defaults:
 
@@ -69,30 +104,38 @@ just staging-ingress-ha-status env=staging
 Rollback intentionally returns DNS/ingress to the K3s singleton defaults and therefore removes the
 one-node availability guarantee. It does not disable or replace K3s components.
 
-## One-node power-off drill
+## Manual one-node power-off drill procedure
 
-After apply and verify, run verification continuously from a different server in its own terminal:
+This is a guarded manual procedure for a future authorized maintenance window. Do not automate a
+shutdown, and never remove another node while redundancy is reduced. After apply and verify, run
+verification continuously from a different server in its own terminal:
 
 ```bash
 while true; do just staging-ingress-ha-verify env=staging; sleep 5; done
 ```
 
-In a second terminal, power off exactly one server, observe it, restore it, wait for readiness, and
-inspect three-member etcd health:
+In a second terminal, manually power off exactly one server, observe it, restore it, wait for
+readiness, and check the contacted API server's built-in readiness endpoint:
 
 ```bash
 ssh sugarkube3 'sudo systemctl poweroff'
 kubectl get nodes --watch
 # Restore power to sugarkube3 using the normal host power procedure.
 kubectl wait --for=condition=Ready node/sugarkube3 --timeout=10m
-ssh sugarkube4 'sudo k3s etcdctl endpoint status --cluster --write-out=table'
+kubectl get --raw='/readyz?verbose' | rg 'etcd|readyz check passed'
 ```
 
-Public endpoints should remain continuously available. Healthchecks.io and PagerDuty should still
-report the intentionally powered-off node; those alerts prove host monitoring works and are not a
-reason to suppress it. Do not test another node until `sugarkube3` is `Ready` **and** the command
-above confirms all three etcd members have recovered. Never remove a second server while etcd
-redundancy is reduced.
+This default check proves that the contacted API server is ready and that its etcd dependency is
+ready. It is **not** a complete per-member etcd health, consistency, or latency report. Deeper
+inspection is optional and requires a separately installed, compatible `etcdctl`, configured with
+the official K3s-managed endpoint and client-certificate paths. Follow the current K3s
+documentation for those paths; do not print certificates, private keys, or Secret contents.
+
+Public endpoints should remain available, subject to the serial-sampling limitation above.
+Healthchecks and PagerDuty should still report the intentionally powered-off node; those alerts
+prove host monitoring works and are not a reason to suppress it. Do not test another node until
+`sugarkube3` is `Ready`, the readiness check passes, and any required optional per-member inspection
+confirms recovery.
 
 This baseline is platform/app agnostic. It does not alter eviction or node-monitor timing, scale
 applications, or change observability credentials. In particular, token.place relay registration

--- a/docs/staging-ingress-ha.md
+++ b/docs/staging-ingress-ha.md
@@ -122,7 +122,7 @@ ssh sugarkube3 'sudo systemctl poweroff'
 kubectl get nodes --watch
 # Restore power to sugarkube3 using the normal host power procedure.
 kubectl wait --for=condition=Ready node/sugarkube3 --timeout=10m
-kubectl get --raw='/readyz?verbose' | rg 'etcd|readyz check passed'
+kubectl get --raw='/readyz?verbose' | grep -E 'etcd|readyz check passed'
 ```
 
 This default check proves that the contacted API server is ready and that its etcd dependency is

--- a/docs/staging-ingress-ha.md
+++ b/docs/staging-ingress-ha.md
@@ -107,7 +107,8 @@ one-node availability guarantee. It does not disable or replace K3s components.
 ## Manual one-node power-off drill procedure
 
 This is a guarded manual procedure for a future authorized maintenance window. Do not automate a
-shutdown, and never remove another node while redundancy is reduced. After apply and verify, run
+shutdown, and never remove another node while redundancy is reduced. The operator workstation must
+have `rg` (ripgrep) installed for the readiness command below. After apply and verify, run
 verification continuously from a different server in its own terminal:
 
 ```bash
@@ -122,7 +123,7 @@ ssh sugarkube3 'sudo systemctl poweroff'
 kubectl get nodes --watch
 # Restore power to sugarkube3 using the normal host power procedure.
 kubectl wait --for=condition=Ready node/sugarkube3 --timeout=10m
-kubectl get --raw='/readyz?verbose' | grep -E 'etcd|readyz check passed'
+kubectl get --raw='/readyz?verbose' | rg 'etcd|readyz check passed'
 ```
 
 This default check proves that the contacted API server is ready and that its etcd dependency is

--- a/scripts/staging_ingress_ha.sh
+++ b/scripts/staging_ingress_ha.sh
@@ -33,11 +33,11 @@ status() {
   normalize_env "$1"; need kubectl; need python3
   local result=0
   printf 'Context: %s (read-only)\n' "$(context)"
-  kubectl -n kube-system get deploy coredns traefik -o wide
-  kubectl -n kube-system get deploy coredns-ha -o wide --ignore-not-found=true
+  kubectl -n kube-system get deploy coredns traefik -o wide || result=1
+  kubectl -n kube-system get deploy coredns-ha -o wide --ignore-not-found=true || result=1
   endpoint_slices kube-dns || result=1
   endpoint_slices traefik || result=1
-  kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o wide
+  kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o wide || result=1
   return "$result"
 }
 assert_owned_or_absent() {

--- a/scripts/staging_ingress_ha.sh
+++ b/scripts/staging_ingress_ha.sh
@@ -2,6 +2,7 @@
 set -Eeuo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TRAEFIK_CONFIG="${ROOT}/clusters/staging/ingress-ha/traefik-helmchartconfig.yaml"
+ENDPOINT_SUMMARY="${ROOT}/scripts/staging_ingress_ha_endpoints.py"
 TIMEOUT="${SUGARKUBE_INGRESS_HA_TIMEOUT:-180s}"
 EXPECTED_CONTEXT=sugar-staging
 OWNER_LABEL='sugarkube.dev/managed-by'
@@ -23,7 +24,20 @@ for k in ("creationTimestamp","resourceVersion","uid","generation","managedField
 d.pop("status",None); print(json.dumps(d,sort_keys=True,indent=2))'
 }
 render() { normalize_env "$1"; need kubectl; need python3; cat "$TRAEFIK_CONFIG"; printf '%s\n' '---'; render_coredns; }
-status() { normalize_env "$1"; need kubectl; printf 'Context: %s (read-only)\n' "$(context)"; kubectl -n kube-system get deploy coredns traefik -o wide; kubectl -n kube-system get deploy coredns-ha -o wide --ignore-not-found=true; kubectl -n kube-system get endpoints kube-dns traefik; kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o wide; }
+endpoint_slices() {
+  local service="$1" minimum_nodes="${2:-0}"
+  kubectl -n kube-system get endpointslices.discovery.k8s.io -l "kubernetes.io/service-name=${service}" -o json |
+    python3 "$ENDPOINT_SUMMARY" "$service" --minimum-nodes "$minimum_nodes"
+}
+status() {
+  normalize_env "$1"; need kubectl; need python3
+  printf 'Context: %s (read-only)\n' "$(context)"
+  kubectl -n kube-system get deploy coredns traefik -o wide
+  kubectl -n kube-system get deploy coredns-ha -o wide --ignore-not-found=true
+  endpoint_slices kube-dns
+  endpoint_slices traefik
+  kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o wide
+}
 assert_owned_or_absent() {
   local kind="$1" name="$2" value error_file resource_file
   error_file="$(mktemp -t sugarkube-ownership.XXXXXX)"
@@ -80,13 +94,7 @@ nodes={p.get("spec",{}).get("nodeName") for p in pods if ready(p)}-{None}
 print(f"{sys.argv[1]}: ready nodes={sorted(nodes)}")
 if len(nodes)<2: raise SystemExit(f"ERROR: fewer than two ready, hostname-spread {sys.argv[1]} pods")' "$name"
   }
-  kubectl -n kube-system get endpoints kube-dns -o json | python3 -c '
-import json,sys
-endpoint=json.load(sys.stdin)
-addresses=[a for subset in endpoint.get("subsets",[]) for a in subset.get("addresses",[])]
-nodes={a.get("nodeName") for a in addresses if a.get("nodeName")}
-print(f"CoreDNS: ready endpoint nodes={sorted(nodes)}")
-if len(addresses)<2 or len(nodes)<2: raise SystemExit("ERROR: fewer than two ready, hostname-spread CoreDNS endpoints")'
+  endpoint_slices kube-dns 2
   kubectl -n kube-system get pods -l app.kubernetes.io/name=traefik -o json | check_spread Traefik
   local tunnel_namespace
   tunnel_namespace="$(kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o json | python3 -c '
@@ -95,7 +103,7 @@ items=json.load(sys.stdin)["items"]
 if len(items) != 1: raise SystemExit(f"ERROR: expected exactly one Cloudflare tunnel Deployment; found {len(items)}")
 print(items[0]["metadata"]["namespace"])')"
   kubectl -n "$tunnel_namespace" get pods -l app.kubernetes.io/name=cloudflare-tunnel -o json | check_spread 'Cloudflare tunnel'
-  for svc in kube-dns traefik; do kubectl -n kube-system get endpoints "$svc" -o json | python3 -c 'import json,sys; e=json.load(sys.stdin); assert any(x.get("addresses") for x in e.get("subsets",[])), "ERROR: Service has no ready backend"'; done
+  endpoint_slices traefik
   kubectl -n default run "$probe" --image="${SUGARKUBE_DNS_TEST_IMAGE:-busybox:1.36}" --restart=Never --command -- nslookup kubernetes.default.svc.cluster.local >/dev/null
   kubectl -n default wait --for=jsonpath='{.status.phase}'=Succeeded "pod/$probe" --timeout="$TIMEOUT" || die "bounded in-cluster DNS probe failed"
   local targets url

--- a/scripts/staging_ingress_ha.sh
+++ b/scripts/staging_ingress_ha.sh
@@ -31,12 +31,14 @@ endpoint_slices() {
 }
 status() {
   normalize_env "$1"; need kubectl; need python3
+  local result=0
   printf 'Context: %s (read-only)\n' "$(context)"
   kubectl -n kube-system get deploy coredns traefik -o wide
   kubectl -n kube-system get deploy coredns-ha -o wide --ignore-not-found=true
-  endpoint_slices kube-dns
-  endpoint_slices traefik
+  endpoint_slices kube-dns || result=1
+  endpoint_slices traefik || result=1
   kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o wide
+  return "$result"
 }
 assert_owned_or_absent() {
   local kind="$1" name="$2" value error_file resource_file

--- a/scripts/staging_ingress_ha_endpoints.py
+++ b/scripts/staging_ingress_ha_endpoints.py
@@ -74,6 +74,12 @@ def describe(key):
     return f"node={node or '<none>'},addresses={len(addresses)}:{family_text},target={target_text}"
 
 
+def endpoint_sort_key(key):
+    """Order endpoints by their full identity without exposing addresses."""
+    node, addresses, target = key
+    return node or "", addresses, target
+
+
 def summarize(document, service, minimum_nodes):
     if not isinstance(document, dict) or not isinstance(document.get("items"), list):
         fail("input must be an EndpointSliceList object with an items array")
@@ -85,7 +91,10 @@ def summarize(document, service, minimum_nodes):
     for item in items:
         if not isinstance(item, dict):
             fail("EndpointSlice item must be an object")
-        labels = item.get("metadata", {}).get("labels", {})
+        metadata = item.get("metadata", {})
+        if not isinstance(metadata, dict):
+            fail("EndpointSlice metadata must be an object when present")
+        labels = metadata.get("labels", {})
         if not isinstance(labels, dict) or labels.get("kubernetes.io/service-name") != service:
             fail(f"EndpointSlice does not belong to Service {service}")
         endpoints = item.get("endpoints")
@@ -101,7 +110,7 @@ def summarize(document, service, minimum_nodes):
 
     healthy = []
     unhealthy = []
-    for key in sorted(grouped, key=describe):
+    for key in sorted(grouped, key=endpoint_sort_key):
         states = grouped[key]
         # Conflicting duplicate observations fail closed until every copy is healthy.
         if all(ready and serving and not terminating for ready, serving, terminating in states):

--- a/scripts/staging_ingress_ha_endpoints.py
+++ b/scripts/staging_ingress_ha_endpoints.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Safely summarize all EndpointSlices selected for one staging Service."""
+
+import argparse
+import ipaddress
+import json
+import sys
+
+
+def fail(message):
+    raise ValueError(message)
+
+
+def optional_bool(value, field):
+    if value is not None and not isinstance(value, bool):
+        fail(f"{field} must be a boolean when present")
+    return value
+
+
+def endpoint_key(endpoint):
+    addresses = endpoint.get("addresses")
+    if (
+        not isinstance(addresses, list)
+        or not addresses
+        or not all(isinstance(address, str) and address for address in addresses)
+    ):
+        fail("endpoint addresses must be a non-empty list of strings")
+    addresses = tuple(sorted(set(addresses)))
+
+    node = endpoint.get("nodeName")
+    if node is not None and (not isinstance(node, str) or not node):
+        fail("endpoint nodeName must be a non-empty string when present")
+
+    target = endpoint.get("targetRef")
+    if target is not None:
+        if not isinstance(target, dict):
+            fail("endpoint targetRef must be an object when present")
+        target = tuple(
+            target.get(key, "") for key in ("apiVersion", "kind", "namespace", "name", "uid")
+        )
+        if not all(isinstance(value, str) for value in target):
+            fail("endpoint targetRef identity fields must be strings when present")
+    else:
+        target = ("", "", "", "", "")
+    return node, addresses, target
+
+
+def condition_state(endpoint):
+    conditions = endpoint.get("conditions", {})
+    if not isinstance(conditions, dict):
+        fail("endpoint conditions must be an object when present")
+    ready_value = optional_bool(conditions.get("ready"), "conditions.ready")
+    serving_value = optional_bool(conditions.get("serving"), "conditions.serving")
+    terminating_value = optional_bool(conditions.get("terminating"), "conditions.terminating")
+
+    # EndpointSlice clients interpret absent ready as ready. Serving was added later and, when
+    # absent, follows effective readiness; absent terminating means not terminating.
+    ready = True if ready_value is None else ready_value
+    serving = ready if serving_value is None else serving_value
+    terminating = False if terminating_value is None else terminating_value
+    return ready, serving, terminating
+
+
+def describe(key):
+    node, addresses, target = key
+    families = []
+    for address in addresses:
+        try:
+            families.append(f"IPv{ipaddress.ip_address(address).version}")
+        except ValueError:
+            families.append("non-IP")
+    target_text = "/".join(part for part in (target[1], target[2], target[3]) if part) or "none"
+    family_text = ",".join(sorted(set(families)))
+    return f"node={node or '<none>'},addresses={len(addresses)}:{family_text},target={target_text}"
+
+
+def summarize(document, service, minimum_nodes):
+    if not isinstance(document, dict) or not isinstance(document.get("items"), list):
+        fail("input must be an EndpointSliceList object with an items array")
+    items = document["items"]
+    if not items:
+        fail(f"no EndpointSlices found for Service {service}")
+
+    grouped = {}
+    for item in items:
+        if not isinstance(item, dict):
+            fail("EndpointSlice item must be an object")
+        labels = item.get("metadata", {}).get("labels", {})
+        if not isinstance(labels, dict) or labels.get("kubernetes.io/service-name") != service:
+            fail(f"EndpointSlice does not belong to Service {service}")
+        endpoints = item.get("endpoints")
+        if not isinstance(endpoints, list):
+            fail("EndpointSlice endpoints must be an array")
+        for endpoint in endpoints:
+            if not isinstance(endpoint, dict):
+                fail("endpoint must be an object")
+            grouped.setdefault(endpoint_key(endpoint), []).append(condition_state(endpoint))
+
+    if not grouped:
+        fail(f"EndpointSlices for Service {service} contain no endpoints")
+
+    healthy = []
+    unhealthy = []
+    for key in sorted(grouped, key=describe):
+        states = grouped[key]
+        # Conflicting duplicate observations fail closed until every copy is healthy.
+        if all(ready and serving and not terminating for ready, serving, terminating in states):
+            healthy.append(key)
+        else:
+            reasons = set()
+            for ready, serving, terminating in states:
+                if not ready:
+                    reasons.add("not-ready")
+                if not serving:
+                    reasons.add("non-serving")
+                if terminating:
+                    reasons.add("terminating")
+            unhealthy.append(f"{describe(key)} ({','.join(sorted(reasons))})")
+
+    nodes = sorted({key[0] for key in healthy if key[0]})
+    print(
+        f"{service}: slices={len(items)} unique={len(grouped)} "
+        f"healthy={len(healthy)} ready nodes={nodes}"
+    )
+    for detail in unhealthy:
+        print(f"{service}: unhealthy {detail}")
+    if not healthy:
+        fail(f"Service {service} has no healthy EndpointSlice backends")
+    if minimum_nodes and (len(healthy) < minimum_nodes or len(nodes) < minimum_nodes):
+        display = "CoreDNS" if service == "kube-dns" else service
+        fail(f"fewer than {minimum_nodes} healthy, hostname-spread {display} endpoints")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("service")
+    parser.add_argument("--minimum-nodes", type=int, default=0)
+    args = parser.parse_args()
+    try:
+        summarize(json.load(sys.stdin), args.service, args.minimum_nodes)
+    except (json.JSONDecodeError, ValueError) as error:
+        print(f"ERROR: invalid EndpointSlice data: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_staging_ingress_ha.py
+++ b/tests/test_staging_ingress_ha.py
@@ -5,6 +5,7 @@ import subprocess
 
 ROOT = pathlib.Path(__file__).parents[1]
 SCRIPT = ROOT / "scripts/staging_ingress_ha.sh"
+ENDPOINT_SUMMARY = ROOT / "scripts/staging_ingress_ha_endpoints.py"
 OWNER = "sugarkube.dev/managed-by"
 
 DEPLOYMENT = {
@@ -18,16 +19,13 @@ DEPLOYMENT = {
             "metadata": {"labels": {"k8s-app": "kube-dns"}},
             "spec": {
                 "serviceAccountName": "coredns",
-                "containers": [
-                    {
-                        "name": "coredns",
-                        "image": "registry.invalid/coredns:v1",
-                        "args": ["-conf", "/etc/coredns/Corefile"],
-                        "readinessProbe": {"httpGet": {"path": "/ready", "port": 8181}},
-                        "livenessProbe": {"httpGet": {"path": "/health", "port": 8080}},
-                        "volumeMounts": [{"name": "config-volume", "mountPath": "/etc/coredns"}],
-                    }
-                ],
+                "containers": [{
+                    "name": "coredns", "image": "registry.invalid/coredns:v1",
+                    "args": ["-conf", "/etc/coredns/Corefile"],
+                    "readinessProbe": {"httpGet": {"path": "/ready", "port": 8181}},
+                    "livenessProbe": {"httpGet": {"path": "/health", "port": 8080}},
+                    "volumeMounts": [{"name": "config-volume", "mountPath": "/etc/coredns"}],
+                }],
                 "volumes": [{"name": "config-volume", "configMap": {"name": "coredns"}}],
             },
         },
@@ -36,11 +34,9 @@ DEPLOYMENT = {
 
 
 def _pod(node):
-    return {
-        "metadata": {},
-        "spec": {"nodeName": node},
-        "status": {"phase": "Running", "containerStatuses": [{"ready": True}]},
-    }
+    return {"metadata": {}, "spec": {"nodeName": node}, "status": {
+        "phase": "Running", "containerStatuses": [{"ready": True}]
+    }}
 
 
 def _slices(service, endpoints=None):
@@ -73,24 +69,10 @@ def _slices(service, endpoints=None):
     }
 
 
-def _stub(
-    tmp_path,
-    *,
-    context="sugar-staging",
-    nodes="node1,node2",
-    workload_nodes=None,
-    tunnels=1,
-    owner="staging-ingress-ha",
-    probes=True,
-    probe_mode="canonical",
-    endpoint_nodes="node1,node2",
-    endpoint_documents=None,
-    resource_absent=False,
-    lookup_error=False,
-    fail_wait="",
-    fail_curl=False,
-    fail_reconcile=False,
-):
+def _stub(tmp_path, *, context="sugar-staging", nodes="node1,node2", workload_nodes=None, tunnels=1,
+          owner="staging-ingress-ha", probes=True, probe_mode="canonical", endpoint_nodes="node1,node2",
+          endpoint_documents=None, resource_absent=False, lookup_error=False, fail_wait="", fail_curl=False,
+          fail_reconcile=False):
     calls = tmp_path / "calls"
     kubectl = tmp_path / "kubectl"
     kubectl.write_text(f"""#!/usr/bin/env python3
@@ -132,9 +114,7 @@ elif "rollout status" in joined and os.environ.get("FAIL_WAIT") and os.environ["
 """)
     kubectl.chmod(0o755)
     curl = tmp_path / "curl"
-    curl.write_text(
-        '#!/bin/sh\necho "$*" >>"$CALLS"\necho "sensitive-url-output" >&2\nexit "${FAIL_CURL:-0}"\n'
-    )
+    curl.write_text('#!/bin/sh\necho "$*" >>"$CALLS"\necho "sensitive-url-output" >&2\nexit "${FAIL_CURL:-0}"\n')
     curl.chmod(0o755)
     endpoint_documents = endpoint_documents or {
         "kube-dns": _slices(
@@ -152,28 +132,16 @@ elif "rollout status" in joined and os.environ.get("FAIL_WAIT") and os.environ["
         "traefik": _slices("traefik"),
     }
     return {
-        **os.environ,
-        "PATH": f"{tmp_path}:{os.environ['PATH']}",
-        "CALLS": str(calls),
-        "FAKE_CONTEXT": context,
-        "DEPLOYMENT": json.dumps(DEPLOYMENT),
+        **os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}", "CALLS": str(calls),
+        "FAKE_CONTEXT": context, "DEPLOYMENT": json.dumps(DEPLOYMENT),
         "COREDNS_NODES": (workload_nodes or {}).get("CoreDNS", nodes),
         "TRAEFIK_NODES": (workload_nodes or {}).get("Traefik", nodes),
         "TUNNEL_NODES": (workload_nodes or {}).get("Cloudflare tunnel", nodes),
-        "TUNNELS": str(tunnels),
-        "OWNER": owner,
-        "PROBES": "1" if probes else "0",
-        "PROBE_MODE": probe_mode,
-        "ENDPOINT_NODES": endpoint_nodes,
-        "ENDPOINT_DOCUMENTS": (
-            endpoint_documents
-            if isinstance(endpoint_documents, str)
-            else json.dumps(endpoint_documents)
-        ),
-        "RESOURCE_ABSENT": "1" if resource_absent else "0",
-        "LOOKUP_ERROR": "1" if lookup_error else "0",
-        "FAIL_WAIT": fail_wait,
-        "FAIL_CURL": "1" if fail_curl else "0",
+        "TUNNELS": str(tunnels), "OWNER": owner, "PROBES": "1" if probes else "0",
+        "PROBE_MODE": probe_mode, "ENDPOINT_NODES": endpoint_nodes,
+        "ENDPOINT_DOCUMENTS": endpoint_documents if isinstance(endpoint_documents, str) else json.dumps(endpoint_documents),
+        "RESOURCE_ABSENT": "1" if resource_absent else "0", "LOOKUP_ERROR": "1" if lookup_error else "0",
+        "FAIL_WAIT": fail_wait, "FAIL_CURL": "1" if fail_curl else "0",
         "FAIL_RECONCILE": "1" if fail_reconcile else "0",
     }, calls
 
@@ -205,35 +173,19 @@ def test_rendered_contracts_and_coredns_clone(tmp_path):
     assert records[("metadata", "name")] == "traefik"
     assert records[("metadata", "labels", OWNER)] == "staging-ingress-ha"
     assert records[("spec", "deployment", "replicas")] == "2"
-    assert (
-        records[
-            (
-                "spec",
-                "affinity",
-                "podAntiAffinity",
-                "requiredDuringSchedulingIgnoredDuringExecution",
-                "topologyKey",
-            )
-        ]
-        == "kubernetes.io/hostname"
-    )
+    assert records[("spec", "affinity", "podAntiAffinity", "requiredDuringSchedulingIgnoredDuringExecution", "topologyKey")] == "kubernetes.io/hostname"
     coredns = json.loads(coredns_text)
     assert coredns["spec"]["replicas"] == 2
     assert coredns["metadata"]["labels"][OWNER] == "staging-ingress-ha"
-    assert coredns["spec"]["template"]["spec"] == DEPLOYMENT["spec"]["template"]["spec"] | {
-        "affinity": coredns["spec"]["template"]["spec"]["affinity"]
-    }
-    term = coredns["spec"]["template"]["spec"]["affinity"]["podAntiAffinity"][
-        "requiredDuringSchedulingIgnoredDuringExecution"
-    ][0]
+    assert coredns["spec"]["template"]["spec"] == DEPLOYMENT["spec"]["template"]["spec"] | {"affinity": coredns["spec"]["template"]["spec"]["affinity"]}
+    term = coredns["spec"]["template"]["spec"]["affinity"]["podAntiAffinity"]["requiredDuringSchedulingIgnoredDuringExecution"][0]
     assert term["topologyKey"] == "kubernetes.io/hostname"
     assert term["labelSelector"]["matchLabels"] == {"k8s-app": "kube-dns"}
 
 
 def test_every_mutation_guard_precedes_cluster_operations(tmp_path):
     for action in ("apply", "upgrade", "verify", "rollback"):
-        case = tmp_path / action
-        case.mkdir()
+        case = tmp_path / action; case.mkdir()
         env, calls = _stub(case, context="production")
         assert "staging-only" in _run(env, action, "prod").stderr
         assert not calls.exists()
@@ -270,8 +222,7 @@ def test_status_reports_all_components_before_failing_for_unhealthy_slices(tmp_p
 
 def test_apply_idempotent_ordered_and_owned_rollback(tmp_path):
     env, calls = _stub(tmp_path)
-    for _ in range(2):
-        assert _run(env, "apply").returncode == 0
+    for _ in range(2): assert _run(env, "apply").returncode == 0
     text = calls.read_text()
     assert text.count("apply -f") == 4
     assert text.index("deployment/coredns-ha") < text.index("traefik-helmchartconfig.yaml")
@@ -280,10 +231,23 @@ def test_apply_idempotent_ordered_and_owned_rollback(tmp_path):
     assert "delete deployment coredns-ha" in text
     assert "delete deployment coredns " not in text
 
-    absent = tmp_path / "absent"
-    absent.mkdir()
+    absent = tmp_path / "absent"; absent.mkdir()
     env, _ = _stub(absent, resource_absent=True)
     assert _run(env, "apply").returncode == 0
+
+
+def test_status_accepts_singleton_slices_after_rollback(tmp_path):
+    singleton = [{"addresses": ["10.0.0.1"], "nodeName": "node1", "conditions": {}}]
+    documents = {
+        "kube-dns": _slices("kube-dns", singleton),
+        "traefik": _slices("traefik", singleton),
+    }
+    env, _ = _stub(tmp_path, endpoint_documents=documents)
+    assert _run(env, "rollback").returncode == 0
+    result = _run(env, "status")
+    assert result.returncode == 0, result.stderr
+    assert "kube-dns: slices=1 unique=1 healthy=1" in result.stdout
+    assert "traefik: slices=1 unique=1 healthy=1" in result.stdout
 
 
 def test_traefik_reconciliation_precedes_rollout_and_fails_closed(tmp_path):
@@ -304,8 +268,7 @@ def test_traefik_reconciliation_precedes_rollout_and_fails_closed(tmp_path):
     assert delete_pos < rollback_wait < rollback_rollout
 
     for action in ("apply", "rollback"):
-        case = tmp_path / f"never-{action}"
-        case.mkdir()
+        case = tmp_path / f"never-{action}"; case.mkdir()
         failed_env, failed_calls = _stub(case, fail_reconcile=True)
         result = _run(failed_env, action)
         assert result.returncode and "reconcile" in result.stderr
@@ -316,15 +279,13 @@ def test_traefik_reconciliation_precedes_rollout_and_fails_closed(tmp_path):
 
 def test_unowned_resources_are_never_modified_or_disclosed(tmp_path):
     for action in ("apply", "rollback"):
-        case = tmp_path / action
-        case.mkdir()
+        case = tmp_path / action; case.mkdir()
         env, calls = _stub(case, owner="someone-else")
         result = _run(env, action)
         assert result.returncode and "not owned" in result.stderr
         assert "someone-else" not in result.stdout + result.stderr
         assert all(word not in calls.read_text() for word in ("apply -f", "delete"))
-    failed = tmp_path / "lookup"
-    failed.mkdir()
+    failed = tmp_path / "lookup"; failed.mkdir()
     env, calls = _stub(failed, lookup_error=True)
     result = _run(env, "apply")
     assert result.returncode and "unable to inspect ownership" in result.stderr
@@ -335,8 +296,7 @@ def test_unowned_resources_are_never_modified_or_disclosed(tmp_path):
 def test_each_pod_workload_rejects_singleton_and_same_node(tmp_path):
     for nodes in ("node1", "node1,node1"):
         for expected in ("Traefik", "Cloudflare tunnel"):
-            case = tmp_path / f"{nodes.replace(',', '-')}-{expected.split()[0]}"
-            case.mkdir()
+            case = tmp_path / f"{nodes.replace(',', '-')}-{expected.split()[0]}"; case.mkdir()
             env, calls = _stub(case, workload_nodes={expected: nodes})
             result = _run(env, "verify")
             assert result.returncode
@@ -346,14 +306,12 @@ def test_each_pod_workload_rejects_singleton_and_same_node(tmp_path):
 
 def test_coredns_requires_two_ready_endpoints_on_distinct_nodes(tmp_path):
     for i, nodes in enumerate(("node1", "node1,node1")):
-        case = tmp_path / str(i)
-        case.mkdir()
+        case = tmp_path / str(i); case.mkdir()
         env, calls = _stub(case, endpoint_nodes=nodes)
         result = _run(env, "verify")
         assert result.returncode and "hostname-spread CoreDNS endpoints" in result.stderr
         assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
-    healthy = tmp_path / "healthy"
-    healthy.mkdir()
+    healthy = tmp_path / "healthy"; healthy.mkdir()
     env, _ = _stub(healthy, endpoint_nodes="node1,node2")
     assert _run(env, "verify").returncode == 0
 
@@ -468,6 +426,27 @@ def test_no_slices_malformed_json_and_malformed_endpoint_fail_safely(tmp_path):
             },
             "metadata must be an object",
         ),
+        (
+            {
+                "kube-dns": {"items": [{"metadata": None, "endpoints": []}]},
+                "traefik": _slices("traefik"),
+            },
+            "metadata must be an object",
+        ),
+        (
+            {
+                "kube-dns": {"items": [{"metadata": {"labels": []}, "endpoints": []}]},
+                "traefik": _slices("traefik"),
+            },
+            "does not belong to Service",
+        ),
+        (
+            {
+                "kube-dns": {"items": [{"metadata": {"labels": None}, "endpoints": []}]},
+                "traefik": _slices("traefik"),
+            },
+            "does not belong to Service",
+        ),
     ]
     for index, (documents, expected) in enumerate(cases):
         case = tmp_path / str(index)
@@ -475,7 +454,44 @@ def test_no_slices_malformed_json_and_malformed_endpoint_fail_safely(tmp_path):
         env, calls = _stub(case, endpoint_documents=documents)
         result = _run(env, "verify")
         assert result.returncode and expected in result.stderr
+        assert "Traceback" not in result.stderr
         assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
+
+
+def _summarize(document, service="kube-dns"):
+    return subprocess.run(
+        ["python3", str(ENDPOINT_SUMMARY), service],
+        input=json.dumps(document), text=True, capture_output=True, check=False,
+    )
+
+
+def test_endpoint_output_is_stable_when_redacted_descriptions_collide():
+    endpoints = [
+        {"addresses": [address], "nodeName": "node1", "conditions": conditions}
+        for address, conditions in (
+            ("10.0.0.2", {"ready": False}),
+            ("10.0.0.1", {"serving": False}),
+        )
+    ]
+    forward = _summarize(_slices("kube-dns", endpoints))
+    reverse = _summarize(_slices("kube-dns", list(reversed(endpoints))))
+    assert (forward.returncode, forward.stdout, forward.stderr) == (
+        reverse.returncode, reverse.stdout, reverse.stderr
+    )
+    assert "10.0.0" not in forward.stdout + forward.stderr
+
+
+def test_conflicting_duplicate_endpoint_is_conservatively_unhealthy():
+    identity = {"addresses": ["10.0.0.1"], "nodeName": "node1"}
+    endpoints = [
+        identity | {"conditions": {"ready": True, "serving": True}},
+        identity | {"conditions": {"ready": False, "serving": False}},
+    ]
+    result = _summarize(_slices("kube-dns", endpoints))
+    assert result.returncode
+    assert "unique=1 healthy=0" in result.stdout
+    assert result.stdout.count("kube-dns: unhealthy ") == 1
+    assert "non-serving,not-ready" in result.stdout
 
 
 def test_healthy_verify_and_unique_tunnel_discovery(tmp_path):
@@ -490,8 +506,7 @@ def test_healthy_verify_and_unique_tunnel_discovery(tmp_path):
 
 def test_zero_or_multiple_tunnel_deployments_fail_and_cleanup(tmp_path):
     for count in (0, 2):
-        case = tmp_path / str(count)
-        case.mkdir()
+        case = tmp_path / str(count); case.mkdir()
         env, calls = _stub(case, tunnels=count)
         result = _run(env, "verify")
         assert result.returncode and f"found {count}" in result.stderr
@@ -499,22 +514,16 @@ def test_zero_or_multiple_tunnel_deployments_fail_and_cleanup(tmp_path):
 
 
 def test_probe_discovery_required_and_curl_failure_redacted(tmp_path):
-    none = tmp_path / "none"
-    none.mkdir()
-    env, calls = _stub(none, probes=False)
+    none = tmp_path / "none"; none.mkdir(); env, calls = _stub(none, probes=False)
     result = _run(env, "verify")
     assert result.returncode and "no critical staging HTTPS Probe targets" in result.stderr
     assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
-    failed = tmp_path / "failed"
-    failed.mkdir()
-    env, calls = _stub(failed, fail_curl=True)
+    failed = tmp_path / "failed"; failed.mkdir(); env, calls = _stub(failed, fail_curl=True)
     result = _run(env, "verify")
     assert result.returncode and "target redacted" in result.stderr
     assert "private.example" not in result.stdout + result.stderr
     assert "sensitive-url-output" not in result.stdout + result.stderr
-    legacy = tmp_path / "legacy"
-    legacy.mkdir()
-    env, calls = _stub(legacy, probe_mode="legacy")
+    legacy = tmp_path / "legacy"; legacy.mkdir(); env, calls = _stub(legacy, probe_mode="legacy")
     result = _run(env, "verify")
     assert result.returncode and "no critical staging HTTPS Probe targets" in result.stderr
     assert "legacy.example" not in calls.read_text()
@@ -522,13 +531,9 @@ def test_probe_discovery_required_and_curl_failure_redacted(tmp_path):
 
 
 def test_rollout_and_dns_probe_timeouts_cleanup(tmp_path):
-    rollout = tmp_path / "rollout"
-    rollout.mkdir()
-    env, _ = _stub(rollout, fail_wait="deployment/coredns-ha")
+    rollout = tmp_path / "rollout"; rollout.mkdir(); env, _ = _stub(rollout, fail_wait="deployment/coredns-ha")
     assert "rollout timed out" in _run(env, "apply").stderr
-    dns = tmp_path / "dns"
-    dns.mkdir()
-    env, calls = _stub(dns, fail_wait="pod/sugarkube")
+    dns = tmp_path / "dns"; dns.mkdir(); env, calls = _stub(dns, fail_wait="pod/sugarkube")
     result = _run(env, "verify")
     assert result.returncode and "DNS probe failed" in result.stderr
     assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()

--- a/tests/test_staging_ingress_ha.py
+++ b/tests/test_staging_ingress_ha.py
@@ -18,13 +18,16 @@ DEPLOYMENT = {
             "metadata": {"labels": {"k8s-app": "kube-dns"}},
             "spec": {
                 "serviceAccountName": "coredns",
-                "containers": [{
-                    "name": "coredns", "image": "registry.invalid/coredns:v1",
-                    "args": ["-conf", "/etc/coredns/Corefile"],
-                    "readinessProbe": {"httpGet": {"path": "/ready", "port": 8181}},
-                    "livenessProbe": {"httpGet": {"path": "/health", "port": 8080}},
-                    "volumeMounts": [{"name": "config-volume", "mountPath": "/etc/coredns"}],
-                }],
+                "containers": [
+                    {
+                        "name": "coredns",
+                        "image": "registry.invalid/coredns:v1",
+                        "args": ["-conf", "/etc/coredns/Corefile"],
+                        "readinessProbe": {"httpGet": {"path": "/ready", "port": 8181}},
+                        "livenessProbe": {"httpGet": {"path": "/health", "port": 8080}},
+                        "volumeMounts": [{"name": "config-volume", "mountPath": "/etc/coredns"}],
+                    }
+                ],
                 "volumes": [{"name": "config-volume", "configMap": {"name": "coredns"}}],
             },
         },
@@ -33,18 +36,64 @@ DEPLOYMENT = {
 
 
 def _pod(node):
-    return {"metadata": {}, "spec": {"nodeName": node}, "status": {
-        "phase": "Running", "containerStatuses": [{"ready": True}]
-    }}
+    return {
+        "metadata": {},
+        "spec": {"nodeName": node},
+        "status": {"phase": "Running", "containerStatuses": [{"ready": True}]},
+    }
 
 
-def _stub(tmp_path, *, context="sugar-staging", nodes="node1,node2", workload_nodes=None, tunnels=1,
-          owner="staging-ingress-ha", probes=True, probe_mode="canonical", endpoint_nodes="node1,node2",
-          resource_absent=False, lookup_error=False, fail_wait="", fail_curl=False,
-          fail_reconcile=False):
+def _slices(service, endpoints=None):
+    if endpoints is None:
+        endpoints = [
+            {
+                "addresses": ["10.0.0.1"],
+                "nodeName": "node1",
+                "conditions": {"ready": True, "serving": True, "terminating": False},
+            },
+            {
+                "addresses": ["2001:db8::2"],
+                "nodeName": "node2",
+                "conditions": {"ready": True, "serving": True, "terminating": False},
+            },
+        ]
+    return {
+        "apiVersion": "discovery.k8s.io/v1",
+        "kind": "EndpointSliceList",
+        "items": [
+            {
+                "metadata": {
+                    "name": f"{service}-abc",
+                    "labels": {"kubernetes.io/service-name": service},
+                },
+                "addressType": "IPv4",
+                "endpoints": endpoints,
+            }
+        ],
+    }
+
+
+def _stub(
+    tmp_path,
+    *,
+    context="sugar-staging",
+    nodes="node1,node2",
+    workload_nodes=None,
+    tunnels=1,
+    owner="staging-ingress-ha",
+    probes=True,
+    probe_mode="canonical",
+    endpoint_nodes="node1,node2",
+    endpoint_documents=None,
+    resource_absent=False,
+    lookup_error=False,
+    fail_wait="",
+    fail_curl=False,
+    fail_reconcile=False,
+):
     calls = tmp_path / "calls"
     kubectl = tmp_path / "kubectl"
-    kubectl.write_text(f'''#!/usr/bin/env python3
+    kubectl.write_text(f"""#!/usr/bin/env python3
 import json, os, sys
 args=sys.argv[1:]
 with open({str(calls)!r}, "a") as f: f.write(" ".join(args)+"\\n")
@@ -67,9 +116,9 @@ elif joined == "get probes -A -l environment=staging,criticality=critical -o jso
     elif os.environ["PROBE_MODE"] == "legacy": items=[{{"spec":{{"url":"https://legacy.example/health"}}}}]
     else: items=[{{"spec":{{"targets":{{"staticConfig":{{"static":["https://private.example/health", "http://ignored.example", "https://private.example/health"]}}}}}}}}]
     print(json.dumps({{"items":items}}))
-elif "get endpoints" in joined and "-o json" in joined:
-    nodes=os.environ["ENDPOINT_NODES"].split(",") if "kube-dns" in joined else ["node1"]
-    print(json.dumps({{"subsets":[{{"addresses":[{{"ip":f"10.0.0.{{i+1}}","nodeName":n}} for i,n in enumerate(nodes) if n]}}]}}))
+elif "get endpointslices.discovery.k8s.io" in joined and "-o json" in joined:
+    service = joined.split("kubernetes.io/service-name=")[1].split()[0]
+    print(os.environ["ENDPOINT_DOCUMENTS"] if os.environ["ENDPOINT_DOCUMENTS"] == "malformed-json" else json.dumps(json.loads(os.environ["ENDPOINT_DOCUMENTS"])[service]))
 elif "wait" in args:
     if os.environ.get("FAIL_WAIT") and os.environ["FAIL_WAIT"] in joined: sys.exit(1)
     if "deployment/traefik" in joined and "jsonpath={{.spec.replicas}}" in joined:
@@ -80,21 +129,51 @@ elif "wait" in args:
         if prerequisite not in calls: sys.exit(1)
     elif "pod/sugarkube" not in joined: sys.exit(1)
 elif "rollout status" in joined and os.environ.get("FAIL_WAIT") and os.environ["FAIL_WAIT"] in joined: sys.exit(1)
-''')
+""")
     kubectl.chmod(0o755)
     curl = tmp_path / "curl"
-    curl.write_text('#!/bin/sh\necho "$*" >>"$CALLS"\necho "sensitive-url-output" >&2\nexit "${FAIL_CURL:-0}"\n')
+    curl.write_text(
+        '#!/bin/sh\necho "$*" >>"$CALLS"\necho "sensitive-url-output" >&2\nexit "${FAIL_CURL:-0}"\n'
+    )
     curl.chmod(0o755)
+    endpoint_documents = endpoint_documents or {
+        "kube-dns": _slices(
+            "kube-dns",
+            [
+                {
+                    "addresses": [f"10.0.0.{i + 1}"],
+                    "nodeName": node,
+                    "conditions": {"ready": True, "serving": True, "terminating": False},
+                }
+                for i, node in enumerate(endpoint_nodes.split(","))
+                if node
+            ],
+        ),
+        "traefik": _slices("traefik"),
+    }
     return {
-        **os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}", "CALLS": str(calls),
-        "FAKE_CONTEXT": context, "DEPLOYMENT": json.dumps(DEPLOYMENT),
+        **os.environ,
+        "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        "CALLS": str(calls),
+        "FAKE_CONTEXT": context,
+        "DEPLOYMENT": json.dumps(DEPLOYMENT),
         "COREDNS_NODES": (workload_nodes or {}).get("CoreDNS", nodes),
         "TRAEFIK_NODES": (workload_nodes or {}).get("Traefik", nodes),
         "TUNNEL_NODES": (workload_nodes or {}).get("Cloudflare tunnel", nodes),
-        "TUNNELS": str(tunnels), "OWNER": owner, "PROBES": "1" if probes else "0",
-        "PROBE_MODE": probe_mode, "ENDPOINT_NODES": endpoint_nodes,
-        "RESOURCE_ABSENT": "1" if resource_absent else "0", "LOOKUP_ERROR": "1" if lookup_error else "0",
-        "FAIL_WAIT": fail_wait, "FAIL_CURL": "1" if fail_curl else "0",
+        "TUNNELS": str(tunnels),
+        "OWNER": owner,
+        "PROBES": "1" if probes else "0",
+        "PROBE_MODE": probe_mode,
+        "ENDPOINT_NODES": endpoint_nodes,
+        "ENDPOINT_DOCUMENTS": (
+            endpoint_documents
+            if isinstance(endpoint_documents, str)
+            else json.dumps(endpoint_documents)
+        ),
+        "RESOURCE_ABSENT": "1" if resource_absent else "0",
+        "LOOKUP_ERROR": "1" if lookup_error else "0",
+        "FAIL_WAIT": fail_wait,
+        "FAIL_CURL": "1" if fail_curl else "0",
         "FAIL_RECONCILE": "1" if fail_reconcile else "0",
     }, calls
 
@@ -126,19 +205,35 @@ def test_rendered_contracts_and_coredns_clone(tmp_path):
     assert records[("metadata", "name")] == "traefik"
     assert records[("metadata", "labels", OWNER)] == "staging-ingress-ha"
     assert records[("spec", "deployment", "replicas")] == "2"
-    assert records[("spec", "affinity", "podAntiAffinity", "requiredDuringSchedulingIgnoredDuringExecution", "topologyKey")] == "kubernetes.io/hostname"
+    assert (
+        records[
+            (
+                "spec",
+                "affinity",
+                "podAntiAffinity",
+                "requiredDuringSchedulingIgnoredDuringExecution",
+                "topologyKey",
+            )
+        ]
+        == "kubernetes.io/hostname"
+    )
     coredns = json.loads(coredns_text)
     assert coredns["spec"]["replicas"] == 2
     assert coredns["metadata"]["labels"][OWNER] == "staging-ingress-ha"
-    assert coredns["spec"]["template"]["spec"] == DEPLOYMENT["spec"]["template"]["spec"] | {"affinity": coredns["spec"]["template"]["spec"]["affinity"]}
-    term = coredns["spec"]["template"]["spec"]["affinity"]["podAntiAffinity"]["requiredDuringSchedulingIgnoredDuringExecution"][0]
+    assert coredns["spec"]["template"]["spec"] == DEPLOYMENT["spec"]["template"]["spec"] | {
+        "affinity": coredns["spec"]["template"]["spec"]["affinity"]
+    }
+    term = coredns["spec"]["template"]["spec"]["affinity"]["podAntiAffinity"][
+        "requiredDuringSchedulingIgnoredDuringExecution"
+    ][0]
     assert term["topologyKey"] == "kubernetes.io/hostname"
     assert term["labelSelector"]["matchLabels"] == {"k8s-app": "kube-dns"}
 
 
 def test_every_mutation_guard_precedes_cluster_operations(tmp_path):
     for action in ("apply", "upgrade", "verify", "rollback"):
-        case = tmp_path / action; case.mkdir()
+        case = tmp_path / action
+        case.mkdir()
         env, calls = _stub(case, context="production")
         assert "staging-only" in _run(env, action, "prod").stderr
         assert not calls.exists()
@@ -154,12 +249,14 @@ def test_status_is_read_only_and_optional_companion_may_be_absent(tmp_path):
     text = calls.read_text()
     assert "get deploy coredns traefik -o wide" in text
     assert "get deploy coredns-ha -o wide --ignore-not-found=true" in text
+    assert text.count("get endpointslices.discovery.k8s.io -l kubernetes.io/service-name=") == 2
     assert all(word not in text for word in ("apply", "patch", "delete", " run "))
 
 
 def test_apply_idempotent_ordered_and_owned_rollback(tmp_path):
     env, calls = _stub(tmp_path)
-    for _ in range(2): assert _run(env, "apply").returncode == 0
+    for _ in range(2):
+        assert _run(env, "apply").returncode == 0
     text = calls.read_text()
     assert text.count("apply -f") == 4
     assert text.index("deployment/coredns-ha") < text.index("traefik-helmchartconfig.yaml")
@@ -168,7 +265,8 @@ def test_apply_idempotent_ordered_and_owned_rollback(tmp_path):
     assert "delete deployment coredns-ha" in text
     assert "delete deployment coredns " not in text
 
-    absent = tmp_path / "absent"; absent.mkdir()
+    absent = tmp_path / "absent"
+    absent.mkdir()
     env, _ = _stub(absent, resource_absent=True)
     assert _run(env, "apply").returncode == 0
 
@@ -191,7 +289,8 @@ def test_traefik_reconciliation_precedes_rollout_and_fails_closed(tmp_path):
     assert delete_pos < rollback_wait < rollback_rollout
 
     for action in ("apply", "rollback"):
-        case = tmp_path / f"never-{action}"; case.mkdir()
+        case = tmp_path / f"never-{action}"
+        case.mkdir()
         failed_env, failed_calls = _stub(case, fail_reconcile=True)
         result = _run(failed_env, action)
         assert result.returncode and "reconcile" in result.stderr
@@ -202,13 +301,15 @@ def test_traefik_reconciliation_precedes_rollout_and_fails_closed(tmp_path):
 
 def test_unowned_resources_are_never_modified_or_disclosed(tmp_path):
     for action in ("apply", "rollback"):
-        case = tmp_path / action; case.mkdir()
+        case = tmp_path / action
+        case.mkdir()
         env, calls = _stub(case, owner="someone-else")
         result = _run(env, action)
         assert result.returncode and "not owned" in result.stderr
         assert "someone-else" not in result.stdout + result.stderr
         assert all(word not in calls.read_text() for word in ("apply -f", "delete"))
-    failed = tmp_path / "lookup"; failed.mkdir()
+    failed = tmp_path / "lookup"
+    failed.mkdir()
     env, calls = _stub(failed, lookup_error=True)
     result = _run(env, "apply")
     assert result.returncode and "unable to inspect ownership" in result.stderr
@@ -219,7 +320,8 @@ def test_unowned_resources_are_never_modified_or_disclosed(tmp_path):
 def test_each_pod_workload_rejects_singleton_and_same_node(tmp_path):
     for nodes in ("node1", "node1,node1"):
         for expected in ("Traefik", "Cloudflare tunnel"):
-            case = tmp_path / f"{nodes.replace(',', '-')}-{expected.split()[0]}"; case.mkdir()
+            case = tmp_path / f"{nodes.replace(',', '-')}-{expected.split()[0]}"
+            case.mkdir()
             env, calls = _stub(case, workload_nodes={expected: nodes})
             result = _run(env, "verify")
             assert result.returncode
@@ -229,14 +331,127 @@ def test_each_pod_workload_rejects_singleton_and_same_node(tmp_path):
 
 def test_coredns_requires_two_ready_endpoints_on_distinct_nodes(tmp_path):
     for i, nodes in enumerate(("node1", "node1,node1")):
-        case = tmp_path / str(i); case.mkdir()
+        case = tmp_path / str(i)
+        case.mkdir()
         env, calls = _stub(case, endpoint_nodes=nodes)
         result = _run(env, "verify")
         assert result.returncode and "hostname-spread CoreDNS endpoints" in result.stderr
         assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
-    healthy = tmp_path / "healthy"; healthy.mkdir()
+    healthy = tmp_path / "healthy"
+    healthy.mkdir()
     env, _ = _stub(healthy, endpoint_nodes="node1,node2")
     assert _run(env, "verify").returncode == 0
+
+
+def test_endpoint_slices_aggregate_deduplicate_and_sort_deterministically(tmp_path):
+    documents = {
+        "kube-dns": {
+            "apiVersion": "discovery.k8s.io/v1",
+            "kind": "EndpointSliceList",
+            "items": [
+                {
+                    "metadata": {"labels": {"kubernetes.io/service-name": "kube-dns"}},
+                    "endpoints": [
+                        {
+                            "addresses": ["2001:db8::2", "10.0.0.2"],
+                            "nodeName": "node2",
+                            "targetRef": {
+                                "kind": "Pod",
+                                "namespace": "kube-system",
+                                "name": "dns-b",
+                            },
+                            "conditions": {},
+                        },
+                    ],
+                },
+                {
+                    "metadata": {"labels": {"kubernetes.io/service-name": "kube-dns"}},
+                    "endpoints": [
+                        {
+                            "addresses": ["10.0.0.1"],
+                            "nodeName": "node1",
+                            "conditions": {"ready": True, "serving": True, "terminating": False},
+                        },
+                        {
+                            "addresses": ["10.0.0.1"],
+                            "nodeName": "node1",
+                            "conditions": {"ready": True, "serving": True, "terminating": False},
+                        },
+                    ],
+                },
+            ],
+        },
+        "traefik": _slices("traefik"),
+    }
+    env, _ = _stub(tmp_path, endpoint_documents=documents)
+    result = _run(env, "verify")
+    assert result.returncode == 0, result.stderr
+    assert "kube-dns: slices=2 unique=2 healthy=2 ready nodes=['node1', 'node2']" in result.stdout
+    assert "10.0.0" not in result.stdout
+
+
+def test_unhealthy_endpoint_conditions_are_diagnostic_and_not_counted(tmp_path):
+    endpoints = [
+        {
+            "addresses": ["10.0.0.1"],
+            "nodeName": "node1",
+            "conditions": {"ready": True, "serving": True},
+        },
+        {
+            "addresses": ["10.0.0.2"],
+            "nodeName": "node2",
+            "conditions": {"ready": False, "serving": False},
+        },
+        {
+            "addresses": ["10.0.0.3"],
+            "nodeName": "node3",
+            "conditions": {"ready": True, "serving": True, "terminating": True},
+        },
+    ]
+    documents = {"kube-dns": _slices("kube-dns", endpoints), "traefik": _slices("traefik")}
+    env, _ = _stub(tmp_path, endpoint_documents=documents)
+    result = _run(env, "verify")
+    assert result.returncode
+    assert "non-serving,not-ready" in result.stdout
+    assert "terminating" in result.stdout
+    assert "hostname-spread CoreDNS endpoints" in result.stderr
+
+
+def test_endpoint_without_node_is_healthy_but_not_hostname_spread(tmp_path):
+    documents = {
+        "kube-dns": _slices(
+            "kube-dns",
+            [
+                {"addresses": ["2001:db8::1"], "conditions": {}},
+                {"addresses": ["10.0.0.2"], "nodeName": "node2", "conditions": {}},
+            ],
+        ),
+        "traefik": _slices("traefik"),
+    }
+    env, _ = _stub(tmp_path, endpoint_documents=documents)
+    result = _run(env, "verify")
+    assert result.returncode and "healthy=2 ready nodes=['node2']" in result.stdout
+
+
+def test_no_slices_malformed_json_and_malformed_endpoint_fail_safely(tmp_path):
+    cases = [
+        ({"kube-dns": {"items": []}, "traefik": _slices("traefik")}, "no EndpointSlices"),
+        ("malformed-json", "invalid EndpointSlice data"),
+        (
+            {
+                "kube-dns": _slices("kube-dns", [{"addresses": "10.0.0.1"}]),
+                "traefik": _slices("traefik"),
+            },
+            "addresses must be",
+        ),
+    ]
+    for index, (documents, expected) in enumerate(cases):
+        case = tmp_path / str(index)
+        case.mkdir()
+        env, calls = _stub(case, endpoint_documents=documents)
+        result = _run(env, "verify")
+        assert result.returncode and expected in result.stderr
+        assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
 
 
 def test_healthy_verify_and_unique_tunnel_discovery(tmp_path):
@@ -251,7 +466,8 @@ def test_healthy_verify_and_unique_tunnel_discovery(tmp_path):
 
 def test_zero_or_multiple_tunnel_deployments_fail_and_cleanup(tmp_path):
     for count in (0, 2):
-        case = tmp_path / str(count); case.mkdir()
+        case = tmp_path / str(count)
+        case.mkdir()
         env, calls = _stub(case, tunnels=count)
         result = _run(env, "verify")
         assert result.returncode and f"found {count}" in result.stderr
@@ -259,16 +475,22 @@ def test_zero_or_multiple_tunnel_deployments_fail_and_cleanup(tmp_path):
 
 
 def test_probe_discovery_required_and_curl_failure_redacted(tmp_path):
-    none = tmp_path / "none"; none.mkdir(); env, calls = _stub(none, probes=False)
+    none = tmp_path / "none"
+    none.mkdir()
+    env, calls = _stub(none, probes=False)
     result = _run(env, "verify")
     assert result.returncode and "no critical staging HTTPS Probe targets" in result.stderr
     assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
-    failed = tmp_path / "failed"; failed.mkdir(); env, calls = _stub(failed, fail_curl=True)
+    failed = tmp_path / "failed"
+    failed.mkdir()
+    env, calls = _stub(failed, fail_curl=True)
     result = _run(env, "verify")
     assert result.returncode and "target redacted" in result.stderr
     assert "private.example" not in result.stdout + result.stderr
     assert "sensitive-url-output" not in result.stdout + result.stderr
-    legacy = tmp_path / "legacy"; legacy.mkdir(); env, calls = _stub(legacy, probe_mode="legacy")
+    legacy = tmp_path / "legacy"
+    legacy.mkdir()
+    env, calls = _stub(legacy, probe_mode="legacy")
     result = _run(env, "verify")
     assert result.returncode and "no critical staging HTTPS Probe targets" in result.stderr
     assert "legacy.example" not in calls.read_text()
@@ -276,9 +498,13 @@ def test_probe_discovery_required_and_curl_failure_redacted(tmp_path):
 
 
 def test_rollout_and_dns_probe_timeouts_cleanup(tmp_path):
-    rollout = tmp_path / "rollout"; rollout.mkdir(); env, _ = _stub(rollout, fail_wait="deployment/coredns-ha")
+    rollout = tmp_path / "rollout"
+    rollout.mkdir()
+    env, _ = _stub(rollout, fail_wait="deployment/coredns-ha")
     assert "rollout timed out" in _run(env, "apply").stderr
-    dns = tmp_path / "dns"; dns.mkdir(); env, calls = _stub(dns, fail_wait="pod/sugarkube")
+    dns = tmp_path / "dns"
+    dns.mkdir()
+    env, calls = _stub(dns, fail_wait="pod/sugarkube")
     result = _run(env, "verify")
     assert result.returncode and "DNS probe failed" in result.stderr
     assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()

--- a/tests/test_staging_ingress_ha.py
+++ b/tests/test_staging_ingress_ha.py
@@ -2,6 +2,11 @@ import json
 import os
 import pathlib
 import subprocess
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from unittest.mock import patch
+
+from scripts import staging_ingress_ha_endpoints
 
 ROOT = pathlib.Path(__file__).parents[1]
 SCRIPT = ROOT / "scripts/staging_ingress_ha.sh"
@@ -458,11 +463,80 @@ def test_no_slices_malformed_json_and_malformed_endpoint_fail_safely(tmp_path):
         assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
 
 
-def _summarize(document, service="kube-dns"):
-    return subprocess.run(
-        ["python3", str(ENDPOINT_SUMMARY), service],
-        input=json.dumps(document), text=True, capture_output=True, check=False,
+def _summarize(document, service="kube-dns", minimum_nodes=0):
+    stdin = StringIO(json.dumps(document))
+    stdout = StringIO()
+    stderr = StringIO()
+    argv = [str(ENDPOINT_SUMMARY), service]
+    if minimum_nodes:
+        argv.extend(["--minimum-nodes", str(minimum_nodes)])
+    with (
+        patch("sys.argv", argv),
+        patch("sys.stdin", stdin),
+        redirect_stdout(stdout),
+        redirect_stderr(stderr),
+    ):
+        returncode = staging_ingress_ha_endpoints.main()
+    return subprocess.CompletedProcess(
+        [str(ENDPOINT_SUMMARY), service], returncode, stdout.getvalue(), stderr.getvalue()
     )
+
+
+def test_endpoint_summarizer_is_covered_in_process():
+    healthy = {
+        "addresses": ["not-an-ip", "10.0.0.1", "10.0.0.1"],
+        "nodeName": "node1",
+        "targetRef": {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "namespace": "kube-system",
+            "name": "dns-a",
+            "uid": "1",
+        },
+        "conditions": {},
+    }
+    result = _summarize(_slices("kube-dns", [healthy]), minimum_nodes=2)
+    assert result.returncode
+    assert "unique=1 healthy=1" in result.stdout
+    assert "fewer than 2 healthy" in result.stderr
+
+    malformed_endpoints = [
+        None,
+        {"addresses": []},
+        {"addresses": [1]},
+        {"addresses": ["10.0.0.1"], "nodeName": ""},
+        {"addresses": ["10.0.0.1"], "targetRef": []},
+        {"addresses": ["10.0.0.1"], "targetRef": {"uid": 1}},
+        {"addresses": ["10.0.0.1"], "conditions": []},
+        {"addresses": ["10.0.0.1"], "conditions": {"ready": "yes"}},
+    ]
+    malformed_documents = [
+        None,
+        {},
+        {"items": []},
+        {"items": [None]},
+        {"items": [{"metadata": None, "endpoints": []}]},
+        {"items": [{"metadata": {"labels": None}, "endpoints": []}]},
+        {
+            "items": [
+                {
+                    "metadata": {"labels": {"kubernetes.io/service-name": "other"}},
+                    "endpoints": [],
+                }
+            ]
+        },
+        {
+            "items": [
+                {"metadata": {"labels": {"kubernetes.io/service-name": "kube-dns"}}}
+            ]
+        },
+    ]
+    malformed_documents.extend(_slices("kube-dns", [endpoint]) for endpoint in malformed_endpoints)
+    for document in malformed_documents:
+        result = _summarize(document)
+        assert result.returncode
+        assert "ERROR: invalid EndpointSlice data:" in result.stderr
+        assert "Traceback" not in result.stderr
 
 
 def test_endpoint_output_is_stable_when_redacted_descriptions_collide():

--- a/tests/test_staging_ingress_ha.py
+++ b/tests/test_staging_ingress_ha.py
@@ -253,6 +253,21 @@ def test_status_is_read_only_and_optional_companion_may_be_absent(tmp_path):
     assert all(word not in text for word in ("apply", "patch", "delete", " run "))
 
 
+def test_status_reports_all_components_before_failing_for_unhealthy_slices(tmp_path):
+    documents = {
+        "kube-dns": _slices("kube-dns", []),
+        "traefik": _slices("traefik"),
+    }
+    env, calls = _stub(tmp_path, endpoint_documents=documents)
+    result = _run(env, "status")
+    assert result.returncode
+    assert "contain no endpoints" in result.stderr
+    assert "traefik: slices=1" in result.stdout
+    assert (
+        "get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o wide" in calls.read_text()
+    )
+
+
 def test_apply_idempotent_ordered_and_owned_rollback(tmp_path):
     env, calls = _stub(tmp_path)
     for _ in range(2):
@@ -443,6 +458,15 @@ def test_no_slices_malformed_json_and_malformed_endpoint_fail_safely(tmp_path):
                 "traefik": _slices("traefik"),
             },
             "addresses must be",
+        ),
+        (
+            {
+                "kube-dns": {
+                    "items": [{"metadata": [], "endpoints": []}],
+                },
+                "traefik": _slices("traefik"),
+            },
+            "metadata must be an object",
         ),
     ]
     for index, (documents, expected) in enumerate(cases):


### PR DESCRIPTION
Closes #2404.

## Summary

- Record the July 29, 2026 staging node-failure drill, including observed continuity, the token.place transient, recovery state, and the drill’s limitations.
- Replace invalid `k3s etcdctl` guidance with the built-in API-server readiness check and document its exact scope.
- Migrate active staging ingress HA status and verification from deprecated core/v1 Endpoints reads to complete EndpointSlice aggregation.
- Link the residual-transient follow-up in #2407.

## Implementation

- Select every EndpointSlice labeled `kubernetes.io/service-name=<service>` and aggregate all matching slices.
- Validate malformed documents and endpoint fields with controlled diagnostics rather than tracebacks.
- Deterministically normalize, sort, and deduplicate endpoints using node name, addresses, and target reference.
- Support multiple slices, duplicate observations, multiple addresses, IPv4 and IPv6, and endpoints without `nodeName`.
- Treat absent conditions according to the documented EndpointSlice contract:
  - absent `ready` is treated as ready;
  - absent `serving` follows effective readiness;
  - absent `terminating` is treated as false.
- Count an endpoint as healthy only when it is ready, serving, and non-terminating. Conflicting duplicate observations are handled conservatively as unhealthy.
- Report stale, non-serving, terminating, and malformed endpoints diagnostically without counting them healthy.
- Preserve distinct-node checks, staging/context guards, bounded waits, cleanup, redaction, and app-agnostic behavior.
- Keep `staging-ingress-ha-status` diagnostic collection running across service failures while returning an aggregate failure status.
- Add deterministic offline coverage for EndpointSlice aggregation, condition handling, malformed input, sorting, deduplication, existing service checks, and safety behavior.
- Exercise the EndpointSlice helper in-process in unit tests so its branches are measured directly, while retaining shell-level integration coverage through `scripts/staging_ingress_ha.sh`.

## Documentation

The dated drill record documents:

- the pre-#2400 singleton CoreDNS and Traefik topology;
- the approximately six-minute historical token.place interruption;
- the post-change node-spread topology;
- shutdown, alerting, continuity, transient, recovery, and replacement-pod observations;
- the sampler and singleton-workload limitations;
- that PagerDuty auto-resolution timing is not claimed without evidence.

The runbooks now use:

`kubectl get --raw='/readyz?verbose' | rg 'etcd|readyz check passed'`

This verifies readiness of the contacted API server and its etcd dependency. It is not a complete per-member etcd health, consistency, or latency report. Deeper inspection is explicitly optional and requires a separately installed compatible `etcdctl` with official K3s-managed endpoints and certificate paths.

## Verification

All relevant latest-head checks completed successfully, including:

- `ci`
- `Test Suite`
- `Spellcheck`
- documentation spellcheck and link checking
- `pi-image` unit and OCI parity smoke checks
- `codecov/patch` at 94.73684%, above the required 90% target

The latest Test Suite completed with 1,966 passed and 53 skipped. `scripts/staging_ingress_ha_endpoints.py` reached 95% coverage.

The earlier 0% patch-coverage report was resolved by executing the helper entry point in-process during unit tests. The remaining six uncovered helper lines do not prevent the required patch-coverage check from passing.

## Scope and safety

The change is limited to the staging HA verifier, its helper and tests, and directly relevant documentation. It does not change cluster topology, application charts, production or Flux configuration, monitoring integrations, node-monitor settings, or K3s-generated files. No live cluster was contacted or mutated, no additional shutdown was performed, and no Secret or credential data was added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69bcaa325c832f834ac2514e072839)