### PR TITLE
Add staging observability dead-man watchdog (Healthchecks webhook + rule)

### DIFF
--- a/clusters/staging/observability/kube-prometheus-stack.values.yaml
+++ b/clusters/staging/observability/kube-prometheus-stack.values.yaml
@@ -4,10 +4,26 @@ prometheus:
   prometheusSpec:
     externalLabels:
       cluster: sugarkube-int
+additionalPrometheusRulesMap:
+  sugarkube-observability-watchdog:
+    groups:
+      - name: sugarkube-observability-watchdog
+        interval: 1m
+        rules:
+          - alert: SugarkubeObservabilityWatchdog
+            expr: vector(1)
+            labels:
+              environment: staging
+              cluster: sugarkube-int
+              purpose: observability-watchdog
+            annotations:
+              summary: Sugarkube staging observability watchdog
+              runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-operations.md#observability-watchdog
 alertmanager:
   alertmanagerSpec:
     secrets:
       - alertmanager-pagerduty
+      - alertmanager-healthchecks-watchdog
   config:
     route:
       receiver: "null"
@@ -18,9 +34,25 @@ alertmanager:
             - environment="staging"
             - cluster="sugarkube-int"
             - severity="critical"
+        - receiver: healthchecks-watchdog
+          matchers:
+            - alertname="SugarkubeObservabilityWatchdog"
+            - environment="staging"
+            - cluster="sugarkube-int"
+            - purpose="observability-watchdog"
+          group_wait: 30s
+          group_interval: 1m
+          repeat_interval: 5m
+          group_by: [alertname, cluster, environment]
     receivers:
       - name: "null"
       - name: pagerduty-synthetic-test
         pagerduty_configs:
           - routing_key_file: /etc/alertmanager/secrets/alertmanager-pagerduty/routing-key
             send_resolved: true
+      - name: healthchecks-watchdog
+        webhook_configs:
+          - url_file: /etc/alertmanager/secrets/alertmanager-healthchecks-watchdog/ping-url
+            send_resolved: false
+            max_alerts: 1
+            timeout: 10s

--- a/docs/observability-alerting.md
+++ b/docs/observability-alerting.md
@@ -7,7 +7,7 @@ described in [`docs/observability-design.md`](./observability-design.md) and
 a human. The secret-file-backed synthetic Alertmanager → PagerDuty path has now been manually proven
 through fire, phone receipt, acknowledgement, and resolution. The host-heartbeat assets in this
 repository are ready for a separate post-merge install on each staging node; that install is not live
-deployment evidence. Real workload routes and the external observability watchdog remain deferred.
+deployment evidence. Real workload routes remain deferred; the staging observability watchdog is implemented.
 
 ## 1. Goals and non-goals
 
@@ -168,7 +168,7 @@ A safe, phased sequence — each step depends on the previous one succeeding:
    incident, resolve the alert, and observe resolution after Alertmanager's expected default
    resolution delay (about five minutes).
 4. Install and verify the external node heartbeats against Healthchecks.io. Implement and verify the
-   observability watchdog only in a later slice.
+   observability watchdog through the implemented exact Healthchecks route.
    Confirm the watchdog's dedicated Alertmanager timing and the Healthchecks.io period/grace match
    the contract in §3; observe multiple repeat notifications before declaring the path healthy.
 5. Audit the existing `kube-prometheus-stack` bundled node rules (starting with `KubeNodeNotReady`).
@@ -231,3 +231,12 @@ it is deployed yet — see the rollout plan above for the actual sequencing.
 - Per-node heartbeat assets are repository-ready but have not been installed on the Pis. The
   node-power-off drill, watchdog, `KubeNodeNotReady` routing, and application alerts remain later
   work.
+
+## Implemented staging observability watchdog
+
+The staging dead-man path is now Prometheus `vector(1)` → an exact four-label Alertmanager route → a
+Secret-file-backed Healthchecks webhook repeating every five minutes. It is distinct from the
+per-node host heartbeat (node/timer failure), ordinary Prometheus alerts (internal conditions, still
+routed to `null` unless explicitly allowlisted), and blackbox endpoint probes (application reachability
+from inside the cluster). Installation, live proof, the eight-minute silence drill, recovery, and
+page-safe rollback are in the [observability watchdog runbook](observability-operations.md#observability-watchdog).

--- a/docs/observability-design.md
+++ b/docs/observability-design.md
@@ -344,7 +344,7 @@ Do not page on symptoms without a response path, such as low traffic, GitHub sta
 ## 12. Phased rollout
 
 1. **Inventory and naming contract**: finalize metric names, labels, privacy rules, and app release gates. Can proceed in parallel with app repo implementation planning.
-2. **Cluster monitoring foundation**: *implemented in staging.* kube-prometheus-stack is deployed and scripted-verified in staging, with resource requests, retention, PV, and Grafana provisioned as documented in [`docs/observability-operations.md`](./observability-operations.md); Alertmanager still runs the no-op `"null"` receiver. Production rollout remains future work.
+2. **Cluster monitoring foundation**: *implemented in staging.* kube-prometheus-stack is deployed and scripted-verified in staging, with resource requests, retention, PV, and Grafana provisioned as documented in [`docs/observability-operations.md`](./observability-operations.md); Alertmanager retains the `"null"` root while exact staging PagerDuty-test and watchdog child routes are allowlisted. Production rollout remains future work.
 3. **Blackbox monitoring**: *implemented in staging.* 16 public probes across all four apps plus TLS expiry are live and scripted-verified, per [`docs/observability-blackbox.md`](./observability-blackbox.md).
 4. **Application scrape integration**: app repos expose safe metrics and chart scrape hooks; Sugarkube enables discovery per environment. DSPACE's authenticated `ServiceMonitor` is live in staging (§7); token.place and danielsmith.io app metrics remain future work per each app's release gate.
 5. **Dashboards**: *implemented in staging* for the currently live signals — see §10. Additional per-app dashboard rows arrive as each app's metrics land.
@@ -379,6 +379,15 @@ Prometheus or Grafana should not be listed as production skills until evidence e
 
 - Which cluster names should distinguish staging and production if both run on Sugarkube-managed hardware?
 - Should app metrics endpoints use bearer tokens, network policy only, or both?
-- The Alertmanager receiver question is answered at the design level: PagerDuty plus Healthchecks.io, per [`docs/observability-alerting.md`](./observability-alerting.md). What remains open is execution — accounts, secret-safe config, and drills, none of which are done yet.
+- The Alertmanager receiver question is answered at the design level: PagerDuty plus Healthchecks.io, per [`docs/observability-alerting.md`](./observability-alerting.md). The staging watchdog now has secret-safe configuration and drill automation; live staging proof and broader alert routing remain open.
 - What Prometheus PV size is realistic after a one-week staging soak on the target Pi hardware?
 - Should Loki remain entirely deferred, or should minimal log labels be designed now without deploying Loki?
+
+## Staging dead-man coverage
+
+Staging now has an observability-watchdog signal whose successful path crosses Prometheus rule
+evaluation, Alertmanager routing, and a Secret-backed Healthchecks delivery. Its five-minute repeat is
+independent of the per-node Healthchecks heartbeat, ordinary Prometheus condition alerts, and in-cluster
+blackbox endpoint probes. The exact routing and operational boundaries are documented in the
+[observability watchdog runbook](observability-operations.md#observability-watchdog); production remains
+unsupported by this staging-only lifecycle.

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -398,6 +398,66 @@ lost, and distinct from the automated evidence above:
 
 Additional dashboards, Grafana persistence, central multi-cluster Grafana, and production
 observability codification are separate follow-ups. The existing blackbox NetworkPolicy is unchanged.
-Alerting onboarding — real Alertmanager receivers, external heartbeats, and failure drills — is no
-longer undesigned scope creep; it is planned, designed work tracked in
-[`docs/observability-alerting.md`](observability-alerting.md), just not yet executed.
+Alerting onboarding is tracked in [`docs/observability-alerting.md`](observability-alerting.md). The
+staging watchdog slice below is implemented; broader ordinary-alert paging remains future work.
+
+## Observability watchdog
+
+The staging-only `SugarkubeObservabilityWatchdog` rule evaluates `vector(1)` every minute. Its fixed
+`environment=staging`, `cluster=sugarkube-int`, and `purpose=observability-watchdog` labels select one
+exact Alertmanager child route. That route waits 30 seconds, groups by alert name, cluster, and
+environment, and repeats every five minutes to the `healthchecks-watchdog` webhook. The webhook reads
+its URL only from the mounted `monitoring/alertmanager-healthchecks-watchdog` Secret's `ping-url` key,
+uses a ten-second timeout, sends at most one alert, and does not send resolved notifications. The root
+receiver remains `null`; the preceding exact synthetic PagerDuty route is unchanged, so ordinary
+Prometheus alerts are still discarded.
+
+Configure the Healthchecks check for a **five-minute period** and **two-minute grace**. The expected
+failure latency is therefore about seven minutes after the last delivered repeat, plus provider and
+PagerDuty processing time. Healthchecks “last ping” is deliberately a manual dashboard checkpoint;
+no Healthchecks account credential belongs in this repository.
+
+### Install, deploy, and verify
+
+```bash
+just kubeconfig-env env=staging
+just observability-watchdog-install env=staging
+just observability-watchdog-secret-check env=staging
+just observability-render env=staging >/dev/null
+just observability-upgrade env=staging
+just observability-watchdog-verify env=staging
+```
+
+The installer accepts no URL argument or environment variable, reads hidden input from `/dev/tty`,
+and streams the Secret manifest through stdin. Render is cluster-independent and contains neither
+integration credential. Install and upgrade fail before Helm mutation unless both the PagerDuty
+`routing-key` and watchdog `ping-url` Secret contracts are nonempty. After verification, manually
+confirm that Healthchecks shows a recent last ping.
+
+### Controlled failure drill and recovery
+
+First confirm manually that Healthchecks is healthy and PagerDuty is ready. Then create only the
+owned, exact four-label silence; it has an automatic eight-minute expiry, so recovery does not
+depend on the operator remaining connected:
+
+```bash
+SUGARKUBE_WATCHDOG_DRILL_CONFIRM=confirmed just observability-watchdog-drill-create env=staging
+just observability-watchdog-drill-status env=staging
+# Optional early recovery:
+just observability-watchdog-drill-clear env=staging
+```
+
+Do **not** stop a node and do **not** manually call the ping URL. During the drill, manually confirm the
+Healthchecks transition after its five-minute period plus two-minute grace, the Healthchecks-generated
+PagerDuty incident, and acknowledgement. After silence expiry (or the owned early-clear), confirm the
+next repeat restores Healthchecks, then confirm PagerDuty recovery and resolution. Automated tests do
+not wait for this real interval.
+
+### Rollback
+
+> **PAGE-SAFETY CHECKPOINT:** pause the Healthchecks check or its PagerDuty integration before any
+> rollback that removes the watchdog receiver. Otherwise rollback itself can generate a page.
+
+After pausing it, roll back Helm by the established guarded staging procedure and run
+`just observability-verify env=staging`. Resume or remove the external check only after its intended
+state is confirmed. Never delete or print either Secret as part of rollback.

--- a/justfile
+++ b/justfile
@@ -3284,6 +3284,30 @@ observability-blackbox-status env='':
 observability-blackbox-verify env='':
     @scripts/observability_blackbox.sh verify '{{ env }}'
 
+# Install or rotate the staging observability watchdog URL from hidden TTY input.
+observability-watchdog-install env='':
+    @scripts/observability_watchdog.sh install '{{ env }}'
+
+# Check both the Secret and key without reading or decoding the value.
+observability-watchdog-secret-check env='':
+    @scripts/observability_watchdog.sh check '{{ env }}'
+
+# Verify the live rule, active alert, generated configuration, mount, and delivery logs.
+observability-watchdog-verify env='':
+    @scripts/observability_watchdog.sh verify '{{ env }}'
+
+# Create the exact-label, automatically expiring controlled drill silence.
+observability-watchdog-drill-create env='':
+    @scripts/observability_watchdog.sh drill-create '{{ env }}'
+
+# Inspect sanitized owned drill-silence status.
+observability-watchdog-drill-status env='':
+    @scripts/observability_watchdog.sh drill-status '{{ env }}'
+
+# Remove only an exact matching owned drill silence before its expiry.
+observability-watchdog-drill-clear env='':
+    @scripts/observability_watchdog.sh drill-clear '{{ env }}'
+
 # Silently configure and enable this staging node's Healthchecks.io heartbeat.
 observability-node-heartbeat-install env='':
     @scripts/observability_node_heartbeat.sh install '{{ env }}'

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -14,6 +14,7 @@ DASHBOARD_VALIDATOR="${ROOT}/scripts/validate_observability_dashboard.py"
 TIMEOUT="${SUGARKUBE_OBSERVABILITY_HELM_TIMEOUT:-20m}"
 GRAFANA_URL="http://sugarkube3.local:30300"
 PAGERDUTY_SECRET="alertmanager-pagerduty"
+WATCHDOG_SECRET="alertmanager-healthchecks-watchdog"
 ALERTMANAGER_VALIDATOR="${ROOT}/scripts/verify_observability_alertmanager.rb"
 
 usage() { echo "Usage: $0 <render|install|upgrade|status|verify|dashboard-verify|pagerduty-test> env=staging [fire|resolve]" >&2; }
@@ -78,6 +79,15 @@ assert_pagerduty_secret() {
   fi
   echo "PagerDuty Secret contract exists (value intentionally not read or printed)."
 }
+assert_watchdog_secret() {
+  local present
+  if ! present="$(kubectl -n "${NAMESPACE}" get secret "${WATCHDOG_SECRET}" -o 'go-template={{if index .data "ping-url"}}present{{end}}' 2>/dev/null)" || [[ "${present}" != present ]]; then
+    echo "ERROR: Secret monitoring/alertmanager-healthchecks-watchdog must contain a nonempty ping-url (value intentionally not read or printed)." >&2
+    return 15
+  fi
+  echo "Watchdog Secret contract exists (value intentionally not read or printed)."
+}
+assert_integration_secrets() { assert_pagerduty_secret; assert_watchdog_secret; }
 release_state() {
   local matches
   # Do not infer absence from `helm status`: transport and authorization errors
@@ -96,8 +106,8 @@ release_state() {
   fi
 }
 render() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; tmp="$(mktemp -t sugarkube-observability-render.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; cat "${tmp}"; }
-install_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; assert_pagerduty_secret; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
-upgrade_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; assert_pagerduty_secret; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
+install_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; assert_integration_secrets; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
+upgrade_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; assert_integration_secrets; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
 status() { require_tools helm kubectl python3; print_resolved staging; assert_context; helm -n "${NAMESPACE}" status "${RELEASE}"; kubectl -n "${NAMESPACE}" get deploy,statefulset,daemonset -l "app.kubernetes.io/instance=${RELEASE}"; kubectl -n "${NAMESPACE}" get prometheus,alertmanager; kubectl -n "${NAMESPACE}" get svc,pvc; kubectl get crd prometheuses.monitoring.coreos.com alertmanagers.monitoring.coreos.com servicemonitors.monitoring.coreos.com probes.monitoring.coreos.com; }
 verify_dspace_targets() {
   require_tools kubectl python3 sleep
@@ -247,7 +257,7 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
     raise SystemExit("ERROR: expected one Bound local-path Prometheus PVC.")'
   [[ "$(kubectl -n "${NAMESPACE}" get prometheus kube-prometheus-stack-prometheus -o jsonpath='{.spec.replicas}')" == 1 ]]
   [[ "$(kubectl -n "${NAMESPACE}" get alertmanager kube-prometheus-stack-alertmanager -o jsonpath='{.spec.replicas}')" == 1 ]]
-  assert_pagerduty_secret
+  assert_integration_secrets
   local alertmanager_yaml="" config_yaml=""
   trap 'rm -f "${alertmanager_yaml:-}" "${config_yaml:-}"' EXIT
   alertmanager_yaml="$(mktemp -t sugarkube-alertmanager-cr.XXXXXX.yaml)"

--- a/scripts/observability_watchdog.sh
+++ b/scripts/observability_watchdog.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+NAMESPACE=monitoring
+SECRET=alertmanager-healthchecks-watchdog
+KEY=ping-url
+TTY="${SUGARKUBE_WATCHDOG_TTY:-/dev/tty}"
+OWNER=sugarkube-observability-watchdog-drill
+
+die() { printf 'ERROR: %s\n' "$1" >&2; exit "${2:-1}"; }
+normalize_env() { local value="${1:-}"; while [[ "$value" == env=* ]]; do value="${value#env=}"; done; [[ "$value" == staging ]] || die 'env=staging is required; production and unknown environments are unsupported.' 2; }
+require_tools() { local tool; for tool in "$@"; do command -v "$tool" >/dev/null || die "required tool is missing: $tool" 127; done; }
+context_guard() {
+  [[ "$(kubectl config current-context 2>/dev/null || true)" == sugar-staging ]] || die "staging context mismatch; run 'just kubeconfig-env env=staging'." 3
+  python3 "$ROOT/scripts/cluster_identity.py" assert --kubeconfig "${KUBECONFIG:-$HOME/.kube/config}" --env staging >/dev/null || die 'staging cluster identity check failed.' 3
+}
+secret_contract() {
+  local present
+  if ! present="$(kubectl -n "$NAMESPACE" get secret "$SECRET" -o "go-template={{if index .data \"$KEY\"}}present{{end}}" 2>/dev/null)" || [[ "$present" != present ]]; then
+    die "Secret $NAMESPACE/$SECRET must contain a nonempty $KEY (value not accessed or printed)." 15
+  fi
+  printf 'Watchdog Secret contract exists (value not accessed or printed).\n'
+}
+install_secret() {
+  local value
+  [[ $# -eq 0 ]] || die 'credentials in command arguments are refused.' 2
+  [[ -z "${HEALTHCHECKS_PING_URL:-}${HEALTHCHECK_PING_URL:-}${PING_URL:-}${WATCHDOG_PING_URL:-}" ]] || die 'ping URLs in environment variables are refused.' 2
+  context_guard; require_tools kubectl python3
+  exec 3<"$TTY" || die 'a readable controlling terminal is required.'
+  [[ "${SUGARKUBE_WATCHDOG_TEST_NONTTY:-0}" == 1 || -t 3 ]] || die 'a controlling terminal is required; piped input is refused.'
+  printf 'Enter the Healthchecks watchdog ping URL (input hidden): ' >&2
+  IFS= read -r -s value <&3 || die 'could not read the URL from the controlling terminal.'
+  printf '\n' >&2
+  [[ "$value" =~ ^https://hc-ping\.com/[0-9a-fA-F-]{36}$ && "$value" != *$'\n'* ]] || die 'ping URL is invalid (value redacted).'
+  if ! printf '%s' "$value" | kubectl -n "$NAMESPACE" create secret generic "$SECRET" --from-file="$KEY=/dev/stdin" --dry-run=client -o yaml | kubectl apply -f - >/dev/null; then
+    unset value; die 'watchdog Secret installation failed (credential redacted).'
+  fi
+  unset value
+  printf 'Installed watchdog Secret contract in monitoring (credential redacted).\n'
+}
+verify_live() {
+  context_guard; require_tools kubectl python3 ruby sleep; secret_contract
+  local prom am cr config logs
+  cr="$(mktemp -t watchdog-alertmanager-cr.XXXXXX)"; config="$(mktemp -t watchdog-alertmanager-config.XXXXXX)"; trap 'rm -f "$cr" "$config"' RETURN
+  kubectl -n "$NAMESPACE" get alertmanager kube-prometheus-stack-alertmanager -o yaml >"$cr"
+  kubectl -n "$NAMESPACE" get secret alertmanager-kube-prometheus-stack-alertmanager -o yaml >"$config"
+  ruby "$ROOT/scripts/verify_observability_alertmanager.rb" live "$cr" "$config"
+  prom="$(kubectl get --raw "/api/v1/namespaces/$NAMESPACE/services/http:kube-prometheus-stack-prometheus:9090/proxy/api/v1/rules?type=alert")"
+  PROM_RESPONSE="$prom" python3 - <<'PY'
+import json, os
+r=json.loads(os.environ.pop("PROM_RESPONSE")); wanted={"alertname":"SugarkubeObservabilityWatchdog","environment":"staging","cluster":"sugarkube-int","purpose":"observability-watchdog"}
+rules=[x for g in r.get("data",{}).get("groups",[]) for x in g.get("rules",[]) if x.get("name")==wanted["alertname"]]
+if len(rules)!=1 or rules[0].get("query")!="vector(1)" or rules[0].get("state")!="firing" or any(rules[0].get("labels",{}).get(k)!=v for k,v in wanted.items() if k!="alertname"):
+ raise SystemExit("ERROR: exact watchdog Prometheus rule is not firing (response redacted).")
+PY
+  am="$(kubectl get --raw "/api/v1/namespaces/$NAMESPACE/services/http:kube-prometheus-stack-alertmanager:9093/proxy/api/v2/alerts")"
+  AM_RESPONSE="$am" python3 - <<'PY'
+import json, os
+alerts=json.loads(os.environ.pop("AM_RESPONSE")); wanted={"alertname":"SugarkubeObservabilityWatchdog","environment":"staging","cluster":"sugarkube-int","purpose":"observability-watchdog"}
+if len([a for a in alerts if all(a.get("labels",{}).get(k)==v for k,v in wanted.items()) and a.get("status",{}).get("state")=="active"])!=1:
+ raise SystemExit("ERROR: exact active watchdog alert is absent from Alertmanager (response redacted).")
+PY
+  sleep "${SUGARKUBE_WATCHDOG_OBSERVE_SECONDS:-10}"
+  logs="$(kubectl -n "$NAMESPACE" logs statefulset/alertmanager-kube-prometheus-stack-alertmanager --since=2m 2>/dev/null || true)"
+  if printf '%s' "$logs" | python3 -c 'import re,sys; s=sys.stdin.read(); raise SystemExit(0 if re.search(r"(?is)(watchdog|healthchecks).{0,200}(error|fail)|(?:error|fail).{0,200}(watchdog|healthchecks)",s) else 1)'; then
+    die 'observed a watchdog delivery error (details redacted).' 18
+  fi
+  printf 'Live watchdog rule, alert, mounted receiver, and bounded delivery observation verified; credentials and responses redacted.\n'
+}
+port_forward() {
+  PF_DIR="$(mktemp -d -t watchdog-alertmanager.XXXXXX)"; PF_PID=''; PF_PORT=''
+  cleanup_pf() { [[ -z "$PF_PID" ]] || { kill "$PF_PID" 2>/dev/null || true; wait "$PF_PID" 2>/dev/null || true; }; rm -rf "$PF_DIR"; }
+  trap cleanup_pf EXIT INT TERM
+  kubectl -n "$NAMESPACE" port-forward --address=127.0.0.1 service/kube-prometheus-stack-alertmanager :9093 >"$PF_DIR/log" 2>&1 & PF_PID=$!
+  for _ in {1..20}; do PF_PORT="$(sed -nE 's/^Forwarding from 127\.0\.0\.1:([0-9]+) -> 9093$/\1/p' "$PF_DIR/log" | head -1)"; [[ -n "$PF_PORT" ]] && break; kill -0 "$PF_PID" 2>/dev/null || break; sleep 1; done
+  [[ -n "$PF_PORT" ]] || die 'Alertmanager loopback connection failed (diagnostics redacted).' 19
+}
+drill() {
+  local action="$1" payload response
+  context_guard; require_tools kubectl python3 curl; port_forward
+  case "$action" in
+    create)
+      printf '\n*** MANUAL CHECKPOINT: confirm the Healthchecks check is healthy and PagerDuty is ready before continuing. ***\n' >&2
+      [[ "${SUGARKUBE_WATCHDOG_DRILL_CONFIRM:-}" == confirmed ]] || die 'set SUGARKUBE_WATCHDOG_DRILL_CONFIRM=confirmed after completing the manual checkpoint; no disruption performed.' 20
+      payload="$(python3 - <<'PY'
+import datetime,json
+now=datetime.datetime.now(datetime.timezone.utc); end=now+datetime.timedelta(minutes=8)
+match=[{"name":k,"value":v,"isRegex":False} for k,v in {"alertname":"SugarkubeObservabilityWatchdog","environment":"staging","cluster":"sugarkube-int","purpose":"observability-watchdog"}.items()]
+print(json.dumps({"matchers":match,"startsAt":now.isoformat(),"endsAt":end.isoformat(),"createdBy":"sugarkube-operator","comment":"sugarkube-observability-watchdog-drill"}))
+PY
+)"
+      response="$(curl -fsS --max-time 10 -H 'Content-Type: application/json' --data-binary @- "http://127.0.0.1:$PF_PORT/api/v2/silences" <<<"$payload")" || die 'silence creation failed (response redacted).'
+      RESPONSE="$response" python3 -c 'import json,os; assert isinstance(json.loads(os.environ.pop("RESPONSE")).get("silenceID"),str)' || die 'silence creation response was invalid (redacted).'
+      printf 'Owned exact-label drill silence created with automatic eight-minute expiry. Confirm Healthchecks/PagerDuty transitions manually.\n' ;;
+    status|clear)
+      response="$(curl -fsS --max-time 10 "http://127.0.0.1:$PF_PORT/api/v2/silences")" || die 'silence query failed (response redacted).'
+      IDS="$(RESPONSE="$response" python3 - <<'PY'
+import json,os
+want={"alertname":"SugarkubeObservabilityWatchdog","environment":"staging","cluster":"sugarkube-int","purpose":"observability-watchdog"}
+out=[]
+for s in json.loads(os.environ.pop("RESPONSE")):
+ m={x.get("name"):x.get("value") for x in s.get("matchers",[]) if not x.get("isRegex")}
+ if s.get("comment")=="sugarkube-observability-watchdog-drill" and m==want and s.get("status",{}).get("state") in ("active","pending"): out.append(s["id"])
+print("\n".join(out))
+PY
+)"
+      if [[ "$action" == clear ]]; then while IFS= read -r id; do [[ -z "$id" ]] || curl -fsS --max-time 10 -X DELETE "http://127.0.0.1:$PF_PORT/api/v2/silence/$id" >/dev/null || die 'owned silence removal failed (response redacted).'; done <<<"$IDS"; printf 'Removed only matching owned watchdog drill silence(s).\n'; else [[ -n "$IDS" ]] && printf 'Owned watchdog drill silence is active or pending.\n' || printf 'No owned active watchdog drill silence exists.\n'; fi ;;
+  esac
+}
+
+[[ $# -ge 2 ]] || die "usage: $0 install|check|verify|drill-create|drill-status|drill-clear env=staging" 2
+action="$1"; normalize_env "$2"; shift 2
+case "$action" in install) install_secret "$@" ;; check) [[ $# -eq 0 ]] || die 'unexpected arguments.' 2; context_guard; secret_contract ;; verify) [[ $# -eq 0 ]] || die 'unexpected arguments.' 2; verify_live ;; drill-create) [[ $# -eq 0 ]] || die 'unexpected arguments.' 2; drill create ;; drill-status) [[ $# -eq 0 ]] || die 'unexpected arguments.' 2; drill status ;; drill-clear) [[ $# -eq 0 ]] || die 'unexpected arguments.' 2; drill clear ;; *) die 'unknown watchdog action.' 2 ;; esac

--- a/scripts/verify_observability_alertmanager.rb
+++ b/scripts/verify_observability_alertmanager.rb
@@ -4,18 +4,26 @@
 require "base64"
 require "yaml"
 
-EXPECTED_SECRET = "alertmanager-pagerduty"
-EXPECTED_PATH = "/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key"
-EXPECTED_RECEIVER = "pagerduty-synthetic-test"
-EXPECTED_MATCHERS = [
+EXPECTED_SECRETS = %w[alertmanager-pagerduty alertmanager-healthchecks-watchdog].freeze
+PAGERDUTY_PATH = "/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key"
+WATCHDOG_PATH = "/etc/alertmanager/secrets/alertmanager-healthchecks-watchdog/ping-url"
+PAGERDUTY_RECEIVER = "pagerduty-synthetic-test"
+WATCHDOG_RECEIVER = "healthchecks-watchdog"
+PAGERDUTY_MATCHERS = [
   'alertname="SugarkubePagerDutyTest"',
   'environment="staging"',
   'cluster="sugarkube-int"',
   'severity="critical"'
 ].freeze
+WATCHDOG_MATCHERS = [
+  'alertname="SugarkubeObservabilityWatchdog"',
+  'environment="staging"',
+  'cluster="sugarkube-int"',
+  'purpose="observability-watchdog"'
+].freeze
 
 def fail_closed(message)
-  warn "ERROR: Alertmanager PagerDuty structure invalid: #{message} (sensitive values not printed)."
+  warn "ERROR: Alertmanager integration structure invalid: #{message} (sensitive values not printed)."
   exit 16
 end
 
@@ -43,7 +51,7 @@ end
 fail_closed("expected exactly one kube-prometheus-stack Alertmanager custom resource") unless alertmanagers.length == 1
 alertmanager = alertmanagers.first
 secrets = alertmanager.dig("spec", "secrets")
-fail_closed("Alertmanager must reference only #{EXPECTED_SECRET}") unless secrets == [EXPECTED_SECRET]
+fail_closed("Alertmanager must reference exactly the two expected Secrets") unless secrets == EXPECTED_SECRETS
 
 config_secret = documents.find do |doc|
   doc["kind"] == "Secret" && doc.dig("metadata", "name") == "alertmanager-kube-prometheus-stack-alertmanager"
@@ -64,14 +72,15 @@ fail_closed("generated Alertmanager configuration is malformed") unless config.i
 inline_credential = lambda do |value|
   case value
   when Hash
-    value.key?("routing_key") || value.key?("service_key") || value.any? { |_key, child| inline_credential.call(child) }
+    value.key?("routing_key") || value.key?("service_key") || value.key?("url") ||
+      value.any? { |_key, child| inline_credential.call(child) }
   when Array
     value.any? { |child| inline_credential.call(child) }
   else
     false
   end
 end
-fail_closed("inline PagerDuty credentials are forbidden") if inline_credential.call(config)
+fail_closed("inline credentials and webhook URLs are forbidden") if inline_credential.call(config)
 
 route = config["route"]
 fail_closed('root receiver must remain "null"') unless route.is_a?(Hash) && route["receiver"] == "null"
@@ -80,15 +89,27 @@ receivers = config["receivers"]
 fail_closed("receiver list is malformed") unless receivers.is_a?(Array)
 fail_closed("receiver list is malformed") unless receivers.all? { |item| item.is_a?(Hash) }
 fail_closed('root "null" receiver is missing') unless receivers.count { |item| item == { "name" => "null" } } == 1
+fail_closed("exactly three receivers are required") unless receivers.length == 3
 pagerduty = receivers.select { |item| item.key?("pagerduty_configs") }
 fail_closed("there must be exactly one PagerDuty receiver") unless pagerduty.length == 1
-fail_closed("PagerDuty receiver name changed") unless pagerduty.first["name"] == EXPECTED_RECEIVER
+fail_closed("PagerDuty receiver name changed") unless pagerduty.first["name"] == PAGERDUTY_RECEIVER
 pd_configs = pagerduty.first["pagerduty_configs"]
 fail_closed("there must be exactly one PagerDuty configuration") unless pd_configs.is_a?(Array) && pd_configs.length == 1
 pd_config = pd_configs.first
 fail_closed("PagerDuty configuration is malformed") unless pd_config.is_a?(Hash)
-fail_closed("PagerDuty must use the exact mounted routing-key file") unless pd_config["routing_key_file"] == EXPECTED_PATH
+fail_closed("PagerDuty must use the exact mounted routing-key file") unless pd_config == {
+  "routing_key_file" => PAGERDUTY_PATH, "send_resolved" => true
+}
 fail_closed("PagerDuty resolved notifications must be enabled") unless pd_config["send_resolved"] == true
+
+webhooks = receivers.select { |item| item.key?("webhook_configs") }
+fail_closed("there must be exactly one webhook receiver") unless webhooks.length == 1
+fail_closed("watchdog receiver name changed") unless webhooks.first["name"] == WATCHDOG_RECEIVER
+webhook_configs = webhooks.first["webhook_configs"]
+fail_closed("there must be exactly one watchdog webhook configuration") unless webhook_configs.is_a?(Array) && webhook_configs.length == 1
+fail_closed("watchdog webhook must use only the mounted URL file and exact delivery contract") unless webhook_configs.first == {
+  "url_file" => WATCHDOG_PATH, "send_resolved" => false, "max_alerts" => 1, "timeout" => "10s"
+}
 
 all_routes = []
 walk_routes = lambda do |candidate|
@@ -101,15 +122,31 @@ walk_routes = lambda do |candidate|
   children.each { |child| walk_routes.call(child) }
 end
 walk_routes.call(route)
-pagerduty_routes = all_routes.select { |candidate| candidate["receiver"] == EXPECTED_RECEIVER }
+pagerduty_routes = all_routes.select { |candidate| candidate["receiver"] == PAGERDUTY_RECEIVER }
 fail_closed("there must be exactly one PagerDuty route") unless pagerduty_routes.length == 1
 synthetic_route = pagerduty_routes.first
 root_children = route["routes"]
 fail_closed("PagerDuty route must be a direct child of the root route") unless
   root_children.is_a?(Array) && root_children.include?(synthetic_route)
 fail_closed("PagerDuty route matchers are not the exact synthetic allowlist") unless
-  synthetic_route["matchers"].is_a?(Array) && synthetic_route["matchers"].sort == EXPECTED_MATCHERS.sort
+  synthetic_route["matchers"].is_a?(Array) && synthetic_route["matchers"].sort == PAGERDUTY_MATCHERS.sort
 fail_closed("PagerDuty route must not contain nested routes") if synthetic_route.key?("routes")
 fail_closed("PagerDuty route must not specify continuation") if synthetic_route.key?("continue")
 
-warn "Alertmanager PagerDuty structure verified (credential value not accessed)."
+watchdog_routes = all_routes.select { |candidate| candidate["receiver"] == WATCHDOG_RECEIVER }
+fail_closed("there must be exactly one watchdog route") unless watchdog_routes.length == 1
+watchdog_route = watchdog_routes.first
+fail_closed("watchdog route must be the second direct child of the null root") unless
+  root_children == [synthetic_route, watchdog_route]
+fail_closed("watchdog route matchers are not the exact allowlist") unless
+  watchdog_route["matchers"].is_a?(Array) && watchdog_route["matchers"].sort == WATCHDOG_MATCHERS.sort
+expected_route_fields = {
+  "receiver" => WATCHDOG_RECEIVER, "matchers" => watchdog_route["matchers"],
+  "group_wait" => "30s", "group_interval" => "1m", "repeat_interval" => "5m",
+  "group_by" => %w[alertname cluster environment]
+}
+fail_closed("watchdog grouping, timing, continuation, or nesting changed") unless watchdog_route == expected_route_fields
+known_receivers = ["null", PAGERDUTY_RECEIVER, WATCHDOG_RECEIVER]
+fail_closed("route tree contains an unexpected or broad receiver") unless all_routes.all? { |candidate| known_receivers.include?(candidate["receiver"]) }
+
+warn "Alertmanager PagerDuty and watchdog structure verified (credential values not accessed)."

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -61,20 +61,23 @@ def test_chart_version_and_values_match_live_staging_baseline():
     assert pvc["resources"]["requests"]["storage"] == "20Gi"
     assert staging["prometheus"]["prometheusSpec"]["externalLabels"] == {"cluster": "sugarkube-int"}
     alertmanager = staging["alertmanager"]
-    assert alertmanager["alertmanagerSpec"]["secrets"] == ["alertmanager-pagerduty"]
+    assert alertmanager["alertmanagerSpec"]["secrets"] == [
+        "alertmanager-pagerduty", "alertmanager-healthchecks-watchdog"
+    ]
     route = alertmanager["config"]["route"]
     assert route["receiver"] == "null"
-    assert route["routes"] == [
-        {
-            "receiver": "pagerduty-synthetic-test",
-            "matchers": [
-                'alertname="SugarkubePagerDutyTest"',
-                'environment="staging"',
-                'cluster="sugarkube-int"',
-                'severity="critical"',
-            ],
-        }
+    assert [child["receiver"] for child in route["routes"]] == [
+        "pagerduty-synthetic-test", "healthchecks-watchdog"
     ]
+    rule = staging["additionalPrometheusRulesMap"]["sugarkube-observability-watchdog"]["groups"][0]
+    assert rule["interval"] == "1m"
+    alert = rule["rules"][0]
+    assert alert == {
+        "alert": "SugarkubeObservabilityWatchdog", "expr": "vector(1)",
+        "labels": {"environment": "staging", "cluster": "sugarkube-int", "purpose": "observability-watchdog"},
+        "annotations": {"summary": "Sugarkube staging observability watchdog", "runbook_url": "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-operations.md#observability-watchdog"},
+    }
+
     pagerduty_receiver = next(
         receiver
         for receiver in alertmanager["config"]["receivers"]
@@ -132,10 +135,8 @@ def rendered_alertmanager_fixture(
 ):
     path = path or "/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key"
     matchers = matchers or [
-        'alertname="SugarkubePagerDutyTest"',
-        'environment="staging"',
-        'cluster="sugarkube-int"',
-        'severity="critical"',
+        'alertname="SugarkubePagerDutyTest"', 'environment="staging"',
+        'cluster="sugarkube-int"', 'severity="critical"',
     ]
     inline_field = "\n            " + "routing_" + "key: forbidden-stub" if inline else ""
     matcher_yaml = "\n".join(f"            - '{matcher}'" for matcher in matchers)
@@ -145,7 +146,7 @@ kind: Alertmanager
 metadata:
   name: kube-prometheus-stack-alertmanager
 spec:
-  secrets: [{secret}]
+  secrets: [{secret}, alertmanager-healthchecks-watchdog]
 ---
 apiVersion: v1
 kind: Secret
@@ -159,22 +160,38 @@ stringData:
         - receiver: pagerduty-synthetic-test
           matchers:
 {matcher_yaml}
+        - receiver: healthchecks-watchdog
+          matchers:
+            - 'alertname="SugarkubeObservabilityWatchdog"'
+            - 'environment="staging"'
+            - 'cluster="sugarkube-int"'
+            - 'purpose="observability-watchdog"'
+          group_wait: 30s
+          group_interval: 1m
+          repeat_interval: 5m
+          group_by: [alertname, cluster, environment]
     receivers:
       - name: "null"
       - name: pagerduty-synthetic-test
         pagerduty_configs:
           - routing_key_file: {path}
             send_resolved: true{inline_field}
+      - name: healthchecks-watchdog
+        webhook_configs:
+          - url_file: /etc/alertmanager/secrets/alertmanager-healthchecks-watchdog/ping-url
+            send_resolved: false
+            max_alerts: 1
+            timeout: 10s
 """
 
 
 @pytest.mark.parametrize(
     ("kwargs", "diagnostic"),
     [
-        ({"secret": "wrong-secret"}, "must reference only"),
+        ({"secret": "wrong-secret"}, "exactly the two expected Secrets"),
         ({"path": "/wrong/path"}, "exact mounted routing-key file"),
         ({"matchers": ['severity="critical"']}, "exact synthetic allowlist"),
-        ({"inline": True}, "inline PagerDuty credentials are forbidden"),
+        ({"inline": True}, "inline credentials and webhook URLs are forbidden"),
     ],
 )
 def test_alertmanager_validator_rejects_missing_mount_wrong_path_inline_and_broad_route(
@@ -269,7 +286,7 @@ def test_alertmanager_validator_redacts_invalid_base64(tmp_path):
                 "    receivers:\n",
                 "    receivers:\n      - name: alternate\n        pagerduty_configs: []\n",
             ),
-            "exactly one PagerDuty receiver",
+            "exactly three receivers are required",
         ),
         (
             lambda text: text.replace(
@@ -297,7 +314,7 @@ def test_alertmanager_validator_redacts_invalid_base64(tmp_path):
                 "    receivers:",
                 "    routing_" + "key: forbidden-stub\n    receivers:",
             ),
-            "inline PagerDuty credentials are forbidden",
+            "inline credentials and webhook URLs are forbidden",
         ),
         (
             lambda text: text.replace(
@@ -308,7 +325,7 @@ def test_alertmanager_validator_redacts_invalid_base64(tmp_path):
                 "      routes:",
                 "      routes:\n        - receiver: alternate\n          matchers: ['severity=~\".*\"']",
             ),
-            "inline PagerDuty credentials are forbidden",
+            "inline credentials and webhook URLs are forbidden",
         ),
     ],
     ids=[
@@ -370,12 +387,12 @@ def test_install_upgrade_are_distinct_and_render_before_mutation():
     install = re.search(r"install_release\(\).*?\nupgrade_release\(", script, re.S).group(0)
     upgrade = re.search(r"upgrade_release\(\).*?\nstatus\(", script, re.S).group(0)
     assert "render_to" in install and "helm install" in install
-    assert install.index("assert_pagerduty_secret") < install.index("render_to")
+    assert install.index("assert_integration_secrets") < install.index("render_to")
     assert install.index("render_to") < install.index("helm install")
     assert 'state="$(release_state)"' in install
     assert "already exists" in install
     assert "render_to" in upgrade and "helm upgrade" in upgrade
-    assert upgrade.index("assert_pagerduty_secret") < upgrade.index("render_to")
+    assert upgrade.index("assert_integration_secrets") < upgrade.index("render_to")
     assert upgrade.index("render_to") < upgrade.index("helm upgrade")
     assert 'state="$(release_state)"' in upgrade
     assert "requires an existing Helm release" in upgrade
@@ -496,7 +513,7 @@ case "$*" in
     printf '%s\n' 'apiVersion: v1' 'kind: ConfigMap' 'metadata:' '  name: kube-prometheus-stack-grafana-dashboards-sugarkube' '  labels:' '    dashboard-provider: sugarkube' 'data:' '  sugarkube-staging-observability.json:' '    |-'
     sed 's/^/      /' "$DASHBOARD"
     printf '%s\n' '---' 'kind: ConfigMap' 'data:' '  dashboardproviders.yaml: |' '    providers:' '      - name: sugarkube' '        options:' '          path: /var/lib/grafana/dashboards/sugarkube' '---' 'kind: Deployment' 'spec:' '  template:' '    spec:' '      containers:' '        - volumeMounts:' '            - name: dashboards-sugarkube' '              mountPath: /var/lib/grafana/dashboards/sugarkube/sugarkube-staging-observability.json' '              subPath: sugarkube-staging-observability.json'
-    printf '%s\n' '---' 'apiVersion: monitoring.coreos.com/v1' 'kind: Alertmanager' 'metadata:' '  name: kube-prometheus-stack-alertmanager' 'spec:' '  secrets:' '    - alertmanager-pagerduty'
+    printf '%s\n' '---' 'apiVersion: monitoring.coreos.com/v1' 'kind: Alertmanager' 'metadata:' '  name: kube-prometheus-stack-alertmanager' 'spec:' '  secrets:' '    - alertmanager-pagerduty' '    - alertmanager-healthchecks-watchdog'
     printf '%s\n' '---' 'apiVersion: v1' 'kind: Secret' 'metadata:' '  name: alertmanager-kube-prometheus-stack-alertmanager' 'stringData:' '  alertmanager.yaml: |'
     sed 's/^/    /' "$ALERTMANAGER_CONFIG"
     exit 0
@@ -516,13 +533,14 @@ case "$*" in
   *"get daemonset kube-prometheus-stack-prometheus-node-exporter"*) [ "$KUBECTL_MODE" = two-nodes ] && echo '2 2' || echo '3 3' ;;
   *"get pvc -o json"*) printf '%s\n' '{"items":[{"metadata":{"name":"generated-pvc","labels":{"app.kubernetes.io/name":"prometheus"}},"spec":{"storageClassName":"local-path"},"status":{"phase":"Bound"}}]}' ;;
   *"get prometheus kube-prometheus-stack-prometheus"*) echo 1 ;;
-  *"get alertmanager kube-prometheus-stack-alertmanager -o yaml"*) printf '%s\n' 'apiVersion: monitoring.coreos.com/v1' 'kind: Alertmanager' 'metadata:' '  name: kube-prometheus-stack-alertmanager' 'spec:' '  secrets:' '    - alertmanager-pagerduty' ;;
+  *"get alertmanager kube-prometheus-stack-alertmanager -o yaml"*) printf '%s\n' 'apiVersion: monitoring.coreos.com/v1' 'kind: Alertmanager' 'metadata:' '  name: kube-prometheus-stack-alertmanager' 'spec:' '  secrets:' '    - alertmanager-pagerduty' '    - alertmanager-healthchecks-watchdog' ;;
   *"get alertmanager kube-prometheus-stack-alertmanager"*) echo 1 ;;
   *"get secret alertmanager-kube-prometheus-stack-alertmanager -o yaml"*)
     printf '%s\n' 'apiVersion: v1' 'kind: Secret' 'metadata:' '  name: alertmanager-kube-prometheus-stack-alertmanager' 'stringData:' '  alertmanager.yaml: |'
     [ "$KUBECTL_MODE" != malformed-alertmanager ] && sed 's/^/    /' "$ALERTMANAGER_CONFIG" || printf '%s\n' '    route: [unterminated'
     ;;
   *"get secret alertmanager-pagerduty -o go-template="*) [ "$KUBECTL_MODE" != missing-pagerduty ] || exit 44; [ "$KUBECTL_MODE" != empty-pagerduty ] && echo present ;;
+  *"get secret alertmanager-healthchecks-watchdog -o go-template="*) [ "$KUBECTL_MODE" != missing-watchdog ] || exit 44; [ "$KUBECTL_MODE" != empty-watchdog ] && echo present ;;
   *"port-forward"*"service/kube-prometheus-stack-alertmanager"*":9093"*)
     [ "$PAGERDUTY_MODE" != forward-exit ] || { echo PORT_FORWARD_SENTINEL; exit 42; }
     echo "$PAGERDUTY_FORWARD_LINE"
@@ -619,12 +637,28 @@ printf '%s' "$code"
         - environment="staging"
         - cluster="sugarkube-int"
         - severity="critical"
+    - receiver: healthchecks-watchdog
+      matchers:
+        - alertname="SugarkubeObservabilityWatchdog"
+        - environment="staging"
+        - cluster="sugarkube-int"
+        - purpose="observability-watchdog"
+      group_wait: 30s
+      group_interval: 1m
+      repeat_interval: 5m
+      group_by: [alertname, cluster, environment]
 receivers:
   - name: "null"
   - name: pagerduty-synthetic-test
     pagerduty_configs:
       - routing_key_file: /etc/alertmanager/secrets/alertmanager-pagerduty/routing-key
         send_resolved: true
+  - name: healthchecks-watchdog
+    webhook_configs:
+      - url_file: /etc/alertmanager/secrets/alertmanager-healthchecks-watchdog/ping-url
+        send_resolved: false
+        max_alerts: 1
+        timeout: 10s
 """,
         encoding="utf-8",
     )

--- a/tests/test_observability_watchdog.py
+++ b/tests/test_observability_watchdog.py
@@ -1,0 +1,65 @@
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALUES = ROOT / "clusters/staging/observability/kube-prometheus-stack.values.yaml"
+SCRIPT = ROOT / "scripts/observability_watchdog.sh"
+JUSTFILE = ROOT / "justfile"
+DOCS = ROOT / "docs/observability-operations.md"
+
+
+def yaml_load(path):
+    result = subprocess.run(["ruby", "-ryaml", "-rjson", "-e", "puts JSON.generate(YAML.safe_load_file(ARGV[0], aliases: false))", str(path)], check=True, text=True, capture_output=True)
+    return json.loads(result.stdout)
+
+
+def test_exact_rule_and_healthchecks_contract():
+    values = yaml_load(VALUES)
+    group = values["additionalPrometheusRulesMap"]["sugarkube-observability-watchdog"]["groups"][0]
+    assert group["interval"] == "1m"
+    assert group["rules"] == [{
+        "alert": "SugarkubeObservabilityWatchdog", "expr": "vector(1)",
+        "labels": {"environment": "staging", "cluster": "sugarkube-int", "purpose": "observability-watchdog"},
+        "annotations": {"summary": "Sugarkube staging observability watchdog", "runbook_url": "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-operations.md#observability-watchdog"},
+    }]
+    alertmanager = values["alertmanager"]
+    assert alertmanager["alertmanagerSpec"]["secrets"] == ["alertmanager-pagerduty", "alertmanager-healthchecks-watchdog"]
+    assert [route["receiver"] for route in alertmanager["config"]["route"]["routes"]] == ["pagerduty-synthetic-test", "healthchecks-watchdog"]
+    watchdog = alertmanager["config"]["route"]["routes"][1]
+    assert watchdog == {
+        "receiver": "healthchecks-watchdog",
+        "matchers": ['alertname="SugarkubeObservabilityWatchdog"', 'environment="staging"', 'cluster="sugarkube-int"', 'purpose="observability-watchdog"'],
+        "group_wait": "30s", "group_interval": "1m", "repeat_interval": "5m",
+        "group_by": ["alertname", "cluster", "environment"],
+    }
+    webhook = alertmanager["config"]["receivers"][2]["webhook_configs"][0]
+    assert webhook == {"url_file": "/etc/alertmanager/secrets/alertmanager-healthchecks-watchdog/ping-url", "send_resolved": False, "max_alerts": 1, "timeout": "10s"}
+    assert "url" not in webhook
+
+
+def test_hidden_installer_and_exact_bounded_drill_contract():
+    script = SCRIPT.read_text()
+    assert 'exec 3<"$TTY"' in script and "read -r -s value <&3" in script
+    assert '--from-file="$KEY=/dev/stdin"' in script and "kubectl apply -f -" in script
+    assert "credentials in command arguments are refused" in script
+    assert "PING_URL" in script and "environment variables are refused" in script
+    assert "timedelta(minutes=8)" in script
+    payload = re.search(r'want=\{([^\n]+)\}', script).group(1)
+    for label in ("alertname", "environment", "cluster", "purpose"):
+        assert f'"{label}"' in payload
+    assert "shutdown" not in script.lower()
+    assert "hc-ping.com" not in script.split("validate", 1)[-1] or "curl" in script
+
+
+def test_documented_staging_recipes_and_five_minute_timing():
+    justfile = JUSTFILE.read_text()
+    docs = DOCS.read_text()
+    for recipe in ("install", "secret-check", "verify", "drill-create", "drill-status", "drill-clear"):
+        assert f"observability-watchdog-{recipe}" in justfile
+    assert "just observability-watchdog-install env=staging" in docs
+    assert "five-minute period" in docs and "two-minute grace" in docs
+    assert "eight-minute expiry" in docs
+    assert "pause the Healthchecks check" in docs


### PR DESCRIPTION
### Motivation

- Implement a staging-only dead-man watchdog that proves the end-to-end observability path (Prometheus → Alertmanager → external Healthchecks) without changing production routing. Refs #2403.
- Provide a secret-safe operator flow and guarded Helm mutation so credentials are never in args, files, or rendered manifests.

### Description

- Add an always-firing Prometheus rule `SugarkubeObservabilityWatchdog` (expr `vector(1)`, 1m interval, fixed labels `environment=staging`, `cluster=sugarkube-int`, `purpose=observability-watchdog`) via `clusters/staging/observability/kube-prometheus-stack.values.yaml` and a runbook link to `docs/observability-operations.md`.
- Add a Secret-backed Alertmanager webhook receiver `healthchecks-watchdog` and mount contract `alertmanager-healthchecks-watchdog:ping-url`, plus a direct-child route under the `null` root with exact matchers and the requested grouping/timing (30s wait, 1m group, 5m repeat, group_by alertname/cluster/environment) in `clusters/staging/observability/kube-prometheus-stack.values.yaml` while preserving the synthetic PagerDuty route/receiver unchanged.
- Extend the Alertmanager validator `scripts/verify_observability_alertmanager.rb` to require exactly the two Secrets, to forbid inline credentials/URLs, and to validate the exact PagerDuty and watchdog receiver/route/fields and ordering.
- Add `scripts/observability_watchdog.sh` providing TTY-hidden Secret install/rotate, contract check, live verification, and a safe, owned drill silence (8-minute expiry) with guarded manual checkpoint and sanitized outputs; add `just` recipes and docs updates (`docs/observability-operations.md`, `docs/observability-alerting.md`, `docs/observability-design.md`) describing install/verify/drill and page-safety rollback guidance.

### Testing

- `bash -n scripts/observability_helm.sh scripts/observability_watchdog.sh` — syntax OK.
- `ruby -c scripts/verify_observability_alertmanager.rb` — syntax OK.
- `python3 -m pytest -q tests/test_observability_watchdog.py` — 3 passed locally.
- Executed focused observability Helm tests (`tests/test_observability_helm.py`) and iteratively adjusted test fixtures and assertions to reflect the two-integration contract and route ordering; observability-focused tests passed in this environment after updates, but a full render/install end-to-end (`just observability-render` / Helm mutation) could not be executed because `helm` is not available in the development environment and the helper port-forward harness can interfere with unattended runs.
- Repository checks: `git diff --cached | ./scripts/scan-secrets.py` and `git diff --cached --check` were run; `bash scripts/checks.sh` reached the repo-wide lint gate and reported pre-existing unrelated lint failures (tooling such as `pre-commit`, `pyspelling`, and `linkchecker` were unavailable in this environment).

Post-merge staging checklist

- Run `just kubeconfig-env env=staging` and confirm `sugar-staging` context.
- Install/rotate the real watchdog ping URL via `just observability-watchdog-install env=staging` (hidden TTY input).
- Confirm `just observability-watchdog-secret-check env=staging` reports the contract present.
- Render then upgrade with `just observability-render env=staging >/dev/null` and `just observability-upgrade env=staging` (Helm) and then run `just observability-watchdog-verify env=staging`.
- Manually confirm Healthchecks last-ping advances and that Healthchecks is configured for a five-minute period + two-minute grace, then perform the controlled drill (`SUGARKUBE_WATCHDOG_DRILL_CONFIRM=confirmed just observability-watchdog-drill-create env=staging`) and verify PagerDuty transitions and recovery by hand.

Residual notes and limits: no real ping URL, PagerDuty key, cluster mutation, or live drill was performed in CI; some verification steps require `helm`, network, or a live staging cluster and must be executed from operator workstations as documented above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c20d4110c832f96dbb4e13ded245a)