### PR TITLE
Enable token.place staging metrics support and add generic app-metrics verifier (Refs #2405)

### DIFF
--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -323,3 +323,42 @@ just cf-tunnel-route host=token.place
 - token.place must preserve relay-blind E2EE: relay diagnostics and logs should expose safe routing metadata only, not plaintext payloads.
 - Verify `/relay/diagnostics`, real external compute-node registration, and a real E2EE request/response before production promotion so relay-compute issues are caught in staging.
 - Keep runtime secrets and per-environment external service configuration outside Helm examples and Sugarkube app config files.
+
+## Staging authenticated application metrics (Phase 1, Refs #2405)
+
+Sugarkube repository support now pins token.place chart `0.1.4` for staging metrics wiring. The published OCI chart was verified directly, not from source-only code:
+
+```bash
+just app-chart-status app=tokenplace
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.4
+helm pull oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.4
+```
+
+The fetched package reported immutable digest `sha256:0f16aef72500b33a598042465a9b703bf16dc7a5071b3d867c4a78d6928be1e7` and package SHA-256 `c960f7c0793032bcaebd8f8d5546cac16a1cc42b9c543c318f15b2243faaec7a`. Inspect the downloaded `tokenplace-0.1.4.tgz` before deploying; it must contain the opt-in `metrics.enabled`, `metrics.auth.existingSecret`, `metrics.auth.secretKey`, `serviceMonitor.enabled`, `/metrics` endpoint authorization through `authorization.credentials`, and bounded `app`, `environment`, `release`, and `cluster` relabelings.
+
+Merging this repository support does **not** deploy it. Use this order for staging only:
+
+1. Install or rotate the existing metrics bearer Secret. The value is read only from an interactive controlling terminal with hidden input and is never accepted as an argument, environment variable, ordinary stdin, shell history, or temporary file:
+
+   ```bash
+   just observability-app-metrics-secret-install app=tokenplace env=staging
+   ```
+
+2. Check the Secret/key contract without decoding or printing the value:
+
+   ```bash
+   just observability-app-metrics-secret-check app=tokenplace env=staging
+   ```
+
+3. Render and deploy token.place staging with the pinned chart and staging values, then run the generic verifier:
+
+   ```bash
+   just app-deploy app=tokenplace env=staging tag="$APP_TAG"
+   just observability-app-metrics-verify app=tokenplace env=staging
+   ```
+
+The public `https://staging.token.place/metrics` endpoint is expected to return HTTP `401` without credentials. Do not print its response body during verification.
+
+Rollback preserves the Secret: redeploy the previous known-good image tag or restore the previous chart pin (`0.1.3`) in `docs/apps/tokenplace.version`, render, and redeploy staging. Do not delete `tokenplace-staging-metrics-token`; it remains useful for safe rotation and future attempts.
+
+Dashboards, alert rules, functional schedulability, shared state, `/api/v1/relay/availability`, and live drill evidence remain follow-up phases after live metrics evidence exists.

--- a/docs/apps/tokenplace.version
+++ b/docs/apps/tokenplace.version
@@ -1,2 +1,2 @@
 # Default tokenplace chart version. Update when new chart releases are published.
-0.1.3
+0.1.4

--- a/docs/examples/tokenplace.values.staging.yaml
+++ b/docs/examples/tokenplace.values.staging.yaml
@@ -14,3 +14,22 @@ ingress:
 env:
   TOKEN_PLACE_ENV: staging
   TOKENPLACE_RELAY_PUBLIC_URL: https://staging.token.place
+
+
+metrics:
+  enabled: true
+  auth:
+    existingSecret: tokenplace-staging-metrics-token
+    secretKey: token
+
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  scrapeTimeout: 10s
+  additionalLabels:
+    release: kube-prometheus-stack
+  relabelings:
+    app: tokenplace
+    environment: staging
+    release: tokenplace
+    cluster: sugarkube-int

--- a/docs/observability-app-metrics.json
+++ b/docs/observability-app-metrics.json
@@ -1,0 +1,44 @@
+{
+  "applications": {
+    "tokenplace": {
+      "staging": {
+        "kubernetesContext": "sugar-staging",
+        "namespace": "tokenplace",
+        "serviceMonitorName": "tokenplace",
+        "expectedTargetCount": 1,
+        "secret": {"name": "tokenplace-staging-metrics-token", "key": "token"},
+        "endpoint": {"path": "/metrics", "interval": "30s", "scrapeTimeout": "10s"},
+        "publicMetrics": {"url": "https://staging.token.place/metrics", "expectedUnauthenticatedStatus": 401},
+        "canonicalTargetLabels": {"app": "tokenplace", "environment": "staging", "release": "tokenplace", "cluster": "sugarkube-int", "namespace": "tokenplace"},
+        "retries": {"attempts": 6, "delaySeconds": 10},
+        "requiredMetricFamilies": [
+          "tokenplace_compute_nodes_registered",
+          "tokenplace_compute_nodes_healthy",
+          "tokenplace_compute_node_lease_age_seconds",
+          "tokenplace_compute_node_evictions_total",
+          "tokenplace_relay_queue_depth",
+          "tokenplace_relay_oldest_queued_request_age_seconds",
+          "tokenplace_relay_in_flight_requests",
+          "tokenplace_relay_oldest_in_flight_age_seconds",
+          "tokenplace_relay_request_outcomes_total",
+          "tokenplace_http_requests_total",
+          "tokenplace_http_request_duration_seconds",
+          "tokenplace_instrumentation_up",
+          "tokenplace_build_info"
+        ],
+        "allowedApplicationLabels": {
+          "app": ["tokenplace"],
+          "environment": ["staging"],
+          "release": ["tokenplace"],
+          "cluster": ["sugarkube-int"],
+          "route": ["/", "/healthz", "/livez", "/metrics", "/api/v1/chat/completions", "/api/v1/meta", "/relay/diagnostics", "unknown"],
+          "method": ["GET", "POST", "OPTIONS"],
+          "status_class": ["2xx", "3xx", "4xx", "5xx"],
+          "outcome": ["success", "timeout", "rate_limited", "dependency_failure", "cancelled", "validation_error", "content_policy", "unknown_error"],
+          "le": []
+        },
+        "forbiddenApplicationLabels": ["authorization", "bearer", "ciphertext", "client_id", "email", "error", "exception", "ip", "key", "model", "prompt", "request_id", "response", "session", "token", "url", "user", "user_id"]
+      }
+    }
+  }
+}

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -459,3 +459,19 @@ PagerDuty incident recovers and resolves. Re-run live verification.
 > pause the Healthchecks check or its PagerDuty integration. Otherwise rollback itself generates a
 > page. After pausing, perform the documented Helm rollback, verify the intended prior structure,
 > and retain or remove the Kubernetes Secret only according to that revision's contract.
+
+## Generic application metrics verification
+
+Application metrics are declared in `docs/observability-app-metrics.json` and verified by the generic application-metrics verifier. The first configured consumer is token.place staging. The verifier is staging-only, asserts the `sugar-staging` Kubernetes context, checks the ServiceMonitor and referenced Secret/key contract without exposing the value, queries Prometheus through the Kubernetes API proxy, validates target count/health/labels/required metric families, enforces bounded application label enums, rejects sensitive label names, and confirms the public unauthenticated `/metrics` response is exactly HTTP `401` without printing the body.
+
+Use the app-specific wrappers when operating one application:
+
+```bash
+just observability-app-metrics-secret-install app=tokenplace env=staging
+just observability-app-metrics-secret-check app=tokenplace env=staging
+just observability-app-metrics-verify app=tokenplace env=staging
+```
+
+`just observability-verify env=staging` also runs every application metrics contract declared in the inventory after the existing observability verification. This does not change the proven DSPACE runtime verifier or DSPACE application configuration.
+
+Merging repository support does not deploy token.place metrics. Install or rotate the metrics Secret first, deploy the staging application chart, then run the verifier. Roll back by preserving the Secret and reverting the application chart pin or image tag. Dashboards, alert rules, live drills, functional schedulability, and shared state remain separate follow-ups requiring live metrics evidence.

--- a/justfile
+++ b/justfile
@@ -3543,3 +3543,15 @@ staging-ingress-ha-verify env='staging':
 
 staging-ingress-ha-rollback env='staging':
     scripts/staging_ingress_ha.sh rollback "{{ env }}"
+
+# Interactively install or rotate an application's staging metrics Secret (hidden input).
+observability-app-metrics-secret-install app env='staging':
+    @scripts/observability_helm.sh app-metrics-secret-install '{{ env }}' '{{ app }}'
+
+# Check an application's metrics Secret/key contract without reading its value.
+observability-app-metrics-secret-check app env='staging':
+    @scripts/observability_helm.sh app-metrics-secret-check '{{ env }}' '{{ app }}'
+
+# Verify an application's configured metrics contract through Prometheus.
+observability-app-metrics-verify app env='staging':
+    @scripts/observability_helm.sh app-metrics-verify '{{ env }}' '{{ app }}'

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -84,7 +84,7 @@ class ReleaseInputs:
 
 def safe_yaml_documents(text: str) -> list[object]:
     """Parse JSON-compatible YAML via Psych's AST, rejecting tags and aliases."""
-    ruby = r'''
+    ruby = r"""
 require "psych"
 require "json"
 scanner = Psych::ScalarScanner.new(Psych::ClassLoader::Restricted.new([], []))
@@ -103,7 +103,7 @@ def convert(node, scanner)
   end
 end
 puts JSON.generate(convert(Psych.parse_stream(STDIN.read), scanner))
-'''
+"""
     try:
         parsed = subprocess.run(
             ["ruby", "-e", ruby], input=text, capture_output=True, text=True, check=False
@@ -158,7 +158,9 @@ def release_associated(
 ) -> bool:
     metadata = document.get("metadata") if isinstance(document.get("metadata"), dict) else {}
     labels = metadata.get("labels") if isinstance(metadata.get("labels"), dict) else {}
-    annotations = metadata.get("annotations") if isinstance(metadata.get("annotations"), dict) else {}
+    annotations = (
+        metadata.get("annotations") if isinstance(metadata.get("annotations"), dict) else {}
+    )
     return (
         scalar(labels.get("app.kubernetes.io/instance")) == release
         or scalar(labels.get("release")) == release
@@ -185,7 +187,9 @@ def dspace_production_metrics_token_is_unsafe(
     if not contains_exact_scalar(document, {"METRICS_TOKEN"}):
         return False
     if metrics_enabled or scalar(document.get("kind")) not in {
-        "Deployment", "StatefulSet", "DaemonSet"
+        "Deployment",
+        "StatefulSet",
+        "DaemonSet",
     }:
         return True
     found, containers = nested_value(document, ("spec", "template", "spec", "containers"))
@@ -205,8 +209,10 @@ def dspace_production_metrics_token_is_unsafe(
             # Chart 3.0.2 uses the pod UID as a safe, unpredictable token when metrics are off.
             if (
                 set(entry) == {"name", "valueFrom"}
-                and isinstance(value_from, dict) and set(value_from) == {"fieldRef"}
-                and isinstance(field_ref, dict) and set(field_ref) == {"fieldPath"}
+                and isinstance(value_from, dict)
+                and set(value_from) == {"fieldRef"}
+                and isinstance(field_ref, dict)
+                and set(field_ref) == {"fieldPath"}
                 and field_ref.get("fieldPath") == "metadata.uid"
             ):
                 safe_entries.add(id(entry))
@@ -229,7 +235,6 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
     except (ValueError, json.JSONDecodeError) as error:
         return [f"rendered output is not safe structural YAML: {error}"]
     workloads: list[tuple[str, str]] = []
-    kinds: set[str] = set()
     ingress_hosts: set[str] = set()
     service_monitors: list[dict[str, object]] = []
     candidates = {inputs.app, inputs.release, *APP_CONTAINER_NAMES.get(inputs.app, set())}
@@ -245,9 +250,6 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
         name = scalar(metadata.get("name"))
         namespace = scalar(metadata.get("namespace"))
         labels = metadata.get("labels") if isinstance(metadata.get("labels"), dict) else {}
-        annotations = (
-            metadata.get("annotations") if isinstance(metadata.get("annotations"), dict) else {}
-        )
         associated = release_associated(
             document,
             inputs.release,
@@ -256,9 +258,10 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                 and kind not in {"Deployment", "StatefulSet", "DaemonSet"}
             ),
         )
-        if inputs.app == "dspace" and kind == "Secret":
+        if kind == "Secret" and inputs.app in {"dspace", "tokenplace"}:
             errors.append(
-                f"DSPACE rendered Secret {name or '<unnamed>'}; literal Secret resources are forbidden"
+                f"{inputs.app.upper()} rendered Secret {name or '<unnamed>'}; "
+                "literal Secret resources are forbidden"
             )
         if namespace and namespace != inputs.namespace:
             errors.append(
@@ -272,10 +275,15 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                 found, containers = nested_value(
                     document, ("spec", "template", "spec", "containers")
                 )
-                intended = [
-                    item
-                    for item in containers if isinstance(item, dict) and scalar(item.get("name")) in candidates
-                ] if found and isinstance(containers, list) else []
+                intended = (
+                    [
+                        item
+                        for item in containers
+                        if isinstance(item, dict) and scalar(item.get("name")) in candidates
+                    ]
+                    if found and isinstance(containers, list)
+                    else []
+                )
                 intended_container_found = intended_container_found or bool(intended)
                 for item in intended:
                     if not scalar(item.get("image")).endswith(expected_suffix):
@@ -300,6 +308,58 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
         errors.append("intended application container does not use the exact requested image tag")
     if inputs.host and inputs.host not in ingress_hosts:
         errors.append(f"no Ingress rule exactly matches expected host {inputs.host!r}")
+    tokenplace_metrics_configured = (
+        "ghcr.io/example/tokenplace" not in manifest
+        and resolved_values_scalar(inputs.values, ("metrics", "enabled")).lower() == "true"
+        and resolved_values_scalar(inputs.values, ("serviceMonitor", "enabled")).lower() == "true"
+    )
+    if inputs.app == "tokenplace" and inputs.env == "staging" and tokenplace_metrics_configured:
+        expected = {"name": "tokenplace-staging-metrics-token", "key": "token"}
+        if len(service_monitors) != 1:
+            errors.append("tokenplace staging metrics must render exactly one ServiceMonitor")
+        for monitor in service_monitors:
+            labels = (
+                monitor.get("metadata", {}).get("labels", {})
+                if isinstance(monitor.get("metadata"), dict)
+                else {}
+            )
+            spec = monitor.get("spec") if isinstance(monitor.get("spec"), dict) else {}
+            endpoints = spec.get("endpoints")
+            endpoint = (
+                endpoints[0]
+                if isinstance(endpoints, list) and endpoints and isinstance(endpoints[0], dict)
+                else {}
+            )
+            creds = (
+                endpoint.get("authorization", {}).get("credentials", {})
+                if isinstance(endpoint.get("authorization"), dict)
+                else {}
+            )
+            if labels.get("release") != "kube-prometheus-stack":
+                errors.append("tokenplace ServiceMonitor must have release: kube-prometheus-stack")
+            if (
+                endpoint.get("path") != "/metrics"
+                or endpoint.get("interval") != "30s"
+                or endpoint.get("scrapeTimeout") != "10s"
+            ):
+                errors.append("tokenplace ServiceMonitor endpoint contract mismatch")
+            if creds != expected:
+                errors.append(
+                    "tokenplace ServiceMonitor must reference the configured metrics Secret/key"
+                )
+            rendered = {
+                r.get("targetLabel"): r.get("replacement")
+                for r in endpoint.get("relabelings", [])
+                if isinstance(r, dict)
+            }
+            for k, v in {
+                "app": "tokenplace",
+                "environment": "staging",
+                "release": "tokenplace",
+                "cluster": "sugarkube-int",
+            }.items():
+                if rendered.get(k) != v:
+                    errors.append(f"tokenplace ServiceMonitor relabeling {k} mismatch")
     if inputs.app == "dspace":
         for required in ("Deployment", "Service"):
             if not any(
@@ -352,7 +412,11 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
 def parse_chart_yaml(text: str) -> dict[str, str]:
     documents = safe_yaml_documents(text)
     document = documents[0] if documents else {}
-    return {str(key): scalar(value) for key, value in document.items()} if isinstance(document, dict) else {}
+    return (
+        {str(key): scalar(value) for key, value in document.items()}
+        if isinstance(document, dict)
+        else {}
+    )
 
 
 def semver_key(v: str) -> tuple[int, int, int, int, tuple[object, ...]]:
@@ -422,13 +486,15 @@ def deployment_app_container_env_sets(
             found.append(
                 (
                     container_name,
-                    {
-                        scalar(item.get("name"))
-                        for item in envs
-                        if isinstance(item, dict) and scalar(item.get("name"))
-                    }
-                    if isinstance(envs, list)
-                    else set(),
+                    (
+                        {
+                            scalar(item.get("name"))
+                            for item in envs
+                            if isinstance(item, dict) and scalar(item.get("name"))
+                        }
+                        if isinstance(envs, list)
+                        else set()
+                    ),
                 )
             )
     return found
@@ -465,7 +531,8 @@ def latest_version(chart: str) -> tuple[str, str]:
         if production_safe_versions
         else (
             "",
-            f"latest unknown: no semver tags found; run: helm show chart {chart} --version <version>",
+            "latest unknown: no semver tags found; run: "
+            f"helm show chart {chart} --version <version>",
         )
     )
 
@@ -488,7 +555,9 @@ def expected_ingress_host(values: tuple[str, ...], explicit: str) -> str:
     host = scalar(resolved_host)
     enabled = scalar(resolved_enabled).lower()
     if enabled == "true" and not host:
-        raise SystemExit("ERROR: ingress.enabled is true but no nonempty ingress.host was resolved.")
+        raise SystemExit(
+            "ERROR: ingress.enabled is true but no nonempty ingress.host was resolved."
+        )
     return host if enabled != "false" else ""
 
 
@@ -689,7 +758,9 @@ def cmd_resolve_host(args: argparse.Namespace) -> int:
     try:
         host = expected_ingress_host(values, args.host)
     except (ValueError, json.JSONDecodeError, SystemExit) as error:
-        print(f"ERROR: values parsing failed while resolving ingress host: {error}", file=sys.stderr)
+        print(
+            f"ERROR: values parsing failed while resolving ingress host: {error}", file=sys.stderr
+        )
         return 1
     print(host)
     return 0

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Declarative application metrics verifier for Sugarkube observability."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_INVENTORY = ROOT / "docs" / "observability-app-metrics.json"
+K8S = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+METRIC = re.compile(r"^[a-zA-Z_:][a-zA-Z0-9_:]*$")
+DURATION = re.compile(r"^[1-9][0-9]*[smh]$")
+SAFE_STD_LABELS = {
+    "__name__",
+    "container",
+    "endpoint",
+    "instance",
+    "job",
+    "namespace",
+    "pod",
+    "service",
+    "prometheus",
+    "prometheus_replica",
+    "pod_template_hash",
+    "app_kubernetes_io_instance",
+    "app_kubernetes_io_name",
+    "app_kubernetes_io_component",
+}
+REDACT = "<redacted>"
+
+
+class ConfigError(ValueError):
+    pass
+
+
+class VerifyError(RuntimeError):
+    pass
+
+
+def normalize_env(env: str) -> str:
+    while env.startswith("env="):
+        env = env[4:]
+    if env == "int":
+        env = "staging"
+    if env != "staging":
+        raise ConfigError("application metrics verification is staging-only")
+    return env
+
+
+def _dict(v: Any, name: str) -> dict[str, Any]:
+    if not isinstance(v, dict):
+        raise ConfigError(f"{name} must be an object")
+    return v
+
+
+def _keys(obj: dict[str, Any], allowed: set[str], name: str) -> None:
+    extra = set(obj) - allowed
+    if extra:
+        raise ConfigError(f"unknown {name} key(s): {', '.join(sorted(extra))}")
+
+
+def _k8s(v: Any, name: str) -> str:
+    if not isinstance(v, str) or not K8S.fullmatch(v):
+        raise ConfigError(f"{name} is not a safe Kubernetes identifier")
+    return v
+
+
+def _unique_strings(v: Any, name: str, pattern: re.Pattern[str] | None = None) -> list[str]:
+    if not isinstance(v, list) or not all(isinstance(x, str) and x for x in v):
+        raise ConfigError(f"{name} must be a list of nonempty strings")
+    if len(v) != len(set(v)):
+        raise ConfigError(f"{name} contains duplicate values")
+    if pattern:
+        bad = [x for x in v if not pattern.fullmatch(x)]
+        if bad:
+            raise ConfigError(f"{name} contains malformed value(s)")
+    return v
+
+
+def load_inventory(path: Path = DEFAULT_INVENTORY) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as e:
+        raise ConfigError("malformed observability app metrics inventory") from e
+    _keys(_dict(data, "inventory"), {"applications"}, "inventory")
+    apps = _dict(data["applications"], "applications")
+    for app, envs in apps.items():
+        _k8s(app, "app")
+        for env, cfg in _dict(envs, f"{app} environments").items():
+            normalize_env(env)
+            validate_config(_dict(cfg, f"{app}/{env}"))
+    return data
+
+
+def validate_config(cfg: dict[str, Any]) -> None:
+    _keys(
+        cfg,
+        {
+            "kubernetesContext",
+            "namespace",
+            "serviceMonitorName",
+            "expectedTargetCount",
+            "secret",
+            "endpoint",
+            "publicMetrics",
+            "canonicalTargetLabels",
+            "retries",
+            "requiredMetricFamilies",
+            "allowedApplicationLabels",
+            "forbiddenApplicationLabels",
+        },
+        "app metrics config",
+    )
+    if cfg.get("kubernetesContext") != "sugar-staging":
+        raise ConfigError("kubernetesContext must be sugar-staging")
+    _k8s(cfg.get("namespace"), "namespace")
+    _k8s(cfg.get("serviceMonitorName"), "serviceMonitorName")
+    if not isinstance(cfg.get("expectedTargetCount"), int) or cfg["expectedTargetCount"] < 1:
+        raise ConfigError("expectedTargetCount must be positive")
+    secret = _dict(cfg.get("secret"), "secret")
+    _keys(secret, {"name", "key"}, "secret")
+    _k8s(secret.get("name"), "secret.name")
+    _k8s(secret.get("key"), "secret.key")
+    endpoint = _dict(cfg.get("endpoint"), "endpoint")
+    _keys(endpoint, {"path", "interval", "scrapeTimeout"}, "endpoint")
+    if endpoint.get("path") != "/metrics":
+        raise ConfigError("endpoint.path must be /metrics")
+    for k in ("interval", "scrapeTimeout"):
+        if not isinstance(endpoint.get(k), str) or not DURATION.fullmatch(endpoint[k]):
+            raise ConfigError(f"endpoint.{k} is malformed")
+    pub = _dict(cfg.get("publicMetrics"), "publicMetrics")
+    _keys(pub, {"url", "expectedUnauthenticatedStatus"}, "publicMetrics")
+    if (
+        not isinstance(pub.get("url"), str)
+        or not pub["url"].startswith("https://")
+        or not pub["url"].endswith("/metrics")
+    ):
+        raise ConfigError("public metrics url is unsafe")
+    if pub.get("expectedUnauthenticatedStatus") != 401:
+        raise ConfigError("expected unauthenticated status must be 401")
+    labels = _dict(cfg.get("canonicalTargetLabels"), "canonicalTargetLabels")
+    for k in ("app", "environment", "release", "cluster", "namespace"):
+        if not isinstance(labels.get(k), str) or not labels[k]:
+            raise ConfigError(f"canonicalTargetLabels.{k} is required")
+    retries = _dict(cfg.get("retries"), "retries")
+    _keys(retries, {"attempts", "delaySeconds"}, "retries")
+    for k in ("attempts", "delaySeconds"):
+        if not isinstance(retries.get(k), int) or not (1 <= retries[k] <= 60):
+            raise ConfigError(f"retries.{k} is out of bounds")
+    _unique_strings(cfg.get("requiredMetricFamilies"), "requiredMetricFamilies", METRIC)
+    allowed = _dict(cfg.get("allowedApplicationLabels"), "allowedApplicationLabels")
+    for name, enum in allowed.items():
+        if not re.fullmatch(r"[a-zA-Z_][a-zA-Z0-9_]*", name):
+            raise ConfigError("invalid application label name")
+        if name in cfg.get("forbiddenApplicationLabels", []):
+            raise ConfigError("label cannot be both allowed and forbidden")
+        if not isinstance(enum, list) or any(not isinstance(x, str) for x in enum):
+            raise ConfigError("invalid enum declaration")
+        if name != "le" and not enum:
+            raise ConfigError("bounded enum must not be empty")
+        if len(enum) != len(set(enum)):
+            raise ConfigError("duplicate enum value")
+    _unique_strings(cfg.get("forbiddenApplicationLabels"), "forbiddenApplicationLabels")
+
+
+def run_json(args: list[str]) -> Any:
+    p = subprocess.run(args, cwd=ROOT, capture_output=True, check=False)
+    if p.returncode:
+        raise VerifyError(f"command failed (details {REDACT})")
+    try:
+        return json.loads(p.stdout.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        raise VerifyError(f"malformed JSON (response {REDACT})") from e
+
+
+def verify_kubectl_contract(app: str, cfg: dict[str, Any]) -> None:
+    ctx = subprocess.run(
+        ["kubectl", "config", "current-context"], capture_output=True, text=True, check=False
+    )
+    if ctx.returncode or ctx.stdout.strip() != cfg["kubernetesContext"]:
+        raise VerifyError("Kubernetes context mismatch")
+    sm = run_json(
+        [
+            "kubectl",
+            "-n",
+            cfg["namespace"],
+            "get",
+            "servicemonitor",
+            cfg["serviceMonitorName"],
+            "-o",
+            "json",
+        ]
+    )
+    ep = _dict(sm.get("spec", {}).get("endpoints", [])[0], "ServiceMonitor endpoint")
+    auth = _dict(ep.get("authorization"), "authorization")
+    creds = _dict(auth.get("credentials"), "credentials")
+    if (
+        ep.get("path") != cfg["endpoint"]["path"]
+        or ep.get("interval") != cfg["endpoint"]["interval"]
+        or ep.get("scrapeTimeout") != cfg["endpoint"]["scrapeTimeout"]
+    ):
+        raise VerifyError("ServiceMonitor endpoint contract mismatch")
+    if creds.get("name") != cfg["secret"]["name"] or creds.get("key") != cfg["secret"]["key"]:
+        raise VerifyError("ServiceMonitor Secret reference mismatch")
+    sec = run_json(
+        ["kubectl", "-n", cfg["namespace"], "get", "secret", cfg["secret"]["name"], "-o", "json"]
+    )
+    if (
+        cfg["secret"]["key"] not in _dict(sec.get("data"), "secret data")
+        or not sec["data"][cfg["secret"]["key"]]
+    ):
+        raise VerifyError("Secret/key contract missing or empty")
+
+
+def prom_query(path: str) -> Any:
+    doc = run_json(
+        [
+            "kubectl",
+            "get",
+            "--raw",
+            "/api/v1/namespaces/monitoring/services/"
+            f"http:kube-prometheus-stack-prometheus:9090/proxy{path}",
+        ]
+    )
+    if doc.get("status") != "success":
+        raise VerifyError("Prometheus API returned unsuccessful status")
+    return doc.get("data")
+
+
+def verify_prometheus(cfg: dict[str, Any]) -> None:
+    last = None
+    for _ in range(cfg["retries"]["attempts"]):
+        try:
+            targets = prom_query("/api/v1/targets")
+            active = [
+                t
+                for t in targets.get("activeTargets", [])
+                if all(
+                    t.get("labels", {}).get(k) == v for k, v in cfg["canonicalTargetLabels"].items()
+                )
+            ]
+            if len(active) == cfg["expectedTargetCount"] and all(
+                t.get("health") == "up" for t in active
+            ):
+                break
+            last = "target convergence failed"
+        except Exception as e:
+            last = e
+        time.sleep(cfg["retries"]["delaySeconds"])
+    else:
+        raise VerifyError(f"target verification failed ({REDACT})") from (
+            last if isinstance(last, Exception) else None
+        )
+    metric_data = prom_query('/api/v1/series?match[]={__name__=~".+"}')
+    names = set()
+    allowed = cfg["allowedApplicationLabels"]
+    forbidden = set(cfg["forbiddenApplicationLabels"])
+    for series in metric_data:
+        name = series.get("__name__") if isinstance(series, dict) else None
+        if not isinstance(name, str):
+            raise VerifyError("structurally invalid Prometheus series")
+        if name in cfg["requiredMetricFamilies"]:
+            names.add(name)
+        if name.startswith(cfg["canonicalTargetLabels"]["app"] + "_"):
+            for label, value in series.items():
+                if label == "__name__" or label in SAFE_STD_LABELS:
+                    continue
+                if label in forbidden or any(bad in label.lower() for bad in forbidden):
+                    raise VerifyError("forbidden application label present")
+                if label in allowed and allowed[label] and value not in allowed[label]:
+                    raise VerifyError("unbounded application label value")
+                if label not in allowed and label not in cfg["canonicalTargetLabels"]:
+                    raise VerifyError("undeclared application label present")
+    missing = sorted(set(cfg["requiredMetricFamilies"]) - names)
+    if missing:
+        raise VerifyError("required metric families are missing")
+
+
+def verify_public_401(cfg: dict[str, Any]) -> None:
+    req = urllib.request.Request(cfg["publicMetrics"]["url"], method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            status = r.status
+    except urllib.error.HTTPError as e:
+        status = e.code
+    except Exception as e:
+        raise VerifyError(f"public metrics transport failed ({REDACT})") from e
+    if status != cfg["publicMetrics"]["expectedUnauthenticatedStatus"]:
+        raise VerifyError("public metrics unauthenticated status mismatch")
+
+
+def select(data: dict[str, Any], app: str, env: str) -> dict[str, Any]:
+    try:
+        return data["applications"][app][normalize_env(env)]
+    except KeyError as e:
+        raise ConfigError("configured app/env not found") from e
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser()
+    sub = p.add_subparsers(dest="cmd", required=True)
+    for n in ("validate", "secret-check", "verify"):
+        s = sub.add_parser(n)
+        s.add_argument("--app", default="")
+        s.add_argument("--env", default="staging")
+        s.add_argument("--inventory", type=Path, default=DEFAULT_INVENTORY)
+    a = p.parse_args(argv)
+    try:
+        data = load_inventory(a.inventory)
+        if a.cmd == "validate":
+            return 0
+        cfg = select(data, a.app, a.env)
+        if a.cmd == "secret-check":
+            verify_kubectl_contract(a.app, cfg)
+            print(
+                "Application metrics Secret contract exists "
+                "(value intentionally not read or printed)."
+            )
+            return 0
+        verify_kubectl_contract(a.app, cfg)
+        verify_prometheus(cfg)
+        verify_public_401(cfg)
+        print(
+            f"Application metrics verified for app={a.app} env=staging "
+            "(sensitive details redacted)."
+        )
+        return 0
+    except (ConfigError, VerifyError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -17,7 +17,7 @@ PAGERDUTY_SECRET="alertmanager-pagerduty"
 WATCHDOG_SECRET="alertmanager-healthchecks-watchdog"
 ALERTMANAGER_VALIDATOR="${ROOT}/scripts/verify_observability_alertmanager.rb"
 
-usage() { echo "Usage: $0 <render|install|upgrade|status|verify|dashboard-verify|pagerduty-test|watchdog-secret-install|watchdog-secret-check|watchdog-verify|watchdog-drill-create|watchdog-drill-status|watchdog-drill-clear> env=staging [fire|resolve]" >&2; }
+usage() { echo "Usage: $0 <render|install|upgrade|status|verify|dashboard-verify|pagerduty-test|watchdog-secret-install|watchdog-secret-check|watchdog-verify|watchdog-drill-create|watchdog-drill-status|watchdog-drill-clear|app-metrics-secret-install|app-metrics-secret-check|app-metrics-verify> env=staging [app]" >&2; }
 normalize_env() {
   local raw="${1:-}"
   while [[ "${raw}" == env=* ]]; do raw="${raw#env=}"; done
@@ -729,6 +729,47 @@ if not isinstance(dashboard, dict) or dashboard.get("uid") != "sugarkube-staging
   return 13
 )
 
+APP_METRICS_VERIFIER="${ROOT}/scripts/observability_app_metrics.py"
+APP_METRICS_TTY="${SUGARKUBE_APP_METRICS_TTY:-/dev/tty}"
+app_metrics_secret_install() {
+  local env app namespace secret key value
+  app="$1"; env="$(normalize_env "$2")"
+  [[ "${env}" == staging ]] || { echo "ERROR: application metrics Secrets are staging-only." >&2; return 2; }
+  assert_context
+  [[ -n "${app}" ]] || { echo "ERROR: app must not be empty." >&2; return 2; }
+  if env | cut -d= -f1 | grep -Eq "^(TOKENPLACE_METRICS|METRICS|SUGARKUBE_APP_METRICS)_TOKEN$"; then echo "ERROR: credential environment variables are refused." >&2; return 2; fi
+  [[ $# == 2 ]] || { echo "ERROR: credential arguments are refused." >&2; return 2; }
+  mapfile -t contract < <(python3 - "$app" "$env" <<'PY'
+import sys
+from scripts import observability_app_metrics as m
+data=m.load_inventory(); cfg=m.select(data, sys.argv[1], sys.argv[2])
+print(cfg['namespace']); print(cfg['secret']['name']); print(cfg['secret']['key'])
+PY
+)
+  namespace="${contract[0]}"; secret="${contract[1]}"; key="${contract[2]}"
+  exec 3<"${APP_METRICS_TTY}"
+  [[ "${SUGARKUBE_APP_METRICS_TEST_NONTTY:-0}" == 1 || -t 3 ]] || { echo "ERROR: an interactive controlling terminal is required." >&2; return 2; }
+  printf 'Enter application metrics bearer token for %s/%s (input hidden): ' "${app}" "${env}" >&2
+  IFS= read -r -s value <&3 || { echo "ERROR: could not read metrics token (value redacted)." >&2; return 2; }
+  printf '\n' >&2
+  [[ -n "${value}" && "${value}" != *$'\n'* && "${value}" != *$'\0'* ]] || { unset value; echo "ERROR: metrics token is invalid (value redacted)." >&2; return 2; }
+  if ! printf '%s' "${value}" | kubectl -n "${namespace}" create secret generic "${secret}" --from-file="${key}"=/dev/stdin --dry-run=client -o yaml | kubectl apply -f - >/dev/null; then
+    unset value; echo "ERROR: application metrics Secret installation failed (value redacted)." >&2; return 1
+  fi
+  unset value
+  echo "Application metrics Secret installed or rotated (value not displayed)."
+}
+app_metrics_secret_check() { assert_context; python3 "${APP_METRICS_VERIFIER}" secret-check --app "$1" --env "$(normalize_env "$2")"; }
+app_metrics_verify() { python3 "${APP_METRICS_VERIFIER}" verify --app "$1" --env "$(normalize_env "$2")"; }
+app_metrics_verify_all() {
+  python3 - <<'PY' | while read -r app env; do app_metrics_verify "$app" "$env"; done
+from scripts import observability_app_metrics as m
+data=m.load_inventory()
+for app, envs in data['applications'].items():
+  for env in envs: print(app, env)
+PY
+}
+
 cmd="${1:-}"; shift || true; [[ -n "${cmd}" ]] || { usage; exit 2; }
 env_arg="${1:-}"; normalize_env "${env_arg}" >/dev/null
 validate_dashboard
@@ -736,4 +777,4 @@ if [[ "${cmd}" == watchdog-drill-create ]]; then
   trap 'exit 130' INT
   trap 'exit 143' TERM
 fi
-case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) dashboard_verify ;; pagerduty-test) pagerduty_test "${2:-${1:-}}" ;; watchdog-secret-install) watchdog_secret_install "${@:2}" ;; watchdog-secret-check) watchdog_secret_check ;; watchdog-verify) watchdog_live_check ;; watchdog-drill-create) watchdog_silence_create ;; watchdog-drill-status) watchdog_silence_list ;; watchdog-drill-clear) watchdog_silence_clear ;; *) usage; exit 2 ;; esac
+case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify; [[ "${SUGARKUBE_OBSERVABILITY_APP_METRICS_SKIP:-0}" == 1 ]] || app_metrics_verify_all ;; dashboard-verify) dashboard_verify ;; pagerduty-test) pagerduty_test "${2:-${1:-}}" ;; watchdog-secret-install) watchdog_secret_install "${@:2}" ;; watchdog-secret-check) watchdog_secret_check ;; watchdog-verify) watchdog_live_check ;; watchdog-drill-create) watchdog_silence_create ;; watchdog-drill-status) watchdog_silence_list ;; watchdog-drill-clear) watchdog_silence_clear ;; app-metrics-secret-install) app_metrics_secret_install "${2:-}" "${env_arg}" ;; app-metrics-secret-check) app_metrics_secret_check "${2:-}" "${env_arg}" ;; app-metrics-verify) app_metrics_verify "${2:-}" "${env_arg}" ;; *) usage; exit 2 ;; esac

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2152,9 +2152,9 @@ def test_app_chart_status_reports_pin_and_stale_latest(
     assert result.returncode == 0, result.stderr + result.stdout
     assert "app: tokenplace" in result.stdout
     assert "chart ref: oci://ghcr.io/futuroptimist/charts/tokenplace" in result.stdout
-    assert "pinned version: 0.1.3" in result.stdout
+    assert "pinned version: 0.1.4" in result.stdout
     assert "chart appVersion: main-deadbee" in result.stdout
-    assert "Pinned chart appears stale: 0.1.3 < 9.9.9" in result.stdout
+    assert "Pinned chart appears stale: 0.1.4 < 9.9.9" in result.stdout
     assert "Run: just app-chart-bump app=tokenplace version=9.9.9" in result.stdout
 
 
@@ -2291,10 +2291,10 @@ def test_app_deploy_uses_app_release_namespace_chart_values(
         assert f"-f {value}" in helm_log
     if app == "tokenplace":
         assert (
-            "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.3" in helm_log
+            "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.4" in helm_log
         )
         assert "template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace" in helm_log
-        assert "--version 0.1.3" in helm_log
+        assert "--version 0.1.4" in helm_log
         assert "--version 9.9.9" not in helm_log
 
 
@@ -2344,7 +2344,7 @@ def test_app_deploy_passes_tokenplace_when_manifest_metadata_env_present(
     assert "9.9.9" not in result.stdout
     assert pin_path.read_text(encoding="utf-8") == before_pin
     helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
-    assert "--version 0.1.3" in helm_log
+    assert "--version 0.1.4" in helm_log
     assert "--version 9.9.9" not in helm_log
 
 
@@ -2364,7 +2364,7 @@ def test_app_redeploy_prints_chart_pin_reminder_without_latest_lookup_or_pin_mut
     assert pin_path.read_text(encoding="utf-8") == before_pin
     helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
     assert "upgrade tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace" in helm_log
-    assert "--version 0.1.3" in helm_log
+    assert "--version 0.1.4" in helm_log
     assert "--version 9.9.9" not in helm_log
 
 
@@ -5033,7 +5033,7 @@ def test_direct_helm_oci_helper_matching_env_succeeds(
 
     assert result.returncode == 0, result.stderr + result.stdout
     helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
-    assert "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.3" in helm_log
+    assert "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.4" in helm_log
     assert "upgrade tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace" in helm_log
     assert "--description" not in helm_log
 
@@ -5257,7 +5257,7 @@ def test_app_redeploy_guard_staging_requested_prod_detected_fails_before_helm(
 def test_app_chart_bump_remains_cluster_independent(generic_app_stub_env: dict[str, str]) -> None:
     env = generic_app_stub_env.copy()
     env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
-    result = _run_just(["app-chart-bump", "app=tokenplace", "version=0.1.3"], env)
+    result = _run_just(["app-chart-bump", "app=tokenplace", "version=0.1.4"], env)
     assert result.returncode == 0, result.stderr + result.stdout
     kubectl_log = Path(env["HOME"]).parent / "kubectl.log"
     assert not kubectl_log.exists() or "get nodes" not in kubectl_log.read_text(encoding="utf-8")
@@ -5275,3 +5275,24 @@ def test_dspace_promote_prod_guard_mismatch_fails_before_helm(
     assert "manifest=<approved-candidate.json> is required" in result.stderr
     helm_log_path = Path(env["HELM_LOG"])
     assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
+
+
+def test_observability_app_metrics_just_recipes_are_secure_and_generic():
+    text = (REPO_ROOT / "justfile").read_text(encoding="utf-8") + "\n" + (
+        REPO_ROOT / "scripts/observability_helm.sh"
+    ).read_text(encoding="utf-8")
+    for recipe in [
+        "observability-app-metrics-secret-install",
+        "observability-app-metrics-secret-check",
+        "observability-app-metrics-verify",
+    ]:
+        assert recipe in text
+    assert "read -r -s value" in text
+    assert '--from-file="${key}"=/dev/stdin' in text
+    assert "credential environment variables are refused" in text
+    assert "credential arguments are refused" in text
+    assert "value not displayed" in text
+    app_metrics_lines = "\n".join(
+        line for line in text.splitlines() if "app_metrics" in line
+    )
+    assert "base64 --decode" not in app_metrics_lines

--- a/tests/test_observability_app_metrics.py
+++ b/tests/test_observability_app_metrics.py
@@ -1,0 +1,65 @@
+import json
+import subprocess
+from pathlib import Path
+import pytest
+from scripts import observability_app_metrics as m
+
+ROOT = Path(__file__).resolve().parents[1]
+INV = ROOT / "docs/observability-app-metrics.json"
+
+
+def test_inventory_accepts_tokenplace_contract():
+    data = m.load_inventory(INV)
+    cfg = data["applications"]["tokenplace"]["staging"]
+    assert cfg["secret"] == {"name": "tokenplace-staging-metrics-token", "key": "token"}
+    assert cfg["expectedTargetCount"] == 1
+    assert cfg["publicMetrics"]["expectedUnauthenticatedStatus"] == 401
+    assert "tokenplace_relay_queue_depth" in cfg["requiredMetricFamilies"]
+    assert "user_id" in cfg["forbiddenApplicationLabels"]
+
+
+def test_inventory_rejects_unknown_keys_and_duplicates(tmp_path):
+    data = json.loads(INV.read_text())
+    data["applications"]["tokenplace"]["staging"]["surprise"] = True
+    p = tmp_path / "bad.json"
+    p.write_text(json.dumps(data))
+    with pytest.raises(m.ConfigError, match="unknown"):
+        m.load_inventory(p)
+    data = json.loads(INV.read_text())
+    fam = data["applications"]["tokenplace"]["staging"]["requiredMetricFamilies"]
+    fam.append(fam[0])
+    p.write_text(json.dumps(data))
+    with pytest.raises(m.ConfigError, match="duplicate"):
+        m.load_inventory(p)
+
+
+def test_inventory_rejects_production_and_invalid_enums(tmp_path):
+    data = json.loads(INV.read_text())
+    data["applications"]["tokenplace"]["prod"] = data["applications"]["tokenplace"].pop("staging")
+    p = tmp_path / "bad.json"
+    p.write_text(json.dumps(data))
+    with pytest.raises(m.ConfigError, match="staging-only"):
+        m.load_inventory(p)
+    data = json.loads(INV.read_text())
+    data["applications"]["tokenplace"]["staging"]["allowedApplicationLabels"]["outcome"] = []
+    p.write_text(json.dumps(data))
+    with pytest.raises(m.ConfigError, match="must not be empty"):
+        m.load_inventory(p)
+
+
+def test_verifier_source_has_no_tokenplace_branch():
+    text = (ROOT / "scripts/observability_app_metrics.py").read_text()
+    assert 'if app == "tokenplace"' not in text
+    assert "if app == 'tokenplace'" not in text
+
+
+def test_redaction_for_malformed_prometheus(monkeypatch):
+    def fake(args, **kwargs):
+        if args[:3] == ["kubectl", "config", "current-context"]:
+            return subprocess.CompletedProcess(args, 0, "sugar-staging", "")
+        return subprocess.CompletedProcess(args, 0, b"{bad-secret-url-http://10.0.0.1}", b"")
+
+    monkeypatch.setattr(m.subprocess, "run", fake)
+    cfg = m.load_inventory(INV)["applications"]["tokenplace"]["staging"]
+    with pytest.raises(m.VerifyError, match="redacted"):
+        m.verify_kubectl_contract("anything", cfg)

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -820,6 +820,7 @@ printf '%s' "$code"
         "ALERTMANAGER_CONFIG": str(tmp_path / "alertmanager-config.yaml"),
         "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_ATTEMPTS": retry_attempts,
         "SUGARKUBE_OBSERVABILITY_TARGET_HEALTH_INTERVAL_SECONDS": retry_interval,
+        "SUGARKUBE_OBSERVABILITY_APP_METRICS_SKIP": "1",
         "SUGARKUBE_WATCHDOG_OBSERVATION_SECONDS": "0",
         "SUGARKUBE_WATCHDOG_TEST_ALLOW_SHORT_OBSERVATION": "1",
         "SUGARKUBE_WATCHDOG_TTY": str(tmp_path / "watchdog-tty"),
@@ -2217,3 +2218,51 @@ def test_watchdog_silence_api_failures_do_not_expose_fixture_contents(tmp_path, 
     assert "response redacted" in output
     if command == "watchdog-drill-clear":
         assert not (tmp_path / "watchdog-silence-deletions").exists()
+
+
+def test_tokenplace_metrics_pin_and_values_contract():
+    assert (ROOT / "docs/apps/tokenplace.version").read_text(encoding="utf-8").splitlines()[
+        1
+    ].strip() == "0.1.4"
+    values = yaml_load(ROOT / "docs/examples/tokenplace.values.staging.yaml")
+    assert values["metrics"] == {
+        "enabled": True,
+        "auth": {"existingSecret": "tokenplace-staging-metrics-token", "secretKey": "token"},
+    }
+    assert values["serviceMonitor"]["enabled"] is True
+    assert values["serviceMonitor"]["interval"] == "30s"
+    assert values["serviceMonitor"]["scrapeTimeout"] == "10s"
+    assert values["serviceMonitor"]["additionalLabels"] == {"release": "kube-prometheus-stack"}
+    assert values["serviceMonitor"]["relabelings"] == {
+        "app": "tokenplace",
+        "environment": "staging",
+        "release": "tokenplace",
+        "cluster": "sugarkube-int",
+    }
+    rendered = subprocess.run(
+        [
+            "helm",
+            "template",
+            "tokenplace",
+            "oci://ghcr.io/futuroptimist/charts/tokenplace",
+            "--version",
+            "0.1.4",
+            "--namespace",
+            "tokenplace",
+            "-f",
+            "docs/examples/tokenplace.values.dev.yaml",
+            "-f",
+            "docs/examples/tokenplace.values.staging.yaml",
+            "--set",
+            "image.tag=main-deadbee",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout
+    assert "kind: ServiceMonitor" in rendered
+    assert "authorization:" in rendered and "credentials:" in rendered
+    assert "tokenplace-staging-metrics-token" in rendered
+    assert "kind: Secret" not in rendered
+    assert "forbidden" not in rendered


### PR DESCRIPTION
### Motivation

- Provide Phase 1 repository support for #2405 by enabling token.place authenticated `/metrics` in staging and adding a generic, declarative application-metrics verifier and secure Secret operator flow.
- Keep metrics credentials out of the repo and enforce a safe operator workflow for installing/rotating the bearer-token Secret.
- Make verification application-agnostic and driven only by a strict inventory so future apps can be added without code branching on app names.

### Description

- Pin token.place chart to `0.1.4` and enable staging metrics via staging overlay values with Secret reference only (Secret `tokenplace-staging-metrics-token`, key `token`), ServiceMonitor enabled, `interval: 30s`, `scrapeTimeout: 10s`, `release: kube-prometheus-stack` label, and the configured relabelings. (`docs/apps/tokenplace.version`, `docs/examples/tokenplace.values.staging.yaml`).
- Add a declarative observability inventory `docs/observability-app-metrics.json` describing token.place staging expectations: namespace, ServiceMonitor name, expected target count, Secret name/key contract, canonical labels, public `/metrics` URL + expected 401, retries, required metric families, allowed/forbidden app label enums.
- Implement a generic verifier `scripts/observability_app_metrics.py` that validates inventory shape, enforces staging-only, asserts Kubernetes context, checks ServiceMonitor endpoint/authorization/Secret reference (without leaking secrets), queries Prometheus via the Kubernetes API proxy, enforces target count/health/labels/required metric families, validates bounded enums, redacts sensitive details, and confirms public unauthenticated `/metrics` returns HTTP 401.
- Add secure Just/helm wrappers and operator recipes: `observability-app-metrics-secret-install`, `observability-app-metrics-secret-check`, and `observability-app-metrics-verify`, integrating them into `scripts/observability_helm.sh` and `justfile` with the same TTY-hidden-input watchdog pattern and refusal of argument/env/non-TTY credential paths.
- Extend the exact-release render gate in `scripts/app_chart.py` to generically forbid literal Secret resources for DSPACE and token.place and to validate token.place ServiceMonitor/authorization/relabeling contract in staging when metrics are enabled so malformed configured metrics contracts fail early during rendering.
- Documentation updates describing the verified OCI chart digest, reproducible verification commands, secure Secret install/check flow, deployment order, public 401 expectations, rollback guidance, and follow-up scope (dashboards/alerts/schedulability remain separate).

### Testing

- Unit/integration test suite: `python3 -m pytest -q tests/test_observability_app_metrics.py tests/test_observability_helm.py tests/test_generic_app_just_recipes.py tests/test_app_config.py` — result: all tests in those suites passed (`499 passed`).
- OCI/helm verification performed locally in the run: `just app-chart-status app=tokenplace` and `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.4` and `helm pull oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.4` — the package and digest were observed during verification (`sha256:0f16aef7...`).
- Observability render dry-run: `just observability-render env=staging >/tmp/observability-render.yaml` — render completed and validators exercised.
- Secret/scan and docs checks: `git diff | python3 scripts/scan-secrets.py` (no committed secrets), `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` — both ran in the environment (spell/link checks passed). `pre-commit run --all-files` was attempted but failed on unrelated repository-wide baseline hooks (existing YAML/flake8/trailing-whitespace checks unrelated to this PR); those unrelated auto-fixes were not left in the commit.

Notes and residuals

- The verifier and installer are staging-only and assert the `sugar-staging` / `sugar-staging` context; they will refuse production to avoid accidental exposure.
- No secret values were added to the repository; the installer reads credentials only from an interactive TTY and writes the Secret via a `kubectl create secret --from-file=... --dry-run=client -o yaml | kubectl apply -f -` flow.
- Creating the GitHub pull request with `gh` was not possible in this environment due to missing authentication; the patch and tests are ready for a maintainer to open the PR with the recommended title "Enable tokenplace staging app metrics support" and body referencing `Refs #2405`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a723a8a8e94832fa2d1b34dde889325)