### PR TITLE
Fix staging watchdog silence JSON transport

### DIFF
--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -443,7 +443,9 @@ checks, not deployment evidence from this change.
 First manually confirm a recent successful Healthchecks ping. Run
 `just observability-watchdog-drill-start env=staging`. It creates only an eight-minute Alertmanager
 silence with the watchdog's exact four labels; automatic expiry preserves recovery if the operator
-disconnects. It never shuts down a node and never manually pings the URL. Inspect it with
+disconnects. Silence creation uses an ephemeral `127.0.0.1` Alertmanager port-forward and an
+explicit JSON request, and refuses any response other than HTTP 200. It never shuts down a node and
+never manually pings the URL. Inspect it with
 `just observability-watchdog-drill-status env=staging`, or remove only that owned silence early with
 `just observability-watchdog-drill-clear env=staging`. Automated tests inspect the payload and do not
 wait eight minutes.

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -230,13 +230,79 @@ PY
   echo "Watchdog rule, active alert, live configuration, pod mount, and bounded repeat observation verified; delivery must be confirmed at Healthchecks."
 )
 
-watchdog_silence_create() {
+watchdog_silence_create() (
+  local port="" line http_status silence_id
+  local -a port_forward_lines=()
+  local drill_pid="" drill_tmp
   assert_context
   cat >&2 <<'EOF2'
 MANUAL CHECKPOINT: confirm Healthchecks has a recent watchdog ping before disruption and confirm the PagerDuty resolution after recovery. This creates only an eight-minute silence.
 EOF2
-  python3 -c 'import json; from datetime import datetime,timedelta,timezone; n=datetime.now(timezone.utc); f=lambda d:d.isoformat(timespec="seconds").replace("+00:00","Z"); print(json.dumps({"matchers":[{"name":k,"value":v,"isRegex":False} for k,v in [("alertname","SugarkubeObservabilityWatchdog"),("environment","staging"),("cluster","sugarkube-int"),("purpose","observability-watchdog")]],"startsAt":f(n),"endsAt":f(n+timedelta(minutes=8)),"createdBy":"sugarkube-observability-watchdog-drill","comment":"Owned staging watchdog failure drill"}))' | kubectl create --raw "${WATCHDOG_API}/silences" -f - | python3 -c 'import json,sys; d=json.load(sys.stdin); print("Owned watchdog drill silence created; id="+d["silenceID"]+"; automatic expiry=8m.")'
-}
+  require_tools kubectl python3 curl sleep
+  drill_tmp="$(mktemp -d -t sugarkube-watchdog-drill.XXXXXX)"
+  chmod 700 "${drill_tmp}"
+  # shellcheck disable=SC2317
+  cleanup_watchdog_drill() {
+    if [[ -n "${drill_pid}" && " $(jobs -pr) " == *" ${drill_pid} "* ]]; then
+      kill "${drill_pid}" 2>/dev/null || true
+    fi
+    [[ -z "${drill_pid}" ]] || wait "${drill_pid}" 2>/dev/null || true
+    rm -rf "${drill_tmp}"
+  }
+  watchdog_forward_running() {
+    [[ " $(jobs -pr) " == *" ${drill_pid} "* ]] && kill -0 "${drill_pid}" 2>/dev/null
+  }
+  trap cleanup_watchdog_drill EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  umask 077
+  python3 -c 'import json; from datetime import datetime,timedelta,timezone; n=datetime.now(timezone.utc); f=lambda d:d.isoformat(timespec="seconds").replace("+00:00","Z"); print(json.dumps({"matchers":[{"name":k,"value":v,"isRegex":False} for k,v in [("alertname","SugarkubeObservabilityWatchdog"),("environment","staging"),("cluster","sugarkube-int"),("purpose","observability-watchdog")]],"startsAt":f(n),"endsAt":f(n+timedelta(minutes=8)),"createdBy":"sugarkube-observability-watchdog-drill","comment":"Owned staging watchdog failure drill"}))' >"${drill_tmp}/payload.json"
+  : >"${drill_tmp}/port-forward.log"
+  kubectl -n "${NAMESPACE}" port-forward --address=127.0.0.1 "service/${RELEASE}-alertmanager" :9093 >"${drill_tmp}/port-forward.log" 2>&1 &
+  drill_pid=$!
+  for _ in {1..20}; do
+    watchdog_forward_running || { echo "ERROR: Alertmanager port-forward stopped (diagnostics redacted)." >&2; return 19; }
+    mapfile -t port_forward_lines <"${drill_tmp}/port-forward.log"
+    for line in "${port_forward_lines[@]}"; do
+      if [[ "${line}" =~ ^Forwarding\ from\ 127\.0\.0\.1:([1-9][0-9]{0,4})\ -\>\ 9093$ ]]; then
+        port="${BASH_REMATCH[1]}"
+        ((10#${port} <= 65535)) || port=""
+      fi
+    done
+    [[ -z "${port}" ]] || break
+    sleep 1
+  done
+  [[ -n "${port}" ]] || { echo "ERROR: Alertmanager port-forward did not establish an owned loopback listener (diagnostics redacted)." >&2; return 19; }
+  watchdog_forward_running || { echo "ERROR: Alertmanager port-forward stopped (diagnostics redacted)." >&2; return 19; }
+  if ! curl --silent --show-error --noproxy '*' --connect-timeout 3 --max-time 10 \
+    --header 'Content-Type: application/json' --data-binary "@${drill_tmp}/payload.json" \
+    --output "${drill_tmp}/response" --write-out '%{http_code}' \
+    "http://127.0.0.1:${port}/api/v2/silences" >"${drill_tmp}/status" 2>"${drill_tmp}/curl.log"; then
+    echo "ERROR: Alertmanager silence request failed (response redacted)." >&2; return 18
+  fi
+  watchdog_forward_running || { echo "ERROR: Alertmanager port-forward stopped (diagnostics redacted)." >&2; return 19; }
+  http_status="$(cat "${drill_tmp}/status")"
+  [[ "${http_status}" =~ ^[0-9]{3}$ && "${http_status}" == 200 ]] || {
+    echo "ERROR: Alertmanager silence request was not accepted (response redacted)." >&2; return 18
+  }
+  if ! silence_id="$(python3 - "${drill_tmp}/response" <<'PY'
+import json, re, sys
+try:
+    with open(sys.argv[1], encoding="utf-8") as response:
+        document = json.load(response)
+except (OSError, UnicodeError, json.JSONDecodeError):
+    raise SystemExit(1)
+silence_id = document.get("silenceID") if isinstance(document, dict) else None
+if not isinstance(silence_id, str) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", silence_id):
+    raise SystemExit(1)
+print(silence_id)
+PY
+  )"; then
+    echo "ERROR: Alertmanager silence response was invalid (response redacted)." >&2; return 18
+  fi
+  printf 'Owned watchdog drill silence created; id=%s; automatic expiry=8m.\n' "${silence_id}"
+)
 watchdog_owned_silences() {
   kubectl get --raw "${WATCHDOG_API}/silences" | python3 -c 'import json,sys; wanted=[("alertname","SugarkubeObservabilityWatchdog"),("environment","staging"),("cluster","sugarkube-int"),("purpose","observability-watchdog")]; out=[]
 for x in json.load(sys.stdin):

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -586,6 +586,7 @@ def run_helper(
     action=None,
     pagerduty_mode="success",
     pagerduty_forward_line="Forwarding from 127.0.0.1:43128 -> 9093",
+    watchdog_drill_mode="success",
     watchdog_tty_text=None,
     command_args=(),
     extra_env=None,
@@ -697,12 +698,6 @@ case "$*" in
       *"alertmanager-1 -c alertmanager"*) printf '%s' "${WATCHDOG_LOG_TEXT_1:-$WATCHDOG_LOG_TEXT}" ;;
     esac
     ;;
-  *"create --raw /api/v1/namespaces/monitoring/services/http:kube-prometheus-stack-alertmanager:9093/proxy/api/v2/silences -f -"*)
-    cat > "$WATCHDOG_SILENCE_PAYLOAD"
-    [ "$KUBECTL_MODE" != watchdog-silence-create-fail ] || exit 48
-    [ "$KUBECTL_MODE" != watchdog-silence-create-malformed ] || { printf '%s\n' '{malformed'; exit 0; }
-    printf '%s\n' '{"silenceID":"created-owned-silence"}'
-    ;;
   *"get --raw /api/v1/namespaces/monitoring/services/http:kube-prometheus-stack-alertmanager:9093/proxy/api/v2/silences"*)
     [ "$KUBECTL_MODE" != watchdog-silences-fail ] || exit 49
     [ "$KUBECTL_MODE" != watchdog-silences-malformed ] || { printf '%s\n' '{malformed'; exit 0; }
@@ -747,14 +742,23 @@ esac
 echo "curl $*" >> "$AUDIT"
 data=""
 noproxy=""
+output=""
+url=""
 while [ "$#" -gt 0 ]; do
   [ "$1" != --data-binary ] || { shift; data=${1#@}; }
   [ "$1" != --noproxy ] || { shift; noproxy=$1; }
+  [ "$1" != --output ] || { shift; output=$1; }
+  url=$1
   shift
 done
 [ "$noproxy" = '*' ] || exit 64
-[ -z "$data" ] || cp "$data" "$ALERT_PAYLOAD"
-case "$PAGERDUTY_MODE" in
+[ -z "$data" ] || case "$url" in
+  */api/v2/silences) cp "$data" "$WATCHDOG_SILENCE_PAYLOAD" ;;
+  *) cp "$data" "$ALERT_PAYLOAD" ;;
+esac
+mode=$PAGERDUTY_MODE
+case "$url" in */api/v2/silences) mode=$WATCHDOG_DRILL_MODE ;; esac
+case "$mode" in
   transport) echo CURL_RESPONSE_SENTINEL >&2; exit 7 ;;
   forward-exit-during-curl) kill -9 "$(cat "$PAGERDUTY_PID")"; /bin/sleep 0.1; code=200 ;;
   http000) code=000 ;;
@@ -764,7 +768,16 @@ case "$PAGERDUTY_MODE" in
   malformed) code=not-a-status ;;
   *) code=200 ;;
 esac
-printf RESPONSE_SENTINEL > "$TMPDIR"/sugarkube-alertmanager-test.*/response
+case "$mode" in
+  malformed-json) printf '{PRIVATE_RESPONSE_SENTINEL' > "$output" ;;
+  missing-id) printf '{"detail":"PRIVATE_RESPONSE_SENTINEL"}' > "$output" ;;
+  invalid-id) printf '{"silenceID":42,"detail":"PRIVATE_RESPONSE_SENTINEL"}' > "$output" ;;
+  unsafe-id) printf '{"silenceID":"bad\\nPRIVATE_RESPONSE_SENTINEL"}' > "$output" ;;
+  *) case "$url" in
+       */api/v2/silences) printf '{"silenceID":"created-owned-silence"}' > "$output" ;;
+       *) printf RESPONSE_SENTINEL > "$output" ;;
+     esac ;;
+esac
 printf '%s' "$code"
 """,
         encoding="utf-8",
@@ -789,6 +802,7 @@ printf '%s' "$code"
         "ALERT_PAYLOAD": str(tmp_path / "alert-payload"),
         "PAGERDUTY_MODE": pagerduty_mode,
         "PAGERDUTY_FORWARD_LINE": pagerduty_forward_line,
+        "WATCHDOG_DRILL_MODE": watchdog_drill_mode,
         "PAGERDUTY_PID": str(tmp_path / "pagerduty.pid"),
         "PAGERDUTY_REAPED": str(tmp_path / "pagerduty.reaped"),
         "ALERTMANAGER_CONFIG": str(tmp_path / "alertmanager-config.yaml"),
@@ -1979,10 +1993,86 @@ def test_watchdog_drill_create_submits_exact_bounded_sanitized_payload(tmp_path)
     assert (ends_at - starts_at).total_seconds() == 8 * 60
     assert "MANUAL CHECKPOINT" in result.stderr
     assert (
+        "port-forward --address=127.0.0.1 "
+        "service/kube-prometheus-stack-alertmanager :9093"
+    ) in audit
+    assert "--header Content-Type: application/json" in audit
+    assert "http://127.0.0.1:43128/api/v2/silences" in audit
+    assert (
         result.stdout
         == "Owned watchdog drill silence created; id=created-owned-silence; automatic expiry=8m.\n"
     )
     assert "shutdown" not in audit.lower() and "hc-ping" not in audit
+    assert (tmp_path / "pagerduty.reaped").read_text(encoding="utf-8").strip() == "reaped"
+    assert not list(tmp_path.glob("sugarkube-watchdog-drill.*"))
+
+
+def test_watchdog_drill_installs_cleanup_and_signal_traps_before_port_forward():
+    script = SCRIPT.read_text(encoding="utf-8")
+    drill = script.split("watchdog_silence_create() (", 1)[1].split(
+        "\n)\nwatchdog_owned_silences()", 1
+    )[0]
+    launch = drill.index('kubectl -n "${NAMESPACE}" port-forward')
+
+    assert "trap cleanup_watchdog_drill EXIT" in drill[:launch]
+    assert "trap 'exit 130' INT" in drill[:launch]
+    assert "trap 'exit 143' TERM" in drill[:launch]
+    assert 'rm -rf "${drill_tmp}"' in drill
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "transport",
+        "http415",
+        "http400",
+        "http503",
+        "http000",
+        "malformed",
+        "malformed-json",
+        "missing-id",
+        "invalid-id",
+        "unsafe-id",
+    ],
+)
+def test_watchdog_drill_create_failures_are_closed_redacted_and_cleaned_up(tmp_path, mode):
+    result, audit = run_helper(tmp_path, "watchdog-drill-create", watchdog_drill_mode=mode)
+
+    assert result.returncode != 0
+    assert audit.count("curl ") == 1
+    output = result.stdout + result.stderr
+    assert "RESPONSE_SENTINEL" not in output
+    assert "CURL_RESPONSE_SENTINEL" not in output
+    assert "PRIVATE_RESPONSE_SENTINEL" not in output
+    assert "credential" not in output.lower()
+    assert "Traceback" not in output
+    assert "response redacted" in result.stderr
+    assert (tmp_path / "pagerduty.reaped").read_text(encoding="utf-8").strip() == "reaped"
+    assert not list(tmp_path.glob("sugarkube-watchdog-drill.*"))
+
+
+@pytest.mark.parametrize(
+    "pagerduty_mode,forward_line",
+    [
+        ("forward-exit", "Forwarding from 127.0.0.1:43128 -> 9093"),
+        ("success", "PORT_FORWARD_SENTINEL"),
+    ],
+)
+def test_watchdog_drill_port_forward_failures_fail_closed_and_clean_up(
+    tmp_path, pagerduty_mode, forward_line
+):
+    result, audit = run_helper(
+        tmp_path,
+        "watchdog-drill-create",
+        pagerduty_mode=pagerduty_mode,
+        pagerduty_forward_line=forward_line,
+    )
+
+    assert result.returncode != 0
+    assert "curl " not in audit
+    assert "PORT_FORWARD_SENTINEL" not in result.stdout + result.stderr
+    assert "Traceback" not in result.stdout + result.stderr
+    assert not list(tmp_path.glob("sugarkube-watchdog-drill.*"))
 
 
 def test_watchdog_silence_status_reports_only_exact_owned_active_or_pending(tmp_path):
@@ -2022,8 +2112,6 @@ def test_watchdog_silence_clear_is_noop_without_owned_silences(tmp_path):
 @pytest.mark.parametrize(
     ("command", "mode"),
     [
-        ("watchdog-drill-create", "watchdog-silence-create-fail"),
-        ("watchdog-drill-create", "watchdog-silence-create-malformed"),
         ("watchdog-drill-status", "watchdog-silences-fail"),
         ("watchdog-drill-status", "watchdog-silences-malformed"),
     ],


### PR DESCRIPTION
### Motivation
- The staging watchdog drill failed live because `kubectl create --raw ... -f -` did not set `Content-Type: application/json`, causing Alertmanager v0.33.1 to reject the POST (HTTP 415) and the downstream JSON parse stage to raise a traceback. 
- Keep the fix narrowly scoped to the silence transport, its tests, and the operator doc so ownership, labels, lifetime, and filtering rules remain unchanged.

### Description
- Replace the failing `kubectl create --raw` silence POST with an owned ephemeral Alertmanager port-forward bound to `127.0.0.1` and an explicit `curl` POST to `/api/v2/silences` that sets `Content-Type: application/json` and posts the generated payload. (changes in `scripts/observability_helm.sh`)
- Use an automatically-allocated local port for the loopback listener, require HTTP 200 before parsing, and validate the returned `silenceID` against a safe identifier regex; all non-200, transport, malformed-JSON, or missing/invalid-ID cases fail closed with concise redacted diagnostics. (changes in `scripts/observability_helm.sh`)
- Install robust cleanup: create a mode-0700 temporary directory, trap `EXIT`, `SIGINT`, and `SIGTERM`, and ensure the owned port-forward and temporary files are removed on success, failure, or signal. (changes in `scripts/observability_helm.sh`)
- Preserve the exact four non-regex matchers, `createdBy`, `comment`, startsAt/endsAt eight-minute lifetime, and existing `watchdog-drill-status` / `watchdog-drill-clear` ownership filtering. (no behavioral changes to labels/ownership)
- Extend tests in `tests/test_observability_helm.py` to assert the owned loopback port-forward, `Content-Type: application/json`, the `/api/v2/silences` endpoint, the exact payload contents and 8-minute lifetime, success parsing on HTTP 200, and fail-closed behavior for port-forward/curl/non-200/malformed responses while ensuring responses and credentials are redacted and temporary artifacts/processes are cleaned. (changes in `tests/test_observability_helm.py`)
- Update the operator runbook to document the ephemeral loopback port-forward, explicit JSON transport, and the requirement for HTTP 200. (changes in `docs/observability-operations.md`)

### Testing
- Ran `python3 -m pytest -q tests/test_observability_helm.py` and observed `179 passed` for the targeted test suite.
- Ran `shellcheck scripts/observability_helm.sh` (passed) and `just observability-render env=staging >/dev/null` (passed) to validate rendering and script hygiene for the changed areas.
- Ran docs checks: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` (both passed in the final run after required tooling), and `git diff --cached | ./scripts/scan-secrets.py` (no secrets exposed in the diff).
- Ran `pre-commit run --files scripts/observability_helm.sh tests/test_observability_helm.py docs/observability-operations.md` and file-level hooks passed; `pre-commit run --all-files` remains blocked by pre-existing unrelated repository-wide YAML/template lint issues (reported by the repository `run-checks` hook) and is out of scope for this change.

Residual risk and follow-up
- This change is narrowly scoped to the silence transport; it does not alter alert rules, routing, receivers, lifetimes, Secret handling, PagerDuty routing, or ownership protections.
- Repository-wide lint issues surfaced by `pre-commit run --all-files` are pre-existing and unrelated; they should be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f7abfc724832fb2a93acdc6327d71)