### PR TITLE
Fix chart-less Helm release verification

### DIFF
--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -105,6 +105,57 @@ class ManifestError(ValueError):
     """A release record is missing or inconsistent."""
 
 
+def helm_status_needs_history(status: object) -> bool:
+    """Return whether status genuinely omits (or nulls) chart metadata."""
+    if not isinstance(status, dict):
+        return False
+    chart = status.get("chart")
+    return chart is None or (isinstance(chart, dict) and chart.get("metadata") is None)
+
+
+def resolve_helm_chart_identity(
+    status: object,
+    history: object,
+    expected_name: str,
+    expected_version: str,
+) -> tuple[str, str, int]:
+    """Resolve an exact chart coordinate, using history only when status omits it."""
+    if not isinstance(status, dict):
+        raise ManifestError("invalid Helm release identity")
+    revision = status.get("version")
+    if type(revision) is not int or revision < 1:
+        raise ManifestError("invalid Helm release identity")
+
+    if not helm_status_needs_history(status):
+        chart = status["chart"]
+        if not isinstance(chart, dict) or not isinstance(chart.get("metadata"), dict):
+            raise ManifestError("invalid Helm release identity")
+        metadata = chart["metadata"]
+        if metadata.get("name") != expected_name or metadata.get("version") != expected_version:
+            raise ManifestError("invalid Helm release identity")
+        return expected_name, expected_version, revision
+
+    if not isinstance(history, list):
+        raise ManifestError("invalid Helm release identity")
+    matches = []
+    for record in history:
+        if not isinstance(record, dict):
+            raise ManifestError("invalid Helm release identity")
+        record_revision = record.get("revision")
+        chart_coordinate = record.get("chart")
+        if (
+            type(record_revision) is not int
+            or record_revision < 1
+            or not isinstance(chart_coordinate, str)
+        ):
+            raise ManifestError("invalid Helm release identity")
+        if record_revision == revision:
+            matches.append(record)
+    if len(matches) != 1 or matches[0]["chart"] != f"{expected_name}-{expected_version}":
+        raise ManifestError("invalid Helm release identity")
+    return expected_name, expected_version, revision
+
+
 def _object(path: Path) -> dict[str, Any]:
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
@@ -1048,7 +1099,34 @@ def main(argv: list[str] | None = None) -> int:
                 "-o",
                 "json",
             ]
-            helm = json.loads(_run(helm_command))
+            history_command = [
+                "helm",
+                "--kubeconfig",
+                args.kubeconfig,
+                "history",
+                args.release,
+                "--namespace",
+                args.namespace,
+                "-o",
+                "json",
+            ]
+
+            def helm_snapshot() -> tuple[dict[str, Any], tuple[str, str, int]]:
+                status = json.loads(_run(helm_command))
+                history = None
+                if helm_status_needs_history(status):
+                    history = json.loads(_run(history_command))
+                identity = resolve_helm_chart_identity(
+                    status, history, "dspace", source["chartVersion"]
+                )
+                if helm_status_needs_history(status):
+                    status = {
+                        **status,
+                        "chart": {"metadata": {"name": identity[0], "version": identity[1]}},
+                    }
+                return status, identity
+
+            helm, helm_binding = helm_snapshot()
             stored_values_result = None
             if source["schemaVersion"] == 2:
                 stored_values = json.loads(
@@ -1085,7 +1163,7 @@ def main(argv: list[str] | None = None) -> int:
                 "json",
             ]
             pods = _settle_release_pods(pod_command)
-            settled_helm = json.loads(_run(helm_command))
+            settled_helm, settled_helm_binding = helm_snapshot()
             workloads = json.loads(
                 _run(
                     [
@@ -1129,10 +1207,11 @@ def main(argv: list[str] | None = None) -> int:
                 args.namespace,
                 args.reservation,
             )
-            stable_helm = json.loads(_run(helm_command))
+            stable_helm, stable_helm_binding = helm_snapshot()
 
-            def binding_fields(status: dict[str, Any]) -> tuple[Any, ...]:
-                metadata = status.get("chart", {}).get("metadata", {})
+            def binding_fields(
+                status: dict[str, Any], identity: tuple[str, str, int]
+            ) -> tuple[Any, ...]:
                 info = status.get("info", {})
                 return (
                     status.get("name"),
@@ -1140,13 +1219,15 @@ def main(argv: list[str] | None = None) -> int:
                     info.get("status"),
                     status.get("version"),
                     info.get("description"),
-                    metadata.get("name"),
-                    metadata.get("version"),
+                    identity[0],
+                    identity[1],
                 )
 
-            if binding_fields(settled_helm) != binding_fields(helm) or binding_fields(
-                stable_helm
-            ) != binding_fields(helm):
+            if binding_fields(settled_helm, settled_helm_binding) != binding_fields(
+                helm, helm_binding
+            ) or binding_fields(stable_helm, stable_helm_binding) != binding_fields(
+                helm, helm_binding
+            ):
                 raise ManifestError("Helm release changed during evidence collection")
             _write_new(args.output, result)
             sidecar.unlink()

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -569,13 +569,27 @@ def helm_identity(
                 ]
             )
         )
-        chart = status["chart"]["metadata"]
-        name = chart["name"]
-        version = chart["version"]
-        revision = status["version"]
-    except (json.JSONDecodeError, KeyError, TypeError):
-        fail(validation_category)
-    if name != "dspace" or version != chart_version or type(revision) is not int or revision < 1:
+        history = None
+        if release_manifest.helm_status_needs_history(status):
+            history = json.loads(
+                command(
+                    [
+                        "helm",
+                        "--kubeconfig",
+                        args.kubeconfig,
+                        "history",
+                        args.release,
+                        "--namespace",
+                        args.namespace,
+                        "-o",
+                        "json",
+                    ]
+                )
+            )
+        name, version, revision = release_manifest.resolve_helm_chart_identity(
+            status, history, "dspace", chart_version
+        )
+    except (json.JSONDecodeError, release_manifest.ManifestError):
         fail(validation_category)
     if (
         enforce_expected_revision

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -162,6 +162,7 @@ def _verify_setup(
             ],
         )
     )
+    helm_histories = iter(override.get("helm_histories", []))
     direct_builds = override.get("direct_builds", {})
     direct_html = override.get("direct_html", {})
     public_build = override.get("public_build", build())
@@ -177,6 +178,8 @@ def _verify_setup(
 
     def command(argv: list[str]) -> str:
         if argv[0] == "helm":
+            if "history" in argv:
+                return json.dumps(next(helm_histories))
             return json.dumps(next(helm_statuses))
         if "pods" in argv:
             return json.dumps({"items": pods})
@@ -442,7 +445,9 @@ def test_modern_identity_failure_never_requests_legacy_surface(
         b"x" * (1024 * 1024 + 1),
         b"\xff" + SENTINEL.encode(),
         b"[" * 2000 + SENTINEL.encode() + b"]" * 2000,
-        json.dumps({"gitSha": "wrong", "generatedAt": "2026-08-01T12:00:00Z", "source": "x"}).encode(),
+        json.dumps(
+            {"gitSha": "wrong", "generatedAt": "2026-08-01T12:00:00Z", "source": "x"}
+        ).encode(),
         json.dumps({"gitSha": RECOVERY_SHA, "generatedAt": "", "source": "x"}).encode(),
         json.dumps({"gitSha": RECOVERY_SHA, "generatedAt": "not-a-date", "source": "x"}).encode(),
         json.dumps(
@@ -452,7 +457,9 @@ def test_modern_identity_failure_never_requests_legacy_surface(
                 "source": SENTINEL,
             }
         ).encode(),
-        json.dumps({"gitSha": RECOVERY_SHA, "generatedAt": "2026-08-01T12:00:00Z", "source": ""}).encode(),
+        json.dumps(
+            {"gitSha": RECOVERY_SHA, "generatedAt": "2026-08-01T12:00:00Z", "source": ""}
+        ).encode(),
         json.dumps(
             {
                 "gitSha": RECOVERY_SHA,
@@ -775,6 +782,24 @@ def test_verify_detects_helm_change_during_chat(
     assert str(raised.value) == "concurrent Helm change"
 
 
+def test_verify_detects_helm_change_during_chat_with_history_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    args, _ = _verify_setup(
+        monkeypatch,
+        tmp_path,
+        overrides={
+            "helm_statuses": [{"version": 7}, {"version": 8}],
+            "helm_histories": [
+                [{"revision": 7, "chart": "dspace-3.1.0"}],
+                [{"revision": 8, "chart": "dspace-3.1.0"}],
+            ],
+        },
+    )
+    with pytest.raises(verifier.VerificationError, match="concurrent Helm change"):
+        verifier.verify(args)
+
+
 def test_missing_or_nonexecutable_runner_fails_safely(tmp_path: Path) -> None:
     args = Namespace(
         environment="staging",
@@ -884,6 +909,88 @@ def test_helm_identity_accepts_real_status_schema(monkeypatch: pytest.MonkeyPatc
     )
     args = Namespace(kubeconfig="k", release="dspace", namespace="dspace", expected_helm_revision=7)
     assert verifier.helm_identity(args, "3.1.0") == ("dspace", "3.1.0", 7)
+
+
+def test_helm_identity_accepts_chartless_status_with_exact_current_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status = {"name": "dspace", "namespace": "dspace", "version": 26, "info": {}}
+    history = [
+        {
+            "revision": 26,
+            "chart": "dspace-3.0.2",
+            "app_version": "3.0.1",
+            "status": "deployed",
+            "description": "sugarkube-release-manifest:reservation",
+        }
+    ]
+    monkeypatch.setattr(
+        verifier,
+        "command",
+        lambda argv: json.dumps(history if "history" in argv else status),
+    )
+    args = Namespace(
+        kubeconfig="k", release="dspace", namespace="dspace", expected_helm_revision=26
+    )
+    assert verifier.helm_identity(args, "3.0.2") == ("dspace", "3.0.2", 26)
+
+
+@pytest.mark.parametrize(
+    "status,history",
+    [
+        ({"version": 26}, []),
+        ({"version": 26}, [{"revision": 25, "chart": "dspace-3.0.2"}]),
+        (
+            {"version": 26},
+            [
+                {"revision": 26, "chart": "dspace-3.0.2"},
+                {"revision": 26, "chart": "dspace-3.0.2"},
+            ],
+        ),
+        ({"version": 26}, [{"revision": 26, "chart": "dspace-3.0.1"}]),
+        ({"version": True}, [{"revision": 1, "chart": "dspace-3.0.2"}]),
+        ({"version": 26}, {"revision": 26, "chart": "dspace-3.0.2"}),
+        ({"version": 26}, [{"revision": "26", "chart": "dspace-3.0.2"}]),
+        ({"version": 26}, [{"revision": 26, "chart": None}]),
+        (
+            {"version": 26, "chart": {"metadata": []}},
+            [{"revision": 26, "chart": "dspace-3.0.2"}],
+        ),
+    ],
+)
+def test_helm_identity_chartless_fallback_failures_are_closed_and_redacted(
+    monkeypatch: pytest.MonkeyPatch, status: object, history: object
+) -> None:
+    history_with_secret = history
+    if isinstance(history, list):
+        history_with_secret = [*history, {"revision": 99, "chart": SENTINEL}]
+    monkeypatch.setattr(
+        verifier,
+        "command",
+        lambda argv: json.dumps(history_with_secret if "history" in argv else status),
+    )
+    args = Namespace(kubeconfig="k", release="dspace", namespace="dspace")
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.helm_identity(args, "3.0.2")
+    assert str(raised.value) == "cluster identity"
+    assert SENTINEL not in str(raised.value)
+
+
+def test_helm_identity_chartless_expected_revision_drift_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        verifier,
+        "command",
+        lambda argv: json.dumps(
+            [{"revision": 26, "chart": "dspace-3.0.2"}] if "history" in argv else {"version": 26}
+        ),
+    )
+    args = Namespace(
+        kubeconfig="k", release="dspace", namespace="dspace", expected_helm_revision=25
+    )
+    with pytest.raises(verifier.VerificationError, match="staging drift"):
+        verifier.helm_identity(args, "3.0.2")
 
 
 def test_command_timeout_is_bounded_and_redacted(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -1007,8 +1007,9 @@ def test_post_reservation_failure_preserves_ownership(tmp_path: Path, monkeypatc
 
 
 @pytest.mark.parametrize("schema_version", [1, 2])
+@pytest.mark.parametrize("chart_in_status", [True, False])
 def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
-    tmp_path: Path, monkeypatch, schema_version: int
+    tmp_path: Path, monkeypatch, schema_version: int, chart_in_status: bool
 ) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
@@ -1045,6 +1046,9 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
             events.append("cluster-identity")
             return "staging\n"
         if command[0] == "helm":
+            if "history" in command:
+                events.append("helm-history")
+                return json.dumps([{"revision": 17, "chart": "dspace-3.2.0"}])
             if "get" in command:
                 events.append("helm-stored-values")
                 return json.dumps(
@@ -1057,14 +1061,15 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
                     }
                 )
             events.append("helm-status")
-            return json.dumps(
-                helm_status(
-                    info={
-                        "status": "deployed",
-                        "description": f"sugarkube-release-manifest:{owner}",
-                    }
-                )
+            status = helm_status(
+                info={
+                    "status": "deployed",
+                    "description": f"sugarkube-release-manifest:{owner}",
+                }
             )
+            if not chart_in_status:
+                status.pop("chart")
+            return json.dumps(status)
         resource = command[command.index("get") + 1]
         if resource == "pods":
             events.append("pod-discovery")
@@ -1122,16 +1127,21 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
         "cluster-identity",
         "helm-status",
     ]
+    if not chart_in_status:
+        expected_events.append("helm-history")
     if schema_version == 2:
         expected_events.append("helm-stored-values")
     expected_events += [
         "pod-discovery",
         "pod-discovery",
         "helm-status",
-        "workload-discovery",
-        "helm-status",
-        "atomic-final-write",
     ]
+    if not chart_in_status:
+        expected_events.append("helm-history")
+    expected_events += ["workload-discovery", "helm-status"]
+    if not chart_in_status:
+        expected_events.append("helm-history")
+    expected_events.append("atomic-final-write")
     assert events == expected_events
     final = manifest.validate(json.loads(output.read_text(encoding="utf-8")), True)
     assert final["helmRevision"] == 17
@@ -1201,8 +1211,9 @@ def test_finalize_cli_settling_failure_preserves_reservation(
 
 
 @pytest.mark.parametrize("changed_field", ["version", "description"])
+@pytest.mark.parametrize("chart_in_status", [True, False])
 def test_finalize_cli_rejects_changed_helm_binding_and_preserves_reservation(
-    tmp_path: Path, monkeypatch, changed_field: str
+    tmp_path: Path, monkeypatch, changed_field: str, chart_in_status: bool
 ) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
@@ -1210,6 +1221,7 @@ def test_finalize_cli_rejects_changed_helm_binding_and_preserves_reservation(
     owner = manifest.reserve(output, candidate(), "staging", "dspace", "dspace")
     description = f"sugarkube-release-manifest:{owner}"
     status_reads = 0
+    current_revision = 17
 
     oci_results = manifest.preflight(
         candidate(), manifest.IMAGE_REF, manifest.CHART_REF, "oras", runner=oras_runner()
@@ -1221,10 +1233,12 @@ def test_finalize_cli_rejects_changed_helm_binding_and_preserves_reservation(
     )
 
     def run(command):
-        nonlocal status_reads
+        nonlocal status_reads, current_revision
         if "cluster_identity.py" in " ".join(command):
             return "staging\n"
         if command[0] == "helm":
+            if "history" in command:
+                return json.dumps([{"revision": current_revision, "chart": "dspace-3.2.0"}])
             status_reads += 1
             info = {"status": "deployed", "description": description}
             status = helm_status(info=info)
@@ -1233,6 +1247,9 @@ def test_finalize_cli_rejects_changed_helm_binding_and_preserves_reservation(
                     status["version"] = 18
                 else:
                     status["info"]["description"] = "another invocation"
+            current_revision = status["version"]
+            if not chart_in_status:
+                status.pop("chart")
             return json.dumps(status)
         resource = command[command.index("get") + 1]
         return json.dumps({"items": [pod("dspace-a")]} if resource == "pods" else workloads())


### PR DESCRIPTION
### Motivation
- Some `helm status --output json` implementations omit or null `chart.metadata`, which causes runtime verification and evidence finalization to fail for otherwise valid releases.
- The goal is a minimal, fail-closed compatibility fix so both the runtime verifier and the finalizer can resolve chart identity from `helm history --output json` only when status chart metadata is genuinely absent.

### Description
- Add a small shared resolver with `helm_status_needs_history(status)` and `resolve_helm_chart_identity(status, history, expected_name, expected_version)` that preserves the primary `status.chart.metadata` path and falls back to history only when the status omits or nulls chart metadata.
- The fallback strictly validates: status `version` must be a positive integer, `history` must be a list of well-formed records, exactly one `history` record must match the status revision, and the record's `chart` string must equal the exact expected coordinate (`<name>-<version>`); all failures raise bounded errors and do not leak raw command output.
- Wire the resolver into both `dspace_runtime_verifier.py::helm_identity()` and all evidence-finalization snapshots/binding comparisons in `dspace_release_manifest.py`, and ensure resolved identity is used in the settled/stable binding checks so concurrent changes and revision drift remain detected.
- Add and update targeted tests in `tests/test_dspace_runtime_verifier.py` and `tests/test_release_manifest.py` covering the chart-less status + exact-history success case, malformed/ambiguous/stale/wrong history, boolean/invalid revisions, expected-revision drift, concurrent changes under fallback, reservation preservation on failures, and the existing status-with-chart path.
- Files changed: `scripts/dspace_runtime_verifier.py`, `scripts/dspace_release_manifest.py`, `tests/test_dspace_runtime_verifier.py`, `tests/test_release_manifest.py`.

### Testing
- Ran the targeted verifier unit suite with `python3 -m pytest -q tests/test_dspace_runtime_verifier.py` and it passed `125 passed`.
- Ran the finalization unit suite with `python3 -m pytest -q tests/test_release_manifest.py` and it passed `198 passed`.
- Ran formatting and import checks with `python3 -m black --check ...` and `python3 -m isort --check-only ...` as part of the verification flow and adjusted formatting where required (reformatting applied); `black`/`isort` checks passed after formatting.
- Verified repository hygiene with `git diff --cached | ./scripts/scan-secrets.py` (no secrets leaked) and ran `git diff --check` (no whitespace errors reported).
- Environment notes: `pre-commit run --all-files` was not available because `pre-commit` is not installed in the runner, and `bash scripts/checks.sh` could not complete because its `just` installer failed to download upstream (HTTP 404); these are environment limitations and did not block the focused test suites above.

Fallback contract (precise):
- Use `status.chart.metadata` when present and well-formed; otherwise:
  - Require `status.version` to be an integer >= 1 (reject booleans).
  - Require `history` to be a `list` of dict records with integer `revision` and string `chart` fields.
  - Find exactly one `history` record with `revision == status.version`.
  - Require that the matching record's `chart` equals the exact expected coordinate `"<name>-<version>"` (no hyphen-splitting heuristics).
  - Fail closed for missing, duplicate, malformed, stale, wrong-revision, or wrong-chart records and redact any sensitive command output in errors.

If you want, I can open the PR with this title/body or adjust wording/detail for reviewers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fc7099e80832fa544141cf6bf3af8)