### PR TITLE
Fix app metrics secret installer TTY fallback

### DIFF
--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import re
 import subprocess
@@ -457,17 +458,20 @@ def install_secret(cfg):
     import getpass
 
     try:
-        tty = open(os.environ.get("SUGARKUBE_APP_METRICS_TTY", "/dev/tty"), "r+")
-    except OSError:
-        fail("an interactive controlling terminal is required")
-    try:
-        with tty:
-            if not tty.isatty() or not tty.readable() or not tty.writable():
-                fail("an interactive controlling terminal is required")
+        try:
+            tty = open(os.environ.get("SUGARKUBE_APP_METRICS_TTY", "/dev/tty"), "r+")
+        except OSError:
             value = getpass.getpass(
-                "Enter application metrics bearer token (input hidden): ", stream=tty
+                "Enter application metrics bearer token (input hidden): ", stream=sys.stderr
             )
-    except (OSError, EOFError):
+        else:
+            with tty:
+                if not tty.isatty() or not tty.readable() or not tty.writable():
+                    fail("an interactive controlling terminal is required")
+                value = getpass.getpass(
+                    "Enter application metrics bearer token (input hidden): ", stream=tty
+                )
+    except (OSError, EOFError, io.UnsupportedOperation):
         fail("credential prompt failed (details redacted)")
     if not value or "\n" in value or "\0" in value:
         fail("credential is invalid (value redacted)")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -6,6 +6,7 @@ import argparse
 import io
 import json
 import os
+import pty
 import subprocess
 import sys
 from pathlib import Path
@@ -6581,7 +6582,7 @@ class _AppMetricsFakeTty:
         return True
 
 
-@pytest.mark.parametrize("tty_result", [OSError("private tty"), _AppMetricsFakeTty(False)])
+@pytest.mark.parametrize("tty_result", [_AppMetricsFakeTty(False)])
 def test_observability_app_metrics_install_secret_rejects_bad_controlling_terminal(
     monkeypatch, capsys, tty_result
 ):
@@ -6601,6 +6602,80 @@ def test_observability_app_metrics_install_secret_rejects_bad_controlling_termin
     combined = capsys.readouterr().out + capsys.readouterr().err + str(excinfo.value)
     assert "controlling terminal is required" in combined
     assert "private tty" not in combined
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_observability_app_metrics_install_secret_falls_back_to_pty_stdin(tmp_path):
+    credential = "interactive-credential-sentinel"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    argv_log = tmp_path / "kubectl-argv.jsonl"
+    kubectl = bin_dir / "kubectl"
+    _write_executable(
+        kubectl,
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+with open(os.environ["KUBECTL_ARGV_LOG"], "a", encoding="utf-8") as stream:
+    stream.write(json.dumps(sys.argv[1:]) + "\\n")
+if sys.argv[1:] == ["config", "current-context"]:
+    print("sugar-staging")
+elif "create" in sys.argv:
+    sys.stdin.buffer.read()
+    print("apiVersion: v1\\nkind: Secret")
+elif sys.argv[1:] == ["apply", "-f", "-"]:
+    sys.stdin.buffer.read()
+else:
+    raise SystemExit(2)
+""",
+    )
+    env = os.environ.copy()
+    for name in (
+        "TOKEN",
+        "METRICS_TOKEN",
+        "TOKENPLACE_METRICS_TOKEN",
+        "SUGARKUBE_APP_METRICS_TOKEN",
+    ):
+        env.pop(name, None)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["KUBECTL_ARGV_LOG"] = str(argv_log)
+    master, slave = pty.openpty()
+    try:
+        proc = subprocess.Popen(
+            [
+                "just",
+                "observability-app-metrics-secret-install",
+                "app=tokenplace",
+                "env=staging",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            stdin=slave,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+            text=False,
+        )
+        os.close(slave)
+        slave = -1
+        prompt = proc.stderr.read(len(b"Enter application metrics bearer token (input hidden): "))
+        os.write(master, credential.encode() + b"\n")
+        stdout, stderr = proc.communicate(timeout=15)
+    finally:
+        os.close(master)
+        if slave >= 0:
+            os.close(slave)
+
+    combined = stdout + prompt + stderr
+    assert proc.returncode == 0, combined.decode(errors="replace")
+    assert b"installed or rotated" in combined
+    assert credential.encode() not in combined
+    calls = [json.loads(line) for line in argv_log.read_text(encoding="utf-8").splitlines()]
+    assert ["config", "current-context"] in calls
+    assert ["apply", "-f", "-"] in calls
+    assert any("create" in call for call in calls)
+    assert credential not in repr(calls)
 
 
 def test_observability_app_metrics_install_secret_prompt_write_failure_is_redacted(


### PR DESCRIPTION
### Motivation

- The secret installer rejected interactive SSH/session usage when `sys.stdin` was a real TTY but reopening `/dev/tty` raised `OSError`, producing "an interactive controlling terminal is required" before prompting or applying the Secret.
- The intent is to preserve secure, non-leaking hidden input while accepting the documented `just observability-app-metrics-secret-install app=tokenplace env=staging` path even when `/dev/tty` cannot be reopened.

### Description

- Continue to prefer a validated controlling terminal when available, but fall back to the standard-library `getpass` prompt on interactive stdin when opening `/dev/tty` raises `OSError`, using `sys.stderr` as the prompt stream in that fallback path. 
- Catch `OSError`, `EOFError`, and `io.UnsupportedOperation` from prompt attempts and keep prompt failures redacted without tracebacks or sensitive details. 
- Preserve refusal of credential environment variables and refusal of non-TTY stdin, keep credential only in-memory and pass it to `kubectl create secret` via the stdin pipe, then immediately clear the Python reference. 
- Add a PTY-backed regression test (`test_observability_app_metrics_install_secret_falls_back_to_pty_stdin`) that invokes the documented `just` recipe in a new session with a PTY stdin, stubs `kubectl`, and asserts the fallback prompt path succeeds and that the credential does not appear in output or recorded command arguments; adjust related unit tests to match the new behavior.

### Testing

- Ran `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k observability_app_metrics` and observed all targeted tests pass (149 passed).
- Ran the focused PTY regression `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k observability_app_metrics_install_secret_falls_back_to_pty_stdin` and it passed.
- Verified Python syntax with `python3 -m py_compile scripts/observability_app_metrics.py tests/test_generic_app_just_recipes.py` which succeeded.
- Ran the repository secret scan `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` which reported no new secrets.
- `pre-commit run --all-files` was not run in this environment because `pre-commit` is not installed (noted as unavailable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7431525b1c832fa069ddbc70648494)