### PR TITLE
Prepare DSPACE production reconciliation (schema v2, recovery input, tests, runbook)

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -101,8 +101,10 @@ and the remote `/chat` journey. A staging candidate or unfinalized result is not
 
 ### 3. Read-only production capture and preflight
 
-Create a restricted, timestamped evidence directory. Capture bounded metadata only; do not run
-`helm get values --all`, dump Secrets, or record response bodies:
+Create a restricted, timestamped evidence directory. Capture bounded metadata only; do not manually
+record `helm get values --all`, dump Secrets, or record response bodies. Schema-v2 finalization reads
+the release's computed Helm values transiently and records only the bounded `helmStoredValues` pass
+result after verifying the image repository, immutable tag, pull policy, and production isolation:
 
 ```bash
 STAMP=$(date -u +%Y%m%dT%H%M%SZ)

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -2,6 +2,161 @@
 
 This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugarkube. The generic `just app-*` recipes are the preferred future path. The `dspace-oci-*` recipes remain compatibility shims and are scheduled for later removal only after the generic flow has been exercised across routine releases.
 
+## Production Helm reconciliation for application 3.0.1
+
+This section **prepares but does not execute** the incident reconciliation tracked by
+Sugarkube issue #2325. Keep the production Helm freeze in place throughout. The reviewed,
+machine-readable input is `docs/apps/dspace.prod-recovery-coordinates.json`: schema 2 keeps the
+application/image revision in `sourceRevision` and independently records the recovery chart's
+revision in `chartSourceRevision`. The `v3.0.1` semantic tag is corroborating metadata only; never
+pass it to Helm, publish it, or use it as an image coordinate. The chart OCI manifest digest is not
+the downloaded chart archive's SHA-256.
+
+### 1. Repository preparation (already performed by this change)
+
+Review the recovery input, production chart pin, production values chain, and immutable image pin.
+The two kubeconfigs must name different files and clusters. These commands are read-only:
+
+```bash
+RECOVERY=docs/apps/dspace.prod-recovery-coordinates.json
+STAGING_KUBECONFIG="$HOME/.kube/config-sugarkube-staging"
+PROD_KUBECONFIG="$HOME/.kube/config-sugarkube-prod"
+DSPACE_SMOKE_RUNNER="$HOME/dspace/scripts/run-remote-chat-smoke.mjs"
+test "$STAGING_KUBECONFIG" != "$PROD_KUBECONFIG"
+test -r "$STAGING_KUBECONFIG" && test -r "$PROD_KUBECONFIG"
+test -x "$DSPACE_SMOKE_RUNNER"
+python3 scripts/app_config.py json --app dspace --env prod
+jq -e '.schemaVersion == 2 and .applicationVersion == "3.0.1" and
+  .sourceRevision == "1a31a569aff2dbeb238e8c2688b9e85140d2077d" and
+  .chartSourceRevision == "63063e287adb92a4158ce2c8e7d378b73f52c1c5" and
+  .imageTag == "main-1a31a56" and
+  .imageDigest == "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401" and
+  .chartVersion == "3.0.2" and
+  .chartDigest == "sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575"' "$RECOVERY"
+```
+
+Before encoding approval, inspect the immutable DSPACE 3.0.1 application contract at revision
+`1a31a569aff2dbeb238e8c2688b9e85140d2077d` and run its contract tests. The recovery behavior is
+OpenAI-first, so set `EXPECTED_PROVIDER=openai` only if that immutable source and its executable
+remote `/chat` runner confirm it. Stop if they say `token-place`, if the runner is unavailable, or
+if any coordinate differs; do not edit evidence to make it agree.
+
+### 2. Operator-supplied approval and staging
+
+Approval identity and UTC time come from the real maintenance approval record. They are not stored
+in the recovery input. Generate both candidates from that same input:
+
+```bash
+APPROVED_AT='<YYYY-MM-DDTHH:MM:SSZ-from-approval>'
+APPROVED_BY='<operator-or-review-record>'
+EXPECTED_PROVIDER=openai
+mkdir -p deployment-candidates/dspace
+python3 scripts/dspace_release_manifest.py candidate --upstream "$RECOVERY" \
+  --output deployment-candidates/dspace/recovery-staging.json --environment staging \
+  --provider "$EXPECTED_PROVIDER" --approved-at "$APPROVED_AT" --approved-by "$APPROVED_BY"
+python3 scripts/dspace_release_manifest.py candidate --upstream "$RECOVERY" \
+  --output deployment-candidates/dspace/recovery-prod.json --environment prod \
+  --provider "$EXPECTED_PROVIDER" --approved-at "$APPROVED_AT" --approved-by "$APPROVED_BY"
+python3 scripts/dspace_release_manifest.py validate \
+  --manifest deployment-candidates/dspace/recovery-staging.json
+python3 scripts/dspace_release_manifest.py validate \
+  --manifest deployment-candidates/dspace/recovery-prod.json
+```
+
+Use the guarded staging recipe, then retain and review its non-overwritable finalized evidence:
+
+```bash
+just app-deploy app=dspace env=staging tag=main-1a31a56 \
+  manifest=deployment-candidates/dspace/recovery-staging.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER" kubeconfig="$STAGING_KUBECONFIG"
+STAGING_EVIDENCE=$(python3 scripts/dspace_release_manifest.py evidence-path \
+  --manifest deployment-candidates/dspace/recovery-staging.json)
+python3 scripts/dspace_release_manifest.py validate --final --manifest "$STAGING_EVIDENCE"
+python3 scripts/dspace_release_manifest.py staging-gate \
+  --manifest deployment-candidates/dspace/recovery-prod.json \
+  --staging-evidence "$STAGING_EVIDENCE"
+```
+
+That gate must prove application version, immutable image tag/digest, chart version/digest, both
+source revisions, OpenAI provider identity, runtime/frontend application revision, health journeys,
+and the remote `/chat` journey. A staging candidate or unfinalized result is not production proof.
+
+### 3. Read-only production capture and preflight
+
+Create a restricted, timestamped evidence directory. Capture bounded metadata only; do not run
+`helm get values --all`, dump Secrets, or record response bodies:
+
+```bash
+STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+CAPTURE="operator-evidence/dspace-prod-reconciliation-$STAMP"
+install -d -m 0700 "$CAPTURE"
+helm --kubeconfig "$PROD_KUBECONFIG" -n dspace history dspace --max 10 -o json >"$CAPTURE/helm-history.json"
+helm --kubeconfig "$PROD_KUBECONFIG" -n dspace status dspace -o json >"$CAPTURE/helm-status.json"
+kubectl --kubeconfig "$PROD_KUBECONFIG" -n dspace get deployment dspace \
+  -o jsonpath='{.metadata.uid}{"\n"}{.spec.template.spec.containers[?(@.name=="dspace")].image}{"\n"}' \
+  >"$CAPTURE/deployment-identity.txt"
+kubectl --kubeconfig "$PROD_KUBECONFIG" -n dspace get pods \
+  -l app.kubernetes.io/name=dspace,app.kubernetes.io/instance=dspace \
+  -o custom-columns=NAME:.metadata.name,UID:.metadata.uid,START:.status.startTime,IMAGE_ID:.status.containerStatuses[?\(@.name==\"dspace\"\)].imageID \
+  >"$CAPTURE/pods.txt"
+python3 scripts/dspace_release_manifest.py preflight \
+  --manifest deployment-candidates/dspace/recovery-prod.json --environment prod \
+  --image-tag main-1a31a56 --chart-version 3.0.2 --print-chart-coordinate \
+  >"$CAPTURE/chart-coordinate.txt"
+```
+
+Before evidence reservation or mutation, use the existing recipe's exact digest-qualified render
+and structural validation. Review that the resolved production chain is the dev base plus production
+overlay; it must contain no staging metrics, staging metrics Secret reference, ServiceMonitor, or
+literal Secret material. Legitimate production `secretKeyRef`/`existingSecret` names are allowed,
+but never print their values. Stop on any render, OCI revision, digest, provider, cluster identity,
+or staging-gate mismatch.
+
+### 4. Guarded production mutation and verification
+
+Only after the approved window and read-only review, invoke the guarded promotion recipe—not raw
+`helm upgrade`, `helm rollback`, or `kubectl apply`:
+
+```bash
+just app-promote-prod app=dspace tag=main-1a31a56 \
+  manifest=deployment-candidates/dspace/recovery-prod.json \
+  staging_evidence="$STAGING_EVIDENCE" smoke_runner="$DSPACE_SMOKE_RUNNER" \
+  staging_kubeconfig="$STAGING_KUBECONFIG" kubeconfig="$PROD_KUBECONFIG"
+PROD_EVIDENCE=$(python3 scripts/dspace_release_manifest.py evidence-path \
+  --manifest deployment-candidates/dspace/recovery-prod.json)
+python3 scripts/dspace_release_manifest.py validate --final --manifest "$PROD_EVIDENCE"
+```
+
+Review the finalized record together with fresh bounded Helm status/history and Deployment/pod
+capture. All serving pods and Helm stored image values must use `main-1a31a56` and the approved
+image digest; installed chart version and OCI provenance must be 3.0.2 and its chart revision/digest.
+Application, runtime, and frontend identity must remain the application revision, not the chart
+revision. Public and direct identity, replica agreement, health paths, configuration/provider, and
+`/chat` must all pass. Preserve candidate, finalized records, command exit statuses, timestamps, and
+secret-safe captures in the external maintenance record.
+
+Lift the Helm freeze only after finalized **production** evidence exists, validation succeeds, every
+verification result is true, the staging gate matches both revisions and every immutable coordinate,
+and reviewers accept the bounded pre/post capture. Otherwise the freeze remains.
+
+### 5. Failure reconciliation and immutable recovery
+
+There is deliberately no fabricated finalized record for the inconsistent pre-change revision 8,
+so it is not a valid rollback target. On any failure, stop, keep the freeze, preserve the reservation
+or redacted failure evidence and bounded post-failure status, and do not immediately mutate again.
+Never use `helm rollback <revision>`, `--reuse-values`, `v3.0.1`, mutable coordinates, or staging
+evidence as a production target.
+
+For this first reconciliation, the truthful recovery path is a separately approved retry/reconcile
+to the same immutable production candidate, using the complete Git-controlled production values and
+the guarded `app-promote-prod` sequence above after diagnosing the failed invocation. If a different
+state must be restored, first supply a genuine finalized production manifest for that immutable
+target and use `just dspace-manifest-rollback` with its explicit
+`dspace:prod:<40-character-application-SHA>` confirmation, production kubeconfig, complete production
+values, executable verifier and `/chat` runner, and a new bounded evidence path. Without such a
+finalized production target, recovery is blocked rather than guessed. A successful retry still
+requires complete post-mutation finalization before the freeze can be reconsidered.
+
 ## Mandatory release verification
 
 DSPACE staging and production releases are verified against an approved immutable release

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -51,12 +51,23 @@ APPROVED_AT='<YYYY-MM-DDTHH:MM:SSZ-from-approval>'
 APPROVED_BY='<operator-or-review-record>'
 EXPECTED_PROVIDER=openai
 mkdir -p deployment-candidates/dspace
-# Keep the routine staging 3.1.0 pin unchanged while testing this recovery's
-# independently approved 3.0.2 chart. app_config gives this explicit version
-# precedence over the environment's version-file setting.
-RECOVERY_STAGING_CONFIG=deployment-candidates/dspace/recovery-staging.env
-cp docs/examples/apps/dspace.env "$RECOVERY_STAGING_CONFIG"
-printf '\nSUGARKUBE_VERSION=3.0.2\n' >>"$RECOVERY_STAGING_CONFIG"
+# Keep the shared staging pin unchanged while selecting the independently
+# approved 3.0.2 production pin for this recovery only.
+RECOVERY_CONFIG=$(mktemp)
+trap 'rm -f "$RECOVERY_CONFIG"' EXIT
+python3 - "$RECOVERY_CONFIG" <<'PY'
+from pathlib import Path
+import sys
+
+source = Path("docs/examples/apps/dspace.env").read_text(encoding="utf-8")
+old = "SUGARKUBE_VERSION_FILE_STAGING=docs/apps/dspace.staging.version"
+new = "SUGARKUBE_VERSION_FILE_STAGING=docs/apps/dspace.prod.version"
+if source.count(old) != 1:
+    raise SystemExit("expected exactly one staging version-file assignment")
+Path(sys.argv[1]).write_text(source.replace(old, new), encoding="utf-8")
+PY
+python3 scripts/app_config.py json --app dspace --env staging \
+  --config "$RECOVERY_CONFIG"
 python3 scripts/dspace_release_manifest.py candidate --upstream "$RECOVERY" \
   --output deployment-candidates/dspace/recovery-staging.json --environment staging \
   --provider "$EXPECTED_PROVIDER" --approved-at "$APPROVED_AT" --approved-by "$APPROVED_BY"
@@ -73,7 +84,7 @@ Use the guarded staging recipe, then retain and review its non-overwritable fina
 
 ```bash
 just app-deploy app=dspace env=staging tag=main-1a31a56 \
-  config="$RECOVERY_STAGING_CONFIG" \
+  config="$RECOVERY_CONFIG" \
   manifest=deployment-candidates/dspace/recovery-staging.json \
   smoke_runner="$DSPACE_SMOKE_RUNNER" kubeconfig="$STAGING_KUBECONFIG"
 STAGING_EVIDENCE=$(python3 scripts/dspace_release_manifest.py evidence-path \
@@ -106,18 +117,58 @@ kubectl --kubeconfig "$PROD_KUBECONFIG" -n dspace get pods \
   -l app.kubernetes.io/name=dspace,app.kubernetes.io/instance=dspace \
   -o 'custom-columns=NAME:.metadata.name,UID:.metadata.uid,START:.status.startTime,IMAGE_ID:.status.containerStatuses[?(@.name=="dspace")].imageID' \
   >"$CAPTURE/pods.txt"
-python3 scripts/dspace_release_manifest.py preflight \
-  --manifest deployment-candidates/dspace/recovery-prod.json --environment prod \
-  --image-tag main-1a31a56 --chart-version 3.0.2 --print-chart-coordinate \
-  >"$CAPTURE/chart-coordinate.txt"
+PROD_HOST=$(python3 scripts/app_chart.py resolve-host \
+  --values docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml)
+PUBLIC_BUILD=$(mktemp)
+DIRECT_BUILD=$(mktemp)
+trap 'rm -f "$RECOVERY_CONFIG" "$PUBLIC_BUILD" "$DIRECT_BUILD"' EXIT
+curl --fail --silent --show-error --max-time 10 --max-filesize 16384 \
+  "https://$PROD_HOST/build-info.json" >"$PUBLIC_BUILD"
+jq -e '{version, revision, shortRevision, image}' "$PUBLIC_BUILD" \
+  >"$CAPTURE/public-build-identity.json"
+POD=$(kubectl --kubeconfig "$PROD_KUBECONFIG" -n dspace get pods \
+  -l app.kubernetes.io/name=dspace,app.kubernetes.io/instance=dspace \
+  -o jsonpath='{.items[0].metadata.name}')
+timeout 10s kubectl --kubeconfig "$PROD_KUBECONFIG" get --raw \
+  "/api/v1/namespaces/dspace/pods/$POD:3000/proxy/build-info.json" \
+  | head -c 16384 >"$DIRECT_BUILD"
+jq -e '{version, revision, shortRevision, image}' "$DIRECT_BUILD" \
+  >"$CAPTURE/direct-build-identity.json"
 ```
 
-Before evidence reservation or mutation, use the existing recipe's exact digest-qualified render
-and structural validation. Review that the resolved production chain is the dev base plus production
-overlay; it must contain no staging metrics, staging metrics Secret reference, ServiceMonitor, or
-literal Secret material. Legitimate production `secretKeyRef`/`existingSecret` names are allowed,
-but never print their values. Stop on any render, OCI revision, digest, provider, cluster identity,
-or staging-gate mismatch.
+Do not run `dspace-release-verify` against the pre-change 3.0.2 candidate: the full verifier
+correctly rejects the currently installed 3.0.1 chart. The bounded captures above retain only the
+four allowlisted identity fields and cap each response at 16 KiB. Before evidence reservation or
+mutation, run the existing recipe's exact read-only digest-qualified render and structural
+validation sequence:
+
+```bash
+eval "$(python3 scripts/app_config.py shell --app dspace --env prod \
+  --config docs/examples/apps/dspace.env --tag main-1a31a56 --require-tag)"
+CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' \
+  "$SUGARKUBE_VERSION_FILE" | head -n1)
+test "$CHART_VERSION" = 3.0.2
+CHART_COORDINATE=$(python3 scripts/dspace_release_manifest.py preflight \
+  --manifest deployment-candidates/dspace/recovery-prod.json --environment prod \
+  --image-tag "$SUGARKUBE_TAG" --chart-version "$CHART_VERSION" \
+  --chart-ref "$SUGARKUBE_CHART" --print-chart-coordinate)
+test "$CHART_COORDINATE" = \
+  'oci://ghcr.io/democratizedspace/charts/dspace@sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575'
+PROD_HOST=$(python3 scripts/app_chart.py resolve-host --values "$SUGARKUBE_VALUES")
+python3 scripts/app_chart.py preflight \
+  --app "$SUGARKUBE_APP" --env "$SUGARKUBE_ENV" --tag "$SUGARKUBE_TAG" \
+  --chart "$CHART_COORDINATE" --version "${SUGARKUBE_VERSION:-}" \
+  --version-file "$SUGARKUBE_VERSION_FILE" --values "$SUGARKUBE_VALUES" \
+  --release "$SUGARKUBE_RELEASE" --namespace "$SUGARKUBE_NAMESPACE" \
+  --host "$PROD_HOST" --pull-policy Always
+```
+
+This must prove chart 3.0.2 at the approved OCI digest and the immutable application image while
+rejecting staging metrics, the staging metrics Secret reference, ServiceMonitor leakage, or literal
+Secret material. Review that the resolved values chain is exactly the dev base plus production
+overlay. Legitimate production `secretKeyRef`/`existingSecret` names are allowed, but never print
+their values. Stop on any render, OCI revision, digest, provider, cluster identity, or staging-gate
+mismatch.
 
 ### 4. Guarded production mutation and verification
 
@@ -128,7 +179,8 @@ Only after the approved window and read-only review, invoke the guarded promotio
 just app-promote-prod app=dspace tag=main-1a31a56 \
   manifest=deployment-candidates/dspace/recovery-prod.json \
   staging_evidence="$STAGING_EVIDENCE" smoke_runner="$DSPACE_SMOKE_RUNNER" \
-  staging_kubeconfig="$STAGING_KUBECONFIG" kubeconfig="$PROD_KUBECONFIG"
+  staging_config="$RECOVERY_CONFIG" staging_kubeconfig="$STAGING_KUBECONFIG" \
+  kubeconfig="$PROD_KUBECONFIG"
 PROD_EVIDENCE=$(python3 scripts/dspace_release_manifest.py evidence-path \
   --manifest deployment-candidates/dspace/recovery-prod.json)
 python3 scripts/dspace_release_manifest.py validate --final --manifest "$PROD_EVIDENCE"
@@ -248,7 +300,7 @@ verification uses the same command with `env=prod` and a production candidate or
 | Release | `dspace` |
 | Namespace | `dspace` |
 | App config | `docs/examples/apps/dspace.env` |
-| Chart version pins | Shared/default `docs/apps/dspace.version`; staging `docs/apps/dspace.staging.version` (`3.1.0`); production `docs/apps/dspace.prod.version` (`3.0.1`) |
+| Chart version pins | Shared/default `docs/apps/dspace.version`; staging `docs/apps/dspace.staging.version` (`3.1.0`); production `docs/apps/dspace.prod.version` (`3.0.2`) |
 | Production tag pin | `docs/apps/dspace.prod.tag` |
 | Verify paths | `/config.json`, `/healthz`, `/livez` |
 
@@ -276,7 +328,7 @@ Use these links before changing a deployment so the workflow runs, package versi
 - `env=staging`: HA staging on the staging Sugarkube cluster with host `staging.democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
   The staging overlay injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`, uses chart `3.1.0`, and persists the authenticated metrics ServiceMonitor configuration discovered by kube-prometheus-stack. The metrics bearer value is not committed; operators manage the existing `dspace-staging-metrics-token` Secret out of band.
 - `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
-  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`. Production remains intentionally pinned to the recovered chart `3.0.1` deployment and image `ghcr.io/democratizedspace/dspace:main-1a31a56`; it does not enable metrics or ServiceMonitor settings.
+  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`. Production is pinned to recovery chart `3.0.2` and image `ghcr.io/democratizedspace/dspace:main-1a31a56`; it does not enable metrics or ServiceMonitor settings.
 - Optional legacy/canary host `prod.democratized.space` uses `docs/examples/dspace.values.prod-subdomain.yaml`. The `dspace-oci-deploy-prod-subdomain` compatibility command selects the secret-free `docs/examples/apps/dspace-prod-subdomain.env` config, preserving that overlay while routing through the same manifest validation, OCI preflight, Helm deployment, and evidence finalization as the generic production path.
 
 ## Find or publish GHCR image
@@ -526,7 +578,7 @@ For staging, the browser smoke must show DSPACE calling `https://staging.token.p
 
 ## Promote production
 
-This configuration change does not promote or mutate production. Promote only after staging sign-off. Prefer the generic command; it uses the prod values chain, resolves chart `3.0.1` from `docs/apps/dspace.prod.version`, and can read `docs/apps/dspace.prod.tag` (`main-1a31a56`) when `tag=` is omitted.
+This configuration change does not promote or mutate production. Promote only after staging sign-off. Prefer the generic command; it uses the prod values chain, resolves chart `3.0.2` from `docs/apps/dspace.prod.version`, and can read `docs/apps/dspace.prod.tag` (`main-1a31a56`) when `tag=` is omitted.
 
 ```bash
 just app-promote-prod app=dspace tag="$APP_TAG" \
@@ -663,11 +715,10 @@ those target coordinates and identity strings plus a non-empty list of
 including a passing `/chat`. Verifier output and response bodies are not echoed.
 Do not infer frontend identity from the semantic application version.
 
-Real production rollback remains unavailable until DSPACE
-[#4732](https://github.com/democratizedspace/dspace/issues/4732) supplies runtime
-and frontend identity and [#4733](https://github.com/democratizedspace/dspace/issues/4733)
-supplies the remote public-journey verifier contract. Tests use a stub; operators
-must not substitute an availability-only check.
+Production rollback is available only when its target is a genuine finalized production record
+whose runtime/frontend identity and public journeys satisfy the current verifier contract. A
+candidate, staging record, fabricated record, or legacy record without those finalized proofs is
+not a rollback target; operators must not substitute an availability-only check.
 
 If anything fails after reservation, the command exits nonzero, leaves a
 redacted failed evidence record, and warns that cluster state may have changed.

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -51,6 +51,12 @@ APPROVED_AT='<YYYY-MM-DDTHH:MM:SSZ-from-approval>'
 APPROVED_BY='<operator-or-review-record>'
 EXPECTED_PROVIDER=openai
 mkdir -p deployment-candidates/dspace
+# Keep the routine staging 3.1.0 pin unchanged while testing this recovery's
+# independently approved 3.0.2 chart. app_config gives this explicit version
+# precedence over the environment's version-file setting.
+RECOVERY_STAGING_CONFIG=deployment-candidates/dspace/recovery-staging.env
+cp docs/examples/apps/dspace.env "$RECOVERY_STAGING_CONFIG"
+printf '\nSUGARKUBE_VERSION=3.0.2\n' >>"$RECOVERY_STAGING_CONFIG"
 python3 scripts/dspace_release_manifest.py candidate --upstream "$RECOVERY" \
   --output deployment-candidates/dspace/recovery-staging.json --environment staging \
   --provider "$EXPECTED_PROVIDER" --approved-at "$APPROVED_AT" --approved-by "$APPROVED_BY"
@@ -67,6 +73,7 @@ Use the guarded staging recipe, then retain and review its non-overwritable fina
 
 ```bash
 just app-deploy app=dspace env=staging tag=main-1a31a56 \
+  config="$RECOVERY_STAGING_CONFIG" \
   manifest=deployment-candidates/dspace/recovery-staging.json \
   smoke_runner="$DSPACE_SMOKE_RUNNER" kubeconfig="$STAGING_KUBECONFIG"
 STAGING_EVIDENCE=$(python3 scripts/dspace_release_manifest.py evidence-path \
@@ -97,7 +104,7 @@ kubectl --kubeconfig "$PROD_KUBECONFIG" -n dspace get deployment dspace \
   >"$CAPTURE/deployment-identity.txt"
 kubectl --kubeconfig "$PROD_KUBECONFIG" -n dspace get pods \
   -l app.kubernetes.io/name=dspace,app.kubernetes.io/instance=dspace \
-  -o custom-columns=NAME:.metadata.name,UID:.metadata.uid,START:.status.startTime,IMAGE_ID:.status.containerStatuses[?\(@.name==\"dspace\"\)].imageID \
+  -o 'custom-columns=NAME:.metadata.name,UID:.metadata.uid,START:.status.startTime,IMAGE_ID:.status.containerStatuses[?(@.name=="dspace")].imageID' \
   >"$CAPTURE/pods.txt"
 python3 scripts/dspace_release_manifest.py preflight \
   --manifest deployment-candidates/dspace/recovery-prod.json --environment prod \

--- a/docs/apps/dspace.prod-recovery-coordinates.json
+++ b/docs/apps/dspace.prod-recovery-coordinates.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 2,
+  "app": "dspace",
+  "applicationVersion": "3.0.1",
+  "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+  "chartSourceRevision": "63063e287adb92a4158ce2c8e7d378b73f52c1c5",
+  "imageTag": "main-1a31a56",
+  "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
+  "chartVersion": "3.0.2",
+  "chartDigest": "sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575",
+  "semanticTag": "v3.0.1"
+}

--- a/docs/apps/dspace.prod.version
+++ b/docs/apps/dspace.prod.version
@@ -1,2 +1,2 @@
 # DSPACE production chart pin. Keep aligned with the recovered production deployment.
-3.0.1
+3.0.2

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -211,6 +211,10 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                 and kind not in {"Deployment", "StatefulSet", "DaemonSet"}
             ),
         )
+        if inputs.app == "dspace" and kind == "Secret":
+            errors.append(
+                f"DSPACE rendered Secret {name or '<unnamed>'}; literal Secret resources are forbidden"
+            )
         if namespace and namespace != inputs.namespace:
             errors.append(
                 f"rendered {kind or 'resource'} {name or '<unnamed>'} has namespace {namespace!r}"

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -494,7 +494,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     # The manifest module's OCI and cluster proof functions deliberately accept
     # candidate records. Project the exact candidate portion of the validated
     # final record rather than reimplementing or weakening those validators.
-    approved = {field: target[field] for field in release.CANDIDATE_FIELDS}
+    approved = {field: target[field] for field in release.candidate_fields(target)}
     approved["recordType"] = "candidate"
     release.validate(approved, False)
     root = REPO_ROOT
@@ -634,9 +634,11 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "imageTag",
                 "imageDigest",
                 "sourceRevision",
+                "chartSourceRevision",
                 "applicationVersion",
                 "expectedDefaultChatProvider",
             )
+            if key in target
         },
         "values": values_proof,
         "before": {

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -75,6 +75,7 @@ FINAL_FIXED_CHECKS = {
     "podImageCoordinates",
     "podImageDigests",
 }
+SCHEMA_V2_FINAL_CHECKS = {"helmStoredValues"}
 RUNTIME_VERIFICATION_FIELDS = (
     "schemaVersion",
     "environment",
@@ -144,6 +145,14 @@ def _final_fields(value: dict[str, Any]) -> tuple[str, ...]:
 def chart_source_revision(value: dict[str, Any]) -> str:
     """Return explicit v2 chart provenance or the schema-v1 same-source invariant."""
     return value["sourceRevision"] if value["schemaVersion"] == 1 else value["chartSourceRevision"]
+
+
+def required_final_checks(value: dict[str, Any]) -> set[str]:
+    """Return the evidence checks required by this record's schema."""
+    checks = set(FINAL_FIXED_CHECKS)
+    if value["schemaVersion"] == 2:
+        checks.update(SCHEMA_V2_FINAL_CHECKS)
+    return checks
 
 
 def _validate_upstream(value: dict[str, Any]) -> None:
@@ -294,9 +303,9 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
             platform_match = PLATFORM_CHECK_RE.fullmatch(check)
             if platform_match:
                 platform_indices.append(int(platform_match.group(1)))
-            elif check not in FINAL_FIXED_CHECKS | RUNTIME_VERIFICATION_CHECKS:
+            elif check not in required_final_checks(value) | RUNTIME_VERIFICATION_CHECKS:
                 raise ManifestError(f"unknown verification result: {check}")
-        missing = sorted(FINAL_FIXED_CHECKS - checks)
+        missing = sorted(required_final_checks(value) - checks)
         if missing:
             raise ManifestError("missing verification results: " + ", ".join(missing))
         if "runtimeVerification" in value:
@@ -638,6 +647,7 @@ def finalize(
     invocation_description: str,
     expected_image_coordinate: str | None = None,
     runtime_verification: dict[str, Any] | None = None,
+    helm_stored_values_result: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     validate(value, False)
     selected = {
@@ -798,6 +808,10 @@ def finalize(
             "details": "every running pod imageID matched approved image digest",
         },
     ]
+    if value["schemaVersion"] == 2:
+        if helm_stored_values_result is None:
+            raise ManifestError("schema-v2 finalization requires Helm stored-values verification")
+        results.append(helm_stored_values_result)
     if runtime_verification is not None:
         runtime_checks = (
             ("runtimeIdentity", "approved runtime source and image identity verified"),
@@ -822,6 +836,56 @@ def finalize(
     if runtime_verification is not None:
         result["runtimeVerification"] = runtime_verification
     return validate(result, True)
+
+
+def verify_helm_stored_values(
+    value: dict[str, Any], stored_values: object, environment: str
+) -> dict[str, Any]:
+    """Verify selected non-secret Helm values without retaining or reporting the raw values."""
+    validate(value, False)
+    if not isinstance(stored_values, dict):
+        raise ManifestError("Helm stored values must be a JSON object")
+
+    image = stored_values.get("image")
+    if not isinstance(image, dict):
+        raise ManifestError("Helm stored image values do not match approved coordinates")
+    expected = {
+        "repository": IMAGE_REF,
+        "tag": value["imageTag"],
+        "pullPolicy": "Always",
+    }
+    if any(image.get(field) != expected_value for field, expected_value in expected.items()):
+        raise ManifestError("Helm stored image values do not match approved coordinates")
+
+    if environment == "prod":
+        metrics = stored_values.get("metrics", {})
+        service_monitor = stored_values.get("serviceMonitor", {})
+        if (
+            not isinstance(metrics, dict)
+            or not isinstance(service_monitor, dict)
+            or metrics.get("enabled") is True
+            or service_monitor.get("enabled") is True
+            or contains_staging_reference(stored_values)
+        ):
+            raise ManifestError("Helm stored production values contain staging-only settings")
+    return {
+        "check": "helmStoredValues",
+        "passed": True,
+        "details": "stored image coordinates, pull policy, and environment isolation matched approval",
+    }
+
+
+def contains_staging_reference(value: object) -> bool:
+    """Detect known staging-only scalar values without reflecting them in diagnostics."""
+    forbidden = {"METRICS_TOKEN", "dspace-staging-metrics-token", "sugarkube-int"}
+    if isinstance(value, dict):
+        return any(
+            contains_staging_reference(key) or contains_staging_reference(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, list):
+        return any(contains_staging_reference(item) for item in value)
+    return isinstance(value, str) and value in forbidden
 
 
 def staging_gate(candidate_value: dict[str, Any], evidence_value: dict[str, Any]) -> int:
@@ -981,6 +1045,28 @@ def main(argv: list[str] | None = None) -> int:
                 "json",
             ]
             helm = json.loads(_run(helm_command))
+            stored_values_result = None
+            if source["schemaVersion"] == 2:
+                stored_values = json.loads(
+                    _run(
+                        [
+                            "helm",
+                            "--kubeconfig",
+                            args.kubeconfig,
+                            "get",
+                            "values",
+                            args.release,
+                            "--namespace",
+                            args.namespace,
+                            "--all",
+                            "-o",
+                            "json",
+                        ]
+                    )
+                )
+                stored_values_result = verify_helm_stored_values(
+                    source, stored_values, args.environment
+                )
             pod_command = [
                 "kubectl",
                 "--kubeconfig",
@@ -1029,6 +1115,7 @@ def main(argv: list[str] | None = None) -> int:
                 runtime_verification=(
                     _object(args.runtime_verification) if args.runtime_verification else None
                 ),
+                helm_stored_values_result=stored_values_result,
             )
             sidecar = verify_reservation(
                 args.output,

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -17,7 +17,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-UPSTREAM_FIELDS = (
+UPSTREAM_FIELDS_V1 = (
     "schemaVersion",
     "app",
     "applicationVersion",
@@ -28,20 +28,25 @@ UPSTREAM_FIELDS = (
     "chartDigest",
     "semanticTag",
 )
-CANDIDATE_FIELDS = UPSTREAM_FIELDS + (
+UPSTREAM_FIELDS_V2 = UPSTREAM_FIELDS_V1[:4] + ("chartSourceRevision",) + UPSTREAM_FIELDS_V1[4:]
+# Retain the public constants for schema-v1 callers and tests.
+UPSTREAM_FIELDS = UPSTREAM_FIELDS_V1
+CANDIDATE_SUFFIX = (
     "recordType",
     "environment",
     "expectedDefaultChatProvider",
     "approvedAt",
     "approvedBy",
 )
-FINAL_FIELDS = CANDIDATE_FIELDS + (
+FINAL_SUFFIX = (
     "helmRevision",
     "pods",
     "runtimeSourceRevision",
     "runtimeSourceRevisionMethod",
     "verificationResults",
 )
+CANDIDATE_FIELDS = UPSTREAM_FIELDS_V1 + CANDIDATE_SUFFIX
+FINAL_FIELDS = CANDIDATE_FIELDS + FINAL_SUFFIX
 OPTIONAL_FINAL_FIELDS = ("runtimeVerification",)
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
@@ -121,9 +126,30 @@ def _exact_fields(value: dict[str, Any], expected: tuple[str, ...]) -> None:
         raise ManifestError("; ".join(parts))
 
 
+def _upstream_fields(value: dict[str, Any]) -> tuple[str, ...]:
+    version = value.get("schemaVersion")
+    if type(version) is not int or version not in {1, 2}:
+        raise ManifestError("schemaVersion must be integer 1 or 2")
+    return UPSTREAM_FIELDS_V1 if version == 1 else UPSTREAM_FIELDS_V2
+
+
+def candidate_fields(value: dict[str, Any]) -> tuple[str, ...]:
+    return _upstream_fields(value) + CANDIDATE_SUFFIX
+
+
+def _final_fields(value: dict[str, Any]) -> tuple[str, ...]:
+    return candidate_fields(value) + FINAL_SUFFIX
+
+
+def chart_source_revision(value: dict[str, Any]) -> str:
+    """Return explicit v2 chart provenance or the schema-v1 same-source invariant."""
+    return value["sourceRevision"] if value["schemaVersion"] == 1 else value["chartSourceRevision"]
+
+
 def _validate_upstream(value: dict[str, Any]) -> None:
-    if value["schemaVersion"] != 1 or value["app"] != "dspace":
-        raise ManifestError("schemaVersion must be 1 and app must be 'dspace'")
+    _upstream_fields(value)
+    if value["app"] != "dspace":
+        raise ManifestError("app must be 'dspace'")
     if not isinstance(value["applicationVersion"], str) or not SEMVER_RE.fullmatch(
         value["applicationVersion"]
     ):
@@ -131,6 +157,9 @@ def _validate_upstream(value: dict[str, Any]) -> None:
     sha = value["sourceRevision"]
     if not isinstance(sha, str) or not SHA_RE.fullmatch(sha):
         raise ManifestError("sourceRevision must be a full 40-character lowercase Git SHA")
+    chart_sha = chart_source_revision(value)
+    if not isinstance(chart_sha, str) or not SHA_RE.fullmatch(chart_sha):
+        raise ManifestError("chartSourceRevision must be a full 40-character lowercase Git SHA")
     tag = value["imageTag"]
     match = IMAGE_TAG_RE.fullmatch(tag) if isinstance(tag, str) else None
     if not match:
@@ -153,7 +182,7 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
     record_type = value.get("recordType")
     if finalized is None:
         finalized = record_type == "final"
-    expected = FINAL_FIELDS if finalized else CANDIDATE_FIELDS
+    expected = _final_fields(value) if finalized else candidate_fields(value)
     if finalized and "runtimeVerification" in value:
         expected += OPTIONAL_FINAL_FIELDS
     _exact_fields(value, expected)
@@ -279,9 +308,7 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
         elif checks & RUNTIME_VERIFICATION_CHECKS:
             raise ManifestError("runtime verification results require runtimeVerification proof")
         if sorted(platform_indices) != list(range(len(platform_indices))):
-            raise ManifestError(
-                "image platform verification indices must be contiguous from zero"
-            )
+            raise ManifestError("image platform verification indices must be contiguous from zero")
         if not platform_indices:
             raise ManifestError("at least one image platform verification result is required")
     return value
@@ -302,9 +329,7 @@ def _write_new(path: Path, value: dict[str, Any]) -> None:
         try:
             os.link(temporary, path)
         except FileExistsError as exc:
-            raise ManifestError(
-                f"refusing to overwrite existing record: {path}"
-            ) from exc
+            raise ManifestError(f"refusing to overwrite existing record: {path}") from exc
         _sync_directory(path.parent)
     finally:
         Path(temporary).unlink(missing_ok=True)
@@ -357,9 +382,7 @@ def reserve(
     try:
         fd = os.open(sidecar, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     except FileExistsError as exc:
-        raise ManifestError(
-            f"evidence destination is already reserved: {sidecar}"
-        ) from exc
+        raise ManifestError(f"evidence destination is already reserved: {sidecar}") from exc
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as stream:
             stream.write(_canonical(metadata))
@@ -395,9 +418,7 @@ def verify_reservation(
     if not secrets.compare_digest(
         json.dumps(metadata, sort_keys=True), json.dumps(expected, sort_keys=True)
     ):
-        raise ManifestError(
-            "reservation ownership or deployment coordinates do not match"
-        )
+        raise ManifestError("reservation ownership or deployment coordinates do not match")
     if normalized.exists():
         raise ManifestError(f"refusing to overwrite existing record: {normalized}")
     return sidecar
@@ -410,9 +431,10 @@ def candidate(
     approved_at: str,
     approved_by: str,
 ) -> dict[str, Any]:
-    _exact_fields(upstream, UPSTREAM_FIELDS)
+    _exact_fields(upstream, _upstream_fields(upstream))
     _validate_upstream(upstream)
-    result = {field: upstream[field] for field in UPSTREAM_FIELDS}
+    fields = _upstream_fields(upstream)
+    result = {field: upstream[field] for field in fields}
     result.update(
         recordType="candidate",
         environment=environment,
@@ -536,7 +558,7 @@ def preflight(
     checks = (
         ("imageDigest", image_digest, value["imageDigest"]),
         ("chartDigest", chart_digest, value["chartDigest"]),
-        ("chartSourceRevision", chart_revision, value["sourceRevision"]),
+        ("chartSourceRevision", chart_revision, chart_source_revision(value)),
     )
     results = [
         {
@@ -757,8 +779,7 @@ def finalize(
             # Helm metadata proves name/version, not immutable OCI content. The
             # guarded mutation therefore installs this approved digest directly.
             "details": (
-                f"chart=dspace; version={chart_version}; "
-                f"coordinate={chart_coordinate(value)}"
+                f"chart=dspace; version={chart_version}; " f"coordinate={chart_coordinate(value)}"
             ),
         },
         {
@@ -812,6 +833,7 @@ def staging_gate(candidate_value: dict[str, Any], evidence_value: dict[str, Any]
     coordinates = (
         "applicationVersion",
         "sourceRevision",
+        "chartSourceRevision",
         "imageTag",
         "imageDigest",
         "chartVersion",
@@ -819,7 +841,19 @@ def staging_gate(candidate_value: dict[str, Any], evidence_value: dict[str, Any]
         "semanticTag",
         "expectedDefaultChatProvider",
     )
-    if any(candidate_value[field] != evidence_value[field] for field in coordinates):
+    if any(
+        (
+            chart_source_revision(candidate_value)
+            if field == "chartSourceRevision"
+            else candidate_value[field]
+        )
+        != (
+            chart_source_revision(evidence_value)
+            if field == "chartSourceRevision"
+            else evidence_value[field]
+        )
+        for field in coordinates
+    ):
         raise ManifestError("manifest/evidence mismatch: staging and prod coordinates differ")
     if "runtimeVerification" not in evidence_value:
         raise ManifestError("staging evidence lacks mandatory runtime verification")
@@ -860,9 +894,7 @@ def main(argv: list[str] | None = None) -> int:
     finish.add_argument("--image-ref", default=IMAGE_REF)
     finish.add_argument("--chart-ref", default=CHART_REF)
     finish.add_argument("--reservation", required=True)
-    finish.add_argument(
-        "--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras")
-    )
+    finish.add_argument("--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
     finish.add_argument("--runtime-verification", type=Path)
     gate = sub.add_parser("staging-gate")
     gate.add_argument("--manifest", type=Path, required=True)
@@ -1021,10 +1053,9 @@ def main(argv: list[str] | None = None) -> int:
                     metadata.get("version"),
                 )
 
-            if (
-                binding_fields(settled_helm) != binding_fields(helm)
-                or binding_fields(stable_helm) != binding_fields(helm)
-            ):
+            if binding_fields(settled_helm) != binding_fields(helm) or binding_fields(
+                stable_helm
+            ) != binding_fields(helm):
                 raise ManifestError("Helm release changed during evidence collection")
             _write_new(args.output, result)
             sidecar.unlink()
@@ -1033,9 +1064,7 @@ def main(argv: list[str] | None = None) -> int:
             print(staging_gate(_object(args.manifest), _object(args.staging_evidence)))
         elif args.command == "check-output":
             if args.output.exists():
-                raise ManifestError(
-                    f"refusing to overwrite existing record: {args.output}"
-                )
+                raise ManifestError(f"refusing to overwrite existing record: {args.output}")
         elif args.command == "reserve":
             sys.stdout.write(
                 reserve(

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -105,7 +105,7 @@ def test_dspace_chart_pins_resolve_staging_and_prod_versions() -> None:
     prod = load_config("dspace", "prod")
 
     assert _first_pin_value(REPO_ROOT / staging["SUGARKUBE_VERSION_FILE"]) == "3.1.0"
-    assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.1"
+    assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.2"
 
 
 def test_dspace_staging_values_enable_authenticated_metrics_servicemonitor() -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -203,7 +203,11 @@ if [[ "$*" == *"get values"* ]]; then
     echo 'Error: Kubernetes cluster unreachable for context sugar-staging' >&2
     exit 1
   fi
-  printf '{{"ingress":{{"host":"%s"}}}}\n' "${{SUGARKUBE_STUB_HELM_HOST:-example.test}}"
+  printf '{{"image":{{"repository":"%s","tag":"%s","pullPolicy":"%s"}},"metrics":{{"enabled":false}},"serviceMonitor":{{"enabled":false}},"ingress":{{"host":"%s"}}}}\n' \
+    "${{SUGARKUBE_STUB_HELM_REPOSITORY:-ghcr.io/democratizedspace/dspace}}" \
+    "${{SUGARKUBE_STUB_HELM_TAG:-main-abcdef0}}" \
+    "${{SUGARKUBE_STUB_HELM_PULL_POLICY:-Always}}" \
+    "${{SUGARKUBE_STUB_HELM_HOST:-example.test}}"
   exit 0
 fi
 if [[ "$*" == show\ chart* ]]; then
@@ -1087,6 +1091,42 @@ spec:
         "bearerTokenSecret" in error
         for error in app_chart.validate_rendered_manifest(invalid_monitor, inputs)
     )
+
+
+@pytest.mark.parametrize("payload", ["data:\n  example: eA==", "stringData:\n  example: synthetic"])
+def test_dspace_render_contract_rejects_secret_resources_without_exposing_contents(
+    payload: str,
+) -> None:
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (), "main-deadbee", ""
+    )
+    rendered = f"kind: Secret\nmetadata:\n  name: rendered-credentials\n{payload}\n"
+    errors = app_chart.validate_rendered_manifest(rendered, inputs)
+    assert any("DSPACE rendered Secret rendered-credentials" in error for error in errors)
+    assert "secret" not in " ".join(errors).replace("Secret", "")
+
+
+def test_dspace_render_contract_allows_secret_references_in_deployment() -> None:
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (), "main-deadbee", ""
+    )
+    rendered = _release_deployment(
+        "dspace",
+        """          env:
+          - name: API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: dspace-production
+                key: token
+---
+kind: Service
+metadata:
+  name: dspace
+  labels:
+    app.kubernetes.io/instance: dspace
+""",
+    )
+    assert app_chart.validate_rendered_manifest(rendered, inputs) == []
 
 
 def test_dspace_resources_require_release_association() -> None:
@@ -2502,30 +2542,27 @@ def test_dspace_oci_deploy_wrapper_propagates_inline_chart_pin(
 
 
 def _write_dspace_candidate(
-    path: Path, environment: str, *, image_digest: str | None = None
+    path: Path, environment: str, *, image_digest: str | None = None, schema_version: int = 1
 ) -> None:
-    path.write_text(
-        json.dumps(
-            {
-                "schemaVersion": 1,
-                "app": "dspace",
-                "applicationVersion": "3.2.0",
-                "sourceRevision": "abcdef0123456789abcdef0123456789abcdef01",
-                "imageTag": "main-abcdef0",
-                "imageDigest": image_digest or "sha256:" + "1" * 64,
-                "chartVersion": "3.1.0" if environment == "staging" else "3.0.2",
-                "chartDigest": "sha256:" + "2" * 64,
-                "semanticTag": "v3.2.0",
-                "recordType": "candidate",
-                "environment": environment,
-                "expectedDefaultChatProvider": "token-place",
-                "approvedAt": "2026-07-26T12:00:00Z",
-                "approvedBy": "synthetic-test-approver",
-            }
-        )
-        + "\n",
-        encoding="utf-8",
-    )
+    record = {
+        "schemaVersion": schema_version,
+        "app": "dspace",
+        "applicationVersion": "3.2.0",
+        "sourceRevision": "abcdef0123456789abcdef0123456789abcdef01",
+        "imageTag": "main-abcdef0",
+        "imageDigest": image_digest or "sha256:" + "1" * 64,
+        "chartVersion": "3.1.0" if environment == "staging" else "3.0.2",
+        "chartDigest": "sha256:" + "2" * 64,
+        "semanticTag": "v3.2.0",
+        "recordType": "candidate",
+        "environment": environment,
+        "expectedDefaultChatProvider": "token-place",
+        "approvedAt": "2026-07-26T12:00:00Z",
+        "approvedBy": "synthetic-test-approver",
+    }
+    if schema_version == 2:
+        record["chartSourceRevision"] = record["sourceRevision"]
+    path.write_text(json.dumps(record) + "\n", encoding="utf-8")
 
 
 def _run_dspace_manifest_rollback(
@@ -2894,6 +2931,26 @@ def test_dspace_guarded_deploy_orders_preflight_mutation_and_finalization(
     collection = next(i for i, line in enumerate(commands) if " status dspace" in line)
     pods = next(i for i, line in enumerate(commands) if " -n dspace get pods" in line)
     assert preflight < mutation < collection < pods
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_schema_v2_stored_value_mismatch_preserves_post_mutation_reservation(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    candidate = tmp_path / "candidate.json"
+    evidence = tmp_path / "evidence.json"
+    _write_dspace_candidate(candidate, "staging", schema_version=2)
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_HELM_TAG"] = "v3.2.0"
+    result = _run_just(
+        ["app-deploy", "dspace", "staging", "main-abcdef0", "", str(candidate), str(evidence)],
+        env,
+    )
+    assert result.returncode != 0
+    assert "Helm stored image values do not match approved coordinates" in result.stderr
+    assert "upgrade " in Path(env["HELM_LOG"]).read_text(encoding="utf-8")
+    assert not evidence.exists()
+    assert Path(str(evidence.resolve()) + ".reservation").exists()
 
 
 @pytest.mark.usefixtures("ensure_just_available")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -189,7 +189,7 @@ if [ "${{1:-}}" = upgrade ]; then
 fi
 if [[ "$*" == *"status dspace --namespace dspace -o json" ]]; then
   chart_version="${{SUGARKUBE_STUB_CHART_VERSION:-3.1.0}}"
-  if [ -z "${{SUGARKUBE_STUB_CHART_VERSION:-}}" ] && [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" = prod ]; then chart_version=3.0.1; fi
+  if [ -z "${{SUGARKUBE_STUB_CHART_VERSION:-}}" ] && [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" = prod ]; then chart_version=3.0.2; fi
   description="$(cat {str(tmp_path / "helm-description")!r} 2>/dev/null || true)"
   revision=7
   if [[ "$*" == *"staging-kubeconfig"* ]]; then
@@ -211,7 +211,7 @@ if [[ "$*" == show\ chart* ]]; then
     version="${{*: -1}}"
     if [[ "$version" == oci://*@sha256:* ]]; then
       version="${{SUGARKUBE_STUB_CHART_VERSION:-3.1.0}}"
-      if [ -z "${{SUGARKUBE_STUB_CHART_VERSION:-}}" ] && [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" = prod ]; then version=3.0.1; fi
+      if [ -z "${{SUGARKUBE_STUB_CHART_VERSION:-}}" ] && [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" = prod ]; then version=3.0.2; fi
     fi
     printf 'apiVersion: v2\nname: dspace\nversion: %s\nappVersion: main-abcdef0\n' "$version"
     exit 0
@@ -1208,7 +1208,7 @@ def test_dspace_production_rejects_staging_metrics_leaks() -> None:
         "dspace",
         "dspace",
         "oci://example/charts/dspace",
-        "3.0.1",
+        "3.0.2",
         (),
         "main-deadbee",
         "democratized.space",
@@ -2513,7 +2513,7 @@ def _write_dspace_candidate(
                 "sourceRevision": "abcdef0123456789abcdef0123456789abcdef01",
                 "imageTag": "main-abcdef0",
                 "imageDigest": image_digest or "sha256:" + "1" * 64,
-                "chartVersion": "3.1.0" if environment == "staging" else "3.0.1",
+                "chartVersion": "3.1.0" if environment == "staging" else "3.0.2",
                 "chartDigest": "sha256:" + "2" * 64,
                 "semanticTag": "v3.2.0",
                 "recordType": "candidate",
@@ -2542,6 +2542,53 @@ def _run_dspace_manifest_rollback(
     env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
     result = _run_just(["dspace-manifest-rollback", *args], env)
     return result, log.read_text(encoding="utf-8").splitlines() if log.exists() else []
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_recovery_staging_config_uses_production_chart_pin(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    source = (REPO_ROOT / "docs/examples/apps/dspace.env").read_text(encoding="utf-8")
+    staging_pin = "SUGARKUBE_VERSION_FILE_STAGING=docs/apps/dspace.staging.version"
+    assert source.count(staging_pin) == 1
+    recovery_config = tmp_path / "recovery-staging.env"
+    recovery_config.write_text(
+        source.replace(
+            staging_pin,
+            "SUGARKUBE_VERSION_FILE_STAGING=docs/apps/dspace.prod.version",
+        ),
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "recovery-staging.json"
+    evidence = tmp_path / "recovery-staging-evidence.json"
+    _write_dspace_candidate(manifest, "staging")
+    candidate = json.loads(manifest.read_text(encoding="utf-8"))
+    candidate["chartVersion"] = "3.0.2"
+    manifest.write_text(json.dumps(candidate) + "\n", encoding="utf-8")
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.0.2"
+
+    result = _run_just(
+        [
+            "app-deploy",
+            "app=dspace",
+            "env=staging",
+            "tag=main-abcdef0",
+            f"config={recovery_config}",
+            f"manifest={manifest}",
+            f"evidence={evidence}",
+            f"smoke_runner={env['DSPACE_SMOKE_RUNNER']}",
+        ],
+        env,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    commands = (tmp_path / "commands.log").read_text(encoding="utf-8")
+    assert "release-manifest preflight" in commands
+    assert "helm template " in commands
+    assert "charts/dspace:3.0.2" in commands
+    assert "docs/examples/dspace.values.staging.yaml" in commands
+    assert "main-abcdef0" in commands
 
 
 @pytest.mark.usefixtures("ensure_just_available")
@@ -3112,12 +3159,12 @@ def test_dspace_prod_verifier_failure_preserves_post_mutation_reservation(
     )
     assert staged.returncode == 0, staged.stderr + staged.stdout
     staging_record = json.loads(staging_evidence.read_text(encoding="utf-8"))
-    staging_record["chartVersion"] = "3.0.1"
+    staging_record["chartVersion"] = "3.0.2"
     staging_evidence.write_text(json.dumps(staging_record) + "\n", encoding="utf-8")
     _write_dspace_candidate(prod_manifest, "prod")
     env = generic_app_stub_env.copy()
     env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
-    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.0.1"
+    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.0.2"
     env["SUGARKUBE_STUB_PROD_VERIFIER_FAIL"] = "1"
     for name in ("helm.log", "commands.log", "runtime-verifier.log"):
         (tmp_path / name).write_text("", encoding="utf-8")

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -50,6 +50,17 @@ def target(environment: str = "staging") -> dict[str, object]:
     return manifest.validate(value, True)
 
 
+def test_schema_v2_final_target_projects_split_provenance_for_rollback() -> None:
+    value = target()
+    value["schemaVersion"] = 2
+    value["chartSourceRevision"] = "1234567890abcdef1234567890abcdef12345678"
+    validated = manifest.validate(value, True)
+    projected = {field: validated[field] for field in manifest.candidate_fields(validated)}
+    projected["recordType"] = "candidate"
+
+    assert manifest.validate(projected, False)["chartSourceRevision"] != projected["sourceRevision"]
+
+
 def verifier_result(**changes: object) -> dict[str, object]:
     value = {
         "schemaVersion": 1,

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -15,9 +15,9 @@ SHA = "abcdef0123456789abcdef0123456789abcdef01"
 DIGEST = "sha256:" + "1" * 64
 
 
-def target(environment: str = "staging") -> dict[str, object]:
+def target(environment: str = "staging", schema_version: int = 1) -> dict[str, object]:
     value = {
-        "schemaVersion": 1,
+        "schemaVersion": schema_version,
         "app": "dspace",
         "applicationVersion": "3.2.0",
         "sourceRevision": SHA,
@@ -43,7 +43,11 @@ def target(environment: str = "staging") -> dict[str, object]:
         "runtimeSourceRevisionMethod": manifest.RUNTIME_METHOD,
         "verificationResults": [],
     }
-    checks = sorted(manifest.FINAL_FIXED_CHECKS) + ["imagePlatformSourceRevision[0]"]
+    if schema_version == 2:
+        value["chartSourceRevision"] = "1234567890abcdef1234567890abcdef12345678"
+    checks = sorted(manifest.required_final_checks(value)) + [
+        "imagePlatformSourceRevision[0]"
+    ]
     value["verificationResults"] = [
         {"check": check, "passed": True, "details": "observed"} for check in checks
     ]
@@ -51,10 +55,7 @@ def target(environment: str = "staging") -> dict[str, object]:
 
 
 def test_schema_v2_final_target_projects_split_provenance_for_rollback() -> None:
-    value = target()
-    value["schemaVersion"] = 2
-    value["chartSourceRevision"] = "1234567890abcdef1234567890abcdef12345678"
-    validated = manifest.validate(value, True)
+    validated = target(schema_version=2)
     projected = {field: validated[field] for field in manifest.candidate_fields(validated)}
     projected["recordType"] = "candidate"
 

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -18,6 +18,7 @@ CHART_DIGEST = "sha256:" + "2" * 64
 PLATFORM_DIGEST = "sha256:" + "3" * 64
 IMAGE_CONFIG_DIGEST = "sha256:" + "4" * 64
 CHART_CONFIG_DIGEST = "sha256:" + "5" * 64
+CHART_SHA = "1234567890abcdef1234567890abcdef12345678"
 
 
 def upstream() -> dict[str, object]:
@@ -32,6 +33,19 @@ def upstream() -> dict[str, object]:
         "chartDigest": CHART_DIGEST,
         "semanticTag": "v3.2.0",
     }
+
+
+def split_upstream() -> dict[str, object]:
+    value = upstream()
+    value["schemaVersion"] = 2
+    value["chartSourceRevision"] = CHART_SHA
+    return value
+
+
+def split_candidate(environment: str = "staging") -> dict[str, object]:
+    return manifest.candidate(
+        split_upstream(), environment, "token-place", "2026-07-26T12:00:00Z", "operator"
+    )
 
 
 def candidate() -> dict[str, object]:
@@ -72,6 +86,50 @@ def test_upstream_import_is_canonical_and_round_trips(tmp_path: Path) -> None:
     assert manifest.validate(loaded) == loaded
     assert output.read_text().endswith("\n")
     assert list(loaded) == list(manifest.CANDIDATE_FIELDS)
+
+
+def test_schema_v2_split_provenance_is_canonical_and_preserved() -> None:
+    value = split_candidate()
+    assert value["chartSourceRevision"] == CHART_SHA
+    assert list(value) == list(manifest.UPSTREAM_FIELDS_V2 + manifest.CANDIDATE_SUFFIX)
+    assert manifest.validate(value) == value
+
+
+def test_versioned_recovery_coordinates_are_exact_and_candidate_consumable() -> None:
+    path = Path("docs/apps/dspace.prod-recovery-coordinates.json")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert value == {
+        "schemaVersion": 2,
+        "app": "dspace",
+        "applicationVersion": "3.0.1",
+        "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+        "chartSourceRevision": "63063e287adb92a4158ce2c8e7d378b73f52c1c5",
+        "imageTag": "main-1a31a56",
+        "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
+        "chartVersion": "3.0.2",
+        "chartDigest": "sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575",
+        "semanticTag": "v3.0.1",
+    }
+    made = manifest.candidate(value, "prod", "openai", "2026-07-31T12:00:00Z", "operator")
+    assert made["imageTag"] == "main-1a31a56"
+    assert made["semanticTag"] == "v3.0.1"
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        lambda value: value.pop("chartSourceRevision"),
+        lambda value: value.update(chartSourceRevision="short"),
+        lambda value: value.update(chartSourceRevision=CHART_SHA.upper()),
+        lambda value: value.update(applicationSourceRevision=SHA),
+        lambda value: value.update(schemaVersion=3),
+    ],
+)
+def test_schema_v2_rejects_missing_malformed_or_unknown_provenance(change) -> None:
+    value = split_upstream()
+    change(value)
+    with pytest.raises(manifest.ManifestError):
+        manifest.candidate(value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator")
 
 
 @pytest.mark.parametrize(
@@ -124,9 +182,12 @@ def test_accepts_strict_semver_prerelease_and_build(version: str) -> None:
     value = upstream()
     value["applicationVersion"] = version
     value["semanticTag"] = f"v{version}"
-    assert manifest.candidate(
-        value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator"
-    )["applicationVersion"] == version
+    assert (
+        manifest.candidate(value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator")[
+            "applicationVersion"
+        ]
+        == version
+    )
 
 
 @pytest.mark.parametrize(
@@ -200,6 +261,25 @@ def test_preflight_checks_exact_descriptors_and_digest_qualified_metadata() -> N
     assert runner.calls[0][-1].endswith(":main-abcdef0")
     assert runner.calls[1][-1] == f"{manifest.IMAGE_REF}@{DIGEST}"
     assert all(":main-abcdef0" not in call[-1] for call in runner.calls[1:])
+
+
+def test_schema_v2_preflight_checks_image_and_chart_provenance_independently() -> None:
+    results = manifest.preflight(
+        split_candidate(),
+        manifest.IMAGE_REF,
+        manifest.CHART_REF,
+        "oras",
+        runner=oras_runner(image_revision=SHA, chart_revision=CHART_SHA),
+    )
+    assert next(item for item in results if item["check"] == "chartSourceRevision")["passed"]
+    with pytest.raises(manifest.ManifestError, match="chartSourceRevision"):
+        manifest.preflight(
+            split_candidate(),
+            manifest.IMAGE_REF,
+            manifest.CHART_REF,
+            "oras",
+            runner=oras_runner(image_revision=CHART_SHA, chart_revision=SHA),
+        )
 
 
 @pytest.mark.parametrize(
@@ -493,6 +573,27 @@ def test_staging_gate_returns_revision_despite_approval_metadata_difference() ->
     assert manifest.staging_gate(production, runtime_final()) == 17
 
 
+def test_schema_v2_finalization_and_staging_gate_preserve_chart_provenance() -> None:
+    staging = split_candidate()
+    final = finalize(
+        value=staging,
+        preflight_results=manifest.preflight(
+            staging,
+            manifest.IMAGE_REF,
+            manifest.CHART_REF,
+            "oras",
+            runner=oras_runner(image_revision=SHA, chart_revision=CHART_SHA),
+        ),
+        runtime_verification=runtime_proof(),
+    )
+    assert final["chartSourceRevision"] == CHART_SHA
+    assert manifest.staging_gate(split_candidate("prod"), final) == 17
+    production = split_candidate("prod")
+    production["chartSourceRevision"] = "0" * 40
+    with pytest.raises(manifest.ManifestError, match="coordinates differ"):
+        manifest.staging_gate(production, final)
+
+
 @pytest.mark.parametrize(
     "field",
     [
@@ -570,9 +671,7 @@ def test_final_validation_requires_every_fixed_check(missing: str) -> None:
 @pytest.mark.parametrize("invalid", ["unknown", "imagePlatformSourceRevision[x]"])
 def test_final_validation_rejects_unknown_or_malformed_checks(invalid: str) -> None:
     value = finalize()
-    value["verificationResults"].append(
-        {"check": invalid, "passed": True, "details": "fabricated"}
-    )
+    value["verificationResults"].append({"check": invalid, "passed": True, "details": "fabricated"})
     with pytest.raises(manifest.ManifestError, match="unknown verification"):
         manifest.validate(value, True)
 
@@ -740,9 +839,7 @@ def test_reservation_is_atomic_and_bound_to_owner(tmp_path: Path) -> None:
     )
     metadata = json.loads(sidecar.read_text(encoding="utf-8"))
     assert metadata["output"] == str(output.resolve())
-    assert metadata["candidateFingerprint"] == manifest._candidate_fingerprint(
-        candidate()
-    )
+    assert metadata["candidateFingerprint"] == manifest._candidate_fingerprint(candidate())
 
 
 def test_reservation_rejects_existing_record_or_reservation(tmp_path: Path) -> None:
@@ -776,9 +873,7 @@ def test_reservation_binds_candidate_output_and_coordinates(tmp_path: Path) -> N
             )
 
 
-def test_post_reservation_failure_preserves_ownership(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_post_reservation_failure_preserves_ownership(tmp_path: Path, monkeypatch) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
     source.write_text(manifest._canonical(candidate()), encoding="utf-8")
@@ -786,9 +881,7 @@ def test_post_reservation_failure_preserves_ownership(
     monkeypatch.setattr(
         manifest,
         "preflight",
-        lambda *args, **kwargs: (_ for _ in ()).throw(
-            manifest.ManifestError("OCI failed")
-        ),
+        lambda *args, **kwargs: (_ for _ in ()).throw(manifest.ManifestError("OCI failed")),
     )
     assert (
         manifest.main(
@@ -965,10 +1058,25 @@ def test_finalize_cli_settling_failure_preserves_reservation(
 
     monkeypatch.setattr(manifest, "_run", run)
     args = [
-        "finalize", "--manifest", str(source), "--output", str(output),
-        "--environment", "staging", "--image-tag", "main-abcdef0",
-        "--chart-version", "3.2.0", "--kubeconfig", "kubeconfig",
-        "--release", "dspace", "--namespace", "dspace", "--reservation", owner,
+        "finalize",
+        "--manifest",
+        str(source),
+        "--output",
+        str(output),
+        "--environment",
+        "staging",
+        "--image-tag",
+        "main-abcdef0",
+        "--chart-version",
+        "3.2.0",
+        "--kubeconfig",
+        "kubeconfig",
+        "--release",
+        "dspace",
+        "--namespace",
+        "dspace",
+        "--reservation",
+        owner,
     ]
     assert manifest.main(args) == 2
     assert not output.exists()
@@ -1010,25 +1118,36 @@ def test_finalize_cli_rejects_changed_helm_binding_and_preserves_reservation(
                     status["info"]["description"] = "another invocation"
             return json.dumps(status)
         resource = command[command.index("get") + 1]
-        return json.dumps(
-            {"items": [pod("dspace-a")]} if resource == "pods" else workloads()
-        )
+        return json.dumps({"items": [pod("dspace-a")]} if resource == "pods" else workloads())
 
     monkeypatch.setattr(manifest, "_run", run)
     args = [
-        "finalize", "--manifest", str(source), "--output", str(output),
-        "--environment", "staging", "--image-tag", "main-abcdef0",
-        "--chart-version", "3.2.0", "--kubeconfig", "kubeconfig",
-        "--release", "dspace", "--namespace", "dspace", "--reservation", owner,
+        "finalize",
+        "--manifest",
+        str(source),
+        "--output",
+        str(output),
+        "--environment",
+        "staging",
+        "--image-tag",
+        "main-abcdef0",
+        "--chart-version",
+        "3.2.0",
+        "--kubeconfig",
+        "kubeconfig",
+        "--release",
+        "dspace",
+        "--namespace",
+        "dspace",
+        "--reservation",
+        owner,
     ]
     assert manifest.main(args) == 2
     assert not output.exists()
     assert manifest.reservation_path(output).exists()
 
 
-def test_public_read_only_and_reservation_dispatch(
-    tmp_path: Path, monkeypatch, capsys
-) -> None:
+def test_public_read_only_and_reservation_dispatch(tmp_path: Path, monkeypatch, capsys) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
     source.write_text(manifest._canonical(candidate()), encoding="utf-8")
@@ -1039,9 +1158,7 @@ def test_public_read_only_and_reservation_dispatch(
         preflight_calls.append(args)
         return real_preflight(*args, **kwargs, runner=oras_runner())
 
-    oci_results = checked_preflight(
-        candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras"
-    )
+    oci_results = checked_preflight(candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras")
     preflight_calls.clear()
     monkeypatch.setattr(manifest, "preflight", checked_preflight)
 
@@ -1122,16 +1239,9 @@ def test_preflight_chart_coordinate_is_not_printed_after_failed_validation(
     monkeypatch.setattr(
         manifest,
         "preflight",
-        lambda *args, **kwargs: real_preflight(
-            *args, **kwargs, runner=oras_runner()
-        ),
+        lambda *args, **kwargs: real_preflight(*args, **kwargs, runner=oras_runner()),
     )
-    assert (
-        manifest.main(
-            ["preflight", "--manifest", str(source), "--print-chart-coordinate"]
-        )
-        == 2
-    )
+    assert manifest.main(["preflight", "--manifest", str(source), "--print-chart-coordinate"]) == 2
     captured = capsys.readouterr()
     assert captured.out == ""
     assert "chartDigest" in captured.err
@@ -1142,10 +1252,11 @@ def test_default_evidence_path_is_stable_and_approval_unique() -> None:
         "deployment-evidence/dspace/staging/main-abcdef0-20260726T120000Z.json"
     )
 
+
 @pytest.mark.parametrize(
     ("change", "message"),
     [
-        (lambda value: value.update(schemaVersion=2), "schemaVersion"),
+        (lambda value: value.update(schemaVersion=3), "schemaVersion"),
         (lambda value: value.update(recordType="final"), "recordType"),
         (lambda value: value.update(approvedAt=1), "approvedAt"),
         (lambda value: value.update(approvedAt="2026-02-30T12:00:00Z"), "valid UTC"),

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -95,6 +95,13 @@ def test_schema_v2_split_provenance_is_canonical_and_preserved() -> None:
     assert manifest.validate(value) == value
 
 
+def test_invalid_upstream_app_fails_closed() -> None:
+    value = upstream()
+    value["app"] = "another-app"
+    with pytest.raises(manifest.ManifestError, match="app must be 'dspace'"):
+        manifest.candidate(value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator")
+
+
 def test_versioned_recovery_coordinates_are_exact_and_candidate_consumable() -> None:
     path = Path("docs/apps/dspace.prod-recovery-coordinates.json")
     value = json.loads(path.read_text(encoding="utf-8"))
@@ -585,6 +592,17 @@ def test_schema_v2_finalization_and_staging_gate_preserve_chart_provenance() -> 
             runner=oras_runner(image_revision=SHA, chart_revision=CHART_SHA),
         ),
         runtime_verification=runtime_proof(),
+        helm_stored_values_result=manifest.verify_helm_stored_values(
+            staging,
+            {
+                "image": {
+                    "repository": manifest.IMAGE_REF,
+                    "tag": staging["imageTag"],
+                    "pullPolicy": "Always",
+                }
+            },
+            "staging",
+        ),
     )
     assert final["chartSourceRevision"] == CHART_SHA
     assert manifest.staging_gate(split_candidate("prod"), final) == 17
@@ -592,6 +610,64 @@ def test_schema_v2_finalization_and_staging_gate_preserve_chart_provenance() -> 
     production["chartSourceRevision"] = "0" * 40
     with pytest.raises(manifest.ManifestError, match="coordinates differ"):
         manifest.staging_gate(production, final)
+
+
+def test_schema_v2_requires_and_round_trips_helm_stored_values_check() -> None:
+    value = split_candidate()
+    with pytest.raises(manifest.ManifestError, match="Helm stored-values verification"):
+        finalize(value=value)
+    final = finalize(
+        value=value,
+        helm_stored_values_result=manifest.verify_helm_stored_values(
+            value,
+            {
+                "image": {
+                    "repository": manifest.IMAGE_REF,
+                    "tag": value["imageTag"],
+                    "pullPolicy": "Always",
+                }
+            },
+            "staging",
+        ),
+    )
+    assert manifest.validate(json.loads(manifest._canonical(final)), True) == final
+
+
+@pytest.mark.parametrize(
+    ("field", "wrong"),
+    [("repository", "example.invalid/dspace"), ("tag", "v3.2.0"), ("pullPolicy", "IfNotPresent")],
+)
+def test_helm_stored_values_reject_image_mismatch(field: str, wrong: str) -> None:
+    value = split_candidate("prod")
+    image = {"repository": manifest.IMAGE_REF, "tag": value["imageTag"], "pullPolicy": "Always"}
+    image[field] = wrong
+    with pytest.raises(manifest.ManifestError, match="stored image values"):
+        manifest.verify_helm_stored_values(value, {"image": image}, "prod")
+
+
+@pytest.mark.parametrize(
+    "leak",
+    [
+        {"metrics": {"enabled": True}},
+        {"serviceMonitor": {"enabled": True}},
+        {"metrics": {"auth": {"existingSecret": "dspace-staging-metrics-token"}}},
+    ],
+)
+def test_helm_stored_values_reject_production_staging_leaks_secret_safely(
+    leak: dict[str, object],
+) -> None:
+    value = split_candidate("prod")
+    stored = {
+        "image": {
+            "repository": manifest.IMAGE_REF,
+            "tag": value["imageTag"],
+            "pullPolicy": "Always",
+        },
+        **leak,
+    }
+    with pytest.raises(manifest.ManifestError, match="staging-only settings") as raised:
+        manifest.verify_helm_stored_values(value, stored, "prod")
+    assert "dspace-staging-metrics-token" not in str(raised.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -633,6 +633,19 @@ def test_schema_v2_requires_and_round_trips_helm_stored_values_check() -> None:
     assert manifest.validate(json.loads(manifest._canonical(final)), True) == final
 
 
+@pytest.mark.parametrize("stored_values", [[], None, "not-an-object"])
+def test_helm_stored_values_reject_non_object_values(stored_values: object) -> None:
+    with pytest.raises(manifest.ManifestError, match="must be a JSON object"):
+        manifest.verify_helm_stored_values(split_candidate("prod"), stored_values, "prod")
+
+
+@pytest.mark.parametrize("image", [None, "not-an-object", []])
+def test_helm_stored_values_reject_missing_or_non_object_image(image: object) -> None:
+    stored_values = {} if image is None else {"image": image}
+    with pytest.raises(manifest.ManifestError, match="stored image values"):
+        manifest.verify_helm_stored_values(split_candidate("prod"), stored_values, "prod")
+
+
 @pytest.mark.parametrize(
     ("field", "wrong"),
     [("repository", "example.invalid/dspace"), ("tag", "v3.2.0"), ("pullPolicy", "IfNotPresent")],
@@ -651,6 +664,7 @@ def test_helm_stored_values_reject_image_mismatch(field: str, wrong: str) -> Non
         {"metrics": {"enabled": True}},
         {"serviceMonitor": {"enabled": True}},
         {"metrics": {"auth": {"existingSecret": "dspace-staging-metrics-token"}}},
+        {"additionalEnv": [{"value": "dspace-staging-metrics-token"}]},
     ],
 )
 def test_helm_stored_values_reject_production_staging_leaks_secret_safely(
@@ -989,16 +1003,22 @@ def test_post_reservation_failure_preserves_ownership(tmp_path: Path, monkeypatc
     assert manifest.reservation_path(output).exists()
 
 
+@pytest.mark.parametrize("schema_version", [1, 2])
 def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path, monkeypatch, schema_version: int
 ) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
-    source.write_text(manifest._canonical(candidate()), encoding="utf-8")
-    owner = manifest.reserve(output, candidate(), "staging", "dspace", "dspace")
+    selected = split_candidate() if schema_version == 2 else candidate()
+    source.write_text(manifest._canonical(selected), encoding="utf-8")
+    owner = manifest.reserve(output, selected, "staging", "dspace", "dspace")
     sidecar = manifest.reservation_path(output)
     oci_results = manifest.preflight(
-        candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras", runner=oras_runner()
+        selected,
+        manifest.IMAGE_REF,
+        manifest.CHART_REF,
+        "oras",
+        runner=oras_runner(chart_revision=CHART_SHA if schema_version == 2 else SHA),
     )
     events = []
 
@@ -1022,6 +1042,17 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
             events.append("cluster-identity")
             return "staging\n"
         if command[0] == "helm":
+            if "get" in command:
+                events.append("helm-stored-values")
+                return json.dumps(
+                    {
+                        "image": {
+                            "repository": manifest.IMAGE_REF,
+                            "tag": selected["imageTag"],
+                            "pullPolicy": "Always",
+                        }
+                    }
+                )
             events.append("helm-status")
             return json.dumps(
                 helm_status(
@@ -1083,10 +1114,14 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
         )
         == 0
     )
-    assert events == [
+    expected_events = [
         "oci-preflight",
         "cluster-identity",
         "helm-status",
+    ]
+    if schema_version == 2:
+        expected_events.append("helm-stored-values")
+    expected_events += [
         "pod-discovery",
         "pod-discovery",
         "helm-status",
@@ -1094,9 +1129,12 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
         "helm-status",
         "atomic-final-write",
     ]
+    assert events == expected_events
     final = manifest.validate(json.loads(output.read_text(encoding="utf-8")), True)
     assert final["helmRevision"] == 17
     assert [item["name"] for item in final["pods"]] == ["dspace-a", "dspace-b"]
+    checks = {item["check"] for item in final["verificationResults"]}
+    assert ("helmStoredValues" in checks) is (schema_version == 2)
     assert not sidecar.exists()
 
 


### PR DESCRIPTION
## Summary

Prepare the repository-side portion of the controlled DSPACE production reconciliation described in #2325.

- Pin the DSPACE production chart to `3.0.2` while retaining image tag `main-1a31a56`.
- Add a machine-readable immutable recovery-coordinate input that is neither approval nor deployment evidence.
- Introduce schema-v2 split provenance so application and chart source revisions are represented and verified independently.
- Preserve schema-v1 compatibility, where chart provenance implicitly equals application provenance.
- Preserve both revisions through candidate generation, staging gates, finalization, evidence, and rollback projection.
- Require schema-v2 finalized evidence to verify bounded Helm stored values.
- Reject rendered Kubernetes `Secret` resources while preserving legitimate production Secret references.
- Expand the reconciliation runbook with recovery-specific staging configuration, secret-safe capture, guarded production promotion, verification, evidence review, freeze-lift criteria, failure handling, and immutable recovery procedures.
- Add focused regression coverage for schema compatibility, malformed provenance and Helm values, staging-reference leakage, rollback projection, and schema-v2 CLI finalization.

## Immutable reconciliation coordinates

- Application version: `3.0.1`
- Application source revision: `1a31a569aff2dbeb238e8c2688b9e85140d2077d`
- Image tag: `main-1a31a56`
- Image digest: `sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401`
- Recovery chart version: `3.0.2`
- Chart source revision: `63063e287adb92a4158ce2c8e7d378b73f52c1c5`
- Chart OCI manifest digest: `sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575`

The downloaded archive checksum `bdc405bfaba7e9bb3e58741209cf0580477739e394ecf76da182a9b4a3fb4d75` is not used as `chartDigest`. The semantic image tag `v3.0.1` remains corroborating metadata only and is never deployed or republished.

## Compatibility and safety

- Schema-v1 records remain valid and retain the implicit invariant `chartSourceRevision == sourceRevision`.
- Schema-v2 records require an explicit, valid `chartSourceRevision`; missing, malformed, unknown, swapped, or mismatched provenance fails closed.
- Image provenance is checked against `sourceRevision`; chart provenance is checked independently against `chartSourceRevision`.
- Runtime and frontend identity continue to match the application source revision.
- Production candidates must match finalized staging evidence across both revisions and every immutable coordinate.
- Schema-v2 finalization transiently verifies computed Helm values and records only bounded, normalized `helmStoredValues` evidence.
- Rollback projection preserves schema version and split chart provenance.
- The recovery runbook uses a temporary staging configuration that selects chart `3.0.2` without changing the repository’s normal staging chart pin.
- Production rendering rejects actual `Secret` resources and staging-only configuration while permitting legitimate production Secret references.

## Operational boundary

This PR prepares and tests repository changes and an operator runbook only. It does not access or mutate a live cluster, publish or retag artifacts, create approval metadata, fabricate finalized evidence, execute the reconciliation, or lift the production Helm freeze.

The runbook requires distinct staging and production kubeconfigs, the executable remote `/chat` smoke runner, finalized staging evidence for the exact coordinates, secret-safe pre-change capture, digest-qualified rendering, guarded deployment recipes, post-rollout verification, bounded failure evidence, and an immutable manifest-based recovery path.

## Verification

Latest head: `402b62ff4c1eb6af3032831110e4113e30641fff`

All relevant latest-head GitHub workflows completed successfully:

- `ci` — 2,292 passed, 21 skipped; Codecov upload completed successfully.
- `Test Suite`
- `Docs`
- `Spellcheck`
- `pi-image` unit and OCI-parity checks

The image-build job was skipped as expected because this PR does not change image source inputs. The refreshed Codecov report confirms that all modified and coverable lines are covered.

Focused verification also completed successfully:

- `tests/test_release_manifest.py` — 194 passed.
- The five-file DSPACE manifest, rollback, recipe, runtime-verifier, and runtime-values suite — 547 passed.
- Production app configuration resolution, Just formatting, diff checks, and scoped secret scanning passed.

Key commands:

~~~bash
python3 -m pytest -q \
  tests/test_release_manifest.py \
  tests/test_manifest_rollback.py \
  tests/test_generic_app_just_recipes.py \
  tests/test_dspace_runtime_verifier.py \
  tests/test_dspace_runtime_values.py

python3 scripts/app_config.py json --app dspace --env prod
just --unstable --fmt --check
git diff --check
git diff main...HEAD | ./scripts/scan-secrets.py
~~~

Separate local reruns of `pre-commit`, `pyspelling`, `linkchecker`, and Helm-based rendering were unavailable in the Codex task environment. The latest-head GitHub documentation and spelling workflows passed. No live-cluster operation or artifact mutation was attempted.

## Operator work remaining

Before #2325 can close, an authorized operator must:

1. Verify the immutable application contract and expected OpenAI-first provider behavior.
2. Supply genuine approval metadata.
3. Deploy and finalize staging evidence for the exact application, image, chart, and both source revisions.
4. Use distinct staging and production kubeconfigs and the executable remote `/chat` smoke runner.
5. Capture bounded, secret-safe pre-change production state and verify the digest-qualified render.
6. Invoke the guarded production promotion recipe.
7. Complete post-rollout identity, health, configuration, stored-values, provenance, and `/chat` verification.
8. Review and preserve finalized production evidence.
9. Lift the Helm freeze only if every required check succeeds; otherwise follow the immutable failure-reconciliation procedure.

Refs #2325

[Codex task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cf15ac8c0832f9cab4b5b259cb521)