### PR TITLE
Fix ORAS release-manifest config blob fetches

### DIFF
--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -516,7 +516,9 @@ def _image_evidence(oras: str, repository: str, tag: str, runner) -> tuple[str, 
         config_digest = image_manifest.get("config", {}).get("digest")
         if not isinstance(config_digest, str) or not DIGEST_RE.fullmatch(config_digest):
             raise ManifestError("image manifest lacks a canonical config digest")
-        config = _json_run(runner, [oras, "blob", "fetch", f"{repository}@{config_digest}"])
+        config = _json_run(
+            runner, [oras, "blob", "fetch", "--output", "-", f"{repository}@{config_digest}"]
+        )
         revision = _revision(config)
         if not isinstance(revision, str):
             raise ManifestError("image config lacks OCI revision label")
@@ -530,7 +532,9 @@ def _chart_evidence(oras: str, repository: str, version: str, runner) -> tuple[s
     config_digest = artifact.get("config", {}).get("digest")
     if not isinstance(config_digest, str) or not DIGEST_RE.fullmatch(config_digest):
         raise ManifestError("chart artifact lacks a canonical config digest")
-    config = _json_run(runner, [oras, "blob", "fetch", f"{repository}@{config_digest}"])
+    config = _json_run(
+        runner, [oras, "blob", "fetch", "--output", "-", f"{repository}@{config_digest}"]
+    )
     revision = _revision(config)
     if not isinstance(revision, str):
         raise ManifestError("chart config lacks OCI revision metadata")
@@ -768,7 +772,9 @@ def finalize(
         {
             "check": "selectedCoordinates",
             "passed": True,
-            "details": f"environment={environment}; imageTag={image_tag}; chartVersion={chart_version}",
+            "details": (
+                f"environment={environment}; imageTag={image_tag}; chartVersion={chart_version}"
+            ),
         },
         {
             "check": "clusterEnvironment",
@@ -871,7 +877,9 @@ def verify_helm_stored_values(
     return {
         "check": "helmStoredValues",
         "passed": True,
-        "details": "stored image coordinates, pull policy, and environment isolation matched approval",
+        "details": (
+            "stored image coordinates, pull policy, and environment isolation matched approval"
+        ),
     }
 
 

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -228,7 +228,7 @@ def oras_runner(*, image_revision: str = SHA, chart_revision: str = SHA):
             "config": {"digest": IMAGE_CONFIG_DIGEST},
             "layers": [],
         },
-        ("blob", "fetch", f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}"): {
+        ("blob", "fetch", "--output", "-", f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}"): {
             "config": {"Labels": {manifest.REVISION_ANNOTATION: image_revision}}
         },
         ("manifest", "fetch", "--descriptor", f"{manifest.CHART_REF}:3.2.0"): {
@@ -240,7 +240,7 @@ def oras_runner(*, image_revision: str = SHA, chart_revision: str = SHA):
             "config": {"digest": CHART_CONFIG_DIGEST},
             "layers": [],
         },
-        ("blob", "fetch", f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}"): {
+        ("blob", "fetch", "--output", "-", f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}"): {
             "annotations": {manifest.REVISION_ANNOTATION: chart_revision}
         },
     }
@@ -268,6 +268,24 @@ def test_preflight_checks_exact_descriptors_and_digest_qualified_metadata() -> N
     assert runner.calls[0][-1].endswith(":main-abcdef0")
     assert runner.calls[1][-1] == f"{manifest.IMAGE_REF}@{DIGEST}"
     assert all(":main-abcdef0" not in call[-1] for call in runner.calls[1:])
+    assert [call for call in runner.calls if call[1:3] == ["blob", "fetch"]] == [
+        [
+            "oras-stub",
+            "blob",
+            "fetch",
+            "--output",
+            "-",
+            f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}",
+        ],
+        [
+            "oras-stub",
+            "blob",
+            "fetch",
+            "--output",
+            "-",
+            f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}",
+        ],
+    ]
 
 
 def test_schema_v2_preflight_checks_image_and_chart_provenance_independently() -> None:
@@ -1457,9 +1475,17 @@ def test_command_and_oci_json_failures(monkeypatch) -> None:
             "platform digest",
         ),
         (("manifest", "fetch", f"{manifest.IMAGE_REF}@{PLATFORM_DIGEST}"), {}, "config digest"),
-        (("blob", "fetch", f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}"), {}, "revision label"),
+        (
+            ("blob", "fetch", "--output", "-", f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}"),
+            {},
+            "revision label",
+        ),
         (("manifest", "fetch", f"{manifest.CHART_REF}@{CHART_DIGEST}"), {}, "config digest"),
-        (("blob", "fetch", f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}"), {}, "revision metadata"),
+        (
+            ("blob", "fetch", "--output", "-", f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}"),
+            {},
+            "revision metadata",
+        ),
     ],
 )
 def test_preflight_rejects_malformed_oci_evidence(command_key, replacement, message) -> None:


### PR DESCRIPTION
### Motivation

- ORAS v1.3.2 enforces that `oras blob fetch` must be called with either `--output` or `--descriptor`; the release preflight previously invoked digest-qualified `blob fetch` without `--output`, causing the preflight to fail with `Error: either `--output` or `--descriptor` must be provided` during immutable OCI resolution.  This break occurred before evidence reservation or any Helm/Kubernetes mutation and must be fixed for read-only recovery gating (references #2325). 

### Description

- Make `oras blob fetch` explicit about returning blob contents on stdout by adding `--output -` to both image-config and chart-config provenance reads in `_image_evidence` and `_chart_evidence` in `scripts/dspace_release_manifest.py`. 
- Update the ORAS test runner fixtures in `tests/test_release_manifest.py` to expect the exact argv including `--output -` for both image and chart config blob fetches. 
- Add a focused regression assertion in `tests/test_release_manifest.py` that every config-content `blob fetch` call includes exactly the `--output -` argument sequence, and update malformed-evidence parametrization to match the new argv. 
- Preserve all invariants: descriptor resolution remains digest-based, manifest/config references stay digest-qualified, image and chart provenance remain independently verified, and the returned stdout continues to be parsed via the existing strict JSON path.  No recovery coordinates, candidate/evidence JSON, Helm recipes, runtime verification, provider logic, or deployment config were modified.

### Testing

- Ran `python3 -m pytest -q tests/test_release_manifest.py` and it passed (194 passed). 
- Ran `python3 -m pytest -q tests/test_manifest_rollback.py tests/test_generic_app_just_recipes.py` and they passed (277 passed, with one pre-existing `SyntaxWarning` about an invalid escape sequence). 
- Ran `python3 -m flake8 scripts/dspace_release_manifest.py tests/test_release_manifest.py` and it passed for the scoped files. 
- Ran repository checks `git diff --check`, `git status --short`, and `git diff --cached | ./scripts/scan-secrets.py` as part of validation and they reported no issues for the scoped changes. 
- Ran `pre-commit run --all-files`, which failed due to pre-existing, repository-wide YAML multi-document and unrelated flake8 issues; those failures are unrelated to this focused change and no unrelated files were kept modified (auto-fixes to unrelated files were reverted). 

Residual risks and notes: the fix is intentionally minimal and targets ORAS stdout selection only; broader pre-commit/flake8/YAML issues in the repository remain and should be handled separately. This PR references #2325 without closing it.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f87f952c0832f9b28a0ed9f6757ea)