### PR TITLE
Fix bounded DSPACE runtime pod settling race

### DIFF
--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -9,6 +9,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -65,6 +66,8 @@ META_RE = re.compile(
 IMAGE_ID_RE = re.compile(r"sha256:[0-9a-f]{64}$")
 HTML_DOCUMENT_RE = re.compile(r"^\s*(?:<!doctype\s+html\b|<html\b)", re.IGNORECASE)
 PUBLIC_HTTP_USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"
+POD_SETTLE_TIMEOUT_SECONDS = release_manifest.POD_SETTLE_TIMEOUT_SECONDS
+POD_SETTLE_INTERVAL_SECONDS = release_manifest.POD_SETTLE_INTERVAL_SECONDS
 
 
 class VerificationError(ValueError):
@@ -129,6 +132,36 @@ def command(argv: list[str]) -> str:
     if completed.returncode:
         fail("cluster identity")
     return completed.stdout
+
+
+def settle_selected_pods(
+    argv: list[str],
+    *,
+    runner: Any = None,
+    monotonic: Any = None,
+    sleeper: Any = None,
+) -> list[dict[str, Any]]:
+    """Return a fresh, settled snapshot of all selector-matched pods."""
+    runner = command if runner is None else runner
+    monotonic = time.monotonic if monotonic is None else monotonic
+    sleeper = time.sleep if sleeper is None else sleeper
+    deadline = monotonic() + POD_SETTLE_TIMEOUT_SECONDS
+    while True:
+        try:
+            items = json.loads(runner(argv)).get("items")
+        except (json.JSONDecodeError, AttributeError, VerificationError):
+            fail("pod/replica identity")
+        if not isinstance(items, list) or not all(isinstance(item, dict) for item in items):
+            fail("pod/replica identity")
+        if not any(
+            item.get("metadata", {}).get("deletionTimestamp") is not None
+            for item in items
+            if isinstance(item.get("metadata", {}), dict)
+        ):
+            return items
+        if monotonic() >= deadline:
+            fail("pod/replica identity")
+        sleeper(POD_SETTLE_INTERVAL_SECONDS)
 
 
 class SameOriginRedirect(urllib.request.HTTPRedirectHandler):
@@ -325,7 +358,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         fail("provider/chat smoke")
 
     selector = f"app.kubernetes.io/name=dspace,app.kubernetes.io/instance={args.release}"
-    raw_pods = command(
+    pods = settle_selected_pods(
         [
             "kubectl",
             "--kubeconfig",
@@ -340,10 +373,6 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
             "json",
         ]
     )
-    try:
-        pods = json.loads(raw_pods).get("items", [])
-    except (json.JSONDecodeError, AttributeError):
-        fail("pod/replica identity")
     if not pods:
         fail("pod/replica identity")
 

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -153,6 +153,7 @@ def _verify_setup(
             }
         )
     pods = override.get("pods", pods)
+    pod_snapshots = iter(override.get("pod_snapshots", []))
     helm_statuses = iter(
         override.get(
             "helm_statuses",
@@ -190,7 +191,7 @@ def _verify_setup(
                 return json.dumps(next(helm_histories))
             return json.dumps(next(helm_statuses))
         if "pods" in argv:
-            return json.dumps({"items": pods})
+            return json.dumps({"items": next(pod_snapshots, pods)})
         if "deployment" in argv:
             return json.dumps(
                 {
@@ -676,6 +677,124 @@ def _pod_overrides(mutator) -> dict[str, object]:  # noqa: ANN001
         pods.append(pod)
     mutator(pods[1])
     return {"pods": pods}
+
+
+def test_verify_refreshes_terminating_snapshot_before_direct_and_smoke_checks(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fresh = _pod_overrides(lambda pod: None)["pods"]
+    terminating = {
+        "metadata": {"name": SENTINEL, "deletionTimestamp": SENTINEL},
+        "status": {"phase": "Failed"},
+    }
+    args, smoke_calls = _verify_setup(
+        monkeypatch,
+        tmp_path,
+        overrides={"pod_snapshots": [[*fresh, terminating], fresh]},
+    )
+    original = verifier.command
+    pod_fetches = 0
+    direct_urls: list[str] = []
+
+    def command(argv: list[str]) -> str:
+        nonlocal pod_fetches
+        if "pods" in argv and "--raw" not in argv:
+            pod_fetches += 1
+        if "--raw" in argv:
+            direct_urls.append(argv[-1])
+        return original(argv)
+
+    monkeypatch.setattr(verifier, "command", command)
+    sleeps: list[float] = []
+    monkeypatch.setattr(verifier.time, "sleep", sleeps.append)
+
+    verifier.verify(args)
+
+    assert pod_fetches == 2
+    assert sleeps == [verifier.POD_SETTLE_INTERVAL_SECONDS]
+    assert len(direct_urls) == 4
+    assert all(SENTINEL not in url for url in direct_urls)
+    assert len(smoke_calls) == 1
+
+
+def test_verify_does_not_wait_or_refresh_an_already_settled_snapshot(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    args, _ = _verify_setup(monkeypatch, tmp_path)
+    original = verifier.command
+    pod_fetches = 0
+
+    def command(argv: list[str]) -> str:
+        nonlocal pod_fetches
+        if "pods" in argv and "--raw" not in argv:
+            pod_fetches += 1
+        return original(argv)
+
+    monkeypatch.setattr(verifier, "command", command)
+    monkeypatch.setattr(
+        verifier.time,
+        "sleep",
+        lambda seconds: pytest.fail("settled pods must not cause a wait"),
+    )
+    verifier.verify(args)
+    assert pod_fetches == 1
+
+
+def test_terminating_pod_timeout_is_bounded_and_redacted(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = json.dumps(
+        {"items": [{"metadata": {"name": SENTINEL, "deletionTimestamp": SENTINEL}}]}
+    )
+    sleeps: list[float] = []
+    clock = iter((0.0, verifier.POD_SETTLE_TIMEOUT_SECONDS))
+
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.settle_selected_pods(
+            [SENTINEL],
+            runner=lambda argv: payload,
+            monotonic=lambda: next(clock),
+            sleeper=sleeps.append,
+        )
+
+    assert str(raised.value) == "pod/replica identity"
+    assert sleeps == []
+    captured = capsys.readouterr()
+    assert SENTINEL not in str(raised.value) + captured.out + captured.err
+
+
+@pytest.mark.parametrize(
+    "mutator",
+    [
+        lambda pod: pod["status"]["conditions"].clear(),
+        lambda pod: pod["metadata"].update({"ownerReferences": SENTINEL}),
+        lambda pod: pod["metadata"]["ownerReferences"][0].update({"uid": SENTINEL}),
+        lambda pod: pod["status"]["containerStatuses"][0].update(
+            {"imageID": "containerd://sha256:" + "2" * 64}
+        ),
+    ],
+    ids=("unready", "malformed", "wrong-owner", "wrong-digest"),
+)
+def test_refresh_does_not_forgive_bad_active_pods(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, mutator
+) -> None:  # noqa: ANN001
+    settled = _pod_overrides(mutator)["pods"]
+    initial = [
+        *_pod_overrides(lambda pod: None)["pods"],
+        {"metadata": {"name": SENTINEL, "deletionTimestamp": SENTINEL}},
+    ]
+    args, _ = _verify_setup(
+        monkeypatch,
+        tmp_path,
+        overrides={"pod_snapshots": [initial, settled]},
+    )
+    monkeypatch.setattr(verifier.time, "sleep", lambda seconds: None)
+
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.verify(args)
+
+    assert str(raised.value) == "pod/replica identity"
+    assert SENTINEL not in str(raised.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation
- The runtime verifier could false-fail immediately after a successful rolling update because Kubernetes may briefly expose an old selector-matched pod with a non-null `metadata.deletionTimestamp` in the initial snapshot.
- The verifier must refresh the complete selector-matched pod list boundedly (rather than filtering a stale snapshot) before validating each active pod so transient terminating pods do not cause spurious `pod/replica identity` failures.

### Description
- Add a verifier-local helper `settle_selected_pods` to `scripts/dspace_runtime_verifier.py` that re-fetches the full selector-matched pod list while any pod in the snapshot has a non-null `metadata.deletionTimestamp`, using the repository’s established timeout/interval (`release_manifest.POD_SETTLE_TIMEOUT_SECONDS` / `release_manifest.POD_SETTLE_INTERVAL_SECONDS`).
- Integrate the settled fresh snapshot into `verify()` so all subsequent checks (phase, Ready condition, ownership via ReplicaSet -> Deployment, image/digest, HTTP port, direct/public identity, and smoke runner) operate only on the refreshed snapshot.
- Make timing and waits deterministic/testable by accepting `runner`, `monotonic`, and `sleeper`-style injection in the helper so tests do not sleep in real time and redaction of sensitive values is preserved on failures.
- Add focused tests in `tests/test_dspace_runtime_verifier.py` that assert: the first snapshot with a terminating pod is refreshed and later validated; direct requests and smoke verification use only the fresh snapshot; already-settled snapshots cause no extra wait; a persistent terminating pod times out and fails as `pod/replica identity` (without leaking sentinel content); and that bad active pods continue to fail normally after settling.

### Testing
- Ran `python3 -m pytest -q tests/test_dspace_runtime_verifier.py` and observed `136 passed`.
- Ran `python3 -m pytest -q tests/test_release_manifest.py` and observed `204 passed`.
- Ran `git diff --check` which reported no issue for the focused changes and ran `git diff --cached | ./scripts/scan-secrets.py` which passed for the staged diff.
- Ran `pre-commit run --all-files` which could not complete cleanly because repository-wide whitespace/EOF hooks modified unrelated baseline files and the YAML hook rejects existing multi-document Kubernetes YAML/Helm templates; those unrelated hook edits were reverted and the focused verification tests and diff checks above pass.

Files changed: `scripts/dspace_runtime_verifier.py`, `tests/test_dspace_runtime_verifier.py`.

Residual risk / follow-ups: run repository-wide `pre-commit` in a fuller environment to reconcile unrelated YAML multi-document policies if desired, but the change is intentionally minimal and covered by targeted unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70d3795568832fb68db63acaba818d)