### PR TITLE
feat(observability): add Sugarkube Production Observability Grafana dashboard (follow-up to #2529 & #2532)

### DIFF
--- a/clusters/prod/observability/dashboards/sugarkube-prod-observability.json
+++ b/clusters/prod/observability/dashboards/sugarkube-prod-observability.json
@@ -1,0 +1,598 @@
+{
+  "id": null,
+  "uid": "sugarkube-prod-observability",
+  "title": "Sugarkube Production Observability",
+  "tags": [
+    "sugarkube",
+    "production",
+    "provisioned"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 41,
+  "version": 1,
+  "editable": false,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Cluster health",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "title": "Scrape availability by job",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 1,
+        "w": 8,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "One is healthy, zero is unhealthy, and absent samples remain NO DATA.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "min by (job) (up)",
+          "legendFormat": "{{job}}",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Ready nodes",
+      "type": "stat",
+      "gridPos": {
+        "x": 8,
+        "y": 1,
+        "w": 8,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Three Ready nodes is the observed visual expectation, not an alert threshold.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(max by (node) (kube_node_status_condition{condition=\"Ready\",status=\"true\"}))",
+          "legendFormat": "Ready nodes",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Node readiness",
+      "type": "stat",
+      "gridPos": {
+        "x": 16,
+        "y": 1,
+        "w": 8,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "One is Ready, zero is not Ready, and absence remains NO DATA.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (node) (kube_node_status_condition{condition=\"Ready\",status=\"true\"})",
+          "legendFormat": "{{node}}",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Workload health",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 7,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 6,
+      "title": "Deployment replica deficit",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "clamp_min(max by (namespace, deployment) (kube_deployment_spec_replicas) - max by (namespace, deployment) (kube_deployment_status_replicas_available), 0)",
+          "legendFormat": "{{namespace}} / {{deployment}}",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Unready pods by namespace",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 8,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (namespace) (max by (namespace, pod) (kube_pod_status_ready{condition=\"false\"}))",
+          "legendFormat": "{{namespace}}",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Problem pods by namespace",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (namespace) (max by (namespace, pod, phase) (kube_pod_status_phase{phase=~\"Pending|Failed|Unknown\"}))",
+          "legendFormat": "{{namespace}}",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "title": "Container restart rate",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (namespace, pod) (max by (namespace, pod, container) (rate(kube_pod_container_status_restarts_total[$__rate_interval])))",
+          "legendFormat": "{{namespace}} / {{pod}}",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "title": "Node and Prometheus capacity",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 11,
+      "title": "Node CPU utilization",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 25,
+        "w": 8,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "noValue": "NO DATA",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (nodename) (100 * (1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]))) * on (instance) group_left (nodename) node_uname_info)",
+          "legendFormat": "{{nodename}}",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "title": "Node memory utilization",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 8,
+        "y": 25,
+        "w": 8,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "noValue": "NO DATA",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (nodename) (100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * on (instance) group_left (nodename) node_uname_info)",
+          "legendFormat": "{{nodename}}",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "title": "Root filesystem utilization",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 16,
+        "y": 25,
+        "w": 8,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "noValue": "NO DATA",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (nodename) (100 * (1 - node_filesystem_avail_bytes{mountpoint=\"/\",fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{mountpoint=\"/\",fstype!~\"tmpfs|overlay\"}) * on (instance) group_left (nodename) node_uname_info)",
+          "legendFormat": "{{nodename}}",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "title": "Prometheus PVC utilization",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 33,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "noValue": "NO DATA",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * (1 - max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_available_bytes{namespace=\"monitoring\",persistentvolumeclaim=~\"prometheus-kube-prometheus-stack-prometheus-db-.*\"}) / max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=\"monitoring\",persistentvolumeclaim=~\"prometheus-kube-prometheus-stack-prometheus-db-.*\"}))",
+          "legendFormat": "{{persistentvolumeclaim}}",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "title": "Prometheus active series",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 33,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (pod) (prometheus_tsdb_head_series)",
+          "legendFormat": "{{pod}}",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "title": "Observability build identity",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 41,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 17,
+      "title": "Observability component build identity",
+      "type": "table",
+      "gridPos": {
+        "x": 0,
+        "y": 42,
+        "w": 24,
+        "h": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Per-pod build identity; missing component samples remain NO DATA.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (pod, version, revision) (prometheus_build_info)",
+          "legendFormat": "Prometheus {{pod}} {{version}} {{revision}}",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (pod, version, revision) (alertmanager_build_info)",
+          "legendFormat": "Alertmanager {{pod}} {{version}} {{revision}}",
+          "refId": "B",
+          "instant": false,
+          "range": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (pod, version, revision) (grafana_build_info)",
+          "legendFormat": "Grafana {{pod}} {{version}} {{revision}}",
+          "refId": "C",
+          "instant": false,
+          "range": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (pod, version, revision) (node_exporter_build_info)",
+          "legendFormat": "node-exporter {{pod}} {{version}} {{revision}}",
+          "refId": "D",
+          "instant": false,
+          "range": true
+        }
+      ]
+    }
+  ]
+}

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -3,7 +3,7 @@
 This runbook covers the live staging stack and repository support for the production
 core-stack lifecycle. It is intentionally non-Flux: operators use guarded Helm commands
 from this repository, with the chart version and full values chain committed in Git.
-Merging production support is not evidence that the stack or a production dashboard is live.
+The production core stack is installed; merging dashboard code is not evidence that the dashboard has been upgraded or visually proven live.
 
 ## Canonical sources
 
@@ -13,6 +13,7 @@ Merging production support is not evidence that the stack or a production dashbo
 - Production overrides: `clusters/prod/observability/kube-prometheus-stack.values.yaml`.
 - Canonical DSPACE rules: `platform/observability/rules/dspace-release-integrity.yaml`.
 - Staging dashboard: `clusters/staging/observability/dashboards/sugarkube-staging-observability.json`.
+- Production dashboard: `clusters/prod/observability/dashboards/sugarkube-prod-observability.json`.
 - Helper: `scripts/observability_helm.sh` through `just observability-*` recipes.
 - Alert delivery, routing, and drill strategy: [`docs/observability-alerting.md`](observability-alerting.md).
 - DSPACE release-integrity triage and focused drills:
@@ -129,18 +130,89 @@ disabled in this initial declarative phase, so UI-created state is ephemeral;
 provisioned dashboards remain code-owned, and durable UI state is a separate
 follow-up decision.
 
-Neither this correction nor PR #2529 proves a production deployment or a
-custom production dashboard. Both require separate, sanitized live evidence.
+PRs #2529 and #2532 established the production core lifecycle and installation evidence; the provisioned production dashboard still requires the post-merge proof below.
 
 The core baseline is one Prometheus and one Alertmanager replica, seven-day / 15
 GB retention, a 20 Gi RWO `local-path` Prometheus claim, and a null-only
 Alertmanager. Local-path storage is node-local and non-expandable, so capacity
 pressure or node loss needs explicit operator action. After at least one
 production week, review retention, WAL/PVC usage, and memory before changing
-capacity. The custom production dashboard is deferred until live stack metric
-families and labels are inventoried. Application panels and metrics lifecycle,
+capacity. The custom production dashboard below uses the completed live core-metric inventory. Application panels and metrics lifecycle,
 blackbox monitoring, alerts, paging, HA, and persistent Grafana UI state are
 also explicitly deferred.
+
+### Live-backed production dashboard
+
+The **Sugarkube Production Observability** dashboard (UID
+`sugarkube-prod-observability`) is a provisioned, single-cluster view. Its local
+Prometheus queries deliberately have no `cluster="sugarkube-prod"` selector:
+Prometheus `externalLabels` are attached to remote-write/federated data, not to
+samples returned by this Prometheus's local query API. Adding that selector
+would therefore turn verified signals into `NO DATA`.
+
+The panels have these operational meanings and query contracts:
+
+- **Scrape availability by job** takes the minimum `up` value for each job;
+  one is healthy, zero is unhealthy, and an absent job remains `NO DATA`.
+- **Ready nodes** deduplicates the Ready gauge per node and sums it. Three is
+  the observed visual expectation, not an alert threshold. **Node readiness**
+  retains each node so one, zero, and missing data remain distinct.
+- **Deployment replica deficit** independently takes the maximum desired and
+  available KSM gauges by namespace/deployment before subtraction and clamps
+  only negative arithmetic to zero. **Unready pods by namespace** and
+  **Problem pods by namespace** first deduplicate pod (and bounded phase) KSM
+  gauges, then sum by namespace; emitted zero is not replaced or hidden.
+- **Container restart rate** deduplicates each namespace/pod/container series,
+  applies `rate` with Grafana's `$__rate_interval`, and sums by namespace/pod.
+- **Node CPU utilization**, **Node memory utilization**, and **Root filesystem
+  utilization** use the verified `node_uname_info` join only to map exporter
+  instances to the permitted `nodename`; the final grouping and legend expose
+  only node names. Percent displays use a zero-to-100 scale.
+- **Prometheus PVC utilization** independently deduplicates available bytes and
+  capacity by namespace/PVC before division. **Prometheus active series** uses
+  `max by (pod)` and remains per pod rather than summing future replicas.
+- **Observability component build identity** presents separate per-pod,
+  version, and revision rows for Prometheus, Alertmanager, Grafana, and
+  node-exporter. `kube_state_metrics_build_info` was absent from production and
+  is intentionally neither displayed nor replaced by another signal.
+
+Every panel preserves missing samples as `NO DATA`; no query uses `or
+vector(0)`. Display thresholds, where present, are guidance only and are not
+production alert thresholds.
+
+Read-only evidence captured on 2026-08-08 from repository SHA
+`2984f3fd5b39d391621f414ae01150cf6c0a7a59`, after successful Helm revision 1,
+showed 23/23 healthy targets on two scrapes across nine jobs: apiserver (3),
+coredns (1), Alertmanager (2), Grafana (1), operator (1), Prometheus (2),
+kube-state-metrics (1), kubelet (9), and node-exporter (3). All three nodes were
+Ready. The candidate queries returned CPU utilization of about 2.39–4.04%,
+memory utilization of about 15.00–25.17%, root-filesystem utilization of about
+6.26–6.50%, eleven zero deployment deficits, six zero problem-pod namespace
+results, twenty zero restart-rate results, about 6.50% Prometheus PVC use, and
+about 174,263 active series. No target URLs, instances, addresses, errors, or
+raw identity-label values were retained.
+
+Grafana persistence remains disabled: mutable UI-created state is ephemeral.
+The immutable provisioned dashboard is code-owned and must be restored by the
+Grafana sidecar/provider after pod recreation. After merge, perform this
+production proof without changing any deferred lifecycle:
+
+1. `export KUBECONFIG="$HOME/.kube/config-sugarkube-prod"` and verify the current
+   context is `sugar-prod`.
+2. Keep the externally managed `127.0.0.1:16443` tunnel running.
+3. Run `just observability-render env=prod`, retain the output privately, and inspect it.
+4. Run `just observability-upgrade env=prod`—not install, because Helm revision 1 exists.
+5. Run `just observability-verify env=prod`.
+6. Run `just observability-dashboard-verify env=prod`.
+7. Delete only the Grafana pod, wait for its deployment rollout, then run the
+   dashboard verification again.
+8. Visually inspect every panel at <http://sugarkube0.local:30300> with
+   credentials from the operator’s secure credential manager.
+9. Record the Git SHA, Helm revision, and private operator-evidence path.
+
+Production application metrics, blackbox monitoring, paging and alerts,
+Grafana persistence, HA, and retention/storage changes remain explicitly
+deferred. This dashboard does not create placeholders for them.
 
 ## Read-only preflight and status
 

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -16,8 +16,12 @@ COMMON_VALUES="${ROOT}/platform/observability/helm/kube-prometheus-stack.values.
 STAGING_VALUES="${ROOT}/clusters/staging/observability/kube-prometheus-stack.values.yaml"
 PROD_VALUES="${ROOT}/clusters/prod/observability/kube-prometheus-stack.values.yaml"
 DSPACE_RULES="${ROOT}/platform/observability/rules/dspace-release-integrity.yaml"
-DASHBOARD="${ROOT}/clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
-DASHBOARD_VALUE="grafana.dashboards.sugarkube.sugarkube-staging-observability.json"
+STAGING_DASHBOARD="${ROOT}/clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
+PROD_DASHBOARD="${ROOT}/clusters/prod/observability/dashboards/sugarkube-prod-observability.json"
+DASHBOARD=""
+DASHBOARD_VALUE=""
+DASHBOARD_UID=""
+DASHBOARD_TITLE=""
 DASHBOARD_VALIDATOR="${ROOT}/scripts/validate_observability_dashboard.py"
 TIMEOUT="${SUGARKUBE_OBSERVABILITY_HELM_TIMEOUT:-20m}"
 GRAFANA_URL="http://sugarkube3.local:30300"
@@ -46,9 +50,12 @@ resolve_environment() {
   ENVIRONMENT="$(normalize_env "$1")"
   if [[ "$ENVIRONMENT" == staging ]]; then
     ENV_VALUES="$STAGING_VALUES"; EXPECTED_CONTEXT="sugar-staging"; GRAFANA_URL="http://sugarkube3.local:30300"
+    DASHBOARD="$STAGING_DASHBOARD"; DASHBOARD_UID="sugarkube-staging-observability"; DASHBOARD_TITLE="Sugarkube Staging Observability"
   else
     ENV_VALUES="$PROD_VALUES"; EXPECTED_CONTEXT="sugar-prod"; GRAFANA_URL="http://sugarkube0.local:30300"
+    DASHBOARD="$PROD_DASHBOARD"; DASHBOARD_UID="sugarkube-prod-observability"; DASHBOARD_TITLE="Sugarkube Production Observability"
   fi
+  DASHBOARD_VALUE="grafana.dashboards.sugarkube.${DASHBOARD_UID}.json"
 }
 require_staging() { [[ "$ENVIRONMENT" == staging ]] || { echo "ERROR: $1 is staging-only; production support is deferred." >&2; exit 2; }; }
 require_tools() { for t in "$@"; do command -v "$t" >/dev/null 2>&1 || { echo "ERROR: required tool missing: $t" >&2; exit 127; }; done; }
@@ -67,9 +74,8 @@ ordered values files:
   - ${COMMON_VALUES}
   - ${ENV_VALUES}
 EOT
-  if [[ "$ENVIRONMENT" == staging ]]; then
-    printf '  - generated mode-0600 rules overlay sourced from %s\ndashboard source (--set-file): %s\n' "$DSPACE_RULES" "$DASHBOARD"
-  fi
+  [[ "$ENVIRONMENT" != staging ]] || printf '  - generated mode-0600 rules overlay sourced from %s\n' "$DSPACE_RULES"
+  printf 'dashboard source (--set-file): %s\n' "$DASHBOARD"
   printf 'Grafana LAN URL: %s (same NodePort is available through the other %s nodes)\n' "$GRAFANA_URL" "$ENVIRONMENT"
 }
 assert_context() {
@@ -105,11 +111,11 @@ validate_rendered_alertmanager() { ruby "${ALERTMANAGER_VALIDATOR}" "${ENVIRONME
 render_to() {
   local out="$1"; shift
   local dashboard_args=()
-  [[ "$ENVIRONMENT" != staging ]] || dashboard_args=(--set-file "${DASHBOARD_VALUE}=${DASHBOARD}")
+  dashboard_args=(--set-file "${DASHBOARD_VALUE}=${DASHBOARD}")
   helm repo add prometheus-community https://prometheus-community.github.io/helm-charts --force-update >/dev/null
   helm repo update prometheus-community >/dev/null
   helm template "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${ENV_VALUES}" "$@" "${dashboard_args[@]}" >"${out}"
-  [[ "$ENVIRONMENT" != staging ]] || validate_rendered_dashboard "${out}"
+  validate_rendered_dashboard "${out}"
   validate_rendered_alertmanager "${out}"
 }
 prepare_render_args() {
@@ -251,9 +257,9 @@ release_state() {
     return 1
   fi
 }
-render() { [[ "$ENVIRONMENT" != staging ]] || validate_dashboard; require_tools helm python3 ruby; print_resolved '<not queried: offline render>'; local tmp; tmp="$(mktemp -t sugarkube-observability-render.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}" "${RULES_OVERLAY:-}"' EXIT; prepare_render_args; render_to "$tmp" "${RENDER_ARGS[@]}"; cat "$tmp"; }
-install_release() { [[ "$ENVIRONMENT" != staging ]] || validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved; assert_context; assert_grafana_secret; [[ "$ENVIRONMENT" != staging ]] || assert_integration_secrets; local tmp state dashboard_args=(); tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}" "${RULES_OVERLAY:-}"' EXIT; prepare_render_args; render_to "$tmp" "${RENDER_ARGS[@]}"; state="$(release_state)"; if [[ "$state" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; [[ "$ENVIRONMENT" != staging ]] || dashboard_args=(--set-file "${DASHBOARD_VALUE}=${DASHBOARD}"); helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${ENV_VALUES}" "${RENDER_ARGS[@]}" "${dashboard_args[@]}" --atomic --wait --timeout "${TIMEOUT}"; }
-upgrade_release() { [[ "$ENVIRONMENT" != staging ]] || validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved; assert_context; assert_grafana_secret; [[ "$ENVIRONMENT" != staging ]] || assert_integration_secrets; local tmp state dashboard_args=(); tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}" "${RULES_OVERLAY:-}"' EXIT; prepare_render_args; render_to "$tmp" "${RENDER_ARGS[@]}"; state="$(release_state)"; if [[ "$state" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; [[ "$ENVIRONMENT" != staging ]] || dashboard_args=(--set-file "${DASHBOARD_VALUE}=${DASHBOARD}"); helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${ENV_VALUES}" "${RENDER_ARGS[@]}" "${dashboard_args[@]}" --atomic --wait --timeout "${TIMEOUT}"; }
+render() { validate_dashboard; require_tools helm python3 ruby; print_resolved '<not queried: offline render>'; local tmp; tmp="$(mktemp -t sugarkube-observability-render.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}" "${RULES_OVERLAY:-}"' EXIT; prepare_render_args; render_to "$tmp" "${RENDER_ARGS[@]}"; cat "$tmp"; }
+install_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved; assert_context; assert_grafana_secret; [[ "$ENVIRONMENT" != staging ]] || assert_integration_secrets; local tmp state dashboard_args=(); tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}" "${RULES_OVERLAY:-}"' EXIT; prepare_render_args; render_to "$tmp" "${RENDER_ARGS[@]}"; state="$(release_state)"; if [[ "$state" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; dashboard_args=(--set-file "${DASHBOARD_VALUE}=${DASHBOARD}"); helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${ENV_VALUES}" "${RENDER_ARGS[@]}" "${dashboard_args[@]}" --atomic --wait --timeout "${TIMEOUT}"; }
+upgrade_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved; assert_context; assert_grafana_secret; [[ "$ENVIRONMENT" != staging ]] || assert_integration_secrets; local tmp state dashboard_args=(); tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}" "${RULES_OVERLAY:-}"' EXIT; prepare_render_args; render_to "$tmp" "${RENDER_ARGS[@]}"; state="$(release_state)"; if [[ "$state" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; dashboard_args=(--set-file "${DASHBOARD_VALUE}=${DASHBOARD}"); helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${ENV_VALUES}" "${RENDER_ARGS[@]}" "${dashboard_args[@]}" --atomic --wait --timeout "${TIMEOUT}"; }
 WATCHDOG_TTY="${SUGARKUBE_WATCHDOG_TTY:-/dev/tty}"
 WATCHDOG_API="/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-alertmanager:9093/proxy/api/v2"
 
@@ -782,7 +788,7 @@ json.dump([{
 
 dashboard_verify() (
   require_tools kubectl python3 curl base64 sleep
-  print_resolved staging
+  print_resolved
   assert_context
   local response body http_status port="" remote_port line
   local -a port_forward_lines=()
@@ -850,7 +856,7 @@ dashboard_verify() (
 
   for _ in {1..20}; do
     kill -0 "${verify_pid}" 2>/dev/null || port_forward_stopped
-    if response="$(curl --silent --show-error --max-time 3 --netrc-file "${verify_tmp}/netrc" --write-out $'\n%{http_code}' "http://127.0.0.1:${port}/api/dashboards/uid/sugarkube-staging-observability" 2>"${verify_tmp}/curl.log")"; then
+    if response="$(curl --silent --show-error --max-time 3 --netrc-file "${verify_tmp}/netrc" --write-out $'\n%{http_code}' "http://127.0.0.1:${port}/api/dashboards/uid/${DASHBOARD_UID}" 2>"${verify_tmp}/curl.log")"; then
       http_status="${response##*$'\n'}"; body="${response%$'\n'*}"
       case "${http_status}" in
         401|403) echo "ERROR: Grafana authentication was rejected (credentials and response redacted)." >&2; return 14 ;;
@@ -864,9 +870,9 @@ try:
 except (json.JSONDecodeError, UnicodeError):
     raise SystemExit("ERROR: Grafana dashboard API returned malformed JSON (response redacted).")
 dashboard = result.get("dashboard") if isinstance(result, dict) else None
-if not isinstance(dashboard, dict) or dashboard.get("uid") != "sugarkube-staging-observability" or dashboard.get("title") != "Sugarkube Staging Observability":
-    raise SystemExit("ERROR: Grafana did not return the expected provisioned dashboard (response redacted).")' <<<"${body}"
-      echo "Grafana API confirmed dashboard UID sugarkube-staging-observability (credentials and response redacted)."
+if not isinstance(dashboard, dict) or dashboard.get("uid") != sys.argv[1] or dashboard.get("title") != sys.argv[2]:
+    raise SystemExit("ERROR: Grafana did not return the expected provisioned dashboard (response redacted).")' "${DASHBOARD_UID}" "${DASHBOARD_TITLE}" <<<"${body}"
+      echo "Grafana API confirmed dashboard UID ${DASHBOARD_UID} (credentials and response redacted)."
       return 0
     fi
     sleep 1
@@ -878,11 +884,11 @@ if not isinstance(dashboard, dict) or dashboard.get("uid") != "sugarkube-staging
 cmd="${1:-}"; shift || true; [[ -n "${cmd}" ]] || { usage; exit 2; }
 env_arg="${1:-}"; resolve_environment "${env_arg}"
 if [[ "${OBSERVABILITY_XTRACE_WAS_ENABLED}" == 1 && "${cmd}" != grafana-secret-install && "${cmd}" != grafana-secret-check ]]; then set -x; fi
-if [[ "${ENVIRONMENT}" == staging && "${cmd}" != grafana-secret-install && "${cmd}" != grafana-secret-check ]]; then
+if [[ "${cmd}" != grafana-secret-install && "${cmd}" != grafana-secret-check ]]; then
   validate_dashboard
 fi
 if [[ "${cmd}" == watchdog-drill-create ]]; then
   trap 'exit 130' INT
   trap 'exit 143' TERM
 fi
-case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) require_staging "dashboard-verify"; dashboard_verify ;; pagerduty-test) require_staging "pagerduty-test"; pagerduty_test "${2:-${1:-}}" ;; grafana-secret-install) grafana_secret_install "${@:2}" ;; grafana-secret-check) grafana_secret_check "${@:2}" ;; watchdog-secret-install) require_staging "watchdog-secret-install"; watchdog_secret_install "${@:2}" ;; watchdog-secret-check) require_staging "watchdog-secret-check"; watchdog_secret_check ;; watchdog-verify) require_staging "watchdog-verify"; watchdog_live_check ;; watchdog-drill-create) require_staging "watchdog-drill-create"; watchdog_silence_create ;; watchdog-drill-status) require_staging "watchdog-drill-status"; watchdog_silence_list ;; watchdog-drill-clear) require_staging "watchdog-drill-clear"; watchdog_silence_clear ;; *) usage; exit 2 ;; esac
+case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) dashboard_verify ;; pagerduty-test) require_staging "pagerduty-test"; pagerduty_test "${2:-${1:-}}" ;; grafana-secret-install) grafana_secret_install "${@:2}" ;; grafana-secret-check) grafana_secret_check "${@:2}" ;; watchdog-secret-install) require_staging "watchdog-secret-install"; watchdog_secret_install "${@:2}" ;; watchdog-secret-check) require_staging "watchdog-secret-check"; watchdog_secret_check ;; watchdog-verify) require_staging "watchdog-verify"; watchdog_live_check ;; watchdog-drill-create) require_staging "watchdog-drill-create"; watchdog_silence_create ;; watchdog-drill-status) require_staging "watchdog-drill-status"; watchdog_silence_list ;; watchdog-drill-clear) require_staging "watchdog-drill-clear"; watchdog_silence_clear ;; *) usage; exit 2 ;; esac

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -890,13 +890,158 @@ def validate_render(path: Path, dashboard_json: str) -> None:
         raise SystemExit("ERROR: rendered dashboard differs from the version-controlled source.")
 
 
+PROD_TITLE = "Sugarkube Production Observability"
+PROD_UID = "sugarkube-prod-observability"
+PROD_ROWS = {
+    "Cluster health",
+    "Workload health",
+    "Node and Prometheus capacity",
+    "Observability build identity",
+}
+PROD_QUERIES = {
+    "Scrape availability by job": ["min by (job) (up)"],
+    "Ready nodes": [
+        'sum(max by (node) (kube_node_status_condition{condition="Ready",status="true"}))'
+    ],
+    "Node readiness": [
+        'max by (node) (kube_node_status_condition{condition="Ready",status="true"})'
+    ],
+    "Deployment replica deficit": [
+        "clamp_min(max by (namespace, deployment) (kube_deployment_spec_replicas) - max by (namespace, deployment) (kube_deployment_status_replicas_available), 0)"
+    ],
+    "Unready pods by namespace": [
+        'sum by (namespace) (max by (namespace, pod) (kube_pod_status_ready{condition="false"}))'
+    ],
+    "Problem pods by namespace": [
+        'sum by (namespace) (max by (namespace, pod, phase) (kube_pod_status_phase{phase=~"Pending|Failed|Unknown"}))'
+    ],
+    "Container restart rate": [
+        "sum by (namespace, pod) (max by (namespace, pod, container) (rate(kube_pod_container_status_restarts_total[$__rate_interval])))"
+    ],
+    "Node CPU utilization": [
+        'max by (nodename) (100 * (1 - avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[$__rate_interval]))) * on (instance) group_left (nodename) node_uname_info)'
+    ],
+    "Node memory utilization": [
+        "max by (nodename) (100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * on (instance) group_left (nodename) node_uname_info)"
+    ],
+    "Root filesystem utilization": [
+        'max by (nodename) (100 * (1 - node_filesystem_avail_bytes{mountpoint="/",fstype!~"tmpfs|overlay"} / node_filesystem_size_bytes{mountpoint="/",fstype!~"tmpfs|overlay"}) * on (instance) group_left (nodename) node_uname_info)'
+    ],
+    "Prometheus PVC utilization": [
+        '100 * (1 - max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_available_bytes{namespace="monitoring",persistentvolumeclaim=~"prometheus-kube-prometheus-stack-prometheus-db-.*"}) / max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace="monitoring",persistentvolumeclaim=~"prometheus-kube-prometheus-stack-prometheus-db-.*"}))'
+    ],
+    "Prometheus active series": ["max by (pod) (prometheus_tsdb_head_series)"],
+    "Observability component build identity": [
+        "max by (pod, version, revision) (prometheus_build_info)",
+        "max by (pod, version, revision) (alertmanager_build_info)",
+        "max by (pod, version, revision) (grafana_build_info)",
+        "max by (pod, version, revision) (node_exporter_build_info)",
+    ],
+}
+
+
+def validate_production_dashboard(path: Path) -> str:
+    """Validate the deliberately fixed, live-backed single-cluster profile."""
+    dashboard = load_dashboard(path)
+    if (dashboard.get("uid"), dashboard.get("title")) != (PROD_UID, PROD_TITLE):
+        raise SystemExit("ERROR: production dashboard UID or title is incorrect.")
+    if dashboard.get("refresh") != "30s" or dashboard.get("time") != {
+        "from": "now-6h",
+        "to": "now",
+    }:
+        raise SystemExit("ERROR: production dashboard refresh or time range is incorrect.")
+    if dashboard.get("templating", {}).get("list") != []:
+        raise SystemExit(
+            "ERROR: production dashboard must not have cluster or environment variables."
+        )
+    items = list(panels(dashboard))
+    rows = [item.get("title") for item in items if item.get("type") == "row"]
+    if len(rows) != len(PROD_ROWS) or set(rows) != PROD_ROWS:
+        raise SystemExit("ERROR: production dashboard rows are missing or duplicated.")
+    for title, expected in PROD_QUERIES.items():
+        panel = panel_named(dashboard, title)
+        actual = [
+            re.sub(r"\s+", " ", target.get("expr", "")).strip()
+            for target in panel.get("targets", [])
+        ]
+        if actual != expected:
+            raise SystemExit(
+                f"ERROR: {title} does not use the required live-backed PromQL contract."
+            )
+        if panel.get("fieldConfig", {}).get("defaults", {}).get("noValue") != "NO DATA":
+            raise SystemExit(f"ERROR: {title} must preserve missing data as NO DATA.")
+    ids = [item.get("id") for item in items]
+    if not ids or any(not isinstance(value, int) for value in ids) or len(ids) != len(set(ids)):
+        raise SystemExit("ERROR: dashboard panel IDs must be present, integer, and unique.")
+    occupied = []
+    for item in items:
+        pos = item.get("gridPos", {})
+        if (
+            any(not isinstance(pos.get(k), int) for k in ("x", "y", "w", "h"))
+            or pos.get("w", 0) <= 0
+            or pos.get("h", 0) <= 0
+            or pos.get("x", -1) < 0
+            or pos.get("x", 0) + pos.get("w", 0) > 24
+        ):
+            raise SystemExit("ERROR: dashboard panels must have valid integer grid positions.")
+        if item.get("type") != "row":
+            rect = (pos["x"], pos["y"], pos["x"] + pos["w"], pos["y"] + pos["h"])
+            if any(
+                rect[0] < old[2] and rect[2] > old[0] and rect[1] < old[3] and rect[3] > old[1]
+                for old in occupied
+            ):
+                raise SystemExit("ERROR: dashboard panel grid positions must not overlap.")
+            occupied.append(rect)
+    serialized = json.dumps(dashboard)
+    expressions = "\n".join(query for queries in PROD_QUERIES.values() for query in queries)
+    forbidden = (
+        "or vector(0)",
+        "kube_state_metrics_build_info",
+        'cluster="sugarkube-prod"',
+        "__inputs",
+    )
+    if any(value in serialized for value in forbidden):
+        raise SystemExit(
+            "ERROR: production dashboard contains an unverified selector, signal, or zero substitution."
+        )
+    if re.search(
+        r"{{\s*(?:instance|ip|url|endpoint|device|system_uuid|provider_id|pod_cidr)\s*}}",
+        serialized,
+    ):
+        raise SystemExit(
+            "ERROR: production dashboard legend exposes a forbidden raw identity label."
+        )
+    datasource_refs = [
+        item.get("datasource", {}).get("uid") for item in items if item.get("type") != "row"
+    ]
+    if not datasource_refs or any(uid != DATASOURCE_UID for uid in datasource_refs):
+        raise SystemExit(
+            "ERROR: production dashboard datasource must use Prometheus UID 'prometheus'."
+        )
+    if "[$__rate_interval]" not in expressions or re.search(
+        r"rate\([^)]*\[[0-9]+[smhd]\]", expressions
+    ):
+        raise SystemExit("ERROR: production rate queries must use $__rate_interval.")
+    return path.read_text(encoding="utf-8")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("dashboard", type=Path)
     parser.add_argument("--rendered", type=Path)
     args = parser.parse_args()
-    dashboard_json = validate_dashboard(args.dashboard)
+    is_production = args.dashboard.name == f"{PROD_UID}.json"
+    dashboard_json = (
+        validate_production_dashboard(args.dashboard)
+        if is_production
+        else validate_dashboard(args.dashboard)
+    )
     if args.rendered:
+        if is_production:
+            global TITLE, UID, DASHBOARD_FILE, DASHBOARD_MOUNT
+            TITLE, UID = PROD_TITLE, PROD_UID
+            DASHBOARD_FILE = f"{UID}.json"
+            DASHBOARD_MOUNT = f"{DASHBOARD_PATH}/{DASHBOARD_FILE}"
         validate_render(args.rendered, dashboard_json)
 
 

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -8,6 +8,7 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 DASHBOARD = ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
+PROD_DASHBOARD = ROOT / "clusters/prod/observability/dashboards/sugarkube-prod-observability.json"
 VALIDATOR = ROOT / "scripts/validate_observability_dashboard.py"
 SCRIPT = ROOT / "scripts/observability_helm.sh"
 PROMETHEUS_VALUES = ROOT / "platform/observability/helm/kube-prometheus-stack.values.common.yaml"
@@ -1101,10 +1102,9 @@ def test_validator_directly_rejects_missing_or_empty_render(tmp_path):
 def test_lifecycle_passes_same_dashboard_to_all_helm_paths():
     script = SCRIPT.read_text(encoding="utf-8")
     assert script.count('--set-file "${DASHBOARD_VALUE}=${DASHBOARD}"') == 3
-    assert (
-        'DASHBOARD_VALUE="grafana.dashboards.sugarkube.sugarkube-staging-observability.json"'
-        in script
-    )
+    assert 'DASHBOARD_VALUE="grafana.dashboards.sugarkube.${DASHBOARD_UID}.json"' in script
+    assert str(DASHBOARD.relative_to(ROOT)) in script
+    assert str(PROD_DASHBOARD.relative_to(ROOT)) in script
     assert script.index(
         "validate_dashboard; require_tools", script.index("install_release")
     ) < script.index("helm install")
@@ -1118,7 +1118,7 @@ def test_dashboard_verifier_is_guarded_read_only_and_redacted():
     body = script.split("dashboard_verify()", 1)[1].split('\ncmd="${1:-}"', 1)[0]
     assert "assert_context" in body
     assert body.index("assert_context") < body.index("get secret grafana-admin-credentials")
-    assert "/api/dashboards/uid/sugarkube-staging-observability" in body
+    assert "/api/dashboards/uid/${DASHBOARD_UID}" in body
     assert "--netrc-file" in body and "chmod 600" in body and "rm -rf" in body
     for mutation in ("helm install", "helm upgrade", "kubectl apply", "kubectl delete"):
         assert mutation not in body
@@ -1126,6 +1126,29 @@ def test_dashboard_verifier_is_guarded_read_only_and_redacted():
     assert "--address=127.0.0.1" in body and '"service/${RELEASE}-grafana" :80' in body
     assert body.index("Forwarding\\ from") < body.index("--netrc-file")
     assert "require_tools kubectl python3 curl base64 sleep" in body
+
+
+def test_production_dashboard_profile_is_live_backed_and_fail_closed():
+    document = json.loads(PROD_DASHBOARD.read_text(encoding="utf-8"))
+    assert validator.validate_production_dashboard(PROD_DASHBOARD)
+    assert document["uid"] == "sugarkube-prod-observability"
+    assert document["title"] == "Sugarkube Production Observability"
+    assert document["templating"]["list"] == []
+    assert {p["title"] for p in all_panels(document) if p["type"] == "row"} == validator.PROD_ROWS
+    assert {p["title"] for p in all_panels(document) if p["type"] != "row"} == set(
+        validator.PROD_QUERIES
+    )
+    changed = json.loads(json.dumps(document))
+    next(p for p in all_panels(changed) if p["title"] == "Ready nodes")["targets"][0][
+        "expr"
+    ] += ' + up{cluster="sugarkube-prod"}'
+    path = PROD_DASHBOARD.parent / ".invalid-test.json"
+    try:
+        path.write_text(json.dumps(changed), encoding="utf-8")
+        with pytest.raises(SystemExit, match="PromQL contract"):
+            validator.validate_production_dashboard(path)
+    finally:
+        path.unlink(missing_ok=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -23,6 +23,7 @@ CANONICAL_DSPACE_RULES = (
 SCRIPT = ROOT / "scripts" / "observability_helm.sh"
 ALERTMANAGER_VALIDATOR = ROOT / "scripts" / "verify_observability_alertmanager.rb"
 DASHBOARD = ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
+PROD_DASHBOARD = ROOT / "clusters/prod/observability/dashboards/sugarkube-prod-observability.json"
 JUSTFILE = ROOT / "justfile"
 FLUX_SYNC = ROOT / "flux" / "gotk-sync.yaml"
 LEGACY = [
@@ -154,20 +155,30 @@ def test_production_values_have_exact_safe_overrides_without_public_exposure_or_
     prod = yaml_load(PROD)
     assert prod == {
         "defaultRules": {"disabled": {"Watchdog": True}},
-        "prometheus": {
-            "prometheusSpec": {"externalLabels": {"cluster": "sugarkube-prod"}}
-        },
+        "prometheus": {"prometheusSpec": {"externalLabels": {"cluster": "sugarkube-prod"}}},
         "alertmanager": {
             "alertmanagerSpec": {"secrets": []},
             "config": {
-                "global": None, "inhibit_rules": None, "templates": None,
-                "route": {"group_by": None, "group_wait": None, "group_interval": None,
-                          "repeat_interval": None, "receiver": "null", "routes": None},
+                "global": None,
+                "inhibit_rules": None,
+                "templates": None,
+                "route": {
+                    "group_by": None,
+                    "group_wait": None,
+                    "group_interval": None,
+                    "repeat_interval": None,
+                    "receiver": "null",
+                    "routes": None,
+                },
                 "receivers": [{"name": "null"}],
             },
         },
     }
-    text = COMMON.read_text(encoding="utf-8") + STAGING.read_text(encoding="utf-8") + PROD.read_text(encoding="utf-8")
+    text = (
+        COMMON.read_text(encoding="utf-8")
+        + STAGING.read_text(encoding="utf-8")
+        + PROD.read_text(encoding="utf-8")
+    )
     forbidden = [
         "longhorn",
         "cloudflare",
@@ -451,7 +462,10 @@ def test_discovery_contract_uses_release_label():
 def test_lifecycle_uses_pinned_version_ordered_values_and_no_reuse_values():
     script = SCRIPT.read_text(encoding="utf-8")
     assert 'CHART="prometheus-community/kube-prometheus-stack"' in script
-    assert 'PROD_VALUES="${ROOT}/clusters/prod/observability/kube-prometheus-stack.values.yaml"' in script
+    assert (
+        'PROD_VALUES="${ROOT}/clusters/prod/observability/kube-prometheus-stack.values.yaml"'
+        in script
+    )
     assert '-f "${COMMON_VALUES}" -f "${ENV_VALUES}"' in script
     assert "--reuse-values" not in script
     assert "--atomic" in script
@@ -635,8 +649,7 @@ def test_justfile_exposes_observability_recipes():
 def test_justfile_normalizes_repeated_env_prefixes_before_staging_metrics_checks():
     text = JUSTFILE.read_text(encoding="utf-8")
     normalization = (
-        'while [ "${env_name#env=}" != "${env_name}" ]; '
-        'do env_name="${env_name#env=}"; done'
+        'while [ "${env_name#env=}" != "${env_name}" ]; ' 'do env_name="${env_name#env=}"; done'
     )
     for recipe in ("observability-install", "observability-upgrade", "observability-verify"):
         recipe_block = text.split(f"{recipe} env='':", 1)[1].split("\n\n", 1)[0]
@@ -996,9 +1009,7 @@ def test_grafana_secret_install_is_exact_redacted_and_rotatable(tmp_path):
         assert forbidden not in audit.lower()
     assert {path.name for path in tmp_path.iterdir()} - before == {"bin", "audit", "tmp"}
     assert list((tmp_path / "tmp").iterdir()) == []
-    repeated, repeated_audit, repeated_credentials = run_grafana_secret_helper(
-        tmp_path / "repeat"
-    )
+    repeated, repeated_audit, repeated_credentials = run_grafana_secret_helper(tmp_path / "repeat")
     assert repeated.returncode == 0, repeated.stderr
     assert repeated_audit.splitlines() == expected_mutations
     assert repeated_credentials == ("operator", "correct horse battery staple")
@@ -1092,6 +1103,9 @@ case "$*" in
   *template*)
     [ "$HELM_MODE" != render-fail ] || exit 31
     if [ "$ENV_NAME" = prod ]; then
+      printf '%s\n' 'apiVersion: v1' 'kind: ConfigMap' 'metadata:' '  name: kube-prometheus-stack-grafana-dashboards-sugarkube' '  labels:' '    dashboard-provider: sugarkube' 'data:' "  $DASHBOARD_UID.json:" '    |-'
+      sed 's/^/      /' "$DASHBOARD"
+      printf '%s\n' '---' 'kind: ConfigMap' 'data:' '  dashboardproviders.yaml: |' '    providers:' '      - name: sugarkube' '        options:' '          path: /var/lib/grafana/dashboards/sugarkube' '---' 'kind: Deployment' 'spec:' '  template:' '    spec:' '      containers:' '        - volumeMounts:' '            - name: dashboards-sugarkube' "              mountPath: /var/lib/grafana/dashboards/sugarkube/$DASHBOARD_UID.json" "              subPath: $DASHBOARD_UID.json"
       printf '%s\n' 'apiVersion: monitoring.coreos.com/v1' 'kind: Alertmanager' 'metadata:' '  name: kube-prometheus-stack-alertmanager' 'spec:' '  secrets: []' '---' 'apiVersion: v1' 'kind: Secret' 'metadata:' '  name: alertmanager-kube-prometheus-stack-alertmanager' 'stringData:' '  alertmanager.yaml: |' '    route:' '      receiver: "null"' '    receivers:' '      - name: "null"'
       exit 0
     fi
@@ -1328,8 +1342,11 @@ printf '%s' "$code"
         "WATCHDOG_SILENCE_DELETIONS": str(tmp_path / "watchdog-silence-deletions"),
         "WATCHDOG_SILENCES": str(tmp_path / "watchdog-silences.json"),
         "WATCHDOG_LOG_TEXT": watchdog_log_text,
-        "DASHBOARD": str(
-            ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
+        "DASHBOARD": str(PROD_DASHBOARD if env_name == "prod" else DASHBOARD),
+        "DASHBOARD_UID": (
+            "sugarkube-prod-observability"
+            if env_name == "prod"
+            else "sugarkube-staging-observability"
         ),
     }
     (tmp_path / "watchdog-tty").write_text(watchdog_tty_text or "", encoding="utf-8")
@@ -1909,6 +1926,7 @@ def run_dashboard_verifier(
     mode="success",
     context="sugar-staging",
     forward_line="Forwarding from 127.0.0.1:43127 -> 3000",
+    env_name="staging",
 ):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(parents=True)
@@ -1919,7 +1937,7 @@ def run_dashboard_verifier(
 echo "kubectl $*" >> "$AUDIT"
 case "$*" in
   "config current-context") echo "$CONTEXT" ;;
-  *"get nodes -o json"*) echo '{"items":[{"metadata":{"name":"n1","labels":{"sugarkube.env":"staging","sugarkube.cluster":"sugar-staging"}}}]}' ;;
+  *"get nodes -o json"*) echo '{"items":[{"metadata":{"name":"n1","labels":{"sugarkube.env":"'"$ENV_NAME"'","sugarkube.cluster":"sugar"}}}]}' ;;
   *"get secret grafana-admin-credentials"*"admin-user"*)
     [ "$MODE" != forward-exits-after-ready ] || { touch "$READY_SECRET"; /bin/sleep 0.2; }
     [ "$MODE" != secret-missing ] || exit 41
@@ -1959,7 +1977,7 @@ case "$MODE" in
   malformed-api) printf '%s\n%s\n' '{' 200 ;;
   wrong-api) printf '%s\n%s\n' '{"dashboard":{"uid":"wrong","title":"wrong"}}' 200 ;;
   interrupt) exit 143 ;;
-  *) printf '%s\n%s\n' '{"dashboard":{"uid":"sugarkube-staging-observability","title":"Sugarkube Staging Observability"}}' 200 ;;
+  *) printf '%s\n%s\n' "{\"dashboard\":{\"uid\":\"$EXPECTED_UID\",\"title\":\"$EXPECTED_TITLE\"}}" 200 ;;
 esac
 """,
         encoding="utf-8",
@@ -1979,9 +1997,16 @@ esac
         "READY_SECRET": str(tmp_path / "secret-requested"),
         "TMPDIR": str(tmp_path),
         "KUBECONFIG": str(tmp_path / "kubeconfig"),
+        "ENV_NAME": env_name,
+        "EXPECTED_UID": f"sugarkube-{env_name}-observability",
+        "EXPECTED_TITLE": (
+            "Sugarkube Production Observability"
+            if env_name == "prod"
+            else "Sugarkube Staging Observability"
+        ),
     }
     result = subprocess.run(
-        ["bash", str(SCRIPT), "dashboard-verify", "env=staging"],
+        ["bash", str(SCRIPT), "dashboard-verify", f"env={env_name}"],
         env=env,
         capture_output=True,
         text=True,
@@ -1998,6 +2023,13 @@ def test_dashboard_verifier_runtime_owns_port_and_cleans_up(tmp_path):
     assert "http://127.0.0.1:43127/" in audit
     assert not list(tmp_path.glob("sugarkube-grafana-verify.*"))
     assert pid_file.read_text(encoding="utf-8").strip() == "terminated"
+
+
+def test_production_dashboard_verifier_requests_production_uid_and_title(tmp_path):
+    result, audit, _ = run_dashboard_verifier(tmp_path, context="sugar-prod", env_name="prod")
+    assert result.returncode == 0, result.stderr
+    assert "/api/dashboards/uid/sugarkube-prod-observability" in audit
+    assert "Grafana API confirmed dashboard UID sugarkube-prod-observability" in result.stdout
 
 
 @pytest.mark.parametrize("remote_port", ["3000", "12345", "80"])
@@ -2728,7 +2760,7 @@ def test_watchdog_silence_api_failures_do_not_expose_fixture_contents(tmp_path, 
 
 
 def production_alertmanager_fixture(*, secrets="[]", route_extra="", receiver_extra="", inline=""):
-    return f'''---
+    return f"""---
 apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
@@ -2746,7 +2778,7 @@ stringData:
       receiver: "null"{route_extra}
     receivers:
       - name: "null"{receiver_extra}{inline}
-'''
+"""
 
 
 def test_production_offline_render_uses_only_ordered_core_values(tmp_path):
@@ -2754,6 +2786,7 @@ def test_production_offline_render_uses_only_ordered_core_values(tmp_path):
     assert result.returncode == 0, result.stderr
     template = next(line for line in audit.splitlines() if "helm template " in line)
     assert template.index(str(COMMON)) < template.index(str(PROD))
+    assert str(PROD_DASHBOARD) in template
     for excluded in (str(STAGING), str(DASHBOARD), "sugarkube-observability-rules"):
         assert excluded not in template
     assert "kubectl" not in audit
@@ -2774,8 +2807,12 @@ def test_production_install_identity_and_explicit_kubeconfig_fail_before_helm_mu
     tmp_path, context, mode, extra_env
 ):
     result, audit = run_helper(
-        tmp_path, "install", env_name="prod", context=context,
-        kubectl_mode=mode, extra_env=extra_env,
+        tmp_path,
+        "install",
+        env_name="prod",
+        context=context,
+        kubectl_mode=mode,
+        extra_env=extra_env,
     )
     assert result.returncode != 0
     assert "helm install" not in audit
@@ -2787,13 +2824,18 @@ def test_production_install_release_and_secret_guards(tmp_path):
     )
     assert installed.returncode == 0, installed.stderr
     assert "helm install" in audit and "--atomic" in audit
-    assert "alertmanager-pagerduty" not in audit and "alertmanager-healthchecks-watchdog" not in audit
+    assert (
+        "alertmanager-pagerduty" not in audit and "alertmanager-healthchecks-watchdog" not in audit
+    )
     existing, audit = run_helper(
         tmp_path / "existing", "install", env_name="prod", context="sugar-prod", helm_mode="present"
     )
     assert existing.returncode != 0 and "helm install" not in audit
     missing, audit = run_helper(
-        tmp_path / "secret", "install", env_name="prod", context="sugar-prod",
+        tmp_path / "secret",
+        "install",
+        env_name="prod",
+        context="sugar-prod",
         kubectl_mode="missing-grafana",
     )
     assert missing.returncode != 0 and "helm " not in audit
@@ -2802,13 +2844,24 @@ def test_production_install_release_and_secret_guards(tmp_path):
 def test_production_core_verify_skips_staging_integrations(tmp_path):
     result, audit = run_helper(tmp_path, "verify", env_name="prod", context="sugar-prod")
     assert result.returncode == 0, result.stderr
-    for required in ("rollout status", "get daemonset", "get pvc -o json", "get svc kube-prometheus-stack-grafana", "get secret grafana-admin-credentials"):
+    for required in (
+        "rollout status",
+        "get daemonset",
+        "get pvc -o json",
+        "get svc kube-prometheus-stack-grafana",
+        "get secret grafana-admin-credentials",
+    ):
         assert required in audit
-    for excluded in ("servicemonitor dspace", "alertmanager-pagerduty", "alertmanager-healthchecks-watchdog", " --raw "):
+    for excluded in (
+        "servicemonitor dspace",
+        "alertmanager-pagerduty",
+        "alertmanager-healthchecks-watchdog",
+        " --raw ",
+    ):
         assert excluded not in audit
 
 
-@pytest.mark.parametrize("command", ["dashboard-verify", "pagerduty-test", "watchdog-verify"])
+@pytest.mark.parametrize("command", ["pagerduty-test", "watchdog-verify"])
 def test_staging_only_subcommands_reject_production(tmp_path, command):
     result, audit = run_helper(tmp_path, command, env_name="prod", context="sugar-prod")
     assert result.returncode != 0
@@ -2831,14 +2884,18 @@ def test_production_alertmanager_validator_accepts_null_only_and_rejects_integra
     valid.write_text(production_alertmanager_fixture(), encoding="utf-8")
     accepted = subprocess.run(
         ["ruby", str(ALERTMANAGER_VALIDATOR), "prod", "rendered", str(valid)],
-        capture_output=True, text=True, check=False,
+        capture_output=True,
+        text=True,
+        check=False,
     )
     assert accepted.returncode == 0, accepted.stderr
     invalid = tmp_path / "invalid.yaml"
     invalid.write_text(production_alertmanager_fixture(**mutation), encoding="utf-8")
     rejected = subprocess.run(
         ["ruby", str(ALERTMANAGER_VALIDATOR), "prod", "rendered", str(invalid)],
-        capture_output=True, text=True, check=False,
+        capture_output=True,
+        text=True,
+        check=False,
     )
     assert rejected.returncode == 16
     assert "forbidden-stub" not in rejected.stderr
@@ -2853,7 +2910,9 @@ def test_production_alertmanager_secret_mount_has_production_specific_diagnostic
     )
     result = subprocess.run(
         ["ruby", str(ALERTMANAGER_VALIDATOR), "prod", "rendered", str(manifest)],
-        capture_output=True, text=True, check=False,
+        capture_output=True,
+        text=True,
+        check=False,
     )
     assert result.returncode == 16
     assert "production Alertmanager must mount no integration Secrets" in result.stderr


### PR DESCRIPTION
### Motivation

- Provision a single, code-owned production Grafana dashboard backed only by the live core Prometheus metrics already observed in production inventory. 
- Ensure production provisioning is environment-aware and separate from the existing staging dashboard and DSPACE rules overlay. 
- Harden the dashboard lifecycle by adding a fail-closed production validator and automated tests that protect missing-data semantics, safe aggregation, and forbidden labels/signals. 
- Document operational meaning, the 2026-08-08 live evidence, and the post-merge proof steps needed to finalize production rollout.

### Description

- Added the production dashboard JSON at `clusters/prod/observability/dashboards/sugarkube-prod-observability.json` implementing the required rows/panels, PromQL contracts, percent units, explicit `NO DATA` semantics, and safe legends/labels. 
- Extended `scripts/observability_helm.sh` to resolve dashboard path, `--set-file` value, UID, title, and LAN URL per `env`, to provision the production dashboard for `env=prod`, and to generalize the read-only `dashboard-verify` routine to request the environment-specific UID/title (keeps secret redaction and loopback port-forward pattern). 
- Extended `scripts/validate_observability_dashboard.py` with a fail-closed production profile (`validate_production_dashboard`) that enforces UID/title/refresh/time, required rows/panels/PromQL expressions, `$__rate_interval` usage, deduplication rules, forbidden signals/selectors (`kube_state_metrics_build_info`, `or vector(0)`, external-label selectors), unique IDs/grid non-overlap, and Prometheus datasource UID `prometheus`. 
- Added/updated tests: `tests/test_observability_dashboard.py` and `tests/test_observability_helm.py` to exercise the production profile, render routing, install/upgrade argument generation, context/identity guards, and the dashboard verifier behavior. 
- Updated `docs/observability-operations.md` with the production dashboard meaning, aggregation/deduplication semantics, the summarized 2026-08-08 evidence, the reason not to add a local `cluster=` selector, that `kube_state_metrics_build_info` was absent, the persistence-disabled recovery note, and a post-merge production procedure. 

Files changed (within allowed scope):
- New: `clusters/prod/observability/dashboards/sugarkube-prod-observability.json`
- Modified: `scripts/observability_helm.sh`, `scripts/validate_observability_dashboard.py`, `tests/test_observability_dashboard.py`, `tests/test_observability_helm.py`, `docs/observability-operations.md`

Note: staging dashboard and staging behavior were left unchanged; the staging DSPACE rules overlay is still only applied in staging.

### Testing

- Validator: `python3 scripts/validate_observability_dashboard.py clusters/prod/observability/dashboards/sugarkube-prod-observability.json` — passed. 
- Unit/regression tests: `pytest -q tests/test_observability_dashboard.py` — 115 passed. 
- Helm render / helm-related tests: `pytest -q tests/test_observability_dashboard.py tests/test_observability_helm.py` — passed (targeted Helm/render checks simulated by test harness). 
- Render smoke: `KUBECONFIG=/dev/null just observability-render env=prod >/tmp/sugarkube-prod-observability-render.txt` and `... env=staging` — attempted but full live Helm render requires local `helm` binary; the repository-level `just` recipes were exercised in tests and the script performs the same `--set-file` plumbing; offline render assertions validated template routing and that production render does not include the staging dashboard. 
- Script checks: `bash -n scripts/observability_helm.sh` and `shellcheck scripts/observability_helm.sh` — passed. 
- Formatting & repo checks: `just --unstable --fmt --check`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` — passed (linkcheck: 208 links validated). 
- Secret scan: `git diff --cached | ./scripts/scan-secrets.py` — passed (sensitive values redacted or replaced; documentation wording adjusted to avoid literal credential text). 

Residual notes and required post-merge operator work

- This PR is the code + tests follow-up to PRs #2529 and #2532 and provisions the production dashboard artifact and validation rules in-repo; it does not modify any live cluster by itself. 
- After merge an operator must perform the production Helm upgrade (example: `just observability-upgrade env=prod`) and then run the dashboard API verification and the pod-recreation proof described in `docs/observability-operations.md` (steps include `just observability-dashboard-verify env=prod`, deleting the Grafana pod and re-running verification, and a visual inspection at the LAN Grafana URL). 
- Some realtime render/install checks that require an installed `helm` binary and an actual KUBECONFIG were exercised by the test harness; live cluster verification and the post-merge upgrade/pod-recreate visual proof remain required and documented above.

If you want, I can open the PR text on your behalf (branch is committed locally as `feat(observability): add production Grafana dashboard`) but I could not push or open the remote PR from this environment because `gh`/auth or remote config is not available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77c2739010832fab682b023d0638f8)