### PR TITLE
Fix bounded DSPACE runtime pod-settling race

### DIFF
--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -423,11 +423,19 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         metadata, spec, status = pod.get("metadata", {}), pod.get("spec", {}), pod.get("status", {})
         if not all(isinstance(value, dict) for value in (metadata, spec, status)):
             fail("pod/replica identity")
+        conditions = status.get("conditions", [])
+        containers = spec.get("containers", [])
+        statuses = status.get("containerStatuses", [])
+        if not all(
+            isinstance(items, list) and all(isinstance(item, dict) for item in items)
+            for items in (conditions, containers, statuses)
+        ):
+            fail("pod/replica identity")
         if metadata.get("deletionTimestamp") is not None or status.get("phase") != "Running":
             fail("pod/replica identity")
         if not any(
             c.get("type") == "Ready" and c.get("status") == "True"
-            for c in status.get("conditions", [])
+            for c in conditions
         ):
             fail("pod/replica identity")
         owner = controller_owner(metadata.get("ownerReferences", []), "ReplicaSet")
@@ -460,8 +468,8 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         rs_owner = controller_owner(rs_owners, "Deployment")
         if rs_owner.get("name") != args.release or rs_owner.get("uid") != deployment_uid:
             fail("pod/replica identity")
-        containers = [c for c in spec.get("containers", []) if c.get("name") == "dspace"]
-        statuses = [c for c in status.get("containerStatuses", []) if c.get("name") == "dspace"]
+        containers = [c for c in containers if c.get("name") == "dspace"]
+        statuses = [c for c in statuses if c.get("name") == "dspace"]
         if len(containers) != 1 or containers[0].get("image") != declared_image:
             fail("pod/replica identity")
         if named_http_port(containers[0], "pod/replica identity") != proxy_port:

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -9,6 +9,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -65,6 +66,8 @@ META_RE = re.compile(
 IMAGE_ID_RE = re.compile(r"sha256:[0-9a-f]{64}$")
 HTML_DOCUMENT_RE = re.compile(r"^\s*(?:<!doctype\s+html\b|<html\b)", re.IGNORECASE)
 PUBLIC_HTTP_USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"
+POD_SETTLE_TIMEOUT_SECONDS = 60.0
+POD_SETTLE_INTERVAL_SECONDS = 2.0
 
 
 class VerificationError(ValueError):
@@ -129,6 +132,37 @@ def command(argv: list[str]) -> str:
     if completed.returncode:
         fail("cluster identity")
     return completed.stdout
+
+
+def settle_selected_pods(
+    argv: list[str],
+    *,
+    runner: Any = None,
+    monotonic: Any = None,
+    sleeper: Any = None,
+) -> list[dict[str, Any]]:
+    """Fetch fresh pod snapshots until selector-matched terminations disappear."""
+    runner = command if runner is None else runner
+    monotonic = time.monotonic if monotonic is None else monotonic
+    sleeper = time.sleep if sleeper is None else sleeper
+    deadline = monotonic() + POD_SETTLE_TIMEOUT_SECONDS
+    while True:
+        try:
+            payload = json.loads(runner(argv))
+            pods = payload.get("items") if isinstance(payload, dict) else None
+        except (json.JSONDecodeError, TypeError):
+            fail("pod/replica identity")
+        if not isinstance(pods, list) or not all(isinstance(pod, dict) for pod in pods):
+            fail("pod/replica identity")
+        if not any(
+            isinstance(pod.get("metadata"), dict)
+            and pod["metadata"].get("deletionTimestamp") is not None
+            for pod in pods
+        ):
+            return pods
+        if monotonic() >= deadline:
+            fail("pod/replica identity")
+        sleeper(POD_SETTLE_INTERVAL_SECONDS)
 
 
 class SameOriginRedirect(urllib.request.HTTPRedirectHandler):
@@ -325,7 +359,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         fail("provider/chat smoke")
 
     selector = f"app.kubernetes.io/name=dspace,app.kubernetes.io/instance={args.release}"
-    raw_pods = command(
+    pods = settle_selected_pods(
         [
             "kubectl",
             "--kubeconfig",
@@ -340,10 +374,6 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
             "json",
         ]
     )
-    try:
-        pods = json.loads(raw_pods).get("items", [])
-    except (json.JSONDecodeError, AttributeError):
-        fail("pod/replica identity")
     if not pods:
         fail("pod/replica identity")
 
@@ -391,6 +421,8 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
     replica_identity: tuple[str, str, str] | None = None
     for pod in pods:
         metadata, spec, status = pod.get("metadata", {}), pod.get("spec", {}), pod.get("status", {})
+        if not all(isinstance(value, dict) for value in (metadata, spec, status)):
+            fail("pod/replica identity")
         if metadata.get("deletionTimestamp") is not None or status.get("phase") != "Running":
             fail("pod/replica identity")
         if not any(

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import json
 import subprocess
 from argparse import Namespace
@@ -366,6 +367,136 @@ def test_derived_http_port_is_used_for_every_direct_request(
     assert len(proxy_urls) == 4
     assert all(":8080/proxy/" in url for url in proxy_urls)
     assert all(":3000/" not in url for url in proxy_urls)
+
+
+def test_verify_refreshes_terminating_snapshot_before_direct_and_smoke(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    args, smoke_calls = _verify_setup(monkeypatch, tmp_path)
+    original = verifier.command
+    settled = json.loads(original(["kubectl", "get", "pods"]))["items"]
+    terminating = deepcopy(settled[0])
+    terminating["metadata"]["name"] = SENTINEL
+    terminating["metadata"]["deletionTimestamp"] = "2026-08-01T09:34:43Z"
+    snapshots = iter([settled + [terminating], settled])
+    pod_fetches = 0
+    direct_urls: list[str] = []
+    sleeps: list[float] = []
+
+    def command(argv: list[str]) -> str:
+        nonlocal pod_fetches
+        if "pods" in argv and "--raw" not in argv:
+            pod_fetches += 1
+            return json.dumps({"items": next(snapshots)})
+        if "--raw" in argv:
+            direct_urls.append(argv[-1])
+        return original(argv)
+
+    monkeypatch.setattr(verifier, "command", command)
+    monkeypatch.setattr(verifier.time, "sleep", sleeps.append)
+
+    verifier.verify(args)
+
+    assert pod_fetches == 2
+    assert sleeps == [verifier.POD_SETTLE_INTERVAL_SECONDS]
+    assert len(direct_urls) == 4
+    assert all(SENTINEL not in url for url in direct_urls)
+    assert len(smoke_calls) == 1
+    assert SENTINEL not in json.dumps(smoke_calls)
+
+
+def test_verify_does_not_refresh_or_wait_for_settled_snapshot(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    args, _ = _verify_setup(monkeypatch, tmp_path)
+    original = verifier.command
+    pod_fetches = 0
+
+    def command(argv: list[str]) -> str:
+        nonlocal pod_fetches
+        if "pods" in argv and "--raw" not in argv:
+            pod_fetches += 1
+        return original(argv)
+
+    monkeypatch.setattr(verifier, "command", command)
+    monkeypatch.setattr(
+        verifier.time, "sleep", lambda _seconds: pytest.fail("settled pods must not sleep")
+    )
+
+    verifier.verify(args)
+
+    assert pod_fetches == 1
+
+
+def test_settle_selected_pods_times_out_without_filtering_or_leaking(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = json.dumps(
+        {
+            "items": [
+                {
+                    "metadata": {
+                        "name": SENTINEL,
+                        "deletionTimestamp": SENTINEL,
+                    }
+                }
+            ]
+        }
+    )
+    fetches: list[list[str]] = []
+    sleeps: list[float] = []
+    times = iter([0.0, 0.0, verifier.POD_SETTLE_TIMEOUT_SECONDS])
+
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.settle_selected_pods(
+            ["kubectl", SENTINEL],
+            runner=lambda argv: fetches.append(argv) or payload,
+            monotonic=lambda: next(times),
+            sleeper=sleeps.append,
+        )
+
+    assert str(raised.value) == "pod/replica identity"
+    assert len(fetches) == 2
+    assert sleeps == [verifier.POD_SETTLE_INTERVAL_SECONDS]
+    captured = capsys.readouterr()
+    assert SENTINEL not in str(raised.value) + captured.out + captured.err
+
+
+@pytest.mark.parametrize(
+    "mutator",
+    [
+        lambda pod: pod["status"].update({"conditions": []}),
+        lambda pod: pod["spec"].update({"containers": []}),
+        lambda pod: pod["metadata"].update({"ownerReferences": []}),
+        lambda pod: pod["status"]["containerStatuses"][0].update(
+            {"imageID": "containerd://sha256:" + "2" * 64}
+        ),
+    ],
+    ids=("unready", "malformed", "incorrect-owner", "wrong-digest"),
+)
+def test_verify_still_rejects_bad_active_pod_after_termination_settles(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, mutator
+) -> None:  # noqa: ANN001
+    args, _ = _verify_setup(monkeypatch, tmp_path)
+    original = verifier.command
+    settled = json.loads(original(["kubectl", "get", "pods"]))["items"]
+    terminating = deepcopy(settled[0])
+    terminating["metadata"]["deletionTimestamp"] = "2026-08-01T09:34:43Z"
+    bad_active = deepcopy(settled)
+    mutator(bad_active[1])
+    snapshots = iter([settled + [terminating], bad_active])
+
+    def command(argv: list[str]) -> str:
+        if "pods" in argv and "--raw" not in argv:
+            return json.dumps({"items": next(snapshots)})
+        return original(argv)
+
+    monkeypatch.setattr(verifier, "command", command)
+    monkeypatch.setattr(verifier.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.verify(args)
+    assert str(raised.value) == "pod/replica identity"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -481,6 +481,52 @@ def test_settle_selected_pods_rejects_non_string_runner_result() -> None:
     assert str(raised.value) == "pod/replica identity"
 
 
+def test_settle_selected_pods_rejects_non_object_pod_without_leaking(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.settle_selected_pods(
+            ["kubectl", "get", "pods"],
+            runner=lambda _argv: json.dumps({"items": [SENTINEL]}),
+        )
+
+    assert str(raised.value) == "pod/replica identity"
+    captured = capsys.readouterr()
+    assert SENTINEL not in str(raised.value) + captured.out + captured.err
+
+
+@pytest.mark.parametrize("section", ["metadata", "spec", "status"])
+def test_verify_rejects_malformed_active_pod_section_after_termination_settles(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    section: str,
+) -> None:
+    args, _ = _verify_setup(monkeypatch, tmp_path)
+    original = verifier.command
+    settled = json.loads(original(["kubectl", "get", "pods"]))["items"]
+    terminating = deepcopy(settled[0])
+    terminating["metadata"]["deletionTimestamp"] = "2026-08-01T09:34:43Z"
+    bad_active = deepcopy(settled)
+    bad_active[1][section] = SENTINEL
+    snapshots = iter([settled + [terminating], bad_active])
+
+    def command(argv: list[str]) -> str:
+        if "pods" in argv and "--raw" not in argv:
+            return json.dumps({"items": next(snapshots)})
+        return original(argv)
+
+    monkeypatch.setattr(verifier, "command", command)
+    monkeypatch.setattr(verifier.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.verify(args)
+
+    assert str(raised.value) == "pod/replica identity"
+    captured = capsys.readouterr()
+    assert SENTINEL not in str(raised.value) + captured.out + captured.err
+
+
 @pytest.mark.parametrize("field", ["conditions", "containers", "containerStatuses"])
 @pytest.mark.parametrize(
     "bad_value", [None, SENTINEL, [SENTINEL]], ids=("none", "non-list", "non-dict")

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -462,6 +462,62 @@ def test_settle_selected_pods_times_out_without_filtering_or_leaking(
     assert SENTINEL not in str(raised.value) + captured.out + captured.err
 
 
+def test_settle_selected_pods_preserves_runner_verification_error() -> None:
+    def runner(_argv: list[str]) -> str:
+        raise verifier.VerificationError("cluster identity")
+
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.settle_selected_pods(["kubectl", "get", "pods"], runner=runner)
+
+    assert str(raised.value) == "cluster identity"
+
+
+def test_settle_selected_pods_rejects_non_string_runner_result() -> None:
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.settle_selected_pods(
+            ["kubectl", "get", "pods"], runner=lambda _argv: {"items": []}
+        )
+
+    assert str(raised.value) == "pod/replica identity"
+
+
+@pytest.mark.parametrize("field", ["conditions", "containers", "containerStatuses"])
+@pytest.mark.parametrize(
+    "bad_value", [None, SENTINEL, [SENTINEL]], ids=("none", "non-list", "non-dict")
+)
+def test_verify_rejects_malformed_active_pod_lists_after_termination_settles(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    field: str,
+    bad_value: object,
+) -> None:
+    args, _ = _verify_setup(monkeypatch, tmp_path)
+    original = verifier.command
+    settled = json.loads(original(["kubectl", "get", "pods"]))["items"]
+    terminating = deepcopy(settled[0])
+    terminating["metadata"]["deletionTimestamp"] = "2026-08-01T09:34:43Z"
+    bad_active = deepcopy(settled)
+    section = "spec" if field == "containers" else "status"
+    bad_active[1][section][field] = bad_value
+    snapshots = iter([settled + [terminating], bad_active])
+
+    def command(argv: list[str]) -> str:
+        if "pods" in argv and "--raw" not in argv:
+            return json.dumps({"items": next(snapshots)})
+        return original(argv)
+
+    monkeypatch.setattr(verifier, "command", command)
+    monkeypatch.setattr(verifier.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.verify(args)
+
+    assert str(raised.value) == "pod/replica identity"
+    captured = capsys.readouterr()
+    assert SENTINEL not in str(raised.value) + captured.out + captured.err
+
+
 @pytest.mark.parametrize(
     "mutator",
     [


### PR DESCRIPTION
### Motivation

Immediately after the successful DSPACE production rolling update for #2325, the runtime verifier failed with `pod/replica identity` because its one-shot selector-matched pod snapshot still contained an old terminating pod. Read-only diagnostics shortly afterward found only the expected ready pods, and the verifier passed without another deployment.

This change removes that bounded post-rollout race without weakening active-pod validation.

### Description

- Add verifier-local `settle_selected_pods` behavior that:
  - fetches the complete selector-matched pod list;
  - waits while any selected pod has a non-null `metadata.deletionTimestamp`;
  - re-fetches the complete list rather than filtering a stale snapshot;
  - uses the repository convention of a 60-second timeout and 2-second non-busy interval.
- Inject command execution, monotonic time, and sleeping dependencies so unit tests remain deterministic and never sleep in real time.
- Fail persistent terminating pods safely as `pod/replica identity` without exposing pod names, payloads, command output, or supplied sentinel values.
- Preserve existing command failures such as cluster connectivity or execution failures as their original `cluster identity` category.
- Validate pod `conditions`, `containers`, and `containerStatuses` as lists of objects before iteration so malformed settled pods fail closed as `pod/replica identity`.
- Preserve strict validation of Running/Ready state, ReplicaSet-to-Deployment ownership, declared image, named HTTP port, runtime digest, direct identity, replica agreement, public identity, chat smoke behavior, and the final concurrent-Helm-change check.

Only the following files changed:

- `scripts/dspace_runtime_verifier.py`
- `tests/test_dspace_runtime_verifier.py`

No deployment candidates, finalized evidence, application/chart pins, Helm values, workflows, manifests, secrets, Kubernetes resources, or DSPACE application code changed. This PR performs no cluster mutation and does not close #2325 or lift the production freeze.

### Testing

Focused deterministic coverage verifies:

- a snapshot containing valid new pods plus an old terminating pod is refreshed and the settled snapshot succeeds;
- direct pod requests and smoke verification use only the fresh snapshot;
- an already-settled snapshot performs no wait or refresh;
- persistent termination reaches the bounded deadline and fails with exactly `pod/replica identity`;
- unready, malformed, incorrectly owned, and wrong-digest active pods remain blocking after settling;
- terminating pods are never merely filtered from a stale snapshot;
- malformed list-typed pod fields fail with the bounded category rather than uncaught type errors;
- runner error categories are preserved and sentinel values are not leaked.

Exact command results:

- `python3 -m pytest -q tests/test_dspace_runtime_verifier.py` — 147 passed.
- `python3 -m pytest -q tests/test_release_manifest.py` — 204 passed.
- `git diff --check` — passed.
- `git diff --cached | ./scripts/scan-secrets.py` — passed.
- `pre-commit run --all-files` — did not complete cleanly because of existing repository-wide YAML parsing and lint failures in unrelated files. Unrelated automatic whitespace/EOF edits were reverted; the scoped whitespace and EOF checks passed.

Related to #2325; does not close it.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70d36a32f0832fb40d910fe2463f7e)