### PR TITLE
Fix DSPACE 3.0.1 recovery runtime verification

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -125,22 +125,25 @@ PUBLIC_BUILD=$(mktemp)
 DIRECT_BUILD=$(mktemp)
 trap 'rm -f "$RECOVERY_CONFIG" "$PUBLIC_BUILD" "$DIRECT_BUILD"' EXIT
 curl --fail --silent --show-error --max-time 10 --max-filesize 16384 \
-  "https://$PROD_HOST/build-info.json" >"$PUBLIC_BUILD"
-jq -e '{version, revision, shortRevision, image}' "$PUBLIC_BUILD" \
+  "https://$PROD_HOST/build-meta.json" >"$PUBLIC_BUILD"
+jq -e '{gitSha, generatedAt, source}' "$PUBLIC_BUILD" \
   >"$CAPTURE/public-build-identity.json"
 POD=$(kubectl --kubeconfig "$PROD_KUBECONFIG" -n dspace get pods \
   -l app.kubernetes.io/name=dspace,app.kubernetes.io/instance=dspace \
   -o jsonpath='{.items[0].metadata.name}')
+HTTP_PORT=$(kubectl --kubeconfig "$PROD_KUBECONFIG" -n dspace get deployment dspace -o json \
+  | jq -er '[.spec.template.spec.containers[] | select(.name == "dspace")
+    | .ports[] | select(.name == "http") | .containerPort] | if length == 1 then .[0] else error("expected one http port") end')
 timeout 10s kubectl --kubeconfig "$PROD_KUBECONFIG" get --raw \
-  "/api/v1/namespaces/dspace/pods/$POD:3000/proxy/build-info.json" \
+  "/api/v1/namespaces/dspace/pods/$POD:$HTTP_PORT/proxy/build-meta.json" \
   | head -c 16384 >"$DIRECT_BUILD"
-jq -e '{version, revision, shortRevision, image}' "$DIRECT_BUILD" \
+jq -e '{gitSha, generatedAt, source}' "$DIRECT_BUILD" \
   >"$CAPTURE/direct-build-identity.json"
 ```
 
 Do not run `dspace-release-verify` against the pre-change 3.0.2 candidate: the full verifier
 correctly rejects the currently installed 3.0.1 chart. The bounded captures above retain only the
-four allowlisted identity fields and cap each response at 16 KiB. Before evidence reservation or
+three allowlisted identity fields and cap each response at 16 KiB. Before evidence reservation or
 mutation, run the existing recipe's exact read-only digest-qualified render and structural
 validation sequence:
 
@@ -221,11 +224,27 @@ requires complete post-mutation finalization before the freeze can be reconsider
 ## Mandatory release verification
 
 DSPACE staging and production releases are verified against an approved immutable release
-manifest. The verifier checks public build identity and frontend marker, every ready serving
-replica's image coordinate, digest, build identity, and frontend marker, then invokes DSPACE's
-non-destructive remote `/chat` harness. It uses read-only Kubernetes API pod proxies. Successful
+manifest. By default, the verifier uses the strict `build-info-v1` contract: public and direct
+`/build-info.json`, exact public and direct HTML revision markers, and agreement across replicas.
+It derives the proxy port from the unique `http` port on the unique Deployment `dspace` container
+and requires every pod's unique `dspace` container to declare that same valid port. It then invokes
+DSPACE's non-destructive remote `/chat` harness with an explicit `--identity-contract
+build-info-v1`. It uses read-only Kubernetes API pod proxies. Successful
 bounded results are included in finalized evidence as `runtimeVerification`; response bodies,
 child output, browser artifacts, headers, cookies, credentials, and request payloads are not saved.
+
+The sole exception is the complete coordinate tuple in
+`docs/apps/dspace.prod-recovery-coordinates.json`, augmented by candidate provider `openai`: schema
+2, application `3.0.1`, source revision `1a31a569aff2dbeb238e8c2688b9e85140d2077d`, chart source
+revision `63063e287adb92a4158ce2c8e7d378b73f52c1c5`, image tag `main-1a31a56`, image digest
+`sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401`, chart `3.0.2` with digest
+`sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575`, and semantic tag
+`v3.0.1`. Only that exact candidate uses `legacy-build-meta-v1`. The verifier proves identical
+`gitSha`, valid non-empty `generatedAt`, and non-empty `source` through public and every direct
+`/build-meta.json`, while still validating bounded non-empty root documents, and passes the legacy
+contract explicitly to the smoke runner. This is not a fallback: any coordinate drift uses the
+modern contract and a modern identity failure remains fatal. The exception changes neither the
+immutable recovery coordinates nor candidate approval.
 
 Prepare a DSPACE checkout with `pnpm install` and `pnpm exec playwright install chromium`. The
 runner must be executable. It mocks provider transport, so no token.place or OpenAI credentials

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -12,6 +12,7 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -42,6 +43,21 @@ RESULT_FIELDS = (
     "journeys",
 )
 BUILD_FIELDS = {"version", "revision", "shortRevision", "image"}
+LEGACY_BUILD_FIELDS = {"gitSha", "generatedAt", "source"}
+MODERN_IDENTITY_CONTRACT = "build-info-v1"
+LEGACY_IDENTITY_CONTRACT = "legacy-build-meta-v1"
+LEGACY_RECOVERY_COORDINATES = {
+    "schemaVersion": 2,
+    "applicationVersion": "3.0.1",
+    "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+    "chartSourceRevision": "63063e287adb92a4158ce2c8e7d378b73f52c1c5",
+    "imageTag": "main-1a31a56",
+    "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
+    "chartVersion": "3.0.2",
+    "chartDigest": "sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575",
+    "semanticTag": "v3.0.1",
+    "expectedDefaultChatProvider": "openai",
+}
 META_RE = re.compile(
     r'<meta\s+[^>]*name=["\']dspace-build-revision["\'][^>]*content=["\']([^"\']+)',
     re.IGNORECASE,
@@ -174,6 +190,64 @@ def marker(raw: bytes, revision: str, category: str) -> None:
         fail(category)
 
 
+def identity_contract(manifest: dict[str, Any]) -> str:
+    """Select legacy identity only for the complete approved recovery tuple."""
+    if all(manifest.get(key) == value for key, value in LEGACY_RECOVERY_COORDINATES.items()):
+        return LEGACY_IDENTITY_CONTRACT
+    return MODERN_IDENTITY_CONTRACT
+
+
+def named_http_port(container: object, category: str) -> int:
+    """Return the unique, valid named HTTP container port."""
+    if not isinstance(container, dict) or not isinstance(container.get("ports"), list):
+        fail(category)
+    matches = [
+        port for port in container["ports"] if isinstance(port, dict) and port.get("name") == "http"
+    ]
+    if len(matches) != 1:
+        fail(category)
+    value = matches[0].get("containerPort")
+    if type(value) is not int or not 1 <= value <= 65535:
+        fail(category)
+    return value
+
+
+def legacy_identity(raw: bytes, revision: str, category: str) -> tuple[str, str, str]:
+    """Validate and normalize the legacy public build metadata contract."""
+    if len(raw) > 1024 * 1024:
+        fail(category)
+    try:
+        value = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        fail(category)
+    if not isinstance(value, dict) or set(value) != LEGACY_BUILD_FIELDS:
+        fail(category)
+    generated_at, source = value.get("generatedAt"), value.get("source")
+    if value.get("gitSha") != revision or not isinstance(generated_at, str) or not generated_at:
+        fail(category)
+    if not isinstance(source, str) or not source.strip():
+        fail(category)
+    try:
+        timestamp = datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+    except ValueError:
+        fail(category)
+    if timestamp.tzinfo is None:
+        fail(category)
+    return revision, generated_at, source
+
+
+def root_document(raw: bytes, category: str) -> None:
+    """Require bounded, non-empty UTF-8 root evidence without inferring identity."""
+    if len(raw) > 1024 * 1024:
+        fail(category)
+    try:
+        value = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        fail(category)
+    if not value.strip():
+        fail(category)
+
+
 def values_expectations(paths: list[Path]) -> tuple[str, str]:
     """Resolve token.place settings through the same ordered merge used by app_chart."""
     try:
@@ -213,6 +287,7 @@ def load_manifest(path: Path) -> dict[str, Any]:
 
 def verify(args: argparse.Namespace) -> dict[str, Any]:
     manifest = load_manifest(args.manifest)
+    contract = identity_contract(manifest)
     expected = {
         "version": manifest["applicationVersion"],
         "revision": manifest["sourceRevision"],
@@ -296,6 +371,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
     declared_image = applications[0].get("image") if len(applications) == 1 else None
     if declared_image not in permitted_images:
         fail("cluster identity")
+    proxy_port = named_http_port(applications[0], "cluster identity")
     if token_values is not None:
         live_env = {item.get("name"): item.get("value") for item in applications[0].get("env", [])}
         if (
@@ -306,7 +382,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
 
     helm_before = helm_identity(args, expected["chart_version"])
 
-    direct_names = []
+    replica_identity: tuple[str, str, str] | None = None
     for pod in pods:
         metadata, spec, status = pod.get("metadata", {}), pod.get("spec", {}), pod.get("status", {})
         if metadata.get("deletionTimestamp") is not None or status.get("phase") != "Running":
@@ -350,42 +426,65 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         statuses = [c for c in status.get("containerStatuses", []) if c.get("name") == "dspace"]
         if len(containers) != 1 or containers[0].get("image") != declared_image:
             fail("pod/replica identity")
+        if named_http_port(containers[0], "pod/replica identity") != proxy_port:
+            fail("pod/replica identity")
         image_id = statuses[0].get("imageID") if len(statuses) == 1 else None
         if image_id_digest(image_id) != expected["digest"]:
             fail("pod/replica identity")
         name = metadata.get("name")
         if not isinstance(name, str) or not name:
             fail("pod/replica identity")
-        direct_names.append(name)
         proxy = ["kubectl", "--kubeconfig", args.kubeconfig, "get", "--raw"]
-        prefix = f"/api/v1/namespaces/{args.namespace}/pods/{name}:3000/proxy"
+        prefix = f"/api/v1/namespaces/{args.namespace}/pods/{name}:{proxy_port}/proxy"
         try:
-            direct_build = command(proxy + [prefix + "/build-info.json"]).encode()
+            identity_path = (
+                "/build-meta.json" if contract == LEGACY_IDENTITY_CONTRACT else "/build-info.json"
+            )
+            direct_build = command(proxy + [prefix + identity_path]).encode()
             direct_html = command(proxy + [prefix + "/"]).encode()
         except VerificationError:
             fail("direct identity")
-        direct_identity = identity(
-            direct_build,
+        direct_identity = (
+            legacy_identity(direct_build, expected["revision"], "direct identity")
+            if contract == LEGACY_IDENTITY_CONTRACT
+            else identity(
+                direct_build,
+                expected["version"],
+                expected["revision"],
+                canonical_image,
+                "direct identity",
+            )
+        )
+        if replica_identity is not None and direct_identity != replica_identity:
+            fail("pod/replica identity")
+        replica_identity = direct_identity
+        if contract == LEGACY_IDENTITY_CONTRACT:
+            root_document(direct_html, "direct identity")
+        else:
+            marker(direct_html, expected["revision"], "direct identity")
+
+    public_identity = (
+        legacy_identity(
+            fetch(base_url + "/build-meta.json", origin),
+            expected["revision"],
+            "public identity",
+        )
+        if contract == LEGACY_IDENTITY_CONTRACT
+        else identity(
+            fetch(base_url + "/build-info.json", origin),
             expected["version"],
             expected["revision"],
             canonical_image,
-            "direct identity",
+            "public identity",
         )
-        if direct_names and "replica_identity" in locals() and direct_identity != replica_identity:
-            fail("pod/replica identity")
-        replica_identity = direct_identity
-        marker(direct_html, expected["revision"], "direct identity")
-
-    public_identity = identity(
-        fetch(base_url + "/build-info.json", origin),
-        expected["version"],
-        expected["revision"],
-        canonical_image,
-        "public identity",
     )
     if public_identity != replica_identity:
         fail("public identity")
-    marker(fetch(base_url + "/", origin), expected["revision"], "public identity")
+    public_root = fetch(base_url + "/", origin)
+    if contract == LEGACY_IDENTITY_CONTRACT:
+        root_document(public_root, "public identity")
+    else:
+        marker(public_root, expected["revision"], "public identity")
 
     smoke_argv = [
         str(smoke),
@@ -397,6 +496,8 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         expected["revision"],
         "--expected-provider",
         expected["provider"],
+        "--identity-contract",
+        contract,
     ]
     if expected["provider"] == "token-place":
         assert token_values is not None
@@ -435,7 +536,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         "frontendSourceRevision": expected["revision"],
         "defaultProvider": expected["provider"],
         "journeys": [
-            {"name": "/build-info.json", "passed": True},
+            {"name": identity_path, "passed": True},
             {"name": "/", "passed": True},
             {"name": "/chat", "passed": True},
         ],

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -437,10 +437,17 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         proxy = ["kubectl", "--kubeconfig", args.kubeconfig, "get", "--raw"]
         prefix = f"/api/v1/namespaces/{args.namespace}/pods/{name}:{proxy_port}/proxy"
         try:
-            identity_path = (
-                "/build-meta.json" if contract == LEGACY_IDENTITY_CONTRACT else "/build-info.json"
-            )
-            direct_build = command(proxy + [prefix + identity_path]).encode()
+            direct_build = command(
+                proxy
+                + [
+                    prefix
+                    + (
+                        "/build-meta.json"
+                        if contract == LEGACY_IDENTITY_CONTRACT
+                        else "/build-info.json"
+                    )
+                ]
+            ).encode()
             direct_html = command(proxy + [prefix + "/"]).encode()
         except VerificationError:
             fail("direct identity")
@@ -536,7 +543,14 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         "frontendSourceRevision": expected["revision"],
         "defaultProvider": expected["provider"],
         "journeys": [
-            {"name": identity_path, "passed": True},
+            {
+                "name": (
+                    "/build-meta.json"
+                    if contract == LEGACY_IDENTITY_CONTRACT
+                    else "/build-info.json"
+                ),
+                "passed": True,
+            },
             {"name": "/", "passed": True},
             {"name": "/chat", "passed": True},
         ],

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -63,6 +63,7 @@ META_RE = re.compile(
     re.IGNORECASE,
 )
 IMAGE_ID_RE = re.compile(r"sha256:[0-9a-f]{64}$")
+HTML_DOCUMENT_RE = re.compile(r"^\s*(?:<!doctype\s+html\b|<html\b)", re.IGNORECASE)
 
 
 class VerificationError(ValueError):
@@ -218,7 +219,7 @@ def legacy_identity(raw: bytes, revision: str, category: str) -> tuple[str, str,
         fail(category)
     try:
         value = json.loads(raw)
-    except (UnicodeDecodeError, json.JSONDecodeError):
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError):
         fail(category)
     if not isinstance(value, dict) or set(value) != LEGACY_BUILD_FIELDS:
         fail(category)
@@ -237,14 +238,14 @@ def legacy_identity(raw: bytes, revision: str, category: str) -> tuple[str, str,
 
 
 def root_document(raw: bytes, category: str) -> None:
-    """Require bounded, non-empty UTF-8 root evidence without inferring identity."""
+    """Require a bounded UTF-8 HTML root document without inferring identity."""
     if len(raw) > 1024 * 1024:
         fail(category)
     try:
         value = raw.decode("utf-8")
     except UnicodeDecodeError:
         fail(category)
-    if not value.strip():
+    if HTML_DOCUMENT_RE.search(value) is None:
         fail(category)
 
 
@@ -288,6 +289,9 @@ def load_manifest(path: Path) -> dict[str, Any]:
 def verify(args: argparse.Namespace) -> dict[str, Any]:
     manifest = load_manifest(args.manifest)
     contract = identity_contract(manifest)
+    identity_path = (
+        "/build-meta.json" if contract == LEGACY_IDENTITY_CONTRACT else "/build-info.json"
+    )
     expected = {
         "version": manifest["applicationVersion"],
         "revision": manifest["sourceRevision"],
@@ -437,17 +441,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         proxy = ["kubectl", "--kubeconfig", args.kubeconfig, "get", "--raw"]
         prefix = f"/api/v1/namespaces/{args.namespace}/pods/{name}:{proxy_port}/proxy"
         try:
-            direct_build = command(
-                proxy
-                + [
-                    prefix
-                    + (
-                        "/build-meta.json"
-                        if contract == LEGACY_IDENTITY_CONTRACT
-                        else "/build-info.json"
-                    )
-                ]
-            ).encode()
+            direct_build = command(proxy + [prefix + identity_path]).encode()
             direct_html = command(proxy + [prefix + "/"]).encode()
         except VerificationError:
             fail("direct identity")
@@ -472,13 +466,13 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
 
     public_identity = (
         legacy_identity(
-            fetch(base_url + "/build-meta.json", origin),
+            fetch(base_url + identity_path, origin),
             expected["revision"],
             "public identity",
         )
         if contract == LEGACY_IDENTITY_CONTRACT
         else identity(
-            fetch(base_url + "/build-info.json", origin),
+            fetch(base_url + identity_path, origin),
             expected["version"],
             expected["revision"],
             canonical_image,
@@ -544,11 +538,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         "defaultProvider": expected["provider"],
         "journeys": [
             {
-                "name": (
-                    "/build-meta.json"
-                    if contract == LEGACY_IDENTITY_CONTRACT
-                    else "/build-info.json"
-                ),
+                "name": identity_path,
                 "passed": True,
             },
             {"name": "/", "passed": True},

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -165,9 +165,12 @@ def _verify_setup(
     direct_builds = override.get("direct_builds", {})
     direct_html = override.get("direct_html", {})
     public_build = override.get("public_build", build())
-    public_html = override.get(
-        "public_html", f'<meta name="dspace-build-revision" content="{SHA}">'
+    default_html = (
+        "<!doctype html><html><head><title>DSPACE</title></head><body></body></html>"
+        if legacy
+        else f'<meta name="dspace-build-revision" content="{SHA}">'
     )
+    public_html = override.get("public_html", default_html)
     legacy_build = json.dumps(
         {"gitSha": revision, "generatedAt": "2026-08-01T12:00:00Z", "source": "dspace"}
     )
@@ -247,7 +250,7 @@ def _verify_setup(
             return override.get("direct_meta", {}).get(pod_name, legacy_build)
         if argv[-1].endswith("build-info.json"):
             return direct_builds.get(pod_name, build())
-        return direct_html.get(pod_name, f'<meta name="dspace-build-revision" content="{SHA}">')
+        return direct_html.get(pod_name, default_html)
 
     monkeypatch.setattr(verifier, "command", command)
     monkeypatch.setattr(
@@ -428,12 +431,14 @@ def test_modern_identity_failure_never_requests_legacy_surface(
 @pytest.mark.parametrize(
     "payload",
     [
-        "{",
-        "x" * (1024 * 1024 + 1),
-        json.dumps({"gitSha": "wrong", "generatedAt": "2026-08-01T12:00:00Z", "source": "x"}),
-        json.dumps({"gitSha": RECOVERY_SHA, "generatedAt": "", "source": "x"}),
-        json.dumps({"gitSha": RECOVERY_SHA, "generatedAt": "not-a-date", "source": "x"}),
-        json.dumps({"gitSha": RECOVERY_SHA, "generatedAt": "2026-08-01T12:00:00Z", "source": ""}),
+        b"{",
+        b"x" * (1024 * 1024 + 1),
+        b"\xff" + SENTINEL.encode(),
+        b"[" * 2000 + SENTINEL.encode() + b"]" * 2000,
+        json.dumps({"gitSha": "wrong", "generatedAt": "2026-08-01T12:00:00Z", "source": "x"}).encode(),
+        json.dumps({"gitSha": RECOVERY_SHA, "generatedAt": "", "source": "x"}).encode(),
+        json.dumps({"gitSha": RECOVERY_SHA, "generatedAt": "not-a-date", "source": "x"}).encode(),
+        json.dumps({"gitSha": RECOVERY_SHA, "generatedAt": "2026-08-01T12:00:00Z", "source": ""}).encode(),
         json.dumps(
             {
                 "gitSha": RECOVERY_SHA,
@@ -441,11 +446,13 @@ def test_modern_identity_failure_never_requests_legacy_surface(
                 "source": "x",
                 "extra": SENTINEL,
             }
-        ),
+        ).encode(),
     ],
     ids=(
         "malformed",
         "oversized",
+        "invalid-utf8",
+        "deeply-nested",
         "wrong-sha",
         "empty-time",
         "bad-time",
@@ -453,9 +460,9 @@ def test_modern_identity_failure_never_requests_legacy_surface(
         "unsafe-shape",
     ),
 )
-def test_legacy_identity_rejects_bad_payloads_without_leaking(payload: str) -> None:
+def test_legacy_identity_rejects_bad_payloads_without_leaking(payload: bytes) -> None:
     with pytest.raises(verifier.VerificationError) as raised:
-        verifier.legacy_identity(payload.encode(), RECOVERY_SHA, "direct identity")
+        verifier.legacy_identity(payload, RECOVERY_SHA, "direct identity")
     assert str(raised.value) == "direct identity"
     assert SENTINEL not in str(raised.value)
 
@@ -491,8 +498,21 @@ def test_legacy_identity_rejects_bad_payloads_without_leaking(payload: str) -> N
         ),
         ({"direct_html": {"dspace-1": ""}}, "direct identity"),
         ({"public_html": ""}, "public identity"),
+        ({"direct_html": {"dspace-1": '{"status":"ok"}'}}, "direct identity"),
+        ({"direct_html": {"dspace-1": "DSPACE is running"}}, "direct identity"),
+        ({"public_html": '{"status":"ok"}'}, "public identity"),
+        ({"public_html": "DSPACE is running"}, "public identity"),
     ],
-    ids=("replica-disagreement", "public-disagreement", "empty-direct-root", "empty-public-root"),
+    ids=(
+        "replica-disagreement",
+        "public-disagreement",
+        "empty-direct-root",
+        "empty-public-root",
+        "json-direct-root",
+        "plain-text-direct-root",
+        "json-public-root",
+        "plain-text-public-root",
+    ),
 )
 def test_legacy_agreement_and_root_evidence_fail_closed(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -10,6 +10,7 @@ from scripts import dspace_runtime_verifier as verifier
 SHA = "abcdef0123456789abcdef0123456789abcdef01"
 DIGEST = "sha256:" + "1" * 64
 SENTINEL = "SENTINEL_SECRET"
+RECOVERY_SHA = "1a31a569aff2dbeb238e8c2688b9e85140d2077d"
 
 
 def manifest(tmp_path: Path, provider: str = "token-place") -> Path:
@@ -34,6 +35,21 @@ def manifest(tmp_path: Path, provider: str = "token-place") -> Path:
             }
         )
     )
+    return path
+
+
+def recovery_manifest(tmp_path: Path, **changes: object) -> Path:
+    value = {
+        **verifier.LEGACY_RECOVERY_COORDINATES,
+        "app": "dspace",
+        "recordType": "candidate",
+        "environment": "prod",
+        "approvedAt": "2026-07-30T00:00:00Z",
+        "approvedBy": "release-test",
+        **changes,
+    }
+    path = tmp_path / "recovery.json"
+    path.write_text(json.dumps(value))
     return path
 
 
@@ -79,19 +95,25 @@ def _verify_setup(
     provider: str = "token-place",
     rollback: bool = False,
     overrides: dict[str, object] | None = None,
+    legacy: bool = False,
 ) -> tuple[Namespace, list[list[str]]]:
     """Install a complete, mutable fake cluster and return verifier arguments."""
     override = overrides or {}
     smoke = tmp_path / "smoke"
     smoke.write_text("#!/bin/sh\nexit 0\n")
     smoke.chmod(0o700)
-    canonical = "ghcr.io/democratizedspace/dspace:main-abcdef0"
-    declared = f"{canonical}@{DIGEST}" if rollback else canonical
+    revision = RECOVERY_SHA if legacy else SHA
+    digest = str(verifier.LEGACY_RECOVERY_COORDINATES["imageDigest"]) if legacy else DIGEST
+    image_tag = "main-1a31a56" if legacy else "main-abcdef0"
+    version = "3.0.1" if legacy else "3.1.0"
+    chart_version = "3.0.2" if legacy else "3.1.0"
+    canonical = f"ghcr.io/democratizedspace/dspace:{image_tag}"
+    declared = f"{canonical}@{digest}" if rollback else canonical
 
     def build(image: str = canonical, revision: str = SHA) -> str:
         return json.dumps(
             {
-                "version": "3.1.0",
+                "version": version,
                 "revision": revision,
                 "shortRevision": revision[:7],
                 "image": image,
@@ -114,11 +136,19 @@ def _verify_setup(
                         }
                     ],
                 },
-                "spec": {"containers": [{"name": "dspace", "image": declared}]},
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "dspace",
+                            "image": declared,
+                            "ports": [{"name": "http", "containerPort": 8080}],
+                        }
+                    ]
+                },
                 "status": {
                     "phase": "Running",
                     "conditions": [{"type": "Ready", "status": "True"}],
-                    "containerStatuses": [{"name": "dspace", "imageID": "containerd://" + DIGEST}],
+                    "containerStatuses": [{"name": "dspace", "imageID": "containerd://" + digest}],
                 },
             }
         )
@@ -127,8 +157,8 @@ def _verify_setup(
         override.get(
             "helm_statuses",
             [
-                {"chart": {"metadata": {"name": "dspace", "version": "3.1.0"}}, "version": 7},
-                {"chart": {"metadata": {"name": "dspace", "version": "3.1.0"}}, "version": 7},
+                {"chart": {"metadata": {"name": "dspace", "version": chart_version}}, "version": 7},
+                {"chart": {"metadata": {"name": "dspace", "version": chart_version}}, "version": 7},
             ],
         )
     )
@@ -137,6 +167,9 @@ def _verify_setup(
     public_build = override.get("public_build", build())
     public_html = override.get(
         "public_html", f'<meta name="dspace-build-revision" content="{SHA}">'
+    )
+    legacy_build = json.dumps(
+        {"gitSha": revision, "generatedAt": "2026-08-01T12:00:00Z", "source": "dspace"}
     )
 
     def command(argv: list[str]) -> str:
@@ -166,6 +199,10 @@ def _verify_setup(
                                     {
                                         "name": "dspace",
                                         "image": override.get("deployment_image", declared),
+                                        "ports": override.get(
+                                            "deployment_ports",
+                                            [{"name": "http", "containerPort": 8080}],
+                                        ),
                                         "env": [
                                             {
                                                 "name": "DSPACE_TOKEN_PLACE_URL",
@@ -206,6 +243,8 @@ def _verify_setup(
         failure = override.get("direct_failure")
         if failure == pod_name:
             raise verifier.VerificationError(SENTINEL)
+        if argv[-1].endswith("build-meta.json"):
+            return override.get("direct_meta", {}).get(pod_name, legacy_build)
         if argv[-1].endswith("build-info.json"):
             return direct_builds.get(pod_name, build())
         return direct_html.get(pod_name, f'<meta name="dspace-build-revision" content="{SHA}">')
@@ -214,7 +253,11 @@ def _verify_setup(
     monkeypatch.setattr(
         verifier,
         "fetch",
-        lambda url, origin: str(public_build if url.endswith(".json") else public_html).encode(),
+        lambda url, origin: str(
+            override.get("public_meta", legacy_build)
+            if url.endswith("build-meta.json")
+            else public_build if url.endswith(".json") else public_html
+        ).encode(),
     )
     monkeypatch.setattr(
         verifier.app_config, "load_config", lambda *args: {"SUGARKUBE_VALUES": "values.yaml"}
@@ -240,7 +283,7 @@ def _verify_setup(
             environment="staging",
             release="dspace",
             namespace="dspace",
-            manifest=manifest(tmp_path, provider),
+            manifest=recovery_manifest(tmp_path) if legacy else manifest(tmp_path, provider),
             application_version=None,
             source_revision=None,
             provider=None,
@@ -286,8 +329,180 @@ def test_verify_uses_safe_exact_smoke_argv(
     result = verifier.verify(args)
     assert list(result) == list(verifier.RESULT_FIELDS)
     assert result["journeys"][-1] == {"name": "/chat", "passed": True}
+    contract_index = seen[-1].index("--identity-contract")
+    assert seen[-1][contract_index + 1] == verifier.MODERN_IDENTITY_CONTRACT
     assert ("--expected-token-place-origin" in seen[-1]) is has_token_args
     assert SENTINEL not in json.dumps(result)
+
+
+def test_derived_http_port_is_used_for_every_direct_request(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    args, _ = _verify_setup(monkeypatch, tmp_path)
+    original = verifier.command
+    proxy_urls: list[str] = []
+
+    def command(argv: list[str]) -> str:
+        if "--raw" in argv:
+            proxy_urls.append(argv[-1])
+        return original(argv)
+
+    monkeypatch.setattr(verifier, "command", command)
+    verifier.verify(args)
+    assert len(proxy_urls) == 4
+    assert all(":8080/proxy/" in url for url in proxy_urls)
+    assert all(":3000/" not in url for url in proxy_urls)
+
+
+@pytest.mark.parametrize(
+    "ports",
+    [
+        [],
+        [{"name": "other", "containerPort": 8080}],
+        [{"name": "http", "containerPort": 8080}, {"name": "http", "containerPort": 8081}],
+        [{"name": "http", "containerPort": "8080"}],
+        [{"name": "http", "containerPort": True}],
+        [{"name": "http", "containerPort": 0}],
+        [{"name": "http", "containerPort": 65536}],
+    ],
+    ids=("missing", "wrong-name", "duplicate", "string", "boolean", "zero", "too-large"),
+)
+def test_deployment_http_port_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, ports: list[dict[str, object]]
+) -> None:
+    args, _ = _verify_setup(monkeypatch, tmp_path, overrides={"deployment_ports": ports})
+    with pytest.raises(verifier.VerificationError, match="cluster identity"):
+        verifier.verify(args)
+
+
+def test_pod_http_port_must_match_deployment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    overrides = _pod_overrides(
+        lambda pod: pod["spec"]["containers"][0]["ports"][0].update({"containerPort": 8081})
+    )
+    args, _ = _verify_setup(monkeypatch, tmp_path, overrides=overrides)
+    with pytest.raises(verifier.VerificationError, match="pod/replica identity"):
+        verifier.verify(args)
+
+
+def test_exact_recovery_uses_legacy_contract_and_truthful_journeys(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    args, seen = _verify_setup(monkeypatch, tmp_path, legacy=True, provider="openai")
+    result = verifier.verify(args)
+    contract_index = seen[-1].index("--identity-contract")
+    assert seen[-1][contract_index + 1] == verifier.LEGACY_IDENTITY_CONTRACT
+    assert result["journeys"] == [
+        {"name": "/build-meta.json", "passed": True},
+        {"name": "/", "passed": True},
+        {"name": "/chat", "passed": True},
+    ]
+
+
+@pytest.mark.parametrize("field", list(verifier.LEGACY_RECOVERY_COORDINATES))
+def test_any_recovery_coordinate_drift_prevents_legacy_selection(field: str) -> None:
+    candidate = dict(verifier.LEGACY_RECOVERY_COORDINATES)
+    candidate[field] = "different"
+    assert verifier.identity_contract(candidate) == verifier.MODERN_IDENTITY_CONTRACT
+
+
+def test_modern_identity_failure_never_requests_legacy_surface(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    args, _ = _verify_setup(monkeypatch, tmp_path, overrides={"direct_builds": {"dspace-1": "{"}})
+    original = verifier.command
+    paths: list[str] = []
+
+    def command(argv: list[str]) -> str:
+        if "--raw" in argv:
+            paths.append(argv[-1])
+        return original(argv)
+
+    monkeypatch.setattr(verifier, "command", command)
+    with pytest.raises(verifier.VerificationError, match="direct identity"):
+        verifier.verify(args)
+    assert paths and all("build-meta.json" not in path for path in paths)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "{",
+        "x" * (1024 * 1024 + 1),
+        json.dumps({"gitSha": "wrong", "generatedAt": "2026-08-01T12:00:00Z", "source": "x"}),
+        json.dumps({"gitSha": RECOVERY_SHA, "generatedAt": "", "source": "x"}),
+        json.dumps({"gitSha": RECOVERY_SHA, "generatedAt": "not-a-date", "source": "x"}),
+        json.dumps({"gitSha": RECOVERY_SHA, "generatedAt": "2026-08-01T12:00:00Z", "source": ""}),
+        json.dumps(
+            {
+                "gitSha": RECOVERY_SHA,
+                "generatedAt": "2026-08-01T12:00:00Z",
+                "source": "x",
+                "extra": SENTINEL,
+            }
+        ),
+    ],
+    ids=(
+        "malformed",
+        "oversized",
+        "wrong-sha",
+        "empty-time",
+        "bad-time",
+        "empty-source",
+        "unsafe-shape",
+    ),
+)
+def test_legacy_identity_rejects_bad_payloads_without_leaking(payload: str) -> None:
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.legacy_identity(payload.encode(), RECOVERY_SHA, "direct identity")
+    assert str(raised.value) == "direct identity"
+    assert SENTINEL not in str(raised.value)
+
+
+@pytest.mark.parametrize(
+    "overrides,category",
+    [
+        (
+            {
+                "direct_meta": {
+                    "dspace-2": json.dumps(
+                        {
+                            "gitSha": RECOVERY_SHA,
+                            "generatedAt": "2026-08-02T12:00:00Z",
+                            "source": "dspace",
+                        }
+                    )
+                }
+            },
+            "pod/replica identity",
+        ),
+        (
+            {
+                "public_meta": json.dumps(
+                    {
+                        "gitSha": RECOVERY_SHA,
+                        "generatedAt": "2026-08-02T12:00:00Z",
+                        "source": "dspace",
+                    }
+                )
+            },
+            "public identity",
+        ),
+        ({"direct_html": {"dspace-1": ""}}, "direct identity"),
+        ({"public_html": ""}, "public identity"),
+    ],
+    ids=("replica-disagreement", "public-disagreement", "empty-direct-root", "empty-public-root"),
+)
+def test_legacy_agreement_and_root_evidence_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    overrides: dict[str, object],
+    category: str,
+) -> None:
+    args, _ = _verify_setup(monkeypatch, tmp_path, legacy=True, overrides=overrides)
+    with pytest.raises(verifier.VerificationError, match=category):
+        verifier.verify(args)
 
 
 @pytest.mark.parametrize(
@@ -352,7 +567,15 @@ def _pod_overrides(mutator) -> dict[str, object]:  # noqa: ANN001
                     }
                 ],
             },
-            "spec": {"containers": [{"name": "dspace", "image": canonical}]},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "dspace",
+                        "image": canonical,
+                        "ports": [{"name": "http", "containerPort": 8080}],
+                    }
+                ]
+            },
             "status": {
                 "phase": "Running",
                 "conditions": [{"type": "Ready", "status": "True"}],

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -378,6 +378,13 @@ def test_deployment_http_port_fails_closed(
         verifier.verify(args)
 
 
+@pytest.mark.parametrize("container", [None, {}, {"ports": None}])
+def test_named_http_port_rejects_malformed_container(container: object) -> None:
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.named_http_port(container, "cluster identity")
+    assert str(raised.value) == "cluster identity"
+
+
 def test_pod_http_port_must_match_deployment(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -438,6 +445,13 @@ def test_modern_identity_failure_never_requests_legacy_surface(
         json.dumps({"gitSha": "wrong", "generatedAt": "2026-08-01T12:00:00Z", "source": "x"}).encode(),
         json.dumps({"gitSha": RECOVERY_SHA, "generatedAt": "", "source": "x"}).encode(),
         json.dumps({"gitSha": RECOVERY_SHA, "generatedAt": "not-a-date", "source": "x"}).encode(),
+        json.dumps(
+            {
+                "gitSha": RECOVERY_SHA,
+                "generatedAt": "2026-08-01T12:00:00",
+                "source": SENTINEL,
+            }
+        ).encode(),
         json.dumps({"gitSha": RECOVERY_SHA, "generatedAt": "2026-08-01T12:00:00Z", "source": ""}).encode(),
         json.dumps(
             {
@@ -456,6 +470,7 @@ def test_modern_identity_failure_never_requests_legacy_surface(
         "wrong-sha",
         "empty-time",
         "bad-time",
+        "timezone-naive",
         "empty-source",
         "unsafe-shape",
     ),
@@ -464,6 +479,21 @@ def test_legacy_identity_rejects_bad_payloads_without_leaking(payload: bytes) ->
     with pytest.raises(verifier.VerificationError) as raised:
         verifier.legacy_identity(payload, RECOVERY_SHA, "direct identity")
     assert str(raised.value) == "direct identity"
+    assert SENTINEL not in str(raised.value)
+
+
+@pytest.mark.parametrize("category", ["direct identity", "public identity"])
+@pytest.mark.parametrize(
+    "payload",
+    [b"<html>" + b"x" * (1024 * 1024) + SENTINEL.encode(), b"\xff" + SENTINEL.encode()],
+    ids=("oversized", "invalid-utf8"),
+)
+def test_root_document_rejects_unsafe_payload_without_leaking(
+    payload: bytes, category: str
+) -> None:
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.root_document(payload, category)
+    assert str(raised.value) == category
     assert SENTINEL not in str(raised.value)
 
 


### PR DESCRIPTION
### Motivation

- The existing runtime verifier assumed a hardcoded pod proxy port and the modern `/build-info.json` + HTML marker identity contract, which prevents verifying the immutable DSPACE 3.0.1 recovery candidate that exposes identity via `/build-meta.json` on the workload's named `http` port.

### Description

- Derive the proxy port from the unique `http` port on the validated Deployment `dspace` container and require every pod's `dspace` container to declare the same valid integer port in `1..65535` using `named_http_port()`; use the resolved port in all pod-proxy URLs instead of `:3000`.
- Centralize an exact allowlist `LEGACY_RECOVERY_COORDINATES` and select `legacy-build-meta-v1` only when the manifest exactly matches that complete tuple, otherwise keep `build-info-v1` as the default via `identity_contract()`.
- Implement bounded legacy validation for `/build-meta.json` with `legacy_identity()` (checks `gitSha`, `generatedAt` timezone-aware timestamp, `source`, replica/public agreement, and bounded UTF-8 root document validation), preserve modern `build-info-v1` checks unchanged, and do not fallback from modern to legacy on failure.
- Always pass the chosen identity contract to the smoke runner via `--identity-contract`, record the truthful journey names (`/build-meta.json` vs `/build-info.json`) in runtime evidence, and add small helper `root_document()` for non-identity root checks.
- Add focused tests in `tests/test_dspace_runtime_verifier.py` to cover port derivation and failure modes, exact allowlisting, legacy payload validation and agreement, smoke-runner argv, no fallback behavior, and journey outputs, and update `docs/apps/dspace.md` to document the derived-port behavior and the recovery-only legacy exception.

### Testing

- Ran `python -m pytest -q tests/test_dspace_runtime_verifier.py` and got `99 passed` for the verifier-focused suite.
- Ran `python -m pytest -q tests/test_release_manifest.py tests/test_manifest_rollback.py` and got `230 passed` for adjacent manifest tests.
- Ran formatting/lint checks with `python -m black` (reformatted the two changed files) and `python -m ruff check scripts/dspace_runtime_verifier.py tests/test_dspace_runtime_verifier.py` (no ruff errors reported for the touched files), and also ran `git diff --cached | ./scripts/scan-secrets.py` (no secrets detected).
- Ran repository checks via `bash scripts/checks.sh` (completed but reported existing repository-wide flake8 findings and skipped KiCad-related checks because KiCad is not installed), and noted `pre-commit`, `pyspelling`, and `linkchecker` were not available in the environment so those specific tools were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ebf415f8c832fa12d838a71c2e7a4)