### PR TITLE
Fix watchdog silence creation transport

### DIFF
--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -443,7 +443,10 @@ checks, not deployment evidence from this change.
 First manually confirm a recent successful Healthchecks ping. Run
 `just observability-watchdog-drill-start env=staging`. It creates only an eight-minute Alertmanager
 silence with the watchdog's exact four labels; automatic expiry preserves recovery if the operator
-disconnects. It never shuts down a node and never manually pings the URL. Inspect it with
+disconnects. The command owns a temporary, automatically allocated `127.0.0.1` Alertmanager
+port-forward and submits the silence as `application/json`; it fails closed unless Alertmanager
+returns HTTP 200 with a valid silence ID. It never shuts down a node and never manually pings the
+URL. Inspect it with
 `just observability-watchdog-drill-status env=staging`, or remove only that owned silence early with
 `just observability-watchdog-drill-clear env=staging`. Automated tests inspect the payload and do not
 wait eight minutes.

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -230,13 +230,73 @@ PY
   echo "Watchdog rule, active alert, live configuration, pod mount, and bounded repeat observation verified; delivery must be confirmed at Healthchecks."
 )
 
-watchdog_silence_create() {
+watchdog_silence_create() (
+  local drill_pid="" drill_tmp port="" line http_status silence_id
+  local -a port_forward_lines=()
   assert_context
   cat >&2 <<'EOF2'
 MANUAL CHECKPOINT: confirm Healthchecks has a recent watchdog ping before disruption and confirm the PagerDuty resolution after recovery. This creates only an eight-minute silence.
 EOF2
-  python3 -c 'import json; from datetime import datetime,timedelta,timezone; n=datetime.now(timezone.utc); f=lambda d:d.isoformat(timespec="seconds").replace("+00:00","Z"); print(json.dumps({"matchers":[{"name":k,"value":v,"isRegex":False} for k,v in [("alertname","SugarkubeObservabilityWatchdog"),("environment","staging"),("cluster","sugarkube-int"),("purpose","observability-watchdog")]],"startsAt":f(n),"endsAt":f(n+timedelta(minutes=8)),"createdBy":"sugarkube-observability-watchdog-drill","comment":"Owned staging watchdog failure drill"}))' | kubectl create --raw "${WATCHDOG_API}/silences" -f - | python3 -c 'import json,sys; d=json.load(sys.stdin); print("Owned watchdog drill silence created; id="+d["silenceID"]+"; automatic expiry=8m.")'
-}
+  require_tools kubectl python3 curl sleep
+  drill_tmp="$(mktemp -d -t sugarkube-watchdog-drill.XXXXXX)"
+  chmod 700 "${drill_tmp}"
+  # shellcheck disable=SC2317
+  cleanup_watchdog_drill() {
+    [[ -z "${drill_pid}" ]] || kill "${drill_pid}" 2>/dev/null || true
+    [[ -z "${drill_pid}" ]] || wait "${drill_pid}" 2>/dev/null || true
+    rm -rf "${drill_tmp}"
+  }
+  port_forward_running() { kill -0 "${drill_pid}" 2>/dev/null; }
+  trap cleanup_watchdog_drill EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  umask 077
+  python3 -c 'import json; from datetime import datetime,timedelta,timezone; n=datetime.now(timezone.utc); f=lambda d:d.isoformat(timespec="seconds").replace("+00:00","Z"); print(json.dumps({"matchers":[{"name":k,"value":v,"isRegex":False} for k,v in [("alertname","SugarkubeObservabilityWatchdog"),("environment","staging"),("cluster","sugarkube-int"),("purpose","observability-watchdog")]],"startsAt":f(n),"endsAt":f(n+timedelta(minutes=8)),"createdBy":"sugarkube-observability-watchdog-drill","comment":"Owned staging watchdog failure drill"}))' >"${drill_tmp}/payload.json"
+  : >"${drill_tmp}/port-forward.log"
+  kubectl -n "${NAMESPACE}" port-forward --address=127.0.0.1 "service/${RELEASE}-alertmanager" :9093 >"${drill_tmp}/port-forward.log" 2>&1 &
+  drill_pid=$!
+  for _ in {1..20}; do
+    port_forward_running || { echo "ERROR: Alertmanager port-forward stopped (diagnostics redacted)." >&2; return 19; }
+    mapfile -t port_forward_lines <"${drill_tmp}/port-forward.log"
+    for line in "${port_forward_lines[@]}"; do
+      if [[ "${line}" =~ ^Forwarding\ from\ 127\.0\.0\.1:([1-9][0-9]{0,4})\ -\>\ 9093$ ]]; then
+        port="${BASH_REMATCH[1]}"
+        ((10#${port} <= 65535)) || port=""
+      fi
+    done
+    [[ -z "${port}" ]] || break
+    sleep 1
+  done
+  [[ -n "${port}" ]] || { echo "ERROR: Alertmanager port-forward did not establish an owned loopback listener (diagnostics redacted)." >&2; return 19; }
+  port_forward_running || { echo "ERROR: Alertmanager port-forward stopped (diagnostics redacted)." >&2; return 19; }
+  if ! curl --silent --show-error --noproxy '*' --connect-timeout 3 --max-time 10 \
+    --header 'Content-Type: application/json' --data-binary "@${drill_tmp}/payload.json" \
+    --output "${drill_tmp}/response" --write-out '%{http_code}' \
+    "http://127.0.0.1:${port}/api/v2/silences" >"${drill_tmp}/status" 2>"${drill_tmp}/curl.log"; then
+    echo "ERROR: Alertmanager silence request failed (response redacted)." >&2; return 18
+  fi
+  port_forward_running || { echo "ERROR: Alertmanager port-forward stopped (diagnostics redacted)." >&2; return 19; }
+  http_status="$(cat "${drill_tmp}/status")"
+  [[ "${http_status}" =~ ^[0-9]{3}$ && "${http_status}" == 200 ]] || {
+    echo "ERROR: Alertmanager silence request was not accepted (response redacted)." >&2; return 18
+  }
+  if ! silence_id="$(python3 - "${drill_tmp}/response" <<'PY'
+import json, re, sys
+try:
+    data = json.load(open(sys.argv[1], encoding="utf-8"))
+    silence_id = data.get("silenceID") if isinstance(data, dict) else None
+except (OSError, UnicodeError, json.JSONDecodeError):
+    raise SystemExit(1)
+if not isinstance(silence_id, str) or not re.fullmatch(r"[A-Za-z0-9_-]+", silence_id):
+    raise SystemExit(1)
+print(silence_id)
+PY
+  )"; then
+    echo "ERROR: Alertmanager silence response was invalid (response redacted)." >&2; return 18
+  fi
+  printf 'Owned watchdog drill silence created; id=%s; automatic expiry=8m.\n' "${silence_id}"
+)
 watchdog_owned_silences() {
   kubectl get --raw "${WATCHDOG_API}/silences" | python3 -c 'import json,sys; wanted=[("alertname","SugarkubeObservabilityWatchdog"),("environment","staging"),("cluster","sugarkube-int"),("purpose","observability-watchdog")]; out=[]
 for x in json.load(sys.stdin):

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -747,13 +747,17 @@ esac
 echo "curl $*" >> "$AUDIT"
 data=""
 noproxy=""
+output=""
+url=""
 while [ "$#" -gt 0 ]; do
   [ "$1" != --data-binary ] || { shift; data=${1#@}; }
   [ "$1" != --noproxy ] || { shift; noproxy=$1; }
+  [ "$1" != --output ] || { shift; output=$1; }
+  case "$1" in http://*) url=$1 ;; esac
   shift
 done
 [ "$noproxy" = '*' ] || exit 64
-[ -z "$data" ] || cp "$data" "$ALERT_PAYLOAD"
+[ -z "$data" ] || { case "$url" in */api/v2/silences) cp "$data" "$WATCHDOG_SILENCE_PAYLOAD" ;; *) cp "$data" "$ALERT_PAYLOAD" ;; esac; }
 case "$PAGERDUTY_MODE" in
   transport) echo CURL_RESPONSE_SENTINEL >&2; exit 7 ;;
   forward-exit-during-curl) kill -9 "$(cat "$PAGERDUTY_PID")"; /bin/sleep 0.1; code=200 ;;
@@ -764,7 +768,13 @@ case "$PAGERDUTY_MODE" in
   malformed) code=not-a-status ;;
   *) code=200 ;;
 esac
-printf RESPONSE_SENTINEL > "$TMPDIR"/sugarkube-alertmanager-test.*/response
+case "$PAGERDUTY_MODE:$url" in
+  malformed-json:*/api/v2/silences) printf RESPONSE_SENTINEL > "$output" ;;
+  missing-id:*/api/v2/silences) printf '%s' '{"private":"RESPONSE_BODY_SENTINEL"}' > "$output" ;;
+  invalid-id:*/api/v2/silences) printf '%s' '{"silenceID":"bad\\nRESPONSE_BODY_SENTINEL"}' > "$output" ;;
+  *:*/api/v2/silences) printf '%s' '{"silenceID":"created-owned-silence"}' > "$output" ;;
+  *) printf RESPONSE_SENTINEL > "$output" ;;
+esac
 printf '%s' "$code"
 """,
         encoding="utf-8",
@@ -1979,10 +1989,65 @@ def test_watchdog_drill_create_submits_exact_bounded_sanitized_payload(tmp_path)
     assert (ends_at - starts_at).total_seconds() == 8 * 60
     assert "MANUAL CHECKPOINT" in result.stderr
     assert (
+        "port-forward --address=127.0.0.1 " "service/kube-prometheus-stack-alertmanager :9093"
+    ) in audit
+    assert "--header Content-Type: application/json" in audit
+    assert "http://127.0.0.1:43128/api/v2/silences" in audit
+    assert (
         result.stdout
         == "Owned watchdog drill silence created; id=created-owned-silence; automatic expiry=8m.\n"
     )
     assert "shutdown" not in audit.lower() and "hc-ping" not in audit
+    assert (tmp_path / "pagerduty.reaped").read_text(encoding="utf-8").strip() == "reaped"
+    assert not list(tmp_path.glob("sugarkube-watchdog-drill.*"))
+
+
+@pytest.mark.parametrize(
+    ("mode", "forward_line"),
+    [("forward-exit", None), ("success", "")],
+)
+def test_watchdog_drill_port_forward_failures_are_redacted_and_cleaned_up(
+    tmp_path, mode, forward_line
+):
+    kwargs = {"pagerduty_mode": mode}
+    if forward_line is not None:
+        kwargs["pagerduty_forward_line"] = forward_line
+    result, _ = run_helper(tmp_path, "watchdog-drill-create", **kwargs)
+
+    assert result.returncode != 0
+    output = result.stdout + result.stderr
+    assert "diagnostics redacted" in output
+    assert "PORT_FORWARD_SENTINEL" not in output
+    assert "Traceback" not in output
+    assert not list(tmp_path.glob("sugarkube-watchdog-drill.*"))
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "transport",
+        "http415",
+        "http400",
+        "http503",
+        "http000",
+        "malformed",
+        "malformed-json",
+        "missing-id",
+        "invalid-id",
+    ],
+)
+def test_watchdog_drill_transport_and_response_failures_are_redacted_and_cleaned_up(tmp_path, mode):
+    result, _ = run_helper(tmp_path, "watchdog-drill-create", pagerduty_mode=mode)
+
+    assert result.returncode != 0
+    output = result.stdout + result.stderr
+    assert "redacted" in output
+    for sentinel in ("CURL_RESPONSE_SENTINEL", "RESPONSE_SENTINEL", "RESPONSE_BODY_SENTINEL"):
+        assert sentinel not in output
+    assert "credential" not in output.lower()
+    assert "Traceback" not in output
+    assert (tmp_path / "pagerduty.reaped").read_text(encoding="utf-8").strip() == "reaped"
+    assert not list(tmp_path.glob("sugarkube-watchdog-drill.*"))
 
 
 def test_watchdog_silence_status_reports_only_exact_owned_active_or_pending(tmp_path):
@@ -2022,8 +2087,6 @@ def test_watchdog_silence_clear_is_noop_without_owned_silences(tmp_path):
 @pytest.mark.parametrize(
     ("command", "mode"),
     [
-        ("watchdog-drill-create", "watchdog-silence-create-fail"),
-        ("watchdog-drill-create", "watchdog-silence-create-malformed"),
         ("watchdog-drill-status", "watchdog-silences-fail"),
         ("watchdog-drill-status", "watchdog-silences-malformed"),
     ],


### PR DESCRIPTION
### Motivation
- The live staging watchdog drill produced HTTP 415 because the previous `kubectl create --raw` POST did not set `Content-Type: application/json`, and the follow-on parser attempted to decode a non-JSON failure response.
- The change must be narrowly scoped to the watchdog drill transport, its tests, and operator docs while preserving matchers, ownership metadata, and the eight-minute expiry.

### Description
- Replace the `kubectl create --raw ... -f -` silence POST with an owned `kubectl port-forward` bound to `127.0.0.1` on an automatically allocated local port and submit `/api/v2/silences` via `curl` with `Content-Type: application/json` in `scripts/observability_helm.sh`.
- Require HTTP `200` before parsing, validate and sanitize the returned `silenceID` (allow only safe chars), and print only the existing sanitized success message on success.
- Fail closed with concise redacted diagnostics (no raw response bodies, fixture sentinels, credentials, or Python tracebacks) on port-forward failure, curl failure, non-200 responses, malformed JSON, or missing/invalid `silenceID`, and guarantee cleanup of the owned port-forward and temp files on EXIT, SIGINT, and SIGTERM.
- Add tests in `tests/test_observability_helm.py` to assert the loopback port-forward is used, `Content-Type` is `application/json`, the request targets `/api/v2/silences`, the payload preserves the four exact matchers/metadata/eight-minute lifetime, and that port-forward/curl/status/response failures are redacted and cleaned up.
- Update `docs/observability-operations.md` to document the owned loopback JSON transport and the fail-closed HTTP-200/silence-ID contract.

### Testing
- `python3 -m pytest -q tests/test_observability_helm.py` — 177 passed (new tests included and passing).
- `shellcheck scripts/observability_helm.sh` — passed (one informational SC2317 suppressed for the cleanup closure).
- `just observability-render env=staging >/dev/null` — exercised and returned successfully in verification runs after installing required tools.
- Docs and link checks: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` — passed in verification after ensuring spellcheck tools; `pre-commit run --files scripts/observability_helm.sh tests/test_observability_helm.py docs/observability-operations.md` — file-level hooks passed while the repository-wide `run-checks` hook remains failing on pre-existing lint violations in unrelated files (no unrelated changes were introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f7acbbfd0832fa56a33eb6c4d9886)