### PR TITLE
Add DSPACE release-integrity alerts, synthetic metric contract, dashboard panels, runbook (Refs #2329)

### DIFF
--- a/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
+++ b/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
@@ -1071,6 +1071,245 @@
           "mode": "multi"
         }
       }
+    },
+    {
+      "id": 22,
+      "title": "DSPACE release integrity",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 60
+      },
+      "panels": []
+    },
+    {
+      "id": 23,
+      "title": "Approved revision",
+      "type": "table",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 61
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (revision) (dspace_release_approved_info{environment=~\"$environment\"})",
+          "refId": "A",
+          "legendFormat": "{{revision}}",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 24,
+      "title": "Active build revisions by pod",
+      "type": "table",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 61
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (pod, revision) (dspace_build_info{environment=~\"$environment\"})",
+          "refId": "A",
+          "legendFormat": "{{pod}} {{revision}}",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 25,
+      "title": "Image-pin agreement",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 61
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(dspace_deployment_image_pin_matches{environment=~\"$environment\"})",
+          "refId": "A",
+          "legendFormat": "",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 26,
+      "title": "DSPACE metrics-target health",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 67
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(up{namespace=\"dspace\",service=~\"dspace.*\"})",
+          "refId": "A",
+          "legendFormat": "",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 27,
+      "title": "/chat synthetic result",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 67
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(dspace_chat_synthetic_success{application=\"dspace\",environment=~\"$environment\"})",
+          "refId": "A",
+          "legendFormat": "",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 28,
+      "title": "/chat synthetic freshness",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 67
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "time() - max(dspace_chat_synthetic_last_run_timestamp_seconds{application=\"dspace\",environment=~\"$environment\"})",
+          "refId": "A",
+          "legendFormat": "",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 29,
+      "title": "Release integrity references",
+      "type": "text",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 73
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "[DSPACE release-integrity runbook](https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md) \u00b7 [Finalized staging evidence](https://github.com/futuroptimist/sugarkube/blob/main/deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json)"
+      },
+      "transparent": true
     }
   ]
 }

--- a/clusters/staging/observability/kube-prometheus-stack.values.yaml
+++ b/clusters/staging/observability/kube-prometheus-stack.values.yaml
@@ -34,7 +34,7 @@ alertmanager:
       routes:
         - receiver: pagerduty-synthetic-test
           matchers:
-            - alertname="SugarkubePagerDutyTest"
+            - alertname=~"^(SugarkubePagerDutyTest|DspaceBuildRevisionMismatch|DspaceMixedBuildRevisions|DspaceDeploymentImagePinMismatch|DspaceChatSyntheticFailed|DspaceMetricsTargetDown)$"
             - environment="staging"
             - cluster="sugarkube-int"
             - severity="critical"

--- a/clusters/staging/observability/rules/dspace-release-integrity.rules.yaml
+++ b/clusters/staging/observability/rules/dspace-release-integrity.rules.yaml
@@ -1,0 +1,126 @@
+{
+  "groups": [
+    {
+      "name": "sugarkube.dspace-release-integrity",
+      "interval": "30s",
+      "rules": [
+        {
+          "record": "dspace_release_approved_info",
+          "expr": "vector(1)",
+          "labels": {
+            "application": "dspace",
+            "environment": "staging",
+            "cluster": "sugarkube-int",
+            "revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d",
+            "image_tag": "main-018687f",
+            "image_digest": "sha256:2b95b7fdccdd011553c8d8617e3090ee27323996c532148fdb147cb9fd6e1b6c"
+          }
+        },
+        {
+          "record": "dspace_deployment_image_pin_matches",
+          "expr": "min(kube_pod_container_info{namespace=\"dspace\",container=\"dspace\",image=\"ghcr.io/democratizedspace/dspace:main-018687f\"}) and on(pod) min(kube_pod_container_status_image_id{namespace=\"dspace\",container=\"dspace\",image_id=~\".*@sha256:2b95b7fdccdd011553c8d8617e3090ee27323996c532148fdb147cb9fd6e1b6c\"})",
+          "labels": {
+            "application": "dspace",
+            "environment": "staging",
+            "cluster": "sugarkube-int"
+          }
+        },
+        {
+          "alert": "DspaceBuildRevisionMismatch",
+          "expr": "(max by (pod, revision) (dspace_build_info{environment=\"staging\",revision!=\"018687f5a7f4de45508c6e36eb28afb3e44da24d\"})) or (label_replace(vector(1), \"revision\", \"unknown\", \"\", \"\") unless on() dspace_build_info{environment=\"staging\"})",
+          "for": "5m",
+          "labels": {
+            "application": "dspace",
+            "environment": "staging",
+            "cluster": "sugarkube-int",
+            "severity": "critical",
+            "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d"
+          },
+          "annotations": {
+            "summary": "DSPACE runtime revision differs from the approved release",
+            "current_revision": "{{ if $labels.revision }}{{ $labels.revision }}{{ else }}unknown{{ end }}",
+            "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d",
+            "remediation": "Verify build identity and pod image IDs, then reconcile to finalized evidence.",
+            "runbook_url": "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md"
+          }
+        },
+        {
+          "alert": "DspaceMixedBuildRevisions",
+          "expr": "count(count by (revision) (dspace_build_info{environment=\"staging\"})) > 1",
+          "for": "5m",
+          "labels": {
+            "application": "dspace",
+            "environment": "staging",
+            "cluster": "sugarkube-int",
+            "severity": "critical",
+            "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d"
+          },
+          "annotations": {
+            "summary": "DSPACE replicas expose mixed build revisions",
+            "current_revision": "{{ if $labels.revision }}{{ $labels.revision }}{{ else }}unknown{{ end }}",
+            "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d",
+            "remediation": "Allow a settling rollout briefly; otherwise stop and reconcile every replica.",
+            "runbook_url": "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md"
+          }
+        },
+        {
+          "alert": "DspaceDeploymentImagePinMismatch",
+          "expr": "(max by (deployment, image) (kube_deployment_container_info{namespace=\"dspace\",deployment=\"dspace\",container=\"dspace\",image!=\"ghcr.io/democratizedspace/dspace:main-018687f@sha256:2b95b7fdccdd011553c8d8617e3090ee27323996c532148fdb147cb9fd6e1b6c\"})) or (label_replace(vector(1), \"revision\", \"unknown\", \"\", \"\") unless on() kube_deployment_container_info{namespace=\"dspace\",deployment=\"dspace\",container=\"dspace\"})",
+          "for": "5m",
+          "labels": {
+            "application": "dspace",
+            "environment": "staging",
+            "cluster": "sugarkube-int",
+            "severity": "critical",
+            "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d"
+          },
+          "annotations": {
+            "summary": "DSPACE Deployment image is not the approved immutable pin",
+            "current_revision": "unknown",
+            "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d",
+            "remediation": "Reconcile the Deployment to the finalized tag and digest; never use a semantic tag.",
+            "runbook_url": "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md"
+          }
+        },
+        {
+          "alert": "DspaceChatSyntheticFailed",
+          "expr": "(dspace_chat_synthetic_success{application=\"dspace\",environment=\"staging\"} == 0) or (time() - dspace_chat_synthetic_last_run_timestamp_seconds{application=\"dspace\",environment=\"staging\"} > 900) or (label_replace(vector(1), \"revision\", \"unknown\", \"\", \"\") unless on() dspace_chat_synthetic_last_run_timestamp_seconds{application=\"dspace\",environment=\"staging\"})",
+          "for": "5m",
+          "labels": {
+            "application": "dspace",
+            "environment": "staging",
+            "cluster": "sugarkube-int",
+            "severity": "critical",
+            "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d"
+          },
+          "annotations": {
+            "summary": "DSPACE non-mutating /chat synthetic failed, is stale, or is missing",
+            "current_revision": "{{ if $labels.revision }}{{ $labels.revision }}{{ else }}unknown{{ end }}",
+            "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d",
+            "remediation": "Inspect freshness first, then the pinned smoke-runner result and provider configuration.",
+            "runbook_url": "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md"
+          }
+        },
+        {
+          "alert": "DspaceMetricsTargetDown",
+          "expr": "(max by (job) (up{namespace=\"dspace\",service=~\"dspace.*\"}) == 0) or (label_replace(vector(1), \"revision\", \"unknown\", \"\", \"\") unless on() up{namespace=\"dspace\",service=~\"dspace.*\"})",
+          "for": "5m",
+          "labels": {
+            "application": "dspace",
+            "environment": "staging",
+            "cluster": "sugarkube-int",
+            "severity": "critical",
+            "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d"
+          },
+          "annotations": {
+            "summary": "DSPACE metrics target is down or missing",
+            "current_revision": "unknown",
+            "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d",
+            "remediation": "Separate scrape/authentication failure from application health before changing DSPACE.",
+            "runbook_url": "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/clusters/staging/observability/rules/dspace-release-integrity.values.json
+++ b/clusters/staging/observability/rules/dspace-release-integrity.values.json
@@ -1,0 +1,130 @@
+{
+  "additionalPrometheusRulesMap": {
+    "dspace-release-integrity": {
+      "groups": [
+        {
+          "name": "sugarkube.dspace-release-integrity",
+          "interval": "30s",
+          "rules": [
+            {
+              "record": "dspace_release_approved_info",
+              "expr": "vector(1)",
+              "labels": {
+                "application": "dspace",
+                "environment": "staging",
+                "cluster": "sugarkube-int",
+                "revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d",
+                "image_tag": "main-018687f",
+                "image_digest": "sha256:2b95b7fdccdd011553c8d8617e3090ee27323996c532148fdb147cb9fd6e1b6c"
+              }
+            },
+            {
+              "record": "dspace_deployment_image_pin_matches",
+              "expr": "min(kube_pod_container_info{namespace=\"dspace\",container=\"dspace\",image=\"ghcr.io/democratizedspace/dspace:main-018687f\"}) and on(pod) min(kube_pod_container_status_image_id{namespace=\"dspace\",container=\"dspace\",image_id=~\".*@sha256:2b95b7fdccdd011553c8d8617e3090ee27323996c532148fdb147cb9fd6e1b6c\"})",
+              "labels": {
+                "application": "dspace",
+                "environment": "staging",
+                "cluster": "sugarkube-int"
+              }
+            },
+            {
+              "alert": "DspaceBuildRevisionMismatch",
+              "expr": "(max by (pod, revision) (dspace_build_info{environment=\"staging\",revision!=\"018687f5a7f4de45508c6e36eb28afb3e44da24d\"})) or (label_replace(vector(1), \"revision\", \"unknown\", \"\", \"\") unless on() dspace_build_info{environment=\"staging\"})",
+              "for": "5m",
+              "labels": {
+                "application": "dspace",
+                "environment": "staging",
+                "cluster": "sugarkube-int",
+                "severity": "critical",
+                "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d"
+              },
+              "annotations": {
+                "summary": "DSPACE runtime revision differs from the approved release",
+                "current_revision": "{{ if $labels.revision }}{{ $labels.revision }}{{ else }}unknown{{ end }}",
+                "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d",
+                "remediation": "Verify build identity and pod image IDs, then reconcile to finalized evidence.",
+                "runbook_url": "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md"
+              }
+            },
+            {
+              "alert": "DspaceMixedBuildRevisions",
+              "expr": "count(count by (revision) (dspace_build_info{environment=\"staging\"})) > 1",
+              "for": "5m",
+              "labels": {
+                "application": "dspace",
+                "environment": "staging",
+                "cluster": "sugarkube-int",
+                "severity": "critical",
+                "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d"
+              },
+              "annotations": {
+                "summary": "DSPACE replicas expose mixed build revisions",
+                "current_revision": "{{ if $labels.revision }}{{ $labels.revision }}{{ else }}unknown{{ end }}",
+                "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d",
+                "remediation": "Allow a settling rollout briefly; otherwise stop and reconcile every replica.",
+                "runbook_url": "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md"
+              }
+            },
+            {
+              "alert": "DspaceDeploymentImagePinMismatch",
+              "expr": "(max by (deployment, image) (kube_deployment_container_info{namespace=\"dspace\",deployment=\"dspace\",container=\"dspace\",image!=\"ghcr.io/democratizedspace/dspace:main-018687f@sha256:2b95b7fdccdd011553c8d8617e3090ee27323996c532148fdb147cb9fd6e1b6c\"})) or (label_replace(vector(1), \"revision\", \"unknown\", \"\", \"\") unless on() kube_deployment_container_info{namespace=\"dspace\",deployment=\"dspace\",container=\"dspace\"})",
+              "for": "5m",
+              "labels": {
+                "application": "dspace",
+                "environment": "staging",
+                "cluster": "sugarkube-int",
+                "severity": "critical",
+                "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d"
+              },
+              "annotations": {
+                "summary": "DSPACE Deployment image is not the approved immutable pin",
+                "current_revision": "unknown",
+                "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d",
+                "remediation": "Reconcile the Deployment to the finalized tag and digest; never use a semantic tag.",
+                "runbook_url": "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md"
+              }
+            },
+            {
+              "alert": "DspaceChatSyntheticFailed",
+              "expr": "(dspace_chat_synthetic_success{application=\"dspace\",environment=\"staging\"} == 0) or (time() - dspace_chat_synthetic_last_run_timestamp_seconds{application=\"dspace\",environment=\"staging\"} > 900) or (label_replace(vector(1), \"revision\", \"unknown\", \"\", \"\") unless on() dspace_chat_synthetic_last_run_timestamp_seconds{application=\"dspace\",environment=\"staging\"})",
+              "for": "5m",
+              "labels": {
+                "application": "dspace",
+                "environment": "staging",
+                "cluster": "sugarkube-int",
+                "severity": "critical",
+                "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d"
+              },
+              "annotations": {
+                "summary": "DSPACE non-mutating /chat synthetic failed, is stale, or is missing",
+                "current_revision": "{{ if $labels.revision }}{{ $labels.revision }}{{ else }}unknown{{ end }}",
+                "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d",
+                "remediation": "Inspect freshness first, then the pinned smoke-runner result and provider configuration.",
+                "runbook_url": "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md"
+              }
+            },
+            {
+              "alert": "DspaceMetricsTargetDown",
+              "expr": "(max by (job) (up{namespace=\"dspace\",service=~\"dspace.*\"}) == 0) or (label_replace(vector(1), \"revision\", \"unknown\", \"\", \"\") unless on() up{namespace=\"dspace\",service=~\"dspace.*\"})",
+              "for": "5m",
+              "labels": {
+                "application": "dspace",
+                "environment": "staging",
+                "cluster": "sugarkube-int",
+                "severity": "critical",
+                "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d"
+              },
+              "annotations": {
+                "summary": "DSPACE metrics target is down or missing",
+                "current_revision": "unknown",
+                "expected_revision": "018687f5a7f4de45508c6e36eb28afb3e44da24d",
+                "remediation": "Separate scrape/authentication failure from application health before changing DSPACE.",
+                "runbook_url": "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -810,3 +810,8 @@ just helm-oci-install release=dspace namespace=dspace chart=oci://ghcr.io/democr
 ```bash
 just helm-oci-upgrade release=dspace namespace=dspace chart=oci://ghcr.io/democratizedspace/charts/dspace values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml version_file=docs/apps/dspace.staging.version tag="$APP_TAG" env=staging
 ```
+
+
+## Release-integrity monitoring
+
+The repository-owned alert rules, bounded `/chat` synthetic metric contract, operational diagnosis, and staging-only drills are documented in the [DSPACE release-integrity runbook](../observability-dspace-release-integrity.md). Repository readiness does not imply deployment or live PagerDuty proof, and production observability remains unsupported.

--- a/docs/observability-alerting.md
+++ b/docs/observability-alerting.md
@@ -29,8 +29,7 @@ post-merge work. Real workload routes remain deferred.
 - Production alert rollout. This document designs the staging path first; production follows only
   after staging drills succeed (see [`docs/observability-design.md`](./observability-design.md) §13).
 - Advanced SLOs, burn-rate alerting, or multi-window error budgets.
-- Exhaustive application-level synthetic checks. The one synthetic check currently in scope
-  (`DspaceChatSyntheticFailed`) is deferred — see [§8](#8-status-and-dependencies).
+- Exhaustive application-level synthetic checks. The bounded producer/consumer contract for `DspaceChatSyntheticFailed` is repository-ready; its externally pinned smoke runner remains an operational prerequisite — see [the release-integrity runbook](./observability-dspace-release-integrity.md).
 
 ## 2. Chosen target architecture
 
@@ -129,7 +128,7 @@ What each check detects, and does not:
 - Staging repository support now mounts `monitoring/alertmanager-pagerduty` and reads its
   `routing-key` key from
   `/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key`; the credential is never inline.
-  The only PagerDuty route is the exact `SugarkubePagerDutyTest` synthetic allowlist. This is
+  The only PagerDuty route is the exact reviewed DSPACE alert plus `SugarkubePagerDutyTest` allowlist. This is
   repository support is deployed in staging, and its synthetic fire/acknowledge/resolve path has
   been manually proven. No real workload alert is routed by that evidence.
 - Set `send_resolved: true` on the PagerDuty receiver so incidents auto-resolve when the underlying
@@ -156,7 +155,7 @@ These are the current alert-design candidates, not proof the rules already exist
 | `PublicEndpointDown` | A blackbox probe's `probe_success` is 0 | Reuses the signal already defined in [`docs/observability-design.md`](./observability-design.md) §6/§11. |
 | `PublicProbeMissing` | An expected blackbox probe target has no recent data at all (distinct from a probe that ran and failed) | Matches the "missing probe data" state already surfaced in the staging dashboard's availability summary panel. |
 | `TLSExpiringSoon` | `probe_ssl_earliest_cert_expiry` crosses a warning/critical threshold | Reuses the signal already defined in [`docs/observability-design.md`](./observability-design.md) §6. |
-| `DspaceChatSyntheticFailed` | A deeper synthetic check exercises DSPACE's dChat path end-to-end | **Explicitly deferred** — see [§8](#8-status-and-dependencies). Not part of the initial rollout. |
+| `DspaceChatSyntheticFailed` | A deeper synthetic check exercises DSPACE's dChat path end-to-end | Repository-ready with a fail-closed metric contract; continuous execution awaits the externally pinned smoke runner. |
 
 ## 6. Rollout and drill plan
 
@@ -164,7 +163,7 @@ A safe, phased sequence — each step depends on the previous one succeeding:
 
 1. Establish PagerDuty and Healthchecks.io accounts and integrations manually (outside this repo).
 2. Deploy and verify the repository's secret-safe receiver foundation (`routing_key_file`, no inline
-   secrets); the root remains the null receiver and only the synthetic test is allowlisted.
+   secrets); the root remains the null receiver and only the reviewed DSPACE alerts plus the synthetic test are allowlisted.
 3. **Proven:** manually fire the synthetic PagerDuty test alert, receive and acknowledge the phone
    incident, resolve the alert, and observe resolution after Alertmanager's expected default
    resolution delay (about five minutes).
@@ -222,12 +221,7 @@ it is deployed yet — see the rollout plan above for the actual sequencing.
 
 ## 8. Status and dependencies
 
-- The deeper DSPACE dChat synthetic check (`DspaceChatSyntheticFailed`) is deferred while token.place
-  staging inference depends on work tracked in `futuroptimist/token.place#1549`. This blocks only that
-  one synthetic check, not the rest of the alerting foundation.
-- Shallow public-endpoint blackbox monitoring (`PublicEndpointDown`, `PublicProbeMissing`,
-  `TLSExpiringSoon`) is already live in staging today, independently of that dependency — see
-  [`docs/observability-blackbox.md`](./observability-blackbox.md).
+- The `DspaceChatSyntheticFailed` consumer and bounded publisher are repository-ready. Continuous execution and live proof still require the externally pinned smoke runner described in the [release-integrity runbook](./observability-dspace-release-integrity.md).
 - The synthetic Alertmanager → PagerDuty fire/acknowledge/resolve drill succeeded, including the
   expected roughly five-minute Alertmanager resolution delay.
 - Per-node heartbeat timers are installed on `sugarkube3`, `sugarkube4`, and `sugarkube5`; their

--- a/docs/observability-dspace-release-integrity.md
+++ b/docs/observability-dspace-release-integrity.md
@@ -1,0 +1,102 @@
+# DSPACE release-integrity alerting and staging drills
+
+## State and immutable coordinates
+
+This repository is **ready**, but repository tests do not prove that rules are deployed or that a page
+was delivered. Staging uses the finalized record
+[`main-018687f-20260805T035722Z.json`](../deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json).
+The generated values in `clusters/staging/observability/rules/` must be regenerated with
+`scripts/generate_dspace_observability_rules.py`; CI proves agreement. Semantic tags are never release
+identity. Production's finalized evidence is render/test input only: production observability remains
+unsupported by the fail-closed Helm helper.
+
+## Signals and diagnosis
+
+All five alerts carry application, environment, cluster, severity, expected revision, a bounded
+current revision (or `unknown`), remediation, and this stable runbook URL.
+
+* **`DspaceBuildRevisionMismatch`** — compare `/build-info.json`, `dspace_build_info`, and each pod's
+  image ID with finalized evidence. Runtime drift with a fresh passing synthetic is identity drift,
+  not synthetic staleness. Reconcile the immutable release rather than a semantic tag.
+* **`DspaceMixedBuildRevisions`** — inspect Deployment rollout status and pod start times. A healthy
+  rollout may briefly contain two active revisions; the five-minute `for` period bounds settling.
+  Beyond that, pause diagnosis and reconcile the stuck replica. Historical SHAs are not exported.
+* **`DspaceDeploymentImagePinMismatch`** — compare the Deployment/pod tag and runtime image digest
+  with evidence. This is workload-spec/image drift; `DspaceBuildRevisionMismatch` instead means the
+  running application's identity endpoint disagrees. Either may fire alone.
+* **`DspaceMetricsTargetDown`** — inspect ServiceMonitor target discovery, bearer-token Secret
+  presence, TLS, and Prometheus target errors without printing credentials. If `/healthz` and public
+  probes pass, treat this as scrape/authentication failure; if they also fail, investigate the app.
+* **`DspaceChatSyntheticFailed`** — first inspect the last-run timestamp. Missing/stale data fails
+  closed and is distinct from `dspace_chat_synthetic_success == 0`, an executed failure. For an
+  executed failure compare public reachability, direct health, and provider dependency metrics:
+  public-only failure suggests ingress; healthy app plus dependency failures suggests provider or
+  configuration failure.
+
+Rollback means restore the prior complete, finalized immutable coordinates through the DSPACE
+release procedure in [the DSPACE guide](apps/dspace.md); do not use an unreviewed `helm rollback` or
+mutable tag. Silence only after ownership and impact are understood.
+
+## Non-mutating `/chat` producer contract
+
+Sugarkube does not vendor or download DSPACE test code. An external scheduler must install a smoke
+runner at an explicitly reviewed **full commit SHA**, run its `/chat` journey with mutation disabled
+and an intercepted/isolated transport, and write only this JSON to a root-owned temporary file:
+
+```json
+{"schemaVersion":1,"journey":"/chat","passed":true,"mutationDisabled":true,"transport":"intercepted","completedAt":1785988800}
+```
+
+Publish atomically to a node-exporter textfile directory:
+
+```bash
+python3 scripts/dspace_chat_synthetic_metrics.py --result /run/dspace-chat/result.json \
+  --output /var/lib/node_exporter/textfile_collector/dspace-chat.prom \
+  --runner-revision 0123456789abcdef0123456789abcdef01234567
+```
+
+Schedule at least every five minutes. The publisher rejects mutable revisions, extra fields (including
+keys, users, prompts, responses, URLs, request IDs, or errors), non-intercepted transport, mutation,
+future results, and results over one hour old. Prometheus pages after 15 minutes without a timestamp.
+Verify the two metric names and timestamp through Prometheus; never `cat` upstream logs containing
+credentials. To roll back, disable the scheduler and remove only `dspace-chat.prom`; missing data then
+fails closed. **Remaining prerequisite:** choose, security-review, install, and schedule the external
+DSPACE smoke-runner artifact at a full commit SHA. Until that happens the alert correctly remains
+firing/missing; continuous synthetic execution is not claimed.
+
+## Post-merge staging drills
+
+These drills require a change window and `sugar-staging`. They do not change the DSPACE release.
+Choose a unique owner, label every temporary rule, and install a 15-minute cleanup trap. The alert
+expressions use only constants, so no fake DSPACE series persist.
+
+```bash
+set -Eeuo pipefail
+[[ "$(kubectl config current-context)" == sugar-staging ]]
+owner="dspace-2329-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+name="${owner,,}"
+cleanup() { kubectl -n monitoring delete prometheusrule "$name" \
+  --ignore-not-found --wait=true; }
+trap cleanup EXIT HUP INT TERM
+python3 - "$name" <<'PY' | kubectl apply -f -
+import json,sys
+name=sys.argv[1]
+alerts=["DspaceBuildRevisionMismatch","DspaceMixedBuildRevisions","DspaceChatSyntheticFailed"]
+rules=[{"alert":a,"expr":"vector(1)","for":"1m","labels":{"application":"dspace","environment":"staging","cluster":"sugarkube-int","severity":"critical","expected_revision":"018687f5a7f4de45508c6e36eb28afb3e44da24d","revision":"unknown","drill_owner":name},"annotations":{"summary":"bounded #2329 staging drill","current_revision":"unknown","expected_revision":"018687f5a7f4de45508c6e36eb28afb3e44da24d","remediation":"remove the uniquely owned drill rule","runbook_url":"https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md"}} for a in alerts]
+print(json.dumps({"apiVersion":"monitoring.coreos.com/v1","kind":"PrometheusRule","metadata":{"name":name,"namespace":"monitoring","labels":{"release":"kube-prometheus-stack","sugarkube.dev/drill-owner":name}},"spec":{"groups":[{"name":name,"rules":rules}]}}))
+PY
+sleep 90
+kubectl -n monitoring get prometheusrule "$name" -o name
+# Confirm all three alerts are firing and PagerDuty received the firing notifications.
+cleanup
+trap - EXIT HUP INT TERM
+# Confirm all three resolve in PagerDuty and no resource with this owner remains:
+! kubectl -n monitoring get prometheusrule -l "sugarkube.dev/drill-owner=$name" -o name | grep .
+```
+
+Run mismatch, mixed, and forced-failure drills separately if distinct PagerDuty incidents are required.
+Before and after, confirm unrelated alerts are unchanged. The staging-only context guard, unique name,
+exact label selector, exact-name deletion, and trap keep the exercise bounded; never run it against
+production. Live acceptance still requires deploying the repository revision, installing the pinned
+runner, observing each real rule, and manually confirming PagerDuty firing, acknowledgement, and
+resolved delivery.

--- a/scripts/dspace_chat_synthetic_metrics.py
+++ b/scripts/dspace_chat_synthetic_metrics.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Atomically publish the bounded contract produced by a pinned DSPACE smoke runner."""
+
+import argparse
+import json
+import os
+import re
+import tempfile
+import time
+from pathlib import Path
+
+SHA = re.compile(r"^[0-9a-f]{40}$")
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--result", type=Path, required=True)
+    p.add_argument("--output", type=Path, required=True)
+    p.add_argument("--runner-revision", required=True)
+    p.add_argument("--now", type=int, default=None)
+    a = p.parse_args()
+    if not SHA.fullmatch(a.runner_revision):
+        p.error("--runner-revision must be a full immutable commit SHA")
+    data = json.loads(a.result.read_text())
+    allowed = {"schemaVersion", "journey", "passed", "mutationDisabled", "transport", "completedAt"}
+    if (
+        set(data) != allowed
+        or data["schemaVersion"] != 1
+        or data["journey"] != "/chat"
+        or data["mutationDisabled"] is not True
+        or data["transport"] != "intercepted"
+    ):
+        p.error("result violates the isolated non-mutating /chat contract")
+    completed = int(data["completedAt"])
+    now = a.now or int(time.time())
+    if completed > now + 60 or completed < now - 3600:
+        p.error("result is future-dated or too old to publish")
+    labels = (
+        'application="dspace",environment="staging",cluster="sugarkube-int",runner_revision="%s"'
+        % a.runner_revision
+    )
+    content = (
+        "# HELP dspace_chat_synthetic_success Last executed isolated /chat synthetic result.\n# TYPE dspace_chat_synthetic_success gauge\ndspace_chat_synthetic_success{%s} %d\n# HELP dspace_chat_synthetic_last_run_timestamp_seconds Completion time of the last executed synthetic.\n# TYPE dspace_chat_synthetic_last_run_timestamp_seconds gauge\ndspace_chat_synthetic_last_run_timestamp_seconds{%s} %d\n"
+        % (labels, 1 if data["passed"] is True else 0, labels, completed)
+    )
+    a.output.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=a.output.parent, prefix=".dspace-chat-", text=True)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, a.output)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_dspace_observability_rules.py
+++ b/scripts/generate_dspace_observability_rules.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Generate bounded DSPACE Prometheus rules from a finalized release record."""
+
+import argparse
+import json
+from pathlib import Path
+
+RUNBOOK = "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md"
+
+
+def generate(evidence: dict) -> dict:
+    required = {"recordType": "final", "app": "dspace", "environment": "staging"}
+    if any(evidence.get(k) != v for k, v in required.items()):
+        raise ValueError("only finalized staging DSPACE evidence is accepted")
+    revision = evidence["sourceRevision"]
+    tag = evidence["imageTag"]
+    digest = evidence["imageDigest"]
+    if len(revision) != 40 or not tag.startswith("main-") or not digest.startswith("sha256:"):
+        raise ValueError("evidence lacks immutable release coordinates")
+    labels = {
+        "application": "dspace",
+        "environment": "staging",
+        "cluster": "sugarkube-int",
+        "severity": "critical",
+        "expected_revision": revision,
+    }
+
+    def alert(
+        name,
+        expr,
+        summary,
+        remediation,
+        current="{{ if $labels.revision }}{{ $labels.revision }}{{ else }}unknown{{ end }}",
+    ):
+        return {
+            "alert": name,
+            "expr": expr,
+            "for": "5m",
+            "labels": labels,
+            "annotations": {
+                "summary": summary,
+                "current_revision": current,
+                "expected_revision": revision,
+                "remediation": remediation,
+                "runbook_url": RUNBOOK,
+            },
+        }
+
+    unknown = 'label_replace(vector(1), "revision", "unknown", "", "")'
+    rules = [
+        {
+            "record": "dspace_release_approved_info",
+            "expr": "vector(1)",
+            "labels": {
+                "application": "dspace",
+                "environment": "staging",
+                "cluster": "sugarkube-int",
+                "revision": revision,
+                "image_tag": tag,
+                "image_digest": digest,
+            },
+        },
+        {
+            "record": "dspace_deployment_image_pin_matches",
+            "expr": f'min(kube_pod_container_info{{namespace="dspace",container="dspace",image="ghcr.io/democratizedspace/dspace:{tag}"}}) and on(pod) min(kube_pod_container_status_image_id{{namespace="dspace",container="dspace",image_id=~".*@{digest}"}})',
+            "labels": {
+                "application": "dspace",
+                "environment": "staging",
+                "cluster": "sugarkube-int",
+            },
+        },
+        alert(
+            "DspaceBuildRevisionMismatch",
+            f'(max by (pod, revision) (dspace_build_info{{environment="staging",revision!="{revision}"}})) or ({unknown} unless on() dspace_build_info{{environment="staging"}})',
+            "DSPACE runtime revision differs from the approved release",
+            "Verify build identity and pod image IDs, then reconcile to finalized evidence.",
+        ),
+        alert(
+            "DspaceMixedBuildRevisions",
+            'count(count by (revision) (dspace_build_info{environment="staging"})) > 1',
+            "DSPACE replicas expose mixed build revisions",
+            "Allow a settling rollout briefly; otherwise stop and reconcile every replica.",
+        ),
+        alert(
+            "DspaceDeploymentImagePinMismatch",
+            f'(max by (deployment, image) (kube_deployment_container_info{{namespace="dspace",deployment="dspace",container="dspace",image!="ghcr.io/democratizedspace/dspace:{tag}@{digest}"}})) or ({unknown} unless on() kube_deployment_container_info{{namespace="dspace",deployment="dspace",container="dspace"}})',
+            "DSPACE Deployment image is not the approved immutable pin",
+            "Reconcile the Deployment to the finalized tag and digest; never use a semantic tag.",
+            "unknown",
+        ),
+        alert(
+            "DspaceChatSyntheticFailed",
+            f'(dspace_chat_synthetic_success{{application="dspace",environment="staging"}} == 0) or (time() - dspace_chat_synthetic_last_run_timestamp_seconds{{application="dspace",environment="staging"}} > 900) or ({unknown} unless on() dspace_chat_synthetic_last_run_timestamp_seconds{{application="dspace",environment="staging"}})',
+            "DSPACE non-mutating /chat synthetic failed, is stale, or is missing",
+            "Inspect freshness first, then the pinned smoke-runner result and provider configuration.",
+        ),
+        alert(
+            "DspaceMetricsTargetDown",
+            f'(max by (job) (up{{namespace="dspace",service=~"dspace.*"}}) == 0) or ({unknown} unless on() up{{namespace="dspace",service=~"dspace.*"}})',
+            "DSPACE metrics target is down or missing",
+            "Separate scrape/authentication failure from application health before changing DSPACE.",
+            "unknown",
+        ),
+    ]
+    return {
+        "additionalPrometheusRulesMap": {
+            "dspace-release-integrity": {
+                "groups": [
+                    {
+                        "name": "sugarkube.dspace-release-integrity",
+                        "interval": "30s",
+                        "rules": rules,
+                    }
+                ]
+            }
+        }
+    }
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("evidence", type=Path)
+    p.add_argument("output", type=Path)
+    p.add_argument("--rules-output", type=Path)
+    a = p.parse_args()
+    data = generate(json.loads(a.evidence.read_text()))
+    a.output.write_text(json.dumps(data, indent=2) + "\n")
+    if a.rules_output:
+        a.rules_output.write_text(
+            json.dumps(
+                {
+                    "groups": data["additionalPrometheusRulesMap"]["dspace-release-integrity"][
+                        "groups"
+                    ]
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -8,6 +8,7 @@ CHART="prometheus-community/kube-prometheus-stack"
 VERSION_FILE="${ROOT}/platform/observability/helm/kube-prometheus-stack.version"
 COMMON_VALUES="${ROOT}/platform/observability/helm/kube-prometheus-stack.values.common.yaml"
 STAGING_VALUES="${ROOT}/clusters/staging/observability/kube-prometheus-stack.values.yaml"
+DSPACE_RULES_VALUES="${ROOT}/clusters/staging/observability/rules/dspace-release-integrity.values.json"
 DASHBOARD="${ROOT}/clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
 DASHBOARD_VALUE="grafana.dashboards.sugarkube.sugarkube-staging-observability.json"
 DASHBOARD_VALIDATOR="${ROOT}/scripts/validate_observability_dashboard.py"
@@ -43,6 +44,7 @@ pinned version: $(cat "${VERSION_FILE}")
 ordered values files:
   - ${COMMON_VALUES}
   - ${STAGING_VALUES}
+  - ${DSPACE_RULES_VALUES}
 dashboard source (--set-file): ${DASHBOARD}
 Grafana LAN URL: ${GRAFANA_URL} (same NodePort is available through the other staging nodes)
 EOT
@@ -64,7 +66,7 @@ render_to() {
   local out="$1"
   helm repo add prometheus-community https://prometheus-community.github.io/helm-charts --force-update >/dev/null
   helm repo update prometheus-community >/dev/null
-  helm template "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" >"${out}"
+  helm template "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" -f "${DSPACE_RULES_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" >"${out}"
   validate_rendered_dashboard "${out}"
   validate_rendered_alertmanager "${out}"
 }
@@ -111,8 +113,8 @@ release_state() {
   fi
 }
 render() { validate_dashboard; require_tools helm python3 ruby; print_resolved staging '<not queried: offline render>'; tmp="$(mktemp -t sugarkube-observability-render.XXXXXX.yaml)"; trap 'rm -f "${tmp}"' EXIT; render_to "${tmp}"; cat "${tmp}"; }
-install_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; assert_integration_secrets; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
-upgrade_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; assert_integration_secrets; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
+install_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; assert_integration_secrets; tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" -f "${DSPACE_RULES_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
+upgrade_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved staging; assert_context; assert_integration_secrets; tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}"' EXIT; render_to "${tmp}"; state="$(release_state)"; if [[ "${state}" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${STAGING_VALUES}" -f "${DSPACE_RULES_VALUES}" --set-file "${DASHBOARD_VALUE}=${DASHBOARD}" --wait --timeout "${TIMEOUT}"; }
 WATCHDOG_TTY="${SUGARKUBE_WATCHDOG_TTY:-/dev/tty}"
 WATCHDOG_API="/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-alertmanager:9093/proxy/api/v2"
 

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -25,6 +25,10 @@ REQUIRED_METRICS = {
     "probe_duration_seconds",
     "probe_http_status_code",
     "probe_ssl_earliest_cert_expiry",
+    "dspace_release_approved_info",
+    "dspace_deployment_image_pin_matches",
+    "dspace_chat_synthetic_success",
+    "dspace_chat_synthetic_last_run_timestamp_seconds",
 }
 EVENT_METRICS = {"dspace_dchat_requests_total", "dspace_dependency_requests_total"}
 OPERATIONAL_ROUTES = '"/(healthz|livez|metrics)"'
@@ -211,8 +215,13 @@ def validate_dashboard(path: Path) -> str:
         if not matching or any("or on() vector(0)" not in expr for expr in matching):
             raise SystemExit(f"ERROR: event-driven metric {metric} must use a safe zero fallback.")
     serialized = json.dumps(dashboard)
-    if re.search(r"https?://", serialized, re.IGNORECASE):
-        raise SystemExit("ERROR: dashboard must not contain embedded raw URLs.")
+    urls = set(re.findall(r'https?://[^)\" ]+', serialized, re.IGNORECASE))
+    allowed_urls = {
+        "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md",
+        "https://github.com/futuroptimist/sugarkube/blob/main/deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json",
+    }
+    if urls != allowed_urls:
+        raise SystemExit("ERROR: dashboard links must be the exact reviewed runbook and evidence URLs.")
     if re.search(r"\$\{?DS_|__inputs", serialized, re.IGNORECASE) or re.search(
         r"(?:\{|,)\s*target\s*(?:=|=~|!~|!=)|{{\s*target\s*}}", expression_text
     ):

--- a/scripts/verify_observability_alertmanager.rb
+++ b/scripts/verify_observability_alertmanager.rb
@@ -10,7 +10,7 @@ PD_RECEIVER = "pagerduty-synthetic-test"
 HC_RECEIVER = "healthchecks-watchdog"
 PD_PATH = "/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key"
 HC_PATH = "/etc/alertmanager/secrets/alertmanager-healthchecks-watchdog/ping-url"
-PD_MATCHERS = ['alertname="SugarkubePagerDutyTest"', 'environment="staging"',
+PD_MATCHERS = ['alertname=~"^(SugarkubePagerDutyTest|DspaceBuildRevisionMismatch|DspaceMixedBuildRevisions|DspaceDeploymentImagePinMismatch|DspaceChatSyntheticFailed|DspaceMetricsTargetDown)$"', 'environment="staging"',
                'cluster="sugarkube-int"', 'severity="critical"'].freeze
 HC_MATCHERS = ['alertname="SugarkubeObservabilityWatchdog"', 'environment="staging"',
                'cluster="sugarkube-int"', 'purpose="observability-watchdog"'].freeze
@@ -89,7 +89,7 @@ fail_closed("Healthchecks webhook must use the exact file, resolution, timeout, 
 
 pd_route, hc_route = children
 fail_closed("PagerDuty route ordering or receiver changed") unless pd_route["receiver"] == PD_RECEIVER
-fail_closed("PagerDuty route matchers are not the exact synthetic allowlist") unless pd_route["matchers"].is_a?(Array) && pd_route["matchers"].sort == PD_MATCHERS.sort
+fail_closed("PagerDuty route matchers are not the exact DSPACE and synthetic allowlist") unless pd_route["matchers"].is_a?(Array) && pd_route["matchers"].sort == PD_MATCHERS.sort
 fail_closed("PagerDuty route must contain only receiver and exact matchers") unless pd_route.keys.sort == %w[matchers receiver]
 expected_hc = {
   "receiver" => HC_RECEIVER, "matchers" => HC_MATCHERS,

--- a/tests/test_dspace_observability.py
+++ b/tests/test_dspace_observability.py
@@ -1,0 +1,123 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+EVIDENCE = ROOT / "deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json"
+VALUES = ROOT / "clusters/staging/observability/rules/dspace-release-integrity.values.json"
+PRODUCER = ROOT / "scripts/dspace_chat_synthetic_metrics.py"
+spec = importlib.util.spec_from_file_location(
+    "generator", ROOT / "scripts/generate_dspace_observability_rules.py"
+)
+gen = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gen)
+
+
+def rules():
+    return json.loads(VALUES.read_text())["additionalPrometheusRulesMap"][
+        "dspace-release-integrity"
+    ]["groups"][0]["rules"]
+
+
+def test_generated_contract_matches_finalized_evidence_and_exact_alerts():
+    evidence = json.loads(EVIDENCE.read_text())
+    assert gen.generate(evidence) == json.loads(VALUES.read_text())
+    alerts = {r["alert"]: r for r in rules() if "alert" in r}
+    assert set(alerts) == {
+        "DspaceBuildRevisionMismatch",
+        "DspaceMixedBuildRevisions",
+        "DspaceDeploymentImagePinMismatch",
+        "DspaceChatSyntheticFailed",
+        "DspaceMetricsTargetDown",
+    }
+    for rule in alerts.values():
+        assert rule["labels"] == {
+            "application": "dspace",
+            "environment": "staging",
+            "cluster": "sugarkube-int",
+            "severity": "critical",
+            "expected_revision": evidence["sourceRevision"],
+        }
+        assert set(rule["annotations"]) == {
+            "summary",
+            "current_revision",
+            "expected_revision",
+            "remediation",
+            "runbook_url",
+        }
+        assert rule["annotations"]["expected_revision"] == evidence["sourceRevision"]
+    text = VALUES.read_text()
+    assert evidence["semanticTag"] not in text
+    assert "prompt" not in text and "request_id" not in text
+    assert evidence["imageTag"] in text and evidence["imageDigest"] in text
+
+
+def test_generator_rejects_nonfinal_and_semantic_identity():
+    evidence = json.loads(EVIDENCE.read_text())
+    evidence["recordType"] = "candidate"
+    with pytest.raises(ValueError):
+        gen.generate(evidence)
+
+
+def run_producer(tmp_path, data, sha="a" * 40):
+    result = tmp_path / "result.json"
+    result.write_text(json.dumps(data))
+    out = tmp_path / "metric.prom"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(PRODUCER),
+            "--result",
+            str(result),
+            "--output",
+            str(out),
+            "--runner-revision",
+            sha,
+            "--now",
+            "2000",
+        ],
+        text=True,
+        capture_output=True,
+    )
+    return proc, out
+
+
+def test_synthetic_contract_distinguishes_executed_failure_and_is_bounded(tmp_path):
+    data = {
+        "schemaVersion": 1,
+        "journey": "/chat",
+        "passed": False,
+        "mutationDisabled": True,
+        "transport": "intercepted",
+        "completedAt": 1900,
+    }
+    proc, out = run_producer(tmp_path, data)
+    assert proc.returncode == 0
+    text = out.read_text()
+    assert "success{" in text and "} 0" in text and "timestamp_seconds{" in text
+    assert set(part.split("=")[0] for part in text.split("{")[1].split("}")[0].split(",")) == {
+        "application",
+        "environment",
+        "cluster",
+        "runner_revision",
+    }
+
+
+@pytest.mark.parametrize("change", [("mutationDisabled", False), ("transport", "network")])
+def test_synthetic_contract_fails_closed_without_credentials(tmp_path, change):
+    data = {
+        "schemaVersion": 1,
+        "journey": "/chat",
+        "passed": True,
+        "mutationDisabled": True,
+        "transport": "intercepted",
+        "completedAt": 1900,
+    }
+    data[change[0]] = change[1]
+    proc, out = run_producer(tmp_path, data)
+    assert proc.returncode != 0 and not out.exists()
+    assert "secret" not in proc.stderr

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -54,6 +54,7 @@ def test_dashboard_identity_defaults_rows_and_required_panels(dashboard):
         "DSPACE runtime and release",
         "DSPACE feature traffic",
         "Blackbox monitoring",
+        "DSPACE release integrity",
     }
     titles = {panel["title"] for panel in panels}
     for title in (
@@ -85,7 +86,10 @@ def test_queries_use_stable_datasource_bounded_labels_and_safe_zero(dashboard):
     assert '"uid": "prometheus"' in serialized
     assert "${DS_" not in serialized and "__inputs" not in serialized
     assert not any("{{target}}" in serialized or "target=~" in expr for expr in expressions)
-    assert "http://" not in serialized and "https://" not in serialized
+    assert "http://" not in serialized
+    assert "https://example" not in serialized
+    assert "observability-dspace-release-integrity.md" in serialized
+    assert "main-018687f-20260805T035722Z.json" in serialized
     assert all(
         "or on() vector(0)" in expr
         for expr in expressions
@@ -359,7 +363,7 @@ def test_validator_rejects_wrong_dashboard_mount(tmp_path, dashboard, mount_path
             ),
             "must use a safe zero fallback",
         ),
-        (lambda item: item.update(links=[{"url": "https://example.invalid"}]), "raw URLs"),
+        (lambda item: item.update(links=[{"url": "https://example.invalid"}]), "dashboard links"),
         (lambda item: item.update(description="${DS_PROMETHEUS}"), "datasource placeholder"),
         (lambda item: item.update(datasource={"uid": "unexpected"}), "datasource references"),
         (

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -85,7 +85,7 @@ def test_chart_version_and_values_match_live_staging_baseline():
     assert route["routes"][0] == {
         "receiver": "pagerduty-synthetic-test",
         "matchers": [
-            'alertname="SugarkubePagerDutyTest"',
+            'alertname=~"^(SugarkubePagerDutyTest|DspaceBuildRevisionMismatch|DspaceMixedBuildRevisions|DspaceDeploymentImagePinMismatch|DspaceChatSyntheticFailed|DspaceMetricsTargetDown)$"',
             'environment="staging"',
             'cluster="sugarkube-int"',
             'severity="critical"',
@@ -151,7 +151,7 @@ def rendered_alertmanager_fixture(
 ):
     path = path or "/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key"
     matchers = matchers or [
-        'alertname="SugarkubePagerDutyTest"',
+        'alertname=~"^(SugarkubePagerDutyTest|DspaceBuildRevisionMismatch|DspaceMixedBuildRevisions|DspaceDeploymentImagePinMismatch|DspaceChatSyntheticFailed|DspaceMetricsTargetDown)$"',
         'environment="staging"',
         'cluster="sugarkube-int"',
         'severity="critical"',
@@ -209,7 +209,7 @@ stringData:
     [
         ({"secret": "wrong-secret"}, "exactly the two expected"),
         ({"path": "/wrong/path"}, "PagerDuty configuration is malformed"),
-        ({"matchers": ['severity="critical"']}, "exact synthetic allowlist"),
+        ({"matchers": ['severity="critical"']}, "exact DSPACE and synthetic allowlist"),
         ({"inline": True}, "inline credentials or webhook URLs are forbidden"),
     ],
 )
@@ -846,7 +846,7 @@ printf '%s' "$code"
   routes:
     - receiver: pagerduty-synthetic-test
       matchers:
-        - alertname="SugarkubePagerDutyTest"
+        - alertname=~"^(SugarkubePagerDutyTest|DspaceBuildRevisionMismatch|DspaceMixedBuildRevisions|DspaceDeploymentImagePinMismatch|DspaceChatSyntheticFailed|DspaceMetricsTargetDown)$"
         - environment="staging"
         - cluster="sugarkube-int"
         - severity="critical"


### PR DESCRIPTION
### Motivation
- Provide bounded Prometheus signals and actionable PagerDuty routing for DSPACE release-coordinate drift, mixed revisions, deployment-image drift, `/chat` synthetic failures, and metrics-target loss while keeping staging-only semantics. 
- Derive the expected immutable coordinates from finalized evidence rather than hand-maintained constants so alerts are provably aligned with the recorded release evidence. 
- Implement a fail-closed, hermetic producer/consumer contract for a non-mutating `/chat` synthetic that publishes two node-exporter textfile metrics and document safe staging drills and operational prerequisites.

### Description
- Add a generator that produces repository-controlled Prometheus rules/recordings from a finalized evidence file: `scripts/generate_dspace_observability_rules.py` and the generated outputs `clusters/staging/observability/rules/dspace-release-integrity.values.json` and `clusters/staging/observability/rules/dspace-release-integrity.rules.yaml` (records + 5 alerts: `DspaceBuildRevisionMismatch`, `DspaceMixedBuildRevisions`, `DspaceDeploymentImagePinMismatch`, `DspaceChatSyntheticFailed`, `DspaceMetricsTargetDown`).
- Add a hermetic publisher implementing the bounded `/chat` synthetic contract: `scripts/dspace_chat_synthetic_metrics.py` which atomically writes Prometheus textfile output and strictly validates the pinned runner SHA, schema, mutation disabled, intercepted transport, and freshness.
- Wire the generated rules into the staging Helm render path and preserve the existing null receiver and watchdog route: `scripts/observability_helm.sh` now includes the DSPACE rules values; `clusters/staging/observability/kube-prometheus-stack.values.yaml` updates the PagerDuty allowlist to include only the exact reviewed DSPACE alerts plus the synthetic test; `scripts/verify_observability_alertmanager.rb` was extended to validate the exact allowlist and preserve `send_resolved:true` and secret-file contract.
- Extend the Grafana dashboard with a release-integrity section (approved revision, active build revisions by pod, image-pin agreement, metrics-target health, `/chat` synthetic result & freshness, and explicit runbook/evidence links) and update the dashboard validator `scripts/validate_observability_dashboard.py` to require the new signals and exact reviewed links.
- Add an actionable runbook describing diagnosis, remediation, staging-only drills, and the remaining external prerequisite (a security-reviewed, pinned smoke-runner at an explicit full commit SHA): `docs/observability-dspace-release-integrity.md`; update related docs to distinguish repository readiness vs live deployment proof (`docs/observability-alerting.md`, `docs/apps/dspace.md`).
- Add focused hermetic tests `tests/test_dspace_observability.py` that assert: the five exact alert names exist, generator rejects non-final evidence, expected coordinates match finalized evidence, semantic tags and unbounded labels are not used, and the synthetic publisher enforces the contract and fails closed on contract violations; update existing dashboard & helm tests to accept the added dashboard panels and allowlist changes.
- Changes keep the staging-only boundary, preserve the root `null` receiver and watchdog route, reuse the existing secret-file PagerDuty contract, and do not perform any live mutations or contact external services.

### Testing
- Unit and integration tests: `python3 -m pytest -q tests/test_observability_helm.py tests/test_observability_dashboard.py tests/test_dspace_observability.py` — 244 passed (focused suites ran and passed in the environment used for generation).
- Focused runs shown during development (examples):
  - `python3 -m pytest -q tests/test_dspace_observability.py` — 5 passed.
  - `python3 -m pytest -q tests/test_observability_dashboard.py tests/test_observability_helm.py` — focused subsets passed after validator updates.
- Dashboard validator: `python3 scripts/validate_observability_dashboard.py clusters/staging/observability/dashboards/sugarkube-staging-observability.json` — success.
- Prometheus rules syntax: `promtool check rules clusters/staging/observability/rules/dspace-release-integrity.rules.yaml` — reported 7 rules found / OK.
- Docs/link/spell checks: `pyspelling -c .spellcheck.yaml` (passed where available) and `linkchecker --no-warnings README.md docs/` — linkcheck passed (internal links OK).
- Secret/scan and pre-commit: `git diff --check` and `git diff | python3 scripts/scan-secrets.py` were run; the committed patch was scanned and sanitized where necessary; `pre-commit run --all-files` in the full repository surfaced unrelated pre-existing checks and formatting issues which were handled without weakening policy (focused changes were formatted and validated). 

Remaining live operational acceptance steps (manual, out-of-repo):
- Install/rotate the `monitoring/alertmanager-pagerduty` and `monitoring/alertmanager-healthchecks-watchdog` Secrets in staging (the repo preserves file-backed secret contract and does not contain keys). 
- Deploy the staging Helm chart that includes the generated rules (`helm install/upgrade` using the updated values files) from an operator environment with `sugar-staging` kubecontext. 
- Choose, security-review, and install a pinned external DSPACE smoke-runner at a reviewed full commit SHA and schedule it to run the non-mutating `/chat` journey and publish via the provided `scripts/dspace_chat_synthetic_metrics.py` contract. 
- Execute the documented staging drills in `docs/observability-dspace-release-integrity.md` to simulate mismatch, mixed-revisions, forced synthetic failure, confirm PagerDuty delivery/acknowledge/resolve, and then clean up temporary drill resources.

Notes and constraints
- This PR is repository-only: it does not change or contact live Kubernetes, PagerDuty, token.place, or Healthchecks.io services; live verification remains an explicit post-merge manual sequence (listed above). 
- The generator enforces that only a finalized staging evidence record is accepted; the runbook documents that production observability remains unsupported until a follow-up codification step. 
- Commit summary: added generated rules/values, generator and publisher scripts, runbook, dashboard panels, tests, and Helm/validator adjustments; commit message: "Add DSPACE release integrity alerting" (Refs #2329).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73eacb3210832f8ce471da23b7ddf4)