### PR TITLE
Support chart-less Helm status verification

### DIFF
--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -105,6 +105,63 @@ class ManifestError(ValueError):
     """A release record is missing or inconsistent."""
 
 
+def helm_status_needs_history(status: object) -> bool:
+    """Validate the status revision and report whether chart metadata is absent."""
+    if not isinstance(status, dict):
+        raise ManifestError("invalid Helm release identity")
+    revision = status.get("version")
+    if type(revision) is not int or revision < 1:
+        raise ManifestError("invalid Helm release identity")
+    chart = status.get("chart")
+    metadata_missing = "chart" not in status or chart is None
+    if isinstance(chart, dict):
+        metadata_missing = "metadata" not in chart or chart.get("metadata") is None
+    elif not metadata_missing:
+        raise ManifestError("invalid Helm release identity")
+    return metadata_missing
+
+
+def resolve_helm_identity(
+    status: object,
+    history: object,
+    expected_name: str,
+    expected_version: str,
+) -> tuple[str, str, int]:
+    """Resolve an exact chart identity, using history only when status omits it."""
+    metadata_missing = helm_status_needs_history(status)
+    assert isinstance(status, dict)
+    revision = status["version"]
+    if not metadata_missing:
+        metadata = status["chart"]["metadata"]
+        if not isinstance(metadata, dict):
+            raise ManifestError("invalid Helm release identity")
+        name, version = metadata.get("name"), metadata.get("version")
+        if name != expected_name or version != expected_version:
+            raise ManifestError("invalid Helm release identity")
+        return name, version, revision
+
+    if not isinstance(history, list):
+        raise ManifestError("invalid Helm release identity")
+    matches = []
+    for record in history:
+        if not isinstance(record, dict):
+            raise ManifestError("invalid Helm release identity")
+        record_revision = record.get("revision")
+        coordinate = record.get("chart")
+        if (
+            type(record_revision) is not int
+            or record_revision < 1
+            or not isinstance(coordinate, str)
+            or not coordinate
+        ):
+            raise ManifestError("invalid Helm release identity")
+        if record_revision == revision:
+            matches.append(record)
+    if len(matches) != 1 or matches[0]["chart"] != f"{expected_name}-{expected_version}":
+        raise ManifestError("invalid Helm release identity")
+    return expected_name, expected_version, revision
+
+
 def _object(path: Path) -> dict[str, Any]:
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
@@ -652,6 +709,7 @@ def finalize(
     expected_image_coordinate: str | None = None,
     runtime_verification: dict[str, Any] | None = None,
     helm_stored_values_result: dict[str, Any] | None = None,
+    helm_history: object = None,
 ) -> dict[str, Any]:
     validate(value, False)
     selected = {
@@ -672,10 +730,12 @@ def finalize(
         raise ManifestError("Helm release status must be deployed")
     if helm_info.get("description") != invocation_description:
         raise ManifestError("Helm release description does not match this invocation")
-    revision = helm_json.get("version")
-    chart_metadata = helm_json.get("chart", {}).get("metadata", {})
-    if chart_metadata.get("name") != "dspace" or chart_metadata.get("version") != chart_version:
-        raise ManifestError("installed Helm chart identity or version does not match approval")
+    try:
+        _, _, revision = resolve_helm_identity(helm_json, helm_history, "dspace", chart_version)
+    except ManifestError as exc:
+        raise ManifestError(
+            "installed Helm chart identity or version does not match approval"
+        ) from exc
 
     selector_labels = {
         "app.kubernetes.io/name": "dspace",
@@ -1048,7 +1108,47 @@ def main(argv: list[str] | None = None) -> int:
                 "-o",
                 "json",
             ]
-            helm = json.loads(_run(helm_command))
+            history_command = [
+                "helm",
+                "--kubeconfig",
+                args.kubeconfig,
+                "history",
+                args.release,
+                "--namespace",
+                args.namespace,
+                "-o",
+                "json",
+            ]
+
+            def helm_snapshot() -> tuple[dict[str, Any], object, tuple[Any, ...]]:
+                try:
+                    status = json.loads(_run(helm_command))
+                except (ManifestError, json.JSONDecodeError) as exc:
+                    raise ManifestError("cannot read Helm release identity") from exc
+                history = None
+                if helm_status_needs_history(status):
+                    try:
+                        history = json.loads(_run(history_command))
+                    except (ManifestError, json.JSONDecodeError) as exc:
+                        raise ManifestError("cannot read Helm release identity") from exc
+                name, version, revision = resolve_helm_identity(
+                    status, history, "dspace", args.chart_version
+                )
+                info = status.get("info", {})
+                if not isinstance(info, dict):
+                    raise ManifestError("invalid Helm release identity")
+                binding = (
+                    status.get("name"),
+                    status.get("namespace"),
+                    info.get("status"),
+                    revision,
+                    info.get("description"),
+                    name,
+                    version,
+                )
+                return status, history, binding
+
+            helm, helm_history, helm_binding = helm_snapshot()
             stored_values_result = None
             if source["schemaVersion"] == 2:
                 stored_values = json.loads(
@@ -1085,7 +1185,7 @@ def main(argv: list[str] | None = None) -> int:
                 "json",
             ]
             pods = _settle_release_pods(pod_command)
-            settled_helm = json.loads(_run(helm_command))
+            _, _, settled_binding = helm_snapshot()
             workloads = json.loads(
                 _run(
                     [
@@ -1120,6 +1220,7 @@ def main(argv: list[str] | None = None) -> int:
                     _object(args.runtime_verification) if args.runtime_verification else None
                 ),
                 helm_stored_values_result=stored_values_result,
+                helm_history=helm_history,
             )
             sidecar = verify_reservation(
                 args.output,
@@ -1129,24 +1230,9 @@ def main(argv: list[str] | None = None) -> int:
                 args.namespace,
                 args.reservation,
             )
-            stable_helm = json.loads(_run(helm_command))
+            _, _, stable_binding = helm_snapshot()
 
-            def binding_fields(status: dict[str, Any]) -> tuple[Any, ...]:
-                metadata = status.get("chart", {}).get("metadata", {})
-                info = status.get("info", {})
-                return (
-                    status.get("name"),
-                    status.get("namespace"),
-                    info.get("status"),
-                    status.get("version"),
-                    info.get("description"),
-                    metadata.get("name"),
-                    metadata.get("version"),
-                )
-
-            if binding_fields(settled_helm) != binding_fields(helm) or binding_fields(
-                stable_helm
-            ) != binding_fields(helm):
+            if settled_binding != helm_binding or stable_binding != helm_binding:
                 raise ManifestError("Helm release changed during evidence collection")
             _write_new(args.output, result)
             sidecar.unlink()

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -569,13 +569,27 @@ def helm_identity(
                 ]
             )
         )
-        chart = status["chart"]["metadata"]
-        name = chart["name"]
-        version = chart["version"]
-        revision = status["version"]
-    except (json.JSONDecodeError, KeyError, TypeError):
-        fail(validation_category)
-    if name != "dspace" or version != chart_version or type(revision) is not int or revision < 1:
+        history = None
+        if release_manifest.helm_status_needs_history(status):
+            history = json.loads(
+                command(
+                    [
+                        "helm",
+                        "--kubeconfig",
+                        args.kubeconfig,
+                        "history",
+                        args.release,
+                        "--namespace",
+                        args.namespace,
+                        "-o",
+                        "json",
+                    ]
+                )
+            )
+        name, version, revision = release_manifest.resolve_helm_identity(
+            status, history, "dspace", chart_version
+        )
+    except (json.JSONDecodeError, release_manifest.ManifestError):
         fail(validation_category)
     if (
         enforce_expected_revision

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -920,8 +920,9 @@ def test_helm_identity_accepts_real_status_schema(monkeypatch: pytest.MonkeyPatc
     assert verifier.helm_identity(args, "3.1.0") == ("dspace", "3.1.0", 7)
 
 
+@pytest.mark.parametrize("chart", [pytest.param("omitted", id="omitted"), None, {"metadata": None}])
 def test_helm_identity_uses_exact_current_history_when_status_omits_chart(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, chart: object
 ) -> None:
     status = {
         "config": {},
@@ -931,6 +932,8 @@ def test_helm_identity_uses_exact_current_history_when_status_omits_chart(
         "namespace": "dspace",
         "version": 26,
     }
+    if chart != "omitted":
+        status["chart"] = chart
     history = [
         {
             "revision": 26,
@@ -940,15 +943,21 @@ def test_helm_identity_uses_exact_current_history_when_status_omits_chart(
             "description": "matching invocation",
         }
     ]
-    monkeypatch.setattr(
-        verifier,
-        "command",
-        lambda argv: json.dumps(history if "history" in argv else status),
-    )
+    history_calls = 0
+
+    def command(argv):
+        nonlocal history_calls
+        if "history" in argv:
+            history_calls += 1
+            return json.dumps(history)
+        return json.dumps(status)
+
+    monkeypatch.setattr(verifier, "command", command)
     args = Namespace(
         kubeconfig="k", release="dspace", namespace="dspace", expected_helm_revision=26
     )
     assert verifier.helm_identity(args, "3.0.2") == ("dspace", "3.0.2", 26)
+    assert history_calls == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -162,6 +162,15 @@ def _verify_setup(
             ],
         )
     )
+    helm_histories = iter(
+        override.get(
+            "helm_histories",
+            [
+                [{"revision": 7, "chart": f"dspace-{chart_version}"}],
+                [{"revision": 7, "chart": f"dspace-{chart_version}"}],
+            ],
+        )
+    )
     direct_builds = override.get("direct_builds", {})
     direct_html = override.get("direct_html", {})
     public_build = override.get("public_build", build())
@@ -177,6 +186,8 @@ def _verify_setup(
 
     def command(argv: list[str]) -> str:
         if argv[0] == "helm":
+            if "history" in argv:
+                return json.dumps(next(helm_histories))
             return json.dumps(next(helm_statuses))
         if "pods" in argv:
             return json.dumps({"items": pods})
@@ -442,7 +453,9 @@ def test_modern_identity_failure_never_requests_legacy_surface(
         b"x" * (1024 * 1024 + 1),
         b"\xff" + SENTINEL.encode(),
         b"[" * 2000 + SENTINEL.encode() + b"]" * 2000,
-        json.dumps({"gitSha": "wrong", "generatedAt": "2026-08-01T12:00:00Z", "source": "x"}).encode(),
+        json.dumps(
+            {"gitSha": "wrong", "generatedAt": "2026-08-01T12:00:00Z", "source": "x"}
+        ).encode(),
         json.dumps({"gitSha": RECOVERY_SHA, "generatedAt": "", "source": "x"}).encode(),
         json.dumps({"gitSha": RECOVERY_SHA, "generatedAt": "not-a-date", "source": "x"}).encode(),
         json.dumps(
@@ -452,7 +465,9 @@ def test_modern_identity_failure_never_requests_legacy_surface(
                 "source": SENTINEL,
             }
         ).encode(),
-        json.dumps({"gitSha": RECOVERY_SHA, "generatedAt": "2026-08-01T12:00:00Z", "source": ""}).encode(),
+        json.dumps(
+            {"gitSha": RECOVERY_SHA, "generatedAt": "2026-08-01T12:00:00Z", "source": ""}
+        ).encode(),
         json.dumps(
             {
                 "gitSha": RECOVERY_SHA,
@@ -775,6 +790,25 @@ def test_verify_detects_helm_change_during_chat(
     assert str(raised.value) == "concurrent Helm change"
 
 
+def test_verify_detects_helm_change_during_chat_with_history_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    args, _ = _verify_setup(
+        monkeypatch,
+        tmp_path,
+        overrides={
+            "helm_statuses": [{"version": 7}, {"version": 8}],
+            "helm_histories": [
+                [{"revision": 7, "chart": "dspace-3.1.0"}],
+                [{"revision": 8, "chart": "dspace-3.1.0"}],
+            ],
+        },
+    )
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.verify(args)
+    assert str(raised.value) == "concurrent Helm change"
+
+
 def test_missing_or_nonexecutable_runner_fails_safely(tmp_path: Path) -> None:
     args = Namespace(
         environment="staging",
@@ -884,6 +918,90 @@ def test_helm_identity_accepts_real_status_schema(monkeypatch: pytest.MonkeyPatc
     )
     args = Namespace(kubeconfig="k", release="dspace", namespace="dspace", expected_helm_revision=7)
     assert verifier.helm_identity(args, "3.1.0") == ("dspace", "3.1.0", 7)
+
+
+def test_helm_identity_uses_exact_current_history_when_status_omits_chart(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status = {
+        "config": {},
+        "info": {"status": "deployed"},
+        "manifest": "redacted",
+        "name": "dspace",
+        "namespace": "dspace",
+        "version": 26,
+    }
+    history = [
+        {
+            "revision": 26,
+            "chart": "dspace-3.0.2",
+            "app_version": "3.0.1",
+            "status": "deployed",
+            "description": "matching invocation",
+        }
+    ]
+    monkeypatch.setattr(
+        verifier,
+        "command",
+        lambda argv: json.dumps(history if "history" in argv else status),
+    )
+    args = Namespace(
+        kubeconfig="k", release="dspace", namespace="dspace", expected_helm_revision=26
+    )
+    assert verifier.helm_identity(args, "3.0.2") == ("dspace", "3.0.2", 26)
+
+
+@pytest.mark.parametrize(
+    "status,history",
+    [
+        ({"version": 26}, []),
+        ({"version": 26}, [{"revision": 25, "chart": "dspace-3.0.2"}]),
+        (
+            {"version": 26},
+            [
+                {"revision": 26, "chart": "dspace-3.0.2"},
+                {"revision": 26, "chart": "dspace-3.0.2"},
+            ],
+        ),
+        ({"version": 26}, [{"revision": 26, "chart": "dspace-3.0.1"}]),
+        ({"version": True}, [{"revision": 1, "chart": "dspace-3.0.2"}]),
+        ({"version": 26}, {"revision": 26, "chart": "dspace-3.0.2"}),
+        ({"version": 26}, [{"revision": "26", "chart": "SENTINEL_SECRET"}]),
+        ({"version": 26, "chart": "invalid"}, [{"revision": 26, "chart": "dspace-3.0.2"}]),
+    ],
+)
+def test_helm_identity_history_fallback_fails_closed_and_redacted(
+    monkeypatch: pytest.MonkeyPatch, status: object, history: object
+) -> None:
+    monkeypatch.setattr(
+        verifier,
+        "command",
+        lambda argv: json.dumps(history if "history" in argv else status),
+    )
+    args = Namespace(
+        kubeconfig="k", release="dspace", namespace="dspace", expected_helm_revision=26
+    )
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.helm_identity(args, "3.0.2")
+    assert str(raised.value) == "cluster identity"
+    assert SENTINEL not in str(raised.value)
+
+
+def test_helm_identity_history_fallback_preserves_expected_revision_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        verifier,
+        "command",
+        lambda argv: json.dumps(
+            [{"revision": 26, "chart": "dspace-3.0.2"}] if "history" in argv else {"version": 26}
+        ),
+    )
+    args = Namespace(
+        kubeconfig="k", release="dspace", namespace="dspace", expected_helm_revision=25
+    )
+    with pytest.raises(verifier.VerificationError, match="staging drift"):
+        verifier.helm_identity(args, "3.0.2")
 
 
 def test_command_timeout_is_bounded_and_redacted(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -1007,8 +1007,9 @@ def test_post_reservation_failure_preserves_ownership(tmp_path: Path, monkeypatc
 
 
 @pytest.mark.parametrize("schema_version", [1, 2])
+@pytest.mark.parametrize("chartless_status", [False, True])
 def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
-    tmp_path: Path, monkeypatch, schema_version: int
+    tmp_path: Path, monkeypatch, schema_version: int, chartless_status: bool
 ) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
@@ -1056,15 +1057,30 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
                         }
                     }
                 )
-            events.append("helm-status")
-            return json.dumps(
-                helm_status(
-                    info={
-                        "status": "deployed",
-                        "description": f"sugarkube-release-manifest:{owner}",
-                    }
+            if "history" in command:
+                events.append("helm-history")
+                return json.dumps(
+                    [
+                        {
+                            "revision": 17,
+                            "chart": "dspace-3.2.0",
+                            "app_version": "3.2.0",
+                            "status": "deployed",
+                            "description": f"sugarkube-release-manifest:{owner}",
+                        }
+                    ]
                 )
+            events.append("helm-status")
+            status = helm_status(
+                info={
+                    "status": "deployed",
+                    "description": f"sugarkube-release-manifest:{owner}",
+                }
             )
+            if chartless_status:
+                status.pop("chart")
+                status.update(config={}, manifest="redacted")
+            return json.dumps(status)
         resource = command[command.index("get") + 1]
         if resource == "pods":
             events.append("pod-discovery")
@@ -1122,16 +1138,21 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
         "cluster-identity",
         "helm-status",
     ]
+    if chartless_status:
+        expected_events.append("helm-history")
     if schema_version == 2:
         expected_events.append("helm-stored-values")
     expected_events += [
         "pod-discovery",
         "pod-discovery",
         "helm-status",
-        "workload-discovery",
-        "helm-status",
-        "atomic-final-write",
     ]
+    if chartless_status:
+        expected_events.append("helm-history")
+    expected_events += ["workload-discovery", "helm-status"]
+    if chartless_status:
+        expected_events.append("helm-history")
+    expected_events.append("atomic-final-write")
     assert events == expected_events
     final = manifest.validate(json.loads(output.read_text(encoding="utf-8")), True)
     assert final["helmRevision"] == 17
@@ -1200,9 +1221,68 @@ def test_finalize_cli_settling_failure_preserves_reservation(
     assert manifest.reservation_path(output).exists()
 
 
+def test_finalize_cli_history_failure_is_redacted_and_preserves_reservation(
+    tmp_path: Path, monkeypatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source = tmp_path / "candidate.json"
+    output = tmp_path / "evidence.json"
+    source.write_text(manifest._canonical(candidate()), encoding="utf-8")
+    owner = manifest.reserve(output, candidate(), "staging", "dspace", "dspace")
+    monkeypatch.setattr(manifest, "preflight", lambda *args, **kwargs: [])
+
+    def run(command):
+        if "cluster_identity.py" in " ".join(command):
+            return "staging\n"
+        if command[0] == "helm" and "history" in command:
+            raise manifest.ManifestError("SENTINEL_SECRET")
+        if command[0] == "helm":
+            status = helm_status(
+                info={
+                    "status": "deployed",
+                    "description": f"sugarkube-release-manifest:{owner}",
+                }
+            )
+            status.pop("chart")
+            return json.dumps(status)
+        raise AssertionError("unexpected command")
+
+    monkeypatch.setattr(manifest, "_run", run)
+    assert (
+        manifest.main(
+            [
+                "finalize",
+                "--manifest",
+                str(source),
+                "--output",
+                str(output),
+                "--environment",
+                "staging",
+                "--image-tag",
+                "main-abcdef0",
+                "--chart-version",
+                "3.2.0",
+                "--kubeconfig",
+                "kubeconfig",
+                "--release",
+                "dspace",
+                "--namespace",
+                "dspace",
+                "--reservation",
+                owner,
+            ]
+        )
+        == 2
+    )
+    captured = capsys.readouterr()
+    assert "SENTINEL_SECRET" not in captured.out + captured.err
+    assert not output.exists()
+    assert manifest.reservation_path(output).exists()
+
+
 @pytest.mark.parametrize("changed_field", ["version", "description"])
+@pytest.mark.parametrize("chartless_status", [False, True])
 def test_finalize_cli_rejects_changed_helm_binding_and_preserves_reservation(
-    tmp_path: Path, monkeypatch, changed_field: str
+    tmp_path: Path, monkeypatch, changed_field: str, chartless_status: bool
 ) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
@@ -1225,6 +1305,17 @@ def test_finalize_cli_rejects_changed_helm_binding_and_preserves_reservation(
         if "cluster_identity.py" in " ".join(command):
             return "staging\n"
         if command[0] == "helm":
+            if "history" in command:
+                return json.dumps(
+                    [
+                        {
+                            "revision": (
+                                18 if changed_field == "version" and status_reads == 2 else 17
+                            ),
+                            "chart": "dspace-3.2.0",
+                        }
+                    ]
+                )
             status_reads += 1
             info = {"status": "deployed", "description": description}
             status = helm_status(info=info)
@@ -1233,6 +1324,8 @@ def test_finalize_cli_rejects_changed_helm_binding_and_preserves_reservation(
                     status["version"] = 18
                 else:
                     status["info"]["description"] = "another invocation"
+            if chartless_status:
+                status.pop("chart")
             return json.dumps(status)
         resource = command[command.index("get") + 1]
         return json.dumps({"items": [pod("dspace-a")]} if resource == "pods" else workloads())

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -1007,9 +1007,17 @@ def test_post_reservation_failure_preserves_ownership(tmp_path: Path, monkeypatc
 
 
 @pytest.mark.parametrize("schema_version", [1, 2])
-@pytest.mark.parametrize("chartless_status", [False, True])
+@pytest.mark.parametrize(
+    "chart_shape",
+    [
+        pytest.param("metadata", id="metadata"),
+        pytest.param("omitted", id="omitted"),
+        pytest.param(None, id="null-chart"),
+        pytest.param({"metadata": None}, id="null-metadata"),
+    ],
+)
 def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
-    tmp_path: Path, monkeypatch, schema_version: int, chartless_status: bool
+    tmp_path: Path, monkeypatch, schema_version: int, chart_shape: object
 ) -> None:
     source = tmp_path / "candidate.json"
     output = tmp_path / "evidence.json"
@@ -1077,9 +1085,11 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
                     "description": f"sugarkube-release-manifest:{owner}",
                 }
             )
-            if chartless_status:
+            if chart_shape == "omitted":
                 status.pop("chart")
                 status.update(config={}, manifest="redacted")
+            elif chart_shape != "metadata":
+                status["chart"] = chart_shape
             return json.dumps(status)
         resource = command[command.index("get") + 1]
         if resource == "pods":
@@ -1138,7 +1148,7 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
         "cluster-identity",
         "helm-status",
     ]
-    if chartless_status:
+    if chart_shape != "metadata":
         expected_events.append("helm-history")
     if schema_version == 2:
         expected_events.append("helm-stored-values")
@@ -1147,10 +1157,10 @@ def test_finalize_cli_collects_bound_evidence_before_consuming_reservation(
         "pod-discovery",
         "helm-status",
     ]
-    if chartless_status:
+    if chart_shape != "metadata":
         expected_events.append("helm-history")
     expected_events += ["workload-discovery", "helm-status"]
-    if chartless_status:
+    if chart_shape != "metadata":
         expected_events.append("helm-history")
     expected_events.append("atomic-final-write")
     assert events == expected_events
@@ -1244,6 +1254,55 @@ def test_finalize_cli_history_failure_is_redacted_and_preserves_reservation(
             )
             status.pop("chart")
             return json.dumps(status)
+        raise AssertionError("unexpected command")
+
+    monkeypatch.setattr(manifest, "_run", run)
+    assert (
+        manifest.main(
+            [
+                "finalize",
+                "--manifest",
+                str(source),
+                "--output",
+                str(output),
+                "--environment",
+                "staging",
+                "--image-tag",
+                "main-abcdef0",
+                "--chart-version",
+                "3.2.0",
+                "--kubeconfig",
+                "kubeconfig",
+                "--release",
+                "dspace",
+                "--namespace",
+                "dspace",
+                "--reservation",
+                owner,
+            ]
+        )
+        == 2
+    )
+    captured = capsys.readouterr()
+    assert "SENTINEL_SECRET" not in captured.out + captured.err
+    assert not output.exists()
+    assert manifest.reservation_path(output).exists()
+
+
+def test_finalize_cli_malformed_status_is_redacted_and_preserves_reservation(
+    tmp_path: Path, monkeypatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source = tmp_path / "candidate.json"
+    output = tmp_path / "evidence.json"
+    source.write_text(manifest._canonical(candidate()), encoding="utf-8")
+    owner = manifest.reserve(output, candidate(), "staging", "dspace", "dspace")
+    monkeypatch.setattr(manifest, "preflight", lambda *args, **kwargs: [])
+
+    def run(command):
+        if "cluster_identity.py" in " ".join(command):
+            return "staging\n"
+        if command[0] == "helm":
+            return json.dumps(["SENTINEL_SECRET"])
         raise AssertionError("unexpected command")
 
     monkeypatch.setattr(manifest, "_run", run)


### PR DESCRIPTION
### Motivation

- Some Helm installations return a `helm status --output json` without `chart.metadata`, which caused DSPACE runtime verification and evidence finalization to fail even when `helm history` contains an exact matching immutable chart coordinate.
- Implement a minimal, fail-closed fallback so verification and finalization succeed when and only when the history contains an unambiguous current-revision record that exactly matches the approved chart coordinate.

### Description

- Added a small, shared Helm identity helper set: `helm_status_needs_history()` and `resolve_helm_identity()` that validate the status revision and resolve chart identity from history only when status chart metadata is absent or null, and fail closed on malformed or ambiguous inputs; these were added to `scripts/dspace_release_manifest.py`.
- Applied the resolver in both paths where chart identity matters: `scripts/dspace_runtime_verifier.py::helm_identity()` now consults `helm history` only when needed and uses `resolve_helm_identity()`, and the finalization snapshot/binding comparisons in `scripts/dspace_release_manifest.py::main()` / `finalize()` use the same resolver so runtime verification and evidence finalization remain consistent.
- Kept the primary `chart.metadata` path unchanged; the fallback contract is strict: (1) validate `status["version"]` is a positive non-boolean int; (2) only if status chart metadata is absent/null consult `helm history --output json`; (3) require a structurally valid history list and exactly one record with `revision == status.version`; (4) require that record's `chart` string equals the exact expected `name-version` (e.g. `dspace-3.0.2`); (5) fail closed on missing/duplicate/malformed/stale/wrong-chart records; and (6) never parse by hyphen-splitting or fallback to older revisions. The resolver returns `(name, version, revision)` for downstream checks.
- Preserve redaction and failure behaviour: command failures remain redacted in diagnostics, the reservation lifecycle and atomic finalization semantics are unchanged, and no Helm/Kubernetes mutations were added.
- Files changed: `scripts/dspace_release_manifest.py`, `scripts/dspace_runtime_verifier.py`, `tests/test_dspace_runtime_verifier.py`, `tests/test_release_manifest.py`.

### Testing

- Run narrow verifier tests: `python3 -m pytest -q tests/test_dspace_runtime_verifier.py` — 124 passed.
- Run finalization tests: `python3 -m pytest -q tests/test_release_manifest.py` — 199 passed.
- Run formatting check: `python3 -m black --check scripts/dspace_runtime_verifier.py scripts/dspace_release_manifest.py tests/test_dspace_runtime_verifier.py tests/test_release_manifest.py` (files reformatted then checked; final check passed after formatting in the patch workflow).
- Repo checks: `bash scripts/checks.sh` executed and completed (environment reported existing repo-wide lint findings unrelated to this change and skipped KiCad/KiBot steps due to environment limits); `pre-commit run --all-files` was not available in the environment.
- Broader run: `python3 -m pytest -q` was started for the full suite; it showed large progress (1,016 passed, 3 skipped) before the practical verification window ended; no failures were observed in the exercised tests.

All added tests assert the contract and redaction requirements: chart-less status with a single matching history entry succeeds; missing/duplicate/malformed/wrong history records fail closed; expected revision drift and concurrent Helm-change detection remain enforced; finalization succeeds with chart-less status across the snapshot sequence and preserves reservations on failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fc727ae3c832f9b9cccc2e1237e16)