### PR TITLE
Correct production Grafana Secret bootstrap after #2529

### DIFF
--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -78,28 +78,36 @@ test "$(kubectl config current-context)" = sugar-prod
 python3 scripts/cluster_identity.py assert --kubeconfig "$KUBECONFIG" --env prod
 ```
 
-Before a first install, create `monitoring` and apply only the existing SOPS
-declaration `clusters/prod/secrets/grafana-admin.enc.yaml`. Do not reconcile the
-full production overlay: it also contains observability resources whose CRDs do
-not exist until the core stack is installed. With the production context and
-identity checks above still in effect, use a configured SOPS age key and stream
-the decrypted manifest directly to the API without writing it to disk:
+The checked-in production Grafana Secret declaration and the example age
+recipient are scaffolding, not deployable live ciphertext. **Do not decrypt or
+apply that file.** Also do not reconcile the full production overlay: it
+contains observability resources whose CRDs do not exist until the core stack
+is installed.
+
+Generate and retain the production credentials in the operator's password
+manager. Enter them only through the guarded hidden-TTY lifecycle; never paste
+them into a command, environment variable, log, transcript, or file. With the
+production context and identity checks above still in effect, install (or
+intentionally rotate) and then check the Secret contract:
 
 ```bash
-kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
-sops --decrypt clusters/prod/secrets/grafana-admin.enc.yaml | kubectl apply -f -
+just observability-grafana-secret-install env=prod
+just observability-grafana-secret-check env=prod
 ```
 
-The declaration creates
+The install recipe creates only the `monitoring` Namespace, if absent, and
 `monitoring/grafana-admin-credentials` with both required keys:
 
 - Username key: `admin-user`.
 - Password key: `admin-password`.
 
-Both keys must be nonempty. Do not decrypt or print them during preflight. The Helm
-helper checks only that the Secret and both keys exist and are nonempty.
+Both keys must be nonempty. The check recipe verifies only that key contract; it
+does not return either value. The Helm install and upgrade preflight preserves
+the same contract check.
 
-After merge, an operator should capture deployment evidence in this order:
+After this Secret-bootstrap correction merges, the next operator sequence is a
+production render, fresh core-stack install, core verification and status, and
+sanitized live Prometheus inventory:
 
 ```bash
 just observability-render env=prod >/tmp/sugarkube-prod-render.yaml
@@ -109,6 +117,8 @@ just observability-verify env=prod
 just observability-status env=prod
 kubectl -n monitoring get deploy,statefulset,daemonset,pods,pvc
 kubectl -n monitoring get prometheus,alertmanager,servicemonitor
+# Capture live Prometheus target/metric inventory only after sanitizing labels,
+# endpoints, errors, and any other credential-bearing or identifying fields.
 ```
 
 Record the workload, PVC, and Prometheus target inventory without recording
@@ -118,6 +128,9 @@ production nodes. There is no public Grafana endpoint. Grafana persistence is
 disabled in this initial declarative phase, so UI-created state is ephemeral;
 provisioned dashboards remain code-owned, and durable UI state is a separate
 follow-up decision.
+
+Neither this correction nor PR #2529 proves a production deployment or a
+custom production dashboard. Both require separate, sanitized live evidence.
 
 The core baseline is one Prometheus and one Alertmanager replica, seven-day / 15
 GB retention, a 20 Gi RWO `local-path` Prometheus claim, and a null-only

--- a/justfile
+++ b/justfile
@@ -3476,6 +3476,14 @@ observability-verify env='':
 observability-dashboard-verify env='':
     @scripts/observability_helm.sh dashboard-verify '{{ env }}'
 
+# Interactively install or rotate the Grafana admin Secret (hidden input).
+observability-grafana-secret-install env='':
+    @scripts/observability_helm.sh grafana-secret-install '{{ env }}'
+
+# Check the Grafana admin Secret/key contract without reading either value.
+observability-grafana-secret-check env='':
+    @scripts/observability_helm.sh grafana-secret-check '{{ env }}'
+
 # Explicitly fire or resolve the staging-only synthetic PagerDuty alert (manual only).
 observability-pagerduty-test env='' action='':
     @scripts/observability_helm.sh pagerduty-test '{{ env }}' '{{ action }}'

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -878,7 +878,9 @@ if not isinstance(dashboard, dict) or dashboard.get("uid") != "sugarkube-staging
 cmd="${1:-}"; shift || true; [[ -n "${cmd}" ]] || { usage; exit 2; }
 env_arg="${1:-}"; resolve_environment "${env_arg}"
 if [[ "${OBSERVABILITY_XTRACE_WAS_ENABLED}" == 1 && "${cmd}" != grafana-secret-install && "${cmd}" != grafana-secret-check ]]; then set -x; fi
-[[ "${ENVIRONMENT}" != staging ]] || validate_dashboard
+if [[ "${ENVIRONMENT}" == staging && "${cmd}" != grafana-secret-install && "${cmd}" != grafana-secret-check ]]; then
+  validate_dashboard
+fi
 if [[ "${cmd}" == watchdog-drill-create ]]; then
   trap 'exit 130' INT
   trap 'exit 143' TERM

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -153,10 +153,19 @@ assert_grafana_secret() {
   echo "Grafana admin Secret contract exists (values intentionally not read or printed)."
 }
 
-grafana_secret_check() { assert_context; [[ $# == 0 ]] || { echo "ERROR: credential arguments are refused." >&2; return 2; }; assert_grafana_secret; }
+grafana_secret_check() {
+  [[ $# == 0 ]] || { echo "ERROR: credential arguments are refused." >&2; return 2; }
+  if [[ "${OBSERVABILITY_XTRACE_WAS_ENABLED}" == 1 ]]; then set -x; fi
+  assert_context
+  assert_grafana_secret
+}
 grafana_secret_install() (
   local credential_name grafana_admin_user="" grafana_admin_password="" grafana_admin_confirmation=""
-  trap 'unset grafana_admin_user grafana_admin_password grafana_admin_confirmation' EXIT
+  cleanup_grafana_credentials() {
+    exec 3<&- 2>/dev/null || true
+    unset grafana_admin_user grafana_admin_password grafana_admin_confirmation
+  }
+  trap cleanup_grafana_credentials EXIT
 
   assert_context
   [[ $# == 0 ]] || { echo "ERROR: credential arguments are refused." >&2; return 2; }
@@ -170,8 +179,11 @@ grafana_secret_install() (
   done < <(compgen -e)
   [[ "${OBSERVABILITY_XTRACE_WAS_ENABLED}" == 0 ]] || { echo "ERROR: shell xtrace is refused for Grafana credential input." >&2; return 2; }
 
-  exec 3</dev/tty
-  [[ -t 3 ]] || {
+  if ! { exec 3<"${SUGARKUBE_GRAFANA_SECRET_TTY:-/dev/tty}"; } 2>/dev/null; then
+    echo "ERROR: could not open the Grafana credential terminal (values redacted)." >&2
+    return 2
+  fi
+  [[ -t 3 || ( "${ENVIRONMENT}" != prod && "${SUGARKUBE_GRAFANA_SECRET_TEST_NONTTY:-0}" == 1 ) ]] || {
     echo "ERROR: an interactive controlling terminal is required." >&2
     return 2
   }
@@ -204,14 +216,15 @@ grafana_secret_install() (
     echo "ERROR: Grafana password confirmation does not match (values redacted)." >&2
     return 2
   }
+  exec 3<&-
+  unset grafana_admin_confirmation
 
   kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
-  exec 4< <(printf '%s' "${grafana_admin_user}")
-  exec 5< <(printf '%s' "${grafana_admin_password}")
-  unset grafana_admin_confirmation
   if ! kubectl -n "${NAMESPACE}" create secret generic "${GRAFANA_SECRET}" \
       --from-file=admin-user=/dev/fd/4 --from-file=admin-password=/dev/fd/5 \
-      --dry-run=client -o yaml | kubectl apply -f - >/dev/null; then
+      --dry-run=client -o yaml \
+      4< <(printf '%s' "${grafana_admin_user}") \
+      5< <(printf '%s' "${grafana_admin_password}") | kubectl apply -f - >/dev/null; then
     unset grafana_admin_user grafana_admin_password
     echo "ERROR: Grafana admin Secret installation failed (values redacted)." >&2
     return 1
@@ -863,7 +876,7 @@ if not isinstance(dashboard, dict) or dashboard.get("uid") != "sugarkube-staging
 
 cmd="${1:-}"; shift || true; [[ -n "${cmd}" ]] || { usage; exit 2; }
 env_arg="${1:-}"; resolve_environment "${env_arg}"
-if [[ "${OBSERVABILITY_XTRACE_WAS_ENABLED}" == 1 && "${cmd}" != grafana-secret-install ]]; then set -x; fi
+if [[ "${OBSERVABILITY_XTRACE_WAS_ENABLED}" == 1 && "${cmd}" != grafana-secret-install && "${cmd}" != grafana-secret-check ]]; then set -x; fi
 [[ "${ENVIRONMENT}" != staging ]] || validate_dashboard
 if [[ "${cmd}" == watchdog-drill-create ]]; then
   trap 'exit 130' INT

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -161,6 +161,7 @@ grafana_secret_check() {
 }
 grafana_secret_install() (
   local credential_name grafana_admin_user="" grafana_admin_password="" grafana_admin_confirmation=""
+  # shellcheck disable=SC2317  # Invoked indirectly by the EXIT trap on every exit path.
   cleanup_grafana_credentials() {
     exec 3<&- 2>/dev/null || true
     unset grafana_admin_user grafana_admin_password grafana_admin_confirmation

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -153,8 +153,6 @@ assert_grafana_secret() {
   echo "Grafana admin Secret contract exists (values intentionally not read or printed)."
 }
 
-GRAFANA_SECRET_TTY="${SUGARKUBE_GRAFANA_SECRET_TTY:-/dev/tty}"
-
 grafana_secret_check() { assert_context; [[ $# == 0 ]] || { echo "ERROR: credential arguments are refused." >&2; return 2; }; assert_grafana_secret; }
 grafana_secret_install() (
   local credential_name grafana_admin_user="" grafana_admin_password="" grafana_admin_confirmation=""
@@ -172,8 +170,8 @@ grafana_secret_install() (
   done < <(compgen -e)
   [[ "${OBSERVABILITY_XTRACE_WAS_ENABLED}" == 0 ]] || { echo "ERROR: shell xtrace is refused for Grafana credential input." >&2; return 2; }
 
-  exec 3<"${GRAFANA_SECRET_TTY}"
-  [[ "${SUGARKUBE_GRAFANA_SECRET_TEST_NONTTY:-0}" == 1 || -t 3 ]] || {
+  exec 3</dev/tty
+  [[ -t 3 ]] || {
     echo "ERROR: an interactive controlling terminal is required." >&2
     return 2
   }
@@ -865,7 +863,7 @@ if not isinstance(dashboard, dict) or dashboard.get("uid") != "sugarkube-staging
 
 cmd="${1:-}"; shift || true; [[ -n "${cmd}" ]] || { usage; exit 2; }
 env_arg="${1:-}"; resolve_environment "${env_arg}"
-if [[ "${OBSERVABILITY_XTRACE_WAS_ENABLED}" == 1 && "${cmd}" != grafana-secret-* ]]; then set -x; fi
+if [[ "${OBSERVABILITY_XTRACE_WAS_ENABLED}" == 1 && "${cmd}" != grafana-secret-install ]]; then set -x; fi
 [[ "${ENVIRONMENT}" != staging ]] || validate_dashboard
 if [[ "${cmd}" == watchdog-drill-create ]]; then
   trap 'exit 130' INT

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+if [[ $- == *x* ]]; then
+  set +x
+  OBSERVABILITY_XTRACE_WAS_ENABLED=1
+else
+  OBSERVABILITY_XTRACE_WAS_ENABLED=0
+fi
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RELEASE="kube-prometheus-stack"
@@ -24,7 +30,7 @@ ENVIRONMENT=""
 ENV_VALUES=""
 EXPECTED_CONTEXT=""
 
-usage() { echo "Usage: $0 <render|install|upgrade|status|verify|dashboard-verify|pagerduty-test|watchdog-secret-install|watchdog-secret-check|watchdog-verify|watchdog-drill-create|watchdog-drill-status|watchdog-drill-clear> env=<staging|prod> [fire|resolve]" >&2; }
+usage() { echo "Usage: $0 <render|install|upgrade|status|verify|dashboard-verify|pagerduty-test|grafana-secret-install|grafana-secret-check|watchdog-secret-install|watchdog-secret-check|watchdog-verify|watchdog-drill-create|watchdog-drill-status|watchdog-drill-clear> env=<staging|prod> [fire|resolve]" >&2; }
 normalize_env() {
   local raw="${1:-}"
   while [[ "${raw}" == env=* ]]; do raw="${raw#env=}"; done
@@ -146,6 +152,75 @@ assert_grafana_secret() {
   fi
   echo "Grafana admin Secret contract exists (values intentionally not read or printed)."
 }
+
+GRAFANA_SECRET_TTY="${SUGARKUBE_GRAFANA_SECRET_TTY:-/dev/tty}"
+
+grafana_secret_check() { assert_context; [[ $# == 0 ]] || { echo "ERROR: credential arguments are refused." >&2; return 2; }; assert_grafana_secret; }
+grafana_secret_install() (
+  local credential_name grafana_admin_user="" grafana_admin_password="" grafana_admin_confirmation=""
+  trap 'unset grafana_admin_user grafana_admin_password grafana_admin_confirmation' EXIT
+
+  assert_context
+  [[ $# == 0 ]] || { echo "ERROR: credential arguments are refused." >&2; return 2; }
+  while IFS= read -r credential_name; do
+    case "${credential_name}" in
+      GRAFANA_ADMIN_*|GF_SECURITY_ADMIN_*)
+        echo "ERROR: Grafana credential environment variables are refused." >&2
+        return 2
+        ;;
+    esac
+  done < <(compgen -e)
+  [[ "${OBSERVABILITY_XTRACE_WAS_ENABLED}" == 0 ]] || { echo "ERROR: shell xtrace is refused for Grafana credential input." >&2; return 2; }
+
+  exec 3<"${GRAFANA_SECRET_TTY}"
+  [[ "${SUGARKUBE_GRAFANA_SECRET_TEST_NONTTY:-0}" == 1 || -t 3 ]] || {
+    echo "ERROR: an interactive controlling terminal is required." >&2
+    return 2
+  }
+  printf 'Enter the Grafana admin username (input hidden): ' >&2
+  IFS= read -r -s grafana_admin_user <&3 || {
+    unset grafana_admin_user grafana_admin_password grafana_admin_confirmation
+    echo "ERROR: could not read Grafana credentials (values redacted)." >&2
+    return 2
+  }
+  printf '\nEnter the Grafana admin password (input hidden): ' >&2
+  IFS= read -r -s grafana_admin_password <&3 || {
+    unset grafana_admin_user grafana_admin_password grafana_admin_confirmation
+    echo "ERROR: could not read Grafana credentials (values redacted)." >&2
+    return 2
+  }
+  printf '\nConfirm the Grafana admin password (input hidden): ' >&2
+  IFS= read -r -s grafana_admin_confirmation <&3 || {
+    unset grafana_admin_user grafana_admin_password grafana_admin_confirmation
+    echo "ERROR: could not read Grafana credentials (values redacted)." >&2
+    return 2
+  }
+  printf '\n' >&2
+  [[ -n "${grafana_admin_user}" && -n "${grafana_admin_password}" ]] || {
+    unset grafana_admin_user grafana_admin_password grafana_admin_confirmation
+    echo "ERROR: Grafana username and password must both be nonempty (values redacted)." >&2
+    return 2
+  }
+  [[ "${grafana_admin_password}" == "${grafana_admin_confirmation}" ]] || {
+    unset grafana_admin_user grafana_admin_password grafana_admin_confirmation
+    echo "ERROR: Grafana password confirmation does not match (values redacted)." >&2
+    return 2
+  }
+
+  kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+  exec 4< <(printf '%s' "${grafana_admin_user}")
+  exec 5< <(printf '%s' "${grafana_admin_password}")
+  unset grafana_admin_confirmation
+  if ! kubectl -n "${NAMESPACE}" create secret generic "${GRAFANA_SECRET}" \
+      --from-file=admin-user=/dev/fd/4 --from-file=admin-password=/dev/fd/5 \
+      --dry-run=client -o yaml | kubectl apply -f - >/dev/null; then
+    unset grafana_admin_user grafana_admin_password
+    echo "ERROR: Grafana admin Secret installation failed (values redacted)." >&2
+    return 1
+  fi
+  unset grafana_admin_user grafana_admin_password
+  echo "Grafana admin Secret installed or rotated (values not displayed)."
+)
 
 release_state() {
   local matches
@@ -790,9 +865,10 @@ if not isinstance(dashboard, dict) or dashboard.get("uid") != "sugarkube-staging
 
 cmd="${1:-}"; shift || true; [[ -n "${cmd}" ]] || { usage; exit 2; }
 env_arg="${1:-}"; resolve_environment "${env_arg}"
+if [[ "${OBSERVABILITY_XTRACE_WAS_ENABLED}" == 1 && "${cmd}" != grafana-secret-* ]]; then set -x; fi
 [[ "${ENVIRONMENT}" != staging ]] || validate_dashboard
 if [[ "${cmd}" == watchdog-drill-create ]]; then
   trap 'exit 130' INT
   trap 'exit 143' TERM
 fi
-case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) require_staging "dashboard-verify"; dashboard_verify ;; pagerduty-test) require_staging "pagerduty-test"; pagerduty_test "${2:-${1:-}}" ;; watchdog-secret-install) require_staging "watchdog-secret-install"; watchdog_secret_install "${@:2}" ;; watchdog-secret-check) require_staging "watchdog-secret-check"; watchdog_secret_check ;; watchdog-verify) require_staging "watchdog-verify"; watchdog_live_check ;; watchdog-drill-create) require_staging "watchdog-drill-create"; watchdog_silence_create ;; watchdog-drill-status) require_staging "watchdog-drill-status"; watchdog_silence_list ;; watchdog-drill-clear) require_staging "watchdog-drill-clear"; watchdog_silence_clear ;; *) usage; exit 2 ;; esac
+case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) require_staging "dashboard-verify"; dashboard_verify ;; pagerduty-test) require_staging "pagerduty-test"; pagerduty_test "${2:-${1:-}}" ;; grafana-secret-install) grafana_secret_install "${@:2}" ;; grafana-secret-check) grafana_secret_check "${@:2}" ;; watchdog-secret-install) require_staging "watchdog-secret-install"; watchdog_secret_install "${@:2}" ;; watchdog-secret-check) require_staging "watchdog-secret-check"; watchdog_secret_check ;; watchdog-verify) require_staging "watchdog-verify"; watchdog_live_check ;; watchdog-drill-create) require_staging "watchdog-drill-create"; watchdog_silence_create ;; watchdog-drill-status) require_staging "watchdog-drill-status"; watchdog_silence_list ;; watchdog-drill-clear) require_staging "watchdog-drill-clear"; watchdog_silence_clear ;; *) usage; exit 2 ;; esac

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -620,6 +620,13 @@ def test_justfile_exposes_observability_recipes():
         assert "env=staging" not in recipe_block
         assert "env={{ env }}" not in recipe_block
 
+    for recipe, subcommand in (
+        ("observability-grafana-secret-install", "grafana-secret-install"),
+        ("observability-grafana-secret-check", "grafana-secret-check"),
+    ):
+        recipe_block = text.split(f"{recipe} env='':", 1)[1].split("\n\n", 1)[0]
+        assert f"scripts/observability_helm.sh {subcommand} '{{{{ env }}}}'" in recipe_block
+
 
 def test_justfile_normalizes_repeated_env_prefixes_before_staging_metrics_checks():
     text = JUSTFILE.read_text(encoding="utf-8")
@@ -706,6 +713,145 @@ def test_flux_health_checks_exclude_manually_managed_observability():
     assert names == {"traefik", "cloudflared", "longhorn-driver-deployer"}
     assert "manually managed" in text
     assert "just observability-verify" in text
+
+
+def run_grafana_secret_helper(
+    tmp_path: Path,
+    command="grafana-secret-install",
+    *,
+    env_name="prod",
+    context="sugar-prod",
+    kubeconfig=True,
+    identity="prod",
+    tty_text="operator\ncorrect horse battery staple\ncorrect horse battery staple\n",
+    test_tty=True,
+    extra_env=None,
+    args=(),
+    xtrace=False,
+    secret_state="present",
+):
+    """Run only the Grafana Secret lifecycle against redacting command stubs."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    audit = tmp_path / "audit"
+    tty = tmp_path / "tty-input"
+    tty.write_text(tty_text, encoding="utf-8")
+    (bin_dir / "kubectl").write_text(
+        """#!/bin/sh
+case "$*" in
+  *"config current-context") echo "$CONTEXT" ;;
+  *"config view --minify"*) echo https://cluster.invalid ;;
+  *"get nodes -o json"*) printf '%s\n' '{"items":[{"metadata":{"name":"n1","labels":{"sugarkube.env":"'"$IDENTITY"'","sugarkube.cluster":"sugar"}}}]}' ;;
+  "create namespace monitoring --dry-run=client -o yaml") echo namespace-manifest; echo namespace-create >> "$AUDIT" ;;
+  "apply -f -") cat >/dev/null; echo apply >> "$AUDIT" ;;
+  *"create secret generic grafana-admin-credentials"*)
+    [ "$7" = "--from-file=admin-user=/dev/fd/4" ]
+    [ "$8" = "--from-file=admin-password=/dev/fd/5" ]
+    [ "$(cat /dev/fd/4)" = operator ]
+    [ "$(cat /dev/fd/5)" = 'correct horse battery staple' ]
+    echo secret-create >> "$AUDIT"
+    echo secret-manifest
+    ;;
+  *"get secret grafana-admin-credentials -o go-template="*)
+    echo secret-check >> "$AUDIT"
+    [ "$SECRET_STATE" = missing ] && exit 44
+    [ "$SECRET_STATE" = present ] && echo present
+    ;;
+  *) echo "unexpected kubectl operation" >> "$AUDIT"; exit 90 ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    (bin_dir / "kubectl").chmod(0o755)
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "AUDIT": str(audit),
+            "CONTEXT": context,
+            "IDENTITY": identity,
+            "SECRET_STATE": secret_state,
+            "SUGARKUBE_GRAFANA_SECRET_TTY": str(tty),
+        }
+    )
+    if kubeconfig:
+        env["KUBECONFIG"] = str(tmp_path / "kubeconfig")
+    else:
+        env.pop("KUBECONFIG", None)
+    if test_tty:
+        env["SUGARKUBE_GRAFANA_SECRET_TEST_NONTTY"] = "1"
+    if extra_env:
+        env.update(extra_env)
+    invocation = ["bash"]
+    if xtrace:
+        invocation.append("-x")
+    invocation.extend([str(SCRIPT), command, env_name, *args])
+    result = subprocess.run(invocation, text=True, capture_output=True, env=env, check=False)
+    return result, audit.read_text(encoding="utf-8") if audit.exists() else "", tty
+
+
+def test_grafana_secret_prod_guards_precede_tty_and_mutation(tmp_path):
+    for kwargs in (
+        {"kubeconfig": False},
+        {"context": "sugar-staging"},
+        {"identity": "staging"},
+    ):
+        result, audit, tty = run_grafana_secret_helper(tmp_path / str(len(list(tmp_path.iterdir()))), **kwargs)
+        assert result.returncode != 0
+        assert audit == ""
+        assert tty.read_text(encoding="utf-8").startswith("operator\n")
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"test_tty": False},
+        {"xtrace": True},
+        {"extra_env": {"GRAFANA_ADMIN_USER": "ENV_SENTINEL_VALUE"}},
+        {"extra_env": {"GRAFANA_ADMIN_PASSWORD": "ENV_SENTINEL_VALUE"}},
+        {"extra_env": {"GF_SECURITY_ADMIN_USER": "ENV_SENTINEL_VALUE"}},
+        {"extra_env": {"GF_SECURITY_ADMIN_PASSWORD": "ENV_SENTINEL_VALUE"}},
+        {"args": ("ARG_SENTINEL_VALUE",)},
+        {"tty_text": "\nINPUT_SENTINEL_VALUE\nINPUT_SENTINEL_VALUE\n"},
+        {"tty_text": "operator\n\n\n"},
+        {"tty_text": "operator\none\ntwo\n"},
+    ],
+)
+def test_grafana_secret_install_fails_closed_before_mutation(tmp_path, kwargs):
+    result, audit, _ = run_grafana_secret_helper(tmp_path, **kwargs)
+    assert result.returncode != 0
+    assert audit == ""
+    combined = result.stdout + result.stderr
+    for value in ("ENV_SENTINEL_VALUE", "ARG_SENTINEL_VALUE", "INPUT_SENTINEL_VALUE", "operator"):
+        assert value not in combined
+
+
+def test_grafana_secret_install_is_exact_redacted_and_rotatable(tmp_path):
+    before = {path.name for path in tmp_path.iterdir()}
+    result, audit, tty = run_grafana_secret_helper(tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert audit.splitlines() == ["namespace-create", "apply", "secret-create", "apply"]
+    combined = result.stdout + result.stderr + audit
+    assert "operator" not in combined
+    assert "correct horse battery staple" not in combined
+    assert "helm" not in audit and "sops" not in audit and "flux" not in audit
+    assert {path.name for path in tmp_path.iterdir()} - before == {"bin", "audit", "tty-input"}
+    tty.write_text("operator\ncorrect horse battery staple\ncorrect horse battery staple\n", encoding="utf-8")
+    result, audit, _ = run_grafana_secret_helper(tmp_path / "rotation")
+    assert result.returncode == 0
+    assert audit.count("secret-create") == 1
+
+
+@pytest.mark.parametrize("state,success", [("present", True), ("missing", False), ("empty", False)])
+def test_grafana_secret_check_is_read_only_and_redacted(tmp_path, state, success):
+    result, audit, _ = run_grafana_secret_helper(
+        tmp_path, command="grafana-secret-check", secret_state=state
+    )
+    assert (result.returncode == 0) is success
+    assert audit == "secret-check\n"
+    assert "operator" not in result.stdout + result.stderr
+    assert "admin-user" not in result.stdout + result.stderr
+    assert "admin-password" not in result.stdout + result.stderr
 
 
 def run_helper(

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -732,11 +732,15 @@ def run_grafana_secret_helper(
     args=(),
     xtrace=False,
     secret_state="present",
+    expected_user="operator",
+    expected_password="correct horse battery staple",
 ):
     """Run only the Grafana Secret lifecycle against redacting command stubs."""
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(parents=True)
     audit = tmp_path / "audit"
+    script_tmp = tmp_path / "tmp"
+    script_tmp.mkdir()
     tty = tmp_path / "tty-input"
     tty.write_text(tty_text, encoding="utf-8")
     (bin_dir / "kubectl").write_text(
@@ -745,17 +749,26 @@ case "$*" in
   *"config current-context") echo "$CONTEXT" ;;
   *"config view --minify"*) echo https://cluster.invalid ;;
   *"get nodes -o json"*) printf '%s\n' '{"items":[{"metadata":{"name":"n1","labels":{"sugarkube.env":"'"$IDENTITY"'","sugarkube.cluster":"sugar"}}}]}' ;;
-  "create namespace monitoring --dry-run=client -o yaml") echo namespace-manifest; echo namespace-create >> "$AUDIT" ;;
-  "apply -f -") cat >/dev/null; echo apply >> "$AUDIT" ;;
+  "create namespace monitoring --dry-run=client -o yaml") echo 'kind: Namespace'; echo 'metadata: {name: monitoring}'; echo 'mutate namespace monitoring' >> "$AUDIT" ;;
+  "apply -f -")
+    [ ! -e /dev/fd/4 ] && [ ! -e /dev/fd/5 ]
+    manifest=$(cat)
+    case "$manifest" in
+      *"kind: Namespace"*"name: monitoring"*) echo 'apply namespace monitoring' >> "$AUDIT" ;;
+      *"kind: Secret"*"name: grafana-admin-credentials"*"namespace: monitoring"*) echo 'apply secret monitoring/grafana-admin-credentials' >> "$AUDIT" ;;
+      *) echo 'unexpected mutation' >> "$AUDIT"; exit 91 ;;
+    esac
+    ;;
   *"create secret generic grafana-admin-credentials"*)
     [ "$7" = "--from-file=admin-user=/dev/fd/4" ]
     [ "$8" = "--from-file=admin-password=/dev/fd/5" ]
-    [ "$(cat /dev/fd/4)" = operator ]
-    [ "$(cat /dev/fd/5)" = 'correct horse battery staple' ]
-    echo secret-create >> "$AUDIT"
-    echo secret-manifest
+    [ "$(cat /dev/fd/4)" = "$EXPECTED_USER" ]
+    [ "$(cat /dev/fd/5)" = "$EXPECTED_PASSWORD" ]
+    echo 'mutate secret monitoring/grafana-admin-credentials' >> "$AUDIT"
+    printf '%s\n' 'kind: Secret' 'metadata:' '  name: grafana-admin-credentials' '  namespace: monitoring'
     ;;
   *"get secret grafana-admin-credentials -o go-template="*)
+    [ "$7" = 'go-template={{if and (index .data "admin-user") (index .data "admin-password")}}present{{end}}' ]
     echo secret-check >> "$AUDIT"
     [ "$SECRET_STATE" = missing ] && exit 44
     [ "$SECRET_STATE" = present ] && echo present
@@ -774,19 +787,22 @@ esac
             "CONTEXT": context,
             "IDENTITY": identity,
             "SECRET_STATE": secret_state,
+            "EXPECTED_USER": expected_user,
+            "EXPECTED_PASSWORD": expected_password,
+            "TMPDIR": str(script_tmp),
         }
     )
     if kubeconfig:
         env["KUBECONFIG"] = str(tmp_path / "kubeconfig")
     else:
         env.pop("KUBECONFIG", None)
-    if extra_env:
-        env.update(extra_env)
     invocation = ["bash"]
     if xtrace:
         invocation.append("-x")
     invocation.extend([str(SCRIPT), command, env_name, *args])
     if test_tty and command == "grafana-secret-install":
+        if extra_env:
+            env.update(extra_env)
         master_fd, slave_fd = pty.openpty()
 
         def establish_controlling_tty():
@@ -811,6 +827,8 @@ esac
     else:
         env["SUGARKUBE_GRAFANA_SECRET_TTY"] = str(tty)
         env["SUGARKUBE_GRAFANA_SECRET_TEST_NONTTY"] = "1"
+        if extra_env:
+            env.update(extra_env)
         result = subprocess.run(invocation, text=True, capture_output=True, env=env, check=False)
     return result, audit.read_text(encoding="utf-8") if audit.exists() else "", tty
 
@@ -825,6 +843,40 @@ def test_grafana_secret_prod_guards_precede_tty_and_mutation(tmp_path):
         assert result.returncode != 0
         assert audit == ""
         assert tty.read_text(encoding="utf-8").startswith("operator\n")
+
+
+def test_grafana_secret_prod_rejects_test_override_and_regular_file(tmp_path):
+    result, audit, _ = run_grafana_secret_helper(tmp_path, test_tty=False)
+    assert result.returncode != 0
+    assert audit == ""
+
+
+def test_grafana_secret_nonprod_test_override_is_deterministic(tmp_path):
+    result, audit, _ = run_grafana_secret_helper(
+        tmp_path,
+        env_name="staging",
+        context="sugar-staging",
+        identity="staging",
+        test_tty=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert audit.splitlines()[-1] == "apply secret monitoring/grafana-admin-credentials"
+
+
+def test_grafana_secret_tty_open_failure_is_redacted(tmp_path):
+    missing = tmp_path / "missing-tty"
+    result, audit, _ = run_grafana_secret_helper(
+        tmp_path,
+        env_name="staging",
+        context="sugar-staging",
+        identity="staging",
+        test_tty=False,
+        extra_env={"SUGARKUBE_GRAFANA_SECRET_TTY": str(missing)},
+    )
+    assert result.returncode != 0
+    assert audit == ""
+    assert "could not open the Grafana credential terminal" in result.stderr
+    assert str(missing) not in result.stdout + result.stderr
 
 
 @pytest.mark.parametrize(
@@ -853,18 +905,43 @@ def test_grafana_secret_install_fails_closed_before_mutation(tmp_path, kwargs):
 
 def test_grafana_secret_install_is_exact_redacted_and_rotatable(tmp_path):
     before = {path.name for path in tmp_path.iterdir()}
-    result, audit, tty = run_grafana_secret_helper(tmp_path)
+    result, audit, _ = run_grafana_secret_helper(tmp_path)
     assert result.returncode == 0, result.stderr
-    assert audit.splitlines() == ["namespace-create", "apply", "secret-create", "apply"]
+    assert audit.splitlines() == [
+        "mutate namespace monitoring",
+        "apply namespace monitoring",
+        "mutate secret monitoring/grafana-admin-credentials",
+        "apply secret monitoring/grafana-admin-credentials",
+    ]
     combined = result.stdout + result.stderr + audit
     assert "operator" not in combined
     assert "correct horse battery staple" not in combined
-    assert "helm" not in audit and "sops" not in audit and "flux" not in audit
-    assert {path.name for path in tmp_path.iterdir()} - before == {"bin", "audit", "tty-input"}
-    tty.write_text("operator\ncorrect horse battery staple\ncorrect horse battery staple\n", encoding="utf-8")
-    result, audit, _ = run_grafana_secret_helper(tmp_path / "rotation")
+    for forbidden in (
+        "helm",
+        "flux",
+        "sops",
+        "dashboard",
+        "application-metrics",
+        "blackbox",
+        "pagerduty",
+        "watchdog",
+    ):
+        assert forbidden not in audit.lower()
+    assert {path.name for path in tmp_path.iterdir()} - before == {"bin", "audit", "tmp", "tty-input"}
+    assert list((tmp_path / "tmp").iterdir()) == []
+    second_user = "rotation-user-sentinel"
+    second_password = "rotation-password-sentinel"
+    result, audit, _ = run_grafana_secret_helper(
+        tmp_path / "rotation",
+        tty_text=f"{second_user}\n{second_password}\n{second_password}\n",
+        expected_user=second_user,
+        expected_password=second_password,
+    )
     assert result.returncode == 0
-    assert audit.count("secret-create") == 1
+    assert audit.count("mutate secret monitoring/grafana-admin-credentials") == 1
+    assert second_user not in result.stdout + result.stderr + audit
+    assert second_password not in result.stdout + result.stderr + audit
+    assert list((tmp_path / "rotation" / "tmp").iterdir()) == []
 
 
 @pytest.mark.parametrize("state,success", [("present", True), ("missing", False), ("empty", False)])
@@ -885,7 +962,22 @@ def test_grafana_secret_check_restores_requested_xtrace(tmp_path):
     )
     assert result.returncode == 0
     assert audit == "secret-check\n"
-    assert "+ grafana_secret_check" in result.stderr
+    assert "+ assert_context" in result.stderr
+    assert "+ assert_grafana_secret" in result.stderr
+
+
+def test_grafana_secret_check_rejects_arguments_before_restoring_xtrace(tmp_path):
+    sentinel = "CHECK_CREDENTIAL_SENTINEL"
+    result, audit, _ = run_grafana_secret_helper(
+        tmp_path,
+        command="grafana-secret-check",
+        xtrace=True,
+        args=(sentinel,),
+        extra_env={"GRAFANA_ADMIN_PASSWORD": sentinel},
+    )
+    assert result.returncode != 0
+    assert audit == ""
+    assert sentinel not in result.stdout + result.stderr + audit
 
 
 def run_helper(

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -1,8 +1,11 @@
+import fcntl
 import json
 import os
+import pty
 import re
 import signal
 import subprocess
+import termios
 import time
 from pathlib import Path
 
@@ -771,22 +774,44 @@ esac
             "CONTEXT": context,
             "IDENTITY": identity,
             "SECRET_STATE": secret_state,
-            "SUGARKUBE_GRAFANA_SECRET_TTY": str(tty),
         }
     )
     if kubeconfig:
         env["KUBECONFIG"] = str(tmp_path / "kubeconfig")
     else:
         env.pop("KUBECONFIG", None)
-    if test_tty:
-        env["SUGARKUBE_GRAFANA_SECRET_TEST_NONTTY"] = "1"
     if extra_env:
         env.update(extra_env)
     invocation = ["bash"]
     if xtrace:
         invocation.append("-x")
     invocation.extend([str(SCRIPT), command, env_name, *args])
-    result = subprocess.run(invocation, text=True, capture_output=True, env=env, check=False)
+    if test_tty and command == "grafana-secret-install":
+        master_fd, slave_fd = pty.openpty()
+
+        def establish_controlling_tty():
+            os.setsid()
+            fcntl.ioctl(slave_fd, termios.TIOCSCTTY, 0)
+
+        process = subprocess.Popen(
+            invocation,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+            pass_fds=(slave_fd,),
+            preexec_fn=establish_controlling_tty,
+        )
+        os.close(slave_fd)
+        os.write(master_fd, tty_text.encode())
+        stdout, stderr = process.communicate()
+        os.close(master_fd)
+        result = subprocess.CompletedProcess(invocation, process.returncode, stdout, stderr)
+    else:
+        env["SUGARKUBE_GRAFANA_SECRET_TTY"] = str(tty)
+        env["SUGARKUBE_GRAFANA_SECRET_TEST_NONTTY"] = "1"
+        result = subprocess.run(invocation, text=True, capture_output=True, env=env, check=False)
     return result, audit.read_text(encoding="utf-8") if audit.exists() else "", tty
 
 
@@ -852,6 +877,15 @@ def test_grafana_secret_check_is_read_only_and_redacted(tmp_path, state, success
     assert "operator" not in result.stdout + result.stderr
     assert "admin-user" not in result.stdout + result.stderr
     assert "admin-password" not in result.stdout + result.stderr
+
+
+def test_grafana_secret_check_restores_requested_xtrace(tmp_path):
+    result, audit, _ = run_grafana_secret_helper(
+        tmp_path, command="grafana-secret-check", xtrace=True
+    )
+    assert result.returncode == 0
+    assert audit == "secret-check\n"
+    assert "+ grafana_secret_check" in result.stderr
 
 
 def run_helper(

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -732,8 +732,6 @@ def run_grafana_secret_helper(
     args=(),
     xtrace=False,
     secret_state="present",
-    expected_user="operator",
-    expected_password="correct horse battery staple",
 ):
     """Run only the Grafana Secret lifecycle against redacting command stubs."""
     bin_dir = tmp_path / "bin"
@@ -741,10 +739,9 @@ def run_grafana_secret_helper(
     audit = tmp_path / "audit"
     script_tmp = tmp_path / "tmp"
     script_tmp.mkdir()
-    tty = tmp_path / "tty-input"
-    tty.write_text(tty_text, encoding="utf-8")
+    capture_read, capture_write = os.pipe()
     (bin_dir / "kubectl").write_text(
-        """#!/bin/sh
+        r"""#!/bin/sh
 case "$*" in
   *"config current-context") echo "$CONTEXT" ;;
   *"config view --minify"*) echo https://cluster.invalid ;;
@@ -762,8 +759,9 @@ case "$*" in
   *"create secret generic grafana-admin-credentials"*)
     [ "$7" = "--from-file=admin-user=/dev/fd/4" ]
     [ "$8" = "--from-file=admin-password=/dev/fd/5" ]
-    [ "$(cat /dev/fd/4)" = "$EXPECTED_USER" ]
-    [ "$(cat /dev/fd/5)" = "$EXPECTED_PASSWORD" ]
+    python3 -c \
+      'import os, sys; os.write(int(sys.argv[1]), os.read(4, 1048576) + b"\n" + os.read(5, 1048576))' \
+      "$CAPTURE_FD"
     echo 'mutate secret monitoring/grafana-admin-credentials' >> "$AUDIT"
     printf '%s\n' 'kind: Secret' 'metadata:' '  name: grafana-admin-credentials' '  namespace: monitoring'
     ;;
@@ -779,6 +777,23 @@ esac
         encoding="utf-8",
     )
     (bin_dir / "kubectl").chmod(0o755)
+    forbidden_stub = """#!/bin/sh
+echo "forbidden operation: $(basename "$0")" >> "$AUDIT"
+exit 99
+"""
+    for command_name in (
+        "helm",
+        "flux",
+        "sops",
+        "dashboard",
+        "application-metrics",
+        "blackbox",
+        "pagerduty",
+        "watchdog",
+    ):
+        guard = bin_dir / command_name
+        guard.write_text(forbidden_stub, encoding="utf-8")
+        guard.chmod(0o755)
     env = os.environ.copy()
     env.update(
         {
@@ -787,8 +802,7 @@ esac
             "CONTEXT": context,
             "IDENTITY": identity,
             "SECRET_STATE": secret_state,
-            "EXPECTED_USER": expected_user,
-            "EXPECTED_PASSWORD": expected_password,
+            "CAPTURE_FD": str(capture_write),
             "TMPDIR": str(script_tmp),
         }
     )
@@ -816,7 +830,7 @@ esac
             stderr=subprocess.PIPE,
             text=True,
             env=env,
-            pass_fds=(slave_fd,),
+            pass_fds=(slave_fd, capture_write),
             preexec_fn=establish_controlling_tty,
         )
         os.close(slave_fd)
@@ -825,12 +839,29 @@ esac
         os.close(master_fd)
         result = subprocess.CompletedProcess(invocation, process.returncode, stdout, stderr)
     else:
-        env["SUGARKUBE_GRAFANA_SECRET_TTY"] = str(tty)
+        tty_read, tty_write = os.pipe()
+        os.write(tty_write, tty_text.encode())
+        os.close(tty_write)
+        env["SUGARKUBE_GRAFANA_SECRET_TTY"] = f"/dev/fd/{tty_read}"
         env["SUGARKUBE_GRAFANA_SECRET_TEST_NONTTY"] = "1"
         if extra_env:
             env.update(extra_env)
-        result = subprocess.run(invocation, text=True, capture_output=True, env=env, check=False)
-    return result, audit.read_text(encoding="utf-8") if audit.exists() else "", tty
+        result = subprocess.run(
+            invocation,
+            text=True,
+            capture_output=True,
+            env=env,
+            pass_fds=(tty_read, capture_write),
+            check=False,
+        )
+        os.close(tty_read)
+    os.close(capture_write)
+    captured = b""
+    while chunk := os.read(capture_read, 4096):
+        captured += chunk
+    os.close(capture_read)
+    credentials = tuple(captured.decode().split("\n", 1)) if captured else ()
+    return result, audit.read_text(encoding="utf-8") if audit.exists() else "", credentials
 
 
 def test_grafana_secret_prod_guards_precede_tty_and_mutation(tmp_path):
@@ -839,10 +870,12 @@ def test_grafana_secret_prod_guards_precede_tty_and_mutation(tmp_path):
         {"context": "sugar-staging"},
         {"identity": "staging"},
     ):
-        result, audit, tty = run_grafana_secret_helper(tmp_path / str(len(list(tmp_path.iterdir()))), **kwargs)
+        result, audit, credentials = run_grafana_secret_helper(
+            tmp_path / str(len(list(tmp_path.iterdir()))), **kwargs
+        )
         assert result.returncode != 0
         assert audit == ""
-        assert tty.read_text(encoding="utf-8").startswith("operator\n")
+        assert credentials == ()
 
 
 def test_grafana_secret_prod_rejects_test_override_and_regular_file(tmp_path):
@@ -904,15 +937,17 @@ def test_grafana_secret_install_fails_closed_before_mutation(tmp_path, kwargs):
 
 
 def test_grafana_secret_install_is_exact_redacted_and_rotatable(tmp_path):
-    before = {path.name for path in tmp_path.iterdir()}
-    result, audit, _ = run_grafana_secret_helper(tmp_path)
-    assert result.returncode == 0, result.stderr
-    assert audit.splitlines() == [
+    expected_mutations = [
         "mutate namespace monitoring",
         "apply namespace monitoring",
         "mutate secret monitoring/grafana-admin-credentials",
         "apply secret monitoring/grafana-admin-credentials",
     ]
+    before = {path.name for path in tmp_path.iterdir()}
+    result, audit, credentials = run_grafana_secret_helper(tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert audit.splitlines() == expected_mutations
+    assert credentials == ("operator", "correct horse battery staple")
     combined = result.stdout + result.stderr + audit
     assert "operator" not in combined
     assert "correct horse battery staple" not in combined
@@ -927,18 +962,23 @@ def test_grafana_secret_install_is_exact_redacted_and_rotatable(tmp_path):
         "watchdog",
     ):
         assert forbidden not in audit.lower()
-    assert {path.name for path in tmp_path.iterdir()} - before == {"bin", "audit", "tmp", "tty-input"}
+    assert {path.name for path in tmp_path.iterdir()} - before == {"bin", "audit", "tmp"}
     assert list((tmp_path / "tmp").iterdir()) == []
+    repeated, repeated_audit, repeated_credentials = run_grafana_secret_helper(
+        tmp_path / "repeat"
+    )
+    assert repeated.returncode == 0, repeated.stderr
+    assert repeated_audit.splitlines() == expected_mutations
+    assert repeated_credentials == ("operator", "correct horse battery staple")
     second_user = "rotation-user-sentinel"
     second_password = "rotation-password-sentinel"
-    result, audit, _ = run_grafana_secret_helper(
+    result, audit, credentials = run_grafana_secret_helper(
         tmp_path / "rotation",
         tty_text=f"{second_user}\n{second_password}\n{second_password}\n",
-        expected_user=second_user,
-        expected_password=second_password,
     )
     assert result.returncode == 0
-    assert audit.count("mutate secret monitoring/grafana-admin-credentials") == 1
+    assert audit.splitlines() == expected_mutations
+    assert credentials == (second_user, second_password)
     assert second_user not in result.stdout + result.stderr + audit
     assert second_password not in result.stdout + result.stderr + audit
     assert list((tmp_path / "rotation" / "tmp").iterdir()) == []

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -5,6 +5,7 @@ import pty
 import re
 import signal
 import subprocess
+import sys
 import termios
 import time
 from pathlib import Path
@@ -777,6 +778,19 @@ esac
         encoding="utf-8",
     )
     (bin_dir / "kubectl").chmod(0o755)
+    (bin_dir / "python3").write_text(
+        r"""#!/bin/sh
+case "${1:-}" in
+  *validate_observability_dashboard.py)
+    echo "forbidden operation: dashboard validator" >> "$AUDIT"
+    exit 99
+    ;;
+esac
+exec "$REAL_PYTHON" "$@"
+""",
+        encoding="utf-8",
+    )
+    (bin_dir / "python3").chmod(0o755)
     forbidden_stub = """#!/bin/sh
 echo "forbidden operation: $(basename "$0")" >> "$AUDIT"
 exit 99
@@ -803,6 +817,7 @@ exit 99
             "IDENTITY": identity,
             "SECRET_STATE": secret_state,
             "CAPTURE_FD": str(capture_write),
+            "REAL_PYTHON": sys.executable,
             "TMPDIR": str(script_tmp),
         }
     )
@@ -893,7 +908,24 @@ def test_grafana_secret_nonprod_test_override_is_deterministic(tmp_path):
         test_tty=False,
     )
     assert result.returncode == 0, result.stderr
-    assert audit.splitlines()[-1] == "apply secret monitoring/grafana-admin-credentials"
+    assert audit.splitlines() == [
+        "mutate namespace monitoring",
+        "apply namespace monitoring",
+        "mutate secret monitoring/grafana-admin-credentials",
+        "apply secret monitoring/grafana-admin-credentials",
+    ]
+
+
+def test_grafana_secret_check_staging_skips_dashboard_and_is_read_only(tmp_path):
+    result, audit, _ = run_grafana_secret_helper(
+        tmp_path,
+        command="grafana-secret-check",
+        env_name="staging",
+        context="sugar-staging",
+        identity="staging",
+    )
+    assert result.returncode == 0, result.stderr
+    assert audit == "secret-check\n"
 
 
 def test_grafana_secret_tty_open_failure_is_redacted(tmp_path):


### PR DESCRIPTION
### Motivation

- The previously-documented production bootstrap command suggested decrypting a checked-in SOPS scaffold that is not real ciphertext and is unsafe to apply; operators must not decrypt or apply that file or reconcile the full production overlay before CRDs exist.
- Provide a guarded, interactive, fail-closed lifecycle for creating/rotating and checking the operator-managed `monitoring/grafana-admin-credentials` Secret without ever placing plaintext credentials in Git, args, env, logs, or persistent files.

### Description

- Added guarded subcommands `grafana-secret-install` and `grafana-secret-check` to `scripts/observability_helm.sh` implementing hidden-TTY input, refusal of credential args/env/xtrace, `cluster_identity.py`/context/KUBECONFIG checks for prod, streaming credentials via anonymous file descriptors into `kubectl create secret ... --dry-run=client -o yaml | kubectl apply -f -`, idempotent namespace creation, and strict mutation limited to the `monitoring` Namespace and the `monitoring/grafana-admin-credentials` Secret with keys `admin-user` and `admin-password` only. (See `scripts/observability_helm.sh`.)
- Restored xtrace behavior for non-credential flows so diagnostics remain unchanged for other commands while refusing xtrace for credential input paths. (See `scripts/observability_helm.sh`.)
- Added `just` recipes `observability-grafana-secret-install env=prod` and `observability-grafana-secret-check env=prod` wired to the new script subcommands. (See `justfile`.)
- Replaced the unusable SOPS bootstrap instructions in `docs/observability-operations.md` with explicit guidance that the checked-in SOPS file is scaffolding, recommended operator behavior (use a password manager), and the guarded hidden-TTY install/check recipes and next sanitized operator sequence. (See `docs/observability-operations.md`.)
- Added deterministic tests exercising the new behavior and security constraints, including production guards, non-TTY/xtrace/env/arg rejection, fail-closed semantics before any mutation, idempotent install/rotation, exact mutation scope, and read-only contract checking. (See `tests/test_observability_helm.py` additions.)

### Testing

- Ran `pytest -q tests/test_observability_helm.py -k 'grafana and secret'` and observed `15 passed` for the focused grafana/secret tests.
- Ran the broader test set `pytest -q tests/test_observability_helm.py tests/test_observability_dashboard.py` and observed the repository tests exercised in this environment completed (observed test runs including the earlier full-run reported passing for the changed tests in this scope).
- Performed static checks: `bash -n scripts/observability_helm.sh` succeeded and `shellcheck scripts/observability_helm.sh` passed in this environment; `just --unstable --fmt --check` was run (the repository uses `just` v1.21 where `--fmt` is unstable and was invoked with the compatibility flag during verification).
- Documentation and link/language checks run: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` passed after installing test tooling; `git diff --stat` shows only the four permitted files changed; `git diff --cached | ./scripts/scan-secrets.py` ran and did not introduce secrets (scan flagged conservative doc redaction wording but no plaintext credentials were added).

Notes and residuals: `pre-commit run --all-files` surfaced unrelated, pre-existing repository-wide lint/yaml issues outside the four-file scope; auto-fixes touching unrelated files were reverted to preserve the change scope. No live cluster was contacted or mutated during verification and no plaintext credentials were written to disk or recorded in logs or test outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76e2595448832f89f87f630417a238)