### PR TITLE
Repair staging DNS-01 certificate operations safely

### DIFF
--- a/clusters/staging/certificates.json
+++ b/clusters/staging/certificates.json
@@ -1,0 +1,39 @@
+{
+  "context": "sugar-staging",
+  "issuerSecret": {
+    "namespace": "cert-manager",
+    "name": "cloudflare-api-token",
+    "key": "api-token"
+  },
+  "zones": [
+    "danielsmith.io",
+    "jobbot3000.tech",
+    "token.place"
+  ],
+  "certificates": [
+    {
+      "namespace": "danielsmith",
+      "name": "danielsmith-staging-tls",
+      "dnsNames": [
+        "staging.danielsmith.io"
+      ],
+      "secretName": "danielsmith-staging-tls"
+    },
+    {
+      "namespace": "jobbot3000",
+      "name": "jobbot3000-staging-tls",
+      "dnsNames": [
+        "staging.jobbot3000.tech"
+      ],
+      "secretName": "jobbot3000-staging-tls"
+    },
+    {
+      "namespace": "tokenplace",
+      "name": "tokenplace-staging-tls",
+      "dnsNames": [
+        "staging.token.place"
+      ],
+      "secretName": "tokenplace-staging-tls"
+    }
+  ]
+}

--- a/docs/apps/jobbot3000.md
+++ b/docs/apps/jobbot3000.md
@@ -180,11 +180,13 @@ kubectl --context sugar-staging get svc,endpoints -n jobbot3000
 kubectl --context sugar-staging logs -n kube-system -l app.kubernetes.io/name=traefik --tail=200
 ```
 
+Use the bounded, redacted status and recovery procedure in [Staging certificate
+operations](../staging-certificate-operations.md). Do not describe raw ACME
+resources or dump controller logs when diagnosing authorization failures.
+
 ```bash
-# Confirm cert-manager issued the staging certificate.
-kubectl --context sugar-staging get certificate,challenge,order -n jobbot3000
-kubectl --context sugar-staging describe certificate -n jobbot3000 jobbot3000-staging-tls
-kubectl --context sugar-staging logs -n cert-manager deploy/cert-manager --tail=200
+just staging-certificate-status env=staging
+just staging-certificate-wait namespace=jobbot3000 certificate=jobbot3000-staging-tls timeout=300 env=staging
 ```
 
 ```bash

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -233,7 +233,8 @@ Common failure modes:
 - **Missing cert-manager CRDs** (`no matches for kind "Certificate"` / `"ClusterIssuer"`): reinstall cert-manager with CRDs enabled.
 - **`clusterissuer.cert-manager.io` resource type missing**: controllers/CRDs are not fully installed yet.
 - **Literal `$(CERT_MANAGER_EMAIL)` in ClusterIssuer**: issuer was applied from Flux-era template without replacement; reapply with `just cert-manager-issuers-apply email=<email>`.
-- **Missing `cloudflare-api-token` secret**: create it with `just cert-manager-cloudflare-token-secret token=<token>`.
+- **Missing `cloudflare-api-token` secret**: follow the hidden-input staging workflow
+  in [Staging certificate operations](staging-certificate-operations.md).
 - **Challenge cleanup errors after successful issuance**: Cloudflare API token is missing `Zone:Read` and/or is scoped to the wrong zone.
 
 Validation sequence:

--- a/docs/staging-certificate-operations.md
+++ b/docs/staging-certificate-operations.md
@@ -1,0 +1,76 @@
+# Staging certificate operations
+
+These operations are staging-only, app-agnostic, bounded, and intentionally do not
+change Ingress TLS or Cloudflare Tunnel transport. The declarative inventory in
+`clusters/staging/certificates.json` is derived from the staging values owned by each
+application. Its complete shared-token zone set is currently `danielsmith.io`,
+`jobbot3000.tech`, and `token.place`.
+
+## Shared-token contract
+
+The token referenced by `cert-manager/cloudflare-api-token` needs **Zone - Zone -
+Read** and **Zone - DNS - Edit**, with resource access explicitly limited to every
+zone in that inventory. Do not select all zones. A present Secret and Ready issuer
+cannot prove dashboard permissions; an operator must confirm them in Cloudflare or
+observe successful DNS-01 presentation.
+
+Editing the existing token's permissions or resource scope in place requires no
+Kubernetes Secret update. If the value is replaced, preserve all three zones,
+especially the working `token.place`, then run `just
+cert-manager-cloudflare-token-secret env=staging`. The prompt is hidden; the value
+travels only over stdin, is never placed in argv, a file, rendered values, output,
+or logs, and is unset on exit or interruption. Never export the old value from
+Kubernetes.
+
+## One certificate at a time
+
+ACME retries and manual renewals can consume rate limits. Perform these checkpoints,
+starting with Danielsmith and proceeding to Jobbot3000 only after it passes:
+
+1. Capture a redacted baseline with `just staging-certificate-status env=staging`.
+   It correlates the newest CertificateRequest, its Orders, and their Challenges by
+   owner UID. Challenges on that chain are **active**; older owned chains are
+   **stale**. Reasons are length-bounded and scrubbed of URLs, query strings,
+   authorization values, token-like values, and key material.
+2. In Cloudflare, manually confirm both permissions and the exact three-zone list.
+   Update the Secret only if the token value changed.
+3. Give existing Challenges five minutes to converge without creating another
+   Order: `just staging-certificate-wait namespace=danielsmith
+   certificate=danielsmith-staging-tls timeout=300 env=staging`.
+4. Only if that bounded wait fails and a retry is justified, run `just
+   staging-certificate-renew namespace=danielsmith
+   certificate=danielsmith-staging-tls timeout=300 env=staging`. This observes the
+   existing chain first, then invokes `cmctl renew` for that exact Certificate and
+   waits for bounded, redacted status. Never delete a Certificate,
+   CertificateRequest, Order, Challenge, or serving Secret as normal recovery.
+5. Require `Ready=True`, the expected Secret present, completed Order/Challenge
+   state, and no new `Found no Zones`. Inspect only the public certificate:
+
+   ```bash
+   kubectl --context sugar-staging -n danielsmith get secret danielsmith-staging-tls \
+     -o jsonpath='{.data.tls\.crt}' | base64 -d | \
+     openssl x509 -noout -subject -issuer -serial -dates -ext subjectAltName
+   ```
+
+   Never select, decode, print, compare, or export `tls.key`.
+6. If the topology exposes direct Traefik TLS, connect to that origin with the
+   hostname/SNI and validate it presents this Kubernetes certificate. Separately
+   validate the public Cloudflare edge certificate and routes:
+
+   ```bash
+   openssl s_client -connect staging.danielsmith.io:443 -servername staging.danielsmith.io </dev/null 2>/dev/null | openssl x509 -noout -issuer -serial -dates -ext subjectAltName
+   curl -fsS https://staging.danielsmith.io/
+   curl -fsS https://staging.danielsmith.io/healthz
+   curl -fsS https://staging.danielsmith.io/livez
+   ```
+
+   The HTTP tunnel makes Kubernetes/origin TLS and Cloudflare edge TLS independent
+   layers. Their issuers and serials need not match.
+7. Repeat steps 1–6 for `jobbot3000/jobbot3000-staging-tls` and
+   `staging.jobbot3000.tech`; do not renew them concurrently.
+
+If failures continue, stop retries and re-check the authoritative-zone selection.
+Rollback means stopping issuance attempts and re-entering a prior known-good token
+from the password manager with the interactive installer. It never means extracting
+credentials from the cluster. These are post-merge live operations; offline tests do
+not establish that issuance succeeded.

--- a/justfile
+++ b/justfile
@@ -790,30 +790,21 @@ cert-manager-install version='v1.14.4':
 
     kubectl -n cert-manager wait --for=condition=Available deployment/cert-manager deployment/cert-manager-webhook deployment/cert-manager-cainjector --timeout=300s
 
-# Create/update the Cloudflare DNS API token Secret used by cert-manager DNS-01.
-cert-manager-cloudflare-token-secret token='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
+# Interactively create/update the staging Cloudflare token without argv or files.
+cert-manager-cloudflare-token-secret env='staging':
+    scripts/install_staging_cloudflare_token.sh "{{ env }}"
 
-    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-    token="{{ token }}"
-    : "${token:=${CF_DNS_API_TOKEN:-}}"
-    token="$(printf '%s' "${token}" | tr -d '\r\n' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
-    case "${token}" in
-        token=*|CF_DNS_API_TOKEN=*|CLOUDFLARE_DNS_API_TOKEN=*)
-            token="${token#*=}"
-            token="$(printf '%s' "${token}" | tr -d '\r\n' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
-            ;;
-    esac
-    if [ -z "${token}" ]; then
-        echo "Set CF_DNS_API_TOKEN or pass token=<cloudflare-dns-api-token>." >&2
-        exit 1
-    fi
+# Read-only, deterministic staging certificate inventory and ACME status.
+staging-certificate-status env='staging':
+    python3 scripts/staging_certificate_ops.py status --env "{{ env }}"
 
-    kubectl get namespace cert-manager >/dev/null 2>&1 || kubectl create namespace cert-manager
-    kubectl -n cert-manager create secret generic cloudflare-api-token \
-        --from-literal=api-token="${token}" \
-        --dry-run=client -o yaml | kubectl apply -f -
+# Observe one certificate for a bounded interval; never initiates issuance.
+staging-certificate-wait namespace certificate timeout='300' env='staging':
+    python3 scripts/staging_certificate_ops.py wait --env "{{ env }}" --namespace "{{ namespace }}" --certificate "{{ certificate }}" --timeout "{{ timeout }}"
+
+# Observe existing Challenges first, then renew exactly one certificate if needed.
+staging-certificate-renew namespace certificate timeout='300' env='staging':
+    python3 scripts/staging_certificate_ops.py renew --env "{{ env }}" --namespace "{{ namespace }}" --certificate "{{ certificate }}" --timeout "{{ timeout }}"
 
 # Apply non-Flux ClusterIssuers with an explicit email (no kustomize vars).
 cert-manager-issuers-apply email:

--- a/scripts/install_staging_cloudflare_token.sh
+++ b/scripts/install_staging_cloudflare_token.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+set +x
+token=''
+cleanup() { unset token; }
+trap cleanup EXIT INT TERM
+
+if [[ ${1-} != staging || $(kubectl config current-context) != sugar-staging ]]; then
+  printf 'ERROR: requires env=staging and current context sugar-staging.\n' >&2
+  exit 2
+fi
+printf 'Cloudflare API token: ' >&2
+IFS= read -r -s token
+printf '\n' >&2
+if [[ -z $token ]]; then
+  printf 'ERROR: token must not be empty.\n' >&2
+  exit 2
+fi
+if ! printf '%s' "$token" | kubectl --context sugar-staging -n cert-manager create secret generic cloudflare-api-token \
+  --from-file=api-token=/dev/stdin --dry-run=client -o yaml | kubectl --context sugar-staging apply -f - >/dev/null; then
+  printf 'ERROR: Secret update failed.\n' >&2
+  exit 1
+fi
+unset token
+printf 'Updated cert-manager/cloudflare-api-token.\n'

--- a/scripts/staging_certificate_ops.py
+++ b/scripts/staging_certificate_ops.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Bounded, redacted and staging-only cert-manager operations."""
+
+import argparse
+import json
+import re
+import subprocess
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_INVENTORY = ROOT / "clusters/staging/certificates.json"
+REDACTIONS = (
+    (re.compile(r"(?i)authorization\s*[:=]\s*(?:bearer\s+)?\S+"), "authorization=[REDACTED]"),
+    (re.compile(r"(?i)(token|api[_-]?key|secret)\s*[:=]\s*\S+"), r"\1=[REDACTED]"),
+    (re.compile(r"https?://\S+"), "[URL REDACTED]"),
+    (re.compile(r"-----BEGIN [^-]*(?:PRIVATE )?KEY-----.*", re.S), "[KEY MATERIAL REDACTED]"),
+)
+
+
+def sanitize(value, limit=240):
+    text = " ".join(str(value or "-").split())
+    for pattern, replacement in REDACTIONS:
+        text = pattern.sub(replacement, text)
+    return text[:limit] + ("…" if len(text) > limit else "")
+
+
+def run_json(context, args):
+    proc = subprocess.run(
+        ["kubectl", "--context", context, *args, "-o", "json"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode:
+        raise RuntimeError(sanitize(proc.stderr))
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("kubectl returned malformed JSON") from exc
+
+
+def condition(resource, kind="Ready"):
+    for item in resource.get("status", {}).get("conditions", []):
+        if item.get("type") == kind:
+            return item.get("status", "Unknown"), sanitize(item.get("reason", "-"))
+    return "Unknown", "-"
+
+
+def owner_uid(resource, kind):
+    for owner in resource.get("metadata", {}).get("ownerReferences", []):
+        if owner.get("kind") == kind:
+            return owner.get("uid")
+    return None
+
+
+def items_by_owner(items, kind, uid):
+    return [item for item in items if owner_uid(item, kind) == uid]
+
+
+def collect(inventory):
+    context = inventory["context"]
+    certs = run_json(context, ["get", "certificates", "--all-namespaces"]).get("items", [])
+    requests = run_json(context, ["get", "certificaterequests", "--all-namespaces"]).get(
+        "items", []
+    )
+    orders = run_json(context, ["get", "orders.acme.cert-manager.io", "--all-namespaces"]).get(
+        "items", []
+    )
+    challenges = run_json(
+        context, ["get", "challenges.acme.cert-manager.io", "--all-namespaces"]
+    ).get("items", [])
+    # Metadata only: never retrieve Secret data or YAML.
+    secret_names = set()
+    for entry in inventory["certificates"]:
+        expected_secret = entry.get("secretName", entry["name"])
+        proc = subprocess.run(
+            [
+                "kubectl",
+                "--context",
+                context,
+                "get",
+                "secret",
+                "-n",
+                entry["namespace"],
+                expected_secret,
+                "-o",
+                "name",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if proc.returncode == 0:
+            secret_names.add((entry["namespace"], expected_secret))
+    issuer_cfg = inventory["issuerSecret"]
+    issuer = run_json(context, ["get", "clusterissuers.cert-manager.io"])
+    key_proc = subprocess.run(
+        [
+            "kubectl",
+            "--context",
+            context,
+            "get",
+            "secret",
+            "-n",
+            issuer_cfg["namespace"],
+            issuer_cfg["name"],
+            "-o",
+            'go-template={{range $k, $_ := .data}}{{$k}}{{"\\n"}}{{end}}',
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    keys = sorted(key_proc.stdout.splitlines()) if key_proc.returncode == 0 else []
+    expected = {(x["namespace"], x["name"]): x for x in inventory["certificates"]}
+    actual = {
+        (x.get("metadata", {}).get("namespace"), x.get("metadata", {}).get("name")): x
+        for x in certs
+    }
+    issuer_secret_state = "yes" if issuer_cfg["key"] in keys else "no"
+    lines = [
+        f"context: {context}",
+        f"issuer-secret: {issuer_cfg['namespace']}/{issuer_cfg['name']} "
+        f"key={issuer_cfg['key']} present={issuer_secret_state}",
+    ]
+    issuer_names = {x.get("metadata", {}).get("name") for x in issuer.get("items", [])}
+    ok = issuer_cfg["key"] in keys
+    for key in sorted(expected):
+        wanted, cert = expected[key], actual.get(key)
+        lines.append(f"certificate: {key[0]}/{key[1]}")
+        if not cert:
+            lines.append("  malformed: certificate missing")
+            ok = False
+            continue
+        spec, status = cert.get("spec", {}), cert.get("status", {})
+        ready, reason = condition(cert)
+        issuer_ref = spec.get("issuerRef", {})
+        issuer_name = issuer_ref.get("name", "-")
+        secret_name = spec.get("secretName", "-")
+        dns = sorted(spec.get("dnsNames", []))
+        issuer_state = "yes" if issuer_name in issuer_names else "no"
+        secret_state = "yes" if (key[0], secret_name) in secret_names else "no"
+        lines.extend(
+            [
+                f"  dnsNames: {','.join(dns) or '-'}",
+                f"  ready: {ready} reason={reason}",
+                f"  revision: {status.get('revision', '-')}",
+                f"  notBefore: {status.get('notBefore', '-')}",
+                f"  notAfter: {status.get('notAfter', '-')}",
+                f"  renewalTime: {status.get('renewalTime', '-')}",
+                f"  issuer: {issuer_ref.get('kind', 'Issuer')}/{issuer_name} "
+                f"present={issuer_state}",
+                f"  secret: {key[0]}/{secret_name} present={secret_state}",
+            ]
+        )
+        cert_uid = cert.get("metadata", {}).get("uid")
+        owned_requests = items_by_owner(requests, "Certificate", cert_uid)
+        active_request = max(
+            owned_requests,
+            key=lambda x: (
+                x.get("metadata", {}).get("creationTimestamp", ""),
+                x.get("metadata", {}).get("name", ""),
+            ),
+            default=None,
+        )
+        active_order_uids = set()
+        if active_request:
+            active_order_uids = {
+                x.get("metadata", {}).get("uid")
+                for x in items_by_owner(
+                    orders, "CertificateRequest", active_request.get("metadata", {}).get("uid")
+                )
+            }
+        request_uids = {x.get("metadata", {}).get("uid") for x in owned_requests}
+        cert_orders = [x for x in orders if owner_uid(x, "CertificateRequest") in request_uids]
+        owned_challenges = [
+            x
+            for x in challenges
+            if owner_uid(x, "Order") in {o.get("metadata", {}).get("uid") for o in cert_orders}
+        ]
+        for challenge in sorted(
+            owned_challenges, key=lambda x: x.get("metadata", {}).get("name", "")
+        ):
+            active = owner_uid(challenge, "Order") in active_order_uids
+            state = challenge.get("status", {}).get("state", "pending")
+            reason_text = sanitize(challenge.get("status", {}).get("reason", "-"))
+            classification = "active" if active else "stale"
+            challenge_name = challenge.get("metadata", {}).get("name", "-")
+            lines.append(
+                f"  challenge: {challenge_name} classification={classification} "
+                f"state={state} reason={reason_text}"
+            )
+        ok = (
+            ok
+            and ready == "True"
+            and (key[0], secret_name) in secret_names
+            and issuer_name in issuer_names
+            and dns == sorted(wanted["dnsNames"])
+        )
+    return "\n".join(lines) + "\n", ok
+
+
+def load_and_guard(args):
+    if args.env != "staging":
+        raise SystemExit("ERROR: env must be staging")
+    inventory = json.loads(Path(args.inventory).read_text())
+    current = subprocess.run(
+        ["kubectl", "config", "current-context"], text=True, capture_output=True, check=False
+    )
+    if current.returncode or current.stdout.strip() != inventory["context"]:
+        raise SystemExit(f"ERROR: current Kubernetes context must be {inventory['context']}")
+    return inventory
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("status", "wait", "renew"))
+    parser.add_argument("--env", required=True)
+    parser.add_argument("--inventory", default=str(DEFAULT_INVENTORY))
+    parser.add_argument("--namespace")
+    parser.add_argument("--certificate")
+    parser.add_argument("--timeout", type=int, default=300)
+    args = parser.parse_args()
+    inventory = load_and_guard(args)
+    if args.command == "status":
+        print(collect(inventory)[0], end="")
+        return
+    matches = [
+        x
+        for x in inventory["certificates"]
+        if x["namespace"] == args.namespace and x["name"] == args.certificate
+    ]
+    if len(matches) != 1:
+        raise SystemExit("ERROR: select exactly one inventoried --namespace and --certificate")
+    deadline = time.monotonic() + max(1, min(args.timeout, 900))
+    inventory = {**inventory, "certificates": matches}
+    # Observe existing resources before renewal; renewal is never automatic.
+    output, healthy = collect(inventory)
+    print(output, end="")
+    if args.command == "renew":
+        while not healthy and time.monotonic() < deadline:
+            time.sleep(min(15, max(0, deadline - time.monotonic())))
+            output, healthy = collect(inventory)
+            print(output, end="")
+        if healthy:
+            return
+        subprocess.run(
+            [
+                "cmctl",
+                "renew",
+                "--context",
+                inventory["context"],
+                "-n",
+                args.namespace,
+                args.certificate,
+            ],
+            check=True,
+        )
+    while time.monotonic() < deadline:
+        output, healthy = collect(inventory)
+        print(output, end="")
+        if healthy:
+            return
+        time.sleep(min(15, max(0, deadline - time.monotonic())))
+    raise SystemExit("ERROR: bounded certificate wait expired")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -3060,9 +3060,9 @@ def test_jobbot3000_runbook_troubleshooting_pins_staging_context() -> None:
     assert "kubectl --context sugar-staging describe ingress" in runbook
     assert "kubectl --context sugar-staging get svc,endpoints" in runbook
     assert "kubectl --context sugar-staging logs -n kube-system" in runbook
-    assert "kubectl --context sugar-staging get certificate,challenge,order" in runbook
-    assert "kubectl --context sugar-staging describe certificate" in runbook
-    assert "kubectl --context sugar-staging logs -n cert-manager" in runbook
+    assert "just staging-certificate-status env=staging" in runbook
+    assert "just staging-certificate-wait namespace=jobbot3000" in runbook
+    assert "kubectl --context sugar-staging get certificate,challenge,order" not in runbook
     assert "helm --kube-context sugar-staging -n jobbot3000 get values jobbot3000" in runbook
     assert "helm --kube-context sugar-staging -n jobbot3000 status jobbot3000" in runbook
     assert "kubectl --context sugar-staging get deploy" in runbook

--- a/tests/test_staging_certificate_ops.py
+++ b/tests/test_staging_certificate_ops.py
@@ -1,0 +1,145 @@
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / "scripts/staging_certificate_ops.py"
+spec = importlib.util.spec_from_file_location("certificate_ops", SCRIPT)
+ops = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ops)
+
+
+def resource(
+    kind,
+    name,
+    namespace="app",
+    uid=None,
+    owner=None,
+    status=None,
+    spec=None,
+    created="2026-01-01T00:00:00Z",
+):
+    metadata = {
+        "name": name,
+        "namespace": namespace,
+        "uid": uid or name,
+        "creationTimestamp": created,
+    }
+    if owner:
+        metadata["ownerReferences"] = [{"kind": owner[0], "uid": owner[1]}]
+    return {"kind": kind, "metadata": metadata, "status": status or {}, "spec": spec or {}}
+
+
+def test_sanitize_is_bounded_and_removes_hostile_material():
+    hostile = (
+        "Authorization: Bearer abc token=supersecret https://acme.test/path?q=secret "
+        "-----BEGIN PRIVATE KEY----- xyz"
+    )
+    value = ops.sanitize(hostile)
+    assert len(value) <= 241
+    for forbidden in ("abc", "supersecret", "acme.test", "PRIVATE KEY", "?q="):
+        assert forbidden not in value
+
+
+def test_owner_correlation_active_and_stale(monkeypatch):
+    cert = resource(
+        "Certificate",
+        "app-tls",
+        uid="cert",
+        spec={
+            "dnsNames": ["staging.example.test"],
+            "secretName": "app-tls",
+            "issuerRef": {"kind": "ClusterIssuer", "name": "issuer"},
+        },
+        status={"conditions": [{"type": "Ready", "status": "False", "reason": "DoesNotExist"}]},
+    )
+    old = resource(
+        "CertificateRequest",
+        "opaque-old",
+        uid="old",
+        owner=("Certificate", "cert"),
+        created="2025-01-01T00:00:00Z",
+    )
+    new = resource(
+        "CertificateRequest",
+        "opaque-new",
+        uid="new",
+        owner=("Certificate", "cert"),
+        created="2026-01-01T00:00:00Z",
+    )
+    order_old = resource("Order", "random-a", uid="oa", owner=("CertificateRequest", "old"))
+    order_new = resource("Order", "random-b", uid="ob", owner=("CertificateRequest", "new"))
+    stale = resource(
+        "Challenge",
+        "unrelated-name-1",
+        owner=("Order", "oa"),
+        status={"state": "invalid", "reason": "Found no Zones"},
+    )
+    active = resource(
+        "Challenge",
+        "unrelated-name-2",
+        owner=("Order", "ob"),
+        status={"state": "pending", "reason": "Found no Zones"},
+    )
+    responses = {
+        "certificates": [cert],
+        "certificaterequests": [old, new],
+        "orders.acme.cert-manager.io": [order_old, order_new],
+        "challenges.acme.cert-manager.io": [stale, active],
+        "clusterissuers.cert-manager.io": [resource("ClusterIssuer", "issuer")],
+    }
+    monkeypatch.setattr(ops, "run_json", lambda context, args: {"items": responses[args[1]]})
+    monkeypatch.setattr(
+        ops.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(
+            a, 0, "api-token\n" if "go-template" in " ".join(a[0]) else "secret/app-tls\n", ""
+        ),
+    )
+    inv = {
+        "context": "sugar-staging",
+        "issuerSecret": {
+            "namespace": "cert-manager",
+            "name": "cloudflare-api-token",
+            "key": "api-token",
+        },
+        "certificates": [
+            {"namespace": "app", "name": "app-tls", "dnsNames": ["staging.example.test"]}
+        ],
+    }
+    output, healthy = ops.collect(inv)
+    assert not healthy
+    assert "unrelated-name-1 classification=stale" in output
+    assert "unrelated-name-2 classification=active" in output
+    assert output == ops.collect(inv)[0]
+
+
+def test_inventory_has_all_shared_zones_and_multiple_apps():
+    inventory = json.loads((ROOT / "clusters/staging/certificates.json").read_text())
+    assert inventory["zones"] == ["danielsmith.io", "jobbot3000.tech", "token.place"]
+    assert len(inventory["certificates"]) == 3
+
+
+def test_staging_guards_and_secret_installer_contract():
+    source = SCRIPT.read_text()
+    shell = (ROOT / "scripts/install_staging_cloudflare_token.sh").read_text()
+    just = (ROOT / "justfile").read_text()
+    assert 'args.env != "staging"' in source
+    assert "current-context" in source and "select exactly one" in source
+    assert "time.monotonic()" in source and "min(args.timeout, 900)" in source
+    assert source.index("collect(inventory)") < source.index('"cmctl",')
+    assert "read -r -s token" in shell
+    assert "--from-file=api-token=/dev/stdin" in shell
+    assert "trap cleanup EXIT INT TERM" in shell and "set +x" in shell
+    assert "delete certificate" not in (source + shell + just).lower()
+    assert "--from-literal=api-token" not in just
+
+
+def test_docs_keep_certificate_layers_separate_and_no_legacy_token_argument():
+    docs = (ROOT / "docs/staging-certificate-operations.md").read_text()
+    runbook = (ROOT / "docs/runbook.md").read_text()
+    assert "token.place" in docs and "independent" in docs
+    assert "Their issuers and serials need not match" in docs
+    assert "token=<token>" not in runbook
+    assert "tls.key" in docs and "Never select" in docs


### PR DESCRIPTION
### Motivation

- Repair the staging cert-manager Cloudflare DNS-01 authorization workflow observed failing for Danielsmith and Jobbot3000 without changing Ingress TLS, Cloudflare Tunnel transport, production, or live cluster state. 
- Provide an app-agnostic, read-only, redacted status and a guarded secret-safe installer so operators can verify and repair certificates without exposing tokens or private keys. 
- Ensure issuance/renewal work is bounded, single-certificate at a time, ownership-correlated, and preserves the working `token.place` shared zone.

### Description

- Added a declarative staging inventory `clusters/staging/certificates.json` that lists `context`, `issuerSecret`, explicit `zones` (currently `danielsmith.io`, `jobbot3000.tech`, `token.place`) and the three staging Certificates and expected Secret names. 
- Implemented `scripts/staging_certificate_ops.py` to provide deterministic, redacted `status`, bounded `wait`, and single-target `renew` behavior that: uses owner-UID correlation for CertificateRequest/Order/Challenge linkage, classifies active vs stale challenges, sanitizes reasons/diagnostics, validates ClusterIssuer Secret key names without emitting values, and never reads/prints `tls.key`. 
- Added a secret-safe interactive installer `scripts/install_staging_cloudflare_token.sh` and replaced the prior `just` recipe to call it; the installer requires `env=staging` and `current-context=sugar-staging`, uses `read -r -s` to hide input, disables shell tracing, pipes the token via stdin into `kubectl create secret ... --from-file=api-token=/dev/stdin --dry-run=client -o yaml | kubectl apply -f -`, unsets the token on exit/interruption, and emits only a bounded confirmation. 
- Exposed `just` recipes: `staging-certificate-status`, `staging-certificate-wait`, `staging-certificate-renew`, and replaced `cert-manager-cloudflare-token-secret` to call the guarded installer; documentation `docs/staging-certificate-operations.md` and runbook references were added/updated to prescribe the ordered, one-certificate-at-a-time recovery workflow and the Cloudflare token least-privilege contract. 

### Testing

- `python3 -m pytest -q tests/test_staging_certificate_ops.py` — 5 tests passed (redaction, owner-correlation active/stale, inventory, staging guards, docs/installer contract). 
- `bash -n scripts/*.sh` — shell syntax checks passed for the added scripts. 
- `rg -n 'cloudflare-api-token|CLOUDFLARE_API_TOKEN|from-literal|token=|cmctl renew|Found no Zones|tls\.key'` — repository search reviewed; remaining matches are intentional (placeholders, encrypted secrets, or unrelated tunnel workflows). 
- `linkchecker --no-warnings README.md docs/` — ran locally; checked 206 links with 0 errors. 
- `git diff --check` and `git diff --cached --check` — passed for the working diff; repository secret scanner flagged literal credential *field names* such as `api-token` (value redacted as expected), not actual secrets. 

Notes and environment limitations: `pre-commit`, `shellcheck`, `just --fmt`, and `pyspelling` utilities were not available in the execution environment so those checks were reported as unavailable; the new files were formatted and unit tests adjusted accordingly. No live cluster mutations or certificate issuance were performed during tests; the PR implements deterministic offline checks and operator-facing bounded procedures for post-merge live actions.

Post-merge operator checklist (brief): run `just staging-certificate-status env=staging` to capture the redacted baseline; confirm Cloudflare `Zone - Zone - Read` and `Zone - DNS - Edit` for the explicit zones; update the Secret only if the token value changed using `just cert-manager-cloudflare-token-secret env=staging`; wait five minutes for existing Challenges with `just staging-certificate-wait ...`; if still failing, use `just staging-certificate-renew ...` for the single named Certificate; verify only `tls.crt` with `openssl` and independently verify origin (Traefik) and public Cloudflare edge TLS and endpoints before proceeding to the next certificate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ac02b0960832fa073f3c7b97dea2e)