### PR TITLE
Fail closed on active Cloudflare authentication blockers

### DIFF
--- a/docs/staging-cert-manager.md
+++ b/docs/staging-cert-manager.md
@@ -79,10 +79,17 @@ just cert-manager-certificate-verify-authorization namespace=danielsmith certifi
 
 It requires the referenced issuer to be `Ready=True`, its Cloudflare solver to reference
 `cert-manager/cloudflare-api-token` key `api-token`, that Secret to exist, and no related active
-Challenge to report `Found no Zones`. It checks only Secret existence and never retrieves, decodes,
-or prints its value. These structural checks cannot prove the token's Cloudflare dashboard scope;
-only a successfully completed DNS-01 Challenge can do that. Do not call Cloudflare APIs in a way
-that risks logging request headers.
+Challenge to report `Found no Zones`, error 9109 (`Invalid access token`), or error 10502
+(`Too many authentication failures`). Terminal Challenges and historical Events remain diagnostic
+only and do not block a healthy current state. The verifier checks only Secret existence and never
+retrieves, decodes, or prints its value. These structural checks cannot prove the token's Cloudflare
+dashboard scope; only a successfully completed DNS-01 Challenge can do that. Do not call Cloudflare
+APIs in a way that risks logging request headers.
+
+If error 9109 or 10502 is active, recovery is blocked before `cmctl renew`. Stop manual retries.
+For 9109, correct or reinstall the credential through the hidden-input recipe above. For 10502,
+also wait for Cloudflare's authentication throttling to clear before retrying the read-only
+authorization gate; Cloudflare does not document a fixed cooldown here, so do not assume one.
 
 Status and structural authorization verification require `kubectl`, but do not require `cmctl`.
 Recovery additionally requires [`cmctl`](https://cert-manager.io/docs/reference/cmctl/). Install it
@@ -117,9 +124,9 @@ do not silently change issuer or Helm/Flux ownership here.
    ```
 
 3. Review the final redacted resource chain. Confirm the new Order and Challenge are valid and no
-   active Challenge reports `Found no Zones`. Confirm the externally served certificate identity
-   and dates independently if Cloudflare edge termination makes them differ from the Kubernetes
-   Secret; never disable TLS verification.
+   active Challenge reports `Found no Zones`, 9109, or 10502. Confirm the externally served
+   certificate identity and dates independently if Cloudflare edge termination makes them differ
+   from the Kubernetes Secret; never disable TLS verification.
 4. Only after the first certificate passes, repeat for Jobbot3000:
 
    ```bash

--- a/scripts/staging_cert_manager.py
+++ b/scripts/staging_cert_manager.py
@@ -23,6 +23,17 @@ REDACT = re.compile(
     r"word|secret)"
     r"(\s*[:=]?\s+|\s*[:=]\s*)[^\s,;]+"
 )
+AUTHORIZATION_BLOCKERS = (
+    (
+        re.compile(r"(?:error\s*:\s*)?9109\b|invalid access token", re.IGNORECASE),
+        "invalid credentials",
+    ),
+    (
+        re.compile(r"(?:error\s*:\s*)?10502\b|too many authentication failures", re.IGNORECASE),
+        "authentication throttling",
+    ),
+    (re.compile(r"found no zones", re.IGNORECASE), "zone authorization"),
+)
 
 
 class OperationError(RuntimeError):
@@ -216,8 +227,13 @@ def verify_authorization(namespace: str, certificate_name: str) -> dict[str, Any
         )
     for challenge in report["challenges"]:
         detail = f"{challenge['reason']} {challenge['message']}"
-        if challenge["active"] and "found no zones" in detail.lower():
-            raise OperationError("active Challenge reports Found no Zones")
+        if challenge["active"]:
+            for pattern, blocker in AUTHORIZATION_BLOCKERS:
+                if pattern.search(detail):
+                    raise OperationError(
+                        f"active Challenge has a Cloudflare {blocker} blocker; "
+                        "stop retries and resolve it before renewal"
+                    )
     print(
         "authorization structure verified; a successful DNS-01 Challenge is still required to prove dashboard scope"
     )
@@ -232,7 +248,12 @@ def install_token() -> None:
         else sys.stdin.buffer.read()
     )
     credential = credential.strip()
-    if not credential or b"\n" in credential or b"\r" in credential:
+    if (
+        not credential
+        or any(byte in b" \t\r\n\v\f" for byte in credential)
+        or credential[:1] in {b"'", b'"'}
+        or credential[-1:] in {b"'", b'"'}
+    ):
         raise OperationError("token input is empty or malformed")
     create = subprocess.Popen(
         kubectl_command(

--- a/tests/test_staging_cert_manager.py
+++ b/tests/test_staging_cert_manager.py
@@ -267,7 +267,7 @@ def test_verify_authorization_success_does_not_require_certificate_ready(monkeyp
                 challenges=[{"active": True, "reason": "PresentError", "message": "Found no Zones"}]
             ),
             0,
-            "Found no Zones",
+            "zone authorization",
         ),
     ],
 )
@@ -281,6 +281,55 @@ def test_verify_authorization_fails_closed(monkeypatch, report, secret_code, mes
     )
     with pytest.raises(MODULE.OperationError, match=message):
         MODULE.verify_authorization("example", "site-tls")
+
+
+@pytest.mark.parametrize(
+    "reason,message,blocker",
+    [
+        ("PresentError", "Error: 9109: Invalid access token", "invalid credentials"),
+        (
+            "PresentError",
+            "Error: 10502: Too many authentication failures. Please try again later.",
+            "authentication throttling",
+        ),
+    ],
+)
+def test_verify_authorization_rejects_active_cloudflare_authentication_blockers(
+    monkeypatch, reason, message, blocker
+):
+    report = authorization_report(
+        challenges=[{"active": True, "reason": reason, "message": message}]
+    )
+    monkeypatch.setattr(MODULE, "staging_guard", lambda: None)
+    monkeypatch.setattr(MODULE, "inventory", lambda *_args: report)
+    monkeypatch.setattr(
+        MODULE,
+        "run",
+        lambda command, **_kwargs: subprocess.CompletedProcess(command, 0, b"secret/name", b""),
+    )
+
+    with pytest.raises(MODULE.OperationError, match=blocker) as caught:
+        MODULE.verify_authorization("example", "site-tls")
+    assert "access token" not in str(caught.value).lower()
+
+
+def test_verify_authorization_ignores_terminal_errors_and_historical_events(monkeypatch):
+    report = authorization_report(
+        challenges=[
+            {"active": False, "reason": "Failed", "message": "Error: 9109"},
+            {"active": True, "reason": "Presented", "message": "DNS record presented"},
+        ]
+    )
+    report["events"] = [{"message": "Error: 10502: historical"}]
+    monkeypatch.setattr(MODULE, "staging_guard", lambda: None)
+    monkeypatch.setattr(MODULE, "inventory", lambda *_args: report)
+    monkeypatch.setattr(
+        MODULE,
+        "run",
+        lambda command, **_kwargs: subprocess.CompletedProcess(command, 0, b"secret/name", b""),
+    )
+
+    assert MODULE.verify_authorization("example", "site-tls") is report
 
 
 def test_kubectl_json_failure_is_redacted(monkeypatch):
@@ -430,6 +479,90 @@ def test_install_token_rejects_empty_input_before_starting_process(monkeypatch):
 
     with pytest.raises(MODULE.OperationError, match="empty or malformed"):
         MODULE.install_token()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        b"Bearer" + b" " + b"wrapped-value",
+        b"embedded" + b"\t" + b"whitespace",
+        b"'quoted-value'",
+        b'"quoted-value"',
+    ],
+)
+def test_install_token_rejects_wrappers_and_whitespace_before_kubectl(monkeypatch, value):
+    class Input:
+        def isatty(self):
+            return False
+
+        buffer = type("Buffer", (), {"read": staticmethod(lambda: value)})()
+
+    monkeypatch.setattr(MODULE, "staging_guard", lambda: None)
+    monkeypatch.setattr(MODULE.sys, "stdin", Input())
+    monkeypatch.setattr(
+        MODULE.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: pytest.fail("malformed input must not start kubectl"),
+    )
+
+    with pytest.raises(MODULE.OperationError, match="empty or malformed") as caught:
+        MODULE.install_token()
+    assert value.decode() not in str(caught.value)
+
+
+@pytest.mark.parametrize("value", [b"legacy-token-shape", b"v1.0-prefixed_token-shape"])
+def test_install_token_accepts_legacy_and_prefixed_shapes_without_disclosure(
+    monkeypatch, capsys, value
+):
+    class Input:
+        def isatty(self):
+            return False
+
+        buffer = type("Buffer", (), {"read": staticmethod(lambda: value + b"\n")})()
+
+    commands = []
+
+    class Process:
+        def __init__(self, command, **_kwargs):
+            commands.append(command)
+            self.stdin = type(
+                "Writer", (), {"write": lambda self, _value: None, "close": lambda self: None}
+            )()
+            self.stdout = type("Reader", (), {"close": lambda self: None})()
+            self.stderr = type("Errors", (), {"read": lambda self: b""})()
+            self.returncode = 0
+
+        def communicate(self):
+            return b"", b""
+
+        def wait(self):
+            return 0
+
+    monkeypatch.setattr(MODULE, "staging_guard", lambda: None)
+    monkeypatch.setattr(MODULE.sys, "stdin", Input())
+    monkeypatch.setattr(MODULE.subprocess, "Popen", Process)
+
+    MODULE.install_token()
+    output = capsys.readouterr()
+    rendered = repr(commands) + output.out + output.err
+    assert value.decode() not in rendered
+
+
+def test_recover_does_not_renew_when_active_authentication_blocker_exists(monkeypatch):
+    monkeypatch.setattr(MODULE.shutil, "which", lambda _name: "/usr/bin/cmctl")
+    monkeypatch.setattr(
+        MODULE,
+        "verify_authorization",
+        lambda *_args: (_ for _ in ()).throw(
+            MODULE.OperationError("active Challenge has a Cloudflare invalid credentials blocker")
+        ),
+    )
+    monkeypatch.setattr(
+        MODULE, "run", lambda *_args, **_kwargs: pytest.fail("cmctl renew must not be invoked")
+    )
+
+    with pytest.raises(MODULE.OperationError, match="invalid credentials"):
+        MODULE.recover("example", "site-tls", "staging.example.test", 60)
 
 
 def test_install_token_redacts_process_failure(monkeypatch):


### PR DESCRIPTION
### Motivation

- The staging Danielsmith state showed an active Challenge with Cloudflare errors (9109 `Invalid access token` and 10502 `Too many authentication failures`) while the structural verifier still succeeded, which could allow another `cmctl renew` attempt during a known authentication failure (closes #2406).

### Description

- Extend the authorization gate to fail-closed when an active Challenge's reason/message matches Cloudflare authentication blockers (9109 / `Invalid access token`, 10502 / `Too many authentication failures`) or the existing `Found no Zones` condition, classifying the blocker as `invalid credentials`, `authentication throttling`, or `zone authorization` and returning a redacted, actionable message.
- Ensure only current active Challenges block recovery while terminal/stale Challenges and historical Events remain diagnostic and do not gate a healthy state.
- Prevent `recover()` from reaching `cmctl renew` when `verify_authorization()` reports an active blocker by surfacing the failure before renewal.
- Harden hidden token installation: reject inputs with embedded whitespace or surrounding quotes (e.g. accidental `Bearer <token>` wrappers or quoted paste) while continuing to accept legacy unprefixed tokens and prefixed token shapes without imposing an exact length or exposing the credential; credential bytes are never printed.
- Update the staging runbook to document that 9109 and 10502 block recovery, to instruct operators to stop manual retries, to reinstall credentials via the hidden-input recipe when needed, and to wait for Cloudflare throttling to clear without inventing a fixed cooldown.
- Files changed: `scripts/staging_cert_manager.py`, `tests/test_staging_cert_manager.py`, `docs/staging-cert-manager.md`.

### Testing

- Ran targeted tests: `python3 -m pytest -q tests/test_staging_cert_manager.py tests/test_cert_manager_just_recipes.py` — 42 passed, 10 skipped (all new and modified tests passed).
- Ran full test suite: `python3 -m pytest -q` — 2009 passed, 61 skipped; one unrelated environment failure in `tests/test_monitoring_blackbox.py` due to missing `helm` executable in the container (not related to these changes).
- Formatting and static checks: `python3 -m black --check scripts/staging_cert_manager.py tests/test_staging_cert_manager.py` (no outstanding issues after formatting); `git diff --cached | ./scripts/scan-secrets.py` reported no committed secrets.
- Environment notes: `pre-commit`, `pyspelling`, and `linkchecker` were not installed in the execution environment so those repo checks were not run here.

Residual risk: CI images without `helm` can cause unrelated test failures; the change is limited to the staging cert-manager helper, tests, and runbook and does not touch issuers, Helm releases, or production configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c04478268832faaba2eac6c25e2fa)