### PR TITLE
Pin DSPACE staging chart to provenance-bearing 3.1.1

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -321,7 +321,7 @@ verification uses the same command with `env=prod` and a production candidate or
 | Release | `dspace` |
 | Namespace | `dspace` |
 | App config | `docs/examples/apps/dspace.env` |
-| Chart version pins | Shared/default `docs/apps/dspace.version`; staging `docs/apps/dspace.staging.version` (`3.1.0`); production `docs/apps/dspace.prod.version` (`3.0.2`) |
+| Chart version pins | Shared/default `docs/apps/dspace.version`; staging `docs/apps/dspace.staging.version` (chart `3.1.1` for application `3.1.0`); production `docs/apps/dspace.prod.version` (`3.0.2`) |
 | Production tag pin | `docs/apps/dspace.prod.tag` |
 | Verify paths | `/config.json`, `/healthz`, `/livez` |
 
@@ -347,7 +347,7 @@ Use these links before changing a deployment so the workflow runs, package versi
 - `env=dev`: future single-node/non-HA environment using `docs/examples/dspace.values.dev.yaml`.
   The dev overlay intentionally does not choose a token.place origin; developers who need local runtime routing can copy `docs/examples/apps/dspace.env` to a local app config and add chart-supported `env` entries to their private values file.
 - `env=staging`: HA staging on the staging Sugarkube cluster with host `staging.democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
-  The staging overlay injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`, uses chart `3.1.0`, and persists the authenticated metrics ServiceMonitor configuration discovered by kube-prometheus-stack. The metrics bearer value is not committed; operators manage the existing `dspace-staging-metrics-token` Secret out of band.
+  The configured staging target injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`, uses provenance-bearing chart `3.1.1` for DSPACE application `3.1.0`, and persists the authenticated metrics ServiceMonitor configuration discovered by kube-prometheus-stack. This pin does not assert that staging has already been restored; the live cluster remains on the validated DSPACE `3.0.1` recovery deployment at Helm revision 26 until guarded restoration. The metrics bearer value is not committed; operators manage the existing `dspace-staging-metrics-token` Secret out of band.
 - `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
   The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`. Production is pinned to recovery chart `3.0.2` and image `ghcr.io/democratizedspace/dspace:main-1a31a56`; it does not enable metrics or ServiceMonitor settings.
 - Optional legacy/canary host `prod.democratized.space` uses `docs/examples/dspace.values.prod-subdomain.yaml`. The `dspace-oci-deploy-prod-subdomain` compatibility command selects the secret-free `docs/examples/apps/dspace-prod-subdomain.env` config, preserving that overlay while routing through the same manifest validation, OCI preflight, Helm deployment, and evidence finalization as the generic production path.

--- a/docs/apps/dspace.staging.version
+++ b/docs/apps/dspace.staging.version
@@ -1,2 +1,3 @@
-# DSPACE staging chart pin. Staging uses chart 3.1.0 for authenticated metrics.
-3.1.0
+# DSPACE staging chart pin. Chart 3.1.1 packages DSPACE application 3.1.0 and supplies
+# the required immutable OCI provenance.
+3.1.1

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -104,7 +104,9 @@ def test_dspace_chart_pins_resolve_staging_and_prod_versions() -> None:
     staging = load_config("dspace", "staging")
     prod = load_config("dspace", "prod")
 
-    assert _first_pin_value(REPO_ROOT / staging["SUGARKUBE_VERSION_FILE"]) == "3.1.0"
+    assert staging["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.staging.version"
+    assert _first_pin_value(REPO_ROOT / staging["SUGARKUBE_VERSION_FILE"]) == "3.1.1"
+    assert prod["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.prod.version"
     assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.2"
 
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2708,7 +2708,7 @@ def _write_dspace_candidate(
         "sourceRevision": "abcdef0123456789abcdef0123456789abcdef01",
         "imageTag": "main-abcdef0",
         "imageDigest": image_digest or "sha256:" + "1" * 64,
-        "chartVersion": "3.1.0" if environment == "staging" else "3.0.2",
+        "chartVersion": "3.1.1" if environment == "staging" else "3.0.2",
         "chartDigest": "sha256:" + "2" * 64,
         "semanticTag": "v3.2.0",
         "recordType": "candidate",


### PR DESCRIPTION
### Motivation

- Ensure Sugarkube's configured DSPACE staging chart is the provenance-bearing package while keeping the deployed application target at DSPACE 3.1.0 and leaving production recovery pins untouched.
- Provide an authoritative, durable pin (with comment) so guarded restoration can use the immutable OCI provenance produced by DSPACE chart publication.

### Description

- Update `docs/apps/dspace.staging.version` to set the only non-comment value to `3.1.1` and add a comment clarifying that chart `3.1.1` packages DSPACE application `3.1.0` and supplies immutable OCI provenance.
- Update `docs/apps/dspace.md` to document the configured staging target as chart `3.1.1` (application `3.1.0`) and explicitly note that the live staging cluster remains on the validated DSPACE `3.0.1` recovery deployment until guarded restoration.
- Adjust focused tests: change `tests/test_dspace_runtime_values.py` to assert staging resolves to `docs/apps/dspace.staging.version` → `3.1.1` and preserve prod expectation `docs/apps/dspace.prod.version` → `3.0.2`.
- Align the narrow guarded-deploy fixture used by recipes by updating `tests/test_generic_app_just_recipes.py` so synthetic staging candidates use `chartVersion: 3.1.1` while production scenarios remain `3.0.2`.
- Files changed: `docs/apps/dspace.staging.version`, `docs/apps/dspace.md`, `tests/test_dspace_runtime_values.py`, `tests/test_generic_app_just_recipes.py`.

### Testing

- Resolved app configs: `python3 scripts/app_config.py json --app dspace --env staging` resolved `SUGARKUBE_VERSION_FILE=docs/apps/dspace.staging.version` whose first non-comment pin is `3.1.1`, and `python3 scripts/app_config.py json --app dspace --env prod` resolved `docs/apps/dspace.prod.version` -> `3.0.2` (both OK).
- Unit/integration tests run: `python3 -m pytest -q tests/test_dspace_runtime_values.py tests/test_app_config.py` — all focused tests passed (63 passed).
- Broader recipe tests: `python3 -m pytest -q tests/test_generic_app_just_recipes.py` — passed after updating the synthetic staging fixture (254 passed).
- Repo checks: `git diff --check` and `git diff | python3 scripts/scan-secrets.py` completed with no issues for the focused diff.
- Docs/tooling checks: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` completed successfully (linkcheck: 207 links checked, 0 warnings/errors).
- `pre-commit run --all-files` was attempted but remains blocked by pre-existing repository-wide `check-yaml` multi-document/Helm-template YAML and unrelated flake8 findings outside this narrow change, so no automatic formatting or broad repo churn was applied.

All changes are narrowly scoped to the DSPACE staging chart pin, its focused tests, and the directly associated runbook text; production pins, image tags/digests, values files, workflows, and recovery records were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a715963493c832fb4f5da5358ec3174)