### PR TITLE
Fix watchdog Alertmanager pod log retrieval

### DIFF
--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -162,16 +162,26 @@ PY
   kubectl -n "${NAMESPACE}" get secret "alertmanager-${RELEASE}-alertmanager" -o yaml >"${tmp}/config"
   ruby "${ALERTMANAGER_VALIDATOR}" live "${tmp}/cr" "${tmp}/config"
   kubectl -n "${NAMESPACE}" get pods -l 'app.kubernetes.io/name=alertmanager' -o json >"${tmp}/pods"
-  python3 - "${tmp}/pods" <<'PY'
-import json, sys
-try: pods=json.load(open(sys.argv[1], encoding="utf-8")).get("items",[])
-except (OSError, UnicodeError, json.JSONDecodeError): raise SystemExit("ERROR: Alertmanager pod data is malformed (response redacted).")
+  python3 - "${tmp}/pods" "${tmp}/pod-names" <<'PY'
+import json, re, sys
+try:
+ doc=json.load(open(sys.argv[1], encoding="utf-8"))
+ pods=doc["items"]
+ if not isinstance(doc,dict) or not isinstance(pods,list): raise TypeError
+ for p in pods:
+  if not isinstance(p,dict) or not isinstance(p.get("metadata",{}),dict) or not isinstance(p.get("metadata",{}).get("labels",{}),dict): raise TypeError
+except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError): raise SystemExit("ERROR: Alertmanager pod data is malformed (response redacted).")
+pods=[p for p in pods if p.get("metadata",{}).get("labels",{}).get("alertmanager")=="kube-prometheus-stack-alertmanager"]
 def mounted(p):
  spec=p.get("spec",{}); vols=spec.get("volumes",[])
  names={v.get("name") for v in vols if v.get("secret",{}).get("secretName")=="alertmanager-healthchecks-watchdog"}
  return names and any(m.get("name") in names and m.get("mountPath")=="/etc/alertmanager/secrets/alertmanager-healthchecks-watchdog" and m.get("readOnly") is True for c in spec.get("containers",[]) for m in c.get("volumeMounts",[]))
 if not pods or any(p.get("status",{}).get("phase")!="Running" or not mounted(p) for p in pods):
  raise SystemExit("ERROR: running Alertmanager pods do not have the exact watchdog Secret mount (response redacted).")
+names=[p.get("metadata",{}).get("name") for p in pods]
+if any(not isinstance(n,str) or not re.fullmatch(r'[a-z0-9](?:[-a-z0-9.]*[a-z0-9])?',n) for n in names):
+ raise SystemExit("ERROR: Alertmanager pod data is malformed (response redacted).")
+open(sys.argv[2],"w",encoding="utf-8").write("".join(n+"\n" for n in names))
 PY
   observation="${SUGARKUBE_WATCHDOG_OBSERVATION_SECONDS:-310}"
   [[ "${observation}" =~ ^[0-9]+$ ]] || { echo "ERROR: watchdog observation duration must be an integer." >&2; return 2; }
@@ -179,9 +189,12 @@ PY
     echo "ERROR: watchdog observation must cover at least one five-minute repeat." >&2; return 2
   fi
   sleep "${observation}"
-  if ! kubectl -n "${NAMESPACE}" logs "statefulset/${RELEASE}-alertmanager" --since="$((observation + 60))s" >"${tmp}/logs" 2>"${tmp}/logs.stderr"; then
-    echo "ERROR: Alertmanager logs could not be retrieved (details redacted)." >&2; return 1
-  fi
+  : >"${tmp}/logs"
+  while IFS= read -r pod; do
+    if ! kubectl -n "${NAMESPACE}" logs "pod/${pod}" -c alertmanager --since="$((observation + 60))s" >>"${tmp}/logs" 2>>"${tmp}/logs.stderr"; then
+      echo "ERROR: Alertmanager logs could not be retrieved (details redacted)." >&2; return 1
+    fi
+  done <"${tmp}/pod-names"
   python3 - "${tmp}/logs" <<'PY'
 import re,sys
 try: text=open(sys.argv[1], encoding="utf-8", errors="replace").read()

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -661,6 +661,10 @@ case "$*" in
     readonly=true
     case "$KUBECTL_MODE" in
       watchdog-no-pods) printf '%s\n' '{"items":[],"private":"POD_FIXTURE_SENTINEL"}'; exit 0 ;;
+      watchdog-malformed-pods) printf '%s\n' '{"items":"private malformed inventory"}'; exit 0 ;;
+      watchdog-multiple-pods|watchdog-second-log-fails)
+        printf '%s\n' '{"items":[{"metadata":{"name":"alertmanager-kube-prometheus-stack-alertmanager-0","labels":{"app.kubernetes.io/name":"alertmanager","alertmanager":"kube-prometheus-stack-alertmanager"}},"status":{"phase":"Running"},"spec":{"volumes":[{"name":"watchdog","secret":{"secretName":"alertmanager-healthchecks-watchdog"}}],"containers":[{"name":"alertmanager","volumeMounts":[{"name":"watchdog","mountPath":"/etc/alertmanager/secrets/alertmanager-healthchecks-watchdog","readOnly":true}]}]}},{"metadata":{"name":"alertmanager-kube-prometheus-stack-alertmanager-1","labels":{"app.kubernetes.io/name":"alertmanager","alertmanager":"kube-prometheus-stack-alertmanager"}},"status":{"phase":"Running"},"spec":{"volumes":[{"name":"watchdog","secret":{"secretName":"alertmanager-healthchecks-watchdog"}}],"containers":[{"name":"alertmanager","volumeMounts":[{"name":"watchdog","mountPath":"/etc/alertmanager/secrets/alertmanager-healthchecks-watchdog","readOnly":true}]}]}},{"metadata":{"name":"alertmanager-unrelated-0","labels":{"app.kubernetes.io/name":"alertmanager","alertmanager":"unrelated"}},"status":{"phase":"Pending"},"spec":{}}],"private":"POD_FIXTURE_SENTINEL"}'
+        exit 0 ;;
       watchdog-pod-not-running) phase=Pending ;;
       watchdog-missing-volume) volume=unmounted ;;
       watchdog-wrong-secret-volume) secret=another-secret ;;
@@ -668,11 +672,12 @@ case "$*" in
       watchdog-wrong-mount-path) mount=/etc/alertmanager/secrets/wrong ;;
       watchdog-mount-not-readonly) readonly=false ;;
     esac
-    printf '%s\n' '{"items":[{"status":{"phase":"'"$phase"'"},"spec":{"volumes":[{"name":"'"$volume"'","secret":{"secretName":"'"$secret"'"}}],"containers":[{"volumeMounts":[{"name":"watchdog","mountPath":"'"$mount"'","readOnly":'"$readonly"'}]}]},"private":"POD_FIXTURE_SENTINEL"}]}'
+    printf '%s\n' '{"items":[{"metadata":{"name":"alertmanager-kube-prometheus-stack-alertmanager-0","labels":{"app.kubernetes.io/name":"alertmanager","alertmanager":"kube-prometheus-stack-alertmanager"}},"status":{"phase":"'"$phase"'"},"spec":{"volumes":[{"name":"'"$volume"'","secret":{"secretName":"'"$secret"'"}}],"containers":[{"name":"alertmanager","volumeMounts":[{"name":"watchdog","mountPath":"'"$mount"'","readOnly":'"$readonly"'}]}]}}],"private":"POD_FIXTURE_SENTINEL"}'
     ;;
-  *"logs statefulset/kube-prometheus-stack-alertmanager"*)
+  *"logs pod/alertmanager-kube-prometheus-stack-alertmanager-"*" -c alertmanager "*)
     case "$KUBECTL_MODE" in
       watchdog-logs-fail) echo 'PRIVATE_LOG_RETRIEVAL_SENTINEL' >&2; exit 51 ;;
+      watchdog-second-log-fails) case "$*" in *alertmanager-1*) echo 'PRIVATE_LOG_RETRIEVAL_SENTINEL' >&2; exit 51 ;; esac ;;
     esac
     printf '%s' "$WATCHDOG_LOG_TEXT"
     ;;
@@ -1718,7 +1723,19 @@ def test_watchdog_live_check_accepts_exact_rule_labels_and_external_alert_labels
     assert "proxy/api/v1/rules" in audit
     assert "/api/v2/alerts" in audit
     assert "get pods -l app.kubernetes.io/name=alertmanager -o json" in audit
-    assert "logs statefulset/kube-prometheus-stack-alertmanager" in audit
+    assert "logs pod/alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager" in audit
+    assert "statefulset/kube-prometheus-stack-alertmanager" not in audit
+    assert not list(tmp_path.glob("sugarkube-watchdog-verify.*"))
+
+
+def test_watchdog_live_check_inspects_every_matching_operator_pod(tmp_path):
+    result, audit = run_helper(tmp_path, "watchdog-verify", kubectl_mode="watchdog-multiple-pods")
+
+    assert result.returncode == 0, result.stderr
+    assert audit.count(" -c alertmanager ") == 2
+    assert "alertmanager-kube-prometheus-stack-alertmanager-0" in audit
+    assert "alertmanager-kube-prometheus-stack-alertmanager-1" in audit
+    assert "alertmanager-unrelated-0" not in audit
 
 
 def test_watchdog_live_check_rejects_extra_rule_label_without_printing_payload(tmp_path):
@@ -1747,6 +1764,14 @@ def test_watchdog_mount_contract_fails_closed_and_redacts_pod_data(tmp_path, mod
     assert result.returncode != 0
     assert "running Alertmanager pods do not have the exact watchdog Secret mount" in result.stderr
     assert "POD_FIXTURE_SENTINEL" not in result.stdout + result.stderr
+
+
+def test_watchdog_malformed_pod_inventory_fails_closed_and_redacts_data(tmp_path):
+    result, _ = run_helper(tmp_path, "watchdog-verify", kubectl_mode="watchdog-malformed-pods")
+
+    assert result.returncode != 0
+    assert "Alertmanager pod data is malformed (response redacted)" in result.stderr
+    assert "private malformed inventory" not in result.stdout + result.stderr
 
 
 @pytest.mark.parametrize(
@@ -1787,6 +1812,18 @@ def test_watchdog_delivery_log_retrieval_failure_is_sanitized(tmp_path):
     assert result.returncode != 0
     assert "Alertmanager logs could not be retrieved (details redacted)" in result.stderr
     assert "PRIVATE_LOG_RETRIEVAL_SENTINEL" not in result.stdout + result.stderr
+
+
+def test_watchdog_delivery_one_of_multiple_log_retrievals_failing_is_sanitized(tmp_path):
+    result, audit = run_helper(
+        tmp_path, "watchdog-verify", kubectl_mode="watchdog-second-log-fails"
+    )
+
+    assert result.returncode != 0
+    assert audit.count(" -c alertmanager ") == 2
+    assert "Alertmanager logs could not be retrieved (details redacted)" in result.stderr
+    assert "PRIVATE_LOG_RETRIEVAL_SENTINEL" not in result.stdout + result.stderr
+    assert not list(tmp_path.glob("sugarkube-watchdog-verify.*"))
 
 
 def watchdog_silence_fixture():


### PR DESCRIPTION
### Motivation

- The staging watchdog verifier attempted to read logs from a generated StatefulSet name (`statefulset/kube-prometheus-stack-alertmanager`) which does not match the Prometheus Operator's Alertmanager pod labels, causing log retrieval to fail during live verification (Healthchecks still received pings). Refs #2403

### Description

- Updated `watchdog_live_check` to reuse the live pod inventory and select only pods labeled with `alertmanager=kube-prometheus-stack-alertmanager`, avoiding any inference of the generated StatefulSet name.
- Replaced the single StatefulSet logs call with explicit per-pod log retrieval from the `alertmanager` container for every selected, running Alertmanager pod, aggregating logs into the verifier's private temporary directory.
- Added strict validation and fail-closed behavior for malformed pod inventory, no matches, non-running pods, missing/incorrect Secret mount, or any per-pod log retrieval failure, while preserving the bounded observation interval and the existing sanitized delivery-error scan.
- Added/updated focused tests in `tests/test_observability_helm.py` covering operator naming shape, avoidance of the obsolete StatefulSet lookup, single and multiple matching pods, unrelated pods, malformed/no matches, explicit `alertmanager` container log reads, sanitized per-pod failures, receiver-attributable delivery errors, unrelated log noise, and temporary-file cleanup.

### Testing

- `bash -n scripts/observability_helm.sh` — passed.
- `shellcheck scripts/observability_helm.sh` — passed.
- `python3 -m pytest -q tests/test_observability_helm.py -k 'watchdog and (log or live)'` — 16 passed.
- `python3 -m pytest -q tests/test_observability_helm.py` — 154 passed.
- `just observability-render env=staging >/dev/null` — passed (render succeeded).
- `git diff --check` and `git diff | ./scripts/scan-secrets.py` — no secrets or diff-check failures for the scoped change.
- `pre-commit run --all-files` — not fully green due to pre-existing, unrelated repository-wide trailing-whitespace, multi-document YAML, and lint failures outside the scope-locked files; these unrelated hook failures prevented a clean full pre-commit pass (no scope-locked changes were introduced to fix unrelated issues).

Post-merge verification: run `just observability-watchdog-verify env=staging`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d5e619708832fae3284b313d0cb44)