### PR TITLE
Fix staging watchdog Alertmanager log retrieval

### DIFF
--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -161,17 +161,26 @@ PY
   kubectl -n "${NAMESPACE}" get alertmanager "${RELEASE}-alertmanager" -o yaml >"${tmp}/cr"
   kubectl -n "${NAMESPACE}" get secret "alertmanager-${RELEASE}-alertmanager" -o yaml >"${tmp}/config"
   ruby "${ALERTMANAGER_VALIDATOR}" live "${tmp}/cr" "${tmp}/config"
-  kubectl -n "${NAMESPACE}" get pods -l 'app.kubernetes.io/name=alertmanager' -o json >"${tmp}/pods"
-  python3 - "${tmp}/pods" <<'PY'
+  kubectl -n "${NAMESPACE}" get pods -l "app.kubernetes.io/name=alertmanager,alertmanager=${RELEASE}-alertmanager" -o json >"${tmp}/pods"
+  python3 - "${tmp}/pods" "${tmp}/pod-names" <<'PY'
 import json, sys
-try: pods=json.load(open(sys.argv[1], encoding="utf-8")).get("items",[])
-except (OSError, UnicodeError, json.JSONDecodeError): raise SystemExit("ERROR: Alertmanager pod data is malformed (response redacted).")
+try:
+ doc=json.load(open(sys.argv[1], encoding="utf-8")); pods=doc["items"]
+ if not isinstance(doc,dict) or not isinstance(pods,list): raise TypeError
+except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError): raise SystemExit("ERROR: Alertmanager pod data is malformed (response redacted).")
 def mounted(p):
  spec=p.get("spec",{}); vols=spec.get("volumes",[])
  names={v.get("name") for v in vols if v.get("secret",{}).get("secretName")=="alertmanager-healthchecks-watchdog"}
  return names and any(m.get("name") in names and m.get("mountPath")=="/etc/alertmanager/secrets/alertmanager-healthchecks-watchdog" and m.get("readOnly") is True for c in spec.get("containers",[]) for m in c.get("volumeMounts",[]))
-if not pods or any(p.get("status",{}).get("phase")!="Running" or not mounted(p) for p in pods):
+try:
+ names=[p["metadata"]["name"] for p in pods]
+ matching=all(p["metadata"]["labels"].get("app.kubernetes.io/name")=="alertmanager" and p["metadata"]["labels"].get("alertmanager")=="kube-prometheus-stack-alertmanager" for p in pods)
+ valid_names=all(isinstance(n,str) and n and all(c.islower() or c.isdigit() or c in ".-" for c in n) for n in names)
+except (KeyError, TypeError): raise SystemExit("ERROR: Alertmanager pod data is malformed (response redacted).")
+if not pods or not matching or not valid_names or any(p.get("status",{}).get("phase")!="Running" or not mounted(p) for p in pods):
  raise SystemExit("ERROR: running Alertmanager pods do not have the exact watchdog Secret mount (response redacted).")
+try: open(sys.argv[2], "w", encoding="utf-8").write("".join(n+"\n" for n in names))
+except OSError: raise SystemExit("ERROR: Alertmanager pod data could not be inspected (response redacted).")
 PY
   observation="${SUGARKUBE_WATCHDOG_OBSERVATION_SECONDS:-310}"
   [[ "${observation}" =~ ^[0-9]+$ ]] || { echo "ERROR: watchdog observation duration must be an integer." >&2; return 2; }
@@ -179,9 +188,12 @@ PY
     echo "ERROR: watchdog observation must cover at least one five-minute repeat." >&2; return 2
   fi
   sleep "${observation}"
-  if ! kubectl -n "${NAMESPACE}" logs "statefulset/${RELEASE}-alertmanager" --since="$((observation + 60))s" >"${tmp}/logs" 2>"${tmp}/logs.stderr"; then
-    echo "ERROR: Alertmanager logs could not be retrieved (details redacted)." >&2; return 1
-  fi
+  : >"${tmp}/logs"
+  while IFS= read -r pod; do
+    if ! kubectl -n "${NAMESPACE}" logs "pod/${pod}" -c alertmanager --since="$((observation + 60))s" >>"${tmp}/logs" 2>>"${tmp}/logs.stderr"; then
+      echo "ERROR: Alertmanager logs could not be retrieved (details redacted)." >&2; return 1
+    fi
+  done <"${tmp}/pod-names"
   python3 - "${tmp}/logs" <<'PY'
 import re,sys
 try: text=open(sys.argv[1], encoding="utf-8", errors="replace").read()

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -653,7 +653,7 @@ case "$*" in
     printf '%s\n' '{"data":{"groups":[{"rules":[{"name":"SugarkubeObservabilityWatchdog","state":"firing","query":"vector(1)","labels":{"environment":"staging","cluster":"sugarkube-int","purpose":"observability-watchdog"'"$extra"'}}]}]}}'
     ;;
   *"/api/v2/alerts"*) printf '%s\n' '[{"status":{"state":"active"},"labels":{"alertname":"SugarkubeObservabilityWatchdog","environment":"staging","cluster":"sugarkube-int","purpose":"observability-watchdog","prometheus":"platform-added"}}]' ;;
-  *"get pods -l app.kubernetes.io/name=alertmanager -o json"*)
+  *"get pods -l app.kubernetes.io/name=alertmanager,alertmanager=kube-prometheus-stack-alertmanager -o json"*)
     phase=Running
     secret=alertmanager-healthchecks-watchdog
     volume=watchdog
@@ -661,6 +661,7 @@ case "$*" in
     readonly=true
     case "$KUBECTL_MODE" in
       watchdog-no-pods) printf '%s\n' '{"items":[],"private":"POD_FIXTURE_SENTINEL"}'; exit 0 ;;
+      watchdog-malformed-pods) printf '%s\n' '{"items":"PRIVATE_POD_FIXTURE_SENTINEL"}'; exit 0 ;;
       watchdog-pod-not-running) phase=Pending ;;
       watchdog-missing-volume) volume=unmounted ;;
       watchdog-wrong-secret-volume) secret=another-secret ;;
@@ -668,11 +669,18 @@ case "$*" in
       watchdog-wrong-mount-path) mount=/etc/alertmanager/secrets/wrong ;;
       watchdog-mount-not-readonly) readonly=false ;;
     esac
-    printf '%s\n' '{"items":[{"status":{"phase":"'"$phase"'"},"spec":{"volumes":[{"name":"'"$volume"'","secret":{"secretName":"'"$secret"'"}}],"containers":[{"volumeMounts":[{"name":"watchdog","mountPath":"'"$mount"'","readOnly":'"$readonly"'}]}]},"private":"POD_FIXTURE_SENTINEL"}]}'
+    pod='{"metadata":{"name":"alertmanager-kube-prometheus-stack-alertmanager-0","labels":{"app.kubernetes.io/name":"alertmanager","alertmanager":"kube-prometheus-stack-alertmanager"}},"status":{"phase":"'"$phase"'"},"spec":{"volumes":[{"name":"'"$volume"'","secret":{"secretName":"'"$secret"'"}}],"containers":[{"name":"alertmanager","volumeMounts":[{"name":"watchdog","mountPath":"'"$mount"'","readOnly":'"$readonly"'}]}]},"private":"POD_FIXTURE_SENTINEL"}'
+    if [ "$KUBECTL_MODE" = watchdog-two-pods ] || [ "$KUBECTL_MODE" = watchdog-second-log-fails ]; then
+      pod2=$(printf '%s' "$pod" | sed 's/alertmanager-0/alertmanager-1/')
+      printf '{"items":[%s,%s]}\n' "$pod" "$pod2"
+    else
+      printf '{"items":[%s]}\n' "$pod"
+    fi
     ;;
-  *"logs statefulset/kube-prometheus-stack-alertmanager"*)
+  *"logs pod/alertmanager-kube-prometheus-stack-alertmanager-"*" -c alertmanager --since="*)
     case "$KUBECTL_MODE" in
       watchdog-logs-fail) echo 'PRIVATE_LOG_RETRIEVAL_SENTINEL' >&2; exit 51 ;;
+      watchdog-second-log-fails) case "$*" in *"alertmanager-1"*) echo 'PRIVATE_LOG_RETRIEVAL_SENTINEL' >&2; exit 51 ;; esac ;;
     esac
     printf '%s' "$WATCHDOG_LOG_TEXT"
     ;;
@@ -1710,15 +1718,24 @@ def test_watchdog_secret_check_rejects_missing_or_empty_ping_url(tmp_path, mode)
     assert "create secret" not in audit and "apply -f -" not in audit
 
 
-def test_watchdog_live_check_accepts_exact_rule_labels_and_external_alert_labels(tmp_path):
-    result, audit = run_helper(tmp_path, "watchdog-verify")
+@pytest.mark.parametrize(("mode", "pod_count"), [("healthy", 1), ("watchdog-two-pods", 2)])
+def test_watchdog_live_check_uses_operator_pods_and_alertmanager_container(
+    tmp_path, mode, pod_count
+):
+    result, audit = run_helper(tmp_path, "watchdog-verify", kubectl_mode=mode)
 
     assert result.returncode == 0, result.stderr
     assert "bounded repeat observation verified" in result.stdout
     assert "proxy/api/v1/rules" in audit
     assert "/api/v2/alerts" in audit
-    assert "get pods -l app.kubernetes.io/name=alertmanager -o json" in audit
-    assert "logs statefulset/kube-prometheus-stack-alertmanager" in audit
+    assert (
+        "get pods -l app.kubernetes.io/name=alertmanager,"
+        "alertmanager=kube-prometheus-stack-alertmanager -o json" in audit
+    )
+    assert audit.count("logs pod/alertmanager-kube-prometheus-stack-alertmanager-") == pod_count
+    assert audit.count(" -c alertmanager --since=") == pod_count
+    assert "logs statefulset/" not in audit
+    assert not list(tmp_path.glob("sugarkube-watchdog-verify.*"))
 
 
 def test_watchdog_live_check_rejects_extra_rule_label_without_printing_payload(tmp_path):
@@ -1747,6 +1764,17 @@ def test_watchdog_mount_contract_fails_closed_and_redacts_pod_data(tmp_path, mod
     assert result.returncode != 0
     assert "running Alertmanager pods do not have the exact watchdog Secret mount" in result.stderr
     assert "POD_FIXTURE_SENTINEL" not in result.stdout + result.stderr
+
+
+def test_watchdog_malformed_pod_inventory_fails_closed_and_is_sanitized(tmp_path):
+    result, audit = run_helper(
+        tmp_path, "watchdog-verify", kubectl_mode="watchdog-malformed-pods"
+    )
+
+    assert result.returncode != 0
+    assert "Alertmanager pod data is malformed (response redacted)" in result.stderr
+    assert "PRIVATE_POD_FIXTURE_SENTINEL" not in result.stdout + result.stderr
+    assert " logs " not in audit
 
 
 @pytest.mark.parametrize(
@@ -1787,6 +1815,19 @@ def test_watchdog_delivery_log_retrieval_failure_is_sanitized(tmp_path):
     assert result.returncode != 0
     assert "Alertmanager logs could not be retrieved (details redacted)" in result.stderr
     assert "PRIVATE_LOG_RETRIEVAL_SENTINEL" not in result.stdout + result.stderr
+
+
+def test_watchdog_second_pod_log_failure_fails_closed_and_is_sanitized(tmp_path):
+    result, audit = run_helper(
+        tmp_path, "watchdog-verify", kubectl_mode="watchdog-second-log-fails"
+    )
+
+    assert result.returncode != 0
+    assert audit.count("logs pod/alertmanager-kube-prometheus-stack-alertmanager-") == 2
+    assert "Alertmanager logs could not be retrieved (details redacted)" in result.stderr
+    assert "PRIVATE_LOG_RETRIEVAL_SENTINEL" not in result.stdout + result.stderr
+    assert "statefulset/kube-prometheus-stack-alertmanager" not in audit
+    assert not list(tmp_path.glob("sugarkube-watchdog-verify.*"))
 
 
 def watchdog_silence_fixture():


### PR DESCRIPTION
### Motivation

- The watchdog verifier attempted to read Alertmanager logs from an inferred `statefulset/${RELEASE}-alertmanager` workload which does not exist for Prometheus Operator-managed Alertmanager pods.  
- This caused `watchdog-verify` to fail even though the rule, active alert, Secret mount, and delivery to Healthchecks were successful.  
- The intent is to select the operator-created Alertmanager pods via stable labels and read the `alertmanager` container logs for each pod, failing closed and keeping diagnostics private.  

### Description

- Change `scripts/observability_helm.sh` to list pods with the Operator label contract `app.kubernetes.io/name=alertmanager,alertmanager=${RELEASE}-alertmanager`, validate the returned JSON, and fail closed on malformed or empty inventories.  
- Reuse the pod inventory to write a private `pod-names` file and iterate over each pod, retrieving logs explicitly from the `alertmanager` container and preserving logs/stderr in the script's private temp directory.  
- Preserve the bounded observation interval, the existing receiver-attributable delivery-error scan, and the final success message while ensuring any per-pod log retrieval failure is sanitized and fails closed.  
- Extend `tests/test_observability_helm.py` to cover operator pod naming (single and multi-pod), malformed/empty inventories, per-pod log failure sanitization, explicit container inspection, removal of the obsolete StatefulSet lookup, and temporary-file cleanup.  

### Testing

- Ran `bash -n scripts/observability_helm.sh` which succeeded.  
- Ran `shellcheck scripts/observability_helm.sh` which succeeded.  
- Ran targeted tests `python3 -m pytest -q tests/test_observability_helm.py -k 'watchdog and (log or live)'` and full file `python3 -m pytest -q tests/test_observability_helm.py`, with the test file passing (the run reported `154 passed`).  
- Ran `just observability-render env=staging` which succeeded for the changed templates, and ran `git diff --check` plus `git diff | ./scripts/scan-secrets.py` which found no leaked credentials.  
- `pre-commit run --all-files` surfaced unrelated, pre-existing repo-wide lint and YAML issues (auto-fixes were reverted to respect the scope lock), and `pyspelling` could not run in this environment due to a missing `aspell` executable; these do not affect the scoped fix.  

Refs #2403

Post-merge verification: run `just observability-watchdog-verify env=staging`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d5e6ffe78832f9d2954654baab6d5)