### PR TITLE
Add Sugarkube Production Observability dashboard and environment-aware provisioning

### DIFF
--- a/clusters/prod/observability/dashboards/sugarkube-prod-observability.json
+++ b/clusters/prod/observability/dashboards/sugarkube-prod-observability.json
@@ -1,0 +1,563 @@
+{
+  "id": null,
+  "uid": "sugarkube-prod-observability",
+  "title": "Sugarkube Production Observability",
+  "tags": [
+    "sugarkube",
+    "production",
+    "provisioned"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 41,
+  "version": 1,
+  "editable": false,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Cluster health",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "id": 2,
+      "type": "table",
+      "title": "Scrape availability by job",
+      "description": "One is healthy, zero is unhealthy, and an absent series remains NO DATA.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "min by (job) (up)",
+          "legendFormat": "{{job}}",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA",
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "UNHEALTHY",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "HEALTHY",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Ready nodes",
+      "description": "Three is the observed production expectation, not an alert threshold.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(max by (node) (kube_node_status_condition{condition=\"Ready\",status=\"true\"}))",
+          "legendFormat": "Ready nodes",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 4,
+      "type": "table",
+      "title": "Node readiness",
+      "description": "One is ready, zero is not ready, and absence remains NO DATA.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (node) (kube_node_status_condition{condition=\"Ready\",status=\"true\"})",
+          "legendFormat": "{{node}}",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA",
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "UNHEALTHY",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "HEALTHY",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 5,
+      "type": "row",
+      "title": "Workload health",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      }
+    },
+    {
+      "id": 6,
+      "type": "table",
+      "title": "Deployment replica deficit",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "clamp_min(max by (namespace, deployment) (kube_deployment_spec_replicas) - max by (namespace, deployment) (kube_deployment_status_replicas_available), 0)",
+          "legendFormat": "{{namespace}} / {{deployment}}",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Unready pods by namespace",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (namespace) (max by (namespace, pod) (kube_pod_status_ready{condition=\"false\"}))",
+          "legendFormat": "{{namespace}}",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Problem pods by namespace",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (namespace) (max by (namespace, pod, phase) (kube_pod_status_phase{phase=~\"Pending|Failed|Unknown\"}))",
+          "legendFormat": "{{namespace}}",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Container restart rate",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (namespace, pod) (max by (namespace, pod, container) (rate(kube_pod_container_status_restarts_total[$__rate_interval])))",
+          "legendFormat": "{{namespace}} / {{pod}}",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Node and Prometheus capacity",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      }
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Node CPU utilization",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 23
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (nodename) (100 * (1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]))) * on (instance) group_left (nodename) node_uname_info)",
+          "legendFormat": "{{nodename}}",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "noValue": "NO DATA",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Node memory utilization",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 23
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (nodename) (100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * on (instance) group_left (nodename) node_uname_info)",
+          "legendFormat": "{{nodename}}",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "noValue": "NO DATA",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Root filesystem utilization",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 23
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (nodename) (100 * (1 - node_filesystem_avail_bytes{mountpoint=\"/\",fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{mountpoint=\"/\",fstype!~\"tmpfs|overlay\"}) * on (instance) group_left (nodename) node_uname_info)",
+          "legendFormat": "{{nodename}}",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "noValue": "NO DATA",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "Prometheus PVC utilization",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "100 * (1 - max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_available_bytes{namespace=\"monitoring\",persistentvolumeclaim=~\"prometheus-kube-prometheus-stack-prometheus-db-.*\"}) / max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=\"monitoring\",persistentvolumeclaim=~\"prometheus-kube-prometheus-stack-prometheus-db-.*\"}))",
+          "legendFormat": "{{persistentvolumeclaim}}",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "noValue": "NO DATA",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "Prometheus active series",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (pod) (prometheus_tsdb_head_series)",
+          "legendFormat": "{{pod}}",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 16,
+      "type": "row",
+      "title": "Observability build identity",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      }
+    },
+    {
+      "id": 17,
+      "type": "table",
+      "title": "Observability component build identity",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (pod, version, revision) (prometheus_build_info)",
+          "legendFormat": "Prometheus {{pod}} {{version}} {{revision}}",
+          "instant": true,
+          "range": false
+        },
+        {
+          "refId": "B",
+          "expr": "max by (pod, version, revision) (alertmanager_build_info)",
+          "legendFormat": "Alertmanager {{pod}} {{version}} {{revision}}",
+          "instant": true,
+          "range": false
+        },
+        {
+          "refId": "C",
+          "expr": "max by (pod, version, revision) (grafana_build_info)",
+          "legendFormat": "Grafana {{pod}} {{version}} {{revision}}",
+          "instant": true,
+          "range": false
+        },
+        {
+          "refId": "D",
+          "expr": "max by (pod, version, revision) (node_exporter_build_info)",
+          "legendFormat": "node-exporter {{pod}} {{version}} {{revision}}",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {}
+    }
+  ]
+}

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -665,3 +665,78 @@ verification is intentionally rejected until production observability is codifie
 Merging this repository support does not deploy any application, create any
 Secret, dashboard, alert rule, schedulability check, shared-state check, or live
 drill.
+
+## Production provisioned dashboard
+
+`Sugarkube Production Observability` is the first production dashboard and is provisioned from
+version-controlled JSON. It uses the single-cluster Prometheus datasource directly, defaults to the
+last six hours, and refreshes every 30 seconds. Grafana UI persistence remains disabled in Phase 1:
+mutable UI edits are ephemeral, while the immutable provisioned dashboard must be recreated from its
+ConfigMap whenever the Grafana pod is replaced.
+
+The panels have these operational meanings:
+
+- **Cluster health:** **Scrape availability by job** takes the minimum `up` value per job, so any
+  failed target makes that job unhealthy; **Ready nodes** deduplicates the Ready condition per node
+  before counting it (three is the observed expectation, not an alert threshold); and **Node
+  readiness** retains each permitted node name. Values of one and zero are real samples; an absent
+  series is `NO DATA` rather than a fabricated zero.
+- **Workload health:** **Deployment replica deficit** independently deduplicates desired and
+  available KSM gauges by namespace/deployment before subtraction and clamps only a negative
+  arithmetic result; **Unready pods by namespace** and **Problem pods by namespace** deduplicate
+  pod gauges before summing; and **Container restart rate** deduplicates container series before
+  summing by namespace/pod. Restart rate uses Grafana's `$__rate_interval`, not a fixed window.
+  Emitted zeroes remain visible and missing series remain `NO DATA`.
+- **Node and Prometheus capacity:** CPU uses idle-time rate and the live-proven `node_uname_info`
+  join; memory and root-filesystem utilization use the same exporter-to-`nodename` mapping. Their
+  final grouping exposes only `nodename`, not target instances. **Prometheus PVC utilization**
+  independently bounds the available and capacity gauges by namespace/PVC before division.
+  **Prometheus active series** uses `max by (pod)` and remains per pod, rather than incorrectly
+  summing future Prometheus replicas. All utilization panels have a display-only 0–100 percent
+  scale; display guidance is not an alert policy.
+- **Observability component build identity:** separate instant queries retain pod, version, and
+  revision for Prometheus, Alertmanager, Grafana, and node-exporter. Component-prefixed legends
+  keep the rows unambiguous. `kube_state_metrics_build_info` is intentionally absent because that
+  family was not present in production and no substitute signal is inferred.
+
+Prometheus `externalLabels` are attached for remote/external use; they are not injected into samples
+returned by local Prometheus queries. Because this dashboard has one production datasource, its
+expressions must not select `cluster="sugarkube-prod"` (or any external cluster label). Doing so
+would turn valid local results into missing data. Internal `on(instance)` joins are used only to map
+node-exporter samples to the permitted `nodename`; raw instances, addresses, URLs, endpoints, and
+other infrastructure identity are neither grouped nor displayed.
+
+### Live production evidence (2026-08-08)
+
+Read-only evidence at repository SHA `2984f3fd5b39d391621f414ae01150cf6c0a7a59`, after successful
+Helm revision 1 installation on context `sugar-prod`, found 23/23 active targets healthy in two
+separate scrapes: `apiserver` (3), `coredns` (1), Alertmanager (2), Grafana (1), operator (1),
+Prometheus (2), kube-state-metrics (1), kubelet (9), and node-exporter (3). Three nodes were Ready.
+Candidate queries returned three CPU results (about 2.39–4.04%), three memory results (about
+15.00–25.17%), three root-filesystem results (about 6.26–6.50%), eleven zero deployment deficits,
+six zero problem-pod namespace results, twenty zero restart-rate results, one Prometheus PVC result
+(about 6.50%), and about 174,263 Prometheus head series. Core node, pod, workload, PVC/volume,
+scrape, Prometheus storage/build, Alertmanager build, Grafana build, and node-exporter build families
+were present. `kube_state_metrics_build_info` was absent and is deliberately omitted. No raw target,
+URL, instance, address, error, or identity-label value was retained.
+
+### Post-merge production dashboard proof
+
+This procedure is intentionally operator-run after merge; repository tests do not contact a cluster.
+
+1. `export KUBECONFIG="$HOME/.kube/config-sugarkube-prod"` and verify the current context is
+   `sugar-prod`.
+2. Keep the externally managed `127.0.0.1:16443` API tunnel running.
+3. Run and inspect `just observability-render env=prod`.
+4. Run `just observability-upgrade env=prod`—not install, because Helm revision 1 already exists.
+5. Run `just observability-verify env=prod`.
+6. Run `just observability-dashboard-verify env=prod`.
+7. Delete only the Grafana pod, wait for the Grafana deployment rollout, then run the dashboard
+   verification again to prove provisioned recovery.
+8. Visually inspect every panel at <http://sugarkube0.local:30300> with credentials from the approved manager.
+9. Record the Git SHA, Helm revision, and private operator-evidence path.
+
+Production application metrics, blackbox monitoring, paging and alert rules, persistent mutable
+Grafana UI state, high availability, and retention/storage changes are explicitly deferred. DSPACE,
+token.place, synthetic checks, application releases, Alertmanager routing, PagerDuty, and watchdog
+behavior remain outside this dashboard lifecycle.

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -16,8 +16,10 @@ COMMON_VALUES="${ROOT}/platform/observability/helm/kube-prometheus-stack.values.
 STAGING_VALUES="${ROOT}/clusters/staging/observability/kube-prometheus-stack.values.yaml"
 PROD_VALUES="${ROOT}/clusters/prod/observability/kube-prometheus-stack.values.yaml"
 DSPACE_RULES="${ROOT}/platform/observability/rules/dspace-release-integrity.yaml"
-DASHBOARD="${ROOT}/clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
-DASHBOARD_VALUE="grafana.dashboards.sugarkube.sugarkube-staging-observability.json"
+DASHBOARD=""
+DASHBOARD_VALUE=""
+DASHBOARD_UID=""
+DASHBOARD_TITLE=""
 DASHBOARD_VALIDATOR="${ROOT}/scripts/validate_observability_dashboard.py"
 TIMEOUT="${SUGARKUBE_OBSERVABILITY_HELM_TIMEOUT:-20m}"
 GRAFANA_URL="http://sugarkube3.local:30300"
@@ -46,9 +48,14 @@ resolve_environment() {
   ENVIRONMENT="$(normalize_env "$1")"
   if [[ "$ENVIRONMENT" == staging ]]; then
     ENV_VALUES="$STAGING_VALUES"; EXPECTED_CONTEXT="sugar-staging"; GRAFANA_URL="http://sugarkube3.local:30300"
+    DASHBOARD_UID="sugarkube-staging-observability"; DASHBOARD_TITLE="Sugarkube Staging Observability"
+    DASHBOARD="${ROOT}/clusters/staging/observability/dashboards/${DASHBOARD_UID}.json"
   else
     ENV_VALUES="$PROD_VALUES"; EXPECTED_CONTEXT="sugar-prod"; GRAFANA_URL="http://sugarkube0.local:30300"
+    DASHBOARD_UID="sugarkube-prod-observability"; DASHBOARD_TITLE="Sugarkube Production Observability"
+    DASHBOARD="${ROOT}/clusters/prod/observability/dashboards/${DASHBOARD_UID}.json"
   fi
+  DASHBOARD_VALUE="grafana.dashboards.sugarkube.${DASHBOARD_UID}.json"
 }
 require_staging() { [[ "$ENVIRONMENT" == staging ]] || { echo "ERROR: $1 is staging-only; production support is deferred." >&2; exit 2; }; }
 require_tools() { for t in "$@"; do command -v "$t" >/dev/null 2>&1 || { echo "ERROR: required tool missing: $t" >&2; exit 127; }; done; }
@@ -67,9 +74,8 @@ ordered values files:
   - ${COMMON_VALUES}
   - ${ENV_VALUES}
 EOT
-  if [[ "$ENVIRONMENT" == staging ]]; then
-    printf '  - generated mode-0600 rules overlay sourced from %s\ndashboard source (--set-file): %s\n' "$DSPACE_RULES" "$DASHBOARD"
-  fi
+  [[ "$ENVIRONMENT" != staging ]] || printf '  - generated mode-0600 rules overlay sourced from %s\n' "$DSPACE_RULES"
+  printf 'dashboard source (--set-file): %s\n' "$DASHBOARD"
   printf 'Grafana LAN URL: %s (same NodePort is available through the other %s nodes)\n' "$GRAFANA_URL" "$ENVIRONMENT"
 }
 assert_context() {
@@ -105,11 +111,11 @@ validate_rendered_alertmanager() { ruby "${ALERTMANAGER_VALIDATOR}" "${ENVIRONME
 render_to() {
   local out="$1"; shift
   local dashboard_args=()
-  [[ "$ENVIRONMENT" != staging ]] || dashboard_args=(--set-file "${DASHBOARD_VALUE}=${DASHBOARD}")
+  dashboard_args=(--set-file "${DASHBOARD_VALUE}=${DASHBOARD}")
   helm repo add prometheus-community https://prometheus-community.github.io/helm-charts --force-update >/dev/null
   helm repo update prometheus-community >/dev/null
   helm template "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${ENV_VALUES}" "$@" "${dashboard_args[@]}" >"${out}"
-  [[ "$ENVIRONMENT" != staging ]] || validate_rendered_dashboard "${out}"
+  validate_rendered_dashboard "${out}"
   validate_rendered_alertmanager "${out}"
 }
 prepare_render_args() {
@@ -251,9 +257,9 @@ release_state() {
     return 1
   fi
 }
-render() { [[ "$ENVIRONMENT" != staging ]] || validate_dashboard; require_tools helm python3 ruby; print_resolved '<not queried: offline render>'; local tmp; tmp="$(mktemp -t sugarkube-observability-render.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}" "${RULES_OVERLAY:-}"' EXIT; prepare_render_args; render_to "$tmp" "${RENDER_ARGS[@]}"; cat "$tmp"; }
-install_release() { [[ "$ENVIRONMENT" != staging ]] || validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved; assert_context; assert_grafana_secret; [[ "$ENVIRONMENT" != staging ]] || assert_integration_secrets; local tmp state dashboard_args=(); tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}" "${RULES_OVERLAY:-}"' EXIT; prepare_render_args; render_to "$tmp" "${RENDER_ARGS[@]}"; state="$(release_state)"; if [[ "$state" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; [[ "$ENVIRONMENT" != staging ]] || dashboard_args=(--set-file "${DASHBOARD_VALUE}=${DASHBOARD}"); helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${ENV_VALUES}" "${RENDER_ARGS[@]}" "${dashboard_args[@]}" --atomic --wait --timeout "${TIMEOUT}"; }
-upgrade_release() { [[ "$ENVIRONMENT" != staging ]] || validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved; assert_context; assert_grafana_secret; [[ "$ENVIRONMENT" != staging ]] || assert_integration_secrets; local tmp state dashboard_args=(); tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}" "${RULES_OVERLAY:-}"' EXIT; prepare_render_args; render_to "$tmp" "${RENDER_ARGS[@]}"; state="$(release_state)"; if [[ "$state" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; [[ "$ENVIRONMENT" != staging ]] || dashboard_args=(--set-file "${DASHBOARD_VALUE}=${DASHBOARD}"); helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${ENV_VALUES}" "${RENDER_ARGS[@]}" "${dashboard_args[@]}" --atomic --wait --timeout "${TIMEOUT}"; }
+render() { validate_dashboard; require_tools helm python3 ruby; print_resolved '<not queried: offline render>'; local tmp; tmp="$(mktemp -t sugarkube-observability-render.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}" "${RULES_OVERLAY:-}"' EXIT; prepare_render_args; render_to "$tmp" "${RENDER_ARGS[@]}"; cat "$tmp"; }
+install_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved; assert_context; assert_grafana_secret; [[ "$ENVIRONMENT" != staging ]] || assert_integration_secrets; local tmp state dashboard_args=(--set-file "${DASHBOARD_VALUE}=${DASHBOARD}"); tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}" "${RULES_OVERLAY:-}"' EXIT; prepare_render_args; render_to "$tmp" "${RENDER_ARGS[@]}"; state="$(release_state)"; if [[ "$state" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${ENV_VALUES}" "${RENDER_ARGS[@]}" "${dashboard_args[@]}" --atomic --wait --timeout "${TIMEOUT}"; }
+upgrade_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved; assert_context; assert_grafana_secret; [[ "$ENVIRONMENT" != staging ]] || assert_integration_secrets; local tmp state dashboard_args=(--set-file "${DASHBOARD_VALUE}=${DASHBOARD}"); tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}" "${RULES_OVERLAY:-}"' EXIT; prepare_render_args; render_to "$tmp" "${RENDER_ARGS[@]}"; state="$(release_state)"; if [[ "$state" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${ENV_VALUES}" "${RENDER_ARGS[@]}" "${dashboard_args[@]}" --atomic --wait --timeout "${TIMEOUT}"; }
 WATCHDOG_TTY="${SUGARKUBE_WATCHDOG_TTY:-/dev/tty}"
 WATCHDOG_API="/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-alertmanager:9093/proxy/api/v2"
 
@@ -782,7 +788,7 @@ json.dump([{
 
 dashboard_verify() (
   require_tools kubectl python3 curl base64 sleep
-  print_resolved staging
+  print_resolved "$EXPECTED_CONTEXT"
   assert_context
   local response body http_status port="" remote_port line
   local -a port_forward_lines=()
@@ -850,7 +856,7 @@ dashboard_verify() (
 
   for _ in {1..20}; do
     kill -0 "${verify_pid}" 2>/dev/null || port_forward_stopped
-    if response="$(curl --silent --show-error --max-time 3 --netrc-file "${verify_tmp}/netrc" --write-out $'\n%{http_code}' "http://127.0.0.1:${port}/api/dashboards/uid/sugarkube-staging-observability" 2>"${verify_tmp}/curl.log")"; then
+    if response="$(curl --silent --show-error --max-time 3 --netrc-file "${verify_tmp}/netrc" --write-out $'\n%{http_code}' "http://127.0.0.1:${port}/api/dashboards/uid/${DASHBOARD_UID}" 2>"${verify_tmp}/curl.log")"; then
       http_status="${response##*$'\n'}"; body="${response%$'\n'*}"
       case "${http_status}" in
         401|403) echo "ERROR: Grafana authentication was rejected (credentials and response redacted)." >&2; return 14 ;;
@@ -864,9 +870,9 @@ try:
 except (json.JSONDecodeError, UnicodeError):
     raise SystemExit("ERROR: Grafana dashboard API returned malformed JSON (response redacted).")
 dashboard = result.get("dashboard") if isinstance(result, dict) else None
-if not isinstance(dashboard, dict) or dashboard.get("uid") != "sugarkube-staging-observability" or dashboard.get("title") != "Sugarkube Staging Observability":
-    raise SystemExit("ERROR: Grafana did not return the expected provisioned dashboard (response redacted).")' <<<"${body}"
-      echo "Grafana API confirmed dashboard UID sugarkube-staging-observability (credentials and response redacted)."
+if not isinstance(dashboard, dict) or dashboard.get("uid") != sys.argv[1] or dashboard.get("title") != sys.argv[2]:
+    raise SystemExit("ERROR: Grafana did not return the expected provisioned dashboard (response redacted).")' "${DASHBOARD_UID}" "${DASHBOARD_TITLE}" <<<"${body}"
+      echo "Grafana API confirmed dashboard UID ${DASHBOARD_UID} (credentials and response redacted)."
       return 0
     fi
     sleep 1
@@ -878,11 +884,11 @@ if not isinstance(dashboard, dict) or dashboard.get("uid") != "sugarkube-staging
 cmd="${1:-}"; shift || true; [[ -n "${cmd}" ]] || { usage; exit 2; }
 env_arg="${1:-}"; resolve_environment "${env_arg}"
 if [[ "${OBSERVABILITY_XTRACE_WAS_ENABLED}" == 1 && "${cmd}" != grafana-secret-install && "${cmd}" != grafana-secret-check ]]; then set -x; fi
-if [[ "${ENVIRONMENT}" == staging && "${cmd}" != grafana-secret-install && "${cmd}" != grafana-secret-check ]]; then
+if [[ "${cmd}" != grafana-secret-install && "${cmd}" != grafana-secret-check ]]; then
   validate_dashboard
 fi
 if [[ "${cmd}" == watchdog-drill-create ]]; then
   trap 'exit 130' INT
   trap 'exit 143' TERM
 fi
-case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) require_staging "dashboard-verify"; dashboard_verify ;; pagerduty-test) require_staging "pagerduty-test"; pagerduty_test "${2:-${1:-}}" ;; grafana-secret-install) grafana_secret_install "${@:2}" ;; grafana-secret-check) grafana_secret_check "${@:2}" ;; watchdog-secret-install) require_staging "watchdog-secret-install"; watchdog_secret_install "${@:2}" ;; watchdog-secret-check) require_staging "watchdog-secret-check"; watchdog_secret_check ;; watchdog-verify) require_staging "watchdog-verify"; watchdog_live_check ;; watchdog-drill-create) require_staging "watchdog-drill-create"; watchdog_silence_create ;; watchdog-drill-status) require_staging "watchdog-drill-status"; watchdog_silence_list ;; watchdog-drill-clear) require_staging "watchdog-drill-clear"; watchdog_silence_clear ;; *) usage; exit 2 ;; esac
+case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) dashboard_verify ;; pagerduty-test) require_staging "pagerduty-test"; pagerduty_test "${2:-${1:-}}" ;; grafana-secret-install) grafana_secret_install "${@:2}" ;; grafana-secret-check) grafana_secret_check "${@:2}" ;; watchdog-secret-install) require_staging "watchdog-secret-install"; watchdog_secret_install "${@:2}" ;; watchdog-secret-check) require_staging "watchdog-secret-check"; watchdog_secret_check ;; watchdog-verify) require_staging "watchdog-verify"; watchdog_live_check ;; watchdog-drill-create) require_staging "watchdog-drill-create"; watchdog_silence_create ;; watchdog-drill-status) require_staging "watchdog-drill-status"; watchdog_silence_list ;; watchdog-drill-clear) require_staging "watchdog-drill-clear"; watchdog_silence_clear ;; *) usage; exit 2 ;; esac

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail-closed validation for the staging Grafana dashboard and Helm render."""
+"""Fail-closed validation for the staging and production Grafana dashboards."""
 
 import argparse
 import json
@@ -775,6 +775,184 @@ def validate_dashboard(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+PROD_UID = "sugarkube-prod-observability"
+PROD_TITLE = "Sugarkube Production Observability"
+PROD_ROWS = {
+    "Cluster health",
+    "Workload health",
+    "Node and Prometheus capacity",
+    "Observability build identity",
+}
+PROD_QUERIES = {
+    "Scrape availability by job": [("min by (job) (up)", "{{job}}")],
+    "Ready nodes": [
+        (
+            'sum(max by (node) (kube_node_status_condition{condition="Ready",status="true"}))',
+            "Ready nodes",
+        )
+    ],
+    "Node readiness": [
+        ('max by (node) (kube_node_status_condition{condition="Ready",status="true"})', "{{node}}")
+    ],
+    "Deployment replica deficit": [
+        (
+            "clamp_min(max by (namespace, deployment) (kube_deployment_spec_replicas) - max by (namespace, deployment) (kube_deployment_status_replicas_available), 0)",
+            "{{namespace}} / {{deployment}}",
+        )
+    ],
+    "Unready pods by namespace": [
+        (
+            'sum by (namespace) (max by (namespace, pod) (kube_pod_status_ready{condition="false"}))',
+            "{{namespace}}",
+        )
+    ],
+    "Problem pods by namespace": [
+        (
+            'sum by (namespace) (max by (namespace, pod, phase) (kube_pod_status_phase{phase=~"Pending|Failed|Unknown"}))',
+            "{{namespace}}",
+        )
+    ],
+    "Container restart rate": [
+        (
+            "sum by (namespace, pod) (max by (namespace, pod, container) (rate(kube_pod_container_status_restarts_total[$__rate_interval])))",
+            "{{namespace}} / {{pod}}",
+        )
+    ],
+    "Node CPU utilization": [
+        (
+            'max by (nodename) (100 * (1 - avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[$__rate_interval]))) * on (instance) group_left (nodename) node_uname_info)',
+            "{{nodename}}",
+        )
+    ],
+    "Node memory utilization": [
+        (
+            "max by (nodename) (100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * on (instance) group_left (nodename) node_uname_info)",
+            "{{nodename}}",
+        )
+    ],
+    "Root filesystem utilization": [
+        (
+            'max by (nodename) (100 * (1 - node_filesystem_avail_bytes{mountpoint="/",fstype!~"tmpfs|overlay"} / node_filesystem_size_bytes{mountpoint="/",fstype!~"tmpfs|overlay"}) * on (instance) group_left (nodename) node_uname_info)',
+            "{{nodename}}",
+        )
+    ],
+    "Prometheus PVC utilization": [
+        (
+            '100 * (1 - max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_available_bytes{namespace="monitoring",persistentvolumeclaim=~"prometheus-kube-prometheus-stack-prometheus-db-.*"}) / max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace="monitoring",persistentvolumeclaim=~"prometheus-kube-prometheus-stack-prometheus-db-.*"}))',
+            "{{persistentvolumeclaim}}",
+        )
+    ],
+    "Prometheus active series": [("max by (pod) (prometheus_tsdb_head_series)", "{{pod}}")],
+    "Observability component build identity": [
+        (
+            "max by (pod, version, revision) (prometheus_build_info)",
+            "Prometheus {{pod}} {{version}} {{revision}}",
+        ),
+        (
+            "max by (pod, version, revision) (alertmanager_build_info)",
+            "Alertmanager {{pod}} {{version}} {{revision}}",
+        ),
+        (
+            "max by (pod, version, revision) (grafana_build_info)",
+            "Grafana {{pod}} {{version}} {{revision}}",
+        ),
+        (
+            "max by (pod, version, revision) (node_exporter_build_info)",
+            "node-exporter {{pod}} {{version}} {{revision}}",
+        ),
+    ],
+}
+
+
+def validate_production_dashboard(path: Path) -> str:
+    dashboard = load_dashboard(path)
+    if (dashboard.get("uid"), dashboard.get("title")) != (PROD_UID, PROD_TITLE):
+        raise SystemExit("ERROR: incorrect production dashboard UID or title.")
+    if dashboard.get("refresh") != "30s" or dashboard.get("time") != {
+        "from": "now-6h",
+        "to": "now",
+    }:
+        raise SystemExit("ERROR: incorrect production refresh or time range.")
+    if dashboard.get("templating", {}).get("list") != []:
+        raise SystemExit("ERROR: production dashboard must not define template variables.")
+    items = list(panels(dashboard))
+    rows = [p.get("title") for p in items if p.get("type") == "row"]
+    if set(rows) != PROD_ROWS or len(rows) != len(PROD_ROWS):
+        raise SystemExit("ERROR: production rows must each appear exactly once.")
+    ids = [p.get("id") for p in items]
+    if any(not isinstance(i, int) for i in ids) or len(ids) != len(set(ids)):
+        raise SystemExit("ERROR: dashboard panel IDs must be present, integer, and unique.")
+    rectangles = []
+    for item in items:
+        pos = item.get("gridPos", {})
+        if (
+            any(not isinstance(pos.get(k), int) for k in ("x", "y", "w", "h"))
+            or pos.get("w", 0) <= 0
+            or pos.get("h", 0) <= 0
+            or pos.get("x", -1) < 0
+            or pos.get("y", -1) < 0
+            or pos["x"] + pos["w"] > 24
+        ):
+            raise SystemExit("ERROR: dashboard panels must have valid integer grid positions.")
+        if item.get("type") != "row":
+            rect = (pos["x"], pos["y"], pos["x"] + pos["w"], pos["y"] + pos["h"])
+            if any(
+                rect[0] < other[2]
+                and rect[2] > other[0]
+                and rect[1] < other[3]
+                and rect[3] > other[1]
+                for other in rectangles
+            ):
+                raise SystemExit("ERROR: dashboard panel grid positions must not overlap.")
+            rectangles.append(rect)
+    for title, expected in PROD_QUERIES.items():
+        panel = panel_named(dashboard, title)
+        actual = [
+            (re.sub(r"\s+", " ", t.get("expr", "")).strip(), t.get("legendFormat"))
+            for t in panel.get("targets", [])
+        ]
+        if actual != expected:
+            raise SystemExit(f"ERROR: {title} does not match the live-backed query contract.")
+        if panel.get("datasource") != {"type": "prometheus", "uid": DATASOURCE_UID}:
+            raise SystemExit(f"ERROR: {title} must use the Prometheus datasource UID.")
+        if panel.get("fieldConfig", {}).get("defaults", {}).get("noValue") != "NO DATA":
+            raise SystemExit(f"ERROR: {title} must preserve NO DATA.")
+    percent_titles = {
+        "Node CPU utilization",
+        "Node memory utilization",
+        "Root filesystem utilization",
+        "Prometheus PVC utilization",
+    }
+    for title in percent_titles:
+        defaults = panel_named(dashboard, title)["fieldConfig"]["defaults"]
+        if (defaults.get("unit"), defaults.get("min"), defaults.get("max")) != ("percent", 0, 100):
+            raise SystemExit("ERROR: production percent panels require a 0-100 percent scale.")
+    serialized = json.dumps(dashboard)
+    expressions = "\n".join(t[0] for values in PROD_QUERIES.values() for t in values)
+    if (
+        "vector(0)" in expressions
+        or "kube_state_metrics_build_info" in serialized
+        or re.search(r"cluster\s*(?:=|=~)", expressions)
+    ):
+        raise SystemExit(
+            "ERROR: production queries contain an unverified or missing-data substitution signal."
+        )
+    forbidden = {
+        "instance",
+        "ip",
+        "url",
+        "endpoint",
+        "device",
+        "system_uuid",
+        "provider_id",
+        "pod_cidr",
+    }
+    legends = " ".join(t[1] for values in PROD_QUERIES.values() for t in values)
+    if any(f"{{{{{label}}}}}" in legends for label in forbidden):
+        raise SystemExit("ERROR: production legends expose a forbidden raw label.")
+    return path.read_text(encoding="utf-8")
+
+
 def validate_render(path: Path, dashboard_json: str) -> None:
     try:
         rendered = path.read_text(encoding="utf-8")
@@ -890,14 +1068,34 @@ def validate_render(path: Path, dashboard_json: str) -> None:
         raise SystemExit("ERROR: rendered dashboard differs from the version-controlled source.")
 
 
+def validate_production_render(path: Path, dashboard_json: str) -> None:
+    """Reuse the exact provisioning checks with the production identity."""
+    global TITLE, UID, DASHBOARD_FILE, DASHBOARD_MOUNT
+    old = (TITLE, UID, DASHBOARD_FILE, DASHBOARD_MOUNT)
+    try:
+        TITLE, UID = PROD_TITLE, PROD_UID
+        DASHBOARD_FILE = f"{UID}.json"
+        DASHBOARD_MOUNT = f"{DASHBOARD_PATH}/{DASHBOARD_FILE}"
+        validate_render(path, dashboard_json)
+    finally:
+        TITLE, UID, DASHBOARD_FILE, DASHBOARD_MOUNT = old
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("dashboard", type=Path)
     parser.add_argument("--rendered", type=Path)
     args = parser.parse_args()
-    dashboard_json = validate_dashboard(args.dashboard)
+    production = args.dashboard.name == f"{PROD_UID}.json"
+    dashboard_json = (
+        validate_production_dashboard(args.dashboard)
+        if production
+        else validate_dashboard(args.dashboard)
+    )
     if args.rendered:
-        validate_render(args.rendered, dashboard_json)
+        (validate_production_render if production else validate_render)(
+            args.rendered, dashboard_json
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -1101,10 +1102,9 @@ def test_validator_directly_rejects_missing_or_empty_render(tmp_path):
 def test_lifecycle_passes_same_dashboard_to_all_helm_paths():
     script = SCRIPT.read_text(encoding="utf-8")
     assert script.count('--set-file "${DASHBOARD_VALUE}=${DASHBOARD}"') == 3
-    assert (
-        'DASHBOARD_VALUE="grafana.dashboards.sugarkube.sugarkube-staging-observability.json"'
-        in script
-    )
+    assert 'DASHBOARD_VALUE="grafana.dashboards.sugarkube.${DASHBOARD_UID}.json"' in script
+    assert 'DASHBOARD_UID="sugarkube-staging-observability"' in script
+    assert 'DASHBOARD_UID="sugarkube-prod-observability"' in script
     assert script.index(
         "validate_dashboard; require_tools", script.index("install_release")
     ) < script.index("helm install")
@@ -1118,7 +1118,7 @@ def test_dashboard_verifier_is_guarded_read_only_and_redacted():
     body = script.split("dashboard_verify()", 1)[1].split('\ncmd="${1:-}"', 1)[0]
     assert "assert_context" in body
     assert body.index("assert_context") < body.index("get secret grafana-admin-credentials")
-    assert "/api/dashboards/uid/sugarkube-staging-observability" in body
+    assert "/api/dashboards/uid/${DASHBOARD_UID}" in body
     assert "--netrc-file" in body and "chmod 600" in body and "rm -rf" in body
     for mutation in ("helm install", "helm upgrade", "kubectl apply", "kubectl delete"):
         assert mutation not in body
@@ -1151,3 +1151,72 @@ def test_malformed_source_fails_before_any_stubbed_cluster_or_helm_access(tmp_pa
     )
     assert result.returncode != 0
     assert "dashboard JSON" in result.stderr
+
+
+PROD_DASHBOARD = ROOT / "clusters/prod/observability/dashboards/sugarkube-prod-observability.json"
+
+
+@pytest.fixture
+def production_dashboard():
+    return json.loads(PROD_DASHBOARD.read_text(encoding="utf-8"))
+
+
+def test_production_dashboard_profile_is_live_backed_and_exact(production_dashboard):
+    validator.validate_production_dashboard(PROD_DASHBOARD)
+    items = list(all_panels(production_dashboard))
+    assert production_dashboard["uid"] == validator.PROD_UID
+    assert production_dashboard["title"] == validator.PROD_TITLE
+    assert production_dashboard["templating"]["list"] == []
+    assert {p["title"] for p in items if p["type"] == "row"} == validator.PROD_ROWS
+    assert {p["title"] for p in items if p["type"] != "row"} == set(validator.PROD_QUERIES)
+    expressions = "\n".join(
+        target["expr"] for panel in items for target in panel.get("targets", [])
+    )
+    expected_metrics = {
+        "up",
+        "kube_node_status_condition",
+        "kube_deployment_spec_replicas",
+        "kube_deployment_status_replicas_available",
+        "kube_pod_status_ready",
+        "kube_pod_status_phase",
+        "kube_pod_container_status_restarts_total",
+        "node_cpu_seconds_total",
+        "node_uname_info",
+        "node_memory_MemAvailable_bytes",
+        "node_memory_MemTotal_bytes",
+        "node_filesystem_avail_bytes",
+        "node_filesystem_size_bytes",
+        "kubelet_volume_stats_available_bytes",
+        "kubelet_volume_stats_capacity_bytes",
+        "prometheus_tsdb_head_series",
+        "prometheus_build_info",
+        "alertmanager_build_info",
+        "grafana_build_info",
+        "node_exporter_build_info",
+    }
+    assert set(re.findall(r"\b[a-zA-Z_:][a-zA-Z0-9_:]*", expressions)) >= expected_metrics
+    assert "cluster=" not in expressions and "vector(0)" not in expressions
+    assert "kube_state_metrics_build_info" not in expressions
+
+
+@pytest.mark.parametrize(
+    ("title", "replacement"),
+    [
+        ("Container restart rate", "[5m]"),
+        ("Prometheus active series", "sum(prometheus_tsdb_head_series)"),
+        (
+            "Prometheus PVC utilization",
+            "kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes",
+        ),
+        ("Node memory utilization", 'node_memory_MemTotal_bytes{cluster="sugarkube-prod"}'),
+    ],
+)
+def test_production_validator_rejects_unsafe_promql(
+    production_dashboard, tmp_path, title, replacement
+):
+    panel = next(p for p in all_panels(production_dashboard) if p["title"] == title)
+    panel["targets"][0]["expr"] = replacement
+    changed = tmp_path / validator.DASHBOARD_FILE
+    changed.write_text(json.dumps(production_dashboard), encoding="utf-8")
+    with pytest.raises(SystemExit, match="live-backed query contract"):
+        validator.validate_production_dashboard(changed)

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -154,20 +154,30 @@ def test_production_values_have_exact_safe_overrides_without_public_exposure_or_
     prod = yaml_load(PROD)
     assert prod == {
         "defaultRules": {"disabled": {"Watchdog": True}},
-        "prometheus": {
-            "prometheusSpec": {"externalLabels": {"cluster": "sugarkube-prod"}}
-        },
+        "prometheus": {"prometheusSpec": {"externalLabels": {"cluster": "sugarkube-prod"}}},
         "alertmanager": {
             "alertmanagerSpec": {"secrets": []},
             "config": {
-                "global": None, "inhibit_rules": None, "templates": None,
-                "route": {"group_by": None, "group_wait": None, "group_interval": None,
-                          "repeat_interval": None, "receiver": "null", "routes": None},
+                "global": None,
+                "inhibit_rules": None,
+                "templates": None,
+                "route": {
+                    "group_by": None,
+                    "group_wait": None,
+                    "group_interval": None,
+                    "repeat_interval": None,
+                    "receiver": "null",
+                    "routes": None,
+                },
                 "receivers": [{"name": "null"}],
             },
         },
     }
-    text = COMMON.read_text(encoding="utf-8") + STAGING.read_text(encoding="utf-8") + PROD.read_text(encoding="utf-8")
+    text = (
+        COMMON.read_text(encoding="utf-8")
+        + STAGING.read_text(encoding="utf-8")
+        + PROD.read_text(encoding="utf-8")
+    )
     forbidden = [
         "longhorn",
         "cloudflare",
@@ -451,7 +461,10 @@ def test_discovery_contract_uses_release_label():
 def test_lifecycle_uses_pinned_version_ordered_values_and_no_reuse_values():
     script = SCRIPT.read_text(encoding="utf-8")
     assert 'CHART="prometheus-community/kube-prometheus-stack"' in script
-    assert 'PROD_VALUES="${ROOT}/clusters/prod/observability/kube-prometheus-stack.values.yaml"' in script
+    assert (
+        'PROD_VALUES="${ROOT}/clusters/prod/observability/kube-prometheus-stack.values.yaml"'
+        in script
+    )
     assert '-f "${COMMON_VALUES}" -f "${ENV_VALUES}"' in script
     assert "--reuse-values" not in script
     assert "--atomic" in script
@@ -635,8 +648,7 @@ def test_justfile_exposes_observability_recipes():
 def test_justfile_normalizes_repeated_env_prefixes_before_staging_metrics_checks():
     text = JUSTFILE.read_text(encoding="utf-8")
     normalization = (
-        'while [ "${env_name#env=}" != "${env_name}" ]; '
-        'do env_name="${env_name#env=}"; done'
+        'while [ "${env_name#env=}" != "${env_name}" ]; ' 'do env_name="${env_name#env=}"; done'
     )
     for recipe in ("observability-install", "observability-upgrade", "observability-verify"):
         recipe_block = text.split(f"{recipe} env='':", 1)[1].split("\n\n", 1)[0]
@@ -996,9 +1008,7 @@ def test_grafana_secret_install_is_exact_redacted_and_rotatable(tmp_path):
         assert forbidden not in audit.lower()
     assert {path.name for path in tmp_path.iterdir()} - before == {"bin", "audit", "tmp"}
     assert list((tmp_path / "tmp").iterdir()) == []
-    repeated, repeated_audit, repeated_credentials = run_grafana_secret_helper(
-        tmp_path / "repeat"
-    )
+    repeated, repeated_audit, repeated_credentials = run_grafana_secret_helper(tmp_path / "repeat")
     assert repeated.returncode == 0, repeated.stderr
     assert repeated_audit.splitlines() == expected_mutations
     assert repeated_credentials == ("operator", "correct horse battery staple")
@@ -1091,13 +1101,15 @@ case "$*" in
   *"repo add"*|*"repo update"*) exit 0 ;;
   *template*)
     [ "$HELM_MODE" != render-fail ] || exit 31
+    dashboard_uid="sugarkube-${ENV_NAME}-observability"
+    [ "$ENV_NAME" != prod ] || dashboard_uid="sugarkube-prod-observability"
+    printf '%s\n' 'apiVersion: v1' 'kind: ConfigMap' 'metadata:' '  name: kube-prometheus-stack-grafana-dashboards-sugarkube' '  labels:' '    dashboard-provider: sugarkube' 'data:' "  ${dashboard_uid}.json:" '    |-'
+    sed 's/^/      /' "$DASHBOARD"
+    printf '%s\n' '---' 'kind: ConfigMap' 'data:' '  dashboardproviders.yaml: |' '    providers:' '      - name: sugarkube' '        options:' '          path: /var/lib/grafana/dashboards/sugarkube' '---' 'kind: Deployment' 'spec:' '  template:' '    spec:' '      containers:' '        - volumeMounts:' '            - name: dashboards-sugarkube' "              mountPath: /var/lib/grafana/dashboards/sugarkube/${dashboard_uid}.json" "              subPath: ${dashboard_uid}.json"
     if [ "$ENV_NAME" = prod ]; then
-      printf '%s\n' 'apiVersion: monitoring.coreos.com/v1' 'kind: Alertmanager' 'metadata:' '  name: kube-prometheus-stack-alertmanager' 'spec:' '  secrets: []' '---' 'apiVersion: v1' 'kind: Secret' 'metadata:' '  name: alertmanager-kube-prometheus-stack-alertmanager' 'stringData:' '  alertmanager.yaml: |' '    route:' '      receiver: "null"' '    receivers:' '      - name: "null"'
+      printf '%s\n' '---' 'apiVersion: monitoring.coreos.com/v1' 'kind: Alertmanager' 'metadata:' '  name: kube-prometheus-stack-alertmanager' 'spec:' '  secrets: []' '---' 'apiVersion: v1' 'kind: Secret' 'metadata:' '  name: alertmanager-kube-prometheus-stack-alertmanager' 'stringData:' '  alertmanager.yaml: |' '    route:' '      receiver: "null"' '    receivers:' '      - name: "null"'
       exit 0
     fi
-    printf '%s\n' 'apiVersion: v1' 'kind: ConfigMap' 'metadata:' '  name: kube-prometheus-stack-grafana-dashboards-sugarkube' '  labels:' '    dashboard-provider: sugarkube' 'data:' '  sugarkube-staging-observability.json:' '    |-'
-    sed 's/^/      /' "$DASHBOARD"
-    printf '%s\n' '---' 'kind: ConfigMap' 'data:' '  dashboardproviders.yaml: |' '    providers:' '      - name: sugarkube' '        options:' '          path: /var/lib/grafana/dashboards/sugarkube' '---' 'kind: Deployment' 'spec:' '  template:' '    spec:' '      containers:' '        - volumeMounts:' '            - name: dashboards-sugarkube' '              mountPath: /var/lib/grafana/dashboards/sugarkube/sugarkube-staging-observability.json' '              subPath: sugarkube-staging-observability.json'
     printf '%s\n' '---' 'apiVersion: monitoring.coreos.com/v1' 'kind: Alertmanager' 'metadata:' '  name: kube-prometheus-stack-alertmanager' 'spec:' '  secrets:' '    - alertmanager-pagerduty' '    - alertmanager-healthchecks-watchdog'
     printf '%s\n' '---' 'apiVersion: v1' 'kind: Secret' 'metadata:' '  name: alertmanager-kube-prometheus-stack-alertmanager' 'stringData:' '  alertmanager.yaml: |'
     sed 's/^/    /' "$ALERTMANAGER_CONFIG"
@@ -1329,7 +1341,8 @@ printf '%s' "$code"
         "WATCHDOG_SILENCES": str(tmp_path / "watchdog-silences.json"),
         "WATCHDOG_LOG_TEXT": watchdog_log_text,
         "DASHBOARD": str(
-            ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
+            ROOT
+            / f"clusters/{env_name}/observability/dashboards/sugarkube-{env_name}-observability.json"
         ),
     }
     (tmp_path / "watchdog-tty").write_text(watchdog_tty_text or "", encoding="utf-8")
@@ -1909,6 +1922,7 @@ def run_dashboard_verifier(
     mode="success",
     context="sugar-staging",
     forward_line="Forwarding from 127.0.0.1:43127 -> 3000",
+    env_name="staging",
 ):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(parents=True)
@@ -1919,7 +1933,7 @@ def run_dashboard_verifier(
 echo "kubectl $*" >> "$AUDIT"
 case "$*" in
   "config current-context") echo "$CONTEXT" ;;
-  *"get nodes -o json"*) echo '{"items":[{"metadata":{"name":"n1","labels":{"sugarkube.env":"staging","sugarkube.cluster":"sugar-staging"}}}]}' ;;
+  *"get nodes -o json"*) printf '{"items":[{"metadata":{"name":"n1","labels":{"sugarkube.env":"%s","sugarkube.cluster":"%s"}}}]}' "$ENV_NAME" "$CONTEXT" ;;
   *"get secret grafana-admin-credentials"*"admin-user"*)
     [ "$MODE" != forward-exits-after-ready ] || { touch "$READY_SECRET"; /bin/sleep 0.2; }
     [ "$MODE" != secret-missing ] || exit 41
@@ -1959,7 +1973,12 @@ case "$MODE" in
   malformed-api) printf '%s\n%s\n' '{' 200 ;;
   wrong-api) printf '%s\n%s\n' '{"dashboard":{"uid":"wrong","title":"wrong"}}' 200 ;;
   interrupt) exit 143 ;;
-  *) printf '%s\n%s\n' '{"dashboard":{"uid":"sugarkube-staging-observability","title":"Sugarkube Staging Observability"}}' 200 ;;
+  *)
+    if [ "$ENV_NAME" = prod ]; then
+      printf '%s\n%s\n' '{"dashboard":{"uid":"sugarkube-prod-observability","title":"Sugarkube Production Observability"}}' 200
+    else
+      printf '%s\n%s\n' '{"dashboard":{"uid":"sugarkube-staging-observability","title":"Sugarkube Staging Observability"}}' 200
+    fi ;;
 esac
 """,
         encoding="utf-8",
@@ -1973,6 +1992,7 @@ esac
         "AUDIT": str(audit),
         "MODE": mode,
         "CONTEXT": context,
+        "ENV_NAME": env_name,
         "PID_FILE": str(pid_file),
         "FORWARD_PID": str(tmp_path / "port-forward.pid"),
         "FORWARD_LINE": forward_line,
@@ -1981,7 +2001,7 @@ esac
         "KUBECONFIG": str(tmp_path / "kubeconfig"),
     }
     result = subprocess.run(
-        ["bash", str(SCRIPT), "dashboard-verify", "env=staging"],
+        ["bash", str(SCRIPT), "dashboard-verify", f"env={env_name}"],
         env=env,
         capture_output=True,
         text=True,
@@ -2728,7 +2748,7 @@ def test_watchdog_silence_api_failures_do_not_expose_fixture_contents(tmp_path, 
 
 
 def production_alertmanager_fixture(*, secrets="[]", route_extra="", receiver_extra="", inline=""):
-    return f'''---
+    return f"""---
 apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
@@ -2746,7 +2766,7 @@ stringData:
       receiver: "null"{route_extra}
     receivers:
       - name: "null"{receiver_extra}{inline}
-'''
+"""
 
 
 def test_production_offline_render_uses_only_ordered_core_values(tmp_path):
@@ -2754,7 +2774,11 @@ def test_production_offline_render_uses_only_ordered_core_values(tmp_path):
     assert result.returncode == 0, result.stderr
     template = next(line for line in audit.splitlines() if "helm template " in line)
     assert template.index(str(COMMON)) < template.index(str(PROD))
-    for excluded in (str(STAGING), str(DASHBOARD), "sugarkube-observability-rules"):
+    for excluded in (
+        str(STAGING),
+        "sugarkube-staging-observability",
+        "sugarkube-observability-rules",
+    ):
         assert excluded not in template
     assert "kubectl" not in audit
     assert "pagerduty" not in result.stdout.lower()
@@ -2774,8 +2798,12 @@ def test_production_install_identity_and_explicit_kubeconfig_fail_before_helm_mu
     tmp_path, context, mode, extra_env
 ):
     result, audit = run_helper(
-        tmp_path, "install", env_name="prod", context=context,
-        kubectl_mode=mode, extra_env=extra_env,
+        tmp_path,
+        "install",
+        env_name="prod",
+        context=context,
+        kubectl_mode=mode,
+        extra_env=extra_env,
     )
     assert result.returncode != 0
     assert "helm install" not in audit
@@ -2787,13 +2815,18 @@ def test_production_install_release_and_secret_guards(tmp_path):
     )
     assert installed.returncode == 0, installed.stderr
     assert "helm install" in audit and "--atomic" in audit
-    assert "alertmanager-pagerduty" not in audit and "alertmanager-healthchecks-watchdog" not in audit
+    assert (
+        "alertmanager-pagerduty" not in audit and "alertmanager-healthchecks-watchdog" not in audit
+    )
     existing, audit = run_helper(
         tmp_path / "existing", "install", env_name="prod", context="sugar-prod", helm_mode="present"
     )
     assert existing.returncode != 0 and "helm install" not in audit
     missing, audit = run_helper(
-        tmp_path / "secret", "install", env_name="prod", context="sugar-prod",
+        tmp_path / "secret",
+        "install",
+        env_name="prod",
+        context="sugar-prod",
         kubectl_mode="missing-grafana",
     )
     assert missing.returncode != 0 and "helm " not in audit
@@ -2802,13 +2835,24 @@ def test_production_install_release_and_secret_guards(tmp_path):
 def test_production_core_verify_skips_staging_integrations(tmp_path):
     result, audit = run_helper(tmp_path, "verify", env_name="prod", context="sugar-prod")
     assert result.returncode == 0, result.stderr
-    for required in ("rollout status", "get daemonset", "get pvc -o json", "get svc kube-prometheus-stack-grafana", "get secret grafana-admin-credentials"):
+    for required in (
+        "rollout status",
+        "get daemonset",
+        "get pvc -o json",
+        "get svc kube-prometheus-stack-grafana",
+        "get secret grafana-admin-credentials",
+    ):
         assert required in audit
-    for excluded in ("servicemonitor dspace", "alertmanager-pagerduty", "alertmanager-healthchecks-watchdog", " --raw "):
+    for excluded in (
+        "servicemonitor dspace",
+        "alertmanager-pagerduty",
+        "alertmanager-healthchecks-watchdog",
+        " --raw ",
+    ):
         assert excluded not in audit
 
 
-@pytest.mark.parametrize("command", ["dashboard-verify", "pagerduty-test", "watchdog-verify"])
+@pytest.mark.parametrize("command", ["pagerduty-test", "watchdog-verify"])
 def test_staging_only_subcommands_reject_production(tmp_path, command):
     result, audit = run_helper(tmp_path, command, env_name="prod", context="sugar-prod")
     assert result.returncode != 0
@@ -2831,14 +2875,18 @@ def test_production_alertmanager_validator_accepts_null_only_and_rejects_integra
     valid.write_text(production_alertmanager_fixture(), encoding="utf-8")
     accepted = subprocess.run(
         ["ruby", str(ALERTMANAGER_VALIDATOR), "prod", "rendered", str(valid)],
-        capture_output=True, text=True, check=False,
+        capture_output=True,
+        text=True,
+        check=False,
     )
     assert accepted.returncode == 0, accepted.stderr
     invalid = tmp_path / "invalid.yaml"
     invalid.write_text(production_alertmanager_fixture(**mutation), encoding="utf-8")
     rejected = subprocess.run(
         ["ruby", str(ALERTMANAGER_VALIDATOR), "prod", "rendered", str(invalid)],
-        capture_output=True, text=True, check=False,
+        capture_output=True,
+        text=True,
+        check=False,
     )
     assert rejected.returncode == 16
     assert "forbidden-stub" not in rejected.stderr
@@ -2853,10 +2901,24 @@ def test_production_alertmanager_secret_mount_has_production_specific_diagnostic
     )
     result = subprocess.run(
         ["ruby", str(ALERTMANAGER_VALIDATOR), "prod", "rendered", str(manifest)],
-        capture_output=True, text=True, check=False,
+        capture_output=True,
+        text=True,
+        check=False,
     )
     assert result.returncode == 16
     assert "production Alertmanager must mount no integration Secrets" in result.stderr
     assert "two expected" not in result.stderr
     assert "alertmanager-pagerduty" not in result.stderr
     assert "alertmanager-healthchecks-watchdog" not in result.stderr
+
+
+def test_production_dashboard_api_verification_is_read_only_and_redacted(tmp_path):
+    result, audit, _ = run_dashboard_verifier(tmp_path, env_name="prod", context="sugar-prod")
+    assert result.returncode == 0, result.stderr
+    assert "/api/dashboards/uid/sugarkube-prod-observability" in audit
+    assert "Grafana API confirmed dashboard UID sugarkube-prod-observability" in result.stdout
+    assert "Sugarkube Production Observability" not in result.stdout + result.stderr
+    assert all(
+        command not in audit
+        for command in ("helm install", "helm upgrade", "kubectl apply", "kubectl delete")
+    )


### PR DESCRIPTION
### Motivation

- Provide the first live-backed production Grafana dashboard that mirrors the verified production Prometheus signals and recovers after Grafana pod recreation while preserving existing staging behavior; this is the dashboard follow-up to #2529 and #2532.

### Description

- Add `clusters/prod/observability/dashboards/sugarkube-prod-observability.json` with UID `sugarkube-prod-observability`, title `Sugarkube Production Observability`, Prometheus datasource UID `prometheus`, default range `now-6h`, refresh `30s`, four required rows, unique panel IDs, non-overlapping grid positions, explicit `NO DATA` handling, percent scales and safe legend/grouping as specified by the production contract.
- Generalize `scripts/observability_helm.sh` to resolve dashboard path, `--set-file` key, UID, title, and LAN URL per environment while preserving the existing staging dashboard and DSPACE overlay behavior; ensure prod render/install/upgrade provisions only the production dashboard and that `dashboard-verify` can target `env=prod` without printing credentials.
- Extend `scripts/validate_observability_dashboard.py` with a fail-closed production profile that enforces UID/title/datasource/refresh/time, required rows and exact live-backed PromQL queries, missing-data semantics, percent scaling, forbidden raw labels and signals (e.g., `kube_state_metrics_build_info`), and layout/ID uniqueness; add render-time production checks that validate the Helm templated ConfigMap block matches the version-controlled JSON exactly.
- Add deterministic regression tests: `tests/test_observability_dashboard.py` (production profile checks, PromQL contract, metric inventory and missing-data semantics) and `tests/test_observability_helm.py` (environment routing, offline render/install/upgrade guards, dashboard API verification stubs); update a small portion of test scaffolding to make verifier tests environment-aware.
- Document the production dashboard and post-merge operator procedure in `docs/observability-operations.md`, including the 2026-08-08 live evidence summary and the reason local queries must not use Prometheus external `cluster` labels.

### Testing

- `python3 scripts/validate_observability_dashboard.py clusters/prod/observability/dashboards/sugarkube-prod-observability.json` — passed.
- `pytest -q tests/test_observability_dashboard.py` — passed (new production tests included).
- `pytest -q tests/test_observability_dashboard.py tests/test_observability_helm.py` — passed (deterministic Helm/kubectl stubs exercised; full lifecycle and dashboard-verifier tests passed in CI-like test harness).
- `bash -n scripts/observability_helm.sh` — passed syntax check.
- `just --unstable --fmt --check` and `black` formatting invoked on touched files — passed for the changed files in this PR.
- `linkchecker --no-warnings README.md docs/` — ran and reported no errors for checked URLs; `pyspelling` was unable to run due to missing `aspell` in this environment.

Notes and follow-ups

- `shellcheck` and `pre-commit` were not available in the execution environment, so `shellcheck` checks were not run here; repository `scripts/checks.sh` was used where appropriate and the tests exercised the expected behavior under deterministic stubs.
- Helm render/install/upgrade in real clusters must still be executed by an operator: after merge run the documented post-merge procedure (explicit `KUBECONFIG` to `sugar-prod`, keep the loopback tunnel, run `just observability-upgrade env=prod`, then `just observability-verify` and `just observability-dashboard-verify`, delete only the Grafana pod and re-run verification, and visually inspect at the LAN URL).
- This change respects scope limits: only allowed files were added/modified and staging dashboard content/behavior was preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77c2502224832fa634a7b16ccb2416)