### PR TITLE
Fix watchdog drill ownership matching for normalized silences

### DIFF
--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -308,11 +308,65 @@ print(f"Owned watchdog drill silence created; id={silence_id}; automatic expiry=
 PY
 )
 watchdog_owned_silences() {
-  kubectl get --raw "${WATCHDOG_API}/silences" | python3 -c 'import json,sys; wanted=[("alertname","SugarkubeObservabilityWatchdog"),("environment","staging"),("cluster","sugarkube-int"),("purpose","observability-watchdog")]; out=[]
-for x in json.load(sys.stdin):
- m=x.get("matchers"); exact=isinstance(m,list) and len(m)==4 and sorted((a.get("name"),a.get("value")) for a in m if isinstance(a,dict) and a.get("isRegex") is False and set(a)=={"name","value","isRegex"})==sorted(wanted)
- if x.get("createdBy")=="sugarkube-observability-watchdog-drill" and x.get("comment")=="Owned staging watchdog failure drill" and x.get("status",{}).get("state") in ("active","pending") and exact: out.append(x["id"])
-print("\n".join(out))'
+  kubectl get --raw "${WATCHDOG_API}/silences" | python3 -c '
+import json
+import re
+import sys
+
+expected_matchers = sorted([
+    ("alertname", "SugarkubeObservabilityWatchdog"),
+    ("environment", "staging"),
+    ("cluster", "sugarkube-int"),
+    ("purpose", "observability-watchdog"),
+])
+
+def has_exact_matchers(matchers):
+    if not isinstance(matchers, list) or len(matchers) != 4:
+        return False
+    actual = []
+    for matcher in matchers:
+        if not isinstance(matcher, dict):
+            return False
+        if set(matcher) not in (
+            {"name", "value", "isRegex"},
+            {"name", "value", "isRegex", "isEqual"},
+        ):
+            return False
+        if not isinstance(matcher["name"], str) or not isinstance(matcher["value"], str):
+            return False
+        if matcher["isRegex"] is not False:
+            return False
+        if "isEqual" in matcher and matcher["isEqual"] is not True:
+            return False
+        actual.append((matcher["name"], matcher["value"]))
+    return sorted(actual) == expected_matchers
+
+try:
+    document = json.load(sys.stdin)
+    if not isinstance(document, list):
+        raise ValueError
+    owned = []
+    for silence in document:
+        if not isinstance(silence, dict):
+            raise ValueError
+        status = silence.get("status")
+        if (
+            silence.get("createdBy") == "sugarkube-observability-watchdog-drill"
+            and silence.get("comment") == "Owned staging watchdog failure drill"
+            and isinstance(status, dict)
+            and status.get("state") in ("active", "pending")
+            and has_exact_matchers(silence.get("matchers"))
+        ):
+            silence_id = silence.get("id")
+            if not isinstance(silence_id, str) or not re.fullmatch(
+                r"[A-Za-z0-9][A-Za-z0-9_-]*", silence_id
+            ):
+                raise ValueError
+            owned.append(silence_id)
+except (AttributeError, json.JSONDecodeError, OSError, TypeError, UnicodeError, ValueError):
+    raise SystemExit("ERROR: Alertmanager returned an invalid silence list (response redacted).")
+
+print("\n".join(owned))'
 }
 watchdog_silence_list() { assert_context; local ids; ids="$(watchdog_owned_silences)"; [[ -n "${ids}" ]] && printf 'Owned active/pending watchdog drill silence IDs:\n%s\n' "${ids}" || echo "No owned active/pending watchdog drill silence."; }
 watchdog_silence_clear() { assert_context; local ids; ids="$(watchdog_owned_silences)"; [[ -n "${ids}" ]] || { echo "No owned active/pending watchdog drill silence to clear."; return; }; while IFS= read -r id; do kubectl delete --raw "${WATCHDOG_API}/silence/${id}" >/dev/null; done <<<"${ids}"; echo "Owned watchdog drill silence cleared."; }

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -710,6 +710,7 @@ case "$*" in
   *"get --raw /api/v1/namespaces/monitoring/services/http:kube-prometheus-stack-alertmanager:9093/proxy/api/v2/silences"*)
     [ "$KUBECTL_MODE" != watchdog-silences-fail ] || exit 49
     [ "$KUBECTL_MODE" != watchdog-silences-malformed ] || { printf '%s\n' '{malformed'; exit 0; }
+    [ "$KUBECTL_MODE" != watchdog-silences-nonutf8 ] || { printf '\377PRIVATE_NON_UTF8_SENTINEL\n'; exit 0; }
     cat "$WATCHDOG_SILENCES"
     ;;
   *"delete --raw /api/v1/namespaces/monitoring/services/http:kube-prometheus-stack-alertmanager:9093/proxy/api/v2/silence/"*)
@@ -2197,8 +2198,10 @@ def test_watchdog_silence_clear_is_noop_without_owned_silences(tmp_path):
     [
         ("watchdog-drill-status", "watchdog-silences-fail"),
         ("watchdog-drill-status", "watchdog-silences-malformed"),
+        ("watchdog-drill-status", "watchdog-silences-nonutf8"),
         ("watchdog-drill-clear", "watchdog-silences-fail"),
         ("watchdog-drill-clear", "watchdog-silences-malformed"),
+        ("watchdog-drill-clear", "watchdog-silences-nonutf8"),
     ],
 )
 def test_watchdog_silence_api_failures_do_not_expose_fixture_contents(tmp_path, command, mode):
@@ -2208,6 +2211,9 @@ def test_watchdog_silence_api_failures_do_not_expose_fixture_contents(tmp_path, 
     assert result.returncode != 0
     output = result.stdout + result.stderr
     assert all(item["fixtureDetail"] not in output for item in fixture)
+    assert "PRIVATE_NON_UTF8_SENTINEL" not in output
     assert "credential" not in output
     assert "Traceback" not in output
     assert "response redacted" in output
+    if command == "watchdog-drill-clear":
+        assert not (tmp_path / "watchdog-silence-deletions").exists()

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -1953,10 +1953,20 @@ def test_watchdog_delivery_one_of_multiple_log_retrievals_fails_closed(tmp_path)
 
 def watchdog_silence_fixture():
     matchers = [
-        {"name": "alertname", "value": "SugarkubeObservabilityWatchdog", "isRegex": False},
-        {"name": "environment", "value": "staging", "isRegex": False},
-        {"name": "cluster", "value": "sugarkube-int", "isRegex": False},
-        {"name": "purpose", "value": "observability-watchdog", "isRegex": False},
+        {
+            "name": "alertname",
+            "value": "SugarkubeObservabilityWatchdog",
+            "isRegex": False,
+            "isEqual": True,
+        },
+        {"name": "environment", "value": "staging", "isRegex": False, "isEqual": True},
+        {"name": "cluster", "value": "sugarkube-int", "isRegex": False, "isEqual": True},
+        {
+            "name": "purpose",
+            "value": "observability-watchdog",
+            "isRegex": False,
+            "isEqual": True,
+        },
     ]
 
     def silence(
@@ -1979,6 +1989,14 @@ def watchdog_silence_fixture():
     return [
         silence("owned-active", "active"),
         silence("owned-pending", "pending"),
+        silence(
+            "owned-legacy",
+            "active",
+            selected_matchers=[
+                {key: value for key, value in matcher.items() if key != "isEqual"}
+                for matcher in matchers
+            ],
+        ),
         silence("owned-expired", "expired"),
         silence("foreign-author", "active", created_by="another-operator"),
         silence("foreign-comment", "active", comment="another drill"),
@@ -1986,6 +2004,36 @@ def watchdog_silence_fixture():
             "regex-matcher",
             "active",
             selected_matchers=[matchers[0] | {"isRegex": True}, *matchers[1:]],
+        ),
+        silence(
+            "unequal-matcher",
+            "active",
+            selected_matchers=[matchers[0] | {"isEqual": False}, *matchers[1:]],
+        ),
+        silence(
+            "string-equality-matcher",
+            "active",
+            selected_matchers=[matchers[0] | {"isEqual": "true"}, *matchers[1:]],
+        ),
+        silence(
+            "unexpected-matcher-field",
+            "active",
+            selected_matchers=[matchers[0] | {"unexpected": False}, *matchers[1:]],
+        ),
+        silence(
+            "malformed-matcher-object",
+            "active",
+            selected_matchers=[{"name": "alertname"}, *matchers[1:]],
+        ),
+        silence(
+            "non-object-matcher",
+            "active",
+            selected_matchers=["alertname=SugarkubeObservabilityWatchdog", *matchers[1:]],
+        ),
+        silence(
+            "duplicate-matcher",
+            "active",
+            selected_matchers=[matchers[0], matchers[0], matchers[2], matchers[3]],
         ),
         silence(
             "extra-matcher",
@@ -2115,9 +2163,10 @@ def test_watchdog_silence_status_reports_only_exact_owned_active_or_pending(tmp_
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.endswith(
-        "Owned active/pending watchdog drill silence IDs:\nowned-active\nowned-pending\n"
+        "Owned active/pending watchdog drill silence IDs:\n"
+        "owned-active\nowned-pending\nowned-legacy\n"
     )
-    for silence in fixture[2:]:
+    for silence in fixture[3:]:
         assert silence["id"] not in result.stdout
         assert silence["fixtureDetail"] not in result.stdout + result.stderr
 
@@ -2128,13 +2177,13 @@ def test_watchdog_silence_clear_deletes_only_exact_owned_active_or_pending(tmp_p
 
     assert result.returncode == 0, result.stderr
     deleted = (tmp_path / "watchdog-silence-deletions").read_text(encoding="utf-8").splitlines()
-    assert deleted == ["owned-active", "owned-pending"]
+    assert deleted == ["owned-active", "owned-pending", "owned-legacy"]
     assert result.stdout.endswith("Owned watchdog drill silence cleared.\n")
     assert all(item["fixtureDetail"] not in result.stdout + result.stderr for item in fixture)
 
 
 def test_watchdog_silence_clear_is_noop_without_owned_silences(tmp_path):
-    fixture = watchdog_silence_fixture()[2:]
+    fixture = watchdog_silence_fixture()[3:]
     result, audit = run_helper(tmp_path, "watchdog-drill-clear", watchdog_silences=fixture)
 
     assert result.returncode == 0, result.stderr
@@ -2148,6 +2197,8 @@ def test_watchdog_silence_clear_is_noop_without_owned_silences(tmp_path):
     [
         ("watchdog-drill-status", "watchdog-silences-fail"),
         ("watchdog-drill-status", "watchdog-silences-malformed"),
+        ("watchdog-drill-clear", "watchdog-silences-fail"),
+        ("watchdog-drill-clear", "watchdog-silences-malformed"),
     ],
 )
 def test_watchdog_silence_api_failures_do_not_expose_fixture_contents(tmp_path, command, mode):
@@ -2157,3 +2208,6 @@ def test_watchdog_silence_api_failures_do_not_expose_fixture_contents(tmp_path, 
     assert result.returncode != 0
     output = result.stdout + result.stderr
     assert all(item["fixtureDetail"] not in output for item in fixture)
+    assert "credential" not in output
+    assert "Traceback" not in output
+    assert "response redacted" in output


### PR DESCRIPTION
### Motivation

Alertmanager v0.33.1 normalizes equality matchers returned by `/api/v2/silences` with an additional boolean `isEqual: true` field. The existing ownership parser allowed only `name`, `value`, and `isRegex`, so it failed to recognize a real repository-owned watchdog silence. Consequently, both `watchdog-drill-status` and `watchdog-drill-clear` reported no owned silence.

This is a follow-up to `01bf30039e34dd659587b091a31a328dcb498cfb` and is related to #2403.

### Changes

- Replace the opaque ownership-filter one-liner in `scripts/observability_helm.sh` with a localized strict parser.
- Accept both supported matcher shapes:
  - legacy matchers without `isEqual`;
  - normalized matchers where `isEqual` is exactly boolean `true`.
- Continue requiring:
  - exactly four matchers and the exact expected name/value pairs;
  - no duplicate, missing, extra, regex, broadened, or unexpected matcher fields;
  - `isRegex` exactly boolean `false`;
  - exact `createdBy` and comment metadata;
  - an `active` or `pending` state;
  - a safe silence ID.
- Fail closed with redacted diagnostics for malformed JSON, invalid UTF-8, unexpected response structures, and failed API calls.
- Extend `tests/test_observability_helm.py` to cover normalized and legacy responses, strict negative cases, status output, clear behavior, API failures, malformed responses, non-UTF-8 input, redaction, and deletion safety.
- Preserve the existing loopback creation transport, eight-minute duration, watchdog labels and timing, ownership metadata, Secret handling, Alertmanager routing, Helm values, and unrelated observability behavior.

### Live validation

`just observability-watchdog-drill-start env=staging` created silence `646420b7-bc16-4346-b9b3-24de84efea8f` with the intended eight-minute lifetime, repository-owned creator/comment, and exactly these matchers:

- `alertname=SugarkubeObservabilityWatchdog`
- `environment=staging`
- `cluster=sugarkube-int`
- `purpose=observability-watchdog`

Alertmanager returned each equality matcher with `isRegex: false` and `isEqual: true`. The silence successfully stopped watchdog delivery, Healthchecks transitioned Down, and PagerDuty incident #5 opened. Automatic silence expiry restored Healthchecks to green and PagerDuty resolved the incident automatically.

### Testing

- `python3 -m pytest -q tests/test_observability_helm.py -k watchdog_silence` — 9 passed, 175 deselected
- `python3 -m pytest -q tests/test_observability_helm.py` — 184 passed
- `shellcheck scripts/observability_helm.sh`
- `just observability-render env=staging >/dev/null`
- `git diff --check`
- `git diff | ./scripts/scan-secrets.py`
- `git diff --cached | ./scripts/scan-secrets.py`
- Codecov reports all modified and coverable lines covered

`pre-commit run --files scripts/observability_helm.sh tests/test_observability_helm.py` completed its scoped formatting hooks, while the repository-wide `run-checks` hook reported existing Flake8 findings outside the two changed files; no unrelated fixes were included.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fbc63f158832f97728d70cca4143e)