### PR TITLE
Send stable User-Agent for public /metrics unauthenticated check

### DIFF
--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -24,6 +24,7 @@ ROOT = Path(__file__).resolve().parents[1]
 CONFIG = ROOT / "platform/observability/app-metrics.json"
 PROM = "/api/v1/namespaces/monitoring/services/http:kube-prometheus-stack-prometheus:9090/proxy"
 KUBECTL_TIMEOUT_SECONDS = 30
+PUBLIC_METRICS_USER_AGENT = "sugarkube-observability-verifier/1.0"
 K8S_NAME = re.compile(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?")
 DURATION = re.compile(r"[1-9][0-9]*[smh]")
 STATUS = re.compile(r"[1-5][0-9][0-9]")
@@ -789,7 +790,11 @@ def verify(app, env):
         opener = urllib.request.build_opener(
             NoRedirect, urllib.request.HTTPHandler, urllib.request.HTTPSHandler
         )
-        response = opener.open(cfg["publicMetrics"]["url"], timeout=10)
+        request = urllib.request.Request(
+            cfg["publicMetrics"]["url"],
+            headers={"User-Agent": PUBLIC_METRICS_USER_AGENT},
+        )
+        response = opener.open(request, timeout=10)
         try:
             got = getattr(response, "status", None)
             if got is None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -5733,9 +5733,14 @@ def test_observability_app_metrics_verify_exercises_targets_metrics_and_public_4
             sample_labels["le"] = "0.5"
         return {"resultType": "vector", "result": [{"metric": sample_labels}]}
 
+    requests = []
+
     class Opener:
-        def open(self, url, timeout):
-            raise app_metrics.urllib.error.HTTPError(url, 401, "unauthorized", {}, None)
+        def open(self, request, timeout):
+            requests.append((request, timeout))
+            raise app_metrics.urllib.error.HTTPError(
+                request.full_url, 401, "unauthorized", {}, None
+            )
 
     monkeypatch.setattr(app_metrics, "appcfg", lambda app, env: cfg)
     monkeypatch.setattr(app_metrics, "assert_context", lambda: None)
@@ -5749,6 +5754,13 @@ def test_observability_app_metrics_verify_exercises_targets_metrics_and_public_4
 
     assert "/api/v1/targets" in queries
     assert any("tokenplace_build_info" in query for query in queries)
+    assert len(requests) == 1
+    request, timeout = requests[0]
+    assert isinstance(request, app_metrics.urllib.request.Request)
+    assert request.full_url == cfg["publicMetrics"]["url"]
+    assert request.get_header("User-agent") == app_metrics.PUBLIC_METRICS_USER_AGENT
+    assert request.get_header("User-agent") == "sugarkube-observability-verifier/1.0"
+    assert timeout == 10
 
 
 def test_observability_app_metrics_verify_fails_on_public_200(monkeypatch):
@@ -5771,7 +5783,7 @@ def test_observability_app_metrics_verify_fails_on_public_200(monkeypatch):
             pass
 
     class Opener:
-        def open(self, url, timeout):
+        def open(self, request, timeout):
             return Response()
 
     monkeypatch.setattr(app_metrics.urllib.request, "build_opener", lambda *args: Opener())
@@ -5803,7 +5815,7 @@ def test_observability_app_metrics_public_uses_actual_success_status_without_bod
 
     response = Response()
     _verify_base(monkeypatch, cfg, prom_func)
-    monkeypatch.setattr(app_metrics.urllib.request, "build_opener", lambda *args: type("Opener", (), {"open": lambda self, url, timeout: response})())
+    monkeypatch.setattr(app_metrics.urllib.request, "build_opener", lambda *args: type("Opener", (), {"open": lambda self, request, timeout: response})())
 
     app_metrics.verify("tokenplace", "staging")
     assert response.closed
@@ -5813,8 +5825,10 @@ def test_observability_app_metrics_public_uses_actual_success_status_without_bod
 def _verify_base(monkeypatch, cfg, prom_func):
     sm = {"spec": {"selector": {"matchLabels": cfg["serviceMonitor"]["selectorMatchLabels"]}, "endpoints": [{"path": "/metrics", "interval": cfg["serviceMonitor"]["interval"], "scrapeTimeout": cfg["serviceMonitor"]["scrapeTimeout"], "authorization": {"type": "Bearer", "credentials": cfg["secret"]}, "relabelings": cfg["serviceMonitor"]["relabelings"]}]}}
     class Opener:
-        def open(self, url, timeout):
-            raise app_metrics.urllib.error.HTTPError(url, 401, "unauthorized", {}, None)
+        def open(self, request, timeout):
+            raise app_metrics.urllib.error.HTTPError(
+                request.full_url, 401, "unauthorized", {}, None
+            )
     monkeypatch.setattr(app_metrics, "appcfg", lambda app, env: cfg)
     monkeypatch.setattr(app_metrics, "assert_context", lambda: None)
     monkeypatch.setattr(app_metrics, "check_secret", lambda cfg: None)
@@ -5822,6 +5836,73 @@ def _verify_base(monkeypatch, cfg, prom_func):
     monkeypatch.setattr(app_metrics, "kjson", lambda args: sm)
     monkeypatch.setattr(app_metrics, "prom", prom_func)
     monkeypatch.setattr(app_metrics.urllib.request, "build_opener", lambda *args: Opener())
+
+
+@pytest.mark.parametrize(
+    ("outcome", "expected_message"),
+    [
+        (403, "public /metrics unauthenticated status mismatch (body redacted)"),
+        ("malformed-sensitive-status", "public /metrics response status was malformed (details redacted)"),
+        (RuntimeError("sensitive-transport-detail"), "public /metrics unauthenticated check failed (details redacted)"),
+    ],
+)
+def test_observability_app_metrics_public_failures_remain_adverse_and_redacted(
+    monkeypatch, capsys, outcome, expected_message
+):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "tokenplace"
+    ]["environments"]["staging"]
+
+    def prom_func(path):
+        if path == "/api/v1/targets":
+            return {"activeTargets": [{
+                "health": "up",
+                "scrapePool": "serviceMonitor/tokenplace/tokenplace/0",
+                "labels": cfg["targetLabels"],
+                "discoveredLabels": {},
+            }]}
+        metric = app_metrics.urllib.parse.unquote(path.rsplit("query=", 1)[-1]).split("{", 1)[0]
+        return {"resultType": "vector", "result": [{"metric": {
+            "__name__": metric,
+            "version": "main-deadbee",
+            "revision": "main-deadbee",
+        }}]}
+
+    class Opener:
+        def open(self, request, timeout):
+            if isinstance(outcome, BaseException):
+                raise outcome
+            if isinstance(outcome, int):
+                raise app_metrics.urllib.error.HTTPError(
+                    request.full_url,
+                    outcome,
+                    "sensitive-reason",
+                    {"X-Sensitive": "sensitive-header"},
+                    io.BytesIO(b"sensitive-response-body"),
+                )
+            return type(
+                "Response",
+                (),
+                {"status": outcome, "close": lambda self: None},
+            )()
+
+    _verify_base(monkeypatch, cfg, prom_func)
+    monkeypatch.setattr(app_metrics.urllib.request, "build_opener", lambda *args: Opener())
+
+    with pytest.raises(app_metrics.Error) as excinfo:
+        app_metrics.verify("tokenplace", "staging")
+
+    captured = capsys.readouterr()
+    combined = str(excinfo.value) + captured.out + captured.err
+    assert expected_message in combined
+    for sentinel in (
+        "sensitive-response-body",
+        "sensitive-reason",
+        "sensitive-header",
+        "sensitive-transport-detail",
+        "malformed-sensitive-status",
+    ):
+        assert sentinel not in combined
 
 
 def test_observability_app_metrics_verify_target_failures_and_retries(monkeypatch):
@@ -6264,9 +6345,9 @@ def test_observability_app_metrics_public_redirect_is_not_followed_and_redacted(
         }}]}
 
     class RedirectingOpener:
-        def open(self, url, timeout):
+        def open(self, request, timeout):
             raise app_metrics.urllib.error.HTTPError(
-                url,
+                request.full_url,
                 302,
                 "Found",
                 {"Location": "https://example.invalid/secret-path"},


### PR DESCRIPTION
### Motivation
- Cloudflare was blocking the verifier when it used Python’s default User-Agent, causing the public `/metrics` unauthenticated check to observe 403 where token.place must return 401; live evidence: `curl` default => 401, `curl` with `Python-urllib/3.11` => 403, `curl` with `sugarkube-observability-verifier/1.0` => 401, `urllib` default => 403, `urllib` with `sugarkube-observability-verifier/1.0` => 401. 
- A 403 is still considered adverse because it proves a WAF/Cloudflare block rather than the application returning the expected unauthenticated `401`, so the verifier must continue to require the exact configured status to prove the authentication boundary.

### Description
- Introduce a named constant `PUBLIC_METRICS_USER_AGENT = "sugarkube-observability-verifier/1.0"` in `scripts/observability_app_metrics.py`.
- Build an explicit `urllib.request.Request` for the configured public metrics URL with the stable `User-Agent` and pass that `Request` to the existing opener, preserving redirects-disabled behavior and the existing ten-second timeout.
- Preserve all existing behaviors: exact status comparison, response-body redaction, finite timeout, controlled transport-error handling, and redirect rejection.
- Add offline tests in `tests/test_generic_app_just_recipes.py` that assert the `Request` carries the exact User-Agent, accept `401`, keep `403` as failure, reject redirects, and ensure sensitive response bodies/headers/exceptions remain redacted.

### Testing
- Ran the focused tests: `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k observability_app_metrics` and observed `157 passed, 255 deselected` (PASS).
- Ran the full test suite: `python3 -m pytest -q tests/test_generic_app_just_recipes.py` and observed `412 passed` (PASS).
- Verified diffs and secrets: `git diff --check` (PASS) and `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` (PASS).
- `pre-commit run --all-files` was not executed because `pre-commit` is not installed in this environment (NOT RUN).
- Style checks: `black --check` / `isort --check-only` reported that the two changed files would be reformatted and `flake8` is not installed in this environment (NOT RUN / environment-limited).

Residual risks & notes: the change is intentionally minimal and scoped only to `scripts/observability_app_metrics.py` and `tests/test_generic_app_just_recipes.py`; it does not alter expected unauthenticated status, retry behavior, chart pins, or any Kubernetes resources.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7561abe14c832f958bac7eb206a432)