### PR TITLE
Prepare controlled DSPACE production reconciliation: add schema-v2 split provenance, recovery coordinates, tests, and runbook (Refs #2325)

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -2,6 +2,147 @@
 
 This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugarkube. The generic `just app-*` recipes are the preferred future path. The `dspace-oci-*` recipes remain compatibility shims and are scheduled for later removal only after the generic flow has been exercised across routine releases.
 
+## Production 3.0.2 reconciliation (Refs #2325)
+
+This repository prepares, but does **not** execute or approve, the one-time reconciliation of the
+intentionally drifted production release. Keep the production Helm freeze in force throughout.
+The version-controlled input `docs/apps/dspace.prod-recovery-coordinates.json` is immutable source
+data, not a candidate, approval, deployment record, or proof. Schema 2 deliberately records the
+application/image revision and recovery-chart revision separately. `v3.0.1` is corroborating
+metadata only; never deploy or republish it. The chart's approved OCI manifest digest is not the
+downloaded archive checksum `bdc405bfaba7e9bb3e58741209cf0580477739e394ecf76da182a9b4a3fb4d75`.
+
+### 1. Repository preparation and operator approval
+
+Start from a clean reviewed checkout. The operator must supply real approval identities and UTC
+times; do not copy the placeholders. Confirm application 3.0.1's immutable configuration contract
+in its source at `1a31a569aff2dbeb238e8c2688b9e85140d2077d` before encoding `openai`. Stop if it
+does not specify the expected OpenAI-first recovery behavior.
+
+```bash
+test "$(cat docs/apps/dspace.prod.version)" = 3.0.2
+test "$(tail -n 1 docs/apps/dspace.prod.tag)" = main-1a31a56
+COORDINATES=docs/apps/dspace.prod-recovery-coordinates.json
+STAGING_KUBECONFIG="$HOME/.kube/config-sugarkube-staging"
+PROD_KUBECONFIG="$HOME/.kube/config-sugarkube-prod"
+DSPACE_SMOKE_RUNNER="$HOME/dspace/scripts/run-remote-chat-smoke.mjs"
+test "$STAGING_KUBECONFIG" != "$PROD_KUBECONFIG"
+test -f "$STAGING_KUBECONFIG" && test -f "$PROD_KUBECONFIG"
+test -x "$DSPACE_SMOKE_RUNNER"
+
+python3 scripts/dspace_release_manifest.py candidate --upstream "$COORDINATES" \
+  --output deployment-candidates/dspace/staging-3.0.2-recovery.json \
+  --environment staging --provider openai \
+  --approved-at '<STAGING-APPROVAL-UTC>' --approved-by '<STAGING-APPROVER>'
+python3 scripts/dspace_release_manifest.py candidate --upstream "$COORDINATES" \
+  --output deployment-candidates/dspace/prod-3.0.2-recovery.json \
+  --environment prod --provider openai \
+  --approved-at '<PRODUCTION-APPROVAL-UTC>' --approved-by '<PRODUCTION-APPROVER>'
+```
+
+Review both candidates and validate them. The generator rejects placeholders that are not valid
+timestamps, but the human approval process remains external to this repository.
+
+### 2. Staging deployment and finalized proof
+
+Deploy staging with the guarded recipe. It performs OCI preflight, digest-qualified rendering,
+reservation, mutation, runtime/frontend identity checks against the **application** revision, and
+the executable remote `/chat` smoke. Preserve its timestamped finalized evidence.
+
+```bash
+STAGING_CANDIDATE=deployment-candidates/dspace/staging-3.0.2-recovery.json
+just app-deploy app=dspace env=staging tag=main-1a31a56 \
+  manifest="$STAGING_CANDIDATE" smoke_runner="$DSPACE_SMOKE_RUNNER" \
+  kubeconfig="$STAGING_KUBECONFIG"
+STAGING_EVIDENCE=$(python3 scripts/dspace_release_manifest.py evidence-path \
+  --manifest "$STAGING_CANDIDATE")
+python3 scripts/dspace_release_manifest.py validate --final --manifest "$STAGING_EVIDENCE"
+just dspace-release-verify env=staging manifest="$STAGING_EVIDENCE" \
+  smoke_runner="$DSPACE_SMOKE_RUNNER" kubeconfig="$STAGING_KUBECONFIG"
+```
+
+Do not proceed unless the final record exactly retains application `3.0.1`, image tag and digest,
+chart `3.0.2` and digest, and both recorded source revisions.
+
+### 3. Read-only production capture and preflight
+
+Create a timestamped, access-restricted evidence directory outside Git. The following capture is
+bounded and avoids Secret objects and Helm values. Review output before sharing it.
+
+```bash
+STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+CAPTURE="$HOME/dspace-prod-reconciliation-$STAMP"
+install -d -m 0700 "$CAPTURE"
+helm --kubeconfig "$PROD_KUBECONFIG" history dspace -n dspace --max 10 -o json >"$CAPTURE/helm-history.json"
+helm --kubeconfig "$PROD_KUBECONFIG" status dspace -n dspace -o json >"$CAPTURE/helm-status.json"
+kubectl --kubeconfig "$PROD_KUBECONFIG" -n dspace get deployment dspace \
+  -o jsonpath='{.metadata.uid}{"\n"}{.spec.template.spec.containers[?(@.name=="dspace")].image}{"\n"}' \
+  >"$CAPTURE/deployment-identity.txt"
+kubectl --kubeconfig "$PROD_KUBECONFIG" -n dspace get pods \
+  -l app.kubernetes.io/name=dspace,app.kubernetes.io/instance=dspace \
+  -o custom-columns=NAME:.metadata.name,UID:.metadata.uid,START:.status.startTime,IMAGE:.spec.containers[?\(@.name=="dspace"\)].image,IMAGEID:.status.containerStatuses[?\(@.name=="dspace"\)].imageID \
+  >"$CAPTURE/pods.txt"
+python3 scripts/dspace_release_manifest.py preflight \
+  --manifest deployment-candidates/dspace/prod-3.0.2-recovery.json \
+  --environment prod --image-tag main-1a31a56 --chart-version 3.0.2
+just dspace-release-verify env=prod \
+  manifest=deployment-candidates/dspace/prod-3.0.2-recovery.json \
+  smoke_runner="$DSPACE_SMOKE_RUNNER" kubeconfig="$PROD_KUBECONFIG"
+```
+
+Also use the existing generic recipe's print/render path and structural checks to review the exact
+digest-qualified chart plus complete production values chain before reservation. It must contain
+no secret values, staging host, staging metrics ServiceMonitor, or staging metrics Secret
+reference; legitimate production Secret references remain allowed. Never run `helm get values
+--all` into shareable evidence.
+
+### 4. Guarded production mutation and verification
+
+Only after an explicit maintenance authorization, staging gate, capture review, and successful
+render may the operator invoke the single guarded mutation. Do not substitute raw `helm upgrade`,
+`helm rollback`, or `kubectl apply`.
+
+```bash
+PROD_CANDIDATE=deployment-candidates/dspace/prod-3.0.2-recovery.json
+just app-promote-prod app=dspace tag=main-1a31a56 manifest="$PROD_CANDIDATE" \
+  staging_evidence="$STAGING_EVIDENCE" smoke_runner="$DSPACE_SMOKE_RUNNER" \
+  kubeconfig="$PROD_KUBECONFIG" staging_kubeconfig="$STAGING_KUBECONFIG"
+PROD_EVIDENCE=$(python3 scripts/dspace_release_manifest.py evidence-path \
+  --manifest "$PROD_CANDIDATE")
+python3 scripts/dspace_release_manifest.py validate --final --manifest "$PROD_EVIDENCE"
+just dspace-release-verify env=prod manifest="$PROD_EVIDENCE" \
+  smoke_runner="$DSPACE_SMOKE_RUNNER" kubeconfig="$PROD_KUBECONFIG"
+```
+
+Review the final record and fresh secret-safe status capture. Helm stored image values, Deployment,
+every ready serving pod and image ID must agree with the immutable image digest; installed chart
+version and OCI provenance must agree with the chart digest and chart revision. Application,
+runtime, frontend, public and direct identity must agree with the application revision. Health,
+configuration, provider behavior, and `/chat` must all pass. Preserve the candidates, finalized
+records, capture directory, reservation/operation identifier, and review decision with timestamps.
+
+Lift the freeze only when finalized production evidence exists, every fixed and runtime check is
+passing, the post-rollout capture is reviewed, and the authorized operator records the separate
+freeze-lift decision. Repository merge, candidate creation, Helm `deployed`, or availability alone
+is insufficient.
+
+### 5. Failure reconciliation and first-reconciliation recovery
+
+On any failure, keep the freeze, preserve the bounded failed evidence/reservation and capture, and
+stop. Inspect the invocation-bound Helm status and current pods before deciding whether mutation
+occurred. There is truthfully no historical finalized production record for revision 8, so it must
+not be fabricated and the manifest rollback command cannot represent that drifted state.
+
+The safe initial recovery is forward reconciliation: after incident review and renewed explicit
+production authorization, use the same immutable production candidate, complete Git-controlled
+production values, staging final evidence, distinct kubeconfigs, and smoke runner to re-run
+`app-promote-prod`; it re-preflights, renders, reserves a new evidence path, mutates, and verifies.
+Never use revision rollback, `--reuse-values`, `v3.0.1`, a mutable coordinate, or staging evidence
+as production evidence. Once a successful finalized production record exists, a later rollback may
+use `just dspace-manifest-rollback` with that **production** record and confirmation
+`dspace:prod:1a31a569aff2dbeb238e8c2688b9e85140d2077d`, producing a new bounded rollback evidence
+record. A failed operation is not a freeze-lift reason.
+
 ## Mandatory release verification
 
 DSPACE staging and production releases are verified against an approved immutable release
@@ -86,7 +227,7 @@ verification uses the same command with `env=prod` and a production candidate or
 | Release | `dspace` |
 | Namespace | `dspace` |
 | App config | `docs/examples/apps/dspace.env` |
-| Chart version pins | Shared/default `docs/apps/dspace.version`; staging `docs/apps/dspace.staging.version` (`3.1.0`); production `docs/apps/dspace.prod.version` (`3.0.1`) |
+| Chart version pins | Shared/default `docs/apps/dspace.version`; staging `docs/apps/dspace.staging.version` (`3.1.0`); production recovery `docs/apps/dspace.prod.version` (`3.0.2`) |
 | Production tag pin | `docs/apps/dspace.prod.tag` |
 | Verify paths | `/config.json`, `/healthz`, `/livez` |
 
@@ -114,7 +255,7 @@ Use these links before changing a deployment so the workflow runs, package versi
 - `env=staging`: HA staging on the staging Sugarkube cluster with host `staging.democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
   The staging overlay injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`, uses chart `3.1.0`, and persists the authenticated metrics ServiceMonitor configuration discovered by kube-prometheus-stack. The metrics bearer value is not committed; operators manage the existing `dspace-staging-metrics-token` Secret out of band.
 - `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
-  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`. Production remains intentionally pinned to the recovered chart `3.0.1` deployment and image `ghcr.io/democratizedspace/dspace:main-1a31a56`; it does not enable metrics or ServiceMonitor settings.
+  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`. Production reconciliation pins recovery chart `3.0.2` and image `ghcr.io/democratizedspace/dspace:main-1a31a56`; it does not enable metrics or ServiceMonitor settings.
 - Optional legacy/canary host `prod.democratized.space` uses `docs/examples/dspace.values.prod-subdomain.yaml`. The `dspace-oci-deploy-prod-subdomain` compatibility command selects the secret-free `docs/examples/apps/dspace-prod-subdomain.env` config, preserving that overlay while routing through the same manifest validation, OCI preflight, Helm deployment, and evidence finalization as the generic production path.
 
 ## Find or publish GHCR image
@@ -364,7 +505,7 @@ For staging, the browser smoke must show DSPACE calling `https://staging.token.p
 
 ## Promote production
 
-This configuration change does not promote or mutate production. Promote only after staging sign-off. Prefer the generic command; it uses the prod values chain, resolves chart `3.0.1` from `docs/apps/dspace.prod.version`, and can read `docs/apps/dspace.prod.tag` (`main-1a31a56`) when `tag=` is omitted.
+This configuration change does not promote or mutate production. Promote only after staging sign-off. Prefer the generic command; it uses the prod values chain, resolves chart `3.0.2` from `docs/apps/dspace.prod.version`, and can read `docs/apps/dspace.prod.tag` (`main-1a31a56`) when `tag=` is omitted.
 
 ```bash
 just app-promote-prod app=dspace tag="$APP_TAG" \
@@ -501,11 +642,10 @@ those target coordinates and identity strings plus a non-empty list of
 including a passing `/chat`. Verifier output and response bodies are not echoed.
 Do not infer frontend identity from the semantic application version.
 
-Real production rollback remains unavailable until DSPACE
-[#4732](https://github.com/democratizedspace/dspace/issues/4732) supplies runtime
-and frontend identity and [#4733](https://github.com/democratizedspace/dspace/issues/4733)
-supplies the remote public-journey verifier contract. Tests use a stub; operators
-must not substitute an availability-only check.
+Production rollback requires an existing finalized production record plus the executable runtime
+and remote-journey verifier contract. During the first reconciliation no truthful record describes
+the drifted revision 8 state; use the forward-reconciliation procedure above rather than inventing
+one or substituting an availability-only check.
 
 If anything fails after reservation, the command exits nonzero, leaves a
 redacted failed evidence record, and warns that cluster state may have changed.

--- a/docs/apps/dspace.prod-recovery-coordinates.json
+++ b/docs/apps/dspace.prod-recovery-coordinates.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 2,
+  "app": "dspace",
+  "applicationVersion": "3.0.1",
+  "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+  "chartSourceRevision": "63063e287adb92a4158ce2c8e7d378b73f52c1c5",
+  "imageTag": "main-1a31a56",
+  "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
+  "chartVersion": "3.0.2",
+  "chartDigest": "sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575",
+  "semanticTag": "v3.0.1"
+}

--- a/docs/apps/dspace.prod.version
+++ b/docs/apps/dspace.prod.version
@@ -1,2 +1,2 @@
-# DSPACE production chart pin. Keep aligned with the recovered production deployment.
-3.0.1
+# DSPACE production recovery chart pin.
+3.0.2

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -494,7 +494,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     # The manifest module's OCI and cluster proof functions deliberately accept
     # candidate records. Project the exact candidate portion of the validated
     # final record rather than reimplementing or weakening those validators.
-    approved = {field: target[field] for field in release.CANDIDATE_FIELDS}
+    approved = {field: target[field] for field in release.candidate_fields(target)}
     approved["recordType"] = "candidate"
     release.validate(approved, False)
     root = REPO_ROOT
@@ -634,6 +634,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "imageTag",
                 "imageDigest",
                 "sourceRevision",
+                *(("chartSourceRevision",) if target["schemaVersion"] == 2 else ()),
                 "applicationVersion",
                 "expectedDefaultChatProvider",
             )

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -28,6 +28,7 @@ UPSTREAM_FIELDS = (
     "chartDigest",
     "semanticTag",
 )
+UPSTREAM_FIELDS_V2 = UPSTREAM_FIELDS[:4] + ("chartSourceRevision",) + UPSTREAM_FIELDS[4:]
 CANDIDATE_FIELDS = UPSTREAM_FIELDS + (
     "recordType",
     "environment",
@@ -35,6 +36,7 @@ CANDIDATE_FIELDS = UPSTREAM_FIELDS + (
     "approvedAt",
     "approvedBy",
 )
+CANDIDATE_FIELDS_V2 = UPSTREAM_FIELDS_V2 + CANDIDATE_FIELDS[len(UPSTREAM_FIELDS) :]
 FINAL_FIELDS = CANDIDATE_FIELDS + (
     "helmRevision",
     "pods",
@@ -42,6 +44,7 @@ FINAL_FIELDS = CANDIDATE_FIELDS + (
     "runtimeSourceRevisionMethod",
     "verificationResults",
 )
+FINAL_FIELDS_V2 = CANDIDATE_FIELDS_V2 + FINAL_FIELDS[len(CANDIDATE_FIELDS) :]
 OPTIONAL_FINAL_FIELDS = ("runtimeVerification",)
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
@@ -121,9 +124,29 @@ def _exact_fields(value: dict[str, Any], expected: tuple[str, ...]) -> None:
         raise ManifestError("; ".join(parts))
 
 
+def _fields(schema_version: Any, finalized: bool | None = None) -> tuple[str, ...]:
+    if type(schema_version) is not int or schema_version not in {1, 2}:
+        raise ManifestError("schemaVersion must be integer 1 or 2")
+    if finalized is None:
+        return UPSTREAM_FIELDS if schema_version == 1 else UPSTREAM_FIELDS_V2
+    if finalized:
+        return FINAL_FIELDS if schema_version == 1 else FINAL_FIELDS_V2
+    return CANDIDATE_FIELDS if schema_version == 1 else CANDIDATE_FIELDS_V2
+
+
+def chart_source_revision(value: dict[str, Any]) -> str:
+    """Return explicit v2 chart provenance or the implicit v1 same-source value."""
+    return value["sourceRevision"] if value["schemaVersion"] == 1 else value["chartSourceRevision"]
+
+
+def candidate_fields(value: dict[str, Any]) -> tuple[str, ...]:
+    """Return the canonical candidate fields for a validated schema version."""
+    return _fields(value.get("schemaVersion"), False)
+
+
 def _validate_upstream(value: dict[str, Any]) -> None:
-    if value["schemaVersion"] != 1 or value["app"] != "dspace":
-        raise ManifestError("schemaVersion must be 1 and app must be 'dspace'")
+    if value["app"] != "dspace":
+        raise ManifestError("app must be 'dspace'")
     if not isinstance(value["applicationVersion"], str) or not SEMVER_RE.fullmatch(
         value["applicationVersion"]
     ):
@@ -131,6 +154,9 @@ def _validate_upstream(value: dict[str, Any]) -> None:
     sha = value["sourceRevision"]
     if not isinstance(sha, str) or not SHA_RE.fullmatch(sha):
         raise ManifestError("sourceRevision must be a full 40-character lowercase Git SHA")
+    chart_sha = chart_source_revision(value)
+    if not isinstance(chart_sha, str) or not SHA_RE.fullmatch(chart_sha):
+        raise ManifestError("chartSourceRevision must be a full 40-character lowercase Git SHA")
     tag = value["imageTag"]
     match = IMAGE_TAG_RE.fullmatch(tag) if isinstance(tag, str) else None
     if not match:
@@ -153,7 +179,9 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
     record_type = value.get("recordType")
     if finalized is None:
         finalized = record_type == "final"
-    expected = FINAL_FIELDS if finalized else CANDIDATE_FIELDS
+    expected = _fields(value.get("schemaVersion"), finalized)
+    if value["schemaVersion"] == 2 and "chartSourceRevision" not in value:
+        raise ManifestError("schemaVersion 2 requires chartSourceRevision")
     if finalized and "runtimeVerification" in value:
         expected += OPTIONAL_FINAL_FIELDS
     _exact_fields(value, expected)
@@ -279,9 +307,7 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
         elif checks & RUNTIME_VERIFICATION_CHECKS:
             raise ManifestError("runtime verification results require runtimeVerification proof")
         if sorted(platform_indices) != list(range(len(platform_indices))):
-            raise ManifestError(
-                "image platform verification indices must be contiguous from zero"
-            )
+            raise ManifestError("image platform verification indices must be contiguous from zero")
         if not platform_indices:
             raise ManifestError("at least one image platform verification result is required")
     return value
@@ -302,9 +328,7 @@ def _write_new(path: Path, value: dict[str, Any]) -> None:
         try:
             os.link(temporary, path)
         except FileExistsError as exc:
-            raise ManifestError(
-                f"refusing to overwrite existing record: {path}"
-            ) from exc
+            raise ManifestError(f"refusing to overwrite existing record: {path}") from exc
         _sync_directory(path.parent)
     finally:
         Path(temporary).unlink(missing_ok=True)
@@ -357,9 +381,7 @@ def reserve(
     try:
         fd = os.open(sidecar, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     except FileExistsError as exc:
-        raise ManifestError(
-            f"evidence destination is already reserved: {sidecar}"
-        ) from exc
+        raise ManifestError(f"evidence destination is already reserved: {sidecar}") from exc
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as stream:
             stream.write(_canonical(metadata))
@@ -395,9 +417,7 @@ def verify_reservation(
     if not secrets.compare_digest(
         json.dumps(metadata, sort_keys=True), json.dumps(expected, sort_keys=True)
     ):
-        raise ManifestError(
-            "reservation ownership or deployment coordinates do not match"
-        )
+        raise ManifestError("reservation ownership or deployment coordinates do not match")
     if normalized.exists():
         raise ManifestError(f"refusing to overwrite existing record: {normalized}")
     return sidecar
@@ -410,9 +430,10 @@ def candidate(
     approved_at: str,
     approved_by: str,
 ) -> dict[str, Any]:
-    _exact_fields(upstream, UPSTREAM_FIELDS)
+    fields = _fields(upstream.get("schemaVersion"))
+    _exact_fields(upstream, fields)
     _validate_upstream(upstream)
-    result = {field: upstream[field] for field in UPSTREAM_FIELDS}
+    result = {field: upstream[field] for field in fields}
     result.update(
         recordType="candidate",
         environment=environment,
@@ -536,7 +557,7 @@ def preflight(
     checks = (
         ("imageDigest", image_digest, value["imageDigest"]),
         ("chartDigest", chart_digest, value["chartDigest"]),
-        ("chartSourceRevision", chart_revision, value["sourceRevision"]),
+        ("chartSourceRevision", chart_revision, chart_source_revision(value)),
     )
     results = [
         {
@@ -736,7 +757,10 @@ def finalize(
         {
             "check": "selectedCoordinates",
             "passed": True,
-            "details": f"environment={environment}; imageTag={image_tag}; chartVersion={chart_version}",
+            "details": (
+                f"environment={environment}; imageTag={image_tag}; "
+                f"chartVersion={chart_version}"
+            ),
         },
         {
             "check": "clusterEnvironment",
@@ -757,8 +781,7 @@ def finalize(
             # Helm metadata proves name/version, not immutable OCI content. The
             # guarded mutation therefore installs this approved digest directly.
             "details": (
-                f"chart=dspace; version={chart_version}; "
-                f"coordinate={chart_coordinate(value)}"
+                f"chart=dspace; version={chart_version}; " f"coordinate={chart_coordinate(value)}"
             ),
         },
         {
@@ -819,6 +842,10 @@ def staging_gate(candidate_value: dict[str, Any], evidence_value: dict[str, Any]
         "semanticTag",
         "expectedDefaultChatProvider",
     )
+    if candidate_value["schemaVersion"] != evidence_value["schemaVersion"]:
+        raise ManifestError("manifest/evidence mismatch: schema versions differ")
+    if chart_source_revision(candidate_value) != chart_source_revision(evidence_value):
+        raise ManifestError("manifest/evidence mismatch: chart source revisions differ")
     if any(candidate_value[field] != evidence_value[field] for field in coordinates):
         raise ManifestError("manifest/evidence mismatch: staging and prod coordinates differ")
     if "runtimeVerification" not in evidence_value:
@@ -860,9 +887,7 @@ def main(argv: list[str] | None = None) -> int:
     finish.add_argument("--image-ref", default=IMAGE_REF)
     finish.add_argument("--chart-ref", default=CHART_REF)
     finish.add_argument("--reservation", required=True)
-    finish.add_argument(
-        "--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras")
-    )
+    finish.add_argument("--oras-command", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
     finish.add_argument("--runtime-verification", type=Path)
     gate = sub.add_parser("staging-gate")
     gate.add_argument("--manifest", type=Path, required=True)
@@ -1021,10 +1046,9 @@ def main(argv: list[str] | None = None) -> int:
                     metadata.get("version"),
                 )
 
-            if (
-                binding_fields(settled_helm) != binding_fields(helm)
-                or binding_fields(stable_helm) != binding_fields(helm)
-            ):
+            if binding_fields(settled_helm) != binding_fields(helm) or binding_fields(
+                stable_helm
+            ) != binding_fields(helm):
                 raise ManifestError("Helm release changed during evidence collection")
             _write_new(args.output, result)
             sidecar.unlink()
@@ -1033,9 +1057,7 @@ def main(argv: list[str] | None = None) -> int:
             print(staging_gate(_object(args.manifest), _object(args.staging_evidence)))
         elif args.command == "check-output":
             if args.output.exists():
-                raise ManifestError(
-                    f"refusing to overwrite existing record: {args.output}"
-                )
+                raise ManifestError(f"refusing to overwrite existing record: {args.output}")
         elif args.command == "reserve":
             sys.stdout.write(
                 reserve(

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -105,7 +105,7 @@ def test_dspace_chart_pins_resolve_staging_and_prod_versions() -> None:
     prod = load_config("dspace", "prod")
 
     assert _first_pin_value(REPO_ROOT / staging["SUGARKUBE_VERSION_FILE"]) == "3.1.0"
-    assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.1"
+    assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.2"
 
 
 def test_dspace_staging_values_enable_authenticated_metrics_servicemonitor() -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -189,7 +189,7 @@ if [ "${{1:-}}" = upgrade ]; then
 fi
 if [[ "$*" == *"status dspace --namespace dspace -o json" ]]; then
   chart_version="${{SUGARKUBE_STUB_CHART_VERSION:-3.1.0}}"
-  if [ -z "${{SUGARKUBE_STUB_CHART_VERSION:-}}" ] && [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" = prod ]; then chart_version=3.0.1; fi
+  if [ -z "${{SUGARKUBE_STUB_CHART_VERSION:-}}" ] && [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" = prod ]; then chart_version=3.0.2; fi
   description="$(cat {str(tmp_path / "helm-description")!r} 2>/dev/null || true)"
   revision=7
   if [[ "$*" == *"staging-kubeconfig"* ]]; then
@@ -211,7 +211,7 @@ if [[ "$*" == show\ chart* ]]; then
     version="${{*: -1}}"
     if [[ "$version" == oci://*@sha256:* ]]; then
       version="${{SUGARKUBE_STUB_CHART_VERSION:-3.1.0}}"
-      if [ -z "${{SUGARKUBE_STUB_CHART_VERSION:-}}" ] && [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" = prod ]; then version=3.0.1; fi
+      if [ -z "${{SUGARKUBE_STUB_CHART_VERSION:-}}" ] && [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" = prod ]; then version=3.0.2; fi
     fi
     printf 'apiVersion: v2\nname: dspace\nversion: %s\nappVersion: main-abcdef0\n' "$version"
     exit 0
@@ -921,8 +921,7 @@ def test_values_null_overlay_clears_inherited_scalars(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     overlay.write_text(
-        "ingress:\n  enabled: false\n  host: null\n"
-        "metrics:\n  auth:\n    existingSecret: ~\n",
+        "ingress:\n  enabled: false\n  host: null\n" "metrics:\n  auth:\n    existingSecret: ~\n",
         encoding="utf-8",
     )
     values = (str(base), str(overlay))
@@ -935,9 +934,7 @@ def test_values_null_overlay_clears_inherited_scalars(tmp_path: Path) -> None:
 def test_parent_null_overlay_clears_inherited_ingress(tmp_path: Path, null_value: str) -> None:
     base = tmp_path / "base.yaml"
     overlay = tmp_path / "overlay.yaml"
-    base.write_text(
-        "ingress:\n  enabled: true\n  host: inherited.example.test\n", encoding="utf-8"
-    )
+    base.write_text("ingress:\n  enabled: true\n  host: inherited.example.test\n", encoding="utf-8")
     overlay.write_text(f"ingress: {null_value}\n", encoding="utf-8")
 
     assert app_chart.expected_ingress_host((str(base), str(overlay)), "") == ""
@@ -988,8 +985,14 @@ def test_dspace_null_overlay_metrics_is_render_safe(tmp_path: Path, null_value: 
     )
     overlay.write_text(f"metrics: {null_value}\n", encoding="utf-8")
     inputs = app_chart.ReleaseInputs(
-        "dspace", "staging", "dspace", "dspace", "chart", "1.0.0",
-        (str(base), str(overlay)), "main-deadbee",
+        "dspace",
+        "staging",
+        "dspace",
+        "dspace",
+        "chart",
+        "1.0.0",
+        (str(base), str(overlay)),
+        "main-deadbee",
     )
 
     assert app_chart.validate_dspace_values("", inputs) == []
@@ -1091,14 +1094,23 @@ spec:
 
 def test_dspace_resources_require_release_association() -> None:
     inputs = app_chart.ReleaseInputs(
-        "dspace", "staging", "dspace", "dspace", "chart", "3.1.0", (),
-        "main-deadbee", "staging.democratized.space",
+        "dspace",
+        "staging",
+        "dspace",
+        "dspace",
+        "chart",
+        "3.1.0",
+        (),
+        "main-deadbee",
+        "staging.democratized.space",
     )
-    manifest = _generic_manifest(
-        release="dspace",
-        image_container="dspace",
-        labels="    app.kubernetes.io/instance: another-release",
-    ) + """---
+    manifest = (
+        _generic_manifest(
+            release="dspace",
+            image_container="dspace",
+            labels="    app.kubernetes.io/instance: another-release",
+        )
+        + """---
 kind: Service
 metadata:
   name: dspace
@@ -1119,6 +1131,7 @@ spec:
         name: dspace-staging-metrics-token
         key: token
 """
+    )
 
     errors = app_chart.validate_rendered_manifest(manifest, inputs)
     assert "DSPACE intended Service did not render" in errors
@@ -1128,7 +1141,13 @@ spec:
 
 def test_dspace_servicemonitor_requires_every_endpoint_authentication() -> None:
     inputs = app_chart.ReleaseInputs(
-        "dspace", "staging", "dspace", "dspace", "chart", "3.1.0", (),
+        "dspace",
+        "staging",
+        "dspace",
+        "dspace",
+        "chart",
+        "3.1.0",
+        (),
         "main-deadbee",
     )
     manifest = """kind: ServiceMonitor
@@ -1160,8 +1179,14 @@ def test_dspace_servicemonitor_uses_rendered_default_token_key(tmp_path: Path) -
         encoding="utf-8",
     )
     inputs = app_chart.ReleaseInputs(
-        "dspace", "staging", "dspace", "dspace", "chart", "3.1.0",
-        (str(values),), "main-deadbee",
+        "dspace",
+        "staging",
+        "dspace",
+        "dspace",
+        "chart",
+        "3.1.0",
+        (str(values),),
+        "main-deadbee",
     )
     manifest = """kind: ServiceMonitor
 metadata:
@@ -1185,8 +1210,14 @@ def test_dspace_values_ignore_unrelated_servicemonitor(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     inputs = app_chart.ReleaseInputs(
-        "dspace", "staging", "dspace", "dspace", "chart", "3.1.0",
-        (str(values),), "main-deadbee",
+        "dspace",
+        "staging",
+        "dspace",
+        "dspace",
+        "chart",
+        "3.1.0",
+        (str(values),),
+        "main-deadbee",
     )
     unrelated = """kind: ServiceMonitor
 metadata:
@@ -1208,7 +1239,7 @@ def test_dspace_production_rejects_staging_metrics_leaks() -> None:
         "dspace",
         "dspace",
         "oci://example/charts/dspace",
-        "3.0.1",
+        "3.0.2",
         (),
         "main-deadbee",
         "democratized.space",
@@ -1241,25 +1272,33 @@ data:
     )
 
 
-@pytest.mark.parametrize(
-    "leak", ["METRICS_TOKEN", "dspace-staging-metrics-token", "sugarkube-int"]
-)
+@pytest.mark.parametrize("leak", ["METRICS_TOKEN", "dspace-staging-metrics-token", "sugarkube-int"])
 def test_dspace_production_checks_only_release_associated_structure(leak: str) -> None:
     inputs = app_chart.ReleaseInputs(
-        "dspace", "prod", "dspace", "dspace", "chart", "3.1.0", (),
-        "main-deadbee", "democratized.space",
+        "dspace",
+        "prod",
+        "dspace",
+        "dspace",
+        "chart",
+        "3.1.0",
+        (),
+        "main-deadbee",
+        "democratized.space",
     )
-    base = _generic_manifest(
-        release="dspace",
-        image_container="dspace",
-        host="democratized.space",
-        labels="    app.kubernetes.io/instance: dspace",
-    ) + """---
+    base = (
+        _generic_manifest(
+            release="dspace",
+            image_container="dspace",
+            host="democratized.space",
+            labels="    app.kubernetes.io/instance: dspace",
+        )
+        + """---
 kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: dspace
 """
+    )
     unrelated = base + f"""---
 # {leak}
 kind: ConfigMap
@@ -1664,9 +1703,7 @@ spec:
             - name: TOKENPLACE_IMAGE_TAG
 """
 
-    assert app_chart.deployment_app_container_env_sets(
-        manifest, "tokenplace", "tokenplace"
-    ) == []
+    assert app_chart.deployment_app_container_env_sets(manifest, "tokenplace", "tokenplace") == []
 
 
 def test_app_chart_cmd_preflight_rejects_metadata_from_unrelated_deployment(
@@ -2513,7 +2550,7 @@ def _write_dspace_candidate(
                 "sourceRevision": "abcdef0123456789abcdef0123456789abcdef01",
                 "imageTag": "main-abcdef0",
                 "imageDigest": image_digest or "sha256:" + "1" * 64,
-                "chartVersion": "3.1.0" if environment == "staging" else "3.0.1",
+                "chartVersion": "3.1.0" if environment == "staging" else "3.0.2",
                 "chartDigest": "sha256:" + "2" * 64,
                 "semanticTag": "v3.2.0",
                 "recordType": "candidate",
@@ -2697,9 +2734,7 @@ def test_dspace_release_verify_ignores_runtime_verifier_override(
     assert not marker.exists()
     invocations = Path(env["RUNTIME_VERIFIER_LOG"]).read_text(encoding="utf-8").splitlines()
     assert len(invocations) == 1
-    assert invocations[0].startswith(
-        f"{REPO_ROOT / 'scripts/dspace_runtime_verifier.py'} verify "
-    )
+    assert invocations[0].startswith(f"{REPO_ROOT / 'scripts/dspace_runtime_verifier.py'} verify ")
 
 
 @pytest.mark.parametrize(
@@ -2765,9 +2800,7 @@ def test_dspace_release_verify_normalizes_public_arguments(
     result = _run_just(["dspace-release-verify", *arguments], generic_app_stub_env)
 
     assert result.returncode == 0, result.stderr + result.stdout
-    invocation = Path(generic_app_stub_env["RUNTIME_VERIFIER_LOG"]).read_text(
-        encoding="utf-8"
-    )
+    invocation = Path(generic_app_stub_env["RUNTIME_VERIFIER_LOG"]).read_text(encoding="utf-8")
     argv = invocation.split()
     required = {
         "--environment": values["env"],
@@ -2901,14 +2934,15 @@ def test_dspace_staging_wrappers_route_sparse_named_arguments_once(
     )
 
     assert result.returncode == 0, result.stderr + result.stdout
-    verifier_lines = Path(generic_app_stub_env["RUNTIME_VERIFIER_LOG"]).read_text(
-        encoding="utf-8"
-    ).splitlines()
+    verifier_lines = (
+        Path(generic_app_stub_env["RUNTIME_VERIFIER_LOG"]).read_text(encoding="utf-8").splitlines()
+    )
     assert len(verifier_lines) == 1
     assert verifier_lines[0].count(f"--manifest {manifest}") == 1
-    assert verifier_lines[0].count(
-        f"--smoke-runner {generic_app_stub_env['DSPACE_SMOKE_RUNNER']}"
-    ) == 1
+    assert (
+        verifier_lines[0].count(f"--smoke-runner {generic_app_stub_env['DSPACE_SMOKE_RUNNER']}")
+        == 1
+    )
 
 
 @pytest.mark.usefixtures("ensure_just_available")
@@ -3107,7 +3141,15 @@ def test_dspace_prod_verifier_failure_preserves_post_mutation_reservation(
     prod_evidence = tmp_path / "prod-evidence.json"
     _write_dspace_candidate(staging_manifest, "staging")
     staged = _run_just(
-        ["app-deploy", "dspace", "staging", "main-abcdef0", "", str(staging_manifest), str(staging_evidence)],
+        [
+            "app-deploy",
+            "dspace",
+            "staging",
+            "main-abcdef0",
+            "",
+            str(staging_manifest),
+            str(staging_evidence),
+        ],
         generic_app_stub_env,
     )
     assert staged.returncode == 0, staged.stderr + staged.stdout
@@ -3147,9 +3189,7 @@ def test_dspace_prod_verifier_failure_preserves_post_mutation_reservation(
     assert not prod_evidence.exists()
     assert Path(str(prod_evidence.resolve()) + ".reservation").exists()
     assert not any(
-        word in line.lower()
-        for line in commands
-        for word in ("rollback", "downgrade", "retry")
+        word in line.lower() for line in commands for word in ("rollback", "downgrade", "retry")
     )
 
 
@@ -4797,9 +4837,7 @@ def test_public_helm_helper_rejects_mutation_marker_without_altering_file(
         "description=public helper boundary test",
         "app=tokenplace",
     ]
-    result = _run_just(
-        [recipe, *public_args, f"mutation_marker={marker}"], generic_app_stub_env
-    )
+    result = _run_just([recipe, *public_args, f"mutation_marker={marker}"], generic_app_stub_env)
 
     assert result.returncode != 0
     assert "justfile does not contain recipe" in result.stderr.casefold()

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -50,6 +50,13 @@ def target(environment: str = "staging") -> dict[str, object]:
     return manifest.validate(value, True)
 
 
+def test_schema_v2_final_target_preserves_split_chart_provenance() -> None:
+    value = target()
+    value["schemaVersion"] = 2
+    value["chartSourceRevision"] = "0123456789abcdef0123456789abcdef01234567"
+    assert manifest.validate(value, True)["chartSourceRevision"] != value["sourceRevision"]
+
+
 def verifier_result(**changes: object) -> dict[str, object]:
     value = {
         "schemaVersion": 1,

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -13,6 +13,7 @@ import pytest
 from scripts import dspace_release_manifest as manifest
 
 SHA = "abcdef0123456789abcdef0123456789abcdef01"
+CHART_SHA = "0123456789abcdef0123456789abcdef01234567"
 DIGEST = "sha256:" + "1" * 64
 CHART_DIGEST = "sha256:" + "2" * 64
 PLATFORM_DIGEST = "sha256:" + "3" * 64
@@ -42,6 +43,69 @@ def candidate() -> dict[str, object]:
         "2026-07-26T12:00:00Z",
         "synthetic-test-approver",
     )
+
+
+def split_upstream() -> dict[str, object]:
+    value = upstream()
+    value["schemaVersion"] = 2
+    value["chartSourceRevision"] = CHART_SHA
+    return value
+
+
+def split_candidate(environment: str = "staging") -> dict[str, object]:
+    return manifest.candidate(
+        split_upstream(), environment, "openai", "2026-07-26T12:00:00Z", "test-approver"
+    )
+
+
+def test_schema_v1_implicitly_retains_same_source_provenance() -> None:
+    value = candidate()
+    assert manifest.validate(value) == value
+    assert manifest.chart_source_revision(value) == SHA
+    assert "chartSourceRevision" not in value
+
+
+def test_schema_v2_split_provenance_is_canonical_and_preserved() -> None:
+    value = split_candidate()
+    assert manifest.validate(value) == value
+    assert list(value) == list(manifest.CANDIDATE_FIELDS_V2)
+    assert value["sourceRevision"] == SHA
+    assert manifest.chart_source_revision(value) == CHART_SHA
+
+
+def test_version_controlled_production_recovery_coordinates_are_exact() -> None:
+    path = Path(__file__).parents[1] / "docs/apps/dspace.prod-recovery-coordinates.json"
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert value == {
+        "schemaVersion": 2,
+        "app": "dspace",
+        "applicationVersion": "3.0.1",
+        "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+        "chartSourceRevision": "63063e287adb92a4158ce2c8e7d378b73f52c1c5",
+        "imageTag": "main-1a31a56",
+        "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
+        "chartVersion": "3.0.2",
+        "chartDigest": "sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575",
+        "semanticTag": "v3.0.1",
+    }
+    generated = manifest.candidate(value, "prod", "openai", "2026-07-31T12:00:00Z", "test-approver")
+    assert generated["imageTag"] == "main-1a31a56"
+    assert generated["chartVersion"] == "3.0.2"
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        lambda x: x.pop("chartSourceRevision"),
+        lambda x: x.update(chartSourceRevision="bad"),
+        lambda x: x.update(schemaVersion=3),
+    ],
+)
+def test_schema_v2_rejects_missing_malformed_unknown_or_swapped_provenance(change) -> None:
+    value = split_upstream()
+    change(value)
+    with pytest.raises(manifest.ManifestError):
+        manifest.candidate(value, "staging", "openai", "2026-07-26T12:00:00Z", "operator")
 
 
 def test_upstream_import_is_canonical_and_round_trips(tmp_path: Path) -> None:
@@ -124,9 +188,12 @@ def test_accepts_strict_semver_prerelease_and_build(version: str) -> None:
     value = upstream()
     value["applicationVersion"] = version
     value["semanticTag"] = f"v{version}"
-    assert manifest.candidate(
-        value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator"
-    )["applicationVersion"] == version
+    assert (
+        manifest.candidate(value, "staging", "token-place", "2026-07-26T12:00:00Z", "operator")[
+            "applicationVersion"
+        ]
+        == version
+    )
 
 
 @pytest.mark.parametrize(
@@ -200,6 +267,25 @@ def test_preflight_checks_exact_descriptors_and_digest_qualified_metadata() -> N
     assert runner.calls[0][-1].endswith(":main-abcdef0")
     assert runner.calls[1][-1] == f"{manifest.IMAGE_REF}@{DIGEST}"
     assert all(":main-abcdef0" not in call[-1] for call in runner.calls[1:])
+
+
+def test_split_preflight_compares_image_and_chart_to_independent_sources() -> None:
+    results = manifest.preflight(
+        split_candidate(),
+        manifest.IMAGE_REF,
+        manifest.CHART_REF,
+        "oras",
+        runner=oras_runner(image_revision=SHA, chart_revision=CHART_SHA),
+    )
+    assert all(item["passed"] for item in results)
+    with pytest.raises(manifest.ManifestError, match="chartSourceRevision"):
+        manifest.preflight(
+            split_candidate(),
+            manifest.IMAGE_REF,
+            manifest.CHART_REF,
+            "oras",
+            runner=oras_runner(image_revision=SHA, chart_revision=SHA),
+        )
 
 
 @pytest.mark.parametrize(
@@ -374,6 +460,30 @@ def test_finalize_collects_sorted_multi_pod_identity() -> None:
         "podImageCoordinates",
         "podImageDigests",
     }
+
+
+def test_schema_v2_split_sources_survive_finalization_and_production_gate() -> None:
+    staging = split_candidate()
+    proof = runtime_proof(defaultProvider="openai")
+    final = finalize(
+        value=staging,
+        preflight_results=manifest.preflight(
+            staging,
+            manifest.IMAGE_REF,
+            manifest.CHART_REF,
+            "oras",
+            runner=oras_runner(image_revision=SHA, chart_revision=CHART_SHA),
+        ),
+        runtime_verification=proof,
+    )
+    assert final["sourceRevision"] == SHA
+    assert final["chartSourceRevision"] == CHART_SHA
+    production = split_candidate("prod")
+    assert manifest.staging_gate(production, final) == 17
+
+    production["chartSourceRevision"] = "0" * 40
+    with pytest.raises(manifest.ManifestError, match="chart source revisions"):
+        manifest.staging_gate(production, final)
 
 
 def test_finalize_optional_digest_coordinate_is_backward_compatible() -> None:
@@ -570,9 +680,7 @@ def test_final_validation_requires_every_fixed_check(missing: str) -> None:
 @pytest.mark.parametrize("invalid", ["unknown", "imagePlatformSourceRevision[x]"])
 def test_final_validation_rejects_unknown_or_malformed_checks(invalid: str) -> None:
     value = finalize()
-    value["verificationResults"].append(
-        {"check": invalid, "passed": True, "details": "fabricated"}
-    )
+    value["verificationResults"].append({"check": invalid, "passed": True, "details": "fabricated"})
     with pytest.raises(manifest.ManifestError, match="unknown verification"):
         manifest.validate(value, True)
 
@@ -740,9 +848,7 @@ def test_reservation_is_atomic_and_bound_to_owner(tmp_path: Path) -> None:
     )
     metadata = json.loads(sidecar.read_text(encoding="utf-8"))
     assert metadata["output"] == str(output.resolve())
-    assert metadata["candidateFingerprint"] == manifest._candidate_fingerprint(
-        candidate()
-    )
+    assert metadata["candidateFingerprint"] == manifest._candidate_fingerprint(candidate())
 
 
 def test_reservation_rejects_existing_record_or_reservation(tmp_path: Path) -> None:
@@ -776,9 +882,7 @@ def test_reservation_binds_candidate_output_and_coordinates(tmp_path: Path) -> N
             )
 
 
-def test_post_reservation_failure_preserves_ownership(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_post_reservation_failure_preserves_ownership(tmp_path: Path, monkeypatch) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
     source.write_text(manifest._canonical(candidate()), encoding="utf-8")
@@ -786,9 +890,7 @@ def test_post_reservation_failure_preserves_ownership(
     monkeypatch.setattr(
         manifest,
         "preflight",
-        lambda *args, **kwargs: (_ for _ in ()).throw(
-            manifest.ManifestError("OCI failed")
-        ),
+        lambda *args, **kwargs: (_ for _ in ()).throw(manifest.ManifestError("OCI failed")),
     )
     assert (
         manifest.main(
@@ -965,10 +1067,25 @@ def test_finalize_cli_settling_failure_preserves_reservation(
 
     monkeypatch.setattr(manifest, "_run", run)
     args = [
-        "finalize", "--manifest", str(source), "--output", str(output),
-        "--environment", "staging", "--image-tag", "main-abcdef0",
-        "--chart-version", "3.2.0", "--kubeconfig", "kubeconfig",
-        "--release", "dspace", "--namespace", "dspace", "--reservation", owner,
+        "finalize",
+        "--manifest",
+        str(source),
+        "--output",
+        str(output),
+        "--environment",
+        "staging",
+        "--image-tag",
+        "main-abcdef0",
+        "--chart-version",
+        "3.2.0",
+        "--kubeconfig",
+        "kubeconfig",
+        "--release",
+        "dspace",
+        "--namespace",
+        "dspace",
+        "--reservation",
+        owner,
     ]
     assert manifest.main(args) == 2
     assert not output.exists()
@@ -1010,25 +1127,36 @@ def test_finalize_cli_rejects_changed_helm_binding_and_preserves_reservation(
                     status["info"]["description"] = "another invocation"
             return json.dumps(status)
         resource = command[command.index("get") + 1]
-        return json.dumps(
-            {"items": [pod("dspace-a")]} if resource == "pods" else workloads()
-        )
+        return json.dumps({"items": [pod("dspace-a")]} if resource == "pods" else workloads())
 
     monkeypatch.setattr(manifest, "_run", run)
     args = [
-        "finalize", "--manifest", str(source), "--output", str(output),
-        "--environment", "staging", "--image-tag", "main-abcdef0",
-        "--chart-version", "3.2.0", "--kubeconfig", "kubeconfig",
-        "--release", "dspace", "--namespace", "dspace", "--reservation", owner,
+        "finalize",
+        "--manifest",
+        str(source),
+        "--output",
+        str(output),
+        "--environment",
+        "staging",
+        "--image-tag",
+        "main-abcdef0",
+        "--chart-version",
+        "3.2.0",
+        "--kubeconfig",
+        "kubeconfig",
+        "--release",
+        "dspace",
+        "--namespace",
+        "dspace",
+        "--reservation",
+        owner,
     ]
     assert manifest.main(args) == 2
     assert not output.exists()
     assert manifest.reservation_path(output).exists()
 
 
-def test_public_read_only_and_reservation_dispatch(
-    tmp_path: Path, monkeypatch, capsys
-) -> None:
+def test_public_read_only_and_reservation_dispatch(tmp_path: Path, monkeypatch, capsys) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
     source.write_text(manifest._canonical(candidate()), encoding="utf-8")
@@ -1039,9 +1167,7 @@ def test_public_read_only_and_reservation_dispatch(
         preflight_calls.append(args)
         return real_preflight(*args, **kwargs, runner=oras_runner())
 
-    oci_results = checked_preflight(
-        candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras"
-    )
+    oci_results = checked_preflight(candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras")
     preflight_calls.clear()
     monkeypatch.setattr(manifest, "preflight", checked_preflight)
 
@@ -1122,16 +1248,9 @@ def test_preflight_chart_coordinate_is_not_printed_after_failed_validation(
     monkeypatch.setattr(
         manifest,
         "preflight",
-        lambda *args, **kwargs: real_preflight(
-            *args, **kwargs, runner=oras_runner()
-        ),
+        lambda *args, **kwargs: real_preflight(*args, **kwargs, runner=oras_runner()),
     )
-    assert (
-        manifest.main(
-            ["preflight", "--manifest", str(source), "--print-chart-coordinate"]
-        )
-        == 2
-    )
+    assert manifest.main(["preflight", "--manifest", str(source), "--print-chart-coordinate"]) == 2
     captured = capsys.readouterr()
     assert captured.out == ""
     assert "chartDigest" in captured.err
@@ -1141,6 +1260,7 @@ def test_default_evidence_path_is_stable_and_approval_unique() -> None:
     assert str(manifest.evidence_path(candidate())) == (
         "deployment-evidence/dspace/staging/main-abcdef0-20260726T120000Z.json"
     )
+
 
 @pytest.mark.parametrize(
     ("change", "message"),


### PR DESCRIPTION
### Motivation

- Address a critical provenance gap: the recovery chart and application image can have different source revisions and the release-manifest tooling must validate them independently using a versioned schema evolution.
- Prepare repository-side inputs, validation, tests, and operator runbook required to perform a single controlled, evidence-backed reconciliation of the intentionally drifted DSPACE production Helm state without mutating any live cluster state.

### Description

- Add schema v2 split-provenance support to `scripts/dspace_release_manifest.py` by introducing `chartSourceRevision` (v2), schema-aware field lists, `chart_source_revision()` helper, and schema-aware validation; preserve implicit v1 behavior where `chartSourceRevision == sourceRevision` is assumed. (key changes in `scripts/dspace_release_manifest.py`)
- Ensure preflight and finalization compare image provenance to `sourceRevision` and chart provenance to `chartSourceRevision`, and enforce schema-consistent staging-gate and candidate/evidence comparisons; preserve runtime/frontend identity as application `sourceRevision` only. (preflight/finalize/staging_gate changes)
- Update rollback integration to project validated final evidence back to an appropriate candidate shape and preserve chart provenance when building approved candidates; include `chartSourceRevision` when present. (`scripts/dspace_manifest_rollback.py`)
- Record immutable recovery coordinates as a version-controlled machine-readable input `docs/apps/dspace.prod-recovery-coordinates.json` (schema v2) and bump the production recovery chart pin in `docs/apps/dspace.prod.version` to `3.0.2` while keeping the production image tag unchanged (`main-1a31a56`).
- Add focused regression tests and update existing tests to cover schema-v1 compatibility, schema-v2 split provenance candidate generation, preflight, staging-gate comparisons, finalization, rollback metadata preservation, and production values-chain safety; and add a detailed copy/paste-ready reconciliation runbook section to `docs/apps/dspace.md` describing repository preparation, operator approval, staging proof, read-only production capture, guarded mutation, verification, freeze-lift criteria, and truthful forward-reconciliation. (test updates under `tests/`)

Files changed (high level): `scripts/dspace_release_manifest.py`, `scripts/dspace_manifest_rollback.py`, `docs/apps/dspace.prod.version`, `docs/apps/dspace.prod-recovery-coordinates.json` (new), `docs/apps/dspace.md` (runbook additions), and focused test updates under `tests/` to validate the new contract and regressions.

This PR prepares the reconciliation only; it does not run any production mutation, publish artifacts, change images, or lift the production Helm freeze. Refs #2325.

### Testing

- Ran the focused unit/behavior suites: `python3 -m pytest -q tests/test_release_manifest.py tests/test_manifest_rollback.py tests/test_generic_app_just_recipes.py tests/test_dspace_runtime_verifier.py tests/test_app_config.py tests/test_dspace_runtime_values.py` — all tests in these suites passed in the execution environment used for this change.
- Verified configuration and helpers: `python3 scripts/app_config.py json --app dspace --env prod` returned the expected production config (uses `docs/apps/dspace.prod.version` and values chain), `just --unstable --fmt --check` and `linkchecker --no-warnings README.md docs/` succeeded, and staged `dspace_release_manifest.py candidate`/`validate` flows accept the new `docs/apps/dspace.prod-recovery-coordinates.json` input.
- Repository checks with `pre-commit run --all-files` and `pyspelling` could not be fully completed in this environment due to unrelated, repository-wide legacy YAML/multi-document issues and missing `aspell`; pre-commit made automated fixes to unrelated files which were not intended to be part of this change and were reverted before the final commit. The environment also lacks `helm` so an exact offline `helm template` of the resolved `oci://...@<chartDigest>` chart could not be executed here; focused, offline values-chain assertions and manifest/render contract tests were exercised and passed.

Residual notes and operator work remaining before executing the reconciliation (not performed by this PR): supply real approval metadata/timestamps, independently validate the application’s OpenAI-first contract at the recorded `sourceRevision`, deploy and finalize staging evidence using the produced candidates, perform the documented read-only production capture and digest-qualified render (requires `helm` and privileged kubeconfigs), run the guarded production promotion sequence, review finalized production evidence, and explicitly authorize any freeze lift. Refs #2325

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cf15d638c832f8ce52a820d864dd3)