### PR TITLE
Fix watchdog silence JSON transport

### DIFF
--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -443,7 +443,9 @@ checks, not deployment evidence from this change.
 First manually confirm a recent successful Healthchecks ping. Run
 `just observability-watchdog-drill-start env=staging`. It creates only an eight-minute Alertmanager
 silence with the watchdog's exact four labels; automatic expiry preserves recovery if the operator
-disconnects. It never shuts down a node and never manually pings the URL. Inspect it with
+disconnects. Silence creation uses an automatically allocated `127.0.0.1` Alertmanager
+port-forward and an explicit JSON request, and removes the listener and temporary request files on
+exit. It never shuts down a node and never manually pings the URL. Inspect it with
 `just observability-watchdog-drill-status env=staging`, or remove only that owned silence early with
 `just observability-watchdog-drill-clear env=staging`. Automated tests inspect the payload and do not
 wait eight minutes.

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -230,13 +230,81 @@ PY
   echo "Watchdog rule, active alert, live configuration, pod mount, and bounded repeat observation verified; delivery must be confirmed at Healthchecks."
 )
 
-watchdog_silence_create() {
+watchdog_silence_create() (
+  require_tools kubectl python3 curl sleep
   assert_context
   cat >&2 <<'EOF2'
 MANUAL CHECKPOINT: confirm Healthchecks has a recent watchdog ping before disruption and confirm the PagerDuty resolution after recovery. This creates only an eight-minute silence.
 EOF2
-  python3 -c 'import json; from datetime import datetime,timedelta,timezone; n=datetime.now(timezone.utc); f=lambda d:d.isoformat(timespec="seconds").replace("+00:00","Z"); print(json.dumps({"matchers":[{"name":k,"value":v,"isRegex":False} for k,v in [("alertname","SugarkubeObservabilityWatchdog"),("environment","staging"),("cluster","sugarkube-int"),("purpose","observability-watchdog")]],"startsAt":f(n),"endsAt":f(n+timedelta(minutes=8)),"createdBy":"sugarkube-observability-watchdog-drill","comment":"Owned staging watchdog failure drill"}))' | kubectl create --raw "${WATCHDOG_API}/silences" -f - | python3 -c 'import json,sys; d=json.load(sys.stdin); print("Owned watchdog drill silence created; id="+d["silenceID"]+"; automatic expiry=8m.")'
-}
+  local port="" line http_status silence_id
+  local -a port_forward_lines=()
+  local drill_pid="" drill_tmp
+  drill_tmp="$(mktemp -d -t sugarkube-watchdog-drill.XXXXXX)"
+  chmod 700 "${drill_tmp}"
+  # shellcheck disable=SC2317
+  cleanup_watchdog_drill() {
+    if [[ -n "${drill_pid}" && " $(jobs -pr) " == *" ${drill_pid} "* ]]; then
+      kill "${drill_pid}" 2>/dev/null || true
+    fi
+    [[ -z "${drill_pid}" ]] || wait "${drill_pid}" 2>/dev/null || true
+    rm -rf "${drill_tmp}"
+  }
+  watchdog_forward_running() {
+    [[ " $(jobs -pr) " == *" ${drill_pid} "* ]] && kill -0 "${drill_pid}" 2>/dev/null
+  }
+  trap cleanup_watchdog_drill EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  umask 077
+  python3 -c 'import json; from datetime import datetime,timedelta,timezone; n=datetime.now(timezone.utc); f=lambda d:d.isoformat(timespec="seconds").replace("+00:00","Z"); print(json.dumps({"matchers":[{"name":k,"value":v,"isRegex":False} for k,v in [("alertname","SugarkubeObservabilityWatchdog"),("environment","staging"),("cluster","sugarkube-int"),("purpose","observability-watchdog")]],"startsAt":f(n),"endsAt":f(n+timedelta(minutes=8)),"createdBy":"sugarkube-observability-watchdog-drill","comment":"Owned staging watchdog failure drill"}))' >"${drill_tmp}/payload.json"
+  : >"${drill_tmp}/port-forward.log"
+  kubectl -n "${NAMESPACE}" port-forward --address=127.0.0.1 "service/${RELEASE}-alertmanager" :9093 >"${drill_tmp}/port-forward.log" 2>&1 &
+  drill_pid=$!
+  for _ in {1..20}; do
+    watchdog_forward_running || { echo "ERROR: Alertmanager port-forward stopped (diagnostics redacted)." >&2; return 19; }
+    mapfile -t port_forward_lines <"${drill_tmp}/port-forward.log"
+    for line in "${port_forward_lines[@]}"; do
+      if [[ "${line}" =~ ^Forwarding\ from\ 127\.0\.0\.1:([1-9][0-9]{0,4})\ -\>\ 9093$ ]]; then
+        port="${BASH_REMATCH[1]}"
+        ((10#${port} <= 65535)) || port=""
+      fi
+    done
+    [[ -z "${port}" ]] || break
+    sleep 1
+  done
+  [[ -n "${port}" ]] || { echo "ERROR: Alertmanager port-forward did not establish an owned loopback listener (diagnostics redacted)." >&2; return 19; }
+  watchdog_forward_running || { echo "ERROR: Alertmanager port-forward stopped (diagnostics redacted)." >&2; return 19; }
+  if ! curl --silent --show-error --noproxy '*' --connect-timeout 3 --max-time 10 \
+    --header 'Content-Type: application/json' --data-binary "@${drill_tmp}/payload.json" \
+    --output "${drill_tmp}/response" --write-out '%{http_code}' \
+    "http://127.0.0.1:${port}/api/v2/silences" >"${drill_tmp}/status" 2>"${drill_tmp}/curl.log"; then
+    echo "ERROR: Alertmanager silence request failed (response redacted)." >&2
+    return 18
+  fi
+  watchdog_forward_running || { echo "ERROR: Alertmanager port-forward stopped (diagnostics redacted)." >&2; return 19; }
+  http_status="$(cat "${drill_tmp}/status")"
+  [[ "${http_status}" =~ ^[0-9]{3}$ && "${http_status}" == 200 ]] || {
+    echo "ERROR: Alertmanager silence request was not accepted (response redacted)." >&2
+    return 18
+  }
+  if ! silence_id="$(python3 - "${drill_tmp}/response" <<'PY'
+import json, re, sys
+try:
+    with open(sys.argv[1], encoding="utf-8") as response:
+        value = json.load(response).get("silenceID")
+    if not isinstance(value, str) or not re.fullmatch(r"[A-Za-z0-9_-]+", value):
+        raise ValueError
+except (OSError, UnicodeError, json.JSONDecodeError, AttributeError, ValueError):
+    raise SystemExit(1)
+print(value)
+PY
+  )"; then
+    echo "ERROR: Alertmanager returned an invalid silence response (response redacted)." >&2
+    return 18
+  fi
+  printf 'Owned watchdog drill silence created; id=%s; automatic expiry=8m.\n' "${silence_id}"
+)
 watchdog_owned_silences() {
   kubectl get --raw "${WATCHDOG_API}/silences" | python3 -c 'import json,sys; wanted=[("alertname","SugarkubeObservabilityWatchdog"),("environment","staging"),("cluster","sugarkube-int"),("purpose","observability-watchdog")]; out=[]
 for x in json.load(sys.stdin):

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -747,13 +747,17 @@ esac
 echo "curl $*" >> "$AUDIT"
 data=""
 noproxy=""
+output=""
+url=""
 while [ "$#" -gt 0 ]; do
   [ "$1" != --data-binary ] || { shift; data=${1#@}; }
   [ "$1" != --noproxy ] || { shift; noproxy=$1; }
+  [ "$1" != --output ] || { shift; output=$1; }
+  case "$1" in http://*) url=$1 ;; esac
   shift
 done
 [ "$noproxy" = '*' ] || exit 64
-[ -z "$data" ] || cp "$data" "$ALERT_PAYLOAD"
+[ -z "$data" ] || if [ "${url##*/}" = silences ]; then cp "$data" "$WATCHDOG_SILENCE_PAYLOAD"; else cp "$data" "$ALERT_PAYLOAD"; fi
 case "$PAGERDUTY_MODE" in
   transport) echo CURL_RESPONSE_SENTINEL >&2; exit 7 ;;
   forward-exit-during-curl) kill -9 "$(cat "$PAGERDUTY_PID")"; /bin/sleep 0.1; code=200 ;;
@@ -764,7 +768,16 @@ case "$PAGERDUTY_MODE" in
   malformed) code=not-a-status ;;
   *) code=200 ;;
 esac
-printf RESPONSE_SENTINEL > "$TMPDIR"/sugarkube-alertmanager-test.*/response
+if [ "${url##*/}" = silences ]; then
+  case "$PAGERDUTY_MODE" in
+    malformed-json) printf '%s' '{RESPONSE_FIXTURE_SENTINEL' > "$output" ;;
+    missing-id) printf '%s' '{"private":"RESPONSE_FIXTURE_SENTINEL"}' > "$output" ;;
+    invalid-id) printf '%s' '{"silenceID":"RESPONSE_FIXTURE_SENTINEL\ncredential"}' > "$output" ;;
+    *) printf '%s' '{"silenceID":"created-owned-silence"}' > "$output" ;;
+  esac
+else
+  printf RESPONSE_SENTINEL > "$output"
+fi
 printf '%s' "$code"
 """,
         encoding="utf-8",
@@ -1961,6 +1974,13 @@ def test_watchdog_drill_create_submits_exact_bounded_sanitized_payload(tmp_path)
     result, audit = run_helper(tmp_path, "watchdog-drill-create")
 
     assert result.returncode == 0, result.stderr
+    assert "create --raw" not in audit
+    assert (
+        "port-forward --address=127.0.0.1 service/kube-prometheus-stack-alertmanager :9093"
+        in audit
+    )
+    assert "--header Content-Type: application/json" in audit
+    assert "http://127.0.0.1:43128/api/v2/silences" in audit
     payload = json.loads((tmp_path / "watchdog-silence-payload").read_text(encoding="utf-8"))
     assert payload["matchers"] == [
         {"name": "alertname", "value": "SugarkubeObservabilityWatchdog", "isRegex": False},
@@ -1983,6 +2003,76 @@ def test_watchdog_drill_create_submits_exact_bounded_sanitized_payload(tmp_path)
         == "Owned watchdog drill silence created; id=created-owned-silence; automatic expiry=8m.\n"
     )
     assert "shutdown" not in audit.lower() and "hc-ping" not in audit
+    assert (tmp_path / "pagerduty.reaped").read_text().strip() == "reaped"
+    assert not list(tmp_path.glob("sugarkube-watchdog-drill.*"))
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "transport",
+        "http415",
+        "http400",
+        "http503",
+        "malformed",
+        "malformed-json",
+        "missing-id",
+        "invalid-id",
+    ],
+)
+def test_watchdog_drill_create_failures_are_redacted_and_cleaned(tmp_path, mode):
+    result, audit = run_helper(tmp_path, "watchdog-drill-create", pagerduty_mode=mode)
+
+    assert result.returncode != 0
+    assert "curl " in audit
+    output = result.stdout + result.stderr
+    assert "response redacted" in output
+    assert "RESPONSE_FIXTURE_SENTINEL" not in output
+    assert "CURL_RESPONSE_SENTINEL" not in output
+    assert "Traceback" not in output
+    forward_pid = (tmp_path / "pagerduty.pid").read_text().strip()
+    assert not Path(f"/proc/{forward_pid}").exists()
+    assert not list(tmp_path.glob("sugarkube-watchdog-drill.*"))
+
+
+def test_watchdog_drill_rejects_port_forward_exit_during_submission(tmp_path):
+    result, audit = run_helper(
+        tmp_path, "watchdog-drill-create", pagerduty_mode="forward-exit-during-curl"
+    )
+
+    assert result.returncode == 19
+    assert "curl " in audit
+    assert "diagnostics redacted" in result.stderr
+    assert "Traceback" not in result.stdout + result.stderr
+    forward_pid = (tmp_path / "pagerduty.pid").read_text().strip()
+    assert not Path(f"/proc/{forward_pid}").exists()
+    assert not list(tmp_path.glob("sugarkube-watchdog-drill.*"))
+
+
+@pytest.mark.parametrize(
+    ("mode", "line"),
+    [
+        ("forward-exit", "Forwarding from 127.0.0.1:43128 -> 9093"),
+        ("success", ""),
+        ("success", "Forwarding from 0.0.0.0:43128 -> 9093"),
+    ],
+)
+def test_watchdog_drill_port_forward_failures_fail_closed_and_cleaned(tmp_path, mode, line):
+    result, audit = run_helper(
+        tmp_path,
+        "watchdog-drill-create",
+        pagerduty_mode=mode,
+        pagerduty_forward_line=line,
+    )
+
+    assert result.returncode == 19
+    assert "curl " not in audit
+    assert "PORT_FORWARD_SENTINEL" not in result.stdout + result.stderr
+    assert "Traceback" not in result.stdout + result.stderr
+    if (tmp_path / "pagerduty.pid").exists():
+        forward_pid = (tmp_path / "pagerduty.pid").read_text().strip()
+        assert not Path(f"/proc/{forward_pid}").exists()
+    assert not list(tmp_path.glob("sugarkube-watchdog-drill.*"))
 
 
 def test_watchdog_silence_status_reports_only_exact_owned_active_or_pending(tmp_path):
@@ -2022,8 +2112,6 @@ def test_watchdog_silence_clear_is_noop_without_owned_silences(tmp_path):
 @pytest.mark.parametrize(
     ("command", "mode"),
     [
-        ("watchdog-drill-create", "watchdog-silence-create-fail"),
-        ("watchdog-drill-create", "watchdog-silence-create-malformed"),
         ("watchdog-drill-status", "watchdog-silences-fail"),
         ("watchdog-drill-status", "watchdog-silences-malformed"),
     ],


### PR DESCRIPTION
### Motivation
- The staging watchdog drill failed live because `kubectl create --raw ... -f -` did not set `Content-Type: application/json`, causing Alertmanager v0.33.1 to reject the POST (HTTP 415) and the subsequent parser to raise a traceback.

### Description
- Replace the raw kubectl POST for creating an Alertmanager silence with an owned `127.0.0.1` port-forward and an explicit `curl` POST to `/api/v2/silences` that sets `Content-Type: application/json` and uses an automatically allocated local port. (updated `scripts/observability_helm.sh`)
- Add robust transport validation: require the port-forward to establish, require `curl` success and HTTP `200`, parse JSON only after status validation, validate a single safe nonempty `silenceID` with a strict regexp, and print only the existing sanitized success message on success. (updated `scripts/observability_helm.sh`)
- Fail closed on port-forward failures, curl failures, non-200 statuses, malformed JSON, or missing/invalid `silenceID`; emit concise redacted diagnostics, avoid printing raw responses/credentials/Python tracebacks, and return nonzero. (updated `scripts/observability_helm.sh`)
- Ensure cleanup of the owned port-forward and temporary files on success, failure, `SIGINT`, and `SIGTERM` via traps. (updated `scripts/observability_helm.sh`)
- Expand and add tests that assert the loopback port-forward is used, `Content-Type: application/json` is sent, the request targets `/api/v2/silences`, the payload preserves the exact four matchers and eight-minute lifetime, and that the various failure modes (HTTP 415/other non-200, malformed JSON, missing/invalid `silenceID`, early port-forward exit) fail closed and clean up without leaking fixtures or tracebacks. (updated `tests/test_observability_helm.py`)
- Document the loopback JSON transport and automatic cleanup in the operator runbook. (updated `docs/observability-operations.md`)
- Files changed: `scripts/observability_helm.sh`, `tests/test_observability_helm.py`, `docs/observability-operations.md`.

### Testing
- Ran unit/regression tests: `python3 -m pytest -q tests/test_observability_helm.py` — passed for the affected watchdog/pagerduty tests (watchdog drill and pagerduty test permutations exercised and validated). ✅
- Static checks: `shellcheck scripts/observability_helm.sh` — warnings addressed and script checked. ✅
- Render verification: `just observability-render env=staging >/dev/null` — executed successfully in this environment. ✅
- Docs and link checks: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` — both completed successfully. ✅
- Secrets scan: `git diff --cached | ./scripts/scan-secrets.py` — run against the staged changes and passed. ✅
- Pre-commit: targeted hooks for the edited files were run and passed; the repository-wide `run-checks` hook reports pre-existing lint issues in unrelated files that are outside the scope of this change. (No unrelated files were modified in this PR.) ⚠️

Residual risk and follow-ups: repository-wide lint/style errors exist and cause the `run-checks` hook to fail in a full pre-commit run; these are pre-existing and outside the narrow scope required by this fix. Recommend separate tidy-up changes for global lint fixes if desired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f7acfca08832f8b61d7e471bbb746)