### PR TITLE
Fix watchdog Alertmanager pod log retrieval

### DIFF
--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -161,17 +161,25 @@ PY
   kubectl -n "${NAMESPACE}" get alertmanager "${RELEASE}-alertmanager" -o yaml >"${tmp}/cr"
   kubectl -n "${NAMESPACE}" get secret "alertmanager-${RELEASE}-alertmanager" -o yaml >"${tmp}/config"
   ruby "${ALERTMANAGER_VALIDATOR}" live "${tmp}/cr" "${tmp}/config"
-  kubectl -n "${NAMESPACE}" get pods -l 'app.kubernetes.io/name=alertmanager' -o json >"${tmp}/pods"
-  python3 - "${tmp}/pods" <<'PY'
+  kubectl -n "${NAMESPACE}" get pods -l "app.kubernetes.io/name=alertmanager,alertmanager=${RELEASE}-alertmanager" -o json >"${tmp}/pods"
+  python3 - "${tmp}/pods" "${tmp}/pod-names" <<'PY'
 import json, sys
-try: pods=json.load(open(sys.argv[1], encoding="utf-8")).get("items",[])
-except (OSError, UnicodeError, json.JSONDecodeError): raise SystemExit("ERROR: Alertmanager pod data is malformed (response redacted).")
+try:
+ doc=json.load(open(sys.argv[1], encoding="utf-8")); pods=doc.get("items")
+ if not isinstance(doc,dict) or not isinstance(pods,list) or any(not isinstance(p,dict) for p in pods): raise ValueError
+except (OSError, UnicodeError, json.JSONDecodeError, AttributeError, ValueError): raise SystemExit("ERROR: Alertmanager pod data is malformed (response redacted).")
 def mounted(p):
  spec=p.get("spec",{}); vols=spec.get("volumes",[])
  names={v.get("name") for v in vols if v.get("secret",{}).get("secretName")=="alertmanager-healthchecks-watchdog"}
  return names and any(m.get("name") in names and m.get("mountPath")=="/etc/alertmanager/secrets/alertmanager-healthchecks-watchdog" and m.get("readOnly") is True for c in spec.get("containers",[]) for m in c.get("volumeMounts",[]))
+try: names=[p["metadata"]["name"] for p in pods]
+except (KeyError, TypeError): raise SystemExit("ERROR: Alertmanager pod data is malformed (response redacted).")
+if any(not isinstance(n,str) or not n for n in names): raise SystemExit("ERROR: Alertmanager pod data is malformed (response redacted).")
 if not pods or any(p.get("status",{}).get("phase")!="Running" or not mounted(p) for p in pods):
  raise SystemExit("ERROR: running Alertmanager pods do not have the exact watchdog Secret mount (response redacted).")
+try:
+ with open(sys.argv[2], "w", encoding="utf-8") as output: output.write("\n".join(names)+"\n")
+except OSError: raise SystemExit("ERROR: Alertmanager pod data could not be inspected (details redacted).")
 PY
   observation="${SUGARKUBE_WATCHDOG_OBSERVATION_SECONDS:-310}"
   [[ "${observation}" =~ ^[0-9]+$ ]] || { echo "ERROR: watchdog observation duration must be an integer." >&2; return 2; }
@@ -179,12 +187,16 @@ PY
     echo "ERROR: watchdog observation must cover at least one five-minute repeat." >&2; return 2
   fi
   sleep "${observation}"
-  if ! kubectl -n "${NAMESPACE}" logs "statefulset/${RELEASE}-alertmanager" --since="$((observation + 60))s" >"${tmp}/logs" 2>"${tmp}/logs.stderr"; then
-    echo "ERROR: Alertmanager logs could not be retrieved (details redacted)." >&2; return 1
-  fi
+  local pod log_index=0
+  while IFS= read -r pod; do
+    log_index=$((log_index + 1))
+    if ! kubectl -n "${NAMESPACE}" logs "pod/${pod}" -c alertmanager --since="$((observation + 60))s" >"${tmp}/logs.${log_index}" 2>"${tmp}/logs.${log_index}.stderr"; then
+      echo "ERROR: Alertmanager logs could not be retrieved (details redacted)." >&2; return 1
+    fi
+  done <"${tmp}/pod-names"
   python3 - "${tmp}/logs" <<'PY'
-import re,sys
-try: text=open(sys.argv[1], encoding="utf-8", errors="replace").read()
+import glob,re,sys
+try: text="".join(open(path, encoding="utf-8", errors="replace").read() for path in glob.glob(sys.argv[1]+".*") if not path.endswith(".stderr"))
 except OSError: raise SystemExit("ERROR: Alertmanager logs could not be inspected (details redacted).")
 receiver=r'(?:healthchecks-watchdog|alertmanager-healthchecks-watchdog)'
 error=r'(?:error|failed|failure|timeout|refused)'

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -653,7 +653,7 @@ case "$*" in
     printf '%s\n' '{"data":{"groups":[{"rules":[{"name":"SugarkubeObservabilityWatchdog","state":"firing","query":"vector(1)","labels":{"environment":"staging","cluster":"sugarkube-int","purpose":"observability-watchdog"'"$extra"'}}]}]}}'
     ;;
   *"/api/v2/alerts"*) printf '%s\n' '[{"status":{"state":"active"},"labels":{"alertname":"SugarkubeObservabilityWatchdog","environment":"staging","cluster":"sugarkube-int","purpose":"observability-watchdog","prometheus":"platform-added"}}]' ;;
-  *"get pods -l app.kubernetes.io/name=alertmanager -o json"*)
+  *"get pods -l app.kubernetes.io/name=alertmanager,alertmanager=kube-prometheus-stack-alertmanager -o json"*)
     phase=Running
     secret=alertmanager-healthchecks-watchdog
     volume=watchdog
@@ -661,6 +661,7 @@ case "$*" in
     readonly=true
     case "$KUBECTL_MODE" in
       watchdog-no-pods) printf '%s\n' '{"items":[],"private":"POD_FIXTURE_SENTINEL"}'; exit 0 ;;
+      watchdog-malformed-pods) printf '%s\n' '{"items":"PRIVATE_MALFORMED_POD_SENTINEL"}'; exit 0 ;;
       watchdog-pod-not-running) phase=Pending ;;
       watchdog-missing-volume) volume=unmounted ;;
       watchdog-wrong-secret-volume) secret=another-secret ;;
@@ -668,11 +669,19 @@ case "$*" in
       watchdog-wrong-mount-path) mount=/etc/alertmanager/secrets/wrong ;;
       watchdog-mount-not-readonly) readonly=false ;;
     esac
-    printf '%s\n' '{"items":[{"status":{"phase":"'"$phase"'"},"spec":{"volumes":[{"name":"'"$volume"'","secret":{"secretName":"'"$secret"'"}}],"containers":[{"volumeMounts":[{"name":"watchdog","mountPath":"'"$mount"'","readOnly":'"$readonly"'}]}]},"private":"POD_FIXTURE_SENTINEL"}]}'
+    pod='{"metadata":{"name":"alertmanager-kube-prometheus-stack-alertmanager-0"},"status":{"phase":"'"$phase"'"},"spec":{"volumes":[{"name":"'"$volume"'","secret":{"secretName":"'"$secret"'"}}],"containers":[{"volumeMounts":[{"name":"watchdog","mountPath":"'"$mount"'","readOnly":'"$readonly"'}]}]},"private":"POD_FIXTURE_SENTINEL"}'
+    case "$KUBECTL_MODE" in
+      watchdog-multiple-pods|watchdog-second-log-fails)
+        second_pod=$(printf '%s' "$pod" | sed 's/alertmanager-0/alertmanager-1/')
+        pod="$pod,$second_pod"
+        ;;
+    esac
+    printf '%s\n' '{"items":['"$pod"']}'
     ;;
-  *"logs statefulset/kube-prometheus-stack-alertmanager"*)
+  *"logs pod/alertmanager-kube-prometheus-stack-alertmanager-"*" -c alertmanager "*)
     case "$KUBECTL_MODE" in
       watchdog-logs-fail) echo 'PRIVATE_LOG_RETRIEVAL_SENTINEL' >&2; exit 51 ;;
+      watchdog-second-log-fails) case "$*" in *alertmanager-1*) echo 'PRIVATE_LOG_RETRIEVAL_SENTINEL' >&2; exit 51 ;; esac ;;
     esac
     printf '%s' "$WATCHDOG_LOG_TEXT"
     ;;
@@ -1717,8 +1726,25 @@ def test_watchdog_live_check_accepts_exact_rule_labels_and_external_alert_labels
     assert "bounded repeat observation verified" in result.stdout
     assert "proxy/api/v1/rules" in audit
     assert "/api/v2/alerts" in audit
-    assert "get pods -l app.kubernetes.io/name=alertmanager -o json" in audit
-    assert "logs statefulset/kube-prometheus-stack-alertmanager" in audit
+    assert (
+        "get pods -l app.kubernetes.io/name=alertmanager,"
+        "alertmanager=kube-prometheus-stack-alertmanager -o json" in audit
+    )
+    assert (
+        "logs pod/alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager --since="
+        in audit
+    )
+    assert "statefulset/kube-prometheus-stack-alertmanager" not in audit
+
+
+def test_watchdog_live_check_inspects_every_matching_alertmanager_pod(tmp_path):
+    result, audit = run_helper(tmp_path, "watchdog-verify", kubectl_mode="watchdog-multiple-pods")
+
+    assert result.returncode == 0, result.stderr
+    assert audit.count(" -c alertmanager --since=") == 2
+    assert "logs pod/alertmanager-kube-prometheus-stack-alertmanager-0" in audit
+    assert "logs pod/alertmanager-kube-prometheus-stack-alertmanager-1" in audit
+    assert "statefulset/" not in audit
 
 
 def test_watchdog_live_check_rejects_extra_rule_label_without_printing_payload(tmp_path):
@@ -1747,6 +1773,14 @@ def test_watchdog_mount_contract_fails_closed_and_redacts_pod_data(tmp_path, mod
     assert result.returncode != 0
     assert "running Alertmanager pods do not have the exact watchdog Secret mount" in result.stderr
     assert "POD_FIXTURE_SENTINEL" not in result.stdout + result.stderr
+
+
+def test_watchdog_malformed_pod_inventory_fails_closed_and_is_sanitized(tmp_path):
+    result, _ = run_helper(tmp_path, "watchdog-verify", kubectl_mode="watchdog-malformed-pods")
+
+    assert result.returncode != 0
+    assert "Alertmanager pod data is malformed" in result.stderr
+    assert "PRIVATE_MALFORMED_POD_SENTINEL" not in result.stdout + result.stderr
 
 
 @pytest.mark.parametrize(
@@ -1787,6 +1821,18 @@ def test_watchdog_delivery_log_retrieval_failure_is_sanitized(tmp_path):
     assert result.returncode != 0
     assert "Alertmanager logs could not be retrieved (details redacted)" in result.stderr
     assert "PRIVATE_LOG_RETRIEVAL_SENTINEL" not in result.stdout + result.stderr
+
+
+def test_watchdog_one_of_multiple_log_retrievals_fails_closed_and_cleans_up(tmp_path):
+    result, audit = run_helper(
+        tmp_path, "watchdog-verify", kubectl_mode="watchdog-second-log-fails"
+    )
+
+    assert result.returncode != 0
+    assert "Alertmanager logs could not be retrieved (details redacted)" in result.stderr
+    assert "PRIVATE_LOG_RETRIEVAL_SENTINEL" not in result.stdout + result.stderr + audit
+    assert audit.count(" -c alertmanager --since=") == 2
+    assert not list(tmp_path.glob("sugarkube-watchdog-verify.*"))
 
 
 def watchdog_silence_fixture():


### PR DESCRIPTION
### Motivation

- The staging watchdog verifier attempted to retrieve Alertmanager logs using a generated StatefulSet name which does not match the Prometheus Operator resource name, causing `watchdog_verify` to fail even when the rule, alert, Secret mount and deliveries were correct (root cause: incorrect/statefulset-based log lookup). 

### Description

- Change `scripts/observability_helm.sh` to select Alertmanager pods with the stable label contract `app.kubernetes.io/name=alertmanager,alertmanager=${RELEASE}-alertmanager`, validate the returned pod JSON, and write the pod names to a private tmp file. 
- Reuse that pod inventory to call `kubectl logs pod/<name> -c alertmanager` for every selected running pod, aggregate logs from the private temp files, and preserve sanitized fail-closed behavior when inventories are malformed or any per-pod retrieval fails. 
- Update `tests/test_observability_helm.py` to assert the new label-based lookup and container-specific log calls, and add focused tests covering the operator naming shape (single + multiple pods), malformed/empty inventories, one-of-multiple log retrieval failure, delivery-error detection, unrelated messages, and temporary-file cleanup. 
- Preserve existing checks (exact rule, active alert, Secret mount and receiver-attributable delivery error scan) and keep all sensitive diagnostics and logs inside the private temporary directory.

### Testing

- Ran `bash -n scripts/observability_helm.sh` and `shellcheck scripts/observability_helm.sh` with no syntax issues reported. 
- Ran the focused pytest subset `python3 -m pytest -q tests/test_observability_helm.py -k 'watchdog and (log or live)'` and the full file `python3 -m pytest -q tests/test_observability_helm.py`, both succeeded (all watchdog-related tests passed). 
- Ran `just observability-render env=staging >/dev/null`, `git diff --check`, and `git diff | ./scripts/scan-secrets.py` with no issues related to this change. 
- Ran `pre-commit run --all-files` which surfaced repository-baseline YAML/flake8 findings unrelated to this focused patch; those are pre-existing and not introduced by this PR. 

Refs #2403

Post-merge: run `just observability-watchdog-verify env=staging` to verify the live staging recovery and Healthchecks deliveries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d5e598a34832fb8b278522f5d4efe)