### PR TITLE
Fix watchdog drill ownership for normalized silences

### DIFF
--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -308,11 +308,58 @@ print(f"Owned watchdog drill silence created; id={silence_id}; automatic expiry=
 PY
 )
 watchdog_owned_silences() {
-  kubectl get --raw "${WATCHDOG_API}/silences" | python3 -c 'import json,sys; wanted=[("alertname","SugarkubeObservabilityWatchdog"),("environment","staging"),("cluster","sugarkube-int"),("purpose","observability-watchdog")]; out=[]
-for x in json.load(sys.stdin):
- m=x.get("matchers"); exact=isinstance(m,list) and len(m)==4 and sorted((a.get("name"),a.get("value")) for a in m if isinstance(a,dict) and a.get("isRegex") is False and set(a)=={"name","value","isRegex"})==sorted(wanted)
- if x.get("createdBy")=="sugarkube-observability-watchdog-drill" and x.get("comment")=="Owned staging watchdog failure drill" and x.get("status",{}).get("state") in ("active","pending") and exact: out.append(x["id"])
-print("\n".join(out))'
+  kubectl get --raw "${WATCHDOG_API}/silences" | python3 -c '
+import json
+import re
+import sys
+
+wanted = {
+    ("alertname", "SugarkubeObservabilityWatchdog"),
+    ("environment", "staging"),
+    ("cluster", "sugarkube-int"),
+    ("purpose", "observability-watchdog"),
+}
+
+def exact_matchers(matchers):
+    if not isinstance(matchers, list) or len(matchers) != len(wanted):
+        return False
+    pairs = []
+    for matcher in matchers:
+        if not isinstance(matcher, dict):
+            return False
+        if not set(matcher) <= {"name", "value", "isRegex", "isEqual"}:
+            return False
+        if not {"name", "value", "isRegex"} <= set(matcher):
+            return False
+        if matcher["isRegex"] is not False:
+            return False
+        if "isEqual" in matcher and matcher["isEqual"] is not True:
+            return False
+        pairs.append((matcher["name"], matcher["value"]))
+    return len(set(pairs)) == len(wanted) and set(pairs) == wanted
+
+try:
+    document = json.load(sys.stdin)
+    if not isinstance(document, list) or not all(isinstance(item, dict) for item in document):
+        raise ValueError
+    owned = []
+    for silence in document:
+        status = silence.get("status")
+        silence_id = silence.get("id")
+        if (
+            silence.get("createdBy") == "sugarkube-observability-watchdog-drill"
+            and silence.get("comment") == "Owned staging watchdog failure drill"
+            and isinstance(status, dict)
+            and status.get("state") in ("active", "pending")
+            and isinstance(silence_id, str)
+            and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]*", silence_id)
+            and exact_matchers(silence.get("matchers"))
+        ):
+            owned.append(silence_id)
+except (json.JSONDecodeError, UnicodeError, ValueError, TypeError):
+    raise SystemExit("ERROR: Alertmanager returned an invalid silences response (response redacted).")
+
+print("\n".join(owned))'
 }
 watchdog_silence_list() { assert_context; local ids; ids="$(watchdog_owned_silences)"; [[ -n "${ids}" ]] && printf 'Owned active/pending watchdog drill silence IDs:\n%s\n' "${ids}" || echo "No owned active/pending watchdog drill silence."; }
 watchdog_silence_clear() { assert_context; local ids; ids="$(watchdog_owned_silences)"; [[ -n "${ids}" ]] || { echo "No owned active/pending watchdog drill silence to clear."; return; }; while IFS= read -r id; do kubectl delete --raw "${WATCHDOG_API}/silence/${id}" >/dev/null; done <<<"${ids}"; echo "Owned watchdog drill silence cleared."; }

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -1953,10 +1953,20 @@ def test_watchdog_delivery_one_of_multiple_log_retrievals_fails_closed(tmp_path)
 
 def watchdog_silence_fixture():
     matchers = [
-        {"name": "alertname", "value": "SugarkubeObservabilityWatchdog", "isRegex": False},
-        {"name": "environment", "value": "staging", "isRegex": False},
-        {"name": "cluster", "value": "sugarkube-int", "isRegex": False},
-        {"name": "purpose", "value": "observability-watchdog", "isRegex": False},
+        {
+            "name": "alertname",
+            "value": "SugarkubeObservabilityWatchdog",
+            "isRegex": False,
+            "isEqual": True,
+        },
+        {"name": "environment", "value": "staging", "isRegex": False, "isEqual": True},
+        {"name": "cluster", "value": "sugarkube-int", "isRegex": False, "isEqual": True},
+        {
+            "name": "purpose",
+            "value": "observability-watchdog",
+            "isRegex": False,
+            "isEqual": True,
+        },
     ]
 
     def silence(
@@ -1979,6 +1989,14 @@ def watchdog_silence_fixture():
     return [
         silence("owned-active", "active"),
         silence("owned-pending", "pending"),
+        silence(
+            "owned-legacy",
+            "active",
+            selected_matchers=[
+                {key: value for key, value in matcher.items() if key != "isEqual"}
+                for matcher in matchers
+            ],
+        ),
         silence("owned-expired", "expired"),
         silence("foreign-author", "active", created_by="another-operator"),
         silence("foreign-comment", "active", comment="another drill"),
@@ -1986,6 +2004,26 @@ def watchdog_silence_fixture():
             "regex-matcher",
             "active",
             selected_matchers=[matchers[0] | {"isRegex": True}, *matchers[1:]],
+        ),
+        silence(
+            "unequal-matcher",
+            "active",
+            selected_matchers=[matchers[0] | {"isEqual": False}, *matchers[1:]],
+        ),
+        silence(
+            "non-boolean-equality",
+            "active",
+            selected_matchers=[matchers[0] | {"isEqual": "true"}, *matchers[1:]],
+        ),
+        silence(
+            "unexpected-matcher-key",
+            "active",
+            selected_matchers=[matchers[0] | {"unexpected": False}, *matchers[1:]],
+        ),
+        silence(
+            "duplicate-matcher",
+            "active",
+            selected_matchers=[matchers[0], matchers[0], *matchers[2:]],
         ),
         silence(
             "extra-matcher",
@@ -1998,7 +2036,8 @@ def watchdog_silence_fixture():
             "active",
             selected_matchers=[matchers[0] | {"value": ".*"}, *matchers[1:]],
         ),
-        silence("malformed", "active", selected_matchers={"not": "a list"}),
+        silence("malformed-list", "active", selected_matchers={"not": "a list"}),
+        silence("malformed-object", "active", selected_matchers=[None, *matchers[1:]]),
     ]
 
 
@@ -2115,9 +2154,10 @@ def test_watchdog_silence_status_reports_only_exact_owned_active_or_pending(tmp_
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.endswith(
-        "Owned active/pending watchdog drill silence IDs:\nowned-active\nowned-pending\n"
+        "Owned active/pending watchdog drill silence IDs:\n"
+        "owned-active\nowned-pending\nowned-legacy\n"
     )
-    for silence in fixture[2:]:
+    for silence in fixture[3:]:
         assert silence["id"] not in result.stdout
         assert silence["fixtureDetail"] not in result.stdout + result.stderr
 
@@ -2128,13 +2168,13 @@ def test_watchdog_silence_clear_deletes_only_exact_owned_active_or_pending(tmp_p
 
     assert result.returncode == 0, result.stderr
     deleted = (tmp_path / "watchdog-silence-deletions").read_text(encoding="utf-8").splitlines()
-    assert deleted == ["owned-active", "owned-pending"]
+    assert deleted == ["owned-active", "owned-pending", "owned-legacy"]
     assert result.stdout.endswith("Owned watchdog drill silence cleared.\n")
     assert all(item["fixtureDetail"] not in result.stdout + result.stderr for item in fixture)
 
 
 def test_watchdog_silence_clear_is_noop_without_owned_silences(tmp_path):
-    fixture = watchdog_silence_fixture()[2:]
+    fixture = watchdog_silence_fixture()[3:]
     result, audit = run_helper(tmp_path, "watchdog-drill-clear", watchdog_silences=fixture)
 
     assert result.returncode == 0, result.stderr


### PR DESCRIPTION
### Motivation

- Alertmanager v0.33.1 normalizes equality matchers by adding boolean `isEqual: true`, which caused the existing watchdog ownership parser to reject real repository-owned silences and made `watchdog-drill-status` and `watchdog-drill-clear` miss or fail to delete them.

### Description

- Replace the one-liner parser in `scripts/observability_helm.sh` with a small Python routine that strictly validates silence documents and accepts either legacy matchers (no `isEqual`) or normalized matchers with `isEqual` exactly boolean `true` while preserving fail-closed protections.
- Enforce exact ownership requirements: exactly four matchers with the four expected `(name,value)` pairs, `isRegex` exactly `false`, optional `isEqual` only when boolean `true`, no unexpected matcher keys, exact `createdBy` and `comment`, safe silence `id` format, and only `active`/`pending` states.
- Update `tests/test_observability_helm.py` fixtures and expectations to cover normalized matchers, legacy responses, and a wide set of rejection cases including `isEqual: false`, non-boolean `isEqual`, unexpected keys, regex/duplicate/missing/extra/broad matchers, malformed structures, foreign metadata, and expired states.
- Preserve redaction and fail-closed behavior for malformed or failed API responses and keep status/clear operations restricted to validated IDs only.

### Testing

- Ran `python3 -m pytest -q tests/test_observability_helm.py` and observed `180 passed`.
- Ran `shellcheck scripts/observability_helm.sh` and `just observability-render env=staging >/dev/null` which completed successfully for the modified paths.
- Verified `git diff --check`, `git diff | ./scripts/scan-secrets.py`, and `git diff --cached | ./scripts/scan-secrets.py` produced no secret exposure for the scoped changes.
- Ran `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` which completed with no errors for the repo links and spelling checks after installing missing system spellchecker dependency.
- Attempted `pre-commit run --all-files`; hooks made auto-fixes to unrelated, pre-existing issues across the repository so those repo-wide failures were not progressed (auto-fixes were reverted and only the scope-locked files were changed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fbc60fa80832f81bdd677c4b4a6de)