### PR TITLE
Add staging observability dead-man watchdog

### DIFF
--- a/clusters/staging/observability/kube-prometheus-stack.values.yaml
+++ b/clusters/staging/observability/kube-prometheus-stack.values.yaml
@@ -4,10 +4,26 @@ prometheus:
   prometheusSpec:
     externalLabels:
       cluster: sugarkube-int
+additionalPrometheusRulesMap:
+  sugarkube-observability-watchdog:
+    groups:
+      - name: sugarkube-observability-watchdog
+        interval: 1m
+        rules:
+          - alert: SugarkubeObservabilityWatchdog
+            expr: vector(1)
+            labels:
+              environment: staging
+              cluster: sugarkube-int
+              purpose: observability-watchdog
+            annotations:
+              summary: Sugarkube staging observability watchdog
+              runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-operations.md#observability-watchdog
 alertmanager:
   alertmanagerSpec:
     secrets:
       - alertmanager-pagerduty
+      - alertmanager-healthchecks-watchdog
   config:
     route:
       receiver: "null"
@@ -18,9 +34,28 @@ alertmanager:
             - environment="staging"
             - cluster="sugarkube-int"
             - severity="critical"
+        - receiver: healthchecks-watchdog
+          matchers:
+            - alertname="SugarkubeObservabilityWatchdog"
+            - environment="staging"
+            - cluster="sugarkube-int"
+            - purpose="observability-watchdog"
+          group_by: [alertname, cluster, environment]
+          group_wait: 30s
+          group_interval: 1m
+          repeat_interval: 5m
+          continue: false
     receivers:
       - name: "null"
       - name: pagerduty-synthetic-test
         pagerduty_configs:
           - routing_key_file: /etc/alertmanager/secrets/alertmanager-pagerduty/routing-key
             send_resolved: true
+      - name: healthchecks-watchdog
+        webhook_configs:
+          - url_file: /etc/alertmanager/secrets/alertmanager-healthchecks-watchdog/ping-url
+            send_resolved: false
+            http_config:
+              follow_redirects: true
+            max_alerts: 1
+            timeout: 10s

--- a/docs/observability-alerting.md
+++ b/docs/observability-alerting.md
@@ -231,3 +231,17 @@ it is deployed yet — see the rollout plan above for the actual sequencing.
 - Per-node heartbeat assets are repository-ready but have not been installed on the Pis. The
   node-power-off drill, watchdog, `KubeNodeNotReady` routing, and application alerts remain later
   work.
+
+## Staging observability watchdog routing
+
+The staging implementation now separates four signals: node heartbeats prove each machine can reach
+an external service; the observability watchdog proves Prometheus, Alertmanager, and outbound webhook
+delivery remain alive; ordinary Prometheus alerts still fall through to the null receiver unless
+explicitly allowlisted; and blackbox probes test externally reachable application endpoints without
+proving the monitoring stack itself can deliver a page.
+
+Only the exact watchdog labels route to the secret-file-backed Healthchecks webhook. Healthchecks is
+configured externally for a five-minute period and two-minute grace and owns the PagerDuty
+integration. The existing exact synthetic PagerDuty route is unchanged and remains first. See the
+[observability watchdog runbook](observability-operations.md#observability-watchdog) for secret
+installation, deployment, live checks, failure drill, recovery, latency, and rollback.

--- a/docs/observability-design.md
+++ b/docs/observability-design.md
@@ -382,3 +382,13 @@ Prometheus or Grafana should not be listed as production skills until evidence e
 - The Alertmanager receiver question is answered at the design level: PagerDuty plus Healthchecks.io, per [`docs/observability-alerting.md`](./observability-alerting.md). What remains open is execution — accounts, secret-safe config, and drills, none of which are done yet.
 - What Prometheus PV size is realistic after a one-week staging soak on the target Pi hardware?
 - Should Loki remain entirely deferred, or should minimal log labels be designed now without deploying Loki?
+
+## Dead-man signal boundaries
+
+Staging uses an always-firing Prometheus rule as an end-to-end observability dead man. Its exact route
+is isolated from the unchanged synthetic PagerDuty route and from the null default. A
+secret-file-backed Alertmanager webhook periodically checks in to Healthchecks; Healthchecks, not the
+cluster, detects absence and opens the PagerDuty incident. This complements rather than replaces
+per-node external heartbeats, ordinary metric alerts, and blackbox endpoint probes. Production is
+intentionally unchanged. Operational details and the safe silence-only drill are in the
+[observability watchdog runbook](observability-operations.md#observability-watchdog).

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -401,3 +401,61 @@ observability codification are separate follow-ups. The existing blackbox Networ
 Alerting onboarding — real Alertmanager receivers, external heartbeats, and failure drills — is no
 longer undesigned scope creep; it is planned, designed work tracked in
 [`docs/observability-alerting.md`](observability-alerting.md), just not yet executed.
+
+## Observability watchdog
+
+The staging dead-man path is deliberately narrow. Prometheus continuously fires
+`SugarkubeObservabilityWatchdog` from `vector(1)` with the fixed `staging`, `sugarkube-int`, and
+`observability-watchdog` labels. Alertmanager sends that alert every five minutes to one
+Healthchecks URL read from the mounted `alertmanager-healthchecks-watchdog/ping-url` Secret. It does
+not send resolved notifications. The null receiver remains the default; ordinary alerts are not
+paged, and the existing synthetic PagerDuty allowlist remains separate.
+
+Configure the external Healthchecks check manually with a **five-minute period** and **two-minute
+grace**, and connect that check to PagerDuty in the Healthchecks dashboard. No Healthchecks account
+credential belongs in this repository. Install or rotate the ping URL using hidden terminal input,
+then inspect only its Kubernetes key contract:
+
+```bash
+just observability-watchdog-secret-install env=staging
+just observability-watchdog-secret-check env=staging
+just observability-render env=staging >/dev/null
+just observability-upgrade env=staging
+just observability-watchdog-verify env=staging
+```
+
+The installer rejects URL arguments and environment variables, requires the `sugar-staging` context
+and staging cluster identity, and streams the Secret through stdin. Rendering is cluster-independent
+and contains only `url_file`; installation and upgrade fail before Helm mutation unless both the
+PagerDuty `routing-key` and watchdog `ping-url` contracts are nonempty. After verification, manually
+confirm that the Healthchecks **last ping** advanced. Expected steady-state delivery is about every
+five minutes; with the configured grace, loss should become Down and page through the external
+Healthchecks → PagerDuty integration in roughly seven minutes, plus provider delivery latency.
+
+### Controlled failure drill
+
+**MANUAL CHECKPOINT:** before creating the silence, confirm Healthchecks is Up, its last ping is
+recent, the Healthchecks → PagerDuty integration is enabled, and an operator is ready to acknowledge
+the incident. The helper never shuts down a node and never directly pings the URL.
+
+```bash
+just observability-watchdog-drill-create env=staging
+just observability-watchdog-drill-status env=staging
+# Optional early recovery:
+just observability-watchdog-drill-clear env=staging
+```
+
+The owned silence matches exactly `alertname`, `environment`, `cluster`, and `purpose`, and expires
+automatically after eight minutes—slightly longer than the five-minute period plus two-minute grace.
+Thus recovery is automatic if the operator disconnects. Do not make automated tests wait through the
+drill. Manually confirm Healthchecks transitions Down, a Healthchecks-generated PagerDuty incident
+arrives, and acknowledge it. At silence expiry (or after the optional early clear), confirm a new ping,
+the Healthchecks transition to Up, and PagerDuty recovery/resolution.
+
+### Watchdog rollback
+
+**Before any rollback that removes the watchdog receiver, pause the Healthchecks check or disable its
+PagerDuty integration; otherwise the rollback itself can generate a page.** Then roll back the Helm
+release, verify the prior revision, and only remove `alertmanager-healthchecks-watchdog` after the
+Alertmanager custom resource no longer mounts it. Keep the external check paused until the dead-man
+sender has been restored or intentionally retired.

--- a/justfile
+++ b/justfile
@@ -3264,6 +3264,30 @@ observability-dashboard-verify env='':
 observability-pagerduty-test env='' action='':
     @scripts/observability_helm.sh pagerduty-test '{{ env }}' '{{ action }}'
 
+# Install or rotate the staging watchdog ping URL using hidden terminal input.
+observability-watchdog-secret-install env='':
+    @scripts/observability_watchdog.sh secret-install '{{ env }}'
+
+# Check the watchdog Secret/key contract without reading the credential.
+observability-watchdog-secret-check env='':
+    @scripts/observability_watchdog.sh secret-check '{{ env }}'
+
+# Verify the live watchdog rule, alert, receiver mount, and recent delivery health.
+observability-watchdog-verify env='':
+    @scripts/observability_watchdog.sh verify '{{ env }}'
+
+# Create the exact, automatically expiring controlled-drill silence.
+observability-watchdog-drill-create env='':
+    @scripts/observability_watchdog.sh drill-create '{{ env }}'
+
+# Inspect only the controlled-drill silence owned by this helper.
+observability-watchdog-drill-status env='':
+    @scripts/observability_watchdog.sh drill-status '{{ env }}'
+
+# Remove only the controlled-drill silence owned by this helper.
+observability-watchdog-drill-clear env='':
+    @scripts/observability_watchdog.sh drill-clear '{{ env }}'
+
 # Render the pinned staging blackbox exporter and Probe manifests (read-only).
 observability-blackbox-render env='':
     @scripts/observability_blackbox.sh render '{{ env }}'

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -14,6 +14,7 @@ DASHBOARD_VALIDATOR="${ROOT}/scripts/validate_observability_dashboard.py"
 TIMEOUT="${SUGARKUBE_OBSERVABILITY_HELM_TIMEOUT:-20m}"
 GRAFANA_URL="http://sugarkube3.local:30300"
 PAGERDUTY_SECRET="alertmanager-pagerduty"
+WATCHDOG_SECRET="alertmanager-healthchecks-watchdog"
 ALERTMANAGER_VALIDATOR="${ROOT}/scripts/verify_observability_alertmanager.rb"
 
 usage() { echo "Usage: $0 <render|install|upgrade|status|verify|dashboard-verify|pagerduty-test> env=staging [fire|resolve]" >&2; }
@@ -78,6 +79,19 @@ assert_pagerduty_secret() {
   fi
   echo "PagerDuty Secret contract exists (value intentionally not read or printed)."
 }
+assert_watchdog_secret() {
+  local present
+  if ! present="$(kubectl -n "${NAMESPACE}" get secret "${WATCHDOG_SECRET}" -o 'go-template={{if index .data "ping-url"}}present{{end}}' 2>/dev/null)"; then
+    echo "ERROR: required Secret monitoring/alertmanager-healthchecks-watchdog is absent; install a nonempty ping-url before deployment or verification." >&2
+    return 15
+  fi
+  if [[ "${present}" != present ]]; then
+    echo "ERROR: Secret monitoring/alertmanager-healthchecks-watchdog must contain a nonempty ping-url (value intentionally not read or printed)." >&2
+    return 15
+  fi
+  echo "Watchdog Secret contract exists (value intentionally not read or printed)."
+}
+assert_alerting_secrets() { assert_pagerduty_secret; assert_watchdog_secret; }
 release_state() {
   local matches
   # Do not infer absence from `helm status`: transport and authorization errors
@@ -96,8 +110,8 @@ release_state() {
   fi
 }
 render() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; tmp="$(mktemp -t sugarkube-observability-render.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; cat "${tmp}"; }
-install_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; assert_pagerduty_secret; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
-upgrade_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; assert_pagerduty_secret; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
+install_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; assert_alerting_secrets; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
+upgrade_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; assert_alerting_secrets; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
 status() { require_tools helm kubectl python3; print_resolved staging; assert_context; helm -n "${NAMESPACE}" status "${RELEASE}"; kubectl -n "${NAMESPACE}" get deploy,statefulset,daemonset -l "app.kubernetes.io/instance=${RELEASE}"; kubectl -n "${NAMESPACE}" get prometheus,alertmanager; kubectl -n "${NAMESPACE}" get svc,pvc; kubectl get crd prometheuses.monitoring.coreos.com alertmanagers.monitoring.coreos.com servicemonitors.monitoring.coreos.com probes.monitoring.coreos.com; }
 verify_dspace_targets() {
   require_tools kubectl python3 sleep
@@ -247,7 +261,7 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
     raise SystemExit("ERROR: expected one Bound local-path Prometheus PVC.")'
   [[ "$(kubectl -n "${NAMESPACE}" get prometheus kube-prometheus-stack-prometheus -o jsonpath='{.spec.replicas}')" == 1 ]]
   [[ "$(kubectl -n "${NAMESPACE}" get alertmanager kube-prometheus-stack-alertmanager -o jsonpath='{.spec.replicas}')" == 1 ]]
-  assert_pagerduty_secret
+  assert_alerting_secrets
   local alertmanager_yaml="" config_yaml=""
   trap 'rm -f "${alertmanager_yaml:-}" "${config_yaml:-}"' EXIT
   alertmanager_yaml="$(mktemp -t sugarkube-alertmanager-cr.XXXXXX.yaml)"

--- a/scripts/observability_watchdog.sh
+++ b/scripts/observability_watchdog.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+NAMESPACE=monitoring
+SECRET=alertmanager-healthchecks-watchdog
+RELEASE=kube-prometheus-stack
+usage() { echo "Usage: $0 <secret-install|secret-check|verify|drill-create|drill-status|drill-clear> env=staging" >&2; }
+normalize_env() { local value="${1:-}"; while [[ "$value" == env=* ]]; do value="${value#env=}"; done; [[ "$value" == staging ]] || { echo "ERROR: watchdog operations require env=staging explicitly." >&2; exit 2; }; }
+require_tools() { for tool in "$@"; do command -v "$tool" >/dev/null || { echo "ERROR: required tool missing: $tool" >&2; exit 127; }; done; }
+assert_context() {
+  local context; context="$(kubectl config current-context 2>/dev/null || true)"
+  [[ "$context" == sugar-staging ]] || { echo "ERROR: expected staging context sugar-staging; refusing operation." >&2; exit 3; }
+  python3 "$ROOT/scripts/cluster_identity.py" assert --kubeconfig "${KUBECONFIG:-${HOME}/.kube/config}" --env staging >/dev/null
+}
+secret_check() {
+  local present
+  if ! present="$(kubectl -n "$NAMESPACE" get secret "$SECRET" -o 'go-template={{if index .data "ping-url"}}present{{end}}' 2>/dev/null)" || [[ "$present" != present ]]; then
+    echo "ERROR: required Secret monitoring/$SECRET is absent or has an empty ping-url (value not accessed or printed)." >&2; return 15
+  fi
+  echo "Watchdog Secret contract exists (value not accessed or printed)."
+}
+secret_install() {
+  [[ $# -eq 0 ]] || { echo "ERROR: the ping URL must not be supplied through argv." >&2; return 2; }
+  [[ -z "${SUGARKUBE_HEALTHCHECKS_PING_URL-}${HEALTHCHECKS_PING_URL-}${WATCHDOG_PING_URL-}" ]] || { echo "ERROR: the ping URL must not be supplied through environment variables." >&2; return 2; }
+  require_tools kubectl python3
+  assert_context
+  [[ -r /dev/tty ]] || { echo "ERROR: a controlling terminal is required for hidden input." >&2; return 2; }
+  local ping_url
+  IFS= read -r -s -p 'Healthchecks watchdog ping URL: ' ping_url </dev/tty; printf '\n' >/dev/tty
+  if ! printf '%s' "$ping_url" | python3 -c 'import sys, urllib.parse
+value=sys.stdin.read()
+parsed=urllib.parse.urlsplit(value)
+valid=(parsed.scheme=="https" and parsed.hostname in {"hc-ping.com", "healthchecks.io"} and bool(parsed.path.strip("/")) and not parsed.username and not getattr(parsed, "pass"+"word") and not parsed.query and not parsed.fragment and "\n" not in value and "\r" not in value)
+raise SystemExit(0 if valid else 1)'; then
+    unset ping_url; echo "ERROR: invalid Healthchecks HTTPS ping URL (value not printed)." >&2; return 15
+  fi
+  if ! printf '%s' "$ping_url" | kubectl -n "$NAMESPACE" create secret generic "$SECRET" --from-file=ping-url=/dev/stdin --dry-run=client -o yaml | kubectl apply -f - >/dev/null; then
+    unset ping_url; echo "ERROR: watchdog Secret installation failed (credential and diagnostics redacted)." >&2; return 15
+  fi
+  unset ping_url
+  echo "Watchdog Secret installed or rotated (value not printed)."
+}
+am_api() { kubectl get --request-timeout=15s --raw "/api/v1/namespaces/$NAMESPACE/services/http:$RELEASE-alertmanager:9093/proxy$1"; }
+verify() {
+  require_tools kubectl python3 ruby
+  assert_context; secret_check
+  local directory; directory="$(mktemp -d -t sugarkube-watchdog-verify.XXXXXX)"; chmod 700 "$directory"; trap 'rm -rf "$directory"' EXIT
+  kubectl -n "$NAMESPACE" get alertmanager "$RELEASE-alertmanager" -o yaml >"$directory/alertmanager.yaml"
+  kubectl -n "$NAMESPACE" get secret "alertmanager-$RELEASE-alertmanager" -o yaml >"$directory/config.yaml"
+  ruby "$ROOT/scripts/verify_observability_alertmanager.rb" live "$directory/alertmanager.yaml" "$directory/config.yaml"
+  kubectl get --request-timeout=15s --raw "/api/v1/namespaces/$NAMESPACE/services/http:$RELEASE-prometheus:9090/proxy/api/v1/rules" >"$directory/rules.json"
+  am_api '/api/v2/alerts?active=true&silenced=false&inhibited=false' >"$directory/alerts.json"
+  python3 - "$directory/rules.json" "$directory/alerts.json" <<'PY'
+import json, sys
+expected={"alertname":"SugarkubeObservabilityWatchdog","environment":"staging","cluster":"sugarkube-int","purpose":"observability-watchdog"}
+rules=json.load(open(sys.argv[1], encoding="utf-8"))
+groups=rules.get("data",{}).get("groups",[])
+found=[r for g in groups for r in g.get("rules",[]) if r.get("name")==expected["alertname"] and r.get("query")=="vector(1)" and r.get("state")=="firing" and all(r.get("labels",{}).get(k)==v for k,v in expected.items() if k!="alertname")]
+if len(found)!=1: raise SystemExit("ERROR: exact watchdog Prometheus rule is not firing.")
+alerts=json.load(open(sys.argv[2], encoding="utf-8"))
+active=[a for a in alerts if a.get("labels")==expected and a.get("status",{}).get("state")=="active"]
+if len(active)!=1: raise SystemExit("ERROR: exact watchdog alert is not active in Alertmanager.")
+PY
+  if kubectl -n "$NAMESPACE" logs "statefulset/alertmanager-$RELEASE-alertmanager" --since=6m 2>/dev/null | grep -Eqi 'healthchecks-watchdog.*(error|fail)|notify.*healthchecks-watchdog.*(error|fail)'; then
+    echo "ERROR: watchdog delivery errors observed during the bounded six-minute log window (details redacted)." >&2; return 20
+  fi
+  echo "Watchdog rule, active alert, mounted receiver, and bounded delivery-error check passed (credentials and responses redacted)."
+  echo "MANUAL CHECKPOINT: confirm the Healthchecks dashboard last-ping time advanced."
+}
+owned_silences() { am_api '/api/v2/silences' | python3 -c 'import json,sys
+for item in json.load(sys.stdin):
+ if item.get("comment")=="sugarkube-observability-watchdog-controlled-drill" and item.get("status",{}).get("state") in {"active","pending"}: print(item.get("id",""))'; }
+drill_create() {
+  require_tools kubectl python3; assert_context
+  [[ -z "$(owned_silences)" ]] || { echo "ERROR: an owned watchdog drill silence already exists." >&2; return 21; }
+  echo "MANUAL CHECKPOINT: confirm Healthchecks is Up and PagerDuty is ready before disruption. This creates only an eight-minute Alertmanager silence; it never shuts down a node or pings Healthchecks."
+  local payload; payload="$(python3 -c 'import json
+from datetime import datetime,timedelta,timezone
+now=datetime.now(timezone.utc)
+fmt=lambda d:d.isoformat(timespec="seconds").replace("+00:00","Z")
+labels={"alertname":"SugarkubeObservabilityWatchdog","environment":"staging","cluster":"sugarkube-int","purpose":"observability-watchdog"}
+print(json.dumps({"matchers":[{"name":k,"value":v,"isRegex":False,"isEqual":True} for k,v in labels.items()],"startsAt":fmt(now),"endsAt":fmt(now+timedelta(minutes=8)),"createdBy":"sugarkube-operator","comment":"sugarkube-observability-watchdog-controlled-drill"}))')"
+  printf '%s' "$payload" | kubectl create --raw "/api/v1/namespaces/$NAMESPACE/services/http:$RELEASE-alertmanager:9093/proxy/api/v2/silences" -f - >/dev/null
+  unset payload
+  echo "Owned watchdog drill silence created; automatic expiry is eight minutes (response redacted)."
+}
+drill_status() { require_tools kubectl python3; assert_context; local ids; ids="$(owned_silences)"; [[ -n "$ids" ]] && echo "Owned watchdog drill silence is present (identifier redacted)." || echo "No owned watchdog drill silence is present."; }
+drill_clear() { require_tools kubectl python3; assert_context; local ids id count=0; ids="$(owned_silences)"; while IFS= read -r id; do [[ -n "$id" ]] || continue; kubectl delete --raw "/api/v1/namespaces/$NAMESPACE/services/http:$RELEASE-alertmanager:9093/proxy/api/v2/silence/$id" >/dev/null; count=$((count+1)); done <<<"$ids"; echo "Removed $count owned watchdog drill silence(s); identifiers and responses redacted."; }
+
+command="${1:-}"; shift || true; env_arg="${1:-}"; shift || true; normalize_env "$env_arg"
+case "$command" in secret-install) secret_install "$@";; secret-check) require_tools kubectl python3; assert_context; secret_check;; verify) verify;; drill-create) drill_create;; drill-status) drill_status;; drill-clear) drill_clear;; *) usage; exit 2;; esac

--- a/scripts/verify_observability_alertmanager.rb
+++ b/scripts/verify_observability_alertmanager.rb
@@ -4,18 +4,14 @@
 require "base64"
 require "yaml"
 
-EXPECTED_SECRET = "alertmanager-pagerduty"
-EXPECTED_PATH = "/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key"
-EXPECTED_RECEIVER = "pagerduty-synthetic-test"
-EXPECTED_MATCHERS = [
-  'alertname="SugarkubePagerDutyTest"',
-  'environment="staging"',
-  'cluster="sugarkube-int"',
-  'severity="critical"'
-].freeze
+EXPECTED_SECRETS = %w[alertmanager-pagerduty alertmanager-healthchecks-watchdog].freeze
+PD_RECEIVER = "pagerduty-synthetic-test"
+WATCHDOG_RECEIVER = "healthchecks-watchdog"
+PD_MATCHERS = ['alertname="SugarkubePagerDutyTest"', 'environment="staging"', 'cluster="sugarkube-int"', 'severity="critical"'].freeze
+WATCHDOG_MATCHERS = ['alertname="SugarkubeObservabilityWatchdog"', 'environment="staging"', 'cluster="sugarkube-int"', 'purpose="observability-watchdog"'].freeze
 
 def fail_closed(message)
-  warn "ERROR: Alertmanager PagerDuty structure invalid: #{message} (sensitive values not printed)."
+  warn "ERROR: Alertmanager integration structure invalid: #{message} (sensitive values not printed)."
   exit 16
 end
 
@@ -29,87 +25,75 @@ begin
     content = content[content.index("---\n")..] if mode == "rendered" && content.index("---\n")
     content.split(/^---\s*$\n?/).filter_map do |document|
       relevant = document.match?(/^kind: Alertmanager\s*$/) ||
-        (document.match?(/^kind: Secret\s*$/) &&
-         document.include?("name: alertmanager-kube-prometheus-stack-alertmanager"))
+        (document.match?(/^kind: Secret\s*$/) && document.include?("name: alertmanager-kube-prometheus-stack-alertmanager"))
       YAML.safe_load(document, permitted_classes: [], aliases: false) if relevant
     end
   end
 rescue StandardError
   fail_closed("input manifests are missing or malformed")
 end
-alertmanagers = documents.select do |doc|
-  doc["kind"] == "Alertmanager" && doc.dig("metadata", "name") == "kube-prometheus-stack-alertmanager"
-end
+alertmanagers = documents.select { |doc| doc["kind"] == "Alertmanager" && doc.dig("metadata", "name") == "kube-prometheus-stack-alertmanager" }
 fail_closed("expected exactly one kube-prometheus-stack Alertmanager custom resource") unless alertmanagers.length == 1
-alertmanager = alertmanagers.first
-secrets = alertmanager.dig("spec", "secrets")
-fail_closed("Alertmanager must reference only #{EXPECTED_SECRET}") unless secrets == [EXPECTED_SECRET]
+secrets = alertmanagers.first.dig("spec", "secrets")
+fail_closed("Alertmanager must reference exactly the two expected Secrets") unless secrets == EXPECTED_SECRETS
 
-config_secret = documents.find do |doc|
-  doc["kind"] == "Secret" && doc.dig("metadata", "name") == "alertmanager-kube-prometheus-stack-alertmanager"
-end
+config_secret = documents.find { |doc| doc["kind"] == "Secret" && doc.dig("metadata", "name") == "alertmanager-kube-prometheus-stack-alertmanager" }
 fail_closed("generated Alertmanager configuration Secret is missing") unless config_secret
-encoded = config_secret.dig("data", "alertmanager.yaml")
-plain = config_secret.dig("stringData", "alertmanager.yaml")
 begin
-  config_text = plain || (Base64.strict_decode64(encoded) if encoded)
-  fail_closed("generated Alertmanager configuration is missing or malformed") unless config_text
-  config = YAML.safe_load(config_text, permitted_classes: [], aliases: false)
+  encoded = config_secret.dig("data", "alertmanager.yaml")
+  text = config_secret.dig("stringData", "alertmanager.yaml") || (Base64.strict_decode64(encoded) if encoded)
+  config = YAML.safe_load(text, permitted_classes: [], aliases: false) if text
 rescue StandardError
-  fail_closed("generated Alertmanager configuration is missing or malformed")
+  config = nil
 end
+fail_closed("generated Alertmanager configuration is missing or malformed") unless config.is_a?(Hash)
 
-fail_closed("generated Alertmanager configuration is malformed") unless config.is_a?(Hash)
-
-inline_credential = lambda do |value|
+forbidden = lambda do |value|
   case value
   when Hash
-    value.key?("routing_key") || value.key?("service_key") || value.any? { |_key, child| inline_credential.call(child) }
-  when Array
-    value.any? { |child| inline_credential.call(child) }
-  else
-    false
+    value.keys.any? { |key| %w[routing_key service_key url].include?(key) } || value.values.any? { |child| forbidden.call(child) }
+  when Array then value.any? { |child| forbidden.call(child) }
+  else false
   end
 end
-fail_closed("inline PagerDuty credentials are forbidden") if inline_credential.call(config)
+fail_closed("inline credentials or webhook URLs are forbidden") if forbidden.call(config)
 
 route = config["route"]
 fail_closed('root receiver must remain "null"') unless route.is_a?(Hash) && route["receiver"] == "null"
-
+children = route["routes"]
+fail_closed("root must contain exactly the two allowlisted direct-child routes") unless children.is_a?(Array) && children.length == 2
 receivers = config["receivers"]
-fail_closed("receiver list is malformed") unless receivers.is_a?(Array)
-fail_closed("receiver list is malformed") unless receivers.all? { |item| item.is_a?(Hash) }
-fail_closed('root "null" receiver is missing') unless receivers.count { |item| item == { "name" => "null" } } == 1
-pagerduty = receivers.select { |item| item.key?("pagerduty_configs") }
-fail_closed("there must be exactly one PagerDuty receiver") unless pagerduty.length == 1
-fail_closed("PagerDuty receiver name changed") unless pagerduty.first["name"] == EXPECTED_RECEIVER
-pd_configs = pagerduty.first["pagerduty_configs"]
+fail_closed("receiver list must contain exactly null, PagerDuty, and watchdog receivers") unless
+  receivers.is_a?(Array) && receivers.all? { |item| item.is_a?(Hash) } && receivers.map { |item| item["name"] } == ["null", PD_RECEIVER, WATCHDOG_RECEIVER]
+fail_closed('root "null" receiver is malformed') unless receivers[0] == { "name" => "null" }
+fail_closed("there must be exactly one PagerDuty receiver") unless receivers.count { |item| item.key?("pagerduty_configs") } == 1
+fail_closed("there must be exactly one webhook receiver") unless receivers.count { |item| item.key?("webhook_configs") } == 1
+
+pd = receivers[1]
+fail_closed("PagerDuty receiver name changed") unless pd["name"] == PD_RECEIVER && pd.keys.sort == %w[name pagerduty_configs]
+pd_configs = pd["pagerduty_configs"]
 fail_closed("there must be exactly one PagerDuty configuration") unless pd_configs.is_a?(Array) && pd_configs.length == 1
-pd_config = pd_configs.first
-fail_closed("PagerDuty configuration is malformed") unless pd_config.is_a?(Hash)
-fail_closed("PagerDuty must use the exact mounted routing-key file") unless pd_config["routing_key_file"] == EXPECTED_PATH
-fail_closed("PagerDuty resolved notifications must be enabled") unless pd_config["send_resolved"] == true
+fail_closed("PagerDuty configuration changed") unless pd_configs[0] == {
+  "routing_key_file" => "/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key", "send_resolved" => true
+}
 
-all_routes = []
-walk_routes = lambda do |candidate|
-  fail_closed("route tree is malformed") unless candidate.is_a?(Hash)
-  all_routes << candidate
-  children = candidate["routes"]
-  return if children.nil?
+webhook = receivers[2]
+fail_closed("watchdog receiver name changed") unless webhook["name"] == WATCHDOG_RECEIVER && webhook.keys.sort == %w[name webhook_configs]
+webhook_configs = webhook["webhook_configs"]
+fail_closed("there must be exactly one watchdog webhook configuration") unless webhook_configs.is_a?(Array) && webhook_configs.length == 1
+fail_closed("watchdog webhook configuration changed") unless webhook_configs[0] == {
+  "url_file" => "/etc/alertmanager/secrets/alertmanager-healthchecks-watchdog/ping-url",
+  "send_resolved" => false, "http_config" => { "follow_redirects" => true }, "max_alerts" => 1, "timeout" => "10s"
+}
 
-  fail_closed("route tree is malformed") unless children.is_a?(Array)
-  children.each { |child| walk_routes.call(child) }
-end
-walk_routes.call(route)
-pagerduty_routes = all_routes.select { |candidate| candidate["receiver"] == EXPECTED_RECEIVER }
-fail_closed("there must be exactly one PagerDuty route") unless pagerduty_routes.length == 1
-synthetic_route = pagerduty_routes.first
-root_children = route["routes"]
-fail_closed("PagerDuty route must be a direct child of the root route") unless
-  root_children.is_a?(Array) && root_children.include?(synthetic_route)
-fail_closed("PagerDuty route matchers are not the exact synthetic allowlist") unless
-  synthetic_route["matchers"].is_a?(Array) && synthetic_route["matchers"].sort == EXPECTED_MATCHERS.sort
-fail_closed("PagerDuty route must not contain nested routes") if synthetic_route.key?("routes")
-fail_closed("PagerDuty route must not specify continuation") if synthetic_route.key?("continue")
+pd_route, watchdog_route = children
+fail_closed("PagerDuty route must remain first and exact") unless pd_route == { "receiver" => PD_RECEIVER, "matchers" => PD_MATCHERS }
+expected_watchdog = {
+  "receiver" => WATCHDOG_RECEIVER, "matchers" => WATCHDOG_MATCHERS,
+  "group_by" => %w[alertname cluster environment], "group_wait" => "30s",
+  "group_interval" => "1m", "repeat_interval" => "5m", "continue" => false
+}
+fail_closed("watchdog route must be the exact second direct child") unless watchdog_route == expected_watchdog
+fail_closed("nested or broad routes are forbidden") if children.any? { |child| child.key?("routes") }
 
-warn "Alertmanager PagerDuty structure verified (credential value not accessed)."
+warn "Alertmanager PagerDuty and watchdog structure verified (credential values not accessed)."

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -61,7 +61,10 @@ def test_chart_version_and_values_match_live_staging_baseline():
     assert pvc["resources"]["requests"]["storage"] == "20Gi"
     assert staging["prometheus"]["prometheusSpec"]["externalLabels"] == {"cluster": "sugarkube-int"}
     alertmanager = staging["alertmanager"]
-    assert alertmanager["alertmanagerSpec"]["secrets"] == ["alertmanager-pagerduty"]
+    assert alertmanager["alertmanagerSpec"]["secrets"] == [
+        "alertmanager-pagerduty",
+        "alertmanager-healthchecks-watchdog",
+    ]
     route = alertmanager["config"]["route"]
     assert route["receiver"] == "null"
     assert route["routes"] == [
@@ -73,7 +76,21 @@ def test_chart_version_and_values_match_live_staging_baseline():
                 'cluster="sugarkube-int"',
                 'severity="critical"',
             ],
-        }
+        },
+        {
+            "receiver": "healthchecks-watchdog",
+            "matchers": [
+                'alertname="SugarkubeObservabilityWatchdog"',
+                'environment="staging"',
+                'cluster="sugarkube-int"',
+                'purpose="observability-watchdog"',
+            ],
+            "group_by": ["alertname", "cluster", "environment"],
+            "group_wait": "30s",
+            "group_interval": "1m",
+            "repeat_interval": "5m",
+            "continue": False,
+        },
     ]
     pagerduty_receiver = next(
         receiver
@@ -145,7 +162,7 @@ kind: Alertmanager
 metadata:
   name: kube-prometheus-stack-alertmanager
 spec:
-  secrets: [{secret}]
+  secrets: [{secret}, alertmanager-healthchecks-watchdog]
 ---
 apiVersion: v1
 kind: Secret
@@ -159,22 +176,41 @@ stringData:
         - receiver: pagerduty-synthetic-test
           matchers:
 {matcher_yaml}
+        - receiver: healthchecks-watchdog
+          matchers:
+            - 'alertname="SugarkubeObservabilityWatchdog"'
+            - 'environment="staging"'
+            - 'cluster="sugarkube-int"'
+            - 'purpose="observability-watchdog"'
+          group_by: [alertname, cluster, environment]
+          group_wait: 30s
+          group_interval: 1m
+          repeat_interval: 5m
+          continue: false
     receivers:
       - name: "null"
       - name: pagerduty-synthetic-test
         pagerduty_configs:
           - routing_key_file: {path}
             send_resolved: true{inline_field}
+      - name: healthchecks-watchdog
+        webhook_configs:
+          - url_file: /etc/alertmanager/secrets/alertmanager-healthchecks-watchdog/ping-url
+            send_resolved: false
+            http_config:
+              follow_redirects: true
+            max_alerts: 1
+            timeout: 10s
 """
 
 
 @pytest.mark.parametrize(
     ("kwargs", "diagnostic"),
     [
-        ({"secret": "wrong-secret"}, "must reference only"),
-        ({"path": "/wrong/path"}, "exact mounted routing-key file"),
-        ({"matchers": ['severity="critical"']}, "exact synthetic allowlist"),
-        ({"inline": True}, "inline PagerDuty credentials are forbidden"),
+        ({"secret": "wrong-secret"}, "exactly the two expected Secrets"),
+        ({"path": "/wrong/path"}, "PagerDuty configuration changed"),
+        ({"matchers": ['severity="critical"']}, "PagerDuty route must remain first and exact"),
+        ({"inline": True}, "inline credentials or webhook URLs are forbidden"),
     ],
 )
 def test_alertmanager_validator_rejects_missing_mount_wrong_path_inline_and_broad_route(
@@ -262,14 +298,14 @@ def test_alertmanager_validator_redacts_invalid_base64(tmp_path):
                 "      routes:\n        - receiver: pagerduty-synthetic-test",
                 "      routes:\n        - receiver: nested\n          routes:\n            - receiver: pagerduty-synthetic-test",
             ),
-            "direct child of the root route",
+            "PagerDuty route must remain first and exact",
         ),
         (
             lambda text: text.replace(
                 "    receivers:\n",
                 "    receivers:\n      - name: alternate\n        pagerduty_configs: []\n",
             ),
-            "exactly one PagerDuty receiver",
+            "receiver list must contain exactly null, PagerDuty, and watchdog receivers",
         ),
         (
             lambda text: text.replace(
@@ -283,21 +319,21 @@ def test_alertmanager_validator_redacts_invalid_base64(tmp_path):
                 "            - 'severity=\"critical\"'",
                 "            - 'severity=\"critical\"'\n          continue: false",
             ),
-            "must not specify continuation",
+            "PagerDuty route must remain first and exact",
         ),
         (
             lambda text: text.replace(
                 "            - 'severity=\"critical\"'",
                 "            - 'severity=\"critical\"'\n          routes: []",
             ),
-            "must not contain nested routes",
+            "PagerDuty route must remain first and exact",
         ),
         (
             lambda text: text.replace(
                 "    receivers:",
                 "    routing_" + "key: forbidden-stub\n    receivers:",
             ),
-            "inline PagerDuty credentials are forbidden",
+            "inline credentials or webhook URLs are forbidden",
         ),
         (
             lambda text: text.replace(
@@ -308,7 +344,7 @@ def test_alertmanager_validator_redacts_invalid_base64(tmp_path):
                 "      routes:",
                 "      routes:\n        - receiver: alternate\n          matchers: ['severity=~\".*\"']",
             ),
-            "inline PagerDuty credentials are forbidden",
+            "inline credentials or webhook URLs are forbidden",
         ),
     ],
     ids=[
@@ -370,12 +406,12 @@ def test_install_upgrade_are_distinct_and_render_before_mutation():
     install = re.search(r"install_release\(\).*?\nupgrade_release\(", script, re.S).group(0)
     upgrade = re.search(r"upgrade_release\(\).*?\nstatus\(", script, re.S).group(0)
     assert "render_to" in install and "helm install" in install
-    assert install.index("assert_pagerduty_secret") < install.index("render_to")
+    assert install.index("assert_alerting_secrets") < install.index("render_to")
     assert install.index("render_to") < install.index("helm install")
     assert 'state="$(release_state)"' in install
     assert "already exists" in install
     assert "render_to" in upgrade and "helm upgrade" in upgrade
-    assert upgrade.index("assert_pagerduty_secret") < upgrade.index("render_to")
+    assert upgrade.index("assert_alerting_secrets") < upgrade.index("render_to")
     assert upgrade.index("render_to") < upgrade.index("helm upgrade")
     assert 'state="$(release_state)"' in upgrade
     assert "requires an existing Helm release" in upgrade
@@ -496,7 +532,7 @@ case "$*" in
     printf '%s\n' 'apiVersion: v1' 'kind: ConfigMap' 'metadata:' '  name: kube-prometheus-stack-grafana-dashboards-sugarkube' '  labels:' '    dashboard-provider: sugarkube' 'data:' '  sugarkube-staging-observability.json:' '    |-'
     sed 's/^/      /' "$DASHBOARD"
     printf '%s\n' '---' 'kind: ConfigMap' 'data:' '  dashboardproviders.yaml: |' '    providers:' '      - name: sugarkube' '        options:' '          path: /var/lib/grafana/dashboards/sugarkube' '---' 'kind: Deployment' 'spec:' '  template:' '    spec:' '      containers:' '        - volumeMounts:' '            - name: dashboards-sugarkube' '              mountPath: /var/lib/grafana/dashboards/sugarkube/sugarkube-staging-observability.json' '              subPath: sugarkube-staging-observability.json'
-    printf '%s\n' '---' 'apiVersion: monitoring.coreos.com/v1' 'kind: Alertmanager' 'metadata:' '  name: kube-prometheus-stack-alertmanager' 'spec:' '  secrets:' '    - alertmanager-pagerduty'
+    printf '%s\n' '---' 'apiVersion: monitoring.coreos.com/v1' 'kind: Alertmanager' 'metadata:' '  name: kube-prometheus-stack-alertmanager' 'spec:' '  secrets:' '    - alertmanager-pagerduty' '    - alertmanager-healthchecks-watchdog'
     printf '%s\n' '---' 'apiVersion: v1' 'kind: Secret' 'metadata:' '  name: alertmanager-kube-prometheus-stack-alertmanager' 'stringData:' '  alertmanager.yaml: |'
     sed 's/^/    /' "$ALERTMANAGER_CONFIG"
     exit 0
@@ -516,13 +552,14 @@ case "$*" in
   *"get daemonset kube-prometheus-stack-prometheus-node-exporter"*) [ "$KUBECTL_MODE" = two-nodes ] && echo '2 2' || echo '3 3' ;;
   *"get pvc -o json"*) printf '%s\n' '{"items":[{"metadata":{"name":"generated-pvc","labels":{"app.kubernetes.io/name":"prometheus"}},"spec":{"storageClassName":"local-path"},"status":{"phase":"Bound"}}]}' ;;
   *"get prometheus kube-prometheus-stack-prometheus"*) echo 1 ;;
-  *"get alertmanager kube-prometheus-stack-alertmanager -o yaml"*) printf '%s\n' 'apiVersion: monitoring.coreos.com/v1' 'kind: Alertmanager' 'metadata:' '  name: kube-prometheus-stack-alertmanager' 'spec:' '  secrets:' '    - alertmanager-pagerduty' ;;
+  *"get alertmanager kube-prometheus-stack-alertmanager -o yaml"*) printf '%s\n' 'apiVersion: monitoring.coreos.com/v1' 'kind: Alertmanager' 'metadata:' '  name: kube-prometheus-stack-alertmanager' 'spec:' '  secrets:' '    - alertmanager-pagerduty' '    - alertmanager-healthchecks-watchdog' ;;
   *"get alertmanager kube-prometheus-stack-alertmanager"*) echo 1 ;;
   *"get secret alertmanager-kube-prometheus-stack-alertmanager -o yaml"*)
     printf '%s\n' 'apiVersion: v1' 'kind: Secret' 'metadata:' '  name: alertmanager-kube-prometheus-stack-alertmanager' 'stringData:' '  alertmanager.yaml: |'
     [ "$KUBECTL_MODE" != malformed-alertmanager ] && sed 's/^/    /' "$ALERTMANAGER_CONFIG" || printf '%s\n' '    route: [unterminated'
     ;;
   *"get secret alertmanager-pagerduty -o go-template="*) [ "$KUBECTL_MODE" != missing-pagerduty ] || exit 44; [ "$KUBECTL_MODE" != empty-pagerduty ] && echo present ;;
+  *"get secret alertmanager-healthchecks-watchdog -o go-template="*) [ "$KUBECTL_MODE" != missing-watchdog ] || exit 44; [ "$KUBECTL_MODE" != empty-watchdog ] && echo present ;;
   *"port-forward"*"service/kube-prometheus-stack-alertmanager"*":9093"*)
     [ "$PAGERDUTY_MODE" != forward-exit ] || { echo PORT_FORWARD_SENTINEL; exit 42; }
     echo "$PAGERDUTY_FORWARD_LINE"
@@ -619,12 +656,31 @@ printf '%s' "$code"
         - environment="staging"
         - cluster="sugarkube-int"
         - severity="critical"
+    - receiver: healthchecks-watchdog
+      matchers:
+        - alertname="SugarkubeObservabilityWatchdog"
+        - environment="staging"
+        - cluster="sugarkube-int"
+        - purpose="observability-watchdog"
+      group_by: [alertname, cluster, environment]
+      group_wait: 30s
+      group_interval: 1m
+      repeat_interval: 5m
+      continue: false
 receivers:
   - name: "null"
   - name: pagerduty-synthetic-test
     pagerduty_configs:
       - routing_key_file: /etc/alertmanager/secrets/alertmanager-pagerduty/routing-key
         send_resolved: true
+  - name: healthchecks-watchdog
+    webhook_configs:
+      - url_file: /etc/alertmanager/secrets/alertmanager-healthchecks-watchdog/ping-url
+        send_resolved: false
+        http_config:
+          follow_redirects: true
+        max_alerts: 1
+        timeout: 10s
 """,
         encoding="utf-8",
     )

--- a/tests/test_observability_watchdog.py
+++ b/tests/test_observability_watchdog.py
@@ -1,0 +1,118 @@
+import json
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VALUES = ROOT / "clusters/staging/observability/kube-prometheus-stack.values.yaml"
+SCRIPT = ROOT / "scripts/observability_watchdog.sh"
+JUSTFILE = ROOT / "justfile"
+
+
+def load_values():
+    result = subprocess.run(
+        [
+            "ruby",
+            "-ryaml",
+            "-rjson",
+            "-e",
+            "puts JSON.generate(YAML.safe_load_file(ARGV[0]))",
+            str(VALUES),
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_exact_watchdog_rule_and_five_minute_delivery_contract():
+    values = load_values()
+    group = values["additionalPrometheusRulesMap"]["sugarkube-observability-watchdog"]["groups"][0]
+    assert group["interval"] == "1m"
+    assert group["rules"] == [
+        {
+            "alert": "SugarkubeObservabilityWatchdog",
+            "expr": "vector(1)",
+            "labels": {
+                "environment": "staging",
+                "cluster": "sugarkube-int",
+                "purpose": "observability-watchdog",
+            },
+            "annotations": {
+                "summary": "Sugarkube staging observability watchdog",
+                "runbook_url": "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-operations.md#observability-watchdog",
+            },
+        }
+    ]
+    watchdog = values["alertmanager"]["config"]["route"]["routes"][1]
+    assert watchdog["repeat_interval"] == "5m"
+    docs = (ROOT / "docs/observability-operations.md").read_text()
+    assert "**five-minute period**" in docs and "**two-minute grace**" in docs
+
+
+def test_secret_file_receiver_and_no_inline_url():
+    values = load_values()
+    receiver = values["alertmanager"]["config"]["receivers"][2]
+    assert receiver == {
+        "name": "healthchecks-watchdog",
+        "webhook_configs": [
+            {
+                "url_file": "/etc/alertmanager/secrets/alertmanager-healthchecks-watchdog/ping-url",
+                "send_resolved": False,
+                "http_config": {"follow_redirects": True},
+                "max_alerts": 1,
+                "timeout": "10s",
+            }
+        ],
+    }
+    assert "url" not in receiver["webhook_configs"][0]
+
+
+def test_installer_hidden_input_redaction_and_env_normalization_are_explicit():
+    script = SCRIPT.read_text()
+    assert "read -r -s" in script and "</dev/tty" in script
+    assert "must not be supplied through argv" in script
+    assert "must not be supplied through environment variables" in script
+    assert "--from-file=ping-url=/dev/stdin" in script
+    assert "value not printed" in script
+    justfile = JUSTFILE.read_text()
+    for recipe in (
+        "secret-install",
+        "secret-check",
+        "verify",
+        "drill-create",
+        "drill-status",
+        "drill-clear",
+    ):
+        assert f"observability-watchdog-{recipe} env=''" in justfile
+        assert f"observability_watchdog.sh {recipe} '{{{{ env }}}}'" in justfile
+    rejected = subprocess.run(
+        ["bash", str(SCRIPT), "secret-check", "env=env=prod"], text=True, capture_output=True
+    )
+    assert rejected.returncode != 0 and "env=env=prod" not in rejected.stderr
+
+
+def test_drill_payload_is_exact_and_bounded_without_real_wait():
+    script = SCRIPT.read_text()
+    labels = {
+        "alertname": "SugarkubeObservabilityWatchdog",
+        "environment": "staging",
+        "cluster": "sugarkube-int",
+        "purpose": "observability-watchdog",
+    }
+    assert f"labels={json.dumps(labels, separators=(',', ':'))}" in script
+    assert "timedelta(minutes=8)" in script
+    assert 'isRegex":False' in script and 'isEqual":True' in script
+    assert "shutdown" not in re.sub(r'echo "[^"]*"', "", script)
+    assert "hc-ping.com" not in script.replace('"hc-ping.com"', "")
+
+
+def test_helm_lifecycle_checks_both_secret_contracts_before_mutation():
+    helm = (ROOT / "scripts/observability_helm.sh").read_text()
+    assert "assert_alerting_secrets() { assert_pagerduty_secret; assert_watchdog_secret; }" in helm
+    for function in ("install_release()", "upgrade_release()"):
+        body = helm.split(function, 1)[1].split("\n", 1)[0]
+        assert body.index("assert_alerting_secrets") < body.index("render_to") < body.index("helm ")
+    assert 'index .data "ping-url"' in helm
+    assert "must contain a nonempty ping-url" in helm


### PR DESCRIPTION
### Motivation

- Implement a narrow, staging-only dead-man path so the observability stack can prove end-to-end delivery even if Prometheus/Alertmanager host experiences problems, tracked as Refs #2403.

### Description

- Add an always-firing Prometheus rule `SugarkubeObservabilityWatchdog` (`expr: vector(1)`) evaluated at 1m with fixed labels `environment: staging`, `cluster: sugarkube-int`, and `purpose: observability-watchdog`, plus a runbook link to the new docs section.
- Add a secret-file-backed Alertmanager webhook receiver `healthchecks-watchdog` mounted via `alertmanager.alertmanagerSpec.secrets: [alertmanager-pagerduty, alertmanager-healthchecks-watchdog]` and configured to use `url_file: /etc/alertmanager/secrets/alertmanager-healthchecks-watchdog/ping-url`, `send_resolved: false`, `timeout: 10s`, and `max_alerts: 1`.
- Keep the root `null` receiver and the existing `pagerduty-synthetic-test` route/receiver unchanged as the first direct child; add a second direct-child watchdog route with exact matchers for `alertname`, `environment`, `cluster`, and `purpose`, `group_wait: 30s`, `group_interval: 1m`, `repeat_interval: 5m`, `group_by: [alertname, cluster, environment]`, and `continue: false`.
- Add secret-safe operator tooling and recipes: `scripts/observability_watchdog.sh` to install/rotate the ping URL via hidden `/dev/tty` input, check the Secret contract without revealing credentials, run bounded live verification, and create/status/clear an exact eight-minute controlled-drill silence; expose these via `just` recipes for staging-only use.
- Extend `scripts/verify_observability_alertmanager.rb` to enforce an exact two-integration contract (PagerDuty + Healthchecks watchdog), forbid inline credentials/URLs, validate `routing_key_file` and `url_file` usage and send_resolved semantics, and require the exact watchdog route placement, grouping, and timings.
- Update `scripts/observability_helm.sh` to assert both secret contracts before any Helm mutation while keeping rendering cluster-independent and secret-free, and add focused tests and docs: `tests/test_observability_watchdog.py`, updated `tests/test_observability_helm.py`, and new docs sections in `docs/observability-operations.md`, `docs/observability-alerting.md`, and `docs/observability-design.md` describing installation, verification, drill, recovery, latency, and rollback guidance.

### Testing

- `bash -n scripts/observability_helm.sh scripts/observability_watchdog.sh`: syntax OK.
- `ruby -c scripts/verify_observability_alertmanager.rb`: syntax OK and the validator was exercised successfully against the rendered YAML.
- `python3 -m pytest -q tests/test_observability_helm.py tests/test_observability_watchdog.py`: focused test suite passed locally after the changes.
- `just observability-render env=staging >/dev/null`: rendering run to validate chart template output (ran after ensuring tools present); rendering validated the Alertmanager structure and dashboards.
- `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/`: documentation checks passed in this run (required installing system spell tool in the runner).
- `git diff --cached | ./scripts/scan-secrets.py`: scanning passed and commit was created without embedding credentials.
- `pre-commit run --all-files`: repository-wide pre-commit checks surfaced pre-existing baseline failures in unrelated multi-document/templated YAML and some flake8 issues outside the scope of this focused change; the implemented files were adjusted to satisfy project secret-safety and style expectations where relevant.

Post-merge staging checklist (operator actions - do not store secrets in repo)

- [ ] Run `just observability-watchdog-secret-install env=staging` to interactively install/rotate the watchdog `ping-url` Secret.
- [ ] Run `just observability-upgrade env=staging` to apply the Helm upgrade (requires both secrets present and non-empty).
- [ ] Run `just observability-watchdog-verify env=staging` to perform the live structural and bounded delivery checks and then manually confirm the Healthchecks “last ping” advanced.
- [ ] Perform the controlled drill: `just observability-watchdog-drill-create env=staging`, confirm Healthchecks → PagerDuty paging and acknowledgement, then optional early clear with `just observability-watchdog-drill-clear env=staging` or wait for automatic expiry.

Refs #2403

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c20cf1c30832f9a4610ecf5170834)