### PR TITLE
Fix application metrics controlling-terminal prompt

### DIFF
--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -457,13 +457,18 @@ def install_secret(cfg):
     import getpass
 
     try:
-        tty = open(os.environ.get("SUGARKUBE_APP_METRICS_TTY", "/dev/tty"), "r")
-    except OSError:
+        tty = open(os.environ.get("SUGARKUBE_APP_METRICS_TTY", "/dev/tty"), "r+")
+    except (OSError, ValueError):
         fail("an interactive controlling terminal is required")
     with tty:
-        if not tty.isatty():
-            fail("an interactive controlling terminal is required")
-        value = getpass.getpass("Enter application metrics bearer token (input hidden): ", stream=tty)
+        try:
+            if not tty.isatty() or not tty.writable():
+                fail("an interactive controlling terminal is required")
+            value = getpass.getpass(
+                "Enter application metrics bearer token (input hidden): ", stream=tty
+            )
+        except (EOFError, OSError, ValueError):
+            fail("interactive credential prompt failed (details redacted)")
     if not value or "\n" in value or "\0" in value:
         fail("credential is invalid (value redacted)")
     proc1 = subprocess.Popen(

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import os
 import subprocess
@@ -6338,7 +6339,12 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
     monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
     import getpass
 
-    monkeypatch.setattr(getpass, "getpass", lambda prompt, stream: "rotated-value")
+    def fake_getpass(prompt, stream):
+        stream.write(prompt)
+        stream.flush()
+        return "rotated-value"
+
+    monkeypatch.setattr(getpass, "getpass", fake_getpass)
 
     class TtyWrapper:
         def __init__(self, handle):
@@ -6353,13 +6359,23 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
         def isatty(self):
             return True
 
+        def writable(self):
+            return self._handle.writable()
+
+        def write(self, value):
+            return self._handle.write(value)
+
+        def flush(self):
+            return self._handle.flush()
+
     real_open = open
-    monkeypatch.setattr(
-        app_metrics,
-        "open",
-        lambda path, mode: TtyWrapper(real_open(path, mode)),
-        raising=False,
-    )
+    open_calls = []
+
+    def fake_open(path, mode):
+        open_calls.append((path, mode))
+        return TtyWrapper(real_open(path, mode))
+
+    monkeypatch.setattr(app_metrics, "open", fake_open, raising=False)
     popen_calls = []
 
     class FakePopen:
@@ -6383,6 +6399,10 @@ def test_observability_app_metrics_install_secret_success_uses_stdin_pipe(
 
     app_metrics.install_secret(cfg)
 
+    assert open_calls == [(str(tty), "r+")]
+    assert tty.read_text(encoding="utf-8") == (
+        "Enter application metrics bearer token (input hidden): "
+    )
     assert popen_calls[0][0] == [
         "kubectl",
         "-n",
@@ -6549,6 +6569,9 @@ class _AppMetricsFakeTty:
     def isatty(self):
         return self.is_tty
 
+    def writable(self):
+        return True
+
 
 @pytest.mark.parametrize("tty_result", [OSError("private tty"), _AppMetricsFakeTty(False)])
 def test_observability_app_metrics_install_secret_rejects_bad_controlling_terminal(
@@ -6570,6 +6593,51 @@ def test_observability_app_metrics_install_secret_rejects_bad_controlling_termin
     combined = capsys.readouterr().out + capsys.readouterr().err + str(excinfo.value)
     assert "controlling terminal is required" in combined
     assert "private tty" not in combined
+
+
+def test_observability_app_metrics_install_secret_prompt_write_failure_is_redacted(
+    monkeypatch, capsys
+):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "tokenplace"
+    ]["environments"]["staging"]
+    credential = "credential-looking-value"
+    private_path = "/private/controlling-terminal"
+    monkeypatch.setenv("SUGARKUBE_APP_METRICS_TTY", private_path)
+    monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
+
+    class PromptWriteFailureTty(_AppMetricsFakeTty):
+        def write(self, value):
+            raise io.UnsupportedOperation(f"not writable: {private_path}: {credential}")
+
+    monkeypatch.setattr(app_metrics, "open", lambda *args: PromptWriteFailureTty(), raising=False)
+
+    def failed_getpass(prompt, stream):
+        stream.write(prompt)
+        stream.flush()
+        return credential
+
+    monkeypatch.setattr("getpass.getpass", failed_getpass)
+    monkeypatch.setattr(
+        app_metrics.subprocess,
+        "Popen",
+        lambda *args, **kwargs: pytest.fail("Secret rendering must not be attempted"),
+    )
+    monkeypatch.setattr(
+        app_metrics.subprocess,
+        "run",
+        lambda *args, **kwargs: pytest.fail("kubectl apply must not be attempted"),
+    )
+
+    with pytest.raises(app_metrics.Error) as excinfo:
+        app_metrics.install_secret(cfg)
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err + str(excinfo.value)
+    assert combined == "ERROR: interactive credential prompt failed (details redacted)"
+    assert "Traceback" not in combined
+    assert private_path not in combined
+    assert credential not in combined
 
 
 @pytest.mark.parametrize("credential", ["", "credential-looking-value\n", "credential-looking-value\0"])


### PR DESCRIPTION
### Motivation

- The installer opened the configured controlling terminal read-only while `getpass` writes its hidden prompt to the supplied `stream`, which caused `io.UnsupportedOperation: not writable` and prevented credential input on a real `/dev/tty` (regression reported in #2405). 
- Prompt I/O failures must fail closed, remain redacted, and must not cause Secret rendering or `kubectl` mutations or leak credential or private path information.

### Description

- Open the configured controlling terminal with read/write mode (`r+`), validate that the handle is an interactive TTY and writable, and use it as the `getpass` prompt `stream`; convert terminal-open and prompt I/O errors into the existing controlled redacted `Error` contract. 
- Catch `EOFError`, `OSError`, and `ValueError` from the prompt and fail with a redacted message (`interactive credential prompt failed (details redacted)`), preserving the repository convention of not catching `KeyboardInterrupt`. 
- Update the success-path test so the fake `getpass` writes and flushes the prompt through the supplied stream and assert the terminal was opened `r+` and that the prompt reached the stream. 
- Add a regression test that simulates a prompt write failure (e.g. `io.UnsupportedOperation`) and asserts the result is a controlled redacted error, contains no traceback, terminal path, or credential, and that no Secret render/apply was attempted; preserved existing refusals of stdin and credential env vars and existing Secret render/apply plumbing.

### Testing

- Ran focused unit tests: `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k 'observability_app_metrics and (install_secret or controlling_terminal or prompt)'`, which passed (11 passed, 393 deselected). 
- Ran broader application-metrics tests: `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k observability_app_metrics`, which passed (149 passed, 255 deselected). 
- Executed additional verification commands: `python3 scripts/observability_app_metrics.py validate` which printed `Application metrics inventory is valid.`, `just --unstable --fmt --check` and `python3 -m py_compile scripts/observability_app_metrics.py` which both succeeded, and `git diff --check` plus secret scans (`git diff | python3 scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py`) which reported no new secret findings. 
- Note: `pre-commit run --all-files` attempted but failed on unrelated, pre-existing repository-wide YAML/flake8 issues and auto-fixed many unrelated files; those out-of-scope automatic fixes were reverted and `pyspelling`/`linkchecker` were not installed in the environment so those checks were not run here.

Fixes: #2405

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74083319c4832fb64c9a1c398a6e0d)