### PR TITLE
Fix staging cert-manager operator recipe arguments

### DIFF
--- a/docs/staging-cert-manager.md
+++ b/docs/staging-cert-manager.md
@@ -36,8 +36,8 @@ Secret metadata/presence, and relevant Events. It reports readiness/reason, DNS 
 credential-shaped event text. It never requests Secret data.
 
 ```bash
-just cert-manager-certificate-status namespace=danielsmith certificate=danielsmith-staging-tls
-just cert-manager-certificate-status namespace=jobbot3000 certificate=jobbot3000-staging-tls
+just cert-manager-certificate-status namespace=danielsmith certificate=danielsmith-staging-tls env=staging
+just cert-manager-certificate-status namespace=jobbot3000 certificate=jobbot3000-staging-tls env=staging
 ```
 
 Check whether an error belongs to an active Challenge rather than a completed/stale one. Confirm
@@ -83,6 +83,16 @@ Challenge to report `Found no Zones`. It checks only Secret existence and never 
 or prints its value. These structural checks cannot prove the token's Cloudflare dashboard scope;
 only a successfully completed DNS-01 Challenge can do that. Do not call Cloudflare APIs in a way
 that risks logging request headers.
+
+Status and structural authorization verification require `kubectl`, but not `cmctl`. Recovery
+additionally requires `cmctl`; follow the
+[official installation guidance](https://cert-manager.io/docs/reference/cmctl/) and confirm the
+executable and client version before attempting a renewal:
+
+```bash
+command -v cmctl
+cmctl version --client
+```
 
 ## One certificate at a time
 

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
-set export := true
+set export
 
 export SUGARKUBE_CLUSTER := env('SUGARKUBE_CLUSTER', 'sugar')
 export SUGARKUBE_SERVERS := env('SUGARKUBE_SERVERS', '1')
@@ -794,20 +794,53 @@ cert-manager-install version='v1.14.4':
 cert-manager-cloudflare-token-secret env='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
-    export SUGARKUBE_ENV="{{ env }}"
+    normalize_argument() {
+        local key="$1" value="$2"
+        if [[ "${value}" == "${key}="* ]]; then value="${value#*=}"; fi
+        if [[ -z "${value}" || "${value}" == *=* ]]; then
+            printf 'ERROR: %s must be a non-empty value or %s=<value>; got %q\n' "${key}" "${key}" "${value}" >&2
+            exit 2
+        fi
+        printf '%s' "${value}"
+    }
+    env_name="$(normalize_argument env {{ quote(env) }})"
+    export SUGARKUBE_ENV="${env_name}"
     python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" install-token
 
 # Report one staging certificate and its complete redacted ACME resource chain.
-cert-manager-certificate-status namespace certificate env='staging':
-    SUGARKUBE_ENV="{{ env }}" python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" status --namespace "{{ namespace }}" --certificate "{{ certificate }}"
+cert-manager-certificate-status namespace certificate env:
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    normalize_argument() { local key="$1" value="$2"; if [[ "${value}" == "${key}="* ]]; then value="${value#*=}"; fi; if [[ -z "${value}" || "${value}" == *=* ]]; then printf 'ERROR: %s must be a non-empty value or %s=<value>; got %q\n' "${key}" "${key}" "${value}" >&2; exit 2; fi; printf '%s' "${value}"; }
+    env_name="$(normalize_argument env {{ quote(env) }})"
+    namespace_name="$(normalize_argument namespace {{ quote(namespace) }})"
+    certificate_name="$(normalize_argument certificate {{ quote(certificate) }})"
+    export SUGARKUBE_ENV="${env_name}"
+    python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" status --namespace "${namespace_name}" --certificate "${certificate_name}"
 
 # Fail-closed structural authorization checks before attempting a staging renewal.
-cert-manager-certificate-verify-authorization namespace certificate env='staging':
-    SUGARKUBE_ENV="{{ env }}" python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" verify-authorization --namespace "{{ namespace }}" --certificate "{{ certificate }}"
+cert-manager-certificate-verify-authorization namespace certificate env:
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    normalize_argument() { local key="$1" value="$2"; if [[ "${value}" == "${key}="* ]]; then value="${value#*=}"; fi; if [[ -z "${value}" || "${value}" == *=* ]]; then printf 'ERROR: %s must be a non-empty value or %s=<value>; got %q\n' "${key}" "${key}" "${value}" >&2; exit 2; fi; printf '%s' "${value}"; }
+    env_name="$(normalize_argument env {{ quote(env) }})"
+    namespace_name="$(normalize_argument namespace {{ quote(namespace) }})"
+    certificate_name="$(normalize_argument certificate {{ quote(certificate) }})"
+    export SUGARKUBE_ENV="${env_name}"
+    python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" verify-authorization --namespace "${namespace_name}" --certificate "${certificate_name}"
 
 # Renew and verify exactly one staging certificate with a bounded wait and HTTPS checks.
-cert-manager-certificate-recover namespace certificate host env='staging' timeout='600':
-    SUGARKUBE_ENV="{{ env }}" python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" recover --namespace "{{ namespace }}" --certificate "{{ certificate }}" --host "{{ host }}" --timeout "{{ timeout }}"
+cert-manager-certificate-recover namespace certificate host env timeout='600':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    normalize_argument() { local key="$1" value="$2"; if [[ "${value}" == "${key}="* ]]; then value="${value#*=}"; fi; if [[ -z "${value}" || "${value}" == *=* ]]; then printf 'ERROR: %s must be a non-empty value or %s=<value>; got %q\n' "${key}" "${key}" "${value}" >&2; exit 2; fi; printf '%s' "${value}"; }
+    env_name="$(normalize_argument env {{ quote(env) }})"
+    namespace_name="$(normalize_argument namespace {{ quote(namespace) }})"
+    certificate_name="$(normalize_argument certificate {{ quote(certificate) }})"
+    host_name="$(normalize_argument host {{ quote(host) }})"
+    timeout_seconds="$(normalize_argument timeout {{ quote(timeout) }})"
+    export SUGARKUBE_ENV="${env_name}"
+    python3 "{{ justfile_directory() }}/scripts/staging_cert_manager.py" recover --namespace "${namespace_name}" --certificate "${certificate_name}" --host "${host_name}" --timeout "${timeout_seconds}"
 
 # Apply non-Flux ClusterIssuers with an explicit email (no kustomize vars).
 cert-manager-issuers-apply email:

--- a/scripts/staging_cert_manager.py
+++ b/scripts/staging_cert_manager.py
@@ -8,6 +8,7 @@ import getpass
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -61,9 +62,13 @@ def secret_present(namespace: str, name: str) -> bool:
     return bool(result.stdout.strip())
 
 
-def staging_guard() -> None:
+def staging_environment_guard() -> None:
     if os.environ.get("SUGARKUBE_ENV") != "staging":
         raise OperationError("refusing operation: export SUGARKUBE_ENV=staging")
+
+
+def staging_guard() -> None:
+    staging_environment_guard()
     result = run(["kubectl", "config", "current-context"])
     context = result.stdout.decode(errors="replace").strip()
     if result.returncode or context != STAGING_CONTEXT:
@@ -275,6 +280,12 @@ def install_token() -> None:
 
 
 def recover(namespace: str, certificate_name: str, host: str, timeout: int) -> None:
+    staging_environment_guard()
+    if shutil.which("cmctl") is None:
+        raise OperationError(
+            "cmctl is required for recovery; install it from "
+            "https://cert-manager.io/docs/reference/cmctl/ and verify with cmctl version --client"
+        )
     report = verify_authorization(namespace, certificate_name)
     normalized_host = host.rstrip(".").lower()
     dns_names = {

--- a/tests/test_cert_manager_just_recipes.py
+++ b/tests/test_cert_manager_just_recipes.py
@@ -1,0 +1,162 @@
+import os
+import pathlib
+import subprocess
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def stubbed_python(tmp_path):
+    output = tmp_path / "invocation.txt"
+    stub = tmp_path / "python3"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        'printf \'SUGARKUBE_ENV=%s\\n\' "${SUGARKUBE_ENV-}" > "${CAPTURE}"\n'
+        'printf \'%s\\n\' "$@" >> "${CAPTURE}"\n'
+    )
+    stub.chmod(0o755)
+    environment = {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}", "CAPTURE": str(output)}
+    return environment, output
+
+
+def run_recipe(stubbed_python, *arguments):
+    environment, output = stubbed_python
+    result = subprocess.run(
+        ["just", "--justfile", str(ROOT / "justfile"), *arguments],
+        cwd=ROOT,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    invocation = output.read_text().splitlines() if output.exists() else []
+    return result, invocation
+
+
+@pytest.mark.parametrize(
+    "arguments,expected",
+    [
+        (("cert-manager-cloudflare-token-secret", "env=staging"), ["install-token"]),
+        (
+            (
+                "cert-manager-certificate-status",
+                "namespace=danielsmith",
+                "certificate=danielsmith-staging-tls",
+                "env=staging",
+            ),
+            ["status", "--namespace", "danielsmith", "--certificate", "danielsmith-staging-tls"],
+        ),
+        (
+            (
+                "cert-manager-certificate-verify-authorization",
+                "namespace=danielsmith",
+                "certificate=danielsmith-staging-tls",
+                "env=staging",
+            ),
+            [
+                "verify-authorization",
+                "--namespace",
+                "danielsmith",
+                "--certificate",
+                "danielsmith-staging-tls",
+            ],
+        ),
+        (
+            (
+                "cert-manager-certificate-recover",
+                "namespace=danielsmith",
+                "certificate=danielsmith-staging-tls",
+                "host=staging.danielsmith.io",
+                "env=staging",
+                "timeout=600",
+            ),
+            [
+                "recover",
+                "--namespace",
+                "danielsmith",
+                "--certificate",
+                "danielsmith-staging-tls",
+                "--host",
+                "staging.danielsmith.io",
+                "--timeout",
+                "600",
+            ],
+        ),
+    ],
+)
+def test_documented_named_arguments_are_normalized(stubbed_python, arguments, expected):
+    result, invocation = run_recipe(stubbed_python, *arguments)
+
+    assert result.returncode == 0, result.stderr
+    assert invocation == [
+        "SUGARKUBE_ENV=staging",
+        str(ROOT / "scripts/staging_cert_manager.py"),
+        *expected,
+    ]
+
+
+def test_status_retains_positional_compatibility(stubbed_python):
+    result, invocation = run_recipe(
+        stubbed_python,
+        "cert-manager-certificate-status",
+        "danielsmith",
+        "danielsmith-staging-tls",
+        "staging",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert invocation[0] == "SUGARKUBE_ENV=staging"
+    assert "namespace=" not in " ".join(invocation)
+
+
+@pytest.mark.parametrize("environment", ["prod", "qa"])
+def test_non_staging_environment_fails_closed_without_kubectl(tmp_path, environment):
+    marker = tmp_path / "kubectl-called"
+    kubectl = tmp_path / "kubectl"
+    kubectl.write_text(f"#!/usr/bin/env bash\ntouch {marker}\n")
+    kubectl.chmod(0o755)
+
+    result = subprocess.run(
+        [
+            "just",
+            "--justfile",
+            str(ROOT / "justfile"),
+            "cert-manager-certificate-status",
+            "namespace=danielsmith",
+            "certificate=danielsmith-staging-tls",
+            f"env={environment}",
+        ],
+        cwd=ROOT,
+        env={**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"},
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 1
+    assert "export SUGARKUBE_ENV=staging" in result.stderr
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ("cert-manager-certificate-status", "namespace=ns", "certificate=cert"),
+        ("cert-manager-certificate-status", "namespace=", "certificate=cert", "env=staging"),
+        (
+            "cert-manager-certificate-status",
+            "host=wrong",
+            "certificate=cert",
+            "env=staging",
+        ),
+        ("cert-manager-cloudflare-token-secret", "env="),
+    ],
+)
+def test_missing_empty_or_mismatched_arguments_fail_before_python(stubbed_python, arguments):
+    result, invocation = run_recipe(stubbed_python, *arguments)
+
+    assert result.returncode != 0
+    assert invocation == []
+    assert "ERROR" in result.stderr or "takes 3" in result.stderr

--- a/tests/test_staging_cert_manager.py
+++ b/tests/test_staging_cert_manager.py
@@ -13,6 +13,12 @@ MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 
 
+@pytest.fixture(autouse=True)
+def available_cmctl(monkeypatch):
+    monkeypatch.setenv("SUGARKUBE_ENV", "staging")
+    monkeypatch.setattr(MODULE.shutil, "which", lambda executable: f"/stub/{executable}")
+
+
 def resource(name, *, owner_kind=None, owner_name=None, status=None, spec=None, conditions=None):
     metadata = {"name": name}
     if owner_kind:
@@ -186,7 +192,10 @@ def test_inventory_propagates_redacted_secret_lookup_failure(monkeypatch):
     assert "<redacted>" in str(caught.value)
 
 
-@pytest.mark.parametrize("environment,context", [("prod", "sugar-staging"), ("staging", "prod")])
+@pytest.mark.parametrize(
+    "environment,context",
+    [("prod", "sugar-staging"), ("qa", "sugar-staging"), ("staging", "prod")],
+)
 def test_staging_guard_rejects_wrong_environment_or_context(monkeypatch, environment, context):
     monkeypatch.setenv("SUGARKUBE_ENV", environment)
     monkeypatch.setattr(
@@ -372,6 +381,40 @@ def test_recover_reports_bounded_failure_without_curl(monkeypatch):
     assert commands == [
         ["cmctl", "--context", "sugar-staging", "renew", "-n", "example", "site-tls"]
     ]
+
+
+def test_recover_missing_cmctl_fails_before_cluster_or_renewal(monkeypatch, capsys):
+    monkeypatch.setattr(MODULE.shutil, "which", lambda _executable: None)
+    monkeypatch.setattr(
+        MODULE.sys,
+        "argv",
+        [
+            "tool",
+            "recover",
+            "--namespace",
+            "example",
+            "--certificate",
+            "site-tls",
+            "--host",
+            "staging.example.test",
+        ],
+    )
+    monkeypatch.setattr(
+        MODULE,
+        "verify_authorization",
+        lambda *_args: pytest.fail("missing cmctl must fail before cluster access"),
+    )
+    monkeypatch.setattr(
+        MODULE,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("missing cmctl must not start a subprocess"),
+    )
+
+    assert MODULE.main() == 1
+    captured = capsys.readouterr()
+    assert "cmctl is required for recovery" in captured.err
+    assert "cmctl version --client" in captured.err
+    assert "Traceback" not in captured.err + captured.out
 
 
 def test_recover_rejects_host_not_named_by_certificate(monkeypatch):


### PR DESCRIPTION
### Motivation

- Repair a name=value propagation regression where `just` passed documented suffixes like `env=staging` literally to the Python operator, causing the guard to refuse execution before any kubectl access.
- Restore the explicit, fail-closed staging safety contract so only `env=staging` and the exact `sugar-staging` kube context are accepted for cluster-facing operations.
- Surface a clear, non-traceback error when `cmctl` is missing so recovery fails fast and safely without attempting renewal.
- Add deterministic regression coverage that exercises the Just recipes end-to-end with a stubbed `python3` to validate exact env/argv propagation and input validation.

### Description

- Normalize recipe arguments in `justfile` for the four affected recipes by adding a `normalize_argument` helper that strips only the expected `key=` prefix, rejects empty or mismatched key-style values, preserves positional invocation compatibility, and sets `SUGARKUBE_ENV` explicitly. (recipes: `cert-manager-cloudflare-token-secret`, `cert-manager-certificate-status`, `cert-manager-certificate-verify-authorization`, `cert-manager-certificate-recover`).
- Strengthen staging checks in `scripts/staging_cert_manager.py` by splitting the environment check into `staging_environment_guard()` and keeping `staging_guard()` for context pinning, and ensuring `SUGARKUBE_ENV` must be exactly `staging` before cluster access.
- Add a precondition in `recover()` that detects a missing `cmctl` via `shutil.which()` and raises an actionable `OperationError` pointing to the official `cmctl` docs and the `cmctl version --client` verification commands.
- Add a new functional test file `tests/test_cert_manager_just_recipes.py` that stubs a `python3` executable and runs the actual `just` recipes to assert exact `SUGARKUBE_ENV` and `argv` propagation, verify positional compatibility, validate malformed/empty inputs fail before Python, and assert non-staging envs fail closed.
- Update unit tests in `tests/test_staging_cert_manager.py` to include an autouse fixture ensuring `cmctl` appears present during those tests and to add a focused `missing cmctl` test exercised via `main()`.
- Update docs `docs/staging-cert-manager.md` to show `env=staging` in examples and explicitly document that status/verify do not require `cmctl` while recovery does, including `command -v cmctl` and `cmctl version --client` guidance.

### Testing

- Ran focused unit tests: `python3 -m pytest -q tests/test_staging_cert_manager.py` — 31 passed.
- Ran new functional Just-recipe tests: `python3 -m pytest -q tests/test_cert_manager_just_recipes.py` — 11 passed.
- Formatting and static checks: `python3 -m black --check` and `python3 -m isort --check-only` for modified files passed; `just --unstable --fmt --check` passed; `git diff --check` and `git diff | ./scripts/scan-secrets.py` passed for the staged changes.
- Link validation: `linkchecker --no-warnings README.md docs/` completed with no errors.
- Reproduction evidence: invoking a stubbed `python3` via `just cert-manager-certificate-status namespace=danielsmith certificate=danielsmith-staging-tls env=staging` produced exactly:
  - `SUGARKUBE_ENV=staging`
  - `--namespace danielsmith`
  - `--certificate danielsmith-staging-tls`
- Warnings / not-run items: `pre-commit run --all-files` encountered unrelated, pre-existing repository-wide hook failures which were not introduced by this PR and were not auto-committed; `pyspelling -c .spellcheck.yaml` could not run in this environment because `aspell` is missing; a full `pytest` run showed the repository test-suite largely passed but one unrelated test failed due to `helm` missing in this execution environment. These are environment/tooling limitations and not regressions from this change.

References #2406 (do not close); no live cluster, Cloudflare API, credential rotation, or certificate mutations were performed during reproduction or testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6bd229c988832fa5140d2d63ccd0ac)