### PR TITLE
Fix bounded DSPACE runtime pod settling race

### DIFF
--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -9,6 +9,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -65,6 +66,8 @@ META_RE = re.compile(
 IMAGE_ID_RE = re.compile(r"sha256:[0-9a-f]{64}$")
 HTML_DOCUMENT_RE = re.compile(r"^\s*(?:<!doctype\s+html\b|<html\b)", re.IGNORECASE)
 PUBLIC_HTTP_USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"
+POD_SETTLE_TIMEOUT_SECONDS = release_manifest.POD_SETTLE_TIMEOUT_SECONDS
+POD_SETTLE_INTERVAL_SECONDS = release_manifest.POD_SETTLE_INTERVAL_SECONDS
 
 
 class VerificationError(ValueError):
@@ -129,6 +132,37 @@ def command(argv: list[str]) -> str:
     if completed.returncode:
         fail("cluster identity")
     return completed.stdout
+
+
+def settle_selected_pods(
+    argv: list[str],
+    *,
+    runner: Any = None,
+    monotonic: Any = None,
+    sleeper: Any = None,
+) -> list[dict[str, Any]]:
+    """Return a fresh, bounded snapshot after terminating selected pods disappear."""
+    runner = command if runner is None else runner
+    monotonic = time.monotonic if monotonic is None else monotonic
+    sleeper = time.sleep if sleeper is None else sleeper
+    deadline = monotonic() + POD_SETTLE_TIMEOUT_SECONDS
+    while True:
+        try:
+            payload = json.loads(runner(argv))
+            pods = payload.get("items") if isinstance(payload, dict) else None
+        except (json.JSONDecodeError, VerificationError):
+            fail("pod/replica identity")
+        if not isinstance(pods, list) or not all(isinstance(pod, dict) for pod in pods):
+            fail("pod/replica identity")
+        if not any(
+            pod.get("metadata", {}).get("deletionTimestamp") is not None
+            for pod in pods
+            if isinstance(pod.get("metadata", {}), dict)
+        ):
+            return pods
+        if monotonic() >= deadline:
+            fail("pod/replica identity")
+        sleeper(POD_SETTLE_INTERVAL_SECONDS)
 
 
 class SameOriginRedirect(urllib.request.HTTPRedirectHandler):
@@ -325,7 +359,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         fail("provider/chat smoke")
 
     selector = f"app.kubernetes.io/name=dspace,app.kubernetes.io/instance={args.release}"
-    raw_pods = command(
+    pods = settle_selected_pods(
         [
             "kubectl",
             "--kubeconfig",
@@ -340,10 +374,6 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
             "json",
         ]
     )
-    try:
-        pods = json.loads(raw_pods).get("items", [])
-    except (json.JSONDecodeError, AttributeError):
-        fail("pod/replica identity")
     if not pods:
         fail("pod/replica identity")
 
@@ -391,6 +421,8 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
     replica_identity: tuple[str, str, str] | None = None
     for pod in pods:
         metadata, spec, status = pod.get("metadata", {}), pod.get("spec", {}), pod.get("status", {})
+        if not all(isinstance(value, dict) for value in (metadata, spec, status)):
+            fail("pod/replica identity")
         if metadata.get("deletionTimestamp") is not None or status.get("phase") != "Running":
             fail("pod/replica identity")
         if not any(

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -678,6 +678,138 @@ def _pod_overrides(mutator) -> dict[str, object]:  # noqa: ANN001
     return {"pods": pods}
 
 
+def test_settle_selected_pods_does_not_refresh_a_settled_snapshot() -> None:
+    calls = 0
+    sleeps: list[float] = []
+
+    def runner(argv: list[str]) -> str:
+        nonlocal calls
+        calls += 1
+        return json.dumps({"items": [{"metadata": {"name": "current"}}]})
+
+    pods = verifier.settle_selected_pods(
+        ["kubectl"], runner=runner, monotonic=lambda: 0.0, sleeper=sleeps.append
+    )
+
+    assert calls == 1
+    assert sleeps == []
+    assert pods[0]["metadata"]["name"] == "current"
+
+
+def test_settle_selected_pods_refreshes_instead_of_filtering_stale_snapshot() -> None:
+    snapshots = iter(
+        [
+            {"items": [{"metadata": {"name": SENTINEL, "deletionTimestamp": "now"}}]},
+            {"items": [{"metadata": {"name": "current"}}]},
+        ]
+    )
+    sleeps: list[float] = []
+
+    pods = verifier.settle_selected_pods(
+        ["kubectl"],
+        runner=lambda argv: json.dumps(next(snapshots)),
+        monotonic=lambda: 0.0,
+        sleeper=sleeps.append,
+    )
+
+    assert sleeps == [verifier.POD_SETTLE_INTERVAL_SECONDS]
+    assert [pod["metadata"]["name"] for pod in pods] == ["current"]
+
+
+def test_settle_selected_pods_times_out_safely_without_leaking(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    times = iter([0.0, 1.0, verifier.POD_SETTLE_TIMEOUT_SECONDS])
+    sleeps: list[float] = []
+    payload = {"items": [{"metadata": {"name": SENTINEL, "deletionTimestamp": SENTINEL}}]}
+
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.settle_selected_pods(
+            ["kubectl", SENTINEL],
+            runner=lambda argv: json.dumps(payload),
+            monotonic=lambda: next(times),
+            sleeper=sleeps.append,
+        )
+
+    assert str(raised.value) == "pod/replica identity"
+    assert sleeps == [verifier.POD_SETTLE_INTERVAL_SECONDS]
+    captured = capsys.readouterr()
+    assert SENTINEL not in str(raised.value) + captured.out + captured.err
+
+
+def test_verify_uses_only_fresh_snapshot_after_terminating_pod(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    args, seen_smoke = _verify_setup(monkeypatch, tmp_path)
+    original = verifier.command
+    fresh = json.loads(original(["kubectl", "pods"]))["items"]
+    stale = {
+        "metadata": {
+            "name": SENTINEL,
+            "deletionTimestamp": SENTINEL,
+            "ownerReferences": SENTINEL,
+        }
+    }
+    snapshots = iter([[*fresh, stale], fresh])
+    pod_fetches = 0
+    direct_paths: list[str] = []
+    sleeps: list[float] = []
+
+    def command(argv: list[str]) -> str:
+        nonlocal pod_fetches
+        if "pods" in argv:
+            pod_fetches += 1
+            return json.dumps({"items": next(snapshots)})
+        if "--raw" in argv:
+            direct_paths.append(argv[-1])
+        return original(argv)
+
+    monkeypatch.setattr(verifier, "command", command)
+    monkeypatch.setattr(verifier.time, "sleep", sleeps.append)
+
+    verifier.verify(args)
+
+    assert pod_fetches == 2
+    assert sleeps == [verifier.POD_SETTLE_INTERVAL_SECONDS]
+    assert len(direct_paths) == 4
+    assert all(SENTINEL not in path for path in direct_paths)
+    assert len(seen_smoke) == 1
+
+
+@pytest.mark.parametrize(
+    "mutator",
+    [
+        lambda pod: pod["status"].update({"conditions": []}),
+        lambda pod: pod.update({"spec": SENTINEL}),
+        lambda pod: pod["metadata"].update({"ownerReferences": []}),
+        lambda pod: pod["status"]["containerStatuses"][0].update(
+            {"imageID": "containerd://sha256:" + "2" * 64}
+        ),
+    ],
+    ids=("unready", "malformed", "wrong-owner", "wrong-digest"),
+)
+def test_verify_fails_closed_for_active_pod_after_settling(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, mutator
+) -> None:  # noqa: ANN001
+    args, _ = _verify_setup(monkeypatch, tmp_path)
+    original = verifier.command
+    active = json.loads(original(["kubectl", "pods"]))["items"]
+    mutator(active[1])
+    terminating = {"metadata": {"name": SENTINEL, "deletionTimestamp": SENTINEL}}
+    snapshots = iter([[terminating], active])
+
+    def command(argv: list[str]) -> str:
+        if "pods" in argv:
+            return json.dumps({"items": next(snapshots)})
+        return original(argv)
+
+    monkeypatch.setattr(verifier, "command", command)
+    monkeypatch.setattr(verifier.time, "sleep", lambda seconds: None)
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.verify(args)
+    assert str(raised.value) == "pod/replica identity"
+
+
 @pytest.mark.parametrize(
     "overrides,category",
     [


### PR DESCRIPTION
### Motivation
- Prevent false `pod/replica identity` failures caused by validating a single stale pod snapshot that still contains a briefly-terminating old pod after a successful rollout. 

### Description
- Add `settle_selected_pods` to `scripts/dspace_runtime_verifier.py` which re-fetches the full selector-matched pod list until no selected pod has a non-null `metadata.deletionTimestamp`, using injected `runner`, `monotonic`, and `sleeper` for deterministic tests. 
- Reuse the release-manifest timeout/interval convention by using `release_manifest.POD_SETTLE_TIMEOUT_SECONDS` and `release_manifest.POD_SETTLE_INTERVAL_SECONDS`. 
- Call the new settling helper before any per-pod validation and add defensive checks so malformed snapshots fail as `pod/replica identity`. 
- Add focused unit tests in `tests/test_dspace_runtime_verifier.py` that exercise fresh snapshots, refresh behavior (no filtering), bounded timeout with redaction, that only settled snapshots are used for direct requests/smoke runs, and that active-but-bad pods still fail closed after settling. 
- Files changed: `scripts/dspace_runtime_verifier.py`, `tests/test_dspace_runtime_verifier.py`.

### Testing
- Ran `python3 -m pytest -q tests/test_dspace_runtime_verifier.py` and observed `137 passed`. 
- Ran `python3 -m pytest -q tests/test_release_manifest.py` and observed `204 passed`. 
- Ran repository checks `git diff --check`, `git diff | ./scripts/scan-secrets.py`, and `git diff --cached | ./scripts/scan-secrets.py` which produced no secrets or diff-check failures for the committed changes. 
- Attempted `pre-commit run --all-files`; the tool was initially not installed in the environment, and after installing it the repository-wide hooks modified unrelated files (trailing-whitespace / EOF fixes) and `check-yaml` reported existing multi-document YAML issues in the repository; these are pre-existing repository-wide issues and not caused by this change, so they were not retained as part of this PR. 

Commands and exact outcomes (summary):
- `python3 -m pytest -q tests/test_dspace_runtime_verifier.py` — 137 passed.
- `python3 -m pytest -q tests/test_release_manifest.py` — 204 passed.
- `git diff --check` — no issues for changed files.
- `git diff | ./scripts/scan-secrets.py` — no secrets detected.
- `git diff --cached | ./scripts/scan-secrets.py` — no secrets detected.
- `pre-commit run --all-files` — could not complete cleanly in this environment due to existing repo-wide formatting/YAML issues (hooks modified unrelated files and `check-yaml` rejected multi-document YAML); these are existing repository problems and were not introduced by this change.

Notes and residual risk
- Waiting is bounded and deterministic in tests via injection; production behavior uses the repository convention (60s timeout, 2s interval). 
- The verifier remains fail-closed: unhealthy, malformed, incorrectly owned, or wrong-digest active pods will still fail with the same error categories. 
- This PR is narrowly scoped to the verifier and its tests; it does not change deployment candidates, manifests, or cluster resources.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70d374ef00832f942076c111ecf0b7)