### PR TITLE
Fix DSPACE production metrics token render validation

### DIFF
--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -178,6 +178,51 @@ def contains_exact_scalar(value: object, expected: set[str]) -> bool:
     return isinstance(value, str) and value in expected
 
 
+def dspace_production_metrics_token_is_unsafe(
+    document: dict[str, object], inputs: ReleaseInputs, *, metrics_enabled: bool
+) -> bool:
+    """Return whether an associated resource has a non-legacy METRICS_TOKEN form."""
+    if not contains_exact_scalar(document, {"METRICS_TOKEN"}):
+        return False
+    if metrics_enabled or scalar(document.get("kind")) not in {
+        "Deployment", "StatefulSet", "DaemonSet"
+    }:
+        return True
+    found, containers = nested_value(document, ("spec", "template", "spec", "containers"))
+    if not found or not isinstance(containers, list):
+        return True
+    candidates = {inputs.app, inputs.release, *APP_CONTAINER_NAMES.get(inputs.app, set())}
+    safe_entries: set[int] = set()
+    for container in containers:
+        if not isinstance(container, dict) or scalar(container.get("name")) not in candidates:
+            continue
+        env = container.get("env")
+        for entry in env if isinstance(env, list) else []:
+            if not isinstance(entry, dict) or scalar(entry.get("name")) != "METRICS_TOKEN":
+                continue
+            value_from = entry.get("valueFrom")
+            field_ref = value_from.get("fieldRef") if isinstance(value_from, dict) else None
+            # Chart 3.0.2 uses the pod UID as a safe, unpredictable token when metrics are off.
+            if (
+                set(entry) == {"name", "valueFrom"}
+                and isinstance(value_from, dict) and set(value_from) == {"fieldRef"}
+                and isinstance(field_ref, dict) and set(field_ref) == {"fieldPath"}
+                and field_ref.get("fieldPath") == "metadata.uid"
+            ):
+                safe_entries.add(id(entry))
+
+    def has_unsafe_token(value: object) -> bool:
+        if isinstance(value, dict):
+            return id(value) not in safe_entries and any(
+                has_unsafe_token(key) or has_unsafe_token(item) for key, item in value.items()
+            )
+        if isinstance(value, list):
+            return any(has_unsafe_token(item) for item in value)
+        return value == "METRICS_TOKEN"
+
+    return has_unsafe_token(document)
+
+
 def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str]:
     try:
         documents = safe_yaml_documents(manifest)
@@ -282,13 +327,21 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                 errors.append(
                     "DSPACE ServiceMonitor bearerTokenSecret name and key must be nonempty"
                 )
-        production_leaks = {"METRICS_TOKEN", "dspace-staging-metrics-token", "sugarkube-int"}
+        production_leaks = {"dspace-staging-metrics-token", "sugarkube-int"}
+        metrics_enabled = (
+            resolved_values_scalar(inputs.values, ("metrics", "enabled")).lower() == "true"
+        )
         if inputs.env == "prod" and (
             service_monitors
             or any(
                 isinstance(doc, dict)
                 and release_associated(doc, inputs.release, allow_name=False)
-                and contains_exact_scalar(doc, production_leaks)
+                and (
+                    contains_exact_scalar(doc, production_leaks)
+                    or dspace_production_metrics_token_is_unsafe(
+                        doc, inputs, metrics_enabled=metrics_enabled
+                    )
+                )
                 for doc in documents
             )
         ):

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1281,6 +1281,126 @@ data:
     )
 
 
+def test_dspace_production_allows_legacy_pod_uid_metrics_token() -> None:
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (), "main-deadbee"
+    )
+    manifest = _release_deployment("dspace", """          env:
+            - name: METRICS_TOKEN
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+---
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: dspace
+""")
+
+    assert app_chart.validate_rendered_manifest(manifest, inputs) == []
+
+
+@pytest.mark.parametrize("source", [
+    "value: literal",
+    "valueFrom:\n                secretKeyRef:\n                  name: staging\n                  key: token",
+    "valueFrom:\n                configMapKeyRef:\n                  name: staging\n                  key: token",
+    "valueFrom:\n                resourceFieldRef:\n                  resource: limits.cpu",
+    "valueFrom:\n                fieldRef:\n                  fieldPath: metadata.name",
+    "",
+    "valueFrom: malformed",
+])
+def test_dspace_production_rejects_unsafe_metrics_token_sources(source: str) -> None:
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (), "main-deadbee"
+    )
+    suffix = f"\n              {source}" if source else ""
+    manifest = _release_deployment("dspace", f"""          env:
+            - name: METRICS_TOKEN{suffix}
+---
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: dspace
+""")
+
+    assert "DSPACE production rendered staging-only metrics configuration" in (
+        app_chart.validate_rendered_manifest(manifest, inputs)
+    )
+
+
+def test_dspace_production_rejects_pod_uid_token_outside_intended_container() -> None:
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (), "main-deadbee"
+    )
+    manifest = _release_deployment("dspace", """        - name: sidecar
+          image: example/sidecar:latest
+          env:
+            - name: METRICS_TOKEN
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+---
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: dspace
+""")
+
+    assert "DSPACE production rendered staging-only metrics configuration" in (
+        app_chart.validate_rendered_manifest(manifest, inputs)
+    )
+
+
+def test_dspace_production_rejects_pod_uid_token_when_metrics_enabled(tmp_path: Path) -> None:
+    values = tmp_path / "values.yaml"
+    values.write_text("metrics:\n  enabled: true\n", encoding="utf-8")
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (str(values),),
+        "main-deadbee",
+    )
+    manifest = _release_deployment("dspace", """          env:
+            - name: METRICS_TOKEN
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+---
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: dspace
+""")
+
+    assert "DSPACE production rendered staging-only metrics configuration" in (
+        app_chart.validate_rendered_manifest(manifest, inputs)
+    )
+
+
+def test_dspace_production_rejects_associated_service_monitor() -> None:
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (), "main-deadbee"
+    )
+    manifest = _release_deployment("dspace", """---
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: dspace
+---
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/instance: dspace
+spec:
+  endpoints:
+    - bearerTokenSecret:
+        name: production
+        key: token
+""")
+
+    assert "DSPACE production rendered staging-only metrics configuration" in (
+        app_chart.validate_rendered_manifest(manifest, inputs)
+    )
+
+
 @pytest.mark.parametrize(
     "leak", ["METRICS_TOKEN", "dspace-staging-metrics-token", "sugarkube-int"]
 )

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1300,6 +1300,43 @@ metadata:
     assert app_chart.validate_rendered_manifest(manifest, inputs) == []
 
 
+def test_dspace_production_allows_legacy_token_with_unrelated_env_entries() -> None:
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (), "main-deadbee"
+    )
+    manifest = _release_deployment("dspace", """          env:
+            - malformed
+            - name: UNRELATED
+              value: METRICS_TOKEN_SUFFIX
+            - name: METRICS_TOKEN
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+---
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: dspace
+""")
+
+    assert app_chart.validate_rendered_manifest(manifest, inputs) == []
+
+
+def test_dspace_production_rejects_token_in_workload_without_containers() -> None:
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (), "main-deadbee"
+    )
+    document = {
+        "kind": "Deployment",
+        "metadata": {"name": "dspace", "labels": {"token": "METRICS_TOKEN"}},
+        "spec": {"template": {"spec": {}}},
+    }
+
+    assert app_chart.dspace_production_metrics_token_is_unsafe(
+        document, inputs, metrics_enabled=False
+    )
+
+
 @pytest.mark.parametrize("source", [
     "value: literal",
     "valueFrom:\n                secretKeyRef:\n                  name: staging\n                  key: token",


### PR DESCRIPTION
### Motivation

- The production render validator treated any exact scalar `METRICS_TOKEN` as a staging-only leak and produced a false-positive for the DSPACE 3.0.2 recovery chart which intentionally renders a downward-API pod UID token when metrics are disabled.
- The goal is to allow that exact safe legacy form while continuing to block any genuinely staging-only or unsafe metrics configuration in production renders.

### Description

- Replace the blanket scalar rejection with structure-aware validation by adding `dspace_production_metrics_token_is_unsafe` in `scripts/app_chart.py`, which accepts only the exact `valueFrom.fieldRef.fieldPath: metadata.uid` form on the intended DSPACE application container when metrics are disabled.
- Update the production leak check to consult resolved `metrics.enabled` and to treat `METRICS_TOKEN` safe only when the new structural checks pass; maintain existing checks for `ServiceMonitor`, `dspace-staging-metrics-token`, and `sugarkube-int`.
- Add focused regression tests in `tests/test_generic_app_just_recipes.py` that verify the safe pod-UID form is allowed and that literal values, `secretKeyRef`, `configMapKeyRef`, `resourceFieldRef`, incorrect `fieldPath`, malformed `valueFrom`, wrong-container placement, metrics-enabled configs, and associated `ServiceMonitor` still fail.
- Include a short code comment explaining why `metadata.uid` (the exact downward-API form) is intentionally treated as safe for the legacy recovery chart.

### Testing

- Ran targeted pytest to exercise the new logic: `python3 -m pytest tests/test_generic_app_just_recipes.py -q -k 'dspace_production or dspace_render_contract or dspace_values or dspace_servicemonitor'` and received `29 passed, 223 deselected`.
- Ran broader suites: `python3 -m pytest tests/test_dspace_runtime_values.py -q` (9 passed) and `python3 -m pytest tests/test_release_manifest.py -q` (204 passed), and a full `pytest -q` showing all tests passing in the environment (no regressions observed).
- Ran documentation link check: `linkchecker --no-warnings README.md docs/` (207 links checked, no errors).
- `pyspelling -c .spellcheck.yaml` could not complete in this environment due to the missing `aspell` binary; it was therefore not run to completion here.
- `pre-commit run --all-files` initialization rewrote unrelated files in the sandboxed environment; those unrelated changes were not included in the focused patch and the test runs above were used to verify behavior instead.

All automated tests that exercise the DSPACE render and production-leak validators passed after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7032c7f7fc832fa952aea6efc30cc4)