### PR TITLE
docs: record completed DSPACE staging verification

### DIFF
--- a/docs/observability-alerting.md
+++ b/docs/observability-alerting.md
@@ -8,7 +8,8 @@ a human. The secret-file-backed synthetic Alertmanager → PagerDuty path has no
 through fire, phone receipt, acknowledgement, and resolution. The host-heartbeat timers are installed
 on `sugarkube3`, `sugarkube4`, and `sugarkube5`. The watchdog configuration and operator workflows
 are repository-ready, while their Secret installation, deployment, and live delivery proof remain
-post-merge work. Only the explicitly allowlisted staging workload routes described below are repository-ready; deployment and live delivery proof remain operator prerequisites.
+post-merge work. Separately, the five explicitly allowlisted DSPACE alerts are deployed in staging;
+all five are healthy, and a three-alert owner-scoped drill proved live delivery and resolution.
 
 ## 1. Goals and non-goals
 
@@ -29,7 +30,8 @@ post-merge work. Only the explicitly allowlisted staging workload routes describ
 - Production alert rollout. This document designs the staging path first; production follows only
   after staging drills succeed (see [`docs/observability-design.md`](./observability-design.md) §13).
 - Advanced SLOs, burn-rate alerting, or multi-window error budgets.
-- Exhaustive application-level synthetic checks. The repository now defines the bounded producer/consumer contract for `DspaceChatSyntheticFailed`; an externally pinned runner and live scheduling remain prerequisites.
+- Exhaustive application-level synthetic checks beyond the bounded `DspaceChatSyntheticFailed`
+  contract. Its externally pinned runner and live five-minute staging schedule are now proven.
 
 ## 2. Chosen target architecture
 
@@ -155,7 +157,7 @@ These are the current alert-design candidates, not proof the rules already exist
 | `PublicEndpointDown` | A blackbox probe's `probe_success` is 0 | Reuses the signal already defined in [`docs/observability-design.md`](./observability-design.md) §6/§11. |
 | `PublicProbeMissing` | An expected blackbox probe target has no recent data at all (distinct from a probe that ran and failed) | Matches the "missing probe data" state already surfaced in the staging dashboard's availability summary panel. |
 | `TLSExpiringSoon` | `probe_ssl_earliest_cert_expiry` crosses a warning/critical threshold | Reuses the signal already defined in [`docs/observability-design.md`](./observability-design.md) §6. |
-| `DspaceChatSyntheticFailed` | An isolated, non-mutating `/chat` result fails or becomes stale | Repository-ready; the pinned external runner, scheduler, deployment, and live drill remain operational prerequisites. |
+| `DspaceChatSyntheticFailed` | An isolated, non-mutating `/chat` result fails or becomes stale | Deployed in staging; its pinned five-minute producer is fresh, and the owner-scoped live drill proved firing and resolved delivery. |
 
 ## 6. Rollout and drill plan
 
@@ -188,7 +190,9 @@ A safe, phased sequence — each step depends on the previous one succeeding:
     gaps and detection latency; fail the drill if a healthy gap exceeds the configured period.
 12. Add custom application and blackbox alerts one at a time, each with its own drill before the next
     is added.
-13. Install and schedule the reviewed, immutable external `/chat` smoke runner, then execute the bounded staging drills in the [release-integrity runbook](./observability-dspace-release-integrity.md).
+13. **Proven in staging:** the reviewed, immutable external `/chat` smoke runner is installed on the
+    trusted operator host and scheduled every five minutes; the bounded drill and exact cleanup are
+    recorded in the [release-integrity runbook](./observability-dspace-release-integrity.md#completed-staging-verification).
 
 Rollback and noise control:
 
@@ -215,12 +219,22 @@ Rollback and noise control:
 
 PagerDuty plus an externally hosted Healthchecks.io is the preferred initial direction because it is
 the only combination here that gives both an acknowledgeable phone workflow *and* a dead-man path that
-survives the monitoring stack's own node going down. Nothing about this preference implies any part of
-it is deployed yet — see the rollout plan above for the actual sequencing.
+survives the monitoring stack's own node going down. Deployment state varies by path: the DSPACE
+five-alert staging route and synthetic PagerDuty path are proven, while the node-power-off and
+watchdog work remains sequenced above. No production deployment is implied.
 
 ## 8. Status and dependencies
 
-- `DspaceChatSyntheticFailed` rules and the bounded textfile producer/consumer contract are repository-ready. Selecting, pinning, installing, and scheduling the external isolated smoke runner, deploying the rules, and completing the live drill remain operational prerequisites.
+- [Sugarkube PR #2501](https://github.com/futuroptimist/sugarkube/pull/2501) supplied the
+  version-controlled DSPACE alert/runbook support, and
+  [DSPACE PR #4806](https://github.com/democratizedspace/dspace/pull/4806) supplied the bounded
+  producer contract at runner revision `92dad0cba4414aa111fd78bf03607c0aacc4043e`. The five-alert
+  route and five-minute producer are deployed in staging; all five alerts are loaded and healthy.
+  The owner-scoped three-alert drill proved Prometheus firing, Alertmanager active state, PagerDuty
+  phone delivery, acknowledgement, resolved delivery, and exact cleanup. See the
+  [sanitized verification record](./observability-dspace-release-integrity.md#completed-staging-verification).
+  This completes the staging proof tracked by
+  [issue #2329](https://github.com/futuroptimist/sugarkube/issues/2329), not a production rollout.
 - Shallow public-endpoint blackbox monitoring (`PublicEndpointDown`, `PublicProbeMissing`,
   `TLSExpiringSoon`) is already live in staging today, independently of that dependency — see
   [`docs/observability-blackbox.md`](./observability-blackbox.md).

--- a/docs/observability-dspace-release-integrity.md
+++ b/docs/observability-dspace-release-integrity.md
@@ -1,9 +1,11 @@
 # DSPACE release-integrity alerting and synthetic runbook
 
-This repository defines the staging rules and PagerDuty route for issue #2329. It does **not**
-prove that Helm has deployed them or that PagerDuty has delivered them. Production labels are part
-of the contract tests, but production observability installation and all production mutation remain
-unsupported. The approved staging coordinate is derived from
+[Sugarkube issue #2329](https://github.com/futuroptimist/sugarkube/issues/2329) tracks this
+staging proof. [Sugarkube PR #2501](https://github.com/futuroptimist/sugarkube/pull/2501) merged the
+version-controlled rules, PagerDuty route, dashboard section, synthetic metric consumer, tests, and
+runbooks. The five-alert route is deployed and live-proven in staging as recorded below. Production
+labels are part of the contract tests, but production observability installation, live testing, and
+all production mutation remain unsupported. The approved staging coordinate is derived from
 [`main-018687f-20260805T035722Z.json`](../deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json);
 the production contract is checked against
 [`main-1a31a56-20260801T093443Z.json`](../deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json).
@@ -68,13 +70,17 @@ python3 scripts/dspace_chat_synthetic_metrics.py \
 Verify both metrics in Prometheus and check timestamp age. A malformed result leaves the prior file
 untouched, which becomes stale and alerts. Roll back by disabling only this scheduler and removing
 only `dspace-chat.prom`; the missing-series branch deliberately continues to alert until the route
-is removed or a valid producer is restored. Remaining live prerequisite: select, review, pin,
-install, and schedule a DSPACE-owned runner that implements the exact isolated contract above.
+is removed or a valid producer is restored. The trusted staging operator host runs one enabled
+five-minute systemd producer, pinned to DSPACE runner revision
+`92dad0cba4414aa111fd78bf03607c0aacc4043e`. That bounded result-file producer contract merged in
+[DSPACE PR #4806](https://github.com/democratizedspace/dspace/pull/4806). Prometheus ingests fresh
+`dspace_chat_synthetic_success` and `dspace_chat_synthetic_timestamp_seconds` series.
 
 ## Staging post-merge drills
 
-Do **not** run these commands as part of repository validation and do not change DSPACE. An operator
-may run this copy-pasteable drill later with the repository-standard `sugar-staging` context. The
+Do **not** run these commands as part of repository validation and do not change DSPACE. This
+reusable, copy-pasteable procedure was used for the completed proof and may be run for future
+regression testing with the repository-standard `sugar-staging` context. The
 Prometheus `cluster="sugarkube-int"` value is a metric label, not a kubectl context.
 
 ```bash
@@ -151,9 +157,29 @@ exposes both bounded series. During the drill compare unrelated alerts and confi
 the null root. After exact-name cleanup, confirm PagerDuty receives a resolved event for every
 firing incident and record timestamps without credentials or payload data.
 
-Rollback consists of disabling the single producer schedule, removing only `dspace-chat.prom`, and
-reverting this staging observability release; removal of the producer alone intentionally makes the
-missing-result state fire. Repository-ready rules and documentation are not evidence of Helm
-deployment, collector installation, runner scheduling, PagerDuty delivery, or operational proof.
-All those live staging prerequisites remain before #2329 can close. No production deployment or
-route is provided or claimed.
+## Completed staging verification
+
+The sanitized operational record for the completed staging proof is:
+
+- Staging `kube-prometheus-stack` is healthy at Helm revision 8 on chart `87.19.0`. Revision 8, its
+  live ConfigMap, and current repository `main` contain the same 44-panel dashboard; the canonical
+  JSON SHA-256 is `59cb188e015574a50a703c5000128d446896b1526f2d9fed9f7dde4ade32717b`.
+- DSPACE remained healthy and unchanged at Helm revision 28, application version `3.1.0`, and source
+  revision `018687f5a7f4de45508c6e36eb28afb3e44da24d`.
+- All five canonical alerts were installed, loaded by Prometheus, healthy, and inactive in the
+  healthy steady state. The owner-scoped drill `dspace-2329-20260808T051818Z-1053` deliberately
+  fired only `DspaceBuildRevisionMismatch`, `DspaceMixedBuildRevisions`, and
+  `DspaceChatSyntheticFailed`.
+- All three drill alerts reached firing in Prometheus and active state in Alertmanager. PagerDuty
+  delivery to the configured iPhone receiver, manual acknowledgement, and resolved delivery were
+  confirmed without recording credentials, routing keys, or payload bodies.
+- The exact temporary PrometheusRule was deleted by name and owner. After cleanup, the drill rule
+  and alerts were absent, canonical observability verification passed, observability remained at
+  revision 8, and DSPACE remained at revision 28.
+- No production cluster, Helm release, or workload was accessed or changed.
+
+Keep operator-local captures out of Git; this bounded, non-secret record is the shareable
+verification evidence. Rollback remains disabling the single producer schedule, removing only
+`dspace-chat.prom`, and reverting the staging observability release; removal of the producer alone
+intentionally makes the missing-result state fire. No production deployment or route is provided
+or claimed.

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -197,16 +197,15 @@ health panels remain Phase 2 work and are not presented as implemented here.
   `"null"`. The existing watchdog route, its order, and its 30-second group wait,
   one-minute group interval, and five-minute repeat interval remain preserved.
   The exact-label `SugarkubePagerDutyTest` route is deployed and has passed its
-  manual fire/acknowledge/resolve delivery drill. Separately, the repository is
-  ready to route exactly `DspaceBuildRevisionMismatch`,
-  `DspaceMixedBuildRevisions`, `DspaceDeploymentImagePinMismatch`,
-  `DspaceChatSyntheticFailed`, and `DspaceMetricsTargetDown` to
-  `pagerduty-dspace`. That five-alert route is not yet deployed or live-proven.
-  Its receiver uses the existing Secret-mounted PagerDuty integration and
-  `send_resolved: true`; unrelated alerts continue to fall through to `"null"`.
-  Deployment, collector/runner setup, and firing/resolved drill prerequisites
-  remain in the focused
-  [DSPACE release-integrity runbook](observability-dspace-release-integrity.md).
+  manual fire/acknowledge/resolve delivery drill. The deployed DSPACE allowlist routes exactly
+  `DspaceBuildRevisionMismatch`, `DspaceMixedBuildRevisions`,
+  `DspaceDeploymentImagePinMismatch`, `DspaceChatSyntheticFailed`, and
+  `DspaceMetricsTargetDown` to `pagerduty-dspace`. All five are loaded, healthy, and inactive in
+  steady state; the owner-scoped staging drill deliberately fired three and proved phone delivery,
+  acknowledgement, resolution, and exact cleanup. Its receiver uses the existing Secret-mounted
+  PagerDuty integration and `send_resolved: true`; unrelated alerts continue to
+  fall through to `"null"`. See the
+  [DSPACE release-integrity verification record](observability-dspace-release-integrity.md#completed-staging-verification).
 - Grafana: persistence disabled, no Ingress, LAN-only NodePort `30300`.
 - The provisioned dashboard defaults to six hours and a 30-second refresh. Its
   top-level public availability summary reports **Healthy endpoints**, **Failed
@@ -322,9 +321,9 @@ five minutes. Retain the procedure below for regression drills.
 
    Confirm the validator reports the exact synthetic route, the exact five-alert
    DSPACE allowlist, file references, and Secret mount contract; remove the
-   temporary render after review. This validates repository structure only; use
-   the focused [DSPACE release-integrity runbook](observability-dspace-release-integrity.md)
-   for the remaining deployment and live firing/resolved drill prerequisites.
+   temporary render after review. This validates repository structure only; the completed DSPACE
+   deployment and live firing/resolved proof are recorded in the focused
+   [DSPACE release-integrity runbook](observability-dspace-release-integrity.md#completed-staging-verification).
 4. Upgrade and verify:
 
    ```bash
@@ -458,6 +457,15 @@ revision restores its dashboard ConfigMap; after a forward fix, the standard
 upgrade lifecycle again supplies the complete values chain and dashboard file.
 
 ## Manually verified staging observations
+
+The DSPACE #2329 verification established a healthy staging `kube-prometheus-stack` Helm revision 8
+using chart `87.19.0`. Its live ConfigMap and repository `main` matched the same 44-panel dashboard
+at canonical JSON SHA-256
+`59cb188e015574a50a703c5000128d446896b1526f2d9fed9f7dde4ade32717b`. DSPACE stayed healthy and
+unchanged at Helm revision 28, application version `3.1.0`, and source revision
+`018687f5a7f4de45508c6e36eb28afb3e44da24d`. The complete sanitized alert and cleanup record is in
+the [DSPACE release-integrity runbook](observability-dspace-release-integrity.md#completed-staging-verification).
+This is staging evidence only; no production observability deployment or live test is claimed.
 
 The reprovisioning proof above is scripted and repeatable: `observability-dashboard-verify` is the
 acceptance evidence, and it runs the same way every time. The following two observations are not

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -468,7 +468,9 @@ def test_operations_runbook_describes_dspace_operator_contract():
 
     assert "SugarkubePagerDutyTest" in operations
     assert "deployed and has passed" in operations
-    assert "That five-alert route is not yet deployed or live-proven" in operations
+    assert "The deployed DSPACE allowlist routes exactly" in operations
+    assert "All five are loaded, healthy, and inactive" in operations
+    assert "owner-scoped staging drill deliberately fired three" in operations
     assert "pagerduty-dspace" in operations
     assert "send_resolved: true" in operations
     assert 'fall through to `"null"`' in operations


### PR DESCRIPTION
### Motivation

- Update the DSPACE runbooks and operator-facing status prose to reflect the completed staging deployment and owner-scoped live firing/resolve drill so issue tracking can be closed after manual verification is acknowledged. Refs #2329.
- Record the precise, non-secret verification facts (merged repo support, DSPACE producer revision, Helm/chart/revision/dashboard checksum, alerts installed and their drill outcome) while continuing to avoid any claim of production rollout.

### Description

- Revise `docs/observability-dspace-release-integrity.md` to record Sugarkube PR #2501, DSPACE PR #4806, the pinned five-minute systemd producer at runner revision `92dad0cba4414aa111fd78bf03607c0aacc4043e`, fresh Prometheus series ingestion, and add a sanitized "Completed staging verification" section with the canonical facts (Helm revisions, dashboard SHA-256, alerts and drill cleanup).
- Update `docs/observability-operations.md` to cite the completed DSPACE staging verification and to add the short, shareable staging observation block describing Helm revision 8 / chart `87.19.0`, the 44-panel dashboard checksum `59cb188e015574a50a703c5000128d446896b1526f2d9fed9f7dde4ade32717b`, and DSPACE revision 28 state.
- Update `docs/observability-alerting.md` to mark the five-alert DSPACE allowlist as deployed and healthy in staging and note that an owner-scoped three-alert drill proved firing, Alertmanager active state, PagerDuty phone delivery, acknowledgement, resolution, and exact PrometheusRule cleanup while preserving the separation from any production rollout.
- Make a small corresponding test update in `tests/test_observability_helm.py` to reflect the new operations-runbook assertions; no behavioral code, Helm values, rules, dashboards, or cluster resources were changed.
- Keep the reusable owner-scoped drill procedure and rollback instructions unchanged and explicitly warn to keep operator-local captures out of Git.

Files changed:
- `docs/observability-dspace-release-integrity.md`
- `docs/observability-operations.md`
- `docs/observability-alerting.md`
- `tests/test_observability_helm.py`

### Testing

- Ran `git diff --check` and it passed.
- Ran focused unit tests: `pytest -q tests/test_observability_helm.py::test_operations_runbook_describes_dspace_operator_contract tests/test_dspace_observability_alerts.py` which passed (17 tests total reported as passing).
- Ran `linkchecker --no-warnings README.md docs/` which completed with `208 links checked, 0 errors`.
- Ran `git diff --cached | ./scripts/scan-secrets.py` against the staged diff and it passed (no secrets committed).
- `pyspelling -c .spellcheck.yaml` could not complete in this environment due to the missing `aspell` binary (warning recorded; no doc text was intentionally added that appears to break spelling rules).
- `pre-commit run --all-files` was attempted but could not be fully completed in this session because the repository contains unrelated, pre-existing YAML/Python lint issues across many files; unrelated automatic whitespace fixes produced by hooks were reverted and only the documented files and the single test file were committed.

Notes and residual risks:
- This PR is documentation-only and does not mutate Helm releases, Kubernetes resources, Prometheus rules, Alertmanager routing, dashboards, scripts, workflows, or any secrets.
- The commit is intentionally minimal and constrained to the runbooks and one test assertion so the repo checks relevant to these docs can run; broader repository linters revealed unrelated pre-existing issues that are out of scope for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76c1450d68832f9713e6bbbefb7b38)