### PR TITLE
Fix app-metrics controlling-terminal prompt (hidden input on real TTY, redacted failures)

### DIFF
--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -457,13 +457,15 @@ def install_secret(cfg):
     import getpass
 
     try:
-        tty = open(os.environ.get("SUGARKUBE_APP_METRICS_TTY", "/dev/tty"), "r")
-    except OSError:
+        tty = open(os.environ.get("SUGARKUBE_APP_METRICS_TTY", "/dev/tty"), "r+")
+        with tty:
+            if not tty.isatty() or not tty.readable() or not tty.writable():
+                fail("an interactive controlling terminal is required")
+            value = getpass.getpass(
+                "Enter application metrics bearer token (input hidden): ", stream=tty
+            )
+    except (OSError, EOFError):
         fail("an interactive controlling terminal is required")
-    with tty:
-        if not tty.isatty():
-            fail("an interactive controlling terminal is required")
-        value = getpass.getpass("Enter application metrics bearer token (input hidden): ", stream=tty)
     if not value or "\n" in value or "\0" in value:
         fail("credential is invalid (value redacted)")
     proc1 = subprocess.Popen(

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import os
 import subprocess
@@ -6338,7 +6339,12 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
     monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
     import getpass
 
-    monkeypatch.setattr(getpass, "getpass", lambda prompt, stream: "rotated-value")
+    def fake_getpass(prompt, stream):
+        stream.write(prompt)
+        stream.flush()
+        return "rotated-value"
+
+    monkeypatch.setattr(getpass, "getpass", fake_getpass)
 
     class TtyWrapper:
         def __init__(self, handle):
@@ -6353,11 +6359,29 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
         def isatty(self):
             return True
 
+        def readable(self):
+            return self._handle.readable()
+
+        def writable(self):
+            return self._handle.writable()
+
+        def write(self, value):
+            return self._handle.write(value)
+
+        def flush(self):
+            return self._handle.flush()
+
     real_open = open
+    opened = []
+
+    def fake_open(path, mode):
+        opened.append((path, mode))
+        return TtyWrapper(real_open(path, mode))
+
     monkeypatch.setattr(
         app_metrics,
         "open",
-        lambda path, mode: TtyWrapper(real_open(path, mode)),
+        fake_open,
         raising=False,
     )
     popen_calls = []
@@ -6383,6 +6407,8 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
 
     app_metrics.install_secret(cfg)
 
+    assert opened == [(str(tty), "r+")]
+    assert tty.read_text(encoding="utf-8").startswith("Enter application metrics bearer token")
     assert popen_calls[0][0] == [
         "kubectl",
         "-n",
@@ -6549,6 +6575,12 @@ class _AppMetricsFakeTty:
     def isatty(self):
         return self.is_tty
 
+    def readable(self):
+        return True
+
+    def writable(self):
+        return True
+
 
 @pytest.mark.parametrize("tty_result", [OSError("private tty"), _AppMetricsFakeTty(False)])
 def test_observability_app_metrics_install_secret_rejects_bad_controlling_terminal(
@@ -6570,6 +6602,52 @@ def test_observability_app_metrics_install_secret_rejects_bad_controlling_termin
     combined = capsys.readouterr().out + capsys.readouterr().err + str(excinfo.value)
     assert "controlling terminal is required" in combined
     assert "private tty" not in combined
+
+
+def test_observability_app_metrics_install_secret_prompt_output_failure_is_redacted(
+    monkeypatch, capsys
+):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "tokenplace"
+    ]["environments"]["staging"]
+    credential = "credential-looking-value"
+    private_path = "/private/controlling-terminal"
+    monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setenv("SUGARKUBE_APP_METRICS_TTY", private_path)
+
+    class FailedPromptTty(_AppMetricsFakeTty):
+        def write(self, value):
+            raise io.UnsupportedOperation(f"cannot write {private_path} {credential}")
+
+        def flush(self):
+            raise AssertionError("flush must not follow a failed write")
+
+    monkeypatch.setattr(app_metrics, "open", lambda *args: FailedPromptTty(), raising=False)
+
+    def fake_getpass(prompt, stream):
+        stream.write(prompt)
+        stream.flush()
+        return credential
+
+    monkeypatch.setattr("getpass.getpass", fake_getpass)
+    monkeypatch.setattr(
+        app_metrics.subprocess,
+        "Popen",
+        lambda *args, **kwargs: pytest.fail("Secret rendering must not be attempted"),
+    )
+    monkeypatch.setattr(
+        app_metrics.subprocess,
+        "run",
+        lambda *args, **kwargs: pytest.fail("kubectl apply must not be attempted"),
+    )
+
+    with pytest.raises(app_metrics.Error) as excinfo:
+        app_metrics.install_secret(cfg)
+    combined = capsys.readouterr().out + capsys.readouterr().err + str(excinfo.value)
+    assert "controlling terminal is required" in combined
+    assert "Traceback" not in combined
+    assert private_path not in combined
+    assert credential not in combined
 
 
 @pytest.mark.parametrize("credential", ["", "credential-looking-value\n", "credential-looking-value\0"])


### PR DESCRIPTION
### Motivation

- The hidden interactive prompt opened the configured controlling terminal read-only so `getpass` failed when it tried to write/flush the prompt, causing `io.UnsupportedOperation: not writable` before any credential was read or Secret created. 

### Description

- Open the configured controlling terminal in read/write mode (`open(..., "r+")`) and require the handle to be an interactive, readable, writable TTY before prompting. 
- Keep rejecting ordinary stdin and credential environment variables, keep hidden input with `getpass`, and preserve the existing Secret render/`kubectl apply` pathway that writes credentials via stdin so the credential never appears in subprocess args. 
- Turn terminal-open, prompt-write/read, EOF, and unsupported-I/O failures into the existing controlled redacted `Error` (no traceback, no private path shown) without catching `KeyboardInterrupt`. 
- Update tests in `tests/test_generic_app_just_recipes.py` to (a) make the fake `getpass` actually write+flush the prompt through the supplied stream and assert the terminal was opened `r+`, and (b) add a failure test where prompt output raises `io.UnsupportedOperation` and assert the result is a controlled redacted error and that no Secret rendering or `kubectl apply` was attempted.

### Testing

- Ran focused verification: `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k "observability_app_metrics and (install_secret or controlling_terminal or prompt)"` — 11 passed (393 deselected). 
- Ran broader module tests: `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k observability_app_metrics` — 149 passed (255 deselected). 
- Ran combined tests: `python3 -m pytest -q tests/test_generic_app_just_recipes.py tests/test_observability_helm.py tests/test_app_config.py` — 642 passed. 
- Ran validation and repo checks: `python3 scripts/observability_app_metrics.py validate` — inventory valid, `just --unstable --fmt --check` — completed, `python3 -m py_compile scripts/observability_app_metrics.py` — OK, `git diff --check` and `git diff | python3 scripts/scan-secrets.py` — OK. 
- Pre-commit: `pre-commit run --all-files` remains blocked by unrelated, pre-existing repository-wide YAML/flake8 violations; per-scope hooks on the changed files (`trailing-whitespace` and `end-of-file-fixer`) were run and passed for the modified files. 

Residual risks and notes: the change is intentionally minimal and limited to `scripts/observability_app_metrics.py` and focused tests; it preserves the secret-render/apply behavior and redaction contract so credentials are never leaked in logs, subprocess args, or exceptions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74082edae4832f9e1c86818648be4a)