### PR TITLE
Fix bounded DSPACE verifier pod settling

### DIFF
--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -9,6 +9,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -65,6 +66,8 @@ META_RE = re.compile(
 IMAGE_ID_RE = re.compile(r"sha256:[0-9a-f]{64}$")
 HTML_DOCUMENT_RE = re.compile(r"^\s*(?:<!doctype\s+html\b|<html\b)", re.IGNORECASE)
 PUBLIC_HTTP_USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"
+POD_SETTLE_TIMEOUT_SECONDS = 60.0
+POD_SETTLE_INTERVAL_SECONDS = 2.0
 
 
 class VerificationError(ValueError):
@@ -129,6 +132,34 @@ def command(argv: list[str]) -> str:
     if completed.returncode:
         fail("cluster identity")
     return completed.stdout
+
+
+def settle_selected_pods(
+    argv: list[str], *, runner: Any = None, monotonic: Any = None, sleeper: Any = None
+) -> list[Any]:
+    """Return a fresh complete pod snapshot after bounded termination settling."""
+    runner = command if runner is None else runner
+    monotonic = time.monotonic if monotonic is None else monotonic
+    sleeper = time.sleep if sleeper is None else sleeper
+    deadline = monotonic() + POD_SETTLE_TIMEOUT_SECONDS
+    while True:
+        try:
+            pods = json.loads(runner(argv)).get("items", [])
+        except (json.JSONDecodeError, AttributeError):
+            fail("pod/replica identity")
+        if not isinstance(pods, list) or not pods:
+            fail("pod/replica identity")
+        try:
+            terminating = any(
+                pod.get("metadata", {}).get("deletionTimestamp") is not None for pod in pods
+            )
+        except AttributeError:
+            fail("pod/replica identity")
+        if not terminating:
+            return pods
+        if monotonic() >= deadline:
+            fail("pod/replica identity")
+        sleeper(POD_SETTLE_INTERVAL_SECONDS)
 
 
 class SameOriginRedirect(urllib.request.HTTPRedirectHandler):
@@ -325,7 +356,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         fail("provider/chat smoke")
 
     selector = f"app.kubernetes.io/name=dspace,app.kubernetes.io/instance={args.release}"
-    raw_pods = command(
+    pods = settle_selected_pods(
         [
             "kubectl",
             "--kubeconfig",
@@ -340,13 +371,6 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
             "json",
         ]
     )
-    try:
-        pods = json.loads(raw_pods).get("items", [])
-    except (json.JSONDecodeError, AttributeError):
-        fail("pod/replica identity")
-    if not pods:
-        fail("pod/replica identity")
-
     canonical_image = f"{release_manifest.IMAGE_REF}:{expected['image_tag']}"
     rollback_image = f"{canonical_image}@{expected['digest']}"
     permitted_images = {canonical_image, rollback_image}
@@ -390,7 +414,11 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
 
     replica_identity: tuple[str, str, str] | None = None
     for pod in pods:
+        if not isinstance(pod, dict):
+            fail("pod/replica identity")
         metadata, spec, status = pod.get("metadata", {}), pod.get("spec", {}), pod.get("status", {})
+        if not all(isinstance(value, dict) for value in (metadata, spec, status)):
+            fail("pod/replica identity")
         if metadata.get("deletionTimestamp") is not None or status.get("phase") != "Running":
             fail("pod/replica identity")
         if not any(

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -1,6 +1,7 @@
 import json
 import subprocess
 from argparse import Namespace
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -153,6 +154,7 @@ def _verify_setup(
             }
         )
     pods = override.get("pods", pods)
+    pod_snapshots = iter(override.get("pod_snapshots", []))
     helm_statuses = iter(
         override.get(
             "helm_statuses",
@@ -185,12 +187,15 @@ def _verify_setup(
     )
 
     def command(argv: list[str]) -> str:
+        command_calls = override.get("command_calls")
+        if isinstance(command_calls, list):
+            command_calls.append(argv)
         if argv[0] == "helm":
             if "history" in argv:
                 return json.dumps(next(helm_histories))
             return json.dumps(next(helm_statuses))
         if "pods" in argv:
-            return json.dumps({"items": pods})
+            return json.dumps({"items": next(pod_snapshots, pods)})
         if "deployment" in argv:
             return json.dumps(
                 {
@@ -676,6 +681,103 @@ def _pod_overrides(mutator) -> dict[str, object]:  # noqa: ANN001
         pods.append(pod)
     mutator(pods[1])
     return {"pods": pods}
+
+
+def test_verify_refreshes_complete_snapshot_before_direct_and_smoke_checks(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fresh = _pod_overrides(lambda pod: None)["pods"]
+    terminating = deepcopy(fresh[0])
+    terminating["metadata"]["name"] = SENTINEL
+    terminating["metadata"]["deletionTimestamp"] = SENTINEL
+    calls: list[list[str]] = []
+    sleeps: list[float] = []
+    args, smoke_calls = _verify_setup(
+        monkeypatch,
+        tmp_path,
+        overrides={
+            "pod_snapshots": [fresh + [terminating], fresh],
+            "command_calls": calls,
+        },
+    )
+    monkeypatch.setattr(verifier.time, "sleep", sleeps.append)
+
+    verifier.verify(args)
+
+    pod_lists = [call for call in calls if "pods" in call]
+    direct_calls = [call for call in calls if "/pods/" in call[-1]]
+    assert len(pod_lists) == 2
+    assert sleeps == [verifier.POD_SETTLE_INTERVAL_SECONDS]
+    assert len(direct_calls) == 4
+    assert all(SENTINEL not in call[-1] for call in direct_calls)
+    assert len(smoke_calls) == 1
+    assert SENTINEL not in json.dumps(smoke_calls)
+
+
+def test_verify_does_not_refresh_or_wait_for_settled_snapshot(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[list[str]] = []
+    sleeps: list[float] = []
+    args, _ = _verify_setup(monkeypatch, tmp_path, overrides={"command_calls": calls})
+    monkeypatch.setattr(verifier.time, "sleep", sleeps.append)
+
+    verifier.verify(args)
+
+    assert len([call for call in calls if "pods" in call]) == 1
+    assert sleeps == []
+
+
+def test_terminating_pod_deadline_fails_redacted_identity_category(capsys) -> None:  # noqa: ANN001
+    payload = json.dumps(
+        {"items": [{"metadata": {"name": SENTINEL, "deletionTimestamp": SENTINEL}}]}
+    )
+    times = iter((0.0, 0.0, verifier.POD_SETTLE_TIMEOUT_SECONDS))
+    sleeps: list[float] = []
+    requests: list[list[str]] = []
+
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.settle_selected_pods(
+            [SENTINEL],
+            runner=lambda argv: requests.append(argv) or payload,
+            monotonic=lambda: next(times),
+            sleeper=sleeps.append,
+        )
+
+    assert str(raised.value) == "pod/replica identity"
+    assert SENTINEL not in str(raised.value)
+    captured = capsys.readouterr()
+    assert captured.out == captured.err == ""
+    assert len(requests) == 2
+    assert sleeps == [verifier.POD_SETTLE_INTERVAL_SECONDS]
+
+
+@pytest.mark.parametrize("fault", ("unready", "malformed", "wrong-owner", "wrong-digest"))
+def test_verify_fails_closed_after_terminating_pod_disappears(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, fault: str
+) -> None:
+    fresh = _pod_overrides(lambda pod: None)["pods"]
+    terminating = deepcopy(fresh[0])
+    terminating["metadata"]["deletionTimestamp"] = SENTINEL
+    bad = deepcopy(fresh)
+    if fault == "unready":
+        bad[1]["status"]["conditions"] = []
+    elif fault == "malformed":
+        bad[1]["spec"] = None
+    elif fault == "wrong-owner":
+        bad[1]["metadata"]["ownerReferences"][0]["uid"] = "wrong"
+    else:
+        bad[1]["status"]["containerStatuses"][0]["imageID"] = "containerd://sha256:" + "2" * 64
+    args, _ = _verify_setup(
+        monkeypatch, tmp_path, overrides={"pod_snapshots": [fresh + [terminating], bad]}
+    )
+    monkeypatch.setattr(verifier.time, "sleep", lambda seconds: None)
+
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.verify(args)
+
+    assert str(raised.value) == "pod/replica identity"
+    assert SENTINEL not in str(raised.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation

- A completed Kubernetes rollout can briefly expose an old selector-matched pod with a non-null `metadata.deletionTimestamp`, causing the verifier to fail `pod/replica identity` on a stale one-shot snapshot.

### Description

- Add a verifier-local, bounded settling helper `settle_selected_pods` that re-fetches the complete selector-matched pod list and waits (non-busy) while any selected pod is terminating, using the repository convention of a 60s timeout and 2s interval.
- Use the helper in `verify()` so the verifier proceeds only after a fresh snapshot contains no terminating pods and never merely filters terminating pods from a stale snapshot.
- Preserve fail-closed behaviour: timeout, malformed snapshots, terminating/non-running/unready active pods, incorrect ownership, or wrong digests still fail as `pod/replica identity` and error messages remain redacted of sensitive values.
- Add deterministic tests and small test-fixture extensions to exercise: refresh-then-succeed, direct/smoke checks using only the settled snapshot, no-wait path for already-settled snapshots, deadline failure that yields the redacted category, and active-pod failures after settling.
- Add small defensive checks validating that pod/metadata/spec/status are well-shaped before further validation.

### Testing

- Ran `python3 -m pytest -q tests/test_dspace_runtime_verifier.py` and observed `136 passed`.
- Ran `python3 -m pytest -q tests/test_release_manifest.py` and observed `204 passed`.
- Ran formatting/lint/CI checks used during development:
  - `git diff --check` — no issues reported.
  - `git diff --cached | ./scripts/scan-secrets.py` — passed.
  - `python3 -m black --check scripts/dspace_runtime_verifier.py tests/test_dspace_runtime_verifier.py` — both files unchanged.
  - `pre-commit run --files scripts/dspace_runtime_verifier.py tests/test_dspace_runtime_verifier.py` — file-level hygiene hooks passed, but the repository-wide `run-checks` hook surfaced pre-existing Flake8 issues in unrelated files.
  - `pre-commit run --all-files` — failed due to pre-existing repository-wide hygiene issues (hooks modified unrelated files and `check-yaml` rejected existing multi-document YAML templates); these failures are pre-existing and unrelated to the changes in this PR.

Changed files: `scripts/dspace_runtime_verifier.py`, `tests/test_dspace_runtime_verifier.py`.

Notes: the change is intentionally minimal and local to the verifier and its tests; it follows the existing `POD_SETTLE_TIMEOUT_SECONDS` / `POD_SETTLE_INTERVAL_SECONDS` convention and makes pod-wait timing injectable for deterministic unit tests. Pre-commit failures reported above are repository-wide, pre-existing issues and were not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70d3773778832f97710abe99f2f530)