### PR TITLE
Migrate staging HA verification to EndpointSlices

### DIFF
--- a/docs/drills/2026-07-29-staging-node-failure.md
+++ b/docs/drills/2026-07-29-staging-node-failure.md
@@ -1,0 +1,45 @@
+# 2026-07-29 staging node-failure drill
+
+## Scope and limitations
+
+> **Important:** The serial sampler cannot prove that no failures occurred between samples. This
+> drill demonstrated continuity of the shared ingress and DNS platform, not fast rescheduling of
+> every singleton workload. token.place happened to remain on a surviving node. PagerDuty detected
+> the incident, but this evidence does **not** establish PagerDuty auto-resolution timing.
+
+This is the durable, sanitized record of the staging drill completed on July 29, 2026. Before
+[PR #2400](https://github.com/futuroptimist/sugarkube/pull/2400), staging ran one CoreDNS replica,
+one Traefik replica, and two Cloudflare Tunnel replicas. A previous loss of `sugarkube3` interrupted
+public token.place service for roughly six minutes. PR #2400 added node-spread CoreDNS coverage and
+two node-separated Traefik replicas.
+
+## Observations
+
+The operator manually powered off `sugarkube3` at approximately
+`2026-07-29T00:05:25-07:00`. No additional node shutdown is required to use this record.
+
+* `sugarkube3` became `NotReady`; `sugarkube4` and `sugarkube5` remained `Ready`. Kubernetes API
+  readiness, including its etcd dependency, remained available.
+* Healthchecks detected the missing node heartbeat and created a PagerDuty incident. No
+  auto-resolution time is claimed.
+* Sampled DSPACE, danielsmith.io, and Jobbot3000 endpoints remained HTTP 200.
+* token.place stayed on `sugarkube4` with zero restarts. It had the only visible transient: one
+  root request took about 4.7 seconds, one `/livez` request took about 10 seconds, and one
+  `/healthz` request returned HTTP 502 after about 10 seconds. Samples were normal again by about
+  `00:06:14`, less than 49 seconds after shutdown. The compute client needed roughly another
+  10–15 seconds to re-register before chat worked.
+* EndpointSlices eventually marked the dead-node Traefik and CoreDNS endpoints `ready:false`,
+  `serving:false`, and `terminating:true`, while surviving endpoints stayed ready and serving. A
+  replacement Traefik pod later scheduled on `sugarkube5`.
+
+After power restoration, all nodes returned to `Ready`. CoreDNS had ready endpoints on all three
+nodes, and Traefik was ready on `sugarkube4` and `sugarkube5`. Ingress HA, blackbox, Prometheus,
+Alertmanager, and node-heartbeat verification passed, and Healthchecks returned green.
+
+## Conclusions
+
+The changed shared DNS/ingress topology kept sampled public services available through a one-node
+failure and recovered its intended spread. The token.place transient and compute-client
+re-registration show why that platform conclusion must not be generalized to uninterrupted or
+fast-rescheduled singleton applications. Residual transient investigation is tracked in
+[issue #2407](https://github.com/futuroptimist/sugarkube/issues/2407).

--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -39,6 +39,20 @@ logs, preparing Helm, and rolling out real workloads like
 
 For the canonical staging CoreDNS, Traefik, and Cloudflare connector availability lifecycle and
 one-server power-off drill, see [Staging DNS and public-ingress high availability](staging-ingress-ha.md).
+Deployed staging has node-spread CoreDNS coverage and two node-separated Traefik replicas. The
+[July 29, 2026 drill record](drills/2026-07-29-staging-node-failure.md) preserves the evidence and
+sampling limitations.
+
+The default API/etcd-dependency readiness check is:
+
+```bash
+kubectl get --raw='/readyz?verbose' | rg 'etcd|readyz check passed'
+```
+
+It proves the contacted API server is ready and its etcd dependency is ready, not complete
+per-member etcd health, consistency, or latency. Optional deeper inspection requires a separately
+installed compatible `etcdctl` using official K3s-managed endpoints and client-certificate paths.
+Never print certificate or private-key contents.
 
 Follow this sequence after imaging and booting the Pis:
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -34,11 +34,15 @@ operator workstation with the `just`, `flux`, `kubectl`, and `sops` CLIs install
    sudo k3s kubectl get nodes -o wide
    ```
 
-4. Confirm the embedded etcd cluster is healthy:
+4. Confirm the contacted API server and its etcd dependency are ready:
 
    ```bash
-   sudo k3s etcdctl endpoint status --cluster --write-out=table
+   kubectl get --raw='/readyz?verbose' | rg 'etcd|readyz check passed'
    ```
+
+   This is not complete per-member etcd health, consistency, or latency reporting. Optional deeper
+   inspection requires a separately installed compatible `etcdctl` using official K3s-managed
+   endpoints and client-certificate paths. Never print certificate or private-key contents.
 
 ## 2. Deploy kube-vip and verify the virtual IP
 

--- a/docs/staging-ingress-ha.md
+++ b/docs/staging-ingress-ha.md
@@ -2,11 +2,16 @@
 
 ## Incident and ownership
 
-When `sugarkube3` was powered off, the other two `control-plane,etcd` servers retained the
+Before PR #2400, when `sugarkube3` was powered off, the other two `control-plane,etcd` servers
+retained the
 two-member majority of the three-member etcd cluster, so etcd and the API remained available.
 Public service nevertheless failed for about six minutes: the sole packaged CoreDNS pod was on the
 lost node. Kubernetes waited its default roughly five-minute `NodeNotReady` eviction interval before
 `TaintManagerEviction` replaced it; the application itself remained running on `sugarkube4`.
+The completed post-change exercise and its limitations are recorded in the
+[July 29, 2026 drill report](drills/2026-07-29-staging-node-failure.md). Deployed staging now has
+node-spread CoreDNS coverage, two node-separated Traefik replicas, and two Cloudflare Tunnel
+replicas.
 
 The active staging lifecycle is deliberately non-Flux:
 
@@ -53,7 +58,14 @@ configuration. Verification requires two ready CoreDNS and Traefik pods on disti
 discovers exactly one Cloudflare tunnel Deployment cluster-wide by the
 `app.kubernetes.io/name=cloudflare-tunnel` label, then checks only matching pods in its namespace;
 zero or multiple releases fail closed. It never queries tunnel Secrets or logs. Verification also
-checks ready `kube-dns` and Traefik Service backends and an in-cluster DNS lookup. Public HTTPS
+aggregates every `discovery.k8s.io/v1` EndpointSlice selected by
+`kubernetes.io/service-name` for `kube-dns` and Traefik, then checks healthy, distinct-node
+backends and an in-cluster DNS lookup. It deterministically deduplicates endpoints across slices,
+including their IPv4/IPv6 addresses, node name, and target reference. Healthy means ready, serving,
+and non-terminating. Per the EndpointSlice consumer contract, absent `ready` is unknown/usable,
+absent `serving` follows `ready`, and absent `terminating` means non-terminating. Unhealthy or
+unnamed-node endpoints remain diagnostic but do not satisfy the distinct-node count. No slices or
+malformed data fail closed. Public HTTPS
 targets are discovered from live Probe resources labeled
 `environment=staging,criticality=critical`, and at least one is required. Curl timeouts are bounded,
 and failures redact the target and curl diagnostics. The temporary DNS pod is removed on success,
@@ -78,20 +90,23 @@ while true; do just staging-ingress-ha-verify env=staging; sleep 5; done
 ```
 
 In a second terminal, power off exactly one server, observe it, restore it, wait for readiness, and
-inspect three-member etcd health:
+check API readiness. This is a manual procedure only; do not automate a shutdown:
 
 ```bash
 ssh sugarkube3 'sudo systemctl poweroff'
 kubectl get nodes --watch
 # Restore power to sugarkube3 using the normal host power procedure.
 kubectl wait --for=condition=Ready node/sugarkube3 --timeout=10m
-ssh sugarkube4 'sudo k3s etcdctl endpoint status --cluster --write-out=table'
+kubectl get --raw='/readyz?verbose' | rg 'etcd|readyz check passed'
 ```
 
 Public endpoints should remain continuously available. Healthchecks.io and PagerDuty should still
 report the intentionally powered-off node; those alerts prove host monitoring works and are not a
-reason to suppress it. Do not test another node until `sugarkube3` is `Ready` **and** the command
-above confirms all three etcd members have recovered. Never remove a second server while etcd
+reason to suppress it. The request proves the contacted API server is ready and that API server's
+etcd dependency is
+ready. It is not a complete per-member etcd health, consistency, or latency report. Do not test
+another node until `sugarkube3` and API readiness have recovered. Never remove a second server
+while etcd
 redundancy is reduced.
 
 This baseline is platform/app agnostic. It does not alter eviction or node-monitor timing, scale

--- a/scripts/endpoint_slice_health.py
+++ b/scripts/endpoint_slice_health.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Summarize every EndpointSlice for one Service without exposing workload data."""
+
+import argparse
+import json
+import sys
+
+
+def fail(message):
+    raise ValueError(message)
+
+
+def load_endpoints(stream):
+    try:
+        document = json.load(stream)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        fail(f"malformed EndpointSlice JSON: {exc.msg}")
+    if not isinstance(document, dict) or not isinstance(document.get("items"), list):
+        fail("malformed EndpointSlice list: expected an items array")
+    if not document["items"]:
+        fail("no EndpointSlices found for Service")
+
+    endpoints = {}
+    for slice_index, endpoint_slice in enumerate(document["items"]):
+        if not isinstance(endpoint_slice, dict) or not isinstance(
+            endpoint_slice.get("endpoints"), list
+        ):
+            fail(f"malformed EndpointSlice at index {slice_index}: expected an endpoints array")
+        for endpoint_index, endpoint in enumerate(endpoint_slice["endpoints"]):
+            where = f"slice {slice_index}, endpoint {endpoint_index}"
+            if not isinstance(endpoint, dict):
+                fail(f"malformed endpoint at {where}: expected an object")
+            addresses = endpoint.get("addresses")
+            if (
+                not isinstance(addresses, list)
+                or not addresses
+                or any(not isinstance(address, str) or not address for address in addresses)
+            ):
+                fail(f"malformed endpoint at {where}: addresses must be non-empty strings")
+            node = endpoint.get("nodeName")
+            if node is not None and not isinstance(node, str):
+                fail(f"malformed endpoint at {where}: nodeName must be a string or null")
+            conditions = endpoint.get("conditions", {})
+            if not isinstance(conditions, dict):
+                fail(f"malformed endpoint at {where}: conditions must be an object")
+            for condition in ("ready", "serving", "terminating"):
+                if condition in conditions and not isinstance(conditions[condition], bool):
+                    fail(f"malformed endpoint at {where}: conditions.{condition} must be boolean")
+            target = endpoint.get("targetRef")
+            if target is not None and not isinstance(target, dict):
+                fail(f"malformed endpoint at {where}: targetRef must be an object or null")
+
+            # Address order and repeated Slice records are not meaningful. If controllers briefly
+            # publish conflicting duplicates, merge conditions conservatively so an unhealthy copy
+            # can never be hidden by a healthy one.
+            key = (node or "", tuple(sorted(set(addresses))), json.dumps(target, sort_keys=True))
+            healthy = (
+                conditions.get("ready", True) is not False
+                and conditions.get("serving", conditions.get("ready", True)) is not False
+                and conditions.get("terminating", False) is not True
+            )
+            record = endpoints.setdefault(
+                key,
+                {
+                    "addresses": key[1],
+                    "node": node,
+                    "target": target,
+                    "healthy": True,
+                    "states": set(),
+                },
+            )
+            record["healthy"] = record["healthy"] and healthy
+            state = ",".join(
+                (
+                    f"{name}={str(conditions[name]).lower()}"
+                    if name in conditions
+                    else f"{name}=absent"
+                )
+                for name in ("ready", "serving", "terminating")
+            )
+            record["states"].add(state)
+    return [endpoints[key] for key in sorted(endpoints)]
+
+
+def target_name(target):
+    if not target:
+        return "none"
+    return "/".join(str(target.get(key, "?")) for key in ("kind", "namespace", "name"))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("service")
+    parser.add_argument("--minimum-healthy", type=int, default=0)
+    parser.add_argument("--minimum-nodes", type=int, default=0)
+    args = parser.parse_args()
+    try:
+        endpoints = load_endpoints(sys.stdin)
+    except ValueError as exc:
+        print(f"ERROR: {args.service}: {exc}", file=sys.stderr)
+        return 2
+
+    healthy = [endpoint for endpoint in endpoints if endpoint["healthy"]]
+    nodes = sorted({endpoint["node"] for endpoint in healthy if endpoint["node"]})
+    print(f"{args.service}: healthy endpoints={len(healthy)} nodes={nodes}")
+    for endpoint in endpoints:
+        state = "healthy" if endpoint["healthy"] else "UNHEALTHY"
+        node = endpoint["node"] or "<none>"
+        states = ";".join(sorted(endpoint["states"]))
+        print(
+            f"  {state}: addresses={','.join(endpoint['addresses'])} node={node} "
+            f"target={target_name(endpoint['target'])} conditions={states}"
+        )
+    if len(healthy) < args.minimum_healthy or len(nodes) < args.minimum_nodes:
+        print(
+            f"ERROR: {args.service}: need at least {args.minimum_healthy} healthy endpoints "
+            f"on {args.minimum_nodes} distinct named nodes",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/staging_ingress_ha.sh
+++ b/scripts/staging_ingress_ha.sh
@@ -2,6 +2,7 @@
 set -Eeuo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TRAEFIK_CONFIG="${ROOT}/clusters/staging/ingress-ha/traefik-helmchartconfig.yaml"
+ENDPOINT_SLICE_HEALTH="${ROOT}/scripts/endpoint_slice_health.py"
 TIMEOUT="${SUGARKUBE_INGRESS_HA_TIMEOUT:-180s}"
 EXPECTED_CONTEXT=sugar-staging
 OWNER_LABEL='sugarkube.dev/managed-by'
@@ -23,7 +24,21 @@ for k in ("creationTimestamp","resourceVersion","uid","generation","managedField
 d.pop("status",None); print(json.dumps(d,sort_keys=True,indent=2))'
 }
 render() { normalize_env "$1"; need kubectl; need python3; cat "$TRAEFIK_CONFIG"; printf '%s\n' '---'; render_coredns; }
-status() { normalize_env "$1"; need kubectl; printf 'Context: %s (read-only)\n' "$(context)"; kubectl -n kube-system get deploy coredns traefik -o wide; kubectl -n kube-system get deploy coredns-ha -o wide --ignore-not-found=true; kubectl -n kube-system get endpoints kube-dns traefik; kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o wide; }
+endpoint_slices() {
+  local service="$1"
+  shift
+  kubectl -n kube-system get endpointslices.discovery.k8s.io -l "kubernetes.io/service-name=${service}" -o json |
+    python3 "$ENDPOINT_SLICE_HEALTH" "$service" "$@"
+}
+status() {
+  normalize_env "$1"; need kubectl; need python3
+  printf 'Context: %s (read-only)\n' "$(context)"
+  kubectl -n kube-system get deploy coredns traefik -o wide
+  kubectl -n kube-system get deploy coredns-ha -o wide --ignore-not-found=true
+  endpoint_slices kube-dns
+  endpoint_slices traefik
+  kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o wide
+}
 assert_owned_or_absent() {
   local kind="$1" name="$2" value error_file resource_file
   error_file="$(mktemp -t sugarkube-ownership.XXXXXX)"
@@ -80,13 +95,7 @@ nodes={p.get("spec",{}).get("nodeName") for p in pods if ready(p)}-{None}
 print(f"{sys.argv[1]}: ready nodes={sorted(nodes)}")
 if len(nodes)<2: raise SystemExit(f"ERROR: fewer than two ready, hostname-spread {sys.argv[1]} pods")' "$name"
   }
-  kubectl -n kube-system get endpoints kube-dns -o json | python3 -c '
-import json,sys
-endpoint=json.load(sys.stdin)
-addresses=[a for subset in endpoint.get("subsets",[]) for a in subset.get("addresses",[])]
-nodes={a.get("nodeName") for a in addresses if a.get("nodeName")}
-print(f"CoreDNS: ready endpoint nodes={sorted(nodes)}")
-if len(addresses)<2 or len(nodes)<2: raise SystemExit("ERROR: fewer than two ready, hostname-spread CoreDNS endpoints")'
+  endpoint_slices kube-dns --minimum-healthy 2 --minimum-nodes 2
   kubectl -n kube-system get pods -l app.kubernetes.io/name=traefik -o json | check_spread Traefik
   local tunnel_namespace
   tunnel_namespace="$(kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o json | python3 -c '
@@ -95,7 +104,7 @@ items=json.load(sys.stdin)["items"]
 if len(items) != 1: raise SystemExit(f"ERROR: expected exactly one Cloudflare tunnel Deployment; found {len(items)}")
 print(items[0]["metadata"]["namespace"])')"
   kubectl -n "$tunnel_namespace" get pods -l app.kubernetes.io/name=cloudflare-tunnel -o json | check_spread 'Cloudflare tunnel'
-  for svc in kube-dns traefik; do kubectl -n kube-system get endpoints "$svc" -o json | python3 -c 'import json,sys; e=json.load(sys.stdin); assert any(x.get("addresses") for x in e.get("subsets",[])), "ERROR: Service has no ready backend"'; done
+  endpoint_slices traefik --minimum-healthy 2 --minimum-nodes 2
   kubectl -n default run "$probe" --image="${SUGARKUBE_DNS_TEST_IMAGE:-busybox:1.36}" --restart=Never --command -- nslookup kubernetes.default.svc.cluster.local >/dev/null
   kubectl -n default wait --for=jsonpath='{.status.phase}'=Succeeded "pod/$probe" --timeout="$TIMEOUT" || die "bounded in-cluster DNS probe failed"
   local targets url

--- a/tests/test_staging_ingress_ha.py
+++ b/tests/test_staging_ingress_ha.py
@@ -5,6 +5,7 @@ import subprocess
 
 ROOT = pathlib.Path(__file__).parents[1]
 SCRIPT = ROOT / "scripts/staging_ingress_ha.sh"
+ENDPOINT_HELPER = ROOT / "scripts/endpoint_slice_health.py"
 OWNER = "sugarkube.dev/managed-by"
 
 DEPLOYMENT = {
@@ -38,10 +39,20 @@ def _pod(node):
     }}
 
 
+def _slices(nodes=("node1", "node2")):
+    return {"apiVersion": "discovery.k8s.io/v1", "kind": "EndpointSliceList", "items": [{
+        "metadata": {"name": "fixture-1"},
+        "endpoints": [{"addresses": [f"192.0.2.{index + 1}"], "nodeName": node,
+                       "conditions": {"ready": True, "serving": True, "terminating": False},
+                       "targetRef": {"kind": "Pod", "namespace": "kube-system", "name": f"pod-{index}"}}
+                      for index, node in enumerate(nodes) if node],
+    }]}
+
+
 def _stub(tmp_path, *, context="sugar-staging", nodes="node1,node2", workload_nodes=None, tunnels=1,
           owner="staging-ingress-ha", probes=True, probe_mode="canonical", endpoint_nodes="node1,node2",
           resource_absent=False, lookup_error=False, fail_wait="", fail_curl=False,
-          fail_reconcile=False):
+          fail_reconcile=False, endpoint_slices=None):
     calls = tmp_path / "calls"
     kubectl = tmp_path / "kubectl"
     kubectl.write_text(f'''#!/usr/bin/env python3
@@ -67,9 +78,8 @@ elif joined == "get probes -A -l environment=staging,criticality=critical -o jso
     elif os.environ["PROBE_MODE"] == "legacy": items=[{{"spec":{{"url":"https://legacy.example/health"}}}}]
     else: items=[{{"spec":{{"targets":{{"staticConfig":{{"static":["https://private.example/health", "http://ignored.example", "https://private.example/health"]}}}}}}}}]
     print(json.dumps({{"items":items}}))
-elif "get endpoints" in joined and "-o json" in joined:
-    nodes=os.environ["ENDPOINT_NODES"].split(",") if "kube-dns" in joined else ["node1"]
-    print(json.dumps({{"subsets":[{{"addresses":[{{"ip":f"10.0.0.{{i+1}}","nodeName":n}} for i,n in enumerate(nodes) if n]}}]}}))
+elif "get endpointslices.discovery.k8s.io" in joined and "-o json" in joined:
+    print(os.environ["ENDPOINT_SLICES"])
 elif "wait" in args:
     if os.environ.get("FAIL_WAIT") and os.environ["FAIL_WAIT"] in joined: sys.exit(1)
     if "deployment/traefik" in joined and "jsonpath={{.spec.replicas}}" in joined:
@@ -92,7 +102,8 @@ elif "rollout status" in joined and os.environ.get("FAIL_WAIT") and os.environ["
         "TRAEFIK_NODES": (workload_nodes or {}).get("Traefik", nodes),
         "TUNNEL_NODES": (workload_nodes or {}).get("Cloudflare tunnel", nodes),
         "TUNNELS": str(tunnels), "OWNER": owner, "PROBES": "1" if probes else "0",
-        "PROBE_MODE": probe_mode, "ENDPOINT_NODES": endpoint_nodes,
+        "PROBE_MODE": probe_mode,
+        "ENDPOINT_SLICES": json.dumps(endpoint_slices or _slices(endpoint_nodes.split(","))),
         "RESOURCE_ABSENT": "1" if resource_absent else "0", "LOOKUP_ERROR": "1" if lookup_error else "0",
         "FAIL_WAIT": fail_wait, "FAIL_CURL": "1" if fail_curl else "0",
         "FAIL_RECONCILE": "1" if fail_reconcile else "0",
@@ -101,6 +112,11 @@ elif "rollout status" in joined and os.environ.get("FAIL_WAIT") and os.environ["
 
 def _run(env, action, stage="staging"):
     return subprocess.run([SCRIPT, action, stage], env=env, text=True, capture_output=True)
+
+
+def _endpoint_run(document, *args):
+    return subprocess.run([ENDPOINT_HELPER, "fixture", *args], input=json.dumps(document),
+                          text=True, capture_output=True)
 
 
 def test_rendered_contracts_and_coredns_clone(tmp_path):
@@ -154,6 +170,7 @@ def test_status_is_read_only_and_optional_companion_may_be_absent(tmp_path):
     text = calls.read_text()
     assert "get deploy coredns traefik -o wide" in text
     assert "get deploy coredns-ha -o wide --ignore-not-found=true" in text
+    assert text.count("get endpointslices.discovery.k8s.io -l kubernetes.io/service-name=") == 2
     assert all(word not in text for word in ("apply", "patch", "delete", " run "))
 
 
@@ -232,7 +249,7 @@ def test_coredns_requires_two_ready_endpoints_on_distinct_nodes(tmp_path):
         case = tmp_path / str(i); case.mkdir()
         env, calls = _stub(case, endpoint_nodes=nodes)
         result = _run(env, "verify")
-        assert result.returncode and "hostname-spread CoreDNS endpoints" in result.stderr
+        assert result.returncode and "distinct named nodes" in result.stderr
         assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
     healthy = tmp_path / "healthy"; healthy.mkdir()
     env, _ = _stub(healthy, endpoint_nodes="node1,node2")
@@ -247,6 +264,72 @@ def test_healthy_verify_and_unique_tunnel_discovery(tmp_path):
     assert "get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o json" in text
     assert "-n tunnel-0 get pods -l app.kubernetes.io/name=cloudflare-tunnel" in text
     assert "delete pod sugarkube-ingress-ha-verify-" in text
+    assert "get endpoints " not in text
+
+
+def test_endpoint_slice_aggregation_dedup_conditions_and_determinism():
+    duplicate = {"addresses": ["2001:db8::2", "192.0.2.2"], "nodeName": "node-b",
+                 "conditions": {"ready": True, "serving": True, "terminating": False},
+                 "targetRef": {"kind": "Pod", "namespace": "ns", "name": "pod-b"}}
+    document = {"items": [
+        {"endpoints": [duplicate, {"addresses": ["192.0.2.1"], "nodeName": "node-a",
+                                  "conditions": {"ready": False, "serving": False}}]},
+        {"endpoints": [dict(duplicate, addresses=list(reversed(duplicate["addresses"]))),
+                       {"addresses": ["2001:db8::3"], "nodeName": "node-c",
+                        "conditions": {"ready": True, "serving": True, "terminating": True}}]},
+    ]}
+    first = _endpoint_run(document, "--minimum-healthy", "1", "--minimum-nodes", "1")
+    second = _endpoint_run({"items": list(reversed(document["items"]))},
+                           "--minimum-healthy", "1", "--minimum-nodes", "1")
+    assert first.returncode == 0, first.stderr
+    assert first.stdout == second.stdout
+    assert first.stdout.count("healthy: addresses=192.0.2.2,2001:db8::2") == 1
+    assert first.stdout.count("UNHEALTHY:") == 2
+    assert "terminating=true" in first.stdout and "ready=false" in first.stdout
+
+
+def test_endpoint_slice_absent_conditions_and_unnamed_nodes():
+    # EndpointSlice says absent conditions are unknown. The verifier follows the consumer contract:
+    # absent ready/serving are usable and absent terminating is non-terminating.
+    result = _endpoint_run({"items": [{"endpoints": [
+        {"addresses": ["2001:db8::1", "192.0.2.1"], "targetRef": None}
+    ]}]}, "--minimum-healthy", "1")
+    assert result.returncode == 0, result.stderr
+    assert "healthy endpoints=1 nodes=[]" in result.stdout
+    assert "node=<none>" in result.stdout
+    assert "ready=absent,serving=absent,terminating=absent" in result.stdout
+    spread = _endpoint_run({"items": [{"endpoints": [
+        {"addresses": ["192.0.2.1"]}, {"addresses": ["192.0.2.2"]}
+    ]}]}, "--minimum-healthy", "2", "--minimum-nodes", "2")
+    assert spread.returncode == 1 and "distinct named nodes" in spread.stderr
+
+
+def test_endpoint_slice_no_slices_and_malformed_input_fail_safely():
+    empty = _endpoint_run({"items": []})
+    assert empty.returncode == 2 and "no EndpointSlices" in empty.stderr
+    malformed_cases = [
+        {}, {"items": [{}]}, {"items": [{"endpoints": [None]}]},
+        {"items": [{"endpoints": [{"addresses": []}]}]},
+        {"items": [{"endpoints": [{"addresses": ["192.0.2.1"], "nodeName": 3}]}]},
+        {"items": [{"endpoints": [{"addresses": ["192.0.2.1"], "conditions": {"ready": "yes"}}]}]},
+        {"items": [{"endpoints": [{"addresses": ["192.0.2.1"], "targetRef": "pod"}]}]},
+    ]
+    for document in malformed_cases:
+        result = _endpoint_run(document)
+        assert result.returncode == 2 and "malformed" in result.stderr
+    raw = subprocess.run([ENDPOINT_HELPER, "fixture"], input="not json", text=True,
+                         capture_output=True)
+    assert raw.returncode == 2 and "malformed EndpointSlice JSON" in raw.stderr
+
+
+def test_unhealthy_endpoint_slices_fail_verify_and_cleanup(tmp_path):
+    document = _slices(("node1", "node2"))
+    document["items"][0]["endpoints"][1]["conditions"]["serving"] = False
+    env, calls = _stub(tmp_path, endpoint_slices=document)
+    result = _run(env, "verify")
+    assert result.returncode and "need at least 2 healthy endpoints" in result.stderr
+    assert "UNHEALTHY" in result.stdout
+    assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
 
 
 def test_zero_or_multiple_tunnel_deployments_fail_and_cleanup(tmp_path):


### PR DESCRIPTION
### Motivation

- Preserve the July 29, 2026 staging node-failure drill as durable evidence and correct stale runbook guidance that recommended an unsupported `k3s etcdctl` command. 
- Replace deprecated core/v1 `Endpoints` reads in the active staging HA verifier with EndpointSlice aggregation to avoid Kubernetes 1.33+ deprecation warnings and provide correct multi-slice coverage.
- Keep the existing staging guards, ownership checks, bounded waits, cleanup, redaction, and app-agnostic behavior while making endpoint health evaluation stricter and deterministic.

### Description

- Add `scripts/endpoint_slice_health.py` which aggregates all `discovery.k8s.io/v1` EndpointSlices selected by `kubernetes.io/service-name=<service>`, validates structure, flattens and deterministically deduplicates endpoints, supports multiple addresses (IPv4/IPv6) and absent `nodeName`, and computes health using `conditions.ready`, `conditions.serving`, and `conditions.terminating` with conservative merging of duplicates.
- Update `scripts/staging_ingress_ha.sh` to call the new EndpointSlice helper for `kube-dns` and `traefik` in both `status` and `verify` code paths and to enforce the ready/serving/non-terminating contract and distinct-node counts.
- Add a sanitized drill record `docs/drills/2026-07-29-staging-node-failure.md` that records the facts, observed timings, outcomes, and explicit limitations of the July 29, 2026 manual power-off exercise and links residual-investigation issue `#2407`.
- Remove the runbook recommendation to run `sudo k3s etcdctl endpoint status --cluster --write-out=table` and document the default scoped readiness check as `kubectl get --raw='/readyz?verbose' | rg 'etcd|readyz check passed'` with clear scope and optional deeper inspection notes requiring a separately installed compatible `etcdctl` and K3s-managed certificate paths.
- Add deterministic offline tests and extend `tests/test_staging_ingress_ha.py` with coverage for single and multiple slices, duplicates, absent conditions, unnamed nodes, IPv4/IPv6, malformed input, deterministic summaries, and integration of the verifier with the existing staging guards and cleanup.

### Testing

- `python3 -m pytest -q tests/test_staging_ingress_ha.py` — 16 passed.
- `bash -n scripts/staging_ingress_ha.sh` — syntax check passed.
- `linkchecker --no-warnings README.md docs/` — linkcheck completed with no errors.
- `git diff --check`, `git diff | ./scripts/scan-secrets.py`, and staged secret scan — no secrets introduced.
- `rg -n 'sudo k3s etcdctl|kubectl.*get endpoints?\b|\.subsets\b' scripts tests docs justfile` — no remaining active recommendations to run `k3s etcdctl`, no active core/v1 `Endpoints` reads, and no `.subsets` usage in the modified runtime paths.

Notes and environment limitations

- `bash scripts/checks.sh` surfaced pre-existing repository-wide Flake8/style warnings unrelated to this change; the new EndpointSlice helper was formatted with Black in-tree.
- `shellcheck` and `pre-commit` were not available in the execution environment, and `pyspelling` failed due to a missing `aspell` binary; these tools should be run in CI or on a developer machine with the required system packages installed.
- No live cluster was contacted or mutated as part of this change and no node shutdowns were performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69bcaed5d4832fbf597c616f12c7c1)