### PR TITLE
observability: fallback to stdin getpass when /dev/tty unavailable for app-metrics secret install

### DIFF
--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -4,10 +4,11 @@
 from __future__ import annotations
 
 import argparse
+import io
 import json
+import os
 import re
 import subprocess
-import os
 import sys
 import time
 import urllib.error
@@ -459,15 +460,21 @@ def install_secret(cfg):
     try:
         tty = open(os.environ.get("SUGARKUBE_APP_METRICS_TTY", "/dev/tty"), "r+")
     except OSError:
-        fail("an interactive controlling terminal is required")
+        tty = None
     try:
-        with tty:
-            if not tty.isatty() or not tty.readable() or not tty.writable():
-                fail("an interactive controlling terminal is required")
-            value = getpass.getpass(
-                "Enter application metrics bearer token (input hidden): ", stream=tty
-            )
-    except (OSError, EOFError):
+        if tty is None:
+            value = getpass.getpass("Enter application metrics bearer token (input hidden): ")
+        else:
+            with tty:
+                if not tty.isatty() or not tty.readable() or not tty.writable():
+                    value = getpass.getpass(
+                        "Enter application metrics bearer token (input hidden): "
+                    )
+                else:
+                    value = getpass.getpass(
+                        "Enter application metrics bearer token (input hidden): ", stream=tty
+                    )
+    except (OSError, EOFError, io.UnsupportedOperation):
         fail("credential prompt failed (details redacted)")
     if not value or "\n" in value or "\0" in value:
         fail("credential is invalid (value redacted)")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -6582,7 +6582,7 @@ class _AppMetricsFakeTty:
 
 
 @pytest.mark.parametrize("tty_result", [OSError("private tty"), _AppMetricsFakeTty(False)])
-def test_observability_app_metrics_install_secret_rejects_bad_controlling_terminal(
+def test_observability_app_metrics_install_secret_falls_back_from_unavailable_controlling_terminal(
     monkeypatch, capsys, tty_result
 ):
     cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
@@ -6596,11 +6596,91 @@ def test_observability_app_metrics_install_secret_rejects_bad_controlling_termin
         return tty_result
 
     monkeypatch.setattr(app_metrics, "open", fake_open, raising=False)
-    with pytest.raises(app_metrics.Error) as excinfo:
-        app_metrics.install_secret(cfg)
-    combined = capsys.readouterr().out + capsys.readouterr().err + str(excinfo.value)
-    assert "controlling terminal is required" in combined
+    monkeypatch.setattr("getpass.getpass", lambda prompt: "fallback-value")
+
+    class FakePopen:
+        returncode = 0
+
+        def __init__(self, args, **kwargs):
+            assert "fallback-value" not in args
+
+        def communicate(self, value):
+            assert value == b"fallback-value"
+            return b"apiVersion: v1\nkind: Secret\n", b""
+
+    monkeypatch.setattr(app_metrics.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(
+        app_metrics.subprocess,
+        "run",
+        lambda args, **kwargs: argparse.Namespace(returncode=0),
+    )
+
+    app_metrics.install_secret(cfg)
+
+    combined = capsys.readouterr().out + capsys.readouterr().err
+    assert "fallback-value" not in combined
     assert "private tty" not in combined
+
+
+def test_observability_app_metrics_secret_install_recipe_uses_stdin_pty_fallback(
+    tmp_path, ensure_just_available
+):
+    import pty
+    import select
+
+    sentinel = "pty-regression-sentinel"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    argv_log = tmp_path / "kubectl-argv.log"
+    _write_executable(
+        bin_dir / "kubectl",
+        f"""#!/bin/sh
+printf '%s\\n' "$*" >> {str(argv_log)!r}
+case " $* " in
+  *" config current-context "*) printf '%s\\n' sugar-staging ;;
+  *" create secret generic "*) cat >/dev/null; printf '%s\\n' 'apiVersion: v1' 'kind: Secret' ;;
+  *" apply -f - "*) cat >/dev/null ;;
+  *) exit 1 ;;
+esac
+""",
+    )
+    master, slave = pty.openpty()
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["SUGARKUBE_APP_METRICS_TTY"] = str(tmp_path / "unavailable-tty")
+    proc = subprocess.Popen(
+        [
+            str(ensure_just_available),
+            "observability-app-metrics-secret-install",
+            "app=tokenplace",
+            "env=staging",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        stdin=slave,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=False,
+        start_new_session=True,
+    )
+    os.close(slave)
+    try:
+        ready, _, _ = select.select([proc.stderr], [], [], 10)
+        assert ready, "credential prompt was not written"
+        prompt = os.read(proc.stderr.fileno(), 4096)
+        os.write(master, f"{sentinel}\n".encode())
+        stdout, stderr = proc.communicate(timeout=10)
+    finally:
+        os.close(master)
+
+    combined = (stdout + prompt + stderr).decode(errors="replace")
+    recorded_argv = argv_log.read_text(encoding="utf-8")
+    assert proc.returncode == 0, combined
+    assert "installed or rotated" in combined
+    assert sentinel not in combined
+    assert sentinel not in recorded_argv
+    assert "create secret generic tokenplace-staging-metrics-token" in recorded_argv
+    assert "apply -f -" in recorded_argv
 
 
 def test_observability_app_metrics_install_secret_prompt_write_failure_is_redacted(
@@ -6648,6 +6728,39 @@ def test_observability_app_metrics_install_secret_prompt_write_failure_is_redact
     assert "Traceback" not in combined
     assert private_tty not in combined
     assert credential not in combined
+
+
+@pytest.mark.parametrize("failure", [OSError("private prompt"), EOFError("private prompt")])
+def test_observability_app_metrics_install_secret_stdin_prompt_failure_is_redacted(
+    monkeypatch, capsys, failure
+):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "tokenplace"
+    ]["environments"]["staging"]
+    monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(
+        app_metrics,
+        "open",
+        lambda *args: (_ for _ in ()).throw(OSError("private tty")),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "getpass.getpass", lambda *args, **kwargs: (_ for _ in ()).throw(failure)
+    )
+    monkeypatch.setattr(
+        app_metrics.subprocess,
+        "Popen",
+        lambda *args, **kwargs: pytest.fail("Secret rendering must not be attempted"),
+    )
+
+    with pytest.raises(app_metrics.Error) as excinfo:
+        app_metrics.install_secret(cfg)
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err + str(excinfo.value)
+    assert "credential prompt failed (details redacted)" in combined
+    assert "Traceback" not in combined
+    assert "private" not in combined
 
 
 @pytest.mark.parametrize("credential", ["", "credential-looking-value\n", "credential-looking-value\0"])


### PR DESCRIPTION
### Motivation

- Fix the installer for application-metrics bearer tokens so the documented interactive recipe works in SSH/session environments where `sys.stdin.isatty()` is true but `/dev/tty` cannot be opened for read/write. The previous logic rejected these sessions with "an interactive controlling terminal is required".

### Description

- Change `scripts/observability_app_metrics.py::install_secret` to prefer a controlling terminal when available but fall back to the standard-library `getpass` prompt on interactive `sys.stdin` when reopening `/dev/tty` fails or when writes to the reopened tty are not usable, while preserving the existing refusals for credential environment variables and non-interactive stdin.
- Keep input echo disabled by using `getpass` for the fallback path and continue to pass the credential only via an in-memory stdin pipe to `kubectl create secret`, then immediately discard the Python reference to the value.
- Preserve controlled redaction and failure handling for `OSError`, `EOFError`, and `io.UnsupportedOperation` without tracebacks or leakage of sensitive data, and maintain existing validation that rejects empty, newline-containing, or NUL-containing credentials.
- Add regression tests in `tests/test_generic_app_just_recipes.py` that exercise: the unavailable-controlling-terminal fallback, a PTY-backed subprocess run of the documented `just observability-app-metrics-secret-install app=tokenplace env=staging` recipe with `kubectl` stubbed (no credential appears in outputs or argv), normal controlling-terminal behavior, non-TTY stdin refusal, and prompt failure redaction for `OSError`/`EOFError`.

### Testing

- Ran the focused PTY regression and related unit tests: `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k observability_app_metrics` — passed (152 passed, deselected others as expected).
- Ran the whole just-recipes test module: `python3 -m pytest -q tests/test_generic_app_just_recipes.py` — passed (407 passed).
- Ran the single PTY regression directly: `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k observability_app_metrics_secret_install_recipe_uses_stdin_pty_fallback` — passed.
- Ran repository checks: `git diff --cached | ./scripts/scan-secrets.py` — passed; `pre-commit run --all-files` modified unrelated files and could not complete cleanly in this environment due to baseline formatting/YAML issues, so unrelated repo-wide hooks were not used to gate this fix here.

Residual risks and notes: The change is intentionally minimal and preserves the security contract; tests confirm the documented interactive recipe works in PTY-backed interactive SSH/session environments that lack a reopenable `/dev/tty`. No credentials were written to logs, argv, files, or environment during tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7431556744832fa9651caf4d5a0220)