### PR TITLE
Set stable public User-Agent for DSPACE runtime verifier HTTP requests

### DIFF
--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -64,6 +64,7 @@ META_RE = re.compile(
 )
 IMAGE_ID_RE = re.compile(r"sha256:[0-9a-f]{64}$")
 HTML_DOCUMENT_RE = re.compile(r"^\s*(?:<!doctype\s+html\b|<html\b)", re.IGNORECASE)
+PUBLIC_HTTP_USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"
 
 
 class VerificationError(ValueError):
@@ -147,8 +148,9 @@ def fetch(url: str, public_origin: tuple[str, str] | None = None) -> bytes:
         if public_origin
         else urllib.request.build_opener()
     )
+    request = urllib.request.Request(url, headers={"User-Agent": PUBLIC_HTTP_USER_AGENT})
     try:
-        with opener.open(url, timeout=15) as response:
+        with opener.open(request, timeout=15) as response:
             return response.read(1024 * 1024 + 1)
     except (OSError, urllib.error.URLError, VerificationError) as exc:
         if isinstance(exc, VerificationError):

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -615,6 +615,21 @@ def test_same_origin_redirect_rejects_cross_origin_before_request() -> None:
     assert SENTINEL not in str(raised.value)
 
 
+def test_same_origin_redirect_preserves_user_agent() -> None:
+    handler = verifier.SameOriginRedirect(("https", "staging.example"))
+    request = verifier.urllib.request.Request(
+        "https://staging.example/build-meta.json",
+        headers={"User-Agent": verifier.PUBLIC_HTTP_USER_AGENT},
+    )
+
+    redirected = handler.redirect_request(
+        request, object(), 302, "Found", {}, "https://staging.example/build-meta-v2.json"
+    )
+
+    assert redirected is not None
+    assert redirected.get_header("User-agent") == verifier.PUBLIC_HTTP_USER_AGENT
+
+
 def _pod_overrides(mutator) -> dict[str, object]:  # noqa: ANN001
     """Build the minimum two-pod override used by fail-closed replica tests."""
     canonical = "ghcr.io/democratizedspace/dspace:main-abcdef0"
@@ -1165,15 +1180,17 @@ def test_fetch_success_and_network_failures_are_bounded(
     category: str,
 ) -> None:
     class Opener:
-        def open(self, url: str, timeout: int) -> _Response:
+        def open(self, request: verifier.urllib.request.Request, timeout: int) -> _Response:
             assert timeout == 15
+            assert request.full_url == "https://dspace.example/build-info.json"
+            assert request.get_header("User-agent") == verifier.PUBLIC_HTTP_USER_AGENT
             return _Response()
 
     monkeypatch.setattr(verifier.urllib.request, "build_opener", lambda *args: Opener())
     assert verifier.fetch("https://dspace.example/build-info.json", origin) == b"bounded"
 
     class BrokenOpener:
-        def open(self, url: str, timeout: int) -> _Response:
+        def open(self, request: verifier.urllib.request.Request, timeout: int) -> _Response:
             raise verifier.urllib.error.URLError(SENTINEL)
 
     monkeypatch.setattr(verifier.urllib.request, "build_opener", lambda *args: BrokenOpener())
@@ -1266,7 +1283,7 @@ def test_kubernetes_metadata_types_fail_closed(call: object, category: str) -> N
 
 def test_fetch_preserves_bounded_redirect_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     class Opener:
-        def open(self, url: str, timeout: int) -> _Response:
+        def open(self, request: verifier.urllib.request.Request, timeout: int) -> _Response:
             raise verifier.VerificationError("public identity")
 
     monkeypatch.setattr(verifier.urllib.request, "build_opener", lambda *args: Opener())


### PR DESCRIPTION
### Motivation

- Cloudflare Browser Integrity Check deterministically rejected the verifier's default `Python-urllib/...` User-Agent, producing a 17-byte response whose SHA-256 is `2938e9f1284180959e33ab1718d0793a72ff6e4cdb8108c34dcd14e69446de5c` (Cloudflare `error code: 1010`).
- A truthful User-Agent probe using `sugarkube-dspace-runtime-verifier/1.0` succeeded 8/8 on staging (four `/build-meta.json` and four `/` requests returned HTTP 200 with valid content), so the verifier must present that exact header for all public requests.

### Description

- Define a single module-level constant `PUBLIC_HTTP_USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"` and use it for all public HTTP requests. 
- Have `fetch()` build an explicit `urllib.request.Request` carrying the `User-Agent` header and pass that Request into the opener so the header is present on the initial request and preserved for same-origin redirects. 
- Keep existing behavior unchanged, including HTTPS and same-origin enforcement, 15s timeout, 1 MiB response bound, cross-origin redirect rejection, error categorization and redaction, identity validation, and output schema. 
- Update tests: adapt fetch mocks to accept `Request` objects, assert the exact `User-Agent` on initial and redirected same-origin requests, add a regression test proving same-origin redirects preserve the header, and preserve cross-origin redirect rejection tests and other bounded/read/network-failure tests.

### Testing

- `python3 -m pytest -q tests/test_dspace_runtime_verifier.py` — PASS: `127 passed in 13.92s`.
- `python3 -m black --check scripts/dspace_runtime_verifier.py tests/test_dspace_runtime_verifier.py` — PASS: 2 files unchanged.
- `python3 -m isort --check-only scripts/dspace_runtime_verifier.py tests/test_dspace_runtime_verifier.py` — PASS.
- `git diff --check` — PASS.
- `git diff --cached | ./scripts/scan-secrets.py` — PASS.
- `linkchecker --no-warnings README.md docs/` — PASS: 207 URLs checked, 0 warnings, 0 errors.
- `pyspelling -c .spellcheck.yaml` — ENVIRONMENT LIMITATION: could not run fully because `aspell` is not installed in the environment.
- `pre-commit run --all-files` — REPOSITORY-BASELINE: whitespace hooks passed but repository-wide `check-yaml` and `run-checks` failed due to existing multi-document/Helm-template YAML shapes and a `just` bootstrap URL returning HTTP 404; these are pre-existing repository baseline issues and not caused by this change.
- `python3 -m flake8 scripts/dspace_runtime_verifier.py tests/test_dspace_runtime_verifier.py` — REPOSITORY-BASELINE: reported pre-existing E501 violations in tests (no new violations introduced by this patch).

Notes: the change is intentionally narrow and only touches the verifier and its focused tests so that no public request relies on the `Python-urllib/...` default User-Agent and the exact header `User-Agent: sugarkube-dspace-runtime-verifier/1.0` is present on initial and same-origin redirected requests while cross-origin redirects remain blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fdc217e14832f823dad0634020ce7)