### PR TITLE
Add guarded staging cert-manager DNS-01 recovery tooling

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -233,7 +233,7 @@ Common failure modes:
 - **Missing cert-manager CRDs** (`no matches for kind "Certificate"` / `"ClusterIssuer"`): reinstall cert-manager with CRDs enabled.
 - **`clusterissuer.cert-manager.io` resource type missing**: controllers/CRDs are not fully installed yet.
 - **Literal `$(CERT_MANAGER_EMAIL)` in ClusterIssuer**: issuer was applied from Flux-era template without replacement; reapply with `just cert-manager-issuers-apply email=<email>`.
-- **Missing `cloudflare-api-token` secret**: create it with `just cert-manager-cloudflare-token-secret token=<token>`.
+- **Missing `cloudflare-api-token` secret**: install it with the hidden-input workflow below.
 - **Challenge cleanup errors after successful issuance**: Cloudflare API token is missing `Zone:Read` and/or is scoped to the wrong zone.
 
 Validation sequence:
@@ -245,6 +245,112 @@ kubectl get certificate --all-namespaces
 kubectl -n cert-manager get secret cloudflare-api-token
 kubectl -n cert-manager logs deploy/cert-manager --tail=100
 ```
+
+### Staging Cloudflare DNS-01 recovery
+
+The shared operator token used by cert-manager must have **Zone / Zone / Read** and
+**Zone / DNS / Edit**. Restrict its resources to the authoritative zones that
+intentionally share it: `token.place`, `danielsmith.io`, and `jobbot3000.tech`.
+Do not grant every-zone access merely to work around `Found no Zones`, and confirm
+the token belongs to the Cloudflare account that owns all three zones. The token is
+not the Cloudflare Tunnel connector token. This procedure does not change the
+remotely managed Tunnel or its current HTTP connection to Traefik.
+
+All recipes below fail closed unless the current context is exactly
+`sugar-staging` and every node reports `sugarkube.env=staging`. They preserve Flux
+and Helm ownership: they neither modify Ingresses/Certificates nor reconcile
+production resources.
+
+Start with a redacted inventory. It reports each Certificate, Ready condition,
+issuer, target Secret presence, revision, validity/renewal timestamps and DNS
+names; its active CertificateRequests, Orders and Challenges; and relevant events.
+It checks Secret object presence and reports the configured key name without retrieving or decoding its value.
+
+```bash
+just cert-manager-staging-status
+```
+
+As observed on 2026-07-29, `letsencrypt-production` and
+`tokenplace/tokenplace-staging-tls` were Ready (token.place revision 1).
+`danielsmith/danielsmith-staging-tls` and
+`jobbot3000/jobbot3000-staging-tls` were `False/DoesNotExist`, their TLS Secrets
+were absent, and their pending Challenges reported `Found no Zones`. Public HTTPS
+still terminated successfully at Cloudflare's edge; that does not prove the
+Kubernetes origin Secrets exist.
+
+In the Cloudflare dashboard, an authorized operator must correct the permission,
+zone-resource, and account scope. This repository does not automate dashboard
+changes. Then install or rotate the Secret without putting the token in argv,
+shell history, rendered terminal output, logs, tests, or Git:
+
+```bash
+just cert-manager-cloudflare-token-secret
+```
+
+The recipe uses hidden input on a terminal. For an operator-controlled protected
+file, use `just cert-manager-cloudflare-token-secret file=/secure/path/token`
+and securely remove that file afterward. A secret manager may provide the value on
+stdin: `secret-manager-read | just cert-manager-cloudflare-token-secret`. Do not
+use a visible environment assignment, positional token, checked-in values file, or
+shell tracing. Verify metadata and authorization without viewing Secret data:
+
+```bash
+kubectl --context sugar-staging -n cert-manager get secret cloudflare-api-token
+just cert-manager-staging-verify-authorization
+```
+
+The verifier exits nonzero while any active Challenge reports `Found no Zones`.
+Also confirm the production issuer remains Ready before renewal:
+
+```bash
+kubectl --context sugar-staging wait --for=condition=Ready \
+  clusterissuer/letsencrypt-production --timeout=60s
+```
+
+#### One-certificate-at-a-time recovery
+
+Let's Encrypt applies duplicate-certificate and other issuance rate limits. Stop
+after any failure; do not loop, repeatedly delete Secrets, Certificates,
+CertificateRequests, Orders or Challenges, or renew both applications together.
+Capture `just cert-manager-staging-status` first, choose one Helm-managed
+Certificate, and use the bounded workflow:
+
+```bash
+just cert-manager-staging-renew namespace=danielsmith \
+  certificate=danielsmith-staging-tls hostname=staging.danielsmith.io timeout=300
+just cert-manager-staging-status
+```
+
+The recipe runs `cmctl renew` for exactly that Certificate, waits at most ten
+minutes (five by default) for `Ready=True`, requires its revision or expiry to
+change, then performs TLS-verified HTTPS requests to `/`, `/healthz`, and `/livez`.
+It does not use `--insecure`. Inspect the new Request, Order, Challenge, events and
+Secret presence in the status output. Independently compare the externally served
+certificate's hostname and expiry when needed:
+
+```bash
+echo | openssl s_client -connect staging.danielsmith.io:443 \
+  -servername staging.danielsmith.io -verify_return_error 2>/dev/null |
+  openssl x509 -noout -subject -issuer -dates -ext subjectAltName
+```
+
+Only after the first certificate and all three public endpoints pass, repeat the
+same workflow once for `jobbot3000/jobbot3000-staging-tls` and
+`staging.jobbot3000.tech`. These are arguments rather than app-specific branches,
+so the tooling remains reusable.
+
+#### Rollback and residual risk
+
+If authorization or issuance fails, stop renewal attempts, retain any current
+serving TLS Secret, and inspect the redacted inventory and cert-manager controller
+logs before considering destructive cleanup. Restore the prior known-good token
+through the same hidden-input/stdin recipe if it is available in the operator's
+secret manager; then verify authorization again. Never retrieve a prior token from
+Kubernetes for display. Cloudflare edge HTTPS can remain healthy while an origin
+Certificate is absent or stale, so it is not sufficient evidence by itself.
+
+Changing the Cloudflare Tunnel's HTTP origin transport is a separate hardening issue and explicitly outside this recovery. Production, Flux-managed resources,
+Helm-managed Ingresses and Cloudflare dashboard configuration remain untouched.
 
 ### Verifier summary block and tests
 

--- a/justfile
+++ b/justfile
@@ -790,30 +790,21 @@ cert-manager-install version='v1.14.4':
 
     kubectl -n cert-manager wait --for=condition=Available deployment/cert-manager deployment/cert-manager-webhook deployment/cert-manager-cainjector --timeout=300s
 
-# Create/update the Cloudflare DNS API token Secret used by cert-manager DNS-01.
-cert-manager-cloudflare-token-secret token='':
-    #!/usr/bin/env bash
-    set -Eeuo pipefail
+# Interactively install/rotate the staging cert-manager token (hidden input), or read stdin/a file.
+cert-manager-cloudflare-token-secret file='':
+    python3 "{{ justfile_directory() }}/scripts/cert_manager_staging.py" install-token {{ if file != '' { '--file ' + quote(file) } else { '' } }}
 
-    export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-    token="{{ token }}"
-    : "${token:=${CF_DNS_API_TOKEN:-}}"
-    token="$(printf '%s' "${token}" | tr -d '\r\n' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
-    case "${token}" in
-        token=*|CF_DNS_API_TOKEN=*|CLOUDFLARE_DNS_API_TOKEN=*)
-            token="${token#*=}"
-            token="$(printf '%s' "${token}" | tr -d '\r\n' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
-            ;;
-    esac
-    if [ -z "${token}" ]; then
-        echo "Set CF_DNS_API_TOKEN or pass token=<cloudflare-dns-api-token>." >&2
-        exit 1
-    fi
+# Redacted, read-only staging Certificate/Request/Order/Challenge inventory.
+cert-manager-staging-status:
+    python3 "{{ justfile_directory() }}/scripts/cert_manager_staging.py" status
 
-    kubectl get namespace cert-manager >/dev/null 2>&1 || kubectl create namespace cert-manager
-    kubectl -n cert-manager create secret generic cloudflare-api-token \
-        --from-literal=api-token="${token}" \
-        --dry-run=client -o yaml | kubectl apply -f -
+# Fail when an active staging Challenge still reports Cloudflare zone authorization failure.
+cert-manager-staging-verify-authorization:
+    python3 "{{ justfile_directory() }}/scripts/cert_manager_staging.py" status
+
+# Renew exactly one staging certificate and perform bounded Ready + public HTTPS checks.
+cert-manager-staging-renew namespace certificate hostname timeout='300':
+    python3 "{{ justfile_directory() }}/scripts/cert_manager_staging.py" renew --namespace {{ quote(namespace) }} --certificate {{ quote(certificate) }} --hostname {{ quote(hostname) }} --timeout {{ quote(timeout) }}
 
 # Apply non-Flux ClusterIssuers with an explicit email (no kustomize vars).
 cert-manager-issuers-apply email:

--- a/scripts/cert_manager_staging.py
+++ b/scripts/cert_manager_staging.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Guarded, redacted cert-manager operations for the staging cluster."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+CONTEXT = "sugar-staging"
+SECRET_NAMESPACE = "cert-manager"
+SECRET_NAME = "cloudflare-api-token"
+SECRET_KEY = "api-token"
+REDACT = re.compile(r"(?i)\b(api[_-]?token|authorization|bearer|secret)\b.*")
+
+
+def safe(value: Any) -> str:
+    """Make controller messages safe for terminals and CI logs."""
+    return REDACT.sub(r"\1=[REDACTED]", str(value or "").replace("\n", " "))
+
+
+def run(
+    args: list[str], *, data: bytes | None = None, capture: bool = True
+) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        args,
+        input=data,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def kubectl(*args: str, check: bool = True) -> bytes:
+    result = run(["kubectl", "--context", CONTEXT, *args])
+    if check and result.returncode:
+        raise RuntimeError(safe(result.stderr.decode(errors="replace")))
+    return result.stdout
+
+
+def assert_staging() -> None:
+    current = kubectl("config", "current-context").decode().strip()
+    if current != CONTEXT:
+        raise RuntimeError(
+            f"refusing cluster access: current context must be {CONTEXT}, got {current or '<none>'}"
+        )
+    nodes = json.loads(kubectl("get", "nodes", "-o", "json"))
+    envs = {
+        item.get("metadata", {}).get("labels", {}).get("sugarkube.env")
+        for item in nodes.get("items", [])
+    }
+    if envs != {"staging"}:
+        raise RuntimeError(
+            "refusing cluster access: node sugarkube.env labels must be exactly staging, "
+            f"got {safe(envs)}"
+        )
+
+
+def objects(resource: str) -> list[dict[str, Any]]:
+    return json.loads(kubectl("get", resource, "--all-namespaces", "-o", "json")).get(
+        "items", []
+    )
+
+
+def condition(item: dict[str, Any]) -> tuple[str, str, str]:
+    conditions = item.get("status", {}).get("conditions", [])
+    ready = next((c for c in conditions if c.get("type") == "Ready"), {})
+    return (
+        safe(ready.get("status", "Unknown")),
+        safe(ready.get("reason", "-")),
+        safe(ready.get("message", "-")),
+    )
+
+
+def owner_names(item: dict[str, Any]) -> set[str]:
+    return {
+        o.get("name", "") for o in item.get("metadata", {}).get("ownerReferences", [])
+    }
+
+
+def active_challenges(data: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    certificate_names = {
+        item.get("metadata", {}).get("name", "") for item in data["certificates"]
+    }
+    request_names = {
+        item.get("metadata", {}).get("name", "")
+        for item in data["certificaterequests"]
+        if owner_names(item) & certificate_names
+    }
+    order_names = {
+        item.get("metadata", {}).get("name", "")
+        for item in data["orders"]
+        if owner_names(item) & request_names
+    }
+    return [
+        item
+        for item in data["challenges"]
+        if owner_names(item) & order_names
+        and item.get("status", {}).get("state") != "valid"
+    ]
+
+
+def render_status(data: dict[str, list[dict[str, Any]]], secret_present: bool) -> str:
+    lines = [
+        f"Cloudflare Secret: {SECRET_NAMESPACE}/{SECRET_NAME} key={SECRET_KEY} "
+        f"present={'yes' if secret_present else 'no'}"
+    ]
+    requests, orders, challenges = (
+        data["certificaterequests"],
+        data["orders"],
+        data["challenges"],
+    )
+    for issuer in sorted(
+        data.get("clusterissuers", []), key=lambda x: x["metadata"].get("name", "")
+    ):
+        ready, reason, message = condition(issuer)
+        refs = []
+        for solver in issuer.get("spec", {}).get("acme", {}).get("solvers", []):
+            ref = (
+                solver.get("dns01", {})
+                .get("cloudflare", {})
+                .get("apiTokenSecretRef", {})
+            )
+            if ref:
+                refs.append(
+                    f"{ref.get('name', '<missing>')}/{ref.get('key', '<missing>')}"
+                )
+        lines.append(
+            f"Issuer: ClusterIssuer/{issuer['metadata'].get('name')} Ready={ready} reason={reason} "
+            f"message={message} CloudflareSecret={','.join(refs) or '-'}"
+        )
+    for cert in sorted(
+        data["certificates"],
+        key=lambda x: (
+            x["metadata"].get("namespace", ""),
+            x["metadata"].get("name", ""),
+        ),
+    ):
+        meta, spec, status = (
+            cert["metadata"],
+            cert.get("spec", {}),
+            cert.get("status", {}),
+        )
+        ns, name = meta.get("namespace", ""), meta.get("name", "")
+        ready, reason, message = condition(cert)
+        issuer = spec.get("issuerRef", {})
+        lines += [
+            "",
+            f"Certificate: {ns}/{name}",
+            f"  Ready: {ready} reason={reason} message={message}",
+            f"  issuer: {issuer.get('kind', 'Issuer')}/{issuer.get('name', '<missing>')}",
+            f"  Secret: {ns}/{spec.get('secretName', '<missing>')} "
+            f"present={'yes' if cert.get('_secretPresent') else 'no'}",
+            f"  revision: {status.get('revision', '-')} "
+            f"notBefore={status.get('notBefore', '-')} notAfter={status.get('notAfter', '-')} "
+            f"renewalTime={status.get('renewalTime', '-')}",
+            f"  DNS names: {', '.join(spec.get('dnsNames', [])) or '-'}",
+        ]
+        related_req = [
+            r
+            for r in requests
+            if r.get("metadata", {}).get("namespace") == ns and name in owner_names(r)
+        ]
+        req_names = {r.get("metadata", {}).get("name", "") for r in related_req}
+        related_orders = [
+            o
+            for o in orders
+            if o.get("metadata", {}).get("namespace") == ns
+            and owner_names(o) & req_names
+        ]
+        order_names = {o.get("metadata", {}).get("name", "") for o in related_orders}
+        related_challenges = [
+            c
+            for c in challenges
+            if c.get("metadata", {}).get("namespace") == ns
+            and owner_names(c) & order_names
+        ]
+        for label, items in (
+            ("CertificateRequest", related_req),
+            ("Order", related_orders),
+            ("Challenge", related_challenges),
+        ):
+            if not items:
+                lines.append(f"  {label}: none")
+            for item in items:
+                state, why, msg = (
+                    condition(item)
+                    if label == "CertificateRequest"
+                    else (
+                        safe(item.get("status", {}).get("state", "pending")),
+                        safe(item.get("status", {}).get("reason", "-")),
+                        safe(item.get("status", {}).get("message", "-")),
+                    )
+                )
+                lines.append(
+                    f"  {label}: {item['metadata'].get('name')} state={state} "
+                    f"reason={why} message={msg}"
+                )
+    for event in data.get("events", []):
+        involved = event.get("involvedObject", {})
+        if involved.get("apiVersion", "").startswith(
+            ("cert-manager.io/", "acme.cert-manager.io/")
+        ):
+            lines.append(
+                f"Event: {involved.get('namespace', '-')}/{involved.get('kind', '-')}/"
+                f"{involved.get('name', '-')} reason={safe(event.get('reason'))} "
+                f"message={safe(event.get('message'))}"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def status() -> int:
+    data = {
+        name: objects(name)
+        for name in (
+            "clusterissuers",
+            "certificates",
+            "certificaterequests",
+            "orders",
+            "challenges",
+            "events",
+        )
+    }
+    for cert in data["certificates"]:
+        namespace = cert.get("metadata", {}).get("namespace", "")
+        secret_name = cert.get("spec", {}).get("secretName", "")
+        result = run(
+            [
+                "kubectl",
+                "--context",
+                CONTEXT,
+                "-n",
+                namespace,
+                "get",
+                "secret",
+                secret_name,
+                "--request-timeout=15s",
+                "-o",
+                "name",
+            ]
+        )
+        cert["_secretPresent"] = bool(secret_name and result.returncode == 0)
+    secret = run(
+        [
+            "kubectl",
+            "--context",
+            CONTEXT,
+            "-n",
+            SECRET_NAMESPACE,
+            "get",
+            "secret",
+            SECRET_NAME,
+            "--request-timeout=15s",
+            "-o",
+            "name",
+        ]
+    )
+    print(render_status(data, secret.returncode == 0), end="")
+    return (
+        1
+        if any(
+            "Found no Zones" in str(c.get("status", {}))
+            for c in active_challenges(data)
+        )
+        else 0
+    )
+
+
+def install_token(path: str | None) -> int:
+    if path:
+        credential = Path(path).read_bytes().rstrip(b"\r\n")
+    elif sys.stdin.isatty():
+        credential = getpass.getpass("Cloudflare API credential: ").encode()
+    else:
+        credential = sys.stdin.buffer.read().rstrip(b"\r\n")
+    if not credential:
+        raise RuntimeError("Cloudflare API token input is empty")
+    rendered = run(
+        [
+            "kubectl",
+            "--context",
+            CONTEXT,
+            "-n",
+            SECRET_NAMESPACE,
+            "create",
+            "secret",
+            "generic",
+            SECRET_NAME,
+            f"--from-file={SECRET_KEY}=/dev/stdin",
+            "--dry-run=client",
+            "-o",
+            "yaml",
+        ],
+        data=credential,
+    )
+    credential = b""  # discard the clear-text reference before applying
+    if rendered.returncode:
+        raise RuntimeError(safe(rendered.stderr.decode(errors="replace")))
+    applied = run(
+        ["kubectl", "--context", CONTEXT, "apply", "-f", "-"], data=rendered.stdout
+    )
+    if applied.returncode:
+        raise RuntimeError(safe(applied.stderr.decode(errors="replace")))
+    print(f"Updated {SECRET_NAMESPACE}/{SECRET_NAME}; token value was not displayed.")
+    return 0
+
+
+def renew(namespace: str, certificate: str, hostname: str, timeout: int) -> int:
+    before = json.loads(
+        kubectl("-n", namespace, "get", "certificate", certificate, "-o", "json")
+    )
+    result = run(["cmctl", "--context", CONTEXT, "renew", "-n", namespace, certificate])
+    if result.returncode:
+        raise RuntimeError(safe(result.stderr.decode(errors="replace")))
+    wait = run(
+        [
+            "kubectl",
+            "--context",
+            CONTEXT,
+            "-n",
+            namespace,
+            "wait",
+            "--for=condition=Ready",
+            f"certificate/{certificate}",
+            f"--timeout={timeout}s",
+        ]
+    )
+    if wait.returncode:
+        raise RuntimeError(
+            f"bounded Ready wait failed: {safe(wait.stderr.decode(errors='replace'))}"
+        )
+    after = json.loads(
+        kubectl("-n", namespace, "get", "certificate", certificate, "-o", "json")
+    )
+    old, new = before.get("status", {}), after.get("status", {})
+    changed = old.get("revision") != new.get("revision") or old.get(
+        "notAfter"
+    ) != new.get("notAfter")
+    if not changed:
+        raise RuntimeError(
+            "Certificate became Ready but neither revision nor expiry changed; "
+            "stop before another renewal"
+        )
+    for path in ("/", "/healthz", "/livez"):
+        probe = run(
+            [
+                "curl",
+                "--fail",
+                "--silent",
+                "--show-error",
+                "--max-time",
+                "15",
+                f"https://{hostname}{path}",
+            ]
+        )
+        if probe.returncode:
+            raise RuntimeError(
+                f"external HTTPS verification failed for {hostname}{path}: "
+                f"{safe(probe.stderr.decode(errors='replace'))}"
+            )
+    print(
+        f"Renewed {namespace}/{certificate}: revision/expiry changed and HTTPS checks "
+        f"passed for {hostname}."
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="action", required=True)
+    sub.add_parser("status")
+    install = sub.add_parser("install-token")
+    install.add_argument("--file")
+    renewal = sub.add_parser("renew")
+    renewal.add_argument("--namespace", required=True)
+    renewal.add_argument("--certificate", required=True)
+    renewal.add_argument("--hostname", required=True)
+    renewal.add_argument("--timeout", type=int, default=300)
+    args = parser.parse_args()
+    assert_staging()
+    if args.action == "status":
+        return status()
+    if args.action == "install-token":
+        return install_token(args.file)
+    if not 30 <= args.timeout <= 600:
+        raise RuntimeError("timeout must be between 30 and 600 seconds")
+    return renew(args.namespace, args.certificate, args.hostname, args.timeout)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (RuntimeError, OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {safe(exc)}", file=sys.stderr)
+        raise SystemExit(2)

--- a/tests/test_cert_manager_staging.py
+++ b/tests/test_cert_manager_staging.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "cert_manager_staging", ROOT / "scripts/cert_manager_staging.py"
+)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def resource(kind: str, name: str, namespace: str = "demo", owner: str = "") -> dict:
+    meta = {"name": name, "namespace": namespace}
+    if owner:
+        meta["ownerReferences"] = [{"name": owner}]
+    return {
+        "apiVersion": "cert-manager.io/v1",
+        "kind": kind,
+        "metadata": meta,
+        "status": {},
+    }
+
+
+def test_render_status_relates_resources_and_redacts_messages() -> None:
+    cert = resource("Certificate", "demo-tls")
+    cert.update(
+        {
+            "spec": {
+                "secretName": "demo-secret",
+                "dnsNames": ["staging.example.test"],
+                "issuerRef": {
+                    "kind": "ClusterIssuer",
+                    "name": "letsencrypt-production",
+                },
+            },
+            "status": {
+                "revision": 2,
+                "notBefore": "2026-01-01",
+                "notAfter": "2026-04-01",
+                "renewalTime": "2026-03-01",
+                "conditions": [{"type": "Ready", "status": "True", "reason": "Ready"}],
+            },
+        }
+    )
+    cert["_secretPresent"] = True
+    issuer = resource("ClusterIssuer", "letsencrypt-production", namespace="")
+    issuer["spec"] = {
+        "acme": {
+            "solvers": [
+                {
+                    "dns01": {
+                        "cloudflare": {
+                            "apiTokenSecretRef": {
+                                "name": "cloudflare-api-token",
+                                "key": "api-token",
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+    req = resource("CertificateRequest", "demo-2", owner="demo-tls")
+    order = resource("Order", "demo-2-order", owner="demo-2")
+    challenge = resource("Challenge", "demo-2-challenge", owner="demo-2-order")
+    challenge["status"] = {
+        "state": "pending",
+        "reason": "authorization: Bearer super-secret",
+    }
+    event = {
+        "involvedObject": {
+            "apiVersion": "acme.cert-manager.io/v1",
+            "kind": "Challenge",
+            "name": "demo-2-challenge",
+            "namespace": "demo",
+        },
+        "reason": "PresentError",
+        "message": "authorization: Bearer never-print-this",
+    }
+    output = MODULE.render_status(
+        {
+            "clusterissuers": [issuer],
+            "certificates": [cert],
+            "certificaterequests": [req],
+            "orders": [order],
+            "challenges": [challenge],
+            "events": [event],
+        },
+        True,
+    )
+    for expected in (
+        "Issuer: ClusterIssuer/letsencrypt-production",
+        "CloudflareSecret=cloudflare-api-token/api-token",
+        "demo/demo-tls",
+        "Ready: True",
+        "revision: 2",
+        "notAfter=2026-04-01",
+        "staging.example.test",
+        "CertificateRequest: demo-2",
+        "Order: demo-2-order",
+        "Challenge: demo-2-challenge",
+        "present=yes",
+        "[REDACTED]",
+    ):
+        assert expected in output
+    assert "super-secret" not in output
+    assert "never-print-this" not in output
+
+
+def test_render_status_handles_missing_issuer_and_stale_unrelated_challenge() -> None:
+    cert = resource("Certificate", "current")
+    cert["spec"] = {"secretName": "current-tls"}
+    stale = resource("Challenge", "old", owner="old-order")
+    output = MODULE.render_status(
+        {
+            "clusterissuers": [],
+            "certificates": [cert],
+            "certificaterequests": [],
+            "orders": [],
+            "challenges": [stale],
+            "events": [],
+        },
+        False,
+    )
+    assert "issuer: Issuer/<missing>" in output
+    assert "Challenge: none" in output
+    assert "old-order" not in output
+    assert "present=no" in output
+
+
+def test_command_structure_never_accepts_token_argument_or_literal() -> None:
+    script = (ROOT / "scripts/cert_manager_staging.py").read_text()
+    justfile = (ROOT / "justfile").read_text()
+    runbook = (ROOT / "docs/runbook.md").read_text()
+    assert "--from-file={SECRET_KEY}=/dev/stdin" in script
+    assert "--from-literal=api-token" not in script + justfile + runbook
+    assert ("token" + "=<cloudflare") not in script + justfile + runbook
+    assert "--insecure" not in script
+    assert 'CONTEXT = "sugar-staging"' in script
+    assert "30 <= args.timeout <= 600" in script
+
+
+def test_active_challenge_parser_excludes_stale_and_completed_challenges() -> None:
+    cert = resource("Certificate", "current")
+    request = resource("CertificateRequest", "current-1", owner="current")
+    order = resource("Order", "current-order", owner="current-1")
+    pending = resource("Challenge", "pending", owner="current-order")
+    pending["status"] = {"state": "pending", "reason": "Found no Zones"}
+    valid = resource("Challenge", "valid", owner="current-order")
+    valid["status"] = {"state": "valid", "reason": "Found no Zones (old message)"}
+    stale = resource("Challenge", "stale", owner="unrelated-order")
+    data = {
+        "certificates": [cert],
+        "certificaterequests": [request],
+        "orders": [order],
+        "challenges": [pending, valid, stale],
+    }
+    assert MODULE.active_challenges(data) == [pending]
+
+
+def test_redaction_covers_failure_output() -> None:
+    assert (
+        MODULE.safe("authorization: Bearer forbidden-value")
+        == "authorization=[REDACTED]"
+    )
+    assert MODULE.safe("ordinary controller failure") == "ordinary controller failure"
+
+
+def test_docs_define_zone_contract_boundaries_and_rollback() -> None:
+    docs = (ROOT / "docs/runbook.md").read_text()
+    for value in (
+        "Zone / Zone / Read",
+        "Zone / DNS / Edit",
+        "token.place",
+        "danielsmith.io",
+        "jobbot3000.tech",
+        "duplicate-certificate",
+        "Restore the prior known-good token",
+        "separate hardening issue",
+        "one Helm-managed",
+    ):
+        assert value in docs


### PR DESCRIPTION
### Motivation

- Provide an app-agnostic, staging-only recovery path for cert-manager Cloudflare DNS-01 authorization failures that reports status without exposing secrets.
- Replace unsafe token-in-argv guidance with a hidden-input / stdin / protected-file workflow so the Cloudflare API token never appears in argv, shell history, logs, rendered output, or Git.
- Support cautious one-certificate-at-a-time renewal with bounded waits and public HTTPS verification to avoid Let’s Encrypt duplicate-certificate and rate-limit risks.

### Description

- Add `scripts/cert_manager_staging.py`, a fail-closed tool that validates `sugar-staging` context and node labels, renders a redacted inventory of `Certificate`, `CertificateRequest`, `Order`, `Challenge`, `ClusterIssuer`, Secret-presence, revision, expiry and relevant events, and exposes `status`, `install-token`, and `renew` actions.
- Replace the unsafe `just` recipe that accepted `token=<value>` with a safe recipe that calls the script and supports hidden terminal input, stdin, or a protected file for token installation, and add `cert-manager-staging-status`, `cert-manager-staging-verify-authorization`, and `cert-manager-staging-renew` recipes.
- Document the required Cloudflare least-privilege token contract (`Zone / Zone / Read` and `Zone / DNS / Edit`) for `token.place`, `danielsmith.io`, and `jobbot3000.tech`, plus sequential recovery, rollback guidance, and explicit out-of-scope notes about the Tunnel transport.
- Add deterministic offline tests (`tests/test_cert_manager_staging.py`) for redaction, resource association, active-vs-stale challenge parsing, missing issuer handling, command-structure safety, and docs checks.

### Testing

- Ran focused static checks: `ruff check scripts/cert_manager_staging.py tests/test_cert_manager_staging.py` (pass) and `flake8 scripts/cert_manager_staging.py tests/test_cert_manager_staging.py` (pass).
- Ran unit tests for the new tests: `python -m pytest -q tests/test_cert_manager_staging.py` (6 passed) and a focused multi-test run `python -m pytest -q tests/test_cert_manager_staging.py tests/test_justfile_formatting.py tests/test_generic_app_just_recipes.py` (pass).
- Executed repository checks: `bash scripts/checks.sh` (focused checks passed; repository-wide flake8 findings unrelated to this change were reported and KiCad checks were skipped because KiCad is not available in the environment).
- Ran full test suite where possible: `python -m pytest -q` completed with 2003 passed and 19 skipped and one unrelated environment failure due to the `helm` executable being unavailable in this environment.
- Verified `git diff --check` succeeded and `git diff --cached | ./scripts/scan-secrets.py` flagged a false-positive match for the removed unsafe `token=<...>` lines (no credentials were added and the patch removes the unsafe guidance).
- Tools not available in the execution environment: `pre-commit`, `pyspelling`, `linkchecker`, `just`, `helm`, and `KiCad`, so those specific commands were not run here.

Residual notes: the changes do not contact a live cluster or Cloudflare account, do not rotate or force-renew certificates in CI, preserve Flux/Helm ownership boundaries, and require an authorized operator to correct Cloudflare dashboard permissions and perform the staged, one-certificate renewals using the new guarded recipes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ad020af94832f8b0a0a4f3f685f3e)