### PR TITLE
Fix DSPACE production metrics render validator false-positive

### DIFF
--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -178,6 +178,49 @@ def contains_exact_scalar(value: object, expected: set[str]) -> bool:
     return isinstance(value, str) and value in expected
 
 
+def count_exact_scalar(value: object, expected: str) -> int:
+    if isinstance(value, dict):
+        return sum(
+            count_exact_scalar(key, expected) + count_exact_scalar(item, expected)
+            for key, item in value.items()
+        )
+    if isinstance(value, list):
+        return sum(count_exact_scalar(item, expected) for item in value)
+    return int(isinstance(value, str) and value == expected)
+
+
+def safe_dspace_metrics_token_count(
+    document: dict[str, object], inputs: ReleaseInputs, metrics_enabled: bool
+) -> int:
+    """Count METRICS_TOKEN entries permitted by the legacy DSPACE chart."""
+    if metrics_enabled or scalar(document.get("kind")) not in {
+        "Deployment",
+        "StatefulSet",
+        "DaemonSet",
+    }:
+        return 0
+    if not release_associated(document, inputs.release, allow_name=False):
+        return 0
+    found, containers = nested_value(document, ("spec", "template", "spec", "containers"))
+    if not found or not isinstance(containers, list):
+        return 0
+    candidates = {inputs.app, inputs.release, *APP_CONTAINER_NAMES.get(inputs.app, set())}
+    safe = 0
+    for container in containers:
+        if not isinstance(container, dict) or scalar(container.get("name")) not in candidates:
+            continue
+        env = container.get("env")
+        for entry in env if isinstance(env, list) else []:
+            # Chart 3.0.2 uses the pod UID as an unpredictable pod-local token to
+            # keep legacy /metrics inaccessible when metrics are disabled.
+            if isinstance(entry, dict) and entry == {
+                "name": "METRICS_TOKEN",
+                "valueFrom": {"fieldRef": {"fieldPath": "metadata.uid"}},
+            }:
+                safe += 1
+    return safe
+
+
 def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str]:
     try:
         documents = safe_yaml_documents(manifest)
@@ -282,15 +325,25 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                 errors.append(
                     "DSPACE ServiceMonitor bearerTokenSecret name and key must be nonempty"
                 )
-        production_leaks = {"METRICS_TOKEN", "dspace-staging-metrics-token", "sugarkube-int"}
+        production_leaks = {"dspace-staging-metrics-token", "sugarkube-int"}
+        metrics_enabled = (
+            resolved_values_scalar(inputs.values, ("metrics", "enabled")).lower() == "true"
+        )
+        associated_documents = [
+            doc
+            for doc in documents
+            if isinstance(doc, dict)
+            and release_associated(doc, inputs.release, allow_name=False)
+        ]
+        unsafe_metrics_token = any(
+            count_exact_scalar(doc, "METRICS_TOKEN")
+            != safe_dspace_metrics_token_count(doc, inputs, metrics_enabled)
+            for doc in associated_documents
+        )
         if inputs.env == "prod" and (
             service_monitors
-            or any(
-                isinstance(doc, dict)
-                and release_associated(doc, inputs.release, allow_name=False)
-                and contains_exact_scalar(doc, production_leaks)
-                for doc in documents
-            )
+            or unsafe_metrics_token
+            or any(contains_exact_scalar(doc, production_leaks) for doc in associated_documents)
         ):
             errors.append("DSPACE production rendered staging-only metrics configuration")
     return errors

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1281,6 +1281,131 @@ data:
     )
 
 
+def _dspace_production_manifest(env_entry: str, container: str = "dspace") -> str:
+    return f"""apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dspace
+  labels:
+    app.kubernetes.io/instance: dspace
+spec:
+  template:
+    spec:
+      containers:
+        - name: {container}
+          image: ghcr.io/example/dspace:main-deadbee
+          env:
+{env_entry}
+---
+kind: Service
+metadata:
+  name: dspace
+  labels:
+    app.kubernetes.io/instance: dspace
+"""
+
+
+def test_dspace_production_allows_legacy_pod_uid_metrics_token() -> None:
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (), "main-deadbee"
+    )
+    manifest = _dspace_production_manifest("""            - name: METRICS_TOKEN
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid""")
+
+    assert app_chart.validate_rendered_manifest(manifest, inputs) == []
+
+
+@pytest.mark.parametrize(
+    "env_entry",
+    [
+        """            - name: METRICS_TOKEN
+              value: literal-token""",
+        """            - name: METRICS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: metrics
+                  key: token""",
+        """            - name: METRICS_TOKEN
+              valueFrom:
+                configMapKeyRef:
+                  name: metrics
+                  key: token""",
+        """            - name: METRICS_TOKEN
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu""",
+        """            - name: METRICS_TOKEN
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name""",
+        """            - name: METRICS_TOKEN""",
+        """            - name: METRICS_TOKEN
+              valueFrom: malformed""",
+    ],
+    ids=[
+        "literal",
+        "secret",
+        "config-map",
+        "resource-field",
+        "incorrect-field",
+        "missing-value-from",
+        "malformed-value-from",
+    ],
+)
+def test_dspace_production_rejects_unsafe_metrics_token_sources(env_entry: str) -> None:
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (), "main-deadbee"
+    )
+
+    errors = app_chart.validate_rendered_manifest(_dspace_production_manifest(env_entry), inputs)
+
+    assert "DSPACE production rendered staging-only metrics configuration" in errors
+
+
+def test_dspace_production_rejects_pod_uid_metrics_token_on_wrong_container() -> None:
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (), "main-deadbee"
+    )
+    manifest = _dspace_production_manifest(
+        """            - name: METRICS_TOKEN
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid""",
+        container="sidecar",
+    )
+
+    errors = app_chart.validate_rendered_manifest(manifest, inputs)
+
+    assert "DSPACE production rendered staging-only metrics configuration" in errors
+
+
+def test_dspace_production_rejects_pod_uid_metrics_token_when_metrics_enabled(
+    tmp_path: Path,
+) -> None:
+    values = tmp_path / "values.yaml"
+    values.write_text("metrics:\n  enabled: true\n", encoding="utf-8")
+    inputs = app_chart.ReleaseInputs(
+        "dspace",
+        "prod",
+        "dspace",
+        "dspace",
+        "chart",
+        "3.0.2",
+        (str(values),),
+        "main-deadbee",
+    )
+    manifest = _dspace_production_manifest("""            - name: METRICS_TOKEN
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid""")
+
+    assert "DSPACE production rendered staging-only metrics configuration" in (
+        app_chart.validate_rendered_manifest(manifest, inputs)
+    )
+
+
 @pytest.mark.parametrize(
     "leak", ["METRICS_TOKEN", "dspace-staging-metrics-token", "sugarkube-int"]
 )


### PR DESCRIPTION
### Motivation

- The production render validator treated any exact scalar `METRICS_TOKEN` as a staging leak and falsely blocked the approved DSPACE 3.0.1 / chart 3.0.2 recovery render which intentionally uses a pod UID downward-API when metrics are disabled.
- The check must remain strict against genuine staging leaks while permitting the single safe legacy form used by chart 3.0.2.

### Description

- Replace the blanket scalar rejection with a structure-aware validation in `scripts/app_chart.py` by adding `count_exact_scalar` and `safe_dspace_metrics_token_count` helpers and using them when evaluating production renders. (files changed: `scripts/app_chart.py`).
- Permit the exact allowed case only when all of these hold: it is an environment entry on the intended DSPACE application container, it has no literal `value`, `valueFrom.fieldRef.fieldPath` equals `metadata.uid`, it does not use other value sources, and the resolved production values do not enable metrics; otherwise continue to reject it.
- Continue rejecting ServiceMonitors, `dspace-staging-metrics-token`, `sugarkube-int`, literal METRICS_TOKEN values, secret/configmap/resourceFieldRef sources, malformed or wrong-field/valueFrom forms, and placement on the wrong container or when metrics are enabled.
- Add focused regression tests in `tests/test_generic_app_just_recipes.py` covering the safe legacy pod-UID token shape, literal and other unsafe sources, malformed/missing `valueFrom`, wrong container, and the metrics-enabled case, while preserving release-association semantics.
- Add a short inline comment next to the downward-API check explaining why the exact `metadata.uid` form is intentionally safe for the legacy chart to prevent future regressions.

### Testing

- Ran focused and broad Python test suites: `python3 -m pytest tests/test_generic_app_just_recipes.py -q` (passed), `python3 -m pytest tests/test_dspace_runtime_values.py -q` (passed), and `python3 -m pytest tests/test_release_manifest.py -q` (passed); combined/full `python3 -m pytest -q` completed successfully (Python test suite passed).
- Ran targeted subset: `python3 -m pytest tests/test_generic_app_just_recipes.py -q -k 'dspace_production or dspace_render_contract or dspace_servicemonitor or dspace_values_ignore'` (all selected tests passed).
- Ran formatting and docs checks: `black` reformatted the two modified files (applied), `black --check` and `linkchecker --no-warnings README.md docs/` succeeded on the modified files and docs links respectively.
- Notes and caveats: `pre-commit run --all-files` remains blocked by unrelated repo-wide trailing-whitespace / multi-document YAML / flake8 findings outside this change; `pyspelling -c .spellcheck.yaml` could not be run in this environment because `aspell` is missing; `scripts/scan-secrets.py` flagged the identifier `unsafe_metrics_token` in staged changes as a false positive (manual inspection confirmed no credential exposure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7032bf685c832f9dc20b8f0d07e839)