### PR TITLE
fix(dspace): allowlist exact 3.1.0 legacy runtime identity

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -246,6 +246,12 @@ contract explicitly to the smoke runner. This is not a fallback: any coordinate 
 modern contract and a modern identity failure remains fatal. The exception changes neither the
 immutable recovery coordinates nor candidate approval.
 
+The exact immutable DSPACE 3.1.0 artifact (source `018687f5a7f4de45508c6e36eb28afb3e44da24d`,
+image `main-018687f` at its approved digest, and chart `3.1.1` at its approved source and digest)
+also predates `build-info-v1` and is explicitly allowlisted for the same strict legacy contract.
+This is not a general fallback; every coordinate must match, and future releases remain subject to
+the modern identity contract.
+
 Prepare a DSPACE checkout with `pnpm install` and `pnpm exec playwright install chromium`. The
 runner must be executable. It mocks provider transport, so no token.place or OpenAI credentials
 are required or accepted:

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -59,6 +59,22 @@ LEGACY_RECOVERY_COORDINATES = {
     "semanticTag": "v3.0.1",
     "expectedDefaultChatProvider": "openai",
 }
+LEGACY_RESTORATION_COORDINATES = {
+    "schemaVersion": 2,
+    "applicationVersion": "3.1.0",
+    "sourceRevision": "018687f5a7f4de45508c6e36eb28afb3e44da24d",
+    "chartSourceRevision": "719644999f284935f792dbe530511278643aa2ef",
+    "imageTag": "main-018687f",
+    "imageDigest": "sha256:2b95b7fdccdd011553c8d8617e3090ee27323996c532148fdb147cb9fd6e1b6c",
+    "chartVersion": "3.1.1",
+    "chartDigest": "sha256:e1f8ab8860e55ee3c8b8ca8cf7bce6ee7ae9c5dbc81ad8bf82b204b51773783b",
+    "semanticTag": "v3.1.0",
+    "expectedDefaultChatProvider": "token-place",
+}
+LEGACY_IDENTITY_COORDINATES = (
+    LEGACY_RECOVERY_COORDINATES,
+    LEGACY_RESTORATION_COORDINATES,
+)
 META_RE = re.compile(
     r'<meta\s+[^>]*name=["\']dspace-build-revision["\'][^>]*content=["\']([^"\']+)',
     re.IGNORECASE,
@@ -228,8 +244,11 @@ def marker(raw: bytes, revision: str, category: str) -> None:
 
 
 def identity_contract(manifest: dict[str, Any]) -> str:
-    """Select legacy identity only for the complete approved recovery tuple."""
-    if all(manifest.get(key) == value for key, value in LEGACY_RECOVERY_COORDINATES.items()):
+    """Select legacy identity only for a complete, explicitly approved tuple."""
+    if any(
+        all(manifest.get(key) == value for key, value in coordinates.items())
+        for coordinates in LEGACY_IDENTITY_COORDINATES
+    ):
         return LEGACY_IDENTITY_CONTRACT
     return MODERN_IDENTITY_CONTRACT
 

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -12,6 +12,7 @@ SHA = "abcdef0123456789abcdef0123456789abcdef01"
 DIGEST = "sha256:" + "1" * 64
 SENTINEL = "SENTINEL_SECRET"
 RECOVERY_SHA = "1a31a569aff2dbeb238e8c2688b9e85140d2077d"
+RESTORATION_SHA = "018687f5a7f4de45508c6e36eb28afb3e44da24d"
 
 
 def manifest(tmp_path: Path, provider: str = "token-place") -> Path:
@@ -97,17 +98,19 @@ def _verify_setup(
     rollback: bool = False,
     overrides: dict[str, object] | None = None,
     legacy: bool = False,
+    legacy_coordinates: dict[str, object] | None = None,
 ) -> tuple[Namespace, list[list[str]]]:
     """Install a complete, mutable fake cluster and return verifier arguments."""
     override = overrides or {}
     smoke = tmp_path / "smoke"
     smoke.write_text("#!/bin/sh\nexit 0\n")
     smoke.chmod(0o700)
-    revision = RECOVERY_SHA if legacy else SHA
-    digest = str(verifier.LEGACY_RECOVERY_COORDINATES["imageDigest"]) if legacy else DIGEST
-    image_tag = "main-1a31a56" if legacy else "main-abcdef0"
-    version = "3.0.1" if legacy else "3.1.0"
-    chart_version = "3.0.2" if legacy else "3.1.0"
+    coordinates = legacy_coordinates or verifier.LEGACY_RECOVERY_COORDINATES
+    revision = str(coordinates["sourceRevision"]) if legacy else SHA
+    digest = str(coordinates["imageDigest"]) if legacy else DIGEST
+    image_tag = str(coordinates["imageTag"]) if legacy else "main-abcdef0"
+    version = str(coordinates["applicationVersion"]) if legacy else "3.1.0"
+    chart_version = str(coordinates["chartVersion"]) if legacy else "3.1.0"
     canonical = f"ghcr.io/democratizedspace/dspace:{image_tag}"
     declared = f"{canonical}@{digest}" if rollback else canonical
 
@@ -298,7 +301,11 @@ def _verify_setup(
             environment="staging",
             release="dspace",
             namespace="dspace",
-            manifest=recovery_manifest(tmp_path) if legacy else manifest(tmp_path, provider),
+            manifest=(
+                recovery_manifest(tmp_path, **coordinates)
+                if legacy
+                else manifest(tmp_path, provider)
+            ),
             application_version=None,
             source_revision=None,
             provider=None,
@@ -654,10 +661,50 @@ def test_exact_recovery_uses_legacy_contract_and_truthful_journeys(
     ]
 
 
+def test_exact_restoration_uses_legacy_token_place_contract_and_truthful_journeys(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    args, seen = _verify_setup(
+        monkeypatch,
+        tmp_path,
+        legacy=True,
+        provider="token-place",
+        legacy_coordinates=verifier.LEGACY_RESTORATION_COORDINATES,
+    )
+    result = verifier.verify(args)
+    smoke_argv = seen[-1]
+    assert smoke_argv[smoke_argv.index("--identity-contract") + 1] == (
+        verifier.LEGACY_IDENTITY_CONTRACT
+    )
+    assert smoke_argv[smoke_argv.index("--expected-provider") + 1] == "token-place"
+    assert smoke_argv[smoke_argv.index("--expected-token-place-origin") + 1] == (
+        "https://token.example"
+    )
+    assert smoke_argv[smoke_argv.index("--expected-token-place-model") + 1] == "model-a"
+    assert result["runtimeSourceRevision"] == RESTORATION_SHA
+    assert result["journeys"] == [
+        {"name": "/build-meta.json", "passed": True},
+        {"name": "/", "passed": True},
+        {"name": "/chat", "passed": True},
+    ]
+
+
 @pytest.mark.parametrize("field", list(verifier.LEGACY_RECOVERY_COORDINATES))
 def test_any_recovery_coordinate_drift_prevents_legacy_selection(field: str) -> None:
     candidate = dict(verifier.LEGACY_RECOVERY_COORDINATES)
     candidate[field] = "different"
+    assert verifier.identity_contract(candidate) == verifier.MODERN_IDENTITY_CONTRACT
+
+
+@pytest.mark.parametrize("field", list(verifier.LEGACY_RESTORATION_COORDINATES))
+def test_any_restoration_coordinate_drift_prevents_legacy_selection(field: str) -> None:
+    candidate = dict(verifier.LEGACY_RESTORATION_COORDINATES)
+    candidate[field] = "different"
+    assert verifier.identity_contract(candidate) == verifier.MODERN_IDENTITY_CONTRACT
+
+
+def test_unrelated_modern_manifest_uses_modern_contract(tmp_path: Path) -> None:
+    candidate = json.loads(manifest(tmp_path).read_text())
     assert verifier.identity_contract(candidate) == verifier.MODERN_IDENTITY_CONTRACT
 
 


### PR DESCRIPTION
### Motivation
- Staging verification misclassified an approved immutable DSPACE 3.1.0 restoration as `build-info-v1` because the verifier only recognized the prior 3.0.1 recovery tuple as legacy, causing verification to fail despite correct runtime evidence.
- The intent is a narrow, fail-closed compatibility fix that allowlists the exact approved 3.1.0 tuple while preserving strict matching semantics and all existing modern-verification behavior.

### Description
- Add an explicit `LEGACY_RESTORATION_COORDINATES` dictionary for the exact approved DSPACE 3.1.0 tuple and combine it with the existing 3.0.1 tuple in `LEGACY_IDENTITY_COORDINATES`, leaving modern behavior unchanged for all other manifests (`scripts/dspace_runtime_verifier.py`).
- Update `identity_contract()` to return `legacy-build-meta-v1` only when every field of one of the explicitly approved tuples matches exactly, preserving fail-closed semantics and avoiding any runtime fallback.
- Preserve legacy verification semantics (use of `/build-meta.json`, exact legacy JSON field set, `generatedAt`/`source` checks, HTML root checks, replica/public agreement) and continue to pass `legacy-build-meta-v1` plus the expected `token-place` origin/model to the smoke runner when applicable.
- Add focused tests to `tests/test_dspace_runtime_verifier.py` that cover: exact 3.0.1 legacy behavior, exact 3.1.0 legacy selection and full token.place journeys, parameterized one-field drift for both allowlisted tuples, unrelated modern manifest behavior, and smoke-runner argv/proof-journey assertions; and add a short explanatory note to `docs/apps/dspace.md` documenting the narrow allowlist.

### Testing
- Ran `python3 -m pytest -q tests/test_dspace_runtime_verifier.py` and observed `163 passed` (success).
- Ran `python3 -m pytest -q tests/test_release_manifest.py` and observed `204 passed` (success).
- Ran `python3 -m pytest -q tests/test_dspace_runtime_verifier.py tests/test_release_manifest.py` and observed `367 passed` in total (success).
- Ran `linkchecker --no-warnings README.md docs/` and observed zero warnings/errors (207 links checked) (success).
- Ran `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` with no issues (success).
- `pre-commit run --all-files` is repository-wide blocked by unrelated YAML/lint issues outside the scoped files, and its auto-fixes were not retained beyond the three changed files (not fixed here by design).
- `pyspelling -c .spellcheck.yaml` could not complete due to missing `aspell` binary in the environment (not-run).

Changed files: `scripts/dspace_runtime_verifier.py`, `tests/test_dspace_runtime_verifier.py`, `docs/apps/dspace.md`.

Design notes and drift coverage: the change is exact-match only (every field must match one of the two explicit tuples), tests parameterize one-field drift across every coordinate for both allowlisted tuples to ensure any deviation selects the modern contract, and no runtime fallback or weakened validation was introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a717da504d0832fabab0d29695c7741)