### PR TITLE
Allow secure app metrics prompts without reopenable /dev/tty

### DIFF
--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
 import json
 import re
 import subprocess
@@ -458,16 +460,25 @@ def install_secret(cfg):
 
     try:
         tty = open(os.environ.get("SUGARKUBE_APP_METRICS_TTY", "/dev/tty"), "r+")
+        tty_context = tty
+        use_stdin_fallback = False
     except OSError:
-        fail("an interactive controlling terminal is required")
+        tty = sys.stdin
+        tty_context = contextlib.nullcontext(tty)
+        use_stdin_fallback = True
     try:
-        with tty:
-            if not tty.isatty() or not tty.readable() or not tty.writable():
+        with tty_context:
+            if not tty.isatty() or not tty.readable() or (
+                not use_stdin_fallback and not tty.writable()
+            ):
                 fail("an interactive controlling terminal is required")
-            value = getpass.getpass(
-                "Enter application metrics bearer token (input hidden): ", stream=tty
+            prompt = "Enter application metrics bearer token (input hidden): "
+            value = (
+                getpass.getpass(prompt)
+                if use_stdin_fallback
+                else getpass.getpass(prompt, stream=tty)
             )
-    except (OSError, EOFError):
+    except (OSError, EOFError, io.UnsupportedOperation):
         fail("credential prompt failed (details redacted)")
     if not value or "\n" in value or "\0" in value:
         fail("credential is invalid (value redacted)")

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -7,14 +7,15 @@ import argparse
 import contextlib
 import io
 import json
+import os
 import re
 import subprocess
-import os
 import sys
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -473,12 +474,14 @@ def install_secret(cfg):
             ):
                 fail("an interactive controlling terminal is required")
             prompt = "Enter application metrics bearer token (input hidden): "
-            value = (
-                getpass.getpass(prompt)
-                if use_stdin_fallback
-                else getpass.getpass(prompt, stream=tty)
-            )
-    except (OSError, EOFError, io.UnsupportedOperation):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", getpass.GetPassWarning)
+                value = (
+                    getpass.getpass(prompt)
+                    if use_stdin_fallback
+                    else getpass.getpass(prompt, stream=tty)
+                )
+    except (OSError, EOFError, io.UnsupportedOperation, getpass.GetPassWarning):
         fail("credential prompt failed (details redacted)")
     if not value or "\n" in value or "\0" in value:
         fail("credential is invalid (value redacted)")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -6734,6 +6734,87 @@ def test_observability_app_metrics_install_secret_rejects_getpass_echo_fallback(
     assert credential not in combined
 
 
+@pytest.mark.parametrize(
+    "prompt_failure", [OSError, EOFError, io.UnsupportedOperation]
+)
+def test_observability_app_metrics_install_secret_stdin_prompt_failures_are_redacted(
+    monkeypatch, capsys, prompt_failure
+):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "tokenplace"
+    ]["environments"]["staging"]
+    private_tty = "/private/controlling-terminal"
+    monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(app_metrics.sys.stdin, "readable", lambda: True)
+    monkeypatch.setattr(
+        app_metrics,
+        "open",
+        lambda *args: (_ for _ in ()).throw(OSError("no controlling terminal")),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "getpass.getpass",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            prompt_failure(f"cannot read {private_tty}")
+        ),
+    )
+    monkeypatch.setattr(
+        app_metrics.subprocess,
+        "Popen",
+        lambda *args, **kwargs: pytest.fail("Secret rendering must not be attempted"),
+    )
+    monkeypatch.setattr(
+        app_metrics.subprocess,
+        "run",
+        lambda *args, **kwargs: pytest.fail("kubectl apply must not be attempted"),
+    )
+
+    with pytest.raises(app_metrics.Error) as excinfo:
+        app_metrics.install_secret(cfg)
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err + str(excinfo.value)
+    assert str(excinfo.value) == "ERROR: credential prompt failed (details redacted)"
+    assert "Traceback" not in combined
+    assert private_tty not in combined
+
+
+def test_observability_app_metrics_install_secret_stdin_prompt_preserves_ctrl_c(
+    monkeypatch
+):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "tokenplace"
+    ]["environments"]["staging"]
+    interrupt = KeyboardInterrupt()
+    monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(app_metrics.sys.stdin, "readable", lambda: True)
+    monkeypatch.setattr(
+        app_metrics,
+        "open",
+        lambda *args: (_ for _ in ()).throw(OSError("no controlling terminal")),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "getpass.getpass",
+        lambda *args, **kwargs: (_ for _ in ()).throw(interrupt),
+    )
+    monkeypatch.setattr(
+        app_metrics.subprocess,
+        "Popen",
+        lambda *args, **kwargs: pytest.fail("Secret rendering must not be attempted"),
+    )
+    monkeypatch.setattr(
+        app_metrics.subprocess,
+        "run",
+        lambda *args, **kwargs: pytest.fail("kubectl apply must not be attempted"),
+    )
+
+    with pytest.raises(KeyboardInterrupt) as excinfo:
+        app_metrics.install_secret(cfg)
+
+    assert excinfo.value is interrupt
+
+
 def test_observability_app_metrics_install_secret_prompt_write_failure_is_redacted(
     monkeypatch, capsys
 ):

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -6,6 +6,8 @@ import argparse
 import io
 import json
 import os
+import pty
+import select
 import subprocess
 import sys
 from pathlib import Path
@@ -6581,7 +6583,7 @@ class _AppMetricsFakeTty:
         return True
 
 
-@pytest.mark.parametrize("tty_result", [OSError("private tty"), _AppMetricsFakeTty(False)])
+@pytest.mark.parametrize("tty_result", [_AppMetricsFakeTty(False)])
 def test_observability_app_metrics_install_secret_rejects_bad_controlling_terminal(
     monkeypatch, capsys, tty_result
 ):
@@ -6601,6 +6603,86 @@ def test_observability_app_metrics_install_secret_rejects_bad_controlling_termin
     combined = capsys.readouterr().out + capsys.readouterr().err + str(excinfo.value)
     assert "controlling terminal is required" in combined
     assert "private tty" not in combined
+
+
+def test_observability_app_metrics_install_secret_falls_back_to_tty_stdin(
+    monkeypatch, tmp_path, ensure_just_available
+):
+    credential = "pty-fallback-sentinel"
+    command_log = tmp_path / "kubectl.jsonl"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "kubectl",
+        f"""#!/usr/bin/env python3
+import json
+import sys
+
+args = sys.argv[1:]
+with open({str(command_log)!r}, "a", encoding="utf-8") as stream:
+    stream.write(json.dumps(args) + "\\n")
+if args == ["config", "current-context"]:
+    print("sugar-staging")
+elif "create" in args:
+    value = sys.stdin.buffer.read()
+    if not value:
+        raise SystemExit(1)
+    sys.stdout.buffer.write(b"apiVersion: v1\\nkind: Secret\\n")
+elif args == ["apply", "-f", "-"]:
+    if b"kind: Secret" not in sys.stdin.buffer.read():
+        raise SystemExit(1)
+else:
+    raise SystemExit(1)
+""",
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["SUGARKUBE_APP_METRICS_TTY"] = str(tmp_path / "unavailable-tty")
+    master, slave = pty.openpty()
+    process = subprocess.Popen(
+        [
+            str(ensure_just_available),
+            "observability-app-metrics-secret-install",
+            "app=tokenplace",
+            "env=staging",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        start_new_session=True,
+    )
+    os.close(slave)
+    output = bytearray()
+    try:
+        while process.poll() is None:
+            readable, _, _ = select.select([master], [], [], 0.1)
+            if readable:
+                try:
+                    output.extend(os.read(master, 4096))
+                except OSError:
+                    break
+                if b"input hidden" in output:
+                    os.write(master, credential.encode() + b"\n")
+                    break
+        process.wait(timeout=10)
+        while select.select([master], [], [], 0)[0]:
+            try:
+                output.extend(os.read(master, 4096))
+            except OSError:
+                break
+    finally:
+        os.close(master)
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+
+    commands = command_log.read_text(encoding="utf-8")
+    assert process.returncode == 0, output.decode(errors="replace")
+    assert "create" in commands and '["apply", "-f", "-"]' in commands
+    assert credential not in output.decode(errors="replace")
+    assert credential not in commands
 
 
 def test_observability_app_metrics_install_secret_prompt_write_failure_is_redacted(

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -10,6 +10,8 @@ import pty
 import select
 import subprocess
 import sys
+import time
+import warnings
 from pathlib import Path
 
 import pytest
@@ -6655,8 +6657,10 @@ else:
     )
     os.close(slave)
     output = bytearray()
+    prompt_seen = False
     try:
-        while process.poll() is None:
+        deadline = time.monotonic() + 10
+        while process.poll() is None and time.monotonic() < deadline:
             readable, _, _ = select.select([master], [], [], 0.1)
             if readable:
                 try:
@@ -6665,7 +6669,13 @@ else:
                     break
                 if b"input hidden" in output:
                     os.write(master, credential.encode() + b"\n")
+                    prompt_seen = True
                     break
+        if not prompt_seen:
+            pytest.fail(
+                "credential prompt was not observed before timeout: "
+                + output.decode(errors="replace")
+            )
         process.wait(timeout=10)
         while select.select([master], [], [], 0)[0]:
             try:
@@ -6678,11 +6688,50 @@ else:
             process.kill()
             process.wait()
 
-    commands = command_log.read_text(encoding="utf-8")
     assert process.returncode == 0, output.decode(errors="replace")
+    assert command_log.exists(), output.decode(errors="replace")
+    commands = command_log.read_text(encoding="utf-8")
     assert "create" in commands and '["apply", "-f", "-"]' in commands
     assert credential not in output.decode(errors="replace")
     assert credential not in commands
+
+
+def test_observability_app_metrics_install_secret_rejects_getpass_echo_fallback(
+    monkeypatch, capsys
+):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "tokenplace"
+    ]["environments"]["staging"]
+    credential = "credential-looking-value"
+    monkeypatch.setattr(app_metrics.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(app_metrics.sys.stdin, "readable", lambda: True)
+    monkeypatch.setattr(
+        app_metrics,
+        "open",
+        lambda *args: (_ for _ in ()).throw(OSError("no controlling terminal")),
+        raising=False,
+    )
+
+    def insecure_getpass(*args, **kwargs):
+        warnings.warn("input may be echoed", getpass.GetPassWarning)
+        return credential
+
+    import getpass
+
+    monkeypatch.setattr(getpass, "getpass", insecure_getpass)
+    monkeypatch.setattr(
+        app_metrics.subprocess,
+        "Popen",
+        lambda *args, **kwargs: pytest.fail("Secret rendering must not be attempted"),
+    )
+
+    with pytest.raises(app_metrics.Error) as excinfo:
+        app_metrics.install_secret(cfg)
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err + str(excinfo.value)
+    assert "credential prompt failed (details redacted)" in combined
+    assert credential not in combined
 
 
 def test_observability_app_metrics_install_secret_prompt_write_failure_is_redacted(


### PR DESCRIPTION
### Motivation

After #2508 merged at `c2fb724205faacf24632c8b1b5ea93aef3f19b68`, the documented command failed on `sugarkube3`:

`just observability-app-metrics-secret-install app=tokenplace env=staging`

In that SSH/session topology, `sys.stdin.isatty()` was true but `/dev/tty` could not be reopened read/write. The installer stopped before prompting or invoking `kubectl`; no saved credential was used and no Helm state changed.

### Summary

- Continue preferring a validated controlling terminal when one can be opened.
- Fall back securely to the existing interactive stdin TTY when opening `/dev/tty` raises `OSError`, without closing `sys.stdin`.
- Use standard-library `getpass` with echo disabled.
- Promote `getpass.GetPassWarning` to a controlled failure so an echo-enabled fallback is never accepted.
- Redact `OSError`, `EOFError`, `io.UnsupportedOperation`, and `GetPassWarning` prompt failures without tracebacks or sensitive details.
- Preserve normal `KeyboardInterrupt` propagation.
- Continue refusing credential environment variables and non-interactive stdin.
- Continue rejecting empty, newline-containing, and NUL-containing credentials.
- Keep the bearer token only in memory, pass it solely through the stdin pipe to `kubectl create secret`, and discard the Python reference afterward.
- Preserve Kubernetes-context validation and the existing Secret/key contract.

### Regression coverage

- Runs the documented `just observability-app-metrics-secret-install app=tokenplace env=staging` recipe with fd 0 attached to a PTY and no accessible `/dev/tty`.
- Uses a stubbed `kubectl`, so the test cannot access a real cluster.
- Verifies Secret rendering and application occur without placing the credential sentinel in terminal output or recorded command arguments.
- Gives the PTY interaction bounded deadlines and guaranteed subprocess cleanup.
- Retains normal controlling-terminal and invalid-terminal coverage.
- Proves environment-variable and non-TTY refusal.
- Proves `OSError`, `EOFError`, `io.UnsupportedOperation`, and `GetPassWarning` failures are redacted and perform no `kubectl` mutation.
- Proves Ctrl-C propagates without mutation.
- Retains invalid-credential and subprocess-failure redaction coverage.

### Testing

- `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k 'observability_app_metrics_install_secret'` — 15 passed, 394 deselected.
- `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k observability_app_metrics` — 154 passed, 255 deselected.
- `python3 -m pytest -q tests/test_generic_app_just_recipes.py` — 409 passed.
- `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k 'stdin_prompt_failures_are_redacted or stdin_prompt_preserves_ctrl_c'` — 4 passed.
- `git diff --check` — passed.
- `git diff | ./scripts/scan-secrets.py` — passed.
- `git diff --cached | ./scripts/scan-secrets.py` — passed.

### Scope

Only `scripts/observability_app_metrics.py` and `tests/test_generic_app_just_recipes.py` are changed. This PR does not modify documentation, chart pins, Helm values, observability inventory, Kubernetes manifests, deployments, or credentials.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74315ac8a0832fa12fc2b9be2d7033)