### PR TITLE
Fix ORAS config blob stdout fetches (--output -) for release preflight

### DIFF
--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -516,7 +516,9 @@ def _image_evidence(oras: str, repository: str, tag: str, runner) -> tuple[str, 
         config_digest = image_manifest.get("config", {}).get("digest")
         if not isinstance(config_digest, str) or not DIGEST_RE.fullmatch(config_digest):
             raise ManifestError("image manifest lacks a canonical config digest")
-        config = _json_run(runner, [oras, "blob", "fetch", f"{repository}@{config_digest}"])
+        config = _json_run(
+            runner, [oras, "blob", "fetch", "--output", "-", f"{repository}@{config_digest}"]
+        )
         revision = _revision(config)
         if not isinstance(revision, str):
             raise ManifestError("image config lacks OCI revision label")
@@ -530,7 +532,9 @@ def _chart_evidence(oras: str, repository: str, version: str, runner) -> tuple[s
     config_digest = artifact.get("config", {}).get("digest")
     if not isinstance(config_digest, str) or not DIGEST_RE.fullmatch(config_digest):
         raise ManifestError("chart artifact lacks a canonical config digest")
-    config = _json_run(runner, [oras, "blob", "fetch", f"{repository}@{config_digest}"])
+    config = _json_run(
+        runner, [oras, "blob", "fetch", "--output", "-", f"{repository}@{config_digest}"]
+    )
     revision = _revision(config)
     if not isinstance(revision, str):
         raise ManifestError("chart config lacks OCI revision metadata")

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -228,7 +228,7 @@ def oras_runner(*, image_revision: str = SHA, chart_revision: str = SHA):
             "config": {"digest": IMAGE_CONFIG_DIGEST},
             "layers": [],
         },
-        ("blob", "fetch", f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}"): {
+        ("blob", "fetch", "--output", "-", f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}"): {
             "config": {"Labels": {manifest.REVISION_ANNOTATION: image_revision}}
         },
         ("manifest", "fetch", "--descriptor", f"{manifest.CHART_REF}:3.2.0"): {
@@ -240,7 +240,7 @@ def oras_runner(*, image_revision: str = SHA, chart_revision: str = SHA):
             "config": {"digest": CHART_CONFIG_DIGEST},
             "layers": [],
         },
-        ("blob", "fetch", f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}"): {
+        ("blob", "fetch", "--output", "-", f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}"): {
             "annotations": {manifest.REVISION_ANNOTATION: chart_revision}
         },
     }
@@ -268,6 +268,15 @@ def test_preflight_checks_exact_descriptors_and_digest_qualified_metadata() -> N
     assert runner.calls[0][-1].endswith(":main-abcdef0")
     assert runner.calls[1][-1] == f"{manifest.IMAGE_REF}@{DIGEST}"
     assert all(":main-abcdef0" not in call[-1] for call in runner.calls[1:])
+    blob_fetches = [call for call in runner.calls if call[1:3] == ["blob", "fetch"]]
+    assert [call[1:5] for call in blob_fetches] == [
+        ["blob", "fetch", "--output", "-"],
+        ["blob", "fetch", "--output", "-"],
+    ]
+    assert {call[-1] for call in blob_fetches} == {
+        f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}",
+        f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}",
+    }
 
 
 def test_schema_v2_preflight_checks_image_and_chart_provenance_independently() -> None:
@@ -1457,9 +1466,29 @@ def test_command_and_oci_json_failures(monkeypatch) -> None:
             "platform digest",
         ),
         (("manifest", "fetch", f"{manifest.IMAGE_REF}@{PLATFORM_DIGEST}"), {}, "config digest"),
-        (("blob", "fetch", f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}"), {}, "revision label"),
+        (
+            (
+                "blob",
+                "fetch",
+                "--output",
+                "-",
+                f"{manifest.IMAGE_REF}@{IMAGE_CONFIG_DIGEST}",
+            ),
+            {},
+            "revision label",
+        ),
         (("manifest", "fetch", f"{manifest.CHART_REF}@{CHART_DIGEST}"), {}, "config digest"),
-        (("blob", "fetch", f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}"), {}, "revision metadata"),
+        (
+            (
+                "blob",
+                "fetch",
+                "--output",
+                "-",
+                f"{manifest.CHART_REF}@{CHART_CONFIG_DIGEST}",
+            ),
+            {},
+            "revision metadata",
+        ),
     ],
 )
 def test_preflight_rejects_malformed_oci_evidence(command_key, replacement, message) -> None:


### PR DESCRIPTION
### Motivation
- During a live, read-only DSPACE 3.0.1 recovery staging gate, ORAS v1.3.2 caused preflight to fail with: `Error: either --output or --descriptor must be provided`, because `oras blob fetch` was invoked without selecting an output for JSON parsing. 
- The intent is to return digest-qualified blob contents on stdout for strict JSON parsing while preserving descriptor/digest-based resolution and all existing invariants (provenance, immutability, and failure boundaries); this change is related to #2325.

### Description
- Request stdout explicitly by adding `--output -` to both digest-qualified `oras blob fetch` calls used for image config and chart config collection in `scripts/dspace_release_manifest.py` (`_image_evidence` and `_chart_evidence`).
- Update the ORAS test runner fixtures in `tests/test_release_manifest.py` to match the exact argv including `--output -` and add a focused regression assertion that every config-content `blob fetch` call includes exactly `--output -` and remains digest-qualified.
- Scope is limited to `scripts/dspace_release_manifest.py` and `tests/test_release_manifest.py` and preserves all existing behavior and JSON parsing paths.

### Testing
- `python3 -m pytest -q tests/test_release_manifest.py` — PASS (194 passed).
- `python3 -m pytest -q tests/test_manifest_rollback.py tests/test_generic_app_just_recipes.py` — PASS.
- `python3 -m flake8 scripts/dspace_release_manifest.py tests/test_release_manifest.py` — PASS.
- `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` — PASS.
- `pre-commit run --all-files` — UNAVAILABLE in this environment (`pre-commit` not installed).
- `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` — UNAVAILABLE in this environment (`pyspelling`/`linkchecker` not installed) and not required because no documentation was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f8801b400832f8f599ccb2e09df58)