### PR TITLE
Fix ORAS release-manifest config blob fetches (--output -)

### DIFF
--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -516,7 +516,9 @@ def _image_evidence(oras: str, repository: str, tag: str, runner) -> tuple[str, 
         config_digest = image_manifest.get("config", {}).get("digest")
         if not isinstance(config_digest, str) or not DIGEST_RE.fullmatch(config_digest):
             raise ManifestError("image manifest lacks a canonical config digest")
-        config = _json_run(runner, [oras, "blob", "fetch", f"{repository}@{config_digest}"])
+        config = _json_run(
+            runner, [oras, "blob", "fetch", "--output", "-", f"{repository}@{config_digest}"]
+        )
         revision = _revision(config)
         if not isinstance(revision, str):
             raise ManifestError("image config lacks OCI revision label")
@@ -530,7 +532,9 @@ def _chart_evidence(oras: str, repository: str, version: str, runner) -> tuple[s
     config_digest = artifact.get("config", {}).get("digest")
     if not isinstance(config_digest, str) or not DIGEST_RE.fullmatch(config_digest):
         raise ManifestError("chart artifact lacks a canonical config digest")
-    config = _json_run(runner, [oras, "blob", "fetch", f"{repository}@{config_digest}"])
+    config = _json_run(
+        runner, [oras, "blob", "fetch", "--output", "-", f"{repository}@{config_digest}"]
+    )
     revision = _revision(config)
     if not isinstance(revision, str):
         raise ManifestError("chart config lacks OCI revision metadata")

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -228,7 +228,7 @@ def oras_runner(*, image_revision: str = SHA, chart_revision: str = SHA):
             "config": {"digest": IMAGE_CONFIG_DIGEST},
             "layers": [],
         },
-        ("blob", "fetch", f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}"): {
+        ("blob", "fetch", "--output", "-", f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}"): {
             "config": {"Labels": {manifest.REVISION_ANNOTATION: image_revision}}
         },
         ("manifest", "fetch", "--descriptor", f"{manifest.CHART_REF}:3.2.0"): {
@@ -240,7 +240,7 @@ def oras_runner(*, image_revision: str = SHA, chart_revision: str = SHA):
             "config": {"digest": CHART_CONFIG_DIGEST},
             "layers": [],
         },
-        ("blob", "fetch", f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}"): {
+        ("blob", "fetch", "--output", "-", f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}"): {
             "annotations": {manifest.REVISION_ANNOTATION: chart_revision}
         },
     }
@@ -268,6 +268,9 @@ def test_preflight_checks_exact_descriptors_and_digest_qualified_metadata() -> N
     assert runner.calls[0][-1].endswith(":main-abcdef0")
     assert runner.calls[1][-1] == f"{manifest.IMAGE_REF}@{DIGEST}"
     assert all(":main-abcdef0" not in call[-1] for call in runner.calls[1:])
+    blob_fetches = [call for call in runner.calls if call[1:3] == ["blob", "fetch"]]
+    assert len(blob_fetches) == 2
+    assert all(call[1:-1] == ["blob", "fetch", "--output", "-"] for call in blob_fetches)
 
 
 def test_schema_v2_preflight_checks_image_and_chart_provenance_independently() -> None:
@@ -1457,9 +1460,17 @@ def test_command_and_oci_json_failures(monkeypatch) -> None:
             "platform digest",
         ),
         (("manifest", "fetch", f"{manifest.IMAGE_REF}@{PLATFORM_DIGEST}"), {}, "config digest"),
-        (("blob", "fetch", f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}"), {}, "revision label"),
+        (
+            ("blob", "fetch", "--output", "-", f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}"),
+            {},
+            "revision label",
+        ),
         (("manifest", "fetch", f"{manifest.CHART_REF}@{CHART_DIGEST}"), {}, "config digest"),
-        (("blob", "fetch", f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}"), {}, "revision metadata"),
+        (
+            ("blob", "fetch", "--output", "-", f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}"),
+            {},
+            "revision metadata",
+        ),
     ],
 )
 def test_preflight_rejects_malformed_oci_evidence(command_key, replacement, message) -> None:


### PR DESCRIPTION
### Motivation
- ORAS v1.3.2 errors when invoking `oras blob fetch` without `--output` during DSPACE release-manifest preflight, producing: `either --output or --descriptor must be provided`; the preflight must return blob contents on stdout for JSON parsing (see #2325). 

### Description
- Request config blob bodies explicitly on stdout by calling `oras blob fetch --output - <repo>@<digest>` in both image and chart provenance collection (`scripts/dspace_release_manifest.py`).
- Update the ORAS test runner fixtures to match the exact new argv and adapt malformed-evidence parametrisations in `tests/test_release_manifest.py`.
- Add a focused regression assertion that both config `blob fetch` calls include exactly `--output -` and preserve all existing digest-qualified and JSON validation invariants.

### Testing
- Ran `python3 -m pytest -q tests/test_release_manifest.py` — PASS (194 passed).
- Ran `python3 -m pytest -q tests/test_manifest_rollback.py tests/test_generic_app_just_recipes.py` — PASS (277 passed).
- Ran `python3 -m flake8 scripts/dspace_release_manifest.py tests/test_release_manifest.py` — UNAVAILABLE (`No module named flake8` in this environment).
- Ran `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` — PASS (no problems reported).
- Attempted `pre-commit run --all-files` — UNAVAILABLE (`pre-commit: command not found` in this environment).

This change is minimal, touches only the scoped files, preserves all existing invariants, and references #2325 for follow-up operational reconciliation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f87ffbfa8832f86650fb9d179b711)