### PR TITLE
Update DSPACE staging token.place model to qwen3-8b-instruct

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -352,7 +352,7 @@ Use these links before changing a deployment so the workflow runs, package versi
 - `env=dev`: future single-node/non-HA environment using `docs/examples/dspace.values.dev.yaml`.
   The dev overlay intentionally does not choose a token.place origin; developers who need local runtime routing can copy `docs/examples/apps/dspace.env` to a local app config and add chart-supported `env` entries to their private values file.
 - `env=staging`: HA staging on the staging Sugarkube cluster with host `staging.democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
-  The configured staging target injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`, uses provenance-bearing chart `3.1.1` for DSPACE application `3.1.0`, and persists the authenticated metrics ServiceMonitor configuration discovered by kube-prometheus-stack. The live staging release has not yet been restored to this target and remains on the validated DSPACE `3.0.1` recovery deployment at Helm revision 26. The metrics bearer value is not committed; operators manage the existing `dspace-staging-metrics-token` Secret out of band.
+  The configured staging target injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=qwen3-8b-instruct`, uses provenance-bearing chart `3.1.1` for DSPACE application `3.1.0`, and persists the authenticated metrics ServiceMonitor configuration discovered by kube-prometheus-stack. The live staging release remains on Helm revision 27 from the immutable DSPACE `3.1.0` staging image; its failed evidence reservation is preserved outside this repository-only desired-state update. The metrics bearer value is not committed; operators manage the existing `dspace-staging-metrics-token` Secret out of band.
 - `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
   The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`. Production is pinned to recovery chart `3.0.2` and image `ghcr.io/democratizedspace/dspace:main-1a31a56`; it does not enable metrics or ServiceMonitor settings.
 - Optional legacy/canary host `prod.democratized.space` uses `docs/examples/dspace.values.prod-subdomain.yaml`. The `dspace-oci-deploy-prod-subdomain` compatibility command selects the secret-free `docs/examples/apps/dspace-prod-subdomain.env` config, preserving that overlay while routing through the same manifest validation, OCI preflight, Helm deployment, and evidence finalization as the generic production path.
@@ -566,7 +566,7 @@ The runtime config check is a required routing gate, not an optional fallback: i
 curl -fsS https://staging.democratized.space/config.json \
   | jq -e '
       .tokenPlace.url == "https://staging.token.place"
-      and .tokenPlace.model == "llama-3.1-8b-instruct"
+      and .tokenPlace.model == "qwen3-8b-instruct"
     '
 ```
 

--- a/docs/examples/dspace.values.staging.yaml
+++ b/docs/examples/dspace.values.staging.yaml
@@ -10,7 +10,7 @@ env:
   - name: DSPACE_TOKEN_PLACE_URL
     value: https://staging.token.place
   - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
-    value: llama-3.1-8b-instruct
+    value: qwen3-8b-instruct
 
 metrics:
   enabled: true

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -65,11 +65,22 @@ def _runtime_env(path: Path) -> dict[str, list[str]]:
     return env
 
 
+def _resolved_runtime_env(paths: str) -> dict[str, list[str]]:
+    """Return runtime env from the comma-separated values chain after overlay resolution."""
+    resolved: dict[str, list[str]] = {}
+    for path in paths.split(","):
+        env = _runtime_env(REPO_ROOT / path.strip())
+        for name, values in env.items():
+            resolved[name] = values
+    return resolved
+
+
 def test_dspace_staging_overlay_points_to_staging_token_place() -> None:
     env = _runtime_env(OVERLAYS["staging"])
 
     assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://staging.token.place"]
-    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["llama-3.1-8b-instruct"]
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["qwen3-8b-instruct"]
+    assert "llama-3.1-8b-instruct" not in env["DSPACE_TOKEN_PLACE_CHAT_MODEL"]
 
 
 def test_dspace_prod_overlay_points_to_prod_token_place() -> None:
@@ -77,6 +88,29 @@ def test_dspace_prod_overlay_points_to_prod_token_place() -> None:
 
     assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://token.place"]
     assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["llama-3.1-8b-instruct"]
+
+
+def test_dspace_staging_values_chain_resolves_canonical_qwen_without_prod_leaks() -> None:
+    config = load_config("dspace", "staging")
+    env = _resolved_runtime_env(config["SUGARKUBE_VALUES"])
+
+    assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://staging.token.place"]
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["qwen3-8b-instruct"]
+    assert sum(
+        len(values) for name, values in env.items() if name == "DSPACE_TOKEN_PLACE_CHAT_MODEL"
+    ) == 1
+    assert "llama-3.1-8b-instruct" not in env["DSPACE_TOKEN_PLACE_CHAT_MODEL"]
+    assert "https://token.place" not in env["DSPACE_TOKEN_PLACE_URL"]
+
+
+def test_dspace_prod_values_chain_stays_prod_without_staging_contamination() -> None:
+    config = load_config("dspace", "prod")
+    env = _resolved_runtime_env(config["SUGARKUBE_VALUES"])
+
+    assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://token.place"]
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["llama-3.1-8b-instruct"]
+    assert "qwen3-8b-instruct" not in env["DSPACE_TOKEN_PLACE_CHAT_MODEL"]
+    assert "https://staging.token.place" not in env["DSPACE_TOKEN_PLACE_URL"]
 
 
 def test_dspace_deployment_overlays_have_no_vite_runtime_env() -> None:


### PR DESCRIPTION
### Motivation
- The DSPACE desired staging runtime should use the canonical `qwen3-8b-instruct` model instead of the legacy `llama-3.1-8b-instruct` to match upstream DSPACE changes and the immutable staging image that supports explicit Qwen requests.  
- Preserve historical records and the existing operator-managed staging Helm revision reservation outside this repository change, and ensure production and other release coordinates remain untouched.

### Description
- Changed the DSPACE staging Helm values overlay so `DSPACE_TOKEN_PLACE_CHAT_MODEL` is exactly `qwen3-8b-instruct` in `docs/examples/dspace.values.staging.yaml`.  
- Updated the active DSPACE staging runbook and the `/config.json` verification example in `docs/apps/dspace.md` to describe the canonical Qwen staging configuration and to state this is a repository-only desired-state update while preserving the revision-27 reservation as an operator follow-up.  
- Extended and adjusted focused tests in `tests/test_dspace_runtime_values.py` to assert that the resolved staging values chain contains exactly one `DSPACE_TOKEN_PLACE_CHAT_MODEL` set to `qwen3-8b-instruct`, that `llama-3.1-8b-instruct` is not present in current staging renders, that the staging token.place origin remains `https://staging.token.place`, and that production overlays remain unchanged.  
- No changes to image tags/digests, chart pins, provider selection, ingress, metrics, ServiceMonitor, production values, Secrets, deployment candidates, finalized evidence, reservation files, or any observability or release coordinates were made.

Files changed:
- `docs/examples/dspace.values.staging.yaml` (staging overlay model value)
- `docs/apps/dspace.md` (staging runbook and verification example)
- `tests/test_dspace_runtime_values.py` (focused regression tests)

### Testing
- Ran the requested focused test selection with full and narrow runs and validated repository checks:  
  - `python3 -m pytest -q tests/test_dspace_runtime_values.py tests/test_generic_app_just_recipes.py tests/test_app_config.py` — result: `319 passed, 1 warning` (all tests in that selection passed).  
  - `python3 -m pytest -q tests/test_dspace_runtime_values.py` — result: `11 passed` (all new/modified assertions passed).  
  - Searched for legacy occurrences with ripgrep: `rg -n "llama-3\.1-8b-instruct" docs/examples/dspace.values.staging.yaml tests/test_dspace_runtime_values.py docs/apps/dspace.md` — results show production assertions or preserved historical references only; no active staging render expects Llama.  
  - Rendering/format checks: `git diff --check` — no whitespace/index errors.  
  - Secret scan: `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` — no secrets detected in the diff.  
- Environment limitations: `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` were not executed here because the required tools are not present in this execution environment (`pre-commit`, `pyspelling`, and `linkchecker` reported not found).  

Explicit non-mutation confirmation
- No Kubernetes, Helm, evidence reservation/finalization, production, Secret, chart pin, image pin, provider, ingress, metrics, ServiceMonitor, observability, or cluster state was changed by these edits.  

Operator note
- This PR updates repository desired state only; operators must separately reconcile the preserved staging Helm revision-27 reservation, create the approved candidate/evidence destination, and perform a guarded staging deployment to apply this change in-cluster.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7299c0027c832f80120279dcc5a05d)