### PR TITLE
dspace(staging): set DSPACE_TOKEN_PLACE_CHAT_MODEL to qwen3-8b-instruct

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -352,7 +352,7 @@ Use these links before changing a deployment so the workflow runs, package versi
 - `env=dev`: future single-node/non-HA environment using `docs/examples/dspace.values.dev.yaml`.
   The dev overlay intentionally does not choose a token.place origin; developers who need local runtime routing can copy `docs/examples/apps/dspace.env` to a local app config and add chart-supported `env` entries to their private values file.
 - `env=staging`: HA staging on the staging Sugarkube cluster with host `staging.democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
-  The configured staging target injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`, uses provenance-bearing chart `3.1.1` for DSPACE application `3.1.0`, and persists the authenticated metrics ServiceMonitor configuration discovered by kube-prometheus-stack. The live staging release has not yet been restored to this target and remains on the validated DSPACE `3.0.1` recovery deployment at Helm revision 26. The metrics bearer value is not committed; operators manage the existing `dspace-staging-metrics-token` Secret out of band.
+  The configured staging target injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=qwen3-8b-instruct`, uses provenance-bearing chart `3.1.1` for DSPACE application `3.1.0`, and persists the authenticated metrics ServiceMonitor configuration discovered by kube-prometheus-stack. The live staging release remains Helm revision 27 from the immutable DSPACE `3.1.0` staging image; operators must reconcile the preserved failed evidence reservation, create a newly approved candidate/evidence destination, and perform a guarded staging deployment before treating this repository desired state as live. The metrics bearer value is not committed; operators manage the existing `dspace-staging-metrics-token` Secret out of band.
 - `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
   The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`. Production is pinned to recovery chart `3.0.2` and image `ghcr.io/democratizedspace/dspace:main-1a31a56`; it does not enable metrics or ServiceMonitor settings.
 - Optional legacy/canary host `prod.democratized.space` uses `docs/examples/dspace.values.prod-subdomain.yaml`. The `dspace-oci-deploy-prod-subdomain` compatibility command selects the secret-free `docs/examples/apps/dspace-prod-subdomain.env` config, preserving that overlay while routing through the same manifest validation, OCI preflight, Helm deployment, and evidence finalization as the generic production path.
@@ -566,7 +566,7 @@ The runtime config check is a required routing gate, not an optional fallback: i
 curl -fsS https://staging.democratized.space/config.json \
   | jq -e '
       .tokenPlace.url == "https://staging.token.place"
-      and .tokenPlace.model == "llama-3.1-8b-instruct"
+      and .tokenPlace.model == "qwen3-8b-instruct"
     '
 ```
 

--- a/docs/examples/dspace.values.staging.yaml
+++ b/docs/examples/dspace.values.staging.yaml
@@ -10,7 +10,7 @@ env:
   - name: DSPACE_TOKEN_PLACE_URL
     value: https://staging.token.place
   - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
-    value: llama-3.1-8b-instruct
+    value: qwen3-8b-instruct
 
 metrics:
   enabled: true

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -69,7 +69,11 @@ def test_dspace_staging_overlay_points_to_staging_token_place() -> None:
     env = _runtime_env(OVERLAYS["staging"])
 
     assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://staging.token.place"]
-    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["llama-3.1-8b-instruct"]
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["qwen3-8b-instruct"]
+    assert len(env["DSPACE_TOKEN_PLACE_CHAT_MODEL"]) == 1
+    assert "llama-3.1-8b-instruct" not in OVERLAYS["staging"].read_text(
+        encoding="utf-8"
+    )
 
 
 def test_dspace_prod_overlay_points_to_prod_token_place() -> None:
@@ -77,6 +81,7 @@ def test_dspace_prod_overlay_points_to_prod_token_place() -> None:
 
     assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://token.place"]
     assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["llama-3.1-8b-instruct"]
+    assert "qwen3-8b-instruct" not in OVERLAYS["prod"].read_text(encoding="utf-8")
 
 
 def test_dspace_deployment_overlays_have_no_vite_runtime_env() -> None:

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -10,6 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.app_config import load_config  # noqa: E402
+from scripts.app_chart import contains_exact_scalar, merged_values_document  # noqa: E402
 
 OVERLAYS = {
     "staging": REPO_ROOT / "docs/examples/dspace.values.staging.yaml",
@@ -65,15 +66,54 @@ def _runtime_env(path: Path) -> dict[str, list[str]]:
     return env
 
 
+def _values_chain(env: str) -> tuple[str, ...]:
+    """Return the configured DSPACE values chain for an environment."""
+    return tuple(load_config("dspace", env)["SUGARKUBE_VALUES"].split(","))
+
+
+def _resolved_runtime_env(env: str) -> dict[str, list[str]]:
+    """Return env entries from the real resolved Helm values chain."""
+    document = merged_values_document(_values_chain(env))
+    entries = document.get("env") if isinstance(document, dict) else None
+    assert isinstance(entries, list)
+
+    resolved: dict[str, list[str]] = {}
+    for entry in entries:
+        assert isinstance(entry, dict)
+        name = entry.get("name")
+        assert isinstance(name, str)
+        value = entry.get("value")
+        resolved.setdefault(name, []).append("" if value is None else str(value))
+    return resolved
+
+
+def _resolved_document(env: str) -> object:
+    """Resolve DSPACE values through the repository merge implementation."""
+    return merged_values_document(_values_chain(env))
+
+
 def test_dspace_staging_overlay_points_to_staging_token_place() -> None:
     env = _runtime_env(OVERLAYS["staging"])
 
     assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://staging.token.place"]
     assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["qwen3-8b-instruct"]
-    assert len(env["DSPACE_TOKEN_PLACE_CHAT_MODEL"]) == 1
-    assert "llama-3.1-8b-instruct" not in OVERLAYS["staging"].read_text(
-        encoding="utf-8"
-    )
+
+
+def test_dspace_resolved_values_keep_staging_and_prod_token_place_separate() -> None:
+    staging_env = _resolved_runtime_env("staging")
+    staging_document = _resolved_document("staging")
+
+    assert staging_env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["qwen3-8b-instruct"]
+    assert staging_env["DSPACE_TOKEN_PLACE_URL"] == ["https://staging.token.place"]
+    assert not contains_exact_scalar(staging_document, {"llama-3.1-8b-instruct"})
+
+    prod_env = _resolved_runtime_env("prod")
+    prod_document = _resolved_document("prod")
+
+    assert prod_env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["llama-3.1-8b-instruct"]
+    assert prod_env["DSPACE_TOKEN_PLACE_URL"] == ["https://token.place"]
+    assert not contains_exact_scalar(prod_document, {"qwen3-8b-instruct"})
+    assert not contains_exact_scalar(prod_document, {"https://staging.token.place"})
 
 
 def test_dspace_prod_overlay_points_to_prod_token_place() -> None:
@@ -81,7 +121,6 @@ def test_dspace_prod_overlay_points_to_prod_token_place() -> None:
 
     assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://token.place"]
     assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["llama-3.1-8b-instruct"]
-    assert "qwen3-8b-instruct" not in OVERLAYS["prod"].read_text(encoding="utf-8")
 
 
 def test_dspace_deployment_overlays_have_no_vite_runtime_env() -> None:


### PR DESCRIPTION
### Motivation

- Move DSPACE staging from the legacy `llama-3.1-8b-instruct` token.place model to the canonical `qwen3-8b-instruct`.
- Keep production, historical records, and every other release coordinate unchanged.

### Changes

- Set `DSPACE_TOKEN_PLACE_CHAT_MODEL=qwen3-8b-instruct` in `docs/examples/dspace.values.staging.yaml`.
- Update the active staging configuration and `/config.json` verification gate in `docs/apps/dspace.md`.
- Add focused regression coverage in `tests/test_dspace_runtime_values.py` using the repository’s actual `merged_values_document` implementation.

The resolved-values tests verify that:

- Staging contains exactly one model entry set to `qwen3-8b-instruct`.
- Staging contains exactly one token.place origin set to `https://staging.token.place`.
- The legacy Llama model is absent from resolved staging values.
- Production remains on `llama-3.1-8b-instruct` and `https://token.place`.
- Production contains no staging-only Qwen model or staging origin.

### Preserved scope

This PR does not change production values, deployment candidates, evidence or reservation files, Secrets, observability configuration, image tags or digests, source revisions, chart versions or digests, provider selection, ingress, metrics, or ServiceMonitor configuration.

Historical and production references to `llama-3.1-8b-instruct` remain intentionally unchanged.

### Verification

- `python3 -m pytest -q tests/test_dspace_runtime_values.py tests/test_generic_app_just_recipes.py tests/test_app_config.py` — `318 passed, 1 warning`
- `just app-config app=dspace env=staging` — confirmed the configured staging values chain
- `just app-verify app=dspace env=staging print_only=1` — generated read-only verification commands
- `rg -n "llama-3\.1-8b-instruct" . --glob '!.git/**'` — retained occurrences classified as production, historical, or regression assertions
- `git diff --check` — passed
- `git diff --cached | ./scripts/scan-secrets.py` — passed

No Helm, Kubernetes, deployment, evidence, reservation, production, or Secret state was changed.

### Operator follow-up

This is repository-only desired-state preparation. Operators must separately reconcile the preserved failed Helm revision-27 reservation, create a newly approved candidate/evidence destination, and perform a guarded staging deployment before treating this configuration as live.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7299dc9d88832fa0a4c712f345283d)