### PR TITLE
Fix application metrics controlling-terminal prompt

### DIFF
--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -457,13 +457,18 @@ def install_secret(cfg):
     import getpass
 
     try:
-        tty = open(os.environ.get("SUGARKUBE_APP_METRICS_TTY", "/dev/tty"), "r")
+        tty = open(os.environ.get("SUGARKUBE_APP_METRICS_TTY", "/dev/tty"), "r+")
     except OSError:
         fail("an interactive controlling terminal is required")
-    with tty:
-        if not tty.isatty():
-            fail("an interactive controlling terminal is required")
-        value = getpass.getpass("Enter application metrics bearer token (input hidden): ", stream=tty)
+    try:
+        with tty:
+            if not tty.isatty() or not tty.readable() or not tty.writable():
+                fail("an interactive controlling terminal is required")
+            value = getpass.getpass(
+                "Enter application metrics bearer token (input hidden): ", stream=tty
+            )
+    except (OSError, EOFError):
+        fail("interactive credential prompt failed (details redacted)")
     if not value or "\n" in value or "\0" in value:
         fail("credential is invalid (value redacted)")
     proc1 = subprocess.Popen(

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import os
 import subprocess
@@ -6338,7 +6339,12 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
     monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
     import getpass
 
-    monkeypatch.setattr(getpass, "getpass", lambda prompt, stream: "rotated-value")
+    def fake_getpass(prompt, stream):
+        stream.write(prompt)
+        stream.flush()
+        return "rotated-value"
+
+    monkeypatch.setattr(getpass, "getpass", fake_getpass)
 
     class TtyWrapper:
         def __init__(self, handle):
@@ -6353,11 +6359,29 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
         def isatty(self):
             return True
 
+        def readable(self):
+            return self._handle.readable()
+
+        def writable(self):
+            return self._handle.writable()
+
+        def write(self, value):
+            return self._handle.write(value)
+
+        def flush(self):
+            return self._handle.flush()
+
     real_open = open
+    open_calls = []
+
+    def fake_open(path, mode):
+        open_calls.append((path, mode))
+        return TtyWrapper(real_open(path, mode))
+
     monkeypatch.setattr(
         app_metrics,
         "open",
-        lambda path, mode: TtyWrapper(real_open(path, mode)),
+        fake_open,
         raising=False,
     )
     popen_calls = []
@@ -6383,6 +6407,10 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
 
     app_metrics.install_secret(cfg)
 
+    assert open_calls == [(str(tty), "r+")]
+    assert tty.read_text(encoding="utf-8") == (
+        "Enter application metrics bearer token (input hidden): "
+    )
     assert popen_calls[0][0] == [
         "kubectl",
         "-n",
@@ -6549,6 +6577,12 @@ class _AppMetricsFakeTty:
     def isatty(self):
         return self.is_tty
 
+    def readable(self):
+        return True
+
+    def writable(self):
+        return True
+
 
 @pytest.mark.parametrize("tty_result", [OSError("private tty"), _AppMetricsFakeTty(False)])
 def test_observability_app_metrics_install_secret_rejects_bad_controlling_terminal(
@@ -6570,6 +6604,44 @@ def test_observability_app_metrics_install_secret_rejects_bad_controlling_termin
     combined = capsys.readouterr().out + capsys.readouterr().err + str(excinfo.value)
     assert "controlling terminal is required" in combined
     assert "private tty" not in combined
+
+
+def test_observability_app_metrics_install_secret_prompt_failure_is_redacted(
+    monkeypatch, capsys
+):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "tokenplace"
+    ]["environments"]["staging"]
+    credential = "credential-looking-value"
+    private_path = "/private/controlling-terminal"
+    monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setenv("SUGARKUBE_APP_METRICS_TTY", private_path)
+    monkeypatch.setattr(app_metrics, "open", lambda *args: _AppMetricsFakeTty(), raising=False)
+
+    def failed_getpass(prompt, stream):
+        raise io.UnsupportedOperation(f"cannot write {private_path}: {credential}")
+
+    monkeypatch.setattr("getpass.getpass", failed_getpass)
+    monkeypatch.setattr(
+        app_metrics.subprocess,
+        "Popen",
+        lambda *args, **kwargs: pytest.fail("Secret rendering must not be attempted"),
+    )
+    monkeypatch.setattr(
+        app_metrics.subprocess,
+        "run",
+        lambda *args, **kwargs: pytest.fail("kubectl apply must not be attempted"),
+    )
+
+    with pytest.raises(app_metrics.Error) as excinfo:
+        app_metrics.install_secret(cfg)
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err + str(excinfo.value)
+    assert "interactive credential prompt failed (details redacted)" in combined
+    assert "Traceback" not in combined
+    assert private_path not in combined
+    assert credential not in combined
 
 
 @pytest.mark.parametrize("credential", ["", "credential-looking-value\n", "credential-looking-value\0"])


### PR DESCRIPTION
### Motivation

- The installer opened the configured controlling terminal read-only, but `getpass.getpass(..., stream=tty)` writes its prompt to the supplied stream, causing interactive runs to fail with `io.UnsupportedOperation: not writable` and preventing credential rotation (#2405). 

### Description

- Open the configured controlling terminal in read/write mode (`open(..., "r+")`) and require the handle be an interactive, readable, writable TTY before prompting. 
- Convert terminal-open, prompt-write/read, EOF, and unsupported-I/O failures into the existing controlled redacted application error instead of leaking tracebacks or terminal paths, and do not catch `KeyboardInterrupt`. 
- Preserve rejection of ordinary stdin and credential environment variables, hidden input behavior, Secret rendering through stdin, and kubectl output suppression. 
- Update tests in `tests/test_generic_app_just_recipes.py` to flush a fake `getpass` prompt through the supplied stream and add a failure test that simulates `io.UnsupportedOperation` while asserting no Secret rendering or `kubectl apply` is attempted. 

### Testing

- Ran `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k "observability_app_metrics and (install_secret or controlling_terminal or prompt)"` and observed all relevant tests pass (`11 passed`).
- Ran `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k observability_app_metrics` and `python3 -m pytest -q tests/test_generic_app_just_recipes.py tests/test_observability_helm.py tests/test_app_config.py` with the updated suite passing (`149 passed` and `642 passed` respectively).
- Verified `python3 scripts/observability_app_metrics.py validate`, `just --unstable --fmt --check`, and `python3 -m py_compile scripts/observability_app_metrics.py` all succeeded; `pre-commit run --all-files` is blocked by pre-existing repo-wide lint/YAML issues outside the scoped change and was not modified beyond the two scoped files; `linkchecker --no-warnings README.md docs/` completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a740815f0c8832f81f08f3141ebacd7)