### PR TITLE
Fix production Grafana Secret bootstrap: guarded TTY install/check, docs and tests

### DIFF
--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -78,16 +78,20 @@ test "$(kubectl config current-context)" = sugar-prod
 python3 scripts/cluster_identity.py assert --kubeconfig "$KUBECONFIG" --env prod
 ```
 
-Before a first install, create `monitoring` and apply only the existing SOPS
-declaration `clusters/prod/secrets/grafana-admin.enc.yaml`. Do not reconcile the
-full production overlay: it also contains observability resources whose CRDs do
-not exist until the core stack is installed. With the production context and
-identity checks above still in effect, use a configured SOPS age key and stream
-the decrypted manifest directly to the API without writing it to disk:
+The checked-in production Grafana Secret declaration and the example age
+recipient are scaffolding, not live, deployable ciphertext. **Do not decrypt or
+apply that file, and do not reconcile the full production overlay**: the overlay
+also contains resources whose CRDs do not exist until the core stack is installed.
+
+Generate and store the username and password in the operator's password manager,
+then enter them only through the guarded hidden-TTY lifecycle. The install recipe
+checks the explicit kubeconfig, `sugar-prod` context, and production cluster
+identity before reading input; it then creates `monitoring` idempotently and
+installs or intentionally rotates only the Grafana Secret:
 
 ```bash
-kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
-sops --decrypt clusters/prod/secrets/grafana-admin.enc.yaml | kubectl apply -f -
+just observability-grafana-secret-install env=prod
+just observability-grafana-secret-check env=prod
 ```
 
 The declaration creates
@@ -96,7 +100,8 @@ The declaration creates
 - Username key: `admin-user`.
 - Password key: `admin-password`.
 
-Both keys must be nonempty. Do not decrypt or print them during preflight. The Helm
+Both keys must be nonempty. The check recipe verifies only that key contract and
+never returns either value. Do not decrypt or print credentials during preflight. The Helm
 helper checks only that the Secret and both keys exist and are nonempty.
 
 After merge, an operator should capture deployment evidence in this order:
@@ -128,6 +133,11 @@ capacity. The custom production dashboard is deferred until live stack metric
 families and labels are inventoried. Application panels and metrics lifecycle,
 blackbox monitoring, alerts, paging, HA, and persistent Grafana UI state are
 also explicitly deferred.
+
+After this correction merges, the next operator sequence is a production render,
+a fresh core-stack install, core verification and status, and a sanitized live
+Prometheus inventory. Neither this PR nor PR #2529 proves a production deployment
+or a custom production dashboard.
 
 ## Read-only preflight and status
 
@@ -318,7 +328,9 @@ health panels remain Phase 2 work and are not presented as implemented here.
 - **Context mismatch:** helper exits before mutation and prints the expected `sugar-staging` context. Rerun `just kubeconfig-env env=staging`.
 - **Missing CRDs:** `observability-verify` fails on Prometheus Operator CRD checks; render/install/upgrade the pinned chart rather than applying Flux CRDs manually.
 - **Unbound PVC:** verify `kubectl -n monitoring get pvc` shows `Bound` and storage class `local-path`; investigate local-path provisioner and node disk health without pinning Prometheus to a node in Git.
-- **Missing Grafana Secret:** create or repair the operator-managed `grafana-admin-credentials` Secret out of band without committing values.
+- **Missing Grafana Secret:** install or rotate it with
+  `just observability-grafana-secret-install env=prod`, then check the redacted
+  key contract with `just observability-grafana-secret-check env=prod`.
 - **Dashboard API verification:** `just observability-dashboard-verify
   env=staging` checks the stable UID through Grafana's API. It validates context
   and cluster identity first, reads the existing Secret without printing it,

--- a/justfile
+++ b/justfile
@@ -3476,6 +3476,14 @@ observability-verify env='':
 observability-dashboard-verify env='':
     @scripts/observability_helm.sh dashboard-verify '{{ env }}'
 
+# Interactively install or rotate the Grafana admin credentials (hidden TTY input).
+observability-grafana-secret-install env='':
+    @scripts/observability_helm.sh grafana-secret-install '{{ env }}'
+
+# Check the Grafana admin Secret key contract without reading either value.
+observability-grafana-secret-check env='':
+    @scripts/observability_helm.sh grafana-secret-check '{{ env }}'
+
 # Explicitly fire or resolve the staging-only synthetic PagerDuty alert (manual only).
 observability-pagerduty-test env='' action='':
     @scripts/observability_helm.sh pagerduty-test '{{ env }}' '{{ action }}'

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -24,7 +24,7 @@ ENVIRONMENT=""
 ENV_VALUES=""
 EXPECTED_CONTEXT=""
 
-usage() { echo "Usage: $0 <render|install|upgrade|status|verify|dashboard-verify|pagerduty-test|watchdog-secret-install|watchdog-secret-check|watchdog-verify|watchdog-drill-create|watchdog-drill-status|watchdog-drill-clear> env=<staging|prod> [fire|resolve]" >&2; }
+usage() { echo "Usage: $0 <render|install|upgrade|status|verify|dashboard-verify|grafana-secret-install|grafana-secret-check|pagerduty-test|watchdog-secret-install|watchdog-secret-check|watchdog-verify|watchdog-drill-create|watchdog-drill-status|watchdog-drill-clear> env=<staging|prod> [fire|resolve]" >&2; }
 normalize_env() {
   local raw="${1:-}"
   while [[ "${raw}" == env=* ]]; do raw="${raw#env=}"; done
@@ -146,6 +146,41 @@ assert_grafana_secret() {
   fi
   echo "Grafana admin Secret contract exists (values intentionally not read or printed)."
 }
+
+GRAFANA_TTY="${SUGARKUBE_GRAFANA_TTY:-/dev/tty}"
+grafana_secret_check() { assert_context; assert_grafana_secret; }
+grafana_secret_install() (
+  local grafana_user="" grafana_password="" grafana_confirmation=""
+  trap 'unset grafana_user grafana_password grafana_confirmation' EXIT INT TERM
+  assert_context
+  [[ $- != *x* ]] || { echo "ERROR: shell xtrace is refused for credential input." >&2; return 2; }
+  [[ ! -v GRAFANA_ADMIN_USER && ! -v GRAFANA_ADMIN_PASSWORD && ! -v GF_SECURITY_ADMIN_USER && ! -v GF_SECURITY_ADMIN_PASSWORD ]] || { echo "ERROR: Grafana credential environment variables are refused." >&2; return 2; }
+  [[ $# == 0 ]] || { echo "ERROR: credential arguments are refused." >&2; return 2; }
+  exec 3<"${GRAFANA_TTY}"
+  [[ "${SUGARKUBE_GRAFANA_TEST_NONTTY:-0}" == 1 || -t 3 ]] || { echo "ERROR: an interactive controlling terminal is required." >&2; return 2; }
+  printf 'Enter the Grafana admin username (input hidden): ' >&2
+  IFS= read -r -s grafana_user <&3 || { echo "ERROR: could not read Grafana credentials (values redacted)." >&2; return 2; }
+  printf '\nEnter the Grafana admin password (input hidden): ' >&2
+  IFS= read -r -s grafana_password <&3 || { echo "\nERROR: could not read Grafana credentials (values redacted)." >&2; return 2; }
+  printf '\nConfirm the Grafana admin password (input hidden): ' >&2
+  IFS= read -r -s grafana_confirmation <&3 || { echo "\nERROR: could not read Grafana credentials (values redacted)." >&2; return 2; }
+  printf '\n' >&2
+  [[ -n "${grafana_user}" && -n "${grafana_password}" ]] || { echo "ERROR: Grafana username and password must both be nonempty (values redacted)." >&2; return 2; }
+  [[ "${grafana_password}" == "${grafana_confirmation}" ]] || { echo "ERROR: Grafana password confirmation does not match (values redacted)." >&2; return 2; }
+
+  if ! kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f - >/dev/null; then
+    echo "ERROR: monitoring Namespace creation failed (credentials redacted)." >&2; return 1
+  fi
+  exec 4< <(printf '%s' "${grafana_user}")
+  exec 5< <(printf '%s' "${grafana_password}")
+  if ! kubectl -n "${NAMESPACE}" create secret generic "${GRAFANA_SECRET}" --from-file=admin-user=/dev/fd/4 --from-file=admin-password=/dev/fd/5 --dry-run=client -o yaml | kubectl apply -f - >/dev/null; then
+    exec 4<&- 5<&-
+    echo "ERROR: Grafana admin Secret installation failed (values redacted)." >&2; return 1
+  fi
+  exec 4<&- 5<&-
+  unset grafana_user grafana_password grafana_confirmation
+  echo "Grafana admin Secret installed or rotated (values not displayed)."
+)
 
 release_state() {
   local matches
@@ -795,4 +830,4 @@ if [[ "${cmd}" == watchdog-drill-create ]]; then
   trap 'exit 130' INT
   trap 'exit 143' TERM
 fi
-case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) require_staging "dashboard-verify"; dashboard_verify ;; pagerduty-test) require_staging "pagerduty-test"; pagerduty_test "${2:-${1:-}}" ;; watchdog-secret-install) require_staging "watchdog-secret-install"; watchdog_secret_install "${@:2}" ;; watchdog-secret-check) require_staging "watchdog-secret-check"; watchdog_secret_check ;; watchdog-verify) require_staging "watchdog-verify"; watchdog_live_check ;; watchdog-drill-create) require_staging "watchdog-drill-create"; watchdog_silence_create ;; watchdog-drill-status) require_staging "watchdog-drill-status"; watchdog_silence_list ;; watchdog-drill-clear) require_staging "watchdog-drill-clear"; watchdog_silence_clear ;; *) usage; exit 2 ;; esac
+case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) require_staging "dashboard-verify"; dashboard_verify ;; grafana-secret-install) grafana_secret_install "${@:2}" ;; grafana-secret-check) grafana_secret_check ;; pagerduty-test) require_staging "pagerduty-test"; pagerduty_test "${2:-${1:-}}" ;; watchdog-secret-install) require_staging "watchdog-secret-install"; watchdog_secret_install "${@:2}" ;; watchdog-secret-check) require_staging "watchdog-secret-check"; watchdog_secret_check ;; watchdog-verify) require_staging "watchdog-verify"; watchdog_live_check ;; watchdog-drill-create) require_staging "watchdog-drill-create"; watchdog_silence_create ;; watchdog-drill-status) require_staging "watchdog-drill-status"; watchdog_silence_list ;; watchdog-drill-clear) require_staging "watchdog-drill-clear"; watchdog_silence_clear ;; *) usage; exit 2 ;; esac

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -725,6 +725,8 @@ def run_helper(
     watchdog_silence_mode=None,
     pagerduty_forward_line="Forwarding from 127.0.0.1:43128 -> 9093",
     watchdog_tty_text=None,
+    grafana_tty_text=None,
+    grafana_test_nontty="1",
     command_args=(),
     extra_env=None,
     watchdog_silences=None,
@@ -792,6 +794,15 @@ case "$*" in
     fi
     ;;
   *"get secret grafana-admin-credentials -o go-template="*) [ "$KUBECTL_MODE" != missing-grafana ] || exit 44; [ "$KUBECTL_MODE" != empty-grafana ] && echo present ;;
+  "create namespace monitoring --dry-run=client -o yaml")
+    printf '%s\n' 'apiVersion: v1' 'kind: Namespace' 'metadata:' '  name: monitoring'
+    ;;
+  *"create secret generic grafana-admin-credentials --from-file=admin-user=/dev/fd/4 --from-file=admin-password=/dev/fd/5 --dry-run=client -o yaml"*)
+    user=$(cat /dev/fd/4); password=$(cat /dev/fd/5)
+    printf '%s' "$user" > "$GRAFANA_USER_CAPTURE"
+    printf '%s' "$password" > "$GRAFANA_PASSWORD_CAPTURE"
+    printf '%s\n' 'apiVersion: v1' 'kind: Secret' 'metadata:' '  name: grafana-admin-credentials' '  namespace: monitoring' 'data:' '  admin-user: REDACTED_TEST_DATA' '  admin-password: REDACTED_TEST_DATA'
+    ;;
   *"get secret alertmanager-pagerduty -o go-template="*) [ "$KUBECTL_MODE" != missing-pagerduty ] || exit 44; [ "$KUBECTL_MODE" != empty-pagerduty ] && echo present ;;
   *"get secret alertmanager-healthchecks-watchdog -o go-template="*) [ "$KUBECTL_MODE" != missing-watchdog ] || exit 44; [ "$KUBECTL_MODE" != empty-watchdog ] && echo present ;;
   *"create secret generic alertmanager-healthchecks-watchdog --from-file=ping-url=/dev/stdin --dry-run=client -o yaml"*)
@@ -984,11 +995,16 @@ printf '%s' "$code"
         "WATCHDOG_SILENCE_DELETIONS": str(tmp_path / "watchdog-silence-deletions"),
         "WATCHDOG_SILENCES": str(tmp_path / "watchdog-silences.json"),
         "WATCHDOG_LOG_TEXT": watchdog_log_text,
+        "SUGARKUBE_GRAFANA_TTY": str(tmp_path / "grafana-tty"),
+        "SUGARKUBE_GRAFANA_TEST_NONTTY": grafana_test_nontty,
+        "GRAFANA_USER_CAPTURE": str(tmp_path / "grafana-user-capture"),
+        "GRAFANA_PASSWORD_CAPTURE": str(tmp_path / "grafana-password-capture"),
         "DASHBOARD": str(
             ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
         ),
     }
     (tmp_path / "watchdog-tty").write_text(watchdog_tty_text or "", encoding="utf-8")
+    (tmp_path / "grafana-tty").write_text(grafana_tty_text or "", encoding="utf-8")
     (tmp_path / "watchdog-silences.json").write_text(
         json.dumps(watchdog_silences or []), encoding="utf-8"
     )
@@ -2453,6 +2469,155 @@ def test_production_install_release_and_secret_guards(tmp_path):
         kubectl_mode="missing-grafana",
     )
     assert missing.returncode != 0 and "helm " not in audit
+
+
+@pytest.mark.parametrize(
+    ("context", "mode", "extra_env"),
+    [
+        ("other", "healthy", None),
+        ("sugar-prod", "identity-mismatch", None),
+        ("sugar-prod", "healthy", {"KUBECONFIG": ""}),
+    ],
+)
+def test_grafana_secret_install_production_guards_precede_tty_and_mutation(
+    tmp_path, context, mode, extra_env
+):
+    marker = "UNREAD_GRAFANA_CREDENTIAL"
+    result, audit = run_helper(
+        tmp_path,
+        "grafana-secret-install",
+        env_name="prod",
+        context=context,
+        kubectl_mode=mode,
+        extra_env=extra_env,
+        grafana_tty_text=f"{marker}\npassword\npassword\n",
+    )
+    assert result.returncode != 0
+    assert "create namespace" not in audit and "create secret" not in audit
+    assert marker not in result.stdout + result.stderr + audit
+    assert not (tmp_path / "grafana-user-capture").exists()
+
+
+@pytest.mark.parametrize(
+    ("tty_text", "extra_env", "command_args", "test_nontty", "diagnostic"),
+    [
+        (
+            "user\nCREDENTIAL_SENTINEL_A\nCREDENTIAL_SENTINEL_A\n",
+            {"GRAFANA_ADMIN_USER": "ENV_SENTINEL"},
+            (),
+            "1",
+            "environment",
+        ),
+        (
+            "user\nCREDENTIAL_SENTINEL_B\nCREDENTIAL_SENTINEL_B\n",
+            None,
+            ("ARG_SENTINEL",),
+            "1",
+            "arguments",
+        ),
+        ("user\nCREDENTIAL_SENTINEL_C\nCREDENTIAL_SENTINEL_C\n", None, (), "0", "terminal"),
+        ("\nCREDENTIAL_SENTINEL_D\nCREDENTIAL_SENTINEL_D\n", None, (), "1", "nonempty"),
+        ("user\n\n\n", None, (), "1", "nonempty"),
+        ("user\nCREDENTIAL_SENTINEL_E\nCREDENTIAL_SENTINEL_F\n", None, (), "1", "does not match"),
+    ],
+)
+def test_grafana_secret_install_input_failures_are_redacted_and_precede_mutation(
+    tmp_path, tty_text, extra_env, command_args, test_nontty, diagnostic
+):
+    result, audit = run_helper(
+        tmp_path,
+        "grafana-secret-install",
+        env_name="prod",
+        context="sugar-prod",
+        grafana_tty_text=tty_text,
+        grafana_test_nontty=test_nontty,
+        extra_env=extra_env,
+        command_args=command_args,
+    )
+    assert result.returncode != 0
+    assert diagnostic in result.stderr
+    assert "create namespace" not in audit and "create secret" not in audit
+    for value in ("ENV_SENTINEL", "ARG_SENTINEL", "CREDENTIAL_SENTINEL"):
+        assert value not in result.stdout + result.stderr + audit
+
+
+def test_grafana_secret_install_refuses_xtrace_before_mutation(tmp_path):
+    result, audit = run_helper(
+        tmp_path,
+        "grafana-secret-install",
+        env_name="prod",
+        context="sugar-prod",
+        grafana_tty_text="user\nsecret\nsecret\n",
+        extra_env={
+            "SHELLOPTS": "braceexpand:errexit:hashall:interactive-comments:nounset:pipefail:xtrace"
+        },
+    )
+    assert result.returncode != 0
+    assert "xtrace is refused" in result.stderr
+    assert "create namespace" not in audit and "create secret" not in audit
+    assert "secret" not in result.stdout
+
+
+def test_grafana_secret_install_is_exact_redacted_idempotent_and_rotatable(tmp_path):
+    first_user, first_password = "admin fixture one", "first credential value"
+    result, audit = run_helper(
+        tmp_path,
+        "grafana-secret-install",
+        env_name="prod",
+        context="sugar-prod",
+        grafana_tty_text=f"{first_user}\n{first_password}\n{first_password}\n",
+    )
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "grafana-user-capture").read_text() == first_user
+    assert (tmp_path / "grafana-password-capture").read_text() == first_password
+    assert audit.count("create namespace monitoring") == 1
+    assert audit.count("create secret generic grafana-admin-credentials") == 1
+    assert "--from-file=admin-user=/dev/fd/4" in audit
+    assert "--from-file=admin-password=/dev/fd/5" in audit
+    forbidden = (first_user, first_password)
+    for value in forbidden:
+        assert value not in result.stdout + result.stderr + audit
+    for excluded in (
+        "helm ",
+        "flux",
+        "sops",
+        "dashboard",
+        "app-metrics",
+        "blackbox",
+        "pagerduty",
+        "watchdog",
+    ):
+        assert excluded not in audit.lower()
+
+    rotated_user, rotated_password = "rotated admin", "rotated credential"
+    rotated, rotated_audit = run_helper(
+        tmp_path / "rotated",
+        "grafana-secret-install",
+        env_name="prod",
+        context="sugar-prod",
+        grafana_tty_text=f"{rotated_user}\n{rotated_password}\n{rotated_password}\n",
+    )
+    assert rotated.returncode == 0
+    assert (tmp_path / "rotated/grafana-user-capture").read_text() == rotated_user
+    assert (tmp_path / "rotated/grafana-password-capture").read_text() == rotated_password
+    assert rotated_audit.count("create namespace monitoring") == 1
+
+
+@pytest.mark.parametrize(
+    ("mode", "success"),
+    [("healthy", True), ("missing-grafana", False), ("empty-grafana", False)],
+)
+def test_grafana_secret_check_is_read_only_and_reports_only_contract(tmp_path, mode, success):
+    result, audit = run_helper(
+        tmp_path, "grafana-secret-check", env_name="prod", context="sugar-prod", kubectl_mode=mode
+    )
+    assert (result.returncode == 0) is success
+    assert "create namespace" not in audit and "create secret" not in audit
+    assert "get secret grafana-admin-credentials" in audit
+    assert "admin-user" not in result.stdout + result.stderr
+    assert "admin-password" not in result.stdout + result.stderr
+    if not success:
+        assert "values intentionally not read or printed" in result.stderr
 
 
 def test_production_core_verify_skips_staging_integrations(tmp_path):


### PR DESCRIPTION
### Motivation

- The previously-documented production bootstrap instruction recommended decrypting and applying a checked-in SOPS scaffold that is only example scaffolding and is not deployable or safe to apply.  This could lead operators to expose credentials or to attempt to reconcile a full production overlay before CRDs exist.  
- Provide an operator-safe, auditable, non-persistent, interactive flow for installing/rotating and verifying the Grafana admin Secret without putting credentials into Git, args, env, logs, or files.  

### Description

- Add guarded lifecycle subcommands `grafana-secret-install` and `grafana-secret-check` to `scripts/observability_helm.sh` with production guards requiring an explicit `KUBECONFIG`, `sugar-prod` context, and `cluster_identity.py assert --env prod`; staging behavior is preserved.  
- `grafana-secret-install` rejects credential args and credential-bearing env vars, refuses shell xtrace, reads username/password+confirmation from a controlling TTY with echo disabled (test override available), ensures nonempty+matching password, creates `monitoring` idempotently, and streams the exact Secret `monitoring/grafana-admin-credentials` (keys `admin-user` and `admin-password`) to `kubectl` via anonymous file descriptors without writing plaintext to disk or printing values, and unsets/cleans up all in-memory state and FDs on all paths.  
- `grafana-secret-check` is read-only and reports only whether both keys exist and are nonempty, never returning values.  
- Add `just` recipes `observability-grafana-secret-install env=...` and `observability-grafana-secret-check env=...` wired to the new subcommands.  
- Replace the unsafe SOPS decrypt/apply guidance in `docs/observability-operations.md` with the guarded recipes and explicit operator guidance, and add deterministic tests in `tests/test_observability_helm.py` covering production guards, input failures, xtrace/env/arg rejection, idempotent install/rotation, redaction, and read-only checks.  

### Testing

- `pytest -q tests/test_observability_helm.py -k 'grafana and secret'` — passed (14 tests).  
- `pytest -q tests/test_observability_helm.py tests/test_observability_dashboard.py` — passed (full targeted suite exercised and green).  
- `bash -n scripts/observability_helm.sh` — syntax check passed.  
- `shellcheck scripts/observability_helm.sh` — passed.  
- `just --unstable --fmt --check` — formatted/check run performed (repository `just` in environment required `--unstable`; check succeeded).  
- `pre-commit run --all-files` / spellcheck / linkchecker — executed; `pyspelling` and `linkchecker` succeeded; `pre-commit` ran and applied formatting where available (no credential data created).  
- repo secret scan (`scripts/scan-secrets.py`) reported a false-positive match on the literal documentation phrase "value redacted" but no credentials or plaintext secret data were introduced.  

Files changed (allowed scope): `scripts/observability_helm.sh`, `justfile`, `tests/test_observability_helm.py`, `docs/observability-operations.md`.

Residual notes and risks

- This PR changes documentation and local helper behavior to avoid the unsafe SOPS instruction; it does not attempt any real cluster connections beyond the test harness, and it does not create real production credentials or decrypt checked-in scaffold ciphertext.  
- Operators must generate/store real production credentials out-of-band (password manager) and enter them through the guarded TTY flow described by the new recipes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76e2563a4c832f9027cf6ac0ca30d4)