### PR TITLE
observability: add token.place Phase 1 dashboard slice (#2405)

### DIFF
--- a/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
+++ b/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
@@ -1071,6 +1071,739 @@
           "mode": "multi"
         }
       }
+    },
+    {
+      "id": 22,
+      "type": "row",
+      "title": "token.place relay and compute capacity",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 60
+      },
+      "panels": []
+    },
+    {
+      "id": 23,
+      "type": "stat",
+      "title": "token.place scrape availability",
+      "description": "Prometheus scrape health per relay pod; missing samples remain NO DATA.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 61
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "min by (pod) (up{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "legendFormat": "{{pod}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "noValue": "NO DATA",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "UNHEALTHY",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "HEALTHY",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 24,
+      "type": "stat",
+      "title": "token.place instrumentation health",
+      "description": "Application instrumentation self-check per relay pod; missing samples remain NO DATA.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 61
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "min by (pod) (tokenplace_instrumentation_up{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "legendFormat": "{{pod}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "noValue": "NO DATA",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "UNHEALTHY",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "HEALTHY",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 25,
+      "type": "stat",
+      "title": "Registered and healthy compute nodes",
+      "description": "Relay-reported logical gauges are deduplicated with max rather than added across relay replicas.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 61
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max(tokenplace_compute_nodes_registered{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "legendFormat": "Registered"
+        },
+        {
+          "refId": "B",
+          "expr": "max(tokenplace_compute_nodes_healthy{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "legendFormat": "Healthy"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 26,
+      "type": "timeseries",
+      "title": "Oldest compute-node lease age",
+      "description": "Maximum reported lease age, deduplicated across relay replicas. Zero is distinct from NO DATA.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 66
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max(tokenplace_compute_node_lease_age_seconds{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "legendFormat": "Oldest lease"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "NO DATA",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 300
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 27,
+      "type": "timeseries",
+      "title": "Compute-node eviction rate by reason",
+      "description": "Summed process-local eviction counter rate grouped only by bounded reason.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 66
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (reason) (rate(tokenplace_compute_node_evictions_total{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"}[$__rate_interval]))",
+          "legendFormat": "{{reason}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 28,
+      "type": "timeseries",
+      "title": "Relay queue depth by provider mode",
+      "description": "Logical queue depth deduplicated with max and grouped by bounded provider_mode.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 66
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (provider_mode) (tokenplace_relay_queue_depth{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "legendFormat": "{{provider_mode}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 29,
+      "type": "timeseries",
+      "title": "Oldest queued-request age by provider mode",
+      "description": "Maximum queued age, deduplicated across relays and grouped only by bounded provider_mode.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 74
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (provider_mode) (tokenplace_relay_oldest_queued_request_age_seconds{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "legendFormat": "{{provider_mode}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "NO DATA",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 300
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 30,
+      "type": "timeseries",
+      "title": "In-flight requests by relay pod",
+      "description": "In-flight ownership is process-local, so future replicas remain separate per pod rather than being combined.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 74
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (pod) (tokenplace_relay_in_flight_requests{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "legendFormat": "{{pod}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 31,
+      "type": "timeseries",
+      "title": "Oldest in-flight age by relay pod",
+      "description": "In-flight ownership is process-local; maximum age is shown separately per relay pod.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 74
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (pod) (tokenplace_relay_oldest_in_flight_age_seconds{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "legendFormat": "{{pod}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "NO DATA",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 300
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 32,
+      "type": "timeseries",
+      "title": "Terminal outcome rate by outcome",
+      "description": "Summed process-local terminal outcome counter rate grouped only by bounded outcome.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 82
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (outcome) (rate(tokenplace_relay_request_outcomes_total{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"}[$__rate_interval]))",
+          "legendFormat": "{{outcome}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 33,
+      "type": "row",
+      "title": "token.place HTTP and release",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 90
+      },
+      "panels": []
+    },
+    {
+      "id": 34,
+      "type": "timeseries",
+      "title": "token.place HTTP request rate",
+      "description": "Summed process-local request rate grouped by normalized route and bounded status class.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 91
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (route, status_class) (rate(tokenplace_http_requests_total{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"}[$__rate_interval]))",
+          "legendFormat": "{{route}} {{status_class}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 35,
+      "type": "timeseries",
+      "title": "token.place HTTP 5xx ratio",
+      "description": "Ratio of 5xx requests to all requests. Missing counters remain NO DATA rather than becoming zero.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 91
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(tokenplace_http_requests_total{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\",status_class=\"5xx\"}[$__rate_interval])) / sum(rate(tokenplace_http_requests_total{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"}[$__rate_interval]))",
+          "legendFormat": "5xx ratio"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "noValue": "NO DATA",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 36,
+      "type": "timeseries",
+      "title": "token.place HTTP latency percentiles",
+      "description": "Histogram percentiles across relay pods, grouped only by normalized route.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 99
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.50, sum by (le, route) (rate(tokenplace_http_request_duration_seconds_bucket{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{route}}"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by (le, route) (rate(tokenplace_http_request_duration_seconds_bucket{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{route}}"
+        },
+        {
+          "refId": "C",
+          "expr": "histogram_quantile(0.99, sum by (le, route) (rate(tokenplace_http_request_duration_seconds_bucket{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{route}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 37,
+      "type": "table",
+      "title": "token.place build identity",
+      "description": "Safe release identity per relay pod: pod, version, and revision.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 99
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (pod, version, revision) (tokenplace_build_info{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "legendFormat": "{{pod}} {{version}} {{revision}}",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true
+            },
+            "indexByName": {
+              "pod": 0,
+              "version": 1,
+              "revision": 2
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -155,6 +155,57 @@ is not rollout evidence.
 - dChat and token.place dependency traffic may be absent until those features
   receive requests. Their queries deliberately fall back to zero: **no requests
   observed** is expected and is not an instrumentation failure.
+
+### token.place Phase 1 dashboard slice
+
+The two token.place rows use only metric families verified from the staging
+target with canonical `app=tokenplace`, `environment=staging`,
+`release=tokenplace`, `cluster=sugarkube-int`, and `namespace=tokenplace`
+labels:
+
+- **token.place relay and compute capacity** shows Prometheus scrape and
+  instrumentation health per relay pod; registered and healthy compute-node
+  counts; the oldest compute-node lease; eviction rate by bounded `reason`;
+  queue depth and oldest queued-request age by bounded `provider_mode`;
+  in-flight count and oldest age per relay pod; and terminal request rate by
+  bounded `outcome`.
+- **token.place HTTP and release** shows summed HTTP request rate by normalized
+  `route` and bounded `status_class`, the 5xx ratio, p50/p95/p99 latency from
+  histogram buckets, and build identity by `pod`, `version`, and `revision`.
+
+Logical shared gauges use `max` to deduplicate values that future relay replicas
+may repeat; they are never added together. In-flight gauges remain per pod
+because their ownership is process-local and aggregation across future replicas
+is not yet a safe operational contract. Process-local HTTP, outcome, and
+eviction counters use summed rates over Grafana's rate interval. Latency
+percentiles sum buckets by `le` and normalized route before calculating the
+quantile. Queries never group by raw scrape targets, instances, URLs, request or
+node identities, payloads, or credential-bearing labels.
+
+Every token.place panel displays a missing series as **NO DATA**. An emitted
+gauge value of zero remains zero, and initialized bounded outcome and eviction
+counters can report a real zero rate. The queries deliberately do not substitute
+zero for absent data. Health mappings distinguish healthy (`1`), unhealthy
+(`0`), and missing data.
+
+A successful encrypted staging request provided the Phase 1 evidence for this
+view: one registered and one healthy node; in-flight requests moving
+`0 → 1 → 0`; a maximum observed in-flight age of approximately `49.52s`;
+completed outcomes moving `1 → 2`; queue depth and queued age remaining zero;
+compute-node evictions remaining zero; and a maximum lease age of approximately
+`28.15s`. The live target was healthy with the canonical labels above. Observed
+outcome labels were the bounded `completed`, `cancelled`, `expired`, `timed_out`,
+`rate_limited`, `dependency_failure`, and `failed` values. This is staging
+evidence, not justification for alert thresholds.
+
+Repository support alone does not prove the provisioned dashboard is live.
+After merge, an operator must run the guarded staging Helm upgrade, verify the
+stable dashboard UID through the Grafana API with
+`just observability-dashboard-verify env=staging`, and visually inspect the
+rendered panels and their no-data behavior. Functional chat availability,
+schedulable-node capacity and availability reasons, and shared-state health
+remain Phase 2 work; this slice does not present placeholder metrics for them.
+
 - Grafana URL: `http://sugarkube3.local:30300`; the same NodePort is available through the other staging nodes.
 - Prometheus, Alertmanager, and administrative services remain ClusterIP-only.
 - No public ingress, public DNS, Cloudflare route, router forwarding, or public observability endpoint is part of this lifecycle.

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -25,12 +25,58 @@ REQUIRED_METRICS = {
     "probe_duration_seconds",
     "probe_http_status_code",
     "probe_ssl_earliest_cert_expiry",
+    "tokenplace_compute_nodes_registered",
+    "tokenplace_compute_nodes_healthy",
+    "tokenplace_compute_node_lease_age_seconds",
+    "tokenplace_compute_node_evictions_total",
+    "tokenplace_relay_queue_depth",
+    "tokenplace_relay_oldest_queued_request_age_seconds",
+    "tokenplace_relay_in_flight_requests",
+    "tokenplace_relay_oldest_in_flight_age_seconds",
+    "tokenplace_relay_request_outcomes_total",
+    "tokenplace_http_requests_total",
+    "tokenplace_http_request_duration_seconds_bucket",
+    "tokenplace_instrumentation_up",
+    "tokenplace_build_info",
 }
 EVENT_METRICS = {"dspace_dchat_requests_total", "dspace_dependency_requests_total"}
 OPERATIONAL_ROUTES = '"/(healthz|livez|metrics)"'
 BLACKBOX_JOB_MATCHER = (
     'job=~"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*"'
 )
+TOKENPLACE_SELECTOR_PARTS = {
+    'app="tokenplace"',
+    'environment=~"$environment"',
+    'release="tokenplace"',
+    'cluster="sugarkube-int"',
+    'namespace="tokenplace"',
+}
+TOKENPLACE_ROWS = {
+    "token.place relay and compute capacity",
+    "token.place HTTP and release",
+}
+TOKENPLACE_PANELS = {
+    "token.place scrape availability",
+    "token.place instrumentation health",
+    "Registered and healthy compute nodes",
+    "Oldest compute-node lease age",
+    "Compute-node eviction rate by reason",
+    "Relay queue depth by provider mode",
+    "Oldest queued-request age by provider mode",
+    "In-flight requests by relay pod",
+    "Oldest in-flight age by relay pod",
+    "Terminal outcome rate by outcome",
+    "token.place HTTP request rate",
+    "token.place HTTP 5xx ratio",
+    "token.place HTTP latency percentiles",
+    "token.place build identity",
+}
+PHASE_2_METRICS = {
+    "tokenplace_chat_availability",
+    "tokenplace_schedulable_node_capacity",
+    "tokenplace_availability_reason",
+    "tokenplace_shared_state_health",
+}
 
 
 def load_dashboard(path: Path) -> dict:
@@ -181,6 +227,97 @@ def validate_dashboard_semantics(dashboard: dict) -> None:
     if matrix.get("type") != "table" or not matrix.get("targets"):
         raise SystemExit("ERROR: dashboard must retain the detailed endpoint matrix.")
 
+    token_rows = [panel.get("title") for panel in panels(dashboard) if panel.get("type") == "row"]
+    if any(token_rows.count(title) != 1 for title in TOKENPLACE_ROWS):
+        raise SystemExit("ERROR: dashboard must contain each token.place Phase 1 row exactly once.")
+    token_panels = {title: panel_named(dashboard, title) for title in TOKENPLACE_PANELS}
+    token_targets = [
+        target
+        for panel in token_panels.values()
+        for target in panel.get("targets", [])
+        if isinstance(target, dict) and isinstance(target.get("expr"), str)
+    ]
+    if not token_targets or any(
+        not TOKENPLACE_SELECTOR_PARTS.issubset(
+            set(re.findall(r'\w+(?:=|=~)"[^"]+"', target["expr"]))
+        )
+        for target in token_targets
+    ):
+        raise SystemExit("ERROR: every token.place query must use the canonical target selector.")
+    expressions = [target["expr"] for target in token_targets]
+    if any("or vector(0)" in expr or "or on() vector(0)" in expr for expr in expressions):
+        raise SystemExit("ERROR: token.place missing data must not be converted to zero.")
+    if any(metric in "\n".join(expressions) for metric in PHASE_2_METRICS):
+        raise SystemExit("ERROR: token.place Phase 2 metrics must not be presented as implemented.")
+
+    logical_metrics = {
+        "tokenplace_compute_nodes_registered",
+        "tokenplace_compute_nodes_healthy",
+        "tokenplace_compute_node_lease_age_seconds",
+        "tokenplace_relay_queue_depth",
+        "tokenplace_relay_oldest_queued_request_age_seconds",
+    }
+    for metric in logical_metrics:
+        matching = [expr for expr in expressions if metric in expr]
+        if not matching or any("sum" in expr or "max" not in expr for expr in matching):
+            raise SystemExit(f"ERROR: logical gauge {metric} must use safe max deduplication.")
+    for metric, grouping in {
+        "tokenplace_compute_node_evictions_total": "reason",
+        "tokenplace_relay_request_outcomes_total": "outcome",
+    }.items():
+        matching = [expr for expr in expressions if metric in expr]
+        if not matching or any(
+            "sum by" not in expr
+            or f"({grouping})" not in expr
+            or "rate(" not in expr
+            or "[$__rate_interval]" not in expr
+            for expr in matching
+        ):
+            raise SystemExit(
+                f"ERROR: process-local counter {metric} must use a summed bounded rate."
+            )
+    http_rates = [expr for expr in expressions if "tokenplace_http_requests_total" in expr]
+    if not http_rates or any(
+        not re.search(r"sum(?: by \([^)]*\))?\s*\(rate\(", expr) for expr in http_rates
+    ):
+        raise SystemExit("ERROR: token.place HTTP counters must use summed rates.")
+    build = token_panels["token.place build identity"]
+    if not any(
+        "max by (pod, version, revision)" in target.get("expr", "")
+        and target.get("legendFormat") == "{{pod}} {{version}} {{revision}}"
+        for target in build.get("targets", [])
+    ):
+        raise SystemExit("ERROR: token.place build identity must remain per pod and release.")
+    unsafe_labels = {
+        "target",
+        "instance",
+        "url",
+        "request_id",
+        "node",
+        "prompt",
+        "output",
+        "authorization",
+        "bearer",
+        "cookie",
+        "credential",
+        "secret",
+        "token",
+        "user",
+    }
+    query_and_legends = "\n".join(
+        target["expr"] + "\n" + str(target.get("legendFormat", "")) for target in token_targets
+    )
+    if any(
+        re.search(rf"(?<![A-Za-z0-9_]){re.escape(label)}(?![A-Za-z0-9_])", query_and_legends)
+        for label in unsafe_labels
+    ):
+        raise SystemExit("ERROR: token.place queries and legends must not expose unsafe labels.")
+    if any(
+        panel.get("fieldConfig", {}).get("defaults", {}).get("noValue") != "NO DATA"
+        for panel in token_panels.values()
+    ):
+        raise SystemExit("ERROR: token.place panels must render missing series as NO DATA.")
+
 
 def validate_dashboard(path: Path) -> str:
     dashboard = load_dashboard(path)
@@ -193,6 +330,27 @@ def validate_dashboard(path: Path) -> str:
         or len(ids) != len(set(ids))
     ):
         raise SystemExit("ERROR: dashboard panel IDs must be present, integer, and unique.")
+    positioned = []
+    for panel in dashboard.get("panels", []):
+        grid = panel.get("gridPos", {})
+        if any(not isinstance(grid.get(key), int) for key in ("x", "y", "w", "h")):
+            raise SystemExit("ERROR: dashboard panels must have integer grid positions.")
+        if grid["x"] < 0 or grid["y"] < 0 or grid["w"] <= 0 or grid["h"] <= 0:
+            raise SystemExit("ERROR: dashboard panel grid positions must be positive and valid.")
+        if grid["x"] + grid["w"] > 24:
+            raise SystemExit("ERROR: dashboard panels must remain inside the 24-column grid.")
+        for other_title, other in positioned:
+            overlaps = not (
+                grid["x"] + grid["w"] <= other["x"]
+                or other["x"] + other["w"] <= grid["x"]
+                or grid["y"] + grid["h"] <= other["y"]
+                or other["y"] + other["h"] <= grid["y"]
+            )
+            if overlaps:
+                raise SystemExit(
+                    f"ERROR: dashboard panels {other_title!r} and {panel.get('title')!r} overlap."
+                )
+        positioned.append((panel.get("title"), grid))
     validate_dashboard_semantics(dashboard)
     expressions = [
         target["expr"]

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -54,6 +54,8 @@ def test_dashboard_identity_defaults_rows_and_required_panels(dashboard):
         "DSPACE runtime and release",
         "DSPACE feature traffic",
         "Blackbox monitoring",
+        "token.place relay and compute capacity",
+        "token.place HTTP and release",
     }
     titles = {panel["title"] for panel in panels}
     for title in (
@@ -73,6 +75,20 @@ def test_dashboard_identity_defaults_rows_and_required_panels(dashboard):
         "Probe duration",
         "HTTP response status",
         "TLS certificate lifetime",
+        "token.place scrape availability",
+        "token.place instrumentation health",
+        "Registered and healthy compute nodes",
+        "Oldest compute-node lease age",
+        "Compute-node eviction rate by reason",
+        "Relay queue depth by provider mode",
+        "Oldest queued-request age by provider mode",
+        "In-flight requests by relay pod",
+        "Oldest in-flight age by relay pod",
+        "Terminal outcome rate by outcome",
+        "token.place HTTP request rate",
+        "token.place HTTP 5xx ratio",
+        "token.place HTTP latency percentiles",
+        "token.place build identity",
     ):
         assert title in titles
 
@@ -98,8 +114,69 @@ def test_queries_use_stable_datasource_bounded_labels_and_safe_zero(dashboard):
     }
 
 
+def test_tokenplace_phase_one_query_contracts(dashboard):
+    token_panels = {
+        panel["title"]: panel
+        for panel in all_panels(dashboard)
+        if any("tokenplace_" in target.get("expr", "") for target in panel.get("targets", []))
+    }
+    expressions = [target["expr"] for panel in token_panels.values() for target in panel["targets"]]
+    required = {
+        "tokenplace_compute_nodes_registered",
+        "tokenplace_compute_nodes_healthy",
+        "tokenplace_compute_node_lease_age_seconds",
+        "tokenplace_compute_node_evictions_total",
+        "tokenplace_relay_queue_depth",
+        "tokenplace_relay_oldest_queued_request_age_seconds",
+        "tokenplace_relay_in_flight_requests",
+        "tokenplace_relay_oldest_in_flight_age_seconds",
+        "tokenplace_relay_request_outcomes_total",
+        "tokenplace_http_requests_total",
+        "tokenplace_http_request_duration_seconds_bucket",
+        "tokenplace_instrumentation_up",
+        "tokenplace_build_info",
+    }
+    assert all(any(metric in expression for expression in expressions) for metric in required)
+    canonical = (
+        'app="tokenplace",environment=~"$environment",release="tokenplace",'
+        'cluster="sugarkube-int",namespace="tokenplace"'
+    )
+    assert all(canonical in expression for expression in expressions)
+    assert not any("vector(0)" in expression for expression in expressions)
+    assert all(
+        panel["fieldConfig"]["defaults"]["noValue"] == "NO DATA" for panel in token_panels.values()
+    )
+    assert (
+        "sum by (reason) (rate("
+        in token_panels["Compute-node eviction rate by reason"]["targets"][0]["expr"]
+    )
+    assert (
+        "sum by (outcome) (rate("
+        in token_panels["Terminal outcome rate by outcome"]["targets"][0]["expr"]
+    )
+    assert all(
+        "[$__rate_interval]" in expression
+        for expression in expressions
+        if "_total" in expression or "_bucket" in expression
+    )
+    assert "max by (pod)" in token_panels["In-flight requests by relay pod"]["targets"][0]["expr"]
+    assert (
+        "max by (pod, version, revision)"
+        in token_panels["token.place build identity"]["targets"][0]["expr"]
+    )
+    assert (
+        "histogram_quantile"
+        in token_panels["token.place HTTP latency percentiles"]["targets"][0]["expr"]
+    )
+
+
 def test_snapshot_tables_use_instant_queries(dashboard):
-    snapshots = {"Endpoint matrix", "Build identity", "HTTP response status"}
+    snapshots = {
+        "Endpoint matrix",
+        "Build identity",
+        "HTTP response status",
+        "token.place build identity",
+    }
     panels = {panel["title"]: panel for panel in all_panels(dashboard)}
     for title in snapshots:
         assert panels[title]["targets"]
@@ -493,6 +570,52 @@ def test_validator_directly_rejects_unsafe_dashboard_sources(
 ):
     candidate = tmp_path / "candidate.json"
     mutation(dashboard)
+    candidate.write_text(json.dumps(dashboard), encoding="utf-8")
+    with pytest.raises(SystemExit, match=message):
+        validator.validate_dashboard(candidate)
+
+
+@pytest.mark.parametrize(
+    ("title", "replacement", "message"),
+    [
+        (
+            "Registered and healthy compute nodes",
+            'sum(tokenplace_compute_nodes_registered{app="tokenplace"})',
+            "canonical target selector",
+        ),
+        (
+            "Compute-node eviction rate by reason",
+            'rate(tokenplace_compute_node_evictions_total{app="tokenplace"}[5m])',
+            "canonical target selector",
+        ),
+        (
+            "Terminal outcome rate by outcome",
+            'sum(rate(tokenplace_relay_request_outcomes_total{app="tokenplace",environment=~'
+            '"$environment",release="tokenplace",cluster="sugarkube-int",namespace="tokenplace"}'
+            "[$__rate_interval])) or vector(0)",
+            "converted to zero",
+        ),
+        (
+            "token.place HTTP request rate",
+            'sum by (instance) (rate(tokenplace_http_requests_total{app="tokenplace",environment=~'
+            '"$environment",release="tokenplace",cluster="sugarkube-int",namespace="tokenplace"}'
+            "[$__rate_interval]))",
+            "unsafe labels",
+        ),
+        (
+            "token.place HTTP latency percentiles",
+            'tokenplace_shared_state_health{app="tokenplace",environment=~"$environment",'
+            'release="tokenplace",cluster="sugarkube-int",namespace="tokenplace"}',
+            "Phase 2 metrics",
+        ),
+    ],
+)
+def test_validator_rejects_tokenplace_query_regressions(
+    tmp_path, dashboard, title, replacement, message
+):
+    panel = next(panel for panel in dashboard["panels"] if panel["title"] == title)
+    panel["targets"][0]["expr"] = replacement
+    candidate = tmp_path / "tokenplace-regression.json"
     candidate.write_text(json.dumps(dashboard), encoding="utf-8")
     with pytest.raises(SystemExit, match=message):
         validator.validate_dashboard(candidate)


### PR DESCRIPTION
### Motivation

- Provide a focused Phase 1 operational view for token.place in the existing Sugarkube Staging Observability dashboard using only metrics already present and verified live in staging. 
- Surface relay- and compute-side capacity, in-flight/queue state, terminal outcomes, HTTP traffic, latency histograms, and per-pod build identity while preserving existing dashboard, DSPACE, and blackbox contracts. 
- Enforce safe aggregation, bounded labels, and explicit missing-data semantics so future replicas and sensitive labels are not misrepresented.

### Description

- Added a token.place slice to `clusters/staging/observability/dashboards/sugarkube-staging-observability.json` with two new rows and panels for scrape/instrumentation health, registered/healthy node counts, lease age, eviction rates by `reason`, queue depth and queued age by `provider_mode`, per-pod in-flight counts and ages, terminal outcome rates by `outcome`, HTTP rate by `route`+`status_class`, 5xx ratio, latency percentiles using `histogram_quantile` over bucket sums, and per-pod `tokenplace_build_info` identity. 
- Extended the fail-closed validator in `scripts/validate_observability_dashboard.py` to require all Phase 1 token.place metric families, enforce the canonical target selector, prohibit unsafe/sensitive labels and Phase 2 metrics, require safe max-deduplication for logical gauges, require summed `rate(...)` for counters, and validate unique integer panel IDs and non-overlapping 24-column grid positions. 
- Added regression tests in `tests/test_observability_dashboard.py` to assert the new rows/panels exist, PromQL contract (selectors, grouping, rate interval, histogram buckets), per-pod semantics for process-local gauges, no substitution of missing series to zero, and Phase 2 exclusion. 
- Documented panel meanings, aggregation and no-data behavior, and the successful encrypted staging request evidence in `docs/observability-operations.md` while preserving the dashboard UID, datasource UID, provisioning path, and other repository contracts.

### Testing

- `python3 scripts/validate_observability_dashboard.py clusters/staging/observability/dashboards/sugarkube-staging-observability.json` — PASS. 
- `pytest -q tests/test_observability_dashboard.py` — PASS (60 passed). 
- `pytest -q tests/test_observability_dashboard.py tests/test_observability_helm.py` — PASS (244 passed). 
- `pyspelling -c .spellcheck.yaml` — PASS, and `linkchecker --no-warnings README.md docs/` — PASS (no link errors). 
- `pre-commit run --all-files` — WARNING: repository-wide YAML and lint issues outside this focused four-file change blocked the full run, but focused formatting hooks and whitespace/end-of-file fixes for the touched files passed. 
- `just observability-render env=staging` / offline Helm render — NOT RUN because `just`/Helm were unavailable in this environment; no cluster was contacted or mutated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7613ba9194832f839b167020ab505e)