### PR TITLE
Prepare controlled DSPACE reconciliation: split-provenance schema, coords, tests, and runbook

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -165,6 +165,134 @@ If the chart changed, bump the chart version in the DSPACE app repo and publish 
 gh workflow run ci-helm.yml --repo democratizedspace/dspace --ref main
 ```
 
+## Production 3.0.2 chart reconciliation (Refs #2325)
+
+This section **prepares** the first reconciliation; it does not authorize or execute it and does
+not lift the production Helm freeze. The immutable input is
+`docs/apps/dspace.recovery-3.0.2.coordinates.json`. Its schema-version-2
+`sourceRevision` identifies application/image `3.0.1`, while `chartSourceRevision` identifies the
+independently built recovery chart `3.0.2`. The `semanticTag` is corroborating metadata only;
+never deploy or republish `v3.0.1`. The downloaded archive checksum is not an OCI manifest digest.
+
+### 1. Repository preparation and operator approval
+
+Start from a reviewed commit, install `oras`, `helm`, `kubectl`, and `jq`, and set distinct
+kubeconfigs plus an executable remote smoke runner. Do not put credentials in these variables.
+Before supplying approval metadata, inspect the immutable application contract at source revision
+`1a31a569aff2dbeb238e8c2688b9e85140d2077d`. Application `3.0.1` must be OpenAI-first; stop if its
+documented/configured default contradicts `openai`.
+
+```bash
+export COORDINATES=docs/apps/dspace.recovery-3.0.2.coordinates.json
+export STAGING_KUBECONFIG=/absolute/path/to/staging.kubeconfig
+export PROD_KUBECONFIG=/absolute/path/to/prod.kubeconfig
+export DSPACE_SMOKE_RUNNER=/absolute/path/to/executable-dspace-chat-smoke
+test "$STAGING_KUBECONFIG" != "$PROD_KUBECONFIG"
+test -r "$STAGING_KUBECONFIG" && test -r "$PROD_KUBECONFIG"
+test -x "$DSPACE_SMOKE_RUNNER"
+
+# Operator-supplied values; use the real approval record, never these placeholders.
+export STAGING_APPROVED_AT='<YYYY-MM-DDTHH:MM:SSZ>' STAGING_APPROVED_BY='<identity-or-record>'
+export PROD_APPROVED_AT='<YYYY-MM-DDTHH:MM:SSZ>' PROD_APPROVED_BY='<identity-or-record>'
+mkdir -p deployment-candidates/dspace
+python3 scripts/dspace_release_manifest.py candidate --upstream "$COORDINATES" \
+  --output deployment-candidates/dspace/recovery-3.0.2-staging.json \
+  --environment staging --provider openai \
+  --approved-at "$STAGING_APPROVED_AT" --approved-by "$STAGING_APPROVED_BY"
+python3 scripts/dspace_release_manifest.py candidate --upstream "$COORDINATES" \
+  --output deployment-candidates/dspace/recovery-3.0.2-prod.json \
+  --environment prod --provider openai \
+  --approved-at "$PROD_APPROVED_AT" --approved-by "$PROD_APPROVED_BY"
+```
+
+### 2. Staging proof for the exact recovery pair
+
+Preflight resolves both OCI descriptors and independently checks image and chart revision
+annotations. Render validation happens inside the guarded recipe before evidence reservation.
+
+```bash
+STAGING_CANDIDATE=deployment-candidates/dspace/recovery-3.0.2-staging.json
+PROD_CANDIDATE=deployment-candidates/dspace/recovery-3.0.2-prod.json
+python3 scripts/dspace_release_manifest.py preflight --manifest "$STAGING_CANDIDATE" \
+  --environment staging --image-tag main-1a31a56 --chart-version 3.0.2
+just app-deploy app=dspace env=staging tag=main-1a31a56 manifest="$STAGING_CANDIDATE" \
+  smoke_runner="$DSPACE_SMOKE_RUNNER" kubeconfig="$STAGING_KUBECONFIG"
+export STAGING_EVIDENCE="$(python3 scripts/dspace_release_manifest.py evidence-path \
+  --manifest "$STAGING_CANDIDATE")"
+python3 scripts/dspace_release_manifest.py validate --manifest "$STAGING_EVIDENCE" --final
+python3 scripts/dspace_release_manifest.py staging-gate --manifest "$PROD_CANDIDATE" \
+  --staging-evidence "$STAGING_EVIDENCE"
+```
+
+The finalized staging record must cover application `3.0.1`, image tag/digest, chart
+version/digest, both source revisions, runtime/frontend application revision, OpenAI provider, and
+the remote `/chat` journey. A staging record is never production evidence.
+
+### 3. Read-only production capture and guarded mutation
+
+Create a timestamped operator evidence directory outside the repository. The following bounded
+capture records identities, not Secret bodies. Review `helm get values` locally and redact any
+unexpected literal secret before preserving it; legitimate `secretKeyRef` names may remain.
+
+```bash
+export CAPTURE="operator-evidence/dspace-reconcile-$(date -u +%Y%m%dT%H%M%SZ)"
+install -d -m 0700 "$CAPTURE"
+helm --kubeconfig "$PROD_KUBECONFIG" history dspace -n dspace -o json --max 10 >"$CAPTURE/helm-history.json"
+helm --kubeconfig "$PROD_KUBECONFIG" status dspace -n dspace -o json >"$CAPTURE/helm-status.json"
+kubectl --kubeconfig "$PROD_KUBECONFIG" -n dspace get deployment dspace \
+  -o jsonpath='{.metadata.uid}{"\n"}{.spec.template.spec.containers[?(@.name=="dspace")].image}{"\n"}' \
+  >"$CAPTURE/deployment-identity.txt"
+kubectl --kubeconfig "$PROD_KUBECONFIG" -n dspace get pods \
+  -l app.kubernetes.io/name=dspace,app.kubernetes.io/instance=dspace \
+  -o custom-columns=NAME:.metadata.name,UID:.metadata.uid,START:.status.startTime,IMAGE_ID:.status.containerStatuses[0].imageID \
+  >"$CAPTURE/pods.txt"
+just dspace-release-verify prod "$PROD_CANDIDATE" "$DSPACE_SMOKE_RUNNER" \
+  kubeconfig="$PROD_KUBECONFIG" >"$CAPTURE/prechange-runtime.json" || true
+python3 scripts/dspace_release_manifest.py preflight --manifest "$PROD_CANDIDATE" \
+  --environment prod --image-tag main-1a31a56 --chart-version 3.0.2
+
+# Maintenance approval is a separate human gate. Only then run the guarded recipe; never use raw
+# helm upgrade, helm rollback, --reuse-values, or kubectl apply.
+just app-promote-prod app=dspace tag=main-1a31a56 manifest="$PROD_CANDIDATE" \
+  staging_evidence="$STAGING_EVIDENCE" smoke_runner="$DSPACE_SMOKE_RUNNER" \
+  kubeconfig="$PROD_KUBECONFIG" staging_kubeconfig="$STAGING_KUBECONFIG"
+export PROD_EVIDENCE="$(python3 scripts/dspace_release_manifest.py evidence-path \
+  --manifest "$PROD_CANDIDATE")"
+python3 scripts/dspace_release_manifest.py validate --manifest "$PROD_EVIDENCE" --final
+just dspace-release-verify prod "$PROD_EVIDENCE" "$DSPACE_SMOKE_RUNNER" \
+  kubeconfig="$PROD_KUBECONFIG" >"$CAPTURE/postchange-runtime.json"
+```
+
+Review the finalized evidence and bounded capture together. Helm stored values, the installed
+chart, Deployment, every serving pod, resolved image digest, application/runtime/frontend
+revision, chart provenance, public/direct identity, health paths, configuration, provider, and
+`/chat` must agree. Keep all timestamped evidence. Lift the freeze only after the production final
+record exists, every check passed, and the operator approval/review is recorded; otherwise keep it.
+
+### 4. Failure reconciliation and initial rollback
+
+On a post-reservation failure, preserve the bounded failed evidence and capture current Helm/pod
+identity before doing anything else. Do not fabricate a final record for revision 8 and do not use
+its obsolete values. For this first reconciliation, the only immutable recovery target available
+is the newly finalized **production** record created above. If it exists and is independently
+reviewed, reconcile back to it with the general digest-qualified rollback primitive and explicit
+production confirmation:
+
+```bash
+test -f "$PROD_EVIDENCE"
+python3 scripts/dspace_release_manifest.py validate --manifest "$PROD_EVIDENCE" --final
+just dspace-manifest-rollback env=prod manifest="$PROD_EVIDENCE" \
+  evidence="$CAPTURE/rollback-$(date -u +%Y%m%dT%H%M%SZ).json" \
+  verifier=scripts/dspace_runtime_verifier.py smoke_runner="$DSPACE_SMOKE_RUNNER" \
+  kubeconfig="$PROD_KUBECONFIG" \
+  confirm='dspace:prod:1a31a569aff2dbeb238e8c2688b9e85140d2077d'
+```
+
+If no finalized production record exists, stop and reconcile manually under the freeze: there is
+no truthful automated rollback target. Never substitute staging evidence, semantic `v3.0.1`, a
+mutable tag, `helm rollback <revision>`, or `--reuse-values`. A failed rollback also stops for
+review; do not chain another mutation.
+
 ## Deploy staging
 
 ### Release-manifest approval and evidence flow

--- a/docs/apps/dspace.prod.version
+++ b/docs/apps/dspace.prod.version
@@ -1,2 +1,2 @@
 # DSPACE production chart pin. Keep aligned with the recovered production deployment.
-3.0.1
+3.0.2

--- a/docs/apps/dspace.recovery-3.0.2.coordinates.json
+++ b/docs/apps/dspace.recovery-3.0.2.coordinates.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 2,
+  "app": "dspace",
+  "applicationVersion": "3.0.1",
+  "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+  "chartSourceRevision": "63063e287adb92a4158ce2c8e7d378b73f52c1c5",
+  "imageTag": "main-1a31a56",
+  "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
+  "chartVersion": "3.0.2",
+  "chartDigest": "sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575",
+  "semanticTag": "v3.0.1"
+}

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -627,16 +627,22 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         "startedAt": started,
         "sugarkubeRevision": sugarkube_revision,
         "target": {
-            key: target[key]
+            key: (
+                release.chart_source_revision(target)
+                if key == "chartSourceRevision"
+                else target[key]
+            )
             for key in (
                 "chartVersion",
                 "chartDigest",
                 "imageTag",
                 "imageDigest",
                 "sourceRevision",
+                "chartSourceRevision",
                 "applicationVersion",
                 "expectedDefaultChatProvider",
             )
+            if key in target or key == "chartSourceRevision"
         },
         "values": values_proof,
         "before": {

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -17,7 +17,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-UPSTREAM_FIELDS = (
+UPSTREAM_FIELDS_V1 = (
     "schemaVersion",
     "app",
     "applicationVersion",
@@ -28,20 +28,25 @@ UPSTREAM_FIELDS = (
     "chartDigest",
     "semanticTag",
 )
-CANDIDATE_FIELDS = UPSTREAM_FIELDS + (
+UPSTREAM_FIELDS_V2 = UPSTREAM_FIELDS_V1[:4] + ("chartSourceRevision",) + UPSTREAM_FIELDS_V1[4:]
+# Kept as aliases for callers constructing legacy records.
+UPSTREAM_FIELDS = UPSTREAM_FIELDS_V1
+CANDIDATE_SUFFIX = (
     "recordType",
     "environment",
     "expectedDefaultChatProvider",
     "approvedAt",
     "approvedBy",
 )
-FINAL_FIELDS = CANDIDATE_FIELDS + (
+CANDIDATE_FIELDS = UPSTREAM_FIELDS_V1 + CANDIDATE_SUFFIX
+FINAL_SUFFIX = (
     "helmRevision",
     "pods",
     "runtimeSourceRevision",
     "runtimeSourceRevisionMethod",
     "verificationResults",
 )
+FINAL_FIELDS = CANDIDATE_FIELDS + FINAL_SUFFIX
 OPTIONAL_FINAL_FIELDS = ("runtimeVerification",)
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
@@ -121,9 +126,21 @@ def _exact_fields(value: dict[str, Any], expected: tuple[str, ...]) -> None:
         raise ManifestError("; ".join(parts))
 
 
+def _upstream_fields(value: dict[str, Any]) -> tuple[str, ...]:
+    version = value.get("schemaVersion")
+    if type(version) is not int or version not in {1, 2}:
+        raise ManifestError("schemaVersion must be integer 1 or 2")
+    return UPSTREAM_FIELDS_V1 if version == 1 else UPSTREAM_FIELDS_V2
+
+
+def chart_source_revision(value: dict[str, Any]) -> str:
+    """Return explicit v2 chart provenance or the implicit v1 same-source value."""
+    return value["sourceRevision"] if value["schemaVersion"] == 1 else value["chartSourceRevision"]
+
+
 def _validate_upstream(value: dict[str, Any]) -> None:
-    if value["schemaVersion"] != 1 or value["app"] != "dspace":
-        raise ManifestError("schemaVersion must be 1 and app must be 'dspace'")
+    if value["app"] != "dspace":
+        raise ManifestError("app must be 'dspace'")
     if not isinstance(value["applicationVersion"], str) or not SEMVER_RE.fullmatch(
         value["applicationVersion"]
     ):
@@ -131,6 +148,9 @@ def _validate_upstream(value: dict[str, Any]) -> None:
     sha = value["sourceRevision"]
     if not isinstance(sha, str) or not SHA_RE.fullmatch(sha):
         raise ManifestError("sourceRevision must be a full 40-character lowercase Git SHA")
+    chart_sha = chart_source_revision(value)
+    if not isinstance(chart_sha, str) or not SHA_RE.fullmatch(chart_sha):
+        raise ManifestError("chartSourceRevision must be a full 40-character lowercase Git SHA")
     tag = value["imageTag"]
     match = IMAGE_TAG_RE.fullmatch(tag) if isinstance(tag, str) else None
     if not match:
@@ -153,7 +173,10 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
     record_type = value.get("recordType")
     if finalized is None:
         finalized = record_type == "final"
-    expected = FINAL_FIELDS if finalized else CANDIDATE_FIELDS
+    upstream_fields = _upstream_fields(value)
+    expected = upstream_fields + (
+        CANDIDATE_SUFFIX + FINAL_SUFFIX if finalized else CANDIDATE_SUFFIX
+    )
     if finalized and "runtimeVerification" in value:
         expected += OPTIONAL_FINAL_FIELDS
     _exact_fields(value, expected)
@@ -279,9 +302,7 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
         elif checks & RUNTIME_VERIFICATION_CHECKS:
             raise ManifestError("runtime verification results require runtimeVerification proof")
         if sorted(platform_indices) != list(range(len(platform_indices))):
-            raise ManifestError(
-                "image platform verification indices must be contiguous from zero"
-            )
+            raise ManifestError("image platform verification indices must be contiguous from zero")
         if not platform_indices:
             raise ManifestError("at least one image platform verification result is required")
     return value
@@ -302,9 +323,7 @@ def _write_new(path: Path, value: dict[str, Any]) -> None:
         try:
             os.link(temporary, path)
         except FileExistsError as exc:
-            raise ManifestError(
-                f"refusing to overwrite existing record: {path}"
-            ) from exc
+            raise ManifestError(f"refusing to overwrite existing record: {path}") from exc
         _sync_directory(path.parent)
     finally:
         Path(temporary).unlink(missing_ok=True)
@@ -357,9 +376,7 @@ def reserve(
     try:
         fd = os.open(sidecar, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     except FileExistsError as exc:
-        raise ManifestError(
-            f"evidence destination is already reserved: {sidecar}"
-        ) from exc
+        raise ManifestError(f"evidence destination is already reserved: {sidecar}") from exc
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as stream:
             stream.write(_canonical(metadata))
@@ -395,9 +412,7 @@ def verify_reservation(
     if not secrets.compare_digest(
         json.dumps(metadata, sort_keys=True), json.dumps(expected, sort_keys=True)
     ):
-        raise ManifestError(
-            "reservation ownership or deployment coordinates do not match"
-        )
+        raise ManifestError("reservation ownership or deployment coordinates do not match")
     if normalized.exists():
         raise ManifestError(f"refusing to overwrite existing record: {normalized}")
     return sidecar
@@ -410,9 +425,10 @@ def candidate(
     approved_at: str,
     approved_by: str,
 ) -> dict[str, Any]:
-    _exact_fields(upstream, UPSTREAM_FIELDS)
+    upstream_fields = _upstream_fields(upstream)
+    _exact_fields(upstream, upstream_fields)
     _validate_upstream(upstream)
-    result = {field: upstream[field] for field in UPSTREAM_FIELDS}
+    result = {field: upstream[field] for field in upstream_fields}
     result.update(
         recordType="candidate",
         environment=environment,
@@ -536,7 +552,7 @@ def preflight(
     checks = (
         ("imageDigest", image_digest, value["imageDigest"]),
         ("chartDigest", chart_digest, value["chartDigest"]),
-        ("chartSourceRevision", chart_revision, value["sourceRevision"]),
+        ("chartSourceRevision", chart_revision, chart_source_revision(value)),
     )
     results = [
         {
@@ -757,8 +773,7 @@ def finalize(
             # Helm metadata proves name/version, not immutable OCI content. The
             # guarded mutation therefore installs this approved digest directly.
             "details": (
-                f"chart=dspace; version={chart_version}; "
-                f"coordinate={chart_coordinate(value)}"
+                f"chart=dspace; version={chart_version}; " f"coordinate={chart_coordinate(value)}"
             ),
         },
         {
@@ -812,6 +827,7 @@ def staging_gate(candidate_value: dict[str, Any], evidence_value: dict[str, Any]
     coordinates = (
         "applicationVersion",
         "sourceRevision",
+        "chartSourceRevision",
         "imageTag",
         "imageDigest",
         "chartVersion",
@@ -819,7 +835,19 @@ def staging_gate(candidate_value: dict[str, Any], evidence_value: dict[str, Any]
         "semanticTag",
         "expectedDefaultChatProvider",
     )
-    if any(candidate_value[field] != evidence_value[field] for field in coordinates):
+    if any(
+        (
+            chart_source_revision(candidate_value)
+            if field == "chartSourceRevision"
+            else candidate_value[field]
+        )
+        != (
+            chart_source_revision(evidence_value)
+            if field == "chartSourceRevision"
+            else evidence_value[field]
+        )
+        for field in coordinates
+    ):
         raise ManifestError("manifest/evidence mismatch: staging and prod coordinates differ")
     if "runtimeVerification" not in evidence_value:
         raise ManifestError("staging evidence lacks mandatory runtime verification")
@@ -860,9 +888,7 @@ def main(argv: list[str] | None = None) -> int:
     finish.add_argument("--image-ref", default=IMAGE_REF)
     finish.add_argument("--chart-ref", default=CHART_REF)
     finish.add_argument("--reservation", required=True)
-    finish.add_argument(
-        "--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras")
-    )
+    finish.add_argument("--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
     finish.add_argument("--runtime-verification", type=Path)
     gate = sub.add_parser("staging-gate")
     gate.add_argument("--manifest", type=Path, required=True)
@@ -1021,10 +1047,9 @@ def main(argv: list[str] | None = None) -> int:
                     metadata.get("version"),
                 )
 
-            if (
-                binding_fields(settled_helm) != binding_fields(helm)
-                or binding_fields(stable_helm) != binding_fields(helm)
-            ):
+            if binding_fields(settled_helm) != binding_fields(helm) or binding_fields(
+                stable_helm
+            ) != binding_fields(helm):
                 raise ManifestError("Helm release changed during evidence collection")
             _write_new(args.output, result)
             sidecar.unlink()
@@ -1033,9 +1058,7 @@ def main(argv: list[str] | None = None) -> int:
             print(staging_gate(_object(args.manifest), _object(args.staging_evidence)))
         elif args.command == "check-output":
             if args.output.exists():
-                raise ManifestError(
-                    f"refusing to overwrite existing record: {args.output}"
-                )
+                raise ManifestError(f"refusing to overwrite existing record: {args.output}")
         elif args.command == "reserve":
             sys.stdout.write(
                 reserve(

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -105,7 +105,7 @@ def test_dspace_chart_pins_resolve_staging_and_prod_versions() -> None:
     prod = load_config("dspace", "prod")
 
     assert _first_pin_value(REPO_ROOT / staging["SUGARKUBE_VERSION_FILE"]) == "3.1.0"
-    assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.1"
+    assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.2"
 
 
 def test_dspace_staging_values_enable_authenticated_metrics_servicemonitor() -> None:

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -12,6 +12,7 @@ from scripts import dspace_manifest_rollback as rollback
 from scripts import dspace_release_manifest as manifest
 
 SHA = "abcdef0123456789abcdef0123456789abcdef01"
+CHART_SHA = "1234567890abcdef1234567890abcdef12345678"
 DIGEST = "sha256:" + "1" * 64
 
 
@@ -48,6 +49,15 @@ def target(environment: str = "staging") -> dict[str, object]:
         {"check": check, "passed": True, "details": "observed"} for check in checks
     ]
     return manifest.validate(value, True)
+
+
+def test_schema_v2_split_provenance_is_valid_for_rollback_and_evidence_target() -> None:
+    value = target()
+    value["schemaVersion"] = 2
+    value["chartSourceRevision"] = CHART_SHA
+    validated = manifest.validate(value, True)
+    assert validated["sourceRevision"] == SHA
+    assert manifest.chart_source_revision(validated) == CHART_SHA
 
 
 def verifier_result(**changes: object) -> dict[str, object]:

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -18,6 +18,8 @@ CHART_DIGEST = "sha256:" + "2" * 64
 PLATFORM_DIGEST = "sha256:" + "3" * 64
 IMAGE_CONFIG_DIGEST = "sha256:" + "4" * 64
 CHART_CONFIG_DIGEST = "sha256:" + "5" * 64
+CHART_SHA = "1234567890abcdef1234567890abcdef12345678"
+RECOVERY_COORDINATES = Path("docs/apps/dspace.recovery-3.0.2.coordinates.json")
 
 
 def upstream() -> dict[str, object]:
@@ -42,6 +44,64 @@ def candidate() -> dict[str, object]:
         "2026-07-26T12:00:00Z",
         "synthetic-test-approver",
     )
+
+
+def split_upstream() -> dict[str, object]:
+    value = upstream()
+    value["schemaVersion"] = 2
+    value["chartSourceRevision"] = CHART_SHA
+    return value
+
+
+def split_candidate(environment: str = "staging") -> dict[str, object]:
+    return manifest.candidate(
+        split_upstream(), environment, "token-place", "2026-07-26T12:00:00Z", "operator"
+    )
+
+
+def test_schema_v1_implicitly_preserves_same_source_chart_provenance() -> None:
+    assert manifest.chart_source_revision(candidate()) == SHA
+
+
+def test_version_controlled_recovery_coordinates_are_exact_and_machine_validated() -> None:
+    value = json.loads(RECOVERY_COORDINATES.read_text(encoding="utf-8"))
+    assert value == {
+        "schemaVersion": 2,
+        "app": "dspace",
+        "applicationVersion": "3.0.1",
+        "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+        "chartSourceRevision": "63063e287adb92a4158ce2c8e7d378b73f52c1c5",
+        "imageTag": "main-1a31a56",
+        "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
+        "chartVersion": "3.0.2",
+        "chartDigest": "sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575",
+        "semanticTag": "v3.0.1",
+    }
+    generated = manifest.candidate(value, "staging", "openai", "2026-07-31T12:00:00Z", "operator")
+    assert generated["chartSourceRevision"] != generated["sourceRevision"]
+
+
+def test_schema_v2_split_provenance_is_canonical_and_preserved() -> None:
+    value = split_candidate()
+    assert value["chartSourceRevision"] == CHART_SHA
+    assert list(value) == list(manifest.UPSTREAM_FIELDS_V2 + manifest.CANDIDATE_SUFFIX)
+    assert json.loads(manifest._canonical(value)) == value
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        lambda value: value.pop("chartSourceRevision"),
+        lambda value: value.update(chartSourceRevision="abc1234"),
+        lambda value: value.update(chartSourceRevision=CHART_SHA.upper()),
+        lambda value: value.update(schemaVersion=3),
+    ],
+)
+def test_schema_v2_rejects_missing_malformed_unknown_or_swapped_provenance(change) -> None:
+    value = split_upstream()
+    change(value)
+    with pytest.raises(manifest.ManifestError):
+        manifest.candidate(value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator")
 
 
 def test_upstream_import_is_canonical_and_round_trips(tmp_path: Path) -> None:
@@ -124,9 +184,12 @@ def test_accepts_strict_semver_prerelease_and_build(version: str) -> None:
     value = upstream()
     value["applicationVersion"] = version
     value["semanticTag"] = f"v{version}"
-    assert manifest.candidate(
-        value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator"
-    )["applicationVersion"] == version
+    assert (
+        manifest.candidate(value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator")[
+            "applicationVersion"
+        ]
+        == version
+    )
 
 
 @pytest.mark.parametrize(
@@ -200,6 +263,36 @@ def test_preflight_checks_exact_descriptors_and_digest_qualified_metadata() -> N
     assert runner.calls[0][-1].endswith(":main-abcdef0")
     assert runner.calls[1][-1] == f"{manifest.IMAGE_REF}@{DIGEST}"
     assert all(":main-abcdef0" not in call[-1] for call in runner.calls[1:])
+
+
+def test_split_preflight_checks_image_and_chart_against_independent_revisions() -> None:
+    results = manifest.preflight(
+        split_candidate(),
+        manifest.IMAGE_REF,
+        manifest.CHART_REF,
+        "oras",
+        runner=oras_runner(image_revision=SHA, chart_revision=CHART_SHA),
+    )
+    details = {item["check"]: item["details"] for item in results}
+    assert CHART_SHA in details["chartSourceRevision"]
+    assert SHA in details["imagePlatformSourceRevision[0]"]
+
+
+@pytest.mark.parametrize(
+    ("image_revision", "chart_revision"),
+    [(CHART_SHA, CHART_SHA), (SHA, SHA), (CHART_SHA, SHA)],
+)
+def test_split_preflight_rejects_collapsed_swapped_or_mismatched_revisions(
+    image_revision: str, chart_revision: str
+) -> None:
+    with pytest.raises(manifest.ManifestError, match="mismatch"):
+        manifest.preflight(
+            split_candidate(),
+            manifest.IMAGE_REF,
+            manifest.CHART_REF,
+            "oras",
+            runner=oras_runner(image_revision=image_revision, chart_revision=chart_revision),
+        )
 
 
 @pytest.mark.parametrize(
@@ -376,6 +469,23 @@ def test_finalize_collects_sorted_multi_pod_identity() -> None:
     }
 
 
+def test_schema_v2_split_provenance_survives_finalization() -> None:
+    value = split_candidate()
+    final = finalize(
+        value=value,
+        preflight_results=manifest.preflight(
+            value,
+            manifest.IMAGE_REF,
+            manifest.CHART_REF,
+            "oras",
+            runner=oras_runner(image_revision=SHA, chart_revision=CHART_SHA),
+        ),
+    )
+    assert final["chartSourceRevision"] == CHART_SHA
+    assert final["runtimeSourceRevision"] == SHA
+    assert manifest.validate(final, True) == final
+
+
 def test_finalize_optional_digest_coordinate_is_backward_compatible() -> None:
     assert finalize()["recordType"] == "final"
     coordinate = f"{manifest.IMAGE_REF}:main-abcdef0@{DIGEST}"
@@ -493,6 +603,26 @@ def test_staging_gate_returns_revision_despite_approval_metadata_difference() ->
     assert manifest.staging_gate(production, runtime_final()) == 17
 
 
+def test_staging_gate_preserves_and_compares_split_chart_provenance() -> None:
+    staging = split_candidate()
+    evidence = finalize(
+        value=staging,
+        preflight_results=manifest.preflight(
+            staging,
+            manifest.IMAGE_REF,
+            manifest.CHART_REF,
+            "oras",
+            runner=oras_runner(image_revision=SHA, chart_revision=CHART_SHA),
+        ),
+        runtime_verification=runtime_proof(),
+    )
+    production = split_candidate("prod")
+    assert manifest.staging_gate(production, evidence) == 17
+    production["chartSourceRevision"] = "0" * 40
+    with pytest.raises(manifest.ManifestError, match="coordinates differ"):
+        manifest.staging_gate(production, evidence)
+
+
 @pytest.mark.parametrize(
     "field",
     [
@@ -570,9 +700,7 @@ def test_final_validation_requires_every_fixed_check(missing: str) -> None:
 @pytest.mark.parametrize("invalid", ["unknown", "imagePlatformSourceRevision[x]"])
 def test_final_validation_rejects_unknown_or_malformed_checks(invalid: str) -> None:
     value = finalize()
-    value["verificationResults"].append(
-        {"check": invalid, "passed": True, "details": "fabricated"}
-    )
+    value["verificationResults"].append({"check": invalid, "passed": True, "details": "fabricated"})
     with pytest.raises(manifest.ManifestError, match="unknown verification"):
         manifest.validate(value, True)
 
@@ -740,9 +868,7 @@ def test_reservation_is_atomic_and_bound_to_owner(tmp_path: Path) -> None:
     )
     metadata = json.loads(sidecar.read_text(encoding="utf-8"))
     assert metadata["output"] == str(output.resolve())
-    assert metadata["candidateFingerprint"] == manifest._candidate_fingerprint(
-        candidate()
-    )
+    assert metadata["candidateFingerprint"] == manifest._candidate_fingerprint(candidate())
 
 
 def test_reservation_rejects_existing_record_or_reservation(tmp_path: Path) -> None:
@@ -776,9 +902,7 @@ def test_reservation_binds_candidate_output_and_coordinates(tmp_path: Path) -> N
             )
 
 
-def test_post_reservation_failure_preserves_ownership(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_post_reservation_failure_preserves_ownership(tmp_path: Path, monkeypatch) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
     source.write_text(manifest._canonical(candidate()), encoding="utf-8")
@@ -786,9 +910,7 @@ def test_post_reservation_failure_preserves_ownership(
     monkeypatch.setattr(
         manifest,
         "preflight",
-        lambda *args, **kwargs: (_ for _ in ()).throw(
-            manifest.ManifestError("OCI failed")
-        ),
+        lambda *args, **kwargs: (_ for _ in ()).throw(manifest.ManifestError("OCI failed")),
     )
     assert (
         manifest.main(
@@ -965,10 +1087,25 @@ def test_finalize_cli_settling_failure_preserves_reservation(
 
     monkeypatch.setattr(manifest, "_run", run)
     args = [
-        "finalize", "--manifest", str(source), "--output", str(output),
-        "--environment", "staging", "--image-tag", "main-abcdef0",
-        "--chart-version", "3.2.0", "--kubeconfig", "kubeconfig",
-        "--release", "dspace", "--namespace", "dspace", "--reservation", owner,
+        "finalize",
+        "--manifest",
+        str(source),
+        "--output",
+        str(output),
+        "--environment",
+        "staging",
+        "--image-tag",
+        "main-abcdef0",
+        "--chart-version",
+        "3.2.0",
+        "--kubeconfig",
+        "kubeconfig",
+        "--release",
+        "dspace",
+        "--namespace",
+        "dspace",
+        "--reservation",
+        owner,
     ]
     assert manifest.main(args) == 2
     assert not output.exists()
@@ -1010,25 +1147,36 @@ def test_finalize_cli_rejects_changed_helm_binding_and_preserves_reservation(
                     status["info"]["description"] = "another invocation"
             return json.dumps(status)
         resource = command[command.index("get") + 1]
-        return json.dumps(
-            {"items": [pod("dspace-a")]} if resource == "pods" else workloads()
-        )
+        return json.dumps({"items": [pod("dspace-a")]} if resource == "pods" else workloads())
 
     monkeypatch.setattr(manifest, "_run", run)
     args = [
-        "finalize", "--manifest", str(source), "--output", str(output),
-        "--environment", "staging", "--image-tag", "main-abcdef0",
-        "--chart-version", "3.2.0", "--kubeconfig", "kubeconfig",
-        "--release", "dspace", "--namespace", "dspace", "--reservation", owner,
+        "finalize",
+        "--manifest",
+        str(source),
+        "--output",
+        str(output),
+        "--environment",
+        "staging",
+        "--image-tag",
+        "main-abcdef0",
+        "--chart-version",
+        "3.2.0",
+        "--kubeconfig",
+        "kubeconfig",
+        "--release",
+        "dspace",
+        "--namespace",
+        "dspace",
+        "--reservation",
+        owner,
     ]
     assert manifest.main(args) == 2
     assert not output.exists()
     assert manifest.reservation_path(output).exists()
 
 
-def test_public_read_only_and_reservation_dispatch(
-    tmp_path: Path, monkeypatch, capsys
-) -> None:
+def test_public_read_only_and_reservation_dispatch(tmp_path: Path, monkeypatch, capsys) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
     source.write_text(manifest._canonical(candidate()), encoding="utf-8")
@@ -1039,9 +1187,7 @@ def test_public_read_only_and_reservation_dispatch(
         preflight_calls.append(args)
         return real_preflight(*args, **kwargs, runner=oras_runner())
 
-    oci_results = checked_preflight(
-        candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras"
-    )
+    oci_results = checked_preflight(candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras")
     preflight_calls.clear()
     monkeypatch.setattr(manifest, "preflight", checked_preflight)
 
@@ -1122,16 +1268,9 @@ def test_preflight_chart_coordinate_is_not_printed_after_failed_validation(
     monkeypatch.setattr(
         manifest,
         "preflight",
-        lambda *args, **kwargs: real_preflight(
-            *args, **kwargs, runner=oras_runner()
-        ),
+        lambda *args, **kwargs: real_preflight(*args, **kwargs, runner=oras_runner()),
     )
-    assert (
-        manifest.main(
-            ["preflight", "--manifest", str(source), "--print-chart-coordinate"]
-        )
-        == 2
-    )
+    assert manifest.main(["preflight", "--manifest", str(source), "--print-chart-coordinate"]) == 2
     captured = capsys.readouterr()
     assert captured.out == ""
     assert "chartDigest" in captured.err
@@ -1142,10 +1281,11 @@ def test_default_evidence_path_is_stable_and_approval_unique() -> None:
         "deployment-evidence/dspace/staging/main-abcdef0-20260726T120000Z.json"
     )
 
+
 @pytest.mark.parametrize(
     ("change", "message"),
     [
-        (lambda value: value.update(schemaVersion=2), "schemaVersion"),
+        (lambda value: value.update(schemaVersion=2), "chartSourceRevision"),
         (lambda value: value.update(recordType="final"), "recordType"),
         (lambda value: value.update(approvedAt=1), "approvedAt"),
         (lambda value: value.update(approvedAt="2026-02-30T12:00:00Z"), "valid UTC"),


### PR DESCRIPTION
### Motivation

- Represent independent chart provenance so a recovery chart built from a different source revision can be validated while preserving existing same-source records. 
- Prepare the repository and operator runbook to reconcile DSPACE production to the approved recovery coordinates (chart 3.0.2 / image tag main-1a31a56) without mutating clusters or claiming approval. 
- Fail closed on missing/malformed provenance and preserve strict immutable-coordinate validation for OCI image and chart digests. 

### Description

- Add schema-v2 split-provenance support to the release manifest flow by introducing `chartSourceRevision` and per-schema upstream field handling in `scripts/dspace_release_manifest.py`, including `chart_source_revision()`, `_upstream_fields()`, and updates to `candidate()`, `preflight()`, `finalize()`, and `staging_gate()` to validate image vs `sourceRevision` and chart vs `chartSourceRevision` independently. 
- Preserve and surface chart provenance in rollback evidence by quoting `chartSourceRevision` through `scripts/dspace_manifest_rollback.py` so rollback evidence and reservation metadata include independent chart provenance when present. 
- Update production chart pin to `3.0.2` while keeping the immutable production image tag unchanged (`docs/apps/dspace.prod.version` and `docs/apps/dspace.prod.tag`). 
- Add one immutable, version-controlled recovery-coordinate input at `docs/apps/dspace.recovery-3.0.2.coordinates.json` containing the exact approved coordinates (application `3.0.1`, `sourceRevision`, `chartSourceRevision`, `main-1a31a56`, image & chart digests, chartVersion `3.0.2`, semanticTag `v3.0.1`) and make it consumable by `scripts/dspace_release_manifest.py candidate`. 
- Add focused regression tests (modified/added in `tests/test_release_manifest.py`, `tests/test_manifest_rollback.py`, `tests/test_dspace_runtime_values.py`) that cover schema-v1 compatibility, schema-v2 split-provenance validation, preflight and staging-gate comparisons, finalization preservation of split provenance, and rejection of malformed/missing/swapped revisions. 
- Add a copy/paste-ready, operator-focused reconciliation runbook section to `docs/apps/dspace.md` that clearly separates repository prep, operator approval metadata, staging proof, read-only production capture, guarded promotion, post-change verification, freeze-lift criteria, and failure/rollback guidance (Refs #2325). 

### Testing

- Ran focused and repository tests: `python3 -m pytest -q tests/test_release_manifest.py tests/test_manifest_rollback.py tests/test_generic_app_just_recipes.py tests/test_dspace_runtime_verifier.py` and `python3 -m pytest -q tests/test_dspace_runtime_values.py tests/test_app_config.py`; these test runs passed (test suites covering the modified release and rollback logic all passed in this environment). 
- Verified `python3 scripts/app_config.py json --app dspace --env prod` produced the expected production values chain that now resolves the chart pin `3.0.2` and retains `main-1a31a56` as the image tag. 
- Ran format and checks: `just --unstable --fmt --check` succeeded, and `python3 -m black --check` was used (files were reformatted as part of development then re-checked). `linkchecker --no-warnings README.md docs/` succeeded. `git diff --check` and `git diff | ./scripts/scan-secrets.py` returned no new issues for the staged changes. 
- Notes about repository-wide hooks and environment limits: `pre-commit run --all-files` triggers the repo YAML checks that fail on pre-existing multi-document Kubernetes YAML elsewhere in the repo (these are pre-existing and outside the scope of this PR); `pyspelling -c .spellcheck.yaml` could not complete in this environment because the `aspell` binary is not available. These do not block the focused manifest and test changes in this PR. 

Summary of changed files and compatibility behavior: `scripts/dspace_release_manifest.py` (schema-v2 + validation updates), `scripts/dspace_manifest_rollback.py` (preserve chart provenance in evidence), `docs/apps/dspace.prod.version` (3.0.2), `docs/apps/dspace.recovery-3.0.2.coordinates.json` (immutable input), `docs/apps/dspace.md` (runbook), and tests under `tests/` updated to cover split-provenance behavior; schema-v1 records remain valid and implicitly treat `chartSourceRevision == sourceRevision`. 

Operator work remaining before the reconciliation can be executed: independently verify the application `3.0.1` OpenAI-first contract, supply genuine approval metadata for staging and prod candidates, run the guarded staging deploy and obtain finalized staging evidence, perform the read-only production capture, run the guarded promotion recipe to produce finalized production evidence, and only then (after review of the produced final record and all checks) consider lifting the production Helm freeze. This PR prepares the repository and runbook but does not perform any of those cluster operations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cf145e240832f80cd830dd11df89a)