### PR TITLE
Harden Cloudflare Tunnel recovery after WAN outages

### DIFF
--- a/clusters/staging/observability/kube-prometheus-stack.values.yaml
+++ b/clusters/staging/observability/kube-prometheus-stack.values.yaml
@@ -55,6 +55,12 @@ alertmanager:
           group_interval: 1m
           repeat_interval: 5m
           continue: false
+        - receiver: pagerduty-dspace
+          matchers:
+            - alertname=~"^(CloudflareTunnelNoConnections|CloudflareTunnelMetricsDown)$"
+            - environment="staging"
+            - cluster="sugarkube-int"
+            - severity="critical"
     receivers:
       - name: "null"
       - name: pagerduty-synthetic-test

--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -15,6 +15,79 @@ The tunnel routes these hostnames to Traefik (or another ingress controller) run
 k3s cluster. You do **not** need to install or run `cloudflared` on your workstation; the connector
 runs inside the cluster.
 
+## WAN outage recovery
+
+### Evidence and root cause
+
+During the 2026-08-04 staging outage, 16 public probes became unreachable at `01:46:04Z`.
+Cloudflare HTTP 530 responses first appeared at `01:56:04Z`, recovery began at `01:59:04Z`, and
+all probes were healthy by `02:00:04Z`. “Unreachable” means no HTTP response was received, whereas
+Cloudflare 530 with error 1033 means Cloudflare could not find a healthy tunnel connector. The 530
+phase therefore lasted 120–180 seconds. See Cloudflare's [error 1033
+reference](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1033/).
+
+Both connectors failed edge DNS discovery. Their `/ready` endpoint correctly became unhealthy,
+but chart version 0.3.2 used that dependency-sensitive endpoint as a liveness probe with a single
+failure threshold. Kubernetes terminated each process roughly 11–12 seconds after startup. The
+connectors synchronized, repeatedly exited cleanly, and eventually reached approximately five
+minutes of Kubernetes restart backoff. Shared CoreDNS, Traefik, and application workloads recovered
+normally. Once allowed to restart after WAN/DNS recovery, each connector established four QUIC
+connections in roughly three seconds.
+
+This was **not** a multi-minute Cloudflare polling interval. `cloudflared` already reconnects with
+backoff; Kubernetes prevented it from staying alive to do so. `/ready` is now readiness-only, with
+three failures at ten-second intervals, and no liveness probe is configured. Kubernetes still
+restarts the container whenever the process exits. Consult Cloudflare's [tunnel troubleshooting](https://developers.cloudflare.com/tunnel/troubleshooting/)
+and [monitoring reference](https://developers.cloudflare.com/tunnel/monitoring/) when diagnosing a
+future incident.
+
+### Supported connector and monitoring policy
+
+Staging pins `cloudflare/cloudflared` 2026.7.3 and its multi-architecture manifest digest. The
+manifest supplies Linux `amd64` and `arm64` images. Do not use `latest`; review Cloudflare's
+[supported downloads](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/)
+before deliberately updating the version and digest. Chart 0.3.2 remains pinned because the
+repository's existing Helm release is the intended reconciliation path; the dormant Flux
+`cloudflared` resources are not an adoption path for this release.
+
+The internal-only `cloudflare-tunnel-metrics` ClusterIP Service exposes port 2000. Its
+ServiceMonitor discovers both pods at `/metrics` every 30 seconds. Alerts cover no aggregate tunnel
+connections for two minutes (critical), fewer than the expected eight aggregate connections for
+ten minutes (warning), and fewer than two healthy metrics targets for five minutes (critical).
+Only sustained critical alerts follow the existing staging PagerDuty route; a brief individual
+QUIC reconnection does not page.
+
+### Separately authorized staging rollout
+
+This procedure is mutating, manual, staging-only, and must never run in CI. Obtain change-owner
+authorization, then:
+
+1. Run `kubectl config current-context` and `just cf-tunnel-verify env=staging` for a read-only
+   baseline. Record public endpoint results without recording identifiers, IP addresses, or token
+   data.
+2. Confirm the owner has approved the rollout and run
+   `scripts/cloudflare_tunnel_harden.sh --confirm-staging`. The script fails closed on context,
+   cluster identity, release uniqueness, and chart ownership; it checks only that
+   `cloudflare/tunnel-token` key `token` exists. It neither reads nor changes its value and does not
+   alter remote-managed ingress.
+3. Watch `kubectl -n cloudflare get pods -l app.kubernetes.io/name=cloudflare-tunnel -w`. The
+   `maxUnavailable: 0`, `maxSurge: 1` rollout and PDB retain at least one ready connector. Re-run
+   `just cf-tunnel-verify env=staging`, then verify every staging public endpoint.
+4. For a separately authorized recovery drill, select exactly one pod by its controller-owned
+   name, record its restart count, and delete only that pod. Do not disrupt a node, DNS, WAN, the
+   Secret, or Cloudflare configuration. Confirm the other connector stays ready, the replacement
+   reaches four HA connections within five minutes, restart counts do not loop, both Prometheus
+   targets return healthy, alerts resolve, and public endpoints remain healthy.
+
+Stop and roll back if no connector remains ready, a connector enters repeated restart/backoff,
+public endpoints fail for two consecutive minutes, the replacement lacks four connections after
+five minutes, metrics targets remain down after five minutes, or critical alerts remain firing.
+Cleanup consists only of allowing the owner-scoped replacement pod to become ready and removing
+any operator-created alert silence. Roll back the Deployment to the recorded pre-rollout image and
+probe specification with an owner-reviewed JSON patch, wait for the HA-safe rollout, and repeat the
+verification. Do **not** uninstall the Helm release, delete the Secret, activate Flux, change host
+routes, or touch production. The connector token remains out of band throughout.
+
 > Cloudflare has two big modes for tunnels: **remotely-managed** (token-only, created in the
 > dashboard) and **locally-managed** (requires `cloudflared login` and a `cert.pem`). Sugarkube uses
 > the **remotely-managed, token-based connector mode** only. If you create the tunnel in the

--- a/justfile
+++ b/justfile
@@ -637,6 +637,7 @@ cf-tunnel-install env='dev' token='':
     if ! helm upgrade --install cloudflare-tunnel cloudflare/cloudflare-tunnel \
     --namespace cloudflare \
     --create-namespace \
+    --version 0.3.2 \
     --values - <<<"${values_yaml}"; then
     helm_exit_code=$?
     echo "Helm upgrade/install failed; diagnostics to follow:" >&2
@@ -653,16 +654,10 @@ cf-tunnel-install env='dev' token='':
     # Force remote-managed token-mode authentication by injecting the TUNNEL_TOKEN env var and running cloudflared
     # exactly as documented for Kubernetes token deployments. Remove config/creds volumes entirely so the pod never
     # mounts credentials.json or any origin certificate material.
-    deployment_patch='[
-    {"op":"replace","path":"/spec/template/spec/volumes","value":[]},
-    {"op":"replace","path":"/spec/template/spec/containers/0/env","value":[{"name":"TUNNEL_TOKEN","valueFrom":{"secretKeyRef":{"name":"tunnel-token","key":"token"}}}]},
-    {"op":"replace","path":"/spec/template/spec/containers/0/volumeMounts","value":[]},
-    {"op":"replace","path":"/spec/template/spec/containers/0/image","value":"cloudflare/cloudflared:2024.8.3"},
-    {"op":"replace","path":"/spec/template/spec/containers/0/command","value":["cloudflared","tunnel","--no-autoupdate","--metrics","0.0.0.0:2000","run"]},
-    {"op":"replace","path":"/spec/template/spec/containers/0/args","value":[]}
-    ]'
+    deployment_patch="$(cat platform/cloudflare-tunnel/deployment-patch.json)"
 
     kubectl -n cloudflare patch deployment cloudflare-tunnel --type json --patch "${deployment_patch}"
+    kubectl apply -k platform/cloudflare-tunnel
 
     helm_note_printed=0
 
@@ -729,6 +724,13 @@ cf-tunnel-reset:
     fi
 
     echo "Cloudflare Tunnel reset complete. Re-run 'just cf-tunnel-install env=<env>' after exporting CF_TUNNEL_TOKEN to reinstall."
+
+# Show Cloudflare Tunnel status and recent logs (for debugging rollout failures).
+cf-tunnel-verify env='staging':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    [ "{{ env }}" = staging ] || { echo "ERROR: verification is staging-only." >&2; exit 2; }
+    python3 scripts/verify_cloudflare_tunnel.py
 
 # Show Cloudflare Tunnel status and recent logs (for debugging rollout failures).
 cf-tunnel-debug:

--- a/platform/cloudflare-tunnel/deployment-patch.json
+++ b/platform/cloudflare-tunnel/deployment-patch.json
@@ -1,0 +1,12 @@
+[
+    {"op":"replace","path":"/spec/replicas","value":2},
+    {"op":"add","path":"/spec/strategy","value":{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":0,"maxSurge":1}}},
+    {"op":"replace","path":"/spec/template/spec/volumes","value":[]},
+    {"op":"replace","path":"/spec/template/spec/containers/0/env","value":[{"name":"TUNNEL_TOKEN","valueFrom":{"secretKeyRef":{"name":"tunnel-token","key":"token"}}}]},
+    {"op":"replace","path":"/spec/template/spec/containers/0/volumeMounts","value":[]},
+    {"op":"replace","path":"/spec/template/spec/containers/0/image","value":"cloudflare/cloudflared:2026.7.3@sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf"},
+    {"op":"replace","path":"/spec/template/spec/containers/0/command","value":["cloudflared","tunnel","--no-autoupdate","--metrics","0.0.0.0:2000","run"]},
+    {"op":"replace","path":"/spec/template/spec/containers/0/args","value":[]},
+    {"op":"remove","path":"/spec/template/spec/containers/0/livenessProbe"},
+    {"op":"add","path":"/spec/template/spec/containers/0/readinessProbe","value":{"httpGet":{"path":"/ready","port":2000},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":2,"failureThreshold":3,"successThreshold":1}}
+    ]

--- a/platform/cloudflare-tunnel/kustomization.yaml
+++ b/platform/cloudflare-tunnel/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - service.yaml
+  - servicemonitor.yaml
+  - pdb.yaml

--- a/platform/cloudflare-tunnel/pdb.yaml
+++ b/platform/cloudflare-tunnel/pdb.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cloudflare-tunnel
+  namespace: cloudflare
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudflare-tunnel
+      app.kubernetes.io/instance: cloudflare-tunnel

--- a/platform/cloudflare-tunnel/service.yaml
+++ b/platform/cloudflare-tunnel/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cloudflare-tunnel-metrics
+  namespace: cloudflare
+  labels:
+    app.kubernetes.io/name: cloudflare-tunnel
+    app.kubernetes.io/instance: cloudflare-tunnel
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: cloudflare-tunnel
+    app.kubernetes.io/instance: cloudflare-tunnel
+  ports:
+    - name: metrics
+      port: 2000
+      targetPort: 2000

--- a/platform/cloudflare-tunnel/servicemonitor.yaml
+++ b/platform/cloudflare-tunnel/servicemonitor.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cloudflare-tunnel
+  namespace: cloudflare
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudflare-tunnel
+      app.kubernetes.io/instance: cloudflare-tunnel
+  namespaceSelector:
+    matchNames:
+      - cloudflare
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s

--- a/platform/observability/rules/cloudflare-tunnel.yaml
+++ b/platform/observability/rules/cloudflare-tunnel.yaml
@@ -1,0 +1,34 @@
+groups:
+  - name: cloudflare-tunnel
+    interval: 30s
+    rules:
+      - alert: CloudflareTunnelNoConnections
+        expr: (sum(cloudflared_tunnel_ha_connections{namespace="cloudflare"}) or vector(0)) == 0
+        for: 2m
+        labels:
+          severity: critical
+          environment: staging
+          cluster: sugarkube-int
+        annotations:
+          summary: No Cloudflare Tunnel edge connections are healthy
+          runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/cloudflare_tunnel.md#wan-outage-recovery
+      - alert: CloudflareTunnelDegraded
+        expr: (sum(cloudflared_tunnel_ha_connections{namespace="cloudflare"}) or vector(0)) > 0 and (sum(cloudflared_tunnel_ha_connections{namespace="cloudflare"}) or vector(0)) < 8
+        for: 10m
+        labels:
+          severity: warning
+          environment: staging
+          cluster: sugarkube-int
+        annotations:
+          summary: Cloudflare Tunnel has fewer than eight aggregate HA connections
+          runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/cloudflare_tunnel.md#wan-outage-recovery
+      - alert: CloudflareTunnelMetricsDown
+        expr: (sum(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"}) or vector(0)) < 2
+        for: 5m
+        labels:
+          severity: critical
+          environment: staging
+          cluster: sugarkube-int
+        annotations:
+          summary: One or more Cloudflare Tunnel metrics targets are absent or down
+          runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/cloudflare_tunnel.md#wan-outage-recovery

--- a/scripts/cloudflare_tunnel_harden.sh
+++ b/scripts/cloudflare_tunnel_harden.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Explicit, staging-only mutating rollout. Never called by CI.
+set -Eeuo pipefail
+[[ "${1:-}" == "--confirm-staging" ]] || { echo "Usage: $0 --confirm-staging" >&2; exit 2; }
+[[ "$(kubectl config current-context)" == sugar-staging ]] || { echo "ERROR: expected sugar-staging context." >&2; exit 3; }
+python3 scripts/cluster_identity.py assert --env staging >/dev/null
+mapfile -t releases < <(helm -n cloudflare list --filter '^cloudflare-tunnel$' -q)
+[[ ${#releases[@]} == 1 && "${releases[0]}" == cloudflare-tunnel ]] || { echo "ERROR: expected one existing cloudflare-tunnel release." >&2; exit 4; }
+[[ "$(helm -n cloudflare status cloudflare-tunnel -o json | python3 -c 'import json,sys; print(json.load(sys.stdin)["chart"])')" == cloudflare-tunnel-0.3.2 ]] || { echo "ERROR: unexpected chart ownership/version." >&2; exit 4; }
+kubectl -n cloudflare get secret tunnel-token -o 'go-template={{if index .data "token"}}present{{end}}' | grep -qx present
+kubectl apply -k platform/cloudflare-tunnel
+kubectl -n cloudflare patch deployment cloudflare-tunnel --type json --patch-file platform/cloudflare-tunnel/deployment-patch.json
+kubectl -n cloudflare rollout status deployment/cloudflare-tunnel --timeout=5m
+python3 scripts/verify_cloudflare_tunnel.py

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -10,6 +10,7 @@ COMMON_VALUES="${ROOT}/platform/observability/helm/kube-prometheus-stack.values.
 STAGING_VALUES="${ROOT}/clusters/staging/observability/kube-prometheus-stack.values.yaml"
 PROD_VALUES="${ROOT}/clusters/prod/observability/kube-prometheus-stack.values.yaml"
 DSPACE_RULES="${ROOT}/platform/observability/rules/dspace-release-integrity.yaml"
+CLOUDFLARE_RULES="${ROOT}/platform/observability/rules/cloudflare-tunnel.yaml"
 DASHBOARD="${ROOT}/clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
 DASHBOARD_VALUE="grafana.dashboards.sugarkube.sugarkube-staging-observability.json"
 DASHBOARD_VALIDATOR="${ROOT}/scripts/validate_observability_dashboard.py"
@@ -89,9 +90,13 @@ create_rules_overlay() {
            rules["groups"].is_a?(Array) && !rules["groups"].empty?
       abort "ERROR: canonical DSPACE rules must contain only a nonempty groups list."
     end
-    overlay = {"additionalPrometheusRulesMap" => {"dspace-release-integrity" => rules}}
-    File.write(ARGV.fetch(1), YAML.dump(overlay))
-  ' "${DSPACE_RULES}" "${RULES_OVERLAY}"
+    cloudflare = YAML.safe_load_file(ARGV.fetch(1), aliases: false)
+    unless cloudflare.is_a?(Hash) && cloudflare.keys == ["groups"] && cloudflare["groups"].is_a?(Array) && !cloudflare["groups"].empty?
+      abort "ERROR: canonical Cloudflare Tunnel rules must contain only a nonempty groups list."
+    end
+    overlay = {"additionalPrometheusRulesMap" => {"dspace-release-integrity" => rules, "cloudflare-tunnel" => cloudflare}}
+    File.write(ARGV.fetch(2), YAML.dump(overlay))
+  ' "${DSPACE_RULES}" "${CLOUDFLARE_RULES}" "${RULES_OVERLAY}"
 }
 validate_dashboard() { python3 "${DASHBOARD_VALIDATOR}" "${DASHBOARD}"; }
 validate_rendered_dashboard() { python3 "${DASHBOARD_VALIDATOR}" "${DASHBOARD}" --rendered "$1"; }

--- a/scripts/verify_cloudflare_tunnel.py
+++ b/scripts/verify_cloudflare_tunnel.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Read-only verification for the staging Cloudflare Tunnel release."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+NAMESPACE = "cloudflare"
+RELEASE = "cloudflare-tunnel"
+IMAGE = (
+    "cloudflare/cloudflared:2026.7.3@sha256:"
+    "e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf"
+)
+PROM_API = "/api/v1/namespaces/monitoring/services/http:kube-prometheus-stack-prometheus:9090/proxy"
+
+
+def run(*args: str) -> str:
+    result = subprocess.run(args, check=False, capture_output=True, text=True)
+    if result.returncode:
+        raise SystemExit(
+            f"ERROR: read-only command failed: {' '.join(args)}\n{result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def kube_json(*args: str) -> dict:
+    return json.loads(run("kubectl", *args, "-o", "json"))
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"ERROR: {message}")
+
+
+def prometheus(path: str) -> dict:
+    return json.loads(run("kubectl", "get", "--raw", PROM_API + path))
+
+
+def main() -> int:
+    run("python3", "scripts/cluster_identity.py", "assert", "--env", "staging")
+    releases = json.loads(run("helm", "-n", NAMESPACE, "list", "--all", "--output", "json"))
+    owned = [item for item in releases if item.get("name") == RELEASE]
+    require(len(owned) == 1, "expected one uniquely owned cloudflare-tunnel Helm release")
+    require(owned[0].get("chart") == "cloudflare-tunnel-0.3.2", "unexpected Helm chart/version")
+
+    deployment = kube_json("-n", NAMESPACE, "get", "deployment", RELEASE)
+    spec = deployment["spec"]
+    require(spec.get("replicas") == 2, "deployment must have exactly two replicas")
+    rolling = spec.get("strategy", {}).get("rollingUpdate", {})
+    require(rolling == {"maxSurge": 1, "maxUnavailable": 0}, "rollout strategy is not HA-safe")
+    container = spec["template"]["spec"]["containers"][0]
+    require(container.get("image") == IMAGE, "connector image is not the supported immutable image")
+    require("livenessProbe" not in container, "WAN-sensitive liveness probe is present")
+    readiness = container.get("readinessProbe", {})
+    require(
+        readiness.get("httpGet") == {"path": "/ready", "port": 2000}, "/ready is not readiness-only"
+    )
+    refs = [e.get("valueFrom", {}).get("secretKeyRef") for e in container.get("env", [])]
+    require(
+        {"name": "tunnel-token", "key": "token"} in refs,
+        "expected token Secret reference is absent",
+    )
+
+    pods = kube_json(
+        "-n", NAMESPACE, "get", "pods", "-l", "app.kubernetes.io/name=cloudflare-tunnel"
+    )["items"]
+    require(len(pods) == 2, "expected exactly two connector pods")
+    require(
+        len({pod["spec"].get("nodeName") for pod in pods}) == 2,
+        "connectors are not on separate nodes",
+    )
+
+    pdb = kube_json("-n", NAMESPACE, "get", "pdb", RELEASE)
+    require(pdb["spec"].get("minAvailable") == 1, "PDB must retain one available connector")
+    service = kube_json("-n", NAMESPACE, "get", "service", "cloudflare-tunnel-metrics")
+    monitor = kube_json("-n", NAMESPACE, "get", "servicemonitor", RELEASE)
+    selector = {"app.kubernetes.io/name": RELEASE, "app.kubernetes.io/instance": RELEASE}
+    require(service["spec"].get("selector") == selector, "metrics Service selector drifted")
+    require(
+        monitor["spec"]["selector"].get("matchLabels") == selector,
+        "ServiceMonitor selector drifted",
+    )
+
+    targets = prometheus("/api/v1/targets")["data"]["activeTargets"]
+    targets = [
+        t
+        for t in targets
+        if t.get("labels", {}).get("namespace") == NAMESPACE
+        and t.get("labels", {}).get("service") == "cloudflare-tunnel-metrics"
+    ]
+    require(
+        len(targets) == 2 and all(t.get("health") == "up" for t in targets),
+        "Prometheus does not see two healthy connector targets",
+    )
+    query = prometheus(
+        "/api/v1/query?query=cloudflared_tunnel_ha_connections%7Bnamespace%3D%22cloudflare%22%7D"
+    )
+    series = query["data"]["result"]
+    require(
+        len(series) == 2 and all(float(item["value"][1]) >= 4 for item in series),
+        "each connector must report at least four HA connections",
+    )
+    rules = prometheus("/api/v1/rules")["data"]["groups"]
+    wanted = {
+        "CloudflareTunnelNoConnections",
+        "CloudflareTunnelDegraded",
+        "CloudflareTunnelMetricsDown",
+    }
+    loaded = {
+        rule.get("name")
+        for group in rules
+        for rule in group.get("rules", [])
+        if rule.get("health") == "ok"
+    }
+    require(wanted <= loaded, "Cloudflare Tunnel alert rules are not loaded and healthy")
+    print(
+        "Cloudflare Tunnel staging release, HA lifecycle, metrics, "
+        "connections, and alerts verified."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_observability_alertmanager.rb
+++ b/scripts/verify_observability_alertmanager.rb
@@ -17,6 +17,8 @@ HC_MATCHERS = ['alertname="SugarkubeObservabilityWatchdog"', 'environment="stagi
                'cluster="sugarkube-int"', 'purpose="observability-watchdog"'].freeze
 DSPACE_MATCHERS = ['alertname=~"^(DspaceBuildRevisionMismatch|DspaceMixedBuildRevisions|DspaceDeploymentImagePinMismatch|DspaceChatSyntheticFailed|DspaceMetricsTargetDown)$"',
                    'environment="staging"', 'cluster="sugarkube-int"', 'severity="critical"'].freeze
+CLOUDFLARE_MATCHERS = ['alertname=~"^(CloudflareTunnelNoConnections|CloudflareTunnelMetricsDown)$"',
+                       'environment="staging"', 'cluster="sugarkube-int"', 'severity="critical"'].freeze
 
 def fail_closed(message)
   warn "ERROR: Alertmanager integration structure invalid: #{message} (sensitive values not printed)."
@@ -82,7 +84,7 @@ if environment == "prod"
 end
 fail_closed("root route must contain only its receiver and exact child routes") unless route.keys.sort == %w[receiver routes]
 children = route["routes"]
-fail_closed("root must have exactly the three allowlisted direct-child routes") unless children.is_a?(Array) && children.length == 3
+fail_closed("root must have exactly the four allowlisted direct-child routes") unless children.is_a?(Array) && children.length == 4
 receivers = config["receivers"]
 fail_closed("receiver list must contain exactly null, two PagerDuty receivers, and Healthchecks") unless receivers.is_a?(Array) && receivers.length == 4 && receivers.all? { |x| x.is_a?(Hash) }
 fail_closed('root "null" receiver is missing or broadened') unless receivers.count { |x| x == { "name" => "null" } } == 1
@@ -105,7 +107,7 @@ webhooks = hc["webhook_configs"]
 expected_webhook = { "url_file" => HC_PATH, "send_resolved" => false, "max_alerts" => 1, "timeout" => "10s" }
 fail_closed("Healthchecks webhook must use the exact file, resolution, timeout, and alert limit") unless webhooks == [expected_webhook]
 
-ds_route, pd_route, hc_route = children
+ds_route, pd_route, hc_route, cloudflare_route = children
 fail_closed("DSPACE route ordering or receiver changed") unless ds_route["receiver"] == DSPACE_RECEIVER
 fail_closed("DSPACE route matchers are not the exact alert allowlist") unless ds_route["matchers"].is_a?(Array) && ds_route["matchers"].sort == DSPACE_MATCHERS.sort
 fail_closed("DSPACE route must contain only receiver and exact matchers") unless ds_route.keys.sort == %w[matchers receiver]
@@ -118,4 +120,7 @@ expected_hc = {
   "group_interval" => "1m", "repeat_interval" => "5m", "continue" => false
 }
 fail_closed("watchdog route is not the exact direct-child allowlist and timing contract") unless hc_route == expected_hc
+fail_closed("Cloudflare route ordering or receiver changed") unless cloudflare_route["receiver"] == DSPACE_RECEIVER
+fail_closed("Cloudflare route matchers are not the exact alert allowlist") unless cloudflare_route["matchers"].is_a?(Array) && cloudflare_route["matchers"].sort == CLOUDFLARE_MATCHERS.sort
+fail_closed("Cloudflare route must contain only receiver and exact matchers") unless cloudflare_route.keys.sort == %w[matchers receiver]
 warn "Alertmanager two-integration structure verified (credential values not accessed)."

--- a/tests/prometheus/cloudflare-tunnel.test.yaml
+++ b/tests/prometheus/cloudflare-tunnel.test.yaml
@@ -1,0 +1,81 @@
+rule_files:
+  - ../../platform/observability/rules/cloudflare-tunnel.yaml
+evaluation_interval: 30s
+tests:
+  - name: two_healthy_connectors
+    input_series:
+      - series: 'cloudflared_tunnel_ha_connections{namespace="cloudflare",pod="connector-a"}'
+        values: '4x30'
+      - series: 'cloudflared_tunnel_ha_connections{namespace="cloudflare",pod="connector-b"}'
+        values: '4x30'
+      - series: 'up{namespace="cloudflare",service="cloudflare-tunnel-metrics",pod="connector-a"}'
+        values: '1x30'
+      - series: 'up{namespace="cloudflare",service="cloudflare-tunnel-metrics",pod="connector-b"}'
+        values: '1x30'
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: CloudflareTunnelNoConnections
+        exp_alerts: []
+      - eval_time: 12m
+        alertname: CloudflareTunnelDegraded
+        exp_alerts: []
+      - eval_time: 12m
+        alertname: CloudflareTunnelMetricsDown
+        exp_alerts: []
+  - name: one_degraded_connector
+    input_series:
+      - series: 'cloudflared_tunnel_ha_connections{namespace="cloudflare",pod="connector-a"}'
+        values: '4x30'
+      - series: 'cloudflared_tunnel_ha_connections{namespace="cloudflare",pod="connector-b"}'
+        values: '2x30'
+    alert_rule_test:
+      - eval_time: 11m
+        alertname: CloudflareTunnelDegraded
+        exp_alerts:
+          - exp_labels: {severity: warning, environment: staging, cluster: sugarkube-int}
+            exp_annotations:
+              summary: Cloudflare Tunnel has fewer than eight aggregate HA connections
+              runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/cloudflare_tunnel.md#wan-outage-recovery
+  - name: zero_connections
+    input_series:
+      - series: 'cloudflared_tunnel_ha_connections{namespace="cloudflare",pod="connector-a"}'
+        values: '0x12'
+      - series: 'cloudflared_tunnel_ha_connections{namespace="cloudflare",pod="connector-b"}'
+        values: '0x12'
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: CloudflareTunnelNoConnections
+        exp_alerts:
+          - exp_labels: {severity: critical, environment: staging, cluster: sugarkube-int}
+            exp_annotations:
+              summary: No Cloudflare Tunnel edge connections are healthy
+              runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/cloudflare_tunnel.md#wan-outage-recovery
+  - name: missing_metrics
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: CloudflareTunnelMetricsDown
+        exp_alerts:
+          - exp_labels: {severity: critical, environment: staging, cluster: sugarkube-int}
+            exp_annotations:
+              summary: One or more Cloudflare Tunnel metrics targets are absent or down
+              runbook_url: https://github.com/futuroptimist/sugarkube/blob/main/docs/cloudflare_tunnel.md#wan-outage-recovery
+  - name: brief_transient_then_recovery
+    input_series:
+      - series: 'cloudflared_tunnel_ha_connections{namespace="cloudflare",pod="connector-a"}'
+        values: '4x2 0x2 4x30'
+      - series: 'cloudflared_tunnel_ha_connections{namespace="cloudflare",pod="connector-b"}'
+        values: '4x2 0x2 4x30'
+      - series: 'up{namespace="cloudflare",service="cloudflare-tunnel-metrics",pod="connector-a"}'
+        values: '1x34'
+      - series: 'up{namespace="cloudflare",service="cloudflare-tunnel-metrics",pod="connector-b"}'
+        values: '1x34'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: CloudflareTunnelNoConnections
+        exp_alerts: []
+      - eval_time: 12m
+        alertname: CloudflareTunnelNoConnections
+        exp_alerts: []
+      - eval_time: 12m
+        alertname: CloudflareTunnelDegraded
+        exp_alerts: []

--- a/tests/test_cloudflare_tunnel_token_mode.py
+++ b/tests/test_cloudflare_tunnel_token_mode.py
@@ -59,7 +59,7 @@ def _extract_recipe_body(name: str) -> str:
                 body.append(line)
                 heredoc_end = "PATCH"
                 continue
-            if line and not line[0].isspace() and line.strip() not in {')', 'EOF', 'PATCH'}:
+            if line and not line[0].isspace() and line.strip() not in {")", "EOF", "PATCH"}:
                 break
             body.append(line)
             continue
@@ -82,11 +82,9 @@ def cf_tunnel_route_recipe_body() -> str:
 
 def _run_cf_tunnel_route_recipe(host: str) -> subprocess.CompletedProcess[str]:
     rendered_body = _extract_cf_tunnel_route_recipe_body().replace("{{ host }}", host)
-    script = textwrap.dedent(
-        """#!/usr/bin/env bash
+    script = textwrap.dedent("""#!/usr/bin/env bash
         set -euo pipefail
-        """
-    ) + rendered_body + "\n"
+        """) + rendered_body + "\n"
 
     with tempfile.NamedTemporaryFile("w", delete=False) as f:
         f.write(script)
@@ -109,25 +107,10 @@ def test_cf_tunnel_route_normalizes_host_prefix(host_input: str) -> None:
 def deployment_patch_ops(cf_recipe_body: str) -> list[dict]:
     """Extract and parse the deployment patch JSON patch payload."""
 
-    match = re.search(
-        r"deployment_patch.*?<<-?'PATCH'.*?\n[ \t]*(?P<patch>\[.*\])\n[ \t]*PATCH",
-        cf_recipe_body,
-        re.S,
+    assert "platform/cloudflare-tunnel/deployment-patch.json" in cf_recipe_body
+    return json.loads(
+        (REPO_ROOT / "platform/cloudflare-tunnel/deployment-patch.json").read_text(encoding="utf-8")
     )
-    if not match:
-        match = re.search(
-            r"deployment_patch=\$?'(?P<patch>\[.*\])'",
-            cf_recipe_body,
-            re.S,
-        )
-
-    assert match, "Deployment patch declaration missing from cf-tunnel-install"
-
-    patch_text = match.group("patch")
-    if "\\n" in patch_text:
-        patch_text = patch_text.encode("utf-8").decode("unicode_escape")
-
-    return json.loads(patch_text)
 
 
 def test_cf_tunnel_install_heredocs_are_well_formed(cf_recipe_body: str) -> None:
@@ -157,15 +140,13 @@ def test_cf_tunnel_install_heredocs_are_well_formed(cf_recipe_body: str) -> None
 
     for terminator, expected_count in opening_counts.items():
         actual_count = terminator_counts.get(terminator, 0)
-        assert actual_count == expected_count, (
-            f"Expected {expected_count} {terminator!r} terminators but found {actual_count}"
-        )
+        assert (
+            actual_count == expected_count
+        ), f"Expected {expected_count} {terminator!r} terminators but found {actual_count}"
         allow_tabs = terminator_allows_tabs.get(terminator, False)
         assert not any(
             _terminator_has_invalid_whitespace(line, terminator, allow_tabs) for line in body
-        ), (
-            f"Terminator {terminator!r} must not be indented or have trailing whitespace"
-        )
+        ), f"Terminator {terminator!r} must not be indented or have trailing whitespace"
 
 
 def _terminator_has_invalid_whitespace(line: str, terminator: str, allow_tabs: bool) -> bool:
@@ -185,8 +166,7 @@ def _terminator_has_invalid_whitespace(line: str, terminator: str, allow_tabs: b
 
 def test_cf_tunnel_install_shell_syntax_is_valid(cf_recipe_body: str) -> None:
     rendered_body = cf_recipe_body.replace("{{ quote(env) }}", "'${env}'")
-    script = textwrap.dedent(
-        """#!/usr/bin/env bash
+    script = textwrap.dedent("""#!/usr/bin/env bash
         set -euo pipefail
 
         # Dummy env so expansions don't blow up under bash -n
@@ -198,8 +178,7 @@ def test_cf_tunnel_install_shell_syntax_is_valid(cf_recipe_body: str) -> None:
         helm() { :; }
         kubectl() { :; }
 
-        """
-    ) + rendered_body + "\n"
+        """) + rendered_body + "\n"
 
     with tempfile.NamedTemporaryFile("w", delete=False) as f:
         f.write(script)
@@ -216,8 +195,7 @@ def test_cf_tunnel_install_shell_syntax_is_valid(cf_recipe_body: str) -> None:
 
 def _run_cf_tunnel_install_recipe(env: str) -> subprocess.CompletedProcess[str]:
     rendered_body = _extract_cf_recipe_body().replace("{{ quote(env) }}", json.dumps(env))
-    script = textwrap.dedent(
-        """#!/usr/bin/env bash
+    script = textwrap.dedent("""#!/usr/bin/env bash
         set -euo pipefail
 
         export CF_TUNNEL_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature
@@ -235,8 +213,7 @@ def _run_cf_tunnel_install_recipe(env: str) -> subprocess.CompletedProcess[str]:
             return 0
         }
 
-        """
-    ) + rendered_body + "\n"
+        """) + rendered_body + "\n"
 
     with tempfile.NamedTemporaryFile("w", delete=False) as f:
         f.write(script)
@@ -292,7 +269,7 @@ def test_deployment_patch_enforces_token_mode(deployment_patch_ops: list[dict]) 
 
     image_op = ops_by_path.get("/spec/template/spec/containers/0/image")
     assert image_op and image_op.get("op") in {"add", "replace"}
-    assert image_op.get("value") == "cloudflare/cloudflared:2024.8.3"
+    assert image_op.get("value").startswith("cloudflare/cloudflared:2026.7.3@sha256:")
 
 
 def test_recipe_relies_on_rollout_status_not_helm_wait(cf_recipe_body: str) -> None:
@@ -319,7 +296,9 @@ def test_teardown_retry_is_baked_into_cf_tunnel_install(cf_recipe_body: str) -> 
     assert "exit 1" in cf_recipe_body
 
 
-def test_deployment_patch_does_not_reference_credentials_file(deployment_patch_ops: list[dict]) -> None:
+def test_deployment_patch_does_not_reference_credentials_file(
+    deployment_patch_ops: list[dict],
+) -> None:
     patch_text = json.dumps(deployment_patch_ops)
     assert "credentials.json" not in patch_text
     assert "creds" not in patch_text
@@ -386,7 +365,9 @@ def test_cf_tunnel_install_normalizes_named_env_arguments(cf_recipe_body: str) -
     assert 'WARNING: env name "int" is deprecated; using env=staging.' in alias_result.stderr
 
 
-def test_cf_tunnel_install_flags_origin_cert_logs(cf_recipe_body: str, origin_cert_guidance_text: str) -> None:
+def test_cf_tunnel_install_flags_origin_cert_logs(
+    cf_recipe_body: str, origin_cert_guidance_text: str
+) -> None:
     assert "Cannot determine default origin certificate path" in cf_recipe_body
     assert "origin_cert_guidance" in cf_recipe_body
     assert 'config_src="cloudflare"' in origin_cert_guidance_text
@@ -399,7 +380,9 @@ def test_reset_and_debug_recipes_exist_and_reset_is_safe() -> None:
     debug_body = _extract_recipe_body("cf-tunnel-debug")
 
     assert "kubectl -n cloudflare delete deploy cloudflare-tunnel" in reset_body
-    assert "kubectl -n cloudflare delete pod -l app.kubernetes.io/name=cloudflare-tunnel" in reset_body
+    assert (
+        "kubectl -n cloudflare delete pod -l app.kubernetes.io/name=cloudflare-tunnel" in reset_body
+    )
     assert "helm -n cloudflare uninstall cloudflare-tunnel" in reset_body
 
     # Secret deletion must remain optional/commented.
@@ -411,7 +394,7 @@ def test_reset_and_debug_recipes_exist_and_reset_is_safe() -> None:
         "kubectl -n cloudflare get deploy,po -l app.kubernetes.io/name=cloudflare-tunnel"
         in debug_body
     )
-    assert "kubectl -n cloudflare logs \"$POD\" --tail=50" in debug_body
+    assert 'kubectl -n cloudflare logs "$POD" --tail=50' in debug_body
     assert "No ConfigMap created in token-only mode" in debug_body
 
 
@@ -421,3 +404,44 @@ def test_debug_recipe_surfaces_origin_cert_guidance(origin_cert_guidance_text: s
     assert "origin_cert_guidance" in debug_body
     assert "behaving like a locally-managed tunnel" in origin_cert_guidance_text
     assert 'config_src="cloudflare"' in origin_cert_guidance_text
+
+
+def test_connector_lifecycle_is_wan_safe(deployment_patch_ops: list[dict]) -> None:
+    ops = {op["path"]: op for op in deployment_patch_ops}
+    assert ops["/spec/replicas"]["value"] == 2
+    assert ops["/spec/strategy"]["value"]["rollingUpdate"] == {
+        "maxUnavailable": 0,
+        "maxSurge": 1,
+    }
+    assert ops["/spec/template/spec/containers/0/livenessProbe"]["op"] == "remove"
+    readiness = ops["/spec/template/spec/containers/0/readinessProbe"]["value"]
+    assert readiness["httpGet"] == {"path": "/ready", "port": 2000}
+    assert readiness["failureThreshold"] == 3
+
+
+def test_metrics_discovery_and_pdb_contracts_exist() -> None:
+    text = (
+        (REPO_ROOT / "platform/cloudflare-tunnel/service.yaml").read_text()
+        + (REPO_ROOT / "platform/cloudflare-tunnel/servicemonitor.yaml").read_text()
+        + (REPO_ROOT / "platform/cloudflare-tunnel/pdb.yaml").read_text()
+    )
+    assert "type: ClusterIP" in text
+    assert "name: metrics" in text and "targetPort: 2000" in text
+    assert "kind: ServiceMonitor" in text
+    assert "release: kube-prometheus-stack" in text
+    assert "path: /metrics" in text and "scrapeTimeout: 10s" in text
+    assert "kind: PodDisruptionBudget" in text and "minAvailable: 1" in text
+
+
+def test_cloudflare_alert_and_verification_contracts_exist() -> None:
+    rules = (REPO_ROOT / "platform/observability/rules/cloudflare-tunnel.yaml").read_text()
+    for name in (
+        "CloudflareTunnelNoConnections",
+        "CloudflareTunnelDegraded",
+        "CloudflareTunnelMetricsDown",
+    ):
+        assert name in rules
+    assert "or vector(0)" in rules
+    verify = (REPO_ROOT / "scripts/verify_cloudflare_tunnel.py").read_text()
+    for contract in ("tunnel-token", '"token"', "livenessProbe", "activeTargets", "/api/v1/rules"):
+        assert contract in verify

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -16,6 +16,7 @@ PROD = ROOT / "clusters" / "prod" / "observability" / "kube-prometheus-stack.val
 CANONICAL_DSPACE_RULES = (
     ROOT / "platform" / "observability" / "rules" / "dspace-release-integrity.yaml"
 )
+CANONICAL_CLOUDFLARE_RULES = ROOT / "platform/observability/rules/cloudflare-tunnel.yaml"
 SCRIPT = ROOT / "scripts" / "observability_helm.sh"
 ALERTMANAGER_VALIDATOR = ROOT / "scripts" / "verify_observability_alertmanager.rb"
 DASHBOARD = ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
@@ -150,20 +151,30 @@ def test_production_values_have_exact_safe_overrides_without_public_exposure_or_
     prod = yaml_load(PROD)
     assert prod == {
         "defaultRules": {"disabled": {"Watchdog": True}},
-        "prometheus": {
-            "prometheusSpec": {"externalLabels": {"cluster": "sugarkube-prod"}}
-        },
+        "prometheus": {"prometheusSpec": {"externalLabels": {"cluster": "sugarkube-prod"}}},
         "alertmanager": {
             "alertmanagerSpec": {"secrets": []},
             "config": {
-                "global": None, "inhibit_rules": None, "templates": None,
-                "route": {"group_by": None, "group_wait": None, "group_interval": None,
-                          "repeat_interval": None, "receiver": "null", "routes": None},
+                "global": None,
+                "inhibit_rules": None,
+                "templates": None,
+                "route": {
+                    "group_by": None,
+                    "group_wait": None,
+                    "group_interval": None,
+                    "repeat_interval": None,
+                    "receiver": "null",
+                    "routes": None,
+                },
                 "receivers": [{"name": "null"}],
             },
         },
     }
-    text = COMMON.read_text(encoding="utf-8") + STAGING.read_text(encoding="utf-8") + PROD.read_text(encoding="utf-8")
+    text = (
+        COMMON.read_text(encoding="utf-8")
+        + STAGING.read_text(encoding="utf-8")
+        + PROD.read_text(encoding="utf-8")
+    )
     forbidden = [
         "longhorn",
         "cloudflare",
@@ -232,6 +243,12 @@ stringData:
           group_interval: 1m
           repeat_interval: 5m
           continue: false
+        - receiver: pagerduty-dspace
+          matchers:
+            - 'alertname=~"^(CloudflareTunnelNoConnections|CloudflareTunnelMetricsDown)$"'
+            - 'environment="staging"'
+            - 'cluster="sugarkube-int"'
+            - 'severity="critical"'
     receivers:
       - name: "null"
       - name: pagerduty-synthetic-test
@@ -447,7 +464,10 @@ def test_discovery_contract_uses_release_label():
 def test_lifecycle_uses_pinned_version_ordered_values_and_no_reuse_values():
     script = SCRIPT.read_text(encoding="utf-8")
     assert 'CHART="prometheus-community/kube-prometheus-stack"' in script
-    assert 'PROD_VALUES="${ROOT}/clusters/prod/observability/kube-prometheus-stack.values.yaml"' in script
+    assert (
+        'PROD_VALUES="${ROOT}/clusters/prod/observability/kube-prometheus-stack.values.yaml"'
+        in script
+    )
     assert '-f "${COMMON_VALUES}" -f "${ENV_VALUES}"' in script
     assert "--reuse-values" not in script
     assert "--atomic" in script
@@ -502,7 +522,8 @@ def test_dspace_rules_have_one_canonical_source_and_exact_overlay(tmp_path):
     overlay = yaml_load(tmp_path / "rules-overlay.yaml")
     assert overlay == {
         "additionalPrometheusRulesMap": {
-            "dspace-release-integrity": yaml_load(CANONICAL_DSPACE_RULES)
+            "dspace-release-integrity": yaml_load(CANONICAL_DSPACE_RULES),
+            "cloudflare-tunnel": yaml_load(CANONICAL_CLOUDFLARE_RULES),
         }
     }
     overlay_paths = re.findall(r"/[^ ]*sugarkube-observability-rules\.[^ ]*\.yaml", audit)
@@ -624,8 +645,7 @@ def test_justfile_exposes_observability_recipes():
 def test_justfile_normalizes_repeated_env_prefixes_before_staging_metrics_checks():
     text = JUSTFILE.read_text(encoding="utf-8")
     normalization = (
-        'while [ "${env_name#env=}" != "${env_name}" ]; '
-        'do env_name="${env_name#env=}"; done'
+        'while [ "${env_name#env=}" != "${env_name}" ]; ' 'do env_name="${env_name#env=}"; done'
     )
     for recipe in ("observability-install", "observability-upgrade", "observability-verify"):
         recipe_block = text.split(f"{recipe} env='':", 1)[1].split("\n\n", 1)[0]
@@ -1021,6 +1041,12 @@ printf '%s' "$code"
       group_interval: 1m
       repeat_interval: 5m
       continue: false
+    - receiver: pagerduty-dspace
+      matchers:
+        - alertname=~"^(CloudflareTunnelNoConnections|CloudflareTunnelMetricsDown)$"
+        - environment="staging"
+        - cluster="sugarkube-int"
+        - severity="critical"
 receivers:
   - name: "null"
   - name: pagerduty-synthetic-test
@@ -2384,7 +2410,7 @@ def test_watchdog_silence_api_failures_do_not_expose_fixture_contents(tmp_path, 
 
 
 def production_alertmanager_fixture(*, secrets="[]", route_extra="", receiver_extra="", inline=""):
-    return f'''---
+    return f"""---
 apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
@@ -2402,7 +2428,7 @@ stringData:
       receiver: "null"{route_extra}
     receivers:
       - name: "null"{receiver_extra}{inline}
-'''
+"""
 
 
 def test_production_offline_render_uses_only_ordered_core_values(tmp_path):
@@ -2430,8 +2456,12 @@ def test_production_install_identity_and_explicit_kubeconfig_fail_before_helm_mu
     tmp_path, context, mode, extra_env
 ):
     result, audit = run_helper(
-        tmp_path, "install", env_name="prod", context=context,
-        kubectl_mode=mode, extra_env=extra_env,
+        tmp_path,
+        "install",
+        env_name="prod",
+        context=context,
+        kubectl_mode=mode,
+        extra_env=extra_env,
     )
     assert result.returncode != 0
     assert "helm install" not in audit
@@ -2443,13 +2473,18 @@ def test_production_install_release_and_secret_guards(tmp_path):
     )
     assert installed.returncode == 0, installed.stderr
     assert "helm install" in audit and "--atomic" in audit
-    assert "alertmanager-pagerduty" not in audit and "alertmanager-healthchecks-watchdog" not in audit
+    assert (
+        "alertmanager-pagerduty" not in audit and "alertmanager-healthchecks-watchdog" not in audit
+    )
     existing, audit = run_helper(
         tmp_path / "existing", "install", env_name="prod", context="sugar-prod", helm_mode="present"
     )
     assert existing.returncode != 0 and "helm install" not in audit
     missing, audit = run_helper(
-        tmp_path / "secret", "install", env_name="prod", context="sugar-prod",
+        tmp_path / "secret",
+        "install",
+        env_name="prod",
+        context="sugar-prod",
         kubectl_mode="missing-grafana",
     )
     assert missing.returncode != 0 and "helm " not in audit
@@ -2458,9 +2493,20 @@ def test_production_install_release_and_secret_guards(tmp_path):
 def test_production_core_verify_skips_staging_integrations(tmp_path):
     result, audit = run_helper(tmp_path, "verify", env_name="prod", context="sugar-prod")
     assert result.returncode == 0, result.stderr
-    for required in ("rollout status", "get daemonset", "get pvc -o json", "get svc kube-prometheus-stack-grafana", "get secret grafana-admin-credentials"):
+    for required in (
+        "rollout status",
+        "get daemonset",
+        "get pvc -o json",
+        "get svc kube-prometheus-stack-grafana",
+        "get secret grafana-admin-credentials",
+    ):
         assert required in audit
-    for excluded in ("servicemonitor dspace", "alertmanager-pagerduty", "alertmanager-healthchecks-watchdog", " --raw "):
+    for excluded in (
+        "servicemonitor dspace",
+        "alertmanager-pagerduty",
+        "alertmanager-healthchecks-watchdog",
+        " --raw ",
+    ):
         assert excluded not in audit
 
 
@@ -2487,14 +2533,18 @@ def test_production_alertmanager_validator_accepts_null_only_and_rejects_integra
     valid.write_text(production_alertmanager_fixture(), encoding="utf-8")
     accepted = subprocess.run(
         ["ruby", str(ALERTMANAGER_VALIDATOR), "prod", "rendered", str(valid)],
-        capture_output=True, text=True, check=False,
+        capture_output=True,
+        text=True,
+        check=False,
     )
     assert accepted.returncode == 0, accepted.stderr
     invalid = tmp_path / "invalid.yaml"
     invalid.write_text(production_alertmanager_fixture(**mutation), encoding="utf-8")
     rejected = subprocess.run(
         ["ruby", str(ALERTMANAGER_VALIDATOR), "prod", "rendered", str(invalid)],
-        capture_output=True, text=True, check=False,
+        capture_output=True,
+        text=True,
+        check=False,
     )
     assert rejected.returncode == 16
     assert "forbidden-stub" not in rejected.stderr
@@ -2509,7 +2559,9 @@ def test_production_alertmanager_secret_mount_has_production_specific_diagnostic
     )
     result = subprocess.run(
         ["ruby", str(ALERTMANAGER_VALIDATOR), "prod", "rendered", str(manifest)],
-        capture_output=True, text=True, check=False,
+        capture_output=True,
+        text=True,
+        check=False,
     )
     assert result.returncode == 16
     assert "production Alertmanager must mount no integration Secrets" in result.stderr


### PR DESCRIPTION
### Motivation

- During a 2026-08-04 staging WAN/DNS outage both cloudflared connectors failed edge DNS discovery and `/ready` (which chart 0.3.2 used as a liveness probe) caused Kubernetes to SIGTERM the processes within ~11–12s, producing synchronized restarts, restart/backoff loops, and a prolonged outage window. 
- The intended fix is to stop killing connectors for edge/DNS failures (use readiness, not liveness), keep connectors alive to use cloudflared’s built-in reconnect/backoff, preserve the existing token-based remote-managed reconciliation path, and add bounded observability/alerting to detect real outages.

### Description

- Lifecycle and image: pin the deployed connector image to the exact supported multi-arch tag `cloudflare/cloudflared:2026.7.3@sha256:e39ee8da81ad5e...91bf`, move `/ready` to a readiness probe, remove the WAN/DNS-sensitive liveness probe, set `replicas: 2`, and add HA-safe rollout `maxUnavailable: 0` and `maxSurge: 1` via `platform/cloudflare-tunnel/deployment-patch.json` and `justfile` changes while preserving the existing `tunnel-token` Secret contract.
- Metrics and PDB: add an internal ClusterIP Service `platform/cloudflare-tunnel/service.yaml`, a `ServiceMonitor` `platform/cloudflare-tunnel/servicemonitor.yaml` that scrapes `/metrics` on port `2000`, and a PodDisruptionBudget `platform/cloudflare-tunnel/pdb.yaml` with `minAvailable: 1` so at least one connector remains available during voluntary disruption.
- Alerts and fixtures: add absent-safe Prometheus rules in `platform/observability/rules/cloudflare-tunnel.yaml` for (1) no connections, (2) degraded aggregate HA connections, and (3) metrics-target absence/down, and add promtool test fixtures `tests/prometheus/cloudflare-tunnel.test.yaml` covering healthy, degraded, zero, missing, transient, and recovered scenarios.
- Verification and operator tooling: add a read-only verification script `scripts/verify_cloudflare_tunnel.py` that checks release ownership, chart version, replicas and node spread, readiness-only `/ready`, absence of liveness, rollout strategy, PDB, Service/ServiceMonitor selection, Prometheus targets, and HA connection counts; add a staging-only, owner-confirmed mutating helper `scripts/cloudflare_tunnel_harden.sh` that applies the kustomize monitoring objects and the JSON patch (the script fails closed on context/checks and does not read Secret values).
- Observability plumbing and tests: integrate the Cloudflare rules into the observability render flow by updating `scripts/observability_helm.sh`, extend Alertmanager validator to accept the new Cloudflare child route, and update tests to assert the new contracts (`tests/test_cloudflare_tunnel_token_mode.py`, `tests/test_observability_helm.py`).
- Documentation and operator runbook: extend `docs/cloudflare_tunnel.md` with the outage timeline, root-cause analysis (why readiness replaces the WAN-sensitive liveness probe), supported-version policy, metrics and alerts, and a separately authorized staging rollout and recovery-drill procedure.

### Testing

- `pytest -q tests/test_cloudflare_tunnel_token_mode.py tests/test_observability_helm.py tests/test_docs_guardrails.py tests/test_staging_ingress_ha.py` — PASS (229 tests passed; final run: `229 passed in 134.88s`).
- Prometheus rule validation: `promtool check rules platform/observability/rules/cloudflare-tunnel.yaml` — PASS (rules syntactically valid).
- Prometheus rule unit tests: `promtool test rules tests/prometheus/cloudflare-tunnel.test.yaml` — PASS (all fixture cases exercised as expected).
- Chart checks: `helm lint <cloudflare-tunnel-0.3.2 chart> --set fullnameOverride=cloudflare-tunnel --set cloudflare.secretName=tunnel-token --set image.tag=2026.7.3` — PASS; `helm template ... --version 0.3.2 --set image.tag=2026.7.3` — PASS (render contains Cloudflare rules and objects).
- Observability render: `scripts/observability_helm.sh render env=staging` — PASS (rendered manifests include Cloudflare rules overlay).
- Static checks and docs: `pyspelling -c .spellcheck.yaml` — PASS; `linkchecker --no-warnings README.md docs/` — PASS (208 URLs checked, no errors).
- Pre-commit focused hooks: `pre-commit run --files <changed-files>` — PASS for whitespace/EOF/YAML hooks and the staged files changed by this PR; `pre-commit run --all-files` — NOT FULLY PASS (pre-existing repository-wide flake8 and some Helm/YAML multi-document issues unrelated to this change remain and are intentionally not modified by this PR).
- Read-only and smoke checks: `bash -n scripts/cloudflare_tunnel_harden.sh` and `python3 -m py_compile scripts/verify_cloudflare_tunnel.py` — PASS; `git diff --cached | ./scripts/scan-secrets.py` — PASS (no secrets introduced by these changes).

Notes and constraints

- The changes preserve the existing live reconciliation contract (the single `cloudflare-tunnel` Helm release and `tunnel-token` Secret) and do not enable any dormant Flux path or change remote-managed ingress rules.
- No live Kubernetes, Helm, Cloudflare, Secret, or production resources were accessed or mutated by these repository changes or CI verification; the included `scripts/cloudflare_tunnel_harden.sh` is an operator-only, explicitly confirmed, staging-only mutating helper and is documented as such.
- Attempted `git push` / `gh pr create` from the environment failed due to missing GitHub credentials; the branch and changes are committed locally on branch `codex/harden-cloudflare-tunnel-wan-recovery` for an operator to push/create the PR when authorized.

Files (high level)

- Added/updated lifecycle and deployment patch: `platform/cloudflare-tunnel/deployment-patch.json`, `justfile` (use patch file, `--version` pin), `scripts/cloudflare_tunnel_harden.sh`.
- Metrics & monitoring objects: `platform/cloudflare-tunnel/service.yaml`, `platform/cloudflare-tunnel/servicemonitor.yaml`, `platform/cloudflare-tunnel/pdb.yaml`, `platform/cloudflare-tunnel/kustomization.yaml`.
- Alerts and promtool tests: `platform/observability/rules/cloudflare-tunnel.yaml`, `tests/prometheus/cloudflare-tunnel.test.yaml`.
- Verification & test integration: `scripts/verify_cloudflare_tunnel.py`, `scripts/observability_helm.sh` (include Cloudflare rules), `scripts/verify_observability_alertmanager.rb` (allow Cloudflare route), and test updates in `tests/test_cloudflare_tunnel_token_mode.py` and `tests/test_observability_helm.py`.
- Docs: `docs/cloudflare_tunnel.md` extended with timeline, root cause, monitoring, and operator rollout/drill guidance.

If you want, I can now:
- prepare a short human-facing merge checklist showing the exact `kubectl`/`helm` commands and the manual verification steps for the owner to run in staging (this must be run manually and is intentionally gated), or
- open the PR on GitHub if provided with push/CLI credentials (the branch is already committed locally: `codex/harden-cloudflare-tunnel-wan-recovery`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7770d3a9c8832fba19bde6fc09bdba)