### PR TITLE
Repair staging DNS-01 certificate operations safely

### DIFF
--- a/clusters/staging/certificates.json
+++ b/clusters/staging/certificates.json
@@ -1,0 +1,9 @@
+{
+  "clusterIssuer": "letsencrypt-production",
+  "cloudflareSecret": {"namespace": "cert-manager", "name": "cloudflare-api-token", "key": "api-token"},
+  "certificates": [
+    {"namespace": "danielsmith", "name": "danielsmith-staging-tls", "dnsNames": ["staging.danielsmith.io"], "zone": "danielsmith.io"},
+    {"namespace": "jobbot3000", "name": "jobbot3000-staging-tls", "dnsNames": ["staging.jobbot3000.tech"], "zone": "jobbot3000.tech"},
+    {"namespace": "tokenplace", "name": "tokenplace-staging-tls", "dnsNames": ["staging.token.place"], "zone": "token.place"}
+  ]
+}

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -233,7 +233,10 @@ Common failure modes:
 - **Missing cert-manager CRDs** (`no matches for kind "Certificate"` / `"ClusterIssuer"`): reinstall cert-manager with CRDs enabled.
 - **`clusterissuer.cert-manager.io` resource type missing**: controllers/CRDs are not fully installed yet.
 - **Literal `$(CERT_MANAGER_EMAIL)` in ClusterIssuer**: issuer was applied from Flux-era template without replacement; reapply with `just cert-manager-issuers-apply email=<email>`.
-- **Missing `cloudflare-api-token` secret**: create it with `just cert-manager-cloudflare-token-secret token=<token>`.
+- **Missing `cloudflare-api-token` secret in staging**: follow the
+  [secret-safe staging certificate runbook](staging-certificates.md) and use its
+  hidden interactive installer. Never pass the credential as an argument or
+  environment assignment.
 - **Challenge cleanup errors after successful issuance**: Cloudflare API token is missing `Zone:Read` and/or is scoped to the wrong zone.
 
 Validation sequence:

--- a/docs/staging-certificates.md
+++ b/docs/staging-certificates.md
@@ -1,0 +1,72 @@
+# Staging certificate operations
+
+This runbook repairs staging DNS-01 authorization without changing Ingress TLS or
+Cloudflare Tunnel transport. All commands are staging-only and require the current
+context to be exactly `sugar-staging`. They do not prove that live issuance has
+succeeded until the live checks below pass.
+
+## Shared Cloudflare credential contract
+
+The declarative source of truth is
+`clusters/staging/certificates.json`. Its current authoritative-zone inventory is
+the complete set found in the staging app values that intentionally use the shared
+cert-manager issuer: `danielsmith.io`, `jobbot3000.tech`, and `token.place`.
+The shared token needs **Zone - Zone - Read** and **Zone - DNS - Edit**, scoped to
+each of those three explicit zones—not all zones. Preserve the already-working
+`token.place` access while repairing the other two.
+
+A present Kubernetes Secret and a Ready ClusterIssuer validate only the configured
+Secret name/key. Kubernetes cannot prove Cloudflare dashboard permissions or
+resource scope. An operator must confirm them in Cloudflare, or successful DNS-01
+presentation must demonstrate them. `Found no Zones` strongly suggests a scope or
+permission problem, but is not conclusive by itself.
+
+Editing the existing Cloudflare token's permissions or resource scope in place
+does **not** require a Kubernetes Secret update. If a replacement token is created,
+use `just cert-token-install env=staging`. The guarded prompt is hidden, disables
+shell tracing, rejects empty input, sends the value through stdin, and never puts
+it in argv, an environment assignment, a rendered value, a temporary file, Git,
+or output. Do not paste credentials into another recipe or log.
+
+## Ordered, one-certificate repair
+
+ACME attempts are rate limited. Complete Danielsmith before starting Jobbot3000;
+reverse this only when a newly captured live baseline documents why.
+
+1. Capture a redacted baseline: `just cert-status env=staging`. Manually confirm
+   the permissions and all three zones above. Change the Secret only when the
+   token value changed.
+2. Let the existing Danielsmith Challenge retry rather than creating another
+   Order: `just cert-wait certificate=danielsmith/danielsmith-staging-tls
+   timeout=300 env=staging`. The bounded output correlates resources through owner
+   references. A Challenge attached to a nonterminal current Order is **active**;
+   terminal or superseded history is **stale**.
+3. If that bounded wait expires and an operator confirms a targeted retry is
+   necessary, run exactly once: `just cert-renew
+   certificate=danielsmith/danielsmith-staging-tls timeout=300 env=staging`.
+   This recipe itself observes the existing Challenge for that bounded interval
+   and skips renewal if it converges. Never delete a
+   Certificate, CertificateRequest, Order, Challenge, or serving Secret as the
+   normal repair. Never renew both applications concurrently.
+4. Run the bounded wait again. Require `Ready=True`, `secretPresent=true`, no
+   active pending/failed Order or Challenge, and no new `Found no Zones`. Then run
+   `just cert-verify certificate=danielsmith/danielsmith-staging-tls env=staging`.
+   It reads only `tls.crt` and prints SAN, issuer, serial, and validity dates; it
+   never reads `tls.key`. Confirm the revision advanced when renewal occurred.
+5. If direct Traefik/origin TLS is reachable in the current topology, test it with
+   the hostname/SNI and confirm it presents the Kubernetes certificate. Separately
+   inspect public `https://staging.danielsmith.io`: Cloudflare edge TLS must be
+   valid, but its issuer and serial are **not expected to match** the Kubernetes
+   certificate because the tunnel currently reaches Traefik over HTTP. Verify
+   `/`, `/healthz`, and `/livez` independently.
+6. Only after every Danielsmith check passes, repeat steps 1–5 for
+   `jobbot3000/jobbot3000-staging-tls` and `staging.jobbot3000.tech`.
+
+## Stop, recovery, and rollback
+
+Stop after a timeout, a new authorization error, or any unexpected resource. Do
+not loop or delete ACME resources; capture another redacted status and diagnose.
+Rollback means stopping retries and re-entering a prior known-good token from the
+password manager with the guarded installer. Never export a credential from
+Kubernetes. Confirm that the restored token still includes `token.place` before
+resuming one certificate at a time.

--- a/justfile
+++ b/justfile
@@ -229,6 +229,33 @@ status:
     if ! command -v k3s >/dev/null 2>&1; then printf '%s\n' 'k3s is not installed yet.' 'Visit https://github.com/futuroptimist/sugarkube/blob/main/docs/raspi_cluster_setup.md.' 'Follow the instructions in that guide before rerunning this command.'; exit 0; fi
     sudo k3s kubectl get nodes -o wide
 
+# Redacted, read-only staging cert-manager inventory.
+cert-status env='staging':
+    python3 scripts/staging_certificates.py status --env "{{ env }}"
+
+# Observe exactly one existing issuance for a bounded interval (maximum 15 minutes).
+cert-wait certificate timeout='300' env='staging':
+    python3 scripts/staging_certificates.py wait --env "{{ env }}" --certificate "{{ certificate }}" --timeout "{{ timeout }}"
+
+# Interactive stdin-only replacement of the shared staging credential.
+cert-token-install env='staging':
+    scripts/install_staging_cloudflare_token.sh "{{ env }}"
+
+# Request one renewal only after cert-wait has expired and an operator confirms it is needed.
+cert-renew certificate timeout='300' env='staging':
+    # Existing Challenges get this bounded convergence window before any new Order is requested.
+    if python3 scripts/staging_certificates.py wait --env "{{ env }}" --certificate "{{ certificate }}" --timeout "{{ timeout }}"; then printf 'Certificate converged; renewal was not requested.\n'; exit 0; else wait_status=$?; fi
+    test "$wait_status" -eq 3 || exit "$wait_status"
+    test "{{ env }}" = staging && test "$(kubectl config current-context)" = sugar-staging
+    case "{{ certificate }}" in */*) ;; *) printf 'certificate must be namespace/name\n' >&2; exit 2;; esac
+    cmctl renew --context sugar-staging --namespace "${certificate%%/*}" "${certificate#*/}"
+
+# Decode only the public certificate and print its SAN, issuer, serial, and dates.
+cert-verify certificate env='staging':
+    test "{{ env }}" = staging && test "$(kubectl config current-context)" = sugar-staging
+    case "{{ certificate }}" in */*) ;; *) printf 'certificate must be namespace/name\n' >&2; exit 2;; esac
+    kubectl --context sugar-staging get secret "${certificate#*/}" -n "${certificate%%/*}" -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -subject -ext subjectAltName -issuer -serial -dates
+
 # Show a summarized status of the HA cluster, Helm CLI, and Traefik ingress.
 
 # This is a read-only health dashboard for debugging and quick checks.
@@ -790,30 +817,9 @@ cert-manager-install version='v1.14.4':
 
     kubectl -n cert-manager wait --for=condition=Available deployment/cert-manager deployment/cert-manager-webhook deployment/cert-manager-cainjector --timeout=300s
 
-# Create/update the Cloudflare DNS API token Secret used by cert-manager DNS-01.
-cert-manager-cloudflare-token-secret token='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
-
-    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-    token="{{ token }}"
-    : "${token:=${CF_DNS_API_TOKEN:-}}"
-    token="$(printf '%s' "${token}" | tr -d '\r\n' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
-    case "${token}" in
-        token=*|CF_DNS_API_TOKEN=*|CLOUDFLARE_DNS_API_TOKEN=*)
-            token="${token#*=}"
-            token="$(printf '%s' "${token}" | tr -d '\r\n' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
-            ;;
-    esac
-    if [ -z "${token}" ]; then
-        echo "Set CF_DNS_API_TOKEN or pass token=<cloudflare-dns-api-token>." >&2
-        exit 1
-    fi
-
-    kubectl get namespace cert-manager >/dev/null 2>&1 || kubectl create namespace cert-manager
-    kubectl -n cert-manager create secret generic cloudflare-api-token \
-        --from-literal=api-token="${token}" \
-        --dry-run=client -o yaml | kubectl apply -f -
+# Compatibility name for the guarded, staging-only interactive installer.
+cert-manager-cloudflare-token-secret env='staging':
+    scripts/install_staging_cloudflare_token.sh "{{ env }}"
 
 # Apply non-Flux ClusterIssuers with an explicit email (no kustomize vars).
 cert-manager-issuers-apply email:

--- a/scripts/install_staging_cloudflare_token.sh
+++ b/scripts/install_staging_cloudflare_token.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+cleanup() { unset token; }
+trap cleanup EXIT INT TERM
+set +x
+
+[[ "${1-}" == "staging" ]] || { printf 'ERROR: environment must be staging.\n' >&2; exit 2; }
+[[ "$(kubectl config current-context)" == "sugar-staging" ]] || { printf 'ERROR: current context must be sugar-staging.\n' >&2; exit 2; }
+printf 'Cloudflare API token (hidden): ' >&2
+IFS= read -r -s token
+printf '\n' >&2
+[[ -n "$token" ]] || { printf 'ERROR: token must not be empty.\n' >&2; exit 2; }
+printf '%s' "$token" | kubectl --context sugar-staging create secret generic cloudflare-api-token \
+  --namespace cert-manager --from-file=api-token=/dev/stdin --dry-run=client -o yaml \
+  | kubectl --context sugar-staging apply -f - >/dev/null
+unset token
+printf 'Cloudflare credential Secret applied in staging.\n'

--- a/scripts/staging_certificates.py
+++ b/scripts/staging_certificates.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Secret-safe, read-only cert-manager status and bounded single-certificate waits."""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INVENTORY = ROOT / "clusters/staging/certificates.json"
+CONTEXT = "sugar-staging"
+KINDS = ("certificates", "certificaterequests", "orders", "challenges")
+
+
+def run_json(*args):
+    result = subprocess.run(
+        ["kubectl", "--context", CONTEXT, *args, "-o", "json"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return json.loads(result.stdout)
+
+
+def run_text(*args):
+    return subprocess.run(
+        ["kubectl", "--context", CONTEXT, *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    ).stdout
+
+
+def current_context():
+    return subprocess.run(
+        ["kubectl", "config", "current-context"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    ).stdout.strip()
+
+
+def clean(value):
+    """Bound diagnostics and remove common credential/private material shapes."""
+    text = str(value or "")
+    text = re.sub(
+        r"-----BEGIN [^-]+-----.*?(?:-----END [^-]+-----|$)", "[redacted]", text, flags=re.S
+    )
+    text = re.sub(r"(?i)\b(authorization|token|api[-_]?key)\s*[:=]\s*\S+", r"\1=[redacted]", text)
+    text = re.sub(r"(?i)\bbearer\s+\S+", "Bearer [redacted]", text)
+    text = re.sub(r"https?://\S+", "[url-redacted]", text)
+    return " ".join(text.split())[:240] or "-"
+
+
+def owner(item, kind):
+    for ref in item.get("metadata", {}).get("ownerReferences", []):
+        if ref.get("kind") == kind:
+            return ref.get("name")
+    return None
+
+
+def condition(item, kind="Ready"):
+    for cond in item.get("status", {}).get("conditions", []):
+        if cond.get("type") == kind:
+            return cond
+    return {}
+
+
+def collect():
+    data = {}
+    for kind in KINDS:
+        data[kind] = run_json("get", kind, "-A").get("items", [])
+    return data
+
+
+def correlated(cert, data):
+    ns = cert["namespace"]
+    requests = [
+        x
+        for x in data["certificaterequests"]
+        if x.get("metadata", {}).get("namespace") == ns and owner(x, "Certificate") == cert["name"]
+    ]
+    request_names = {x.get("metadata", {}).get("name") for x in requests}
+    orders = [
+        x
+        for x in data["orders"]
+        if x.get("metadata", {}).get("namespace") == ns
+        and owner(x, "CertificateRequest") in request_names
+    ]
+    order_names = {x.get("metadata", {}).get("name") for x in orders}
+    challenges = [
+        x
+        for x in data["challenges"]
+        if x.get("metadata", {}).get("namespace") == ns and owner(x, "Order") in order_names
+    ]
+
+    def key(item):
+        return item.get("metadata", {}).get("name", "")
+
+    return sorted(requests, key=key), sorted(orders, key=key), sorted(challenges, key=key)
+
+
+def render(inventory, data, secrets, issuer):
+    lines = []
+    issuer_ok = issuer.get("metadata", {}).get("name") == inventory["clusterIssuer"]
+    solver = (((issuer.get("spec") or {}).get("acme") or {}).get("solvers") or [{}])[0]
+    ref = ((solver.get("dns01") or {}).get("cloudflare") or {}).get("apiTokenSecretRef") or {}
+    expected = inventory["cloudflareSecret"]
+    secret = next(
+        (
+            x
+            for x in secrets
+            if x.get("metadata", {}).get("name") == expected["name"]
+            and x.get("metadata", {}).get("namespace") == expected["namespace"]
+        ),
+        None,
+    )
+    secret_ok = bool(secret and expected["key"] in secret.get("data", {}))
+    lines.append(
+        f"issuer={inventory['clusterIssuer']} present={str(issuer_ok).lower()} secret={expected['namespace']}/{expected['name']} key={expected['key']} configured={str(ref.get('name') == expected['name'] and ref.get('key') == expected['key']).lower()} present={str(secret_ok).lower()}"  # noqa: E501
+    )
+    cert_items = {
+        (x.get("metadata", {}).get("namespace"), x.get("metadata", {}).get("name")): x
+        for x in data["certificates"]
+    }
+    tls_names = {
+        (x.get("metadata", {}).get("namespace"), x.get("metadata", {}).get("name")) for x in secrets
+    }
+    for wanted in sorted(inventory["certificates"], key=lambda x: (x["namespace"], x["name"])):
+        item = cert_items.get((wanted["namespace"], wanted["name"]), {})
+        status = item.get("status", {})
+        cond = condition(item)
+        spec = item.get("spec", {})
+        issuer_ref = spec.get("issuerRef", {})
+        lines.append(
+            f"certificate={wanted['namespace']}/{wanted['name']} dns={','.join(spec.get('dnsNames') or wanted['dnsNames'])} ready={cond.get('status', 'Missing')} reason={clean(cond.get('reason', '-'))} revision={status.get('revision', '-')} notBefore={status.get('notBefore', '-')} notAfter={status.get('notAfter', '-')} renewalTime={status.get('renewalTime', '-')} issuer={issuer_ref.get('kind', '-')}/{issuer_ref.get('name', '-')} secret={spec.get('secretName', wanted['name'])} secretPresent={str((wanted['namespace'], spec.get('secretName', wanted['name'])) in tls_names).lower()}"  # noqa: E501
+        )
+        requests, orders, challenges = correlated(wanted, data)
+        active_order_names = {
+            x.get("metadata", {}).get("name")
+            for x in orders
+            if x.get("status", {}).get("state") not in ("valid", "invalid")
+        }
+        for challenge in challenges:
+            state = challenge.get("status", {}).get("state", "pending")
+            active = owner(challenge, "Order") in active_order_names and state not in (
+                "valid",
+                "invalid",
+            )
+            lines.append(
+                f"  challenge={challenge.get('metadata', {}).get('name', '[malformed]')} state={state} classification={'active' if active else 'stale'} reason={clean(challenge.get('status', {}).get('reason'))}"  # noqa: E501
+            )
+        lines.append(
+            f"  resources=requests:{len(requests)} orders:{len(orders)} challenges:{len(challenges)}"  # noqa: E501
+        )
+    return "\n".join(lines)
+
+
+def snapshot(inventory):
+    data = collect()
+    expected = inventory["cloudflareSecret"]
+    secrets = []
+    try:
+        keys = run_text(
+            "get",
+            "secret",
+            expected["name"],
+            "-n",
+            expected["namespace"],
+            "-o",
+            'go-template={{range $k, $_ := .data}}{{$k}}{{"\\n"}}{{end}}',
+        )
+        secrets.append(
+            {
+                "metadata": {"name": expected["name"], "namespace": expected["namespace"]},
+                "data": {key: None for key in keys.splitlines()},
+            }
+        )
+    except subprocess.CalledProcessError:
+        pass
+    # Existence is checked through metadata.name; private Secret data is never requested.
+    for cert in inventory["certificates"]:
+        try:
+            name = run_text(
+                "get",
+                "secret",
+                cert["name"],
+                "-n",
+                cert["namespace"],
+                "-o",
+                "jsonpath={.metadata.name}",
+            )
+            secrets.append({"metadata": {"name": name, "namespace": cert["namespace"]}})
+        except subprocess.CalledProcessError:
+            pass
+    try:
+        issuer = run_json("get", "clusterissuer", inventory["clusterIssuer"])
+    except subprocess.CalledProcessError:
+        issuer = {}
+    return render(inventory, data, secrets, issuer)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("status", "wait"))
+    parser.add_argument("--env", required=True)
+    parser.add_argument("--certificate")
+    parser.add_argument("--timeout", type=int, default=300)
+    args = parser.parse_args()
+    if args.env != "staging":
+        parser.error("this command requires --env staging")
+    if current_context() != CONTEXT:
+        parser.error(f"current Kubernetes context must be {CONTEXT}")
+    inventory = json.loads(INVENTORY.read_text())
+    if args.command == "status":
+        print(snapshot(inventory))
+        return
+    if (
+        not args.certificate
+        or "/" not in args.certificate
+        or args.timeout < 1
+        or args.timeout > 900
+    ):
+        parser.error("wait requires --certificate namespace/name and --timeout 1..900")
+    wanted = [
+        x for x in inventory["certificates"] if f"{x['namespace']}/{x['name']}" == args.certificate
+    ]
+    if len(wanted) != 1:
+        parser.error("certificate is not in the staging inventory")
+    inventory["certificates"] = wanted
+    deadline = time.monotonic() + args.timeout
+    while True:
+        output = snapshot(inventory)
+        print(output, flush=True)
+        line = next(x for x in output.splitlines() if x.startswith("certificate="))
+        if (
+            " ready=True " in line
+            and " secretPresent=true" in line
+            and "classification=active" not in output
+            and "Found no Zones" not in output
+        ):
+            return
+        if time.monotonic() >= deadline:
+            print("bounded wait expired without readiness", file=sys.stderr)
+            raise SystemExit(3)
+        time.sleep(min(15, max(0, deadline - time.monotonic())))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_staging_certificates.py
+++ b/tests/test_staging_certificates.py
@@ -1,0 +1,136 @@
+import importlib.util
+import json
+from pathlib import Path
+
+PATH = Path(__file__).parents[1] / "scripts/staging_certificates.py"
+SPEC = importlib.util.spec_from_file_location("staging_certificates", PATH)
+certs = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(certs)
+
+
+def resource(kind, name, namespace="app", owner_kind=None, owner_name=None, status=None):
+    metadata = {"name": name, "namespace": namespace}
+    if owner_kind:
+        metadata["ownerReferences"] = [{"kind": owner_kind, "name": owner_name}]
+    return {"kind": kind, "metadata": metadata, "status": status or {}}
+
+
+def test_owner_correlation_active_stale_and_redaction():
+    inventory = {
+        "clusterIssuer": "issuer",
+        "cloudflareSecret": {"namespace": "cm", "name": "cf", "key": "api-token"},
+        "certificates": [
+            {"namespace": "app", "name": "one", "dnsNames": ["one.example"], "zone": "example"},
+            {"namespace": "other", "name": "two", "dnsNames": ["two.test"], "zone": "test"},
+        ],
+    }
+    certificate = resource(
+        "Certificate",
+        "one",
+        status={
+            "revision": 1,
+            "conditions": [{"type": "Ready", "status": "False", "reason": "DoesNotExist"}],
+        },
+    )
+    certificate["spec"] = {
+        "dnsNames": ["one.example"],
+        "secretName": "one",
+        "issuerRef": {"kind": "ClusterIssuer", "name": "issuer"},
+    }
+    request = resource(
+        "CertificateRequest", "random-request", owner_kind="Certificate", owner_name="one"
+    )
+    order = resource(
+        "Order",
+        "random-order",
+        owner_kind="CertificateRequest",
+        owner_name="random-request",
+        status={"state": "pending"},
+    )
+    active = resource(
+        "Challenge",
+        "random-active",
+        owner_kind="Order",
+        owner_name="random-order",
+        status={
+            "state": "pending",
+            "reason": "Found no Zones https://host/path?q=SECRET Authorization: Bearer_SECRET",
+        },
+    )
+    stale_order = resource(
+        "Order",
+        "old-order",
+        owner_kind="CertificateRequest",
+        owner_name="random-request",
+        status={"state": "invalid"},
+    )
+    stale = resource(
+        "Challenge",
+        "old",
+        owner_kind="Order",
+        owner_name="old-order",
+        status={"state": "pending", "reason": "-----BEGIN PRIVATE KEY----- bad"},
+    )
+    data = {
+        "certificates": [certificate],
+        "certificaterequests": [request],
+        "orders": [order, stale_order],
+        "challenges": [active, stale],
+    }
+    issuer = {
+        "metadata": {"name": "issuer"},
+        "spec": {
+            "acme": {
+                "solvers": [
+                    {
+                        "dns01": {
+                            "cloudflare": {"apiTokenSecretRef": {"name": "cf", "key": "api-token"}}
+                        }
+                    }
+                ]
+            }
+        },
+    }
+    output = certs.render(
+        inventory,
+        data,
+        [{"metadata": {"namespace": "cm", "name": "cf"}, "data": {"api-token": None}}],
+        issuer,
+    )
+    assert "random-active state=pending classification=active" in output
+    assert "old state=pending classification=stale" in output
+    assert "Bearer_SECRET" not in output and "PRIVATE KEY" not in output and "?q=" not in output
+    assert "certificate=other/two" in output and "ready=Missing" in output
+    assert output == certs.render(
+        inventory,
+        data,
+        [{"metadata": {"namespace": "cm", "name": "cf"}, "data": {"api-token": None}}],
+        issuer,
+    )
+
+
+def test_inventory_and_scripts_are_secret_safe_and_nondestructive():
+    inventory = json.loads(
+        (Path(__file__).parents[1] / "clusters/staging/certificates.json").read_text()
+    )
+    assert {x["zone"] for x in inventory["certificates"]} == {
+        "token.place",
+        "danielsmith.io",
+        "jobbot3000.tech",
+    }
+    installer = (
+        Path(__file__).parents[1] / "scripts/install_staging_cloudflare_token.sh"
+    ).read_text()
+    assert "read -r -s token" in installer
+    assert "--from-file=api-token=/dev/stdin" in installer
+    assert "from-literal" not in installer and "mktemp" not in installer
+    implementation = PATH.read_text()
+    assert "delete" not in implementation and "tls.key" not in implementation
+    justfile = (Path(__file__).parents[1] / "justfile").read_text()
+    renew = justfile[
+        justfile.index("cert-renew certificate") : justfile.index(
+            "# Decode only", justfile.index("cert-renew certificate")
+        )
+    ]
+    assert renew.index("staging_certificates.py wait") < renew.index("cmctl renew")
+    assert "timeout" in renew and "delete" not in renew


### PR DESCRIPTION
### Motivation

- Provide a staging-only, app-agnostic, secret-safe workflow to diagnose and repair cert-manager Cloudflare DNS-01 failures without touching Ingress TLS, tunnels, or application charts.

### Description

- Add a declarative staging certificate inventory in `clusters/staging/certificates.json` listing the ClusterIssuer, Cloudflare Secret reference, and the three staging certificates/zones.
- Add `scripts/staging_certificates.py`, a read-only, context-guarded tool that reports redacted Certificate/CertificateRequest/Order/Challenge state, correlates ACME resources via owner references, classifies active vs stale challenges, and provides a bounded single-certificate wait.
- Add `scripts/install_staging_cloudflare_token.sh`, a hidden-stdin interactive installer that pipes the token to `kubectl --from-file=api-token=/dev/stdin` and unsets it on exit without ever emitting the value.
- Add justfile recipes: `cert-status`, `cert-wait`, `cert-token-install`, `cert-renew`, and `cert-verify`; `cert-renew` first waits for bounded convergence and only calls `cmctl renew` for one explicitly named certificate when necessary, and `cert-verify` inspects only `tls.crt` via `openssl` (never `tls.key`).
- Replace the unsafe literal-token just recipe with a compatibility alias to the guarded installer and update runbook docs with a new `docs/staging-certificates.md` describing the shared-token contract, ordered one-at-a-time repair, redaction guarantees, and operator steps.
- Add deterministic tests `tests/test_staging_certificates.py` asserting owner-based correlation, active/stale classification, redaction of token-like/private-key content, preservation of the shared-zone inventory, and secret-safe installer semantics.

### Testing

- Ran unit tests: `python3 -m pytest -q tests/test_staging_certificates.py` — 2 passed.
- Style/quality: `black --check` (scripts/tests), `flake8` targeted checks, and `python3 -m py_compile scripts/staging_certificates.py` passed for the modified files; broader repo linters surfaced pre-existing unrelated issues that were not changed by this PR.
- Shell checks: `bash -n scripts/*.sh` passed; `shellcheck` unavailable in this environment.
- Docs/link checks: `linkchecker --no-warnings README.md docs/` passed in this environment.
- Secret scan: `git diff --cached | ./scripts/scan-secrets.py` flagged the literal `--from-file=api-token=/dev/stdin` occurrence; this was reviewed and confirmed to be the safe stdin-only installer usage and not a credential leak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ac02e1794832f92086b1754846c05)