### PR TITLE
Fix DSPACE Helm identity fallback for chart-less status

### DIFF
--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -601,6 +601,61 @@ def chart_coordinate(value: dict[str, Any]) -> str:
     return f"oci://{CHART_REF}@{value['chartDigest']}"
 
 
+def helm_status_needs_history(status: object) -> bool:
+    """Return whether Helm omitted (or nullified) status chart metadata."""
+    if not isinstance(status, dict):
+        return False
+    chart = status.get("chart")
+    return chart is None or (isinstance(chart, dict) and chart.get("metadata") is None)
+
+
+def resolve_helm_chart_identity(
+    status: object,
+    history: object,
+    expected_name: str,
+    expected_version: str,
+) -> tuple[str, str, int]:
+    """Resolve an exact chart identity, using history only when status omitted it."""
+    if not isinstance(status, dict):
+        raise ManifestError("invalid Helm release identity")
+    revision = status.get("version")
+    if type(revision) is not int or revision < 1:
+        raise ManifestError("invalid Helm release identity")
+
+    chart = status.get("chart")
+    if chart is not None and not isinstance(chart, dict):
+        raise ManifestError("invalid Helm release identity")
+    metadata = chart.get("metadata") if isinstance(chart, dict) else None
+    if metadata is not None:
+        if not isinstance(metadata, dict):
+            raise ManifestError("invalid Helm release identity")
+        if metadata.get("name") != expected_name or metadata.get("version") != expected_version:
+            raise ManifestError("installed Helm chart identity or version does not match approval")
+        return expected_name, expected_version, revision
+
+    if not isinstance(history, list):
+        raise ManifestError("invalid Helm chart identity history")
+    matches = []
+    for record in history:
+        if not isinstance(record, dict):
+            raise ManifestError("invalid Helm chart identity history")
+        record_revision = record.get("revision")
+        record_chart = record.get("chart")
+        if (
+            type(record_revision) is not int
+            or record_revision < 1
+            or not isinstance(record_chart, str)
+        ):
+            raise ManifestError("invalid Helm chart identity history")
+        if record_revision == revision:
+            matches.append(record)
+    if len(matches) != 1:
+        raise ManifestError("Helm release history does not uniquely match the current revision")
+    if matches[0]["chart"] != f"{expected_name}-{expected_version}":
+        raise ManifestError("installed Helm chart identity or version does not match approval")
+    return expected_name, expected_version, revision
+
+
 def _image_id_digest(image_id: str) -> str:
     match = re.search(r"sha256:[0-9a-f]{64}$", image_id)
     if not match:
@@ -635,6 +690,15 @@ def _settle_release_pods(
         sleeper(POD_SETTLE_INTERVAL_SECONDS)
 
 
+def _helm_snapshot(
+    status_command: list[str], history_command: list[str]
+) -> tuple[dict[str, Any], object]:
+    """Read a Helm status and its history only when chart metadata is omitted."""
+    status = json.loads(_run(status_command))
+    history = json.loads(_run(history_command)) if helm_status_needs_history(status) else None
+    return status, history
+
+
 def finalize(
     value: dict[str, Any],
     helm_json: dict[str, Any],
@@ -652,6 +716,7 @@ def finalize(
     expected_image_coordinate: str | None = None,
     runtime_verification: dict[str, Any] | None = None,
     helm_stored_values_result: dict[str, Any] | None = None,
+    helm_history_json: object = None,
 ) -> dict[str, Any]:
     validate(value, False)
     selected = {
@@ -672,10 +737,9 @@ def finalize(
         raise ManifestError("Helm release status must be deployed")
     if helm_info.get("description") != invocation_description:
         raise ManifestError("Helm release description does not match this invocation")
-    revision = helm_json.get("version")
-    chart_metadata = helm_json.get("chart", {}).get("metadata", {})
-    if chart_metadata.get("name") != "dspace" or chart_metadata.get("version") != chart_version:
-        raise ManifestError("installed Helm chart identity or version does not match approval")
+    _, _, revision = resolve_helm_chart_identity(
+        helm_json, helm_history_json, "dspace", chart_version
+    )
 
     selector_labels = {
         "app.kubernetes.io/name": "dspace",
@@ -1048,7 +1112,18 @@ def main(argv: list[str] | None = None) -> int:
                 "-o",
                 "json",
             ]
-            helm = json.loads(_run(helm_command))
+            history_command = [
+                "helm",
+                "--kubeconfig",
+                args.kubeconfig,
+                "history",
+                args.release,
+                "--namespace",
+                args.namespace,
+                "-o",
+                "json",
+            ]
+            helm, helm_history = _helm_snapshot(helm_command, history_command)
             stored_values_result = None
             if source["schemaVersion"] == 2:
                 stored_values = json.loads(
@@ -1085,7 +1160,7 @@ def main(argv: list[str] | None = None) -> int:
                 "json",
             ]
             pods = _settle_release_pods(pod_command)
-            settled_helm = json.loads(_run(helm_command))
+            settled_helm, settled_history = _helm_snapshot(helm_command, history_command)
             workloads = json.loads(
                 _run(
                     [
@@ -1120,6 +1195,7 @@ def main(argv: list[str] | None = None) -> int:
                     _object(args.runtime_verification) if args.runtime_verification else None
                 ),
                 helm_stored_values_result=stored_values_result,
+                helm_history_json=helm_history,
             )
             sidecar = verify_reservation(
                 args.output,
@@ -1129,24 +1205,28 @@ def main(argv: list[str] | None = None) -> int:
                 args.namespace,
                 args.reservation,
             )
-            stable_helm = json.loads(_run(helm_command))
+            stable_helm, stable_history = _helm_snapshot(helm_command, history_command)
 
-            def binding_fields(status: dict[str, Any]) -> tuple[Any, ...]:
-                metadata = status.get("chart", {}).get("metadata", {})
+            def binding_fields(status: dict[str, Any], history: object) -> tuple[Any, ...]:
                 info = status.get("info", {})
+                name, version, revision = resolve_helm_chart_identity(
+                    status, history, "dspace", args.chart_version
+                )
                 return (
                     status.get("name"),
                     status.get("namespace"),
                     info.get("status"),
-                    status.get("version"),
+                    revision,
                     info.get("description"),
-                    metadata.get("name"),
-                    metadata.get("version"),
+                    name,
+                    version,
                 )
 
-            if binding_fields(settled_helm) != binding_fields(helm) or binding_fields(
-                stable_helm
-            ) != binding_fields(helm):
+            initial_binding = binding_fields(helm, helm_history)
+            if (
+                binding_fields(settled_helm, settled_history) != initial_binding
+                or binding_fields(stable_helm, stable_history) != initial_binding
+            ):
                 raise ManifestError("Helm release changed during evidence collection")
             _write_new(args.output, result)
             sidecar.unlink()

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -569,13 +569,27 @@ def helm_identity(
                 ]
             )
         )
-        chart = status["chart"]["metadata"]
-        name = chart["name"]
-        version = chart["version"]
-        revision = status["version"]
-    except (json.JSONDecodeError, KeyError, TypeError):
-        fail(validation_category)
-    if name != "dspace" or version != chart_version or type(revision) is not int or revision < 1:
+        history = None
+        if release_manifest.helm_status_needs_history(status):
+            history = json.loads(
+                command(
+                    [
+                        "helm",
+                        "--kubeconfig",
+                        args.kubeconfig,
+                        "history",
+                        args.release,
+                        "--namespace",
+                        args.namespace,
+                        "-o",
+                        "json",
+                    ]
+                )
+            )
+        name, version, revision = release_manifest.resolve_helm_chart_identity(
+            status, history, "dspace", chart_version
+        )
+    except (json.JSONDecodeError, release_manifest.ManifestError):
         fail(validation_category)
     if (
         enforce_expected_revision

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -162,6 +162,7 @@ def _verify_setup(
             ],
         )
     )
+    helm_histories = iter(override.get("helm_histories", []))
     direct_builds = override.get("direct_builds", {})
     direct_html = override.get("direct_html", {})
     public_build = override.get("public_build", build())
@@ -177,6 +178,8 @@ def _verify_setup(
 
     def command(argv: list[str]) -> str:
         if argv[0] == "helm":
+            if "history" in argv:
+                return json.dumps(next(helm_histories))
             return json.dumps(next(helm_statuses))
         if "pods" in argv:
             return json.dumps({"items": pods})
@@ -775,6 +778,24 @@ def test_verify_detects_helm_change_during_chat(
     assert str(raised.value) == "concurrent Helm change"
 
 
+def test_verify_detects_concurrent_helm_change_with_history_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    args, _ = _verify_setup(
+        monkeypatch,
+        tmp_path,
+        overrides={
+            "helm_statuses": [{"version": 7}, {"version": 8}],
+            "helm_histories": [
+                [{"revision": 7, "chart": "dspace-3.1.0"}],
+                [{"revision": 8, "chart": "dspace-3.1.0"}],
+            ],
+        },
+    )
+    with pytest.raises(verifier.VerificationError, match="concurrent Helm change"):
+        verifier.verify(args)
+
+
 def test_missing_or_nonexecutable_runner_fails_safely(tmp_path: Path) -> None:
     args = Namespace(
         environment="staging",
@@ -884,6 +905,72 @@ def test_helm_identity_accepts_real_status_schema(monkeypatch: pytest.MonkeyPatc
     )
     args = Namespace(kubeconfig="k", release="dspace", namespace="dspace", expected_helm_revision=7)
     assert verifier.helm_identity(args, "3.1.0") == ("dspace", "3.1.0", 7)
+
+
+def test_helm_identity_accepts_chartless_status_with_exact_current_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status = {
+        "config": {},
+        "info": {},
+        "manifest": "",
+        "name": "dspace",
+        "namespace": "dspace",
+        "version": 26,
+    }
+    history = [
+        {
+            "revision": 26,
+            "chart": "dspace-3.0.2",
+            "app_version": "3.0.1",
+            "status": "deployed",
+            "description": "sugarkube-release-manifest:reservation",
+        }
+    ]
+    outputs = iter((status, history))
+    monkeypatch.setattr(verifier, "command", lambda argv: json.dumps(next(outputs)))
+    args = Namespace(
+        kubeconfig="k", release="dspace", namespace="dspace", expected_helm_revision=26
+    )
+    assert verifier.helm_identity(args, "3.0.2") == ("dspace", "3.0.2", 26)
+
+
+@pytest.mark.parametrize(
+    "history",
+    [
+        [],
+        [{"revision": 25, "chart": "dspace-3.0.2"}],
+        [{"revision": 26, "chart": "dspace-3.0.1"}],
+        [{"revision": 26, "chart": "dspace-3.0.2"}] * 2,
+        {"revision": 26, "chart": "dspace-3.0.2"},
+        [{"revision": True, "chart": "dspace-3.0.2"}],
+        [{"revision": 26, "chart": {"secret": SENTINEL}}],
+    ],
+)
+def test_helm_identity_chartless_history_fails_closed_and_redacts(
+    monkeypatch: pytest.MonkeyPatch, history: object
+) -> None:
+    outputs = iter(({"version": 26}, history))
+    monkeypatch.setattr(verifier, "command", lambda argv: json.dumps(next(outputs)))
+    args = Namespace(
+        kubeconfig="k", release="dspace", namespace="dspace", expected_helm_revision=26
+    )
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.helm_identity(args, "3.0.2")
+    assert str(raised.value) == "cluster identity"
+    assert SENTINEL not in str(raised.value)
+
+
+def test_helm_identity_chartless_expected_revision_drift_is_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    outputs = iter(({"version": 26}, [{"revision": 26, "chart": "dspace-3.0.2"}]))
+    monkeypatch.setattr(verifier, "command", lambda argv: json.dumps(next(outputs)))
+    args = Namespace(
+        kubeconfig="k", release="dspace", namespace="dspace", expected_helm_revision=25
+    )
+    with pytest.raises(verifier.VerificationError, match="staging drift"):
+        verifier.helm_identity(args, "3.0.2")
 
 
 def test_command_timeout_is_bounded_and_redacted(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -95,6 +95,26 @@ def test_schema_v2_split_provenance_is_canonical_and_preserved() -> None:
     assert manifest.validate(value) == value
 
 
+@pytest.mark.parametrize("revision", [None, 0, -1, True, "26"])
+def test_chartless_helm_identity_rejects_malformed_status_revision(revision: object) -> None:
+    with pytest.raises(manifest.ManifestError, match="invalid Helm release identity"):
+        manifest.resolve_helm_chart_identity(
+            {"version": revision}, [{"revision": 26, "chart": "dspace-3.0.2"}], "dspace", "3.0.2"
+        )
+
+
+def test_status_chart_metadata_remains_the_primary_helm_identity_path() -> None:
+    status = {
+        "version": 26,
+        "chart": {"metadata": {"name": "dspace", "version": "3.0.2"}},
+    }
+    assert manifest.resolve_helm_chart_identity(status, {"malformed": True}, "dspace", "3.0.2") == (
+        "dspace",
+        "3.0.2",
+        26,
+    )
+
+
 def test_invalid_upstream_app_fails_closed() -> None:
     value = upstream()
     value["app"] = "another-app"
@@ -1007,8 +1027,9 @@ def test_post_reservation_failure_preserves_ownership(tmp_path: Path, monkeypatc
 
 
 @pytest.mark.parametrize("schema_version", [1, 2])
+@pytest.mark.parametrize("chartless_status", [False, True])
 def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
-    tmp_path: Path, monkeypatch, schema_version: int
+    tmp_path: Path, monkeypatch, schema_version: int, chartless_status: bool
 ) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
@@ -1056,15 +1077,29 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
                         }
                     }
                 )
-            events.append("helm-status")
-            return json.dumps(
-                helm_status(
-                    info={
-                        "status": "deployed",
-                        "description": f"sugarkube-release-manifest:{owner}",
-                    }
+            if "history" in command:
+                events.append("helm-history")
+                return json.dumps(
+                    [
+                        {
+                            "revision": 17,
+                            "chart": "dspace-3.2.0",
+                            "app_version": "3.2.0",
+                            "status": "deployed",
+                            "description": f"sugarkube-release-manifest:{owner}",
+                        }
+                    ]
                 )
+            events.append("helm-status")
+            status = helm_status(
+                info={
+                    "status": "deployed",
+                    "description": f"sugarkube-release-manifest:{owner}",
+                }
             )
+            if chartless_status:
+                status.pop("chart")
+            return json.dumps(status)
         resource = command[command.index("get") + 1]
         if resource == "pods":
             events.append("pod-discovery")
@@ -1122,16 +1157,21 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
         "cluster-identity",
         "helm-status",
     ]
+    if chartless_status:
+        expected_events.append("helm-history")
     if schema_version == 2:
         expected_events.append("helm-stored-values")
     expected_events += [
         "pod-discovery",
         "pod-discovery",
         "helm-status",
-        "workload-discovery",
-        "helm-status",
-        "atomic-final-write",
     ]
+    if chartless_status:
+        expected_events.append("helm-history")
+    expected_events += ["workload-discovery", "helm-status"]
+    if chartless_status:
+        expected_events.append("helm-history")
+    expected_events.append("atomic-final-write")
     assert events == expected_events
     final = manifest.validate(json.loads(output.read_text(encoding="utf-8")), True)
     assert final["helmRevision"] == 17
@@ -1201,8 +1241,9 @@ def test_finalize_cli_settling_failure_preserves_reservation(
 
 
 @pytest.mark.parametrize("changed_field", ["version", "description"])
+@pytest.mark.parametrize("chartless_status", [False, True])
 def test_finalize_cli_rejects_changed_helm_binding_and_preserves_reservation(
-    tmp_path: Path, monkeypatch, changed_field: str
+    tmp_path: Path, monkeypatch, changed_field: str, chartless_status: bool
 ) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
@@ -1225,6 +1266,17 @@ def test_finalize_cli_rejects_changed_helm_binding_and_preserves_reservation(
         if "cluster_identity.py" in " ".join(command):
             return "staging\n"
         if command[0] == "helm":
+            if "history" in command:
+                return json.dumps(
+                    [
+                        {
+                            "revision": (
+                                18 if status_reads == 2 and changed_field == "version" else 17
+                            ),
+                            "chart": "dspace-3.2.0",
+                        }
+                    ]
+                )
             status_reads += 1
             info = {"status": "deployed", "description": description}
             status = helm_status(info=info)
@@ -1233,6 +1285,8 @@ def test_finalize_cli_rejects_changed_helm_binding_and_preserves_reservation(
                     status["version"] = 18
                 else:
                     status["info"]["description"] = "another invocation"
+            if chartless_status:
+                status.pop("chart")
             return json.dumps(status)
         resource = command[command.index("get") + 1]
         return json.dumps({"items": [pod("dspace-a")]} if resource == "pods" else workloads())


### PR DESCRIPTION
### Motivation

- Some Helm implementations emit a `helm status --output json` that omits or nulls `chart.metadata`, which previously caused runtime verification and evidence finalization to fail even when history contained the approved chart coordinate.
- The verifier required `status["chart"]["metadata"]` and the finalizer compared chart metadata directly, so a minimal compatibility path that is fail-closed was needed to recover identity without weakening guarantees.
- The change must preserve revision, reservation, immutable-coordinate, and concurrent-change protections and apply the same resolution everywhere the chart identity matters.

### Description

- Added a small shared resolver to `scripts/dspace_release_manifest.py`: `helm_status_needs_history(status)`, `resolve_helm_chart_identity(status, history, expected_name, expected_version)`, and `_helm_snapshot(...)`, and used them to drive finalization; these implement the strict fallback contract that treats `status.chart.metadata` as primary and uses history only when absent. (files changed: `scripts/dspace_release_manifest.py`)
- Updated runtime verification to call the shared resolver in `scripts/dspace_runtime_verifier.py::helm_identity()` and to invoke `helm history -o json` only when needed, preserving bounded error categories and expected-revision drift semantics. (file changed: `scripts/dspace_runtime_verifier.py`)
- Finalization now snapshots both status and history when necessary, passes the history into `finalize()`, and applies the same identity normalization to initial, settled, and stable Helm snapshots used for binding comparisons. (file changed: `scripts/dspace_release_manifest.py`)
- Added and updated regression tests that cover: the observed chart-less status + matching history shape, the original metadata path, malformed or ambiguous history entries, stale/older/wrong-chart history, expected-revision drift, concurrent Helm-change detection under fallback, atomic finalization with reservation preservation, and redaction of command output. (files changed: `tests/test_dspace_runtime_verifier.py`, `tests/test_release_manifest.py`)
- Files changed: `scripts/dspace_release_manifest.py`, `scripts/dspace_runtime_verifier.py`, `tests/test_dspace_runtime_verifier.py`, `tests/test_release_manifest.py`.
- Exact fallback contract implemented: prefer `status.chart.metadata` when present; when absent or null require `status.version` to be a positive non-boolean integer; require `history` to be a structurally-valid list and find exactly one record with `revision == status.version`; require that the matching history record's `chart` string equals the exact coordinate `<name>-<version>` (no hyphen-splitting heuristics); fail-closed for missing/duplicate/malformed/stale/wrong/chart records; do not fall back to last/older history entries; do not leak raw command output in errors.

### Testing

- Ran `python3 -m pytest -q tests/test_dspace_runtime_verifier.py` and it passed (123 tests passed).
- Ran `python3 -m pytest -q tests/test_release_manifest.py` and it passed (204 tests passed).
- Ran the combined test runs and full `pytest` and all modified and existing tests passed (total 327 tests passed across the suites exercised).
- Formatting/lint: `black` was run and reformatted test/implementation blocks as needed; `pre-commit run --all-files` was not available in the environment and therefore not executed; secret scans (`./scripts/scan-secrets.py`) and `git diff --check` were run with no issues.

All automated tests added/updated for the fallback contract passed; the change keeps the primary metadata path intact and fails closed for any ambiguous or malformed history input.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fc72511b4832fac6d81ebce7ba789)