### PR TITLE
Add guarded staging cert-manager Cloudflare recovery tooling

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -233,7 +233,9 @@ Common failure modes:
 - **Missing cert-manager CRDs** (`no matches for kind "Certificate"` / `"ClusterIssuer"`): reinstall cert-manager with CRDs enabled.
 - **`clusterissuer.cert-manager.io` resource type missing**: controllers/CRDs are not fully installed yet.
 - **Literal `$(CERT_MANAGER_EMAIL)` in ClusterIssuer**: issuer was applied from Flux-era template without replacement; reapply with `just cert-manager-issuers-apply email=<email>`.
-- **Missing `cloudflare-api-token` secret**: create it with `just cert-manager-cloudflare-token-secret token=<token>`.
+- **Missing `cloudflare-api-token` Secret**: use the guarded, hidden-input workflow in
+  [the staging certificate recovery runbook](staging-cert-manager-recovery.md). Never put a token
+  in a command argument or visible environment assignment.
 - **Challenge cleanup errors after successful issuance**: Cloudflare API token is missing `Zone:Read` and/or is scoped to the wrong zone.
 
 Validation sequence:

--- a/docs/staging-cert-manager-recovery.md
+++ b/docs/staging-cert-manager-recovery.md
@@ -1,0 +1,125 @@
+# Staging cert-manager Cloudflare recovery
+
+## Scope, boundaries, and observed state
+
+This operator runbook is only for the `sugar-staging` context. The recipes fail closed for every
+other environment or context. They do not manage production, Flux, application releases,
+Cloudflare dashboard settings, or the remotely managed Cloudflare Tunnel. In particular, the
+tunnel's current HTTP connection to Traefik is a separate hardening issue and must not be changed
+during this recovery.
+
+The live observation on 2026-07-29 was:
+
+| Certificate | State | Detail |
+| --- | --- | --- |
+| `tokenplace/tokenplace-staging-tls` | `Ready=True`, revision 1 | Serving Secret exists. |
+| `danielsmith/danielsmith-staging-tls` | `Ready=False`, `DoesNotExist` | Order and Challenge pending; serving Secret missing. |
+| `jobbot3000/jobbot3000-staging-tls` | `Ready=False`, `DoesNotExist` | Order and Challenge pending; serving Secret missing. |
+
+Both failing Challenges reported `Found no Zones` and advised checking `Zone.read` rights. The
+`letsencrypt-production` ClusterIssuer was Ready and its shared
+`cert-manager/cloudflare-api-token` Secret existed. All three Certificates are created by their
+Helm-managed Ingresses. Public HTTPS was still available through Cloudflare edge certificates;
+that does not prove origin certificate issuance works.
+
+## Least-privilege token contract
+
+Create or rotate an API token in the correct Cloudflare account with exactly these permissions:
+
+* **Zone / Zone / Read**;
+* **Zone / DNS / Edit**.
+
+Resource access must explicitly include the authoritative zones `token.place`, `danielsmith.io`,
+and `jobbot3000.tech`. Do not use an all-zones grant unless a separately documented operational
+reason requires it. The repository cannot verify dashboard policy directly; an authorized operator
+must review it without copying the credential into an issue, log, test, or file.
+
+## Configure the inventory and inspect first
+
+Set the non-secret, app-owned inventory. Shared implementation contains no application branches:
+
+```bash
+export SUGARKUBE_STAGING_CERTIFICATES=$'tokenplace/tokenplace-staging-tls/staging.token.place\ndanielsmith/danielsmith-staging-tls/staging.danielsmith.io\njobbot3000/jobbot3000-staging-tls/staging.jobbot3000.tech'
+just staging-cert-status env=staging
+```
+
+The read-only report includes each Certificate's Ready condition, issuer, DNS name, Secret
+presence, revision, validity and renewal times, plus related CertificateRequests, Orders,
+Challenges, and events. Messages containing credential-related terms are replaced with
+`[redacted]`; Secret values are never printed or decoded. Active pending resources are labeled
+separately from stale or completed ones.
+
+## Install or rotate the operator-managed token
+
+First select the exact context and re-check the dashboard contract above:
+
+```bash
+kubectl config use-context sugar-staging
+just staging-cert-token-install env=staging
+```
+
+The recipe reads hidden input when attached to a terminal. For a non-interactive operator session,
+pipe the token from an appropriately protected credential-vault or file command to the recipe's
+standard input. Do not type it into the command line, export it, enable shell tracing, redirect the
+rendered Secret, or save it in Git. The implementation uses
+`--from-file=api-token=/dev/stdin --dry-run=client -o yaml | kubectl apply -f -`; the token is never
+an argument and rendered YAML travels only through the pipe.
+
+Then perform read-only structural authorization checks:
+
+```bash
+just staging-cert-authorization-verify env=staging
+```
+
+This proves the production issuer is Ready, references exactly Secret `cloudflare-api-token` key
+`api-token`, the Opaque Secret has exactly that key, and the configured certificate inventory is
+healthy. It cannot prove Cloudflare resource authorization until a DNS-01 Challenge succeeds.
+
+## One-certificate recovery and external verification
+
+Let's Encrypt enforces duplicate-certificate and other issuance rate limits. Repeated renewal,
+deletion, or recreation attempts can exhaust them. Do not delete a Certificate, serving Secret,
+CertificateRequest, Order, or Challenge as a first response. Wait for an attempt to finish and
+inspect its state. Recover exactly one failing certificate in an authorized maintenance window:
+
+```bash
+just staging-cert-recover env=staging certificate=danielsmith/danielsmith-staging-tls/staging.danielsmith.io
+```
+
+The guarded recipe runs one `cmctl renew`, waits at most five minutes for `Ready=True`, requires the
+serving Secret, and requires revision or expiry to change. It then performs TLS-verified requests
+to `/`, `/healthz`, and `/livez`, and uses OpenSSL hostname and chain verification against the
+externally served endpoint. TLS verification is never disabled. Finally it prints the redacted
+resource report so the new Request, Order, Challenge, revision, expiry, renewal time, and events
+can be recorded. Inspect it and confirm the new Challenge is complete without `Found no Zones`.
+
+Only after the first certificate and all external paths succeed, repeat once for the second:
+
+```bash
+just staging-cert-recover env=staging certificate=jobbot3000/jobbot3000-staging-tls/staging.jobbot3000.tech
+```
+
+If a certificate is already healthy and no controlled renewal is necessary, do not force one merely
+to exercise the recipe. Record its Ready, revision, and expiry state instead.
+
+## Failure handling and rollback
+
+On any bounded-wait or verification failure, stop. Do not loop the recipe. Run the read-only status
+recipe and inspect active resources and controller logs with an authorized, redaction-aware process.
+Confirm the correct Cloudflare account, both permissions, all three resource zones, issuer
+Secret/name/key, and the token's formatting before considering cleanup.
+
+Rollback is credential rotation, not Kubernetes object deletion:
+
+1. Restore the prior known-good token through `just staging-cert-token-install env=staging`, if it
+   remains authorized and is available from the approved credential vault.
+2. Stop all renewal attempts to protect Let's Encrypt rate-limit budget.
+3. Retain every current serving TLS Secret where possible.
+4. Inspect controller logs and active Requests, Orders, and Challenges before any destructive
+   cleanup; escalate rather than guessing.
+5. Re-run status and external TLS checks. Rotation does not change Flux or production state.
+
+Cloudflare edge success can mask a missing origin Secret, and the tunnel currently uses HTTP to
+Traefik. Therefore external HTTPS is necessary but not sufficient evidence; retain the Kubernetes
+Ready/Secret/revision/expiry evidence too. Dashboard authorization and both controlled renewals
+remain deliberate manual staging operations and are never run in CI.

--- a/justfile
+++ b/justfile
@@ -791,29 +791,13 @@ cert-manager-install version='v1.14.4':
     kubectl -n cert-manager wait --for=condition=Available deployment/cert-manager deployment/cert-manager-webhook deployment/cert-manager-cainjector --timeout=300s
 
 # Create/update the Cloudflare DNS API token Secret used by cert-manager DNS-01.
-cert-manager-cloudflare-token-secret token='':
+cert-manager-cloudflare-token-secret:
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
     export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-    token="{{ token }}"
-    : "${token:=${CF_DNS_API_TOKEN:-}}"
-    token="$(printf '%s' "${token}" | tr -d '\r\n' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
-    case "${token}" in
-        token=*|CF_DNS_API_TOKEN=*|CLOUDFLARE_DNS_API_TOKEN=*)
-            token="${token#*=}"
-            token="$(printf '%s' "${token}" | tr -d '\r\n' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
-            ;;
-    esac
-    if [ -z "${token}" ]; then
-        echo "Set CF_DNS_API_TOKEN or pass token=<cloudflare-dns-api-token>." >&2
-        exit 1
-    fi
-
-    kubectl get namespace cert-manager >/dev/null 2>&1 || kubectl create namespace cert-manager
-    kubectl -n cert-manager create secret generic cloudflare-api-token \
-        --from-literal=api-token="${token}" \
-        --dry-run=client -o yaml | kubectl apply -f -
+    printf 'This compatibility recipe is staging-only.\n' >&2
+    scripts/staging_cert_manager.sh install-token staging
 
 # Apply non-Flux ClusterIssuers with an explicit email (no kustomize vars).
 cert-manager-issuers-apply email:
@@ -3286,3 +3270,16 @@ staging-ingress-ha-verify env='staging':
 
 staging-ingress-ha-rollback env='staging':
     scripts/staging_ingress_ha.sh rollback "{{ env }}"
+
+# Redacted staging certificate inventory and recovery lifecycle.
+staging-cert-status env='staging':
+    scripts/staging_cert_manager.sh status "{{ env }}"
+
+staging-cert-token-install env='staging':
+    scripts/staging_cert_manager.sh install-token "{{ env }}"
+
+staging-cert-authorization-verify env='staging':
+    scripts/staging_cert_manager.sh verify-authorization "{{ env }}"
+
+staging-cert-recover certificate env='staging':
+    scripts/staging_cert_manager.sh recover "{{ env }}" "{{ certificate }}"

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -6,6 +6,7 @@ such as API keys or tokens. If `ripsecrets` is available it will be used for a
 more thorough scan; otherwise a lightweight regex-based fallback is used. Any
 findings are printed to stderr so they don't pollute stdout.
 """
+
 from __future__ import annotations
 
 import os
@@ -36,8 +37,7 @@ HEALTHCHECKS_URL = re.compile(
     re.IGNORECASE,
 )
 HEALTHCHECKS_UUID = re.compile(
-    r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-"
-    r"[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-" r"[89ab][0-9a-f]{3}-[0-9a-f]{12}",
     re.IGNORECASE,
 )
 
@@ -46,6 +46,13 @@ HEALTHCHECKS_UUID = re.compile(
 SAFE_PLACEHOLDERS = (
     re.compile(r"^\+\s*passwordKey:\s*admin-password\s*$"),
     re.compile(r"^\+\s*-\s*Password key:\s*`admin-password`\.\s*$"),
+    # This is a file descriptor, not a value. It is the required safe shape for
+    # piping a cert-manager token without exposing it in argv.
+    re.compile(
+        r"^\+(?!.*(?:password|api[_-]?key))"
+        r"(?!.*token\s*[:=](?!/dev/stdin)).*--from-file=api-token=/dev/stdin.*$",
+        re.IGNORECASE,
+    ),
 )
 
 

--- a/scripts/staging_cert_manager.py
+++ b/scripts/staging_cert_manager.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Render a deterministic, redacted cert-manager resource report."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+REDACTED_WORDS = ("token", "secret", "authorization", "credential")
+
+
+def safe(value: object) -> str:
+    text = "" if value is None else str(value).replace("\n", " ")
+    lowered = text.lower()
+    if any(word in lowered for word in REDACTED_WORDS):
+        return "[redacted]"
+    return text
+
+
+def condition(resource: dict, kind: str = "Ready") -> tuple[str, str, str]:
+    for item in resource.get("status", {}).get("conditions", []):
+        if item.get("type") == kind:
+            return (
+                str(item.get("status", "Unknown")),
+                safe(item.get("reason")) or "-",
+                safe(item.get("message")) or "-",
+            )
+    return "Unknown", "-", "-"
+
+
+def owner_names(resource: dict) -> set[str]:
+    return {str(x.get("name")) for x in resource.get("metadata", {}).get("ownerReferences", [])}
+
+
+def main() -> int:
+    document = json.load(sys.stdin)
+    inventory = document["inventory"]
+    resources = document["resources"]
+    events = resources.get("events", {}).get("items", [])
+    result = 0
+    for wanted in inventory:
+        namespace, cert_name, hostname = wanted.split("/", 2)
+        certs = [
+            x
+            for x in resources["certificates"].get("items", [])
+            if x.get("metadata", {}).get("namespace") == namespace
+            and x.get("metadata", {}).get("name") == cert_name
+        ]
+        print(f"Certificate: {namespace}/{cert_name}")
+        print(f"DNS name: {hostname}")
+        if not certs:
+            print("Ready: False (DoesNotExist)")
+            print("Secret present: False")
+            print("CertificateRequests: none\nOrders: none\nChallenges: none\nEvents: none")
+            result = 1
+            continue
+        cert = certs[0]
+        ready, reason, message = condition(cert)
+        spec, status = cert.get("spec", {}), cert.get("status", {})
+        issuer = spec.get("issuerRef", {})
+        issuer_name = issuer.get("name")
+        if not issuer_name:
+            result = 1
+        print(f"Ready: {ready} ({reason}) - {message}")
+        print(f"Issuer: {issuer.get('kind', 'Issuer')}/{issuer_name or 'MISSING'}")
+        issuer_resources = [
+            item
+            for item in resources["issuers"].get("items", [])
+            if item.get("metadata", {}).get("name") == issuer_name
+        ]
+        if issuer_resources:
+            issuer_ready, issuer_reason, _ = condition(issuer_resources[0])
+            print(f"Issuer Ready: {issuer_ready} ({issuer_reason})")
+        else:
+            print("Issuer Ready: Unknown (DoesNotExist)")
+            result = 1
+        dns_names = spec.get("dnsNames", [])
+        print(f"Certificate DNS names: {', '.join(map(str, dns_names)) or '-'}")
+        if hostname not in dns_names:
+            result = 1
+        secret_present = bool(
+            document.get("secrets", {}).get(namespace, {}).get(spec.get("secretName", ""))
+        )
+        print(f"Secret present: {secret_present}")
+        print(f"Revision: {status.get('revision', '-')}")
+        not_before = status.get("notBefore", "-")
+        not_after = status.get("notAfter", "-")
+        renewal = status.get("renewalTime", "-")
+        print(f"Validity: notBefore={not_before} notAfter={not_after} renewalTime={renewal}")
+        requests = [
+            x
+            for x in resources["requests"].get("items", [])
+            if x.get("metadata", {}).get("namespace") == namespace and cert_name in owner_names(x)
+        ]
+        request_names = {x.get("metadata", {}).get("name") for x in requests}
+        orders = [
+            x
+            for x in resources["orders"].get("items", [])
+            if x.get("metadata", {}).get("namespace") == namespace
+            and owner_names(x) & request_names
+        ]
+        order_names = {x.get("metadata", {}).get("name") for x in orders}
+        challenges = [
+            x
+            for x in resources["challenges"].get("items", [])
+            if x.get("metadata", {}).get("namespace") == namespace and owner_names(x) & order_names
+        ]
+        for label, items in (
+            ("CertificateRequests", requests),
+            ("Orders", orders),
+            ("Challenges", challenges),
+        ):
+            print(f"{label}:")
+            if not items:
+                print("  none")
+            for item in items:
+                name = item.get("metadata", {}).get("name", "unknown")
+                state = item.get("status", {}).get("state")
+                cstatus, creason, cmessage = condition(item)
+                active = state in {"pending", "processing"} or (
+                    state is None and cstatus == "Unknown"
+                )
+                activity = "active" if active else "stale/complete"
+                state_text = safe(state) or cstatus
+                print(
+                    f"  {name}: {activity} state={state_text} "
+                    f"reason={creason} message={cmessage}"
+                )
+        relevant = [
+            e
+            for e in events
+            if e.get("metadata", {}).get("namespace") == namespace
+            and e.get("involvedObject", {}).get("name")
+            in (
+                {cert_name}
+                | request_names
+                | order_names
+                | {x.get("metadata", {}).get("name") for x in challenges}
+            )
+        ]
+        print("Events:")
+        if not relevant:
+            print("  none")
+        for event in relevant[-10:]:
+            print(f"  {safe(event.get('reason')) or '-'}: {safe(event.get('message')) or '-'}")
+        print()
+        if ready != "True":
+            result = 1
+    return result
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/staging_cert_manager.sh
+++ b/scripts/staging_cert_manager.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXPECTED_CONTEXT=sugar-staging
+TIMEOUT="${SUGARKUBE_CERT_MANAGER_TIMEOUT:-300s}"
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 2; }
+need() { command -v "$1" >/dev/null 2>&1 || die "required command '$1' was not found"; }
+normalize_env() { [[ "${1#env=}" == staging ]] || die 'this lifecycle is staging-only; use env=staging'; }
+guard() { normalize_env "$1"; [[ "$(kubectl config current-context 2>/dev/null || true)" == "$EXPECTED_CONTEXT" ]] || die "refusing mutation: current context must be exactly ${EXPECTED_CONTEXT}"; }
+inventory() {
+  [[ -n "${SUGARKUBE_STAGING_CERTIFICATES:-}" ]] || die 'set SUGARKUBE_STAGING_CERTIFICATES to newline-separated namespace/certificate/hostname entries'
+  printf '%s\n' "$SUGARKUBE_STAGING_CERTIFICATES" | awk 'NF' | while IFS= read -r item; do
+    [[ "$item" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?/[a-z0-9]([-a-z0-9]*[a-z0-9])?/([A-Za-z0-9-]+\.)+[A-Za-z]{2,}$ ]] || die "invalid certificate inventory entry: ${item}"
+    printf '%s\n' "$item"
+  done
+}
+status() {
+  normalize_env "$1"; need kubectl; need python3
+  local tmp; tmp="$(mktemp -d -t sugarkube-cert-status.XXXXXX)"; trap 'rm -rf "${tmp:-}"' EXIT
+  for pair in 'certificates certificates' 'requests certificaterequests' 'orders orders.acme.cert-manager.io' 'challenges challenges.acme.cert-manager.io' 'issuers clusterissuers' 'events events'; do
+    read -r key kind <<<"$pair"; kubectl get "$kind" -A -o json >"$tmp/$key.json" || die "unable to read ${kind} (output suppressed)"
+  done
+  python3 - "$tmp" "$(inventory)" <<'PY' >"$tmp/input.json"
+import json,pathlib,subprocess,sys
+p=pathlib.Path(sys.argv[1]); inv=sys.argv[2].splitlines()
+resources={x.stem:json.loads(x.read_text()) for x in p.glob('*.json')}
+secrets={}
+for entry in inv:
+    ns,cert,_=entry.split('/',2)
+    found=[x for x in resources['certificates'].get('items',[]) if x.get('metadata',{}).get('namespace')==ns and x.get('metadata',{}).get('name')==cert]
+    name=found[0].get('spec',{}).get('secretName') if found else None
+    if name:
+        check=subprocess.run(['kubectl','-n',ns,'get','secret',name,'-o','name'],text=True,capture_output=True)
+        secrets.setdefault(ns,{})[name]=check.returncode==0
+print(json.dumps({'inventory':inv,'resources':resources,'secrets':secrets}))
+PY
+  python3 "$ROOT/scripts/staging_cert_manager.py" <"$tmp/input.json"
+}
+install_token() {
+  guard "$1"; need kubectl
+  local credential=''
+  if [[ -t 0 ]]; then read -r -s -p 'Cloudflare credential (input hidden): ' credential; printf '\n' >&2; else IFS= read -r credential || true; fi
+  [[ -n "$credential" ]] || die 'Cloudflare credential input was empty'
+  trap 'unset credential' EXIT
+  printf '%s' "$credential" | kubectl -n cert-manager create secret generic cloudflare-api-token --from-file=api-token=/dev/stdin --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+  unset credential
+  printf 'Installed cert-manager/cloudflare-api-token from hidden input/stdin; value not displayed.\n'
+}
+verify_authorization() {
+  guard "$1"
+  local issuer
+  issuer="$(kubectl get clusterissuer letsencrypt-production -o json)" || die 'unable to inspect letsencrypt-production'
+  ISSUER="$issuer" python3 - <<'PY'
+import json,os
+d=json.loads(os.environ['ISSUER']); conditions=d.get('status',{}).get('conditions',[])
+assert any(x.get('type')=='Ready' and x.get('status')=='True' for x in conditions), 'issuer is not Ready'
+ref=d['spec']['acme']['solvers'][0]['dns01']['cloudflare']['apiTokenSecretRef']
+assert ref=={'name':'cloudflare-api-token','key':'api-token'}, 'unexpected Cloudflare Secret reference'
+PY
+  kubectl -n cert-manager get secret cloudflare-api-token -o json | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d.get("type")=="Opaque"; assert set(d.get("data",{}))=={"api-token"}' || die 'Secret must be Opaque with exactly the api-token key'
+  status "$1"
+}
+recover() {
+  guard "$1"; need cmctl; need curl; need openssl
+  local target="${2:-}" ns cert host before after
+  [[ -n "$target" ]] || die 'pass one namespace/certificate/hostname inventory entry'
+  inventory | grep -Fxq -- "$target" || die 'certificate is not in SUGARKUBE_STAGING_CERTIFICATES'
+  IFS=/ read -r ns cert host <<<"$target"
+  before="$(kubectl -n "$ns" get certificate "$cert" -o json)" || die 'certificate does not exist; do not force renewal until status is understood'
+  cmctl renew -n "$ns" "$cert"
+  kubectl -n "$ns" wait --for=condition=Ready "certificate/$cert" --timeout="$TIMEOUT" || die 'bounded Ready wait failed; stop retries and inspect status'
+  kubectl -n "$ns" get secret "$(python3 -c 'import json,sys; print(json.load(sys.stdin)["spec"]["secretName"])' <<<"$before")" -o name >/dev/null
+  after="$(kubectl -n "$ns" get certificate "$cert" -o json)"
+  BEFORE="$before" AFTER="$after" python3 - <<'PY'
+import json,os
+b=json.loads(os.environ['BEFORE']).get('status',{}); a=json.loads(os.environ['AFTER']).get('status',{})
+assert any(x.get('type')=='Ready' and x.get('status')=='True' for x in a.get('conditions',[])), 'certificate is not Ready'
+assert a.get('revision') != b.get('revision') or a.get('notAfter') != b.get('notAfter'), 'revision and expiry did not change; stop rather than retrying'
+PY
+  for path in / /healthz /livez; do curl --fail --silent --show-error --max-time 15 --output /dev/null "https://${host}${path}"; done
+  openssl s_client -connect "${host}:443" -servername "$host" -verify_hostname "$host" -verify_return_error </dev/null 2>/dev/null | openssl x509 -noout -dates >/dev/null
+  status "$1"
+}
+case "${1:-}" in
+  status) status "${2:-}";;
+  install-token) install_token "${2:-}";;
+  verify-authorization) verify_authorization "${2:-}";;
+  recover) recover "${2:-}" "${3:-}";;
+  *) die 'usage: staging_cert_manager.sh status|install-token|verify-authorization|recover staging [namespace/certificate/hostname]';;
+esac

--- a/tests/scan_secrets_test.py
+++ b/tests/scan_secrets_test.py
@@ -65,6 +65,13 @@ def test_regex_scan_ignores_removed_lines(scan_secrets):
     assert not scan_secrets.regex_scan(diff)
 
 
+def test_regex_scan_allows_only_stdin_token_file_descriptor(scan_secrets):
+    safe = "+kubectl create secret --from-file=api-token=/dev/stdin"
+    unsafe = "+kubectl create secret --from-file=api-" + "token" + "=credential.txt"
+    assert not scan_secrets.regex_scan(["+++ b/script.sh", safe])
+    assert scan_secrets.regex_scan(["+++ b/script.sh", unsafe])
+
+
 def test_main_exit_codes(monkeypatch, scan_secrets):
     monkeypatch.setattr(scan_secrets, "run_ripsecrets", lambda diff_text: None)
     monkeypatch.setattr(
@@ -165,9 +172,7 @@ def test_run_ripsecrets_logs_to_stderr(monkeypatch, scan_secrets, capsys):
     assert "leak" in capsys.readouterr().err
 
 
-def test_run_ripsecrets_redacts_healthchecks_diagnostics(
-    monkeypatch, scan_secrets, capsys
-):
+def test_run_ripsecrets_redacts_healthchecks_diagnostics(monkeypatch, scan_secrets, capsys):
     monkeypatch.setattr(scan_secrets.shutil, "which", lambda _: "/bin/ripsecrets")
     uuid = "12345678" + "-1234-4123-8123-123456789abc"
     url = "https://" + "hc-ping.com/" + uuid

--- a/tests/test_staging_cert_manager.py
+++ b/tests/test_staging_cert_manager.py
@@ -1,0 +1,159 @@
+import json
+import os
+import pathlib
+import subprocess
+
+ROOT = pathlib.Path(__file__).parents[1]
+REPORT = ROOT / "scripts/staging_cert_manager.py"
+SCRIPT = ROOT / "scripts/staging_cert_manager.sh"
+JUSTFILE = (ROOT / "justfile").read_text()
+DOC = (ROOT / "docs/staging-cert-manager-recovery.md").read_text()
+
+
+def resource(name, namespace="demo", *, owner=None, state=None, message=None):
+    item = {"metadata": {"name": name, "namespace": namespace}, "status": {}}
+    if owner:
+        item["metadata"]["ownerReferences"] = [{"name": owner}]
+    if state:
+        item["status"]["state"] = state
+    if message:
+        item["status"]["conditions"] = [
+            {"type": "Ready", "status": "False", "reason": "Pending", "message": message}
+        ]
+    return item
+
+
+def document():
+    cert = resource("site-tls")
+    cert["spec"] = {
+        "secretName": "site-tls",
+        "dnsNames": ["staging.example.test"],
+        "issuerRef": {"kind": "ClusterIssuer", "name": "letsencrypt-production"},
+    }
+    cert["status"] = {
+        "revision": 2,
+        "notBefore": "2026-01-01Z",
+        "notAfter": "2026-04-01Z",
+        "renewalTime": "2026-03-01Z",
+        "conditions": [
+            {
+                "type": "Ready",
+                "status": "True",
+                "reason": "Ready",
+                "message": "Certificate is current",
+            }
+        ],
+    }
+    request = resource("site-tls-2", owner="site-tls")
+    order = resource("site-tls-2-abc", owner="site-tls-2", state="valid")
+    old = resource("old", owner="site-tls-2-abc", state="valid")
+    challenge = resource(
+        "challenge",
+        owner="site-tls-2-abc",
+        state="pending",
+        message="credential bearer-material",
+    )
+    return {
+        "inventory": ["demo/site-tls/staging.example.test"],
+        "secrets": {"demo": {"site-tls": True}},
+        "resources": {
+            "certificates": {"items": [cert]},
+            "requests": {"items": [request]},
+            "orders": {"items": [order]},
+            "challenges": {"items": [old, challenge]},
+            "issuers": {
+                "items": [
+                    {
+                        "metadata": {"name": "letsencrypt-production"},
+                        "status": {
+                            "conditions": [
+                                {
+                                    "type": "Ready",
+                                    "status": "True",
+                                    "reason": "ACMEAccountRegistered",
+                                }
+                            ]
+                        },
+                    }
+                ]
+            },
+            "events": {
+                "items": [
+                    {
+                        "metadata": {"namespace": "demo"},
+                        "involvedObject": {"name": "challenge"},
+                        "reason": "PresentError",
+                        "message": "Found no Zones",
+                    }
+                ]
+            },
+        },
+    }
+
+
+def test_redacted_report_and_active_stale_parsing():
+    raw = json.dumps(document())
+    result = subprocess.run([REPORT], input=raw, text=True, capture_output=True)
+    assert result.returncode == 0
+    assert "Revision: 2" in result.stdout
+    assert "Issuer Ready: True" in result.stdout
+    assert "Certificate DNS names: staging.example.test" in result.stdout
+    assert "Secret present: True" in result.stdout
+    assert "challenge: active state=pending" in result.stdout
+    assert "old: stale/complete state=valid" in result.stdout
+    assert "bearer-material" not in result.stdout
+    assert "[redacted]" in result.stdout
+    assert "Found no Zones" in result.stdout
+
+
+def test_missing_certificate_and_malformed_issuer_fail():
+    missing = document()
+    missing["inventory"] = ["demo/missing/staging.example.test"]
+    assert subprocess.run([REPORT], input=json.dumps(missing), text=True).returncode == 1
+    malformed = document()
+    malformed["resources"]["certificates"]["items"][0]["spec"]["issuerRef"] = {}
+    assert subprocess.run([REPORT], input=json.dumps(malformed), text=True).returncode == 1
+
+
+def test_mutation_guard_runs_before_commands(tmp_path):
+    kubectl = tmp_path / "kubectl"
+    calls = tmp_path / "calls"
+    kubectl.write_text(
+        f'#!/bin/sh\necho "$*" >>"{calls}"\n'
+        '[ "$*" = "config current-context" ] && echo production\n'
+    )
+    kubectl.chmod(0o755)
+    env = {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"}
+    result = subprocess.run(
+        [SCRIPT, "install-token", "staging"],
+        env=env,
+        input="do-not-log-this\n",
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode != 0
+    assert "exactly sugar-staging" in result.stderr
+    assert calls.read_text().splitlines() == ["config current-context"]
+    assert "do-not-log-this" not in result.stdout + result.stderr + calls.read_text()
+
+
+def test_command_structure_has_no_unsafe_token_arguments():
+    source = SCRIPT.read_text()
+    assert "--from-file=api-token=/dev/stdin" in source
+    assert "--from-literal=api-token" not in source
+    recipe = JUSTFILE.split("cert-manager-cloudflare-token-secret:", 1)[1].split(
+        "# Apply non-Flux", 1
+    )[0]
+    assert "--from-literal" not in recipe
+    assert 'cmctl renew -n "$ns" "$cert"' in source
+    assert '--timeout="$TIMEOUT"' in source
+    assert '-verify_hostname "$host" -verify_return_error' in source
+
+
+def test_docs_define_generic_inventory_permissions_and_boundaries():
+    assert "SUGARKUBE_STAGING_CERTIFICATES" in DOC
+    assert "Zone / Zone / Read" in DOC and "Zone / DNS / Edit" in DOC
+    for zone in ("token.place", "danielsmith.io", "jobbot3000.tech"):
+        assert zone in DOC
+    assert "duplicate-certificate" in DOC
+    assert "must not be changed" in DOC


### PR DESCRIPTION
### Motivation

- Staging Certificates for `staging.danielsmith.io` and `staging.jobbot3000.tech` were failing DNS‑01 Challenges with Cloudflare `Found no Zones` errors while an operator-managed Cloudflare API token and documented workflows exposed the token unsafely.  A guarded, app-agnostic operator workflow and redacted status reporter were required to diagnose and recover without leaking credentials or hitting ACME limits. 
- The runbook must be staging-only, preserve Flux/production boundaries, avoid touching Cloudflare dashboard/tunnel transport, and provide one-certificate-at-a-time recovery with bounded waits and explicit rollback guidance. 
- Tests and secret-scanning need deterministic offline coverage to prevent regressions (redaction, safe stdin usage, inventory validation, active/stale parsing, and mutation guards). 

### Description

- Added a deterministic redacted cert-manager status renderer `scripts/staging_cert_manager.py` that reports Certificates, issuer readiness, Secret presence, revision, validity/renewal times, CertificateRequests/Orders/Challenges, and relevant events while redacting credential-like text. 
- Added a staging-only operator script `scripts/staging_cert_manager.sh` providing exact-context guards (`sugar-staging`), an inventory validator via `SUGARKUBE_STAGING_CERTIFICATES`, a hidden-input/stdin token installation (`install-token`), structural issuer/Secret checks (`verify-authorization`), and a bounded one-certificate recovery workflow (`recover`) that runs `cmctl renew`, requires serving Secret creation and revision/expiry change, and performs strict external TLS verification. 
- Replaced the unsafe `token=<value>` Just recipe with a compatibility shim that invokes the guarded installer and added Just recipes: `staging-cert-status`, `staging-cert-token-install`, `staging-cert-authorization-verify`, and `staging-cert-recover`. 
- Added a runbook `docs/staging-cert-manager-recovery.md` documenting observed staging state, required Cloudflare permissions (`Zone / Zone / Read` and `Zone / DNS / Edit`), explicit zone scope (`token.place`, `danielsmith.io`, `jobbot3000.tech`), safe installation guidance (hidden prompt or stdin), one-at-a-time recovery, rollback, and ACME-rate-limit cautions. 
- Extended the repository secret scanner to allow the safe `--from-file=api-token=/dev/stdin` pattern while continuing to reject literal or file-based token arguments, and added offline tests: `tests/test_staging_cert_manager.py` and `tests/scan_secrets_test.py` to cover redaction, parsing, guards, safe command patterns, and behavior on missing/malformed resources. 

### Testing

- Ran unit/cli tests for the new tooling: `python3 -m pytest -q tests/scan_secrets_test.py tests/test_staging_cert_manager.py` — 26 passed. 
- Static checks and linters: `python3 -m flake8 scripts/scan-secrets.py scripts/staging_cert_manager.py tests/scan_secrets_test.py tests/test_staging_cert_manager.py` passed, and `python3 -m black --check scripts/staging_cert_manager.py tests/test_staging_cert_manager.py` passed; `bash -n scripts/staging_cert_manager.sh` passed. 
- Documentation and repo checks: `pyspelling -c .spellcheck.yaml` passed and `linkchecker --no-warnings README.md docs/` completed with no errors. 
- Justfile integration: `just --unstable --fmt --check` completed for the modified recipes. 
- Secret-scan and pre-commit hooks: `git diff --cached | ./scripts/scan-secrets.py` passed and targeted pre-commit hooks (`trailing-whitespace`, `end-of-file-fixer`) were applied to changed files. 
- Broader test suite: `python3 -m pytest -q` ran (2,004 passed, 19 skipped) but one environment-limited failure remains because `helm` is not installed in this environment (`tests/test_monitoring_blackbox.py::test_lifecycle_network_policy_is_exact_and_chart_render_backed`), which is unrelated to these changes. 

Notes and residual risks

- No live cluster or Cloudflare dashboard was contacted or mutated by this PR; the runbook prescribes manual dashboard review and one-at-a-time controlled recoveries. 
- Cloudflare authorization cannot be proven offline; successful DNS‑01 challenges and Cloudflare dashboard verification remain required operator steps. 
- The workflow intentionally bounds waits and avoids destructive deletions to reduce the risk of hitting Let’s Encrypt rate limits; operators must follow the documented one-at-a-time sequence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ad0045960832f8b4f2c419a353e03)