### PR TITLE
Fix DSPACE runtime verifier User-Agent

### DIFF
--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -46,6 +46,7 @@ BUILD_FIELDS = {"version", "revision", "shortRevision", "image"}
 LEGACY_BUILD_FIELDS = {"gitSha", "generatedAt", "source"}
 MODERN_IDENTITY_CONTRACT = "build-info-v1"
 LEGACY_IDENTITY_CONTRACT = "legacy-build-meta-v1"
+PUBLIC_HTTP_USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"
 LEGACY_RECOVERY_COORDINATES = {
     "schemaVersion": 2,
     "applicationVersion": "3.0.1",
@@ -147,8 +148,9 @@ def fetch(url: str, public_origin: tuple[str, str] | None = None) -> bytes:
         if public_origin
         else urllib.request.build_opener()
     )
+    request = urllib.request.Request(url, headers={"User-Agent": PUBLIC_HTTP_USER_AGENT})
     try:
-        with opener.open(url, timeout=15) as response:
+        with opener.open(request, timeout=15) as response:
             return response.read(1024 * 1024 + 1)
     except (OSError, urllib.error.URLError, VerificationError) as exc:
         if isinstance(exc, VerificationError):

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -607,12 +607,32 @@ def test_verify_redacts_failed_http_identity(
 
 def test_same_origin_redirect_rejects_cross_origin_before_request() -> None:
     handler = verifier.SameOriginRedirect(("https", "staging.example"))
+    request = verifier.urllib.request.Request(
+        "https://staging.example/build-info.json",
+        headers={"User-Agent": verifier.PUBLIC_HTTP_USER_AGENT},
+    )
     with pytest.raises(verifier.VerificationError) as raised:
         handler.redirect_request(
-            object(), object(), 302, SENTINEL, {}, "https://attacker.invalid/secret"
+            request, object(), 302, SENTINEL, {}, "https://attacker.invalid/secret"
         )
     assert str(raised.value) == "public identity"
     assert SENTINEL not in str(raised.value)
+
+
+def test_same_origin_redirect_retains_public_user_agent() -> None:
+    handler = verifier.SameOriginRedirect(("https", "staging.example"))
+    request = verifier.urllib.request.Request(
+        "https://staging.example/build-info.json",
+        headers={"User-Agent": verifier.PUBLIC_HTTP_USER_AGENT},
+    )
+
+    redirected = handler.redirect_request(
+        request, object(), 302, "Found", {}, "https://staging.example/release/build-info.json"
+    )
+
+    assert redirected is not None
+    assert redirected.full_url == "https://staging.example/release/build-info.json"
+    assert redirected.get_header("User-agent") == verifier.PUBLIC_HTTP_USER_AGENT
 
 
 def _pod_overrides(mutator) -> dict[str, object]:  # noqa: ANN001
@@ -1165,15 +1185,17 @@ def test_fetch_success_and_network_failures_are_bounded(
     category: str,
 ) -> None:
     class Opener:
-        def open(self, url: str, timeout: int) -> _Response:
+        def open(self, request: verifier.urllib.request.Request, timeout: int) -> _Response:
             assert timeout == 15
+            assert request.full_url == "https://dspace.example/build-info.json"
+            assert request.get_header("User-agent") == verifier.PUBLIC_HTTP_USER_AGENT
             return _Response()
 
     monkeypatch.setattr(verifier.urllib.request, "build_opener", lambda *args: Opener())
     assert verifier.fetch("https://dspace.example/build-info.json", origin) == b"bounded"
 
     class BrokenOpener:
-        def open(self, url: str, timeout: int) -> _Response:
+        def open(self, request: verifier.urllib.request.Request, timeout: int) -> _Response:
             raise verifier.urllib.error.URLError(SENTINEL)
 
     monkeypatch.setattr(verifier.urllib.request, "build_opener", lambda *args: BrokenOpener())
@@ -1266,7 +1288,7 @@ def test_kubernetes_metadata_types_fail_closed(call: object, category: str) -> N
 
 def test_fetch_preserves_bounded_redirect_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     class Opener:
-        def open(self, url: str, timeout: int) -> _Response:
+        def open(self, request: verifier.urllib.request.Request, timeout: int) -> _Response:
             raise verifier.VerificationError("public identity")
 
     monkeypatch.setattr(verifier.urllib.request, "build_opener", lambda *args: Opener())


### PR DESCRIPTION
### Motivation

- Cloudflare Browser Integrity Check deterministically rejected urllib's default `Python-urllib/...` User-Agent (eight `/build-meta.json` + eight `/` requests returned HTTP 403 with the 17-byte body whose SHA-256 is `2938e9f1284180959e33ab1718d0793a72ff6e4cdb8108c34dcd14e69446de5c`, corresponding to Cloudflare `error code: 1010\n`), while a probe using the truthful `sugarkube-dspace-runtime-verifier/1.0` User-Agent succeeded 8/8; the change aims to make the verifier present that stable, truthful header on every public request.

### Description

- Define a single module-level constant `PUBLIC_HTTP_USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"` in `scripts/dspace_runtime_verifier.py`.
- Construct an explicit `urllib.request.Request` inside `fetch()` with that header and call `opener.open(request, timeout=15)`, preserving the 15s timeout, 1MiB read bound, HTTPS and same-origin enforcement, and existing failure/redaction behavior.
- Preserve fail-closed cross-origin redirect behavior and ensure the header is retained across accepted same-origin redirects by leaving `SameOriginRedirect` unchanged and testing header retention on redirected requests.
- Update tests to accept and inspect the `Request` object, assert the exact User-Agent on initial and same-origin redirected requests, and preserve all existing bounded-read, network-failure, failure-category, and redaction tests in `tests/test_dspace_runtime_verifier.py`.

### Testing

- `python3 -m pytest -q tests/test_dspace_runtime_verifier.py` — PASS: `127 passed in 17.10s`.
- `black --check scripts/dspace_runtime_verifier.py tests/test_dspace_runtime_verifier.py` — PASS: files unchanged.
- `isort --check-only scripts/dspace_runtime_verifier.py tests/test_dspace_runtime_verifier.py` — PASS.
- `linkchecker --no-warnings README.md docs/` — PASS: 207 URLs checked, 0 warnings, 0 errors.
- `git diff --cached | ./scripts/scan-secrets.py` and `git diff --cached --check` — PASS.
- `pre-commit run --all-files` — ENVIRONMENT NOTE: `pre-commit` was initially not installed; after installing it, repository-wide hooks attempted to modify unrelated pre-existing files (trailing-whitespace/EOF and YAML checks) and the run was interrupted to avoid out-of-scope churn; unrelated automatic edits were not committed.
- `pyspelling -c .spellcheck.yaml` — ENVIRONMENT NOTE: could not run due to missing `aspell` binary in the environment.

Residual risk and follow-ups: this is a minimal, focused change to identify the verifier client; it does not add retries, disable TLS, weaken redirect checks, impersonate browsers, or touch deployment/evidence artifacts; run CI/pre-commit in your normal developer environment (with `aspell` and repo-wide hooks available) to validate repository-wide hooks that were intentionally not applied here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fdc24f6bc832f95a115d958b7fd72)