### PR TITLE
Migrate staging HA verification to EndpointSlices

### DIFF
--- a/docs/raspi_cluster_operations.md
+++ b/docs/raspi_cluster_operations.md
@@ -37,8 +37,10 @@ logs, preparing Helm, and rolling out real workloads like
 
 ## Golden path: HA dev cluster → Helm → Traefik → workloads
 
-For the canonical staging CoreDNS, Traefik, and Cloudflare connector availability lifecycle and
-one-server power-off drill, see [Staging DNS and public-ingress high availability](staging-ingress-ha.md).
+For the canonical node-spread staging CoreDNS and Traefik topology, Cloudflare connector
+availability lifecycle, safe one-server power-off procedure, and dated July 29, 2026 drill evidence,
+see [Staging DNS and public-ingress high availability](staging-ingress-ha.md). That drill establishes
+shared ingress/DNS continuity, not rapid recovery of every singleton workload.
 
 Follow this sequence after imaging and booting the Pis:
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -34,11 +34,17 @@ operator workstation with the `just`, `flux`, `kubectl`, and `sops` CLIs install
    sudo k3s kubectl get nodes -o wide
    ```
 
-4. Confirm the embedded etcd cluster is healthy:
+4. Confirm the contacted API server and its etcd dependency are ready:
 
    ```bash
-   sudo k3s etcdctl endpoint status --cluster --write-out=table
+   kubectl get --raw='/readyz?verbose' | rg 'etcd|readyz check passed'
    ```
+
+   This built-in check proves the contacted API server is ready and that API server's etcd
+   dependency is ready. It is not a complete per-member etcd health, consistency, or latency
+   report. For optional deeper inspection, install a separately packaged, K3s-version-compatible
+   `etcdctl` and use the official K3s-managed endpoints and client-certificate paths. Never print
+   certificate, private-key, or Secret contents; K3s does not provide a `k3s etcdctl` subcommand.
 
 ## 2. Deploy kube-vip and verify the virtual IP
 

--- a/docs/staging-ingress-ha.md
+++ b/docs/staging-ingress-ha.md
@@ -2,11 +2,11 @@
 
 ## Incident and ownership
 
-When `sugarkube3` was powered off, the other two `control-plane,etcd` servers retained the
-two-member majority of the three-member etcd cluster, so etcd and the API remained available.
-Public service nevertheless failed for about six minutes: the sole packaged CoreDNS pod was on the
-lost node. Kubernetes waited its default roughly five-minute `NodeNotReady` eviction interval before
-`TaintManagerEviction` replaced it; the application itself remained running on `sugarkube4`.
+Before [PR #2400](https://github.com/futuroptimist/sugarkube/pull/2400), staging had one CoreDNS
+replica, one Traefik replica, and two Cloudflare Tunnel replicas. Losing `sugarkube3` then caused
+roughly six minutes of public token.place interruption. PR #2400 added node-spread CoreDNS coverage
+and two node-separated Traefik replicas. The deployed staging topology is therefore no longer the
+packaged singleton default.
 
 The active staging lifecycle is deliberately non-Flux:
 
@@ -53,7 +53,14 @@ configuration. Verification requires two ready CoreDNS and Traefik pods on disti
 discovers exactly one Cloudflare tunnel Deployment cluster-wide by the
 `app.kubernetes.io/name=cloudflare-tunnel` label, then checks only matching pods in its namespace;
 zero or multiple releases fail closed. It never queries tunnel Secrets or logs. Verification also
-checks ready `kube-dns` and Traefik Service backends and an in-cluster DNS lookup. Public HTTPS
+aggregates every EndpointSlice selected by `kubernetes.io/service-name` for `kube-dns` and Traefik,
+then checks those Service backends and an in-cluster DNS lookup. Exact duplicate endpoints are
+flattened and removed and summaries are sorted. An endpoint is healthy only when effective
+`ready=true`, effective `serving=true`, and `terminating=false`; all other endpoints remain visible
+as diagnostics but do not count. Per the EndpointSlice API compatibility contract, absent `ready`
+means ready; absent `serving` follows effective readiness; and absent `terminating` means false.
+Endpoints may have multiple IPv4 or IPv6 addresses or no `nodeName`, although a missing node cannot
+satisfy a distinct-node requirement. Missing slices and malformed responses fail closed. Public HTTPS
 targets are discovered from live Probe resources labeled
 `environment=staging,criticality=critical`, and at least one is required. Curl timeouts are bounded,
 and failures redact the target and curl diagnostics. The temporary DNS pod is removed on success,
@@ -69,7 +76,34 @@ just staging-ingress-ha-status env=staging
 Rollback intentionally returns DNS/ingress to the K3s singleton defaults and therefore removes the
 one-node availability guarantee. It does not disable or replace K3s components.
 
-## One-node power-off drill
+## July 29, 2026 staging drill record
+
+The post-change drill manually powered off `sugarkube3` at approximately
+`2026-07-29T00:05:25-07:00`. It became `NotReady`, while `sugarkube4` and `sugarkube5` stayed
+`Ready`; the Kubernetes API and its etcd dependency remained ready. Healthchecks detected the
+missing node heartbeat and created a PagerDuty incident. This record does **not** claim a PagerDuty
+auto-resolution time because the available evidence does not establish one.
+
+Serial samples of DSPACE, danielsmith.io, and Jobbot3000 stayed HTTP 200. token.place remained on
+`sugarkube4` with zero restarts, but had the only visible transient: one root request took about 4.7
+seconds, one `/livez` request took about 10 seconds, and one `/healthz` request returned HTTP 502
+after about 10 seconds. Samples were normal again by approximately `00:06:14`, less than 49 seconds
+after shutdown. Its compute client took roughly another 10–15 seconds to re-register before chat
+worked.
+
+EndpointSlices eventually marked dead-node Traefik and CoreDNS endpoints `ready:false`,
+`serving:false`, and `terminating:true`, while surviving endpoints stayed ready and serving. A
+replacement Traefik pod later scheduled on `sugarkube5`. After restoration, all nodes were `Ready`,
+CoreDNS had ready endpoints on all three nodes, and Traefik was ready on `sugarkube4` and
+`sugarkube5`. Ingress HA, blackbox, Prometheus, Alertmanager, and node-heartbeat verification all
+passed, and Healthchecks returned green.
+
+> **Evidence limitations:** the sampler was serial and cannot prove zero failures between samples.
+> This drill proved shared ingress and DNS continuity, not fast rescheduling of every singleton
+> workload. token.place happened to remain on a surviving node. The observed residual transient is
+> tracked in [issue #2407](https://github.com/futuroptimist/sugarkube/issues/2407).
+
+## Safe one-node power-off drill procedure
 
 After apply and verify, run verification continuously from a different server in its own terminal:
 
@@ -78,21 +112,27 @@ while true; do just staging-ingress-ha-verify env=staging; sleep 5; done
 ```
 
 In a second terminal, power off exactly one server, observe it, restore it, wait for readiness, and
-inspect three-member etcd health:
+check the contacted API server's built-in readiness:
 
 ```bash
 ssh sugarkube3 'sudo systemctl poweroff'
 kubectl get nodes --watch
 # Restore power to sugarkube3 using the normal host power procedure.
 kubectl wait --for=condition=Ready node/sugarkube3 --timeout=10m
-ssh sugarkube4 'sudo k3s etcdctl endpoint status --cluster --write-out=table'
+kubectl get --raw='/readyz?verbose' | rg 'etcd|readyz check passed'
 ```
 
 Public endpoints should remain continuously available. Healthchecks.io and PagerDuty should still
 report the intentionally powered-off node; those alerts prove host monitoring works and are not a
-reason to suppress it. Do not test another node until `sugarkube3` is `Ready` **and** the command
-above confirms all three etcd members have recovered. Never remove a second server while etcd
-redundancy is reduced.
+reason to suppress it. The readiness command proves that the contacted API server is ready and that
+API server's etcd dependency is ready. It is not a complete per-member etcd health, consistency, or
+latency report. Do not test another node until `sugarkube3` is `Ready` and the readiness check passes.
+Never remove a second server while etcd redundancy is reduced.
+
+Deeper inspection is optional. Install a separately packaged, K3s-version-compatible `etcdctl`, and
+configure it with the official K3s-managed etcd endpoints and client-certificate paths. Follow the
+current K3s documentation for those paths; never print certificates, private keys, or Secret
+contents. K3s does not provide a `k3s etcdctl` subcommand.
 
 This baseline is platform/app agnostic. It does not alter eviction or node-monitor timing, scale
 applications, or change observability credentials. In particular, token.place relay registration

--- a/scripts/endpoint_slice_summary.py
+++ b/scripts/endpoint_slice_summary.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Summarize and validate all EndpointSlices selected for one Service."""
+
+import argparse
+import json
+import sys
+
+
+def fail(message):
+    raise ValueError(message)
+
+
+def optional_bool(conditions, name):
+    value = conditions.get(name)
+    if value is not None and not isinstance(value, bool):
+        fail(f"condition {name!r} must be boolean or null")
+    return value
+
+
+def summarize(document, service):
+    if not isinstance(document, dict) or not isinstance(document.get("items"), list):
+        fail("EndpointSlice response must contain an items array")
+    if not document["items"]:
+        fail(f"no EndpointSlices found for Service {service}")
+
+    records = set()
+    for slice_ in document["items"]:
+        if not isinstance(slice_, dict) or not isinstance(slice_.get("endpoints"), list):
+            fail("each EndpointSlice must contain an endpoints array")
+        for endpoint in slice_["endpoints"]:
+            if not isinstance(endpoint, dict):
+                fail("each EndpointSlice endpoint must be an object")
+            addresses = endpoint.get("addresses")
+            if (not isinstance(addresses, list) or not addresses or
+                    any(not isinstance(address, str) or not address for address in addresses)):
+                fail("each EndpointSlice endpoint must have one or more string addresses")
+            node = endpoint.get("nodeName")
+            if node is not None and not isinstance(node, str):
+                fail("endpoint nodeName must be a string or null")
+            conditions = endpoint.get("conditions", {})
+            if not isinstance(conditions, dict):
+                fail("endpoint conditions must be an object")
+            ready_value = optional_bool(conditions, "ready")
+            serving_value = optional_bool(conditions, "serving")
+            terminating_value = optional_bool(conditions, "terminating")
+            # EndpointSlice clients must treat an absent ready as ready. Serving was
+            # introduced later, so an absent value follows effective readiness.
+            ready = ready_value is not False
+            serving = ready if serving_value is None else serving_value
+            terminating = terminating_value is True
+            target = endpoint.get("targetRef")
+            if target is not None and not isinstance(target, dict):
+                fail("endpoint targetRef must be an object or null")
+            target_text = "-" if target is None else "/".join(
+                str(target.get(key, "-")) for key in ("kind", "namespace", "name", "uid")
+            )
+            records.add((node or "-", tuple(sorted(set(addresses))), ready, serving,
+                         terminating, target_text))
+
+    ordered = sorted(records, key=lambda record: (record[0], record[1], record[5], record[2:5]))
+    healthy = [record for record in ordered if record[2] and record[3] and not record[4]]
+    healthy_nodes = sorted({record[0] for record in healthy if record[0] != "-"})
+    lines = [f"{service}: healthy endpoints={len(healthy)} nodes={healthy_nodes}"]
+    for node, addresses, ready, serving, terminating, target in ordered:
+        state = "healthy" if ready and serving and not terminating else "unhealthy"
+        lines.append(
+            f"  {state} node={node} addresses={','.join(addresses)} "
+            f"ready={str(ready).lower()} serving={str(serving).lower()} "
+            f"terminating={str(terminating).lower()} targetRef={target}"
+        )
+    return "\n".join(lines), len(healthy), len(healthy_nodes)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--service", required=True)
+    parser.add_argument("--min-healthy", type=int, default=1)
+    parser.add_argument("--min-nodes", type=int, default=0)
+    args = parser.parse_args()
+    try:
+        document = json.load(sys.stdin)
+        output, healthy, nodes = summarize(document, args.service)
+        print(output)
+        if healthy < args.min_healthy or nodes < args.min_nodes:
+            fail(f"Service {args.service} has fewer than the required healthy endpoints/nodes")
+    except (json.JSONDecodeError, ValueError) as error:
+        print(f"ERROR: invalid EndpointSlice data: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/staging_ingress_ha.sh
+++ b/scripts/staging_ingress_ha.sh
@@ -2,6 +2,7 @@
 set -Eeuo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TRAEFIK_CONFIG="${ROOT}/clusters/staging/ingress-ha/traefik-helmchartconfig.yaml"
+ENDPOINT_SUMMARY="${ROOT}/scripts/endpoint_slice_summary.py"
 TIMEOUT="${SUGARKUBE_INGRESS_HA_TIMEOUT:-180s}"
 EXPECTED_CONTEXT=sugar-staging
 OWNER_LABEL='sugarkube.dev/managed-by'
@@ -23,7 +24,12 @@ for k in ("creationTimestamp","resourceVersion","uid","generation","managedField
 d.pop("status",None); print(json.dumps(d,sort_keys=True,indent=2))'
 }
 render() { normalize_env "$1"; need kubectl; need python3; cat "$TRAEFIK_CONFIG"; printf '%s\n' '---'; render_coredns; }
-status() { normalize_env "$1"; need kubectl; printf 'Context: %s (read-only)\n' "$(context)"; kubectl -n kube-system get deploy coredns traefik -o wide; kubectl -n kube-system get deploy coredns-ha -o wide --ignore-not-found=true; kubectl -n kube-system get endpoints kube-dns traefik; kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o wide; }
+summarize_service() {
+  local service="$1" min_healthy="${2:-1}" min_nodes="${3:-0}"
+  kubectl -n kube-system get endpointslices.discovery.k8s.io -l "kubernetes.io/service-name=${service}" -o json |
+    python3 "$ENDPOINT_SUMMARY" --service "$service" --min-healthy "$min_healthy" --min-nodes "$min_nodes"
+}
+status() { normalize_env "$1"; need kubectl; need python3; printf 'Context: %s (read-only)\n' "$(context)"; kubectl -n kube-system get deploy coredns traefik -o wide; kubectl -n kube-system get deploy coredns-ha -o wide --ignore-not-found=true; summarize_service kube-dns; summarize_service traefik; kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o wide; }
 assert_owned_or_absent() {
   local kind="$1" name="$2" value error_file resource_file
   error_file="$(mktemp -t sugarkube-ownership.XXXXXX)"
@@ -80,13 +86,7 @@ nodes={p.get("spec",{}).get("nodeName") for p in pods if ready(p)}-{None}
 print(f"{sys.argv[1]}: ready nodes={sorted(nodes)}")
 if len(nodes)<2: raise SystemExit(f"ERROR: fewer than two ready, hostname-spread {sys.argv[1]} pods")' "$name"
   }
-  kubectl -n kube-system get endpoints kube-dns -o json | python3 -c '
-import json,sys
-endpoint=json.load(sys.stdin)
-addresses=[a for subset in endpoint.get("subsets",[]) for a in subset.get("addresses",[])]
-nodes={a.get("nodeName") for a in addresses if a.get("nodeName")}
-print(f"CoreDNS: ready endpoint nodes={sorted(nodes)}")
-if len(addresses)<2 or len(nodes)<2: raise SystemExit("ERROR: fewer than two ready, hostname-spread CoreDNS endpoints")'
+  summarize_service kube-dns 2 2 || die "fewer than two ready, hostname-spread CoreDNS endpoints"
   kubectl -n kube-system get pods -l app.kubernetes.io/name=traefik -o json | check_spread Traefik
   local tunnel_namespace
   tunnel_namespace="$(kubectl get deployment -A -l app.kubernetes.io/name=cloudflare-tunnel -o json | python3 -c '
@@ -95,7 +95,7 @@ items=json.load(sys.stdin)["items"]
 if len(items) != 1: raise SystemExit(f"ERROR: expected exactly one Cloudflare tunnel Deployment; found {len(items)}")
 print(items[0]["metadata"]["namespace"])')"
   kubectl -n "$tunnel_namespace" get pods -l app.kubernetes.io/name=cloudflare-tunnel -o json | check_spread 'Cloudflare tunnel'
-  for svc in kube-dns traefik; do kubectl -n kube-system get endpoints "$svc" -o json | python3 -c 'import json,sys; e=json.load(sys.stdin); assert any(x.get("addresses") for x in e.get("subsets",[])), "ERROR: Service has no ready backend"'; done
+  summarize_service traefik 1
   kubectl -n default run "$probe" --image="${SUGARKUBE_DNS_TEST_IMAGE:-busybox:1.36}" --restart=Never --command -- nslookup kubernetes.default.svc.cluster.local >/dev/null
   kubectl -n default wait --for=jsonpath='{.status.phase}'=Succeeded "pod/$probe" --timeout="$TIMEOUT" || die "bounded in-cluster DNS probe failed"
   local targets url

--- a/tests/test_staging_ingress_ha.py
+++ b/tests/test_staging_ingress_ha.py
@@ -5,6 +5,7 @@ import subprocess
 
 ROOT = pathlib.Path(__file__).parents[1]
 SCRIPT = ROOT / "scripts/staging_ingress_ha.sh"
+SUMMARY = ROOT / "scripts/endpoint_slice_summary.py"
 OWNER = "sugarkube.dev/managed-by"
 
 DEPLOYMENT = {
@@ -40,6 +41,7 @@ def _pod(node):
 
 def _stub(tmp_path, *, context="sugar-staging", nodes="node1,node2", workload_nodes=None, tunnels=1,
           owner="staging-ingress-ha", probes=True, probe_mode="canonical", endpoint_nodes="node1,node2",
+          endpoint_slices=None,
           resource_absent=False, lookup_error=False, fail_wait="", fail_curl=False,
           fail_reconcile=False):
     calls = tmp_path / "calls"
@@ -67,9 +69,11 @@ elif joined == "get probes -A -l environment=staging,criticality=critical -o jso
     elif os.environ["PROBE_MODE"] == "legacy": items=[{{"spec":{{"url":"https://legacy.example/health"}}}}]
     else: items=[{{"spec":{{"targets":{{"staticConfig":{{"static":["https://private.example/health", "http://ignored.example", "https://private.example/health"]}}}}}}}}]
     print(json.dumps({{"items":items}}))
-elif "get endpoints" in joined and "-o json" in joined:
-    nodes=os.environ["ENDPOINT_NODES"].split(",") if "kube-dns" in joined else ["node1"]
-    print(json.dumps({{"subsets":[{{"addresses":[{{"ip":f"10.0.0.{{i+1}}","nodeName":n}} for i,n in enumerate(nodes) if n]}}]}}))
+elif "get endpointslices.discovery.k8s.io" in joined and "-o json" in joined:
+    if os.environ.get("ENDPOINT_SLICES"): print(os.environ["ENDPOINT_SLICES"])
+    else:
+        nodes=os.environ["ENDPOINT_NODES"].split(",") if "service-name=kube-dns" in joined else ["node1"]
+        print(json.dumps({{"items":[{{"endpoints":[{{"addresses":[f"10.0.0.{{i+1}}"],"nodeName":n,"conditions":{{"ready":True,"serving":True,"terminating":False}},"targetRef":{{"kind":"Pod","namespace":"kube-system","name":f"pod-{{i}}"}}}} for i,n in enumerate(nodes) if n]}}]}}))
 elif "wait" in args:
     if os.environ.get("FAIL_WAIT") and os.environ["FAIL_WAIT"] in joined: sys.exit(1)
     if "deployment/traefik" in joined and "jsonpath={{.spec.replicas}}" in joined:
@@ -93,6 +97,7 @@ elif "rollout status" in joined and os.environ.get("FAIL_WAIT") and os.environ["
         "TUNNEL_NODES": (workload_nodes or {}).get("Cloudflare tunnel", nodes),
         "TUNNELS": str(tunnels), "OWNER": owner, "PROBES": "1" if probes else "0",
         "PROBE_MODE": probe_mode, "ENDPOINT_NODES": endpoint_nodes,
+        "ENDPOINT_SLICES": "" if endpoint_slices is None else endpoint_slices,
         "RESOURCE_ABSENT": "1" if resource_absent else "0", "LOOKUP_ERROR": "1" if lookup_error else "0",
         "FAIL_WAIT": fail_wait, "FAIL_CURL": "1" if fail_curl else "0",
         "FAIL_RECONCILE": "1" if fail_reconcile else "0",
@@ -101,6 +106,29 @@ elif "rollout status" in joined and os.environ.get("FAIL_WAIT") and os.environ["
 
 def _run(env, action, stage="staging"):
     return subprocess.run([SCRIPT, action, stage], env=env, text=True, capture_output=True)
+
+
+def _summarize(document, service="kube-dns", minimum=1, nodes=0):
+    return subprocess.run(
+        [SUMMARY, "--service", service, "--min-healthy", str(minimum), "--min-nodes", str(nodes)],
+        input=document if isinstance(document, str) else json.dumps(document), text=True,
+        capture_output=True,
+    )
+
+
+def _slice(*endpoints):
+    return {"endpoints": list(endpoints)}
+
+
+def _endpoint(addresses, node=None, conditions=None, target="pod"):
+    value = {"addresses": addresses}
+    if node is not None:
+        value["nodeName"] = node
+    if conditions is not None:
+        value["conditions"] = conditions
+    if target is not None:
+        value["targetRef"] = {"kind": "Pod", "namespace": "kube-system", "name": target}
+    return value
 
 
 def test_rendered_contracts_and_coredns_clone(tmp_path):
@@ -237,6 +265,72 @@ def test_coredns_requires_two_ready_endpoints_on_distinct_nodes(tmp_path):
     healthy = tmp_path / "healthy"; healthy.mkdir()
     env, _ = _stub(healthy, endpoint_nodes="node1,node2")
     assert _run(env, "verify").returncode == 0
+
+
+def test_endpoint_slices_aggregate_deduplicate_and_sort_deterministically():
+    duplicate = _endpoint(["2001:db8::2", "10.0.0.2"], "node2", {}, "dns-b")
+    document = {"items": [
+        _slice(duplicate, _endpoint(["10.0.0.1"], "node1", {}, "dns-a")),
+        _slice(duplicate),
+    ]}
+    first = _summarize(document, minimum=2, nodes=2)
+    second = _summarize({"items": list(reversed(document["items"]))}, minimum=2, nodes=2)
+    assert first.returncode == 0, first.stderr
+    assert first.stdout == second.stdout
+    assert "healthy endpoints=2 nodes=['node1', 'node2']" in first.stdout
+    assert "addresses=10.0.0.2,2001:db8::2" in first.stdout
+    assert first.stdout.index("node=node1") < first.stdout.index("node=node2")
+
+
+def test_endpoint_slice_health_contract_and_diagnostics():
+    document = {"items": [_slice(
+        _endpoint(["10.0.0.1"], "node1", {"ready": True, "serving": True,
+                                                    "terminating": False}, "healthy"),
+        _endpoint(["10.0.0.2"], "node2", {"ready": False, "serving": True}, "not-ready"),
+        _endpoint(["10.0.0.3"], "node3", {"ready": True, "serving": True,
+                                                    "terminating": True}, "terminating"),
+        _endpoint(["10.0.0.4"], "node4", {"ready": True, "serving": False}, "not-serving"),
+        _endpoint(["2001:db8::5"], conditions={}, target=None),
+    )]}
+    result = _summarize(document, minimum=2, nodes=1)
+    assert result.returncode == 0, result.stderr
+    assert "healthy endpoints=2 nodes=['node1']" in result.stdout
+    assert result.stdout.count("  unhealthy ") == 3
+    assert "node=- addresses=2001:db8::5 ready=true serving=true terminating=false targetRef=-" in result.stdout
+
+
+def test_endpoint_slice_empty_and_malformed_data_fail_safely():
+    invalid = [
+        "not json", {"items": []}, {"items": [_slice({"addresses": []})]},
+        {"items": [{"endpoints": "wrong"}]},
+        {"items": [_slice(_endpoint(["10.0.0.1"], conditions={"ready": "yes"}))]},
+        {"items": [_slice({"addresses": ["10.0.0.1"], "targetRef": "pod"})]},
+    ]
+    for document in invalid:
+        result = _summarize(document)
+        assert result.returncode == 2
+        assert "ERROR: invalid EndpointSlice data" in result.stderr
+
+
+def test_verify_rejects_unhealthy_duplicate_endpoint_nodes_and_no_slices(tmp_path):
+    cases = [
+        {"items": [_slice(
+            _endpoint(["10.0.0.1"], "node1", {"ready": True, "serving": True}),
+            _endpoint(["10.0.0.2"], "node1", {"ready": True, "serving": True}),
+        )]},
+        {"items": [_slice(
+            _endpoint(["10.0.0.1"], "node1", {"ready": True, "serving": True}),
+            _endpoint(["10.0.0.2"], "node2", {"ready": True, "serving": True,
+                                                    "terminating": True}),
+        )]},
+        {"items": []},
+    ]
+    for index, slices in enumerate(cases):
+        case = tmp_path / str(index); case.mkdir()
+        env, calls = _stub(case, endpoint_slices=json.dumps(slices))
+        result = _run(env, "verify")
+        assert result.returncode and "hostname-spread CoreDNS endpoints" in result.stderr
+        assert "delete pod sugarkube-ingress-ha-verify-" in calls.read_text()
 
 
 def test_healthy_verify_and_unique_tunnel_discovery(tmp_path):


### PR DESCRIPTION
### Motivation

- Preserve the July 29, 2026 staging node-failure drill as a durable record and correct invalid etcd guidance that recommended a non-existent `k3s etcdctl` invocation.
- Replace deprecated core/v1 `Endpoints` reads in the active staging HA verifier with a robust EndpointSlice-based aggregation that avoids Kubernetes 1.33+ deprecation warnings.
- Keep the verifier's existing staging/context guard, distinct-node checks, redaction, bounded waits, and safety behavior while making health-counting explicit and deterministic.

### Description

- Added a focused EndpointSlice summarizer `scripts/endpoint_slice_summary.py` that reads all matching EndpointSlices (selected by `kubernetes.io/service-name=<service>`), flattens and deterministically deduplicates endpoints, supports multi-address (IPv4/IPv6) entries and endpoints without `nodeName`, validates shape/malformed data, and emits a stable sorted summary.
- Updated `scripts/staging_ingress_ha.sh` to call EndpointSlice summarization for `kube-dns` and Traefik (replacing `kubectl get endpoints` / `.subsets` logic) and to preserve existing verify/apply/rollback guards and Cloudflare discovery behavior.
- Documented EndpointSlice health semantics and choices: an endpoint counts healthy only when effective `ready=true`, effective `serving=true`, and `terminating=false`; absent `ready` is treated as ready, absent `serving` follows effective readiness, and absent `terminating` means false.
- Removed the repository guidance recommending `sudo k3s etcdctl endpoint status --cluster --write-out=table` and added the documented default readiness check `kubectl get --raw='/readyz?verbose' | rg 'etcd|readyz check passed'` with an explicit note of its scope and instructions for optional deeper inspection using a separately installed, compatible `etcdctl` and K3s-managed endpoints/cert paths.
- Added deterministic offline tests and test harness changes in `tests/test_staging_ingress_ha.py` covering single-slice, multi-slice, duplicate endpoints, absent condition fields, terminating/serving/not-ready cases, IPv4/IPv6, endpoints without `nodeName`, malformed JSON, deterministic summary ordering, and integration of the verifier's failure/cleanup behavior.
- Updated docs: `docs/staging-ingress-ha.md`, `docs/runbook.md`, and `docs/raspi_cluster_operations.md` to include the dated July 29, 2026 drill record, the corrected etcd readiness guidance, the EndpointSlice behavior summary, and an explicit statement of evidence limitations (and link to residual issue `#2407`).

Files changed (high-level): `scripts/endpoint_slice_summary.py`, `scripts/staging_ingress_ha.sh`, `tests/test_staging_ingress_ha.py`, `docs/staging-ingress-ha.md`, `docs/runbook.md`, `docs/raspi_cluster_operations.md`.

### Testing

- Ran `python3 -m pytest -q tests/test_staging_ingress_ha.py` and all tests passed: `16 passed`.
- Static and tooling checks run locally:
  - `bash -n scripts/staging_ingress_ha.sh` — passed.
  - `shellcheck scripts/staging_ingress_ha.sh` — passed (shellcheck available in CI environment used here).
  - `pyspelling -c .spellcheck.yaml` — passed.
  - `linkchecker --no-warnings README.md docs/` — passed (internal links checked, 0 errors).
  - `rg -n 'sudo k3s etcdctl|kubectl.*get endpoints?\b|\.subsets\b' scripts tests docs justfile` — confirmed no active recommendations or executable usages of the invalid `k3s etcdctl` command and no remaining `get endpoints` or `.subsets` reads in the active verifier paths.
- Repository-wide checks:
  - `bash scripts/checks.sh` — reported pre-existing, unrelated Flake8 / project-wide lint issues (not introduced by this change).
  - `pre-commit run --all-files` — blocked by pre-existing YAML parsing and unrelated repository-wide lint failures; these were not introduced by this PR.

Notes and residuals

- The PR keeps the verifier read-only except for controlled temporary probe pod creation and preserves redaction and cleanup behavior.
- The changes avoid reading or exposing any Secret/certificate contents; deeper etcd member inspection is explicitly optional and documented to require separately-installed tooling and K3s-managed certificate paths.
- If CI enforces additional project-wide linting hooks, follow-up fixes to unrelated files will be required; those failures are existing and outside the scoped changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69bcb15d54832f9a3cdb6a6a43eda1)