### PR TITLE
observability: send stable User-Agent for public /metrics unauthenticated check

### DIFF
--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -24,6 +24,7 @@ ROOT = Path(__file__).resolve().parents[1]
 CONFIG = ROOT / "platform/observability/app-metrics.json"
 PROM = "/api/v1/namespaces/monitoring/services/http:kube-prometheus-stack-prometheus:9090/proxy"
 KUBECTL_TIMEOUT_SECONDS = 30
+USER_AGENT = "sugarkube-observability-verifier/1.0"
 K8S_NAME = re.compile(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?")
 DURATION = re.compile(r"[1-9][0-9]*[smh]")
 STATUS = re.compile(r"[1-5][0-9][0-9]")
@@ -789,7 +790,10 @@ def verify(app, env):
         opener = urllib.request.build_opener(
             NoRedirect, urllib.request.HTTPHandler, urllib.request.HTTPSHandler
         )
-        response = opener.open(cfg["publicMetrics"]["url"], timeout=10)
+        request = urllib.request.Request(
+            cfg["publicMetrics"]["url"], headers={"User-Agent": USER_AGENT}
+        )
+        response = opener.open(request, timeout=10)
         try:
             got = getattr(response, "status", None)
             if got is None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -5710,6 +5710,7 @@ def test_observability_app_metrics_verify_exercises_targets_metrics_and_public_4
         }
     }
     queries: list[str] = []
+    requests = []
 
     def fake_kjson(args):
         if args[:4] == ["kubectl", "-n", "tokenplace", "get"] and args[4] == "servicemonitor":
@@ -5734,8 +5735,11 @@ def test_observability_app_metrics_verify_exercises_targets_metrics_and_public_4
         return {"resultType": "vector", "result": [{"metric": sample_labels}]}
 
     class Opener:
-        def open(self, url, timeout):
-            raise app_metrics.urllib.error.HTTPError(url, 401, "unauthorized", {}, None)
+        def open(self, request, timeout):
+            requests.append((request, timeout))
+            raise app_metrics.urllib.error.HTTPError(
+                request.full_url, 401, "unauthorized", {}, None
+            )
 
     monkeypatch.setattr(app_metrics, "appcfg", lambda app, env: cfg)
     monkeypatch.setattr(app_metrics, "assert_context", lambda: None)
@@ -5749,6 +5753,119 @@ def test_observability_app_metrics_verify_exercises_targets_metrics_and_public_4
 
     assert "/api/v1/targets" in queries
     assert any("tokenplace_build_info" in query for query in queries)
+    assert len(requests) == 1
+    request, timeout = requests[0]
+    assert isinstance(request, app_metrics.urllib.request.Request)
+    assert request.full_url == cfg["publicMetrics"]["url"]
+    assert request.get_header("User-agent") == app_metrics.USER_AGENT
+    assert app_metrics.USER_AGENT == "sugarkube-observability-verifier/1.0"
+    assert timeout == 10
+
+
+def test_observability_app_metrics_public_403_remains_adverse_and_redacted(
+    monkeypatch, capsys
+):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "tokenplace"
+    ]["environments"]["staging"]
+    sensitive = "response-body-sensitive-sentinel"
+
+    def prom_func(path):
+        if path == "/api/v1/targets":
+            return {"activeTargets": [{
+                "health": "up",
+                "scrapePool": "serviceMonitor/tokenplace/tokenplace/0",
+                "labels": cfg["targetLabels"],
+                "discoveredLabels": {},
+            }]}
+        metric = app_metrics.urllib.parse.unquote(path.rsplit("query=", 1)[-1]).split("{", 1)[0]
+        return {"resultType": "vector", "result": [{"metric": {
+            "__name__": metric,
+            "version": "main-deadbee",
+            "revision": "main-deadbee",
+        }}]}
+
+    class SensitiveBody:
+        def read(self, *args):
+            raise AssertionError(sensitive)
+
+        def close(self):
+            pass
+
+    class Opener:
+        def open(self, request, timeout):
+            raise app_metrics.urllib.error.HTTPError(
+                request.full_url, 403, sensitive, {}, SensitiveBody()
+            )
+
+    _verify_base(monkeypatch, cfg, prom_func)
+    monkeypatch.setattr(app_metrics.urllib.request, "build_opener", lambda *args: Opener())
+
+    with pytest.raises(app_metrics.Error) as excinfo:
+        app_metrics.verify("tokenplace", "staging")
+
+    captured = capsys.readouterr()
+    assert str(excinfo.value) == (
+        "ERROR: public /metrics unauthenticated status mismatch (body redacted)"
+    )
+    assert sensitive not in str(excinfo.value)
+    assert sensitive not in captured.out
+    assert sensitive not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("failure", "message"),
+    [
+        ("transport", "unauthenticated check failed (details redacted)"),
+        ("malformed", "response status was malformed (details redacted)"),
+    ],
+)
+def test_observability_app_metrics_public_failures_remain_redacted(
+    monkeypatch, capsys, failure, message
+):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "tokenplace"
+    ]["environments"]["staging"]
+    sensitive = "transport-sensitive-sentinel"
+
+    def prom_func(path):
+        if path == "/api/v1/targets":
+            return {"activeTargets": [{
+                "health": "up",
+                "scrapePool": "serviceMonitor/tokenplace/tokenplace/0",
+                "labels": cfg["targetLabels"],
+                "discoveredLabels": {},
+            }]}
+        metric = app_metrics.urllib.parse.unquote(path.rsplit("query=", 1)[-1]).split("{", 1)[0]
+        return {"resultType": "vector", "result": [{"metric": {
+            "__name__": metric,
+            "version": "main-deadbee",
+            "revision": "main-deadbee",
+        }}]}
+
+    class Response:
+        status = sensitive
+
+        def close(self):
+            pass
+
+    class Opener:
+        def open(self, request, timeout):
+            if failure == "transport":
+                raise OSError(sensitive)
+            return Response()
+
+    _verify_base(monkeypatch, cfg, prom_func)
+    monkeypatch.setattr(app_metrics.urllib.request, "build_opener", lambda *args: Opener())
+
+    with pytest.raises(app_metrics.Error) as excinfo:
+        app_metrics.verify("tokenplace", "staging")
+
+    captured = capsys.readouterr()
+    assert message in str(excinfo.value)
+    assert sensitive not in str(excinfo.value)
+    assert sensitive not in captured.out
+    assert sensitive not in captured.err
 
 
 def test_observability_app_metrics_verify_fails_on_public_200(monkeypatch):


### PR DESCRIPTION
### Motivation

- The verifier's public `/metrics` unauthenticated check was blocked by Cloudflare when using Python's default User-Agent, so the check must present a stable, truthful User-Agent to reach the application rather than be dropped by the edge.
- Live staging evidence showed differing Cloudflare behavior by User-Agent: `curl` default: 401; `curl` with `Python-urllib/3.11`: 403; `curl` with `sugarkube-observability-verifier/1.0`: 401; `urllib` default: 403; `urllib` with `Python-urllib/3.11`: 403; `urllib` with `sugarkube-observability-verifier/1.0`: 401; and `urllib` with curl User-Agent: 401, proving that a stable UA is required and that 403 is a Cloudflare block, not a valid app response.

### Description

- Add a `USER_AGENT = "sugarkube-observability-verifier/1.0"` constant and construct an `urllib.request.Request` with that `User-Agent` for the public metrics check, passing the `Request` to the existing opener so redirects remain disabled and the 10s timeout is preserved.
- Preserve existing behavior for response-body redaction, strict numeric status validation, rejects of 403 as success, controlled transport-error handling, and disabled redirects.
- Modify only `scripts/observability_app_metrics.py` and `tests/test_generic_app_just_recipes.py` to keep the diff minimal and follow the scoped change requirements.

### Testing

- Ran `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k observability_app_metrics` and received `157 passed, 255 deselected` confirming the focused regression coverage for the verifier.
- Ran `python3 -m pytest -q tests/test_generic_app_just_recipes.py` and received `412 passed`, validating the broader test surface unaffected by the change.
- Ran targeted pre-commit hooks `pre-commit run trailing-whitespace --files scripts/observability_app_metrics.py tests/test_generic_app_just_recipes.py` and `pre-commit run end-of-file-fixer --files scripts/observability_app_metrics.py tests/test_generic_app_just_recipes.py` which passed for the changed files, and ran `git diff --check` plus `git diff | ./scripts/scan-secrets.py` which reported no issues for the committed changes; a full `pre-commit run --all-files` was attempted but failed on unrelated, pre-existing repo-wide checks which were not part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7561ad21d4832fb0d8abc375902aec)