### PR TITLE
Harden Cloudflare Tunnel recovery after WAN outages

### DIFF
--- a/clusters/staging/observability/kube-prometheus-stack.values.yaml
+++ b/clusters/staging/observability/kube-prometheus-stack.values.yaml
@@ -38,6 +38,12 @@ alertmanager:
             - environment="staging"
             - cluster="sugarkube-int"
             - severity="critical"
+        - receiver: pagerduty-dspace
+          matchers:
+            - alertname="CloudflareTunnelNoHealthyConnections"
+            - environment="staging"
+            - cluster="sugarkube-int"
+            - severity="critical"
         - receiver: pagerduty-synthetic-test
           matchers:
             - alertname="SugarkubePagerDutyTest"

--- a/config/cloudflare-tunnel/monitoring.yaml
+++ b/config/cloudflare-tunnel/monitoring.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cloudflare-tunnel-metrics
+  namespace: cloudflare
+  labels:
+    app.kubernetes.io/name: cloudflare-tunnel
+    app.kubernetes.io/instance: cloudflare-tunnel
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: cloudflare-tunnel
+    app.kubernetes.io/instance: cloudflare-tunnel
+  ports:
+    - name: metrics
+      port: 2000
+      targetPort: 2000
+      protocol: TCP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cloudflare-tunnel
+  namespace: cloudflare
+  labels:
+    release: kube-prometheus-stack
+    app.kubernetes.io/name: cloudflare-tunnel
+    app.kubernetes.io/instance: cloudflare-tunnel
+spec:
+  namespaceSelector:
+    matchNames: [cloudflare]
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudflare-tunnel
+      app.kubernetes.io/instance: cloudflare-tunnel
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cloudflare-tunnel
+  namespace: cloudflare
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudflare-tunnel
+      app.kubernetes.io/instance: cloudflare-tunnel

--- a/config/cloudflare-tunnel/values.yaml
+++ b/config/cloudflare-tunnel/values.yaml
@@ -1,5 +1,5 @@
-# Repository baseline for manually managed releases in every environment.
-# Applied by `just cf-tunnel-install`; environment-specific names are set by the recipe.
+# Canonical values for the manually managed staging release.
+# Selected only for staging by `just cf-tunnel-install`.
 # This is not a Flux resource.
 fullnameOverride: cloudflare-tunnel
 replicaCount: 2

--- a/config/cloudflare-tunnel/values.yaml
+++ b/config/cloudflare-tunnel/values.yaml
@@ -1,0 +1,21 @@
+# Repository source of truth for the manually managed staging release.
+# Applied only by `just cf-tunnel-install env=staging`; this is not a Flux resource.
+fullnameOverride: cloudflare-tunnel
+replicaCount: 2
+image:
+  repository: cloudflare/cloudflared
+  tag: 2026.7.3
+  pullPolicy: IfNotPresent
+cloudflare:
+  tunnelName: sugarkube-staging
+  tunnelId: ""
+  secretName: tunnel-token
+  ingress: []
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: cloudflare-tunnel
+            app.kubernetes.io/instance: cloudflare-tunnel

--- a/config/cloudflare-tunnel/values.yaml
+++ b/config/cloudflare-tunnel/values.yaml
@@ -1,5 +1,6 @@
-# Repository source of truth for the manually managed staging release.
-# Applied only by `just cf-tunnel-install env=staging`; this is not a Flux resource.
+# Repository baseline for manually managed releases in every environment.
+# Applied by `just cf-tunnel-install`; environment-specific names are set by the recipe.
+# This is not a Flux resource.
 fullnameOverride: cloudflare-tunnel
 replicaCount: 2
 image:

--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -151,7 +151,7 @@ Run these commands on `sugarkube0` (or whichever node has the Sugarkube checkout
 
 4. Verify readiness (Pods should report `/ready` = `200`):
 
-   The `cloudflare/cloudflared:2024.8.3` image is minimal and does **not** ship `curl`, so
+   The `cloudflare/cloudflared:2026.7.3` image is minimal and does **not** ship `curl`, so
    `kubectl exec ... curl ...` fails with `executable file not found in $PATH`. Kubernetes already
    probes `http://localhost:2000/ready`, so manual checks are optional. If you want to confirm the
    connector yourself, use a two-shell port-forward from `sugarkube0` (or any node with `kubectl`
@@ -407,3 +407,124 @@ for temporary local development. See
 - After apex promotion, `prod.democratized.space` can be converted to a redirect to
   `https://democratized.space`.
 - The Sugarkube dspace app expects this persistent tunnel setup to be in place.
+
+
+## WAN/DNS outage recovery contract
+
+### Evidence and root cause
+
+During the staging incident on 2026-08-04, 16 public probes became unreachable at
+`01:46:04Z`. The first Cloudflare HTTP 530 responses appeared at `01:56:04Z`, recovery began at
+`01:59:04Z`, and every probe had recovered by `02:00:04Z`; the observed 530 phase lasted 120–180
+seconds. An unreachable probe means no HTTP response reached the observer. By contrast, Cloudflare
+HTTP 530 with error 1033 means Cloudflare answered but had no healthy connector connected to the
+edge. See Cloudflare's [error 1033 explanation](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1033/)
+and [Tunnel troubleshooting guide](https://developers.cloudflare.com/tunnel/troubleshooting/).
+
+Both connectors failed edge DNS discovery during the WAN/DNS outage. The old Kubernetes liveness
+probe called `/ready`, an endpoint which depends on an active edge connection, and killed each pod
+about 11–12 seconds after it started. Their synchronized clean exits eventually produced roughly
+five-minute Kubernetes restart backoffs. After WAN/DNS recovery and a restart, each connector
+registered four QUIC connections in about three seconds. The delay was therefore **not** a
+multi-minute polling interval: cloudflared already reconnects with backoff, but Kubernetes prevented
+it from staying alive long enough to do so.
+
+`/ready` on port 2000 is now readiness-only (10-second period, two-second timeout, three failures).
+A disconnected connector is removed from readiness without being killed. There is deliberately no
+liveness probe: no documented process-local endpoint in this chart remains healthy independently of
+WAN, DNS, and edge availability, and Kubernetes restarts the container if cloudflared exits. Two
+replicas use required hostname anti-affinity, rolling updates use `maxUnavailable: 0` and
+`maxSurge: 1`, and a disruption budget keeps at least one connector available.
+
+### Supported version, metrics, and alerts
+
+The staging connector is pinned to `cloudflare/cloudflared:2026.7.3` and the verified multi-platform
+manifest digest. The manifest contains Linux `amd64` and `arm64` images, matching development and
+Pi cluster needs. Never substitute `latest`; review the [official downloads and supported-version
+page](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/)
+before updating both tag and verified digest. Chart `cloudflare-tunnel-0.3.2` does not expose a
+digest value, so the canonical install recipe applies the immutable `tag@digest` to the chart-owned
+Deployment without changing the chart version.
+
+The private `cloudflare-tunnel-metrics` ClusterIP Service selects only the two release pods. Its
+ServiceMonitor is discovered by `kube-prometheus-stack` and scrapes each pod as a distinct target at
+`/metrics` every 30 seconds with a 10-second timeout. Nothing exposes port 2000 publicly. Cloudflare
+documents these [connector metrics and readiness semantics](https://developers.cloudflare.com/tunnel/monitoring/).
+
+### Alerts
+
+- `CloudflareTunnelNoHealthyConnections` pages after aggregate
+  `cloudflared_tunnel_ha_connections` remains zero for five minutes while both scrape targets are
+  healthy.
+- `CloudflareTunnelConnectionsDegraded` warns after ten minutes if fewer than two connector series
+  exist or either connector reports fewer than the expected four HA connections. This delay excludes
+  ordinary rolling churn and brief individual QUIC reconnections.
+- `CloudflareTunnelMetricsTargetsDown` warns after five minutes if `up` shows fewer than two healthy
+  targets, including absent series. Missing telemetry does not by itself prove tunnel failure.
+
+Run the repository-owned, read-only gate only against staging:
+
+```bash
+just cf-tunnel-verify env=staging
+```
+
+It fails closed on the context, chart/release ownership, image, probes, HA scheduling and rollout,
+Secret **reference**, Service/ServiceMonitor selectors, two Prometheus targets, HA connection counts,
+and loaded/non-firing alerts. It never reads Secret data.
+
+### Separately authorized post-merge rollout and recovery drill
+
+This procedure is manual, staging-only, and must never run in CI. Obtain owner authorization and a
+maintenance window before starting. The live `cloudflare/cloudflare-tunnel` Helm release installed
+by `just cf-tunnel-install` is the intended reconciliation path. The dormant `platform/cloudflared`
+Flux resources use a different namespace and credential contract; do not reconcile or adopt them as
+part of this rollout.
+
+1. Select staging and prove ownership before mutation:
+
+   ```bash
+   just assert-cluster-env env=staging
+   test "$(kubectl config current-context)" = sugar-staging
+   helm -n cloudflare list --filter '^cloudflare-tunnel$'
+   kubectl -n cloudflare get deploy cloudflare-tunnel -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}{"\n"}'
+   kubectl -n cloudflare get secret tunnel-token -o 'go-template={{if index .data "token"}}token key present (value not read){{end}}{{"\n"}}'
+   ```
+
+   Stop unless exactly one deployed `cloudflare-tunnel` release exists and the Deployment is
+   Helm-managed. Do not print, replace, rotate, or recreate the existing Secret. Remote-managed host
+   routes stay in Cloudflare and are not part of this repository rollout.
+
+2. Record `helm -n cloudflare history cloudflare-tunnel`, the current revision, public endpoint
+   results, pod/node placement, and image. With the existing token supplied out of band in the
+   operator's environment, run `just cf-tunnel-install env=staging`. Watch
+   `kubectl -n cloudflare rollout status deploy/cloudflare-tunnel --timeout=5m` and confirm at every
+   transition that at least one old or new pod remains Ready.
+3. Run `just cf-tunnel-verify env=staging`; verify two Ready pods on separate nodes, version
+   `2026.7.3`, readiness-only `/ready`, two Prometheus targets, four HA connections per connector,
+   healthy alerts, and every approved staging public endpoint.
+4. For the authorized recovery drill, delete **one owner-selected pod only** by its exact name:
+
+   ```bash
+   pod='<one cloudflare-tunnel pod selected by the owner>'
+   kubectl -n cloudflare delete pod "$pod"
+   kubectl -n cloudflare rollout status deploy/cloudflare-tunnel --timeout=5m
+   just cf-tunnel-verify env=staging
+   ```
+
+   Do not disrupt a node, WAN, DNS, both pods, the Deployment, the Secret, or any production
+   resource. The replacement must reconnect within five minutes while the other connector and public
+   endpoints remain available.
+5. Cleanup is only `unset CF_TUNNEL_TOKEN CF_TUNNEL_NAME CF_TUNNEL_ID pod`; retain the two healthy
+   replacement pods, Service, ServiceMonitor, and PDB. No drill resource should remain.
+
+Rollback immediately if no connector stays Ready, a public endpoint fails for two consecutive
+one-minute checks, a replacement does not reach four HA connections within five minutes, metrics
+remain below two healthy targets, or a new critical alert fires. Use
+`helm -n cloudflare rollback cloudflare-tunnel <recorded-revision> --wait --timeout 5m`, then restore
+the repository-owned monitoring manifest if needed and re-run the public checks. Because Helm 0.3.2
+does not retain the post-install lifecycle patch in an older revision, rollback is an emergency
+availability action; do not delete or alter `tunnel-token`, and stop for owner review before any
+further rollout.
+
+The connector token remains out of band. It is never stored in Git, metrics, test fixtures, operator
+captures, or commands that print its value.

--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -454,8 +454,8 @@ documents these [connector metrics and readiness semantics](https://developers.c
 ### Alerts
 
 - `CloudflareTunnelNoHealthyConnections` pages after aggregate
-  `cloudflared_tunnel_ha_connections` remains zero for five minutes while both scrape targets are
-  healthy.
+  `cloudflared_tunnel_ha_connections` remains zero for five minutes when at least one connection series is present. Missing connection
+  metrics do not prove an outage.
 - `CloudflareTunnelConnectionsDegraded` warns after ten minutes if fewer than two connector series
   exist or either connector reports fewer than the expected four HA connections. This delay excludes
   ordinary rolling churn and brief individual QUIC reconnections.
@@ -487,7 +487,7 @@ part of this rollout.
    test "$(kubectl config current-context)" = sugar-staging
    helm -n cloudflare list --filter '^cloudflare-tunnel$'
    kubectl -n cloudflare get deploy cloudflare-tunnel -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}{"\n"}'
-   kubectl -n cloudflare get secret tunnel-token -o 'go-template={{if index .data "token"}}token key present (value not read){{end}}{{"\n"}}'
+   kubectl -n cloudflare get secret tunnel-token -o name
    ```
 
    Stop unless exactly one deployed `cloudflare-tunnel` release exists and the Deployment is
@@ -502,20 +502,26 @@ part of this rollout.
 3. Run `just cf-tunnel-verify env=staging`; verify two Ready pods on separate nodes, version
    `2026.7.3`, readiness-only `/ready`, two Prometheus targets, four HA connections per connector,
    healthy alerts, and every approved staging public endpoint.
-4. For the authorized recovery drill, delete **one owner-selected pod only** by its exact name:
+4. A pod-deletion drill is not an acceptable WAN-recovery test: it proves replacement, not that the
+   same cloudflared processes stay alive during dependency loss and reconnect afterward. The repository
+   shows that staging uses Kubernetes `NetworkPolicy`, but it does not establish which staging CNI
+   enforces a temporary egress-deny policy or prove that an exact release selector cannot affect other
+   workloads. Therefore the dependency-loss drill is **blocked** pending separate owner confirmation of
+   the staging CNI and its egress-policy behavior. Do not apply a speculative policy or substitute pod
+   deletion.
 
-   ```bash
-   pod='<one cloudflare-tunnel pod selected by the owner>'
-   kubectl -n cloudflare delete pod "$pod"
-   kubectl -n cloudflare rollout status deploy/cloudflare-tunnel --timeout=5m
-   just cf-tunnel-verify env=staging
-   ```
-
-   Do not disrupt a node, WAN, DNS, both pods, the Deployment, the Secret, or any production
-   resource. The replacement must reconnect within five minutes while the other connector and public
-   endpoints remain available.
-5. Cleanup is only `unset CF_TUNNEL_TOKEN CF_TUNNEL_NAME CF_TUNNEL_ID pod`; retain the two healthy
-   replacement pods, Service, ServiceMonitor, and PDB. No drill resource should remain.
+   Once that evidence is recorded, a separately authorized procedure must use a uniquely named,
+   temporary `NetworkPolicy` in `cloudflare`, selecting exactly
+   `app.kubernetes.io/name=cloudflare-tunnel` and
+   `app.kubernetes.io/instance=cloudflare-tunnel`. Before applying it, record both pod names, UIDs, and
+   restart counts and install a cleanup trap that deletes that exact policy name. Keep the deny interval
+   below five minutes (the shortest alert `for` duration); verify readiness becomes false while both UIDs
+   and restart counts remain unchanged. Delete the exact policy, then require those same two pods to
+   become Ready and report at least four HA connections each within five minutes. This contract may be
+   executed only after the CNI safety blocker is resolved and the exact manifest is separately reviewed.
+5. Cleanup is `unset CF_TUNNEL_TOKEN CF_TUNNEL_NAME CF_TUNNEL_ID`; retain the two healthy pods,
+   Service, ServiceMonitor, and PDB. If a future authorized drill resolves the blocker, exact deletion of
+   its uniquely named NetworkPolicy is mandatory even on interruption.
 
 Rollback immediately if no connector stays Ready, a public endpoint fails for two consecutive
 one-minute checks, a replacement does not reach four HA connections within five minutes, metrics

--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -495,8 +495,9 @@ part of this rollout.
    routes stay in Cloudflare and are not part of this repository rollout.
 
 2. Record `helm -n cloudflare history cloudflare-tunnel`, the current revision, public endpoint
-   results, pod/node placement, and image. With the existing token supplied out of band in the
-   operator's environment, run `just cf-tunnel-install env=staging`. Watch
+   results, pod/node placement, and image. The preflight-confirmed Secret is preserved: supply no
+   token argument or `CF_TUNNEL_TOKEN` value, and do not read, print, or reapply the token. Run
+   `just cf-tunnel-install env=staging`. Watch
    `kubectl -n cloudflare rollout status deploy/cloudflare-tunnel --timeout=5m` and confirm at every
    transition that at least one old or new pod remains Ready.
 3. Run `just cf-tunnel-verify env=staging`; verify two Ready pods on separate nodes, version

--- a/justfile
+++ b/justfile
@@ -611,14 +611,9 @@ cf-tunnel-install env='dev' token='':
     helm repo add cloudflare https://cloudflare.github.io/helm-charts --force-update
     helm repo update cloudflare
 
-    values_yaml=$(printf '%s\n' \
-    'fullnameOverride: cloudflare-tunnel' \
-    'cloudflare:' \
-    "  tunnelName: \"${CF_TUNNEL_NAME:-sugarkube-${env_name}}\"" \
-    "  tunnelId: \"${CF_TUNNEL_ID:-}\"" \
-    '  secretName: tunnel-token' \
-    '  ingress: []'
-    )
+    values_file="{{ justfile_directory() }}/config/cloudflare-tunnel/values.yaml"
+    monitoring_file="{{ justfile_directory() }}/config/cloudflare-tunnel/monitoring.yaml"
+    chart_version="0.3.2"
 
     existing=$(helm -n cloudflare list --filter '^cloudflare-tunnel$' --output json 2>/dev/null || true)
     if [ -n "${existing}" ]; then
@@ -637,7 +632,10 @@ cf-tunnel-install env='dev' token='':
     if ! helm upgrade --install cloudflare-tunnel cloudflare/cloudflare-tunnel \
     --namespace cloudflare \
     --create-namespace \
-    --values - <<<"${values_yaml}"; then
+    --version "${chart_version}" \
+    --values "${values_file}" \
+    --set-string "cloudflare.tunnelName=${CF_TUNNEL_NAME:-sugarkube-${env_name}}" \
+    --set-string "cloudflare.tunnelId=${CF_TUNNEL_ID:-}"; then
     helm_exit_code=$?
     echo "Helm upgrade/install failed; diagnostics to follow:" >&2
     helm -n cloudflare status cloudflare-tunnel || true
@@ -657,12 +655,18 @@ cf-tunnel-install env='dev' token='':
     {"op":"replace","path":"/spec/template/spec/volumes","value":[]},
     {"op":"replace","path":"/spec/template/spec/containers/0/env","value":[{"name":"TUNNEL_TOKEN","valueFrom":{"secretKeyRef":{"name":"tunnel-token","key":"token"}}}]},
     {"op":"replace","path":"/spec/template/spec/containers/0/volumeMounts","value":[]},
-    {"op":"replace","path":"/spec/template/spec/containers/0/image","value":"cloudflare/cloudflared:2024.8.3"},
+    {"op":"replace","path":"/spec/replicas","value":2},
+    {"op":"replace","path":"/spec/strategy","value":{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":0,"maxSurge":1}}},
+    {"op":"replace","path":"/spec/template/spec/containers/0/image","value":"cloudflare/cloudflared:2026.7.3@sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf"},
     {"op":"replace","path":"/spec/template/spec/containers/0/command","value":["cloudflared","tunnel","--no-autoupdate","--metrics","0.0.0.0:2000","run"]},
-    {"op":"replace","path":"/spec/template/spec/containers/0/args","value":[]}
+    {"op":"replace","path":"/spec/template/spec/containers/0/args","value":[]},
+    {"op":"remove","path":"/spec/template/spec/containers/0/livenessProbe"},
+    {"op":"add","path":"/spec/template/spec/containers/0/readinessProbe","value":{"httpGet":{"path":"/ready","port":2000},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":2,"failureThreshold":3,"successThreshold":1}}
     ]'
 
     kubectl -n cloudflare patch deployment cloudflare-tunnel --type json --patch "${deployment_patch}"
+    # These owner-scoped resources remain on ClusterIP and select only this release.
+    kubectl apply -f "${monitoring_file}"
 
     helm_note_printed=0
 
@@ -673,27 +677,13 @@ cf-tunnel-install env='dev' token='':
     kubectl -n cloudflare get deploy,po -l app.kubernetes.io/name=cloudflare-tunnel || true
     kubectl -n cloudflare logs deploy/cloudflare-tunnel --tail=50 || true
 
-    echo "Attempting teardown + retry: deleting existing pods and retrying rollout..." >&2
-    kubectl -n cloudflare delete pod -l app.kubernetes.io/name=cloudflare-tunnel || true
-
-    sleep 5
-
-    if ! kubectl -n cloudflare rollout status deployment/cloudflare-tunnel --timeout=60s; then
-    echo "cloudflare-tunnel still failing after teardown+retry; see logs above." >&2
-    helm -n cloudflare status cloudflare-tunnel || true
-    kubectl -n cloudflare get deploy,po -l app.kubernetes.io/name=cloudflare-tunnel || true
+    # Never delete both connectors to force a retry: that defeats the HA rollout contract and can
+    # synchronize their restart backoff. Leave the live rollout intact for owner diagnosis.
     logs=$(kubectl -n cloudflare logs deploy/cloudflare-tunnel --tail=50 2>/dev/null || true)
-    printf '%s\n' "${logs}"
-
-        if printf '%s' "${logs}" | grep -Eq "Cannot determine default origin certificate path|client didn't specify origincert path"; then
-            printf '%s\n' "${origin_cert_guidance}" >&2
-        fi
-    if [ "${helm_exit_code:-0}" -ne 0 ] && [ "${helm_note_printed}" -eq 0 ]; then
-    echo "Note: Helm reported errors earlier; token-mode patches still applied." >&2
-    helm_note_printed=1
+    if printf '%s' "${logs}" | grep -Eq "Cannot determine default origin certificate path|client didn't specify origincert path"; then
+        printf '%s\n' "${origin_cert_guidance}" >&2
     fi
     exit 1
-    fi
     fi
 
     if [ "${helm_exit_code:-0}" -ne 0 ] && [ "${helm_note_printed}" -eq 0 ]; then
@@ -707,6 +697,10 @@ cf-tunnel-install env='dev' token='':
     "- Tunnel name: ${CF_TUNNEL_NAME:-sugarkube-${env_name}}" \
     '- Verify readiness: kubectl -n cloudflare get deploy,po -l app.kubernetes.io/name=cloudflare-tunnel' \
     '- Readiness endpoint: /ready must return 200'
+
+# Read-only staging verification; never reads Secret data.
+cf-tunnel-verify env='staging':
+    scripts/verify_cloudflare_tunnel.sh {{ quote(env) }}
 
 # Hard reset the Cloudflare Tunnel resources in the cluster for a fresh cf-tunnel-install.
 cf-tunnel-reset:

--- a/justfile
+++ b/justfile
@@ -569,9 +569,14 @@ cf-tunnel-install env='dev' token='':
 
     origin_cert_guidance="{{ origin_cert_guidance }}"
 
+    kubectl get namespace cloudflare >/dev/null 2>&1 || kubectl create namespace cloudflare
+
+    if kubectl -n cloudflare get secret tunnel-token -o name >/dev/null 2>&1; then
+    echo "Using existing cloudflare/tunnel-token Secret; its value was not read or changed."
+    else
     : "${token:=${CF_TUNNEL_TOKEN:-}}"
     if [ -z "${token}" ]; then
-    echo "Set CF_TUNNEL_TOKEN or pass token=<tunnel-token> to proceed." >&2
+    echo "Set CF_TUNNEL_TOKEN or pass token=<tunnel-token> for the initial installation." >&2
     exit 1
     fi
 
@@ -589,7 +594,6 @@ cf-tunnel-install env='dev' token='':
     if printf '%s' "${token}" | grep -q "cloudflared"; then
     token="$(printf '%s' "${token}" | awk '{print $NF}')"
     fi
-    # Final whitespace trim after all token transforms
     token="$(printf '%s' "${token}" | sed -e 's/^ *//' -e 's/ *$//')"
 
     token_len=${#token}
@@ -602,11 +606,10 @@ cf-tunnel-install env='dev' token='':
     echo "Ensure you copied the connector token from the 'tunnel run --token' snippet." >&2
     fi
 
-    kubectl get namespace cloudflare >/dev/null 2>&1 || kubectl create namespace cloudflare
-
     kubectl -n cloudflare create secret generic tunnel-token \
     --from-literal=token="${token}" \
     --dry-run=client -o yaml | kubectl apply -f -
+    fi
 
     helm repo add cloudflare https://cloudflare.github.io/helm-charts --force-update
     helm repo update cloudflare
@@ -614,6 +617,19 @@ cf-tunnel-install env='dev' token='':
     values_file="{{ justfile_directory() }}/config/cloudflare-tunnel/values.yaml"
     monitoring_file="{{ justfile_directory() }}/config/cloudflare-tunnel/monitoring.yaml"
     chart_version="0.3.2"
+    values_yaml=$(printf '%s\n' \
+    'fullnameOverride: cloudflare-tunnel' \
+    'cloudflare:' \
+    "  tunnelName: \"${CF_TUNNEL_NAME:-sugarkube-${env_name}}\"" \
+    "  tunnelId: \"${CF_TUNNEL_ID:-}\"" \
+    '  secretName: tunnel-token' \
+    '  ingress: []')
+    helm_values=(--values -)
+    if [ "${env_name}" = "staging" ]; then
+    helm_values=(--version "${chart_version}" --values "${values_file}" \
+    --set-string "cloudflare.tunnelName=${CF_TUNNEL_NAME:-sugarkube-${env_name}}" \
+    --set-string "cloudflare.tunnelId=${CF_TUNNEL_ID:-}")
+    fi
 
     existing=$(helm -n cloudflare list --filter '^cloudflare-tunnel$' --output json 2>/dev/null || true)
     if [ -n "${existing}" ]; then
@@ -632,10 +648,7 @@ cf-tunnel-install env='dev' token='':
     if ! helm upgrade --install cloudflare-tunnel cloudflare/cloudflare-tunnel \
     --namespace cloudflare \
     --create-namespace \
-    --version "${chart_version}" \
-    --values "${values_file}" \
-    --set-string "cloudflare.tunnelName=${CF_TUNNEL_NAME:-sugarkube-${env_name}}" \
-    --set-string "cloudflare.tunnelId=${CF_TUNNEL_ID:-}"; then
+    "${helm_values[@]}" <<<"${values_yaml}"; then
     helm_exit_code=$?
     echo "Helm upgrade/install failed; diagnostics to follow:" >&2
     helm -n cloudflare status cloudflare-tunnel || true
@@ -655,18 +668,22 @@ cf-tunnel-install env='dev' token='':
     {"op":"replace","path":"/spec/template/spec/volumes","value":[]},
     {"op":"replace","path":"/spec/template/spec/containers/0/env","value":[{"name":"TUNNEL_TOKEN","valueFrom":{"secretKeyRef":{"name":"tunnel-token","key":"token"}}}]},
     {"op":"replace","path":"/spec/template/spec/containers/0/volumeMounts","value":[]},
-    {"op":"replace","path":"/spec/replicas","value":2},
-    {"op":"replace","path":"/spec/strategy","value":{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":0,"maxSurge":1}}},
-    {"op":"add","path":"/spec/template/spec/affinity","value":{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"topologyKey":"kubernetes.io/hostname","labelSelector":{"matchLabels":{"app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}}}]}}},
-    {"op":"replace","path":"/spec/template/spec/containers/0/image","value":"cloudflare/cloudflared:2026.7.3@sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf"},
+    {"op":"replace","path":"/spec/template/spec/containers/0/image","value":"cloudflare/cloudflared:2024.8.3"},
     {"op":"replace","path":"/spec/template/spec/containers/0/command","value":["cloudflared","tunnel","--no-autoupdate","--metrics","0.0.0.0:2000","run"]},
-    {"op":"replace","path":"/spec/template/spec/containers/0/args","value":[]},
-    {"op":"remove","path":"/spec/template/spec/containers/0/livenessProbe"},
-    {"op":"add","path":"/spec/template/spec/containers/0/readinessProbe","value":{"httpGet":{"path":"/ready","port":2000},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":2,"failureThreshold":3,"successThreshold":1}}
+    {"op":"replace","path":"/spec/template/spec/containers/0/args","value":[]}
     ]'
 
     kubectl -n cloudflare patch deployment cloudflare-tunnel --type json --patch "${deployment_patch}"
     if [ "${env_name}" = "staging" ]; then
+    staging_patch='[
+    {"op":"replace","path":"/spec/template/spec/containers/0/image","value":"cloudflare/cloudflared:2026.7.3@sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf"},
+    {"op":"replace","path":"/spec/replicas","value":2},
+    {"op":"replace","path":"/spec/strategy","value":{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":0,"maxSurge":1}}},
+    {"op":"add","path":"/spec/template/spec/affinity","value":{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"topologyKey":"kubernetes.io/hostname","labelSelector":{"matchLabels":{"app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}}}]}}},
+    {"op":"remove","path":"/spec/template/spec/containers/0/livenessProbe"},
+    {"op":"add","path":"/spec/template/spec/containers/0/readinessProbe","value":{"httpGet":{"path":"/ready","port":2000},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":2,"failureThreshold":3,"successThreshold":1}}
+    ]'
+    kubectl -n cloudflare patch deployment cloudflare-tunnel --type json --patch "${staging_patch}"
     # Production and development do not necessarily install the ServiceMonitor CRD.
     # These staging owner-scoped resources remain on ClusterIP and select only this release.
     kubectl apply -f "${monitoring_file}"

--- a/justfile
+++ b/justfile
@@ -657,6 +657,7 @@ cf-tunnel-install env='dev' token='':
     {"op":"replace","path":"/spec/template/spec/containers/0/volumeMounts","value":[]},
     {"op":"replace","path":"/spec/replicas","value":2},
     {"op":"replace","path":"/spec/strategy","value":{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":0,"maxSurge":1}}},
+    {"op":"add","path":"/spec/template/spec/affinity","value":{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"topologyKey":"kubernetes.io/hostname","labelSelector":{"matchLabels":{"app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}}}]}}},
     {"op":"replace","path":"/spec/template/spec/containers/0/image","value":"cloudflare/cloudflared:2026.7.3@sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf"},
     {"op":"replace","path":"/spec/template/spec/containers/0/command","value":["cloudflared","tunnel","--no-autoupdate","--metrics","0.0.0.0:2000","run"]},
     {"op":"replace","path":"/spec/template/spec/containers/0/args","value":[]},
@@ -665,8 +666,11 @@ cf-tunnel-install env='dev' token='':
     ]'
 
     kubectl -n cloudflare patch deployment cloudflare-tunnel --type json --patch "${deployment_patch}"
-    # These owner-scoped resources remain on ClusterIP and select only this release.
+    if [ "${env_name}" = "staging" ]; then
+    # Production and development do not necessarily install the ServiceMonitor CRD.
+    # These staging owner-scoped resources remain on ClusterIP and select only this release.
     kubectl apply -f "${monitoring_file}"
+    fi
 
     helm_note_printed=0
 

--- a/platform/observability/rules/cloudflare-tunnel.yaml
+++ b/platform/observability/rules/cloudflare-tunnel.yaml
@@ -1,0 +1,44 @@
+---
+groups:
+  - name: cloudflare-tunnel
+    interval: 30s
+    rules:
+      - alert: CloudflareTunnelNoHealthyConnections
+        expr: (sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"}) or vector(0)) == 0 and on() count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1) == 2
+        for: 5m
+        labels:
+          application: cloudflare-tunnel
+          environment: staging
+          cluster: sugarkube-int
+          severity: critical
+        annotations:
+          summary: No Cloudflare Tunnel edge connections are healthy
+          description: Both staging connectors have reported zero aggregate HA connections for five minutes.
+          remediation: Check WAN and DNS first; do not restart connectors that are alive and reconnecting.
+          runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/cloudflare_tunnel.md#alerts
+      - alert: CloudflareTunnelConnectionsDegraded
+        expr: count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"} < 4) > 0 or count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"}) < 2 or absent(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"})
+        for: 10m
+        labels:
+          application: cloudflare-tunnel
+          environment: staging
+          cluster: sugarkube-int
+          severity: warning
+        annotations:
+          summary: Cloudflare Tunnel connector capacity is degraded
+          description: Fewer than two connectors report metrics or a connector has fewer than four HA connections.
+          remediation: Inspect target and connector status after excluding an ordinary rolling upgrade.
+          runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/cloudflare_tunnel.md#alerts
+      - alert: CloudflareTunnelMetricsTargetsDown
+        expr: count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1) < 2 or absent(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"})
+        for: 5m
+        labels:
+          application: cloudflare-tunnel
+          environment: staging
+          cluster: sugarkube-int
+          severity: warning
+        annotations:
+          summary: Cloudflare Tunnel metrics targets are absent or down
+          description: Prometheus has fewer than two healthy cloudflared scrape targets; this does not alone prove the tunnel is down.
+          remediation: Check ServiceMonitor discovery, Service selectors, pods, and network policy.
+          runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/cloudflare_tunnel.md#alerts

--- a/platform/observability/rules/cloudflare-tunnel.yaml
+++ b/platform/observability/rules/cloudflare-tunnel.yaml
@@ -4,7 +4,7 @@ groups:
     interval: 30s
     rules:
       - alert: CloudflareTunnelNoHealthyConnections
-        expr: (sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"}) or vector(0)) == 0 and on() count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1) == 2
+        expr: (sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"}) == 0) and (count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"}) > 0)
         for: 5m
         labels:
           application: cloudflare-tunnel
@@ -13,11 +13,11 @@ groups:
           severity: critical
         annotations:
           summary: No Cloudflare Tunnel edge connections are healthy
-          description: Both staging connectors have reported zero aggregate HA connections for five minutes.
+          description: The available staging connector metrics have reported zero aggregate HA connections for five minutes.
           remediation: Check WAN and DNS first; do not restart connectors that are alive and reconnecting.
           runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/cloudflare_tunnel.md#alerts
       - alert: CloudflareTunnelConnectionsDegraded
-        expr: count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"} < 4) > 0 or count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"}) < 2 or absent(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"})
+        expr: ((count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"}) > 0) and (count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"}) < 2)) or (count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"} < 4) > 0)
         for: 10m
         labels:
           application: cloudflare-tunnel
@@ -30,7 +30,7 @@ groups:
           remediation: Inspect target and connector status after excluding an ordinary rolling upgrade.
           runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/cloudflare_tunnel.md#alerts
       - alert: CloudflareTunnelMetricsTargetsDown
-        expr: count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1) < 2 or absent(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"})
+        expr: (count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1) or vector(0)) < 2
         for: 5m
         labels:
           application: cloudflare-tunnel

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -10,6 +10,7 @@ COMMON_VALUES="${ROOT}/platform/observability/helm/kube-prometheus-stack.values.
 STAGING_VALUES="${ROOT}/clusters/staging/observability/kube-prometheus-stack.values.yaml"
 PROD_VALUES="${ROOT}/clusters/prod/observability/kube-prometheus-stack.values.yaml"
 DSPACE_RULES="${ROOT}/platform/observability/rules/dspace-release-integrity.yaml"
+CLOUDFLARE_RULES="${ROOT}/platform/observability/rules/cloudflare-tunnel.yaml"
 DASHBOARD="${ROOT}/clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
 DASHBOARD_VALUE="grafana.dashboards.sugarkube.sugarkube-staging-observability.json"
 DASHBOARD_VALIDATOR="${ROOT}/scripts/validate_observability_dashboard.py"
@@ -84,14 +85,20 @@ create_rules_overlay() {
   RULES_OVERLAY="$(mktemp -t sugarkube-observability-rules.XXXXXX.yaml)"
   chmod 600 "${RULES_OVERLAY}"
   ruby -ryaml -e '
-    rules = YAML.safe_load_file(ARGV.fetch(0), aliases: false)
-    unless rules.is_a?(Hash) && rules.keys == ["groups"] &&
-           rules["groups"].is_a?(Array) && !rules["groups"].empty?
-      abort "ERROR: canonical DSPACE rules must contain only a nonempty groups list."
+    dspace = YAML.safe_load_file(ARGV.fetch(0), aliases: false)
+    cloudflare = YAML.safe_load_file(ARGV.fetch(1), aliases: false)
+    {"DSPACE" => dspace, "Cloudflare Tunnel" => cloudflare}.each do |name, rules|
+      unless rules.is_a?(Hash) && rules.keys == ["groups"] &&
+             rules["groups"].is_a?(Array) && !rules["groups"].empty?
+        abort "ERROR: canonical #{name} rules must contain only a nonempty groups list."
+      end
     end
-    overlay = {"additionalPrometheusRulesMap" => {"dspace-release-integrity" => rules}}
-    File.write(ARGV.fetch(1), YAML.dump(overlay))
-  ' "${DSPACE_RULES}" "${RULES_OVERLAY}"
+    overlay = {"additionalPrometheusRulesMap" => {
+      "dspace-release-integrity" => dspace,
+      "cloudflare-tunnel" => cloudflare,
+    }}
+    File.write(ARGV.fetch(2), YAML.dump(overlay))
+  ' "${DSPACE_RULES}" "${CLOUDFLARE_RULES}" "${RULES_OVERLAY}"
 }
 validate_dashboard() { python3 "${DASHBOARD_VALIDATOR}" "${DASHBOARD}"; }
 validate_rendered_dashboard() { python3 "${DASHBOARD_VALIDATOR}" "${DASHBOARD}" --rendered "$1"; }

--- a/scripts/verify_cloudflare_tunnel.sh
+++ b/scripts/verify_cloudflare_tunnel.sh
@@ -20,6 +20,13 @@ jq -e --arg image "${expected_image}" '
   .spec.replicas == 2 and
   .spec.strategy.rollingUpdate.maxUnavailable == 0 and
   .spec.strategy.rollingUpdate.maxSurge == 1 and
+  .spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution == [{
+    "topologyKey":"kubernetes.io/hostname",
+    "labelSelector":{"matchLabels":{
+      "app.kubernetes.io/name":"cloudflare-tunnel",
+      "app.kubernetes.io/instance":"cloudflare-tunnel"
+    }}
+  }] and
   .spec.template.spec.containers[0].image == $image and
   (.spec.template.spec.containers[0] | has("livenessProbe") | not) and
   .spec.template.spec.containers[0].readinessProbe.httpGet.path == "/ready" and

--- a/scripts/verify_cloudflare_tunnel.sh
+++ b/scripts/verify_cloudflare_tunnel.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Read-only verification for the manually managed staging Cloudflare Tunnel release.
+set -Eeuo pipefail
+
+env_name="${1#env=}"
+[[ "${env_name}" == staging ]] || { echo "ERROR: Cloudflare Tunnel verification is staging-only." >&2; exit 2; }
+expected_context="sugar-staging"
+context="$(kubectl config current-context)"
+[[ "${context}" == "${expected_context}" ]] || { echo "ERROR: expected context ${expected_context}; got ${context:-<none>}." >&2; exit 3; }
+
+releases="$(helm -n cloudflare list -o json)"
+release_count="$(jq '[.[] | select(.name == "cloudflare-tunnel")] | length' <<<"${releases}")"
+[[ "${release_count}" == 1 ]] || { echo "ERROR: expected exactly one cloudflare/cloudflare-tunnel Helm release; found ${release_count}." >&2; exit 4; }
+[[ "$(jq -r '.[] | select(.name == "cloudflare-tunnel") | .chart' <<<"${releases}")" == "cloudflare-tunnel-0.3.2" ]] || { echo "ERROR: release must use chart cloudflare-tunnel-0.3.2." >&2; exit 4; }
+
+deployment="$(kubectl -n cloudflare get deployment cloudflare-tunnel -o json)"
+expected_image='cloudflare/cloudflared:2026.7.3@sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf'
+jq -e --arg image "${expected_image}" '
+  .metadata.labels["app.kubernetes.io/managed-by"] == "Helm" and
+  .spec.replicas == 2 and
+  .spec.strategy.rollingUpdate.maxUnavailable == 0 and
+  .spec.strategy.rollingUpdate.maxSurge == 1 and
+  .spec.template.spec.containers[0].image == $image and
+  (.spec.template.spec.containers[0] | has("livenessProbe") | not) and
+  .spec.template.spec.containers[0].readinessProbe.httpGet.path == "/ready" and
+  .spec.template.spec.containers[0].readinessProbe.httpGet.port == 2000 and
+  .spec.template.spec.containers[0].env == [{"name":"TUNNEL_TOKEN","valueFrom":{"secretKeyRef":{"name":"tunnel-token","key":"token"}}}] and
+  (.spec.template.spec.volumes | length) == 0
+' <<<"${deployment}" >/dev/null
+
+pods="$(kubectl -n cloudflare get pods -l app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel -o json)"
+jq -e '[.items[] | select(.status.phase == "Running")] | length == 2 and ([.items[].spec.nodeName] | unique | length == 2)' <<<"${pods}" >/dev/null
+kubectl -n cloudflare get pdb cloudflare-tunnel -o json | jq -e '.spec.minAvailable == 1' >/dev/null
+service="$(kubectl -n cloudflare get service cloudflare-tunnel-metrics -o json)"
+monitor="$(kubectl -n cloudflare get servicemonitor cloudflare-tunnel -o json)"
+jq -e '.spec.type == "ClusterIP" and .spec.selector == {"app.kubernetes.io/instance":"cloudflare-tunnel","app.kubernetes.io/name":"cloudflare-tunnel"} and .spec.ports == [{"name":"metrics","port":2000,"protocol":"TCP","targetPort":2000}]' <<<"${service}" >/dev/null
+jq -e '.metadata.labels.release == "kube-prometheus-stack" and .spec.selector.matchLabels == {"app.kubernetes.io/instance":"cloudflare-tunnel","app.kubernetes.io/name":"cloudflare-tunnel"} and .spec.endpoints[0].path == "/metrics"' <<<"${monitor}" >/dev/null
+
+prom_query() {
+  local query encoded
+  query="$1"
+  encoded="$(jq -nr --arg v "${query}" '$v|@uri')"
+  kubectl get --raw "/api/v1/namespaces/monitoring/services/http:kube-prometheus-stack-prometheus:9090/proxy/api/v1/query?query=${encoded}"
+}
+[[ "$(prom_query 'count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1)' | jq -r '.data.result[0].value[1] // "0"')" == 2 ]]
+[[ "$(prom_query 'count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"} >= 4)' | jq -r '.data.result[0].value[1] // "0"')" == 2 ]]
+[[ "$(prom_query 'count(ALERTS{alertname=~"CloudflareTunnel(NoHealthyConnections|ConnectionsDegraded|MetricsTargetsDown)",alertstate="firing"})' | jq -r '.data.result[0].value[1] // "0"')" == 0 ]]
+rules="$(kubectl get --raw '/api/v1/namespaces/monitoring/services/http:kube-prometheus-stack-prometheus:9090/proxy/api/v1/rules?type=alert')"
+jq -e '[.data.groups[].rules[] | select(.name == "CloudflareTunnelNoHealthyConnections" or .name == "CloudflareTunnelConnectionsDegraded" or .name == "CloudflareTunnelMetricsTargetsDown") | select(.health == "ok")] | length == 3' <<<"${rules}" >/dev/null
+printf '%s\n' 'Cloudflare Tunnel staging verification passed (Secret values were not read).'

--- a/scripts/verify_observability_alertmanager.rb
+++ b/scripts/verify_observability_alertmanager.rb
@@ -17,6 +17,8 @@ HC_MATCHERS = ['alertname="SugarkubeObservabilityWatchdog"', 'environment="stagi
                'cluster="sugarkube-int"', 'purpose="observability-watchdog"'].freeze
 DSPACE_MATCHERS = ['alertname=~"^(DspaceBuildRevisionMismatch|DspaceMixedBuildRevisions|DspaceDeploymentImagePinMismatch|DspaceChatSyntheticFailed|DspaceMetricsTargetDown)$"',
                    'environment="staging"', 'cluster="sugarkube-int"', 'severity="critical"'].freeze
+CLOUDFLARE_MATCHERS = ['alertname="CloudflareTunnelNoHealthyConnections"', 'environment="staging"',
+                       'cluster="sugarkube-int"', 'severity="critical"'].freeze
 
 def fail_closed(message)
   warn "ERROR: Alertmanager integration structure invalid: #{message} (sensitive values not printed)."
@@ -82,7 +84,7 @@ if environment == "prod"
 end
 fail_closed("root route must contain only its receiver and exact child routes") unless route.keys.sort == %w[receiver routes]
 children = route["routes"]
-fail_closed("root must have exactly the three allowlisted direct-child routes") unless children.is_a?(Array) && children.length == 3
+fail_closed("root must have exactly the four allowlisted direct-child routes") unless children.is_a?(Array) && children.length == 4
 receivers = config["receivers"]
 fail_closed("receiver list must contain exactly null, two PagerDuty receivers, and Healthchecks") unless receivers.is_a?(Array) && receivers.length == 4 && receivers.all? { |x| x.is_a?(Hash) }
 fail_closed('root "null" receiver is missing or broadened') unless receivers.count { |x| x == { "name" => "null" } } == 1
@@ -105,10 +107,13 @@ webhooks = hc["webhook_configs"]
 expected_webhook = { "url_file" => HC_PATH, "send_resolved" => false, "max_alerts" => 1, "timeout" => "10s" }
 fail_closed("Healthchecks webhook must use the exact file, resolution, timeout, and alert limit") unless webhooks == [expected_webhook]
 
-ds_route, pd_route, hc_route = children
+ds_route, cloudflare_route, pd_route, hc_route = children
 fail_closed("DSPACE route ordering or receiver changed") unless ds_route["receiver"] == DSPACE_RECEIVER
 fail_closed("DSPACE route matchers are not the exact alert allowlist") unless ds_route["matchers"].is_a?(Array) && ds_route["matchers"].sort == DSPACE_MATCHERS.sort
 fail_closed("DSPACE route must contain only receiver and exact matchers") unless ds_route.keys.sort == %w[matchers receiver]
+fail_closed("Cloudflare route ordering or receiver changed") unless cloudflare_route["receiver"] == DSPACE_RECEIVER
+fail_closed("Cloudflare route matchers are not the exact critical allowlist") unless cloudflare_route["matchers"].is_a?(Array) && cloudflare_route["matchers"].sort == CLOUDFLARE_MATCHERS.sort
+fail_closed("Cloudflare route must contain only receiver and exact matchers") unless cloudflare_route.keys.sort == %w[matchers receiver]
 fail_closed("PagerDuty route ordering or receiver changed") unless pd_route["receiver"] == PD_RECEIVER
 fail_closed("PagerDuty route matchers are not the exact synthetic allowlist") unless pd_route["matchers"].is_a?(Array) && pd_route["matchers"].sort == PD_MATCHERS.sort
 fail_closed("PagerDuty route must contain only receiver and exact matchers") unless pd_route.keys.sort == %w[matchers receiver]

--- a/tests/prometheus/cloudflare-tunnel.test.yaml
+++ b/tests/prometheus/cloudflare-tunnel.test.yaml
@@ -1,0 +1,106 @@
+rule_files:
+  - ../../platform/observability/rules/cloudflare-tunnel.yaml
+evaluation_interval: 1m
+tests:
+  - name: two healthy connectors
+    interval: 1m
+    input_series:
+      - series: 'up{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-1"}'
+        values: '1x20'
+      - series: 'up{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-2"}'
+        values: '1x20'
+      - series: 'cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-1"}'
+        values: '4x20'
+      - series: 'cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-2"}'
+        values: '4x20'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: CloudflareTunnelNoHealthyConnections
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: CloudflareTunnelConnectionsDegraded
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: CloudflareTunnelMetricsTargetsDown
+        exp_alerts: []
+  - name: one degraded connector and recovery
+    interval: 1m
+    input_series:
+      - series: 'up{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-1"}'
+        values: '1x25'
+      - series: 'up{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-2"}'
+        values: '1x25'
+      - series: 'cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-1"}'
+        values: '4x25'
+      - series: 'cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-2"}'
+        values: '2x15 4x10'
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: CloudflareTunnelConnectionsDegraded
+        exp_alerts:
+          - exp_labels: {application: cloudflare-tunnel, environment: staging, cluster: sugarkube-int, severity: warning}
+            exp_annotations:
+              summary: Cloudflare Tunnel connector capacity is degraded
+              description: Fewer than two connectors report metrics or a connector has fewer than four HA connections.
+              remediation: Inspect target and connector status after excluding an ordinary rolling upgrade.
+              runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/cloudflare_tunnel.md#alerts
+      - eval_time: 20m
+        alertname: CloudflareTunnelConnectionsDegraded
+        exp_alerts: []
+  - name: zero connections
+    interval: 1m
+    input_series:
+      - series: 'up{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-1"}'
+        values: '1x15'
+      - series: 'up{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-2"}'
+        values: '1x15'
+      - series: 'cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-1"}'
+        values: '0x15'
+      - series: 'cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-2"}'
+        values: '0x15'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: CloudflareTunnelNoHealthyConnections
+        exp_alerts:
+          - exp_labels: {application: cloudflare-tunnel, environment: staging, cluster: sugarkube-int, severity: critical}
+            exp_annotations:
+              summary: No Cloudflare Tunnel edge connections are healthy
+              description: Both staging connectors have reported zero aggregate HA connections for five minutes.
+              remediation: Check WAN and DNS first; do not restart connectors that are alive and reconnecting.
+              runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/cloudflare_tunnel.md#alerts
+  - name: missing metrics
+    interval: 1m
+    input_series:
+      - series: 'unrelated_metric'
+        values: '1x15'
+    alert_rule_test:
+      - eval_time: 7m
+        alertname: CloudflareTunnelMetricsTargetsDown
+        exp_alerts:
+          - exp_labels: {application: cloudflare-tunnel, environment: staging, cluster: sugarkube-int, severity: warning, namespace: cloudflare, service: cloudflare-tunnel-metrics}
+            exp_annotations:
+              summary: Cloudflare Tunnel metrics targets are absent or down
+              description: Prometheus has fewer than two healthy cloudflared scrape targets; this does not alone prove the tunnel is down.
+              remediation: Check ServiceMonitor discovery, Service selectors, pods, and network policy.
+              runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/cloudflare_tunnel.md#alerts
+      - eval_time: 7m
+        alertname: CloudflareTunnelNoHealthyConnections
+        exp_alerts: []
+  - name: brief transient degradation
+    interval: 1m
+    input_series:
+      - series: 'up{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-1"}'
+        values: '1x20'
+      - series: 'up{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-2"}'
+        values: '1x20'
+      - series: 'cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-1"}'
+        values: '4x5 2x5 4x10'
+      - series: 'cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-2"}'
+        values: '4x20'
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: CloudflareTunnelConnectionsDegraded
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: CloudflareTunnelConnectionsDegraded
+        exp_alerts: []

--- a/tests/prometheus/cloudflare-tunnel.test.yaml
+++ b/tests/prometheus/cloudflare-tunnel.test.yaml
@@ -51,7 +51,7 @@ tests:
     interval: 1m
     input_series:
       - series: 'up{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-1"}'
-        values: '1x15'
+        values: '0x15'
       - series: 'up{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-2"}'
         values: '1x15'
       - series: 'cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics",instance="connector-1"}'
@@ -65,7 +65,7 @@ tests:
           - exp_labels: {application: cloudflare-tunnel, environment: staging, cluster: sugarkube-int, severity: critical}
             exp_annotations:
               summary: No Cloudflare Tunnel edge connections are healthy
-              description: Both staging connectors have reported zero aggregate HA connections for five minutes.
+              description: The available staging connector metrics have reported zero aggregate HA connections for five minutes.
               remediation: Check WAN and DNS first; do not restart connectors that are alive and reconnecting.
               runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/cloudflare_tunnel.md#alerts
   - name: missing metrics
@@ -77,7 +77,7 @@ tests:
       - eval_time: 7m
         alertname: CloudflareTunnelMetricsTargetsDown
         exp_alerts:
-          - exp_labels: {application: cloudflare-tunnel, environment: staging, cluster: sugarkube-int, severity: warning, namespace: cloudflare, service: cloudflare-tunnel-metrics}
+          - exp_labels: {application: cloudflare-tunnel, environment: staging, cluster: sugarkube-int, severity: warning}
             exp_annotations:
               summary: Cloudflare Tunnel metrics targets are absent or down
               description: Prometheus has fewer than two healthy cloudflared scrape targets; this does not alone prove the tunnel is down.

--- a/tests/test_cloudflare_tunnel_hardening.py
+++ b/tests/test_cloudflare_tunnel_hardening.py
@@ -1,6 +1,6 @@
-from pathlib import Path
 import json
 import subprocess
+from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 

--- a/tests/test_cloudflare_tunnel_hardening.py
+++ b/tests/test_cloudflare_tunnel_hardening.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+import json
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def docs(path):
+    result = subprocess.run(
+        [
+            "ruby",
+            "-ryaml",
+            "-rjson",
+            "-e",
+            "docs=[]; YAML.load_stream(File.read(ARGV[0])) { |d| docs << d }; puts JSON.generate(docs)",
+            str(ROOT / path),
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_values_preserve_remote_managed_ha_contract():
+    values = docs("config/cloudflare-tunnel/values.yaml")[0]
+    assert values["replicaCount"] == 2
+    assert values["image"] == {
+        "repository": "cloudflare/cloudflared",
+        "tag": "2026.7.3",
+        "pullPolicy": "IfNotPresent",
+    }
+    assert values["cloudflare"]["secretName"] == "tunnel-token"
+    assert values["cloudflare"]["ingress"] == []
+    anti = values["affinity"]["podAntiAffinity"]["requiredDuringSchedulingIgnoredDuringExecution"]
+    assert anti[0]["topologyKey"] == "kubernetes.io/hostname"
+
+
+def test_private_metrics_discovery_and_pdb_contract():
+    service, monitor, pdb = docs("config/cloudflare-tunnel/monitoring.yaml")
+    selector = {
+        "app.kubernetes.io/name": "cloudflare-tunnel",
+        "app.kubernetes.io/instance": "cloudflare-tunnel",
+    }
+    assert service["spec"]["type"] == "ClusterIP"
+    assert service["spec"]["selector"] == selector
+    assert service["spec"]["ports"] == [
+        {"name": "metrics", "port": 2000, "targetPort": 2000, "protocol": "TCP"}
+    ]
+    assert monitor["metadata"]["namespace"] == "cloudflare"
+    assert monitor["metadata"]["labels"]["release"] == "kube-prometheus-stack"
+    assert monitor["spec"]["selector"]["matchLabels"] == selector
+    assert monitor["spec"]["endpoints"] == [
+        {"port": "metrics", "path": "/metrics", "interval": "30s", "scrapeTimeout": "10s"}
+    ]
+    assert pdb["spec"]["minAvailable"] == 1
+    assert pdb["spec"]["selector"]["matchLabels"] == selector
+
+
+def test_verifier_is_read_only_and_secret_safe():
+    script = (ROOT / "scripts/verify_cloudflare_tunnel.sh").read_text()
+    subprocess.run(["bash", "-n", str(ROOT / "scripts/verify_cloudflare_tunnel.sh")], check=True)
+    for mutation in (
+        "kubectl apply",
+        "kubectl patch",
+        "kubectl delete",
+        "helm upgrade",
+        ".data.token",
+    ):
+        assert mutation not in script
+    assert "sugar-staging" in script
+    assert "Secret values were not read" in script

--- a/tests/test_cloudflare_tunnel_token_mode.py
+++ b/tests/test_cloudflare_tunnel_token_mode.py
@@ -305,6 +305,21 @@ def test_deployment_patch_enforces_token_mode(deployment_patch_ops: list[dict]) 
         "maxUnavailable": 0,
         "maxSurge": 1,
     }
+    assert ops_by_path["/spec/template/spec/affinity"]["value"] == {
+        "podAntiAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": [
+                {
+                    "topologyKey": "kubernetes.io/hostname",
+                    "labelSelector": {
+                        "matchLabels": {
+                            "app.kubernetes.io/name": "cloudflare-tunnel",
+                            "app.kubernetes.io/instance": "cloudflare-tunnel",
+                        }
+                    },
+                }
+            ]
+        }
+    }
 
 
 def test_recipe_relies_on_rollout_status_not_helm_wait(cf_recipe_body: str) -> None:
@@ -390,6 +405,18 @@ def test_cf_tunnel_install_normalizes_named_env_arguments(cf_recipe_body: str) -
     alias_result = _run_cf_tunnel_install_recipe("int")
     assert alias_result.returncode == 0, alias_result.stderr
     assert 'WARNING: env name "int" is deprecated; using env=staging.' in alias_result.stderr
+
+
+def test_cf_tunnel_monitoring_is_applied_only_in_staging() -> None:
+    staging = _run_cf_tunnel_install_recipe("staging")
+    assert staging.returncode == 0, staging.stderr
+    assert "KUBECTL:apply -f " in staging.stdout
+    assert "/config/cloudflare-tunnel/monitoring.yaml" in staging.stdout
+
+    for env_name in ("dev", "prod"):
+        result = _run_cf_tunnel_install_recipe(env_name)
+        assert result.returncode == 0, result.stderr
+        assert "/config/cloudflare-tunnel/monitoring.yaml" not in result.stdout
 
 
 def test_cf_tunnel_install_flags_origin_cert_logs(cf_recipe_body: str, origin_cert_guidance_text: str) -> None:

--- a/tests/test_cloudflare_tunnel_token_mode.py
+++ b/tests/test_cloudflare_tunnel_token_mode.py
@@ -292,7 +292,19 @@ def test_deployment_patch_enforces_token_mode(deployment_patch_ops: list[dict]) 
 
     image_op = ops_by_path.get("/spec/template/spec/containers/0/image")
     assert image_op and image_op.get("op") in {"add", "replace"}
-    assert image_op.get("value") == "cloudflare/cloudflared:2024.8.3"
+    assert image_op.get("value") == (
+        "cloudflare/cloudflared:2026.7.3@"
+        "sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf"
+    )
+
+    assert ops_by_path["/spec/template/spec/containers/0/livenessProbe"]["op"] == "remove"
+    readiness = ops_by_path["/spec/template/spec/containers/0/readinessProbe"]["value"]
+    assert readiness["httpGet"] == {"path": "/ready", "port": 2000}
+    assert readiness["failureThreshold"] == 3
+    assert ops_by_path["/spec/strategy"]["value"]["rollingUpdate"] == {
+        "maxUnavailable": 0,
+        "maxSurge": 1,
+    }
 
 
 def test_recipe_relies_on_rollout_status_not_helm_wait(cf_recipe_body: str) -> None:
@@ -304,18 +316,12 @@ def test_recipe_relies_on_rollout_status_not_helm_wait(cf_recipe_body: str) -> N
     assert "--wait" not in cf_recipe_body
 
 
-def test_teardown_retry_is_baked_into_cf_tunnel_install(cf_recipe_body: str) -> None:
+def test_failed_rollout_never_deletes_both_connectors(cf_recipe_body: str) -> None:
     assert (
         "kubectl -n cloudflare delete pod -l app.kubernetes.io/name=cloudflare-tunnel"
-        in cf_recipe_body
+        not in cf_recipe_body
     )
-
-    rollout_calls = re.findall(
-        r"kubectl -n cloudflare rollout status deployment/cloudflare-tunnel --timeout=\d+s",
-        cf_recipe_body,
-    )
-    assert len(rollout_calls) >= 2, "Expected two rollout status calls (initial + retry)"
-    assert "cloudflare-tunnel still failing after teardown+retry" in cf_recipe_body
+    assert "synchronize their restart backoff" in cf_recipe_body
     assert "exit 1" in cf_recipe_body
 
 
@@ -373,10 +379,10 @@ def test_cf_tunnel_install_normalizes_named_env_arguments(cf_recipe_body: str) -
 
         combined_output = result.stdout + result.stderr
         assert re.search(
-            r"HELM:upgrade --install cloudflare-tunnel cloudflare/cloudflare-tunnel .* --values -",
+            r"HELM:upgrade --install cloudflare-tunnel cloudflare/cloudflare-tunnel .* --values .*/config/cloudflare-tunnel/values.yaml",
             result.stdout,
         )
-        assert f'HELM_STDIN:  tunnelName: "sugarkube-{normalized_env}"' in combined_output
+        assert f"--set-string cloudflare.tunnelName=sugarkube-{normalized_env}" in combined_output
         assert f"- Tunnel name: sugarkube-{normalized_env}" in combined_output
         assert "sugarkube-env=staging" not in combined_output
         assert "sugarkube-env=env=staging" not in combined_output

--- a/tests/test_cloudflare_tunnel_token_mode.py
+++ b/tests/test_cloudflare_tunnel_token_mode.py
@@ -107,27 +107,11 @@ def test_cf_tunnel_route_normalizes_host_prefix(host_input: str) -> None:
 
 @pytest.fixture(scope="module")
 def deployment_patch_ops(cf_recipe_body: str) -> list[dict]:
-    """Extract and parse the deployment patch JSON patch payload."""
+    """Extract and combine the common and staging JSON patch payloads."""
 
-    match = re.search(
-        r"deployment_patch.*?<<-?'PATCH'.*?\n[ \t]*(?P<patch>\[.*\])\n[ \t]*PATCH",
-        cf_recipe_body,
-        re.S,
-    )
-    if not match:
-        match = re.search(
-            r"deployment_patch=\$?'(?P<patch>\[.*\])'",
-            cf_recipe_body,
-            re.S,
-        )
-
-    assert match, "Deployment patch declaration missing from cf-tunnel-install"
-
-    patch_text = match.group("patch")
-    if "\\n" in patch_text:
-        patch_text = patch_text.encode("utf-8").decode("unicode_escape")
-
-    return json.loads(patch_text)
+    payloads = re.findall(r"(?:deployment|staging)_patch=\$?'(?P<patch>\[.*?\])'", cf_recipe_body, re.S)
+    assert len(payloads) == 2, "Common and staging patch declarations are required"
+    return [operation for payload in payloads for operation in json.loads(payload)]
 
 
 def test_cf_tunnel_install_heredocs_are_well_formed(cf_recipe_body: str) -> None:
@@ -214,13 +198,17 @@ def test_cf_tunnel_install_shell_syntax_is_valid(cf_recipe_body: str) -> None:
         Path(path).unlink(missing_ok=True)
 
 
-def _run_cf_tunnel_install_recipe(env: str) -> subprocess.CompletedProcess[str]:
+def _run_cf_tunnel_install_recipe(
+    env: str, *, secret_exists: bool = True, token: str | None = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature"
+) -> subprocess.CompletedProcess[str]:
     rendered_body = _extract_cf_recipe_body().replace("{{ quote(env) }}", json.dumps(env))
     script = textwrap.dedent(
         """#!/usr/bin/env bash
         set -euo pipefail
 
-        export CF_TUNNEL_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature
+        if [ {{TOKEN_SET}} = yes ]; then
+            export CF_TUNNEL_TOKEN={{TOKEN}}
+        fi
         helm() {
             printf 'HELM:%s\n' "$*"
             if [ ! -t 0 ]; then
@@ -229,6 +217,9 @@ def _run_cf_tunnel_install_recipe(env: str) -> subprocess.CompletedProcess[str]:
         }
         kubectl() {
             printf 'KUBECTL:%s\n' "$*"
+            if [ "$*" = "-n cloudflare get secret tunnel-token -o name" ] && [ {{SECRET_EXISTS}} = no ]; then
+                return 1
+            fi
             if [ ! -t 0 ]; then
                 sed 's/^/KUBECTL_STDIN:/' <&0 >/dev/null
             fi
@@ -237,6 +228,9 @@ def _run_cf_tunnel_install_recipe(env: str) -> subprocess.CompletedProcess[str]:
 
         """
     ) + rendered_body + "\n"
+    script = script.replace("{{SECRET_EXISTS}}", "yes" if secret_exists else "no")
+    script = script.replace("{{TOKEN_SET}}", "yes" if token is not None else "no")
+    script = script.replace("{{TOKEN}}", json.dumps(token or ""))
 
     with tempfile.NamedTemporaryFile("w", delete=False) as f:
         f.write(script)
@@ -417,6 +411,29 @@ def test_cf_tunnel_monitoring_is_applied_only_in_staging() -> None:
         result = _run_cf_tunnel_install_recipe(env_name)
         assert result.returncode == 0, result.stderr
         assert "/config/cloudflare-tunnel/monitoring.yaml" not in result.stdout
+        assert "ServiceMonitor" not in result.stdout
+        assert "--values -" in result.stdout
+        assert "/config/cloudflare-tunnel/values.yaml" not in result.stdout
+        assert result.stdout.count("KUBECTL:-n cloudflare patch deployment") == 1
+
+
+def test_existing_secret_is_preserved_without_token_input() -> None:
+    result = _run_cf_tunnel_install_recipe("staging", secret_exists=True, token=None)
+    assert result.returncode == 0, result.stderr
+    assert "kubectl -n cloudflare get secret tunnel-token -o name" in _extract_cf_recipe_body()
+    assert "create secret generic tunnel-token" not in result.stdout
+    assert "--from-literal" not in result.stdout
+
+
+def test_initial_install_requires_and_creates_secret_from_out_of_band_token() -> None:
+    missing = _run_cf_tunnel_install_recipe("staging", secret_exists=False, token=None)
+    assert missing.returncode != 0
+    assert "initial installation" in missing.stderr
+
+    created = _run_cf_tunnel_install_recipe("staging", secret_exists=False)
+    assert created.returncode == 0, created.stderr
+    assert "kubectl -n cloudflare create secret generic tunnel-token" in _extract_cf_recipe_body()
+    assert "KUBECTL:apply -f -" in created.stdout
 
 
 def test_cf_tunnel_install_flags_origin_cert_logs(cf_recipe_body: str, origin_cert_guidance_text: str) -> None:

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -16,6 +16,9 @@ PROD = ROOT / "clusters" / "prod" / "observability" / "kube-prometheus-stack.val
 CANONICAL_DSPACE_RULES = (
     ROOT / "platform" / "observability" / "rules" / "dspace-release-integrity.yaml"
 )
+CANONICAL_CLOUDFLARE_RULES = (
+    ROOT / "platform" / "observability" / "rules" / "cloudflare-tunnel.yaml"
+)
 SCRIPT = ROOT / "scripts" / "observability_helm.sh"
 ALERTMANAGER_VALIDATOR = ROOT / "scripts" / "verify_observability_alertmanager.rb"
 DASHBOARD = ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
@@ -98,7 +101,7 @@ def test_chart_version_and_values_match_live_staging_baseline():
         "group_interval": None,
         "repeat_interval": None,
     }
-    assert route["routes"][1] == {
+    assert route["routes"][2] == {
         "receiver": "pagerduty-synthetic-test",
         "matchers": [
             'alertname="SugarkubePagerDutyTest"',
@@ -110,7 +113,7 @@ def test_chart_version_and_values_match_live_staging_baseline():
     dspace_route = route["routes"][0]
     assert dspace_route["receiver"] == "pagerduty-dspace"
     assert dspace_route["matchers"][0] == DSPACE_ALERT_MATCHER
-    watchdog_route = route["routes"][2]
+    watchdog_route = route["routes"][3]
     assert watchdog_route["receiver"] == "healthchecks-watchdog"
     assert watchdog_route["repeat_interval"] == "5m"
     pagerduty_receiver = next(
@@ -166,7 +169,6 @@ def test_production_values_have_exact_safe_overrides_without_public_exposure_or_
     text = COMMON.read_text(encoding="utf-8") + STAGING.read_text(encoding="utf-8") + PROD.read_text(encoding="utf-8")
     forbidden = [
         "longhorn",
-        "cloudflare",
         "IngressRoute",
         "kind: Ingress",
         "pass" + "word:",
@@ -215,6 +217,12 @@ stringData:
         - receiver: pagerduty-dspace
           matchers:
             - '{DSPACE_ALERT_MATCHER}'
+            - 'environment="staging"'
+            - 'cluster="sugarkube-int"'
+            - 'severity="critical"'
+        - receiver: pagerduty-dspace
+          matchers:
+            - 'alertname="CloudflareTunnelNoHealthyConnections"'
             - 'environment="staging"'
             - 'cluster="sugarkube-int"'
             - 'severity="critical"'
@@ -502,7 +510,8 @@ def test_dspace_rules_have_one_canonical_source_and_exact_overlay(tmp_path):
     overlay = yaml_load(tmp_path / "rules-overlay.yaml")
     assert overlay == {
         "additionalPrometheusRulesMap": {
-            "dspace-release-integrity": yaml_load(CANONICAL_DSPACE_RULES)
+            "dspace-release-integrity": yaml_load(CANONICAL_DSPACE_RULES),
+            "cloudflare-tunnel": yaml_load(CANONICAL_CLOUDFLARE_RULES),
         }
     }
     overlay_paths = re.findall(r"/[^ ]*sugarkube-observability-rules\.[^ ]*\.yaml", audit)
@@ -651,7 +660,7 @@ def test_watchdog_documentation_timing_matches_configuration():
         assert f"just observability-watchdog-{recipe} env=staging" in operations
 
     staging = yaml_load(STAGING)
-    route = staging["alertmanager"]["config"]["route"]["routes"][2]
+    route = staging["alertmanager"]["config"]["route"]["routes"][3]
     assert route["repeat_interval"] == "5m"
     assert re.search(r"five-minute period and\s+two-minute grace", operations)
     assert re.search(r"eight-minute Alertmanager\s+silence", operations)
@@ -1001,6 +1010,12 @@ printf '%s' "$code"
     - receiver: pagerduty-dspace
       matchers:
         - {DSPACE_ALERT_MATCHER}
+        - environment="staging"
+        - cluster="sugarkube-int"
+        - severity="critical"
+    - receiver: pagerduty-dspace
+      matchers:
+        - alertname="CloudflareTunnelNoHealthyConnections"
         - environment="staging"
         - cluster="sugarkube-int"
         - severity="critical"

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -166,13 +166,15 @@ def test_production_values_have_exact_safe_overrides_without_public_exposure_or_
             },
         },
     }
-    text = COMMON.read_text(encoding="utf-8") + STAGING.read_text(encoding="utf-8") + PROD.read_text(encoding="utf-8")
+    text = COMMON.read_text(encoding="utf-8") + PROD.read_text(encoding="utf-8")
     forbidden = [
         "longhorn",
         "IngressRoute",
         "kind: Ingress",
         "pass" + "word:",
         "admin" + "Pass" + "word",
+        "cloudflare-tunnel",
+        "CloudflareTunnel",
     ]
     for needle in forbidden:
         assert needle not in text


### PR DESCRIPTION
### Motivation

A staging WAN/DNS outage showed that Kubernetes was killing both Cloudflare Tunnel connectors because `/ready` was configured as a liveness probe. The synchronized clean exits led to restart backoff and delayed recovery even though cloudflared already reconnects internally.

Across 16 public probes, service became unreachable at `2026-08-04T01:46:04Z`, Cloudflare HTTP 530/1033 responses began at `01:56:04Z`, recovery began at `01:59:04Z`, and all probes recovered by `02:00:04Z`. Unreachable probes received no HTTP response; HTTP 530/1033 meant Cloudflare responded but had no healthy connector.

### Changes

- Make `/ready` on port 2000 readiness-only with bounded thresholds and remove the WAN-sensitive liveness probe.
- Preserve two replicas and enforce required hostname anti-affinity directly on the Deployment.
- Use an HA-safe rolling strategy with `maxUnavailable: 0`, `maxSurge: 1`, and a `PodDisruptionBudget` requiring one available connector.
- Keep chart version `0.3.2` and pin staging to `cloudflare/cloudflared:2026.7.3@sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf`. The verified manifest supports Linux `amd64` and `arm64`.
- Apply the new values, lifecycle hardening, metrics resources, and observability contract only to normalized `env=staging`; dev and production retain their previous install behavior.
- Preserve the existing `tunnel-token` Secret during upgrades by checking only its metadata. Existing installations require no token input and never read, print, compare, or reapply the token. Initial installations may still accept protected out-of-band token input.
- Add a private ClusterIP metrics Service, a release-scoped ServiceMonitor, and distinct Prometheus targets for both connectors.
- Add focused alerts for zero aggregate connections, degraded connector capacity, and missing/down metrics targets. Absent connection series are treated as missing telemetry rather than a proven tunnel outage.
- Add promtool fixtures covering healthy connectors, one degraded connector, zero connections, missing metrics, transient degradation, and recovery.
- Add the staging-only, read-only `just cf-tunnel-verify env=staging` workflow to verify release ownership, image, replicas, node separation, probes, rollout strategy, disruption budget, Secret reference, metrics discovery, connections, and loaded alerts.
- Expand `docs/cloudflare_tunnel.md` with the outage timeline, root cause, metrics and alert semantics, supported-version policy, rollout, rollback, and recovery-drill requirements.

### Operator workflow and drill status

The rollout is separately authorized, manual, and staging-only. It preserves remote-managed ingress configuration and the existing token Secret.

A pod-deletion test is explicitly rejected as a WAN-recovery drill because it tests replacement rather than survival and reconnection of the same processes. The dependency-loss drill remains blocked pending owner confirmation of the staging CNI and its egress-policy behavior. No speculative NetworkPolicy was added or applied. The runbook documents the bounded, release-scoped contract that must be separately reviewed once that blocker is resolved.

### Validation

Focused repository validation completed successfully:

~~~sh
pytest -q \
  tests/test_cloudflare_tunnel_token_mode.py \
  tests/test_cloudflare_tunnel_hardening.py \
  tests/test_observability_helm.py \
  tests/test_docs_guardrails.py
# 232 passed

pytest -q \
  tests/test_cloudflare_tunnel_token_mode.py \
  tests/test_cloudflare_tunnel_hardening.py \
  tests/test_docs_guardrails.py
# 24 passed after the final documentation/header correction

promtool check rules platform/observability/rules/cloudflare-tunnel.yaml
promtool test rules tests/prometheus/cloudflare-tunnel.test.yaml
bash -n scripts/verify_cloudflare_tunnel.sh
ruby -c scripts/verify_observability_alertmanager.rb
PATH=/tmp/tools:$PATH scripts/observability_helm.sh render env=staging
PATH=/tmp/tools:$PATH just --unstable --fmt --check
helm lint /tmp/cfchart/cloudflare-tunnel \
  -f config/cloudflare-tunnel/values.yaml
helm template cloudflare-tunnel /tmp/cfchart/cloudflare-tunnel \
  -n cloudflare \
  -f config/cloudflare-tunnel/values.yaml
pyspelling -c .spellcheck.yaml
linkchecker --no-warnings README.md docs/
git diff --check
git diff --cached | ./scripts/scan-secrets.py
~~~

The broad `pre-commit run --all-files` encountered pre-existing repository-wide whitespace, multi-document YAML, and formatting findings; unrelated automatic edits were reverted. The final two-file follow-up environment lacked `pyspelling`, `linkchecker`, and `pre-commit`, but the latest-head GitHub workflows independently completed successfully:

- Spellcheck #4373
- Verify Justfile formatting #2391
- Docs #6249
- Test Suite #10429
- pi-image #3973
- ci #2742

No live Kubernetes cluster, Helm release, Cloudflare configuration, Secret, remote-managed route, or production resource was accessed or changed. All changes are repository-side.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7770ca6724832fa8339b10530862d4)