### PR TITLE
Fix app metrics secret TTY fallback

### DIFF
--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -4,10 +4,11 @@
 from __future__ import annotations
 
 import argparse
+import io
 import json
+import os
 import re
 import subprocess
-import os
 import sys
 import time
 import urllib.error
@@ -457,17 +458,22 @@ def install_secret(cfg):
     import getpass
 
     try:
-        tty = open(os.environ.get("SUGARKUBE_APP_METRICS_TTY", "/dev/tty"), "r+")
-    except OSError:
-        fail("an interactive controlling terminal is required")
-    try:
-        with tty:
-            if not tty.isatty() or not tty.readable() or not tty.writable():
-                fail("an interactive controlling terminal is required")
+        try:
+            tty = open(os.environ.get("SUGARKUBE_APP_METRICS_TTY", "/dev/tty"), "r+")
+        except OSError:
+            tty = None
+        if tty is None:
             value = getpass.getpass(
-                "Enter application metrics bearer token (input hidden): ", stream=tty
+                "Enter application metrics bearer token (input hidden): ", stream=sys.stdin
             )
-    except (OSError, EOFError):
+        else:
+            with tty:
+                if not tty.isatty() or not tty.readable() or not tty.writable():
+                    fail("an interactive controlling terminal is required")
+                value = getpass.getpass(
+                    "Enter application metrics bearer token (input hidden): ", stream=tty
+                )
+    except (OSError, EOFError, io.UnsupportedOperation):
         fail("credential prompt failed (details redacted)")
     if not value or "\n" in value or "\0" in value:
         fail("credential is invalid (value redacted)")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -6581,14 +6581,14 @@ class _AppMetricsFakeTty:
         return True
 
 
-@pytest.mark.parametrize("tty_result", [OSError("private tty"), _AppMetricsFakeTty(False)])
 def test_observability_app_metrics_install_secret_rejects_bad_controlling_terminal(
-    monkeypatch, capsys, tty_result
+    monkeypatch, capsys
 ):
     cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
         "tokenplace"
     ]["environments"]["staging"]
     monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
+    tty_result = _AppMetricsFakeTty(False)
 
     def fake_open(*args):
         if isinstance(tty_result, BaseException):
@@ -6601,6 +6601,55 @@ def test_observability_app_metrics_install_secret_rejects_bad_controlling_termin
     combined = capsys.readouterr().out + capsys.readouterr().err + str(excinfo.value)
     assert "controlling terminal is required" in combined
     assert "private tty" not in combined
+
+
+def test_observability_app_metrics_install_secret_falls_back_to_interactive_stdin(
+    monkeypatch, capsys
+):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "tokenplace"
+    ]["environments"]["staging"]
+    credential = "pty-fallback-sentinel"
+    monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(
+        app_metrics,
+        "open",
+        lambda *args: (_ for _ in ()).throw(OSError(f"private tty {credential}")),
+        raising=False,
+    )
+    prompted_streams = []
+    monkeypatch.setattr(
+        "getpass.getpass",
+        lambda prompt, stream: prompted_streams.append(stream) or credential,
+    )
+    commands = []
+
+    class RenderSecret:
+        returncode = 0
+
+        def __init__(self, args, **kwargs):
+            commands.append((args, kwargs))
+
+        def communicate(self, value):
+            assert value == credential.encode()
+            return b"apiVersion: v1\nkind: Secret\n", b""
+
+    monkeypatch.setattr(app_metrics.subprocess, "Popen", RenderSecret)
+    monkeypatch.setattr(
+        app_metrics.subprocess,
+        "run",
+        lambda args, **kwargs: commands.append((args, kwargs))
+        or argparse.Namespace(returncode=0),
+    )
+
+    app_metrics.install_secret(cfg)
+
+    assert prompted_streams == [app_metrics.sys.stdin]
+    assert len(commands) == 2
+    assert commands[1][0] == ["kubectl", "apply", "-f", "-"]
+    captured = capsys.readouterr()
+    assert credential not in captured.out + captured.err
+    assert all(credential not in repr(args) for args, _ in commands)
 
 
 def test_observability_app_metrics_install_secret_prompt_write_failure_is_redacted(


### PR DESCRIPTION
### Motivation
- A production SSH/session where `sys.stdin.isatty() == True` but `/dev/tty` cannot be opened caused `observability-app-metrics-secret-install` to fail with `ERROR: an interactive controlling terminal is required`.\
- The intent is to continue refusing credential env vars and non-interactive stdin while accepting the documented interactive case by falling back to a hidden prompt on the real stdin TTY when reopening `/dev/tty` fails.\
- Prompt failures must remain redacted and Ctrl-C behavior must be preserved, and the bearer token must never be leaked to args, env, files, output, or tracebacks.

### Description
- Change `install_secret()` in `scripts/observability_app_metrics.py` to prefer opening a controlling terminal when available but fall back to calling `getpass.getpass(..., stream=sys.stdin)` when opening `/dev/tty` raises `OSError`.\
- Add `io` to the imports and extend the prompt-exception handler to include `io.UnsupportedOperation` so failed prompt operations are redacted without tracebacks.\
- Preserve existing validation: refuse credential environment variables, refuse ordinary non-TTY stdin, reject empty/newline/NUL credentials, pass the credential only via an in-memory stdin pipe to `kubectl create secret`, then clear the in-memory reference.\
- Add a regression test `test_observability_app_metrics_install_secret_falls_back_to_interactive_stdin` in `tests/test_generic_app_just_recipes.py` that simulates `sys.stdin.isatty() == True` and `open('/dev/tty')` raising `OSError`, verifies the fallback to `sys.stdin` for `getpass`, confirms render/apply calls occur, and asserts the credential is absent from captured output and recorded command arguments.\
- Tweak an existing controlling-terminal rejection test to keep the invalid-open case covered while removing the direct OSError variant which is now exercised by the new fallback test.

### Testing
- Ran `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k observability_app_metrics` which passed with `149 passed, 255 deselected`.\
- Ran the focused regression `python3 -m pytest -q tests/test_generic_app_just_recipes.py::test_observability_app_metrics_install_secret_falls_back_to_interactive_stdin` which passed (`1 passed`).\
- Ran the full file `python3 -m pytest -q tests/test_generic_app_just_recipes.py` which passed (`404 passed` in CI run).\
- Ran the pair of focused tests together which passed (`2 passed`).\
- Ran `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py`; no secret leaks detected.\
- `pre-commit`, `pyspelling`, and `linkchecker` were not available in the execution environment so those checks were not run here.\

Commit: `d5d18474` (`Fix app metrics secret TTY fallback`). No pull request was created from this environment because the GitHub CLI is unauthenticated and no PR helper tool was available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a743157922c832f9eda38dd0441aa93)