### PR TITLE
Repair staging cert-manager operator recipe arguments

### DIFF
--- a/docs/staging-cert-manager.md
+++ b/docs/staging-cert-manager.md
@@ -36,8 +36,8 @@ Secret metadata/presence, and relevant Events. It reports readiness/reason, DNS 
 credential-shaped event text. It never requests Secret data.
 
 ```bash
-just cert-manager-certificate-status namespace=danielsmith certificate=danielsmith-staging-tls
-just cert-manager-certificate-status namespace=jobbot3000 certificate=jobbot3000-staging-tls
+just cert-manager-certificate-status namespace=danielsmith certificate=danielsmith-staging-tls env=staging
+just cert-manager-certificate-status namespace=jobbot3000 certificate=jobbot3000-staging-tls env=staging
 ```
 
 Check whether an error belongs to an active Challenge rather than a completed/stale one. Confirm
@@ -83,6 +83,16 @@ Challenge to report `Found no Zones`. It checks only Secret existence and never 
 or prints its value. These structural checks cannot prove the token's Cloudflare dashboard scope;
 only a successfully completed DNS-01 Challenge can do that. Do not call Cloudflare APIs in a way
 that risks logging request headers.
+
+Status and structural authorization verification require `kubectl`, but not `cmctl`. Recovery
+additionally requires the cert-manager command-line tool. Follow the
+[official cmctl installation guidance](https://cert-manager.io/docs/reference/cmctl/) (do not use
+an unpinned curl-pipe installer), then verify the installed client before recovery:
+
+```bash
+command -v cmctl
+cmctl version --client
+```
 
 ## One certificate at a time
 

--- a/justfile
+++ b/justfile
@@ -794,20 +794,53 @@ cert-manager-install version='v1.14.4':
 cert-manager-cloudflare-token-secret env='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
-    export SUGARKUBE_ENV="{{ env }}"
+    normalize_arg() {
+        local key="$1" value="$2"
+        if [[ "${value}" == "${key}="* ]]; then value="${value#*=}"; fi
+        if [[ -z "${value}" || "${value}" == *=* ]]; then
+            printf 'ERROR: %s must be a non-empty value or %s=<value>; got %q.\n' "${key}" "${key}" "${value}" >&2
+            exit 2
+        fi
+        printf '%s' "${value}"
+    }
+    env_value="$(normalize_arg env {{ quote(env) }})"
+    export SUGARKUBE_ENV="${env_value}"
     python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" install-token
 
 # Report one staging certificate and its complete redacted ACME resource chain.
-cert-manager-certificate-status namespace certificate env='staging':
-    SUGARKUBE_ENV="{{ env }}" python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" status --namespace "{{ namespace }}" --certificate "{{ certificate }}"
+cert-manager-certificate-status namespace certificate env='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    normalize_arg() { local key="$1" value="$2"; if [[ "${value}" == "${key}="* ]]; then value="${value#*=}"; fi; if [[ -z "${value}" || "${value}" == *=* ]]; then printf 'ERROR: %s must be a non-empty value or %s=<value>; got %q.\n' "${key}" "${key}" "${value}" >&2; exit 2; fi; printf '%s' "${value}"; }
+    env_value="$(normalize_arg env {{ quote(env) }})"
+    namespace_value="$(normalize_arg namespace {{ quote(namespace) }})"
+    certificate_value="$(normalize_arg certificate {{ quote(certificate) }})"
+    export SUGARKUBE_ENV="${env_value}"
+    python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" status --namespace "${namespace_value}" --certificate "${certificate_value}"
 
 # Fail-closed structural authorization checks before attempting a staging renewal.
-cert-manager-certificate-verify-authorization namespace certificate env='staging':
-    SUGARKUBE_ENV="{{ env }}" python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" verify-authorization --namespace "{{ namespace }}" --certificate "{{ certificate }}"
+cert-manager-certificate-verify-authorization namespace certificate env='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    normalize_arg() { local key="$1" value="$2"; if [[ "${value}" == "${key}="* ]]; then value="${value#*=}"; fi; if [[ -z "${value}" || "${value}" == *=* ]]; then printf 'ERROR: %s must be a non-empty value or %s=<value>; got %q.\n' "${key}" "${key}" "${value}" >&2; exit 2; fi; printf '%s' "${value}"; }
+    env_value="$(normalize_arg env {{ quote(env) }})"
+    namespace_value="$(normalize_arg namespace {{ quote(namespace) }})"
+    certificate_value="$(normalize_arg certificate {{ quote(certificate) }})"
+    export SUGARKUBE_ENV="${env_value}"
+    python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" verify-authorization --namespace "${namespace_value}" --certificate "${certificate_value}"
 
 # Renew and verify exactly one staging certificate with a bounded wait and HTTPS checks.
-cert-manager-certificate-recover namespace certificate host env='staging' timeout='600':
-    SUGARKUBE_ENV="{{ env }}" python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" recover --namespace "{{ namespace }}" --certificate "{{ certificate }}" --host "{{ host }}" --timeout "{{ timeout }}"
+cert-manager-certificate-recover namespace certificate host env='' timeout='600':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    normalize_arg() { local key="$1" value="$2"; if [[ "${value}" == "${key}="* ]]; then value="${value#*=}"; fi; if [[ -z "${value}" || "${value}" == *=* ]]; then printf 'ERROR: %s must be a non-empty value or %s=<value>; got %q.\n' "${key}" "${key}" "${value}" >&2; exit 2; fi; printf '%s' "${value}"; }
+    env_value="$(normalize_arg env {{ quote(env) }})"
+    namespace_value="$(normalize_arg namespace {{ quote(namespace) }})"
+    certificate_value="$(normalize_arg certificate {{ quote(certificate) }})"
+    host_value="$(normalize_arg host {{ quote(host) }})"
+    timeout_value="$(normalize_arg timeout {{ quote(timeout) }})"
+    export SUGARKUBE_ENV="${env_value}"
+    python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" recover --namespace "${namespace_value}" --certificate "${certificate_value}" --host "${host_value}" --timeout "${timeout_value}"
 
 # Apply non-Flux ClusterIssuers with an explicit email (no kustomize vars).
 cert-manager-issuers-apply email:

--- a/scripts/staging_cert_manager.py
+++ b/scripts/staging_cert_manager.py
@@ -8,6 +8,7 @@ import getpass
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -275,6 +276,11 @@ def install_token() -> None:
 
 
 def recover(namespace: str, certificate_name: str, host: str, timeout: int) -> None:
+    if shutil.which("cmctl") is None:
+        raise OperationError(
+            "cmctl is required for recovery; install it from "
+            "https://cert-manager.io/docs/reference/cmctl/ and verify with 'cmctl version --client'"
+        )
     report = verify_authorization(namespace, certificate_name)
     normalized_host = host.rstrip(".").lower()
     dns_names = {

--- a/tests/test_cert_manager_just_recipes.py
+++ b/tests/test_cert_manager_just_recipes.py
@@ -1,0 +1,121 @@
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def run_recipe(tmp_path, *arguments):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    stub = bin_dir / "python3"
+    stub.write_text(
+        f"#!{sys.executable}\n"
+        "import json, os, sys\n"
+        "print(json.dumps({'environment': os.environ.get('SUGARKUBE_ENV'), "
+        "'argv': sys.argv[2:]}))\n"
+    )
+    stub.chmod(0o755)
+    environment = {**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"}
+    return subprocess.run(
+        ["just", "--justfile", str(ROOT / "justfile"), *arguments],
+        cwd=ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "arguments,expected",
+    [
+        (["cert-manager-cloudflare-token-secret", "env=staging"], ["install-token"]),
+        (
+            [
+                "cert-manager-certificate-status",
+                "namespace=danielsmith",
+                "certificate=danielsmith-staging-tls",
+                "env=staging",
+            ],
+            [
+                "status",
+                "--namespace",
+                "danielsmith",
+                "--certificate",
+                "danielsmith-staging-tls",
+            ],
+        ),
+        (
+            [
+                "cert-manager-certificate-verify-authorization",
+                "namespace=danielsmith",
+                "certificate=danielsmith-staging-tls",
+                "env=staging",
+            ],
+            [
+                "verify-authorization",
+                "--namespace",
+                "danielsmith",
+                "--certificate",
+                "danielsmith-staging-tls",
+            ],
+        ),
+        (
+            [
+                "cert-manager-certificate-recover",
+                "namespace=danielsmith",
+                "certificate=danielsmith-staging-tls",
+                "host=staging.danielsmith.io",
+                "env=staging",
+                "timeout=600",
+            ],
+            [
+                "recover",
+                "--namespace",
+                "danielsmith",
+                "--certificate",
+                "danielsmith-staging-tls",
+                "--host",
+                "staging.danielsmith.io",
+                "--timeout",
+                "600",
+            ],
+        ),
+    ],
+)
+def test_documented_named_arguments_are_normalized(tmp_path, arguments, expected):
+    result = run_recipe(tmp_path, *arguments)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload == {"environment": "staging", "argv": expected}
+
+
+def test_positional_arguments_remain_compatible(tmp_path):
+    result = run_recipe(
+        tmp_path, "cert-manager-certificate-status", "danielsmith", "site-tls", "staging"
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {
+        "environment": "staging",
+        "argv": ["status", "--namespace", "danielsmith", "--certificate", "site-tls"],
+    }
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ["cert-manager-certificate-status", "namespace=ns", "certificate=cert"],
+        ["cert-manager-certificate-status", "namespace=ns", "certificate=cert", "env="],
+        ["cert-manager-certificate-status", "host=wrong", "certificate=cert", "env=staging"],
+    ],
+)
+def test_empty_or_mismatched_arguments_fail_before_python(tmp_path, arguments):
+    result = run_recipe(tmp_path, *arguments)
+    assert result.returncode != 0
+    assert "ERROR:" in result.stderr
+    assert result.stdout == ""

--- a/tests/test_staging_cert_manager.py
+++ b/tests/test_staging_cert_manager.py
@@ -13,6 +13,11 @@ MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 
 
+@pytest.fixture(autouse=True)
+def cmctl_is_available(monkeypatch):
+    monkeypatch.setattr(MODULE.shutil, "which", lambda executable: f"/usr/bin/{executable}")
+
+
 def resource(name, *, owner_kind=None, owner_name=None, status=None, spec=None, conditions=None):
     metadata = {"name": name}
     if owner_kind:
@@ -186,7 +191,10 @@ def test_inventory_propagates_redacted_secret_lookup_failure(monkeypatch):
     assert "<redacted>" in str(caught.value)
 
 
-@pytest.mark.parametrize("environment,context", [("prod", "sugar-staging"), ("staging", "prod")])
+@pytest.mark.parametrize(
+    "environment,context",
+    [("prod", "sugar-staging"), ("qa", "sugar-staging"), ("staging", "prod")],
+)
 def test_staging_guard_rejects_wrong_environment_or_context(monkeypatch, environment, context):
     monkeypatch.setenv("SUGARKUBE_ENV", environment)
     monkeypatch.setattr(
@@ -372,6 +380,44 @@ def test_recover_reports_bounded_failure_without_curl(monkeypatch):
     assert commands == [
         ["cmctl", "--context", "sugar-staging", "renew", "-n", "example", "site-tls"]
     ]
+
+
+def test_recover_missing_cmctl_fails_before_cluster_or_renewal(monkeypatch):
+    monkeypatch.setattr(MODULE.shutil, "which", lambda _executable: None)
+    monkeypatch.setattr(
+        MODULE,
+        "verify_authorization",
+        lambda *_args: pytest.fail("missing cmctl must fail before cluster access"),
+    )
+    monkeypatch.setattr(
+        MODULE, "run", lambda *_args, **_kwargs: pytest.fail("no subprocess may be started")
+    )
+
+    with pytest.raises(MODULE.OperationError, match="cmctl is required.*cmctl version --client"):
+        MODULE.recover("example", "site-tls", "staging.example.test", 60)
+
+
+def test_main_reports_missing_cmctl_without_traceback(monkeypatch, capsys):
+    monkeypatch.setattr(MODULE.shutil, "which", lambda _executable: None)
+    monkeypatch.setattr(
+        MODULE.sys,
+        "argv",
+        [
+            "tool",
+            "recover",
+            "--namespace",
+            "example",
+            "--certificate",
+            "site-tls",
+            "--host",
+            "staging.example.test",
+        ],
+    )
+
+    assert MODULE.main() == 1
+    captured = capsys.readouterr()
+    assert "ERROR: cmctl is required" in captured.err
+    assert "Traceback" not in captured.err
 
 
 def test_recover_rejects_host_not_named_by_certificate(monkeypatch):


### PR DESCRIPTION
### Motivation

- A recent change forwarded documented `name=value` suffixes literally into the Python operator, causing the staging guard to receive `env=staging` (not `staging`) and refuse to run before any Kubernetes access. 
- The cert-manager recovery path also proceeded to `cmctl renew` without a clear preflight when `cmctl` was missing, producing noisy failures instead of a short, actionable error. 
- Deterministic regression coverage was required to ensure documented `name=value` invocations reach Python exactly as intended and to preserve fail-closed behavior.

### Description

- Normalize only the expected prefixes for each recipe in `justfile` (added `normalize_arg` and per-recipe normalization) so `env=staging` -> `staging`, `namespace=...`, `certificate=...`, `host=...`, and `timeout=...` reach Python unchanged while preserving positional invocation where practical. 
- Require `env` explicitly on the four cluster-facing recipes (`cert-manager-cloudflare-token-secret`, `cert-manager-certificate-status`, `cert-manager-certificate-verify-authorization`, and `cert-manager-certificate-recover`) and keep the Python `staging_guard()` checks that enforce `SUGARKUBE_ENV == "staging"` and `kubectl` context `sugar-staging`. 
- Add a preflight `cmctl` check in `scripts/staging_cert_manager.py` using `shutil.which()` that raises an `OperationError` with an actionable message (and no traceback) when `cmctl` is absent, leaving renewal logic unchanged. 
- Update `docs/staging-cert-manager.md` to require `env=staging` in examples and to document that `cmctl` is a recovery-only prerequisite with verification commands and a link to the official guidance. 
- Add deterministic regression tests: `tests/test_cert_manager_just_recipes.py` exercising Just recipes with a stubbed `python3` to assert exact `SUGARKUBE_ENV` and `argv` propagation, and extend `tests/test_staging_cert_manager.py` to cover the missing-`cmctl` failure mode and main-path behavior.

### Testing

- Focused unit/functional tests: `python3 -m pytest -q tests/test_staging_cert_manager.py` passed (32 tests) and `python3 -m pytest -q tests/test_cert_manager_just_recipes.py` passed (8 tests). 
- Style and tooling checks: `python3 -m black --check` and `python3 -m isort --check-only` on the modified files succeeded, and `just --unstable --fmt --check` succeeded. 
- Docs and secrets scans: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` succeeded, and `git diff | ./scripts/scan-secrets.py` found no new secrets. 
- Reproduction evidence: executing the fixed recipe with a stubbed `python3` produced exactly `SUGARKUBE_ENV=staging` and `--namespace danielsmith --certificate danielsmith-staging-tls` as documented. 
- Repository-wide `pre-commit run --all-files` and a full `pytest` run were attempted but failed on pre-existing, unrelated whole-repo lint/YAML issues; these failures are unrelated to the focused cert-manager changes and were not modified by this PR.

References #2406 (not closed) — controlled live renewals remain outstanding and no live cluster, credential, Cloudflare API, or certificate mutations were performed during reproduction or tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6bd226930c832f93089ca775b81fbb)