### PR TITLE
Fix DSPACE verifier User-Agent for Cloudflare BIC

### DIFF
--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -64,6 +64,7 @@ META_RE = re.compile(
 )
 IMAGE_ID_RE = re.compile(r"sha256:[0-9a-f]{64}$")
 HTML_DOCUMENT_RE = re.compile(r"^\s*(?:<!doctype\s+html\b|<html\b)", re.IGNORECASE)
+PUBLIC_HTTP_USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"
 
 
 class VerificationError(ValueError):
@@ -147,8 +148,9 @@ def fetch(url: str, public_origin: tuple[str, str] | None = None) -> bytes:
         if public_origin
         else urllib.request.build_opener()
     )
+    request = urllib.request.Request(url, headers={"User-Agent": PUBLIC_HTTP_USER_AGENT})
     try:
-        with opener.open(url, timeout=15) as response:
+        with opener.open(request, timeout=15) as response:
             return response.read(1024 * 1024 + 1)
     except (OSError, urllib.error.URLError, VerificationError) as exc:
         if isinstance(exc, VerificationError):

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -605,14 +605,40 @@ def test_verify_redacts_failed_http_identity(
     assert SENTINEL not in str(raised.value) + captured.out + captured.err
 
 
-def test_same_origin_redirect_rejects_cross_origin_before_request() -> None:
+def test_same_origin_redirect_rejects_cross_origin_before_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     handler = verifier.SameOriginRedirect(("https", "staging.example"))
+    redirected = False
+
+    def redirect(*args: object) -> None:
+        nonlocal redirected
+        redirected = True
+
+    monkeypatch.setattr(verifier.urllib.request.HTTPRedirectHandler, "redirect_request", redirect)
     with pytest.raises(verifier.VerificationError) as raised:
         handler.redirect_request(
             object(), object(), 302, SENTINEL, {}, "https://attacker.invalid/secret"
         )
     assert str(raised.value) == "public identity"
     assert SENTINEL not in str(raised.value)
+    assert redirected is False
+
+
+def test_same_origin_redirect_preserves_user_agent() -> None:
+    handler = verifier.SameOriginRedirect(("https", "staging.example"))
+    request = verifier.urllib.request.Request(
+        "https://staging.example/build-meta.json",
+        headers={"User-Agent": verifier.PUBLIC_HTTP_USER_AGENT},
+    )
+
+    redirected = handler.redirect_request(
+        request, object(), 302, "Found", {}, "https://staging.example/build-meta.json?current=1"
+    )
+
+    assert redirected is not None
+    assert redirected.full_url == "https://staging.example/build-meta.json?current=1"
+    assert redirected.get_header("User-agent") == verifier.PUBLIC_HTTP_USER_AGENT
 
 
 def _pod_overrides(mutator) -> dict[str, object]:  # noqa: ANN001
@@ -1159,26 +1185,35 @@ class _Response:
     ("origin", "category"),
     [(None, "direct identity"), (("https", "dspace.example"), "public identity")],
 )
+@pytest.mark.parametrize("path", ["/build-meta.json", "/"], ids=("identity", "root"))
 def test_fetch_success_and_network_failures_are_bounded(
     monkeypatch: pytest.MonkeyPatch,
     origin: tuple[str, str] | None,
     category: str,
+    path: str,
 ) -> None:
+    url = f"https://dspace.example{path}"
+
     class Opener:
-        def open(self, url: str, timeout: int) -> _Response:
+        def open(self, request: verifier.urllib.request.Request, timeout: int) -> _Response:
             assert timeout == 15
+            assert request.full_url == url
+            assert dict(request.header_items()) == {
+                "User-agent": verifier.PUBLIC_HTTP_USER_AGENT,
+            }
             return _Response()
 
     monkeypatch.setattr(verifier.urllib.request, "build_opener", lambda *args: Opener())
-    assert verifier.fetch("https://dspace.example/build-info.json", origin) == b"bounded"
+    assert verifier.fetch(url, origin) == b"bounded"
 
     class BrokenOpener:
-        def open(self, url: str, timeout: int) -> _Response:
+        def open(self, request: verifier.urllib.request.Request, timeout: int) -> _Response:
+            assert request.get_header("User-agent") == verifier.PUBLIC_HTTP_USER_AGENT
             raise verifier.urllib.error.URLError(SENTINEL)
 
     monkeypatch.setattr(verifier.urllib.request, "build_opener", lambda *args: BrokenOpener())
     with pytest.raises(verifier.VerificationError) as raised:
-        verifier.fetch("https://dspace.example/build-info.json", origin)
+        verifier.fetch(url, origin)
     assert str(raised.value) == category
     assert SENTINEL not in str(raised.value)
 
@@ -1266,7 +1301,8 @@ def test_kubernetes_metadata_types_fail_closed(call: object, category: str) -> N
 
 def test_fetch_preserves_bounded_redirect_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     class Opener:
-        def open(self, url: str, timeout: int) -> _Response:
+        def open(self, request: verifier.urllib.request.Request, timeout: int) -> _Response:
+            assert request.get_header("User-agent") == verifier.PUBLIC_HTTP_USER_AGENT
             raise verifier.VerificationError("public identity")
 
     monkeypatch.setattr(verifier.urllib.request, "build_opener", lambda *args: Opener())


### PR DESCRIPTION
### Motivation

- Cloudflare Browser Integrity Check deterministically rejected urllib’s default `Python-urllib/...` User-Agent: eight `/build-meta.json` requests and eight `/` requests returned HTTP 403 with the 17-byte `error code: 1010\n` response (SHA-256 `2938e9f1284180959e33ab1718d0793a72ff6e4cdb8108c34dcd14e69446de5c`).
- The truthful `User-Agent: sugarkube-dspace-runtime-verifier/1.0` subsequently passed 8/8 staging probes: four identity requests and four root-document requests, all HTTP 200 with valid content.

### Description

- Define the module-level `PUBLIC_HTTP_USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"` constant.
- Have `fetch()` construct an explicit `urllib.request.Request` carrying that header, eliminating reliance on urllib’s default User-Agent for both identity and root-document requests.
- Preserve the header across accepted same-origin redirects.
- Strengthen the cross-origin regression test to prove the parent redirect handler is never invoked for a cross-origin target.
- Preserve the existing 15-second timeout, one-megabyte response bound, HTTPS and same-origin enforcement, bounded failure categories, secret redaction, identity validation, and output schema.
- Do not add retries, weaken TLS or redirect checks, accept HTTP error bodies as success, or impersonate curl or a browser.

### Scope

Only these files are changed:

- `scripts/dspace_runtime_verifier.py`
- `tests/test_dspace_runtime_verifier.py`

No candidates, evidence, chart pins, deployment configuration, Kubernetes resources, reservations, Cloudflare settings, or DSPACE repository content are changed.

### Verification

- `python3 -m pytest -q tests/test_dspace_runtime_verifier.py` — PASS: `129 passed in 1.13s`.
- `python3 -m black --check scripts/dspace_runtime_verifier.py tests/test_dspace_runtime_verifier.py` — PASS: both files unchanged.
- `python3 -m isort --check-only scripts/dspace_runtime_verifier.py tests/test_dspace_runtime_verifier.py` — PASS.
- `git diff origin/main...HEAD | ./scripts/scan-secrets.py` — PASS: no findings.
- `linkchecker --no-warnings README.md docs/` — PASS: 207 URLs checked with no warnings or errors.
- `pre-commit run --files scripts/dspace_runtime_verifier.py tests/test_dspace_runtime_verifier.py` — file-hygiene hooks passed; the repository-wide `run-checks` hook continued to report existing violations outside this patch.
- `pre-commit run --all-files` — repository-baseline hygiene and YAML failures remained outside this focused change.
- `pyspelling -c .spellcheck.yaml` — unavailable because the environment lacked the `aspell` executable; no documentation files changed.

Latest-head GitHub Actions for `a3464578be44161788d67ea07365d68a1de6b35b` all completed successfully:

- `ci` run 2588
- `Test Suite` run 9941
- `pi-image` run 3711

Conditional OCI/build work in `pi-image` was skipped as designed because this PR does not touch OCI-related paths.

### Operational note

This PR records the observed Cloudflare 1010 evidence and successful 8/8 truthful-User-Agent probe. It does not claim that live recovery is complete or modify the existing recovery state.

------

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fdc23302c832f9097faf5d567bd44)