### PR TITLE
Allowlist exact DSPACE 3.1.0 tuple for legacy build-meta identity

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -246,6 +246,11 @@ contract explicitly to the smoke runner. This is not a fallback: any coordinate 
 modern contract and a modern identity failure remains fatal. The exception changes neither the
 immutable recovery coordinates nor candidate approval.
 
+The exact immutable DSPACE 3.1.0 artifact (source `018687f5a7f4de45508c6e36eb28afb3e44da24d`,
+image `main-018687f`, and chart `3.1.1`) also predates `build-info-v1` and is explicitly allowlisted
+for the same strict legacy contract. This is not a general fallback: every coordinate must match,
+and unrecognized or future releases remain subject to the modern identity contract.
+
 Prepare a DSPACE checkout with `pnpm install` and `pnpm exec playwright install chromium`. The
 runner must be executable. It mocks provider transport, so no token.place or OpenAI credentials
 are required or accepted:

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -59,6 +59,19 @@ LEGACY_RECOVERY_COORDINATES = {
     "semanticTag": "v3.0.1",
     "expectedDefaultChatProvider": "openai",
 }
+LEGACY_310_COORDINATES = {
+    "schemaVersion": 2,
+    "applicationVersion": "3.1.0",
+    "sourceRevision": "018687f5a7f4de45508c6e36eb28afb3e44da24d",
+    "chartSourceRevision": "719644999f284935f792dbe530511278643aa2ef",
+    "imageTag": "main-018687f",
+    "imageDigest": "sha256:2b95b7fdccdd011553c8d8617e3090ee27323996c532148fdb147cb9fd6e1b6c",
+    "chartVersion": "3.1.1",
+    "chartDigest": "sha256:e1f8ab8860e55ee3c8b8ca8cf7bce6ee7ae9c5dbc81ad8bf82b204b51773783b",
+    "semanticTag": "v3.1.0",
+    "expectedDefaultChatProvider": "token-place",
+}
+LEGACY_IDENTITY_COORDINATES = (LEGACY_RECOVERY_COORDINATES, LEGACY_310_COORDINATES)
 META_RE = re.compile(
     r'<meta\s+[^>]*name=["\']dspace-build-revision["\'][^>]*content=["\']([^"\']+)',
     re.IGNORECASE,
@@ -228,8 +241,11 @@ def marker(raw: bytes, revision: str, category: str) -> None:
 
 
 def identity_contract(manifest: dict[str, Any]) -> str:
-    """Select legacy identity only for the complete approved recovery tuple."""
-    if all(manifest.get(key) == value for key, value in LEGACY_RECOVERY_COORDINATES.items()):
+    """Select legacy identity only for a complete approved immutable tuple."""
+    if any(
+        all(manifest.get(key) == value for key, value in coordinates.items())
+        for coordinates in LEGACY_IDENTITY_COORDINATES
+    ):
         return LEGACY_IDENTITY_CONTRACT
     return MODERN_IDENTITY_CONTRACT
 

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -726,8 +726,8 @@ def test_any_310_coordinate_drift_prevents_legacy_selection(field: str) -> None:
     assert verifier.identity_contract(candidate) == verifier.MODERN_IDENTITY_CONTRACT
 
 
-def test_unrelated_modern_manifest_uses_modern_contract() -> None:
-    candidate = dict(verifier.LEGACY_310_COORDINATES, sourceRevision=SHA)
+def test_unrelated_modern_manifest_uses_modern_contract(tmp_path: Path) -> None:
+    candidate = json.loads(manifest(tmp_path).read_text())
     assert verifier.identity_contract(candidate) == verifier.MODERN_IDENTITY_CONTRACT
 
 

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -115,6 +115,9 @@ def _verify_setup(
     legacy_310: bool = False,
 ) -> tuple[Namespace, list[list[str]]]:
     """Install a complete, mutable fake cluster and return verifier arguments."""
+    if legacy and legacy_310:
+        raise ValueError("legacy and legacy_310 are mutually exclusive")
+
     override = overrides or {}
     smoke = tmp_path / "smoke"
     smoke.write_text("#!/bin/sh\nexit 0\n")
@@ -313,16 +316,19 @@ def _verify_setup(
         )
 
     monkeypatch.setattr(verifier.subprocess, "run", smoke_run)
+    if legacy_310:
+        manifest_path = legacy_310_manifest(tmp_path)
+    elif legacy:
+        manifest_path = recovery_manifest(tmp_path)
+    else:
+        manifest_path = manifest(tmp_path, provider)
+
     return (
         Namespace(
             environment="staging",
             release="dspace",
             namespace="dspace",
-            manifest=(
-                legacy_310_manifest(tmp_path)
-                if legacy_310
-                else recovery_manifest(tmp_path) if legacy else manifest(tmp_path, provider)
-            ),
+            manifest=manifest_path,
             application_version=None,
             source_revision=None,
             provider=None,
@@ -334,6 +340,13 @@ def _verify_setup(
         ),
         seen,
     )
+
+
+def test_verify_setup_rejects_conflicting_legacy_flags(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _verify_setup(monkeypatch, tmp_path, legacy=True, legacy_310=True)
 
 
 @pytest.mark.parametrize("provider,has_token_args", [("token-place", True), ("openai", False)])

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -54,6 +54,21 @@ def recovery_manifest(tmp_path: Path, **changes: object) -> Path:
     return path
 
 
+def legacy_310_manifest(tmp_path: Path, **changes: object) -> Path:
+    value = {
+        **verifier.LEGACY_310_COORDINATES,
+        "app": "dspace",
+        "recordType": "candidate",
+        "environment": "staging",
+        "approvedAt": "2026-07-30T00:00:00Z",
+        "approvedBy": "release-test",
+        **changes,
+    }
+    path = tmp_path / "legacy-3.1.0.json"
+    path.write_text(json.dumps(value))
+    return path
+
+
 def test_capabilities_schema_and_order(capsys: pytest.CaptureFixture[str]) -> None:
     assert (
         verifier.main(
@@ -97,17 +112,22 @@ def _verify_setup(
     rollback: bool = False,
     overrides: dict[str, object] | None = None,
     legacy: bool = False,
+    legacy_310: bool = False,
 ) -> tuple[Namespace, list[list[str]]]:
     """Install a complete, mutable fake cluster and return verifier arguments."""
     override = overrides or {}
     smoke = tmp_path / "smoke"
     smoke.write_text("#!/bin/sh\nexit 0\n")
     smoke.chmod(0o700)
-    revision = RECOVERY_SHA if legacy else SHA
-    digest = str(verifier.LEGACY_RECOVERY_COORDINATES["imageDigest"]) if legacy else DIGEST
-    image_tag = "main-1a31a56" if legacy else "main-abcdef0"
-    version = "3.0.1" if legacy else "3.1.0"
-    chart_version = "3.0.2" if legacy else "3.1.0"
+    coordinates = (
+        verifier.LEGACY_310_COORDINATES if legacy_310 else verifier.LEGACY_RECOVERY_COORDINATES
+    )
+    is_legacy = legacy or legacy_310
+    revision = str(coordinates["sourceRevision"]) if is_legacy else SHA
+    digest = str(coordinates["imageDigest"]) if is_legacy else DIGEST
+    image_tag = str(coordinates["imageTag"]) if is_legacy else "main-abcdef0"
+    version = str(coordinates["applicationVersion"]) if is_legacy else "3.1.0"
+    chart_version = str(coordinates["chartVersion"]) if is_legacy else "3.1.0"
     canonical = f"ghcr.io/democratizedspace/dspace:{image_tag}"
     declared = f"{canonical}@{digest}" if rollback else canonical
 
@@ -177,7 +197,7 @@ def _verify_setup(
     public_build = override.get("public_build", build())
     default_html = (
         "<!doctype html><html><head><title>DSPACE</title></head><body></body></html>"
-        if legacy
+        if is_legacy
         else f'<meta name="dspace-build-revision" content="{SHA}">'
     )
     public_html = override.get("public_html", default_html)
@@ -298,7 +318,11 @@ def _verify_setup(
             environment="staging",
             release="dspace",
             namespace="dspace",
-            manifest=recovery_manifest(tmp_path) if legacy else manifest(tmp_path, provider),
+            manifest=(
+                legacy_310_manifest(tmp_path)
+                if legacy_310
+                else recovery_manifest(tmp_path) if legacy else manifest(tmp_path, provider)
+            ),
             application_version=None,
             source_revision=None,
             provider=None,
@@ -654,10 +678,43 @@ def test_exact_recovery_uses_legacy_contract_and_truthful_journeys(
     ]
 
 
+def test_exact_310_token_place_uses_legacy_contract_and_truthful_journeys(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    args, seen = _verify_setup(monkeypatch, tmp_path, legacy_310=True)
+    result = verifier.verify(args)
+    smoke_argv = seen[-1]
+    assert (
+        smoke_argv[smoke_argv.index("--identity-contract") + 1] == verifier.LEGACY_IDENTITY_CONTRACT
+    )
+    assert smoke_argv[smoke_argv.index("--expected-provider") + 1] == "token-place"
+    assert (
+        smoke_argv[smoke_argv.index("--expected-token-place-origin") + 1] == "https://token.example"
+    )
+    assert smoke_argv[smoke_argv.index("--expected-token-place-model") + 1] == "model-a"
+    assert result["journeys"] == [
+        {"name": "/build-meta.json", "passed": True},
+        {"name": "/", "passed": True},
+        {"name": "/chat", "passed": True},
+    ]
+
+
 @pytest.mark.parametrize("field", list(verifier.LEGACY_RECOVERY_COORDINATES))
 def test_any_recovery_coordinate_drift_prevents_legacy_selection(field: str) -> None:
     candidate = dict(verifier.LEGACY_RECOVERY_COORDINATES)
     candidate[field] = "different"
+    assert verifier.identity_contract(candidate) == verifier.MODERN_IDENTITY_CONTRACT
+
+
+@pytest.mark.parametrize("field", list(verifier.LEGACY_310_COORDINATES))
+def test_any_310_coordinate_drift_prevents_legacy_selection(field: str) -> None:
+    candidate = dict(verifier.LEGACY_310_COORDINATES)
+    candidate[field] = "different"
+    assert verifier.identity_contract(candidate) == verifier.MODERN_IDENTITY_CONTRACT
+
+
+def test_unrelated_modern_manifest_uses_modern_contract() -> None:
+    candidate = dict(verifier.LEGACY_310_COORDINATES, sourceRevision=SHA)
     assert verifier.identity_contract(candidate) == verifier.MODERN_IDENTITY_CONTRACT
 
 
@@ -799,6 +856,64 @@ def test_legacy_agreement_and_root_evidence_fail_closed(
     category: str,
 ) -> None:
     args, _ = _verify_setup(monkeypatch, tmp_path, legacy=True, overrides=overrides)
+    with pytest.raises(verifier.VerificationError, match=category):
+        verifier.verify(args)
+
+
+@pytest.mark.parametrize(
+    "overrides,category",
+    [
+        (
+            {
+                "direct_meta": {
+                    "dspace-1": json.dumps(
+                        {
+                            "gitSha": RECOVERY_SHA,
+                            "generatedAt": "2026-08-01T12:00:00Z",
+                            "source": "dspace",
+                        }
+                    )
+                }
+            },
+            "direct identity",
+        ),
+        (
+            {
+                "public_meta": json.dumps(
+                    {
+                        "gitSha": verifier.LEGACY_310_COORDINATES["sourceRevision"],
+                        "generatedAt": "2026-08-01T12:00:00Z",
+                        "source": "dspace",
+                        "extra": True,
+                    }
+                )
+            },
+            "public identity",
+        ),
+        (
+            {
+                "direct_meta": {
+                    "dspace-2": json.dumps(
+                        {
+                            "gitSha": verifier.LEGACY_310_COORDINATES["sourceRevision"],
+                            "generatedAt": "2026-08-02T12:00:00Z",
+                            "source": "dspace",
+                        }
+                    )
+                }
+            },
+            "pod/replica identity",
+        ),
+    ],
+    ids=("wrong-sha", "extra-field", "replica-disagreement"),
+)
+def test_310_legacy_metadata_failures_remain_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    overrides: dict[str, object],
+    category: str,
+) -> None:
+    args, _ = _verify_setup(monkeypatch, tmp_path, legacy_310=True, overrides=overrides)
     with pytest.raises(verifier.VerificationError, match=category):
         verifier.verify(args)
 


### PR DESCRIPTION
### Motivation
- The verifier only recognised the single immutable recovery tuple for DSPACE `3.0.1` as `legacy-build-meta-v1`, causing the approved immutable DSPACE `3.1.0` restoration to be treated as `build-info-v1` and fail runtime verification despite exposing legacy `/build-meta.json` metadata.

### Description
- Add an exact-match allowlist for the approved DSPACE `3.1.0` coordinates by introducing `LEGACY_310_COORDINATES` and combining it with the existing recovery tuple into `LEGACY_IDENTITY_COORDINATES` in `scripts/dspace_runtime_verifier.py` so `identity_contract()` returns `legacy-build-meta-v1` only when a manifest matches any complete tuple exactly.
- Preserve fail-closed behavior by requiring an exact field-by-field match for the whole tuple and not introducing any runtime fallback from modern to legacy contracts. 
- Keep existing legacy verification semantics (use `/build-meta.json`, require exact legacy JSON field set, full SHA verification, non-empty `generatedAt`/`source`, HTML root check without modern marker, and replica+public agreement) and ensure `token-place` smoke-runner args (origin and model) are passed unchanged when applicable.
- Add focused tests and fixtures in `tests/test_dspace_runtime_verifier.py` covering the original `3.0.1` tuple, the exact `3.1.0` tuple, one-field drift across every field for both allowlisted tuples, unrelated modern manifests, complete `3.1.0` verification including smoke-runner argv assertions, and negative cases for wrong SHA/extra fields/replica disagreement.
- Add a brief note to `docs/apps/dspace.md` documenting that the exact immutable DSPACE `3.1.0` artifact is explicitly allowlisted for the strict legacy contract and that this is not a general fallback for future releases.

### Testing
- Ran `python3 -m pytest -q tests/test_dspace_runtime_verifier.py` and observed `166 passed` indicating the new 3.1.0 paths and drift checks behave as expected.
- Ran `python3 -m pytest -q tests/test_release_manifest.py` and observed `204 passed` to confirm related manifest validation remained unaffected.
- Ran `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` which completed successfully for the touched docs.
- Ran repository `pre-commit` hooks for the changed files which passed whitespace/EOF hooks, but `pre-commit run --all-files` (full repo) failed on unrelated baseline YAML/flake8/linters outside the scope of this change and those files were not modified by this PR.

Files changed: `scripts/dspace_runtime_verifier.py`, `tests/test_dspace_runtime_verifier.py`, `docs/apps/dspace.md`.

Design notes and residual risk: this is an exact-match, allowlist-only fix that does not weaken verification semantics or add fallbacks; repository-wide lint/YAML issues remain pre-existing and unrelated to this change and are noted in the test output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a717db0ac70832fb3de394cc5eb271a)