### PR TITLE
Repair staging cert-manager DNS-01 operations

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -233,7 +233,7 @@ Common failure modes:
 - **Missing cert-manager CRDs** (`no matches for kind "Certificate"` / `"ClusterIssuer"`): reinstall cert-manager with CRDs enabled.
 - **`clusterissuer.cert-manager.io` resource type missing**: controllers/CRDs are not fully installed yet.
 - **Literal `$(CERT_MANAGER_EMAIL)` in ClusterIssuer**: issuer was applied from Flux-era template without replacement; reapply with `just cert-manager-issuers-apply email=<email>`.
-- **Missing `cloudflare-api-token` secret**: create it with `just cert-manager-cloudflare-token-secret token=<token>`.
+- **Missing `cloudflare-api-token` Secret in staging**: follow the hidden-input installer and least-privilege contract in [Staging certificate operations](staging-certificates.md).
 - **Challenge cleanup errors after successful issuance**: Cloudflare API token is missing `Zone:Read` and/or is scoped to the wrong zone.
 
 Validation sequence:
@@ -242,8 +242,8 @@ Validation sequence:
 kubectl get crd | grep cert-manager.io
 kubectl get clusterissuer letsencrypt-staging letsencrypt-production
 kubectl get certificate --all-namespaces
-kubectl -n cert-manager get secret cloudflare-api-token
-kubectl -n cert-manager logs deploy/cert-manager --tail=100
+just cert-status namespace=danielsmith certificate=danielsmith-staging-tls env=staging
+# Continue with the bounded, redacted workflow in docs/staging-certificates.md.
 ```
 
 ### Verifier summary block and tests

--- a/docs/staging-certificates.md
+++ b/docs/staging-certificates.md
@@ -1,0 +1,70 @@
+# Staging certificate operations
+
+These operations are staging-only, one Certificate at a time, and do not change
+Ingress TLS or the HTTP Cloudflare Tunnel origin. The declarative inventory in
+`scripts/staging_certificate_inventory.json` is derived from the app-owned
+staging values. It currently lists the shared token's complete intentional zone
+set: `danielsmith.io`, `jobbot3000.tech`, and the already-working `token.place`.
+Update that inventory when an app-owned staging TLS configuration changes.
+
+## Shared Cloudflare token contract
+
+The `cert-manager/cloudflare-api-token` token needs **Zone - Zone - Read** and
+**Zone - DNS - Edit**, scoped explicitly to all three authoritative zones above.
+Do not use “all zones” while this least-privilege list is possible. Secret
+existence and key-name validation cannot prove Cloudflare dashboard permissions;
+an operator must confirm them or observe successful DNS-01 presentation.
+
+Editing the existing token's permissions or resource scope in place needs no
+Kubernetes Secret update. If its value changes, use the hidden interactive
+installer (never an argument, environment assignment, rendered value, log, or
+temporary file):
+
+```console
+just cert-manager-cloudflare-token-secret env=staging
+```
+
+A replacement token must retain every shared zone, especially healthy
+`token.place`. The installer requires current context `sugar-staging`, disables
+tracing, uses hidden input and stdin, and clears the shell variable on exit or
+interruption. Never export a prior token from Kubernetes; retrieve it from the
+password manager. Cloudflare dashboard/API changes remain manual.
+
+## Ordered repair runbook
+
+ACME retries consume rate limits. Complete Danielsmith before starting Jobbot3000:
+
+1. Confirm `kubectl config current-context` is exactly `sugar-staging`. Capture a
+   redacted baseline with `just cert-status namespace=danielsmith
+   certificate=danielsmith-staging-tls env=staging`.
+2. Manually confirm both required permissions and the explicit three-zone scope.
+   Update the Secret only if the token value changed.
+3. Run `just cert-wait namespace=danielsmith
+   certificate=danielsmith-staging-tls timeout=300 env=staging`. This bounded,
+   read-only wait lets owned pending Challenges converge without creating Orders.
+4. Only if it times out and the operator approves one rate-limited retry, run
+   `just cert-renew namespace=danielsmith certificate=danielsmith-staging-tls
+   timeout=300 env=staging`. It observes existing Challenges for the bounded
+   interval **before** issuing one explicitly targeted `cmctl renew`. Never delete
+   Certificates, Requests, Orders, Challenges, or serving Secrets.
+5. Run the bounded wait again. Require `Ready=True`, TLS Secret present, completed
+   current Order/Challenge state, and no new sanitized `Found no Zones` reason.
+   `ACTIVE` means a pending/processing Challenge owned through the newest owned
+   CertificateRequest and Order; older or no-longer-processing failures are
+   `STALE` history.
+6. Run `just cert-verify namespace=danielsmith
+   certificate=danielsmith-staging-tls env=staging`. It reads only `tls.crt` and
+   prints SAN, issuer, serial, and dates; it never reads `tls.key`.
+7. If topology permits, test Traefik/origin TLS directly with SNI and verify it
+   presents that Kubernetes certificate. Separately test public Cloudflare edge
+   TLS validity and `https://staging.danielsmith.io/`, `/healthz`, and `/livez`.
+   The HTTP tunnel makes origin and edge separate certificate layers; their
+   issuers and serials need not match.
+8. At a manual checkpoint, repeat steps 1–7 for `jobbot3000/jobbot3000-staging-tls`.
+   Never renew both concurrently and never contact production.
+
+On a fresh `Found no Zones`, stop retries and recheck dashboard scope. Recovery
+is permission correction followed by the bounded observation sequence. Rollback
+means stopping retries and re-entering a prior known-good token from the password
+manager with the installer—not deleting ACME resources or exporting a Secret.
+These are post-merge live operations; offline tests do not establish issuance.

--- a/justfile
+++ b/justfile
@@ -790,30 +790,22 @@ cert-manager-install version='v1.14.4':
 
     kubectl -n cert-manager wait --for=condition=Available deployment/cert-manager deployment/cert-manager-webhook deployment/cert-manager-cainjector --timeout=300s
 
-# Create/update the Cloudflare DNS API token Secret used by cert-manager DNS-01.
-cert-manager-cloudflare-token-secret token='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
+# Interactively create/update the staging Cloudflare token without argv or files.
+cert-manager-cloudflare-token-secret env='staging':
+    test "{{ env }}" = staging || { echo 'ERROR: only env=staging is permitted.' >&2; exit 1; }
+    scripts/install_staging_cloudflare_token.sh
 
-    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-    token="{{ token }}"
-    : "${token:=${CF_DNS_API_TOKEN:-}}"
-    token="$(printf '%s' "${token}" | tr -d '\r\n' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
-    case "${token}" in
-        token=*|CF_DNS_API_TOKEN=*|CLOUDFLARE_DNS_API_TOKEN=*)
-            token="${token#*=}"
-            token="$(printf '%s' "${token}" | tr -d '\r\n' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
-            ;;
-    esac
-    if [ -z "${token}" ]; then
-        echo "Set CF_DNS_API_TOKEN or pass token=<cloudflare-dns-api-token>." >&2
-        exit 1
-    fi
+cert-status namespace certificate env='staging':
+    scripts/staging_certificate_ops.py status --env "{{ env }}" --namespace "{{ namespace }}" --certificate "{{ certificate }}"
 
-    kubectl get namespace cert-manager >/dev/null 2>&1 || kubectl create namespace cert-manager
-    kubectl -n cert-manager create secret generic cloudflare-api-token \
-        --from-literal=api-token="${token}" \
-        --dry-run=client -o yaml | kubectl apply -f -
+cert-wait namespace certificate timeout='300' env='staging':
+    scripts/staging_certificate_ops.py wait --env "{{ env }}" --namespace "{{ namespace }}" --certificate "{{ certificate }}" --timeout "{{ timeout }}"
+
+cert-renew namespace certificate timeout='300' env='staging':
+    scripts/staging_certificate_ops.py renew --env "{{ env }}" --namespace "{{ namespace }}" --certificate "{{ certificate }}" --timeout "{{ timeout }}"
+
+cert-verify namespace certificate env='staging':
+    scripts/staging_certificate_ops.py verify --env "{{ env }}" --namespace "{{ namespace }}" --certificate "{{ certificate }}"
 
 # Apply non-Flux ClusterIssuers with an explicit email (no kustomize vars).
 cert-manager-issuers-apply email:

--- a/scripts/install_staging_cloudflare_token.sh
+++ b/scripts/install_staging_cloudflare_token.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+set +x
+cleanup() { unset token; }
+trap cleanup EXIT INT TERM
+if [ "$(kubectl config current-context)" != "sugar-staging" ]; then
+  printf 'ERROR: current context must be exactly sugar-staging.\n' >&2
+  exit 1
+fi
+printf 'Cloudflare DNS API token (hidden): ' >&2
+IFS= read -r -s token
+printf '\n' >&2
+if [ -z "${token}" ]; then
+  printf 'ERROR: token must not be empty.\n' >&2
+  exit 1
+fi
+printf '%s' "${token}" | kubectl --context sugar-staging -n cert-manager create secret generic cloudflare-api-token \
+  --from-file=api-token=/dev/stdin --dry-run=client -o yaml | \
+  kubectl --context sugar-staging apply -f - >/dev/null
+cleanup
+printf 'Cloudflare token Secret applied in staging.\n'

--- a/scripts/staging_certificate_inventory.json
+++ b/scripts/staging_certificate_inventory.json
@@ -1,0 +1,9 @@
+{
+  "context": "sugar-staging",
+  "issuerSecret": {"namespace": "cert-manager", "name": "cloudflare-api-token", "key": "api-token"},
+  "certificates": [
+    {"namespace": "danielsmith", "name": "danielsmith-staging-tls", "dnsNames": ["staging.danielsmith.io"], "zone": "danielsmith.io"},
+    {"namespace": "jobbot3000", "name": "jobbot3000-staging-tls", "dnsNames": ["staging.jobbot3000.tech"], "zone": "jobbot3000.tech"},
+    {"namespace": "tokenplace", "name": "tokenplace-staging-tls", "dnsNames": ["staging.token.place"], "zone": "token.place"}
+  ]
+}

--- a/scripts/staging_certificate_ops.py
+++ b/scripts/staging_certificate_ops.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Deterministic, redacted, staging-only cert-manager operations."""
+
+import argparse, base64, json, re, subprocess, sys, time
+from pathlib import Path
+
+INV = Path(__file__).with_name("staging_certificate_inventory.json")
+
+
+def run(*argv, stdin=None):
+    return subprocess.run(argv, input=stdin, text=True, check=True, capture_output=True).stdout
+
+
+def sanitize(value):
+    value = str(value or "-")
+    value = re.sub(r"-----BEGIN[\s\S]*?-----END[^-]*-----", "[REDACTED]", value)
+    value = re.sub(r"(?i)authorization\s*[:=]\s*\S+", "Authorization=[REDACTED]", value)
+    value = re.sub(r"https?://\S+", "[REDACTED URL]", value)
+    value = re.sub(r"(?i)\b(private|bearer)\b", "[REDACTED]", value)
+    value = re.sub(r"(?i)(token|secret|api[-_ ]?key)\s*[:=]\s*\S+", r"\1=[REDACTED]", value)
+    value = " ".join(value.split())
+    return value[:180] + ("…" if len(value) > 180 else "")
+
+
+def resources(kind, ns):
+    out = run("kubectl", "--context", "sugar-staging", "-n", ns, "get", kind, "-o", "json")
+    return json.loads(out).get("items", [])
+
+
+def owner(resource, kind):
+    refs = resource.get("metadata", {}).get("ownerReferences", [])
+    return next(
+        (x.get("uid") for x in refs if x.get("kind") == kind and x.get("controller", True)), None
+    )
+
+
+def condition(resource, kind="Ready"):
+    return next(
+        (x for x in resource.get("status", {}).get("conditions", []) if x.get("type") == kind), {}
+    )
+
+
+def secret_keys(ns, name):
+    # Only metadata and key names are emitted; values are never decoded or displayed.
+    fmt = "{.metadata.name}{'|'}{range $k,$v := .data}{$k}{' '}{end}"
+    try:
+        return run(
+            "kubectl",
+            "--context",
+            "sugar-staging",
+            "-n",
+            ns,
+            "get",
+            "secret",
+            name,
+            "-o",
+            "jsonpath=" + fmt,
+        ).strip()
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def state(ns):
+    data = {
+        k: resources(k, ns) for k in ("certificates", "certificaterequests", "orders", "challenges")
+    }
+    data["clusterissuers"] = resources("clusterissuers", ns)
+    return data
+
+
+def render(entry, data, issuer_secret):
+    cert = next(
+        (x for x in data["certificates"] if x.get("metadata", {}).get("name") == entry["name"]),
+        None,
+    )
+    if not cert:
+        return f"Certificate {entry['namespace']}/{entry['name']} MALFORMED_OR_MISSING"
+    m, spec, status = cert.get("metadata", {}), cert.get("spec", {}), cert.get("status", {})
+    ready, issuer = condition(cert), spec.get("issuerRef") or {}
+    lines = [
+        f"Certificate {entry['namespace']}/{entry['name']}",
+        f"  dnsNames: {','.join(sorted(spec.get('dnsNames') or [])) or '-'}",
+        f"  Ready: {ready.get('status','Unknown')} reason={sanitize(ready.get('reason'))}",
+        f"  revision: {status.get('revision','-')} notBefore={status.get('notBefore','-')} notAfter={status.get('notAfter','-')} renewalTime={status.get('renewalTime','-')}",
+        f"  issuerRef: {issuer.get('kind','Issuer')}/{issuer.get('name','-')} expectedSecret: {spec.get('secretName','-')}",
+    ]
+    reqs = sorted(
+        (x for x in data["certificaterequests"] if owner(x, "Certificate") == m.get("uid")),
+        key=lambda x: (
+            x.get("metadata", {}).get("creationTimestamp", ""),
+            x.get("metadata", {}).get("name", ""),
+        ),
+    )
+    req_uids = {x.get("metadata", {}).get("uid") for x in reqs}
+    active_req = {x.get("metadata", {}).get("uid") for x in reqs[-1:]}
+    orders = [x for x in data["orders"] if owner(x, "CertificateRequest") in req_uids]
+    order_uids = {x.get("metadata", {}).get("uid") for x in orders}
+    active_orders = {
+        x.get("metadata", {}).get("uid")
+        for x in orders
+        if owner(x, "CertificateRequest") in active_req
+    }
+    for request in reqs:
+        rc = condition(request)
+        lines.append(
+            f"  CertificateRequest {request.get('metadata',{}).get('name','?')}: Ready={rc.get('status','Unknown')} reason={sanitize(rc.get('reason'))}"
+        )
+    for order in sorted(orders, key=lambda x: x.get("metadata", {}).get("name", "")):
+        os = order.get("status", {})
+        lines.append(
+            f"  Order {order.get('metadata',{}).get('name','?')}: state={os.get('state','pending')} reason={sanitize(os.get('reason'))}"
+        )
+    challenges = [x for x in data["challenges"] if owner(x, "Order") in order_uids]
+    for ch in sorted(challenges, key=lambda x: x.get("metadata", {}).get("name", "")):
+        cs = ch.get("status", {})
+        active = owner(ch, "Order") in active_orders and (
+            cs.get("processing") is True
+            or ("processing" not in cs and cs.get("state") in (None, "", "pending"))
+        )
+        lines.append(
+            f"  Challenge {ch.get('metadata',{}).get('name','?')}: {'ACTIVE' if active else 'STALE'} state={cs.get('state','pending')} reason={sanitize(cs.get('reason'))}"
+        )
+    secret = spec.get("secretName", "")
+    lines.append(
+        f"  TLS Secret: {'present' if secret and secret_keys(entry['namespace'],secret) else 'MISSING'}"
+    )
+    shape = secret_keys(issuer_secret["namespace"], issuer_secret["name"])
+    keys = shape.partition("|")[2].split()
+    issuer_resource = next(
+        (
+            x
+            for x in data.get("clusterissuers", [])
+            if x.get("metadata", {}).get("name") == issuer.get("name")
+        ),
+        None,
+    )
+    refs = []
+    if issuer_resource:
+        for solver in issuer_resource.get("spec", {}).get("acme", {}).get("solvers", []):
+            ref = solver.get("dns01", {}).get("cloudflare", {}).get("apiTokenSecretRef")
+            if ref:
+                refs.append((ref.get("name"), ref.get("key")))
+    configured = (issuer_secret["name"], issuer_secret["key"]) in refs
+    valid = configured and issuer_secret["key"] in keys
+    lines.append(
+        f"  issuer Secret contract: {'valid' if valid else 'MISSING name/key'} ({issuer_secret['namespace']}/{issuer_secret['name']} key={issuer_secret['key']})"
+    )
+    if not issuer_resource:
+        lines.append("  issuer validation: MISSING issuer")
+    return "\n".join(lines)
+
+
+def converged(cert, data, secret_present):
+    if condition(cert).get("status") != "True" or not secret_present:
+        return False
+    reqs = sorted(
+        (
+            x
+            for x in data["certificaterequests"]
+            if owner(x, "Certificate") == cert.get("metadata", {}).get("uid")
+        ),
+        key=lambda x: x.get("metadata", {}).get("creationTimestamp", ""),
+    )
+    if not reqs:
+        return True  # cert-manager may already have garbage-collected successful ACME resources.
+    request = reqs[-1]
+    orders = [
+        x
+        for x in data["orders"]
+        if owner(x, "CertificateRequest") == request.get("metadata", {}).get("uid")
+    ]
+    if any(x.get("status", {}).get("state") not in ("valid",) for x in orders):
+        return False
+    order_uids = {x.get("metadata", {}).get("uid") for x in orders}
+    challenges = [x for x in data["challenges"] if owner(x, "Order") in order_uids]
+    for challenge in challenges:
+        status = challenge.get("status", {})
+        if (
+            status.get("state") not in ("valid",)
+            or "found no zones" in str(status.get("reason", "")).lower()
+        ):
+            return False
+    return True
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("command", choices=("status", "wait", "renew", "verify"))
+    p.add_argument("--env", required=True)
+    p.add_argument("--namespace", required=True)
+    p.add_argument("--certificate", required=True)
+    p.add_argument("--timeout", type=int, default=300)
+    a = p.parse_args()
+    inv = json.loads(INV.read_text())
+    if a.env != "staging":
+        p.error("only env=staging is permitted")
+    if run("kubectl", "config", "current-context").strip() != inv["context"]:
+        p.error("current context must be exactly sugar-staging")
+    matches = [
+        x
+        for x in inv["certificates"]
+        if x["namespace"] == a.namespace and x["name"] == a.certificate
+    ]
+    if len(matches) != 1:
+        p.error("target exactly one certificate from the staging inventory")
+    if not 1 <= a.timeout <= 900:
+        p.error("timeout must be between 1 and 900 seconds")
+    entry = matches[0]
+    if a.command == "status":
+        print(render(entry, state(a.namespace), inv["issuerSecret"]))
+        return
+    if a.command == "verify":
+        encoded = run(
+            "kubectl",
+            "--context",
+            inv["context"],
+            "-n",
+            a.namespace,
+            "get",
+            "secret",
+            a.certificate,
+            "-o",
+            "jsonpath={.data.tls\\.crt}",
+        )
+        pem = base64.b64decode(encoded, validate=True).decode()
+        print(
+            run(
+                "openssl",
+                "x509",
+                "-noout",
+                "-subject",
+                "-issuer",
+                "-serial",
+                "-dates",
+                "-ext",
+                "subjectAltName",
+                stdin=pem,
+            ),
+            end="",
+        )
+        return
+    deadline = time.monotonic() + a.timeout
+    while True:
+        current = state(a.namespace)
+        print(render(entry, current, inv["issuerSecret"]), flush=True)
+        cert = next(
+            (
+                x
+                for x in current["certificates"]
+                if x.get("metadata", {}).get("name") == a.certificate
+            ),
+            {},
+        )
+        if converged(cert, current, secret_keys(a.namespace, a.certificate)):
+            return
+        if time.monotonic() >= deadline:
+            if a.command == "renew":
+                run(
+                    "cmctl",
+                    "renew",
+                    "--context",
+                    inv["context"],
+                    "--namespace",
+                    a.namespace,
+                    a.certificate,
+                )
+                print(
+                    f"Existing Challenges did not converge; targeted renewal requested for {a.namespace}/{a.certificate}"
+                )
+                return
+            raise SystemExit("bounded wait expired; stop before considering one targeted renewal")
+        time.sleep(min(15, max(0, deadline - time.monotonic())))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_staging_certificate_ops.py
+++ b/tests/test_staging_certificate_ops.py
@@ -1,0 +1,182 @@
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+spec = importlib.util.spec_from_file_location(
+    "certops", ROOT / "scripts/staging_certificate_ops.py"
+)
+ops = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ops)
+ENTRY = {
+    "namespace": "app",
+    "name": "app-staging-tls",
+    "dnsNames": ["staging.example.test"],
+    "zone": "example.test",
+}
+ISSUER = {"namespace": "cert-manager", "name": "cloudflare-api-token", "key": "api-token"}
+
+
+def resource(
+    kind, name, uid, owner_kind=None, owner_uid=None, status=None, created="2026-01-01T00:00:00Z"
+):
+    m = {"name": name, "uid": uid, "creationTimestamp": created}
+    if owner_kind:
+        m["ownerReferences"] = [{"kind": owner_kind, "uid": owner_uid, "controller": True}]
+    return {"kind": kind, "metadata": m, "status": status or {}}
+
+
+def fixture(active=True, healthy=False, malformed=False, stale=False):
+    cert = resource("Certificate", "app-staging-tls", "cert")
+    cert["spec"] = {
+        "dnsNames": ["staging.example.test"],
+        "secretName": "app-staging-tls",
+        "issuerRef": {"kind": "ClusterIssuer", "name": "letsencrypt-production"},
+    }
+    cert["status"] = (
+        {"revision": 1}
+        if healthy
+        else {"conditions": [{"type": "Ready", "status": "False", "reason": "DoesNotExist"}]}
+    )
+    req = resource("CertificateRequest", "req", "req", "Certificate", "cert")
+    order = resource("Order", "order", "order", "CertificateRequest", "req")
+    reason = "Found no Zones https://evil.invalid/?token=SUPERSECRET Authorization: Bearer PRIVATE -----BEGIN PRIVATE KEY----- bad -----END PRIVATE KEY-----"
+    ch = resource(
+        "Challenge",
+        "challenge",
+        "ch",
+        "Order",
+        "order",
+        {"state": "pending", "processing": active, "reason": reason},
+    )
+    issuer = {
+        "metadata": {"name": "letsencrypt-production"},
+        "spec": {
+            "acme": {
+                "solvers": [
+                    {
+                        "dns01": {
+                            "cloudflare": {
+                                "apiTokenSecretRef": {
+                                    "name": "cloudflare-api-token",
+                                    "key": "api-token",
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+    }
+    data = {
+        "certificates": [cert],
+        "certificaterequests": [req],
+        "orders": [order],
+        "challenges": [ch],
+        "clusterissuers": [issuer],
+    }
+    if malformed:
+        data["certificates"] = []
+    if stale:
+        ch["status"]["processing"] = False
+    return data
+
+
+def test_active_failure_is_owned_redacted_and_deterministic(monkeypatch):
+    monkeypatch.setattr(
+        ops,
+        "secret_keys",
+        lambda ns, name: "cloudflare-api-token|api-token" if ns == "cert-manager" else "",
+    )
+    out = ops.render(ENTRY, fixture(), ISSUER)
+    assert out == ops.render(ENTRY, fixture(), ISSUER)
+    assert "Challenge challenge: ACTIVE" in out and "TLS Secret: MISSING" in out
+    for leaked in ("SUPERSECRET", "PRIVATE", "evil.invalid", "BEGIN PRIVATE KEY"):
+        assert leaked not in out
+    assert len(next(x for x in out.splitlines() if "reason=" in x)) < 240
+
+
+def test_stale_healthy_missing_and_malformed(monkeypatch):
+    monkeypatch.setattr(ops, "secret_keys", lambda *_: "name|tls.crt tls.key api-token")
+    assert "STALE" in ops.render(ENTRY, fixture(stale=True), ISSUER)
+    assert "TLS Secret: present" in ops.render(ENTRY, fixture(healthy=True), ISSUER)
+    assert "MALFORMED_OR_MISSING" in ops.render(ENTRY, fixture(malformed=True), ISSUER)
+
+
+def test_missing_issuer_and_key(monkeypatch):
+    data = fixture()
+    data["certificates"][0]["spec"]["issuerRef"] = {"kind": "ClusterIssuer"}
+    monkeypatch.setattr(ops, "secret_keys", lambda *_: "")
+    out = ops.render(ENTRY, data, ISSUER)
+    assert "MISSING issuer" in out and "MISSING name/key" in out
+
+
+def test_inventory_multiple_apps_and_preserves_working_zone():
+    inv = json.loads((ROOT / "scripts/staging_certificate_inventory.json").read_text())
+    assert len(inv["certificates"]) == 3
+    assert {x["zone"] for x in inv["certificates"]} == {
+        "token.place",
+        "danielsmith.io",
+        "jobbot3000.tech",
+    }
+
+
+def test_installer_and_workflow_are_secret_safe_and_nondestructive():
+    installer = (ROOT / "scripts/install_staging_cloudflare_token.sh").read_text()
+    program = (ROOT / "scripts/staging_certificate_ops.py").read_text()
+    assert "read -r -s token" in installer and "set +x" in installer
+    assert "--from-file=api-token=/dev/stdin" in installer and "unset token" in installer
+    assert "from-literal" not in installer and "mktemp" not in installer
+    assert 'a.command == "renew"' in program and program.index(
+        'a.command == "renew"'
+    ) > program.index("deadline = time.monotonic")
+    assert '"cmctl"' in program and '"renew"' in program
+    for destructive in ("kubectl delete", "delete certificate", "delete order", "delete challenge"):
+        assert destructive not in program.lower()
+    assert "tls\\\\.key" not in program and ".data.tls\\\\.crt" in program
+
+
+def test_rejects_wrong_environment_before_cluster_access(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "ops",
+            "status",
+            "--env",
+            "prod",
+            "--namespace",
+            "app",
+            "--certificate",
+            "app-staging-tls",
+        ],
+    )
+    try:
+        ops.main()
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("non-staging accepted")
+
+
+def test_wrong_context_rejected(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "ops",
+            "status",
+            "--env",
+            "staging",
+            "--namespace",
+            "app",
+            "--certificate",
+            "app-staging-tls",
+        ],
+    )
+    monkeypatch.setattr(ops, "run", lambda *a, **k: "production\n")
+    try:
+        ops.main()
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("wrong context accepted")


### PR DESCRIPTION
### Motivation
- Provide a safe, app-agnostic, staging-only operator path to inspect and repair DNS-01 failures reported by cert-manager without reading or exposing Secrets or private keys.
- Replace unsafe token-in-argv/environment recipes with a secret-safe interactive installer and document the least-privilege Cloudflare token contract and an ordered, one-certificate-at-a-time repair runbook.
- Make diagnosis deterministic, redacted, and ownership-aware so active vs stale ACME resources are classified consistently.

### Description
- Added a declarative, app-agnostic staging inventory `scripts/staging_certificate_inventory.json` listing the three intentional shared zones and the ClusterIssuer secret contract.
- Implemented `scripts/staging_certificate_ops.py`, a deterministic, redacted tool that reports Certificate status, correlates CertificateRequests→Orders→Challenges by ownership, classifies `ACTIVE` vs `STALE` challenges, validates the ClusterIssuer secret/key name (without decoding values), reports TLS secret presence (without exposing `tls.key`), provides a bounded `wait` that observes existing Challenges before requesting a renewal, supports a targeted `cmctl renew`, and verifies only `tls.crt` using `openssl`.
- Added a secret-safe interactive installer `scripts/install_staging_cloudflare_token.sh` that requires exact `sugar-staging` context, uses hidden `read -r -s`, disables tracing, pipes the token via stdin to `kubectl --from-file=api-token=/dev/stdin`, and unsets the variable on exit/interrupt.
- Exposed `just` recipes in `justfile`: `cert-manager-cloudflare-token-secret env=staging`, `cert-status`, `cert-wait`, `cert-renew` (timeoutable), and `cert-verify`, all requiring `env=staging` and a single explicit inventory target.
- Added `docs/staging-certificates.md` documenting the token contract, the secret-safe installer, the ordered single-certificate repair runbook, and the distinction between Kubernetes/origin TLS and Cloudflare edge TLS; updated `docs/runbook.md` to point operators to the redacted workflow.
- Added deterministic offline tests `tests/test_staging_certificate_ops.py` covering healthy, active/stale failures, malformed/missing resources, inventory integrity, redaction (no token/key leakage), staging/context guards, and non-destructive behavior.

### Testing
- Unit tests: `python3 -m pytest -q tests/test_staging_certificate_ops.py` — 7 passed.
- Full test run: `python3 -m pytest -q` — passed in this environment.
- Shell checks: `bash -n scripts/*.sh` — no syntax errors.
- Justfile formatting/check: `just --unstable --fmt --check` — passed.
- Repository checks: `bash scripts/checks.sh` — executed (environment tools vary); core checks passed where available.
- Documentation link check: `linkchecker --no-warnings README.md docs/` — 206 links checked, 0 errors.
- Secret scan / diffs: `git diff | ./scripts/scan-secrets.py` — completed; the scanner emitted a heuristic warning about documentation wording only and no credential/private-key material was present.
- Sensitive pattern search: `rg -n 'cloudflare-api-token|CLOUDFLARE_API_TOKEN|from-literal|token=|cmctl renew|Found no Zones|tls\.key' scripts tests docs justfile clusters` — results reviewed and are legitimate (guarded references, inventory, tests, docs); no unsafe new occurrences that expose token values were introduced.

Environment notes and limitations
- `shellcheck`, `aspell` (used by `pyspelling`), and `pre-commit` were not available in the execution environment so those specific checks were not run here; the code was written to pass them where feasible and `bash -n` plus unit tests passed.

Files changed (high level)
- Added: `scripts/staging_certificate_ops.py`, `scripts/staging_certificate_inventory.json`, `scripts/install_staging_cloudflare_token.sh`, `docs/staging-certificates.md`, `tests/test_staging_certificate_ops.py`.
- Modified: `justfile`, `docs/runbook.md`.

Operator post-merge checklist (executions to perform on the live staging cluster)
1. Capture a redacted baseline: `just cert-status namespace=danielsmith certificate=danielsmith-staging-tls env=staging`.
2. Confirm Cloudflare token permissions and explicit zones (danielsmith.io, jobbot3000.tech, token.place) manually in the Cloudflare dashboard.
3. If the token value changed, run the hidden installer: `just cert-manager-cloudflare-token-secret env=staging` (follow prompts).
4. Observe existing Challenges with `just cert-wait ...` (bounded) to allow convergence; do not create new Orders automatically.
5. If needed after the bounded wait, request one targeted renewal: `just cert-renew namespace=danielsmith certificate=danielsmith-staging-tls timeout=300 env=staging`.
6. Verify `Ready=True`, TLS Secret present, current Order/Challenge completed and absence of new `Found no Zones`, then run `just cert-verify ...` to inspect `tls.crt` only.
7. Repeat for `jobbot3000` only after Danielsmith is fully verified.

If you want, I can open the PR with this title/body or split the changes into smaller follow-ups; otherwise the repo is ready for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ac029d2f8832f9aee843486758533)