### PR TITLE
Fail staging cert-manager recovery closed on Cloudflare auth errors (9109 / 10502)

### DIFF
--- a/docs/staging-cert-manager.md
+++ b/docs/staging-cert-manager.md
@@ -79,10 +79,19 @@ just cert-manager-certificate-verify-authorization namespace=danielsmith certifi
 
 It requires the referenced issuer to be `Ready=True`, its Cloudflare solver to reference
 `cert-manager/cloudflare-api-token` key `api-token`, that Secret to exist, and no related active
-Challenge to report `Found no Zones`. It checks only Secret existence and never retrieves, decodes,
-or prints its value. These structural checks cannot prove the token's Cloudflare dashboard scope;
-only a successfully completed DNS-01 Challenge can do that. Do not call Cloudflare APIs in a way
-that risks logging request headers.
+Challenge to report `Found no Zones`, error 9109 (`Invalid access token`), or error 10502
+(`Too many authentication failures`). Current active Challenge status blocks the gate; terminal
+Challenges and historical Events remain diagnostic and do not independently block recovery. The
+verifier checks only Secret existence and never retrieves, decodes, or prints its value. These
+structural checks cannot prove the token's Cloudflare dashboard scope; only a successfully
+completed DNS-01 Challenge can do that. Do not call Cloudflare APIs in a way that risks logging
+request headers.
+
+If 9109 or 10502 is active, stop manual retries. For 9109, correct the credential or its scope and
+reinstall it through the hidden-input recipe above. For 10502, wait for Cloudflare's authentication
+throttling to clear without assuming a fixed cooldown. Then retry the read-only authorization gate
+before attempting recovery. A `Found no Zones` blocker requires correcting `Zone.read`, the
+account, or explicit zone scope before rerunning the gate.
 
 Status and structural authorization verification require `kubectl`, but do not require `cmctl`.
 Recovery additionally requires [`cmctl`](https://cert-manager.io/docs/reference/cmctl/). Install it
@@ -117,9 +126,9 @@ do not silently change issuer or Helm/Flux ownership here.
    ```
 
 3. Review the final redacted resource chain. Confirm the new Order and Challenge are valid and no
-   active Challenge reports `Found no Zones`. Confirm the externally served certificate identity
-   and dates independently if Cloudflare edge termination makes them differ from the Kubernetes
-   Secret; never disable TLS verification.
+   active Challenge reports `Found no Zones`, 9109, or 10502. Confirm the externally served
+   certificate identity and dates independently if Cloudflare edge termination makes them differ
+   from the Kubernetes Secret; never disable TLS verification.
 4. Only after the first certificate passes, repeat for Jobbot3000:
 
    ```bash

--- a/scripts/staging_cert_manager.py
+++ b/scripts/staging_cert_manager.py
@@ -23,6 +23,17 @@ REDACT = re.compile(
     r"word|secret)"
     r"(\s*[:=]?\s+|\s*[:=]\s*)[^\s,;]+"
 )
+AUTHORIZATION_BLOCKERS = (
+    (
+        re.compile(r"(?i)\b(?:9109|invalid access token)\b"),
+        "invalid credentials; reinstall the Cloudflare token",
+    ),
+    (
+        re.compile(r"(?i)\b(?:10502|too many authentication failures)\b"),
+        "authentication throttling; stop retries and wait for Cloudflare to clear it",
+    ),
+    (re.compile(r"(?i)\bfound no zones\b"), "zone authorization; check Zone.read and zone scope"),
+)
 
 
 class OperationError(RuntimeError):
@@ -216,8 +227,10 @@ def verify_authorization(namespace: str, certificate_name: str) -> dict[str, Any
         )
     for challenge in report["challenges"]:
         detail = f"{challenge['reason']} {challenge['message']}"
-        if challenge["active"] and "found no zones" in detail.lower():
-            raise OperationError("active Challenge reports Found no Zones")
+        if challenge["active"]:
+            for pattern, action in AUTHORIZATION_BLOCKERS:
+                if pattern.search(detail):
+                    raise OperationError(f"active Challenge blocked by Cloudflare {action}")
     print(
         "authorization structure verified; a successful DNS-01 Challenge is still required to prove dashboard scope"
     )
@@ -232,7 +245,16 @@ def install_token() -> None:
         else sys.stdin.buffer.read()
     )
     credential = credential.strip()
-    if not credential or b"\n" in credential or b"\r" in credential:
+    quoted = (
+        len(credential) >= 2
+        and credential[:1] == credential[-1:]
+        and credential[:1]
+        in {
+            b"'",
+            b'"',
+        }
+    )
+    if not credential or re.search(rb"\s", credential) or quoted:
         raise OperationError("token input is empty or malformed")
     create = subprocess.Popen(
         kubectl_command(

--- a/scripts/staging_cert_manager.py
+++ b/scripts/staging_cert_manager.py
@@ -34,6 +34,7 @@ AUTHORIZATION_BLOCKERS = (
     ),
     (re.compile(r"(?i)\bfound no zones\b"), "zone authorization; check Zone.read and zone scope"),
 )
+TERMINAL_CHALLENGE_STATES = {"valid", "invalid", "expired", "revoked", "errored"}
 
 
 class OperationError(RuntimeError):
@@ -189,8 +190,7 @@ def inventory(namespace: str, certificate_name: str) -> dict[str, Any]:
             {
                 **resource_state(item),
                 "dnsName": item.get("spec", {}).get("dnsName"),
-                "active": item.get("status", {}).get("state")
-                not in {"valid", "expired", "invalid"},
+                "active": item.get("status", {}).get("state") not in TERMINAL_CHALLENGE_STATES,
             }
             for item in challenges
         ],

--- a/tests/test_staging_cert_manager.py
+++ b/tests/test_staging_cert_manager.py
@@ -118,6 +118,109 @@ def test_inventory_rejects_missing_issuer_reference(monkeypatch):
         MODULE.inventory("example", "broken")
 
 
+def inventory_with_challenges(monkeypatch, challenges):
+    certificate = resource(
+        "site-tls",
+        spec={
+            "dnsNames": ["staging.example.test"],
+            "issuerRef": {"name": "letsencrypt-staging", "kind": "ClusterIssuer"},
+        },
+    )
+    request = resource("site-tls-1", owner_kind="Certificate", owner_name="site-tls")
+    order = resource("site-tls-1-order", owner_kind="CertificateRequest", owner_name="site-tls-1")
+    for challenge in challenges:
+        challenge["metadata"]["ownerReferences"] = [{"kind": "Order", "name": "site-tls-1-order"}]
+    responses = {
+        "certificate": certificate,
+        "clusterissuer": resource(
+            "letsencrypt-staging",
+            spec={
+                "acme": {
+                    "solvers": [
+                        {
+                            "dns01": {
+                                "cloudflare": {
+                                    "apiTokenSecretRef": {
+                                        "name": "cloudflare-api-token",
+                                        "key": "api-token",
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            conditions=[{"type": "Ready", "status": "True"}],
+        ),
+        "certificaterequests": {"items": [request]},
+        "orders": {"items": [order]},
+        "challenges": {"items": challenges},
+        "events": {"items": []},
+    }
+    monkeypatch.setattr(
+        MODULE,
+        "kubectl_json",
+        lambda args: responses[next(item for item in responses if item in args)],
+    )
+    return MODULE.inventory("example", "site-tls")
+
+
+@pytest.mark.parametrize("state", sorted(MODULE.TERMINAL_CHALLENGE_STATES))
+def test_inventory_marks_every_terminal_challenge_state_inactive(monkeypatch, state):
+    report = inventory_with_challenges(
+        monkeypatch, [resource("challenge", status={"state": state})]
+    )
+
+    assert report["challenges"][0]["active"] is False
+
+
+@pytest.mark.parametrize("state", ["errored", "revoked"])
+@pytest.mark.parametrize(
+    "detail", ["Error: 9109", "Error: 10502: Too many authentication failures", "Found no Zones"]
+)
+def test_terminal_challenge_auth_text_does_not_block_authorization(monkeypatch, state, detail):
+    report = inventory_with_challenges(
+        monkeypatch,
+        [resource("terminal", status={"state": state, "reason": detail})],
+    )
+    assert report["challenges"][0]["active"] is False
+
+    monkeypatch.setattr(MODULE, "staging_guard", lambda: None)
+    monkeypatch.setattr(MODULE, "inventory", lambda *_args: report)
+    monkeypatch.setattr(
+        MODULE,
+        "run",
+        lambda command, **_kwargs: subprocess.CompletedProcess(command, 0, b"secret/name", b""),
+    )
+
+    assert MODULE.verify_authorization("example", "site-tls") is report
+
+
+@pytest.mark.parametrize("detail", ["Error: 9109", "Error: 10502"])
+def test_pending_auth_challenge_blocks_verification_and_recovery(monkeypatch, detail):
+    report = inventory_with_challenges(
+        monkeypatch,
+        [resource("pending", status={"state": "pending", "message": detail})],
+    )
+    assert report["challenges"][0]["active"] is True
+
+    monkeypatch.setattr(MODULE, "staging_guard", lambda: None)
+    monkeypatch.setattr(MODULE, "inventory", lambda *_args: report)
+    monkeypatch.setattr(MODULE.shutil, "which", lambda _name: "/usr/bin/cmctl")
+
+    def secret_lookup_only(command, **_kwargs):
+        if command[0] == "cmctl":
+            pytest.fail("cmctl renew must not be invoked")
+        return subprocess.CompletedProcess(command, 0, b"secret/name", b"")
+
+    monkeypatch.setattr(MODULE, "run", secret_lookup_only)
+
+    with pytest.raises(MODULE.OperationError, match="active Challenge blocked"):
+        MODULE.verify_authorization("example", "site-tls")
+    with pytest.raises(MODULE.OperationError, match="active Challenge blocked"):
+        MODULE.recover("example", "site-tls", "staging.example.test", 60)
+
+
 @pytest.mark.parametrize(
     "stdout,expected",
     [(b"secret/site-tls\n", True), (b"", False)],

--- a/tests/test_staging_cert_manager.py
+++ b/tests/test_staging_cert_manager.py
@@ -267,7 +267,27 @@ def test_verify_authorization_success_does_not_require_certificate_ready(monkeyp
                 challenges=[{"active": True, "reason": "PresentError", "message": "Found no Zones"}]
             ),
             0,
-            "Found no Zones",
+            "zone authorization",
+        ),
+        (
+            authorization_report(
+                challenges=[{"active": True, "reason": "PresentError", "message": "Error: 9109"}]
+            ),
+            0,
+            "invalid credentials",
+        ),
+        (
+            authorization_report(
+                challenges=[
+                    {
+                        "active": True,
+                        "reason": "Error: 10502: Too many authentication failures",
+                        "message": "",
+                    }
+                ]
+            ),
+            0,
+            "authentication throttling",
         ),
     ],
 )
@@ -281,6 +301,27 @@ def test_verify_authorization_fails_closed(monkeypatch, report, secret_code, mes
     )
     with pytest.raises(MODULE.OperationError, match=message):
         MODULE.verify_authorization("example", "site-tls")
+
+
+def test_verify_authorization_ignores_terminal_errors_and_historical_events(monkeypatch):
+    report = authorization_report(
+        challenges=[
+            {"active": False, "reason": "PresentError", "message": "Error: 9109"},
+            {"active": True, "reason": "Presented", "message": "DNS record presented"},
+        ]
+    )
+    report["events"] = [
+        {"reason": "PresentError", "message": "Error: 10502: Too many authentication failures"}
+    ]
+    monkeypatch.setattr(MODULE, "staging_guard", lambda: None)
+    monkeypatch.setattr(MODULE, "inventory", lambda *_args: report)
+    monkeypatch.setattr(
+        MODULE,
+        "run",
+        lambda command, **_kwargs: subprocess.CompletedProcess(command, 0, b"secret/name", b""),
+    )
+
+    assert MODULE.verify_authorization("example", "site-tls") is report
 
 
 def test_kubectl_json_failure_is_redacted(monkeypatch):
@@ -430,6 +471,98 @@ def test_install_token_rejects_empty_input_before_starting_process(monkeypatch):
 
     with pytest.raises(MODULE.OperationError, match="empty or malformed"):
         MODULE.install_token()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        b"Bearer " + b"token-shaped-value",
+        b"token shaped value",
+        b"'token-shaped-value'",
+        b'"token-shaped-value"',
+    ],
+)
+def test_install_token_rejects_wrapped_or_whitespace_input_before_kubectl(monkeypatch, value):
+    class Input:
+        def isatty(self):
+            return False
+
+        buffer = type("Buffer", (), {"read": staticmethod(lambda: value)})()
+
+    monkeypatch.setattr(MODULE, "staging_guard", lambda: None)
+    monkeypatch.setattr(MODULE.sys, "stdin", Input())
+    monkeypatch.setattr(
+        MODULE.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: pytest.fail("malformed input must not start kubectl"),
+    )
+
+    with pytest.raises(MODULE.OperationError, match="empty or malformed") as caught:
+        MODULE.install_token()
+    assert value.decode() not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [b"legacy" + b"TokenShape_123", b"v1.0-" + b"prefixed_Token-Shape_456"],
+)
+def test_install_token_accepts_legacy_and_prefixed_shapes_without_disclosure(
+    monkeypatch, capsys, value
+):
+    class Input:
+        def isatty(self):
+            return False
+
+        buffer = type("Buffer", (), {"read": staticmethod(lambda: value)})()
+
+    writes = []
+
+    class Process:
+        def __init__(self, _command, **_kwargs):
+            self.stdin = type(
+                "Writer",
+                (),
+                {
+                    "write": lambda _self, item: writes.append(len(item)),
+                    "close": lambda _self: None,
+                },
+            )()
+            self.stdout = type("Reader", (), {"close": lambda _self: None})()
+            self.stderr = type("Errors", (), {"read": lambda _self: b""})()
+            self.returncode = 0
+
+        def communicate(self):
+            return b"", b""
+
+        def wait(self):
+            return 0
+
+    monkeypatch.setattr(MODULE, "staging_guard", lambda: None)
+    monkeypatch.setattr(MODULE.sys, "stdin", Input())
+    monkeypatch.setattr(MODULE.subprocess, "Popen", Process)
+
+    MODULE.install_token()
+
+    output = capsys.readouterr()
+    assert writes == [len(value)]
+    assert value.decode() not in output.out + output.err
+
+
+def test_recover_does_not_renew_when_authorization_is_blocked(monkeypatch):
+    monkeypatch.setattr(MODULE.shutil, "which", lambda _name: "/usr/bin/cmctl")
+    monkeypatch.setattr(
+        MODULE,
+        "verify_authorization",
+        lambda *_args: (_ for _ in ()).throw(
+            MODULE.OperationError("active Challenge blocked by Cloudflare invalid credentials")
+        ),
+    )
+    monkeypatch.setattr(
+        MODULE, "run", lambda *_args, **_kwargs: pytest.fail("cmctl renew must not be invoked")
+    )
+
+    with pytest.raises(MODULE.OperationError, match="invalid credentials"):
+        MODULE.recover("example", "site-tls", "staging.example.test", 60)
 
 
 def test_install_token_redacts_process_failure(monkeypatch):


### PR DESCRIPTION
### Motivation

Staging showed an active DNS-01 Challenge reporting Cloudflare error 10502 (`Too many authentication failures`) and recent error 9109 (`Invalid access token`), while the structural authorization verifier still succeeded. Because recovery invokes this verifier before `cmctl renew`, the previous behavior could permit another issuance attempt during a known authentication failure.

This focused follow-up makes the staging workflow fail closed without making live Kubernetes or Cloudflare changes.

### Changes

- Reject current active Challenges reporting:
  - 9109 / `Invalid access token`;
  - 10502 / `Too many authentication failures`;
  - `Found no Zones`.
- Return concise, redacted remediation for invalid credentials, authentication throttling, and zone authorization.
- Classify cert-manager’s final Challenge states—`valid`, `invalid`, `expired`, `revoked`, and `errored`—as inactive so retained terminal diagnostics do not block a healthy current state.
- Ensure `recover()` cannot reach `cmctl renew` while an active blocker exists.
- Reject hidden token input containing embedded whitespace, `Bearer <token>` wrappers, or surrounding quotes while accepting legacy and prefixed token shapes without fixed-length assumptions.
- Update the staging runbook with stop/fix/wait guidance, no invented cooldown, and the existing one-certificate-at-a-time and ACME-rate-limit cautions.

### Safety and scope

- Status and authorization verification fetch only Secret metadata/presence, never Secret data.
- Credentials remain on stdin and are not placed in argv or emitted in output.
- Historical Events and terminal Challenges remain diagnostic only.
- Staging guards, context pinning, and existing recipe interfaces are unchanged.
- No issuers, Helm releases, application resources, production configuration, or unrelated observability tooling are modified.

### Testing

- `python3 -m pytest -q tests/test_staging_cert_manager.py tests/test_cert_manager_just_recipes.py` — 65 passed.
- `python3 -m black --check scripts/staging_cert_manager.py tests/test_staging_cert_manager.py`
- `git diff --check`
- `git diff --cached | ./scripts/scan-secrets.py`
- The task environment could not complete the full local suite because `helm`, `pre-commit`, `pyspelling`, and `linkchecker` were unavailable; latest-head GitHub Actions provide repository-level validation.

### Operational follow-up

This PR hardens the authorization and recovery gate; it does not itself rotate the Cloudflare credential or prove successful renewals for the affected certificates. Those operational acceptance steps remain tracked by issue #2406.

Related issue: #2406

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c0451b918832f9b2ef1b480a71b7a)