### PR TITLE
Normalize named application-metrics arguments (handle app=... in Just invocations)

### DIFF
--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -367,6 +367,18 @@ def normalize_live_env(env: str) -> str:
     return value
 
 
+def normalize_live_app(app: str) -> str:
+    if not isinstance(app, str):
+        fail("application metrics application is unsupported")
+    value = app.strip()
+    if value.startswith("app="):
+        value = value[4:].strip()
+    if not value or "=" in value:
+        fail("application metrics application must be a non-empty Kubernetes name")
+    name(value, "application metrics application")
+    return value
+
+
 def run(args):
     try:
         return subprocess.run(
@@ -398,6 +410,7 @@ def assert_context():
 
 
 def appcfg(app, env):
+    app = normalize_live_app(app)
     env = normalize_live_env(env)
     inv = load_config()
     try:
@@ -673,6 +686,8 @@ def query_required_families(cfg: dict[str, Any], derived_values: dict[str, str])
     return found
 
 def verify(app, env):
+    app = normalize_live_app(app)
+    env = normalize_live_env(env)
     cfg = appcfg(app, env)
     assert_context()
     check_secret(cfg)
@@ -890,16 +905,18 @@ def main(argv=None):
             for app in inv["applications"]:
                 verify(app, env)
             return 0
-        if not a.app:
+        if a.app is None:
             fail("--app is required")
-        cfg = appcfg(a.app, a.env)
+        app = normalize_live_app(a.app)
+        env = normalize_live_env(a.env)
+        cfg = appcfg(app, env)
         assert_context()
         if a.mode == "secret-check":
             check_secret(cfg)
         elif a.mode == "secret-install":
             install_secret(cfg)
         elif a.mode == "verify":
-            verify(a.app, a.env)
+            verify(app, env)
         return 0
     except Error as e:
         print(e, file=sys.stderr)

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -5324,17 +5324,30 @@ def test_dspace_promote_prod_guard_mismatch_fails_before_helm(
     assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
 
 
-def test_observability_app_metrics_recipes_are_declared():
-    text = (REPO_ROOT / "justfile").read_text(encoding="utf-8")
-    assert "observability-app-metrics-secret-install app env='staging'" in text
-    assert "observability_app_metrics.py secret-install --app '{{ app }}' --env '{{ env }}'" in text
-    assert "observability-app-metrics-secret-check app env='staging'" in text
-    assert "observability-app-metrics-verify app env='staging'" in text
-    script = (REPO_ROOT / "scripts/observability_app_metrics.py").read_text(encoding="utf-8")
-    assert "getpass.getpass" in script
-    assert "validate-render" in script
-    assert "credential environment variables are refused" in script
-    assert "Secret contract exists (value was not returned to the verifier)" in script
+@pytest.mark.parametrize(
+    ("recipe", "mode"),
+    [
+        ("observability-app-metrics-secret-install", "secret-install"),
+        ("observability-app-metrics-secret-check", "secret-check"),
+        ("observability-app-metrics-verify", "verify"),
+    ],
+)
+def test_observability_app_metrics_documented_named_just_invocations(
+    ensure_just_available: Path, tmp_path: Path, recipe: str, mode: str
+):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "python.log"
+    _write_executable(bin_dir / "python3", f"#!/bin/sh\nprintf '%s\\n' \"$*\" > {str(log)!r}\n")
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+
+    result = _run_just([recipe, "app=tokenplace", "env=staging"], env)
+
+    assert result.returncode == 0, result.stderr
+    assert log.read_text(encoding="utf-8").strip() == (
+        f"scripts/observability_app_metrics.py {mode} --app app=tokenplace --env env=staging"
+    )
 
 # Focused declarative app-metrics verifier coverage; kept here with the just recipe
 # tests so Phase 1 remains scoped to the generic app operator surface.
@@ -6339,9 +6352,10 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
             "validate_render",
             ("example", "preview", "candidate.yaml", "example-ns", "example-release"),
         ),
-        (["secret-check", "--app", "example"], "check_secret", ("cfg",)),
-        (["secret-install", "--app", "example"], "install_secret", ("cfg",)),
-        (["verify", "--app", "example", "--env", "int"], "verify", ("example", "int")),
+        (["secret-check", "--app", "app=tokenplace", "--env", "env=staging"], "check_secret", ("cfg",)),
+        (["secret-install", "--app", "app=tokenplace", "--env", "env=staging"], "install_secret", ("cfg",)),
+        (["verify", "--app", "app=tokenplace", "--env", "env=staging"], "verify", ("tokenplace", "staging")),
+        (["verify", "--app", "tokenplace", "--env", "staging"], "verify", ("tokenplace", "staging")),
     ],
 )
 def test_observability_app_metrics_main_dispatches_exactly(
@@ -6368,6 +6382,30 @@ def test_observability_app_metrics_main_dispatches_exactly(
 def test_observability_app_metrics_main_requires_app(mode, capsys):
     assert app_metrics.main([mode]) == 2
     assert "--app is required" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("app", ["", "app=", "app=foo=bar", "Uppercase"])
+def test_observability_app_metrics_rejects_malformed_app_before_live_operations(
+    monkeypatch, capsys, app
+):
+    monkeypatch.setattr(
+        app_metrics,
+        "appcfg",
+        lambda *args: pytest.fail("inventory lookup reached"),
+    )
+    monkeypatch.setattr(
+        app_metrics,
+        "assert_context",
+        lambda: pytest.fail("context check reached"),
+    )
+    monkeypatch.setattr(
+        app_metrics,
+        "install_secret",
+        lambda cfg: pytest.fail("credential handling reached"),
+    )
+
+    assert app_metrics.main(["secret-install", "--app", app]) == 2
+    assert "application metrics application" in capsys.readouterr().err
 
 
 def test_observability_app_metrics_main_reports_delegated_error(monkeypatch, capsys):


### PR DESCRIPTION
### Motivation

- The Just recipes forward named-looking values literally (for example `app=tokenplace`), which caused the operator to look up `app=tokenplace/staging` instead of `tokenplace/staging` during live operations.  
- Environment normalization already existed via `normalize_live_env()`, so the normalization boundary for `app=` needed a controlled, symmetric treatment at the Python live-operation boundary.  
- The change must reject malformed/residual-assignment-style app inputs early and preserve positional invocation compatibility such as `tokenplace staging`.

### Description

- Added `normalize_live_app(app: str)` to `scripts/observability_app_metrics.py` to strip one leading `app=` token, validate non-empty and well-formed Kubernetes names, and fail closed on malformed inputs.  
- Applied `normalize_live_app()` consistently at the live-operation dispatch boundary and inside `appcfg()` and `verify()` so inventory lookup, context checks, and verification messages use the normalized `tokenplace/staging` form.  
- Kept positional invocation compatibility intact and preserved credential-redaction and fail-closed behavior.  
- Replaced the prior string-only Justfile assertion with focused regression tests in `tests/test_generic_app_just_recipes.py` that exercise the exact documented `just` invocation shape `app=tokenplace env=staging`, delegation, positional compatibility, and early rejection of malformed assignment-like inputs.

### Testing

- Ran the focused Just/observability tests with `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k observability_app_metrics`, which passed with `146 passed, 255 deselected`.  
- Ran a broader validation set with `python3 -m pytest -q tests/test_generic_app_just_recipes.py tests/test_observability_helm.py tests/test_app_config.py`, which passed with `639 passed`.  
- Ran inventory validation `python3 scripts/observability_app_metrics.py validate` which printed `Application metrics inventory is valid.`.  
- Ran formatting/checks: `just --unstable --fmt --check` succeeded after enabling the unstable flag, `git diff --check` passed, and `git diff | python3 scripts/scan-secrets.py` passed; `pre-commit run --all-files` was not fully green due to pre-existing, unrelated repository-wide hooks and lint findings and did not block this focused change.  

Branch/commit and PR notes: the change is committed on branch `codex/normalize-app-metrics-arguments` as `619e4f54` with the two modified files `scripts/observability_app_metrics.py` and `tests/test_generic_app_just_recipes.py`, and an automated attempt to open a PR could not complete from this environment because GitHub CLI authentication/push access was not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73eeb9ac7c832f9fdf3ac354421502)