### PR TITLE
Fix staging cert-manager Just recipes: normalize name=value args, require env, detect missing cmctl

### DIFF
--- a/docs/staging-cert-manager.md
+++ b/docs/staging-cert-manager.md
@@ -36,8 +36,8 @@ Secret metadata/presence, and relevant Events. It reports readiness/reason, DNS 
 credential-shaped event text. It never requests Secret data.
 
 ```bash
-just cert-manager-certificate-status namespace=danielsmith certificate=danielsmith-staging-tls
-just cert-manager-certificate-status namespace=jobbot3000 certificate=jobbot3000-staging-tls
+just cert-manager-certificate-status namespace=danielsmith certificate=danielsmith-staging-tls env=staging
+just cert-manager-certificate-status namespace=jobbot3000 certificate=jobbot3000-staging-tls env=staging
 ```
 
 Check whether an error belongs to an active Challenge rather than a completed/stale one. Confirm
@@ -83,6 +83,15 @@ Challenge to report `Found no Zones`. It checks only Secret existence and never 
 or prints its value. These structural checks cannot prove the token's Cloudflare dashboard scope;
 only a successfully completed DNS-01 Challenge can do that. Do not call Cloudflare APIs in a way
 that risks logging request headers.
+
+Status and structural authorization checks use `kubectl` and do not require `cmctl`. Recovery
+requires the `cmctl` client; follow the [official installation guidance](https://cert-manager.io/docs/reference/cmctl/)
+and verify the installed client before attempting recovery:
+
+```bash
+command -v cmctl
+cmctl version --client
+```
 
 ## One certificate at a time
 

--- a/justfile
+++ b/justfile
@@ -791,23 +791,56 @@ cert-manager-install version='v1.14.4':
     kubectl -n cert-manager wait --for=condition=Available deployment/cert-manager deployment/cert-manager-webhook deployment/cert-manager-cainjector --timeout=300s
 
 # Create/update the staging Cloudflare DNS API token Secret from hidden input or stdin.
-cert-manager-cloudflare-token-secret env='':
+cert-manager-cloudflare-token-secret env:
     #!/usr/bin/env bash
     set -Eeuo pipefail
-    export SUGARKUBE_ENV="{{ env }}"
+    normalize_argument() {
+        local expected="$1" value="$2"
+        if [[ "${value}" == "${expected}="* ]]; then value="${value#"${expected}="}"; fi
+        if [[ -z "${value}" ]]; then
+            printf 'ERROR: %s must not be empty; use %s=<value>.\n' "${expected}" "${expected}" >&2
+            exit 2
+        fi
+        if [[ "${value}" == *"="* ]]; then
+            printf 'ERROR: unexpected value for %s: %q; use %s=<value>.\n' "${expected}" "${value}" "${expected}" >&2
+            exit 2
+        fi
+        printf '%s' "${value}"
+    }
+    export SUGARKUBE_ENV="$(normalize_argument env {{ quote(env) }})"
     python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" install-token
 
 # Report one staging certificate and its complete redacted ACME resource chain.
-cert-manager-certificate-status namespace certificate env='staging':
-    SUGARKUBE_ENV="{{ env }}" python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" status --namespace "{{ namespace }}" --certificate "{{ certificate }}"
+cert-manager-certificate-status namespace certificate env:
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    normalize_argument() { local expected="$1" value="$2"; if [[ "${value}" == "${expected}="* ]]; then value="${value#"${expected}="}"; fi; if [[ -z "${value}" ]]; then printf 'ERROR: %s must not be empty; use %s=<value>.\n' "${expected}" "${expected}" >&2; exit 2; fi; if [[ "${value}" == *"="* ]]; then printf 'ERROR: unexpected value for %s: %q; use %s=<value>.\n' "${expected}" "${value}" "${expected}" >&2; exit 2; fi; printf '%s' "${value}"; }
+    namespace_value="$(normalize_argument namespace {{ quote(namespace) }})"
+    certificate_value="$(normalize_argument certificate {{ quote(certificate) }})"
+    export SUGARKUBE_ENV="$(normalize_argument env {{ quote(env) }})"
+    python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" status --namespace "${namespace_value}" --certificate "${certificate_value}"
 
 # Fail-closed structural authorization checks before attempting a staging renewal.
-cert-manager-certificate-verify-authorization namespace certificate env='staging':
-    SUGARKUBE_ENV="{{ env }}" python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" verify-authorization --namespace "{{ namespace }}" --certificate "{{ certificate }}"
+cert-manager-certificate-verify-authorization namespace certificate env:
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    normalize_argument() { local expected="$1" value="$2"; if [[ "${value}" == "${expected}="* ]]; then value="${value#"${expected}="}"; fi; if [[ -z "${value}" ]]; then printf 'ERROR: %s must not be empty; use %s=<value>.\n' "${expected}" "${expected}" >&2; exit 2; fi; if [[ "${value}" == *"="* ]]; then printf 'ERROR: unexpected value for %s: %q; use %s=<value>.\n' "${expected}" "${value}" "${expected}" >&2; exit 2; fi; printf '%s' "${value}"; }
+    namespace_value="$(normalize_argument namespace {{ quote(namespace) }})"
+    certificate_value="$(normalize_argument certificate {{ quote(certificate) }})"
+    export SUGARKUBE_ENV="$(normalize_argument env {{ quote(env) }})"
+    python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" verify-authorization --namespace "${namespace_value}" --certificate "${certificate_value}"
 
 # Renew and verify exactly one staging certificate with a bounded wait and HTTPS checks.
-cert-manager-certificate-recover namespace certificate host env='staging' timeout='600':
-    SUGARKUBE_ENV="{{ env }}" python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" recover --namespace "{{ namespace }}" --certificate "{{ certificate }}" --host "{{ host }}" --timeout "{{ timeout }}"
+cert-manager-certificate-recover namespace certificate host env timeout='600':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    normalize_argument() { local expected="$1" value="$2"; if [[ "${value}" == "${expected}="* ]]; then value="${value#"${expected}="}"; fi; if [[ -z "${value}" ]]; then printf 'ERROR: %s must not be empty; use %s=<value>.\n' "${expected}" "${expected}" >&2; exit 2; fi; if [[ "${value}" == *"="* ]]; then printf 'ERROR: unexpected value for %s: %q; use %s=<value>.\n' "${expected}" "${value}" "${expected}" >&2; exit 2; fi; printf '%s' "${value}"; }
+    namespace_value="$(normalize_argument namespace {{ quote(namespace) }})"
+    certificate_value="$(normalize_argument certificate {{ quote(certificate) }})"
+    host_value="$(normalize_argument host {{ quote(host) }})"
+    export SUGARKUBE_ENV="$(normalize_argument env {{ quote(env) }})"
+    timeout_value="$(normalize_argument timeout {{ quote(timeout) }})"
+    python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" recover --namespace "${namespace_value}" --certificate "${certificate_value}" --host "${host_value}" --timeout "${timeout_value}"
 
 # Apply non-Flux ClusterIssuers with an explicit email (no kustomize vars).
 cert-manager-issuers-apply email:

--- a/scripts/staging_cert_manager.py
+++ b/scripts/staging_cert_manager.py
@@ -8,6 +8,7 @@ import getpass
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -275,6 +276,10 @@ def install_token() -> None:
 
 
 def recover(namespace: str, certificate_name: str, host: str, timeout: int) -> None:
+    if shutil.which("cmctl") is None:
+        raise OperationError(
+            "cmctl is required for recovery; install it and verify with 'cmctl version --client'"
+        )
     report = verify_authorization(namespace, certificate_name)
     normalized_host = host.rstrip(".").lower()
     dns_names = {

--- a/tests/test_cert_manager_just.py
+++ b/tests/test_cert_manager_just.py
@@ -1,0 +1,170 @@
+import os
+import pathlib
+import subprocess
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def python_stub(tmp_path):
+    executable = tmp_path / "python3"
+    executable.write_text(
+        "#!/bin/sh\n"
+        "printf 'SUGARKUBE_ENV=%s\\n' \"${SUGARKUBE_ENV-}\"\n"
+        "printf '%s\\n' \"$@\"\n"
+    )
+    executable.chmod(0o755)
+    return tmp_path
+
+
+def run_just(arguments, *, path=None):
+    environment = os.environ.copy()
+    if path is not None:
+        environment["PATH"] = f"{path}:{environment['PATH']}"
+    return subprocess.run(
+        ["just", "--justfile", str(ROOT / "justfile"), *arguments],
+        cwd=ROOT,
+        env=environment,
+        input=b"",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "arguments,expected",
+    [
+        (
+            ["cert-manager-cloudflare-token-secret", "env=staging"],
+            ["install-token"],
+        ),
+        (
+            [
+                "cert-manager-certificate-status",
+                "namespace=danielsmith",
+                "certificate=danielsmith-staging-tls",
+                "env=staging",
+            ],
+            ["status", "--namespace", "danielsmith", "--certificate", "danielsmith-staging-tls"],
+        ),
+        (
+            [
+                "cert-manager-certificate-verify-authorization",
+                "namespace=danielsmith",
+                "certificate=danielsmith-staging-tls",
+                "env=staging",
+            ],
+            [
+                "verify-authorization",
+                "--namespace",
+                "danielsmith",
+                "--certificate",
+                "danielsmith-staging-tls",
+            ],
+        ),
+        (
+            [
+                "cert-manager-certificate-recover",
+                "namespace=danielsmith",
+                "certificate=danielsmith-staging-tls",
+                "host=staging.danielsmith.io",
+                "env=staging",
+                "timeout=600",
+            ],
+            [
+                "recover",
+                "--namespace",
+                "danielsmith",
+                "--certificate",
+                "danielsmith-staging-tls",
+                "--host",
+                "staging.danielsmith.io",
+                "--timeout",
+                "600",
+            ],
+        ),
+    ],
+)
+def test_documented_named_arguments_are_normalized(python_stub, arguments, expected):
+    result = run_just(arguments, path=python_stub)
+
+    assert result.returncode == 0, result.stderr.decode()
+    assert result.stdout.decode().splitlines() == [
+        "SUGARKUBE_ENV=staging",
+        str(ROOT / "scripts" / "staging_cert_manager.py"),
+        *expected,
+    ]
+
+
+def test_positional_arguments_remain_supported(python_stub):
+    result = run_just(
+        ["cert-manager-certificate-status", "danielsmith", "site-tls", "staging"],
+        path=python_stub,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.decode().splitlines()[-5:] == [
+        "status",
+        "--namespace",
+        "danielsmith",
+        "--certificate",
+        "site-tls",
+    ]
+
+
+@pytest.mark.parametrize("environment", ["prod", "development"])
+def test_non_staging_environment_fails_closed(environment):
+    result = run_just(
+        [
+            "cert-manager-certificate-status",
+            "namespace=danielsmith",
+            "certificate=site-tls",
+            f"env={environment}",
+        ]
+    )
+
+    assert result.returncode != 0
+    assert b"refusing operation: export SUGARKUBE_ENV=staging" in result.stderr
+    assert b"Traceback" not in result.stderr
+
+
+def test_omitted_environment_is_rejected_by_just():
+    result = run_just(["cert-manager-certificate-status", "danielsmith", "site-tls"])
+
+    assert result.returncode != 0
+    assert b"takes 3" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "arguments,message",
+    [
+        (
+            [
+                "cert-manager-certificate-status",
+                "namespace=",
+                "certificate=site-tls",
+                "env=staging",
+            ],
+            b"namespace must not be empty",
+        ),
+        (
+            [
+                "cert-manager-certificate-status",
+                "certificate=site-tls",
+                "namespace=danielsmith",
+                "env=staging",
+            ],
+            b"unexpected value for namespace",
+        ),
+    ],
+)
+def test_empty_or_mismatched_named_arguments_fail_cleanly(python_stub, arguments, message):
+    result = run_just(arguments, path=python_stub)
+
+    assert result.returncode != 0
+    assert message in result.stderr
+    assert b"Traceback" not in result.stderr
+    assert b"SUGARKUBE_ENV=" not in result.stdout

--- a/tests/test_staging_cert_manager.py
+++ b/tests/test_staging_cert_manager.py
@@ -356,6 +356,7 @@ def test_recover_reports_bounded_failure_without_curl(monkeypatch):
         }
     ]
     monkeypatch.setattr(MODULE, "verify_authorization", lambda *_args: states[0])
+    monkeypatch.setattr(MODULE.shutil, "which", lambda _name: "/usr/bin/cmctl")
     monkeypatch.setattr(MODULE, "inventory", lambda *_args: states[0])
     commands = []
 
@@ -375,6 +376,7 @@ def test_recover_reports_bounded_failure_without_curl(monkeypatch):
 
 
 def test_recover_rejects_host_not_named_by_certificate(monkeypatch):
+    monkeypatch.setattr(MODULE.shutil, "which", lambda _name: "/usr/bin/cmctl")
     monkeypatch.setattr(
         MODULE,
         "verify_authorization",
@@ -485,6 +487,7 @@ def test_recover_success_checks_each_https_path(monkeypatch, capsys):
     }
     commands = []
     monkeypatch.setattr(MODULE, "verify_authorization", lambda *_args: before)
+    monkeypatch.setattr(MODULE.shutil, "which", lambda _name: "/usr/bin/cmctl")
     monkeypatch.setattr(MODULE, "inventory", lambda *_args: after)
     monkeypatch.setattr(
         MODULE,
@@ -518,6 +521,7 @@ def test_recover_propagates_command_failures(monkeypatch, failure):
     }
     after = {"certificate": {**report["certificate"], "revision": 2}}
     monkeypatch.setattr(MODULE, "verify_authorization", lambda *_args: report)
+    monkeypatch.setattr(MODULE.shutil, "which", lambda _name: "/usr/bin/cmctl")
     monkeypatch.setattr(MODULE, "inventory", lambda *_args: after)
     monkeypatch.setattr(MODULE.time, "monotonic", lambda: 0)
 
@@ -537,6 +541,40 @@ def test_recover_propagates_command_failures(monkeypatch, failure):
     with pytest.raises(MODULE.OperationError, match=expected) as caught:
         MODULE.recover("example", "site-tls", "staging.example.test", 60)
     assert "command-marker" not in str(caught.value)
+
+
+def test_recover_missing_cmctl_fails_without_subprocess_or_traceback(monkeypatch, capsys):
+    monkeypatch.setattr(MODULE.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        MODULE,
+        "verify_authorization",
+        lambda *_args: pytest.fail("missing cmctl must fail before cluster authorization"),
+    )
+    monkeypatch.setattr(
+        MODULE,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("missing cmctl must not start a subprocess"),
+    )
+    monkeypatch.setattr(
+        MODULE.sys,
+        "argv",
+        [
+            "tool",
+            "recover",
+            "--namespace",
+            "example",
+            "--certificate",
+            "site-tls",
+            "--host",
+            "staging.example.test",
+        ],
+    )
+
+    assert MODULE.main() == 1
+    error = capsys.readouterr().err
+    assert "cmctl is required for recovery" in error
+    assert "cmctl version --client" in error
+    assert "Traceback" not in error
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation
- The Just recipes added in the previous change were forwarding documented `name=value` suffixes literally (e.g. `env=staging`) so the Python guard saw the wrong values and failed before any kubectl/cmctl calls. 
- Recovery did not fail fast when the `cmctl` client was missing, which produced confusing behavior during operator-driven renewals. 
- Deterministic regression coverage was required to prove exact `just` to-Python propagation, preserve positional invocation, and keep the fail-closed staging safeguards.

### Description
- Normalize only the expected prefixes in the four affected Just recipes by adding a `normalize_argument` helper and explicit per-parameter handling so `env=staging` -> `staging` (and similarly for `namespace=`, `certificate=`, `host=`, `timeout=`), reject empty values, and preserve positional compatibility (`justfile`).
- Make `env` an explicit required operator input for the staging token, status, verification, and recovery recipes instead of silently defaulting to staging (`justfile`).
- Add a pre-check in `scripts/staging_cert_manager.py` that fails fast with an actionable `OperationError` when `cmctl` is not found, and import `shutil` to support that check (`scripts/staging_cert_manager.py`).
- Add a focused functional test file that stubs `python3` and runs the documented `just` invocations to assert exact `SUGARKUBE_ENV` and argv propagation, plus tests for positional compatibility, omitted/non-staging env handling, and malformed key-style inputs (`tests/test_cert_manager_just.py`).
- Update existing tests to mock `shutil.which` where appropriate and add a test that verifies the missing-`cmctl` failure path produces a concise operator-facing error without starting subprocesses or emitting a traceback (`tests/test_staging_cert_manager.py`).
- Update `docs/staging-cert-manager.md` to require `env=staging` in examples and to document `cmctl` as a recovery-only prerequisite with links and verification commands.

### Testing
- Ran focused unit tests: `python3 -m pytest -q tests/test_staging_cert_manager.py` (30 passed) and `python3 -m pytest -q tests/test_cert_manager_just.py` (10 passed). 
- Formatting and import checks for the modified Python files passed: `python3 -m black --check` and `python3 -m isort --check-only` for `scripts/staging_cert_manager.py`, `tests/test_staging_cert_manager.py`, and the new `tests/test_cert_manager_just.py` succeeded. 
- Verified the updated `just` recipes with a stubbed `python3` produced the exact documented output for the status command: `SUGARKUBE_ENV=staging` followed by `status --namespace danielsmith --certificate danielsmith-staging-tls`. 
- `just --unstable --fmt --check` reported repository-wide formatting differences under the locally installable `just` (1.53) versus the newer `just` referenced by CI (1.57), which is an environment/tooling mismatch and not a functional regression in these changes. 
- `pre-commit run --all-files` and a full repository `pytest` run were not used as blockers here because they surface unrelated, pre-existing repository-wide lint/format/YAML issues; focused tests and checks for the modified scope passed and CI should validate the repository-wide checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6bd20ce2a8832f817befa78353b5e1)