### PR TITLE
Fix DSPACE production metrics render validation

### DIFF
--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -178,6 +178,50 @@ def contains_exact_scalar(value: object, expected: set[str]) -> bool:
     return isinstance(value, str) and value in expected
 
 
+def dspace_production_metrics_leak(document: dict[str, object], inputs: ReleaseInputs) -> bool:
+    staging_values = {"dspace-staging-metrics-token", "sugarkube-int"}
+    if contains_exact_scalar(document, staging_values):
+        return True
+
+    def metrics_token_count(value: object) -> int:
+        if isinstance(value, dict):
+            return sum(
+                metrics_token_count(key) + metrics_token_count(item)
+                for key, item in value.items()
+            )
+        if isinstance(value, list):
+            return sum(metrics_token_count(item) for item in value)
+        return int(value == "METRICS_TOKEN")
+
+    token_count = metrics_token_count(document)
+    if not token_count:
+        return False
+    if scalar(document.get("kind")) not in {"Deployment", "StatefulSet", "DaemonSet"}:
+        return True
+    if resolved_values_scalar(inputs.values, ("metrics", "enabled")).lower() == "true":
+        return True
+
+    found, containers = nested_value(document, ("spec", "template", "spec", "containers"))
+    candidates = {inputs.app, inputs.release, *APP_CONTAINER_NAMES.get(inputs.app, set())}
+    safe_entries = 0
+    if found and isinstance(containers, list):
+        for container in containers:
+            if not isinstance(container, dict) or scalar(container.get("name")) not in candidates:
+                continue
+            env = container.get("env")
+            if not isinstance(env, list):
+                continue
+            for entry in env:
+                # Chart 3.0.2 deliberately uses the pod UID as an unpredictable, pod-local
+                # token to keep legacy disabled metrics inaccessible without a Secret.
+                if isinstance(entry, dict) and entry == {
+                    "name": "METRICS_TOKEN",
+                    "valueFrom": {"fieldRef": {"fieldPath": "metadata.uid"}},
+                }:
+                    safe_entries += 1
+    return token_count != safe_entries
+
+
 def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str]:
     try:
         documents = safe_yaml_documents(manifest)
@@ -282,13 +326,12 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                 errors.append(
                     "DSPACE ServiceMonitor bearerTokenSecret name and key must be nonempty"
                 )
-        production_leaks = {"METRICS_TOKEN", "dspace-staging-metrics-token", "sugarkube-int"}
         if inputs.env == "prod" and (
             service_monitors
             or any(
                 isinstance(doc, dict)
                 and release_associated(doc, inputs.release, allow_name=False)
-                and contains_exact_scalar(doc, production_leaks)
+                and dspace_production_metrics_leak(doc, inputs)
                 for doc in documents
             )
         ):

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1281,6 +1281,134 @@ data:
     )
 
 
+def _dspace_production_metrics_manifest(env: str) -> str:
+    return _release_deployment("dspace", env) + """---
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: dspace
+"""
+
+
+def test_dspace_production_allows_legacy_pod_uid_metrics_token_when_disabled(
+    tmp_path: Path,
+) -> None:
+    values = tmp_path / "prod.yaml"
+    values.write_text("metrics:\n  enabled: false\n", encoding="utf-8")
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (str(values),),
+        "main-deadbee", "",
+    )
+    manifest = _dspace_production_metrics_manifest(
+        """          env:
+            - name: METRICS_TOKEN
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+"""
+    )
+
+    assert app_chart.validate_rendered_manifest(manifest, inputs) == []
+    values.write_text("metrics:\n  enabled: true\n", encoding="utf-8")
+    assert "DSPACE production rendered staging-only metrics configuration" in (
+        app_chart.validate_rendered_manifest(manifest, inputs)
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "              value: literal-token\n",
+        """              valueFrom:
+                secretKeyRef: {name: metrics, key: token}
+""",
+        """              valueFrom:
+                configMapKeyRef: {name: metrics, key: token}
+""",
+        """              valueFrom:
+                resourceFieldRef: {resource: limits.cpu}
+""",
+        """              valueFrom:
+                fieldRef: {fieldPath: metadata.name}
+""",
+        "",
+        "              valueFrom: malformed\n",
+    ],
+    ids=[
+        "literal", "secret", "config-map", "resource-field", "wrong-field",
+        "missing-value-from", "malformed-value-from",
+    ],
+)
+def test_dspace_production_rejects_unsafe_metrics_token_sources(source: str) -> None:
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (),
+        "main-deadbee", "",
+    )
+    env = "          env:\n            - name: METRICS_TOKEN\n" + source
+
+    assert "DSPACE production rendered staging-only metrics configuration" in (
+        app_chart.validate_rendered_manifest(_dspace_production_metrics_manifest(env), inputs)
+    )
+
+
+def test_dspace_production_rejects_metrics_token_on_wrong_container() -> None:
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (),
+        "main-deadbee", "",
+    )
+    env = """        - name: sidecar
+          image: ghcr.io/example/sidecar:main-deadbee
+          env:
+            - name: METRICS_TOKEN
+              valueFrom:
+                fieldRef: {fieldPath: metadata.uid}
+"""
+
+    assert "DSPACE production rendered staging-only metrics configuration" in (
+        app_chart.validate_rendered_manifest(_dspace_production_metrics_manifest(env), inputs)
+    )
+
+
+@pytest.mark.parametrize("leak", ["dspace-staging-metrics-token", "sugarkube-int"])
+def test_dspace_production_still_rejects_associated_staging_identifiers(leak: str) -> None:
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (),
+        "main-deadbee", "",
+    )
+    manifest = _dspace_production_metrics_manifest("") + f"""---
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: dspace
+data:
+  leak: {leak}
+"""
+
+    assert "DSPACE production rendered staging-only metrics configuration" in (
+        app_chart.validate_rendered_manifest(manifest, inputs)
+    )
+
+
+def test_dspace_production_still_rejects_associated_service_monitor() -> None:
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (),
+        "main-deadbee", "",
+    )
+    manifest = _dspace_production_metrics_manifest("") + """---
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/instance: dspace
+spec:
+  endpoints:
+    - bearerTokenSecret: {name: metrics, key: token}
+"""
+
+    assert "DSPACE production rendered staging-only metrics configuration" in (
+        app_chart.validate_rendered_manifest(manifest, inputs)
+    )
+
+
 @pytest.mark.parametrize(
     "leak", ["METRICS_TOKEN", "dspace-staging-metrics-token", "sugarkube-int"]
 )


### PR DESCRIPTION
### Motivation

- A blanket scalar check flagged any `METRICS_TOKEN` in release-associated rendered resources as a staging-only leak and produced a false positive for the approved DSPACE chart 3.0.2 recovery render.
- Chart 3.0.2 intentionally renders `METRICS_TOKEN` as a downward-API entry using the pod UID when metrics are disabled, which is safe and must be allowed in production renders.
- The change introduces structure-aware validation so only truly staging-only or unsafe metrics configurations are rejected while preserving existing release-association behavior.

### Description

- Added a focused `dspace_production_metrics_leak(document, inputs)` validator that (a) still flags `dspace-staging-metrics-token` and `sugarkube-int`, (b) counts `METRICS_TOKEN` occurrences and permits only the exact per-container entry `name: METRICS_TOKEN` with `valueFrom.fieldRef.fieldPath: metadata.uid` on the intended DSPACE container when resolved `metrics.enabled` is false, and (c) rejects any other placement, literal value, Secret/ConfigMap/resource refs, malformed sources, or when metrics are enabled.
- Replaced the previous blanket `contains_exact_scalar(..., {

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7032c480cc832f97cc01df3dc61030)