### PR TITLE
Enable token.place staging authenticated metrics and add generic app-metrics verifier (Refs #2405)

### DIFF
--- a/docs/apps/tokenplace.md
+++ b/docs/apps/tokenplace.md
@@ -323,3 +323,53 @@ just cf-tunnel-route host=token.place
 - token.place must preserve relay-blind E2EE: relay diagnostics and logs should expose safe routing metadata only, not plaintext payloads.
 - Verify `/relay/diagnostics`, real external compute-node registration, and a real E2EE request/response before production promotion so relay-compute issues are caught in staging.
 - Keep runtime secrets and per-environment external service configuration outside Helm examples and Sugarkube app config files.
+
+## Phase 1 staging authenticated metrics (Refs #2405)
+
+Chart `0.1.4` is publicly fetchable from `oci://ghcr.io/futuroptimist/charts/tokenplace` and was verified from the fetched OCI package, not from source checkout alone. The immutable registry digest reported by Helm is `sha256:0f16aef72500b33a598042465a9b703bf16dc7a5071b3d867c4a78d6928be1e7`; the downloaded chart archive checksum observed during verification was `sha256:c960f7c0793032bcaebd8f8d5546cac16a1cc42b9c543c318f15b2243faaec7a`.
+
+Reproduce the package verification before changing the pin or deploying:
+
+```bash
+just app-chart-status app=tokenplace
+helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.4
+helm pull oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.4
+mkdir -p /tmp/tokenplace-chart-0.1.4
+printf '%s  %s\n' c960f7c0793032bcaebd8f8d5546cac16a1cc42b9c543c318f15b2243faaec7a tokenplace-0.1.4.tgz | sha256sum -c -
+tar -xzf tokenplace-0.1.4.tgz -C /tmp/tokenplace-chart-0.1.4
+rg -n 'metrics:|existingSecret|secretKey|serviceMonitor|authorization|/metrics|targetLabel: (app|environment|release|cluster)' /tmp/tokenplace-chart-0.1.4/tokenplace
+```
+
+The staging overlay enables only authenticated metrics references: `metrics.enabled=true`, `metrics.auth.existingSecret=tokenplace-staging-metrics-token`, `metrics.auth.secretKey=token`, and a `ServiceMonitor` labeled for `release=kube-prometheus-stack`. It must render references to the Secret but never a Secret resource or token value.
+
+Deployment order:
+
+1. Install or rotate the staging metrics Secret from an interactive terminal. The command refuses credential arguments, environment variables, ordinary stdin, and non-staging contexts.
+
+   ```bash
+   just observability-app-metrics-secret-install app=tokenplace env=staging
+   ```
+
+2. Check the Secret/key contract without decoding or printing the value.
+
+   ```bash
+   just observability-app-metrics-secret-check app=tokenplace env=staging
+   ```
+
+3. Deploy or upgrade token.place staging with the pinned chart and staging values.
+
+   ```bash
+   just app-deploy app=tokenplace env=staging tag="$APP_TAG"
+   ```
+
+4. Verify the generic application metrics contract.
+
+   ```bash
+   just observability-app-metrics-verify app=tokenplace env=staging
+   ```
+
+The public unauthenticated `https://staging.token.place/metrics` endpoint is expected to return HTTP `401` and the verifier checks only the status, not the response body.
+
+Merging this repository support does not deploy token.place staging. Roll back repository support by reverting `docs/apps/tokenplace.version` to `0.1.3` and removing the staging metrics overlay, then redeploy staging with the previous chart pin if needed. Preserve `tokenplace-staging-metrics-token` during rollback so a later fixed chart can reuse or rotate it safely.
+
+Dashboards, alert rules, functional schedulability metrics, shared state, `/api/v1/relay/availability`, and live drill evidence remain follow-up work after live metrics are available.

--- a/docs/apps/tokenplace.version
+++ b/docs/apps/tokenplace.version
@@ -1,2 +1,2 @@
 # Default tokenplace chart version. Update when new chart releases are published.
-0.1.3
+0.1.4

--- a/docs/examples/tokenplace.values.staging.yaml
+++ b/docs/examples/tokenplace.values.staging.yaml
@@ -14,3 +14,20 @@ ingress:
 env:
   TOKEN_PLACE_ENV: staging
   TOKENPLACE_RELAY_PUBLIC_URL: https://staging.token.place
+metrics:
+  enabled: true
+  auth:
+    existingSecret: tokenplace-staging-metrics-token
+    secretKey: token
+
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  scrapeTimeout: 10s
+  additionalLabels:
+    release: kube-prometheus-stack
+  relabelings:
+    app: tokenplace
+    environment: staging
+    release: tokenplace
+    cluster: sugarkube-int

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,15 @@
+# Observability operations
+
+## Declarative application metrics verification
+
+Application metrics contracts live in `platform/observability/app-metrics.json`. The inventory is strict, data-only configuration: it declares the Kubernetes context, namespace, `ServiceMonitor`, Secret name/key, canonical target labels, required metric families, allowed bounded application label enums, forbidden sensitive labels, retry settings, and the expected unauthenticated public `/metrics` status.
+
+Operators can install, check, and verify a configured staging application without placing credentials in Git, arguments, environment variables, logs, or temporary files:
+
+```bash
+just observability-app-metrics-secret-install app=tokenplace env=staging
+just observability-app-metrics-secret-check app=tokenplace env=staging
+just observability-app-metrics-verify app=tokenplace env=staging
+```
+
+`just observability-verify env=staging` remains the full observability verification entry point and now also runs all configured application metrics verifiers after the established DSPACE and observability checks. Production application metrics verification is intentionally refused until production observability is codified.

--- a/justfile
+++ b/justfile
@@ -3490,6 +3490,19 @@ observability-watchdog-drill-clear env='':
     @scripts/observability_helm.sh watchdog-drill-clear '{{ env }}'
 
 # Render the pinned staging blackbox exporter and Probe manifests (read-only).
+
+# Interactively install or rotate a staging application metrics bearer token (hidden input).
+observability-app-metrics-secret-install app env='staging':
+    @scripts/observability_helm.sh app-metrics-secret-install '{{ env }}' 'app={{ app }}'
+
+# Check a staging application metrics Secret/key contract without reading its value.
+observability-app-metrics-secret-check app env='staging':
+    @scripts/observability_helm.sh app-metrics-secret-check '{{ env }}' 'app={{ app }}'
+
+# Verify configured staging application metrics through Prometheus and the public 401 contract.
+observability-app-metrics-verify app env='staging':
+    @scripts/observability_helm.sh app-metrics-verify '{{ env }}' 'app={{ app }}'
+
 observability-blackbox-render env='':
     @scripts/observability_blackbox.sh render '{{ env }}'
 

--- a/platform/observability/app-metrics.json
+++ b/platform/observability/app-metrics.json
@@ -1,0 +1,115 @@
+{
+  "applications": {
+    "tokenplace": {
+      "environments": {
+        "staging": {
+          "kubernetesContext": "sugar-staging",
+          "namespace": "tokenplace",
+          "serviceMonitorName": "tokenplace",
+          "expectedTargetCount": 1,
+          "secret": {
+            "name": "tokenplace-staging-metrics-token",
+            "key": "token"
+          },
+          "endpoint": {
+            "path": "/metrics",
+            "interval": "30s",
+            "scrapeTimeout": "10s",
+            "publicUrl": "https://staging.token.place/metrics",
+            "expectedUnauthenticatedStatus": 401
+          },
+          "targetLabels": {
+            "app": "tokenplace",
+            "environment": "staging",
+            "release": "tokenplace",
+            "cluster": "sugarkube-int"
+          },
+          "retries": {
+            "attempts": 6,
+            "delaySeconds": 10
+          },
+          "requiredMetricFamilies": [
+            "tokenplace_compute_nodes_registered",
+            "tokenplace_compute_nodes_healthy",
+            "tokenplace_compute_node_lease_age_seconds",
+            "tokenplace_compute_node_evictions_total",
+            "tokenplace_relay_queue_depth",
+            "tokenplace_relay_oldest_queued_request_age_seconds",
+            "tokenplace_relay_in_flight_requests",
+            "tokenplace_relay_oldest_in_flight_age_seconds",
+            "tokenplace_relay_request_outcomes_total",
+            "tokenplace_http_requests_total",
+            "tokenplace_http_request_duration_seconds",
+            "tokenplace_instrumentation_up",
+            "tokenplace_build_info"
+          ],
+          "allowedApplicationLabels": {
+            "method": [
+              "GET",
+              "POST",
+              "PUT",
+              "PATCH",
+              "DELETE",
+              "OPTIONS",
+              "HEAD"
+            ],
+            "route": [
+              "/",
+              "/livez",
+              "/healthz",
+              "/metrics",
+              "/relay/diagnostics",
+              "/api/v1/meta",
+              "/api/v1/relay/request",
+              "/api/v1/relay/response"
+            ],
+            "status": [
+              "success",
+              "error",
+              "accepted",
+              "rejected",
+              "timeout",
+              "not_found",
+              "unauthorized"
+            ],
+            "outcome": [
+              "success",
+              "error",
+              "timeout",
+              "evicted",
+              "expired",
+              "cancelled"
+            ],
+            "version": [
+              "0.1.1"
+            ],
+            "commit": [
+              "unknown"
+            ],
+            "build_date": [
+              "unknown"
+            ]
+          },
+          "forbiddenApplicationLabels": [
+            "authorization",
+            "cookie",
+            "email",
+            "instance",
+            "ip",
+            "node",
+            "password",
+            "pod",
+            "remote_addr",
+            "scrapeUrl",
+            "secret",
+            "session",
+            "token",
+            "url",
+            "user",
+            "username"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Generic verifier for declaratively configured authenticated app metrics."""
+
+from __future__ import annotations
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = ROOT / "platform/observability/app-metrics.json"
+SAFE = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+LABEL = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+DUR = re.compile(r"^[1-9][0-9]*s$")
+METRIC = re.compile(r"^[a-zA-Z_:][a-zA-Z0-9_:]*$")
+STANDARD = {
+    "job",
+    "namespace",
+    "service",
+    "endpoint",
+    "container",
+    "prometheus",
+    "prometheus_replica",
+    "pod",
+    "instance",
+}
+
+
+class Error(Exception):
+    pass
+
+
+def die(msg, code=2):
+    print(f"ERROR: {msg}", file=sys.stderr)
+    return code
+
+
+def load(path=CONFIG):
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except Exception as e:
+        raise Error("malformed app metrics inventory (details redacted)") from e
+    if set(data) != {"applications"} or not isinstance(data["applications"], dict):
+        raise Error("inventory must contain only applications")
+    for app, ad in data["applications"].items():
+        if not SAFE.fullmatch(app):
+            raise Error("unsafe application name")
+        if set(ad) != {"environments"} or set(ad["environments"]) != {"staging"}:
+            raise Error("only staging app metrics are supported")
+        c = ad["environments"]["staging"]
+        allowed = {
+            "kubernetesContext",
+            "namespace",
+            "serviceMonitorName",
+            "expectedTargetCount",
+            "secret",
+            "endpoint",
+            "targetLabels",
+            "retries",
+            "requiredMetricFamilies",
+            "allowedApplicationLabels",
+            "forbiddenApplicationLabels",
+        }
+        if set(c) != allowed:
+            raise Error(f"unknown app metrics keys for {app}")
+        for k in ("namespace", "serviceMonitorName"):
+            if not SAFE.fullmatch(c[k]):
+                raise Error("unsafe Kubernetes identifier")
+        if c["kubernetesContext"] != "sugar-staging":
+            raise Error("staging context must be sugar-staging")
+        if not isinstance(c["expectedTargetCount"], int) or c["expectedTargetCount"] < 1:
+            raise Error("invalid expected target count")
+        if (
+            set(c["secret"]) != {"name", "key"}
+            or not SAFE.fullmatch(c["secret"]["name"])
+            or not SAFE.fullmatch(c["secret"]["key"])
+        ):
+            raise Error("invalid secret contract")
+        if set(c["endpoint"]) != {
+            "path",
+            "interval",
+            "scrapeTimeout",
+            "publicUrl",
+            "expectedUnauthenticatedStatus",
+        }:
+            raise Error("invalid endpoint declaration")
+        if (
+            c["endpoint"]["path"] != "/metrics"
+            or not DUR.fullmatch(c["endpoint"]["interval"])
+            or not DUR.fullmatch(c["endpoint"]["scrapeTimeout"])
+        ):
+            raise Error("invalid endpoint timing/path")
+        if c["endpoint"]["expectedUnauthenticatedStatus"] != 401:
+            raise Error("invalid unauthenticated status")
+        if set(c["targetLabels"]) != {"app", "environment", "release", "cluster"} or any(
+            not isinstance(v, str) or not v for v in c["targetLabels"].values()
+        ):
+            raise Error("invalid canonical target labels")
+        mets = c["requiredMetricFamilies"]
+        if len(mets) != len(set(mets)) or any(not METRIC.fullmatch(m) for m in mets):
+            raise Error("duplicate or malformed metric name")
+        enums = c["allowedApplicationLabels"]
+        if not isinstance(enums, dict) or any(
+            not LABEL.fullmatch(k)
+            or not isinstance(v, list)
+            or not v
+            or len(v) != len(set(v))
+            or any(not isinstance(x, str) or not x or len(x) > 100 for x in v)
+            for k, v in enums.items()
+        ):
+            raise Error("invalid enum declarations")
+        forbidden = c["forbiddenApplicationLabels"]
+        if (
+            not isinstance(forbidden, list)
+            or len(forbidden) != len(set(forbidden))
+            or any(not LABEL.fullmatch(x) for x in forbidden)
+        ):
+            raise Error("invalid forbidden label declarations")
+    return data
+
+
+def cfg(app, env, path=CONFIG):
+    env = (
+        "staging"
+        if env in ("staging", "env=staging", "int", "env=int")
+        else env.replace("env=", "")
+    )
+    if env != "staging":
+        raise Error("production app metrics verification is refused; pass env=staging")
+    d = load(path)["applications"]
+    if app not in d:
+        raise Error("app is not configured for metrics verification")
+    return d[app]["environments"][env]
+
+
+def run(cmd):
+    p = subprocess.run(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if p.returncode:
+        raise Error("command failed (details redacted)")
+    return p.stdout
+
+
+def secret_install(app, env):
+    c = cfg(app, env)
+    if any(
+        k
+        for k in ("TOKEN", "METRICS_TOKEN", "TOKENPLACE_METRICS_TOKEN")
+        if __import__("os").environ.get(k)
+    ):
+        raise Error("credential environment variables are refused")
+    if not sys.stdin.isatty():
+        raise Error("an interactive controlling terminal is required")
+    import getpass
+
+    v = getpass.getpass(
+        "Enter application metrics bearer token (input hidden): ", stream=sys.stderr
+    )
+    if not v or "\n" in v:
+        raise Error("credential is invalid (value redacted)")
+    p1 = subprocess.Popen(
+        [
+            "kubectl",
+            "-n",
+            c["namespace"],
+            "create",
+            "secret",
+            "generic",
+            c["secret"]["name"],
+            f'--from-file={c["secret"]["key"]}=/dev/stdin',
+            "--dry-run=client",
+            "-o",
+            "yaml",
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    out, err = p1.communicate(v)
+    v = None
+    if p1.returncode:
+        raise Error("Secret rendering failed (value redacted)")
+    p2 = subprocess.run(
+        ["kubectl", "apply", "-f", "-"],
+        input=out,
+        text=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    if p2.returncode:
+        raise Error("Secret installation failed (value redacted)")
+    print("Application metrics Secret installed or rotated (value not displayed).")
+
+
+def secret_check(app, env):
+    c = cfg(app, env)
+    out = run(
+        [
+            "kubectl",
+            "-n",
+            c["namespace"],
+            "get",
+            "secret",
+            c["secret"]["name"],
+            "-o",
+            f'go-template={{{{if index .data "{c["secret"]["key"]}"}}}}present{{{{end}}}}',
+        ]
+    )
+    if out != "present":
+        raise Error(
+            "required Secret/key is absent or empty (value intentionally not read or printed)"
+        )
+    print("Application metrics Secret contract exists (value intentionally not read or printed).")
+
+
+def verify(app, env):
+    c = cfg(app, env)
+    if run(["kubectl", "config", "current-context"]).strip() != c["kubernetesContext"]:
+        raise Error("context mismatch for staging app metrics")
+    secret_check(app, env)
+    sm = json.loads(
+        run(
+            [
+                "kubectl",
+                "-n",
+                c["namespace"],
+                "get",
+                "servicemonitor",
+                c["serviceMonitorName"],
+                "-o",
+                "json",
+            ]
+        )
+    )
+    ep = sm["spec"]["endpoints"][0]
+    auth = ep.get("authorization", {}).get("credentials", {})
+    if (
+        ep.get("path") != c["endpoint"]["path"]
+        or ep.get("interval") != c["endpoint"]["interval"]
+        or ep.get("scrapeTimeout") != c["endpoint"]["scrapeTimeout"]
+        or auth.get("name") != c["secret"]["name"]
+        or auth.get("key") != c["secret"]["key"]
+    ):
+        raise Error("ServiceMonitor endpoint/auth contract mismatch")
+    try:
+        urllib.request.urlopen(c["endpoint"]["publicUrl"], timeout=10)
+    except Exception as e:
+        if getattr(e, "code", None) != c["endpoint"]["expectedUnauthenticatedStatus"]:
+            raise Error("public metrics endpoint returned unexpected unauthenticated status")
+    for i in range(c["retries"]["attempts"]):
+        targets = json.loads(
+            run(
+                [
+                    "kubectl",
+                    "get",
+                    "--raw",
+                    "/api/v1/namespaces/monitoring/services/http:kube-prometheus-stack-prometheus:9090/proxy/api/v1/targets",
+                ]
+            )
+        )
+        if targets.get("status") != "success":
+            raise Error("Prometheus API status was unsuccessful")
+        active = targets.get("data", {}).get("activeTargets", [])
+        matched = [
+            t
+            for t in active
+            if all(t.get("labels", {}).get(k) == v for k, v in c["targetLabels"].items())
+        ]
+        if len(matched) == c["expectedTargetCount"] and all(
+            t.get("health") == "up" for t in matched
+        ):
+            break
+        if i + 1 == c["retries"]["attempts"]:
+            raise Error("configured targets are absent, down, or partial (responses redacted)")
+        time.sleep(c["retries"]["delaySeconds"])
+    series = json.loads(
+        run(
+            [
+                "kubectl",
+                "get",
+                "--raw",
+                '/api/v1/namespaces/monitoring/services/http:kube-prometheus-stack-prometheus:9090/proxy/api/v1/series?match[]={__name__=~".*"}',
+            ]
+        )
+    )
+    if series.get("status") != "success" or not isinstance(series.get("data"), list):
+        raise Error("Prometheus series response is structurally invalid")
+    names = {s.get("__name__") for s in series["data"]}
+    missing = [m for m in c["requiredMetricFamilies"] if m not in names]
+    if missing:
+        raise Error("required metric families are missing")
+    forbidden = set(c["forbiddenApplicationLabels"])
+    for s in series["data"]:
+        for k, v in s.items():
+            if k in forbidden:
+                raise Error("forbidden application label present")
+            if k in c["allowedApplicationLabels"] and v not in c["allowedApplicationLabels"][k]:
+                raise Error("unbounded application label value present")
+    print(f"Application metrics verified for {app} staging.")
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "command",
+        choices=["validate-config", "secret-install", "secret-check", "verify", "verify-all"],
+    )
+    ap.add_argument("--app")
+    ap.add_argument("--env", default="staging")
+    ap.add_argument("--config", default=str(CONFIG))
+    a = ap.parse_args(argv)
+    try:
+        if a.command == "validate-config":
+            load(Path(a.config))
+            print("Application metrics inventory is valid.")
+            return 0
+        if a.command == "verify-all":
+            for app in load(Path(a.config))["applications"]:
+                verify(app, a.env)
+        elif a.command == "secret-install":
+            secret_install(a.app, a.env)
+        elif a.command == "secret-check":
+            secret_check(a.app, a.env)
+        elif a.command == "verify":
+            verify(a.app, a.env)
+        return 0
+    except (Error, json.JSONDecodeError, UnicodeError, KeyError, TypeError) as e:
+        return die(str(e))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -17,7 +17,7 @@ PAGERDUTY_SECRET="alertmanager-pagerduty"
 WATCHDOG_SECRET="alertmanager-healthchecks-watchdog"
 ALERTMANAGER_VALIDATOR="${ROOT}/scripts/verify_observability_alertmanager.rb"
 
-usage() { echo "Usage: $0 <render|install|upgrade|status|verify|dashboard-verify|pagerduty-test|watchdog-secret-install|watchdog-secret-check|watchdog-verify|watchdog-drill-create|watchdog-drill-status|watchdog-drill-clear> env=staging [fire|resolve]" >&2; }
+usage() { echo "Usage: $0 <render|install|upgrade|status|verify|dashboard-verify|pagerduty-test|watchdog-secret-install|watchdog-secret-check|watchdog-verify|watchdog-drill-create|watchdog-drill-status|watchdog-drill-clear|app-metrics-secret-install|app-metrics-secret-check|app-metrics-verify> env=staging [app=<name>]" >&2; }
 normalize_env() {
   local raw="${1:-}"
   while [[ "${raw}" == env=* ]]; do raw="${raw#env=}"; done
@@ -67,6 +67,7 @@ render_to() {
   helm template "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" >"${out}"
   validate_rendered_dashboard "${out}"
   validate_rendered_alertmanager "${out}"
+  python3 "${ROOT}/scripts/observability_app_metrics.py" validate-config >/dev/null
 }
 assert_pagerduty_secret() {
   local present
@@ -135,6 +136,7 @@ watchdog_secret_install() {
   echo "Watchdog Secret installed or rotated (value not displayed)."
 }
 
+verify_app_metrics_all() { python3 "${ROOT}/scripts/observability_app_metrics.py" verify-all --env staging; }
 watchdog_live_check() (
   require_tools kubectl python3 ruby sleep
   assert_context
@@ -538,6 +540,7 @@ if len(claims) != 1 or claims[0].get("status", {}).get("phase") != "Bound" or cl
   echo "DSPACE ServiceMonitor secret reference exists (value intentionally not printed)."
 
   verify_dspace_targets
+  verify_app_metrics_all
   echo "Grafana LAN URL: ${GRAFANA_URL} (same NodePort is available through the other staging nodes)"
 )
 
@@ -736,4 +739,6 @@ if [[ "${cmd}" == watchdog-drill-create ]]; then
   trap 'exit 130' INT
   trap 'exit 143' TERM
 fi
-case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) dashboard_verify ;; pagerduty-test) pagerduty_test "${2:-${1:-}}" ;; watchdog-secret-install) watchdog_secret_install "${@:2}" ;; watchdog-secret-check) watchdog_secret_check ;; watchdog-verify) watchdog_live_check ;; watchdog-drill-create) watchdog_silence_create ;; watchdog-drill-status) watchdog_silence_list ;; watchdog-drill-clear) watchdog_silence_clear ;; *) usage; exit 2 ;; esac
+app_arg="${2:-}"
+while [[ "${app_arg}" == app=* ]]; do app_arg="${app_arg#app=}"; done
+case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) dashboard_verify ;; pagerduty-test) pagerduty_test "${2:-${1:-}}" ;; watchdog-secret-install) watchdog_secret_install "${@:2}" ;; watchdog-secret-check) watchdog_secret_check ;; watchdog-verify) watchdog_live_check ;; app-metrics-secret-install) assert_context; python3 "${ROOT}/scripts/observability_app_metrics.py" secret-install --app "${app_arg}" --env staging ;; app-metrics-secret-check) assert_context; python3 "${ROOT}/scripts/observability_app_metrics.py" secret-check --app "${app_arg}" --env staging ;; app-metrics-verify) python3 "${ROOT}/scripts/observability_app_metrics.py" verify --app "${app_arg}" --env staging ;; watchdog-drill-create) watchdog_silence_create ;; watchdog-drill-status) watchdog_silence_list ;; watchdog-drill-clear) watchdog_silence_clear ;; *) usage; exit 2 ;; esac

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -46,6 +46,11 @@ HEALTHCHECKS_UUID = re.compile(
 SAFE_PLACEHOLDERS = (
     re.compile(r"^\+\s*passwordKey:\s*admin-password\s*$"),
     re.compile(r"^\+\s*-\s*Password key:\s*`admin-password`\.\s*$"),
+    re.compile(r"^\+\s*\"key\":\s*\"token\",?\s*$"),
+    re.compile(r"^\+\s*secretKey:\s*token\s*$"),
+    re.compile(r"^\+\s*\"forbiddenApplicationLabels\":\s*\[.*\"password\".*\"token\".*\],?\s*$"),
+    re.compile(r"^\+\s*\"password\",?\s*$"),
+    re.compile(r"^\+\s*\"token\",?\s*$"),
 )
 
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -220,7 +220,7 @@ if [[ "$*" == show\ chart* ]]; then
     printf 'apiVersion: v2\nname: dspace\nversion: %s\nappVersion: main-abcdef0\n' "$version"
     exit 0
   fi
-  printf 'apiVersion: v2\nname: tokenplace\nversion: 0.1.3\nappVersion: main-deadbee\ndigest: sha256:abc123\n'
+  printf 'apiVersion: v2\nname: tokenplace\nversion: 0.1.4\nappVersion: main-deadbee\ndigest: sha256:abc123\n'
   exit 0
 fi
 if [[ "$*" == template* ]]; then
@@ -403,7 +403,7 @@ case "${{url}}" in
     ;;
   https://api.github.com/users/futuroptimist/packages/container/charts%2Ftokenplace/versions*)
     status=200
-    body='[{{"metadata":{{"container":{{"tags":["0.1.3","0.1.4-rc.1","0.1.4"]}}}}}}]'
+    body='[{{"metadata":{{"container":{{"tags":["0.1.4","0.1.4-rc.1","0.1.4"]}}}}}}]'
     ;;
 esac
 if [ "${{method}}" = "OPTIONS" ]; then
@@ -661,7 +661,7 @@ def test_app_chart_cmd_status_reports_helm_show_failure(
         chart="oci://ghcr.io/futuroptimist/charts/tokenplace",
         version_file="docs/apps/tokenplace.version",
     )
-    monkeypatch.setattr(app_chart, "read_pin", lambda path: "0.1.3")
+    monkeypatch.setattr(app_chart, "read_pin", lambda path: "0.1.4")
     monkeypatch.setattr(
         app_chart,
         "helm_show",
@@ -680,7 +680,7 @@ def test_app_chart_cmd_status_prints_metadata_without_stale_warning(
         chart="oci://ghcr.io/futuroptimist/charts/tokenplace",
         version_file="docs/apps/tokenplace.version",
     )
-    monkeypatch.setattr(app_chart, "read_pin", lambda path: "0.1.3")
+    monkeypatch.setattr(app_chart, "read_pin", lambda path: "0.1.4")
     monkeypatch.setattr(
         app_chart,
         "helm_show",
@@ -688,12 +688,12 @@ def test_app_chart_cmd_status_prints_metadata_without_stale_warning(
             [], 0, "apiVersion: v2\nappVersion: main-deadbee\ndigest: sha256:abc\n", ""
         ),
     )
-    monkeypatch.setattr(app_chart, "latest_version", lambda chart: ("0.1.3", "test"))
+    monkeypatch.setattr(app_chart, "latest_version", lambda chart: ("0.1.4", "test"))
 
     assert app_chart.cmd_status(args) == 0
     out = capsys.readouterr().out
     assert "chart appVersion: main-deadbee" in out
-    assert "latest version: 0.1.3 (test)" in out
+    assert "latest version: 0.1.4 (test)" in out
     assert "Pinned chart appears stale" not in out
 
 
@@ -1492,7 +1492,7 @@ def test_app_chart_cmd_preflight_reports_helm_template_failure(
         tag="main-deadbee",
         chart="oci://ghcr.io/futuroptimist/charts/tokenplace",
         version_file="docs/apps/tokenplace.version",
-        version="0.1.3",
+        version="0.1.4",
         release="tokenplace",
         namespace="tokenplace",
         values="values-a.yaml, values-b.yaml",
@@ -1534,7 +1534,7 @@ def test_app_chart_cmd_preflight_reports_helm_show_failure(
         tag="main-deadbee",
         chart="oci://ghcr.io/futuroptimist/charts/tokenplace",
         version_file="docs/apps/tokenplace.version",
-        version="0.1.3",
+        version="0.1.4",
         release="tokenplace",
         namespace="tokenplace",
         values=str(values),
@@ -1591,7 +1591,7 @@ def _assert_preflight_failure_context(error: str, operation: str) -> None:
         "release=tokenplace",
         "namespace=tokenplace",
         "chart=oci://ghcr.io/futuroptimist/charts/tokenplace",
-        "version=0.1.3",
+        "version=0.1.4",
         "tag=main-deadbee",
         "host=staging.example.test",
     ):
@@ -1606,7 +1606,7 @@ def _preflight_args() -> argparse.Namespace:
         tag="main-deadbee",
         chart="oci://ghcr.io/futuroptimist/charts/tokenplace",
         version_file="docs/apps/tokenplace.version",
-        version="0.1.3",
+        version="0.1.4",
         release="tokenplace",
         namespace="tokenplace",
         values="",
@@ -1661,7 +1661,7 @@ def test_app_chart_cmd_preflight_reports_missing_app_container_envs(
         tag="main-deadbee",
         chart="oci://ghcr.io/futuroptimist/charts/tokenplace",
         version_file="docs/apps/tokenplace.version",
-        version="0.1.3",
+        version="0.1.4",
         release="tokenplace",
         namespace="tokenplace",
         values="values-a.yaml, values-b.yaml",
@@ -1698,7 +1698,7 @@ def test_app_chart_cmd_preflight_rejects_envs_split_across_candidate_containers(
         tag="main-deadbee",
         chart="oci://ghcr.io/futuroptimist/charts/tokenplace",
         version_file="docs/apps/tokenplace.version",
-        version="0.1.3",
+        version="0.1.4",
         release="tokenplace",
         namespace="tokenplace",
         values="",
@@ -1875,7 +1875,7 @@ def test_app_chart_cmd_preflight_rejects_metadata_from_unrelated_deployment(
         tag="main-deadbee",
         chart="oci://ghcr.io/futuroptimist/charts/tokenplace",
         version_file="docs/apps/tokenplace.version",
-        version="0.1.3",
+        version="0.1.4",
         release="tokenplace",
         namespace="tokenplace",
         values="",
@@ -1935,7 +1935,7 @@ def test_app_chart_cmd_preflight_passes_when_relay_envs_present(
         tag="main-deadbee",
         chart="oci://ghcr.io/futuroptimist/charts/tokenplace",
         version_file="docs/apps/tokenplace.version",
-        version="0.1.3",
+        version="0.1.4",
         release="tokenplace",
         namespace="tokenplace",
         values="",
@@ -1964,7 +1964,7 @@ def test_app_chart_cmd_preflight_passes_when_relay_envs_present(
     )
 
     assert app_chart.cmd_preflight(args) == 0
-    assert "chart version: 0.1.3" in capsys.readouterr().out
+    assert "chart version: 0.1.4" in capsys.readouterr().out
 
 
 def test_app_chart_cmd_bump_reports_empty_version_and_show_failure(
@@ -2152,9 +2152,9 @@ def test_app_chart_status_reports_pin_and_stale_latest(
     assert result.returncode == 0, result.stderr + result.stdout
     assert "app: tokenplace" in result.stdout
     assert "chart ref: oci://ghcr.io/futuroptimist/charts/tokenplace" in result.stdout
-    assert "pinned version: 0.1.3" in result.stdout
+    assert "pinned version: 0.1.4" in result.stdout
     assert "chart appVersion: main-deadbee" in result.stdout
-    assert "Pinned chart appears stale: 0.1.3 < 9.9.9" in result.stdout
+    assert "Pinned chart appears stale: 0.1.4 < 9.9.9" in result.stdout
     assert "Run: just app-chart-bump app=tokenplace version=9.9.9" in result.stdout
 
 
@@ -2170,7 +2170,7 @@ def test_app_chart_latest_version_falls_back_to_user_owned_ghcr_packages(
         return subprocess.CompletedProcess(
             args,
             0,
-            '[{"metadata":{"container":{"tags":["0.1.3","0.1.4-rc.1","0.1.4"]}}}]',
+            '[{"metadata":{"container":{"tags":["0.1.4","0.1.4-rc.1","0.1.4"]}}}]',
             "",
         )
 
@@ -2212,15 +2212,15 @@ def test_app_chart_bump_updates_only_pin_file_in_temp_config(
     env = generic_app_stub_env.copy()
     env["SUGARKUBE_APP_CONFIG_DIR"] = str(tmp_path)
     result = _run_just(
-        ["app-chart-bump", "app=tokenplace", "version=0.1.3"],
+        ["app-chart-bump", "app=tokenplace", "version=0.1.4"],
         env,
     )
 
     assert result.returncode == 0, result.stderr + result.stdout
-    assert pin.read_text(encoding="utf-8") == "# Default tokenplace chart version.\n0.1.3\n"
+    assert pin.read_text(encoding="utf-8") == "# Default tokenplace chart version.\n0.1.4\n"
     assert "git add" in result.stdout
     helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
-    assert "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.3" in helm_log
+    assert "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.4" in helm_log
 
 
 def test_app_chart_bump_refuses_empty_version(generic_app_stub_env: dict[str, str]) -> None:
@@ -2291,10 +2291,10 @@ def test_app_deploy_uses_app_release_namespace_chart_values(
         assert f"-f {value}" in helm_log
     if app == "tokenplace":
         assert (
-            "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.3" in helm_log
+            "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.4" in helm_log
         )
         assert "template tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace" in helm_log
-        assert "--version 0.1.3" in helm_log
+        assert "--version 0.1.4" in helm_log
         assert "--version 9.9.9" not in helm_log
 
 
@@ -2344,7 +2344,7 @@ def test_app_deploy_passes_tokenplace_when_manifest_metadata_env_present(
     assert "9.9.9" not in result.stdout
     assert pin_path.read_text(encoding="utf-8") == before_pin
     helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
-    assert "--version 0.1.3" in helm_log
+    assert "--version 0.1.4" in helm_log
     assert "--version 9.9.9" not in helm_log
 
 
@@ -2364,7 +2364,7 @@ def test_app_redeploy_prints_chart_pin_reminder_without_latest_lookup_or_pin_mut
     assert pin_path.read_text(encoding="utf-8") == before_pin
     helm_log = Path(env["HELM_LOG"]).read_text(encoding="utf-8")
     assert "upgrade tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace" in helm_log
-    assert "--version 0.1.3" in helm_log
+    assert "--version 0.1.4" in helm_log
     assert "--version 9.9.9" not in helm_log
 
 
@@ -2436,7 +2436,7 @@ def test_app_redeploy_host_resolution_failure_stops_before_release_activity(
                 "SUGARKUBE_RELEASE=tokenplace",
                 "SUGARKUBE_NAMESPACE=tokenplace",
                 "SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/tokenplace",
-                "SUGARKUBE_VERSION=0.1.3",
+                "SUGARKUBE_VERSION=0.1.4",
                 f"SUGARKUBE_VALUES_STAGING={values}",
             ]
         )
@@ -2481,7 +2481,7 @@ def test_helm_oci_install_and_upgrade_keep_authoritative_inputs_identical(
         "chart=oci://ghcr.io/futuroptimist/charts/tokenplace",
         "values=docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml",
         "host=staging.token.place",
-        "version=0.1.3",
+        "version=0.1.4",
         "tag=main-deadbee",
         "env=staging",
         "app=tokenplace",
@@ -4181,7 +4181,7 @@ def test_app_cors_verify_actual_sends_configured_request_headers(
                 "SUGARKUBE_RELEASE=tokenplace",
                 "SUGARKUBE_NAMESPACE=tokenplace",
                 "SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/tokenplace",
-                "SUGARKUBE_VERSION=0.1.3",
+                "SUGARKUBE_VERSION=0.1.4",
                 "SUGARKUBE_VALUES_STAGING=deploy/helm/tokenplace/values.staging.yaml",
                 "SUGARKUBE_CORS_VERIFY_PATH=/api/v1/chat/completions",
                 "SUGARKUBE_CORS_VERIFY_METHOD=POST",
@@ -4249,7 +4249,7 @@ def test_app_cors_verify_bad_expected_statuses_is_operator_error(
                 "SUGARKUBE_RELEASE=tokenplace",
                 "SUGARKUBE_NAMESPACE=tokenplace",
                 "SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/tokenplace",
-                "SUGARKUBE_VERSION=0.1.3",
+                "SUGARKUBE_VERSION=0.1.4",
                 "SUGARKUBE_VALUES_STAGING=deploy/helm/tokenplace/values.staging.yaml",
                 "SUGARKUBE_CORS_VERIFY_EXPECTED_STATUSES=400,abc",
             ]
@@ -4279,7 +4279,7 @@ def test_app_cors_verify_config_third_argument_remains_config(
                 "SUGARKUBE_RELEASE=tokenplace",
                 "SUGARKUBE_NAMESPACE=tokenplace",
                 "SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/tokenplace",
-                "SUGARKUBE_VERSION=0.1.3",
+                "SUGARKUBE_VERSION=0.1.4",
                 "SUGARKUBE_VALUES_STAGING=deploy/helm/tokenplace/values.staging.yaml",
                 "SUGARKUBE_CORS_VERIFY_PATH=/custom-cors",
                 "SUGARKUBE_CORS_VERIFY_METHOD=POST",
@@ -5033,7 +5033,7 @@ def test_direct_helm_oci_helper_matching_env_succeeds(
 
     assert result.returncode == 0, result.stderr + result.stdout
     helm_log = Path(generic_app_stub_env["HELM_LOG"]).read_text(encoding="utf-8")
-    assert "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.3" in helm_log
+    assert "show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.4" in helm_log
     assert "upgrade tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace" in helm_log
     assert "--description" not in helm_log
 
@@ -5052,7 +5052,7 @@ def test_public_helm_helper_rejects_mutation_marker_without_altering_file(
         "chart=oci://ghcr.io/futuroptimist/charts/tokenplace",
         "values=docs/examples/tokenplace.values.staging.yaml",
         "host=staging.token.place",
-        "version=0.1.3",
+        "version=0.1.4",
         "version_file=",
         "tag=main-deadbee",
         "default_tag=main-deadbee",
@@ -5082,7 +5082,7 @@ def test_direct_helm_oci_helper_uses_digest_coordinate_without_version(
             "release=tokenplace",
             "namespace=tokenplace",
             f"chart={coordinate}",
-            "version=0.1.3",
+            "version=0.1.4",
             "tag=main-deadbee",
             "env=staging",
         ],
@@ -5257,7 +5257,7 @@ def test_app_redeploy_guard_staging_requested_prod_detected_fails_before_helm(
 def test_app_chart_bump_remains_cluster_independent(generic_app_stub_env: dict[str, str]) -> None:
     env = generic_app_stub_env.copy()
     env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
-    result = _run_just(["app-chart-bump", "app=tokenplace", "version=0.1.3"], env)
+    result = _run_just(["app-chart-bump", "app=tokenplace", "version=0.1.4"], env)
     assert result.returncode == 0, result.stderr + result.stdout
     kubectl_log = Path(env["HOME"]).parent / "kubectl.log"
     assert not kubectl_log.exists() or "get nodes" not in kubectl_log.read_text(encoding="utf-8")
@@ -5275,3 +5275,10 @@ def test_dspace_promote_prod_guard_mismatch_fails_before_helm(
     assert "manifest=<approved-candidate.json> is required" in result.stderr
     helm_log_path = Path(env["HELM_LOG"])
     assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
+
+def test_observability_app_metrics_recipes_are_declared():
+    text = (REPO_ROOT / "justfile").read_text(encoding="utf-8")
+    assert "observability-app-metrics-secret-install app env='staging'" in text
+    assert "observability-app-metrics-secret-check app env='staging'" in text
+    assert "observability-app-metrics-verify app env='staging'" in text
+    assert "app-metrics-secret-install '{{ env }}' 'app={{ app }}'" in text

--- a/tests/test_observability_app_metrics.py
+++ b/tests/test_observability_app_metrics.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+import pytest
+from scripts import observability_app_metrics as m
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_inventory_tokenplace_contract_is_strict():
+    data = m.load()
+    c = data["applications"]["tokenplace"]["environments"]["staging"]
+    assert c["secret"] == {"name": "tokenplace-staging-metrics-token", "key": "token"}
+    assert c["expectedTargetCount"] == 1
+    assert c["endpoint"]["path"] == "/metrics"
+    assert c["endpoint"]["expectedUnauthenticatedStatus"] == 401
+    assert c["targetLabels"] == {
+        "app": "tokenplace",
+        "environment": "staging",
+        "release": "tokenplace",
+        "cluster": "sugarkube-int",
+    }
+    assert "tokenplace_build_info" in c["requiredMetricFamilies"]
+    assert len(c["requiredMetricFamilies"]) == len(set(c["requiredMetricFamilies"]))
+
+
+def test_inventory_rejects_unknown_and_duplicate(tmp_path):
+    bad = {
+        "applications": {
+            "demo": {"environments": {"staging": dict(m.cfg("tokenplace", "staging"), extra=True)}}
+        }
+    }
+    p = tmp_path / "bad.json"
+    p.write_text(json.dumps(bad))
+    with pytest.raises(m.Error, match="unknown"):
+        m.load(p)
+    bad["applications"]["demo"]["environments"]["staging"].pop("extra")
+    bad["applications"]["demo"]["environments"]["staging"]["requiredMetricFamilies"] = ["x", "x"]
+    p.write_text(json.dumps(bad))
+    with pytest.raises(m.Error, match="duplicate"):
+        m.load(p)
+
+
+def test_verifier_source_has_no_tokenplace_branch():
+    src = (ROOT / "scripts/observability_app_metrics.py").read_text()
+    assert 'if app == "tokenplace"' not in src
+    assert "if app == 'tokenplace'" not in src
+
+
+def test_secret_install_refuses_env_and_nontty(monkeypatch):
+    monkeypatch.setenv("METRICS_TOKEN", "redacted")
+    with pytest.raises(m.Error, match="environment"):
+        m.secret_install("tokenplace", "staging")
+    monkeypatch.delenv("METRICS_TOKEN")
+    monkeypatch.setattr(m.sys.stdin, "isatty", lambda: False)
+    with pytest.raises(m.Error, match="terminal"):
+        m.secret_install("tokenplace", "staging")
+
+
+def test_cli_rejects_production(capsys):
+    assert m.main(["verify", "--app", "tokenplace", "--env", "prod"]) == 2
+    assert "production" in capsys.readouterr().err

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -2217,3 +2217,17 @@ def test_watchdog_silence_api_failures_do_not_expose_fixture_contents(tmp_path, 
     assert "response redacted" in output
     if command == "watchdog-drill-clear":
         assert not (tmp_path / "watchdog-silence-deletions").exists()
+
+def test_tokenplace_staging_metrics_values_are_secret_references_only():
+    values = (ROOT / "docs/examples/tokenplace.values.staging.yaml").read_text()
+    assert "enabled: true" in values
+    assert "existingSecret: tokenplace-staging-metrics-token" in values
+    assert "secretKey: token" in values
+    assert "release: kube-prometheus-stack" in values
+    assert "scrapeTimeout: 10s" in values
+    assert "kind: Secret" not in values
+    assert "TOKENPLACE_METRICS_TOKEN" not in values
+
+
+def test_tokenplace_chart_pin_is_published_metrics_version():
+    assert (ROOT / "docs/apps/tokenplace.version").read_text().strip().endswith("0.1.4")


### PR DESCRIPTION
### Motivation
- Enable token.place's existing authenticated `/metrics` in staging by pinning the published OCI chart and wiring a staging-only overlay that references a bearer-token Secret instead of committing credentials. 
- Provide a generic, declarative application-metrics inventory and an application-agnostic verifier so operators can validate authenticated metrics contracts safely before/after deploying apps. 
- Add secure operator recipes to install and check staging-only metrics Secrets using hidden interactive input and integrate app-metrics verification into the observability verification flow while preserving existing DSPACE checks. 

### Description
- Pin token.place staging chart to `0.1.4` by updating `docs/apps/tokenplace.version` and enable authenticated metrics in `docs/examples/tokenplace.values.staging.yaml` with `metrics.auth.existingSecret=tokenplace-staging-metrics-token`, `secretKey=token`, and a `ServiceMonitor` configuration (interval `30s`, scrapeTimeout `10s`, `release: kube-prometheus-stack`, and the canonical relabels). 
- Add a strict, data-only inventory `platform/observability/app-metrics.json` describing token.place staging contract: kube context/namespace, ServiceMonitor name, expected target count, secret name/key contract, canonical target labels, public `/metrics` 401 expectation, retries, required metric families, allowed label enums, and forbidden sensitive labels. 
- Implement a generic verifier `scripts/observability_app_metrics.py` that validates the inventory, refuses production, supports `validate-config`, `secret-install`, `secret-check`, `verify`, and `verify-all`, checks ServiceMonitor/Secret references via `kubectl` without printing values, queries Prometheus through the API proxy, enforces target/health/labels/metric-family constraints, validates the public 401 behavior while redacting sensitive content, and refuses non-TTY/env/argument credential input when installing Secrets. 
- Wire inventory validation and `verify-all` into observability tooling by updating `scripts/observability_helm.sh` (validate-config during render and run app-metrics verification after the proven DSPACE checks) and add `just` recipes for `observability-app-metrics-secret-install`, `observability-app-metrics-secret-check`, and `observability-app-metrics-verify`. 
- Add operator documentation (`docs/apps/tokenplace.md`, `docs/observability.md`) describing the OCI verification digest and reproducible commands, secure Secret workflow, deployment order, verifier usage, rollback notes, and follow-ups; add focused tests (`tests/test_observability_app_metrics.py`) and extend existing tests to assert values/pin/recipes. 
- Adjust `scripts/scan-secrets.py` narrowly to avoid false-positives for exact metadata placeholders while preserving scanning for real credential patterns, and ensure no Secret values are committed anywhere. 

### Testing
- Ran focused pytest targets: `python3 -m pytest -q tests/test_observability_app_metrics.py tests/test_observability_helm.py tests/test_generic_app_just_recipes.py tests/test_app_config.py`, and the modified/added tests passed in this environment (targeted suites passed; full suite run during development showed the repository-wide test baseline passing locally). 
- Verified OCI precondition and chart package by running `just app-chart-status app=tokenplace`, `helm show chart oci://ghcr.io/futuroptimist/charts/tokenplace --version 0.1.4`, and `helm pull ... --version 0.1.4`, which produced digest `sha256:0f16aef72500b33a598042465a9b703bf16dc7a5071b3d867c4a78d6928be1e7` and confirmed the required `metrics`/`serviceMonitor` contract in the fetched chart. 
- Render check executed offline with `just observability-render env=staging` and `python3 scripts/observability_app_metrics.py validate-config` (both succeeded); `linkchecker --no-warnings README.md docs/` succeeded. 
- `pre-commit run --all-files` was attempted but could not be completed cleanly in this container because repository baseline hooks flagged unrelated YAML/flake8 issues and a missing `aspell` caused `pyspelling` to fail, so those broader baseline fixes were not changed in this focused PR. 
- Attempted to open a GitHub PR with `gh pr create`, but the execution environment is not authenticated to GitHub CLI, so the PR was not created here (local branch/commit present and ready). 

Residual notes and scope
- No Secret values or credentials were added to the repository; the inventory contains only identifiers and enums. 
- This PR uses `Refs #2405` and implements Phase 1 repository support only; dashboards, alert rules, and Phase 2 work remain follow-ups requiring live metrics evidence. 
- I could not run `pyspelling` fully because `aspell` is missing in the container and `pre-commit` reported existing baseline issues outside the narrow scope; these are noted in the commit message and should be handled separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a723a8c2db0832fa31584ac3b63b14d)