### PR TITLE
Add DSPACE release‑integrity alerts, PagerDuty routing, synthetic publisher, dashboard and runbook (Refs #2329)

### DIFF
--- a/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
+++ b/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
@@ -835,6 +835,202 @@
       }
     },
     {
+      "id": 22,
+      "type": "row",
+      "title": "DSPACE release integrity",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "panels": []
+    },
+    {
+      "id": 23,
+      "type": "stat",
+      "title": "Approved revision",
+      "description": "Finalized evidence: https://github.com/futuroptimist/sugarkube/blob/main/deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "dspace:approved_release_info{environment=~\"$environment\"}",
+          "instant": true,
+          "range": false,
+          "legendFormat": "{{expected_revision}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "id": 24,
+      "type": "table",
+      "title": "Active build revisions by pod",
+      "description": "Runbook: https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 4,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "max by (pod, revision) (dspace_build_info{environment=~\"$environment\"})",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 25,
+      "type": "stat",
+      "title": "Image-pin agreement",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 9,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "count(kube_pod_container_info{environment=~\"$environment\",namespace=\"dspace\",container=\"dspace\",image_id!~\".*sha256:2b95b7fdccdd011553c8d8617e3090ee27323996c532148fdb147cb9fd6e1b6c$\"})",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 26,
+      "type": "stat",
+      "title": "DSPACE metrics-target health",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 14,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "max(up{environment=~\"$environment\",namespace=\"dspace\",service=\"dspace\"})",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 27,
+      "type": "stat",
+      "title": "/chat synthetic result",
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 18,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "dspace_chat_synthetic_success{environment=~\"$environment\"}",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "MISSING"
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 28,
+      "type": "stat",
+      "title": "/chat synthetic freshness",
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 21,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "time() - dspace_chat_synthetic_timestamp_seconds{environment=~\"$environment\"}",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "STALE / MISSING"
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
       "id": 16,
       "type": "row",
       "title": "Blackbox monitoring",
@@ -843,7 +1039,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 55
       }
     },
     {
@@ -859,7 +1055,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 42
+        "y": 56
       },
       "targets": [
         {
@@ -927,7 +1123,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 42
+        "y": 56
       },
       "targets": [
         {
@@ -965,7 +1161,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 51
+        "y": 65
       },
       "targets": [
         {
@@ -1026,7 +1222,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 51
+        "y": 65
       },
       "targets": [
         {

--- a/clusters/staging/observability/kube-prometheus-stack.values.yaml
+++ b/clusters/staging/observability/kube-prometheus-stack.values.yaml
@@ -5,6 +5,130 @@ prometheus:
     externalLabels:
       cluster: sugarkube-int
 additionalPrometheusRulesMap:
+  dspace-release-integrity:
+    groups:
+      - name: dspace-release-integrity
+        interval: 1m
+        rules:
+          # This bounded, generated representation is checked against the finalized
+          # evidence by tests/test_dspace_observability.py. Never use semanticTag here.
+          - record: dspace:approved_release_info
+            expr: vector(1)
+            labels:
+              application: dspace
+              environment: staging
+              cluster: sugarkube-int
+              expected_revision: 018687f5a7f4de45508c6e36eb28afb3e44da24d
+              expected_image_digest: sha256:2b95b7fdccdd011553c8d8617e3090ee27323996c532148fdb147cb9fd6e1b6c
+              evidence: deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json
+          - record: dspace:approved_revision_info
+            expr: label_replace(dspace:approved_release_info, "revision", "$1", "expected_revision", "(.+)")
+          - alert: DspaceBuildRevisionMismatch
+            expr: |
+              (max by (application, environment, cluster, revision, expected_revision) (
+                dspace_build_info{environment="staging"}
+                * on (environment) group_left(application, cluster, expected_revision) dspace:approved_release_info
+              ) unless on (environment, revision) dspace:approved_revision_info)
+              or
+              label_replace(
+                dspace:approved_release_info unless on (environment) dspace_build_info{environment="staging"},
+                "revision", "unknown", "expected_revision", ".+"
+              )
+            for: 10m
+            labels:
+              severity: critical
+              application: dspace
+              environment: staging
+              cluster: sugarkube-int
+            annotations:
+              summary: DSPACE runtime revision differs from the approved release
+              remediation: Verify serving pod identity, then roll back or redeploy the finalized immutable coordinates.
+              current_revision: '{{ $labels.revision }}'
+              expected_revision: '{{ $labels.expected_revision }}'
+              runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md#dspacebuildrevisionmismatch
+          - alert: DspaceMixedBuildRevisions
+            expr: |
+              label_replace(
+                (count by (environment) (count by (environment, revision) (dspace_build_info{environment="staging"})) > 1)
+                * on (environment) group_left(application, cluster, expected_revision) dspace:approved_release_info,
+                "revision", "mixed", "expected_revision", ".+"
+              )
+            for: 10m
+            labels:
+              severity: critical
+              application: dspace
+              environment: staging
+              cluster: sugarkube-int
+            annotations:
+              summary: DSPACE serving replicas report mixed build revisions
+              remediation: Confirm the rollout exceeded its settling window; inspect ReplicaSets and restore one approved revision.
+              current_revision: '{{ $labels.revision }}'
+              expected_revision: '{{ $labels.expected_revision }}'
+              runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md#dspacemixedbuildrevisions
+          - alert: DspaceDeploymentImagePinMismatch
+            expr: |
+              label_replace(
+                max by (environment, pod) (kube_pod_container_info{environment="staging", namespace="dspace", container="dspace", image_id!="docker-pullable://ghcr.io/democratizedspace/dspace@sha256:2b95b7fdccdd011553c8d8617e3090ee27323996c532148fdb147cb9fd6e1b6c"})
+                * on (environment) group_left(application, cluster, expected_revision) dspace:approved_release_info,
+                "revision", "unknown", "expected_revision", ".+"
+              )
+            for: 10m
+            labels:
+              severity: critical
+              application: dspace
+              environment: staging
+              cluster: sugarkube-int
+            annotations:
+              summary: DSPACE active pod image digest differs from the approved pin
+              remediation: Compare the Deployment template and pod imageID with finalized evidence; redeploy the digest pin.
+              current_revision: '{{ $labels.revision }}'
+              expected_revision: '{{ $labels.expected_revision }}'
+              runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md#dspacedeploymentimagepinmismatch
+          - alert: DspaceChatSyntheticFailed
+            expr: |
+              label_replace(
+                (((dspace_chat_synthetic_success{environment="staging"} == 0)
+                  and on (environment) (time() - dspace_chat_synthetic_timestamp_seconds{environment="staging"} <= 900))
+                  * on (environment) group_left(application, cluster, expected_revision) dspace:approved_release_info),
+                "synthetic_state", "executed_failure", "environment", ".+"
+              )
+              or
+              label_replace(
+                (dspace:approved_release_info unless on (environment) dspace_chat_synthetic_timestamp_seconds{environment="staging"})
+                or (dspace:approved_release_info * on (environment) (time() - dspace_chat_synthetic_timestamp_seconds{environment="staging"} > 900)),
+                "synthetic_state", "missing_or_stale", "environment", ".+"
+              )
+            for: 5m
+            labels:
+              severity: critical
+              application: dspace
+              environment: staging
+              cluster: sugarkube-int
+            annotations:
+              summary: DSPACE non-mutating /chat synthetic failed or is stale
+              remediation: Inspect synthetic_state, freshness, provider health, and configuration without supplying user API keys.
+              current_revision: '{{ $labels.revision }}'
+              expected_revision: '{{ $labels.expected_revision }}'
+              runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md#dspacechatsyntheticfailed
+          - alert: DspaceMetricsTargetDown
+            expr: |
+              label_replace(
+                (dspace:approved_release_info unless on (environment) up{environment="staging", namespace="dspace", service="dspace"})
+                or (dspace:approved_release_info * on (environment) (max by (environment) (up{environment="staging", namespace="dspace", service="dspace"}) == 0)),
+                "revision", "unknown", "expected_revision", ".+"
+              )
+            for: 5m
+            labels:
+              severity: critical
+              application: dspace
+              environment: staging
+              cluster: sugarkube-int
+            annotations:
+              summary: Prometheus has no healthy DSPACE metrics target
+              remediation: Check ServiceMonitor discovery, authentication, networking, and /metrics separately from application health.
+              current_revision: '{{ $labels.revision }}'
+              expected_revision: '{{ $labels.expected_revision }}'
+              runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md#dspacemetricstargetdown
   sugarkube-observability-watchdog:
     groups:
       - name: sugarkube-observability-watchdog
@@ -49,9 +173,19 @@ alertmanager:
           group_interval: 1m
           repeat_interval: 5m
           continue: false
+        - receiver: pagerduty-dspace
+          matchers:
+            - alertname=~"^(DspaceBuildRevisionMismatch|DspaceMixedBuildRevisions|DspaceDeploymentImagePinMismatch|DspaceChatSyntheticFailed|DspaceMetricsTargetDown)$"
+            - environment="staging"
+            - cluster="sugarkube-int"
+            - severity="critical"
     receivers:
       - name: "null"
       - name: pagerduty-synthetic-test
+        pagerduty_configs:
+          - routing_key_file: /etc/alertmanager/secrets/alertmanager-pagerduty/routing-key
+            send_resolved: true
+      - name: pagerduty-dspace
         pagerduty_configs:
           - routing_key_file: /etc/alertmanager/secrets/alertmanager-pagerduty/routing-key
             send_resolved: true

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -2,6 +2,11 @@
 
 This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugarkube. The generic `just app-*` recipes are the preferred future path. The `dspace-oci-*` recipes remain compatibility shims and are scheduled for later removal only after the generic flow has been exercised across routine releases.
 
+Release monitoring is defined in the [DSPACE release-integrity alert runbook](../observability-dspace-release-integrity.md).
+Its non-mutating `/chat` publisher consumes this runtime verifier's bounded JSON result; continuous
+execution still requires an externally installed smoke runner pinned by immutable commit and digest,
+isolated/intercepted transport with mutation disabled, and the documented staging scheduler.
+
 ## Production Helm reconciliation for application 3.0.1
 
 This section **prepares but does not execute** the incident reconciliation tracked by

--- a/docs/observability-alerting.md
+++ b/docs/observability-alerting.md
@@ -8,7 +8,7 @@ a human. The secret-file-backed synthetic Alertmanager → PagerDuty path has no
 through fire, phone receipt, acknowledgement, and resolution. The host-heartbeat timers are installed
 on `sugarkube3`, `sugarkube4`, and `sugarkube5`. The watchdog configuration and operator workflows
 are repository-ready, while their Secret installation, deployment, and live delivery proof remain
-post-merge work. Real workload routes remain deferred.
+post-merge work. The exact five-alert DSPACE workload allowlist is repository-ready; live staging deployment and drills remain required.
 
 ## 1. Goals and non-goals
 
@@ -30,7 +30,7 @@ post-merge work. Real workload routes remain deferred.
   after staging drills succeed (see [`docs/observability-design.md`](./observability-design.md) §13).
 - Advanced SLOs, burn-rate alerting, or multi-window error budgets.
 - Exhaustive application-level synthetic checks. The one synthetic check currently in scope
-  (`DspaceChatSyntheticFailed`) is deferred — see [§8](#8-status-and-dependencies).
+  (`DspaceChatSyntheticFailed`) now has a fail-closed producer/consumer contract; the pinned external scheduler remains a prerequisite — see [the runbook](./observability-dspace-release-integrity.md).
 
 ## 2. Chosen target architecture
 
@@ -156,7 +156,7 @@ These are the current alert-design candidates, not proof the rules already exist
 | `PublicEndpointDown` | A blackbox probe's `probe_success` is 0 | Reuses the signal already defined in [`docs/observability-design.md`](./observability-design.md) §6/§11. |
 | `PublicProbeMissing` | An expected blackbox probe target has no recent data at all (distinct from a probe that ran and failed) | Matches the "missing probe data" state already surfaced in the staging dashboard's availability summary panel. |
 | `TLSExpiringSoon` | `probe_ssl_earliest_cert_expiry` crosses a warning/critical threshold | Reuses the signal already defined in [`docs/observability-design.md`](./observability-design.md) §6. |
-| `DspaceChatSyntheticFailed` | A deeper synthetic check exercises DSPACE's dChat path end-to-end | **Explicitly deferred** — see [§8](#8-status-and-dependencies). Not part of the initial rollout. |
+| `DspaceChatSyntheticFailed` | A non-mutating check exercises DSPACE's `/chat` path end-to-end | Repository-ready with stale/missing fail-closed semantics; external pinned runner installation and live staging proof remain. |
 
 ## 6. Rollout and drill plan
 
@@ -222,9 +222,9 @@ it is deployed yet — see the rollout plan above for the actual sequencing.
 
 ## 8. Status and dependencies
 
-- The deeper DSPACE dChat synthetic check (`DspaceChatSyntheticFailed`) is deferred while token.place
-  staging inference depends on work tracked in `futuroptimist/token.place#1549`. This blocks only that
-  one synthetic check, not the rest of the alerting foundation.
+- The DSPACE `/chat` bounded publisher and fail-closed alert consumer are repository-ready. The
+  immutable external smoke runner, scheduler/textfile installation, and live staging proof remain
+  prerequisites; see [the release-integrity runbook](./observability-dspace-release-integrity.md).
 - Shallow public-endpoint blackbox monitoring (`PublicEndpointDown`, `PublicProbeMissing`,
   `TLSExpiringSoon`) is already live in staging today, independently of that dependency — see
   [`docs/observability-blackbox.md`](./observability-blackbox.md).

--- a/docs/observability-dspace-release-integrity.md
+++ b/docs/observability-dspace-release-integrity.md
@@ -1,0 +1,110 @@
+# DSPACE release-integrity alerts
+
+This runbook covers repository support for the five staging DSPACE alerts. The approved staging
+coordinate is read from the finalized [release evidence](../deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json),
+not from the semantic application tag. Production coordinates are tested as a contract only;
+Sugarkube does **not** currently install production observability.
+
+## Shared triage
+
+Open the Grafana **DSPACE release integrity** row and record the expected revision, active revisions,
+image-pin agreement, target health, synthetic result, and freshness. Use `just dspace-release-verify
+env=staging ...` for an authoritative, non-mutating runtime verification. A revision label is always
+the bounded active/approved revision, `mixed`, or `unknown`; request data and raw errors are never
+metrics labels.
+
+## DspaceBuildRevisionMismatch
+
+After the ten-minute settling window, compare `/build-meta.json`, the pod's OCI revision annotation,
+and finalized evidence. A present but different revision is runtime drift; `unknown` means identity
+telemetry is missing. Restore the approved digest with the guarded DSPACE deployment workflow or
+roll back to finalized evidence. Do not “fix” the alert by changing the expected SHA.
+
+## DspaceMixedBuildRevisions
+
+Check Deployment progress and ReplicaSets. Mixed revisions for less than the alert's ten-minute
+`for` period are an ordinary settling rollout. If it fires, identify stuck old replicas and either
+finish the approved rollout or use the documented guarded rollback. Never delete pods merely to
+silence the signal before determining why the controller retained both revisions.
+
+## DspaceDeploymentImagePinMismatch
+
+This compares active pod `imageID` digests with the approved immutable digest. It is distinct from
+runtime identity: a digest mismatch means the Deployment/pod image coordinate drifted; a build
+revision mismatch with the right digest means the artifact reports the wrong runtime identity.
+Inspect the Helm stored values and Deployment template, then redeploy the finalized digest.
+
+## DspaceChatSyntheticFailed
+
+The `synthetic_state` label distinguishes `executed_failure` from `missing_or_stale`. First inspect
+the timestamp: stale telemetry is a scheduler/exporter problem, not evidence that `/chat` executed
+and failed. For an executed failure, verify public HTTP/TLS and then run the pinned smoke runner with
+intercepted/isolated transport and mutation disabled. Separate public route failures from provider
+or configuration failures by comparing the direct build identity and provider reported by
+`dspace_runtime_verifier.py`. Never supply, require, or log user credentials.
+
+### Producer installation and schedule
+
+The repository consumer contract expects two gauges, with only `application`, `environment`, and
+the active full `revision` as labels:
+
+```text
+dspace_chat_synthetic_success{application="dspace",environment="staging",revision="<40-hex>"} 1
+dspace_chat_synthetic_timestamp_seconds{application="dspace",environment="staging",revision="<40-hex>"} <unix-seconds>
+```
+
+An external scheduler is still required. Pin the DSPACE smoke-runner artifact by immutable commit
+and verified digest; cloning a branch or downloading mutable code at runtime is forbidden. Schedule
+it at most every five minutes, invoke `dspace_runtime_verifier.py verify` with its documented named
+`--smoke-runner` contract, isolated/intercepted transport, and mutation disabled, then atomically
+publish the bounded result to the node-exporter textfile directory:
+
+```bash
+python3 scripts/dspace_synthetic_metrics.py \
+  --result /run/dspace-synthetic/runtime-verification.json \
+  --output /var/lib/node_exporter/textfile_collector/dspace-chat-synthetic.prom
+```
+
+The publisher refuses common credential environment variables. Configure Prometheus to collect that
+textfile through the already-managed node exporter, confirm both gauges and their label set in
+Grafana, and stop/remove the scheduler plus its single `.prom` file to roll back. Missing data fails
+closed after 15 minutes. Until the pinned external runner, scheduler, and textfile mount are installed
+and verified in staging, the repository is **ready**, not continuously deployed or operationally
+proven.
+
+## DspaceMetricsTargetDown
+
+This alert covers missing discovery and `up == 0`. Inspect ServiceMonitor selection, bearer-token
+Secret mounting, NetworkPolicy, and `/metrics`. A scrape failure can coexist with a healthy public
+application; compare blackbox/public health before treating it as an application outage. Conversely,
+a healthy scrape does not prove `/chat` works.
+
+## Post-merge staging drills
+
+Run only against context `sugar-staging`. Use a unique owner value and a temporary `PrometheusRule`
+in `monitoring`; do not change the DSPACE release. The safe pattern below makes cleanup select the
+exact name **and** owner, so it cannot remove another drill:
+
+```bash
+export DRILL_ID="dspace-2329-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+test "$(kubectl config current-context)" = sugar-staging
+trap 'kubectl -n monitoring delete prometheusrule "$DRILL_ID" \
+  --field-selector "metadata.name=$DRILL_ID" --ignore-not-found' EXIT
+```
+
+Create bounded temporary rules with labels `drill_owner="$DRILL_ID"`, `environment="staging"`, and
+`cluster="sugarkube-int"`: (1) replace the expected revision only in the temporary mismatch
+expression; (2) use two `label_replace(vector(1), "revision", ...)` series for mixed revisions; and
+(3) set the temporary synthetic-success series to zero with a current timestamp. Give each rule a
+15-minute maximum lifetime annotation and the production-rejecting namespace/context guards above.
+Confirm each exact alert in Prometheus and Alertmanager, then confirm PagerDuty firing and resolved
+notifications. Delete each rule and wait for resolution before the next. Finally run:
+
+```bash
+test -z "$(kubectl -n monitoring get prometheusrule "$DRILL_ID" --ignore-not-found -o name)"
+kubectl -n monitoring get prometheusrules -l "drill_owner=$DRILL_ID" -o name | test "$(wc -l)" -eq 0
+```
+
+Do not silence, edit the installed rules, route unrelated alerts, or target production. Live
+PagerDuty receipt/resolution, all three simulated firings, cleanup, and the external synthetic
+installation remain explicit post-merge acceptance steps.

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -4,6 +4,10 @@ This runbook covers the current live **staging-only** kube-prometheus-stack life
 
 Production observability is intentionally unsupported in this slice because no production live baseline has been proven yet.
 
+For the repository-ready DSPACE release-coordinate, mixed-revision, image-pin, `/chat` synthetic,
+and metrics-target alerts, use the [DSPACE release-integrity runbook](./observability-dspace-release-integrity.md).
+Its exact PagerDuty allowlist retains this staging-only deployment boundary.
+
 ## Canonical sources
 
 - Chart version: `platform/observability/helm/kube-prometheus-stack.version` (`87.19.0`).

--- a/scripts/dspace_synthetic_metrics.py
+++ b/scripts/dspace_synthetic_metrics.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Publish a bounded DSPACE runtime-verifier result for a Prometheus textfile collector."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import tempfile
+import time
+from pathlib import Path
+
+REVISION = re.compile(r"[0-9a-f]{40}")
+FORBIDDEN_ENV = tuple(
+    name + "_" + "KEY" for name in ("OPENAI_API", "TOKEN_PLACE_API", "DSPACE_API")
+)
+
+
+def render(document: object, now: int) -> str:
+    if not isinstance(document, dict) or document.get("schemaVersion") != 1:
+        raise ValueError("runtime verifier result is malformed")
+    environment = document.get("environment")
+    revision = document.get("runtimeSourceRevision")
+    journeys = document.get("journeys")
+    if (
+        environment not in {"staging", "prod"}
+        or not isinstance(revision, str)
+        or not REVISION.fullmatch(revision)
+    ):
+        raise ValueError("runtime verifier identity is malformed")
+    if not isinstance(journeys, list):
+        raise ValueError("runtime verifier journeys are malformed")
+    chat = [item for item in journeys if isinstance(item, dict) and item.get("name") == "/chat"]
+    if len(chat) != 1 or type(chat[0].get("passed")) is not bool:  # noqa: E721
+        raise ValueError("runtime verifier must report exactly one bounded /chat result")
+    labels = f'application="dspace",environment="{environment}",revision="{revision}"'
+    success = 1 if chat[0]["passed"] else 0
+    return (
+        "# HELP dspace_chat_synthetic_success Last non-mutating /chat check result.\n"
+        "# TYPE dspace_chat_synthetic_success gauge\n"
+        f"dspace_chat_synthetic_success{{{labels}}} {success}\n"
+        "# HELP dspace_chat_synthetic_timestamp_seconds Unix time of the last executed check.\n"
+        "# TYPE dspace_chat_synthetic_timestamp_seconds gauge\n"
+        f"dspace_chat_synthetic_timestamp_seconds{{{labels}}} {now}\n"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--result", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--timestamp", type=int, default=None, help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    if any(os.environ.get(name) for name in FORBIDDEN_ENV):
+        parser.error("credential environment variables are refused")
+    document = json.loads(args.result.read_text(encoding="utf-8"))
+    payload = render(document, int(time.time()) if args.timestamp is None else args.timestamp)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{args.output.name}.", dir=args.output.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, args.output)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/export_dspace_prometheus_rules.py
+++ b/scripts/export_dspace_prometheus_rules.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Export the Helm-owned DSPACE rule group as a promtool-compatible rule file."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+source = root / "clusters/staging/observability/kube-prometheus-stack.values.yaml"
+if len(sys.argv) != 2:
+    raise SystemExit(f"usage: {sys.argv[0]} OUTPUT")
+loaded = json.loads(
+    subprocess.run(
+        [
+            "ruby",
+            "-ryaml",
+            "-rjson",
+            "-e",
+            "puts JSON.generate(YAML.safe_load_file(ARGV[0], aliases: true))",
+            str(source),
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout
+)
+groups = loaded["additionalPrometheusRulesMap"]["dspace-release-integrity"]["groups"]
+out = Path(sys.argv[1])
+rendered = subprocess.run(
+    ["ruby", "-ryaml", "-e", "puts YAML.dump({'groups' => JSON.parse(STDIN.read)})"],
+    input=json.dumps(groups),
+    text=True,
+    capture_output=True,
+    check=True,
+    env={**__import__("os").environ, "RUBYOPT": "-rjson"},
+).stdout
+out.write_text(rendered, encoding="utf-8")

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -22,6 +22,10 @@ REQUIRED_METRICS = {
     "dspace_build_info",
     "dspace_dchat_requests_total",
     "dspace_dependency_requests_total",
+    "dspace:approved_release_info",
+    "kube_pod_container_info",
+    "dspace_chat_synthetic_success",
+    "dspace_chat_synthetic_timestamp_seconds",
     "probe_duration_seconds",
     "probe_http_status_code",
     "probe_ssl_earliest_cert_expiry",
@@ -58,6 +62,26 @@ def panel_named(dashboard: dict, title: str) -> dict:
 
 
 def validate_dashboard_semantics(dashboard: dict) -> None:
+    release_panels = {
+        "Approved revision": "dspace:approved_release_info",
+        "Active build revisions by pod": "dspace_build_info",
+        "Image-pin agreement": "kube_pod_container_info",
+        "DSPACE metrics-target health": "up",
+        "/chat synthetic result": "dspace_chat_synthetic_success",
+        "/chat synthetic freshness": "dspace_chat_synthetic_timestamp_seconds",
+    }
+    for title, metric in release_panels.items():
+        panel = panel_named(dashboard, title)
+        if not any(metric in target.get("expr", "") for target in panel.get("targets", [])):
+            raise SystemExit(f"ERROR: {title} must query {metric}.")
+    serialized = json.dumps(dashboard)
+    if (
+        "docs/observability-dspace-release-integrity.md" not in serialized
+        or "deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json" not in serialized
+    ):
+        raise SystemExit(
+            "ERROR: release-integrity dashboard must link the runbook and finalized evidence."
+        )
     variables = {
         variable.get("name"): variable
         for variable in dashboard.get("templating", {}).get("list", [])
@@ -211,7 +235,14 @@ def validate_dashboard(path: Path) -> str:
         if not matching or any("or on() vector(0)" not in expr for expr in matching):
             raise SystemExit(f"ERROR: event-driven metric {metric} must use a safe zero fallback.")
     serialized = json.dumps(dashboard)
-    if re.search(r"https?://", serialized, re.IGNORECASE):
+    allowed_links = (
+        "https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md",
+        "https://github.com/futuroptimist/sugarkube/blob/main/deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json",
+    )
+    scrubbed = serialized
+    for link in allowed_links:
+        scrubbed = scrubbed.replace(link, "")
+    if re.search(r"https?://", scrubbed, re.IGNORECASE):
         raise SystemExit("ERROR: dashboard must not contain embedded raw URLs.")
     if re.search(r"\$\{?DS_|__inputs", serialized, re.IGNORECASE) or re.search(
         r"(?:\{|,)\s*target\s*(?:=|=~|!~|!=)|{{\s*target\s*}}", expression_text

--- a/scripts/verify_observability_alertmanager.rb
+++ b/scripts/verify_observability_alertmanager.rb
@@ -7,11 +7,16 @@ require "yaml"
 PD_SECRET = "alertmanager-pagerduty"
 HC_SECRET = "alertmanager-healthchecks-watchdog"
 PD_RECEIVER = "pagerduty-synthetic-test"
+DSPACE_RECEIVER = "pagerduty-dspace"
 HC_RECEIVER = "healthchecks-watchdog"
 PD_PATH = "/etc/alertmanager/secrets/alertmanager-pagerduty/routing-key"
 HC_PATH = "/etc/alertmanager/secrets/alertmanager-healthchecks-watchdog/ping-url"
 PD_MATCHERS = ['alertname="SugarkubePagerDutyTest"', 'environment="staging"',
                'cluster="sugarkube-int"', 'severity="critical"'].freeze
+DSPACE_MATCHERS = [
+  'alertname=~"^(DspaceBuildRevisionMismatch|DspaceMixedBuildRevisions|DspaceDeploymentImagePinMismatch|DspaceChatSyntheticFailed|DspaceMetricsTargetDown)$"',
+  'environment="staging"', 'cluster="sugarkube-int"', 'severity="critical"'
+].freeze
 HC_MATCHERS = ['alertname="SugarkubeObservabilityWatchdog"', 'environment="staging"',
                'cluster="sugarkube-int"', 'purpose="observability-watchdog"'].freeze
 
@@ -64,19 +69,20 @@ route = config["route"]
 fail_closed('root receiver must remain "null"') unless route.is_a?(Hash) && route["receiver"] == "null"
 fail_closed("root route must contain only its receiver and exact child routes") unless route.keys.sort == %w[receiver routes]
 children = route["routes"]
-fail_closed("root must have exactly the two allowlisted direct-child routes") unless children.is_a?(Array) && children.length == 2
+fail_closed("root must have exactly the three allowlisted direct-child routes") unless children.is_a?(Array) && children.length == 3
 receivers = config["receivers"]
-fail_closed("receiver list must contain exactly null, PagerDuty, and Healthchecks") unless receivers.is_a?(Array) && receivers.length == 3 && receivers.all? { |x| x.is_a?(Hash) }
+fail_closed("receiver list must contain exactly null, two PagerDuty, and Healthchecks") unless receivers.is_a?(Array) && receivers.length == 4 && receivers.all? { |x| x.is_a?(Hash) }
 fail_closed('root "null" receiver is missing or broadened') unless receivers.count { |x| x == { "name" => "null" } } == 1
 
 pd_receivers = receivers.select { |x| x.key?("pagerduty_configs") }
-fail_closed("there must be exactly one PagerDuty receiver") unless pd_receivers.length == 1
-pd = pd_receivers.first
-fail_closed("PagerDuty receiver name changed") unless pd["name"] == PD_RECEIVER
-fail_closed("PagerDuty receiver is malformed") unless pd.keys.sort == %w[name pagerduty_configs]
-pd_configs = pd["pagerduty_configs"]
-fail_closed("there must be exactly one PagerDuty configuration") unless pd_configs.is_a?(Array) && pd_configs.length == 1
-fail_closed("PagerDuty configuration is malformed") unless pd_configs.first == { "routing_key_file" => PD_PATH, "send_resolved" => true }
+fail_closed("there must be exactly two PagerDuty receivers") unless pd_receivers.length == 2
+fail_closed("PagerDuty receiver names changed") unless pd_receivers.map { |x| x["name"] }.sort == [DSPACE_RECEIVER, PD_RECEIVER].sort
+pd_receivers.each do |pd|
+  fail_closed("PagerDuty receiver is malformed") unless pd.keys.sort == %w[name pagerduty_configs]
+  pd_configs = pd["pagerduty_configs"]
+  fail_closed("there must be exactly one PagerDuty configuration per receiver") unless pd_configs.is_a?(Array) && pd_configs.length == 1
+  fail_closed("PagerDuty configuration is malformed") unless pd_configs.first == { "routing_key_file" => PD_PATH, "send_resolved" => true }
+end
 
 webhook_receivers = receivers.select { |x| x.key?("webhook_configs") }
 fail_closed("there must be exactly one webhook receiver") unless webhook_receivers.length == 1
@@ -87,7 +93,10 @@ webhooks = hc["webhook_configs"]
 expected_webhook = { "url_file" => HC_PATH, "send_resolved" => false, "max_alerts" => 1, "timeout" => "10s" }
 fail_closed("Healthchecks webhook must use the exact file, resolution, timeout, and alert limit") unless webhooks == [expected_webhook]
 
-pd_route, hc_route = children
+pd_route, hc_route, dspace_route = children
+fail_closed("DSPACE PagerDuty route ordering or receiver changed") unless dspace_route["receiver"] == DSPACE_RECEIVER
+fail_closed("DSPACE PagerDuty route matchers are not the exact alert allowlist") unless dspace_route["matchers"].is_a?(Array) && dspace_route["matchers"].sort == DSPACE_MATCHERS.sort
+fail_closed("DSPACE PagerDuty route must contain only receiver and exact matchers") unless dspace_route.keys.sort == %w[matchers receiver]
 fail_closed("PagerDuty route ordering or receiver changed") unless pd_route["receiver"] == PD_RECEIVER
 fail_closed("PagerDuty route matchers are not the exact synthetic allowlist") unless pd_route["matchers"].is_a?(Array) && pd_route["matchers"].sort == PD_MATCHERS.sort
 fail_closed("PagerDuty route must contain only receiver and exact matchers") unless pd_route.keys.sort == %w[matchers receiver]
@@ -97,4 +106,4 @@ expected_hc = {
   "group_interval" => "1m", "repeat_interval" => "5m", "continue" => false
 }
 fail_closed("watchdog route is not the exact direct-child allowlist and timing contract") unless hc_route == expected_hc
-warn "Alertmanager two-integration structure verified (credential values not accessed)."
+warn "Alertmanager exact DSPACE/test PagerDuty and watchdog structure verified (credential values not accessed)."

--- a/tests/prometheus/dspace-alerts.rules.yaml
+++ b/tests/prometheus/dspace-alerts.rules.yaml
@@ -1,0 +1,128 @@
+---
+groups:
+- name: dspace-release-integrity
+  interval: 1m
+  rules:
+  - record: dspace:approved_release_info
+    expr: vector(1)
+    labels:
+      application: dspace
+      environment: staging
+      cluster: sugarkube-int
+      expected_revision: '018687f5a7f4de45508c6e36eb28afb3e44da24d'
+      expected_image_digest: sha256:2b95b7fdccdd011553c8d8617e3090ee27323996c532148fdb147cb9fd6e1b6c
+      evidence: deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json
+  - record: dspace:approved_revision_info
+    expr: label_replace(dspace:approved_release_info, "revision", "$1", "expected_revision",
+      "(.+)")
+  - alert: DspaceBuildRevisionMismatch
+    expr: |
+      (max by (application, environment, cluster, revision, expected_revision) (
+        dspace_build_info{environment="staging"}
+        * on (environment) group_left(application, cluster, expected_revision) dspace:approved_release_info
+      ) unless on (environment, revision) dspace:approved_revision_info)
+      or
+      label_replace(
+        dspace:approved_release_info unless on (environment) dspace_build_info{environment="staging"},
+        "revision", "unknown", "expected_revision", ".+"
+      )
+    for: 10m
+    labels:
+      severity: critical
+      application: dspace
+      environment: staging
+      cluster: sugarkube-int
+    annotations:
+      summary: DSPACE runtime revision differs from the approved release
+      remediation: Verify serving pod identity, then roll back or redeploy the finalized
+        immutable coordinates.
+      current_revision: "{{ $labels.revision }}"
+      expected_revision: "{{ $labels.expected_revision }}"
+      runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md#dspacebuildrevisionmismatch
+  - alert: DspaceMixedBuildRevisions
+    expr: |
+      label_replace(
+        (count by (environment) (count by (environment, revision) (dspace_build_info{environment="staging"})) > 1)
+        * on (environment) group_left(application, cluster, expected_revision) dspace:approved_release_info,
+        "revision", "mixed", "expected_revision", ".+"
+      )
+    for: 10m
+    labels:
+      severity: critical
+      application: dspace
+      environment: staging
+      cluster: sugarkube-int
+    annotations:
+      summary: DSPACE serving replicas report mixed build revisions
+      remediation: Confirm the rollout exceeded its settling window; inspect ReplicaSets
+        and restore one approved revision.
+      current_revision: "{{ $labels.revision }}"
+      expected_revision: "{{ $labels.expected_revision }}"
+      runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md#dspacemixedbuildrevisions
+  - alert: DspaceDeploymentImagePinMismatch
+    expr: |
+      label_replace(
+        max by (environment, pod) (kube_pod_container_info{environment="staging", namespace="dspace", container="dspace", image_id!="docker-pullable://ghcr.io/democratizedspace/dspace@sha256:2b95b7fdccdd011553c8d8617e3090ee27323996c532148fdb147cb9fd6e1b6c"})
+        * on (environment) group_left(application, cluster, expected_revision) dspace:approved_release_info,
+        "revision", "unknown", "expected_revision", ".+"
+      )
+    for: 10m
+    labels:
+      severity: critical
+      application: dspace
+      environment: staging
+      cluster: sugarkube-int
+    annotations:
+      summary: DSPACE active pod image digest differs from the approved pin
+      remediation: Compare the Deployment template and pod imageID with finalized
+        evidence; redeploy the digest pin.
+      current_revision: "{{ $labels.revision }}"
+      expected_revision: "{{ $labels.expected_revision }}"
+      runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md#dspacedeploymentimagepinmismatch
+  - alert: DspaceChatSyntheticFailed
+    expr: |
+      label_replace(
+        (((dspace_chat_synthetic_success{environment="staging"} == 0)
+          and on (environment) (time() - dspace_chat_synthetic_timestamp_seconds{environment="staging"} <= 900))
+          * on (environment) group_left(application, cluster, expected_revision) dspace:approved_release_info),
+        "synthetic_state", "executed_failure", "environment", ".+"
+      )
+      or
+      label_replace(
+        (dspace:approved_release_info unless on (environment) dspace_chat_synthetic_timestamp_seconds{environment="staging"})
+        or (dspace:approved_release_info * on (environment) (time() - dspace_chat_synthetic_timestamp_seconds{environment="staging"} > 900)),
+        "synthetic_state", "missing_or_stale", "environment", ".+"
+      )
+    for: 5m
+    labels:
+      severity: critical
+      application: dspace
+      environment: staging
+      cluster: sugarkube-int
+    annotations:
+      summary: DSPACE non-mutating /chat synthetic failed or is stale
+      remediation: Inspect synthetic_state, freshness, provider health, and configuration
+        without supplying user API keys.
+      current_revision: "{{ $labels.revision }}"
+      expected_revision: "{{ $labels.expected_revision }}"
+      runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md#dspacechatsyntheticfailed
+  - alert: DspaceMetricsTargetDown
+    expr: |
+      label_replace(
+        (dspace:approved_release_info unless on (environment) up{environment="staging", namespace="dspace", service="dspace"})
+        or (dspace:approved_release_info * on (environment) (max by (environment) (up{environment="staging", namespace="dspace", service="dspace"}) == 0)),
+        "revision", "unknown", "expected_revision", ".+"
+      )
+    for: 5m
+    labels:
+      severity: critical
+      application: dspace
+      environment: staging
+      cluster: sugarkube-int
+    annotations:
+      summary: Prometheus has no healthy DSPACE metrics target
+      remediation: Check ServiceMonitor discovery, authentication, networking, and
+        /metrics separately from application health.
+      current_revision: "{{ $labels.revision }}"
+      expected_revision: "{{ $labels.expected_revision }}"
+      runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md#dspacemetricstargetdown

--- a/tests/prometheus/dspace-alerts.test.yaml
+++ b/tests/prometheus/dspace-alerts.test.yaml
@@ -1,0 +1,11 @@
+rule_files:
+  - dspace-alerts.rules.yaml
+evaluation_interval: 1m
+tests:
+  - interval: 1m
+    promql_expr_test:
+      - expr: dspace:approved_release_info
+        eval_time: 1m
+        exp_samples:
+          - labels: 'dspace:approved_release_info{application="dspace",cluster="sugarkube-int",environment="staging",evidence="deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json",expected_image_digest="sha256:2b95b7fdccdd011553c8d8617e3090ee27323996c532148fdb147cb9fd6e1b6c",expected_revision="018687f5a7f4de45508c6e36eb28afb3e44da24d"}'
+            value: 1

--- a/tests/test_dspace_observability.py
+++ b/tests/test_dspace_observability.py
@@ -1,0 +1,142 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import dspace_synthetic_metrics
+
+ROOT = Path(__file__).resolve().parents[1]
+VALUES = ROOT / "clusters/staging/observability/kube-prometheus-stack.values.yaml"
+EVIDENCE = ROOT / "deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json"
+PROMTOOL_RULES = ROOT / "tests/prometheus/dspace-alerts.rules.yaml"
+
+
+def yaml_load(path: Path):
+    return json.loads(
+        subprocess.run(
+            [
+                "ruby",
+                "-ryaml",
+                "-rjson",
+                "-e",
+                "puts JSON.generate(YAML.safe_load_file(ARGV[0], aliases: true))",
+                str(path),
+            ],
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout
+    )
+
+
+def rules():
+    return yaml_load(VALUES)["additionalPrometheusRulesMap"]["dspace-release-integrity"]["groups"][
+        0
+    ]["rules"]
+
+
+def test_exact_alert_contract_and_coordinates_come_from_finalized_evidence():
+    alerts = {rule["alert"]: rule for rule in rules() if "alert" in rule}
+    assert set(alerts) == {
+        "DspaceBuildRevisionMismatch",
+        "DspaceMixedBuildRevisions",
+        "DspaceDeploymentImagePinMismatch",
+        "DspaceChatSyntheticFailed",
+        "DspaceMetricsTargetDown",
+    }
+    evidence = json.loads(EVIDENCE.read_text(encoding="utf-8"))
+    approved = next(
+        rule for rule in rules() if rule.get("record") == "dspace:approved_release_info"
+    )
+    assert approved["labels"]["expected_revision"] == evidence["sourceRevision"]
+    assert approved["labels"]["expected_image_digest"] == evidence["imageDigest"]
+    assert approved["labels"]["evidence"] == str(EVIDENCE.relative_to(ROOT))
+    assert evidence["semanticTag"] not in VALUES.read_text(encoding="utf-8")
+    for rule in alerts.values():
+        assert rule["labels"] == {
+            "severity": "critical",
+            "application": "dspace",
+            "environment": "staging",
+            "cluster": "sugarkube-int",
+        }
+        assert set(rule["annotations"]) == {
+            "summary",
+            "remediation",
+            "current_revision",
+            "expected_revision",
+            "runbook_url",
+        }
+        assert rule["annotations"]["runbook_url"].startswith(
+            "https://github.com/futuroptimist/sugarkube/blob/main/docs/"
+        )
+
+
+def test_promtool_rule_copy_is_deterministically_exported(tmp_path):
+    exported = tmp_path / "rules.yaml"
+    subprocess.run(
+        ["python3", str(ROOT / "scripts/export_dspace_prometheus_rules.py"), str(exported)],
+        check=True,
+    )
+    assert exported.read_text(encoding="utf-8") == PROMTOOL_RULES.read_text(encoding="utf-8")
+
+
+def test_promql_covers_mismatch_mixed_missing_failed_stale_and_bounded_labels():
+    text = VALUES.read_text(encoding="utf-8")
+    assert "unless on (environment, revision)" in text  # mismatch and normal agreement
+    assert "count by (environment, revision)" in text  # mixed active revisions only
+    assert 'revision", "unknown"' in text  # bounded missing identity state
+    assert "dspace_chat_synthetic_success" in text and "== 0" in text
+    assert "dspace_chat_synthetic_timestamp_seconds" in text and "> 900" in text
+    assert "unless on (environment) up" in text and "== 0" in text
+    forbidden = ("prompt", "response", "user_id", "session", "request_id", "raw_error")
+    assert not any(value in text.lower() for value in forbidden)
+
+
+def runtime_result(passed=True):
+    return {
+        "schemaVersion": 1,
+        "environment": "staging",
+        "release": "dspace",
+        "namespace": "dspace",
+        "applicationVersion": "3.1.0",
+        "runtimeSourceRevision": "0" * 40,
+        "frontendSourceRevision": "0" * 40,
+        "defaultProvider": "token-place",
+        "journeys": [{"name": "/chat", "passed": passed}],
+    }
+
+
+@pytest.mark.parametrize(("passed", "value"), [(True, " 1\n"), (False, " 0\n")])
+def test_synthetic_publisher_is_bounded_and_distinguishes_execution(passed, value):
+    rendered = dspace_synthetic_metrics.render(runtime_result(passed), 1234)
+    assert value in rendered
+    assert "timestamp_seconds" in rendered and " 1234\n" in rendered
+    assert set(
+        part.split("=")[0] for part in rendered.split("{", 1)[1].split("}", 1)[0].split(",")
+    ) == {"application", "environment", "revision"}
+
+
+def test_synthetic_publisher_refuses_credential_env_and_writes_atomically(tmp_path):
+    result = tmp_path / "result.json"
+    result.write_text(json.dumps(runtime_result()), encoding="utf-8")
+    output = tmp_path / "collector" / "result.prom"
+    env = {**os.environ, "OPENAI" + "_API" + "_KEY": "must-not-be-accepted"}
+    completed = subprocess.run(
+        [
+            "python3",
+            str(ROOT / "scripts/dspace_synthetic_metrics.py"),
+            "--result",
+            str(result),
+            "--output",
+            str(output),
+        ],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+    assert completed.returncode != 0
+    assert "must-not-be-accepted" not in completed.stderr
+    assert not output.exists()

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -53,6 +53,7 @@ def test_dashboard_identity_defaults_rows_and_required_panels(dashboard):
         "DSPACE HTTP",
         "DSPACE runtime and release",
         "DSPACE feature traffic",
+        "DSPACE release integrity",
         "Blackbox monitoring",
     }
     titles = {panel["title"] for panel in panels}
@@ -85,7 +86,8 @@ def test_queries_use_stable_datasource_bounded_labels_and_safe_zero(dashboard):
     assert '"uid": "prometheus"' in serialized
     assert "${DS_" not in serialized and "__inputs" not in serialized
     assert not any("{{target}}" in serialized or "target=~" in expr for expr in expressions)
-    assert "http://" not in serialized and "https://" not in serialized
+    assert "http://" not in serialized
+    assert serialized.count("https://") == 2
     assert all(
         "or on() vector(0)" in expr
         for expr in expressions

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -189,12 +189,22 @@ stringData:
           group_interval: 1m
           repeat_interval: 5m
           continue: false
+        - receiver: pagerduty-dspace
+          matchers:
+            - 'alertname=~"^(DspaceBuildRevisionMismatch|DspaceMixedBuildRevisions|DspaceDeploymentImagePinMismatch|DspaceChatSyntheticFailed|DspaceMetricsTargetDown)$"'
+            - 'environment="staging"'
+            - 'cluster="sugarkube-int"'
+            - 'severity="critical"'
     receivers:
       - name: "null"
       - name: pagerduty-synthetic-test
         pagerduty_configs:
           - routing_key_file: {path}
             send_resolved: true{inline_field}
+      - name: pagerduty-dspace
+        pagerduty_configs:
+          - routing_key_file: {path}
+            send_resolved: true
       - name: healthchecks-watchdog
         webhook_configs:
           - url_file: /etc/alertmanager/secrets/alertmanager-healthchecks-watchdog/ping-url
@@ -861,9 +871,19 @@ printf '%s' "$code"
       group_interval: 1m
       repeat_interval: 5m
       continue: false
+    - receiver: pagerduty-dspace
+      matchers:
+        - alertname=~"^(DspaceBuildRevisionMismatch|DspaceMixedBuildRevisions|DspaceDeploymentImagePinMismatch|DspaceChatSyntheticFailed|DspaceMetricsTargetDown)$"
+        - environment="staging"
+        - cluster="sugarkube-int"
+        - severity="critical"
 receivers:
   - name: "null"
   - name: pagerduty-synthetic-test
+    pagerduty_configs:
+      - routing_key_file: /etc/alertmanager/secrets/alertmanager-pagerduty/routing-key
+        send_resolved: true
+  - name: pagerduty-dspace
     pagerduty_configs:
       - routing_key_file: /etc/alertmanager/secrets/alertmanager-pagerduty/routing-key
         send_resolved: true


### PR DESCRIPTION
### Motivation
- Detect and page the five DSPACE release-integrity failure modes (revision drift, mixed replicas, image-pin drift, `/chat` synthetic failure, and metrics-target loss) with bounded Prometheus signals and actionable operator context. 
- Provide a safe, reviewed PagerDuty allowlist and preserve the existing null root and watchdog delivery contract while keeping staging-only deployment boundaries. 
- Offer a hermetic producer/consumer contract for the non-mutating `/chat` synthetic that refuses credential leakage and makes staged live drills deterministic and removable.

### Description
- Add a Helm-managed Prometheus rule group `dspace-release-integrity` that implements the exact alerts `DspaceBuildRevisionMismatch`, `DspaceMixedBuildRevisions`, `DspaceDeploymentImagePinMismatch`, `DspaceChatSyntheticFailed`, and `DspaceMetricsTargetDown` and derives expected immutable coordinates from the finalized staging evidence file `deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json` (no semantic tag usage). (`clusters/staging/observability/kube-prometheus-stack.values.yaml`)
- Extend Alertmanager routing to preserve the `null` receiver and watchdog route while adding an exact allowlist route and `pagerduty-dspace` receiver that sends `send_resolved: true` and only accepts a file-backed routing key; the validator was extended to enforce the exact contract. (`clusters/staging/observability/kube-prometheus-stack.values.yaml`, `scripts/verify_observability_alertmanager.rb`)
- Implement a bounded, atomic Prometheus textfile publisher `scripts/dspace_synthetic_metrics.py` that consumes a validated runtime-verifier JSON result and writes two gauges (`dspace_chat_synthetic_success` and `dspace_chat_synthetic_timestamp_seconds`) with only `application`, `environment`, and bounded full `revision` labels, and that refuses credential-bearing environment variables. (`scripts/dspace_synthetic_metrics.py`)
- Add `scripts/export_dspace_prometheus_rules.py` to export the Helm-owned rule group into a promtool-compatible file and committed `tests/prometheus/dspace-alerts.rules.yaml` plus `tests/prometheus/dspace-alerts.test.yaml` for promtool unit tests. (`scripts/export_dspace_prometheus_rules.py`, `tests/prometheus/*`)
- Extend the Grafana dashboard and validator to include a DSPACE “release integrity” row showing approved revision, active build revisions by pod, image-pin agreement, metrics-target health, `/chat` synthetic result and freshness, and to require links to the runbook and finalized evidence. (`clusters/staging/observability/dashboards/sugarkube-staging-observability.json`, `scripts/validate_observability_dashboard.py`, `tests/test_observability_dashboard.py`)
- Add a focused runbook `docs/observability-dspace-release-integrity.md` documenting diagnosis, remediation, the producer/consumer contract for the synthetic, required external prerequisites, and safe post-merge staging drill procedures that create uniquely owned temporary rules and clean up only their own resources. (`docs/observability-dspace-release-integrity.md`)
- Add hermetic tests `tests/test_dspace_observability.py` that assert the five alert names exist, the PromQL uses bounded labels and a deterministic approved coordinate from the finalized evidence, the synthetic publisher behavior, and that promtool exports/tests are deterministic. (`tests/test_dspace_observability.py`)
- Preserve the staging-only observability boundary and explicitly document remaining live prerequisites and drills required for full operational proof; this PR uses `Refs #2329` as required.

### Testing
- Ran focused unit and integration-style tests with `pytest`: `python3 -m pytest -q tests/test_observability_helm.py tests/test_observability_dashboard.py tests/test_dspace_observability.py` and all added/affected tests passed (final run: tests passed). 
- Validated dashboard linting: `python3 scripts/validate_observability_dashboard.py clusters/staging/observability/dashboards/sugarkube-staging-observability.json` succeeded. 
- Exported and validated Prometheus rules with `scripts/export_dspace_prometheus_rules.py` and promtool: `python3 scripts/export_dspace_prometheus_rules.py tests/prometheus/dspace-alerts.rules.yaml` then `promtool check rules tests/prometheus/dspace-alerts.rules.yaml` and `promtool test rules tests/prometheus/dspace-alerts.test.yaml` both succeeded. 
- Verified Alertmanager validator and Helm helper checks: `ruby -c scripts/verify_observability_alertmanager.rb` and `bash -n scripts/observability_helm.sh` (syntax checks) passed; the validator was updated to enforce the exact DSPACE allowlist and receiver contract. 
- Ran formatting and static checks: `python3 -m black`/`ruff`/`pre-commit` were executed during the rollout and any necessary formatting was applied; `pre-commit run --all-files` was executed in the environment after installing pre-commit. 
- Not-run / environment notes: `pyspelling -c .spellcheck.yaml` failed in this environment due to a system Aspell dictionary problem (`/usr/lib/aspell/en-common.rws` format) and is environment-specific; `bash scripts/observability_helm.sh render env=staging` was not executed to mutate live clusters because `helm` was unavailable in the offline test environment, and all Helm-related validations were performed hermetically via the repository validators and tests above. 

Remaining live acceptance steps (explicit, not performed by this PR):
- Install the pinned external smoke-runner artifact and its scheduler in staging, mount the node-exporter textfile collector, and verify the pinned runner's immutable commit+digest and isolated/mutation-disabled execution. 
- Deploy the Helm staging observability values (staging only) and confirm Alertmanager has the `pagerduty-dspace` Secret mounted and validated by `scripts/verify_observability_alertmanager.rb`. 
- Execute the documented staging drills that: (1) simulate expected-revision mismatch, (2) simulate mixed revisions, (3) force a synthetic failure, (4) verify PagerDuty receives firing and resolved notifications, and (5) confirm cleanup removes only drill-owned resources; follow the runbook `docs/observability-dspace-release-integrity.md`.

Refs #2329

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73ead77578832f949d24e9e93fcf8b)