### PR TITLE
Fix ORAS release-manifest config blob fetches

### DIFF
--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -516,7 +516,9 @@ def _image_evidence(oras: str, repository: str, tag: str, runner) -> tuple[str, 
         config_digest = image_manifest.get("config", {}).get("digest")
         if not isinstance(config_digest, str) or not DIGEST_RE.fullmatch(config_digest):
             raise ManifestError("image manifest lacks a canonical config digest")
-        config = _json_run(runner, [oras, "blob", "fetch", f"{repository}@{config_digest}"])
+        config = _json_run(
+            runner, [oras, "blob", "fetch", "--output", "-", f"{repository}@{config_digest}"]
+        )
         revision = _revision(config)
         if not isinstance(revision, str):
             raise ManifestError("image config lacks OCI revision label")
@@ -530,7 +532,9 @@ def _chart_evidence(oras: str, repository: str, version: str, runner) -> tuple[s
     config_digest = artifact.get("config", {}).get("digest")
     if not isinstance(config_digest, str) or not DIGEST_RE.fullmatch(config_digest):
         raise ManifestError("chart artifact lacks a canonical config digest")
-    config = _json_run(runner, [oras, "blob", "fetch", f"{repository}@{config_digest}"])
+    config = _json_run(
+        runner, [oras, "blob", "fetch", "--output", "-", f"{repository}@{config_digest}"]
+    )
     revision = _revision(config)
     if not isinstance(revision, str):
         raise ManifestError("chart config lacks OCI revision metadata")

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -228,7 +228,7 @@ def oras_runner(*, image_revision: str = SHA, chart_revision: str = SHA):
             "config": {"digest": IMAGE_CONFIG_DIGEST},
             "layers": [],
         },
-        ("blob", "fetch", f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}"): {
+        ("blob", "fetch", "--output", "-", f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}"): {
             "config": {"Labels": {manifest.REVISION_ANNOTATION: image_revision}}
         },
         ("manifest", "fetch", "--descriptor", f"{manifest.CHART_REF}:3.2.0"): {
@@ -240,7 +240,7 @@ def oras_runner(*, image_revision: str = SHA, chart_revision: str = SHA):
             "config": {"digest": CHART_CONFIG_DIGEST},
             "layers": [],
         },
-        ("blob", "fetch", f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}"): {
+        ("blob", "fetch", "--output", "-", f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}"): {
             "annotations": {manifest.REVISION_ANNOTATION: chart_revision}
         },
     }
@@ -268,6 +268,25 @@ def test_preflight_checks_exact_descriptors_and_digest_qualified_metadata() -> N
     assert runner.calls[0][-1].endswith(":main-abcdef0")
     assert runner.calls[1][-1] == f"{manifest.IMAGE_REF}@{DIGEST}"
     assert all(":main-abcdef0" not in call[-1] for call in runner.calls[1:])
+    blob_fetches = [call for call in runner.calls if call[1:3] == ["blob", "fetch"]]
+    assert blob_fetches == [
+        [
+            "oras-stub",
+            "blob",
+            "fetch",
+            "--output",
+            "-",
+            f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}",
+        ],
+        [
+            "oras-stub",
+            "blob",
+            "fetch",
+            "--output",
+            "-",
+            f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}",
+        ],
+    ]
 
 
 def test_schema_v2_preflight_checks_image_and_chart_provenance_independently() -> None:
@@ -1457,9 +1476,29 @@ def test_command_and_oci_json_failures(monkeypatch) -> None:
             "platform digest",
         ),
         (("manifest", "fetch", f"{manifest.IMAGE_REF}@{PLATFORM_DIGEST}"), {}, "config digest"),
-        (("blob", "fetch", f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}"), {}, "revision label"),
+        (
+            (
+                "blob",
+                "fetch",
+                "--output",
+                "-",
+                f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}",
+            ),
+            {},
+            "revision label",
+        ),
         (("manifest", "fetch", f"{manifest.CHART_REF}@{CHART_DIGEST}"), {}, "config digest"),
-        (("blob", "fetch", f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}"), {}, "revision metadata"),
+        (
+            (
+                "blob",
+                "fetch",
+                "--output",
+                "-",
+                f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}",
+            ),
+            {},
+            "revision metadata",
+        ),
     ],
 )
 def test_preflight_rejects_malformed_oci_evidence(command_key, replacement, message) -> None:


### PR DESCRIPTION
### Motivation
- The ORAS v1.3.2 client returns `Error: either --output or --descriptor must be provided` when `blob fetch` is invoked without selecting an output, which broke the DSPACE release-manifest preflight during immutable artifact resolution (`=== Resolve immutable OCI artifacts ===` error observed).

### Description
- Request config blob contents explicitly on stdout by adding `--output -` to both image-config and chart-config `oras blob fetch` calls in `scripts/dspace_release_manifest.py` so the existing JSON parsing receives the blob on stdout.
- Update the ORAS test runner fixtures in `tests/test_release_manifest.py` to match the exact new argv for `blob fetch` (digest-qualified reference + `--output -`).
- Add a focused regression assertion that verifies every config-content `blob fetch` command includes exactly `--output -` and the expected digest-qualified argument, preserving digest-based resolution and all provenance invariants.

### Testing
- Ran `python3 -m pytest -q tests/test_release_manifest.py` which passed: `194 passed`.
- Ran `python3 -m pytest -q tests/test_manifest_rollback.py tests/test_generic_app_just_recipes.py` which passed: `277 passed` with one pre-existing `SyntaxWarning` in the suite.
- Verification commands and results: `python3 -m flake8 scripts/dspace_release_manifest.py tests/test_release_manifest.py` reported pre-existing `E501` warnings (lines unchanged by this PR) so linting failed due to repository-wide style issues; `pre-commit run --all-files` also surfaced existing unrelated YAML/lint failures that were not changed by this minimal fix; `git diff --check` passed and `git diff --cached | ./scripts/scan-secrets.py` passed.

Notes: change is intentionally minimal and scoped to `scripts/dspace_release_manifest.py` and `tests/test_release_manifest.py`; this PR references #2325 without closing it. The branch committed was `codex/oras-blob-output` with message `Fix ORAS config blob stdout fetches`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f87ef560c832fa3c54ab41c84008d)