### PR TITLE
Fix staging watchdog silence JSON transport

### DIFF
--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -443,7 +443,9 @@ checks, not deployment evidence from this change.
 First manually confirm a recent successful Healthchecks ping. Run
 `just observability-watchdog-drill-start env=staging`. It creates only an eight-minute Alertmanager
 silence with the watchdog's exact four labels; automatic expiry preserves recovery if the operator
-disconnects. It never shuts down a node and never manually pings the URL. Inspect it with
+disconnects. The command sends JSON directly to Alertmanager through a temporary, automatically
+allocated `127.0.0.1` port-forward and removes that listener when it finishes. It never shuts down a
+node and never manually pings the URL. Inspect it with
 `just observability-watchdog-drill-status env=staging`, or remove only that owned silence early with
 `just observability-watchdog-drill-clear env=staging`. Automated tests inspect the payload and do not
 wait eight minutes.

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -678,4 +678,8 @@ if not isinstance(dashboard, dict) or dashboard.get("uid") != "sugarkube-staging
 cmd="${1:-}"; shift || true; [[ -n "${cmd}" ]] || { usage; exit 2; }
 env_arg="${1:-}"; normalize_env "${env_arg}" >/dev/null
 validate_dashboard
+if [[ "${cmd}" == watchdog-drill-create ]]; then
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+fi
 case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) dashboard_verify ;; pagerduty-test) pagerduty_test "${2:-${1:-}}" ;; watchdog-secret-install) watchdog_secret_install "${@:2}" ;; watchdog-secret-check) watchdog_secret_check ;; watchdog-verify) watchdog_live_check ;; watchdog-drill-create) watchdog_silence_create ;; watchdog-drill-status) watchdog_silence_list ;; watchdog-drill-clear) watchdog_silence_clear ;; *) usage; exit 2 ;; esac

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -230,13 +230,83 @@ PY
   echo "Watchdog rule, active alert, live configuration, pod mount, and bounded repeat observation verified; delivery must be confirmed at Healthchecks."
 )
 
-watchdog_silence_create() {
+watchdog_silence_create() (
+  local port="" line http_status silence_pid="" silence_tmp
+  local -a port_forward_lines=()
+  require_tools kubectl python3 curl sleep
   assert_context
   cat >&2 <<'EOF2'
 MANUAL CHECKPOINT: confirm Healthchecks has a recent watchdog ping before disruption and confirm the PagerDuty resolution after recovery. This creates only an eight-minute silence.
 EOF2
-  python3 -c 'import json; from datetime import datetime,timedelta,timezone; n=datetime.now(timezone.utc); f=lambda d:d.isoformat(timespec="seconds").replace("+00:00","Z"); print(json.dumps({"matchers":[{"name":k,"value":v,"isRegex":False} for k,v in [("alertname","SugarkubeObservabilityWatchdog"),("environment","staging"),("cluster","sugarkube-int"),("purpose","observability-watchdog")]],"startsAt":f(n),"endsAt":f(n+timedelta(minutes=8)),"createdBy":"sugarkube-observability-watchdog-drill","comment":"Owned staging watchdog failure drill"}))' | kubectl create --raw "${WATCHDOG_API}/silences" -f - | python3 -c 'import json,sys; d=json.load(sys.stdin); print("Owned watchdog drill silence created; id="+d["silenceID"]+"; automatic expiry=8m.")'
-}
+  silence_tmp="$(mktemp -d -t sugarkube-watchdog-silence.XXXXXX)"
+  chmod 700 "${silence_tmp}"
+  # shellcheck disable=SC2317
+  cleanup_watchdog_silence() {
+    if [[ -n "${silence_pid}" && " $(jobs -pr) " == *" ${silence_pid} "* ]]; then
+      kill "${silence_pid}" 2>/dev/null || true
+    fi
+    [[ -z "${silence_pid}" ]] || wait "${silence_pid}" 2>/dev/null || true
+    rm -rf "${silence_tmp}"
+  }
+  silence_port_forward_running() {
+    [[ " $(jobs -pr) " == *" ${silence_pid} "* ]] && kill -0 "${silence_pid}" 2>/dev/null
+  }
+  trap cleanup_watchdog_silence EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  umask 077
+  python3 -c 'import json; from datetime import datetime,timedelta,timezone; n=datetime.now(timezone.utc); f=lambda d:d.isoformat(timespec="seconds").replace("+00:00","Z"); print(json.dumps({"matchers":[{"name":k,"value":v,"isRegex":False} for k,v in [("alertname","SugarkubeObservabilityWatchdog"),("environment","staging"),("cluster","sugarkube-int"),("purpose","observability-watchdog")]],"startsAt":f(n),"endsAt":f(n+timedelta(minutes=8)),"createdBy":"sugarkube-observability-watchdog-drill","comment":"Owned staging watchdog failure drill"}))' >"${silence_tmp}/payload.json"
+  : >"${silence_tmp}/port-forward.log"
+  kubectl -n "${NAMESPACE}" port-forward --address=127.0.0.1 "service/${RELEASE}-alertmanager" :9093 >"${silence_tmp}/port-forward.log" 2>&1 &
+  silence_pid=$!
+  for _ in {1..20}; do
+    if ! silence_port_forward_running; then
+      echo "ERROR: Alertmanager port-forward stopped (diagnostics redacted)." >&2
+      return 19
+    fi
+    mapfile -t port_forward_lines <"${silence_tmp}/port-forward.log"
+    for line in "${port_forward_lines[@]}"; do
+      if [[ "${line}" =~ ^Forwarding\ from\ 127\.0\.0\.1:([1-9][0-9]{0,4})\ -\>\ 9093$ ]]; then
+        port="${BASH_REMATCH[1]}"
+        ((10#${port} <= 65535)) || port=""
+      fi
+    done
+    [[ -z "${port}" ]] || break
+    sleep 1
+  done
+  [[ -n "${port}" ]] || { echo "ERROR: Alertmanager port-forward did not establish an owned loopback listener (diagnostics redacted)." >&2; return 19; }
+  silence_port_forward_running || { echo "ERROR: Alertmanager port-forward stopped (diagnostics redacted)." >&2; return 19; }
+
+  if ! curl --silent --show-error --noproxy '*' --connect-timeout 3 --max-time 10 \
+    --header 'Content-Type: application/json' --data-binary "@${silence_tmp}/payload.json" \
+    --output "${silence_tmp}/response" --write-out '%{http_code}' \
+    "http://127.0.0.1:${port}/api/v2/silences" >"${silence_tmp}/status" 2>"${silence_tmp}/curl.log"; then
+    echo "ERROR: Alertmanager v2 API silence request failed (response redacted)." >&2
+    return 18
+  fi
+  silence_port_forward_running || { echo "ERROR: Alertmanager port-forward stopped (diagnostics redacted)." >&2; return 19; }
+  http_status="$(cat "${silence_tmp}/status")"
+  [[ "${http_status}" =~ ^[0-9]{3}$ && "${http_status}" == 200 ]] || {
+    echo "ERROR: Alertmanager v2 API silence request was not accepted (response redacted)." >&2
+    return 18
+  }
+  python3 - "${silence_tmp}/response" <<'PY'
+import json
+import re
+import sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as response:
+        document = json.load(response)
+    silence_id = document.get("silenceID") if isinstance(document, dict) else None
+    if not isinstance(silence_id, str) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]*", silence_id):
+        raise ValueError
+except (OSError, UnicodeError, json.JSONDecodeError, ValueError):
+    raise SystemExit("ERROR: Alertmanager returned an invalid silence response (response redacted).")
+print(f"Owned watchdog drill silence created; id={silence_id}; automatic expiry=8m.")
+PY
+)
 watchdog_owned_silences() {
   kubectl get --raw "${WATCHDOG_API}/silences" | python3 -c 'import json,sys; wanted=[("alertname","SugarkubeObservabilityWatchdog"),("environment","staging"),("cluster","sugarkube-int"),("purpose","observability-watchdog")]; out=[]
 for x in json.load(sys.stdin):

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -1,7 +1,9 @@
 import json
 import os
 import re
+import signal
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -585,12 +587,14 @@ def run_helper(
     retry_interval="1",
     action=None,
     pagerduty_mode="success",
+    watchdog_silence_mode=None,
     pagerduty_forward_line="Forwarding from 127.0.0.1:43128 -> 9093",
     watchdog_tty_text=None,
     command_args=(),
     extra_env=None,
     watchdog_silences=None,
     watchdog_log_text="",
+    interrupt_signal=None,
 ):
     """Run the lifecycle against deterministic command stubs and return its audit log."""
     bin_dir = tmp_path / "bin"
@@ -757,10 +761,16 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 [ "$noproxy" = '*' ] || exit 64
-[ -z "$data" ] || { cp "$data" "$ALERT_PAYLOAD"; cp "$data" "$WATCHDOG_SILENCE_PAYLOAD"; }
-case "$PAGERDUTY_MODE" in
+[ -z "$data" ] || case "$url" in
+  */api/v2/silences) cp "$data" "$WATCHDOG_SILENCE_PAYLOAD" ;;
+  *) cp "$data" "$ALERT_PAYLOAD" ;;
+esac
+mode=$PAGERDUTY_MODE
+case "$url" in */api/v2/silences) mode=$WATCHDOG_SILENCE_MODE ;; esac
+case "$mode" in
   transport) echo CURL_RESPONSE_SENTINEL >&2; exit 7 ;;
   forward-exit-during-curl) kill -9 "$(cat "$PAGERDUTY_PID")"; /bin/sleep 0.1; code=200 ;;
+  signal-wait) /bin/sleep 30; code=200 ;;
   http000) code=000 ;;
   http415) code=415 ;;
   http400) code=400 ;;
@@ -770,7 +780,7 @@ case "$PAGERDUTY_MODE" in
 esac
 case "$url" in
   */api/v2/silences)
-    case "$PAGERDUTY_MODE" in
+    case "$WATCHDOG_SILENCE_MODE" in
       response-malformed) printf '%s' '{malformed' > "$output" ;;
       response-missing) printf '%s' '{"fixture":"PRIVATE_RESPONSE_SENTINEL"}' > "$output" ;;
       response-invalid-id) printf '%s' '{"silenceID":"PRIVATE_RESPONSE_SENTINEL\ncredential"}' > "$output" ;;
@@ -802,6 +812,7 @@ printf '%s' "$code"
         "TARGET_RESPONSE_DELAY": target_response_delay,
         "ALERT_PAYLOAD": str(tmp_path / "alert-payload"),
         "PAGERDUTY_MODE": pagerduty_mode,
+        "WATCHDOG_SILENCE_MODE": watchdog_silence_mode or pagerduty_mode,
         "PAGERDUTY_FORWARD_LINE": pagerduty_forward_line,
         "PAGERDUTY_PID": str(tmp_path / "pagerduty.pid"),
         "PAGERDUTY_REAPED": str(tmp_path / "pagerduty.reaped"),
@@ -877,20 +888,40 @@ receivers:
         else:
             responses.write_text("\n".join(target_responses) + "\n", encoding="utf-8")
         env["TARGET_RESPONSES"] = str(responses)
-    result = subprocess.run(
-        [
-            "bash",
-            str(SCRIPT),
-            command,
-            "env=staging",
-            *([action] if action is not None else []),
-            *command_args,
-        ],
-        text=True,
-        capture_output=True,
-        env=env,
-        check=False,
-    )
+    argv = [
+        "bash",
+        str(SCRIPT),
+        command,
+        "env=staging",
+        *([action] if action is not None else []),
+        *command_args,
+    ]
+    if interrupt_signal is None:
+        result = subprocess.run(argv, text=True, capture_output=True, env=env, check=False)
+    else:
+        process = subprocess.Popen(
+            argv,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            start_new_session=True,
+        )
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if (tmp_path / "pagerduty.pid").exists() and list(
+                tmp_path.glob("sugarkube-watchdog-silence.*")
+            ):
+                break
+            if process.poll() is not None:
+                break
+            time.sleep(0.01)
+        assert process.poll() is None, "watchdog drill exited before signal injection"
+        assert (tmp_path / "pagerduty.pid").exists(), "port-forward did not start"
+        assert list(tmp_path.glob("sugarkube-watchdog-silence.*")), "temporary directory missing"
+        os.killpg(process.pid, interrupt_signal)
+        stdout, stderr = process.communicate(timeout=5)
+        result = subprocess.CompletedProcess(argv, process.returncode, stdout, stderr)
     return result, audit.read_text(encoding="utf-8") if audit.exists() else ""
 
 
@@ -1997,8 +2028,7 @@ def test_watchdog_drill_create_submits_exact_bounded_sanitized_payload(tmp_path)
         == "Owned watchdog drill silence created; id=created-owned-silence; automatic expiry=8m.\n"
     )
     assert (
-        "port-forward --address=127.0.0.1 "
-        "service/kube-prometheus-stack-alertmanager :9093"
+        "port-forward --address=127.0.0.1 " "service/kube-prometheus-stack-alertmanager :9093"
     ) in audit
     assert "--header Content-Type: application/json" in audit
     assert "http://127.0.0.1:43128/api/v2/silences" in audit
@@ -2007,19 +2037,31 @@ def test_watchdog_drill_create_submits_exact_bounded_sanitized_payload(tmp_path)
     assert "shutdown" not in audit.lower() and "hc-ping" not in audit
 
 
-def test_watchdog_drill_create_installs_cleanup_and_signal_traps_before_forwarding():
-    script = SCRIPT.read_text(encoding="utf-8")
-    create = script.split("watchdog_silence_create() (", 1)[1].split(
-        "\n)\nwatchdog_owned_silences()", 1
-    )[0]
-    forward = create.index('kubectl -n "${NAMESPACE}" port-forward')
+@pytest.mark.parametrize(
+    ("interrupt_signal", "expected_returncode"),
+    [(signal.SIGINT, 130), (signal.SIGTERM, 143)],
+)
+def test_watchdog_drill_create_signals_clean_up_runtime_resources(
+    tmp_path, interrupt_signal, expected_returncode
+):
+    result, _ = run_helper(
+        tmp_path,
+        "watchdog-drill-create",
+        watchdog_silence_mode="signal-wait",
+        interrupt_signal=interrupt_signal,
+    )
 
-    assert "trap cleanup_watchdog_silence EXIT" in create[:forward]
-    assert "trap 'exit 130' INT" in create[:forward]
-    assert "trap 'exit 143' TERM" in create[:forward]
-    assert 'kill "${silence_pid}"' in create
-    assert 'wait "${silence_pid}"' in create
-    assert 'rm -rf "${silence_tmp}"' in create
+    assert result.returncode == expected_returncode
+    port_forward_pid = int((tmp_path / "pagerduty.pid").read_text(encoding="utf-8"))
+    with pytest.raises(ProcessLookupError):
+        os.kill(port_forward_pid, 0)
+    assert (tmp_path / "pagerduty.reaped").read_text(encoding="utf-8").strip() == "reaped"
+    assert not list(tmp_path.glob("sugarkube-watchdog-silence.*"))
+    output = result.stdout + result.stderr
+    assert "PRIVATE_RESPONSE_SENTINEL" not in output
+    assert "CURL_RESPONSE_SENTINEL" not in output
+    assert "credential" not in output
+    assert "Traceback" not in output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -747,13 +747,17 @@ esac
 echo "curl $*" >> "$AUDIT"
 data=""
 noproxy=""
+output=""
+url=""
 while [ "$#" -gt 0 ]; do
   [ "$1" != --data-binary ] || { shift; data=${1#@}; }
   [ "$1" != --noproxy ] || { shift; noproxy=$1; }
+  [ "$1" != --output ] || { shift; output=$1; }
+  url=$1
   shift
 done
 [ "$noproxy" = '*' ] || exit 64
-[ -z "$data" ] || cp "$data" "$ALERT_PAYLOAD"
+[ -z "$data" ] || { cp "$data" "$ALERT_PAYLOAD"; cp "$data" "$WATCHDOG_SILENCE_PAYLOAD"; }
 case "$PAGERDUTY_MODE" in
   transport) echo CURL_RESPONSE_SENTINEL >&2; exit 7 ;;
   forward-exit-during-curl) kill -9 "$(cat "$PAGERDUTY_PID")"; /bin/sleep 0.1; code=200 ;;
@@ -764,7 +768,17 @@ case "$PAGERDUTY_MODE" in
   malformed) code=not-a-status ;;
   *) code=200 ;;
 esac
-printf RESPONSE_SENTINEL > "$TMPDIR"/sugarkube-alertmanager-test.*/response
+case "$url" in
+  */api/v2/silences)
+    case "$PAGERDUTY_MODE" in
+      response-malformed) printf '%s' '{malformed' > "$output" ;;
+      response-missing) printf '%s' '{"fixture":"PRIVATE_RESPONSE_SENTINEL"}' > "$output" ;;
+      response-invalid-id) printf '%s' '{"silenceID":"PRIVATE_RESPONSE_SENTINEL\ncredential"}' > "$output" ;;
+      *) printf '%s' '{"silenceID":"created-owned-silence"}' > "$output" ;;
+    esac
+    ;;
+  *) printf RESPONSE_SENTINEL > "$output" ;;
+esac
 printf '%s' "$code"
 """,
         encoding="utf-8",
@@ -1982,7 +1996,75 @@ def test_watchdog_drill_create_submits_exact_bounded_sanitized_payload(tmp_path)
         result.stdout
         == "Owned watchdog drill silence created; id=created-owned-silence; automatic expiry=8m.\n"
     )
+    assert (
+        "port-forward --address=127.0.0.1 "
+        "service/kube-prometheus-stack-alertmanager :9093"
+    ) in audit
+    assert "--header Content-Type: application/json" in audit
+    assert "http://127.0.0.1:43128/api/v2/silences" in audit
+    assert (tmp_path / "pagerduty.reaped").read_text(encoding="utf-8").strip() == "reaped"
+    assert not list(tmp_path.glob("sugarkube-watchdog-silence.*"))
     assert "shutdown" not in audit.lower() and "hc-ping" not in audit
+
+
+def test_watchdog_drill_create_installs_cleanup_and_signal_traps_before_forwarding():
+    script = SCRIPT.read_text(encoding="utf-8")
+    create = script.split("watchdog_silence_create() (", 1)[1].split(
+        "\n)\nwatchdog_owned_silences()", 1
+    )[0]
+    forward = create.index('kubectl -n "${NAMESPACE}" port-forward')
+
+    assert "trap cleanup_watchdog_silence EXIT" in create[:forward]
+    assert "trap 'exit 130' INT" in create[:forward]
+    assert "trap 'exit 143' TERM" in create[:forward]
+    assert 'kill "${silence_pid}"' in create
+    assert 'wait "${silence_pid}"' in create
+    assert 'rm -rf "${silence_tmp}"' in create
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "forward-exit",
+        "forward-exit-during-curl",
+        "transport",
+        "http000",
+        "http415",
+        "http400",
+        "http503",
+        "malformed",
+        "response-malformed",
+        "response-missing",
+        "response-invalid-id",
+    ],
+)
+def test_watchdog_drill_create_failures_are_closed_redacted_and_cleaned_up(tmp_path, mode):
+    result, _ = run_helper(tmp_path, "watchdog-drill-create", pagerduty_mode=mode)
+
+    assert result.returncode != 0
+    output = result.stdout + result.stderr
+    assert "PRIVATE_RESPONSE_SENTINEL" not in output
+    assert "CURL_RESPONSE_SENTINEL" not in output
+    assert "PORT_FORWARD_SENTINEL" not in output
+    assert "credential" not in output
+    assert "Traceback" not in output
+    assert not list(tmp_path.glob("sugarkube-watchdog-silence.*"))
+    if (tmp_path / "pagerduty.pid").exists() and mode != "forward-exit-during-curl":
+        assert (tmp_path / "pagerduty.reaped").read_text(encoding="utf-8").strip() == "reaped"
+
+
+def test_watchdog_drill_create_rejects_unusable_forward_line(tmp_path):
+    result, _ = run_helper(
+        tmp_path,
+        "watchdog-drill-create",
+        pagerduty_forward_line="Forwarding from 0.0.0.0:43128 -> 9093",
+    )
+
+    assert result.returncode != 0
+    assert "diagnostics redacted" in result.stderr
+    assert "Traceback" not in result.stderr
+    assert (tmp_path / "pagerduty.reaped").read_text(encoding="utf-8").strip() == "reaped"
+    assert not list(tmp_path.glob("sugarkube-watchdog-silence.*"))
 
 
 def test_watchdog_silence_status_reports_only_exact_owned_active_or_pending(tmp_path):
@@ -2022,8 +2104,6 @@ def test_watchdog_silence_clear_is_noop_without_owned_silences(tmp_path):
 @pytest.mark.parametrize(
     ("command", "mode"),
     [
-        ("watchdog-drill-create", "watchdog-silence-create-fail"),
-        ("watchdog-drill-create", "watchdog-silence-create-malformed"),
         ("watchdog-drill-status", "watchdog-silences-fail"),
         ("watchdog-drill-status", "watchdog-silences-malformed"),
     ],


### PR DESCRIPTION
### Motivation
- A live `just observability-watchdog-drill-start env=staging` run produced HTTP 415 from Alertmanager because the previous `kubectl create --raw ... -f -` transport did not set `Content-Type: application/json`, and downstream code attempted to parse a non-JSON failure response. 
- The fix must be narrowly scoped to the watchdog drill transport, its tests, and operator documentation while preserving the exact four matchers, drill metadata, eight-minute lifetime, manual checkpoint, and owned silence filtering.

### Description
- Replace the failing `kubectl create --raw ... -f -` silence creation with an owned Alertmanager loopback port-forward bound to `127.0.0.1` on an automatically allocated local port and POST the payload with `curl` to `/api/v2/silences` including the header `Content-Type: application/json` and `--data-binary` of the generated JSON payload. (changed `scripts/observability_helm.sh`)
- Require HTTP `200` before parsing a JSON response, validate a sanitized nonempty `silenceID`, and print only the existing sanitized success string, failing closed with concise redacted diagnostics on port-forward/curl/status/parse errors. (changed `scripts/observability_helm.sh`)
- Add robust cleanup and signal traps to stop/reap the owned port-forward and remove temporary files on success, failure, `SIGINT`, and `SIGTERM`, and preserve existing ownership filtering for status and clear operations. (changed `scripts/observability_helm.sh`)
- Extend tests in `tests/test_observability_helm.py` to verify the owned loopback transport, exact `Content-Type`, the `/api/v2/silences` target, payload matchers/metadata/8-minute lifetime, HTTP/transport/response failure handling, redaction (no raw responses/credentials/tracebacks), and cleanup of temporary artifacts; update `docs/observability-operations.md` to document the temporary loopback transport. (changed `tests/test_observability_helm.py`, `docs/observability-operations.md`)

### Testing
- `python3 -m pytest -q tests/test_observability_helm.py` — tests covering the watchdog drill and related flows ran and passed locally (`179 passed`).
- `shellcheck scripts/observability_helm.sh` — shellcheck reported no issues for the modified script after edits.
- `just observability-render env=staging >/dev/null` and supporting tooling — the observability render ran successfully in the environment used for verification after required `helm` was available. 
- Documentation and docs/links checks — `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` were executed and passed for the changed docs, and `git diff --cached | ./scripts/scan-secrets.py` was run to verify no secrets were staged.
- Note: `pre-commit run --all-files` flagged pre-existing repository-wide style/YAML/flake8 findings unrelated to this change; unrelated auto-edits from that hook were reverted and are not part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f7acd4448832fb1241d15d161b16f)