### PR TITLE
Allowlist immutable DSPACE 3.1.0 legacy runtime identity

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -246,6 +246,13 @@ contract explicitly to the smoke runner. This is not a fallback: any coordinate 
 modern contract and a modern identity failure remains fatal. The exception changes neither the
 immutable recovery coordinates nor candidate approval.
 
+The exact immutable DSPACE 3.1.0 artifact at source revision
+`018687f5a7f4de45508c6e36eb28afb3e44da24d`, image `main-018687f` with its approved digest, and
+chart 3.1.1 with its approved source revision and digest also predates `build-info-v1` and is
+explicitly allowlisted for the same strict `legacy-build-meta-v1` contract. This is not a general
+fallback: every release coordinate must match that allowlist entry, and future releases remain
+subject to the modern identity contract.
+
 Prepare a DSPACE checkout with `pnpm install` and `pnpm exec playwright install chromium`. The
 runner must be executable. It mocks provider transport, so no token.place or OpenAI credentials
 are required or accepted:

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -47,7 +47,7 @@ BUILD_FIELDS = {"version", "revision", "shortRevision", "image"}
 LEGACY_BUILD_FIELDS = {"gitSha", "generatedAt", "source"}
 MODERN_IDENTITY_CONTRACT = "build-info-v1"
 LEGACY_IDENTITY_CONTRACT = "legacy-build-meta-v1"
-LEGACY_RECOVERY_COORDINATES = {
+LEGACY_DSPACE_3_0_1_COORDINATES = {
     "schemaVersion": 2,
     "applicationVersion": "3.0.1",
     "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
@@ -59,6 +59,22 @@ LEGACY_RECOVERY_COORDINATES = {
     "semanticTag": "v3.0.1",
     "expectedDefaultChatProvider": "openai",
 }
+LEGACY_DSPACE_3_1_0_COORDINATES = {
+    "schemaVersion": 2,
+    "applicationVersion": "3.1.0",
+    "sourceRevision": "018687f5a7f4de45508c6e36eb28afb3e44da24d",
+    "chartSourceRevision": "719644999f284935f792dbe530511278643aa2ef",
+    "imageTag": "main-018687f",
+    "imageDigest": "sha256:2b95b7fdccdd011553c8d8617e3090ee27323996c532148fdb147cb9fd6e1b6c",
+    "chartVersion": "3.1.1",
+    "chartDigest": "sha256:e1f8ab8860e55ee3c8b8ca8cf7bce6ee7ae9c5dbc81ad8bf82b204b51773783b",
+    "semanticTag": "v3.1.0",
+    "expectedDefaultChatProvider": "token-place",
+}
+APPROVED_LEGACY_IDENTITY_COORDINATES = (
+    LEGACY_DSPACE_3_0_1_COORDINATES,
+    LEGACY_DSPACE_3_1_0_COORDINATES,
+)
 META_RE = re.compile(
     r'<meta\s+[^>]*name=["\']dspace-build-revision["\'][^>]*content=["\']([^"\']+)',
     re.IGNORECASE,
@@ -228,8 +244,11 @@ def marker(raw: bytes, revision: str, category: str) -> None:
 
 
 def identity_contract(manifest: dict[str, Any]) -> str:
-    """Select legacy identity only for the complete approved recovery tuple."""
-    if all(manifest.get(key) == value for key, value in LEGACY_RECOVERY_COORDINATES.items()):
+    """Select legacy identity only for a complete approved immutable tuple."""
+    if any(
+        all(manifest.get(key) == value for key, value in coordinates.items())
+        for coordinates in APPROVED_LEGACY_IDENTITY_COORDINATES
+    ):
         return LEGACY_IDENTITY_CONTRACT
     return MODERN_IDENTITY_CONTRACT
 

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -12,6 +12,7 @@ SHA = "abcdef0123456789abcdef0123456789abcdef01"
 DIGEST = "sha256:" + "1" * 64
 SENTINEL = "SENTINEL_SECRET"
 RECOVERY_SHA = "1a31a569aff2dbeb238e8c2688b9e85140d2077d"
+RESTORATION_SHA = "018687f5a7f4de45508c6e36eb28afb3e44da24d"
 
 
 def manifest(tmp_path: Path, provider: str = "token-place") -> Path:
@@ -41,7 +42,7 @@ def manifest(tmp_path: Path, provider: str = "token-place") -> Path:
 
 def recovery_manifest(tmp_path: Path, **changes: object) -> Path:
     value = {
-        **verifier.LEGACY_RECOVERY_COORDINATES,
+        **verifier.LEGACY_DSPACE_3_0_1_COORDINATES,
         "app": "dspace",
         "recordType": "candidate",
         "environment": "prod",
@@ -50,6 +51,21 @@ def recovery_manifest(tmp_path: Path, **changes: object) -> Path:
         **changes,
     }
     path = tmp_path / "recovery.json"
+    path.write_text(json.dumps(value))
+    return path
+
+
+def restoration_manifest(tmp_path: Path, **changes: object) -> Path:
+    value = {
+        **verifier.LEGACY_DSPACE_3_1_0_COORDINATES,
+        "app": "dspace",
+        "recordType": "candidate",
+        "environment": "staging",
+        "approvedAt": "2026-08-04T00:00:00Z",
+        "approvedBy": "release-test",
+        **changes,
+    }
+    path = tmp_path / "restoration.json"
     path.write_text(json.dumps(value))
     return path
 
@@ -96,18 +112,22 @@ def _verify_setup(
     provider: str = "token-place",
     rollback: bool = False,
     overrides: dict[str, object] | None = None,
-    legacy: bool = False,
+    legacy: str | None = None,
 ) -> tuple[Namespace, list[list[str]]]:
     """Install a complete, mutable fake cluster and return verifier arguments."""
     override = overrides or {}
     smoke = tmp_path / "smoke"
     smoke.write_text("#!/bin/sh\nexit 0\n")
     smoke.chmod(0o700)
-    revision = RECOVERY_SHA if legacy else SHA
-    digest = str(verifier.LEGACY_RECOVERY_COORDINATES["imageDigest"]) if legacy else DIGEST
-    image_tag = "main-1a31a56" if legacy else "main-abcdef0"
-    version = "3.0.1" if legacy else "3.1.0"
-    chart_version = "3.0.2" if legacy else "3.1.0"
+    coordinates = {
+        "recovery": verifier.LEGACY_DSPACE_3_0_1_COORDINATES,
+        "restoration": verifier.LEGACY_DSPACE_3_1_0_COORDINATES,
+    }.get(legacy)
+    revision = str(coordinates["sourceRevision"]) if coordinates else SHA
+    digest = str(coordinates["imageDigest"]) if coordinates else DIGEST
+    image_tag = str(coordinates["imageTag"]) if coordinates else "main-abcdef0"
+    version = str(coordinates["applicationVersion"]) if coordinates else "3.1.0"
+    chart_version = str(coordinates["chartVersion"]) if coordinates else "3.1.0"
     canonical = f"ghcr.io/democratizedspace/dspace:{image_tag}"
     declared = f"{canonical}@{digest}" if rollback else canonical
 
@@ -298,7 +318,13 @@ def _verify_setup(
             environment="staging",
             release="dspace",
             namespace="dspace",
-            manifest=recovery_manifest(tmp_path) if legacy else manifest(tmp_path, provider),
+            manifest=(
+                recovery_manifest(tmp_path)
+                if legacy == "recovery"
+                else restoration_manifest(tmp_path)
+                if legacy == "restoration"
+                else manifest(tmp_path, provider)
+            ),
             application_version=None,
             source_revision=None,
             provider=None,
@@ -643,7 +669,7 @@ def test_pod_http_port_must_match_deployment(
 def test_exact_recovery_uses_legacy_contract_and_truthful_journeys(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    args, seen = _verify_setup(monkeypatch, tmp_path, legacy=True, provider="openai")
+    args, seen = _verify_setup(monkeypatch, tmp_path, legacy="recovery", provider="openai")
     result = verifier.verify(args)
     contract_index = seen[-1].index("--identity-contract")
     assert seen[-1][contract_index + 1] == verifier.LEGACY_IDENTITY_CONTRACT
@@ -654,11 +680,105 @@ def test_exact_recovery_uses_legacy_contract_and_truthful_journeys(
     ]
 
 
-@pytest.mark.parametrize("field", list(verifier.LEGACY_RECOVERY_COORDINATES))
-def test_any_recovery_coordinate_drift_prevents_legacy_selection(field: str) -> None:
-    candidate = dict(verifier.LEGACY_RECOVERY_COORDINATES)
+def test_exact_restoration_uses_legacy_contract() -> None:
+    assert (
+        verifier.identity_contract(dict(verifier.LEGACY_DSPACE_3_1_0_COORDINATES))
+        == verifier.LEGACY_IDENTITY_CONTRACT
+    )
+
+
+def test_exact_restoration_verifies_legacy_token_place_journeys(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    args, seen = _verify_setup(monkeypatch, tmp_path, legacy="restoration")
+
+    result = verifier.verify(args)
+
+    smoke_argv = seen[-1]
+    assert smoke_argv[smoke_argv.index("--identity-contract") + 1] == (
+        verifier.LEGACY_IDENTITY_CONTRACT
+    )
+    assert smoke_argv[smoke_argv.index("--expected-provider") + 1] == "token-place"
+    assert smoke_argv[smoke_argv.index("--expected-token-place-origin") + 1] == (
+        "https://token.example"
+    )
+    assert smoke_argv[smoke_argv.index("--expected-token-place-model") + 1] == "model-a"
+    assert result["journeys"] == [
+        {"name": "/build-meta.json", "passed": True},
+        {"name": "/", "passed": True},
+        {"name": "/chat", "passed": True},
+    ]
+
+
+@pytest.mark.parametrize("field", list(verifier.LEGACY_DSPACE_3_1_0_COORDINATES))
+def test_any_restoration_coordinate_drift_prevents_legacy_selection(field: str) -> None:
+    candidate = dict(verifier.LEGACY_DSPACE_3_1_0_COORDINATES)
     candidate[field] = "different"
     assert verifier.identity_contract(candidate) == verifier.MODERN_IDENTITY_CONTRACT
+
+
+def test_unrelated_manifest_uses_modern_contract() -> None:
+    assert verifier.identity_contract({"applicationVersion": "4.0.0"}) == (
+        verifier.MODERN_IDENTITY_CONTRACT
+    )
+
+
+@pytest.mark.parametrize(
+    "overrides,category",
+    [
+        (
+            {
+                "direct_meta": {
+                    "dspace-1": json.dumps(
+                        {
+                            "gitSha": "wrong",
+                            "generatedAt": "2026-08-01T12:00:00Z",
+                            "source": "dspace",
+                        }
+                    )
+                }
+            },
+            "direct identity",
+        ),
+        (
+            {
+                "public_meta": json.dumps(
+                    {
+                        "gitSha": RESTORATION_SHA,
+                        "generatedAt": "2026-08-01T12:00:00Z",
+                        "source": "dspace",
+                        "extra": True,
+                    }
+                )
+            },
+            "public identity",
+        ),
+        (
+            {
+                "direct_meta": {
+                    "dspace-2": json.dumps(
+                        {
+                            "gitSha": RESTORATION_SHA,
+                            "generatedAt": "2026-08-02T12:00:00Z",
+                            "source": "dspace",
+                        }
+                    )
+                }
+            },
+            "pod/replica identity",
+        ),
+    ],
+    ids=("wrong-sha", "extra-field", "replica-disagreement"),
+)
+def test_restoration_legacy_metadata_remains_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    overrides: dict[str, object],
+    category: str,
+) -> None:
+    args, _ = _verify_setup(monkeypatch, tmp_path, legacy="restoration", overrides=overrides)
+    with pytest.raises(verifier.VerificationError, match=category):
+        verifier.verify(args)
 
 
 def test_modern_identity_failure_never_requests_legacy_surface(
@@ -798,7 +918,7 @@ def test_legacy_agreement_and_root_evidence_fail_closed(
     overrides: dict[str, object],
     category: str,
 ) -> None:
-    args, _ = _verify_setup(monkeypatch, tmp_path, legacy=True, overrides=overrides)
+    args, _ = _verify_setup(monkeypatch, tmp_path, legacy="recovery", overrides=overrides)
     with pytest.raises(verifier.VerificationError, match=category):
         verifier.verify(args)
 


### PR DESCRIPTION
### Motivation
- The verifier currently treats only the DSPACE 3.0.1 recovery tuple as `legacy-build-meta-v1`, which caused an approved immutable DSPACE 3.1.0 restoration to be misclassified as `build-info-v1` and fail verification after staging rollout.
- The change must be narrowly scoped, fail-closed, and preserve existing legacy semantics while allowing the single approved 3.1.0 tuple to be verified using the legacy `/build-meta.json` surface and token.place smoke-runner arguments.

### Description
- Refactor the legacy coordinate representation into explicit allowlisted tuples and add the exact approved DSPACE 3.1.0 coordinates; selection now returns `legacy-build-meta-v1` only when a manifest exactly matches one of the allowlisted tuples. (changed: `scripts/dspace_runtime_verifier.py`)
- Preserve fail-closed semantics by matching every field of each allowlisted tuple (schemaVersion, applicationVersion, sourceRevision, chartSourceRevision, imageTag, imageDigest, chartVersion, chartDigest, semanticTag, expectedDefaultChatProvider) and rejecting any drift. (exact-match design and drift coverage implemented in `identity_contract`) 
- Retain legacy verification semantics (use `/build-meta.json`, require exact legacy JSON fields including full `gitSha`, non-empty `generatedAt`/`source`, require HTML root at `/` without requiring the modern meta marker, and require replica/public agreement), and ensure the smoke-runner receives `legacy-build-meta-v1` plus token.place origin/model for the 3.1.0 case. (no runtime fallback added)
- Add focused unit tests exercising the original 3.0.1 tuple, the exact 3.1.0 tuple, parameterized one-field drift across every 3.1.0 field, unrelated modern manifest behaviour, full verification journeys for the 3.1.0 token.place manifest, smoke-runner argument checks, and fail-closed rejections for wrong SHA / malformed metadata / replica disagreement. (changed: `tests/test_dspace_runtime_verifier.py`) 
- Add a minimal durable note to `docs/apps/dspace.md` describing that the exact immutable DSPACE 3.1.0 artifact is explicitly allowlisted for the legacy contract and that this is not a general fallback. (changed: `docs/apps/dspace.md`)

### Testing
- `python3 -m pytest -q tests/test_dspace_runtime_verifier.py tests/test_release_manifest.py` — ran the focused pytest suite and reported `361 passed` (success).
- `python3 -m unittest tests.test_dspace_runtime_verifier` and `python3 -m unittest tests.test_release_manifest` — both `unittest` invocations collected zero tests (the test modules use pytest conventions), producing `Ran 0 tests` / `NO TESTS RAN` (informational/expected).
- Documentation and linters run: `pyspelling -c .spellcheck.yaml` (passed) and `linkchecker --no-warnings README.md docs/` (passed with 207 links checked), and `git diff --check` (passed); `git diff --cached | ./scripts/scan-secrets.py` also passed.
- `pre-commit run --all-files` could not complete repository-wide because unrelated, pre-existing YAML parsing and lint issues were detected and some auto-fixes would have been applied; those unrelated auto-fixes were not propagated beyond the focused changes in this PR (note: this PR avoids broad formatting/lint churn).
- `black --check scripts/dspace_runtime_verifier.py tests/test_dspace_runtime_verifier.py` reported that two files would be reformatted; these were not reformatted here to keep the diff minimal and reviewable.

Changed files
- `scripts/dspace_runtime_verifier.py` (refactor/add allowlist + identity selection change)
- `tests/test_dspace_runtime_verifier.py` (added tests for 3.1.0 allowlist, drift coverage, smoke-runner checks, and fail-closed cases)
- `docs/apps/dspace.md` (document the narrow allowlist exception)

Verification notes and residual risks
- Exact-match design: matching is implemented as a per-field equality check against fully-specified allowlisted coordinate tuples, and parameterized tests mutate each field to ensure any drift prevents legacy selection.
- No runtime fallback or endpoint-probing behaviour was introduced and all legacy-path checks remain strict and unchanged.
- Residual / follow-up: repository-wide formatting and lint issues exist and were intentionally not changed in this narrow PR; maintainers may run full `pre-commit run --all-files` or `black`/`flake8` sweeps separately if desired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a717db5a52c832f8270f170c49e5fbe)