### PR TITLE
Set stable User-Agent for DSPACE runtime verifier

### DIFF
--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -64,6 +64,7 @@ META_RE = re.compile(
 )
 IMAGE_ID_RE = re.compile(r"sha256:[0-9a-f]{64}$")
 HTML_DOCUMENT_RE = re.compile(r"^\s*(?:<!doctype\s+html\b|<html\b)", re.IGNORECASE)
+USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"
 
 
 class VerificationError(ValueError):
@@ -147,8 +148,9 @@ def fetch(url: str, public_origin: tuple[str, str] | None = None) -> bytes:
         if public_origin
         else urllib.request.build_opener()
     )
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
     try:
-        with opener.open(url, timeout=15) as response:
+        with opener.open(request, timeout=15) as response:
             return response.read(1024 * 1024 + 1)
     except (OSError, urllib.error.URLError, VerificationError) as exc:
         if isinstance(exc, VerificationError):

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -615,6 +615,21 @@ def test_same_origin_redirect_rejects_cross_origin_before_request() -> None:
     assert SENTINEL not in str(raised.value)
 
 
+def test_same_origin_redirect_preserves_user_agent() -> None:
+    handler = verifier.SameOriginRedirect(("https", "staging.example"))
+    request = verifier.urllib.request.Request(
+        "https://staging.example/build-meta.json",
+        headers={"User-Agent": verifier.USER_AGENT},
+    )
+
+    redirected = handler.redirect_request(
+        request, object(), 302, "Found", {}, "https://staging.example/build-meta-v2.json"
+    )
+
+    assert redirected is not None
+    assert redirected.get_header("User-agent") == verifier.USER_AGENT
+
+
 def _pod_overrides(mutator) -> dict[str, object]:  # noqa: ANN001
     """Build the minimum two-pod override used by fail-closed replica tests."""
     canonical = "ghcr.io/democratizedspace/dspace:main-abcdef0"
@@ -1159,26 +1174,34 @@ class _Response:
     ("origin", "category"),
     [(None, "direct identity"), (("https", "dspace.example"), "public identity")],
 )
+@pytest.mark.parametrize("path", ["build-meta.json", ""])
 def test_fetch_success_and_network_failures_are_bounded(
     monkeypatch: pytest.MonkeyPatch,
     origin: tuple[str, str] | None,
     category: str,
+    path: str,
 ) -> None:
+    url = f"https://dspace.example/{path}"
+
     class Opener:
-        def open(self, url: str, timeout: int) -> _Response:
+        def open(self, request: verifier.urllib.request.Request, timeout: int) -> _Response:
             assert timeout == 15
+            assert request.full_url == url
+            assert request.get_header("User-agent") == verifier.USER_AGENT
+            assert dict(request.header_items()) == {"User-agent": verifier.USER_AGENT}
             return _Response()
 
     monkeypatch.setattr(verifier.urllib.request, "build_opener", lambda *args: Opener())
-    assert verifier.fetch("https://dspace.example/build-info.json", origin) == b"bounded"
+    assert verifier.fetch(url, origin) == b"bounded"
 
     class BrokenOpener:
-        def open(self, url: str, timeout: int) -> _Response:
+        def open(self, request: verifier.urllib.request.Request, timeout: int) -> _Response:
+            assert request.get_header("User-agent") == verifier.USER_AGENT
             raise verifier.urllib.error.URLError(SENTINEL)
 
     monkeypatch.setattr(verifier.urllib.request, "build_opener", lambda *args: BrokenOpener())
     with pytest.raises(verifier.VerificationError) as raised:
-        verifier.fetch("https://dspace.example/build-info.json", origin)
+        verifier.fetch(url, origin)
     assert str(raised.value) == category
     assert SENTINEL not in str(raised.value)
 
@@ -1266,7 +1289,8 @@ def test_kubernetes_metadata_types_fail_closed(call: object, category: str) -> N
 
 def test_fetch_preserves_bounded_redirect_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     class Opener:
-        def open(self, url: str, timeout: int) -> _Response:
+        def open(self, request: verifier.urllib.request.Request, timeout: int) -> _Response:
+            assert request.get_header("User-agent") == verifier.USER_AGENT
             raise verifier.VerificationError("public identity")
 
     monkeypatch.setattr(verifier.urllib.request, "build_opener", lambda *args: Opener())


### PR DESCRIPTION
### Motivation

- Cloudflare Browser Integrity Check deterministically rejected the verifier's default `Python-urllib/...` User-Agent; operational evidence showed 16 requests (eight `/build-meta.json` and eight `/`) returned HTTP 403 with the 17-byte body whose SHA-256 is `2938e9f1284180959e33ab1718d0793a72ff6e4cdb8108c34dcd14e69446de5c` corresponding to Cloudflare `error code: 1010\n`.
- A truthful probe using `User-Agent: sugarkube-dspace-runtime-verifier/1.0` succeeded 8/8 against staging (four metadata and four root-document requests), so the verifier must send that exact header on every public request without changing other safety checks.

### Description

- Add a single module-level constant `USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"` and construct an explicit `urllib.request.Request` with that header for every call in `fetch()` so urllib's default `Python-urllib/...` is never used.
- Ensure the explicit `Request` is used for both identity (metadata) and root-document fetches and preserved across same-origin redirects by leaving the existing `SameOriginRedirect` semantics in place.
- Update unit tests to accept and assert an explicit `Request` object, add a regression proving a same-origin redirect preserves the User-Agent, and keep cross-origin redirects fail-closed and all existing bounded behaviors untouched.

### Testing

- `python3 -m pytest -q tests/test_dspace_runtime_verifier.py` — PASS: `129 passed` (observed `129 passed in 20.19s` then `129 passed in 1.17s` in focused runs).
- `python3 -m black --check scripts/dspace_runtime_verifier.py tests/test_dspace_runtime_verifier.py` — PASS: `2 files would be left unchanged`.
- `python3 -m isort --check-only scripts/dspace_runtime_verifier.py tests/test_dspace_runtime_verifier.py` — PASS.
- `git diff --cached | ./scripts/scan-secrets.py` — PASS (no secrets reported).
- `pre-commit run --files scripts/dspace_runtime_verifier.py tests/test_dspace_runtime_verifier.py` — targeted hooks passed; repository-wide `pre-commit run --all-files` reported unrelated, pre-existing lint/YAML issues outside this change.
- Doc checks could not be run in this environment: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` are not available here (no executables installed), and no documentation files were changed.

Residual risk and notes: this change is intentionally minimal and preserves all verifier safety checks (HTTPS and same-origin enforcement, 15s timeout, 1MiB read bound, failure redaction, identity contracts); it does not add retries or relax security. The PR reports the observed Cloudflare 1010 evidence and the successful 8/8 truthful-User-Agent probe but does not assert live recovery is complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fdc18cbc4832f88e4520d4e4306a2)