### PR TITLE
Prepare DSPACE production reconciliation: add schema-v2 split provenance and recovery coordinates

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -86,7 +86,7 @@ verification uses the same command with `env=prod` and a production candidate or
 | Release | `dspace` |
 | Namespace | `dspace` |
 | App config | `docs/examples/apps/dspace.env` |
-| Chart version pins | Shared/default `docs/apps/dspace.version`; staging `docs/apps/dspace.staging.version` (`3.1.0`); production `docs/apps/dspace.prod.version` (`3.0.1`) |
+| Chart version pins | Shared/default `docs/apps/dspace.version`; staging `docs/apps/dspace.staging.version` (`3.1.0`); production `docs/apps/dspace.prod.version` (`3.0.2`) |
 | Production tag pin | `docs/apps/dspace.prod.tag` |
 | Verify paths | `/config.json`, `/healthz`, `/livez` |
 
@@ -114,7 +114,7 @@ Use these links before changing a deployment so the workflow runs, package versi
 - `env=staging`: HA staging on the staging Sugarkube cluster with host `staging.democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
   The staging overlay injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`, uses chart `3.1.0`, and persists the authenticated metrics ServiceMonitor configuration discovered by kube-prometheus-stack. The metrics bearer value is not committed; operators manage the existing `dspace-staging-metrics-token` Secret out of band.
 - `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
-  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`. Production remains intentionally pinned to the recovered chart `3.0.1` deployment and image `ghcr.io/democratizedspace/dspace:main-1a31a56`; it does not enable metrics or ServiceMonitor settings.
+  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`. Production remains intentionally pinned to recovery chart `3.0.2` and image `ghcr.io/democratizedspace/dspace:main-1a31a56`; it does not enable metrics or ServiceMonitor settings.
 - Optional legacy/canary host `prod.democratized.space` uses `docs/examples/dspace.values.prod-subdomain.yaml`. The `dspace-oci-deploy-prod-subdomain` compatibility command selects the secret-free `docs/examples/apps/dspace-prod-subdomain.env` config, preserving that overlay while routing through the same manifest validation, OCI preflight, Helm deployment, and evidence finalization as the generic production path.
 
 ## Find or publish GHCR image
@@ -571,3 +571,90 @@ just helm-oci-install release=dspace namespace=dspace chart=oci://ghcr.io/democr
 ```bash
 just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.staging.version tag="$APP_TAG" env=staging
 ```
+
+## Production Helm-state reconciliation (Refs #2325)
+
+This section **prepares but does not execute** the maintenance operation. The Helm freeze remains
+in force. `docs/apps/dspace.recovery-coordinates.json` is immutable coordinate input, not approval
+or deployment evidence. Its schema 2 fields deliberately bind the 3.0.1 application image to its
+source and the 3.0.2 recovery chart to a different source. The semantic `v3.0.1` field is
+corroborating metadata only: never deploy or republish it. The package checksum is not the OCI
+manifest digest.
+
+### 1. Repository preparation and operator approval
+
+Use distinct cluster credentials and an executable upstream smoke runner. First inspect the
+3.0.1 application's immutable configuration contract and confirm that `openai` is its default;
+stop if it contradicts the expected OpenAI-first recovery behavior. Supply real approval metadata
+only after that review:
+
+```bash
+export STAGING_KUBECONFIG="$HOME/.kube/config-sugarkube-staging"
+export PROD_KUBECONFIG="$HOME/.kube/config-sugarkube-prod"
+export DSPACE_SMOKE_RUNNER="$HOME/dspace/scripts/run-remote-chat-smoke.mjs"
+test "$STAGING_KUBECONFIG" != "$PROD_KUBECONFIG"
+test -x "$DSPACE_SMOKE_RUNNER"
+COORDINATES=docs/apps/dspace.recovery-coordinates.json
+APPROVED_AT='<YYYY-MM-DDTHH:MM:SSZ>' APPROVED_BY='<operator identity>'
+python3 scripts/dspace_release_manifest.py candidate --upstream "$COORDINATES" \
+  --output deployment-candidates/dspace/staging.json --environment staging --provider openai \
+  --approved-at "$APPROVED_AT" --approved-by "$APPROVED_BY"
+python3 scripts/dspace_release_manifest.py candidate --upstream "$COORDINATES" \
+  --output deployment-candidates/dspace/prod.json --environment prod --provider openai \
+  --approved-at "$APPROVED_AT" --approved-by "$APPROVED_BY"
+```
+
+### 2. Stage and prove the exact release
+
+Preflight resolves image and chart OCI provenance independently and prints the digest-qualified
+chart. Render and inspect the production values chain before reserving anything: metrics and its
+staging Secret must be absent, no Secret value may be printed, and legitimate production
+`secretKeyRef` references remain.
+
+```bash
+python3 scripts/dspace_release_manifest.py preflight --manifest deployment-candidates/dspace/staging.json --print-chart-coordinate
+python3 scripts/app_config.py json --app dspace --env prod
+just app-deploy app=dspace env=staging tag=main-1a31a56 \
+  manifest=deployment-candidates/dspace/staging.json smoke_runner="$DSPACE_SMOKE_RUNNER" \
+  kubeconfig="$STAGING_KUBECONFIG"
+just dspace-release-verify env=staging \
+  manifest=deployment-evidence/dspace/staging/<finalized-record>.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER" kubeconfig="$STAGING_KUBECONFIG"
+python3 scripts/dspace_release_manifest.py staging-gate \
+  --manifest deployment-candidates/dspace/prod.json \
+  --staging-evidence deployment-evidence/dspace/staging/<finalized-record>.json
+```
+
+### 3. Read-only production capture, guarded mutation, and review
+
+Before mutation, save timestamped, access-restricted output from bounded `helm history`/`status`
+and `kubectl get` queries covering Deployment image/identity, serving pod UIDs, start times and
+image IDs, plus public/direct runtime identity. Do not capture Secret objects or rendered Secret
+values. Run production preflight and digest-qualified render verification before evidence
+reservation. Then use only the guarded promotion recipe:
+
+```bash
+python3 scripts/dspace_release_manifest.py preflight --manifest deployment-candidates/dspace/prod.json --print-chart-coordinate
+just app-promote-prod app=dspace tag=main-1a31a56 \
+  manifest=deployment-candidates/dspace/prod.json \
+  staging_evidence=deployment-evidence/dspace/staging/<finalized-record>.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER" kubeconfig="$PROD_KUBECONFIG" \
+  staging_kubeconfig="$STAGING_KUBECONFIG"
+```
+
+Review the timestamped finalized production evidence and independently confirm Helm stored values,
+Deployment and every serving pod, image digest, application/runtime/frontend revision, chart
+version/digest/source revision, public/direct identity, health paths, configuration, and `/chat`.
+Lift the freeze only when finalized production evidence exists and every check passes.
+
+### 4. Failure reconciliation and immutable rollback
+
+On failure, retain the reservation and bounded failure evidence; do not claim success or use
+`helm rollback`, `--reuse-values`, a semantic image tag, mutable coordinates, or staging evidence
+as production proof. Because the drifted revision 8 has no truthful finalized production record,
+it is not a rollback target. Stop traffic-changing work and reconcile manually until an explicitly
+approved, immutable **production** target with complete production values is available. Then invoke
+`just dspace-manifest-rollback` with exact production confirmation and that finalized production
+record; it performs a fresh digest-qualified upgrade and mandatory post-mutation verification.
+Until such a record exists, the safe initial-reconciliation response is to preserve the failed
+state/evidence and keep the freeze, not manufacture historical evidence.

--- a/docs/apps/dspace.prod.version
+++ b/docs/apps/dspace.prod.version
@@ -1,2 +1,2 @@
 # DSPACE production chart pin. Keep aligned with the recovered production deployment.
-3.0.1
+3.0.2

--- a/docs/apps/dspace.recovery-coordinates.json
+++ b/docs/apps/dspace.recovery-coordinates.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 2,
+  "app": "dspace",
+  "applicationVersion": "3.0.1",
+  "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+  "chartSourceRevision": "63063e287adb92a4158ce2c8e7d378b73f52c1c5",
+  "imageTag": "main-1a31a56",
+  "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
+  "chartVersion": "3.0.2",
+  "chartDigest": "sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575",
+  "semanticTag": "v3.0.1"
+}

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -28,6 +28,7 @@ UPSTREAM_FIELDS = (
     "chartDigest",
     "semanticTag",
 )
+UPSTREAM_V2_FIELDS = UPSTREAM_FIELDS[:4] + ("chartSourceRevision",) + UPSTREAM_FIELDS[4:]
 CANDIDATE_FIELDS = UPSTREAM_FIELDS + (
     "recordType",
     "environment",
@@ -35,6 +36,7 @@ CANDIDATE_FIELDS = UPSTREAM_FIELDS + (
     "approvedAt",
     "approvedBy",
 )
+CANDIDATE_V2_FIELDS = UPSTREAM_V2_FIELDS + CANDIDATE_FIELDS[len(UPSTREAM_FIELDS) :]
 FINAL_FIELDS = CANDIDATE_FIELDS + (
     "helmRevision",
     "pods",
@@ -42,6 +44,7 @@ FINAL_FIELDS = CANDIDATE_FIELDS + (
     "runtimeSourceRevisionMethod",
     "verificationResults",
 )
+FINAL_V2_FIELDS = CANDIDATE_V2_FIELDS + FINAL_FIELDS[len(CANDIDATE_FIELDS) :]
 OPTIONAL_FINAL_FIELDS = ("runtimeVerification",)
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
@@ -122,8 +125,10 @@ def _exact_fields(value: dict[str, Any], expected: tuple[str, ...]) -> None:
 
 
 def _validate_upstream(value: dict[str, Any]) -> None:
-    if value["schemaVersion"] != 1 or value["app"] != "dspace":
-        raise ManifestError("schemaVersion must be 1 and app must be 'dspace'")
+    if type(value["schemaVersion"]) is not int or value["schemaVersion"] not in {1, 2}:
+        raise ManifestError("schemaVersion must be integer 1 or 2")
+    if value["app"] != "dspace":
+        raise ManifestError("app must be 'dspace'")
     if not isinstance(value["applicationVersion"], str) or not SEMVER_RE.fullmatch(
         value["applicationVersion"]
     ):
@@ -131,6 +136,12 @@ def _validate_upstream(value: dict[str, Any]) -> None:
     sha = value["sourceRevision"]
     if not isinstance(sha, str) or not SHA_RE.fullmatch(sha):
         raise ManifestError("sourceRevision must be a full 40-character lowercase Git SHA")
+    if value["schemaVersion"] == 2:
+        chart_sha = value["chartSourceRevision"]
+        if not isinstance(chart_sha, str) or not SHA_RE.fullmatch(chart_sha):
+            raise ManifestError(
+                "chartSourceRevision must be a full 40-character lowercase Git SHA"
+            )
     tag = value["imageTag"]
     match = IMAGE_TAG_RE.fullmatch(tag) if isinstance(tag, str) else None
     if not match:
@@ -153,7 +164,12 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
     record_type = value.get("recordType")
     if finalized is None:
         finalized = record_type == "final"
-    expected = FINAL_FIELDS if finalized else CANDIDATE_FIELDS
+    schema = value.get("schemaVersion")
+    if schema == 2 and "chartSourceRevision" not in value:
+        raise ManifestError("schemaVersion 2 requires chartSourceRevision")
+    expected = (FINAL_V2_FIELDS if finalized else CANDIDATE_V2_FIELDS) if schema == 2 else (
+        FINAL_FIELDS if finalized else CANDIDATE_FIELDS
+    )
     if finalized and "runtimeVerification" in value:
         expected += OPTIONAL_FINAL_FIELDS
     _exact_fields(value, expected)
@@ -410,9 +426,10 @@ def candidate(
     approved_at: str,
     approved_by: str,
 ) -> dict[str, Any]:
-    _exact_fields(upstream, UPSTREAM_FIELDS)
+    fields = UPSTREAM_V2_FIELDS if upstream.get("schemaVersion") == 2 else UPSTREAM_FIELDS
+    _exact_fields(upstream, fields)
     _validate_upstream(upstream)
-    result = {field: upstream[field] for field in UPSTREAM_FIELDS}
+    result = {field: upstream[field] for field in fields}
     result.update(
         recordType="candidate",
         environment=environment,
@@ -536,7 +553,11 @@ def preflight(
     checks = (
         ("imageDigest", image_digest, value["imageDigest"]),
         ("chartDigest", chart_digest, value["chartDigest"]),
-        ("chartSourceRevision", chart_revision, value["sourceRevision"]),
+        (
+            "chartSourceRevision",
+            chart_revision,
+            value.get("chartSourceRevision", value["sourceRevision"]),
+        ),
     )
     results = [
         {
@@ -819,6 +840,10 @@ def staging_gate(candidate_value: dict[str, Any], evidence_value: dict[str, Any]
         "semanticTag",
         "expectedDefaultChatProvider",
     )
+    if candidate_value["schemaVersion"] != evidence_value["schemaVersion"]:
+        raise ManifestError("manifest/evidence mismatch: schema versions differ")
+    if candidate_value["schemaVersion"] == 2:
+        coordinates += ("chartSourceRevision",)
     if any(candidate_value[field] != evidence_value[field] for field in coordinates):
         raise ManifestError("manifest/evidence mismatch: staging and prod coordinates differ")
     if "runtimeVerification" not in evidence_value:

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -105,7 +105,7 @@ def test_dspace_chart_pins_resolve_staging_and_prod_versions() -> None:
     prod = load_config("dspace", "prod")
 
     assert _first_pin_value(REPO_ROOT / staging["SUGARKUBE_VERSION_FILE"]) == "3.1.0"
-    assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.1"
+    assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.2"
 
 
 def test_dspace_staging_values_enable_authenticated_metrics_servicemonitor() -> None:

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -1292,3 +1292,80 @@ def test_finalize_rejects_noncanonical_image_id() -> None:
     item["status"]["containerStatuses"][0]["imageID"] = "not-a-digest"
     with pytest.raises(manifest.ManifestError, match="non-canonical pod imageID"):
         finalize(pods_json={"items": [item]})
+
+CHART_SHA = "fedcba9876543210fedcba9876543210fedcba98"
+
+
+def split_upstream() -> dict[str, object]:
+    value = upstream()
+    value["schemaVersion"] = 2
+    value["chartSourceRevision"] = CHART_SHA
+    return value
+
+
+def test_schema_v2_split_provenance_round_trips_and_gates() -> None:
+    staging = manifest.candidate(
+        split_upstream(), "staging", "openai", "2026-07-26T12:00:00Z", "operator"
+    )
+    prod = dict(staging, environment="prod")
+    assert staging["sourceRevision"] == SHA
+    assert staging["chartSourceRevision"] == CHART_SHA
+    final = dict(
+        staging,
+        recordType="final",
+        helmRevision=9,
+        pods=[{"name": "dspace-0", "startTime": "2026-07-26T12:01:00Z", "imageID": f"{manifest.IMAGE_REF}@{DIGEST}"}],
+        runtimeSourceRevision=SHA,
+        runtimeSourceRevisionMethod=manifest.RUNTIME_METHOD,
+        verificationResults=[
+            {"check": check, "passed": True, "details": "observed"}
+            for check in sorted(manifest.FINAL_FIXED_CHECKS | manifest.RUNTIME_VERIFICATION_CHECKS)
+            + ["imagePlatformSourceRevision[0]"]
+        ],
+        runtimeVerification={
+            "schemaVersion": 1, "environment": "staging", "release": "dspace", "namespace": "dspace",
+            "applicationVersion": "3.2.0", "runtimeSourceRevision": SHA,
+            "frontendSourceRevision": SHA, "defaultProvider": "openai",
+            "journeys": [{"name": "/chat", "passed": True}],
+        },
+    )
+    assert manifest.validate(final, True)["chartSourceRevision"] == CHART_SHA
+    assert manifest.staging_gate(prod, final) == 9
+    with pytest.raises(manifest.ManifestError, match="coordinates differ"):
+        manifest.staging_gate(dict(prod, chartSourceRevision="0" * 40), final)
+
+
+def test_schema_v2_preflight_uses_independent_revisions() -> None:
+    value = manifest.candidate(
+        split_upstream(), "staging", "openai", "2026-07-26T12:00:00Z", "operator"
+    )
+    manifest.preflight(value, manifest.IMAGE_REF, manifest.CHART_REF, "oras", runner=oras_runner(chart_revision=CHART_SHA))
+    with pytest.raises(manifest.ManifestError, match="chartSourceRevision"):
+        manifest.preflight(value, manifest.IMAGE_REF, manifest.CHART_REF, "oras", runner=oras_runner(image_revision=CHART_SHA, chart_revision=SHA))
+
+
+@pytest.mark.parametrize("change", [
+    lambda x: x.pop("chartSourceRevision"),
+    lambda x: x.update(chartSourceRevision="abc"),
+    lambda x: x.update(extraRevision=SHA),
+])
+def test_schema_v2_rejects_missing_malformed_or_unknown_provenance(change) -> None:
+    value = split_upstream()
+    change(value)
+    with pytest.raises(manifest.ManifestError):
+        manifest.candidate(value, "staging", "openai", "2026-07-26T12:00:00Z", "operator")
+
+
+def test_recovery_coordinate_file_is_exact_and_candidate_consumable() -> None:
+    value = json.loads(Path("docs/apps/dspace.recovery-coordinates.json").read_text())
+    assert value == {
+        "schemaVersion": 2, "app": "dspace", "applicationVersion": "3.0.1",
+        "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+        "chartSourceRevision": "63063e287adb92a4158ce2c8e7d378b73f52c1c5",
+        "imageTag": "main-1a31a56",
+        "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
+        "chartVersion": "3.0.2",
+        "chartDigest": "sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575",
+        "semanticTag": "v3.0.1",
+    }
+    assert manifest.candidate(value, "prod", "openai", "2026-07-31T00:00:00Z", "operator")["chartSourceRevision"] == value["chartSourceRevision"]


### PR DESCRIPTION
### Motivation

- Fix the preflight/manifest contract to allow a valid recovery pair where the application `sourceRevision` and the recovery chart `chartSourceRevision` are different, without weakening existing same-source validation. 
- Record the exact immutable recovery coordinates for the approved reconciliation target in-repo so operators can generate candidates and stage/produce evidence from an auditable input. 
- Provide a copy/paste-ready operator runbook and focused tests so the repository side of the reconciliation can be performed safely without touching clusters or lifting the Helm freeze. 

### Description

- Add schema v2 support with explicit `chartSourceRevision` while preserving schema-v1 implicit same-source behavior; introduce `UPSTREAM_V2_FIELDS`, `CANDIDATE_V2_FIELDS`, and `FINAL_V2_FIELDS` and accept `schemaVersion` 1 or 2. 
- Enforce fail-closed validation: require `chartSourceRevision` for schema v2, validate application `sourceRevision` and chart `chartSourceRevision` independently, and keep runtime identity tied to the application `sourceRevision`. 
- Update OCI preflight to check chart provenance against `chartSourceRevision` (falling back to `sourceRevision` for schema v1) and make staging-gate compare schema versions and `chartSourceRevision` when present. 
- Add immutable recovery input `docs/apps/dspace.recovery-coordinates.json` containing the exact approved coordinates (app v3.0.1, image `main-1a31a56`, image digest, recovery chart 3.0.2, chart digest, and explicit `chartSourceRevision`) and update production chart pin in `docs/apps/dspace.prod.version` to `3.0.2` while keeping the production image tag unchanged. 
- Add/adjust focused regression tests in `tests/test_release_manifest.py` and `tests/test_dspace_runtime_values.py` to cover schema-v1 and schema-v2 flows, preflight/gate behavior, malformed/missing/swap cases, and production values isolation. 
- Extend `docs/apps/dspace.md` with a phased operator runbook (repository preparation, operator approval, staging proof, read-only capture, guarded promotion, post-rollout verification, freeze-lift criteria, and immutable rollback constraints) that explicitly states this PR prepares but does not execute the reconciliation. 

### Testing

- Ran focused pytest suites: `python3 -m pytest -q tests/test_release_manifest.py tests/test_manifest_rollback.py tests/test_generic_app_just_recipes.py tests/test_dspace_runtime_verifier.py tests/test_dspace_runtime_values.py` and the targeted tests used by the runbook, and all exercised tests passed. 
- Ran `python3 scripts/app_config.py json --app dspace --env prod` to verify resolved production values-chain and confirm production overlays do not leak staging-only metrics/Secrets. 
- Ran `just --unstable --fmt --check`, `git diff --check`, and repository secret scans (`git diff --cached | ./scripts/scan-secrets.py`) with no new issues found. 
- Unavailable in this environment: `pre-commit`, `pyspelling`, and `linkchecker` so those checks were not executed here and should be run by CI or an operator before merge. 

Files changed (high level): `scripts/dspace_release_manifest.py`, `docs/apps/dspace.recovery-coordinates.json`, `docs/apps/dspace.prod.version`, `docs/apps/dspace.md`, `tests/test_release_manifest.py`, `tests/test_dspace_runtime_values.py`.

Schema compatibility: schema-v1 manifests remain valid and retain the invariant that chart provenance equals application `sourceRevision`; schema-v2 requires `chartSourceRevision` and verifies application and chart provenance independently.

Operator work remaining (must be done out-of-repo, as the runbook prescribes): generate staging and production candidates from the committed recovery coordinates, preflight and deploy to staging, obtain finalized staging evidence for both source revisions, perform read-only production capture and preflight render verification, then run the guarded promotion recipe and collect finalized production evidence before lifting the Helm freeze (all steps use distinct kubeconfigs and the approved smoke runner). 

Refs #2325

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cf1576a44832f9f7940e20892dc9f)