### PR TITLE
Fix application metrics controlling terminal prompt

### DIFF
--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -457,13 +457,18 @@ def install_secret(cfg):
     import getpass
 
     try:
-        tty = open(os.environ.get("SUGARKUBE_APP_METRICS_TTY", "/dev/tty"), "r")
+        tty = open(os.environ.get("SUGARKUBE_APP_METRICS_TTY", "/dev/tty"), "r+")
     except OSError:
         fail("an interactive controlling terminal is required")
-    with tty:
-        if not tty.isatty():
-            fail("an interactive controlling terminal is required")
-        value = getpass.getpass("Enter application metrics bearer token (input hidden): ", stream=tty)
+    try:
+        with tty:
+            if not tty.isatty() or not tty.readable() or not tty.writable():
+                fail("an interactive controlling terminal is required")
+            value = getpass.getpass(
+                "Enter application metrics bearer token (input hidden): ", stream=tty
+            )
+    except (OSError, EOFError):
+        fail("credential prompt failed (details redacted)")
     if not value or "\n" in value or "\0" in value:
         fail("credential is invalid (value redacted)")
     proc1 = subprocess.Popen(

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import os
 import sys
+import termios
 import time
 import urllib.error
 import urllib.parse
@@ -443,6 +444,28 @@ def check_secret(cfg):
     print("Application metrics Secret contract exists (value was not returned to the verifier).")
 
 
+def read_hidden(tty, prompt):
+    """Read a line with echo disabled on the supplied controlling terminal."""
+    fd = tty.fileno()
+    original = termios.tcgetattr(fd)
+    hidden = original.copy()
+    hidden[3] &= ~termios.ECHO
+    try:
+        termios.tcsetattr(fd, termios.TCSAFLUSH, hidden)
+        tty.write(prompt)
+        tty.flush()
+        value = tty.readline()
+        if not value:
+            raise EOFError
+    finally:
+        termios.tcsetattr(fd, termios.TCSAFLUSH, original)
+        tty.write("\n")
+        tty.flush()
+    if value.endswith("\n"):
+        value = value[:-1]
+    return value
+
+
 def install_secret(cfg):
     for bad in (
         "TOKEN",
@@ -454,8 +477,6 @@ def install_secret(cfg):
             fail("credential environment variables are refused")
     if not sys.stdin.isatty():
         fail("ordinary stdin is refused; use an interactive controlling terminal")
-    import getpass
-
     try:
         tty = open(os.environ.get("SUGARKUBE_APP_METRICS_TTY", "/dev/tty"), "r+")
     except OSError:
@@ -464,8 +485,8 @@ def install_secret(cfg):
         with tty:
             if not tty.isatty() or not tty.readable() or not tty.writable():
                 fail("an interactive controlling terminal is required")
-            value = getpass.getpass(
-                "Enter application metrics bearer token (input hidden): ", stream=tty
+            value = read_hidden(
+                tty, "Enter application metrics bearer token (input hidden): "
             )
     except (OSError, EOFError):
         fail("credential prompt failed (details redacted)")

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -9,7 +9,6 @@ import re
 import subprocess
 import os
 import sys
-import termios
 import time
 import urllib.error
 import urllib.parse
@@ -444,28 +443,6 @@ def check_secret(cfg):
     print("Application metrics Secret contract exists (value was not returned to the verifier).")
 
 
-def read_hidden(tty, prompt):
-    """Read a line with echo disabled on the supplied controlling terminal."""
-    fd = tty.fileno()
-    original = termios.tcgetattr(fd)
-    hidden = original.copy()
-    hidden[3] &= ~termios.ECHO
-    try:
-        termios.tcsetattr(fd, termios.TCSAFLUSH, hidden)
-        tty.write(prompt)
-        tty.flush()
-        value = tty.readline()
-        if not value:
-            raise EOFError
-    finally:
-        termios.tcsetattr(fd, termios.TCSAFLUSH, original)
-        tty.write("\n")
-        tty.flush()
-    if value.endswith("\n"):
-        value = value[:-1]
-    return value
-
-
 def install_secret(cfg):
     for bad in (
         "TOKEN",
@@ -477,6 +454,8 @@ def install_secret(cfg):
             fail("credential environment variables are refused")
     if not sys.stdin.isatty():
         fail("ordinary stdin is refused; use an interactive controlling terminal")
+    import getpass
+
     try:
         tty = open(os.environ.get("SUGARKUBE_APP_METRICS_TTY", "/dev/tty"), "r+")
     except OSError:
@@ -485,8 +464,8 @@ def install_secret(cfg):
         with tty:
             if not tty.isatty() or not tty.readable() or not tty.writable():
                 fail("an interactive controlling terminal is required")
-            value = read_hidden(
-                tty, "Enter application metrics bearer token (input hidden): "
+            value = getpass.getpass(
+                "Enter application metrics bearer token (input hidden): ", stream=tty
             )
     except (OSError, EOFError):
         fail("credential prompt failed (details redacted)")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import os
 import subprocess
@@ -6338,7 +6339,12 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
     monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
     import getpass
 
-    monkeypatch.setattr(getpass, "getpass", lambda prompt, stream: "rotated-value")
+    def fake_getpass(prompt, stream):
+        stream.write(prompt)
+        stream.flush()
+        return "rotated-value"
+
+    monkeypatch.setattr(getpass, "getpass", fake_getpass)
 
     class TtyWrapper:
         def __init__(self, handle):
@@ -6353,11 +6359,29 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
         def isatty(self):
             return True
 
+        def readable(self):
+            return self._handle.readable()
+
+        def writable(self):
+            return self._handle.writable()
+
+        def write(self, value):
+            return self._handle.write(value)
+
+        def flush(self):
+            return self._handle.flush()
+
     real_open = open
+    open_calls = []
+
+    def fake_open(path, mode):
+        open_calls.append((path, mode))
+        return TtyWrapper(real_open(path, mode))
+
     monkeypatch.setattr(
         app_metrics,
         "open",
-        lambda path, mode: TtyWrapper(real_open(path, mode)),
+        fake_open,
         raising=False,
     )
     popen_calls = []
@@ -6383,6 +6407,7 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
 
     app_metrics.install_secret(cfg)
 
+    assert open_calls == [(str(tty), "r+")]
     assert popen_calls[0][0] == [
         "kubectl",
         "-n",
@@ -6549,6 +6574,12 @@ class _AppMetricsFakeTty:
     def isatty(self):
         return self.is_tty
 
+    def readable(self):
+        return True
+
+    def writable(self):
+        return True
+
 
 @pytest.mark.parametrize("tty_result", [OSError("private tty"), _AppMetricsFakeTty(False)])
 def test_observability_app_metrics_install_secret_rejects_bad_controlling_terminal(
@@ -6570,6 +6601,53 @@ def test_observability_app_metrics_install_secret_rejects_bad_controlling_termin
     combined = capsys.readouterr().out + capsys.readouterr().err + str(excinfo.value)
     assert "controlling terminal is required" in combined
     assert "private tty" not in combined
+
+
+def test_observability_app_metrics_install_secret_prompt_write_failure_is_redacted(
+    monkeypatch, capsys
+):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "tokenplace"
+    ]["environments"]["staging"]
+    credential = "credential-looking-value"
+    private_tty = "/private/controlling-terminal"
+    monkeypatch.setenv("SUGARKUBE_APP_METRICS_TTY", private_tty)
+    monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
+
+    class PromptWriteFailure(_AppMetricsFakeTty):
+        def write(self, value):
+            raise io.UnsupportedOperation(f"cannot write {private_tty} {credential}")
+
+        def flush(self):
+            raise AssertionError("flush must not follow a failed write")
+
+    def fake_getpass(prompt, stream):
+        stream.write(prompt)
+        stream.flush()
+        return credential
+
+    monkeypatch.setattr(app_metrics, "open", lambda *args: PromptWriteFailure(), raising=False)
+    monkeypatch.setattr("getpass.getpass", fake_getpass)
+    monkeypatch.setattr(
+        app_metrics.subprocess,
+        "Popen",
+        lambda *args, **kwargs: pytest.fail("Secret rendering must not be attempted"),
+    )
+    monkeypatch.setattr(
+        app_metrics.subprocess,
+        "run",
+        lambda *args, **kwargs: pytest.fail("kubectl apply must not be attempted"),
+    )
+
+    with pytest.raises(app_metrics.Error) as excinfo:
+        app_metrics.install_secret(cfg)
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err + str(excinfo.value)
+    assert "credential prompt failed (details redacted)" in combined
+    assert "Traceback" not in combined
+    assert private_tty not in combined
+    assert credential not in combined
 
 
 @pytest.mark.parametrize("credential", ["", "credential-looking-value\n", "credential-looking-value\0"])

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -6337,6 +6337,15 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
     tty.write_text("", encoding="utf-8")
     monkeypatch.setenv("SUGARKUBE_APP_METRICS_TTY", str(tty))
     monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
+    import getpass
+
+    def fake_getpass(prompt, stream):
+        stream.write(prompt)
+        stream.flush()
+        return "rotated-value"
+
+    monkeypatch.setattr(getpass, "getpass", fake_getpass)
+
     class TtyWrapper:
         def __init__(self, handle):
             self._handle = handle
@@ -6356,17 +6365,11 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
         def writable(self):
             return self._handle.writable()
 
-        def fileno(self):
-            return self._handle.fileno()
-
         def write(self, value):
             return self._handle.write(value)
 
         def flush(self):
             return self._handle.flush()
-
-        def readline(self):
-            return "rotated-value\n"
 
     real_open = open
     open_calls = []
@@ -6380,16 +6383,6 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
         "open",
         fake_open,
         raising=False,
-    )
-    terminal_changes = []
-    original_attributes = [0, 0, 0, app_metrics.termios.ECHO]
-    monkeypatch.setattr(
-        app_metrics.termios, "tcgetattr", lambda fd: original_attributes.copy()
-    )
-    monkeypatch.setattr(
-        app_metrics.termios,
-        "tcsetattr",
-        lambda fd, when, attrs: terminal_changes.append((fd, when, attrs.copy())),
     )
     popen_calls = []
 
@@ -6415,8 +6408,6 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
     app_metrics.install_secret(cfg)
 
     assert open_calls == [(str(tty), "r+")]
-    assert terminal_changes[0][2][3] & app_metrics.termios.ECHO == 0
-    assert terminal_changes[-1][2] == original_attributes
     assert popen_calls[0][0] == [
         "kubectl",
         "-n",
@@ -6589,27 +6580,6 @@ class _AppMetricsFakeTty:
     def writable(self):
         return True
 
-    def fileno(self):
-        return 123
-
-    def readline(self):
-        return "credential-looking-value\n"
-
-    def write(self, value):
-        return len(value)
-
-    def flush(self):
-        return None
-
-
-def _mock_app_metrics_termios(monkeypatch):
-    monkeypatch.setattr(
-        app_metrics.termios,
-        "tcgetattr",
-        lambda fd: [0, 0, 0, app_metrics.termios.ECHO],
-    )
-    monkeypatch.setattr(app_metrics.termios, "tcsetattr", lambda *args: None)
-
 
 @pytest.mark.parametrize("tty_result", [OSError("private tty"), _AppMetricsFakeTty(False)])
 def test_observability_app_metrics_install_secret_rejects_bad_controlling_terminal(
@@ -6643,7 +6613,6 @@ def test_observability_app_metrics_install_secret_prompt_write_failure_is_redact
     private_tty = "/private/controlling-terminal"
     monkeypatch.setenv("SUGARKUBE_APP_METRICS_TTY", private_tty)
     monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
-    _mock_app_metrics_termios(monkeypatch)
 
     class PromptWriteFailure(_AppMetricsFakeTty):
         def write(self, value):
@@ -6652,7 +6621,13 @@ def test_observability_app_metrics_install_secret_prompt_write_failure_is_redact
         def flush(self):
             raise AssertionError("flush must not follow a failed write")
 
+    def fake_getpass(prompt, stream):
+        stream.write(prompt)
+        stream.flush()
+        return credential
+
     monkeypatch.setattr(app_metrics, "open", lambda *args: PromptWriteFailure(), raising=False)
+    monkeypatch.setattr("getpass.getpass", fake_getpass)
     monkeypatch.setattr(
         app_metrics.subprocess,
         "Popen",
@@ -6684,10 +6659,7 @@ def test_observability_app_metrics_install_secret_rejects_invalid_hidden_input(
     ]["environments"]["staging"]
     monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(app_metrics, "open", lambda *args: _AppMetricsFakeTty(), raising=False)
-    _mock_app_metrics_termios(monkeypatch)
-    monkeypatch.setattr(
-        _AppMetricsFakeTty, "readline", lambda self: f"{credential}\n"
-    )
+    monkeypatch.setattr("getpass.getpass", lambda *args, **kwargs: credential)
     with pytest.raises(app_metrics.Error) as excinfo:
         app_metrics.install_secret(cfg)
     combined = capsys.readouterr().out + capsys.readouterr().err + str(excinfo.value)
@@ -6706,7 +6678,7 @@ def test_observability_app_metrics_install_secret_subprocess_failures_are_redact
     credential = "credential-looking-value"
     monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(app_metrics, "open", lambda *args: _AppMetricsFakeTty(), raising=False)
-    _mock_app_metrics_termios(monkeypatch)
+    monkeypatch.setattr("getpass.getpass", lambda *args, **kwargs: credential)
 
     class FailedRender:
         returncode = int(failure == "render")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -6337,15 +6337,6 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
     tty.write_text("", encoding="utf-8")
     monkeypatch.setenv("SUGARKUBE_APP_METRICS_TTY", str(tty))
     monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
-    import getpass
-
-    def fake_getpass(prompt, stream):
-        stream.write(prompt)
-        stream.flush()
-        return "rotated-value"
-
-    monkeypatch.setattr(getpass, "getpass", fake_getpass)
-
     class TtyWrapper:
         def __init__(self, handle):
             self._handle = handle
@@ -6365,11 +6356,17 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
         def writable(self):
             return self._handle.writable()
 
+        def fileno(self):
+            return self._handle.fileno()
+
         def write(self, value):
             return self._handle.write(value)
 
         def flush(self):
             return self._handle.flush()
+
+        def readline(self):
+            return "rotated-value\n"
 
     real_open = open
     open_calls = []
@@ -6383,6 +6380,16 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
         "open",
         fake_open,
         raising=False,
+    )
+    terminal_changes = []
+    original_attributes = [0, 0, 0, app_metrics.termios.ECHO]
+    monkeypatch.setattr(
+        app_metrics.termios, "tcgetattr", lambda fd: original_attributes.copy()
+    )
+    monkeypatch.setattr(
+        app_metrics.termios,
+        "tcsetattr",
+        lambda fd, when, attrs: terminal_changes.append((fd, when, attrs.copy())),
     )
     popen_calls = []
 
@@ -6408,6 +6415,8 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
     app_metrics.install_secret(cfg)
 
     assert open_calls == [(str(tty), "r+")]
+    assert terminal_changes[0][2][3] & app_metrics.termios.ECHO == 0
+    assert terminal_changes[-1][2] == original_attributes
     assert popen_calls[0][0] == [
         "kubectl",
         "-n",
@@ -6580,6 +6589,27 @@ class _AppMetricsFakeTty:
     def writable(self):
         return True
 
+    def fileno(self):
+        return 123
+
+    def readline(self):
+        return "credential-looking-value\n"
+
+    def write(self, value):
+        return len(value)
+
+    def flush(self):
+        return None
+
+
+def _mock_app_metrics_termios(monkeypatch):
+    monkeypatch.setattr(
+        app_metrics.termios,
+        "tcgetattr",
+        lambda fd: [0, 0, 0, app_metrics.termios.ECHO],
+    )
+    monkeypatch.setattr(app_metrics.termios, "tcsetattr", lambda *args: None)
+
 
 @pytest.mark.parametrize("tty_result", [OSError("private tty"), _AppMetricsFakeTty(False)])
 def test_observability_app_metrics_install_secret_rejects_bad_controlling_terminal(
@@ -6613,6 +6643,7 @@ def test_observability_app_metrics_install_secret_prompt_write_failure_is_redact
     private_tty = "/private/controlling-terminal"
     monkeypatch.setenv("SUGARKUBE_APP_METRICS_TTY", private_tty)
     monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
+    _mock_app_metrics_termios(monkeypatch)
 
     class PromptWriteFailure(_AppMetricsFakeTty):
         def write(self, value):
@@ -6621,13 +6652,7 @@ def test_observability_app_metrics_install_secret_prompt_write_failure_is_redact
         def flush(self):
             raise AssertionError("flush must not follow a failed write")
 
-    def fake_getpass(prompt, stream):
-        stream.write(prompt)
-        stream.flush()
-        return credential
-
     monkeypatch.setattr(app_metrics, "open", lambda *args: PromptWriteFailure(), raising=False)
-    monkeypatch.setattr("getpass.getpass", fake_getpass)
     monkeypatch.setattr(
         app_metrics.subprocess,
         "Popen",
@@ -6659,7 +6684,10 @@ def test_observability_app_metrics_install_secret_rejects_invalid_hidden_input(
     ]["environments"]["staging"]
     monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(app_metrics, "open", lambda *args: _AppMetricsFakeTty(), raising=False)
-    monkeypatch.setattr("getpass.getpass", lambda *args, **kwargs: credential)
+    _mock_app_metrics_termios(monkeypatch)
+    monkeypatch.setattr(
+        _AppMetricsFakeTty, "readline", lambda self: f"{credential}\n"
+    )
     with pytest.raises(app_metrics.Error) as excinfo:
         app_metrics.install_secret(cfg)
     combined = capsys.readouterr().out + capsys.readouterr().err + str(excinfo.value)
@@ -6678,7 +6706,7 @@ def test_observability_app_metrics_install_secret_subprocess_failures_are_redact
     credential = "credential-looking-value"
     monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(app_metrics, "open", lambda *args: _AppMetricsFakeTty(), raising=False)
-    monkeypatch.setattr("getpass.getpass", lambda *args, **kwargs: credential)
+    _mock_app_metrics_termios(monkeypatch)
 
     class FailedRender:
         returncode = int(failure == "render")


### PR DESCRIPTION
Refs #2405

## Summary

- Fix the application-metrics Secret installer’s hidden prompt by opening its controlling terminal in read/write mode.
- Validate that the handle is an interactive, readable, writable TTY.
- Convert prompt I/O and EOF failures into the existing controlled, redacted error path.
- Keep the change limited to `scripts/observability_app_metrics.py` and focused tests in `tests/test_generic_app_just_recipes.py`.

## Root cause

The installer opened the controlling terminal with mode `"r"`, but `getpass.getpass(..., stream=tty)` writes and flushes its prompt through the supplied stream. On staging, this raised `io.UnsupportedOperation: not writable` before any credential was read or Kubernetes operation began.

## Implementation

- Open the supported `/dev/tty` operator path with mode `"r+"`.
- Require `isatty()`, `readable()`, and `writable()` before prompting.
- Preserve hidden input through Unix `getpass`.
- Convert terminal-open, prompt-write/read, EOF, and unsupported-I/O failures into static redacted application errors.
- Continue allowing `KeyboardInterrupt` to propagate.
- Preserve:
  - rejection of ordinary stdin;
  - rejection of credential environment variables;
  - Secret rendering through the stdin pipe;
  - suppression of kubectl output;
  - clearing the local credential reference after rendering;
  - existing argument normalization and deployment behavior.

The documented invocation remains unchanged:

`just observability-app-metrics-secret-install app=tokenplace env=staging`

## Review disposition

A Codex review correctly noted that Unix `getpass` uses its `stream` argument for prompt output while independently opening `/dev/tty` for credential input.

Repository search confirmed that `SUGARKUBE_APP_METRICS_TTY` appears only in this helper and its focused tests. It is an internal test seam, not documented alternate-PTY operator support. On the supported operator path, the supplied stream and the terminal used by `getpass` are the same `/dev/tty`.

A temporary manual `termios` reader was therefore reverted as out of scope. Alternate-PTY input support, if desired, should be designed separately rather than expanding this focused repair.

## Regression coverage

- The success-path fake `getpass` writes and flushes the prompt through the supplied stream before returning a fake credential.
- The success test asserts that the terminal is opened with mode `"r+"`.
- A prompt-write failure raises `io.UnsupportedOperation` containing fake credential and private-path material, then verifies:
  - the result is a controlled redacted application error;
  - no traceback, credential, or terminal path appears;
  - Secret rendering is not attempted;
  - `kubectl apply` is not attempted.
- Existing invalid-input, subprocess-failure, complete-redaction, argument-normalization, and Secret pipeline tests remain intact.

The tests directly cover terminal mode, prompt write/flush, redacted failure, and fail-closed behavior. They do not directly emulate terminal echo; hidden typed or pasted input remains provided by the retained `getpass` implementation.

## Verification

- `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k 'observability_app_metrics and (install_secret or controlling_terminal or prompt)'`
  - `11 passed, 393 deselected`
- `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k observability_app_metrics`
  - `149 passed, 255 deselected`
- `python3 -m pytest -q tests/test_generic_app_just_recipes.py tests/test_observability_helm.py tests/test_app_config.py`
  - `642 passed`
- `python3 scripts/observability_app_metrics.py validate`
  - Passed; inventory valid.
- `just --unstable --fmt --check`
  - Passed.
- `python3 -m py_compile scripts/observability_app_metrics.py`
  - Passed.
- `git diff --check`
  - Passed.
- `git diff | python3 scripts/scan-secrets.py`
  - Passed.
- Baseline-range whitespace and secret scans passed.
- Baseline diff contains exactly the two scoped files.
- `git status --short`
  - No output; working tree clean.
- `pre-commit`, `pyspelling`, and `linkchecker` were unavailable in the execution environment; no documentation was changed.

No Kubernetes access, real credential entry, Secret creation, Helm mutation, or staging deployment was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7408284960832f997c323069133130)