### PR TITLE
Fix staging watchdog Alertmanager log retrieval

### DIFF
--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -162,16 +162,25 @@ PY
   kubectl -n "${NAMESPACE}" get secret "alertmanager-${RELEASE}-alertmanager" -o yaml >"${tmp}/config"
   ruby "${ALERTMANAGER_VALIDATOR}" live "${tmp}/cr" "${tmp}/config"
   kubectl -n "${NAMESPACE}" get pods -l 'app.kubernetes.io/name=alertmanager' -o json >"${tmp}/pods"
-  python3 - "${tmp}/pods" <<'PY'
+  python3 - "${tmp}/pods" "${RELEASE}-alertmanager" >"${tmp}/pod-names" <<'PY'
 import json, sys
-try: pods=json.load(open(sys.argv[1], encoding="utf-8")).get("items",[])
-except (OSError, UnicodeError, json.JSONDecodeError): raise SystemExit("ERROR: Alertmanager pod data is malformed (response redacted).")
+try:
+ doc=json.load(open(sys.argv[1], encoding="utf-8"))
+ pods=doc["items"]
+ if not isinstance(doc,dict) or not isinstance(pods,list): raise TypeError
+except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError): raise SystemExit("ERROR: Alertmanager pod data is malformed (response redacted).")
 def mounted(p):
  spec=p.get("spec",{}); vols=spec.get("volumes",[])
  names={v.get("name") for v in vols if v.get("secret",{}).get("secretName")=="alertmanager-healthchecks-watchdog"}
  return names and any(m.get("name") in names and m.get("mountPath")=="/etc/alertmanager/secrets/alertmanager-healthchecks-watchdog" and m.get("readOnly") is True for c in spec.get("containers",[]) for m in c.get("volumeMounts",[]))
-if not pods or any(p.get("status",{}).get("phase")!="Running" or not mounted(p) for p in pods):
+try:
+ selected=[p for p in pods if p.get("metadata",{}).get("labels",{}).get("alertmanager")==sys.argv[2]]
+ names=[p["metadata"]["name"] for p in selected]
+ if any(not isinstance(p,dict) for p in pods) or any(not isinstance(n,str) or not n for n in names): raise TypeError
+except (AttributeError, KeyError, TypeError): raise SystemExit("ERROR: Alertmanager pod data is malformed (response redacted).")
+if not selected or any(p.get("status",{}).get("phase")!="Running" or not mounted(p) for p in selected):
  raise SystemExit("ERROR: running Alertmanager pods do not have the exact watchdog Secret mount (response redacted).")
+print(*names, sep="\n")
 PY
   observation="${SUGARKUBE_WATCHDOG_OBSERVATION_SECONDS:-310}"
   [[ "${observation}" =~ ^[0-9]+$ ]] || { echo "ERROR: watchdog observation duration must be an integer." >&2; return 2; }
@@ -179,9 +188,12 @@ PY
     echo "ERROR: watchdog observation must cover at least one five-minute repeat." >&2; return 2
   fi
   sleep "${observation}"
-  if ! kubectl -n "${NAMESPACE}" logs "statefulset/${RELEASE}-alertmanager" --since="$((observation + 60))s" >"${tmp}/logs" 2>"${tmp}/logs.stderr"; then
-    echo "ERROR: Alertmanager logs could not be retrieved (details redacted)." >&2; return 1
-  fi
+  : >"${tmp}/logs"
+  while IFS= read -r pod; do
+    if ! kubectl -n "${NAMESPACE}" logs "pod/${pod}" -c alertmanager --since="$((observation + 60))s" >>"${tmp}/logs" 2>>"${tmp}/logs.stderr"; then
+      echo "ERROR: Alertmanager logs could not be retrieved (details redacted)." >&2; return 1
+    fi
+  done <"${tmp}/pod-names"
   python3 - "${tmp}/logs" <<'PY'
 import re,sys
 try: text=open(sys.argv[1], encoding="utf-8", errors="replace").read()

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -166,19 +166,35 @@ PY
 import json, sys
 try:
  doc=json.load(open(sys.argv[1], encoding="utf-8"))
+ if not isinstance(doc,dict): raise TypeError
  pods=doc["items"]
- if not isinstance(doc,dict) or not isinstance(pods,list): raise TypeError
+ if not isinstance(pods,list): raise TypeError
 except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError): raise SystemExit("ERROR: Alertmanager pod data is malformed (response redacted).")
-def mounted(p):
- spec=p.get("spec",{}); vols=spec.get("volumes",[])
- names={v.get("name") for v in vols if v.get("secret",{}).get("secretName")=="alertmanager-healthchecks-watchdog"}
- return names and any(m.get("name") in names and m.get("mountPath")=="/etc/alertmanager/secrets/alertmanager-healthchecks-watchdog" and m.get("readOnly") is True for c in spec.get("containers",[]) for m in c.get("volumeMounts",[]))
 try:
- selected=[p for p in pods if p.get("metadata",{}).get("labels",{}).get("alertmanager")==sys.argv[2]]
+ def mapping(value):
+  if not isinstance(value,dict): raise TypeError
+  return value
+ def sequence(value):
+  if not isinstance(value,list): raise TypeError
+  return value
+ def mounted(p):
+  spec=mapping(p.get("spec",{}))
+  vols=sequence(spec.get("volumes",[]))
+  names={mapping(v).get("name") for v in vols if mapping(mapping(v).get("secret",{})).get("secretName")=="alertmanager-healthchecks-watchdog"}
+  containers=sequence(spec.get("containers",[]))
+  mounts=[mapping(m) for c in containers for m in sequence(mapping(c).get("volumeMounts",[]))]
+  return bool(names) and any(m.get("name") in names and m.get("mountPath")=="/etc/alertmanager/secrets/alertmanager-healthchecks-watchdog" and m.get("readOnly") is True for m in mounts)
+ selected=[]
+ for pod in pods:
+  pod=mapping(pod); metadata=mapping(pod.get("metadata",{})); labels=mapping(metadata.get("labels",{}))
+  if labels.get("alertmanager")==sys.argv[2]: selected.append(pod)
  names=[p["metadata"]["name"] for p in selected]
- if any(not isinstance(p,dict) for p in pods) or any(not isinstance(n,str) or not n for n in names): raise TypeError
+ if any(not isinstance(n,str) or not n for n in names): raise TypeError
+ valid=all(mapping(p.get("status",{})).get("phase")=="Running" and mounted(p) for p in selected)
 except (AttributeError, KeyError, TypeError): raise SystemExit("ERROR: Alertmanager pod data is malformed (response redacted).")
-if not selected or any(p.get("status",{}).get("phase")!="Running" or not mounted(p) for p in selected):
+if not selected:
+ raise SystemExit("ERROR: no operator-managed Alertmanager pods matched the expected resource (response redacted).")
+if not valid:
  raise SystemExit("ERROR: running Alertmanager pods do not have the exact watchdog Secret mount (response redacted).")
 print(*names, sep="\n")
 PY

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -163,40 +163,44 @@ PY
   ruby "${ALERTMANAGER_VALIDATOR}" live "${tmp}/cr" "${tmp}/config"
   kubectl -n "${NAMESPACE}" get pods -l 'app.kubernetes.io/name=alertmanager' -o json >"${tmp}/pods"
   python3 - "${tmp}/pods" "${RELEASE}-alertmanager" >"${tmp}/pod-names" <<'PY'
-import json, sys
+import json, re, sys
 try:
  doc=json.load(open(sys.argv[1], encoding="utf-8"))
- if not isinstance(doc,dict): raise TypeError
- pods=doc["items"]
- if not isinstance(pods,list): raise TypeError
-except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError): raise SystemExit("ERROR: Alertmanager pod data is malformed (response redacted).")
-try:
  def mapping(value):
   if not isinstance(value,dict): raise TypeError
   return value
  def sequence(value):
   if not isinstance(value,list): raise TypeError
   return value
- def mounted(p):
-  spec=mapping(p.get("spec",{}))
-  vols=sequence(spec.get("volumes",[]))
-  names={mapping(v).get("name") for v in vols if mapping(mapping(v).get("secret",{})).get("secretName")=="alertmanager-healthchecks-watchdog"}
-  containers=sequence(spec.get("containers",[]))
-  mounts=[mapping(m) for c in containers for m in sequence(mapping(c).get("volumeMounts",[]))]
-  return bool(names) and any(m.get("name") in names and m.get("mountPath")=="/etc/alertmanager/secrets/alertmanager-healthchecks-watchdog" and m.get("readOnly") is True for m in mounts)
+ mapping(doc)
+ pods=sequence(doc["items"])
  selected=[]
  for pod in pods:
-  pod=mapping(pod); metadata=mapping(pod.get("metadata",{})); labels=mapping(metadata.get("labels",{}))
-  if labels.get("alertmanager")==sys.argv[2]: selected.append(pod)
- names=[p["metadata"]["name"] for p in selected]
- if any(not isinstance(n,str) or not n for n in names): raise TypeError
- valid=all(mapping(p.get("status",{})).get("phase")=="Running" and mounted(p) for p in selected)
-except (AttributeError, KeyError, TypeError): raise SystemExit("ERROR: Alertmanager pod data is malformed (response redacted).")
+  pod=mapping(pod)
+  metadata=mapping(pod["metadata"])
+  labels=mapping(metadata["labels"])
+  name=metadata["name"]
+  if not isinstance(name,str) or len(name)>253 or not re.fullmatch(r'[a-z0-9](?:[-a-z0-9.]*[a-z0-9])?',name): raise TypeError
+  mapping(pod["status"])
+  spec=mapping(pod["spec"])
+  vols=sequence(spec.get("volumes",[]))
+  names=set()
+  for volume in vols:
+   volume=mapping(volume)
+   secret=volume.get("secret")
+   if secret is not None and mapping(secret).get("secretName")=="alertmanager-healthchecks-watchdog": names.add(volume.get("name"))
+  containers=sequence(spec.get("containers",[]))
+  mounts=[]
+  for container in containers:
+   container=mapping(container)
+   mounts.extend(mapping(mount) for mount in sequence(container.get("volumeMounts",[])))
+  if labels.get("alertmanager")==sys.argv[2]: selected.append((name,pod["status"].get("phase"),bool(names) and any(m.get("name") in names and m.get("mountPath")=="/etc/alertmanager/secrets/alertmanager-healthchecks-watchdog" and m.get("readOnly") is True for m in mounts)))
+except (OSError, UnicodeError, json.JSONDecodeError, AttributeError, KeyError, TypeError): raise SystemExit("ERROR: Alertmanager pod data is malformed (response redacted).")
 if not selected:
  raise SystemExit("ERROR: no operator-managed Alertmanager pods matched the expected resource (response redacted).")
-if not valid:
+if not all(phase=="Running" and mounted for _,phase,mounted in selected):
  raise SystemExit("ERROR: running Alertmanager pods do not have the exact watchdog Secret mount (response redacted).")
-print(*names, sep="\n")
+print(*(name for name,_,_ in selected), sep="\n")
 PY
   observation="${SUGARKUBE_WATCHDOG_OBSERVATION_SECONDS:-310}"
   [[ "${observation}" =~ ^[0-9]+$ ]] || { echo "ERROR: watchdog observation duration must be an integer." >&2; return 2; }
@@ -204,13 +208,16 @@ PY
     echo "ERROR: watchdog observation must cover at least one five-minute repeat." >&2; return 2
   fi
   sleep "${observation}"
-  : >"${tmp}/logs"
+  local log_index=0
   while IFS= read -r pod; do
-    if ! kubectl -n "${NAMESPACE}" logs "pod/${pod}" -c alertmanager --since="$((observation + 60))s" >>"${tmp}/logs" 2>>"${tmp}/logs.stderr"; then
+    if ! kubectl -n "${NAMESPACE}" logs "pod/${pod}" -c alertmanager --since="$((observation + 60))s" >"${tmp}/logs.${log_index}" 2>"${tmp}/logs.${log_index}.stderr"; then
       echo "ERROR: Alertmanager logs could not be retrieved (details redacted)." >&2; return 1
     fi
+    log_index=$((log_index + 1))
   done <"${tmp}/pod-names"
-  python3 - "${tmp}/logs" <<'PY'
+  local log_count=${log_index}
+  for ((log_index=0; log_index<log_count; log_index++)); do
+  python3 - "${tmp}/logs.${log_index}" <<'PY'
 import re,sys
 try: text=open(sys.argv[1], encoding="utf-8", errors="replace").read()
 except OSError: raise SystemExit("ERROR: Alertmanager logs could not be inspected (details redacted).")
@@ -219,6 +226,7 @@ error=r'(?:error|failed|failure|timeout|refused)'
 if re.search(fr'(?i)(?:{receiver}).{{0,240}}{error}|{error}.{{0,240}}(?:{receiver})', text):
  raise SystemExit("ERROR: watchdog receiver delivery error observed (details redacted).")
 PY
+  done
   echo "Watchdog rule, active alert, live configuration, pod mount, and bounded repeat observation verified; delivery must be confirmed at Healthchecks."
 )
 

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -673,8 +673,16 @@ case "$*" in
     case "$KUBECTL_MODE" in
       watchdog-unrelated-pod) pod='{"metadata":{"name":"unrelated-alertmanager-0","labels":{"alertmanager":"another-resource"}},"status":{"phase":"Running"},"spec":{}}' ;;
       watchdog-malformed-status) pod="$(printf '%s' "$pod" | sed 's/"status":{"phase":"Running"}/"status":"PRIVATE_MALFORMED_POD_FIXTURE"/')" ;;
-      watchdog-malformed-volumes) pod="$(printf '%s' "$pod" | sed 's/"volumes":\[/"volumes":"PRIVATE_MALFORMED_POD_FIXTURE","ignored":\[/')" ;;
-      watchdog-malformed-containers) pod="$(printf '%s' "$pod" | sed 's/"containers":\[/"containers":"PRIVATE_MALFORMED_POD_FIXTURE","ignoredContainers":\[/')" ;;
+      watchdog-malformed-metadata) pod="$(printf '%s' "$pod" | sed 's/"metadata":{/"metadata":"PRIVATE_MALFORMED_POD_FIXTURE","ignored":{/')" ;;
+      watchdog-malformed-labels) pod="$(printf '%s' "$pod" | sed 's/"labels":{/"labels":"PRIVATE_MALFORMED_POD_FIXTURE","ignoredLabels":{/')" ;;
+      watchdog-malformed-name) pod="$(printf '%s' "$pod" | sed 's|alertmanager-kube-prometheus-stack-alertmanager-0|PRIVATE_MALFORMED_POD_FIXTURE\\nhttps://fixture.invalid/user:credential@example|')" ;;
+      watchdog-malformed-spec) pod="$(printf '%s' "$pod" | sed 's/"spec":{/"spec":"PRIVATE_MALFORMED_POD_FIXTURE","ignoredSpec":{/')" ;;
+      watchdog-malformed-volumes) pod="$(printf '%s' "$pod" | sed 's/"volumes":\\[/"volumes":"PRIVATE_MALFORMED_POD_FIXTURE","ignored":[/')" ;;
+      watchdog-malformed-volume) pod="$(printf '%s' "$pod" | sed 's/{"name":"watchdog","secret"/"PRIVATE_MALFORMED_POD_FIXTURE",{"name":"watchdog","secret"/')" ;;
+      watchdog-malformed-containers) pod="$(printf '%s' "$pod" | sed 's/"containers":\\[/"containers":"PRIVATE_MALFORMED_POD_FIXTURE","ignoredContainers":[/')" ;;
+      watchdog-malformed-container) pod="$(printf '%s' "$pod" | sed 's/{"volumeMounts"/"PRIVATE_MALFORMED_POD_FIXTURE",{"volumeMounts"/')" ;;
+      watchdog-malformed-mounts) pod="$(printf '%s' "$pod" | sed 's/"volumeMounts":\\[/"volumeMounts":"PRIVATE_MALFORMED_POD_FIXTURE","ignoredMounts":[/')" ;;
+      watchdog-malformed-mount) pod="$(printf '%s' "$pod" | sed 's/{"name":"watchdog","mountPath"/"PRIVATE_MALFORMED_POD_FIXTURE",{"name":"watchdog","mountPath"/')" ;;
       watchdog-multiple-pods|watchdog-second-log-fails) pod="$pod,$(printf '%s' "$pod" | sed 's/alertmanager-0/alertmanager-1/')" ;;
     esac
     printf '%s\n' '{"items":['"$pod"']}'
@@ -684,7 +692,10 @@ case "$*" in
       watchdog-logs-fail) echo 'PRIVATE_LOG_RETRIEVAL_SENTINEL' >&2; exit 51 ;;
       watchdog-second-log-fails) case "$*" in *"-1 -c alertmanager"*) echo 'PRIVATE_LOG_RETRIEVAL_SENTINEL' >&2; exit 51 ;; esac ;;
     esac
-    printf '%s' "$WATCHDOG_LOG_TEXT"
+    case "$*" in
+      *"alertmanager-0 -c alertmanager"*) printf '%s' "${WATCHDOG_LOG_TEXT_0:-$WATCHDOG_LOG_TEXT}" ;;
+      *"alertmanager-1 -c alertmanager"*) printf '%s' "${WATCHDOG_LOG_TEXT_1:-$WATCHDOG_LOG_TEXT}" ;;
+    esac
     ;;
   *"create --raw /api/v1/namespaces/monitoring/services/http:kube-prometheus-stack-alertmanager:9093/proxy/api/v2/silences -f -"*)
     cat > "$WATCHDOG_SILENCE_PAYLOAD"
@@ -1750,23 +1761,38 @@ def test_watchdog_live_check_fails_closed_without_matching_resource_pods(tmp_pat
     assert result.returncode != 0
     assert "no operator-managed Alertmanager pods matched the expected resource" in result.stderr
     assert " logs " not in audit
+    assert "POD_FIXTURE_SENTINEL" not in result.stdout + result.stderr + audit
+    assert not list(tmp_path.glob("sugarkube-watchdog-verify.*"))
 
 
 @pytest.mark.parametrize(
     "mode",
     [
         "watchdog-malformed-pods",
+        "watchdog-malformed-metadata",
+        "watchdog-malformed-labels",
+        "watchdog-malformed-name",
         "watchdog-malformed-status",
+        "watchdog-malformed-spec",
         "watchdog-malformed-volumes",
+        "watchdog-malformed-volume",
         "watchdog-malformed-containers",
+        "watchdog-malformed-container",
+        "watchdog-malformed-mounts",
+        "watchdog-malformed-mount",
     ],
 )
 def test_watchdog_live_check_fails_closed_on_malformed_pod_inventory(tmp_path, mode):
-    result, _ = run_helper(tmp_path, "watchdog-verify", kubectl_mode=mode)
+    result, audit = run_helper(tmp_path, "watchdog-verify", kubectl_mode=mode)
 
     assert result.returncode != 0
     assert "pod data is malformed (response redacted)" in result.stderr
-    assert "PRIVATE_MALFORMED_POD_FIXTURE" not in result.stdout + result.stderr
+    exposed = result.stdout + result.stderr + audit
+    assert "Traceback" not in exposed
+    assert "PRIVATE_MALFORMED_POD_FIXTURE" not in exposed
+    assert "fixture.invalid" not in exposed
+    assert "credential@example" not in exposed
+    assert not list(tmp_path.glob("sugarkube-watchdog-verify.*"))
 
 
 def test_watchdog_live_check_rejects_extra_rule_label_without_printing_payload(tmp_path):
@@ -1826,6 +1852,38 @@ def test_watchdog_delivery_ignores_unrelated_alertmanager_errors(tmp_path):
     assert result.returncode == 0, result.stderr
     assert "bounded repeat observation verified" in result.stdout
     assert private_log not in result.stdout + result.stderr
+
+
+def test_watchdog_delivery_does_not_join_separate_pod_logs(tmp_path):
+    result, _ = run_helper(
+        tmp_path,
+        "watchdog-verify",
+        kubectl_mode="watchdog-multiple-pods",
+        extra_env={
+            "WATCHDOG_LOG_TEXT_0": "healthchecks-watchdog",
+            "WATCHDOG_LOG_TEXT_1": "error LOG_FIXTURE_SENTINEL",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "bounded repeat observation verified" in result.stdout
+    assert "LOG_FIXTURE_SENTINEL" not in result.stdout + result.stderr
+    assert not list(tmp_path.glob("sugarkube-watchdog-verify.*"))
+
+
+def test_watchdog_delivery_same_pod_receiver_error_still_fails(tmp_path):
+    private_log = "healthchecks-watchdog error LOG_FIXTURE_SENTINEL"
+    result, _ = run_helper(
+        tmp_path,
+        "watchdog-verify",
+        kubectl_mode="watchdog-multiple-pods",
+        extra_env={"WATCHDOG_LOG_TEXT_0": private_log, "WATCHDOG_LOG_TEXT_1": "healthy"},
+    )
+
+    assert result.returncode != 0
+    assert "watchdog receiver delivery error observed" in result.stderr
+    assert private_log not in result.stdout + result.stderr
+    assert not list(tmp_path.glob("sugarkube-watchdog-verify.*"))
 
 
 def test_watchdog_delivery_log_retrieval_failure_is_sanitized(tmp_path):

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -672,6 +672,9 @@ case "$*" in
     pod='{"metadata":{"name":"alertmanager-kube-prometheus-stack-alertmanager-0","labels":{"alertmanager":"kube-prometheus-stack-alertmanager"}},"status":{"phase":"'"$phase"'"},"spec":{"volumes":[{"name":"'"$volume"'","secret":{"secretName":"'"$secret"'"}}],"containers":[{"volumeMounts":[{"name":"watchdog","mountPath":"'"$mount"'","readOnly":'"$readonly"'}]}]},"private":"POD_FIXTURE_SENTINEL"}'
     case "$KUBECTL_MODE" in
       watchdog-unrelated-pod) pod='{"metadata":{"name":"unrelated-alertmanager-0","labels":{"alertmanager":"another-resource"}},"status":{"phase":"Running"},"spec":{}}' ;;
+      watchdog-malformed-status) pod="$(printf '%s' "$pod" | sed 's/"status":{"phase":"Running"}/"status":"PRIVATE_MALFORMED_POD_FIXTURE"/')" ;;
+      watchdog-malformed-volumes) pod="$(printf '%s' "$pod" | sed 's/"volumes":\[/"volumes":"PRIVATE_MALFORMED_POD_FIXTURE","ignored":\[/')" ;;
+      watchdog-malformed-containers) pod="$(printf '%s' "$pod" | sed 's/"containers":\[/"containers":"PRIVATE_MALFORMED_POD_FIXTURE","ignoredContainers":\[/')" ;;
       watchdog-multiple-pods|watchdog-second-log-fails) pod="$pod,$(printf '%s' "$pod" | sed 's/alertmanager-0/alertmanager-1/')" ;;
     esac
     printf '%s\n' '{"items":['"$pod"']}'
@@ -1745,12 +1748,21 @@ def test_watchdog_live_check_fails_closed_without_matching_resource_pods(tmp_pat
     result, audit = run_helper(tmp_path, "watchdog-verify", kubectl_mode=mode)
 
     assert result.returncode != 0
-    assert "exact watchdog Secret mount" in result.stderr
+    assert "no operator-managed Alertmanager pods matched the expected resource" in result.stderr
     assert " logs " not in audit
 
 
-def test_watchdog_live_check_fails_closed_on_malformed_pod_inventory(tmp_path):
-    result, _ = run_helper(tmp_path, "watchdog-verify", kubectl_mode="watchdog-malformed-pods")
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "watchdog-malformed-pods",
+        "watchdog-malformed-status",
+        "watchdog-malformed-volumes",
+        "watchdog-malformed-containers",
+    ],
+)
+def test_watchdog_live_check_fails_closed_on_malformed_pod_inventory(tmp_path, mode):
+    result, _ = run_helper(tmp_path, "watchdog-verify", kubectl_mode=mode)
 
     assert result.returncode != 0
     assert "pod data is malformed (response redacted)" in result.stderr
@@ -1768,7 +1780,6 @@ def test_watchdog_live_check_rejects_extra_rule_label_without_printing_payload(t
 @pytest.mark.parametrize(
     "mode",
     [
-        "watchdog-no-pods",
         "watchdog-pod-not-running",
         "watchdog-missing-volume",
         "watchdog-wrong-secret-volume",

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -661,6 +661,7 @@ case "$*" in
     readonly=true
     case "$KUBECTL_MODE" in
       watchdog-no-pods) printf '%s\n' '{"items":[],"private":"POD_FIXTURE_SENTINEL"}'; exit 0 ;;
+      watchdog-malformed-pods) printf '%s\n' '{"items":"PRIVATE_MALFORMED_POD_FIXTURE"}'; exit 0 ;;
       watchdog-pod-not-running) phase=Pending ;;
       watchdog-missing-volume) volume=unmounted ;;
       watchdog-wrong-secret-volume) secret=another-secret ;;
@@ -668,11 +669,17 @@ case "$*" in
       watchdog-wrong-mount-path) mount=/etc/alertmanager/secrets/wrong ;;
       watchdog-mount-not-readonly) readonly=false ;;
     esac
-    printf '%s\n' '{"items":[{"status":{"phase":"'"$phase"'"},"spec":{"volumes":[{"name":"'"$volume"'","secret":{"secretName":"'"$secret"'"}}],"containers":[{"volumeMounts":[{"name":"watchdog","mountPath":"'"$mount"'","readOnly":'"$readonly"'}]}]},"private":"POD_FIXTURE_SENTINEL"}]}'
+    pod='{"metadata":{"name":"alertmanager-kube-prometheus-stack-alertmanager-0","labels":{"alertmanager":"kube-prometheus-stack-alertmanager"}},"status":{"phase":"'"$phase"'"},"spec":{"volumes":[{"name":"'"$volume"'","secret":{"secretName":"'"$secret"'"}}],"containers":[{"volumeMounts":[{"name":"watchdog","mountPath":"'"$mount"'","readOnly":'"$readonly"'}]}]},"private":"POD_FIXTURE_SENTINEL"}'
+    case "$KUBECTL_MODE" in
+      watchdog-unrelated-pod) pod='{"metadata":{"name":"unrelated-alertmanager-0","labels":{"alertmanager":"another-resource"}},"status":{"phase":"Running"},"spec":{}}' ;;
+      watchdog-multiple-pods|watchdog-second-log-fails) pod="$pod,$(printf '%s' "$pod" | sed 's/alertmanager-0/alertmanager-1/')" ;;
+    esac
+    printf '%s\n' '{"items":['"$pod"']}'
     ;;
-  *"logs statefulset/kube-prometheus-stack-alertmanager"*)
+  *"logs pod/alertmanager-kube-prometheus-stack-alertmanager-"*" -c alertmanager "*)
     case "$KUBECTL_MODE" in
       watchdog-logs-fail) echo 'PRIVATE_LOG_RETRIEVAL_SENTINEL' >&2; exit 51 ;;
+      watchdog-second-log-fails) case "$*" in *"-1 -c alertmanager"*) echo 'PRIVATE_LOG_RETRIEVAL_SENTINEL' >&2; exit 51 ;; esac ;;
     esac
     printf '%s' "$WATCHDOG_LOG_TEXT"
     ;;
@@ -1718,7 +1725,36 @@ def test_watchdog_live_check_accepts_exact_rule_labels_and_external_alert_labels
     assert "proxy/api/v1/rules" in audit
     assert "/api/v2/alerts" in audit
     assert "get pods -l app.kubernetes.io/name=alertmanager -o json" in audit
-    assert "logs statefulset/kube-prometheus-stack-alertmanager" in audit
+    assert "logs pod/alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager" in audit
+    assert "statefulset/kube-prometheus-stack-alertmanager" not in audit
+    assert not list(tmp_path.glob("sugarkube-watchdog-verify.*"))
+
+
+def test_watchdog_live_check_inspects_every_matching_operator_pod(tmp_path):
+    result, audit = run_helper(tmp_path, "watchdog-verify", kubectl_mode="watchdog-multiple-pods")
+
+    assert result.returncode == 0, result.stderr
+    assert audit.count(" -c alertmanager ") == 2
+    assert "logs pod/alertmanager-kube-prometheus-stack-alertmanager-0" in audit
+    assert "logs pod/alertmanager-kube-prometheus-stack-alertmanager-1" in audit
+    assert "statefulset/kube-prometheus-stack-alertmanager" not in audit
+
+
+@pytest.mark.parametrize("mode", ["watchdog-no-pods", "watchdog-unrelated-pod"])
+def test_watchdog_live_check_fails_closed_without_matching_resource_pods(tmp_path, mode):
+    result, audit = run_helper(tmp_path, "watchdog-verify", kubectl_mode=mode)
+
+    assert result.returncode != 0
+    assert "exact watchdog Secret mount" in result.stderr
+    assert " logs " not in audit
+
+
+def test_watchdog_live_check_fails_closed_on_malformed_pod_inventory(tmp_path):
+    result, _ = run_helper(tmp_path, "watchdog-verify", kubectl_mode="watchdog-malformed-pods")
+
+    assert result.returncode != 0
+    assert "pod data is malformed (response redacted)" in result.stderr
+    assert "PRIVATE_MALFORMED_POD_FIXTURE" not in result.stdout + result.stderr
 
 
 def test_watchdog_live_check_rejects_extra_rule_label_without_printing_payload(tmp_path):
@@ -1787,6 +1823,18 @@ def test_watchdog_delivery_log_retrieval_failure_is_sanitized(tmp_path):
     assert result.returncode != 0
     assert "Alertmanager logs could not be retrieved (details redacted)" in result.stderr
     assert "PRIVATE_LOG_RETRIEVAL_SENTINEL" not in result.stdout + result.stderr
+
+
+def test_watchdog_delivery_one_of_multiple_log_retrievals_fails_closed(tmp_path):
+    result, audit = run_helper(
+        tmp_path, "watchdog-verify", kubectl_mode="watchdog-second-log-fails"
+    )
+
+    assert result.returncode != 0
+    assert audit.count(" -c alertmanager ") == 2
+    assert "Alertmanager logs could not be retrieved (details redacted)" in result.stderr
+    assert "PRIVATE_LOG_RETRIEVAL_SENTINEL" not in result.stdout + result.stderr
+    assert not list(tmp_path.glob("sugarkube-watchdog-verify.*"))
 
 
 def watchdog_silence_fixture():


### PR DESCRIPTION
### Motivation
- The staging live verifier requested logs from `statefulset/kube-prometheus-stack-alertmanager` but the Prometheus Operator renders pods for the `Alertmanager` resource (e.g. `alertmanager-kube-prometheus-stack-alertmanager-0`), so the inferred StatefulSet lookup failed even though Alertmanager was healthy (observed root cause: mismatched StatefulSet name inference). 
- The goal is to reliably select and inspect the operator-managed Alertmanager pods, preserve the existing exact rule/secret/mount/delivery checks, and fail closed on malformed data or retrieval failures.

### Description
- Updated `scripts/observability_helm.sh` to reuse the `kubectl` pod JSON inventory, select only pods whose `metadata.labels.alertmanager` equals the rendered Alertmanager resource name, validate the pod inventory shape, and print the selected pod names into a private temp file. 
- Replaced the inferred `statefulset/...` logs request with explicit per-pod log retrieval from the `alertmanager` container (`kubectl ... logs pod/<name> -c alertmanager`) and kept all logs and stderr inside the existing private temporary directory. 
- Implemented strict fail-closed behavior for malformed pod inventory, no matching pods, non-`Running` pods, missing/incorrect Secret mounts, or any per-pod log retrieval failure while preserving the bounded observation interval and the existing receiver-attributable delivery-error scan. 
- Added and adjusted focused tests in `tests/test_observability_helm.py` to cover the operator naming shape, single and multiple pods, malformed/no-match inventories, container-specific log inspection, sanitized per-pod failures, receiver-delivery errors, unrelated errors, and temporary-file cleanup.

### Testing
- Ran `bash -n scripts/observability_helm.sh` which completed without syntax errors. 
- Ran `shellcheck scripts/observability_helm.sh` (installed in the run) which completed without actionable findings for the changed code. 
- Ran `python3 -m pytest -q tests/test_observability_helm.py -k 'watchdog and (log or live)'` and observed `19 passed, 137 deselected`. 
- Ran `python3 -m pytest -q tests/test_observability_helm.py` and observed `156 passed`. 
- Ran `just observability-render env=staging >/dev/null`, `git diff --check`, and `git diff | ./scripts/scan-secrets.py` which completed successfully for this focused change. 
- Attempted `pre-commit run --all-files` but the repository-wide hooks exposed unrelated trailing-whitespace/YAML/flake8 issues outside this change; those hook edits were discarded to keep the commit focused. 

Refs #2403

Post-merge verification: run `just observability-watchdog-verify env=staging` to confirm the staging watchdog live check in-cluster.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d5e6bd638832fa0833ef5e3d7f5d2)