### PR TITLE
Normalize application metrics Just arguments

### DIFF
--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -367,6 +367,17 @@ def normalize_live_env(env: str) -> str:
     return value
 
 
+def normalize_application_argument(app: str) -> str:
+    if not isinstance(app, str):
+        fail("application must be a non-empty safe Kubernetes name")
+    value = app.strip()
+    if value.startswith("app="):
+        value = value[4:].strip()
+    if not value or "=" in value or len(value) > 63 or not K8S_NAME.fullmatch(value):
+        fail("application must be a non-empty safe Kubernetes name")
+    return value
+
+
 def run(args):
     try:
         return subprocess.run(
@@ -398,6 +409,7 @@ def assert_context():
 
 
 def appcfg(app, env):
+    app = normalize_application_argument(app)
     env = normalize_live_env(env)
     inv = load_config()
     try:
@@ -673,6 +685,8 @@ def query_required_families(cfg: dict[str, Any], derived_values: dict[str, str])
     return found
 
 def verify(app, env):
+    app = normalize_application_argument(app)
+    env = normalize_live_env(env)
     cfg = appcfg(app, env)
     assert_context()
     check_secret(cfg)
@@ -881,7 +895,8 @@ def main(argv=None):
         if a.mode == "validate-render":
             if not a.app:
                 fail("--app is required")
-            validate_render(a.app, a.env, a.input, a.release_namespace, a.release_name)
+            app = normalize_application_argument(a.app)
+            validate_render(app, a.env, a.input, a.release_namespace, a.release_name)
             print("Rendered application metrics contract is valid.")
             return 0
         if a.mode == "verify-all":
@@ -892,14 +907,16 @@ def main(argv=None):
             return 0
         if not a.app:
             fail("--app is required")
-        cfg = appcfg(a.app, a.env)
+        app = normalize_application_argument(a.app)
+        env = normalize_live_env(a.env)
+        cfg = appcfg(app, env)
         assert_context()
         if a.mode == "secret-check":
             check_secret(cfg)
         elif a.mode == "secret-install":
             install_secret(cfg)
         elif a.mode == "verify":
-            verify(a.app, a.env)
+            verify(app, env)
         return 0
     except Error as e:
         print(e, file=sys.stderr)

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -6195,9 +6195,10 @@ def test_observability_app_metrics_rejects_malformed_app_before_live_operations(
     assert app not in captured.err
 
 
-def test_observability_app_metrics_rejects_empty_application_argument():
+@pytest.mark.parametrize("app", ["", None])
+def test_observability_app_metrics_rejects_empty_application_argument(app):
     with pytest.raises(app_metrics.Error) as excinfo:
-        app_metrics.normalize_application_argument("")
+        app_metrics.normalize_application_argument(app)
     assert str(excinfo.value) == "ERROR: application must be a non-empty safe Kubernetes name"
 
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -5324,17 +5324,60 @@ def test_dspace_promote_prod_guard_mismatch_fails_before_helm(
     assert not helm_log_path.exists() or helm_log_path.read_text(encoding="utf-8") == ""
 
 
-def test_observability_app_metrics_recipes_are_declared():
-    text = (REPO_ROOT / "justfile").read_text(encoding="utf-8")
-    assert "observability-app-metrics-secret-install app env='staging'" in text
-    assert "observability_app_metrics.py secret-install --app '{{ app }}' --env '{{ env }}'" in text
-    assert "observability-app-metrics-secret-check app env='staging'" in text
-    assert "observability-app-metrics-verify app env='staging'" in text
-    script = (REPO_ROOT / "scripts/observability_app_metrics.py").read_text(encoding="utf-8")
-    assert "getpass.getpass" in script
-    assert "validate-render" in script
-    assert "credential environment variables are refused" in script
-    assert "Secret contract exists (value was not returned to the verifier)" in script
+@pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize(
+    ("recipe", "mode"),
+    [
+        ("observability-app-metrics-secret-install", "secret-install"),
+        ("observability-app-metrics-secret-check", "secret-check"),
+        ("observability-app-metrics-verify", "verify"),
+    ],
+)
+def test_observability_app_metrics_named_just_arguments_are_normalized_before_delegation(
+    tmp_path: Path, recipe: str, mode: str
+) -> None:
+    log = tmp_path / "delegation.json"
+    harness = tmp_path / "app_metrics_harness.py"
+    harness.write_text(
+        """import json
+import os
+import sys
+from scripts import observability_app_metrics as subject
+
+calls = []
+subject.assert_context = lambda: calls.append(["context"])
+subject.install_secret = lambda cfg: calls.append(["secret-install", cfg["namespace"]])
+subject.check_secret = lambda cfg: calls.append(["secret-check", cfg["namespace"]])
+subject.verify = lambda app, env: calls.append(["verify", app, env])
+rc = subject.main(sys.argv[2:])
+with open(os.environ["APP_METRICS_DELEGATION_LOG"], "w", encoding="utf-8") as stream:
+    json.dump({"argv": sys.argv[2:], "calls": calls}, stream)
+raise SystemExit(rc)
+""",
+        encoding="utf-8",
+    )
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "python3",
+        f"#!/bin/sh\nexec {sys.executable!r} {str(harness)!r} \"$@\"\n",
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    env["APP_METRICS_DELEGATION_LOG"] = str(log)
+
+    result = _run_just([recipe, "app=tokenplace", "env=staging"], env)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    delegated = json.loads(log.read_text(encoding="utf-8"))
+    assert delegated["argv"] == [mode, "--app", "app=tokenplace", "--env", "env=staging"]
+    expected_operation = (
+        ["verify", "tokenplace", "staging"]
+        if mode == "verify"
+        else [mode, "tokenplace"]
+    )
+    assert delegated["calls"] == [["context"], expected_operation]
 
 # Focused declarative app-metrics verifier coverage; kept here with the just recipe
 # tests so Phase 1 remains scoped to the generic app operator surface.
@@ -6131,6 +6174,45 @@ def test_observability_app_metrics_live_environment_normalization_and_rejection(
     assert app_metrics.normalize_live_env("env=staging") == "staging"
 
 
+@pytest.mark.parametrize("app", ["app=", "app=foo=bar", "app=Bad_Name", "-bad"])
+def test_observability_app_metrics_rejects_malformed_app_before_live_operations(
+    monkeypatch, capsys, app
+):
+    monkeypatch.setattr(
+        app_metrics, "load_config", lambda: pytest.fail("inventory lookup must not run")
+    )
+    monkeypatch.setattr(
+        app_metrics, "assert_context", lambda: pytest.fail("context check must not run")
+    )
+    monkeypatch.setattr(
+        app_metrics, "install_secret", lambda cfg: pytest.fail("credential handling must not run")
+    )
+
+    assert app_metrics.main(["secret-install", f"--app={app}", "--env", "staging"]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.strip() == "ERROR: application must be a non-empty safe Kubernetes name"
+    assert app not in captured.err
+
+
+def test_observability_app_metrics_rejects_empty_application_argument():
+    with pytest.raises(app_metrics.Error) as excinfo:
+        app_metrics.normalize_application_argument("")
+    assert str(excinfo.value) == "ERROR: application must be a non-empty safe Kubernetes name"
+
+
+def test_observability_app_metrics_positional_values_remain_compatible(monkeypatch):
+    calls = []
+    monkeypatch.setattr(app_metrics, "appcfg", lambda app, env: {"namespace": app})
+    monkeypatch.setattr(app_metrics, "assert_context", lambda: calls.append("context"))
+    monkeypatch.setattr(
+        app_metrics, "check_secret", lambda cfg: calls.append((cfg["namespace"], "staging"))
+    )
+
+    assert app_metrics.main(["secret-check", "--app", "tokenplace", "--env", "staging"]) == 0
+    assert calls == ["context", ("tokenplace", "staging")]
+
+
 def test_observability_app_metrics_verify_all_uses_normalized_requested_env(monkeypatch):
     doc = {"schemaVersion": 1, "applications": {"first": {}, "second": {}}}
     called = []
@@ -6341,7 +6423,7 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
         ),
         (["secret-check", "--app", "example"], "check_secret", ("cfg",)),
         (["secret-install", "--app", "example"], "install_secret", ("cfg",)),
-        (["verify", "--app", "example", "--env", "int"], "verify", ("example", "int")),
+        (["verify", "--app", "example", "--env", "int"], "verify", ("example", "staging")),
     ],
 )
 def test_observability_app_metrics_main_dispatches_exactly(


### PR DESCRIPTION
Refs #2405

## Summary

- Add a controlled application-argument normalization boundary in `scripts/observability_app_metrics.py`.
- Normalize `app=tokenplace` to `tokenplace` before inventory lookup, context validation, credential handling, and verification output.
- Preserve positional application values such as `tokenplace staging`.
- Replace string-only recipe assertions with executable, cluster-free regression coverage for all three documented application-metrics recipes.
- Keep the change limited to the Python helper and focused tests; no inventory, chart, Secret, staging, dashboard, alert, or deployment behavior changes.

## Root cause

The Just recipes correctly preserved their documented interface but forwarded assignment-shaped arguments literally:

- `--app app=tokenplace`
- `--env env=staging`

The existing environment normalizer handled `env=staging`, but no equivalent application normalizer existed. Inventory lookup therefore attempted the literal key `app=tokenplace/staging` and failed before context validation or credential input.

## Implementation

`normalize_application_argument()` now:

- strips one optional `app=` prefix;
- trims surrounding whitespace;
- accepts valid Kubernetes application names;
- rejects empty, non-string, residual-assignment, oversized, and malformed values;
- emits only controlled, redacted errors.

Normalization is applied at the existing Python operation boundaries:

- `appcfg()` before inventory lookup;
- `verify()` before lookup and displayed results;
- `main()` before dispatching secret installation, secret checking, and verification;
- the `validate-render` entrypoint before its inventory lookup.

The existing `normalize_live_env()` behavior remains unchanged, including `int` → `staging` compatibility.

## Regression coverage

`tests/test_generic_app_just_recipes.py` now verifies:

- the exact documented `app=tokenplace env=staging` Just invocation for:
  - `observability-app-metrics-secret-install`;
  - `observability-app-metrics-secret-check`;
  - `observability-app-metrics-verify`;
- normalized `tokenplace/staging` values reach the configured operation without a real token or Kubernetes cluster;
- positional application values remain compatible;
- malformed and assignment-like values fail before inventory lookup, context checks, or credential handling;
- errors do not echo rejected values;
- both empty-string and defensive non-string inputs exercise the normalization rejection path.

The follow-up coverage commit adds the `None` case to exercise the one production branch previously reported as uncovered by Codecov. It changes tests only.

## Review note

Copilot observed that the existing `verify` dispatch performs inventory and context checks in both `main()` and `verify()`. That redundancy predates this PR and is intentionally unchanged to keep this repair focused on argument normalization. Removing it would be unrelated control-flow refactoring and is not required for correctness.

## Verification

- `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k observability_app_metrics`
  - 148 passed, 255 deselected.
- `python3 -m pytest -q tests/test_generic_app_just_recipes.py tests/test_observability_helm.py tests/test_app_config.py`
  - Passed.
- `python3 scripts/observability_app_metrics.py validate`
  - Printed `Application metrics inventory is valid.`
- `just --unstable --fmt --check`
  - Passed; the installed Just version requires the unstable formatting flag.
- `git diff --check`
  - Passed.
- `git diff --cached | ./scripts/scan-secrets.py`
  - Passed.

The full PR remains limited to:

- `scripts/observability_app_metrics.py`;
- `tests/test_generic_app_just_recipes.py`.

No Kubernetes access, credential creation, staging mutation, or deployment operation was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73eecc8088832f822d78d2fe0e45c4)