### PR TITLE
Fix DSPACE 3.0.1 recovery runtime verification

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -125,22 +125,25 @@ PUBLIC_BUILD=$(mktemp)
 DIRECT_BUILD=$(mktemp)
 trap 'rm -f "$RECOVERY_CONFIG" "$PUBLIC_BUILD" "$DIRECT_BUILD"' EXIT
 curl --fail --silent --show-error --max-time 10 --max-filesize 16384 \
-  "https://$PROD_HOST/build-info.json" >"$PUBLIC_BUILD"
-jq -e '{version, revision, shortRevision, image}' "$PUBLIC_BUILD" \
+  "https://$PROD_HOST/build-meta.json" >"$PUBLIC_BUILD"
+jq -e '{gitSha, generatedAt, source}' "$PUBLIC_BUILD" \
   >"$CAPTURE/public-build-identity.json"
 POD=$(kubectl --kubeconfig "$PROD_KUBECONFIG" -n dspace get pods \
   -l app.kubernetes.io/name=dspace,app.kubernetes.io/instance=dspace \
   -o jsonpath='{.items[0].metadata.name}')
+HTTP_PORT=$(kubectl --kubeconfig "$PROD_KUBECONFIG" -n dspace get deployment dspace \
+  -o jsonpath='{.spec.template.spec.containers[?(@.name=="dspace")].ports[?(@.name=="http")].containerPort}')
 timeout 10s kubectl --kubeconfig "$PROD_KUBECONFIG" get --raw \
-  "/api/v1/namespaces/dspace/pods/$POD:3000/proxy/build-info.json" \
+  "/api/v1/namespaces/dspace/pods/$POD:$HTTP_PORT/proxy/build-meta.json" \
   | head -c 16384 >"$DIRECT_BUILD"
-jq -e '{version, revision, shortRevision, image}' "$DIRECT_BUILD" \
+jq -e '{gitSha, generatedAt, source}' "$DIRECT_BUILD" \
   >"$CAPTURE/direct-build-identity.json"
 ```
 
 Do not run `dspace-release-verify` against the pre-change 3.0.2 candidate: the full verifier
 correctly rejects the currently installed 3.0.1 chart. The bounded captures above retain only the
-four allowlisted identity fields and cap each response at 16 KiB. Before evidence reservation or
+three allowlisted legacy identity fields and cap each response at 16 KiB. Before evidence
+reservation or
 mutation, run the existing recipe's exact read-only digest-qualified render and structural
 validation sequence:
 
@@ -226,6 +229,19 @@ replica's image coordinate, digest, build identity, and frontend marker, then in
 non-destructive remote `/chat` harness. It uses read-only Kubernetes API pod proxies. Successful
 bounded results are included in finalized evidence as `runtimeVerification`; response bodies,
 child output, browser artifacts, headers, cookies, credentials, and request payloads are not saved.
+
+The default identity contract is `build-info-v1`: public and direct `/build-info.json` plus the
+root HTML build-revision marker must agree for every replica. The verifier derives the proxy port
+from the unique `http` port on the validated Deployment's unique `dspace` container and requires
+the same valid named port on every pod; it does not assume a numeric port. The sole exception is
+`legacy-build-meta-v1`, selected only when every approved 3.0.1 recovery coordinate (schema,
+application and chart revisions, image and chart tags/digests, semantic tag, and OpenAI provider)
+matches exactly. In that mode, bounded public and direct `/build-meta.json` documents must contain
+the approved full `gitSha`, a valid non-empty `generatedAt`, and a non-empty `source`, and must agree
+across all replicas. Bounded non-empty root documents are still checked, but the legacy HTML is not
+treated as a revision marker. Sugarkube always passes the selected contract explicitly to DSPACE's
+smoke runner. This exception is not a fallback after modern verification fails and does not alter
+immutable coordinates, candidate approval, or finalized evidence.
 
 Prepare a DSPACE checkout with `pnpm install` and `pnpm exec playwright install chromium`. The
 runner must be executable. It mocks provider transport, so no token.place or OpenAI credentials

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import datetime
 import json
 import os
 import re
@@ -42,6 +43,19 @@ RESULT_FIELDS = (
     "journeys",
 )
 BUILD_FIELDS = {"version", "revision", "shortRevision", "image"}
+LEGACY_BUILD_FIELDS = {"gitSha", "generatedAt", "source"}
+LEGACY_RECOVERY_COORDINATES = {
+    "schemaVersion": 2,
+    "applicationVersion": "3.0.1",
+    "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+    "chartSourceRevision": "63063e287adb92a4158ce2c8e7d378b73f52c1c5",
+    "imageTag": "main-1a31a56",
+    "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
+    "chartVersion": "3.0.2",
+    "chartDigest": "sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575",
+    "semanticTag": "v3.0.1",
+    "expectedDefaultChatProvider": "openai",
+}
 META_RE = re.compile(
     r'<meta\s+[^>]*name=["\']dspace-build-revision["\'][^>]*content=["\']([^"\']+)',
     re.IGNORECASE,
@@ -163,6 +177,65 @@ def identity(
     return version, revision, runtime_image or image
 
 
+def identity_contract(manifest: dict[str, Any]) -> str:
+    """Select the sole audited legacy exception; all coordinate drift stays modern."""
+    if all(manifest.get(key) == value for key, value in LEGACY_RECOVERY_COORDINATES.items()):
+        return "legacy-build-meta-v1"
+    return "build-info-v1"
+
+
+def named_http_port(container: object, category: str) -> int:
+    """Return the unique, valid named HTTP port from a trusted container."""
+    if not isinstance(container, dict) or not isinstance(container.get("ports"), list):
+        fail(category)
+    matches = [
+        port for port in container["ports"] if isinstance(port, dict) and port.get("name") == "http"
+    ]
+    if len(matches) != 1:
+        fail(category)
+    value = matches[0].get("containerPort")
+    if type(value) is not int or not 1 <= value <= 65535:
+        fail(category)
+    return value
+
+
+def legacy_identity(raw: bytes, revision: str, category: str) -> tuple[str, str, str]:
+    if len(raw) > 1024 * 1024:
+        fail(category)
+    try:
+        value = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        fail(category)
+    if not isinstance(value, dict) or set(value) != LEGACY_BUILD_FIELDS:
+        fail(category)
+    git_sha, generated_at, source = (
+        value.get("gitSha"),
+        value.get("generatedAt"),
+        value.get("source"),
+    )
+    if git_sha != revision or not isinstance(generated_at, str) or not generated_at.strip():
+        fail(category)
+    if not isinstance(source, str) or not source.strip():
+        fail(category)
+    try:
+        parsed = datetime.datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+    except ValueError:
+        fail(category)
+    if parsed.tzinfo is None:
+        fail(category)
+    return git_sha, generated_at, source
+
+
+def root_document(raw: bytes, category: str) -> None:
+    if len(raw) > 1024 * 1024 or not raw:
+        fail(category)
+    try:
+        if not raw.decode("utf-8").strip():
+            fail(category)
+    except UnicodeDecodeError:
+        fail(category)
+
+
 def marker(raw: bytes, revision: str, category: str) -> None:
     if len(raw) > 1024 * 1024:
         fail(category)
@@ -213,6 +286,7 @@ def load_manifest(path: Path) -> dict[str, Any]:
 
 def verify(args: argparse.Namespace) -> dict[str, Any]:
     manifest = load_manifest(args.manifest)
+    contract = identity_contract(manifest)
     expected = {
         "version": manifest["applicationVersion"],
         "revision": manifest["sourceRevision"],
@@ -296,6 +370,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
     declared_image = applications[0].get("image") if len(applications) == 1 else None
     if declared_image not in permitted_images:
         fail("cluster identity")
+    proxy_port = named_http_port(applications[0], "cluster identity")
     if token_values is not None:
         live_env = {item.get("name"): item.get("value") for item in applications[0].get("env", [])}
         if (
@@ -306,7 +381,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
 
     helm_before = helm_identity(args, expected["chart_version"])
 
-    direct_names = []
+    replica_identity: tuple[str, str, str] | None = None
     for pod in pods:
         metadata, spec, status = pod.get("metadata", {}), pod.get("spec", {}), pod.get("status", {})
         if metadata.get("deletionTimestamp") is not None or status.get("phase") != "Running":
@@ -350,42 +425,63 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         statuses = [c for c in status.get("containerStatuses", []) if c.get("name") == "dspace"]
         if len(containers) != 1 or containers[0].get("image") != declared_image:
             fail("pod/replica identity")
+        if named_http_port(containers[0], "pod/replica identity") != proxy_port:
+            fail("pod/replica identity")
         image_id = statuses[0].get("imageID") if len(statuses) == 1 else None
         if image_id_digest(image_id) != expected["digest"]:
             fail("pod/replica identity")
         name = metadata.get("name")
         if not isinstance(name, str) or not name:
             fail("pod/replica identity")
-        direct_names.append(name)
         proxy = ["kubectl", "--kubeconfig", args.kubeconfig, "get", "--raw"]
-        prefix = f"/api/v1/namespaces/{args.namespace}/pods/{name}:3000/proxy"
+        prefix = f"/api/v1/namespaces/{args.namespace}/pods/{name}:{proxy_port}/proxy"
         try:
-            direct_build = command(proxy + [prefix + "/build-info.json"]).encode()
+            identity_path = (
+                "/build-meta.json" if contract == "legacy-build-meta-v1" else "/build-info.json"
+            )
+            direct_build = command(proxy + [prefix + identity_path]).encode()
             direct_html = command(proxy + [prefix + "/"]).encode()
         except VerificationError:
             fail("direct identity")
-        direct_identity = identity(
-            direct_build,
+        direct_identity = (
+            legacy_identity(direct_build, expected["revision"], "direct identity")
+            if contract == "legacy-build-meta-v1"
+            else identity(
+                direct_build,
+                expected["version"],
+                expected["revision"],
+                canonical_image,
+                "direct identity",
+            )
+        )
+        if replica_identity is not None and direct_identity != replica_identity:
+            fail("pod/replica identity")
+        replica_identity = direct_identity
+        if contract == "legacy-build-meta-v1":
+            root_document(direct_html, "direct identity")
+        else:
+            marker(direct_html, expected["revision"], "direct identity")
+
+    identity_path = "/build-meta.json" if contract == "legacy-build-meta-v1" else "/build-info.json"
+    public_raw = fetch(base_url + identity_path, origin)
+    public_identity = (
+        legacy_identity(public_raw, expected["revision"], "public identity")
+        if contract == "legacy-build-meta-v1"
+        else identity(
+            public_raw,
             expected["version"],
             expected["revision"],
             canonical_image,
-            "direct identity",
+            "public identity",
         )
-        if direct_names and "replica_identity" in locals() and direct_identity != replica_identity:
-            fail("pod/replica identity")
-        replica_identity = direct_identity
-        marker(direct_html, expected["revision"], "direct identity")
-
-    public_identity = identity(
-        fetch(base_url + "/build-info.json", origin),
-        expected["version"],
-        expected["revision"],
-        canonical_image,
-        "public identity",
     )
     if public_identity != replica_identity:
         fail("public identity")
-    marker(fetch(base_url + "/", origin), expected["revision"], "public identity")
+    public_root = fetch(base_url + "/", origin)
+    if contract == "legacy-build-meta-v1":
+        root_document(public_root, "public identity")
+    else:
+        marker(public_root, expected["revision"], "public identity")
 
     smoke_argv = [
         str(smoke),
@@ -397,6 +493,8 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         expected["revision"],
         "--expected-provider",
         expected["provider"],
+        "--identity-contract",
+        contract,
     ]
     if expected["provider"] == "token-place":
         assert token_values is not None
@@ -435,7 +533,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         "frontendSourceRevision": expected["revision"],
         "defaultProvider": expected["provider"],
         "journeys": [
-            {"name": "/build-info.json", "passed": True},
+            {"name": identity_path, "passed": True},
             {"name": "/", "passed": True},
             {"name": "/chat", "passed": True},
         ],

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -114,7 +114,15 @@ def _verify_setup(
                         }
                     ],
                 },
-                "spec": {"containers": [{"name": "dspace", "image": declared}]},
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "dspace",
+                            "image": declared,
+                            "ports": [{"name": "http", "containerPort": 8080}],
+                        }
+                    ]
+                },
                 "status": {
                     "phase": "Running",
                     "conditions": [{"type": "Ready", "status": "True"}],
@@ -166,6 +174,10 @@ def _verify_setup(
                                     {
                                         "name": "dspace",
                                         "image": override.get("deployment_image", declared),
+                                        "ports": override.get(
+                                            "deployment_ports",
+                                            [{"name": "http", "containerPort": 8080}],
+                                        ),
                                         "env": [
                                             {
                                                 "name": "DSPACE_TOKEN_PLACE_URL",
@@ -202,11 +214,12 @@ def _verify_setup(
                     }
                 }
             )
+        override.setdefault("proxy_urls", []).append(argv[-1])
         pod_name = argv[-1].split("/pods/", 1)[1].split(":", 1)[0]
         failure = override.get("direct_failure")
         if failure == pod_name:
             raise verifier.VerificationError(SENTINEL)
-        if argv[-1].endswith("build-info.json"):
+        if argv[-1].endswith(".json"):
             return direct_builds.get(pod_name, build())
         return direct_html.get(pod_name, f'<meta name="dspace-build-revision" content="{SHA}">')
 
@@ -286,8 +299,101 @@ def test_verify_uses_safe_exact_smoke_argv(
     result = verifier.verify(args)
     assert list(result) == list(verifier.RESULT_FIELDS)
     assert result["journeys"][-1] == {"name": "/chat", "passed": True}
+    assert seen[-1][seen[-1].index("--identity-contract") + 1] == "build-info-v1"
     assert ("--expected-token-place-origin" in seen[-1]) is has_token_args
     assert SENTINEL not in json.dumps(result)
+
+
+def test_verify_derives_named_http_port_for_every_proxy(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    overrides: dict[str, object] = {"proxy_urls": []}
+    args, _ = _verify_setup(monkeypatch, tmp_path, overrides=overrides)
+    verifier.verify(args)
+    urls = overrides["proxy_urls"]
+    assert len(urls) == 4
+    assert all(":8080/proxy/" in url for url in urls)
+    assert not any(":3000/" in url for url in urls)
+
+
+@pytest.mark.parametrize(
+    "ports",
+    [
+        [],
+        [{"name": "http", "containerPort": 8080}, {"name": "http", "containerPort": 8081}],
+        [{"name": "http", "containerPort": "8080"}],
+        [{"name": "http", "containerPort": True}],
+        [{"name": "http", "containerPort": 0}],
+        [{"name": "http", "containerPort": 65536}],
+    ],
+    ids=("missing", "duplicate", "malformed", "boolean", "low", "high"),
+)
+def test_verify_rejects_invalid_deployment_http_ports(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, ports: list[dict[str, object]]
+) -> None:
+    args, _ = _verify_setup(monkeypatch, tmp_path, overrides={"deployment_ports": ports})
+    with pytest.raises(verifier.VerificationError, match="cluster identity"):
+        verifier.verify(args)
+
+
+def test_verify_rejects_pod_http_port_mismatch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    overrides = _pod_overrides(
+        lambda pod: pod["spec"]["containers"][0]["ports"][0].update({"containerPort": 8081})
+    )
+    args, _ = _verify_setup(monkeypatch, tmp_path, overrides=overrides)
+    with pytest.raises(verifier.VerificationError, match="pod/replica identity"):
+        verifier.verify(args)
+
+
+@pytest.mark.parametrize("field", list(verifier.LEGACY_RECOVERY_COORDINATES))
+def test_only_complete_recovery_tuple_selects_legacy(field: str) -> None:
+    approved = dict(verifier.LEGACY_RECOVERY_COORDINATES)
+    assert verifier.identity_contract(approved) == "legacy-build-meta-v1"
+    approved[field] = "drift"
+    assert verifier.identity_contract(approved) == "build-info-v1"
+
+
+def test_legacy_contract_verifies_meta_roots_and_truthful_journeys(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    meta = json.dumps({"gitSha": SHA, "generatedAt": "2026-08-02T12:00:00Z", "source": "release"})
+    overrides: dict[str, object] = {
+        "direct_builds": {"dspace-1": meta, "dspace-2": meta},
+        "public_build": meta,
+        "public_html": "<html>legacy</html>",
+        "direct_html": {"dspace-1": "<html>legacy</html>", "dspace-2": "<html>legacy</html>"},
+        "proxy_urls": [],
+    }
+    args, seen = _verify_setup(monkeypatch, tmp_path, overrides=overrides)
+    monkeypatch.setattr(verifier, "identity_contract", lambda manifest: "legacy-build-meta-v1")
+    result = verifier.verify(args)
+    assert result["journeys"] == [
+        {"name": "/build-meta.json", "passed": True},
+        {"name": "/", "passed": True},
+        {"name": "/chat", "passed": True},
+    ]
+    assert seen[-1][seen[-1].index("--identity-contract") + 1] == "legacy-build-meta-v1"
+    assert all("build-info.json" not in url for url in overrides["proxy_urls"])
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        SENTINEL,
+        "x" * (1024 * 1024 + 1),
+        json.dumps({"gitSha": "f" * 40, "generatedAt": "2026-08-02T12:00:00Z", "source": "x"}),
+        json.dumps({"gitSha": SHA, "generatedAt": "", "source": "x"}),
+        json.dumps({"gitSha": SHA, "generatedAt": "not-a-time", "source": "x"}),
+        json.dumps({"gitSha": SHA, "generatedAt": "2026-08-02T12:00:00Z", "source": ""}),
+    ],
+)
+def test_legacy_identity_failures_are_bounded(payload: str) -> None:
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.legacy_identity(payload.encode(), SHA, "direct identity")
+    assert str(raised.value) == "direct identity"
+    assert SENTINEL not in str(raised.value)
 
 
 @pytest.mark.parametrize(
@@ -352,7 +458,15 @@ def _pod_overrides(mutator) -> dict[str, object]:  # noqa: ANN001
                     }
                 ],
             },
-            "spec": {"containers": [{"name": "dspace", "image": canonical}]},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "dspace",
+                        "image": canonical,
+                        "ports": [{"name": "http", "containerPort": 8080}],
+                    }
+                ]
+            },
             "status": {
                 "phase": "Running",
                 "conditions": [{"type": "Ready", "status": "True"}],


### PR DESCRIPTION
### Motivation

- The existing runtime verifier assumed a hardcoded pod proxy port (`:3000`) and always required the modern `/build-info.json` + HTML-marker contract, which prevents verifying the immutable DSPACE 3.0.1 recovery artifact that exposes a named `http` port and legacy `/build-meta.json` identity.
- The change implements a single audited exception for the immutable 3.0.1 recovery tuple while preserving strict modern verification for every other candidate.

### Description

- Derive the direct-pod proxy port from the validated Deployment: select the unique `dspace` container port entry named `http`, require exactly one match, validate `containerPort` is an integer in `1..65535`, and require every verified pod container to expose the same named port, then use that port for all pod-proxy URLs (file: `scripts/dspace_runtime_verifier.py`).
- Centralize an exact-coordinate allowlist for the 3.0.1 recovery candidate and choose the identity contract via `identity_contract(manifest)` so every non-exact coordinate uses `build-info-v1` while the exact tuple selects `legacy-build-meta-v1` (file: `scripts/dspace_runtime_verifier.py`).
- Add bounded, fail-closed legacy verification: fetch and validate public and pod `/build-meta.json` payloads (fields `gitSha`, `generatedAt`, `source`), require replica and public/direct agreement, validate bounded root HTML without treating it as a revision marker, and do not require `/build-info.json` or the HTML revision meta in legacy mode (file: `scripts/dspace_runtime_verifier.py`).
- Always pass an explicit `--identity-contract` (either `build-info-v1` or `legacy-build-meta-v1`) to the configured DSPACE smoke runner and record journeys that were actually verified (file: `scripts/dspace_runtime_verifier.py`).
- Extend focused tests in `tests/test_dspace_runtime_verifier.py` to cover named-port derivation and validation, legacy selection only for the complete exact tuple, legacy payload edge-cases, smoke-runner argv assertions, and truthful journey names; update test fixtures to include named `http` ports.
- Update documentation in `docs/apps/dspace.md` to document derived named-port behavior, the modern default identity contract, the exact-coordinate legacy exception, and the `/build-meta.json` public/direct proof required by the recovery flow.

### Testing

- Ran `python -m pytest -q tests/test_dspace_runtime_verifier.py` and observed `92 passed` (focused verifier suite succeeded).
- Ran `python -m pytest -q tests/test_release_manifest.py tests/test_manifest_rollback.py` and observed `230 passed` (related manifest suites succeeded).
- Ran static checks and formatting: `python -m ruff check scripts/dspace_runtime_verifier.py tests/test_dspace_runtime_verifier.py` (passed) and `python -m black` formatting was applied then rechecked; final `ruff`/`black` checks passed for the modified files.
- Ran repository checks: `git diff --cached | ./scripts/scan-secrets.py` (passed) and `bash scripts/checks.sh` (completed; it reported existing repository-wide pycodestyle findings unrelated to this focused change and skipped KiBot because KiCad is not installed in the environment).
- Environment limitations: `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` could not be executed here because those tools are not installed in the execution environment. These are noted and left for CI or maintainer-run verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ebf525238832f96789684ae91e4fc)