### PR TITLE
Require DSPACE source-integrity and chat gates

### DIFF
--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -1,5 +1,23 @@
 # Sugarkube app deployment contract
 
+## DSPACE promotion verification
+
+DSPACE is the only application with an additional source-integrity gate. Every
+standard deploy, redeploy, promotion, and compatibility wrapper requires an
+executable `smoke_runner`. Production also requires `staging_evidence`: a
+finalized staging record whose application version, full source revision,
+image tag/digest, chart version/digest, semantic tag, and approved default
+provider equal the production candidate. Approval metadata may differ.
+
+The enforced order is finalized staging evidence validation, live staging
+Helm/replica/runtime/frontend/chat verification, production preflight and
+render, evidence reservation, Helm mutation, production verification, then
+evidence finalization. Verification is read-only and uses Kubernetes API pod
+proxies. Finalized records add bounded identity, replica-agreement, provider,
+and chat checks without storing HTTP bodies, child output, browser state,
+credentials, or request data. Historical schema-version-1 finalized records
+remain valid and available to the explicit rollback path.
+
 Sugarkube now exposes a generic app deployment surface where each app is
 identified by a small local config file and deployed with shared `just` recipes.
 This page is the contract that app repositories and local operator configs should

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -1,5 +1,56 @@
 # democratized.space (dspace) on Sugarkube
 
+## Mandatory source-integrity and `/chat` gate
+
+Standard staging and production operations require the DSPACE checkout's
+non-destructive remote smoke runner. In that checkout, run `pnpm install` and
+`pnpm exec playwright install chromium`, then point Sugarkube at the executable
+itself (not at a shell command):
+
+```bash
+DSPACE_SMOKE_RUNNER="$HOME/dspace/scripts/run-remote-chat-smoke.mjs"
+
+just dspace-release-verify \
+  env=staging \
+  manifest=deployment-evidence/dspace/staging/<finalized-record>.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER"
+```
+
+The verifier reads the public host and token.place origin/model from the exact
+environment values chain, checks every live DSPACE replica, and proves the
+public build identity, frontend marker, and isolated `/chat` journey. It
+invokes the runner directly and discards its output. The runner mocks provider
+transport: real token.place or OpenAI credentials are neither required nor
+accepted. For an OpenAI-default manifest, token.place arguments are omitted;
+for a token.place-default manifest, both values come from the selected chain.
+
+Deploy staging with its approved candidate to create finalized evidence:
+
+```bash
+just app-deploy app=dspace env=staging tag=main-REPLACE_SHORTSHA \
+  manifest=deployment-candidates/dspace/staging.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER"
+```
+
+Production promotion additionally requires that finalized staging record. The
+live staging gate runs before production rendering, evidence reservation, or
+mutation and rejects stale Helm revisions or differing immutable coordinates:
+
+```bash
+just app-promote-prod \
+  app=dspace \
+  tag=main-REPLACE_SHORTSHA \
+  manifest=deployment-candidates/dspace/prod.json \
+  staging_evidence=deployment-evidence/dspace/staging/<finalized-record>.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER"
+```
+
+After mutation the same checks run before the record is finalized under
+`deployment-evidence/dspace/<environment>/`. Failure leaves a post-mutation
+reservation for the existing reconciliation workflow, writes no success
+record, and never automatically retries or rolls back. Standalone production
+verification uses the same command with `env=prod`.
+
 This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugarkube. The generic `just app-*` recipes are the preferred future path. The `dspace-oci-*` recipes remain compatibility shims and are scheduled for later removal only after the generic flow has been exercised across routine releases.
 
 ## Artifact model

--- a/justfile
+++ b/justfile
@@ -1664,24 +1664,44 @@ app-config app env='staging' config='':
       --config {{ quote(config) }}
 
 # DSPACE-only fail-closed recovery from previously finalized immutable evidence.
-dspace-manifest-rollback env manifest evidence verifier confirm='' config='' kubeconfig='':
+dspace-manifest-rollback env manifest evidence smoke_runner verifier='' confirm='' config='' kubeconfig='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
     kubeconfig_path={{ quote(kubeconfig) }}
     if [ -z "${kubeconfig_path}" ]; then
       kubeconfig_path="${KUBECONFIG:-${HOME}/.kube/config}"
     fi
+    verifier_path={{ quote(verifier) }}
+    [ -n "${verifier_path}" ] || verifier_path="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py"
     python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py" \
       --environment {{ quote(env) }} \
       --manifest {{ quote(manifest) }} \
       --evidence {{ quote(evidence) }} \
-      --verifier {{ quote(verifier) }} \
+      --verifier "${verifier_path}" \
+      --smoke-runner {{ quote(smoke_runner) }} \
       --confirm {{ quote(confirm) }} \
       --config {{ quote(config) }} \
       --kubeconfig "${kubeconfig_path}"
 
+# Read-only DSPACE runtime, replica, frontend, and isolated /chat proof.
+dspace-release-verify env manifest smoke_runner config='' kubeconfig='' compare_manifest='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    kubeconfig_path={{ quote(kubeconfig) }}
+    if [ -z "${kubeconfig_path}" ]; then
+      export KUBECONFIG="${HOME}/.kube/config"
+      just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env {{ quote(env) }}
+      kubeconfig_path="${KUBECONFIG}"
+    fi
+    command=("{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" verify
+      --environment {{ quote(env) }} --release dspace --namespace dspace
+      --manifest {{ quote(manifest) }} --smoke-runner {{ quote(smoke_runner) }}
+      --config {{ quote(config) }} --kubeconfig "${kubeconfig_path}")
+    [ -z {{ quote(compare_manifest) }} ] || command+=(--compare-manifest {{ quote(compare_manifest) }})
+    "${command[@]}"
+
 # Generic immutable-tag app deploy backed by docs/examples/apps/*.env or local app configs.
-app-deploy app env='staging' tag='' config='' manifest='' evidence='':
+app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1697,11 +1717,21 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
     evidence_output={{ quote(evidence) }}
     while [ "${release_manifest#manifest=}" != "${release_manifest}" ]; do release_manifest="${release_manifest#manifest=}"; done
     while [ "${evidence_output#evidence=}" != "${evidence_output}" ]; do evidence_output="${evidence_output#evidence=}"; done
+    if [ "${SUGARKUBE_APP}" = dspace ] && [ "${SUGARKUBE_ENV}" = prod ]; then
+      if [ -z {{ quote(staging_evidence) }} ] || [ -z {{ quote(smoke_runner) }} ]; then
+        echo "ERROR: staging_evidence=<finalized-staging.json> and smoke_runner=<executable> are required for DSPACE prod." >&2
+        exit 2
+      fi
+      just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify \
+        env=staging manifest={{ quote(staging_evidence) }} smoke_runner={{ quote(smoke_runner) }} \
+        compare_manifest="${release_manifest}"
+    fi
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
       if [ -z "${release_manifest}" ]; then
         echo "ERROR: manifest=<approved-candidate.json> is required for DSPACE ${SUGARKUBE_ENV}." >&2
         exit 2
       fi
+      if [ -z {{ quote(smoke_runner) }} ]; then echo "ERROR: smoke_runner=<executable> is required for DSPACE." >&2; exit 2; fi
       chart_version="${SUGARKUBE_VERSION:-}"
       if [ -z "${chart_version}" ]; then
         chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -n1)"
@@ -1751,16 +1781,22 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='':
     fi
     [ -z "${mutation_marker:-}" ] || rm -f "${mutation_marker}"
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
+      runtime_proof="$(mktemp)"
+      trap 'rm -f "${runtime_proof:-}"' EXIT
+      just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify \
+        env="${SUGARKUBE_ENV}" manifest="${release_manifest}" smoke_runner={{ quote(smoke_runner) }} \
+        config="${SUGARKUBE_CONFIG_PATH}" kubeconfig="${KUBECONFIG}" >"${runtime_proof}"
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize \
         --manifest "${release_manifest}" --output "${evidence_output}" \
         --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" \
         --chart-version "${chart_version}" --kubeconfig "${KUBECONFIG}" \
         --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
-        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}"
+        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}" \
+        --runtime-verification "${runtime_proof}"
     fi
 
 # Generic upgrade-only app redeploy backed by app config files.
-app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
+app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1776,8 +1812,13 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
     evidence_output={{ quote(evidence) }}
     while [ "${release_manifest#manifest=}" != "${release_manifest}" ]; do release_manifest="${release_manifest#manifest=}"; done
     while [ "${evidence_output#evidence=}" != "${evidence_output}" ]; do evidence_output="${evidence_output#evidence=}"; done
+    if [ "${SUGARKUBE_APP}" = dspace ] && [ "${SUGARKUBE_ENV}" = prod ]; then
+      if [ -z {{ quote(staging_evidence) }} ] || [ -z {{ quote(smoke_runner) }} ]; then echo "ERROR: staging_evidence and smoke_runner are required for DSPACE prod." >&2; exit 2; fi
+      just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify env=staging manifest={{ quote(staging_evidence) }} smoke_runner={{ quote(smoke_runner) }} compare_manifest="${release_manifest}"
+    fi
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
       if [ -z "${release_manifest}" ]; then echo "ERROR: manifest=<approved-candidate.json> is required for DSPACE ${SUGARKUBE_ENV}." >&2; exit 2; fi
+      if [ -z {{ quote(smoke_runner) }} ]; then echo "ERROR: smoke_runner=<executable> is required for DSPACE." >&2; exit 2; fi
       chart_version="${SUGARKUBE_VERSION:-}"
       if [ -z "${chart_version}" ]; then chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -n1)"; fi
       chart_coordinate="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" preflight --manifest "${release_manifest}" --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" \
@@ -1821,14 +1862,17 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='':
     fi
     [ -z "${mutation_marker:-}" ] || rm -f "${mutation_marker}"
     if [ "${SUGARKUBE_APP}" = dspace ] && { [ "${SUGARKUBE_ENV}" = staging ] || [ "${SUGARKUBE_ENV}" = prod ]; }; then
+      runtime_proof="$(mktemp)"
+      trap 'rm -f "${runtime_proof:-}"' EXIT
+      just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify env="${SUGARKUBE_ENV}" manifest="${release_manifest}" smoke_runner={{ quote(smoke_runner) }} config="${SUGARKUBE_CONFIG_PATH}" kubeconfig="${KUBECONFIG}" >"${runtime_proof}"
       python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" finalize --manifest "${release_manifest}" --output "${evidence_output}" \
         --environment "${SUGARKUBE_ENV}" --image-tag "${SUGARKUBE_TAG}" --chart-version "${chart_version}" --kubeconfig "${KUBECONFIG}" \
         --release "${SUGARKUBE_RELEASE}" --namespace "${SUGARKUBE_NAMESPACE}" \
-        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}"
+        --chart-ref "${SUGARKUBE_CHART}" --reservation "${evidence_reservation}" --runtime-verification "${runtime_proof}"
     fi
 
 # Promote an app to prod with an explicit immutable tag, or the configured prod tag file.
-app-promote-prod app tag='' config='' manifest='' evidence='':
+app-promote-prod app tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1844,6 +1888,8 @@ app-promote-prod app tag='' config='' manifest='' evidence='':
       app="${SUGARKUBE_APP}" env=prod tag="${SUGARKUBE_TAG}" config="${SUGARKUBE_CONFIG_PATH}")
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Show the pinned chart version and whether a newer semver chart appears published.
@@ -1969,17 +2015,19 @@ app-cors-verify app env='staging' config='' origin='https://cors-smoke.invalid' 
 #
 
 # Use this for steady-state release validation flows where explicit image pinning matters.
-dspace-oci-deploy env='staging' tag='' manifest='' evidence='':
+dspace-oci-deploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
     delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-deploy app=dspace env={{ quote(env) }} tag={{ quote(tag) }})
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Use this for optional canary/smoke testing before or alongside apex promotion workflows.
-dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='':
+dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1987,12 +2035,14 @@ dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='':
       "{{ justfile_directory() }}/docs/examples/apps/dspace-prod-subdomain.env")
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Promote dspace to production apex (democratized.space) using immutable tags.
 
 # If tag is omitted, this reads the pinned value from docs/apps/dspace.prod.tag.
-dspace-oci-promote-prod tag='' manifest='' evidence='':
+dspace-oci-promote-prod tag='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -2006,16 +2056,20 @@ dspace-oci-promote-prod tag='' manifest='' evidence='':
     delegate=(just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy env=prod tag="${SUGARKUBE_TAG}")
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Fast redeploy of dspace from GHCR (emergency mutable-tag refresh).
-dspace-oci-redeploy env='staging' tag='' manifest='' evidence='':
+dspace-oci-redeploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
     delegate=(just --justfile "{{ justfile_directory() }}/justfile" app-redeploy app=dspace env={{ quote(env) }} tag={{ quote(tag) }})
     [ -z {{ quote(manifest) }} ] || delegate+=(manifest={{ quote(manifest) }})
     [ -z {{ quote(evidence) }} ] || delegate+=(evidence={{ quote(evidence) }})
+    [ -z {{ quote(staging_evidence) }} ] || delegate+=(staging_evidence={{ quote(staging_evidence) }})
+    [ -z {{ quote(smoke_runner) }} ] || delegate+=(smoke_runner={{ quote(smoke_runner) }})
     "${delegate[@]}"
 
 # Dump dspace and Traefik logs for debugging HTTP 500s.

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -740,6 +740,19 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             "--provider",
             target["expectedDefaultChatProvider"],
         ]
+        if getattr(args, "smoke_runner", None) is not None:
+            verifier_command.extend(
+                [
+                    "--manifest",
+                    str(args.manifest),
+                    "--smoke-runner",
+                    str(args.smoke_runner),
+                    "--config",
+                    args.config,
+                    "--kubeconfig",
+                    args.kubeconfig,
+                ]
+            )
         failed_stage = "runtime-verification"
         verifier = validate_verifier_result(
             json_command(runner, verifier_command, "runtime verifier"), target, args.environment
@@ -790,8 +803,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "status": observed_info.get("status"),
                 "chartName": observed_chart.get("name"),
                 "chartVersion": chart_version(observed_helm),
-                "invocationDescriptionMatches": observed_info.get("description")
-                == description,
+                "invocationDescriptionMatches": observed_info.get("description") == description,
             }
         except Exception:
             diagnostics["helm"] = "unavailable"
@@ -823,6 +835,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--manifest", type=Path, required=True)
     parser.add_argument("--evidence", type=Path, required=True)
     parser.add_argument("--verifier", type=Path, required=True)
+    parser.add_argument("--smoke-runner", type=Path)
     parser.add_argument("--confirm", default="")
     parser.add_argument("--config", default="")
     parser.add_argument("--kubeconfig", default=str(Path.home() / ".kube" / "config-sugarkube"))

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -69,6 +69,14 @@ FINAL_FIXED_CHECKS = {
     "podImageCoordinates",
     "podImageDigests",
 }
+RUNTIME_CHECKS = {
+    "runtimeIdentity",
+    "frontendIdentity",
+    "replicaAgreement",
+    "publicDirectAgreement",
+    "defaultProvider",
+    "remoteChatSmoke",
+}
 PLATFORM_CHECK_RE = re.compile(r"^imagePlatformSourceRevision\[(0|[1-9][0-9]*)\]$")
 POD_SETTLE_TIMEOUT_SECONDS = 60.0
 POD_SETTLE_INTERVAL_SECONDS = 2.0
@@ -206,15 +214,13 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
             platform_match = PLATFORM_CHECK_RE.fullmatch(check)
             if platform_match:
                 platform_indices.append(int(platform_match.group(1)))
-            elif check not in FINAL_FIXED_CHECKS:
+            elif check not in FINAL_FIXED_CHECKS | RUNTIME_CHECKS:
                 raise ManifestError(f"unknown verification result: {check}")
         missing = sorted(FINAL_FIXED_CHECKS - checks)
         if missing:
             raise ManifestError("missing verification results: " + ", ".join(missing))
         if sorted(platform_indices) != list(range(len(platform_indices))):
-            raise ManifestError(
-                "image platform verification indices must be contiguous from zero"
-            )
+            raise ManifestError("image platform verification indices must be contiguous from zero")
         if not platform_indices:
             raise ManifestError("at least one image platform verification result is required")
     return value
@@ -235,9 +241,7 @@ def _write_new(path: Path, value: dict[str, Any]) -> None:
         try:
             os.link(temporary, path)
         except FileExistsError as exc:
-            raise ManifestError(
-                f"refusing to overwrite existing record: {path}"
-            ) from exc
+            raise ManifestError(f"refusing to overwrite existing record: {path}") from exc
         _sync_directory(path.parent)
     finally:
         Path(temporary).unlink(missing_ok=True)
@@ -290,9 +294,7 @@ def reserve(
     try:
         fd = os.open(sidecar, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     except FileExistsError as exc:
-        raise ManifestError(
-            f"evidence destination is already reserved: {sidecar}"
-        ) from exc
+        raise ManifestError(f"evidence destination is already reserved: {sidecar}") from exc
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as stream:
             stream.write(_canonical(metadata))
@@ -328,9 +330,7 @@ def verify_reservation(
     if not secrets.compare_digest(
         json.dumps(metadata, sort_keys=True), json.dumps(expected, sort_keys=True)
     ):
-        raise ManifestError(
-            "reservation ownership or deployment coordinates do not match"
-        )
+        raise ManifestError("reservation ownership or deployment coordinates do not match")
     if normalized.exists():
         raise ManifestError(f"refusing to overwrite existing record: {normalized}")
     return sidecar
@@ -548,6 +548,7 @@ def finalize(
     cluster_environment: str,
     invocation_description: str,
     expected_image_coordinate: str | None = None,
+    runtime_verification: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     validate(value, False)
     selected = {
@@ -668,7 +669,10 @@ def finalize(
         {
             "check": "selectedCoordinates",
             "passed": True,
-            "details": f"environment={environment}; imageTag={image_tag}; chartVersion={chart_version}",
+            "details": (
+                f"environment={environment}; imageTag={image_tag}; "
+                f"chartVersion={chart_version}"
+            ),
         },
         {
             "check": "clusterEnvironment",
@@ -689,8 +693,7 @@ def finalize(
             # Helm metadata proves name/version, not immutable OCI content. The
             # guarded mutation therefore installs this approved digest directly.
             "details": (
-                f"chart=dspace; version={chart_version}; "
-                f"coordinate={chart_coordinate(value)}"
+                f"chart=dspace; version={chart_version}; " f"coordinate={chart_coordinate(value)}"
             ),
         },
         {
@@ -709,6 +712,64 @@ def finalize(
             "details": "every running pod imageID matched approved image digest",
         },
     ]
+    if runtime_verification is not None:
+        expected_runtime = {
+            "schemaVersion": 1,
+            "environment": environment,
+            "release": release,
+            "namespace": namespace,
+            "applicationVersion": value["applicationVersion"],
+            "runtimeSourceRevision": value["sourceRevision"],
+            "frontendSourceRevision": value["sourceRevision"],
+            "defaultProvider": value["expectedDefaultChatProvider"],
+        }
+        if set(runtime_verification) != {
+            *expected_runtime,
+            "journeys",
+        } or any(
+            runtime_verification.get(key) != wanted for key, wanted in expected_runtime.items()
+        ):
+            raise ManifestError("runtime verification result does not match approved release")
+        journeys = runtime_verification.get("journeys")
+        if not isinstance(journeys, list) or not any(
+            item == {"name": "/chat", "passed": True} for item in journeys
+        ):
+            raise ManifestError("runtime verification did not prove /chat")
+        count = len(pods)
+        results.extend(
+            (
+                {
+                    "check": "runtimeIdentity",
+                    "passed": True,
+                    "details": "approved application version and full source revision reported",
+                },
+                {
+                    "check": "frontendIdentity",
+                    "passed": True,
+                    "details": "approved full source revision reported by frontend marker",
+                },
+                {
+                    "check": "replicaAgreement",
+                    "passed": True,
+                    "details": f"{count} serving replica(s) reported one approved identity",
+                },
+                {
+                    "check": "publicDirectAgreement",
+                    "passed": True,
+                    "details": "public and every direct-origin identity agreed",
+                },
+                {
+                    "check": "defaultProvider",
+                    "passed": True,
+                    "details": f"approved default provider={value['expectedDefaultChatProvider']}",
+                },
+                {
+                    "check": "remoteChatSmoke",
+                    "passed": True,
+                    "details": "isolated remote /chat journey passed without provider traffic",
+                },
+            )
+        )
     result = dict(value)
     result.update(
         recordType="final",
@@ -755,9 +816,8 @@ def main(argv: list[str] | None = None) -> int:
     finish.add_argument("--image-ref", default=IMAGE_REF)
     finish.add_argument("--chart-ref", default=CHART_REF)
     finish.add_argument("--reservation", required=True)
-    finish.add_argument(
-        "--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras")
-    )
+    finish.add_argument("--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
+    finish.add_argument("--runtime-verification", type=Path)
     available = sub.add_parser("check-output")
     available.add_argument("--output", type=Path, required=True)
     destination = sub.add_parser("evidence-path")
@@ -885,6 +945,9 @@ def main(argv: list[str] | None = None) -> int:
                 namespace=args.namespace,
                 cluster_environment=cluster_environment,
                 invocation_description=invocation_description,
+                runtime_verification=(
+                    _object(args.runtime_verification) if args.runtime_verification else None
+                ),
             )
             sidecar = verify_reservation(
                 args.output,
@@ -909,19 +972,16 @@ def main(argv: list[str] | None = None) -> int:
                     metadata.get("version"),
                 )
 
-            if (
-                binding_fields(settled_helm) != binding_fields(helm)
-                or binding_fields(stable_helm) != binding_fields(helm)
-            ):
+            if binding_fields(settled_helm) != binding_fields(helm) or binding_fields(
+                stable_helm
+            ) != binding_fields(helm):
                 raise ManifestError("Helm release changed during evidence collection")
             _write_new(args.output, result)
             sidecar.unlink()
             _sync_directory(args.output.expanduser().resolve(strict=False).parent)
         elif args.command == "check-output":
             if args.output.exists():
-                raise ManifestError(
-                    f"refusing to overwrite existing record: {args.output}"
-                )
+                raise ManifestError(f"refusing to overwrite existing record: {args.output}")
         elif args.command == "reserve":
             sys.stdout.write(
                 reserve(

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Prove DSPACE identity and chat behavior without mutating the cluster.
+
+The JSON written by this program is intentionally small.  In particular, HTTP
+and child-process content is never copied into diagnostics or evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import app_config  # noqa: E402
+from scripts import dspace_release_manifest as release_manifest  # noqa: E402
+
+CAPABILITIES = (
+    "applicationVersion",
+    "runtimeSourceRevision",
+    "frontendSourceRevision",
+    "defaultProvider",
+    "publicJourneys",
+)
+RESULT_FIELDS = (
+    "schemaVersion",
+    "environment",
+    "release",
+    "namespace",
+    "applicationVersion",
+    "runtimeSourceRevision",
+    "frontendSourceRevision",
+    "defaultProvider",
+    "journeys",
+)
+REVISION_META_RE = re.compile(
+    r'<meta\s+[^>]*name=["\']dspace-build-revision["\'][^>]*content=["\']([^"\']+)["\'][^>]*>',
+    re.IGNORECASE,
+)
+REVISION_META_RE_REVERSED = re.compile(
+    r'<meta\s+[^>]*content=["\']([^"\']+)["\'][^>]*name=["\']dspace-build-revision["\'][^>]*>',
+    re.IGNORECASE,
+)
+
+
+class VerificationError(ValueError):
+    """A safe, classified runtime verification failure."""
+
+
+Runner = Callable[[list[str]], str]
+
+
+def run(command: list[str]) -> str:
+    completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    if completed.returncode:
+        raise VerificationError(f"provider/chat smoke: command failed: {command[0]}")
+    return completed.stdout
+
+
+def _json_command(runner: Runner, command: list[str], category: str) -> dict[str, Any]:
+    try:
+        value = json.loads(_command(runner, command, category))
+    except json.JSONDecodeError as exc:
+        raise VerificationError(f"{category}: command did not return valid JSON") from exc
+    if not isinstance(value, dict):
+        raise VerificationError(f"{category}: command returned an invalid object")
+    return value
+
+
+def _command(runner: Runner, command: list[str], category: str) -> str:
+    try:
+        return runner(command)
+    except Exception as exc:
+        raise VerificationError(f"{category}: command failed") from exc
+
+
+class SameOriginRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        if urllib.parse.urlsplit(newurl)[:2] != urllib.parse.urlsplit(req.full_url)[:2]:
+            raise VerificationError("public identity: redirect changed origin")
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def fetch(url: str, category: str) -> bytes:
+    try:
+        with urllib.request.build_opener(SameOriginRedirect()).open(url, timeout=15) as response:
+            return response.read(1024 * 1024 + 1)
+    except VerificationError:
+        raise
+    except (OSError, urllib.error.URLError) as exc:
+        raise VerificationError(f"{category}: endpoint is unreachable") from exc
+
+
+def _identity(body: bytes, expected_version: str, expected_revision: str, category: str) -> None:
+    try:
+        value = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise VerificationError(f"{category}: invalid build identity") from exc
+    expected = {
+        "version": expected_version,
+        "revision": expected_revision,
+        "shortRevision": expected_revision[:7],
+    }
+    if not isinstance(value, dict) or any(
+        value.get(key) != wanted for key, wanted in expected.items()
+    ):
+        raise VerificationError(f"{category}: version or revision mismatch")
+    image = value.get("image")
+    if image is not None and not isinstance(image, str):
+        raise VerificationError(f"{category}: invalid runtime image coordinate")
+
+
+def _frontend(body: bytes, expected_revision: str, category: str) -> None:
+    try:
+        html = body.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise VerificationError(f"{category}: invalid frontend marker") from exc
+    match = REVISION_META_RE.search(html) or REVISION_META_RE_REVERSED.search(html)
+    if not match or match.group(1) != expected_revision:
+        raise VerificationError(f"{category}: frontend revision mismatch")
+
+
+def _values_expectations(paths: list[Path]) -> dict[str, str]:
+    """Read the three non-secret scalar contracts from the ordered values chain."""
+    result: dict[str, str] = {}
+    for path in paths:
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            raise VerificationError("manifest/evidence mismatch: cannot read values chain") from exc
+        section = ""
+        env_name: str | None = None
+        for raw in lines:
+            line = raw.split("#", 1)[0].rstrip()
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if len(line) == len(line.lstrip()) and stripped.endswith(":"):
+                section = stripped[:-1]
+                env_name = None
+                continue
+            if section == "ingress" and re.fullmatch(r"host:\s*.+", stripped):
+                result["host"] = stripped.split(":", 1)[1].strip().strip("\"'")
+            if section == "env":
+                name = re.fullmatch(r"-\s*name:\s*(\S+)", stripped)
+                if name:
+                    env_name = name.group(1).strip("\"'")
+                value = re.fullmatch(r"value:\s*(.+)", stripped)
+                if value and env_name in {
+                    "DSPACE_TOKEN_PLACE_URL",
+                    "DSPACE_TOKEN_PLACE_CHAT_MODEL",
+                }:
+                    result[env_name] = value.group(1).strip().strip("\"'")
+    return result
+
+
+def expectations(config: dict[str, str], provider: str) -> tuple[str, str | None, str | None]:
+    paths = []
+    for raw in config["SUGARKUBE_VALUES"].split(","):
+        path = Path(raw.strip()).expanduser()
+        paths.append(path if path.is_absolute() else REPO_ROOT / path)
+    values = _values_expectations(paths)
+    host = values.get("host")
+    if not isinstance(host, str) or not host:
+        raise VerificationError("manifest/evidence mismatch: rendered ingress host is missing")
+    if provider == "openai":
+        return host, None, None
+    origin = values.get("DSPACE_TOKEN_PLACE_URL")
+    model = values.get("DSPACE_TOKEN_PLACE_CHAT_MODEL")
+    if not all(isinstance(value, str) and value for value in (origin, model)):
+        raise VerificationError("manifest/evidence mismatch: token.place expectations are missing")
+    return host, origin, model
+
+
+def _pods(runner: Runner, kubeconfig: str, namespace: str, release: str) -> list[dict[str, Any]]:
+    selector = f"app.kubernetes.io/name=dspace,app.kubernetes.io/instance={release}"
+    value = _json_command(
+        runner,
+        [
+            "kubectl",
+            "--kubeconfig",
+            kubeconfig,
+            "-n",
+            namespace,
+            "get",
+            "pods",
+            "-l",
+            selector,
+            "-o",
+            "json",
+        ],
+        "pod/replica identity",
+    )
+    items = value.get("items")
+    if not isinstance(items, list) or not items:
+        raise VerificationError("pod/replica identity: no serving replicas")
+    return items
+
+
+def verify(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
+    manifest = release_manifest.validate(release_manifest._object(args.manifest), None)
+    if manifest["environment"] != args.environment:
+        raise VerificationError("manifest/evidence mismatch: environment differs")
+    expected = {
+        "applicationVersion": args.application_version or manifest["applicationVersion"],
+        "sourceRevision": args.source_revision or manifest["sourceRevision"],
+        "provider": args.provider or manifest["expectedDefaultChatProvider"],
+    }
+    for field, key in (
+        ("applicationVersion", "applicationVersion"),
+        ("sourceRevision", "sourceRevision"),
+    ):
+        if (
+            args.__dict__.get(
+                "application_version" if field == "applicationVersion" else "source_revision"
+            )
+            and expected[field] != manifest[key]
+        ):
+            raise VerificationError("manifest/evidence mismatch: argv expectation differs")
+    if args.provider and args.provider != manifest["expectedDefaultChatProvider"]:
+        raise VerificationError("manifest/evidence mismatch: provider differs")
+    if args.compare_manifest:
+        comparison = release_manifest.validate(
+            release_manifest._object(args.compare_manifest), None
+        )
+        coordinates = (
+            "applicationVersion",
+            "sourceRevision",
+            "imageTag",
+            "imageDigest",
+            "chartVersion",
+            "chartDigest",
+            "semanticTag",
+            "expectedDefaultChatProvider",
+        )
+        if any(manifest[field] != comparison[field] for field in coordinates):
+            raise VerificationError(
+                "manifest/evidence mismatch: immutable staging and production coordinates differ"
+            )
+    smoke = args.smoke_runner.expanduser()
+    if not smoke.is_file() or not os.access(smoke, os.X_OK):
+        raise VerificationError("provider/chat smoke: runner must be an existing executable file")
+    config = app_config.load_config("dspace", args.environment, args.config or None)
+    host, token_origin, token_model = expectations(config, expected["provider"])
+    base_url = f"https://{host}"
+    coordinate = f"{release_manifest.IMAGE_REF}:{manifest['imageTag']}"
+    digest = manifest["imageDigest"]
+
+    deployment = _json_command(
+        runner,
+        [
+            "kubectl",
+            "--kubeconfig",
+            args.kubeconfig,
+            "-n",
+            args.namespace,
+            "get",
+            "deployment",
+            args.release,
+            "-o",
+            "json",
+        ],
+        "cluster identity",
+    )
+    live_containers = [
+        item
+        for item in deployment.get("spec", {})
+        .get("template", {})
+        .get("spec", {})
+        .get("containers", [])
+        if isinstance(item, dict) and item.get("name") == "dspace"
+    ]
+    if len(live_containers) != 1 or live_containers[0].get("image") not in {
+        coordinate,
+        f"{coordinate}@{digest}",
+    }:
+        raise VerificationError("cluster identity: Deployment image differs from approval")
+    live_env = {
+        item.get("name"): item.get("value")
+        for item in live_containers[0].get("env", [])
+        if isinstance(item, dict)
+    }
+    if expected["provider"] == "token-place" and (
+        live_env.get("DSPACE_TOKEN_PLACE_URL") != token_origin
+        or live_env.get("DSPACE_TOKEN_PLACE_CHAT_MODEL") != token_model
+    ):
+        raise VerificationError("cluster identity: Deployment routing differs from values")
+
+    if manifest["recordType"] == "final":
+        helm = _json_command(
+            runner,
+            [
+                "helm",
+                "--kubeconfig",
+                args.kubeconfig,
+                "status",
+                args.release,
+                "--namespace",
+                args.namespace,
+                "-o",
+                "json",
+            ],
+            "staging drift",
+        )
+        if helm.get("version") != manifest["helmRevision"]:
+            raise VerificationError("staging drift: Helm revision differs from evidence")
+        chart = helm.get("chart", {}).get("metadata", {})
+        if chart.get("name") != "dspace" or chart.get("version") != manifest["chartVersion"]:
+            raise VerificationError("cluster identity: installed chart differs from approval")
+
+    public_build = fetch(base_url + "/build-info.json", "public identity")
+    _identity(
+        public_build, expected["applicationVersion"], expected["sourceRevision"], "public identity"
+    )
+    public_value = json.loads(public_build)
+    if public_value.get("image") is not None and public_value["image"] != coordinate:
+        raise VerificationError("public identity: runtime image coordinate mismatch")
+    _frontend(
+        fetch(base_url + "/", "public identity"), expected["sourceRevision"], "public identity"
+    )
+
+    names: set[str] = set()
+    for pod in _pods(runner, args.kubeconfig, args.namespace, args.release):
+        metadata = pod.get("metadata", {})
+        status = pod.get("status", {})
+        name = metadata.get("name")
+        if (
+            not isinstance(name, str)
+            or name in names
+            or metadata.get("deletionTimestamp") is not None
+        ):
+            raise VerificationError("pod/replica identity: stale or duplicate replica")
+        names.add(name)
+        ready = any(
+            c.get("type") == "Ready" and c.get("status") == "True"
+            for c in status.get("conditions", [])
+        )
+        containers = [
+            c for c in pod.get("spec", {}).get("containers", []) if c.get("name") == "dspace"
+        ]
+        statuses = [c for c in status.get("containerStatuses", []) if c.get("name") == "dspace"]
+        if (
+            status.get("phase") != "Running"
+            or not ready
+            or len(containers) != 1
+            or len(statuses) != 1
+        ):
+            raise VerificationError("pod/replica identity: replica is not Running and Ready")
+        if containers[0].get("image") not in {coordinate, f"{coordinate}@{digest}"}:
+            raise VerificationError("pod/replica identity: image coordinate mismatch")
+        if not str(statuses[0].get("imageID", "")).endswith(digest):
+            raise VerificationError("pod/replica identity: image digest mismatch")
+        proxy = f"/api/v1/namespaces/{args.namespace}/pods/{name}:3000/proxy"
+        direct_build = _command(
+            runner,
+            [
+                "kubectl",
+                "--kubeconfig",
+                args.kubeconfig,
+                "get",
+                "--raw",
+                proxy + "/build-info.json",
+            ],
+            "direct identity",
+        )
+        _identity(
+            direct_build.encode(),
+            expected["applicationVersion"],
+            expected["sourceRevision"],
+            "direct identity",
+        )
+        direct_value = json.loads(direct_build)
+        if direct_value != public_value:
+            raise VerificationError("direct identity: public and direct identity differ")
+        direct_html = _command(
+            runner,
+            ["kubectl", "--kubeconfig", args.kubeconfig, "get", "--raw", proxy + "/"],
+            "direct identity",
+        )
+        _frontend(direct_html.encode(), expected["sourceRevision"], "direct identity")
+
+    smoke_command = [
+        str(smoke),
+        "--base-url",
+        base_url,
+        "--expected-version",
+        expected["applicationVersion"],
+        "--expected-revision",
+        expected["sourceRevision"],
+        "--expected-provider",
+        expected["provider"],
+    ]
+    if expected["provider"] == "token-place":
+        smoke_command += [
+            "--expected-token-place-origin",
+            token_origin,
+            "--expected-token-place-model",
+            token_model,
+        ]
+    _command(runner, smoke_command, "provider/chat smoke")
+    return {
+        "schemaVersion": 1,
+        "environment": args.environment,
+        "release": args.release,
+        "namespace": args.namespace,
+        "applicationVersion": expected["applicationVersion"],
+        "runtimeSourceRevision": expected["sourceRevision"],
+        "frontendSourceRevision": expected["sourceRevision"],
+        "defaultProvider": expected["provider"],
+        "journeys": [
+            {"name": "/build-info.json", "passed": True},
+            {"name": "/chat", "passed": True},
+        ],
+    }
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser()
+    commands = root.add_subparsers(dest="command", required=True)
+    for name in ("capabilities", "verify"):
+        command = commands.add_parser(name)
+        command.add_argument("--environment", choices=("staging", "prod"), required=True)
+        command.add_argument("--release", required=True)
+        command.add_argument("--namespace", required=True)
+        if name == "verify":
+            command.add_argument("--manifest", type=Path, required=True)
+            command.add_argument("--smoke-runner", type=Path, required=True)
+            command.add_argument("--config", default="")
+            command.add_argument("--kubeconfig", required=True)
+            command.add_argument("--application-version")
+            command.add_argument("--source-revision")
+            command.add_argument("--provider", choices=("token-place", "openai"))
+            command.add_argument("--compare-manifest", type=Path)
+    return root
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        if args.command == "capabilities":
+            result = {
+                "schemaVersion": 1,
+                "environment": args.environment,
+                "release": args.release,
+                "namespace": args.namespace,
+                "capabilities": list(CAPABILITIES),
+            }
+        else:
+            result = verify(args)
+        sys.stdout.write(json.dumps(result, indent=2, ensure_ascii=True) + "\n")
+    except (VerificationError, release_manifest.ManifestError, app_config.AppConfigError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -1,0 +1,182 @@
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import dspace_runtime_verifier as verifier
+
+SHA = "abcdef0123456789abcdef0123456789abcdef01"
+DIGEST = "sha256:" + "1" * 64
+
+
+def manifest(environment: str = "staging", provider: str = "token-place") -> dict[str, object]:
+    return {
+        "schemaVersion": 1,
+        "app": "dspace",
+        "applicationVersion": "3.2.0",
+        "sourceRevision": SHA,
+        "imageTag": "main-abcdef0",
+        "imageDigest": DIGEST,
+        "chartVersion": "3.2.0",
+        "chartDigest": "sha256:" + "2" * 64,
+        "semanticTag": "v3.2.0",
+        "recordType": "candidate",
+        "environment": environment,
+        "expectedDefaultChatProvider": provider,
+        "approvedAt": "2026-07-29T12:00:00Z",
+        "approvedBy": "release-manager",
+    }
+
+
+def test_capabilities_schema_is_exact(capsys: pytest.CaptureFixture[str]) -> None:
+    assert (
+        verifier.main(
+            [
+                "capabilities",
+                "--environment",
+                "staging",
+                "--release",
+                "dspace",
+                "--namespace",
+                "dspace",
+            ]
+        )
+        == 0
+    )
+    assert json.loads(capsys.readouterr().out) == {
+        "schemaVersion": 1,
+        "environment": "staging",
+        "release": "dspace",
+        "namespace": "dspace",
+        "capabilities": list(verifier.CAPABILITIES),
+    }
+
+
+def test_values_expectations_omit_token_place_for_openai(tmp_path: Path, monkeypatch) -> None:
+    values = tmp_path / "values.yaml"
+    values.write_text("ingress:\n  host: example.test\nenv: []\n", encoding="utf-8")
+    monkeypatch.setattr(verifier, "REPO_ROOT", tmp_path)
+    assert verifier.expectations({"SUGARKUBE_VALUES": str(values)}, "openai") == (
+        "example.test",
+        None,
+        None,
+    )
+
+
+def test_chat_argv_is_exact_and_child_output_is_not_returned(tmp_path: Path, monkeypatch) -> None:
+    record = tmp_path / "manifest.json"
+    record.write_text(json.dumps(manifest()), encoding="utf-8")
+    smoke = tmp_path / "smoke"
+    smoke.write_text("#!/bin/sh\n", encoding="utf-8")
+    smoke.chmod(0o755)
+    values = tmp_path / "values.yaml"
+    values.write_text(
+        "ingress:\n  host: staging.example\nenv:\n"
+        "- name: DSPACE_TOKEN_PLACE_URL\n  value: https://token.example\n"
+        "- name: DSPACE_TOKEN_PLACE_CHAT_MODEL\n  value: approved-model\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        verifier.app_config,
+        "load_config",
+        lambda *_args: {"SUGARKUBE_VALUES": str(values)},
+    )
+    build = json.dumps({"version": "3.2.0", "revision": SHA, "shortRevision": SHA[:7]})
+    html = f'<meta name="dspace-build-revision" content="{SHA}">'.encode()
+    monkeypatch.setattr(
+        verifier, "fetch", lambda url, _category: build.encode() if url.endswith("json") else html
+    )
+    calls: list[list[str]] = []
+
+    def runner(command: list[str]) -> str:
+        calls.append(command)
+        if "deployment" in command:
+            return json.dumps(
+                {
+                    "spec": {
+                        "template": {
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "dspace",
+                                        "image": "ghcr.io/democratizedspace/dspace:main-abcdef0",
+                                        "env": [
+                                            {
+                                                "name": "DSPACE_TOKEN_PLACE_URL",
+                                                "value": "https://token.example",
+                                            },
+                                            {
+                                                "name": "DSPACE_TOKEN_PLACE_CHAT_MODEL",
+                                                "value": "approved-model",
+                                            },
+                                        ],
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            )
+        if "pods" in command:
+            return json.dumps(
+                {
+                    "items": [
+                        {
+                            "metadata": {"name": "dspace-1"},
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "dspace",
+                                        "image": "ghcr.io/democratizedspace/dspace:main-abcdef0",
+                                    }
+                                ]
+                            },
+                            "status": {
+                                "phase": "Running",
+                                "conditions": [{"type": "Ready", "status": "True"}],
+                                "containerStatuses": [
+                                    {"name": "dspace", "imageID": "image@" + DIGEST}
+                                ],
+                            },
+                        }
+                    ]
+                }
+            )
+        if command[-1].endswith("build-info.json"):
+            return build
+        if command[0] == str(smoke):
+            return "SENTINEL-SECRET"
+        return html.decode()
+
+    args = argparse.Namespace(
+        manifest=record,
+        environment="staging",
+        release="dspace",
+        namespace="dspace",
+        application_version=None,
+        source_revision=None,
+        provider=None,
+        compare_manifest=None,
+        smoke_runner=smoke,
+        config="",
+        kubeconfig="kubeconfig",
+    )
+    result = verifier.verify(args, runner)
+    assert result["journeys"][-1] == {"name": "/chat", "passed": True}
+    assert calls[-1] == [
+        str(smoke),
+        "--base-url",
+        "https://staging.example",
+        "--expected-version",
+        "3.2.0",
+        "--expected-revision",
+        SHA,
+        "--expected-provider",
+        "token-place",
+        "--expected-token-place-origin",
+        "https://token.example",
+        "--expected-token-place-model",
+        "approved-model",
+    ]
+    assert "SENTINEL" not in json.dumps(result)


### PR DESCRIPTION
### Motivation

- Prevent production version drift by making DSPACE runtime identity and `/chat` verification mandatory before and after promotion, and reuse the existing manifest/evidence contracts.

### Description

- Add an argv-only DSPACE runtime verifier at `scripts/dspace_runtime_verifier.py` implementing the existing capability/result schemas and performing read-only checks of public build identity, frontend marker, deployment routing, per-replica image/digest agreement, and invoking the DSPACE remote `/chat` smoke runner as argv only.
- Add `just dspace-release-verify` to run the verifier and wire it into DSPACE deploy/promote/redeploy/manifests so staging evidence and a hermetic smoke-runner are required for production flows; pass `--runtime-verification` into `finalize` so results become bounded verification entries in finalized evidence.
- Extend `scripts/dspace_release_manifest.py` to accept and validate optional runtime verification and to recognize new runtime-related verification checks without breaking schema-v1 compatibility for historical evidence.
- Wire rollback to call the real verifier (via `scripts/dspace_manifest_rollback.py`) while keeping the rollback confirmation, reservation, and Helm-concurrency protections, and propagate the `smoke_runner` argument where available.
- Add hermetic unit tests `tests/test_dspace_runtime_verifier.py` covering capability schema, values-derived expectations, exact smoke argv, deployment and pod identity checks, and child-output redaction.
- Update docs: `docs/apps/dspace.md` and `docs/app_deployment_contract.md` with usage, checkout prerequisites, and the required staging-evidence + smoke-runner promotion flow.

### Testing

- Ran unit tests: `python3 -m pytest -q tests/test_dspace_runtime_verifier.py tests/test_release_manifest.py tests/test_manifest_rollback.py tests/test_generic_app_just_recipes.py tests/test_up_recipe_calls.py` and fixed verifier-related failures; the focused test suite passed in this environment (hermetic stubs exercised).  Exact command was used during development and tests covering the verifier passed.
- Static checks: reformatted with `black` and ran `python3 -m flake8` against modified scripts and new tests; changed implementation files passed; broader flake8 reported pre-existing style issues in unrelated long test lines which were not weakened.
- Repository checks: `bash scripts/test-helm-oci-install.sh`, `git diff --check`, and `./scripts/scan-secrets.py` on staged changes were executed and succeeded in this environment; `just --unstable --fmt --check` and `pre-commit` were not available in the runner but recipe semantics were exercised by the tests.

Closes #2328

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6bd015030c832f8ab8ce65e64b20dc)