### PR TITLE
Update DSPACE staging token.place model to qwen3-8b-instruct

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -352,7 +352,7 @@ Use these links before changing a deployment so the workflow runs, package versi
 - `env=dev`: future single-node/non-HA environment using `docs/examples/dspace.values.dev.yaml`.
   The dev overlay intentionally does not choose a token.place origin; developers who need local runtime routing can copy `docs/examples/apps/dspace.env` to a local app config and add chart-supported `env` entries to their private values file.
 - `env=staging`: HA staging on the staging Sugarkube cluster with host `staging.democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
-  The configured staging target injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`, uses provenance-bearing chart `3.1.1` for DSPACE application `3.1.0`, and persists the authenticated metrics ServiceMonitor configuration discovered by kube-prometheus-stack. The live staging release has not yet been restored to this target and remains on the validated DSPACE `3.0.1` recovery deployment at Helm revision 26. The metrics bearer value is not committed; operators manage the existing `dspace-staging-metrics-token` Secret out of band.
+  The configured staging target injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=qwen3-8b-instruct`, uses provenance-bearing chart `3.1.1` for DSPACE application `3.1.0`, and persists the authenticated metrics ServiceMonitor configuration discovered by kube-prometheus-stack. The live staging release currently remains on preserved Helm revision 27 from the immutable DSPACE `3.1.0` staging image; reconciling that reservation and performing a guarded staging deployment is an operator task outside this repository-only desired-state change. The metrics bearer value is not committed; operators manage the existing `dspace-staging-metrics-token` Secret out of band.
 - `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
   The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`. Production is pinned to recovery chart `3.0.2` and image `ghcr.io/democratizedspace/dspace:main-1a31a56`; it does not enable metrics or ServiceMonitor settings.
 - Optional legacy/canary host `prod.democratized.space` uses `docs/examples/dspace.values.prod-subdomain.yaml`. The `dspace-oci-deploy-prod-subdomain` compatibility command selects the secret-free `docs/examples/apps/dspace-prod-subdomain.env` config, preserving that overlay while routing through the same manifest validation, OCI preflight, Helm deployment, and evidence finalization as the generic production path.
@@ -566,7 +566,7 @@ The runtime config check is a required routing gate, not an optional fallback: i
 curl -fsS https://staging.democratized.space/config.json \
   | jq -e '
       .tokenPlace.url == "https://staging.token.place"
-      and .tokenPlace.model == "llama-3.1-8b-instruct"
+      and .tokenPlace.model == "qwen3-8b-instruct"
     '
 ```
 

--- a/docs/examples/dspace.values.staging.yaml
+++ b/docs/examples/dspace.values.staging.yaml
@@ -10,7 +10,7 @@ env:
   - name: DSPACE_TOKEN_PLACE_URL
     value: https://staging.token.place
   - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
-    value: llama-3.1-8b-instruct
+    value: qwen3-8b-instruct
 
 metrics:
   enabled: true

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -69,7 +69,28 @@ def test_dspace_staging_overlay_points_to_staging_token_place() -> None:
     env = _runtime_env(OVERLAYS["staging"])
 
     assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://staging.token.place"]
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["qwen3-8b-instruct"]
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"].count("llama-3.1-8b-instruct") == 0
+
+
+def test_dspace_staging_resolved_values_keep_single_qwen_model_and_origin() -> None:
+    env: dict[str, list[str]] = {}
+    for values_file in EXPECTED_VALUES_CHAINS["staging"].split(","):
+        for name, values in _runtime_env(REPO_ROOT / values_file).items():
+            env[name] = values
+
+    assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://staging.token.place"]
+    assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["qwen3-8b-instruct"]
+    assert "llama-3.1-8b-instruct" not in env["DSPACE_TOKEN_PLACE_CHAT_MODEL"]
+
+
+def test_dspace_prod_overlay_is_not_contaminated_by_staging_values() -> None:
+    env = _runtime_env(OVERLAYS["prod"])
+
+    assert env["DSPACE_TOKEN_PLACE_URL"] == ["https://token.place"]
     assert env["DSPACE_TOKEN_PLACE_CHAT_MODEL"] == ["llama-3.1-8b-instruct"]
+    assert "https://staging.token.place" not in env["DSPACE_TOKEN_PLACE_URL"]
+    assert "qwen3-8b-instruct" not in env["DSPACE_TOKEN_PLACE_CHAT_MODEL"]
 
 
 def test_dspace_prod_overlay_points_to_prod_token_place() -> None:


### PR DESCRIPTION
### Motivation
- Bring the repository desired-state for DSPACE staging in line with the DSPACE canonical Qwen migration so staging renders `qwen3-8b-instruct` instead of the legacy `llama-3.1-8b-instruct` while keeping the staging token.place origin unchanged. 
- Keep production and historical records unchanged and make the operator-facing runbook explicit that reconciling the preserved Helm revision reservation is an out-of-repo operator task. 

### Description
- Change `DSPACE_TOKEN_PLACE_CHAT_MODEL` in the staging values overlay to `qwen3-8b-instruct` by updating `docs/examples/dspace.values.staging.yaml`. 
- Update the active staging runbook in `docs/apps/dspace.md` to describe the canonical Qwen staging configuration and note that the preserved Helm revision-27 reservation reconciliation is an operator task outside this repository-only change. 
- Add focused regression assertions to `tests/test_dspace_runtime_values.py` that ensure the resolved staging values contain exactly one `DSPACE_TOKEN_PLACE_CHAT_MODEL` set to `qwen3-8b-instruct`, that the legacy Llama value is not present for current staging, that the staging origin remains `https://staging.token.place`, and that production is not contaminated by staging-only values. 
- Preserve all other DSPACE release coordinates (chart pin, image tag/digest, source revision, ingress, metrics, ServiceMonitor, provider selection) and do not change production values or Secrets. 

### Testing
- Ran focused test suite with `python3 -m pytest -q tests/test_dspace_runtime_values.py tests/test_generic_app_just_recipes.py tests/test_app_config.py` which completed with `319 passed, 1 warning` (no failures). 
- Verified `git diff --check` reported no whitespace or diff issues and ran `git diff --cached | ./scripts/scan-secrets.py` which produced no secret findings. 
- Attempted the read-only values/chart preflight `python3 scripts/app_chart.py preflight ...` but it could not run because `helm` is not installed in the environment; no Helm/cluster actions were executed. 
- Searched the repo for lingering `llama-3.1-8b-instruct` occurrences and confirmed remaining instances are production or historical documentation, not active staging desired-state. 

Notes and non-mutation confirmation: the change is repository-only and small (files changed: `docs/examples/dspace.values.staging.yaml`, `docs/apps/dspace.md`, `tests/test_dspace_runtime_values.py`), a commit was created locally (`Update DSPACE staging token.place model to Qwen`), and no Kubernetes, Helm, evidence, reservation, production, Secret, or other cluster state was modified as part of this work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7299e85704832fa3947c875f57c5ed)