### PR TITLE
Fix watchdog drill ownership matching for normalized silences

### DIFF
--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -308,11 +308,70 @@ print(f"Owned watchdog drill silence created; id={silence_id}; automatic expiry=
 PY
 )
 watchdog_owned_silences() {
-  kubectl get --raw "${WATCHDOG_API}/silences" | python3 -c 'import json,sys; wanted=[("alertname","SugarkubeObservabilityWatchdog"),("environment","staging"),("cluster","sugarkube-int"),("purpose","observability-watchdog")]; out=[]
-for x in json.load(sys.stdin):
- m=x.get("matchers"); exact=isinstance(m,list) and len(m)==4 and sorted((a.get("name"),a.get("value")) for a in m if isinstance(a,dict) and a.get("isRegex") is False and set(a)=={"name","value","isRegex"})==sorted(wanted)
- if x.get("createdBy")=="sugarkube-observability-watchdog-drill" and x.get("comment")=="Owned staging watchdog failure drill" and x.get("status",{}).get("state") in ("active","pending") and exact: out.append(x["id"])
-print("\n".join(out))'
+  kubectl get --raw "${WATCHDOG_API}/silences" | python3 -c '
+import json
+import re
+import sys
+
+wanted = {
+    ("alertname", "SugarkubeObservabilityWatchdog"),
+    ("environment", "staging"),
+    ("cluster", "sugarkube-int"),
+    ("purpose", "observability-watchdog"),
+}
+base_keys = {"name", "value", "isRegex"}
+
+try:
+    document = json.load(sys.stdin)
+    if not isinstance(document, list):
+        raise ValueError
+
+    owned_ids = []
+    for silence in document:
+        if not isinstance(silence, dict):
+            continue
+        matchers = silence.get("matchers")
+        if not isinstance(matchers, list) or len(matchers) != 4:
+            continue
+
+        pairs = []
+        for matcher in matchers:
+            if not isinstance(matcher, dict):
+                break
+            keys = set(matcher)
+            if keys not in (base_keys, base_keys | {"isEqual"}):
+                break
+            if matcher["isRegex"] is not False:
+                break
+            if "isEqual" in matcher and matcher["isEqual"] is not True:
+                break
+            if not isinstance(matcher["name"], str) or not isinstance(matcher["value"], str):
+                break
+            pair = (matcher["name"], matcher["value"])
+            if pair not in wanted:
+                break
+            pairs.append(pair)
+        else:
+            status = silence.get("status")
+            exact = len(set(pairs)) == 4 and set(pairs) == wanted
+            owned = (
+                silence.get("createdBy") == "sugarkube-observability-watchdog-drill"
+                and silence.get("comment") == "Owned staging watchdog failure drill"
+                and isinstance(status, dict)
+                and status.get("state") in ("active", "pending")
+                and exact
+            )
+            if owned:
+                silence_id = silence.get("id")
+                if not isinstance(silence_id, str) or not re.fullmatch(
+                    r"[A-Za-z0-9][A-Za-z0-9_-]*", silence_id
+                ):
+                    raise ValueError
+                owned_ids.append(silence_id)
+except (json.JSONDecodeError, TypeError, ValueError):
+    raise SystemExit("ERROR: Alertmanager returned an invalid silence list (response redacted).")
+
+print("\n".join(owned_ids))'
 }
 watchdog_silence_list() { assert_context; local ids; ids="$(watchdog_owned_silences)"; [[ -n "${ids}" ]] && printf 'Owned active/pending watchdog drill silence IDs:\n%s\n' "${ids}" || echo "No owned active/pending watchdog drill silence."; }
 watchdog_silence_clear() { assert_context; local ids; ids="$(watchdog_owned_silences)"; [[ -n "${ids}" ]] || { echo "No owned active/pending watchdog drill silence to clear."; return; }; while IFS= read -r id; do kubectl delete --raw "${WATCHDOG_API}/silence/${id}" >/dev/null; done <<<"${ids}"; echo "Owned watchdog drill silence cleared."; }

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -1952,12 +1952,13 @@ def test_watchdog_delivery_one_of_multiple_log_retrievals_fails_closed(tmp_path)
 
 
 def watchdog_silence_fixture():
-    matchers = [
+    legacy_matchers = [
         {"name": "alertname", "value": "SugarkubeObservabilityWatchdog", "isRegex": False},
         {"name": "environment", "value": "staging", "isRegex": False},
         {"name": "cluster", "value": "sugarkube-int", "isRegex": False},
         {"name": "purpose", "value": "observability-watchdog", "isRegex": False},
     ]
+    normalized_matchers = [matcher | {"isEqual": True} for matcher in legacy_matchers]
 
     def silence(
         identifier,
@@ -1965,40 +1966,84 @@ def watchdog_silence_fixture():
         *,
         created_by="sugarkube-observability-watchdog-drill",
         comment="Owned staging watchdog failure drill",
-        selected_matchers=None,
+        selected_matchers=normalized_matchers,
     ):
         return {
             "id": identifier,
             "status": {"state": state},
             "createdBy": created_by,
             "comment": comment,
-            "matchers": matchers if selected_matchers is None else selected_matchers,
+            "matchers": selected_matchers,
             "fixtureDetail": f"private-detail-{identifier}",
         }
 
     return [
         silence("owned-active", "active"),
-        silence("owned-pending", "pending"),
+        silence("owned-pending", "pending", selected_matchers=legacy_matchers),
         silence("owned-expired", "expired"),
         silence("foreign-author", "active", created_by="another-operator"),
         silence("foreign-comment", "active", comment="another drill"),
         silence(
             "regex-matcher",
             "active",
-            selected_matchers=[matchers[0] | {"isRegex": True}, *matchers[1:]],
+            selected_matchers=[
+                normalized_matchers[0] | {"isRegex": True},
+                *normalized_matchers[1:],
+            ],
+        ),
+        silence(
+            "not-equal-matcher",
+            "active",
+            selected_matchers=[
+                normalized_matchers[0] | {"isEqual": False},
+                *normalized_matchers[1:],
+            ],
+        ),
+        silence(
+            "string-equal-matcher",
+            "active",
+            selected_matchers=[
+                normalized_matchers[0] | {"isEqual": "true"},
+                *normalized_matchers[1:],
+            ],
+        ),
+        silence(
+            "unexpected-matcher-key",
+            "active",
+            selected_matchers=[
+                normalized_matchers[0] | {"unexpected": False},
+                *normalized_matchers[1:],
+            ],
         ),
         silence(
             "extra-matcher",
             "active",
-            selected_matchers=[*matchers, {"name": "node", "value": "all", "isRegex": False}],
+            selected_matchers=[
+                *normalized_matchers,
+                {"name": "node", "value": "all", "isRegex": False},
+            ],
         ),
-        silence("missing-matcher", "active", selected_matchers=matchers[:-1]),
+        silence("missing-matcher", "active", selected_matchers=normalized_matchers[:-1]),
+        silence(
+            "duplicate-matcher",
+            "active",
+            selected_matchers=[
+                normalized_matchers[0],
+                normalized_matchers[0],
+                *normalized_matchers[2:],
+            ],
+        ),
         silence(
             "broad-matcher",
             "active",
-            selected_matchers=[matchers[0] | {"value": ".*"}, *matchers[1:]],
+            selected_matchers=[normalized_matchers[0] | {"value": ".*"}, *normalized_matchers[1:]],
         ),
         silence("malformed", "active", selected_matchers={"not": "a list"}),
+        silence(
+            "malformed-object",
+            "active",
+            selected_matchers=[None, *normalized_matchers[1:]],
+        ),
     ]
 
 
@@ -2148,6 +2193,8 @@ def test_watchdog_silence_clear_is_noop_without_owned_silences(tmp_path):
     [
         ("watchdog-drill-status", "watchdog-silences-fail"),
         ("watchdog-drill-status", "watchdog-silences-malformed"),
+        ("watchdog-drill-clear", "watchdog-silences-fail"),
+        ("watchdog-drill-clear", "watchdog-silences-malformed"),
     ],
 )
 def test_watchdog_silence_api_failures_do_not_expose_fixture_contents(tmp_path, command, mode):
@@ -2157,3 +2204,6 @@ def test_watchdog_silence_api_failures_do_not_expose_fixture_contents(tmp_path, 
     assert result.returncode != 0
     output = result.stdout + result.stderr
     assert all(item["fixtureDetail"] not in output for item in fixture)
+    assert "credential" not in output
+    assert "Traceback" not in output
+    assert not (tmp_path / "watchdog-silence-deletions").exists()


### PR DESCRIPTION
### Motivation

- Alertmanager v0.33.1 normalizes equality matchers by adding a boolean `isEqual: true`, which caused the previous ownership filter to miss real repository-owned silences returned by the API. 
- The intent is to recognize real server-normalized silences while keeping the existing fail-closed exact-match protections so `watchdog-drill-status` and `watchdog-drill-clear` operate only on genuine owned active/pending silences.

### Description

- Replace the one-liner matcher parser in `scripts/observability_helm.sh::watchdog_owned_silences` with a small readable Python validator that accepts either the legacy matcher shape or the server-normalized shape when `isEqual` is exactly boolean `true`, enforces `isRegex: false`, validates `name`/`value` types, permits only the optional `isEqual` key in addition to `name/value/isRegex`, and requires exactly the four expected matcher name/value pairs and no duplicates. 
- Preserve exact ownership guards by checking `createdBy`, `comment`, `status.state` (must be `active` or `pending`), safe silence `id` format, and failing closed with a redacted error on malformed or unexpected API responses. 
- Extend `tests/test_observability_helm.py` fixtures and assertions to cover normalized responses (`isEqual: true`), legacy responses (absent `isEqual`), and strict rejection cases including `isEqual: false`, non-boolean `isEqual`, unexpected matcher keys, regex matchers, duplicate/missing/extra/broadened matchers, malformed objects, foreign metadata, expired states, and to ensure `status` prints and `clear` deletes only exact owned IDs. 

### Testing

- `python3 -m pytest -q tests/test_observability_helm.py` — 182 passed. 
- `shellcheck scripts/observability_helm.sh` — OK, and `just observability-render env=staging >/dev/null` — OK (render verified); `git diff --check` and `git diff | ./scripts/scan-secrets.py` — OK; `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` — OK. 
- `pre-commit run --all-files` was attempted but the repository already contains unrelated YAML/flake8 issues and whitespace hooks that modified other files; those automatic unrelated edits were reverted and are out of scope for this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fbc565280832fa43c650c385f38ac)