### PR TITLE
Fail closed on active Cloudflare authentication blockers

### DIFF
--- a/docs/staging-cert-manager.md
+++ b/docs/staging-cert-manager.md
@@ -65,7 +65,9 @@ just cert-manager-cloudflare-token-secret env=staging < /operator/private/cloudf
 
 The recipe sends bytes to `kubectl create secret --from-file=api-token=/dev/stdin` and pipes its
 client-side manifest directly to `kubectl apply -f -`. It suppresses rendered content and never
-puts the credential in argv, shell history, logs, tests, or Git. Confirm only metadata:
+puts the credential in argv, shell history, logs, tests, or Git. It rejects pasted `Bearer …`
+wrappers, embedded whitespace, and surrounding quote wrappers before running `kubectl`; paste or
+stream only the token itself. Confirm only metadata:
 
 ```bash
 kubectl -n cert-manager get secret cloudflare-api-token -o name
@@ -79,8 +81,11 @@ just cert-manager-certificate-verify-authorization namespace=danielsmith certifi
 
 It requires the referenced issuer to be `Ready=True`, its Cloudflare solver to reference
 `cert-manager/cloudflare-api-token` key `api-token`, that Secret to exist, and no related active
-Challenge to report `Found no Zones`. It checks only Secret existence and never retrieves, decodes,
-or prints its value. These structural checks cannot prove the token's Cloudflare dashboard scope;
+Challenge to report `Found no Zones`, Cloudflare error 9109 (`Invalid access token`), or Cloudflare
+error 10502 (`Too many authentication failures`). Terminal Challenges and historical Events remain
+visible in status for diagnosis but do not independently block a healthy current state. The gate
+checks only Secret existence and never retrieves, decodes, or prints its value. These structural
+checks cannot prove the token's Cloudflare dashboard scope;
 only a successfully completed DNS-01 Challenge can do that. Do not call Cloudflare APIs in a way
 that risks logging request headers.
 
@@ -107,6 +112,12 @@ do not silently change issuer or Helm/Flux ownership here.
 
 1. Capture the redacted status above, then run `cert-manager-certificate-verify-authorization`.
    The Certificate itself need not already be Ready: recovery exists to repair that condition.
+   If the active Challenge reports 9109 or 10502, stop manual retries. Correct and reinstall an
+   invalid credential through the hidden-input recipe when needed. For authentication throttling,
+   wait for Cloudflare throttling to clear before retrying this read-only gate; do not assume a
+   fixed cooldown. Treat `Found no Zones` as a zone authorization problem and correct account,
+   zone, or token scope before retrying the gate. Recovery will not call `cmctl renew` while any of
+   these blockers is active.
 2. Run **one** recovery with the matching namespace, Certificate, and DNS name. The command uses
    `cmctl renew`, bounds its wait (default ten minutes), requires `Ready=True`, Secret creation,
    and a revision or expiry change, then uses normal TLS verification for `/`, `/healthz`, and
@@ -117,9 +128,9 @@ do not silently change issuer or Helm/Flux ownership here.
    ```
 
 3. Review the final redacted resource chain. Confirm the new Order and Challenge are valid and no
-   active Challenge reports `Found no Zones`. Confirm the externally served certificate identity
-   and dates independently if Cloudflare edge termination makes them differ from the Kubernetes
-   Secret; never disable TLS verification.
+   active Challenge reports a Cloudflare authentication or zone-authorization blocker. Confirm the
+   externally served certificate identity and dates independently if Cloudflare edge termination
+   makes them differ from the Kubernetes Secret; never disable TLS verification.
 4. Only after the first certificate passes, repeat for Jobbot3000:
 
    ```bash

--- a/scripts/staging_cert_manager.py
+++ b/scripts/staging_cert_manager.py
@@ -18,6 +18,23 @@ STAGING_CONTEXT = "sugar-staging"
 TOKEN_SECRET_NAMESPACE = "cert-manager"
 TOKEN_SECRET_NAME = "cloudflare-api-token"
 TOKEN_SECRET_KEY = "api-token"
+AUTHORIZATION_BLOCKERS = (
+    (
+        re.compile(r"(?:error\s*:\s*)?9109\b|invalid access token", re.IGNORECASE),
+        "invalid credentials",
+        "reinstall the credential before retrying",
+    ),
+    (
+        re.compile(r"(?:error\s*:\s*)?10502\b|too many authentication failures", re.IGNORECASE),
+        "authentication throttling",
+        "stop retries and wait for throttling to clear",
+    ),
+    (
+        re.compile(r"found no zones", re.IGNORECASE),
+        "zone authorization",
+        "correct the account, zone, or token scope before retrying",
+    ),
+)
 REDACT = re.compile(
     r"(?i)\b(authorization\s*[:=]?\s*bearer|bearer|api[-_ ]?(?:token|key)|credential|pass"
     r"word|secret)"
@@ -216,8 +233,13 @@ def verify_authorization(namespace: str, certificate_name: str) -> dict[str, Any
         )
     for challenge in report["challenges"]:
         detail = f"{challenge['reason']} {challenge['message']}"
-        if challenge["active"] and "found no zones" in detail.lower():
-            raise OperationError("active Challenge reports Found no Zones")
+        if challenge["active"]:
+            for pattern, blocker, action in AUTHORIZATION_BLOCKERS:
+                if pattern.search(detail):
+                    raise OperationError(
+                        f"active Challenge has a Cloudflare {blocker} blocker; {action}, then "
+                        "re-run authorization verification"
+                    )
     print(
         "authorization structure verified; a successful DNS-01 Challenge is still required to prove dashboard scope"
     )
@@ -232,7 +254,16 @@ def install_token() -> None:
         else sys.stdin.buffer.read()
     )
     credential = credential.strip()
-    if not credential or b"\n" in credential or b"\r" in credential:
+    quoted = (
+        len(credential) >= 2
+        and credential[:1] == credential[-1:]
+        and credential[:1]
+        in {
+            b"'",
+            b'"',
+        }
+    )
+    if not credential or any(chr(byte).isspace() for byte in credential) or quoted:
         raise OperationError("token input is empty or malformed")
     create = subprocess.Popen(
         kubectl_command(

--- a/tests/test_staging_cert_manager.py
+++ b/tests/test_staging_cert_manager.py
@@ -267,7 +267,27 @@ def test_verify_authorization_success_does_not_require_certificate_ready(monkeyp
                 challenges=[{"active": True, "reason": "PresentError", "message": "Found no Zones"}]
             ),
             0,
-            "Found no Zones",
+            "zone authorization",
+        ),
+        (
+            authorization_report(
+                challenges=[{"active": True, "reason": "PresentError", "message": "Error: 9109"}]
+            ),
+            0,
+            "invalid credentials",
+        ),
+        (
+            authorization_report(
+                challenges=[
+                    {
+                        "active": True,
+                        "reason": "Error: 10502: Too many authentication failures",
+                        "message": "",
+                    }
+                ]
+            ),
+            0,
+            "authentication throttling",
         ),
     ],
 )
@@ -283,6 +303,36 @@ def test_verify_authorization_fails_closed(monkeypatch, report, secret_code, mes
         MODULE.verify_authorization("example", "site-tls")
 
 
+def test_verify_authorization_ignores_terminal_errors_and_historical_events(monkeypatch):
+    report = authorization_report(
+        challenges=[
+            {
+                "active": False,
+                "reason": "PresentError",
+                "message": "Error: 9109: Invalid access token",
+            },
+            {"active": True, "reason": "Pending", "message": "Waiting for DNS propagation"},
+        ]
+    )
+    report["events"] = [
+        {
+            "object": "Challenge",
+            "type": "Warning",
+            "reason": "PresentError",
+            "message": "Error: 10502: Too many authentication failures",
+        }
+    ]
+    monkeypatch.setattr(MODULE, "staging_guard", lambda: None)
+    monkeypatch.setattr(MODULE, "inventory", lambda *_args: report)
+    monkeypatch.setattr(
+        MODULE,
+        "run",
+        lambda command, **_kwargs: subprocess.CompletedProcess(command, 0, b"secret/name", b""),
+    )
+
+    assert MODULE.verify_authorization("example", "site-tls") is report
+
+
 def test_kubectl_json_failure_is_redacted(monkeypatch):
     monkeypatch.setattr(
         MODULE,
@@ -296,12 +346,15 @@ def test_kubectl_json_failure_is_redacted(monkeypatch):
     assert "visible-value" not in str(caught.value)
 
 
-def test_runtime_token_command_uses_stdin_and_context(monkeypatch, capsys):
+@pytest.mark.parametrize(
+    "token", [b"legacy-token-shaped-value", b"v1.0-prefixed-token-shaped-value"]
+)
+def test_runtime_token_command_uses_stdin_and_context(monkeypatch, capsys, token):
     class Input:
         def isatty(self):
             return False
 
-        buffer = type("Buffer", (), {"read": staticmethod(lambda: b"runtime-credential")})()
+        buffer = type("Buffer", (), {"read": staticmethod(lambda: token)})()
 
     commands = []
 
@@ -326,7 +379,8 @@ def test_runtime_token_command_uses_stdin_and_context(monkeypatch, capsys):
     monkeypatch.setattr(MODULE.subprocess, "Popen", Process)
     MODULE.install_token()
     rendered = " ".join(word for command in commands for word in command)
-    assert "runtime-credential" not in rendered + capsys.readouterr().out
+    output = rendered + capsys.readouterr().out
+    assert token.decode() not in output
     assert "--from-file=" + MODULE.TOKEN_SECRET_KEY + "=/dev/stdin" in rendered
     assert commands[0][1:3] == ["--context", "sugar-staging"]
 
@@ -430,6 +484,62 @@ def test_install_token_rejects_empty_input_before_starting_process(monkeypatch):
 
     with pytest.raises(MODULE.OperationError, match="empty or malformed"):
         MODULE.install_token()
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        b"Bearer token-shaped-value",
+        b"token shaped value",
+        b"'token-shaped-value'",
+        b'"token-shaped-value"',
+    ],
+)
+def test_install_token_rejects_wrapped_or_whitespace_input_before_kubectl(monkeypatch, malformed):
+    class Input:
+        def isatty(self):
+            return False
+
+        buffer = type("Buffer", (), {"read": staticmethod(lambda: malformed)})()
+
+    monkeypatch.setattr(MODULE, "staging_guard", lambda: None)
+    monkeypatch.setattr(MODULE.sys, "stdin", Input())
+    monkeypatch.setattr(
+        MODULE.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: pytest.fail("malformed input must not start kubectl"),
+    )
+
+    with pytest.raises(MODULE.OperationError, match="empty or malformed") as caught:
+        MODULE.install_token()
+    assert malformed.decode() not in str(caught.value)
+
+
+def test_recover_does_not_renew_with_active_authentication_blocker(monkeypatch):
+    report = authorization_report(
+        challenges=[
+            {
+                "active": True,
+                "reason": "PresentError",
+                "message": "Error: 9109: Invalid access token",
+            }
+        ]
+    )
+    commands = []
+    monkeypatch.setattr(MODULE.shutil, "which", lambda _name: "/usr/bin/cmctl")
+    monkeypatch.setattr(MODULE, "staging_guard", lambda: None)
+    monkeypatch.setattr(MODULE, "inventory", lambda *_args: report)
+    monkeypatch.setattr(
+        MODULE,
+        "run",
+        lambda command, **_kwargs: commands.append(command)
+        or subprocess.CompletedProcess(command, 0, b"secret/name", b""),
+    )
+
+    with pytest.raises(MODULE.OperationError, match="invalid credentials"):
+        MODULE.recover("example", "site-tls", "staging.example.test", 60)
+
+    assert all(command[0] != "cmctl" for command in commands)
 
 
 def test_install_token_redacts_process_failure(monkeypatch):


### PR DESCRIPTION
### Motivation

- The staging Danielsmith Certificate showed active Cloudflare errors (10502 / "Too many authentication failures" and 9109 / "Invalid access token") but the structural verifier only failed on `Found no Zones`, allowing recovery to proceed despite active auth failures.  This change ensures we fail closed on current Cloudflare authentication/authorization blockers.\
- Prevent accidental retries or `cmctl renew` runs while Cloudflare credentials are known to be invalid or throttled.\
- Harden hidden token installation against common malformed paste wrappers that would silently install wrong values.\

### Description

- Add `AUTHORIZATION_BLOCKERS` patterns and classification for active Challenge text to detect: 9109 (`invalid credentials`), 10502 (`authentication throttling`), and the existing `Found no Zones` (`zone authorization`).\
- Extend `verify_authorization()` to inspect only active Challenges and raise a concise, redacted `OperationError` with actionable guidance when a blocker is matched, preventing the verifier from returning success in those cases.\
- Ensure `recover()` calls `verify_authorization()` before running `cmctl renew`, so recovery cannot reach `cmctl` while an active blocker exists.\
- Harden `install_token()` input validation to reject values with embedded whitespace, surrounding quotes, or `Bearer …` wrappers before starting `kubectl`, while keeping legacy and prefixed token shapes acceptable; credential bytes are never printed, logged, or placed in argv.\
- Update `docs/staging-cert-manager.md` to document that active errors 9109 and 10502 block recovery, instruct operators to stop retries, reinstall credentials via the hidden-input recipe and wait for throttling to clear (without inventing a fixed cooldown), and preserve one-certificate-at-a-time and ACME-rate-limit guidance.\
- Add deterministic tests in `tests/test_staging_cert_manager.py` covering active `Found no Zones`, 9109, 10502, ignoring terminal/stale Challenges and historical Events, `recover()` never reaching `cmctl renew` when blocked, malformed wrapped/whitespace credentials rejected early, and valid legacy/prefixed token-shaped inputs accepted.\

### Testing

- Ran the focused test set: `python3 -m pytest -q tests/test_staging_cert_manager.py tests/test_cert_manager_just_recipes.py` — 41 passed, 10 skipped.\
- Ran formatter check and fixed files with `python3 -m black` (scripts/tests were reformatted) and then confirmed formatting with `python3 -m black --check scripts/staging_cert_manager.py tests/test_staging_cert_manager.py`.\
- Ran repository checks: `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` (scan-secrets passed).\
- Ran the full test suite `python3 -m pytest -q` in the environment: 2008 passed, 61 skipped, and one unrelated failure in a monitoring test because `helm` is not installed in the execution environment (FileNotFoundError), not related to these changes.\
- Could not run `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, or `linkchecker --no-warnings README.md docs/` in this environment due to the corresponding tools being unavailable; these are documented in the PR testing notes.\

Closes #2406

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c0453e114832fbccfd25d948827b6)