### PR TITLE
Fail closed on active Cloudflare auth failures

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -240,8 +240,11 @@ Common failure modes:
   --from-file=api-token=/dev/stdin`; never put the token in a command argument or visible shell
   environment assignment.
   In staging, run the guarded `cert-manager-certificate-verify-authorization` recipe before one
-  recovery attempt; it requires the exact `sugar-staging` context. Structural checks do not prove
-  Cloudflare dashboard scope until a DNS-01 Challenge succeeds.
+  recovery attempt; it requires the exact `sugar-staging` context and blocks active Cloudflare
+  `9109`, `10502`, and `Found no Zones` errors. Stop retries, correct credentials through the
+  hidden-input workflow when needed, and wait for authentication throttling to clear before
+  rerunning the read-only gate. Structural checks do not prove Cloudflare dashboard scope until a
+  DNS-01 Challenge succeeds.
 - **Challenge cleanup errors after successful issuance**: Cloudflare API token is missing `Zone:Read` and/or is scoped to the wrong zone.
 
 Validation sequence:

--- a/docs/staging-cert-manager.md
+++ b/docs/staging-cert-manager.md
@@ -79,10 +79,20 @@ just cert-manager-certificate-verify-authorization namespace=danielsmith certifi
 
 It requires the referenced issuer to be `Ready=True`, its Cloudflare solver to reference
 `cert-manager/cloudflare-api-token` key `api-token`, that Secret to exist, and no related active
-Challenge to report `Found no Zones`. It checks only Secret existence and never retrieves, decodes,
-or prints its value. These structural checks cannot prove the token's Cloudflare dashboard scope;
+Challenge to report `Found no Zones`, `9109` / `Invalid access token`, or `10502` /
+`Too many authentication failures`. Only current, active Challenge status blocks the gate;
+terminal Challenges and historical Events remain useful diagnostics but do not independently
+block a healthy current state. The verifier checks only Secret existence and never retrieves,
+decodes, or prints its value. These structural checks cannot prove the token's Cloudflare
+dashboard scope;
 only a successfully completed DNS-01 Challenge can do that. Do not call Cloudflare APIs in a way
 that risks logging request headers.
+
+If `9109` or `10502` blocks the gate, stop manual retries. For invalid credentials, correct and
+reinstall the credential through the hidden-input recipe above. For authentication throttling,
+wait for Cloudflare throttling to clear before retrying the read-only authorization gate; Cloudflare
+does not document a fixed cooldown here, so do not assume one. A `Found no Zones` blocker requires
+correct account and zone scope before reinstalling the credential and rerunning the gate.
 
 Status and structural authorization verification require `kubectl`, but do not require `cmctl`.
 Recovery additionally requires [`cmctl`](https://cert-manager.io/docs/reference/cmctl/). Install it
@@ -117,7 +127,8 @@ do not silently change issuer or Helm/Flux ownership here.
    ```
 
 3. Review the final redacted resource chain. Confirm the new Order and Challenge are valid and no
-   active Challenge reports `Found no Zones`. Confirm the externally served certificate identity
+   active Challenge reports a Cloudflare authentication or zone-authorization blocker. Confirm the
+   externally served certificate identity
    and dates independently if Cloudflare edge termination makes them differ from the Kubernetes
    Secret; never disable TLS verification.
 4. Only after the first certificate passes, repeat for Jobbot3000:

--- a/scripts/staging_cert_manager.py
+++ b/scripts/staging_cert_manager.py
@@ -23,6 +23,23 @@ REDACT = re.compile(
     r"word|secret)"
     r"(\s*[:=]?\s+|\s*[:=]\s*)[^\s,;]+"
 )
+AUTHORIZATION_BLOCKERS = (
+    (
+        ("9109", "invalid access token"),
+        "invalid Cloudflare credentials",
+        "reinstall the credential with the hidden-input recipe",
+    ),
+    (
+        ("10502", "too many authentication failures"),
+        "Cloudflare authentication throttling",
+        "stop retries and wait for throttling to clear",
+    ),
+    (
+        ("found no zones",),
+        "Cloudflare zone authorization",
+        "correct the credential's account and zone scope",
+    ),
+)
 
 
 class OperationError(RuntimeError):
@@ -215,9 +232,15 @@ def verify_authorization(namespace: str, certificate_name: str) -> dict[str, Any
             f"required Secret {TOKEN_SECRET_NAMESPACE}/{TOKEN_SECRET_NAME} is missing or inaccessible"
         )
     for challenge in report["challenges"]:
-        detail = f"{challenge['reason']} {challenge['message']}"
-        if challenge["active"] and "found no zones" in detail.lower():
-            raise OperationError("active Challenge reports Found no Zones")
+        if not challenge["active"]:
+            continue
+        detail = f"{challenge['reason']} {challenge['message']}".lower()
+        for indicators, blocker, action in AUTHORIZATION_BLOCKERS:
+            if any(indicator in detail for indicator in indicators):
+                raise OperationError(
+                    f"active Challenge blocked by {blocker}; {action}, then retry authorization "
+                    "verification"
+                )
     print(
         "authorization structure verified; a successful DNS-01 Challenge is still required to prove dashboard scope"
     )
@@ -232,7 +255,12 @@ def install_token() -> None:
         else sys.stdin.buffer.read()
     )
     credential = credential.strip()
-    if not credential or b"\n" in credential or b"\r" in credential:
+    quoted = (
+        len(credential) >= 2
+        and credential[:1] == credential[-1:]
+        and credential[:1] in {b"'", b'"'}
+    )
+    if not credential or any(chr(byte).isspace() for byte in credential) or quoted:
         raise OperationError("token input is empty or malformed")
     create = subprocess.Popen(
         kubectl_command(

--- a/tests/test_staging_cert_manager.py
+++ b/tests/test_staging_cert_manager.py
@@ -267,7 +267,21 @@ def test_verify_authorization_success_does_not_require_certificate_ready(monkeyp
                 challenges=[{"active": True, "reason": "PresentError", "message": "Found no Zones"}]
             ),
             0,
-            "Found no Zones",
+            "zone authorization",
+        ),
+        (
+            authorization_report(
+                challenges=[{"active": True, "reason": "PresentError", "message": "Error: 9109"}]
+            ),
+            0,
+            "invalid Cloudflare credentials",
+        ),
+        (
+            authorization_report(
+                challenges=[{"active": True, "reason": "PresentError", "message": "Error: 10502"}]
+            ),
+            0,
+            "authentication throttling",
         ),
     ],
 )
@@ -283,6 +297,47 @@ def test_verify_authorization_fails_closed(monkeypatch, report, secret_code, mes
         MODULE.verify_authorization("example", "site-tls")
 
 
+@pytest.mark.parametrize("state", ["valid", "expired", "invalid"])
+def test_verify_authorization_ignores_terminal_challenge_errors(monkeypatch, state):
+    report = authorization_report(
+        challenges=[
+            {
+                "active": False,
+                "state": state,
+                "reason": "PresentError",
+                "message": "Error: 9109: Invalid access token",
+            }
+        ]
+    )
+    monkeypatch.setattr(MODULE, "staging_guard", lambda: None)
+    monkeypatch.setattr(MODULE, "inventory", lambda *_args: report)
+    monkeypatch.setattr(
+        MODULE,
+        "run",
+        lambda command, **_kwargs: subprocess.CompletedProcess(command, 0, b"secret/name", b""),
+    )
+
+    assert MODULE.verify_authorization("example", "site-tls") is report
+
+
+def test_verify_authorization_ignores_historical_error_events(monkeypatch):
+    report = authorization_report(
+        challenges=[{"active": True, "reason": "Pending", "message": "Waiting for DNS"}]
+    )
+    report["events"] = [
+        {"reason": "PresentError", "message": "Error: 10502: Too many authentication failures"}
+    ]
+    monkeypatch.setattr(MODULE, "staging_guard", lambda: None)
+    monkeypatch.setattr(MODULE, "inventory", lambda *_args: report)
+    monkeypatch.setattr(
+        MODULE,
+        "run",
+        lambda command, **_kwargs: subprocess.CompletedProcess(command, 0, b"secret/name", b""),
+    )
+
+    assert MODULE.verify_authorization("example", "site-tls") is report
+
+
 def test_kubectl_json_failure_is_redacted(monkeypatch):
     monkeypatch.setattr(
         MODULE,
@@ -296,12 +351,13 @@ def test_kubectl_json_failure_is_redacted(monkeypatch):
     assert "visible-value" not in str(caught.value)
 
 
-def test_runtime_token_command_uses_stdin_and_context(monkeypatch, capsys):
+@pytest.mark.parametrize("credential", [b"x" * 32, b"v1.0-" + b"x" * 48])
+def test_runtime_token_command_uses_valid_shapes_via_stdin(monkeypatch, capsys, credential):
     class Input:
         def isatty(self):
             return False
 
-        buffer = type("Buffer", (), {"read": staticmethod(lambda: b"runtime-credential")})()
+        buffer = type("Buffer", (), {"read": staticmethod(lambda: credential)})()
 
     commands = []
 
@@ -326,7 +382,8 @@ def test_runtime_token_command_uses_stdin_and_context(monkeypatch, capsys):
     monkeypatch.setattr(MODULE.subprocess, "Popen", Process)
     MODULE.install_token()
     rendered = " ".join(word for command in commands for word in command)
-    assert "runtime-credential" not in rendered + capsys.readouterr().out
+    output = rendered + capsys.readouterr().out
+    assert credential.decode() not in output
     assert "--from-file=" + MODULE.TOKEN_SECRET_KEY + "=/dev/stdin" in rendered
     assert commands[0][1:3] == ["--context", "sugar-staging"]
 
@@ -402,6 +459,26 @@ def test_recover_rejects_host_not_named_by_certificate(monkeypatch):
     assert commands == []
 
 
+def test_recover_does_not_renew_when_active_authentication_is_blocked(monkeypatch):
+    report = authorization_report(
+        challenges=[{"active": True, "reason": "PresentError", "message": "Invalid access token"}]
+    )
+    monkeypatch.setattr(MODULE.shutil, "which", lambda _name: "/usr/bin/cmctl")
+    monkeypatch.setattr(MODULE, "staging_guard", lambda: None)
+    monkeypatch.setattr(MODULE, "inventory", lambda *_args: report)
+    commands = []
+
+    def fake_run(command, **_kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, b"secret/name", b"")
+
+    monkeypatch.setattr(MODULE, "run", fake_run)
+    with pytest.raises(MODULE.OperationError, match="invalid Cloudflare credentials"):
+        MODULE.recover("example", "site-tls", "staging.example.test", 60)
+
+    assert not any(command[0] == "cmctl" for command in commands)
+
+
 def test_kubectl_json_rejects_invalid_json(monkeypatch):
     monkeypatch.setattr(
         MODULE,
@@ -430,6 +507,35 @@ def test_install_token_rejects_empty_input_before_starting_process(monkeypatch):
 
     with pytest.raises(MODULE.OperationError, match="empty or malformed"):
         MODULE.install_token()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        b"Bearer " + b"x" * 24,
+        b"legacy\tvalue",
+        b"'" + b"x" * 24 + b"'",
+        b'"' + b"x" * 24 + b'"',
+    ],
+)
+def test_install_token_rejects_wrapped_or_whitespace_input_before_kubectl(monkeypatch, value):
+    class Input:
+        def isatty(self):
+            return False
+
+        buffer = type("Buffer", (), {"read": staticmethod(lambda: value)})()
+
+    monkeypatch.setattr(MODULE, "staging_guard", lambda: None)
+    monkeypatch.setattr(MODULE.sys, "stdin", Input())
+    monkeypatch.setattr(
+        MODULE.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: pytest.fail("malformed input must not start kubectl"),
+    )
+
+    with pytest.raises(MODULE.OperationError, match="empty or malformed") as caught:
+        MODULE.install_token()
+    assert value.decode() not in str(caught.value)
 
 
 def test_install_token_redacts_process_failure(monkeypatch):


### PR DESCRIPTION
### Motivation

- Operational status showed an active DNS-01 Challenge reporting Cloudflare authentication blockers (examples include `Error: 10502: Too many authentication failures` and recent `Error: 9109: Invalid access token`) while the structural verifier still exited successfully, which could allow another issuance attempt despite known Cloudflare auth problems.

### Description

- Extend `verify_authorization()` to treat active Challenge status containing Cloudflare `9109` (invalid token), `10502` (authentication throttling), or the existing `Found no Zones` signal as a fail-closed blocker and return a concise, redacted, actionable reason rather than proceeding.
- Ensure the decision is based only on current active Challenge status and that terminal/stale Challenges or historical Events do not block authorization verification.
- Make `recover()` inherit the gate so it cannot invoke `cmctl renew` while an active Cloudflare auth blocker is present.
- Harden `install_token()` to reject obviously malformed pasted values by refusing embedded whitespace wrappers and surrounding single/double quotes while still accepting valid legacy/prefixed token shapes, and avoid exposing credential data in any output or subprocess argv.
- Add deterministic unit tests exercising: active Found-no-Zones, 9109, 10502 rejections; terminal/stale Challenge and historical Event non-blocking behavior; `recover()` short-circuiting (no `cmctl` run) when blocked; malformed-wrapped/whitespace credential rejection; and valid token-shaped stdin acceptance.
- Update `docs/staging-cert-manager.md` and the related runbook text to document the new gating semantics and operator guidance (stop retries, reinstall credential via hidden-input recipe for invalid credentials, wait for throttling to clear for 10502, do not assume a fixed cooldown) while preserving one-certificate-at-a-time / ACME rate-limit cautions.

### Testing

- Ran the focused test suite: `python3 -m pytest -q tests/test_staging_cert_manager.py tests/test_cert_manager_just_recipes.py` — all tests passed (54 passed, 10 skipped in local runs shown during rollout).
- Ran full test run: `python3 -m pytest -q` — majority passed (2011 passed, 61 skipped) with one unrelated environment-local failure pointing to a missing `helm` executable in CI emulation; the failure is not related to these changes.
- Formatting and static checks: `python3 -m black --check scripts/staging_cert_manager.py tests/test_staging_cert_manager.py` and `python3 -m isort --check-only scripts/staging_cert_manager.py tests/test_staging_cert_manager.py` passed after formatting; `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` passed.
- Repository pre-commit hooks were exercised; unrelated whitespace fixes were applied and reverted for files outside the change scope where appropriate, and targeted pre-commit hooks for the changed files passed; `git diff --cached | ./scripts/scan-secrets.py` returned no exposed secrets.

Closes #2406

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c044f1478832fa00a5f8c5e625afb)