### PR TITLE
Pin DSPACE staging chart to provenance-bearing 3.1.1

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -321,7 +321,7 @@ verification uses the same command with `env=prod` and a production candidate or
 | Release | `dspace` |
 | Namespace | `dspace` |
 | App config | `docs/examples/apps/dspace.env` |
-| Chart version pins | Shared/default `docs/apps/dspace.version`; staging `docs/apps/dspace.staging.version` (`3.1.0`); production `docs/apps/dspace.prod.version` (`3.0.2`) |
+| Chart version pins | Shared/default `docs/apps/dspace.version`; staging `docs/apps/dspace.staging.version` (`3.1.1`, packaging DSPACE application `3.1.0`); production `docs/apps/dspace.prod.version` (`3.0.2`) |
 | Production tag pin | `docs/apps/dspace.prod.tag` |
 | Verify paths | `/config.json`, `/healthz`, `/livez` |
 
@@ -347,7 +347,7 @@ Use these links before changing a deployment so the workflow runs, package versi
 - `env=dev`: future single-node/non-HA environment using `docs/examples/dspace.values.dev.yaml`.
   The dev overlay intentionally does not choose a token.place origin; developers who need local runtime routing can copy `docs/examples/apps/dspace.env` to a local app config and add chart-supported `env` entries to their private values file.
 - `env=staging`: HA staging on the staging Sugarkube cluster with host `staging.democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
-  The staging overlay injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`, uses chart `3.1.0`, and persists the authenticated metrics ServiceMonitor configuration discovered by kube-prometheus-stack. The metrics bearer value is not committed; operators manage the existing `dspace-staging-metrics-token` Secret out of band.
+  The staging overlay injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`, is configured for provenance-bearing chart `3.1.1`, which packages DSPACE application `3.1.0`, and persists the authenticated metrics ServiceMonitor configuration discovered by kube-prometheus-stack. The metrics bearer value is not committed; operators manage the existing `dspace-staging-metrics-token` Secret out of band.
 - `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
   The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`. Production is pinned to recovery chart `3.0.2` and image `ghcr.io/democratizedspace/dspace:main-1a31a56`; it does not enable metrics or ServiceMonitor settings.
 - Optional legacy/canary host `prod.democratized.space` uses `docs/examples/dspace.values.prod-subdomain.yaml`. The `dspace-oci-deploy-prod-subdomain` compatibility command selects the secret-free `docs/examples/apps/dspace-prod-subdomain.env` config, preserving that overlay while routing through the same manifest validation, OCI preflight, Helm deployment, and evidence finalization as the generic production path.

--- a/docs/apps/dspace.staging.version
+++ b/docs/apps/dspace.staging.version
@@ -1,2 +1,2 @@
-# DSPACE staging chart pin. Staging uses chart 3.1.0 for authenticated metrics.
-3.1.0
+# DSPACE staging chart pin. Chart 3.1.1 packages DSPACE application 3.1.0 and supplies the required immutable OCI provenance.
+3.1.1

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -104,7 +104,9 @@ def test_dspace_chart_pins_resolve_staging_and_prod_versions() -> None:
     staging = load_config("dspace", "staging")
     prod = load_config("dspace", "prod")
 
-    assert _first_pin_value(REPO_ROOT / staging["SUGARKUBE_VERSION_FILE"]) == "3.1.0"
+    assert staging["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.staging.version"
+    assert _first_pin_value(REPO_ROOT / staging["SUGARKUBE_VERSION_FILE"]) == "3.1.1"
+    assert prod["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.prod.version"
     assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.2"
 
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -188,7 +188,7 @@ if [ "${{1:-}}" = upgrade ]; then
   done
 fi
 if [[ "$*" == *"status dspace --namespace dspace -o json" ]]; then
-  chart_version="${{SUGARKUBE_STUB_CHART_VERSION:-3.1.0}}"
+  chart_version="${{SUGARKUBE_STUB_CHART_VERSION:-3.1.1}}"
   if [ -z "${{SUGARKUBE_STUB_CHART_VERSION:-}}" ] && [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" = prod ]; then chart_version=3.0.2; fi
   description="$(cat {str(tmp_path / "helm-description")!r} 2>/dev/null || true)"
   revision=7
@@ -214,7 +214,7 @@ if [[ "$*" == show\ chart* ]]; then
   if [[ "$*" == *"charts/dspace"* ]]; then
     version="${{*: -1}}"
     if [[ "$version" == oci://*@sha256:* ]]; then
-      version="${{SUGARKUBE_STUB_CHART_VERSION:-3.1.0}}"
+      version="${{SUGARKUBE_STUB_CHART_VERSION:-3.1.1}}"
       if [ -z "${{SUGARKUBE_STUB_CHART_VERSION:-}}" ] && [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" = prod ]; then version=3.0.2; fi
     fi
     printf 'apiVersion: v2\nname: dspace\nversion: %s\nappVersion: main-abcdef0\n' "$version"
@@ -2708,7 +2708,7 @@ def _write_dspace_candidate(
         "sourceRevision": "abcdef0123456789abcdef0123456789abcdef01",
         "imageTag": "main-abcdef0",
         "imageDigest": image_digest or "sha256:" + "1" * 64,
-        "chartVersion": "3.1.0" if environment == "staging" else "3.0.2",
+        "chartVersion": "3.1.1" if environment == "staging" else "3.0.2",
         "chartDigest": "sha256:" + "2" * 64,
         "semanticTag": "v3.2.0",
         "recordType": "candidate",
@@ -3198,7 +3198,7 @@ def test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates(
 
     _write_dspace_candidate(prod_manifest, "prod")
     prod_record = json.loads(prod_manifest.read_text(encoding="utf-8"))
-    prod_record["chartVersion"] = "3.1.0"
+    prod_record["chartVersion"] = "3.1.1"
     prod_manifest.write_text(json.dumps(prod_record) + "\n", encoding="utf-8")
     config = tmp_path / "dspace.env"
     config.write_text(
@@ -3208,7 +3208,7 @@ def test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates(
                 "SUGARKUBE_RELEASE=dspace",
                 "SUGARKUBE_NAMESPACE=dspace",
                 "SUGARKUBE_CHART=oci://ghcr.io/democratizedspace/charts/dspace",
-                "SUGARKUBE_VERSION=3.1.0",
+                "SUGARKUBE_VERSION=3.1.1",
                 "SUGARKUBE_PROD_TAG_FILE=docs/apps/dspace.prod.tag",
                 "SUGARKUBE_VALUES_DEV=docs/examples/dspace.values.dev.yaml",
                 "SUGARKUBE_VALUES_STAGING=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml",
@@ -3218,7 +3218,7 @@ def test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates(
         + "\n",
         encoding="utf-8",
     )
-    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.1.0"
+    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.1.1"
     env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
     runtime_log = Path(env["RUNTIME_VERIFIER_LOG"])
     runtime_log.write_text("", encoding="utf-8")


### PR DESCRIPTION
### Motivation

- Ensure Sugarkube staging references the provenance-bearing DSPACE chart `3.1.1` while keeping the deployed application target (appVersion) at `3.1.0` so a later guarded restoration can validate immutable provenance. 
- Preserve production recovery coordinates and immutable image pinning (`docs/apps/dspace.prod.version` = `3.0.2`, production tag `main-1a31a56`) and avoid any changes to values, providers, evidence, or cluster resources.

### Description

- Update `docs/apps/dspace.staging.version` to change the non-comment pin value from `3.1.0` to `3.1.1` and replace the comment to explain that chart `3.1.1` packages DSPACE application `3.1.0` and supplies immutable OCI provenance. 
- Update `docs/apps/dspace.md` to describe the configured staging chart pin as `3.1.1` and explicitly note it packages application `3.1.0`, leaving production notes untouched. 
- Update `tests/test_dspace_runtime_values.py` to assert staging resolves `docs/apps/dspace.staging.version` → `3.1.1` and to preserve the production expectation of `3.0.2`. 
- Adjust DSPACE-focused test stubs in `tests/test_generic_app_just_recipes.py` so synthetic/stubbed chart data and candidate fixtures expect staging `3.1.1` where appropriate, while keeping production recovery expectations (`3.0.2`) unchanged.

Changed files: `docs/apps/dspace.staging.version`, `docs/apps/dspace.md`, `tests/test_dspace_runtime_values.py`, `tests/test_generic_app_just_recipes.py`.

### Testing

- Ran `python3 scripts/app_config.py json --app dspace --env staging` and observed `SUGARKUBE_VERSION_FILE` → `docs/apps/dspace.staging.version` and the file contains `3.1.1`, and ran `python3 scripts/app_config.py json --app dspace --env prod` which resolves to `docs/apps/dspace.prod.version` → `3.0.2`.
- Ran `python3 -m pytest -q tests/test_dspace_runtime_values.py tests/test_app_config.py` and received `63 passed`.
- Ran `python3 -m pytest -q tests/test_generic_app_just_recipes.py` and received `254 passed` (focused and generic test suites exercised the updated staging coordinate and guards).
- Ran repository sanity checks `git diff --check`, `git diff | python3 scripts/scan-secrets.py`, and `git diff --cached | ./scripts/scan-secrets.py`, all returned clean results; note that `pre-commit`, `pyspelling`, and `linkchecker` were not available in the container so those repo-wide checks could not be executed locally.

All changes are confined to the staging chart pin, its focused tests and directly associated documentation; production pins, image tags, recovery records, values, workflows, and deployment evidence were preserved unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71595e0e48832fbde04f375bdf96f6)