### PR TITLE
fix(dspace): allowlist exact 3.1.0 legacy runtime identity tuple

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -246,6 +246,12 @@ contract explicitly to the smoke runner. This is not a fallback: any coordinate 
 modern contract and a modern identity failure remains fatal. The exception changes neither the
 immutable recovery coordinates nor candidate approval.
 
+The exact immutable DSPACE `3.1.0` restoration artifact (chart `3.1.1`, source
+`018687f5a7f4de45508c6e36eb28afb3e44da24d`) also predates `build-info-v1` and is explicitly
+allowlisted by its complete release tuple for the same strict legacy contract. This is not a
+general fallback: coordinate drift and all future releases remain subject to the modern identity
+contract.
+
 Prepare a DSPACE checkout with `pnpm install` and `pnpm exec playwright install chromium`. The
 runner must be executable. It mocks provider transport, so no token.place or OpenAI credentials
 are required or accepted:

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -59,6 +59,22 @@ LEGACY_RECOVERY_COORDINATES = {
     "semanticTag": "v3.0.1",
     "expectedDefaultChatProvider": "openai",
 }
+LEGACY_RESTORATION_COORDINATES = {
+    "schemaVersion": 2,
+    "applicationVersion": "3.1.0",
+    "sourceRevision": "018687f5a7f4de45508c6e36eb28afb3e44da24d",
+    "chartSourceRevision": "719644999f284935f792dbe530511278643aa2ef",
+    "imageTag": "main-018687f",
+    "imageDigest": "sha256:2b95b7fdccdd011553c8d8617e3090ee27323996c532148fdb147cb9fd6e1b6c",
+    "chartVersion": "3.1.1",
+    "chartDigest": "sha256:e1f8ab8860e55ee3c8b8ca8cf7bce6ee7ae9c5dbc81ad8bf82b204b51773783b",
+    "semanticTag": "v3.1.0",
+    "expectedDefaultChatProvider": "token-place",
+}
+LEGACY_IDENTITY_COORDINATES = (
+    LEGACY_RECOVERY_COORDINATES,
+    LEGACY_RESTORATION_COORDINATES,
+)
 META_RE = re.compile(
     r'<meta\s+[^>]*name=["\']dspace-build-revision["\'][^>]*content=["\']([^"\']+)',
     re.IGNORECASE,
@@ -228,8 +244,11 @@ def marker(raw: bytes, revision: str, category: str) -> None:
 
 
 def identity_contract(manifest: dict[str, Any]) -> str:
-    """Select legacy identity only for the complete approved recovery tuple."""
-    if all(manifest.get(key) == value for key, value in LEGACY_RECOVERY_COORDINATES.items()):
+    """Select legacy identity only for a complete, explicitly approved tuple."""
+    if any(
+        all(manifest.get(key) == value for key, value in coordinates.items())
+        for coordinates in LEGACY_IDENTITY_COORDINATES
+    ):
         return LEGACY_IDENTITY_CONTRACT
     return MODERN_IDENTITY_CONTRACT
 

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -12,6 +12,7 @@ SHA = "abcdef0123456789abcdef0123456789abcdef01"
 DIGEST = "sha256:" + "1" * 64
 SENTINEL = "SENTINEL_SECRET"
 RECOVERY_SHA = "1a31a569aff2dbeb238e8c2688b9e85140d2077d"
+RESTORATION_SHA = "018687f5a7f4de45508c6e36eb28afb3e44da24d"
 
 
 def manifest(tmp_path: Path, provider: str = "token-place") -> Path:
@@ -50,6 +51,21 @@ def recovery_manifest(tmp_path: Path, **changes: object) -> Path:
         **changes,
     }
     path = tmp_path / "recovery.json"
+    path.write_text(json.dumps(value))
+    return path
+
+
+def restoration_manifest(tmp_path: Path, **changes: object) -> Path:
+    value = {
+        **verifier.LEGACY_RESTORATION_COORDINATES,
+        "app": "dspace",
+        "recordType": "candidate",
+        "environment": "staging",
+        "approvedAt": "2026-07-30T00:00:00Z",
+        "approvedBy": "release-test",
+        **changes,
+    }
+    path = tmp_path / "restoration.json"
     path.write_text(json.dumps(value))
     return path
 
@@ -97,17 +113,19 @@ def _verify_setup(
     rollback: bool = False,
     overrides: dict[str, object] | None = None,
     legacy: bool = False,
+    legacy_coordinates: dict[str, object] | None = None,
 ) -> tuple[Namespace, list[list[str]]]:
     """Install a complete, mutable fake cluster and return verifier arguments."""
     override = overrides or {}
     smoke = tmp_path / "smoke"
     smoke.write_text("#!/bin/sh\nexit 0\n")
     smoke.chmod(0o700)
-    revision = RECOVERY_SHA if legacy else SHA
-    digest = str(verifier.LEGACY_RECOVERY_COORDINATES["imageDigest"]) if legacy else DIGEST
-    image_tag = "main-1a31a56" if legacy else "main-abcdef0"
-    version = "3.0.1" if legacy else "3.1.0"
-    chart_version = "3.0.2" if legacy else "3.1.0"
+    coordinates = legacy_coordinates or verifier.LEGACY_RECOVERY_COORDINATES
+    revision = str(coordinates["sourceRevision"]) if legacy else SHA
+    digest = str(coordinates["imageDigest"]) if legacy else DIGEST
+    image_tag = str(coordinates["imageTag"]) if legacy else "main-abcdef0"
+    version = str(coordinates["applicationVersion"]) if legacy else "3.1.0"
+    chart_version = str(coordinates["chartVersion"]) if legacy else "3.1.0"
     canonical = f"ghcr.io/democratizedspace/dspace:{image_tag}"
     declared = f"{canonical}@{digest}" if rollback else canonical
 
@@ -298,7 +316,13 @@ def _verify_setup(
             environment="staging",
             release="dspace",
             namespace="dspace",
-            manifest=recovery_manifest(tmp_path) if legacy else manifest(tmp_path, provider),
+            manifest=(
+                restoration_manifest(tmp_path)
+                if legacy and coordinates is verifier.LEGACY_RESTORATION_COORDINATES
+                else recovery_manifest(tmp_path)
+                if legacy
+                else manifest(tmp_path, provider)
+            ),
             application_version=None,
             source_revision=None,
             provider=None,
@@ -654,10 +678,123 @@ def test_exact_recovery_uses_legacy_contract_and_truthful_journeys(
     ]
 
 
+def test_exact_restoration_uses_legacy_contract_with_token_place_proof(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    args, seen = _verify_setup(
+        monkeypatch,
+        tmp_path,
+        legacy=True,
+        legacy_coordinates=verifier.LEGACY_RESTORATION_COORDINATES,
+    )
+    result = verifier.verify(args)
+
+    smoke_argv = seen[-1]
+    assert smoke_argv[smoke_argv.index("--identity-contract") + 1] == (
+        verifier.LEGACY_IDENTITY_CONTRACT
+    )
+    assert smoke_argv[smoke_argv.index("--expected-provider") + 1] == "token-place"
+    assert smoke_argv[smoke_argv.index("--expected-token-place-origin") + 1] == (
+        "https://token.example"
+    )
+    assert smoke_argv[smoke_argv.index("--expected-token-place-model") + 1] == "model-a"
+    assert result["journeys"] == [
+        {"name": "/build-meta.json", "passed": True},
+        {"name": "/", "passed": True},
+        {"name": "/chat", "passed": True},
+    ]
+
+
+@pytest.mark.parametrize(
+    "overrides,category",
+    [
+        (
+            {
+                "direct_meta": {
+                    "dspace-1": json.dumps(
+                        {
+                            "gitSha": "wrong",
+                            "generatedAt": "2026-08-01T12:00:00Z",
+                            "source": "dspace",
+                        }
+                    )
+                }
+            },
+            "direct identity",
+        ),
+        (
+            {
+                "direct_meta": {
+                    "dspace-1": json.dumps(
+                        {
+                            "gitSha": RESTORATION_SHA,
+                            "generatedAt": "2026-08-01T12:00:00Z",
+                            "source": "dspace",
+                            "extra": True,
+                        }
+                    )
+                }
+            },
+            "direct identity",
+        ),
+        (
+            {
+                "direct_meta": {
+                    "dspace-2": json.dumps(
+                        {
+                            "gitSha": RESTORATION_SHA,
+                            "generatedAt": "2026-08-02T12:00:00Z",
+                            "source": "dspace",
+                        }
+                    )
+                }
+            },
+            "pod/replica identity",
+        ),
+    ],
+    ids=("wrong-sha", "extra-field", "replica-disagreement"),
+)
+def test_restoration_legacy_metadata_failures_remain_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    overrides: dict[str, object],
+    category: str,
+) -> None:
+    args, _ = _verify_setup(
+        monkeypatch,
+        tmp_path,
+        legacy=True,
+        legacy_coordinates=verifier.LEGACY_RESTORATION_COORDINATES,
+        overrides=overrides,
+    )
+    with pytest.raises(verifier.VerificationError, match=category):
+        verifier.verify(args)
+
+
 @pytest.mark.parametrize("field", list(verifier.LEGACY_RECOVERY_COORDINATES))
 def test_any_recovery_coordinate_drift_prevents_legacy_selection(field: str) -> None:
     candidate = dict(verifier.LEGACY_RECOVERY_COORDINATES)
     candidate[field] = "different"
+    assert verifier.identity_contract(candidate) == verifier.MODERN_IDENTITY_CONTRACT
+
+
+@pytest.mark.parametrize("field", list(verifier.LEGACY_RESTORATION_COORDINATES))
+def test_any_restoration_coordinate_drift_prevents_legacy_selection(field: str) -> None:
+    candidate = dict(verifier.LEGACY_RESTORATION_COORDINATES)
+    candidate[field] = "different"
+    assert verifier.identity_contract(candidate) == verifier.MODERN_IDENTITY_CONTRACT
+
+
+def test_unrelated_modern_manifest_uses_modern_contract() -> None:
+    candidate = dict(verifier.LEGACY_RESTORATION_COORDINATES)
+    candidate.update(
+        {
+            "applicationVersion": "4.0.0",
+            "sourceRevision": "a" * 40,
+            "imageTag": "main-aaaaaaa",
+            "semanticTag": "v4.0.0",
+        }
+    )
     assert verifier.identity_contract(candidate) == verifier.MODERN_IDENTITY_CONTRACT
 
 


### PR DESCRIPTION
### Motivation

- The runtime verifier only recognized the original DSPACE 3.0.1 recovery tuple as `legacy-build-meta-v1`, causing an approved immutable DSPACE 3.1.0 restoration to be treated as `build-info-v1` and fail verification despite correct legacy metadata being served.

### Description

- Add an explicit allowlist entry for the exact approved DSPACE 3.1.0 restoration tuple and refactor the legacy coordinate representation so `identity_contract()` recognizes either approved legacy tuple only when every coordinate matches exactly; otherwise the modern `build-info-v1` contract remains active. (changed files: `scripts/dspace_runtime_verifier.py`)
- Preserve fail-closed semantics by exact-matching every field in each approved tuple and not introducing any runtime fallback or endpoint-based heuristic. (logic in `identity_contract()` now iterates over `LEGACY_IDENTITY_COORDINATES` containing both tuples)
- Add focused tests that cover: exact 3.0.1 recovery still selecting legacy contract; exact 3.1.0 restoration selecting legacy contract; parameterized one-field drift across every field in both allowlisted tuples preventing legacy selection; unrelated modern manifest selecting modern contract; full 3.1.0 token.place verification exercising `/build-meta.json`, `/`, and `/chat` journeys; smoke-runner argv includes legacy contract, `token-place`, origin and model; and rejection cases for wrong SHA, malformed/extra metadata, and replica disagreement. (changed file: `tests/test_dspace_runtime_verifier.py`)
- Document the narrow exception in `docs/apps/dspace.md`, stating the 3.1.0 artifact predates `build-info-v1` and is explicitly allowlisted and not a general fallback. (changed file: `docs/apps/dspace.md`)

### Testing

- `python3 -m pytest -q tests/test_dspace_runtime_verifier.py` — 166 passed.
- `python3 -m pytest -q tests/test_release_manifest.py` — 204 passed.
- `linkchecker --no-warnings docs/apps/dspace.md` — passed (no link errors).
- `git diff --cached | ./scripts/scan-secrets.py` and `git diff --cached --check` — passed (no new secrets or diff-check issues).
- `pre-commit run --files scripts/dspace_runtime_verifier.py tests/test_dspace_runtime_verifier.py docs/apps/dspace.md` — run started successfully but the repository-wide checks reported pre-existing Flake8/formatting issues unrelated to this focused change; these are pre-existing and not introduced by this PR.
- `pyspelling -c .spellcheck.yaml` could not complete in this environment because the `aspell` binary is not installed, so spelling checks were not run here.

Residual notes and risks: the change is narrowly scoped to an explicit allowlist of two immutable tuples and their tests and documentation; it does not weaken validation or add any runtime fallback. Follow-up: operator should re-run the repository verifier against the existing Helm revision after this PR is merged to finalize evidence (no redeploy needed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a717db24e2c832fa21905eda464b687)