### PR TITLE
Fix Alertmanager watchdog drill ownership matching

### DIFF
--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -308,11 +308,62 @@ print(f"Owned watchdog drill silence created; id={silence_id}; automatic expiry=
 PY
 )
 watchdog_owned_silences() {
-  kubectl get --raw "${WATCHDOG_API}/silences" | python3 -c 'import json,sys; wanted=[("alertname","SugarkubeObservabilityWatchdog"),("environment","staging"),("cluster","sugarkube-int"),("purpose","observability-watchdog")]; out=[]
-for x in json.load(sys.stdin):
- m=x.get("matchers"); exact=isinstance(m,list) and len(m)==4 and sorted((a.get("name"),a.get("value")) for a in m if isinstance(a,dict) and a.get("isRegex") is False and set(a)=={"name","value","isRegex"})==sorted(wanted)
- if x.get("createdBy")=="sugarkube-observability-watchdog-drill" and x.get("comment")=="Owned staging watchdog failure drill" and x.get("status",{}).get("state") in ("active","pending") and exact: out.append(x["id"])
-print("\n".join(out))'
+  kubectl get --raw "${WATCHDOG_API}/silences" | python3 -c '
+import json
+import re
+import sys
+
+wanted = sorted([
+    ("alertname", "SugarkubeObservabilityWatchdog"),
+    ("environment", "staging"),
+    ("cluster", "sugarkube-int"),
+    ("purpose", "observability-watchdog"),
+])
+
+def has_exact_matchers(matchers):
+    if not isinstance(matchers, list) or len(matchers) != 4:
+        return False
+    pairs = []
+    for matcher in matchers:
+        if not isinstance(matcher, dict):
+            return False
+        required_keys = {"name", "value", "isRegex"}
+        allowed_keys = required_keys | {"isEqual"}
+        if not required_keys <= set(matcher) <= allowed_keys:
+            return False
+        if matcher["isRegex"] is not False:
+            return False
+        if "isEqual" in matcher and matcher["isEqual"] is not True:
+            return False
+        pairs.append((matcher["name"], matcher["value"]))
+    return sorted(pairs) == wanted
+
+try:
+    silences = json.load(sys.stdin)
+    if not isinstance(silences, list):
+        raise ValueError
+    owned = []
+    for silence in silences:
+        if not isinstance(silence, dict):
+            raise ValueError
+        status = silence.get("status")
+        if (
+            silence.get("createdBy") == "sugarkube-observability-watchdog-drill"
+            and silence.get("comment") == "Owned staging watchdog failure drill"
+            and isinstance(status, dict)
+            and status.get("state") in ("active", "pending")
+            and has_exact_matchers(silence.get("matchers"))
+        ):
+            silence_id = silence.get("id")
+            if not isinstance(silence_id, str) or not re.fullmatch(
+                r"[A-Za-z0-9][A-Za-z0-9_-]*", silence_id
+            ):
+                raise ValueError
+            owned.append(silence_id)
+except (AttributeError, json.JSONDecodeError, TypeError, ValueError):
+    raise SystemExit("ERROR: Alertmanager returned an invalid silence list (response redacted).")
+
+print("\n".join(owned))'
 }
 watchdog_silence_list() { assert_context; local ids; ids="$(watchdog_owned_silences)"; [[ -n "${ids}" ]] && printf 'Owned active/pending watchdog drill silence IDs:\n%s\n' "${ids}" || echo "No owned active/pending watchdog drill silence."; }
 watchdog_silence_clear() { assert_context; local ids; ids="$(watchdog_owned_silences)"; [[ -n "${ids}" ]] || { echo "No owned active/pending watchdog drill silence to clear."; return; }; while IFS= read -r id; do kubectl delete --raw "${WATCHDOG_API}/silence/${id}" >/dev/null; done <<<"${ids}"; echo "Owned watchdog drill silence cleared."; }

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -1952,12 +1952,13 @@ def test_watchdog_delivery_one_of_multiple_log_retrievals_fails_closed(tmp_path)
 
 
 def watchdog_silence_fixture():
-    matchers = [
+    legacy_matchers = [
         {"name": "alertname", "value": "SugarkubeObservabilityWatchdog", "isRegex": False},
         {"name": "environment", "value": "staging", "isRegex": False},
         {"name": "cluster", "value": "sugarkube-int", "isRegex": False},
         {"name": "purpose", "value": "observability-watchdog", "isRegex": False},
     ]
+    normalized_matchers = [matcher | {"isEqual": True} for matcher in legacy_matchers]
 
     def silence(
         identifier,
@@ -1965,40 +1966,80 @@ def watchdog_silence_fixture():
         *,
         created_by="sugarkube-observability-watchdog-drill",
         comment="Owned staging watchdog failure drill",
-        selected_matchers=None,
+        selected_matchers=normalized_matchers,
     ):
         return {
             "id": identifier,
             "status": {"state": state},
             "createdBy": created_by,
             "comment": comment,
-            "matchers": matchers if selected_matchers is None else selected_matchers,
+            "matchers": selected_matchers,
             "fixtureDetail": f"private-detail-{identifier}",
         }
 
     return [
         silence("owned-active", "active"),
-        silence("owned-pending", "pending"),
+        silence("owned-pending-legacy", "pending", selected_matchers=legacy_matchers),
         silence("owned-expired", "expired"),
         silence("foreign-author", "active", created_by="another-operator"),
         silence("foreign-comment", "active", comment="another drill"),
         silence(
             "regex-matcher",
             "active",
-            selected_matchers=[matchers[0] | {"isRegex": True}, *matchers[1:]],
+            selected_matchers=[
+                normalized_matchers[0] | {"isRegex": True},
+                *normalized_matchers[1:],
+            ],
+        ),
+        silence(
+            "not-equal-matcher",
+            "active",
+            selected_matchers=[
+                normalized_matchers[0] | {"isEqual": False},
+                *normalized_matchers[1:],
+            ],
+        ),
+        silence(
+            "non-boolean-equality",
+            "active",
+            selected_matchers=[
+                normalized_matchers[0] | {"isEqual": "true"},
+                *normalized_matchers[1:],
+            ],
+        ),
+        silence(
+            "unexpected-matcher-key",
+            "active",
+            selected_matchers=[
+                normalized_matchers[0] | {"unexpected": False},
+                *normalized_matchers[1:],
+            ],
         ),
         silence(
             "extra-matcher",
             "active",
-            selected_matchers=[*matchers, {"name": "node", "value": "all", "isRegex": False}],
+            selected_matchers=[
+                *normalized_matchers,
+                {"name": "node", "value": "all", "isRegex": False, "isEqual": True},
+            ],
         ),
-        silence("missing-matcher", "active", selected_matchers=matchers[:-1]),
+        silence("missing-matcher", "active", selected_matchers=normalized_matchers[:-1]),
+        silence(
+            "duplicate-matcher",
+            "active",
+            selected_matchers=[
+                normalized_matchers[0],
+                normalized_matchers[0],
+                *normalized_matchers[2:],
+            ],
+        ),
         silence(
             "broad-matcher",
             "active",
-            selected_matchers=[matchers[0] | {"value": ".*"}, *matchers[1:]],
+            selected_matchers=[normalized_matchers[0] | {"value": ".*"}, *normalized_matchers[1:]],
         ),
         silence("malformed", "active", selected_matchers={"not": "a list"}),
+        silence("malformed-object", "active", selected_matchers=[None, *normalized_matchers[1:]]),
     ]
 
 
@@ -2115,7 +2156,9 @@ def test_watchdog_silence_status_reports_only_exact_owned_active_or_pending(tmp_
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.endswith(
-        "Owned active/pending watchdog drill silence IDs:\nowned-active\nowned-pending\n"
+        "Owned active/pending watchdog drill silence IDs:\n"
+        "owned-active\n"
+        "owned-pending-legacy\n"
     )
     for silence in fixture[2:]:
         assert silence["id"] not in result.stdout
@@ -2128,7 +2171,7 @@ def test_watchdog_silence_clear_deletes_only_exact_owned_active_or_pending(tmp_p
 
     assert result.returncode == 0, result.stderr
     deleted = (tmp_path / "watchdog-silence-deletions").read_text(encoding="utf-8").splitlines()
-    assert deleted == ["owned-active", "owned-pending"]
+    assert deleted == ["owned-active", "owned-pending-legacy"]
     assert result.stdout.endswith("Owned watchdog drill silence cleared.\n")
     assert all(item["fixtureDetail"] not in result.stdout + result.stderr for item in fixture)
 
@@ -2148,6 +2191,8 @@ def test_watchdog_silence_clear_is_noop_without_owned_silences(tmp_path):
     [
         ("watchdog-drill-status", "watchdog-silences-fail"),
         ("watchdog-drill-status", "watchdog-silences-malformed"),
+        ("watchdog-drill-clear", "watchdog-silences-fail"),
+        ("watchdog-drill-clear", "watchdog-silences-malformed"),
     ],
 )
 def test_watchdog_silence_api_failures_do_not_expose_fixture_contents(tmp_path, command, mode):
@@ -2157,3 +2202,5 @@ def test_watchdog_silence_api_failures_do_not_expose_fixture_contents(tmp_path, 
     assert result.returncode != 0
     output = result.stdout + result.stderr
     assert all(item["fixtureDetail"] not in output for item in fixture)
+    assert "credential" not in output
+    assert "Traceback" not in output


### PR DESCRIPTION
### Motivation

- Alertmanager v0.33.1 normalizes equality matchers by adding `isEqual: true`, which caused the previous ownership parser to fail to recognize legitimately created watchdog drill silences returned by the v2 API. 
- The change must accept normalized responses while preserving strict fail-closed ownership protections so only exact repository-owned active/pending silences are reported or cleared.

### Description

- Replace the one-liner parser in `scripts/observability_helm.sh` with a small Python routine that validates the silence list, allowing an optional `isEqual` key only when its value is exactly boolean `True` and otherwise enforcing strict checks for shape, keys, `isRegex: False`, exact name/value pairs, creator/comment, and active/pending state. 
- Add a safe silence ID check (regex) and convert malformed or unexpected API responses into a redacted, nonzero diagnostic to preserve fail-closed behavior. 
- Update `tests/test_observability_helm.py` to include fixtures covering Alertmanager-normalized matchers (`isEqual: true`), legacy responses without `isEqual`, and many negative cases (regex matchers, `isEqual: false`, non-boolean equality, unexpected matcher keys, duplicates, missing/extra matchers, broadened values, and malformed objects). 
- Keep the scope constrained to `scripts/observability_helm.sh` and `tests/test_observability_helm.py` and preserve all other watchdog/drill behavior and timings.

### Testing

- Ran `python3 -m pytest -q tests/test_observability_helm.py` and observed all tests in that file pass (`182 passed`).
- Ran `shellcheck scripts/observability_helm.sh`, `just observability-render env=staging >/dev/null`, `git diff --check`, and `git diff | ./scripts/scan-secrets.py` as focused repo checks and they completed successfully in the patched environment. 
- Ran documentation checks `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` which completed with no link/spelling failures for the changed scope. 
- Attempted `pre-commit run --all-files`; repository-wide pre-existing YAML/flake8/trailing-whitespace issues outside the scope of this change caused hooks to edit other files and fail, so those unrelated fixes were not included here and the attempt is noted rather than merged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fbc69b7a0832f9b316d26a6cc3997)