### PR TITLE
Use stable User-Agent for public /metrics verifier (sugarkube-observability-verifier/1.0)

### DIFF
--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -24,6 +24,7 @@ ROOT = Path(__file__).resolve().parents[1]
 CONFIG = ROOT / "platform/observability/app-metrics.json"
 PROM = "/api/v1/namespaces/monitoring/services/http:kube-prometheus-stack-prometheus:9090/proxy"
 KUBECTL_TIMEOUT_SECONDS = 30
+PUBLIC_METRICS_USER_AGENT = "sugarkube-observability-verifier/1.0"
 K8S_NAME = re.compile(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?")
 DURATION = re.compile(r"[1-9][0-9]*[smh]")
 STATUS = re.compile(r"[1-5][0-9][0-9]")
@@ -789,7 +790,10 @@ def verify(app, env):
         opener = urllib.request.build_opener(
             NoRedirect, urllib.request.HTTPHandler, urllib.request.HTTPSHandler
         )
-        response = opener.open(cfg["publicMetrics"]["url"], timeout=10)
+        request = urllib.request.Request(
+            cfg["publicMetrics"]["url"], headers={"User-Agent": PUBLIC_METRICS_USER_AGENT}
+        )
+        response = opener.open(request, timeout=10)
         try:
             got = getattr(response, "status", None)
             if got is None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -5710,6 +5710,7 @@ def test_observability_app_metrics_verify_exercises_targets_metrics_and_public_4
         }
     }
     queries: list[str] = []
+    public_requests = []
 
     def fake_kjson(args):
         if args[:4] == ["kubectl", "-n", "tokenplace", "get"] and args[4] == "servicemonitor":
@@ -5734,8 +5735,11 @@ def test_observability_app_metrics_verify_exercises_targets_metrics_and_public_4
         return {"resultType": "vector", "result": [{"metric": sample_labels}]}
 
     class Opener:
-        def open(self, url, timeout):
-            raise app_metrics.urllib.error.HTTPError(url, 401, "unauthorized", {}, None)
+        def open(self, request, timeout):
+            public_requests.append((request, timeout))
+            raise app_metrics.urllib.error.HTTPError(
+                request.full_url, 401, "unauthorized", {}, None
+            )
 
     monkeypatch.setattr(app_metrics, "appcfg", lambda app, env: cfg)
     monkeypatch.setattr(app_metrics, "assert_context", lambda: None)
@@ -5749,9 +5753,16 @@ def test_observability_app_metrics_verify_exercises_targets_metrics_and_public_4
 
     assert "/api/v1/targets" in queries
     assert any("tokenplace_build_info" in query for query in queries)
+    request, timeout = public_requests.pop()
+    assert isinstance(request, app_metrics.urllib.request.Request)
+    assert request.full_url == cfg["publicMetrics"]["url"]
+    assert request.get_header("User-agent") == app_metrics.PUBLIC_METRICS_USER_AGENT
+    assert request.get_header("User-agent") == "sugarkube-observability-verifier/1.0"
+    assert timeout == 10
 
 
-def test_observability_app_metrics_verify_fails_on_public_200(monkeypatch):
+@pytest.mark.parametrize("status", [200, 403])
+def test_observability_app_metrics_verify_fails_on_public_status(monkeypatch, capsys, status):
     cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"]["tokenplace"]["environments"]["staging"]
     sm = {"spec": {"selector": {"matchLabels": cfg["serviceMonitor"]["selectorMatchLabels"]}, "endpoints": [{"path": "/metrics", "interval": cfg["serviceMonitor"]["interval"], "scrapeTimeout": cfg["serviceMonitor"]["scrapeTimeout"], "authorization": {"type": "Bearer", "credentials": cfg["secret"]}, "relabelings": cfg["serviceMonitor"]["relabelings"]}]}}
     monkeypatch.setattr(app_metrics, "appcfg", lambda app, env: cfg)
@@ -5762,7 +5773,7 @@ def test_observability_app_metrics_verify_fails_on_public_200(monkeypatch):
     monkeypatch.setattr(app_metrics, "prom", lambda path: {"activeTargets": [{"health": "up", "scrapePool": "serviceMonitor/tokenplace/tokenplace/0", "labels": cfg["targetLabels"], "discoveredLabels": {}}]} if path == "/api/v1/targets" else {"resultType": "vector", "result": [{"metric": {"__name__": app_metrics.urllib.parse.unquote(path.rsplit("query=", 1)[-1]).split("{", 1)[0], "version": "main-deadbee", "revision": "main-deadbee"}}]})
 
     class Response:
-        status = 200
+        body = "sensitive-response-body-sentinel"
 
         def read(self, size):
             raise AssertionError("response body must not be read")
@@ -5771,13 +5782,18 @@ def test_observability_app_metrics_verify_fails_on_public_200(monkeypatch):
             pass
 
     class Opener:
-        def open(self, url, timeout):
-            return Response()
+        def open(self, request, timeout):
+            response = Response()
+            response.status = status
+            return response
 
     monkeypatch.setattr(app_metrics.urllib.request, "build_opener", lambda *args: Opener())
     with pytest.raises(SystemExit) as excinfo:
         app_metrics.verify("tokenplace", "staging")
-    assert "status mismatch" in str(excinfo.value)
+    message = str(excinfo.value)
+    captured = capsys.readouterr()
+    assert "status mismatch (body redacted)" in message
+    assert "sensitive-response-body-sentinel" not in message + captured.out + captured.err
 
 
 def test_observability_app_metrics_public_uses_actual_success_status_without_body(monkeypatch):
@@ -5822,6 +5838,64 @@ def _verify_base(monkeypatch, cfg, prom_func):
     monkeypatch.setattr(app_metrics, "kjson", lambda args: sm)
     monkeypatch.setattr(app_metrics, "prom", prom_func)
     monkeypatch.setattr(app_metrics.urllib.request, "build_opener", lambda *args: Opener())
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected"),
+    [
+        (app_metrics.urllib.error.URLError("sensitive-transport-sentinel"), "check failed"),
+        ("sensitive-malformed-status-sentinel", "status was malformed"),
+    ],
+)
+def test_observability_app_metrics_public_failures_are_redacted(
+    monkeypatch, capsys, failure, expected
+):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "tokenplace"
+    ]["environments"]["staging"]
+
+    def prom_func(path):
+        if path == "/api/v1/targets":
+            return {
+                "activeTargets": [
+                    {
+                        "health": "up",
+                        "scrapePool": "serviceMonitor/tokenplace/tokenplace/0",
+                        "labels": cfg["targetLabels"],
+                        "discoveredLabels": {},
+                    }
+                ]
+            }
+        metric = app_metrics.urllib.parse.unquote(path.rsplit("query=", 1)[-1]).split("{", 1)[0]
+        return {
+            "resultType": "vector",
+            "result": [
+                {
+                    "metric": {
+                        "__name__": metric,
+                        "version": "main-deadbee",
+                        "revision": "main-deadbee",
+                    }
+                }
+            ],
+        }
+
+    class Opener:
+        def open(self, request, timeout):
+            if isinstance(failure, Exception):
+                raise failure
+            return type("Response", (), {"status": failure, "close": lambda self: None})()
+
+    _verify_base(monkeypatch, cfg, prom_func)
+    monkeypatch.setattr(app_metrics.urllib.request, "build_opener", lambda *args: Opener())
+
+    with pytest.raises(app_metrics.Error) as excinfo:
+        app_metrics.verify("tokenplace", "staging")
+
+    captured = capsys.readouterr()
+    output = str(excinfo.value) + captured.out + captured.err
+    assert expected in output
+    assert "sensitive-" not in output
 
 
 def test_observability_app_metrics_verify_target_failures_and_retries(monkeypatch):


### PR DESCRIPTION
### Motivation
- Prometheus discovered the target but the public `/metrics` unauthenticated check failed because Cloudflare blocks Python's default `User-Agent`, so the verifier must send a stable, truthful User-Agent to exercise the application authentication boundary rather than being blocked by Cloudflare.  Live evidence: `curl` default → 401, `curl` with `Python-urllib/3.11` → 403, `curl` with `sugarkube-observability-verifier/1.0` → 401, `urllib` default → 403, `urllib` with explicit `Python-urllib/3.11` → 403, `urllib` with `sugarkube-observability-verifier/1.0` → 401, and `urllib` with curl User-Agent → 401. 403 remains adverse because it indicates Cloudflare blocked the verifier rather than token.place enforcing the app auth boundary. 

### Description
- Add a named constant `PUBLIC_METRICS_USER_AGENT = "sugarkube-observability-verifier/1.0"` and construct an `urllib.request.Request` with that `User-Agent` header for the public `/metrics` check. 
- Pass the `Request` to the existing `urllib` opener (preserving redirects disabled and the finite `timeout=10`), and preserve the exact configured status comparison and redacted failure messaging. 
- Update offline tests to assert the `Request` was used, the exact `User-Agent` is sent, 401 is accepted, 403 still fails, redirects are not followed, response bodies and sensitive sentinels are not leaked, and transport/malformed-status failures remain redacted. 

### Testing
- Ran focused tests with `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k observability_app_metrics` which completed successfully (`157 passed, 255 deselected, 1 warning`).
- Ran the full file tests with `python3 -m pytest -q tests/test_generic_app_just_recipes.py` which exited with status `0` and no failing tests in the changed areas. 
- Performed repository checks: `git diff --check` and `git diff | ./scripts/scan-secrets.py` on the staged diff passed, and `pre-commit run --all-files` was not executed because `pre-commit` is not installed in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75619f21d8832f817de0836397cef3)