### PR TITLE
Allow legacy DSPACE pod-UID METRICS_TOKEN in prod renders; tighten staging-metrics checks

### DIFF
--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -178,6 +178,56 @@ def contains_exact_scalar(value: object, expected: set[str]) -> bool:
     return isinstance(value, str) and value in expected
 
 
+def contains_unsafe_dspace_metrics_token(
+    document: dict[str, object], candidates: set[str], metrics_enabled: bool
+) -> bool:
+    safe_entries: set[int] = set()
+    kind = scalar(document.get("kind"))
+    if kind in {"Deployment", "StatefulSet", "DaemonSet"} and not metrics_enabled:
+        found, containers = nested_value(document, ("spec", "template", "spec", "containers"))
+        if found and isinstance(containers, list):
+            for container in containers:
+                if (
+                    not isinstance(container, dict)
+                    or scalar(container.get("name")) not in candidates
+                ):
+                    continue
+                env = container.get("env")
+                if not isinstance(env, list):
+                    continue
+                for entry in env:
+                    if not isinstance(entry, dict):
+                        continue
+                    value_from = entry.get("valueFrom")
+                    field_ref = (
+                        value_from.get("fieldRef") if isinstance(value_from, dict) else None
+                    )
+                    # Chart 3.0.2 uses the pod UID as a safe pod-local token when metrics are off.
+                    if (
+                        set(entry) == {"name", "valueFrom"}
+                        and entry.get("name") == "METRICS_TOKEN"
+                        and isinstance(value_from, dict)
+                        and set(value_from) == {"fieldRef"}
+                        and isinstance(field_ref, dict)
+                        and set(field_ref) == {"fieldPath"}
+                        and field_ref.get("fieldPath") == "metadata.uid"
+                    ):
+                        safe_entries.add(id(entry))
+
+    def contains_unsafe(value: object) -> bool:
+        if isinstance(value, dict):
+            if id(value) in safe_entries:
+                return False
+            return any(
+                contains_unsafe(key) or contains_unsafe(item) for key, item in value.items()
+            )
+        if isinstance(value, list):
+            return any(contains_unsafe(item) for item in value)
+        return value == "METRICS_TOKEN"
+
+    return contains_unsafe(document)
+
+
 def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str]:
     try:
         documents = safe_yaml_documents(manifest)
@@ -282,13 +332,19 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                 errors.append(
                     "DSPACE ServiceMonitor bearerTokenSecret name and key must be nonempty"
                 )
-        production_leaks = {"METRICS_TOKEN", "dspace-staging-metrics-token", "sugarkube-int"}
+        production_leaks = {"dspace-staging-metrics-token", "sugarkube-int"}
+        metrics_enabled = (
+            resolved_values_scalar(inputs.values, ("metrics", "enabled")).lower() == "true"
+        )
         if inputs.env == "prod" and (
             service_monitors
             or any(
                 isinstance(doc, dict)
                 and release_associated(doc, inputs.release, allow_name=False)
-                and contains_exact_scalar(doc, production_leaks)
+                and (
+                    contains_exact_scalar(doc, production_leaks)
+                    or contains_unsafe_dspace_metrics_token(doc, candidates, metrics_enabled)
+                )
                 for doc in documents
             )
         ):

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1281,6 +1281,121 @@ data:
     )
 
 
+def test_dspace_production_allows_legacy_pod_uid_metrics_token(tmp_path: Path) -> None:
+    values = tmp_path / "prod-values.yaml"
+    values.write_text("metrics:\n  enabled: false\n", encoding="utf-8")
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (str(values),),
+        "main-deadbee",
+    )
+    manifest = _release_deployment(
+        "dspace",
+        """          env:
+            - name: METRICS_TOKEN
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+---
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: dspace
+""",
+    )
+
+    assert app_chart.validate_rendered_manifest(manifest, inputs) == []
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        "value: literal-token",
+        "valueFrom:\n                secretKeyRef:\n                  name: metrics\n                  key: token",
+        "valueFrom:\n                configMapKeyRef:\n                  name: metrics\n                  key: token",
+        "valueFrom:\n                resourceFieldRef:\n                  resource: limits.cpu",
+        "valueFrom:\n                fieldRef:\n                  fieldPath: metadata.name",
+        "# no value source",
+        "valueFrom: {}",
+        "valueFrom: malformed",
+    ],
+)
+def test_dspace_production_rejects_unsafe_metrics_token_sources(entry: str) -> None:
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (), "main-deadbee"
+    )
+    manifest = _release_deployment(
+        "dspace",
+        f"""          env:
+            - name: METRICS_TOKEN
+              {entry}
+---
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: dspace
+""",
+    )
+
+    assert "DSPACE production rendered staging-only metrics configuration" in (
+        app_chart.validate_rendered_manifest(manifest, inputs)
+    )
+
+
+def test_dspace_production_rejects_pod_uid_metrics_token_on_wrong_container() -> None:
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (), "main-deadbee"
+    )
+    manifest = _release_deployment(
+        "dspace",
+        """        - name: sidecar
+          image: ghcr.io/example/sidecar:main-deadbee
+          env:
+            - name: METRICS_TOKEN
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+---
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: dspace
+""",
+    )
+
+    assert "DSPACE production rendered staging-only metrics configuration" in (
+        app_chart.validate_rendered_manifest(manifest, inputs)
+    )
+
+
+def test_dspace_production_rejects_pod_uid_metrics_token_when_metrics_enabled(
+    tmp_path: Path,
+) -> None:
+    values = tmp_path / "prod-values.yaml"
+    values.write_text("metrics:\n  enabled: true\n", encoding="utf-8")
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (str(values),),
+        "main-deadbee",
+    )
+    manifest = _release_deployment(
+        "dspace",
+        """          env:
+            - name: METRICS_TOKEN
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+---
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: dspace
+""",
+    )
+
+    assert "DSPACE production rendered staging-only metrics configuration" in (
+        app_chart.validate_rendered_manifest(manifest, inputs)
+    )
+
+
 @pytest.mark.parametrize(
     "leak", ["METRICS_TOKEN", "dspace-staging-metrics-token", "sugarkube-int"]
 )


### PR DESCRIPTION
### Motivation

- The existing validator treated every exact scalar `METRICS_TOKEN` in release-associated rendered resources as a staging leak and produced a false positive for the approved DSPACE 3.0.1 / chart 3.0.2 recovery reconciliation. 
- Chart 3.0.2 intentionally renders `METRICS_TOKEN` via the downward API (`valueFrom.fieldRef.fieldPath: metadata.uid`) when `metrics.enabled` is false, which is a safe pod-local token and must be allowed while preserving all other staging-leak protections.

### Description

- Implemented a structure-aware validator `contains_unsafe_dspace_metrics_token` in `scripts/app_chart.py` that recognizes and allows only the exact safe form: an env entry named `METRICS_TOKEN` with `valueFrom.fieldRef.fieldPath == "metadata.uid"` on the intended DSPACE application container when metrics are disabled, and treats all other forms as unsafe.  
- Replaced the blanket `METRICS_TOKEN` scalar rejection with the above structure-aware check while keeping existing production-leak checks for `ServiceMonitor`, `dspace-staging-metrics-token`, `sugarkube-int`, literal values, secret/configmap/resource refs, wrong fieldPaths, wrong containers, and unrelated resources.  
- Added a short inline comment explaining why the exact `metadata.uid` downward-API form is intentionally considered safe for the legacy chart to guide future reviewers.  
- Added focused regression tests in `tests/test_generic_app_just_recipes.py` that assert acceptance of the safe pod-UID token and rejection of literal values, `secretKeyRef`/`configMapKeyRef`/`resourceFieldRef`, incorrect `fieldPath`, malformed/missing `valueFrom`, wrong container placement, presence of ServiceMonitor, and staging-token strings; tests preserve existing release-association behavior.

Files changed: `scripts/app_chart.py`, `tests/test_generic_app_just_recipes.py`.

### Testing

- Ran the focused generic app tests: `python3 -m pytest tests/test_generic_app_just_recipes.py -q` and observed `251 passed`.  
- Ran DSPACE values and release-manifest suites: `python3 -m pytest tests/test_dspace_runtime_values.py -q` (`9 passed`) and `python3 -m pytest tests/test_release_manifest.py -q` (`204 passed`).  
- Ran the focused DSPACE production tests: `python3 -m pytest tests/test_generic_app_just_recipes.py -q -k 'dspace_production'` and observed `22 passed`.  
- Performed repository checks: `git diff --cached | ./scripts/scan-secrets.py` and `git diff --cached --check` completed without issue in this environment.  
- Attempted a full test run (`python3 -m pytest -q`) but the broader suite encountered an unrelated test that requires the `helm` executable which is not available in this environment; the run stopped after many tests passed (environment-limited).  
- `pre-commit`, `pyspelling`, and `linkchecker` were not available in the execution environment so those checks were not run here.  

All focused regression tests covering the safe legacy chart shape and the unsafe variants passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7032c6421c832fa23e5b2b61cac054)